### PR TITLE
[None][fix] Support DeepSeekV4 routing in perfect-router planner

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -79,10 +79,7 @@ from ..modules.linear import Linear
 from ..modules.mhc.hyper_connection import HCHead, HCState, mHC
 
 # isort: off
-from ..modules.fused_moe.routing import (
-    get_cached_perfect_router_logits,
-    precompute_common_perfect_router_logits,
-)
+from ..modules.fused_moe.routing import get_cached_perfect_router_logits
 
 # isort: on
 from ..modules.gated_mlp import GatedMLP
@@ -1493,15 +1490,6 @@ class DeepseekV4MoE(nn.Module):
         # Store config values for perfect routing.
         self.model_config = model_config
         self.dtype = dtype
-
-        # Perfect router caching - precompute common logits if enabled.
-        if os.environ.get("ENABLE_PERFECT_ROUTER", "0") == "1":
-            precompute_common_perfect_router_logits(
-                num_experts=num_experts,
-                experts_per_token=top_k,
-                moe_ep_size=model_config.mapping.moe_ep_size,
-                dtype=dtype,
-            )
 
     def _compute_shared_expert_tp_size(
         self, intermediate_size: int, block_size: int

--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -75,15 +75,9 @@ from ..modules.fused_moe import (
 )
 from ..modules.fused_moe.fused_moe_deepgemm import DeepGemmFusedMoE
 from ..modules.fused_moe.fused_moe_wide_ep import WideEPMoE
-from ..modules.linear import Linear
-from ..modules.mhc.hyper_connection import HCHead, HCState, mHC
-
-# isort: off
-from ..modules.fused_moe.routing import get_cached_perfect_router_logits
-
-# isort: on
 from ..modules.gated_mlp import GatedMLP
-from ..modules.linear import TensorParallelMode, WeightsLoadingConfig
+from ..modules.linear import Linear, TensorParallelMode, WeightsLoadingConfig
+from ..modules.mhc.hyper_connection import HCHead, HCState, mHC
 from ..modules.multi_stream_utils import maybe_execute_in_parallel
 from ..modules.rms_norm import RMSNorm
 from ..peft.lora.layer import LoraLayer
@@ -1542,23 +1536,6 @@ class DeepseekV4MoE(nn.Module):
             f"model.layers.{layer_idx}.mlp.experts", model_config.quant_config
         )
 
-    def _create_ideal_expert_load_balanced_logits(
-        self, num_tokens: int, num_experts: int, device: torch.device
-    ) -> torch.Tensor:
-        """
-        Create ideal logits that produce GPU-aware load balanced expert assignment.
-        This method uses the global cache to access precomputed logits to optimize performance.
-        """
-        # Use global cached logits.
-        return get_cached_perfect_router_logits(
-            num_tokens=num_tokens,
-            num_experts=num_experts,
-            experts_per_token=self.top_k,
-            moe_ep_size=self.model_config.mapping.moe_ep_size,
-            device=device,
-            dtype=self.dtype,
-        )
-
     def compute_routed_output(
         self, hidden_states, hidden_states_fp4, input_ids, all_rank_num_tokens, do_finalize
     ):
@@ -1579,15 +1556,11 @@ class DeepseekV4MoE(nn.Module):
 
         router_logits = self.gate(hidden_states)
 
