### PR TITLE
[None][feat] add Visual Gen Auto path for Diffusers transformers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ accelerate>=1.7.0
 build
 colored
 cuda-python>=13
-diffusers>=0.37.1
+diffusers>=0.37.1,<0.41.0  # visual_gen auto path tested on 0.39-0.40 — see auto/auto_pipeline._check_diffusers_version
 ftfy
 lark
 mpi4py

--- a/tensorrt_llm/_torch/visual_gen/auto/__init__.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/__init__.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""VisGen-Auto: torch.export + FX-rewrite path for diffusers transformers.
+
+Coexists with the handwritten visual-gen pipelines as a fallback. Dispatch
+between the two is in `tensorrt_llm._torch.visual_gen.pipeline_registry.AutoPipeline`,
+keyed on `DiffusionModelConfig.pipeline_mode` (`auto` | `fallback` | `strict`).
+Public surface: `AutoTransformerPipeline`, `VisGenFamilyAdapter`, `RewritePolicy`.
+"""
+
+from .adapter import VisGenFamilyAdapter
+from .pipeline import AutoTransformerPipeline
+from .policy import RewritePolicy
+
+__all__ = [
+    "AutoTransformerPipeline",
+    "RewritePolicy",
+    "VisGenFamilyAdapter",
+]

--- a/tensorrt_llm/_torch/visual_gen/auto/adapter.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/adapter.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Per-family adapter contract for VisGen-Auto.
+
+A family adapter describes a Diffusers transformer family enough for the
+auto path to capture and rewrite it: which Diffusers class it targets, how
+to build example inputs for `torch.export`, which dims are dynamic, which
+rewrite policy applies, and (optionally) Ulysses + custom-pass hooks.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import torch
+
+    from ..config import DiffusionModelConfig
+    from .pass_manager import PassManager
+    from .policy import RewritePolicy
+
+
+class VisGenFamilyAdapter(ABC):
+    """Abstract base class for family adapters."""
+
+    family: str = ""
+    diffusers_transformer_cls: str = ""
+
+    @abstractmethod
+    def example_inputs(
+        self,
+        cfg: "DiffusionModelConfig",
+        device: "torch.device",
+        dtype: "torch.dtype",
+    ) -> tuple[tuple, dict[str, Any]]:
+        """Return `(args, kwargs)` for `torch.export.export`.
+
+        Tensors must be materialized on `device` with floating-point dtype
+        `dtype`; integer tensors (timestep, ids) keep their natural dtype.
+        Returning `args=()` and using kwargs for everything is conventional
+        because Diffusers transformers take all inputs as kwargs.
+        """
+
+    @abstractmethod
+    def dynamic_shapes(self, cfg: "DiffusionModelConfig") -> dict[str, Any]:
+        """Return the `dynamic_shapes` arg for `torch.export.export`.
+
+        Keys are kwarg names from `example_inputs`; values are dim specs as
+        accepted by `torch.export` (e.g. ``{0: torch.export.Dim("B"),
+        1: torch.export.Dim("S_img")}`` or ``None`` for fully static).
+        """
+
+    @abstractmethod
+    def rewrite_policy(self, cfg: "DiffusionModelConfig") -> "RewritePolicy":
+        """Return the rewrite policy for this family + config combination."""
+
+    def default_quant_exclude_modules(self) -> list[str]:
+        """Glob patterns for `nn.Linear` modules that should NOT be quantized
+        when this family runs through the auto path.
+
+        Default is empty; families with known quantization-sensitive layers
+        override this. The patterns are merged with the user-supplied
+        `quant_config.exclude_modules` (union — user can only add, never
+        remove a family default by passing their own list).
+        """
+        return []
+
+    # ------------------------------------------------------------------
+    # Multi-GPU (Ulysses) hooks
+    # ------------------------------------------------------------------
+    @property
+    def uses_internal_seq_shard(self) -> bool:
+        """When True, the family shards the flat sequence INSIDE the captured
+        model.forward (after patch+flatten) and all-gathers before output
+        projection. `_GraphModuleAsTransformer` skips its pipeline-boundary
+        shard/gather hooks for these families.
+
+        Image-DiT families (FLUX, SD3, ...) have already-token-flat
+        `(B, S_img, C)` inputs and stick with boundary sharding — default
+        `False`. Video-DiT families (WAN, ...) have 5-D `(B, C, T, H, W)`
+        pre-patch inputs where the flat-sequence half doesn't map cleanly
+        to any single 5-D axis, so they override this to `True` and provide
+        a `pre_capture_patch` that bakes the slice + gather into the
+        captured graph.
+        """
+        return False
+
+    def customize_passes(self, pm: "PassManager") -> None:
+        """Optional hook called by ``apply_rewrites`` after the default pass
+        list (built from ``RewritePolicy``) is constructed but before it runs.
+
+        Adapters can splice in family-specific passes via the manager's
+        ``insert_before`` / ``insert_after`` / ``replace`` / ``remove`` /
+        ``append`` primitives. Default is a no-op — only families with a
+        structural pattern not covered by the shared passes need this.
+
+        Example::
+
+            def customize_passes(self, pm):
+                from .my_family_passes import fuse_my_thing
+
+                pm.insert_after("fuse_qkv", Pass("fuse_my_thing", fuse_my_thing))
+        """
+        return None
+
+    def pre_capture_patch(self, model, visual_gen_mapping) -> None:
+        """Optional hook called by `AutoDiffusersPipeline` right before
+        `torch.export.export`. Families with `uses_internal_seq_shard=True`
+        monkey-patch the model's `forward` here to inject the per-rank
+        sequence slice + `visgen_auto.all_gather_seq` call. Other families
+        leave this as a no-op.
+
+        `visual_gen_mapping` may be `None` (single-GPU); in that case the
+        patch should be a no-op (no slicing needed).
+        """
+        return None

--- a/tensorrt_llm/_torch/visual_gen/auto/auto_pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/auto_pipeline.py
@@ -1,0 +1,839 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end pipeline wrapper for the auto path.
+
+`AutoDiffusersPipeline` is the Diffusers-shaped factory used internally by
+the user-facing `AutoTransformerPipeline` (see ``pipeline.py``): it loads
+a Diffusers `DiffusionPipeline` from a checkpoint, captures + rewrites the
+transformer through the auto path, and swaps the captured `GraphModule`
+back into the Diffusers pipeline as the new `.transformer`. End-to-end
+generation then goes through the Diffusers pipeline's `__call__`, which
+runs text encoding, the scheduler loop (now invoking our captured
+transformer), and VAE decode.
+
+`AutoDiffusersPipeline` is *not* a `BasePipeline` subclass. The user-facing
+`AutoTransformerPipeline` is the `BasePipeline`-shaped adapter that the
+loader/executor see; it delegates the heavy lifting here.
+
+Note: the Diffusers pipeline calls the transformer in eager — its
+`__call__` accesses attributes like `.config`, `.dtype`, expects a
+specific forward signature, and may attach forward hooks. The captured
+`GraphModule` doesn't carry all of these. `_GraphModuleAsTransformer`
+wraps the GraphModule with the minimum attribute surface needed.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING, Any, Optional
+
+import torch
+import torch.nn as nn
+
+from tensorrt_llm.logger import logger
+
+from . import ops  # noqa: F401 — registers torch.ops.visgen_auto.*
+
+if TYPE_CHECKING:
+    from ..config import DiffusionModelConfig
+    from .adapter import VisGenFamilyAdapter
+
+
+# --- Ulysses sequence sharding helpers ---------------------------------------
+# Keys whose tensor lives in the image-sequence axis (S_img). The shard pass
+# slices these along dim=1 (B, S, ...) so each rank only feeds its `S/P` tokens
+# into the captured transformer. img_ids and txt_ids are RoPE positional ids;
+# img_ids tracks the image sequence and is sharded the same way. txt_ids stays
+# replicated (the encoder side has a fixed text seq length).
+_IMG_SEQ_KWARGS = ("hidden_states", "img_ids")
+
+
+def _shard_seq_kwargs(kwargs: dict[str, Any], vgm) -> dict[str, Any]:
+    """Slice image-sequence-axis tensors so each rank sees `S/P` tokens.
+
+    Operates on a *copy* of kwargs — leaves caller's dict alone. Tensors
+    whose sequence dim isn't divisible by `ulysses_size` raise rather than
+    silently misalign across ranks.
+    """
+    P = vgm.ulysses_size
+    rank = vgm.ulysses_rank
+    out = dict(kwargs)
+    for k in _IMG_SEQ_KWARGS:
+        t = out.get(k)
+        if not isinstance(t, torch.Tensor):
+            continue
+        # Diffusers passes `img_ids` un-batched in some families (FLUX.1:
+        # shape `(S, 3)`) and batched in others (FLUX.2: `(B, S, 4)`).
+        # Heuristic: 2-D tensors are `(S, coord_dim)` (shard dim 0);
+        # 3-D or higher are `(B, S, ...)` (shard dim 1).
+        seq_dim = 0 if t.ndim == 2 else 1
+        S = t.shape[seq_dim]
+        if S % P != 0:
+            raise ValueError(
+                f"AutoDiffusersPipeline Ulysses: `{k}` seq dim {S} (axis "
+                f"{seq_dim} of shape {tuple(t.shape)}) not divisible by "
+                f"ulysses_size {P}. Pick a resolution where the post-patch "
+                f"seq length is divisible by {P}."
+            )
+        local = S // P
+        out[k] = t.narrow(seq_dim, rank * local, local).contiguous()
+    return out
+
+
+def _split_batch_args_kwargs(args, kwargs, vgm):
+    """Slice the CFG-doubled batch (dim-0) by ``cfg_rank``.
+
+    Diffusers pipelines that use classifier-free guidance build a
+    CFG-doubled batch ``[uncond, cond]`` (or vice-versa) and pass it to
+    the transformer. With ``cfg_size > 1`` we split that batch across the
+    cfg group so each rank only forwards on its half — the gather on
+    the way out re-assembles ``[uncond, cond]`` invisibly to the pipeline.
+
+    Heuristic: only tensors whose dim-0 is a non-trivial multiple of
+    ``cfg_size`` get sliced. Singleton or non-batch tensors (e.g. FLUX.1's
+    un-batched ``img_ids`` of shape ``(S, 3)``) pass through unchanged.
+    """
+    P = getattr(vgm, "cfg_size", 1)
+    if P <= 1:
+        return args, kwargs
+    R = vgm.cfg_rank
+
+    def _is_batch_tensor(t) -> bool:
+        # Heuristic: a 2-D tensor with shape `(S, coord_dim)` (FLUX.1 `img_ids`)
+        # is un-batched; everything ≥3-D with non-trivial dim-0 is batched.
+        return isinstance(t, torch.Tensor) and t.ndim >= 2 and t.shape[0] > 1
+
+    # Detect the CFG-doubled batch. We expect at least one ≥3-D tensor whose
+    # dim-0 is a non-trivial multiple of `cfg_size`. If we can't find any, the
+    # caller is passing a single-sample batch under cfg_size>1 — silently
+    # bypassing the split would let the gather (which expects `cfg_size` ranks
+    # of output) collide with shape mismatches later. Fail loud.
+    candidates = [t for t in list(args) + list(kwargs.values()) if _is_batch_tensor(t)]
+    if not any(t.shape[0] % P == 0 and t.shape[0] >= P for t in candidates):
+        raise ValueError(
+            f"CFG-parallel ({P}-way) requested but no input tensor has a "
+            f"dim-0 divisible by {P}. Diffusers pipelines must produce a "
+            f"CFG-doubled batch (guidance_scale > 1.0) for CFG-parallel to "
+            "make sense. Got dim-0 values: "
+            f"{[t.shape[0] for t in candidates]}."
+        )
+
+    def _slice(t):
+        if not isinstance(t, torch.Tensor) or t.ndim == 0:
+            return t
+        B = t.shape[0]
+        if B % P != 0 or B // P < 1:
+            return t
+        local = B // P
+        return t.narrow(0, R * local, local).contiguous()
+
+    new_args = tuple(_slice(a) for a in args)
+    new_kwargs = {k: _slice(v) for k, v in kwargs.items()}
+    return new_args, new_kwargs
+
+
+def _gather_batch_output(out, vgm):
+    """All-gather output along batch dim (0) across the cfg group.
+
+    Mirrors `_gather_seq_output` but on dim-0. Diffusers reads back
+    `(B_full, ...)` after the transformer call (it then does the
+    `uncond + gs * (cond - uncond)` guidance combine), so we restore the
+    full batch before returning.
+    """
+    import torch.distributed as dist
+
+    P = getattr(vgm, "cfg_size", 1)
+    if P <= 1:
+        return out
+    pg = vgm.cfg_group
+    if pg is None:
+        # `cfg_group` is None when the device mesh hasn't been built yet
+        # (`VisualGenMapping.__init__` only builds the mesh when
+        # `dist.is_initialized()`). Falling through would default to the
+        # world group — silent corruption across the whole world. Fail
+        # loud instead so the caller fixes the init order.
+        raise RuntimeError(
+            "AutoDiffusersPipeline: cfg_size > 1 but VisualGenMapping has no "
+            "cfg_group (device mesh not built). Initialize torch.distributed "
+            "and re-construct VisualGenMapping before pipeline creation."
+        )
+
+    def _gather(t: torch.Tensor) -> torch.Tensor:
+        if not isinstance(t, torch.Tensor):
+            return t
+        gathered = [torch.empty_like(t) for _ in range(P)]
+        dist.all_gather(gathered, t.contiguous(), group=pg)
+        return torch.cat(gathered, dim=0)
+
+    if isinstance(out, torch.Tensor):
+        return _gather(out)
+    if isinstance(out, tuple):
+        # LTX-2 returns `(noise_pred_video, noise_pred_audio)` — every
+        # CFG-doubled head needs the gather. Walk the whole tuple.
+        return tuple(_gather(x) if isinstance(x, torch.Tensor) else x for x in out)
+    if hasattr(out, "sample"):
+        out.sample = _gather(out.sample)
+        return out
+    return out
+
+
+def _gather_seq_output(out, vgm):
+    """All-gather the image-sequence-sharded output back to full seq.
+
+    Captured Diffusers transformers return either a tensor or a tuple/object
+    whose first element is the noise prediction shaped `(B, S_img, ...)`.
+    We mirror the input call's `return_dict=False` convention by gathering
+    the first tensor and re-packing.
+    """
+    import torch.distributed as dist
+
+    P = vgm.ulysses_size
+    pg = vgm.ulysses_group
+    if pg is None:
+        raise RuntimeError(
+            "AutoDiffusersPipeline: ulysses_size > 1 but VisualGenMapping has "
+            "no ulysses_group (device mesh not built). Initialize "
+            "torch.distributed and re-construct VisualGenMapping before "
+            "pipeline creation."
+        )
+
+    def _gather(t: torch.Tensor) -> torch.Tensor:
+        if not isinstance(t, torch.Tensor) or t.dim() < 2:
+            return t
+        gathered = [torch.empty_like(t) for _ in range(P)]
+        dist.all_gather(gathered, t.contiguous(), group=pg)
+        return torch.cat(gathered, dim=1)
+
+    if isinstance(out, torch.Tensor):
+        return _gather(out)
+    if isinstance(out, tuple):
+        return (_gather(out[0]),) + tuple(out[1:])
+    # Diffusers Transformer2DModelOutput-like — has `.sample`
+    if hasattr(out, "sample"):
+        out.sample = _gather(out.sample)
+        return out
+    return out
+
+
+def _resolve_adapter(diffusers_transformer_cls: str) -> "VisGenFamilyAdapter":
+    """Look up the family adapter for a Diffusers transformer class.
+
+    Adapters declare which class they target via `diffusers_transformer_cls`.
+    Falls back to the generic MM-DiT adapter (S2 best-effort) if no
+    family-specific adapter matches.
+    """
+    from .families import (
+        Flux2Adapter,
+        FluxAdapter,
+        LTX2Adapter,
+        LTXAdapter,
+        MMDiTAdapter,
+        PixArtAdapter,
+        SanaAdapter,
+        SD3Adapter,
+        WanAdapter,
+    )
+
+    registry = [
+        FluxAdapter(),
+        Flux2Adapter(),
+        SD3Adapter(),
+        WanAdapter(),
+        LTXAdapter(),
+        LTX2Adapter(),
+        PixArtAdapter(),
+        SanaAdapter(),
+    ]
+    for adapter in registry:
+        if adapter.diffusers_transformer_cls == diffusers_transformer_cls:
+            return adapter
+    logger.warning(
+        f"No family adapter for {diffusers_transformer_cls!r}; "
+        f"falling back to generic MMDiTAdapter (S2 best-effort)."
+    )
+    return MMDiTAdapter()
+
+
+# Tested-against Diffusers version range. Bump the upper bound only after
+# re-running the family-adapter smoke tests against the new release (see
+# `tests/unittest/_torch/visual_gen/test_auto_*`).
+_DIFFUSERS_MIN = (0, 39)
+_DIFFUSERS_MAX_EXCL = (0, 41)
+
+
+def _check_diffusers_version() -> None:
+    """Warn (loudly) if the runtime Diffusers is outside the auto path's
+    tested range. Adapters monkey-patch `transformer.forward` and reach for
+    family-specific sub-module names — a Diffusers minor bump that renames
+    `patch_embedding` → `patch_embed` etc. silently breaks Ulysses for the
+    affected family. The version gate makes the bump an intentional act.
+
+    Set `VISGEN_AUTO_DIFFUSERS_VERSION_CHECK=skip` to suppress the warning
+    (e.g. when re-running family smokes against a candidate new release).
+    """
+    import os
+
+    if os.environ.get("VISGEN_AUTO_DIFFUSERS_VERSION_CHECK", "").lower() == "skip":
+        return
+
+    import diffusers
+
+    raw = getattr(diffusers, "__version__", "0.0.0")
+    # `0.39.0.dev0` → (0, 39, 0)
+    parts = raw.split("+")[0].split(".dev")[0].split(".")
+    try:
+        major, minor = int(parts[0]), int(parts[1])
+    except (ValueError, IndexError):
+        logger.warning(
+            f"AutoDiffusersPipeline: could not parse diffusers version {raw!r}; "
+            "version compatibility check skipped."
+        )
+        return
+
+    cur = (major, minor)
+    if cur < _DIFFUSERS_MIN or cur >= _DIFFUSERS_MAX_EXCL:
+        logger.warning(
+            f"AutoDiffusersPipeline: diffusers=={raw} is outside the auto "
+            f"path's tested range [>= {'.'.join(map(str, _DIFFUSERS_MIN))}, "
+            f"< {'.'.join(map(str, _DIFFUSERS_MAX_EXCL))}). Family adapters "
+            "(WAN, LTX-2, LTX, SD3, PixArt) reach into specific Diffusers "
+            "transformer sub-modules via `pre_capture_patch` monkey-patches — "
+            "a renamed attribute or signature change will silently break "
+            "Ulysses for the affected family. Re-run "
+            "`tests/unittest/_torch/visual_gen/test_auto_*` before relying on "
+            "this combination. Set VISGEN_AUTO_DIFFUSERS_VERSION_CHECK=skip "
+            "to suppress."
+        )
+
+
+@contextlib.contextmanager
+def _family_preload_overrides(checkpoint_dir: str):
+    """Context-managed Diffusers class-attribute overrides for the load.
+
+    Some Diffusers transformer classes set `_keep_in_fp32_modules` to keep
+    sub-modules (e.g. `condition_embedder` on WAN) in FP32 even when the user
+    requests `torch_dtype=BF16`. The auto path's `torch.export` capture trips
+    on the FP32↔BF16 boundary inside `patch_embedding`'s Conv3d. The
+    handwritten path materializes weights itself and doesn't care.
+
+    Earlier versions of this code mutated the Diffusers class attribute
+    permanently (`WanTransformer3DModel._keep_in_fp32_modules = []`), which
+    affected any handwritten / parity / ablation code that later instantiated
+    the same Diffusers class in the same Python process. Wrap the mutation
+    in a context manager and restore the original value on exit so the
+    mutation is scoped strictly to the `from_pretrained` call.
+    """
+    import json
+    import os
+
+    overrides: list[tuple[type, str, Any]] = []  # (cls, attr, original_value)
+
+    index_path = os.path.join(checkpoint_dir, "model_index.json")
+    if os.path.exists(index_path):
+        try:
+            with open(index_path) as f:
+                class_name = json.load(f).get("_class_name", "")
+        except Exception:  # noqa: BLE001 — best-effort
+            class_name = ""
+
+        if "Wan" in class_name:
+            try:
+                from diffusers.models.transformers.transformer_wan import WanTransformer3DModel
+
+                # Snapshot a shallow *copy*, not a reference — Diffusers
+                # could mutate the list in-place between save and restore
+                # and we'd otherwise re-install the mutated list.
+                original = WanTransformer3DModel._keep_in_fp32_modules
+                snapshot = list(original) if isinstance(original, list) else original
+                overrides.append((WanTransformer3DModel, "_keep_in_fp32_modules", snapshot))
+                WanTransformer3DModel._keep_in_fp32_modules = []
+            except ImportError:
+                pass
+
+    try:
+        yield
+    finally:
+        for cls, attr, original in overrides:
+            setattr(cls, attr, original)
+
+
+class _GraphModuleAsTransformer(nn.Module):
+    """Wrap a captured `GraphModule` to expose the Diffusers transformer's
+    attribute surface: ``.config``, ``.dtype``, ``.device``, etc.
+
+    The wrapped GraphModule retains all the model parameters (so attribute
+    lookups for weights resolve correctly) and forwards `__call__` through
+    the captured graph.
+
+    Kwarg filtering: Diffusers pipelines pass kwargs (e.g.,
+    ``joint_attention_kwargs`` for SD3) that the captured graph wasn't
+    traced with. The wrapper restricts incoming kwargs to the set the
+    captured graph accepts (`expected_kwargs`) and discards the rest.
+    """
+
+    def __init__(
+        self,
+        captured_gm: torch.fx.GraphModule,
+        original_transformer: nn.Module,
+        expected_kwargs: tuple[str, ...] | None = None,
+        uses_internal_seq_shard: bool = False,
+    ) -> None:
+        super().__init__()
+        # `_gm` holds the captured graph + its parameters (as attributes on the
+        # GraphModule itself). Wrapping in a ModuleList-style attribute keeps
+        # PyTorch's module registry happy.
+        self._gm = captured_gm
+        # Mirror attributes from the original transformer so the Diffusers
+        # pipeline's calling code sees a familiar object surface.
+        self.config = original_transformer.config
+        # Diffusers reads `transformer.dtype` and casts hidden_states to it
+        # before calling the transformer. For quantized models the first
+        # parameter is FP8 storage; reporting that here would make Diffusers
+        # feed FP8 inputs (which torch.randn-style buffers also can't represent)
+        # to the captured graph. Use the compute dtype instead.
+        from .capture import _infer_module_device_dtype
+
+        _, self._target_dtype = _infer_module_device_dtype(original_transformer)
+        # Forward-chunking / gradient-checkpointing attributes the diffusers
+        # pipeline may read — keep them False/None.
+        self.gradient_checkpointing = False
+        # Kwarg names the captured graph was traced with — incoming kwargs
+        # are filtered to this set.
+        self._expected_kwargs: tuple[str, ...] = expected_kwargs or ()
+        # When True, the captured graph already shards the sequence internally
+        # (e.g. WAN via pre_capture_patch). Skip the pipeline-boundary shard
+        # and gather hooks — the captured model.forward takes care of it.
+        self._uses_internal_seq_shard = uses_internal_seq_shard
+        # Stash a reference to the original transformer without registering
+        # it as a child module — pipelines (e.g., LTX-2) sometimes invoke
+        # helpers like `self.transformer.rope.prepare_video_coords(...)` *before*
+        # calling forward, so attribute lookups must fall through to it.
+        # Storing in `__dict__` avoids nn.Module's auto-registration which
+        # would double the parameter count in the wrapper's state_dict.
+        object.__setattr__(self, "_original_transformer", original_transformer)
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self._target_dtype
+
+    @property
+    def device(self) -> torch.device:
+        for p in self._gm.parameters():
+            return p.device
+        return torch.device("cpu")
+
+    def forward(self, *args, **kwargs) -> Any:
+        if self._expected_kwargs:
+            # Restrict kwargs to the captured-graph signature so torch.export's
+            # pre-call check doesn't reject extras like `joint_attention_kwargs`.
+            kwargs = {k: kwargs[k] for k in self._expected_kwargs if k in kwargs}
+
+        # Multi-GPU CFG / Ulysses orchestration. CFG goes first (outermost):
+        # the captured graph operates on `B_local = B_full / cfg_size`, so we
+        # slice the incoming CFG-doubled batch by `cfg_rank` before the
+        # Ulysses step sees it. The gathers reverse the order on the way out.
+        from . import ops as _ops
+
+        vgm = _ops.get_current_mapping()
+        cfg_size = getattr(vgm, "cfg_size", 1) if vgm is not None else 1
+        ulysses_size = getattr(vgm, "ulysses_size", 1) if vgm is not None else 1
+        do_cfg = cfg_size > 1
+        if do_cfg:
+            args, kwargs = _split_batch_args_kwargs(args, kwargs, vgm)
+
+        # Adapters that shard the flat sequence inside the captured model
+        # (`uses_internal_seq_shard=True`) skip the pipeline-boundary hooks —
+        # the captured graph already does slice + all_gather_seq.
+        do_boundary_seq = ulysses_size > 1 and not self._uses_internal_seq_shard
+        if do_boundary_seq:
+            kwargs = _shard_seq_kwargs(kwargs, vgm)
+
+        out = self._gm(*args, **kwargs)
+
+        if do_boundary_seq:
+            out = _gather_seq_output(out, vgm)
+        if do_cfg:
+            out = _gather_batch_output(out, vgm)
+        return out
+
+    def cache_context(self, *args, **kwargs):
+        """No-op context manager for Diffusers pipelines that use
+        `with self.transformer.cache_context(...)` for attention caching.
+
+        The captured graph doesn't participate in Diffusers' attention cache
+        infrastructure; replaying the captured graph naively is the auto
+        path's caching story (it skips Python-level cache machinery).
+        """
+        from contextlib import nullcontext
+
+        return nullcontext()
+
+    def __getattr__(self, name: str):
+        """Fall back to the wrapped original transformer for attribute
+        accesses Diffusers makes on the transformer that aren't on the
+        captured `GraphModule` (e.g., random `.config` sub-fields, methods
+        like `enable_*`, etc.). nn.Module's `__getattr__` only fires after
+        normal attribute lookup misses, so this doesn't shadow `_gm`.
+        """
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            # Look on the wrapped GraphModule first, then fall through to
+            # the original transformer (which carries helper submodules like
+            # `rope`, `pos_embed`, ... that pipelines may call directly).
+            gm = self.__dict__.get("_modules", {}).get("_gm")
+            if gm is not None and hasattr(gm, name):
+                return getattr(gm, name)
+            orig = self.__dict__.get("_original_transformer")
+            if orig is not None and hasattr(orig, name):
+                return getattr(orig, name)
+            raise
+
+
+class AutoDiffusersPipeline:
+    """Minimum-viable end-to-end pipeline using a Diffusers shell + captured transformer."""
+
+    def __init__(
+        self,
+        checkpoint_dir: str,
+        model_config: "DiffusionModelConfig",
+        adapter: Optional["VisGenFamilyAdapter"] = None,
+        visual_gen_mapping=None,
+        enable_torch_compile: bool = False,
+        torch_compile_mode: str = "default",
+    ) -> None:
+        """
+        Args:
+            checkpoint_dir: HF / Diffusers checkpoint path
+            model_config: visual_gen DiffusionModelConfig
+            adapter: optional explicit family adapter (default: auto-resolve from transformer class)
+            visual_gen_mapping: optional `VisualGenMapping` for multi-GPU. CFG
+                parallel splits the CFG-doubled batch across `cfg_group`;
+                Ulysses shards the sequence across `ulysses_group`. TP is gated
+                behind upstream PR NVIDIA/TensorRT-LLM#13614.
+            enable_torch_compile: when True, wraps the captured `GraphModule`'s
+                forward with `torch.compile(..., mode=torch_compile_mode)` after
+                rewrites. Inductor fuses pointwise ops + generates Triton
+                kernels for the captured graph, closing the gap with the
+                handwritten path's `TorchCompileConfig` (`pipeline.py:420`).
+                First forward pays Inductor codegen cost (1-5 min on a 14-19B
+                transformer); subsequent forwards use the cached compiled
+                graph.
+            torch_compile_mode: passed straight to `torch.compile`. Default
+                **`"default"`** — Inductor codegen without CUDA graphs.
+                `"reduce-overhead"` enables CUDA graphs but is incompatible
+                with Diffusers' per-step output-tensor re-allocation (the
+                scheduler returns freshly allocated `latents` each step, and a
+                replayed CUDA graph still references the previous step's
+                buffers — silent corruption). Only switch to `reduce-overhead`
+                if the caller pins the latents buffer across steps.
+                `"max-autotune"` tries more kernel candidates (longer warmup).
+        """
+        from diffusers import DiffusionPipeline
+
+        # Fail-loud if the runtime Diffusers is outside the range the family
+        # adapters were tested against. Adapters monkey-patch Diffusers'
+        # transformer.forward (5 of 8 families) and reach into specific
+        # sub-module attributes (`patch_embedding`, `scale_shift_table`,
+        # `norm_out`, ...); a Diffusers minor bump that renames any of these
+        # silently breaks Ulysses for the affected family.
+        _check_diffusers_version()
+
+        self.checkpoint_dir = checkpoint_dir
+        self.model_config = model_config
+        self.enable_torch_compile = enable_torch_compile
+        self.torch_compile_mode = torch_compile_mode
+
+        # Plumb the mapping into model_config so adapters and capture see it
+        # (mirroring `pipeline_loader._setup_visual_gen_mapping`).
+        if visual_gen_mapping is not None:
+            model_config.visual_gen_mapping = visual_gen_mapping
+            # Make the mapping available to `auto/ops.py` (which is called from
+            # inside the captured graph at runtime and can't take a tensor arg).
+            from . import ops as _ops
+
+            _ops.set_current_mapping(visual_gen_mapping)
+        self.visual_gen_mapping = visual_gen_mapping
+
+        # Family-specific pre-load mutations Diffusers needs us to apply before
+        # `from_pretrained` builds the transformer (currently: WAN's
+        # `_keep_in_fp32_modules = []`). Scoped to this `from_pretrained` call
+        # only — restored on context exit so we don't action-at-a-distance
+        # any handwritten / parity code that later instantiates the same
+        # Diffusers class in the same Python process.
+        logger.info(f"AutoDiffusersPipeline: loading Diffusers pipeline from {checkpoint_dir}")
+        dtype = model_config.torch_dtype
+        with _family_preload_overrides(checkpoint_dir):
+            self._pipe = DiffusionPipeline.from_pretrained(checkpoint_dir, torch_dtype=dtype)
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if visual_gen_mapping is not None:
+            device = torch.device(
+                f"cuda:{visual_gen_mapping.local_rank}"
+                if hasattr(visual_gen_mapping, "local_rank")
+                else f"cuda:{visual_gen_mapping.rank % torch.cuda.device_count()}"
+            )
+        self._pipe = self._pipe.to(device)
+        self._device = device
+
+        # Resolve adapter once — for dual-transformer pipelines (Wan 2.2 has
+        # `transformer` for high-noise stage + `transformer_2` for low-noise
+        # stage; same class for both), the adapter is shared.
+        primary = self._pipe.transformer
+        cls_name = type(primary).__name__
+        if adapter is None:
+            adapter = _resolve_adapter(cls_name)
+        self.adapter = adapter
+        logger.info(
+            f"AutoDiffusersPipeline: transformer={cls_name}, adapter={type(adapter).__name__}"
+        )
+
+        # *Forward-compat gate*: visual_gen TP is currently blocked on
+        # NVIDIA/TensorRT-LLM#13614. Check once at __init__ before any
+        # per-transformer processing; same gate covers both passes.
+        tp_size = getattr(visual_gen_mapping, "tp_size", 1) if visual_gen_mapping is not None else 1
+        if tp_size > 1:
+            from tensorrt_llm._torch.device_mesh import DeviceMeshTopologyImpl
+
+            mesh = DeviceMeshTopologyImpl.device_mesh
+            if mesh is not None and "pp" not in mesh.mesh_dim_names:
+                raise NotImplementedError(
+                    "VisGen-Auto TP is blocked on NVIDIA/TensorRT-LLM#13614. "
+                    "Until that PR (which patches `VisualGenMapping.build_mesh` "
+                    "to add dummy pp/cp dims) merges, `tp_size > 1` will crash "
+                    "inside TRT-LLM `AllReduce` on `mapping.pp_rank`. The "
+                    "auto-path TP code (`auto/tp_annotate.py` + the `mapping` "
+                    "thread-through in `replace_linear_with_trtllm`) is staged "
+                    "and will compose automatically once #13614 lands. "
+                    "Use Ulysses (`ulysses_size > 1`) for multi-GPU in the "
+                    "meantime — it doesn't go through `AllReduce`."
+                )
+
+        tp_mapping = (
+            visual_gen_mapping.to_llm_mapping()
+            if (visual_gen_mapping is not None and tp_size > 1)
+            else None
+        )
+
+        # Snapshot user's quant_config.exclude_modules so the sensitivity
+        # heuristic (which mutates the list in-place) starts from the same
+        # baseline for each transformer pass.
+        qc = getattr(model_config, "quant_config", None)
+        baseline_excludes: Optional[list] = (
+            list(qc.exclude_modules) if (qc is not None and qc.exclude_modules) else None
+        )
+
+        # Find all transformer slots on the Diffusers pipeline. The standard
+        # convention is `transformer` (single-transformer pipelines: Flux/Flux2/
+        # SD3) plus optional `transformer_2` (Wan 2.2 two-stage denoising).
+        # Generalizing here means any future Diffusers pipeline that adds a
+        # `transformer_3` etc. also lands cleanly.
+        transformer_attrs = [
+            a for a in ("transformer", "transformer_2") if getattr(self._pipe, a, None) is not None
+        ]
+        logger.info(
+            f"AutoDiffusersPipeline: will capture {len(transformer_attrs)} transformer(s): "
+            f"{transformer_attrs}"
+        )
+        self._original_transformers: dict[str, "nn.Module"] = {}
+        for attr in transformer_attrs:
+            self._capture_one_transformer(
+                attr,
+                adapter=adapter,
+                model_config=model_config,
+                tp_size=tp_size,
+                tp_mapping=tp_mapping,
+                baseline_excludes=baseline_excludes,
+            )
+        # Keep one reference for parity comparisons (backwards-compatible
+        # shape with the prior single-transformer API).
+        self._original_transformer = self._original_transformers.get("transformer")
+
+    def _capture_one_transformer(
+        self,
+        attr: str,
+        *,
+        adapter: "VisGenFamilyAdapter",
+        model_config: "DiffusionModelConfig",
+        tp_size: int,
+        tp_mapping,
+        baseline_excludes: Optional[list],
+    ) -> None:
+        """Process one transformer slot (`transformer` or `transformer_2`):
+        TP-annotate → quant-replace Linears → torch.export → apply rewrites →
+        wrap as `_GraphModuleAsTransformer` → write back to `self._pipe.<attr>`.
+
+        Each pass starts from the user-provided `exclude_modules` baseline so
+        the sensitivity heuristic (which mutates `quant_config.exclude_modules`
+        in-place) re-derives patterns per transformer independently.
+        """
+        import torch  # local to keep linter happy in the function scope
+
+        orig = getattr(self._pipe, attr)
+        self._original_transformers[attr] = orig
+        logger.info(f"AutoDiffusersPipeline: processing `{attr}` ({type(orig).__name__})")
+
+        # Pre-export TP annotation (per-transformer, since each has its own
+        # attn.heads attributes and Linear instances).
+        if tp_size > 1:
+            from .tp_annotate import annotate_tp_roles
+
+            annotate_tp_roles(orig, tp_size)
+
+        # Pre-export Ulysses patch for families that shard inside the model.
+        # Image-DiTs default to no-op; video-DiTs (e.g. WAN) monkey-patch the
+        # forward to inject `x = x[rank-slice]` after patchify+flatten and
+        # `torch.ops.visgen_auto.all_gather_seq(x)` before output proj.
+        # The patch reads ulysses_rank/size as Python constants so the
+        # captured graph bakes them in.
+        if adapter.uses_internal_seq_shard:
+            adapter.pre_capture_patch(orig, self.visual_gen_mapping)
+
+        # Reset exclude_modules to the user's baseline so the sensitivity
+        # heuristic re-derives patterns from THIS transformer's module tree
+        # rather than inheriting whatever was merged from a previous pass.
+        qc = getattr(model_config, "quant_config", None)
+        if qc is not None:
+            qc.exclude_modules = list(baseline_excludes) if baseline_excludes else None
+
+        dtype = model_config.torch_dtype
+        need_replace = (qc is not None and qc.quant_algo is not None) or tp_size > 1
+        if need_replace:
+            if qc is None or qc.quant_algo is None:
+                from tensorrt_llm.models.modeling_utils import QuantConfig
+
+                qc = QuantConfig()
+                model_config.quant_config = qc
+
+            from .quantize import replace_linear_with_trtllm
+
+            family_excludes = adapter.default_quant_exclude_modules()
+            if family_excludes:
+                user_excludes = list(qc.exclude_modules or [])
+                merged = list(dict.fromkeys(user_excludes + family_excludes))
+                if merged != user_excludes:
+                    qc.exclude_modules = merged
+                    logger.info(
+                        f"AutoDiffusersPipeline[{attr}]: merged family exclude_modules "
+                        f"{family_excludes} -> {qc.exclude_modules}"
+                    )
+
+            n = replace_linear_with_trtllm(orig, qc, dtype, mapping=tp_mapping)
+            logger.info(
+                f"AutoDiffusersPipeline[{attr}]: pre-export Linear replacement "
+                f"(quant={qc.quant_algo}, tp={tp_size}): {n} Linears wrapped"
+            )
+
+        # Capture + rewrite
+        from .capture import _infer_module_device_dtype, capture_transformer
+        from .rewrite import apply_rewrites
+
+        logger.info(f"AutoDiffusersPipeline[{attr}]: capturing via torch.export ...")
+        cfg_size = (
+            getattr(self.visual_gen_mapping, "cfg_size", 1)
+            if self.visual_gen_mapping is not None
+            else 1
+        )
+        ep = capture_transformer(orig, adapter, model_config, cfg_size=cfg_size)
+        gm = ep.module()
+        policy = adapter.rewrite_policy(model_config)
+        # `adapter` is passed so its `customize_passes(pm)` hook can splice
+        # in family-specific passes (insert_after / replace / etc.) before
+        # the default pipeline runs. Default hook is a no-op.
+        apply_rewrites(gm, policy, adapter=adapter)
+        logger.info(f"AutoDiffusersPipeline[{attr}]: rewrites applied")
+
+        # Discover the kwarg set the captured graph was traced with so the
+        # wrapper can filter out-of-band kwargs from the Diffusers pipeline.
+        device_, dtype_ = _infer_module_device_dtype(orig)
+        _, sample_kwargs = adapter.example_inputs(model_config, device_, dtype_)
+        expected_kwargs = tuple(sample_kwargs.keys())
+
+        wrapped = _GraphModuleAsTransformer(
+            gm,
+            orig,
+            expected_kwargs=expected_kwargs,
+            uses_internal_seq_shard=adapter.uses_internal_seq_shard,
+        )
+        if self.enable_torch_compile:
+            # Compile the captured GraphModule (not the wrapper). The wrapper's
+            # `forward` does pre/post sequence shard/gather + kwarg filtering
+            # in Python; we want those to stay eager so the compiled boundary
+            # only covers the dense transformer math. Inductor handles
+            # GraphModules natively + our `visgen_auto::*` custom ops have
+            # `register_fake` shims (see `auto/ops.py`) so the codegen path
+            # has the meta info it needs.
+            logger.info(
+                f"AutoDiffusersPipeline[{attr}]: wrapping with "
+                f"torch.compile(mode={self.torch_compile_mode!r}) "
+                f"— first forward will pay Inductor codegen cost"
+            )
+            wrapped._gm = torch.compile(wrapped._gm, mode=self.torch_compile_mode)
+        setattr(self._pipe, attr, wrapped)
+
+    @property
+    def diffusers_pipe(self):
+        return self._pipe
+
+    @property
+    def captured_transformer(self) -> _GraphModuleAsTransformer:
+        return self._pipe.transformer
+
+    @property
+    def device(self) -> torch.device:
+        # The Diffusers pipeline is `.to(device)`'d in `__init__`; expose the
+        # selected device so callers (e.g. `AutoTransformerPipeline.infer`)
+        # don't reach into the underscored `_device` field.
+        return self._device
+
+    def __call__(self, *args, **kwargs):
+        return self._pipe(*args, **kwargs)
+
+    def warmup(self, **pipeline_kwargs) -> None:
+        """Trigger torch.compile codegen by running a short denoise pass.
+
+        When `enable_torch_compile=True`, the captured GraphModule is
+        wrapped with `torch.compile` but compilation is lazy — codegen
+        fires on the first call. For long-denoise pipelines (50-step
+        Wan, 40-step LTX-2) this codegen lands *inside* the measured
+        denoise window, eating most of the steady-state perf win on
+        single-run benchmarks. The handwritten path solves this with
+        `PipelineLoader(...).load(skip_warmup=False)` which calls a
+        `_run_warmup(...)` hook on each pipeline class. We mirror that
+        here without taking a dependency on the handwritten
+        `PipelineLoader`: the caller passes the same kwargs they'd hand
+        to `__call__`, with a small `num_inference_steps` (default 4 —
+        enough to cross Wan 2.2's `boundary_ratio=0.875` so both
+        transformer + transformer_2 codegen fires; single-tx pipelines
+        only need ≥1).
+
+        No-op when `enable_torch_compile=False`.
+
+        Args:
+            **pipeline_kwargs: forwarded to `self._pipe(...)`. Override
+                `num_inference_steps` for finer control, otherwise 4 is
+                the safe default for dual-tx pipelines.
+        """
+        if not self.enable_torch_compile:
+            return
+        pipeline_kwargs.setdefault("num_inference_steps", 4)
+        # Use a no-op prompt; the compile cost is shape-driven, not
+        # prompt-driven. Match the handwritten Wan warmup conventions.
+        pipeline_kwargs.setdefault("prompt", "warmup")
+        # Note: don't default `negative_prompt` — Flux/Flux2 are
+        # guidance-distilled and reject it. Caller passes it when the
+        # diffusers pipeline accepts it (SD3, WAN, LTX-2).
+        # Suppress the per-step tqdm bar during warmup to keep logs clean.
+        # `set_progress_bar_config` is a no-op on some Diffusers pipelines
+        # that don't define it (e.g. older custom community pipelines);
+        # an `AttributeError` from a missing method is the only expected
+        # failure here.
+        try:
+            self._pipe.set_progress_bar_config(disable=True)
+        except AttributeError:
+            pass
+        with torch.no_grad():
+            self._pipe(**pipeline_kwargs)
+        try:
+            self._pipe.set_progress_bar_config(disable=False)
+        except AttributeError:
+            pass

--- a/tensorrt_llm/_torch/visual_gen/auto/capture.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/capture.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""torch.export wrapper for the auto path.
+
+Thin wrapper around `torch.export.export(strict=False, dynamic_shapes=...)`.
+The family adapter supplies the example-input and dynamic-shape spec; this
+module just runs `torch.export` against them, with optional CFG-parallel
+example slicing so the captured graph operates at the per-rank batch.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import torch
+import torch.nn as nn
+
+from tensorrt_llm.logger import logger
+
+if TYPE_CHECKING:
+    from ..config import DiffusionModelConfig
+    from .adapter import VisGenFamilyAdapter
+
+
+_COMPUTE_DTYPES = (torch.bfloat16, torch.float16, torch.float32, torch.float64)
+
+
+def _infer_module_device_dtype(module: nn.Module) -> tuple[torch.device, torch.dtype]:
+    """Pick a (device, compute-dtype) pair for example-input construction.
+
+    For quantized models the first parameter may be FP8/NVFP4/INT — types that
+    `torch.randn` does not support. We pick the *compute* dtype (BF16/FP16/FP32)
+    that the model's forward actually accepts as input, not the weight storage
+    dtype. Walk parameters/buffers for the first floating-point compute dtype.
+    """
+    device: Optional[torch.device] = None
+    for p in module.parameters():
+        if device is None:
+            device = p.device
+        if p.dtype in _COMPUTE_DTYPES:
+            return p.device, p.dtype
+    for b in module.buffers():
+        if device is None:
+            device = b.device
+        if b.dtype in _COMPUTE_DTYPES:
+            return b.device, b.dtype
+    return device or torch.device("cpu"), torch.get_default_dtype()
+
+
+def capture_transformer(
+    module: nn.Module,
+    adapter: "VisGenFamilyAdapter",
+    cfg: "DiffusionModelConfig",
+    cfg_size: int = 1,
+) -> torch.export.ExportedProgram:
+    """Capture `module` to an `ExportedProgram` using `torch.export`.
+
+    Tensors are materialized on `module`'s device with `module`'s parameter
+    dtype. The adapter supplies kwargs and dynamic-shape spec.
+
+    When ``cfg_size > 1`` (CFG-parallel), the example-input batch is sliced
+    to ``B // cfg_size`` so the captured graph operates on the per-rank
+    batch the wrapper's CFG-split feeds it at runtime. Static-B adapters
+    (PixArt-Σ, Sana) end up with the captured graph specialized at
+    ``B_example / cfg_size``; dynamic-B adapters (FLUX, FLUX.2, SD3, WAN,
+    LTX, LTX-2) re-specialize via ``Dim.AUTO`` / dynamic ``Dim``.
+
+    Returns the `ExportedProgram`. Caller is responsible for downstream
+    `run_decompositions()` / FX rewrites.
+    """
+    device, dtype = _infer_module_device_dtype(module)
+    args, kwargs = adapter.example_inputs(cfg, device, dtype)
+    dynamic_shapes = adapter.dynamic_shapes(cfg)
+
+    if cfg_size > 1:
+
+        def _slice_b(t):
+            if not isinstance(t, torch.Tensor) or t.ndim == 0:
+                return t
+            B = t.shape[0]
+            if B % cfg_size != 0 or B // cfg_size < 1:
+                return t
+            return t.narrow(0, 0, B // cfg_size).contiguous()
+
+        args = tuple(_slice_b(a) for a in args)
+        kwargs = {k: _slice_b(v) for k, v in kwargs.items()}
+
+        # After slicing, any tensor whose dim-0 is now 1 will trip
+        # torch.export's `ConstraintViolationError: Constraints violated (B)
+        # — you marked B as dynamic but your code specialized it to (1)`
+        # because the model code's `B == 1` branches force specialization.
+        # Strip the dim-0 entry from each kwarg's dynamic_shapes spec
+        # whenever its tensor's dim-0 is now 1.
+        def _maybe_drop_dim0(t, spec):
+            if not isinstance(t, torch.Tensor) or t.ndim == 0:
+                return spec
+            if t.shape[0] != 1 or not isinstance(spec, dict):
+                return spec
+            return {k: v for k, v in spec.items() if k != 0}
+
+        if isinstance(dynamic_shapes, dict):
+            dynamic_shapes = {
+                k: _maybe_drop_dim0(kwargs.get(k), v) for k, v in dynamic_shapes.items()
+            }
+
+    logger.info(
+        f"VisGen-Auto capture: family={adapter.family}, "
+        f"device={device}, dtype={dtype}, "
+        f"kwarg shapes={
+            {k: tuple(v.shape) if isinstance(v, torch.Tensor) else v for k, v in kwargs.items()}
+        }"
+    )
+
+    with torch.no_grad():
+        ep = torch.export.export(
+            module,
+            args=args,
+            kwargs=kwargs,
+            dynamic_shapes=dynamic_shapes,
+            strict=False,
+        )
+    return ep

--- a/tensorrt_llm/_torch/visual_gen/auto/families/__init__.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/families/__init__.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Family adapters for VisGen-Auto.
+
+Each adapter declares the example inputs, dynamic shapes, and rewrite policy
+for one Diffusers transformer family. The base contract is
+``VisGenFamilyAdapter`` in ``../adapter.py``.
+"""
+
+from .flux import FluxAdapter
+from .flux2 import Flux2Adapter
+from .ltx import LTXAdapter
+from .ltx2 import LTX2Adapter
+from .mmdit import MMDiTAdapter
+from .pixart import PixArtAdapter
+from .sana import SanaAdapter
+from .sd3 import SD3Adapter
+from .wan import WanAdapter
+
+__all__ = [
+    "FluxAdapter",
+    "Flux2Adapter",
+    "LTXAdapter",
+    "LTX2Adapter",
+    "MMDiTAdapter",
+    "PixArtAdapter",
+    "SanaAdapter",
+    "SD3Adapter",
+    "WanAdapter",
+]

