### PR TITLE
[None][fix] Warn on experimental DeepSeek-V4 base checkpoints

### DIFF
--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -539,6 +539,16 @@ class ModelConfig(Generic[TConfig]):
         return None
 
     @staticmethod
+    def _is_deepseek_v4_base_checkpoint(checkpoint_dir: str) -> bool:
+        tensor_info = ModelConfig._get_safetensors_header_for_tensor(
+            checkpoint_dir, _DEEPSEEK_V4_ROUTED_EXPERT_WEIGHT)
+        if tensor_info is None:
+            return False
+
+        return ModelConfig._detect_deepseek_v4_routed_moe_layout(
+            checkpoint_dir) not in ("mxfp4", "nvfp4")
+
+    @staticmethod
     def _has_deepseek_v4_layer_only_modelopt_quant_config(
             quant_config_file: str) -> bool:
         with open(quant_config_file) as f:
@@ -779,6 +789,11 @@ class ModelConfig(Generic[TConfig]):
                             indexer_k_dtype=indexer_k_dtype)
                 elif pretrained_config.architectures[
                         0] == "DeepseekV4ForCausalLM":
+                    if cls._is_deepseek_v4_base_checkpoint(checkpoint_dir):
+                        logger.warning(
+                            "Support for DeepSeek-V4 Base checkpoints is "
+                            "experimental. For better supported behavior, use "
+                            "a DeepSeek-V4 Instruct checkpoint.")
                     indexer_config = update_sparse_attention_indexer_config(
                         pretrained_config, kwargs)
                     checkpoint_compress_ratios = getattr(

--- a/tests/unittest/_torch/test_model_config.py
+++ b/tests/unittest/_torch/test_model_config.py
@@ -1,9 +1,11 @@
+import json
+import struct
 import types
 
 import pytest
 import torch
 
-from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.model_config import _DEEPSEEK_V4_ROUTED_EXPERT_WEIGHT, ModelConfig
 from tensorrt_llm._torch.pyexecutor.model_loader import validate_and_set_kv_cache_quant
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
@@ -116,3 +118,39 @@ def test_validate_and_set_kv_cache_quant_rejects_invalid_dtype():
     model_config = _make_model_config_with_kv_quant(QuantAlgo.FP8)
     with pytest.raises(ValueError, match="Accepted types are"):
         validate_and_set_kv_cache_quant(model_config, "invalid_dtype")
+
+
+def _write_safetensors_header(checkpoint_dir, tensor_dtype, tensor_shape):
+    shard_name = "model-00001-of-00001.safetensors"
+    header = {
+        _DEEPSEEK_V4_ROUTED_EXPERT_WEIGHT: {
+            "dtype": tensor_dtype,
+            "shape": tensor_shape,
+            "data_offsets": [0, 0],
+        }
+    }
+    encoded_header = json.dumps(header).encode("utf-8")
+
+    with open(checkpoint_dir / shard_name, "wb") as f:
+        f.write(struct.pack("<Q", len(encoded_header)))
+        f.write(encoded_header)
+
+    with open(checkpoint_dir / "model.safetensors.index.json", "w") as f:
+        json.dump({"weight_map": {_DEEPSEEK_V4_ROUTED_EXPERT_WEIGHT: shard_name}}, f)
+
+
+@pytest.mark.parametrize(
+    "tensor_dtype,tensor_shape,expected_layout,expected_is_base",
+    [
+        pytest.param("I8", [2048, 2048], "mxfp4", False, id="mxfp4"),
+        pytest.param("U8", [2048, 2048], "nvfp4", False, id="nvfp4"),
+        pytest.param("F8_E4M3", [2048, 4096], None, True, id="base-fp8"),
+    ],
+)
+def test_deepseek_v4_base_checkpoint_detection(
+    tmp_path, tensor_dtype, tensor_shape, expected_layout, expected_is_base
+):
+    _write_safetensors_header(tmp_path, tensor_dtype, tensor_shape)
+
+    assert ModelConfig._detect_deepseek_v4_routed_moe_layout(str(tmp_path)) == expected_layout
+    assert ModelConfig._is_deepseek_v4_base_checkpoint(str(tmp_path)) is expected_is_base


### PR DESCRIPTION
@coderabbitai summary

## Description

DeepSeek-V4 Base checkpoints currently go through the same config path as the better supported DeepSeek-V4 Instruct checkpoints, but Base support is still experimental. The Base checkpoints in `/raid/model` can be distinguished from Instruct checkpoints by routed MoE safetensors metadata: Instruct expert tensors use the existing MXFP4/NVFP4 layouts, while Base expert tensors are not MXFP4 or NVFP4.

This PR adds a small DeepSeek-V4 Base checkpoint detector that reuses the routed MoE tensor metadata check and emits a warning when users load a Base checkpoint. The warning tells users that Base support is experimental and recommends using a DeepSeek-V4 Instruct checkpoint.

## Test Coverage

Added unit coverage for DeepSeek-V4 routed expert metadata detection:
- MXFP4 metadata is detected as a non-Base checkpoint.
- NVFP4 metadata is detected as a non-Base checkpoint.
- FP8 routed expert metadata is detected as a Base checkpoint.

Validation run locally:
- `PATH=/usr/bin:$PATH pre-commit run --files tensorrt_llm/_torch/model_config.py tests/unittest/_torch/test_model_config.py`
- `/usr/bin/python3.12 -m py_compile tensorrt_llm/_torch/model_config.py tests/unittest/_torch/test_model_config.py`

Not run successfully:
- `PYTHONPATH=$PWD pytest tests/unittest/_torch/test_model_config.py -k deepseek_v4_base_checkpoint_detection` fails during test bootstrap because the local environment is missing `nvtx`.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
