### PR TITLE
[https://nvbugs/6117814][fix] AutoDeploy: Fix Eagle cu_seqlen data race

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -1431,8 +1431,8 @@ class SequenceInfo:
         use_initial_states[:] = input_pos > 0
 
         # --- Bulk device-to-host sync ---
-        # TODO: we have to continue thinking about this and dissect more what fields are needed in
-        # the forward pass if we use cudagraph...
+        # TODO: May need to dissect what fields are needed in the forward pass to reduce
+        # data movement.
         if sync_to_host:
             self._input_buffer.copy_to_host()
 
@@ -1465,13 +1465,9 @@ class SequenceInfo:
         an all-decode layout where each sequence has exactly 1 token. We assume that we just take
         the last position of each sequence for the metadata.
 
-        NOTE: update device tensors first and mirror back to host only for active host graph
-        inputs. This matches offset_pos_and_cache_ and avoids rewriting inactive host staging
-        buffers during the drafting loop.
-
-        NOTE: we assume the same structure as in nest_sequences for when to update the arguments.
-        In particular, arguments that are always updated in nest_sequences are also updated here.
-        Others are updated optionally depending on the argument being active.
+        NOTE: update device tensors first and mirror back to host only when an updated host-side
+        argument is active. This avoids rewriting inactive host staging buffers during the drafting
+        loop.
         """
         # already in generate mode
         if self.is_generate_only:
@@ -1484,6 +1480,7 @@ class SequenceInfo:
         self.batch_info.update([0, 0, 0, 0, num_seq, num_seq])
         self.batch_info.update_tokens_gather_info(num_seq, False)
 
+        # check if we need a d2h sync
         _REQUIRES_UPDATE = {
             "input_ids",
             "input_pos",
@@ -1521,6 +1518,9 @@ class SequenceInfo:
         self.copy_("position_ids", input_pos, strict=False)
         self.copy_("use_initial_states", input_pos > 0)
 
+        # --- Bulk device-to-host sync ---
+        # TODO: May need to dissect what fields are needed in the forward pass to reduce
+        # data movement.
         if sync_to_host:
             self._input_buffer.copy_to_host()
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -1465,8 +1465,9 @@ class SequenceInfo:
         an all-decode layout where each sequence has exactly 1 token. We assume that we just take
         the last position of each sequence for the metadata.
 
-        NOTE: right now, we always update both host and device tensor to ensure this does not
-        interfere with the device-to-host sync in offset_pos_and_cache_.
+        NOTE: update device tensors first and mirror back to host only for active host graph
+        inputs. This matches offset_pos_and_cache_ and avoids rewriting inactive host staging
+        buffers during the drafting loop.
 
         NOTE: we assume the same structure as in nest_sequences for when to update the arguments.
         In particular, arguments that are always updated in nest_sequences are also updated here.
@@ -1483,31 +1484,45 @@ class SequenceInfo:
         self.batch_info.update([0, 0, 0, 0, num_seq, num_seq])
         self.batch_info.update_tokens_gather_info(num_seq, False)
 
-        for device, suffix in (
-            (self.host_device, self._host_suffix),
-            (self.device, ""),
-        ):
-            # --- input_ids ---
-            # use cu_seqlen as heuristic to get the input_ids if available
-            input_ids_flat = self.get_arg(f"input_ids{suffix}", truncate=False, unflatten=False)
-            extraction_indices = (self.get_arg(f"cu_seqlen{suffix}", truncate=True)[1:] - 1).long()
-            self.copy_(f"input_ids{suffix}", input_ids_flat[extraction_indices], strict=False)
+        _REQUIRES_UPDATE = {
+            "input_ids",
+            "input_pos",
+            "cu_seqlen",
+            "seq_len",
+            "position_ids",
+            "use_initial_states",
+        }
+        needs_d2h_sync = [
+            k + self._host_suffix
+            for k in _REQUIRES_UPDATE
+            if self._is_active(k + self._host_suffix, check_both=False)
+        ]
+        sync_to_host = any(needs_d2h_sync)
 
-            # --- input_pos ---
-            input_pos = self.get_arg(f"input_pos{suffix}", truncate=True)
-            input_pos += self.get_arg(f"seq_len{suffix}", truncate=True) - 1
+        # --- input_ids ---
+        # use cu_seqlen as heuristic to get the input_ids if available
+        input_ids_flat = self.get_arg("input_ids", truncate=False, unflatten=False)
+        extraction_indices = (self.get_arg("cu_seqlen", truncate=True)[1:] - 1).long()
+        self.copy_("input_ids", input_ids_flat[extraction_indices], strict=False)
 
-            # --- cu_seqlen ---
-            cu_seqlen = torch.arange(num_seq + 1, dtype=torch.int32, device=device)
-            self.copy_(f"cu_seqlen{suffix}", cu_seqlen)
+        # --- input_pos ---
+        input_pos = self.get_arg("input_pos", truncate=True)
+        input_pos += self.get_arg("seq_len", truncate=True) - 1
 
-            # --- seq_len ---
-            seq_len = self.get_arg(f"seq_len{suffix}", truncate=True)
-            seq_len.fill_(1)
+        # --- cu_seqlen ---
+        cu_seqlen = torch.arange(num_seq + 1, dtype=torch.int32, device=self.device)
+        self.copy_("cu_seqlen", cu_seqlen)
 
-            # --- update derivative metadata that change in generate-only mode if active ---
-            self.copy_(f"position_ids{suffix}", input_pos, strict=False)
-            self.copy_(f"use_initial_states{suffix}", input_pos > 0)
+        # --- seq_len ---
+        seq_len = self.get_arg("seq_len", truncate=True)
+        seq_len.fill_(1)
+
+        # --- update derivative metadata that change in generate-only mode if active ---
+        self.copy_("position_ids", input_pos, strict=False)
+        self.copy_("use_initial_states", input_pos > 0)
+
+        if sync_to_host:
+            self._input_buffer.copy_to_host()
 
     def copy_(self, name: str, src: torch.Tensor, strict: bool = True) -> None:
         """Copy a tensor into the buffer. USE WITH CAUTION!

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -1431,6 +1431,9 @@ class SequenceInfo:
         use_initial_states[:] = input_pos > 0
 
         # --- Bulk device-to-host sync ---
+        # This ensures that the H2D copy done by InputBuffer.copy_to_device() has been executed
+        # before we update the host-side tensors.
+        # By gating this on sync_to_host, we ensure that we only sync when a custom op needs updated host arguments.
         # TODO: May need to dissect what fields are needed in the forward pass to reduce
         # data movement.
         if sync_to_host:
@@ -1466,8 +1469,16 @@ class SequenceInfo:
         the last position of each sequence for the metadata.
 
         NOTE: update device tensors first and mirror back to host only when an updated host-side
-        argument is active. This avoids rewriting inactive host staging buffers during the drafting
-        loop.
+        argument is active.
+
+        This prevents race conditions with the H2D copy done by InputBuffer.copy_to_device().
+        The H2D copy was queued before the forward pass, but may not have been executed yet.
+        If this copy has not been executed and we updated host arguments directly,
+        we would be overwriting them with new values which would lead to these new values getting copied
+        to device when we wanted to copy the old data. By updating via a D2H sync on the active stream,
+        we ensure that these host-side tensors are updated *after* the H2D copy has been executed.
+
+        Additionally, we make sure the D2H sync only happens only when a custom op needs updated host arguments.
         """
         # already in generate mode
         if self.is_generate_only:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -1496,25 +1496,25 @@ class SequenceInfo:
         ]
         sync_to_host = any(needs_d2h_sync)
 
-        # --- input_ids ---
+        # --- input_ids (device) ---
         # use cu_seqlen as heuristic to get the input_ids if available
         input_ids_flat = self.get_arg("input_ids", truncate=False, unflatten=False)
         extraction_indices = (self.get_arg("cu_seqlen", truncate=True)[1:] - 1).long()
         self.copy_("input_ids", input_ids_flat[extraction_indices], strict=False)
 
-        # --- input_pos ---
+        # --- input_pos (device) ---
         input_pos = self.get_arg("input_pos", truncate=True)
         input_pos += self.get_arg("seq_len", truncate=True) - 1
 
-        # --- cu_seqlen ---
+        # --- cu_seqlen (device) ---
         cu_seqlen = torch.arange(num_seq + 1, dtype=torch.int32, device=self.device)
         self.copy_("cu_seqlen", cu_seqlen)
 
-        # --- seq_len ---
+        # --- seq_len (device) ---
         seq_len = self.get_arg("seq_len", truncate=True)
         seq_len.fill_(1)
 
-        # --- update derivative metadata that change in generate-only mode if active ---
+        # ---  update derivative metadata that change in generate-only mode if active (device) ---
         self.copy_("position_ids", input_pos, strict=False)
         self.copy_("use_initial_states", input_pos > 0)
 

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -10,8 +10,6 @@ accuracy/test_llm_api.py::TestLlama3_1_8BInstruct::test_gather_generation_logits
 accuracy/test_llm_api.py::TestLlama3_1_8BInstruct::test_guided_decoding_4gpus[xgrammar] SKIP (https://nvbugs/5346443)
 accuracy/test_llm_api.py::TestMistralNemo12B::test_fp8 SKIP (https://nvbugs/5413197)
 accuracy/test_llm_api_autodeploy.py::TestGemma4MoE::test_bf16 SKIP (https://nvbugs/6158397)
-accuracy/test_llm_api_autodeploy.py::TestLlama3_1_8B_Instruct_Eagle3::test_eagle3_one_model[flashinfer] SKIP (https://nvbugs/6117814)
-accuracy/test_llm_api_autodeploy.py::TestLlama3_1_8B_Instruct_Eagle3::test_eagle3_one_model[trtllm] SKIP (https://nvbugs/6117814)
 accuracy/test_llm_api_autodeploy.py::TestMiniMaxM2::test_finegrained_fp8 SKIP (https://nvbugs/6158397)
 accuracy/test_llm_api_autodeploy.py::TestNemotronNanoV3::test_accuracy[nvfp4-4-trtllm] SKIP (https://nvbugs/6120981)
 accuracy/test_llm_api_autodeploy.py::TestNemotronSuperV3::test_functional_small[bf16] SKIP (https://nvbugs/6162114)

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/test_switch_to_generate_inplace.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/test_switch_to_generate_inplace.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -291,6 +291,44 @@ class TestSwitchToGeneratePageBoundary:
 
 class TestSwitchToGenerateHostArgHandling:
     """Validate host arg warning and d2h sync behavior."""
+
+    def test_inactive_host_mirror_not_synced_by_switch_to_generate(self):
+        """Inactive host mirrors should keep pre-transition staging values."""
+        si = _make_seq_info()
+        _nest_prefill(
+            si,
+            input_ids=[[1, 2, 3], [4, 5, 6, 7]],
+            pages_per_seq=[1, 1],
+            cache_loc=[10, 20],
+        )
+
+        host_cu_before = si._input_buffer.get_host_view("cu_seqlen")[:3].clone()
+
+        si.switch_to_generate_()
+
+        device_cu = si._input_buffer.get_view("cu_seqlen")
+        assert device_cu[:3].tolist() == [0, 1, 2]
+
+        host_cu = si._input_buffer.get_host_view("cu_seqlen")
+        assert host_cu[:3].tolist() == host_cu_before.tolist()
+        assert host_cu[:3].tolist() == [0, 3, 7]
+
+    def test_active_host_mirror_synced_by_switch_to_generate(self):
+        """Active host mirrors should be refreshed from device metadata."""
+        si = _make_seq_info(extra_activate=("cu_seqlen_host",))
+        _nest_prefill(
+            si,
+            input_ids=[[1, 2, 3], [4, 5, 6, 7]],
+            pages_per_seq=[1, 1],
+            cache_loc=[10, 20],
+        )
+
+        si.switch_to_generate_()
+
+        device_cu = si._input_buffer.get_view("cu_seqlen")
+        host_cu = si._input_buffer.get_host_view("cu_seqlen")
+        assert device_cu[:3].tolist() == [0, 1, 2]
+        assert host_cu[:3].tolist() == [0, 1, 2]
 
     def test_non_native_host_arg_syncs_device_to_host(self):
         """Activating a non-native host arg should sync device -> host instead of raising."""

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/test_switch_to_generate_inplace.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/test_switch_to_generate_inplace.py
@@ -76,6 +76,27 @@ def _nest_prefill(si: SequenceInfo, input_ids, pages_per_seq, cache_loc, **kw):
     return si
 
 
+def _snapshot_host_views(si: SequenceInfo):
+    """Snapshot full host buffers so current-length updates do not hide host writes."""
+    return {
+        name: si._input_buffer.get_host_view(name).clone() for name in si._input_buffer.tensor_names
+    }
+
+
+def _host_views_unchanged(si: SequenceInfo, snapshots):
+    """Return whether host staging buffers are byte-for-byte unchanged."""
+    return all(
+        torch.equal(si._input_buffer.get_host_view(name), expected)
+        for name, expected in snapshots.items()
+    )
+
+
+def _has_active_host_arg(si: SequenceInfo):
+    """Return whether any managed host mirror is an active graph input."""
+    host_mirrors = {name + si._host_suffix for name in si._input_buffer.tensor_names}
+    return bool(host_mirrors & set(si._active_args))
+
+
 class TestSwitchToGeneratePackedToDecode:
     """Packed (prefill/extend) layout -> decode layout."""
 
@@ -292,7 +313,7 @@ class TestSwitchToGeneratePageBoundary:
 class TestSwitchToGenerateHostArgHandling:
     """Validate host arg warning and d2h sync behavior."""
 
-    def test_inactive_host_mirror_not_synced_by_switch_to_generate(self):
+    def test_inactive_host_mirrors_not_synced_by_switch_to_generate(self):
         """Inactive host mirrors should keep pre-transition staging values."""
         si = _make_seq_info()
         _nest_prefill(
@@ -302,16 +323,40 @@ class TestSwitchToGenerateHostArgHandling:
             cache_loc=[10, 20],
         )
 
-        host_cu_before = si._input_buffer.get_host_view("cu_seqlen")[:3].clone()
+        assert not _has_active_host_arg(si)
+        host_views_before = _snapshot_host_views(si)
 
         si.switch_to_generate_()
 
         device_cu = si._input_buffer.get_view("cu_seqlen")
         assert device_cu[:3].tolist() == [0, 1, 2]
 
-        host_cu = si._input_buffer.get_host_view("cu_seqlen")
-        assert host_cu[:3].tolist() == host_cu_before.tolist()
-        assert host_cu[:3].tolist() == [0, 3, 7]
+        assert _host_views_unchanged(si, host_views_before)
+        assert si._input_buffer.get_host_view("cu_seqlen")[:3].tolist() == [0, 3, 7]
+
+    def test_inactive_host_mirrors_not_synced_by_offset_pos_and_cache(self):
+        """Inactive host mirrors should keep pre-offset staging values."""
+        si = _make_seq_info()
+        si.nest_sequences(
+            [1, 2],
+            cu_seqlen=[0, 1, 2],
+            input_pos=[5, 10],
+            batch_info=[0, 0, 0, 0, 2, 2],
+            cache_loc=[10, 11, 20, 21, 22],
+            cu_num_pages=[0, 2, 5],
+            extra_page_per_seq=[-1, -1],
+        )
+
+        assert not _has_active_host_arg(si)
+        host_views_before = _snapshot_host_views(si)
+
+        increment = torch.tensor([1, 1], dtype=torch.int32, device=si.device)
+        si.offset_pos_and_cache_(increment)
+
+        device_pos = si._input_buffer.get_view("position_ids")
+        assert device_pos[:2].tolist() == [6, 11]
+
+        assert _host_views_unchanged(si, host_views_before)
 
     def test_active_host_mirror_synced_by_switch_to_generate(self):
         """Active host mirrors should be refreshed from device metadata."""


### PR DESCRIPTION
Also fixes: #13135 

We had a data race that was caught by QA on H20s that affected Llama-3.1-8B-Instruct with Eagle3 on H20s.

Note: This is *not actually* the same as the bug that was initially filed for https://nvbugspro.nvidia.com/bug/6117814. The bug was initially filed for low acceptance rate for the FlashInfer backend. After the bug was addressed, we added TRTLLM Attention backend for Eagle3 and reparametrized the test, and the TRTLLM Attention variant triggered this bug.

However, the actual bug caught affects many surfaces. It is likely that it may help in resolving other issues filed for AutoDeploy MTP, such as https://github.com/NVIDIA/TensorRT-LLM/issues/13135, and could resolve a flaky test reported here: https://nvbugspro.nvidia.com/bug/6108526 even though it uses the FlashInfer attn backend. After this merge, we need to triage the extent of this fix further.

Bug summary:

The H2D copy in nest_sequences() can conflict with host metadata updates made during the Eagle3 / MTP one model flow.

1) H2D copy in nest_sequences() is scheduled for an extend request with seq_len > 1
2) switch_to_device_() was called setting the host sequence length to 1 per sequence.
3) H2D copy occurs - copying sequence length 1 per sequence to device.
4) Extend path called with sequence length 1 per sequence, despite num_draft_tokens > 0 -> fails.

This manifested most easily with the overlap scheduler enabled with TRTLLM Attention backend, as this is where the lack of host syncs creates the most asymmetry between GPU and CPU scheduling, and Eagle3 with TRTLLM Attention does not actually need updated `cu_seqlen` metadata on _host_ . 

Now we use the same pattern as in offset_pos_and_cache_() - update the metadata we need on device because that is primarily where it is needed, and then sync it to host if needed by the current attention backend. For TRTLLM Attention this results in no sync. For FlashInfer attention, there is a host sync, but it is needed to guarantee data is consistent in the presence of the data race described above.

Now for TRTLLM Attention the flow is:

1) H2D copy in nest_sequences() is scheduled for an extend request with seq_len > 1
2) switch_to_device_() was called, NOT updating the host cu_seqlen.
3) H2D copy occurs - copying host cu_seqlen to device - fine, it has not been modified.
4) Extend path called with expected args

For FlashInfer (ignoring the host sync between target and draft for this backend; the example holds without it):
1) H2D copy in nest_sequences() is scheduled for an extend request with seq_len > 1
2) switch_to_device_() was called - schedules copy from device to host but does NOT change host metadata.
3) H2D copy occurs - copies old host sequence length to device.
4) Extend path called with expected sequence lengths.
5) Device metadata updated + D2H copy happens - sequence length is 1 everywhere consistently. Drafting continues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized data transfer during model generation initialization by selectively syncing only necessary data between host and device, reducing unnecessary data movement overhead.

* **Tests**
  * Extended test coverage to verify correct host-device synchronization behavior during generation mode transitions.
  * Resolved previously skipped test cases, confirming accuracy tests now pass successfully.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14008)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
