### PR TITLE
[None][fix] Handle DeepSeek-V4 fused A scale shape

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -77,6 +77,7 @@ from ..modules.fused_moe.fused_moe_deepgemm import DeepGemmFusedMoE
 from ..modules.fused_moe.fused_moe_wide_ep import WideEPMoE
 from ..modules.linear import Linear
 from ..modules.mhc.hyper_connection import HCHead, HCState, mHC
+from ..utils import replace_parameter_and_save_metadata
 
 # isort: off
 from ..modules.fused_moe.routing import (
@@ -222,6 +223,56 @@ def _resolve_enable_fused_hc(config: PretrainedConfig) -> bool:
     if env is not None:
         return env not in ("0", "false", "False")
     return bool(getattr(config, "enable_fused_hc", True))
+
+
+def _copy_deepseek_v4_fused_a_weight_scale(
+    module: Linear, fused_a: torch.Tensor, fused_a_scale: torch.Tensor
+) -> None:
+    if tuple(module.weight_scale.shape) == tuple(fused_a_scale.shape):
+        module.weight_scale.data.copy_(fused_a_scale)
+        return
+
+    if (
+        module.weight_scale.ndim == 2
+        and fused_a_scale.ndim == 2
+        and module.weight_scale.shape[0] >= fused_a_scale.shape[0]
+        and module.weight_scale.shape[1] == fused_a_scale.shape[1]
+    ):
+        module.weight_scale.data[0 : fused_a_scale.shape[0]].copy_(fused_a_scale)
+        return
+
+    expected_fp8_scale_shape = (
+        math.ceil(fused_a.shape[0] / 128),
+        math.ceil(fused_a.shape[1] / 128),
+    )
+    can_rebuild_fp8_scale = (
+        fused_a_scale.ndim == 2
+        and tuple(fused_a_scale.shape) == expected_fp8_scale_shape
+        and tuple(module.weight.shape) == tuple(fused_a.shape)
+    )
+    if not can_rebuild_fp8_scale:
+        raise RuntimeError(
+            "DeepSeek-V4 fused A projection weight_scale shape mismatch: "
+            f"module={tuple(module.weight_scale.shape)}, checkpoint={tuple(fused_a_scale.shape)}, "
+            f"weight={tuple(module.weight.shape)}, checkpoint_weight={tuple(fused_a.shape)}"
+        )
+
+    corrected_weight_scale = nn.Parameter(
+        torch.empty(
+            fused_a_scale.shape,
+            dtype=module.weight_scale.dtype,
+            device=module.weight_scale.device,
+        ),
+        requires_grad=False,
+    )
+    replace_parameter_and_save_metadata(
+        module,
+        "weight_scale",
+        corrected_weight_scale,
+        module.rebuild_tensor_metadata,
+    )
+
+    module.weight_scale.data.copy_(fused_a_scale)
 
 
 def _remap_deepseek_v4_checkpoint_keys(
@@ -950,7 +1001,7 @@ class DeepseekV4WeightLoader:
                             fused_a_scale = kv_a_proj_with_mqa_scale
                         # For DeepseekV32: kv_a_proj_with_mqa is oversized
                         # to include indexer k weights, which is filled in post_load_weights.
-                        module.weight_scale.data[0 : fused_a_scale.shape[0]].copy_(fused_a_scale)
+                        _copy_deepseek_v4_fused_a_weight_scale(module, fused_a, fused_a_scale)
                     else:
                         fused_a = weights[f"{'.'.join(names[:-1])}.kv_a_proj_with_mqa.weight"][:]
                         if not is_lite:
@@ -967,9 +1018,7 @@ class DeepseekV4WeightLoader:
                                 ][:]
                                 fused_a_scale = torch.cat([q_a_proj_scale, fused_a_scale], dim=0)
 
-                            module.weight_scale.data[0 : fused_a_scale.shape[0]].copy_(
-                                fused_a_scale
-                            )
+                            _copy_deepseek_v4_fused_a_weight_scale(module, fused_a, fused_a_scale)
                         # For DeepseekV32: kv_a_proj_with_mqa is oversized
                         # to include indexer k weights, which is filled in post_load_weights.
                         module.weight.data[0 : fused_a.shape[0]].copy_(fused_a)

--- a/tests/unittest/_torch/modeling/test_modeling_deepseekv4.py
+++ b/tests/unittest/_torch/modeling/test_modeling_deepseekv4.py
@@ -10,6 +10,7 @@ from transformers import PretrainedConfig
 
 # from utils.util import default_dtype
 import tensorrt_llm
+from tensorrt_llm._torch.attention_backend.interface import AttentionForwardArgs
 from tensorrt_llm._torch.attention_backend.sparse.deepseek_v4.cache_manager import (
     DeepseekV4CacheManager,
 )
@@ -19,7 +20,6 @@ from tensorrt_llm._torch.attention_backend.sparse.deepseek_v4.deepseek_v4 import
     DeepseekV4TrtllmAttention,
     DeepseekV4TrtllmAttentionMetadata,
 )
