### PR TITLE
[None][fix] Handle unset attention_dp_relax in ADP routers

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -304,7 +304,7 @@ class DefaultADPRouter(ADPRouter):
             scheduling_params = getattr(req_item.request, "py_scheduling_params", None)
             if scheduling_params is None:
                 return True
-            return scheduling_params.attention_dp_relax
+            return scheduling_params.attention_dp_relax is not False
 
         sorted_requests = sorted(new_requests, key=get_relax_value)
 
@@ -576,7 +576,7 @@ class KVCacheAwareADPRouter(ADPRouter):
             scheduling_params = getattr(req_item.request, "py_scheduling_params", None)
             if scheduling_params is None:
                 return True
-            return scheduling_params.attention_dp_relax
+            return scheduling_params.attention_dp_relax is not False
 
         sorted_requests = sorted(new_requests, key=get_relax_value)
 

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -304,7 +304,7 @@ class DefaultADPRouter(ADPRouter):
             scheduling_params = getattr(req_item.request, "py_scheduling_params", None)
             if scheduling_params is None:
                 return True
-            return scheduling_params.attention_dp_relax is not False
+            return scheduling_params.attention_dp_relax
 
         sorted_requests = sorted(new_requests, key=get_relax_value)
 
@@ -576,7 +576,7 @@ class KVCacheAwareADPRouter(ADPRouter):
             scheduling_params = getattr(req_item.request, "py_scheduling_params", None)
             if scheduling_params is None:
                 return True
-            return scheduling_params.attention_dp_relax is not False
+            return scheduling_params.attention_dp_relax
 
         sorted_requests = sorted(new_requests, key=get_relax_value)
 

--- a/tensorrt_llm/scheduling_params.py
+++ b/tensorrt_llm/scheduling_params.py
@@ -10,12 +10,13 @@ class SchedulingParams:
 
     Args:
         attention_dp_rank (int): The rank of target attention dp
-        attention_dp_relax (bool): Whether to allow the request to be scheduled to other attention dp for better throughput
+        attention_dp_relax (bool): Whether to allow the request to be scheduled to other attention dp for better
+            throughput. Defaults to True.
         agent_hierarchy (AgentHierarchy): Path of (agent_type, node_id) tuples
             identifying this request's position in an agent execution tree.
             Used by the batch scheduler for hierarchy-aware scheduling.
     """
 
     attention_dp_rank: Optional[int] = None
-    attention_dp_relax: Optional[bool] = None
+    attention_dp_relax: bool = True
     agent_hierarchy: Optional[AgentHierarchy] = None

--- a/tests/unittest/_torch/executor/test_adp_router.py
+++ b/tests/unittest/_torch/executor/test_adp_router.py
@@ -203,6 +203,22 @@ class TestDefaultADPRouter:
         assert len(result[0]) == 1
         assert len(result[1]) == 0
 
+    def test_none_attention_dp_relax_is_relaxed(self):
+        router = DefaultADPRouter(dist=_mock_dist())
+        states = [
+            RankState(rank=0, num_active_requests=0, num_active_tokens=0),
+            RankState(rank=1, num_active_requests=0, num_active_tokens=0),
+        ]
+        req_relax = _make_request_item(1, target_dp_rank=0, attention_dp_relax=None)
+        req_strict = _make_request_item(2, target_dp_rank=0, attention_dp_relax=False)
+
+        result, _ = router.route_requests(
+            states, [req_relax, req_strict], max_num_active_requests=1
+        )
+
+        assert result[0] == [req_strict]
+        assert req_relax in result[1]
+
     def test_favors_less_loaded_rank(self):
         router = DefaultADPRouter(dist=_mock_dist())
         states = [
@@ -925,6 +941,18 @@ class TestKVCacheAwareADPRouterRouting:
         result, _ = router.route_requests(self._rank_states(2), [req], max_num_active_requests=10)
         assert result[0] == []
         assert result[1] == [req]
+
+    def test_none_attention_dp_relax_is_relaxed(self):
+        router = self._make_router(tp_size=2)
+        req_relax = _make_request_item(1, target_dp_rank=0, attention_dp_relax=None)
+        req_strict = _make_request_item(2, target_dp_rank=0, attention_dp_relax=False)
+
+        result, _ = router.route_requests(
+            self._rank_states(2), [req_relax, req_strict], max_num_active_requests=1
+        )
+
+        assert result[0] == [req_strict]
+        assert req_relax in result[1]
 
     def test_match_rate_threshold_gates_cache_affinity(self):
         """With rank 0 loaded but holding cache, and rank 1 idle with no

