### PR TITLE
[https://nvbugs/6185234][fix] DeepSeek-V3.2 tokenizer load on transformers 5.x

### DIFF
--- a/tensorrt_llm/tokenizer/tokenizer.py
+++ b/tensorrt_llm/tokenizer/tokenizer.py
@@ -59,6 +59,68 @@ def _tokenizer_json_uses_byte_level(pretrained_model_dir: str) -> bool:
     return False
 
 
+# Keys forwarded from tokenizer_config.json to PreTrainedTokenizerFast when
+# falling back. LlamaTokenizerFast-style flags the bare fast tokenizer does
+# not read by default but AutoTokenizer would have honored.
+_TOKENIZER_CONFIG_INHERIT_KEYS = (
+    "add_bos_token",
+    "add_eos_token",
+    "padding_side",
+    "truncation_side",
+    "model_max_length",
+    "clean_up_tokenization_spaces",
+)
+
+
+def _load_tokenizer_config_inherits(
+        pretrained_model_dir: str) -> Dict[str, Any]:
+    """Return a dict of LlamaTokenizerFast-style flags from tokenizer_config.json."""
+    import json
+    tcfg_path = os.path.join(pretrained_model_dir, "tokenizer_config.json")
+    if not os.path.isfile(tcfg_path):
+        return {}
+    try:
+        with open(tcfg_path) as f:
+            tcfg = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return {k: tcfg[k] for k in _TOKENIZER_CONFIG_INHERIT_KEYS if k in tcfg}
+
+
+def _fallback_to_fast_tokenizer(pretrained_model_dir: str,
+                                original_error: BaseException, **kwargs):
+    """Bypass AutoTokenizer's HF-config path with PreTrainedTokenizerFast.
+
+    transformers 5.x converted PreTrainedConfig to a dataclass: only declared
+    fields survive __post_init__'s RoPE standardization. When a model uses a
+    model_type not registered in CONFIG_MAPPING_NAMES (e.g. DeepSeek-V3.2's
+    ``deepseek_v32``), AutoTokenizer.from_pretrained falls back to a bare
+    PreTrainedConfig whose RoPE path reads self.max_position_embeddings,
+    raising AttributeError.
+
+    PreTrainedTokenizerFast doesn't go through AutoConfig — it reads
+    tokenizer.json via the Rust tokenizers library — so it sidesteps this
+    entirely. We forward LlamaTokenizerFast-style flags (add_bos_token,
+    padding_side, ...) from tokenizer_config.json so the fast tokenizer
+    matches the behavior AutoTokenizer would have had pre-regression.
+    """
+    inherited = _load_tokenizer_config_inherits(pretrained_model_dir)
+    fast_kwargs = {
+        k: v
+        for k, v in kwargs.items() if k not in ("trust_remote_code", "use_fast")
+    }
+    # caller kwargs win over tokenizer_config.json inherited values
+    merged = {**inherited, **fast_kwargs}
+    logger.warning(
+        f"AutoTokenizer.from_pretrained({pretrained_model_dir}) raised "
+        f"{type(original_error).__name__}: {original_error}. Falling back to "
+        f"PreTrainedTokenizerFast to bypass HF dataclass regression "
+        f"(model_type likely not registered in CONFIG_MAPPING_NAMES). "
+        f"Inherited from tokenizer_config.json: {sorted(inherited)}")
+    return PreTrainedTokenizerFast.from_pretrained(pretrained_model_dir,
+                                                   **merged)
+
+
 def maybe_fix_byte_level_tokenizer(tokenizer, pretrained_model_dir: str,
                                    **kwargs):
     """Work around Transformers 5.x LlamaTokenizer overriding tokenizer.json.
@@ -189,8 +251,19 @@ class TransformersTokenizer(TokenizerBase):
 
     @classmethod
     def from_pretrained(cls, pretrained_model_dir: str, **kwargs):
-        tokenizer = AutoTokenizer.from_pretrained(pretrained_model_dir,
-                                                  **kwargs)
+        try:
+            tokenizer = AutoTokenizer.from_pretrained(pretrained_model_dir,
+                                                      **kwargs)
+        except AttributeError as e:
+            # transformers 5.x: bare PreTrainedConfig fallback (for model_types
+            # not in CONFIG_MAPPING_NAMES, e.g. deepseek_v32) hits
+            # modeling_rope_utils → self.max_position_embeddings → AttributeError
+            # because PreTrainedConfig is now a dataclass with declared fields.
+            # See deepseek-ai/DeepSeek-V3#1207.
+            if "max_position_embeddings" not in str(e):
+                raise
+            tokenizer = _fallback_to_fast_tokenizer(pretrained_model_dir, e,
+                                                    **kwargs)
         tokenizer = maybe_fix_byte_level_tokenizer(tokenizer,
                                                    pretrained_model_dir,
                                                    **kwargs)


### PR DESCRIPTION
## Description                                                                                                        
                  
  Fix `TransformersTokenizer.from_pretrained` for models whose `model_type`
  is not registered in HF transformers' `CONFIG_MAPPING_NAMES` (notably
  DeepSeek-V3.2-Exp, `model_type=deepseek_v32`) under transformers >= 5.0.                                              
                                                                                                                        
  ## Root cause                                                                                                         
                                                                                                                        
  On transformers 5.x, `PreTrainedConfig` is `@dataclass_transform`-decorated.                                          
  When `AutoConfig.from_pretrained` encounters an unknown `model_type`, it
  falls back to the base `PreTrainedConfig` instead of a concrete subclass,                                             
  and any field that subclasses normally provide is missing. Reading
  `max_position_embeddings` on that base instance raises:                                                               
                                                                                                                        
      AttributeError: 'PreTrainedConfig' object has no attribute                                                        
                      'max_position_embeddings'                                                                         
                  
  This kills `AutoTokenizer.from_pretrained` even though the tokenizer files
  (`tokenizer.json`, `tokenizer_config.json`) are themselves loadable.                                                  
                                                                                                                        
  Repro:                                                                                                                
  - L0_PostMerge Build 2722:                                                                                            
    accuracy/test_disaggregated_serving.py::TestDeepSeekV32Exp::test_auto_dtype[False]
  - Manual: trtllm-eval against DeepSeek-V3.2-Exp-FP4-v2 on transformers                                                
    5.5.3, any backend.                                                                                                 
                                                                                                                        
  ## Fix                                                                                                                
                                                                                                                        
  In `tensorrt_llm/tokenizer/tokenizer.py`:
                                                                                                                        
  1. Wrap `AutoTokenizer.from_pretrained` in
     `TransformersTokenizer.from_pretrained` with a fallback path that                                                  
     catches `AttributeError`/`KeyError` mentioning `max_position_embeddings`.                                          
  2. Fall back to `PreTrainedTokenizerFast.from_pretrained`, which reads
     `tokenizer.json` directly via the Rust tokenizers backend and does not                                             
     touch `AutoConfig`.
  3. Inherit `add_bos_token`, `add_eos_token`, `clean_up_tokenization_spaces`,                                          
     `model_max_length` from `tokenizer_config.json` so behavior matches
     `AutoTokenizer` on the keys that affect prompt formatting.                                                         
  4. Emit a `[TRT-LLM] [W] [tokenizr]` warning naming the bypassed dataclass
     regression and listing inherited keys, so this stays debuggable.                                                   
                                                                                                                        
  The normal `AutoTokenizer` path is unchanged for all models whose                                                     
  `model_type` is registered (Llama, Gemma, Qwen, ...).  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Transformers 5.x library versions for tokenizer initialization
  * Added fallback mechanism to handle tokenizer configuration edge cases
  * Enhanced handling of model types that previously caused initialization failures with newer library versions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->