### PR TITLE
[None][feat] add encoder-decoder model foundations

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -256,7 +256,12 @@ class AttentionMetadata:
         # The model executor sets seqlens to None initially.
         if self._seq_lens_kv is not None:
             self._seq_lens_kv = maybe_pin_memory(self._seq_lens_kv)
-            self._seq_lens_kv_cuda = self._seq_lens_kv.cuda(non_blocking=True)
+            if self.is_cuda_graph and self._seq_lens_kv_cuda is not None:
+                self._seq_lens_kv_cuda.copy_(self._seq_lens_kv,
+                                             non_blocking=True)
+            else:
+                self._seq_lens_kv_cuda = self._seq_lens_kv.cuda(
+                    non_blocking=True)
 
     @property
     def seq_lens_kv_cuda(self):
@@ -397,6 +402,78 @@ class AttentionMetadata:
         """
         Hook to be called when using helix parallelism.
         """
+
+    def create_cross_metadata(
+        self,
+        encoder_seq_lens: torch.Tensor,
+        enc_dec_kv_cache_manager: Union[KVCacheManager, KVCacheManagerV2,
+                                        None] = None,
+        *,
+        encoder_num_cached_tokens_per_seq: Optional[List[int]] = None,
+    ) -> "AttentionMetadata":
+        """Build a sub-metadata instance for cross-attention.
+
+        The returned metadata shares Q-side fields (``seq_lens``,
+        ``request_ids``, ``num_contexts``) with ``self`` (the decoder
+        self-attention metadata) and overrides the K/V-side with the encoder
+        lengths so that ``returned.is_cross is True``.
+
+        This is intended to be called by the runtime / unit tests once the
+        encoder lengths and cross-pool KV cache manager are known. The
+        returned object is a *new* metadata instance (not stored on
+        ``self.cross``); callers can attach it to ``self.cross`` if desired.
+
+        Args:
+            encoder_seq_lens: Per-request encoder sequence length (CPU
+                int32 tensor). On the first decoder context step this is
+                the full encoder length; on generation steps it should be
+                ``0`` (no new K/V tokens to add to the cross pool — the
+                encoder K/V are already cached).
+            enc_dec_kv_cache_manager: KV cache manager for the cross pool.
+                When ``None``, the returned metadata uses the stateless
+                (no-KV-cache) path (suitable for unit tests).
+            encoder_num_cached_tokens_per_seq: Per-request count of encoder
+                K/V tokens already present in the cross pool. ``None``
+                defaults to 0 (context phase, nothing cached yet).
+
+        Returns:
+            A new ``AttentionMetadata`` of the same subclass as ``self``,
+            with ``seq_lens_kv`` set to ``encoder_seq_lens`` so that
+            ``is_cross`` becomes ``True``.
+        """
+        cross_md = copy.copy(self)
+        cross_md._saved_tensors = {}
+        if self.is_cuda_graph:
+            # Cross-attention has K/V lengths from the encoder, while
+            # self-attention has K/V lengths from the decoder. Keep their
+            # CUDA graph metadata buffers separate so preparing cross metadata
+            # cannot overwrite self-attention sequence lengths.
+            cross_md.cuda_graph_buffers = Buffers()
+        cross_md.kv_cache_manager = enc_dec_kv_cache_manager
+        cross_md._seq_lens_kv = None
+        cross_md._seq_lens_kv_cuda = None
+        cross_md.cross = None
+        cross_md.seq_lens_kv = encoder_seq_lens
+        if encoder_num_cached_tokens_per_seq is not None:
+            from ..metadata import KVCacheParams
+            base_params = self.kv_cache_params
+            cross_md.kv_cache_params = KVCacheParams(
+                use_cache=base_params.use_cache if base_params is not None else
+                (enc_dec_kv_cache_manager is not None),
+                num_cached_tokens_per_seq=list(
+                    encoder_num_cached_tokens_per_seq),
+                block_ids_per_seq=base_params.block_ids_per_seq
+                if base_params is not None else None,
+                host_max_attention_window_sizes=base_params.
+                host_max_attention_window_sizes
+                if base_params is not None else None,
+                host_sink_token_length=base_params.host_sink_token_length
+                if base_params is not None else None,
+                num_extra_kv_tokens=base_params.num_extra_kv_tokens
+                if base_params is not None else 0,
+            )
+        cross_md.__post_init__()
+        return cross_md
 
     def update_for_spec_dec(self) -> None:
         """
@@ -705,6 +782,8 @@ class AttentionForwardArgs:
     attention_window_size: Optional[int] = None
     attention_mask_data: Optional[torch.Tensor] = None
     attention_sinks: Optional[torch.Tensor] = None
+    relative_attention_bias: Optional[torch.Tensor] = None
+    relative_attention_max_distance: int = 0
 
     latent_cache: Optional[torch.Tensor] = None
     q_pe: Optional[torch.Tensor] = None

--- a/tensorrt_llm/_torch/attention_backend/vanilla.py
+++ b/tensorrt_llm/_torch/attention_backend/vanilla.py
@@ -314,16 +314,23 @@ class VanillaAttention(AttentionBackend[VanillaAttentionMetadata]):
             metadata: AttentionMetadata,
             *,
             attention_mask: AttentionMask = PredefinedAttentionMask.CAUSAL,
-            position_ids: Optional[torch.Tensor] = None) -> torch.Tensor:
-        """
-        This function is used to perform attention without kv cache.
+            position_ids: Optional[torch.Tensor] = None,
+            **kwargs) -> torch.Tensor:
+        """Perform attention without kv cache.
+
+        Supports both self-attention (Q and K/V have matching per-request
+        lengths) and cross-attention (Q-side lengths from
+        ``metadata.seq_lens``, K/V-side lengths from ``metadata.seq_lens_kv``,
+        i.e. ``metadata.is_cross is True``).
+
         Args:
-            q (torch.Tensor): Query tensor with shape (seq_len, num_heads * head_dim) or (seq_len, (num_heads + 2 * num_kv_heads) * head_dim),
-            k (Optional[torch.Tensor]): Key tensor with shape (seq_len, num_heads * head_dim) or None,
-            v (Optional[torch.Tensor]): Value tensor with shape (seq_len, num_heads * head_dim) or None,
+            q: Query tensor, shape ``(seq_len_q, num_heads * head_dim)``
+                or ``(seq_len_q, (num_heads + 2*num_kv_heads) * head_dim)``.
+            k: Key tensor, shape ``(seq_len_kv, num_kv_heads * head_dim)`` or
+                None (fused QKV input).
+            v: Value tensor, shape ``(seq_len_kv, num_kv_heads * head_dim)``
+                or None (fused QKV input).
         """
-        # lazy loading
-        from flash_attn.flash_attn_interface import flash_attn_varlen_func
         head_dim = q.shape[-1]
         is_fused_qkv = False
         if (k is None) or (v is None):
@@ -345,15 +352,51 @@ class VanillaAttention(AttentionBackend[VanillaAttentionMetadata]):
         assert q.dim() == 3
         assert k.dim() == 3
         assert v.dim() == 3
-        seqlens_in_batch = metadata.seq_lens
-        assert seqlens_in_batch is not None, "seq_len can not be None for remove padding inputs attention!"
-        max_seqlen_in_batch = seqlens_in_batch.max().item()
-        cu_seqlens = F.pad(
-            torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32),
-            (1, 0)).to(q.device)
+        seqlens_q = metadata.seq_lens
+        assert seqlens_q is not None, "seq_len can not be None for remove padding inputs attention!"
+        seqlens_kv = metadata.seq_lens_kv
+        # In cross-attention the K/V-side lengths differ from the Q-side
+        # lengths and must be tracked separately for cu_seqlens.
+        is_cross = metadata.is_cross
+        if is_fused_qkv and is_cross:
+            raise ValueError(
+                "Cross-attention with fused QKV input is not supported: pass "
+                "Q, K, V as separate tensors when metadata.is_cross is True.")
+        max_seqlen_q = int(seqlens_q.max().item())
+        cu_seqlens_q = F.pad(torch.cumsum(seqlens_q, dim=0, dtype=torch.int32),
+                             (1, 0)).to(q.device)
+        if is_cross:
+            assert seqlens_kv is not None, (
+                "metadata.seq_lens_kv must be set for cross-attention "
+                "(no_kv_cache_forward). Got None.")
+            assert seqlens_kv.sum().item() == k.size(0), (
+                "K tensor token count does not match metadata.seq_lens_kv: "
+                f"k.shape[0]={k.size(0)} vs sum(seq_lens_kv)="
+                f"{seqlens_kv.sum().item()}.")
+            max_seqlen_k = int(seqlens_kv.max().item())
+            cu_seqlens_k = F.pad(
+                torch.cumsum(seqlens_kv, dim=0, dtype=torch.int32),
+                (1, 0)).to(q.device)
+        else:
+            max_seqlen_k = max_seqlen_q
+            cu_seqlens_k = cu_seqlens_q
 
-        max_seqlen_q = max_seqlen_k = max_seqlen_in_batch
-        cu_seqlens_q = cu_seqlens_k = cu_seqlens
+        # flash-attn only supports fp16/bf16; fall back to PyTorch SDPA for
+        # other dtypes (e.g. float32), mirroring the TRT backend's behaviour
+        # of disabling context_fmha for float32.
+        if q.dtype not in (torch.float16, torch.bfloat16):
+            return self._no_kv_cache_sdpa_fallback(q, k, v, num_heads,
+                                                   num_kv_heads, head_dim,
+                                                   seqlens_q, cu_seqlens_q,
+                                                   max_seqlen_q, attention_mask,
+                                                   seqlens_kv, cu_seqlens_k,
+                                                   max_seqlen_k)
+
+        from flash_attn.flash_attn_interface import flash_attn_varlen_func
+
+        softmax_scale = None
+        if self.q_scaling is not None:
+            softmax_scale = 1 / (math.sqrt(head_dim) * self.q_scaling)
 
         attn_output_unpad = flash_attn_varlen_func(
             q,
@@ -364,15 +407,74 @@ class VanillaAttention(AttentionBackend[VanillaAttentionMetadata]):
             max_seqlen_q,
             max_seqlen_k,
             dropout_p=0.0,
-            softmax_scale=None,
+            softmax_scale=softmax_scale,
             causal=attention_mask == PredefinedAttentionMask.CAUSAL,
-            # window_size=(-1, -1),  # -1 means infinite context window
             alibi_slopes=None,
             deterministic=False,
             return_attn_probs=False,
         )
 
         return attn_output_unpad.reshape(attn_output_unpad.size(0), -1)
