### PR TITLE
[TRTLLM-9905][infra] Upload results periodically

### DIFF
--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2444,7 +2444,13 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                 // wrote the file avoids this cross-client visibility window entirely.
                 // After the mtime check confirms a change, sshRefreshCacheCmd primes
                 // the login node's NFS cache before the SCP step reads the file.
-                def sshStatCmd = Utils.sshUserCmd(remote, "\"srun --overlap --quiet --jobid='${slurmJobId}' --ntasks=1 stat -c %Y '${remoteWorkspaceTrk}/results.xml' || echo 0\"")
+                // Some clusters' srun cli_filter plugin rejects any job step that
+                // doesn't carry -A <account> (e.g. "You must specify an account"),
+                // so this overlap step needs the same account the sbatch submission
+                // used, pulled out of partition.additionalArgs.
+                def slurmAccountMatch = (partition.additionalArgs =~ /(?:^|\s)-A\s+(\S+)/)
+                def srunAccountArg = slurmAccountMatch.find() ? "-A ${slurmAccountMatch.group(1)} " : ""
+                def sshStatCmd = Utils.sshUserCmd(remote, "\"srun --overlap ${srunAccountArg}--quiet --jobid='${slurmJobId}' --ntasks=1 stat -c %Y '${remoteWorkspaceTrk}/results.xml' || echo 0\"")
                 def scpXmlCmd = scpFromRemoteCmd(remote, "${remoteWorkspaceTrk}/results*.xml", "${stageName}/")
                 def scpUnfinishedCmd = scpFromRemoteCmd(remote, "${remoteWorkspaceTrk}/unfinished_test.txt", "${stageName}/")
                 def sshRefreshCacheCmd = Utils.sshUserCmd(remote, "\"ls '${remoteWorkspaceTrk}/' > /dev/null 2>&1; ls -la '${remoteWorkspaceTrk}/results.xml' > /dev/null 2>&1 || true\"")

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1472,12 +1472,6 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
     // a retryable infra failure (a retry follows) -- otherwise a stage that fails
     // an intermediate attempt and passes on retry leaves the build UNSTABLE.
     def caughtStageError = null
-    // Tracks whether the Run Pytest stage's track step returned without
-    // throwing. Only on `true` do we sweep this stage's progress tar from
-    // Artifactory in the finally block (forensic tars from failed runs are
-    // kept). Set after the `node(...)` block; defaults to false so any
-    // earlier-thrown exception leaves the progress tar untouched.
-    def pytestSucceeded = false
 
     try {
         // Run ssh command to start node in desired cluster via SLURM
@@ -2197,8 +2191,6 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
             echo "Finished test stage execution."
             }  // end CloudManager.withSlurmFrontendFailover
         }  // end withCredentials
-        // Reached only if no stage above (Initialize Test, Run Pytest) threw.
-        pytestSucceeded = true
     } catch (InterruptedException e) {
         stageIsInterrupted = true
         throw e
@@ -2892,7 +2884,6 @@ def cacheErrorAndUploadResult(stageName, taskRunner, finallyRunner, noResultIfSu
                     sh "echo '${stageXml}' > ${stageName}/results-stage.xml"
                 }
             }
-            sh "STAGE_NAME=${stageName}"
             sh "STAGE_NAME=${stageName} && env | sort > ${stageName}/debug_env.txt"
             echo "Upload test results."
             sh "tar -czvf results-${stageName}${postTag}.tar.gz ${stageName}/"

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -4012,8 +4012,8 @@ def periodicUploadProgress(stageName, sentinelPath, intervalSec = PROGRESS_UPLOA
                 echo "[PROGRESS-UPLOAD] ${stageName}: uploaded checkpoint (mtime=${mtime})"
             } catch (InterruptedException ie) {
                 throw ie
-            } catch (Exception ue) {
-                echo "[PROGRESS-UPLOAD] ${stageName}: upload iteration failed (non-fatal): ${ue.message}"
+            } catch (Exception ex) {
+                echo "[PROGRESS-UPLOAD] ${stageName}: upload iteration failed (non-fatal): ${ex.message}"
             }
         }
         echo "[PROGRESS-UPLOAD] ${stageName}: pytest done, watcher exiting"
