### PR TITLE
[None][feat] Add swiglu clamp to CuteDSL NVF4 MOE FC1 kernels

### DIFF
--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -42,6 +42,7 @@ from ...utils import ActivationType, is_gated_activation
 from .custom_pipeline import PipelineCpAsyncUmma
 from .utils import (
     TRTLLM_ENABLE_PDL,
+    fclip_xorsign,
     fmin,
     griddepcontrol_launch_dependents,
     griddepcontrol_wait,
@@ -278,6 +279,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         raster_along_m: bool = False,
         b_tensor_l_sizes: Optional[Tuple[int, ...]] = None,
         activation_type: ActivationType = ActivationType.Swiglu,
+        swiglu_limit: cutlass.Float32 = float('inf'),
     ):
         """Initializes the configuration for a Blackwell blockscaled dense GEMM kernel with
         gather operation and fused activation.
@@ -407,6 +409,9 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         self.num_tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
 
         self.vectorized_f32 = vectorized_f32
+
+        self.swiglu_limit = swiglu_limit
+        self.has_swiglu_limit = (swiglu_limit != float('inf'))
 
         # Multi-B tensor configuration
         if b_tensor_l_sizes is None:
@@ -3008,6 +3013,14 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                     (acc_vec_gate[i], acc_vec_gate[i + 1]),
                     (cutlass.Float32(alpha_val), cutlass.Float32(alpha_val)),
                 )
+                # SwiGLU clamp
+                if cutlass.const_expr(self.has_swiglu_limit):
+                    gate_lo = fmin(acc_vec_gate_alpha[0], self.swiglu_limit)
+                    gate_hi = fmin(acc_vec_gate_alpha[1], self.swiglu_limit)
+                    acc_vec_gate_alpha = (gate_lo, gate_hi)
+                    up_lo = fclip_xorsign(acc_vec_up_alpha[0], self.swiglu_limit)
+                    up_hi = fclip_xorsign(acc_vec_up_alpha[1], self.swiglu_limit)
+                    acc_vec_up_alpha = (up_lo, up_hi)
                 tCompute_log2e = cute.arch.mul_packed_f32x2(
                     (acc_vec_gate_alpha[0], acc_vec_gate_alpha[1]),
                     (-LOG2_E, -LOG2_E),
@@ -3042,6 +3055,9 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
             for i in cutlass.range_constexpr(cute.size(acc_vec_up.shape)):
                 acc_vec_up_alpha = acc_vec_up[i] * cutlass.Float32(alpha_val)
                 acc_vec_gate_alpha = acc_vec_gate[i] * cutlass.Float32(alpha_val)
+                if cutlass.const_expr(self.has_swiglu_limit):
+                    acc_vec_gate_alpha = fmin(acc_vec_gate_alpha, self.swiglu_limit)
+                    acc_vec_up_alpha = fclip_xorsign(acc_vec_up_alpha, self.swiglu_limit)
                 tCompute[i] = acc_vec_up_alpha * silu_f32(acc_vec_gate_alpha, fastmath=True)
 
     @cute.jit

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -279,7 +279,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         raster_along_m: bool = False,
         b_tensor_l_sizes: Optional[Tuple[int, ...]] = None,
         activation_type: ActivationType = ActivationType.Swiglu,
-        swiglu_limit: cutlass.Float32 = float('inf'),
+        swiglu_limit: cutlass.Float32 = float("inf"),
     ):
         """Initializes the configuration for a Blackwell blockscaled dense GEMM kernel with
         gather operation and fused activation.
@@ -411,7 +411,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         self.vectorized_f32 = vectorized_f32
 
         self.swiglu_limit = swiglu_limit
-        self.has_swiglu_limit = (swiglu_limit != float('inf'))
+        self.has_swiglu_limit = swiglu_limit != float("inf")
 
         # Multi-B tensor configuration
         if b_tensor_l_sizes is None:

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm_swiglu_fusion.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm_swiglu_fusion.py
@@ -181,7 +181,7 @@ class Sm100BlockScaledContiguousGroupedGemmSwigluFusionKernel:
         mma_tiler_mn: Tuple[int, int],
         cluster_shape_mn: Tuple[int, int],
         vectorized_f32: bool,
