### PR TITLE
[None][fix] sync warmup forward decision across TP ranks

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -853,6 +853,36 @@ class PyTorchModelEngine(ModelEngine):
         with self.no_cuda_graph():
             self._general_warmup_impl(resource_manager, warmup_requests_configs)
 
+    def _require_warmup_batch_on_all_tp_ranks(
+            self, batch: Optional[ScheduledRequests], num_tokens: int,
+            num_gen_tokens: int, warmup_name: str) -> ScheduledRequests:
+        """Return batch iff every TP rank has a valid warmup batch.
+
+        Warmup forward passes issue tp_comm collectives (e.g.
+        ``_get_all_rank_num_tokens`` under attention-DP). If only some TP
+        ranks run the forward, they deadlock against peers that skipped, and
+        those skipped peers subsequently reach the ``COMM_WORLD`` barrier in
+        ``PyExecutor._set_global_steady_clock_offset``, producing a cross-comm
+        deadlock. Raise instead of silently skipping so a missing autotuner
+        warmup is exposed rather than turning into an unexpected perf drop.
+        """
+        local_has_batch = int(batch is not None)
+        if self.mapping.tp_size <= 1:
+            flags = [local_has_batch]
+        else:
+            flags = self.dist.tp_allgather(local_has_batch)
+        flags = [int(flag) for flag in flags]
+
+        if all(flags):
+            assert batch is not None
+            return batch
+
+        raise RuntimeError(
+            f"Cannot run {warmup_name} warmup with {num_tokens} tokens and "
+            f"{num_gen_tokens} generation tokens: at least one TP rank could "
+            "not allocate a dummy warmup batch from KV cache. "
+            f"Per-TP-rank batch availability: {list(flags)}.")
+
     def _general_warmup_impl(
             self, resource_manager: ResourceManager,
             warmup_requests_configs: List[Tuple[int, int]]) -> None:
@@ -866,8 +896,8 @@ class PyTorchModelEngine(ModelEngine):
                         self._create_warmup_request(resource_manager,
                                                     num_tokens, num_gen_tokens),
                         resource_manager) as batch:
-                    if batch is None:
-                        continue  # Not enough KV cache space
+                    batch = self._require_warmup_batch_on_all_tp_ranks(
+                        batch, num_tokens, num_gen_tokens, "general")
                     logger.info(
                         f"Run warmup with {num_tokens} tokens, include {num_gen_tokens} generation tokens"
                     )
@@ -901,28 +931,29 @@ class PyTorchModelEngine(ModelEngine):
                 resource_manager, curr_max_num_tokens, 0)
             with self._release_batch_context(warmup_request,
                                              resource_manager) as batch:
-                if batch is not None:
-                    # Reset the flag is_first_draft for the draft model.
-                    # This is necessary for overlap scheduler.
-                    spec_resource_manager = resource_manager.get_resource_manager(
-                        ResourceManagerType.SPEC_RESOURCE_MANAGER)
-                    if self.is_draft_model and isinstance(
-                            spec_resource_manager, Eagle3ResourceManager):
-                        spec_resource_manager.is_first_draft = True
+                batch = self._require_warmup_batch_on_all_tp_ranks(
+                    batch, curr_max_num_tokens, 0, "autotuner")
+                # Reset the flag is_first_draft for the draft model.
+                # This is necessary for overlap scheduler.
+                spec_resource_manager = resource_manager.get_resource_manager(
+                    ResourceManagerType.SPEC_RESOURCE_MANAGER)
+                if self.is_draft_model and isinstance(
+                        spec_resource_manager, Eagle3ResourceManager):
+                    spec_resource_manager.is_first_draft = True
 
-                    self.forward(batch,
-                                 new_tensors_device=None,
-                                 resource_manager=resource_manager)
+                self.forward(batch,
+                             new_tensors_device=None,
+                             resource_manager=resource_manager)
 