--- a/tensorrt_llm/_torch/visual_gen/auto/families/flux.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/families/flux.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Flux family adapter for the auto path.
+
+Targets Diffusers `FluxTransformer2DModel` (Flux.1).
+`torch.export.export(strict=False)` succeeds on this transformer with
+dynamic batch / image_seq / txt_seq dims; the dim choices and example
+shapes below were validated against full Flux.1-dev (19 dual-stream +
+38 single-stream blocks).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from ..adapter import VisGenFamilyAdapter
+from ..policy import RewritePolicy
+
+if TYPE_CHECKING:
+    from ...config import DiffusionModelConfig
+
+# Tiny example dims for export tracing. These are unrelated to runtime — the
+# captured graph uses dynamic dims, so these only serve to seed shape-symbol
+# resolution. Picked to be > 1 so `torch.export` does not specialize the
+# batch dim to 1.
+_EXAMPLE_BATCH = 2
+_EXAMPLE_IMG_SEQ = 64
+_EXAMPLE_TXT_SEQ = 16
+
+# Dynamic-shape range for Flux1 image/text sequences. Bounds are loose; the
+# rewriter must not depend on them for correctness.
+_DIM_BATCH_MAX = 8
+_DIM_IMG_SEQ_MAX = 16384
+_DIM_TXT_SEQ_MAX = 1024
+
+
+def _arch_dim(cfg: "DiffusionModelConfig", attr: str, default: int) -> int:
+    """Read an architectural dim from `cfg.pretrained_config`, with a fallback.
+
+    `pretrained_config` is a `SimpleNamespace` populated from the transformer's
+    `config.json` (see `DiffusionModelConfig.from_pretrained`), so attributes
+    correspond to the keys diffusers writes there.
+    """
+    pc = getattr(cfg, "pretrained_config", None)
+    return int(getattr(pc, attr, default)) if pc is not None else default
+
+
+class FluxAdapter(VisGenFamilyAdapter):
+    family = "Flux"
+    diffusers_transformer_cls = "FluxTransformer2DModel"
+
+    def example_inputs(
+        self,
+        cfg: "DiffusionModelConfig",
+        device: "torch.device",
+        dtype: "torch.dtype",
+    ) -> tuple[tuple, dict[str, Any]]:
+        in_channels = _arch_dim(cfg, "in_channels", 64)
+        joint_dim = _arch_dim(cfg, "joint_attention_dim", 4096)
+        pooled_dim = _arch_dim(cfg, "pooled_projection_dim", 768)
+        # FLUX.1-dev sets `guidance_embeds=True` → the pipeline passes a
+        # `guidance` tensor at runtime. FLUX.1-schnell omits it.
+        pc = getattr(cfg, "pretrained_config", None)
+        guidance_embeds = bool(getattr(pc, "guidance_embeds", False))
+
+        B = _EXAMPLE_BATCH
+        S_img = _EXAMPLE_IMG_SEQ
+        S_txt = _EXAMPLE_TXT_SEQ
+
+        kwargs: dict[str, Any] = {
+            "hidden_states": torch.randn(B, S_img, in_channels, device=device, dtype=dtype),
+            "encoder_hidden_states": torch.randn(B, S_txt, joint_dim, device=device, dtype=dtype),
+            "pooled_projections": torch.randn(B, pooled_dim, device=device, dtype=dtype),
+            # Diffusers' FluxPipeline passes `timestep / 1000` with dtype matching
+            # `latents.dtype` (BF16 in our pipeline runs). Match that here so the
+            # captured graph's Long→BF16 cast doesn't drift the BF16→BF16 runtime path.
+            "timestep": torch.full((B,), 0.5, device=device, dtype=dtype),
+            "img_ids": torch.zeros(S_img, 3, device=device, dtype=dtype),
+            "txt_ids": torch.zeros(S_txt, 3, device=device, dtype=dtype),
+            "return_dict": False,
+        }
+        if guidance_embeds:
+            # FLUX.1-dev passes guidance as float32 (Diffusers' FluxPipeline
+            # uses torch.full((B,), guidance_scale, dtype=torch.float32)).
+            kwargs["guidance"] = torch.full((B,), 3.5, device=device, dtype=torch.float32)
+        return (), kwargs
+
+    def dynamic_shapes(self, cfg: "DiffusionModelConfig") -> dict[str, Any]:
+        pc = getattr(cfg, "pretrained_config", None)
+        guidance_embeds = bool(getattr(pc, "guidance_embeds", False))
+
+        B = torch.export.Dim("B", min=1, max=_DIM_BATCH_MAX)
+        S_img = torch.export.Dim("S_img", min=16, max=_DIM_IMG_SEQ_MAX)
+        S_txt = torch.export.Dim("S_txt", min=1, max=_DIM_TXT_SEQ_MAX)
+        spec: dict[str, Any] = {
+            "hidden_states": {0: B, 1: S_img},
+            "encoder_hidden_states": {0: B, 1: S_txt},
+            "pooled_projections": {0: B},
+            "timestep": {0: B},
+            "img_ids": {0: S_img},
+            "txt_ids": {0: S_txt},
+            "return_dict": None,
+        }
+        if guidance_embeds:
+            spec["guidance"] = {0: B}
+        return spec
+
+    def rewrite_policy(self, cfg: "DiffusionModelConfig") -> RewritePolicy:
+        return RewritePolicy(attention_backend=cfg.attention.backend)

--- a/tensorrt_llm/_torch/visual_gen/auto/families/flux2.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/families/flux2.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Flux2 family adapter for the auto path.
+
+Targets Diffusers `Flux2Transformer2DModel` (FLUX.2-dev/-pro). Differences vs
+Flux1:
+- No `pooled_projections` — Flux2 uses `time_guidance_embed(timestep, guidance)`
+  for modulation, not the combined timestep+pooled embedding.
+- `axes_dims_rope` is 4-axis (Flux1: 3-axis).
+- Supports optional KV-cache reference-image flow (`kv_cache_mode`,
+  `num_ref_tokens`). This adapter targets the *no-ref-tokens* path
+  (`kv_cache_mode=None`); ref-token support is a follow-up.
+- `joint_attention_dim` is much larger (15360 in FLUX.2-dev — T5 + Mistral).
+- 8 double-stream + 48 single-stream blocks (vs Flux1: 19 + 38).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from ..adapter import VisGenFamilyAdapter
+from ..policy import RewritePolicy
+
+if TYPE_CHECKING:
+    from ...config import DiffusionModelConfig
+
+# Tiny example dims for export tracing.
+_EXAMPLE_BATCH = 2
+_EXAMPLE_IMG_SEQ = 64
+_EXAMPLE_TXT_SEQ = 16
+
+_DIM_BATCH_MAX = 8
+_DIM_IMG_SEQ_MAX = 16384
+_DIM_TXT_SEQ_MAX = 1024
+
+
+def _arch_dim(cfg: "DiffusionModelConfig", attr: str, default: int) -> int:
+    pc = getattr(cfg, "pretrained_config", None)
+    return int(getattr(pc, attr, default)) if pc is not None else default
+
+
+class Flux2Adapter(VisGenFamilyAdapter):
+    family = "Flux2"
+    diffusers_transformer_cls = "Flux2Transformer2DModel"
+
+    def example_inputs(
+        self,
+        cfg: "DiffusionModelConfig",
+        device: "torch.device",
+        dtype: "torch.dtype",
+    ) -> tuple[tuple, dict[str, Any]]:
+        in_channels = _arch_dim(cfg, "in_channels", 128)
+        joint_dim = _arch_dim(cfg, "joint_attention_dim", 15360)
+        # `guidance_embeds=True` for FLUX.2-dev (CFG-distilled, takes guidance scalar);
+        # `guidance_embeds=False` for FLUX.2-klein (fully distilled, pipeline passes
+        # `guidance=None`). Match the pipeline's call shape at capture time.
+        pc = getattr(cfg, "pretrained_config", None)
+        guidance_embeds = bool(getattr(pc, "guidance_embeds", True)) if pc is not None else True
+
+        B = _EXAMPLE_BATCH
+        S_img = _EXAMPLE_IMG_SEQ
+        S_txt = _EXAMPLE_TXT_SEQ
+
+        # KV-cache / ref-token kwargs (kv_cache, kv_cache_mode, num_ref_tokens,
+        # ref_fixed_timestep) are NOT included — they have safe defaults
+        # (None / 0 / 0.0) and the Diffusers pipeline doesn't pass them.
+        # Including them in `example_inputs` would force runtime to pass them
+        # too (torch.export's kwarg-set is strict). Ref-token support is a
+        # follow-up adapter mode.
+        kwargs: dict[str, Any] = {
+            "hidden_states": torch.randn(B, S_img, in_channels, device=device, dtype=dtype),
+            "encoder_hidden_states": torch.randn(B, S_txt, joint_dim, device=device, dtype=dtype),
+            "timestep": torch.full((B,), 0.5, device=device, dtype=dtype),
+            # 4-axis RoPE ids (vs Flux1's 3-axis), passed as 3D `(B, S, 4)` by
+            # Diffusers' Flux2Pipeline (Flux1 used 2D).
+            "img_ids": torch.zeros(B, S_img, 4, device=device, dtype=dtype),
+            "txt_ids": torch.zeros(B, S_txt, 4, device=device, dtype=dtype),
+            "guidance": (
+                torch.full((B,), 3.5, device=device, dtype=torch.float32)
+                if guidance_embeds
+                else None
+            ),
+            "return_dict": False,
+        }
+        return (), kwargs
+
+    def dynamic_shapes(self, cfg: "DiffusionModelConfig") -> dict[str, Any]:
+        pc = getattr(cfg, "pretrained_config", None)
+        guidance_embeds = bool(getattr(pc, "guidance_embeds", True)) if pc is not None else True
+        B = torch.export.Dim("B", min=1, max=_DIM_BATCH_MAX)
+        S_img = torch.export.Dim("S_img", min=16, max=_DIM_IMG_SEQ_MAX)
+        S_txt = torch.export.Dim("S_txt", min=1, max=_DIM_TXT_SEQ_MAX)
+        return {
+            "hidden_states": {0: B, 1: S_img},
+            "encoder_hidden_states": {0: B, 1: S_txt},
+            "timestep": {0: B},
+            "img_ids": {0: B, 1: S_img},
+            "txt_ids": {0: B, 1: S_txt},
+            "guidance": {0: B} if guidance_embeds else None,
+            "return_dict": None,
+        }
+
+    def rewrite_policy(self, cfg: "DiffusionModelConfig") -> RewritePolicy:
+        return RewritePolicy(attention_backend=cfg.attention.backend)
+
+    # No `default_quant_exclude_modules` override: the structural heuristic in
+    # `auto/sensitivity.py` auto-detects `time_guidance_embed.*` from the
+    # module tree (its `timestep_embedder.linear_1` has `in_features=256`).
+    # Override here only if a family has Linears the heuristic misses.

--- a/tensorrt_llm/_torch/visual_gen/auto/families/ltx.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/families/ltx.py
@@ -1,0 +1,227 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""LTX-Video family adapter for the auto path.
+
+Targets Diffusers `LTXVideoTransformer3DModel` (LTX-Video, not the
+audiovisual LTX-2). Forward signature is image-DiT-shaped:
+
+- `hidden_states`: `(B, S_video, in_channels)` — already patched + flattened
+  by Diffusers' `LTXVideoPipeline` before calling the transformer
+- `encoder_hidden_states`: `(B, S_text, cross_attention_dim)`
+- `timestep`: `(B,)`
+- `encoder_attention_mask`: `(B, S_text)` (used as additive bias internally)
+- plus optional `num_frames / height / width` ints, `video_coords`,
+  `rope_interpolation_scale`, etc. — we leave at defaults for the spike
+
+LTX-2 (`LTX2VideoTransformer3DModel`) is the audiovisual variant with 17+
+kwargs including audio inputs and per-modality sigmas — out of scope here,
+needs its own adapter.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from ..adapter import VisGenFamilyAdapter
+from ..policy import RewritePolicy
+
+if TYPE_CHECKING:
+    from ...config import DiffusionModelConfig
+
+
+_EX_B = 2  # CFG-doubled runtime batch — Dim.AUTO with hint=1 specializes
+_EX_VIDEO_SEQ = 256
+_EX_TEXT_SEQ = 64
+# Patched by the runner before capture so the int kwargs (num_frames/height/
+# width) get baked into the captured graph at the runtime production shape
+# (otherwise diffusers' default 25 frames @ 704×512 → static-int guard fail
+# at any other shape).
+_EX_NUM_FRAMES = 1
+_EX_H = 16
+_EX_W = 16
+
+
+class LTXAdapter(VisGenFamilyAdapter):
+    family = "LTX-Video"
+    diffusers_transformer_cls = "LTXVideoTransformer3DModel"
+
+    def example_inputs(
+        self,
+        cfg: "DiffusionModelConfig",
+        device: "torch.device",
+        dtype: "torch.dtype",
+    ) -> tuple[tuple, dict[str, Any]]:
+        pc = cfg.pretrained_config
+        in_channels = getattr(pc, "in_channels", 128)
+        # encoder_hidden_states comes from T5 (caption_channels), then
+        # gets projected by `caption_projection` to `inner_dim` inside the
+        # transformer. The kwarg's *input* dim is `caption_channels`, not
+        # `cross_attention_dim`.
+        caption_channels = getattr(pc, "caption_channels", 4096)
+
+        # `num_frames`/`height`/`width` are baked into the captured graph as
+        # static literals (Guard failed: num_frames == ... at runtime if they
+        # change). The diffusers `LTXPipeline` passes these explicitly per
+        # call. Read the production values from the adapter module so the
+        # parity runner (which patches `_EX_NUM_FRAMES`/`_EX_H`/`_EX_W`
+        # before capture) can specialize at runtime shape.
+        kwargs: dict[str, Any] = {
+            "hidden_states": torch.randn(
+                _EX_B, _EX_VIDEO_SEQ, in_channels, device=device, dtype=dtype
+            ),
+            "encoder_hidden_states": torch.randn(
+                _EX_B, _EX_TEXT_SEQ, caption_channels, device=device, dtype=dtype
+            ),
+            "timestep": torch.full((_EX_B,), 500, device=device, dtype=torch.long),
+            "encoder_attention_mask": torch.ones(
+                _EX_B, _EX_TEXT_SEQ, device=device, dtype=torch.long
+            ),
+            "num_frames": _EX_NUM_FRAMES,
+            "height": _EX_H,
+            "width": _EX_W,
+            "return_dict": False,
+        }
+        return (), kwargs
+
+    def dynamic_shapes(self, cfg: "DiffusionModelConfig") -> dict[str, Any]:
+        # Same story as WanAdapter — LTX's forward has shape-dependent
+        # int reshapes; Dim.AUTO lets export specialize without erroring.
+        AUTO = torch.export.Dim.AUTO
+        return {
+            "hidden_states": {0: AUTO, 1: AUTO},
+            "encoder_hidden_states": {0: AUTO, 1: AUTO},
+            "timestep": {0: AUTO},
+            "encoder_attention_mask": {0: AUTO, 1: AUTO},
+            "num_frames": None,
+            "height": None,
+            "width": None,
+            "return_dict": None,
+        }
+
+    def rewrite_policy(self, cfg: "DiffusionModelConfig") -> RewritePolicy:
+        # LTX uses `qk_norm='rms_norm_across_heads'` — RMSNorm operates on
+        # the full `inner_dim` (across all heads). Our `fused_dit_qk_norm_rope`
+        # kernel only supports per-head norm (head_dim ≤ 128); disable the
+        # fusion here. Drift impact is sub-perceptual (ULP noise) and only
+        # matters for pixel-equality tests anyway.
+        return RewritePolicy(
+            attention_backend=cfg.attention.backend,
+            fuse_qk_rope=False,
+        )
+
+    @property
+    def uses_internal_seq_shard(self) -> bool:
+        # LTX-Video's `hidden_states` is already token-flat `(B, S, C)`
+        # — but `self.rope(hidden_states, num_frames, height, width, ...)`
+        # internally builds a per-token coords tensor sized to the full S,
+        # so the pipeline-boundary shard would have the rope module see a
+        # smaller hidden_states but still try to build full coords (guard
+        # fail). Use the in-model shard pattern: compute rope on the full
+        # sequence first, slice both `hidden_states` and the rope outputs
+        # by ulysses_rank, run blocks, all-gather before `norm_out`.
+        return True
+
+    def pre_capture_patch(self, model, visual_gen_mapping) -> None:
+        ulysses_size = getattr(visual_gen_mapping, "ulysses_size", 1) if visual_gen_mapping else 1
+        if ulysses_size <= 1:
+            return
+        ulysses_rank = getattr(visual_gen_mapping, "ulysses_rank", 0)
+
+        from types import MethodType
+
+        def _ltx_ulysses_forward(
+            self,
+            hidden_states,
+            encoder_hidden_states,
+            timestep,
+            encoder_attention_mask,
+            num_frames=None,
+            height=None,
+            width=None,
+            rope_interpolation_scale=None,
+            video_coords=None,
+            attention_kwargs=None,
+            return_dict: bool = False,
+        ):
+            from diffusers.models.modeling_outputs import Transformer2DModelOutput
+
+            # Compute rope on the full sequence first (it depends on num_frames
+            # / height / width before any sharding).
+            image_rotary_emb = self.rope(
+                hidden_states,
+                num_frames,
+                height,
+                width,
+                rope_interpolation_scale,
+                video_coords,
+            )
+
+            if encoder_attention_mask is not None and encoder_attention_mask.ndim == 2:
+                encoder_attention_mask = (
+                    1 - encoder_attention_mask.to(hidden_states.dtype)
+                ) * -10000.0
+                encoder_attention_mask = encoder_attention_mask.unsqueeze(1)
+
+            batch_size = hidden_states.size(0)
+            hidden_states = self.proj_in(hidden_states)
+
+            # --- Ulysses shard: slice hidden_states and rope along seq dim ---
+            P = ulysses_size
+            R = ulysses_rank
+            S = hidden_states.shape[1]
+            chunk = S // P
+            hidden_states = hidden_states[:, R * chunk : (R + 1) * chunk, :].contiguous()
+            if isinstance(image_rotary_emb, (tuple, list)):
+                # LTX-Video rope returns (cos, sin); both shape (B, S, D) or (B, H, S, D).
+                def _shard_rope_leaf(t):
+                    if not isinstance(t, torch.Tensor) or t.dim() < 2:
+                        return t
+                    # seq dim heuristic: same as handwritten LTX-2 shard.
+                    if t.dim() == 4 and t.shape[2] == S:
+                        return t[:, :, R * chunk : (R + 1) * chunk].contiguous()
+                    if t.dim() == 3 and t.shape[1] == S:
+                        return t[:, R * chunk : (R + 1) * chunk].contiguous()
+                    return t
+
+                image_rotary_emb = tuple(_shard_rope_leaf(t) for t in image_rotary_emb)
+            # --------------------------------------------------------------------
+
+            temb, embedded_timestep = self.time_embed(
+                timestep.flatten(),
+                batch_size=batch_size,
+                hidden_dtype=hidden_states.dtype,
+            )
+            temb = temb.view(batch_size, -1, temb.size(-1))
+            embedded_timestep = embedded_timestep.view(batch_size, -1, embedded_timestep.size(-1))
+
+            encoder_hidden_states = self.caption_projection(encoder_hidden_states)
+            encoder_hidden_states = encoder_hidden_states.view(
+                batch_size, -1, hidden_states.size(-1)
+            )
+
+            for block in self.transformer_blocks:
+                hidden_states = block(
+                    hidden_states=hidden_states,
+                    encoder_hidden_states=encoder_hidden_states,
+                    temb=temb,
+                    image_rotary_emb=image_rotary_emb,
+                    encoder_attention_mask=encoder_attention_mask,
+                )
+
+            # --- Gather hidden_states back to full S before output ---
+            hidden_states = torch.ops.visgen_auto.all_gather_seq(hidden_states, 1, ulysses_size)
+            # ----------------------------------------------------------
+
+            scale_shift_values = self.scale_shift_table[None, None] + embedded_timestep[:, :, None]
+            shift, scale = scale_shift_values[:, :, 0], scale_shift_values[:, :, 1]
+            hidden_states = self.norm_out(hidden_states)
+            hidden_states = hidden_states * (1 + scale) + shift
+            output = self.proj_out(hidden_states)
+
+            if not return_dict:
+                return (output,)
+            return Transformer2DModelOutput(sample=output)
+
+        model.forward = MethodType(_ltx_ulysses_forward, model)

