### PR TITLE
[#14100][fix] audio_url decodes data URI base64 like image_url

### DIFF
--- a/tensorrt_llm/inputs/utils.py
+++ b/tensorrt_llm/inputs/utils.py
@@ -215,6 +215,17 @@ async def async_load_video(video: str,
         raise ValueError(f"Unsupported URL scheme: {parsed_url.scheme!r}")
 
 
+def load_base64_audio(parsed_url) -> BytesIO:
+    data_spec, data = parsed_url.path.split(",", 1)
+    _, data_type = data_spec.split(";", 1)
+
+    if data_type != "base64":
+        msg = "Only base64 data URLs are supported for now."
+        raise NotImplementedError(msg)
+
+    return BytesIO(base64.b64decode(data))
+
+
 def load_audio(
     audio: str,
     format: str = "pt",
@@ -224,6 +235,8 @@ def load_audio(
     if parsed_url.scheme in ["http", "https"]:
         resp = _safe_request_get(audio, stream=False)
         audio = BytesIO(resp.content)
+    elif parsed_url.scheme == "data":
+        audio = load_base64_audio(parsed_url)
     elif parsed_url.scheme in ("", "file"):
         audio = _normalize_file_uri(
             audio) if parsed_url.scheme == "file" else audio
@@ -250,6 +263,8 @@ async def async_load_audio(
         session = await _get_aiohttp_session()
         audio_data = await _safe_aiohttp_get(audio, session=session)
         audio = BytesIO(audio_data)
+    elif parsed_url.scheme == "data":
+        audio = await asyncio.to_thread(load_base64_audio, parsed_url)
     elif parsed_url.scheme in ("", "file"):
         audio = _normalize_file_uri(
             audio) if parsed_url.scheme == "file" else audio

--- a/tensorrt_llm/inputs/utils.py
+++ b/tensorrt_llm/inputs/utils.py
@@ -216,6 +216,17 @@ async def async_load_video(video: str,
         raise ValueError(f"Unsupported URL scheme: {parsed_url.scheme!r}")
 
 
+def load_base64_audio(parsed_url) -> BytesIO:
+    data_spec, data = parsed_url.path.split(",", 1)
+    _, data_type = data_spec.split(";", 1)
+
+    if data_type != "base64":
+        msg = "Only base64 data URLs are supported for now."
+        raise NotImplementedError(msg)
+
+    return BytesIO(base64.b64decode(data))
+
+
 def load_audio(
     audio: str,
     format: str = "pt",
@@ -225,6 +236,8 @@ def load_audio(
     if parsed_url.scheme in ["http", "https"]:
         resp = _safe_request_get(audio, stream=False)
         audio = BytesIO(resp.content)
+    elif parsed_url.scheme == "data":
+        audio = load_base64_audio(parsed_url)
     elif parsed_url.scheme in ("", "file"):
         audio = _normalize_file_uri(
             audio) if parsed_url.scheme == "file" else audio
@@ -251,6 +264,8 @@ async def async_load_audio(
         session = await _get_aiohttp_session()
         audio_data = await _safe_aiohttp_get(audio, session=session)
         audio = BytesIO(audio_data)
+    elif parsed_url.scheme == "data":
+        audio = await asyncio.to_thread(load_base64_audio, parsed_url)
     elif parsed_url.scheme in ("", "file"):
         audio = _normalize_file_uri(
             audio) if parsed_url.scheme == "file" else audio

--- a/tests/unittest/inputs/test_async_media_loading.py
+++ b/tests/unittest/inputs/test_async_media_loading.py
@@ -49,6 +49,16 @@ def _make_audio_file(tmp_path: str) -> str:
     return tmp_path
 
 
+def _make_audio_data_url() -> str:
+    sample_rate = 16000
+    time_axis = np.linspace(0, 0.05, int(sample_rate * 0.05), endpoint=False)
+    audio_samples = (np.sin(2 * np.pi * 440 * time_axis) * 0.5).astype(np.float32)
+    audio_buf = BytesIO()
+    soundfile.write(audio_buf, audio_samples, sample_rate, format="WAV")
+    b64_str = base64.b64encode(audio_buf.getvalue()).decode()
+    return f"data:audio/wav;base64,{b64_str}"
+
+
 # ──────────────────────────────────────────────────────────────
 # async_load_image
 # ──────────────────────────────────────────────────────────────
@@ -112,6 +122,13 @@ class TestAsyncLoadAudio:
         audio_array, sample_rate = await async_load_audio(wav_path)
         assert isinstance(audio_array, np.ndarray)
         assert sample_rate == 16000  # matches the sr=16000 used in _make_audio_file
+
+    @pytest.mark.asyncio
+    async def test_load_audio_from_data_url(self):
+        url = _make_audio_data_url()
+        audio_array, sample_rate = await async_load_audio(url)
+        assert isinstance(audio_array, np.ndarray)
+        assert sample_rate == 16000
 
     @pytest.mark.asyncio
     async def test_cpu_work_runs_in_executor(self):

--- a/tests/unittest/inputs/test_async_media_loading.py
+++ b/tests/unittest/inputs/test_async_media_loading.py
@@ -52,6 +52,16 @@ def _make_audio_file(tmp_path: str) -> str:
     return tmp_path
 
 
+def _make_audio_data_url() -> str:
+    sample_rate = 16000
+    time_axis = np.linspace(0, 0.05, int(sample_rate * 0.05), endpoint=False)
+    audio_samples = (np.sin(2 * np.pi * 440 * time_axis) * 0.5).astype(np.float32)
+    audio_buf = BytesIO()
+    soundfile.write(audio_buf, audio_samples, sample_rate, format="WAV")
+    b64_str = base64.b64encode(audio_buf.getvalue()).decode()
+    return f"data:audio/wav;base64,{b64_str}"
+
+
 # ──────────────────────────────────────────────────────────────
 # async_load_image
 # ──────────────────────────────────────────────────────────────
@@ -115,6 +125,13 @@ class TestAsyncLoadAudio:
         audio_array, sample_rate = await async_load_audio(wav_path)
         assert isinstance(audio_array, np.ndarray)
         assert sample_rate == 16000  # matches the sr=16000 used in _make_audio_file
+
+    @pytest.mark.asyncio
+    async def test_load_audio_from_data_url(self):
+        url = _make_audio_data_url()
+        audio_array, sample_rate = await async_load_audio(url)
+        assert isinstance(audio_array, np.ndarray)
+        assert sample_rate == 16000
 
     @pytest.mark.asyncio
     async def test_cpu_work_runs_in_executor(self):


### PR DESCRIPTION
The audio_url branch in trtllm-serve doesn't decode data URIs even though image_url already does. When a client sends an inline base64 WAV the long URL reaches soundfile.read as a filesystem path and libsndfile fails with Supplied filename too long, then audios None bubbles up and the Phi-4-MM processor crashes with a confusing message. This adds a data scheme branch to load_audio and async_load_audio that mirrors what load_base64_image already does on the image side, and a regression test that loads a real WAV through a data audio/wav base64 URL. Fixes #14100.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading audio from base64-encoded data URLs. Audio loading functions now accept and properly decode data-scheme URLs containing base64-encoded audio content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14115)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->