### PR TITLE
[None][perf] DFlash performance optimizations

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_speculative.py
+++ b/tensorrt_llm/_torch/models/modeling_speculative.py
@@ -22,6 +22,12 @@ from ..modules.linear import (Linear, TensorParallelMode, WeightMode,
                               WeightsLoadingConfig)
 from ..modules.rms_norm import RMSNorm
 from ..modules.rotary_embedding import RotaryEmbedding
+
+try:
+    from ..custom_ops import \
+        flashinfer_apply_rope_with_cos_sin_cache_inplace as _flashinfer_rope
+except ImportError:
+    _flashinfer_rope = None
 from ..pyexecutor.guided_decoder import CapturableGuidedDecoder
 from ..speculative import (SpecMetadata, get_spec_worker,
                            should_use_separate_draft_kv_cache)
@@ -1025,17 +1031,11 @@ class DFlashForCausalLM(nn.Module):
         Layout of k_flat: row (i*L + l) holds layer l of position i, so
         positions must be repeat_interleaved by L to match.
         """
-        try:
-            from ..custom_ops import \
-                flashinfer_apply_rope_with_cos_sin_cache_inplace
-        except ImportError:
-            flashinfer_apply_rope_with_cos_sin_cache_inplace = None
-
         positions_int32 = positions.view(-1).to(torch.int32)
         if L > 1:
             positions_int32 = positions_int32.repeat_interleave(L)
 
-        if flashinfer_apply_rope_with_cos_sin_cache_inplace is not None:
+        if _flashinfer_rope is not None:
             # flashinfer requires a non-None query tensor; pass a single-head
             # scratch so the extra rotate is negligible.
             need_rows = k_flat.shape[0]
@@ -1044,7 +1044,7 @@ class DFlashForCausalLM(nn.Module):
                     or dummy_q.shape[0] < need_rows):
                 dummy_q = k_flat.new_empty(need_rows, self._head_dim)
                 self._rope_dummy_q = dummy_q
-            flashinfer_apply_rope_with_cos_sin_cache_inplace(
+            _flashinfer_rope(
                 positions_int32,
                 dummy_q[:need_rows],
                 k_flat,
@@ -1169,24 +1169,23 @@ class DFlashForCausalLM(nn.Module):
         num_heads_per_rank = attn0.num_heads
         num_kv_heads_per_rank = attn0.num_key_value_heads
         has_qk_norm = hasattr(attn0, 'q_norm') and hasattr(attn0, 'k_norm')
-        # Use the C++ fused_qk_norm_rope kernel when available — handles
-        # q_norm + k_norm + RoPE in a single in-place CUDA kernel. Only
-        # valid on bf16 qkv and when the drafter has qk-norm.
-        use_fused_qk_norm_rope = (has_qk_norm
-                                  and hasattr(attn0, 'apply_qk_norm_rope')
-                                  and getattr(attn0, 'pos_embd_params',
-                                              None) is not None
-                                  and noise_embedding.dtype == torch.bfloat16)
+        # Apply RoPE via the same flashinfer in-place kernel + cos/sin cache
+        # that precompute_context_kv uses. Sharing the cache is critical —
+        # fused_qk_norm_rope / apply_rotary_pos_emb derive YaRN (or other
+        # scaled) frequencies on their own, and a mismatch against the cached
+        # cos/sin breaks context-vs-query attention and collapses acceptance.
+        use_fused_rope = (_flashinfer_rope is not None and has_qk_norm
+                          and noise_embedding.dtype == torch.bfloat16)
 
         B = noise_embedding.shape[0]
         block_size = noise_embedding.shape[1]
 
         hidden_states = noise_embedding  # [B, block_size, hidden]
 
-        # Precompute RoPE cos/sin for the Q path when fused_qk_norm_rope
-        # is not available.
+        # Precompute RoPE cos/sin for the pure-PyTorch fallback path only.
+        # The fused flashinfer path reads self._get_cos_sin_cache() inline.
         rope_dtype = hidden_states.dtype
-        if not use_fused_qk_norm_rope:
+        if not use_fused_rope:
             q_rope_cos, q_rope_sin = self._get_rope_cos_sin(query_positions,
                                                             dtype=rope_dtype)
         _rope = RotaryEmbedding.apply_rotary_pos_emb
@@ -1218,22 +1217,29 @@ class DFlashForCausalLM(nn.Module):
             # QKV projection on normed query tokens (2D)
             qkv_query = attn_mod.qkv_proj(hs_normed_flat)  # [B*blk, qkv_size]
 
-            # Fused q_norm + k_norm + RoPE in one CUDA kernel (mutates qkv).
-            if use_fused_qk_norm_rope:
-                attn_mod.apply_qk_norm_rope(qkv_query, query_positions_flat_i32)
-                # Slices of qkv_query are non-contiguous in the last dim, so
-                # use reshape (may copy) instead of view.
-                q_all_2d = qkv_query[:, :q_size]
-                k_noise_2d = qkv_query[:, q_size:q_size + kv_size]
-                v_noise_2d = qkv_query[:, q_size + kv_size:]
-                Q_bshd = q_all_2d.reshape(B, block_size, num_heads_per_rank,
-                                          head_dim)
-                k_noise_bshd = k_noise_2d.reshape(B, block_size,
-                                                  num_kv_heads_per_rank,
-                                                  head_dim)
-                v_noise_bshd = v_noise_2d.reshape(B, block_size,
-                                                  num_kv_heads_per_rank,
-                                                  head_dim)
+            if use_fused_rope:
+                # Per-head RMSNorm on q/k (returns new contiguous tensors),
+                # then flashinfer in-place RoPE sharing the same cos/sin cache
+                # as precompute_context_kv.
+                q = attn_mod.q_norm(qkv_query[:, :q_size].reshape(
+                    -1, head_dim)).view(-1, q_size)
+                k = attn_mod.k_norm(qkv_query[:,
+                                              q_size:q_size + kv_size].reshape(
+                                                  -1,
+                                                  head_dim)).view(-1, kv_size)
+                _flashinfer_rope(
+                    query_positions_flat_i32,
+                    q,
+                    k,
+                    head_dim,
+                    self._get_cos_sin_cache(),
+                    self._is_neox,
+                )
+                Q_bshd = q.view(B, block_size, num_heads_per_rank, head_dim)
+                k_noise_bshd = k.view(B, block_size, num_kv_heads_per_rank,
+                                      head_dim)
+                v_noise_bshd = qkv_query[:, q_size + kv_size:].reshape(
+                    B, block_size, num_kv_heads_per_rank, head_dim)
             else:
                 qkv_query_3d = qkv_query.reshape(B, block_size, -1)
                 q_all = qkv_query_3d[..., :q_size]

--- a/tensorrt_llm/_torch/models/modeling_speculative.py
+++ b/tensorrt_llm/_torch/models/modeling_speculative.py
@@ -3,6 +3,7 @@ from dataclasses import replace
 from typing import Dict, Generic, List, Optional, Tuple
 
 import torch
+import torch.nn.functional as F
 from torch import nn
 from transformers import LlamaConfig, PretrainedConfig
 
@@ -849,11 +850,16 @@ class DFlashForCausalLM(nn.Module):
         self._rotary_cos_sin = None
         self._is_neox = True
 
-        # FlashAttention KV buffer - lazily initialized on first dflash_forward
-        self._kv_buf_k = None
-        self._kv_buf_v = None
-        self._cache_seqlens = None
-        self._block_offsets = None
+        self._cos_sin_cache_fp32 = None
+        self._rope_dummy_q = None
+
+        # Lazy-built after weights load (see _build_fused_kv_buffers).
+        self._fused_kv_weight = None  # [L*2*kv_size, hidden]
+        self._fused_kv_bias = None  # [L*2*kv_size] or None
+        self._k_norm_weights = None  # list of L tensors, each [head_dim]
+        self._num_attn_layers = 0
+        self._head_dim = 0
+        self._num_kv_heads = 0
 
     def _init_rope(self):
         """Initialize RoPE from the draft model's attention configuration.
@@ -952,6 +958,161 @@ class DFlashForCausalLM(nn.Module):
         self.draft_model_full.lm_head = target_model.lm_head
         self.lm_head = target_model.lm_head
 
