### PR TITLE
[None][feat] Implement VSWA front-eviction for the Triton attention kernels

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -502,7 +502,6 @@ public:
         , mNumTokens(numTokens)
         , mBeamWidth(beamWidth)
         , mKvCacheRetentionConfig(std::move(kvCacheRetentionConfig))
-        , mNumFrontBlocksRemoved(0)
         , mCurrentPrepopulatedPromptLen(std::numeric_limits<SizeType32>::max())
     {
         auto const numWindowSizes = windowSizeToMetadata.size();
@@ -511,6 +510,12 @@ public:
         for (auto const [windowSize, metadata] : windowSizeToMetadata)
         {
             mCacheBlockIds[windowSize] = std::vector<std::vector<KVCacheBlock::IdType>>(beamWidth);
+            // Front-eviction count is tracked per-window: SWA pools may evict blocks while
+            // full-attention pools never do, and each pool's index math needs its own count.
+            // Pre-existing behavior (a single shared counter) only worked when one
+            // KVCacheManager == one window; once a single manager hosts multiple pools, the
+            // counter must be per-window.
+            mNumFrontBlocksRemovedPerWindow[windowSize] = 0;
             auto const numPools = metadata.numPools;
             auto const maxBlocks = metadata.maxBlocksPerSeq;
             mCacheBlockIndices[windowSize]
@@ -546,9 +551,21 @@ public:
         return mNumTokens;
     }
 
-    [[nodiscard]] SizeType32 getNumFrontBlocksRemoved() const
+    //! \brief Front-evicted blocks for the specified window only.
+    //! \details Only SWA windows ever evict; full-attention windows always return 0.
+    //!          Callers iterating per-pool MUST pass the relevant windowSize so that
+    //!          SWA evictions are not attributed to non-SWA pools.
+    //!          The no-argument / aggregate-across-windows overload was deliberately
+    //!          removed: implicit aggregation hid window-qualification bugs at call sites.
+    //!          Callers that genuinely want a sum should iterate the registered windows
+    //!          explicitly.
+    [[nodiscard]] SizeType32 getNumFrontBlocksRemoved(SizeType32 windowSize) const
     {
-        return mNumFrontBlocksRemoved;
+        auto it = mNumFrontBlocksRemovedPerWindow.find(windowSize);
+        TLLM_CHECK_WITH_INFO(it != mNumFrontBlocksRemovedPerWindow.end(),
+            "GenerationRequest::getNumFrontBlocksRemoved: windowSize=%d not registered for request %lu", windowSize,
+            static_cast<unsigned long>(mRequestId));
+        return it->second;
     }
 
     [[nodiscard]] SizeType32 getBeamWidth() const
@@ -593,12 +610,18 @@ public:
         {
             beamBlockIds.clear();
         }
-        mNumFrontBlocksRemoved = 0;
+        // Reset only this window's counter, not the others — clearing one pool's blocks
+        // must not invalidate the eviction state of co-existing pools.
+        auto it = mNumFrontBlocksRemovedPerWindow.find(windowSize);
+        if (it != mNumFrontBlocksRemovedPerWindow.end())
+        {
+            it->second = 0;
+        }
     }
 
     void removeFrontBlock(SizeType32 windowSize)
     {
-        ++mNumFrontBlocksRemoved;
+        ++mNumFrontBlocksRemovedPerWindow.at(windowSize);
     }
 
     void removeLastBlock(SizeType32 windowSize)
@@ -656,8 +679,10 @@ private:
     std::unordered_map<SizeType32, runtime::ITensor::SharedPtr> mCacheBlockIndices;
     // The retention priority to assign to decode blocks
     executor::KvCacheRetentionConfig mKvCacheRetentionConfig;
-    // Number of front blocks removed from the sequence
-    SizeType32 mNumFrontBlocksRemoved;
+    // Number of front blocks evicted from the sequence, tracked per window size.
+    // Each WindowBlockManager increments only its own entry on detachFrontBlock; full-attn
+    // windows always stay at 0 since they never trigger SWA eviction.
+    std::map<SizeType32, SizeType32> mNumFrontBlocksRemovedPerWindow;
     // Set of used blocks by the sequence
     std::set<KVCacheBlock::IdType> mUsedBlocks;
     // Current prepopulated prompt length
@@ -912,6 +937,31 @@ public:
     [[nodiscard]] SizeType32 getWindowSize() const noexcept
     {
         return mWindowSize;
+    }
+
+    //! \brief Return this manager's KV-cache element data type.
+    //! \details Each WindowBlockManager carries its own dtype, which lets BlockManager
+    //!          host pools with mixed precisions when constructed with a per-window
+    //!          dtype map.  Empty pools or NVFP4-scale pools are routed through the
+    //!          per-pool tensor metadata instead.
+    [[nodiscard]] nvinfer1::DataType getDataType() const noexcept
+    {
+        return mDataType;
+    }
+
+    //! \brief Return the head_dim shared by all KV pools in this window manager.
+    //! \details All pools constructed under a WindowBlockManager share a single
+    //!          head_dim (the constructor's @c sizePerHead), so we read it from the
+    //!          first pool.  Returns 0 if no pools are present, or if the pool was
+    //!          built with @c sizePerHead<=0 (recurrent-state pools use -1 as a
+    //!          sentinel and do not have a meaningful head dimension).
+    [[nodiscard]] SizeType32 getSizePerHead() const noexcept
+    {
+        if (mPools.empty() || mPools.front().sizePerHead <= 0)
+        {
+            return 0;
+        }
+        return mPools.front().sizePerHead;
     }
 
     [[nodiscard]] std::string const& getLogPrefix() const noexcept
@@ -1323,6 +1373,17 @@ public:
     using SizeType32 = tensorrt_llm::runtime::SizeType32;
     using BaseEvictionPolicy = tensorrt_llm::batch_manager::eviction_policy::BaseEvictionPolicy;
 
+    //! \brief Construct a BlockManager.
+    //! \param sizePerHead Default head size (used for any window without an entry in
+    //!        @p sizePerHeadPerWindow).
+    //! \param dtype Default KV-cache data type (used for any window without an entry in
+    //!        @p dtypePerWindow).
+    //! \param sizePerHeadPerWindow Optional per-window override of @p sizePerHead.  Lets
+    //!        a single BlockManager host pools with distinct head dimensions (e.g. Gemma4
+    //!        SWA layers with head_dim=256 alongside full-attention layers with head_dim=512).
+    //!        Empty map = uniform @p sizePerHead.
+    //! \param dtypePerWindow Optional per-window override of @p dtype.  Empty map = uniform
+    //!        @p dtype.  Pools that don't appear in the map fall back to @p dtype.
     explicit BlockManager(std::vector<SizeType32> const& numKvHeadsPerLayer, SizeType32 sizePerHead,
         SizeType32 tokensPerBlock, BlocksPerWindow const& blocksPerWindow, SizeType32 maxNumSequences,
         CudaStreamPtr stream, SizeType32 maxSequenceLength, SizeType32 maxBeamWidth,
@@ -1334,8 +1395,9 @@ public:
         std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
         std::optional<kvc::BaseAgentConfig> agentConfig = std::nullopt, bool enableIndexerKCache = false,
         SizeType32 indexerKCacheQuantBlockSize = 128, SizeType32 indexerKCacheIndexHeadDim = 0,
-        bool indexerKCacheUseFp4 = false,
-        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt);
+        bool indexerKCacheUseFp4 = false, std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt,
+        std::map<SizeType32, SizeType32> const& sizePerHeadPerWindow = {},
+        std::map<SizeType32, nvinfer1::DataType> const& dtypePerWindow = {});
 
     [[nodiscard]] bool isEnableIndexerKCache() const
     {
@@ -1445,6 +1507,43 @@ public:
             numFreeBlocksPerWindowSize[windowSize] = manager.getNumFreeBlocks();
         }
         return numFreeBlocksPerWindowSize;
+    }
+
+    //! \brief Per-window head_dim view across all WindowBlockManagers.
+    //! \details Equivalent to the @c sizePerHeadPerWindow constructor argument when supplied,
+    //!          otherwise every entry equals the scalar @c sizePerHead.  Lets callers
+    //!          (e.g. Python-side tensor reshaping or kernel dispatch) discover per-pool
+    //!          head_dim without reaching into KVCacheBlockPool.
+    [[nodiscard]] std::map<SizeType32, SizeType32> getSizePerHeadPerWindow() const
+    {
+        std::map<SizeType32, SizeType32> result;
+        for (auto const& [windowSize, manager] : mWindowBlockManagers)
+        {
+            result[windowSize] = manager.getSizePerHead();
+        }
+        return result;
+    }
+
+    //! \brief Per-window dtype view across all WindowBlockManagers.
+    //! \details Mirrors @c getSizePerHeadPerWindow for KV-cache element type.
+    [[nodiscard]] std::map<SizeType32, nvinfer1::DataType> getDataTypePerWindow() const
+    {
+        std::map<SizeType32, nvinfer1::DataType> result;
+        for (auto const& [windowSize, manager] : mWindowBlockManagers)
+        {
+            result[windowSize] = manager.getDataType();
+        }
+        return result;
+    }
+
+    [[nodiscard]] SizeType32 getSizePerHeadForWindow(SizeType32 windowSize) const
+    {
+        return mWindowBlockManagers.at(windowSize).getSizePerHead();
+    }
+
+    [[nodiscard]] nvinfer1::DataType getDataTypeForWindow(SizeType32 windowSize) const
+    {
+        return mWindowBlockManagers.at(windowSize).getDataType();
     }
 
     [[nodiscard]] SizeType32 getNumFreeBlocks() const
@@ -1977,9 +2076,9 @@ public:
     ///          of memory requirements. The weighting considers both the window size and the number of
     ///          layers using each window size, as well as the sum of cache sizes per token for each window.
     /// @param config KV cache configuration parameters
-    /// @param dtype Data type used for KV cache values
+    /// @param dtype Default KV-cache data type (used for any window without an entry in @p dtypePerWindow)
     /// @param numKvHeadsPerLayer Number of KV heads for each local layer (caller selects self/cross attention heads)
-    /// @param sizePerHead Size of each attention head
+    /// @param sizePerHead Default head size (used for any window without an entry in @p sizePerHeadPerWindow)
     /// @param tokensPerBlock Number of tokens per KV cache block
     /// @param worldConfig World configuration for multi-GPU setups
     /// @param windowSizeToLayers Map from attention window size to vector of layer indices using that window size
@@ -1988,13 +2087,20 @@ public:
     /// @param extraCostMemory Additional memory cost to account for CacheTransBufferManager::preAllocBufferSize
     /// @param kvFactor Factor for KV cache size calculation (typically 2 for key+value)
     /// @param maxBatchSize Maximum batch size
+    /// @param linearAttentionMetadata Optional metadata for linear / recurrent state pools.
+    /// @param sizePerHeadPerWindow Optional per-window override of @p sizePerHead.  Lets a single
+    ///        BlockManager budget pools with distinct head dimensions (e.g. Gemma4 SWA head_dim=256
+    ///        + full-attention head_dim=512).  Empty map = uniform @p sizePerHead.
+    /// @param dtypePerWindow Optional per-window override of @p dtype.  Empty = uniform.
     /// @return Map from window size to tuple of (primary blocks, secondary blocks)
     [[nodiscard]] static BlocksPerWindow calculateMaxNumBlocks(executor::KvCacheConfig const& config,
         nvinfer1::DataType dtype, std::vector<SizeType32> const& numKvHeadsPerLayer, SizeType32 sizePerHead,
         SizeType32 tokensPerBlock, tensorrt_llm::runtime::WorldConfig const& worldConfig,
         std::map<SizeType32, std::vector<SizeType32>> const& windowSizeToLayers, uint64_t allottedPrimaryMemBytes,
         uint64_t allottedSecondaryMemBytes, size_t extraCostMemory, SizeType32 kvFactor, SizeType32 maxBatchSize,
-        std::optional<LinearAttentionMetadata> const& linearAttentionMetadata = std::nullopt);
+        std::optional<LinearAttentionMetadata> const& linearAttentionMetadata = std::nullopt,
+        std::map<SizeType32, SizeType32> const& sizePerHeadPerWindow = {},
+        std::map<SizeType32, nvinfer1::DataType> const& dtypePerWindow = {});
 
     /// @brief Calculates the maximum batch size that can fit the kv-cache, given that all sequences in the batch have
     /// the provided input and output length.
@@ -2042,6 +2148,16 @@ public:
     using CudaStreamPtr = std::shared_ptr<runtime::CudaStream>;
     using CacheType = tensorrt_llm::batch_manager::kv_cache_manager::CacheType;
 
+    //! \brief Construct a KVCacheManager.
+    //! \param sizePerHead Default head size used for any window without an entry in
+    //!        @p sizePerHeadPerWindow.
+    //! \param dtype Default KV-cache data type used for any window without an entry in
+    //!        @p dtypePerWindow.
+    //! \param sizePerHeadPerWindow Optional per-window override of @p sizePerHead.
+    //!        Hosts mixed-shape pools (e.g. Gemma4 SWA head_dim=256 + full head_dim=512)
+    //!        inside a single manager so the existing block reuse, scheduling, MPI
+    //!        reduction, and disagg transfer machinery applies natively.  Empty = uniform.
+    //! \param dtypePerWindow Optional per-window override of @p dtype.  Empty = uniform.
     KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         BlocksPerWindow const& blocksPerWindow, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,
         std::vector<SizeType32> const& maxAttentionWindowVec, nvinfer1::DataType dtype, SizeType32 sinkTokenLength,
@@ -2053,7 +2169,9 @@ public:
         std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
         bool enableIndexerKCache = false, SizeType32 indexerKCacheQuantBlockSize = 128,
         SizeType32 indexerKCacheIndexHeadDim = 0, bool indexerKCacheUseFp4 = false,
-        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt);
+        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt,
+        std::map<SizeType32, SizeType32> const& sizePerHeadPerWindow = {},
+        std::map<SizeType32, nvinfer1::DataType> const& dtypePerWindow = {});
 
     KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         BlocksPerWindow const& blocksPerWindow, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,
@@ -2066,7 +2184,9 @@ public:
         std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
         bool enableIndexerKCache = false, SizeType32 indexerKCacheQuantBlockSize = 128,
         SizeType32 indexerKCacheIndexHeadDim = 0, bool indexerKCacheUseFp4 = false,
-        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt);
+        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt,
+        std::map<SizeType32, SizeType32> const& sizePerHeadPerWindow = {},
+        std::map<SizeType32, nvinfer1::DataType> const& dtypePerWindow = {});
 
     KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         BlocksPerWindow const& blocksPerWindow, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,
@@ -2079,7 +2199,9 @@ public:
         std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager = nullptr,
         bool enableIndexerKCache = false, SizeType32 indexerKCacheQuantBlockSize = 128,
         SizeType32 indexerKCacheIndexHeadDim = 0, bool indexerKCacheUseFp4 = false,
-        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt);
+        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt,
+        std::map<SizeType32, SizeType32> const& sizePerHeadPerWindow = {},
+        std::map<SizeType32, nvinfer1::DataType> const& dtypePerWindow = {});
 
     KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, SizeType32 sizePerHead, SizeType32 tokensPerBlock,
         BlocksPerWindow const& blocksPerWindow, SizeType32 maxNumSequences, SizeType32 maxBeamWidth,
@@ -2088,7 +2210,9 @@ public:
         CacheType cacheType = CacheType::kSELF, bool enablePartialReuse = true, bool copyOnpartialReuse = true,
         bool enableIndexerKCache = false, SizeType32 indexerKCacheQuantBlockSize = 128,
         SizeType32 indexerKCacheIndexHeadDim = 0, bool indexerKCacheUseFp4 = false,
-        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt);
+        std::optional<LinearAttentionMetadata> linearAttentionMetadata = std::nullopt,
+        std::map<SizeType32, SizeType32> const& sizePerHeadPerWindow = {},
+        std::map<SizeType32, nvinfer1::DataType> const& dtypePerWindow = {});
 
     ~KVCacheManager() override = default;
 

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -652,6 +652,11 @@ void CacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& sess
     {
         NVTX3_SCOPED_RANGE(formatInputRecvBuffer);
 
+        // TODO(disagg-multi-dtype): pool 0's dtype is treated as canonical for the wire
+        // transport here.  Pools with differing dtypes are rejected up-front in
+        // CacheTransBufferManager's constructor (see cacheTransBuffer.cpp).  When
+        // per-pool dtype dispatch lands, this single dataType variable must be replaced
+        // with a per-pool lookup keyed by the source pool of each block.
         auto dataType = mCacheManager->getPrimaryPool(0)->getDataType();
         bool layerWise = common::getEnvDisaggLayerwise() && numPools == 1;
         if (layerWise)

--- a/cpp/tensorrt_llm/batch_manager/cacheTransBuffer.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransBuffer.cpp
@@ -253,6 +253,28 @@ CacheTransBufferManager::CacheTransBufferManager(
 {
     // TODO: FP4 dataSize
     TLLM_CHECK(mCacheManager);
+    // TODO(disagg-multi-dtype): Per-pool dtype dispatch in formatter / transfer buffer
+    // not yet implemented.  Disagg currently picks pool 0's dtype as the canonical
+    // transport type (above), so any KV pool with a different dtype would be silently
+    // miscoerced on the wire.  Fail loudly until per-pool dispatch lands.  We restrict
+    // the comparison to KV pools (getNumPools(false, false)) since block-scale and
+    // indexer-K pools legitimately have their own dtypes and travel through their own
+    // code paths.
+    if (!transferIndexerKCache)
+    {
+        auto const numKvPools = mCacheManager->getBlockManager().getNumPools(
+            /*includeBlockScalePools=*/false, /*includeIndexerKCachePools=*/false);
+        auto const dtype0 = mCacheManager->getPrimaryPool(0)->getDataType();
+        for (SizeType32 i = 1; i < numKvPools; ++i)
+        {
+            auto const dtypeI = mCacheManager->getPrimaryPool(i)->getDataType();
+            TLLM_CHECK_WITH_INFO(dtypeI == dtype0,
+                "Disaggregated KV cache transfer does not yet support pools with differing dtypes "
+                "(pool 0 dtype=%d, pool %d dtype=%d). TODO(disagg-multi-dtype): per-pool dtype "
+                "dispatch in formatter.",
+                static_cast<int>(dtype0), i, static_cast<int>(dtypeI));
+        }
+    }
     TLLM_LOG_INFO("CacheTransBufferManager created for KV cache");
 }
 

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -582,7 +582,9 @@ BlockManager::BlockManager(std::vector<SizeType32> const& numKvHeadsPerLayer, Si
     std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager,
     std::optional<BaseAgentConfig> agentConfig, bool enableIndexerKCache, SizeType32 indexerKCacheQuantBlockSize,
     SizeType32 indexerKCacheIndexHeadDim, bool indexerKCacheUseFp4,
-    std::optional<LinearAttentionMetadata> linearAttentionMetadata)
+    std::optional<LinearAttentionMetadata> linearAttentionMetadata,
+    std::map<SizeType32, SizeType32> const& sizePerHeadPerWindow,
+    std::map<SizeType32, nvinfer1::DataType> const& dtypePerWindow)
     : mNumLayers{static_cast<SizeType32>(numKvHeadsPerLayer.size())}
     , mTokensPerBlock{tokensPerBlock}
     , mEventManager{std::move(eventManager)}
@@ -658,8 +660,17 @@ BlockManager::BlockManager(std::vector<SizeType32> const& numKvHeadsPerLayer, Si
             }
         }
 
-        mWindowBlockManagers.try_emplace(SizeType32(windowSize), dtype, windowSize, layersWithWindowSize,
-            numKvHeadsPerLayer, sizePerHead, tokensPerBlock,
+        // Per-window head_dim and dtype: fall back to the scalars if no override was supplied.
+        // Lets a single BlockManager host pools with distinct shapes (Gemma4-style mixed
+        // attention types) without giving up the existing radix-tree / scheduler / disagg
+        // machinery that already iterates pools internally.
+        auto const sizePerHeadIt = sizePerHeadPerWindow.find(windowSize);
+        auto const windowSizePerHead
+            = (sizePerHeadIt != sizePerHeadPerWindow.end()) ? sizePerHeadIt->second : sizePerHead;
+        auto const dtypeIt = dtypePerWindow.find(windowSize);
+        auto const windowDtype = (dtypeIt != dtypePerWindow.end()) ? dtypeIt->second : dtype;
+        mWindowBlockManagers.try_emplace(SizeType32(windowSize), windowDtype, windowSize, layersWithWindowSize,
+            numKvHeadsPerLayer, windowSizePerHead, tokensPerBlock,
             /*isSWA=*/(windowSize < maxSequenceLength) && (windowSize >= 0), allottedPrimaryBlocks,
             allottedSecondaryBlocks, maxNumSequences, stream, cacheType, secondaryOffloadMinPriority, mEventManager,
             enablePartialReuse, copyOnPartialReuse, kvCacheConnectorManager, mLookupTree, mLoopbackAgent,
@@ -2173,7 +2184,7 @@ void WindowBlockManager::adjustBlocksIfNeeded(GenerationRequest& sequence)
 {
     auto const minTokensForBlockDetach = mWindowSize + mTokensPerBlock;
     while (mIsSWA && // A block only go out-of-window in SWA
-        (sequence.getNumTokens() - sequence.getNumFrontBlocksRemoved() * getTokensPerBlock()
+        (sequence.getNumTokens() - sequence.getNumFrontBlocksRemoved(mWindowSize) * getTokensPerBlock()
             >= minTokensForBlockDetach))
     {
         // Detaching block for SWA is non-trivial due to the radix tree structure.
@@ -2866,11 +2877,18 @@ void BlockManager::pinBlocks(GenerationRequest& sequence)
 
 void BlockManager::unpinBlocksById(std::vector<KVCacheBlock::IdType> const& blockIds)
 {
-    // Use the first window size
     if (mWindowBlockManagers.empty())
     {
         return;
     }
+    // Block IDs are window-scoped (each WindowBlockManager owns its own
+    // mAllBlocksById vector), so silently dispatching to the first window
+    // would corrupt refcounts whenever the caller's IDs belong to a different
+    // window.  Multi-window block-ID-keyed retention pinning needs
+    // window-qualified handles; until that lands, refuse the multi-window case.
+    TLLM_CHECK_WITH_INFO(mWindowBlockManagers.size() == 1,
+        "BlockManager::unpinBlocksById currently only supports single-window managers; "
+        "multi-window block-ID-keyed retention pinning requires window-qualified handles (TODO).");
     auto& firstManager = mWindowBlockManagers.begin()->second;
     firstManager.unpinBlocksById(blockIds);
 }
@@ -3067,9 +3085,11 @@ std::optional<KVCacheBlock::IdType> WindowBlockManager::releaseBlocks(
         TLLM_LOG_DEBUG("%s::releaseBlocks Request %lu, %d blocks stored for reuse", mLogPrefix.c_str(),
             sequence.getRequestId(), numBlocksStoredForReuse);
     }
-    // Iterate all allocated blocks (including placeholder sentinels at OOW positions);
-    // EvictionPolicy::releaseBlock silently skips placeholders.
-    for (auto it = allocatedBlocks.rbegin(); it != allocatedBlocks.rend(); ++it)
+    // Stop short of any front placeholder sentinels left by SWA detachFrontBlock for
+    // this window — they live at the front of allocatedBlocks (i.e. the tail of the
+    // reverse iteration) and have no ref counts to release.
+    for (auto it = allocatedBlocks.rbegin();
+         it != allocatedBlocks.rend() - sequence.getNumFrontBlocksRemoved(mWindowSize); ++it)
     {
         auto& block = *it;
         // Decrease ref count
@@ -3124,13 +3144,15 @@ KVCacheManager::KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, Size
     SizeType32 sinkTokenLength, int64_t stream, runtime::SizeType32 maxSequenceLength, SizeType32 chunkSize,
     bool enableBlockReuse, CacheType cacheType, bool enablePartialReuse, bool copyOnPartialReuse,
     bool enableIndexerKCache, SizeType32 indexerKCacheQuantBlockSize, SizeType32 indexerKCacheIndexHeadDim,
-    bool indexerKCacheUseFp4, std::optional<LinearAttentionMetadata> linearAttentionMetadata)
+    bool indexerKCacheUseFp4, std::optional<LinearAttentionMetadata> linearAttentionMetadata,
+    std::map<SizeType32, SizeType32> const& sizePerHeadPerWindow,
+    std::map<SizeType32, nvinfer1::DataType> const& dtypePerWindow)
     : KVCacheManager(std::vector<SizeType32>(numLayers, numKvHeads), sizePerHead, tokensPerBlock, blocksPerWindow,
         maxNumSequences, maxBeamWidth, maxAttentionWindowVec, dtype, sinkTokenLength,
         std::make_shared<runtime::CudaStream>(reinterpret_cast<cudaStream_t>(stream)), maxSequenceLength, chunkSize,
         enableBlockReuse, cacheType, std::nullopt, nullptr, enablePartialReuse, copyOnPartialReuse, nullptr,
         enableIndexerKCache, indexerKCacheQuantBlockSize, indexerKCacheIndexHeadDim, indexerKCacheUseFp4,
-        linearAttentionMetadata)
+        linearAttentionMetadata, sizePerHeadPerWindow, dtypePerWindow)
 {
 }
 
@@ -3142,13 +3164,15 @@ KVCacheManager::KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer
     std::shared_ptr<KVCacheEventManager> eventManager, bool enablePartialReuse, bool copyOnPartialReuse,
     std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager, bool enableIndexerKCache,
     SizeType32 indexerKCacheQuantBlockSize, SizeType32 indexerKCacheIndexHeadDim, bool indexerKCacheUseFp4,
-    std::optional<LinearAttentionMetadata> linearAttentionMetadata)
+    std::optional<LinearAttentionMetadata> linearAttentionMetadata,
+    std::map<SizeType32, SizeType32> const& sizePerHeadPerWindow,
+    std::map<SizeType32, nvinfer1::DataType> const& dtypePerWindow)
     : KVCacheManager(numKvHeadsPerLayer, sizePerHead, tokensPerBlock, blocksPerWindow, maxNumSequences, maxBeamWidth,
         maxAttentionWindowVec, dtype, sinkTokenLength,
         std::make_shared<runtime::CudaStream>(reinterpret_cast<cudaStream_t>(stream)), maxSequenceLength, chunkSize,
         enableBlockReuse, cacheType, secondaryOffloadMinPriority, eventManager, enablePartialReuse, copyOnPartialReuse,
         kvCacheConnectorManager, enableIndexerKCache, indexerKCacheQuantBlockSize, indexerKCacheIndexHeadDim,
-        indexerKCacheUseFp4, linearAttentionMetadata)
+        indexerKCacheUseFp4, linearAttentionMetadata, sizePerHeadPerWindow, dtypePerWindow)
 {
 }
 
@@ -3160,7 +3184,9 @@ KVCacheManager::KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer
     std::shared_ptr<KVCacheEventManager> eventManager, bool enablePartialReuse, bool copyOnPartialReuse,
     std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager, bool enableIndexerKCache,
     SizeType32 indexerKCacheQuantBlockSize, SizeType32 indexerKCacheIndexHeadDim, bool indexerKCacheUseFp4,
-    std::optional<LinearAttentionMetadata> linearAttentionMetadata)
+    std::optional<LinearAttentionMetadata> linearAttentionMetadata,
+    std::map<SizeType32, SizeType32> const& sizePerHeadPerWindow,
+    std::map<SizeType32, nvinfer1::DataType> const& dtypePerWindow)
     : mMaxBeamWidth(maxBeamWidth)
     , mDataType(dtype)
     , mMaxAttentionWindow(*std::max_element(maxAttentionWindowVec.begin(), maxAttentionWindowVec.end()))
@@ -3172,7 +3198,8 @@ KVCacheManager::KVCacheManager(std::vector<SizeType32> const& numKvHeadsPerLayer
           std::move(stream), maxSequenceLength, maxBeamWidth, maxAttentionWindowVec, dtype, mSinkBubbleLength,
           mChunkSize, cacheType, secondaryOffloadMinPriority, std::move(eventManager), enablePartialReuse,
           copyOnPartialReuse, std::move(kvCacheConnectorManager), std::nullopt, enableIndexerKCache,
-          indexerKCacheQuantBlockSize, indexerKCacheIndexHeadDim, indexerKCacheUseFp4, linearAttentionMetadata)
+          indexerKCacheQuantBlockSize, indexerKCacheIndexHeadDim, indexerKCacheUseFp4, linearAttentionMetadata,
+          sizePerHeadPerWindow, dtypePerWindow)
     // disable block reuse for sink bubble since chopVectorIntoBlocks does not match KV cache blocks in this case
     , mEnableBlockReuse{mSinkBubbleLength > 0 ? false : enableBlockReuse}
 {
@@ -3200,12 +3227,15 @@ KVCacheManager::KVCacheManager(SizeType32 numLayers, SizeType32 numKvHeads, Size
     std::shared_ptr<KVCacheEventManager> eventManager, bool enablePartialReuse, bool copyOnPartialReuse,
     std::shared_ptr<kv_connector::KvCacheConnectorManager> kvCacheConnectorManager, bool enableIndexerKCache,
     SizeType32 indexerKCacheQuantBlockSize, SizeType32 indexerKCacheIndexHeadDim, bool indexerKCacheUseFp4,
-    std::optional<LinearAttentionMetadata> linearAttentionMetadata)
+    std::optional<LinearAttentionMetadata> linearAttentionMetadata,
+    std::map<SizeType32, SizeType32> const& sizePerHeadPerWindow,
+    std::map<SizeType32, nvinfer1::DataType> const& dtypePerWindow)
     : KVCacheManager(std::vector<SizeType32>(numLayers, numKvHeads), sizePerHead, tokensPerBlock, blocksPerWindow,
         maxNumSequences, maxBeamWidth, maxAttentionWindowVec, dtype, sinkTokenLength, std::move(stream),
         maxSequenceLength, chunkSize, enableBlockReuse, cacheType, secondaryOffloadMinPriority, std::move(eventManager),
         enablePartialReuse, copyOnPartialReuse, std::move(kvCacheConnectorManager), enableIndexerKCache,
-        indexerKCacheQuantBlockSize, indexerKCacheIndexHeadDim, indexerKCacheUseFp4, linearAttentionMetadata)
+        indexerKCacheQuantBlockSize, indexerKCacheIndexHeadDim, indexerKCacheUseFp4, linearAttentionMetadata,
+        sizePerHeadPerWindow, dtypePerWindow)
 {
 }
 
