### PR TITLE
[TRTLLM-12527][feat] Parallelize multi-shard visual-gen checkpoint loading and pre-fetch checking

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/checkpoints/prefetch.py
+++ b/tensorrt_llm/_torch/visual_gen/checkpoints/prefetch.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Host page-cache prefetch helpers for visual generation checkpoints."""
+
+import multiprocessing
+import os
+from concurrent.futures import ThreadPoolExecutor
+from typing import Iterable, Optional, Set
+
+import psutil
+import torch.distributed as dist
+
+from tensorrt_llm.logger import logger
+
+_PREFETCH_CHUNK_SIZE = 16 * 1024 * 1024
+
+
+def _dist_initialized() -> bool:
+    return dist.is_available() and dist.is_initialized()
+
+
+def _dist_barrier() -> None:
+    if _dist_initialized():
+        dist.barrier()
+
+
+def _get_int_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, ""))
+    except ValueError:
+        return default
+
+
+def _local_rank_and_size() -> tuple[int, int]:
+    if not _dist_initialized():
+        return 0, 1
+
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    local_rank = _get_int_env("LOCAL_RANK", rank)
+    local_size = _get_int_env("LOCAL_WORLD_SIZE", world_size)
+
+    if local_size < 1 or local_rank < 0 or local_rank >= local_size:
+        return rank, world_size
+    return local_rank, local_size
+
+
+def _get_local_available_host_memory() -> int:
+    """Return the minimum available host memory observed by local ranks.
+
+    The prefetch/skip decision must be the same for all ranks that synchronize
+    at the post-prefetch barrier. Use torch.distributed to collect per-rank
+    snapshots and reduce the local slice to its minimum.
+    """
+    available_memory = psutil.virtual_memory().available
+    if not _dist_initialized() or dist.get_world_size() == 1:
+        return available_memory
+
+    world_size = dist.get_world_size()
+    gathered_memory: list[int | None] = [None] * world_size
+    dist.all_gather_object(gathered_memory, int(available_memory))
+
+    local_rank, local_size = _local_rank_and_size()
+    local_start = dist.get_rank() - local_rank
+    local_end = min(local_start + local_size, world_size)
+    local_memory = [
+        memory for memory in gathered_memory[local_start:local_end] if memory is not None
+    ]
+    if not local_memory:
+        return available_memory
+    return min(local_memory)
+
+
+def _normalize_paths(
+    file_names: Iterable[str],
+    prefetched_paths: Optional[Set[str]],
+) -> list[str]:
+    paths: list[str] = []
+    seen: set[str] = set()
+    for file_name in file_names:
+        path = os.path.abspath(file_name)
+        if path in seen:
+            continue
+        seen.add(path)
+        if prefetched_paths is not None and path in prefetched_paths:
+            continue
+        paths.append(path)
+    return paths
+
+
+def _prefetch_file(file_name: str, description: str) -> None:
+    if not os.path.exists(file_name):
+        return
+
+    logger.info(f"Prefetching {description} file {file_name} to host page cache...")
+    with open(file_name, "rb") as f:
+        while f.read(_PREFETCH_CHUNK_SIZE):
+            pass
+    logger.info(f"Finished prefetching {description} file {file_name}.")
+
+
+def prefetch_files_to_host_cache(
+    file_names: Iterable[str],
+    *,
+    description: str,
+    prefetched_paths: Optional[Set[str]] = None,
+    ignore_errors: bool = False,
+) -> bool:
+    """Warm checkpoint files in host page cache across distributed local ranks.
+
+    Returns True only when all selected files were already prefetched or were
+    prefetched successfully. If prefetch is skipped or fails, returns False
+    when ignore_errors=True and raises otherwise.
+    """
+    paths = _normalize_paths(file_names, prefetched_paths)
+    success = False
+    try:
+        if not paths:
+            success = True
+            return True
+
+        prefetch_size = sum(os.path.getsize(path) for path in paths if os.path.exists(path))
+        available_memory = _get_local_available_host_memory()
+        if prefetch_size >= available_memory * 0.9:
+            logger.info(
+                f"Skipping {description} prefetch because files require "
+                f"{prefetch_size / (1024**3):.2f}GB and available host memory is "
+                f"{available_memory / (1024**3):.2f}GB."
+            )
+            return False
+
+        local_rank, local_size = _local_rank_and_size()
+        local_paths = paths[local_rank::local_size]
+        if local_paths:
+            logger.info(
+                f"Prefetching {prefetch_size / (1024**3):.2f}GB {description} "
+                "files across distributed local ranks."
+            )
+            max_workers = min(multiprocessing.cpu_count() * 2, 16, len(local_paths))
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                list(executor.map(lambda path: _prefetch_file(path, description), local_paths))
+
+        success = True
+        return True
+    except Exception as exc:
+        if not ignore_errors:
+            raise
+        logger.warning(f"{description} prefetch failed; continuing without prefetch: {exc}")
+        return False
+    finally:
+        if success and prefetched_paths is not None:
+            prefetched_paths.update(paths)
+        _dist_barrier()

--- a/tensorrt_llm/_torch/visual_gen/checkpoints/weight_loader.py
+++ b/tensorrt_llm/_torch/visual_gen/checkpoints/weight_loader.py
@@ -1,17 +1,71 @@
 """Weight loader for diffusion models."""
 
 import json
+import multiprocessing
+import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any, Dict, List, Union
 
+import psutil
 import torch
 import tqdm
 
 from tensorrt_llm._torch.models.checkpoints.base_weight_loader import BaseWeightLoader
 from tensorrt_llm._torch.visual_gen.pipeline_registry import PipelineComponent
+from tensorrt_llm._utils import local_mpi_barrier, local_mpi_rank, local_mpi_size
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
+
+_PREFETCH_CHUNK_SIZE = 16 * 1024 * 1024
+
+
+def _prefetch_file(file_name: str) -> None:
+    if not os.path.exists(file_name):
+        return
+
+    logger.info(f"Prefetching checkpoint file {file_name} to host page cache...")
+    with open(file_name, "rb") as f:
+        while f.read(_PREFETCH_CHUNK_SIZE):
+            pass
+    logger.info(f"Finished prefetching checkpoint file {file_name}.")
+
+
+def _prefetch_safetensors_files(file_names: List[str]) -> None:
+    """Warm safetensors files in host page cache across local ranks."""
+    paths: List[str] = []
+    seen = set()
+    for file_name in file_names:
+        path = os.path.abspath(file_name)
+        if path not in seen:
+            paths.append(path)
+            seen.add(path)
+
+    if not paths:
+        return
+
+    try:
+        prefetch_size = sum(os.path.getsize(path) for path in paths if os.path.exists(path))
+        available_memory = psutil.virtual_memory().available
+        if prefetch_size >= available_memory * 0.9:
+            logger.info(
+                "Skipping visual-gen checkpoint prefetch because files require "
+                f"{prefetch_size / (1024**3):.2f}GB and available host memory is "
+                f"{available_memory / (1024**3):.2f}GB."
+            )
+            return
+
+        local_paths = paths[local_mpi_rank() :: local_mpi_size()]
+        if local_paths:
+            logger.info(
+                f"Prefetching {prefetch_size / (1024**3):.2f}GB visual-gen "
+                "checkpoint files across local ranks."
+            )
+            max_workers = min(multiprocessing.cpu_count() * 2, 16, len(local_paths))
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                list(executor.map(_prefetch_file, local_paths))
+    finally:
+        local_mpi_barrier()
 
 
 class WeightLoader(BaseWeightLoader):
@@ -87,6 +141,9 @@ class WeightLoader(BaseWeightLoader):
             weight_files = self._find_weight_files(weight_dir)
             if not weight_files:
                 raise ValueError(f"No weight files found in {weight_dir}")
+
+            if all(wf.endswith(".safetensors") for wf in weight_files):
+                _prefetch_safetensors_files(weight_files)
 
             component_weights = self._load_weight_files(weight_files, component, is_pipeline)
             all_weights[component] = component_weights

--- a/tensorrt_llm/_torch/visual_gen/checkpoints/weight_loader.py
+++ b/tensorrt_llm/_torch/visual_gen/checkpoints/weight_loader.py
@@ -1,71 +1,18 @@
 """Weight loader for diffusion models."""
 
 import json
-import multiprocessing
-import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any, Dict, List, Union
 
-import psutil
 import torch
 import tqdm
 
 from tensorrt_llm._torch.models.checkpoints.base_weight_loader import BaseWeightLoader
+from tensorrt_llm._torch.visual_gen.checkpoints.prefetch import prefetch_files_to_host_cache
 from tensorrt_llm._torch.visual_gen.pipeline_registry import PipelineComponent
-from tensorrt_llm._utils import local_mpi_barrier, local_mpi_rank, local_mpi_size
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
-
-_PREFETCH_CHUNK_SIZE = 16 * 1024 * 1024
-
-
-def _prefetch_file(file_name: str) -> None:
-    if not os.path.exists(file_name):
-        return
-
-    logger.info(f"Prefetching checkpoint file {file_name} to host page cache...")
-    with open(file_name, "rb") as f:
-        while f.read(_PREFETCH_CHUNK_SIZE):
-            pass
-    logger.info(f"Finished prefetching checkpoint file {file_name}.")
-
-
-def _prefetch_safetensors_files(file_names: List[str]) -> None:
-    """Warm safetensors files in host page cache across local ranks."""
-    paths: List[str] = []
-    seen = set()
-    for file_name in file_names:
-        path = os.path.abspath(file_name)
-        if path not in seen:
-            paths.append(path)
-            seen.add(path)
-
-    if not paths:
-        return
-
-    try:
-        prefetch_size = sum(os.path.getsize(path) for path in paths if os.path.exists(path))
-        available_memory = psutil.virtual_memory().available
-        if prefetch_size >= available_memory * 0.9:
-            logger.info(
-                "Skipping visual-gen checkpoint prefetch because files require "
-                f"{prefetch_size / (1024**3):.2f}GB and available host memory is "
-                f"{available_memory / (1024**3):.2f}GB."
-            )
-            return
-
-        local_paths = paths[local_mpi_rank() :: local_mpi_size()]
-        if local_paths:
-            logger.info(
-                f"Prefetching {prefetch_size / (1024**3):.2f}GB visual-gen "
-                "checkpoint files across local ranks."
-            )
-            max_workers = min(multiprocessing.cpu_count() * 2, 16, len(local_paths))
-            with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                list(executor.map(_prefetch_file, local_paths))
-    finally:
-        local_mpi_barrier()
 
 
 class WeightLoader(BaseWeightLoader):
@@ -73,7 +20,7 @@ class WeightLoader(BaseWeightLoader):
     Weight loader for diffusion models.
 
     Loads weights from safetensors/bin files, similar to HfWeightLoader
-    but simpler (no parallel loading optimization for now).
+    but tailored for diffusion checkpoint layouts.
 
     Supports loading multiple components (e.g., transformer and transformer_2):
         loader = WeightLoader(components=["transformer", "transformer_2"])
@@ -143,7 +90,10 @@ class WeightLoader(BaseWeightLoader):
                 raise ValueError(f"No weight files found in {weight_dir}")
 
             if all(wf.endswith(".safetensors") for wf in weight_files):
-                _prefetch_safetensors_files(weight_files)
+                prefetch_files_to_host_cache(
+                    weight_files,
+                    description="visual-gen checkpoint",
+                )
 
             component_weights = self._load_weight_files(weight_files, component, is_pipeline)
             all_weights[component] = component_weights

--- a/tensorrt_llm/_torch/visual_gen/checkpoints/weight_loader.py
+++ b/tensorrt_llm/_torch/visual_gen/checkpoints/weight_loader.py
@@ -1,6 +1,7 @@
 """Weight loader for diffusion models."""
 
 import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any, Dict, List, Union
 
@@ -87,12 +88,7 @@ class WeightLoader(BaseWeightLoader):
             if not weight_files:
                 raise ValueError(f"No weight files found in {weight_dir}")
 
-            # Load all weights with progress bar
-            component_weights = {}
-            desc = f"Loading {component}" if is_pipeline else "Loading checkpoint"
-            for wf in tqdm.tqdm(weight_files, desc=desc):
-                component_weights.update(self._load_file(wf))
-
+            component_weights = self._load_weight_files(weight_files, component, is_pipeline)
             all_weights[component] = component_weights
 
         # Return flat dict for single component (backward compatibility)
@@ -101,6 +97,32 @@ class WeightLoader(BaseWeightLoader):
 
         # Return nested dict for multiple components
         return all_weights
+
+    def _load_weight_files(
+        self, weight_files: List[str], component: str, is_pipeline: bool
+    ) -> Dict[str, Any]:
+        desc = f"Loading {component}" if is_pipeline else "Loading checkpoint"
+        if len(weight_files) <= 1:
+            component_weights = {}
+            for wf in tqdm.tqdm(weight_files, desc=desc):
+                component_weights.update(self._load_file(wf))
+            return component_weights
+
+        workers = min(4, len(weight_files))
+
+        logger.info(f"Loading {len(weight_files)} {component} shard files with {workers} workers")
+        component_weights = {}
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = {executor.submit(self._load_file, wf): wf for wf in weight_files}
+            for future in tqdm.tqdm(as_completed(futures), total=len(futures), desc=desc):
+                wf = futures[future]
+                try:
+                    loaded = future.result()
+                except Exception as exc:
+                    raise RuntimeError(f"Failed to load weight file {wf}") from exc
+                component_weights.update(loaded)
+
+        return component_weights
 
     def _find_weight_files(self, weight_dir) -> List[str]:
         """Find safetensors or bin weight files.

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
@@ -5,11 +5,14 @@
 import copy
 import gc
 import json
