### PR TITLE
[https://nvbugs/6094070][fix] Skip ray-marked integration tests when --run-ray is not set

### DIFF
--- a/tests/integration/defs/conftest.py
+++ b/tests/integration/defs/conftest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -2259,6 +2259,14 @@ def pytest_collection_modifyitems(session, config, items):
 
     if waives_file:
         apply_waives(waives_file, items, config)
+
+    # Skip tests with pytest.mark.ray unless --run-ray is passed.
+    if not config.getoption("--run-ray"):
+        skip_marker = pytest.mark.skip(
+            reason="Ray tests skipped; pass --run-ray to enable")
+        for item in items:
+            if item.get_closest_marker("ray") is not None:
+                item.add_marker(skip_marker)
 
     # We have to remove prefix temporarily before splitting the test list
     # After that change back the test id.


### PR DESCRIPTION
## Summary
Adds skip logic for ray-marked tests in `tests/integration/defs/conftest.py`, mirroring `tests/unittest/conftest.py:202-211`. Pipelines without ray installed (e.g. `LLM_FUNCTION_CLUSTER_TEST`) will now skip ray tests instead of failing with `ModuleNotFoundError`.

L0 Ray stage is unaffected — Jenkins already passes `--run-ray` for `*-Ray-*` stages.

Fixes https://nvbugs/6094070

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced weight-loading behavior for linear layers with improved support for NVFP4 quantization.
  * Added support for partial weight reloading across different weight modes.
  * Better handling of weight management during model loading.

* **Tests**
  * Updated test collection and configuration logic for improved test execution flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->