+
+    def _no_kv_cache_sdpa_fallback(
+            self,
+            q: torch.Tensor,
+            k: torch.Tensor,
+            v: torch.Tensor,
+            num_heads: int,
+            num_kv_heads: int,
+            head_dim: int,
+            seqlens_q: torch.Tensor,
+            cu_seqlens_q: torch.Tensor,
+            max_seqlen_q: int,
+            attention_mask: AttentionMask,
+            seqlens_kv: Optional[torch.Tensor] = None,
+            cu_seqlens_k: Optional[torch.Tensor] = None,
+            max_seqlen_k: Optional[int] = None) -> torch.Tensor:
+        """PyTorch SDPA fallback for dtypes not supported by flash-attn.
+
+        When ``seqlens_kv`` / ``cu_seqlens_k`` are provided, K/V are sliced
+        independently of Q (cross-attention path).
+        """
+        del max_seqlen_q, max_seqlen_k  # only seqlens / cu_seqlens are used
+        is_causal = (attention_mask == PredefinedAttentionMask.CAUSAL)
+        num_kv_groups = num_heads // num_kv_heads
+        num_requests = seqlens_q.numel()
+
+        if seqlens_kv is None or cu_seqlens_k is None:
+            seqlens_kv = seqlens_q
+            cu_seqlens_k = cu_seqlens_q
+
+        outputs = []
+        for i in range(num_requests):
+            start_q = cu_seqlens_q[i].item()
+            end_q = cu_seqlens_q[i + 1].item()
+            start_k = cu_seqlens_k[i].item()
+            end_k = cu_seqlens_k[i + 1].item()
+            q_s = q[start_q:end_q].transpose(0, 1).unsqueeze(0)
+            k_s = k[start_k:end_k].transpose(0, 1).unsqueeze(0)
+            v_s = v[start_k:end_k].transpose(0, 1).unsqueeze(0)
+            k_s = repeat_kv(k_s, num_kv_groups)
+            v_s = repeat_kv(v_s, num_kv_groups)
+
+            qk_scale = None
+            if self.q_scaling is not None:
+                qk_scale = 1 / (math.sqrt(head_dim) * self.q_scaling)
+
+            # SDPA's is_causal flag implies square attention. For
+            # cross-attention (different Q/K lengths) we never apply a causal
+            # mask: the decoder Q attends to all encoder K/V tokens.
+            sdpa_is_causal = is_causal and (end_q - start_q) == (end_k -
+                                                                 start_k)
+            out = F.scaled_dot_product_attention(q_s,
+                                                 k_s,
+                                                 v_s,
+                                                 is_causal=sdpa_is_causal,
+                                                 scale=qk_scale)
+            outputs.append(out.squeeze(0).transpose(0, 1))
+
+        result = torch.cat(outputs, dim=0)
+        return result.reshape(result.size(0), -1)
 
     def forward(self,
                 q: torch.Tensor,

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -117,6 +117,7 @@ class ModelConfig(Generic[TConfig]):
     sparse_attention_config: Optional["SparseAttentionConfig"] = None
 
     is_generation: bool = True
+    is_encoder_decoder: bool = False
     max_num_tokens: int = 8192
     max_seq_len: Optional[int] = None
 
@@ -182,6 +183,10 @@ class ModelConfig(Generic[TConfig]):
         super().__setattr__(key, value)
 
     def __post_init__(self):
+        if self.pretrained_config:
+            self.is_encoder_decoder = self.is_encoder_decoder_model(
+                self.pretrained_config)
+
         if self.pretrained_config and hasattr(self.pretrained_config,
                                               "architectures"):
             self.is_generation = self.is_generation_model(
@@ -248,6 +253,18 @@ class ModelConfig(Generic[TConfig]):
             return self.per_layer_quant_configs[name]
 
         raise ValueError(f'quant config of {name} is not found')
+
+    @staticmethod
+    def is_encoder_decoder_model(pretrained_config: Optional[TConfig]) -> bool:
+        if pretrained_config is None:
+            return False
+        text_config = pretrained_config
+        get_text_config = getattr(pretrained_config, "get_text_config", None)
+        if callable(get_text_config):
+            text_config = get_text_config()
+        elif hasattr(pretrained_config, "text_config"):
+            text_config = pretrained_config.text_config
+        return getattr(text_config, "is_encoder_decoder", False)
 
     @staticmethod
     def is_generation_model(model_architectures: Optional[List[str]],

--- a/tensorrt_llm/_torch/models/__init__.py
+++ b/tensorrt_llm/_torch/models/__init__.py
@@ -1,6 +1,8 @@
 import transformers
 
 from .modeling_auto import AutoModelForCausalLM
+from .modeling_bart import (BartForConditionalGeneration,
+                            MBartForConditionalGeneration)
 from .modeling_bert import BertForSequenceClassification
 from .modeling_clip import CLIPVisionModel
 from .modeling_cohere2 import Cohere2ForCausalLM
@@ -38,12 +40,14 @@ from .modeling_qwen_moe import Qwen2MoeForCausalLM
 from .modeling_seedoss import SeedOssForCausalLM
 from .modeling_siglip import SiglipVisionModel
 from .modeling_starcoder2 import Starcoder2ForCausalLM
+from .modeling_t5 import T5ForConditionalGeneration
 from .modeling_utils import get_model_architecture
 from .modeling_vila import VilaModel
 
 # Note: for better readiblity, this should have same order as imports above
 __all__ = [
     "AutoModelForCausalLM",
+    "BartForConditionalGeneration",
     "BertForSequenceClassification",
     "CLIPVisionModel",
     "DeepseekV3ForCausalLM",
@@ -71,6 +75,8 @@ __all__ = [
     "Qwen2MoeForCausalLM",
     "SiglipVisionModel",
     "Starcoder2ForCausalLM",
+    "T5ForConditionalGeneration",
+    "MBartForConditionalGeneration",
     "get_model_architecture",
     "VilaModel",
     "Qwen2VLModel",

--- a/tensorrt_llm/_torch/models/modeling_bart.py
+++ b/tensorrt_llm/_torch/models/modeling_bart.py
@@ -1,0 +1,707 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""PyTorch-flow BART / mBART encoder-decoder model for TensorRT-LLM.
+
+Covers ``BartForConditionalGeneration`` and ``MBartForConditionalGeneration``.
+
+Key differences from T5:
+    - LayerNorm instead of RMSNorm.
+    - Post-norm (residual → add → LayerNorm) instead of pre-norm.
+    - Learned absolute positional embeddings (not relative bias).
+    - GELU activation (not ReLU / gated).
+    - Bias in attention and MLP projections.
+    - Embedding scale = sqrt(d_model).
+"""
+
+import math
+from typing import Dict, Optional
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers import BartConfig
+
+from ..attention_backend import AttentionMetadata
+from ..attention_backend.interface import PredefinedAttentionMask
+from ..model_config import ModelConfig
+from ..modules.attention import Attention
+from ..modules.cross_attention import CrossAttention
+from ..modules.embedding import Embedding, LMHead
+from ..modules.encoder_decoder_layer import EncoderDecoderLayer, EncoderLayer
+from ..modules.layer_norm import LayerNorm
+from ..modules.linear import TensorParallelMode
+from ..modules.logits_processor import LogitsProcessor
+from ..modules.mlp import MLP
+from .modeling_utils import PostInitCaller, register_auto_model
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+
+def _bart_encoder_hidden_size(config: BartConfig) -> int:
+    return config.d_model
+
+
+def _bart_decoder_hidden_size(config: BartConfig) -> int:
+    return config.d_model
+
+
+def _bart_encoder_num_heads(config: BartConfig) -> int:
+    return config.encoder_attention_heads
+
+
+def _bart_decoder_num_heads(config: BartConfig) -> int:
+    return config.decoder_attention_heads
+
+
+def _bart_encoder_ffn_dim(config: BartConfig) -> int:
+    return config.encoder_ffn_dim
+
+
+def _bart_decoder_ffn_dim(config: BartConfig) -> int:
+    return config.decoder_ffn_dim
+
+
+def _bart_encoder_num_layers(config: BartConfig) -> int:
+    return config.encoder_layers
+
+
+def _bart_decoder_num_layers(config: BartConfig) -> int:
+    return config.decoder_layers
+
+
+def _bart_head_dim(config: BartConfig) -> int:
+    return config.d_model // config.encoder_attention_heads
+
+
+# ---------------------------------------------------------------------------
+# BART Attention
+# ---------------------------------------------------------------------------
+
+
+class BartSelfAttention(Attention):
+    """BART-style MHA with bias and no positional encoding in the kernel.
+
+    BART uses learned positional embeddings added to the input before the
+    attention layer, so no RoPE or other in-kernel positional encoding is
+    needed.
+    """
+
+    def __init__(
+        self,
+        model_config: ModelConfig[BartConfig],
+        num_heads: int,
+        layer_idx: Optional[int] = None,
+    ):
+        config = model_config.pretrained_config
+        super().__init__(
+            hidden_size=config.d_model,
+            num_attention_heads=num_heads,
+            num_key_value_heads=num_heads,
+            max_position_embeddings=config.max_position_embeddings,
+            bias=True,
+            pos_embd_params=None,
+            layer_idx=layer_idx,
+            dtype=config.torch_dtype,
+            config=model_config,
+        )
+
+    def apply_rope(self, q, k, v, position_ids):
+        """BART uses learned pos embeddings, not RoPE — pass through."""
+        return q, k, v
+
+
+class BartCrossAttention(CrossAttention):
+    """BART-style cross-attention with bias."""
+
+    def __init__(
+        self,
+        model_config: ModelConfig[BartConfig],
+        layer_idx: Optional[int] = None,
+    ):
+        config = model_config.pretrained_config
+        num_heads = _bart_decoder_num_heads(config)
+        super().__init__(
+            hidden_size=config.d_model,
+            num_attention_heads=num_heads,
+            num_key_value_heads=num_heads,
+            encoder_hidden_size=config.d_model,
+            bias=True,
+            layer_idx=layer_idx,
+            dtype=config.torch_dtype,
+            config=model_config,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Encoder layer
+# ---------------------------------------------------------------------------
+
+
+class BartEncoderLayer(EncoderLayer):
+    """BART encoder layer: self-attention → add+LN → MLP → add+LN (post-norm)."""
+
+    def __init__(
+        self,
+        model_config: ModelConfig[BartConfig],
+        layer_idx: int,
+    ):
+        super().__init__()
+        config = model_config.pretrained_config
+        hidden_size = config.d_model
+        ffn_dim = _bart_encoder_ffn_dim(config)
+        num_heads = _bart_encoder_num_heads(config)
+
+        self.self_attn = BartSelfAttention(model_config, num_heads=num_heads, layer_idx=layer_idx)
+
+        self.self_attn_layer_norm = LayerNorm(
+            hidden_size=hidden_size,
+            eps=1e-5,
+            dtype=config.torch_dtype,
+            has_bias=True,
+        )
+
+        self.mlp = MLP(
+            hidden_size=hidden_size,
+            intermediate_size=ffn_dim,
+            bias=True,
+            activation=F.gelu,
+            dtype=config.torch_dtype,
+            config=model_config,
+            layer_idx=layer_idx,
+        )
+
+        self.final_layer_norm = LayerNorm(
+            hidden_size=hidden_size,
+            eps=1e-5,
+            dtype=config.torch_dtype,
+            has_bias=True,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        position_ids: Optional[torch.IntTensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.self_attn(
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            attn_metadata=attn_metadata,
+            attention_mask=PredefinedAttentionMask.FULL,
+        )
+        hidden_states = residual + hidden_states
+        hidden_states = self.self_attn_layer_norm(hidden_states)
+
+        residual = hidden_states
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        hidden_states = self.final_layer_norm(hidden_states)
+
+        return hidden_states
+
+
+# ---------------------------------------------------------------------------
+# Decoder layer
+# ---------------------------------------------------------------------------
+
+
+class BartDecoderLayer(EncoderDecoderLayer):
+    """BART decoder layer: self-attn → add+LN → cross-attn → add+LN → MLP → add+LN."""
+
+    def __init__(
+        self,
+        model_config: ModelConfig[BartConfig],
+        layer_idx: int,
+    ):
+        super().__init__()
+        config = model_config.pretrained_config
+        hidden_size = config.d_model
+        ffn_dim = _bart_decoder_ffn_dim(config)
+        num_heads = _bart_decoder_num_heads(config)
+
+        self.self_attn = BartSelfAttention(model_config, num_heads=num_heads, layer_idx=layer_idx)
+
+        self.self_attn_layer_norm = LayerNorm(
+            hidden_size=hidden_size,
+            eps=1e-5,
+            dtype=config.torch_dtype,
+            has_bias=True,
+        )
+
+        self.cross_attn = BartCrossAttention(model_config, layer_idx=layer_idx)
+
+        self.cross_attn_layer_norm = LayerNorm(
+            hidden_size=hidden_size,
+            eps=1e-5,
+            dtype=config.torch_dtype,
+            has_bias=True,
+        )
+
+        self.mlp = MLP(
+            hidden_size=hidden_size,
+            intermediate_size=ffn_dim,
+            bias=True,
+            activation=F.gelu,
+            dtype=config.torch_dtype,
+            config=model_config,
+            layer_idx=layer_idx,
+        )
+
+        self.final_layer_norm = LayerNorm(
+            hidden_size=hidden_size,
+            eps=1e-5,
+            dtype=config.torch_dtype,
+            has_bias=True,
+        )
+
+    def forward(
+        self,
+        position_ids: torch.IntTensor,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        cross_attn_metadata: Optional[AttentionMetadata] = None,
+        skip_cross_kv_projection: bool = False,
+        **kwargs,
+    ) -> torch.Tensor:
+        # Self-attention (post-norm)
+        residual = hidden_states
+        hidden_states = self.self_attn(
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            attn_metadata=attn_metadata,
+            attention_mask=PredefinedAttentionMask.CAUSAL,
+        )
+        hidden_states = residual + hidden_states
+        hidden_states = self.self_attn_layer_norm(hidden_states)
+
+        # Cross-attention (post-norm)
+        residual = hidden_states
+        hidden_states = self.cross_attn(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            attn_metadata=attn_metadata,
+            cross_attn_metadata=cross_attn_metadata,
+            skip_cross_kv_projection=skip_cross_kv_projection,
+        )
+        hidden_states = residual + hidden_states
+        hidden_states = self.cross_attn_layer_norm(hidden_states)
+
+        # MLP (post-norm)
+        residual = hidden_states
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        hidden_states = self.final_layer_norm(hidden_states)
+
+        return hidden_states
+
+
+# ---------------------------------------------------------------------------
+# Encoder / Decoder stacks
+# ---------------------------------------------------------------------------
+
+
+class BartEncoder(nn.Module):
+    """BART encoder: positional embedding + encoder layers."""
+
+    def __init__(self, model_config: ModelConfig[BartConfig]):
+        super().__init__()
+        config = model_config.pretrained_config
+        num_layers = _bart_encoder_num_layers(config)
+
+        # HF BART uses offset=2 for the padding token, so the actual embedding
+        # table has max_position_embeddings + 2 entries.
+        self.embed_positions = Embedding(
+            config.max_position_embeddings + 2,
+            config.d_model,
+            dtype=config.torch_dtype,
+        )
+        self.layernorm_embedding = LayerNorm(
+            hidden_size=config.d_model,
+            eps=1e-5,
+            dtype=config.torch_dtype,
+            has_bias=True,
+        )
+        self.layers = nn.ModuleList(
+            [BartEncoderLayer(model_config, layer_idx=i) for i in range(num_layers)]
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        position_ids: Optional[torch.IntTensor] = None,
+    ) -> torch.Tensor:
+        if position_ids is not None:
+            hidden_states = hidden_states + self.embed_positions(position_ids)
+        hidden_states = self.layernorm_embedding(hidden_states)
+
+        for layer in self.layers:
+            hidden_states = layer(
+                hidden_states=hidden_states,
+                attn_metadata=attn_metadata,
+                position_ids=position_ids,
+            )
+        return hidden_states
+
+
+class BartDecoder(nn.Module):
+    """BART decoder: positional embedding + decoder layers."""
+
+    def __init__(self, model_config: ModelConfig[BartConfig]):
+        super().__init__()
+        config = model_config.pretrained_config
+        num_layers = _bart_decoder_num_layers(config)
+
+        self.embed_positions = Embedding(
+            config.max_position_embeddings + 2,
+            config.d_model,
+            dtype=config.torch_dtype,
+        )
+        self.layernorm_embedding = LayerNorm(
+            hidden_size=config.d_model,
+            eps=1e-5,
+            dtype=config.torch_dtype,
+            has_bias=True,
+        )
+        self.layers = nn.ModuleList(
+            [BartDecoderLayer(model_config, layer_idx=i) for i in range(num_layers)]
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        position_ids: Optional[torch.IntTensor] = None,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        cross_attn_metadata: Optional[AttentionMetadata] = None,
+        skip_cross_kv_projection: bool = False,
+    ) -> torch.Tensor:
+        if position_ids is not None:
+            hidden_states = hidden_states + self.embed_positions(position_ids)
+        hidden_states = self.layernorm_embedding(hidden_states)
+
+        for layer in self.layers:
+            hidden_states = layer(
+                position_ids=position_ids,
+                hidden_states=hidden_states,
+                attn_metadata=attn_metadata,
+                encoder_hidden_states=encoder_hidden_states,
+                cross_attn_metadata=cross_attn_metadata,
+                skip_cross_kv_projection=skip_cross_kv_projection,
+            )
+        return hidden_states
+
+
+# ---------------------------------------------------------------------------
+# Top-level model
+# ---------------------------------------------------------------------------
+
+
+class BartModel(nn.Module):
+    """BART encoder-decoder body (no lm_head)."""
+
+    def __init__(self, model_config: ModelConfig[BartConfig]):
+        super().__init__()
+        self.model_config = model_config
+        config = model_config.pretrained_config
+
+        self.shared_embedding = Embedding(
+            config.vocab_size,
+            config.d_model,
+            dtype=config.torch_dtype,
+            mapping=model_config.mapping,
+            tensor_parallel_mode=TensorParallelMode.COLUMN,
+            gather_output=True,
+        )
+        self.embed_scale = math.sqrt(config.d_model)
+        # HF BART learned position embeddings reserve indices 0 and 1.
+        self.position_id_offset = 2
+
+        self.encoder = BartEncoder(model_config)
+        self.decoder = BartDecoder(model_config)
+
+    def forward(
+        self,
+        attn_metadata: AttentionMetadata,
+        input_ids: Optional[torch.IntTensor] = None,
+        encoder_input_ids: Optional[torch.IntTensor] = None,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.IntTensor] = None,
+        encoder_position_ids: Optional[torch.IntTensor] = None,
+        encoder_attn_metadata: Optional[AttentionMetadata] = None,
+        cross_attn_metadata: Optional[AttentionMetadata] = None,
+        skip_cross_kv_projection: bool = False,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        if encoder_hidden_states is None and encoder_input_ids is not None:
+            assert encoder_attn_metadata is not None
+            encoder_embeds = self.shared_embedding(encoder_input_ids) * self.embed_scale
+            encoder_hidden_states = self.encoder(
+                hidden_states=encoder_embeds,
+                attn_metadata=encoder_attn_metadata,
+                position_ids=encoder_position_ids,
+            )
+
+        if inputs_embeds is None:
+            assert input_ids is not None
+            inputs_embeds = self.shared_embedding(input_ids) * self.embed_scale
+
+        decoder_output = self.decoder(
+            hidden_states=inputs_embeds,
+            attn_metadata=attn_metadata,
+            position_ids=position_ids,
+            encoder_hidden_states=encoder_hidden_states,
+            cross_attn_metadata=cross_attn_metadata,
+            skip_cross_kv_projection=skip_cross_kv_projection,
+        )
+        return decoder_output
+
+
+@register_auto_model("BartForConditionalGeneration")
+class BartForConditionalGeneration(nn.Module, metaclass=PostInitCaller):
+    """BART encoder-decoder model with LM head."""
+
+    def __init__(self, model_config: ModelConfig[BartConfig]):
+        super().__init__()
+        self.model_config = model_config
+        config = model_config.pretrained_config
+
+        self.model = BartModel(model_config)
+
+        self.lm_head = LMHead(
+            config.vocab_size,
+            config.d_model,
+            dtype=config.torch_dtype,
+            mapping=model_config.mapping,
+            tensor_parallel_mode=TensorParallelMode.COLUMN,
+            gather_output=True,
+            reduce_output=False,
+        )
+
+        if getattr(config, "tie_word_embeddings", False):
+            self.lm_head.weight = self.model.shared_embedding.weight
+
+        self.logits_processor = LogitsProcessor()
+
+    def __post_init__(self):
+        for _, module in self.named_modules():
+            if callable(getattr(module, "create_weights", None)):
+                module.create_weights()
+
+    def __pp_init__(self):
+        pass
+
+    @property
+    def config(self):
+        return self.model_config.pretrained_config
+
+    def forward(
+        self,
+        attn_metadata: AttentionMetadata,
+        input_ids: Optional[torch.IntTensor] = None,
+        position_ids: Optional[torch.IntTensor] = None,
+        encoder_input_ids: Optional[torch.IntTensor] = None,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        encoder_position_ids: Optional[torch.IntTensor] = None,
+        encoder_attn_metadata: Optional[AttentionMetadata] = None,
+        cross_attn_metadata: Optional[AttentionMetadata] = None,
+        skip_cross_kv_projection: bool = False,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        return_context_logits: bool = False,
+        **kwargs,
+    ) -> torch.Tensor:
+        hidden_states = self.model(
+            attn_metadata=attn_metadata,
+            input_ids=input_ids,
+            encoder_input_ids=encoder_input_ids,
+            encoder_hidden_states=encoder_hidden_states,
+            position_ids=position_ids,
+            encoder_position_ids=encoder_position_ids,
+            encoder_attn_metadata=encoder_attn_metadata,
+            cross_attn_metadata=cross_attn_metadata,
+            skip_cross_kv_projection=skip_cross_kv_projection,
+            inputs_embeds=inputs_embeds,
+        )
+
+        return self.logits_processor.forward(
+            hidden_states,
+            self.lm_head,
+            attn_metadata,
+            return_context_logits,
+        )
+
+    def infer_max_seq_len(self) -> int:
+        config = self.model_config.pretrained_config
+        return getattr(config, "max_position_embeddings", 1024)
+
+    def load_weights(self, weights: Dict, **kwargs):
+        config = self.model_config.pretrained_config
+        tllm_weights = _convert_hf_bart_weights(
+            weights, config, dtype=self.model_config.torch_dtype
+        )
+
+        for name, module in self.named_modules():
+            if len(list(module.parameters(recurse=False))) == 0:
+                continue
+            if name not in tllm_weights:
+                continue
+            w = tllm_weights[name]
+            if hasattr(module, "load_weights"):
+                module.load_weights(weights=w)
+            else:
+                for n, p in module.named_parameters(recurse=False):
+                    if n in w[0]:
+                        p.data.copy_(w[0][n][:])
+
+
+@register_auto_model("MBartForConditionalGeneration")
+class MBartForConditionalGeneration(BartForConditionalGeneration):
+    """mBART reuses the BART architecture with the same weight schema."""
+
+    pass
+
+
+def _convert_hf_bart_weights(
+    hf_weights: Dict[str, torch.Tensor],
+    config: BartConfig,
+    dtype: Optional[torch.dtype] = None,
+) -> Dict:
+    """Map HuggingFace BART/mBART state_dict keys to TRT-LLM module-tree keys.
+
+    Args:
+        hf_weights: HuggingFace model ``state_dict``.
+        config: HuggingFace ``BartConfig``.
+        dtype: Target precision.  When specified, every weight tensor is cast
+            to this dtype before being returned — mirroring the legacy TRT path's
+            ``convert_weight_to_dtype(params, config.dtype)`` logic.
+
+    HF BART weight layout (prefix ``model.``):
+        model.shared.weight
+        model.encoder.embed_positions.weight
+        model.encoder.layernorm_embedding.{weight,bias}
+        model.encoder.layers.{i}.self_attn.{q_proj,k_proj,v_proj,out_proj}.{weight,bias}
+        model.encoder.layers.{i}.self_attn_layer_norm.{weight,bias}
+        model.encoder.layers.{i}.fc1.{weight,bias}
+        model.encoder.layers.{i}.fc2.{weight,bias}
+        model.encoder.layers.{i}.final_layer_norm.{weight,bias}
+        model.decoder.embed_positions.weight
+        model.decoder.layernorm_embedding.{weight,bias}
+        model.decoder.layers.{i}.self_attn.{q_proj,k_proj,v_proj,out_proj}.{weight,bias}
+        model.decoder.layers.{i}.self_attn_layer_norm.{weight,bias}
+        model.decoder.layers.{i}.encoder_attn.{q_proj,k_proj,v_proj,out_proj}.{weight,bias}
+        model.decoder.layers.{i}.encoder_attn_layer_norm.{weight,bias}
+        model.decoder.layers.{i}.fc1.{weight,bias}, fc2.{weight,bias}
+        model.decoder.layers.{i}.final_layer_norm.{weight,bias}
+        lm_head.weight
+    """
+    if dtype is not None:
+        hf_weights = {k: v.to(dtype) for k, v in hf_weights.items()}
+
+    out: Dict[str, list] = {}
+    enc_layers = config.encoder_layers
+    dec_layers = config.decoder_layers
+
+    # HF BartForConditionalGeneration uses "model." prefix;
+    # HF BartModel does not.  Detect and normalise.
+    has_prefix = any(k.startswith("model.") for k in hf_weights)
+    p = "model." if has_prefix else ""
+
+    def _get(key: str) -> torch.Tensor:
+        if key in hf_weights:
+            return hf_weights[key]
+        raise KeyError(f"Missing expected HF weight: {key}")
+
+    def _maybe(key: str):
+        return hf_weights.get(key, None)
+
+    def _wb(prefix: str) -> dict:
+        d = {"weight": _get(f"{prefix}.weight")}
+        b = _maybe(f"{prefix}.bias")
+        if b is not None:
+            d["bias"] = b
+        return d
+
+    # Shared embedding
+    out["model.shared_embedding"] = [{"weight": _get(f"{p}shared.weight")}]
+
+    # LM head
+    if "lm_head.weight" in hf_weights:
+        out["lm_head"] = [{"weight": _get("lm_head.weight")}]
+
+    # Encoder positional embedding
+    out["model.encoder.embed_positions"] = [{"weight": _get(f"{p}encoder.embed_positions.weight")}]
+    out["model.encoder.layernorm_embedding"] = [_wb(f"{p}encoder.layernorm_embedding")]
+
+    # Encoder layers
+    for i in range(enc_layers):
+        hpfx = f"{p}encoder.layers.{i}"
+        tgt = f"model.encoder.layers.{i}"
+
+        # Self-attention (fused QKV)
+        out[f"{tgt}.self_attn.qkv_proj"] = [
+            _wb(f"{hpfx}.self_attn.q_proj"),
+            _wb(f"{hpfx}.self_attn.k_proj"),
+            _wb(f"{hpfx}.self_attn.v_proj"),
+        ]
+        out[f"{tgt}.self_attn.o_proj"] = [_wb(f"{hpfx}.self_attn.out_proj")]
+
+        out[f"{tgt}.self_attn_layer_norm"] = [_wb(f"{hpfx}.self_attn_layer_norm")]
+
+        # MLP: BART uses fc1 (up_proj) and fc2 (down_proj)
+        out[f"{tgt}.mlp.up_proj"] = [_wb(f"{hpfx}.fc1")]
+        out[f"{tgt}.mlp.down_proj"] = [_wb(f"{hpfx}.fc2")]
+
+        out[f"{tgt}.final_layer_norm"] = [_wb(f"{hpfx}.final_layer_norm")]
+
+    # Decoder positional embedding
+    out["model.decoder.embed_positions"] = [{"weight": _get(f"{p}decoder.embed_positions.weight")}]
+    out["model.decoder.layernorm_embedding"] = [_wb(f"{p}decoder.layernorm_embedding")]
+
+    # Decoder layers
+    for i in range(dec_layers):
+        hpfx = f"{p}decoder.layers.{i}"
+        tgt = f"model.decoder.layers.{i}"
+
+        # Self-attention (fused QKV)
+        out[f"{tgt}.self_attn.qkv_proj"] = [
+            _wb(f"{hpfx}.self_attn.q_proj"),
+            _wb(f"{hpfx}.self_attn.k_proj"),
+            _wb(f"{hpfx}.self_attn.v_proj"),
+        ]
+        out[f"{tgt}.self_attn.o_proj"] = [_wb(f"{hpfx}.self_attn.out_proj")]
+
+        out[f"{tgt}.self_attn_layer_norm"] = [_wb(f"{hpfx}.self_attn_layer_norm")]
+
+        # Cross-attention (separate projections)
+        out[f"{tgt}.cross_attn.q_proj"] = [_wb(f"{hpfx}.encoder_attn.q_proj")]
+        out[f"{tgt}.cross_attn.k_proj"] = [_wb(f"{hpfx}.encoder_attn.k_proj")]
+        out[f"{tgt}.cross_attn.v_proj"] = [_wb(f"{hpfx}.encoder_attn.v_proj")]
+        out[f"{tgt}.cross_attn.o_proj"] = [_wb(f"{hpfx}.encoder_attn.out_proj")]
+
+        out[f"{tgt}.cross_attn_layer_norm"] = [_wb(f"{hpfx}.encoder_attn_layer_norm")]
+
+        # MLP
+        out[f"{tgt}.mlp.up_proj"] = [_wb(f"{hpfx}.fc1")]
+        out[f"{tgt}.mlp.down_proj"] = [_wb(f"{hpfx}.fc2")]
+
+        out[f"{tgt}.final_layer_norm"] = [_wb(f"{hpfx}.final_layer_norm")]
+
+    return out

--- a/tensorrt_llm/_torch/models/modeling_t5.py
+++ b/tensorrt_llm/_torch/models/modeling_t5.py
@@ -1,0 +1,1089 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""PyTorch-flow T5 encoder-decoder model for TensorRT-LLM.
+
+Supports T5 (``T5ForConditionalGeneration``) and Flan-T5 (gated MLP variant).
+mBART and BART share a separate ``modeling_bart.py`` file.
+
+Architecture:
+    Encoder: stack of self-attention (non-causal) layers with RMSNorm.
+    Decoder: stack of self-attention (causal) + cross-attention + MLP layers.
+    Top-level: encoder + decoder + lm_head.
+
+HF config normalization:
+    T5Config stores dims as ``d_model``, ``d_kv``, ``d_ff``, ``num_heads``,
+    ``num_layers``, ``num_decoder_layers``.  The ``hidden_size`` /
+    ``num_hidden_layers`` / ``num_attention_heads`` aliases are available via
+    HF property accessors but ``num_key_value_heads`` and
+    ``intermediate_size`` are not — helper functions below extract them.
+"""
+
+import math
+from typing import Dict, Optional
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from transformers import T5Config
+
+from ..attention_backend import AttentionMetadata
+from ..attention_backend.interface import PredefinedAttentionMask
+from ..model_config import ModelConfig
+from ..modules.attention import Attention
+from ..modules.cross_attention import CrossAttention
+from ..modules.embedding import Embedding, LMHead
+from ..modules.encoder_decoder_layer import EncoderDecoderLayer, EncoderLayer
+from ..modules.gated_mlp import GatedMLP
+from ..modules.linear import TensorParallelMode
+from ..modules.logits_processor import LogitsProcessor
+from ..modules.mlp import MLP
+from ..modules.rms_norm import RMSNorm
+from .modeling_utils import PostInitCaller, register_auto_model
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+
+def _t5_num_kv_heads(config: T5Config) -> int:
+    """T5 uses MHA — KV heads == Q heads."""
+    return config.num_heads
+
+
+def _t5_intermediate_size(config: T5Config) -> int:
+    return config.d_ff
+
+
+def _t5_is_gated_act(config: T5Config) -> bool:
+    return getattr(config, "is_gated_act", False)
+
+
+def _t5_head_dim(config: T5Config) -> int:
+    return config.d_kv
+
+
+def _t5_q_scaling(config: T5Config) -> float:
+    # TRT-LLM attention backends use 1 / (sqrt(head_dim) * q_scaling).
+    # T5 matches Hugging Face by leaving QK scores unscaled.
+    return 1.0 / math.sqrt(_t5_head_dim(config))
+
+
+def _t5_dense_act_fn(config: T5Config):
+    """Resolve the T5 MLP activation function from the HF config.
+
+    Standard T5 uses ``relu``; Flan-T5 (``gated-gelu``) uses ``gelu_new``.
+    """
+
+    def _gelu_new(x: torch.Tensor) -> torch.Tensor:
+        return (
+            0.5
+            * x
+            * (1.0 + torch.tanh(math.sqrt(2.0 / math.pi) * (x + 0.044715 * torch.pow(x, 3.0))))
+        )
+
+    act_name = getattr(config, "dense_act_fn", None) or "relu"
+    _ACT_FN_MAP = {
+        "relu": F.relu,
+        "gelu": F.gelu,
+        "gelu_new": _gelu_new,
+        "silu": F.silu,
+        "swish": F.silu,
+    }
+    if act_name not in _ACT_FN_MAP:
+        raise ValueError(
+            f"Unsupported T5 dense_act_fn '{act_name}'. Supported: {list(_ACT_FN_MAP.keys())}"
+        )
+    return _ACT_FN_MAP[act_name]
+
+
+def _t5_gated_act_fn(config: T5Config):
+    act_fn = _t5_dense_act_fn(config)
+
+    def gated_act_fn(hidden_states: torch.Tensor) -> torch.Tensor:
+        gate, up = hidden_states.chunk(2, dim=-1)
+        return act_fn(gate) * up
+
+    return gated_act_fn
+
+
+def _clamp_fp16_infs(hidden_states: torch.Tensor) -> torch.Tensor:
+    if hidden_states.dtype != torch.float16:
+        return hidden_states
+
+    return torch.clamp(hidden_states, min=-64000.0, max=64000.0)
+
+
+def _t5_encoder_num_layers(config: T5Config) -> int:
+    return config.num_layers
+
+
+def _t5_decoder_num_layers(config: T5Config) -> int:
+    return getattr(config, "num_decoder_layers", None) or config.num_layers
+
+
+# ---------------------------------------------------------------------------
+# T5 Relative Position Bias
+# ---------------------------------------------------------------------------
+
+
+class T5RelativePositionBias(nn.Module):
+    """Learned relative position bias for T5 attention.
+
+    Only instantiated on the first layer of each stack (encoder / decoder).
+    The computed bias is shared across all layers in the same stack.
+    """
+
+    def __init__(
+        self,
+        num_buckets: int,
+        num_heads: int,
+        max_distance: int,
+        is_decoder: bool,
+        dtype: Optional[torch.dtype] = None,
+    ):
+        super().__init__()
+        self.num_buckets = num_buckets
+        self.max_distance = max_distance
+        self.is_decoder = is_decoder
+        self.relative_attention_bias = nn.Embedding(num_buckets, num_heads, dtype=dtype)
+
+    @staticmethod
+    def _relative_position_bucket(
+        relative_position: torch.Tensor,
+        bidirectional: bool = True,
+        num_buckets: int = 32,
+        max_distance: int = 128,
+    ) -> torch.Tensor:
+        relative_buckets = 0
+        if bidirectional:
+            num_buckets //= 2
+            relative_buckets += (relative_position > 0).to(torch.long) * num_buckets
+            relative_position = torch.abs(relative_position)
+        else:
+            relative_position = -torch.min(relative_position, torch.zeros_like(relative_position))
+
+        max_exact = num_buckets // 2
+        is_small = relative_position < max_exact
+
+        relative_position_if_large = max_exact + (
+            torch.log(relative_position.float() / max_exact)
+            / math.log(max_distance / max_exact)
+            * (num_buckets - max_exact)
+        ).to(torch.long)
+        relative_position_if_large = torch.min(
+            relative_position_if_large,
+            torch.full_like(relative_position_if_large, num_buckets - 1),
+        )
+
+        relative_buckets += torch.where(is_small, relative_position, relative_position_if_large)
+        return relative_buckets
+
+    def forward(self, query_length: int, key_length: int, device: torch.device) -> torch.Tensor:
+        """Return position bias of shape ``(1, num_heads, query_length, key_length)``."""
+        context_position = torch.arange(query_length, dtype=torch.long, device=device)[:, None]
+        memory_position = torch.arange(key_length, dtype=torch.long, device=device)[None, :]
+        relative_position = memory_position - context_position
+
+        bucket_ids = self._relative_position_bucket(
+            relative_position,
+            bidirectional=not self.is_decoder,
+            num_buckets=self.num_buckets,
+            max_distance=self.max_distance,
+        )
+        values = self.relative_attention_bias(bucket_ids)
+        # (query_length, key_length, num_heads) → (1, num_heads, q, k)
+        return values.permute(2, 0, 1).unsqueeze(0)
+
+
+# ---------------------------------------------------------------------------
+# T5 Attention (self-attention with relative position bias support)
+# ---------------------------------------------------------------------------
+
+
+class T5Attention(Attention):
+    """T5-style multi-head self-attention.
+
+    When ``position_bias`` is provided (from a ``T5RelativePositionBias``
+    module living on layer 0), it is added to the QK^T scores before
+    softmax.  Without a KV cache the module computes SDPA directly
+    (bypassing the VANILLA backend's ``flash_attn_varlen_func`` which
+    cannot accept an additive bias).  With a KV cache it passes the learned
+    relative-attention table to the TRTLLM backend.
+    """
+
+    def __init__(
+        self,
+        model_config: ModelConfig[T5Config],
+        layer_idx: Optional[int] = None,
+        is_decoder: bool = True,
+    ):
+        config = model_config.pretrained_config
+        num_heads = config.num_heads
+        num_kv_heads = _t5_num_kv_heads(config)
+        hidden_size = config.d_model
+
+        super().__init__(
+            hidden_size=hidden_size,
+            num_attention_heads=num_heads,
+            num_key_value_heads=num_kv_heads,
+            max_position_embeddings=512,
+            bias=False,
+            pos_embd_params=None,
+            layer_idx=layer_idx,
+            dtype=config.torch_dtype,
+            config=model_config,
+            q_scaling=_t5_q_scaling(config),
+            head_dim=_t5_head_dim(config),
+        )
+        self._is_decoder = is_decoder
+        self._head_dim = _t5_head_dim(config)
+
+    def apply_rope(self, q, k, v, position_ids):
+        """T5 has no RoPE — pass through unchanged."""
+        return q, k, v
+
+    def _split_qkv(
+        self,
+        hidden_states: torch.Tensor,
+        num_tokens: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        qkv = self.qkv_proj(hidden_states)
+        q_size = self.num_heads * self._head_dim
+        kv_size = self.num_key_value_heads * self._head_dim
+        q, k, v = qkv[:num_tokens].split([q_size, kv_size, kv_size], dim=-1)
+
+        q = q.view(-1, self.num_heads, self._head_dim)
+        k = k.view(-1, self.num_key_value_heads, self._head_dim)
+        v = v.view(-1, self.num_key_value_heads, self._head_dim)
+        return q, k, v
+
+    @staticmethod
+    def _slice_position_bias(
+        position_bias: torch.Tensor,
+        query_length: int,
+        key_length: int,
+    ) -> torch.Tensor:
+        query_start = key_length - query_length
+        return position_bias[:, :, query_start:key_length, :key_length].squeeze(0)
+
+    def _local_position_bias(
+        self,
+        position_bias: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        if position_bias.shape[1] != self.num_heads:
+            head_start = self.tp_rank * self.num_heads
+            head_end = head_start + self.num_heads
+            if position_bias.shape[1] < head_end:
+                raise ValueError(
+                    f"T5 position bias has {position_bias.shape[1]} heads, "
+                    f"but rank {self.tp_rank} needs heads [{head_start}, {head_end})."
+                )
+            position_bias = position_bias[:, head_start:head_end]
+
+        return position_bias.to(
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        ).contiguous()
+
+    def _local_relative_attention_bias(
+        self,
+        relative_attention_bias: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        if relative_attention_bias.shape[0] != self.num_heads:
+            head_start = self.tp_rank * self.num_heads
+            head_end = head_start + self.num_heads
+            if relative_attention_bias.shape[0] < head_end:
+                raise ValueError(
+                    f"T5 relative attention bias has {relative_attention_bias.shape[0]} heads, "
+                    f"but rank {self.tp_rank} needs heads [{head_start}, {head_end})."
+                )
+            relative_attention_bias = relative_attention_bias[head_start:head_end]
+
+        return relative_attention_bias.to(
+            device=hidden_states.device,
+            dtype=hidden_states.dtype,
+        ).contiguous()
+
+    def forward(
+        self,
+        position_ids: Optional[torch.IntTensor] = None,
+        hidden_states: Optional[torch.Tensor] = None,
+        attn_metadata: Optional[AttentionMetadata] = None,
+        attention_mask: Optional[PredefinedAttentionMask] = None,
+        position_bias: Optional[torch.Tensor] = None,
+        relative_attention_bias: Optional[torch.Tensor] = None,
+        relative_attention_max_distance: int = 0,
+        **kwargs,
+    ) -> torch.Tensor:
+        if position_bias is None and relative_attention_bias is None:
+            return super().forward(
+                position_ids=position_ids,
+                hidden_states=hidden_states,
+                attn_metadata=attn_metadata,
+                attention_mask=attention_mask,
+                **kwargs,
+            )
+
+        assert attn_metadata is not None
+        assert hidden_states is not None
+        if attn_metadata.kv_cache_manager is not None:
+            if relative_attention_bias is None:
+                raise ValueError("Cached T5 attention requires a relative attention bias table.")
+            relative_attention_bias = self._local_relative_attention_bias(
+                relative_attention_bias,
+                hidden_states,
+            )
+            return super().forward(
+                position_ids=position_ids,
+                hidden_states=hidden_states,
+                attn_metadata=attn_metadata,
+                attention_mask=attention_mask,
+                relative_attention_bias=relative_attention_bias,
+                relative_attention_max_distance=relative_attention_max_distance,
+                **kwargs,
+            )
+
+        # Manual SDPA with additive position bias (no-KV-cache path).
+        assert position_bias is not None
+        position_bias = self._local_position_bias(position_bias, hidden_states)
+        num_tokens = attn_metadata.num_tokens
+        q, k, v = self._split_qkv(hidden_states, num_tokens)
+
+        # Per-request SDPA with position bias applied to each request's scores.
+        seq_lens = attn_metadata.seq_lens
+        offset = 0
+        outputs = []
+        for seq_len in seq_lens:
+            sl = int(seq_len)
+            q_s = q[offset : offset + sl].transpose(0, 1)  # (H, S, D)
+            k_s = k[offset : offset + sl].transpose(0, 1)
+            v_s = v[offset : offset + sl].transpose(0, 1)
+
+            scores = torch.matmul(q_s, k_s.transpose(-2, -1))
+            # position_bias: (1, H, qlen, klen) — slice to this request's lengths
+            scores = scores + self._slice_position_bias(position_bias, sl, sl)
+
+            if self._is_decoder:
+                causal_mask = torch.triu(
+                    torch.full((sl, sl), float("-inf"), device=scores.device, dtype=scores.dtype),
+                    diagonal=1,
+                )
+                scores = scores + causal_mask
+
+            attn_weights = F.softmax(scores.float(), dim=-1).to(q.dtype)
+            out = torch.matmul(attn_weights, v_s)  # (H, S, D)
+            outputs.append(out.transpose(0, 1))  # (S, H, D)
+            offset += sl
+
+        attn_output = torch.cat(outputs, dim=0)  # (T, H, D)
+        attn_output = attn_output.reshape(num_tokens, -1)
+        attn_output = self.o_proj(attn_output)
+        return attn_output
+
+
+class T5CrossAttention(CrossAttention):
+    """T5-style cross-attention with the same sizing conventions."""
+
+    def __init__(
+        self,
+        model_config: ModelConfig[T5Config],
+        layer_idx: Optional[int] = None,
+    ):
+        config = model_config.pretrained_config
+        num_heads = config.num_heads
+        num_kv_heads = _t5_num_kv_heads(config)
+        hidden_size = config.d_model
+
+        super().__init__(
+            hidden_size=hidden_size,
+            num_attention_heads=num_heads,
+            num_key_value_heads=num_kv_heads,
+            encoder_hidden_size=hidden_size,
+            bias=False,
+            layer_idx=layer_idx,
+            dtype=config.torch_dtype,
+            config=model_config,
+            q_scaling=_t5_q_scaling(config),
+            head_dim=_t5_head_dim(config),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Encoder layer
+# ---------------------------------------------------------------------------
+
+
+class T5EncoderLayer(EncoderLayer):
+    """T5 encoder layer: pre-norm self-attention + pre-norm MLP."""
+
+    def __init__(
+        self,
+        model_config: ModelConfig[T5Config],
+        layer_idx: int,
+    ):
+        super().__init__()
+        config = model_config.pretrained_config
+        hidden_size = config.d_model
+        intermediate_size = _t5_intermediate_size(config)
+        is_gated = _t5_is_gated_act(config)
+
+        act_fn = _t5_gated_act_fn(config) if is_gated else _t5_dense_act_fn(config)
+
+        self.self_attn = T5Attention(model_config, layer_idx=layer_idx, is_decoder=False)
+
+        self.input_layernorm = RMSNorm(
+            hidden_size=hidden_size,
+            eps=config.layer_norm_epsilon,
+            dtype=config.torch_dtype,
+        )
+        self.post_attention_layernorm = RMSNorm(
+            hidden_size=hidden_size,
+            eps=config.layer_norm_epsilon,
+            dtype=config.torch_dtype,
+        )
+
+        if is_gated:
+            self.mlp = GatedMLP(
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                bias=False,
+                activation=act_fn,
+                dtype=config.torch_dtype,
+                config=model_config,
+                layer_idx=layer_idx,
+            )
+        else:
+            self.mlp = MLP(
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                bias=False,
+                activation=act_fn,
+                dtype=config.torch_dtype,
+                config=model_config,
+                layer_idx=layer_idx,
+            )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        position_ids: Optional[torch.IntTensor] = None,
+        position_bias: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+
+        hidden_states = self.self_attn(
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            attn_metadata=attn_metadata,
+            attention_mask=PredefinedAttentionMask.FULL,
+            position_bias=position_bias,
+        )
+        hidden_states = residual + hidden_states
+        hidden_states = _clamp_fp16_infs(hidden_states)
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        hidden_states = _clamp_fp16_infs(hidden_states)
+
+        return hidden_states
+
+
+# ---------------------------------------------------------------------------
+# Decoder layer (self-attn + cross-attn + MLP)
+# ---------------------------------------------------------------------------
+
+
+class T5DecoderLayer(EncoderDecoderLayer):
+    """T5 decoder layer: pre-norm self-attention + pre-norm cross-attention +
+    pre-norm MLP."""
+
+    def __init__(
+        self,
+        model_config: ModelConfig[T5Config],
+        layer_idx: int,
+    ):
+        super().__init__()
+        config = model_config.pretrained_config
+        hidden_size = config.d_model
+        intermediate_size = _t5_intermediate_size(config)
+        is_gated = _t5_is_gated_act(config)
+
+        act_fn = _t5_gated_act_fn(config) if is_gated else _t5_dense_act_fn(config)
+
+        self.self_attn = T5Attention(model_config, layer_idx=layer_idx, is_decoder=True)
+
+        self.cross_attn = T5CrossAttention(model_config, layer_idx=layer_idx)
+
+        self.input_layernorm = RMSNorm(
+            hidden_size=hidden_size,
+            eps=config.layer_norm_epsilon,
+            dtype=config.torch_dtype,
+        )
+        self.post_attention_layernorm = RMSNorm(
+            hidden_size=hidden_size,
+            eps=config.layer_norm_epsilon,
+            dtype=config.torch_dtype,
+        )
+        self.cross_attn_layernorm = RMSNorm(
+            hidden_size=hidden_size,
+            eps=config.layer_norm_epsilon,
+            dtype=config.torch_dtype,
+        )
+
+        if is_gated:
+            self.mlp = GatedMLP(
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                bias=False,
+                activation=act_fn,
+                dtype=config.torch_dtype,
+                config=model_config,
+                layer_idx=layer_idx,
+            )
+        else:
+            self.mlp = MLP(
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                bias=False,
+                activation=act_fn,
+                dtype=config.torch_dtype,
+                config=model_config,
+                layer_idx=layer_idx,
+            )
+
+    def forward(
+        self,
+        position_ids: torch.IntTensor,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        cross_attn_metadata: Optional[AttentionMetadata] = None,
+        skip_cross_kv_projection: bool = False,
+        position_bias: Optional[torch.Tensor] = None,
+        relative_attention_bias: Optional[torch.Tensor] = None,
+        relative_attention_max_distance: int = 0,
+        **kwargs,
+    ) -> torch.Tensor:
+        # Self-attention (pre-norm)
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(
+            position_ids=position_ids,
+            hidden_states=hidden_states,
+            attn_metadata=attn_metadata,
+            attention_mask=PredefinedAttentionMask.CAUSAL,
+            position_bias=position_bias,
+            relative_attention_bias=relative_attention_bias,
+            relative_attention_max_distance=relative_attention_max_distance,
+        )
+        hidden_states = residual + hidden_states
+        hidden_states = _clamp_fp16_infs(hidden_states)
+
+        # Cross-attention (pre-norm)
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.cross_attn(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            attn_metadata=attn_metadata,
+            cross_attn_metadata=cross_attn_metadata,
+            skip_cross_kv_projection=skip_cross_kv_projection,
+        )
+        hidden_states = residual + hidden_states
+        hidden_states = _clamp_fp16_infs(hidden_states)
+
+        # MLP (pre-norm)
+        residual = hidden_states
+        hidden_states = self.cross_attn_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        hidden_states = _clamp_fp16_infs(hidden_states)
+
+        return hidden_states
+
+
+# ---------------------------------------------------------------------------
+# Encoder stack
+# ---------------------------------------------------------------------------
+
+
+class T5Encoder(nn.Module):
+    """T5 encoder: shared embedding → encoder layers → final RMSNorm."""
+
+    def __init__(self, model_config: ModelConfig[T5Config]):
+        super().__init__()
+        config = model_config.pretrained_config
+        num_layers = _t5_encoder_num_layers(config)
+
+        self.relative_position_bias = T5RelativePositionBias(
+            num_buckets=config.relative_attention_num_buckets,
+            num_heads=config.num_heads,
+            max_distance=config.relative_attention_max_distance,
+            is_decoder=False,
+            dtype=config.torch_dtype,
+        )
+
+        self.layers = nn.ModuleList(
+            [T5EncoderLayer(model_config, layer_idx=i) for i in range(num_layers)]
+        )
+        self.final_layernorm = RMSNorm(
+            hidden_size=config.d_model,
+            eps=config.layer_norm_epsilon,
+            dtype=config.torch_dtype,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        position_ids: Optional[torch.IntTensor] = None,
+    ) -> torch.Tensor:
+        seq_len = hidden_states.shape[0]
+        position_bias = self.relative_position_bias(seq_len, seq_len, hidden_states.device)
+
+        for layer in self.layers:
+            hidden_states = layer(
+                hidden_states=hidden_states,
+                attn_metadata=attn_metadata,
+                position_ids=position_ids,
+                position_bias=position_bias,
+            )
+        hidden_states = self.final_layernorm(hidden_states)
+        return hidden_states
+
+
+# ---------------------------------------------------------------------------
+# Decoder stack
+# ---------------------------------------------------------------------------
+
+
+class T5Decoder(nn.Module):
+    """T5 decoder: decoder layers → final RMSNorm."""
+
+    def __init__(self, model_config: ModelConfig[T5Config]):
+        super().__init__()
+        config = model_config.pretrained_config
+        num_layers = _t5_decoder_num_layers(config)
+
+        self.relative_position_bias = T5RelativePositionBias(
+            num_buckets=config.relative_attention_num_buckets,
+            num_heads=config.num_heads,
+            max_distance=config.relative_attention_max_distance,
+            is_decoder=True,
+            dtype=config.torch_dtype,
+        )
+
+        self.layers = nn.ModuleList(
+            [T5DecoderLayer(model_config, layer_idx=i) for i in range(num_layers)]
+        )
+        self.final_layernorm = RMSNorm(
+            hidden_size=config.d_model,
+            eps=config.layer_norm_epsilon,
+            dtype=config.torch_dtype,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        position_ids: Optional[torch.IntTensor] = None,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        cross_attn_metadata: Optional[AttentionMetadata] = None,
+        skip_cross_kv_projection: bool = False,
+    ) -> torch.Tensor:
+        position_bias = None
+        relative_attention_bias = None
+        relative_attention_max_distance = 0
+        if attn_metadata.kv_cache_manager is None:
+            seq_len = hidden_states.shape[0]
+            position_bias = self.relative_position_bias(seq_len, seq_len, hidden_states.device)
+        else:
+            relative_attention_bias = (
+                self.relative_position_bias.relative_attention_bias.weight.transpose(0, 1)
+            )
+            relative_attention_max_distance = self.relative_position_bias.max_distance
+
+        for layer in self.layers:
+            hidden_states = layer(
+                position_ids=position_ids,
+                hidden_states=hidden_states,
+                attn_metadata=attn_metadata,
+                encoder_hidden_states=encoder_hidden_states,
+                cross_attn_metadata=cross_attn_metadata,
+                skip_cross_kv_projection=skip_cross_kv_projection,
+                position_bias=position_bias,
+                relative_attention_bias=relative_attention_bias,
+                relative_attention_max_distance=relative_attention_max_distance,
+            )
+        hidden_states = self.final_layernorm(hidden_states)
+        return hidden_states
+
+
+# ---------------------------------------------------------------------------
+# Top-level model
+# ---------------------------------------------------------------------------
+
+
+class T5Model(nn.Module):
+    """Full T5 encoder-decoder model body (no lm_head).
+
+    The shared embedding table is used for both encoder and decoder inputs
+    (T5 ties encoder/decoder embeddings by default).
+    """
+
+    def __init__(self, model_config: ModelConfig[T5Config]):
+        super().__init__()
+        self.model_config = model_config
+        config = model_config.pretrained_config
+
+        self.shared_embedding = Embedding(
+            config.vocab_size,
+            config.d_model,
+            dtype=config.torch_dtype,
+            mapping=model_config.mapping,
+            tensor_parallel_mode=TensorParallelMode.COLUMN,
+            gather_output=True,
+        )
+
+        self.encoder = T5Encoder(model_config)
+        self.decoder = T5Decoder(model_config)
+
+    def forward(
+        self,
+        attn_metadata: AttentionMetadata,
+        input_ids: Optional[torch.IntTensor] = None,
+        encoder_input_ids: Optional[torch.IntTensor] = None,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.IntTensor] = None,
+        encoder_position_ids: Optional[torch.IntTensor] = None,
+        encoder_attn_metadata: Optional[AttentionMetadata] = None,
+        cross_attn_metadata: Optional[AttentionMetadata] = None,
+        skip_cross_kv_projection: bool = False,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """Forward the full encoder-decoder model.
+
+        When ``encoder_hidden_states`` is already provided (from a previous
+        encoder pass cached by the runtime), skip the encoder entirely.
+
+        Args:
+            attn_metadata: Decoder-side attention metadata.
+            input_ids: Decoder input token IDs.
+            encoder_input_ids: Encoder input token IDs.
+            encoder_hidden_states: Pre-computed encoder output.
+            position_ids: Decoder position IDs.
+            encoder_position_ids: Encoder position IDs.
+            encoder_attn_metadata: Encoder-side attention metadata.
+            cross_attn_metadata: Metadata for cross-attention layers.
+            skip_cross_kv_projection: If ``True``, skip K/V projection in
+                cross-attention (generation steps after the first context step).
+            inputs_embeds: Pre-computed decoder input embeddings.
+        """
+        if encoder_hidden_states is None and encoder_input_ids is not None:
+            assert encoder_attn_metadata is not None
+            encoder_embeds = self.shared_embedding(encoder_input_ids)
+            encoder_hidden_states = self.encoder(
+                hidden_states=encoder_embeds,
+                attn_metadata=encoder_attn_metadata,
+                position_ids=encoder_position_ids,
+            )
+
+        if inputs_embeds is None:
+            assert input_ids is not None
+            inputs_embeds = self.shared_embedding(input_ids)
+
+        decoder_output = self.decoder(
+            hidden_states=inputs_embeds,
+            attn_metadata=attn_metadata,
+            position_ids=position_ids,
+            encoder_hidden_states=encoder_hidden_states,
+            cross_attn_metadata=cross_attn_metadata,
+            skip_cross_kv_projection=skip_cross_kv_projection,
+        )
+        return decoder_output
+
+
+@register_auto_model("T5ForConditionalGeneration")
+class T5ForConditionalGeneration(nn.Module, metaclass=PostInitCaller):
+    """T5 encoder-decoder model with LM head for conditional generation.
+
+    Registered for the HF architecture name ``T5ForConditionalGeneration``.
+    """
+
+    def __init__(self, model_config: ModelConfig[T5Config]):
+        super().__init__()
+        self.model_config = model_config
+        config = model_config.pretrained_config
+
+        self.model = T5Model(model_config)
+
+        self.lm_head = LMHead(
+            config.vocab_size,
+            config.d_model,
+            dtype=config.torch_dtype,
+            mapping=model_config.mapping,
+            tensor_parallel_mode=TensorParallelMode.COLUMN,
+            gather_output=True,
+            reduce_output=False,
+        )
+
+        # T5 ties lm_head to shared embedding by default
+        if getattr(config, "tie_word_embeddings", True):
+            self.lm_head.weight = self.model.shared_embedding.weight
+
+        self.logits_processor = LogitsProcessor()
+
+        # T5 convention: scale logits by 1/sqrt(d_model)
+        self.rescale_before_lm_head = True
+        self.d_model = config.d_model
+
+    def __post_init__(self):
+        for _, module in self.named_modules():
+            if callable(getattr(module, "create_weights", None)):
+                module.create_weights()
+
+    def __pp_init__(self):
+        pass
+
+    @property
+    def config(self):
+        return self.model_config.pretrained_config
+
+    def forward(
+        self,
+        attn_metadata: AttentionMetadata,
+        input_ids: Optional[torch.IntTensor] = None,
+        position_ids: Optional[torch.IntTensor] = None,
+        encoder_input_ids: Optional[torch.IntTensor] = None,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        encoder_position_ids: Optional[torch.IntTensor] = None,
+        encoder_attn_metadata: Optional[AttentionMetadata] = None,
+        cross_attn_metadata: Optional[AttentionMetadata] = None,
+        skip_cross_kv_projection: bool = False,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        return_context_logits: bool = False,
+        **kwargs,
+    ) -> torch.Tensor:
+        hidden_states = self.model(
+            attn_metadata=attn_metadata,
+            input_ids=input_ids,
+            encoder_input_ids=encoder_input_ids,
+            encoder_hidden_states=encoder_hidden_states,
+            position_ids=position_ids,
+            encoder_position_ids=encoder_position_ids,
+            encoder_attn_metadata=encoder_attn_metadata,
+            cross_attn_metadata=cross_attn_metadata,
+            skip_cross_kv_projection=skip_cross_kv_projection,
+            inputs_embeds=inputs_embeds,
+        )
+
+        if self.rescale_before_lm_head:
+            hidden_states = hidden_states * (self.d_model**-0.5)
+
+        return self.logits_processor.forward(
+            hidden_states,
+            self.lm_head,
+            attn_metadata,
+            return_context_logits,
+        )
+
+    def infer_max_seq_len(self) -> int:
+        return 512
+
+    def load_weights(self, weights: Dict, **kwargs):
+        config = self.model_config.pretrained_config
+        tllm_weights = _convert_hf_t5_weights(weights, config, dtype=self.model_config.torch_dtype)
+
+        if "lm_head.weight" in weights:
+            self.lm_head.weight = nn.Parameter(torch.empty_like(self.lm_head.weight))
+
+        for name, module in self.named_modules():
+            if len(list(module.parameters(recurse=False))) == 0:
+                continue
+            if name not in tllm_weights:
+                continue
+            w = tllm_weights[name]
+            if hasattr(module, "load_weights"):
+                module.load_weights(weights=w)
+            else:
+                for n, p in module.named_parameters(recurse=False):
+                    if n in w[0]:
+                        p.data.copy_(w[0][n][:])
+
+
+def _convert_hf_t5_weights(
+    hf_weights: Dict[str, torch.Tensor],
+    config: T5Config,
+    dtype: Optional[torch.dtype] = None,
+) -> Dict:
+    """Map HuggingFace T5 state_dict keys to TRT-LLM module-tree keys.
+
+    Returns a dict keyed by TRT-LLM module path, where each value is a list of
+    weight dicts suitable for ``module.load_weights(weights=...)``.
+
+    Args:
+        hf_weights: HuggingFace model ``state_dict``.
+        config: HuggingFace ``T5Config``.
+        dtype: Target precision.  When specified, every weight tensor is cast
+            to this dtype before being returned — mirroring the legacy TRT path's
+            ``convert_weight_to_dtype(params, config.dtype)`` logic.
+
+    HF T5 weight layout:
+        shared.weight
+        encoder.block.{i}.layer.0.SelfAttention.{q,k,v,o}.weight
+        encoder.block.{i}.layer.0.layer_norm.weight
+        encoder.block.{i}.layer.{1}.DenseReluDense.{wi,wo}.weight  (non-gated)
+        encoder.block.{i}.layer.{1}.DenseReluDense.{wi_0,wi_1,wo}.weight (gated)
+        encoder.block.{i}.layer.{1}.layer_norm.weight
+        encoder.final_layer_norm.weight
+        decoder.block.{i}.layer.0.SelfAttention.{q,k,v,o}.weight
+        decoder.block.{i}.layer.1.EncDecAttention.{q,k,v,o}.weight
+        decoder.block.{i}.layer.{0,1,2}.layer_norm.weight
+        decoder.block.{i}.layer.2.DenseReluDense.{wi,wo|wi_0,wi_1,wo}.weight
+        decoder.final_layer_norm.weight
+        lm_head.weight
+    """
+    if dtype is not None:
+        hf_weights = {k: v.to(dtype) for k, v in hf_weights.items()}
+
+    out: Dict[str, list] = {}
+    is_gated = getattr(config, "is_gated_act", False)
+    enc_layers = config.num_layers
+    dec_layers = getattr(config, "num_decoder_layers", None) or config.num_layers
+
+    def _get(key: str) -> torch.Tensor:
+        if key in hf_weights:
+            return hf_weights[key]
+        raise KeyError(f"Missing expected HF weight: {key}")
+
+    # Shared embedding
+    out["model.shared_embedding"] = [{"weight": _get("shared.weight")}]
+
+    # LM head
+    if "lm_head.weight" in hf_weights:
+        out["lm_head"] = [{"weight": _get("lm_head.weight")}]
+
+    # Encoder
+    for i in range(enc_layers):
+        pfx = f"encoder.block.{i}"
+        tgt = f"model.encoder.layers.{i}"
+
+        # Self-attention (fused QKV in TRT-LLM)
+        out[f"{tgt}.self_attn.qkv_proj"] = [
+            {"weight": _get(f"{pfx}.layer.0.SelfAttention.q.weight")},
+            {"weight": _get(f"{pfx}.layer.0.SelfAttention.k.weight")},
+            {"weight": _get(f"{pfx}.layer.0.SelfAttention.v.weight")},
+        ]
+        out[f"{tgt}.self_attn.o_proj"] = [{"weight": _get(f"{pfx}.layer.0.SelfAttention.o.weight")}]
+
+        # Pre-attention layer norm
+        out[f"{tgt}.input_layernorm"] = [{"weight": _get(f"{pfx}.layer.0.layer_norm.weight")}]
+
+        # MLP (layer.1 for encoder)
+        if is_gated:
+            out[f"{tgt}.mlp.gate_up_proj"] = [
+                {"weight": _get(f"{pfx}.layer.1.DenseReluDense.wi_0.weight")},
+                {"weight": _get(f"{pfx}.layer.1.DenseReluDense.wi_1.weight")},
+            ]
+        else:
+            out[f"{tgt}.mlp.up_proj"] = [
+                {"weight": _get(f"{pfx}.layer.1.DenseReluDense.wi.weight")}
+            ]
+        out[f"{tgt}.mlp.down_proj"] = [{"weight": _get(f"{pfx}.layer.1.DenseReluDense.wo.weight")}]
+
+        # Post-attention (pre-MLP) layer norm
+        out[f"{tgt}.post_attention_layernorm"] = [
+            {"weight": _get(f"{pfx}.layer.1.layer_norm.weight")}
+        ]
+
+    # Encoder relative position bias (only layer 0 in HF)
+    rpb_key = "encoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight"
+    if rpb_key in hf_weights:
+        out["model.encoder.relative_position_bias.relative_attention_bias"] = [
+            {"weight": _get(rpb_key)}
+        ]
+
+    # Encoder final layer norm
+    out["model.encoder.final_layernorm"] = [{"weight": _get("encoder.final_layer_norm.weight")}]
+
+    # Decoder
+    for i in range(dec_layers):
+        pfx = f"decoder.block.{i}"
+        tgt = f"model.decoder.layers.{i}"
+
+        # Self-attention (fused QKV)
+        out[f"{tgt}.self_attn.qkv_proj"] = [
+            {"weight": _get(f"{pfx}.layer.0.SelfAttention.q.weight")},
+            {"weight": _get(f"{pfx}.layer.0.SelfAttention.k.weight")},
+            {"weight": _get(f"{pfx}.layer.0.SelfAttention.v.weight")},
+        ]
+        out[f"{tgt}.self_attn.o_proj"] = [{"weight": _get(f"{pfx}.layer.0.SelfAttention.o.weight")}]
+
+        # Self-attention layer norm
+        out[f"{tgt}.input_layernorm"] = [{"weight": _get(f"{pfx}.layer.0.layer_norm.weight")}]
+
+        # Cross-attention (separate projections in CrossAttention module)
+        out[f"{tgt}.cross_attn.q_proj"] = [
+            {"weight": _get(f"{pfx}.layer.1.EncDecAttention.q.weight")}
+        ]
+        out[f"{tgt}.cross_attn.k_proj"] = [
+            {"weight": _get(f"{pfx}.layer.1.EncDecAttention.k.weight")}
+        ]
+        out[f"{tgt}.cross_attn.v_proj"] = [
+            {"weight": _get(f"{pfx}.layer.1.EncDecAttention.v.weight")}
+        ]
+        out[f"{tgt}.cross_attn.o_proj"] = [
+            {"weight": _get(f"{pfx}.layer.1.EncDecAttention.o.weight")}
+        ]
+
+        # Cross-attention layer norm (post_attention_layernorm in T5DecoderLayer)
+        out[f"{tgt}.post_attention_layernorm"] = [
+            {"weight": _get(f"{pfx}.layer.1.layer_norm.weight")}
+        ]
+
+        # MLP (layer.2 for decoder)
+        if is_gated:
+            out[f"{tgt}.mlp.gate_up_proj"] = [
+                {"weight": _get(f"{pfx}.layer.2.DenseReluDense.wi_0.weight")},
+                {"weight": _get(f"{pfx}.layer.2.DenseReluDense.wi_1.weight")},
+            ]
+        else:
+            out[f"{tgt}.mlp.up_proj"] = [
+                {"weight": _get(f"{pfx}.layer.2.DenseReluDense.wi.weight")}
+            ]
+        out[f"{tgt}.mlp.down_proj"] = [{"weight": _get(f"{pfx}.layer.2.DenseReluDense.wo.weight")}]
+
+        # Pre-MLP layer norm
+        out[f"{tgt}.cross_attn_layernorm"] = [{"weight": _get(f"{pfx}.layer.2.layer_norm.weight")}]
+
+    # Decoder relative position bias (only layer 0 in HF)
+    rpb_key = "decoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight"
+    if rpb_key in hf_weights:
+        out["model.decoder.relative_position_bias.relative_attention_bias"] = [
+            {"weight": _get(rpb_key)}
+        ]
+
+    # Decoder final layer norm
+    out["model.decoder.final_layernorm"] = [{"weight": _get("decoder.final_layer_norm.weight")}]
+
+    return out

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -112,28 +112,35 @@ def attn_custom_op_inplace(
     attention_window_size: Optional[int],
     attention_mask_data: Optional[torch.Tensor],
     attention_sinks: Optional[torch.Tensor],
+    relative_attention_bias: Optional[torch.Tensor],
+    relative_attention_max_distance: int,
     layer_idx: str,
     output: torch.Tensor,
     output_sf: Optional[torch.Tensor],
 ) -> None:
     metadata, attn_layer = extract_extra_attrs(layer_idx, "attn")
+    rel_attn_max_distance = relative_attention_max_distance
     mask = PredefinedAttentionMask(
         attention_mask
     ) if attention_mask != CustomAttentionMask.CUSTOM else CustomAttentionMask(
         attention_mask)
     # NVFP4 output cannot be supported by torch compile for TRTLLM backend.
-    attn_layer._attn_impl(q,
-                          k,
-                          v,
-                          metadata,
-                          mask,
-                          mrope_rotary_cos_sin,
-                          mrope_position_deltas,
-                          attention_window_size,
-                          attention_mask_data,
-                          output=output,
-                          output_sf=output_sf,
-                          attention_sinks=attention_sinks)
+    attn_layer._attn_impl(
+        q,
+        k,
+        v,
+        metadata,
+        mask,
+        mrope_rotary_cos_sin,
+        mrope_position_deltas,
+        attention_window_size,
+        attention_mask_data,
+        output=output,
+        output_sf=output_sf,
+        attention_sinks=attention_sinks,
+        relative_attention_bias=relative_attention_bias,
+        relative_attention_max_distance=rel_attn_max_distance,
+    )
 
 
 def _helix_post_process(
@@ -708,9 +715,12 @@ class Attention(nn.Module):
         output: Optional[torch.Tensor] = None,
         output_sf: Optional[torch.Tensor] = None,
         attention_sinks: Optional[torch.Tensor] = None,
+        relative_attention_bias: Optional[torch.Tensor] = None,
+        relative_attention_max_distance: int = 0,
         has_lora: bool = False,
     ):
         num_tokens = attn_metadata.num_tokens
+        rel_attn_max_distance = relative_attention_max_distance
 
         q = q[:num_tokens, :]
         if k is not None:
@@ -752,6 +762,8 @@ class Attention(nn.Module):
                     attention_mask_data=attention_mask_data,
                     softmax_stats_tensor=softmax_stats,
                     attention_sinks=attention_sinks,
+                    relative_attention_bias=relative_attention_bias,
+                    relative_attention_max_distance=rel_attn_max_distance,
                 ))
             if isinstance(attn_output, tuple):
                 attn_output = attn_output[0]
@@ -791,6 +803,8 @@ class Attention(nn.Module):
                 output=output[:num_tokens, :] if output is not None else None,
                 output_sf=output_sf,
                 attention_sinks=attention_sinks,
+                relative_attention_bias=relative_attention_bias,
+                relative_attention_max_distance=rel_attn_max_distance,
             ))
         if isinstance(attn_output, tuple):
             assert len(
@@ -810,10 +824,13 @@ class Attention(nn.Module):
         attention_mask_data: Optional[torch.Tensor],
         mrope_config: Optional[dict],
         attention_sinks: Optional[torch.Tensor] = None,
+        relative_attention_bias: Optional[torch.Tensor] = None,
+        relative_attention_max_distance: int = 0,
         has_lora: bool = False,
     ):
         mrope_rotary_cos_sin = None
         mrope_position_deltas = None
+        rel_attn_max_distance = relative_attention_max_distance
         if mrope_config is not None:
             if "mrope_rotary_cos_sin" in mrope_config:
                 mrope_rotary_cos_sin = mrope_config["mrope_rotary_cos_sin"]
@@ -842,22 +859,28 @@ class Attention(nn.Module):
                 attention_window_size,
                 attention_mask_data,
                 attention_sinks,
+                relative_attention_bias,
+                relative_attention_max_distance,
                 self.layer_idx_str,
                 output,
                 output_sf,
             )
         else:
-            output, output_sf = self._attn_impl(q,
-                                                k,
-                                                v,
-                                                attn_metadata,
-                                                attention_mask,
-                                                mrope_rotary_cos_sin,
-                                                mrope_position_deltas,
-                                                attention_window_size,
-                                                attention_mask_data,
-                                                attention_sinks=attention_sinks,
-                                                has_lora=has_lora)
+            output, output_sf = self._attn_impl(
+                q,
+                k,
+                v,
+                attn_metadata,
+                attention_mask,
+                mrope_rotary_cos_sin,
+                mrope_position_deltas,
+                attention_window_size,
+                attention_mask_data,
+                attention_sinks=attention_sinks,
+                relative_attention_bias=relative_attention_bias,
+                relative_attention_max_distance=rel_attn_max_distance,
+                has_lora=has_lora,
+            )
         if output_sf is not None:
             output = Fp4QuantizedTensor(output, output_sf)
 
@@ -875,6 +898,8 @@ class Attention(nn.Module):
         attention_window_size: Optional[int] = None,
         attention_mask_data: Optional[torch.Tensor] = None,
         attention_sinks: Optional[torch.Tensor] = None,
+        relative_attention_bias: Optional[torch.Tensor] = None,
+        relative_attention_max_distance: int = 0,
         **kwargs,
     ) -> torch.Tensor:
         """
@@ -939,17 +964,24 @@ class Attention(nn.Module):
 
         if attention_sinks is not None:
             assert self.attn_backend == "TRTLLM", "Attention sinks are only supported for TRTLLM backend."
+        if relative_attention_bias is not None:
+            assert self.attn_backend == "TRTLLM", "Relative attention bias is only supported for TRTLLM backend."
 
-        attn_output = self.forward_impl(q,
-                                        k,
-                                        v,
-                                        attn_metadata,
-                                        attention_mask,
-                                        attention_window_size,
-                                        attention_mask_data,
-                                        mrope_config=mrope_config,
-                                        attention_sinks=attention_sinks,
-                                        has_lora=bool(lora_params))
+        rel_attn_max_distance = relative_attention_max_distance
+        attn_output = self.forward_impl(
+            q,
+            k,
+            v,
+            attn_metadata,
+            attention_mask,
+            attention_window_size,
+            attention_mask_data,
+            mrope_config=mrope_config,
+            attention_sinks=attention_sinks,
+            relative_attention_bias=relative_attention_bias,
+            relative_attention_max_distance=rel_attn_max_distance,
+            has_lora=bool(lora_params),
+        )
 
         if self.attn_output_gate:
             gate = torch.sigmoid(gate)

--- a/tensorrt_llm/_torch/modules/cross_attention.py
+++ b/tensorrt_llm/_torch/modules/cross_attention.py
@@ -1,0 +1,291 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Cross-attention module for encoder-decoder models.
+
+Unlike self-attention, cross-attention uses Q from the decoder hidden states
+and K/V from the encoder output (or from a cached cross-KV pool after the
+first decoder context step).
+"""
+
+from typing import Optional
+
+import torch
+from torch import nn
+
+from ..attention_backend import AttentionMetadata
+from ..attention_backend.interface import AttentionBackend, PredefinedAttentionMask
+from ..attention_backend.utils import create_attention
+from ..distributed import AllReduceParams
+from ..model_config import ModelConfig
+from .linear import Linear, TensorParallelMode
+
+
+class CrossAttention(nn.Module):
+    """Cross-attention layer for encoder-decoder models.
+
+    Computes attention where Q comes from decoder hidden states and K/V come
+    from encoder output. On the first decoder context step, K/V are projected
+    from encoder_hidden_states and written into the cross-KV cache pool. On
+    subsequent generation steps, K/V are read from the cache without
+    re-projection.
+
+    The cross-attention sub-layer honors ``ModelConfig.attn_backend``: when
+    set to ``"TRTLLM"`` it dispatches through the production C++ attention op
+    on every supported architecture. Blackwell uses the ``trtllm_gen`` kernels,
+    while earlier architectures use the legacy ``thop.attention`` wrapper.
+
+    Encoder and decoder self-attention are unaffected and continue to use
+    whatever backend ``ModelConfig.attn_backend`` selects.
+    """
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int,
+        num_attention_heads: int,
+        num_key_value_heads: int,
+        encoder_hidden_size: Optional[int] = None,
+        max_position_embeddings: int = 512,
+        bias: bool = False,
+        layer_idx: Optional[int] = None,
+        dtype: Optional[torch.dtype] = None,
+        dense_bias: Optional[bool] = None,
+        config: Optional[ModelConfig] = None,
+        q_scaling: float = 1.0,
+        head_dim: Optional[int] = None,
+    ):
+        super().__init__()
+        self.layer_idx = layer_idx
+        config = config or ModelConfig()
+        self.hidden_size = hidden_size
+        self.encoder_hidden_size = encoder_hidden_size or hidden_size
+        self.num_heads = num_attention_heads
+        if head_dim is not None:
+            self.head_dim = head_dim
+        else:
+            self.head_dim = getattr(config.pretrained_config, "head_dim", None)
+            if not isinstance(self.head_dim, int):
+                self.head_dim = self.hidden_size // self.num_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.q_scaling = q_scaling
+
+        if dense_bias is None:
+            dense_bias = bias
+
+        self.mapping = config.mapping
+        tp_size = self.mapping.tp_size
+        if self.mapping.enable_attention_dp:
+            tp_size = 1
+
+        assert self.num_heads % tp_size == 0
+        self.num_heads = self.num_heads // tp_size
+        self.num_key_value_heads = (self.num_key_value_heads + tp_size - 1) // tp_size
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_key_value_heads * self.head_dim
+
+        mapping = config.mapping
+
+        self.q_proj = Linear(
+            self.hidden_size,
+            tp_size * self.q_size,
+            bias=bias,
+            dtype=dtype,
+            mapping=mapping,
+            tensor_parallel_mode=TensorParallelMode.COLUMN,
+            quant_config=config.get_quant_config(),
+            skip_create_weights_in_init=config.skip_create_weights_in_init,
+        )
+
+        self.k_proj = Linear(
+            self.encoder_hidden_size,
+            tp_size * self.kv_size,
+            bias=bias,
+            dtype=dtype,
+            mapping=mapping,
+            tensor_parallel_mode=TensorParallelMode.COLUMN,
+            quant_config=config.get_quant_config(),
+            skip_create_weights_in_init=config.skip_create_weights_in_init,
+        )
+
+        self.v_proj = Linear(
+            self.encoder_hidden_size,
+            tp_size * self.kv_size,
+            bias=bias,
+            dtype=dtype,
+            mapping=mapping,
+            tensor_parallel_mode=TensorParallelMode.COLUMN,
+            quant_config=config.get_quant_config(),
+            skip_create_weights_in_init=config.skip_create_weights_in_init,
+        )
+
+        self.o_proj = Linear(
+            tp_size * self.q_size,
+            self.hidden_size,
+            bias=dense_bias,
+            dtype=dtype,
+            mapping=mapping,
+            tensor_parallel_mode=TensorParallelMode.ROW,
+            quant_config=config.get_quant_config(),
+            skip_create_weights_in_init=config.skip_create_weights_in_init,
+            reduce_output=True,
+        )
+
+        # Cross-attention backend selection honors ``ModelConfig.attn_backend``
+        # directly, mirroring the behavior of self-attention.
+        self.attn: AttentionBackend = create_attention(
+            config.attn_backend,
+            layer_idx,
+            self.num_heads,
+            self.head_dim,
+            self.num_key_value_heads,
+            q_scaling=self.q_scaling,
+        )
+
+        if not config.skip_create_weights_in_init:
+            self.create_weights()
+
+    def create_weights(self):
+        self.q_proj.create_weights()
+        self.k_proj.create_weights()
+        self.v_proj.create_weights()
+        self.o_proj.create_weights()
+
+    @staticmethod
+    def _infer_encoder_seq_lens(
+        encoder_hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+    ) -> torch.Tensor:
+        """Infer per-request encoder lengths from ``encoder_hidden_states``.
+
+        Used as a fallback when ``cross_attn_metadata`` is not provided.
+        Only single-request batches are unambiguous; multi-request batches
+        require the caller to supply ``cross_attn_metadata`` with explicit
+        ``seq_lens_kv``.
+        """
+        num_encoder_tokens = encoder_hidden_states.shape[0]
+        num_requests = int(attn_metadata.seq_lens.numel())
+        if num_requests == 1:
+            return torch.tensor([num_encoder_tokens], dtype=torch.int32)
+        if num_encoder_tokens % num_requests != 0:
+            raise ValueError(
+                "Cannot infer encoder_seq_lens from encoder_hidden_states for "
+                f"a multi-request batch (num_requests={num_requests}, "
+                f"num_encoder_tokens={num_encoder_tokens}). "
+                "Pass an explicit cross_attn_metadata with seq_lens_kv set."
+            )
+        per_request = num_encoder_tokens // num_requests
+        return torch.full((num_requests,), per_request, dtype=torch.int32)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: Optional[torch.Tensor],
+        attn_metadata: AttentionMetadata,
+        cross_attn_metadata: Optional[AttentionMetadata] = None,
+        skip_cross_kv_projection: bool = False,
+        all_reduce_params: Optional[AllReduceParams] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """Forward pass for cross-attention.
+
+        Args:
+            hidden_states: Decoder hidden states ``[num_tokens, hidden_size]``.
+            encoder_hidden_states: Encoder output. Required on the first
+                decoder context step (when ``skip_cross_kv_projection`` is
+                ``False``). ``None`` for generation steps.
+            attn_metadata: Decoder-side attention metadata (Q-side lengths).
+            cross_attn_metadata: Cross-attention metadata carrying encoder
+                K/V-side lengths, cross-pool block tables, etc. Must satisfy
+                ``cross_attn_metadata.is_cross is True`` (i.e. the K/V-side
+                ``seq_lens_kv`` differs from the Q-side ``seq_lens``). When
+                ``None``, the module auto-builds a stateless cross metadata
+                from ``attn_metadata`` and the inferred encoder lengths
+                (single-request batches only — see
+                :meth:`_infer_encoder_seq_lens`).
+            skip_cross_kv_projection: When ``True``, K/V are read from the
+                cross-KV cache without re-projection (decoder generation
+                steps). When ``False``, K/V are projected from
+                ``encoder_hidden_states`` and written into the cache (first
+                decoder context step).
+            all_reduce_params: AllReduce parameters for TP output projection.
+
+        Returns:
+            Output tensor ``[num_tokens, hidden_size]``.
+        """
+        # Resolve / build the cross-attention metadata. We require that the
+        # backend sees ``metadata.is_cross is True`` so that the no-KV-cache
+        # path uses the encoder-side cu_seqlens, and so that the with-KV-cache
+        # path uses the cross pool.
+        metadata = cross_attn_metadata
+        if metadata is None:
+            if skip_cross_kv_projection:
+                raise ValueError(
+                    "cross_attn_metadata is required when "
+                    "skip_cross_kv_projection=True: the module needs the "
+                    "cross-pool block tables and cached encoder lengths to "
+                    "read K/V from the cache."
+                )
+            assert encoder_hidden_states is not None, (
+                "encoder_hidden_states is required when cross-KV projection "
+                "is not skipped (first decoder context step)."
+            )
+            encoder_seq_lens = self._infer_encoder_seq_lens(encoder_hidden_states, attn_metadata)
+            metadata = attn_metadata.create_cross_metadata(
+                encoder_seq_lens=encoder_seq_lens,
+                enc_dec_kv_cache_manager=None,
+            )
+        else:
+            assert metadata.is_cross, (
+                "cross_attn_metadata.is_cross must be True. Build it via "
+                "attn_metadata.create_cross_metadata(encoder_seq_lens, "
+                "enc_dec_kv_cache_manager) so seq_lens_kv differs from "
+                "seq_lens."
+            )
+
+        q = self.q_proj(hidden_states)
+
+        if not skip_cross_kv_projection:
+            assert encoder_hidden_states is not None, (
+                "encoder_hidden_states is required when cross-KV projection "
+                "is not skipped (first decoder context step)."
+            )
+            k = self.k_proj(encoder_hidden_states)
+            v = self.v_proj(encoder_hidden_states)
+        else:
+            # Generation step: skip projection, K/V are already in the
+            # cross-KV cache (written during the first decoder context step).
+            # The backend reads them from ``metadata.kv_cache_manager``.
+            assert metadata.kv_cache_manager is not None, (
+                "skip_cross_kv_projection=True requires a populated "
+                "cross-KV cache manager on cross_attn_metadata."
+            )
+            k = None
+            v = None
+
+        num_tokens = attn_metadata.num_tokens
+        q = q[:num_tokens, :]
+
+        attn_output = self.attn.forward(
+            q,
+            k,
+            v,
+            metadata,
+            attention_mask=PredefinedAttentionMask.FULL,
+        )
+        if isinstance(attn_output, tuple):
+            attn_output = attn_output[0]
+
+        attn_output = self.o_proj(attn_output, all_reduce_params=all_reduce_params)
+        return attn_output

--- a/tensorrt_llm/_torch/modules/encoder_decoder_layer.py
+++ b/tensorrt_llm/_torch/modules/encoder_decoder_layer.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Abstract base classes for encoder layers and encoder-decoder layers."""
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+import torch
+from torch import nn
+
+from ..attention_backend import AttentionMetadata
+
+
+class EncoderLayer(nn.Module, ABC):
+    """Abstract base class for encoder layers (self-attention only, non-causal)."""
+
+    @abstractmethod
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        position_ids: Optional[torch.IntTensor] = None,
+        **kwargs,
+    ) -> torch.Tensor: ...
+
+
+class EncoderDecoderLayer(nn.Module, ABC):
+    """Abstract base class for decoder layers with cross-attention.
+
+    Order: self-attention → cross-attention → MLP.
+    """
+
+    @abstractmethod
+    def forward(
+        self,
+        position_ids: torch.IntTensor,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        cross_attn_metadata: Optional[AttentionMetadata] = None,
+        skip_cross_kv_projection: bool = False,
+        **kwargs,
+    ) -> torch.Tensor: ...

--- a/tensorrt_llm/_torch/modules/rms_norm.py
+++ b/tensorrt_llm/_torch/modules/rms_norm.py
@@ -186,7 +186,8 @@ class RMSNorm(nn.Module):
                     gather=True,
                     use_gemma=self.use_gemma,
                 )
-        elif IS_FLASHINFER_AVAILABLE:
+        elif IS_FLASHINFER_AVAILABLE and hidden_states.dtype in (
+                torch.float16, torch.bfloat16):
             from ..custom_ops import (flashinfer_fused_add_rmsnorm,
                                       flashinfer_gemma_fused_add_rmsnorm,
                                       flashinfer_gemma_rmsnorm,

--- a/tests/unittest/_torch/modeling/test_modeling_enc_dec.py
+++ b/tests/unittest/_torch/modeling/test_modeling_enc_dec.py
@@ -1,0 +1,650 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for PyTorch encoder-decoder model foundations.
+
+These tests intentionally use the VANILLA attention backend. TRTLLM backend,
+dual-pool KV cache, scheduler, and public LLM API coverage live in later PRs
+in the encoder-decoder stack.
+"""
+
+import os
+import unittest
+from copy import deepcopy
+from pathlib import Path
+
+import torch
+from transformers import BartConfig, T5Config
+
+from tensorrt_llm._torch.attention_backend.utils import get_attention_backend
+from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.models.modeling_bart import BartDecoderLayer, BartEncoderLayer, BartModel
+from tensorrt_llm._torch.models.modeling_t5 import (
+    T5DecoderLayer,
+    T5Encoder,
+    T5EncoderLayer,
+    T5Model,
+)
+from tensorrt_llm._torch.modules.cross_attention import CrossAttention
+
+
+def _make_vanilla_metadata(seq_lens):
+    metadata_cls = get_attention_backend("VANILLA").Metadata
+    seq_lens_tensor = torch.tensor(seq_lens, dtype=torch.int32)
+    total_tokens = sum(seq_lens)
+    num_requests = len(seq_lens)
+    metadata = metadata_cls(
+        max_num_requests=num_requests,
+        max_num_tokens=total_tokens,
+        kv_cache_manager=None,
+        request_ids=list(range(num_requests)),
+        prompt_lens=seq_lens,
+        seq_lens=seq_lens_tensor,
+        num_contexts=num_requests,
+    )
+    metadata.max_seq_len = max(seq_lens)
+    metadata.prepare()
+    return metadata
+
+
+SMALL_T5_CONFIG = {
+    "architectures": ["T5ForConditionalGeneration"],
+    "d_model": 64,
+    "d_kv": 8,
+    "d_ff": 128,
+    "num_heads": 8,
+    "num_layers": 2,
+    "num_decoder_layers": 2,
+    "vocab_size": 100,
+    "relative_attention_num_buckets": 32,
+    "relative_attention_max_distance": 128,
+    "layer_norm_epsilon": 1e-6,
+    "feed_forward_proj": "relu",
+    "is_encoder_decoder": True,
+    "is_gated_act": False,
+    "model_type": "t5",
+    "decoder_start_token_id": 0,
+    "pad_token_id": 0,
+    "eos_token_id": 1,
+    "torch_dtype": "bfloat16",
+}
+
+
+SMALL_BART_CONFIG = {
+    "architectures": ["BartForConditionalGeneration"],
+    "d_model": 64,
+    "encoder_ffn_dim": 128,
+    "decoder_ffn_dim": 128,
+    "encoder_layers": 2,
+    "decoder_layers": 2,
+    "encoder_attention_heads": 8,
+    "decoder_attention_heads": 8,
+    "vocab_size": 100,
+    "max_position_embeddings": 128,
+    "activation_function": "gelu",
+    "is_encoder_decoder": True,
+    "model_type": "bart",
+    "decoder_start_token_id": 2,
+    "pad_token_id": 1,
+    "eos_token_id": 2,
+    "bos_token_id": 0,
+    "torch_dtype": "bfloat16",
+}
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestCrossAttention(unittest.TestCase):
+    def setUp(self):
+        torch.random.manual_seed(42)
+
+    def test_cross_attention_forward(self):
+        device = torch.device("cuda")
+        dtype = torch.bfloat16
+        hidden_size = 64
+        num_heads = 8
+        num_tokens_decoder = 4
+        num_tokens_encoder = 8
+
+        t5_cfg = deepcopy(SMALL_T5_CONFIG)
+        config = ModelConfig(
+            pretrained_config=T5Config.from_dict(t5_cfg),
+            attn_backend="VANILLA",
+        )
+        cross_attn = CrossAttention(
+            hidden_size=hidden_size,
+            num_attention_heads=num_heads,
+            num_key_value_heads=num_heads,
+            encoder_hidden_size=hidden_size,
+            bias=False,
+            layer_idx=0,
+            dtype=dtype,
+            config=config,
+        ).to(device)
+
+        decoder_hs = torch.randn(num_tokens_decoder, hidden_size, device=device, dtype=dtype)
+        encoder_hs = torch.randn(num_tokens_encoder, hidden_size, device=device, dtype=dtype)
+        metadata = _make_vanilla_metadata([num_tokens_decoder])
+
+        with torch.inference_mode():
+            output = cross_attn(
+                hidden_states=decoder_hs,
+                encoder_hidden_states=encoder_hs,
+                attn_metadata=metadata,
+                skip_cross_kv_projection=False,
+            )
+        self.assertEqual(output.shape, (num_tokens_decoder, hidden_size))
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestT5Modules(unittest.TestCase):
+    def setUp(self):
+        torch.random.manual_seed(42)
+        self.device = torch.device("cuda")
+        self.dtype = torch.bfloat16
+        self.hf_config = T5Config.from_dict(deepcopy(SMALL_T5_CONFIG))
+        self.model_config = ModelConfig(
+            pretrained_config=self.hf_config,
+            attn_backend="VANILLA",
+        )
+
+    def test_t5_encoder_layer_forward(self):
+        layer = T5EncoderLayer(self.model_config, layer_idx=0).to(self.device)
+        num_tokens = 6
+        hidden_states = torch.randn(
+            num_tokens, self.hf_config.d_model, device=self.device, dtype=self.dtype
+        )
+        metadata = _make_vanilla_metadata([num_tokens])
+
+        output = layer(hidden_states=hidden_states, attn_metadata=metadata)
+        self.assertEqual(output.shape, (num_tokens, self.hf_config.d_model))
+
+    def test_t5_decoder_layer_forward(self):
+        layer = T5DecoderLayer(self.model_config, layer_idx=0).to(self.device)
+        num_dec = 4
+        num_enc = 8
+        decoder_hs = torch.randn(
+            num_dec, self.hf_config.d_model, device=self.device, dtype=self.dtype
+        )
+        encoder_hs = torch.randn(
+            num_enc, self.hf_config.d_model, device=self.device, dtype=self.dtype
+        )
+        metadata = _make_vanilla_metadata([num_dec])
+
+        output = layer(
+            position_ids=torch.arange(num_dec, device=self.device),
+            hidden_states=decoder_hs,
+            attn_metadata=metadata,
+            encoder_hidden_states=encoder_hs,
+            skip_cross_kv_projection=False,
+        )
+        self.assertEqual(output.shape, (num_dec, self.hf_config.d_model))
+
+    def test_t5_encoder_stack_forward(self):
+        encoder = T5Encoder(self.model_config).to(self.device)
+        num_tokens = 10
+        hidden_states = torch.randn(
+            num_tokens, self.hf_config.d_model, device=self.device, dtype=self.dtype
+        )
+        metadata = _make_vanilla_metadata([num_tokens])
+
+        output = encoder(hidden_states=hidden_states, attn_metadata=metadata)
+        self.assertEqual(output.shape, (num_tokens, self.hf_config.d_model))
+
+    def test_t5_model_forward(self):
+        model = T5Model(self.model_config).to(self.device)
+        enc_len = 8
+        dec_len = 4
+        encoder_ids = torch.randint(0, self.hf_config.vocab_size, (enc_len,), device=self.device)
+        decoder_ids = torch.randint(0, self.hf_config.vocab_size, (dec_len,), device=self.device)
+        enc_metadata = _make_vanilla_metadata([enc_len])
+        dec_metadata = _make_vanilla_metadata([dec_len])
+
+        output = model(
+            attn_metadata=dec_metadata,
+            input_ids=decoder_ids,
+            encoder_input_ids=encoder_ids,
+            encoder_attn_metadata=enc_metadata,
+            skip_cross_kv_projection=False,
+        )
+        self.assertEqual(output.shape, (dec_len, self.hf_config.d_model))
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestBartModules(unittest.TestCase):
+    def setUp(self):
+        torch.random.manual_seed(42)
+        self.device = torch.device("cuda")
+        self.dtype = torch.bfloat16
+        self.hf_config = BartConfig.from_dict(deepcopy(SMALL_BART_CONFIG))
+        self.model_config = ModelConfig(
+            pretrained_config=self.hf_config,
+            attn_backend="VANILLA",
+        )
+
+    def test_bart_encoder_layer_forward(self):
+        layer = BartEncoderLayer(self.model_config, layer_idx=0).to(self.device)
+        num_tokens = 6
+        hidden_states = torch.randn(
+            num_tokens, self.hf_config.d_model, device=self.device, dtype=self.dtype
+        )
+        metadata = _make_vanilla_metadata([num_tokens])
+
+        output = layer(hidden_states=hidden_states, attn_metadata=metadata)
+        self.assertEqual(output.shape, (num_tokens, self.hf_config.d_model))
+
+    def test_bart_decoder_layer_forward(self):
+        layer = BartDecoderLayer(self.model_config, layer_idx=0).to(self.device)
+        num_dec = 4
+        num_enc = 8
+        decoder_hs = torch.randn(
+            num_dec, self.hf_config.d_model, device=self.device, dtype=self.dtype
+        )
+        encoder_hs = torch.randn(
+            num_enc, self.hf_config.d_model, device=self.device, dtype=self.dtype
+        )
+        metadata = _make_vanilla_metadata([num_dec])
+
+        output = layer(
+            position_ids=torch.arange(num_dec, device=self.device),
+            hidden_states=decoder_hs,
+            attn_metadata=metadata,
+            encoder_hidden_states=encoder_hs,
+            skip_cross_kv_projection=False,
+        )
+        self.assertEqual(output.shape, (num_dec, self.hf_config.d_model))
+
+    def test_bart_model_forward(self):
+        model = BartModel(self.model_config).to(self.device)
+        self.assertEqual(model.position_id_offset, 2)
+        enc_len = 8
+        dec_len = 4
+        encoder_ids = torch.randint(0, self.hf_config.vocab_size, (enc_len,), device=self.device)
+        decoder_ids = torch.randint(0, self.hf_config.vocab_size, (dec_len,), device=self.device)
+        offset = 2
+        enc_positions = torch.arange(offset, offset + enc_len, device=self.device)
+        dec_positions = torch.arange(offset, offset + dec_len, device=self.device)
+        enc_metadata = _make_vanilla_metadata([enc_len])
+        dec_metadata = _make_vanilla_metadata([dec_len])
+
+        output = model(
+            attn_metadata=dec_metadata,
+            input_ids=decoder_ids,
+            encoder_input_ids=encoder_ids,
+            encoder_position_ids=enc_positions,
+            position_ids=dec_positions,
+            encoder_attn_metadata=enc_metadata,
+            skip_cross_kv_projection=False,
+        )
+        self.assertEqual(output.shape, (dec_len, self.hf_config.d_model))
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestModelRegistration(unittest.TestCase):
+    def test_t5_registered(self):
+        from tensorrt_llm._torch.models.modeling_utils import MODEL_CLASS_MAPPING
+
+        self.assertIn("T5ForConditionalGeneration", MODEL_CLASS_MAPPING)
+
+    def test_bart_registered(self):
+        from tensorrt_llm._torch.models.modeling_utils import MODEL_CLASS_MAPPING
+
+        self.assertIn("BartForConditionalGeneration", MODEL_CLASS_MAPPING)
+
+    def test_mbart_registered(self):
+        from tensorrt_llm._torch.models.modeling_utils import MODEL_CLASS_MAPPING
+
+        self.assertIn("MBartForConditionalGeneration", MODEL_CLASS_MAPPING)
+
+    def test_model_config_enc_dec_flag(self):
+        t5_config = T5Config.from_dict(deepcopy(SMALL_T5_CONFIG))
+        mc = ModelConfig(pretrained_config=t5_config)
+        self.assertTrue(mc.is_encoder_decoder)
+
+        bart_config = BartConfig.from_dict(deepcopy(SMALL_BART_CONFIG))
+        mc = ModelConfig(pretrained_config=bart_config)
+        self.assertTrue(mc.is_encoder_decoder)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestT5WeightLoading(unittest.TestCase):
+    def setUp(self):
+        torch.random.manual_seed(42)
+        self.device = torch.device("cuda")
+        self.dtype = torch.bfloat16
+
+    def test_t5_load_weights_and_encoder_parity(self):
+        import transformers
+
+        hf_config = T5Config.from_dict(deepcopy(SMALL_T5_CONFIG))
+        hf_model = transformers.T5ForConditionalGeneration(hf_config).to(self.device).to(self.dtype)
+        hf_model.eval()
+        hf_weights = hf_model.state_dict()
+
+        model_config = ModelConfig(
+            pretrained_config=hf_config,
+            attn_backend="VANILLA",
+        )
+        from tensorrt_llm._torch.models.modeling_t5 import T5ForConditionalGeneration as TllmT5
+
+        tllm_model = TllmT5(model_config).to(self.device)
+        tllm_model.load_weights(hf_weights)
+        tllm_model.eval()
+
+        enc_len = 8
+        encoder_ids = torch.randint(0, hf_config.vocab_size, (1, enc_len), device=self.device)
+
+        with torch.inference_mode():
+            hf_enc_out = hf_model.encoder(input_ids=encoder_ids).last_hidden_state.squeeze(0)
+
+        enc_metadata = _make_vanilla_metadata([enc_len])
+        enc_embeds = tllm_model.model.shared_embedding(encoder_ids.squeeze(0))
+
+        with torch.inference_mode():
+            tllm_enc_out = tllm_model.model.encoder(
+                hidden_states=enc_embeds,
+                attn_metadata=enc_metadata,
+            )
+
+        max_diff = (hf_enc_out.to(self.dtype) - tllm_enc_out.to(self.dtype)).abs().max().item()
+        self.assertLess(max_diff, 1e-3)
+
+    def test_t5_load_weights_runs_forward(self):
+        import transformers
+
+        hf_config = T5Config.from_dict(deepcopy(SMALL_T5_CONFIG))
+        hf_model = transformers.T5ForConditionalGeneration(hf_config)
+        hf_model.eval()
+        hf_weights = hf_model.state_dict()
+
+        model_config = ModelConfig(
+            pretrained_config=hf_config,
+            attn_backend="VANILLA",
+        )
+        from tensorrt_llm._torch.models.modeling_t5 import T5ForConditionalGeneration as TllmT5
+
+        tllm_model = TllmT5(model_config).to(self.device)
+        tllm_model.load_weights(hf_weights)
+        tllm_model.eval()
+
+        enc_len = 8
+        dec_len = 4
+        encoder_ids = torch.randint(0, hf_config.vocab_size, (enc_len,), device=self.device)
+        decoder_ids = torch.randint(0, hf_config.vocab_size, (dec_len,), device=self.device)
+        enc_metadata = _make_vanilla_metadata([enc_len])
+        dec_metadata = _make_vanilla_metadata([dec_len])
+
+        with torch.inference_mode():
+            tllm_out = tllm_model(
+                attn_metadata=dec_metadata,
+                input_ids=decoder_ids,
+                encoder_input_ids=encoder_ids,
+                encoder_attn_metadata=enc_metadata,
+                skip_cross_kv_projection=False,
+            )
+
+        self.assertEqual(tllm_out.shape[-1], hf_config.vocab_size)
+        self.assertTrue(torch.isfinite(tllm_out).all())
+
+    def test_t5_for_conditional_generation_load_weights(self):
+        import transformers
+
+        hf_config = T5Config.from_dict(deepcopy(SMALL_T5_CONFIG))
+        hf_model = transformers.T5ForConditionalGeneration(hf_config)
+        hf_model.eval()
+        hf_weights = hf_model.state_dict()
+
+        model_config = ModelConfig(
+            pretrained_config=hf_config,
+            attn_backend="VANILLA",
+        )
+        from tensorrt_llm._torch.models.modeling_t5 import T5ForConditionalGeneration
+
+        tllm_model = T5ForConditionalGeneration(model_config).to(self.device)
+        tllm_model.load_weights(hf_weights)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestBartWeightLoading(unittest.TestCase):
+    def setUp(self):
+        torch.random.manual_seed(42)
+        self.device = torch.device("cuda")
+        self.dtype = torch.bfloat16
+
+    def test_bart_load_weights_and_encoder_parity(self):
+        import transformers
+
+        hf_config = BartConfig.from_dict(deepcopy(SMALL_BART_CONFIG))
+        hf_model = transformers.BartModel(hf_config).to(self.device).to(self.dtype)
+        hf_model.eval()
+        hf_weights = hf_model.state_dict()
+
+        model_config = ModelConfig(
+            pretrained_config=hf_config,
+            attn_backend="VANILLA",
+        )
+        from tensorrt_llm._torch.models.modeling_bart import (
+            BartForConditionalGeneration as TllmBart,
+        )
+        from tensorrt_llm._torch.models.modeling_bart import _convert_hf_bart_weights
+
+        tllm_model = TllmBart(model_config).to(self.device)
+        tllm_weights = _convert_hf_bart_weights(hf_weights, hf_config)
+        loaded_count = 0
+        for name, module in tllm_model.named_modules():
+            if len(list(module.parameters(recurse=False))) == 0:
+                continue
+            if name not in tllm_weights:
+                continue
+            weights = tllm_weights[name]
+            if hasattr(module, "load_weights"):
+                module.load_weights(weights=weights)
+            else:
+                for param_name, param in module.named_parameters(recurse=False):
+                    if param_name in weights[0]:
+                        param.data.copy_(weights[0][param_name][:])
+            loaded_count += 1
+
+        self.assertGreater(loaded_count, 0)
+        tllm_model.eval()
+
+        enc_len = 8
+        encoder_ids = torch.randint(0, hf_config.vocab_size, (1, enc_len), device=self.device)
+
+        embed_scale = hf_config.d_model**0.5
+        with torch.inference_mode():
+            hf_enc_out = hf_model.encoder(
+                inputs_embeds=hf_model.shared(encoder_ids) * embed_scale,
+            ).last_hidden_state.squeeze(0)
+
+        offset = 2
+        enc_positions = torch.arange(offset, offset + enc_len, device=self.device)
+        enc_metadata = _make_vanilla_metadata([enc_len])
+        enc_embeds = tllm_model.model.shared_embedding(encoder_ids.squeeze(0)) * embed_scale
+
+        with torch.inference_mode():
+            tllm_enc_out = tllm_model.model.encoder(
+                hidden_states=enc_embeds,
+                attn_metadata=enc_metadata,
+                position_ids=enc_positions,
+            )
+
+        max_diff = (hf_enc_out.to(self.dtype) - tllm_enc_out.to(self.dtype)).abs().max().item()
+        self.assertLess(max_diff, 1e-4)
+
+    def test_bart_for_conditional_generation_load_weights(self):
+        import transformers
+
+        hf_config = BartConfig.from_dict(deepcopy(SMALL_BART_CONFIG))
+        hf_model = transformers.BartForConditionalGeneration(hf_config)
+        hf_model.eval()
+        hf_weights = hf_model.state_dict()
+
+        model_config = ModelConfig(
+            pretrained_config=hf_config,
+            attn_backend="VANILLA",
+        )
+        from tensorrt_llm._torch.models.modeling_bart import BartForConditionalGeneration
+
+        tllm_model = BartForConditionalGeneration(model_config).to(self.device)
+        tllm_model.load_weights(hf_weights)
+
+
+def _get_llm_models_root():
+    root = Path("/home/scratch.trt_llm_data/llm-models/")
+    if "LLM_MODELS_ROOT" in os.environ:
+        root = Path(os.environ["LLM_MODELS_ROOT"])
+    if not root.exists():
+        root = Path("/scratch.trt_llm_data/llm-models/")
+    return root if root.exists() else None
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestT5SmallRealWeights(unittest.TestCase):
+    def setUp(self):
+        torch.random.manual_seed(42)
+        self.device = torch.device("cuda")
+        self.dtype = torch.bfloat16
+
+        models_root = _get_llm_models_root()
+        if models_root is None:
+            self.skipTest("LLM_MODELS_ROOT not found")
+        self.model_path = str(models_root / "t5-small")
+        if not os.path.isdir(self.model_path):
+            self.skipTest(f"t5-small not found at {self.model_path}")
+
+    def test_t5_small_encoder_parity(self):
+        import transformers
+
+        hf_model = (
+            transformers.T5ForConditionalGeneration.from_pretrained(self.model_path)
+            .to(self.device)
+            .to(self.dtype)
+        )
+        hf_model.eval()
+        hf_config = hf_model.config
+        hf_weights = hf_model.state_dict()
+
+        hf_config.torch_dtype = self.dtype
+        model_config = ModelConfig(
+            pretrained_config=hf_config,
+            attn_backend="VANILLA",
+        )
+        from tensorrt_llm._torch.models.modeling_t5 import T5ForConditionalGeneration as TllmT5
+
+        tllm_model = TllmT5(model_config).to(self.device)
+        tllm_model.load_weights(hf_weights)
+        tllm_model.eval()
+
+        for name, param in tllm_model.named_parameters():
+            self.assertEqual(param.dtype, self.dtype, name)
+
+        enc_len = 16
+        encoder_ids = torch.randint(0, hf_config.vocab_size, (1, enc_len), device=self.device)
+
+        with torch.inference_mode():
+            hf_enc_out = hf_model.encoder(input_ids=encoder_ids).last_hidden_state.squeeze(0)
+
+        enc_metadata = _make_vanilla_metadata([enc_len])
+        enc_embeds = tllm_model.model.shared_embedding(encoder_ids.squeeze(0))
+
+        with torch.inference_mode():
+            tllm_enc_out = tllm_model.model.encoder(
+                hidden_states=enc_embeds,
+                attn_metadata=enc_metadata,
+            )
+
+        max_diff = (hf_enc_out - tllm_enc_out).abs().max().item()
+        self.assertLess(max_diff, 0.05)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestBartLargeCNNRealWeights(unittest.TestCase):
+    def setUp(self):
+        torch.random.manual_seed(42)
+        self.device = torch.device("cuda")
+        self.dtype = torch.bfloat16
+
+        models_root = _get_llm_models_root()
+        if models_root is None:
+            self.skipTest("LLM_MODELS_ROOT not found")
+        self.model_path = str(models_root / "bart-large-cnn")
+        if not os.path.isdir(self.model_path):
+            self.skipTest(f"bart-large-cnn not found at {self.model_path}")
+
+    def test_bart_large_cnn_encoder_parity(self):
+        import transformers
+
+        hf_model = (
+            transformers.BartModel.from_pretrained(self.model_path).to(self.device).to(self.dtype)
+        )
+        hf_model.eval()
+        hf_config = hf_model.config
+        hf_weights = hf_model.state_dict()
+
+        hf_config.torch_dtype = self.dtype
+        model_config = ModelConfig(
+            pretrained_config=hf_config,
+            attn_backend="VANILLA",
+        )
+        from tensorrt_llm._torch.models.modeling_bart import (
+            BartForConditionalGeneration as TllmBart,
+        )
+        from tensorrt_llm._torch.models.modeling_bart import _convert_hf_bart_weights
+
+        tllm_model = TllmBart(model_config).to(self.device)
+        tllm_weights = _convert_hf_bart_weights(hf_weights, hf_config, dtype=self.dtype)
+        for name, module in tllm_model.named_modules():
+            if len(list(module.parameters(recurse=False))) == 0:
+                continue
+            if name not in tllm_weights:
+                continue
+            weights = tllm_weights[name]
+            if hasattr(module, "load_weights"):
+                module.load_weights(weights=weights)
+            else:
+                for param_name, param in module.named_parameters(recurse=False):
+                    if param_name in weights[0]:
+                        param.data.copy_(weights[0][param_name][:])
+        tllm_model.eval()
+
+        for name, param in tllm_model.named_parameters():
+            self.assertEqual(param.dtype, self.dtype, name)
+
+        enc_len = 16
+        encoder_ids = torch.randint(0, hf_config.vocab_size, (1, enc_len), device=self.device)
+
+        embed_scale = hf_config.d_model**0.5
+        with torch.inference_mode():
+            hf_enc_out = hf_model.encoder(
+                inputs_embeds=hf_model.shared(encoder_ids) * embed_scale,
+            ).last_hidden_state.squeeze(0)
+
+        offset = 2
+        enc_positions = torch.arange(offset, offset + enc_len, device=self.device)
+        enc_metadata = _make_vanilla_metadata([enc_len])
+        enc_embeds = tllm_model.model.shared_embedding(encoder_ids.squeeze(0)) * embed_scale
+
+        with torch.inference_mode():
+            tllm_enc_out = tllm_model.model.encoder(
+                hidden_states=enc_embeds,
+                attn_metadata=enc_metadata,
+                position_ids=enc_positions,
+            )
+
+        max_diff = (hf_enc_out - tllm_enc_out).abs().max().item()
+        self.assertLess(max_diff, 0.1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittest/_torch/test_model_config.py
+++ b/tests/unittest/_torch/test_model_config.py
@@ -16,6 +16,7 @@ def make_pretrained_config(
     head_dim: int | None = None,
     num_hidden_layers: int = 1,
     vocab_size: int = 3000,
+    is_encoder_decoder: bool = False,
 ):
     # A minimal config object that provides the attributes used by
     # ModelConfig.get_bindings_model_config().
@@ -32,6 +33,7 @@ def make_pretrained_config(
         num_hidden_layers=num_hidden_layers,
         vocab_size=vocab_size,
         torch_dtype=torch.float16,
+        is_encoder_decoder=is_encoder_decoder,
     )
 
 
@@ -116,3 +118,14 @@ def test_validate_and_set_kv_cache_quant_rejects_invalid_dtype():
     model_config = _make_model_config_with_kv_quant(QuantAlgo.FP8)
     with pytest.raises(ValueError, match="Accepted types are"):
         validate_and_set_kv_cache_quant(model_config, "invalid_dtype")
+
+
+def test_model_config_sets_is_encoder_decoder_from_pretrained_config():
+    model_config = ModelConfig(
+        pretrained_config=make_pretrained_config(
+            head_dim=4,
+            is_encoder_decoder=True,
+        )
+    )
+
+    assert model_config.is_encoder_decoder is True


### PR DESCRIPTION
## Description

Adds the PyTorch encoder-decoder model foundation for T5/BART-style models.

This PR introduces:
- ModelConfig.is_encoder_decoder detection from HF configs
- PyTorch T5 model definitions
- PyTorch BART/mBART model definitions
- shared encoder-decoder layer abstractions
- cross-attention module support
- relative attention bias plumbing through the vanilla/model-level attention path
- VANILLA backend support for cross-attention with distinct Q and K/V sequence lengths
model registration for T5, BART, and mBART
model/config unit coverage for construction, forward passes, registration, weight loading, and encoder parity

## Test Coverage
pytest -q tests/unittest/_torch/test_model_config.py
pytest -q tests/unittest/_torch/modeling/test_modeling_enc_dec.py

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for T5, BART, and mBART encoder-decoder models
  * Introduced cross-attention mechanism for encoder-decoder architectures
  * Added relative attention bias support in attention modules
  * Enhanced attention metadata handling for cross-attention scenarios

* **Tests**
  * Added comprehensive test coverage for encoder-decoder models

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14108)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->