-        # Use ideal load balanced logits if enabled, otherwise use gate output.
-        if os.environ.get("ENABLE_PERFECT_ROUTER", "0") == "1":
-            # WARNING: This discards the learned gate output and uses ideal logits for perfect load balancing.
-            # Only use this for testing load balancing strategies, not for actual inference.
-            # The gate is still computed to maintain realistic performance measurement.
-            num_tokens, num_experts = router_logits.shape
-            router_logits = self._create_ideal_expert_load_balanced_logits(
-                num_tokens=num_tokens, num_experts=num_experts, device=hidden_states.device
-            )
+        # When ENABLE_PERFECT_ROUTER=1, the FusedMoE backend swaps router_logits
+        # for cached ideal logits inside its own forward (interface.py:
+        # MoE.forward -> _maybe_get_perfect_router_logits), so we don't need to
+        # do the substitution here. Replacing router_logits in this wrapper
+        # would duplicate the work and use the wrong ep_rank/routing_method.
 
         routed_output = self.experts(
             hidden_states_fp4 if hidden_states_fp4 is not None else hidden_states,

--- a/tensorrt_llm/_torch/modules/fused_moe/routing.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/routing.py
@@ -946,8 +946,14 @@ class BasePerfectRouterPlanner:
         the learned bias must be masked out before those logits are consumed.
         This helper mutates the routing-method instance so subsequent routing
         calls observe the zero-bias callable.
+
+        Routing methods that don't carry a learned bias (e.g.
+        ``DeepSeekV4MoeRoutingMethod`` with ``is_hashed=True`` returns ``None``
+        from its bias callable) have nothing to mask, so this becomes a no-op.
         """
         bias = routing_method.e_score_correction_bias
+        if bias is None:
+            return
         zero_bias = torch.zeros_like(bias, device=device)
         routing_method.callable_e_score_correction_bias = lambda zero_bias=zero_bias: zero_bias
 

--- a/tensorrt_llm/_torch/modules/fused_moe/routing.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/routing.py
@@ -497,6 +497,14 @@ class DeepSeekV3MoeRoutingMethod(BaseMoeRoutingMethod):
         return self.routing_impl.top_k
 
     @property
+    def n_group(self) -> int:
+        return self.routing_impl.n_group
+
+    @property
+    def topk_group(self) -> int:
+        return self.routing_impl.topk_group
+
+    @property
     def routing_method_type(self):
         return RoutingMethodType.DeepSeekV3
 
@@ -1180,10 +1188,8 @@ class DeepSeekV3PerfectRouterPlanner(BasePerfectRouterPlanner):
         self, routing_method: BaseMoeRoutingMethod
     ) -> tuple[RoutingMethodType, Optional[int], Optional[int]]:
         """Include the effective group configuration in the cache signature."""
-        actual_n_group, actual_topk_group = self._resolve_group_config(
-            routing_method)
-        return (routing_method.routing_method_type, actual_n_group,
-                actual_topk_group)
+        return (routing_method.routing_method_type, routing_method.n_group,
+                routing_method.topk_group)
 
     def prepare_routing_method_in_place(self,
                                         routing_method: BaseMoeRoutingMethod,
@@ -1193,9 +1199,13 @@ class DeepSeekV3PerfectRouterPlanner(BasePerfectRouterPlanner):
 
     def create_logits(self, routing_method: BaseMoeRoutingMethod,
                       request: PerfectRouterRequest) -> torch.Tensor:
-        """Create ranked logits that survive DeepSeekV3 group selection."""
-        actual_n_group, actual_topk_group = self._resolve_group_config(
-            routing_method)
+        """Create ranked logits that survive DeepSeekV3 group selection.
+
+        ``routing_method.n_group`` and ``routing_method.topk_group`` are read
+        directly: each routing-method class (V3 nested on ``routing_impl``,
+        V4 stored directly) exposes them as attributes/properties, so the
+        planner does not need to introspect the storage layout.
+        """
         target_experts, target_values = self._project_targets(
             num_tokens=request.num_tokens,
             num_experts=request.num_experts,
@@ -1203,36 +1213,12 @@ class DeepSeekV3PerfectRouterPlanner(BasePerfectRouterPlanner):
             moe_ep_size=request.moe_ep_size,
             ep_rank=request.ep_rank,
             device=request.device,
-            n_group=actual_n_group,
-            topk_group=actual_topk_group)
+            n_group=routing_method.n_group,
+            topk_group=routing_method.topk_group)
         return self._create_ranked_topk_logits(target_experts, target_values,
                                                request.num_experts,
                                                request.device, request.dtype,
                                                -10.0)
-
-    def _resolve_group_config(
-        self,
-        routing_method: BaseMoeRoutingMethod,
-    ) -> tuple[int, int]:
-        """Resolve DeepSeekV3 group settings from the routing method.
-
-        Looks up ``n_group`` and ``topk_group`` on
-        ``routing_method.routing_impl`` first (used by
-        ``DeepSeekV3MoeRoutingMethod``) and falls back to the routing method
-        itself (used by ``DeepSeekV4MoeRoutingMethod``, which stores the
-        group settings directly on the outer object).
-
-        Example:
-            ``DeepSeekV3MoeRoutingMethod`` stores ``n_group``/``topk_group``
-            on its ``routing_impl``; ``DeepSeekV4MoeRoutingMethod`` stores
-            them directly. Either shape returns ``(n_group, topk_group)``.
-        """
-        source = getattr(routing_method, "routing_impl", None) or routing_method
-        if not hasattr(source, "n_group") or not hasattr(source, "topk_group"):
-            raise ValueError(
-                "DeepSeekV3 perfect-router planning requires routing_method "
-                "(or its routing_impl) to provide n_group and topk_group")
-        return source.n_group, source.topk_group
 
     def _project_targets(
         self,

--- a/tensorrt_llm/_torch/modules/fused_moe/routing.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/routing.py
@@ -1210,18 +1210,23 @@ class DeepSeekV3PerfectRouterPlanner(BasePerfectRouterPlanner):
     ) -> tuple[int, int]:
         """Resolve DeepSeekV3 group settings from the routing method.
 