+    def precompute_context_kv(
+        self,
+        projected_hidden: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Post-norm / post-RoPE K and V for ALL drafter layers in one fused GEMM.
+
+        Args:
+            projected_hidden: [N, hidden_size], already fc + hidden_norm'd.
+            positions:        [N] int32/64, RoPE positions for each entry.
+        Returns:
+            k: [N, L, nkv, hd]  post k_norm and RoPE
+            v: [N, L, nkv, hd]  post split only
+        """
+        if self._fused_kv_weight is None:
+            self._build_fused_kv_buffers()
+        N = projected_hidden.shape[0]
+        L = self._num_attn_layers
+        nkv = self._num_kv_heads
+        hd = self._head_dim
+        weight_dtype = self._fused_kv_weight.dtype
+        if projected_hidden.dtype != weight_dtype:
+            projected_hidden = projected_hidden.to(weight_dtype)
+
+        kv_flat = F.linear(projected_hidden, self._fused_kv_weight,
+                           self._fused_kv_bias)
+        # Per-layer layout [L0_K|L0_V|L1_K|L1_V|...] keeps K and V contiguous
+        # after the select() splits — no extra copy required.
+        kv = kv_flat.view(N, L, 2, nkv, hd)
+        k = kv[:, :, 0].contiguous()
+        v = kv[:, :, 1].contiguous()
+
+        if self._k_norm_weights:
+            for i in range(L):
+                k[:, i] = self.model.layers[i].self_attn.k_norm(k[:, i])
+
+        self._fused_rope_inplace(k.view(N * L, nkv * hd), positions, N, L)
+        return k, v
+
+    def _get_cos_sin_cache(self) -> torch.Tensor:
+        """Return the flashinfer-style cos/sin cache for the drafter.
+
+        Shape [max_positions, head_dim], fp32 — flashinfer's
+        apply_rope_with_cos_sin_cache_inplace requires fp32 regardless of
+        the query/key dtype.
+        """
+        if self._cos_sin_cache_fp32 is not None:
+            return self._cos_sin_cache_fp32
+        if not self._rope_initialized:
+            self._init_rope()
+        max_pos = self._rotary_cos_sin.shape[0]
+        self._cos_sin_cache_fp32 = self._rotary_cos_sin.view(max_pos, -1).to(
+            torch.float32).contiguous()
+        return self._cos_sin_cache_fp32
+
+    def _fused_rope_inplace(
+        self,
+        k_flat: torch.Tensor,
+        positions: torch.Tensor,
+        N: int,
+        L: int,
+    ) -> None:
+        """In-place fused RoPE over [N*L, nkv*hd] K values.
+
+        Layout of k_flat: row (i*L + l) holds layer l of position i, so
+        positions must be repeat_interleaved by L to match.
+        """
+        try:
+            from ..custom_ops import \
+                flashinfer_apply_rope_with_cos_sin_cache_inplace
+        except ImportError:
+            flashinfer_apply_rope_with_cos_sin_cache_inplace = None
+
+        positions_int32 = positions.view(-1).to(torch.int32)
+        if L > 1:
+            positions_int32 = positions_int32.repeat_interleave(L)
+
+        if flashinfer_apply_rope_with_cos_sin_cache_inplace is not None:
+            # flashinfer requires a non-None query tensor; pass a single-head
+            # scratch so the extra rotate is negligible.
+            need_rows = k_flat.shape[0]
+            dummy_q = self._rope_dummy_q
+            if (dummy_q is None or dummy_q.dtype != k_flat.dtype
+                    or dummy_q.shape[0] < need_rows):
+                dummy_q = k_flat.new_empty(need_rows, self._head_dim)
+                self._rope_dummy_q = dummy_q
+            flashinfer_apply_rope_with_cos_sin_cache_inplace(
+                positions_int32,
+                dummy_q[:need_rows],
+                k_flat,
+                self._head_dim,
+                self._get_cos_sin_cache(),
+                self._is_neox,
+            )
+            return
+
+        # Pure-PyTorch fallback (older environments without flashinfer).
+        cos, sin = self._get_rope_cos_sin(positions_int32.view(1, -1),
+                                          dtype=k_flat.dtype)
+        k_roped = RotaryEmbedding.apply_rotary_pos_emb(
+            k_flat.view(k_flat.shape[0], -1, self._head_dim),
+            cos.squeeze(0),
+            sin.squeeze(0),
+            unsqueeze_dim=1,
+            is_neox=self._is_neox,
+        )
+        k_flat.copy_(k_roped.view_as(k_flat))
+
+    def _build_fused_kv_buffers(self) -> None:
+        """Stack per-layer KV projection + k_norm weights for a single fused GEMM.
+
+        Must run after weights are loaded.
+        """
+        if self._fused_kv_weight is not None:
+            return
+        layers_attn = [layer.self_attn for layer in self.model.layers]
+        attn0 = layers_attn[0]
+        q_size = attn0.q_size
+        kv_size = attn0.kv_size
+        head_dim = attn0.head_dim
+        num_kv_heads = attn0.num_key_value_heads
+        for a in layers_attn[1:]:
+            assert (a.kv_size == kv_size and a.head_dim == head_dim
+                    and a.num_key_value_heads == num_kv_heads), (
+                        "DFlash fused KV requires all drafter layers to share "
+                        "kv_size / head_dim / num_kv_heads.")
+
+        has_k_norm = [hasattr(a, 'k_norm') for a in layers_attn]
+        assert all(has_k_norm) or not any(has_k_norm), (
+            "DFlash fused KV requires either all or no drafter layers to have k_norm."
+        )
+
+        kv_weights = [
+            a.qkv_proj.weight[q_size:q_size + 2 * kv_size] for a in layers_attn
+        ]
+        fused_kv_weight = torch.cat(kv_weights, dim=0).contiguous()
+        if attn0.qkv_proj.bias is not None:
+            kv_biases = [
+                a.qkv_proj.bias[q_size:q_size + 2 * kv_size]
+                for a in layers_attn
+            ]
+            self._fused_kv_bias = torch.cat(kv_biases, dim=0).contiguous()
+        else:
+            self._fused_kv_bias = None
+
+        self._k_norm_weights = ([a.k_norm.weight.data for a in layers_attn]
+                                if all(has_k_norm) else None)
+        self._num_attn_layers = len(layers_attn)
+        self._head_dim = head_dim
+        self._num_kv_heads = num_kv_heads
+        self._fused_kv_weight = fused_kv_weight
+        logger.debug(
+            f"DFlash: fused KV weights built for {self._num_attn_layers} layers "
+            f"(fused_kv_weight shape={tuple(self._fused_kv_weight.shape)})")
+
     def _get_rope_cos_sin(self, positions, dtype=None):
         """Get cos/sin for given positions, suitable for apply_rotary_pos_emb.
 
@@ -977,32 +1138,28 @@ class DFlashForCausalLM(nn.Module):
     def dflash_forward(
         self,
         noise_embedding: torch.Tensor,
-        target_hidden: torch.Tensor,
         query_positions: torch.Tensor,
-        context_positions: torch.Tensor,
         num_ctx_per_req: torch.Tensor,
+        ctx_k_cache: torch.Tensor,
+        ctx_v_cache: torch.Tensor,
+        ctx_cache_batch_idx: torch.Tensor,
     ) -> torch.Tensor:
-        """Custom DFlash forward with batched cross-attention.
+        """DFlash draft forward with cross-attention over a pooled K/V buffer.
 
-        All operations use fixed-shape padded tensors for CUDA graph
-        compatibility. Padding in target_hidden is masked via attention mask.
-
-        In each layer:
-        - Q from input_layernorm(hidden_states) via q_proj
-        - K/V from concat(target_hidden, input_layernorm(hidden_states)) via k_proj/v_proj
-        - target_hidden does NOT go through input_layernorm (stays constant)
-        - Non-causal attention via flash_attn_with_kvcache
+        All shapes are fixed so the forward is CUDA-graph compatible.
 
         Args:
-            noise_embedding: [B, block_size, hidden_size] - token embeddings
-            target_hidden: [B, max_ctx, hidden_size] - padded projected target features
-            query_positions: [B, block_size] - positions for query tokens
-            context_positions: [B, max_ctx] - positions for context tokens (padded)
-            num_ctx_per_req: [B] - actual context length per request
+            noise_embedding: [B, block_size, hidden_size]
+            query_positions: [B, block_size]
+            num_ctx_per_req: [B] — per-batch context length in the pool
+            ctx_k_cache: [pool_batch, L, max_ctx+block_size, nkv, hd]
+            ctx_v_cache: [pool_batch, L, max_ctx+block_size, nkv, hd]
+            ctx_cache_batch_idx: [B] — slot index into the pool per batch entry
         Returns:
-            hidden_states: [B * block_size, hidden_size]
+            [B * block_size, hidden_size]
         """
         import torch.nn.functional as F
+        from flash_attn import flash_attn_with_kvcache
 
         layer0 = self.model.layers[0]
         attn0 = layer0.self_attn
@@ -1012,54 +1169,35 @@ class DFlashForCausalLM(nn.Module):
         num_heads_per_rank = attn0.num_heads
         num_kv_heads_per_rank = attn0.num_key_value_heads
         has_qk_norm = hasattr(attn0, 'q_norm') and hasattr(attn0, 'k_norm')
+        # Use the C++ fused_qk_norm_rope kernel when available — handles
+        # q_norm + k_norm + RoPE in a single in-place CUDA kernel. Only
+        # valid on bf16 qkv and when the drafter has qk-norm.
+        use_fused_qk_norm_rope = (has_qk_norm
+                                  and hasattr(attn0, 'apply_qk_norm_rope')
+                                  and getattr(attn0, 'pos_embd_params',
+                                              None) is not None
+                                  and noise_embedding.dtype == torch.bfloat16)
 
         B = noise_embedding.shape[0]
         block_size = noise_embedding.shape[1]
-        max_ctx = target_hidden.shape[1]
-        kv_len = max_ctx + block_size
 
         hidden_states = noise_embedding  # [B, block_size, hidden]
 
-        # Lazy-init pre-allocated KV buffers for flash_attn_with_kvcache.
-        # Re-allocate if B grows (warmup uses increasing batch sizes
-        # before CUDA graph capture locks in the final padded size).
-        if self._kv_buf_k is None or B > self._kv_buf_k.shape[0]:
-            assert self._kv_buf_k is None or \
-                kv_len == self._kv_buf_k.shape[1], \
-                f"kv_len changed: {self._kv_buf_k.shape[1]} -> {kv_len}"
-            self._kv_buf_k = torch.zeros(B,
-                                         kv_len,
-                                         num_kv_heads_per_rank,
-                                         head_dim,
-                                         dtype=hidden_states.dtype,
-                                         device='cuda')
-            self._kv_buf_v = torch.zeros(B,
-                                         kv_len,
-                                         num_kv_heads_per_rank,
-                                         head_dim,
-                                         dtype=hidden_states.dtype,
-                                         device='cuda')
-            self._cache_seqlens = torch.zeros(B,
-                                              dtype=torch.int32,
-                                              device='cuda')
-            self._block_offsets = torch.arange(block_size, device='cuda')
-        # Actual KV length per request: context + noise tokens
-        self._cache_seqlens[:B] = num_ctx_per_req + block_size
-
-        # Scatter indices for noise placement: place noise right after
-        # each request's valid context so cache_seqlens covers
-        # [valid_ctx | noise] contiguously without padding gaps.
-        noise_pos = num_ctx_per_req[:B].unsqueeze(1) + self._block_offsets
-        noise_scatter_idx = noise_pos.unsqueeze(-1).unsqueeze(-1).expand(
-            -1, -1, num_kv_heads_per_rank, head_dim)
-
-        # Precompute RoPE cos/sin (positions are constant across layers)
+        # Precompute RoPE cos/sin for the Q path when fused_qk_norm_rope
+        # is not available.
         rope_dtype = hidden_states.dtype
-        q_rope_cos, q_rope_sin = self._get_rope_cos_sin(query_positions,
-                                                        dtype=rope_dtype)
-        ctx_rope_cos, ctx_rope_sin = self._get_rope_cos_sin(context_positions,
+        if not use_fused_qk_norm_rope:
+            q_rope_cos, q_rope_sin = self._get_rope_cos_sin(query_positions,
                                                             dtype=rope_dtype)
         _rope = RotaryEmbedding.apply_rotary_pos_emb
+
+        # cache_seqlens (BEFORE append). flash_attn appends block_size
+        # k/v at cache_seqlens[i]..+block_size for batch i.
+        cache_seqlens_i32 = num_ctx_per_req[:B].to(torch.int32)
+        cache_batch_idx_i32 = ctx_cache_batch_idx.to(torch.int32)
+
+        # Flatten query positions once for the fused QK-norm-RoPE kernel.
+        query_positions_flat_i32 = query_positions.reshape(-1).to(torch.int32)
 
         residual = None
 
@@ -1070,99 +1208,84 @@ class DFlashForCausalLM(nn.Module):
             hs_flat = hidden_states.reshape(-1, hidden_states.shape[-1])
             if residual is None:
                 residual = hidden_states.clone()
-                hs_normed = layer.input_layernorm(hs_flat).reshape(
-                    B, block_size, -1)
+                hs_normed_flat = layer.input_layernorm(hs_flat)
             else:
                 res_flat = residual.reshape(-1, residual.shape[-1])
                 hs_normed_flat, res_flat = layer.input_layernorm(
                     hs_flat, res_flat)
-                hs_normed = hs_normed_flat.reshape(B, block_size, -1)
                 residual = res_flat.reshape(B, block_size, -1)
 
-            # QKV projection on normed query tokens
-            qkv_query = attn_mod.qkv_proj(
-                hs_normed.reshape(-1, hs_normed.shape[-1]))
-            qkv_query = qkv_query.reshape(B, block_size, -1)
-            q_all = qkv_query[..., :q_size]
-            k_noise_all = qkv_query[..., q_size:q_size + kv_size]
-            v_noise_all = qkv_query[..., q_size + kv_size:]
+            # QKV projection on normed query tokens (2D)
+            qkv_query = attn_mod.qkv_proj(hs_normed_flat)  # [B*blk, qkv_size]
 
-            # K/V from target_hidden (NO input_layernorm!)
-            # Combined K+V projection in a single GEMM for efficiency
-            qkv_weight = attn_mod.qkv_proj.weight
-            kv_weight = qkv_weight[q_size:]  # [2*kv_size, hidden]
-            qkv_bias = getattr(attn_mod.qkv_proj, 'bias', None)
-            kv_bias = qkv_bias[q_size:] if qkv_bias is not None else None
-
-            # Context K/V via single GEMM: [B*max_ctx, 2*kv_size]
-            th_flat = target_hidden.reshape(-1, target_hidden.shape[-1])
-            kv_ctx = F.linear(th_flat, kv_weight,
-                              kv_bias).reshape(B, max_ctx, 2 * kv_size)
-            k_ctx_all = kv_ctx[..., :kv_size]
-            v_ctx_all = kv_ctx[..., kv_size:]
-
-            # QK norm (only for architectures that use it, e.g. Qwen3)
-            if has_qk_norm:
-                q_for_rope = attn_mod.q_norm(q_all.reshape(
-                    -1, head_dim)).reshape(B, block_size, q_size)
-                k_noise_for_rope = attn_mod.k_norm(
-                    k_noise_all.reshape(-1, head_dim)).reshape(
-                        B, block_size, kv_size)
-                k_ctx_for_rope = attn_mod.k_norm(k_ctx_all.reshape(
-                    -1, head_dim)).reshape(B, max_ctx, kv_size)
+            # Fused q_norm + k_norm + RoPE in one CUDA kernel (mutates qkv).
+            if use_fused_qk_norm_rope:
+                attn_mod.apply_qk_norm_rope(qkv_query, query_positions_flat_i32)
+                # Slices of qkv_query are non-contiguous in the last dim, so
+                # use reshape (may copy) instead of view.
+                q_all_2d = qkv_query[:, :q_size]
+                k_noise_2d = qkv_query[:, q_size:q_size + kv_size]
+                v_noise_2d = qkv_query[:, q_size + kv_size:]
+                Q_bshd = q_all_2d.reshape(B, block_size, num_heads_per_rank,
+                                          head_dim)
+                k_noise_bshd = k_noise_2d.reshape(B, block_size,
+                                                  num_kv_heads_per_rank,
+                                                  head_dim)
+                v_noise_bshd = v_noise_2d.reshape(B, block_size,
+                                                  num_kv_heads_per_rank,
+                                                  head_dim)
             else:
-                q_for_rope = q_all
-                k_noise_for_rope = k_noise_all
-                k_ctx_for_rope = k_ctx_all
+                qkv_query_3d = qkv_query.reshape(B, block_size, -1)
+                q_all = qkv_query_3d[..., :q_size]
+                k_noise_all = qkv_query_3d[..., q_size:q_size + kv_size]
+                v_noise_all = qkv_query_3d[..., q_size + kv_size:]
+                if has_qk_norm:
+                    q_for_rope = attn_mod.q_norm(q_all.reshape(
+                        -1, head_dim)).reshape(B, block_size, q_size)
+                    k_noise_for_rope = attn_mod.k_norm(
+                        k_noise_all.reshape(-1, head_dim)).reshape(
+                            B, block_size, kv_size)
+                else:
+                    q_for_rope = q_all
+                    k_noise_for_rope = k_noise_all
+                Q = _rope(q_for_rope.reshape(B, block_size, num_heads_per_rank,
+                                             head_dim).transpose(1, 2),
+                          q_rope_cos,
+                          q_rope_sin,
+                          unsqueeze_dim=1,
+                          is_neox=self._is_neox)
+                k_noise_rope = _rope(k_noise_for_rope.reshape(
+                    B, block_size, num_kv_heads_per_rank,
+                    head_dim).transpose(1, 2),
+                                     q_rope_cos,
+                                     q_rope_sin,
+                                     unsqueeze_dim=1,
+                                     is_neox=self._is_neox)
+                Q_bshd = Q.transpose(1, 2)
+                k_noise_bshd = k_noise_rope.transpose(1, 2)
+                v_noise_bshd = v_noise_all.reshape(B, block_size,
+                                                   num_kv_heads_per_rank,
+                                                   head_dim)
 
-            # Apply RoPE using precomputed cos/sin
-            Q = _rope(q_for_rope.reshape(B, block_size, num_heads_per_rank,
-                                         head_dim).transpose(1, 2),
-                      q_rope_cos,
-                      q_rope_sin,
-                      unsqueeze_dim=1,
-                      is_neox=self._is_neox)
-            k_noise_rope = _rope(k_noise_for_rope.reshape(
-                B, block_size, num_kv_heads_per_rank, head_dim).transpose(1, 2),
-                                 q_rope_cos,
-                                 q_rope_sin,
-                                 unsqueeze_dim=1,
-                                 is_neox=self._is_neox)
+            # Per-layer view into the pooled ctx cache.
+            # [pool_batch, max_ctx+block, nkv, hd]; flash_attn dereferences
+            # each batch via cache_batch_idx, no gather.
+            layer_k_cache = ctx_k_cache[:, layer_idx]
+            layer_v_cache = ctx_v_cache[:, layer_idx]
 
-            k_ctx_rope = _rope(k_ctx_for_rope.reshape(B, max_ctx,
-                                                      num_kv_heads_per_rank,
-                                                      head_dim).transpose(1, 2),
-                               ctx_rope_cos,
-                               ctx_rope_sin,
-                               unsqueeze_dim=1,
-                               is_neox=self._is_neox)
-
-            # Fill KV buffer: [B, seq, nkv, hd] layout for flash_attn.
-            # Context fills [0, max_ctx), noise is scattered right after
-            # each request's valid context via noise_scatter_idx so
-            # cache_seqlens covers [valid_ctx | noise] contiguously.
-            self._kv_buf_k[:B, :max_ctx] = k_ctx_rope.transpose(1, 2)
-            self._kv_buf_k[:B].scatter_(1, noise_scatter_idx,
-                                        k_noise_rope.transpose(1, 2))
-            self._kv_buf_v[:B, :max_ctx] = v_ctx_all.reshape(
-                B, max_ctx, num_kv_heads_per_rank, head_dim)
-            self._kv_buf_v[:B].scatter_(
-                1, noise_scatter_idx,
-                v_noise_all.reshape(B, block_size, num_kv_heads_per_rank,
-                                    head_dim))
-
-            # Q: [B, heads, block_size, hd] -> [B, block_size, heads, hd]
-            Q_bshd = Q.transpose(1, 2)
-
-            from flash_attn import flash_attn_with_kvcache
+            # flash_attn writes k_noise/v_noise in-place into the cache at
+            # positions cache_seqlens[i]..+block_size for each batch i.
+            # Replaces the old torch.scatter_ step.
             out = flash_attn_with_kvcache(
                 q=Q_bshd,
-                k_cache=self._kv_buf_k[:B],
-                v_cache=self._kv_buf_v[:B],
-                cache_seqlens=self._cache_seqlens[:B],
+                k_cache=layer_k_cache,
+                v_cache=layer_v_cache,
+                k=k_noise_bshd,
+                v=v_noise_bshd,
+                cache_seqlens=cache_seqlens_i32,
+                cache_batch_idx=cache_batch_idx_i32,
                 causal=False,
             )
-            # [B, block_size, heads, hd] -> [B*block_size, q_size]
             attn_output = out.reshape(B * block_size, q_size)
 
             # o_proj (flat 2D, handles all-reduce internally)

--- a/tensorrt_llm/_torch/models/modeling_speculative.py
+++ b/tensorrt_llm/_torch/models/modeling_speculative.py
@@ -9,7 +9,7 @@ from transformers import LlamaConfig, PretrainedConfig
 
 from tensorrt_llm.logger import logger
 
-from ...functional import PositionEmbeddingType
+from ...functional import PositionEmbeddingType, RotaryScalingType
 from ..attention_backend import AttentionMetadata
 from ..attention_backend.interface import PositionalEmbeddingParams, RopeParams
 from ..model_config import ModelConfig, TConfig
@@ -860,12 +860,14 @@ class DFlashForCausalLM(nn.Module):
         self._rope_dummy_q = None
 
         # Lazy-built after weights load (see _build_fused_kv_buffers).
-        self._fused_kv_weight = None  # [L*2*kv_size, hidden]
-        self._fused_kv_bias = None  # [L*2*kv_size] or None
-        self._k_norm_weights = None  # list of L tensors, each [head_dim]
+        self._fused_kv_weight = None
+        self._fused_kv_bias = None
+        self._k_norm_weights = None
         self._num_attn_layers = 0
         self._head_dim = 0
         self._num_kv_heads = 0
+        self._has_qk_norm = False
+        self._use_fused_qk_norm_rope = False
 
     def _init_rope(self):
         """Initialize RoPE from the draft model's attention configuration.
@@ -1109,6 +1111,25 @@ class DFlashForCausalLM(nn.Module):
         self._head_dim = head_dim
         self._num_kv_heads = num_kv_heads
         self._fused_kv_weight = fused_kv_weight
+
+        # fused_qk_norm_rope derives YaRN / partial-rotary frequencies on
+        # the fly, which can disagree with precompute_context_kv's cached
+        # cos/sin. Only enable it when the drafter uses plain RoPE.
+        self._has_qk_norm = (all(has_k_norm)
+                             and all(hasattr(a, 'q_norm') for a in layers_attn))
+        rope_params = getattr(getattr(attn0, 'pos_embd_params', None), 'rope',
+                              None)
+        scale_type = getattr(rope_params, 'scale_type', None)
+        partial_rotary_factor = getattr(
+            getattr(attn0, 'pretrained_config', None), 'partial_rotary_factor',
+            1.0)
+        self._use_fused_qk_norm_rope = (self._has_qk_norm
+                                        and hasattr(attn0, 'apply_qk_norm_rope')
+                                        and rope_params is not None
+                                        and scale_type
+                                        in (None, RotaryScalingType.none)
+                                        and partial_rotary_factor == 1.0)
+
         logger.debug(
             f"DFlash: fused KV weights built for {self._num_attn_layers} layers "
             f"(fused_kv_weight shape={tuple(self._fused_kv_weight.shape)})")
@@ -1158,8 +1179,10 @@ class DFlashForCausalLM(nn.Module):
         Returns:
             [B * block_size, hidden_size]
         """
-        import torch.nn.functional as F
         from flash_attn import flash_attn_with_kvcache
+
+        if self._fused_kv_weight is None:
+            self._build_fused_kv_buffers()
 
         layer0 = self.model.layers[0]
         attn0 = layer0.self_attn
@@ -1168,14 +1191,12 @@ class DFlashForCausalLM(nn.Module):
         head_dim = attn0.head_dim
         num_heads_per_rank = attn0.num_heads
         num_kv_heads_per_rank = attn0.num_key_value_heads
-        has_qk_norm = hasattr(attn0, 'q_norm') and hasattr(attn0, 'k_norm')
-        # Apply RoPE via the same flashinfer in-place kernel + cos/sin cache
-        # that precompute_context_kv uses. Sharing the cache is critical —
-        # fused_qk_norm_rope / apply_rotary_pos_emb derive YaRN (or other
-        # scaled) frequencies on their own, and a mismatch against the cached
-        # cos/sin breaks context-vs-query attention and collapses acceptance.
+
+        has_qk_norm = self._has_qk_norm
+        is_bf16 = noise_embedding.dtype == torch.bfloat16
+        use_fused_qk_norm_rope = self._use_fused_qk_norm_rope and is_bf16
         use_fused_rope = (_flashinfer_rope is not None and has_qk_norm
-                          and noise_embedding.dtype == torch.bfloat16)
+                          and is_bf16 and not use_fused_qk_norm_rope)
 
         B = noise_embedding.shape[0]
         block_size = noise_embedding.shape[1]
@@ -1217,7 +1238,24 @@ class DFlashForCausalLM(nn.Module):
             # QKV projection on normed query tokens (2D)
             qkv_query = attn_mod.qkv_proj(hs_normed_flat)  # [B*blk, qkv_size]
 
-            if use_fused_rope:
+            if use_fused_qk_norm_rope:
+                # One kernel does q_norm + k_norm + RoPE in-place on qkv.
+                # Only safe when the drafter's rope params don't use YaRN /
+                # long-rope / partial-rotary — otherwise fall back to the
+                # shared-cache path below.
+                attn_mod.apply_qk_norm_rope(qkv_query, query_positions_flat_i32)
+                q_all_2d = qkv_query[:, :q_size]
+                k_noise_2d = qkv_query[:, q_size:q_size + kv_size]
+                v_noise_2d = qkv_query[:, q_size + kv_size:]
+                Q_bshd = q_all_2d.reshape(B, block_size, num_heads_per_rank,
+                                          head_dim)
+                k_noise_bshd = k_noise_2d.reshape(B, block_size,
+                                                  num_kv_heads_per_rank,
+                                                  head_dim)
+                v_noise_bshd = v_noise_2d.reshape(B, block_size,
+                                                  num_kv_heads_per_rank,
+                                                  head_dim)
+            elif use_fused_rope:
                 # Per-head RMSNorm on q/k (returns new contiguous tensors),
                 # then flashinfer in-place RoPE sharing the same cos/sin cache
                 # as precompute_context_kv.
@@ -1279,9 +1317,8 @@ class DFlashForCausalLM(nn.Module):
             layer_k_cache = ctx_k_cache[:, layer_idx]
             layer_v_cache = ctx_v_cache[:, layer_idx]
 
-            # flash_attn writes k_noise/v_noise in-place into the cache at
-            # positions cache_seqlens[i]..+block_size for each batch i.
-            # Replaces the old torch.scatter_ step.
+            # flash_attn appends k_noise/v_noise in-place at
+            # cache_seqlens[i]..+block_size for each batch i.
             out = flash_attn_with_kvcache(
                 q=Q_bshd,
                 k_cache=layer_k_cache,

--- a/tensorrt_llm/_torch/models/modeling_speculative.py
+++ b/tensorrt_llm/_torch/models/modeling_speculative.py
@@ -862,7 +862,8 @@ class DFlashForCausalLM(nn.Module):
         # Lazy-built after weights load (see _build_fused_kv_buffers).
         self._fused_kv_weight = None
         self._fused_kv_bias = None
-        self._k_norm_weights = None
+        self._k_norm_stacked = None
+        self._k_norm_eps = None
         self._num_attn_layers = 0
         self._head_dim = 0
         self._num_kv_heads = 0
@@ -998,9 +999,11 @@ class DFlashForCausalLM(nn.Module):
         k = kv[:, :, 0].contiguous()
         v = kv[:, :, 1].contiguous()
 
-        if self._k_norm_weights:
-            for i in range(L):
-                k[:, i] = self.model.layers[i].self_attn.k_norm(k[:, i])
+        if self._k_norm_stacked is not None:
+            # Fuse L per-layer RMSNorms into one. k is [N, L, nkv, hd];
+            # each layer has its own weight ([L, hd]) but shares eps.
+            k = F.rms_norm(k, (hd, ), eps=self._k_norm_eps)
+            k = k * self._k_norm_stacked.view(1, L, 1, hd)
 
         self._fused_rope_inplace(k.view(N * L, nkv * hd), positions, N, L)
         return k, v
@@ -1105,8 +1108,19 @@ class DFlashForCausalLM(nn.Module):
         else:
             self._fused_kv_bias = None
 
-        self._k_norm_weights = ([a.k_norm.weight.data for a in layers_attn]
-                                if all(has_k_norm) else None)
+        if all(has_k_norm):
+            k_norm0 = layers_attn[0].k_norm
+            eps = k_norm0.variance_epsilon
+            eps_set = {a.k_norm.variance_epsilon for a in layers_attn}
+            assert len(eps_set) == 1, (
+                f"DFlash fused k_norm requires all drafter layers to share "
+                f"variance_epsilon; got {sorted(eps_set)}.")
+            self._k_norm_stacked = torch.stack(
+                [a.k_norm.weight.data for a in layers_attn])
+            self._k_norm_eps = eps
+        else:
+            self._k_norm_stacked = None
+            self._k_norm_eps = None
         self._num_attn_layers = len(layers_attn)
         self._head_dim = head_dim
         self._num_kv_heads = num_kv_heads

--- a/tensorrt_llm/_torch/modules/mamba/gdn_mixer.py
+++ b/tensorrt_llm/_torch/modules/mamba/gdn_mixer.py
@@ -466,7 +466,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
         num_decodes = kwargs["num_decodes"]
 
         if is_target_verify:
-            draft_token_num = spec_metadata.max_draft_len + 1
+            draft_token_num = spec_metadata.max_total_draft_tokens + 1
             assert num_decodes > 0
             assert mixed_qkv.shape[0] == num_decodes * draft_token_num
             assert a.shape[0] == num_decodes * draft_token_num
@@ -634,7 +634,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
             )
 
             if is_target_verify:
-                draft_token_num = spec_metadata.max_draft_len + 1
+                draft_token_num = spec_metadata.max_total_draft_tokens + 1
                 assert num_decodes > 0
                 assert mixed_qkv_d.shape[0] == num_decodes * draft_token_num
                 assert a_d.shape[0] == num_decodes * draft_token_num
@@ -738,7 +738,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
                 last_recurrent_state = last_recurrent_state.to(ssm_states.dtype, copy=False)
                 ssm_states[state_indices_p] = last_recurrent_state
 
-            draft_token_num = spec_metadata.max_draft_len + 1
+            draft_token_num = spec_metadata.max_total_draft_tokens + 1
             query_d = query[:, num_prefill_tokens:, :, :].reshape(
                 num_decodes, draft_token_num, self.num_k_heads // self.attn_tp_size, self.head_k_dim
             )

--- a/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
@@ -868,7 +868,7 @@ class MixedMambaHybridCacheManager(KVCacheManager, MambaCacheManager):
             mamba_ssm_cache_dtype,
             mamba_layer_mask,
             execution_stream,
-            speculative_num_draft_tokens=(spec_config.max_draft_len
+            speculative_num_draft_tokens=(spec_config.tokens_per_gen_step - 1
                                           if spec_config is not None else None),
             model_type=model_type,
             use_replay_state_update=use_replay_state_update,

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -420,8 +420,12 @@ class PyTorchModelEngine(ModelEngine):
             self.without_logits = self.spec_config.spec_dec_mode.without_logits(
             ) or self.model_is_wrapped
             self.max_total_draft_tokens = spec_config.tokens_per_gen_step - 1
-            # PARD/DFlash use 2K tokens per gen request (K accepted + K masks), so
-            # their per-request draft buffer width is 2K-1 = max_total_draft_tokens.
+            # Parallel-draft modes (PARD, DFlash) size their per-request draft
+            # buffer by tokens_per_gen_step - 1 so the engine reserves exactly
+            # one slot per draft token the target will verify.  PARD still uses
+            # 2K tokens per gen req (K drafts + K mask fillers); DFlash was
+            # reduced to K+1 (K drafts + 1 bonus) - the spec config's
+            # tokens_per_gen_step carries the per-algorithm width.
             if spec_config.spec_dec_mode.is_parallel_draft():
                 self.max_draft_len = self.max_total_draft_tokens
             else:
@@ -3898,9 +3902,10 @@ class PyTorchModelEngine(ModelEngine):
             # to spec_metadata so downstream code (eagle3, interface, trtllm) can read it.
             spec_metadata.runtime_draft_len = self.runtime_draft_len
 
-            # PARD/DFlash have 2K tokens per gen request, not K+1.  Pass 2K-1
-            # so generation_lengths = 2K and the XQA kernel computes
-            # the correct past_kv_len.
+            # Parallel-draft modes advertise a per-gen-step width via
+            # tokens_per_gen_step (PARD: 2K, DFlash: K+1).  Pass
+            # (tokens_per_gen_step - 1) so generation_lengths = tokens_per_gen_step
+            # and the XQA kernel computes the correct past_kv_len.
             if spec_metadata.spec_dec_mode.is_parallel_draft():
                 sd_max_draft_len = self.original_max_total_draft_tokens
                 sd_max_total = self.original_max_total_draft_tokens

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1636,8 +1636,14 @@ class PyTorchModelEngine(ModelEngine):
                     'attn_metadata'].num_chunked_ctx_requests
                 previous_batch_tokens = inputs['input_ids'].shape[
                     0] - num_ctx_tokens
-                inputs['position_ids'][0, num_ctx_tokens:] += (
-                    self.previous_pos_id_offsets_cuda[:previous_batch_tokens])
+                if inputs['position_ids'].ndim == 3:  # mrope: [3, 1, N]
+                    inputs['position_ids'][:, :, num_ctx_tokens:] += (
+                        self.
+                        previous_pos_id_offsets_cuda[:previous_batch_tokens])
+                else:
+                    inputs['position_ids'][0, num_ctx_tokens:] += (
+                        self.
+                        previous_pos_id_offsets_cuda[:previous_batch_tokens])
                 if hasattr(inputs['attn_metadata'], 'kv_lens_cuda'):
                     if num_ctx_requests >= num_chunked_ctx_requests and num_chunked_ctx_requests > 0:
                         # The generation requests with draft_tokens are treated as chunked context requests when extend_ctx returns True.
@@ -1677,8 +1683,14 @@ class PyTorchModelEngine(ModelEngine):
                     'attn_metadata'].num_chunked_ctx_requests
                 previous_batch_tokens = inputs['input_ids'].shape[
                     0] - num_ctx_tokens
-                inputs['position_ids'][0, num_ctx_tokens:] -= (
-                    self.previous_pos_id_offsets_cuda[:previous_batch_tokens])
+                if inputs['position_ids'].ndim == 3:  # mrope: [3, 1, N]
+                    inputs['position_ids'][:, :, num_ctx_tokens:] -= (
+                        self.
+                        previous_pos_id_offsets_cuda[:previous_batch_tokens])
+                else:
+                    inputs['position_ids'][0, num_ctx_tokens:] -= (
+                        self.
+                        previous_pos_id_offsets_cuda[:previous_batch_tokens])
                 # Only TrtllmAttentionMetadata has kv_lens_cuda.
                 if isinstance(inputs['attn_metadata'], TrtllmAttentionMetadata):
                     if num_ctx_requests >= num_chunked_ctx_requests and num_chunked_ctx_requests > 0:

--- a/tensorrt_llm/_torch/speculative/dflash.py
+++ b/tensorrt_llm/_torch/speculative/dflash.py
@@ -25,6 +25,7 @@ from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
 from ..attention_backend import AttentionMetadata
+from ..pyexecutor.mamba_cache_manager import MambaHybridCacheManager
 from ..pyexecutor.resource_manager import BaseResourceManager
 from .interface import SpecMetadata, SpecWorkerBase
 
@@ -397,6 +398,14 @@ class DFlashWorker(SpecWorkerBase):
             logits_for_accept, draft_tokens, num_contexts, batch_size, spec_metadata
         )
 
+        # Update GDN/Mamba recurrent states to the accepted token's state.
+        if num_gens > 0 and isinstance(attn_metadata.kv_cache_manager, MambaHybridCacheManager):
+            attn_metadata.kv_cache_manager.update_mamba_states(
+                attn_metadata=attn_metadata,
+                num_accepted_tokens=num_accepted_tokens,
+                state_indices=attn_metadata.mamba_metadata.state_indices,
+            )
+
         # Pad accepted_tokens from (batch, K+1) to (batch, 2K) to match sampler buffer
         if K > 1:
             acc_padding = torch.zeros(
@@ -409,7 +418,12 @@ class DFlashWorker(SpecWorkerBase):
             attn_metadata, num_accepted_tokens, num_contexts, batch_size
         )
 
-        position_ids = position_ids.squeeze(0)
+        # Collapse mrope [3, 1, N] to 1D by taking the first (temporal) dimension.
+        # The draft model uses standard 1D RoPE, so only scalar positions are needed.
+        if position_ids.ndim == 3:
+            position_ids = position_ids[0, 0]
+        else:
+            position_ids = position_ids.squeeze(0)
 
         # Get total tokens processed by target model (for hidden state extraction)
         total_target_tokens = input_ids.shape[0]

--- a/tensorrt_llm/_torch/speculative/dflash.py
+++ b/tensorrt_llm/_torch/speculative/dflash.py
@@ -675,8 +675,8 @@ class DFlashWorker(SpecWorkerBase):
                     proj_flat.to(self._ctx_k_buf.dtype), pos_flat
                 )
                 mask_bc = mask_1d.view(-1, 1, 1, 1).to(k_new.dtype)
-                k_new = k_new * mask_bc
-                v_new = v_new * mask_bc
+                k_new.mul_(mask_bc)
+                v_new.mul_(mask_bc)
                 slot_long = slot_flat.long()
                 col_long = col_flat.long()
                 self._ctx_k_buf[slot_long, :, col_long] = k_new

--- a/tensorrt_llm/_torch/speculative/dflash.py
+++ b/tensorrt_llm/_torch/speculative/dflash.py
@@ -168,16 +168,15 @@ class DFlashWorker(SpecWorkerBase):
         self._resolved_mask_token_id = None
         self._resolved_block_size = None
 
-        # Pre-allocated context buffers (lazy-init on first forward).
-        # Replaces per-request Python dicts with fixed-size CUDA buffers
-        # indexed by slot, enabling CUDA graph compatibility.
+        # Pre-allocated per-slot context K/V buffers, built lazily on the
+        # first forward. Fixed-size so slot-indexed reads/writes are CUDA
+        # graph compatible.
         self._ctx_buf_inited = False
-        self._ctx_buf = None  # [max_batch, max_ctx, proj_dim]
-        self._ctx_pos_buf = None  # [max_batch, max_ctx]
-        self._ctx_len = None  # [max_batch] actual context length per slot
-        self._batch_to_slot = None  # [max_batch] maps batch pos -> buffer slot
+        self._ctx_len = None
+        self._batch_to_slot = None
         self._max_ctx = 0
-        self._proj_dim = 0
+        self._ctx_k_buf = None  # [max_batch, L, max_ctx+block, nkv, hd]
+        self._ctx_v_buf = None
 
         # Slot management (Python, updated in prepare() and eager mode)
         self._req_to_slot = {}  # request_id -> slot index
@@ -201,16 +200,10 @@ class DFlashWorker(SpecWorkerBase):
         return 2 * self.max_draft_len
 
     def _lazy_init_ctx_buffers(self, draft_model, spec_metadata):
-        """Initialize pre-allocated context buffers on first forward."""
         if self._ctx_buf_inited:
             return
 
         max_batch = spec_metadata.max_num_requests
-
-        if hasattr(draft_model, "fc"):
-            self._proj_dim = draft_model.fc.weight.shape[0]
-        else:
-            self._proj_dim = spec_metadata.hidden_size
 
         config_max_ctx = getattr(self.spec_config, "max_ctx_len", None)
         if config_max_ctx is not None:
@@ -222,20 +215,30 @@ class DFlashWorker(SpecWorkerBase):
 
         dtype = draft_model.fc.weight.dtype if hasattr(draft_model, "fc") else torch.bfloat16
 
-        self._ctx_buf = torch.zeros(
-            (max_batch, self._max_ctx, self._proj_dim), dtype=dtype, device="cuda"
-        )
-        self._ctx_pos_buf = torch.zeros((max_batch, self._max_ctx), dtype=torch.long, device="cuda")
         self._ctx_len = torch.zeros(max_batch, dtype=torch.long, device="cuda")
         self._batch_to_slot = torch.zeros(max_batch, dtype=torch.long, device="cuda")
 
         self._free_slots = deque(range(max_batch))
         self._req_to_slot = {}
+
+        # +block_size slack lets per-iter noise K/V scatter into the gathered
+        # view and flash_attn read it in place.
+        assert hasattr(draft_model, "_build_fused_kv_buffers"), (
+            "DFlash draft model must define _build_fused_kv_buffers."
+        )
+        draft_model._build_fused_kv_buffers()
+        L = draft_model._num_attn_layers
+        nkv = draft_model._num_kv_heads
+        hd = draft_model._head_dim
+        block_size = getattr(draft_model, "block_size", None) or (self.max_draft_len + 1)
+        kv_shape = (max_batch, L, self._max_ctx + block_size, nkv, hd)
+        self._ctx_k_buf = torch.zeros(kv_shape, dtype=dtype, device="cuda")
+        self._ctx_v_buf = torch.zeros(kv_shape, dtype=dtype, device="cuda")
         self._ctx_buf_inited = True
 
         logger.info(
             f"DFlash: allocated ctx buffers: max_batch={max_batch}, "
-            f"max_ctx={self._max_ctx}, proj_dim={self._proj_dim}, dtype={dtype}"
+            f"max_ctx={self._max_ctx}, dtype={dtype}"
         )
 
     def _prepare_attn_metadata_for_dflash(self, attn_metadata, spec_metadata):
@@ -343,9 +346,16 @@ class DFlashWorker(SpecWorkerBase):
             end = min(cur + slen, self._max_ctx)
             actual = end - cur
             if actual > 0:
-                self._ctx_buf[slot, cur:end] = chunk_proj[:actual].to(self._ctx_buf.dtype)
-                self._ctx_pos_buf[slot, cur:end] = chunk_pos[:actual]
+                chunk_proj_cast = chunk_proj[:actual].to(self._ctx_k_buf.dtype)
                 self._ctx_len[slot] = end
+                # Precompute post-norm/post-RoPE K,V for this prefill chunk
+                # so decode iters can read without re-projecting.
+                chunk_k, chunk_v = draft_model.precompute_context_kv(
+                    chunk_proj_cast, chunk_pos[:actual]
+                )
+                # chunk_k/v: [actual, L, nkv, hd] → [L, actual, nkv, hd]
+                self._ctx_k_buf[slot, :, cur:end] = chunk_k.permute(1, 0, 2, 3)
+                self._ctx_v_buf[slot, :, cur:end] = chunk_v.permute(1, 0, 2, 3)
             offset += slen
 
     def forward(
@@ -458,13 +468,13 @@ class DFlashWorker(SpecWorkerBase):
 
         if num_gens > 0:
             with self.draft_kv_cache_context(attn_metadata, draft_kv_cache_manager):
-                # Use custom dflash_forward with cross-attention
                 hidden_states_out = draft_model.dflash_forward(
                     noise_embedding=inputs["noise_embedding"],
-                    target_hidden=inputs["target_hidden"],
                     query_positions=inputs["query_positions"],
-                    context_positions=inputs["context_positions"],
                     num_ctx_per_req=inputs["num_ctx_per_req"],
+                    ctx_k_cache=inputs["ctx_k_cache"],
+                    ctx_v_cache=inputs["ctx_v_cache"],
+                    ctx_cache_batch_idx=inputs["ctx_cache_batch_idx"],
                 )
 
                 # Gather K logits per gen request from mask positions (1..K).
@@ -546,17 +556,14 @@ class DFlashWorker(SpecWorkerBase):
         draft_model: nn.Module,
         total_target_tokens: int = 0,
     ):
-        """
-        Prepare inputs for DFlash draft model with proper cross-attention.
+        """Prepare inputs for DFlash's draft forward.
 
         For gen requests, builds:
-        - noise_embedding: token embeddings for [accepted_tokens + mask_tokens] (2K per req)
-        - target_hidden: projected target features at accepted positions (context for cross-attn)
-        - query_positions: position IDs for all 2K query tokens
-        - context_positions: position IDs for the accepted (context) tokens
-        - num_ctx_per_req: per-request context token counts
-
-        The target_hidden stays CONSTANT across layers and provides K/V context.
+        - noise_embedding: token embeddings for [accepted + mask] tokens
+        - query_positions: position IDs for the query tokens
+        - num_ctx_per_req: per-request context length in the pool
+        - ctx_k_cache / ctx_v_cache / ctx_cache_batch_idx: slot-indexed
+          views of the persistent per-layer K/V pool.
         """
         num_contexts = attn_metadata.num_contexts
         batch_size = attn_metadata.num_seqs
@@ -657,7 +664,6 @@ class DFlashWorker(SpecWorkerBase):
                     gen_hs_to_project.to(draft_model.fc.weight.dtype)
                 )
                 projected_to_store = draft_model.hidden_norm(projected_to_store)
