### PR TITLE
[None][fix] Strong-ref disconnect watcher tasks in OpenAI server

### DIFF
--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -227,6 +227,14 @@ class OpenAIServer(_VideoRoutesMixin):
         # Energy monitoring
         self.energy_monitor = None
 
+        # Strong references to fire-and-forget disconnect-watcher tasks.
+        # asyncio's event loop only keeps weak refs to tasks, so a task that
+        # isn't held elsewhere can be GC'd mid-execution and its closure
+        # (raw_request, promise) released abruptly.  See cpython issues
+        # gh-91887, gh-128627.  We keep the task in a set and discard via
+        # done callback so memory does not creep over long-running serves.
+        self._disconnect_watcher_tasks: set[asyncio.Task] = set()
+
         # as disagg-worker
         self.disagg_cluster_storage = None
         self.disagg_cluster_worker = None
@@ -527,6 +535,15 @@ class OpenAIServer(_VideoRoutesMixin):
             logger.info(
                 f"{raw_request.client} is disconnected, abort {promise.request_id}"
             )
+
+    def _spawn_disconnect_watcher(self, raw_request: Request,
+                                  promise) -> asyncio.Task:
+        # Strong-ref the task so the event loop's weak set cannot drop it,
+        # and remove it on completion so the set does not grow unbounded.
+        task = asyncio.create_task(self.await_disconnected(raw_request, promise))
+        self._disconnect_watcher_tasks.add(task)
+        task.add_done_callback(self._disconnect_watcher_tasks.discard)
+        return task
 
     @property
     def postproc_worker_enabled(self) -> bool:
@@ -1233,7 +1250,7 @@ class OpenAIServer(_VideoRoutesMixin):
                 trace_headers=trace_headers,
                 scheduling_params=scheduling_params,
             )
-            asyncio.create_task(self.await_disconnected(raw_request, promise))
+            self._spawn_disconnect_watcher(raw_request, promise)
             if not self.postproc_worker_enabled:
                 postproc_args.tokenizer = self.tokenizer
                 postproc_args.num_prompt_tokens = len(promise.prompt_token_ids)
@@ -1343,7 +1360,7 @@ class OpenAIServer(_VideoRoutesMixin):
                 prompt["multi_modal_data"] = mm_data
 
             promise = self.generator.generate_async(inputs=prompt, )
-            asyncio.create_task(self.await_disconnected(raw_request, promise))
+            self._spawn_disconnect_watcher(raw_request, promise)
 
             response = await create_mm_embedding_response(promise)
             return JSONResponse(content=response.model_dump())
@@ -1519,8 +1536,7 @@ class OpenAIServer(_VideoRoutesMixin):
                     lora_request=request.lora_request,
                     disaggregated_params=disaggregated_params,
                     trace_headers=trace_headers)
-                asyncio.create_task(
-                    self.await_disconnected(raw_request, promise))
+                self._spawn_disconnect_watcher(raw_request, promise)
                 if not self.postproc_worker_enabled:
                     postproc_args.tokenizer = self.tokenizer
                     postproc_args.num_prompt_tokens = len(
@@ -1643,7 +1659,7 @@ class OpenAIServer(_VideoRoutesMixin):
                 postproc_args.num_prompt_tokens = len(promise.prompt_token_ids)
 
             # Disconnect cancellation
-            asyncio.create_task(self.await_disconnected(raw_request, promise))
+            self._spawn_disconnect_watcher(raw_request, promise)
 
             # Handle streaming
             if request.stream:
@@ -1779,7 +1795,7 @@ class OpenAIServer(_VideoRoutesMixin):
                 logger.warning(
                     "Postproc workers are enabled, request will not be stored!")
 
-            asyncio.create_task(self.await_disconnected(raw_request, promise))
+            self._spawn_disconnect_watcher(raw_request, promise)
 
             if request.stream:
                 return StreamingResponse(content=create_streaming_generator(


### PR DESCRIPTION
The 5 fire-and-forget `asyncio.create_task(self.await_disconnected(...))` sites in `openai_server.py` did not retain a reference to the returned Task object. Python's asyncio loop holds only WEAK refs to tasks (see cpython gh-91887, gh-128627), so the task can be GC'd mid-execution and its closure (`raw_request`, `promise`) released abruptly.

Even when the task does run to completion, the prior pattern provides no observability into how many watchers are alive at any moment and makes it impossible to bound by shutdown.

Fix: introduce a per-server `_disconnect_watcher_tasks: set[asyncio.Task]` strong-ref set, and a `_spawn_disconnect_watcher()` helper that adds the task and registers `set.discard` as a done callback. All 5 call sites (chat, mm-encoder, completion, responses-api, score) now go through the helper.

Net behavior: identical for happy-path requests; safer under GC pressure and high concurrency; trivially observable via `len(server._disconnect_watcher_tasks)`.

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