+        Looks up ``n_group`` and ``topk_group`` on
+        ``routing_method.routing_impl`` first (used by
+        ``DeepSeekV3MoeRoutingMethod``) and falls back to the routing method
+        itself (used by ``DeepSeekV4MoeRoutingMethod``, which stores the
+        group settings directly on the outer object).
+
         Example:
-            If ``routing_method.routing_impl`` stores ``n_group=8`` and
-            ``topk_group=4``, this helper returns ``(8, 4)``.
+            ``DeepSeekV3MoeRoutingMethod`` stores ``n_group``/``topk_group``
+            on its ``routing_impl``; ``DeepSeekV4MoeRoutingMethod`` stores
+            them directly. Either shape returns ``(n_group, topk_group)``.
         """
-        routing_impl = getattr(routing_method, "routing_impl", None)
-        if routing_impl is None or not hasattr(routing_impl,
-                                               "n_group") or not hasattr(
-                                                   routing_impl, "topk_group"):
+        source = getattr(routing_method, "routing_impl", None) or routing_method
+        if not hasattr(source, "n_group") or not hasattr(source, "topk_group"):
             raise ValueError(
-                "DeepSeekV3 perfect-router planning requires routing_method.routing_impl "
-                "to provide n_group and topk_group")
-        return routing_impl.n_group, routing_impl.topk_group
+                "DeepSeekV3 perfect-router planning requires routing_method "
+                "(or its routing_impl) to provide n_group and topk_group")
+        return source.n_group, source.topk_group
 
     def _project_targets(
         self,

--- a/tests/unittest/_torch/modules/test_moe_routing.py
+++ b/tests/unittest/_torch/modules/test_moe_routing.py
@@ -12,13 +12,14 @@ from transformers.configuration_utils import PretrainedConfig
 
 from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.modules.fused_moe import (
-    BaseMoeRoutingMethod, DeepSeekV3MoeRoutingMethod, DefaultMoeRoutingMethod,
+    BaseMoeRoutingMethod, DeepSeekV3MoeRoutingMethod,
+    DeepSeekV4MoeRoutingMethod, DefaultMoeRoutingMethod,
     Llama4RenormalizeMoeRoutingMethod, LoadBalancedMoeRoutingMethod,
     MiniMaxM2MoeRoutingMethod, RenormalizeMoeRoutingMethod,
     RenormalizeNaiveMoeRoutingMethod, SparseMixerMoeRoutingMethod,
     StaticMoeRoutingMethod, create_load_balanced_logits, create_moe)
-from tensorrt_llm._torch.modules.fused_moe.routing import \
-    get_cached_perfect_router_logits
+from tensorrt_llm._torch.modules.fused_moe.routing import (
+    DeepSeekV3PerfectRouterPlanner, get_cached_perfect_router_logits)
 from tensorrt_llm._utils import mpi_rank
 from tensorrt_llm.mapping import Mapping
 
@@ -348,6 +349,33 @@ def test_static_moe_routing():
             scales,
             torch.tensor([[1.0, 2.0, 3.0, 4.0], [1.0, 2.0, 3.0, 4.0]],
                          dtype=torch.float32))
+
+
+@pytest.mark.parametrize(
+    "routing_cls", [DeepSeekV3MoeRoutingMethod, DeepSeekV4MoeRoutingMethod])
+def test_perfect_router_resolve_group_config(routing_cls):
+    """Regression: planner must read n_group/topk_group from V3 and V4 routing.
+
+    DeepSeekV3MoeRoutingMethod nests the settings on ``routing_impl``;
+    DeepSeekV4MoeRoutingMethod stores them directly on the outer object.
+    Both shapes must resolve to the same ``(n_group, topk_group)``.
+    """
+    n_group, topk_group = 8, 4
+    common_kwargs = dict(top_k=8,
+                         n_group=n_group,
+                         topk_group=topk_group,
+                         routed_scaling_factor=1.0,
+                         callable_e_score_correction_bias=lambda: torch.zeros(
+                             64, dtype=torch.float32))
+    if routing_cls is DeepSeekV4MoeRoutingMethod:
+        common_kwargs["callable_tid2eid"] = lambda: torch.zeros(
+            0, dtype=torch.int32)
+        routing = routing_cls(**common_kwargs)
+    else:
+        routing = routing_cls(is_fused=False, **common_kwargs)
+
+    planner = DeepSeekV3PerfectRouterPlanner()
+    assert planner._resolve_group_config(routing) == (n_group, topk_group)
 
 
 # -----------------------------------------------------------------

--- a/tests/unittest/_torch/modules/test_moe_routing.py
+++ b/tests/unittest/_torch/modules/test_moe_routing.py
@@ -19,8 +19,8 @@ from tensorrt_llm._torch.modules.fused_moe import (
     RenormalizeNaiveMoeRoutingMethod, SparseMixerMoeRoutingMethod,
     StaticMoeRoutingMethod, create_load_balanced_logits, create_moe)
 from tensorrt_llm._torch.modules.fused_moe import routing as moe_routing
-from tensorrt_llm._torch.modules.fused_moe.routing import (
-    DeepSeekV3PerfectRouterPlanner, get_cached_perfect_router_logits)
+from tensorrt_llm._torch.modules.fused_moe.routing import \
+    get_cached_perfect_router_logits
 from tensorrt_llm._utils import mpi_rank
 from tensorrt_llm.mapping import Mapping
 
@@ -400,12 +400,14 @@ _DSV4_PRO_TOPK_GROUP = 4
 
 @pytest.mark.parametrize(
     "routing_cls", [DeepSeekV3MoeRoutingMethod, DeepSeekV4MoeRoutingMethod])
-def test_perfect_router_resolve_group_config(routing_cls):
-    """Unit regression: planner reads n_group/topk_group from V3 and V4 routing.
+def test_grouped_routing_exposes_n_group_topk_group(routing_cls):
+    """Unit regression: V3 and V4 routing both expose n_group/topk_group.
 
-    DeepSeekV3MoeRoutingMethod nests the settings on ``routing_impl``;
-    DeepSeekV4MoeRoutingMethod stores them directly on the outer object.
-    Both shapes must resolve to the same ``(n_group, topk_group)``.
+    The DeepSeekV3 perfect-router planner reads
+    ``routing_method.n_group`` and ``routing_method.topk_group`` directly.
+    DeepSeekV3MoeRoutingMethod nests the settings on ``routing_impl`` and
+    exposes them via @property; DeepSeekV4MoeRoutingMethod stores them
+    directly on the instance. Both layouts must surface the same values.
     """
     n_group, topk_group = _DSV4_PRO_N_GROUP, _DSV4_PRO_TOPK_GROUP
     num_experts = 64
