### PR TITLE
[https://nvbugs/6163147][fix] unfuse transformers 5.x fused Mixtral MoE for modelopt quant path

### DIFF
--- a/tensorrt_llm/quantization/quantize_by_modelopt.py
+++ b/tensorrt_llm/quantization/quantize_by_modelopt.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +30,7 @@ from accelerate.hooks import remove_hook_from_module
 from datasets import load_dataset
 from modelopt.torch.utils import print_rank_0
 from safetensors.torch import load_file, save_file
+from torch import nn
 from torch.utils.data import DataLoader
 from transformers import (AutoConfig, AutoModelForCausalLM, AutoProcessor,
                           AutoTokenizer)
@@ -281,6 +282,74 @@ def get_hf_config(ckpt_path):
         return AutoConfig.from_pretrained(ckpt_path, trust_remote_code=True)
 
 
+class _FusedExpertLinearView(nn.Module):
+    # Linear-like module whose weight is a view into a shared 3D MoE tensor.
+    # Used by _unfuse_mixtral_for_modelopt to present the per-expert structure
+    # that modelopt's exporter iterates, without copying weights.
+    def __init__(self, weight_view: torch.Tensor):
+        super().__init__()
+        self.weight = nn.Parameter(weight_view, requires_grad=False)
+        self.bias = None
+
+    def forward(self, x):
+        return torch.nn.functional.linear(x, self.weight, self.bias)
+
+
+class _MixtralExpertShim(nn.Module):
+    pass
+
+
+class _MixtralSparseMoeBlockShim(nn.Module):
+    # Name kept as "MixtralSparseMoeBlock" via __init__ override so that
+    # modelopt's `"mixtral" in type(experts).__name__.lower()` checks match.
+    pass
+
+
+_MixtralSparseMoeBlockShim.__name__ = "MixtralSparseMoeBlock"
+
+
+def _unfuse_mixtral_for_modelopt(model: nn.Module) -> None:
+    # transformers 5.x stores Mixtral experts as a single MixtralExperts module
+    # with 3D fused tensors (`gate_up_proj`, `down_proj`) under `layer.mlp`,
+    # and dropped the per-expert ModuleList layout that nvidia-modelopt 0.37
+    # iterates. This shim synthesizes the old-style `layer.block_sparse_moe`
+    # with `experts[i].{w1,w2,w3}.weight` as zero-copy views into the fused
+    # tensors so modelopt's MoE exporter works unmodified.
+    try:
+        from transformers.models.mixtral.modeling_mixtral import MixtralExperts
+    except ImportError:
+        return
+
+    if not (hasattr(model, "model") and hasattr(model.model, "layers")):
+        return
+
+    for layer in model.model.layers:
+        mlp = getattr(layer, "mlp", None)
+        if mlp is None:
+            continue
+        experts = getattr(mlp, "experts", None)
+        if not isinstance(experts, MixtralExperts):
+            continue
+
+        num_experts = experts.num_experts
+        intermediate = experts.intermediate_dim
+        gate_up = experts.gate_up_proj  # [N, 2*I, H]
+        down = experts.down_proj  # [N, H, I]
+
+        new_experts = nn.ModuleList()
+        for i in range(num_experts):
+            shim = _MixtralExpertShim()
+            shim.w1 = _FusedExpertLinearView(gate_up[i, :intermediate, :])
+            shim.w3 = _FusedExpertLinearView(gate_up[i, intermediate:, :])
+            shim.w2 = _FusedExpertLinearView(down[i])
+            new_experts.append(shim)
+
+        new_block = _MixtralSparseMoeBlockShim()
+        new_block.experts = new_experts
+        new_block.gate = mlp.gate
+        layer.block_sparse_moe = new_block
+
+
 def _get_llava_qwen_model(model_dir, dtype, device):
     if "hf" in model_dir:
         from transformers import LlavaOnevisionForConditionalGeneration
@@ -352,6 +421,12 @@ def get_model(ckpt_path: str,
             model.lm_head = lm_head
 
     model.eval()
+
+    # transformers 5.x changed Mixtral MoE to a fused 3D layout that
+    # nvidia-modelopt 0.37 cannot iterate. Restructure into per-expert
+    # block_sparse_moe layout using zero-copy tensor views.
+    if hf_config.model_type == "mixtral":
+        _unfuse_mixtral_for_modelopt(model)
 
     model_dtype = next(model.parameters()).dtype
     if torch_dtype != model_dtype:


### PR DESCRIPTION
transformers 5.x stores Mixtral experts as a single MixtralExperts module with 3D fused tensors (gate_up_proj, down_proj) under layer.mlp, and dropped the per-expert ModuleList layout that nvidia-modelopt 0.37 iterates (e.g. len(module.experts), module.experts[i].w1.weight). Calling quantize.py for Mixtral on transformers 5.3 fails with "TypeError: object of type 'MixtralExperts' has no len()" inside modelopt's build_moe_config.

Mirror the approach taken in ddd76aa99d ("fix: unfuse HF transformers 5.x fused MoE weights for Mixtral") which handled the TRT-LLM PyTorch backend's state_dict path. The modelopt path is different: it goes through transformers.from_pretrained, which returns a constructed live model, so the unfuse has to operate on the module tree rather than a state_dict.

Add _unfuse_mixtral_for_modelopt(model) that, for each decoder layer holding the new fused MixtralExperts, synthesizes the old-style layer.block_sparse_moe.experts[i].{w1,w2,w3}.weight using zero-copy nn.Parameter views into the fused 3D tensors. The shim class name "MixtralSparseMoeBlock" keeps modelopt's "mixtral" type checks matching.

Invoked from get_model() immediately after model.eval(), gated on hf_config.model_type == "mixtral".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Mixtral models during quantization and export operations with nvidia-modelopt, enabling optimized inference for mixture-of-experts architectures.

* **Improvements**
  * Enhanced automatic model initialization to properly handle Mixtral model variants from recent HuggingFace Transformers releases for seamless compatibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14027)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
