### PR TITLE
[https://nvbugs/6185234][fix] register deepseek_v32 / kimi_k2 with transformers AutoConfig

### DIFF
--- a/tensorrt_llm/_torch/configs/__init__.py
+++ b/tensorrt_llm/_torch/configs/__init__.py
@@ -1,3 +1,27 @@
 from tensorrt_llm._torch.configs.deepseek_v3 import DeepseekV3Config
 
+
+def _register_custom_configs_with_transformers() -> None:
+    # Make AutoConfig.from_pretrained / AutoTokenizer.from_pretrained accept
+    # model_types that TRT-LLM understands but upstream transformers does not
+    # (DeepSeek-V3.2 and Kimi K2 both ship config.json with these model_types
+    # and rely on TRT-LLM's local DeepseekV3Config workaround).
+    #
+    # Without this, transformers 5.5.x falls back to a bare PreTrainedConfig
+    # that lacks attributes like `max_position_embeddings`, and
+    # AutoTokenizer.from_pretrained then raises AttributeError before any
+    # tokenizer can be constructed. Bypass AutoConfig.register's model_type
+    # consistency check (DeepseekV3Config.model_type is "deepseek_v3") by
+    # writing into the underlying mapping directly.
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING
+
+    for model_type in ("deepseek_v32", "kimi_k2"):
+        if model_type in CONFIG_MAPPING:
+            continue
+        CONFIG_MAPPING.register(model_type, DeepseekV3Config, exist_ok=True)
+
+
+_register_custom_configs_with_transformers()
+del _register_custom_configs_with_transformers
+
 __all__ = ["DeepseekV3Config"]

--- a/tensorrt_llm/_torch/models/__init__.py
+++ b/tensorrt_llm/_torch/models/__init__.py
@@ -1,5 +1,10 @@
 import transformers
 
+# Importing _torch.configs triggers AutoConfig registration for TRT-LLM-only
+# model_types (deepseek_v32, kimi_k2) so AutoTokenizer.from_pretrained works
+# under transformers >= 5.5; see _torch/configs/__init__.py.
+import tensorrt_llm._torch.configs  # noqa: F401
+
 from .modeling_auto import AutoModelForCausalLM
 from .modeling_bert import BertForSequenceClassification
 from .modeling_clip import CLIPVisionModel

--- a/tests/unittest/_torch/test_custom_config_registration.py
+++ b/tests/unittest/_torch/test_custom_config_registration.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the transformers AutoConfig / AutoTokenizer dispatch
+for TRT-LLM-only model_types (deepseek_v32, kimi_k2).
+
+Before this registration, transformers >= 5.5 falls back to a bare
+PreTrainedConfig that lacks `max_position_embeddings`, and
+AutoTokenizer.from_pretrained then raises AttributeError on it. The
+broken test that motivated this — perf/test_perf_sanity.py disagg gen_only
+on GB200 — only runs in L0_PostMerge because it needs 12 GB200 GPUs across
+3 nodes, so a cheap pre-merge unit test is the right place to catch
+regressions.
+"""
+
+import json
+
+import pytest
+
+import tensorrt_llm  # noqa: F401  triggers AutoConfig registration
+from tensorrt_llm._torch.configs import DeepseekV3Config
+
+
+@pytest.mark.parametrize("model_type", ["deepseek_v32", "kimi_k2"])
+def test_custom_model_type_registered_with_autoconfig(model_type):
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING
+
+    assert model_type in CONFIG_MAPPING
+    assert CONFIG_MAPPING[model_type] is DeepseekV3Config
+
+
+@pytest.mark.parametrize("model_type", ["deepseek_v32", "kimi_k2"])
+def test_autoconfig_from_pretrained_resolves_to_local_config(tmp_path, model_type):
+    # Mirrors what the benchmark_serving subprocess does under the hood:
+    # AutoTokenizer.from_pretrained -> AutoConfig.from_pretrained. Without
+    # the registration this fails through to a bare PreTrainedConfig that
+    # lacks `max_position_embeddings`.
+    from transformers import AutoConfig
+
+    model_dir = tmp_path / model_type
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": model_type,
+                "max_position_embeddings": 16384,
+            }
+        )
+    )
+
+    cfg = AutoConfig.from_pretrained(str(model_dir))
+    assert isinstance(cfg, DeepseekV3Config)
+    assert cfg.max_position_embeddings == 16384


### PR DESCRIPTION
transformers 5.5.3 (PR #13994) no longer carries default `max_position_embeddings` on bare `PreTrainedConfig`. For model types that TRT-LLM understands locally but upstream transformers doesn't recognise (deepseek_v32, kimi_k2 — DeepSeek-V3.2 / Kimi-K2 checkpoints), `AutoConfig.from_pretrained` falls through to the bare config, and `AutoTokenizer.from_pretrained` then raises
`'PreTrainedConfig' object has no attribute 'max_position_embeddings'` before any tokenizer is constructed.

Caught by GB200 disagg perf-sanity
`disagg_upload-gen_only-gb200_deepseek-v32-fp4_1k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL` in L0_PostMerge #2722: the `benchmark_serving` subprocess prints argparse `Namespace(...)` and exits 1 on the very next `get_tokenizer -> AutoTokenizer.from_pretrained(... trust_remote_code=True)` call. CTX/GEN servers log the same warning via `load_hf_tokenizer`. Pre-merge missed it because pre-merge DeepSeek-V3.2 coverage (TestDeepSeekV32 on DGX-B200) goes through `LLM(...)` which has tokenizer-load fallbacks, and only the post-merge GB200 perf-sanity stage runs `trtllm-serve` + `benchmark_serving`.

Fix: register `deepseek_v32` and `kimi_k2` against the local `DeepseekV3Config` in `transformers.models.auto.configuration_auto.CONFIG_MAPPING` at TRT-LLM import time, mirroring the existing `_CONFIG_REGISTRY` in `tensorrt_llm/_torch/pyexecutor/config_utils.py`. Registration goes through the underlying mapping (not `AutoConfig.register`) to bypass its `config.model_type == key` consistency check — `DeepseekV3Config` keeps `model_type = "deepseek_v3"` so existing in-engine paths are unaffected.

Trigger is placed in `tensorrt_llm/_torch/models/__init__.py` (already eagerly imported from `tensorrt_llm/__init__.py`) to avoid adding to `tensorrt_llm/__init__.py`'s E402 legacy-ruff baseline.

Pre-merge regression coverage added in
`tests/unittest/_torch/test_custom_config_registration.py`: both registration presence and an end-to-end
`AutoConfig.from_pretrained(<tmpdir config.json with model_type>)` call that hits the exact dispatch the broken post-merge test triggered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `deepseek_v32` and `kimi_k2` model types with Transformers' AutoConfig and AutoTokenizer.
  * Improved compatibility with Transformers 5.5+.

* **Tests**
  * Added regression tests for model type registration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
