### PR TITLE
[None][fix] handle ADP dummy allocation failure

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3625,13 +3625,19 @@ class PyExecutor:
                     and self.kv_cache_transceiver is not None
                     and self.max_num_tokens is not None):
                 token_nums = [self.max_num_tokens]
-            llm_request = self.kv_cache_manager.add_dummy_requests(
+            dummy_requests = self.kv_cache_manager.add_dummy_requests(
                 request_ids=[0],
                 token_nums=token_nums,
                 is_gen=self._adp_dummy_is_gen,
                 prepare_resource=True,
                 max_num_draft_tokens=self.max_total_draft_tokens,
-            )[0]
+            )
+            if dummy_requests is None:
+                logger.warning(
+                    "Skipping attention-DP dummy request because KV cache "
+                    "resources are unavailable; retrying next iteration.")
+                return
+            llm_request = dummy_requests[0]
             llm_request.is_attention_dp_dummy = True
             spec_resource_manager = self.resource_manager.get_resource_manager(
                 ResourceManagerType.SPEC_RESOURCE_MANAGER)

--- a/tests/unittest/_torch/executor/test_benchmark_disagg.py
+++ b/tests/unittest/_torch/executor/test_benchmark_disagg.py
@@ -572,6 +572,23 @@ class TestPadAttentionDpDummyBenchmarkDisagg:
         ex._pad_attention_dp_dummy_request()
         ex.kv_cache_manager.add_dummy_requests.assert_called_once()
 
+    def test_skips_when_dummy_allocation_fails(self):
+        """A saturated KV cache should skip the ADP dummy for this iteration."""
+        ex = MockPadDummyExecutor(
+            is_benchmark_disagg=True,
+            benchmark_fill_phase_active=False,
+            kv_cache_transceiver=Mock(),
+            active_requests=[],
+            expected_num_active_requests=1,
+        )
+        ex.kv_cache_manager.add_dummy_requests.return_value = None
+
+        ex._pad_attention_dp_dummy_request()
+
+        ex.kv_cache_manager.add_dummy_requests.assert_called_once()
+        ex.resource_manager.get_resource_manager.assert_not_called()
+        assert ex.active_requests == []
+
     def test_no_dummy_needed_when_active_requests_ready(self):
         """Rank has ready requests: needs_dummy condition is False."""
         ready_req = _make_active_request(in_init=False, in_transfer=False)


### PR DESCRIPTION
## Description

PR #14255 made `KVCacheManagerV2.add_dummy_requests()` return `None` when KV cache resources cannot be allocated, for example when the V2 `IndexMapper` is saturated by disaggregated generation transfer state. The attention-DP dummy padding caller still indexed the return value directly, which turned the expected allocation failure path into a `TypeError: 'NoneType' object is not subscriptable`.

This change handles the `None` return in `_pad_attention_dp_dummy_request()` by skipping dummy insertion for the current iteration. That leaves the rank empty, allowing the existing queue/forward gating to avoid the forward pass and retry on a later iteration after resources become available.

## Test Coverage

- `PYTHONPYCACHEPREFIX=/private/tmp/pycache python3 -m py_compile tensorrt_llm/_torch/pyexecutor/py_executor.py tests/unittest/_torch/executor/test_benchmark_disagg.py`
- `git diff --check`
- `python3 -m pytest tests/unittest/_torch/executor/test_benchmark_disagg.py -k PadAttentionDpDummyBenchmarkDisagg` (not run locally: `pytest` is not installed in the local Python environment)