### PR TITLE
[None][feat] Enable 2 DSv4 perf optimizations by default

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1530,7 +1530,7 @@ def _(
 # deep_gemm_gen_tuning_buckets is imported from ..utils
 
 _USE_FUSED_FP8_QUANT_PACK = os.environ.get("TRTLLM_FUSED_FP8_QUANT_PACK",
-                                           "0") == "1"
+                                           "1") == "1"
 
 
 def _fp8_quantize_1x128_ue8m0(input: torch.Tensor, tactic: int):

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -2195,7 +2195,7 @@ class MLA(nn.Module):
         # with q_b_proj + q_b_layernorm. The indexer is launched on a
         # dedicated stream and still uses a different aux stream for its
         # internal q-proj/weights-proj split.
-        _v4_extra_overlap = (os.environ.get("TRTLLM_MLA_EXTRA_OVERLAP", "0")
+        _v4_extra_overlap = (os.environ.get("TRTLLM_MLA_EXTRA_OVERLAP", "1")
                              == "1" and self.compressor is not None
                              and self.aux_stream is not None)
 


### PR DESCRIPTION
## Description

Flip the default of two previously opt-in DSv4 perf flags so users get them out of the box. Both remain user-disableable via the same env vars they always had.

| Default flipped | File | Source | Disable |
|---|---|---|---|
| `TRTLLM_FUSED_FP8_QUANT_PACK` `"0" → "1"` | `tensorrt_llm/_torch/custom_ops/torch_custom_ops.py` | PR #13628 — fused FP8 1×128 quantize + UE8M0 pack on SM100 | `TRTLLM_FUSED_FP8_QUANT_PACK=0` |
| `TRTLLM_MLA_EXTRA_OVERLAP` `"0" → "1"` | `tensorrt_llm/_torch/modules/attention.py` | PR #13629 — MLA dependency-aware overlap on DSv4 | `TRTLLM_MLA_EXTRA_OVERLAP=0` |

A third originally-proposed flip (`use_cute_dsl_blockscaling_bmm` from `False` to `True`) is **dropped from this PR** and deferred. The cute_dsl FP8 BMM path also fires for DSv3 K/V absorption BMMs on Blackwell + FP8 block-scales — the `fp8_block_scaling_bmm_out` dispatcher at `tensorrt_llm/_torch/modules/attention.py:1161` is not gated on `is_deepseek_v4`, so flipping the default would silently change DSv3 perf behavior (the K/V BMMs switch from `torch.bmm` against pre-dequanted bf16 weights to `cute_dsl_fp8_bmm_blackwell` consuming native FP8). DSv3 Blackwell + FP8 block-scales hasn't been re-benched, so a separate PR will re-propose the flip after a DSv3 smoke confirms no regression.

## Test Coverage

- Existing DSv4 unit + integration tests already exercise both flipped defaults (they were the opt-in path in PR #13628 / #13629). No new tests needed for the flips themselves.
- Manual bench: DSv4-Pro 8k-1k on GB300 with both defaults on (the bench configuration we've been running for the past two weeks) is the practical regression baseline; no perf drop observed.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