-                projected_to_store = projected_to_store.reshape(num_gens, K + 1, -1)
                 gen_num_accepted_long = gen_num_accepted.long()
                 col_idx = self._ctx_len[slots].unsqueeze(1) + offsets_kp1.unsqueeze(0)
                 write_mask = offsets_kp1.unsqueeze(0) < gen_num_accepted_long.unsqueeze(1)
@@ -669,25 +675,27 @@ class DFlashWorker(SpecWorkerBase):
                 # _ctx_len range, so they're harmless.
                 slot_flat = slots.unsqueeze(1).expand(-1, K + 1).reshape(-1)
                 col_flat = col_idx.reshape(-1)
-                proj_flat = projected_to_store.reshape(-1, self._proj_dim)
+                proj_flat = projected_to_store  # already [num_gens*(K+1), proj_dim]
                 pos_flat = ctx_position_ids.long().reshape(-1)
-
                 mask_1d = write_mask.reshape(-1)
-                proj_masked = proj_flat * mask_1d.unsqueeze(1).to(proj_flat.dtype)
-                pos_masked = pos_flat * mask_1d.long()
 
-                self._ctx_buf[slot_flat, col_flat] = proj_masked.to(self._ctx_buf.dtype)
-                self._ctx_pos_buf[slot_flat, col_flat] = pos_masked
+                # Fast path: store the pre-projected/pre-RoPE'd K/V.
+                # dflash_forward reads these directly via cache_batch_idx.
+                k_new, v_new = draft_model.precompute_context_kv(
+                    proj_flat.to(self._ctx_k_buf.dtype), pos_flat
+                )
+                mask_bc = mask_1d.view(-1, 1, 1, 1).to(k_new.dtype)
+                k_new = k_new * mask_bc
+                v_new = v_new * mask_bc
+                slot_long = slot_flat.long()
+                col_long = col_flat.long()
+                self._ctx_k_buf[slot_long, :, col_long] = k_new
+                self._ctx_v_buf[slot_long, :, col_long] = v_new
 
                 self._ctx_len[slots] += gen_num_accepted_long
                 self._ctx_len.clamp_(max=self._max_ctx)
 
