### PR TITLE
[https://nvbugs/6133201][fix] Bump GEN max_num_tokens in disagg perf YAMLs

### DIFF
--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_1k1k_con2048_ctx2_dep4_gen1_dep16_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_1k1k_con2048_ctx2_dep4_gen1_dep16_eplb0_mtp3_ccb-NIXL.yaml
@@ -48,7 +48,7 @@ worker_config:
   gen:
     print_iter_log: true
     max_batch_size: 768
-    max_num_tokens: 1536
+    max_num_tokens: 3072
     tensor_parallel_size: 16
     moe_expert_parallel_size: 16
     pipeline_parallel_size: 1

--- a/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_1k1k_con2048_ctx2_dep4_gen1_dep16_eplb288_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_deepseek-r1-fp4_1k1k_con2048_ctx2_dep4_gen1_dep16_eplb288_mtp3_ccb-NIXL.yaml
@@ -48,7 +48,7 @@ worker_config:
   gen:
     print_iter_log: true
     max_batch_size: 768
-    max_num_tokens: 1536
+    max_num_tokens: 3072
     tensor_parallel_size: 16
     moe_expert_parallel_size: 16
     pipeline_parallel_size: 1

--- a/tests/scripts/perf/disaggregated/gb200_deepseek-r1-fp4_1k1k_con2048_ctx2_dep4_gen1_dep16_eplb0_mtp3_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_deepseek-r1-fp4_1k1k_con2048_ctx2_dep4_gen1_dep16_eplb0_mtp3_ccb-NIXL.yaml
@@ -48,7 +48,7 @@ worker_config:
   gen:
     print_iter_log: true
     max_batch_size: 768
-    max_num_tokens: 1536
+    max_num_tokens: 3072
     tensor_parallel_size: 16
     moe_expert_parallel_size: 16
     pipeline_parallel_size: 1

--- a/tests/scripts/perf/disaggregated/gb200_qwen3-235b-fp4_1k1k_ctx2_gen1_dep16_bs128_eplb0_mtp3_con2048_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_qwen3-235b-fp4_1k1k_ctx2_gen1_dep16_bs128_eplb0_mtp3_con2048_ccb-NIXL.yaml
@@ -48,7 +48,7 @@ worker_config:
     enable_attention_dp: true
     pipeline_parallel_size: 1
     max_batch_size: 128
-    max_num_tokens: 256
+    max_num_tokens: 512
     max_seq_len: 2251
     cuda_graph_config:
       enable_padding: true

--- a/tests/scripts/perf/disaggregated/gb300_qwen3-235b-fp4_1k1k_ctx2_gen1_dep16_bs128_eplb0_mtp3_con2048_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb300_qwen3-235b-fp4_1k1k_ctx2_gen1_dep16_bs128_eplb0_mtp3_con2048_ccb-NIXL.yaml
@@ -48,7 +48,7 @@ worker_config:
     enable_attention_dp: true
     pipeline_parallel_size: 1
     max_batch_size: 128
-    max_num_tokens: 256
+    max_num_tokens: 512
     max_seq_len: 2251
     cuda_graph_config:
       enable_padding: true


### PR DESCRIPTION
## Summary

Fix [nvbugs/6133201](https://nvbugs/6133201): five GEN-engine YAMLs added by #13343 set `max_num_tokens` to exactly half of what `max_batch_size × (1 + max_draft_len)` requires under MTP/Eagle3. At high concurrency with attention-DP routing, the per-rank check in `_prepare_tp_inputs` trips, the worker dies, and the rest of the disagg job blocks forever in NIXL/UCX collectives — the benchmark client sees a stuck `0/16384` progress bar until the job-step timeout fires.

```
AssertionError: total_num_tokens (260) should be less than or equal to max_num_tokens (256)
```

This PR bumps `max_num_tokens` in the five mismatched files so the invariant `max_num_tokens ≥ max_batch_size × (1 + max_draft_len)` holds:

| File | mbs | mdl | old mnt | new mnt |
|---|---|---|---|---|
| `perf/disaggregated/gb200_qwen3-235b-fp4_…_dep16_bs128_…_mtp3_con2048_ccb-NIXL.yaml` | 128 | 3 | 256 | **512** |
| `perf/disaggregated/gb300_qwen3-235b-fp4_…_dep16_bs128_…_mtp3_con2048_ccb-NIXL.yaml` | 128 | 3 | 256 | **512** |
| `perf/disaggregated/gb200_deepseek-r1-fp4_…_con2048_…_dep16_eplb0_mtp3_ccb-NIXL.yaml` | 768 | 3 | 1536 | **3072** |
| `perf-sanity/disaggregated/gb200_deepseek-r1-fp4_…_con2048_…_dep16_eplb0_mtp3_ccb-NIXL.yaml` | 768 | 3 | 1536 | **3072** |
| `perf-sanity/disaggregated/gb200_deepseek-r1-fp4_…_con2048_…_dep16_eplb288_mtp3_ccb-NIXL.yaml` | 768 | 3 | 1536 | **3072** |

The bug report only covers the first row (`disagg-e2e-gb200_qwen3-235b-fp4_…_con2048_…_mtp3_ccb-NIXL`), but the GB300 sibling was already confirmed reproducing in comment 2 of the nvbug, and the three DeepSeek-R1 entries are the same latent arithmetic mismatch — fixing them together prevents the same failure firing on a different test next run.

This is a test-config fix only — no source-code changes. A separate follow-up should enforce the invariant either in `LlmArgs` validation or in the ADP router's per-rank scheduling so future YAMLs cannot land with this inconsistency silently.

## Test plan

- [x] Reproduced and verified on GB200 against the original artifact's source SHA + container image: with `max_num_tokens=512` the failing test (`perf/test_perf_sanity.py::test_e2e[disagg-e2e-gb200_qwen3-235b-fp4_…_con2048_…_mtp3_ccb-NIXL]`) completes in 332 s with non-zero throughput; without the bump the assertion fires within seconds of the first NIXL transfer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated performance and sanity benchmark configurations for multiple model inference scenarios, including DeepSeek R1 FP4 and Qwen3-235B. Increased generation token limits to enable comprehensive capacity testing and improved performance benchmarking across various hardware configurations and deployment environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14191)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->