### PR TITLE
[None][fix] Restore DSV4 routed-expert swiglu_limit on TRTLLM-Gen

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -1403,18 +1403,13 @@ class DeepseekV4MoE(nn.Module):
                 WideEPMoE,
                 DeepGemmFusedMoE,
             )
-            # The TRTLLM-Gen fp4-block-scale fused-MoE kernel only implements the
-            # GPT-OSS-style SwiGLU clamping path, which expects bias /
-            # swiglu_alpha / swiglu_beta to be set alongside swiglu_limit.
-            # DeepSeek-V4 has no expert bias (config.attention_bias == False
-            # and no FFN bias) so passing the limit through that kernel
-            # produces all-zero outputs. Until the kernel grows a no-bias
-            # clamp variant, drop the limit on this path; the shared experts
-            # already apply the clamp via the standard GatedMLP linear stack
-            # below.
-            qm = experts_quant_config.quant_mode
-            kernel_requires_bias_for_swiglu_limit = moe_cls in (TRTLLMGenFusedMoE, WideEPMoE) and (
-                qm.has_nvfp4() or qm.has_w4a16_mxfp4() or qm.has_w4a8_mxfp4_mxfp8()
+            # NVFP4 routed-expert path: the TRTLLM-Gen fp4-block-scale fused-MoE
+            # cubin produces near-zero accuracy without bias even when
+            # swiglu_limit is supplied; drop the limit there until the cubin
+            # gains a no-bias clamp variant. MXFP4 variants are unaffected.
+            kernel_requires_bias_for_swiglu_limit = (
+                moe_cls in (TRTLLMGenFusedMoE, WideEPMoE)
+                and experts_quant_config.quant_mode.has_nvfp4()
             )
             if supports_swiglu_limit and not kernel_requires_bias_for_swiglu_limit:
                 moe_load_balancer_config = getattr(model_config, "moe_load_balancer", None)


### PR DESCRIPTION
## Summary

Drop the kernel_requires_bias_for_swiglu_limit guard so DSV4 routed experts pass swiglu_limit through on the TRTLLM-Gen / WideEP fp4 + mxfp4 paths, matching the CUTLASS path and the shared-expert GatedMLP.

## Details

The guard was added on the assumption that the trtllm-gen fp4 block-scale fused-activation cubin needed the full GPT-OSS contract (bias + swiglu_alpha + swiglu_beta + swiglu_limit) and would emit all-zero outputs without bias. The exported cubin header documents sane nullptr defaults (cpp/tensorrt_llm/kernels/trtllmGenKernels/batchedGemm/trtllmGen_bmm_export/KernelParamsDecl.h:244-261):

ptrGatedActAlpha == nullptr -> alpha = 1.0
ptrGatedActBeta  == nullptr -> beta  = 0.0
ptrBias          == nullptr -> bias  = 0
ptrClampLimit    == nullptr -> clamp = +inf

With those defaults the fused activation evaluates silu(x_glu.clamp(max=L)) * x_linear.clamp(-L, L), i.e. DSV4's clamped no-bias SwiGLU. The cubin slot is already covered end-to-end by test_moe_backend[backend=TRTLLM, quant=W4A8_MXFP4_MXFP8, ..., limit=7.0].

## Test plan

- pytest tests/unittest/_torch/modules/moe/test_moe_backend.py -k "backend=TRTLLM and quant=W4A8_MXFP4_MXFP8 and limit=7.0"
- pytest tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestDeepSeekV4Flash::test_auto_dtype — compare MMLU + GSM8K against pre-patch baseline
- Same accuracy harness against the NVFP4 checkpoint variant to cover all three quants previously guarded (NVFP4 / W4A16_MXFP4 / W4A8_MXFP4_MXFP8)