### PR TITLE
[#8542][feat] AutoDeploy: add Llama-3.1-8B FP8 perf-sanity test on H100

### DIFF
--- a/tests/integration/defs/perf/test_perf_sanity.py
+++ b/tests/integration/defs/perf/test_perf_sanity.py
@@ -56,6 +56,7 @@ MODEL_PATH_DICT = {
     "llama_v3.3_70b_instruct_fp4": "llama-3.3-models/Llama-3.3-70B-Instruct-FP4",
     "deepseek_v3_lite_fp8": "DeepSeek-V3-Lite/fp8",
     "llama_v3.1_8b_instruct": "llama-3.1-model/Llama-3.1-8B-Instruct",
+    "llama_v3.1_8b_instruct_fp8": "llama-3.1-model/Llama-3.1-8B-Instruct-FP8",
     "glm_5_nvfp4": "GLM-5-NVFP4",
 }
 

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -523,3 +523,5 @@ l0_h100:
   - examples/test_ad_speculative_decoding.py::test_eagle_wrapper_forward[2]
   - examples/test_ad_speculative_decoding.py::test_nemotron_mtp_model_with_weights
   - examples/test_ad_guided_decoding.py::test_autodeploy_guided_decoding_main_json
+  # ------------- AutoDeploy Perf Sanity ---------------
+  - perf/test_perf_sanity.py::test_e2e[aggr_upload-llama3_1_8b_fp8_ad_hopper-llama3_1_8b_ad_ws1_1k1k] TIMEOUT (120)

--- a/tests/scripts/perf-sanity/aggregated/llama3_1_8b_fp8_ad_hopper.yaml
+++ b/tests/scripts/perf-sanity/aggregated/llama3_1_8b_fp8_ad_hopper.yaml
@@ -1,0 +1,21 @@
+metadata:
+  model_name: llama_v3.1_8b_instruct_fp8
+  supported_gpus:
+  - H100
+  - H200
+hardware:
+  gpus_per_node: 1
+server_configs:
+  # 1k1k config - AutoDeploy backend, 1 GPU (Llama-3.1-8B FP8 on Hopper)
+  - name: "llama3_1_8b_ad_ws1_1k1k"
+    model_name: "llama_v3.1_8b_instruct_fp8"
+    backend: "_autodeploy"
+    extra_llm_api_config_path: "examples/auto_deploy/model_registry/configs/llama3_1_8b.yaml"
+    world_size: 1
+    client_configs:
+      - name: "con64_iter10_1k1k"
+        concurrency: 64
+        iterations: 10
+        isl: 1024
+        osl: 1024
+        backend: "openai"


### PR DESCRIPTION
Mirrors the structure of ``super_ad_blackwell-super_ad_ws1_1k1k`` but targets single-GPU AutoDeploy on Hopper.

Changes:
- ``tests/integration/defs/perf/test_perf_sanity.py``: add ``llama_v3.1_8b_instruct_fp8`` → ``llama-3.1-model/Llama-3.1-8B-Instruct-FP8`` to ``MODEL_PATH_DICT`` so the new config can resolve the model directory.
- ``tests/scripts/perf-sanity/aggregated/llama3_1_8b_fp8_ad_hopper.yaml``: new perf-sanity config with one server config ``llama3_1_8b_ad_ws1_1k1k`` — ``backend: _autodeploy``, ``world_size: 1``, pointing at ``examples/auto_deploy/model_registry/configs/llama3_1_8b.yaml`` (FP8 + trtllm attention + GEMM/RoPE/SiLU fusions). Client config matches the reference: concurrency 64, 10 iterations, ISL=OSL=1024, openai backend.
- ``tests/integration/test_lists/test-db/l0_h100.yml``: enroll the new test in the pre-merge ``backend: autodeploy`` block on single-GPU H100.

The new test is discoverable as
``perf/test_perf_sanity.py::test_e2e[aggr_upload-llama3_1_8b_fp8_ad_hopper-llama3_1_8b_ad_ws1_1k1k]`` and maps to the ``H100_PCIe-AutoDeploy-1`` CI stage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added performance sanity test support for Llama 3.1 8B FP8 model on H100 and H200 GPUs.
  * Added new test configuration for FP8 model variant with Hopper architecture optimization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14039)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