@@ -3217,16 +3247,21 @@ void KVCacheManager::allocatePools(bool useUvm)
     uint64_t cacheSizeBytes = 0;
     for (SizeType32 poolIdx = 0; poolIdx < numPools; poolIdx++)
     {
-        auto const cacheShape = mBlockManager.getPrimaryPool(poolIdx)->getShape();
+        auto const& primaryPool = mBlockManager.getPrimaryPool(poolIdx);
+        auto const cacheShape = primaryPool->getShape();
         auto const cacheVolume = ITensor::volume(cacheShape);
+        // Query the per-pool dtype from the tensor itself rather than the manager-level
+        // mDataType.  Each pool may carry its own dtype: NVFP4 element / scale pools, or
+        // a future per-window override map can mix precisions inside a single manager.
+        auto const poolDataType = primaryPool->getDataType();
 #ifdef ENABLE_FP4
-        auto const isFp4 = mDataType == nvinfer1::DataType::kFP4;
+        auto const isFp4 = poolDataType == nvinfer1::DataType::kFP4;
 #else
         auto const isFp4 = false;
 #endif
         if (!isFp4)
         {
-            cacheSizeBytes += cacheVolume * BufferDataType(mDataType).getSize();
+            cacheSizeBytes += cacheVolume * BufferDataType(poolDataType).getSize();
         }
         else
         {
@@ -3426,7 +3461,8 @@ SizeType32 KVCacheManager::getRemainingBlocksToCompletion(
             auto const& seq = seqIt->second;
             // Subtract detached front blocks (from SWA sliding) which are still
             // in the cache block ID list but no longer held by the sequence.
-            numAllocBlocksPerBeam = seq.getCacheBlockIds(windowSize).at(0).size() - seq.getNumFrontBlocksRemoved();
+            numAllocBlocksPerBeam
+                = seq.getCacheBlockIds(windowSize).at(0).size() - seq.getNumFrontBlocksRemoved(windowSize);
         }
     }
 
@@ -3564,7 +3600,7 @@ void WindowBlockManager::detachFrontBlock(GenerationRequest& sequence)
     auto const requestId = sequence.getRequestId();
     auto const beamWidth = sequence.getBeamWidth();
     auto& allocatedBlocks = mAllocatedBlocksPerSeq.at(requestId);
-    SizeType32 outOfWindowBlockIdx = sequence.getNumFrontBlocksRemoved();
+    SizeType32 outOfWindowBlockIdx = sequence.getNumFrontBlocksRemoved(mWindowSize);
 
     for (auto beamIdx = 0; beamIdx < beamWidth; ++beamIdx)
     {
@@ -3607,6 +3643,12 @@ void WindowBlockManager::detachFrontBlock(GenerationRequest& sequence)
 
     // Disconnect first block from sequence and remove it from allocated blocks
     sequence.removeFrontBlock(mWindowSize);
+
+    // Surface the per-window eviction count post-increment so logs show the
+    // running counter for *this* window (the existing block-id log above only
+    // identifies which physical block was detached).
+    TLLM_LOG_DEBUG("%s::detachFrontBlock window=%d count=%d", mLogPrefix.c_str(), mWindowSize,
+        sequence.getNumFrontBlocksRemoved(mWindowSize));
 }
 
 PrefixReuseSummary KVCacheManager::analyzePrefixReuse(
@@ -4104,7 +4146,9 @@ BlocksPerWindow BaseKVCacheManager::calculateMaxNumBlocks(executor::KvCacheConfi
     SizeType32 tokensPerBlock, WorldConfig const& worldConfig,
     std::map<SizeType32, std::vector<SizeType32>> const& windowSizeToLayers, uint64_t allottedPrimaryMemBytes,
     uint64_t allottedSecondaryMemBytes, size_t extraCostMemory, SizeType32 kvFactor, SizeType32 maxBatchSize,
-    std::optional<LinearAttentionMetadata> const& linearAttentionMetadata)
+    std::optional<LinearAttentionMetadata> const& linearAttentionMetadata,
+    std::map<SizeType32, SizeType32> const& sizePerHeadPerWindow,
+    std::map<SizeType32, nvinfer1::DataType> const& dtypePerWindow)
 {
     TLLM_LOG_DEBUG("Calculating max num blocks: {.allottedPrimaryMemBytes=%" PRIu64
                    ", .allottedSecondaryMemBytes=%" PRIu64 "}",
@@ -4122,12 +4166,23 @@ BlocksPerWindow BaseKVCacheManager::calculateMaxNumBlocks(executor::KvCacheConfi
     std::map<SizeType32, SizeType32> cacheSizeBytesPerTokenPerWindow;
     for (auto const& [windowSize, managedLayers] : windowSizeToLayers)
     {
-        auto const cacheSizePerToken = LinearAttentionMetadata::hasLinearCache(windowSize)
-            ? 1
-            : BaseKVCacheManager::calculateCacheSizePerTokenForSingleWindowSize(
-                numKvHeadsPerLayer, sizePerHead, managedLayers, kvFactor);
-        auto const cacheSizeBytesPerToken = cacheSizePerToken * BufferDataType(dtype).getSize();
-        cacheSizeBytesPerTokenPerWindow[windowSize] = cacheSizeBytesPerToken;
+        if (LinearAttentionMetadata::hasLinearCache(windowSize))
+        {
+            cacheSizeBytesPerTokenPerWindow[windowSize] = 1;
+            continue;
+        }
+        // Per-window head_dim and dtype: if the caller supplied an override map,
+        // use it; otherwise fall back to the scalars. This budgets pools whose
+        // (head_dim, dtype) differ across windows (Gemma4-style mixed attention)
+        // through the same single-manager path the rest of the C++ machinery uses.
+        auto const sizePerHeadIt = sizePerHeadPerWindow.find(windowSize);
+        auto const windowSizePerHead
+            = (sizePerHeadIt != sizePerHeadPerWindow.end()) ? sizePerHeadIt->second : sizePerHead;
+        auto const dtypeIt = dtypePerWindow.find(windowSize);
+        auto const windowDtype = (dtypeIt != dtypePerWindow.end()) ? dtypeIt->second : dtype;
+        auto const cacheSizePerToken = BaseKVCacheManager::calculateCacheSizePerTokenForSingleWindowSize(
+            numKvHeadsPerLayer, windowSizePerHead, managedLayers, kvFactor);
+        cacheSizeBytesPerTokenPerWindow[windowSize] = cacheSizePerToken * BufferDataType(windowDtype).getSize();
     }
 
     // When the model is mamba hybrid (i.e. has only 2 windows sizes: max_seq_len and

--- a/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/kvCacheManager.cpp
@@ -406,6 +406,8 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
             nb::arg("world_config"), nb::arg("window_size_to_layers"), nb::arg("allotted_primary_mem_bytes"),
             nb::arg("allotted_secondary_mem_bytes"), nb::arg("extra_cost_memory"), nb::arg("kv_factor"),
             nb::arg("max_batch_size"), nb::arg("linear_attention_metadata") = std::nullopt,
+            nb::arg("size_per_head_per_window") = std::map<SizeType32, SizeType32>{},
+            nb::arg("dtype_per_window") = std::map<SizeType32, nvinfer1::DataType>{},
             nb::call_guard<nb::gil_scoped_release>())
         .def("allocate_pools", &BaseKVCacheManager::allocatePools, nb::call_guard<nb::gil_scoped_release>())
         .def("release_pools", &BaseKVCacheManager::releasePools, nb::call_guard<nb::gil_scoped_release>())
@@ -588,6 +590,18 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
         .def("analyze_prefix_reuse", &BaseKVCacheManager::analyzePrefixReuse, nb::arg("unique_tokens"),
             nb::arg("llm_request"), nb::call_guard<nb::gil_scoped_release>())
         .def("get_cache_block_ids", &BaseKVCacheManager::getCacheBlockIds, nb::call_guard<nb::gil_scoped_release>())
+        .def(
+            "get_num_front_blocks_removed",
+            [](BaseKVCacheManager const& self, tb::LlmRequest::RequestIdType requestId, SizeType32 windowSize)
+            {
+                auto const& seq = self.getSequence(requestId);
+                // Per-window query.  windowSize is required (no aggregation): the Python
+                // wrapper in resource_manager.py provides a "default to first window"
+                // convenience layer; the C++/nanobind boundary stays explicit so that
+                // every caller is forced to think about which pool's counter it wants.
+                return seq.getNumFrontBlocksRemoved(windowSize);
+            },
+            nb::arg("request_id"), nb::arg("window_size"), nb::call_guard<nb::gil_scoped_release>())
         .def("get_batch_cache_block_ids", &BaseKVCacheManager::getBatchCacheBlockIds,
             nb::call_guard<nb::gil_scoped_release>())
         .def("flush_iteration_events", &BaseKVCacheManager::flushIterationEvents,
@@ -622,7 +636,8 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
                  std::vector<SizeType32> const&, nvinfer1::DataType, SizeType32, int64_t, SizeType32, SizeType32, bool,
                  tbk::CacheType, std::optional<tensorrt_llm::executor::RetentionPriority>,
                  std::shared_ptr<tbk::KVCacheEventManager>, bool, bool, std::shared_ptr<tbc::KvCacheConnectorManager>,
-                 bool, SizeType32, SizeType32, bool, std::optional<tbk::LinearAttentionMetadata>>(),
+                 bool, SizeType32, SizeType32, bool, std::optional<tbk::LinearAttentionMetadata>,
+                 std::map<SizeType32, SizeType32> const&, std::map<SizeType32, nvinfer1::DataType> const&>(),
             nb::arg("num_kv_heads_per_layer"), nb::arg("size_per_head"), nb::arg("tokens_per_block"),
             nb::arg("blocks_per_window"), nb::arg("max_num_sequences"), nb::arg("max_beam_width"),
             nb::arg("max_attention_window_vec"), nb::arg("dtype"), nb::arg("sink_token_length"), nb::arg("stream"),
@@ -632,7 +647,10 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
             nb::arg("copy_on_partial_reuse") = true, nb::arg("kv_connector_manager") = nullptr,
             nb::arg("enable_indexer_k_cache") = false, nb::arg("indexer_k_cache_quant_block_size") = 128,
             nb::arg("indexer_k_cache_index_head_dim") = 0, nb::arg("indexer_k_cache_use_fp4") = false,
-            nb::arg("linear_attention_metadata").none() = std::nullopt, nb::call_guard<nb::gil_scoped_release>())
+            nb::arg("linear_attention_metadata").none() = std::nullopt,
+            nb::arg("size_per_head_per_window") = std::map<SizeType32, SizeType32>{},
+            nb::arg("dtype_per_window") = std::map<SizeType32, nvinfer1::DataType>{},
+            nb::call_guard<nb::gil_scoped_release>())
         .def(
             "scheduling_has_free_blocks",
             [](tbk::KVCacheManager& self, SizeType32 numRequired, SizeType32 windowSize)
@@ -640,6 +658,13 @@ void tb::kv_cache_manager::KVCacheManagerBindings::initBindings(nb::module_& m)
             nb::arg("num_required"), nb::arg("window_size"), nb::call_guard<nb::gil_scoped_release>())
         .def_prop_ro(
             "is_variable_window", [](tbk::KVCacheManager& self) { return self.getBlockManager().isVariableWindow(); })
+        // Per-window introspection helpers — let Python discover (windowSize → head_dim) and
+        // (windowSize → dtype) so a single KVCacheManager can host mixed-shape pools without
+        // a Python-side wrapper duplicating the layer→pool routing.
+        .def_prop_ro("size_per_head_per_window",
+            [](tbk::KVCacheManager& self) { return self.getBlockManager().getSizePerHeadPerWindow(); })
+        .def_prop_ro(
+            "dtype_per_window", [](tbk::KVCacheManager& self) { return self.getBlockManager().getDataTypePerWindow(); })
         .def("copy_linear_attention_block", &tbk::KVCacheManager::copyLinearAttentionBlock, nb::arg("llm_request"),
             nb::call_guard<nb::gil_scoped_release>());
 }

--- a/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/kvCacheManagerTest.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "tensorrt_llm/batch_manager/kvCacheManager.h"
+#include "tensorrt_llm/batch_manager/cacheTransBuffer.h"
 #include "tensorrt_llm/batch_manager/common.h"
 #include "tensorrt_llm/batch_manager/kvCacheConnector.h"
 #include "tensorrt_llm/batch_manager/kvCacheEventManager.h"
@@ -9797,4 +9798,514 @@ TEST_F(KVCacheManagerTest, KvCacheConnector_DecodeBlockBoundary_ParityWithBaseli
             << "Block count diverged at decode step " << i << " (baseline=" << baseline[i]
             << ", withConnector=" << withConnector[i] << "); see issue #13320";
     }
+}
+
+// =============================================================================
+// Per-window head_dim / dtype overrides on BlockManager and KVCacheManager,
+// plus per-window front-eviction bookkeeping on GenerationRequest.
+// Production surface added in commits 1c273f0594 and 823d6ea0e1; the previous
+// tests (KVCacheManagerVariableWindowAttentionWithReuseTest, FP4BlockScaleManagementTest)
+// only exercise uniform-shape pools.
+// =============================================================================
+
+namespace
+{
+//! \brief Find the absolute pool index whose window size matches @p windowSize.
+SizeType32 findPoolIdxForWindow(BlockManager const& blockManager, SizeType32 windowSize)
+{
+    auto const numPools = blockManager.getNumPools(/*includeBlockScalePools=*/false);
+    for (SizeType32 poolIdx = 0; poolIdx < numPools; ++poolIdx)
+    {
+        if (blockManager.getPoolWindowSize(poolIdx) == windowSize)
+        {
+            return poolIdx;
+        }
+    }
+    TLLM_THROW("No pool found for window size %d", windowSize);
+}
+} // namespace
+
+TEST_F(KVCacheManagerTest, BlockManagerTestPerWindowSizePerHead)
+{
+    auto constexpr numLayers = 2;
+    auto constexpr numKvHeads = 2;
+    auto constexpr scalarSizePerHead = 64;
+    auto constexpr tokensPerBlock = 4;
+    auto constexpr blocksInPrimary = 4;
+    auto constexpr blocksInSecondary = 0;
+    auto constexpr maxNumSequences = 4;
+    auto constexpr maxBeamWidth = 1;
+    auto constexpr smallWindow = 1024;
+    auto constexpr largeWindow = 4096;
+    auto constexpr smallSizePerHead = 64;
+    auto constexpr largeSizePerHead = 128;
+    auto const stream = std::make_shared<tr::CudaStream>();
+    auto const maxAttentionWindowVec = std::vector<SizeType32>{smallWindow, largeWindow};
+    auto const blocksPerWindow = BlocksPerWindow{
+        {smallWindow, {blocksInPrimary, blocksInSecondary}}, {largeWindow, {blocksInPrimary, blocksInSecondary}}};
+    auto const sizePerHeadPerWindow
+        = std::map<SizeType32, SizeType32>{{smallWindow, smallSizePerHead}, {largeWindow, largeSizePerHead}};
+
+    BlockManager blockManager(std::vector<BlockManager::SizeType32>(numLayers, numKvHeads), scalarSizePerHead,
+        tokensPerBlock, blocksPerWindow, maxNumSequences, stream, /*maxSequenceLength=*/largeWindow, maxBeamWidth,
+        maxAttentionWindowVec, nvinfer1::DataType::kHALF, /*sinkBubbleLength=*/0, /*chunkSize=*/0, CacheType::kSELF,
+        /*secondaryOffloadMinPriority=*/std::nullopt, /*eventManager=*/nullptr,
+        /*enablePartialReuse=*/true, /*copyOnPartialReuse=*/true, /*kvCacheConnectorManager=*/nullptr,
+        /*agentConfig=*/std::nullopt, /*enableIndexerKCache=*/false,
+        /*indexerKCacheQuantBlockSize=*/128, /*indexerKCacheIndexHeadDim=*/0, /*indexerKCacheUseFp4=*/false,
+        /*linearAttentionMetadata=*/std::nullopt, sizePerHeadPerWindow);
+    blockManager.allocatePools(/*useUvm=*/false);
+
+    auto const perWindow = blockManager.getSizePerHeadPerWindow();
+    ASSERT_EQ(perWindow.size(), 2u);
+    EXPECT_EQ(perWindow.at(smallWindow), smallSizePerHead);
+    EXPECT_EQ(perWindow.at(largeWindow), largeSizePerHead);
+    EXPECT_EQ(blockManager.getSizePerHeadForWindow(smallWindow), smallSizePerHead);
+    EXPECT_EQ(blockManager.getSizePerHeadForWindow(largeWindow), largeSizePerHead);
+
+    // Each WindowBlockManager has its own KVCacheBlockPool::sizePerHead reflecting the override.
+    auto const smallPoolIdx = findPoolIdxForWindow(blockManager, smallWindow);
+    auto const largePoolIdx = findPoolIdxForWindow(blockManager, largeWindow);
+    EXPECT_EQ(blockManager.getPool(smallPoolIdx).sizePerHead, smallSizePerHead);
+    EXPECT_EQ(blockManager.getPool(largePoolIdx).sizePerHead, largeSizePerHead);
+    EXPECT_NE(blockManager.getPool(smallPoolIdx).sizePerHead, blockManager.getPool(largePoolIdx).sizePerHead);
+    // blockSize = numKvHeads * sizePerHead * tokensPerBlock — should also differ accordingly.
+    EXPECT_EQ(blockManager.getPool(smallPoolIdx).blockSize, numKvHeads * smallSizePerHead * tokensPerBlock);
+    EXPECT_EQ(blockManager.getPool(largePoolIdx).blockSize, numKvHeads * largeSizePerHead * tokensPerBlock);
+}
+
+TEST_F(KVCacheManagerTest, BlockManagerTestPerWindowDataType)
+{
+    auto constexpr numLayers = 2;
+    auto constexpr numKvHeads = 2;
+    auto constexpr sizePerHead = 64;
+    auto constexpr tokensPerBlock = 4;
+    auto constexpr blocksInPrimary = 4;
+    auto constexpr blocksInSecondary = 0;
+    auto constexpr maxNumSequences = 4;
+    auto constexpr maxBeamWidth = 1;
+    auto constexpr smallWindow = 1024;
+    auto constexpr largeWindow = 4096;
+    auto const stream = std::make_shared<tr::CudaStream>();
+    auto const maxAttentionWindowVec = std::vector<SizeType32>{smallWindow, largeWindow};
+    auto const blocksPerWindow = BlocksPerWindow{
+        {smallWindow, {blocksInPrimary, blocksInSecondary}}, {largeWindow, {blocksInPrimary, blocksInSecondary}}};
+    auto const dtypePerWindow = std::map<SizeType32, nvinfer1::DataType>{
+        {smallWindow, nvinfer1::DataType::kHALF}, {largeWindow, nvinfer1::DataType::kBF16}};
+
+    BlockManager blockManager(std::vector<BlockManager::SizeType32>(numLayers, numKvHeads), sizePerHead, tokensPerBlock,
+        blocksPerWindow, maxNumSequences, stream, /*maxSequenceLength=*/largeWindow, maxBeamWidth,
+        maxAttentionWindowVec,
+        /*scalarDtype=*/nvinfer1::DataType::kFLOAT, /*sinkBubbleLength=*/0, /*chunkSize=*/0, CacheType::kSELF,
+        /*secondaryOffloadMinPriority=*/std::nullopt, /*eventManager=*/nullptr,
+        /*enablePartialReuse=*/true, /*copyOnPartialReuse=*/true, /*kvCacheConnectorManager=*/nullptr,
+        /*agentConfig=*/std::nullopt, /*enableIndexerKCache=*/false,
+        /*indexerKCacheQuantBlockSize=*/128, /*indexerKCacheIndexHeadDim=*/0, /*indexerKCacheUseFp4=*/false,
+        /*linearAttentionMetadata=*/std::nullopt, /*sizePerHeadPerWindow=*/{}, dtypePerWindow);
+    blockManager.allocatePools(/*useUvm=*/false);
+
+    auto const perWindow = blockManager.getDataTypePerWindow();
+    ASSERT_EQ(perWindow.size(), 2u);
+    EXPECT_EQ(perWindow.at(smallWindow), nvinfer1::DataType::kHALF);
+    EXPECT_EQ(perWindow.at(largeWindow), nvinfer1::DataType::kBF16);
+    EXPECT_EQ(blockManager.getDataTypeForWindow(smallWindow), nvinfer1::DataType::kHALF);
+    EXPECT_EQ(blockManager.getDataTypeForWindow(largeWindow), nvinfer1::DataType::kBF16);
+    EXPECT_NE(blockManager.getDataTypeForWindow(smallWindow), blockManager.getDataTypeForWindow(largeWindow));
+}
+
+TEST_F(KVCacheManagerTest, BlockManagerTestPerWindowFallback)
+{
+    auto constexpr numLayers = 2;
+    auto constexpr numKvHeads = 2;
+    auto constexpr scalarSizePerHead = 64;
+    auto constexpr tokensPerBlock = 4;
+    auto constexpr blocksInPrimary = 4;
+    auto constexpr blocksInSecondary = 0;
+    auto constexpr maxNumSequences = 4;
+    auto constexpr maxBeamWidth = 1;
+    auto constexpr smallWindow = 1024;
+    auto constexpr largeWindow = 4096;
+    auto constexpr scalarDtype = nvinfer1::DataType::kHALF;
+    auto const stream = std::make_shared<tr::CudaStream>();
+    auto const maxAttentionWindowVec = std::vector<SizeType32>{smallWindow, largeWindow};
+    auto const blocksPerWindow = BlocksPerWindow{
+        {smallWindow, {blocksInPrimary, blocksInSecondary}}, {largeWindow, {blocksInPrimary, blocksInSecondary}}};
+
+    // No per-window overrides — expect both windows to fall back to scalars.
+    BlockManager blockManager(std::vector<BlockManager::SizeType32>(numLayers, numKvHeads), scalarSizePerHead,
+        tokensPerBlock, blocksPerWindow, maxNumSequences, stream, /*maxSequenceLength=*/largeWindow, maxBeamWidth,
+        maxAttentionWindowVec, scalarDtype, /*sinkBubbleLength=*/0, /*chunkSize=*/0);
+    blockManager.allocatePools(/*useUvm=*/false);
+
+    auto const perWindowSizePerHead = blockManager.getSizePerHeadPerWindow();
+    auto const perWindowDtype = blockManager.getDataTypePerWindow();
+    ASSERT_EQ(perWindowSizePerHead.size(), 2u);
+    ASSERT_EQ(perWindowDtype.size(), 2u);
+    EXPECT_EQ(perWindowSizePerHead.at(smallWindow), scalarSizePerHead);
+    EXPECT_EQ(perWindowSizePerHead.at(largeWindow), scalarSizePerHead);
+    EXPECT_EQ(perWindowDtype.at(smallWindow), scalarDtype);
+    EXPECT_EQ(perWindowDtype.at(largeWindow), scalarDtype);
+    EXPECT_EQ(blockManager.getSizePerHeadForWindow(smallWindow), blockManager.getSizePerHeadForWindow(largeWindow));
+    EXPECT_EQ(blockManager.getDataTypeForWindow(smallWindow), blockManager.getDataTypeForWindow(largeWindow));
+}
+
+// Static; does not require a GPU device.
+TEST(BaseKVCacheManagerCalculateMaxNumBlocks, PerWindowOverrideDivergesByteBudget)
+{
+    using SizeType32 = tensorrt_llm::runtime::SizeType32;
+    auto constexpr numLayers = 2;
+    auto constexpr numKvHeads = 2;
+    auto constexpr scalarSizePerHead = 64;
+    auto constexpr largeSizePerHead = 128;
+    auto constexpr tokensPerBlock = 64;
+    auto constexpr smallWindow = 1024;
+    auto constexpr largeWindow = 4096;
+    auto constexpr kvFactor = 2;
+    auto constexpr maxBatchSize = 1;
+
+    auto const numKvHeadsPerLayer = std::vector<SizeType32>(numLayers, numKvHeads);
+    // Layer 0 → smallWindow, layer 1 → largeWindow.
+    auto const windowSizeToLayers = std::map<SizeType32, std::vector<SizeType32>>{
+        {smallWindow, std::vector<SizeType32>{0}}, {largeWindow, std::vector<SizeType32>{1}}};
+    uint64_t const allottedPrimaryMemBytes = static_cast<uint64_t>(1) << 30; // 1 GiB
+    uint64_t const allottedSecondaryMemBytes = static_cast<uint64_t>(1) << 30;
+    size_t const extraCostMemory = 0;
+    auto const dtype = nvinfer1::DataType::kHALF;
+    tensorrt_llm::executor::KvCacheConfig const config{};
+    tensorrt_llm::runtime::WorldConfig const worldConfig{};
+
+    auto const baseline = BaseKVCacheManager::calculateMaxNumBlocks(config, dtype, numKvHeadsPerLayer,
+        scalarSizePerHead, tokensPerBlock, worldConfig, windowSizeToLayers, allottedPrimaryMemBytes,
+        allottedSecondaryMemBytes, extraCostMemory, kvFactor, maxBatchSize);
+
+    auto const sizePerHeadPerWindow
+        = std::map<SizeType32, SizeType32>{{smallWindow, scalarSizePerHead}, {largeWindow, largeSizePerHead}};
+    auto const overridden
+        = BaseKVCacheManager::calculateMaxNumBlocks(config, dtype, numKvHeadsPerLayer, scalarSizePerHead,
+            tokensPerBlock, worldConfig, windowSizeToLayers, allottedPrimaryMemBytes, allottedSecondaryMemBytes,
+            extraCostMemory, kvFactor, maxBatchSize, /*linearAttentionMetadata=*/std::nullopt, sizePerHeadPerWindow);
+
+    ASSERT_NE(baseline.find(smallWindow), baseline.end());
+    ASSERT_NE(baseline.find(largeWindow), baseline.end());
+    ASSERT_NE(overridden.find(smallWindow), overridden.end());
+    ASSERT_NE(overridden.find(largeWindow), overridden.end());
+
+    auto const& [baselineSmallPrim, baselineSmallSec] = baseline.at(smallWindow);
+    auto const& [baselineLargePrim, baselineLargeSec] = baseline.at(largeWindow);
+    auto const& [overSmallPrim, overSmallSec] = overridden.at(smallWindow);
+    auto const& [overLargePrim, overLargeSec] = overridden.at(largeWindow);
+
+    // Sanity: every count is positive.
+    EXPECT_GT(baselineSmallPrim, 0);
+    EXPECT_GT(baselineLargePrim, 0);
+    EXPECT_GT(overSmallPrim, 0);
+    EXPECT_GT(overLargePrim, 0);
+
+    // Default share allocation gives equal share (1/N) to each window, so baseline gives the
+    // same number of blocks per window when both windows have identical bytes/token.
+    EXPECT_EQ(baselineSmallPrim, baselineLargePrim);
+
+    // Override only doubles bytes/token for the *large* window.  Equal share is unchanged,
+    // so the small window's block count stays the same and the large window's halves.
+    EXPECT_EQ(overSmallPrim, baselineSmallPrim);
+    EXPECT_EQ(overSmallSec, baselineSmallSec);
+    EXPECT_LT(overLargePrim, baselineLargePrim);
+    EXPECT_LT(overLargeSec, baselineLargeSec);
+    // Large window pays double bytes/token under override → roughly half the blocks.
+    EXPECT_NEAR(static_cast<double>(overLargePrim) / baselineLargePrim, 0.5, 0.01);
+}
+
+TEST_F(KVCacheManagerTest, KVCacheManagerSWAEvictionCountPerWindow)
+{
+    auto constexpr numLayers = 2;
+    auto constexpr numKvHeads = 2;
+    auto constexpr sizePerHead = 64;
+    auto constexpr tokensPerBlock = 4;
+    auto constexpr maxNumSequences = 4;
+    auto constexpr maxBeamWidth = 1;
+    auto constexpr sinkTokenLength = 0;
+    auto constexpr dtype = nvinfer1::DataType::kHALF;
+    auto const stream = std::make_shared<tr::CudaStream>();
+    auto constexpr maxSequenceLength = 128;
+    auto constexpr maxNewTokens = 40;
+
+    // Layer 0 lives in the SWA pool; layer 1 lives in the full-attention pool.
+    auto constexpr swaWindow = 8;
+    auto constexpr fullWindow = 128;
+    auto const maxAttentionWindowVec = std::vector<SizeType32>{swaWindow, fullWindow};
+
+    auto constexpr blocksInPrimary = 8;
+    auto constexpr blocksInSecondary = 0;
+    auto const blocksPerWindow = BlocksPerWindow{
+        {swaWindow, {blocksInPrimary, blocksInSecondary}}, {fullWindow, {blocksInPrimary, blocksInSecondary}}};
+
+    KVCacheManager kvCacheManager(numLayers, numKvHeads, sizePerHead, tokensPerBlock, blocksPerWindow, maxNumSequences,
+        maxBeamWidth, maxAttentionWindowVec, dtype, sinkTokenLength, stream, maxSequenceLength, /*chunkSize=*/0,
+        /*enableBlockReuse=*/false);
+    kvCacheManager.allocatePools(/*useUvm=*/false);
+
+    auto constexpr beamWidth = maxBeamWidth;
+    auto constexpr beamIdx = 0;
+    tr::SamplingConfig const samplingConfig{beamWidth};
+    bool constexpr isStreaming{false};
+    TokenIdType constexpr firstToken = 1000;
+
+    int inputLength = 11; // > swaWindow (8); < fullWindow (128)
+    auto inputTokens = std::make_shared<VecTokens>(inputLength);
+    std::iota(inputTokens->begin(), inputTokens->end(), firstToken);
+    auto llmRequest
+        = std::make_shared<LlmRequest>(/*requestId=*/0, maxNewTokens, inputTokens, samplingConfig, isStreaming);
+
+    kvCacheManager.addSequenceBatch({{{/*requestId=*/0, inputLength, beamWidth}}}, {std::ref(*llmRequest)});
+    GenerationRequest const& seq = kvCacheManager.getSequence(/*requestId=*/0);
+
+    // No tokens added past the SWA window yet — both counters are zero.
+    EXPECT_EQ(seq.getNumFrontBlocksRemoved(swaWindow), 0);
+    EXPECT_EQ(seq.getNumFrontBlocksRemoved(fullWindow), 0);
+    EXPECT_EQ(seq.getNumFrontBlocksRemoved(swaWindow) + seq.getNumFrontBlocksRemoved(fullWindow), 0);
+
+    // Add one token past the window. SWA pool detaches block 0; full pool does not.
+    llmRequest->addNewToken(firstToken + inputLength, beamIdx);
+    kvCacheManager.addToken(/*requestId=*/0);
+
+    EXPECT_EQ(seq.getNumFrontBlocksRemoved(swaWindow), 1) << "SWA pool should have evicted exactly one front block";
+    EXPECT_EQ(seq.getNumFrontBlocksRemoved(fullWindow), 0) << "Full-attention pool must never front-evict";
+    EXPECT_EQ(seq.getNumFrontBlocksRemoved(swaWindow) + seq.getNumFrontBlocksRemoved(fullWindow), 1)
+        << "Aggregate sum must equal the SWA-only count";
+
+    // Drive a second SWA eviction; full-attn count stays at zero.
+    llmRequest->addNewToken(firstToken + inputLength + 1, beamIdx);
+    kvCacheManager.addToken(/*requestId=*/0);
+    llmRequest->addNewToken(firstToken + inputLength + 2, beamIdx);
+    kvCacheManager.addToken(/*requestId=*/0);
+    llmRequest->addNewToken(firstToken + inputLength + 3, beamIdx);
+    kvCacheManager.addToken(/*requestId=*/0);
+    llmRequest->addNewToken(firstToken + inputLength + 4, beamIdx);
+    kvCacheManager.addToken(/*requestId=*/0);
+
+    auto const swaEvictedAfter = seq.getNumFrontBlocksRemoved(swaWindow);
+    EXPECT_GT(swaEvictedAfter, 1) << "Continued generation should keep evicting SWA blocks";
+    EXPECT_EQ(seq.getNumFrontBlocksRemoved(fullWindow), 0);
+    EXPECT_EQ(seq.getNumFrontBlocksRemoved(swaWindow) + seq.getNumFrontBlocksRemoved(fullWindow), swaEvictedAfter);
+
+    tensorrt_llm::testing::KvCacheManagerTestUtil::simulatePrefillCompletion(*llmRequest);
+    EXPECT_NO_THROW(static_cast<void>(kvCacheManager.removeSequence(/*requestId=*/0, llmRequest)));
+}
+
+TEST_F(KVCacheManagerTest, GenerationRequestClearCacheBlocksPerWindowResetsOnlyThatWindow)
+{
+    // Use a real BlockManager solely to obtain a valid windowSizeToMetadata map; the
+    // bookkeeping under test (removeFrontBlock / clearCacheBlocks / getNumFrontBlocksRemoved)
+    // lives entirely on GenerationRequest.
+    auto constexpr numLayers = 2;
+    auto constexpr numKvHeads = 2;
+    auto constexpr sizePerHead = 64;
+    auto constexpr tokensPerBlock = 4;
+    auto constexpr blocksInPrimary = 4;
+    auto constexpr blocksInSecondary = 0;
+    auto constexpr maxNumSequences = 4;
+    auto constexpr maxBeamWidth = 1;
+    auto constexpr swaWindow = 8;
+    auto constexpr fullWindow = 128;
+    auto const stream = std::make_shared<tr::CudaStream>();
+    auto const maxAttentionWindowVec = std::vector<SizeType32>{swaWindow, fullWindow};
+    auto const blocksPerWindow = BlocksPerWindow{
+        {swaWindow, {blocksInPrimary, blocksInSecondary}}, {fullWindow, {blocksInPrimary, blocksInSecondary}}};
+
+    BlockManager blockManager(std::vector<BlockManager::SizeType32>(numLayers, numKvHeads), sizePerHead, tokensPerBlock,
+        blocksPerWindow, maxNumSequences, stream, /*maxSequenceLength=*/fullWindow, maxBeamWidth, maxAttentionWindowVec,
+        nvinfer1::DataType::kHALF, /*sinkBubbleLength=*/0, /*chunkSize=*/0);
+    blockManager.allocatePools(/*useUvm=*/false);
+
+    auto constexpr requestId = 7;
+    auto constexpr numTokens = 1;
+    GenerationRequest seq{requestId, numTokens, maxBeamWidth, blockManager.getWindowSizesMetadata()};
+
+    // Drive each window's counter to a distinct non-zero value.
+    seq.removeFrontBlock(swaWindow);
+    seq.removeFrontBlock(swaWindow);
+    seq.removeFrontBlock(fullWindow);
+
+    EXPECT_EQ(seq.getNumFrontBlocksRemoved(swaWindow), 2);
+    EXPECT_EQ(seq.getNumFrontBlocksRemoved(fullWindow), 1);
+    EXPECT_EQ(seq.getNumFrontBlocksRemoved(swaWindow) + seq.getNumFrontBlocksRemoved(fullWindow), 3);
+
+    // Clearing one window's blocks must not touch the other window's counter.
+    seq.clearCacheBlocks(swaWindow);
+    EXPECT_EQ(seq.getNumFrontBlocksRemoved(swaWindow), 0);
+    EXPECT_EQ(seq.getNumFrontBlocksRemoved(fullWindow), 1);
+    EXPECT_EQ(seq.getNumFrontBlocksRemoved(swaWindow) + seq.getNumFrontBlocksRemoved(fullWindow), 1);
+
+    // Symmetrically: clearing the other window resets only that one.
+    seq.clearCacheBlocks(fullWindow);
+    EXPECT_EQ(seq.getNumFrontBlocksRemoved(swaWindow), 0);
+    EXPECT_EQ(seq.getNumFrontBlocksRemoved(fullWindow), 0);
+    EXPECT_EQ(seq.getNumFrontBlocksRemoved(swaWindow) + seq.getNumFrontBlocksRemoved(fullWindow), 0);
+}
+
+// A5: Smoke-test VSWA + radix prefix reuse with mixed head_dim.
+//
+// Coverage: constructs a KVCacheManager whose two windows have different head_dim
+// (sizePerHeadPerWindow = {smallWindow -> 256, largeWindow -> 512}) with reuse +
+// partial reuse enabled, runs addSequenceBatch / storeContextBlocks / removeSequence
+// for two sequences sharing a prefix, and asserts pool routing is not cross-
+// contaminated and refcounts are balanced.  This is the smoke variant called for in
+// the spec: a complete prefix-reuse hit-rate scenario across mixed head_dim is more
+// brittle to set up and is left as a follow-up.
+TEST_F(KVCacheManagerTest, VswaMixedHeadDimReuseSmoke)
+{
+    auto constexpr numLayers = 2;
+    auto constexpr numKvHeads = 2;
+    auto constexpr scalarSizePerHead = 64;
+    auto constexpr tokensPerBlock = 4;
+    auto constexpr blocksInPrimary = 16;
+    auto constexpr blocksInSecondary = 0;
+    auto constexpr maxNumSequences = 4;
+    auto constexpr maxBeamWidth = 1;
+    auto constexpr smallWindow = 32;
+    auto constexpr largeWindow = 64;
+    auto constexpr smallSizePerHead = 256;
+    auto constexpr largeSizePerHead = 512;
+    auto constexpr sinkTokenLength = 0;
+    auto constexpr dtype = nvinfer1::DataType::kHALF;
+    auto constexpr maxSequenceLength = 64;
+    auto constexpr maxNewTokens = 0;
+    auto const stream = std::make_shared<tr::CudaStream>();
+    auto const maxAttentionWindowVec = std::vector<SizeType32>{smallWindow, largeWindow};
+    auto const blocksPerWindow = BlocksPerWindow{
+        {smallWindow, {blocksInPrimary, blocksInSecondary}}, {largeWindow, {blocksInPrimary, blocksInSecondary}}};
+    auto const sizePerHeadPerWindow
+        = std::map<SizeType32, SizeType32>{{smallWindow, smallSizePerHead}, {largeWindow, largeSizePerHead}};
+
+    KVCacheManager kvCacheManager(numLayers, numKvHeads, scalarSizePerHead, tokensPerBlock, blocksPerWindow,
+        maxNumSequences, maxBeamWidth, maxAttentionWindowVec, dtype, sinkTokenLength, stream, maxSequenceLength,
+        /*chunkSize=*/0, /*enableBlockReuse=*/true, CacheType::kSELF,
+        /*secondaryOffloadMinPriority=*/std::nullopt, /*eventManager=*/nullptr,
+        /*enablePartialReuse=*/true, /*copyOnpartialReuse=*/true,
+        /*kvCacheConnectorManager=*/nullptr,
+        /*enableIndexerKCache=*/false, /*indexerKCacheQuantBlockSize=*/128, /*indexerKCacheIndexHeadDim=*/0,
+        /*indexerKCacheUseFp4=*/false,
+        /*linearAttentionMetadata=*/std::nullopt, sizePerHeadPerWindow);
+    kvCacheManager.allocatePools(/*useUvm=*/false);
+
+    // Both windows registered with their distinct head_dims.
+    EXPECT_EQ(kvCacheManager.getBlockManager().getSizePerHeadForWindow(smallWindow), smallSizePerHead);
+    EXPECT_EQ(kvCacheManager.getBlockManager().getSizePerHeadForWindow(largeWindow), largeSizePerHead);
+
+    auto const freeBefore = kvCacheManager.getBlockManager().getNumFreeBlocksPerWindowSize();
+
+    auto constexpr beamWidth = maxBeamWidth;
+    tr::SamplingConfig const samplingConfig{beamWidth};
+    bool constexpr isStreaming{false};
+
+    // Sequence A: 12-token prompt across two blocks (block-aligned at 8 tokens, partial third).
+    auto inputTokensA = std::make_shared<VecTokens>(VecTokens{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12});
+    auto const inputLengthA = static_cast<SizeType32>(inputTokensA->size());
+    auto llmRequestA
+        = std::make_shared<LlmRequest>(/*requestId=*/0, maxNewTokens, inputTokensA, samplingConfig, isStreaming);
+
+    EXPECT_NO_THROW(
+        kvCacheManager.addSequenceBatch({{{/*requestId=*/0, inputLengthA, beamWidth}}}, {std::ref(*llmRequestA)}));
+
+    // Both windows must have allocated some blocks for this sequence — neither pool
+    // can be empty (i.e. neither pool was skipped due to mixed head_dim routing).
+    auto const& seqA = kvCacheManager.getSequence(/*requestId=*/0);
+    EXPECT_FALSE(seqA.getCacheBlockIds(smallWindow).at(0).empty()) << "small-window pool must allocate";
+    EXPECT_FALSE(seqA.getCacheBlockIds(largeWindow).at(0).empty()) << "large-window pool must allocate";
+
+    tensorrt_llm::testing::KvCacheManagerTestUtil::simulatePrefillCompletion(*llmRequestA);
+    EXPECT_NO_THROW(static_cast<void>(kvCacheManager.removeSequence(/*requestId=*/0, llmRequestA)));
+
+    // Sequence B: shares an 8-token prefix with sequence A, then diverges.
+    auto inputTokensB = std::make_shared<VecTokens>(VecTokens{1, 2, 3, 4, 5, 6, 7, 8, 99, 100});
+    auto const inputLengthB = static_cast<SizeType32>(inputTokensB->size());
+    auto llmRequestB
+        = std::make_shared<LlmRequest>(/*requestId=*/1, maxNewTokens, inputTokensB, samplingConfig, isStreaming);
+
+    EXPECT_NO_THROW(
+        kvCacheManager.addSequenceBatch({{{/*requestId=*/1, inputLengthB, beamWidth}}}, {std::ref(*llmRequestB)}));
+
+    auto const& seqB = kvCacheManager.getSequence(/*requestId=*/1);
+    EXPECT_FALSE(seqB.getCacheBlockIds(smallWindow).at(0).empty());
+    EXPECT_FALSE(seqB.getCacheBlockIds(largeWindow).at(0).empty());
+
+    tensorrt_llm::testing::KvCacheManagerTestUtil::simulatePrefillCompletion(*llmRequestB);
+    EXPECT_NO_THROW(static_cast<void>(kvCacheManager.removeSequence(/*requestId=*/1, llmRequestB)));
+
+    // After both sequences have been removed and their reuse-eligible blocks have
+    // been returned, the per-window free-block counts must equal what we started
+    // with (no leaked refcounts in either pool).
+    auto const freeAfter = kvCacheManager.getBlockManager().getNumFreeBlocksPerWindowSize();
+    ASSERT_EQ(freeAfter.size(), freeBefore.size());
+    for (auto const& [windowSize, free] : freeBefore)
+    {
+        ASSERT_NE(freeAfter.find(windowSize), freeAfter.end());
+        EXPECT_EQ(freeAfter.at(windowSize), free)
+            << "Window " << windowSize << " has leaked or extra blocks after removeSequence.";
+    }
+}
+
+// A6: VSWA + disagg dtype mismatch must fire the A4 guard.
+//
+// The constructor of CacheTransBufferManager picks pool 0's dtype as canonical for
+// the wire transport.  When a KVCacheManager hosts pools with differing dtypes
+// (mixed-precision per-window), that silent coercion would corrupt the wire format.
+// The guard added in cacheTransBuffer.cpp must throw at construction time.
+//
+// This test only exercises the helper / construction path that runs the guard; it
+// does not stand up a full disaggregated transfer (out of scope at unit-test
+// granularity).
+TEST_F(KVCacheManagerTest, VswaDisaggDtypeMismatchTriggersGuard)
+{
+    auto constexpr numLayers = 2;
+    auto constexpr numKvHeads = 2;
+    auto constexpr sizePerHead = 64;
+    auto constexpr tokensPerBlock = 4;
+    auto constexpr blocksInPrimary = 4;
+    auto constexpr blocksInSecondary = 0;
+    auto constexpr maxNumSequences = 4;
+    auto constexpr maxBeamWidth = 1;
+    auto constexpr smallWindow = 32;
+    auto constexpr largeWindow = 64;
+    auto constexpr sinkTokenLength = 0;
+    auto constexpr maxSequenceLength = 64;
+    auto const stream = std::make_shared<tr::CudaStream>();
+    auto const maxAttentionWindowVec = std::vector<SizeType32>{smallWindow, largeWindow};
+    auto const blocksPerWindow = BlocksPerWindow{
+        {smallWindow, {blocksInPrimary, blocksInSecondary}}, {largeWindow, {blocksInPrimary, blocksInSecondary}}};
+    auto const dtypePerWindow = std::map<SizeType32, nvinfer1::DataType>{
+        {smallWindow, nvinfer1::DataType::kHALF}, {largeWindow, nvinfer1::DataType::kBF16}};
+
+    auto kvCacheManager = std::make_unique<KVCacheManager>(numLayers, numKvHeads, sizePerHead, tokensPerBlock,
+        blocksPerWindow, maxNumSequences, maxBeamWidth, maxAttentionWindowVec, /*dtype=*/nvinfer1::DataType::kHALF,
+        sinkTokenLength, stream, maxSequenceLength,
+        /*chunkSize=*/0, /*enableBlockReuse=*/false, CacheType::kSELF,
+        /*secondaryOffloadMinPriority=*/std::nullopt, /*eventManager=*/nullptr,
+        /*enablePartialReuse=*/true, /*copyOnpartialReuse=*/true,
+        /*kvCacheConnectorManager=*/nullptr,
+        /*enableIndexerKCache=*/false, /*indexerKCacheQuantBlockSize=*/128, /*indexerKCacheIndexHeadDim=*/0,
+        /*indexerKCacheUseFp4=*/false,
+        /*linearAttentionMetadata=*/std::nullopt,
+        /*sizePerHeadPerWindow=*/std::map<SizeType32, SizeType32>{}, dtypePerWindow);
+    kvCacheManager->allocatePools(/*useUvm=*/false);
+
+    // Sanity: the manager really does host KV pools with two different dtypes.
+    auto const numKvPools = kvCacheManager->getBlockManager().getNumPools(
+        /*includeBlockScalePools=*/false, /*includeIndexerKCachePools=*/false);
+    ASSERT_GE(numKvPools, 2);
+    auto const dtype0 = kvCacheManager->getPrimaryPool(0)->getDataType();
+    bool foundMismatch = false;
+    for (SizeType32 i = 1; i < numKvPools; ++i)
+    {
+        if (kvCacheManager->getPrimaryPool(i)->getDataType() != dtype0)
+        {
+            foundMismatch = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(foundMismatch) << "Test setup must produce at least two pools with different dtypes";
+
+    // The guard in CacheTransBufferManager's constructor must reject this.
+    EXPECT_THROW({ CacheTransBufferManager const ctbm(kvCacheManager.get(), /*maxNumTokens=*/std::nullopt); },
+        tensorrt_llm::common::TllmException);
 }

--- a/examples/auto_deploy/model_registry/configs/gemma4_moe.yaml
+++ b/examples/auto_deploy/model_registry/configs/gemma4_moe.yaml
@@ -10,6 +10,7 @@ attn_backend: triton_paged
 compile_backend: torch-cudagraph
 cuda_graph_config:
   batch_sizes: [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
+  max_batch_size: 512
 max_num_tokens: 8192
 max_batch_size: 512
 max_seq_len: 8192

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/flashinfer_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/flashinfer_attention.py
@@ -577,10 +577,18 @@ class FlashInferAttention(AttentionDescriptor):
     def get_cache_initializers(
         cls, source_attn_node: Node, cache_config: KvCacheConfig
     ) -> ResourceHandlerDict:
+        """Build the per-layer KV handler used by the kvcache transform.
+
+        ``sliding_window`` is propagated into the handler so that handler
+        equality (and therefore KV grouping) reflects it: layers with different
+        windows land in separate pools.
+        """
         # source op is [bsnd] layout already
         k_fake: FakeTensor = source_attn_node.args[1].meta["val"]
         num_kv_heads = k_fake.shape[2]
         head_dim = k_fake.shape[3]
+        (sw,) = extract_op_args(source_attn_node, "sliding_window")
+        sliding_window = sw if isinstance(sw, int) and sw > 0 else 0
 
         return {
             "kv_cache": KVPagedResourceHandler(
@@ -589,6 +597,7 @@ class FlashInferAttention(AttentionDescriptor):
                 dtype=cls.resolve_cache_dtype(cache_config.dtype, k_fake.dtype),
                 kv_factor=2,
                 kv_layout=_GlobalFlashInferPlanner.kv_layout,
+                sliding_window=sliding_window,
             )
         }
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/triton_paged_attention.py
@@ -1495,9 +1495,17 @@ class TritonPagedAttention(AttentionDescriptor):
     def get_cache_initializers(
         cls, source_attn_node: Node, cache_config: KvCacheConfig
     ) -> ResourceHandlerDict:
+        """Build the per-layer KV handler used by the kvcache transform.
+
+        ``sliding_window`` is read from the source attention node and passed into
+        the handler so that handler equality (and therefore KV grouping) reflects
+        it: layers with different windows map to different pools.
+        """
         k_fake: FakeTensor = source_attn_node.args[1].meta["val"]
         num_kv_heads = k_fake.shape[2]
         head_dim = k_fake.shape[3]
+        (sw,) = extract_op_args(source_attn_node, "sliding_window")
+        sliding_window = sw if isinstance(sw, int) and sw > 0 else 0
 
         return {
             "kv_cache": KVPagedResourceHandler(
@@ -1506,6 +1514,7 @@ class TritonPagedAttention(AttentionDescriptor):
                 dtype=cls.resolve_cache_dtype(cache_config.dtype, k_fake.dtype),
                 kv_factor=2,
                 kv_layout=KV_LAYOUT,
+                sliding_window=sliding_window,
             )
         }
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/trtllm_attention.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention/trtllm_attention.py
@@ -845,7 +845,12 @@ class TrtllmAttention(AttentionDescriptor):
     def get_cache_initializers(
         cls, source_attn_node: Node, cache_config: KvCacheConfig
     ) -> ResourceHandlerDict:
-        """Return only KV cache handler (no workspace handler, managed like flashinfer)."""
+        """Return only the KV cache handler (no workspace handler; managed like flashinfer).
+
+        ``sliding_window`` is propagated into the handler so that handler equality
+        (and therefore KV grouping) reflects it — layers with different windows
+        end up in separate pools.
+        """
         # In fused QKV mode, K arg is the same as Q (flat fused tensor), so use hints.
         if source_attn_node.meta.get("_trtllm_fused_qkv"):
             num_kv_heads = source_attn_node.meta["_trtllm_num_kv_heads"]
@@ -869,6 +874,8 @@ class TrtllmAttention(AttentionDescriptor):
             num_kv_heads = k_fake.shape[2]
             head_dim = k_fake.shape[3]
             kv_dtype = k_fake.dtype
+        (sw,) = extract_op_args(source_attn_node, "sliding_window")
+        sliding_window = sw if isinstance(sw, int) and sw > 0 else 0
 
         return {
             "kv_cache": KVPagedResourceHandler(
@@ -877,6 +884,7 @@ class TrtllmAttention(AttentionDescriptor):
                 dtype=cls.resolve_cache_dtype(cache_config.dtype, kv_dtype),
                 kv_factor=2,
                 kv_layout="HND",
+                sliding_window=sliding_window,
             )
         }
 

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -1364,9 +1364,7 @@ class SequenceInfo:
                 # Use per-group last_page_len when supplied (window-capped for SWA
                 # under eviction), otherwise fall back to the global value.
                 if last_page_len_per_group is not None:
-                    self._stage_arg(
-                        f"last_page_len{suffix}", last_page_len_per_group[group_idx]
-                    )
+                    self._stage_arg(f"last_page_len{suffix}", last_page_len_per_group[group_idx])
                 elif cu_num_pages_per_group is not None:
                     self._stage_arg(f"last_page_len{suffix}", lpl_host)
                 if extra_page_per_seq_per_group is not None:

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -966,12 +966,21 @@ class SequenceInfo:
             self._input_buffer.add_truncatable_tensor(
                 f"extra_page_per_seq{suffix}", self.max_batch_size, torch.int
             )
+            # Per-group seq_len_with_cache: under SWA front-eviction the window's
+            # live cache length diverges from the global (input_pos + seq_len),
+            # so groups 1..N-1 carry their own window-capped values for both the
+            # kernel's mask math and the prepare-extra-metadata op (which uses
+            # it to compute write positions for new KV tokens).
+            self._input_buffer.add_truncatable_tensor(
+                f"seq_len_with_cache{suffix}", self.max_batch_size, torch.int
+            )
             # Register as available args (device + host variants)
             group_names = [
                 f"cache_loc{suffix}",
                 f"cu_num_pages{suffix}",
                 f"last_page_len{suffix}",
                 f"extra_page_per_seq{suffix}",
+                f"seq_len_with_cache{suffix}",
             ]
             for base_name in group_names:
                 self._available_args.add(base_name)
@@ -1222,6 +1231,8 @@ class SequenceInfo:
         cache_loc_per_group: Optional[Dict[int, Sequence[int]]] = None,
         cu_num_pages_per_group: Optional[Dict[int, Sequence[int]]] = None,
         extra_page_per_seq_per_group: Optional[Dict[int, Sequence[int]]] = None,
+        seq_len_with_cache_per_group: Optional[Dict[int, Sequence[int]]] = None,
+        last_page_len_per_group: Optional[Dict[int, Sequence[int]]] = None,
         ### RUNTIME ARGUMENTS ######################################################################
         gather_context_logits: bool = False,
         _gather_idx: Union[Sequence[int], torch.Tensor, None] = None,
@@ -1316,6 +1327,7 @@ class SequenceInfo:
         # Default per-group metadata when the caller doesn't provide per-group
         # data (warmup, set_example_sequence, CUDA graph capture).  Replicate
         # group 0's data to all groups so every kernel receives valid metadata.
+        # seq_len_with_cache is replicated with the global value below.
         if cache_loc_per_group is None and self.num_window_groups >= 2:
             for group_idx in range(1, self.num_window_groups):
                 suffix = f"_g{group_idx}"
@@ -1332,6 +1344,8 @@ class SequenceInfo:
                 ("cache_loc_per_group", cache_loc_per_group),
                 ("cu_num_pages_per_group", cu_num_pages_per_group),
                 ("extra_page_per_seq_per_group", extra_page_per_seq_per_group),
+                ("seq_len_with_cache_per_group", seq_len_with_cache_per_group),
+                ("last_page_len_per_group", last_page_len_per_group),
             ):
                 if mapping is None:
                     continue
@@ -1347,6 +1361,13 @@ class SequenceInfo:
                 self._stage_arg(f"cache_loc{suffix}", group_cache_loc)
                 if cu_num_pages_per_group is not None:
                     self._stage_arg(f"cu_num_pages{suffix}", cu_num_pages_per_group[group_idx])
+                # Use per-group last_page_len when supplied (window-capped for SWA
+                # under eviction), otherwise fall back to the global value.
+                if last_page_len_per_group is not None:
+                    self._stage_arg(
+                        f"last_page_len{suffix}", last_page_len_per_group[group_idx]
+                    )
+                elif cu_num_pages_per_group is not None:
                     self._stage_arg(f"last_page_len{suffix}", lpl_host)
                 if extra_page_per_seq_per_group is not None:
                     self._stage_arg(
@@ -1372,10 +1393,25 @@ class SequenceInfo:
             pages_per_seq = cu_num_pages_host[1:] - cu_num_pages_host[:-1]
             self._stage_arg("pages_per_seq", pages_per_seq)
 
-        # update sequence length with cache (unclamped global value — per-group
-        # clamping is handled separately in the VSWA staging blocks below)
+        # update sequence length with cache.  Group 0 always carries the
+        # unclamped global value (input_pos + seq_len); non-zero groups carry
+        # window-capped values when the caller supplies them (SWA front-eviction
+        # path), otherwise they replicate the global value.
         seq_len_with_cache = ip_host + sl_host
         self._stage_arg("seq_len_with_cache", seq_len_with_cache)
+        if self.num_window_groups >= 2:
+            for group_idx in range(1, self.num_window_groups):
+                suffix = f"_g{group_idx}"
+                if (
+                    seq_len_with_cache_per_group is not None
+                    and group_idx in seq_len_with_cache_per_group
+                ):
+                    self._stage_arg(
+                        f"seq_len_with_cache{suffix}",
+                        seq_len_with_cache_per_group[group_idx],
+                    )
+                else:
+                    self._stage_arg(f"seq_len_with_cache{suffix}", seq_len_with_cache)
 
         # prompt_lens: original context length per sequence, constant across iterations.
         # Defaults to seq_len when not provided (correct for prefill).
@@ -1604,6 +1640,15 @@ class SequenceInfo:
         # --- seq_len_with_cache (device) ---
         swc = self.get_arg("seq_len_with_cache", truncate=True)
         swc += offset
+
+        # Keep per-group seq_len_with_cache in sync with the global value for
+        # the overlap scheduler path.  This is exact in the non-eviction regime;
+        # under eviction the next nest_sequences re-caps to the window.
+        for group_idx in range(1, self.num_window_groups):
+            suffix = f"_g{group_idx}"
+            if self._is_active(f"seq_len_with_cache{suffix}"):
+                swc_g = self.get_arg(f"seq_len_with_cache{suffix}", truncate=True)
+                swc_g += offset
 
         # --- use_initial_states (device) ---
         use_initial_states = self.get_arg("use_initial_states", truncate=True)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -354,6 +354,29 @@ class InputBuffer:
         self._device_views[name] = self._trunc_device_bufs[name].view(dtype)
         self._host_views[name] = self._trunc_host_bufs[name].view(dtype)
 
+    def add_truncatable_tensor(self, name: str, max_numel: int, dtype: torch.dtype) -> None:
+        """Add a new truncatable tensor after initialization.
+
+        Args:
+            name: Name of the tensor.
+            max_numel: Maximum number of elements.
+            dtype: Data type.
+        """
+        assert name not in self._tensor_specs, f"Tensor '{name}' already registered"
+        self._tensor_specs[name] = (max_numel, dtype)
+        self._tensor_order.append(name)
+        self._truncatable_names.add(name)
+        self._current_lengths[name] = 0
+
+        byte_size = max_numel * dtype.itemsize
+        device = self._device_buffer.device
+        self._trunc_device_bufs[name] = torch.empty(byte_size, dtype=torch.uint8, device=device)
+        self._trunc_host_bufs[name] = torch.empty(
+            byte_size, dtype=torch.uint8, device="cpu", pin_memory=prefer_pinned()
+        )
+        self._device_views[name] = self._trunc_device_bufs[name].view(dtype)
+        self._host_views[name] = self._trunc_host_bufs[name].view(dtype)
+
     def to(self, *args, **kwargs) -> None:
         """Move all device buffers to a new device/dtype."""
         old_device = self._device_buffer.device
@@ -720,6 +743,11 @@ class SequenceInfo:
         self._extra_args: Dict[str, Optional[torch.Tensor]] = {}
         ############################################################################################
 
+        # VSWA WINDOW GROUPS #######################################################################
+        self._window_groups: List[int] = []
+        self._window_group_map: Dict[int, int] = {}
+        ############################################################################################
+
         # HOST PREPARE FOR ATTENTION FORWARD #######################################################
         self._host_prepare_functions: List[Tuple[PrepareMetadataHostCallable, List[str]]] = []
 
@@ -863,13 +891,20 @@ class SequenceInfo:
         num_blocks_estimate = num_blocks_estimate_per_seq * self.max_batch_size
         return num_blocks_estimate * self.tokens_per_block
 
-    def update_cache_information(self, num_blocks: int, block_offset_multiplier: int = 0) -> None:
+    def update_cache_information(
+        self,
+        num_blocks: int,
+        block_offset_multiplier: int = 0,
+    ) -> None:
         """Update cache information after cache manager creation.
 
         Sets num_blocks and block_offset_multiplier, writes max_seq_info into BatchInfo
         (constant after this call), and resizes cache_loc if needed.
+
+        Args:
+            num_blocks: Number of blocks in the primary pool.
+            block_offset_multiplier: Block offset multiplier derived from kv_cache strides.
         """
-        # set num_blocks and block_offset_multiplier
         self._num_blocks = num_blocks
 
         # write max_seq_info once into BatchInfo (constant after this call)
@@ -890,6 +925,87 @@ class SequenceInfo:
 
         if estimated_capacity > cache_loc_capacity:
             self._input_buffer.resize("cache_loc", estimated_capacity)
+            # Keep per-group cache_loc buffers in sync
+            for group_idx in range(1, self.num_window_groups):
+                self._input_buffer.resize(f"cache_loc_g{group_idx}", estimated_capacity)
+
+    def register_window_groups(self, window_sizes: List[int]) -> None:
+        """Register VSWA window groups and create per-group cache tensors.
+
+        Group ordering here matches the KV-cache group/pool ordering produced by
+        the kvcache transform — ``window_sizes[g]`` belongs to pool ``g``, so a
+        single ``group_idx`` routes graph metadata, storage pools, and runtime
+        inputs together.
+
+        Group 0 reuses the existing ``cache_loc`` / ``cu_num_pages`` /
+        ``last_page_len`` / ``extra_page_per_seq`` tensors.
+        Groups 1..N-1 get new dedicated tensors (``cache_loc_g{i}``,
+        ``cu_num_pages_g{i}``, ...).
+
+        Args:
+            window_sizes: List of per-group window sizes (one entry per group, in
+                the same order as the KV groups).  Full-attention groups use
+                ``max_seq_len``.
+        """
+        assert len(window_sizes) >= 2, "register_window_groups requires at least 2 distinct windows"
+        self._window_groups = list(window_sizes)
+        self._window_group_map = {ws: idx for idx, ws in enumerate(window_sizes)}
+
+        cache_loc_cap = self._input_buffer.get_capacity("cache_loc")
+        for group_idx in range(1, len(window_sizes)):
+            suffix = f"_g{group_idx}"
+            self._input_buffer.add_truncatable_tensor(
+                f"cache_loc{suffix}", cache_loc_cap, torch.int
+            )
+            self._input_buffer.add_truncatable_tensor(
+                f"cu_num_pages{suffix}", self.max_batch_size + 1, torch.int
+            )
+            self._input_buffer.add_truncatable_tensor(
+                f"last_page_len{suffix}", self.max_batch_size, torch.int
+            )
+            self._input_buffer.add_truncatable_tensor(
+                f"extra_page_per_seq{suffix}", self.max_batch_size, torch.int
+            )
+            # Register as available args (device + host variants)
+            group_names = [
+                f"cache_loc{suffix}",
+                f"cu_num_pages{suffix}",
+                f"last_page_len{suffix}",
+                f"extra_page_per_seq{suffix}",
+            ]
+            for base_name in group_names:
+                self._available_args.add(base_name)
+                self._available_args.add(base_name + self._host_suffix)
+
+            # Zero-fill all per-group device buffers so shape-checking forward
+            # passes (resize_kv_cache) that run before nest_sequences don't read
+            # uninitialized data.  With zeros: cache_loc→block 0 (safe),
+            # cu_num_pages→0 pages.
+            for base_name in group_names:
+                self._input_buffer._trunc_device_bufs[base_name].zero_()
+
+    @property
+    def window_groups(self) -> List[int]:
+        """Sorted list of distinct window sizes, or empty if non-VSWA."""
+        return self._window_groups
+
+    @property
+    def window_group_map(self) -> Dict[int, int]:
+        """Map from window_size to group index."""
+        return self._window_group_map
+
+    @property
+    def num_window_groups(self) -> int:
+        """Number of window groups (0 or 1 for non-VSWA, 2+ for VSWA)."""
+        return len(self._window_groups)
+
+    def get_cache_loc_for_group(self, group_idx: int) -> str:
+        """Return the cache_loc tensor name for a given window group."""
+        return "cache_loc" if group_idx == 0 else f"cache_loc_g{group_idx}"
+
+    def get_cu_num_pages_for_group(self, group_idx: int) -> str:
+        """Return the cu_num_pages tensor name for a given window group."""
+        return "cu_num_pages" if group_idx == 0 else f"cu_num_pages_g{group_idx}"
 
     def activate_arg(self, arg_name: str) -> bool:
         """Activate a desired argument.
@@ -1102,6 +1218,10 @@ class SequenceInfo:
         extra_page_per_seq: Optional[Sequence[int]] = None,
         slot_idx: Union[Sequence[int], torch.Tensor, None] = None,
         prompt_lens: Union[Sequence[int], torch.Tensor, None] = None,
+        ### VSWA PER-GROUP CACHE DATA (groups 1..N-1; group 0 uses cache_loc/cu_num_pages above) ###
+        cache_loc_per_group: Optional[Dict[int, Sequence[int]]] = None,
+        cu_num_pages_per_group: Optional[Dict[int, Sequence[int]]] = None,
+        extra_page_per_seq_per_group: Optional[Dict[int, Sequence[int]]] = None,
         ### RUNTIME ARGUMENTS ######################################################################
         gather_context_logits: bool = False,
         _gather_idx: Union[Sequence[int], torch.Tensor, None] = None,
@@ -1193,6 +1313,46 @@ class SequenceInfo:
         # check for updated extra_page_per_seq
         self._stage_arg("extra_page_per_seq", extra_page_per_seq)
 
+        # Default per-group metadata when the caller doesn't provide per-group
+        # data (warmup, set_example_sequence, CUDA graph capture).  Replicate
+        # group 0's data to all groups so every kernel receives valid metadata.
+        if cache_loc_per_group is None and self.num_window_groups >= 2:
+            for group_idx in range(1, self.num_window_groups):
+                suffix = f"_g{group_idx}"
+                self._stage_arg(f"cache_loc{suffix}", cache_loc)
+                self._stage_arg(f"cu_num_pages{suffix}", cu_num_pages)
+                self._stage_arg(f"last_page_len{suffix}", lpl_host)
+                self._stage_arg(f"extra_page_per_seq{suffix}", extra_page_per_seq)
+        elif cache_loc_per_group is not None and self.num_window_groups >= 2:
+            # Guard against partial maps: every registered non-zero group must be
+            # present in each of the per-group dicts, otherwise omitted groups
+            # would silently reuse the previous batch's staged tensors.
+            expected = set(range(1, self.num_window_groups))
+            for name, mapping in (
+                ("cache_loc_per_group", cache_loc_per_group),
+                ("cu_num_pages_per_group", cu_num_pages_per_group),
+                ("extra_page_per_seq_per_group", extra_page_per_seq_per_group),
+            ):
+                if mapping is None:
+                    continue
+                missing = expected - set(mapping.keys())
+                assert not missing, f"{name} missing entries for groups {sorted(missing)}"
+
+        # Stage VSWA per-group cache data (groups 1..N-1)
+        if cache_loc_per_group is not None:
+            for group_idx, group_cache_loc in cache_loc_per_group.items():
+                if group_idx == 0:
+                    continue
+                suffix = f"_g{group_idx}"
+                self._stage_arg(f"cache_loc{suffix}", group_cache_loc)
+                if cu_num_pages_per_group is not None:
+                    self._stage_arg(f"cu_num_pages{suffix}", cu_num_pages_per_group[group_idx])
+                    self._stage_arg(f"last_page_len{suffix}", lpl_host)
+                if extra_page_per_seq_per_group is not None:
+                    self._stage_arg(
+                        f"extra_page_per_seq{suffix}", extra_page_per_seq_per_group[group_idx]
+                    )
+
         ### UPDATE OPTIONAL DERIVATIVE METADATA ####################################################
         if self._is_required("position_ids"):
             # set new position_ids and make sure to flatten it
@@ -1212,7 +1372,8 @@ class SequenceInfo:
             pages_per_seq = cu_num_pages_host[1:] - cu_num_pages_host[:-1]
             self._stage_arg("pages_per_seq", pages_per_seq)
 
-        # update sequence length with cache
+        # update sequence length with cache (unclamped global value — per-group
+        # clamping is handled separately in the VSWA staging blocks below)
         seq_len_with_cache = ip_host + sl_host
         self._stage_arg("seq_len_with_cache", seq_len_with_cache)
 
@@ -1403,6 +1564,25 @@ class SequenceInfo:
             last_page_len %= self.tokens_per_block
             last_page_len += 1
 
+            # Adjust per-group cache assignments for VSWA groups 1..N-1
+            for group_idx in range(1, self.num_window_groups):
+                suffix = f"_g{group_idx}"
+                if self._is_active(f"cache_loc{suffix}"):
+                    lpl_g = self.get_arg(f"last_page_len{suffix}", truncate=True)
+                    lpl_g += offset
+                    delta_g = (lpl_g > self.tokens_per_block).int() - (lpl_g <= 0).int()
+                    torch.ops.auto_deploy.adjust_ragged_triton(
+                        cache_loc=self.get_arg(f"cache_loc{suffix}"),
+                        cu_num_blocks=self.get_arg(f"cu_num_pages{suffix}"),
+                        extra_idx=self.get_arg(f"extra_page_per_seq{suffix}"),
+                        delta=delta_g,
+                        num_sequences=num_sequences,
+                        max_blocks_per_seq=self.max_blocks_per_seq,
+                    )
+                    lpl_g -= 1
+                    lpl_g %= self.tokens_per_block
+                    lpl_g += 1
+
         # --- position_ids (device) ---
         position_ids = self.get_arg("position_ids", truncate=True, unflatten=False)
         # position_ids is per-token while offset is per-sequence; expand if needed
@@ -1570,15 +1750,24 @@ class ResourceHandler(ABC):
 class KVPagedResourceHandler(ResourceHandler):
     """Handler for paged KV cache resources.
 
-    This handler indicates the resource should be managed by the standard KVCacheManager.
+    This handler indicates the resource should be managed by the standard
+    KVCacheManager.  Handler equality (``__eq__``) is the single source of
+    truth for KV-cache grouping: layers whose handlers compare equal share a
+    storage pool and a metadata set (``group_idx == pool_idx``), and differ
+    otherwise.  Including ``sliding_window`` in the equality means same-head-dim
+    layers with different windows land in separate pools with their own
+    ``max_attention_window``.
 
     Args:
         num_kv_heads: Number of key-value heads.
         head_dim: Dimension of each head.
         dtype: The dtype of the KV cache.
         kv_factor: The factor of the KV cache. Default is 2 for combined k/v cache.
-        kv_layout: Memory layout for the KV cache. Either "HND" (head-num-dim) or "NHD" (num-head-dim).
-            Default is "HND" which is the standard layout for flashinfer.
+        kv_layout: Memory layout for the KV cache. Either "HND" (head-num-dim) or
+            "NHD" (num-head-dim). Default is "HND" which is the standard layout
+            for flashinfer.
+        sliding_window: Sliding window size for this layer.  ``0`` means full
+            attention; a positive value puts this layer in its own VSWA group.
     """
 
     @property
@@ -1593,6 +1782,7 @@ class KVPagedResourceHandler(ResourceHandler):
         dtype: torch.dtype,
         kv_factor: int = 2,
         kv_layout: Literal["HND", "NHD"] = "HND",
+        sliding_window: int = 0,
     ) -> None:
         """Initialize the KVPagedResourceHandler.
 
@@ -1602,6 +1792,7 @@ class KVPagedResourceHandler(ResourceHandler):
             dtype: The dtype of the KV cache.
             kv_factor: The factor of the KV cache. Default is 2.
             kv_layout: Memory layout - "HND" or "NHD". Default is "HND".
+            sliding_window: Sliding window size for this layer. 0 means full attention.
         """
         self.num_kv_heads = num_kv_heads
         self.head_dim = head_dim
@@ -1609,9 +1800,18 @@ class KVPagedResourceHandler(ResourceHandler):
         self.kv_factor = kv_factor
         assert kv_factor in [1, 2], f"Invalid kv_factor: {kv_factor}"
         self.kv_layout = kv_layout
+        self.sliding_window = (
+            sliding_window if isinstance(sliding_window, int) and sliding_window > 0 else 0
+        )
 
     def __eq__(self, other: Optional[ResourceHandler]) -> bool:
-        """Check compatibility for KVCacheManager (head_dim and dtype must match)."""
+        """Check compatibility — layers in the same group share a KVCacheManager pool.
+
+        Including sliding_window means same-head-dim layers with different windows
+        get separate pools.  This trades slightly higher memory (one pool per unique
+        window instead of a shared pool with multiple windows) for a simpler design
+        where group = pool = metadata set, with no cross-referencing needed.
+        """
         if type(other) is not type(self):
             return False
         return (
@@ -1619,6 +1819,7 @@ class KVPagedResourceHandler(ResourceHandler):
             and self.dtype == other.dtype
             and self.kv_factor == other.kv_factor
             and self.kv_layout == other.kv_layout
+            and self.sliding_window == other.sliding_window
         )
 
     def _get_bytes_per_token(self) -> int:

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -863,11 +863,19 @@ class ADEngine(ModelEngine):
         cache_loc_per_group: Optional[Dict[int, List[int]]] = None
         cu_num_pages_per_group: Optional[Dict[int, List[int]]] = None
         extra_page_per_seq_per_group: Optional[Dict[int, List[int]]] = None
+        # Per-pool window-capped metadata.  Group 0 keeps the unclamped global
+        # value; groups 1..N-1 cap at their window so SWA front-eviction stays
+        # invisible to the kernel (it sees a coherent local-coord view of the
+        # live page list).
+        seq_len_with_cache_per_group: Optional[Dict[int, List[int]]] = None
+        last_page_len_per_group: Optional[Dict[int, List[int]]] = None
         batch_cache_indices: Optional[List[List[int]]] = None
         if is_vswa:
             cache_loc_per_group = {g: [] for g in range(1, len(kv_group_windows))}
             cu_num_pages_per_group = {g: [0] for g in range(1, len(kv_group_windows))}
             extra_page_per_seq_per_group = {g: [] for g in range(1, len(kv_group_windows))}
+            seq_len_with_cache_per_group = {g: [] for g in range(1, len(kv_group_windows))}
+            last_page_len_per_group = {g: [] for g in range(1, len(kv_group_windows))}
         else:
             # Per-iter host overhead optimization (#13560): single batched
             # cache lookup for all requests in the single-window path.
@@ -902,6 +910,13 @@ class ADEngine(ModelEngine):
                     all_indices = kv_cache_manager.get_cache_indices(
                         request, window_size=group_window
                     )
+                    # SWA front-eviction: get_cache_indices returns the FULL
+                    # historical page list including front-evicted entries (the
+                    # C++ side bumps a counter rather than popping mCacheBlockIds).
+                    # The live slice starts at [front_removed:].
+                    front_removed = kv_cache_manager.get_num_front_blocks_removed(
+                        request.py_request_id, window_size=group_window
+                    )
                     # Active blocks = pages needed to fit end_compute_i tokens within
                     # this window.  The trailing slot in all_indices (when present)
                     # is the reserved spillover page.
@@ -909,24 +924,38 @@ class ADEngine(ModelEngine):
                     pages_for_active = (
                         active_token_count + kv_cache_manager.tokens_per_block - 1
                     ) // kv_cache_manager.tokens_per_block
-                    num_active = min(len(all_indices), pages_for_active)
-                    active_indices = all_indices[:num_active]
+                    live_len = len(all_indices) - front_removed
+                    num_active = min(live_len, pages_for_active)
+                    active_indices = all_indices[front_removed : front_removed + num_active]
+                    extra_slot_idx = front_removed + num_active
+                    has_extra = len(all_indices) > extra_slot_idx
 
                     if pool_idx == 0:
                         cache_loc.extend(active_indices)
                         cu_num_pages.append(cu_num_pages[i] + num_active)
-                        if len(all_indices) > num_active:
-                            extra_page_per_seq.append(all_indices[num_active])
+                        if has_extra:
+                            extra_page_per_seq.append(all_indices[extra_slot_idx])
                         else:
                             extra_page_per_seq.append(-1)
                     else:
                         cache_loc_per_group[pool_idx].extend(active_indices)
                         prev = cu_num_pages_per_group[pool_idx][i]
                         cu_num_pages_per_group[pool_idx].append(prev + num_active)
-                        if len(all_indices) > num_active:
-                            extra_page_per_seq_per_group[pool_idx].append(all_indices[num_active])
+                        if has_extra:
+                            extra_page_per_seq_per_group[pool_idx].append(
+                                all_indices[extra_slot_idx]
+                            )
                         else:
                             extra_page_per_seq_per_group[pool_idx].append(-1)
+                        # Window-capped seq_len_with_cache for this pool:
+                        # active_token_count covers the cached portion + new tokens
+                        # in window-local coords.  last_page_len follows from it.
+                        seq_len_with_cache_per_group[pool_idx].append(active_token_count)
+                        if active_token_count > 0:
+                            lpl_i = (active_token_count - 1) % _tokens_per_block + 1
+                        else:
+                            lpl_i = 0
+                        last_page_len_per_group[pool_idx].append(lpl_i)
             else:
                 # Inline get_num_kv_blocks (pure Python, saves function-call overhead per request)
                 num_active_blocks_i = (end_compute_i + _tokens_per_block - 1) // _tokens_per_block
@@ -971,6 +1000,8 @@ class ADEngine(ModelEngine):
             cache_loc_per_group=cache_loc_per_group,
             cu_num_pages_per_group=cu_num_pages_per_group,
             extra_page_per_seq_per_group=extra_page_per_seq_per_group,
+            seq_len_with_cache_per_group=seq_len_with_cache_per_group,
+            last_page_len_per_group=last_page_len_per_group,
             gather_context_logits=gather_context_logits,
             _gather_idx=flat_gather_indices,
             _mask_scatter_indices=mask_scatter_indices,

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -837,17 +837,46 @@ class ADEngine(ModelEngine):
             if is_overlap:
                 mask_scatter_indices.extend(list(range(cu_seqlen[-2], cu_seqlen[-1])))
 
-        # store cache information for all requests now
+        # Store cache information for all requests.
+        # All KV pools are hosted by a single C++ KVCacheManager; pool index is
+        # the position of the window in self.cache_seq_interface.kv_group_windows
+        # (the same source the kvcache transform used to register window groups
+        # on SequenceInfo).  Per-window queries on the manager route to the
+        # correct C++ pool via mLayerToWindowSize.
+        kv_group_windows = self.cache_seq_interface.kv_group_windows
+        is_vswa = len(kv_group_windows) >= 2
+
+        # Cache hot lookups so the per-request loop avoids repeated C++
+        # dispatch / hasattr calls.
         _tokens_per_block = kv_cache_manager.tokens_per_block
         _use_mamba = hasattr(kv_cache_manager, "mamba_cache_index")
+
         cache_loc: List[int] = []
         cu_num_pages: List[int] = [0]
         extra_page_per_seq: List[int] = []
         state_slot_idx: List[int] = []
 
-        batch_cache_indices = kv_cache_manager.get_batch_cache_indices(
-            [r.py_request_id for r in ordered_requests]
-        )
+        # Per-pool variants for VSWA (pools 1..N-1); pool 0 reuses the base
+        # lists above.  These are the data-transport shape that the kernels
+        # consume; their source is now a single per-window get_cache_indices()
+        # call against the unified manager.
+        cache_loc_per_group: Optional[Dict[int, List[int]]] = None
+        cu_num_pages_per_group: Optional[Dict[int, List[int]]] = None
+        extra_page_per_seq_per_group: Optional[Dict[int, List[int]]] = None
+        batch_cache_indices: Optional[List[List[int]]] = None
+        if is_vswa:
+            cache_loc_per_group = {g: [] for g in range(1, len(kv_group_windows))}
+            cu_num_pages_per_group = {g: [0] for g in range(1, len(kv_group_windows))}
+            extra_page_per_seq_per_group = {g: [] for g in range(1, len(kv_group_windows))}
+        else:
+            # Per-iter host overhead optimization (#13560): single batched
+            # cache lookup for all requests in the single-window path.
+            # layer_idx=0 lets the unified manager resolve the unique window
+            # even when max_attention_window_vec has multiple identical entries.
+            batch_cache_indices = kv_cache_manager.get_batch_cache_indices(
+                [r.py_request_id for r in ordered_requests],
+                layer_idx=0,
+            )
 
         for i, request in enumerate(ordered_requests):
             # store seq slot idx (use mamba_cache_index if available)
@@ -861,17 +890,55 @@ class ADEngine(ModelEngine):
             # get some info on the current request
             seq_len_i = cu_seqlen[i + 1] - cu_seqlen[i]
             end_compute_i = input_pos[i] + seq_len_i
-            # Inline get_num_kv_blocks (pure Python, saves function-call overhead per request)
-            num_active_blocks_i = (end_compute_i + _tokens_per_block - 1) // _tokens_per_block
 
-            # construct cache information for the current request
-            cache_indices = batch_cache_indices[i]
-            cache_loc.extend(cache_indices[:num_active_blocks_i])
-            cu_num_pages.append(cu_num_pages[i] + num_active_blocks_i)
-            if len(cache_indices) > num_active_blocks_i:
-                extra_page_per_seq.append(cache_indices[num_active_blocks_i])
+            if is_vswa:
+                # Per-WINDOW loop against the single unified manager — one
+                # get_cache_indices call per window, routed via window_size= so
+                # the C++ side picks the correct pool. Each pool keeps a
+                # contiguous page list per sequence; we slice it to the active
+                # block prefix and reserve the trailing slot, if any, as the
+                # spillover page.
+                for pool_idx, group_window in enumerate(kv_group_windows):
+                    all_indices = kv_cache_manager.get_cache_indices(
+                        request, window_size=group_window
+                    )
+                    # Active blocks = pages needed to fit end_compute_i tokens within
+                    # this window.  The trailing slot in all_indices (when present)
+                    # is the reserved spillover page.
+                    active_token_count = min(end_compute_i, group_window)
+                    pages_for_active = (
+                        active_token_count + kv_cache_manager.tokens_per_block - 1
+                    ) // kv_cache_manager.tokens_per_block
+                    num_active = min(len(all_indices), pages_for_active)
+                    active_indices = all_indices[:num_active]
+
+                    if pool_idx == 0:
+                        cache_loc.extend(active_indices)
+                        cu_num_pages.append(cu_num_pages[i] + num_active)
+                        if len(all_indices) > num_active:
+                            extra_page_per_seq.append(all_indices[num_active])
+                        else:
+                            extra_page_per_seq.append(-1)
+                    else:
+                        cache_loc_per_group[pool_idx].extend(active_indices)
+                        prev = cu_num_pages_per_group[pool_idx][i]
+                        cu_num_pages_per_group[pool_idx].append(prev + num_active)
+                        if len(all_indices) > num_active:
+                            extra_page_per_seq_per_group[pool_idx].append(all_indices[num_active])
+                        else:
+                            extra_page_per_seq_per_group[pool_idx].append(-1)
             else:
-                extra_page_per_seq.append(-1)
+                # Inline get_num_kv_blocks (pure Python, saves function-call overhead per request)
+                num_active_blocks_i = (end_compute_i + _tokens_per_block - 1) // _tokens_per_block
+                # Single-pool path: reuse the batched cache lookup performed
+                # before the loop (#13560 host-overhead optimization).
+                cache_indices = batch_cache_indices[i]
+                cache_loc.extend(cache_indices[:num_active_blocks_i])
+                cu_num_pages.append(cu_num_pages[i] + num_active_blocks_i)
+                if len(cache_indices) > num_active_blocks_i:
+                    extra_page_per_seq.append(cache_indices[num_active_blocks_i])
+                else:
+                    extra_page_per_seq.append(-1)
 
         # Store batch information based on prefill, decode, and extend requests.
         num_decode = len(generation_requests)
@@ -901,6 +968,9 @@ class ADEngine(ModelEngine):
             extra_page_per_seq=extra_page_per_seq,
             slot_idx=state_slot_idx,
             prompt_lens=prompt_lens,
+            cache_loc_per_group=cache_loc_per_group,
+            cu_num_pages_per_group=cu_num_pages_per_group,
+            extra_page_per_seq_per_group=extra_page_per_seq_per_group,
             gather_context_logits=gather_context_logits,
             _gather_idx=flat_gather_indices,
             _mask_scatter_indices=mask_scatter_indices,

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -14,7 +14,7 @@ import types
 from collections import abc, defaultdict
 from dataclasses import dataclass
 from types import MethodType, SimpleNamespace
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -407,6 +407,43 @@ def maybe_pad_for_cuda_graph(func):
         return ret
 
     return wrapper
+
+
+def _compute_window_local_view(
+    all_indices: Sequence[int],
+    front_removed: int,
+    end_compute_i: int,
+    group_window: int,
+    tokens_per_block: int,
+) -> Tuple[List[int], int, int, int]:
+    """Compute the window-coherent metadata view for one (request, window) pair.
+
+    Under SWA front-eviction, the C++ KVCacheManager returns the full historical
+    page list (including evicted entries at the front) from get_cache_indices
+    while a separate per-window counter (get_num_front_blocks_removed) tracks
+    how many of those entries are stale.  This helper slices the historical
+    list down to the live window in window-local coordinates so the kernel
+    sees a contiguous page table starting at position 0.
+
+    Returns:
+        active_indices: the live slice of all_indices to hand the kernel.
+        extra_page: the spillover page id (the next slot past num_active), or
+            -1 when there is no spillover slot.
+        seq_len_with_cache: window-capped total length (cached + new tokens).
+        last_page_len: derived from seq_len_with_cache and tokens_per_block.
+    """
+    active_token_count = min(end_compute_i, group_window)
+    pages_for_active = (active_token_count + tokens_per_block - 1) // tokens_per_block
+    live_len = len(all_indices) - front_removed
+    num_active = min(live_len, pages_for_active)
+    active_indices = list(all_indices[front_removed : front_removed + num_active])
+    extra_slot_idx = front_removed + num_active
+    extra_page = all_indices[extra_slot_idx] if len(all_indices) > extra_slot_idx else -1
+    if active_token_count > 0:
+        last_page_len = (active_token_count - 1) % tokens_per_block + 1
+    else:
+        last_page_len = 0
+    return active_indices, extra_page, active_token_count, last_page_len
 
 
 class ADEngine(ModelEngine):
@@ -913,48 +950,37 @@ class ADEngine(ModelEngine):
                     # SWA front-eviction: get_cache_indices returns the FULL
                     # historical page list including front-evicted entries (the
                     # C++ side bumps a counter rather than popping mCacheBlockIds).
-                    # The live slice starts at [front_removed:].
+                    # _compute_window_local_view slices it down to the live
+                    # window in window-local coords.
                     front_removed = kv_cache_manager.get_num_front_blocks_removed(
                         request.py_request_id, window_size=group_window
                     )
-                    # Active blocks = pages needed to fit end_compute_i tokens within
-                    # this window.  The trailing slot in all_indices (when present)
-                    # is the reserved spillover page.
-                    active_token_count = min(end_compute_i, group_window)
-                    pages_for_active = (
-                        active_token_count + kv_cache_manager.tokens_per_block - 1
-                    ) // kv_cache_manager.tokens_per_block
-                    live_len = len(all_indices) - front_removed
-                    num_active = min(live_len, pages_for_active)
-                    active_indices = all_indices[front_removed : front_removed + num_active]
-                    extra_slot_idx = front_removed + num_active
-                    has_extra = len(all_indices) > extra_slot_idx
+                    (
+                        active_indices,
+                        extra_page,
+                        active_token_count,
+                        lpl_i,
+                    ) = _compute_window_local_view(
+                        all_indices,
+                        front_removed=front_removed,
+                        end_compute_i=end_compute_i,
+                        group_window=group_window,
+                        tokens_per_block=_tokens_per_block,
+                    )
+                    num_active = len(active_indices)
 
                     if pool_idx == 0:
                         cache_loc.extend(active_indices)
                         cu_num_pages.append(cu_num_pages[i] + num_active)
-                        if has_extra:
-                            extra_page_per_seq.append(all_indices[extra_slot_idx])
-                        else:
-                            extra_page_per_seq.append(-1)
+                        extra_page_per_seq.append(extra_page)
                     else:
                         cache_loc_per_group[pool_idx].extend(active_indices)
                         prev = cu_num_pages_per_group[pool_idx][i]
                         cu_num_pages_per_group[pool_idx].append(prev + num_active)
-                        if has_extra:
-                            extra_page_per_seq_per_group[pool_idx].append(
-                                all_indices[extra_slot_idx]
-                            )
-                        else:
-                            extra_page_per_seq_per_group[pool_idx].append(-1)
-                        # Window-capped seq_len_with_cache for this pool:
-                        # active_token_count covers the cached portion + new tokens
-                        # in window-local coords.  last_page_len follows from it.
+                        extra_page_per_seq_per_group[pool_idx].append(extra_page)
+                        # Window-capped seq_len_with_cache + last_page_len for
+                        # this pool — group 0 keeps the unclamped global value.
                         seq_len_with_cache_per_group[pool_idx].append(active_token_count)
-                        if active_token_count > 0:
-                            lpl_i = (active_token_count - 1) % _tokens_per_block + 1
-                        else:
-                            lpl_i = 0
                         last_page_len_per_group[pool_idx].append(lpl_i)
             else:
                 # Inline get_num_kv_blocks (pure Python, saves function-call overhead per request)

--- a/tensorrt_llm/_torch/auto_deploy/shim/interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/interface.py
@@ -133,8 +133,17 @@ class CachedSequenceInterface:
 
         self._resource_lookup: ResourceHandlerDict = {}
         self._caches: Dict[str, torch.Tensor] = {}
-        # KVCacheManager (or MambaHybridCacheManager) for managed resources
+        # KVCacheManager (or MambaHybridCacheManager) for managed resources.
+        # A single KVCacheManager hosts all KV pools (full-attention + per-window
+        # SWA) via the C++ per-window head_dim/dtype overrides; cross-pool
+        # admission, event flush, disagg transfer, and the shared radix tree all
+        # live in C++.
         self._kv_cache_manager: Optional[Union[KVCacheManager, MambaHybridCacheManager]] = None
+        # Per-pool sliding window sizes, published by the kvcache transform and
+        # consumed by the executor.  Pool index == position in this list, in the
+        # same order as the C++ manager's internal pool ordering (see
+        # ``size_per_head_per_window`` keys).
+        self._kv_group_windows: List[int] = []
         # lookup of unmanaged resources
         self._unmanaged_resources: List[str] = []
         self._spec_config = spec_config
@@ -291,37 +300,98 @@ class CachedSequenceInterface:
 
     def _identify_managed_kv_resources(
         self,
-    ) -> Tuple[Optional[KVPagedResourceHandler], ResourceHandlerDict]:
-        """Identify KV resources compatible with the reference handler for KVCacheManager.
+    ) -> Tuple[
+        ResourceHandlerDict,
+        Dict[int, int],
+        Dict[int, "DataType"],
+        Dict[str, int],
+    ]:
+        """Identify all managed KV resources and their per-window shape maps.
 
-        The first KVPagedResourceHandler becomes the reference. All handlers matching
-        the reference (via __eq__) are collected for managed allocation.
+        A single C++ ``KVCacheManager`` now hosts every KV pool (full-attention
+        and per-window SWA), so we no longer split the Python side into
+        independent group dicts.  Layers are grouped internally by their
+        effective sliding-window key (``sliding_window`` if > 0 else
+        ``max_seq_len``); within a window-group all layers MUST share the same
+        ``head_dim`` and ``dtype`` because the C++ ctor takes one
+        ``size_per_head`` and one ``dtype`` per window.
+
+        The order of windows in the returned maps fixes the pool index used
+        everywhere downstream (Python's ``kv_group_windows`` and the C++
+        ``mLayerToWindowSize`` routing); we preserve insertion order matching
+        the order in which layers register their handlers.
 
         Returns:
-            Tuple of (reference_handler, managed_resources_dict).
-            reference_handler is None if no KV paged resources exist.
+            Tuple of:
+                - kv_managed: ResourceHandlerDict — every KVPagedResourceHandler
+                  in registration order; passed to the C++ ctor as the layer
+                  list.
+                - size_per_head_per_window: Dict[int, int] — maps each effective
+                  window size to the head_dim of layers in that window.
+                - dtype_per_window: Dict[int, DataType] — maps each window size
+                  to the C++ DataType enum of layers in that window.
+                - window_per_layer: Dict[str, int] — maps the resource name to
+                  its effective window size; used by the executor to route
+                  ``get_cache_indices`` calls per window without re-deriving the
+                  window from each handler.
+
+        Raises:
+            RuntimeError: if two layers share an effective window but disagree
+                on head_dim or dtype (the C++ ctor cannot represent that), or
+                if ``self._requires_uniform_kv_caches`` is True and we end up
+                with more than one distinct window.
         """
-        kv_ref: Optional[KVPagedResourceHandler] = None
         kv_managed: ResourceHandlerDict = {}
+        size_per_head_per_window: Dict[int, int] = {}
+        dtype_per_window: Dict[int, "DataType"] = {}
+        window_per_layer: Dict[str, int] = {}
+
+        max_seq_len = self.info.max_seq_len
 
         for name, handler in self._resource_lookup.items():
             if not isinstance(handler, KVPagedResourceHandler):
                 continue
-            if kv_ref is None:
-                kv_ref = handler
-            if handler == kv_ref:
-                kv_managed[name] = handler
-            elif self._requires_uniform_kv_caches:
-                raise RuntimeError(
-                    f"KV resource {name} is not compatible with the managed KV reference "
-                    f"(reference: head_dim={kv_ref.head_dim}, dtype={kv_ref.dtype}, "
-                    f"kv_factor={kv_ref.kv_factor}, kv_layout={kv_ref.kv_layout}; "
-                    f"candidate: head_dim={handler.head_dim}, dtype={handler.dtype}, "
-                    f"kv_factor={handler.kv_factor}, kv_layout={handler.kv_layout}). "
-                    "This configuration requires all KV caches to be managed."
-                )
+            # Effective window: full-attention layers (sliding_window == 0) use
+            # max_seq_len so the C++ side gets a single concrete window key.
+            effective_window = handler.sliding_window if handler.sliding_window > 0 else max_seq_len
 
-        return kv_ref, kv_managed
+            kv_managed[name] = handler
+            window_per_layer[name] = effective_window
+
+            handler_dtype = torch_dtype_to_binding(handler.dtype)
+            if effective_window in size_per_head_per_window:
+                if size_per_head_per_window[effective_window] != handler.head_dim:
+                    raise RuntimeError(
+                        f"KV layer {name} has head_dim={handler.head_dim} but window "
+                        f"{effective_window} already has head_dim="
+                        f"{size_per_head_per_window[effective_window]}. The C++ KVCacheManager "
+                        "requires all layers in a window to share head_dim."
+                    )
+                if dtype_per_window[effective_window] != handler_dtype:
+                    raise RuntimeError(
+                        f"KV layer {name} has dtype={handler.dtype} but window "
+                        f"{effective_window} already has dtype="
+                        f"{dtype_per_window[effective_window]}. The C++ KVCacheManager "
+                        "requires all layers in a window to share dtype."
+                    )
+            else:
+                size_per_head_per_window[effective_window] = handler.head_dim
+                dtype_per_window[effective_window] = handler_dtype
+
+        # If the runtime requires uniform KV caches (e.g. legacy single-pool
+        # path), more than one distinct window is incompatible.
+        if len(size_per_head_per_window) > 1 and self._requires_uniform_kv_caches:
+            windows_repr = ", ".join(
+                f"window={w} head_dim={size_per_head_per_window[w]} dtype={dtype_per_window[w]}"
+                for w in size_per_head_per_window
+            )
+            raise RuntimeError(
+                "KV resources are not uniform: "
+                f"{windows_repr}. "
+                "This configuration requires all KV caches to share a single pool."
+            )
+
+        return kv_managed, size_per_head_per_window, dtype_per_window, window_per_layer
 
     def _identify_managed_state_resources(
         self,
@@ -413,21 +483,43 @@ class CachedSequenceInterface:
         self,
         max_tokens: Optional[int],
         kv_managed: ResourceHandlerDict,
+        window_per_layer: Optional[Dict[str, int]] = None,
     ) -> KvCacheConfig:
         """Prepare and configure KvCacheConfig for cache manager creation.
 
-        Handles deep copy, max_tokens synchronization across ranks, block reuse settings,
-        copy_on_partial_reuse validation, and free_gpu_memory_fraction normalization.
+        Handles deep copy, max_tokens synchronization across ranks, block reuse
+        settings, copy_on_partial_reuse validation, and free_gpu_memory_fraction
+        normalization.
+
+        ``max_attention_window`` is the per-layer window list (one entry per
+        managed KV layer, in the order ``kv_managed`` enumerates them).  The C++
+        ctor groups these layers internally by window into pools using its
+        ``mLayerToWindowSize`` map.  Full-attention layers report
+        ``max_seq_len`` (i.e. their effective window).
 
         Args:
             max_tokens: Maximum tokens to allocate, or None to use config defaults.
             kv_managed: Dict of KV resources that will be managed by KVCacheManager.
+            window_per_layer: Map from layer resource name to effective window.
+                Required when ``kv_managed`` is non-empty.
 
         Returns:
             Configured KvCacheConfig ready for cache manager creation.
         """
         # Make a deep copy of the kv_cache_config to avoid modifying the original object
         kv_cache_config = copy.deepcopy(self._kv_cache_config_original)
+
+        # Build per-layer max_attention_window in kv_managed insertion order.
+        # The C++ side groups layers by this value into pools.
+        if kv_managed:
+            assert window_per_layer is not None, (
+                "window_per_layer must be supplied when kv_managed is non-empty"
+            )
+            kv_cache_config.max_attention_window = [
+                window_per_layer[name] for name in kv_managed.keys()
+            ]
+        else:
+            kv_cache_config.max_attention_window = None
 
         # Update kv_cache_config based on max_tokens if provided
         if max_tokens is not None:
@@ -469,31 +561,70 @@ class CachedSequenceInterface:
 
     def _build_kv_cache_kwargs(
         self,
-        kv_ref: Optional[KVPagedResourceHandler],
         kv_managed: ResourceHandlerDict,
         kv_cache_config: KvCacheConfig,
+        size_per_head_per_window: Optional[Dict[int, int]] = None,
+        dtype_per_window: Optional[Dict[int, "DataType"]] = None,
     ) -> Dict:
         """Build common kwargs for KVCacheManager or MambaHybridCacheManager.
 
+        With the C++ per-window head_dim/dtype overrides, a single manager
+        can host pools with mixed shapes.  We pass:
+
+        - ``head_dim`` / ``dtype`` as scalar defaults (fall-back values for any
+          window not present in the per-window override maps).  We pick the
+          maximum head_dim and the dtype of the first window so the default is
+          a sane upper bound on per-pool memory accounting.
+        - ``size_per_head_per_window`` / ``dtype_per_window`` as the per-window
+          override dicts that the C++ ctor uses to build pools with the
+          correct shapes.
+
         Args:
-            kv_ref: Reference KV handler defining head_dim and dtype, or None.
             kv_managed: Dict of KV resources to be managed.
             kv_cache_config: Configured KvCacheConfig.
+            size_per_head_per_window: Per-window head_dim overrides.
+            dtype_per_window: Per-window C++ DataType overrides.
 
         Returns:
             Dict of kwargs suitable for both KVCacheManager and MambaHybridCacheManager.
         """
+        size_per_head_per_window = size_per_head_per_window or {}
+        dtype_per_window = dtype_per_window or {}
+
         # create arguments first that differ whether we have managed kv caches or not
-        kv_cache_kwargs = {}
+        kv_cache_kwargs: Dict = {}
         if kv_managed:
-            kv_cache_type = CacheTypeCpp.SELFKONLY if kv_ref.kv_factor == 1 else CacheTypeCpp.SELF
+            # kv_factor is uniform across the managed set: __init__ asserts
+            # kv_factor in {1, 2}, and AutoDeploy only mixes kv_factor=2 layers
+            # in the same model today.  We take the first handler's value.
+            ref_handler = next(iter(kv_managed.values()))
+            kv_cache_type = (
+                CacheTypeCpp.SELFKONLY if ref_handler.kv_factor == 1 else CacheTypeCpp.SELF
+            )
+            # Default head_dim: the largest across all windows, so any window
+            # that falls back to the scalar gets a safe upper bound.  The
+            # per-window overrides take precedence in the C++ ctor.
+            default_head_dim = (
+                max(size_per_head_per_window.values())
+                if size_per_head_per_window
+                else ref_handler.head_dim
+            )
+            # Default dtype: dtype of the first window.  Same reasoning — the
+            # per-window overrides take precedence.
+            default_dtype = (
+                next(iter(dtype_per_window.values()))
+                if dtype_per_window
+                else torch_dtype_to_binding(ref_handler.dtype)
+            )
             kv_cache_kwargs.update(
                 {
                     "kv_cache_type": kv_cache_type,
                     "num_layers": len(kv_managed),
                     "num_kv_heads": [h.num_kv_heads for h in kv_managed.values()],
-                    "head_dim": kv_ref.head_dim,
-                    "dtype": torch_dtype_to_binding(kv_ref.dtype),
+                    "head_dim": default_head_dim,
+                    "dtype": default_dtype,
+                    "size_per_head_per_window": size_per_head_per_window,
+                    "dtype_per_window": dtype_per_window,
                 }
             )
         else:
@@ -504,6 +635,8 @@ class CachedSequenceInterface:
                     "num_kv_heads": [1],
                     "head_dim": 1,
                     "dtype": DataType.HALF,
+                    "size_per_head_per_window": {},
+                    "dtype_per_window": {},
                 }
             )
         # remaining arguments are the same for both cases