-        swiglu_limit: cutlass.Float32 = float('inf'),
+        swiglu_limit: cutlass.Float32 = float("inf"),
     ):
         """Initializes the configuration for a Blackwell blockscaled dense GEMM kernel with SwiGLU fusion.
 
@@ -269,7 +269,7 @@ class Sm100BlockScaledContiguousGroupedGemmSwigluFusionKernel:
         self.vectorized_f32 = vectorized_f32
 
         self.swiglu_limit = swiglu_limit
-        self.has_swiglu_limit = (swiglu_limit != float('inf'))
+        self.has_swiglu_limit = swiglu_limit != float("inf")
 
     def _setup_attributes(self):
         """Set up configurations that are dependent on GEMM inputs
@@ -1822,7 +1822,9 @@ class Sm100BlockScaledContiguousGroupedGemmSwigluFusionKernel:
                             acc_vec_gate_alpha = acc_vec_gate[i] * cutlass.Float32(alpha_val)
                             if cutlass.const_expr(self.has_swiglu_limit):
                                 acc_vec_gate_alpha = fmin(acc_vec_gate_alpha, self.swiglu_limit)
-                                acc_vec_up_alpha = fclip_xorsign(acc_vec_up_alpha, self.swiglu_limit)
+                                acc_vec_up_alpha = fclip_xorsign(
+                                    acc_vec_up_alpha, self.swiglu_limit
+                                )
                             tCompute[i] = acc_vec_up_alpha * silu_f32(
                                 acc_vec_gate_alpha, fastmath=True
                             )

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm_swiglu_fusion.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm_swiglu_fusion.py
@@ -40,6 +40,7 @@ from cutlass.cute.nvgpu import cpasync, tcgen05
 
 from .utils import (
     TRTLLM_ENABLE_PDL,
+    fclip_xorsign,
     fmin,
     griddepcontrol_launch_dependents,
     griddepcontrol_wait,
@@ -180,6 +181,7 @@ class Sm100BlockScaledContiguousGroupedGemmSwigluFusionKernel:
         mma_tiler_mn: Tuple[int, int],
         cluster_shape_mn: Tuple[int, int],
         vectorized_f32: bool,
+        swiglu_limit: cutlass.Float32 = float('inf'),
     ):
         """Initializes the configuration for a Blackwell blockscaled dense GEMM kernel with SwiGLU fusion.
 
@@ -265,6 +267,9 @@ class Sm100BlockScaledContiguousGroupedGemmSwigluFusionKernel:
         self.num_tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
 
         self.vectorized_f32 = vectorized_f32
+
+        self.swiglu_limit = swiglu_limit
+        self.has_swiglu_limit = (swiglu_limit != float('inf'))
 
     def _setup_attributes(self):
         """Set up configurations that are dependent on GEMM inputs
@@ -1772,6 +1777,14 @@ class Sm100BlockScaledContiguousGroupedGemmSwigluFusionKernel:
                                 (acc_vec_gate[i], acc_vec_gate[i + 1]),
                                 (cutlass.Float32(alpha_val), cutlass.Float32(alpha_val)),
                             )
+                            # SwiGLU clamp
+                            if cutlass.const_expr(self.has_swiglu_limit):
+                                gate_lo = fmin(acc_vec_gate_alpha[0], self.swiglu_limit)
+                                gate_hi = fmin(acc_vec_gate_alpha[1], self.swiglu_limit)
+                                acc_vec_gate_alpha = (gate_lo, gate_hi)
+                                up_lo = fclip_xorsign(acc_vec_up_alpha[0], self.swiglu_limit)
+                                up_hi = fclip_xorsign(acc_vec_up_alpha[1], self.swiglu_limit)
+                                acc_vec_up_alpha = (up_lo, up_hi)
                             tCompute_log2e = cute.arch.mul_packed_f32x2(
                                 (acc_vec_gate_alpha[0], acc_vec_gate_alpha[1]), (-LOG2_E, -LOG2_E)
                             )
@@ -1807,6 +1820,9 @@ class Sm100BlockScaledContiguousGroupedGemmSwigluFusionKernel:
                         for i in cutlass.range_constexpr(cute.size(tTR_rAcc_up)):
                             acc_vec_up_alpha = acc_vec_up[i] * cutlass.Float32(alpha_val)
                             acc_vec_gate_alpha = acc_vec_gate[i] * cutlass.Float32(alpha_val)
