### PR TITLE
[TRTLLM-12589][fix] Reset MoE A2A dispatch state on warmup OOM

### DIFF
--- a/tensorrt_llm/_torch/distributed/moe_alltoall.py
+++ b/tensorrt_llm/_torch/distributed/moe_alltoall.py
@@ -310,9 +310,19 @@ class MoeAlltoAll:
             payload_in_workspace, use_low_precision_combine)
 
         # Reset state for next round
-        self._state = _A2AState()
+        self.reset_state()
 
         return output
+
+    def reset_state(self) -> None:
+        """Reset the dispatch/combine state machine to ``idle``.
+
+        Safe to call between forward passes (or from an error handler) to
+        recover from a forward that called ``dispatch`` but did not reach
+        ``combine`` — e.g. because an OOM aborted the forward. Without this,
+        the next ``dispatch`` would fire the assert at line 239.
+        """
+        self._state = _A2AState()
 
     def get_combine_payload_tensor_in_workspace(
             self, runtime_max_tokens_per_rank: int, hidden_size: int,

--- a/tensorrt_llm/_torch/modules/fused_moe/communication/nvlink_one_sided.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/nvlink_one_sided.py
@@ -541,9 +541,19 @@ class NVLinkOneSided(Communication):
         )
 
         # Reset state for next round
-        self._dispatch_state = {"phase": "idle"}
+        self.reset_state()
 
         return output
+
+    def reset_state(self) -> None:
+        """Reset the dispatch/combine state machine to ``idle``.
+
+        Safe to call between forward passes (or from an error handler) to
+        recover from a forward that called ``dispatch`` but did not reach
+        ``combine`` — e.g. because an OOM aborted the forward. Without this,
+        the next ``dispatch`` would raise ``dispatch called twice``.
+        """
+        self._dispatch_state = {"phase": "idle"}
 
     def get_combine_payload_tensor_in_workspace(
         self, runtime_max_tokens_per_rank: int, hidden_size: int, dtype: torch.dtype

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -909,7 +909,35 @@ class PyTorchModelEngine(ModelEngine):
                 logger.warning(
                     f"OOM during general warmup with {num_tokens} tokens, "
                     f"{num_gen_tokens} generation tokens. Skipping.")
+                # If the OOM aborted the forward between dispatch() and
+                # combine(), the MoE A2A state machines are stuck in
+                # ``dispatched`` and the next warmup will hit
+                # ``dispatch called twice``. Reset them before retrying a
+                # smaller shape.
+                self._reset_moe_alltoall_state()
                 torch.cuda.empty_cache()
+
+    def _reset_moe_alltoall_state(self) -> None:
+        """Reset all MoE all-to-all state machines reachable from ``self.model``.
+
+        Each MoE backend keeps a small dispatch/combine phase state per layer
+        (``MoeAlltoAll`` or ``NVLinkOneSided``). A forward that calls
+        ``dispatch`` but raises before reaching ``combine`` (e.g., a warmup
+        OOM mid-MoE) leaves that state in ``dispatched``, which fails the
+        invariant on the next ``dispatch`` call. This helper walks the model
+        and resets any A2A state found, so subsequent forwards start clean.
+        """
+        for module in self.model.modules():
+            for attr_name in ("moe_a2a", "comm"):
+                obj = getattr(module, attr_name, None)
+                reset = getattr(obj, "reset_state", None)
+                if callable(reset):
+                    try:
+                        reset()
+                    except Exception as e:  # noqa: BLE001
+                        logger.warning(
+                            f"Failed to reset MoE A2A state on {type(module).__name__}.{attr_name}: {e}"
+                        )
 
     def _run_autotuner_warmup(self, resource_manager: ResourceManager):
         """Runs a forward pass to populate the autotuner cache."""


### PR DESCRIPTION
The MoE all-to-all dispatch/combine state machine (MoeAlltoAll._state.phase and NVLinkOneSided._dispatch_state["phase"]) is left in "dispatched" when a forward raises between dispatch() and combine(). _general_warmup_impl's "try / except OutOfMemoryError" catches the OOM and clears CUDA cache but does not reset Python-side stateful objects, so the next warmup config's forward fails the dispatch() invariant with

  "dispatch called twice without an intervening combine"

This converts the "skip this warmup shape and try a smaller one" behavior the framework intended into "die at server startup with a confusing assert that has nothing to do with memory".

Fix:
* Add reset_state() to MoeAlltoAll and NVLinkOneSided.
* In _general_warmup_impl's OOM handler, walk self.model.modules() and call reset_state() on any moe_a2a / comm submodule that exposes it, before retrying the next warmup config.

Non-OOM exceptions are deliberately not covered: they escape the `except OutOfMemoryError` block, propagate through PyExecutor.__init__ and kill the server before any further dispatch() runs, so the stuck state machine never gets exercised again -- guarding that path would violate "don't guard against scenarios that can't happen".

This restores the documented "skip OOMing config" semantics. The underlying 4096-token warmup OOM at kv_cache_free_gpu_memory_fraction=0.9 is a separate KV pool sizing issue and is not addressed here.