### PR TITLE
[TRTLLM-12478][fix] Synchronize prepare inputs H2D copy

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -561,6 +561,8 @@ class PyTorchModelEngine(ModelEngine):
 
         self.kv_cache_dtype_byte_size = self.get_kv_cache_dtype_byte_size()
 
+        self._prepare_inputs_event: Optional[torch.cuda.Event] = None
+
     def register_forward_pass_callable(self, callable: Callable):
         self.forward_pass_callable = callable
 
@@ -3998,11 +4000,16 @@ class PyTorchModelEngine(ModelEngine):
                     spec_tree_manager._all_slot_ids_buf[idx] = slot
                     idx += 1
 
+            if self._prepare_inputs_event is not None:
+                # Wait for H2D copy in last iteration, otherwise _prepare_inputs will modify host input and break last iteration's input
+                self._prepare_inputs_event.synchronize()
             inputs, gather_ids = self._prepare_inputs(
                 padded_requests, kv_cache_manager, attn_metadata, spec_metadata,
                 new_tensors_device, cache_indirection_buffer,
                 num_accepted_tokens_device, req_id_to_old_request,
                 resource_manager, can_run_graph)
+            self._prepare_inputs_event = torch.cuda.Event()
+            self._prepare_inputs_event.record()
 
             with with_shared_pool(self.cuda_graph_runner.get_graph_pool()):
                 if not can_run_graph:

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -4000,9 +4000,6 @@ class PyTorchModelEngine(ModelEngine):
                     spec_tree_manager._all_slot_ids_buf[idx] = slot
                     idx += 1
 
-            if self._prepare_inputs_event is not None:
-                # Wait for H2D copy in last iteration, otherwise _prepare_inputs will modify host input and break last iteration's input
-                self._prepare_inputs_event.synchronize()
             inputs, gather_ids = self._prepare_inputs(
                 padded_requests, kv_cache_manager, attn_metadata, spec_metadata,
                 new_tensors_device, cache_indirection_buffer,
@@ -4259,3 +4256,11 @@ class PyTorchModelEngine(ModelEngine):
                 lp(request.py_request_id, logits_row, token_ids, None, None)
 
             logits_tensor[idx] = logits_row.view(-1)
+
+    def wait_for_input_copy(self):
+        """
+        Wait for input preparation and H2D copy of previous iteration before modifying host input,
+        otherwise the input of previous iteration will be overwritten.
+        """
+        if self._prepare_inputs_event is not None:
+            self._prepare_inputs_event.synchronize()

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2718,6 +2718,10 @@ class PyExecutor:
 
                 self._handle_disagg_cache_errors_synced()
 
+                # Need to wait for the copy of previous iteration before modifying any host memory copied to GPU,
+                # and for scheduler V2, it will modify the host page table, so wait before scheduling.
+                # This wait is also needed for legacy scheduler, but it can be pushed later, e.g. before model_engine._prepare_inputs().
+                self.model_engine.wait_for_input_copy()
                 scheduled_batch, iter_stats = self._prepare_and_schedule_batch()
                 self._handle_control_request()
 


### PR DESCRIPTION
@coderabbitai summary

## Description

Synchronize the previous iteration's `_prepare_inputs` H2D copy before preparing inputs for the next forward iteration. This prevents host-side input buffers from being mutated while the previous iteration may still consume the copied data through CUDA graph execution in the overlap scheduler path.

## Test Coverage

- Pre-commit hooks passed during `git commit -s`.
- Ran `/home/scratch.jiaganc_gpu/workspace/trtllm/dsv4/dep_perf_flash.sh` with and without the patch on `gb-nvl-082-compute06`; both runs completed successfully and the single-run comparison did not show a throughput regression.
- Ran `/home/scratch.jiaganc_gpu/workspace/trtllm/dsv4/dep_perf_flash.sh` with Nsight Systems capture enabled; generated `/home/scratch.jiaganc_gpu/workspace/trtllm/dsv4/perf/dep_perf_flash_1024_1024_1024_DEP4_512_65536_MTP3_05140748.nsys-rep`.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
