### PR TITLE
[None][chore] Enforce Claude Code skill and agent naming convention via pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2868,6 +2868,15 @@ repos:
         entry: python scripts/check_auto_deploy_imports.py
         language: python
         files: ^tensorrt_llm/_torch/auto_deploy/.*\.py$
+    -   id: check-skill-naming-convention
+        name: Check Claude Code skill naming convention
+        entry: python scripts/check_skill_naming_convention.py
+        language: python
+        additional_dependencies:
+        - PyYAML
+        pass_filenames: false
+        files: >-
+          ^(\.claude/skills/[^/]+/SKILL\.md|\.claude/agents/.*\.md|scripts/check_skill_naming_convention\.py)$
     -   id:  type-check
         name: Run static analysis of type correctness using mypy
         entry: scripts/run_mypy.sh

--- a/scripts/check_skill_naming_convention.py
+++ b/scripts/check_skill_naming_convention.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Enforce the Claude Code skill (and agent) naming convention.
+
+The skill naming convention is defined in ``.claude/README.md``. Agents follow
+the same convention, so this check covers both.
+
+For every skill (``.claude/skills/*/SKILL.md``) and agent
+(``.claude/agents/*.md``):
+
+1. The on-disk name (file stem or directory name) must start with one of the
+   prefixes in ``ALLOWED_PREFIXES`` below, followed by ``-`` and at least one
+   descriptive character.
+2. The frontmatter ``name:`` field must match the on-disk name.
+
+``ALLOWED_PREFIXES`` is the authoritative list. When adding or renaming a
+prefix, update both this list and the prefix table in
+``.claude/README.md``.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+ALLOWED_PREFIXES = (
+    "ad-",
+    "exec-",
+    "kernel-",
+    "perf-",
+    "trtllm-",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+NAMING_DOC = REPO_ROOT / ".claude" / "README.md"
+AGENTS_DIR = REPO_ROOT / ".claude" / "agents"
+SKILLS_DIR = REPO_ROOT / ".claude" / "skills"
+
+FRONTMATTER_RE = re.compile(r"\A(?:<!--.*?-->\s*)*---\n(.*?)\n---\n?", re.DOTALL)
+
+
+def load_frontmatter_name(path: Path) -> str | None:
+    m = FRONTMATTER_RE.match(path.read_text())
+    if not m:
+        return None
+    data = yaml.safe_load(m.group(1)) or {}
+    name = data.get("name")
+    return name if isinstance(name, str) else None
+
+
+def check_prefix(name: str) -> str | None:
+    for prefix in ALLOWED_PREFIXES:
+        if name.startswith(prefix) and len(name) > len(prefix):
+            return None
+    options = ", ".join(ALLOWED_PREFIXES)
+    return f"does not start with an allowed prefix ({options})"
+
+
+def collect_items() -> list[tuple[Path, str]]:
+    items: list[tuple[Path, str]] = []
+    for path in sorted(SKILLS_DIR.glob("*/SKILL.md")):
+        items.append((path, path.parent.name))
+    for path in sorted(AGENTS_DIR.glob("*.md")):
+        items.append((path, path.stem))
+    return items
+
+
+def main() -> int:
+    violations: list[str] = []
+
+    for path, expected_name in collect_items():
+        rel = path.relative_to(REPO_ROOT)
+
+        msg = check_prefix(expected_name)
+        if msg:
+            violations.append(f"{rel}: {expected_name!r} {msg}")
+
+        fm_name = load_frontmatter_name(path)
+        if fm_name is None:
+            violations.append(f"{rel}: missing `name` field in frontmatter")
+        elif fm_name != expected_name:
+            violations.append(
+                f"{rel}: frontmatter name {fm_name!r} != on-disk name {expected_name!r}"
+            )
+
+    if violations:
+        doc_rel = NAMING_DOC.relative_to(REPO_ROOT)
+        print(f"Skill naming convention violations (see {doc_rel}):", file=sys.stderr)
+        for v in violations:
+            print(f"  {v}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated validation for naming conventions of Claude skills and agents to ensure consistency and maintainability across the codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Enforces the Claude Code skill (and agent) naming convention documented in `.claude/README.md` via a pre-commit hook:

1. Every skill (`.claude/skills/*/SKILL.md`) and agent (`.claude/agents/*.md`) on-disk name must start with one of the approved domain prefixes — `ad-`, `exec-`, `kernel-`, `perf-`, `trtllm-` — followed by a descriptive suffix.
2. The frontmatter `name:` field must match the on-disk name (directory name for skills, file stem for agents).

The hook runs `scripts/check_skill_naming_convention.py` whenever a skill, agent, or the checker itself is touched, and fails the commit with a list of violations. This keeps new contributions aligned with the convention without manual review.

## Test Coverage

- `python scripts/check_skill_naming_convention.py` exits 0 on the current tree; all existing skills and agents already comply with the documented prefixes.
- The hook's `files:` filter scopes runs to `.claude/skills/<name>/SKILL.md`, `.claude/agents/*.md`, and the checker script itself, so it only fires on relevant changes.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