-            # Read padded context from buffers (fixed shape for CUDA graph)
-            target_hidden = self._ctx_buf[slots]
-            context_positions = self._ctx_pos_buf[slots].long()
             num_ctx_per_req_t = self._ctx_len[slots]
-
-            # 3D padded tensors for CUDA graph compatible dflash_forward
             noise_embedding = noise_embed_2d
             query_positions = query_position_ids.long()
 
@@ -698,15 +706,15 @@ class DFlashWorker(SpecWorkerBase):
             attn_metadata._seq_lens[num_contexts : num_contexts + num_gens] = total_tokens_per_req
         else:
             noise_embedding = hidden_states.new_empty(0, 0, hidden_dim)
-            target_hidden = hidden_states.new_empty(0, 0, hidden_dim)
             query_positions = torch.empty(0, 0, dtype=torch.long, device="cuda")
-            context_positions = torch.empty(0, 0, dtype=torch.long, device="cuda")
             num_ctx_per_req_t = torch.empty(0, dtype=torch.long, device="cuda")
+            slots = torch.empty(0, dtype=torch.long, device="cuda")
 
         return {
             "noise_embedding": noise_embedding,
-            "target_hidden": target_hidden,
             "query_positions": query_positions,
-            "context_positions": context_positions,
             "num_ctx_per_req": num_ctx_per_req_t,
+            "ctx_k_cache": self._ctx_k_buf,
+            "ctx_v_cache": self._ctx_v_buf,
+            "ctx_cache_batch_idx": slots,
         }

