### PR TITLE
[None][bug] NVFP4 MoE: requantize w1/w3 when global scales differ

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -2329,9 +2329,22 @@ class NVFP4FusedMoEMethod(FusedMoEMethodBase):
                 continue
 
             if not torch.allclose(w1_ws2, w3_ws2):
+                # Subclasses are expected to have already requantized the
+                # smaller-sf2 side (gate or up) against max(w1_ws2, w3_ws2)
+                # before this point, so the kernel's shared alpha is
+                # consistent with both block-scale tensors. If they reach
+                # here still unequal, the block scales were left calibrated
+                # against their original sf2 and the kernel will silently
+                # apply the wrong dequantization scale to whichever side has
+                # the smaller sf2 -- warn loudly.
                 logger.warning(
                     f"w1_weight_scale_2 != w3_weight_scale_2 ({w1_ws2} != {w3_ws2}), "
-                    f"selecting the larger value. Accuracy may be affected.")
+                    f"selecting the larger value. The block scales were not "
+                    f"rescaled to compensate; the kernel will use an inflated "
+                    f"effective scale on the smaller-sf2 side. Accuracy will "
+                    f"be affected; preferred fix is to pre-fuse the scales in "
+                    f"the checkpoint (re-quantize gate and up against "
+                    f"max(gate_sf2, up_sf2)).")
                 w1_ws2 = torch.max(w1_ws2, w3_ws2)
                 w3_ws2 = w1_ws2
 
@@ -2724,7 +2737,106 @@ class NVFP4CutlassFusedMoEMethod(NVFP4FusedMoEMethod):
                 "constant", 0).contiguous()
         return source_tensor
 
+    @staticmethod
+    def _requantize_fp4_with_new_scale_2(weight: torch.Tensor,
+                                         weight_scale: torch.Tensor,
+                                         old_scale_2: torch.Tensor,
+                                         new_scale_2: torch.Tensor):
+        """Dequantize an NVFP4 weight + block scale tensor pair using the
+        original per-tensor global scale, then requantize with ``new_scale_2``.
+
+        Returns a (new_weight, new_weight_scale) pair with the same shapes,
+        dtypes, and device as the originals.  Use this when fusing two
+        projections (e.g. gate/up) that were calibrated with different
+        weight_scale_2 values into a single GEMM whose alpha must be derived
+        from a shared scale -- if only the alpha is changed without
+        requantizing the smaller-sf2 side, the kernel applies an inflated
+        effective scale to that side and dequantization is wrong.
+        """
+        orig_scale_dtype = weight_scale.dtype
+        orig_scale_shape = weight_scale.shape
+        orig_weight_device = weight.device
+
+        # Dequantize on whichever device is convenient and bf16-cast for
+        # numerical stability through the requant; the ops themselves run
+        # on CUDA.
+        dequant_shape = (weight.shape[0], weight.shape[1] * 2)
+        weight_dequant = torch.ops.tensorrt_llm.e2m1_and_ufp8sf_scale_to_float_v2(
+            weight.contiguous(),
+            weight_scale.flatten().view(float4_sf_dtype).contiguous(),
+            old_scale_2, 16, 1, True).to(dtype=torch.bfloat16).reshape(
+                dequant_shape)
+
+        weight_requant, weight_scale_requant = torch.ops.trtllm.fp4_quantize(
+            weight_dequant.cuda(), (1.0 / new_scale_2).cuda(), 16, False)
+
+        return (weight_requant.to(device=orig_weight_device,
+                                  dtype=weight.dtype),
+                weight_scale_requant.reshape(orig_scale_shape).view(
+                    orig_scale_dtype).to(device=weight_scale.device))
+
+    def _fuse_w3_w1_scale_2(self, module: torch.nn.Module):
+        """Pre-fuse gate (w1) and up (w3) weight_scale_2 in-place by
+        requantizing the smaller-sf2 side against max(w1_sf2, w3_sf2).
+
+        Without this step the kernel applies a shared alpha = max(sf2) *
+        input_scale to both halves, but the smaller-sf2 side's block scales
+        were calibrated against its own (smaller) sf2 -- so the effective
+        dequant scale on that side is inflated by max_sf2/own_sf2.  See
+        comment in _reconcile_and_compute_alphas for the assumption.
+        """
+        if (not hasattr(module, 'tmp_weight_scale_2')
+                or not hasattr(module, 'tmp_cutlass_w3_w1_weights')
+                or not hasattr(module, 'tmp_cutlass_w3_w1_weight_scales')):
+            return
+
+        # Build an index of (expert_idx -> list of (weight_entry, scale_entry))
+        # so we can update regular and shared-expert copies of the same expert
+        # in lockstep.
+        by_expert: Dict[int, List[Tuple[Dict, Dict]]] = {}
+        weight_buckets: Dict[int, List[Dict]] = {}
+        for (_, expert_idx), entry in module.tmp_cutlass_w3_w1_weights.items():
+            weight_buckets.setdefault(expert_idx, []).append(entry)
+        for (_, expert_idx), entry in (
+                module.tmp_cutlass_w3_w1_weight_scales.items()):
+            for w_entry in weight_buckets.get(expert_idx, []):
+                by_expert.setdefault(expert_idx, []).append((w_entry, entry))
+
+        for expert_idx, scales in module.tmp_weight_scale_2.items():
+            w1_sf2 = scales.get('w1')
+            w3_sf2 = scales.get('w3')
+            if w1_sf2 is None or w3_sf2 is None:
+                continue
+            if torch.allclose(w1_sf2, w3_sf2):
+                continue
+
+            max_sf2 = torch.max(w1_sf2, w3_sf2)
+            for w_entry, s_entry in by_expert.get(expert_idx, []):
+                for half in ('w1', 'w3'):
+                    old_sf2 = scales[half]
+                    if torch.allclose(old_sf2, max_sf2):
+                        continue  # Already at max, no requant needed.
+                    weight = w_entry.get(half)
+                    scale = s_entry.get(half)
+                    if weight is None or scale is None:
+                        continue
+                    new_weight, new_scale = (
+                        self._requantize_fp4_with_new_scale_2(
+                            weight, scale, old_sf2, max_sf2))
+                    w_entry[half] = new_weight
+                    s_entry[half] = new_scale
+
+            # Mark this expert as fused so _reconcile_and_compute_alphas
+            # skips the warning and just computes alpha from the shared sf2.
+            scales['w1'] = max_sf2
+            scales['w3'] = max_sf2
+
     def process_weights_after_loading(self, module: torch.nn.Module):
