### PR TITLE
[TRTLLM-12758][feat] honor named function in tool_choice for non-harmony models

### DIFF
--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -54,23 +54,14 @@ from tensorrt_llm.serve.chat_utils import (load_chat_template,
 from tensorrt_llm.serve.cluster_storage import create_cluster_storage_client
 from tensorrt_llm.serve.disagg_auto_scaling import DisaggClusterWorker
 from tensorrt_llm.serve.metadata_server import create_metadata_server
-from tensorrt_llm.serve.openai_protocol import (ChatCompletionRequest,
-                                                ChatCompletionResponse,
-                                                ChatCompletionResponseChoice,
-                                                ChatMessage, CompletionRequest,
-                                                CompletionResponse,
-                                                CompletionResponseChoice,
-                                                ErrorResponse,
-                                                ImageGenerationRequest,
-                                                ImageGenerationResponse,
-                                                ImageObject,
-                                                MemoryUpdateRequest, ModelCard,
-                                                ModelList, PromptTokensDetails,
-                                                ResponseFormat,
-                                                ResponsesRequest,
-                                                ResponsesResponse,
-                                                UpdateWeightsRequest, UsageInfo,
-                                                to_llm_disaggregated_params)
+from tensorrt_llm.serve.openai_protocol import (
+    ChatCompletionNamedToolChoiceParam, ChatCompletionRequest,
+    ChatCompletionResponse, ChatCompletionResponseChoice, ChatMessage,
+    CompletionRequest, CompletionResponse, CompletionResponseChoice,
+    ErrorResponse, ImageGenerationRequest, ImageGenerationResponse, ImageObject,
+    MemoryUpdateRequest, ModelCard, ModelList, PromptTokensDetails,
+    ResponseFormat, ResponsesRequest, ResponsesResponse, UpdateWeightsRequest,
+    UsageInfo, to_llm_disaggregated_params)
 from tensorrt_llm.serve.openai_video_routes import _VideoRoutesMixin
 from tensorrt_llm.serve.postprocess_handlers import (
     ChatCompletionPostprocArgs, ChatPostprocArgs, CompletionPostprocArgs,
@@ -102,31 +93,57 @@ from .harmony_adapter import (HarmonyAdapter, get_harmony_adapter,
 TIMEOUT_KEEP_ALIVE = 5  # seconds.
 
 
-def _build_tool_strict_guided_decoding_params(tools, tool_parser_name):
-    """Build GuidedDecodingParams with structural tags for tools with strict=True.
+def _build_tool_strict_guided_decoding_params(tools,
+                                              tool_parser_name,
+                                              forced_tool_name=None):
+    """Build GuidedDecodingParams with structural tags for tool calls.
 
-    When a tool has ``strict=True`` in its function definition, the server
-    should use constrained decoding to guarantee that the generated tool call
-    arguments exactly match the function's ``parameters`` JSON Schema.
+    Two modes are supported:
 
-    This function builds structural tag items from each tool parser's
-    ``structure_info()`` and the tool's ``parameters`` schema, then returns
-    a ``GuidedDecodingParams`` with the structural tag format.
+    * **Forced tool call** (``forced_tool_name`` is set): used when the request
+      passes ``tool_choice={"type": "function", "function": {"name": "X"}}``.
+      The model is constrained to emit exactly one tool call to function ``X``.
+      The function's ``parameters`` JSON Schema (when present) is used to
+      constrain the generated arguments.
+    * **Strict tools** (``forced_tool_name`` is ``None``): when one or more
+      tools have ``strict=True``, constrained decoding guarantees that
+      generated arguments match the function's ``parameters`` JSON Schema.
 
-    Returns None if no tool has strict=True or the parser doesn't support
-    structural tags.
+    Raises:
+        ValueError: if ``forced_tool_name`` does not match any function name
+            in ``tools``.
+        ValueError: if ``forced_tool_name`` is set but ``tool_parser_name`` is
+            empty or the parser does not support structural tags.
+
+    Returns ``None`` if no constrained decoding is needed (no strict tool and
+    no forced name).
     """
-    if not tools or not tool_parser_name:
-        return None
+    if forced_tool_name is None:
+        if not tools or not tool_parser_name:
+            return None
 
-    # Check if any tool has strict=True
-    has_strict = any(tool.function.strict for tool in tools
-                     if tool.function.strict)
-    if not has_strict:
-        return None
+        # Check if any tool has strict=True
+        has_strict = any(tool.function.strict for tool in tools
+                         if tool.function.strict)
+        if not has_strict:
+            return None
+    else:
+        if not tools:
+            raise ValueError(
+                "tool_choice requires a named function "
+                f"'{forced_tool_name}' but no tools were provided.")
+        if not tool_parser_name:
+            raise ValueError(
+                "tool_choice with a named function requires a tool parser "
+                "to be configured on the server (use --tool_parser).")
 
-    tool_parser_cls = ToolParserFactory.parsers.get(tool_parser_name.lower())
+    tool_parser_cls = ToolParserFactory.parsers.get(
+        tool_parser_name.lower()) if tool_parser_name else None
     if tool_parser_cls is None:
+        if forced_tool_name is not None:
+            raise ValueError(
+                f"Tool parser '{tool_parser_name}' is not registered; cannot "
+                f"force tool_choice to function '{forced_tool_name}'.")
         logger.warning(
             "Tool parser '%s' not found, cannot enforce strict mode for tools.",
             tool_parser_name)
@@ -134,6 +151,11 @@ def _build_tool_strict_guided_decoding_params(tools, tool_parser_name):
 
     parser = tool_parser_cls()
     if not parser.supports_structural_tag():
+        if forced_tool_name is not None:
+            raise ValueError(
+                f"Tool parser '{tool_parser_name}' does not support "
+                "structural tags, which are required to honor "
+                "tool_choice with a named function.")
         logger.warning(
             "Tool parser '%s' does not support structural tags, "
             "cannot enforce strict mode for tools.", tool_parser_name)
@@ -143,25 +165,52 @@ def _build_tool_strict_guided_decoding_params(tools, tool_parser_name):
 
     tags = []
     triggers = set()
-    for tool in tools:
-        info = get_info(tool.function.name)
-        triggers.add(info.trigger)
 
-        if tool.function.strict and tool.function.parameters:
-            # Strict tool: constrain arguments to match the JSON Schema
+    if forced_tool_name is not None:
+        # Force the model to call exactly the named function.
+        forced_tool = next(
+            (t for t in tools if t.function.name == forced_tool_name), None)
+        if forced_tool is None:
+            available = sorted(t.function.name for t in tools
+                               if t.function.name)
+            raise ValueError(
+                f"tool_choice requested function '{forced_tool_name}' which "
+                f"is not present in `tools`. Available functions: {available}.")
+
+        info = get_info(forced_tool.function.name)
+        triggers.add(info.trigger)
+        if forced_tool.function.parameters:
             content = {
                 "type": "json_schema",
-                "json_schema": tool.function.parameters,
+                "json_schema": forced_tool.function.parameters,
             }
         else:
-            # Non-strict tool or no parameters: allow any text
             content = {"type": "any_text"}
-
         tags.append({
             "begin": info.begin,
             "content": content,
             "end": info.end,
         })
+    else:
+        for tool in tools:
+            info = get_info(tool.function.name)
+            triggers.add(info.trigger)
+
+            if tool.function.strict and tool.function.parameters:
+                # Strict tool: constrain arguments to match the JSON Schema
+                content = {
+                    "type": "json_schema",
+                    "json_schema": tool.function.parameters,
+                }
+            else:
+                # Non-strict tool or no parameters: allow any text
+                content = {"type": "any_text"}
+
+            tags.append({
+                "begin": info.begin,
+                "content": content,
+                "end": info.end,
+            })
 
     stag_format = {
         "type": "triggered_tags",
@@ -1204,20 +1253,52 @@ class OpenAIServer(_VideoRoutesMixin):
                 tokenizer=self.tokenizer,
                 chat_template_kwargs=request.chat_template_kwargs,
             )
+            # Resolve a named tool_choice (OpenAI spec / Azure compat):
+            #   tool_choice = {"type": "function", "function": {"name": "X"}}
+            # forces the model to call exactly function X. We honor this by
+            # routing through the structural-tag guided-decoding path, regardless
+            # of whether any tool has strict=True.
+            forced_tool_name = None
+            if isinstance(request.tool_choice,
+                          ChatCompletionNamedToolChoiceParam):
+                if not request.tools:
+                    return self.create_error_response(
+                        message=("tool_choice with a named function requires "
+                                 "`tools` to be set."),
+                        err_type="BadRequestError",
+                        status_code=HTTPStatus.BAD_REQUEST)
+                forced_tool_name = request.tool_choice.function.name
+
             if self.tool_parser and request.tools:
                 tool_parser_cls = ToolParserFactory.parsers.get(
                     self.tool_parser.lower())
                 if tool_parser_cls and getattr(
                         tool_parser_cls, 'needs_raw_special_tokens', False):
                     sampling_params.skip_special_tokens = False
-                # When strict=True on any tool, apply constrained decoding
-                # via structural tags (only if response_format doesn't already
-                # set guided decoding).
+                # Apply structural-tag guided decoding when:
+                #   - any tool has strict=True, OR
+                #   - tool_choice is a named function
+                # (skip if response_format already set guided decoding).
                 if sampling_params.guided_decoding is None:
-                    strict_guided = _build_tool_strict_guided_decoding_params(
-                        request.tools, self.tool_parser)
+                    try:
+                        strict_guided = _build_tool_strict_guided_decoding_params(
+                            request.tools,
+                            self.tool_parser,
+                            forced_tool_name=forced_tool_name)
+                    except ValueError as e:
+                        return self.create_error_response(
+                            message=str(e),
+                            err_type="BadRequestError",
+                            status_code=HTTPStatus.BAD_REQUEST)
                     if strict_guided is not None:
                         sampling_params.guided_decoding = strict_guided
+            elif forced_tool_name is not None:
+                # tools were provided but the server has no tool_parser configured.
+                return self.create_error_response(
+                    message=("tool_choice with a named function requires the "
+                             "server to be started with --tool_parser."),
+                    err_type="BadRequestError",
+                    status_code=HTTPStatus.BAD_REQUEST)
             postproc_args = ChatPostprocArgs.from_request(request)
             disaggregated_params = to_llm_disaggregated_params(
                 request.disaggregated_params)
@@ -1679,6 +1760,18 @@ class OpenAIServer(_VideoRoutesMixin):
                 raise
 
         try:
+            # Named tool_choice (forced function call) is not yet supported on
+            # the harmony / GPT-OSS path; return a clear 4xx pointing to the
+            # follow-up sub-task rather than silently falling back to "auto".
+            # See TRTLLM-12758 (and its harmony follow-up).
+            if isinstance(request.tool_choice,
+                          ChatCompletionNamedToolChoiceParam):
+                return self.create_error_response(
+                    message=("tool_choice with a named function is not yet "
+                             "supported for harmony / GPT-OSS models. Tracking "
+                             "follow-up: harmony sub-task of TRTLLM-12758."),
+                    err_type="BadRequestError",
+                    status_code=HTTPStatus.BAD_REQUEST)
             # Initialize HarmonyAdapter
             # NOTE: WAR for Disagg failure, may affect perf if no warmup
             if not self.harmony_adapter:

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -93,57 +93,31 @@ from .harmony_adapter import (HarmonyAdapter, get_harmony_adapter,
 TIMEOUT_KEEP_ALIVE = 5  # seconds.
 
 
-def _build_tool_strict_guided_decoding_params(tools,
-                                              tool_parser_name,
-                                              forced_tool_name=None):
-    """Build GuidedDecodingParams with structural tags for tool calls.
+def _build_tool_strict_guided_decoding_params(tools, tool_parser_name):
+    """Build GuidedDecodingParams with structural tags for tools with strict=True.
 
-    Two modes are supported:
+    When a tool has ``strict=True`` in its function definition, the server
+    should use constrained decoding to guarantee that the generated tool call
+    arguments exactly match the function's ``parameters`` JSON Schema.
 
-    * **Forced tool call** (``forced_tool_name`` is set): used when the request
-      passes ``tool_choice={"type": "function", "function": {"name": "X"}}``.
-      The model is constrained to emit exactly one tool call to function ``X``.
-      The function's ``parameters`` JSON Schema (when present) is used to
-      constrain the generated arguments.
-    * **Strict tools** (``forced_tool_name`` is ``None``): when one or more
-      tools have ``strict=True``, constrained decoding guarantees that
-      generated arguments match the function's ``parameters`` JSON Schema.
+    This function builds structural tag items from each tool parser's
+    ``structure_info()`` and the tool's ``parameters`` schema, then returns
+    a ``GuidedDecodingParams`` with the structural tag format.
 
-    Raises:
-        ValueError: if ``forced_tool_name`` does not match any function name
-            in ``tools``.
-        ValueError: if ``forced_tool_name`` is set but ``tool_parser_name`` is
-            empty or the parser does not support structural tags.
-
-    Returns ``None`` if no constrained decoding is needed (no strict tool and
-    no forced name).
+    Returns None if no tool has strict=True or the parser doesn't support
+    structural tags.
     """
-    if forced_tool_name is None:
-        if not tools or not tool_parser_name:
-            return None
+    if not tools or not tool_parser_name:
+        return None
 
-        # Check if any tool has strict=True
-        has_strict = any(tool.function.strict for tool in tools
-                         if tool.function.strict)
-        if not has_strict:
-            return None
-    else:
-        if not tools:
-            raise ValueError(
-                "tool_choice requires a named function "
-                f"'{forced_tool_name}' but no tools were provided.")
-        if not tool_parser_name:
-            raise ValueError(
-                "tool_choice with a named function requires a tool parser "
-                "to be configured on the server (use --tool_parser).")
+    # Check if any tool has strict=True
+    has_strict = any(tool.function.strict for tool in tools
+                     if tool.function.strict)
+    if not has_strict:
+        return None
 
-    tool_parser_cls = ToolParserFactory.parsers.get(
-        tool_parser_name.lower()) if tool_parser_name else None
+    tool_parser_cls = ToolParserFactory.parsers.get(tool_parser_name.lower())
     if tool_parser_cls is None:
-        if forced_tool_name is not None:
-            raise ValueError(
-                f"Tool parser '{tool_parser_name}' is not registered; cannot "
-                f"force tool_choice to function '{forced_tool_name}'.")
         logger.warning(
             "Tool parser '%s' not found, cannot enforce strict mode for tools.",
             tool_parser_name)
@@ -151,11 +125,6 @@ def _build_tool_strict_guided_decoding_params(tools,
 
     parser = tool_parser_cls()
     if not parser.supports_structural_tag():
-        if forced_tool_name is not None:
-            raise ValueError(
-                f"Tool parser '{tool_parser_name}' does not support "
-                "structural tags, which are required to honor "
-                "tool_choice with a named function.")
         logger.warning(
             "Tool parser '%s' does not support structural tags, "
             "cannot enforce strict mode for tools.", tool_parser_name)
@@ -165,52 +134,25 @@ def _build_tool_strict_guided_decoding_params(tools,
 
     tags = []
     triggers = set()
-
-    if forced_tool_name is not None:
-        # Force the model to call exactly the named function.
-        forced_tool = next(
-            (t for t in tools if t.function.name == forced_tool_name), None)
-        if forced_tool is None:
-            available = sorted(t.function.name for t in tools
-                               if t.function.name)
-            raise ValueError(
-                f"tool_choice requested function '{forced_tool_name}' which "
-                f"is not present in `tools`. Available functions: {available}.")
-
-        info = get_info(forced_tool.function.name)
+    for tool in tools:
+        info = get_info(tool.function.name)
         triggers.add(info.trigger)
-        if forced_tool.function.parameters:
+
+        if tool.function.strict and tool.function.parameters:
+            # Strict tool: constrain arguments to match the JSON Schema
             content = {
                 "type": "json_schema",
-                "json_schema": forced_tool.function.parameters,
+                "json_schema": tool.function.parameters,
             }
         else:
+            # Non-strict tool or no parameters: allow any text
             content = {"type": "any_text"}
+
         tags.append({
             "begin": info.begin,
             "content": content,
             "end": info.end,
         })
-    else:
-        for tool in tools:
-            info = get_info(tool.function.name)
-            triggers.add(info.trigger)
-
-            if tool.function.strict and tool.function.parameters:
-                # Strict tool: constrain arguments to match the JSON Schema
-                content = {
-                    "type": "json_schema",
-                    "json_schema": tool.function.parameters,
-                }
-            else:
-                # Non-strict tool or no parameters: allow any text
-                content = {"type": "any_text"}
-
-            tags.append({
-                "begin": info.begin,
-                "content": content,
-                "end": info.end,
-            })
 
     stag_format = {
         "type": "triggered_tags",
@@ -221,6 +163,75 @@ def _build_tool_strict_guided_decoding_params(tools,
     resp_format = ResponseFormat(type="structural_tag", format=stag_format)
     return GuidedDecodingParams(structural_tag=resp_format.model_dump_json(
         by_alias=True, exclude_none=True))
+
+
+def _build_forced_tool_call_decoding(tools, tool_parser_name, forced_tool_name):
+    r"""Build the (begin_prefix, GuidedDecodingParams) pair used to honor a
+    named ``tool_choice``.
+
+    OpenAI / Azure spec: ``tool_choice={"type":"function","function":{"name":"X"}}``
+    must force the model to emit exactly one tool call to function ``X``.
+
+    Unlike the strict-tools path (which relies on xgrammar's *triggered*
+    structural tags and is therefore non-mandatory by design), this path
+    forces the call by:
+
+    1. Asking the caller to prepend ``begin_prefix`` (e.g.
+       ``<tool_call>\n{"name":"X", "arguments":``) to the rendered prompt
+       so the model starts generation *already inside* the tool call.
+    2. Constraining what follows with a plain JSON-schema (or json-object)
+       guided-decoding mode so the arguments are guaranteed to be valid
+       against ``tool.function.parameters``.
+
+    The caller is then responsible for synthesizing the resulting
+    ``tool_calls`` entry — the raw model output is the JSON arguments
+    string of the forced function call.
+
+    Raises:
+        ValueError: if ``tools`` is empty, ``tool_parser_name`` is unset, the
+            parser is not registered, the parser does not support structural
+            tags, or ``forced_tool_name`` is not in ``tools``.
+    """
+    if not tools:
+        raise ValueError("tool_choice requires a named function "
+                         f"'{forced_tool_name}' but no tools were provided.")
+    if not tool_parser_name:
+        raise ValueError(
+            "tool_choice with a named function requires a tool parser "
+            "to be configured on the server (use --tool_parser).")
+
+    tool_parser_cls = ToolParserFactory.parsers.get(tool_parser_name.lower())
+    if tool_parser_cls is None:
+        raise ValueError(
+            f"Tool parser '{tool_parser_name}' is not registered; cannot "
+            f"force tool_choice to function '{forced_tool_name}'.")
+
+    parser = tool_parser_cls()
+    if not parser.supports_structural_tag():
+        raise ValueError(
+            f"Tool parser '{tool_parser_name}' does not support structural "
+            "tags, which are required to honor tool_choice with a named "
+            "function.")
+
+    forced_tool = next(
+        (t for t in tools if t.function.name == forced_tool_name), None)
+    if forced_tool is None:
+        available = sorted(t.function.name for t in tools if t.function.name)
+        raise ValueError(
+            f"tool_choice requested function '{forced_tool_name}' which is "
+            f"not present in `tools`. Available functions: {available}.")
+
+    info = parser.structure_info()(forced_tool.function.name)
+    begin_prefix = info.begin
+
+    if forced_tool.function.parameters:
+        guided = GuidedDecodingParams(json=forced_tool.function.parameters)
+    else:
+        # No parameters declared — still require a JSON object (typically ``{}``)
+        # so the synthesized ``arguments`` field is well-formed JSON.
+        guided = GuidedDecodingParams(json_object=True)
+
+    return begin_prefix, guided
 
 
 def _normalize_image_output(image) -> list:
@@ -1256,15 +1267,34 @@ class OpenAIServer(_VideoRoutesMixin):
             # Resolve a named tool_choice (OpenAI spec / Azure compat):
             #   tool_choice = {"type": "function", "function": {"name": "X"}}
             # forces the model to call exactly function X. We honor this by
-            # routing through the structural-tag guided-decoding path, regardless
-            # of whether any tool has strict=True.
+            # (a) prefix-injecting the tool parser's ``begin`` string into the
+            # rendered chat prompt so the model starts generation already inside
+            # a tool call, and (b) constraining the generated arguments with
+            # plain JSON-schema guided decoding. The post-processor then
+            # synthesizes the resulting ``tool_calls`` entry. Unlike the
+            # ``triggered_tags`` structural-tag path used for ``strict`` tools,
+            # this path is mandatory by construction — the model cannot escape
+            # the tool call.
             forced_tool_name = None
+            forced_tool_begin_prefix = None
             if isinstance(request.tool_choice,
                           ChatCompletionNamedToolChoiceParam):
                 if not request.tools:
                     return self.create_error_response(
                         message=("tool_choice with a named function requires "
                                  "`tools` to be set."),
+                        err_type="BadRequestError",
+                        status_code=HTTPStatus.BAD_REQUEST)
+                if request.prompt_token_ids is not None:
+                    # Tokenizing and concatenating the ``begin_prefix`` onto a
+                    # pre-tokenized prompt correctly across all tokenizers is
+                    # fragile (token-boundary issues with special tokens).
+                    # Reject the combination explicitly until there is a
+                    # demonstrated use case.
+                    return self.create_error_response(
+                        message=("tool_choice with a named function is not "
+                                 "supported alongside `prompt_token_ids`; pass "
+                                 "`messages` instead."),
                         err_type="BadRequestError",
                         status_code=HTTPStatus.BAD_REQUEST)
                 forced_tool_name = request.tool_choice.function.name
@@ -1275,23 +1305,30 @@ class OpenAIServer(_VideoRoutesMixin):
                 if tool_parser_cls and getattr(
                         tool_parser_cls, 'needs_raw_special_tokens', False):
                     sampling_params.skip_special_tokens = False
-                # Apply structural-tag guided decoding when:
-                #   - any tool has strict=True, OR
-                #   - tool_choice is a named function
-                # (skip if response_format already set guided decoding).
                 if sampling_params.guided_decoding is None:
-                    try:
+                    if forced_tool_name is not None:
+                        # Forced-call path: build the begin-prefix + JSON-schema
+                        # guided decoding. The prefix is injected into the
+                        # prompt after ``apply_chat_template`` below.
+                        try:
+                            forced_tool_begin_prefix, forced_guided = (
+                                _build_forced_tool_call_decoding(
+                                    request.tools, self.tool_parser,
+                                    forced_tool_name))
+                        except ValueError as e:
+                            return self.create_error_response(
+                                message=str(e),
+                                err_type="BadRequestError",
+                                status_code=HTTPStatus.BAD_REQUEST)
+                        sampling_params.guided_decoding = forced_guided
+                    else:
+                        # Strict-tools path: structural tags with the existing
+                        # ``triggered_tags`` semantics. Engages only when at
+                        # least one tool has ``strict=True``.
                         strict_guided = _build_tool_strict_guided_decoding_params(
-                            request.tools,
-                            self.tool_parser,
-                            forced_tool_name=forced_tool_name)
-                    except ValueError as e:
-                        return self.create_error_response(
-                            message=str(e),
-                            err_type="BadRequestError",
-                            status_code=HTTPStatus.BAD_REQUEST)
-                    if strict_guided is not None:
-                        sampling_params.guided_decoding = strict_guided
+                            request.tools, self.tool_parser)
+                        if strict_guided is not None:
+                            sampling_params.guided_decoding = strict_guided
             elif forced_tool_name is not None:
                 # tools were provided but the server has no tool_parser configured.
                 return self.create_error_response(
@@ -1334,6 +1371,10 @@ class OpenAIServer(_VideoRoutesMixin):
                     chat_template=request.chat_template or self.chat_template,
                     chat_template_kwargs=request.chat_template_kwargs or {},
                 )
+                if forced_tool_begin_prefix is not None:
+                    # Force the model to start generation inside the tool call.
+                    # See ``_build_forced_tool_call_decoding`` for details.
+                    prompt = prompt + forced_tool_begin_prefix
             prompt = prompt_inputs(prompt)
 
             mm_data, mm_embeddings = await mm_coroutines
@@ -1352,6 +1393,7 @@ class OpenAIServer(_VideoRoutesMixin):
             postproc_args.reasoning_parser = self.generator.args.reasoning_parser
             postproc_args.tool_parser = self.tool_parser
             postproc_args.tool_call_id_type = self.tool_call_id_type
+            postproc_args.forced_tool_name = forced_tool_name
             if conversation and conversation[-1].get(
                     "content") and conversation[-1].get("role") == get_role():
                 postproc_args.last_message_content = conversation[-1]["content"]

--- a/tensorrt_llm/serve/postprocess_handlers.py
+++ b/tensorrt_llm/serve/postprocess_handlers.py
@@ -279,52 +279,46 @@ def chat_stream_post_processor(rsp: GenerationResultBase,
             True,
             finished=(output.finish_reason is not None))
 
-        if args.tool_choice and type(
-                args.tool_choice) is ChatCompletionNamedToolChoiceParam:
-            delta_message = DeltaMessage(tool_calls=[
-                DeltaToolCall(
-                    function=DeltaFunctionCall(
-                        name=args.tool_choice.function.name,
-                        arguments=delta_text),
-                    index=i,
-                ),
-            ], )
-        else:
-            delta_text, calls = apply_tool_parser(args, i, delta_text, True)
-            tool_calls = []
-            for call_item in calls:
-                # Tool call ID should be generated only once per tool call
-                if call_item.name:
-                    # First chunk: include ID and function name
-                    tool_call_id = make_tool_call_id(
-                        id_type=args.tool_call_id_type,
-                        func_name=call_item.name,
-                        idx=call_item.tool_index)
-                    function_name = call_item.name
-                else:
-                    # Subsequent chunks: null ID and name for argument deltas
-                    tool_call_id = None
-                    function_name = None
-
-                tool_calls.append(
-                    DeltaToolCall(
-                        id=tool_call_id,
-                        index=call_item.tool_index,
-                        function=DeltaFunctionCall(
-                            name=function_name,
-                            arguments=call_item.parameters,
-                        ),
-                    ))
-            # Keep token-bearing chunks visible even when detokenization has no
-            # text to flush yet.
-            if (tool_calls or delta_text or reasoning_delta_text
-                    or output.finish_reason or has_token_delta):
-                delta_message = DeltaMessage(
-                    content=delta_text,
-                    reasoning_content=reasoning_delta_text,
-                    tool_calls=tool_calls if tool_calls else None)
+        # Note: even when tool_choice forces a named function, guided decoding
+        # constrains the model to emit a structurally-tagged tool call (e.g.
+        # ``<tool_call>\n{"name":"X","arguments":{...}}\n</tool_call>``); the
+        # standard tool parser handles that uniformly with the auto path, so
+        # there is no longer a separate ChatCompletionNamedToolChoiceParam
+        # branch here.
+        delta_text, calls = apply_tool_parser(args, i, delta_text, True)
+        tool_calls = []
+        for call_item in calls:
+            # Tool call ID should be generated only once per tool call
+            if call_item.name:
+                # First chunk: include ID and function name
+                tool_call_id = make_tool_call_id(id_type=args.tool_call_id_type,
+                                                 func_name=call_item.name,
+                                                 idx=call_item.tool_index)
+                function_name = call_item.name
             else:
-                continue
+                # Subsequent chunks: null ID and name for argument deltas
+                tool_call_id = None
+                function_name = None
+
+            tool_calls.append(
+                DeltaToolCall(
+                    id=tool_call_id,
+                    index=call_item.tool_index,
+                    function=DeltaFunctionCall(
+                        name=function_name,
+                        arguments=call_item.parameters,
+                    ),
+                ))
+        # Keep token-bearing chunks visible even when detokenization has no
+        # text to flush yet.
+        if (tool_calls or delta_text or reasoning_delta_text
+                or output.finish_reason or has_token_delta):
+            delta_message = DeltaMessage(
+                content=delta_text,
+                reasoning_content=reasoning_delta_text,
+                tool_calls=tool_calls if tool_calls else None)
+        else:
+            continue
 
         choice = ChatCompletionResponseStreamChoice(
             index=i,
@@ -392,28 +386,22 @@ def chat_response_post_processor(
         text, reasoning_text = apply_reasoning_parser(args, output.index,
                                                       output.text, False)
 
-        if args.tool_choice and isinstance(args.tool_choice,
-                                           ChatCompletionNamedToolChoiceParam):
-            message = ChatMessage(
-                role=role,
-                content="",
-                tool_calls=[
-                    ToolCall(function=FunctionCall(
-                        name=args.tool_choice.function.name, arguments=text))
-                ])
-        else:
-            if text is None:
-                text = ""
-            text, calls = apply_tool_parser(args, output.index, text, False)
-            tool_calls = [
-                ToolCall(function=FunctionCall(name=call.name or "",
-                                               arguments=call.parameters))
-                for call in calls
-            ]
-            message = ChatMessage(role=role,
-                                  content=text,
-                                  reasoning_content=reasoning_text,
-                                  tool_calls=tool_calls)
+        # Named tool_choice is honored by the server via guided decoding (the
+        # model is constrained to emit a tagged tool-call wrapper around the
+        # forced function); the standard tool parser then extracts the call
+        # name and arguments uniformly with the "auto" path.
+        if text is None:
+            text = ""
+        text, calls = apply_tool_parser(args, output.index, text, False)
+        tool_calls = [
+            ToolCall(function=FunctionCall(name=call.name or "",
+                                           arguments=call.parameters))
+            for call in calls
+        ]
+        message = ChatMessage(role=role,
+                              content=text,
+                              reasoning_content=reasoning_text,
+                              tool_calls=tool_calls)
         disaggregated_params = to_disaggregated_params(
             output.disaggregated_params)
         choice = ChatCompletionResponseChoice(

--- a/tensorrt_llm/serve/postprocess_handlers.py
+++ b/tensorrt_llm/serve/postprocess_handlers.py
@@ -88,6 +88,19 @@ class ChatPostprocArgs(PostprocArgs):
     tool_parser_dict: dict[int, BaseToolParser] = field(default_factory=dict)
     has_tool_call: dict[int, bool] = field(default_factory=dict)
     tool_call_id_type: str = "random"
+    # When set, ``tool_choice = {"type": "function", "function": {"name": X}}``
+    # was requested. The server prefix-injects the parser's tool-call ``begin``
+    # string into the prompt and constrains the args with JSON-schema guided
+    # decoding (see ``_build_forced_tool_call_decoding`` in openai_server.py),
+    # so the raw model output IS the JSON ``arguments`` string of the forced
+    # call. The chat post-processors below short-circuit the tool parser and
+    # synthesize a single ``ToolCall`` for this function.
+    forced_tool_name: Optional[str] = None
+    # Per-output flag tracking whether the streaming forced-call path has
+    # already emitted the opening delta (with id and function name). The id is
+    # generated once on the first non-empty delta; subsequent deltas omit it
+    # and only stream argument fragments.
+    forced_tool_name_sent: dict[int, bool] = field(default_factory=dict)
     chat_template_kwargs: Optional[dict[str, Any]] = None
     ctx_usage: Optional[UsageInfo] = None
     # Cache per-request stream metadata so every chunk reuses the same response
@@ -279,36 +292,67 @@ def chat_stream_post_processor(rsp: GenerationResultBase,
             True,
             finished=(output.finish_reason is not None))
 
-        # Note: even when tool_choice forces a named function, guided decoding
-        # constrains the model to emit a structurally-tagged tool call (e.g.
-        # ``<tool_call>\n{"name":"X","arguments":{...}}\n</tool_call>``); the
-        # standard tool parser handles that uniformly with the auto path, so
-        # there is no longer a separate ChatCompletionNamedToolChoiceParam
-        # branch here.
-        delta_text, calls = apply_tool_parser(args, i, delta_text, True)
-        tool_calls = []
-        for call_item in calls:
-            # Tool call ID should be generated only once per tool call
-            if call_item.name:
-                # First chunk: include ID and function name
-                tool_call_id = make_tool_call_id(id_type=args.tool_call_id_type,
-                                                 func_name=call_item.name,
-                                                 idx=call_item.tool_index)
-                function_name = call_item.name
-            else:
-                # Subsequent chunks: null ID and name for argument deltas
-                tool_call_id = None
-                function_name = None
+        # Forced-call path: ``tool_choice = {"type":"function","function":
+        # {"name":X}}`` was requested. The server prefix-injected the parser's
+        # ``begin`` string into the prompt and constrained the args with
+        # JSON-schema guided decoding, so ``delta_text`` IS the next chunk of
+        # the JSON ``arguments`` string for function X. Synthesize a single
+        # DeltaToolCall and bypass the tool parser entirely.
+        if args.forced_tool_name is not None:
+            tool_calls = []
+            if delta_text:
+                if not args.forced_tool_name_sent.get(i, False):
+                    tool_call_id = make_tool_call_id(
+                        id_type=args.tool_call_id_type,
+                        func_name=args.forced_tool_name,
+                        idx=0)
+                    args.forced_tool_name_sent[i] = True
+                    tool_calls.append(
+                        DeltaToolCall(
+                            id=tool_call_id,
+                            index=0,
+                            type="function",
+                            function=DeltaFunctionCall(
+                                name=args.forced_tool_name,
+                                arguments=delta_text,
+                            ),
+                        ))
+                else:
+                    tool_calls.append(
+                        DeltaToolCall(
+                            index=0,
+                            function=DeltaFunctionCall(arguments=delta_text, ),
+                        ))
+            # Forced calls never produce assistant text content.
+            delta_text = ""
+            # Make sure the final chunk's finish_reason flips to "tool_calls".
+            args.has_tool_call[i] = True
+        else:
+            delta_text, calls = apply_tool_parser(args, i, delta_text, True)
+            tool_calls = []
+            for call_item in calls:
+                # Tool call ID should be generated only once per tool call
+                if call_item.name:
+                    # First chunk: include ID and function name
+                    tool_call_id = make_tool_call_id(
+                        id_type=args.tool_call_id_type,
+                        func_name=call_item.name,
+                        idx=call_item.tool_index)
+                    function_name = call_item.name
+                else:
+                    # Subsequent chunks: null ID and name for argument deltas
+                    tool_call_id = None
+                    function_name = None
 
-            tool_calls.append(
-                DeltaToolCall(
-                    id=tool_call_id,
-                    index=call_item.tool_index,
-                    function=DeltaFunctionCall(
-                        name=function_name,
-                        arguments=call_item.parameters,
-                    ),
-                ))
+                tool_calls.append(
+                    DeltaToolCall(
+                        id=tool_call_id,
+                        index=call_item.tool_index,
+                        function=DeltaFunctionCall(
+                            name=function_name,
+                            arguments=call_item.parameters,
+                        ),
+                    ))
         # Keep token-bearing chunks visible even when detokenization has no
         # text to flush yet.
         if (tool_calls or delta_text or reasoning_delta_text
@@ -386,18 +430,34 @@ def chat_response_post_processor(
         text, reasoning_text = apply_reasoning_parser(args, output.index,
                                                       output.text, False)
 
-        # Named tool_choice is honored by the server via guided decoding (the
-        # model is constrained to emit a tagged tool-call wrapper around the
-        # forced function); the standard tool parser then extracts the call
-        # name and arguments uniformly with the "auto" path.
         if text is None:
             text = ""
-        text, calls = apply_tool_parser(args, output.index, text, False)
-        tool_calls = [
-            ToolCall(function=FunctionCall(name=call.name or "",
-                                           arguments=call.parameters))
-            for call in calls
-        ]
+
+        # Forced-call path: ``tool_choice = {"type":"function","function":
+        # {"name":X}}`` was requested. The server prefix-injected the parser's
+        # ``begin`` string into the prompt and constrained the args with
+        # JSON-schema guided decoding, so ``text`` IS the JSON ``arguments``
+        # string of the forced call. Skip the tool parser and synthesize the
+        # call directly.
+        if args.forced_tool_name is not None:
+            tool_call_id = make_tool_call_id(id_type=args.tool_call_id_type,
+                                             func_name=args.forced_tool_name,
+                                             idx=0)
+            tool_calls = [
+                ToolCall(id=tool_call_id,
+                         function=FunctionCall(name=args.forced_tool_name,
+                                               arguments=text))
+            ]
+            # Forced calls never produce assistant text content.
+            text = ""
+            args.has_tool_call[output.index] = True
+        else:
+            text, calls = apply_tool_parser(args, output.index, text, False)
+            tool_calls = [
+                ToolCall(function=FunctionCall(name=call.name or "",
+                                               arguments=call.parameters))
+                for call in calls
+            ]
         message = ChatMessage(role=role,
                               content=text,
                               reasoning_content=reasoning_text,

--- a/tensorrt_llm/serve/postprocess_handlers.py
+++ b/tensorrt_llm/serve/postprocess_handlers.py
@@ -566,20 +566,36 @@ def chat_response_post_processor(
             if text is None:
                 text = ""
             arguments_end = forced_tool_arguments_end(text)
-            arguments = text if arguments_end is None else text[:arguments_end]
-            args.has_tool_call[output.index] = True
-            message = ChatMessage(
-                role=role,
-                content="",
-                tool_calls=[
-                    ToolCall(id=make_tool_call_id(
-                        id_type=args.tool_call_id_type,
-                        func_name=forced_tool.function.name,
-                        idx=0),
-                             function=FunctionCall(
-                                 name=forced_tool.function.name,
-                                 arguments=arguments))
-                ])
+            if arguments_end is None:
+                # No complete JSON value: the generation was truncated (token
+                # budget, abort) or empty. Reporting the partial text as
+                # ``arguments`` would hand the caller something json.loads()
+                # rejects, and claiming finish_reason="tool_calls" would assert
+                # a call that was never completed. Return the text as content
+                # instead, mirroring the no-markup fallback on the extraction
+                # path below and the streaming path, which only flips
+                # finish_reason once a call has actually been streamed.
+                logger.warning(
+                    f"Forced tool_choice '{forced_tool.function.name}' but the "
+                    "model did not produce a complete JSON arguments value; "
+                    "returning the text as content.")
+                message = ChatMessage(role=role,
+                                      content=text,
+                                      reasoning_content=reasoning_text)
+            else:
+                args.has_tool_call[output.index] = True
+                message = ChatMessage(
+                    role=role,
+                    content="",
+                    tool_calls=[
+                        ToolCall(id=make_tool_call_id(
+                            id_type=args.tool_call_id_type,
+                            func_name=forced_tool.function.name,
+                            idx=0),
+                                 function=FunctionCall(
+                                     name=forced_tool.function.name,
+                                     arguments=text[:arguments_end]))
+                    ])
         elif forced_tool:
             # The parser extracts the forced call from the model's native
             # markup; any free-text preamble becomes content per OpenAI

--- a/tests/unittest/llmapi/apps/_test_openai_tool_call.py
+++ b/tests/unittest/llmapi/apps/_test_openai_tool_call.py
@@ -119,3 +119,99 @@ async def test_tool_parser_streaming(client: openai.AsyncOpenAI,
     assert parameters
     args = json.loads(parameters)
     get_current_temperature(**args)
+
+
+# --------------------------------------------------------------------------
+# Named tool_choice (forced function call) — TRTLLM-12758
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_named_tool_choice_forces_function_call(
+        client: openai.AsyncOpenAI, model_name: str):
+    """OpenAI/Azure spec: tool_choice={"type":"function","function":{"name":"X"}}
+    must force the model to emit a tool_call to function X.
+    """
+    response = await client.chat.completions.create(
+        model=model_name,
+        messages=[{
+            "role": "user",
+            # Prompt that on its own would not normally produce a tool call.
+            "content": "Just say hi.",
+        }],
+        tools=TOOLS,
+        tool_choice={
+            "type": "function",
+            "function": {
+                "name": "get_current_temperature"
+            },
+        },
+    )
+    message = response.choices[0].message
+    assert message.tool_calls, (f"Expected forced tool_calls, got: {message}")
+    assert len(message.tool_calls) == 1
+    forced_call = message.tool_calls[0]
+    assert forced_call.function.name == "get_current_temperature"
+    # Arguments must be valid JSON matching the schema (location is required).
+    args = json.loads(forced_call.function.arguments)
+    assert "location" in args
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_named_tool_choice_missing_function_returns_400(
+        client: openai.AsyncOpenAI, model_name: str):
+    """Forcing a function name that is not present in `tools` must fail with
+    HTTP 400 and an error message that identifies the missing function."""
+    with pytest.raises(openai.BadRequestError) as exc:
+        await client.chat.completions.create(
+            model=model_name,
+            messages=[{
+                "role": "user",
+                "content": "Hello"
+            }],
+            tools=TOOLS,
+            tool_choice={
+                "type": "function",
+                "function": {
+                    "name": "function_that_does_not_exist"
+                },
+            },
+        )
+    assert exc.value.status_code == 400
+    assert "function_that_does_not_exist" in str(exc.value)
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_tool_choice_auto_unchanged(client: openai.AsyncOpenAI,
+                                          model_name: str):
+    """Regression: tool_choice='auto' continues to work unchanged."""
+    response = await client.chat.completions.create(
+        model=model_name,
+        messages=[{
+            "role": "user",
+            "content": "What's the temperature in San Francisco now?",
+        }],
+        tools=TOOLS,
+        tool_choice="auto",
+    )
+    assert response.choices[0].finish_reason == "tool_calls"
+    assert response.choices[0].message.tool_calls
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_tool_choice_none_unchanged(client: openai.AsyncOpenAI,
+                                          model_name: str):
+    """Regression: tool_choice='none' continues to work unchanged (no tool calls)."""
+    response = await client.chat.completions.create(
+        model=model_name,
+        messages=[{
+            "role":
+            "user",
+            "content":
+            "Reply with the single word 'hello' and nothing else.",
+        }],
+        tools=TOOLS,
+        tool_choice="none",
+    )
+    # finish_reason should not be "tool_calls" when explicitly disabled.
+    assert response.choices[0].finish_reason != "tool_calls"

--- a/tests/unittest/llmapi/apps/_test_openai_tool_call.py
+++ b/tests/unittest/llmapi/apps/_test_openai_tool_call.py
@@ -215,3 +215,56 @@ async def test_tool_choice_none_unchanged(client: openai.AsyncOpenAI,
     )
     # finish_reason should not be "tool_calls" when explicitly disabled.
     assert response.choices[0].finish_reason != "tool_calls"
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_named_tool_choice_streaming(client: openai.AsyncOpenAI,
+                                           model_name: str):
+    """Streaming counterpart of the forced-function-call test: the very first
+    tool-call delta must carry the forced function name and a tool-call id;
+    subsequent deltas stream the JSON ``arguments`` of the same call."""
+    response = await client.chat.completions.create(
+        model=model_name,
+        messages=[{
+            "role": "user",
+            # A prompt that on its own would not produce a tool call.
+            "content": "Just say hi.",
+        }],
+        tools=TOOLS,
+        tool_choice={
+            "type": "function",
+            "function": {
+                "name": "get_current_temperature"
+            },
+        },
+        stream=True,
+    )
+
+    tool_id = None
+    tool_name = None
+    arguments = ""
+    finish_reason = None
+
+    async for chunk in response:
+        choice = chunk.choices[0]
+        if choice.delta.tool_calls:
+            tc = choice.delta.tool_calls[0]
+            # All deltas must be on the same tool-call index.
+            assert tc.index == 0
+            if tc.id:
+                # ID may arrive on the first chunk only.
+                assert tool_id is None, "tool_call id sent more than once"
+                tool_id = tc.id
+            if tc.function.name:
+                assert tool_name is None, "tool_call name sent more than once"
+                tool_name = tc.function.name
+            if tc.function.arguments:
+                arguments += tc.function.arguments
+        if choice.finish_reason:
+            finish_reason = choice.finish_reason
+
+    assert tool_id is not None
+    assert tool_name == "get_current_temperature"
+    assert finish_reason == "tool_calls"
+    args = json.loads(arguments)
+    assert "location" in args

--- a/tests/unittest/llmapi/apps/test_tool_parsers.py
+++ b/tests/unittest/llmapi/apps/test_tool_parsers.py
@@ -3683,49 +3683,61 @@ _SCHEMA_QUERY = {
 }
 
 
-class TestBuildToolForcedNameGuidedDecoding:
-    """Test the forced_tool_name path of _build_tool_strict_guided_decoding_params.
+class TestBuildForcedToolCallDecoding:
+    """Test ``_build_forced_tool_call_decoding`` from openai_server.
 
     Covers OpenAI-spec ``tool_choice = {"type": "function",
     "function": {"name": "X"}}`` for non-harmony tool parsers (TRTLLM-12758).
+    The helper returns ``(begin_prefix, GuidedDecodingParams)``: the caller
+    prefix-injects ``begin_prefix`` into the rendered chat prompt and applies
+    the guided-decoding params to the request, so the model is forced to
+    start generation inside the tool call and the resulting arguments are
+    JSON-schema valid.
     """
 
     @pytest.mark.parametrize(
         "parser_name",
         ["qwen3", "deepseek_v3", "kimi_k2", "gemma4"],
     )
-    def test_forced_name_builds_single_tag(self, parser_name):
-        """Forcing a name yields a single structural tag.
+    def test_forced_name_returns_prefix_and_json_schema(self, parser_name):
+        """Forced-name path returns a parser-specific prefix and JSON schema.
 
-        Across multiple parser families, the tag's ``begin`` must contain the
-        forced function name.
+        Across parser families, ``begin_prefix`` must contain the forced
+        function name and the guided-decoding params must constrain the args
+        to the function's ``parameters`` JSON Schema.
         """
+        from tensorrt_llm.sampling_params import GuidedDecodingParams
         from tensorrt_llm.serve.openai_server import \
-            _build_tool_strict_guided_decoding_params
+            _build_forced_tool_call_decoding
+        from tensorrt_llm.serve.tool_parser.tool_parser_factory import \
+            ToolParserFactory
 
         tools = _make_tools(("get_weather", _SCHEMA_LOCATION),
                             ("search_web", _SCHEMA_QUERY))
-        result = _build_tool_strict_guided_decoding_params(
-            tools, parser_name, forced_tool_name="get_weather")
-        assert result is not None
-        assert result.structural_tag is not None
+        begin_prefix, guided = _build_forced_tool_call_decoding(
+            tools, parser_name, "get_weather")
 
-        stag = json.loads(result.structural_tag)
-        assert stag["type"] == "structural_tag"
-        fmt = stag["format"]
-        assert fmt["type"] == "triggered_tags"
-        # Exactly one tag — the forced function only.
-        assert len(fmt["tags"]) == 1
-        tag = fmt["tags"][0]
-        assert "get_weather" in tag["begin"]
-        # Forced name with parameters → json_schema constraint.
-        assert tag["content"]["type"] == "json_schema"
-        assert tag["content"]["json_schema"] == _SCHEMA_LOCATION
+        # ``begin_prefix`` is exactly the parser's tool-call begin string.
+        parser = ToolParserFactory.parsers[parser_name.lower()]()
+        expected_begin = parser.structure_info()("get_weather").begin
+        assert begin_prefix == expected_begin
+        assert "get_weather" in begin_prefix
 
-    def test_forced_name_no_parameters_uses_any_text(self):
-        """When the forced function has no parameters, fall back to any_text."""
+        assert isinstance(guided, GuidedDecodingParams)
+        assert guided.json == _SCHEMA_LOCATION
+        assert guided.json_object is False
+        assert guided.structural_tag is None
+
+    def test_forced_name_no_parameters_uses_json_object(self):
+        """Forced-name path falls back to ``json_object`` when no schema.
+
+        When the forced function has no ``parameters``, the helper falls back
+        to ``json_object=True`` so the synthesized ``arguments`` field is still
+        well-formed JSON (typically ``{}``).
+        """
+        from tensorrt_llm.sampling_params import GuidedDecodingParams
         from tensorrt_llm.serve.openai_server import \
-            _build_tool_strict_guided_decoding_params
+            _build_forced_tool_call_decoding
 
         tools = [
             ChatCompletionToolsParam(
@@ -3738,98 +3750,90 @@ class TestBuildToolForcedNameGuidedDecoding:
                                             parameters=_SCHEMA_QUERY),
             ),
         ]
-        result = _build_tool_strict_guided_decoding_params(
-            tools, "qwen3", forced_tool_name="ping")
-        assert result is not None
-        stag = json.loads(result.structural_tag)
-        tag = stag["format"]["tags"][0]
-        assert "ping" in tag["begin"]
-        assert tag["content"]["type"] == "any_text"
+        begin_prefix, guided = _build_forced_tool_call_decoding(
+            tools, "qwen3", "ping")
+        assert "ping" in begin_prefix
+        assert isinstance(guided, GuidedDecodingParams)
+        assert guided.json is None
+        assert guided.json_object is True
 
     def test_forced_name_ignores_strict_flag(self):
-        """Forced name constrains decoding even when no tool has strict=True.
-
-        Otherwise the OpenAI spec semantics for a named ``tool_choice`` would
-        not be honored.
-        """
-        from tensorrt_llm.serve.openai_server import \
-            _build_tool_strict_guided_decoding_params
+        """The forced-call path engages regardless of any ``strict=True``."""
+        from tensorrt_llm.serve.openai_server import (
+            _build_forced_tool_call_decoding,
+            _build_tool_strict_guided_decoding_params)
 
         tools = _make_tools(("get_weather", _SCHEMA_LOCATION))
-        # Without forced_tool_name, no strict→None.
+        # Strict-tools path is unchanged: no strict → None.
         assert _build_tool_strict_guided_decoding_params(tools, "qwen3") is None
-        # With forced_tool_name, structural tag is built regardless.
-        forced = _build_tool_strict_guided_decoding_params(
-            tools, "qwen3", forced_tool_name="get_weather")
-        assert forced is not None
+        # Forced-call path: always constrains.
+        begin_prefix, guided = _build_forced_tool_call_decoding(
+            tools, "qwen3", "get_weather")
+        assert begin_prefix
+        assert guided is not None
 
     def test_forced_name_missing_raises_value_error(self):
         """Forcing a function that is not in tools must raise ValueError."""
         from tensorrt_llm.serve.openai_server import \
-            _build_tool_strict_guided_decoding_params
+            _build_forced_tool_call_decoding
 
         tools = _make_tools(("get_weather", _SCHEMA_LOCATION))
         with pytest.raises(ValueError) as exc:
-            _build_tool_strict_guided_decoding_params(
-                tools, "qwen3", forced_tool_name="missing_fn")
+            _build_forced_tool_call_decoding(tools, "qwen3", "missing_fn")
         msg = str(exc.value)
         assert "missing_fn" in msg
-        # Available functions should be reported in the error message.
-        assert "get_weather" in msg
+        assert "get_weather" in msg  # available functions reported
 
     def test_forced_name_no_tools_raises_value_error(self):
         """Forcing a function without any tools provided is a 4xx-class error."""
         from tensorrt_llm.serve.openai_server import \
-            _build_tool_strict_guided_decoding_params
+            _build_forced_tool_call_decoding
 
         with pytest.raises(ValueError):
-            _build_tool_strict_guided_decoding_params(
-                [], "qwen3", forced_tool_name="get_weather")
+            _build_forced_tool_call_decoding([], "qwen3", "get_weather")
         with pytest.raises(ValueError):
-            _build_tool_strict_guided_decoding_params(
-                None, "qwen3", forced_tool_name="get_weather")
+            _build_forced_tool_call_decoding(None, "qwen3", "get_weather")
 
     def test_forced_name_no_parser_raises_value_error(self):
         """Forcing a function on a server without a tool_parser is a 4xx."""
         from tensorrt_llm.serve.openai_server import \
-            _build_tool_strict_guided_decoding_params
+            _build_forced_tool_call_decoding
 
         tools = _make_tools(("get_weather", _SCHEMA_LOCATION))
         with pytest.raises(ValueError):
-            _build_tool_strict_guided_decoding_params(
-                tools, None, forced_tool_name="get_weather")
+            _build_forced_tool_call_decoding(tools, None, "get_weather")
         with pytest.raises(ValueError):
-            _build_tool_strict_guided_decoding_params(
-                tools, "", forced_tool_name="get_weather")
+            _build_forced_tool_call_decoding(tools, "", "get_weather")
 
     def test_forced_name_unsupported_parser_raises_value_error(self):
         """Parsers that do not support structural tags cannot honor forced names."""
         from tensorrt_llm.serve.openai_server import \
-            _build_tool_strict_guided_decoding_params
+            _build_forced_tool_call_decoding
 
         tools = _make_tools(("get_weather", _SCHEMA_LOCATION))
         # glm4, glm47, qwen3_coder, minimax_m2 do not support structural tags.
         for parser_name in ("glm4", "glm47", "qwen3_coder", "minimax_m2"):
             with pytest.raises(ValueError) as exc:
-                _build_tool_strict_guided_decoding_params(
-                    tools, parser_name, forced_tool_name="get_weather")
+                _build_forced_tool_call_decoding(tools, parser_name,
+                                                 "get_weather")
             assert "structural" in str(exc.value).lower()
 
     def test_forced_name_unknown_parser_raises_value_error(self):
-        """An unregistered parser name should also raise on forced_tool_name."""
+        """An unregistered parser name should also raise."""
         from tensorrt_llm.serve.openai_server import \
-            _build_tool_strict_guided_decoding_params
+            _build_forced_tool_call_decoding
 
         tools = _make_tools(("get_weather", _SCHEMA_LOCATION))
         with pytest.raises(ValueError):
-            _build_tool_strict_guided_decoding_params(
-                tools, "no_such_parser", forced_tool_name="get_weather")
+            _build_forced_tool_call_decoding(tools, "no_such_parser",
+                                             "get_weather")
 
     def test_strict_path_unchanged_by_default(self):
-        """Strict-tools path is unchanged when no forced name is requested.
+        """Strict-tools path stays untouched without ``strict=True``.
 
-        Regression for existing ``tool_choice='auto'`` behavior: must still
-        return ``None`` when no tool has ``strict=True``.
+        Regression guard: ``_build_tool_strict_guided_decoding_params`` must
+        still return ``None`` when no tool has ``strict=True``, independent of
+        the new forced-call helper.
         """
         from tensorrt_llm.serve.openai_server import \
             _build_tool_strict_guided_decoding_params

--- a/tests/unittest/llmapi/apps/test_tool_parsers.py
+++ b/tests/unittest/llmapi/apps/test_tool_parsers.py
@@ -3647,5 +3647,196 @@ class TestBuildToolStrictGuidedDecoding:
         assert "calculate" in fmt["tags"][0]["begin"]
 
 
+# ============================================================================
+# Named tool_choice (forced function call) Tests — TRTLLM-12758
+# ============================================================================
+
+
+def _make_tools(*specs):
+    """Helper: build a list of ChatCompletionToolsParam from (name, params) specs."""
+    return [
+        ChatCompletionToolsParam(
+            type="function",
+            function=FunctionDefinition(name=name, parameters=params),
+        ) for name, params in specs
+    ]
+
+
+_SCHEMA_LOCATION = {
+    "type": "object",
+    "properties": {
+        "location": {
+            "type": "string"
+        },
+    },
+    "required": ["location"],
+}
+
+_SCHEMA_QUERY = {
+    "type": "object",
+    "properties": {
+        "query": {
+            "type": "string"
+        },
+    },
+    "required": ["query"],
+}
+
+
+class TestBuildToolForcedNameGuidedDecoding:
+    """Test the forced_tool_name path of _build_tool_strict_guided_decoding_params.
+
+    Covers OpenAI-spec ``tool_choice = {"type": "function",
+    "function": {"name": "X"}}`` for non-harmony tool parsers (TRTLLM-12758).
+    """
+
+    @pytest.mark.parametrize(
+        "parser_name",
+        ["qwen3", "deepseek_v3", "kimi_k2", "gemma4"],
+    )
+    def test_forced_name_builds_single_tag(self, parser_name):
+        """Forcing a name yields a single structural tag.
+
+        Across multiple parser families, the tag's ``begin`` must contain the
+        forced function name.
+        """
+        from tensorrt_llm.serve.openai_server import \
+            _build_tool_strict_guided_decoding_params
+
+        tools = _make_tools(("get_weather", _SCHEMA_LOCATION),
+                            ("search_web", _SCHEMA_QUERY))
+        result = _build_tool_strict_guided_decoding_params(
+            tools, parser_name, forced_tool_name="get_weather")
+        assert result is not None
+        assert result.structural_tag is not None
+
+        stag = json.loads(result.structural_tag)
+        assert stag["type"] == "structural_tag"
+        fmt = stag["format"]
+        assert fmt["type"] == "triggered_tags"
+        # Exactly one tag — the forced function only.
+        assert len(fmt["tags"]) == 1
+        tag = fmt["tags"][0]
+        assert "get_weather" in tag["begin"]
+        # Forced name with parameters → json_schema constraint.
+        assert tag["content"]["type"] == "json_schema"
+        assert tag["content"]["json_schema"] == _SCHEMA_LOCATION
+
+    def test_forced_name_no_parameters_uses_any_text(self):
+        """When the forced function has no parameters, fall back to any_text."""
+        from tensorrt_llm.serve.openai_server import \
+            _build_tool_strict_guided_decoding_params
+
+        tools = [
+            ChatCompletionToolsParam(
+                type="function",
+                function=FunctionDefinition(name="ping"),
+            ),
+            ChatCompletionToolsParam(
+                type="function",
+                function=FunctionDefinition(name="other",
+                                            parameters=_SCHEMA_QUERY),
+            ),
+        ]
+        result = _build_tool_strict_guided_decoding_params(
+            tools, "qwen3", forced_tool_name="ping")
+        assert result is not None
+        stag = json.loads(result.structural_tag)
+        tag = stag["format"]["tags"][0]
+        assert "ping" in tag["begin"]
+        assert tag["content"]["type"] == "any_text"
+
+    def test_forced_name_ignores_strict_flag(self):
+        """Forced name constrains decoding even when no tool has strict=True.
+
+        Otherwise the OpenAI spec semantics for a named ``tool_choice`` would
+        not be honored.
+        """
+        from tensorrt_llm.serve.openai_server import \
+            _build_tool_strict_guided_decoding_params
+
+        tools = _make_tools(("get_weather", _SCHEMA_LOCATION))
+        # Without forced_tool_name, no strict→None.
+        assert _build_tool_strict_guided_decoding_params(tools, "qwen3") is None
+        # With forced_tool_name, structural tag is built regardless.
+        forced = _build_tool_strict_guided_decoding_params(
+            tools, "qwen3", forced_tool_name="get_weather")
+        assert forced is not None
+
+    def test_forced_name_missing_raises_value_error(self):
+        """Forcing a function that is not in tools must raise ValueError."""
+        from tensorrt_llm.serve.openai_server import \
+            _build_tool_strict_guided_decoding_params
+
+        tools = _make_tools(("get_weather", _SCHEMA_LOCATION))
+        with pytest.raises(ValueError) as exc:
+            _build_tool_strict_guided_decoding_params(
+                tools, "qwen3", forced_tool_name="missing_fn")
+        msg = str(exc.value)
+        assert "missing_fn" in msg
+        # Available functions should be reported in the error message.
+        assert "get_weather" in msg
+
+    def test_forced_name_no_tools_raises_value_error(self):
+        """Forcing a function without any tools provided is a 4xx-class error."""
+        from tensorrt_llm.serve.openai_server import \
+            _build_tool_strict_guided_decoding_params
+
+        with pytest.raises(ValueError):
+            _build_tool_strict_guided_decoding_params(
+                [], "qwen3", forced_tool_name="get_weather")
+        with pytest.raises(ValueError):
+            _build_tool_strict_guided_decoding_params(
+                None, "qwen3", forced_tool_name="get_weather")
+
+    def test_forced_name_no_parser_raises_value_error(self):
+        """Forcing a function on a server without a tool_parser is a 4xx."""
+        from tensorrt_llm.serve.openai_server import \
+            _build_tool_strict_guided_decoding_params
+
+        tools = _make_tools(("get_weather", _SCHEMA_LOCATION))
+        with pytest.raises(ValueError):
+            _build_tool_strict_guided_decoding_params(
+                tools, None, forced_tool_name="get_weather")
+        with pytest.raises(ValueError):
+            _build_tool_strict_guided_decoding_params(
+                tools, "", forced_tool_name="get_weather")
+
+    def test_forced_name_unsupported_parser_raises_value_error(self):
+        """Parsers that do not support structural tags cannot honor forced names."""
+        from tensorrt_llm.serve.openai_server import \
+            _build_tool_strict_guided_decoding_params
+
+        tools = _make_tools(("get_weather", _SCHEMA_LOCATION))
+        # glm4, glm47, qwen3_coder, minimax_m2 do not support structural tags.
+        for parser_name in ("glm4", "glm47", "qwen3_coder", "minimax_m2"):
+            with pytest.raises(ValueError) as exc:
+                _build_tool_strict_guided_decoding_params(
+                    tools, parser_name, forced_tool_name="get_weather")
+            assert "structural" in str(exc.value).lower()
+
+    def test_forced_name_unknown_parser_raises_value_error(self):
+        """An unregistered parser name should also raise on forced_tool_name."""
+        from tensorrt_llm.serve.openai_server import \
+            _build_tool_strict_guided_decoding_params
+
+        tools = _make_tools(("get_weather", _SCHEMA_LOCATION))
+        with pytest.raises(ValueError):
+            _build_tool_strict_guided_decoding_params(
+                tools, "no_such_parser", forced_tool_name="get_weather")
+
+    def test_strict_path_unchanged_by_default(self):
+        """Strict-tools path is unchanged when no forced name is requested.
+
+        Regression for existing ``tool_choice='auto'`` behavior: must still
+        return ``None`` when no tool has ``strict=True``.
+        """
+        from tensorrt_llm.serve.openai_server import \
+            _build_tool_strict_guided_decoding_params
+
+        tools = _make_tools(("get_weather", _SCHEMA_LOCATION))
+        assert _build_tool_strict_guided_decoding_params(tools, "qwen3") is None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unittest/llmapi/apps/test_tool_parsers.py
+++ b/tests/unittest/llmapi/apps/test_tool_parsers.py
@@ -5110,6 +5110,45 @@ class TestForcedToolChoicePostprocessing:
         assert json.loads(function.arguments) == {"location": "NYC"}
         assert choice.finish_reason == "tool_calls"
 
+    def test_forced_choice_incomplete_arguments_returns_content(
+            self, sample_tools):
+        """A truncated arguments value must not be reported as a tool call.
+
+        Guided decoding constrains the shape but not the length: hitting the
+        token budget leaves a partial JSON value. Reporting it as `arguments`
+        would hand the caller something json.loads() rejects, and claiming
+        finish_reason="tool_calls" would assert a call that never completed.
+        """
+        from tensorrt_llm.serve.postprocess_handlers import \
+            chat_response_post_processor
+
+        args = self._make_args(sample_tools,
+                               tool_parser="qwen3",
+                               forced_tool_name="get_weather")
+        rsp = self._fake_response('{"location": "San Fra')
+
+        choice = chat_response_post_processor(rsp, args).choices[0]
+
+        assert not choice.message.tool_calls
+        assert choice.message.content == '{"location": "San Fra'
+        assert choice.finish_reason != "tool_calls"
+
+    def test_forced_choice_empty_generation_returns_no_tool_call(
+            self, sample_tools):
+        """An empty generation must not become a tool call with empty args."""
+        from tensorrt_llm.serve.postprocess_handlers import \
+            chat_response_post_processor
+
+        args = self._make_args(sample_tools,
+                               tool_parser="qwen3",
+                               forced_tool_name="get_weather")
+        rsp = self._fake_response("")
+
+        choice = chat_response_post_processor(rsp, args).choices[0]
+
+        assert not choice.message.tool_calls
+        assert choice.finish_reason != "tool_calls"
+
     def test_forced_choice_streaming_stops_at_end_of_arguments(
             self, sample_tools):
         """The stream stops emitting once the arguments value completes."""


### PR DESCRIPTION

Wires `tool_choice = {"type": "function", "function": {"name": "X"}}` through the existing structural-tag / xgrammar guided-decoding path so that trtllm-serve forces the model to emit a single tool call to the named function, matching the OpenAI/Azure spec and vLLM/SGLang behavior.

- Extend `_build_tool_strict_guided_decoding_params` with `forced_tool_name=...`. When set, exactly one structural tag is emitted for that function (json_schema constraint when parameters are present, any_text otherwise). Validation raises ValueError for: name not in tools, no tools provided, no tool_parser configured, or a parser that does not support structural tags.
- In `openai_chat`, detect `ChatCompletionNamedToolChoiceParam` and route through the guided-decoding path regardless of any tool's strict flag; surface the validation errors above as HTTP 400.
- In `chat_harmony`, return HTTP 400 with a clear pointer to the harmony follow-up sub-task (out of scope for TRTLLM-12758).
- Drop the now-incorrect "wrap entire raw output as the named function's arguments" branches in `chat_response_post_processor` and `chat_stream_post_processor`. With guided decoding the model emits a full structurally-tagged tool-call wrapper that the standard tool parser already handles uniformly with `tool_choice="auto"`.
- Unit tests in `test_tool_parsers.py` cover four parser families (qwen3, deepseek_v3, kimi_k2, gemma4), missing-name / no-tools / no-parser / unsupported-parser (glm4, glm47, qwen3_coder, minimax_m2) / unknown-parser error paths, the no-parameters fallback, and confirm the existing strict-tools path is unchanged.
- Server-level integration tests in `_test_openai_tool_call.py` add a forced-name happy path on Qwen3-0.6B, a missing-function 400, and regression coverage for tool_choice="auto" / "none".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

* Added named-function `tool_choice` support for non-harmony models.
* Added structural-tag/xgrammar guided decoding.
* Added HTTP 400 validation for unsupported or invalid configurations.
* Added streaming and non-streaming forced function calls.
* Preserved `auto`, `none`, and strict-tool behavior.

## Dev Engineer Review

* Validates named tools, parser support, tool availability, guided-decoding backends, and pre-tokenized prompts.
* Rejects unsupported harmony named-function requests with HTTP 400.
* Removes legacy named-function output wrapping.
* Truncates forced tool arguments after the first complete JSON value.
* Preserves tool-call metadata and streaming finish behavior.
* No configuration or test-list changes were detected.
* CI failures require investigation before rerun.

## QA Engineer Review

* Added server tests for forced named calls, missing functions, `auto`, `none`, streaming behavior, incompatible `response_format`, and base64 prompt token IDs.
* Added parser tests for prefixes, JSON-schema guidance, `json_object` fallback, strict-tool interaction, invalid parser configurations, and JSON argument truncation.
* No test-list files were modified.
* Test-list coverage mapping was not identified.
* **Verdict: needs follow-up.**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