+                            if cutlass.const_expr(self.has_swiglu_limit):
+                                acc_vec_gate_alpha = fmin(acc_vec_gate_alpha, self.swiglu_limit)
+                                acc_vec_up_alpha = fclip_xorsign(acc_vec_up_alpha, self.swiglu_limit)
                             tCompute[i] = acc_vec_up_alpha * silu_f32(
                                 acc_vec_gate_alpha, fastmath=True
                             )

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/utils.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/utils.py
@@ -217,6 +217,35 @@ def fmin(a: Union[float, cutlass.Float32],
         ))
 
 
+@dsl_user_op
+def fclip_xorsign(a: Union[float, cutlass.Float32],
+                  limit: Union[float, cutlass.Float32],
+                  *,
+                  loc=None,
+                  ip=None) -> cutlass.Float32:
+    """Symmetric clip.
+
+    Emits PTX ``min.xorsign.abs.f32`` with semantics
+    ``d = sign(a XOR limit) * min(|a|, |limit|)``.
+    When ``limit > 0`` this equals ``clip(a, -limit, +limit)``.
+
+    Requires sm_86+.
+    """
+    return cutlass.Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [
+                cutlass.Float32(a).ir_value(loc=loc, ip=ip),
+                cutlass.Float32(limit).ir_value(loc=loc, ip=ip),
+            ],
+            "min.xorsign.abs.f32 $0, $1, $2;",
+            "=f,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        ))
+
+
 def sigmoid_f32(a: Union[float, cutlass.Float32],
                 fastmath: bool = False) -> Union[float, cutlass.Float32]:
     """

--- a/tests/scripts/cute_dsl_kernels/run_blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/tests/scripts/cute_dsl_kernels/run_blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -620,6 +620,7 @@ def run(
     use_cupti: bool = False,
     raster_along_m: bool = False,
     num_b_tensors: int = None,
+    swiglu_limit: float = float('inf'),
     **kwargs,
 ):
     """Run contiguous grouped GEMM with gather operation and SwiGLU fusion for FC1 layer.
@@ -755,6 +756,7 @@ def run(
         topk=1,
         raster_along_m=raster_along_m,
         b_tensor_l_sizes=b_tensor_l_sizes if multi_b_mode else None,
+        swiglu_limit=swiglu_limit,
     )
 
     # Compute max active clusters on current device
@@ -893,6 +895,11 @@ def run(
             gate_result = gemm_result[
                 0, :, n_block + interleave_granularity : n_block + 2 * interleave_granularity
             ]
+
+            # SwiGLU clamp
+            if swiglu_limit != float('inf'):
+                gate_result = gate_result.clamp(max=swiglu_limit)
+                up_result = up_result.clamp(min=-swiglu_limit, max=swiglu_limit)
 
             # SwiGLU: up * silu(gate) where silu(x) = x * sigmoid(x)
             silu_gate = gate_result * torch.sigmoid(gate_result)
@@ -1387,6 +1394,12 @@ if __name__ == "__main__":
         help="Number of B tensors to split into (for multi-B tensor test). "
         "If specified, enables multi-B tensor mode. Must be 2, 3, or 4.",
     )
+    parser.add_argument(
+        "--swiglu_limit",
+        type=float,
+        default=float('inf'),
+        help="Swiglu clamp factor, +inf (default) disables clamp",
+    )
 
     args = parser.parse_args()
 
@@ -1453,6 +1466,7 @@ if __name__ == "__main__":
         args.use_cupti,
         args.raster_along_m,
         args.num_b_tensors,
+        args.swiglu_limit,
     )
     print(f"Execution time: {exec_time:.2f} us")
     print("PASS")

--- a/tests/scripts/cute_dsl_kernels/run_blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/tests/scripts/cute_dsl_kernels/run_blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -620,7 +620,7 @@ def run(
     use_cupti: bool = False,
     raster_along_m: bool = False,
     num_b_tensors: int = None,
-    swiglu_limit: float = float('inf'),
+    swiglu_limit: float = float("inf"),
     **kwargs,
 ):
     """Run contiguous grouped GEMM with gather operation and SwiGLU fusion for FC1 layer.
@@ -897,7 +897,7 @@ def run(
             ]
 
             # SwiGLU clamp
-            if swiglu_limit != float('inf'):
+            if swiglu_limit != float("inf"):
                 gate_result = gate_result.clamp(max=swiglu_limit)
                 up_result = up_result.clamp(min=-swiglu_limit, max=swiglu_limit)
 
@@ -1397,7 +1397,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--swiglu_limit",
         type=float,
-        default=float('inf'),
+        default=float("inf"),
         help="Swiglu clamp factor, +inf (default) disables clamp",
     )
 

--- a/tests/scripts/cute_dsl_kernels/run_blockscaled_contiguous_grouped_gemm_swiglu_fusion.py
+++ b/tests/scripts/cute_dsl_kernels/run_blockscaled_contiguous_grouped_gemm_swiglu_fusion.py
@@ -440,6 +440,7 @@ def run(
     use_cold_l2: bool = False,
     permuted_m: int = None,
     use_cupti: bool = False,
+    swiglu_limit: float = float('inf'),
     **kwargs,
 ):
     """Prepare A/B/C tensors, launch GPU kernel, and reference checking.
