### PR TITLE
[None][fix] Reuse prior-attempt passes when infra retry fires

### DIFF
--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -861,7 +861,7 @@ def executeLLMTestOnSlurm(pipeline, platform, testList, config=VANILLA_CONFIG, p
     runner {
         // TODO: refactor the finallyRunner to reuse within slurm or nonslurm job.
         cacheErrorAndUploadResult(stageName, {
-            runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config, perfMode, stageName, splitId, splits, skipInstallWheel, cpver)
+            runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config, perfMode, stageName, splitId, splits, skipInstallWheel, cpver, false, postTag)
         }, {
             // If the execution test list is null, remove the test result xml
             sh """
@@ -1116,7 +1116,7 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
 
                 // Add passed test list from previous pipeline run to the waives.txt
                 if (testFilter[(REUSE_TEST)] != false) {
-                    reusePassedTestResults(llmSrcLocal, stageName, "${llmSrcLocal}/tests/integration/test_lists/waives.txt")
+                    reusePassedTestResults(llmSrcLocal, stageName, "${llmSrcLocal}/tests/integration/test_lists/waives.txt", postTag)
                 }
 
                 Utils.copyFileToRemoteHost(
@@ -2773,23 +2773,110 @@ def mergeWaivesTxt(pipeline, llmSrc, stageName) {
     }
 }
 
-def reusePassedTestResults(llmSrc, stageName, waivesTxt) {
+/**
+ * Append passes that previously succeeded for this commit + stage to the
+ * stage's waives.txt as SKIPs, so the upcoming pytest run skips them.
+ *
+ * Two sources are merged:
+ *
+ *  1. OpenSearch records of prior pipeline runs for the same commit and
+ *     stage (the historical mechanism). Populated only after a pipeline
+ *     completes -- has nothing to say about the current run.
+ *
+ *  2. Tarballs uploaded by earlier attempts of the *current* build, when
+ *     the infra-failure retry loop has fired. The current run's attempt 1
+ *     uploads its (partial) results before the retry kicks off; this
+ *     function downloads them and extracts passes via test_rerun.py's
+ *     extract_passed_tests mode. Closes the gap where a retry would
+ *     otherwise re-run every test that already passed pre-failure.
+ *
+ * @param llmSrc      Local TRT-LLM source root.
+ * @param stageName   Stage name; both the OpenSearch query key and the
+ *                    Artifactory artifact prefix (`results-${stageName}*`).
+ * @param waivesTxt   Path to the stage's waives.txt; passes are appended
+ *                    here with reason "SKIP (Reused from previous pipeline)".
+ * @param postTag     This attempt's full tar suffix (e.g. ""
+ *                    on attempt 1, "-attempt-2" on the first retry,
+ *                    "-SubJob-RunTest-attempt-2" for a retried sub-job).
+ *                    Used by priorAttemptTags() to enumerate earlier
+ *                    attempts in this build.
+ */
+def reusePassedTestResults(llmSrc, stageName, waivesTxt, String postTag = "") {
     try {
-        // Get passed test list from open search
-        def passedTestListFile = "${WORKSPACE}/${stageName}/passed_test_list.txt"
+        def reusedTests = []
+        def workDir = "${WORKSPACE}/${stageName}"
+        sh "mkdir -p ${workDir}"
+
+        // 1. OpenSearch lookup -- tests that PASSED in a previous pipeline run
+        //    for this commit + stage.
+        def passedTestListFile = "${workDir}/passed_test_list.txt"
         sh """
             python3 ${llmSrc}/jenkins/scripts/open_search_query.py \
             --commit-id ${env.gitlabCommit} \
             --stage-name ${stageName} \
             --output-file ${passedTestListFile}
         """
+        if (fileExists(passedTestListFile)) {
+            reusedTests += readFile(file: passedTestListFile).readLines().collect { it.trim() }.findAll { it }
+        }
 
-        def passedTestList = readFile(file: passedTestListFile).readLines()
-        def reusedTests = passedTestList.collect { test -> test.trim() }
+        // 2. Prior-attempt recovery -- tests that PASSED in an earlier attempt
+        //    of THIS pipeline run before infra retry fired. Only runs if postTag
+        //    decodes as a retry attempt (matches "...-attempt-N").
+        def priorTags = priorAttemptTags(postTag)
+        if (!priorTags.isEmpty()) {
+            def priorXmls = []
+            priorTags.each { priorTag ->
+                def tarName = "results-${stageName}${priorTag}.tar.gz"
+                def tarUrl = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/test-results/${tarName}"
+                def priorDir = "${workDir}/prior${priorTag.replace('-', '_')}"
+                sh "mkdir -p ${priorDir}"
+                // Probe with HEAD so we can distinguish "this prior attempt never
+                // uploaded a tarball" (HTTP 404, expected when an attempt died
+                // before its finally block ran) from real errors (auth, 5xx,
+                // network). Only 404 is benign; anything else fails the build
+                // so silent skips don't mask a configuration regression.
+                def httpStatus = sh(returnStdout: true,
+                                    script: "curl -sS -o /dev/null -w '%{http_code}' --connect-timeout 10 --max-time 30 '${tarUrl}'").trim()
+                if (httpStatus == '404') {
+                    echo "Prior attempt artifact ${tarName} not present (HTTP 404); skipping"
+                    return
+                }
+                if (httpStatus != '200') {
+                    error "Probing prior attempt artifact ${tarName} returned HTTP ${httpStatus} (expected 200 or 404)"
+                }
+                sh "cd ${priorDir} && wget -nv -nc '${tarUrl}'"
+                sh "cd ${priorDir} && tar -xzf ${tarName}"
+                // results.xml may live at ${stageName}/results.xml inside the
+                // tar, or at the tar's root depending on how it was packaged.
+                // Scan both.
+                def xmlFiles = sh(returnStdout: true,
+                                  script: "find ${priorDir} -maxdepth 4 -name 'results*.xml' 2>/dev/null | tr '\\n' ',' | sed 's/,\$//'").trim()
+                if (xmlFiles) {
+                    priorXmls += xmlFiles.split(',') as List
+                }
+            }
+            if (!priorXmls.isEmpty()) {
+                def priorPassedFile = "${workDir}/prior_attempt_passed.txt"
+                sh """
+                    python3 ${llmSrc}/jenkins/scripts/test_rerun.py \
+                    extract_passed_tests \
+                    --output-file ${priorPassedFile} \
+                    --input-files ${priorXmls.join(',')}
+                """
+                if (fileExists(priorPassedFile)) {
+                    def priorPasses = readFile(file: priorPassedFile).readLines().collect { it.trim() }.findAll { it }
+                    if (!priorPasses.isEmpty()) {
+                        echo "Reusing ${priorPasses.size()} passed test(s) from prior attempt(s): ${priorTags}"
+                    }
+                    reusedTests += priorPasses
+                }
+            }
+        }
 
-        // Append reused tests to waives.txt
+        // 3. Dedupe and append everything to waives.txt as SKIPs.
+        reusedTests = reusedTests.unique()
         if (reusedTests.size() > 0) {
-            // Build the content to append
             def reusedTestsContent = reusedTests.collect { test ->
                 "${test} SKIP (Reused from previous pipeline)"
             }.join('\n')
@@ -2812,7 +2899,47 @@ REUSED_TESTS_EOF
     }
 }
 
-def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CONFIG, perfMode=false, stageName="Undefined", splitId=1, splits=1, skipInstallWheel=false, cpver="cp312", typeCheck=false)
+/**
+ * Decode a postTag into the postTags used by prior attempts of the same
+ * stage in this build.
+ *
+ * The retry runner (runKubernetesPodWithInfraRetry, runLLMTestlistOnSlurm)
+ * composes postTag as ``${callerSuppliedBase}-attempt-${N}`` for retries
+ * (and the bare base for attempt 1, e.g. ``""`` or ``"-SubJob-RunTest"``).
+ * This function inverts that composition to enumerate the postTags of
+ * earlier attempts so reusePassedTestResults() can locate their uploaded
+ * tarballs.
+ *
+ * Returns an empty list when ``postTag`` does not encode a retry — either
+ * attempt 1 (``postTag == ""``), or a caller-supplied tag that never went
+ * through the retry loop (e.g. ``"-SubJob-RunTest"``).
+ *
+ * Examples:
+ *
+ *   ""                            -> []
+ *   "-attempt-2"                  -> [""]
+ *   "-attempt-3"                  -> ["", "-attempt-2"]
+ *   "-SubJob-RunTest-attempt-2"   -> ["-SubJob-RunTest"]
+ *   "-SubJob-RunTest"             -> []
+ *
+ * @param postTag the current attempt's full tar suffix.
+ * @return List of postTag strings, ordered oldest-attempt-first.
+ */
+@NonCPS
+def priorAttemptTags(String postTag) {
+    if (!postTag) return []
+    def m = postTag =~ /^(.*)-attempt-(\d+)$/
+    if (!m.matches()) return []
+    String base = m[0][1]
+    int currentAttempt = (m[0][2] as Integer)
+    def priors = [base]   // attempt 1 used the caller's base tag, e.g. "" or "-SubJob-RunTest"
+    for (int n = 2; n < currentAttempt; n++) {
+        priors << "${base}-attempt-${n}"
+    }
+    return priors
+}
+
+def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CONFIG, perfMode=false, stageName="Undefined", splitId=1, splits=1, skipInstallWheel=false, cpver="cp312", typeCheck=false, String postTag="")
 {
     // Step 1: create LLM_ROOT dir and clean up the workspace
     def llmRootConfig = "${LLM_ROOT}${config}"
@@ -2969,7 +3096,7 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
 
         // Add passed test list from previous pipeline run to the waives.txt
         if (testFilter[(REUSE_TEST)] != false) {
-            reusePassedTestResults(llmSrc, stageName, "${llmSrc}/tests/integration/test_lists/waives.txt")
+            reusePassedTestResults(llmSrc, stageName, "${llmSrc}/tests/integration/test_lists/waives.txt", postTag)
         }
 
         // Process shard test list and create separate files for regular and isolate tests
@@ -3170,7 +3297,7 @@ def runLLMTestlistOnPlatform(pipeline, platform, testList, config=VANILLA_CONFIG
     splitId = collapse.splitId
 
     cacheErrorAndUploadResult(stageName, {
-        runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config, perfMode, stageName, splitId, splits, skipInstallWheel, cpver, typeCheck)
+        runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config, perfMode, stageName, splitId, splits, skipInstallWheel, cpver, typeCheck, postTag)
     }, {
         if (testFilter[(DEBUG_MODE)]) {
             try {

--- a/jenkins/scripts/test_rerun.py
+++ b/jenkins/scripts/test_rerun.py
@@ -1,7 +1,13 @@
 import argparse
 import os
 import sys
-import xml.etree.ElementTree as ET
+
+# defusedxml hardens the standard library's ElementTree against XXE and
+# billion-laughs-style entity expansion attacks. The JUnit XML files we parse
+# come from Artifactory and are produced by trusted pipelines, but defending
+# at the parser layer is cheap and protects us if an attacker ever gains
+# write access to the artifact store.
+import defusedxml.ElementTree as ET
 
 
 def parse_name(classname, name, filename):
@@ -49,6 +55,55 @@ def process_xml_failed_tests(xml_filename, failSignaturesList, rerun_0_file,
                     rerun_0_file.write(test_to_line[test_name] + '\n')
                     print(test_name + " will not rerun")
     return ran_tests
+
+
+def extract_passed_tests(output_file, xml_filenames):
+    """Write the names of passed test cases from JUnit XMLs, one per line.
+
+    A testcase is considered passed if it has no ``<failure>``, ``<error>``,
+    or ``<skipped>`` child element. Names are deduplicated across all input
+    XMLs using the same ``parse_name`` helper as ``generate_rerun_tests_list``
+    so the output format matches the OpenSearch passed-test list consumed by
+    ``reusePassedTestResults`` in ``jenkins/L0_Test.groovy``.
+
+    Used to recover the partial set of passes from a prior retry attempt's
+    uploaded results tarball when the infra-failure retry loop fires — the
+    OpenSearch path only sees data from previously-completed pipeline runs.
+
+    Args:
+        output_file: Path to the output text file (created/overwritten).
+        xml_filenames: Iterable of JUnit XML file paths. Missing files and
+            malformed XML are skipped with a printed warning; a partial set
+            does not fail the function.
+    """
+    seen = set()
+    with open(output_file, 'w') as out_file:
+        for xml_filename in xml_filenames:
+            if not os.path.exists(xml_filename):
+                continue
+            try:
+                root = ET.parse(xml_filename).getroot()
+            except ET.ParseError as e:
+                print(f"Skipping malformed {xml_filename}: {e}")
+                continue
+            # Accept either <testsuites><testsuite>... or top-level <testsuite>.
+            suites = root.findall(
+                'testsuite') if root.tag == 'testsuites' else [root]
+            for suite in suites:
+                for case in suite.findall('testcase'):
+                    if case.find('failure') is not None:
+                        continue
+                    if case.find('error') is not None:
+                        continue
+                    if case.find('skipped') is not None:
+                        continue
+                    test_name = parse_name(case.attrib.get('classname', ''),
+                                           case.attrib.get('name', ''),
+                                           case.attrib.get('file', ''))
+                    if test_name in seen:
+                        continue
+                    seen.add(test_name)
+                    out_file.write(test_name + '\n')
 
 
 def generate_rerun_tests_list(outdir, xml_filename, failSignaturesList,
@@ -534,3 +589,16 @@ if __name__ == '__main__':
         args = parser.parse_args(sys.argv[2:])
         input_files = args.input_files.split(',')
         generate_rerun_report(args.output_file, input_files)
+
+    elif (sys.argv[1] == "extract_passed_tests"):
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            '--output-file',
+            required=True,
+            help='Output file listing passed test names, one per line')
+        parser.add_argument('--input-files',
+                            required=True,
+                            help='Comma-separated JUnit XML files to scan')
+        args = parser.parse_args(sys.argv[2:])
+        input_files = [p for p in args.input_files.split(',') if p]
+        extract_passed_tests(args.output_file, input_files)

--- a/jenkins/scripts/test_rerun.py
+++ b/jenkins/scripts/test_rerun.py
@@ -1,13 +1,7 @@
 import argparse
 import os
 import sys
-
-# defusedxml hardens the standard library's ElementTree against XXE and
-# billion-laughs-style entity expansion attacks. The JUnit XML files we parse
-# come from Artifactory and are produced by trusted pipelines, but defending
-# at the parser layer is cheap and protects us if an attacker ever gains
-# write access to the artifact store.
-import defusedxml.ElementTree as ET
+import xml.etree.ElementTree as ET
 
 
 def parse_name(classname, name, filename):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,9 +32,6 @@ pytest-rerunfailures
 ruff==0.9.4
 lm_eval[api]==0.4.10
 docstring_parser
-# Hardened XML parser for JUnit results processed by jenkins/scripts/test_rerun.py.
-# CI-only -- not a runtime dep of the TRT-LLM package.
-defusedxml
 genai-perf==0.0.13
 opentelemetry-sdk>=1.26.0
 opentelemetry-api>=1.26.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,6 +32,9 @@ pytest-rerunfailures
 ruff==0.9.4
 lm_eval[api]==0.4.10
 docstring_parser
+# Hardened XML parser for JUnit results processed by jenkins/scripts/test_rerun.py.
+# CI-only -- not a runtime dep of the TRT-LLM package.
+defusedxml
 genai-perf==0.0.13
 opentelemetry-sdk>=1.26.0
 opentelemetry-api>=1.26.0


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced infrastructure retry handling with improved recovery mechanism that reuses previously passing tests from earlier pipeline attempts
  * Added capability to extract and identify passed test cases from JUnit XML result files for better test tracking

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14002)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

When the infra-failure retry loop fires (e.g. a stage hits the SLURM walltime "DUE TO TIME LIMIT" pattern, the K8s pod gets evicted with "Reason: Evicted", etc.), each retry attempt today runs the test list from scratch even though the prior attempt may have completed many passes before the failure. The existing reusePassedTestResults() only queries OpenSearch, which is populated *after* a pipeline run completes -- it has no visibility into passes from the current run's earlier attempts because those attempts never reached completion.

Observed in a real build of L0_Test-SBSA-Multi-GPU #974: the first attempt timed out partway through; the retry attempt re-ran the entire test list including everything that had already passed.

Fix: reusePassedTestResults() now also downloads any prior-attempt tarballs from this build's own Artifactory upload path and parses their results.xml for passes, merging them with the OpenSearch list before appending the union to waives.txt as SKIPs.

- reusePassedTestResults() takes a new postTag arg.
- New helper priorAttemptTags(postTag) decodes the suffix and returns the postTag values used by earlier attempts of the same stage in this build.
- For each prior tag, wget the tarball from ${UPLOAD_PATH}/test-results/. 404 is benign and skipped.
- Untar, find results.xml, feed into a new test_rerun.py extract_passed_tests mode that walks JUnit XML and emits passed test names via the existing parse_name helper.
- Merge with OpenSearch results, dedupe, append to waives.txt with the same SKIP-reason marker -- downstream pytest waive-list handling is unchanged.

Threading:
- runLLMTestlistOnPlatformImpl(): new postTag parameter.
- runLLMTestlistOnPlatform() and executeLLMTestOnSlurm() pass it through.
- The two reusePassedTestResults() call sites (SLURM path at L1298, K8s path at L3176) now pass postTag.

If REUSE_TEST is explicitly disabled, the whole function is short- circuited at the call site, so the new behaviour is opt-in via the existing flag.

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
