### PR TITLE
[None][refactor] clean up AttentionForwardArgs

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -708,7 +708,8 @@ class AttentionForwardArgs:
 
     latent_cache: Optional[torch.Tensor] = None
     q_pe: Optional[torch.Tensor] = None
-    mrope_config: Optional[dict] = None
+    mrope_rotary_cos_sin: Optional[torch.Tensor] = None
+    mrope_position_deltas: Optional[torch.Tensor] = None
 
     softmax_stats_tensor: Optional[torch.Tensor] = None
     chunked_prefill_buffer_batch_size: int = 1
@@ -726,9 +727,7 @@ class AttentionForwardArgs:
     sage_attn_num_elts_per_blk_v: int = 0
     sage_attn_qk_int8: bool = False
 
-    enable_attn_nvfp4_output: bool = True
     topk_indices: Optional[torch.Tensor] = None
-    is_generation: bool = False
 
 
 _ATTENTION_FORWARD_ARGS_FIELDS = frozenset(

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -12,7 +12,8 @@ import torch.nn.functional as F
 import tensorrt_llm
 import tensorrt_llm.bindings
 from tensorrt_llm._torch.attention_backend.interface import (
-    AttentionForwardArgs, MLAParams, PositionalEmbeddingParams)
+    AttentionForwardArgs, AttentionInputType, MLAParams,
+    PositionalEmbeddingParams)
 from tensorrt_llm._torch.attention_backend.trtllm import (
     TrtllmAttention, TrtllmAttentionMetadata)
 from tensorrt_llm._torch.cute_dsl_utils import IS_CUTLASS_DSL_AVAILABLE
@@ -2356,9 +2357,11 @@ class DSATrtllmAttention(TrtllmAttention):
     ) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
         """Transform local TopK indices to global paged KV cache indices."""
         # Transform the local topk indices to global topk indices in paged kv cache
+        is_generation = (forward_args.attention_input_type ==
+                         AttentionInputType.generation_only)
         topk_indices_global, _ = transform_local_topk_and_prepare_pool_view(
             forward_args.topk_indices, metadata,
-            self.get_local_layer_idx(metadata), forward_args.is_generation)
+            self.get_local_layer_idx(metadata), is_generation)
 
         # TODO: Use sparse_attn_indexer to predict the indices for DSA attention
         # return self.indexer(q, k, metadata, hidden_states, qr, position_ids)

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1328,12 +1328,8 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         kv_scale_quant_orig = (self.kv_scale_quant_orig
                                if forward_args.kv_scales_sf is None else
                                forward_args.kv_scales_sf)
-        mrope_rotary_cos_sin = forward_args.mrope_config.get(
-            'mrope_rotary_cos_sin'
-        ) if forward_args.mrope_config is not None else None
-        mrope_position_deltas = forward_args.mrope_config.get(
-            'mrope_position_deltas'
-        ) if forward_args.mrope_config is not None else None
+        mrope_rotary_cos_sin = forward_args.mrope_rotary_cos_sin
+        mrope_position_deltas = forward_args.mrope_position_deltas
         workspace = metadata.workspace if not metadata.is_cuda_graph else metadata.cuda_graph_workspace
         flash_mla_tile_scheduler_metadata = (
             metadata.flash_mla_tile_scheduler_metadata

--- a/tensorrt_llm/_torch/models/modeling_qwen.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen.py
@@ -156,7 +156,7 @@ class QwenDecoderLayer(DecoderLayer):
         hidden_states: torch.Tensor,
         attn_metadata: AttentionMetadata,
         residual: Optional[torch.Tensor],
-        mrope_config: Optional[Tuple[torch.Tensor, int]] = None,
+        mrope_config: Optional[dict] = None,
         spec_metadata: Optional[SpecMetadata] = None,
         **kwargs,
     ) -> torch.Tensor:
@@ -217,7 +217,7 @@ class QwenModel(DecoderModel):
         input_ids: Optional[torch.IntTensor] = None,
         position_ids: Optional[torch.IntTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
-        mrope_config: Optional[Tuple[torch.Tensor, int]] = None,
+        mrope_config: Optional[dict] = None,
         spec_metadata: Optional[SpecMetadata] = None,
         **kwargs,
     ) -> torch.Tensor:

--- a/tensorrt_llm/_torch/models/modeling_seedoss.py
+++ b/tensorrt_llm/_torch/models/modeling_seedoss.py
@@ -87,7 +87,7 @@ class SeedOssDecoderLayer(DecoderLayer):
         hidden_states: torch.Tensor,
         attn_metadata: AttentionMetadata,
         residual: Optional[torch.Tensor],
-        mrope_config: Optional[Tuple[torch.Tensor, int]] = None,
+        mrope_config: Optional[dict] = None,
         spec_metadata: Optional[SpecMetadata] = None,
         **kwargs,
     ) -> torch.Tensor:
@@ -151,7 +151,7 @@ class SeedOssModel(DecoderModel):
         input_ids: Optional[torch.IntTensor] = None,
         position_ids: Optional[torch.IntTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
-        mrope_config: Optional[Tuple[torch.Tensor, int]] = None,
+        mrope_config: Optional[dict] = None,
         spec_metadata: Optional[SpecMetadata] = None,
         **kwargs,
     ) -> torch.Tensor:

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -718,14 +718,6 @@ class Attention(nn.Module):
         if v is not None:
             v = v[:num_tokens, :]
 