--- a/tensorrt_llm/_torch/visual_gen/auto/families/ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/families/ltx2.py
@@ -1,0 +1,454 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""LTX-2 family adapter for the auto path.
+
+Targets Diffusers `LTX2VideoTransformer3DModel` (audiovisual LTX-2.x).
+Distinct from `LTXAdapter` which handles LTX-Video (no audio).
+
+The forward sig is significantly bigger than LTX-Video — joint video+audio
+streams, per-modality text embeddings, per-modality timesteps, and
+pre-computed RoPE coords.  We match the authoritative runtime call in
+`diffusers.pipelines.ltx2.pipeline_ltx2.LTX2Pipeline.__call__` (see line
+1224).
+
+Notes:
+- `timestep` at runtime is shape `(B,)` — the model broadcasts internally.
+  The class docstring says `(B, S_video)` but the pipeline always passes
+  `(B,)`.  We capture with `(B,)`.
+- `sigma = timestep` in the pipeline call (LTX-2.3 cross-attn modulation).
+- `video_coords` / `audio_coords` are pre-computed on the pipeline side
+  from `num_frames`/`height`/`width`/`fps` — we provide them explicitly
+  so export doesn't have to symbolically resolve int math inside
+  `LTX2AudioVideoRotaryPosEmbed`.
+- `qk_norm="rms_norm_across_heads"` (same as LTX-Video) → disable
+  `fuse_qk_rope` (the kernel only supports per-head RMSNorm).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from ..adapter import VisGenFamilyAdapter
+from ..policy import RewritePolicy
+
+if TYPE_CHECKING:
+    from ...config import DiffusionModelConfig
+
+
+_EX_B = 2  # match CFG-doubled runtime batch (positive + negative prompts)
+_EX_VIDEO_SEQ = 512
+_EX_AUDIO_SEQ = 128
+_EX_TEXT_SEQ = 64
+_EX_NUM_FRAMES = 8
+_EX_LATENT_H = 8
+_EX_LATENT_W = 8
+_EX_AUDIO_NUM_FRAMES = 8
+_EX_FPS = 24.0
+_EX_TIMESTEP = 500
+
+
+def _arch_dim(cfg: "DiffusionModelConfig", attr: str, default: int) -> int:
+    pc = getattr(cfg, "pretrained_config", None)
+    return int(getattr(pc, attr, default)) if pc is not None else default
+
+
+class LTX2Adapter(VisGenFamilyAdapter):
+    family = "LTX-2"
+    diffusers_transformer_cls = "LTX2VideoTransformer3DModel"
+
+    def example_inputs(
+        self,
+        cfg: "DiffusionModelConfig",
+        device: "torch.device",
+        dtype: "torch.dtype",
+    ) -> tuple[tuple, dict[str, Any]]:
+        in_channels = _arch_dim(cfg, "in_channels", 128)
+        audio_in_channels = _arch_dim(cfg, "audio_in_channels", 128)
+        caption_channels = _arch_dim(cfg, "caption_channels", 3840)
+
+        B = _EX_B
+        S_video = _EX_VIDEO_SEQ
+        S_audio = _EX_AUDIO_SEQ
+        S_text = _EX_TEXT_SEQ
+
+        kwargs: dict[str, Any] = {
+            # Joint video+audio streams (post-patchify, flat sequences).
+            "hidden_states": torch.randn(B, S_video, in_channels, device=device, dtype=dtype),
+            "audio_hidden_states": torch.randn(
+                B, S_audio, audio_in_channels, device=device, dtype=dtype
+            ),
+            # Per-modality text embeddings (Gemma3 → caption_channels).
+            "encoder_hidden_states": torch.randn(
+                B, S_text, caption_channels, device=device, dtype=dtype
+            ),
+            "audio_encoder_hidden_states": torch.randn(
+                B, S_text, caption_channels, device=device, dtype=dtype
+            ),
+            # Timestep is (B,) at runtime — pipeline does `t.expand(B)`.
+            # Pass Long to match scheduler outputs.
+            "timestep": torch.full((B,), _EX_TIMESTEP, device=device, dtype=torch.long),
+            # sigma == timestep at runtime (LTX-2.3 cross-attn modulation).
+            "sigma": torch.full((B,), float(_EX_TIMESTEP), device=device, dtype=dtype),
+            "encoder_attention_mask": torch.ones(B, S_text, device=device, dtype=torch.long),
+            "audio_encoder_attention_mask": torch.ones(B, S_text, device=device, dtype=torch.long),
+            # Pre-computed RoPE coords — supplying these bypasses internal int
+            # math from num_frames/height/width (which would specialize hard
+            # during export). The int kwargs num_frames/height/width/fps/
+            # audio_num_frames are deliberately *omitted* — the transformer
+            # only consults them when video_coords/audio_coords is None, and
+            # leaving them out of the captured signature means the wrapper's
+            # kwargs filter drops them at runtime instead of forcing a
+            # specialization-failed guard.
+            "video_coords": torch.zeros(B, 3, S_video, 2, device=device, dtype=dtype),
+            "audio_coords": torch.zeros(B, 1, S_audio, 2, device=device, dtype=dtype),
+            # Bool/None flags.
+            "isolate_modalities": False,
+            "spatio_temporal_guidance_blocks": None,
+            "perturbation_mask": None,
+            "use_cross_timestep": False,
+            "attention_kwargs": None,
+            "return_dict": False,
+        }
+        return (), kwargs
+
+    def dynamic_shapes(self, cfg: "DiffusionModelConfig") -> dict[str, Any]:
+        # LTX family has shape-dependent int reshapes inside RoPE / block
+        # forwards. Dim.AUTO lets export specialize without erroring.
+        AUTO = torch.export.Dim.AUTO
+        return {
+            "hidden_states": {0: AUTO, 1: AUTO},
+            "audio_hidden_states": {0: AUTO, 1: AUTO},
+            "encoder_hidden_states": {0: AUTO, 1: AUTO},
+            "audio_encoder_hidden_states": {0: AUTO, 1: AUTO},
+            "timestep": {0: AUTO},
+            "sigma": {0: AUTO},
+            "encoder_attention_mask": {0: AUTO, 1: AUTO},
+            "audio_encoder_attention_mask": {0: AUTO, 1: AUTO},
+            "video_coords": {0: AUTO, 2: AUTO},
+            "audio_coords": {0: AUTO, 2: AUTO},
+            # Static / not tensors (num_frames/height/width/fps/audio_num_frames
+            # are filtered out of the runtime call by the wrapper's
+            # _expected_kwargs check — they are not in example_inputs).
+            "isolate_modalities": None,
+            "spatio_temporal_guidance_blocks": None,
+            "perturbation_mask": None,
+            "use_cross_timestep": None,
+            "attention_kwargs": None,
+            "return_dict": None,
+        }
+
+    def rewrite_policy(self, cfg: "DiffusionModelConfig") -> RewritePolicy:
+        # LTX-2 uses `qk_norm="rms_norm_across_heads"` — same constraint as
+        # LTX-Video. The fused DiT QK-norm+RoPE kernel only handles per-head
+        # RMSNorm (head_dim ≤ 128); disable it here.
+        return RewritePolicy(
+            attention_backend=cfg.attention.backend,
+            fuse_qk_rope=False,
+        )
+
+    # No family-specific excludes needed: `auto/sensitivity.py`'s
+    # "narrow-dim embedder, either direction" heuristic catches both the
+    # in-side (proj_in, time_embed, ...) and out-side (proj_out → 128 VAE
+    # latent channels, audio_proj_out → same) for LTX-2 automatically.
+
+    @property
+    def uses_internal_seq_shard(self) -> bool:
+        # Joint audio+video transformer: video stream is sharded along its
+        # sequence dim; audio and text are kept full on every rank. The
+        # shard/gather hooks have to be injected *inside* `model.forward`
+        # because the cross-modal v2a attention needs an explicit all-gather
+        # of the video K/V (audio Q is full → must see all video tokens).
+        return True
+
+    def pre_capture_patch(self, model, visual_gen_mapping) -> None:
+        ulysses_size = getattr(visual_gen_mapping, "ulysses_size", 1) if visual_gen_mapping else 1
+        if ulysses_size <= 1:
+            return
+        ulysses_rank = getattr(visual_gen_mapping, "ulysses_rank", 0)
+
+        from types import MethodType
+
+        import torch
+        from torch import nn
+
+        # --- v2a wrapper -----------------------------------------------------
+        # `block.video_to_audio_attn` is the only attention site where audio Q
+        # (full) reads video K/V (sharded). Wrap it to all-gather both the
+        # encoder_hidden_states (video stream) and the key_rotary_emb (video
+        # rope for the K side) before delegating. Video rope is split-mode →
+        # shape (B, H, S, D) with seq at dim 2; the wrapper handles either
+        # 4-D split or 3-D interleaved by probing the tensor rank.
+        class _V2ACrossAttnWrapper(nn.Module):
+            def __init__(self, original):
+                super().__init__()
+                self.original = original
+
+            def forward(
+                self,
+                hidden_states,  # audio Q, full
+                encoder_hidden_states=None,  # video K/V, sharded
+                query_rotary_emb=None,
+                key_rotary_emb=None,
+                attention_mask=None,
+                **kwargs,
+            ):
+                if encoder_hidden_states is not None:
+                    encoder_hidden_states = torch.ops.visgen_auto.all_gather_seq(
+                        encoder_hidden_states, 1, ulysses_size
+                    )
+                if key_rotary_emb is not None:
+                    cos, sin = key_rotary_emb
+                    # split rope (B, H, S, D) → seq at dim 2;
+                    # interleaved rope (B, S, D) → seq at dim 1.
+                    seq_dim = 2 if cos.dim() == 4 else 1
+                    cos = torch.ops.visgen_auto.all_gather_seq(cos, seq_dim, ulysses_size)
+                    sin = torch.ops.visgen_auto.all_gather_seq(sin, seq_dim, ulysses_size)
+                    key_rotary_emb = (cos, sin)
+                return self.original(
+                    hidden_states,
+                    encoder_hidden_states=encoder_hidden_states,
+                    query_rotary_emb=query_rotary_emb,
+                    key_rotary_emb=key_rotary_emb,
+                    attention_mask=attention_mask,
+                    **kwargs,
+                )
+
+        for block in model.transformer_blocks:
+            block.video_to_audio_attn = _V2ACrossAttnWrapper(block.video_to_audio_attn)
+
+        # --- monkey-patched forward -----------------------------------------
+        # Copy of the diffusers LTX2VideoTransformer3DModel.forward with two
+        # surgical edits:
+        #   (a) after `proj_in(hidden_states)`, slice the video stream and the
+        #       video rope tensors along their seq dim by ulysses_rank;
+        #   (b) before `norm_out(hidden_states)`, `all_gather_seq` the video
+        #       stream so the final scale/shift/proj_out runs on full S_video.
+        # Audio path is untouched; encoder_hidden_states (text) kept full.
+        P = ulysses_size
+        R = ulysses_rank
+
+        def _ltx2_ulysses_forward(
+            self,
+            hidden_states,
+            audio_hidden_states,
+            encoder_hidden_states,
+            audio_encoder_hidden_states,
+            timestep,
+            audio_timestep=None,
+            sigma=None,
+            audio_sigma=None,
+            encoder_attention_mask=None,
+            audio_encoder_attention_mask=None,
+            video_coords=None,
+            audio_coords=None,
+            isolate_modalities: bool = False,
+            spatio_temporal_guidance_blocks=None,
+            perturbation_mask=None,
+            use_cross_timestep: bool = False,
+            attention_kwargs=None,
+            return_dict: bool = False,
+        ):
+            from diffusers.models.transformers.transformer_ltx2 import AudioVisualModelOutput
+
+            audio_timestep = audio_timestep if audio_timestep is not None else timestep
+            audio_sigma = audio_sigma if audio_sigma is not None else sigma
+
+            if encoder_attention_mask is not None and encoder_attention_mask.ndim == 2:
+                encoder_attention_mask = (
+                    1 - encoder_attention_mask.to(hidden_states.dtype)
+                ) * -10000.0
+                encoder_attention_mask = encoder_attention_mask.unsqueeze(1)
+            if audio_encoder_attention_mask is not None and audio_encoder_attention_mask.ndim == 2:
+                audio_encoder_attention_mask = (
+                    1 - audio_encoder_attention_mask.to(audio_hidden_states.dtype)
+                ) * -10000.0
+                audio_encoder_attention_mask = audio_encoder_attention_mask.unsqueeze(1)
+
+            batch_size = hidden_states.size(0)
+
+            # 1. RoPE — pipeline already supplied coords; our adapter declines
+            # `num_frames`/`height`/`width`/`fps`/`audio_num_frames` so the
+            # `if video_coords is None` recompute path is unreachable here.
+            video_rotary_emb = self.rope(video_coords, device=hidden_states.device)
+            audio_rotary_emb = self.audio_rope(audio_coords, device=audio_hidden_states.device)
+            video_cross_attn_rotary_emb = self.cross_attn_rope(
+                video_coords[:, 0:1, :], device=hidden_states.device
+            )
+            audio_cross_attn_rotary_emb = self.cross_attn_audio_rope(
+                audio_coords[:, 0:1, :], device=audio_hidden_states.device
+            )
+
+            # 2. Patchify
+            hidden_states = self.proj_in(hidden_states)
+            audio_hidden_states = self.audio_proj_in(audio_hidden_states)
+
+            # --- Ulysses shard: slice video stream + video rope along seq ----
+            S = hidden_states.shape[1]
+            chunk = S // P
+
+            def _shard_dim(t, dim):
+                # only shard if dim has the expected video seq length
+                if t is None or t.shape[dim] != S:
+                    return t
+                idx = [slice(None)] * t.dim()
+                idx[dim] = slice(R * chunk, (R + 1) * chunk)
+                return t[tuple(idx)].contiguous()
+
+            def _shard_rope(rope):
+                if rope is None:
+                    return None
+                cos, sin = rope
+                # split rope: (B, H, S, D) → seq at dim 2
+                # interleaved rope: (B, S, D) → seq at dim 1
+                dim = 2 if cos.dim() == 4 else 1
+                return (_shard_dim(cos, dim), _shard_dim(sin, dim))
+
+            hidden_states = hidden_states[:, R * chunk : (R + 1) * chunk, :].contiguous()
+            video_rotary_emb = _shard_rope(video_rotary_emb)
+            video_cross_attn_rotary_emb = _shard_rope(video_cross_attn_rotary_emb)
+            # ------------------------------------------------------------------
+
+            # 3. Timestep embeddings — temb / embedded_timestep are typically
+            # (B, 1, D) and broadcast against (B, S, D), so no shard needed.
+            temb, embedded_timestep = self.time_embed(
+                timestep.flatten(),
+                batch_size=batch_size,
+                hidden_dtype=hidden_states.dtype,
+            )
+            temb = temb.view(batch_size, -1, temb.size(-1))
+            embedded_timestep = embedded_timestep.view(batch_size, -1, embedded_timestep.size(-1))
+            temb_audio, audio_embedded_timestep = self.audio_time_embed(
+                audio_timestep.flatten(),
+                batch_size=batch_size,
+                hidden_dtype=audio_hidden_states.dtype,
+            )
+            temb_audio = temb_audio.view(batch_size, -1, temb_audio.size(-1))
+            audio_embedded_timestep = audio_embedded_timestep.view(
+                batch_size, -1, audio_embedded_timestep.size(-1)
+            )
+
+            if self.prompt_modulation:
+                temb_prompt, _ = self.prompt_adaln(
+                    sigma.flatten(),
+                    batch_size=batch_size,
+                    hidden_dtype=hidden_states.dtype,
+                )
+                temb_prompt_audio, _ = self.audio_prompt_adaln(
+                    audio_sigma.flatten(),
+                    batch_size=batch_size,
+                    hidden_dtype=audio_hidden_states.dtype,
+                )
+                temb_prompt = temb_prompt.view(batch_size, -1, temb_prompt.size(-1))
+                temb_prompt_audio = temb_prompt_audio.view(
+                    batch_size, -1, temb_prompt_audio.size(-1)
+                )
+            else:
+                temb_prompt = temb_prompt_audio = None
+
+            # 3.2. Cross attn modulation params
+            from diffusers.models.transformers.transformer_ltx2 import (
+                LTX2AdaLayerNormSingle,  # noqa: F401
+            )
+
+            ts_mult = (
+                self.config.cross_attn_timestep_scale_multiplier
+                / self.config.timestep_scale_multiplier
+            )
+            video_ca_ts = audio_sigma.flatten() if use_cross_timestep else timestep.flatten()
+            v_ca_ss, _ = self.av_cross_attn_video_scale_shift(
+                video_ca_ts, batch_size=batch_size, hidden_dtype=hidden_states.dtype
+            )
+            v_a2v_gate, _ = self.av_cross_attn_video_a2v_gate(
+                video_ca_ts * ts_mult, batch_size=batch_size, hidden_dtype=hidden_states.dtype
+            )
+            v_ca_ss = v_ca_ss.view(batch_size, -1, v_ca_ss.shape[-1])
+            v_a2v_gate = v_a2v_gate.view(batch_size, -1, v_a2v_gate.shape[-1])
+            audio_ca_ts = sigma.flatten() if use_cross_timestep else audio_timestep.flatten()
+            a_ca_ss, _ = self.av_cross_attn_audio_scale_shift(
+                audio_ca_ts, batch_size=batch_size, hidden_dtype=audio_hidden_states.dtype
+            )
+            a_v2a_gate, _ = self.av_cross_attn_audio_v2a_gate(
+                audio_ca_ts * ts_mult, batch_size=batch_size, hidden_dtype=audio_hidden_states.dtype
+            )
+            a_ca_ss = a_ca_ss.view(batch_size, -1, a_ca_ss.shape[-1])
+            a_v2a_gate = a_v2a_gate.view(batch_size, -1, a_v2a_gate.shape[-1])
+
+            # 4. Prompt embeddings — kept full on every rank
+            if self.config.use_prompt_embeddings:
+                encoder_hidden_states = self.caption_projection(encoder_hidden_states)
+                encoder_hidden_states = encoder_hidden_states.view(
+                    batch_size, -1, hidden_states.size(-1)
+                )
+                audio_encoder_hidden_states = self.audio_caption_projection(
+                    audio_encoder_hidden_states
+                )
+                audio_encoder_hidden_states = audio_encoder_hidden_states.view(
+                    batch_size, -1, audio_hidden_states.size(-1)
+                )
+
+            # 5. Blocks
+            stg = set(spatio_temporal_guidance_blocks or [])
+            all_pert = False
+            if perturbation_mask is not None and perturbation_mask.ndim == 1:
+                perturbation_mask = perturbation_mask[:, None, None]
+            if perturbation_mask is not None:
+                all_pert = torch.all(perturbation_mask == 0).item()
+
+            for i, block in enumerate(self.transformer_blocks):
+                bpm = perturbation_mask if i in stg else None
+                bap = all_pert if i in stg else False
+                hidden_states, audio_hidden_states = block(
+                    hidden_states=hidden_states,
+                    audio_hidden_states=audio_hidden_states,
+                    encoder_hidden_states=encoder_hidden_states,
+                    audio_encoder_hidden_states=audio_encoder_hidden_states,
+                    temb=temb,
+                    temb_audio=temb_audio,
+                    temb_ca_scale_shift=v_ca_ss,
+                    temb_ca_audio_scale_shift=a_ca_ss,
+                    temb_ca_gate=v_a2v_gate,
+                    temb_ca_audio_gate=a_v2a_gate,
+                    temb_prompt=temb_prompt,
+                    temb_prompt_audio=temb_prompt_audio,
+                    video_rotary_emb=video_rotary_emb,
+                    audio_rotary_emb=audio_rotary_emb,
+                    ca_video_rotary_emb=video_cross_attn_rotary_emb,
+                    ca_audio_rotary_emb=audio_cross_attn_rotary_emb,
+                    encoder_attention_mask=encoder_attention_mask,
+                    audio_encoder_attention_mask=audio_encoder_attention_mask,
+                    self_attention_mask=None,
+                    audio_self_attention_mask=None,
+                    a2v_cross_attention_mask=None,
+                    v2a_cross_attention_mask=None,
+                    use_a2v_cross_attention=not isolate_modalities,
+                    use_v2a_cross_attention=not isolate_modalities,
+                    perturbation_mask=bpm,
+                    all_perturbed=bap,
+                )
+
+            # --- Ulysses gather: bring video stream back to full S ----------
+            hidden_states = torch.ops.visgen_auto.all_gather_seq(hidden_states, 1, ulysses_size)
+            # -----------------------------------------------------------------
+
+            # 6. Output
+            scale_shift = self.scale_shift_table[None, None] + embedded_timestep[:, :, None]
+            shift, scale = scale_shift[:, :, 0], scale_shift[:, :, 1]
+            hidden_states = self.norm_out(hidden_states)
+            hidden_states = hidden_states * (1 + scale) + shift
+            output = self.proj_out(hidden_states)
+
+            audio_scale_shift = (
+                self.audio_scale_shift_table[None, None] + audio_embedded_timestep[:, :, None]
+            )
+            audio_shift, audio_scale = audio_scale_shift[:, :, 0], audio_scale_shift[:, :, 1]
+            audio_hidden_states = self.audio_norm_out(audio_hidden_states)
+            audio_hidden_states = audio_hidden_states * (1 + audio_scale) + audio_shift
+            audio_output = self.audio_proj_out(audio_hidden_states)
+
+            if not return_dict:
+                return (output, audio_output)
+            return AudioVisualModelOutput(sample=output, audio_sample=audio_output)
+
+        model.forward = MethodType(_ltx2_ulysses_forward, model)

--- a/tensorrt_llm/_torch/visual_gen/auto/families/mmdit.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/families/mmdit.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Generic MM-DiT adapter — fallback when no family-specific adapter matches.
+
+Used when an unrecognized but Diffusers-shaped checkpoint routes to the auto
+path under ``pipeline_mode="fallback"``. Assumes the transformer follows the
+standard MM-DiT calling convention: joint text+image stream, dual modulation
+streams, RoPE positional encodings. Best-effort — families with a
+custom signature should ship their own adapter.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from ..adapter import VisGenFamilyAdapter
+from ..policy import RewritePolicy
+
+if TYPE_CHECKING:
+    from ...config import DiffusionModelConfig
+
+
+class MMDiTAdapter(VisGenFamilyAdapter):
+    family = "MMDiT-generic"
+    diffusers_transformer_cls = ""  # matches by fallback, not by class name
+
+    def example_inputs(
+        self,
+        cfg: "DiffusionModelConfig",
+        device: "torch.device",
+        dtype: "torch.dtype",
+    ) -> tuple[tuple, dict[str, Any]]:
+        raise NotImplementedError(
+            "MMDiTAdapter.example_inputs is a generic-fallback stub. To onboard a new "
+            "Diffusers transformer family, subclass VisGenFamilyAdapter and supply "
+            "example_inputs / dynamic_shapes (see SD3Adapter or FluxAdapter for examples)."
+        )
+
+    def dynamic_shapes(self, cfg: "DiffusionModelConfig") -> dict[str, Any]:
+        raise NotImplementedError("MMDiTAdapter.dynamic_shapes lands per-family.")
+
+    def rewrite_policy(self, cfg: "DiffusionModelConfig") -> RewritePolicy:
+        return RewritePolicy(attention_backend=cfg.attention.backend)

--- a/tensorrt_llm/_torch/visual_gen/auto/families/pixart.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/families/pixart.py
@@ -1,0 +1,227 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""PixArt family adapter (PixArt-Σ / PixArt-α).
+
+Targets Diffusers `PixArtTransformer2DModel`. Architecture:
+- `hidden_states` is 4-D `(B, C, H, W)` raw latents — patchified internally
+  via `PatchEmbed`.
+- Single-stream attention (no MM-DiT joint), with cross-attention to text
+  embeddings (`encoder_hidden_states`) of shape `(B, S_text, caption_channels)`.
+- `caption_channels` (default 4096) ≠ inner_dim (1152 for Σ-XL).
+- Uses `AdaLayerNormSingle` (`norm_type="ada_norm_single"`) — needs
+  `added_cond_kwargs={"resolution":..., "aspect_ratio":...}` only when
+  `use_additional_conditions=True`. The Σ-XL config doesn't set this
+  to True by default, but the pipeline passes `added_cond_kwargs` anyway.
+- `qk_norm`: none (no per-head RMSNorm) → `fuse_qk_rope=False`. Also
+  no RoPE — positions come from learned PatchEmbed, like SD3.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from ..adapter import VisGenFamilyAdapter
+from ..policy import RewritePolicy
+
+if TYPE_CHECKING:
+    from ...config import DiffusionModelConfig
+
+
+_EX_B = 2  # CFG-doubled batch (PixArt uses guidance_scale > 1 by default)
+_DEFAULT_LATENT_H = 128  # Σ-XL @ 1024² → 1024/8 = 128
+_DEFAULT_LATENT_W = 128
+_EX_TXT_SEQ = 300  # PixArt-Σ uses T5-XXL with default max_sequence_length=300
+
+
+def _arch_dim(cfg: "DiffusionModelConfig", attr: str, default: int) -> int:
+    pc = getattr(cfg, "pretrained_config", None)
+    return int(getattr(pc, attr, default)) if pc is not None else default
+
+
+class PixArtAdapter(VisGenFamilyAdapter):
+    family = "PixArt"
+    diffusers_transformer_cls = "PixArtTransformer2DModel"
+
+    def example_inputs(
+        self,
+        cfg: "DiffusionModelConfig",
+        device: "torch.device",
+        dtype: "torch.dtype",
+    ) -> tuple[tuple, dict[str, Any]]:
+        in_channels = _arch_dim(cfg, "in_channels", 4)
+        caption_channels = _arch_dim(cfg, "caption_channels", 4096)
+
+        B = _EX_B
+        H = _DEFAULT_LATENT_H
+        W = _DEFAULT_LATENT_W
+        S_txt = _EX_TXT_SEQ
+
+        # PixArtSigmaPipeline calls the transformer with `hidden_states`
+        # POSITIONAL (see diffusers/pipelines/pixart_alpha/pipeline_pixart_sigma.py).
+        # Pass it as a positional in example_inputs so capture matches.
+        hidden_states = torch.randn(B, in_channels, H, W, device=device, dtype=dtype)
+        kwargs: dict[str, Any] = {
+            "encoder_hidden_states": torch.randn(
+                B, S_txt, caption_channels, device=device, dtype=dtype
+            ),
+            "timestep": torch.full((B,), 500, device=device, dtype=torch.long),
+            "encoder_attention_mask": torch.ones(B, S_txt, device=device, dtype=torch.long),
+            # PixArt-Σ XL-2 has `use_additional_conditions=False`; the
+            # diffusers `PixArtSigmaPipeline` passes
+            # `added_cond_kwargs = {"resolution": None, "aspect_ratio": None}`
+            # (both values literally None). If we capture with tensors here,
+            # the captured graph traces tensor `.size()` ops that crash on
+            # None at runtime. Match the pipeline's call shape literally.
+            "added_cond_kwargs": {"resolution": None, "aspect_ratio": None},
+            "return_dict": False,
+        }
+        return (hidden_states,), kwargs
+
+    def dynamic_shapes(self, cfg: "DiffusionModelConfig") -> dict[str, Any]:
+        # All-static for first-light. PixArt-Σ has internal divisibility
+        # asserts on H/W (PatchEmbed) and on S_txt (caption_projection); the
+        # cleanest start is to specialize the captured graph at the example
+        # shape, which matches runtime CFG batch=2 + S_txt=64.
+        # Flat dict keyed by forward-signature parameter names — torch.export
+        # matches by name across (args, kwargs).
+        return {
+            "hidden_states": None,
+            "encoder_hidden_states": None,
+            "timestep": None,
+            "encoder_attention_mask": None,
+            "added_cond_kwargs": {
+                "resolution": None,
+                "aspect_ratio": None,
+            },
+            "return_dict": None,
+        }
+
+    def rewrite_policy(self, cfg: "DiffusionModelConfig") -> RewritePolicy:
+        # PixArt has no QK-RMSNorm (just plain SDPA after Q/K projections).
+        return RewritePolicy(
+            attention_backend=cfg.attention.backend,
+            fuse_qk_rope=False,
+        )
+
+    @property
+    def uses_internal_seq_shard(self) -> bool:
+        # 4-D `(B, C, H, W)` input → patchify inside via `self.pos_embed`.
+        # Same shard pattern as SD3: slice the flat sequence *after*
+        # `pos_embed`, all-gather before `norm_out`/`proj_out`.
+        return True
+
+    def pre_capture_patch(self, model, visual_gen_mapping) -> None:
+        ulysses_size = getattr(visual_gen_mapping, "ulysses_size", 1) if visual_gen_mapping else 1
+        if ulysses_size <= 1:
+            return
+        ulysses_rank = getattr(visual_gen_mapping, "ulysses_rank", 0)
+
+        from types import MethodType
+
+        def _pixart_ulysses_forward(
+            self,
+            hidden_states,
+            encoder_hidden_states=None,
+            timestep=None,
+            added_cond_kwargs=None,
+            cross_attention_kwargs=None,
+            attention_mask=None,
+            encoder_attention_mask=None,
+            return_dict: bool = False,
+        ):
+            from diffusers.models.modeling_outputs import Transformer2DModelOutput
+
+            # Attention mask → bias (matches diffusers' built-in conversion).
+            if attention_mask is not None and attention_mask.ndim == 2:
+                attention_mask = (1 - attention_mask.to(hidden_states.dtype)) * -10000.0
+                attention_mask = attention_mask.unsqueeze(1)
+            if encoder_attention_mask is not None and encoder_attention_mask.ndim == 2:
+                encoder_attention_mask = (
+                    1 - encoder_attention_mask.to(hidden_states.dtype)
+                ) * -10000.0
+                encoder_attention_mask = encoder_attention_mask.unsqueeze(1)
+
+            batch_size = hidden_states.shape[0]
+            height = hidden_states.shape[-2] // self.config.patch_size
+            width = hidden_states.shape[-1] // self.config.patch_size
+
+            # 1. pos_embed produces token-flat `(B, S, inner_dim)`.
+            hidden_states = self.pos_embed(hidden_states)
+
+            # --- Ulysses shard on the flat image-stream sequence ---
+            P = ulysses_size
+            R = ulysses_rank
+            S = hidden_states.shape[1]
+            chunk = S // P
+            hidden_states = hidden_states[:, R * chunk : (R + 1) * chunk, :].contiguous()
+            # Text (`encoder_hidden_states`) is kept full on every rank;
+            # the cross-attention in each block has full text K/V and
+            # sharded image Q → output is sharded image, no gather needed.
+            # ----------------------------------------------------------
+
+            timestep, embedded_timestep = self.adaln_single(
+                timestep,
+                added_cond_kwargs,
+                batch_size=batch_size,
+                hidden_dtype=hidden_states.dtype,
+            )
+
+            if self.caption_projection is not None:
+                encoder_hidden_states = self.caption_projection(encoder_hidden_states)
+                encoder_hidden_states = encoder_hidden_states.view(
+                    batch_size, -1, hidden_states.shape[-1]
+                )
+
+            for block in self.transformer_blocks:
+                hidden_states = block(
+                    hidden_states,
+                    attention_mask=attention_mask,
+                    encoder_hidden_states=encoder_hidden_states,
+                    encoder_attention_mask=encoder_attention_mask,
+                    timestep=timestep,
+                    cross_attention_kwargs=cross_attention_kwargs,
+                    class_labels=None,
+                )
+
+            # --- Gather image sequence back to full S before output ---
+            hidden_states = torch.ops.visgen_auto.all_gather_seq(hidden_states, 1, ulysses_size)
+            # ----------------------------------------------------------
+
+            shift, scale = (
+                self.scale_shift_table[None]
+                + embedded_timestep[:, None].to(self.scale_shift_table.device)
+            ).chunk(2, dim=1)
+            hidden_states = self.norm_out(hidden_states)
+            hidden_states = hidden_states * (1 + scale.to(hidden_states.device)) + shift.to(
+                hidden_states.device
+            )
+            hidden_states = self.proj_out(hidden_states)
+            hidden_states = hidden_states.squeeze(1)
+
+            # Unpatchify.
+            hidden_states = hidden_states.reshape(
+                shape=(
+                    -1,
+                    height,
+                    width,
+                    self.config.patch_size,
+                    self.config.patch_size,
+                    self.out_channels,
+                )
+            )
+            hidden_states = torch.einsum("nhwpqc->nchpwq", hidden_states)
+            output = hidden_states.reshape(
+                shape=(
+                    -1,
+                    self.out_channels,
+                    height * self.config.patch_size,
+                    width * self.config.patch_size,
+                )
+            )
+            if not return_dict:
+                return (output,)
+            return Transformer2DModelOutput(sample=output)
+
+        model.forward = MethodType(_pixart_ulysses_forward, model)

--- a/tensorrt_llm/_torch/visual_gen/auto/families/sana.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/families/sana.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Sana family adapter (Efficient-Large-Model/Sana_*).
+
+Targets Diffusers `SanaTransformer2DModel`. Architecture (per the 1.6B
+config):
+- `in_channels=32`, `patch_size=1` (no spatial patchify — operates directly
+  on VAE latents at 32× compression).
+- `num_attention_heads=70`, `attention_head_dim=32` → `inner_dim=2240`.
+- Separate self-attention (`num_attention_heads=70`) and cross-attention
+  (`num_cross_attention_heads=20`, `cross_attention_head_dim=112`).
+- `caption_channels=2304` (Gemma-2-2B text encoder output).
+- 4-D `hidden_states (B, C, H, W)` input.
+- Uses **linear attention** in self-attention (not standard quadratic SDPA).
+  This is the Sana paper's headline trick — auto path's `visgen_auto.sdpa`
+  pattern matcher only catches `F.scaled_dot_product_attention`, so the
+  linear-attn blocks remain in eager. Cross-attention is regular SDPA and
+  gets rewritten normally.
+- No QK-RMSNorm, no RoPE.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from ..adapter import VisGenFamilyAdapter
+from ..policy import RewritePolicy
+
+if TYPE_CHECKING:
+    from ...config import DiffusionModelConfig
+
+
+_EX_B = 2  # CFG-doubled batch
+_DEFAULT_LATENT_H = 32  # 1024 / 32 (VAE compression) = 32
+_DEFAULT_LATENT_W = 32
+_EX_TXT_SEQ = 300  # Sana uses Gemma-2 with similar default text seq
+
+
+def _arch_dim(cfg: "DiffusionModelConfig", attr: str, default: int) -> int:
+    pc = getattr(cfg, "pretrained_config", None)
+    return int(getattr(pc, attr, default)) if pc is not None else default
+
+
+class SanaAdapter(VisGenFamilyAdapter):
+    family = "Sana"
+    diffusers_transformer_cls = "SanaTransformer2DModel"
+
+    def example_inputs(
+        self,
+        cfg: "DiffusionModelConfig",
+        device: "torch.device",
+        dtype: "torch.dtype",
+    ) -> tuple[tuple, dict[str, Any]]:
+        in_channels = _arch_dim(cfg, "in_channels", 32)
+        caption_channels = _arch_dim(cfg, "caption_channels", 2304)
+
+        B = _EX_B
+        H = _DEFAULT_LATENT_H
+        W = _DEFAULT_LATENT_W
+        S_txt = _EX_TXT_SEQ
+
+        # SanaPipeline calls the transformer with `hidden_states` POSITIONAL.
+        hidden_states = torch.randn(B, in_channels, H, W, device=device, dtype=dtype)
+        kwargs: dict[str, Any] = {
+            "encoder_hidden_states": torch.randn(
+                B, S_txt, caption_channels, device=device, dtype=dtype
+            ),
+            "timestep": torch.full((B,), 500, device=device, dtype=torch.long),
+            "encoder_attention_mask": torch.ones(B, S_txt, device=device, dtype=torch.long),
+            "return_dict": False,
+        }
+        return (hidden_states,), kwargs
+
+    def dynamic_shapes(self, cfg: "DiffusionModelConfig") -> dict[str, Any]:
+        # All-static for first-light (same rationale as PixArt). Sana's
+        # linear-attention blocks have internal reshapes that don't admit
+        # cleanly to Dim() constraints; specialize at example shape.
+        return {
+            "hidden_states": None,
+            "encoder_hidden_states": None,
+            "timestep": None,
+            "encoder_attention_mask": None,
+            "return_dict": None,
+        }
+
+    def rewrite_policy(self, cfg: "DiffusionModelConfig") -> RewritePolicy:
+        # No QK-RMSNorm, no RoPE → fuse_qk_rope=False.
+        #
+        # NOTE: `attention.backend` (`VANILLA` / `TRTLLM` / `FA4`) is a no-op
+        # for Sana self-attention sites — Sana's linear attention blocks don't
+        # call `F.scaled_dot_product_attention`, so the SDPA rewriter's
+        # pattern matcher skips them entirely. The backend still applies to
+        # cross-attention sites (which use quadratic SDPA), but the
+        # headline perf characteristic of Sana is the linear self-attn,
+        # which stays in eager. Document this asymmetry vs. handwritten Sana.
+        return RewritePolicy(
+            attention_backend=cfg.attention.backend,
+            fuse_qk_rope=False,
+        )

--- a/tensorrt_llm/_torch/visual_gen/auto/families/sd3.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/families/sd3.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""SD3 / SD3.5 family adapter for the auto path.
+
+Targets Diffusers `SD3Transformer2DModel`. Architecture differs from Flux.1:
+
+- **Input shape**: `hidden_states` is ``(B, C, H, W)`` raw image (not
+  pre-patched) — patching happens inside the transformer via `PatchEmbed`.
+- **No RoPE**: position information is in a *learned* `PatchEmbed`
+  (additive), so there are no cos/sin tensors in the captured graph. The
+  ``qk_rope_fusion`` matchers correctly skip these sites because their
+  pattern keys on an ``aten.add.Tensor`` consuming two muls — no such
+  node exists when RoPE is absent.
+- **All joint attention**: every block is a `JointTransformerBlock` (no
+  single stream). First 13 layers in SD3.5 also have a
+  ``use_dual_attention=True`` extra self-attention on the hidden side
+  (an additional single-stream site per affected block).
+- **qk_norm**: SD3.5 uses per-head RMSNorm (same as Flux.1). SD3 (without
+  .5) uses none.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from ..adapter import VisGenFamilyAdapter
+from ..policy import RewritePolicy
+
+if TYPE_CHECKING:
+    from ...config import DiffusionModelConfig
+
+# Example dims for export tracing. H/W refer to LATENT dimensions (the shape
+# the transformer actually sees — `hidden_states` is `(B, in_channels, H_lat,
+# W_lat)` where the VAE has already downsampled the image by 8×).  For a
+# 512×512 image, H_lat = W_lat = 64. Kept *static* at the actual latent
+# resolution; broad dynamic H/W would trip many divisibility guards in
+# SD3's `PatchEmbed`.
+_EXAMPLE_BATCH = 2
+_DEFAULT_LATENT_H = 64
+_DEFAULT_LATENT_W = 64
+_EXAMPLE_TXT_SEQ = 64
+_EXAMPLE_TIMESTEP = 500
+
+
+def _arch_dim(cfg: "DiffusionModelConfig", attr: str, default: int) -> int:
+    pc = getattr(cfg, "pretrained_config", None)
+    return int(getattr(pc, attr, default)) if pc is not None else default
+
+
+def _cfg_dim(cfg: "DiffusionModelConfig", attr: str, default: int) -> int:
+    """Read a value from cfg, with a default fallback (cfg attrs may not exist)."""
+    return int(getattr(cfg, attr, default))
+
+
+class SD3Adapter(VisGenFamilyAdapter):
+    family = "SD3"
+    diffusers_transformer_cls = "SD3Transformer2DModel"
+
+    def example_inputs(
+        self,
+        cfg: "DiffusionModelConfig",
+        device: "torch.device",
+        dtype: "torch.dtype",
+    ) -> tuple[tuple, dict[str, Any]]:
+        in_channels = _arch_dim(cfg, "in_channels", 16)
+        joint_dim = _arch_dim(cfg, "joint_attention_dim", 4096)
+        pooled_dim = _arch_dim(cfg, "pooled_projection_dim", 2048)
+
+        B = _EXAMPLE_BATCH
+        H = _cfg_dim(cfg, "latent_height", _DEFAULT_LATENT_H)
+        W = _cfg_dim(cfg, "latent_width", _DEFAULT_LATENT_W)
+        S_txt = _EXAMPLE_TXT_SEQ
+
+        kwargs: dict[str, Any] = {
+            "hidden_states": torch.randn(B, in_channels, H, W, device=device, dtype=dtype),
+            "encoder_hidden_states": torch.randn(B, S_txt, joint_dim, device=device, dtype=dtype),
+            "pooled_projections": torch.randn(B, pooled_dim, device=device, dtype=dtype),
+            # SD3 uses FlowMatchEulerDiscreteScheduler — timestep is a float
+            # (sigma value), not a Long. The forward signature is annotated
+            # `LongTensor` but Diffusers' SD3 pipeline passes FP32 (the
+            # scheduler's default).  The transformer casts internally.
+            "timestep": torch.full(
+                (B,), float(_EXAMPLE_TIMESTEP), device=device, dtype=torch.float32
+            ),
+            "return_dict": False,
+        }
+        return (), kwargs
+
+    def dynamic_shapes(self, cfg: "DiffusionModelConfig") -> dict[str, Any]:
+        # H/W are static (captured at example_inputs size). Making them
+        # dynamic requires modeling the model's `pos_embed_max_size` bound
+        # and internal divisibility constraints (H % 2, W % 2) — defer to a
+        # follow-up. For now: capture per resolution; if you change H/W,
+        # re-capture.
+        B = torch.export.Dim("B", min=1, max=8)
+        S_txt = torch.export.Dim("S_txt", min=1, max=512)
+        return {
+            "hidden_states": {0: B},
+            "encoder_hidden_states": {0: B, 1: S_txt},
+            "pooled_projections": {0: B},
+            "timestep": {0: B},
+            "return_dict": None,
+        }
+
+    def rewrite_policy(self, cfg: "DiffusionModelConfig") -> RewritePolicy:
+        return RewritePolicy(attention_backend=cfg.attention.backend)
+
+    @property
+    def uses_internal_seq_shard(self) -> bool:
+        # SD3's `hidden_states` is 4-D `(B, C, H, W)` like a video DiT —
+        # the boundary-level dim-1 shard would slice channels, not the
+        # post-pos_embed sequence. Use the in-model shard pattern (mirroring
+        # WAN's): slice after `self.pos_embed(...)` produces the flat
+        # `(B, S, hidden)` sequence, all-gather before `norm_out`.
+        return True
+
+    def pre_capture_patch(self, model, visual_gen_mapping) -> None:
+        ulysses_size = getattr(visual_gen_mapping, "ulysses_size", 1) if visual_gen_mapping else 1
+        if ulysses_size <= 1:
+            return
+        ulysses_rank = getattr(visual_gen_mapping, "ulysses_rank", 0)
+
+        from types import MethodType
+
+        def _sd3_ulysses_forward(
+            self,
+            hidden_states,
+            encoder_hidden_states=None,
+            pooled_projections=None,
+            timestep=None,
+            return_dict: bool = False,
+            **_unused,  # joint_attention_kwargs, block_controlnet_hidden_states, skip_layers
+        ):
+            from diffusers.models.modeling_outputs import Transformer2DModelOutput
+
+            height, width = hidden_states.shape[-2:]
+
+            # pos_embed produces token-flat `(B, S, inner_dim)`.
+            hidden_states = self.pos_embed(hidden_states)
+
+            # --- Ulysses shard on the flat image-stream sequence ---
+            P = ulysses_size
+            R = ulysses_rank
+            S = hidden_states.shape[1]
+            chunk = S // P
+            hidden_states = hidden_states[:, R * chunk : (R + 1) * chunk, :].contiguous()
+            # NOTE: SD3 is MM-DiT — each block concatenates text+image inside
+            # for joint attention. Text (`encoder_hidden_states`) is kept
+            # full on every rank; only the image stream is sharded. The
+            # UlyssesAttention inside `visgen_auto.sdpa` will all-to-all the
+            # concatenated stream, redistributing across heads.
+            # --------------------------------------------------------
+
+            temb = self.time_text_embed(timestep, pooled_projections)
+            encoder_hidden_states = self.context_embedder(encoder_hidden_states)
+
+            for block in self.transformer_blocks:
+                encoder_hidden_states, hidden_states = block(
+                    hidden_states=hidden_states,
+                    encoder_hidden_states=encoder_hidden_states,
+                    temb=temb,
+                    joint_attention_kwargs=None,
+                )
+
+            # --- Gather image sequence back to full S ---
+            hidden_states = torch.ops.visgen_auto.all_gather_seq(hidden_states, 1, ulysses_size)
+            # --------------------------------------------
+
+            hidden_states = self.norm_out(hidden_states, temb)
+            hidden_states = self.proj_out(hidden_states)
+
+            patch_size = self.config.patch_size
+            h2 = height // patch_size
+            w2 = width // patch_size
+            hidden_states = hidden_states.reshape(
+                (hidden_states.shape[0], h2, w2, patch_size, patch_size, self.out_channels)
+            )
+            hidden_states = torch.einsum("nhwpqc->nchpwq", hidden_states)
+            output = hidden_states.reshape(
+                (hidden_states.shape[0], self.out_channels, h2 * patch_size, w2 * patch_size)
+            )
+            if not return_dict:
+                return (output,)
+            return Transformer2DModelOutput(sample=output)
+
+        model.forward = MethodType(_sd3_ulysses_forward, model)

