### PR TITLE
[None][test] Add verl post-merge E2E gates (0.5B convergence + 7B Megatron smoke)

### DIFF
--- a/tests/integration/defs/verl/.gitignore
+++ b/tests/integration/defs/verl/.gitignore
@@ -1,1 +1,2 @@
 verl_repo/
+logs/

--- a/tests/integration/defs/verl/conftest.py
+++ b/tests/integration/defs/verl/conftest.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Expose the session-scoped ``verl_setup`` fixture to every test in this directory.
+
+The fixture is defined in ``test_verl_cases.py`` with ``autouse=True``, but
+pytest's autouse semantics only apply within the defining module, so tests
+in sibling files (``test_verl_E2E_*.py``) would hit KeyError on env vars
+like ``TRTLLM_TEST_MODEL_PATH_ROOT`` and ModuleNotFoundError on
+``verl.trainer.main_ppo`` without this re-export. Re-importing here makes
+the fixture (and its autouse) visible to every test in this package, so
+the E2E files inherit the verl clone/install + env-var export from
+``verl_config.yml`` without having to import it themselves.
+"""
+
+from .test_verl_cases import verl_setup  # noqa: F401

--- a/tests/integration/defs/verl/test_verl_E2E_convergence.py
+++ b/tests/integration/defs/verl/test_verl_E2E_convergence.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""E2E smoke + IS-ratio sanity gate for verl GRPO training with TRT-LLM rollout.
+
+Runs 30 GRPO training steps on Qwen2.5-0.5B-Instruct + GSM8K against the
+pinned verl revision, parses the trainer's per-step stdout, and asserts:
+
+  1. ``max(critic/rewards/mean) > 0.01`` — the model shows *any* learning
+     signal (i.e. at least one step where it gets >0 correct out of 64).
+     This is not a real convergence assertion — verl's own
+     ``check_results.py`` uses 0.2 with much longer training. Calibrated
+     instead to GSM8K's binary 0/1 reward × effective batch=64, so
+     non-zero rewards are 1/64=0.0156, 2/64=0.0313, 4/64=0.0625, …;
+     the threshold survives runs that only hit 1/64 once.
+  2. ``max(actor/ppo_kl) < 0.1`` — the importance-sampling ratio
+     ``π_train/π_rollout`` stays in ``[exp(-0.1), exp(0.1)] ≈ [0.905,
+     1.105]`` (i.e. near 1 within ±10%). Catches weight-sync / dtype /
+     NaN-gradient regressions on the trainer↔rollout boundary.
+
+Empirical 20-step dry-runs on this config measured
+``max(critic/rewards/mean) ∈ {0.0156, 0.0625}`` (heavy-tail spikes) and
+``max(actor/ppo_kl) ≤ 5e-4`` — both bounds clear with significant margin.
+"""
+
+import os
+
+import pytest
+
+from .test_verl_cases import _check_convergence, _ensure_gsm8k, _run_verl_train
+
+
+@pytest.mark.timeout(1800)
+def test_e2e_convergence_qwen25_05b_grpo_trtllm():
+    """30-step GRPO on GSM8K + Qwen2.5-0.5B-Instruct + TRT-LLM rollout."""
+    model = os.path.join(os.environ["TRTLLM_TEST_MODEL_PATH_ROOT"], "Qwen/Qwen2.5-0.5B-Instruct")
+    data_dir = _ensure_gsm8k("/tmp/verl-data/gsm8k")
+    log_file = _run_verl_train(
+        [
+            "algorithm.adv_estimator=grpo",
+            f"actor_rollout_ref.model.path={model}",
+            f"data.train_files=['{data_dir}/train.parquet']",
+            f"data.val_files=['{data_dir}/test.parquet']",
+            "data.train_batch_size=16",
+            "data.max_prompt_length=512",
+            # GSM8K chain-of-thought + final answer typically needs 200-400
+            # tokens; at 128 we observed 98.4% of rollouts getting clipped
+            # → 0 valid answers → 0 reward → 0 advantage → 0 gradient → policy
+            # never updates (ppo_kl=0). 512 gives the 0.5B model room to
+            # actually produce answers and learn.
+            "data.max_response_length=512",
+            "actor_rollout_ref.actor.ppo_mini_batch_size=8",
+            "actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1",
+            "actor_rollout_ref.rollout.name=trtllm",
+            "actor_rollout_ref.rollout.tensor_model_parallel_size=1",
+            "actor_rollout_ref.rollout.n=4",
+            "actor_rollout_ref.rollout.max_num_seqs=16",
+            # 16 seqs × (512 prompt + 512 response) = 16384 worst-case
+            # batched tokens; bump from the trtllm rollout default (1024)
+            # so generation isn't artificially serialized.
+            "actor_rollout_ref.rollout.max_num_batched_tokens=16384",
+            "actor_rollout_ref.rollout.max_model_len=1024",
+            "actor_rollout_ref.rollout.gpu_memory_utilization=0.6",
+            "actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1",
+            "actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1",
+            "trainer.logger=['console']",
+            "trainer.n_gpus_per_node=4",
+            "trainer.nnodes=1",
+            "trainer.total_training_steps=30",
+            "trainer.save_freq=-1",
+            "trainer.test_freq=-1",
+        ],
+        timeout=1800,
+    )
+    _check_convergence(log_file, target=0.01, ppo_kl_max=0.1)

