### PR TITLE
[TRTLLM-12288][feat] Support NVFP4 W4A16 inference on Hopper for Nemotron H models

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -313,39 +313,12 @@ class NemotronHMOE(nn.Module):
             for key in [EventType.Main, EventType.MoeShared]
         }
 
-    _E2M1_VALUES = torch.tensor(
-        [0, 0.5, 1, 1.5, 2, 3, 4, 6, 0, -0.5, -1, -1.5, -2, -3, -4, -6])
-
-    @staticmethod
-    def _dequant_nvfp4_tensor(packed: torch.Tensor, weight_scale: torch.Tensor,
-                              weight_scale_2: torch.Tensor,
-                              target_dtype: torch.dtype) -> torch.Tensor:
-        """Dequantize a single NVFP4 packed weight tensor to target_dtype."""
-        packed_uint8 = (packed.view(torch.uint8)
-                        if packed.dtype != torch.uint8 else packed)
-        N, K_packed = packed_uint8.shape
-        K = K_packed * 2
-
-        low = (packed_uint8 & 0x0F).long()
-        high = ((packed_uint8 >> 4) & 0x0F).long()
-        idx = torch.empty(N, K, dtype=torch.long, device=packed.device)
-        idx[:, 0::2] = low
-        idx[:, 1::2] = high
-        lut = NemotronHMOE._E2M1_VALUES.to(packed.device)
-        vals = lut[idx]
-
-        block_size = 16
-        num_blocks = N * (K // block_size)
-        ws = weight_scale.to(torch.float32).reshape(-1)[:num_blocks]
-        s2 = weight_scale_2.to(torch.float32)
-        block_scales = (ws * s2).view(N, K // block_size, 1)
-        vals = vals.view(N, K // block_size, block_size) * block_scales
-        return vals.view(N, K).to(target_dtype)
-
     def _wrap_moe_load_weights_for_dequant(self):
         """Wrap self.experts.load_weights to dequant NVFP4 expert weights to BF16."""
         import functools
         import types
+
+        import tensorrt_llm.quantization.utils.fp4_utils as fp4_utils
 
         original_load_weights = self.experts.load_weights.__func__
         target_dtype = torch.bfloat16
@@ -369,8 +342,9 @@ class NemotronHMOE(nn.Module):
                         packed = tensor[...].cuda()
                         ws = new_dict[scale_key][...].cuda()
                         ws2 = new_dict[scale2_key][...].cuda()
-                        new_dict[key] = NemotronHMOE._dequant_nvfp4_tensor(
-                            packed, ws, ws2, target_dtype)
+                        N, K = packed.shape[0], packed.shape[1] * 2
+                        new_dict[key] = fp4_utils.dequantize_nvfp4(
+                            packed, ws, ws2, N, K, target_dtype)
                         del new_dict[scale_key]
                         del new_dict[scale2_key]
                         for suffix in ('.input_scale', '.input_quantizer'):

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -218,12 +218,27 @@ class NemotronHMOE(nn.Module):
         # when loading NVFP4/W4A8_NVFP4_FP8 quantized expert weights.
         # Look up the per-expert quant config from quant_config_dict and use it for create_moe.
         moe_model_config = model_config
+        self._nvfp4_dequant_moe = False
         if model_config.quant_config_dict is not None:
             experts_prefix = f"model.layers.{layer_idx}.mixer.experts."
             for key, cfg in model_config.quant_config_dict.items():
                 if key.startswith(experts_prefix):
-                    moe_model_config = replace(model_config, quant_config=cfg)
+                    # On GPUs without FP4 tensor cores (sm < 100), dequant NVFP4
+                    # expert weights to BF16 at load time and run MoE unquantized.
+                    if cfg.quant_mode.has_nvfp4() and get_sm_version() < 100:
+                        self._nvfp4_dequant_moe = True
+                    else:
+                        moe_model_config = replace(model_config,
+                                                   quant_config=cfg)
                     break
+
+        # When the global quant config (not per-layer dict) indicates NVFP4 on Hopper,
+        # also enable the dequant path.
+        if (not self._nvfp4_dequant_moe
+                and model_config.quant_config is not None
+                and model_config.quant_config.quant_mode.has_nvfp4()
+                and get_sm_version() < 100):
+            self._nvfp4_dequant_moe = True
 
         # Setup MoE experts.
         self.experts = create_moe(
@@ -240,6 +255,9 @@ class NemotronHMOE(nn.Module):
             bias=self.mlp_bias,
             activation_type=self.activation_type,
         )
+
+        if self._nvfp4_dequant_moe:
+            self._wrap_moe_load_weights_for_dequant()
 
         if reduce_output:
             self.allreduce = AllReduce(
@@ -294,6 +312,75 @@ class NemotronHMOE(nn.Module):
             key: torch.cuda.Event()
             for key in [EventType.Main, EventType.MoeShared]
         }
+
+    _E2M1_VALUES = torch.tensor(
+        [0, 0.5, 1, 1.5, 2, 3, 4, 6, 0, -0.5, -1, -1.5, -2, -3, -4, -6])
+
+    @staticmethod
+    def _dequant_nvfp4_tensor(packed: torch.Tensor, weight_scale: torch.Tensor,
+                              weight_scale_2: torch.Tensor,
+                              target_dtype: torch.dtype) -> torch.Tensor:
+        """Dequantize a single NVFP4 packed weight tensor to target_dtype."""
+        packed_uint8 = (packed.view(torch.uint8)
+                        if packed.dtype != torch.uint8 else packed)
+        N, K_packed = packed_uint8.shape
+        K = K_packed * 2
+
+        low = (packed_uint8 & 0x0F).long()
+        high = ((packed_uint8 >> 4) & 0x0F).long()
+        idx = torch.empty(N, K, dtype=torch.long, device=packed.device)
+        idx[:, 0::2] = low
+        idx[:, 1::2] = high
+        lut = NemotronHMOE._E2M1_VALUES.to(packed.device)
+        vals = lut[idx]
+
+        block_size = 16
+        num_blocks = N * (K // block_size)
+        ws = weight_scale.to(torch.float32).reshape(-1)[:num_blocks]
+        s2 = weight_scale_2.to(torch.float32)
+        block_scales = (ws * s2).view(N, K // block_size, 1)
+        vals = vals.view(N, K // block_size, block_size) * block_scales
+        return vals.view(N, K).to(target_dtype)
+
+    def _wrap_moe_load_weights_for_dequant(self):
+        """Wrap self.experts.load_weights to dequant NVFP4 expert weights to BF16."""
+        import functools
+        import types
+
+        original_load_weights = self.experts.load_weights.__func__
+        target_dtype = torch.bfloat16
+
+        @functools.wraps(original_load_weights)
+        def _dequant_load_weights(self_moe, weights, **kwargs):
+            if not weights:
+                return original_load_weights(self_moe, weights, **kwargs)
+            dequanted = []
+            for w_dict in weights:
+                new_dict = dict(w_dict)
+                for key in list(new_dict.keys()):
+                    if not key.endswith('.weight'):
+                        continue
+                    scale_key = key.replace('.weight', '.weight_scale')
+                    scale2_key = key.replace('.weight', '.weight_scale_2')
+                    tensor = new_dict[key]
+                    if (tensor[...].dtype == torch.uint8
+                            and scale_key in new_dict
+                            and scale2_key in new_dict):
+                        packed = tensor[...].cuda()
+                        ws = new_dict[scale_key][...].cuda()
+                        ws2 = new_dict[scale2_key][...].cuda()
+                        new_dict[key] = NemotronHMOE._dequant_nvfp4_tensor(
+                            packed, ws, ws2, target_dtype)
+                        del new_dict[scale_key]
+                        del new_dict[scale2_key]
+                        for suffix in ('.input_scale', '.input_quantizer'):
+                            k = key.replace('.weight', suffix)
+                            new_dict.pop(k, None)
+                dequanted.append(new_dict)
+            return original_load_weights(self_moe, dequanted, **kwargs)
+
+        self.experts.load_weights = types.MethodType(_dequant_load_weights,
+                                                     self.experts)
 
     def forward(
         self,
@@ -403,10 +490,12 @@ class NemotronHLayer(DecoderLayer):
 
         quant_mode = (model_config.quant_config.quant_mode
                       if model_config.quant_config is not None else None)
-        self.is_nvfp4 = quant_mode is not None and quant_mode.has_nvfp4()
+        _has_fp4_hw = get_sm_version() >= 100
+        self.is_nvfp4 = (quant_mode is not None and quant_mode.has_nvfp4()
+                         and _has_fp4_hw)
         # For MIXED_PRECISION models, the global quant_mode is QuantMode(0). Check per-layer
         # quant_config_dict to see if this specific layer is NVFP4-quantized.
-        if not self.is_nvfp4 and model_config.quant_config_dict is not None:
+        if not self.is_nvfp4 and _has_fp4_hw and model_config.quant_config_dict is not None:
             layer_prefix = f"model.layers.{layer_idx}."
             for key, cfg in model_config.quant_config_dict.items():
                 if key.startswith(layer_prefix) and cfg.quant_mode.has_nvfp4():

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -1870,40 +1870,24 @@ class NVFP4W4A16LinearMethod(NVFP4LinearMethod):
     Activations remain in BF16 throughout -- no FP4 activation quantization.
     """
 
-    _E2M1_VALUES = torch.tensor(
-        [0, 0.5, 1, 1.5, 2, 3, 4, 6, 0, -0.5, -1, -1.5, -2, -3, -4, -6])
-
     supports_nccl_symmetric_memory_window_output: ClassVar[bool] = False
 
     def _dequantize_weight(self, module: Linear) -> torch.Tensor:
         """Dequantize FP4 packed weights to module.dtype (typically BF16)."""
         weight = module.weight.data
-        N_padded = weight.shape[0]
-        K_packed = weight.shape[1]
-        K = K_packed * 2
+        K = weight.shape[1] * 2
         N = module.out_features
         sf_vec_size = module.scaling_vector_size
 
-        weight_uint8 = weight.view(torch.uint8)
-        low = (weight_uint8 & 0x0F).long()
-        high = ((weight_uint8 >> 4) & 0x0F).long()
-        idx = torch.empty(N_padded, K, dtype=torch.long, device=weight.device)
-        idx[:, 0::2] = low
-        idx[:, 1::2] = high
-        lut = self._E2M1_VALUES.to(weight.device)
-        vals = lut[idx]
-
+        # Un-interleave per-block scales from CUTLASS swizzled layout to flat 2D
         scale_rows = fp4_utils.pad_up(N, 128)
         ws_2d = unswizzle_sf(module.weight_scale.data, scale_rows, K,
                              sf_vec_size)
-        ws_2d = ws_2d[:N_padded, :K // sf_vec_size].to(torch.float32)
+        ws_flat = ws_2d[:weight.shape[0], :K // sf_vec_size]
 
-        scale_2 = module.weight_scale_2.data.to(torch.float32)
-        block_scales = (ws_2d * scale_2).unsqueeze(-1)
-        vals = vals.view(N_padded, K // sf_vec_size, sf_vec_size) * block_scales
-        vals = vals.view(N_padded, K)
-
-        return vals[:N].to(module.dtype)
+        return fp4_utils.dequantize_nvfp4(weight, ws_flat,
+                                          module.weight_scale_2.data, N, K,
+                                          module.dtype, sf_vec_size)
 
     def apply(self, module: Linear, input: torch.Tensor,
               bias: Optional[torch.Tensor]):

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -1861,6 +1861,66 @@ class NVFP4LinearMethod(LinearMethodBase):
                     module.rebuild_tensor_metadata)
 
 
+class NVFP4W4A16LinearMethod(NVFP4LinearMethod):
+    """W4A16 fallback for NVFP4 weights on GPUs without FP4 tensor cores.
+
+    Inherits NVFP4LinearMethod's weight storage and loading (FP4 packed weights
+    + per-block FP8 scales + global scale). Overrides apply() to dequantize
+    weights to BF16 and use standard matmul instead of nvfp4_gemm.
+    Activations remain in BF16 throughout -- no FP4 activation quantization.
+    """
+
+    _E2M1_VALUES = torch.tensor(
+        [0, 0.5, 1, 1.5, 2, 3, 4, 6, 0, -0.5, -1, -1.5, -2, -3, -4, -6])
+
+    supports_nccl_symmetric_memory_window_output: ClassVar[bool] = False
+
+    def _dequantize_weight(self, module: Linear) -> torch.Tensor:
+        """Dequantize FP4 packed weights to module.dtype (typically BF16)."""
+        weight = module.weight.data
+        N_padded = weight.shape[0]
+        K_packed = weight.shape[1]
+        K = K_packed * 2
+        N = module.out_features
+        sf_vec_size = module.scaling_vector_size
+
+        weight_uint8 = weight.view(torch.uint8)
+        low = (weight_uint8 & 0x0F).long()
+        high = ((weight_uint8 >> 4) & 0x0F).long()
+        idx = torch.empty(N_padded, K, dtype=torch.long, device=weight.device)
+        idx[:, 0::2] = low
+        idx[:, 1::2] = high
+        lut = self._E2M1_VALUES.to(weight.device)
+        vals = lut[idx]
+
+        scale_rows = fp4_utils.pad_up(N, 128)
+        ws_2d = unswizzle_sf(module.weight_scale.data, scale_rows, K,
+                             sf_vec_size)
+        ws_2d = ws_2d[:N_padded, :K // sf_vec_size].to(torch.float32)
+
+        scale_2 = module.weight_scale_2.data.to(torch.float32)
+        block_scales = (ws_2d * scale_2).unsqueeze(-1)
+        vals = vals.view(N_padded, K // sf_vec_size, sf_vec_size) * block_scales
+        vals = vals.view(N_padded, K)
+
+        return vals[:N].to(module.dtype)
+
+    def apply(self, module: Linear, input: torch.Tensor,
+              bias: Optional[torch.Tensor]):
+        w_bf16 = self._dequantize_weight(module)
+        output = F.linear(input, w_bf16, bias)
+        return output
+
+    def apply_linear_allreduce(self, module: Linear, input: torch.Tensor,
+                               bias: Optional[torch.Tensor], tp_rank: int,
+                               tp_group: List[int]):
+        output = self.apply(module, input, bias)
+        return output
+
+    def post_load_weights(self, module: Linear):
+        """Skip FP4 GEMM alignment padding -- not needed for BF16 matmul."""
+
+
 class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
 
     def create_weights(self, module: Linear, in_features: int,
@@ -2716,6 +2776,8 @@ def get_quant_method(quant_config: Optional[QuantConfig] = None):
     if quant_config.layer_quant_mode.has_fp8_block_scales():
         return FP8BlockScalesLinearMethod()
     if quant_config.layer_quant_mode.has_nvfp4():
+        if get_sm_version() < 100:
+            return NVFP4W4A16LinearMethod()
         if quant_config.quant_algo == QuantAlgo.NVFP4_ARC:
             return NVFP4ARCLinearMethod()
         else:

--- a/tensorrt_llm/quantization/utils/fp4_utils.py
+++ b/tensorrt_llm/quantization/utils/fp4_utils.py
@@ -16,7 +16,13 @@ float4_e2m1x2 = FLOAT4_E2M1X2
 float4_sf_dtype = SF_DTYPE
 fp4_buckets = FP4_BUCKETS
 
-__all__ = ['float4_e2m1x2', 'float4_sf_dtype', 'pad_up', 'fp4_buckets']
+E2M1_VALUES = torch.tensor(
+    [0, 0.5, 1, 1.5, 2, 3, 4, 6, 0, -0.5, -1, -1.5, -2, -3, -4, -6])
+
+__all__ = [
+    'float4_e2m1x2', 'float4_sf_dtype', 'pad_up', 'fp4_buckets', 'E2M1_VALUES',
+    'dequantize_nvfp4'
+]
 
 
 def pad_up(x: int, y: int) -> int:
@@ -204,3 +210,49 @@ def shuffle_matrix_sf_a(
 
     # 128x4
     return torch.ops.trtllm.block_scale_interleave(w_shuffled)
+
+
+def dequantize_nvfp4(
+    packed_weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    weight_scale_2: torch.Tensor,
+    out_features: int,
+    in_features: int,
+    target_dtype: torch.dtype = torch.bfloat16,
+    block_size: int = 16,
+) -> torch.Tensor:
+    """Dequantize NVFP4 packed weights to a floating-point dtype.
+
+    Args:
+        packed_weight: [N, K/2] uint8 with two E2M1 nibbles per byte.
+        weight_scale: Per-block scales (FP8 or FP32), flat or shaped.
+        weight_scale_2: Per-tensor global scale (FP32 scalar).
+        out_features: Unpadded number of output rows (N).
+        in_features: Unpadded number of input columns (K).
+        target_dtype: Output dtype (default bfloat16).
+        block_size: Number of elements per scale block (default 16).
+
+    Returns:
+        Dequantized weight tensor of shape [out_features, in_features].
+    """
+    packed_uint8 = (packed_weight.view(torch.uint8)
+                    if packed_weight.dtype != torch.uint8 else packed_weight)
+    N_stored = packed_uint8.shape[0]
+    K = packed_uint8.shape[1] * 2
+    device = packed_uint8.device
+
+    low = (packed_uint8 & 0x0F).long()
+    high = ((packed_uint8 >> 4) & 0x0F).long()
+    idx = torch.empty(N_stored, K, dtype=torch.long, device=device)
+    idx[:, 0::2] = low
+    idx[:, 1::2] = high
+    vals = E2M1_VALUES.to(device)[idx]
+
+    num_blocks = N_stored * (K // block_size)
+    ws = weight_scale.to(torch.float32).reshape(-1)[:num_blocks]
+    s2 = weight_scale_2.to(torch.float32)
+    block_scales = (ws * s2).view(N_stored, K // block_size, 1)
+    vals = vals.view(N_stored, K // block_size, block_size) * block_scales
+    vals = vals.view(N_stored, K)
+
+    return vals[:out_features, :in_features].to(target_dtype)

--- a/tests/unittest/_torch/thop/parallel/test_nvfp4_w4a16.py
+++ b/tests/unittest/_torch/thop/parallel/test_nvfp4_w4a16.py
@@ -1,0 +1,310 @@
+"""Tests for NVFP4 W4A16 (dequant-to-BF16) path on GPUs without FP4 tensor cores.
+
+Tests:
+1. Dequant round-trip: quantize BF16 -> NVFP4 -> dequant, verify closeness
+2. NVFP4W4A16LinearMethod forward matches manual dequant + F.linear
+3. W4A4 vs W4A16 output comparison (Blackwell-only)
+4. SM version routing in get_quant_method
+5. MoE weight dequant correctness
+"""
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.auto_deploy.custom_ops.quantization.torch_quant import (
+    _dequantize_nvfp4,
+    _quantize_nvfp4,
+)
+from tensorrt_llm._torch.modules.linear import (
+    Linear,
+    NVFP4LinearMethod,
+    NVFP4W4A16LinearMethod,
+    get_quant_method,
+)
+from tensorrt_llm._utils import get_sm_version
+from tensorrt_llm.math_utils import pad_up
+from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
+
+SCALING_VECTOR_SIZE = 16
+FP8_MAX = 448.0
+E2M1_MAX = 6.0
+
+
+def _make_nvfp4_weights(out_features, in_features, dtype=torch.bfloat16):
+    """Create NVFP4 quantized weights from random BF16 data.
+
+    Returns (w_original, w_fp4_packed, block_scale_fp8, weight_scale_2)
+    where the scales are in ModelOpt checkpoint format (not CUTLASS swizzled).
+    """
+    w = torch.randn(out_features, in_features, dtype=dtype).cuda()
+    w_float = w.float()
+    weight_scale_2 = w_float.abs().amax().float() / (E2M1_MAX * FP8_MAX)
+
+    packed_weight, block_scale = _quantize_nvfp4(w_float, SCALING_VECTOR_SIZE, weight_scale_2)
+    packed_uint8 = packed_weight.to(torch.uint8)
+    block_scale_fp8 = block_scale.to(torch.float8_e4m3fn)
+
+    return w, packed_uint8, block_scale_fp8, weight_scale_2
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Test 1: Dequant round-trip correctness
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("shape", [(128, 256), (192, 128), (7168, 16384)])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_nvfp4_dequant_roundtrip(shape, dtype):
+    """Quantize BF16 -> NVFP4 -> dequant and verify closeness to original."""
+    out_features, in_features = shape
+    w_orig, packed, bs_fp8, ws2 = _make_nvfp4_weights(out_features, in_features, dtype)
+
+    # Dequant using the reference AutoDeploy function
+    w_recovered = _dequantize_nvfp4(packed, bs_fp8, ws2, (out_features, in_features), dtype)
+
+    # FP4 E2M1 has very coarse quantization, so tolerances are loose.
+    # The important thing is no systematic bias or index errors.
+    torch.testing.assert_close(w_recovered, w_orig.to(dtype), atol=0.5, rtol=0.15)
+
+
+@pytest.mark.parametrize("shape", [(128, 256), (192, 128)])
+def test_nvfp4_dequant_w4a16_matches_reference(shape):
+    """Verify NVFP4W4A16LinearMethod._dequantize_weight matches _dequantize_nvfp4."""
+    out_features, in_features = shape
+    _, packed, bs_fp8, ws2 = _make_nvfp4_weights(out_features, in_features)
+
+    ref = _dequantize_nvfp4(packed, bs_fp8, ws2, (out_features, in_features), torch.bfloat16)
+
+    # Build the E2M1 LUT-based dequant used by NVFP4W4A16LinearMethod
+    method = NVFP4W4A16LinearMethod()
+    lut = method._E2M1_VALUES.to(packed.device)
+    low = (packed.view(torch.uint8) & 0x0F).long()
+    high = ((packed.view(torch.uint8) >> 4) & 0x0F).long()
+    idx = torch.empty(out_features, in_features, dtype=torch.long, device=packed.device)
+    idx[:, 0::2] = low
+    idx[:, 1::2] = high
+    vals = lut[idx]
+
+    num_blocks = out_features * (in_features // SCALING_VECTOR_SIZE)
+    ws = bs_fp8.to(torch.float32).reshape(-1)[:num_blocks]
+    s2 = ws2.to(torch.float32)
+    block_scales = (ws * s2).view(out_features, in_features // 16, 1)
+    vals = vals.view(out_features, in_features // 16, 16) * block_scales
+    manual = vals.view(out_features, in_features).to(torch.bfloat16)
+
+    torch.testing.assert_close(manual, ref, atol=1e-3, rtol=1e-3)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Test 2: NVFP4W4A16LinearMethod forward pass
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("mnk", [(4, 192, 128), (1, 128, 256), (16, 192, 128)])
+def test_nvfp4_w4a16_linear_forward(mnk):
+    """Forward pass of NVFP4W4A16LinearMethod matches manual dequant + F.linear."""
+    seq_len, out_features, in_features = mnk
+    dtype = torch.bfloat16
+    torch.manual_seed(42)
+
+    x = torch.randn(seq_len, in_features, dtype=dtype).cuda()
+    w_orig, packed, bs_fp8, ws2 = _make_nvfp4_weights(out_features, in_features, dtype)
+
+    # Compute reference: dequant + F.linear
+    w_dequant = _dequantize_nvfp4(packed, bs_fp8, ws2, (out_features, in_features), dtype)
+    ref_output = torch.nn.functional.linear(x, w_dequant)
+
+    # Build Linear with W4A16 method (force it regardless of actual SM)
+    qc = QuantConfig(quant_algo=QuantAlgo.NVFP4)
+    with patch("tensorrt_llm._torch.modules.linear.get_sm_version", return_value=90):
+        linear = Linear(
+            in_features=in_features,
+            out_features=out_features,
+            bias=False,
+            dtype=dtype,
+            quant_config=qc,
+        )
+
+    # Verify the method is W4A16
+    assert isinstance(linear.linear_method, NVFP4W4A16LinearMethod)
+
+    # Prepare weight_scale in ModelOpt format (unswizzled FP8)
+    bs_unswizzled = bs_fp8.view(torch.float8_e4m3fn)
+
+    # input_scale: ModelOpt stores amax/(448*6), which becomes weight_scale_2
+    input_scale_ckpt = torch.tensor([1.0 / (FP8_MAX * E2M1_MAX)])  # dummy static scale
+
+    linear.load_weights(
+        [
+            {
+                "weight": packed.cpu(),
+                "weight_scale": bs_unswizzled.cpu(),
+                "weight_scale_2": ws2.cpu(),
+                "input_scale": input_scale_ckpt.cpu(),
+            }
+        ]
+    )
+    linear = linear.cuda()
+
+    with torch.inference_mode():
+        output = linear(x)
+
+    torch.testing.assert_close(output, ref_output, atol=0.01, rtol=0.01)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Test 3: W4A4 vs W4A16 output comparison (Blackwell only)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(get_sm_version() < 100, reason="W4A4 NVFP4 GEMM requires Blackwell (sm >= 100)")
+@pytest.mark.parametrize("mnk", [(4, 192, 128), (128, 192, 128)])
+def test_w4a4_vs_w4a16_output_comparison(mnk):
+    """On Blackwell, compare W4A4 and W4A16 outputs on same weights/input."""
+    from tensorrt_llm._torch.autotuner import autotune
+
+    seq_len, out_features, in_features = mnk
+    dtype = torch.bfloat16
+    torch.manual_seed(0)
+
+    x = torch.randn(seq_len, in_features, dtype=dtype).cuda()
+    x_sf_global = (FP8_MAX * E2M1_MAX) / x.abs().max().float()
+
+    w = torch.randn(out_features, in_features, dtype=dtype).cuda()
+    w_sf_global = (FP8_MAX * E2M1_MAX) / w.abs().max().float()
+    w_fp4, w_sf_block = torch.ops.trtllm.fp4_quantize(w, w_sf_global, SCALING_VECTOR_SIZE, False)
+
+    w_sf_block_unswizzled = torch.ops.trtllm.block_scale_interleave_reverse(
+        w_sf_block.cpu().view(pad_up(out_features, 128), -1)
+    )
+
+    weight_dict = {
+        "input_scale": 1.0 / x_sf_global.cpu(),
+        "weight": w_fp4.cpu(),
+        "weight_scale": w_sf_block_unswizzled.view(torch.float8_e4m3fn),
+        "weight_scale_2": 1.0 / w_sf_global.cpu(),
+    }
+
+    # W4A4 path (native NVFP4)
+    qc = QuantConfig(quant_algo=QuantAlgo.NVFP4)
+    l_w4a4 = Linear(
+        in_features=in_features,
+        out_features=out_features,
+        bias=False,
+        dtype=dtype,
+        quant_config=qc,
+        nvfp4_allowed_backends=["cutlass"],
+    )
+    l_w4a4.load_weights([dict(weight_dict)])
+    l_w4a4 = l_w4a4.cuda()
+
+    with torch.inference_mode(), autotune():
+        out_w4a4 = l_w4a4(x)
+
+    # W4A16 path (dequant to BF16)
+    with patch("tensorrt_llm._torch.modules.linear.get_sm_version", return_value=90):
+        l_w4a16 = Linear(
+            in_features=in_features,
+            out_features=out_features,
+            bias=False,
+            dtype=dtype,
+            quant_config=qc,
+        )
+    assert isinstance(l_w4a16.linear_method, NVFP4W4A16LinearMethod)
+    l_w4a16.load_weights([dict(weight_dict)])
+    l_w4a16 = l_w4a16.cuda()
+
+    with torch.inference_mode():
+        out_w4a16 = l_w4a16(x)
+
+    # Outputs differ due to activation quantization in W4A4 and GEMM precision,
+    # but should be in the same ballpark. Use generous tolerance.
+    torch.testing.assert_close(out_w4a4, out_w4a16, atol=1.0, rtol=0.15)
+
+    # Verify they're reasonably correlated (cosine sim > 0.95)
+    cos_sim = torch.nn.functional.cosine_similarity(
+        out_w4a4.flatten().float(), out_w4a16.flatten().float(), dim=0
+    )
+    assert cos_sim > 0.95, f"Cosine similarity too low: {cos_sim:.4f}"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Test 4: SM version routing in get_quant_method
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_get_quant_method_routes_w4a16_on_hopper():
+    """get_quant_method returns NVFP4W4A16LinearMethod when sm < 100."""
+    qc = QuantConfig(quant_algo=QuantAlgo.NVFP4)
+    with patch("tensorrt_llm._torch.modules.linear.get_sm_version", return_value=90):
+        method = get_quant_method(qc)
+    assert isinstance(method, NVFP4W4A16LinearMethod)
+
+
+def test_get_quant_method_routes_nvfp4_on_blackwell():
+    """get_quant_method returns NVFP4LinearMethod when sm >= 100."""
+    qc = QuantConfig(quant_algo=QuantAlgo.NVFP4)
+    with patch("tensorrt_llm._torch.modules.linear.get_sm_version", return_value=100):
+        method = get_quant_method(qc)
+    assert isinstance(method, NVFP4LinearMethod)
+    assert not isinstance(method, NVFP4W4A16LinearMethod)
+
+
+def test_get_quant_method_routes_arc_on_blackwell():
+    """get_quant_method still returns NVFP4ARCLinearMethod for ARC on Blackwell."""
+    from tensorrt_llm._torch.modules.linear import NVFP4ARCLinearMethod
+
+    qc = QuantConfig(quant_algo=QuantAlgo.NVFP4_ARC)
+    with patch("tensorrt_llm._torch.modules.linear.get_sm_version", return_value=100):
+        method = get_quant_method(qc)
+    assert isinstance(method, NVFP4ARCLinearMethod)
+
+
+def test_get_quant_method_routes_w4a16_for_arc_on_hopper():
+    """On Hopper, even NVFP4_ARC should route to W4A16 (no FP4 tensor cores)."""
+    qc = QuantConfig(quant_algo=QuantAlgo.NVFP4_ARC)
+    with patch("tensorrt_llm._torch.modules.linear.get_sm_version", return_value=90):
+        method = get_quant_method(qc)
+    assert isinstance(method, NVFP4W4A16LinearMethod)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Test 5: MoE weight dequant correctness
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_moe_dequant_nvfp4_tensor():
+    """NemotronHMOE._dequant_nvfp4_tensor matches _dequantize_nvfp4 reference."""
+    from tensorrt_llm._torch.models.modeling_nemotron_h import NemotronHMOE
+
+    out_features, in_features = 192, 128
+    _, packed, bs_fp8, ws2 = _make_nvfp4_weights(out_features, in_features)
+
+    ref = _dequantize_nvfp4(packed, bs_fp8, ws2, (out_features, in_features), torch.bfloat16)
+
+    result = NemotronHMOE._dequant_nvfp4_tensor(packed, bs_fp8, ws2, torch.bfloat16)
+
+    torch.testing.assert_close(result, ref, atol=1e-3, rtol=1e-3)
+
+
+@pytest.mark.parametrize("num_experts", [2, 4])
+def test_moe_dequant_multiple_experts(num_experts):
+    """Verify per-expert dequant produces correct results for stacked experts."""
+    from tensorrt_llm._torch.models.modeling_nemotron_h import NemotronHMOE
+
+    hidden = 128
+    intermediate = 192
+    dtype = torch.bfloat16
+
+    for expert_idx in range(num_experts):
+        torch.manual_seed(expert_idx)
+        _, packed, bs_fp8, ws2 = _make_nvfp4_weights(intermediate, hidden, dtype)
+
+        ref = _dequantize_nvfp4(packed, bs_fp8, ws2, (intermediate, hidden), dtype)
+        result = NemotronHMOE._dequant_nvfp4_tensor(packed, bs_fp8, ws2, dtype)
+
+        torch.testing.assert_close(
+            result, ref, atol=1e-3, rtol=1e-3, msg=f"Expert {expert_idx} dequant mismatch"
+        )

--- a/tests/unittest/_torch/thop/parallel/test_nvfp4_w4a16.py
+++ b/tests/unittest/_torch/thop/parallel/test_nvfp4_w4a16.py
@@ -109,7 +109,7 @@ def test_nvfp4_w4a16_linear_forward(mnk):
             quant_config=qc,
         )
 
-    assert isinstance(linear.linear_method, NVFP4W4A16LinearMethod)
+    assert isinstance(linear.quant_method, NVFP4W4A16LinearMethod)
 
     bs_unswizzled = bs_fp8.view(torch.float8_e4m3fn)
     input_scale_ckpt = torch.tensor([1.0 / (FP8_MAX * E2M1_MAX)])
@@ -190,7 +190,7 @@ def test_w4a4_vs_w4a16_output_comparison(mnk):
             dtype=dtype,
             quant_config=qc,
         )
-    assert isinstance(l_w4a16.linear_method, NVFP4W4A16LinearMethod)
+    assert isinstance(l_w4a16.quant_method, NVFP4W4A16LinearMethod)
     l_w4a16.load_weights([dict(weight_dict)])
     l_w4a16 = l_w4a16.cuda()
 

--- a/tests/unittest/_torch/thop/parallel/test_nvfp4_w4a16.py
+++ b/tests/unittest/_torch/thop/parallel/test_nvfp4_w4a16.py
@@ -37,7 +37,8 @@ def _make_nvfp4_weights(out_features, in_features, dtype=torch.bfloat16):
     """Create NVFP4 quantized weights from random BF16 data.
 
     Returns (w_original, w_fp4_packed, block_scale_fp8, weight_scale_2)
-    where the scales are in ModelOpt checkpoint format (not CUTLASS swizzled).
+    where the scales are padded to the layout that load_weights expects
+    (matching real ModelOpt checkpoint format).
     """
     w = torch.randn(out_features, in_features, dtype=dtype).cuda()
     w_float = w.float()
@@ -47,7 +48,16 @@ def _make_nvfp4_weights(out_features, in_features, dtype=torch.bfloat16):
     packed_uint8 = packed_weight.to(torch.uint8)
     block_scale_fp8 = block_scale.to(torch.float8_e4m3fn)
 
-    return w, packed_uint8, block_scale_fp8, weight_scale_2
+    n_sf = out_features
+    k_sf = in_features // SCALING_VECTOR_SIZE
+    n_sf_padded = pad_up(n_sf, 128)
+    k_sf_padded = pad_up(k_sf, 4)
+    bs_padded = torch.zeros(
+        n_sf_padded, k_sf_padded, dtype=block_scale_fp8.dtype, device=block_scale_fp8.device
+    )
+    bs_padded[:n_sf, :k_sf] = block_scale_fp8
+
+    return w, packed_uint8, bs_padded, weight_scale_2
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/tests/unittest/_torch/thop/parallel/test_nvfp4_w4a16.py
+++ b/tests/unittest/_torch/thop/parallel/test_nvfp4_w4a16.py
@@ -5,7 +5,7 @@ Tests:
 2. NVFP4W4A16LinearMethod forward matches manual dequant + F.linear
 3. W4A4 vs W4A16 output comparison (Blackwell-only)
 4. SM version routing in get_quant_method
-5. MoE weight dequant correctness
+5. Shared fp4_utils.dequantize_nvfp4 correctness
 """
 
 from unittest.mock import patch
@@ -13,6 +13,7 @@ from unittest.mock import patch
 import pytest
 import torch
 
+import tensorrt_llm.quantization.utils.fp4_utils as fp4_utils
 from tensorrt_llm._torch.auto_deploy.custom_ops.quantization.torch_quant import (
     _dequantize_nvfp4,
     _quantize_nvfp4,
@@ -61,40 +62,21 @@ def test_nvfp4_dequant_roundtrip(shape, dtype):
     out_features, in_features = shape
     w_orig, packed, bs_fp8, ws2 = _make_nvfp4_weights(out_features, in_features, dtype)
 
-    # Dequant using the reference AutoDeploy function
     w_recovered = _dequantize_nvfp4(packed, bs_fp8, ws2, (out_features, in_features), dtype)
 
-    # FP4 E2M1 has very coarse quantization, so tolerances are loose.
-    # The important thing is no systematic bias or index errors.
     torch.testing.assert_close(w_recovered, w_orig.to(dtype), atol=0.5, rtol=0.15)
 
 
 @pytest.mark.parametrize("shape", [(128, 256), (192, 128)])
-def test_nvfp4_dequant_w4a16_matches_reference(shape):
-    """Verify NVFP4W4A16LinearMethod._dequantize_weight matches _dequantize_nvfp4."""
+def test_nvfp4_dequant_shared_matches_reference(shape):
+    """Verify fp4_utils.dequantize_nvfp4 matches the AutoDeploy _dequantize_nvfp4 reference."""
     out_features, in_features = shape
     _, packed, bs_fp8, ws2 = _make_nvfp4_weights(out_features, in_features)
 
     ref = _dequantize_nvfp4(packed, bs_fp8, ws2, (out_features, in_features), torch.bfloat16)
+    result = fp4_utils.dequantize_nvfp4(packed, bs_fp8, ws2, out_features, in_features)
 
-    # Build the E2M1 LUT-based dequant used by NVFP4W4A16LinearMethod
-    method = NVFP4W4A16LinearMethod()
-    lut = method._E2M1_VALUES.to(packed.device)
-    low = (packed.view(torch.uint8) & 0x0F).long()
-    high = ((packed.view(torch.uint8) >> 4) & 0x0F).long()
-    idx = torch.empty(out_features, in_features, dtype=torch.long, device=packed.device)
-    idx[:, 0::2] = low
-    idx[:, 1::2] = high
-    vals = lut[idx]
-
-    num_blocks = out_features * (in_features // SCALING_VECTOR_SIZE)
-    ws = bs_fp8.to(torch.float32).reshape(-1)[:num_blocks]
-    s2 = ws2.to(torch.float32)
-    block_scales = (ws * s2).view(out_features, in_features // 16, 1)
-    vals = vals.view(out_features, in_features // 16, 16) * block_scales
-    manual = vals.view(out_features, in_features).to(torch.bfloat16)
-
-    torch.testing.assert_close(manual, ref, atol=1e-3, rtol=1e-3)
+    torch.testing.assert_close(result, ref, atol=1e-3, rtol=1e-3)
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -110,10 +92,10 @@ def test_nvfp4_w4a16_linear_forward(mnk):
     torch.manual_seed(42)
 
     x = torch.randn(seq_len, in_features, dtype=dtype).cuda()
-    w_orig, packed, bs_fp8, ws2 = _make_nvfp4_weights(out_features, in_features, dtype)
+    _, packed, bs_fp8, ws2 = _make_nvfp4_weights(out_features, in_features, dtype)
 
     # Compute reference: dequant + F.linear
-    w_dequant = _dequantize_nvfp4(packed, bs_fp8, ws2, (out_features, in_features), dtype)
+    w_dequant = fp4_utils.dequantize_nvfp4(packed, bs_fp8, ws2, out_features, in_features)
     ref_output = torch.nn.functional.linear(x, w_dequant)
 
     # Build Linear with W4A16 method (force it regardless of actual SM)
@@ -127,14 +109,10 @@ def test_nvfp4_w4a16_linear_forward(mnk):
             quant_config=qc,
         )
 
-    # Verify the method is W4A16
     assert isinstance(linear.linear_method, NVFP4W4A16LinearMethod)
 
-    # Prepare weight_scale in ModelOpt format (unswizzled FP8)
     bs_unswizzled = bs_fp8.view(torch.float8_e4m3fn)
-
-    # input_scale: ModelOpt stores amax/(448*6), which becomes weight_scale_2
-    input_scale_ckpt = torch.tensor([1.0 / (FP8_MAX * E2M1_MAX)])  # dummy static scale
+    input_scale_ckpt = torch.tensor([1.0 / (FP8_MAX * E2M1_MAX)])
 
     linear.load_weights(
         [
@@ -219,11 +197,8 @@ def test_w4a4_vs_w4a16_output_comparison(mnk):
     with torch.inference_mode():
         out_w4a16 = l_w4a16(x)
 
-    # Outputs differ due to activation quantization in W4A4 and GEMM precision,
-    # but should be in the same ballpark. Use generous tolerance.
     torch.testing.assert_close(out_w4a4, out_w4a16, atol=1.0, rtol=0.15)
 
-    # Verify they're reasonably correlated (cosine sim > 0.95)
     cos_sim = torch.nn.functional.cosine_similarity(
         out_w4a4.flatten().float(), out_w4a16.flatten().float(), dim=0
     )
@@ -271,29 +246,24 @@ def test_get_quant_method_routes_w4a16_for_arc_on_hopper():
 
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Test 5: MoE weight dequant correctness
+# Test 5: Shared fp4_utils.dequantize_nvfp4 correctness
 # ──────────────────────────────────────────────────────────────────────────────
 
 
-def test_moe_dequant_nvfp4_tensor():
-    """NemotronHMOE._dequant_nvfp4_tensor matches _dequantize_nvfp4 reference."""
-    from tensorrt_llm._torch.models.modeling_nemotron_h import NemotronHMOE
-
+def test_shared_dequant_matches_auto_deploy_reference():
+    """fp4_utils.dequantize_nvfp4 matches _dequantize_nvfp4 from AutoDeploy."""
     out_features, in_features = 192, 128
     _, packed, bs_fp8, ws2 = _make_nvfp4_weights(out_features, in_features)
 
     ref = _dequantize_nvfp4(packed, bs_fp8, ws2, (out_features, in_features), torch.bfloat16)
-
-    result = NemotronHMOE._dequant_nvfp4_tensor(packed, bs_fp8, ws2, torch.bfloat16)
+    result = fp4_utils.dequantize_nvfp4(packed, bs_fp8, ws2, out_features, in_features)
 
     torch.testing.assert_close(result, ref, atol=1e-3, rtol=1e-3)
 
 
 @pytest.mark.parametrize("num_experts", [2, 4])
-def test_moe_dequant_multiple_experts(num_experts):
-    """Verify per-expert dequant produces correct results for stacked experts."""
-    from tensorrt_llm._torch.models.modeling_nemotron_h import NemotronHMOE
-
+def test_shared_dequant_multiple_experts(num_experts):
+    """Verify dequant produces correct results across multiple expert weights."""
     hidden = 128
     intermediate = 192
     dtype = torch.bfloat16
@@ -303,7 +273,7 @@ def test_moe_dequant_multiple_experts(num_experts):
         _, packed, bs_fp8, ws2 = _make_nvfp4_weights(intermediate, hidden, dtype)
 
         ref = _dequantize_nvfp4(packed, bs_fp8, ws2, (intermediate, hidden), dtype)
-        result = NemotronHMOE._dequant_nvfp4_tensor(packed, bs_fp8, ws2, dtype)
+        result = fp4_utils.dequantize_nvfp4(packed, bs_fp8, ws2, intermediate, hidden, dtype)
 
         torch.testing.assert_close(
             result, ref, atol=1e-3, rtol=1e-3, msg=f"Expert {expert_idx} dequant mismatch"


### PR DESCRIPTION
On GPUs without FP4 tensor cores (sm < 100, e.g. Hopper), dequantize NVFP4 weights to BF16 and use standard matmul instead of nvfp4_gemm. Activations remain in BF16 throughout.

Changes:
- Add NVFP4W4A16LinearMethod: inherits NVFP4 weight storage, overrides apply() to dequant weights to BF16 + F.linear
- Route get_quant_method() to W4A16 method when sm < 100
- Guard is_nvfp4 in NemotronHLayer with sm >= 100 to disable fused RMSNorm+NVFP4 and Fp4QuantizedTensor on Hopper
- MoE on Hopper: override quant config to unquantized, wrap load_weights to dequant NVFP4 expert weights to BF16 at load time
- Add unit tests for dequant, linear forward, routing, and MoE dequant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NVFP4 quantization fallback support for older GPUs, enabling inference on a broader range of hardware by automatically converting quantized weights during model loading.

* **Tests**
  * Added comprehensive test coverage for NVFP4 dequantization and fallback inference behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14009)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