--- a/tensorrt_llm/_torch/speculative/dflash.py
+++ b/tensorrt_llm/_torch/speculative/dflash.py
@@ -220,6 +220,10 @@ class DFlashWorker(SpecWorkerBase):
         self._free_slots = deque(range(max_batch))
         self._req_to_slot = {}
 
+        self._resolved_block_size = getattr(draft_model, "block_size", None) or (
+            self.max_draft_len + 1
+        )
+
         # +block_size slack lets per-iter noise K/V scatter into the gathered
         # view and flash_attn read it in place.
         assert hasattr(draft_model, "_build_fused_kv_buffers"), (
@@ -229,8 +233,7 @@ class DFlashWorker(SpecWorkerBase):
         L = draft_model._num_attn_layers
         nkv = draft_model._num_kv_heads
         hd = draft_model._head_dim
-        block_size = getattr(draft_model, "block_size", None) or (self.max_draft_len + 1)
-        kv_shape = (max_batch, L, self._max_ctx + block_size, nkv, hd)
+        kv_shape = (max_batch, L, self._max_ctx + self._resolved_block_size, nkv, hd)
         self._ctx_k_buf = torch.zeros(kv_shape, dtype=dtype, device="cuda")
         self._ctx_v_buf = torch.zeros(kv_shape, dtype=dtype, device="cuda")
         self._ctx_buf_inited = True
@@ -585,11 +588,6 @@ class DFlashWorker(SpecWorkerBase):
                     "or ensure the draft model config has 'dflash_config.mask_token_id' or 'mask_token_id'."
                 )
         mask_token_id = self._resolved_mask_token_id