@@ -602,18 +735,27 @@ class CachedSequenceInterface:
 
         return manager, num_managed_mamba_layers
 
-    def _assign_kv_cache_views(self, kv_managed: Dict[str, KVPagedResourceHandler]) -> int:
+    def _assign_kv_cache_views(
+        self, kv_managed: Dict[str, KVPagedResourceHandler], manager: KVCacheManager
+    ) -> int:
         """Retrieve and assign buffer views for managed KV paged resources.
+
+        ``manager.get_buffers`` is per-layer-aware: it reads the layer's
+        head_dim from the underlying C++ ``size_per_head_per_window`` map when
+        one is set (mixed-shape pools, Gemma4-style VSWA), and falls back to
+        the manager-level scalar otherwise.  We can therefore use a single
+        call regardless of single-pool vs. multi-pool deployments.
 
         Args:
             kv_managed: Dict of KV resources managed by the cache manager.
+            manager: The KVCacheManager that owns these resources.
 
         Returns:
             block_offset_multiplier derived from the first KV cache view's strides.
         """
         block_offset_multiplier = 0
         for idx, (name, h) in enumerate(kv_managed.items()):
-            view = self._kv_cache_manager.get_buffers(idx, kv_layout=h.kv_layout)
+            view = manager.get_buffers(idx, kv_layout=h.kv_layout)
             assert view[0].is_contiguous(), f"Non-contiguous kv cache resource for {name}"
             self._caches[name] = view
 
