### PR TITLE
[None][fix] AutoDeploy: Cleanup CUDA graph memory in shutdown

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -567,6 +567,39 @@ class ADEngine(ModelEngine):
             PyTorchModelEngine._execute_logit_post_processors, self
         )
 
+    def _release_cuda_graphs(self) -> None:
+        def _reset_cuda_graph(graph: object) -> None:
+            if isinstance(graph, torch.cuda.CUDAGraph):
+                graph.reset()
+
+        model = getattr(self, "model", None)
+        if model is not None:
+            for module in model.modules():
+                if module.__class__.__name__ == "CapturedGraph":
+                    cudagraphs = getattr(module, "cudagraphs", None)
+                    if isinstance(cudagraphs, dict):
+                        for graph in list(cudagraphs.values()):
+                            _reset_cuda_graph(graph)
+                        cudagraphs.clear()
+                    module._cuda_graph_mem_pool = None
+                    module._input_buffers = []
+                    module._out_buffer_flat = None
+
+                if module.__class__.__name__ == "PiecewiseCapturedGraph":
+                    static_input_buffers = getattr(module, "_static_input_buffers", None)
+                    if isinstance(static_input_buffers, dict):
+                        static_input_buffers.clear()
+
+                if module.__class__.__name__ == "ADPiecewiseRunner":
+                    entries = getattr(module, "entries", None)
+                    if isinstance(entries, dict):
+                        for entry in entries.values():
+                            _reset_cuda_graph(getattr(entry, "cuda_graph", None))
+                        entries.clear()
+                    module._graph_pool = None
+
+        torch.cuda.empty_cache()
+
     def _store_prefill_multimodal_metadata(
         self,
         ordered_requests: RequestList,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved GPU memory management with optimized cleanup of computation graphs and enhanced memory caching strategies. Includes automatic memory optimization designed to reduce memory fragmentation, improve resource efficiency, and enhance system stability. This improvement ensures more consistent performance during extended computation sessions and helps prevent memory-related issues.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14050)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

PyExecutor calls _release_cuda_graphs() but it is not defined in ADExecutor. Define the method, release both decode graphs and piecewise graphs. This is called as part of PyExecutor shutdown() and is guarded by
`if engine is not None and hasattr(engine, '_release_cuda_graphs')`
which means is was a nop for AD

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
