### PR TITLE
[None][chore] Remove trailing spaces from module name in logger output

### DIFF
--- a/cpp/include/tensorrt_llm/common/logger.h
+++ b/cpp/include/tensorrt_llm/common/logger.h
@@ -34,7 +34,7 @@ namespace common
 
 /// Map a raw module directory name to a short display abbreviation.
 /// Every known module gets an explicit entry; unknown modules fall through as-is.
-/// Display padding to 8 characters is handled by getPrefix() via printf %-8s formatting.
+/// getPrefix() prints the module name with no padding.
 constexpr std::string_view formatModule(std::string_view module)
 {
     // Source modules (cpp/tensorrt_llm/*)
@@ -117,7 +117,7 @@ public:
                 return formatModule(path.substr(moduleStart, slashPos - moduleStart));
             }
         }
-        return "  others";
+        return "others";
     }
 
     Logger(Logger const&) = delete;
@@ -296,17 +296,17 @@ private:
     {
         if (rank_ >= 0)
         {
-            return tensorrt_llm::common::fmtstr("%s [%s] [%-8.*s] [RANK %d] ", kPREFIX, getLevelName(level),
+            return tensorrt_llm::common::fmtstr("%s [%s] [%.*s][RANK %d] ", kPREFIX, getLevelName(level),
                 static_cast<int>(module.size()), module.data(), rank_);
         }
         return tensorrt_llm::common::fmtstr(
-            "%s [%s] [%-8.*s] ", kPREFIX, getLevelName(level), static_cast<int>(module.size()), module.data());
+            "%s [%s] [%.*s] ", kPREFIX, getLevelName(level), static_cast<int>(module.size()), module.data());
     }
 
     // With module, explicit rank
     static inline std::string getPrefix(Level const level, std::string_view module, int const rank)
     {
-        return tensorrt_llm::common::fmtstr("%s [%s] [%-8.*s] [RANK %d] ", kPREFIX, getLevelName(level),
+        return tensorrt_llm::common::fmtstr("%s [%s] [%.*s][RANK %d] ", kPREFIX, getLevelName(level),
             static_cast<int>(module.size()), module.data(), rank);
     }
 };

--- a/cpp/tests/unit_tests/common/loggerTest.cpp
+++ b/cpp/tests/unit_tests/common/loggerTest.cpp
@@ -40,7 +40,7 @@ TEST(LoggerModuleTest, ExtractModuleMatchesEnvKey)
     EXPECT_EQ(Logger::extractModule("/code/tensorrt_llm/batch_manager/s.cpp"), "batchmgr");
     EXPECT_EQ(Logger::extractModule("/code/tensorrt_llm/common/logger.h"), "common");
     EXPECT_EQ(Logger::extractModule("/code/tensorrt_llm/thop/alloc.cpp"), "thop");
-    EXPECT_EQ(Logger::extractModule("/random/path/foo.cpp"), "  others");
+    EXPECT_EQ(Logger::extractModule("/random/path/foo.cpp"), "others");
 }
 
 TEST(LoggerModuleTest, PerModuleFilterGainControl)

--- a/tensorrt_llm/logger.py
+++ b/tensorrt_llm/logger.py
@@ -83,13 +83,13 @@ _MODULE_ABBREVIATIONS = {
 
 
 def _format_module(name: str) -> str:
-    """Return a fixed-width display string for *name* (``_MODULE_WIDTH`` chars).
+    """Return a display string for *name*.
 
-    Long names are abbreviated via ``_MODULE_ABBREVIATIONS``;
-    short names are right-padded with spaces.
+    Long names are abbreviated via ``_MODULE_ABBREVIATIONS``; no padding is
+    applied, so short names print at their natural width.
     """
     display = _MODULE_ABBREVIATIONS.get(name, name)
-    return display[:_MODULE_WIDTH].ljust(_MODULE_WIDTH)
+    return display[:_MODULE_WIDTH]
 
 
 # Cache: filename -> module name (avoids repeated frame inspection).
@@ -278,10 +278,13 @@ class Logger(metaclass=Singleton):
             return
         parts = [f"[{self.PREFIX}]"]
         parts.append(severity)
+        module_rank = ""
         if module:
-            parts.append(f"[{_format_module(module)}]")
+            module_rank += f"[{_format_module(module)}]"
         if self.rank is not None:
-            parts.append(f"[RANK {self.rank}]")
+            module_rank += f"[RANK {self.rank}]"
+        if module_rank:
+            parts.append(module_rank)
         parts.extend(map(str, msg))
         self._func_wrapper(severity)(" ".join(parts))
 

--- a/tests/unittest/utils/test_logger.py
+++ b/tests/unittest/utils/test_logger.py
@@ -71,10 +71,10 @@ class TestExtractModule:
 class TestFormatModule:
     """Tests for _format_module which produces fixed-width display names."""
 
-    def test_short_name_padded(self):
+    def test_short_name(self):
         result = _format_module("serve")
-        assert len(result) == 8
-        assert result == "serve   "
+        assert len(result) == 5
+        assert result == "serve"
 
     def test_exact_8_char(self):
         result = _format_module("executor")
@@ -191,7 +191,7 @@ class TestLoggerOutput:
         exec(code, fake_globals)
 
         output = capture_log.getvalue()
-        assert "[serve   ]" in output
+        assert "[serve]" in output
         assert "from serve" in output
 
 


### PR DESCRIPTION
The output log now displays  as below

```
[05/14/2026-07:06:30] [TRT-LLM] [I] [llmapi] Using LLM with PyTorch backend
[05/14/2026-07:06:30] [TRT-LLM] [W] [llmapi] Using default gpus_per_node: 4
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined logging output formatting to eliminate fixed-width padding from module name prefixes. Log messages now display module names more compactly without alignment padding, resulting in cleaner, more concise log output across logging systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14122)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->