--- a/tensorrt_llm/_torch/visual_gen/auto/families/wan.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/families/wan.py
@@ -1,0 +1,226 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""WAN family adapter for the auto path.
+
+Targets Diffusers `WanTransformer3DModel` (Wan2.1 / 2.2). Major differences
+from the image-DiT families:
+
+- 5-D `hidden_states` `(B, C, T, H, W)` — video latents pre-patch. Internal
+  `Conv3d(patch_size=(1,2,2))` flattens to a sequence inside the model.
+- `encoder_hidden_states` is text-only (T2V); the I2V variant adds a
+  separate `encoder_hidden_states_image` arg which we skip (None).
+- `qk_norm='rms_norm_across_heads'` — full-mode RMSNorm. PR #13614's new
+  RMSNorm with `allreduce_variance=True` will be relevant for TP here.
+- Much larger: 40 layers, FFN dim 13824, 14B params per transformer.
+
+This adapter is a *spike* — intended to confirm the auto path's
+infrastructure (capture, sensitivity heuristic, dispatcher) doesn't have
+image-DiT-specific assumptions baked in. End-to-end inference will require
+matching the Diffusers `WanPipeline` shell (dual transformers, scheduler
+specifics), which is follow-up work.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from ..adapter import VisGenFamilyAdapter
+from ..policy import RewritePolicy
+
+if TYPE_CHECKING:
+    from ...config import DiffusionModelConfig
+
+
+# Minimum-viable example shapes for capture. Real inference will use much
+# larger spatial dims (e.g., 480×832 or 720×1280) and 81–161 frames.
+_EX_B = 1
+_EX_C = 16  # WAN T2V default in_channels
+_EX_T = 4  # post-patch frames; with patch_size[0]=1 this is raw frame count
+_EX_H = 32  # post-patch_embedding height (so input H = 32 * patch_size[1] = 64)
+_EX_W = 32
+_EX_TEXT_LEN = 32
+_EX_TEXT_DIM = 4096
+
+
+class WanAdapter(VisGenFamilyAdapter):
+    family = "Wan"
+    diffusers_transformer_cls = "WanTransformer3DModel"
+
+    def example_inputs(
+        self,
+        cfg: "DiffusionModelConfig",
+        device: "torch.device",
+        dtype: "torch.dtype",
+    ) -> tuple[tuple, dict[str, Any]]:
+        pc = cfg.pretrained_config
+        C = getattr(pc, "in_channels", _EX_C)
+        text_dim = getattr(pc, "text_dim", _EX_TEXT_DIM)
+        patch = getattr(pc, "patch_size", (1, 2, 2))
+
+        # Input video latent is `(B, C, T, H, W)` *before* patch_embedding.
+        # The model's `Conv3d(patch_size=patch)` produces post-patch
+        # `(B, inner_dim, T/p_t, H/p_h, W/p_w)`, then flatten+transpose to seq.
+        H_in = _EX_H * patch[1]
+        W_in = _EX_W * patch[2]
+        T_in = _EX_T * patch[0]
+
+        # `encoder_hidden_states_image` is the I2V branch; Diffusers'
+        # T2V `WanPipeline.__call__` doesn't pass it. Including it in the
+        # captured-graph signature would force the pipeline to pass it too
+        # (torch.export's kwarg-set is strict at runtime). Drop it for the
+        # T2V capture; I2V is a follow-up adapter mode.
+        kwargs: dict[str, Any] = {
+            "hidden_states": torch.randn(_EX_B, C, T_in, H_in, W_in, device=device, dtype=dtype),
+            "timestep": torch.full((_EX_B,), 500, device=device, dtype=torch.long),
+            "encoder_hidden_states": torch.randn(
+                _EX_B, _EX_TEXT_LEN, text_dim, device=device, dtype=dtype
+            ),
+            "return_dict": False,
+            "attention_kwargs": None,
+        }
+        return (), kwargs
+
+    def dynamic_shapes(self, cfg: "DiffusionModelConfig") -> dict[str, Any]:
+        # WAN's forward has shape-dependent control flow (frame counts, patch
+        # math via `hidden_states.shape[...]` used as Python ints in reshapes).
+        # Trying to mark these as Dim.DYNAMIC trips torch.export's specialization
+        # detector. We fall back to AUTO for now — produces a static capture per
+        # call, sufficient for the spike. Re-captures across resolution changes
+        # land as follow-up (sharding + dynamic-shape recovery is per-family work).
+        AUTO = torch.export.Dim.AUTO
+        return {
+            "hidden_states": {0: AUTO, 2: AUTO, 3: AUTO, 4: AUTO},
+            "timestep": {0: AUTO},
+            "encoder_hidden_states": {0: AUTO, 1: AUTO},
+            "return_dict": None,
+            "attention_kwargs": None,
+        }
+
+    def rewrite_policy(self, cfg: "DiffusionModelConfig") -> RewritePolicy:
+        # WAN's `qk_norm` is `rms_norm_across_heads`: RMSNorm operates on the
+        # full inner_dim (5120 = 40 heads × 128 head_dim) BEFORE the unflatten
+        # to per-head shape — verified by walking the captured graph
+        # (`rms_norm.args[1] == [5120]`, then `aten.unflatten.int(..., 2, [40,
+        # -1])` downstream). The `fused_dit_qk_norm_rope` kernel only handles
+        # per-head RMSNorm (head_dim ≤ 128), so the fusion isn't applicable —
+        # disable explicitly to make the policy honest. Same constraint as
+        # LTX-Video / LTX-2.
+        return RewritePolicy(
+            attention_backend=cfg.attention.backend,
+            fuse_qk_rope=False,
+        )
+
+    @property
+    def uses_internal_seq_shard(self) -> bool:
+        # WAN's 5-D `(B, C, T, H, W)` input doesn't admit a clean axis-aligned
+        # half (T=21 odd; H_p × W_p partial slices break the patch+flatten
+        # row-major order). Handwritten visual_gen WAN shards the flat sequence
+        # *inside* the model after `patch_embedding.flatten(2).transpose(1,2)`
+        # and `all_gather`s before `norm_out`. We mirror that by monkey-patching
+        # the forward in `pre_capture_patch`.
+        return True
+
+    def pre_capture_patch(self, model, visual_gen_mapping) -> None:
+        ulysses_size = getattr(visual_gen_mapping, "ulysses_size", 1) if visual_gen_mapping else 1
+        if ulysses_size <= 1:
+            return  # single-GPU — no patch needed
+        ulysses_rank = getattr(visual_gen_mapping, "ulysses_rank", 0)
+
+        # Capture the originals so the wrapped forward can call into them.
+        # Reuse the model's internals; we only inject slice + all_gather around
+        # the existing block loop.
+        from types import MethodType
+
+        # `_wan_ulysses_forward` is bound to the model below; closes over
+        # `ulysses_size` and `ulysses_rank` as Python constants so torch.export
+        # bakes them into the captured graph.
+        def _wan_ulysses_forward(
+            self,
+            hidden_states,
+            timestep,
+            encoder_hidden_states,
+            return_dict: bool = False,
+            attention_kwargs=None,
+        ):
+            from diffusers.models.modeling_outputs import Transformer2DModelOutput
+
+            batch_size, _C, num_frames, height, width = hidden_states.shape
+            p_t, p_h, p_w = self.config.patch_size
+            post_patch_num_frames = num_frames // p_t
+            post_patch_height = height // p_h
+            post_patch_width = width // p_w
+
+            rotary_emb = self.rope(hidden_states)
+            hidden_states = self.patch_embedding(hidden_states)
+            hidden_states = hidden_states.flatten(2).transpose(1, 2)
+            # hidden_states: (B, S, inner_dim) — full sequence on every rank.
+
+            # --- Ulysses shard along the flat sequence (handwritten WAN pattern) ---
+            P = ulysses_size
+            R = ulysses_rank
+            S = hidden_states.shape[1]
+            # S must be divisible by P; choose resolutions that satisfy this
+            # (for p06 @ 81×720×1280 with patch (1,2,2) → S = 21×45×80 = 75600,
+            # divisible by 2/4/6/...).
+            chunk = S // P
+            hidden_states = hidden_states[:, R * chunk : (R + 1) * chunk, :].contiguous()
+
+            if isinstance(rotary_emb, (tuple, list)):
+                rotary_emb = tuple(
+                    (
+                        t[:, R * chunk : (R + 1) * chunk].contiguous()
+                        if isinstance(t, torch.Tensor)
+                        else t
+                    )
+                    for t in rotary_emb
+                )
+            elif isinstance(rotary_emb, torch.Tensor):
+                rotary_emb = rotary_emb[:, R * chunk : (R + 1) * chunk].contiguous()
+            # ----------------------------------------------------------------
+
+            temb, timestep_proj, encoder_hidden_states, encoder_hidden_states_image = (
+                self.condition_embedder(
+                    timestep, encoder_hidden_states, None, timestep_seq_len=None
+                )
+            )
+            timestep_proj = timestep_proj.unflatten(1, (6, -1))
+
+            for block in self.blocks:
+                hidden_states = block(
+                    hidden_states, encoder_hidden_states, timestep_proj, rotary_emb
+                )
+
+            # --- Gather sequence back to full S before output projection ----
+            hidden_states = torch.ops.visgen_auto.all_gather_seq(hidden_states, 1, ulysses_size)
+            # ----------------------------------------------------------------
+
+            shift, scale = (self.scale_shift_table.to(temb.device) + temb.unsqueeze(1)).chunk(
+                2, dim=1
+            )
+            shift = shift.to(hidden_states.device)
+            scale = scale.to(hidden_states.device)
+            hidden_states = (self.norm_out(hidden_states.float()) * (1 + scale) + shift).type_as(
+                hidden_states
+            )
+            hidden_states = self.proj_out(hidden_states)
+
+            hidden_states = hidden_states.reshape(
+                batch_size,
+                post_patch_num_frames,
+                post_patch_height,
+                post_patch_width,
+                p_t,
+                p_h,
+                p_w,
+                -1,
+            )
+            hidden_states = hidden_states.permute(0, 7, 1, 4, 2, 5, 3, 6)
+            output = hidden_states.flatten(6, 7).flatten(4, 5).flatten(2, 3)
+
+            if not return_dict:
+                return (output,)
+            return Transformer2DModelOutput(sample=output)
+
+        model.forward = MethodType(_wan_ulysses_forward, model)

--- a/tensorrt_llm/_torch/visual_gen/auto/fusion.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/fusion.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""DiT-specific FX fusion passes for the auto path.
+
+QKV-GEMM fusion: any group of ``aten.linear`` calls that share the same
+input gets merged into one fused linear + ``torch.narrow`` slices. In a
+Diffusers Flux attention block this turns 3 separate Q/K/V projections
+into 1 fused projection (the same shape the handwritten ``qkv_proj``
+gives), which is the dominant per-block perf term.
+
+The implementation mirrors AutoDeploy's `_insert_fused_gemm` shape but
+lives outside the AD ``BaseTransform`` scaffolding so we don't have to
+stub ``ModelFactory`` / ``CachedSequenceInterface`` just to call one
+graph rewrite.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+import torch
+import torch.fx as fx
+import torch.nn as nn
+
+from tensorrt_llm.logger import logger
+
+
+def _fuse_same_input_linears(gm: fx.GraphModule) -> int:
+    """Fuse ``aten.linear`` calls that share the same input activation.
+
+    Pattern (per attention site, captured from Diffusers Flux):
+        x = ... (normed hidden state)
+        q = linear(x, W_q [, b_q])    # (B, S, num_heads * head_dim)
+        k = linear(x, W_k [, b_k])
+        v = linear(x, W_v [, b_v])
+
+    Rewrite:
+        W_qkv = concat([W_q, W_k, W_v], dim=0)              # baked at fusion time
+        b_qkv = concat([b_q, b_k, b_v], dim=0) if present
+        qkv   = linear(x, W_qkv [, b_qkv])
+        q = narrow(qkv, -1, 0, out_q)
+        k = narrow(qkv, -1, out_q, out_k)
+        v = narrow(qkv, -1, out_q + out_k, out_v)
+
+    The fused weight and bias are registered as new parameters on `gm` so
+    the cost is paid once at rewrite time, not on every forward.
+
+    Returns the number of fused groups (one per attention-projection site).
+    """
+    g = gm.graph
+
+    # Group linears by their input activation node.
+    by_input: dict[fx.Node, list[fx.Node]] = defaultdict(list)
+    for n in g.nodes:
+        if n.op != "call_function" or n.target is not torch.ops.aten.linear.default:
+            continue
+        if len(n.args) < 2:
+            continue
+        by_input[n.args[0]].append(n)
+
+    n_fused_groups = 0
+    fused_idx = 0
+
+    for input_node, linears in by_input.items():
+        if len(linears) < 2:
+            continue
+
+        # All weights/biases must be addressable via get_attr (i.e., come from
+        # gm.named_parameters), and the bias state must be consistent across
+        # the group. Mixed bias/no-bias groups are skipped to keep the pass safe.
+        weight_nodes: list[fx.Node] = []
+        bias_nodes: list[fx.Node | None] = []
+        skip = False
+        for ln in linears:
+            w = ln.args[1] if len(ln.args) > 1 else None
+            b = ln.args[2] if len(ln.args) > 2 else None
+            if not isinstance(w, fx.Node) or w.op != "get_attr":
+                skip = True
+                break
+            if b is not None and (not isinstance(b, fx.Node) or b.op != "get_attr"):
+                skip = True
+                break
+            weight_nodes.append(w)
+            bias_nodes.append(b)
+        if skip:
+            continue
+        if not (all(b is None for b in bias_nodes) or all(b is not None for b in bias_nodes)):
+            continue
+
+        try:
+            weights = [gm.get_parameter(w.target) for w in weight_nodes]
+        except AttributeError:
+            continue
+
+        dtypes = {w.dtype for w in weights}
+        if len(dtypes) != 1:
+            logger.debug(
+                f"VisGen-Auto fusion: skipping mixed-dtype group on {input_node.name}: {dtypes}"
+            )
+            continue
+        in_features = {w.shape[1] for w in weights}
+        if len(in_features) != 1:
+            logger.debug(
+                f"VisGen-Auto fusion: skipping mixed in_features group on {input_node.name}: "
+                f"{in_features}"
+            )
+            continue
+
+        out_sizes = [int(w.shape[0]) for w in weights]
+        fused_weight = torch.cat(weights, dim=0).contiguous()
+        fused_w_name = f"_visgen_auto_fused_w_{fused_idx}"
+        gm.register_parameter(fused_w_name, nn.Parameter(fused_weight, requires_grad=False))
+
+        fused_b_name: str | None = None
+        if bias_nodes[0] is not None:
+            biases = [gm.get_parameter(b.target) for b in bias_nodes]
+            fused_bias = torch.cat(biases, dim=0).contiguous()
+            fused_b_name = f"_visgen_auto_fused_b_{fused_idx}"
+            gm.register_parameter(fused_b_name, nn.Parameter(fused_bias, requires_grad=False))
+
+        first = linears[0]
+        with g.inserting_before(first):
+            w_node = g.get_attr(fused_w_name)
+            b_node = g.get_attr(fused_b_name) if fused_b_name else None
+            fused_args = (
+                (input_node, w_node, b_node) if b_node is not None else (input_node, w_node)
+            )
+            fused_linear = g.call_function(
+                torch.ops.aten.linear.default,
+                args=fused_args,
+            )
+            offset = 0
+            for orig, size in zip(linears, out_sizes):
+                narrow_node = g.call_function(
+                    torch.narrow,
+                    args=(fused_linear, -1, offset, size),
+                )
+                orig.replace_all_uses_with(narrow_node)
+                offset += size
+
+        for orig in linears:
+            g.erase_node(orig)
+
+        n_fused_groups += 1
+        fused_idx += 1
+
+    if n_fused_groups > 0:
+        g.lint()
+        gm.recompile()
+
+    logger.info(f"VisGen-Auto fusion: same-input-linear groups fused = {n_fused_groups}")
+    return n_fused_groups