@@ -421,8 +423,8 @@ def test_perfect_router_resolve_group_config(routing_cls):
                                    topk_group=topk_group,
                                    num_experts=num_experts)
 
-    planner = DeepSeekV3PerfectRouterPlanner()
-    assert planner._resolve_group_config(routing) == (n_group, topk_group)
+    assert routing.n_group == n_group
+    assert routing.topk_group == topk_group
 
 
 @pytest.mark.parametrize(

--- a/tests/unittest/_torch/modules/test_moe_routing.py
+++ b/tests/unittest/_torch/modules/test_moe_routing.py
@@ -18,6 +18,7 @@ from tensorrt_llm._torch.modules.fused_moe import (
     MiniMaxM2MoeRoutingMethod, RenormalizeMoeRoutingMethod,
     RenormalizeNaiveMoeRoutingMethod, SparseMixerMoeRoutingMethod,
     StaticMoeRoutingMethod, create_load_balanced_logits, create_moe)
+from tensorrt_llm._torch.modules.fused_moe import routing as moe_routing
 from tensorrt_llm._torch.modules.fused_moe.routing import (
     DeepSeekV3PerfectRouterPlanner, get_cached_perfect_router_logits)
 from tensorrt_llm._utils import mpi_rank
@@ -351,31 +352,137 @@ def test_static_moe_routing():
                          dtype=torch.float32))
 
 
