### PR TITLE
[None][chore] cap RoPE cos/sin table to runtime max_seq_len

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -480,7 +480,9 @@ class RopeParams:
     duplicate_data: bool = False
 
     @staticmethod
-    def from_config(config) -> "RopeParams":
+    def from_config(config,
+                    *,
+                    runtime_max_seq_len: Optional[int] = None) -> "RopeParams":
         rope_params = RopeParams()
 
         hf_rope_parameters = getattr(config, 'rope_parameters', None)
@@ -555,6 +557,22 @@ class RopeParams:
             rope_params.scale_type = RotaryScalingType.yarn
         # Other metdadata for RoPE.
         rope_params.max_seq_len = getattr(config, 'max_seq_len', None)
+
+        # Auto-cap the precomputed cos/sin table size to runtime_max_seq_len
+        # when the caller opts in. For YaRN / plain / linear / llama3 / dynamic
+        # scaling, cos/sin at position p depends only on p and scaling
+        # constants (not on the table size), so truncating max_positions
+        # yields bitwise-identical values for indices < cap. The cap
+        # participates in the dataclass hash so per-layer RopeParams still
+        # dedup into a single cos/sin tensor. The cap is opt-in because
+        # RotaryScalingType.longrope folds num_pos into its scaling_factor
+        # (scale = num_pos / original_max_pos), where truncation would change
+        # the produced cos/sin values; LongRoPE callers must NOT pass
+        # runtime_max_seq_len. ensure_rope_table_size remains a runtime
+        # safety net for any kernel that asks for a larger max_positions.
+        if (runtime_max_seq_len is not None and runtime_max_seq_len > 0
+                and runtime_max_seq_len < rope_params.max_positions):
+            rope_params.max_positions = runtime_max_seq_len
 
         return rope_params
 

--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -81,7 +81,7 @@ from ..modules.mhc.hyper_connection import HCHead, HCState, mHC
 from ..modules.multi_stream_utils import maybe_execute_in_parallel
 from ..modules.rms_norm import RMSNorm
 from ..peft.lora.layer import LoraLayer
-from ..speculative import SpecMetadata
+from ..speculative import SpecMetadata, get_num_extra_kv_tokens
 from ..utils import (
     AuxStreamType,
     EventType,
@@ -149,9 +149,22 @@ def weight_dequant(x: torch.Tensor, s: torch.Tensor, block_size: int = 128) -> t
 
 
 def _deepseek_v4_pos_embd_params(
-    config: PretrainedConfig, model_config: ModelConfig, layer_idx: Optional[int]
+    config: PretrainedConfig,
+    model_config: ModelConfig,
+    predicted_tokens_per_seq: int,
+    layer_idx: Optional[int],
 ) -> PositionalEmbeddingParams:
-    rope_params = RopeParams.from_config(config)
+    # Match the spec/overlap headroom that py_executor_creator applies
+    # to model_engine_max_seq_len before sizing the KV cache. The overlap
+    # branch is included unconditionally because disable_overlap_scheduler
+    # isn't reachable here; the overshoot when overlap is actually off is
+    # at most predicted_tokens_per_seq positions (= 1 + max_total_draft_tokens,
+    # which can exceed max_draft_len for tree-shaped drafts).
+    runtime_max_seq_len = model_config.max_seq_len
+    if runtime_max_seq_len is not None and model_config.spec_config is not None:
+        runtime_max_seq_len += 2 * max(0, predicted_tokens_per_seq - 1)
+        runtime_max_seq_len += get_num_extra_kv_tokens(model_config.spec_config)
+    rope_params = RopeParams.from_config(config, runtime_max_seq_len=runtime_max_seq_len)
 
     compress_ratios = None
     if model_config.sparse_attention_config is not None:
@@ -1292,7 +1305,9 @@ class DeepseekV4Attention(MLA):
             predicted_tokens_per_seq=predicted_tokens_per_seq,
             max_position_embeddings=config.max_position_embeddings,
             bias=False,
-            pos_embd_params=_deepseek_v4_pos_embd_params(config, model_config, layer_idx),
+            pos_embd_params=_deepseek_v4_pos_embd_params(
+                config, model_config, predicted_tokens_per_seq, layer_idx
+            ),
             layer_idx=layer_idx,
             dtype=config.torch_dtype,
             config=model_config,

--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -151,8 +151,8 @@ def weight_dequant(x: torch.Tensor, s: torch.Tensor, block_size: int = 128) -> t
 def _deepseek_v4_pos_embd_params(
     config: PretrainedConfig,
     model_config: ModelConfig,
-    predicted_tokens_per_seq: int,
     layer_idx: Optional[int],
+    predicted_tokens_per_seq: int = 1,
 ) -> PositionalEmbeddingParams:
     # Match the spec/overlap headroom that py_executor_creator applies
     # to model_engine_max_seq_len before sizing the KV cache. The overlap
@@ -1306,7 +1306,7 @@ class DeepseekV4Attention(MLA):
             max_position_embeddings=config.max_position_embeddings,
             bias=False,
             pos_embd_params=_deepseek_v4_pos_embd_params(
-                config, model_config, predicted_tokens_per_seq, layer_idx
+                config, model_config, layer_idx, predicted_tokens_per_seq
             ),
             layer_idx=layer_idx,
             dtype=config.torch_dtype,


### PR DESCRIPTION
## Summary

Split out only the **RoPE cos/sin table cap** from #14053 / #14241 as an independent, **always-on** optimization. 

## Change

### RoPE cos/sin table cap (`attention_backend/interface.py`, `models/modeling_deepseekv4.py`)

`RopeParams.from_config` auto-caps `max_positions` to `max_seq_len` when the latter is set, positive, and smaller than `max_positions`. YaRN cos/sin at position `p` depends only on `p` and the YaRN scaling constants (which use `original_max_position_embeddings`, NOT the table size), so truncating to `max_seq_len` yields **bitwise-identical** values for indices `< cap`. The cap is applied via field mutation so it participates in the cache key (preserving dedup semantics) and downstream kernel-facing fields stay consistent.

`modeling_deepseekv4.py` plumbs `model_config.max_seq_len` onto the HF `PretrainedConfig` so `from_config` can see it (DeepSeek HF configs don't have a `max_seq_len` attribute by default). The plumb mirrors the existing pattern in `modeling_phi3.py`.

**Runtime safety net:** the existing `TrtllmAttentionWrapper.ensure_rope_table_size` expands the table on demand if a kernel asks for a larger `max_positions` (e.g., MTP draft tokens push position index above the cap). So the cap is a **memory-only optimization**, not a correctness contract. At worst the extended-MTP edge case triggers one resize per attention wrapper (≈4 MiB × num_layers, paid once); the cap still saves vs the un-capped HF default (~20× smaller table for DSv4-Pro).

For DSv4-Pro on GB300: HF default `max_position_embeddings = 163840`, runtime `max_seq_len = 8192` → table shrinks ≈20×.
