### PR TITLE
[https://nvbugs/6162128][tests] Skip nano v3 E2E tests entirely on G/B300

### DIFF
--- a/tests/integration/defs/accuracy/test_llm_api_pytorch_multimodal.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch_multimodal.py
@@ -544,6 +544,10 @@ class TestMistralSmall24B(LlmapiAccuracyTestHarness):
             task.evaluate(llm, sampling_params=self.sampling_params)
 
 
+# Skip for B300 / GB300:
+# * B300 coverage does not meaningfully extend what we test via B200.
+# * GB300 may not be entirely up to date for `llm-models`, leading to repo-wide CI errors.
+@skip_post_blackwell_ultra
 class TestNanoV3Omni(LlmapiAccuracyTestHarness):
     # The score here may be lower than VLMEvalKitMcore (official) runs. This path uses
     # lm_eval's MMMU task, prompt formatting, and scoring, while VLMEvalKitMcore
@@ -644,14 +648,7 @@ class TestNanoV3Omni(LlmapiAccuracyTestHarness):
                 128,
                 QuantAlgo.MIXED_PRECISION,
                 (MMMU_TASK_SPEC, VOXPOPULI_TASK_SPEC, VIDEOMME_TASK_SPEC),
-                marks=(
-                    skip_pre_blackwell,
-                    # Skip for B300 / GB300:
-                    # * B300 coverage does not meaningfully extend what we test via B200.
-                    # * GB300 may not be entirely up to date for `llm-models`, leading to repo-wide
-                    #   CI errors.
-                    skip_post_blackwell_ultra,
-                ),
+                marks=(skip_pre_blackwell,),
                 id="nvfp4",
             ),
         ],


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test configuration markers for hardware-specific test scenarios, adjusting skip conditions for post-Blackwell Ultra environments while refining coverage across different hardware configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14185)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

The `llm-models` repo is out of sync on GB300 nodes.
Skip problematic test `TestNanoV3Omni` entirely on these
nodes since they do not meaningfully improve coverage
anyway.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
