### PR TITLE
[#8542][feat] AutoDeploy: add DeepSeek-R1 FP8 perf-sanity test on 8x B200 post merge

### DIFF
--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -385,3 +385,5 @@ l0_dgx_b200:
   tests:
   - accuracy/test_llm_api_autodeploy.py::TestModelRegistryAccuracy::test_autodeploy_from_registry[deepseek-ai_DeepSeek-R1-0528-True]
   - accuracy/test_llm_api_autodeploy.py::TestQwen3_5_397B_MoE::test_nvfp4[8]
+  # ------------- AutoDeploy Perf Sanity ---------------
+  - perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_r1_fp8_ad_blackwell-r1_fp8_ad_ws8_1k1k] TIMEOUT (120)

--- a/tests/scripts/perf-sanity/aggregated/deepseek_r1_fp8_ad_blackwell.yaml
+++ b/tests/scripts/perf-sanity/aggregated/deepseek_r1_fp8_ad_blackwell.yaml
@@ -1,0 +1,20 @@
+metadata:
+  model_name: deepseek_r1_0528_fp8
+  supported_gpus:
+  - B200
+hardware:
+  gpus_per_node: 8
+server_configs:
+  # 1k1k config - AutoDeploy backend, 8 GPUs (DeepSeek-R1 0528 FP8 on DGX B200)
+  - name: "r1_fp8_ad_ws8_1k1k"
+    model_name: "deepseek_r1_0528_fp8"
+    backend: "_autodeploy"
+    extra_llm_api_config_path: "examples/auto_deploy/model_registry/configs/deepseek-r1.yaml"
+    world_size: 8
+    client_configs:
+      - name: "con64_iter10_1k1k"
+        concurrency: 64
+        iterations: 10
+        isl: 1024
+        osl: 1024
+        backend: "openai"


### PR DESCRIPTION
Mirrors super_ad_blackwell-super_ad_ws4_1k1k but for DeepSeek-R1 0528 FP8 on a full DGX B200 (8 GPUs).

Changes:
- ``tests/scripts/perf-sanity/aggregated/deepseek_r1_fp8_ad_blackwell.yaml``: new perf-sanity config with one server config ``r1_fp8_ad_ws8_1k1k`` using the ``_autodeploy`` backend, ``world_size: 8``, and the existing ``examples/auto_deploy/model_registry/configs/deepseek-r1.yaml`` (MLA + trtllm_mla cached attention + fuse_rope_into_trtllm_mla + multi-stream MoE + AllReduce-residual-RMSNorm fusion + sharding). Client config matches the reference: concurrency 64, 10 iterations, ISL=OSL=1024, openai backend.
- ``tests/integration/test_lists/test-db/l0_dgx_b200.yml``: enroll the new test in the existing 8-GPU ``stage: post_merge`` / ``backend: autodeploy`` block alongside the existing DeepSeek-R1-0528 accuracy registry test.

The ``deepseek_r1_0528_fp8 -> DeepSeek-R1/DeepSeek-R1-0528/`` mapping already exists in ``test_perf_sanity.py::MODEL_PATH_DICT``, so no edit to the test driver is required.

Test ID:
``perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_r1_fp8_ad_blackwell-r1_fp8_ad_ws8_1k1k]``

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added performance sanity test coverage for the Deepseek R1 model on the latest GPU hardware configurations to ensure system reliability and performance standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14040)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