--- a/tests/unittest/_torch/executor/test_adp_router.py
+++ b/tests/unittest/_torch/executor/test_adp_router.py
@@ -21,6 +21,7 @@ from tensorrt_llm._torch.pyexecutor.scheduler.adp_router import (
     RankIterStatsPayload,
     RankState,
 )
+from tensorrt_llm.scheduling_params import SchedulingParams
 
 
 def _mock_dist(tp_rank=0, tp_size=1, has_cp_helix=False):
@@ -203,13 +204,14 @@ class TestDefaultADPRouter:
         assert len(result[0]) == 1
         assert len(result[1]) == 0
 
-    def test_none_attention_dp_relax_is_relaxed(self):
+    def test_default_attention_dp_relax_is_relaxed(self):
         router = DefaultADPRouter(dist=_mock_dist())
         states = [
             RankState(rank=0, num_active_requests=0, num_active_tokens=0),
             RankState(rank=1, num_active_requests=0, num_active_tokens=0),
         ]
-        req_relax = _make_request_item(1, target_dp_rank=0, attention_dp_relax=None)
+        req_relax = _make_request_item(1, target_dp_rank=0)
+        req_relax.request.py_scheduling_params = SchedulingParams(attention_dp_rank=0)
         req_strict = _make_request_item(2, target_dp_rank=0, attention_dp_relax=False)
 
         result, _ = router.route_requests(
@@ -942,9 +944,10 @@ class TestKVCacheAwareADPRouterRouting:
         assert result[0] == []
         assert result[1] == [req]
 
-    def test_none_attention_dp_relax_is_relaxed(self):
+    def test_default_attention_dp_relax_is_relaxed(self):
         router = self._make_router(tp_size=2)
-        req_relax = _make_request_item(1, target_dp_rank=0, attention_dp_relax=None)
+        req_relax = _make_request_item(1, target_dp_rank=0)
+        req_relax.request.py_scheduling_params = SchedulingParams(attention_dp_rank=0)
         req_strict = _make_request_item(2, target_dp_rank=0, attention_dp_relax=False)
 
         result, _ = router.route_requests(


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request scheduling to correctly treat unset parameters as permitting relaxed routing mode, ensuring proper request distribution under capacity constraints.

* **Tests**
  * Added unit tests verifying request routing behavior with different parameter configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Fix an ADP router crash when a request has `SchedulingParams`, but `attention_dp_relax` is unset and causing NoneType comparison. Hit this issue when doing perfwork for DS V4 using inferenceX benchmarking script but both main and DS V4 branch will have this issue. 

 `SchedulingParams.attention_dp_relax` is typed as `Optional[bool]` and defaults to `None`.

  The ADP routers were using this field directly as the sort key:


 ` return scheduling_params.attention_dp_relax`

  This was previously mostly hidden for OpenAI serving because requests often had no `py_scheduling_params`, so the router took the safe path:

```
  if scheduling_params is None:
      return True
```

  After a31d650304e / #11173, OpenAI chat and harmony paths create SchedulingParams(agent_hierarchy=...) and pass it into generation. That means `scheduling_params` is present, but `attention_dp_relax` remains `None`. With multiple such requests, Python sorting can compare `None` values and fail with:
`TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'`

Fix:
Treat only an explicit False as strict and keep None aligned with the existing missing-scheduling-params behavior. Apply the same logic to both DefaultADPRouter and KVCacheAwareADPRouter, with regression coverage for both paths.


## Test Coverage

Added regression coverage for both ADP router implementations where one request has `attention_dp_relax=None `and another has `attention_dp_relax=False`.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