@@ -546,6 +547,7 @@ def run(
         mma_tiler_mn,
         cluster_shape_mn,
         vectorized_f32,
+        swiglu_limit=swiglu_limit,
     )
 
     # Compute max active clusters on current device
@@ -625,6 +627,10 @@ def run(
         gate_idx = block_cols[1::2].reshape(-1)
         ref_up = ref.index_select(1, up_idx)
         ref_gate = ref.index_select(1, gate_idx)
+        # SwiGLU clamp
+        if swiglu_limit != float('inf'):
+            ref_gate = ref_gate.clamp(max=swiglu_limit)
+            ref_up = ref_up.clamp(min=-swiglu_limit, max=swiglu_limit)
         ref_after_swiglu = ref_up * (ref_gate * torch.sigmoid(ref_gate))
         print(f"ref: {ref.shape}, {ref.stride()}")
 
@@ -996,6 +1002,12 @@ if __name__ == "__main__":
     )
     parser.add_argument("--skip_ref_check", action="store_true", help="Skip reference checking")
     parser.add_argument("--use_cold_l2", action="store_true", default=False, help="Use cold L2")
+    parser.add_argument(
+        "--swiglu_limit",
+        type=float,
+        default=float('inf'),
+        help="Swiglu clamp factor, +inf (default) disables clamp",
+    )
 
     args = parser.parse_args()
 
@@ -1048,6 +1060,7 @@ if __name__ == "__main__":
         args.use_cold_l2,
         args.permuted_m,
         args.use_cupti,
+        args.swiglu_limit,
     )
 
     print(f"Execution time: {exec_time:.2f} us")

--- a/tests/scripts/cute_dsl_kernels/run_blockscaled_contiguous_grouped_gemm_swiglu_fusion.py
+++ b/tests/scripts/cute_dsl_kernels/run_blockscaled_contiguous_grouped_gemm_swiglu_fusion.py
@@ -440,7 +440,7 @@ def run(
     use_cold_l2: bool = False,
     permuted_m: int = None,
     use_cupti: bool = False,
-    swiglu_limit: float = float('inf'),
+    swiglu_limit: float = float("inf"),
     **kwargs,
 ):
     """Prepare A/B/C tensors, launch GPU kernel, and reference checking.
@@ -628,7 +628,7 @@ def run(
         ref_up = ref.index_select(1, up_idx)
         ref_gate = ref.index_select(1, gate_idx)
         # SwiGLU clamp
-        if swiglu_limit != float('inf'):
+        if swiglu_limit != float("inf"):
             ref_gate = ref_gate.clamp(max=swiglu_limit)
             ref_up = ref_up.clamp(min=-swiglu_limit, max=swiglu_limit)
         ref_after_swiglu = ref_up * (ref_gate * torch.sigmoid(ref_gate))
@@ -1005,7 +1005,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--swiglu_limit",
         type=float,
-        default=float('inf'),
+        default=float("inf"),
         help="Swiglu clamp factor, +inf (default) disables clamp",
     )
 


### PR DESCRIPTION
Adds optional swiglu_limit (scalar, +inf default = no clamp) to fc1 gather+act_fusion and early swiglu_fusion kernels, plus the matching --swiglu_limit flag in their run scripts.

Gate uses fmin (one-sided); up uses fclip_xorsign (new helper in utils.py) which emits PTX min.xorsign.abs.f32 for symmetric clip in a single op. has_swiglu_limit constexpr DCE keeps the no-clamp path byte-equivalent to baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced optional `swiglu_limit` parameter for GEMM kernels to control SwiGLU activation value clamping
  * Allows limiting activation values for improved numerical stability when configured
  * Command-line support added for specifying the clamp limit
  * Default behavior unchanged (no clamping when parameter remains at infinity)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
