### PR TITLE
[TRTLLM-12706][perf] Optimize beam search candidate reconstruction by skipping prompt-prefix copies

### DIFF
--- a/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernelsTemplate.h
+++ b/cpp/tensorrt_llm/kernels/beamSearchKernels/beamSearchKernelsTemplate.h
@@ -370,6 +370,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
                 // The last token
                 int indexPrev = (topId / nV) % nBM;
                 int const step = bh.sequenceLengths[slot * nBM + indexPrev];
+                int const inputLength = bh.inputLengths[slot * nBM + indexPrev];
                 int const offsetCBA = (slot * nBM * 2 + nCBA) * nMSL;
                 bh.outputIdsCBA[offsetCBA + step] = bh.endIds[slot];
                 if (bh.logProbsCBA != nullptr)
@@ -377,7 +378,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
                     bh.logProbsCBA[offsetCBA + step] = (float) topLogProb - smemCumLogProbs[(topId / nV) % nBM];
                 }
                 // Previous tokens
-                for (int j = step - 1; j >= 0; j--)
+                for (int j = step - 1; j >= inputLength; j--)
                 {
                     bh.outputIdsCBA[offsetCBA + j] = bh.outputIdsPtr[slot][indexPrev * nMSL + j];
                     indexPrev = bh.parentIdsPtr[slot][indexPrev * nMSL + j];
@@ -385,7 +386,7 @@ __launch_bounds__(BLOCK_SIZE) __global__ void beamStage3Kernel(
                 if (bh.logProbsCBA != nullptr && bh.logProbsTiled != nullptr)
                 {
                     indexPrev = (topId / nV) % nBM;
-                    for (int j = step - 1; j >= 0; j--)
+                    for (int j = step - 1; j >= inputLength; j--)
                     {
                         int const index = (j * nMBS + slot) * nBM + indexPrev;
                         bh.logProbsCBA[offsetCBA + j] = bh.logProbsTiled[index];

--- a/cpp/tensorrt_llm/kernels/decodingKernels.cu
+++ b/cpp/tensorrt_llm/kernels/decodingKernels.cu
@@ -345,6 +345,7 @@ __global__ void insertUnfinishedPathKernel(BeamHypotheses bh)
         int const srcBeam = bid * nBM + i;
         int const dstBeam = bid * nBM * 2 + i + indexDstStart;
         int const step = bh.sequenceLengths[srcBeam] - 1;
+        int const inputLength = bh.inputLengths[srcBeam];
 
         // The last token
         int const srcId = srcBeam * nMSL + step;
@@ -356,7 +357,7 @@ __global__ void insertUnfinishedPathKernel(BeamHypotheses bh)
         }
         // Previous tokens
         int prevId = bh.parentIdsUnfinish[srcId];
-        for (int j = step - 1; j >= 0; --j)
+        for (int j = step - 1; j >= inputLength; --j)
         {
             int const index = bid * nBM * nMSL + prevId * nMSL + j;
             bh.outputIdsCBA[dstBeam * nMSL + j] = bh.outputIdsUnfinish[index];
@@ -365,7 +366,7 @@ __global__ void insertUnfinishedPathKernel(BeamHypotheses bh)
         if (bOutputLogProbs)
         {
             prevId = bh.parentIdsUnfinish[srcId];
-            for (int j = step - 1; j >= 0; --j)
+            for (int j = step - 1; j >= inputLength; --j)
             {
                 int const index = bid * nBM * nMSL + prevId * nMSL + j;
                 bh.logProbsCBA[dstBeam * nMSL + j] = bh.logProbsTiled[j * nMBS * nBM + bid * nBM + prevId];
@@ -498,17 +499,26 @@ __global__ void finalizeKernel(BeamHypotheses bh)
     // Move bh.outputIds, bh.logProbs
     for (int beamIdx = 0; beamIdx < nBM; beamIdx++)
     {
+        int const inputLength = bh.inputLengths[bid * nBM + beamIdx];
         for (int i = tid; i < smemSL[beamIdx]; i += blockDim.x)
         {
             int const dst = bid * nBM * nMSL + beamIdx * nMSL + i;
-            int const src = bid * nBM * 2 * nMSL + smemRank[beamIdx] * nMSL + i;
-            bh.outputIds[dst] = bh.outputIdsCBA[src];
+            if (i < inputLength)
+            {
+                int const src = bid * nBM * nMSL + beamIdx * nMSL + i;
+                bh.outputIds[dst] = bh.outputIdsUnfinish[src];
+            }
+            else
+            {
+                int const src = bid * nBM * 2 * nMSL + smemRank[beamIdx] * nMSL + i;
+                bh.outputIds[dst] = bh.outputIdsCBA[src];
+            }
         }
         if (bh.logProbs != nullptr)
         {
             for (int i = tid; i < smemSL[beamIdx]; i += blockDim.x)
             {
-                if (int const inputLength = bh.inputLengths[bid * nBM + beamIdx]; i >= inputLength)
+                if (i >= inputLength)
                 {
                     int const dst = bid * nBM * nMSL + beamIdx * nMSL + i;
                     int const src = bid * nBM * 2 * nMSL + smemRank[beamIdx] * nMSL + i;

--- a/cpp/tests/unit_tests/kernels/decodingKernelTest.cpp
+++ b/cpp/tests/unit_tests/kernels/decodingKernelTest.cpp
@@ -287,6 +287,190 @@ TEST_F(TestBeamHypothesesCopy, SingleBatchTest)
     checkAllEqual();
 }
 
+void runFinalizeKeepsPromptPrefixFromUnfinishedIds(SizeType32 beamWidth)
+{
+    SizeType32 constexpr batchSize{2};
+    SizeType32 constexpr maxSeqLen{9};
+    auto constexpr nvTokenIdType = TRTDataType<TokenIdType>::value;
+    auto constexpr nvSizeType = TRTDataType<SizeType32>::value;
+    auto constexpr nvFloatType = TRTDataType<float>::value;
+    auto constexpr nvBoolType = TRTDataType<bool>::value;
+
+    auto stream = std::make_shared<tensorrt_llm::runtime::CudaStream>();
+    auto bufferManager = std::make_shared<tensorrt_llm::runtime::BufferManager>(stream);
+
+    auto const idsShape = ITensor::makeShape({batchSize, beamWidth, maxSeqLen});
+    auto const cbaShape = ITensor::makeShape({batchSize, beamWidth * 2, maxSeqLen});
+    auto const beamShape = ITensor::makeShape({batchSize, beamWidth});
+    auto const cbaBeamShape = ITensor::makeShape({batchSize, beamWidth * 2});
+
+    auto outputIds = bufferManager->gpu(idsShape, nvTokenIdType);
+    auto outputIdsUnfinish = bufferManager->gpu(idsShape, nvTokenIdType);
+    auto parentIdsUnfinish = bufferManager->gpu(idsShape, nvSizeType);
+    auto outputIdsCBA = bufferManager->gpu(cbaShape, nvTokenIdType);
+    auto sequenceLengths = bufferManager->gpu(beamShape, nvSizeType);
+    auto inputLengths = bufferManager->gpu(beamShape, nvSizeType);
+    auto cumLogProbs = bufferManager->gpu(beamShape, nvFloatType);
+    auto sequenceLengthsCBA = bufferManager->gpu(cbaBeamShape, nvSizeType);
+    auto cumLogProbsCBA = bufferManager->gpu(cbaBeamShape, nvFloatType);
+    auto normedScoresCBA = bufferManager->gpu(cbaBeamShape, nvFloatType);
+    auto numBeamsCBA = bufferManager->gpu(ITensor::makeShape({batchSize}), nvSizeType);
+    auto batchDones = bufferManager->gpu(ITensor::makeShape({batchSize}), nvBoolType);
+    auto lengthPenalties = bufferManager->gpu(ITensor::makeShape({batchSize}), nvFloatType);
+
+    std::vector<TokenIdType> outputIdsHost(batchSize * beamWidth * maxSeqLen, 0);
+    std::vector<TokenIdType> outputIdsUnfinishHost(batchSize * beamWidth * maxSeqLen, -1);
+    std::vector<SizeType32> parentIdsUnfinishHost(batchSize * beamWidth * maxSeqLen, 0);
+    std::vector<TokenIdType> outputIdsCBAHost(batchSize * beamWidth * 2 * maxSeqLen, -777);
+    std::vector<SizeType32> sequenceLengthsHost(batchSize * beamWidth, 0);
+    std::vector<SizeType32> inputLengthsHost(batchSize * beamWidth, 0);
+    std::vector<float> cumLogProbsHost(batchSize * beamWidth, 0.0f);
+    std::vector<SizeType32> sequenceLengthsCBAHost(batchSize * beamWidth * 2, 0);
+    std::vector<float> cumLogProbsCBAHost(batchSize * beamWidth * 2, -100.0f);
+    std::vector<float> normedScoresCBAHost(batchSize * beamWidth * 2, -100.0f);
+    std::vector<SizeType32> numBeamsCBAHost(batchSize, beamWidth);
+    bool batchDonesHost[batchSize] = {false, false};
+    float lengthPenaltiesHost[batchSize] = {0.0f, 0.0f};
+
+    auto promptToken = [](SizeType32 batchIdx, SizeType32 pos) -> TokenIdType
+    { return static_cast<TokenIdType>((batchIdx + 1) * 100 + pos); };
+    auto unfinishedToken = [](SizeType32 batchIdx, SizeType32 beamIdx, SizeType32 pos) -> TokenIdType
+    { return static_cast<TokenIdType>(1000 + batchIdx * 100 + beamIdx * 10 + pos); };
+    auto cbaToken = [](SizeType32 batchIdx, SizeType32 cbaIdx, SizeType32 pos) -> TokenIdType
+    { return static_cast<TokenIdType>(3000 + batchIdx * 100 + cbaIdx * 10 + pos); };
+    auto inputLengthForBatch = [](SizeType32 batchIdx) -> SizeType32 { return batchIdx == 0 ? 3 : 5; };
+    auto sequenceLengthForBatch = [](SizeType32 batchIdx) -> SizeType32 { return batchIdx == 0 ? 7 : 8; };
+
+    for (SizeType32 batchIdx = 0; batchIdx < batchSize; ++batchIdx)
+    {
+        SizeType32 const inputLength = inputLengthForBatch(batchIdx);
+        SizeType32 const sequenceLength = sequenceLengthForBatch(batchIdx);
+        SizeType32 const idsBatchOffset = batchIdx * beamWidth * maxSeqLen;
+        SizeType32 const cbaBatchOffset = batchIdx * beamWidth * 2 * maxSeqLen;
+        SizeType32 const cbaBeamOffset = batchIdx * beamWidth * 2;
+
+        for (SizeType32 beamIdx = 0; beamIdx < beamWidth; ++beamIdx)
+        {
+            SizeType32 const beamOffset = idsBatchOffset + beamIdx * maxSeqLen;
+            inputLengthsHost[batchIdx * beamWidth + beamIdx] = inputLength;
+            sequenceLengthsHost[batchIdx * beamWidth + beamIdx] = sequenceLength;
+            cumLogProbsHost[batchIdx * beamWidth + beamIdx]
+                = beamWidth == 1 ? 12.0f : (beamIdx == 1 ? 12.0f : 5.0f + beamIdx * 3.0f);
+
+            for (SizeType32 pos = 0; pos < sequenceLength; ++pos)
+            {
+                outputIdsUnfinishHost[beamOffset + pos]
+                    = pos < inputLength ? promptToken(batchIdx, pos) : unfinishedToken(batchIdx, beamIdx, pos);
+                parentIdsUnfinishHost[beamOffset + pos] = beamIdx;
+            }
+        }
+
+        for (SizeType32 cbaIdx = 0; cbaIdx < beamWidth; ++cbaIdx)
+        {
+            sequenceLengthsCBAHost[cbaBeamOffset + cbaIdx] = sequenceLength;
+            normedScoresCBAHost[cbaBeamOffset + cbaIdx]
+                = beamWidth == 1 ? 10.0f : (cbaIdx == 1 ? 10.0f : 1.0f - cbaIdx * 2.0f);
+            cumLogProbsCBAHost[cbaBeamOffset + cbaIdx] = normedScoresCBAHost[cbaBeamOffset + cbaIdx];
+            for (SizeType32 pos = inputLength; pos < sequenceLength; ++pos)
+            {
+                outputIdsCBAHost[cbaBatchOffset + cbaIdx * maxSeqLen + pos] = cbaToken(batchIdx, cbaIdx, pos);
+            }
+        }
+    }
+
+    bufferManager->copy(outputIdsHost.data(), *outputIds);
+    bufferManager->copy(outputIdsUnfinishHost.data(), *outputIdsUnfinish);
+    bufferManager->copy(parentIdsUnfinishHost.data(), *parentIdsUnfinish);
+    bufferManager->copy(outputIdsCBAHost.data(), *outputIdsCBA);
+    bufferManager->copy(sequenceLengthsHost.data(), *sequenceLengths);
+    bufferManager->copy(inputLengthsHost.data(), *inputLengths);
+    bufferManager->copy(cumLogProbsHost.data(), *cumLogProbs);
+    bufferManager->copy(sequenceLengthsCBAHost.data(), *sequenceLengthsCBA);
+    bufferManager->copy(cumLogProbsCBAHost.data(), *cumLogProbsCBA);
+    bufferManager->copy(normedScoresCBAHost.data(), *normedScoresCBA);
+    bufferManager->copy(numBeamsCBAHost.data(), *numBeamsCBA);
+    bufferManager->copy(batchDonesHost, *batchDones);
+    bufferManager->copy(lengthPenaltiesHost, *lengthPenalties);
+    stream->synchronize();
+
+    tk::BeamHypotheses bh;
+    bh.nMaxBatchSize = batchSize;
+    bh.nBatchSize = batchSize;
+    bh.nBeamWidth = beamWidth;
+    bh.nMaxSeqLen = maxSeqLen;
+    bh.lengthPenalties = bufferCast<float>(*lengthPenalties);
+    bh.inputLengths = bufferCast<SizeType32>(*inputLengths);
+    bh.outputIds = bufferCast<TokenIdType>(*outputIds);
+    bh.sequenceLengths = bufferCast<SizeType32>(*sequenceLengths);
+    bh.cumLogProbs = bufferCast<float>(*cumLogProbs);
+    bh.outputIdsCBA = bufferCast<TokenIdType>(*outputIdsCBA);
+    bh.sequenceLengthsCBA = bufferCast<SizeType32>(*sequenceLengthsCBA);
+    bh.cumLogProbsCBA = bufferCast<float>(*cumLogProbsCBA);
+    bh.normedScoresCBA = bufferCast<float>(*normedScoresCBA);
+    bh.numBeamsCBA = bufferCast<SizeType32>(*numBeamsCBA);
+    bh.batchDones = bufferCast<bool>(*batchDones);
+    bh.outputIdsUnfinish = bufferCast<TokenIdType>(*outputIdsUnfinish);
+    bh.parentIdsUnfinish = bufferCast<SizeType32>(*parentIdsUnfinish);
+
+    tk::invokeInsertUnfinishedPath(bh, stream->get());
+    tk::invokeFinalize(bh, stream->get());
+    stream->synchronize();
+
+    auto outputIdsResult = bufferManager->copyFrom(*outputIds, MemoryType::kCPU);
+    auto sequenceLengthsResult = bufferManager->copyFrom(*sequenceLengths, MemoryType::kCPU);
+    stream->synchronize();
+    auto const outputIdsPtr = bufferCast<TokenIdType>(*outputIdsResult);
+    auto const sequenceLengthsPtr = bufferCast<SizeType32>(*sequenceLengthsResult);
+
+    for (SizeType32 batchIdx = 0; batchIdx < batchSize; ++batchIdx)
+    {
+        SizeType32 const inputLength = inputLengthForBatch(batchIdx);
+        SizeType32 const sequenceLength = sequenceLengthForBatch(batchIdx);
+        for (SizeType32 beamIdx = 0; beamIdx < beamWidth; ++beamIdx)
+        {
+            EXPECT_EQ(sequenceLengthsPtr[batchIdx * beamWidth + beamIdx], sequenceLength);
+            SizeType32 selectedCbaIdx = 0;
+            if (beamWidth == 1)
+            {
+                selectedCbaIdx = 1;
+            }
+            else
+            {
+                selectedCbaIdx = beamIdx == 0 ? 4 : (beamIdx == 1 ? 5 : 1);
+            }
+
+            for (SizeType32 pos = 0; pos < sequenceLength; ++pos)
+            {
+                TokenIdType expected = promptToken(batchIdx, pos);
+                if (pos >= inputLength)
+                {
+                    if (selectedCbaIdx >= beamWidth)
+                    {
+                        expected = unfinishedToken(batchIdx, selectedCbaIdx - beamWidth, pos);
+                    }
+                    else
+                    {
+                        expected = cbaToken(batchIdx, selectedCbaIdx, pos);
+                    }
+                }
+                SizeType32 const dst = batchIdx * beamWidth * maxSeqLen + beamIdx * maxSeqLen + pos;
+                EXPECT_EQ(outputIdsPtr[dst], expected)
+                    << "batchIdx=" << batchIdx << ", beamIdx=" << beamIdx << ", pos=" << pos;
+            }
+        }
+    }
+}
+
+TEST(BeamHypothesesFinalizeTest, KeepsPromptPrefixFromUnfinishedIds)
+{
+    runFinalizeKeepsPromptPrefixFromUnfinishedIds(3);
+}
+
+TEST(BeamHypothesesFinalizeTest, KeepsPromptPrefixFromUnfinishedIdsBeamWidthOne)
+{
+    runFinalizeKeepsPromptPrefixFromUnfinishedIds(1);
+}
+
 /**
  * @brief Fills a slice of a tensor with data from a source array.
  *


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced beam search kernel logic to correctly preserve input prompt tokens during candidate beam finalization and unfinished path insertion, preventing accidental overwriting of input sequence prefixes in output sequences.

* **Tests**
  * Added dedicated test cases for beam hypothesis finalization across multiple beam widths to ensure proper preservation of prompt token prefixes in decoding operations and validate correct token selection from various beam sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Beam search Stage3 can spend unnecessary time reconstructing candidate sequences when beams finish early. The existing path copies the prompt prefix into candidate buffers even though that prefix is already present in the unfinished output buffer and is unchanged by decoding.

 This PR skips prompt-prefix copies during finished-beam promotion and unfinished-path insertion. Finalization reconstructs the final output by reading prompt-prefix tokens from `outputIdsUnfinish` and generated tokens from the candidate buffer. This reduces redundant memory traffic while preserving the reconstructed token sequence.

## Test Coverage

Added unit coverage in `decodingKernelTest` for finalization preserving the prompt prefix from unfinished output IDs, including:
  - multi-beam case
  - `beam_width=1` edge case

Validated focused test locally on H200 and L40S:
  - `BeamHypothesesFinalizeTest.KeepsPromptPrefixFromUnfinishedIds`
  - `BeamHypothesesFinalizeTest.KeepsPromptPrefixFromUnfinishedIdsBeamWidthOne`
 
Additionally, verified the perf on L40s locally, the average `beamStage3Kernel` launch time dropped from about 80 us to about 18 us, roughly a 4.5x improvement for that kernel.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