--- a/tensorrt_llm/_torch/visual_gen/auto/ops.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/ops.py
@@ -1,0 +1,392 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Custom ops for the auto path.
+
+`torch.ops.visgen_auto.sdpa` is the lowering target the SDPA pattern matcher
+in `rewrite.py` points at. The op is intentionally narrower than
+`F.scaled_dot_product_attention`:
+
+- Non-causal only (no `is_causal` parameter).
+- No KV cache (no cache id, no `n_rep`).
+- No attention mask.
+- No dropout.
+
+This matches the diffusers DiT invariant. The body dispatches to whichever
+visual-gen attention backend the rewriter selected (the `backend` kwarg on
+the FX node, threaded through from `RewritePolicy.attention_backend`).
+
+**Backend-generic dispatcher.** Backend construction goes through visual_gen's
+own factory (`attention_backend/utils.py:get_visual_gen_attention_backend`),
+so any class that implements the `AttentionBackend` ABC and registers in
+that factory is reachable from the auto path without code changes here.
+Layout selection reads `backend.preferred_layout` (HND vs NHD) instead of
+hard-coding per backend name. Future parallel backends (Ulysses, Ring, Star,
+Attention2D) plug in via the same path — they just need to declare a
+`preferred_layout` and implement `forward(q, k, v, **kwargs)`.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import torch
+import torch.library
+import torch.nn.functional as F
+
+_BACKEND_CACHE: dict[tuple, object] = {}
+
+# Process-wide current `VisualGenMapping`. Set by `AutoDiffusersPipeline.__init__`
+# when multi-GPU is requested. Read inside `_get_backend` to decide whether to
+# wrap an inner backend with `UlyssesAttention`. Mapping objects can't be passed
+# through FX node kwargs (process groups aren't serializable), so we route via a
+# module-level slot — analogous to how the handwritten path reads
+# `model_config.visual_gen_mapping` at construction time.
+_CURRENT_MAPPING = None
+
+
+def set_current_mapping(mapping) -> None:
+    """Register the active VisualGenMapping for backend construction."""
+    global _CURRENT_MAPPING
+    _CURRENT_MAPPING = mapping
+    # Mapping changed → invalidate cached backends so the next `_get_backend`
+    # constructs with the new ulysses_size / process_group.
+    _BACKEND_CACHE.clear()
+
+
+def get_current_mapping():
+    return _CURRENT_MAPPING
+
+
+def _get_backend(name: str, num_heads: int, head_dim: int, dtype: torch.dtype):
+    """Construct (and cache) a visual_gen `AttentionBackend` for `name`.
+
+    Uses `attention_backend/utils.py:get_visual_gen_attention_backend` so any
+    backend registered in that factory (current: VANILLA, TRTLLM, FA4; future:
+    Ulysses, Ring, Star, Attention2D, ...) is reachable without per-backend
+    branches here.
+
+    When a multi-GPU `VisualGenMapping` is active and `ulysses_size > 1`, the
+    inner backend is constructed with `num_heads // ulysses_size` (Ulysses
+    shards heads across the inner backend) and wrapped with
+    `UlyssesAttention(inner, vgm.ulysses_group)`. The wrapper handles the
+    sequence ↔ head all-to-all on each forward call.
+    """
+    vgm = _CURRENT_MAPPING
+    ulysses_size = getattr(vgm, "ulysses_size", 1) if vgm is not None else 1
+
+    key = (name, num_heads, head_dim, dtype, ulysses_size)
+    cached = _BACKEND_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    from ..attention_backend.utils import get_visual_gen_attention_backend
+
+    # Inner backend's head count is sharded across the Ulysses dim. When
+    # ulysses_size == 1 the math collapses to the plain single-GPU path.
+    inner_num_heads = num_heads // ulysses_size
+
+    cls = get_visual_gen_attention_backend(name)
+    init_kwargs = dict(
+        layer_idx=0,
+        num_heads=inner_num_heads,
+        head_dim=head_dim,
+        dtype=dtype,
+    )
+    # TRTLLM mandates `attention_metadata_state` at construction (it raises
+    # otherwise). Provide a fresh per-site state — populated lazily on first
+    # forward. Other backends ignore the extra kwarg via their `**kwargs`.
+    init_kwargs["attention_metadata_state"] = {"metadata": None, "capacity": (0, 0)}
+
+    backend = cls(**init_kwargs)
+
+    # Wrap with Ulysses sequence parallelism if requested. Composes around the
+    # inner backend — UlyssesAttention's `preferred_layout` is NHD; the
+    # dispatcher's input/output normalization in `_dispatch_attention` reads
+    # `.preferred_layout` after the wrap, so layout handling stays uniform.
+    if ulysses_size > 1:
+        from ..attention_backend.parallel import UlyssesAttention
+
+        backend = UlyssesAttention(
+            inner_backend=backend,
+            process_group=vgm.ulysses_group,
+        )
+
+    _BACKEND_CACHE[key] = backend
+    return backend
+
+
+def _dispatch_attention(
+    backend_obj, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+) -> torch.Tensor:
+    """Call `backend_obj.forward(q, k, v)` and normalize input/output to HND.
+
+    The captured graph hands us HND `(B, H, S, D)` — what
+    `F.scaled_dot_product_attention` receives from a Diffusers DiT block.
+    Different backends prefer different layouts; we drive the conversion from
+    `backend.preferred_layout` so no branches per backend name are needed.
+
+    Output normalization: most backends return their preferred layout (4D),
+    but TRTLLM returns flattened `(B, S, H*D)` (3D). Detect and reshape.
+    """
+    from ..attention_backend.interface import AttentionTensorLayout
+
+    layout = backend_obj.preferred_layout
+    B, H, S_q, D = q.shape
+    S_kv = k.shape[2]
+
+    if layout == AttentionTensorLayout.NHD:
+        q_in = q.transpose(1, 2).contiguous()  # (B, S_q, H, D)
+        k_in = k.transpose(1, 2).contiguous()
+        v_in = v.transpose(1, 2).contiguous()
+        # TRTLLM consumes batch_size / seq_len kwargs; other backends accept
+        # them via the ABC's `**kwargs` and ignore. See `AttentionBackend`
+        # docstring in `attention_backend/interface.py`.
+        out = backend_obj.forward(
+            q_in,
+            k_in,
+            v_in,
+            batch_size=B,
+            seq_len=S_q,
+            seq_len_kv=S_kv,
+        )
+        if out.dim() == 3:  # TRTLLM returns (B, S, H*D)
+            out = out.reshape(B, S_q, H, D)
+        return out.transpose(1, 2).contiguous()  # → HND
+    # HND-preferring backend (VANILLA today) — no conversion needed.
+    return backend_obj.forward(q, k, v)
+
+
+@torch.library.custom_op("visgen_auto::sdpa", mutates_args=())
+def visgen_auto_sdpa(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: Optional[float] = None,
+    backend: str = "VANILLA",
+) -> torch.Tensor:
+    """Non-causal, cacheless joint MM-DiT attention.
+
+    Tensors are in `[B, H, S, D]` (HND) layout — what `F.scaled_dot_product_attention`
+    receives from a Diffusers DiT attention block.
+
+    Args:
+        q: `(B, H, S_q, D)` query.
+        k: `(B, H_kv, S_kv, D)` key.
+        v: `(B, H_kv, S_kv, D)` value.
+        scale: explicit softmax scale; `None` falls back to `1/sqrt(D)`.
+        backend: one of `"VANILLA"`, `"TRTLLM"`, `"FA4"`. Currently only
+            VANILLA is wired; the others log a warning and fall back.
+
+    Returns:
+        `(B, H, S_q, D)` attention output.
+    """
+    # VanillaAttention bakes scale = 1/sqrt(head_dim) into the instance.
+    # If the caller passes a non-default scale, route through F.SDPA directly
+    # — preserves correctness while keeping the common path fast.
+    if scale is not None and not math.isclose(scale, 1.0 / math.sqrt(q.shape[-1])):
+        return F.scaled_dot_product_attention(q, k, v, scale=scale)
+
+    be = _get_backend(backend, num_heads=q.shape[1], head_dim=q.shape[-1], dtype=q.dtype)
+    return _dispatch_attention(be, q, k, v)
+
+
+@visgen_auto_sdpa.register_fake
+def _visgen_auto_sdpa_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    scale: Optional[float] = None,
+    backend: str = "VANILLA",
+) -> torch.Tensor:
+    return torch.empty_like(q)
+
+
+@torch.library.custom_op("visgen_auto::dit_qk_norm_rope", mutates_args=())
+def visgen_auto_dit_qk_norm_rope(
+    qkv: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    norm_q_weight: torch.Tensor,
+    norm_k_weight: torch.Tensor,
+    num_heads_q: int,
+    num_heads_k: int,
+    num_heads_v: int,
+    head_dim: int,
+    eps: float,
+    interleave: bool,
+    norm_q_add_weight: Optional[torch.Tensor] = None,
+    norm_k_add_weight: Optional[torch.Tensor] = None,
+    num_txt_tokens: int = -1,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Single-stream per-head RMSNorm on Q/K + RoPE on Q/K, packed QKV in.
+
+    Wraps `torch.ops.trtllm.fused_dit_qk_norm_rope`, which does the math
+    in-register with FP32 cos/sin — equivalent to handwritten Flux's
+    `fusedDiTQKNormRopeKernel` path. The pattern matcher in
+    The QK-rope fusion pattern matchers in `auto/qk_rope_fusion.py` target this op as the
+    lowering site.
+
+    Args:
+        qkv: packed QKV ``(B, S, (H_q + H_k + H_v) * D)`` in BF16 — comes
+            directly from the QKV-fused linear output. Will be cloned
+            internally; caller's tensor is not mutated.
+        cos: cosine table ``(S, D)`` or any shape reshapeable to that,
+            FP32 inside the kernel (cast if needed).
+        sin: sine table, same shape as ``cos``.
+        norm_q_weight: ``(D,)`` per-head RMSNorm weight for Q.
+        norm_k_weight: ``(D,)`` per-head RMSNorm weight for K.
+        num_heads_q, num_heads_k, num_heads_v: head counts.
+        head_dim: per-head dimension D.
+        eps: RMSNorm epsilon.
+        interleave: True for Flux-style adjacent-pair rotation
+            (`x.reshape(..., D//2, 2).unbind(-1)`), False for rotate-half.
+
+    Returns:
+        ``(Q, K, V)`` each shaped ``(B, H, S, D)``, ready for SDPA.
+    """
+    B, S, total_dim = qkv.shape
+    expected_total = (num_heads_q + num_heads_k + num_heads_v) * head_dim
+    assert total_dim == expected_total, (
+        f"QKV total dim {total_dim} != expected "
+        f"({num_heads_q} + {num_heads_k} + {num_heads_v}) * {head_dim} = {expected_total}"
+    )
+
+    # Clone for in-place safety: callers may still hold references to the
+    # original QKV (e.g., the FX node feeding this op has other uses).
+    qkv_2d = qkv.reshape(B * S, total_dim).contiguous().clone()
+
+    cos_2d = cos.reshape(-1, head_dim).float().contiguous()
+    sin_2d = sin.reshape(-1, head_dim).float().contiguous()
+    assert cos_2d.shape[0] == S, f"cos seq dim {cos_2d.shape[0]} != S {S}"
+    assert sin_2d.shape == cos_2d.shape, "sin/cos shape mismatch"
+
+    cos_tiled = cos_2d.repeat(B, 1) if B > 1 else cos_2d
+    sin_tiled = sin_2d.repeat(B, 1) if B > 1 else sin_2d
+
+    # Dual-stream: when num_txt_tokens > 0, the kernel uses different norm
+    # weights for the first `num_txt_tokens` tokens (encoder side, from
+    # `*_add_weight`) versus the rest (hidden side, from `*_weight`).
+    # tokens_per_batch tells the kernel the per-batch seq length so it can
+    # find the encoder/hidden boundary within each batch via modulo.
+    tokens_per_batch = S if num_txt_tokens > 0 else 0
+    q_add = norm_q_add_weight.contiguous() if norm_q_add_weight is not None else None
+    k_add = norm_k_add_weight.contiguous() if norm_k_add_weight is not None else None
+
+    torch.ops.trtllm.fused_dit_qk_norm_rope(
+        qkv_2d,
+        num_heads_q,
+        num_heads_k,
+        num_heads_v,
+        head_dim,
+        eps,
+        norm_q_weight.contiguous(),
+        norm_k_weight.contiguous(),
+        q_add,
+        k_add,
+        cos_tiled,
+        sin_tiled,
+        num_txt_tokens,
+        interleave,
+        tokens_per_batch,
+    )
+
+    q_dim = num_heads_q * head_dim
+    k_dim = num_heads_k * head_dim
+
+    qkv_3d = qkv_2d.reshape(B, S, total_dim)
+    q = qkv_3d[..., :q_dim].reshape(B, S, num_heads_q, head_dim).transpose(1, 2).contiguous()
+    k = (
+        qkv_3d[..., q_dim : q_dim + k_dim]
+        .reshape(B, S, num_heads_k, head_dim)
+        .transpose(1, 2)
+        .contiguous()
+    )
+    v = (
+        qkv_3d[..., q_dim + k_dim :]
+        .reshape(B, S, num_heads_v, head_dim)
+        .transpose(1, 2)
+        .contiguous()
+    )
+    return q, k, v
+
+
+@visgen_auto_dit_qk_norm_rope.register_fake
+def _visgen_auto_dit_qk_norm_rope_fake(
+    qkv: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    norm_q_weight: torch.Tensor,
+    norm_k_weight: torch.Tensor,
+    num_heads_q: int,
+    num_heads_k: int,
+    num_heads_v: int,
+    head_dim: int,
+    eps: float,
+    interleave: bool,
+    norm_q_add_weight: Optional[torch.Tensor] = None,
+    norm_k_add_weight: Optional[torch.Tensor] = None,
+    num_txt_tokens: int = -1,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    B, S, _ = qkv.shape
+    q = qkv.new_empty(B, num_heads_q, S, head_dim)
+    k = qkv.new_empty(B, num_heads_k, S, head_dim)
+    v = qkv.new_empty(B, num_heads_v, S, head_dim)
+    return q, k, v
+
+
+@torch.library.custom_op("visgen_auto::all_gather_seq", mutates_args=())
+def visgen_auto_all_gather_seq(
+    x: torch.Tensor, dim: int = 1, ulysses_size: int = 1
+) -> torch.Tensor:
+    """All-gather a sequence-sharded tensor along `dim` across the current
+    Ulysses process group.
+
+    `ulysses_size` is an explicit kwarg (not derived from a global) so the
+    `register_fake` meta below is deterministic over its args — Inductor's
+    stride propagation relies on this when the captured graph is later
+    re-traced under `torch.compile`. Earlier versions read `ulysses_size`
+    from `_CURRENT_MAPPING`; if the global changed between capture and
+    Inductor re-trace, codegen produced buggy strides. The runtime group
+    is still resolved from `_CURRENT_MAPPING.ulysses_group` (a process
+    handle is not a constexpr).
+
+    `pre_capture_patch` in each family closes over `ulysses_size` as a
+    Python int and passes it here, so the value gets baked into the
+    captured FX graph as a literal node arg.
+
+    Single-rank fast path (`ulysses_size == 1`) is a no-op clone so the
+    op is safe to use without distributed init.
+
+    `dim` defaults to 1 (WAN/SD3 callers); LTX-2's split-mode RoPE tensors
+    have seq at dim 2.
+    """
+    if ulysses_size == 1:
+        return x.clone()
+
+    vgm = _CURRENT_MAPPING
+    if vgm is None or getattr(vgm, "ulysses_group", None) is None:
+        raise RuntimeError(
+            "visgen_auto.all_gather_seq called with ulysses_size > 1 but no "
+            "VisualGenMapping is active (or it has no ulysses_group). Call "
+            "`auto.ops.set_current_mapping(vgm)` before running the captured "
+            "graph."
+        )
+
+    import torch.distributed as dist
+
+    x = x.contiguous()
+    gathered = [torch.empty_like(x) for _ in range(ulysses_size)]
+    dist.all_gather(gathered, x, group=vgm.ulysses_group)
+    return torch.cat(gathered, dim=dim)
+
+
+@visgen_auto_all_gather_seq.register_fake
+def _visgen_auto_all_gather_seq_fake(
+    x: torch.Tensor, dim: int = 1, ulysses_size: int = 1
+) -> torch.Tensor:
+    # Deterministic over args — no global lookup. Inductor uses this fake
+    # meta for stride propagation across torch.compile re-traces.
+    out_shape = list(x.shape)
+    out_shape[dim] = out_shape[dim] * ulysses_size
+    return x.new_empty(out_shape)

--- a/tensorrt_llm/_torch/visual_gen/auto/pass_manager.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/pass_manager.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Minimal ordered pass pipeline for the visgen-auto FX rewrites.
+
+Designed to be deliberately small — the visgen-auto path has 5-6 passes with
+one canonical ordering; the value of a full pass-manager framework
+(`BaseTransform`, registry, fixpoint loop, dependency graph, per-pass
+serialization) doesn't pay for itself at this scale. What this module
+provides is the *one* feature that's hard to add later: a stable composition
+surface for family adapters that need to splice in family-specific passes.
+
+Contract:
+
+* A pass is `Pass(name, fn)` where `fn(gm) -> Any`. Return value is logged
+  but not interpreted (counts vary across passes — some return the number
+  of rewrites, some return a `GraphModule`, some return None).
+* The manager is ordered. No registry, no priorities, no implicit ordering
+  by name. The order is the order passes appear in the list.
+* No fixpoint. Each pass runs exactly once per `run()` call. Today's passes
+  are independent — A doesn't create patterns B can re-rewrite.
+* Composition: `append`, `insert_before`, `insert_after`, `replace`,
+  `remove`. All mutate in place + return self for chaining.
+
+When a family adapter wants to slot in a custom pass, it overrides
+`VisGenFamilyAdapter.customize_passes(pm)` on the way through `apply_rewrites`.
+That's the only public extension point.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List
+
+import torch.fx as fx
+
+from tensorrt_llm.logger import logger
+
+
+@dataclass(frozen=True)
+class Pass:
+    """One FX rewrite, applied once in pipeline order.
+
+    `fn(gm)` may return an int (#nodes rewritten), the (mutated) GraphModule,
+    or `None` — the manager doesn't interpret it, only logs it.
+    """
+
+    name: str
+    fn: Callable[[fx.GraphModule], Any]
+
+
+class PassManager:
+    """Ordered list of passes with insert/replace/remove primitives."""
+
+    def __init__(self, passes: Iterable[Pass] = ()) -> None:
+        self._passes: List[Pass] = list(passes)
+
+    # ------------------------------------------------------------------
+    # Inspection
+    # ------------------------------------------------------------------
+
+    def names(self) -> List[str]:
+        return [p.name for p in self._passes]
+
+    def __contains__(self, name: str) -> bool:
+        return any(p.name == name for p in self._passes)
+
+    def __len__(self) -> int:
+        return len(self._passes)
+
+    def _index(self, name: str) -> int:
+        for i, p in enumerate(self._passes):
+            if p.name == name:
+                return i
+        raise KeyError(f"PassManager: no pass named {name!r} (have {self.names()})")
+
+    # ------------------------------------------------------------------
+    # Composition primitives (each returns self for chaining)
+    # ------------------------------------------------------------------
+
+    def append(self, p: Pass) -> "PassManager":
+        if p.name in self:
+            raise ValueError(f"PassManager: pass {p.name!r} already present")
+        self._passes.append(p)
+        return self
+
+    def insert_before(self, anchor: str, p: Pass) -> "PassManager":
+        if p.name in self:
+            raise ValueError(f"PassManager: pass {p.name!r} already present")
+        self._passes.insert(self._index(anchor), p)
+        return self
+
+    def insert_after(self, anchor: str, p: Pass) -> "PassManager":
+        if p.name in self:
+            raise ValueError(f"PassManager: pass {p.name!r} already present")
+        self._passes.insert(self._index(anchor) + 1, p)
+        return self
+
+    def replace(self, name: str, p: Pass) -> "PassManager":
+        # Allow same-name replacement; bypass the "already present" check.
+        i = self._index(name)
+        self._passes[i] = p
+        return self
+
+    def remove(self, name: str) -> "PassManager":
+        del self._passes[self._index(name)]
+        return self
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+
+    def run(
+        self,
+        gm: fx.GraphModule,
+        *,
+        skip: Iterable[str] = (),
+    ) -> Dict[str, Any]:
+        """Run each pass in order, logging name + wall-time + return value.
+
+        Returns a `{pass_name: return_value}` dict. Exceptions propagate
+        (one bad pass aborts the pipeline — debugging a partial rewrite is
+        worse than a clean failure).
+        """
+        skip_set = set(skip)
+        results: Dict[str, Any] = {}
+        for p in self._passes:
+            if p.name in skip_set:
+                logger.info(f"VisGen-Auto PassManager: skip {p.name!r}")
+                continue
+            t0 = time.perf_counter()
+            try:
+                rv = p.fn(gm)
+            except Exception:
+                dt_ms = 1000.0 * (time.perf_counter() - t0)
+                logger.error(f"VisGen-Auto PassManager: pass {p.name!r} raised after {dt_ms:.1f}ms")
+                raise
+            dt_ms = 1000.0 * (time.perf_counter() - t0)
+            results[p.name] = rv
+            logger.info(f"VisGen-Auto PassManager: {p.name} → {rv!r} in {dt_ms:.1f}ms")
+        return results

--- a/tensorrt_llm/_torch/visual_gen/auto/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/pipeline.py
@@ -1,0 +1,404 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""AutoTransformerPipeline — standalone Visual Gen pipeline for the auto path.
+
+Not a `BasePipeline` subclass. The handwritten path's `BasePipeline` makes
+strong assumptions about the load lifecycle (`MetaInitMode` wrap →
+`_materialize_meta_tensors` → `load_transformer_weights` →
+`load_standard_components` → ...) that don't apply to the auto path:
+Diffusers' `DiffusionPipeline.from_pretrained` loads weights and standard
+components eagerly in one call, and that call must run outside any
+meta-tensor dispatch.
+
+Rather than subclass `BasePipeline` and silently no-op the lifecycle hooks
+(which led to a "subclass-as-marker" anti-pattern flagged in code review),
+this class stands on its own and exposes only the surface the executor and
+loader actually consume:
+
+* ``infer(req: DiffusionRequest) → MediaOutput`` — executor entry point
+* ``warmup()`` / ``warmup_cache_key`` / ``_warmed_up_shapes`` — warmup contract
+* ``default_generation_params`` / ``extra_param_specs`` — executor defaulting
+* ``mapping`` / ``model_config`` / ``transformer`` / ``vae`` / ... — view-only
+
+The loader (`pipeline_loader.py`) detects this class via ``isinstance`` and
+branches around the handwritten-only hooks. Construction is invoked from
+``pipeline_loader.PipelineLoader._create_pipeline`` under
+``pipeline_mode in {"auto", "fallback-and-unregistered"}``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+
+from tensorrt_llm.logger import logger
+from tensorrt_llm.mapping import Mapping
+
+from ..output import MediaOutput
+
+if TYPE_CHECKING:
+    from ..config import DiffusionModelConfig
+    from ..executor import DiffusionRequest
+
+
+# Family-name → default warmup shapes / frame counts. Used when the user
+# didn't pin `model_config.compilation.resolutions`/`num_frames`. Tokens are
+# matched against `type(diffusers_pipe).__name__`.
+_DEFAULT_RES_BY_FAMILY: Tuple[Tuple[str, List[Tuple[int, int]]], ...] = (
+    ("Wan", [(720, 1280)]),
+    ("LTX2", [(512, 768)]),
+    ("LTX", [(512, 704)]),
+    ("Flux2", [(1024, 1024)]),
+    ("Flux", [(1024, 1024)]),
+    ("PixArt", [(1024, 1024)]),
+    ("Sana", [(1024, 1024)]),
+    ("StableDiffusion3", [(1024, 1024)]),
+)
+
+_DEFAULT_FRAMES_BY_FAMILY: Tuple[Tuple[str, List[int]], ...] = (
+    ("Wan", [81]),
+    ("LTX2", [121]),
+    ("LTX", [33]),
+)
+
+
+def _match_family(name: str, table: Tuple[Tuple[str, Any], ...], default: Any) -> Any:
+    for tok, value in table:
+        if tok in name:
+            return value
+    return default
+
+
+class AutoTransformerPipeline(nn.Module):
+    """Standalone pipeline for the auto path. NOT a `BasePipeline` subclass —
+    see module docstring for why.
+
+    All heavy lifting (Diffusers load + capture + rewrite + compile) happens
+    in `__init__`. There is no separate "load weights" / "load standard
+    components" phase: by the time `__init__` returns, the pipeline is ready
+    to serve `warmup()` and `infer(req)`.
+    """
+
+    def __init__(
+        self,
+        model_config: "DiffusionModelConfig",
+        checkpoint_dir: str,
+    ) -> None:
+        super().__init__()
+        # Surface known divergences vs the handwritten path BEFORE we start
+        # the expensive load — operator sees the warnings even if Diffusers
+        # crashes mid-load.
+        self._warn_silent_divergences(model_config)
+
+        self.model_config = model_config
+        self.config = model_config.pretrained_config
+        self.mapping: Mapping = getattr(model_config, "mapping", None) or Mapping()
+        self._warmed_up_shapes: set = set()
+        self._checkpoint_dir = checkpoint_dir
+        # Components that the executor / introspection code may read.
+        # Populated below from the inner Diffusers pipeline.
+        self.transformer: Optional[nn.Module] = None
+        self.vae: Optional[nn.Module] = None
+        self.text_encoder: Optional[nn.Module] = None
+        self.tokenizer: Optional[Any] = None
+        self.scheduler: Optional[Any] = None
+
+        # Lazy import to keep auto_pipeline.py / pipeline.py / families/* import
+        # cycles tame.
+        from .auto_pipeline import AutoDiffusersPipeline
+
+        compile_cfg = getattr(model_config, "torch_compile", None)
+        enable_compile = bool(getattr(compile_cfg, "enable_torch_compile", False))
+        vgm = getattr(model_config, "visual_gen_mapping", None)
+
+        self._inner: AutoDiffusersPipeline = AutoDiffusersPipeline(
+            checkpoint_dir,
+            model_config,
+            visual_gen_mapping=vgm,
+            enable_torch_compile=enable_compile,
+            # `reduce-overhead` (CUDA graphs) is unsafe when Diffusers
+            # re-allocates the per-step `latents` tensor. See
+            # `auto_pipeline.AutoDiffusersPipeline.__init__` docstring.
+            torch_compile_mode="default",
+        )
+        dpipe = self._inner.diffusers_pipe
+        self._family_name = type(dpipe).__name__
+        self.transformer = self._inner.captured_transformer
+        self.vae = getattr(dpipe, "vae", None)
+        self.text_encoder = getattr(dpipe, "text_encoder", None)
+        self.tokenizer = getattr(dpipe, "tokenizer", None)
+        self.scheduler = getattr(dpipe, "scheduler", None)
+
+    # ------------------------------------------------------------------
+    # Pre-construction divergence warnings
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _warn_silent_divergences(model_config: "DiffusionModelConfig") -> None:
+        """Log warnings for `VisualGenArgs` fields the auto path silently
+        no-ops. Mirrors what the handwritten path supports but auto doesn't.
+
+        Listed here (not in `AutoDiffusersPipeline`) because these are
+        product-level features the operator selects via config; the inner
+        factory is a Diffusers-shaped utility unaware of `VisualGenArgs`.
+        """
+        # Cache acceleration (TeaCache / Cache-DiT). `cache_backend` is
+        # `Optional[Literal["teacache", "cache_dit"]]` — falsy means no
+        # cache backend selected; we don't need a `!= "none"` clause.
+        cache_backend = getattr(model_config, "cache_backend", None)
+        if cache_backend:
+            logger.warning(
+                f"AutoTransformerPipeline: cache_backend={cache_backend!r} is "
+                "a no-op on the auto path "
+                "(transformer wrapper's `cache_context` returns nullcontext)."
+            )
+        # Per-layer quantization.
+        if getattr(model_config, "quant_config_dict", None):
+            logger.warning(
+                "AutoTransformerPipeline: per-layer `quant_config_dict` is not "
+                "wired on the auto path — only the global `quant_config` is "
+                "applied to all Linears."
+            )
+        # Parallel VAE.
+        mapping = getattr(model_config, "mapping", None)
+        ws = getattr(mapping, "world_size", 1) if mapping is not None else 1
+        if getattr(model_config, "enable_parallel_vae", False) and ws > 1:
+            logger.warning(
+                "AutoTransformerPipeline: enable_parallel_vae=True is a no-op "
+                "on the auto path (no `vae_adapter_class` registered)."
+            )
+        # CUDA graphs.
+        cuda_graph_cfg = getattr(model_config, "cuda_graph", None)
+        if cuda_graph_cfg is not None and getattr(cuda_graph_cfg, "enable_cuda_graph", False):
+            logger.warning(
+                "AutoTransformerPipeline: cuda_graph.enable_cuda_graph=True is "
+                "a no-op on the auto path. Use "
+                "`torch_compile.enable_torch_compile=True` instead "
+                "(Inductor codegen, mode='default')."
+            )
+
+    # ------------------------------------------------------------------
+    # Executor / loader duck-typed surface
+    # ------------------------------------------------------------------
+
+    @property
+    def rank(self) -> int:
+        return dist.get_rank() if dist.is_initialized() else 0
+
+    @property
+    def world_size(self) -> int:
+        return dist.get_world_size() if dist.is_initialized() else 1
+
+    @property
+    def dtype(self) -> torch.dtype:
+        if self.transformer is not None:
+            try:
+                return next(self.transformer.parameters()).dtype
+            except StopIteration:
+                pass
+        return torch.float32
+
+    @property
+    def device(self) -> torch.device:
+        return self._inner.device if self._inner is not None else torch.device("cpu")
+
+    @property
+    def default_generation_params(self) -> dict:
+        """Executor consumes this for `_merge_defaults`. The auto path has
+        no opinion — Diffusers pipelines define their own per-call defaults
+        and `infer()` drops `None` fields before calling the pipe.
+        """
+        return {}
+
+    @property
+    def extra_param_specs(self) -> dict:
+        """No model-specific schema-validated extras on the auto path."""
+        return {}
+
+    def warmup_cache_key(self, height: int, width: int, num_frames: int) -> tuple:
+        # Image families' Diffusers `__call__` doesn't take `num_frames`;
+        # video families do.
+        if not self._is_video_family():
+            return (height, width)
+        return (height, width, num_frames)
+
+    # ------------------------------------------------------------------
+    # Warmup
+    # ------------------------------------------------------------------
+
+    @property
+    def default_warmup_resolutions(self) -> List[Tuple[int, int]]:
+        return _match_family(self._family_name, _DEFAULT_RES_BY_FAMILY, [(1024, 1024)])
+
+    @property
+    def default_warmup_num_frames(self) -> List[int]:
+        return _match_family(self._family_name, _DEFAULT_FRAMES_BY_FAMILY, [1])
+
+    @property
+    def default_warmup_steps(self) -> int:
+        return 2
+
+    def _resolve_warmup_plan(self) -> Tuple[List[Tuple[int, int, int]], int]:
+        """Same precedence as `BasePipeline.resolve_warmup_plan`."""
+        warmup_cfg = self.model_config.compilation
+        if warmup_cfg.resolutions is not None or warmup_cfg.num_frames is not None:
+            resolutions = warmup_cfg.resolutions or self.default_warmup_resolutions
+            num_frames_list = warmup_cfg.num_frames or self.default_warmup_num_frames
+        else:
+            resolutions = self.default_warmup_resolutions
+            num_frames_list = self.default_warmup_num_frames
+        import itertools
+
+        shapes = [(h, w, f) for (h, w), f in itertools.product(resolutions, num_frames_list)]
+        return shapes, self.default_warmup_steps
+
+    def warmup(self) -> None:
+        """Run warmup inference to trigger torch.compile + populate
+        `_warmed_up_shapes`. OOM and other failures fast-fail at startup —
+        matches the handwritten `BasePipeline.warmup` contract.
+        """
+        import time
+
+        shapes, steps = self._resolve_warmup_plan()
+        if not shapes:
+            logger.info("Warmup disabled (no warmup shapes)")
+            return
+        logger.info(f"AutoTransformerPipeline warmup: {len(shapes)} shapes, {steps} steps each")
+        t0 = time.time()
+        for h, w, f in shapes:
+            logger.info(f"Warmup: {h}x{w}, {f} frames, {steps} steps")
+            self._run_warmup(h, w, f, steps)
+            torch.cuda.synchronize()
+        self._warmed_up_shapes = {self.warmup_cache_key(h, w, f) for h, w, f in shapes}
+        logger.info(f"Warmup completed in {time.time() - t0:.2f}s")
+
+    def _run_warmup(self, height: int, width: int, num_frames: int, steps: int) -> None:
+        kwargs: Dict[str, Any] = {
+            "prompt": "warmup",
+            "height": height,
+            "width": width,
+            "num_inference_steps": steps,
+        }
+        if self._is_video_family():
+            kwargs["num_frames"] = num_frames
+            kwargs["output_type"] = "pt"
+        self._inner._pipe(**kwargs)
+
+    # ------------------------------------------------------------------
+    # Family classification (used by infer + warmup)
+    # ------------------------------------------------------------------
+
+    def _is_video_family(self) -> bool:
+        return any(tok in self._family_name for tok in ("Wan", "LTX"))
+
+    def _is_audio_visual_family(self) -> bool:
+        return "LTX2" in self._family_name
+
+    def _is_distilled_no_negative(self) -> bool:
+        # FLUX.1 / FLUX.2 (incl. schnell, dev, Kontext, klein) are
+        # guidance-distilled and reject `negative_prompt`. `startswith("Flux")`
+        # subsumes `Flux2` — listed once for clarity.
+        return self._family_name.startswith("Flux")
+
+    # ------------------------------------------------------------------
+    # Executor entry point
+    # ------------------------------------------------------------------
+
+    def infer(self, req: "DiffusionRequest") -> MediaOutput:
+        """Translate a `DiffusionRequest` into Diffusers pipe kwargs, call the
+        pipe, wrap the result as `MediaOutput`.
+        """
+        generator = torch.Generator(device=self.device).manual_seed(req.seed)
+        kwargs: Dict[str, Any] = {
+            "prompt": req.prompt,
+            "height": req.height,
+            "width": req.width,
+            "num_inference_steps": req.num_inference_steps,
+            "guidance_scale": req.guidance_scale,
+            "generator": generator,
+        }
+        if req.negative_prompt and not self._is_distilled_no_negative():
+            kwargs["negative_prompt"] = req.negative_prompt
+        if req.num_frames is not None and self._is_video_family():
+            kwargs["num_frames"] = req.num_frames
+        if req.frame_rate is not None and self._is_audio_visual_family():
+            kwargs["frame_rate"] = req.frame_rate
+        if req.max_sequence_length is not None and any(
+            tok in self._family_name
+            for tok in ("StableDiffusion3", "Flux", "Wan", "PixArt", "LTX", "Sana")
+        ):
+            kwargs["max_sequence_length"] = req.max_sequence_length
+        if req.extra_params:
+            kwargs.update(req.extra_params)
+        # Re-apply the distilled-no-negative guard AFTER extra_params merge —
+        # otherwise a user passing `extra_params={"negative_prompt": ...}` can
+        # smuggle the kwarg back into a FLUX-family call that rejects it.
+        if self._is_distilled_no_negative():
+            kwargs.pop("negative_prompt", None)
+        # Drop None values so Diffusers uses each pipeline's defaults.
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        kwargs["output_type"] = "pt"
+
+        result = self._inner._pipe(**kwargs)
+        return _wrap_diffusers_output(result, self._family_name)
+
+
+# ---------------------------------------------------------------------------
+# Diffusers pipeline output → MediaOutput
+# ---------------------------------------------------------------------------
+
+
+def _to_uint8(x: torch.Tensor) -> torch.Tensor:
+    """Scale [0, 1] float tensor → uint8."""
+    return x.clamp(0, 1).mul(255).round().to(torch.uint8)
+
+
+def _wrap_diffusers_output(result: Any, family_name: str) -> MediaOutput:
+    """Adapt a Diffusers pipeline result (`.images`, `.frames`, `.audio`) to
+    the unified `MediaOutput(image=..., video=..., audio=...)` shape.
+
+    Conventions (matching the handwritten path):
+    - `image`: `(H, W, C)` uint8 — first image of batch.
+    - `video`: `(T, H, W, C)` uint8 — first sample of batch.
+    - `audio`: tensor as-returned by the pipeline.
+    """
+    out = MediaOutput()
+    is_video_family = any(tok in family_name for tok in ("Wan", "LTX"))
+
+    images = getattr(result, "images", None)
+    if images is not None and not is_video_family:
+        # Diffusers image pipelines with `output_type="pt"` return
+        # `(B, C, H, W)` float in [0, 1].
+        if isinstance(images, torch.Tensor) and images.dim() == 4:
+            out.image = _to_uint8(images[0]).permute(1, 2, 0).contiguous()
+        return out
+
+    frames = getattr(result, "frames", None)
+    if frames is not None:
+        # WAN: `(B, T, H, W, C)`; LTX-Video / LTX-2: `(B, T, C, H, W)`.
+        # Use the family hint instead of shape-sniffing to avoid the
+        # degenerate `(T, H, W, C=3)` ↔ `(T, C=3, H, W)` ambiguity.
+        if isinstance(frames, torch.Tensor):
+            vid = frames[0] if frames.dim() == 5 else frames
+            if isinstance(vid, torch.Tensor) and vid.dim() == 4:
+                if "Wan" in family_name:
+                    # Already (T, H, W, C).
+                    out.video = _to_uint8(vid).contiguous()
+                else:
+                    # LTX family: (T, C, H, W) → permute to (T, H, W, C).
+                    out.video = _to_uint8(vid).permute(0, 2, 3, 1).contiguous()
+        elif isinstance(frames, (list, tuple)) and frames:
+            first = frames[0]
+            if isinstance(first, torch.Tensor) and first.dim() == 4:
+                vid = first
+                if "LTX" in family_name:
+                    vid = vid.permute(0, 2, 3, 1)
+                out.video = _to_uint8(vid).contiguous()
+
+    audio = getattr(result, "audio", None)
+    if audio is not None and isinstance(audio, torch.Tensor):
+        out.audio = audio
+    return out

--- a/tensorrt_llm/_torch/visual_gen/auto/policy.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/policy.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Rewrite policy for the auto path.
+
+A `RewritePolicy` is what a `VisGenFamilyAdapter` returns to declare which
+fusions/lowerings the rewrite pipeline should run on the captured FX graph.
+The full set of toggles will grow as rewrites land; for the S1 skeleton we
+keep only what dispatch needs to identify a policy object exists.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+from pydantic import Field as PydanticField
+
+
+class RewritePolicy(BaseModel):
+    """Per-family declarations for the FX rewrite pipeline.
+
+    Today the matchers wire `attention_backend` because the family adapter and
+    pipeline shell need to know which backend to bind. Other toggles are
+    placeholders that will gain rewrite-pass meaning in later stages.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    attention_backend: str = PydanticField(
+        "TRTLLM",
+        description=(
+            "Name of the visual_gen attention backend to lower SDPA to. "
+            "Any string registered in `attention_backend/utils.py:get_visual_gen_attention_backend` "
+            "is accepted — VANILLA, TRTLLM, FA4 today; future Ulysses / Ring / "
+            "Star / Attention2D backends become reachable here without "
+            "auto-path code changes."
+        ),
+    )
+    fuse_qkv: bool = PydanticField(
+        True,
+        description="Run same-input GEMM fusion on the QKV projection.",
+    )
+    fuse_qk_rope: bool = PydanticField(
+        True,
+        description=(
+            "Lower the (QK-RMSNorm + RoPE) cluster to TRT-LLM's "
+            "`fused_dit_qk_norm_rope` kernel (single + dual-stream sites). "
+            "Default True. Disable for exact-match parity vs Diffusers eager "
+            "(the kernel has sub-BF16-ULP precision differences that compound "
+            "over multi-step inference; perceptually invisible but breaks "
+            "pixel-equality tests). Env var `VISGEN_AUTO_DISABLE_QKROPE=1` "
+            "overrides this to False without code changes."
+        ),
+    )
+    fuse_silu_mul: bool = PydanticField(
+        True,
+        description="Run SwiGLU/SiLU*gate fusion in the MLP.",
+    )
+    fuse_add_rmsnorm: bool = PydanticField(
+        True,
+        description="Fuse add-residual + RMSNorm where AutoDeploy's pass matches.",
+    )

--- a/tensorrt_llm/_torch/visual_gen/auto/qk_rope_fusion.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/qk_rope_fusion.py
@@ -1,0 +1,899 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""QK-norm + RoPE pattern matcher: replace the captured Diffusers single-stream
+attention site's (QK-norm + RoPE) subgraph with one call to
+`torch.ops.visgen_auto.dit_qk_norm_rope` (which wraps TRT-LLM's hand-fused
+`fused_dit_qk_norm_rope` kernel).
+
+This pass runs *after* `_fuse_same_input_linears` in ``fusion.py``, which
+already merges the Q/K/V projections into a single fused linear. The
+captured pattern per single-stream attention site:
+
+    fused_qkv = linear(x, W_qkv [, b_qkv])    # output of QKV-GEMM fusion
+    q_n = narrow(fused_qkv, -1, 0, q_dim)
+    k_n = narrow(fused_qkv, -1, q_dim, k_dim)
+    v_n = narrow(fused_qkv, -1, q_dim + k_dim, v_dim)
+    q_unf = unflatten(q_n, -1, (H, D))
+    k_unf = unflatten(k_n, -1, (H, D))
+    v_unf = unflatten(v_n, -1, (H, D))
+    q_norm = rms_norm(q_unf, [D], norm_q.weight, eps)
+    k_norm = rms_norm(k_unf, [D], norm_k.weight, eps)
+    # ... RoPE math (~30 ops, ends with q_rope and k_rope) ...
+    q_p = permute(q_rope, [0, 2, 1, 3])       # (B, S, H, D) -> (B, H, S, D)
+    k_p = permute(k_rope, [0, 2, 1, 3])
+    v_p = permute(v_unf, [0, 2, 1, 3])
+    sdpa = visgen_auto.sdpa(q_p, k_p, v_p, ...)
+
+Rewrite: replace the entire cluster with
+
+    qkv_norm_rope = visgen_auto.dit_qk_norm_rope(
+        fused_qkv, cos, sin, norm_q.weight, norm_k.weight,
+        H_q, H_k, H_v, D, eps, interleave=True)
+    q_p = getitem(qkv_norm_rope, 0)
+    k_p = getitem(qkv_norm_rope, 1)
+    v_p = getitem(qkv_norm_rope, 2)
+    sdpa = visgen_auto.sdpa(q_p, k_p, v_p, ...)
+
+Double-stream blocks (those with an intermediate `cat` that joins encoder
+and hidden Q/K/V before RoPE) are handled by the separate
+``fuse_qk_norm_rope_dual_stream`` matcher in this same module, which
+configures the kernel's dual-stream parameters (`q_add_weight`,
+`k_add_weight`, `num_txt_tokens`).
+"""
+
+from __future__ import annotations
+
+import operator
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import torch.fx as fx
+
+from tensorrt_llm.logger import logger
+
+from . import ops  # noqa: F401 — ensures torch.ops.visgen_auto.sdpa is registered
+
+_SDPA_TARGETS = (torch.ops.visgen_auto.sdpa.default,)
+
+
+@dataclass
+class _SingleStreamSite:
+    """Resolved structural info for one single-stream attention site."""
+
+    sdpa_node: fx.Node
+    fused_qkv_linear: fx.Node  # the linear node producing packed QKV
+    qkv_start: int  # offset of Q (start of QKV slice) in the linear output
+    norm_q_weight: fx.Node  # get_attr for norm_q.weight
+    norm_k_weight: fx.Node  # get_attr for norm_k.weight
+    cos_node: fx.Node  # cos tensor consumed by RoPE
+    sin_node: fx.Node  # sin tensor consumed by RoPE
+    num_heads_q: int
+    num_heads_k: int
+    num_heads_v: int
+    head_dim: int
+    eps: float
+
+
+def _walk_back_skipping(node: fx.Node, skip_targets: set) -> Optional[fx.Node]:
+    """Walk backwards through nodes whose target is in ``skip_targets`` (single-input
+    transparent ops), returning the first node *not* in ``skip_targets``.
+    """
+    cur = node
+    seen = set()
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        if cur.op != "call_function" or cur.target not in skip_targets:
+            return cur
+        if not cur.args:
+            return None
+        cur = cur.args[0] if isinstance(cur.args[0], fx.Node) else None
+    return None
+
+
+_TRANSPARENT_OPS = {
+    torch.ops.aten.permute.default,
+    torch.ops.aten.transpose.int,
+    torch.ops.aten.contiguous.default,
+    torch.ops.aten.clone.default,
+    torch.ops.aten.flatten.using_ints,
+    torch.ops.aten.unflatten.int,
+    torch.ops.aten.unsqueeze.default,
+    torch.ops.aten.reshape.default,
+    torch.ops.aten.view.default,
+    torch.ops.aten.to.dtype,
+    torch.ops.aten.to.dtype_layout,
+    torch.ops.aten._to_copy.default,
+}
+
+
+def _trace_back_to_narrow(start: fx.Node) -> Optional[fx.Node]:
+    """Skip transparent ops back until reaching ``torch.narrow``."""
+    cur = start
+    for _ in range(20):
+        if cur is None or not isinstance(cur, fx.Node):
+            return None
+        if cur.op == "call_function" and cur.target is torch.narrow:
+            return cur
+        if cur.op == "call_function" and cur.target in _TRANSPARENT_OPS:
+            cur = cur.args[0] if cur.args else None
+            continue
+        return None
+    return None
+
+
+def _trace_back_to_rms_norm(start: fx.Node) -> Optional[fx.Node]:
+    """Walk backwards from `start` through RoPE math + transparent ops, returning
+    the first ``aten.rms_norm`` ancestor reachable through allowed-op chains.
+
+    Uses BFS because `mul.Tensor(q, cos)` and `add.Tensor(q*cos, q_rot*sin)`
+    each have two tensor inputs and the rms_norm ancestor can be on either
+    branch. Bounded depth + visited-set guards against runaway. Bails out
+    (returns None) on any non-allowed op (e.g. ``aten.cat`` for double-stream).
+    """
+    rope_math = {
+        torch.ops.aten.mul.Tensor,
+        torch.ops.aten.add.Tensor,
+        torch.ops.aten.neg.default,
+        torch.ops.aten.stack.default,
+        torch.ops.aten.unbind.int,
+        operator.getitem,
+        torch.ops.aten.unsqueeze.default,
+    } | _TRANSPARENT_OPS
+
+    visited = set()
+    stack = [start]
+    while stack:
+        cur = stack.pop()
+        if not isinstance(cur, fx.Node) or id(cur) in visited:
+            continue
+        visited.add(id(cur))
+        if len(visited) > 200:
+            return None
+        if cur.op != "call_function":
+            continue
+        if cur.target is torch.ops.aten.rms_norm.default:
+            return cur
+        if cur.target not in rope_math:
+            # Skip this branch (e.g. cat for cos/sin source, or cat for
+            # double-stream Q joint concat). Single-stream sites still
+            # have Q reachable through other branches; double-stream
+            # sites correctly fail to find rms_norm because Q goes
+            # *through* cat, which we don't traverse.
+            continue
+        for n in _node_inputs(cur):
+            stack.append(n)
+    return None
+
+
+def _is_visgen_fused_qkv(linear_node: fx.Node) -> bool:
+    """True if the linear's weight came from the QKV-GEMM fusion pass."""
+    if not (
+        linear_node.op == "call_function" and linear_node.target is torch.ops.aten.linear.default
+    ):
+        return False
+    if len(linear_node.args) < 2:
+        return False
+    w = linear_node.args[1]
+    return (
+        isinstance(w, fx.Node)
+        and w.op == "get_attr"
+        and str(w.target).startswith("_visgen_auto_fused_w_")
+    )
+
+
+_ROPE_ROTATE_OPS = {
+    torch.ops.aten.neg.default,
+    torch.ops.aten.stack.default,
+    torch.ops.aten.unbind.int,
+    operator.getitem,
+}
+
+
+def _node_inputs(node: fx.Node):
+    """Yield every fx.Node that appears in `node.args` (including inside lists/tuples)."""
+    for a in node.args:
+        if isinstance(a, fx.Node):
+            yield a
+        elif isinstance(a, (list, tuple)):
+            for sub in a:
+                if isinstance(sub, fx.Node):
+                    yield sub
+
+
+def _has_q_ancestor(start: fx.Node) -> bool:
+    """BFS through transparent + RoPE-rotate + cat ops looking for an `rms_norm` ancestor.
+
+    Returns True if reachable — meaning this argument is the Q-side of a
+    RoPE mul (either `q * cos` directly or `rotate_half(q) * sin`).
+    `aten.cat.default` is included because double-stream attention has
+    Q traversing a joint encoder+hidden cat between rms_norm and the
+    RoPE add.
+    """
+    allowed = _TRANSPARENT_OPS | _ROPE_ROTATE_OPS | {torch.ops.aten.cat.default}
+    visited = set()
+    stack = [start]
+    while stack:
+        cur = stack.pop()
+        if not isinstance(cur, fx.Node) or id(cur) in visited:
+            continue
+        visited.add(id(cur))
+        if len(visited) > 200:
+            return False
+        if cur.op != "call_function":
+            continue
+        if cur.target is torch.ops.aten.rms_norm.default:
+            return True
+        if cur.target in allowed:
+            for n in _node_inputs(cur):
+                stack.append(n)
+    return False
+
+
+def _find_cos_sin_sources(rope_add_node: fx.Node) -> Optional[tuple[fx.Node, fx.Node]]:
+    """From an RoPE-result add node (q*cos + q_rot*sin), return (cos_src, sin_src).
+
+    Captured pattern (Flux1, after type promotion to FP32):
+        add(mul(q_cast, cos_cast), mul(q_rot_cast, sin_cast))
+    The first mul corresponds to ``x * cos`` (Flux's `apply_rotary_emb`
+    convention: ``out = x.float() * cos + x_rotated.float() * sin``), so
+    its non-Q arg is cos. The second mul's non-Q arg is sin.
+
+    Q-side identification is by tracing through transparent + RoPE-rotate
+    ops to an `rms_norm` ancestor.
+    """
+    if rope_add_node.op != "call_function" or rope_add_node.target is not torch.ops.aten.add.Tensor:
+        return None
+    if len(rope_add_node.args) < 2:
+        return None
+
+    non_q_sides: list[Optional[fx.Node]] = [None, None]
+    for i, mul_node in enumerate(rope_add_node.args[:2]):
+        if not (
+            isinstance(mul_node, fx.Node)
+            and mul_node.op == "call_function"
+            and mul_node.target is torch.ops.aten.mul.Tensor
+        ):
+            return None
+        if len(mul_node.args) < 2:
+            return None
+        # Identify which mul-arg is the Q-side (has rms_norm ancestor).
+        q_side_idx = None
+        for j, arg in enumerate(mul_node.args[:2]):
+            if isinstance(arg, fx.Node) and _has_q_ancestor(arg):
+                q_side_idx = j
+                break
+        if q_side_idx is None:
+            return None
+        other_idx = 1 - q_side_idx
+        other = mul_node.args[other_idx]
+        if not isinstance(other, fx.Node):
+            return None
+        non_q_sides[i] = other
+
+    # By Flux convention: first mul is ``x * cos``, second is ``x_rot * sin``.
+    return non_q_sides[0], non_q_sides[1]
+
+
+def _walk_back_to(start: fx.Node, sentinels: set) -> Optional[fx.Node]:
+    cur = start
+    for _ in range(40):
+        if cur is None or not isinstance(cur, fx.Node):
+            return None
+        if cur.op == "call_function" and cur.target in sentinels:
+            return cur
+        if cur.op == "call_function" and cur.target in _TRANSPARENT_OPS:
+            cur = cur.args[0] if cur.args else None
+            continue
+        return None
+    return None
+
+
+def _resolve_site(gm: fx.GraphModule, sdpa: fx.Node) -> Optional[_SingleStreamSite]:
+    """Resolve a single-stream attention site; return None if not matching."""
+    q_in, k_in, v_in = sdpa.args[0], sdpa.args[1], sdpa.args[2]
+
+    # Q path must include an rms_norm + a RoPE add. Trace to the RoPE add first.
+    q_rope_add = _trace_back_first_op(q_in, torch.ops.aten.add.Tensor)
+    k_rope_add = _trace_back_first_op(k_in, torch.ops.aten.add.Tensor)
+    if q_rope_add is None or k_rope_add is None:
+        return None
+
+    cs = _find_cos_sin_sources(q_rope_add)
+    if cs is None:
+        return None
+    cos_node, sin_node = cs
+
+    # Trace from RoPE add → rms_norm (skipping RoPE math)
+    q_rms = _trace_back_to_rms_norm(q_rope_add)
+    k_rms = _trace_back_to_rms_norm(k_rope_add)
+    if q_rms is None or k_rms is None:
+        return None
+
+    # rms_norm inputs trace to narrow (after unflatten/etc.)
+    q_narrow = _trace_back_to_narrow(q_rms.args[0])
+    k_narrow = _trace_back_to_narrow(k_rms.args[0])
+    v_narrow = _trace_back_to_narrow(v_in)
+    if not (q_narrow and k_narrow and v_narrow):
+        return None
+
+    if q_narrow.args[0] is not k_narrow.args[0] or v_narrow.args[0] is not q_narrow.args[0]:
+        return None
+
+    fused_qkv = q_narrow.args[0]
+    if not isinstance(fused_qkv, fx.Node) or not _is_visgen_fused_qkv(fused_qkv):
+        return None
+
+    # Double-stream sites are rejected implicitly: `_trace_back_to_rms_norm`
+    # only traverses allowed ops and does NOT walk through `aten.cat`, so on
+    # double-stream blocks (where Q goes through a joint cat between rms_norm
+    # and the RoPE add) the rms_norm walker returns None.
+
+    # Per-narrow sizes give us (q_dim, k_dim, v_dim). narrow args: (input, dim, start, length).
+    q_dim = int(q_narrow.args[3])
+    k_dim = int(k_narrow.args[3])
+    v_dim = int(v_narrow.args[3])
+    q_start = int(q_narrow.args[2])
+    k_start = int(k_narrow.args[2])
+    v_start = int(v_narrow.args[2])
+    # Require QKV contiguous in the linear output. Flux1 layouts seen:
+    #  - transformer_block (double): linear is QKV-only, q_start=0
+    #  - single_transformer_block: linear is [MLP | Q | K | V], q_start = mlp_dim
+    if k_start != q_start + q_dim or v_start != q_start + q_dim + k_dim:
+        return None
+    head_dim = int(q_rms.args[1][0]) if len(q_rms.args) > 1 else None
+    if head_dim is None or q_dim % head_dim != 0:
+        return None
+    num_heads_q = q_dim // head_dim
+    num_heads_k = k_dim // head_dim
+    num_heads_v = v_dim // head_dim
+
+    eps = float(q_rms.args[3]) if len(q_rms.args) > 3 else 1e-6
+
+    return _SingleStreamSite(
+        sdpa_node=sdpa,
+        fused_qkv_linear=fused_qkv,
+        qkv_start=q_start,
+        norm_q_weight=q_rms.args[2],
+        norm_k_weight=k_rms.args[2],
+        cos_node=cos_node,
+        sin_node=sin_node,
+        num_heads_q=num_heads_q,
+        num_heads_k=num_heads_k,
+        num_heads_v=num_heads_v,
+        head_dim=head_dim,
+        eps=eps,
+    )
+
+
+def _trace_back_first_op(start: fx.Node, target_op) -> Optional[fx.Node]:
+    cur = start
+    for _ in range(20):
+        if cur is None or not isinstance(cur, fx.Node):
+            return None
+        if cur.op == "call_function" and cur.target is target_op:
+            return cur
+        if cur.op == "call_function" and cur.target in _TRANSPARENT_OPS:
+            cur = cur.args[0] if cur.args else None
+            continue
+        return None
+    return None
+
+
+def _trace_back_to_chunk_split(start: fx.Node) -> Optional[tuple]:
+    """Walk back from `start` looking for `aten.chunk.default(qkv_src, 3, -1)`.
+
+    Tolerated on the way: `_TRANSPARENT_OPS`, `aten.unflatten.int` (the (H,D)
+    reshape that follows the chunk pick), and a single `operator.getitem`
+    (the chunk-index pick). Returns ``(chunk_node, chunk_idx)`` if the chain
+    reaches a 3-way chunk on the last dim, else None.
+
+    Used by `_resolve_split_chunk_site` for FLUX.2 single-stream blocks
+    whose attention site is structured as:
+        linear → split_with_sizes([qkv, mlp], -1) → getitem(0)
+              → chunk(3, -1) → getitem(k) → unflatten([H, D]) → rms_norm → ...
+    rather than FLUX.1's `_fuse_same_input_linears`-produced narrow chain.
+    """
+    cur = start
+    chunk_idx = None
+    for _ in range(20):
+        if not isinstance(cur, fx.Node) or cur.op != "call_function":
+            return None
+        if cur.target is torch.ops.aten.chunk.default:
+            return (cur, chunk_idx)
+        if cur.target is operator.getitem:
+            # First getitem we see should be the chunk-index pick.
+            if chunk_idx is None and len(cur.args) >= 2:
+                parent = cur.args[0]
+                if (
+                    isinstance(parent, fx.Node)
+                    and parent.op == "call_function"
+                    and parent.target is torch.ops.aten.chunk.default
+                ):
+                    chunk_idx = cur.args[1]
+            cur = cur.args[0] if cur.args else None
+            continue
+        if cur.target is torch.ops.aten.unflatten.int:
+            cur = cur.args[0] if cur.args else None
+            continue
+        if cur.target in _TRANSPARENT_OPS:
+            cur = cur.args[0] if cur.args else None
+            continue
+        return None
+    return None
+
+
+def _resolve_split_chunk_site(gm: fx.GraphModule, sdpa: fx.Node) -> Optional[_SingleStreamSite]:
+    """Resolve a single-stream attention site that uses a Diffusers-native
+    combined QKV linear (e.g. FLUX.2's ``to_qkv_mlp_proj``), not the
+    ``_fuse_same_input_linears``-produced narrow chain that FLUX.1 uses.
+
+    The combined linear's output is split into a QKV portion and an MLP
+    portion via ``aten.split_with_sizes([qkv_total, mlp_total], -1)``; the
+    QKV portion is then ``aten.chunk(3, -1)``-ed into Q/K/V. We accept
+    chunk-input forms:
+      - ``getitem(split_with_sizes(linear, [...], -1), idx)`` (FLUX.2),
+      - or ``linear.default`` directly (chunk-only, no MLP split).
+
+    Returns a ``_SingleStreamSite`` carrying the chunk-input as the
+    ``fused_qkv_linear`` (since it's already (B, S, qkv_total) shaped); the
+    rewrite step's ``torch.narrow(fused_qkv_linear, -1, 0, qkv_total)`` is
+    a free view in this case.
+    """
+    q_in, k_in, v_in = sdpa.args[0], sdpa.args[1], sdpa.args[2]
+
+    q_rope_add = _trace_back_first_op(q_in, torch.ops.aten.add.Tensor)
+    k_rope_add = _trace_back_first_op(k_in, torch.ops.aten.add.Tensor)
+    if q_rope_add is None or k_rope_add is None:
+        return None
+    cs = _find_cos_sin_sources(q_rope_add)
+    if cs is None:
+        return None
+    cos_node, sin_node = cs
+
+    q_rms = _trace_back_to_rms_norm(q_rope_add)
+    k_rms = _trace_back_to_rms_norm(k_rope_add)
+    if q_rms is None or k_rms is None:
+        return None
+
+    q_chunk_info = _trace_back_to_chunk_split(q_rms.args[0])
+    k_chunk_info = _trace_back_to_chunk_split(k_rms.args[0])
+    v_chunk_info = _trace_back_to_chunk_split(v_in)
+    if not (q_chunk_info and k_chunk_info and v_chunk_info):
+        return None
+
+    q_chunk, q_idx = q_chunk_info
+    k_chunk, k_idx = k_chunk_info
+    v_chunk, v_idx = v_chunk_info
+    if q_chunk is not k_chunk or q_chunk is not v_chunk:
+        return None
+    if (q_idx, k_idx, v_idx) != (0, 1, 2):
+        return None
+    if len(q_chunk.args) < 2 or q_chunk.args[1] != 3:
+        return None
+
+    chunk_input = q_chunk.args[0]
+    if not isinstance(chunk_input, fx.Node) or chunk_input.op != "call_function":
+        return None
+
+    qkv_total: Optional[int] = None
+    if chunk_input.target is operator.getitem and len(chunk_input.args) >= 2:
+        sws_node, sws_idx = chunk_input.args[0], chunk_input.args[1]
+        if not (
+            isinstance(sws_node, fx.Node)
+            and sws_node.op == "call_function"
+            and sws_node.target is torch.ops.aten.split_with_sizes.default
+        ):
+            return None
+        sizes = sws_node.args[1]
+        if not isinstance(sizes, (list, tuple)) or not isinstance(sws_idx, int):
+            return None
+        if sws_idx < 0 or sws_idx >= len(sizes):
+            return None
+        qkv_total = int(sizes[sws_idx])
+        # The split's underlying linear must exist (used by the qkv branch);
+        # we don't need its node directly because `chunk_input` is already
+        # the qkv-shaped tensor.
+        if not (
+            isinstance(sws_node.args[0], fx.Node)
+            and sws_node.args[0].op == "call_function"
+            and sws_node.args[0].target is torch.ops.aten.linear.default
+        ):
+            return None
+    elif chunk_input.target is torch.ops.aten.linear.default:
+        # Direct chunk-of-linear (rare; no MLP co-mixed in the linear output).
+        w = chunk_input.args[1] if len(chunk_input.args) > 1 else None
+        if not isinstance(w, fx.Node) or w.op != "get_attr":
+            return None
+        try:
+            qkv_total = int(gm.get_parameter(w.target).shape[0])
+        except (AttributeError, IndexError):
+            return None
+    else:
+        return None
+
+    if qkv_total is None:
+        return None
+
+    head_dim_arg = q_rms.args[1] if len(q_rms.args) > 1 else None
+    if not isinstance(head_dim_arg, (list, tuple)) or not head_dim_arg:
+        return None
+    head_dim = int(head_dim_arg[0])
+    chunk_size = qkv_total // 3
+    if chunk_size * 3 != qkv_total:
+        return None
+    num_heads = chunk_size // head_dim
+    if num_heads * head_dim != chunk_size:
+        return None
+
+    eps = float(q_rms.args[3]) if len(q_rms.args) > 3 else 1e-6
+
+    return _SingleStreamSite(
+        sdpa_node=sdpa,
+        # `chunk_input` is already (B, S, qkv_total)-shaped — the rewrite's
+        # `narrow(fused_qkv_linear, -1, 0, qkv_total)` is a free view.
+        fused_qkv_linear=chunk_input,
+        qkv_start=0,
+        norm_q_weight=q_rms.args[2],
+        norm_k_weight=k_rms.args[2],
+        cos_node=cos_node,
+        sin_node=sin_node,
+        num_heads_q=num_heads,
+        num_heads_k=num_heads,
+        num_heads_v=num_heads,
+        head_dim=head_dim,
+        eps=eps,
+    )
+
+
+def _path_contains_op(start: fx.Node, end: fx.Node, target_op) -> bool:
+    visited = set()
+    stack = [start]
+    while stack:
+        cur = stack.pop()
+        if cur is end or id(cur) in visited:
+            continue
+        visited.add(id(cur))
+        if cur.op == "call_function" and cur.target is target_op:
+            return True
+        for a in cur.args:
+            if isinstance(a, fx.Node):
+                stack.append(a)
+    return False
+
+
+def fuse_qk_norm_rope(gm: fx.GraphModule) -> int:
+    """Replace single-stream QK-norm+RoPE clusters with `dit_qk_norm_rope` calls.
+
+    Returns the number of single-stream attention sites rewritten.
+    """
+    g = gm.graph
+    target_op = torch.ops.visgen_auto.dit_qk_norm_rope.default
+
+    sdpa_nodes = [n for n in g.nodes if n.op == "call_function" and n.target in _SDPA_TARGETS]
+
+    n_rewritten = 0
+    n_skipped = 0
+    for sdpa in sdpa_nodes:
+        # Try FLUX.1-style first (fused-QKV linear from
+        # `_fuse_same_input_linears` + narrow). Fall back to FLUX.2-style
+        # (Diffusers-native combined `to_qkv_mlp_proj` linear that goes
+        # through `split_with_sizes → getitem(0) → chunk(3, -1)`).
+        site = _resolve_site(gm, sdpa) or _resolve_split_chunk_site(gm, sdpa)
+        if site is None:
+            n_skipped += 1
+            continue
+
+        qkv_total = (site.num_heads_q + site.num_heads_k + site.num_heads_v) * site.head_dim
+        with g.inserting_before(sdpa):
+            # Slice the fused linear output to just the QKV portion. Flux.1
+            # single_transformer_block packs the linear as [MLP | Q | K | V]
+            # so qkv_start > 0; double_transformer_block packs as [Q | K | V]
+            # alone (qkv_start == 0).
+            qkv_only = g.call_function(
+                torch.narrow,
+                args=(site.fused_qkv_linear, -1, site.qkv_start, qkv_total),
+            )
+            op_call = g.call_function(
+                target_op,
+                args=(
+                    qkv_only,
+                    site.cos_node,
+                    site.sin_node,
+                    site.norm_q_weight,
+                    site.norm_k_weight,
+                    site.num_heads_q,
+                    site.num_heads_k,
+                    site.num_heads_v,
+                    site.head_dim,
+                    site.eps,
+                    True,  # interleave: Flux uses adjacent-pair rotation
+                ),
+            )
+            q_out = g.call_function(operator.getitem, args=(op_call, 0))
+            k_out = g.call_function(operator.getitem, args=(op_call, 1))
+            v_out = g.call_function(operator.getitem, args=(op_call, 2))
+
+        sdpa.replace_input_with(sdpa.args[0], q_out)
+        sdpa.replace_input_with(sdpa.args[1], k_out)
+        sdpa.replace_input_with(sdpa.args[2], v_out)
+
+        n_rewritten += 1
+
+    if n_rewritten:
+        # `_assert_tensor_metadata` is treated as having side effects by FX
+        # DCE — it'll keep the entire old RoPE+norm chain alive even though
+        # SDPA no longer consumes it. Strip these asserts so DCE can collapse
+        # the old chain. The asserts are export-time shape/dtype sanity
+        # checks; removing them at this point is safe.
+        for n in list(g.nodes):
+            if (
+                n.op == "call_function"
+                and n.target is torch.ops.aten._assert_tensor_metadata.default
+            ):
+                g.erase_node(n)
+        g.eliminate_dead_code()
+        g.lint()
+        gm.recompile()
+
+    logger.info(
+        f"VisGen-Auto qk_rope_fusion: rewrote {n_rewritten} single-stream sites; "
+        f"skipped {n_skipped} (double-stream or non-matching)"
+    )
+    return n_rewritten
+
+
+# ---------------------------------------------------------------------------
+# Double-stream (joint-attention) matcher — FLUX.1/.2 dual_transformer_blocks
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _DoubleStreamSite:
+    sdpa_node: fx.Node
+    encoder_linear: fx.Node  # fused QKV linear for encoder (txt) side
+    hidden_linear: fx.Node  # fused QKV linear for hidden (img) side
+    qkv_start: int  # offset of Q in each linear's output
+    encoder_norm_q_weight: fx.Node  # norm_added_q.weight
+    encoder_norm_k_weight: fx.Node  # norm_added_k.weight
+    hidden_norm_q_weight: fx.Node  # norm_q.weight
+    hidden_norm_k_weight: fx.Node  # norm_k.weight
+    cos_node: fx.Node
+    sin_node: fx.Node
+    num_heads_q: int
+    num_heads_k: int
+    num_heads_v: int
+    head_dim: int
+    eps: float
+
+
+def _trace_forward_to_rms_norm(narrow_node: fx.Node) -> Optional[fx.Node]:
+    """BFS forward through unflatten/transparent ops from a narrow to find its rms_norm."""
+    frontier = {narrow_node}
+    for _ in range(6):
+        nxt = set()
+        for n in frontier:
+            for u in n.users:
+                if u.op != "call_function":
+                    continue
+                if u.target is torch.ops.aten.rms_norm.default:
+                    return u
+                if u.target in _TRANSPARENT_OPS:
+                    nxt.add(u)
+        if not nxt:
+            return None
+        frontier = nxt
+    return None
+
+
+def _find_linear_qkv_rms_norms(linear: fx.Node) -> Optional[dict]:
+    """Find Q/K narrows under a fused QKV linear and the rms_norms consuming them.
+
+    Returns ``{qkv_start, q_dim, k_dim, v_dim, head_dim, eps, norm_q, norm_k}`` or None.
+    """
+    narrows = []
+    for u in linear.users:
+        if (
+            u.op == "call_function"
+            and u.target is torch.narrow
+            and len(u.args) >= 4
+            and isinstance(u.args[2], int)
+            and isinstance(u.args[3], int)
+        ):
+            narrows.append((u, int(u.args[2]), int(u.args[3])))
+    if len(narrows) < 3:
+        return None
+    narrows.sort(key=lambda x: x[1])
+
+    # Find a Q,K,V triple where the offsets line up consecutively
+    for i in range(len(narrows) - 2):
+        (qn, q_start, q_dim), (kn, k_start, k_dim), (_vn, v_start, v_dim) = (
+            narrows[i],
+            narrows[i + 1],
+            narrows[i + 2],
+        )
+        if k_start != q_start + q_dim or v_start != q_start + q_dim + k_dim:
+            continue
+        norm_q = _trace_forward_to_rms_norm(qn)
+        norm_k = _trace_forward_to_rms_norm(kn)
+        if norm_q is None or norm_k is None:
+            continue
+        head_dim = int(norm_q.args[1][0]) if len(norm_q.args) > 1 else None
+        if head_dim is None or q_dim % head_dim != 0:
+            continue
+        eps = float(norm_q.args[3]) if len(norm_q.args) > 3 else 1e-6
+        return {
+            "qkv_start": q_start,
+            "q_dim": q_dim,
+            "k_dim": k_dim,
+            "v_dim": v_dim,
+            "head_dim": head_dim,
+            "eps": eps,
+            "norm_q": norm_q,
+            "norm_k": norm_k,
+        }
+    return None
+
+
+def _resolve_double_stream_site(gm: fx.GraphModule, sdpa: fx.Node) -> Optional[_DoubleStreamSite]:
+    """Resolve a double-stream attention site; return None if not matching."""
+    q_in, _k_in, v_in = sdpa.args[0], sdpa.args[1], sdpa.args[2]
+
+    # V never has rms_norm or RoPE. V path traces to a cat (joint encoder+hidden).
+    v_cat = _trace_back_first_op(v_in, torch.ops.aten.cat.default)
+    if v_cat is None:
+        return None
+    if not isinstance(v_cat.args[0], (list, tuple)) or len(v_cat.args[0]) != 2:
+        return None
+    # Flux convention: cat([encoder_v, hidden_v], dim=...).
+    encoder_v_input, hidden_v_input = v_cat.args[0]
+
+    encoder_v_narrow = _trace_back_to_narrow(encoder_v_input)
+    hidden_v_narrow = _trace_back_to_narrow(hidden_v_input)
+    if not (encoder_v_narrow and hidden_v_narrow):
+        return None
+    encoder_linear = encoder_v_narrow.args[0]
+    hidden_linear = hidden_v_narrow.args[0]
+    if not isinstance(encoder_linear, fx.Node) or not isinstance(hidden_linear, fx.Node):
+        return None
+    if encoder_linear is hidden_linear:
+        return None  # not a dual-stream pattern
+    if not (_is_visgen_fused_qkv(encoder_linear) and _is_visgen_fused_qkv(hidden_linear)):
+        return None
+
+    enc = _find_linear_qkv_rms_norms(encoder_linear)
+    hid = _find_linear_qkv_rms_norms(hidden_linear)
+    if not (enc and hid):
+        return None
+    # Require symmetric shape across the two sides
+    for key in ("qkv_start", "q_dim", "k_dim", "v_dim", "head_dim"):
+        if enc[key] != hid[key]:
+            return None
+
+    q_rope_add = _trace_back_first_op(q_in, torch.ops.aten.add.Tensor)
+    if q_rope_add is None:
+        return None
+    cs = _find_cos_sin_sources(q_rope_add)
+    if cs is None:
+        return None
+    cos_node, sin_node = cs
+
+    return _DoubleStreamSite(
+        sdpa_node=sdpa,
+        encoder_linear=encoder_linear,
+        hidden_linear=hidden_linear,
+        qkv_start=enc["qkv_start"],
+        encoder_norm_q_weight=enc["norm_q"].args[2],
+        encoder_norm_k_weight=enc["norm_k"].args[2],
+        hidden_norm_q_weight=hid["norm_q"].args[2],
+        hidden_norm_k_weight=hid["norm_k"].args[2],
+        cos_node=cos_node,
+        sin_node=sin_node,
+        num_heads_q=enc["q_dim"] // enc["head_dim"],
+        num_heads_k=enc["k_dim"] // enc["head_dim"],
+        num_heads_v=enc["v_dim"] // enc["head_dim"],
+        head_dim=enc["head_dim"],
+        eps=enc["eps"],
+    )
+
+
+def fuse_qk_norm_rope_dual_stream(graph_module: fx.GraphModule) -> int:
+    """Replace double-stream attention clusters with `dit_qk_norm_rope` calls
+    using the kernel's dual-stream mode (`q_add_weight` + `num_txt_tokens`).
+    """
+    g = graph_module.graph
+    target_op = torch.ops.visgen_auto.dit_qk_norm_rope.default
+
+    sdpa_nodes = [n for n in g.nodes if n.op == "call_function" and n.target in _SDPA_TARGETS]
+
+    n_rewritten = 0
+    n_skipped = 0
+    for sdpa in sdpa_nodes:
+        # Skip SDPA sites already rewritten as single-stream (their args are
+        # getitem of an existing dit_qk_norm_rope call).
+        q_input = sdpa.args[0]
+        if (
+            isinstance(q_input, fx.Node)
+            and q_input.op == "call_function"
+            and q_input.target is operator.getitem
+        ):
+            parent = q_input.args[0] if q_input.args else None
+            if (
+                isinstance(parent, fx.Node)
+                and parent.op == "call_function"
+                and parent.target is target_op
+            ):
+                continue
+
+        site = _resolve_double_stream_site(graph_module, sdpa)
+        if site is None:
+            n_skipped += 1
+            continue
+
+        qkv_total = (site.num_heads_q + site.num_heads_k + site.num_heads_v) * site.head_dim
+        with g.inserting_before(sdpa):
+            enc_qkv = g.call_function(
+                torch.narrow,
+                args=(site.encoder_linear, -1, site.qkv_start, qkv_total),
+            )
+            hid_qkv = g.call_function(
+                torch.narrow,
+                args=(site.hidden_linear, -1, site.qkv_start, qkv_total),
+            )
+            # Joint concat along seq dim — encoder first per Flux convention.
+            joint_qkv = g.call_function(
+                torch.ops.aten.cat.default,
+                args=([enc_qkv, hid_qkv], 1),
+            )
+            # `num_txt_tokens` is the per-batch encoder seq length, taken
+            # symbolically from the encoder linear's output shape.
+            num_txt_tokens = g.call_function(
+                torch.ops.aten.sym_size.int,
+                args=(enc_qkv, 1),
+            )
+            op_call = g.call_function(
+                target_op,
+                args=(
+                    joint_qkv,
+                    site.cos_node,
+                    site.sin_node,
+                    site.hidden_norm_q_weight,
+                    site.hidden_norm_k_weight,
+                    site.num_heads_q,
+                    site.num_heads_k,
+                    site.num_heads_v,
+                    site.head_dim,
+                    site.eps,
+                    True,  # interleave
+                ),
+                kwargs={
+                    "norm_q_add_weight": site.encoder_norm_q_weight,
+                    "norm_k_add_weight": site.encoder_norm_k_weight,
+                    "num_txt_tokens": num_txt_tokens,
+                },
+            )
+            q_out = g.call_function(operator.getitem, args=(op_call, 0))
+            k_out = g.call_function(operator.getitem, args=(op_call, 1))
+            v_out = g.call_function(operator.getitem, args=(op_call, 2))
+
+        sdpa.replace_input_with(sdpa.args[0], q_out)
+        sdpa.replace_input_with(sdpa.args[1], k_out)
+        sdpa.replace_input_with(sdpa.args[2], v_out)
+        n_rewritten += 1
+
+    if n_rewritten:
+        for n in list(g.nodes):
+            if (
+                n.op == "call_function"
+                and n.target is torch.ops.aten._assert_tensor_metadata.default
+            ):
+                g.erase_node(n)
+        g.eliminate_dead_code()
+        g.lint()
+        graph_module.recompile()
+
+    logger.info(
+        f"VisGen-Auto qk_rope_fusion (dual): rewrote {n_rewritten} double-stream sites; "
+        f"skipped {n_skipped}"
+    )
+    return n_rewritten

--- a/tensorrt_llm/_torch/visual_gen/auto/quantize.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/quantize.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Pre-export quantization for the auto path.
+
+Strategy: walk the Diffusers transformer BEFORE `torch.export`, replace
+every ``nn.Linear`` with ``tensorrt_llm._torch.modules.Linear(quant_config=...)``,
+load the BF16 weight via TRT-LLM's ``Linear.load_weights`` (which
+dynamically quantizes to FP8/NVFP4 + scale at load time, mirroring
+``DynamicLinearWeightLoader`` in the handwritten path). The captured graph
+then contains real ``torch.ops.tensorrt_llm.*`` quant ops that
+``torch.export`` traces cleanly — unlike modelopt's ``TensorQuantizer``
+modules whose ``FakeTensor`` state torch.export rejects.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from typing import TYPE_CHECKING
+
+import torch
+import torch.nn as nn
+
+from tensorrt_llm._torch.modules.linear import Linear as TRTLLMLinear
+from tensorrt_llm._torch.modules.linear import TensorParallelMode
+from tensorrt_llm._torch.visual_gen.quantization.ops import quantize_nvfp4
+from tensorrt_llm.logger import logger
+from tensorrt_llm.quantization.mode import QuantAlgo
+
+if TYPE_CHECKING:
+    from tensorrt_llm.models.modeling_utils import QuantConfig
+
+
+def _prequantize_weight_dict(
+    weight_dict: dict[str, "torch.Tensor"],
+    quant_algo,
+) -> dict[str, "torch.Tensor"]:
+    """For storage-shape-changing quant algos (NVFP4 packs 2 4-bit values
+    into 1 uint8), pre-pack the weight so `Linear.load_weights_vanilla`'s
+    `copy_(src)` finds the right destination shape.
+
+    FP8 keeps `(out, in)` shape (just narrower dtype) — PyTorch's `.copy_`
+    converts BF16→FP8 inline, so no pre-quant needed.
+    NVFP4 changes shape to `(out, in/2)` — pre-pack here.
+    """
+    if quant_algo != QuantAlgo.NVFP4:
+        return weight_dict
+    w = weight_dict["weight"]
+    if w.device.type != "cuda":
+        w = w.cuda()
+    qweight, weight_scale, weight_scale_2 = quantize_nvfp4(w)
+    return {
+        **weight_dict,
+        "weight": qweight,
+        "weight_scale": weight_scale,
+        "weight_scale_2": weight_scale_2,
+    }
+
+
+def _is_excluded(qualified_name: str, patterns: list[str] | None) -> bool:
+    """Match against `quant_config.exclude_modules`-style glob patterns.
+
+    Mirrors `QuantConfig.is_module_excluded_from_quantization` semantics:
+    a Linear at qualified name `name` is excluded if any pattern matches
+    `name` directly OR matches any suffix of the path (so `"*x_embedder*"`
+    matches `time_guidance_embed.timestep_embedder.linear_1` via the
+    bare `timestep_embedder.linear_1` tail).
+    """
+    if not patterns:
+        return False
+    parts = qualified_name.split(".")
+    candidates = [qualified_name] + [".".join(parts[i:]) for i in range(1, len(parts))]
+    for pat in patterns:
+        for cand in candidates:
+            if fnmatch.fnmatch(cand, pat):
+                return True
+    return False
+
+
+def _tp_kwargs_for(child: nn.Linear, mapping) -> dict:
+    """Return TP construction kwargs for a tagged Linear, or `{}` if untagged.
+
+    A Linear with `_tp_role` ∈ {qkv, ff_in} → COLUMN (output-split)
+    A Linear with `_tp_role` ∈ {out_proj, ff_out} → ROW (input-split, all-reduce)
+    Untagged Linears stay replicated.
+    """
+    if mapping is None:
+        return {}
+    role = getattr(child, "_tp_role", None)
+    if role is None:
+        return {}
+    if role in ("qkv", "ff_in"):
+        return {"mapping": mapping, "tensor_parallel_mode": TensorParallelMode.COLUMN}
+    if role in ("out_proj", "ff_out"):
+        return {"mapping": mapping, "tensor_parallel_mode": TensorParallelMode.ROW}
+    return {}
+
+
+def replace_linear_with_trtllm(
+    module: nn.Module,
+    quant_config: "QuantConfig",
+    dtype: torch.dtype,
+    _name_prefix: str = "",
+    _count: list | None = None,
+    mapping=None,
+) -> int:
+    """Recursively swap every ``nn.Linear`` in `module` with TRT-LLM's
+    quant-aware `Linear(quant_config=...)`, copying the BF16 weight and
+    letting TRT-LLM's ``Linear.load_weights`` apply dynamic quantization
+    (BF16 → FP8 or NVFP4 + scale at load time).
+
+    Skips:
+      - ``TRTLLMLinear`` instances (already quantized)
+      - Any module whose qualified name matches `quant_config.exclude_modules`
+        (glob patterns; defaults to ``[]`` if unset)
+
+    Returns the number of modules replaced.
+    """
+    if _count is None:
+        _count = [0, 0]  # [replaced, excluded]
+        # Top-level call: union structural auto-detected patterns into the
+        # user's `exclude_modules` so the auto path doesn't need per-family
+        # hand-curated lists. See `auto/sensitivity.py` for the heuristic.
+        from .sensitivity import find_quantization_sensitive_linears
+
+        auto_patterns = find_quantization_sensitive_linears(module)
+        if auto_patterns:
+            user_patterns = list(quant_config.exclude_modules or [])
+            combined = list(dict.fromkeys(user_patterns + auto_patterns))
+            if combined != user_patterns:
+                logger.info(
+                    f"VisGen-Auto sensitivity: auto-detected {auto_patterns}; "
+                    f"final exclude_modules={combined}"
+                )
+                quant_config.exclude_modules = combined
+    exclude_patterns = getattr(quant_config, "exclude_modules", None)
+    for child_name, child in list(module.named_children()):
+        full_name = f"{_name_prefix}.{child_name}" if _name_prefix else child_name
+        if isinstance(child, nn.Linear) and not isinstance(child, TRTLLMLinear):
+            if _is_excluded(full_name, exclude_patterns):
+                _count[1] += 1
+                continue
+            tp_kwargs = _tp_kwargs_for(child, mapping)
+            new_linear = TRTLLMLinear(
+                in_features=child.in_features,
+                out_features=child.out_features,
+                bias=child.bias is not None,
+                dtype=dtype,
+                quant_config=quant_config,
+                skip_create_weights_in_init=False,
+                # We're dynamically quantizing from BF16 weights with no
+                # calibration data, so activation scales must be computed at
+                # runtime. For NVFP4, `Linear.__init__` eagerly creates an
+                # `input_scale=Parameter(1.0)`, and the forward path treats a
+                # non-None `input_scale` as the *static* branch unless this
+                # flag is set — which would produce garbage output without
+                # real calibration data.
+                force_dynamic_quantization=True,
+                **tp_kwargs,
+            ).to(child.weight.device)
+            wd = {"weight": child.weight.data}
+            if child.bias is not None:
+                wd["bias"] = child.bias.data
+            wd = _prequantize_weight_dict(wd, quant_config.quant_algo)
+            new_linear.load_weights([wd])
+            setattr(module, child_name, new_linear)
+            _count[0] += 1
+        else:
+            replace_linear_with_trtllm(
+                child, quant_config, dtype, full_name, _count, mapping=mapping
+            )
+    if not _name_prefix and _count[0]:
+        msg = (
+            f"VisGen-Auto quantize: replaced {_count[0]} nn.Linear modules with "
+            f"TRT-LLM Linear(quant_algo={quant_config.quant_algo})"
+        )
+        if _count[1]:
+            msg += f", excluded {_count[1]} via exclude_modules={exclude_patterns}"
+        logger.info(msg)
+    return _count[0]

