### PR TITLE
[None][fix] Return 3-tuple from check_gen_transfer_status fast path

### DIFF
--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -523,7 +523,7 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
     def check_gen_transfer_status(self, at_least_request_num: Optional[int]):
         # Skip the allgather in _gen_consensus when this transceiver never receives (pure CTX role).
         if not self._ever_had_recv_session:
-            return [], []
+            return [], [], []
         block_all = at_least_request_num is None
         wait_num = at_least_request_num if not block_all else 0
 


### PR DESCRIPTION
## Summary

- Fix tuple-arity mismatch in `KvCacheTransceiverV2.check_gen_transfer_status`: the pure-CTX early-out returned `[], []` while the normal path and the sole caller (`py_executor._check_disagg_gen_cache_transfer_status`) expect a 3-tuple `(completed, failed, cancelled_reqs)`.
- Both return paths now return `[], [], []` / `(completed, failed, cancelled_reqs)` consistently.

## Repro

On a fresh disagg run (DSv4-Pro, `ctx1_gen1_dep16`, GB300), the GEN side's executor died with:

```
[RANK 0] Error in event loop: not enough values to unpack (expected 3, got 2)
  File ".../py_executor.py", line 3874, in _check_disagg_gen_cache_transfer_status
    _, _, cancelled_reqs = result
ValueError: not enough values to unpack (expected 3, got 2)
```

Triggered when `_ever_had_recv_session` is still False on the first scheduling iteration after warm-up (no recv session opened yet on this rank). The 2-tuple was introduced in #14042 (`Skip transceiver tp_allgather when no sessions ever opened`).

## Test plan

- [x] Re-run the failing benchmark `bm_deepseek-v4-pro-sol-1024-1024-ratio08-20260514-GB300/ctx1_gen1_dep16_concurrency16_eplb0_mtp0` and confirm no `ValueError` is raised.
- [x] Existing disagg unit tests under `tests/unittest/disaggregated/` pass.