### PR TITLE
[None][infra] Add explicit llmapi-compatibility label gh check when api touched

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -46,6 +46,7 @@ Please review the following before submitting your PR:
 - PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
 - PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
 - Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
+- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
 - Any new dependencies have been scanned for license and vulnerabilities
 - [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
 - Documentation updated as needed

--- a/.github/workflows/llm-api-compatibility.yml
+++ b/.github/workflows/llm-api-compatibility.yml
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: LLM API Compatibility
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  check-llm-api-compatibility:
+    name: Check LLM API Compatibility Label
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Validate LLM API compatibility label
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const referencePrefixes = [
+              'tests/unittest/api_stability/references/',
+              'tests/unittest/api_stability/references_committed/',
+            ];
+            // Keep these names in sync with the PR template and API-change guide.
+            const compatibleApiLabel = 'api-compatible';
+            const breakingApiLabel = 'api-breaking';
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+
+            const changedPaths = files
+              .flatMap((file) => [file.filename, file.previous_filename].filter(Boolean));
+            const apiReferenceChanged = changedPaths.some((path) =>
+              referencePrefixes.some((prefix) => path.startsWith(prefix))
+            );
+
+            if (!apiReferenceChanged) {
+              core.info('No API stability reference changes detected.');
+              return;
+            }
+
+            const labelNames = new Set(
+              (context.payload.pull_request.labels || []).map((label) => label.name)
+            );
+            const apiChangeLabels = [compatibleApiLabel, breakingApiLabel].filter((label) =>
+              labelNames.has(label)
+            );
+
+            if (apiChangeLabels.length !== 1) {
+              core.setFailed(
+                'API stability reference files changed. Apply exactly one ' +
+                `of these labels: '${compatibleApiLabel}' or '${breakingApiLabel}'.`
+              );
+              return;
+            }
+
+            if (
+              apiChangeLabels[0] === breakingApiLabel &&
+              !context.payload.pull_request.title.includes('BREAKING')
+            ) {
+              core.setFailed("Breaking LLM API changes must include 'BREAKING' in the PR title.");
+              return;
+            }
+
+            core.info(`LLM API change label accepted: ${apiChangeLabels[0]}`);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,9 +121,9 @@ Meanwhile, please add the "release blocker" label to any PRs that could potentia
 
 ## Tests and Code Review for Protected APIs
 
-Some APIs are committed to be stable; any breaking changes to these APIs require careful design and review.
+Some APIs are committed to be stable; breaking changes to these APIs should be avoided and require careful design and review.
 
-This repo contains an [API stability testsuite](./tests/api_stability) to protect committed APIs (currently including the core components of LLM API). If your PR brings breaking changes to the protected APIs, the API stability tests will fail, reporting errors like:
+This repo contains an [API stability testsuite](./tests/unittest/api_stability) to protect committed APIs (currently including the core components of LLM API). If your PR brings breaking changes to the protected APIs, the API stability tests will fail, reporting errors like:
 
 ```txt
 def test_signature(self):
@@ -138,6 +138,7 @@ tests/api_stability/test_api_stability.py:241: AssertionError
 ```
 
 As the error message suggests, please ask for reviews from the code owners of the corresponding APIs.
+If API stability reference files change, classify the accepted LLM API contract change with `api-compatible` or `api-breaking`; `api-breaking` also requires `BREAKING` in the PR title. See the [API change guide](./docs/source/developer-guide/api-change.md) for details.
 
 
 ## Signing Your Work

--- a/docs/source/developer-guide/api-change.md
+++ b/docs/source/developer-guide/api-change.md
@@ -29,6 +29,21 @@ TensorRT LLM classifies APIs into two categories:
 - Schema stored in: `tests/unittest/api_stability/references/`
 - See [API status documentation](https://nvidia.github.io/TensorRT-LLM/llm-api/reference.html) for complete details
 
+### LLM API Change Classification
+
+Any backwards-incompatible LLM API change is breaking, regardless of whether the
+affected API is committed, prototype, beta, deprecated, or otherwise
+non-committed. Examples include removing arguments or methods, making optional
+arguments required, changing defaults in a way existing callers observe,
+narrowing accepted values, or changing return shapes/types.
+
+Do not break committed APIs. Prefer deprecation and migration paths. Breaking a
+non-committed API is less strict, but should still be avoided unless justified.
+If a pull request updates API stability reference files, classify the accepted
+contract change with exactly one GitHub label enforced by the LLM API
+Compatibility workflow: `api-compatible` or `api-breaking`. For `api-breaking`,
+include `BREAKING` in the PR title.
+
 ## API Schema Management
 
 All API schemas are:
@@ -264,12 +279,15 @@ When modifying existing methods:
 1. **Non-breaking changes** (adding optional parameters):
    - Update the method signature
    - Update the schema file
+   - Apply the `api-compatible` label if API stability reference files change
    - No status change needed
 
 2. **Breaking changes** (changing required parameters, return types):
-   - Only allowed for non-committed APIs
-   - Consider deprecation path for beta APIs
-   - Update documentation with migration guide
+   - Treat as breaking regardless of committed, prototype, beta, or deprecated status
+   - Do not break committed APIs; prefer deprecation and migration paths
+   - Avoid breaking non-committed APIs too, unless justified
+   - Apply the `api-breaking` label
+   - Include `BREAKING` in the PR title
 
 ### Best Practices
 


### PR DESCRIPTION
## Summary

LLM API reference gate. Separate workflow.

If `tests/unittest/api_stability/references*` changes, PR needs exactly one label:

- `api-compatible`
- `api-breaking`

`api-breaking` also needs `BREAKING` in title.

## Why

Reference update = accepted API contract change. Label makes compatibility intent visible.

## Notes

Normal PR: workflow runs green, logs no reference changes.

Rename/move-out covered via GitHub `previous_filename`.

## Testing

- pre-commit on amended commit
- YAML parse for both workflows
- Node syntax check for embedded workflow script
- mocked smoke cases for no-op, missing label, rename-out, compatible, breaking title
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance on API breaking changes, including requirements for change classification and PR titling.

* **Chores**
  * Added automated validation for API compatibility labeling on pull requests affecting stability reference files.
  * Updated repository workflow headers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14064)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->