### PR TITLE
[https://nvbugs/6160248][fix] AutoDeploy: fixed broken pattern matching of fuse_rope_into_trtllm_attention transform

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_rope_into_trtllm_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_rope_into_trtllm_attention.py
@@ -350,17 +350,28 @@ def _find_inv_freq_tensor(
 
 
 def _unwrap_contiguous(node: Node) -> Node:
-    """Skip past any chain of ``contiguous`` calls, in either ``aten``
-    overload form or the Python-level ``Tensor.contiguous`` method form."""
+    """Skip past any chain of ``contiguous`` calls in any form the graph may
+    emit: the ``aten.contiguous.default`` overload, a ``call_function`` to
+    ``Tensor.contiguous``, or a ``call_method`` with target ``"contiguous"``
+    (which is what ``fuse_gemms_mixed_children`` emits via
+    ``graph.call_method("contiguous", ...)``)."""
     current = node
-    while isinstance(current, Node) and current.op == "call_function":
-        is_aten_contig = is_op(current, torch.ops.aten.contiguous.default)
-        is_method_contig = getattr(current.target, "__name__", "") == "contiguous"
-        if not (is_aten_contig or is_method_contig):
-            break
-        if not isinstance(current.args[0], Node):
-            break
-        current = current.args[0]
+    while isinstance(current, Node):
+        if current.op == "call_method" and current.target == "contiguous":
+            if not current.args or not isinstance(current.args[0], Node):
+                break
+            current = current.args[0]
+            continue
+        if current.op == "call_function":
+            is_aten_contig = is_op(current, torch.ops.aten.contiguous.default)
+            is_method_contig = getattr(current.target, "__name__", "") == "contiguous"
+            if not (is_aten_contig or is_method_contig):
+                break
+            if not current.args or not isinstance(current.args[0], Node):
+                break
+            current = current.args[0]
+            continue
+        break
     return current
 
 
@@ -392,6 +403,9 @@ def _try_trace_to_fused_qkv(
         view_shape = current.args[1] if len(current.args) > 1 else None
         if not isinstance(view_input, Node):
             return None
+        # The view may sit on top of a ``.contiguous()`` introduced by
+        # GEMM fusion; peel it off before checking for the getitem split.
+        view_input = _unwrap_contiguous(view_input)
         if not isinstance(view_shape, (list, tuple)) or len(view_shape) < 4:
             return None
         nh, hd = view_shape[2], view_shape[3]
@@ -427,6 +441,10 @@ def _try_trace_to_fused_qkv(
         view_shape = current.args[1] if len(current.args) > 1 else None
         if not isinstance(view_input, Node):
             return None
+        # ``fuse_gemms_mixed_children`` emits ``narrow → contiguous → view``,
+        # where the contiguous is a ``call_method`` node.  Peel any
+        # contiguous(s) sitting between the view and the narrow.
+        view_input = _unwrap_contiguous(view_input)
         if not isinstance(view_shape, (list, tuple)) or len(view_shape) < 4:
             return None
         hd = view_shape[3]

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_rope_into_trtllm_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_rope_into_trtllm_attention.py
@@ -357,21 +357,16 @@ def _unwrap_contiguous(node: Node) -> Node:
     ``graph.call_method("contiguous", ...)``)."""
     current = node
     while isinstance(current, Node):
-        if current.op == "call_method" and current.target == "contiguous":
-            if not current.args or not isinstance(current.args[0], Node):
-                break
-            current = current.args[0]
-            continue
-        if current.op == "call_function":
-            is_aten_contig = is_op(current, torch.ops.aten.contiguous.default)
-            is_method_contig = getattr(current.target, "__name__", "") == "contiguous"
-            if not (is_aten_contig or is_method_contig):
-                break
-            if not current.args or not isinstance(current.args[0], Node):
-                break
-            current = current.args[0]
-            continue
-        break
+        is_method_contig = current.op == "call_method" and current.target == "contiguous"
+        is_function_contig = current.op == "call_function" and (
+            is_op(current, torch.ops.aten.contiguous.default)
+            or getattr(current.target, "__name__", "") == "contiguous"
+        )
+        if not (is_method_contig or is_function_contig):
+            break
+        if not current.args or not isinstance(current.args[0], Node):
+            break
+        current = current.args[0]
     return current
 
 


### PR DESCRIPTION
The recent commit 6cd23bccdf changed fuse_gemms_mixed_children to emit narrow → contiguous (call_method) → view instead of split_with_sizes  (closure) → getitem. But _try_trace_to_fused_qkv._trace_narrow only handles view → narrow directly — it does not unwrap a call_method("contiguous", ...) node sitting  between the view and the narrow, and _unwrap_contiguous only handles call_function contiguous, not the call_method form. Result: the passthrough leg silently fails and  _trtllm_fused_qkv is never set.       

Fix:
- Extend ``_unwrap_contiguous`` to also skip ``call_method`` nodes whose target is the string ``"contiguous"``.
- In ``_trace_narrow`` and ``_trace_split`` apply ``_unwrap_contiguous`` to the view's input before testing for narrow / getitem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attention optimization logic to correctly handle additional tensor operation patterns, ensuring more reliable detection and fusion of fused QKV operations across diverse model architectures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14038)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