-from tensorrt_llm._torch.attention_backend.interface import AttentionForwardArgs
 from tensorrt_llm._torch.attention_backend.trtllm import TrtllmAttention
 from tensorrt_llm._torch.configs.deepseekv4 import DeepseekV4Config
 from tensorrt_llm._torch.metadata import KVCacheParams
@@ -29,6 +29,7 @@ from tensorrt_llm._torch.models.modeling_deepseekv4 import (
     DeepseekV4ForCausalLM,
     DeepseekV4Gate,
     DeepseekV4MTP,
+    _copy_deepseek_v4_fused_a_weight_scale,
     _deepseek_v4_pos_embd_params,
     _remap_deepseek_v4_checkpoint_keys,
     _resolve_enable_fused_hc,
@@ -168,6 +169,35 @@ def test_deepseek_v4_weight_remap_for_fp8_routed_experts():
 
     assert "model.layers.0.mlp.experts.0.w1.weight_scale_inv" in remapped
     assert "model.layers.0.mlp.experts.0.w1.weight_scale" not in remapped
+
+
+def test_deepseek_v4_fused_a_weight_scale_rebuilds_fp8_shape():
+    module = torch.nn.Module()
+    module.weight = torch.nn.Parameter(torch.empty((2048, 7168), dtype=torch.float8_e4m3fn))
+    module.weight_scale = torch.nn.Parameter(torch.empty((16, 16), dtype=torch.float32))
+    module.rebuild_tensor_metadata = {}
+    fused_a = torch.empty((2048, 7168), dtype=torch.float8_e4m3fn)
+    fused_a_scale = torch.ones((16, 56), dtype=torch.float32)
+
+    _copy_deepseek_v4_fused_a_weight_scale(module, fused_a, fused_a_scale)
+
+    assert module.weight_scale.shape == fused_a_scale.shape
+    assert torch.equal(module.weight_scale, fused_a_scale)
+
+
+def test_deepseek_v4_fused_a_weight_scale_keeps_oversized_slice():
+    module = torch.nn.Module()
+    module.weight = torch.nn.Parameter(torch.empty((2176, 7168), dtype=torch.float8_e4m3fn))
+    module.weight_scale = torch.nn.Parameter(torch.zeros((17, 56), dtype=torch.float32))
+    module.rebuild_tensor_metadata = {}
+    fused_a = torch.empty((2048, 7168), dtype=torch.float8_e4m3fn)
+    fused_a_scale = torch.ones((16, 56), dtype=torch.float32)
+
+    _copy_deepseek_v4_fused_a_weight_scale(module, fused_a, fused_a_scale)
+
+    assert module.weight_scale.shape == (17, 56)
+    assert torch.equal(module.weight_scale[:16], fused_a_scale)
+    assert torch.equal(module.weight_scale[16], torch.zeros(56))
 
 
 def test_deepseek_v4_kv_norm_keeps_full_head_dim():
@@ -619,9 +649,7 @@ def test_deepseek_v4_sparse_ratios_keep_explicit_override(tmp_path, monkeypatch)
     assert model_config.sparse_attention_config.compress_ratios == explicit_ratios
 
 
-def test_deepseek_v4_sparse_ratios_resolve_mtp_layers_from_checkpoint(
-    tmp_path, monkeypatch
-):
+def test_deepseek_v4_sparse_ratios_resolve_mtp_layers_from_checkpoint(tmp_path, monkeypatch):
     checkpoint_ratios = [128, 128]
     config = DeepseekV4Config(
         architectures=["DeepseekV4ForCausalLM"],


### PR DESCRIPTION
@coderabbitai summary

## Description

Fix DeepSeek-V4 NVFP4 expert checkpoint loading when the checkpoint fused A projection scale has the FP8 block-scale shape `(16, 56)`, while the module can be initialized with a stale/mismatched `(16, 16)` `weight_scale`.

The loader now preserves the existing oversized slice-copy behavior for padded `kv_a_proj_with_mqa` modules, and rebuilds the `weight_scale` parameter plus tensor metadata only when the checkpoint scale matches the expected FP8 block-scale shape for the fused A projection.

## Test Coverage

- Built TensorRT-LLM wheel: `tensorrt_llm-1.3.0rc15-cp312-cp312-linux_x86_64.whl`.
- Installed the built wheel, then installed the current source in editable mode for Python-layer validation.
- `pre-commit run --files tensorrt_llm/_torch/models/modeling_deepseekv4.py tests/unittest/_torch/modeling/test_modeling_deepseekv4.py`
- `PYTHONNOUSERSITE=1 pytest tests/unittest/_torch/modeling/test_modeling_deepseekv4.py -k "fused_a_weight_scale or routed_moe_quant_config or weight_remap" -q` (`8 passed`)
- Manually validated the NVFP4 checkpoint at `/home/scratch.fanrongl_coreai/models/deepseek_v4/pro-nvfp4-experts-v3.5`: checkpoint fused scale is `(16, 56)` and the loader helper rebuilds module `weight_scale` from `(16, 16)` to `(16, 56)`.
- Full GPU model run was not started because all B300 GPUs on the shared machine were already occupied with ~144-146 GiB used per GPU.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
