### PR TITLE
[None][fix] Trim CTX-side over-allocated KV blocks for MTP disagg transfer

### DIFF
--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -189,6 +189,21 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
                 groups.append(np.array([], dtype=np.int64))
                 continue
             block_ids = adapter.get_block_ids(req, idx, lg)
+
+            # CTX-only over-allocation guard: the KV cache manager may
+            # reserve trailing blocks for MTP / speculative-decoding draft
+            # positions that hold no useful context state. The receiver
+            # computes total_blocks from token_range.end in
+            # Sender._build_kv_write_meta, so extra src blocks would
+            # violate the protocol invariant `src.size <= total_blocks`
+            # and the Sender would silently drop the response. GEN-side
+            # extra blocks are legitimate (draft tokens) and are handled
+            # by the existing `block_diff == 1` branch in transfer.py.
+            if not is_gen_only and token_range is not None:
+                ctx_total_blocks = (token_range.end + tpb - 1) // tpb
+                if block_ids.size > ctx_total_blocks:
+                    block_ids = block_ids[:ctx_total_blocks]
+
             window_size = lg.sliding_window_size
 
             if window_size is not None:

--- a/tests/unittest/disaggregated/test_cache_reuse_adapter.py
+++ b/tests/unittest/disaggregated/test_cache_reuse_adapter.py
@@ -199,6 +199,68 @@ class TestAdapterPerLayerGroup:
 
 
 # ---------------------------------------------------------------------------
+# _create_kv_slice CTX-side over-allocation guard (MTP / spec-decoding).
+# ---------------------------------------------------------------------------
+
+
+def _ctx_overalloc_trim(block_ids, token_range_end, tpb, is_gen_only=False):
+    """Replicate the CTX-side over-allocation guard in _create_kv_slice.
+
+    The KV cache manager may reserve trailing blocks for MTP /
+    speculative-decoding draft positions that hold no useful context
+    state. The receiver computes total_blocks from token_range.end in
+    Sender._build_kv_write_meta, so extra src blocks would violate the
+    protocol invariant ``src.size <= total_blocks`` and cause the
+    Sender to silently drop the response. GEN-side extra blocks are
+    legitimate (draft tokens) and are handled by the receiver's
+    ``block_diff == 1`` branch in transfer.py.
+    """
+    block_ids = np.array(block_ids, dtype=np.int64)
+    if not is_gen_only:
+        ctx_total_blocks = (token_range_end + tpb - 1) // tpb
+        if block_ids.size > ctx_total_blocks:
+            block_ids = block_ids[:ctx_total_blocks]
+    return block_ids
+
+
+class TestCtxOverAllocationTrim:
+    """Regression for DSv4 + MTP=3 disagg KV transfer (1024-token prompt,
+    tpb=128): cache manager allocates 9 blocks but token_range.end=1024
+    only covers 8, so the trailing MTP scratch block must be dropped.
+    """
+
+    TPB = 128
+
+    def test_mtp_extra_block_dropped(self):
+        # prompt_len=1024 → total_blocks=8; manager exposed 9 blocks.
+        out = _ctx_overalloc_trim(list(range(9)), token_range_end=1024, tpb=self.TPB)
+        np.testing.assert_array_equal(out, list(range(8)))
+
+    def test_no_overalloc_unchanged(self):
+        # mtp0 path: block_ids.size == total_blocks → no-op.
+        out = _ctx_overalloc_trim(list(range(8)), token_range_end=1024, tpb=self.TPB)
+        np.testing.assert_array_equal(out, list(range(8)))
+
+    def test_gen_only_skipped(self):
+        # GEN-side extra block is the draft-token block; guard must not fire.
+        out = _ctx_overalloc_trim(
+            list(range(9)), token_range_end=1024, tpb=self.TPB, is_gen_only=True
+        )
+        np.testing.assert_array_equal(out, list(range(9)))
+
+    def test_partial_block_prompt_rounds_up(self):
+        # prompt_len=1025 → ceil → total_blocks=9; nothing to drop.
+        out = _ctx_overalloc_trim(list(range(9)), token_range_end=1025, tpb=self.TPB)
+        np.testing.assert_array_equal(out, list(range(9)))
+
+    def test_chunked_prefill_slice(self):
+        # Chunked prefill: token_range carries a sub-range (end=512).
+        # total_blocks=4, manager exposed 9 blocks → trim to 4.
+        out = _ctx_overalloc_trim(list(range(9)), token_range_end=512, tpb=self.TPB)
+        np.testing.assert_array_equal(out, list(range(4)))
+
+
+# ---------------------------------------------------------------------------
 # _create_kv_slice SWA block trim: window-trim + cache-skip via per-layer cached.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- For MTP / speculative-decoding context-only requests, the KV cache manager reserves trailing blocks for draft positions that hold no useful context state. The disagg receiver computes `total_blocks` from `token_range.end` in `Sender._build_kv_write_meta`, so the extra src block violates `src.size <= total_blocks`; the Sender silently drops the response, the generation side waits out `kv_transfer_timeout_ms`, and the sync executor deadlocks on the next batch.
- This PR trims the trailing over-allocated blocks on the CTX path in `KvCacheTransceiverV2._create_kv_slice` so the slice exposes only the blocks covered by `token_range.end`. GEN-side extra blocks are left untouched — they are legitimate draft-token blocks handled by the existing `block_diff == 1` branch in `transfer.py`.

## Failure signature (before fix)

DSv4 + disagg + MTP=3 sweep, e.g. `ctx1_gen1_dep8_concurrency512_eplb384_mtp3` on GB300:

CTX log (`3_output_CTX_0.log`):
```
[RANK 0] Sender: error handling REQUEST_DATA: src block list (9) exceeds total slice blocks (8); slice_end=1024, tpb=128
```

GEN log (`3_output_GEN_0.log`):
```
[RANK 7] Disagg KV cache transfer error: rank=7 local_err_count=2
tensorrt_llm.executor.utils.RequestError: Disagg KV cache transfer error
[RANK 0..7] Hang detected after 300 seconds.
  ... request_and_receive_sync → wait_complete(blocking=True) → event.wait()
```

Bench: 0/512 successful. MTP=0 baseline runs 512/512 successful (confirming the bug is MTP-specific).

## Test plan

- [x] Added `TestCtxOverAllocationTrim` (5 cases) in `tests/unittest/disaggregated/test_cache_reuse_adapter.py` covering: MTP+1024-prompt regression, mtp0 no-op, GEN-side bypass, non-aligned prompt length, chunked-prefill slice.
- [ ] Validate end-to-end on cmh GB300: re-run `ctx1_gen1_dep8_concurrency512_eplb384_mtp3` and confirm 512/512 successful (parity with mtp0 baseline).
- [ ] Validate the full `*_mtp1` and `*_mtp3` sweep clears.