--- a/tests/integration/defs/verl/test_verl_E2E_feature.py
+++ b/tests/integration/defs/verl/test_verl_E2E_feature.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""E2E feature-combination smoke gate for verl + TRT-LLM rollout.
+
+Exercises the most-feature-loaded recipe currently shipped by verl —
+``examples/grpo_trainer/run_qwen3_8b_megatron.sh`` — with Megatron
+(TP=2/PP=1) actor + TRT-LLM rollout (TP=2) on Qwen2.5-7B-Instruct, runs
+3 training steps, and passes when the subprocess exits 0.
+
+Why 3 steps (not 1):
+  - step 1 covers the cold-start path: resource pool, Megatron init,
+    initial weight transfer trainer→rollout, first rollout, first PPO update.
+  - step 2 covers the post-update path: weight resync after the actor
+    has been updated, second rollout with refreshed weights.
+  - step 3 covers steady state: confirms it's not a "only the first
+    iteration works" regression.
+
+Purpose is a smoke gate over the Megatron-actor + TRT-LLM-rollout
+combination. No per-step metric assertion — that's the convergence-style
+gate in ``test_verl_E2E_convergence.py``.
+
+The shell recipe defaults to ``NGPUS_PER_NODE=8``; the verl CI stage runs
+on 4 GPUs (DGX_B200-4_GPUs-Verl-Post-Merge-1), so we override to 4 +
+``NNODES=1`` to keep the resource pool sizeable.
+"""
+
+import os
+import subprocess
+
+import pytest
+
+from .test_verl_cases import VERL_ROOT, _ensure_gsm8k
+
+
+@pytest.mark.timeout(1500)
+def test_e2e_smoke_qwen25_7b_megatron_trtllm():
+    """1-step Megatron(TP=2,PP=1) GRPO + Qwen2.5-7B + TRT-LLM rollout."""
+    model = os.path.join(os.environ["TRTLLM_TEST_MODEL_PATH_ROOT"], "Qwen/Qwen2.5-7B-Instruct")
+    data_dir = _ensure_gsm8k("/tmp/verl-data/gsm8k")
+    env = os.environ.copy()
+    # The recipe builds its TRAINER array from these env vars; default is
+    # NGPUS_PER_NODE=8 which makes verl's resource pool manager refuse to
+    # allocate ("Total available GPUs 4 < total desired GPUs 8") on the
+    # 4-GPU verl post-merge stage.
+    env.update(
+        {
+            "ACTOR_TP": "2",
+            "ACTOR_PP": "1",
+            "ROLLOUT_TP": "2",
+            "NGPUS_PER_NODE": "4",
+            "NNODES": "1",
+            "INFER_BACKEND": "trtllm",
+            "MODEL_PATH": model,
+        }
+    )
+    cmd = [
+        "bash",
+        os.path.join(VERL_ROOT, "examples/grpo_trainer/run_qwen3_8b_megatron.sh"),
+        "trainer.total_training_steps=3",
+        "data.train_batch_size=32",
+        "data.max_prompt_length=128",
+        "data.max_response_length=64",
+        "actor_rollout_ref.rollout.n=1",
+        "actor_rollout_ref.actor.ppo_mini_batch_size=32",
+        "actor_rollout_ref.rollout.max_num_seqs=32",
+        "actor_rollout_ref.rollout.max_num_batched_tokens=1024",
+        "actor_rollout_ref.rollout.max_model_len=256",
+        f"data.train_files=['{data_dir}/train.parquet']",
+        f"data.val_files=['{data_dir}/test.parquet']",
+        "trainer.logger=['console']",
+    ]
+    result = subprocess.run(cmd, cwd=VERL_ROOT, env=env, timeout=1500)
+    assert result.returncode == 0, f"run_qwen3_8b_megatron.sh exited {result.returncode}"

--- a/tests/integration/defs/verl/test_verl_cases.py
+++ b/tests/integration/defs/verl/test_verl_cases.py
@@ -22,8 +22,10 @@ fine-grained waiving without blanket-skipping a whole file.
 """
 
 import os