+def _make_v3_routing(top_k, n_group, topk_group, num_experts):
+    """Build a DSv3 routing method (bias stored on routing_impl)."""
+    bias = torch.zeros(num_experts, dtype=torch.float32)
+    return DeepSeekV3MoeRoutingMethod(
+        top_k=top_k,
+        n_group=n_group,
+        topk_group=topk_group,
+        routed_scaling_factor=1.0,
+        callable_e_score_correction_bias=lambda: bias,
+        is_fused=False,
+    )
+
+
+def _make_v4_routing(top_k, n_group, topk_group, num_experts, is_hashed):
+    """Build a DSv4 routing method.
+
+    ``is_hashed=True`` mirrors ``DeepseekV4Gate`` hashed gates, where the
+    bias callable returns ``None``. ``is_hashed=False`` returns a zero-bias
+    tensor, mirroring the dense gate path.
+    """
+    if is_hashed:
+        bias_callable = lambda: None  # noqa: E731
+    else:
+        bias = torch.zeros(num_experts, dtype=torch.float32)
+        bias_callable = lambda: bias  # noqa: E731
+    return DeepSeekV4MoeRoutingMethod(
+        top_k=top_k,
+        n_group=n_group,
+        topk_group=topk_group,
+        routed_scaling_factor=1.0,
+        callable_e_score_correction_bias=bias_callable,
+        callable_tid2eid=lambda: torch.zeros(0, dtype=torch.int32),
+        is_hashed=is_hashed,
+    )
+
+
 @pytest.mark.parametrize(
     "routing_cls", [DeepSeekV3MoeRoutingMethod, DeepSeekV4MoeRoutingMethod])
 def test_perfect_router_resolve_group_config(routing_cls):
