### PR TITLE
[None][feat] Enable LTX-2 TeaCache

### DIFF
--- a/examples/visual_gen/visual_gen_ltx2.py
+++ b/examples/visual_gen/visual_gen_ltx2.py
@@ -8,7 +8,7 @@ import argparse
 import time
 
 from tensorrt_llm import VisualGen, VisualGenArgs, VisualGenParams, logger
-from tensorrt_llm._torch.visual_gen.config import CacheDiTConfig
+from tensorrt_llm._torch.visual_gen.config import CacheDiTConfig, TeaCacheConfig
 
 logger.set_level("info")
 
@@ -134,6 +134,22 @@ def parse_args():
     )
 
     # Diffusion cache acceleration
+    parser.add_argument(
+        "--enable_teacache",
+        action="store_true",
+        help="Enable TeaCache stage-1 acceleration.",
+    )
+    parser.add_argument(
+        "--teacache_thresh",
+        type=float,
+        default=None,
+        help="TeaCache similarity threshold. Omit to use the LTX-2 default.",
+    )
+    parser.add_argument(
+        "--use_ret_steps",
+        action="store_true",
+        help="Use ret_steps TeaCache mode.",
+    )
     parser.add_argument(
         "--enable_cache_dit",
         action="store_true",
@@ -335,9 +351,21 @@ def _cache_dit_config_from_args(args) -> CacheDiTConfig:
     return CacheDiTConfig(**overrides)
 
 
+def _teacache_config_from_args(args) -> TeaCacheConfig:
+    """Build TeaCacheConfig from CLI args."""
+    kwargs: dict = {
+        "use_ret_steps": args.use_ret_steps,
+    }
+    if args.teacache_thresh is not None:
+        kwargs["teacache_thresh"] = args.teacache_thresh
+    return TeaCacheConfig(**kwargs)
+
+
 def _build_diffusion_args(args) -> VisualGenArgs:
     """Build VisualGenArgs from parsed CLI args."""
-    if args.enable_cache_dit:
+    if args.enable_teacache:
+        cache_kwargs = {"cache": _teacache_config_from_args(args)}
+    elif args.enable_cache_dit:
         logger.info("Cache DiT enabled; LTX2 will run as a one-stage pipeline.")
         cache_kwargs = {"cache": _cache_dit_config_from_args(args)}
     else:
@@ -377,6 +405,9 @@ def _build_diffusion_args(args) -> VisualGenArgs:
 
 def main():
     args = parse_args()
+
+    if args.enable_teacache and args.enable_cache_dit:
+        raise ValueError("--enable_teacache and --enable_cache_dit are mutually exclusive.")
 
     attn2d_size = args.attn2d_row_size * args.attn2d_col_size
     if attn2d_size > 1 and args.ulysses_size > 1:

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
@@ -16,7 +16,7 @@ import torch.distributed as dist
 from transformers import Gemma3ForConditionalGeneration, GemmaTokenizerFast
 
 from tensorrt_llm._torch.utils import make_weak_ref
-from tensorrt_llm._torch.visual_gen.cache.teacache import CacheContext
+from tensorrt_llm._torch.visual_gen.cache.teacache import CacheContext, register_extractor
 from tensorrt_llm._torch.visual_gen.config import PipelineComponent
 from tensorrt_llm._torch.visual_gen.cuda_graph_runner import CUDAGraphRunner, CUDAGraphRunnerConfig
 from tensorrt_llm._torch.visual_gen.output import CudaPhaseTimer, PipelineOutput
@@ -200,18 +200,26 @@ def _load_ltx2_transformer_weights(
     return weights
 
 
-# TeaCache polynomial coefficients for LTX-0.9.1-HFIE. Calibrated from the LTX-Video model family.
-# Maps raw embedding L1 distances to rescaled distances for cache decisions.
-# Coefficients are from:
-# https://huggingface.co/jbilcke-hf/LTX-Video-0.9.1-HFIE/blob/main/teacache.py#L42
-# TODO: Need to verify coefficients for correctness.
-
-# LTX2_TEACACHE_COEFFICIENTS = {
-#     "ltx": {
-#         "ret_steps": [2.14700694e+01, -1.28016453e+01, 2.31279151e+00, 7.92487521e-01, 9.69274326e-03],
-#         "standard": [2.14700694e+01, -1.28016453e+01, 2.31279151e+00, 7.92487521e-01, 9.69274326e-03],
-#     },
-# }
+# Coefficients calibrated from LTX-2 BF16 stage-1 samples using the output
+# relative-L1 fit. Stage 2 uses a short distilled refinement schedule and is
+# kept uncached by the two-stage pipeline.
+LTX2_TEACACHE_COEFFICIENTS = {
+    "ret_steps": [
+        -18.763005693192905,
+        24.5964390395728,
+        -8.718555981283336,
+        0.977153258766494,
+        0.02979450913205161,
+    ],
+    "standard": [
+        -18.763005693192905,
+        24.5964390395728,
+        -8.718555981283336,
+        0.977153258766494,
+        0.02979450913205161,
+    ],
+    "default_thresh": 0.2,
+}
 
 
 class LTX2TeaCacheExtractor:
@@ -964,13 +972,15 @@ class LTX2Pipeline(BasePipeline):
         """Finalize after weight loading: TeaCache, Cache-DiT, derived attributes."""
         super().post_load_weights()
 
-        # TODO: TeaCache disabled: LTX2_TEACACHE_COEFFICIENTS are unverified.
-        # To re-enable, uncomment the following lines and verify coefficients.
-        # register_extractor(
-        #     "LTXModel",
-        #     LTX2TeaCacheExtractor(self._compute_ltx2_timestep_embedding),
-        # )
-        # self._setup_teacache(self.transformer, coefficients=LTX2_TEACACHE_COEFFICIENTS)
+        if self.transformer is not None and self.model_config.cache_backend == "teacache":
+            register_extractor(
+                "LTXModel",
+                LTX2TeaCacheExtractor(self._compute_ltx2_timestep_embedding),
+            )
+            self._setup_cache_acceleration(
+                self.transformer,
+                coefficients=LTX2_TEACACHE_COEFFICIENTS,
+            )
 
         # Cache-DiT
         if self.transformer is not None and self.model_config.cache_backend == "cache_dit":

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
@@ -801,6 +801,18 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
         # ================================================================
         # Stage 2: refinement denoising with distilled LoRA
         # ================================================================
+        # The current TeaCache coefficients are calibrated for stage 1 only.
+        # Stage 2 uses a short distilled schedule with different shapes, so run
+        # it uncached and re-arm TeaCache for the next request afterwards.
+        teacache_was_enabled = (
+            self.model_config.cache_backend == "teacache"
+            and getattr(self, "cache_accelerator", None) is not None
+            and self.cache_accelerator.is_enabled()
+        )
+        if teacache_was_enabled:
+            logger.info("TeaCache: disabling for LTX-2 stage 2 refinement")
+            self.cache_accelerator.unwrap()
+
         # For FP4 models (static-packed or dynamic), stage 2 always runs in
         # BF16: the quant_method is swapped to UnquantizedLinearMethod inside
         # _apply_lora_deltas and restored afterwards.  BF16 models are unaffected.
@@ -859,6 +871,8 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
                     f"Restored {restored} LoRA-touched weights after stage 2, but {n} were applied."
                 )
             logger.info("Un-merged distilled LoRA after stage 2")
+            if teacache_was_enabled:
+                self.cache_accelerator.wrap(model=self.transformer)
 
         # ================================================================
         # Decode

--- a/tensorrt_llm/_torch/visual_gen/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline.py
@@ -401,6 +401,30 @@ class BasePipeline(nn.Module):
         if not coefficients:
             return
         teacache_cfg = self.model_config.teacache
+
+        def apply_coeff_data(model_size: str, coeff_data: Any) -> None:
+            if isinstance(coeff_data, dict):
+                mode = "ret_steps" if teacache_cfg.use_ret_steps else "standard"
+                if mode in coeff_data:
+                    teacache_cfg.coefficients = coeff_data[mode]
+                    logger.info(f"TeaCache: Using {model_size} coefficients ({mode} mode)")
+                default_thresh = coeff_data.get("default_thresh")
+                if (
+                    default_thresh is not None
+                    and "teacache_thresh" not in teacache_cfg.model_fields_set
+                ):
+                    teacache_cfg.teacache_thresh = default_thresh
+                    logger.info(f"TeaCache: Using {model_size} default threshold {default_thresh}")
+            else:
+                teacache_cfg.coefficients = coeff_data
+                logger.info(f"TeaCache: Using {model_size} coefficients")
+
+        if isinstance(coefficients, dict) and (
+            "standard" in coefficients or "ret_steps" in coefficients
+        ):
+            apply_coeff_data(self.__class__.__name__, coefficients)
+            return
+
         checkpoint_path = (
             getattr(getattr(self.model_config, "pretrained_config", None), "_name_or_path", "")
             or ""
@@ -409,23 +433,7 @@ class BasePipeline(nn.Module):
         for model_size, coeff_data in coefficients.items():
             if model_size.lower() in checkpoint_path.lower():
                 matched = True
-                if isinstance(coeff_data, dict):
-                    mode = "ret_steps" if teacache_cfg.use_ret_steps else "standard"
-                    if mode in coeff_data:
-                        teacache_cfg.coefficients = coeff_data[mode]
-                        logger.info(f"TeaCache: Using {model_size} coefficients ({mode} mode)")
-                    default_thresh = coeff_data.get("default_thresh")
-                    if (
-                        default_thresh is not None
-                        and "teacache_thresh" not in teacache_cfg.model_fields_set
-                    ):
-                        teacache_cfg.teacache_thresh = default_thresh
-                        logger.info(
-                            f"TeaCache: Using {model_size} default threshold {default_thresh}"
-                        )
-                else:
-                    teacache_cfg.coefficients = coeff_data
-                    logger.info(f"TeaCache: Using {model_size} coefficients")
+                apply_coeff_data(model_size, coeff_data)
                 break
         if not matched:
             raise ValueError(


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * TeaCache acceleration support for LTX2 stage-1 diffusion with configurable thresholds and parameters
  * New CLI options: --enable_teacache, --teacache_thresh, --use_ret_steps for customizable TeaCache configuration

* **Improvements**
  * TeaCache and Cache-DiT now enforced as mutually exclusive to prevent conflicting acceleration methods
  * Improved TeaCache behavior in multi-stage refinement pipelines with automatic stage-aware activation and deactivation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14157)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Perf benchmark shows significant improvement on stage1 denoising time.

| Precision | TeaCache | Model Load(s) | Stage1(s) | Stage2(s) | Cache Hits | Generation(s) | LPIPS Score |
  |---|---|---:|---:|---:|---|---:|---|
  | BF16 | Off | 164.54 | 39.66 | 9.39 | n/a | 70.98 | Reference |
  | BF16 | On | 48.00 | 12.57 (3.16x) | 9.33 | 75.0% (30/40) | 43.92 (1.62x) | 0.528631 |
  | FP8 | Off | 117.84 | 42.28 | 17.08 | n/a | 77.40 | Reference |
  | FP8 | On | 47.42 | 13.97 (3.03x) | 10.55 | 75.0% (30/40) | 42.63 (1.82x) | 0.521271 |
  | FP4 | Off | 97.94 | 39.66 | 10.91 | n/a | 68.99 | Reference |
  | FP4 | On | 46.79 | 13.47 (2.94x) | 10.79 | 75.0% (30/40) | 42.82 (1.61x) | 0.522667 |

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
