### PR TITLE
[None][feat] Upgrade NIXL to v1.0.1 and UCX to v1.21.x

### DIFF
--- a/docker/common/install_nixl.sh
+++ b/docker/common/install_nixl.sh
@@ -4,7 +4,7 @@ set -ex
 GITHUB_URL="https://github.com"
 UCX_INSTALL_PATH="/usr/local/ucx/"
 CUDA_PATH="/usr/local/cuda"
-NIXL_VERSION="0.9.0"
+NIXL_VERSION="v1.0.1"
 NIXL_REPO="https://github.com/ai-dynamo/nixl.git"
 OLD_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 

--- a/docker/common/install_ucx.sh
+++ b/docker/common/install_ucx.sh
@@ -9,7 +9,12 @@ UCX_REPO="https://github.com/openucx/ucx.git"
 
 mkdir -p /third-party-source
 
-rm -rf ${UCX_INSTALL_PATH}
+# Drop the trailing slash so this also removes a pre-existing *symlink* at
+# ${UCX_INSTALL_PATH} (the NGC PyTorch base image ships /usr/local/ucx as a
+# symlink to /opt/hpcx/ucx). Without this, `make install` writes through the
+# symlink into /opt/hpcx/ucx, and the later /opt/hpcx/ucx -> /usr/local/ucx
+# replacement creates an infinite symlink loop.
+rm -rf "${UCX_INSTALL_PATH%/}"
 git clone -b ${UCX_VERSION} ${UCX_REPO}
 cd ucx
 git checkout ${UCX_COMMIT}

--- a/docker/common/install_ucx.sh
+++ b/docker/common/install_ucx.sh
@@ -35,7 +35,11 @@ make install -j$(nproc)
 # in the container — PyTorch, NCCL, UCC, plus the C++/Python NIXL stack —
 # resolves the same UCX SONAMEs.
 for d in /opt/hpcx/ucx /opt/hpcx-*/ucx; do
-    if [ -e "$d" ] && [ ! -L "$d" ]; then
+    # `[ -e ]` catches real dirs/files; `[ -L ]` separately catches symlinks
+    # (including broken ones, where -e returns false). Together they replace
+    # any pre-existing UCX — real dir, stale symlink to an old UCX, or our
+    # own symlink on re-run (idempotent).
+    if [ -e "$d" ] || [ -L "$d" ]; then
         echo "Replacing pre-existing UCX at $d with symlink to ${UCX_INSTALL_PATH%/}"
         rm -rf "$d"
         ln -s "${UCX_INSTALL_PATH%/}" "$d"

--- a/docker/common/install_ucx.sh
+++ b/docker/common/install_ucx.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -ex
 
-UCX_VERSION="v1.20.x"
-UCX_COMMIT="f656dbdf93e72e60b5d6ca78b9e3d9e744e789bd"
+UCX_VERSION="v1.21.x"
+UCX_COMMIT="167a4c6a311d9a42e30a37dcc01b8a3e73ea2826"
 UCX_INSTALL_PATH="/usr/local/ucx/"
 CUDA_PATH="/usr/local/cuda"
 UCX_REPO="https://github.com/openucx/ucx.git"
@@ -30,6 +30,21 @@ cd ucx
   --with-dm                       \
   --enable-mt
 make install -j$(nproc)