--- a/tensorrt_llm/_torch/visual_gen/auto/rewrite.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/rewrite.py
@@ -1,0 +1,296 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""FX rewrite pipeline for the auto path.
+
+The first pass rewrites `aten::scaled_dot_product_attention.*` calls to
+`torch.ops.visgen_auto.sdpa` (see `ops.py`). The pattern matcher validates
+that the SDPA call is non-causal and unmasked — DiT-invariant — and refuses
+to rewrite anything else (e.g., an LLM-shaped causal attention with a
+`bool` mask). Subsequent passes (QKV-GEMM fusion in ``fusion.py``,
+QK-norm+RoPE fusion in ``qk_rope_fusion.py``, FP8/NVFP4-contig insertion,
+``_assert_tensor_metadata`` strip) run in canonical order via the
+``PassManager`` in ``pass_manager.py``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import torch
+import torch.fx as fx
+
+from tensorrt_llm.logger import logger
+
+from . import ops  # noqa: F401 — registers torch.ops.visgen_auto.sdpa
+
+if TYPE_CHECKING:
+    from .adapter import VisGenFamilyAdapter
+    from .pass_manager import PassManager
+    from .policy import RewritePolicy
+
+
+_SDPA_TARGETS = (
+    torch.ops.aten.scaled_dot_product_attention.default,
+    torch.ops.aten._scaled_dot_product_cudnn_attention.default,
+    torch.ops.aten._scaled_dot_product_efficient_attention.default,
+    torch.ops.aten._scaled_dot_product_flash_attention.default,
+)
+
+
+def _rewrite_sdpa_to_visgen(graph_module: fx.GraphModule, backend: str = "VANILLA") -> int:
+    """Replace SDPA call nodes with `torch.ops.visgen_auto.sdpa`.
+
+    DiT invariant: SDPA is called as ``sdpa(q, k, v)`` (or with explicit
+    ``scale=`` and/or ``is_causal=False``) — no attn_mask, no dropout,
+    non-causal. Calls violating that are skipped (the pass stays
+    conservative; an upstream layer can lower them differently later).
+
+    Args:
+        graph_module: target GraphModule (mutated in place).
+        backend: attention-backend selection written into the inserted
+            `visgen_auto.sdpa` node (one of ``"VANILLA"``, ``"TRTLLM"``,
+            ``"FA4"``). Pulled from `RewritePolicy.attention_backend`.
+
+    Returns the number of nodes rewritten.
+    """
+    target_op = torch.ops.visgen_auto.sdpa.default
+    n_rewritten = 0
+    n_skipped = 0
+    g = graph_module.graph
+
+    for node in list(g.nodes):
+        if node.op != "call_function" or node.target not in _SDPA_TARGETS:
+            continue
+
+        if not _is_dit_compatible_sdpa(node):
+            n_skipped += 1
+            continue
+
+        q, k, v = node.args[0], node.args[1], node.args[2]
+        scale = node.kwargs.get("scale", None)
+
+        new_kwargs: dict = {"backend": backend}
+        if scale is not None:
+            new_kwargs["scale"] = scale
+
+        # Force BHSD contiguous on q/k/v. Diffusers DiT blocks reach SDPA via
+        # `view(B,S,H,D).transpose(1,2)` — a non-contiguous view. Inductor is
+        # free to "realize" that view as a contig copy in its codegen (which it
+        # does silently at 4-rank Ulysses on PixArt/LTX-Video at S=1024), but
+        # the `assert_size_stride` check on the SDPA input still references
+        # the captured-time (transpose-view) strides → AssertionError at
+        # runtime. Inserting `.contiguous()` explicitly pins both planning and
+        # realization to the same layout. No-op when already contig.
+        #
+        # Use the `call_function(aten.contiguous.default, ...)` form, NOT
+        # `call_method("contiguous", ...)`. The qk_rope_fusion pattern matcher
+        # walks back from each SDPA's q/k input through `_TRANSPARENT_OPS`
+        # (which contains `aten.contiguous.default`) looking for an
+        # `aten.rms_norm` ancestor; a `call_method` node breaks the walk and
+        # silently disables the QK-rope fusion on every attention site.
+        with g.inserting_before(node):
+            q_c = g.call_function(torch.ops.aten.contiguous.default, args=(q,))
+            k_c = g.call_function(torch.ops.aten.contiguous.default, args=(k,))
+            v_c = g.call_function(torch.ops.aten.contiguous.default, args=(v,))
+            new_node = g.call_function(
+                target_op,
+                args=(q_c, k_c, v_c),
+                kwargs=new_kwargs,
+            )
+
+        # Some SDPA overloads return a tuple ``(out, ...)``; aten default
+        # returns the tensor directly. If users of `node` index into it,
+        # they'll need to be re-pointed at `new_node` (single-output).
+        # The DiT case captured here yields a single-tensor result on every
+        # overload we've observed, so we replace uses 1:1.
+        node.replace_all_uses_with(new_node)
+        g.erase_node(node)
+        n_rewritten += 1
+
+    if n_rewritten or n_skipped:
+        graph_module.graph.lint()
+        graph_module.recompile()
+    logger.info(
+        f"VisGen-Auto rewrite: SDPA → visgen_auto.sdpa "
+        f"(rewritten={n_rewritten}, skipped={n_skipped})"
+    )
+    return n_rewritten
+
+
+def _is_dit_compatible_sdpa(node: fx.Node) -> bool:
+    """Validate that an SDPA call matches the DiT invariant.
+
+    Accepts: 3-arg call (q, k, v), or with ``scale=`` and/or
+    ``is_causal=False``. Rejects everything else.
+    """
+    if len(node.args) > 3:
+        # Positional attn_mask / dropout_p / is_causal / scale.
+        # SDPA signature: (q, k, v, attn_mask=None, dropout_p=0.0,
+        #                  is_causal=False, scale=None, enable_gqa=False).
+        attn_mask = node.args[3] if len(node.args) > 3 else None
+        dropout_p = node.args[4] if len(node.args) > 4 else 0.0
+        is_causal = node.args[5] if len(node.args) > 5 else False
+        if attn_mask is not None:
+            return False
+        if dropout_p:
+            return False
+        if is_causal:
+            return False
+
+    if node.kwargs:
+        if node.kwargs.get("attn_mask") is not None:
+            return False
+        if node.kwargs.get("dropout_p", 0.0):
+            return False
+        if node.kwargs.get("is_causal", False):
+            return False
+
+    return True
+
+
+def _ensure_contiguous_for_fp8_quant(graph_module: fx.GraphModule) -> int:
+    """Prepend `.contiguous()` to inputs of every FP8/NVFP4 activation-quant
+    call in the captured graph.
+
+    The underlying ops (`fp8Op.cpp:e4m3_quantize_helper` for FP8,
+    `fp4Quantize.cpp:fp4_quantize` for NVFP4, plus their GEMM downstream
+    callers) require contiguous input. `Linear.apply_linear` upstream does
+    `input = input.reshape(-1, input.shape[-1])` without forcing contiguity
+    — so when the caller-side `hidden_states` is itself non-contiguous
+    (e.g. Diffusers' `_pack_latents` returns a `permute().reshape()` chain
+    that produces a non-contiguous view at FLUX.2 input dims), the reshape
+    is also non-contiguous and the quant op rejects it.
+
+    `.contiguous()` is a cheap no-op when the input is already contiguous,
+    so this is safe to apply unconditionally.
+    """
+    quant_targets: tuple = (
+        torch.ops.tensorrt_llm.quantize_e4m3_per_tensor.default,
+        torch.ops.tensorrt_llm.static_quantize_e4m3_per_tensor.default,
+    )
+    # NVFP4 quant ops live under `torch.ops.trtllm` (different namespace from
+    # FP8). Guarded by hasattr so the rewrite still compiles on builds without
+    # the NVFP4 build flag.
+    if hasattr(torch.ops, "trtllm"):
+        for opname in ("fp4_quantize", "tunable_fp4_quantize"):
+            op = getattr(torch.ops.trtllm, opname, None)
+            if op is not None:
+                quant_targets = quant_targets + (op.default,)
+    n = 0
+    g = graph_module.graph
+    for node in list(g.nodes):
+        if node.op != "call_function" or node.target not in quant_targets:
+            continue
+        if not node.args:
+            continue
+        x = node.args[0]
+        # Skip if we've already inserted a contiguous() call for this input.
+        if (
+            isinstance(x, fx.Node)
+            and x.op == "call_function"
+            and x.target is torch.ops.aten.contiguous.default
+        ):
+            continue
+        with g.inserting_before(node):
+            contig = g.call_function(torch.ops.aten.contiguous.default, args=(x,))
+        new_args = (contig,) + tuple(node.args[1:])
+        node.args = new_args
+        n += 1
+    if n:
+        g.lint()
+        graph_module.recompile()
+    return n
+
+
+def _strip_assert_tensor_metadata(graph_module: fx.GraphModule) -> int:
+    """Remove all `aten._assert_tensor_metadata` nodes from the captured graph.
+
+    `torch.export` inserts these as runtime guards on tensor dtype / device /
+    layout matching what was seen at capture time. They're useful during
+    development but routinely fire false positives when the captured graph
+    re-runs with values that have the right semantics but differ by a fixed
+    detail (e.g., quant scales whose dtype slightly differs at capture vs
+    runtime). For our auto-path use cases (replay captured graphs with the
+    same shapes), the asserts add no correctness value and block
+    legitimate runs.
+    """
+    n = 0
+    g = graph_module.graph
+    for node in list(g.nodes):
+        if (
+            node.op == "call_function"
+            and node.target is torch.ops.aten._assert_tensor_metadata.default
+        ):
+            g.erase_node(node)
+            n += 1
+    if n:
+        g.lint()
+        graph_module.recompile()
+    return n
+
+
+def _build_default_pass_manager(policy: "RewritePolicy") -> "PassManager":
+    """Construct the default visgen-auto pass pipeline from a `RewritePolicy`.
+
+    Pass order is canonical and load-bearing — qk_rope fusion depends on
+    QKV fusion having already produced the same-input narrow markers it
+    walks back to. Adapters that need different ordering should override
+    `customize_passes` and re-order via the manager primitives.
+
+    Pass names (stable; family adapter hooks reference them):
+        sdpa_rewrite          → `_rewrite_sdpa_to_visgen`
+        fuse_qkv              → `_fuse_same_input_linears` (if policy.fuse_qkv)
+        qk_rope_single        → `fuse_qk_norm_rope` (if enabled)
+        qk_rope_dual          → `fuse_qk_norm_rope_dual_stream` (if enabled)
+        contig_for_fp8_quant  → `_ensure_contiguous_for_fp8_quant`
+        strip_assert_metadata → `_strip_assert_tensor_metadata`
+    """
+    import os
+
+    from .pass_manager import Pass, PassManager
+
+    pm = PassManager()
+    pm.append(
+        Pass(
+            "sdpa_rewrite",
+            lambda gm: _rewrite_sdpa_to_visgen(gm, backend=policy.attention_backend),
+        )
+    )
+    if policy.fuse_qkv:
+        from .fusion import _fuse_same_input_linears
+
+        pm.append(Pass("fuse_qkv", _fuse_same_input_linears))
+        qk_rope_enabled = policy.fuse_qk_rope and not os.environ.get("VISGEN_AUTO_DISABLE_QKROPE")
+        if qk_rope_enabled:
+            from .qk_rope_fusion import fuse_qk_norm_rope, fuse_qk_norm_rope_dual_stream
+
+            pm.append(Pass("qk_rope_single", fuse_qk_norm_rope))
+            pm.append(Pass("qk_rope_dual", fuse_qk_norm_rope_dual_stream))
+    pm.append(Pass("contig_for_fp8_quant", _ensure_contiguous_for_fp8_quant))
+    # `_strip_assert_tensor_metadata` is always last — export-time shape/dtype
+    # guards spuriously fail at runtime on FP8/NVFP4 graphs, and DCE can't
+    # collapse the old qk_rope chains while these asserts hold them alive.
+    pm.append(Pass("strip_assert_metadata", _strip_assert_tensor_metadata))
+    return pm
+
+
+def apply_rewrites(
+    graph_module: fx.GraphModule,
+    policy: "RewritePolicy",
+    adapter: "Optional[VisGenFamilyAdapter]" = None,
+) -> fx.GraphModule:
+    """Apply the rewrite pipeline declared by `policy`.
+
+    Build a default `PassManager` from the policy, give `adapter` a chance
+    to splice in family-specific passes via `customize_passes(pm)`, then
+    run. Returning the same GraphModule (mutated in place).
+
+    `adapter` is optional for backward compatibility with callers that
+    only have a `RewritePolicy` (e.g. existing tests). When absent, the
+    pipeline is exactly what `RewritePolicy` declares — no family hooks.
+    """
+    pm = _build_default_pass_manager(policy)
+    if adapter is not None:
+        adapter.customize_passes(pm)
+    pm.run(graph_module)
+    return graph_module