@@ -670,13 +812,74 @@ class CachedSequenceInterface:
             dtype=handler.dtype,
         )
 
+    def _has_swa_window(self, size_per_head_per_window: Dict[int, int]) -> bool:
+        """Return True if any window is smaller than max_seq_len (i.e. SWA pool exists)."""
+        max_seq_len = self.info.max_seq_len
+        return any(w < max_seq_len for w in size_per_head_per_window.keys())
+
+    def _compute_total_token_budget(
+        self,
+        kv_managed: ResourceHandlerDict,
+        size_per_head_per_window: Dict[int, int],
+        total_max_tokens: Optional[int],
+    ) -> Optional[int]:
+        """Compute the total max_tokens budget for the unified KVCacheManager.
+
+        With a single C++ manager hosting all pools, ``BaseKVCacheManager::
+        calculateMaxNumBlocks`` does the per-pool split internally using the
+        per-window head_dim/dtype overrides.  We just need to compute the total
+        token budget; the C++ side derives N (max concurrent sequences) from
+        the total byte budget divided by the combined per-sequence cost across
+        all pools, then gives each pool N × its per-window tokens.
+
+        We retain a Python-side cap to keep the budget feasible during prefill
+        warmup before the C++ side has a chance to validate against
+        ``calculateMaxNumBlocks``.
+
+        Args:
+            kv_managed: All managed KV layers.
+            size_per_head_per_window: Map of effective window → head_dim, used
+                here purely to detect whether at least one SWA pool exists.
+            total_max_tokens: Caller-provided budget, or None to defer to
+                ``free_gpu_memory_fraction``.
+
+        Returns:
+            Total max_tokens for the manager, or None to defer to the
+            ``free_gpu_memory_fraction`` path.
+        """
+        # If the caller didn't pass a budget and there's no SWA pool, defer to
+        # free_gpu_memory_fraction inside the manager — same as the legacy path.
+        if total_max_tokens is None and not self._has_swa_window(size_per_head_per_window):
+            return None
+
+        if total_max_tokens is None:
+            # If the user already pinned max_tokens via KvCacheConfig, keep it:
+            # _prepare_kv_cache_config will preserve that value untouched.
+            if self._kv_cache_config_original.max_tokens is not None:
+                return None
+            # SWA present but no total budget — conservative single-sequence estimate.
+            # The C++ side will still bound this against available memory.
+            return self.info.max_seq_len
+
+        tpb = self.info.tokens_per_block
+        # Cap at max_batch_size × max_seq_len (can't need more than one
+        # full sequence per slot during prefill).
+        capped = min(total_max_tokens, self.info.max_batch_size * self.info.max_seq_len)
+        # Floor: at least one block per sequence for warmup feasibility.
+        min_tokens = self.info.max_batch_size * tpb
+        return max(capped, min_tokens)
+
     def _create_kv_cache_manager(self, max_tokens: Optional[int] = None) -> Dict:
-        """Create KVCacheManager or MambaHybridCacheManager with standard layout.
+        """Create a single KVCacheManager that hosts every KV pool.
 
         For paged resources (KVPagedResourceHandler):
-        - Uses the first KVPagedResourceHandler's head_dim and dtype as reference
-        - Compatible resources (matching head_dim and dtype) go into KVCacheManager
-        - Incompatible resources are allocated locally via handler.allocate()
+        - All managed layers are passed to one ``KVCacheManager`` instance.
+        - Per-window ``head_dim`` and ``dtype`` flow through the new
+          ``size_per_head_per_window`` / ``dtype_per_window`` ctor kwargs; the
+          C++ side groups layers internally by their effective window into
+          pools using its ``mLayerToWindowSize`` map.
+        - Cross-pool admission, event flush, disagg transfer, and the shared
+          radix tree are all handled in C++.
 
         For state resources (SSMResourceHandler, CausalConvResourceHandler, StateResourceHandler):
         - SSMResourceHandler maps to MambaHybridCacheManager's ssm_states buffer
@@ -694,20 +897,41 @@ class CachedSequenceInterface:
                 1. the final number of tokens is synced (min) across ranks
                 2. rounding for getting a multiple of tokens_per_block
         """
-        # 1. Identify managed resources
-        kv_ref, kv_managed = self._identify_managed_kv_resources()
+        # 1. Identify managed resources and per-window shape maps
+        (
+            kv_managed,
+            size_per_head_per_window,
+            dtype_per_window,
+            window_per_layer,
+        ) = self._identify_managed_kv_resources()
+
         ssm_ref, ssm_managed, ssm_spec, conv_ref, conv_managed, conv_spec = (
             self._identify_managed_state_resources()
         )
-
-        # 2. Prepare configuration
-        kv_cache_config = self._prepare_kv_cache_config(max_tokens, kv_managed)
-        kv_cache_kwargs = self._build_kv_cache_kwargs(kv_ref, kv_managed, kv_cache_config)
-
-        # 3. Create cache manager (delegate to state helper if state resources exist)
         has_state_resources = ssm_managed or conv_managed
-        if has_state_resources:
-            # NOTE: +1 for cuda graph padding
+
+        # 2. Compute the total token budget; the C++ side splits it across pools.
+        total_max_tokens = self._compute_total_token_budget(
+            kv_managed, size_per_head_per_window, max_tokens
+        )
+
+        kv_cache_config = self._prepare_kv_cache_config(
+            total_max_tokens, kv_managed, window_per_layer
+        )
+        kv_cache_kwargs = self._build_kv_cache_kwargs(
+            kv_managed,
+            kv_cache_config,
+            size_per_head_per_window=size_per_head_per_window,
+            dtype_per_window=dtype_per_window,
+        )
+
+        # 3. Build the unified manager (single instance covers every pool).
+        if not kv_managed and not has_state_resources:
+            # Pure dummy manager: no KV layers, no state — used for state-only or
+            # cache-less models.  We still need a manager so PyExecutor has a
+            # handle to call.
+            self._kv_cache_manager = KVCacheManager(**kv_cache_kwargs)
+        elif has_state_resources:
             kv_cache_kwargs["max_batch_size"] = self.info.max_num_state_slots
             self._kv_cache_manager, _ = self._create_and_assign_state_views(
                 kv_cache_kwargs,
@@ -719,18 +943,47 @@ class CachedSequenceInterface:
                 conv_spec,
             )
         else:
-            # No typed state resources - use pure KVCacheManager
             self._kv_cache_manager = KVCacheManager(**kv_cache_kwargs)
 
-        # 4. Store tuned config
+        ad_logger.info(
+            f"KV manager: {len(kv_managed)} layers across "
+            f"{len(size_per_head_per_window)} pool(s); "
+            f"size_per_head_per_window={size_per_head_per_window}, "
+            f"max_attention_window={kv_cache_config.max_attention_window}, "
+            f"max_tokens={total_max_tokens}"
+        )
+
+        # 4. Store tuned config (mirrors the kv_cache_config used at ctor time).
         self._kv_cache_config_tuned = kv_cache_config
 
-        # 5. Assign KV views (compute block_offset_multiplier from first view's strides)
-        block_offset_multiplier = self._assign_kv_cache_views(kv_managed)
+        # 5. Refresh per-pool window list from the finalized manager: KVCacheManager
+        # may clamp each window to min(window, max_seq_len) during construction, so
+        # the transform-time _kv_group_windows can become stale.  Downstream callers
+        # (ad_executor.get_cache_indices(window_size=...)) need the post-clamp
+        # values to hit the correct pool key in C++.
+        if kv_managed and self._kv_group_windows:
+            manager_windows = list(dict.fromkeys(self._kv_cache_manager.max_attention_window_vec))
+            if manager_windows and manager_windows != self._kv_group_windows:
+                ad_logger.info(
+                    f"Refreshing kv_group_windows from manager: "
+                    f"{self._kv_group_windows} -> {manager_windows}"
+                )
+                self._kv_group_windows = manager_windows
 
-        # 6. Update cache information (resize cache_loc, set max_seq_info with all max sizes)
+        # 6. Assign KV views and update cache information.
+        block_offset_multiplier = 0
+        if kv_managed:
+            block_offset_multiplier = self._assign_kv_cache_views(
+                kv_managed, self._kv_cache_manager
+            )
+
+        num_blocks = getattr(
+            self._kv_cache_manager,
+            "blocks_in_primary_pool",
+            self._kv_cache_manager.get_max_resource_count(),
+        )
         self.info.update_cache_information(
-            num_blocks=self._kv_cache_manager.blocks_in_primary_pool,
+            num_blocks=num_blocks,
             block_offset_multiplier=block_offset_multiplier,
         )
 
@@ -743,11 +996,11 @@ class CachedSequenceInterface:
             self._clear_caches,
         )
 
-        # 9. Compute final token count and cache statistics
+        # 8. Compute final token count and cache statistics
         max_resource_count = self._kv_cache_manager.get_max_resource_count()
         max_tokens_final = max_resource_count * self._kv_cache_manager.tokens_per_block
 
-        # 10. Collect statistics of different types of resources
+        # 9. Collect statistics of different types of resources
         num_state_total = sum(
             1 for h in self._resource_lookup.values() if isinstance(h, StateResourceHandler)
         )
@@ -866,12 +1119,16 @@ class CachedSequenceInterface:
 
         This implements the two-phase approach: after running a forward pass during estimation
         to allocate intermediate memory, call this method to recreate the cache manager.
-        The new manager will compute optimal capacity based on current free GPU memory.
+
+        For multi-pool (dual head_dim): the C++
+        ``BaseKVCacheManager::calculateMaxNumBlocks`` distributes the budget
+        across pools using the per-window head_dim/dtype overrides — the
+        Python side just provides the total token budget.
         """
         if not self.needs_resize():
             return
 
-        # Calculate bytes-per-token for paged (resizable) resources
+        # Calculate bytes-per-token for ALL paged resources (across all groups)
         paged_bytes_per_token = sum(
             h.bytes_per_token for h in self._resource_lookup.values() if h.is_paged
         )
@@ -890,14 +1147,14 @@ class CachedSequenceInterface:
         _, free_mem, *_ = get_mem_info(empty_cache=True)
 
         # Compute available memory for paged caches
-        # Reserve space for non-paged caches and mem_exclude, then apply free_gpu_memory_fraction
         free_gpu_memory_fraction = self._kv_cache_config_original.free_gpu_memory_fraction
         mem_for_paged_optimal = (
             free_mem - non_paged_bytes_total - mem_exclude
         ) * free_gpu_memory_fraction
         max_tokens_optimal = int(mem_for_paged_optimal // paged_bytes_per_token)
 
-        # Create new cache manager with optimal capacity
+        # Recreate the unified manager — the C++ side splits the total token
+        # budget across pools internally based on per-window head_dim/dtype.
         cache_stats = self._create_kv_cache_manager(max_tokens=max_tokens_optimal)
         max_tokens_final = cache_stats["max_tokens"]
 
@@ -916,8 +1173,26 @@ class CachedSequenceInterface:
         )
 
     @property
+    def kv_group_windows(self) -> List[int]:
+        """Per-pool window sizes, in the order the C++ manager exposes them.
+
+        Pool index == position in this list, matching the keys order of the
+        unified manager's ``size_per_head_per_window`` property.
+        """
+        return self._kv_group_windows
+
+    def set_kv_groups(self, group_windows: List[int]) -> None:
+        """Store per-pool window sizes (called by the kvcache transform).
+
+        ``group_windows[i]`` is the effective window of pool ``i``; the order
+        must match the unified ``KVCacheManager``'s pool ordering (i.e., the
+        insertion order of the per-window keys).
+        """
+        self._kv_group_windows = list(group_windows)
+
+    @property
     def kv_cache_manager(self) -> Optional[KVCacheManager]:
-        """Return the KVCacheManager managing paged resources, or None if not initialized."""
+        """Return the unified KVCacheManager, or None if not initialized."""
         assert self._kv_cache_manager is not None, "KVCacheManager not initialized."
         return self._kv_cache_manager
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
@@ -453,13 +453,9 @@ class _InsertCachedOperator(BaseTransform):
                         if base in vswa_swappable_bases:
                             is_host = arg_name.endswith(host_suffix)
                             group_arg = f"{base}_g{gi}{host_suffix if is_host else ''}"
-                            group_inputs.append(
-                                self._add_or_retrieve_input(gm, cm, group_arg)
-                            )
+                            group_inputs.append(self._add_or_retrieve_input(gm, cm, group_arg))
                         else:
-                            group_inputs.append(
-                                self._add_or_retrieve_input(gm, cm, arg_name)
-                            )
+                            group_inputs.append(self._add_or_retrieve_input(gm, cm, arg_name))
                     meta_nodes_extra_by_group[gi] = self._insert_extra_metadata_op(
                         gm, prep_meta_op, group_inputs, const_args_extra, num_meta_out
                     )

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
@@ -392,6 +392,13 @@ class _InsertCachedOperator(BaseTransform):
         num_groups = len(handler_groups)
         is_multi_group = num_groups >= 2
         vswa_group_nodes: dict[int, dict[str, "Node"]] = {}
+        # Per-group extra-metadata: group 0 reuses the previously-built nodes;
+        # groups 1..N-1 get their own prepare-extra call wired to per-group
+        # swappable inputs.  This is required because some backends' prepare-extra
+        # ops (e.g. Triton's, which consumes seq_len_with_cache) would otherwise
+        # produce group-0 outputs that silently feed every layer.
+        meta_nodes_extra_by_group: Dict[int, List[Node]] = {0: meta_nodes_extra}
+        host_suffix = "_host"
 
         if is_multi_group:
             group_windows = [
@@ -401,9 +408,19 @@ class _InsertCachedOperator(BaseTransform):
             cm.info.register_window_groups(group_windows)
             cm.set_kv_groups(group_windows)
 
+            # Names that are routed per-group end-to-end.  seq_len_with_cache is
+            # in this set because under SWA front-eviction the live window's
+            # length diverges from the global (input_pos + seq_len); the kernel,
+            # the prepare-extra op, and the host prepare all need the
+            # window-capped value.
+            vswa_swappable_bases = {
+                "cache_loc",
+                "cu_num_pages",
+                "last_page_len",
+                "seq_len_with_cache",
+            }
+
             # Create per-group graph placeholders for groups 1..N-1
-            vswa_swappable_bases = {"cache_loc", "cu_num_pages", "last_page_len"}
-            host_suffix = "_host"
             std_arg_names = self.attn_descriptor.get_standard_metadata_args()
             for gi in range(1, num_groups):
                 vswa_group_nodes[gi] = {}
@@ -415,6 +432,42 @@ class _InsertCachedOperator(BaseTransform):
                         vswa_group_nodes[gi][arg_name] = self._add_or_retrieve_input(
                             gm, cm, group_arg
                         )
+
+            # Per-group prepare-extra-metadata: re-invoke the op with this
+            # group's swappable inputs so each non-zero group's downstream
+            # consumers (e.g. update_paged_kv_cache write positions) reflect
+            # the window-capped view.  Skipped when the backend has no extra-op.
+            prep_meta_op, num_meta_out, const_args_extra = (
+                self.attn_descriptor.get_prepare_extra_metadata_info(source_attn_nodes[0])
+            )
+            if prep_meta_op is not None and num_meta_out > 0:
+                op_arg_names = [
+                    arg.name
+                    for arg in get_op_schema(prep_meta_op).arguments
+                    if arg.name in cm.info.available_args
+                ]
+                for gi in range(1, num_groups):
+                    group_inputs: List[Node] = []
+                    for arg_name in op_arg_names:
+                        base = arg_name.removesuffix(host_suffix)
+                        if base in vswa_swappable_bases:
+                            is_host = arg_name.endswith(host_suffix)
+                            group_arg = f"{base}_g{gi}{host_suffix if is_host else ''}"
+                            group_inputs.append(
+                                self._add_or_retrieve_input(gm, cm, group_arg)
+                            )
+                        else:
+                            group_inputs.append(
+                                self._add_or_retrieve_input(gm, cm, arg_name)
+                            )
+                    meta_nodes_extra_by_group[gi] = self._insert_extra_metadata_op(
+                        gm, prep_meta_op, group_inputs, const_args_extra, num_meta_out
+                    )
+            else:
+                # Backend has no extra-op: every group gets an empty list (which
+                # is what the original meta_nodes_extra would have been anyway).
+                for gi in range(1, num_groups):
+                    meta_nodes_extra_by_group[gi] = []
 
         # --- Pass 2: insert cached attention nodes with correct group metadata ---
         for (
@@ -433,13 +486,15 @@ class _InsertCachedOperator(BaseTransform):
                     if arg_name in vswa_group_nodes.get(group_idx, {}):
                         layer_meta_nodes_std[arg_pos] = vswa_group_nodes[group_idx][arg_name]
 
+            layer_meta_nodes_extra = meta_nodes_extra_by_group.get(group_idx, meta_nodes_extra)
+
             self._insert_cached_attn_node(
                 gm,
                 attn_node,
                 attn_descriptor.get_cached_attention_op(),
                 qkv,
                 layer_meta_nodes_std,
-                meta_nodes_extra,
+                layer_meta_nodes_extra,
                 cache_in_nodes,
                 constants,
                 prepared_mask,

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
@@ -14,7 +14,30 @@
 # limitations under the License.
 
 
-"""Graph transformation to automatically add kv cache into fused MHA op."""
+"""Graph transformation to automatically add kv cache into fused MHA op.
+
+The transform runs in two passes so that KV grouping is driven by a single
+source of truth — ``KVPagedResourceHandler.__eq__``:
+
+    Pass 1: Walk each source attention node, ask the backend descriptor for the
+    KV handler via ``get_cache_initializers``, and assign a ``group_idx`` by
+    comparing the handler against previously-seen handlers (`_find_or_add_group`
+    semantics).  Same equivalence class → same group.  Because the handler's
+    equality includes ``sliding_window``, same-head-dim layers with different
+    windows automatically land in different groups.
+
+    Pass 2: For multi-group models, publish the per-group window sizes to the
+    interface (``set_kv_groups``) and to SequenceInfo
+    (``register_window_groups``), allocate per-group metadata placeholders for
+    groups ``1..N-1``, and insert cached attention ops with their layer's
+    group's metadata nodes.
+
+After the transform, ``group_idx == pool_idx`` holds everywhere: the executor
+reads per-pool windows from ``cache_seq_interface.kv_group_windows`` and
+issues per-window queries (``get_cache_indices(request, window_size=W)``)
+against the unified ``KVCacheManager``; the C++ side routes each call to the
+correct pool via its ``mLayerToWindowSize`` map.
+"""
 
 import inspect
 import operator
@@ -259,14 +282,46 @@ class _InsertCachedOperator(BaseTransform):
         # Register host-side prepare_metadata function for attention descriptor.
         self._process_metadata_host(cm)
 
-        # replace fused attention node with attention node that has kv cache
+        # Seed KvCacheConfig.max_attention_window from per-layer sliding_window
+        # annotations so the rest of the KV-cache config plumbing (e.g.
+        # downstream C++ validators that inspect the vector) sees the intended
+        # per-layer windows.  The per-group KVCacheManager pools are configured
+        # separately in _prepare_kv_cache_config, using each group's reference
+        # handler.
+        per_layer_sliding_windows = []
+        for attn_node in source_attn_nodes:
+            (sw,) = extract_op_args(attn_node, "sliding_window")
+            per_layer_sliding_windows.append(sw)
+
+        has_any_sliding_window = any(
+            isinstance(sw, int) and sw > 0 for sw in per_layer_sliding_windows
+        )
+        if cm.kv_cache_config.max_attention_window is None and has_any_sliding_window:
+            max_attention_window = [
+                sw if isinstance(sw, int) and sw > 0 else cm.info.max_seq_len
+                for sw in per_layer_sliding_windows
+            ]
+            cm.update_kv_cache_config(max_attention_window=max_attention_window)
+
+        # --- Pass 1: register resources and assign per-layer group_idx ---
+        # Group identity comes from KVPagedResourceHandler.__eq__ (which
+        # includes sliding_window).  A group IS a pool IS a metadata set.
+        from ...custom_ops.attention_interface import KVPagedResourceHandler
+
+        handler_groups: list[KVPagedResourceHandler] = []
+        per_layer_group_idx: list[int] = []
+        group_idx_by_layer_idx: dict[int, int] = {}
+
         num_cached_attn_replacements = 0
         cache_nodes_by_layer_idx = {}
         semantic_mask_cache: Dict[Node, Node] = {}
-        for attn_node in source_attn_nodes:
-            # pick out GEMMs
-            qkv = attn_node.args[: attn_descriptor.get_num_qkv_args()]
+        # Collect per-layer info for the second pass (node insertion).
+        # Tuple layout:
+        #   (attn_node, qkv, cache_in_nodes, constants, group_idx, prepared_mask)
+        layer_infos: list[tuple] = []
 
+        for attn_node in source_attn_nodes:
+            qkv = attn_node.args[: attn_descriptor.get_num_qkv_args()]
             layer_idx = attn_descriptor.get_layer_idx(attn_node)
             shared_kv_source_layer_idx = attn_descriptor.get_shared_kv_source_layer_idx(attn_node)
 
@@ -287,23 +342,36 @@ class _InsertCachedOperator(BaseTransform):
                         f"Missing shared-KV source layer {shared_kv_source_layer_idx}."
                     )
                 cache_in_nodes = cache_nodes_by_layer_idx[shared_kv_source_layer_idx]
+                # Shared-KV layers inherit their source layer's group
+                group_idx = group_idx_by_layer_idx.get(shared_kv_source_layer_idx, 0)
             else:
-                # setup + store cache initializers and caches as input nodes
                 if layer_idx is not None and layer_idx in cache_nodes_by_layer_idx:
                     raise RuntimeError(
                         f"Duplicate KV cache owner detected for layer {layer_idx}. "
                         "Each non-shared attention layer must own exactly one cache."
                     )
                 cache_in_nodes = []
+                group_idx = 0
                 for k, resource_handler in attn_descriptor.get_cache_initializers(
                     attn_node, cm.kv_cache_config
                 ).items():
                     resource_name = cm.add_resource(k, resource_handler)
                     cache_in_nodes.append(self._process_cache_node(gm, resource_name))
+                    # Determine group from handler equality
+                    if isinstance(resource_handler, KVPagedResourceHandler):
+                        for gi, ref in enumerate(handler_groups):
+                            if resource_handler == ref:
+                                group_idx = gi
+                                break
+                        else:
+                            group_idx = len(handler_groups)
+                            handler_groups.append(resource_handler)
                 if layer_idx is not None:
                     cache_nodes_by_layer_idx[layer_idx] = cache_in_nodes
+                    group_idx_by_layer_idx[layer_idx] = group_idx
 
-            # allow backend-specific prep before constants are extracted
+            per_layer_group_idx.append(group_idx)
+
             attn_descriptor.prepare_node_for_cache_insertion(gm, attn_node)
 
             prepared_mask = self._process_semantic_mask(
@@ -316,20 +384,68 @@ class _InsertCachedOperator(BaseTransform):
             )
             constants = attn_descriptor.get_constants(attn_node)
 
-            # insert cached attention replacement op
+            layer_infos.append(
+                (attn_node, qkv, cache_in_nodes, constants, group_idx, prepared_mask)
+            )
+
+        # --- Multi-group setup: register metadata groups and create graph placeholders ---
+        num_groups = len(handler_groups)
+        is_multi_group = num_groups >= 2
+        vswa_group_nodes: dict[int, dict[str, "Node"]] = {}
+
+        if is_multi_group:
+            group_windows = [
+                h.sliding_window if h.sliding_window > 0 else cm.info.max_seq_len
+                for h in handler_groups
+            ]
+            cm.info.register_window_groups(group_windows)
+            cm.set_kv_groups(group_windows)
+
+            # Create per-group graph placeholders for groups 1..N-1
+            vswa_swappable_bases = {"cache_loc", "cu_num_pages", "last_page_len"}
+            host_suffix = "_host"
+            std_arg_names = self.attn_descriptor.get_standard_metadata_args()
+            for gi in range(1, num_groups):
+                vswa_group_nodes[gi] = {}
+                for arg_name in std_arg_names:
+                    base = arg_name.removesuffix(host_suffix)
+                    if base in vswa_swappable_bases:
+                        is_host = arg_name.endswith(host_suffix)
+                        group_arg = f"{base}_g{gi}{host_suffix if is_host else ''}"
+                        vswa_group_nodes[gi][arg_name] = self._add_or_retrieve_input(
+                            gm, cm, group_arg
+                        )
+
+        # --- Pass 2: insert cached attention nodes with correct group metadata ---
+        for (
+            attn_node,
+            qkv,
+            cache_in_nodes,
+            constants,
+            group_idx,
+            prepared_mask,
+        ) in layer_infos:
+            layer_meta_nodes_std = meta_nodes_std
+            if is_multi_group and group_idx > 0:
+                std_arg_names = self.attn_descriptor.get_standard_metadata_args()
+                layer_meta_nodes_std = list(meta_nodes_std)
+                for arg_pos, arg_name in enumerate(std_arg_names):
+                    if arg_name in vswa_group_nodes.get(group_idx, {}):
+                        layer_meta_nodes_std[arg_pos] = vswa_group_nodes[group_idx][arg_name]
+
             self._insert_cached_attn_node(
                 gm,
                 attn_node,
                 attn_descriptor.get_cached_attention_op(),
                 qkv,
-                meta_nodes_std,
+                layer_meta_nodes_std,
                 meta_nodes_extra,
                 cache_in_nodes,
                 constants,
                 prepared_mask,
             )
 
-            num_cached_attn_replacements += 1
+        num_cached_attn_replacements = len(layer_infos)
 
         info = TransformInfo(
             skipped=False,

--- a/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/mamba_cache_manager.py
@@ -866,6 +866,11 @@ class MixedMambaHybridCacheManager(KVCacheManager, MambaCacheManager,
         model_type: str = "nemotron_hybrid",
         is_draft: bool = False,
         use_replay_state_update: bool = False,
+        # Optional per-window head_dim / dtype overrides forwarded to the C++
+        # KVCacheManager ctor. Lets a single manager host pools with mixed
+        # shapes (e.g. Gemma4 hybrid attention). See KVCacheManager.__init__.
+        size_per_head_per_window: Optional[Dict[int, int]] = None,
+        dtype_per_window: Optional[Dict[int, "DataType"]] = None,
     ) -> None:
 
         # mamba hybrid cache requires block reuse to be disabled in KV cache config
@@ -915,6 +920,8 @@ class MixedMambaHybridCacheManager(KVCacheManager, MambaCacheManager,
             is_estimating_kv_cache=is_estimating_kv_cache,
             execution_stream=execution_stream,
             is_draft=is_draft,
+            size_per_head_per_window=size_per_head_per_window,
+            dtype_per_window=dtype_per_window,
         )
 
     def prepare_resources(self, scheduled_batch: ScheduledRequests):
@@ -1116,6 +1123,7 @@ class CppMambaHybridCacheManager(KVCacheManager, MambaHybridCacheManager):
             layer_mask=layer_mask,
             is_estimating_kv_cache=is_estimating_kv_cache,
             linear_attention_metadata=self.linear_attention_metadata,
+            **kwargs,
         )
 
         assert self.local_num_mamba_layers > 0, "At least one mamba layer is required"

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -331,6 +331,13 @@ class KVCacheManager(BaseResourceManager):
         is_estimating_kv_cache: bool = False,
         execution_stream: Optional[torch.cuda.Stream] = None,
         linear_attention_metadata: Optional[LinearAttentionMetadata] = None,
+        # Optional per-window head_dim / dtype overrides forwarded to the C++ ctor.
+        # Empty {} = uniform shape across all windows (default behavior).  Lets a
+        # single KVCacheManager host pools with mixed shapes when a model has
+        # heterogeneous attention types (e.g. Gemma4 SWA head_dim=256 +
+        # full-attention head_dim=512).
+        size_per_head_per_window: Optional[Dict[int, int]] = None,
+        dtype_per_window: Optional[Dict[int, "DataType"]] = None,
         **kwargs,
     ) -> None:
         self.mapping = mapping
@@ -390,6 +397,18 @@ class KVCacheManager(BaseResourceManager):
 
         self.num_kv_heads = num_kv_heads
         self.head_dim = head_dim
+        # Per-window head_dim / dtype override maps.  When non-empty, each
+        # window in max_attention_window_vec may have its own head_dim and/or
+        # dtype that differs from the manager-level scalars.  Used by
+        # heterogeneous-attention models (e.g. Gemma4 SWA head_dim=256
+        # alongside full-attention head_dim=512).  Empty dict means uniform
+        # shape (every window uses self.head_dim / self.dtype).  Keys are
+        # remapped after window clamping in
+        # _validate_and_adjust_attention_windows.
+        self.size_per_head_per_window: Dict[int, int] = dict(
+            size_per_head_per_window) if size_per_head_per_window else {}
+        self.dtype_per_window: Dict[int, "DataType"] = dict(
+            dtype_per_window) if dtype_per_window else {}
         self.tokens_per_block = tokens_per_block
         self.max_seq_len = max_seq_len
         self.max_batch_size = max_batch_size
@@ -474,7 +493,6 @@ class KVCacheManager(BaseResourceManager):
                 ), "calculate_max_num_blocks_for_vswa only accepts KvCacheConfig"
                 blocks_per_window = self.calculate_max_num_blocks_for_vswa(
                     kv_cache_config=kv_cache_config,
-                    model_config=model_config,
                     extra_cost_memory=0,
                 )
                 if mapping.world_size > 1:
@@ -525,7 +543,7 @@ class KVCacheManager(BaseResourceManager):
                 }
 
         # Validate and adjust attention windows against their upper bounds if needed