+import re
 import subprocess
 import sys
+import tempfile
 
 import pytest
 import yaml
@@ -139,6 +141,130 @@ def _run_verl_test(test_path, extra_args=None, timeout=600):
 def _run_single(verl_file, case_name, timeout=600):
     """Run exactly one verl pytest case by name."""
     _run_verl_test(verl_file, extra_args=["-k", case_name], timeout=timeout)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers for E2E training tests (test_verl_E2E_*.py)
+# ---------------------------------------------------------------------------
+
+_STEP_LINE = re.compile(r"step:\d+ - ")
+
+
+def _run_verl_train(extra_args, log_file=None, timeout=1800):
+    """Run ``python3 -m verl.trainer.main_ppo`` in VERL_ROOT with Hydra overrides.
+
+    Stdout/stderr are written to ``log_file`` (default: a fresh mktemp).
+    Asserts the subprocess return code is 0 and returns the log path so the
+    caller can grep per-step metrics out of it.
+    """
+    if log_file is None:
+        log_file = tempfile.mktemp(suffix="-verl-train.log")
+    cmd = [sys.executable, "-m", "verl.trainer.main_ppo", *extra_args]
+    with open(log_file, "w") as fh:
+        result = subprocess.run(
+            cmd,
+            cwd=VERL_ROOT,
+            env=os.environ.copy(),
+            stdout=fh,
+            stderr=subprocess.STDOUT,
+            timeout=timeout,
+        )
+    assert result.returncode == 0, f"verl trainer exited {result.returncode}; see {log_file}"
+    return log_file
+
+
+def _ensure_gsm8k(local_dir):
+    """Resolve a directory containing GSM8K's ``train.parquet`` + ``test.parquet``.
+
+    Checks (in order): the requested ``local_dir`` and
+    ``$TRTLLM_TEST_DATA_PATH/gsm8k``. Falls back to runtime preprocess via
+    ``examples/data_preprocess/gsm8k.py`` (network download; ~10 MB, finishes
+    in well under a minute on CI nodes).
+    """
+    candidates = [
+        local_dir,
+        os.path.join(os.environ.get("TRTLLM_TEST_DATA_PATH", ""), "gsm8k"),
+    ]
+    for path in candidates:
+        if path and os.path.exists(os.path.join(path, "train.parquet")):
+            return path
+    os.makedirs(local_dir, exist_ok=True)
+    subprocess.check_call(
+        [sys.executable, "examples/data_preprocess/gsm8k.py", "--local_dir", local_dir],
+        cwd=VERL_ROOT,
+    )
+    return local_dir
+
+
+def _check_convergence(log_file, target=0.01, ppo_kl_max=0.1):
+    """Parse the verl trainer's stdout log for per-step metrics and assert two bounds.
+
+      1. **Convergence (learning signal)**: ``max(critic/rewards/mean) > target``
+         — the model has to show *any* learning signal during the short loop.
+         Mirrors verl's own ``tests/special_e2e/check_results.py`` (which uses
+         ``best_reward > args.target`` with default 0.2). We use a much lower
+         target (0.01) because: (a) GSM8K reward is binary 0/1 and our gate
+         runs only ~30 steps on Qwen2.5-0.5B with effective batch
+         ``train_batch_size(16) × rollout.n(4) = 64``, so non-zero rewards
+         can only be ``1/64=0.0156``, ``2/64=0.0313``, ``4/64=0.0625`` …;
+         (b) higher thresholds (e.g. ``> 0.05``) proved empirically flaky
+         over 20-step dry-runs — success spikes are heavy-tail — so we trade
+         a tighter convergence claim for run-to-run reliability; (c) Test 1's
+         role is a *smoke + IS-ratio* gate, not a real convergence assertion
+         (that needs 100s of steps).
+
+      2. **Importance-sampling ratio near 1**: ``max(actor/ppo_kl) < ppo_kl_max``
+         — the trainer's policy must stay close to the rollout policy.
+         ``actor/ppo_kl`` is verl's per-step ``mean(-log(ratio))`` where
+         ``ratio = π_train / π_rollout``. Threshold 0.1 means
+         ``ratio ∈ [exp(-0.1), exp(0.1)] ≈ [0.905, 1.105]`` — i.e. the ratio
+         stays *near 1 within ±10%*. A weight-sync / dtype / NaN-gradient
+         regression drives this up immediately (matches the framing of the
+         "RL Collapse from training-inference mismatch" paper referenced in
+         ``verl/trainer/config/algorithm.py:72``). Tighter than the
+         ``PPO_KL_MAX = 0.2`` used in ``test_verl_E2E_standalone`` because
+         empirical TRTLLM-rollout runs on this config have measured
+         ``|ppo_kl| < 5e-4`` (~200× headroom on the 0.1 bound).
+
+    Verl prints one summary line per step in the form
+    ``step:N - key1:val1 - key2:val2 - …``. When the trainer runs as a Ray
+    actor the line is prefixed by ``(TaskRunner pid=N)`` plus ANSI colour
+    escapes, so we anchor at the ``step:N - `` substring via regex rather
+    than assuming the line starts with ``step:`` (verl's own
+    ``check_results.py`` uses ``startswith("step")`` and would miss
+    Ray-prefixed lines).
+    """
+    rewards, kls = [], []
+    with open(log_file) as fh:
+        for line in fh:
+            m = _STEP_LINE.search(line)
+            if not m:
+                continue
+            for kv in line[m.start() :].split(" - "):
+                try:
+                    key, val = kv.strip().split(":", 1)
+                except ValueError:
+                    continue
+                try:
+                    f = float(val)
+                except ValueError:
+                    continue
+                if key == "critic/rewards/mean":
+                    rewards.append(f)
+                elif key == "actor/ppo_kl":
+                    kls.append(f)
+    assert rewards, f"No critic/rewards/mean lines parsed from {log_file}"
+    best = max(rewards)
+    assert best > target, (
+        f"Convergence target not met: best critic/rewards/mean={best:.4f} "
+        f"<= {target}; see {log_file}"
+    )
+    assert kls, f"No actor/ppo_kl lines parsed from {log_file}"
+    worst_kl = max(kls)
+    assert worst_kl < ppo_kl_max, (
+        f"Importance-sampling ratio out of band: max(actor/ppo_kl)="
+        f"{worst_kl:.4f} >= {ppo_kl_max} (ratio not near 1); see {log_file}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/defs/verl/verl_config.yml
+++ b/tests/integration/defs/verl/verl_config.yml
@@ -50,3 +50,4 @@ verl_config:
     - "Qwen/Qwen2.5-0.5B-Instruct"
     - "Qwen/Qwen2.5-1.5B-Instruct"
     - "Qwen/Qwen2.5-VL-7B-Instruct"
+    - "Qwen/Qwen2.5-7B-Instruct"

--- a/tests/integration/defs/verl/verl_config.yml
+++ b/tests/integration/defs/verl/verl_config.yml
@@ -16,7 +16,7 @@ verl_config:
     # Create nvshmem symlink (needed before DeepEP build)
     - >-
       (cd /usr/local/lib/python3.12/dist-packages/nvidia/nvshmem/lib &&
-      ln -s libnvshmem_host.so.3 libnvshmem_host.so)
+      ln -sf libnvshmem_host.so.3 libnvshmem_host.so)
     # Install DeepEP
     - >-
       git clone -b hybrid-ep https://github.com/deepseek-ai/DeepEP.git &&