-
-        if self._resolved_block_size is None:
-            self._resolved_block_size = getattr(draft_model, "block_size", None) or (
-                self.max_draft_len + 1
-            )
 
         # Get the embed_tokens layer from the draft model
         embed_tokens = draft_model.draft_model_full.model.embed_tokens

--- a/tensorrt_llm/_torch/speculative/dflash.py
+++ b/tensorrt_llm/_torch/speculative/dflash.py
@@ -164,7 +164,6 @@ class DFlashWorker(SpecWorkerBase):
         super().__init__(use_separate_draft_kv_cache)
         self.spec_config = spec_config
         self.mapping = mapping
-        self._mask_embed = None  # Cached mask token embedding (CUDA-graph safe)
         self._resolved_mask_token_id = None
         self._resolved_block_size = None
 
@@ -617,40 +616,33 @@ class DFlashWorker(SpecWorkerBase):
             block_size = self._resolved_block_size
             query_tokens_per_req = block_size
 
-            if self._mask_embed is None:
-                mask_token = torch.tensor([mask_token_id], dtype=torch.long, device="cuda")
-                self._mask_embed = embed_tokens(mask_token).detach()
-
-            # Start with all mask embeddings for block_size tokens
-            noise_embed_2d = self._mask_embed.expand(
-                num_gens * query_tokens_per_req, hidden_dim
-            ).clone()
-            noise_embed_2d = noise_embed_2d.reshape(num_gens, query_tokens_per_req, hidden_dim)
-
-            # Fill position 0 (bonus) with embedding of last accepted token
-            bonus_indices = (gen_num_accepted - 1).long().clamp(min=0).unsqueeze(1)
-            bonus_token_ids = gen_accepted_tokens.gather(1, bonus_indices).squeeze(1)
-            bonus_embeds = embed_tokens(bonus_token_ids.long())
-            noise_embed_2d[:, 0, :] = bonus_embeds.to(noise_embed_2d.dtype)
-
             # Get slots for gen requests from pre-computed mapping
             slots = self._batch_to_slot[num_contexts : num_contexts + num_gens]
 