--- a/tensorrt_llm/_torch/visual_gen/auto/sensitivity.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/sensitivity.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Auto-detect quantization-sensitive Linears via module-tree structure.
+
+The goal: replace hand-curated per-family exclude lists (e.g. the
+`["*time_guidance_embed*"]` we had on `Flux2Adapter`) with a structural
+heuristic that applies to any Diffusers transformer.
+
+Heuristic ("narrow-dim embedder, either direction"):
+
+- Skip per-step block stacks (children that are `nn.ModuleList`) — Linears
+  in those run once per token site and have block-local fan-out, so their
+  per-tensor FP8 error doesn't propagate model-wide.
+- For each remaining top-level child module, scan its descendant `nn.Linear`
+  instances. If *any* of them has a narrow input dim (`in_features <=
+  SMALL_DIM_THRESHOLD`, i.e., it's a conditioning embedder reading a low-dim
+  scalar/code) *or* a narrow output dim (`out_features <= SMALL_DIM_THRESHOLD`,
+  i.e., it projects to a small latent channel count), treat the whole
+  subtree as quant-sensitive and emit a `*<name>*` glob pattern that
+  excludes all its Linears.
+
+Why this works on DiT-family models:
+
+- Timestep / guidance / label embedders project a 1-D or low-dim scalar
+  (256 sinusoidal channels, 128 patch latents, 768 pooled-text features)
+  into the model hidden dim. The first Linear in that MLP always has small
+  `in_features`. Its output (`temb`) feeds every modulation linear in every
+  block, so per-tensor FP8 rounding error there compounds system-wide
+  (LPIPS 0.10 vs 0.04 on FLUX.2 when the modulation MLP's first Linear is
+  NOT excluded).
+- Final output projections (`proj_out`, `audio_proj_out`) compress the full
+  inner_dim *down* to the tiny VAE latent channel count (out_features=128
+  for LTX-2, ~64 for FLUX/SD3 patches). Weight-side rounding there feeds
+  directly into the latent the VAE/vocoder upsamples, amplifying drift
+  into pixels/waveform (LTX-2 NVFP4 LPIPS 0.066 → 0.050 once excluded).
+- Per-block attention/MLP Linears (`to_q`, `to_k`, etc.) all read the
+  hidden-dim activation (6144 for FLUX.2) and write back to the same
+  hidden dim, which is well above the threshold, so they're not falsely
+  excluded.
+
+This catches the canonical sensitive layers without any family-specific
+configuration:
+
+- FLUX.1: `time_text_embed.timestep_embedder.linear_1` (256→3072) triggers
+  in-side exclusion of the whole `time_text_embed.*` subtree
+- FLUX.2: `time_guidance_embed.timestep_embedder.linear_1` (256→6144) triggers
+  in-side exclusion of the whole `time_guidance_embed.*` subtree
+- SD3:    same pattern under `time_text_embed.*`
+- LTX-2:  `proj_out` (4096→128) + `audio_proj_out` (2048→128) trigger
+  out-side exclusion — replaces the need for an LTX2Adapter
+  `default_quant_exclude_modules` override
+
+Users can still pass their own `quant_config.exclude_modules` to add layers;
+the auto-detected patterns are unioned in.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch.nn as nn
+
+# Conservative default. The smallest activation a DiT block sees is the
+# hidden dim (typically 1024+); anything ≤512 in_features or ≤512 out_features
+# almost certainly comes from a low-dim conditioning projection or a
+# latent-channel compression.
+SMALL_DIM_THRESHOLD = 512
+
+# Back-compat alias — older call sites pass `max_embed_in_dim=`.
+SMALL_INPUT_DIM_THRESHOLD = SMALL_DIM_THRESHOLD
+
+
+def _all_linear_descendants(module: nn.Module) -> list[tuple[str, nn.Linear]]:
+    """Return every `nn.Linear` reachable under `module`, with relative names."""
+    return [(n, m) for n, m in module.named_modules() if isinstance(m, nn.Linear)]
+
+
+def find_quantization_sensitive_linears(
+    root: nn.Module,
+    max_embed_in_dim: int = SMALL_DIM_THRESHOLD,
+    max_embed_out_dim: int | None = None,
+) -> list[str]:
+    """Return glob patterns covering Linears that produce conditioning signals
+    or compress to latent channels.
+
+    Args:
+        root: The transformer module to analyse.
+        max_embed_in_dim: A Linear with `in_features <= this` triggers
+            "conditioning embedder" detection on its containing subtree.
+        max_embed_out_dim: A Linear with `out_features <= this` triggers
+            "latent compression" detection on its containing subtree.
+
+    Returns:
+        Glob patterns of the form ``["*<top_level_child_name>*", ...]`` suitable
+        for `QuantConfig.exclude_modules`. Empty list if nothing triggers.
+
+    Env override: setting `VISGEN_SENSITIVITY_OUT_DIM` overrides the
+    `max_embed_out_dim` default. Set to `0` to disable the out-side rule
+    entirely (useful for regression-testing against the old in-only
+    behavior).
+    """
+    if max_embed_out_dim is None:
+        env = os.environ.get("VISGEN_SENSITIVITY_OUT_DIM")
+        max_embed_out_dim = int(env) if env is not None else SMALL_DIM_THRESHOLD
+    patterns: list[str] = []
+    for name, child in root.named_children():
+        if isinstance(child, nn.ModuleList):
+            continue
+        child_linears = _all_linear_descendants(child)
+        if not child_linears:
+            continue
+        if any(
+            lin.in_features <= max_embed_in_dim or lin.out_features <= max_embed_out_dim
+            for _, lin in child_linears
+        ):
+            patterns.append(f"*{name}*")
+    return patterns

--- a/tensorrt_llm/_torch/visual_gen/auto/tp_annotate.py
+++ b/tensorrt_llm/_torch/visual_gen/auto/tp_annotate.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Annotate Diffusers `nn.Linear`s with TP roles (pre-export).
+
+For TP we need to know which Linears are attention Q/K/V projections (output-
+split — TensorParallelMode.COLUMN) vs output projections / MLP-down (input-
+split with all-reduce — TensorParallelMode.ROW). The auto path's structural
+fusion passes already detect these roles in the captured FX graph (e.g.,
+`auto/fusion.py:_fuse_same_input_linears` finds Q/K/V via "same input + feed
+attention reshape"), but `replace_linear_with_trtllm` runs *before* capture
+on the original `nn.Module` tree — so we need a pre-capture annotator.
+
+Strategy: walk the module tree, find container classes whose names indicate
+attention or feed-forward role (`*Attention*`, `*Attn*`, `*FeedForward*`,
+`*FFN*`, `*MLP*`), and tag their direct-child `nn.Linear`s by attribute
+name (Diffusers naming is highly stable for these: `to_q/k/v`, `to_out`,
+`add_q_proj`, `to_qkv_mlp_proj`, `linear_in/out`, ...).
+
+Why this isn't fragile: every DiT-family Diffusers transformer follows the
+same `Attention(...).to_q/.to_out` and `FeedForward(...).linear_in/.linear_out`
+conventions — they're enforced by Diffusers' `AttentionModuleMixin`. Adding
+a new family means at most a few extra attribute names in the table below.
+
+The annotator also **patches `attn.heads` to `H // tp_size`** on each attention
+module. Diffusers' attention reshape is `query.unflatten(-1, (attn.heads, -1))`
+— with the patched count, the unflatten produces `(B, S, H/P, head_dim)` on
+each rank when the TP-sharded Linear emits `(B, S, hidden/P)`. No FX-graph
+rewrite of the reshape is needed.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+import torch.nn as nn
+
+from tensorrt_llm.logger import logger
+
+# Tagged via `module._tp_role`. The keys correspond to TensorParallelMode:
+#   "qkv", "ff_in"  → COLUMN (output-split, no collective)
+#   "out_proj", "ff_out" → ROW (input-split, all-reduce after)
+_QKV_NAMES = frozenset(
+    {
+        "to_q",
+        "to_k",
+        "to_v",
+        "add_q_proj",
+        "add_k_proj",
+        "add_v_proj",
+        "qkv_proj",
+        "to_qkv",
+        "add_qkv_proj",
+        "to_qkv_mlp_proj",  # FLUX.2 single-stream fused
+    }
+)
+_OUT_NAMES = frozenset(
+    {
+        "to_out",
+        "to_add_out",
+        "out_proj",
+    }
+)
+_FF_IN_NAMES = frozenset(
+    {
+        "linear_in",
+        "linear_1",
+        "fc1",
+        "gate_proj",
+        "up_proj",
+        "proj_in",
+    }
+)
+_FF_OUT_NAMES = frozenset(
+    {
+        "linear_out",
+        "linear_2",
+        "fc2",
+        "down_proj",
+    }
+)
+
+
+def _is_attention_module(module: nn.Module) -> bool:
+    name = type(module).__name__
+    return "Attention" in name or name.endswith("Attn")
+
+
+def _is_ffn_module(module: nn.Module) -> bool:
+    name = type(module).__name__
+    upper = name.upper()
+    return (
+        "FEEDFORWARD" in upper
+        or "FFN" in upper
+        or (upper.endswith("MLP") and "FORMER" not in upper)
+    )
+
+
+def _tag_linear(module: nn.Linear, role: str, counts: defaultdict) -> None:
+    module._tp_role = role
+    counts[role] += 1
+
+
+def _tag_attention_children(attn: nn.Module, counts: defaultdict) -> None:
+    """Walk one attention module's direct children, tag Q/K/V/out by name."""
+    for child_name, child in attn.named_children():
+        if isinstance(child, nn.Linear):
+            if child_name in _QKV_NAMES:
+                _tag_linear(child, "qkv", counts)
+            elif child_name in _OUT_NAMES:
+                _tag_linear(child, "out_proj", counts)
+        elif isinstance(child, nn.ModuleList):
+            # to_out is sometimes ModuleList([Linear, Dropout])
+            if child_name in _OUT_NAMES:
+                for sub in child:
+                    if isinstance(sub, nn.Linear):
+                        _tag_linear(sub, "out_proj", counts)
+
+
+def _tag_ffn_children(ffn: nn.Module, counts: defaultdict) -> None:
+    for child_name, child in ffn.named_children():
+        if not isinstance(child, nn.Linear):
+            continue
+        if child_name in _FF_IN_NAMES:
+            _tag_linear(child, "ff_in", counts)
+        elif child_name in _FF_OUT_NAMES:
+            _tag_linear(child, "ff_out", counts)
+
+
+def annotate_tp_roles(transformer: nn.Module, tp_size: int) -> dict[str, Any]:
+    """Tag every Linear in attention/FFN containers with a TP role and patch
+    `attn.heads = num_heads // tp_size` on each attention module.
+
+    Returns a summary dict with role counts and patched-attention count.
+    Untagged Linears (embedders, modulation projections, output projection of
+    the transformer, etc.) stay replicated — no TP, no collective.
+    """
+    if tp_size <= 1:
+        return {"qkv": 0, "out_proj": 0, "ff_in": 0, "ff_out": 0, "attn_patched": 0}
+
+    counts: defaultdict = defaultdict(int)
+    n_attn_patched = 0
+    for name, module in transformer.named_modules():
+        if _is_attention_module(module):
+            _tag_attention_children(module, counts)
+            # Patch the head count so `unflatten(-1, (attn.heads, -1))` produces
+            # the sharded head count at capture time.
+            if hasattr(module, "heads"):
+                if module.heads % tp_size != 0:
+                    raise ValueError(
+                        f"TP annotate: {name}.heads={module.heads} not divisible by "
+                        f"tp_size={tp_size}"
+                    )
+                module.heads = module.heads // tp_size
+                n_attn_patched += 1
+        elif _is_ffn_module(module):
+            _tag_ffn_children(module, counts)
+    summary = dict(counts)
+    summary["attn_patched"] = n_attn_patched
+    logger.info(f"VisGen-Auto TP annotate: {dict(summary)} (tp_size={tp_size})")
+    return summary

--- a/tensorrt_llm/_torch/visual_gen/config.py
+++ b/tensorrt_llm/_torch/visual_gen/config.py
@@ -36,6 +36,7 @@ from tensorrt_llm.quantization.mode import QuantAlgo
 # =============================================================================
 
 CacheBackendName = Literal["teacache", "cache_dit"]
+PipelineMode = Literal["fallback", "auto", "strict"]
 
 # =============================================================================
 # Pipeline component identifiers
@@ -530,6 +531,18 @@ class VisualGenArgs(StrictBaseModel):
     # Skip warmup inference after loading (useful for testing or fast startup)
     skip_warmup: bool = False
 
+    # VisGen-Auto dispatch mode — handled by
+    # `tensorrt_llm._torch.visual_gen.pipeline_registry.AutoPipeline`.
+    pipeline_mode: PipelineMode = PydanticField(
+        "fallback",
+        description=(
+            "Dispatch mode for the auto-pipeline path. "
+            "'fallback' (default): use handwritten pipeline if registered, else auto. "
+            "'auto': force the auto path even for registered checkpoints (parity testing). "
+            "'strict': use handwritten if registered, else raise."
+        ),
+    )
+
     # Sub-configs (dict input for quant_config is coerced to QuantConfig in model_validator)
     quant_config: QuantConfig = PydanticField(default_factory=QuantConfig)
     compilation: CompilationConfig = PydanticField(default_factory=CompilationConfig)
@@ -693,6 +706,7 @@ class DiffusionModelConfig(BaseModel):
     attention_metadata_state: Optional[Dict[str, Any]] = None
     parallel: ParallelConfig = PydanticField(default_factory=ParallelConfig)
     cache: Optional[CacheConfig] = None
+    pipeline_mode: PipelineMode = "fallback"
 
     @property
     def cache_backend(self) -> Optional[CacheBackendName]:
@@ -940,6 +954,7 @@ class DiffusionModelConfig(BaseModel):
         attention_cfg = args.attention if args else AttentionConfig()
         parallel_cfg = args.parallel if args else ParallelConfig()
         cache_cfg = args.cache if args else None
+        pipeline_mode: PipelineMode = args.pipeline_mode if args else "fallback"
 
         component = PipelineComponent.TRANSFORMER
         checkpoint_path = Path(checkpoint_dir)
@@ -1070,6 +1085,7 @@ class DiffusionModelConfig(BaseModel):
             attention_metadata_state=attention_metadata_state,
             parallel=parallel_cfg,
             cache=cache_cfg,
+            pipeline_mode=pipeline_mode,
             skip_create_weights_in_init=True,
             extra_attrs=extra_attrs,
             **kwargs,

--- a/tensorrt_llm/_torch/visual_gen/models/wan/transformer_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/transformer_wan.py
@@ -416,31 +416,16 @@ class WanBlock(nn.Module):
             encoder_hidden_states_text = encoder_hidden_states[:, image_context_length:]
 
         # Text cross-attention
-        batch_size, seq_len = norm_x.shape[:2]
         q, k, v = self.attn2.get_qkv(norm_x, encoder_hidden_states_text)
         q, k = self.attn2.apply_qk_norm(q, k)
-        attn2_output = self.attn2._attn_impl(
-            q,
-            k,
-            v,
-            batch_size=batch_size,
-            seq_len=seq_len,
-            kv_seq_len=encoder_hidden_states_text.shape[1],
-        )
+        attn2_output = self.attn2._attn_impl(q, k, v)
 
         # I2V: image cross-attention
         if encoder_hidden_states_img is not None:
             key_img = self.add_k_proj(encoder_hidden_states_img)
             value_img = self.add_v_proj(encoder_hidden_states_img)
             key_img = self.norm_added_k(key_img)
-            attn_img_output = self.attn2._attn_impl(
-                q,
-                key_img,
-                value_img,
-                batch_size=batch_size,
-                seq_len=seq_len,
-                kv_seq_len=encoder_hidden_states_img.shape[1],
-            )
+            attn_img_output = self.attn2._attn_impl(q, key_img, value_img)
             attn2_output = attn2_output + attn_img_output
 
         # Apply to_out once to the combined (text + image) attention output

--- a/tensorrt_llm/_torch/visual_gen/pipeline_loader.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline_loader.py
@@ -16,7 +16,7 @@ Dynamic Quantization:
 
 import os
 import time
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 import torch
 import torch.distributed as dist
@@ -28,10 +28,7 @@ from tensorrt_llm.logger import logger
 
 from .config import DiffusionModelConfig, VisualGenArgs
 from .mapping import VisualGenMapping
-from .models import AutoPipeline
-
-if TYPE_CHECKING:
-    from .models import BasePipeline
+from .models import BasePipeline
 
 
 class PipelineLoader:
@@ -128,24 +125,32 @@ class PipelineLoader:
         self,
         checkpoint_dir: Optional[str] = None,
         skip_warmup: bool = False,
-    ) -> "BasePipeline":
+    ):
         """
-        Load a diffusion pipeline with optional dynamic quantization.
+        Load a diffusion pipeline. Returns either a `BasePipeline` (handwritten
+        path) or an `AutoTransformerPipeline` (auto path) — the two are NOT
+        in the same class hierarchy; callers use `isinstance(pipeline,
+        BasePipeline)` to gate handwritten-only operations.
 
         Flow:
-        1. Resolve checkpoint_dir (local path or HuggingFace Hub model ID)
-        2. Load config via DiffusionModelConfig.from_pretrained()
-        3. Create pipeline via AutoPipeline.from_config() with MetaInit
-        4. Load transformer weights via pipeline.load_transformer_weights()
-        5. Load auxiliary components (VAE, text_encoder)
-        6. Call pipeline.post_load_weights()
+        1. Resolve checkpoint_dir (local path or HuggingFace Hub model ID).
+        2. Load config via DiffusionModelConfig.from_pretrained().
+        3. `_create_pipeline` branches on auto vs handwritten:
+           - Handwritten: MetaInitMode wrap → materialize → load weights →
+             load standard components → post-load hooks → torch.compile →
+             warmup.
+           - Auto: skip MetaInitMode (Diffusers from_pretrained loads weights
+             eagerly), do all load work in __init__, then warmup. The auto
+             path silently ignores `args.text_encoder_path` and
+             `args.skip_components` (Diffusers' from_pretrained owns
+             standard-component loading) — warnings emitted below.
 
         Args:
             checkpoint_dir: Local path or HF Hub model ID (uses args.checkpoint_path if not provided)
             skip_warmup: If True, skip warmup inference after loading (useful for testing)
 
         Returns:
-            Loaded pipeline (WanPipeline, FluxPipeline, etc.) - type auto-detected
+            Loaded pipeline — `BasePipeline` subclass or `AutoTransformerPipeline`.
         """
         # Resolve checkpoint_dir
         checkpoint_dir = checkpoint_dir or (self.args.checkpoint_path if self.args else None)
@@ -180,62 +185,83 @@ class PipelineLoader:
         self._setup_visual_gen_mapping(config)
 
         # =====================================================================
-        # STEP 2: Create Pipeline with MetaInit
-        # Pipeline type is auto-detected from model_index.json
-        # - Meta tensors (no GPU memory until materialization)
-        # - If quant_config specifies FP8, Linear layers have FP8 weight buffers
+        # STEP 2: Create Pipeline
+        # Pipeline type is auto-detected from model_index.json.
+        # - Handwritten path: meta-init wrap so Linear layers don't allocate
+        #   GPU buffers until step 2b's materialize. Weights are loaded in
+        #   step 3 / step 4 below.
+        # - Auto path (AutoTransformerPipeline): Diffusers'
+        #   `DiffusionPipeline.from_pretrained` loads all weights eagerly in
+        #   one call, which is incompatible with meta-tensor dispatch — so we
+        #   skip MetaInitMode entirely for the auto branch. The auto path
+        #   does ALL load work inside `__init__`.
         # =====================================================================
-        logger.info("Creating pipeline with MetaInitMode")
-        with MetaInitMode():
-            pipeline = AutoPipeline.from_config(config, checkpoint_dir)
+        pipeline = self._create_pipeline(config, checkpoint_dir)
+        is_handwritten = isinstance(pipeline, BasePipeline)
 
-        # Convert meta tensors to CUDA tensors
-        self._materialize_meta_tensors(pipeline)
-        pipeline.to(self.device)
+        # The auto path's component-loading is owned by Diffusers'
+        # `from_pretrained` (inside `AutoDiffusersPipeline.__init__`); the
+        # loader's `text_encoder_path` / `skip_components` knobs do not apply.
+        # Warn loudly if the user set them — they will be silently dropped.
+        if not is_handwritten:
+            if text_encoder_path:
+                logger.warning(
+                    f"AutoTransformerPipeline ignores VisualGenArgs.text_encoder_path"
+                    f"={text_encoder_path!r}; Diffusers' from_pretrained loads "
+                    "the text encoder from the checkpoint directory directly. "
+                    "Use a Diffusers-shaped checkpoint with the desired text "
+                    "encoder co-located, or override after construction via "
+                    "`pipeline._inner._pipe.text_encoder = ...`."
+                )
+            if skip_components:
+                logger.warning(
+                    f"AutoTransformerPipeline ignores VisualGenArgs.skip_components"
+                    f"={list(skip_components)!r}; Diffusers' from_pretrained loads "
+                    "all components eagerly. To skip a component, edit the "
+                    "checkpoint's `model_index.json` or replace the component "
+                    "post-construction."
+                )
 
-        # =====================================================================
-        # STEP 3: Load Transformer Weights
-        # Each pipeline implements load_transformer_weights() for its own
-        # checkpoint format.  The default (BasePipeline) uses WeightLoader
-        # for diffusers-compatible checkpoints with a transformer/ subdir.
-        # If dynamic_weight_quant=True:
-        #   - BF16 checkpoint weights are loaded
-        #   - Quantized on-the-fly to FP8/NVFP4 by DynamicLinearWeightLoader
-        #   - Copied into model's quantized buffers
-        # =====================================================================
-        weights = pipeline.load_transformer_weights(checkpoint_dir)
-        pipeline.load_weights(weights)
+        # ----- Handwritten-only lifecycle (steps 2b-4) ------------------------
+        if is_handwritten:
+            # Convert meta tensors to CUDA tensors
+            self._materialize_meta_tensors(pipeline)
+            pipeline.to(self.device)
 
-        # =====================================================================
-        # STEP 4: Load Standard Components (VAE, TextEncoder, etc.)
-        # These are NOT quantized - loaded as-is from checkpoint
-        # =====================================================================
-        extra_kwargs = {}
-        if text_encoder_path:
-            extra_kwargs["text_encoder_path"] = text_encoder_path
-        pipeline.load_standard_components(
-            checkpoint_dir,
-            self.device,
-            skip_components,
-            **extra_kwargs,
-        )
+            # STEP 3: Load transformer weights (handwritten checkpoint format).
+            weights = pipeline.load_transformer_weights(checkpoint_dir)
+            pipeline.load_weights(weights)
+
+            # STEP 4: Load standard components (VAE, TextEncoder, etc.).
+            extra_kwargs = {}
+            if text_encoder_path:
+                extra_kwargs["text_encoder_path"] = text_encoder_path
+            pipeline.load_standard_components(
+                checkpoint_dir,
+                self.device,
+                skip_components,
+                **extra_kwargs,
+            )
+
         logger.info(f"Model loaded successfully in {time.time() - load_start:.2f}s")
 
         # =====================================================================
-        # STEP 5: Post-load Hooks (TeaCache setup, etc.)
+        # STEP 5: Post-load hooks
+        # Common hooks run on both paths; handwritten-only hooks gated on
+        # `is_handwritten` to keep the auto path from advertising features it
+        # silently no-ops.
         # =====================================================================
-
         t0 = time.time()
-        if config.parallel.parallel_vae_size > 1:
+        if is_handwritten and config.parallel.parallel_vae_size > 1:
             pipeline.setup_parallel_vae()
 
         if hasattr(pipeline, "post_load_weights"):
             pipeline.post_load_weights()
 
-        if config.torch_compile.enable_torch_compile:
+        if is_handwritten and config.torch_compile.enable_torch_compile:
             torch._dynamo.config.cache_size_limit = 128
             pipeline.torch_compile()
-        else:
+        elif is_handwritten:
             logger.info("torch.compile disabled by config")
 
         if not skip_warmup:
@@ -252,19 +278,58 @@ class PipelineLoader:
             logger.info("Warmup skipped (skip_warmup=True)")
 
         if config.pipeline.enable_layerwise_nvtx_marker:
-            from tensorrt_llm._torch.pyexecutor.layerwise_nvtx_marker import LayerwiseNvtxMarker
+            if not is_handwritten:
+                # `transformer_components` is a `BasePipeline` concept (multi-
+                # stream pipelines like WAN 2.2 declare both `transformer` and
+                # `transformer_2`); the auto path has only the captured
+                # GraphModule and doesn't expose the same enumeration. Skip
+                # the marker on the auto path with an info log rather than
+                # crashing on AttributeError.
+                logger.info(
+                    "enable_layerwise_nvtx_marker=True ignored on the auto path "
+                    "(no `transformer_components` enumeration)"
+                )
+            else:
+                from tensorrt_llm._torch.pyexecutor.layerwise_nvtx_marker import LayerwiseNvtxMarker
 
-            marker = LayerwiseNvtxMarker()
-            module_prefix = pipeline.__class__.__name__
-            for transformer_component in pipeline.transformer_components:
-                logger.info(f"Registering layerwise NVTX markers for {transformer_component}")
-                marker.register_hooks(getattr(pipeline, transformer_component), module_prefix)
+                marker = LayerwiseNvtxMarker()
+                module_prefix = pipeline.__class__.__name__
+                for transformer_component in pipeline.transformer_components:
+                    logger.info(f"Registering layerwise NVTX markers for {transformer_component}")
+                    marker.register_hooks(getattr(pipeline, transformer_component), module_prefix)
 
         logger.info(
             f"Pipeline loaded: {pipeline.__class__.__name__} "
             f"(total load time: {time.time() - load_start:.2f}s)"
         )
         return pipeline
+
+    def _create_pipeline(self, config: DiffusionModelConfig, checkpoint_dir: str):
+        """Build the pipeline instance, branching on auto vs handwritten path.
+
+        The handwritten path is constructed inside `MetaInitMode` so its
+        Linear layers don't allocate GPU buffers until step 2b's materialize.
+        The auto path is constructed *outside* MetaInitMode because Diffusers'
+        `DiffusionPipeline.from_pretrained` loads weights eagerly (and meta
+        tensors confuse it).
+
+        Dispatch (`AutoPipeline.from_config`) reuses the existing handwritten
+        registry; the auto branch returns an `AutoTransformerPipeline` which is
+        NOT a `BasePipeline` subclass — the caller uses `isinstance` to gate
+        handwritten-only lifecycle hooks.
+        """
+        # Resolve which path will be taken so we know whether MetaInitMode
+        # applies, without duplicating the registry's dispatch logic.
+        from .auto.pipeline import AutoTransformerPipeline
+        from .pipeline_registry import AutoPipeline as _AP
+
+        target_cls = _AP.resolve_target_class(config, checkpoint_dir)
+        if target_cls is AutoTransformerPipeline:
+            logger.info("Creating AutoTransformerPipeline (no MetaInitMode)")
+            return AutoTransformerPipeline(config, checkpoint_dir)
+        logger.info(f"Creating {target_cls.__name__} with MetaInitMode")
+        with MetaInitMode():
+            return target_cls(config)
 
     def _materialize_meta_tensors(self, module: torch.nn.Module) -> None:
         """

--- a/tensorrt_llm/_torch/visual_gen/pipeline_registry.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline_registry.py
@@ -3,11 +3,18 @@
 Follows: VisualGenArgs → PipelineLoader → DiffusionModelConfig → AutoPipeline → BasePipeline
 
 All pipelines (Wan, Flux, Flux2, LTX2) register via @register_pipeline decorator.
+
+Dispatch is controlled by `DiffusionModelConfig.pipeline_mode`:
+
+- ``fallback`` (default): registered class_name -> handwritten pipeline,
+  unregistered -> AutoTransformerPipeline.
+- ``auto``: always AutoTransformerPipeline, ignoring registration.
+- ``strict``: registered -> handwritten, unregistered -> raise.
 """
 
 import json
 import os
-from typing import TYPE_CHECKING, Dict, Type
+from typing import TYPE_CHECKING, Dict, Optional, Tuple, Type
 
 from tensorrt_llm.logger import logger
 
@@ -17,6 +24,19 @@ if TYPE_CHECKING:
 
 # Global registry: pipeline_name -> pipeline_class
 PIPELINE_REGISTRY: Dict[str, Type["BasePipeline"]] = {}
+
+
+class _UnregisteredClassName(Exception):
+    """Raised by ``_detect_from_checkpoint`` when a Diffusers ``model_index.json``
+    exists but its ``_class_name`` is not in the handwritten ``PIPELINE_REGISTRY``.
+
+    The dispatch layer catches this to route the checkpoint to the auto path
+    under ``pipeline_mode="fallback"``.
+    """
+
+    def __init__(self, class_name: str) -> None:
+        super().__init__(f"Unregistered Diffusers class_name: {class_name!r}")
+        self.class_name = class_name
 
 
 def register_pipeline(name: str):
@@ -43,30 +63,70 @@ class AutoPipeline:
     def from_config(
         config: "DiffusionModelConfig",
         checkpoint_dir: str,
-    ) -> "BasePipeline":
+    ):
         """
         Create pipeline instance from DiffusionModelConfig.
+
+        Dispatch follows ``config.pipeline_mode`` — see module docstring for
+        the three-mode behavior.
+
+        Returns either a `BasePipeline` (handwritten) or an
+        `AutoTransformerPipeline` (auto path). The two are NOT in the same
+        class hierarchy by design — see the module docstring at
+        ``auto/pipeline.py`` for the rationale.
         """
-        # Detect pipeline type from model_index.json or from model safetensors
-        pipeline_type = AutoPipeline._detect_from_checkpoint(checkpoint_dir)
+        target_cls = AutoPipeline.resolve_target_class(config, checkpoint_dir)
+        from .auto.pipeline import AutoTransformerPipeline
 
-        if pipeline_type not in PIPELINE_REGISTRY:
-            raise ValueError(
-                f"Unknown pipeline: '{pipeline_type}'. "
-                f"Available: {list(PIPELINE_REGISTRY.keys())}\n"
-                f"Checkpoint: {checkpoint_dir}"
-            )
+        if target_cls is AutoTransformerPipeline:
+            logger.info(f"AutoPipeline: Creating AutoTransformerPipeline from {checkpoint_dir}")
+            return AutoTransformerPipeline(config, checkpoint_dir)
+        logger.info(f"AutoPipeline: Creating {target_cls.__name__} from {checkpoint_dir}")
+        return target_cls(config)
 
-        pipeline_class = PIPELINE_REGISTRY[pipeline_type]
+    @staticmethod
+    def resolve_target_class(
+        config: "DiffusionModelConfig",
+        checkpoint_dir: str,
+    ):
+        """Resolve which pipeline class will handle this checkpoint, without
+        instantiating it. The loader uses this to know whether to wrap
+        construction in `MetaInitMode` (handwritten only).
+        """
+        from .auto.pipeline import AutoTransformerPipeline
+
+        mode = getattr(config, "pipeline_mode", "fallback")
+        if mode == "auto":
+            return AutoTransformerPipeline
+
+        pipeline_type, raw_class_name = AutoPipeline._resolve_pipeline_type(checkpoint_dir)
+        if pipeline_type is None:
+            if mode == "strict":
+                raise ValueError(
+                    f"pipeline_mode='strict' but no handwritten pipeline is registered for "
+                    f"class_name='{raw_class_name}' at {checkpoint_dir}. "
+                    f"Available: {list(PIPELINE_REGISTRY.keys())}"
+                )
+            # mode == "fallback" — drop to auto path.
+            return AutoTransformerPipeline
 
         # Let the pipeline class upgrade itself to a specialised variant
         # (e.g. LTX2Pipeline → LTX2TwoStagesPipeline) based on config.
-        pipeline_class = pipeline_class.resolve_variant(config)
+        return PIPELINE_REGISTRY[pipeline_type].resolve_variant(config)
 