-                    # pp_recv in AutoTuner choose_one will never be called if there is no tuning op during the forward pass.
-                    # So we need to make an extra call to consume the previous rank's pp_send to guarantee that the previous rank's pp_send is released.
-                    AutoTuner.get().cache_pp_recv()
-                    # Send the cache after the tuning process to the next PP rank
-                    AutoTuner.get().cache_pp_send()
-                    # Clean the pp flag to avoid deadlock with synchronous send/recv
-                    AutoTuner.get().clean_pp_flag()
+                # pp_recv in AutoTuner choose_one will never be called if there is no tuning op during the forward pass.
+                # So we need to make an extra call to consume the previous rank's pp_send to guarantee that the previous rank's pp_send is released.
+                AutoTuner.get().cache_pp_recv()
+                # Send the cache after the tuning process to the next PP rank
+                AutoTuner.get().cache_pp_send()
+                # Clean the pp flag to avoid deadlock with synchronous send/recv
+                AutoTuner.get().clean_pp_flag()
 
-                    torch.cuda.synchronize()
+                torch.cuda.synchronize()
 
         logger.info(
             f"[Autotuner] Cache size after warmup is {len(AutoTuner.get().profiling_cache)}"


### PR DESCRIPTION
## Summary

Fix a cross-comm deadlock in `PyTorchModelEngine.warmup` that surfaces under attention-DP when ranks' KV cache pools have asymmetric capacity.

## Bug

`PyTorchModelEngine.warmup` calls `_run_autotuner_warmup` and `_general_warmup_impl`, which each invoke `self.forward` only when the per-rank warmup batch is non-None:

```python
with self._release_batch_context(warmup_request, resource_manager) as batch:
    if batch is not None:   # <- rank-divergent under attention-DP
        ...
        self.forward(batch, ...)
```

Under attention-DP each rank's KV cache pool capacity can differ, so `_create_warmup_request` may return a valid batch on some TP ranks and `None` on others. The ranks then diverge:

- Ranks with valid batches enter `forward`, which (under attention-DP) issues `tp_comm` collectives in `_get_all_rank_num_tokens` (`self.dist.tp_allgather(num_tokens)`).
- Ranks with `batch is None` skip the forward entirely, exit the `autotune()` / warmup context, advance to subsequent warmup steps, and finally reach the `COMM_WORLD.Barrier()` in `PyExecutor._set_global_steady_clock_offset`.

`tp_comm` and `COMM_WORLD` are distinct MPI communicators, so the two waiting groups never satisfy each other and the job hangs forever. Verified with py-spy + gdb on a DeepSeek-V4-Pro `trtllm-bench` ctx-only run with `--tp 4 --ep 4` (attention-DP=4), `--max_num_tokens 16384`, `--max_batch_size 16`, `--kv_cache_free_gpu_mem_fraction 0.4`:

- One rank stuck in `_run_autotuner_warmup` → `forward` → `_get_all_rank_num_tokens` → `tp_allgather` (recursive-doubling step 0, waiting on a peer).
- Three ranks stuck in `_set_global_steady_clock_offset` → `MPI_Barrier(COMM_WORLD)`.

The boundary moves with available KV memory but the deadlock pattern is the same; bumping `kv_cache_free_gpu_mem_fraction` from 0.3 to 0.4 just shifted the diverging-rank set from {0,3} to {3}.

## Fix

Add a `_all_tp_ranks_have_warmup_batch` helper that `tp_allgather`s batch validity across TP ranks. Gate the warmup forward in both `_run_autotuner_warmup` and `_general_warmup_impl` on the symmetric result, so all TP peers either run or all skip.

- No-op when `tp_size <= 1`.
- The conservative skip path leaves the autotuner cache empty when any rank lacks capacity (ops fall back to default tactics), which is preferable to hanging the job.
- The extra `tp_allgather` of a single int per warmup batch is negligible.

## Test plan

- [x] Re-run the affected `trtllm-bench` ctx-only configs (`ctx_1024 BS=16 MTPx, --max_num_tokens 16384, --kv_cache_free_gpu_mem_fraction 0.3/0.4`) on 4×GB300 and confirm warmup completes instead of hanging.
- [x] Verify pre-existing TP=4 / attention-DP benchmarks (e.g. `ctx_8192 BS=2`) still pass.
- [x] `pytest tests/unittest/_torch/` for the pyexecutor area on the CI runners.

CI may need `/bot run --extra-stage "DGX_B200-4_GPUs-AutoDeploy-1, DGX_H100-4_GPUs-AutoDeploy-1"` since this touches `_torch/pyexecutor/model_engine.py`.