-            # Position starts from accumulated context length (BEFORE
-            # adding current step's features).
-            gen_pos_starts = self._ctx_len[slots].int()
+            K_plus_1 = K + 1
 
-            # Context positions for storing new accepted tokens (reused below)
-            offsets_kp1 = torch.arange(K + 1, dtype=torch.long, device="cuda")
-            ctx_position_ids = (
-                gen_pos_starts.unsqueeze(1) + offsets_kp1.unsqueeze(0).int()
-            )  # [num_gens, K+1]
+            bonus_idx = (gen_num_accepted - 1).clamp_min(0).long().unsqueeze(1)
+            bonus = gen_accepted_tokens.gather(1, bonus_idx).squeeze(1).long()
 
-            # Query positions start AFTER the full context including current
-            # step's accepted features
-            gen_query_start = gen_pos_starts + gen_num_accepted.to(torch.int32)
-            query_offsets = torch.arange(query_tokens_per_req, dtype=torch.int32, device="cuda")
-            query_position_ids = gen_query_start.unsqueeze(1) + query_offsets.unsqueeze(0)
+            ctx_len_gen = self._ctx_len[slots]
+            j_block = torch.arange(query_tokens_per_req, dtype=torch.long, device="cuda")
+            offsets_kp1 = torch.arange(K_plus_1, dtype=torch.long, device="cuda")
+
+            query_position_ids = (
+                ctx_len_gen.unsqueeze(1)
+                + gen_num_accepted.long().unsqueeze(1)
+                + j_block.unsqueeze(0)
+            )
+            ctx_position_ids = ctx_len_gen.unsqueeze(1) + offsets_kp1.unsqueeze(0)
+
+            # Go through embed_tokens.forward (NOT .weight[...]) so TP-sharded
+            # vocabs mask out ranks that don't own the token id and all-reduce.
+            mask_tok = torch.full((1,), int(mask_token_id), dtype=torch.long, device="cuda")
+            combined_embed = embed_tokens(torch.cat([bonus, mask_tok], dim=0))
+            embed_bonus = combined_embed[:num_gens]
+            embed_mask = combined_embed[num_gens]
+            noise_embed_2d = embed_mask.expand(num_gens, query_tokens_per_req, -1).clone()
+            noise_embed_2d[:, 0, :] = embed_bonus
 
             # Accumulate new accepted features into context buffers
             if has_target_features:

--- a/tensorrt_llm/_torch/speculative/dflash.py
+++ b/tensorrt_llm/_torch/speculative/dflash.py
@@ -191,12 +191,14 @@ class DFlashWorker(SpecWorkerBase):
 
     @property
     def _draft_tokens_per_req(self) -> int:
-        """Total tokens per gen request in the draft forward.
+        """Target-forward tokens per gen request: K drafts + 1 bonus.
 
-        Uses 2K to fit all accepted tokens (up to K+1) plus K-1 mask tokens,
-        ensuring K unique predictions regardless of how many tokens were accepted.
+        Previously this was 2K (K+1 accepted + K-1 mask fillers), but the
+        fillers contribute nothing beyond the K+1 prefix the acceptance
+        check and context store consume, so carrying them through every
+        target layer is wasted work that dominates step time at large batch.
         """
-        return 2 * self.max_draft_len
+        return self.max_draft_len + 1
 
     def _lazy_init_ctx_buffers(self, draft_model, spec_metadata):
         if self._ctx_buf_inited:
@@ -389,22 +391,14 @@ class DFlashWorker(SpecWorkerBase):
 
         self._execute_guided_decoder_if_present(logits)
 
-        # draft_tokens buffer has (2K-1) entries per gen request; extract the K real drafts
+        # Target now emits K+1 logits per gen request and the previous step
+        # stored K draft tokens per gen request (no filler padding).
         if num_gens > 0:
-            draft_tokens_raw = spec_metadata.draft_tokens
-            draft_tokens = draft_tokens_raw.reshape(num_gens, 2 * K - 1)[:, :K]
+            draft_tokens = spec_metadata.draft_tokens.reshape(num_gens, K)
         else:
             draft_tokens = spec_metadata.draft_tokens.reshape(0, K)
 
-        # logits have 2K entries per gen request; extract K+1 for acceptance
-        if num_gens > 0:
-            ctx_logits = logits[:num_contexts]
-            vocab_size = logits.shape[-1]
-            gen_logits_2k = logits[num_contexts:].reshape(num_gens, 2 * K, vocab_size)
-            gen_logits_kp1 = gen_logits_2k[:, : K + 1, :].reshape(-1, vocab_size)
-            logits_for_accept = torch.cat([ctx_logits, gen_logits_kp1], dim=0)
-        else:
-            logits_for_accept = logits
+        logits_for_accept = logits
 
         accepted_tokens, num_accepted_tokens = self._sample_and_accept_draft_tokens_base(
             logits_for_accept, draft_tokens, num_contexts, batch_size, spec_metadata
@@ -417,13 +411,6 @@ class DFlashWorker(SpecWorkerBase):
                 num_accepted_tokens=num_accepted_tokens,
                 state_indices=attn_metadata.mamba_metadata.state_indices,
             )
-
-        # Pad accepted_tokens from (batch, K+1) to (batch, 2K) to match sampler buffer
-        if K > 1:
-            acc_padding = torch.zeros(
-                (batch_size, K - 1), dtype=accepted_tokens.dtype, device=accepted_tokens.device
-            )
-            accepted_tokens = torch.cat([accepted_tokens, acc_padding], dim=1)
 
         self._prepare_attn_metadata_for_dflash(attn_metadata, spec_metadata)
         self._prepare_kv_for_draft_forward(
@@ -503,23 +490,14 @@ class DFlashWorker(SpecWorkerBase):
 
                 gen_draft_tokens = gen_draft_tokens.type(torch.int32)
 
-                # Pad from (num_gens, K) to (num_gens, 2K-1).
-                if K > 1:
-                    pad = torch.zeros((num_gens, K - 1), dtype=torch.int32, device="cuda")
-                    gen_draft_tokens = torch.cat([gen_draft_tokens, pad], dim=1)
-
         else:
-            gen_draft_tokens = torch.empty((0, 2 * K - 1), dtype=torch.int32, device="cuda")
+            gen_draft_tokens = torch.empty((0, K), dtype=torch.int32, device="cuda")
 
         if num_contexts > 0 and num_gens > 0:
-            ctx_draft_tokens = torch.zeros(
-                (num_contexts, 2 * K - 1), dtype=torch.int32, device="cuda"
-            )
+            ctx_draft_tokens = torch.zeros((num_contexts, K), dtype=torch.int32, device="cuda")
             next_draft_tokens = torch.cat([ctx_draft_tokens, gen_draft_tokens], dim=0)
         elif num_contexts > 0:
-            next_draft_tokens = torch.zeros(
-                (num_contexts, 2 * K - 1), dtype=torch.int32, device="cuda"
-            )
+            next_draft_tokens = torch.zeros((num_contexts, K), dtype=torch.int32, device="cuda")
         else:
             next_draft_tokens = gen_draft_tokens
 
@@ -599,7 +577,7 @@ class DFlashWorker(SpecWorkerBase):
             gen_num_accepted = num_accepted_tokens[num_contexts : num_contexts + num_gens]
             gen_accepted_tokens = accepted_tokens[num_contexts : num_contexts + num_gens, :]
 
-            total_tokens_per_req = self._draft_tokens_per_req  # 2K
+            total_tokens_per_req = self._draft_tokens_per_req  # K+1
             K = self.max_draft_len
 
             # Get captured multi-layer hidden states from spec_metadata
@@ -645,11 +623,10 @@ class DFlashWorker(SpecWorkerBase):
             # Accumulate new accepted features into context buffers
             if has_target_features:
                 gen_start = attn_metadata.num_ctx_tokens
+                # Target now processes exactly K+1 tokens per gen req, so the
+                # captured slice is already the full set we need to project.
                 gen_hs = captured_hs[gen_start : gen_start + num_gens * total_tokens_per_req]
-                gen_hs = gen_hs.reshape(num_gens, total_tokens_per_req, -1)
-
-                # Only project K+1 tokens (the accepted ones), not all 2K
-                gen_hs_to_project = gen_hs[:, : K + 1, :].reshape(-1, gen_hs.shape[-1])
+                gen_hs_to_project = gen_hs.reshape(-1, gen_hs.shape[-1])
                 projected_to_store = draft_model.fc(
                     gen_hs_to_project.to(draft_model.fc.weight.dtype)
                 )
@@ -689,7 +666,8 @@ class DFlashWorker(SpecWorkerBase):
             noise_embedding = noise_embed_2d
             query_positions = query_position_ids.long()
 
-            # Update seq_lens for gen requests to 2K
+            # Update seq_lens for gen requests to K+1 (the number of tokens
+            # the target forward actually processed).
             attn_metadata._seq_lens_cuda[num_contexts : num_contexts + num_gens] = (
                 total_tokens_per_req
             )

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1753,8 +1753,12 @@ class DFlashDecodingConfig(DecodingBaseConfig):
 
     @property
     def tokens_per_gen_step(self) -> int:
-        """DFlash needs 2K tokens per gen request: K+1 accepted + K-1 masks."""
-        return 2 * self.max_draft_len
+        """DFlash only needs K+1 tokens per gen request (K drafts + 1 bonus).
+
+        The draft produces its own mask queries internally; passing mask
+        fillers through the target is pure wasted work at large batch size.
+        """
+        return self.max_draft_len + 1
 
     def supports_backend(self, backend: str) -> bool:
         return backend == "pytorch"

--- a/tests/integration/defs/accuracy/references/gsm8k.yaml
+++ b/tests/integration/defs/accuracy/references/gsm8k.yaml
@@ -200,6 +200,10 @@ Qwen/Qwen3.5-4B:
   - quant_algo: FP8_BLOCK_SCALES
     kv_cache_quant_algo: FP8
     accuracy: 80.5
+  - spec_dec_algo: DFlash
+    quant_algo: FP8_BLOCK_SCALES
+    kv_cache_quant_algo: FP8
+    accuracy: 80.5
 Qwen/Qwen3.5-35B-A3B:
   - dtype: bfloat16
     accuracy: 89.196

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -6204,6 +6204,22 @@ class TestQwen3_5_4B(LlmapiAccuracyTestHarness):
             task.evaluate(llm,
                           extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS)
 
+    @skip_pre_hopper
+    def test_dflash(self):
+        target_model_path = f"{llm_models_root()}/Qwen3.5-4B-FP8"
+        dflash_model_path = f"{llm_models_root()}/Qwen3.5-4B-DFlash"
+        spec_config = DFlashDecodingConfig(max_draft_len=4,
+                                           speculative_model=dflash_model_path)
+        with LLM(target_model_path,
+                 max_seq_len=4096,
+                 max_batch_size=8,
+                 kv_cache_config=self.kv_cache_config,
+                 cuda_graph_config=self.cuda_graph_config,
+                 speculative_config=spec_config) as llm:
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm,
+                          extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS)
+
 
 @pytest.mark.skip_less_device_memory(80000)
 class TestQwen3_5_35B_A3B(LlmapiAccuracyTestHarness):

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -732,6 +732,7 @@ accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B_Instruct_2507::test_skip_sof
 accuracy/test_llm_api_pytorch.py::TestQwen3_4B::test_eagle3
 accuracy/test_llm_api_pytorch.py::TestQwen3_5_4B::test_bf16
 accuracy/test_llm_api_pytorch.py::TestQwen3_5_4B::test_fp8
+accuracy/test_llm_api_pytorch.py::TestQwen3_5_4B::test_dflash
 accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_bf16
 accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_fp8[enable_block_reuse=False]
 accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_fp8[enable_block_reuse=True]

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -136,6 +136,7 @@ l0_h100:
   - accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_dflash
   - accuracy/test_llm_api_pytorch.py::TestQwen3_5_4B::test_bf16
   - accuracy/test_llm_api_pytorch.py::TestQwen3_5_4B::test_fp8
+  - accuracy/test_llm_api_pytorch.py::TestQwen3_5_4B::test_dflash
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_scales_cuda_graph_padding[mtp_nextn=0]
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_scales_cuda_graph_padding[mtp_nextn=2]
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Nano::test_fp8

--- a/tests/unittest/_torch/speculative/hw_agnostic/test_dflash.py
+++ b/tests/unittest/_torch/speculative/hw_agnostic/test_dflash.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import sys
 import unittest
@@ -11,63 +26,82 @@ from tensorrt_llm.llmapi import CudaGraphConfig, DFlashDecodingConfig, KvCacheCo
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
+PROMPTS = [
+    "The capital of France is",
+    "The president of the United States is",
+    "The future of AI is",
+]
 
-@pytest.mark.parametrize("disable_overlap_scheduler", [True, False])
-def test_dflash(disable_overlap_scheduler: bool):
-    """Test DFlash speculative decoding with CUDA graph support.
 