+import multiprocessing
 import os
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
+import psutil
 import safetensors.torch
 import torch
 import torch.distributed as dist
@@ -22,6 +25,7 @@ from tensorrt_llm._torch.visual_gen.output import CudaPhaseTimer, PipelineOutput
 from tensorrt_llm._torch.visual_gen.pipeline import BasePipeline, ExtraParamSchema
 from tensorrt_llm._torch.visual_gen.pipeline_registry import PipelineComponent, register_pipeline
 from tensorrt_llm._torch.visual_gen.utils import postprocess_video_tensor
+from tensorrt_llm._utils import local_mpi_barrier, local_mpi_rank, local_mpi_size
 from tensorrt_llm.logger import logger
 
 from .ltx2_core.audio_vae import AudioDecoderConfigurator, VocoderConfigurator, decode_audio
@@ -151,6 +155,66 @@ def _assert_resolution(height: int, width: int, *, is_two_stage: bool = False) -
         )
 
 
+_LTX2_PREFETCHED_SAFETENSORS: Set[str] = set()
+_LTX2_PREFETCH_CHUNK_SIZE = 16 * 1024 * 1024
+
+
+def _prefetch_ltx2_file(file_name: str) -> None:
+    if not os.path.exists(file_name):
+        return
+
+    logger.info(f"Prefetching LTX-2 checkpoint file {file_name} to host page cache...")
+    with open(file_name, "rb") as f:
+        while f.read(_LTX2_PREFETCH_CHUNK_SIZE):
+            pass
+    logger.info(f"Finished prefetching LTX-2 checkpoint file {file_name}.")
+
+
+def _prefetch_ltx2_safetensors_files(file_names: List[str]) -> None:
+    """Warm LTX-2 safetensors files in the host page cache.
+
+    For multi-GPU runs, local ranks split the file list and synchronize before
+    weight loading so ranks do not duplicate the prefetch work on the same node.
+    """
+    paths: List[str] = []
+    seen: Set[str] = set()
+    for file_name in file_names:
+        path = os.path.abspath(file_name)
+        if path not in seen:
+            paths.append(path)
+            seen.add(path)
+
+    paths = [path for path in paths if path not in _LTX2_PREFETCHED_SAFETENSORS]
+    try:
+        if not paths:
+            return
+
+        prefetch_size = sum(os.path.getsize(path) for path in paths if os.path.exists(path))
+        available_memory = psutil.virtual_memory().available
+        if prefetch_size >= available_memory * 0.9:
+            logger.info(
+                "Skipping LTX-2 checkpoint prefetch because files require "
+                f"{prefetch_size / (1024**3):.2f}GB and available host memory is "
+                f"{available_memory / (1024**3):.2f}GB."
+            )
+            return
+
+        local_paths = paths[local_mpi_rank() :: local_mpi_size()]
+        if local_paths:
+            logger.info(
+                f"Prefetching {prefetch_size / (1024**3):.2f}GB LTX-2 checkpoint "
+                "files across local ranks."
+            )
+            max_workers = min(multiprocessing.cpu_count() * 2, 16, len(local_paths))
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                list(executor.map(_prefetch_ltx2_file, local_paths))
+    except Exception as exc:
+        logger.warning(f"LTX-2 checkpoint prefetch failed; continuing without prefetch: {exc}")
+    finally:
+        _LTX2_PREFETCHED_SAFETENSORS.update(paths)
+        local_mpi_barrier()
+
+
 def _load_ltx2_transformer_weights(
     checkpoint_dir: str,
     prefix: str,
@@ -177,6 +241,8 @@ def _load_ltx2_transformer_weights(
 
     if not sft_paths:
         raise ValueError(f"No safetensors files found in {checkpoint_dir}")
+
+    _prefetch_ltx2_safetensors_files(sft_paths)
 
     exclude_prefixes = tuple(exclude_prefixes) if exclude_prefixes else ()
 
@@ -860,6 +926,7 @@ class LTX2Pipeline(BasePipeline):
         # --- Resolve native config ----------------------------------------
         native_config = self.model_config.extra_attrs.get("monolithic_safetensors_config")
         sft_paths = _find_safetensors_files(checkpoint_dir)
+        _prefetch_ltx2_safetensors_files(sft_paths)
 
         if native_config is None and sft_paths:
             native_config = _read_safetensors_config(sft_paths[0])

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
@@ -5,14 +5,11 @@
 import copy
 import gc
 import json
-import multiprocessing
 import os
 import time
-from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
-import psutil
 import safetensors.torch
 import torch
 import torch.distributed as dist
@@ -20,12 +17,12 @@ from transformers import Gemma3ForConditionalGeneration, GemmaTokenizerFast
 
 from tensorrt_llm._torch.utils import make_weak_ref
 from tensorrt_llm._torch.visual_gen.cache.teacache import CacheContext
+from tensorrt_llm._torch.visual_gen.checkpoints.prefetch import prefetch_files_to_host_cache
 from tensorrt_llm._torch.visual_gen.cuda_graph_runner import CUDAGraphRunner, CUDAGraphRunnerConfig
 from tensorrt_llm._torch.visual_gen.output import CudaPhaseTimer, PipelineOutput
 from tensorrt_llm._torch.visual_gen.pipeline import BasePipeline, ExtraParamSchema
 from tensorrt_llm._torch.visual_gen.pipeline_registry import PipelineComponent, register_pipeline
 from tensorrt_llm._torch.visual_gen.utils import postprocess_video_tensor
-from tensorrt_llm._utils import local_mpi_barrier, local_mpi_rank, local_mpi_size
 from tensorrt_llm.logger import logger
 
 from .ltx2_core.audio_vae import AudioDecoderConfigurator, VocoderConfigurator, decode_audio
@@ -156,63 +153,20 @@ def _assert_resolution(height: int, width: int, *, is_two_stage: bool = False) -
 
 
 _LTX2_PREFETCHED_SAFETENSORS: Set[str] = set()
-_LTX2_PREFETCH_CHUNK_SIZE = 16 * 1024 * 1024
 
 
-def _prefetch_ltx2_file(file_name: str) -> None:
-    if not os.path.exists(file_name):
-        return
-
-    logger.info(f"Prefetching LTX-2 checkpoint file {file_name} to host page cache...")
-    with open(file_name, "rb") as f:
-        while f.read(_LTX2_PREFETCH_CHUNK_SIZE):
-            pass
-    logger.info(f"Finished prefetching LTX-2 checkpoint file {file_name}.")
-
-
-def _prefetch_ltx2_safetensors_files(file_names: List[str]) -> None:
+def _prefetch_ltx2_safetensors_files(file_names: List[str]) -> bool:
     """Warm LTX-2 safetensors files in the host page cache.
 
-    For multi-GPU runs, local ranks split the file list and synchronize before
+    For distributed runs, local ranks split the file list and synchronize before
     weight loading so ranks do not duplicate the prefetch work on the same node.
     """
-    paths: List[str] = []
-    seen: Set[str] = set()
-    for file_name in file_names:
-        path = os.path.abspath(file_name)
-        if path not in seen:
-            paths.append(path)
-            seen.add(path)
-
-    paths = [path for path in paths if path not in _LTX2_PREFETCHED_SAFETENSORS]
-    try:
-        if not paths:
-            return
-
-        prefetch_size = sum(os.path.getsize(path) for path in paths if os.path.exists(path))
-        available_memory = psutil.virtual_memory().available
-        if prefetch_size >= available_memory * 0.9:
-            logger.info(
-                "Skipping LTX-2 checkpoint prefetch because files require "
-                f"{prefetch_size / (1024**3):.2f}GB and available host memory is "
-                f"{available_memory / (1024**3):.2f}GB."
-            )
-            return
-
-        local_paths = paths[local_mpi_rank() :: local_mpi_size()]
-        if local_paths:
-            logger.info(
-                f"Prefetching {prefetch_size / (1024**3):.2f}GB LTX-2 checkpoint "
-                "files across local ranks."
-            )
-            max_workers = min(multiprocessing.cpu_count() * 2, 16, len(local_paths))
-            with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                list(executor.map(_prefetch_ltx2_file, local_paths))
-    except Exception as exc:
-        logger.warning(f"LTX-2 checkpoint prefetch failed; continuing without prefetch: {exc}")
-    finally:
-        _LTX2_PREFETCHED_SAFETENSORS.update(paths)
-        local_mpi_barrier()
+    return prefetch_files_to_host_cache(
+        file_names,
+        description="LTX-2 checkpoint",
+        prefetched_paths=_LTX2_PREFETCHED_SAFETENSORS,
+        ignore_errors=True,
+    )
 
 
 def _load_ltx2_transformer_weights(

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
@@ -35,7 +35,12 @@ from .ltx2_core.types import (
 )
 from .ltx2_core.upsampler import LatentUpsamplerConfigurator, upsample_video
 from .ltx2_core.video_vae import TilingConfig
-from .pipeline_ltx2 import LTX2Pipeline, _assert_resolution, _find_safetensors_files
+from .pipeline_ltx2 import (
+    LTX2Pipeline,
+    _assert_resolution,
+    _find_safetensors_files,
+    _prefetch_ltx2_safetensors_files,
+)
 
 STAGE_2_DISTILLED_SIGMA_VALUES = [0.909375, 0.725, 0.421875, 0.0]
 _FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
@@ -64,6 +69,7 @@ def _load_lora_deltas(
     sft_paths = _find_safetensors_files(lora_path)
     if not sft_paths:
         raise ValueError(f"No safetensors files found at {lora_path}")
+    _prefetch_ltx2_safetensors_files(sft_paths)
 
     raw: Dict[str, torch.Tensor] = {}
     alpha_dict: Dict[str, float] = {}
@@ -627,6 +633,7 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
             sft_paths = _find_safetensors_files(spatial_upsampler_path)
             if not sft_paths:
                 raise ValueError(f"No safetensors files found at {spatial_upsampler_path}")
+            _prefetch_ltx2_safetensors_files(sft_paths)
 
             config: Dict[str, Any] = {}
             try:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit
Similar to LLM [sharded loading](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py#L106) and [pre-fetch](https://github.com/NVIDIA/TensorRT-LLM/blob/ca876e034345f613685c66c108e3279b4a6d1a82/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py#L89).

* **Refactor**
  * Optimized weight loading for visual generation models to process sharded files concurrently, improving performance when multiple weight files are present.
  * Enhanced error reporting to clearly identify which weight file shard failed during loading.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14021)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

With this PR, the improvements are great.

| model | mode | weight GB | model/pipeline load | vs baseline |
|---|---|---:|---:|---:|
| Wan2.1-T2V-14B-Diffusers | prefetch + parallel shard | 80.39 | 88.23s | 52.3% faster, 2.09x |
| Wan2.1-T2V-14B-Diffusers | parallel shard only | 80.39 | 193.55s | 4.7% slower, 0.95x |
| Wan2.1-T2V-14B-Diffusers | no features | 80.39 | 184.82s | baseline |
| Wan2.2-T2V-A14B-Diffusers | prefetch + parallel shard | 126.18 | 146.85s | 67.5% faster, 3.08x |
| Wan2.2-T2V-A14B-Diffusers | parallel shard only | 126.18 | 344.26s | 23.9% faster, 1.31x |
| Wan2.2-T2V-A14B-Diffusers | no features | 126.18 | 452.53s | baseline |
| FLUX.1-dev | prefetch + parallel shard | 34.08 | 82.34s | 2.1% faster, 1.02x |
| FLUX.1-dev | parallel shard only | 34.08 | 88.48s | 5.2% slower, 0.95x |
| FLUX.1-dev | no features | 34.08 | 84.09s | baseline |
| FLUX.2-dev | prefetch + parallel shard | 113.14 | 193.71s | 32.8% faster, 1.49x |
| FLUX.2-dev | parallel shard only | 113.14 | 292.94s | 1.6% slower, 0.98x |
| FLUX.2-dev | no features | 113.14 | 288.39s | baseline |

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