+        # Requantize per-expert when gate (w1) and up (w3) have different
+        # per-tensor weight_scale_2 -- must run before cat+pad+interleave
+        # so the rescaled block scales feed into the finalized buffers.
+        self._fuse_w3_w1_scale_2(module)
+
         # Finalize w3_w1 weights: cat + pad
         if hasattr(module, 'tmp_cutlass_w3_w1_weights'):
             for entry in module.tmp_cutlass_w3_w1_weights.values():

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -2756,10 +2756,18 @@ class NVFP4CutlassFusedMoEMethod(NVFP4FusedMoEMethod):
         orig_scale_dtype = weight_scale.dtype
         orig_scale_shape = weight_scale.shape
         orig_weight_device = weight.device
+        orig_scale_device = weight_scale.device
 
-        # Dequantize on whichever device is convenient and bf16-cast for
-        # numerical stability through the requant; the ops themselves run
-        # on CUDA.
+        # fp4_quantize requires a CUDA tensor. Regular experts live on this
+        # rank's GPU (cuda:local_rank); shared experts (online EPLB) are staged
+        # on CPU. Pick the weight's own CUDA device when available, otherwise
+        # the rank's active CUDA device -- never a bare .cuda() (== cuda:0),
+        # which would spill onto the wrong GPU under multi-GPU TP.
+        compute_device = weight.device if weight.is_cuda else torch.device(
+            'cuda', torch.cuda.current_device())
+
+        # Dequantize on the input's native device (the dequant op accepts CPU
+        # and CUDA) and bf16-cast for numerical stability through the requant.
         dequant_shape = (weight.shape[0], weight.shape[1] * 2)
         weight_dequant = torch.ops.tensorrt_llm.e2m1_and_ufp8sf_scale_to_float_v2(
             weight.contiguous(),
@@ -2768,12 +2776,13 @@ class NVFP4CutlassFusedMoEMethod(NVFP4FusedMoEMethod):
                 dequant_shape)
 
         weight_requant, weight_scale_requant = torch.ops.trtllm.fp4_quantize(
-            weight_dequant.cuda(), (1.0 / new_scale_2).cuda(), 16, False)
+            weight_dequant.to(compute_device),
+            (1.0 / new_scale_2).to(compute_device), 16, False)
 
         return (weight_requant.to(device=orig_weight_device,
                                   dtype=weight.dtype),
                 weight_scale_requant.reshape(orig_scale_shape).view(
-                    orig_scale_dtype).to(device=weight_scale.device))
+                    orig_scale_dtype).to(device=orig_scale_device))
 
     def _fuse_w3_w1_scale_2(self, module: torch.nn.Module):
         """Pre-fuse gate (w1) and up (w3) weight_scale_2 in-place by
@@ -2784,25 +2793,64 @@ class NVFP4CutlassFusedMoEMethod(NVFP4FusedMoEMethod):
         were calibrated against its own (smaller) sf2 -- so the effective
         dequant scale on that side is inflated by max_sf2/own_sf2.  See
         comment in _reconcile_and_compute_alphas for the assumption.
+
+        Regular and shared (online EPLB) experts are fused independently:
+        each set of experts has its own per-tensor sf2 dict and its own dst
+        weight/scale buffers, and both index local experts from slot 0. They
+        must not be merged -- the regular sf2 is unrelated to the shared one,
+        so fusing them in the same bucket would requantize shared weights
+        against the wrong scale and leave tmp_shared_weight_scale_2 untouched
+        (still mismatched, still warning).
         """