-        blocks_per_window, self.max_seq_len, self.max_attention_window_vec = self._validate_and_adjust_attention_windows(
+        blocks_per_window, self.max_seq_len, self.max_attention_window_vec, window_adjustments = self._validate_and_adjust_attention_windows(
             max_attention_window_vec=self.max_attention_window_vec,
             blocks_per_window=blocks_per_window,
             tokens_per_block=tokens_per_block,
@@ -533,6 +551,24 @@ class KVCacheManager(BaseResourceManager):
             max_seq_len=self.max_seq_len,
             max_beam_width=max_beam_width,
         )
+
+        # Remap per-window override-dict keys to match the post-clamp window
+        # sizes.  Without this, an override supplied for a pre-clamp window
+        # (e.g. 32768) would be silently dropped when the validator clamps
+        # the window down (e.g. to 16384), leaving the C++ side to fall back
+        # on the manager-level scalar — which is exactly the heterogeneous
+        # case these dicts exist to handle.
+        if window_adjustments:
+            if self.size_per_head_per_window:
+                self.size_per_head_per_window = {
+                    window_adjustments.get(w, w): v
+                    for w, v in self.size_per_head_per_window.items()
+                }
+            if self.dtype_per_window:
+                self.dtype_per_window = {
+                    window_adjustments.get(w, w): v
+                    for w, v in self.dtype_per_window.items()
+                }
 
         if kv_cache_type != CacheTypeCpp.SELF:
             assert len(
@@ -577,6 +613,10 @@ class KVCacheManager(BaseResourceManager):
             'indexer_k_cache_index_head_dim': indexer_k_cache_index_head_dim,
             'indexer_k_cache_use_fp4': indexer_k_cache_use_fp4,
             'linear_attention_metadata': linear_attention_metadata,
+            # Forward the (possibly remapped) per-window override dicts.
+            # Keys are aligned with the post-clamp window sizes.
+            'size_per_head_per_window': self.size_per_head_per_window,
+            'dtype_per_window': self.dtype_per_window,
         }
 
         if self.event_buffer_max_size > 0:
@@ -1156,6 +1196,26 @@ class KVCacheManager(BaseResourceManager):
         assert len(result) == 1
         return result[0]
 
+    def get_num_front_blocks_removed(self,
+                                     request_id: int,
+                                     window_size: Optional[int] = None) -> int:
+        """Get the number of front blocks evicted by SWA for a sequence.
+
+        Args:
+            request_id: The request id.
+            window_size: Optional window size.  When supplied, returns the
+                per-window eviction count (zero for non-SWA windows).  When
+                omitted, defaults to ``self.max_attention_window_vec[0]`` —
+                this matches the historical single-pool behavior for
+                callers that never thought about windows, while keeping the
+                C++ contract uniformly per-window.  VSWA callers should
+                always pass ``window_size`` explicitly.
+        """
+        if window_size is None:
+            window_size = self.max_attention_window_vec[0]
+        return self.impl.get_num_front_blocks_removed(request_id,
+                                                      window_size=window_size)
+
     def unpin_blocks_by_id(self, kv_cache_block_id: int):
         self.impl.unpin_blocks_by_id(kv_cache_block_id)
 
@@ -1192,8 +1252,9 @@ class KVCacheManager(BaseResourceManager):
             window_size = self.max_attention_window_vec[0]
         else:
             layer_offset = self.layer_offsets[layer_idx]
-            window_size = self.max_attention_window_vec[layer_offset % len(
-                self.max_attention_window_vec)]
+            # Explicit layer_offset -> window_size mapping (no modulo
+            # masking length mismatches between pattern and num_local_layers).
+            window_size = self._get_layer_offset_to_window_size()[layer_offset]
 
         result = self.impl.get_batch_cache_block_ids(request_ids, window_size)
         for i in range(len(result)):
@@ -1238,9 +1299,25 @@ class KVCacheManager(BaseResourceManager):
 
         Note that different attention backend/implementation can have different KV layouts,
         "kv_layout" should be set accordingly to avoid surprises.
+
+        Per-layer head_dim: when the underlying C++ manager hosts multiple pools with
+        distinct head_dim (e.g., Gemma4 SWA head_dim=256 alongside full-attention
+        head_dim=512), this method reads the layer's effective head_dim from
+        ``self.size_per_head_per_window`` rather than the manager-level scalar.
+        Single-pool managers fall back to ``self.head_dim``.
         '''
         layer_offset = self.layer_offsets[layer_idx]
         result = self.impl.get_primary_pool_data(layer_offset)
+
+        # Resolve per-layer head_dim through an explicit layer_offset ->
+        # window_size mapping (no modulo masking length mismatches).  When no
+        # override map is set (uniform manager), fall back to self.head_dim.
+        if self.size_per_head_per_window:
+            window_size = self._get_layer_offset_to_window_size()[layer_offset]
+            layer_head_dim = self.size_per_head_per_window.get(
+                window_size, self.head_dim)
+        else:
+            layer_head_dim = self.head_dim
 
         assert kv_layout in ["NHD",
                              "HND"], f"Unsupported kv_layout: {kv_layout}"
@@ -1250,7 +1327,7 @@ class KVCacheManager(BaseResourceManager):
                 self.kv_factor,
                 self.tokens_per_block,
                 self.num_kv_heads_per_layer[layer_offset],
-                self.head_dim,
+                layer_head_dim,
             )
         else:
             return result.reshape(
@@ -1258,7 +1335,7 @@ class KVCacheManager(BaseResourceManager):
                 self.kv_factor,
                 self.num_kv_heads_per_layer[layer_offset],
                 self.tokens_per_block,
-                self.head_dim,
+                layer_head_dim,
             )
 
     def get_indexer_k_cache_pool_data(self, layer_idx: int) -> torch.Tensor:
@@ -1343,6 +1420,131 @@ class KVCacheManager(BaseResourceManager):
     def rewind_kv_cache(self, request: LlmRequest, rewind_len: int):
         self.impl.rewind_kv_cache(request.py_request_id, rewind_len)
 
+    def calculate_cache_size_per_token(self,
+                                       layers: Set[int],
+                                       window_size: Optional[int] = None
+                                       ) -> int:
+        """Compute the (raw, dtype-agnostic) KV cache size per token for a set of layers.
+
+        head_dim is resolved per-layer when ``self.size_per_head_per_window``
+        is non-empty: the layer's window is looked up via
+        ``_get_layer_offset_to_window_size`` and the override dict is
+        consulted; otherwise ``self.head_dim`` is used.
+
+        Args:
+            layers: Set of layer offsets.
+            window_size: Optional window-size hint.  When provided AND every
+                layer in ``layers`` belongs to the same window, head_dim is
+                read directly from ``self.size_per_head_per_window`` for that
+                window — bypassing the per-layer lookup loop.  When omitted,
+                head_dim is resolved per layer (the heterogeneous-layer case).
+
+        Returns:
+            cache size per token (number of elements, not bytes).
+        """
+        if not self.size_per_head_per_window:
+            # Uniform head_dim — original formula.
+            total_kv_heads = sum(self.num_kv_heads_per_layer[i] for i in layers)
+            return total_kv_heads * self.kv_factor * self.head_dim
+
+        if window_size is not None:
+            # Single-window fast path (per-window override map).
+            head_dim = self.size_per_head_per_window.get(
+                window_size, self.head_dim)
+            total_kv_heads = sum(self.num_kv_heads_per_layer[i] for i in layers)
+            return total_kv_heads * self.kv_factor * head_dim
+
+        # Heterogeneous-layer slow path: layers may span multiple windows
+        # with different head_dim.
+        layer_offset_to_window_size = self._get_layer_offset_to_window_size()
+        total = 0
+        for i in layers:
+            layer_window = layer_offset_to_window_size[i]
+            layer_head_dim = self.size_per_head_per_window.get(
+                layer_window, self.head_dim)
+            total += self.num_kv_heads_per_layer[i] * layer_head_dim
+        return total * self.kv_factor
+
+    def _calculate_cache_bytes_per_token_for_layers(
+            self,
+            layers: Set[int],
+            window_size: Optional[int] = None,
+            dtype_default: Optional[DataType] = None) -> int:
+        """Compute KV cache bytes per token for a set of layers.
+
+        When ``self.dtype_per_window`` is non-empty, dtype is resolved per
+        layer (or per the supplied ``window_size`` for the homogeneous fast
+        path).  Otherwise ``dtype_default`` (or ``self.dtype``) is used.
+
+        Handles NVFP4 scaling-factor overhead, computed per dtype.
+        """
+        if dtype_default is None:
+            dtype_default = self.dtype
+
+        # Homogeneous fast path: a single dtype applies to every layer in
+        # `layers`.  This holds when (a) no per-window dtype overrides exist
+        # OR (b) a window_size hint is supplied (single-window case).
+        if not self.dtype_per_window or window_size is not None:
+            if window_size is not None and self.dtype_per_window:
+                effective_dtype = self.dtype_per_window.get(
+                    window_size, dtype_default)
+            else:
+                effective_dtype = dtype_default
+            cache_size_per_token = self.calculate_cache_size_per_token(
+                layers, window_size=window_size)
+            cache_bytes_per_token = get_size_in_bytes(cache_size_per_token,
+                                                      effective_dtype)
+            if effective_dtype == DataType.NVFP4:
+                cache_bytes_per_token += KVCacheManager.calculate_scaling_factor_size_bytes(
+                    cache_size_per_token,
+                    quant_vector_size=16,
+                    scaling_factor_dtype=DataType.FP8)
+            return cache_bytes_per_token
+
+        # Heterogeneous path: dtype varies per layer.  Sum bytes per layer.
+        layer_offset_to_window_size = self._get_layer_offset_to_window_size()
+        total_bytes = 0
+        for i in layers:
+            layer_window = layer_offset_to_window_size[i]
+            layer_head_dim = self.size_per_head_per_window.get(
+                layer_window, self.head_dim)
+            layer_dtype = self.dtype_per_window.get(layer_window, dtype_default)
+            layer_elements = (self.num_kv_heads_per_layer[i] * self.kv_factor *
+                              layer_head_dim)
+            layer_bytes = get_size_in_bytes(layer_elements, layer_dtype)
+            if layer_dtype == DataType.NVFP4:
+                layer_bytes += KVCacheManager.calculate_scaling_factor_size_bytes(
+                    layer_elements,
+                    quant_vector_size=16,
+                    scaling_factor_dtype=DataType.FP8)
+            total_bytes += layer_bytes
+        return total_bytes
+
+    def _get_layer_offset_to_window_size(self) -> Dict[int, int]:
+        """Inverse of _get_window_size_to_layers: layer_offset -> window_size.
+
+        Asserts every local layer is mapped exactly once.  This is the
+        explicit, length-mismatch-safe replacement for
+        ``max_attention_window_vec[layer_offset % len(max_attention_window_vec)]``
+        — that modulo silently masks length mismatches between the window
+        pattern and num_local_layers; this helper catches them via the
+        assert below.
+        """
+        window_size_to_layers = self._get_window_size_to_layers()
+        layer_offset_to_window_size: Dict[int, int] = {}
+        for window_size, layer_offsets in window_size_to_layers.items():
+            for layer_offset in layer_offsets:
+                assert layer_offset not in layer_offset_to_window_size, (
+                    f"layer_offset {layer_offset} mapped to multiple window "
+                    f"sizes ({layer_offset_to_window_size[layer_offset]} and "
+                    f"{window_size}) — window pattern is malformed.")
+                layer_offset_to_window_size[layer_offset] = window_size
+        assert len(layer_offset_to_window_size) == self.num_local_layers, (
+            f"layer_offset_to_window_size covers "
+            f"{len(layer_offset_to_window_size)} layers but num_local_layers "
+            f"is {self.num_local_layers}.")
+        return layer_offset_to_window_size
+
     def _get_window_size_to_layers(self) -> dict[int, list[int]]:
         """
         Get the window size to layers mapping.
@@ -1383,34 +1585,27 @@ class KVCacheManager(BaseResourceManager):
         window_size_to_layers: Dict[int, List[int]],
         max_attention_window_vec: List[int],
         kv_cache_config: KvCacheConfig,
-        model_config: ModelConfigCpp,
         pool_memory_bytes: int,
         kv_factor: int,
         dtype: DataType,
         is_cross_attention: bool = False,
+        model_config: Optional[ModelConfigCpp] = None,
     ) -> Tuple[Dict[int, List[int]], List[int]]:
 
         assert is_cross_attention is False, 'Cross attention is not supported'
 
         max_tokens_from_config = kv_cache_config.max_tokens
 
-        def calculate_cache_size_per_token(layers: Set[int]) -> int:
-            # Same as BaseKVCacheManager::calculateCacheSizePerTokenForSingleWindowSize
-            total_kv_heads = sum(self.num_kv_heads_per_layer[i] for i in layers)
-            return total_kv_heads * kv_factor * model_config.head_size
-
-        # Calculate the required memory bytes per sequence.
+        # Calculate the required memory bytes per sequence.  Each window's
+        # bytes-per-token is computed with that window's effective head_dim
+        # / dtype (per-window override map), falling back to the manager
+        # scalars when no override is registered.
         required_mem_bytes_per_seq = 0
         for window_size in sorted(window_size_to_layers):
             layers = window_size_to_layers[window_size]
-            cache_size_per_token = calculate_cache_size_per_token(layers)
-            cache_size_bytes_per_token = get_size_in_bytes(
-                cache_size_per_token, dtype)
-            if dtype == DataType.NVFP4:
-                cache_size_bytes_per_token += KVCacheManager.calculate_scaling_factor_size_bytes(
-                    cache_size_per_token,
-                    quant_vector_size=16,
-                    scaling_factor_dtype=DataType.FP8)
+            cache_size_bytes_per_token = (
+                self._calculate_cache_bytes_per_token_for_layers(
+                    layers, window_size=window_size, dtype_default=dtype))
             required_mem_bytes_per_seq += window_size * cache_size_bytes_per_token
         logger.info(
             f'Required memory per sequence: {required_mem_bytes_per_seq} bytes')
@@ -1439,16 +1634,13 @@ class KVCacheManager(BaseResourceManager):
         for window_size in sorted(window_size_to_layers):
             layers = window_size_to_layers[window_size]
             if remaining_mem_bytes > 0 and remaining_layers:
-                # Calculate cache size per token for remaining layers only
-                cache_size_per_token = calculate_cache_size_per_token(
-                    remaining_layers)
-                cache_size_bytes_per_token = get_size_in_bytes(
-                    cache_size_per_token, dtype)
-                if dtype == DataType.NVFP4:
-                    cache_size_bytes_per_token += KVCacheManager.calculate_scaling_factor_size_bytes(
-                        cache_size_per_token,
-                        quant_vector_size=16,
-                        scaling_factor_dtype=DataType.FP8)
+                # Calculate cache size per token for remaining layers only.
+                # ``remaining_layers`` may span multiple windows with
+                # different head_dim / dtype, so the helper resolves each
+                # layer's effective shape and dtype individually.
+                cache_size_bytes_per_token = (
+                    self._calculate_cache_bytes_per_token_for_layers(
+                        remaining_layers, dtype_default=dtype))
                 logger.debug(
                     f'Cache size per token for {len(remaining_layers)} layers: '
                     f'{cache_size_bytes_per_token} bytes')
@@ -1577,7 +1769,7 @@ class KVCacheManager(BaseResourceManager):
     def calculate_max_num_blocks_for_vswa(
             self,
             kv_cache_config: KvCacheConfig,
-            model_config: Optional[ModelConfigCpp],
+            model_config: Optional[ModelConfigCpp] = None,
             extra_cost_memory: int = 0) -> dict[int, tuple[int, int]]:
         """
         Currently, this function is added to support *ONLY* VSWA.
@@ -1623,31 +1815,19 @@ class KVCacheManager(BaseResourceManager):
                 extra_cost_memory=extra_cost_memory,
             )
 
-        # VSWA case: use C++ implementation for variable window sizes
-        if model_config is None:
-            raise ValueError(
-                "model_config is required for VSWA (Variable Sliding Window Attention)"
-            )
-        assert model_config.layer_types is not None, "layer_types have to be set correctly for VSWA"
-        if self.is_vswa:
-            # Adjust the window sizes to fit the memory if even a single sequence
-            # cannot fit in the memory.
-            window_size_to_layers, max_attention_window_vec = self.adjust_window_sizes_for_vswa(
-                window_size_to_layers=window_size_to_layers,
-                max_attention_window_vec=self.max_attention_window_vec,
-                model_config=model_config,
-                kv_cache_config=kv_cache_config,
-                pool_memory_bytes=self._primary_pool_memory_bytes,
-                kv_factor=self.kv_factor,
-                dtype=self.dtype,
-                is_cross_attention=is_cross_attention,
-            )
-            self.max_attention_window_vec = max_attention_window_vec
-
-        def calculate_cache_size_per_token(layers: Set[int]) -> int:
-            # Same as BaseKVCacheManager::calculateCacheSizePerTokenForSingleWindowSize
-            total_kv_heads = sum(self.num_kv_heads_per_layer[i] for i in layers)
-            return total_kv_heads * self.kv_factor * model_config.head_size
+        # VSWA case: adjust window sizes via Python helper that derives
+        # head_dim from self.  model_config is no longer required because
+        # head_size is read from self.head_dim, set during __init__.
+        window_size_to_layers, max_attention_window_vec = self.adjust_window_sizes_for_vswa(
+            window_size_to_layers=window_size_to_layers,
+            max_attention_window_vec=self.max_attention_window_vec,
+            kv_cache_config=kv_cache_config,
+            pool_memory_bytes=self._primary_pool_memory_bytes,
+            kv_factor=self.kv_factor,
+            dtype=self.dtype,
+            is_cross_attention=is_cross_attention,
+        )
+        self.max_attention_window_vec = max_attention_window_vec
 
         logger.info(
             f"Primary pool memory bytes: {self._primary_pool_memory_bytes}")
@@ -1678,9 +1858,12 @@ class KVCacheManager(BaseResourceManager):
         blocks_per_window = {}
         for window_idx, (window_size, layers) in enumerate(
                 sorted(window_size_to_layers.items())):
-            cache_size_per_token = calculate_cache_size_per_token(layers)
-            cache_size_bytes_per_token = get_size_in_bytes(
-                cache_size_per_token, self.dtype)
+            # Per-window head_dim and dtype (with scalar fallback) — needed
+            # for heterogeneous-attention models like Gemma4 where SWA and
+            # full-attention pools have different head_dim.
+            cache_size_bytes_per_token = (
+                self._calculate_cache_bytes_per_token_for_layers(
+                    layers, window_size=window_size))
 
             primary_tokens = self._primary_pool_memory_bytes * window_size_shares[
                 window_idx] / cache_size_bytes_per_token
@@ -1718,7 +1901,7 @@ class KVCacheManager(BaseResourceManager):
         sink_token_length: int,
         max_seq_len: int,
         max_beam_width: int,
-    ) -> Tuple[BlocksPerWindow, int, List[int]]:
+    ) -> Tuple[BlocksPerWindow, int, List[int], Dict[int, int]]:
         """
         Validate and adjust attention windows against their upper bounds if needed.
         If there is no adjustment, the returned max_attention_window_vec will be the same as the input.
@@ -1731,7 +1914,12 @@ class KVCacheManager(BaseResourceManager):
             max_seq_len: Maximum sequence length
 
         Returns:
-            Tuple of (adjusted_blocks_per_window, adjusted_max_seq_len, adjusted_max_attention_window_vec)
+            Tuple of (adjusted_blocks_per_window, adjusted_max_seq_len,
+            adjusted_max_attention_window_vec, window_adjustments).
+            window_adjustments maps pre_clamp -> post_clamp window size for
+            every window that was clamped (empty if nothing was adjusted) so
+            callers can rewrite parallel per-window override dicts (e.g.
+            size_per_head_per_window, dtype_per_window).
         """
         window_adjustments = {}
         # Validate each window size in blocks_per_window against its upper bound
@@ -1774,9 +1962,9 @@ class KVCacheManager(BaseResourceManager):
             adjusted_max_seq_len = max(adjusted_window_vec)
             logger.warning(f"Adjusted max_seq_len to {adjusted_max_seq_len}")
 
-            return adjusted_blocks_per_window, adjusted_max_seq_len, adjusted_window_vec
+            return adjusted_blocks_per_window, adjusted_max_seq_len, adjusted_window_vec, window_adjustments
         else:
-            return blocks_per_window, max_seq_len, max_attention_window_vec
+            return blocks_per_window, max_seq_len, max_attention_window_vec, {}
 
     def pin_blocks(self, request_id: int):
         self.impl.pin_blocks(request_id)

--- a/tests/integration/defs/accuracy/references/passkey_retrieval_64k.yaml
+++ b/tests/integration/defs/accuracy/references/passkey_retrieval_64k.yaml
@@ -2,3 +2,9 @@ meta-llama/Llama-3.1-8B:
   - accuracy: 99
   - quant_algo: FP8_PER_CHANNEL_PER_TOKEN
     accuracy: 99
+google/gemma-4-26B-A4B-it:
+  # TODO: replace with measured accuracy after the first CI run.  Placeholder
+  # is set conservatively to the same nominal "found-or-not" baseline as
+  # Llama-3.1; PassKey retrieval is binary and a correctly-evicting SWA model
+  # whose global layers see the full 64k context should land close to 99.
+  - accuracy: 99

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -29,7 +29,7 @@ from tensorrt_llm.sampling_params import SamplingParams
 
 from ..conftest import get_device_count, llm_models_root, skip_pre_blackwell
 from .accuracy_core import (GSM8K, MMLU, MMMU, CnnDailymail,
-                            LlmapiAccuracyTestHarness)
+                            LlmapiAccuracyTestHarness, PassKeyRetrieval64k)
 
 _AD_CONFIGS_DIR = (Path(get_llm_root()) / 'examples' / 'auto_deploy' /
                    'model_registry' / 'configs')
@@ -1180,6 +1180,47 @@ class TestGemma4MoE(LlmapiAccuracyTestHarness):
             task = GSM8K(self.MODEL_NAME)
             task.evaluate(
                 llm,
+                extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS,
+            )
+
+    @pytest.mark.timeout(7200)
+    @pytest.mark.skip_less_device_memory(80000)
+    def test_bf16_long_context(self):
+        """End-to-end accuracy guard for the SWA front-eviction path.
+
+        Gemma-4's SWA window is 1024 tokens; the global-attention layers see
+        the full context. A 64k-prompt PassKey retrieval task drives heavy
+        front-eviction on the SWA pool while keeping the passkey reachable
+        through the full-attention layers — the workload that exercises the
+        Phase-2 (window-coherent metadata + per-group prepare-extra) path
+        added by the accompanying source change.
+
+        Pre-Phase-2: the SWA layer reads stale/evicted page entries and the
+        write-position for new tokens overshoots the live page list, so
+        accuracy collapses well below the registered reference even though
+        MMMU / MMLU / GSM8K (all short-prompt) stay healthy.
+        """
+        yaml_paths, registry_world_size = _get_registry_yaml_extra(
+            self.MODEL_NAME)
+        if get_device_count() < registry_world_size:
+            pytest.skip("Not enough devices for world size, skipping test")
+
+        sampling_params = SamplingParams(
+            max_tokens=PassKeyRetrieval64k.MAX_OUTPUT_LEN,
+            truncate_prompt_tokens=PassKeyRetrieval64k.MAX_INPUT_LEN,
+            end_id=None,
+            pad_id=None,
+            n=1,
+            use_beam_search=False,
+        )
+        with AutoDeployLLM(model=self.MODEL_PATH,
+                           tokenizer=self.MODEL_PATH,
+                           world_size=registry_world_size,
+                           yaml_extra=yaml_paths) as llm:
+            task = PassKeyRetrieval64k(self.MODEL_NAME)
+            task.evaluate(
+                llm,
+                sampling_params=sampling_params,
                 extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS,
             )
 

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -1122,24 +1122,22 @@ class TestKimiK2_5(LlmapiAccuracyTestHarness):
 
 
 class TestGemma4MoE(LlmapiAccuracyTestHarness):
-    """Bench-run coverage for Gemma4 MoE via AutoDeploy."""
+    """Gemma4 MoE accuracy via AutoDeploy on the dual-pool C++ KVCacheManager.
+
+    Gemma4-26B-A4B-it is the first AutoDeploy model with mixed (head_dim, dtype)
+    across attention windows: SWA layers use head_dim=256 and global-attention
+    layers use head_dim=512.  A single C++ KVCacheManager hosts both pools via
+    the per-window overrides added by commits 1c273f0594 / 823d6ea0e1, and the
+    Python AutoDeploy shim drives them through one `_create_kv_cache_manager`
+    call (commit f37ef9b844).  This integration test exercises the path
+    end-to-end against the registered MMMU / MMLU / GSM8K reference accuracies.
+    """
 
     MODEL_NAME = "google/gemma-4-26B-A4B-it"
     MODEL_PATH = hf_id_to_local_model_dir(MODEL_NAME)
     EXTRA_EVALUATOR_KWARGS = {
         "apply_chat_template": True,
     }
-
-    def get_default_sampling_params(self):
-        return SamplingParams(
-            max_tokens=MMMU.MAX_OUTPUT_LEN,  # noqa: F821
-            truncate_prompt_tokens=MMMU.MAX_INPUT_LEN,  # noqa: F821
-            stop="<|endoftext|>",
-            end_id=None,
-            pad_id=None,
-            n=1,
-            use_beam_search=False,
-        )
 
     @pytest.mark.skip_less_device_memory(80000)
     def test_bf16(self):
@@ -1148,15 +1146,40 @@ class TestGemma4MoE(LlmapiAccuracyTestHarness):
         if get_device_count() < registry_world_size:
             pytest.skip("Not enough devices for world size, skipping test")
 
-        sampling_params = self.get_default_sampling_params()
+        sampling_params = SamplingParams(end_id=None,
+                                         pad_id=None,
+                                         n=1,
+                                         use_beam_search=False)
+        # MMMU needs its own output-length / truncation / stop-token config; the
+        # text tasks below reuse the generic sampling_params above.
+        mmmu_sampling_params = SamplingParams(
+            max_tokens=MMMU.MAX_OUTPUT_LEN,
+            truncate_prompt_tokens=MMMU.MAX_INPUT_LEN,
+            stop="<|endoftext|>",
+            end_id=None,
+            pad_id=None,
+            n=1,
+            use_beam_search=False,
+        )
         with AutoDeployLLM(model=self.MODEL_PATH,
                            tokenizer=self.MODEL_PATH,
                            world_size=registry_world_size,
                            yaml_extra=yaml_paths) as llm:
-            task = MMMU(self.MODEL_NAME)  # noqa: F821
+            task = MMMU(self.MODEL_NAME)
+            task.evaluate(
+                llm,
+                sampling_params=mmmu_sampling_params,
+                extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS,
+            )
+            task = MMLU(self.MODEL_NAME)
             task.evaluate(
                 llm,
                 sampling_params=sampling_params,
+                extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS,
+            )
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(
+                llm,
                 extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS,
             )
 

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_kvcache_vswa_metadata.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_kvcache_vswa_metadata.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Graph-shape tests for the VSWA per-group metadata wiring in the kvcache transform.
+
+The kvcache transform builds a per-window page table layout. Phase-1 of the
+Gemma-4 enablement (PR #13745) only routed *standard* metadata (cache_loc,
+cu_num_pages, last_page_len) per group; the *extra*-metadata op (the host-side
+prepare that produces e.g. update_paged_kv_cache write positions) was built
+once from group-0 inputs and reused for every layer. With seq_len_with_cache
+added to the swappable set (Phase 2), the extra-metadata op MUST also run per
+group, otherwise non-zero-group layers silently consume group-0's
+seq_len_with_cache (window-uncapped) → wrong write positions under eviction.
+
+These tests are graph-shape only — no GPU, no kernel execution.
+"""
+
+import pytest
+import torch
+
+import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterface
+from tensorrt_llm._torch.auto_deploy.transform.interface import SharedConfig, Stages
+from tensorrt_llm._torch.auto_deploy.transform.library.kvcache import (
+    InsertCachedAttention,
+    InsertCachedAttentionConfig,
+)
+
+
+class _TwoWindowModule(torch.nn.Module):
+    """A tiny two-layer model: layer 0 is SWA (sliding_window=256), layer 1
+    is full attention.  This forces the transform to create two window groups.
+    """
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        qkv = hidden_states.view(hidden_states.shape[0], hidden_states.shape[1], 2, 4)
+        swa_layer = torch.ops.auto_deploy.torch_attention(
+            qkv,
+            qkv,
+            qkv,
+            None,        # attn_mask
+            0.0,         # dropout_p
+            True,        # is_causal
+            1.0,         # scale
+            None,        # sinks
+            256,         # sliding_window  <-- SWA group
+            None,        # logit_cap
+            "bsnd",
+            0,           # layer_idx
+        )
+        full_layer = torch.ops.auto_deploy.torch_attention(
+            qkv,
+            qkv,
+            qkv,
+            None,
+            0.0,
+            True,
+            1.0,
+            None,
+            None,        # sliding_window=None  <-- full-attention group
+            None,
+            "bsnd",
+            1,
+        )
+        return swa_layer + full_layer
+
+
+def _run_transform(backend: str):
+    module = _TwoWindowModule().eval()
+    gm = torch_export_to_gm(module, (torch.randn(1, 4, 8),))
+    cm = CachedSequenceInterface(
+        max_seq_len=512,
+        max_batch_size=2,
+        max_num_tokens=512,
+        device="cpu",
+    )
+    transform = InsertCachedAttention(
+        InsertCachedAttentionConfig(stage=Stages.CACHE_INIT, backend=backend)
+    )
+    gm, info = transform._apply(gm, cm, factory=None, shared_config=SharedConfig())
+    return gm, info, cm
+
+
+def _placeholder_names(gm) -> list:
+    return [node.target for node in gm.graph.nodes if node.op == "placeholder"]
+
+
+def test_vswa_registers_per_group_seq_len_with_cache_placeholders():
+    """Group 1 must have its own seq_len_with_cache_g1{_host} placeholders so
+    the SWA group's window-capped value reaches the kernel and the extra-op.
+    """
+    gm, info, cm = _run_transform(backend="triton")
+    assert info.num_matches == 2, "expected 2 cached-attention insertions"
+
+    names = _placeholder_names(gm)
+    # Group 0 keeps the unsuffixed name; group 1 must have its own _g1 variant.
+    assert "seq_len_with_cache_host" in names
+    assert "seq_len_with_cache_g1_host" in names, (
+        "seq_len_with_cache must be in vswa_swappable_bases — without per-group "
+        "wiring, SWA layers silently consume group-0's window-uncapped value."
+    )
+
+
+def test_vswa_extra_metadata_is_per_group():
+    """The Triton backend's prepare-extra op consumes seq_len_with_cache. With
+    seq_len_with_cache routed per-group, the transform MUST invoke the
+    extra-op once per group; otherwise non-zero-group layers route through
+    group-0's prepare-extra output and the swappable seq_len_with_cache_g1
+    placeholder is dead.
+
+    This is the regression guard against the pre-fix transform behavior
+    described in the autodeploy-kvcache-vswa-meta-nodes-extra backlog.
+    """
+    gm, info, cm = _run_transform(backend="triton")
+
+    prep_meta_op = torch.ops.auto_deploy.triton_paged_prepare_metadata.default
+    prep_calls = [
+        node
+        for node in gm.graph.nodes
+        if node.op == "call_function" and node.target == prep_meta_op
+    ]
+    assert len(prep_calls) == 2, (
+        f"expected one prepare-extra call per group (2 groups), got {len(prep_calls)}"
+    )
+
+    # The two calls must consume DIFFERENT seq_len_with_cache placeholders:
+    # one from group 0 (unsuffixed), one from group 1 (suffixed).
+    swc_inputs_by_call = []
+    for call in prep_calls:
+        swc_input = None
+        for arg in call.args:
+            if (
+                isinstance(arg, torch.fx.Node)
+                and arg.op == "placeholder"
+                and "seq_len_with_cache" in str(arg.target)
+            ):
+                swc_input = str(arg.target)
+                break
+        assert swc_input is not None, (
+            f"prepare-extra call {call.format_node()} did not consume any "
+            f"seq_len_with_cache placeholder"
+        )
+        swc_inputs_by_call.append(swc_input)
+
+    assert len(set(swc_inputs_by_call)) == 2, (
+        f"both prepare-extra calls consume the same seq_len_with_cache "
+        f"input ({swc_inputs_by_call}); per-group routing failed"
+    )
+
+
+def test_vswa_each_layer_routes_to_its_groups_extra_metadata():
+    """The cached-attn call for group 1 (the SWA layer) must consume the
+    group-1 prepare-extra outputs, not group 0's.
+    """
+    gm, info, cm = _run_transform(backend="triton")
+
+    cached_op = torch.ops.auto_deploy.triton_paged_mha_with_cache.default
+    cached_calls = [
+        node
+        for node in gm.graph.nodes
+        if node.op == "call_function" and node.target == cached_op
+    ]
+    assert len(cached_calls) == 2
+
+    # For each cached-attn call, find which seq_len_with_cache placeholder its
+    # extra-metadata args ultimately depend on.  We do a simple recursive walk
+    # through args (bounded by graph size) since the prepare-extra outputs are
+    # getitem nodes of a call_function whose args include the placeholder.
+    def find_swc_dep(node, visited=None):
+        if visited is None:
+            visited = set()
+        if id(node) in visited:
+            return None
+        visited.add(id(node))
+        if isinstance(node, torch.fx.Node):
+            if node.op == "placeholder" and "seq_len_with_cache" in str(node.target):
+                return str(node.target)
+            if node.op in ("call_function", "call_method"):
+                for arg in list(node.args) + list(node.kwargs.values()):
+                    result = find_swc_dep(arg, visited)
+                    if result is not None:
+                        return result
+        return None
+
+    deps_per_call = []
+    for call in cached_calls:
+        # The first three args are q/k/v; standard metadata follows.  Walk all
+        # args until we find a seq_len_with_cache placeholder dependency.
+        dep = None
+        for arg in call.args:
+            dep = find_swc_dep(arg)
+            if dep is not None:
+                break
+        assert dep is not None, "no seq_len_with_cache dependency found"
+        deps_per_call.append(dep)
+
+    # The two cached-attn calls (one per layer = one per group) must each route
+    # to a distinct seq_len_with_cache placeholder.
+    assert len(set(deps_per_call)) == 2, (
+        f"both cached-attn calls depend on the same seq_len_with_cache "
+        f"placeholder ({deps_per_call}); per-group wiring failed"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_kvcache_vswa_metadata.py
+++ b/tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_kvcache_vswa_metadata.py
@@ -39,15 +39,15 @@ class _TwoWindowModule(torch.nn.Module):
             qkv,
             qkv,
             qkv,
-            None,        # attn_mask
-            0.0,         # dropout_p
-            True,        # is_causal
-            1.0,         # scale
-            None,        # sinks
-            256,         # sliding_window  <-- SWA group
-            None,        # logit_cap
+            None,  # attn_mask
+            0.0,  # dropout_p
+            True,  # is_causal
+            1.0,  # scale
+            None,  # sinks
+            256,  # sliding_window  <-- SWA group
+            None,  # logit_cap
             "bsnd",
-            0,           # layer_idx
+            0,  # layer_idx
         )
         full_layer = torch.ops.auto_deploy.torch_attention(
             qkv,
@@ -58,7 +58,7 @@ class _TwoWindowModule(torch.nn.Module):
             True,
             1.0,
             None,
-            None,        # sliding_window=None  <-- full-attention group
+            None,  # sliding_window=None  <-- full-attention group
             None,
             "bsnd",
             1,
@@ -157,9 +157,7 @@ def test_vswa_each_layer_routes_to_its_groups_extra_metadata():
 
     cached_op = torch.ops.auto_deploy.triton_paged_mha_with_cache.default
     cached_calls = [
-        node
-        for node in gm.graph.nodes
-        if node.op == "call_function" and node.target == cached_op
+        node for node in gm.graph.nodes if node.op == "call_function" and node.target == cached_op
     ]
     assert len(cached_calls) == 2
 

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_paged_attention_swa.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_paged_attention_swa.py
@@ -94,10 +94,11 @@ def _write_kv_to_cache(
     page_table: torch.Tensor,
     page_size: int,
 ):
-    """Write all of (k, v) sequentially into kv_cache at the pages listed in
-    page_table. k, v are flat [tokens, n_kv_heads, head_dim]. page_table is
-    a 1D int32 tensor listing physical page ids in token-order. Assumes
-    page_table covers exactly enough pages for k.shape[0] tokens.
+    """Write all of (k, v) sequentially into kv_cache at the listed pages.
+
+    k, v are flat [tokens, n_kv_heads, head_dim]. page_table is a 1D int32
+    tensor listing physical page ids in token-order. Assumes page_table
+    covers exactly enough pages for k.shape[0] tokens.
     """
     from tensorrt_llm._torch.auto_deploy.custom_ops.attention.triton_paged_attention import (
         update_paged_kv_cache,
@@ -290,9 +291,7 @@ class TestTritonPagedSWAFrontEviction:
 
         b_idx = torch.zeros(new_chunk, dtype=torch.int32, device="cuda")
         positions = torch.arange(new_chunk, dtype=torch.int32, device="cuda")
-        kv_indptr_for_write = torch.tensor(
-            [0, new_pages_needed], dtype=torch.int32, device="cuda"
-        )
+        kv_indptr_for_write = torch.tensor([0, new_pages_needed], dtype=torch.int32, device="cuda")
         update_paged_kv_cache(
             new_k, new_v, b_idx, positions, kv_cache, new_page_table, kv_indptr_for_write
         )
@@ -348,7 +347,9 @@ class TestTritonPagedSWAFrontEviction:
             full_v.float(),
             # sw=0 in the kernel ⇒ no SW pruning; reproduce that by feeding a
             # window larger than the entire kv length.
-            sliding_window=sliding_window if with_sliding_window else (live_cache_tokens + new_chunk + 1),
+            sliding_window=sliding_window
+            if with_sliding_window
+            else (live_cache_tokens + new_chunk + 1),
             cache_len_before_q=live_cache_tokens,
         ).to(output.dtype)
 

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_paged_attention_swa.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_paged_attention_swa.py
@@ -1,0 +1,359 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""SWA correctness tests for Triton paged attention.
+
+Two regimes that the existing kernel tests don't exercise:
+
+1. **Long prefill SWA** (no eviction yet): a single prefill longer than the
+   sliding window. The kernel must apply the SW mask within the chunk itself.
+   This is the lightweight regression that catches mask-math regressions
+   without spinning up a real KVCacheManager.
+
+2. **Front-eviction SWA** (eviction has happened): the shim hands the kernel
+   a window-coherent local-coord view — sliced cache_loc, window-capped
+   seq_len_with_cache. The kernel must produce the same output as SDPA on the
+   live window only. Pre-fix kernels that mixed coordinate spaces silently
+   dropped boundary pages and corrupted masks; under Option B (everything
+   local) the kernel needs no changes, so these tests should pass before AND
+   after the shim/transform fix. They are the regression guard against future
+   coordinate-space mistakes.
+"""
+
+import math
+
+import pytest
+import torch
+
+import tensorrt_llm._torch.auto_deploy  # noqa: F401
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+
+
+def _sdpa_reference_with_sw(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    sliding_window: int,
+    cache_len_before_q: int,
+) -> torch.Tensor:
+    """Reference SDPA with a per-query causal + sliding-window mask.
+
+    Inputs are in [tokens, n_heads, head_dim] (flat). For each query token at
+    local position `q_pos = cache_len_before_q + i` (i ∈ [0, q_len)), the
+    valid keys are positions in [max(0, q_pos - W + 1), q_pos].
+    """
+    q_t = q.transpose(0, 1).unsqueeze(0)  # [1, n_heads, q_len, head_dim]
+    k_t = k.transpose(0, 1).unsqueeze(0)  # [1, n_kv_heads, kv_len, head_dim]
+    v_t = v.transpose(0, 1).unsqueeze(0)
+
+    n_heads = q_t.shape[1]
+    n_kv_heads = k_t.shape[1]
+    if n_heads != n_kv_heads:
+        rep = n_heads // n_kv_heads
+        k_t = k_t.repeat_interleave(rep, dim=1)
+        v_t = v_t.repeat_interleave(rep, dim=1)
+
+    q_len = q_t.shape[2]
+    kv_len = k_t.shape[2]
+
+    head_dim = q_t.shape[-1]
+    scale = 1.0 / math.sqrt(head_dim)
+    scores = torch.matmul(q_t, k_t.transpose(-2, -1)) * scale  # [1, h, q_len, kv_len]
+
+    # mask in [q_len, kv_len]; q_pos = cache_len_before_q + i
+    q_positions = torch.arange(q_len, device=q.device) + cache_len_before_q
+    kv_positions = torch.arange(kv_len, device=q.device)
+    diff = q_positions.unsqueeze(1) - kv_positions.unsqueeze(0)
+    causal_ok = diff >= 0
+    window_ok = diff < sliding_window
+    valid = causal_ok & window_ok
+    scores = scores.masked_fill(~valid.unsqueeze(0).unsqueeze(0), float("-inf"))
+
+    weights = torch.softmax(scores, dim=-1)
+    out = torch.matmul(weights, v_t)  # [1, h, q_len, head_dim]
+    return out.squeeze(0).transpose(0, 1)  # [q_len, n_heads, head_dim]
+
+
+def _write_kv_to_cache(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    kv_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    page_size: int,
+):
+    """Write all of (k, v) sequentially into kv_cache at the pages listed in
+    page_table. k, v are flat [tokens, n_kv_heads, head_dim]. page_table is
+    a 1D int32 tensor listing physical page ids in token-order. Assumes
+    page_table covers exactly enough pages for k.shape[0] tokens.
+    """
+    from tensorrt_llm._torch.auto_deploy.custom_ops.attention.triton_paged_attention import (
+        update_paged_kv_cache,
+    )
+
+    n_tokens = k.shape[0]
+    batch_indices = torch.zeros(n_tokens, dtype=torch.int32, device=k.device)
+    positions = torch.arange(n_tokens, dtype=torch.int32, device=k.device)
+    kv_indptr = torch.tensor([0, page_table.numel()], dtype=torch.int32, device=k.device)
+    update_paged_kv_cache(k, v, batch_indices, positions, kv_cache, page_table, kv_indptr)
+
+
+class TestTritonPagedLongPrefillSWA:
+    """Prefill longer than the sliding window — no eviction yet.
+
+    Verifies the kernel correctly applies the SW mask within a single long
+    prefill chunk. Covers BOTH the Phase-1 (full pages) and Phase-2 (boundary
+    pages) code paths since prefill_len > W * 2 forces both.
+    """
+
+    @pytest.mark.parametrize("page_size", [16, 64])
+    @pytest.mark.parametrize("sliding_window", [128, 256])
+    @pytest.mark.parametrize("prefill_len_mult", [1, 2, 4])  # 1*W, 2*W, 4*W
+    @pytest.mark.parametrize("n_heads,n_kv_heads", [(4, 4), (8, 2)])
+    @pytest.mark.parametrize("head_dim", [64, 128])
+    def test_long_prefill_sw_matches_sdpa(
+        self,
+        page_size: int,
+        sliding_window: int,
+        prefill_len_mult: int,
+        n_heads: int,
+        n_kv_heads: int,
+        head_dim: int,
+    ):
+        from tensorrt_llm._torch.auto_deploy.custom_ops.attention.triton_paged_attention import (
+            triton_paged_context,
+        )
+
+        torch.manual_seed(0)
+        prefill_len = sliding_window * prefill_len_mult
+        # Round prefill_len up so it spans whole + boundary pages naturally.
+        num_pages = (prefill_len + page_size - 1) // page_size
+        num_blocks = num_pages + 4
+
+        q = torch.randn(prefill_len, n_heads, head_dim, dtype=torch.float16, device="cuda")
+        k = torch.randn(prefill_len, n_kv_heads, head_dim, dtype=torch.float16, device="cuda")
+        v = torch.randn(prefill_len, n_kv_heads, head_dim, dtype=torch.float16, device="cuda")
+
+        kv_cache = torch.zeros(
+            num_blocks, 2, n_kv_heads, page_size, head_dim, dtype=torch.float16, device="cuda"
+        )
+        page_table = torch.arange(num_pages, dtype=torch.int32, device="cuda")
+        _write_kv_to_cache(k, v, kv_cache, page_table, page_size)
+
+        qo_indptr = torch.tensor([0, prefill_len], dtype=torch.int32, device="cuda")
+        kv_indptr = torch.tensor([0, num_pages], dtype=torch.int32, device="cuda")
+        kv_indices = page_table.clone()
+        last_token_in_page = prefill_len % page_size
+        kv_last_page_len = torch.tensor(
+            [last_token_in_page if last_token_in_page > 0 else page_size],
+            dtype=torch.int32,
+            device="cuda",
+        )
+        seq_len_with_cache = torch.tensor([prefill_len], dtype=torch.int32, device="cuda")
+
+        sm_scale = 1.0 / math.sqrt(head_dim)
+        output = triton_paged_context(
+            q,
+            kv_cache,
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            seq_len_with_cache,
+            sm_scale,
+            sliding_window=sliding_window,
+        )
+
+        ref = _sdpa_reference_with_sw(
+            q.float(),
+            k.float(),
+            v.float(),
+            sliding_window=sliding_window,
+            cache_len_before_q=0,
+        ).to(output.dtype)
+
+        torch.testing.assert_close(output.float(), ref.float(), rtol=1e-2, atol=1e-2)
+
+
+class TestTritonPagedSWAFrontEviction:
+    """Front-eviction SWA — the shim hands the kernel a window-local view.
+
+    The setup mirrors what `ad_executor.py` does after Phase 2: it slices
+    `cache_loc` to the live (post-eviction) pages and caps
+    `seq_len_with_cache` at the window. With Option B (everything local), the
+    kernel needs no changes — these tests are the regression guard for that
+    contract.
+    """
+
+    @pytest.mark.parametrize("front_removed", [0, 1, 4])
+    @pytest.mark.parametrize("chunk", [1, 64, 128])
+    @pytest.mark.parametrize("page_size", [16, 64])
+    @pytest.mark.parametrize("with_sliding_window", [True, False])
+    def test_front_evicted_context_matches_sdpa_on_live_window(
+        self,
+        front_removed: int,
+        chunk: int,
+        page_size: int,
+        with_sliding_window: bool,
+    ):
+        from tensorrt_llm._torch.auto_deploy.custom_ops.attention.triton_paged_attention import (
+            triton_paged_context,
+        )
+
+        # Fixed simple geometry for clarity. Window W=256 → 16 pages at PAGE_SIZE=16,
+        # 4 pages at PAGE_SIZE=64.
+        torch.manual_seed(0)
+        sliding_window = 256
+        n_heads = 4
+        n_kv_heads = 4
+        head_dim = 64
+
+        # Total cached tokens (post-fill, pre-chunk). Make this exactly equal to W
+        # so the "live" window contains exactly W tokens regardless of front_removed.
+        total_cache_tokens = sliding_window
+        # The historical page list must include the front-evicted pages too.
+        historical_pages = front_removed + (total_cache_tokens + page_size - 1) // page_size
+        num_blocks = historical_pages + 4 + (chunk + page_size - 1) // page_size
+
+        # Build a historical KV history: front_removed*page_size junk tokens
+        # (will not be read) + total_cache_tokens real tokens, then `chunk` new
+        # tokens being processed.
+        live_cache_tokens = total_cache_tokens
+        new_chunk = chunk
+
+        # Allocate cache and a "historical" page table (front_removed pages
+        # contain stale data; the rest contain live cached tokens).
+        kv_cache = torch.zeros(
+            num_blocks, 2, n_kv_heads, page_size, head_dim, dtype=torch.float16, device="cuda"
+        )
+
+        # Real (live + new) KV data we want the kernel to attend to.
+        live_k = torch.randn(
+            live_cache_tokens, n_kv_heads, head_dim, dtype=torch.float16, device="cuda"
+        )
+        live_v = torch.randn(
+            live_cache_tokens, n_kv_heads, head_dim, dtype=torch.float16, device="cuda"
+        )
+        new_k = torch.randn(new_chunk, n_kv_heads, head_dim, dtype=torch.float16, device="cuda")
+        new_v = torch.randn(new_chunk, n_kv_heads, head_dim, dtype=torch.float16, device="cuda")
+        # Stale data the kernel must NOT read (we'll keep these pages
+        # zero-filled — if the kernel reads them it'll skew the output).
+
+        # Page table layout (historical, full list):
+        #   [stale_0, stale_1, ..., stale_{front_removed-1}, live_0, ..., new_pages...]
+        live_pages_needed = (live_cache_tokens + page_size - 1) // page_size
+        new_pages_needed = (new_chunk + page_size - 1) // page_size
+        # Total physical pages used by this request, from page 0..end:
+        all_pages = torch.arange(
+            historical_pages + new_pages_needed, dtype=torch.int32, device="cuda"
+        )
+
+        # Write live KV to the live pages (positions [front_removed*page_size,
+        # front_removed*page_size + live_cache_tokens)) of the global cache.
+        live_page_table = all_pages[front_removed : front_removed + live_pages_needed]
+        _write_kv_to_cache(live_k, live_v, kv_cache, live_page_table, page_size)
+        # Write new chunk KV to the new pages (just after the live pages).
+        new_page_table = all_pages[
+            front_removed + live_pages_needed : front_removed + live_pages_needed + new_pages_needed
+        ]
+        # Pad to page boundary for the write helper.
+        new_k_padded = torch.zeros(
+            new_pages_needed * page_size, n_kv_heads, head_dim, dtype=torch.float16, device="cuda"
+        )
+        new_v_padded = torch.zeros_like(new_k_padded)
+        # Page-aligned local offset for the chunk's first token: it sits right
+        # after the live cache, in local coords that's live_cache_tokens.
+        # Since live_cache_tokens is a multiple of page_size (we set it = W and
+        # require page_size | W), the chunk starts at offset 0 within new_page_table.
+        assert live_cache_tokens % page_size == 0, (
+            "test geometry assumes live cache is page-aligned"
+        )
+        new_k_padded[:new_chunk] = new_k
+        new_v_padded[:new_chunk] = new_v
+        # We can't easily write a partial-page; only fill if new_chunk is multiple of page_size.
+        # For partial pages, fall back to per-token write.
+        from tensorrt_llm._torch.auto_deploy.custom_ops.attention.triton_paged_attention import (
+            update_paged_kv_cache,
+        )
+
+        b_idx = torch.zeros(new_chunk, dtype=torch.int32, device="cuda")
+        positions = torch.arange(new_chunk, dtype=torch.int32, device="cuda")
+        kv_indptr_for_write = torch.tensor(
+            [0, new_pages_needed], dtype=torch.int32, device="cuda"
+        )
+        update_paged_kv_cache(
+            new_k, new_v, b_idx, positions, kv_cache, new_page_table, kv_indptr_for_write
+        )
+
+        # Shim's view: slice the historical page table to live + new only.
+        # This is exactly `all_indices[front_removed : front_removed + num_active]`
+        # in ad_executor.py after Phase 2.
+        live_view_pages = all_pages[
+            front_removed : front_removed + live_pages_needed + new_pages_needed
+        ].contiguous()
+        num_kv_pages = live_view_pages.numel()
+
+        # Q is the chunk's queries.
+        q = torch.randn(new_chunk, n_heads, head_dim, dtype=torch.float16, device="cuda")
+
+        qo_indptr = torch.tensor([0, new_chunk], dtype=torch.int32, device="cuda")
+        kv_indptr = torch.tensor([0, num_kv_pages], dtype=torch.int32, device="cuda")
+        # Window-capped seq_len_with_cache: live_cache_tokens + new_chunk
+        # (NOT the global value which would include the evicted prefix).
+        seq_len_with_cache = torch.tensor(
+            [live_cache_tokens + new_chunk], dtype=torch.int32, device="cuda"
+        )
+        last_token_in_page = (live_cache_tokens + new_chunk) % page_size
+        kv_last_page_len = torch.tensor(
+            [last_token_in_page if last_token_in_page > 0 else page_size],
+            dtype=torch.int32,
+            device="cuda",
+        )
+
+        sm_scale = 1.0 / math.sqrt(head_dim)
+        sw_arg = sliding_window if with_sliding_window else 0
+        output = triton_paged_context(
+            q,
+            kv_cache,
+            qo_indptr,
+            kv_indptr,
+            live_view_pages,
+            kv_last_page_len,
+            seq_len_with_cache,
+            sm_scale,
+            sliding_window=sw_arg,
+        )
+
+        # SDPA reference computed on the LIVE window only: keys/values are
+        # [live_k; new_k], queries are `q`. Cache length before q is
+        # live_cache_tokens. Sliding window applied if requested (passing
+        # sw=0 corresponds to plain causal on the live window).
+        full_k = torch.cat([live_k, new_k], dim=0)
+        full_v = torch.cat([live_v, new_v], dim=0)
+        ref = _sdpa_reference_with_sw(
+            q.float(),
+            full_k.float(),
+            full_v.float(),
+            # sw=0 in the kernel ⇒ no SW pruning; reproduce that by feeding a
+            # window larger than the entire kv length.
+            sliding_window=sliding_window if with_sliding_window else (live_cache_tokens + new_chunk + 1),
+            cache_len_before_q=live_cache_tokens,
+        ).to(output.dtype)
+
+        torch.testing.assert_close(output.float(), ref.float(), rtol=1e-2, atol=1e-2)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unittest/auto_deploy/singlegpu/shim/test_ad_executor_swa_eviction.py
+++ b/tests/unittest/auto_deploy/singlegpu/shim/test_ad_executor_swa_eviction.py
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration test for the shim's SWA front-eviction metadata path.
+
+Drives a real two-window CachedSequenceInterface + KVCacheManager (so the
+historical `get_cache_indices` payload reflects real C++ page-table state),
+then monkeypatches `get_num_front_blocks_removed` to simulate eviction at
+controlled counts.  The shim helper `_compute_window_local_view` must
+produce a window-coherent local-coord view: live page slice, window-capped
+seq_len_with_cache, derived last_page_len, and a coherent spillover slot.
+
+`get_num_front_blocks_removed` is monkeypatched (not driven by real decode)
+because firing real SWA eviction from Python without a model requires
+either spinning up a full ADEngine + model or adding a test-only C++
+binding to bump the counter directly — both are out of scope.  The patch
+covers exactly what the C++ side would otherwise do: bump a counter
+without mutating mCacheBlockIds, so the historical page list still
+contains the evicted-but-stale-entries-at-the-front pattern that the
+shim is supposed to handle.
+"""
+
+import pytest
+import torch
+from _model_test_utils import default_max_num_tokens
+
+from tensorrt_llm._torch.auto_deploy._compat import KvCacheConfig
+from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import KVPagedResourceHandler
+from tensorrt_llm._torch.auto_deploy.shim.ad_executor import _compute_window_local_view
+from tensorrt_llm._torch.auto_deploy.shim.interface import CachedSequenceInterface
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+
+
+# Geometry shared across cases: SWA window of 64 tokens with tokens_per_block=32
+# gives 2 pages per window — small enough to exercise eviction boundaries
+# without ballooning runtime.
+SWA_WINDOW = 64
+FULL_WINDOW = 128
+TOKENS_PER_BLOCK = 32
+PAGES_PER_SWA_WINDOW = SWA_WINDOW // TOKENS_PER_BLOCK  # 2
+
+
+@pytest.fixture
+def two_window_interface():
+    """A real CachedSequenceInterface hosting a dual-pool KVCacheManager.
+
+    Layer 0 lives in an SWA window (W=64); layer 1 lives in a full window.
+    This is the Gemma-4 geometry — exactly the path Phase 2 fixes.
+    """
+    interface = CachedSequenceInterface(
+        max_seq_len=FULL_WINDOW,
+        max_batch_size=2,
+        max_num_tokens=default_max_num_tokens(FULL_WINDOW, 2),
+        device="cuda",
+        kv_cache_config=KvCacheConfig(
+            tokens_per_block=TOKENS_PER_BLOCK,
+            max_tokens=1024,
+            free_gpu_memory_fraction=0.0,
+        ),
+    )
+    interface.add_resource(
+        "kv_swa", KVPagedResourceHandler(4, 32, dtype=torch.float16, sliding_window=SWA_WINDOW)
+    )
+    interface.add_resource("kv_full", KVPagedResourceHandler(4, 32, dtype=torch.float16))
+    interface.initialize_resources()
+    return interface
+
+
+def _add_request(manager, request_id: int, token_num: int):
+    """Add a dummy request that allocates pages for `token_num` tokens."""
+    out = manager.add_dummy_requests([request_id], token_nums=[token_num])
+    assert out is not None and len(out) == 1, "manager did not allocate the request"
+    return out[0]
+
+
+def test_helper_no_eviction_passes_through(two_window_interface):
+    """Sanity guard: front_removed=0 reproduces the pre-Phase-2 view.
+
+    Asserts `all_indices[:num_active]`, full window-capped
+    seq_len_with_cache, and the next slot as the spillover page.
+    """
+    manager = two_window_interface.kv_cache_manager
+    req = _add_request(manager, request_id=42, token_num=SWA_WINDOW)
+
+    all_indices = manager.get_cache_indices(req, window_size=SWA_WINDOW)
+    assert manager.get_num_front_blocks_removed(req.py_request_id, window_size=SWA_WINDOW) == 0
+
+    active_indices, extra_page, swc, lpl = _compute_window_local_view(
+        all_indices,
+        front_removed=0,
+        end_compute_i=SWA_WINDOW,
+        group_window=SWA_WINDOW,
+        tokens_per_block=TOKENS_PER_BLOCK,
+    )
+
+    assert active_indices == list(all_indices[:PAGES_PER_SWA_WINDOW])
+    assert swc == SWA_WINDOW
+    assert lpl == TOKENS_PER_BLOCK
+    # No spillover slot when num_active fully consumes the historical list.
+    if len(all_indices) > PAGES_PER_SWA_WINDOW:
+        assert extra_page == all_indices[PAGES_PER_SWA_WINDOW]
+    else:
+        assert extra_page == -1
+
+
+@pytest.mark.parametrize("front_removed", [1, PAGES_PER_SWA_WINDOW])
+def test_helper_with_simulated_eviction_slices_correctly(
+    two_window_interface, monkeypatch, front_removed
+):
+    """Eviction-aware slicing and window-capping.
+
+    With front_removed > 0, the slice must start at front_removed and
+    seq_len_with_cache must stay within the window even when end_compute_i
+    represents many evicted-token-worths of progress.
+
+    Simulates a request that has cumulatively seen
+    ``front_removed * tokens_per_block + SWA_WINDOW`` tokens, i.e.
+    ``front_removed`` pages have already been front-evicted on the SWA pool.
+    """
+    manager = two_window_interface.kv_cache_manager
+    # Allocate enough pages to span (evicted + live + a spillover slot) so
+    # get_cache_indices returns a realistic-length list.
+    total_tokens = front_removed * TOKENS_PER_BLOCK + SWA_WINDOW + 1
+    req = _add_request(manager, request_id=43, token_num=total_tokens)
+
+    # Bump the eviction counter the way detachFrontBlock would (the C++ side
+    # bumps `mNumFrontBlocksRemovedPerWindow[ws]` without mutating
+    # mCacheBlockIds, so get_cache_indices STILL returns the full list and
+    # the shim must slice [front_removed:] off it).
+    real_query = manager.get_num_front_blocks_removed
+
+    def fake_front_removed(request_id, window_size=None):
+        if request_id == req.py_request_id and window_size == SWA_WINDOW:
+            return front_removed
+        return real_query(request_id, window_size=window_size)
+
+    monkeypatch.setattr(manager, "get_num_front_blocks_removed", fake_front_removed)
+
+    all_indices = manager.get_cache_indices(req, window_size=SWA_WINDOW)
+    front = manager.get_num_front_blocks_removed(req.py_request_id, window_size=SWA_WINDOW)
+    assert front == front_removed
+
+    # end_compute_i is the global position; the helper must cap it at the window.
+    end_compute_i = total_tokens
+    active_indices, extra_page, swc, lpl = _compute_window_local_view(
+        all_indices,
+        front_removed=front,
+        end_compute_i=end_compute_i,
+        group_window=SWA_WINDOW,
+        tokens_per_block=TOKENS_PER_BLOCK,
+    )
+
+    # 1. Live slice starts at front_removed, exactly the pages a Phase-2-aware
+    #    shim hands the kernel.
+    expected_slice = list(all_indices[front_removed : front_removed + PAGES_PER_SWA_WINDOW])
+    assert active_indices == expected_slice, (
+        f"slice mismatch: front_removed={front_removed}, "
+        f"all_indices={list(all_indices)}, active={active_indices}"
+    )
+
+    # 2. seq_len_with_cache is window-capped: this is the contract the kernel
+    #    relies on (total_kv_len - q_len ≤ W in local coords).
+    assert swc == SWA_WINDOW
+    assert swc <= SWA_WINDOW, f"swc={swc} exceeded window={SWA_WINDOW}"
+
+    # 3. last_page_len consistent with seq_len_with_cache.
+    expected_lpl = (swc - 1) % TOKENS_PER_BLOCK + 1 if swc > 0 else 0
+    assert lpl == expected_lpl
+
+    # 4. The page table the kernel sees holds enough capacity for the
+    #    cached portion (the integration invariant called out in the
+    #    backlog: len(active) * PAGE_SIZE >= seq_len_with_cache - q_len).
+    q_len = 0  # Pure cache-coverage check, ignore new tokens here.
+    assert len(active_indices) * TOKENS_PER_BLOCK >= swc - q_len
+
+
+def test_helper_caps_seq_len_with_cache_below_window(two_window_interface, monkeypatch):
+    """Below-window end_compute_i reports actual progress, not the window size.
+
+    When end_compute_i is BELOW the window (early prefill / short request),
+    seq_len_with_cache reports the actual progress, not the window size — the
+    helper must not over-pad.
+    """
+    manager = two_window_interface.kv_cache_manager
+    req = _add_request(manager, request_id=44, token_num=SWA_WINDOW)
+
+    monkeypatch.setattr(manager, "get_num_front_blocks_removed", lambda req_id, window_size=None: 0)
+    all_indices = manager.get_cache_indices(req, window_size=SWA_WINDOW)
+
+    short_end = TOKENS_PER_BLOCK + 5  # < SWA_WINDOW
+    _, _, swc, lpl = _compute_window_local_view(
+        all_indices,
+        front_removed=0,
+        end_compute_i=short_end,
+        group_window=SWA_WINDOW,
+        tokens_per_block=TOKENS_PER_BLOCK,
+    )
+    assert swc == short_end
+    assert lpl == ((short_end - 1) % TOKENS_PER_BLOCK + 1)
+
+
+def test_helper_does_not_consume_evicted_extra_slot(two_window_interface, monkeypatch):
+    """Spillover slot must live AFTER the live window, never inside evicted range.
+
+    Pre-Phase-2 code that referenced `all_indices[num_active]` would land
+    inside the evicted region whenever front_removed > 0 — this test guards
+    against that.
+    """
+    manager = two_window_interface.kv_cache_manager
+    front_removed = 2
+    total_tokens = front_removed * TOKENS_PER_BLOCK + SWA_WINDOW + 1
+    req = _add_request(manager, request_id=45, token_num=total_tokens)
+    monkeypatch.setattr(
+        manager,
+        "get_num_front_blocks_removed",
+        lambda req_id, window_size=None: front_removed,
+    )
+
+    all_indices = manager.get_cache_indices(req, window_size=SWA_WINDOW)
+    _, extra_page, _, _ = _compute_window_local_view(
+        all_indices,
+        front_removed=front_removed,
+        end_compute_i=total_tokens,
+        group_window=SWA_WINDOW,
+        tokens_per_block=TOKENS_PER_BLOCK,
+    )
+
+    expected_extra_idx = front_removed + PAGES_PER_SWA_WINDOW
+    if len(all_indices) > expected_extra_idx:
+        assert extra_page == all_indices[expected_extra_idx]
+        # Crucially, the spillover slot is NOT in the front-evicted range.
+        assert expected_extra_idx >= front_removed
+    else:
+        assert extra_page == -1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unittest/auto_deploy/singlegpu/shim/test_cached_sequence_interface.py
+++ b/tests/unittest/auto_deploy/singlegpu/shim/test_cached_sequence_interface.py
@@ -782,6 +782,19 @@ def test_sequence_info_update_cache_information_resizes():
         assert seq_info._input_buffer.get_capacity("cache_loc") >= expected_capacity
 
 
+def test_sequence_info_update_cache_information_preserves_max_blocks():
+    """Verify max_blocks_per_seq is always based on max_seq_len (not window)."""
+    seq_info = SequenceInfo(
+        max_seq_len=128,
+        max_batch_size=4,
+        tokens_per_block=32,
+    )
+
+    original_max_blocks = seq_info.max_blocks_per_seq  # ceil(128 / 32) = 4
+    seq_info.update_cache_information(num_blocks=100)
+    assert seq_info.max_blocks_per_seq == original_max_blocks
+
+
 def test_sequence_info_last_page_len_uses_tokens_per_block():
     """Verify nest_sequences calculates last_page_len using tokens_per_block."""
     seq_info = SequenceInfo(
@@ -1191,3 +1204,270 @@ def test_register_host_prepare_populates_requires_copy():
 
     assert "batch_info_host" in seq_info._active_host_prep_args
     assert "cu_num_pages_host" in seq_info._active_host_prep_args
+
+
+# =============================================================================
+# Multi-Window (VSWA) KV Cache Tests — single unified KVCacheManager hosting
+# multiple C++ pools via the per-window head_dim/dtype overrides.
+# =============================================================================
+
+
+def test_identify_managed_kv_resources_single_window():
+    """Single head_dim and no sliding window collapses into one window entry."""
+    interface = CachedSequenceInterface(
+        max_seq_len=128,
+        max_batch_size=4,
+        max_num_tokens=default_max_num_tokens(128, 4),
+        device="cuda",
+        kv_cache_config=KvCacheConfig(
+            tokens_per_block=32, max_tokens=1024, free_gpu_memory_fraction=0.0
+        ),
+    )
+    name_0 = interface.add_resource("kv_0", KVPagedResourceHandler(8, 64, dtype=torch.float16))
+    name_1 = interface.add_resource("kv_1", KVPagedResourceHandler(8, 64, dtype=torch.float16))
+
+    (
+        kv_managed,
+        size_per_head_per_window,
+        dtype_per_window,
+        window_per_layer,
+    ) = interface._identify_managed_kv_resources()
+
+    assert len(kv_managed) == 2
+    # No sliding_window → effective window = max_seq_len.
+    assert size_per_head_per_window == {128: 64}
+    assert set(dtype_per_window.keys()) == {128}
+    assert window_per_layer == {name_0: 128, name_1: 128}
+
+
+def test_identify_managed_kv_resources_dual_window_gemma4_pattern():
+    """Gemma4-style mix: SWA layers with smaller head_dim + full-attn layer with larger head_dim."""
+    interface = CachedSequenceInterface(
+        max_seq_len=128,
+        max_batch_size=4,
+        max_num_tokens=default_max_num_tokens(128, 4),
+        device="cuda",
+        kv_cache_config=KvCacheConfig(
+            tokens_per_block=32, max_tokens=1024, free_gpu_memory_fraction=0.0
+        ),
+    )
+    # SWA window: head_dim=64
+    swa_name_0 = interface.add_resource(
+        "kv_0", KVPagedResourceHandler(8, 64, dtype=torch.float16, sliding_window=64)
+    )
+    swa_name_1 = interface.add_resource(
+        "kv_1", KVPagedResourceHandler(8, 64, dtype=torch.float16, sliding_window=64)
+    )
+    # Full-attention window: head_dim=128
+    full_name = interface.add_resource("kv_2", KVPagedResourceHandler(4, 128, dtype=torch.float16))
+
+    (
+        kv_managed,
+        size_per_head_per_window,
+        dtype_per_window,
+        window_per_layer,
+    ) = interface._identify_managed_kv_resources()
+
+    assert len(kv_managed) == 3
+    # Two windows, keyed by effective window size; full-attention falls back to max_seq_len.
+    assert size_per_head_per_window == {64: 64, 128: 128}
+    assert set(dtype_per_window.keys()) == {64, 128}
+    assert window_per_layer[swa_name_0] == 64
+    assert window_per_layer[swa_name_1] == 64
+    assert window_per_layer[full_name] == 128
+
+
+def test_identify_managed_kv_resources_no_unmanaged():
+    """All KV layers are part of the unified manager — none left unmanaged."""
+    interface = CachedSequenceInterface(
+        max_seq_len=128,
+        max_batch_size=4,
+        max_num_tokens=default_max_num_tokens(128, 4),
+        device="cuda",
+        kv_cache_config=KvCacheConfig(
+            tokens_per_block=32, max_tokens=1024, free_gpu_memory_fraction=0.0
+        ),
+    )
+    interface.add_resource("kv_0", KVPagedResourceHandler(8, 64, dtype=torch.float16))
+    interface.add_resource(
+        "kv_1", KVPagedResourceHandler(8, 64, dtype=torch.float16, sliding_window=64)
+    )
+    interface.add_resource(
+        "kv_2", KVPagedResourceHandler(4, 128, dtype=torch.float16, sliding_window=32)
+    )
+
+    (
+        kv_managed,
+        size_per_head_per_window,
+        _dtype_per_window,
+        window_per_layer,
+    ) = interface._identify_managed_kv_resources()
+
+    assert len(kv_managed) == 3
+    assert len(window_per_layer) == 3
+    # Three distinct effective windows in this fixture: 32, 64, max_seq_len(=128).
+    assert set(size_per_head_per_window.keys()) == {32, 64, 128}
+
+
+def test_identify_managed_kv_resources_rejects_mixed_head_dim_in_same_window():
+    """Layers sharing an effective window must agree on head_dim."""
+    interface = CachedSequenceInterface(
+        max_seq_len=128,
+        max_batch_size=4,
+        max_num_tokens=default_max_num_tokens(128, 4),
+        device="cuda",
+        kv_cache_config=KvCacheConfig(
+            tokens_per_block=32, max_tokens=1024, free_gpu_memory_fraction=0.0
+        ),
+    )
+    # Both default to sliding_window=0 → effective window = max_seq_len. Different head_dims
+    # in the same window are not representable by one C++ pool.
+    interface.add_resource("kv_0", KVPagedResourceHandler(8, 64, dtype=torch.float16))
+    interface.add_resource("kv_1", KVPagedResourceHandler(4, 128, dtype=torch.float16))
+
+    with pytest.raises(RuntimeError, match="head_dim"):
+        interface._identify_managed_kv_resources()
+
+
+def test_two_windows_create_unified_manager_with_two_pools():
+    """Gemma4-style two-window fixture creates a single KVCacheManager hosting both pools."""
+    interface = CachedSequenceInterface(
+        max_seq_len=128,
+        max_batch_size=4,
+        max_num_tokens=default_max_num_tokens(128, 4),
+        device="cuda",
+        kv_cache_config=KvCacheConfig(
+            tokens_per_block=32, max_tokens=1024, free_gpu_memory_fraction=0.0
+        ),
+    )
+    # SWA window: head_dim=64, sliding_window=64
+    interface.add_resource(
+        "kv_0", KVPagedResourceHandler(8, 64, dtype=torch.float16, sliding_window=64)
+    )
+    interface.add_resource(
+        "kv_1", KVPagedResourceHandler(8, 64, dtype=torch.float16, sliding_window=64)
+    )
+    # Full-attention window: head_dim=128
+    interface.add_resource("kv_2", KVPagedResourceHandler(4, 128, dtype=torch.float16))
+
+    interface.initialize_resources()
+    mgr = interface.kv_cache_manager
+
+    assert isinstance(mgr, KVCacheManager)
+    # The unified C++ manager exposes per-window head_dim/dtype maps via its impl.
+    assert dict(mgr.impl.size_per_head_per_window) == {64: 64, 128: 128}
+    assert set(mgr.impl.dtype_per_window.keys()) == {64, 128}
+
+
+def test_single_window_creates_plain_kv_cache_manager():
+    """One window creates a plain KVCacheManager with a single C++ pool."""
+    interface = CachedSequenceInterface(
+        max_seq_len=128,
+        max_batch_size=4,
+        max_num_tokens=default_max_num_tokens(128, 4),
+        device="cuda",
+        kv_cache_config=KvCacheConfig(
+            tokens_per_block=32, max_tokens=1024, free_gpu_memory_fraction=0.0
+        ),
+    )
+    interface.add_resource("kv_0", KVPagedResourceHandler(8, 64, dtype=torch.float16))
+    interface.add_resource("kv_1", KVPagedResourceHandler(8, 64, dtype=torch.float16))
+
+    interface.initialize_resources()
+
+    assert isinstance(interface.kv_cache_manager, KVCacheManager)
+    # Exactly one window key in the per-window map (max_seq_len, since sliding_window=0).
+    assert len(interface.kv_cache_manager.impl.size_per_head_per_window) == 1
+
+
+def test_dual_pool_cache_views_correct_shape():
+    """Mixed-head_dim VSWA: each layer's cache view uses its own head_dim/num_kv_heads."""
+    interface = CachedSequenceInterface(
+        max_seq_len=128,
+        max_batch_size=4,
+        max_num_tokens=default_max_num_tokens(128, 4),
+        device="cuda",
+        kv_cache_config=KvCacheConfig(
+            tokens_per_block=32, max_tokens=1024, free_gpu_memory_fraction=0.0
+        ),
+    )
+    # SWA layer with head_dim=64.
+    interface.add_resource(
+        "kv_0", KVPagedResourceHandler(8, 64, dtype=torch.float16, sliding_window=64)
+    )
+    # Full-attention layer with head_dim=128 (different window, so different head_dim is allowed).
+    interface.add_resource("kv_1", KVPagedResourceHandler(4, 128, dtype=torch.float16))
+
+    interface.initialize_resources()
+
+    # SWA layer (head_dim=64): cache view shape [..., 8, 32, 64]
+    kv_0 = interface._caches[list(interface._caches.keys())[0]]
+    assert kv_0.shape[-1] == 64
+    assert kv_0.shape[-3] == 8  # num_kv_heads
+
+    # Full-attn layer (head_dim=128): cache view shape [..., 4, 32, 128]
+    kv_1 = interface._caches[list(interface._caches.keys())[1]]
+    assert kv_1.shape[-1] == 128
+    assert kv_1.shape[-3] == 4  # num_kv_heads
+
+
+def test_unified_manager_lifecycle():
+    """One unified KVCacheManager handles lifecycle for all pools."""
+    interface = CachedSequenceInterface(
+        max_seq_len=128,
+        max_batch_size=4,
+        max_num_tokens=default_max_num_tokens(128, 4),
+        device="cuda",
+        kv_cache_config=KvCacheConfig(
+            tokens_per_block=32, max_tokens=1024, free_gpu_memory_fraction=0.0
+        ),
+    )
+    interface.add_resource(
+        "kv_0", KVPagedResourceHandler(8, 64, dtype=torch.float16, sliding_window=64)
+    )
+    interface.add_resource("kv_1", KVPagedResourceHandler(4, 128, dtype=torch.float16))
+
+    interface.initialize_resources()
+    mgr = interface.kv_cache_manager
+
+    assert isinstance(mgr, KVCacheManager)
+    # Single C++ impl backs every pool.
+    assert mgr.impl is not None
+    # Free-block accounting is a single number across all pools.
+    assert mgr.get_num_free_blocks() >= 0
+    # Lifecycle close is idempotent for the unified manager.
+    mgr.shutdown()
+
+
+def test_max_attention_window_from_handler_sliding_window():
+    """Handlers with sliding_window drive the per-window dispatch and pool grouping."""
+    interface = CachedSequenceInterface(
+        max_seq_len=256,
+        max_batch_size=4,
+        max_num_tokens=default_max_num_tokens(256, 4),
+        device="cuda",
+        kv_cache_config=KvCacheConfig(
+            tokens_per_block=32,
+            max_tokens=2048,
+            free_gpu_memory_fraction=0.0,
+        ),
+    )
+    # SWA window: head_dim=64, sliding_window=64
+    interface.add_resource(
+        "kv_0", KVPagedResourceHandler(8, 64, dtype=torch.float16, sliding_window=64)
+    )
+    interface.add_resource(
+        "kv_1", KVPagedResourceHandler(8, 64, dtype=torch.float16, sliding_window=64)
+    )
+    # Full-attention window: head_dim=128, no sliding_window → effective window = max_seq_len.
+    interface.add_resource("kv_2", KVPagedResourceHandler(4, 128, dtype=torch.float16))
+
+    interface.initialize_resources()
+    mgr = interface.kv_cache_manager
+
+    assert isinstance(mgr, KVCacheManager)
+    # Per-window head_dim map exposes the SWA window plus the full-attention (max_seq_len) window.
+    size_map = dict(mgr.impl.size_per_head_per_window)
+    assert size_map == {64: 64, 256: 128}
+    # The per-layer max_attention_window vector mirrors the effective windows in registration order.
+    assert mgr.max_attention_window_vec == [64, 64, 256]

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_kv_cache.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_kv_cache.py
@@ -819,3 +819,582 @@ def test_insert_cached_mla_attention_preserves_non_flashinfer_backend():
     backend = InsertCachedMLAAttention.resolve_backend_for_node("torch_mla", attn_node)
 
     assert backend == "torch_mla"
+
+
+# =============================================================================
+# Sliding Window KV Cache Integration Tests
+# =============================================================================
+
+
+class SlidingWindowGQA(GQAWithSdpaAndEmbedding):
+    """GQA model with a configurable per-layer sliding_window for testing."""
+
+    def __init__(
+        self,
+        num_attention_heads: int,
+        hidden_size: int,
+        num_key_value_heads: int,
+        vocab_size: int = 1000,
+        sliding_window: Optional[int] = None,
+    ):
+        super().__init__(num_attention_heads, hidden_size, num_key_value_heads, vocab_size)
+        self._sliding_window = sliding_window
+
+    @torch.no_grad()
+    def forward(
+        self, input_ids: torch.Tensor, position_ids: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        x = self.embed_tokens(input_ids)
+        b, s, _ = x.shape
+        q = self.q_proj(x).view(b, s, self.num_heads, self.head_dim)
+        k = self.k_proj(x).view(b, s, self.num_kv_heads, self.head_dim)
+        v = self.v_proj(x).view(b, s, self.num_kv_heads, self.head_dim)
+        attn_output = torch.ops.auto_deploy.torch_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            dropout_p=0.0,
+            is_causal=True,
+            scale=None,
+            sinks=None,
+            sliding_window=self._sliding_window,
+            logit_cap=None,
+            layout="bsnd",
+        )
+        return self.o_proj(attn_output.reshape(b, s, -1))
+
+
+class VSWAModel(nn.Module):
+    """Model with two attention layers: one sliding-window, one full-attention (VSWA)."""
+
+    def __init__(
+        self,
+        num_attention_heads: int,
+        hidden_size: int,
+        num_key_value_heads: int,
+        vocab_size: int = 1000,
+        sliding_window: int = 32,
+    ):
+        super().__init__()
+        self.num_heads = num_attention_heads
+        self.num_kv_heads = num_key_value_heads
+        self.head_dim = hidden_size // num_attention_heads
+        self.embed_tokens = nn.Embedding(vocab_size, hidden_size)
+        self.q_proj_0 = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.k_proj_0 = nn.Linear(hidden_size, num_key_value_heads * self.head_dim, bias=False)
+        self.v_proj_0 = nn.Linear(hidden_size, num_key_value_heads * self.head_dim, bias=False)
+        self.o_proj_0 = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.q_proj_1 = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.k_proj_1 = nn.Linear(hidden_size, num_key_value_heads * self.head_dim, bias=False)
+        self.v_proj_1 = nn.Linear(hidden_size, num_key_value_heads * self.head_dim, bias=False)
+        self.o_proj_1 = nn.Linear(hidden_size, hidden_size, bias=False)
+        self._sliding_window = sliding_window
+
+    @torch.no_grad()
+    def forward(
+        self, input_ids: torch.Tensor, position_ids: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        x = self.embed_tokens(input_ids)
+        b, s, _ = x.shape
+
+        # Layer 0: sliding window attention
+        q0 = self.q_proj_0(x).view(b, s, self.num_heads, self.head_dim)
+        k0 = self.k_proj_0(x).view(b, s, self.num_kv_heads, self.head_dim)
+        v0 = self.v_proj_0(x).view(b, s, self.num_kv_heads, self.head_dim)
+        a0 = torch.ops.auto_deploy.torch_attention(
+            q0,
+            k0,
+            v0,
+            attn_mask=None,
+            dropout_p=0.0,
+            is_causal=True,
+            scale=None,
+            sinks=None,
+            sliding_window=self._sliding_window,
+            logit_cap=None,
+            layout="bsnd",
+        )
+        x = x + self.o_proj_0(a0.reshape(b, s, -1))
+
+        # Layer 1: full attention (no sliding window)
+        q1 = self.q_proj_1(x).view(b, s, self.num_heads, self.head_dim)
+        k1 = self.k_proj_1(x).view(b, s, self.num_kv_heads, self.head_dim)
+        v1 = self.v_proj_1(x).view(b, s, self.num_kv_heads, self.head_dim)
+        a1 = torch.ops.auto_deploy.torch_attention(
+            q1,
+            k1,
+            v1,
+            attn_mask=None,
+            dropout_p=0.0,
+            is_causal=True,
+            scale=None,
+            sinks=None,
+            sliding_window=None,
+            logit_cap=None,
+            layout="bsnd",
+        )
+        return x + self.o_proj_1(a1.reshape(b, s, -1))
+
+
+def _build_optimizer_with_backend(model, backend="triton_paged"):
+    """Helper to create an InferenceOptimizer for testing."""
+    return InferenceOptimizer(
+        DummyFactory(model, cache_config_updates={}),
+        {
+            "build_model": {
+                "stage": "factory",
+                "run_per_gm": False,
+                "device": "cuda",
+                "run_graph_cleanup": False,
+                "requires_clean_graph": False,
+            },
+            "export_to_gm": {
+                "stage": "export",
+                "strict": False,
+                "run_per_gm": False,
+                "clone_state_dict": True,
+                "run_graph_cleanup": False,
+                "requires_clean_graph": False,
+            },
+            "cleanup_input_constraints": {
+                "stage": "post_export",
+            },
+            "insert_cached_attention": {
+                "stage": "cache_init",
+                "backend": backend,
+            },
+        },
+    )
+
+
+@torch.inference_mode()
+def test_insert_cached_attention_extracts_sliding_window():
+    """Verify insert_cached_attention sets max_attention_window from graph sliding_window."""
+    sliding_window = 32
+    max_seq_len = 128
+    batch_size = 4
+
+    kv_cache_config = KvCacheConfig(
+        tokens_per_block=max_seq_len,
+        max_tokens=batch_size * max_seq_len,
+        free_gpu_memory_fraction=0.0,
+    )
+    cm = CachedSequenceInterface(
+        max_seq_len=max_seq_len,
+        max_batch_size=batch_size,
+        max_num_tokens=default_max_num_tokens(max_seq_len, batch_size),
+        device="cuda",
+        kv_cache_config=kv_cache_config,
+    )
+
+    assert cm.kv_cache_config.max_attention_window is None
+
+    model = SlidingWindowGQA(
+        num_attention_heads=8,
+        hidden_size=512,
+        num_key_value_heads=8,
+        sliding_window=sliding_window,
+    ).to(dtype=torch.float16, device="cuda")
+
+    optimizer = _build_optimizer_with_backend(model)
+    optimizer(cm)
+
+    assert cm.kv_cache_config.max_attention_window is not None
+    assert cm.kv_cache_config.max_attention_window == [sliding_window]
+
+
+@torch.inference_mode()
+def test_insert_cached_attention_no_sliding_window_leaves_config_unchanged():
+    """Verify insert_cached_attention does not set max_attention_window for non-SWA models."""
+    max_seq_len = 128
+    batch_size = 4
+
+    kv_cache_config = KvCacheConfig(
+        tokens_per_block=max_seq_len,
+        max_tokens=batch_size * max_seq_len,
+        free_gpu_memory_fraction=0.0,
+    )
+    cm = CachedSequenceInterface(
+        max_seq_len=max_seq_len,
+        max_batch_size=batch_size,
+        max_num_tokens=default_max_num_tokens(max_seq_len, batch_size),
+        device="cuda",
+        kv_cache_config=kv_cache_config,
+    )
+
+    model = GQAWithSdpaAndEmbedding(
+        num_attention_heads=8,
+        hidden_size=512,
+        num_key_value_heads=8,
+    ).to(dtype=torch.float16, device="cuda")
+
+    optimizer = _build_optimizer_with_backend(model)
+    optimizer(cm)
+
+    assert cm.kv_cache_config.max_attention_window is None
+
+
+@torch.inference_mode()
+def test_insert_cached_attention_respects_user_override():
+    """Verify insert_cached_attention does not overwrite user-set max_attention_window."""
+    max_seq_len = 128
+    batch_size = 4
+    user_window = [64]
+
+    kv_cache_config = KvCacheConfig(
+        tokens_per_block=max_seq_len,
+        max_tokens=batch_size * max_seq_len,
+        free_gpu_memory_fraction=0.0,
+        max_attention_window=user_window,
+    )
+    cm = CachedSequenceInterface(
+        max_seq_len=max_seq_len,
+        max_batch_size=batch_size,
+        max_num_tokens=default_max_num_tokens(max_seq_len, batch_size),
+        device="cuda",
+        kv_cache_config=kv_cache_config,
+    )
+
+    model = SlidingWindowGQA(
+        num_attention_heads=8,
+        hidden_size=512,
+        num_key_value_heads=8,
+        sliding_window=32,
+    ).to(dtype=torch.float16, device="cuda")
+
+    optimizer = _build_optimizer_with_backend(model)
+    optimizer(cm)
+
+    # User-provided value must be preserved
+    assert cm.kv_cache_config.max_attention_window == user_window
+
+
+@torch.inference_mode()
+def test_insert_cached_attention_vswa_preserves_per_layer_windows():
+    """Verify VSWA model preserves per-layer window sizes for proportional allocation."""
+    sliding_window = 32
+    max_seq_len = 128
+    batch_size = 4
+
+    kv_cache_config = KvCacheConfig(
+        tokens_per_block=32,
+        max_tokens=batch_size * max_seq_len,
+        free_gpu_memory_fraction=0.0,
+    )
+    cm = CachedSequenceInterface(
+        max_seq_len=max_seq_len,
+        max_batch_size=batch_size,
+        max_num_tokens=default_max_num_tokens(max_seq_len, batch_size),
+        device="cuda",
+        kv_cache_config=kv_cache_config,
+    )
+
+    model = VSWAModel(
+        num_attention_heads=8,
+        hidden_size=512,
+        num_key_value_heads=8,
+        sliding_window=sliding_window,
+    ).to(dtype=torch.float16, device="cuda")
+
+    optimizer = _build_optimizer_with_backend(model)
+    optimizer(cm)
+
+    # VSWA preserves per-layer windows: [32, 128] (not collapsed)
+    assert cm.kv_cache_config.max_attention_window is not None
+    assert len(cm.kv_cache_config.max_attention_window) == 2
+    assert cm.kv_cache_config.max_attention_window == [sliding_window, max_seq_len]
+
+    # Window groups should be registered on SequenceInfo
+    assert cm.info.num_window_groups == 2
+    assert cm.info.window_groups == [sliding_window, max_seq_len]
+    assert cm.info.window_group_map == {sliding_window: 0, max_seq_len: 1}
+
+
+@torch.inference_mode()
+def test_kv_cache_manager_initialized_with_sliding_window():
+    """Verify KVCacheManager receives max_attention_window_vec from SWA model.
+
+    Runs the full insert_cached_attention + initialize_cache pipeline.
+    """
+    import math
+
+    sliding_window = 32
+    max_seq_len = 128
+    batch_size = 4
+    tokens_per_block = 16
+
+    kv_cache_config = KvCacheConfig(
+        tokens_per_block=tokens_per_block,
+        max_tokens=batch_size * max_seq_len,
+        free_gpu_memory_fraction=0.0,
+    )
+    cm = CachedSequenceInterface(
+        max_seq_len=max_seq_len,
+        max_batch_size=batch_size,
+        max_num_tokens=default_max_num_tokens(max_seq_len, batch_size),
+        device="cuda",
+        kv_cache_config=kv_cache_config,
+    )
+
+    model = SlidingWindowGQA(
+        num_attention_heads=8,
+        hidden_size=512,
+        num_key_value_heads=8,
+        sliding_window=sliding_window,
+    ).to(dtype=torch.float16, device="cuda")
+
+    # Run insert_cached_attention + initialize_cache
+    optimizer = InferenceOptimizer(
+        DummyFactory(model, cache_config_updates={}),
+        {
+            "build_model": {
+                "stage": "factory",
+                "run_per_gm": False,
+                "device": "cuda",
+                "run_graph_cleanup": False,
+                "requires_clean_graph": False,
+            },
+            "export_to_gm": {
+                "stage": "export",
+                "strict": False,
+                "run_per_gm": False,
+                "clone_state_dict": True,
+                "run_graph_cleanup": False,
+                "requires_clean_graph": False,
+            },
+            "cleanup_input_constraints": {
+                "stage": "post_export",
+            },
+            "insert_cached_attention": {
+                "stage": "cache_init",
+                "backend": "triton_paged",
+            },
+            "initialize_cache": {
+                "stage": "cache_init",
+                "run_per_gm": False,
+            },
+        },
+    )
+    optimizer(cm)
+
+    # KVCacheManager should exist and carry the window vector
+    mgr = cm.kv_cache_manager
+    assert mgr.max_attention_window_vec == [sliding_window]
+
+    # max_blocks_per_seq is based on max_seq_len (not window) because sequences
+    # temporarily need full blocks during prefill; SWA eviction frees them during decode.
+    expected_max_blocks = math.ceil(max_seq_len / tokens_per_block)
+    assert cm.info.max_blocks_per_seq == expected_max_blocks
+
+
+@torch.inference_mode()
+def test_kv_cache_manager_vswa_proportional_allocation():
+    """Verify VSWA models get proportional pool allocation in KVCacheManager.
+
+    KVCacheManager detects VSWA from the per-layer max_attention_window vector
+    and allocates separate block pools per window size.
+    """
+    import math
+
+    sliding_window = 32
+    max_seq_len = 128
+    batch_size = 4
+    tokens_per_block = 16
+
+    kv_cache_config = KvCacheConfig(
+        tokens_per_block=tokens_per_block,
+        max_tokens=batch_size * max_seq_len,
+        free_gpu_memory_fraction=0.0,
+    )
+    cm = CachedSequenceInterface(
+        max_seq_len=max_seq_len,
+        max_batch_size=batch_size,
+        max_num_tokens=default_max_num_tokens(max_seq_len, batch_size),
+        device="cuda",
+        kv_cache_config=kv_cache_config,
+    )
+
+    model = VSWAModel(
+        num_attention_heads=8,
+        hidden_size=512,
+        num_key_value_heads=8,
+        sliding_window=sliding_window,
+    ).to(dtype=torch.float16, device="cuda")
+
+    optimizer = InferenceOptimizer(
+        DummyFactory(model, cache_config_updates={}),
+        {
+            "build_model": {
+                "stage": "factory",
+                "run_per_gm": False,
+                "device": "cuda",
+                "run_graph_cleanup": False,
+                "requires_clean_graph": False,
+            },
+            "export_to_gm": {
+                "stage": "export",
+                "strict": False,
+                "run_per_gm": False,
+                "clone_state_dict": True,
+                "run_graph_cleanup": False,
+                "requires_clean_graph": False,
+            },
+            "cleanup_input_constraints": {
+                "stage": "post_export",
+            },
+            "insert_cached_attention": {
+                "stage": "cache_init",
+                "backend": "triton_paged",
+            },
+            "initialize_cache": {
+                "stage": "cache_init",
+                "run_per_gm": False,
+            },
+        },
+    )
+    optimizer(cm)
+
+    # KVCacheManager should detect VSWA with per-layer windows.  A single C++
+    # KVCacheManager now hosts both pools via the per-window head_dim/dtype
+    # overrides — there is no MultiPoolKVCacheManager wrapper anymore.
+    mgr = cm.kv_cache_manager
+    from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
+
+    assert isinstance(mgr, KVCacheManager)
+    # The unified manager exposes one pool per effective window via the C++ impl.
+    assert len(mgr.impl.size_per_head_per_window) == 2
+
+    # max_blocks_per_seq reflects the larger window (full-attention layer)
+    expected_max_blocks = math.ceil(max_seq_len / tokens_per_block)
+    assert cm.info.max_blocks_per_seq == expected_max_blocks
+
+    # Per-group cache tensors should be registered on SequenceInfo
+    assert cm.info.num_window_groups == 2
+    assert "cache_loc_g1" in cm.info.available_args
+    assert "cu_num_pages_g1" in cm.info.available_args
+
+
+# =============================================================================
+# VSWA SequenceInfo and Graph Wiring Tests
+# =============================================================================
+
+
+@torch.inference_mode()
+def test_sequence_info_register_window_groups():
+    """Verify register_window_groups creates per-group tensors in InputBuffer."""
+    from tensorrt_llm._torch.auto_deploy.custom_ops.attention_interface import SequenceInfo
+
+    max_seq_len = 128
+    batch_size = 4
+    tokens_per_block = 16
+
+    seq_info = SequenceInfo(
+        max_seq_len=max_seq_len,
+        max_batch_size=batch_size,
+        tokens_per_block=tokens_per_block,
+    )
+
+    # Before registration: no window groups
+    assert seq_info.num_window_groups == 0
+    assert seq_info.window_groups == []
+
+    # Register two groups: [32, 128]
+    seq_info.register_window_groups([32, 128])
+
+    assert seq_info.num_window_groups == 2
+    assert seq_info.window_groups == [32, 128]
+    assert seq_info.window_group_map == {32: 0, 128: 1}
+
+    # Group 0 reuses existing tensors (cache_loc, cu_num_pages, etc.)
+    # Group 1 gets new tensors
+    assert "cache_loc_g1" in seq_info.available_args
+    assert "cu_num_pages_g1" in seq_info.available_args
+    assert "cu_num_pages_g1_host" in seq_info.available_args
+    assert "last_page_len_g1" in seq_info.available_args
+    assert "last_page_len_g1_host" in seq_info.available_args
+    assert "extra_page_per_seq_g1" in seq_info.available_args
+
+    # Group 0 names should NOT appear with _g0 suffix
+    assert "cache_loc_g0" not in seq_info.available_args
+
+
+@torch.inference_mode()
+def test_vswa_graph_has_per_group_placeholders():
+    """Verify VSWA model graph contains per-group cache_loc/cu_num_pages placeholders."""
+    sliding_window = 32
+    max_seq_len = 128
+    batch_size = 4
+
+    kv_cache_config = KvCacheConfig(
+        tokens_per_block=32,
+        max_tokens=batch_size * max_seq_len,
+        free_gpu_memory_fraction=0.0,
+    )
+    cm = CachedSequenceInterface(
+        max_seq_len=max_seq_len,
+        max_batch_size=batch_size,
+        max_num_tokens=default_max_num_tokens(max_seq_len, batch_size),
+        device="cuda",
+        kv_cache_config=kv_cache_config,
+    )
+
+    model = VSWAModel(
+        num_attention_heads=8,
+        hidden_size=512,
+        num_key_value_heads=8,
+        sliding_window=sliding_window,
+    ).to(dtype=torch.float16, device="cuda")
+
+    optimizer = _build_optimizer_with_backend(model)
+    gm = optimizer(cm)
+
+    # Check that per-group graph placeholders exist
+    placeholder_names = [n.target for n in gm.graph.nodes if n.op == "placeholder"]
+    assert "cache_loc" in placeholder_names
+    assert "cu_num_pages" in placeholder_names
+    # Group 1 should have its own placeholders
+    assert "cache_loc_g1" in placeholder_names
+    assert "cu_num_pages_g1" in placeholder_names
+
+
+# =============================================================================
+# Phase 3: sink_token_length wiring through get_constants
+# =============================================================================
+
+
+def test_trtllm_get_constants_does_not_include_sink_token_length():
+    """Verify TrtllmAttention.get_constants returns node-level constants only.
+
+    sink_token_length is a runtime config (KvCacheConfig), not a model parameter.
+    It is appended by the kvcache transform at insertion time, not by get_constants.
+    """
+    from tensorrt_llm._torch.auto_deploy.custom_ops.attention.trtllm_attention import (
+        TrtllmAttention,
+    )
+    from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+    from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
+
+    model = (
+        SlidingWindowGQA(
+            num_attention_heads=8,
+            hidden_size=512,
+            num_key_value_heads=8,
+            sliding_window=32,
+        )
+        .eval()
+        .to(dtype=torch.float16, device="cpu")
+    )
+
+    input_ids = torch.randint(0, 1000, (1, 4))
+    gm = torch_export_to_gm(model, (input_ids,))
+
+    source_op = TrtllmAttention.get_source_attention_op()
+    source_nodes = [n for n in gm.graph.nodes if is_op(n, source_op)]
+    assert len(source_nodes) == 1
+
+    constants = TrtllmAttention.get_constants(source_nodes[0])
+    # Last constant is None (out placeholder); sink_token_length is NOT here
+    # (it's appended at the transform site from KvCacheConfig, not by get_constants)
+    assert constants[-1] is None
+    assert len(constants) == 6  # scale, sw, kv_so, kv_qs, out_scale, out


### PR DESCRIPTION
## Summary

Phase 2 of the Gemma-4 enablement (#13745 was Phase 1).  Under SWA
front-eviction the live window's cache length diverges from the global
`input_pos + seq_len`, so the kernel, the prepare-extra-metadata op, and the
per-group host prepare all need a window-capped `seq_len_with_cache`.  The
shim hands the kernel a window-coherent local-coord view per group;
kernel masks stay in local coordinates and need no changes.

End-to-end this unblocks long-context Gemma-4 (prompts > W=1024) where
front-eviction actually fires.  Pre-Phase-2, SWA layers silently read
stale page entries and the write-position for new tokens overshoots the
live page list, so accuracy collapses on long prompts while short-prompt
benchmarks (MMMU / MMLU / GSM8K) stay healthy.

## Source changes

- `custom_ops/attention_interface.py`: allocate per-group
  `seq_len_with_cache_g{i}`; extend `nest_sequences` with
  `seq_len_with_cache_per_group` / `last_page_len_per_group`; keep
  per-group `seq_len_with_cache` in sync inside `offset_pos_and_cache_`.
- `shim/ad_executor.py`: per `(request, window)`, query
  `get_num_front_blocks_removed`, slice `cache_loc` as
  `all_indices[front_removed : front_removed + num_active]`, compute
  window-capped per-group `seq_len_with_cache` and `last_page_len`.
  Math extracted into `_compute_window_local_view` for testability.
- `transform/library/kvcache.py`: add `"seq_len_with_cache"` to
  `vswa_swappable_bases`; build per-group `meta_nodes_extra_by_group` by
  re-invoking the backend's prepare-extra op once per non-zero group
  (generic over `vswa_swappable_bases`, not hardcoded names) so backends
  whose extra-op consumes swappable names (e.g. Triton, TrtllmAttention)
  no longer silently route every non-zero-group layer through group-0
  inputs.

No kernel changes — both `_paged_context_kernel` and
`_flash_decode_stage1_kernel` are already shift-invariant in local
coordinates.

## Test coverage

| Layer | File | What it guards |
|---|---|---|
| Transform graph shape | `tests/unittest/_torch/auto_deploy/unit/singlegpu/transformations/library/test_kvcache_vswa_metadata.py` | Per-group `seq_len_with_cache_g{i}_host` placeholders exist; the prepare-extra op is invoked once per group; each cached-attention call's `meta_nodes_extra` slot resolves to its own group's input. Fails on the pre-fix transform. CPU-only. |
| Triton kernel | `tests/unittest/auto_deploy/singlegpu/custom_ops/attention/test_triton_paged_attention_swa.py` | (a) Long-prefill SWA: prefill_len ∈ {1, 2, 4}×W, exercising both Phase-1 full-page and Phase-2 boundary-page masking; (b) Front-eviction: parametrized over `front_removed ∈ {0, 1, 4}`, `chunk ∈ {1, 64, 128}`, `page_size ∈ {16, 64}`, with/without sliding window. SDPA reference on the live window. |
| Shim integration | `tests/unittest/auto_deploy/singlegpu/shim/test_ad_executor_swa_eviction.py` | Real two-window `CachedSequenceInterface` + `KVCacheManager`; monkeypatches `get_num_front_blocks_removed` (real eviction can't be fired from Python without a model). Asserts: live-slice correctness, window-capped `seq_len_with_cache`, consistent `last_page_len`, page-table capacity invariant, spillover slot lives AFTER the live window. |
| End-to-end accuracy | `tests/integration/defs/accuracy/test_llm_api_autodeploy.py::TestGemma4MoE::test_bf16_long_context` | `PassKeyRetrieval64k` (64k prompts) on Gemma-4-26B-A4B-it — forces heavy SWA front-eviction while keeping the passkey reachable through full-attention layers. Reference accuracy registered in `passkey_retrieval_64k.yaml` (placeholder = 99, to be replaced with the measured value after the first CI run). |

## Known coverage gaps (no fast unit regression guard yet)

The following are transitively covered by the E2E test but lack
dedicated unit-level tests; flagged here so a follow-up can fill them
when convenient:

1. `nest_sequences` argument handling for `seq_len_with_cache_per_group`
   / `last_page_len_per_group` (override vs. default-replicate vs.
   partial-map guard).
2. `offset_pos_and_cache_` per-group `seq_len_with_cache` sync on the
   overlap-scheduler path.
3. Full `_prepare_inputs` shim flow integration (currently only the
   extracted helper is unit-tested; the surrounding `nest_sequences`
   plumbing is only exercised E2E).

## Out of scope (separately backlogged)

- `ad_executor.py`'s non-VSWA single-window branch still uses
  `cache_indices[:num_active_blocks_i]` without an eviction-aware
  slice.  Latent bug only if a single-window SWA model is wired up
  through AutoDeploy in the future; not Gemma-4-blocking.  Tracked in
  the project backlog.

## CI

Suggested run:

```
/bot run --extra-stage "DGX_H100-1_GPUs-AutoDeploy-1, DGX_B200-4_GPUs-AutoDeploy-1"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Variable Sliding Window Attention (VSWA) enabling different attention window sizes across model layers with independent memory optimization per window.
  * Introduced per-window KV cache configuration supporting heterogeneous head dimensions and data types for improved memory efficiency.
  * Extended long-context inference capabilities with 64k token passkey retrieval support for advanced models.

* **Tests**
  * Comprehensive test coverage for sliding window attention correctness and front-eviction behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14121)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->