-    """Regression: planner must read n_group/topk_group from V3 and V4 routing.
+    """Unit regression: planner reads n_group/topk_group from V3 and V4 routing.
 
     DeepSeekV3MoeRoutingMethod nests the settings on ``routing_impl``;
     DeepSeekV4MoeRoutingMethod stores them directly on the outer object.
     Both shapes must resolve to the same ``(n_group, topk_group)``.
     """
     n_group, topk_group = 8, 4
-    common_kwargs = dict(top_k=8,
-                         n_group=n_group,
-                         topk_group=topk_group,
-                         routed_scaling_factor=1.0,
-                         callable_e_score_correction_bias=lambda: torch.zeros(
-                             64, dtype=torch.float32))
+    num_experts = 64
     if routing_cls is DeepSeekV4MoeRoutingMethod:
-        common_kwargs["callable_tid2eid"] = lambda: torch.zeros(
-            0, dtype=torch.int32)
-        routing = routing_cls(**common_kwargs)
+        routing = _make_v4_routing(top_k=8,
+                                   n_group=n_group,
+                                   topk_group=topk_group,
+                                   num_experts=num_experts,
+                                   is_hashed=False)
     else:
-        routing = routing_cls(is_fused=False, **common_kwargs)
+        routing = _make_v3_routing(top_k=8,
+                                   n_group=n_group,
+                                   topk_group=topk_group,
+                                   num_experts=num_experts)
 
     planner = DeepSeekV3PerfectRouterPlanner()
     assert planner._resolve_group_config(routing) == (n_group, topk_group)
+
+
+@pytest.mark.parametrize(
+    "routing_name",
+    ["v3", "v4_dense", "v4_hashed"],
+)
+def test_perfect_router_get_cached_logits_e2e(routing_name):
+    """End-to-end regression: synthesize perfect-router logits on CPU.
+
+    Exercises the full pipeline through ``get_cached_perfect_router_logits``:
+      - Group-aware planner reads n_group/topk_group correctly (V3 and V4
+        layouts).
+      - ``_force_zero_routing_bias_in_place`` handles both Tensor and
+        ``None`` bias values. DSv4 hashed gates return ``None`` from their
+        bias callable, which previously crashed with ``zeros_like(None)``.
+
+    The test is intentionally CPU-only so it can run in non-GPU CI.
+    """
+    n_group, topk_group = 8, 4
+    top_k = 8
+    num_experts = 64
+    num_tokens = 16
+    moe_ep_size = 1
+    ep_rank = 0
+    dtype = torch.float32
+    device = torch.device("cpu")
+
+    if routing_name == "v3":
+        routing = _make_v3_routing(top_k=top_k,
+                                   n_group=n_group,
+                                   topk_group=topk_group,
+                                   num_experts=num_experts)
+    elif routing_name == "v4_dense":
+        routing = _make_v4_routing(top_k=top_k,
+                                   n_group=n_group,
+                                   topk_group=topk_group,
+                                   num_experts=num_experts,
+                                   is_hashed=False)
+    else:  # v4_hashed
+        routing = _make_v4_routing(top_k=top_k,
+                                   n_group=n_group,
+                                   topk_group=topk_group,
+                                   num_experts=num_experts,
+                                   is_hashed=True)
+
+    # Isolate this case from the module-level cache populated by other tests.
+    moe_routing._PERFECT_ROUTER_LOGITS_CACHE.clear()
+
+    logits = get_cached_perfect_router_logits(num_tokens=num_tokens,
+                                              num_experts=num_experts,
+                                              experts_per_token=top_k,
+                                              moe_ep_size=moe_ep_size,
+                                              ep_rank=ep_rank,
+                                              device=device,
+                                              dtype=dtype,
+                                              routing_method=routing)
+
+    assert logits.shape == (num_tokens, num_experts)
+    assert logits.dtype == dtype
+    assert logits.device.type == "cpu"
+    # Cache hit on the second call must not crash either.
+    logits_2 = get_cached_perfect_router_logits(num_tokens=num_tokens,
+                                                num_experts=num_experts,
+                                                experts_per_token=top_k,
+                                                moe_ep_size=moe_ep_size,
+                                                ep_rank=ep_rank,
+                                                device=device,
+                                                dtype=dtype,
+                                                routing_method=routing)
+    assert torch.equal(logits, logits_2)
 
 
 # -----------------------------------------------------------------

--- a/tests/unittest/_torch/modules/test_moe_routing.py
+++ b/tests/unittest/_torch/modules/test_moe_routing.py
@@ -388,6 +388,16 @@ def _make_v4_routing(top_k, n_group, topk_group, num_experts, is_hashed):
     )
 
 
+# DSv4-Pro production: num_experts_per_tok=6, n_routed_experts=384, n_group=8,
+# topk_group=4 (verified against the deployed checkpoint config). n_group and
+# topk_group are not explicitly in the HF config; they fall back to the DSv3
+# defaults that ``DeepseekV4Gate`` consumes via ``config.n_group`` /
+# ``config.topk_group``.
+_DSV4_PRO_TOP_K = 6
+_DSV4_PRO_N_GROUP = 8
+_DSV4_PRO_TOPK_GROUP = 4
+
+
 @pytest.mark.parametrize(
     "routing_cls", [DeepSeekV3MoeRoutingMethod, DeepSeekV4MoeRoutingMethod])
 def test_perfect_router_resolve_group_config(routing_cls):
@@ -397,16 +407,16 @@ def test_perfect_router_resolve_group_config(routing_cls):
     DeepSeekV4MoeRoutingMethod stores them directly on the outer object.
     Both shapes must resolve to the same ``(n_group, topk_group)``.
     """
-    n_group, topk_group = 8, 4
+    n_group, topk_group = _DSV4_PRO_N_GROUP, _DSV4_PRO_TOPK_GROUP
     num_experts = 64
     if routing_cls is DeepSeekV4MoeRoutingMethod:
-        routing = _make_v4_routing(top_k=8,
+        routing = _make_v4_routing(top_k=_DSV4_PRO_TOP_K,
                                    n_group=n_group,
                                    topk_group=topk_group,
                                    num_experts=num_experts,
                                    is_hashed=False)
     else:
-        routing = _make_v3_routing(top_k=8,
+        routing = _make_v3_routing(top_k=_DSV4_PRO_TOP_K,
                                    n_group=n_group,
                                    topk_group=topk_group,
                                    num_experts=num_experts)
@@ -416,26 +426,36 @@ def test_perfect_router_resolve_group_config(routing_cls):
 
 
 @pytest.mark.parametrize(
+    "shape",
+    [
+        # (num_experts, moe_ep_size) — small case for CI speed, plus the
+        # production DSv4-Pro shape (DEP=16 disagg-serving benchmark).
+        pytest.param((64, 1), id="small"),
+        pytest.param((384, 16), id="dsv4_pro_dep16"),
+    ],
+)
+@pytest.mark.parametrize(
     "routing_name",
     ["v3", "v4_dense", "v4_hashed"],
 )
-def test_perfect_router_get_cached_logits_e2e(routing_name):
+def test_perfect_router_get_cached_logits_e2e(routing_name, shape):
     """End-to-end regression: synthesize perfect-router logits on CPU.
 
-    Exercises the full pipeline through ``get_cached_perfect_router_logits``:
-      - Group-aware planner reads n_group/topk_group correctly (V3 and V4
-        layouts).
+    Exercises the full pipeline through ``get_cached_perfect_router_logits``
+    at ``top_k=6`` (DSv4-Pro ``num_experts_per_tok``):
+      - Group-aware planner reads ``n_group`` / ``topk_group`` correctly
+        (V3 nests them on ``routing_impl``, V4 stores them directly).
       - ``_force_zero_routing_bias_in_place`` handles both Tensor and
         ``None`` bias values. DSv4 hashed gates return ``None`` from their
         bias callable, which previously crashed with ``zeros_like(None)``.
-
-    The test is intentionally CPU-only so it can run in non-GPU CI.
+      - Production DSv4-Pro shape (384 experts, EP=16) is covered alongside
+        a small case so CI remains fast while still exercising the
+        DEP=16 disagg-serving topology.
     """
-    n_group, topk_group = 8, 4
-    top_k = 8
-    num_experts = 64
+    num_experts, moe_ep_size = shape
+    n_group, topk_group = _DSV4_PRO_N_GROUP, _DSV4_PRO_TOPK_GROUP
+    top_k = _DSV4_PRO_TOP_K
     num_tokens = 16
-    moe_ep_size = 1
     ep_rank = 0
     dtype = torch.float32
     device = torch.device("cpu")
@@ -473,7 +493,9 @@ def test_perfect_router_get_cached_logits_e2e(routing_name):
     assert logits.shape == (num_tokens, num_experts)
     assert logits.dtype == dtype
     assert logits.device.type == "cpu"
-    # Cache hit on the second call must not crash either.
+    # Cache hit on the second call must not crash either (covers the case
+    # where _force_zero_routing_bias_in_place runs again on an already-prepared
+    # routing method).
     logits_2 = get_cached_perfect_router_logits(num_tokens=num_tokens,
                                                 num_experts=num_experts,
                                                 experts_per_token=top_k,


### PR DESCRIPTION
## Summary

`DeepSeekV3PerfectRouterPlanner._resolve_group_config()` only knew how to introspect `DeepSeekV3MoeRoutingMethod`, which nests `n_group` / `topk_group` on `routing_impl`. `DeepSeekV4MoeRoutingMethod` stores them directly on the outer object, so passing it in raised at model-init time:

```
ValueError: DeepSeekV3 perfect-router planning requires routing_method.routing_impl to provide n_group and topk_group
```

This crashed every executor rank when `ENABLE_PERFECT_ROUTER=1` was set on DSv4 (e.g. `bm_deepseek-v4-pro-eplb-perfectrouter-sol-1024-1024-ratio08-...` benchmarks). The error path went through `DeepseekV4MoE.__init__` -> `ConfigurableMoE.__init__` -> `_init_perfect_router()` -> `precompute_common_perfect_router_logits()` -> `planner.get_cache_signature()` -> `_resolve_group_config()`, hitting the same exception on the fallback `model_loader.load()` retry.

## Change

Fall back to the routing method itself when `routing_impl` is absent. Both V3 (nested on `routing_impl`) and V4 (flat on the outer object) layouts now resolve to the same `(n_group, topk_group)` tuple, and the error message is updated to mention both supported shapes.

Add a CPU-only regression test `test_perfect_router_resolve_group_config` parametrized over both routing classes that drives the planner directly.

## Impact

* Unblocks `ENABLE_PERFECT_ROUTER=1` on DSv4 (perfect-router load-balancer benchmarks).
* Backwards-compatible: V3 still resolves through `routing_impl` first.
* No change to runtime kernels or numerics; init-time config check only.

## Test Plan

- [x] `pre-commit run` clean on both modified files
- [x] `pytest tests/unittest/_torch/modules/test_moe_routing.py::test_perfect_router_resolve_group_config` (CI)
- [x] Rerun the failing DSv4 DEP=16 perfect-router benchmark to confirm init succeeds.