### PR TITLE
[None][fix] MegaMoE: reject TEP topology in __init__

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py
@@ -238,23 +238,24 @@ class MegaMoEDeepGemm(MoE):
                 f"divisible by ep_size ({self.ep_size})."
             )
 
-        # ADP semantics: DG's fp8_fp4_mega_moe subsumes cross-rank token
-        # dispatch into its internal symm_mem exchange. When EP spans
-        # *all* ranks that may carry tokens (i.e. ``ep_size ==
-        # parallel_size``), no outer allgather / reducescatter is needed:
-        # every token's origin rank is inside the EP group and DG returns
-        # results to that origin. If EP is a strict subset of
-        # parallel_size (e.g. attention-DP > moe_ep_size), some tokens
-        # live on ranks that the DG kernel cannot reach — that topology
-        # is not yet supported.
+        # DG's fp8_fp4_mega_moe assumes the MoE input is partitioned across
+        # ranks (each rank's SymmBuffer holds a unique slice). Supported:
+        # single rank, or DEP with ep_size == parallel_size. Reject both
+        # DEP > EP (some tokens unreachable) and TEP (input TP-replicated
+        # so dispatch sees parallel_size duplicate copies — math correct,
+        # wall ~parallel_size× slower).
         if self.use_dp and self.parallel_size > 1:
             assert self.ep_size == self.parallel_size, (
                 f"MegaMoEDeepGemm with enable_attention_dp=True requires "
                 f"ep_size == parallel_size (got ep_size={self.ep_size}, "
-                f"parallel_size={self.parallel_size}). Configurations "
-                f"with ADP > EP are not yet supported; add the standard "
-                f"allgather(pre) + reducescatter(post) wrapper before "
-                f"calling fp8_fp4_mega_moe to support them."
+                f"parallel_size={self.parallel_size})."
+            )
+        elif (not self.use_dp) and self.parallel_size > 1:
+            raise NotImplementedError(
+                f"MegaMoEDeepGemm does not support TEP "
+                f"(enable_attention_dp=False, parallel_size="
+                f"{self.parallel_size}>1). Use moe_config.backend=TRTLLM "
+                f"or enable attention-DP with ep_size == parallel_size."
             )
 
         # apply_router_weight_on_input pre-multiplies routing weights


### PR DESCRIPTION
## Description

`MegaMoEDeepGemm` (`scheduler_kind=FUSED_COMM`) fuses dispatch + GEMMs + combine into a single NVLink-SymmBuffer kernel that assumes the MoE input is partitioned across ranks. The existing `__init__` guard only validates DEP (`use_dp=True`, `ep_size==parallel_size`). **TEP** (`enable_attention_dp=False`, `parallel_size>1`) silently runs: the MoE input is TP-replicated (attention's `o_proj` AllReduce), so SymmBuffer dispatch sees `parallel_size` duplicate copies of each routed slot and runs expert compute on every copy. Math is correct, wall is `~parallel_size×` slower.

DSv4-Pro 8k-1k TEP8 c=128 mtp0:

| backend | sys_total tok/s | Δ vs TRTLLM |
| --- | ---: | ---: |
| TRTLLM | 16095 | — |
| MEGAMOE_DEEPGEMM | 11948 | **−25.8%** |

DEP8 c=512 (supported path): MEGAMOE +2.66% vs TRTLLM. A torch.profiler trace localizes the entire TEP gap inside `sm100_fp8_fp4_mega_moe_impl<10560,...>` (3.94 ms/invocation × 61 layers vs ~430 ms total for TRTLLM's split GEMMs over the same window).

This PR adds a symmetric `NotImplementedError` for the TEP case with an actionable error (use `TRTLLM` backend or enable attention-DP). The existing DEP guard is unchanged. Future work: replace rejection with either a slice+AG Python wrapper or a `kSkipCrossRankComm` DG kernel template.

## Test Coverage

- TEP8 c=128 mtp0 `MEGAMOE_DEEPGEMM`: before — silent 11948 tok/s (−25.8%); after — clean `NotImplementedError` surfaced via `create_moe.py:128`.
- DEP8 c=512 mtp0 `MEGAMOE_DEEPGEMM`: still initializes and produces ~33752 tok/s (supported path untouched).
- Unit test deferred: existing `MegaMoEDeepGemm` test scaffold is single-rank, so the new branch isn't triggered. A TP=2 DDP fixture would be a follow-up.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