-        logger.info(f"AutoPipeline: Creating {pipeline_class.__name__} from {checkpoint_dir}")
+    @staticmethod
+    def _resolve_pipeline_type(checkpoint_dir: str) -> Tuple[Optional[str], Optional[str]]:
+        """Return ``(registered_pipeline_type, raw_class_name)``.
 
-        # Instantiate pipeline with DiffusionModelConfig
-        return pipeline_class(config)
+        ``registered_pipeline_type`` is ``None`` when no handwritten pipeline is
+        registered for the detected class_name. ``raw_class_name`` carries the
+        original ``_class_name`` from ``model_index.json`` for diagnostics and
+        for the auto path's family-adapter selection.
+        """
+        try:
+            return AutoPipeline._detect_from_checkpoint(checkpoint_dir), None
+        except _UnregisteredClassName as exc:
+            return None, exc.class_name
 
     @staticmethod
     def _detect_from_checkpoint(checkpoint_dir: str) -> str:
@@ -75,6 +135,12 @@ class AutoPipeline:
         Resolution order:
         1. ``model_index.json`` (diffusers directory layout)
         2. Safetensors metadata (LTX-2 native single-file format)
+
+        Raises ``_UnregisteredClassName`` (carrying the raw class_name) when a
+        Diffusers ``model_index.json`` exists but its ``_class_name`` is not
+        recognized — callers in fallback/auto mode can recover from this.
+        Raises ``ValueError`` only when we cannot identify a Diffusers
+        checkpoint at all.
         """
         index_path = os.path.join(checkpoint_dir, "model_index.json")
 
@@ -101,6 +167,11 @@ class AutoPipeline:
                 return "Flux2Pipeline"
             if "Flux" in class_name:
                 return "FluxPipeline"
+
+            # Diffusers checkpoint with an unrecognized class_name. Surface it
+            # via a typed exception so AutoPipeline.from_config can route it
+            # to the auto path under fallback mode.
+            raise _UnregisteredClassName(class_name)
 
         #########################################################
         # 2. Single-safetensors with embedded metadata (LTX-2 specific)

--- a/tests/unittest/_torch/visual_gen/test_auto_capture_smokes.py
+++ b/tests/unittest/_torch/visual_gen/test_auto_capture_smokes.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Auto-path capture smoke tests — guards against silent fusion regressions.
+
+For each family adapter:
+1. Import the adapter (catches Diffusers minor-bump renames at import time).
+2. Build `example_inputs` against the real Diffusers transformer (catches
+   signature drift).
+3. `torch.export` the transformer + apply rewrites.
+4. Assert the rewritten GraphModule contains the expected
+   `visgen_auto::sdpa` / `visgen_auto::dit_qk_norm_rope` node counts.
+
+The node-count assertion is the bit that catches **silent perf
+regressions** from PyTorch / Diffusers bumps: if a decomposition change
+breaks the QK-rope pattern matcher, the fusion falls back to eager. The
+test runs end-to-end without errors but flags the missing fusion.
+
+Heavy: each capture builds the real Diffusers transformer (BF16 weights).
+Gated on `LLM_MODELS_ROOT` + `RUN_VISGEN_AUTO_SMOKES=1`. CI stage operator
+opts in by setting the env var on appropriate GPU runners.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+import torch
+
+_RUN_FLAG = os.environ.get("RUN_VISGEN_AUTO_SMOKES", "").lower() in ("1", "true", "yes")
+
+
+def _llm_models_root() -> Path:
+    """Mirror the resolution order used elsewhere in `tests/unittest/_torch/visual_gen/`
+    (see ``test_model_loader.py``): respect ``LLM_MODELS_ROOT`` env if set,
+    else fall back to the two TRT-LLM CI mount points. Returned path may
+    not exist — callers must check before use (we skip the test on miss
+    rather than fail, so this is usable on workstations without the CI
+    data mount).
+    """
+    if "LLM_MODELS_ROOT" in os.environ:
+        return Path(os.environ["LLM_MODELS_ROOT"])
+    for candidate in (
+        Path("/home/scratch.trt_llm_data_ci/llm-models/"),
+        Path("/scratch.trt_llm_data/llm-models/"),
+    ):
+        if candidate.exists():
+            return candidate
+    # Neither set nor available; return a non-existent sentinel so the
+    # `ckpt.exists()` check in the test body produces a clean skip with
+    # a helpful path in the message.
+    return Path("/llm-models-not-configured")
+
+
+_FAMILIES = [
+    pytest.param(
+        "FluxPipeline",
+        "FLUX.1-dev",
+        # FLUX.1 has 19 dual-stream + 38 single-stream blocks → 57 total
+        # attention sites. The QK-rope fusion replaces the (RMSNorm + RoPE)
+        # cluster feeding each SDPA's Q/K with a single `dit_qk_norm_rope`
+        # call; the SDPA itself stays (it's what runs the actual attention,
+        # just with pre-fused Q/K inputs). So expect ≈ 57 of each, and a
+        # missing-fusion regression shows up as `dit_qk_norm_rope < ~50`.
+        {"dit_qk_norm_rope_ge": 50, "sdpa_ge": 50},
+        id="flux1",
+    ),
+    pytest.param(
+        "Flux2Pipeline",
+        "FLUX.2-dev",
+        # FLUX.2 has 8 dual + 48 single blocks → 56 total SDPA sites. After
+        # the 2026-05-18 matcher extension (`_resolve_split_chunk_site`),
+        # ALL 56 sites fuse: 48 single-stream go through the new
+        # `linear → split_with_sizes → getitem → chunk(3, -1)` path, and
+        # 8 dual-stream go through `_resolve_double_stream_site`. Floor of
+        # 50 catches anything that regresses below "almost full coverage".
+        {"dit_qk_norm_rope_ge": 50, "sdpa_ge": 50},
+        id="flux2",
+    ),
+    pytest.param(
+        "StableDiffusion3Pipeline",
+        "stable-diffusion-3.5-medium",
+        # SD3.5-medium has 24 MM-DiT blocks → 24 SDPA sites. No QK-RMSNorm
+        # fusion path; SDPA stays as `visgen_auto::sdpa` (not fused into
+        # `dit_qk_norm_rope`). Floor of 20 catches a 4-block regression.
+        {"dit_qk_norm_rope_ge": 0, "sdpa_ge": 20},
+        id="sd35",
+    ),
+]
+
+
+@pytest.mark.gpu
+@pytest.mark.skipif(not _RUN_FLAG, reason="Set RUN_VISGEN_AUTO_SMOKES=1 to opt in")
+@pytest.mark.parametrize("pipeline_class,subdir,expected", _FAMILIES)
+def test_family_capture_and_rewrite_node_count(pipeline_class, subdir, expected):
+    """Capture + rewrite a real Diffusers transformer and assert the
+    expected number of `visgen_auto::*` nodes appear in the GraphModule.
+
+    This test fails LOUDLY if a Diffusers/PyTorch bump silently regresses
+    the FX pattern matcher to no-op (fusion falls back to eager —
+    everything still runs, just slower).
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    root = _llm_models_root()
+    ckpt = root / subdir
+    if not ckpt.exists():
+        pytest.skip(f"checkpoint {ckpt} not available")
+
+    from diffusers import DiffusionPipeline
+
+    from tensorrt_llm._torch.visual_gen.auto.auto_pipeline import _resolve_adapter
+    from tensorrt_llm._torch.visual_gen.auto.capture import capture_transformer
+    from tensorrt_llm._torch.visual_gen.auto.rewrite import apply_rewrites
+    from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig
+
+    # Build the Diffusers pipeline (real class signatures so we catch
+    # adapter signature drift), then immediately drop the heavy ancillary
+    # components — we only need the transformer for capture, and the
+    # combined text-encoder + VAE + transformer set blows past 140 GiB
+    # for FLUX.1 / FLUX.2 on a single H200. Move only the transformer
+    # to CUDA.
+    pipe = DiffusionPipeline.from_pretrained(str(ckpt), torch_dtype=torch.bfloat16)
+    transformer = pipe.transformer
+    # Free text encoders, VAE, etc. — they keep ~80 GiB of bf16 weights
+    # alive on FLUX.2 between Mistral + T5 + VAE.
+    for attr in (
+        "text_encoder",
+        "text_encoder_2",
+        "text_encoder_3",
+        "tokenizer",
+        "tokenizer_2",
+        "tokenizer_3",
+        "vae",
+    ):
+        if hasattr(pipe, attr):
+            setattr(pipe, attr, None)
+    import gc
+
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    transformer = transformer.to("cuda")
+    adapter = _resolve_adapter(type(transformer).__name__)
+    model_config = DiffusionModelConfig.from_pretrained(str(ckpt))
+
+    ep = capture_transformer(transformer, adapter, model_config)
+    gm = ep.module()
+    apply_rewrites(gm, adapter.rewrite_policy(model_config))
+
+    # Count target node calls in the rewritten GM.
+    sdpa_target = torch.ops.visgen_auto.sdpa.default
+    qkr_target = torch.ops.visgen_auto.dit_qk_norm_rope.default
+    sdpa_count = sum(
+        1 for n in gm.graph.nodes if n.op == "call_function" and n.target is sdpa_target
+    )
+    qkr_count = sum(1 for n in gm.graph.nodes if n.op == "call_function" and n.target is qkr_target)
+
+    if "dit_qk_norm_rope_ge" in expected:
+        assert qkr_count >= expected["dit_qk_norm_rope_ge"], (
+            f"{pipeline_class}: expected ≥{expected['dit_qk_norm_rope_ge']} "
+            f"dit_qk_norm_rope nodes after rewrite, got {qkr_count}. "
+            "Likely cause: a Diffusers or PyTorch bump changed the FX pattern "
+            "the qk_rope_fusion matcher walks; fusion fell back to eager and "
+            "perf regressed silently. Investigate `auto/qk_rope_fusion.py`."
+        )
+    if "sdpa_ge" in expected:
+        assert sdpa_count >= expected["sdpa_ge"], (
+            f"{pipeline_class}: expected ≥{expected['sdpa_ge']} "
+            f"visgen_auto::sdpa nodes after rewrite, got {sdpa_count}. "
+            "The SDPA rewriter's pattern probably stopped matching — "
+            "`aten._scaled_dot_product_*` decomposition changed in PyTorch?"
+        )
+
+
+@pytest.mark.skipif(not _RUN_FLAG, reason="Set RUN_VISGEN_AUTO_SMOKES=1 to opt in")
+def test_family_adapter_imports():
+    """Pre-flight: every family adapter must import cleanly. Catches
+    `from diffusers... import X` failures at import time rather than
+    later under a confusing torch.export traceback.
+    """
+    from tensorrt_llm._torch.visual_gen.auto.families import (  # noqa: F401
+        Flux2Adapter,
+        FluxAdapter,
+        LTX2Adapter,
+        LTXAdapter,
+        MMDiTAdapter,
+        PixArtAdapter,
+        SanaAdapter,
+        SD3Adapter,
+        WanAdapter,
+    )

--- a/tests/unittest/_torch/visual_gen/test_auto_dispatch.py
+++ b/tests/unittest/_torch/visual_gen/test_auto_dispatch.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Auto-path dispatch logic tests (CPU-only, no checkpoint required).
+
+Verifies `AutoPipeline.resolve_target_class` and `AutoPipeline.from_config`
+correctly route to the handwritten registry or the `AutoTransformerPipeline`
+based on `pipeline_mode` × registered/unregistered `class_name`.
+
+These tests don't load weights or build a real pipeline — they only check
+the resolver's class selection, so they're cheap and CI-safe.
+"""
+
+import json
+import os
+import tempfile
+from types import SimpleNamespace
+
+import pytest
+
+
+def _write_model_index(tmpdir: str, class_name: str) -> str:
+    """Create a minimal Diffusers `model_index.json` so the resolver's
+    checkpoint detection has something to read.
+    """
+    path = os.path.join(tmpdir, "model_index.json")
+    with open(path, "w") as f:
+        json.dump({"_class_name": class_name, "_diffusers_version": "0.39.0"}, f)
+    return tmpdir
+
+
+def _mk_config(pipeline_mode: str) -> SimpleNamespace:
+    """Minimal stand-in for `DiffusionModelConfig`. `resolve_target_class`
+    only reads `.pipeline_mode`; the rest is irrelevant to dispatch.
+    """
+    return SimpleNamespace(pipeline_mode=pipeline_mode)
+
+
+# ---------------------------------------------------------------------------
+# resolve_target_class
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_auto_mode_always_returns_auto():
+    """`pipeline_mode='auto'` should bypass the registry entirely."""
+    from tensorrt_llm._torch.visual_gen.auto.pipeline import AutoTransformerPipeline
+    from tensorrt_llm._torch.visual_gen.pipeline_registry import AutoPipeline
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # Even with a checkpoint that WOULD register as FluxPipeline...
+        _write_model_index(tmp, "FluxPipeline")
+        cls = AutoPipeline.resolve_target_class(_mk_config("auto"), tmp)
+    assert cls is AutoTransformerPipeline
+
+
+def test_resolve_fallback_registered_returns_handwritten():
+    """`pipeline_mode='fallback'` + registered class → handwritten pipeline."""
+    from tensorrt_llm._torch.visual_gen.models import flux  # noqa: F401 — registers
+    from tensorrt_llm._torch.visual_gen.pipeline_registry import PIPELINE_REGISTRY, AutoPipeline
+
+    # FluxPipeline should be in the registry after the import side effect.
+    if "FluxPipeline" not in PIPELINE_REGISTRY:
+        pytest.skip("FluxPipeline not registered (registry import side-effect missing)")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        _write_model_index(tmp, "FluxPipeline")
+        cls = AutoPipeline.resolve_target_class(_mk_config("fallback"), tmp)
+    # `resolve_variant` may upgrade to a specialised subclass; verify the
+    # resolved class is at least a subclass of the registered one.
+    assert issubclass(cls, PIPELINE_REGISTRY["FluxPipeline"])
+
+
+def test_resolve_fallback_unregistered_returns_auto():
+    """`pipeline_mode='fallback'` + unregistered class → auto path."""
+    from tensorrt_llm._torch.visual_gen.auto.pipeline import AutoTransformerPipeline
+    from tensorrt_llm._torch.visual_gen.pipeline_registry import AutoPipeline
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # `SomeUnregisteredCustomPipeline` won't match any substring rule in
+        # `_detect_from_checkpoint` and won't be in the registry.
+        _write_model_index(tmp, "SomeUnregisteredCustomPipeline")
+        cls = AutoPipeline.resolve_target_class(_mk_config("fallback"), tmp)
+    assert cls is AutoTransformerPipeline
+
+
+def test_resolve_strict_unregistered_raises():
+    """`pipeline_mode='strict'` + unregistered class → ValueError."""
+    from tensorrt_llm._torch.visual_gen.pipeline_registry import AutoPipeline
+
+    with tempfile.TemporaryDirectory() as tmp:
+        _write_model_index(tmp, "SomeUnregisteredCustomPipeline")
+        with pytest.raises(ValueError, match="strict"):
+            AutoPipeline.resolve_target_class(_mk_config("strict"), tmp)
+
+
+def test_resolve_strict_registered_returns_handwritten():
+    """`pipeline_mode='strict'` + registered class → handwritten pipeline."""
+    from tensorrt_llm._torch.visual_gen.models import flux  # noqa: F401 — registers
+    from tensorrt_llm._torch.visual_gen.pipeline_registry import PIPELINE_REGISTRY, AutoPipeline
+
+    if "FluxPipeline" not in PIPELINE_REGISTRY:
+        pytest.skip("FluxPipeline not registered")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        _write_model_index(tmp, "FluxPipeline")
+        cls = AutoPipeline.resolve_target_class(_mk_config("strict"), tmp)
+    assert issubclass(cls, PIPELINE_REGISTRY["FluxPipeline"])
+
+
+# ---------------------------------------------------------------------------
+# Inheritance contract
+# ---------------------------------------------------------------------------
+
+
+def test_auto_transformer_pipeline_is_not_base_pipeline():
+    """`AutoTransformerPipeline` is intentionally NOT a `BasePipeline` subclass.
+
+    The loader (`pipeline_loader.PipelineLoader.load`) branches on
+    `isinstance(pipeline, BasePipeline)` to gate handwritten-only lifecycle
+    hooks (`_materialize_meta_tensors`, `load_transformer_weights`,
+    `load_weights`, `load_standard_components`, `torch_compile`). If a
+    future refactor accidentally re-introduces inheritance, those hooks
+    will silently no-op against an auto path that does its load work in
+    `__init__` instead — a regression that's hard to spot at code review
+    but easy to catch with this test.
+    """
+    from tensorrt_llm._torch.visual_gen.auto.pipeline import AutoTransformerPipeline
+    from tensorrt_llm._torch.visual_gen.pipeline import BasePipeline
+
+    assert not issubclass(AutoTransformerPipeline, BasePipeline), (
+        "AutoTransformerPipeline must NOT inherit from BasePipeline — see "
+        "auto/pipeline.py module docstring for the rationale."
+    )
+
+
+def test_auto_transformer_pipeline_implements_executor_surface():
+    """The auto path doesn't subclass BasePipeline but DOES need to expose the
+    methods/attrs the executor reads. Catch silent breakage if a future edit
+    removes one.
+    """
+    from tensorrt_llm._torch.visual_gen.auto.pipeline import AutoTransformerPipeline
+
+    for name in (
+        "infer",  # executor.py:327
+        "warmup",  # pipeline_loader.py:244 / :246
+        "warmup_cache_key",  # executor.py:317
+        "default_generation_params",  # executor.py:189
+        "extra_param_specs",  # executor.py:190
+    ):
+        assert hasattr(AutoTransformerPipeline, name), (
+            f"AutoTransformerPipeline is missing executor-required method/property {name!r}"
+        )

--- a/tests/unittest/_torch/visual_gen/test_auto_family_preload.py
+++ b/tests/unittest/_torch/visual_gen/test_auto_family_preload.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""`_family_preload_overrides` context-manager tests (CPU-only).
+
+Verifies the auto path's Diffusers class-attribute mutations are scoped to
+the load duration (save + restore in `finally`), rather than the permanent
+mutation pattern earlier versions used.
+
+Regression target: a future edit that drops the save/restore around the
+WAN `_keep_in_fp32_modules = []` mutation would let it leak into
+mixed-mode evaluation in the same Python process.
+"""
+
+import json
+import os
+import tempfile
+
+import pytest
+
+
+def _write_index(tmp: str, class_name: str) -> str:
+    path = os.path.join(tmp, "model_index.json")
+    with open(path, "w") as f:
+        json.dump({"_class_name": class_name, "_diffusers_version": "0.39.0"}, f)
+    return tmp
+
+
+def test_no_override_for_non_wan_family():
+    """Override list is empty when the checkpoint isn't WAN — context is a no-op."""
+    from tensorrt_llm._torch.visual_gen.auto.auto_pipeline import _family_preload_overrides
+
+    with tempfile.TemporaryDirectory() as tmp:
+        _write_index(tmp, "FluxPipeline")
+        # Body executes cleanly; nothing to assert beyond "no exception."
+        with _family_preload_overrides(tmp):
+            pass
+
+
+def test_wan_keep_in_fp32_modules_restored_on_normal_exit():
+    """WAN: list is set to [] inside the `with`, restored on normal exit."""
+    try:
+        from diffusers.models.transformers.transformer_wan import WanTransformer3DModel
+    except ImportError:
+        pytest.skip("diffusers WanTransformer3DModel not available")
+
+    from tensorrt_llm._torch.visual_gen.auto.auto_pipeline import _family_preload_overrides
+
+    # Inject a non-empty sentinel so we can detect both the mutation AND the
+    # restore (a default-empty list would mask either).
+    original = WanTransformer3DModel._keep_in_fp32_modules
+    sentinel = ["__test_sentinel_module__"]
+    WanTransformer3DModel._keep_in_fp32_modules = sentinel
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_index(tmp, "WanPipeline")
+            with _family_preload_overrides(tmp):
+                # Inside the context: empty list (the override).
+                assert WanTransformer3DModel._keep_in_fp32_modules == []
+            # After exit: original (sentinel) value restored.
+            assert WanTransformer3DModel._keep_in_fp32_modules == sentinel
+    finally:
+        WanTransformer3DModel._keep_in_fp32_modules = original
+
+
+def test_wan_keep_in_fp32_modules_restored_on_exception():
+    """The override must restore even if the body raises — that's the whole
+    point of the `try/finally` in `_family_preload_overrides`.
+    """
+    try:
+        from diffusers.models.transformers.transformer_wan import WanTransformer3DModel
+    except ImportError:
+        pytest.skip("diffusers WanTransformer3DModel not available")
+
+    from tensorrt_llm._torch.visual_gen.auto.auto_pipeline import _family_preload_overrides
+
+    original = WanTransformer3DModel._keep_in_fp32_modules
+    sentinel = ["__test_sentinel_module__"]
+    WanTransformer3DModel._keep_in_fp32_modules = sentinel
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_index(tmp, "WanPipeline")
+            with pytest.raises(RuntimeError, match="simulated"):
+                with _family_preload_overrides(tmp):
+                    raise RuntimeError("simulated from_pretrained failure")
+            # Despite the exception, the override is restored.
+            assert WanTransformer3DModel._keep_in_fp32_modules == sentinel
+    finally:
+        WanTransformer3DModel._keep_in_fp32_modules = original
+
+
+def test_wan_snapshot_is_a_copy_not_a_reference():
+    """If the original list were captured by reference (and Diffusers ever
+    mutated it in place between save and restore), the restore would just
+    re-install the mutated list. We snapshot a `list(...)` copy.
+    """
+    try:
+        from diffusers.models.transformers.transformer_wan import WanTransformer3DModel
+    except ImportError:
+        pytest.skip("diffusers WanTransformer3DModel not available")
+
+    from tensorrt_llm._torch.visual_gen.auto.auto_pipeline import _family_preload_overrides
+
+    original = WanTransformer3DModel._keep_in_fp32_modules
+    sentinel = ["alpha", "beta"]
+    WanTransformer3DModel._keep_in_fp32_modules = sentinel
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_index(tmp, "WanPipeline")
+            with _family_preload_overrides(tmp):
+                # Simulate an external mutation of the *original* list during
+                # the `with` body. If the snapshot were by reference, this
+                # mutation would be visible after restore.
+                sentinel.append("gamma")
+            # Restore should have re-installed the snapshot (alpha, beta) —
+            # without the simulated `gamma` mutation.
+            assert WanTransformer3DModel._keep_in_fp32_modules == ["alpha", "beta"]
+    finally:
+        WanTransformer3DModel._keep_in_fp32_modules = original
+
+
+def test_missing_model_index_is_silent_noop():
+    """If the directory has no `model_index.json` (e.g. single-safetensor
+    checkpoints like LTX-2), `_family_preload_overrides` is a clean no-op.
+    """
+    from tensorrt_llm._torch.visual_gen.auto.auto_pipeline import _family_preload_overrides
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # No model_index.json written.
+        with _family_preload_overrides(tmp):
+            pass

--- a/tests/unittest/_torch/visual_gen/test_auto_pass_manager.py
+++ b/tests/unittest/_torch/visual_gen/test_auto_pass_manager.py
@@ -1,0 +1,262 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""PassManager unit tests (CPU-only, no checkpoint required).
+
+Exercises the composition primitives + default-pipeline construction. The
+manager only needs an `fx.GraphModule` argument to its passes, but for
+ordering/composition tests a dummy stand-in suffices.
+"""
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Manager composition primitives
+# ---------------------------------------------------------------------------
+
+
+def test_basic_append_and_run():
+    from tensorrt_llm._torch.visual_gen.auto.pass_manager import Pass, PassManager
+
+    log: list[str] = []
+    pm = PassManager()
+    pm.append(Pass("a", lambda _gm: (log.append("a"), 1)[1]))
+    pm.append(Pass("b", lambda _gm: (log.append("b"), 2)[1]))
+
+    results = pm.run(_gm_sentinel())
+    assert log == ["a", "b"]
+    assert results == {"a": 1, "b": 2}
+    assert pm.names() == ["a", "b"]
+    assert len(pm) == 2
+    assert "a" in pm and "z" not in pm
+
+
+def test_insert_before_and_after():
+    from tensorrt_llm._torch.visual_gen.auto.pass_manager import Pass, PassManager
+
+    pm = PassManager(
+        [
+            Pass("alpha", lambda _gm: 0),
+            Pass("gamma", lambda _gm: 0),
+        ]
+    )
+    pm.insert_after("alpha", Pass("beta", lambda _gm: 0))
+    pm.insert_before("alpha", Pass("first", lambda _gm: 0))
+    assert pm.names() == ["first", "alpha", "beta", "gamma"]
+
+
+def test_replace():
+    from tensorrt_llm._torch.visual_gen.auto.pass_manager import Pass, PassManager
+
+    pm = PassManager(
+        [
+            Pass("a", lambda _gm: "old"),
+            Pass("b", lambda _gm: 0),
+        ]
+    )
+    pm.replace("a", Pass("a", lambda _gm: "new"))
+    results = pm.run(_gm_sentinel())
+    assert results["a"] == "new"
+
+
+def test_remove():
+    from tensorrt_llm._torch.visual_gen.auto.pass_manager import Pass, PassManager
+
+    pm = PassManager(
+        [
+            Pass("a", lambda _gm: 0),
+            Pass("b", lambda _gm: 0),
+            Pass("c", lambda _gm: 0),
+        ]
+    )
+    pm.remove("b")
+    assert pm.names() == ["a", "c"]
+
+
+def test_skip_via_run_arg():
+    from tensorrt_llm._torch.visual_gen.auto.pass_manager import Pass, PassManager
+
+    log: list[str] = []
+    pm = PassManager(
+        [
+            Pass("a", lambda _gm: log.append("a")),
+            Pass("b", lambda _gm: log.append("b")),
+            Pass("c", lambda _gm: log.append("c")),
+        ]
+    )
+    pm.run(_gm_sentinel(), skip=["b"])
+    assert log == ["a", "c"]
+
+
+def test_unknown_anchor_raises_key_error():
+    from tensorrt_llm._torch.visual_gen.auto.pass_manager import Pass, PassManager
+
+    pm = PassManager([Pass("a", lambda _gm: 0)])
+    with pytest.raises(KeyError, match=r"no pass named 'nope'"):
+        pm.insert_after("nope", Pass("new", lambda _gm: 0))
+    with pytest.raises(KeyError):
+        pm.remove("nope")
+    with pytest.raises(KeyError):
+        pm.replace("nope", Pass("new", lambda _gm: 0))
+
+
+def test_duplicate_name_on_append_raises():
+    from tensorrt_llm._torch.visual_gen.auto.pass_manager import Pass, PassManager
+
+    pm = PassManager([Pass("a", lambda _gm: 0)])
+    with pytest.raises(ValueError, match=r"already present"):
+        pm.append(Pass("a", lambda _gm: 0))
+    with pytest.raises(ValueError, match=r"already present"):
+        pm.insert_before("a", Pass("a", lambda _gm: 0))
+    with pytest.raises(ValueError, match=r"already present"):
+        pm.insert_after("a", Pass("a", lambda _gm: 0))
+
+
+def test_pass_exception_propagates_and_logs():
+    from tensorrt_llm._torch.visual_gen.auto.pass_manager import Pass, PassManager
+
+    def boom(_gm):
+        raise RuntimeError("simulated pass failure")
+
+    pm = PassManager(
+        [
+            Pass("ok1", lambda _gm: 0),
+            Pass("bad", boom),
+            Pass("ok2", lambda _gm: 0),  # must NOT run after the bad one
+        ]
+    )
+    log: list[str] = []
+    pm._passes[0] = Pass("ok1", lambda _gm: log.append("ok1"))
+    pm._passes[2] = Pass("ok2", lambda _gm: log.append("ok2"))
+    with pytest.raises(RuntimeError, match="simulated"):
+        pm.run(_gm_sentinel())
+    # ok1 ran; ok2 did NOT (bad raised first).
+    assert log == ["ok1"]
+
+
+def test_chaining_returns_self():
+    from tensorrt_llm._torch.visual_gen.auto.pass_manager import Pass, PassManager
+
+    pm = PassManager()
+    out = (
+        pm.append(Pass("a", lambda _gm: 0))
+        .append(Pass("c", lambda _gm: 0))
+        .insert_before("c", Pass("b", lambda _gm: 0))
+    )
+    assert out is pm
+    assert pm.names() == ["a", "b", "c"]
+
+
+# ---------------------------------------------------------------------------
+# Default pipeline construction from RewritePolicy
+# ---------------------------------------------------------------------------
+
+
+def test_default_pipeline_full_policy():
+    """All fusions enabled → all 6 passes registered in canonical order."""
+    from tensorrt_llm._torch.visual_gen.auto.policy import RewritePolicy
+    from tensorrt_llm._torch.visual_gen.auto.rewrite import _build_default_pass_manager
+
+    pm = _build_default_pass_manager(RewritePolicy())  # defaults: all True
+    assert pm.names() == [
+        "sdpa_rewrite",
+        "fuse_qkv",
+        "qk_rope_single",
+        "qk_rope_dual",
+        "contig_for_fp8_quant",
+        "strip_assert_metadata",
+    ]
+
+
+def test_default_pipeline_qkv_off():
+    """`fuse_qkv=False` removes both QKV and qk_rope passes (qk_rope depends on QKV)."""
+    from tensorrt_llm._torch.visual_gen.auto.policy import RewritePolicy
+    from tensorrt_llm._torch.visual_gen.auto.rewrite import _build_default_pass_manager
+
+    pm = _build_default_pass_manager(RewritePolicy(fuse_qkv=False))
+    assert pm.names() == [
+        "sdpa_rewrite",
+        "contig_for_fp8_quant",
+        "strip_assert_metadata",
+    ]
+
+
+def test_default_pipeline_qk_rope_off():
+    """`fuse_qk_rope=False` keeps `fuse_qkv` but drops both qk_rope passes."""
+    from tensorrt_llm._torch.visual_gen.auto.policy import RewritePolicy
+    from tensorrt_llm._torch.visual_gen.auto.rewrite import _build_default_pass_manager
+
+    pm = _build_default_pass_manager(RewritePolicy(fuse_qk_rope=False))
+    assert pm.names() == [
+        "sdpa_rewrite",
+        "fuse_qkv",
+        "contig_for_fp8_quant",
+        "strip_assert_metadata",
+    ]
+
+
+def test_default_pipeline_env_override(monkeypatch):
+    """`VISGEN_AUTO_DISABLE_QKROPE` env var disables qk_rope without code change."""
+    from tensorrt_llm._torch.visual_gen.auto.policy import RewritePolicy
+    from tensorrt_llm._torch.visual_gen.auto.rewrite import _build_default_pass_manager
+
+    monkeypatch.setenv("VISGEN_AUTO_DISABLE_QKROPE", "1")
+    pm = _build_default_pass_manager(RewritePolicy())
+    assert "qk_rope_single" not in pm
+    assert "qk_rope_dual" not in pm
+    assert "fuse_qkv" in pm  # still present
+
+
+# ---------------------------------------------------------------------------
+# Adapter hook
+# ---------------------------------------------------------------------------
+
+
+def test_customize_passes_hook_fires(monkeypatch):
+    """Adapter's `customize_passes(pm)` is called between pipeline construction
+    and run, and adapter changes are reflected at run time.
+    """
+    from tensorrt_llm._torch.visual_gen.auto.pass_manager import Pass
+    from tensorrt_llm._torch.visual_gen.auto.policy import RewritePolicy
+
+    # Don't depend on importing a real adapter — fake one with just the
+    # hook + a sentinel pass.
+    class _Fake:
+        def customize_passes(self, pm):
+            pm.insert_after("sdpa_rewrite", Pass("custom", lambda _gm: "ran"))
+
+    # Build the default pipeline + fire the hook + capture order.
+    from tensorrt_llm._torch.visual_gen.auto.rewrite import _build_default_pass_manager
+
+    pm = _build_default_pass_manager(RewritePolicy())
+    _Fake().customize_passes(pm)
+    assert pm.names() == [
+        "sdpa_rewrite",
+        "custom",  # ← spliced in
+        "fuse_qkv",
+        "qk_rope_single",
+        "qk_rope_dual",
+        "contig_for_fp8_quant",
+        "strip_assert_metadata",
+    ]
+
+
+def test_adapter_default_customize_is_noop():
+    """Default `VisGenFamilyAdapter.customize_passes` does nothing — adapters
+    that don't override see the canonical pipeline unchanged.
+    """
+    from tensorrt_llm._torch.visual_gen.auto.families import FluxAdapter
+    from tensorrt_llm._torch.visual_gen.auto.pass_manager import PassManager
+
+    pm_before = PassManager()
+    FluxAdapter().customize_passes(pm_before)
+    assert pm_before.names() == []
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _gm_sentinel():
+    """Return any object — the composition tests above never inspect it."""
+    return object()


### PR DESCRIPTION
## Summary

Adds a torch.export-based path under `tensorrt_llm/_torch/visual_gen/auto/` that captures a Diffusers transformer, applies a small set of DiT-specific FX rewrites (`visgen_auto::sdpa`, `visgen_auto::dit_qk_norm_rope`, `visgen_auto::all_gather_seq`), and swaps the rewritten `GraphModule` back into the Diffusers pipeline as its `.transformer`. The boundary stays at the denoiser: text encoder, scheduler, latent packing, and VAE remain Python on top.

Coexists with the existing handwritten visual_gen pipelines as a parallel onboarding path. Dispatch is keyed on `DiffusionModelConfig.pipeline_mode` (`fallback` | `auto` | `strict`) in `pipeline_registry.AutoPipeline`. The loader (`pipeline_loader.py`) `isinstance`-branches on the resolved class so the handwritten-only lifecycle hooks (`MetaInitMode`, `_materialize_meta_tensors`, `load_transformer_weights`, `load_weights`, `load_standard_components`, `torch_compile`) only fire for `BasePipeline` subclasses.

## Usage

For a Diffusers checkpoint with no handwritten TRT-LLM pipeline (e.g. SD3.5), the same loader API used for FLUX/WAN/LTX-2 just works — `pipeline_mode="fallback"` (default) routes it through the auto path:

```python
from tensorrt_llm._torch.visual_gen import VisualGenArgs
from tensorrt_llm._torch.visual_gen.pipeline_loader import PipelineLoader
from tensorrt_llm._torch.visual_gen.executor import DiffusionRequest

args = VisualGenArgs(checkpoint_path="stabilityai/stable-diffusion-3.5-medium")
pipeline = PipelineLoader(args).load()    # AutoTransformerPipeline

output = pipeline.infer(DiffusionRequest(
    request_id=1,
    prompt=["a cat holding a sign that says hello"],
    height=1024, width=1024,
    num_inference_steps=28, guidance_scale=7.0,
    seed=42,
))   # → MediaOutput(image=(H, W, C) uint8)
```

Same checkpoint via `trtllm-serve`:

```bash
trtllm-serve stabilityai/stable-diffusion-3.5-medium --port 8000
```

`infer(req: DiffusionRequest) → MediaOutput` is identical to the handwritten path's surface, so the executor / server doesn't see whether it hit a handwritten pipeline or the auto path. No per-family handwritten transformer is needed.

## Coverage

- **Family adapters** (`auto/families/`): FLUX.1, FLUX.2, SD3.5, WAN 2.2, LTX-Video, LTX-2, PixArt-Σ, Sana, plus a generic MM-DiT fallback.
- **Quantization**: BF16/FP8/NVFP4 via `auto/quantize.py`. Sensitivity-driven per-Linear excludes in `auto/sensitivity.py`.
- **Multi-GPU**: Ulysses sequence parallel + CFG-parallel batch split + hybrid CFG × Ulysses.
- Custom-op fake metas are deterministic over args (no module-global side channels).
- A `PassManager` (`auto/pass_manager.py`) declares the canonical pass order; family adapters can splice in custom passes via `customize_passes(pm)`.

## Bundled fix

`models/wan/transformer_wan.py` drops redundant `batch_size=` / `seq_len=` / `kv_seq_len=` kwargs on cross-attention `_attn_impl` calls — already derived from `q.shape`, were producing duplicate-kwarg collisions for some backends.

## Requirements

Pins `diffusers<0.41.0`. Family adapters reach into Diffusers transformer sub-modules via `pre_capture_patch` monkey-patches and are tested against 0.39-0.40. A runtime check in `auto_pipeline._check_diffusers_version` warns outside the tested range (suppressible via `VISGEN_AUTO_DIFFUSERS_VERSION_CHECK=skip`).

## Test plan

- [x] `pytest tests/unittest/_torch/visual_gen/test_auto_dispatch.py` — 7 CPU-only tests covering dispatch + inheritance contract.
- [x] `pytest tests/unittest/_torch/visual_gen/test_auto_family_preload.py` — 5 CPU-only tests covering `_family_preload_overrides` save/restore.
- [x] `pytest tests/unittest/_torch/visual_gen/test_auto_pass_manager.py` — 15 CPU-only tests covering pass-manager composition + default-pipeline construction + adapter hook.
- [x] `RUN_VISGEN_AUTO_SMOKES=1 pytest tests/unittest/_torch/visual_gen/test_auto_capture_smokes.py` — 4 GPU-gated per-family captures + node-count assertions.

**Next step:** post `/bot run --disable-fail-fast` to kick the full CI pipeline once review is requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