-        mrope_config = None
-        if mrope_rotary_cos_sin is not None or mrope_position_deltas is not None:
-            mrope_config = dict()
-            if mrope_rotary_cos_sin is not None:
-                mrope_config["mrope_rotary_cos_sin"] = mrope_rotary_cos_sin
-            if mrope_position_deltas is not None:
-                mrope_config["mrope_position_deltas"] = mrope_position_deltas
-
         # Helix CP generation path: get partial outputs with softmax stats,
         # then exchange and combine across CP ranks.
         # NOTE: The helix post-process combine step works on unquantized
@@ -747,7 +739,8 @@ class Attention(nn.Module):
                 attn_metadata,
                 forward_args=AttentionForwardArgs(
                     attention_mask=attention_mask,
-                    mrope_config=mrope_config,
+                    mrope_rotary_cos_sin=mrope_rotary_cos_sin,
+                    mrope_position_deltas=mrope_position_deltas,
                     attention_window_size=attention_window_size,
                     attention_mask_data=attention_mask_data,
                     softmax_stats_tensor=softmax_stats,
@@ -785,7 +778,8 @@ class Attention(nn.Module):
                 kv_scales_sf=kv_scales_sf,
                 kv_scales_sf_inv=kv_scales_sf_inv,
                 attention_mask=attention_mask,
-                mrope_config=mrope_config,
+                mrope_rotary_cos_sin=mrope_rotary_cos_sin,
+                mrope_position_deltas=mrope_position_deltas,
                 attention_window_size=attention_window_size,
                 attention_mask_data=attention_mask_data,
                 output=output[:num_tokens, :] if output is not None else None,
@@ -2576,7 +2570,6 @@ class MLA(nn.Module):
             latent_cache=latent_cache,  # kvcache and k_pe
             q_pe=q_pe,  # used by `invokeMLARopeGeneration`
             topk_indices=topk_indices,  # used by DSA attention
-            is_generation=True,  # used by DSA attention
             cu_q_seqlens=cu_q_seqlens,  # used by `mlaGeneration`
             cu_kv_seqlens=cu_kv_seqlens,  # used by `mlaGeneration`
             fmha_scheduler_counter=
@@ -2694,7 +2687,6 @@ class MLA(nn.Module):
             latent_cache=latent_cache,  # kvcache and k_pe
             q_pe=q_pe,  # used by `invokeMLARopeGeneration`
             topk_indices=topk_indices,  # used by DSA attention
-            is_generation=False,  # used by DSA attention
         )
         fused_q = None
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated attention mechanism parameter passing for multi-head RoPE (mRoPE) tensors to improve data flow through attention layers.
  * Updated `mrope_config` parameter type annotations in Qwen and SeedOss models from `Optional[Tuple[torch.Tensor, int]]` to `Optional[dict]`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Three small cleanups of `AttentionForwardArgs` and adjacent code. Each is
self-contained and behavior-preserving; bundled here because they touch the
same dataclass.

### 1. Flatten `mrope_config` into two tensor fields

```diff
-mrope_config: Optional[dict] = None
+mrope_rotary_cos_sin:  Optional[torch.Tensor] = None
+mrope_position_deltas: Optional[torch.Tensor] = None
```

The dict was being **built** in `Attention._attn_impl` from two input
tensors and then **destructured** back to those same two tensors in
`Attention.forward_impl` — a pointless roundtrip. The new fields skip
the wrap/unwrap.

The upstream `Attention.forward(mrope_config: Optional[dict])` and the
decoder-layer-facing kwarg shape are **kept**: `forward_impl` still
destructures the dict from callers, then flows the two flat tensors into
the new `AttentionForwardArgs` fields. The multimodal pipeline contract
(`multimodal_data["mrope_config"]`) is untouched.

Also fixes four stale `Optional[Tuple[torch.Tensor, int]]` annotations on
`mrope_config` in `modeling_qwen.py` (lines 159, 220) and
`modeling_seedoss.py` (lines 90, 154). These were pre-existing wrong type
hints — Python doesn't validate annotations at runtime, so the
dict-vs-tuple mismatch was silently tolerated.

### 2. Delete `AttentionForwardArgs.enable_attn_nvfp4_output`

Defined with a default of `True` but never read anywhere in
`tensorrt_llm/`, `tests/`, or `cpp/`. Verified via repository-wide grep.

### 3. Delete `AttentionForwardArgs.is_generation`

Exactly one consumer: the topk-indices transform in `sparse/dsa.py`. That
consumer now derives the same value from
`forward_args.attention_input_type == AttentionInputType.generation_only`
— which was already the correct source of truth (the two construction
sites in `Attention._attn_forward_gen` callers always set both fields
consistently).

## Test Coverage

No new tests. Behavior is preserved end-to-end:

- `Attention.forward`'s decoder-layer-facing kwarg shape (with
  `mrope_config: Optional[dict]`) is unchanged.
- `multimodal_data["mrope_config"]` flow through `multimodal.py` /
  `llm.py` / `runtime/` is unchanged.
- `TrtllmAttention._run` and the thop attention op are unchanged at the
  ABI level (the dict-`get` is replaced with a direct field read but
  produces the same values).
- Existing unit tests for the attention backend
  (`tests/unittest/_torch/attention/`) and the multimodal smoke tests
  for qwen2vl / seedoss / hunyuan_dense exercise the
  `mrope_config`-touching paths.

This PR is the first of a series splitting a larger refactor of the
attention dispatch layer. The follow-up PRs are scoped strictly above
this one and don't change `AttentionForwardArgs`'s shape further.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