-        if (not hasattr(module, 'tmp_weight_scale_2')
-                or not hasattr(module, 'tmp_cutlass_w3_w1_weights')
+        if (not hasattr(module, 'tmp_cutlass_w3_w1_weights')
                 or not hasattr(module, 'tmp_cutlass_w3_w1_weight_scales')):
             return
 
-        # Build an index of (expert_idx -> list of (weight_entry, scale_entry))
-        # so we can update regular and shared-expert copies of the same expert
-        # in lockstep.
-        by_expert: Dict[int, List[Tuple[Dict, Dict]]] = {}
-        weight_buckets: Dict[int, List[Dict]] = {}
-        for (_, expert_idx), entry in module.tmp_cutlass_w3_w1_weights.items():
-            weight_buckets.setdefault(expert_idx, []).append(entry)
-        for (_, expert_idx), entry in (
-                module.tmp_cutlass_w3_w1_weight_scales.items()):
-            for w_entry in weight_buckets.get(expert_idx, []):
-                by_expert.setdefault(expert_idx, []).append((w_entry, entry))
+        # Regular experts: weights/scales destined for the module's own
+        # w3_w1 buffers, with per-tensor sf2 in tmp_weight_scale_2.
+        if hasattr(module, 'tmp_weight_scale_2'):
+            self._fuse_w3_w1_scale_2_for_dst(
+                module, module.tmp_weight_scale_2,
+                module.w3_w1_weight.data.storage().data_ptr(),
+                module.w3_w1_weight_scale.data.storage().data_ptr())
 
-        for expert_idx, scales in module.tmp_weight_scale_2.items():
+        # Shared experts (online EPLB): staged in the local_shared buffers
+        # with their own per-tensor sf2 in tmp_shared_weight_scale_2.
+        if (hasattr(module, 'tmp_shared_weight_scale_2')
+                and getattr(module, 'local_shared_w3_w1_tensors', None)
+                is not None and getattr(
+                    module, 'local_shared_w3_w1_scale_tensors', None)
+                is not None):
+            self._fuse_w3_w1_scale_2_for_dst(
+                module, module.tmp_shared_weight_scale_2,
+                module.local_shared_w3_w1_tensors.storage().data_ptr(),
+                module.local_shared_w3_w1_scale_tensors.storage().data_ptr())
+
+    def _fuse_w3_w1_scale_2_for_dst(self, module: torch.nn.Module,
+                                    sf2_by_expert: Dict[int, Dict],
+                                    weight_dst_base: int, scale_dst_base: int):
+        """Fuse w1/w3 sf2 for one set of experts (regular or shared).
+
+        ``weight_dst_base`` / ``scale_dst_base`` are the ``data_ptr()`` of the
+        destination weight / scale buffers for this set; the tmp dicts are
+        keyed on ``(dst_base, expert_idx)`` precisely so regular and shared
+        copies of the same local expert id can be told apart. We select only
+        the entries for this set, so each ``expert_idx`` maps to exactly one
+        weight entry and one scale entry.
+        """
+        weights_by_expert: Dict[int, Dict] = {
+            expert_idx: entry
+            for (base, expert_idx), entry in
+            module.tmp_cutlass_w3_w1_weights.items() if base == weight_dst_base
+        }
+        scales_by_expert: Dict[int, Dict] = {
+            expert_idx: entry
+            for (base, expert_idx), entry in
+            module.tmp_cutlass_w3_w1_weight_scales.items()
+            if base == scale_dst_base
+        }
+
+        for expert_idx, scales in sf2_by_expert.items():
             w1_sf2 = scales.get('w1')
             w3_sf2 = scales.get('w3')
             if w1_sf2 is None or w3_sf2 is None:
@@ -2811,7 +2859,9 @@ class NVFP4CutlassFusedMoEMethod(NVFP4FusedMoEMethod):
                 continue
 
             max_sf2 = torch.max(w1_sf2, w3_sf2)
-            for w_entry, s_entry in by_expert.get(expert_idx, []):
+            w_entry = weights_by_expert.get(expert_idx)
+            s_entry = scales_by_expert.get(expert_idx)
+            if w_entry is not None and s_entry is not None:
                 for half in ('w1', 'w3'):
                     old_sf2 = scales[half]
                     if torch.allclose(old_sf2, max_sf2):


### PR DESCRIPTION
## Summary

`NVFP4FusedMoEMethod._reconcile_and_compute_alphas` (in `tensorrt_llm/_torch/modules/fused_moe/quantization.py`) silently produces wrong dequantization when a checkpoint stores **different per-tensor `weight_scale_2` (sf2) for gate (`w1`) and up (`w3`)**.

The current behaviour:
1. Detect the mismatch (`torch.allclose(w1_ws2, w3_ws2)` is false).
2. Log a warning.
3. Pick `max(w1_sf2, w3_sf2)` and use it for the shared `fc31_alpha`.
4. Compute alpha.
5. **Do nothing to the block scales (`weight_scale`).**

The block scales on the smaller-sf2 side were calibrated against their own (smaller) sf2 and are never rescaled. The kernel then applies a shared `alpha = max_sf2 * input_scale` to both halves of the fused gate+up GEMM, which means the effective dequant scale on the smaller-sf2 side is inflated by `max_sf2 / own_sf2`.

For a representative DeepSeek-V3-style expert in our checkpoint:
- `gate_sf2 = 3.85e-05`
- `up_sf2 = 4.83e-05`
- ratio `= 1.2547`

→ gate output is inflated by ~1.25× silently. This degrades accuracy noticeably on MoE evals.

The same checkpoint re-quantized so both gate and up share `max(gate_sf2, up_sf2)` (i.e. block scales recalibrated against the shared sf2) recovers accuracy fully — confirming the root cause.

## Numerical verification

Sampled gate/up pairs from two otherwise-identical NVFP4 checkpoints — one pre-fused, one not — and confirmed:
- For every pair, `fused_sf2 == max(gate_sf2, up_sf2)` from the non-fused (7/7 sampled base-model pairs, 384/384 MTP pairs, zero mismatches).
- The fused gate block scales equal the non-fused gate block scales × `gate_sf2 / max_sf2` (≈ 0.797 for the example expert above), matching what this PR's requant produces.

## Fix

`NVFP4CutlassFusedMoEMethod.process_weights_after_loading` now requantizes the smaller-sf2 side against `max(w1_sf2, w3_sf2)` **before** the per-expert `cat + pad + interleave` of weights and block scales. After requant, both halves share the same `weight_scale_2`, so:
- The block scales feeding into the finalized `module.fc31_weight_scale` are consistent with the shared alpha.
- `_reconcile_and_compute_alphas` sees equal sf2 and does not warn.
- This is a **no-op** when the checkpoint is already pre-fused (`gate_sf2 == up_sf2`).

Mechanically the requant mirrors the existing `requantize_weight_with_new_scale` pattern already used for fused attention QKV in `modeling_deepseekv3.py`:
1. Dequant FP4 weight using original sf2 → bf16.
2. Requant bf16 weight against new sf2 → new FP4 weight + new block scales.

The warning text in `_reconcile_and_compute_alphas` is also tightened to make clear that reaching it means the block scales were not adjusted and accuracy *will* be affected — so other backends (TRT-LLM Gen, custom paths) that don't yet perform this requant produce a visible diagnostic instead of an "Accuracy may be affected" hedge.

## Scope

- **Fixed**: `NVFP4CutlassFusedMoEMethod` (which `NVFP4CuteDslFusedMoEMethod` inherits from — so that path is covered too).
- **Not fixed in this PR** (still relies on pre-fused checkpoints, but now warn loudly):
  - `NVFP4TRTLLMGenFusedMoEMethod` — has its own weight shuffling path; needs a separate fix.
  - `WInt4AFP8FusedMoEMethod` VANILLA path (lines ~1635) — does a uniform `block_scale /= max_sf2` which also doesn't correctly handle per-half differences, but that's a separate W4A8 issue.

## Test plan

- [ ] Run an existing NVFP4 MoE unit test (e.g. `tests/unittest/_torch/modules/test_fused_moe.py`) with a fabricated checkpoint where `gate_sf2 != up_sf2`; assert dequant output matches a reference quantized with `max(gate_sf2, up_sf2)`.
- [ ] Confirm no-op behaviour for pre-fused checkpoints (e.g. ModelOpt output where the export step already fuses scales): same `fc31_weight_scale`, same `fc31_alpha`, no warning.
- [ ] Sanity-check accuracy on a non-pre-fused DeepSeek-V3-style NVFP4 MoE checkpoint vs the same checkpoint re-quantized with pre-fused scales — should now match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quantization handling for FP4 fused MoE weights with mismatched scales—system now automatically reconciles scale differences during processing.
  * Enhanced diagnostic warnings to provide clearer guidance when weight scale mismatches occur.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->