@@ -4075,8 +4075,8 @@ def periodicUploadProgressSlurm(pipeline, Map remote, String jobUID, String stag
                 echo "[PROGRESS-UPLOAD] ${stageName}: uploaded sbatch checkpoint (mtime=${mtime})"
             } catch (InterruptedException ie) {
                 throw ie
-            } catch (Exception ue) {
-                echo "[PROGRESS-UPLOAD] ${stageName}: upload iteration failed (non-fatal): ${ue.message}"
+            } catch (Exception ex) {
+                echo "[PROGRESS-UPLOAD] ${stageName}: upload iteration failed (non-fatal): ${ex.message}"
             }
         }
         echo "[PROGRESS-UPLOAD] ${stageName}: track done, watcher exiting"

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -4020,20 +4020,17 @@ REUSED_TESTS_EOF
 // Build-scoped: ${UPLOAD_PATH} is per-build, so unswept progress tars are
 // garbage-collected with the rest of the build's artifacts anyway.
 def deleteProgressArtifact(stageName) {
-    def target = "${UPLOAD_PATH}/test-results-progress/results-${stageName}-progress.tar.gz"
+    def targetUrl = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/test-results-progress/results-${stageName}-progress.tar.gz"
     try {
-        rtServer(
-            id: 'Artifactory',
-            url: 'https://urm.nvidia.com/artifactory',
-            credentialsId: 'urm-artifactory-creds',
-            bypassProxy: true,
-            timeout: 300,
-        )
-        rtDelete(
-            serverId: 'Artifactory',
-            spec: """{ "files": [ { "pattern": "${target}" } ] }""",
-        )
-        echo "[PROGRESS-UPLOAD] ${stageName}: deleted progress tar ${target}"
+        withCredentials([usernamePassword(
+                credentialsId: 'urm-artifactory-creds',
+                usernameVariable: 'ART_USER',
+                passwordVariable: 'ART_PASS')]) {
+            sh """
+                curl -fsSL --retry 2 -X DELETE -u "\$ART_USER:\$ART_PASS" '${targetUrl}'
+            """
+        }
+        echo "[PROGRESS-UPLOAD] ${stageName}: deleted progress tar ${targetUrl}"
     } catch (InterruptedException e) {
         throw e
     } catch (Exception e) {

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2051,12 +2051,14 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                 def progressUrl = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/test-results/${progressTar}"
                 def remoteWorkspaceTrk = "/home/svc_tensorrt/bloom/scripts/${jobUID}"
                 def trackCmd = Utils.sshUserCmd(remote, scriptTrackPathNode)
-                // ls flushes the NFS attribute cache on the login node so the
-                // subsequent stat returns the mtime written by the compute node.
-                def sshStatCmd = Utils.sshUserCmd(remote, "\"ls '${remoteWorkspaceTrk}/' > /dev/null 2>&1; stat -c %Y '${remoteWorkspaceTrk}/results.xml' 2>/dev/null || echo 0\"")
+                // ls -la on the specific file forces LOOKUP+GETATTR on the NFS server,
+                // bypassing any stale per-file attribute cache on the login node.
+                // This is more reliable than ls on the directory (READDIR/READDIRPLUS),
+                // which is affected by the rdirplus/nordirplus mount option.
+                def sshStatCmd = Utils.sshUserCmd(remote, "\"ls -la '${remoteWorkspaceTrk}/results.xml' > /dev/null 2>&1; stat -c %Y '${remoteWorkspaceTrk}/results.xml' 2>/dev/null || echo 0\"")
                 def scpXmlCmd = scpFromRemoteCmd(remote, "${remoteWorkspaceTrk}/results*.xml", "${stageName}/")
                 def scpUnfinishedCmd = scpFromRemoteCmd(remote, "${remoteWorkspaceTrk}/unfinished_test.txt", "${stageName}/")
-                def sshRefreshCacheCmd = Utils.sshUserCmd(remote, "\"ls '${remoteWorkspaceTrk}/' > /dev/null 2>&1 || true\"")
+                def sshRefreshCacheCmd = Utils.sshUserCmd(remote, "\"ls -la '${remoteWorkspaceTrk}/results.xml' > /dev/null 2>&1 || true\"")
                 def sshListPerfCmd = Utils.sshUserCmd(remote, "\"find '${remoteWorkspaceTrk}' -maxdepth 1 -type d \\( -name 'aggr*' -o -name 'disagg*' \\) -print 2>/dev/null || true\"")
                 def scpPerfTemplate = scpFromRemoteCmd(remote, "PERF_FOLDER_PLACEHOLDER", "${stageName}/")
                 sh "rm -f ${pytestDoneFile}"

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2100,6 +2100,9 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                         passwordVariable: 'ART_PASS')]) {
                     sh """
                         set +e
+                        export STAGE_NAME='${stageName}'
+                        export PROGRESS_TAR='${progressTar}'
+                        export PROGRESS_URL='${progressUrl}'
                         # ---- background watcher: SSH-stat remote XML, SCP, tar, upload ----
                         (
                             last=0
@@ -2115,13 +2118,8 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                                     echo "[PROGRESS-UPLOAD] ${stageName}: scp failed; skipping this iteration"
                                     continue
                                 fi
-                                ( cd '${WORKSPACE}' && tar -czf '${progressTar}' '${stageName}/' ) || continue
-                                if curl -fsSL --retry 2 -u "\$ART_USER:\$ART_PASS" \\
-                                        -T '${WORKSPACE}/${progressTar}' '${progressUrl}'; then
-                                    echo "[PROGRESS-UPLOAD] ${stageName}: uploaded sbatch checkpoint (mtime=\$m)"
-                                else
-                                    echo "[PROGRESS-UPLOAD] ${stageName}: upload iteration failed (non-fatal)"
-                                fi
+                                LABEL="sbatch checkpoint (mtime=\$m)" \\
+                                bash '${WORKSPACE}/jenkins/scripts/progress_upload_snapshot.sh' || continue
                             done
                             echo "[PROGRESS-UPLOAD] ${stageName}: track done, watcher exiting"
                         ) &
@@ -2143,11 +2141,8 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
 
                         # ---- immediate final snapshot ----
                         if [ -f '${WORKSPACE}/${stageName}/results.xml' ]; then
-                            ( cd '${WORKSPACE}' && tar -czf '${progressTar}' '${stageName}/' ) && \
-                            curl -fsSL --retry 2 -u "\$ART_USER:\$ART_PASS" \
-                                -T '${WORKSPACE}/${progressTar}' '${progressUrl}' && \
-                            echo "[PROGRESS-UPLOAD] ${stageName}: uploaded sbatch final snapshot" || \
-                            echo "[PROGRESS-UPLOAD] ${stageName}: sbatch final snapshot upload failed (non-fatal)"
+                            LABEL='sbatch final snapshot' \\
+                            bash '${WORKSPACE}/jenkins/scripts/progress_upload_snapshot.sh' || true
                         fi
 
                         exit \$rc
@@ -3730,18 +3725,16 @@ def rerunFailedTests(stageName, llmSrc, testCmdLine, resultFileName="results.xml
                     passwordVariable: 'ART_PASS')]) {
                 sh """
                     set +e
+                    export STAGE_NAME='${stageName}'
+                    export PROGRESS_TAR='${rerunProgressTar}'
+                    export PROGRESS_URL='${rerunProgressUrl}'
                     # ---- background watcher for rerun${times} ----
                     (
                         while [ ! -f '${rerunDoneFile}' ]; do
                             sleep ${PROGRESS_UPLOAD_INTERVAL_SEC}
                             [ -f '${rerunDoneFile}' ] && break
-                            ( cd '${WORKSPACE}' && tar -czf '${rerunProgressTar}' '${stageName}/' ) || continue
-                            if curl -fsSL --retry 2 -u "\$ART_USER:\$ART_PASS" \\
-                                    -T '${WORKSPACE}/${rerunProgressTar}' '${rerunProgressUrl}'; then
-                                echo "[PROGRESS-UPLOAD] ${stageName}: rerun${times} checkpoint uploaded"
-                            else
-                                echo "[PROGRESS-UPLOAD] ${stageName}: rerun${times} checkpoint upload failed (non-fatal)"
-                            fi
+                            LABEL='rerun${times} checkpoint' \\
+                            bash '${WORKSPACE}/jenkins/scripts/progress_upload_snapshot.sh' || continue
                         done
                         echo "[PROGRESS-UPLOAD] ${stageName}: rerun${times} watcher exiting"
                     ) &
@@ -3756,11 +3749,8 @@ def rerunFailedTests(stageName, llmSrc, testCmdLine, resultFileName="results.xml
                     wait \$WATCHER_PID 2>/dev/null || true
 
                     # ---- immediate final snapshot of rerun${times} ----
-                    ( cd '${WORKSPACE}' && tar -czf '${rerunProgressTar}' '${stageName}/' ) && \\
-                    curl -fsSL --retry 2 -u "\$ART_USER:\$ART_PASS" \\
-                        -T '${WORKSPACE}/${rerunProgressTar}' '${rerunProgressUrl}' && \\
-                    echo "[PROGRESS-UPLOAD] ${stageName}: rerun${times} final snapshot uploaded" || \\
-                    echo "[PROGRESS-UPLOAD] ${stageName}: rerun${times} final snapshot upload failed (non-fatal)"
+                    LABEL='rerun${times} final snapshot' \\
+                    bash '${WORKSPACE}/jenkins/scripts/progress_upload_snapshot.sh' || true
 
                     exit \$rc
                 """
@@ -4455,6 +4445,9 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
                                 passwordVariable: 'ART_PASS')]) {
                             sh """
                                 set +e
+                                export STAGE_NAME='${stageName}'
+                                export PROGRESS_TAR='${progressTar}'
+                                export PROGRESS_URL='${progressUrl}'
                                 # ---- background watcher ----
                                 (
                                     last=0
@@ -4465,13 +4458,8 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
                                         m=\$(stat -c %Y "\$xml" 2>/dev/null || echo 0)
                                         [ "\$m" -le "\$last" ] && continue
                                         last=\$m
-                                        ( cd '${WORKSPACE}' && tar -czf '${progressTar}' '${stageName}/' ) || continue
-                                        if curl -fsSL --retry 2 -u "\$ART_USER:\$ART_PASS" \\
-                                                -T '${WORKSPACE}/${progressTar}' '${progressUrl}'; then
-                                            echo "[PROGRESS-UPLOAD] ${stageName}: uploaded checkpoint (mtime=\$m)"
-                                        else
-                                            echo "[PROGRESS-UPLOAD] ${stageName}: upload iteration failed (non-fatal)"
-                                        fi
+                                        LABEL="checkpoint (mtime=\$m)" \\
+                                        bash '${WORKSPACE}/jenkins/scripts/progress_upload_snapshot.sh' || continue
                                     done
                                     echo "[PROGRESS-UPLOAD] ${stageName}: pytest done, watcher exiting"
                                 ) &
@@ -4488,11 +4476,8 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
 
                                 # ---- immediate final snapshot of run 1 ----
                                 if [ -f '${WORKSPACE}/${stageName}/results.xml' ]; then
-                                    ( cd '${WORKSPACE}' && tar -czf '${progressTar}' '${stageName}/' ) && \
-                                    curl -fsSL --retry 2 -u "\$ART_USER:\$ART_PASS" \
-                                        -T '${WORKSPACE}/${progressTar}' '${progressUrl}' && \
-                                    echo "[PROGRESS-UPLOAD] ${stageName}: uploaded run1 final snapshot" || \
-                                    echo "[PROGRESS-UPLOAD] ${stageName}: run1 final snapshot upload failed (non-fatal)"
+                                    LABEL='run1 final snapshot' \\
+                                    bash '${WORKSPACE}/jenkins/scripts/progress_upload_snapshot.sh' || true
                                 fi
 
                                 exit \$rc

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2051,14 +2051,16 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                 def progressUrl = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/test-results/${progressTar}"
                 def remoteWorkspaceTrk = "/home/svc_tensorrt/bloom/scripts/${jobUID}"
                 def trackCmd = Utils.sshUserCmd(remote, scriptTrackPathNode)
-                // ls -la on the specific file forces LOOKUP+GETATTR on the NFS server,
-                // bypassing any stale per-file attribute cache on the login node.
-                // This is more reliable than ls on the directory (READDIR/READDIRPLUS),
-                // which is affected by the rdirplus/nordirplus mount option.
-                def sshStatCmd = Utils.sshUserCmd(remote, "\"ls -la '${remoteWorkspaceTrk}/results.xml' > /dev/null 2>&1; stat -c %Y '${remoteWorkspaceTrk}/results.xml' 2>/dev/null || echo 0\"")
+                // Two-stage NFS cache flush:
+                // 1. ls on the directory (READDIR) makes newly created files visible
+                //    when the login node has a negative dcache entry for results.xml.
+                // 2. ls -la on the file (LOOKUP+GETATTR) refreshes the per-file
+                //    attribute cache for an already-known file whose mtime changed.
+                // Both are needed: the file-only ls does nothing when the file is new.
+                def sshStatCmd = Utils.sshUserCmd(remote, "\"ls '${remoteWorkspaceTrk}/' > /dev/null 2>&1; ls -la '${remoteWorkspaceTrk}/results.xml' > /dev/null 2>&1; stat -c %Y '${remoteWorkspaceTrk}/results.xml' 2>/dev/null || echo 0\"")
                 def scpXmlCmd = scpFromRemoteCmd(remote, "${remoteWorkspaceTrk}/results*.xml", "${stageName}/")
                 def scpUnfinishedCmd = scpFromRemoteCmd(remote, "${remoteWorkspaceTrk}/unfinished_test.txt", "${stageName}/")
-                def sshRefreshCacheCmd = Utils.sshUserCmd(remote, "\"ls -la '${remoteWorkspaceTrk}/results.xml' > /dev/null 2>&1 || true\"")
+                def sshRefreshCacheCmd = Utils.sshUserCmd(remote, "\"ls '${remoteWorkspaceTrk}/' > /dev/null 2>&1; ls -la '${remoteWorkspaceTrk}/results.xml' > /dev/null 2>&1 || true\"")
                 def sshListPerfCmd = Utils.sshUserCmd(remote, "\"find '${remoteWorkspaceTrk}' -maxdepth 1 -type d \\( -name 'aggr*' -o -name 'disagg*' \\) -print 2>/dev/null || true\"")
                 def scpPerfTemplate = scpFromRemoteCmd(remote, "PERF_FOLDER_PLACEHOLDER", "${stageName}/")
                 sh "rm -f ${pytestDoneFile}"

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -4020,7 +4020,11 @@ REUSED_TESTS_EOF
 // Build-scoped: ${UPLOAD_PATH} is per-build, so unswept progress tars are
 // garbage-collected with the rest of the build's artifacts anyway.
 def deleteProgressArtifact(stageName) {
-    def targetUrl = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/test-results-progress/results-${stageName}-progress.tar.gz"
+    // UPLOAD_PATH points to the virtual repo `sw-tensorrt-generic`, which
+    // accepts GET/PUT but returns 404 on DELETE. Rewrite to the backing
+    // local repo so the delete actually lands.
+    def deletePath = UPLOAD_PATH.replaceFirst(/^sw-tensorrt-generic\//, 'sw-tensorrt-generic-local/')
+    def targetUrl = "https://urm.nvidia.com/artifactory/${deletePath}/test-results-progress/results-${stageName}-progress.tar.gz"
     try {
         withCredentials([usernamePassword(
                 credentialsId: 'urm-artifactory-creds',

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2058,7 +2058,7 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                 // wrote the file avoids this cross-client visibility window entirely.
                 // After the mtime check confirms a change, sshRefreshCacheCmd primes
                 // the login node's NFS cache before the SCP step reads the file.
-                def sshStatCmd = Utils.sshUserCmd(remote, "\"srun --overlap --quiet --jobid='${slurmJobId}' --ntasks=1 stat -c %Y '${remoteWorkspaceTrk}/results.xml' 2>/dev/null || echo 0\"")
+                def sshStatCmd = Utils.sshUserCmd(remote, "\"srun --overlap --quiet --jobid='${slurmJobId}' --ntasks=1 stat -c %Y '${remoteWorkspaceTrk}/results.xml' || echo 0\"")
                 def scpXmlCmd = scpFromRemoteCmd(remote, "${remoteWorkspaceTrk}/results*.xml", "${stageName}/")
                 def scpUnfinishedCmd = scpFromRemoteCmd(remote, "${remoteWorkspaceTrk}/unfinished_test.txt", "${stageName}/")
                 def sshRefreshCacheCmd = Utils.sshUserCmd(remote, "\"ls '${remoteWorkspaceTrk}/' > /dev/null 2>&1; ls -la '${remoteWorkspaceTrk}/results.xml' > /dev/null 2>&1 || true\"")

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2051,9 +2051,12 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                 def progressUrl = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/test-results/${progressTar}"
                 def remoteWorkspaceTrk = "/home/svc_tensorrt/bloom/scripts/${jobUID}"
                 def trackCmd = Utils.sshUserCmd(remote, scriptTrackPathNode)
-                def sshStatCmd = Utils.sshUserCmd(remote, "\"stat -c %Y ${remoteWorkspaceTrk}/results.xml 2>/dev/null || echo 0\"")
+                // ls flushes the NFS attribute cache on the login node so the
+                // subsequent stat returns the mtime written by the compute node.
+                def sshStatCmd = Utils.sshUserCmd(remote, "\"ls '${remoteWorkspaceTrk}/' > /dev/null 2>&1; stat -c %Y '${remoteWorkspaceTrk}/results.xml' 2>/dev/null || echo 0\"")
                 def scpXmlCmd = scpFromRemoteCmd(remote, "${remoteWorkspaceTrk}/results*.xml", "${stageName}/")
                 def scpUnfinishedCmd = scpFromRemoteCmd(remote, "${remoteWorkspaceTrk}/unfinished_test.txt", "${stageName}/")
+                def sshRefreshCacheCmd = Utils.sshUserCmd(remote, "\"ls '${remoteWorkspaceTrk}/' > /dev/null 2>&1 || true\"")
                 def sshListPerfCmd = Utils.sshUserCmd(remote, "\"find '${remoteWorkspaceTrk}' -maxdepth 1 -type d \\( -name 'aggr*' -o -name 'disagg*' \\) -print 2>/dev/null || true\"")
                 def scpPerfTemplate = scpFromRemoteCmd(remote, "PERF_FOLDER_PLACEHOLDER", "${stageName}/")
                 sh "rm -f ${pytestDoneFile}"
@@ -2096,6 +2099,7 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
 
                         # ---- immediate final snapshot ----
                         mkdir -p '${WORKSPACE}/${stageName}'
+                        ${sshRefreshCacheCmd}
                         for _attempt in 1 2 3; do
                             ${scpXmlCmd} && break
                             [ \$_attempt -lt 3 ] && echo "[PROGRESS-UPLOAD] ${stageName}: scp xml failed, retry \$_attempt/3" && sleep 10

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2109,7 +2109,7 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                         LABEL_PREFIX='sbatch checkpoint' \\
                         SLURM_SSH_STAT_CMD='${sshStatCmd}' \\
                         SLURM_SCP_XML_CMD='${scpXmlCmd}' \\
-                        bash '${WORKSPACE}/jenkins/scripts/progress_upload_watcher.sh' &
+                        bash '${llmSrcLocal}/jenkins/scripts/progress_upload_watcher.sh' &
                         WATCHER_PID=\$!
 
                         # ---- foreground track: retry up to 3 times on failure ----
@@ -2127,9 +2127,11 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                         wait \$WATCHER_PID 2>/dev/null || true
 
                         # ---- immediate final snapshot ----
+                        mkdir -p '${WORKSPACE}/${stageName}'
+                        ${scpXmlCmd} || true
                         if [ -f '${WORKSPACE}/${stageName}/results.xml' ]; then
                             LABEL='sbatch final snapshot' \\
-                            bash '${WORKSPACE}/jenkins/scripts/progress_upload_snapshot.sh' || true
+                            bash '${llmSrcLocal}/jenkins/scripts/progress_upload_snapshot.sh' || true
                         fi
 
                         exit \$rc
@@ -3716,7 +3718,7 @@ def rerunFailedTests(stageName, llmSrc, testCmdLine, resultFileName="results.xml
                     PROGRESS_DONE_FILE='${rerunDoneFile}' \\
                     PROGRESS_INTERVAL=${PROGRESS_UPLOAD_INTERVAL_SEC} \\
                     LABEL_PREFIX='rerun${times} checkpoint' \\
-                    bash '${WORKSPACE}/jenkins/scripts/progress_upload_watcher.sh' &
+                    bash '${llmSrc}/jenkins/scripts/progress_upload_watcher.sh' &
                     WATCHER_PID=\$!
 
                     # ---- foreground rerun ----
@@ -3729,7 +3731,7 @@ def rerunFailedTests(stageName, llmSrc, testCmdLine, resultFileName="results.xml
 
                     # ---- immediate final snapshot of rerun${times} ----
                     LABEL='rerun${times} final snapshot' \\
-                    bash '${WORKSPACE}/jenkins/scripts/progress_upload_snapshot.sh' || true
+                    bash '${llmSrc}/jenkins/scripts/progress_upload_snapshot.sh' || true
 
                     exit \$rc
                 """
@@ -4432,7 +4434,7 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
                                 PROGRESS_INTERVAL=${PROGRESS_UPLOAD_INTERVAL_SEC} \\
                                 LABEL_PREFIX='checkpoint' \\
                                 XML_PATH='${WORKSPACE}/${stageName}/results.xml' \\
-                                bash '${WORKSPACE}/jenkins/scripts/progress_upload_watcher.sh' &
+                                bash '${llmSrc}/jenkins/scripts/progress_upload_watcher.sh' &
                                 WATCHER_PID=\$!
 
                                 # ---- foreground pytest ----
@@ -4447,7 +4449,7 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
                                 # ---- immediate final snapshot of run 1 ----
                                 if [ -f '${WORKSPACE}/${stageName}/results.xml' ]; then
                                     LABEL='run1 final snapshot' \\
-                                    bash '${WORKSPACE}/jenkins/scripts/progress_upload_snapshot.sh' || true
+                                    bash '${llmSrc}/jenkins/scripts/progress_upload_snapshot.sh' || true
                                 fi
 
                                 exit \$rc

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2140,6 +2140,16 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
 
                         touch '${pytestDoneFile}'
                         wait \$WATCHER_PID 2>/dev/null || true
+
+                        # ---- immediate final snapshot ----
+                        if [ -f '${WORKSPACE}/${stageName}/results.xml' ]; then
+                            ( cd '${WORKSPACE}' && tar -czf '${progressTar}' '${stageName}/' ) && \
+                            curl -fsSL --retry 2 -u "\$ART_USER:\$ART_PASS" \
+                                -T '${WORKSPACE}/${progressTar}' '${progressUrl}' && \
+                            echo "[PROGRESS-UPLOAD] ${stageName}: uploaded sbatch final snapshot" || \
+                            echo "[PROGRESS-UPLOAD] ${stageName}: sbatch final snapshot upload failed (non-fatal)"
+                        fi
+
                         exit \$rc
                     """
                 }
@@ -2218,11 +2228,7 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
             boolean suppressTestReporting = (caughtStageError != null && retryContext != null) &&
                 retryContextAllowsRetry(null, retryContext, caughtStageError, false)
             uploadResults(pipeline, cluster, partition.clusterName, jobUID, stageName, stageIsInterrupted, postTag, suppressTestReporting)
-            if (pytestSucceeded) {
-                // pytest reached its natural end: drop the in-progress checkpoint
-                // tar; the final tar just uploaded by uploadResults supersedes it.
-                deleteProgressArtifact(stageName)
-            }
+            deleteProgressArtifact(stageName)
         } finally {
             stage("Clean Up Slurm Resource") {
                 // Workaround to handle the interruption during clean up SLURM resources
@@ -2906,6 +2912,7 @@ def cacheErrorAndUploadResult(stageName, taskRunner, finallyRunner, noResultIfSu
                 "results-${stageName}${postTag}.tar.gz",
                 "${UPLOAD_PATH}/test-results/"
             )
+            deleteProgressArtifact(stageName)
             if (!suppressTestReporting) {
                 junit(testResults: "${stageName}/results*.xml")
             }
@@ -4071,9 +4078,15 @@ def deleteProgressArtifact(stageName) {
                 credentialsId: 'urm-artifactory-creds',
                 usernameVariable: 'ART_USER',
                 passwordVariable: 'ART_PASS')]) {
-            sh """
-                curl -fsSL --retry 2 -X DELETE -u "\$ART_USER:\$ART_PASS" '${targetUrl}'
-            """
+            def httpStatus = sh(
+                script: "curl -sSo /dev/null -w '%{http_code}' --retry 2 -u \"\$ART_USER:\$ART_PASS\" '${targetUrl}'",
+                returnStdout: true
+            ).trim()
+            if (httpStatus == '404') {
+                echo "[PROGRESS-UPLOAD] ${stageName}: progress tar not found, skipping delete"
+                return
+            }
+            sh "curl -fsSL --retry 2 -X DELETE -u \"\$ART_USER:\$ART_PASS\" '${targetUrl}'"
         }
         echo "[PROGRESS-UPLOAD] ${stageName}: deleted progress tar ${targetUrl}"
     } catch (InterruptedException e) {
@@ -4558,13 +4571,6 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
         if (fileExists("${stageName}/results-timeout.xml") || generateTimeoutTestResultXml(pipeline, stageName)) {
             error "Some tests terminated unexpectedly, please check the test report."
         }
-
-        // pytest succeeded (possibly after rerun) -- the in-progress checkpoint
-        // tar is no longer needed; the stage's `finally` will upload the final
-        // results tar shortly. Drop the progress tar so consumers don't pick
-        // up a stale snapshot. Forensic tars from failed runs are intentionally
-        // left in place.
-        deleteProgressArtifact(stageName)
 
         if (perfMode) {
             // Only PyTorch perf stages remain; the TensorRT perf baseline was removed.

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -182,9 +182,9 @@ SLURM_NON_TERMINAL_STATES = [
 
 // How often the background shell watcher snapshots the in-progress
 // ${stageName}/ directory (containing the PeriodicJUnitXML reporter's
-// results.xml) up to Artifactory. 5 minutes balances Artifactory traffic
+// results.xml) up to Artifactory. 10 minutes balances Artifactory traffic
 // against staleness for multi-hour test stages.
-PROGRESS_UPLOAD_INTERVAL_SEC = 300
+PROGRESS_UPLOAD_INTERVAL_SEC = 600
 
 // Typed-exception hierarchy and FailureClassifier (PATTERN_CATALOG, classify(),
 // flattenThrowable) live in trtllm-jenkins-shared-lib under src/trtllm/. They
@@ -303,64 +303,65 @@ def scrapeSlurmLogForDeviceFault(def pipeline, Map remote, String remoteLogPath)
 // `postTag` uniquifies the uploaded tar filename, the Artifactory guard key and
 // the locally-staged result XMLs when the same stageName is uploaded more than
 // once in a build (e.g. SLURM infra-failure retries). First attempt passes "".
-def uploadResults(def pipeline, SlurmCluster cluster, String clusterName, String nodeName, String stageName, Boolean stageIsInterrupted, String postTag="", boolean suppressTestReporting=false) {
-    CloudManager.withSlurmSshCredentialRemotes(pipeline, clusterName, cluster) { remotes ->
-        // Pin one reachable frontend for the whole collect: every download targets
-        // the same node workspace (/home/svc_tensorrt/bloom/scripts/${nodeName}),
-        // so the find + scps must all hit the login node that holds those files.
-        // No whole-closure failover here -- uploadArtifacts/junit must not re-run.
-        def remote = CloudManager.selectReachableSlurmRemote(pipeline, remotes)
-        def hasTimeoutTest = false
-        def downloadResultSucceed = false
-        def downloadPerfResultSucceed = false
+def uploadResults(def pipeline, SlurmCluster cluster, String clusterName, String nodeName, String stageName, String postTag="", boolean suppressTestReporting=false) {
+    pipeline.stage('Submit Test Result') {
+        sh "ls -al ${stageName}/ || true"
 
-        pipeline.stage('Submit Test Result') {
-            sh "mkdir -p ${stageName}"
-            // Download timeout test results
-            def timeoutTestFilePath = "/home/svc_tensorrt/bloom/scripts/${nodeName}/unfinished_test.txt"
-            def downloadTimeoutTestSucceed = Utils.exec(pipeline, script: scpFromRemoteCmd(remote, timeoutTestFilePath, "${stageName}/"), returnStatus: true, numRetries: 3) == 0
-            if (downloadTimeoutTestSucceed) {
-                if (stageIsInterrupted) {
-                    echo "Stage is interrupted, skip to generate terminated unexpectedly test result."
+        // Check whether the progress watcher ever succeeded in uploading a tar.
+        // progress_upload_snapshot.sh writes this sentinel on each successful PUT.
+        def progressOkFile = "${WORKSPACE}/results-${stageName}${postTag}-progress.tar.gz.upload_ok"
+        def progressEverUploaded = fileExists(progressOkFile)
+
+        if (progressEverUploaded) {
+            // Move the progress tar to the final test-results location via Artifactory server-side
+            // move (no data re-transfer). Virtual repo sw-tensorrt-generic does not support move;
+            // rewrite to the backing local repo as we do for DELETE in deleteProgressArtifact().
+            def localUploadPath = UPLOAD_PATH.replaceFirst(/^sw-tensorrt-generic\//, 'sw-tensorrt-generic-local/')
+            def srcArtPath = "${localUploadPath}/test-results/results-${stageName}${postTag}-progress.tar.gz"
+            def dstArtPath = "${localUploadPath}/test-results/results-${stageName}${postTag}.tar.gz"
+            withCredentials([usernamePassword(
+                    credentialsId: 'urm-artifactory-creds',
+                    usernameVariable: 'ART_USER',
+                    passwordVariable: 'ART_PASS')]) {
+                def rc = sh(
+                    script: """curl -fsSL --retry 2 -u "\$ART_USER:\$ART_PASS" -X POST \
+                        'https://urm.nvidia.com/artifactory/api/move/${srcArtPath}?to=/${dstArtPath}'""",
+                    returnStatus: true
+                )
+                if (rc == 0) {
+                    echo "[PROGRESS-UPLOAD] ${stageName}: progress tar moved to test-results/ as results-${stageName}${postTag}.tar.gz"
                 } else {
-                    sh "ls -al ${stageName}/"
-                    // Generate timeout test result xml if there are terminated unexpectedly tests
-                    hasTimeoutTest = generateTimeoutTestResultXml(pipeline, stageName)
+                    echo "[PROGRESS-UPLOAD] ${stageName}: move failed (rc=${rc}); results may already be at destination or progress tar was deleted"
                 }
             }
-            // Download normal test results
-            def resultsFilePath = "/home/svc_tensorrt/bloom/scripts/${nodeName}/results*.xml"
-            downloadResultSucceed = Utils.exec(pipeline, script: scpFromRemoteCmd(remote, resultsFilePath, "${stageName}/"), returnStatus: true, numRetries: 3) == 0
-
-            // Download perf test results
-            def perfResultsBasePath = "/home/svc_tensorrt/bloom/scripts/${nodeName}"
-            def folderListOutput = Utils.exec(
-                pipeline,
-                script: Utils.sshUserCmd(
-                    remote,
-                    "\"find '${perfResultsBasePath}' -maxdepth 1 -type d \\( -name 'aggr*' -o -name 'disagg*' \\) -printf '%f\\n' || true\""
-                ),
-                returnStdout: true,
-                numRetries: 3
-            )?.trim() ?: ""
-            def perfFolders = folderListOutput.split(/\s+/).collect { it.trim().replaceAll(/\/$/, '') }.findAll { it }
-            echo "Perf Result Folders: ${perfFolders}"
-            if (perfFolders) {
-                def scpSources = perfFolders.size() == 1
-                    ? "${perfResultsBasePath}/${perfFolders[0]}"
-                    : "{${perfFolders.collect { "${perfResultsBasePath}/${it}" }.join(',')}}"
-                downloadPerfResultSucceed = Utils.exec(pipeline, script: scpFromRemoteCmd(remote, scpSources, "${stageName}/"), returnStatus: true, numRetries: 3) == 0
+        } else {
+            // Progress upload never succeeded (Artifactory unreachable, watcher not started, etc.).
+            // Fall back to original approach: tar local XML files and upload directly.
+            // Use --transform so tar contents carry the postTag filename without touching disk files.
+            echo "[PROGRESS-UPLOAD] ${stageName}: no successful progress upload recorded, falling back to direct upload"
+            def xmlCount = sh(script: "ls ${stageName}/results*.xml 2>/dev/null | wc -l", returnStdout: true).trim().toInteger()
+            if (xmlCount > 0) {
+                def transformOpt = postTag ? "--transform 's|^\\(${stageName}/results[^/]*\\)\\.xml\$|\\1${postTag}.xml|'" : ""
+                sh "tar -czvf results-${stageName}${postTag}.tar.gz ${transformOpt} ${stageName}/"
+                ensureStageResultNotUploaded("${stageName}${postTag}")
+                trtllm_utils.uploadArtifacts(
+                    "results-${stageName}${postTag}.tar.gz",
+                    "${UPLOAD_PATH}/test-results/"
+                )
+            } else {
+                println("No results xml to submit")
             }
+        }
 
-            // Pull this stage's per-process .cbtscov files as one archive into ${stageName}/cbts/; bounded and non-fatal.
-            if (isCbtsStage(stageName)) {
+        // Pull this stage's per-process .cbtscov files as one archive into ${stageName}/cbts/; bounded and non-fatal.
+        if (isCbtsStage(stageName)) {
+            CloudManager.withSlurmSshCredentials(pipeline, clusterName, cluster) { remote ->
                 def remoteWs = "/home/svc_tensorrt/bloom/scripts/${nodeName}"
                 def cbtsLocalDir = "${stageName}/cbts"
                 def cbtsArchive = "cbts_coverage_${stageName}.tar.gz"
                 sh "mkdir -p ${cbtsLocalDir}"
                 try {
                     timeout(time: 5, unit: 'MINUTES') {
-                        // Pack on the login node; drop a partial archive when nothing matches so the scp fails cleanly.
                         Utils.exec(
                             pipeline,
                             script: Utils.sshUserCmd(
@@ -386,44 +387,28 @@ def uploadResults(def pipeline, SlurmCluster cluster, String clusterName, String
                     echo "CBTS: coverage pull for ${stageName} skipped (${e.message}); continuing."
                 }
             }
-
-            echo "hasTimeoutTest: ${hasTimeoutTest}, downloadResultSucceed: ${downloadResultSucceed}, downloadPerfResultSucceed: ${downloadPerfResultSucceed}"
-            if (hasTimeoutTest || downloadResultSucceed || downloadPerfResultSucceed) {
-                // On retry attempts, rename freshly-downloaded result XMLs so that
-                // (a) the tar for this attempt is distinguishable from prior attempts
-                //     already uploaded to Artifactory, and
-                // (b) the junit() glob below picks up this attempt's results as a
-                //     separate set, keeping earlier attempts' test data visible in
-                //     the Jenkins build report rather than overwriting it.
-                if (postTag) {
-                    sh """
-                        cd ${stageName}
-                        for f in results*.xml; do
-                            [ -f "\$f" ] || continue
-                            case "\$f" in *${postTag}.xml) continue ;; esac
-                            name=\"\${f%.xml}\"
-                            mv \"\$f\" \"\${name}${postTag}.xml\" || true
-                        done
-                    """
-                }
-                sh "ls -al ${stageName}/"
-                echo "Upload test results."
-                sh "tar -czvf results-${stageName}${postTag}.tar.gz ${stageName}/"
-                ensureStageResultNotUploaded("${stageName}${postTag}")
-                trtllm_utils.uploadArtifacts(
-                    "results-${stageName}${postTag}.tar.gz",
-                    "${UPLOAD_PATH}/test-results/"
-                )
-            } else {
-                println("No results xml to submit")
-            }
         }
+    }
 
-        if ((hasTimeoutTest || downloadResultSucceed) && !suppressTestReporting) {
-            junit(allowEmptyResults: true, testResults: "${stageName}/results*.xml")
-        } else if (suppressTestReporting) {
-            echo "[INFRA-RETRY] ${stageName}${postTag}: suppressing junit() because a retry is still planned"
-        }
+    // Rename local results*.xml with postTag so junit() reports each attempt separately.
+    // This is the only place we touch disk files; snapshot.sh uses --transform instead.
+    if (postTag) {
+        sh """
+            cd ${stageName}
+            for f in results*.xml; do
+                [ -f "\$f" ] || continue
+                case "\$f" in *${postTag}.xml) continue ;; esac
+                mv "\$f" "\${f%.xml}${postTag}.xml" || true
+            done
+        """
+    }
+
+    // junit() uses local XML files already downloaded by the final progress snapshot.
+    def hasLocalResults = sh(script: "ls ${stageName}/results*.xml 2>/dev/null | wc -l", returnStdout: true).trim().toInteger() > 0
+    if (hasLocalResults && !suppressTestReporting) {
+        junit(allowEmptyResults: true, testResults: "${stageName}/results*.xml")
+    } else if (suppressTestReporting) {
+        echo "[INFRA-RETRY] ${stageName}${postTag}: suppressing junit() because a retry is still planned"
     }
 }
 
@@ -2087,12 +2072,15 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                 // as a background subshell) so Blue Ocean renders the stage
                 // as a single box instead of a nested parallel split.
                 def pytestDoneFile = "${WORKSPACE}/.pytest-done-${stageName}"
-                def progressTar = "results-${stageName}-progress.tar.gz"
-                def progressUrl = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/test-results-progress/${progressTar}"
+                def progressTar = "results-${stageName}${postTag}-progress.tar.gz"
+                def progressUrl = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/test-results/${progressTar}"
                 def remoteWorkspaceTrk = "/home/svc_tensorrt/bloom/scripts/${jobUID}"
                 def trackCmd = Utils.sshUserCmd(remote, scriptTrackPathNode)
                 def sshStatCmd = Utils.sshUserCmd(remote, "\"stat -c %Y ${remoteWorkspaceTrk}/results.xml 2>/dev/null || echo 0\"")
                 def scpXmlCmd = scpFromRemoteCmd(remote, "${remoteWorkspaceTrk}/results*.xml", "${stageName}/")
+                def scpUnfinishedCmd = scpFromRemoteCmd(remote, "${remoteWorkspaceTrk}/unfinished_test.txt", "${stageName}/")
+                def sshListPerfCmd = Utils.sshUserCmd(remote, "\"find '${remoteWorkspaceTrk}' -maxdepth 1 -type d \\( -name 'aggr*' -o -name 'disagg*' \\) -print 2>/dev/null || true\"")
+                def scpPerfTemplate = scpFromRemoteCmd(remote, "PERF_FOLDER_PLACEHOLDER", "${stageName}/")
                 sh "rm -f ${pytestDoneFile}"
                 withCredentials([usernamePassword(
                         credentialsId: 'urm-artifactory-creds',
@@ -2103,12 +2091,17 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                         export STAGE_NAME='${stageName}'
                         export PROGRESS_TAR='${progressTar}'
                         export PROGRESS_URL='${progressUrl}'
+                        export TIMEOUT_XML_SCRIPT='${llmSrcLocal}/jenkins/scripts/generate_timeout_xml.py'
+                        export POST_TAG='${postTag}'
                         # ---- background watcher: SSH-stat remote XML, SCP, tar, upload ----
                         PROGRESS_DONE_FILE='${pytestDoneFile}' \\
                         PROGRESS_INTERVAL=${PROGRESS_UPLOAD_INTERVAL_SEC} \\
                         LABEL_PREFIX='sbatch checkpoint' \\
                         SLURM_SSH_STAT_CMD='${sshStatCmd}' \\
                         SLURM_SCP_XML_CMD='${scpXmlCmd}' \\
+                        SLURM_SCP_UNFINISHED_CMD='${scpUnfinishedCmd}' \\
+                        SLURM_SSH_LIST_PERF_CMD='${sshListPerfCmd}' \\
+                        SLURM_SCP_PERF_TEMPLATE='${scpPerfTemplate}' \\
                         bash '${llmSrcLocal}/jenkins/scripts/progress_upload_watcher.sh' &
                         WATCHER_PID=\$!
 
@@ -2128,9 +2121,30 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
 
                         # ---- immediate final snapshot ----
                         mkdir -p '${WORKSPACE}/${stageName}'
-                        ${scpXmlCmd} || true
+                        for _attempt in 1 2 3; do
+                            ${scpXmlCmd} && break
+                            [ \$_attempt -lt 3 ] && echo "[PROGRESS-UPLOAD] ${stageName}: scp xml failed, retry \$_attempt/3" && sleep 10
+                        done || true
+                        _unfinished_ok=0
+                        for _attempt in 1 2 3; do
+                            ${scpUnfinishedCmd} && { _unfinished_ok=1; break; }
+                            echo "[PROGRESS-UPLOAD] ${stageName}: scp unfinished failed (attempt \$_attempt/3)"
+                            [ \$_attempt -lt 3 ] && sleep 10
+                        done
+                        [ "\$_unfinished_ok" -eq 0 ] && echo "[PROGRESS-UPLOAD] ${stageName}: scp unfinished not available, skipping"
+                        SCP_PERF_TMPL='${scpPerfTemplate}'
+                        while IFS= read -r perf_folder; do
+                            [ -z "\$perf_folder" ] && continue
+                            _perf_ok=0
+                            for _attempt in 1 2 3; do
+                                eval "\${SCP_PERF_TMPL//PERF_FOLDER_PLACEHOLDER/\$perf_folder}" && { _perf_ok=1; break; }
+                                echo "[PROGRESS-UPLOAD] ${stageName}: scp perf \$perf_folder failed (attempt \$_attempt/3)"
+                                [ \$_attempt -lt 3 ] && sleep 10
+                            done
+                            [ "\$_perf_ok" -eq 0 ] && echo "[PROGRESS-UPLOAD] ${stageName}: scp perf \$perf_folder failed after 3 attempts"
+                        done < <(eval '${sshListPerfCmd}' 2>/dev/null || true)
                         if [ -f '${WORKSPACE}/${stageName}/results.xml' ]; then
-                            LABEL='sbatch final snapshot' \\
+                            LABEL='sbatch final snapshot' FINAL_SNAPSHOT=1 \\
                             bash '${llmSrcLocal}/jenkins/scripts/progress_upload_snapshot.sh' || true
                         fi
 
@@ -2209,8 +2223,8 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
             // failure classifies as UserFailure -> not suppressed -> reported.
             boolean suppressTestReporting = (caughtStageError != null && retryContext != null) &&
                 retryContextAllowsRetry(null, retryContext, caughtStageError, false)
-            uploadResults(pipeline, cluster, partition.clusterName, jobUID, stageName, stageIsInterrupted, postTag, suppressTestReporting)
-            deleteProgressArtifact(stageName)
+            uploadResults(pipeline, cluster, partition.clusterName, jobUID, stageName, postTag, suppressTestReporting)
+            deleteProgressArtifact(stageName, postTag)
         } finally {
             stage("Clean Up Slurm Resource") {
                 // Workaround to handle the interruption during clean up SLURM resources
@@ -2888,12 +2902,36 @@ def cacheErrorAndUploadResult(stageName, taskRunner, finallyRunner, noResultIfSu
             }
             sh "STAGE_NAME=${stageName} && env | sort > ${stageName}/debug_env.txt"
             echo "Upload test results."
-            sh "tar -czvf results-${stageName}${postTag}.tar.gz ${stageName}/"
-            trtllm_utils.uploadArtifacts(
-                "results-${stageName}${postTag}.tar.gz",
-                "${UPLOAD_PATH}/test-results/"
-            )
-            deleteProgressArtifact(stageName)
+            def progressOkFile = "${WORKSPACE}/results-${stageName}${postTag}-progress.tar.gz.upload_ok"
+            if (fileExists(progressOkFile)) {
+                def localUploadPath = UPLOAD_PATH.replaceFirst(/^sw-tensorrt-generic\//, 'sw-tensorrt-generic-local/')
+                def srcArtPath = "${localUploadPath}/test-results/results-${stageName}${postTag}-progress.tar.gz"
+                def dstArtPath = "${localUploadPath}/test-results/results-${stageName}${postTag}.tar.gz"
+                withCredentials([usernamePassword(
+                        credentialsId: 'urm-artifactory-creds',
+                        usernameVariable: 'ART_USER',
+                        passwordVariable: 'ART_PASS')]) {
+                    def rc = sh(
+                        script: """curl -fsSL --retry 2 -u "\$ART_USER:\$ART_PASS" -X POST \
+                            'https://urm.nvidia.com/artifactory/api/move/${srcArtPath}?to=/${dstArtPath}'""",
+                        returnStatus: true
+                    )
+                    if (rc == 0) {
+                        echo "[PROGRESS-UPLOAD] ${stageName}: progress tar moved to test-results/ as results-${stageName}${postTag}.tar.gz"
+                    } else {
+                        echo "[PROGRESS-UPLOAD] ${stageName}: move failed (rc=${rc}); results may already be at destination or progress tar was deleted"
+                    }
+                }
+            } else {
+                echo "[PROGRESS-UPLOAD] ${stageName}: no successful progress upload recorded, falling back to direct upload"
+                def transformOpt = postTag ? "--transform 's|^\\(${stageName}/results[^/]*\\)\\.xml\$|\\1${postTag}.xml|'" : ""
+                sh "tar -czvf results-${stageName}${postTag}.tar.gz ${transformOpt} ${stageName}/"
+                trtllm_utils.uploadArtifacts(
+                    "results-${stageName}${postTag}.tar.gz",
+                    "${UPLOAD_PATH}/test-results/"
+                )
+            }
+            deleteProgressArtifact(stageName, postTag)
             if (!suppressTestReporting) {
                 junit(testResults: "${stageName}/results*.xml")
             }
@@ -3701,7 +3739,7 @@ def rerunFailedTests(stageName, llmSrc, testCmdLine, resultFileName="results.xml
             "--reruns ${times - 1}"
         ]
         def rerunProgressTar = "results-${stageName}-progress.tar.gz"
-        def rerunProgressUrl = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/test-results-progress/${rerunProgressTar}"
+        def rerunProgressUrl = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/test-results/${rerunProgressTar}"
         def rerunDoneFile = "${WORKSPACE}/.rerun${times}-done-${stageName}"
         sh "rm -f ${rerunDoneFile}"
         try {
@@ -3730,7 +3768,7 @@ def rerunFailedTests(stageName, llmSrc, testCmdLine, resultFileName="results.xml
                     wait \$WATCHER_PID 2>/dev/null || true
 
                     # ---- immediate final snapshot of rerun${times} ----
-                    LABEL='rerun${times} final snapshot' \\
+                    LABEL='rerun${times} final snapshot' FINAL_SNAPSHOT=1 \\
                     bash '${llmSrc}/jenkins/scripts/progress_upload_snapshot.sh' || true
 
                     exit \$rc
@@ -4038,12 +4076,12 @@ REUSED_TESTS_EOF
 //
 // Build-scoped: ${UPLOAD_PATH} is per-build, so unswept progress tars are
 // garbage-collected with the rest of the build's artifacts anyway.
-def deleteProgressArtifact(stageName) {
+def deleteProgressArtifact(stageName, postTag="") {
     // UPLOAD_PATH points to the virtual repo `sw-tensorrt-generic`, which
     // accepts GET/PUT but returns 404 on DELETE. Rewrite to the backing
     // local repo so the delete actually lands.
     def deletePath = UPLOAD_PATH.replaceFirst(/^sw-tensorrt-generic\//, 'sw-tensorrt-generic-local/')
-    def targetUrl = "https://urm.nvidia.com/artifactory/${deletePath}/test-results-progress/results-${stageName}-progress.tar.gz"
+    def targetUrl = "https://urm.nvidia.com/artifactory/${deletePath}/test-results/results-${stageName}${postTag}-progress.tar.gz"
     try {
         withCredentials([usernamePassword(
                 credentialsId: 'urm-artifactory-creds',
@@ -4409,8 +4447,8 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
                 // (success or failure). Lives outside ${stageName}/ so the
                 // `rm -rf ${stageName}/` at pytest startup doesn't wipe it.
                 def pytestDoneFile = "${WORKSPACE}/.pytest-done-${stageName}"
-                def progressTar = "results-${stageName}-progress.tar.gz"
-                def progressUrl = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/test-results-progress/${progressTar}"
+                def progressTar = "results-${stageName}${postTag}-progress.tar.gz"
+                def progressUrl = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/test-results/${progressTar}"
                 sh "rm -f ${pytestDoneFile}"
                 try {
                     if (preprocessedLists.regularCount > 0) {
@@ -4429,6 +4467,8 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
                                 export STAGE_NAME='${stageName}'
                                 export PROGRESS_TAR='${progressTar}'
                                 export PROGRESS_URL='${progressUrl}'
+                                export TIMEOUT_XML_SCRIPT='${llmSrc}/jenkins/scripts/generate_timeout_xml.py'
+                                export POST_TAG='${postTag}'
                                 # ---- background watcher ----
                                 PROGRESS_DONE_FILE='${pytestDoneFile}' \\
                                 PROGRESS_INTERVAL=${PROGRESS_UPLOAD_INTERVAL_SEC} \\
@@ -4448,7 +4488,7 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
 
                                 # ---- immediate final snapshot of run 1 ----
                                 if [ -f '${WORKSPACE}/${stageName}/results.xml' ]; then
-                                    LABEL='run1 final snapshot' \\
+                                    LABEL='run1 final snapshot' FINAL_SNAPSHOT=1 \\
                                     bash '${llmSrc}/jenkins/scripts/progress_upload_snapshot.sh' || true
                                 fi
 

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -3712,11 +3712,52 @@ def rerunFailedTests(stageName, llmSrc, testCmdLine, resultFileName="results.xml
             "--periodic-junit-xmlpath ${xmlFile}",
             "--reruns ${times - 1}"
         ]
+        def rerunProgressTar = "results-${stageName}-progress.tar.gz"
+        def rerunProgressUrl = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/test-results-progress/${rerunProgressTar}"
+        def rerunDoneFile = "${WORKSPACE}/.rerun${times}-done-${stageName}"
+        sh "rm -f ${rerunDoneFile}"
         try {
-            sh """
-                cd ${llmSrc}/tests/integration/defs && \
-                ${newTestCmdLine.join(" ")}
-            """
+            withCredentials([usernamePassword(
+                    credentialsId: 'urm-artifactory-creds',
+                    usernameVariable: 'ART_USER',
+                    passwordVariable: 'ART_PASS')]) {
+                sh """
+                    set +e
+                    # ---- background watcher for rerun${times} ----
+                    (
+                        while [ ! -f '${rerunDoneFile}' ]; do
+                            sleep ${PROGRESS_UPLOAD_INTERVAL_SEC}
+                            [ -f '${rerunDoneFile}' ] && break
+                            ( cd '${WORKSPACE}' && tar -czf '${rerunProgressTar}' '${stageName}/' ) || continue
+                            if curl -fsSL --retry 2 -u "\$ART_USER:\$ART_PASS" \\
+                                    -T '${WORKSPACE}/${rerunProgressTar}' '${rerunProgressUrl}'; then
+                                echo "[PROGRESS-UPLOAD] ${stageName}: rerun${times} checkpoint uploaded"
+                            else
+                                echo "[PROGRESS-UPLOAD] ${stageName}: rerun${times} checkpoint upload failed (non-fatal)"
+                            fi
+                        done
+                        echo "[PROGRESS-UPLOAD] ${stageName}: rerun${times} watcher exiting"
+                    ) &
+                    WATCHER_PID=\$!
+
+                    # ---- foreground rerun ----
+                    cd ${llmSrc}/tests/integration/defs && \\
+                    ${newTestCmdLine.join(" ")}
+                    rc=\$?
+
+                    touch '${rerunDoneFile}'
+                    wait \$WATCHER_PID 2>/dev/null || true
+
+                    # ---- immediate final snapshot of rerun${times} ----
+                    ( cd '${WORKSPACE}' && tar -czf '${rerunProgressTar}' '${stageName}/' ) && \\
+                    curl -fsSL --retry 2 -u "\$ART_USER:\$ART_PASS" \\
+                        -T '${WORKSPACE}/${rerunProgressTar}' '${rerunProgressUrl}' && \\
+                    echo "[PROGRESS-UPLOAD] ${stageName}: rerun${times} final snapshot uploaded" || \\
+                    echo "[PROGRESS-UPLOAD] ${stageName}: rerun${times} final snapshot upload failed (non-fatal)"
+
+                    exit \$rc
+                """
+            }
         } catch(InterruptedException e) {
             throw e
         } catch (Exception e) {
@@ -4431,6 +4472,16 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
 
                                 touch '${pytestDoneFile}'
                                 wait \$WATCHER_PID 2>/dev/null || true
+
+                                # ---- immediate final snapshot of run 1 ----
+                                if [ -f '${WORKSPACE}/${stageName}/results.xml' ]; then
+                                    ( cd '${WORKSPACE}' && tar -czf '${progressTar}' '${stageName}/' ) && \
+                                    curl -fsSL --retry 2 -u "\$ART_USER:\$ART_PASS" \
+                                        -T '${WORKSPACE}/${progressTar}' '${progressUrl}' && \
+                                    echo "[PROGRESS-UPLOAD] ${stageName}: uploaded run1 final snapshot" || \
+                                    echo "[PROGRESS-UPLOAD] ${stageName}: run1 final snapshot upload failed (non-fatal)"
+                                fi
+
                                 exit \$rc
                             """
                         }

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -307,34 +307,9 @@ def uploadResults(def pipeline, SlurmCluster cluster, String clusterName, String
     pipeline.stage('Submit Test Result') {
         sh "ls -al ${stageName}/ || true"
 
-        // Check whether the progress watcher ever succeeded in uploading a tar.
-        // progress_upload_snapshot.sh writes this sentinel on each successful PUT.
-        def progressOkFile = "${WORKSPACE}/results-${stageName}${postTag}-progress.tar.gz.upload_ok"
-        def progressEverUploaded = fileExists(progressOkFile)
-
-        if (progressEverUploaded) {
-            // Move the progress tar to the final test-results location via Artifactory server-side
-            // move (no data re-transfer). Virtual repo sw-tensorrt-generic does not support move;
-            // rewrite to the backing local repo as we do for DELETE in deleteProgressArtifact().
-            def localUploadPath = UPLOAD_PATH.replaceFirst(/^sw-tensorrt-generic\//, 'sw-tensorrt-generic-local/')
-            def srcArtPath = "${localUploadPath}/test-results/results-${stageName}${postTag}-progress.tar.gz"
-            def dstArtPath = "${localUploadPath}/test-results/results-${stageName}${postTag}.tar.gz"
-            withCredentials([usernamePassword(
-                    credentialsId: 'urm-artifactory-creds',
-                    usernameVariable: 'ART_USER',
-                    passwordVariable: 'ART_PASS')]) {
-                def rc = sh(
-                    script: """curl -fsSL --retry 2 -u "\$ART_USER:\$ART_PASS" -X POST \
-                        'https://urm.nvidia.com/artifactory/api/move/${srcArtPath}?to=/${dstArtPath}'""",
-                    returnStatus: true
-                )
-                if (rc == 0) {
-                    echo "[PROGRESS-UPLOAD] ${stageName}: progress tar moved to test-results/ as results-${stageName}${postTag}.tar.gz"
-                } else {
-                    echo "[PROGRESS-UPLOAD] ${stageName}: move failed (rc=${rc}); results may already be at destination or progress tar was deleted"
-                }
-            }
-        } else {
+        // Promote progress tar to final path, or fall back to direct upload.
+        // progress_upload_snapshot.sh writes the sentinel on each successful PUT.
+        if (!promoteProgressTar(stageName, postTag)) {
             // Progress upload never succeeded (Artifactory unreachable, watcher not started, etc.).
             // Fall back to original approach: tar local XML files and upload directly.
             // Use --transform so tar contents carry the postTag filename without touching disk files.
@@ -2902,27 +2877,7 @@ def cacheErrorAndUploadResult(stageName, taskRunner, finallyRunner, noResultIfSu
             }
             sh "STAGE_NAME=${stageName} && env | sort > ${stageName}/debug_env.txt"
             echo "Upload test results."
-            def progressOkFile = "${WORKSPACE}/results-${stageName}${postTag}-progress.tar.gz.upload_ok"
-            if (fileExists(progressOkFile)) {
-                def localUploadPath = UPLOAD_PATH.replaceFirst(/^sw-tensorrt-generic\//, 'sw-tensorrt-generic-local/')
-                def srcArtPath = "${localUploadPath}/test-results/results-${stageName}${postTag}-progress.tar.gz"
-                def dstArtPath = "${localUploadPath}/test-results/results-${stageName}${postTag}.tar.gz"
-                withCredentials([usernamePassword(
-                        credentialsId: 'urm-artifactory-creds',
-                        usernameVariable: 'ART_USER',
-                        passwordVariable: 'ART_PASS')]) {
-                    def rc = sh(
-                        script: """curl -fsSL --retry 2 -u "\$ART_USER:\$ART_PASS" -X POST \
-                            'https://urm.nvidia.com/artifactory/api/move/${srcArtPath}?to=/${dstArtPath}'""",
-                        returnStatus: true
-                    )
-                    if (rc == 0) {
-                        echo "[PROGRESS-UPLOAD] ${stageName}: progress tar moved to test-results/ as results-${stageName}${postTag}.tar.gz"
-                    } else {
-                        echo "[PROGRESS-UPLOAD] ${stageName}: move failed (rc=${rc}); results may already be at destination or progress tar was deleted"
-                    }
-                }
-            } else {
+            if (!promoteProgressTar(stageName, postTag)) {
                 echo "[PROGRESS-UPLOAD] ${stageName}: no successful progress upload recorded, falling back to direct upload"
                 def transformOpt = postTag ? "--transform 's|^\\(${stageName}/results[^/]*\\)\\.xml\$|\\1${postTag}.xml|'" : ""
                 sh "tar -czvf results-${stageName}${postTag}.tar.gz ${transformOpt} ${stageName}/"
@@ -3756,6 +3711,7 @@ def rerunFailedTests(stageName, llmSrc, testCmdLine, resultFileName="results.xml
                     PROGRESS_DONE_FILE='${rerunDoneFile}' \\
                     PROGRESS_INTERVAL=${PROGRESS_UPLOAD_INTERVAL_SEC} \\
                     LABEL_PREFIX='rerun${times} checkpoint' \\
+                    XML_PATH='${xmlFile}' \\
                     bash '${llmSrc}/jenkins/scripts/progress_upload_watcher.sh' &
                     WATCHER_PID=\$!
 
@@ -4068,6 +4024,37 @@ REUSED_TESTS_EOF
     }
 }
 
+// Promotes the progress tar to the final results path via an Artifactory
+// server-side move (no data re-transfer). Returns true when a progress
+// snapshot existed and was promoted; false when no snapshot was ever uploaded.
+// Virtual repo sw-tensorrt-generic does not support move; rewrite to the
+// backing local repo as we do for DELETE in deleteProgressArtifact().
+def promoteProgressTar(stageName, postTag="") {
+    def progressOkFile = "${WORKSPACE}/results-${stageName}${postTag}-progress.tar.gz.upload_ok"
+    if (!fileExists(progressOkFile)) {
+        return false
+    }
+    def localUploadPath = UPLOAD_PATH.replaceFirst(/^sw-tensorrt-generic\//, 'sw-tensorrt-generic-local/')
+    def srcArtPath = "${localUploadPath}/test-results/results-${stageName}${postTag}-progress.tar.gz"
+    def dstArtPath = "${localUploadPath}/test-results/results-${stageName}${postTag}.tar.gz"
+    withCredentials([usernamePassword(
+            credentialsId: 'urm-artifactory-creds',
+            usernameVariable: 'ART_USER',
+            passwordVariable: 'ART_PASS')]) {
+        def rc = sh(
+            script: """curl -fsSL --retry 2 -u "\$ART_USER:\$ART_PASS" -X POST \
+                'https://urm.nvidia.com/artifactory/api/move/${srcArtPath}?to=/${dstArtPath}'""",
+            returnStatus: true
+        )
+        if (rc == 0) {
+            echo "[PROGRESS-UPLOAD] ${stageName}: progress tar moved to test-results/ as results-${stageName}${postTag}.tar.gz"
+        } else {
+            echo "[PROGRESS-UPLOAD] ${stageName}: move failed (rc=${rc}); results may already be at destination or progress tar was deleted"
+        }
+    }
+    return true
+}
+
 // Removes the in-progress checkpoint tarball uploaded by the inline
 // shell watcher in runLLMTestlistOnPlatformImpl / runLLMTestlistWithSbatch.
 // Called only when the pytest+rerun execution
@@ -4088,16 +4075,17 @@ def deleteProgressArtifact(stageName, postTag="") {
                 usernameVariable: 'ART_USER',
                 passwordVariable: 'ART_PASS')]) {
             def httpStatus = sh(
-                script: "curl -sSo /dev/null -w '%{http_code}' --retry 2 -u \"\$ART_USER:\$ART_PASS\" '${targetUrl}'",
+                script: "curl -sSo /dev/null -w '%{http_code}' --retry 2 -X DELETE -u \"\$ART_USER:\$ART_PASS\" '${targetUrl}'",
                 returnStdout: true
             ).trim()
-            if (httpStatus == '404') {
+            if (httpStatus == '204' || httpStatus == '200') {
+                echo "[PROGRESS-UPLOAD] ${stageName}: deleted progress tar ${targetUrl}"
+            } else if (httpStatus == '404') {
                 echo "[PROGRESS-UPLOAD] ${stageName}: progress tar not found, skipping delete"
-                return
+            } else {
+                echo "[PROGRESS-UPLOAD] ${stageName}: delete returned HTTP ${httpStatus} (non-fatal)"
             }
-            sh "curl -fsSL --retry 2 -X DELETE -u \"\$ART_USER:\$ART_PASS\" '${targetUrl}'"
         }
-        echo "[PROGRESS-UPLOAD] ${stageName}: deleted progress tar ${targetUrl}"
     } catch (InterruptedException e) {
         throw e
     } catch (Exception e) {

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2051,13 +2051,14 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                 def progressUrl = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/test-results/${progressTar}"
                 def remoteWorkspaceTrk = "/home/svc_tensorrt/bloom/scripts/${jobUID}"
                 def trackCmd = Utils.sshUserCmd(remote, scriptTrackPathNode)
-                // Two-stage NFS cache flush:
-                // 1. ls on the directory (READDIR) makes newly created files visible
-                //    when the login node has a negative dcache entry for results.xml.
-                // 2. ls -la on the file (LOOKUP+GETATTR) refreshes the per-file
-                //    attribute cache for an already-known file whose mtime changed.
-                // Both are needed: the file-only ls does nothing when the file is new.
-                def sshStatCmd = Utils.sshUserCmd(remote, "\"ls '${remoteWorkspaceTrk}/' > /dev/null 2>&1; ls -la '${remoteWorkspaceTrk}/results.xml' > /dev/null 2>&1; stat -c %Y '${remoteWorkspaceTrk}/results.xml' 2>/dev/null || echo 0\"")
+                // Stat on the compute node via srun --overlap to bypass the login
+                // node's NFS attribute cache.  The login node's NFS client can cache
+                // a stale directory view for up to acdirmax seconds after the compute
+                // node creates results.xml; running stat directly on the node that
+                // wrote the file avoids this cross-client visibility window entirely.
+                // After the mtime check confirms a change, sshRefreshCacheCmd primes
+                // the login node's NFS cache before the SCP step reads the file.
+                def sshStatCmd = Utils.sshUserCmd(remote, "\"srun --overlap --quiet --jobid='${slurmJobId}' --ntasks=1 stat -c %Y '${remoteWorkspaceTrk}/results.xml' 2>/dev/null || echo 0\"")
                 def scpXmlCmd = scpFromRemoteCmd(remote, "${remoteWorkspaceTrk}/results*.xml", "${stageName}/")
                 def scpUnfinishedCmd = scpFromRemoteCmd(remote, "${remoteWorkspaceTrk}/unfinished_test.txt", "${stageName}/")
                 def sshRefreshCacheCmd = Utils.sshUserCmd(remote, "\"ls '${remoteWorkspaceTrk}/' > /dev/null 2>&1; ls -la '${remoteWorkspaceTrk}/results.xml' > /dev/null 2>&1 || true\"")
@@ -2080,6 +2081,7 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                         PROGRESS_INTERVAL=${PROGRESS_UPLOAD_INTERVAL_SEC} \\
                         LABEL_PREFIX='sbatch checkpoint' \\
                         SLURM_SSH_STAT_CMD='${sshStatCmd}' \\
+                        SLURM_SSH_REFRESH_CACHE_CMD='${sshRefreshCacheCmd}' \\
                         SLURM_SCP_XML_CMD='${scpXmlCmd}' \\
                         SLURM_SCP_UNFINISHED_CMD='${scpUnfinishedCmd}' \\
                         SLURM_SSH_LIST_PERF_CMD='${sshListPerfCmd}' \\

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -180,6 +180,12 @@ SLURM_NON_TERMINAL_STATES = [
     "REQUEUED", "RESIZING", "SUSPENDED", "SIGNALING", "STOPPED",
 ]
 
+// How often the periodicUploadProgress watcher snapshots the in-progress
+// ${stageName}/ directory (containing the PeriodicJUnitXML reporter's
+// results.xml) up to Artifactory. 5 minutes balances Artifactory traffic
+// against staleness for multi-hour test stages.
+PROGRESS_UPLOAD_INTERVAL_SEC = 300
+
 // Typed-exception hierarchy and FailureClassifier (PATTERN_CATALOG, classify(),
 // flattenThrowable) live in trtllm-jenkins-shared-lib under src/trtllm/. They
 // were originally inline here, but the Jenkins script-security sandbox
@@ -1466,6 +1472,12 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
     // a retryable infra failure (a retry follows) -- otherwise a stage that fails
     // an intermediate attempt and passes on retry leaves the build UNSTABLE.
     def caughtStageError = null
+    // Tracks whether the Run Pytest stage's track step returned without
+    // throwing. Only on `true` do we sweep this stage's progress tar from
+    // Artifactory in the finally block (forensic tars from failed runs are
+    // kept). Set after the `node(...)` block; defaults to false so any
+    // earlier-thrown exception leaves the progress tar untouched.
+    def pytestSucceeded = false
 
     try {
         // Run ssh command to start node in desired cluster via SLURM
@@ -2074,13 +2086,27 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                 // -- it fails the closure over to another frontend and the submit guard
                 // reuses the still-active job -- so the monitor needs no same-frontend
                 // retries of its own.
-                Utils.exec(
-                    pipeline,
-                    timeout: false,
-                    script: Utils.sshUserCmd(
-                        remote,
-                        scriptTrackPathNode
-                    )
+                def pytestDoneFile = "${WORKSPACE}/.pytest-done-${stageName}"
+                sh "rm -f ${pytestDoneFile}"
+                parallel(
+                    'track': {
+                        try {
+                            Utils.exec(
+                                pipeline,
+                                timeout: false,
+                                script: Utils.sshUserCmd(
+                                    remote,
+                                    scriptTrackPathNode
+                                )
+                            )
+                        } finally {
+                            sh "touch ${pytestDoneFile}"
+                        }
+                    },
+                    'progress-upload': {
+                        periodicUploadProgressSlurm(pipeline, remote, jobUID, stageName, pytestDoneFile)
+                    },
+                    failFast: false,
                 )
 
                 // Verdict: "<STATE> <EXIT_CODE>"; success is COMPLETED + exit 0.
@@ -2138,6 +2164,8 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
             echo "Finished test stage execution."
             }  // end CloudManager.withSlurmFrontendFailover
         }  // end withCredentials
+        // Reached only if no stage above (Initialize Test, Run Pytest) threw.
+        pytestSucceeded = true
     } catch (InterruptedException e) {
         stageIsInterrupted = true
         throw e
@@ -2155,6 +2183,11 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
             boolean suppressTestReporting = (caughtStageError != null && retryContext != null) &&
                 retryContextAllowsRetry(null, retryContext, caughtStageError, false)
             uploadResults(pipeline, cluster, partition.clusterName, jobUID, stageName, stageIsInterrupted, postTag, suppressTestReporting)
+            if (pytestSucceeded) {
+                // pytest reached its natural end: drop the in-progress checkpoint
+                // tar; the final tar just uploaded by uploadResults supersedes it.
+                deleteProgressArtifact(stageName)
+            }
         } finally {
             stage("Clean Up Slurm Resource") {
                 // Workaround to handle the interruption during clean up SLURM resources
@@ -3943,6 +3976,145 @@ REUSED_TESTS_EOF
     }
 }
 
+// Watcher that runs alongside pytest and periodically snapshots the stage's
+// in-progress test-results directory to Artifactory under a separate
+// `test-results-progress/` path. The PeriodicJUnitXML pytest plugin already
+// rewrites `${WORKSPACE}/${stageName}/results.xml` atomically every batch;
+// this function snapshots whatever is on disk so a pod eviction / SIGKILL
+// that prevents the stage's `finally` upload still leaves a usable
+// checkpoint behind.
+//
+// Polls the XML's mtime so unchanged files are skipped. Upload failures are
+// logged and swallowed -- the watcher must never break the pytest branch.
+// Exits cleanly when ${sentinelPath} appears (touched by the pytest branch's
+// `finally`) or on interrupt.
+//
+// Progress tarballs use a `-progress.tar.gz` suffix so they do not collide
+// with the final stage tar's `ensureStageResultNotUploaded` guard.
+def periodicUploadProgress(stageName, sentinelPath, intervalSec = PROGRESS_UPLOAD_INTERVAL_SEC) {
+    def xmlPath = "${WORKSPACE}/${stageName}/results.xml"
+    def progressTar = "results-${stageName}-progress.tar.gz"
+    def remoteTarget = "${UPLOAD_PATH}/test-results-progress/"
+    long lastMtime = 0
+    try {
+        while (!fileExists(sentinelPath)) {
+            sleep(intervalSec)
+            if (fileExists(sentinelPath)) break
+            if (!fileExists(xmlPath)) continue
+            try {
+                def mtimeStr = sh(returnStdout: true,
+                                  script: "stat -c %Y '${xmlPath}' 2>/dev/null || echo 0").trim()
+                long mtime = mtimeStr ? (mtimeStr as long) : 0L
+                if (mtime <= lastMtime) continue
+                lastMtime = mtime
+                sh "tar -czf ${progressTar} ${stageName}/"
+                trtllm_utils.uploadArtifacts(progressTar, remoteTarget)
+                echo "[PROGRESS-UPLOAD] ${stageName}: uploaded checkpoint (mtime=${mtime})"
+            } catch (InterruptedException ie) {
+                throw ie
+            } catch (Exception ue) {
+                echo "[PROGRESS-UPLOAD] ${stageName}: upload iteration failed (non-fatal): ${ue.message}"
+            }
+        }
+        echo "[PROGRESS-UPLOAD] ${stageName}: pytest done, watcher exiting"
+    } catch (InterruptedException e) {
+        echo "[PROGRESS-UPLOAD] ${stageName}: watcher interrupted, exiting"
+        throw e
+    }
+}
+
+// SLURM-sbatch variant of periodicUploadProgress. Used by
+// runLLMTestlistWithSbatch where pytest runs on a SLURM compute node (no
+// Jenkins agent) and writes results to /home/svc_tensorrt/bloom/scripts/
+// ${jobUID}/ on the SLURM front-end node, mounted-shared with the compute
+// node. The watcher runs on the Jenkins controller: SSH-stats the remote
+// XML's mtime; on advance, SCPs the latest results*.xml into the
+// controller's ${WORKSPACE}/${stageName}/ then tars + uploads via the
+// existing trtllm_utils.uploadArtifacts.
+//
+// Only XML files are fetched (no perf folders) -- those are written at
+// session end and would just bloat each checkpoint without adding recovery
+// value. Failures inside the loop are echoed and swallowed; only
+// InterruptedException escapes.
+def periodicUploadProgressSlurm(pipeline, Map remote, String jobUID, String stageName,
+                                String sentinelPath, int intervalSec = PROGRESS_UPLOAD_INTERVAL_SEC) {
+    def remoteWorkspace = "/home/svc_tensorrt/bloom/scripts/${jobUID}"
+    def remoteXmlGlob = "${remoteWorkspace}/results*.xml"
+    def remoteMtimeProbe = "${remoteWorkspace}/results.xml"
+    def progressTar = "results-${stageName}-progress.tar.gz"
+    def remoteTarget = "${UPLOAD_PATH}/test-results-progress/"
+    long lastMtime = 0
+    try {
+        while (!fileExists(sentinelPath)) {
+            sleep(intervalSec)
+            if (fileExists(sentinelPath)) break
+            try {
+                def mtimeStr = Utils.exec(
+                    pipeline,
+                    script: Utils.sshUserCmd(remote,
+                        "\"stat -c %Y ${remoteMtimeProbe} 2>/dev/null || echo 0\""),
+                    returnStdout: true,
+                    numRetries: 1,
+                ).trim()
+                long mtime = mtimeStr.isNumber() ? (mtimeStr as long) : 0L
+                if (mtime <= lastMtime) continue
+                lastMtime = mtime
+                sh "mkdir -p ${stageName}"
+                def scpRc = Utils.exec(
+                    pipeline,
+                    script: scpFromRemoteCmd(remote, remoteXmlGlob, "${stageName}/"),
+                    returnStatus: true,
+                    numRetries: 1,
+                )
+                if (scpRc != 0) {
+                    echo "[PROGRESS-UPLOAD] ${stageName}: scp returned ${scpRc}; skipping this iteration"
+                    continue
+                }
+                sh "tar -czf ${progressTar} ${stageName}/"
+                trtllm_utils.uploadArtifacts(progressTar, remoteTarget)
+                echo "[PROGRESS-UPLOAD] ${stageName}: uploaded sbatch checkpoint (mtime=${mtime})"
+            } catch (InterruptedException ie) {
+                throw ie
+            } catch (Exception ue) {
+                echo "[PROGRESS-UPLOAD] ${stageName}: upload iteration failed (non-fatal): ${ue.message}"
+            }
+        }
+        echo "[PROGRESS-UPLOAD] ${stageName}: track done, watcher exiting"
+    } catch (InterruptedException e) {
+        echo "[PROGRESS-UPLOAD] ${stageName}: watcher interrupted, exiting"
+        throw e
+    }
+}
+
+// Removes the in-progress checkpoint tarball this stage uploaded via
+// periodicUploadProgress. Called only when the pytest+rerun execution
+// succeeded -- forensic checkpoints from failed runs are kept so the
+// orphan reflects "this attempt did not finish cleanly".
+//
+// Build-scoped: ${UPLOAD_PATH} is per-build, so unswept progress tars are
+// garbage-collected with the rest of the build's artifacts anyway.
+def deleteProgressArtifact(stageName) {
+    def target = "${UPLOAD_PATH}/test-results-progress/results-${stageName}-progress.tar.gz"
+    try {
+        rtServer(
+            id: 'Artifactory',
+            url: 'https://urm.nvidia.com/artifactory',
+            credentialsId: 'urm-artifactory-creds',
+            bypassProxy: true,
+            timeout: 300,
+        )
+        rtDelete(
+            serverId: 'Artifactory',
+            spec: """{ "files": [ { "pattern": "${target}" } ] }""",
+        )
+        echo "[PROGRESS-UPLOAD] ${stageName}: deleted progress tar ${target}"
+    } catch (InterruptedException e) {
+        throw e
+    } catch (Exception e) {
+        echo "[PROGRESS-UPLOAD] ${stageName}: progress tar delete failed (non-fatal): ${e.message}"
+    }
+}
+
 /**
  * Decode a postTag into the postTags used by prior attempts of the same
  * stage in this build.
@@ -4281,26 +4453,45 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
                 string(credentialsId: 'llm_evaltool_repo_url', variable: 'EVALTOOL_REPO_URL')
             ]) {
                 sh "env | sort"
+                // Sentinel that the watcher polls to know pytest has exited
+                // (success or failure). Lives outside ${stageName}/ so the
+                // `rm -rf ${stageName}/` at pytest startup doesn't wipe it.
+                def pytestDoneFile = "${WORKSPACE}/.pytest-done-${stageName}"
+                sh "rm -f ${pytestDoneFile}"
                 try {
-                    if (preprocessedLists.regularCount > 0) {
-                        sh """
-                            rm -rf ${stageName}/ && \
-                            cd ${llmSrc}/tests/integration/defs && \
-                            ${pytestCommand.join(" ")}
-                        """
-                    } else {
-                        echo "No regular tests to run for stage ${stageName}"
-                        noRegularTests = true
-                        sh "mkdir -p ${stageName}"
-                        // Create an empty results.xml file for consistency
-                        sh """
-                            echo '<?xml version="1.0" encoding="UTF-8"?>' > ${stageName}/results.xml
-                            echo '<testsuites>' >> ${stageName}/results.xml
-                            echo '<testsuite name="${stageName}" errors="0" failures="0" skipped="0" tests="0" time="0.0">' >> ${stageName}/results.xml
-                            echo '</testsuite>' >> ${stageName}/results.xml
-                            echo '</testsuites>' >> ${stageName}/results.xml
-                        """
-                    }
+                    parallel(
+                        'pytest': {
+                            try {
+                                if (preprocessedLists.regularCount > 0) {
+                                    sh """
+                                        rm -rf ${stageName}/ && \
+                                        cd ${llmSrc}/tests/integration/defs && \
+                                        ${pytestCommand.join(" ")}
+                                    """
+                                } else {
+                                    echo "No regular tests to run for stage ${stageName}"
+                                    noRegularTests = true
+                                    sh "mkdir -p ${stageName}"
+                                    // Create an empty results.xml file for consistency
+                                    sh """
+                                        echo '<?xml version="1.0" encoding="UTF-8"?>' > ${stageName}/results.xml
+                                        echo '<testsuites>' >> ${stageName}/results.xml
+                                        echo '<testsuite name="${stageName}" errors="0" failures="0" skipped="0" tests="0" time="0.0">' >> ${stageName}/results.xml
+                                        echo '</testsuite>' >> ${stageName}/results.xml
+                                        echo '</testsuites>' >> ${stageName}/results.xml
+                                    """
+                                }
+                            } finally {
+                                // Touched in finally so the watcher exits whether
+                                // pytest succeeded, failed, or was interrupted.
+                                sh "touch ${pytestDoneFile}"
+                            }
+                        },
+                        'progress-upload': {
+                            periodicUploadProgress(stageName, pytestDoneFile)
+                        },
+                        failFast: false,
+                    )
                 } catch (InterruptedException e) {
                     throw e
                 } catch (Exception e) {
@@ -4360,6 +4551,13 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
         if (fileExists("${stageName}/results-timeout.xml") || generateTimeoutTestResultXml(pipeline, stageName)) {
             error "Some tests terminated unexpectedly, please check the test report."
         }
+
+        // pytest succeeded (possibly after rerun) -- the in-progress checkpoint
+        // tar is no longer needed; the stage's `finally` will upload the final
+        // results tar shortly. Drop the progress tar so consumers don't pick
+        // up a stale snapshot. Forensic tars from failed runs are intentionally
+        // left in place.
+        deleteProgressArtifact(stageName)
 
         if (perfMode) {
             // Only PyTorch perf stages remain; the TensorRT perf baseline was removed.

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -180,7 +180,7 @@ SLURM_NON_TERMINAL_STATES = [
     "REQUEUED", "RESIZING", "SUSPENDED", "SIGNALING", "STOPPED",
 ]
 
-// How often the periodicUploadProgress watcher snapshots the in-progress
+// How often the background shell watcher snapshots the in-progress
 // ${stageName}/ directory (containing the PeriodicJUnitXML reporter's
 // results.xml) up to Artifactory. 5 minutes balances Artifactory traffic
 // against staleness for multi-hour test stages.
@@ -2087,27 +2087,62 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                 // reuses the still-active job -- so the monitor needs no same-frontend
                 // retries of its own.
                 def pytestDoneFile = "${WORKSPACE}/.pytest-done-${stageName}"
+                def progressTar = "results-${stageName}-progress.tar.gz"
+                def progressUrl = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/test-results-progress/${progressTar}"
+                def remoteWorkspaceTrk = "/home/svc_tensorrt/bloom/scripts/${jobUID}"
+                def trackCmd = Utils.sshUserCmd(remote, scriptTrackPathNode)
+                def sshStatCmd = Utils.sshUserCmd(remote, "\"stat -c %Y ${remoteWorkspaceTrk}/results.xml 2>/dev/null || echo 0\"")
+                def scpXmlCmd = scpFromRemoteCmd(remote, "${remoteWorkspaceTrk}/results*.xml", "${stageName}/")
                 sh "rm -f ${pytestDoneFile}"
-                parallel(
-                    'track': {
-                        try {
-                            Utils.exec(
-                                pipeline,
-                                timeout: false,
-                                script: Utils.sshUserCmd(
-                                    remote,
-                                    scriptTrackPathNode
-                                )
-                            )
-                        } finally {
-                            sh "touch ${pytestDoneFile}"
-                        }
-                    },
-                    'progress-upload': {
-                        periodicUploadProgressSlurm(pipeline, remote, jobUID, stageName, pytestDoneFile)
-                    },
-                    failFast: false,
-                )
+                withCredentials([usernamePassword(
+                        credentialsId: 'urm-artifactory-creds',
+                        usernameVariable: 'ART_USER',
+                        passwordVariable: 'ART_PASS')]) {
+                    sh """
+                        set +e
+                        # ---- background watcher: SSH-stat remote XML, SCP, tar, upload ----
+                        (
+                            last=0
+                            while [ ! -f '${pytestDoneFile}' ]; do
+                                sleep ${PROGRESS_UPLOAD_INTERVAL_SEC}
+                                [ -f '${pytestDoneFile}' ] && break
+                                m=\$(${sshStatCmd} 2>/dev/null | tr -dc '0-9')
+                                [ -z "\$m" ] && m=0
+                                [ "\$m" -le "\$last" ] && continue
+                                last=\$m
+                                mkdir -p '${WORKSPACE}/${stageName}'
+                                if ! ${scpXmlCmd}; then
+                                    echo "[PROGRESS-UPLOAD] ${stageName}: scp failed; skipping this iteration"
+                                    continue
+                                fi
+                                ( cd '${WORKSPACE}' && tar -czf '${progressTar}' '${stageName}/' ) || continue
+                                if curl -fsSL --retry 2 -u "\$ART_USER:\$ART_PASS" \\
+                                        -T '${WORKSPACE}/${progressTar}' '${progressUrl}'; then
+                                    echo "[PROGRESS-UPLOAD] ${stageName}: uploaded sbatch checkpoint (mtime=\$m)"
+                                else
+                                    echo "[PROGRESS-UPLOAD] ${stageName}: upload iteration failed (non-fatal)"
+                                fi
+                            done
+                            echo "[PROGRESS-UPLOAD] ${stageName}: track done, watcher exiting"
+                        ) &
+                        WATCHER_PID=\$!
+
+                        # ---- foreground track: retry up to 3 times on failure ----
+                        attempt=0
+                        rc=1
+                        while [ \$attempt -lt 3 ]; do
+                            ${trackCmd}
+                            rc=\$?
+                            [ \$rc -eq 0 ] && break
+                            attempt=\$((attempt+1))
+                            [ \$attempt -lt 3 ] && echo "Track failed (rc=\$rc), retry \$attempt/3" && sleep 30
+                        done
+
+                        touch '${pytestDoneFile}'
+                        wait \$WATCHER_PID 2>/dev/null || true
+                        exit \$rc
+                    """
+                }
 
                 // Verdict: "<STATE> <EXIT_CODE>"; success is COMPLETED + exit 0.
                 def jobResult = readSlurmWorkspaceFile(pipeline, remote, "${jobWorkspace}/slurm_job_result.txt", stageName, 3)
@@ -3976,118 +4011,9 @@ REUSED_TESTS_EOF
     }
 }
 
-// Watcher that runs alongside pytest and periodically snapshots the stage's
-// in-progress test-results directory to Artifactory under a separate
-// `test-results-progress/` path. The PeriodicJUnitXML pytest plugin already
-// rewrites `${WORKSPACE}/${stageName}/results.xml` atomically every batch;
-// this function snapshots whatever is on disk so a pod eviction / SIGKILL
-// that prevents the stage's `finally` upload still leaves a usable
-// checkpoint behind.
-//
-// Polls the XML's mtime so unchanged files are skipped. Upload failures are
-// logged and swallowed -- the watcher must never break the pytest branch.
-// Exits cleanly when ${sentinelPath} appears (touched by the pytest branch's
-// `finally`) or on interrupt.
-//
-// Progress tarballs use a `-progress.tar.gz` suffix so they do not collide
-// with the final stage tar's `ensureStageResultNotUploaded` guard.
-def periodicUploadProgress(stageName, sentinelPath, intervalSec = PROGRESS_UPLOAD_INTERVAL_SEC) {
-    def xmlPath = "${WORKSPACE}/${stageName}/results.xml"
-    def progressTar = "results-${stageName}-progress.tar.gz"
-    def remoteTarget = "${UPLOAD_PATH}/test-results-progress/"
-    long lastMtime = 0
-    try {
-        while (!fileExists(sentinelPath)) {
-            sleep(intervalSec)
-            if (fileExists(sentinelPath)) break
-            if (!fileExists(xmlPath)) continue
-            try {
-                def mtimeStr = sh(returnStdout: true,
-                                  script: "stat -c %Y '${xmlPath}' 2>/dev/null || echo 0").trim()
-                long mtime = mtimeStr ? (mtimeStr as long) : 0L
-                if (mtime <= lastMtime) continue
-                lastMtime = mtime
-                sh "tar -czf ${progressTar} ${stageName}/"
-                trtllm_utils.uploadArtifacts(progressTar, remoteTarget)
-                echo "[PROGRESS-UPLOAD] ${stageName}: uploaded checkpoint (mtime=${mtime})"
-            } catch (InterruptedException ie) {
-                throw ie
-            } catch (Exception ex) {
-                echo "[PROGRESS-UPLOAD] ${stageName}: upload iteration failed (non-fatal): ${ex.message}"
-            }
-        }
-        echo "[PROGRESS-UPLOAD] ${stageName}: pytest done, watcher exiting"
-    } catch (InterruptedException e) {
-        echo "[PROGRESS-UPLOAD] ${stageName}: watcher interrupted, exiting"
-        throw e
-    }
-}
-
-// SLURM-sbatch variant of periodicUploadProgress. Used by
-// runLLMTestlistWithSbatch where pytest runs on a SLURM compute node (no
-// Jenkins agent) and writes results to /home/svc_tensorrt/bloom/scripts/
-// ${jobUID}/ on the SLURM front-end node, mounted-shared with the compute
-// node. The watcher runs on the Jenkins controller: SSH-stats the remote
-// XML's mtime; on advance, SCPs the latest results*.xml into the
-// controller's ${WORKSPACE}/${stageName}/ then tars + uploads via the
-// existing trtllm_utils.uploadArtifacts.
-//
-// Only XML files are fetched (no perf folders) -- those are written at
-// session end and would just bloat each checkpoint without adding recovery
-// value. Failures inside the loop are echoed and swallowed; only
-// InterruptedException escapes.
-def periodicUploadProgressSlurm(pipeline, Map remote, String jobUID, String stageName,
-                                String sentinelPath, int intervalSec = PROGRESS_UPLOAD_INTERVAL_SEC) {
-    def remoteWorkspace = "/home/svc_tensorrt/bloom/scripts/${jobUID}"
-    def remoteXmlGlob = "${remoteWorkspace}/results*.xml"
-    def remoteMtimeProbe = "${remoteWorkspace}/results.xml"
-    def progressTar = "results-${stageName}-progress.tar.gz"
-    def remoteTarget = "${UPLOAD_PATH}/test-results-progress/"
-    long lastMtime = 0
-    try {
-        while (!fileExists(sentinelPath)) {
-            sleep(intervalSec)
-            if (fileExists(sentinelPath)) break
-            try {
-                def mtimeStr = Utils.exec(
-                    pipeline,
-                    script: Utils.sshUserCmd(remote,
-                        "\"stat -c %Y ${remoteMtimeProbe} 2>/dev/null || echo 0\""),
-                    returnStdout: true,
-                    numRetries: 1,
-                ).trim()
-                long mtime = mtimeStr.isNumber() ? (mtimeStr as long) : 0L
-                if (mtime <= lastMtime) continue
-                lastMtime = mtime
-                sh "mkdir -p ${stageName}"
-                def scpRc = Utils.exec(
-                    pipeline,
-                    script: scpFromRemoteCmd(remote, remoteXmlGlob, "${stageName}/"),
-                    returnStatus: true,
-                    numRetries: 1,
-                )
-                if (scpRc != 0) {
-                    echo "[PROGRESS-UPLOAD] ${stageName}: scp returned ${scpRc}; skipping this iteration"
-                    continue
-                }
-                sh "tar -czf ${progressTar} ${stageName}/"
-                trtllm_utils.uploadArtifacts(progressTar, remoteTarget)
-                echo "[PROGRESS-UPLOAD] ${stageName}: uploaded sbatch checkpoint (mtime=${mtime})"
-            } catch (InterruptedException ie) {
-                throw ie
-            } catch (Exception ex) {
-                echo "[PROGRESS-UPLOAD] ${stageName}: upload iteration failed (non-fatal): ${ex.message}"
-            }
-        }
-        echo "[PROGRESS-UPLOAD] ${stageName}: track done, watcher exiting"
-    } catch (InterruptedException e) {
-        echo "[PROGRESS-UPLOAD] ${stageName}: watcher interrupted, exiting"
-        throw e
-    }
-}
-
-// Removes the in-progress checkpoint tarball this stage uploaded via
-// periodicUploadProgress. Called only when the pytest+rerun execution
+// Removes the in-progress checkpoint tarball uploaded by the inline
+// shell watcher in runLLMTestlistOnPlatformImpl / runLLMTestlistWithSbatch.
+// Called only when the pytest+rerun execution
 // succeeded -- forensic checkpoints from failed runs are kept so the
 // orphan reflects "this attempt did not finish cleanly".
 //
@@ -4457,41 +4383,70 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
                 // (success or failure). Lives outside ${stageName}/ so the
                 // `rm -rf ${stageName}/` at pytest startup doesn't wipe it.
                 def pytestDoneFile = "${WORKSPACE}/.pytest-done-${stageName}"
+                def progressTar = "results-${stageName}-progress.tar.gz"
+                def progressUrl = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/test-results-progress/${progressTar}"
                 sh "rm -f ${pytestDoneFile}"
                 try {
-                    parallel(
-                        'pytest': {
-                            try {
-                                if (preprocessedLists.regularCount > 0) {
-                                    sh """
-                                        rm -rf ${stageName}/ && \
-                                        cd ${llmSrc}/tests/integration/defs && \
-                                        ${pytestCommand.join(" ")}
-                                    """
-                                } else {
-                                    echo "No regular tests to run for stage ${stageName}"
-                                    noRegularTests = true
-                                    sh "mkdir -p ${stageName}"
-                                    // Create an empty results.xml file for consistency
-                                    sh """
-                                        echo '<?xml version="1.0" encoding="UTF-8"?>' > ${stageName}/results.xml
-                                        echo '<testsuites>' >> ${stageName}/results.xml
-                                        echo '<testsuite name="${stageName}" errors="0" failures="0" skipped="0" tests="0" time="0.0">' >> ${stageName}/results.xml
-                                        echo '</testsuite>' >> ${stageName}/results.xml
-                                        echo '</testsuites>' >> ${stageName}/results.xml
-                                    """
-                                }
-                            } finally {
-                                // Touched in finally so the watcher exits whether
-                                // pytest succeeded, failed, or was interrupted.
-                                sh "touch ${pytestDoneFile}"
-                            }
-                        },
-                        'progress-upload': {
-                            periodicUploadProgress(stageName, pytestDoneFile)
-                        },
-                        failFast: false,
-                    )
+                    if (preprocessedLists.regularCount > 0) {
+                        // Run pytest in the foreground while a shell subshell
+                        // watcher periodically tars + uploads results.xml. The
+                        // watcher is a background subshell of the same `sh`
+                        // step (not a Groovy parallel branch) so Blue Ocean
+                        // renders the stage as a single box rather than a
+                        // nested parallel split.
+                        withCredentials([usernamePassword(
+                                credentialsId: 'urm-artifactory-creds',
+                                usernameVariable: 'ART_USER',
+                                passwordVariable: 'ART_PASS')]) {
+                            sh """
+                                set +e
+                                # ---- background watcher ----
+                                (
+                                    last=0
+                                    while [ ! -f '${pytestDoneFile}' ]; do
+                                        sleep ${PROGRESS_UPLOAD_INTERVAL_SEC}
+                                        [ -f '${pytestDoneFile}' ] && break
+                                        xml='${WORKSPACE}/${stageName}/results.xml'
+                                        m=\$(stat -c %Y "\$xml" 2>/dev/null || echo 0)
+                                        [ "\$m" -le "\$last" ] && continue
+                                        last=\$m
+                                        ( cd '${WORKSPACE}' && tar -czf '${progressTar}' '${stageName}/' ) || continue
+                                        if curl -fsSL --retry 2 -u "\$ART_USER:\$ART_PASS" \\
+                                                -T '${WORKSPACE}/${progressTar}' '${progressUrl}'; then
+                                            echo "[PROGRESS-UPLOAD] ${stageName}: uploaded checkpoint (mtime=\$m)"
+                                        else
+                                            echo "[PROGRESS-UPLOAD] ${stageName}: upload iteration failed (non-fatal)"
+                                        fi
+                                    done
+                                    echo "[PROGRESS-UPLOAD] ${stageName}: pytest done, watcher exiting"
+                                ) &
+                                WATCHER_PID=\$!
+
+                                # ---- foreground pytest ----
+                                rm -rf '${stageName}/'
+                                cd '${llmSrc}/tests/integration/defs'
+                                ${pytestCommand.join(" ")}
+                                rc=\$?
+
+                                touch '${pytestDoneFile}'
+                                wait \$WATCHER_PID 2>/dev/null || true
+                                exit \$rc
+                            """
+                        }
+                    } else {
+                        echo "No regular tests to run for stage ${stageName}"
+                        noRegularTests = true
+                        sh "mkdir -p ${stageName}"
+                        // Create an empty results.xml file for consistency
+                        sh """
+                            echo '<?xml version="1.0" encoding="UTF-8"?>' > ${stageName}/results.xml
+                            echo '<testsuites>' >> ${stageName}/results.xml
+                            echo '<testsuite name="${stageName}" errors="0" failures="0" skipped="0" tests="0" time="0.0">' >> ${stageName}/results.xml
+                            echo '</testsuite>' >> ${stageName}/results.xml
+                            echo '</testsuites>' >> ${stageName}/results.xml
+                        """
+                        sh "touch ${pytestDoneFile}"
+                    }
                 } catch (InterruptedException e) {
                     throw e
                 } catch (Exception e) {

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2086,6 +2086,12 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                 // -- it fails the closure over to another frontend and the submit guard
                 // reuses the still-active job -- so the monitor needs no same-frontend
                 // retries of its own.
+                // Track the Slurm job alongside a controller-side watcher
+                // that SSH-stats the remote results.xml and SCPs / uploads
+                // a progress tar whenever the file's mtime advances. Both
+                // run inside a single `sh` step (track in foreground, watcher
+                // as a background subshell) so Blue Ocean renders the stage
+                // as a single box instead of a nested parallel split.
                 def pytestDoneFile = "${WORKSPACE}/.pytest-done-${stageName}"
                 def progressTar = "results-${stageName}-progress.tar.gz"
                 def progressUrl = "https://urm.nvidia.com/artifactory/${UPLOAD_PATH}/test-results-progress/${progressTar}"
@@ -2104,25 +2110,12 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
                         export PROGRESS_TAR='${progressTar}'
                         export PROGRESS_URL='${progressUrl}'
                         # ---- background watcher: SSH-stat remote XML, SCP, tar, upload ----
-                        (
-                            last=0
-                            while [ ! -f '${pytestDoneFile}' ]; do
-                                sleep ${PROGRESS_UPLOAD_INTERVAL_SEC}
-                                [ -f '${pytestDoneFile}' ] && break
-                                m=\$(${sshStatCmd} 2>/dev/null | tr -dc '0-9')
-                                [ -z "\$m" ] && m=0
-                                [ "\$m" -le "\$last" ] && continue
-                                last=\$m
-                                mkdir -p '${WORKSPACE}/${stageName}'
-                                if ! ${scpXmlCmd}; then
-                                    echo "[PROGRESS-UPLOAD] ${stageName}: scp failed; skipping this iteration"
-                                    continue
-                                fi
-                                LABEL="sbatch checkpoint (mtime=\$m)" \\
-                                bash '${WORKSPACE}/jenkins/scripts/progress_upload_snapshot.sh' || continue
-                            done
-                            echo "[PROGRESS-UPLOAD] ${stageName}: track done, watcher exiting"
-                        ) &
+                        PROGRESS_DONE_FILE='${pytestDoneFile}' \\
+                        PROGRESS_INTERVAL=${PROGRESS_UPLOAD_INTERVAL_SEC} \\
+                        LABEL_PREFIX='sbatch checkpoint' \\
+                        SLURM_SSH_STAT_CMD='${sshStatCmd}' \\
+                        SLURM_SCP_XML_CMD='${scpXmlCmd}' \\
+                        bash '${WORKSPACE}/jenkins/scripts/progress_upload_watcher.sh' &
                         WATCHER_PID=\$!
 
                         # ---- foreground track: retry up to 3 times on failure ----
@@ -3729,15 +3722,10 @@ def rerunFailedTests(stageName, llmSrc, testCmdLine, resultFileName="results.xml
                     export PROGRESS_TAR='${rerunProgressTar}'
                     export PROGRESS_URL='${rerunProgressUrl}'
                     # ---- background watcher for rerun${times} ----
-                    (
-                        while [ ! -f '${rerunDoneFile}' ]; do
-                            sleep ${PROGRESS_UPLOAD_INTERVAL_SEC}
-                            [ -f '${rerunDoneFile}' ] && break
-                            LABEL='rerun${times} checkpoint' \\
-                            bash '${WORKSPACE}/jenkins/scripts/progress_upload_snapshot.sh' || continue
-                        done
-                        echo "[PROGRESS-UPLOAD] ${stageName}: rerun${times} watcher exiting"
-                    ) &
+                    PROGRESS_DONE_FILE='${rerunDoneFile}' \\
+                    PROGRESS_INTERVAL=${PROGRESS_UPLOAD_INTERVAL_SEC} \\
+                    LABEL_PREFIX='rerun${times} checkpoint' \\
+                    bash '${WORKSPACE}/jenkins/scripts/progress_upload_watcher.sh' &
                     WATCHER_PID=\$!
 
                     # ---- foreground rerun ----
@@ -4449,20 +4437,11 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
                                 export PROGRESS_TAR='${progressTar}'
                                 export PROGRESS_URL='${progressUrl}'
                                 # ---- background watcher ----
-                                (
-                                    last=0
-                                    while [ ! -f '${pytestDoneFile}' ]; do
-                                        sleep ${PROGRESS_UPLOAD_INTERVAL_SEC}
-                                        [ -f '${pytestDoneFile}' ] && break
-                                        xml='${WORKSPACE}/${stageName}/results.xml'
-                                        m=\$(stat -c %Y "\$xml" 2>/dev/null || echo 0)
-                                        [ "\$m" -le "\$last" ] && continue
-                                        last=\$m
-                                        LABEL="checkpoint (mtime=\$m)" \\
-                                        bash '${WORKSPACE}/jenkins/scripts/progress_upload_snapshot.sh' || continue
-                                    done
-                                    echo "[PROGRESS-UPLOAD] ${stageName}: pytest done, watcher exiting"
-                                ) &
+                                PROGRESS_DONE_FILE='${pytestDoneFile}' \\
+                                PROGRESS_INTERVAL=${PROGRESS_UPLOAD_INTERVAL_SEC} \\
+                                LABEL_PREFIX='checkpoint' \\
+                                XML_PATH='${WORKSPACE}/${stageName}/results.xml' \\
+                                bash '${WORKSPACE}/jenkins/scripts/progress_upload_watcher.sh' &
                                 WATCHER_PID=\$!
 
                                 # ---- foreground pytest ----

--- a/jenkins/scripts/progress_upload_snapshot.sh
+++ b/jenkins/scripts/progress_upload_snapshot.sh
@@ -7,14 +7,62 @@
 #   PROGRESS_TAR  tar filename (relative to WORKSPACE)
 #   PROGRESS_URL  Artifactory PUT URL
 #   LABEL         short description for log messages (e.g. "checkpoint", "run1 final snapshot")
+#
+# Optional:
+#   PROGRESS_HASH_FILE  path to store the content hash of the last successful upload
+#                       (default: ${WORKSPACE}/${PROGRESS_TAR}.last_hash)
+#                       Set to empty string to disable dedup.
+#   TIMEOUT_XML_SCRIPT  path to generate_timeout_xml.py; when set, regenerates
+#                       results-timeout.xml from unfinished_test.txt before each upload.
 
 set +e
-( cd "$WORKSPACE" && tar -czf "$PROGRESS_TAR" "${STAGE_NAME}/" ) || {
-    echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: ${LABEL} tar failed"
-    exit 1
-}
+
+# --- Generate timeout XML from unfinished_test.txt (final snapshot only) ---
+# Skipped during periodic snapshots so incomplete unfinished_test.txt does not produce premature timeout reports.
+if [ -n "$FINAL_SNAPSHOT" ] && \
+        [ -n "$TIMEOUT_XML_SCRIPT" ] && [ -f "${WORKSPACE}/${STAGE_NAME}/unfinished_test.txt" ]; then
+    ( cd "$WORKSPACE" && python3 "$TIMEOUT_XML_SCRIPT" \
+        --stage-name "$STAGE_NAME" \
+        --test-file-path "unfinished_test.txt" \
+        --output-file "${WORKSPACE}/${STAGE_NAME}/results-timeout.xml" ) 2>/dev/null || true
+fi
+
+# --- Fix testsuite name in XML files (pytest default -> stage name) ---
+find "${WORKSPACE}/${STAGE_NAME}" -name "*.xml" -exec \
+    sed -i "s|testsuite name=\"pytest\"|testsuite name=\"${STAGE_NAME}\"|g" {} + 2>/dev/null || true
+
+# --- Content-based dedup: skip upload when stage directory is unchanged ---
+HASH_FILE="${PROGRESS_HASH_FILE-${WORKSPACE}/${PROGRESS_TAR}.last_hash}"
+if [ -n "$HASH_FILE" ]; then
+    current_hash=$(find "${WORKSPACE}/${STAGE_NAME}" -type f | sort \
+                   | xargs sha256sum 2>/dev/null | sha256sum | awk '{print $1}')
+    last_hash=$(cat "$HASH_FILE" 2>/dev/null || echo "")
+    if [ -n "$current_hash" ] && [ "$current_hash" = "$last_hash" ]; then
+        echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: ${LABEL} content unchanged, skipping upload"
+        exit 0
+    fi
+fi
+
+# Use --transform to rename results*.xml inside the tar when POST_TAG is set,
+# without touching the on-disk files (SCP overwrites them cleanly next iteration).
+if [ -n "$POST_TAG" ]; then
+    ( cd "$WORKSPACE" && tar -czf "$PROGRESS_TAR" \
+        --transform "s|^\(${STAGE_NAME}/results[^/]*\)\.xml$|\1${POST_TAG}.xml|" \
+        "${STAGE_NAME}/" ) || {
+        echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: ${LABEL} tar failed"
+        exit 1
+    }
+else
+    ( cd "$WORKSPACE" && tar -czf "$PROGRESS_TAR" "${STAGE_NAME}/" ) || {
+        echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: ${LABEL} tar failed"
+        exit 1
+    }
+fi
+rm -f "${WORKSPACE}/${PROGRESS_TAR}.upload_ok" 2>/dev/null || true
 if curl -fsSL --retry 2 -u "$ART_USER:$ART_PASS" \
         -T "${WORKSPACE}/${PROGRESS_TAR}" "$PROGRESS_URL"; then
+    [ -n "$HASH_FILE" ] && echo "$current_hash" > "$HASH_FILE"
+    touch "${WORKSPACE}/${PROGRESS_TAR}.upload_ok" 2>/dev/null || true
     echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: ${LABEL} uploaded"
 else
     echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: ${LABEL} upload failed (non-fatal)"

--- a/jenkins/scripts/progress_upload_snapshot.sh
+++ b/jenkins/scripts/progress_upload_snapshot.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Tar the stage results directory and upload a progress snapshot to Artifactory.
+# Exits 0 on success, 1 on failure (logs the outcome either way).
+#
+# Required env vars (WORKSPACE/ART_USER/ART_PASS are injected by Jenkins/withCredentials):
+#   STAGE_NAME    stage directory name and log prefix
+#   PROGRESS_TAR  tar filename (relative to WORKSPACE)
+#   PROGRESS_URL  Artifactory PUT URL
+#   LABEL         short description for log messages (e.g. "checkpoint", "run1 final snapshot")
+
+set +e
+( cd "$WORKSPACE" && tar -czf "$PROGRESS_TAR" "${STAGE_NAME}/" ) || {
+    echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: ${LABEL} tar failed"
+    exit 1
+}
+if curl -fsSL --retry 2 -u "$ART_USER:$ART_PASS" \
+        -T "${WORKSPACE}/${PROGRESS_TAR}" "$PROGRESS_URL"; then
+    echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: ${LABEL} uploaded"
+else
+    echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: ${LABEL} upload failed (non-fatal)"
+    exit 1
+fi

--- a/jenkins/scripts/progress_upload_snapshot.sh
+++ b/jenkins/scripts/progress_upload_snapshot.sh
@@ -59,7 +59,7 @@ else
     }
 fi
 rm -f "${WORKSPACE}/${PROGRESS_TAR}.upload_ok" 2>/dev/null || true
-if curl -fsSL --retry 2 -u "$ART_USER:$ART_PASS" \
+if curl -fsSL --retry 2 -o /dev/null -u "$ART_USER:$ART_PASS" \
         -T "${WORKSPACE}/${PROGRESS_TAR}" "$PROGRESS_URL"; then
     [ -n "$HASH_FILE" ] && echo "$current_hash" > "$HASH_FILE"
     touch "${WORKSPACE}/${PROGRESS_TAR}.upload_ok" 2>/dev/null || true

--- a/jenkins/scripts/progress_upload_watcher.sh
+++ b/jenkins/scripts/progress_upload_watcher.sh
@@ -29,11 +29,12 @@ while [ ! -f "$PROGRESS_DONE_FILE" ]; do
     _poll=$((_poll + 1))
 
     if [ -n "$SLURM_SSH_STAT_CMD" ]; then
-        _raw=$(eval "$SLURM_SSH_STAT_CMD" 2>&1)
-        _rc=$?
-        m=$(printf '%s' "$_raw" | tr -dc '0-9')
+        # SLURM_SSH_STAT_CMD runs ls on the remote dir first to flush the NFS
+        # attribute cache, then stats results.xml. Use grep to extract the
+        # integer mtime so SSH banners cannot pollute the value.
+        m=$(eval "$SLURM_SSH_STAT_CMD" 2>/dev/null | grep -oE '^[0-9]+$' | head -1)
         [ -z "$m" ] && m=0
-        echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: poll #${_poll} ssh_rc=${_rc} raw='${_raw}' mtime=${m} last=${last}"
+        echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: poll #${_poll} mtime=${m} last=${last}"
         [ "$m" -le "$last" ] && continue
         last=$m
         mkdir -p "${WORKSPACE}/${STAGE_NAME}"

--- a/jenkins/scripts/progress_upload_watcher.sh
+++ b/jenkins/scripts/progress_upload_watcher.sh
@@ -22,13 +22,18 @@
 
 set +e
 last=0
+_poll=0
 while [ ! -f "$PROGRESS_DONE_FILE" ]; do
     sleep "$PROGRESS_INTERVAL"
     [ -f "$PROGRESS_DONE_FILE" ] && break
+    _poll=$((_poll + 1))
 
     if [ -n "$SLURM_SSH_STAT_CMD" ]; then
-        m=$(eval "$SLURM_SSH_STAT_CMD" 2>/dev/null | tr -dc '0-9')
+        _raw=$(eval "$SLURM_SSH_STAT_CMD" 2>&1)
+        _rc=$?
+        m=$(printf '%s' "$_raw" | tr -dc '0-9')
         [ -z "$m" ] && m=0
+        echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: poll #${_poll} ssh_rc=${_rc} raw='${_raw}' mtime=${m} last=${last}"
         [ "$m" -le "$last" ] && continue
         last=$m
         mkdir -p "${WORKSPACE}/${STAGE_NAME}"

--- a/jenkins/scripts/progress_upload_watcher.sh
+++ b/jenkins/scripts/progress_upload_watcher.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Background progress-upload watcher. Polls for results changes and calls
+# progress_upload_snapshot.sh on each update, until PROGRESS_DONE_FILE appears.
+#
+# Required env vars (WORKSPACE/ART_USER/ART_PASS injected by Jenkins/withCredentials;
+# STAGE_NAME/PROGRESS_TAR/PROGRESS_URL exported by the caller sh block):
+#   PROGRESS_DONE_FILE  sentinel file; watcher exits when it exists
+#   PROGRESS_INTERVAL   poll interval in seconds
+#   LABEL_PREFIX        log label prefix, e.g. "checkpoint", "sbatch checkpoint"
+#
+# SLURM mode (set both to activate):
+#   SLURM_SSH_STAT_CMD  shell command that prints the remote results.xml mtime
+#   SLURM_SCP_XML_CMD   shell command that SCPs remote results*.xml locally
+#
+# Local mode with mtime guard (set to activate; omit for rerun mode):
+#   XML_PATH            path to local results.xml to stat
+
+set +e
+last=0
+while [ ! -f "$PROGRESS_DONE_FILE" ]; do
+    sleep "$PROGRESS_INTERVAL"
+    [ -f "$PROGRESS_DONE_FILE" ] && break
+
+    if [ -n "$SLURM_SSH_STAT_CMD" ]; then
+        m=$(eval "$SLURM_SSH_STAT_CMD" 2>/dev/null | tr -dc '0-9')
+        [ -z "$m" ] && m=0
+        [ "$m" -le "$last" ] && continue
+        last=$m
+        mkdir -p "${WORKSPACE}/${STAGE_NAME}"
+        if ! eval "$SLURM_SCP_XML_CMD"; then
+            echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: scp failed; skipping this iteration"
+            continue
+        fi
+    elif [ -n "$XML_PATH" ]; then
+        m=$(stat -c %Y "$XML_PATH" 2>/dev/null || echo 0)
+        [ "$m" -le "$last" ] && continue
+        last=$m
+    fi
+
+    LABEL="${LABEL_PREFIX}${m:+ (mtime=$m)}" \
+    bash "${WORKSPACE}/jenkins/scripts/progress_upload_snapshot.sh" || continue
+done
+echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: watcher exiting"

--- a/jenkins/scripts/progress_upload_watcher.sh
+++ b/jenkins/scripts/progress_upload_watcher.sh
@@ -9,11 +9,16 @@
 #   LABEL_PREFIX        log label prefix, e.g. "checkpoint", "sbatch checkpoint"
 #
 # SLURM mode (set both to activate):
-#   SLURM_SSH_STAT_CMD  shell command that prints the remote results.xml mtime
-#   SLURM_SCP_XML_CMD   shell command that SCPs remote results*.xml locally
+#   SLURM_SSH_STAT_CMD        shell command that prints the remote results.xml mtime
+#   SLURM_SCP_XML_CMD         shell command that SCPs remote results*.xml locally
+#
+# SLURM mode optional enrichment (non-fatal; each retried up to 3 times):
+#   SLURM_SCP_UNFINISHED_CMD  shell command that SCPs remote unfinished_test.txt locally
+#   SLURM_SSH_LIST_PERF_CMD   shell command that prints remote perf folder paths (one per line)
+#   SLURM_SCP_PERF_TEMPLATE   SCP command with PERF_FOLDER_PLACEHOLDER substituted per folder
 #
 # Local mode with mtime guard (set to activate; omit for rerun mode):
-#   XML_PATH            path to local results.xml to stat
+#   XML_PATH                  path to local results.xml to stat
 
 set +e
 last=0
@@ -27,9 +32,38 @@ while [ ! -f "$PROGRESS_DONE_FILE" ]; do
         [ "$m" -le "$last" ] && continue
         last=$m
         mkdir -p "${WORKSPACE}/${STAGE_NAME}"
-        if ! eval "$SLURM_SCP_XML_CMD"; then
-            echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: scp failed; skipping this iteration"
+        _scp_ok=0
+        for _attempt in 1 2 3; do
+            eval "$SLURM_SCP_XML_CMD" && { _scp_ok=1; break; }
+            echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: scp xml failed, retry ${_attempt}/3"
+            sleep 10
+        done
+        if [ "$_scp_ok" -eq 0 ]; then
+            echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: scp failed after 3 attempts; skipping this iteration"
             continue
+        fi
+        # Fetch unfinished_test.txt for timeout XML generation (retry 3 times)
+        if [ -n "$SLURM_SCP_UNFINISHED_CMD" ]; then
+            _unfinished_ok=0
+            for _attempt in 1 2 3; do
+                eval "$SLURM_SCP_UNFINISHED_CMD" && { _unfinished_ok=1; break; }
+                echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: scp unfinished failed (attempt ${_attempt}/3)"
+                [ "$_attempt" -lt 3 ] && sleep 10
+            done
+            [ "$_unfinished_ok" -eq 0 ] && echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: scp unfinished not available, skipping"
+        fi
+        # Fetch perf result folders (aggr*/disagg*) one by one (retry 3 times each)
+        if [ -n "$SLURM_SSH_LIST_PERF_CMD" ] && [ -n "$SLURM_SCP_PERF_TEMPLATE" ]; then
+            while IFS= read -r folder; do
+                [ -z "$folder" ] && continue
+                _perf_ok=0
+                for _attempt in 1 2 3; do
+                    eval "${SLURM_SCP_PERF_TEMPLATE//PERF_FOLDER_PLACEHOLDER/$folder}" && { _perf_ok=1; break; }
+                    echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: scp perf $folder failed (attempt ${_attempt}/3)"
+                    [ "$_attempt" -lt 3 ] && sleep 10
+                done
+                [ "$_perf_ok" -eq 0 ] && echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: scp perf $folder failed after 3 attempts"
+            done < <(eval "$SLURM_SSH_LIST_PERF_CMD" 2>/dev/null)
         fi
     elif [ -n "$XML_PATH" ]; then
         m=$(stat -c %Y "$XML_PATH" 2>/dev/null || echo 0)

--- a/jenkins/scripts/progress_upload_watcher.sh
+++ b/jenkins/scripts/progress_upload_watcher.sh
@@ -38,6 +38,6 @@ while [ ! -f "$PROGRESS_DONE_FILE" ]; do
     fi
 
     LABEL="${LABEL_PREFIX}${m:+ (mtime=$m)}" \
-    bash "${WORKSPACE}/jenkins/scripts/progress_upload_snapshot.sh" || continue
+    bash "$(dirname "${BASH_SOURCE[0]}")/progress_upload_snapshot.sh" || continue
 done
 echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: watcher exiting"

--- a/jenkins/scripts/progress_upload_watcher.sh
+++ b/jenkins/scripts/progress_upload_watcher.sh
@@ -10,6 +10,10 @@
 #
 # SLURM mode (set both to activate):
 #   SLURM_SSH_STAT_CMD        shell command that prints the remote results.xml mtime
+#                             (run on the compute node via srun --overlap to bypass
+#                             the login node's NFS attribute cache)
+#   SLURM_SSH_REFRESH_CACHE_CMD  shell command run on the login node to prime its NFS
+#                             cache after the stat detects a change, before SCP
 #   SLURM_SCP_XML_CMD         shell command that SCPs remote results*.xml locally
 #
 # SLURM mode optional enrichment (non-fatal; each retried up to 3 times):
@@ -37,6 +41,13 @@ while [ ! -f "$PROGRESS_DONE_FILE" ]; do
         echo "[PROGRESS-UPLOAD] ${STAGE_NAME}: poll #${_poll} mtime=${m} last=${last}"
         [ "$m" -le "$last" ] && continue
         last=$m
+        # Prime the login node's NFS cache before SCP: the stat above ran on the
+        # compute node (via srun --overlap) so the login node may still have a
+        # stale view of the directory.  Running ls on the login node here forces
+        # a fresh READDIR/GETATTR RPC to the NFS server before we attempt SCP.
+        if [ -n "$SLURM_SSH_REFRESH_CACHE_CMD" ]; then
+            eval "$SLURM_SSH_REFRESH_CACHE_CMD" 2>/dev/null || true
+        fi
         mkdir -p "${WORKSPACE}/${STAGE_NAME}"
         _scp_ok=0
         for _attempt in 1 2 3; do


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test execution now uploads progress snapshots every 10 minutes.
  * SLURM, native pytest, and rerun flows monitor progress in the background.
  * Progress snapshots include XML, unfinished-test, and performance artifacts when available.
  * Snapshots skip uploads when result content is unchanged.

* **Bug Fixes**
  * Progress checkpoints are promoted to final result artifacts when available.
  * Progress artifacts are cleaned up after successful completion.
  * Direct tar and upload remains the fallback when no checkpoint exists.
  * Progress-upload failures remain non-fatal during monitoring.
  * Tar and upload failures fail the snapshot script.
  * `uploadResults` consumes downloaded artifacts and supports tagged XML results.
  * Retry attempts use distinct progress-artifact tags to prevent stale uploads from superseded retries.

## Dev Engineer Review

* The implementation adds watcher and completion-sentinel handling for SLURM, native pytest, and rerun execution.
* The upload interval changes from 300 to 600 seconds.
* `uploadResults`, `promoteProgressTar`, and `deleteProgressArtifact` use consistent progress-artifact handling.
* The watcher retries remote artifact retrieval and does not stop the main test flow after transient progress-upload failures.
* The snapshot script normalizes XML names, generates optional timeout XML, skips unchanged results, and records successful-upload hashes.
* Review should verify Jenkins concurrency behavior, sentinel cleanup, Artifactory path rewriting, interruption handling, and compatibility with `CODING_GUIDELINES.md`.
* No test files or test-list files are changed.

## QA Engineer Review

No test changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