--- a/tests/integration/test_lists/test-db/l0_verl.yml
+++ b/tests/integration/test_lists/test-db/l0_verl.yml
@@ -34,3 +34,5 @@ l0_verl:
   - verl/test_verl_cases.py::test_wake_sleep_cycle
   - verl/test_verl_cases.py::test_inter_node_trtllm_rollout
   - verl/test_verl_cases.py::test_trtllm_abort
+  - verl/test_verl_E2E_convergence.py::test_e2e_convergence_qwen25_05b_grpo_trtllm
+  - verl/test_verl_E2E_feature.py::test_e2e_smoke_qwen25_7b_megatron_trtllm


### PR DESCRIPTION
## Description

Adds two E2E training tests to the existing `DGX_B200-4_GPUs-Verl-Post-Merge-1` Jenkins stage, layered directly on top of #14037.

#14037 bumps the verl pin to `d324b01` and replaces the three file-level verl wrappers with 19 per-case wrappers. The verl pin is unchanged in this PR.

Until this PR, the verl post-merge stage only ran rollout unit tests; no end-to-end training test exercised the trainer ↔ rollout boundary owned by TRT-LLM.

This PR adds:

- **`test_e2e_convergence_qwen25_05b_grpo_trtllm`**
  - Runs 30-step GRPO on Qwen2.5-0.5B-Instruct + GSM8K + TRT-LLM rollout.
  - Asserts:
    - `max(critic/rewards/mean) > 0.01` to verify a learning signal.
    - `max(actor/ppo_kl) < 0.1` to verify the trainer policy stays close to the rollout policy.
  - This catches weight-sync, dtype, and NaN-gradient regressions at the TRT-LLM rollout boundary.

- **`test_e2e_smoke_qwen25_7b_megatron_trtllm`**
  - Runs a 3-step Megatron actor + TRT-LLM rollout smoke test on Qwen2.5-7B-Instruct.
  - Configuration:
    - Megatron actor: TP=2, PP=1
    - TRT-LLM rollout: TP=2
    - Script: `examples/grpo_trainer/run_qwen3_8b_megatron.sh`
  - Pass condition: subprocess exits with code `0`.
  - Exercises the most feature-loaded combination currently shipped by verl: Megatron + TP/PP + TRT-LLM.

## Stacking

This PR is **stacked on #14037**.

GitHub will show both commits in the diff until #14037 merges. After #14037 is merged, the diff will automatically recompute to only the eight files added or modified in this PR.

Please merge #14037 first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added end-to-end GRPO training convergence validation tests.
  * Added smoke test for Qwen model training workflow.

* **Tests**
  * Expanded integration test suite with comprehensive coverage for placement groups, resource pools, async operations, and rollout scenarios.
  * Reorganized test structure with granular test cases for improved maintainability.

* **Chores**
  * Updated model configuration and pinned new model version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->