-    This test verifies that DFlash speculative decoding works
-    correctly with CUDA graphs and padding enabled.
-    """
-    attn_backend = "TRTLLM"
-    enable_block_reuse = False
-    enable_chunked_prefill = False
-
-    total_mem_gb = torch.cuda.get_device_properties(0).total_memory / 1e9
-    if total_mem_gb < 35:
-        pytest.skip("Not enough memory to load target + draft model")
-
-    models_path = llm_models_root()
-    dflash_model_dir = f"{models_path}/Qwen3-8B-DFlash-b16"
-    target_model_dir = f"{models_path}/Qwen3/Qwen3-8B"
-
-    # Test with 3 requests and max_batch_size=4 to trigger padding
-    max_batch_size = 4
-    max_draft_len = 4
-    kv_cache_config = KvCacheConfig(enable_block_reuse=enable_block_reuse, max_tokens=2048)
-    use_cuda_graph = True
-    cuda_graph_config = (
-        CudaGraphConfig(batch_sizes=[1, 2, 4], enable_padding=True) if use_cuda_graph else None
+def _make_llm_config(
+    target_model_dir: str,
+    dflash_model_dir: str,
+    disable_overlap_scheduler: bool,
+    max_draft_len: int = 4,
+    max_batch_size: int = 4,
+):
+    kv_cache_config = KvCacheConfig(enable_block_reuse=False, max_tokens=2048)
+    cuda_graph_config = CudaGraphConfig(batch_sizes=[1, 2, 4], enable_padding=True)
+    spec_config = DFlashDecodingConfig(
+        max_draft_len=max_draft_len,
+        speculative_model=dflash_model_dir,
     )
-
-    llm_common_config = dict(
+    return dict(
         model=target_model_dir,
-        attn_backend=attn_backend,
+        attn_backend="TRTLLM",
         disable_overlap_scheduler=disable_overlap_scheduler,
         cuda_graph_config=cuda_graph_config,
         max_batch_size=max_batch_size,
         kv_cache_config=kv_cache_config,
         max_seq_len=2048,
-        enable_chunked_prefill=enable_chunked_prefill,
+        enable_chunked_prefill=False,
+        speculative_config=spec_config,
     )
 
-    spec_config = DFlashDecodingConfig(
-        max_draft_len=max_draft_len,
-        speculative_model=dflash_model_dir,
+
+def _run_and_check(llm_config: dict, min_avg_accepted: float):
+    llm = LLM(**llm_config)
+    outputs = llm.generate(PROMPTS, SamplingParams(max_tokens=256, temperature=0))
+    llm.shutdown()
+
+    avg_accepted = [o.avg_decoded_tokens_per_iter - 1 for o in outputs]
+    mean_accepted = sum(avg_accepted) / len(avg_accepted)
+    assert mean_accepted >= min_avg_accepted, (
+        f"mean avg accepted {mean_accepted:.2f} < threshold {min_avg_accepted} "
+        f"(per request: {[f'{a:.2f}' for a in avg_accepted]})"
     )
 
-    # Create the LLM instance
-    llm_spec = LLM(**llm_common_config, speculative_config=spec_config)
 
-    prompts = [
-        "The capital of France is",
-        "The president of the United States is",
-        "The future of AI is",
-    ]
+@pytest.mark.parametrize("disable_overlap_scheduler", [True, False])
+def test_dflash_qwen3_8b(disable_overlap_scheduler: bool):
+    """Test DFlash with Qwen3-8B BF16: CUDA graphs, padding, and draft acceptance."""
+    total_mem_gb = torch.cuda.get_device_properties(0).total_memory / 1e9
+    if total_mem_gb < 35:
+        pytest.skip("Not enough memory to load target + draft model")
 
-    sampling_params = SamplingParams(max_tokens=1024, temperature=0)
-    llm_spec.generate(prompts, sampling_params)
-    llm_spec.shutdown()
+    models_path = llm_models_root()
+    llm_config = _make_llm_config(
+        target_model_dir=f"{models_path}/Qwen3/Qwen3-8B",
+        dflash_model_dir=f"{models_path}/Qwen3-8B-DFlash-b16",
+        disable_overlap_scheduler=disable_overlap_scheduler,
+    )
+    _run_and_check(llm_config, min_avg_accepted=1.0)
+
+
+@pytest.mark.parametrize("disable_overlap_scheduler", [True, False])
+def test_dflash_qwen3_5_4b(disable_overlap_scheduler: bool):
+    """Test DFlash with Qwen3.5-4B BF16: CUDA graphs, padding, and draft acceptance."""
+    total_mem_gb = torch.cuda.get_device_properties(0).total_memory / 1e9
+    if total_mem_gb < 20:
+        pytest.skip("Not enough memory to load target + draft model")
+
+    models_path = llm_models_root()
+    llm_config = _make_llm_config(
+        target_model_dir=f"{models_path}/Qwen3.5-4B",
+        dflash_model_dir=f"{models_path}/Qwen3.5-4B-DFlash",
+        disable_overlap_scheduler=disable_overlap_scheduler,
+    )
+    _run_and_check(llm_config, min_avg_accepted=1.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Performance optimizations for the DFlash speculative-decoding worker on the PyTorch backend.  The headline change is dropping the K-1 mask-filler tokens that DFlash was forwarding through every target layer; the rest are supporting fusions that close the remaining gap on the draft side.

Qwen3-8B on B200, TP=4, MTBench:

| Config | DFlash (this branch) | Eagle3 |
|---|---:|---:|
| bs=64 mdl=3 | **5064 TPS/gpu** | 4363 (**+16.1%**) |
| bs=64 mdl=7 | **4756 TPS/gpu** | 4548 (**+4.6%**) |

Acceptance length is byte-for-byte preserved vs. the pre-branch baseline.

## Commits

- `d517eed` **DFlash: drop K-1 filler tokens from target gen input** — reduce `tokens_per_gen_step` from 2K to K+1, remove the paired slicing/padding.  +14.5% TPS/gpu at bs=64 mdl=3 (main large-batch win).
- `59ea073` DFlash: fuse cross-layer k_norm and avoid mask-mul alloc.
- `f609129` DFlash: use fused qk-norm+rope on non-YaRN draft.
- `785cdee` DFlash: fuse query-input build in pure Torch + fused embedding lookup.
- `5c45f60` DFlash: match RoPE between context and query for YaRN (bug fix).
- `cbdb9f4` DFlash: migrate draft path to per-layer cached K/V pool.
- `4d73942` DFlash: Qwen3.5 fixes (cherry-pick).

## Test plan

- [x] `tests/unittest/_torch/speculative/hw_agnostic/test_dflash.py::test_dflash_qwen3_8b` (both overlap-scheduler variants) — pass
- [x] `tests/unittest/_torch/speculative/hw_agnostic/test_dflash.py::test_dflash_qwen3_5_4b` (both variants) — pass
- [x] `tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestQwen3_8B::test_dflash` (GSM8K) — pass
- [ ] `/bot run`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive test coverage for DFlash speculative decoding on Qwen3 and Qwen3.5 models with GSM8K evaluation

* **Improvements**
  * Optimized DFlash context K/V precomputation and caching for improved memory efficiency
  * Refined draft token generation strategy and position ID handling for speculative decoding

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/13995)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->