### PR TITLE
[None][chore] log KV cache utilization and context tokens per iter

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1057,7 +1057,7 @@ class PyExecutor:
                     f"iter = {self.iter_counter}, "
                     f"global_rank = {self.global_rank}, "
                     f"rank = {self.dist.rank}, "
-                    f"num_scheduled_requests: {self.num_scheduled_requests}, "
+                    f"num_scheduled_requests = {self.num_scheduled_requests}, "
                     f"kv_cache_util = {kv_util_str}, "
                     f"currank_total_requests = {self.num_fetch_requests_cur_rank}/"
                     f"{self.num_fetch_requests}, "

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1048,16 +1048,22 @@ class PyExecutor:
                 host_step_time = (end_time - start_time) * 1000  # milliseconds
                 formatted_timestamp = datetime.datetime.now().strftime(
                     "%Y-%m-%d %H:%M:%S")
+                kv_util_str = "N/A"
+                if self.kv_cache_manager is not None:
+                    kv_stats = self.kv_cache_manager.get_kv_cache_stats()
+                    if kv_stats.max_num_blocks > 0:
+                        kv_util_str = f"{1.0 - kv_stats.free_num_blocks / kv_stats.max_num_blocks:.3f}"
                 logger.info(
                     f"iter = {self.iter_counter}, "
                     f"global_rank = {self.global_rank}, "
                     f"rank = {self.dist.rank}, "
+                    f"num_scheduled_requests: {self.num_scheduled_requests}, "
+                    f"kv_cache_util = {kv_util_str}, "
                     f"currank_total_requests = {self.num_fetch_requests_cur_rank}/"
                     f"{self.num_fetch_requests}, "
                     f"host_step_time = {host_step_time}ms, "
                     f"prev_device_step_time = {prev_device_step_time}, "
                     f"timestamp = {formatted_timestamp}, "
-                    f"num_scheduled_requests: {self.num_scheduled_requests}, "
                     f"states = {self.model_engine.iter_states}")
 
             it += 1
@@ -3759,8 +3765,11 @@ class PyExecutor:
             num_accepted_tokens_device: Optional[torch.Tensor] = None):
         ExpertStatistic.set_iter(self.iter_counter)
 
+        num_ctx_tokens = sum(req.context_chunk_size
+                             for req in scheduled_requests.context_requests)
+
         @nvtx_range(
-            f"[Executor] _forward_step {self.iter_counter}: {scheduled_requests.num_context_requests} ctx reqs, {scheduled_requests.num_generation_requests} gen reqs"
+            f"[Executor] _forward_step {self.iter_counter}: {scheduled_requests.num_context_requests} ctx reqs, {num_ctx_tokens} ctx tokens, {scheduled_requests.num_generation_requests} gen reqs"
         )
         def forward(scheduled_requests, resource_manager, new_tensors_device,
                     gather_context_logits, cache_indirection_buffer,


### PR DESCRIPTION
## Description

Adds two pieces of per-iteration observability to the PyTorch `PyExecutor`:

1. **KV cache utilization in the per-iter info log.** Derived from `KVCacheManager.get_kv_cache_stats()` as `1 - free_num_blocks / max_num_blocks`. Also moves `num_scheduled_requests` adjacent to it so the per-iter scheduling picture reads as a single block. The stats fetch sits inside the existing `self.print_log` gate, so there is no extra cost when per-iter logging is disabled. When the KV cache manager is unavailable or uninitialized (`max_num_blocks == 0`), the field reports `N/A`.

2. **Context-token count in the `_forward_step` NVTX range label.** Sums `context_chunk_size` over scheduled context requests so the total context-token count appears next to the existing ctx/gen request counts in nsys traces.

No behavior change outside of logging/tracing.

## Test Coverage

This is a logging/tracing-only change with no new code paths or APIs:
- No new unit tests are warranted; existing `PyExecutor` tests continue to exercise the gated log site.
- Manual verification: run a workload with per-iter logging enabled and confirm `kv_cache_util` appears and tracks expected behavior across prefill/generation; capture an nsys trace and confirm the `_forward_step` NVTX range shows the `<N> ctx tokens` field.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