+# Replace any pre-existing UCX (e.g. HPC-X's UCX shipped in the NGC PyTorch
+# base image) with a symlink to our freshly-installed one, so every binary
+# in the container — PyTorch, NCCL, UCC, plus the C++/Python NIXL stack —
+# resolves the same UCX SONAMEs.
+for d in /opt/hpcx/ucx /opt/hpcx-*/ucx; do
+    if [ -e "$d" ] && [ ! -L "$d" ]; then
+        echo "Replacing pre-existing UCX at $d with symlink to ${UCX_INSTALL_PATH%/}"
+        rm -rf "$d"
+        ln -s "${UCX_INSTALL_PATH%/}" "$d"
+    fi
+done
+# Make /usr/local/ucx/lib known to the system dynamic linker so binaries
+# without an explicit RPATH (or with $ORIGIN-relative RPATH) still find it.
+echo "${UCX_INSTALL_PATH%/}/lib" > /etc/ld.so.conf.d/ucx.conf
+ldconfig
 cd ..
 rm -rf ucx  # Remove UCX source to save space
 echo "export LD_LIBRARY_PATH=${UCX_INSTALL_PATH}/lib:\$LD_LIBRARY_PATH" >> "${ENV}"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -40,7 +40,7 @@ opentelemetry-semantic-conventions-ai>=0.4.1
 fuzzywuzzy==0.18.0
 aiperf==0.6.0
 nanobind>=2.9.0
-nixl==0.9.0
+nixl==1.0.1
 cupti-python>=13.0,<13.2
 nvidia-cuda-cupti>=13.0,<13.2
 cxxfilt

--- a/tests/unittest/disaggregated/test_agent.py
+++ b/tests/unittest/disaggregated/test_agent.py
@@ -55,9 +55,12 @@ class MemoryManager:
     allocated_memory: list[torch.Tensor] = field(default_factory=list)
 
     def allocate_memory(
-        self, size: int, name: str, memory_type=MemoryType.VRAM, device_id: int = 0
+        self, size: int, name: str, memory_type: str = "VRAM", device_id: int = 0
     ) -> RegMemoryDescs:
-        device = torch.device(f"cuda:{device_id}" if memory_type == MemoryType.VRAM else "cpu")
+        # `memory_type` is the string used by RegMemoryDescs (see base/agent.py);
+        # do not compare against `MemoryType.VRAM`, which is overridden to a C++ enum
+        # when the C++ binding is available.
+        device = torch.device(f"cuda:{device_id}" if memory_type == "VRAM" else "cpu")
 
         # Allocate memory block using torch.Tensor and track it
         block = torch.zeros(size, dtype=torch.uint8, device=device)

--- a/tests/unittest/others/test_kv_cache_transceiver.py
+++ b/tests/unittest/others/test_kv_cache_transceiver.py
@@ -261,6 +261,7 @@ def create_hybrid_cache_manager(mapping,
         mamba_layer_mask=mamba_layer_mask,
         mamba_cache_dtype=mamba_conv_dtype,
         mamba_ssm_cache_dtype=mamba_ssm_dtype,
+        is_disagg=True,
         kv_cache_config=KvCacheConfig(
             max_tokens=256,
             enable_block_reuse=False,


### PR DESCRIPTION
Bump NIXL from 0.9.0 to v1.0.1 (requires UCX 1.21.x) and UCX from v1.20.x to v1.21.x in the dev container.

After installing UCX 1.21 to /usr/local/ucx, replace any pre-existing HPC-X UCX directory shipped in the NGC PyTorch base image (/opt/hpcx*/ucx) with a symlink to /usr/local/ucx and refresh the system linker cache. This ensures PyTorch/NCCL/UCC and the NIXL stack resolve the same single UCX 1.21 binary, fixing the dual-UCX-load failure (mix of UCX 1.20 and 1.21 in the same process) that prevented the NIXL UCX backend from initializing in disagg tests.

Update the matching test fixtures: switch test_agent.py to the string "VRAM" memory_type (NIXL 1.0.1 rebinds MemoryType to a C++ enum at runtime, so direct enum comparison no longer matches the strings flowing through RegMemoryDescs), and pass is_disagg=True to create_hybrid_cache_manager in test_kv_cache_transceiver.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NIXL to version 1.0.1.
  * Updated UCX to version 1.21.x with enhanced linker configuration.
  * Updated development dependencies.

* **Tests**
  * Improved test infrastructure for memory allocation and cache management operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14056)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->