### PR TITLE
[None][feat] Gemma4 MM: native vision + audio towers

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_gemma4_audio.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4_audio.py
@@ -15,61 +15,782 @@
 """Native TRT-LLM Gemma4 audio tower (Conformer).
 
 Replaces ``AutoModel.from_config(config.audio_config)`` in
-``modeling_gemma4mm.py``. **Greenfield**: this is the first native Conformer
-implementation in the fork (Phi4MM also uses HF reuse via ``importlib``
-at ``modeling_phi4mm.py:106``). Conformer = mel-subsample conv + macaron
-FFN + relative-position attention + depthwise conv branch -- not standard
-ViT/transformer layout.
+``modeling_gemma4mm.py``. Greenfield: first native Conformer port in the
+fork. The audio attention is **chunked local attention with relative-position
+bias + softcap tanh + per-dim query scale** — fundamentally non-standard
+shape, so it stays pure PyTorch instead of inheriting TRT-LLM ``Attention``
+(unlike vision, which routes through the standard backend dispatch).
+``Linear`` comes from TRT-LLM for layout parity with the vision tower.
+RMSNorm reuses HF's ``Gemma4RMSNorm`` directly (plain ``w * x / rms`` — not
+the Gemma3 ``(1 + w) * x / rms`` LLM variant) instead of the TRT-LLM
+``RMSNorm`` module — the TRT-LLM module dispatches to ``flashinfer_rmsnorm``
+whose CUTE kernel rejects non-contiguous row strides, and
+``Gemma4AudioLightConv1d`` feeds it exactly such tensors via
+``depthwise_conv1d(x.transpose(1,2)).transpose(1,2)``. Audio is prefill-only;
+the unfused path's overhead is negligible. The subsample conv stack uses
+plain ``nn.LayerNorm`` (HF uses real LN there, not RMSNorm).
 
-Architecture references (HF transformers 5.5.3, verified 2026-05-14 spike):
-- ``Gemma4AudioRelPositionalEncoding`` @ ``transformers/models/gemma4/modeling_gemma4.py:178``
-- ``Gemma4AudioAttention`` @ ``:209``
-- ``Gemma4AudioLayer`` @ ``:485``
-
-Migration plan: ``GEMMA4_MM_TOWER_MIGRATION.md`` §3 Phase 2.
-Gated behind vision Tier 3 parity per acceptance gate matrix (§1.6.10).
+Architecture references (HF transformers 5.5.3 ``modeling_gemma4.py``):
+- ``Gemma4ClippableLinear``                     @ ``:128``
+- ``Gemma4RMSNorm``                             @ ``:157``
+- ``Gemma4AudioRelPositionalEncoding``          @ ``:178``
+- ``Gemma4AudioAttention``                      @ ``:209``
+- ``Gemma4AudioSubSampleConvProjectionLayer``   @ ``:317``
+- ``Gemma4AudioSubSampleConvProjection``        @ ``:345``
+- ``Gemma4AudioFeedForward``                    @ ``:375``
+- ``Gemma4AudioCausalConv1d``                   @ ``:411``
+- ``Gemma4AudioLightConv1d``                    @ ``:444``
+- ``Gemma4AudioLayer``                          @ ``:485``
+- ``Gemma4AudioModel``                          @ ``:1800``
 """
 
-from typing import Dict, Optional
+import math
+import os
+from dataclasses import dataclass
+from functools import cached_property
+from typing import Dict, Optional, Tuple
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
+from transformers.activations import ACT2FN
+from transformers.models.gemma4.modeling_gemma4 import Gemma4RMSNorm as _HFGemma4RMSNorm
 
 from ..model_config import ModelConfig
+from ..modules.linear import Linear
+from .modeling_utils import _load_weights_impl
+
+# DEBUG_PROBE_BEGIN: gated by env var, fires only when DEBUG_AUDIO_TOWER=1.
+_DEBUG_AUDIO = os.environ.get("DEBUG_AUDIO_TOWER", "0") == "1"
+
+
+def _audio_stats(name: str, t: Optional[torch.Tensor]) -> None:
+    if not _DEBUG_AUDIO or t is None:
+        return
+    f = t.detach().float()
+    finite_frac = torch.isfinite(f).float().mean().item()
+    print(
+        f"  [audio] {name:32s} shape={tuple(t.shape)} dtype={t.dtype} "
+        f"mean={f.mean().item():+.4g} std={f.std().item():.4g} "
+        f"absmax={f.abs().max().item():.4g} finite={finite_frac:.4f}",
+        flush=True,
+    )
+
+
+# DEBUG_PROBE_END
+
+
+@dataclass
+class _AudioOutput:
+    """Stand-in for ``transformers.Gemma4AudioModelOutput`` (fields used by caller)."""
+
+    last_hidden_state: torch.Tensor
+    attention_mask: Optional[torch.Tensor] = None
+
+
+# ---------------------------------------------------------------------------
+# RMSNorm: thin kwarg/dtype adapter over HF's ``Gemma4RMSNorm`` (see module
+# docstring for why this isn't the TRT-LLM ``RMSNorm`` module).
+# ---------------------------------------------------------------------------
+
+
+class _Gemma4AudioRMSNorm(_HFGemma4RMSNorm):
+    """Kwarg + dtype adapter around HF ``Gemma4RMSNorm`` (``w * x / rms(x)``)."""
+
+    def __init__(self, *, hidden_size: int, eps: float, dtype: Optional[torch.dtype] = None):
+        super().__init__(hidden_size, eps=eps)
+        if dtype is not None:
+            with torch.no_grad():
+                self.weight.data = self.weight.data.to(dtype)
+
+
+# ---------------------------------------------------------------------------
+# Clippable linear wrapper (same shape as Gemma4VisionClippableLinear)
+# ---------------------------------------------------------------------------
+
+
+class Gemma4AudioClippableLinear(nn.Module):
+    """TRT-LLM ``Linear`` + optional input/output clamping.
+
+    Mirrors HF ``Gemma4ClippableLinear``: four scalar buffers initialised to
+    sentinel -inf / +inf so an unclipped checkpoint is a no-op; populated by
+    the checkpoint when ``use_clipped_linears=True``.
+    """
+
+    def __init__(
+        self,
+        config,
+        in_features: int,
+        out_features: int,
+        dtype: torch.dtype,
+        bias: bool = False,
+        mapping=None,
+    ) -> None:
+        super().__init__()
+        self.use_clipped_linears = bool(getattr(config, "use_clipped_linears", False))
+        self.linear = Linear(
+            in_features=in_features,
+            out_features=out_features,
+            bias=bias,
+            dtype=dtype,
+            mapping=mapping,
+        )
+        if self.use_clipped_linears:
+            self.register_buffer("input_min", torch.tensor(-float("inf")))
+            self.register_buffer("input_max", torch.tensor(float("inf")))
+            self.register_buffer("output_min", torch.tensor(-float("inf")))
+            self.register_buffer("output_max", torch.tensor(float("inf")))
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self.use_clipped_linears:
+            hidden_states = torch.clamp(hidden_states, self.input_min, self.input_max)
+        hidden_states = self.linear(hidden_states)
+        if self.use_clipped_linears:
+            hidden_states = torch.clamp(hidden_states, self.output_min, self.output_max)
+        return hidden_states
+
+
+# ---------------------------------------------------------------------------
+# Relative positional encoding (fixed sinusoidal, concat[sin, cos] layout)
+# ---------------------------------------------------------------------------
+
+
+class Gemma4AudioRelPositionalEncoding(nn.Module):
+    """Sinusoidal relative position embeddings used by ``Gemma4AudioAttention``.
+
+    HF parity: ``forward`` returns ``[1, context_size, hidden_size]`` with the
+    *fixed* ``position_ids = arange(12, -1, -1)`` (per the reference impl —
+    note this hard-codes 13 positions; the value is preserved verbatim).
+    """
+
+    inv_timescales: torch.Tensor
+
+    def __init__(self, config):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.context_size = (
+            config.attention_chunk_size
+            + config.attention_context_left
+            - 1
+            + config.attention_context_right
+        )
+        min_timescale = 1.0
+        max_timescale = 10000.0
+        num_timescales = self.hidden_size // 2
+        log_timescale_increment = math.log(max_timescale / min_timescale) / max(
+            num_timescales - 1, 1
+        )
+        inv_timescales = min_timescale * torch.exp(
+            torch.arange(num_timescales) * -log_timescale_increment
+        )
+        self.register_buffer(
+            "inv_timescales", inv_timescales.unsqueeze(0).unsqueeze(0), persistent=False
+        )
+
+    @torch.no_grad()
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        # Verbatim from HF: hard-coded 13-step range (see :201).
+        position_ids = torch.arange(12, -1, -1, device=hidden_states.device)
+        position_ids = position_ids[..., None]
+        scaled_time = position_ids * self.inv_timescales.to(device=hidden_states.device)
+        pos_embed = torch.cat([torch.sin(scaled_time), torch.cos(scaled_time)], dim=-1)
+        return pos_embed.to(dtype=hidden_states.dtype)
+
+
+# ---------------------------------------------------------------------------
+# Chunked local attention with relative-position bias
+# ---------------------------------------------------------------------------
+
+
+class Gemma4AudioAttention(nn.Module):
+    """Chunked local attention with relative position bias and softcap tanh.
+
+    Stays pure PyTorch — the shape (5D blocked, ``[B, 1, num_blocks,
+    chunk_size, context_size]``) and the rel-shift trick don't map to TRT-LLM
+    flashinfer / trtllm-gen kernels. Audio sequences are short (≤750 tokens
+    for the 30s window), so the perf cost vs vision is minimal.
+    """
+
+    def __init__(self, config, layer_idx: int, dtype: torch.dtype, mapping=None):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.attention_logits_soft_cap = config.attention_logit_cap
+        self.head_dim = config.hidden_size // config.num_attention_heads
+        self.num_heads = config.num_attention_heads
+
+        # See HF :220-221 — these scale factors are baked into q/k pre-attn.
+        self.q_scale = (self.head_dim**-0.5) / math.log(2)
+        self.k_scale = math.log(1 + math.e) / math.log(2)
+
+        self.chunk_size = config.attention_chunk_size
+        self.max_past_horizon = config.attention_context_left - 1
+        self.max_future_horizon = config.attention_context_right
+        self.context_size = self.chunk_size + self.max_past_horizon + self.max_future_horizon
+
+        self.q_proj = Gemma4AudioClippableLinear(
+            config, config.hidden_size, self.num_heads * self.head_dim, dtype, mapping=mapping
+        )
+        self.k_proj = Gemma4AudioClippableLinear(
+            config, config.hidden_size, self.num_heads * self.head_dim, dtype, mapping=mapping
+        )
+        self.v_proj = Gemma4AudioClippableLinear(
+            config, config.hidden_size, self.num_heads * self.head_dim, dtype, mapping=mapping
+        )
+        self.post = Gemma4AudioClippableLinear(
+            config, config.hidden_size, config.hidden_size, dtype, mapping=mapping
+        )
+
+        # Relative-position key projection is *not* clipped in HF.
+        self.relative_k_proj = Linear(
+            in_features=config.hidden_size,
+            out_features=self.num_heads * self.head_dim,
+            bias=False,
+            dtype=dtype,
+            mapping=mapping,
+        )
+        self.per_dim_scale = nn.Parameter(torch.zeros(self.head_dim, dtype=dtype))
+        self.register_buffer(
+            "softcap", torch.tensor(self.attention_logits_soft_cap), persistent=False
+        )
+
+    def _convert_to_block(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Split ``(B, T, H, D)`` into ``(B, num_blocks, chunk_size, H, D)``."""
+        batch_size, seq_len, num_heads, head_dim = hidden_states.shape
+        num_blocks = (seq_len + self.chunk_size - 1) // self.chunk_size
+        pad = num_blocks * self.chunk_size - seq_len
+        hidden_states = F.pad(hidden_states, (0, 0, 0, 0, 0, pad))
+        return hidden_states.reshape(
+            batch_size, num_blocks, self.chunk_size, num_heads, head_dim
+        ).contiguous()
+
+    def _extract_block_context(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Extract overlapping context windows of ``context_size`` per block."""
+        batch_size, seq_len, num_heads, head_dim = hidden_states.shape
+        hidden_states = F.pad(
+            hidden_states,
+            (0, 0, 0, 0, self.max_past_horizon, self.max_future_horizon + self.chunk_size - 1),
+        )
+        hidden_states = hidden_states.unfold(1, self.context_size, self.chunk_size)
+        hidden_states = torch.movedim(hidden_states, -1, 2)
+        return hidden_states.contiguous()
+
+    def _rel_shift(self, x: torch.Tensor) -> torch.Tensor:
+        """Transformer-XL appendix-B relative position shift."""
+        batch_size, num_heads, num_blocks, block_size, position_length = x.shape
+        context_size = self.context_size
+        x = F.pad(x, (0, context_size + 1 - position_length))
+        x = x.view(batch_size, num_heads, num_blocks, block_size * (context_size + 1))
+        x = x[..., : block_size * context_size]
+        return x.view(batch_size, num_heads, num_blocks, block_size, context_size)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        batch_size, seq_length, _ = hidden_states.shape
+        hidden_shape = (batch_size, seq_length, self.num_heads, self.head_dim)
+
+        # HF runs q/k/v in float32 to keep the softcap + softmax stable.
+        query_states = self.q_proj(hidden_states).float().view(hidden_shape)
+        key_states = self.k_proj(hidden_states).float().view(hidden_shape)
+        value_states = self.v_proj(hidden_states).float().view(hidden_shape)
+
+        query_states = query_states * self.q_scale * F.softplus(self.per_dim_scale)
+        key_states = key_states * self.k_scale
+
+        query_states = self._convert_to_block(query_states)
+        key_states = self._extract_block_context(key_states)
+        value_states = self._extract_block_context(value_states)
+        num_blocks = query_states.shape[1]
+
+        relative_key_states = self.relative_k_proj(position_embeddings)
+        relative_key_states = relative_key_states.view(-1, self.num_heads, self.head_dim)
+        relative_key_states = relative_key_states.to(dtype=query_states.dtype)
+
+        # AC: content × content. BD: content × relative positions (rel-shifted).
+        queries = query_states.permute(0, 3, 1, 2, 4)
+        matrix_ac = queries @ key_states.permute(0, 3, 1, 4, 2)
+
+        queries_flat = queries.reshape(batch_size, self.num_heads, -1, self.head_dim)
+        matrix_bd = queries_flat @ relative_key_states.permute(1, 2, 0)
+        matrix_bd = matrix_bd.reshape(batch_size, self.num_heads, num_blocks, self.chunk_size, -1)
+        matrix_bd = self._rel_shift(matrix_bd)
+
+        attn_weights = matrix_ac + matrix_bd
+        attn_weights = attn_weights / self.softcap
+        attn_weights = torch.tanh(attn_weights)
+        attn_weights = attn_weights * self.softcap
+
+        if attention_mask is not None:
+            attn_weights = attn_weights.masked_fill(
+                attention_mask.logical_not(), self.config.attention_invalid_logits_value
+            )
+
+        attn_weights = F.softmax(attn_weights, dim=-1, dtype=torch.float32).to(value_states.dtype)
+        attn_output = attn_weights @ value_states.permute(0, 3, 1, 2, 4)
+        attn_output = attn_output.permute(0, 2, 3, 1, 4).reshape(
+            batch_size, num_blocks * self.chunk_size, -1
+        )
+        attn_output = attn_output[:, :seq_length].contiguous()
+        attn_output = self.post(attn_output.to(dtype=self.post.linear.weight.dtype))
+        return attn_output, attn_weights
+
+
+# ---------------------------------------------------------------------------
+# Subsample conv stack (mel → encoder embeddings, stride 4 total)
+# ---------------------------------------------------------------------------
+
+
+class Gemma4AudioSubSampleConvProjectionLayer(nn.Module):
+    """Conv2d 3x3 stride 2 + LayerNorm (real LN, not RMSNorm) + ReLU."""
+
+    def __init__(self, in_channels: int, out_channels: int, norm_eps: float, dtype: torch.dtype):
+        super().__init__()
+        self.conv = nn.Conv2d(
+            in_channels=in_channels,
+            out_channels=out_channels,
+            kernel_size=(3, 3),
+            stride=(2, 2),
+            padding=1,
+            bias=False,
+            dtype=dtype,
+        )
+        self.norm = nn.LayerNorm(
+            out_channels, eps=norm_eps, elementwise_affine=True, bias=False, dtype=dtype
+        )
+        self.act = nn.ReLU()
+
+    def forward(
+        self, hidden_states: torch.Tensor, mask: Optional[torch.Tensor] = None
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        if mask is not None:
+            mask = mask.to(device=hidden_states.device)
+            hidden_states = hidden_states * mask[:, None, :, None]
+        hidden_states = self.conv(hidden_states.to(self.conv.weight.dtype))
+        # LayerNorm on the channel dim — permute, norm, permute back.
+        hidden_states = self.act(
+            self.norm(hidden_states.permute(0, 2, 3, 1)).permute(0, 3, 1, 2).contiguous()
+        )
+        if mask is not None:
+            mask = mask[:, ::2]
+        return hidden_states, mask
+
+
+class Gemma4AudioSubSampleConvProjection(nn.Module):
+    """Two-stage stride-2 subsample (4× downsample) + linear projection to hidden_size."""
+
+    def __init__(self, config, dtype: torch.dtype, mapping=None):
+        super().__init__()
+        self.layer0 = Gemma4AudioSubSampleConvProjectionLayer(
+            in_channels=1,
+            out_channels=config.subsampling_conv_channels[0],
+            norm_eps=config.rms_norm_eps,
+            dtype=dtype,
+        )
+        self.layer1 = Gemma4AudioSubSampleConvProjectionLayer(
+            in_channels=config.subsampling_conv_channels[0],
+            out_channels=config.subsampling_conv_channels[1],
+            norm_eps=config.rms_norm_eps,
+            dtype=dtype,
+        )
+        # HF :358 — both Conv2d strides are 2, so input mel dim shrinks by 4.
+        # Output flatten dim = (mel_dim // 4) * out_channels[1] — but HF
+        # parameterises off subsampling_conv_channels[0] // 4. We preserve
+        # that verbatim to avoid any silent off-by-one vs the checkpoint.
+        proj_input_dim = (
+            config.subsampling_conv_channels[0] // 4
+        ) * config.subsampling_conv_channels[1]
+        self.input_proj_linear = Linear(
+            in_features=proj_input_dim,
+            out_features=config.hidden_size,
+            bias=False,
+            dtype=dtype,
+            mapping=mapping,
+        )
+
+    def forward(
+        self,
+        input_features: torch.Tensor,
+        input_features_mask: Optional[torch.Tensor] = None,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        hidden_states = input_features.unsqueeze(1)  # (B, 1, T, mel)
+        hidden_states, mask = self.layer0(hidden_states, input_features_mask)
+        hidden_states, mask = self.layer1(hidden_states, mask)
+
+        batch_size, _, seq_len, _ = hidden_states.shape
+        # (B, C, T', mel') → (B, T', mel'*C) for the linear projection.
+        hidden_states = (
+            hidden_states.permute(0, 2, 3, 1).contiguous().reshape(batch_size, seq_len, -1)
+        )
+        return self.input_proj_linear(hidden_states), mask
+
+
+# ---------------------------------------------------------------------------
+# Macaron feedforward + light conv1d branch
+# ---------------------------------------------------------------------------
+
+
+class Gemma4AudioFeedForward(nn.Module):
+    """Macaron-style FFN with pre/post norm and residual_weight scaling."""
+
+    def __init__(self, config, dtype: torch.dtype, mapping=None):
+        super().__init__()
+        self.config = config
+        self.ffw_layer_1 = Gemma4AudioClippableLinear(
+            config, config.hidden_size, config.hidden_size * 4, dtype, mapping=mapping
+        )
+        self.ffw_layer_2 = Gemma4AudioClippableLinear(
+            config, config.hidden_size * 4, config.hidden_size, dtype, mapping=mapping
+        )
+        self.pre_layer_norm = _Gemma4AudioRMSNorm(
+            hidden_size=config.hidden_size, eps=config.rms_norm_eps, dtype=dtype
+        )
+        self.post_layer_norm = _Gemma4AudioRMSNorm(
+            hidden_size=config.hidden_size, eps=config.rms_norm_eps, dtype=dtype
+        )
+        self.act_fn = ACT2FN[config.hidden_act]
+        self.gradient_clipping = config.gradient_clipping
+        self.post_layer_scale = config.residual_weight
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        gradient_clipping = min(
+            self.gradient_clipping,
+            torch.finfo(self.ffw_layer_1.linear.weight.dtype).max,
+        )
+        residual = hidden_states
+        hidden_states = torch.clamp(hidden_states, -gradient_clipping, gradient_clipping)
+        hidden_states = self.pre_layer_norm(hidden_states)
+        hidden_states = self.ffw_layer_1(hidden_states)
+        hidden_states = self.act_fn(hidden_states)
+        hidden_states = self.ffw_layer_2(hidden_states)
+        hidden_states = torch.clamp(hidden_states, -gradient_clipping, gradient_clipping)
+        hidden_states = self.post_layer_norm(hidden_states)
+        hidden_states = hidden_states * self.post_layer_scale
+        hidden_states = hidden_states + residual
+        return hidden_states
+
+
+class Gemma4AudioCausalConv1d(nn.Conv1d):
+    """Left-padded Conv1d so the receptive field stays causal."""
+
+    @cached_property
+    def left_pad(self):
+        effective_kernel_size = (self.kernel_size[0] - 1) * self.dilation[0] + 1
+        return effective_kernel_size - self.stride[0]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = nn.functional.pad(x, (self.left_pad, 0))
+        return super().forward(x)
+
+
+class Gemma4AudioLightConv1d(nn.Module):
+    """Depthwise causal conv branch with GLU activation and pre/conv norms."""
+
+    def __init__(self, config, dtype: torch.dtype, mapping=None):
+        super().__init__()
+        self.config = config
+        self.linear_start = Gemma4AudioClippableLinear(
+            config, config.hidden_size, config.hidden_size * 2, dtype, mapping=mapping
+        )
+        self.linear_end = Gemma4AudioClippableLinear(
+            config, config.hidden_size, config.hidden_size, dtype, mapping=mapping
+        )
+        self.depthwise_conv1d = Gemma4AudioCausalConv1d(
+            in_channels=config.hidden_size,
+            out_channels=config.hidden_size,
+            kernel_size=config.conv_kernel_size,
+            groups=config.hidden_size,
+            bias=False,
+            dtype=dtype,
+        )
+        self.pre_layer_norm = _Gemma4AudioRMSNorm(
+            hidden_size=config.hidden_size, eps=config.rms_norm_eps, dtype=dtype
+        )
+        self.conv_norm = _Gemma4AudioRMSNorm(
+            hidden_size=config.hidden_size, eps=config.rms_norm_eps, dtype=dtype
+        )
+        self.act_fn = ACT2FN[config.hidden_act]
+        self.gradient_clipping = config.gradient_clipping
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.pre_layer_norm(hidden_states)
+        hidden_states = self.linear_start(hidden_states)
+        hidden_states = F.glu(hidden_states, dim=-1)
+        hidden_states = self.depthwise_conv1d(hidden_states.transpose(1, 2)).transpose(1, 2)
+        gradient_clipping = min(
+            self.gradient_clipping,
+            torch.finfo(self.linear_start.linear.weight.dtype).max,
+        )
+        hidden_states = torch.clamp(hidden_states, -gradient_clipping, gradient_clipping)
+        hidden_states = self.conv_norm(hidden_states)
+        hidden_states = self.act_fn(hidden_states)
+        hidden_states = self.linear_end(hidden_states)
+        hidden_states = hidden_states + residual
+        return hidden_states
+
+
+# ---------------------------------------------------------------------------
+# Conformer encoder layer + top-level model
+# ---------------------------------------------------------------------------
+
+
+class Gemma4AudioLayer(nn.Module):
+    """Conformer block: FF1 → attn → FF2 → light-conv → out_norm."""
+
+    def __init__(self, config, layer_idx: int, dtype: torch.dtype, mapping=None):
+        super().__init__()
+        self.config = config
+        self.feed_forward1 = Gemma4AudioFeedForward(config, dtype=dtype, mapping=mapping)
+        self.feed_forward2 = Gemma4AudioFeedForward(config, dtype=dtype, mapping=mapping)
+        self.self_attn = Gemma4AudioAttention(
+            config, layer_idx=layer_idx, dtype=dtype, mapping=mapping
+        )
+        self.lconv1d = Gemma4AudioLightConv1d(config, dtype=dtype, mapping=mapping)
+        self.norm_pre_attn = _Gemma4AudioRMSNorm(
+            hidden_size=config.hidden_size, eps=config.rms_norm_eps, dtype=dtype
+        )
+        self.norm_post_attn = _Gemma4AudioRMSNorm(
+            hidden_size=config.hidden_size, eps=config.rms_norm_eps, dtype=dtype
+        )
+        self.norm_out = _Gemma4AudioRMSNorm(
+            hidden_size=config.hidden_size, eps=config.rms_norm_eps, dtype=dtype
+        )
+        self.gradient_clipping = config.gradient_clipping
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor],
+        position_embeddings: torch.Tensor,
+    ) -> torch.Tensor:
+        gradient_clipping = min(
+            self.gradient_clipping,
+            torch.finfo(self.norm_pre_attn.weight.dtype).max,
+        )
+
+        hidden_states = self.feed_forward1(hidden_states)
+        residual = hidden_states
+
+        hidden_states = torch.clamp(hidden_states, -gradient_clipping, gradient_clipping)
+        hidden_states = self.norm_pre_attn(hidden_states)
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            position_embeddings=position_embeddings,
+            attention_mask=attention_mask,
+        )
+        hidden_states = torch.clamp(hidden_states, -gradient_clipping, gradient_clipping)
+        hidden_states = self.norm_post_attn(hidden_states)
+        hidden_states = hidden_states + residual
+
+        hidden_states = self.lconv1d(hidden_states)
+        hidden_states = self.feed_forward2(hidden_states)
+        hidden_states = torch.clamp(hidden_states, -gradient_clipping, gradient_clipping)
+        hidden_states = self.norm_out(hidden_states)
+        return hidden_states
 
 
 class Gemma4AudioModel(nn.Module):
-    """Gemma4 audio tower (skeleton; bodies filled by subsequent commits).
+    """Gemma4 audio tower (USM-Conformer encoder).
 
-    Input contract (preserved from HF ``Gemma4AudioModel.forward``, see
-    ``modeling_gemma4mm.py:800`` call site):
-        audio_features: (B, mel_T, 128) -- mel-spectrogram frames
-        attention_mask: (B, mel_T) bool -- valid frame mask
+    Input contract (preserved from HF ``Gemma4AudioModel.forward``):
+        input_features:  (B, mel_T, mel_bins) — mel-spectrogram frames
+        attention_mask:  (B, mel_T) bool — True for valid frames
 
-    Output: object with ``last_hidden_state`` ``(B, T_audio, H_audio)`` and
-    optional ``attention_mask`` (bool, post-subsample) used by caller to drop
-    padding frames before projection.
+    Returns ``_AudioOutput`` with:
+        last_hidden_state: (B, T_audio, output_proj_dims)
+        attention_mask:    (B, T_audio) bool — post-subsample frame validity
     """
 
     def __init__(self, model_config: ModelConfig):
         super().__init__()
         self.model_config = model_config
         self.config = model_config.pretrained_config
+        dtype = getattr(self.config, "torch_dtype", None) or torch.bfloat16
+        mapping = getattr(model_config, "mapping", None)
+
+        self.subsample_conv_projection = Gemma4AudioSubSampleConvProjection(
+            self.config, dtype=dtype, mapping=mapping
+        )
+        self.rel_pos_enc = Gemma4AudioRelPositionalEncoding(self.config)
+        self.layers = nn.ModuleList(
+            [
+                Gemma4AudioLayer(self.config, layer_idx=i, dtype=dtype, mapping=mapping)
+                for i in range(self.config.num_hidden_layers)
+            ]
+        )
+        self.output_proj = Linear(
+            in_features=self.config.hidden_size,
+            out_features=self.config.output_proj_dims,
+            bias=True,
+            dtype=dtype,
+            mapping=mapping,
+        )
+
+    def _convert_4d_mask_to_blocked_5d(self, mask_4d: torch.Tensor) -> torch.Tensor:
+        """Reshape ``[B, 1, T, T]`` causal/window mask → ``[B, 1, num_blocks, chunk_size, context_size]``."""
+        batch_size, _, seq_len, _ = mask_4d.shape
+        device = mask_4d.device
+        chunk_size = self.config.attention_chunk_size
+        max_past_horizon = self.config.attention_context_left - 1
+        max_future_horizon = self.config.attention_context_right
+
+        num_blocks = (seq_len + chunk_size - 1) // chunk_size
+        padded_seq_len = num_blocks * chunk_size
+        pad_amount = padded_seq_len - seq_len
+
+        mask_4d = F.pad(mask_4d, (0, pad_amount, 0, pad_amount), value=False)
+        mask_5d = mask_4d.reshape(batch_size, 1, num_blocks, chunk_size, padded_seq_len)
+        mask_5d = F.pad(mask_5d, (max_past_horizon, max_future_horizon), value=False)
+
+        block_starts = torch.arange(num_blocks, device=device) * chunk_size
+        offsets = torch.arange(chunk_size + max_past_horizon + max_future_horizon, device=device)
+        kv_indices = block_starts[:, None] + offsets[None, :]
+        kv_indices = kv_indices[None, None, :, None, :].expand(batch_size, 1, -1, chunk_size, -1)
+        return mask_5d.gather(-1, kv_indices)
+
+    def _build_chunked_local_mask(
+        self, output_mask: torch.Tensor, seq_len: int, device: torch.device
+    ) -> torch.Tensor:
+        """Build the blocked 5D attention mask from the post-subsample frame mask.
+
+        HF builds the dense 4D mask via ``create_bidirectional_mask`` +
+        ``sliding_window_mask_function((ctx_left-1, ctx_right))``. We replicate
+        that semantics directly: True where both row and column frames are
+        valid AND ``j`` is within ``[i - max_past, i + max_future]``.
+        """
+        # Valid (i, j) cells: both frames valid.
+        valid = output_mask.bool()  # (B, T)
+        valid_4d = valid.unsqueeze(1).unsqueeze(2) & valid.unsqueeze(1).unsqueeze(-1)
+
+        # Sliding-window: |i - j| within (-max_past, +max_future).
+        idx = torch.arange(seq_len, device=device)
+        rel = idx.unsqueeze(0) - idx.unsqueeze(1)  # (T, T): j - i
+        window = (rel >= -self.max_past_horizon) & (rel <= self.max_future_horizon)
+        return valid_4d & window.unsqueeze(0).unsqueeze(0)
+
+    @property
+    def max_past_horizon(self) -> int:
+        return self.config.attention_context_left - 1
+
+    @property
+    def max_future_horizon(self) -> int:
+        return self.config.attention_context_right
 
     @torch.inference_mode()
     def forward(
         self,
-        audio_features: torch.Tensor,
+        input_features: torch.Tensor,
         attention_mask: Optional[torch.Tensor] = None,
         **kwargs,
-    ):
-        raise NotImplementedError(
-            "Gemma4AudioModel.forward is a skeleton; implementation pending "
-            "(greenfield Conformer; see GEMMA4_MM_TOWER_MIGRATION.md §3 Phase 2)."
+    ) -> _AudioOutput:
+        # DEBUG_PROBE_BEGIN
+        if _DEBUG_AUDIO:
+            print("[audio] === Gemma4AudioModel.forward ===", flush=True)
+            _audio_stats("input_features (mel)", input_features)
+            _audio_stats(
+                "attention_mask", attention_mask.float() if attention_mask is not None else None
+            )
+        # DEBUG_PROBE_END
+        hidden_states, output_mask = self.subsample_conv_projection(input_features, attention_mask)
+        # DEBUG_PROBE_BEGIN
+        _audio_stats("after subsample_conv_proj", hidden_states)
+        _audio_stats(
+            "output_mask (subsample)", output_mask.float() if output_mask is not None else None
         )
+        # DEBUG_PROBE_END
+        position_embeddings = self.rel_pos_enc(hidden_states)
+        # DEBUG_PROBE_BEGIN
+        _audio_stats("rel_pos_enc", position_embeddings)
+        # DEBUG_PROBE_END
+
+        # output_mask: (B, T_audio) bool. Frames where mask is False are pad.
+        if output_mask is None:
+            output_mask = torch.ones(
+                hidden_states.shape[:2], dtype=torch.bool, device=hidden_states.device
+            )
+        attn_mask_4d = self._build_chunked_local_mask(
+            output_mask, seq_len=hidden_states.shape[1], device=hidden_states.device
+        )
+        attn_mask_5d = self._convert_4d_mask_to_blocked_5d(attn_mask_4d)
+        # DEBUG_PROBE_BEGIN
+        _audio_stats("attn_mask_5d", attn_mask_5d.float())
+        # DEBUG_PROBE_END
+
+        n_layers = len(self.layers)
+        for i, layer in enumerate(self.layers):
+            hidden_states = layer(
+                hidden_states=hidden_states,
+                attention_mask=attn_mask_5d,
+                position_embeddings=position_embeddings,
+            )
+            # DEBUG_PROBE_BEGIN: log layers 0 / mid / last
+            if _DEBUG_AUDIO and (i == 0 or i == n_layers // 2 or i == n_layers - 1):
+                _audio_stats(f"after layer[{i}]", hidden_states)
+            # DEBUG_PROBE_END
+
+        hidden_states = self.output_proj(hidden_states)
+        # DEBUG_PROBE_BEGIN
+        _audio_stats("after output_proj (final)", hidden_states)
+        # DEBUG_PROBE_END
+        return _AudioOutput(last_hidden_state=hidden_states, attention_mask=output_mask)
 
     def load_weights(self, weights: Dict[str, torch.Tensor]):
-        raise NotImplementedError(
-            "Gemma4AudioModel.load_weights is a skeleton; implementation "
-            "pending (HF↔TRT-LLM key remap for Conformer layers)."
-        )
+        """Load HF ``Gemma4AudioModel`` weights.
+
+        Layout differences vs HF:
+          - Our ``Gemma4AudioClippableLinear.linear`` is TRT-LLM ``Linear``;
+            HF's ``Gemma4ClippableLinear.linear`` is ``nn.Linear``. Both store
+            weight at ``.linear.weight`` so the keys match without remapping.
+          - Top-level ``output_proj`` is a TRT-LLM ``Linear`` (HF uses
+            ``nn.Linear``); both expose ``.weight`` / ``.bias``.
+          - ``Gemma4AudioCausalConv1d`` subclasses ``nn.Conv1d`` directly, no
+            wrapper. Conv2d in the subsample stack is also plain ``nn.Conv2d``.
+          - Audio attention does *not* fuse q/k/v (HF keeps them separate too).
+
+        Clipping buffers (``input_min`` etc. on ``Gemma4AudioClippableLinear``)
+        live as named buffers and aren't iterated by ``_load_weights_impl``'s
+        parameter walk, so we copy them explicitly below.
+        """
+        _load_weights_impl(self, weights)
+        for name, buf in self.named_buffers():
+            if name in weights:
+                buf.data.copy_(weights[name].to(buf.dtype).to(buf.device))
+        # DEBUG_PROBE_BEGIN: verify checkpoint actually landed
+        if _DEBUG_AUDIO:
+            print("[audio] === load_weights summary ===", flush=True)
+            print(f"  checkpoint keys provided: {len(weights)}", flush=True)
+            loaded_param_keys = {n for n, _ in self.named_parameters()}
+            covered_params = sum(1 for k in weights if k in loaded_param_keys)
+            print(
+                f"  params covered by ckpt:   {covered_params}/{len(loaded_param_keys)}", flush=True
+            )
+            # Spot-check a few _Gemma4AudioRMSNorm weights — if they're all
+            # zeros, the (1+w) convention reduces to identity scaling and
+            # explains "BLEU=1.9, model ignores audio". Sample 3 RMSNorms.
+            picks = []
+            for name, mod in self.named_modules():
+                if isinstance(mod, _Gemma4AudioRMSNorm):
+                    picks.append((name, mod.weight))
+                    if len(picks) >= 3:
+                        break
+            for name, w in picks:
+                f = w.detach().float()
+                print(
+                    f"  rmsnorm[{name}].weight stats: "
+                    f"mean={f.mean().item():+.4g} std={f.std().item():.4g} "
+                    f"absmax={f.abs().max().item():.4g} zero_frac={(f == 0).float().mean().item():.4f}",
+                    flush=True,
+                )
+            # Also spot-check one clippable linear's input_min/output_max buffers.
+            for name, mod in self.named_modules():
+                if isinstance(mod, Gemma4AudioClippableLinear):
+                    for bname in ("input_min", "input_max", "output_min", "output_max"):
+                        b = getattr(mod, bname, None)
+                        if b is not None:
+                            print(f"  clip[{name}].{bname}: {b.item():+.4g}", flush=True)
+                    break
+        # DEBUG_PROBE_END

--- a/tensorrt_llm/_torch/models/modeling_gemma4_audio.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4_audio.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Native TRT-LLM Gemma4 audio tower (Conformer).
+
+Replaces ``AutoModel.from_config(config.audio_config)`` in
+``modeling_gemma4mm.py``. **Greenfield**: this is the first native Conformer
+implementation in the fork (Phi4MM also uses HF reuse via ``importlib``
+at ``modeling_phi4mm.py:106``). Conformer = mel-subsample conv + macaron
+FFN + relative-position attention + depthwise conv branch -- not standard
+ViT/transformer layout.
+
+Architecture references (HF transformers 5.5.3, verified 2026-05-14 spike):
+- ``Gemma4AudioRelPositionalEncoding`` @ ``transformers/models/gemma4/modeling_gemma4.py:178``
+- ``Gemma4AudioAttention`` @ ``:209``
+- ``Gemma4AudioLayer`` @ ``:485``
+
+Migration plan: ``GEMMA4_MM_TOWER_MIGRATION.md`` §3 Phase 2.
+Gated behind vision Tier 3 parity per acceptance gate matrix (§1.6.10).
+"""
+
+from typing import Dict, Optional
+
+import torch
+import torch.nn as nn
+
+from ..model_config import ModelConfig
+
+
+class Gemma4AudioModel(nn.Module):
+    """Gemma4 audio tower (skeleton; bodies filled by subsequent commits).
+
+    Input contract (preserved from HF ``Gemma4AudioModel.forward``, see
+    ``modeling_gemma4mm.py:800`` call site):
+        audio_features: (B, mel_T, 128) -- mel-spectrogram frames
+        attention_mask: (B, mel_T) bool -- valid frame mask
+
+    Output: object with ``last_hidden_state`` ``(B, T_audio, H_audio)`` and
+    optional ``attention_mask`` (bool, post-subsample) used by caller to drop
+    padding frames before projection.
+    """
+
+    def __init__(self, model_config: ModelConfig):
+        super().__init__()
+        self.model_config = model_config
+        self.config = model_config.pretrained_config
+
+    @torch.inference_mode()
+    def forward(
+        self,
+        audio_features: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        **kwargs,
+    ):
+        raise NotImplementedError(
+            "Gemma4AudioModel.forward is a skeleton; implementation pending "
+            "(greenfield Conformer; see GEMMA4_MM_TOWER_MIGRATION.md §3 Phase 2)."
+        )
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]):
+        raise NotImplementedError(
+            "Gemma4AudioModel.load_weights is a skeleton; implementation "
+            "pending (HF↔TRT-LLM key remap for Conformer layers)."
+        )

--- a/tensorrt_llm/_torch/models/modeling_gemma4_audio.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4_audio.py
@@ -61,7 +61,7 @@ from .modeling_utils import _load_weights_impl
 
 
 @dataclass
-class _AudioOutput:
+class AudioOutput:
     """Stand-in for ``transformers.Gemma4AudioModelOutput`` (fields used by caller)."""
 
     last_hidden_state: torch.Tensor
@@ -74,7 +74,7 @@ class _AudioOutput:
 # ---------------------------------------------------------------------------
 
 
-class _Gemma4AudioRMSNorm(_HFGemma4RMSNorm):
+class Gemma4AudioRMSNorm(_HFGemma4RMSNorm):
     """Kwarg + dtype adapter around HF ``Gemma4RMSNorm`` (``w * x / rms(x)``)."""
 
     def __init__(self, *, hidden_size: int, eps: float, dtype: Optional[torch.dtype] = None):
@@ -425,10 +425,10 @@ class Gemma4AudioFeedForward(nn.Module):
         self.ffw_layer_2 = Gemma4AudioClippableLinear(
             config, config.hidden_size * 4, config.hidden_size, dtype, mapping=mapping
         )
-        self.pre_layer_norm = _Gemma4AudioRMSNorm(
+        self.pre_layer_norm = Gemma4AudioRMSNorm(
             hidden_size=config.hidden_size, eps=config.rms_norm_eps, dtype=dtype
         )
-        self.post_layer_norm = _Gemma4AudioRMSNorm(
+        self.post_layer_norm = Gemma4AudioRMSNorm(
             hidden_size=config.hidden_size, eps=config.rms_norm_eps, dtype=dtype
         )
         self.act_fn = ACT2FN[config.hidden_act]
@@ -486,10 +486,10 @@ class Gemma4AudioLightConv1d(nn.Module):
             bias=False,
             dtype=dtype,
         )
-        self.pre_layer_norm = _Gemma4AudioRMSNorm(
+        self.pre_layer_norm = Gemma4AudioRMSNorm(
             hidden_size=config.hidden_size, eps=config.rms_norm_eps, dtype=dtype
         )
-        self.conv_norm = _Gemma4AudioRMSNorm(
+        self.conv_norm = Gemma4AudioRMSNorm(
             hidden_size=config.hidden_size, eps=config.rms_norm_eps, dtype=dtype
         )
         self.act_fn = ACT2FN[config.hidden_act]
@@ -530,13 +530,13 @@ class Gemma4AudioLayer(nn.Module):
             config, layer_idx=layer_idx, dtype=dtype, mapping=mapping
         )
         self.lconv1d = Gemma4AudioLightConv1d(config, dtype=dtype, mapping=mapping)
-        self.norm_pre_attn = _Gemma4AudioRMSNorm(
+        self.norm_pre_attn = Gemma4AudioRMSNorm(
             hidden_size=config.hidden_size, eps=config.rms_norm_eps, dtype=dtype
         )
-        self.norm_post_attn = _Gemma4AudioRMSNorm(
+        self.norm_post_attn = Gemma4AudioRMSNorm(
             hidden_size=config.hidden_size, eps=config.rms_norm_eps, dtype=dtype
         )
-        self.norm_out = _Gemma4AudioRMSNorm(
+        self.norm_out = Gemma4AudioRMSNorm(
             hidden_size=config.hidden_size, eps=config.rms_norm_eps, dtype=dtype
         )
         self.gradient_clipping = config.gradient_clipping
@@ -580,7 +580,7 @@ class Gemma4AudioModel(nn.Module):
         input_features:  (B, mel_T, mel_bins) — mel-spectrogram frames
         attention_mask:  (B, mel_T) bool — True for valid frames
 
-    Returns ``_AudioOutput`` with:
+    Returns ``AudioOutput`` with:
         last_hidden_state: (B, T_audio, output_proj_dims)
         attention_mask:    (B, T_audio) bool — post-subsample frame validity
     """
@@ -666,7 +666,7 @@ class Gemma4AudioModel(nn.Module):
         input_features: torch.Tensor,
         attention_mask: Optional[torch.Tensor] = None,
         **kwargs,
-    ) -> _AudioOutput:
+    ) -> AudioOutput:
         hidden_states, output_mask = self.subsample_conv_projection(input_features, attention_mask)
         position_embeddings = self.rel_pos_enc(hidden_states)
 
@@ -688,7 +688,7 @@ class Gemma4AudioModel(nn.Module):
             )
 
         hidden_states = self.output_proj(hidden_states)
-        return _AudioOutput(last_hidden_state=hidden_states, attention_mask=output_mask)
+        return AudioOutput(last_hidden_state=hidden_states, attention_mask=output_mask)
 
     def load_weights(self, weights: Dict[str, torch.Tensor]):
         """Load HF ``Gemma4AudioModel`` weights.

--- a/tensorrt_llm/_torch/models/modeling_gemma4_audio.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4_audio.py
@@ -53,7 +53,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from transformers.activations import ACT2FN
-from transformers.models.gemma4.modeling_gemma4 import Gemma4RMSNorm as _HFGemma4RMSNorm
 
 from ..model_config import ModelConfig
 from ..modules.linear import Linear
@@ -69,19 +68,27 @@ class AudioOutput:
 
 
 # ---------------------------------------------------------------------------
-# RMSNorm: thin kwarg/dtype adapter over HF's ``Gemma4RMSNorm`` (see module
-# docstring for why this isn't the TRT-LLM ``RMSNorm`` module).
+# RMSNorm: native plain ``w * x / rms`` (not the Gemma3 LLM ``(1 + w) * x /
+# rms`` variant). Re-implemented inline to keep this file free of
+# ``transformers.models.gemma4`` imports — see the matching docstring in
+# ``modeling_gemma4_vision.Gemma4VisionRMSNorm`` for the full rationale.
 # ---------------------------------------------------------------------------
 
 
-class Gemma4AudioRMSNorm(_HFGemma4RMSNorm):
-    """Kwarg + dtype adapter around HF ``Gemma4RMSNorm`` (``w * x / rms(x)``)."""
+class Gemma4AudioRMSNorm(nn.Module):
+    """Native plain RMSNorm for the Gemma4 audio tower (``w * x / rms(x)``)."""
 
     def __init__(self, *, hidden_size: int, eps: float, dtype: Optional[torch.dtype] = None):
-        super().__init__(hidden_size, eps=eps)
-        if dtype is not None:
-            with torch.no_grad():
-                self.weight.data = self.weight.data.to(dtype)
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(
+            torch.ones(hidden_size, dtype=dtype if dtype is not None else torch.float32)
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x32 = x.float()
+        normed = x32 * torch.rsqrt(x32.pow(2).mean(-1, keepdim=True) + self.eps)
+        return (normed * self.weight.float()).to(x.dtype)
 
 
 # ---------------------------------------------------------------------------

--- a/tensorrt_llm/_torch/models/modeling_gemma4_audio.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4_audio.py
@@ -45,7 +45,6 @@ Architecture references (HF transformers 5.5.3 ``modeling_gemma4.py``):
 """
 
 import math
-import os
 from dataclasses import dataclass
 from functools import cached_property
 from typing import Dict, Optional, Tuple
@@ -59,25 +58,6 @@ from transformers.models.gemma4.modeling_gemma4 import Gemma4RMSNorm as _HFGemma
 from ..model_config import ModelConfig
 from ..modules.linear import Linear
 from .modeling_utils import _load_weights_impl
-
-# DEBUG_PROBE_BEGIN: gated by env var, fires only when DEBUG_AUDIO_TOWER=1.
-_DEBUG_AUDIO = os.environ.get("DEBUG_AUDIO_TOWER", "0") == "1"
-
-
-def _audio_stats(name: str, t: Optional[torch.Tensor]) -> None:
-    if not _DEBUG_AUDIO or t is None:
-        return
-    f = t.detach().float()
-    finite_frac = torch.isfinite(f).float().mean().item()
-    print(
-        f"  [audio] {name:32s} shape={tuple(t.shape)} dtype={t.dtype} "
-        f"mean={f.mean().item():+.4g} std={f.std().item():.4g} "
-        f"absmax={f.abs().max().item():.4g} finite={finite_frac:.4f}",
-        flush=True,
-    )
-
-
-# DEBUG_PROBE_END
 
 
 @dataclass
@@ -687,25 +667,8 @@ class Gemma4AudioModel(nn.Module):
         attention_mask: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> _AudioOutput:
-        # DEBUG_PROBE_BEGIN
-        if _DEBUG_AUDIO:
-            print("[audio] === Gemma4AudioModel.forward ===", flush=True)
-            _audio_stats("input_features (mel)", input_features)
-            _audio_stats(
-                "attention_mask", attention_mask.float() if attention_mask is not None else None
-            )
-        # DEBUG_PROBE_END
         hidden_states, output_mask = self.subsample_conv_projection(input_features, attention_mask)
-        # DEBUG_PROBE_BEGIN
-        _audio_stats("after subsample_conv_proj", hidden_states)
-        _audio_stats(
-            "output_mask (subsample)", output_mask.float() if output_mask is not None else None
-        )
-        # DEBUG_PROBE_END
         position_embeddings = self.rel_pos_enc(hidden_states)
-        # DEBUG_PROBE_BEGIN
-        _audio_stats("rel_pos_enc", position_embeddings)
-        # DEBUG_PROBE_END
 
         # output_mask: (B, T_audio) bool. Frames where mask is False are pad.
         if output_mask is None:
@@ -716,26 +679,15 @@ class Gemma4AudioModel(nn.Module):
             output_mask, seq_len=hidden_states.shape[1], device=hidden_states.device
         )
         attn_mask_5d = self._convert_4d_mask_to_blocked_5d(attn_mask_4d)
-        # DEBUG_PROBE_BEGIN
-        _audio_stats("attn_mask_5d", attn_mask_5d.float())
-        # DEBUG_PROBE_END
 
-        n_layers = len(self.layers)
-        for i, layer in enumerate(self.layers):
+        for layer in self.layers:
             hidden_states = layer(
                 hidden_states=hidden_states,
                 attention_mask=attn_mask_5d,
                 position_embeddings=position_embeddings,
             )
-            # DEBUG_PROBE_BEGIN: log layers 0 / mid / last
-            if _DEBUG_AUDIO and (i == 0 or i == n_layers // 2 or i == n_layers - 1):
-                _audio_stats(f"after layer[{i}]", hidden_states)
-            # DEBUG_PROBE_END
 
         hidden_states = self.output_proj(hidden_states)
-        # DEBUG_PROBE_BEGIN
-        _audio_stats("after output_proj (final)", hidden_states)
-        # DEBUG_PROBE_END
         return _AudioOutput(last_hidden_state=hidden_states, attention_mask=output_mask)
 
     def load_weights(self, weights: Dict[str, torch.Tensor]):
@@ -759,38 +711,3 @@ class Gemma4AudioModel(nn.Module):
         for name, buf in self.named_buffers():
             if name in weights:
                 buf.data.copy_(weights[name].to(buf.dtype).to(buf.device))
-        # DEBUG_PROBE_BEGIN: verify checkpoint actually landed
-        if _DEBUG_AUDIO:
-            print("[audio] === load_weights summary ===", flush=True)
-            print(f"  checkpoint keys provided: {len(weights)}", flush=True)
-            loaded_param_keys = {n for n, _ in self.named_parameters()}
-            covered_params = sum(1 for k in weights if k in loaded_param_keys)
-            print(
-                f"  params covered by ckpt:   {covered_params}/{len(loaded_param_keys)}", flush=True
-            )
-            # Spot-check a few _Gemma4AudioRMSNorm weights — if they're all
-            # zeros, the (1+w) convention reduces to identity scaling and
-            # explains "BLEU=1.9, model ignores audio". Sample 3 RMSNorms.
-            picks = []
-            for name, mod in self.named_modules():
-                if isinstance(mod, _Gemma4AudioRMSNorm):
-                    picks.append((name, mod.weight))
-                    if len(picks) >= 3:
-                        break
-            for name, w in picks:
-                f = w.detach().float()
-                print(
-                    f"  rmsnorm[{name}].weight stats: "
-                    f"mean={f.mean().item():+.4g} std={f.std().item():.4g} "
-                    f"absmax={f.abs().max().item():.4g} zero_frac={(f == 0).float().mean().item():.4f}",
-                    flush=True,
-                )
-            # Also spot-check one clippable linear's input_min/output_max buffers.
-            for name, mod in self.named_modules():
-                if isinstance(mod, Gemma4AudioClippableLinear):
-                    for bname in ("input_min", "input_max", "output_min", "output_max"):
-                        b = getattr(mod, bname, None)
-                        if b is not None:
-                            print(f"  clip[{name}].{bname}: {b.item():+.4g}", flush=True)
-                    break
-        # DEBUG_PROBE_END

--- a/tensorrt_llm/_torch/models/modeling_gemma4_vision.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4_vision.py
@@ -40,7 +40,7 @@ Architecture references (HF transformers 5.5.3 ``modeling_gemma4.py``):
 
 import math
 from dataclasses import dataclass
-from typing import Dict, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -751,6 +751,7 @@ class Gemma4VisionModel(nn.Module):
         pixel_values: torch.Tensor,
         pixel_position_ids: torch.Tensor,
         output_length: Optional[int] = None,
+        image_seq_lens: Optional[List[int]] = None,
     ) -> VisionOutput:
         if output_length is None:
             k = self.config.pooling_kernel_size
@@ -773,7 +774,16 @@ class Gemma4VisionModel(nn.Module):
         flat_cos = cos_btn[valid]
         flat_sin = sin_btn[valid]
         flat_position_ids = pixel_position_ids[valid]
-        seq_lens_cpu = valid.sum(dim=-1).to(torch.int).cpu()
+
+        # Per-image valid-patch count → ``attn_metadata.prompt_lens``, always
+        # CPU-derived to keep the GPU stream free of D2H syncs.
+        if image_seq_lens is not None:
+            assert len(image_seq_lens) == B, (
+                f"image_seq_lens length mismatch: got {len(image_seq_lens)}, expected {B}"
+            )
+            seq_lens_cpu = torch.tensor(image_seq_lens, dtype=torch.int, device="cpu")
+        else:
+            seq_lens_cpu = torch.full((B,), N, dtype=torch.int, device="cpu")
 
         attn_metadata = self._prepare_attn_metadata(seq_lens_cpu)
 

--- a/tensorrt_llm/_torch/models/modeling_gemma4_vision.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4_vision.py
@@ -63,7 +63,7 @@ from .modeling_utils import _load_weights_impl
 # rejects non-fp32 / non-contiguous strides and 1152-wide bf16 inputs from
 # SigLip. HF's class is pure PyTorch and handles ``with_scale=False`` (the
 # weightless ``v_norm`` case) via a flag.
-class _Gemma4VisionRMSNorm(_HFGemma4RMSNorm):
+class Gemma4VisionRMSNorm(_HFGemma4RMSNorm):
     """Kwarg + dtype adapter around HF ``Gemma4RMSNorm``."""
 
     def __init__(
@@ -81,7 +81,7 @@ class _Gemma4VisionRMSNorm(_HFGemma4RMSNorm):
 
 
 @dataclass
-class _VisionOutput:
+class VisionOutput:
     """Stand-in for ``transformers.BaseModelOutputWithPast`` (only field used)."""
 
     last_hidden_state: torch.Tensor
@@ -279,15 +279,33 @@ class Gemma4VisionAttention(Attention):
     so we pass ``q_scaling = 1 / sqrt(head_dim)`` to neutralize the sqrt.
     """
 
+    # trtllm-gen FMHA on sm100a ships cubins for these head_dim sizes only.
+    # Variants whose HF ``head_dim`` is not in this set are padded up to the
+    # next supported size; the kernel sees zero-padded q/k/v while RMSNorm,
+    # RoPE, and o_proj math run on the unpadded HF channels (see ``forward``
+    # for the slice / re-pad dance and ``Gemma4VisionModel.load_weights`` for
+    # weight zero-padding). Gemma4 26B/31B vision: ``head_dim=72`` → 80.
+    _FMHA_SUPPORTED_HEAD_DIMS = (64, 80, 128, 256, 512)
+
     def __init__(
         self, model_config: ModelConfig, vision_config, layer_idx: int, dtype: torch.dtype
     ):
-        head_dim = getattr(
+        hf_head_dim = getattr(
             vision_config,
             "head_dim",
             vision_config.hidden_size // vision_config.num_attention_heads,
         )
-        q_scaling = 1.0 / math.sqrt(head_dim)
+        if hf_head_dim in self._FMHA_SUPPORTED_HEAD_DIMS:
+            padded_head_dim = hf_head_dim
+        else:
+            padded_head_dim = next(d for d in self._FMHA_SUPPORTED_HEAD_DIMS if d >= hf_head_dim)
+        # TRT-LLM ``Attention`` applies ``qk_scale = 1 / (sqrt(self.head_dim) *
+        # q_scaling)``; HF ``Gemma4VisionAttention`` sets ``scaling = 1.0`` (no
+        # ``1/sqrt(d)`` rescale). Use the padded ``head_dim`` here so the scale
+        # exactly cancels — the padded q/k channels are zero, so the dot product
+        # is numerically the same regardless of ``sqrt(padded)`` vs
+        # ``sqrt(hf_head_dim)``.
+        q_scaling = 1.0 / math.sqrt(padded_head_dim)
         max_pe = getattr(vision_config, "max_position_embeddings", None) or (
             getattr(vision_config, "position_embedding_size", 0) ** 2 or 4096
         )
@@ -304,20 +322,27 @@ class Gemma4VisionAttention(Attention):
             dense_bias=False,
             config=model_config,
             q_scaling=q_scaling,
-            head_dim=head_dim,
+            head_dim=padded_head_dim,
         )
         self.vision_config = vision_config
+        # ``self.head_dim`` is now ``padded_head_dim`` (the kernel-facing value).
+        # ``self.hf_head_dim`` is the original HF head_dim; norm + RoPE see
+        # this dim only. ``self.head_dim_pad`` is the zero-padding width.
+        self.hf_head_dim = hf_head_dim
+        self.head_dim_pad = padded_head_dim - hf_head_dim
 
         # HF Gemma4RMSNorm is the plain variant (``x_normed * weight``, no
         # ``(1+w)``). v_norm has ``with_scale=False`` (no learnable weight).
-        self.q_norm = _Gemma4VisionRMSNorm(
-            hidden_size=self.head_dim, eps=vision_config.rms_norm_eps, dtype=dtype
+        # Norms operate on ``hf_head_dim``; padded channels are sliced off
+        # before norm and re-padded with zeros after RoPE (see ``forward``).
+        self.q_norm = Gemma4VisionRMSNorm(
+            hidden_size=self.hf_head_dim, eps=vision_config.rms_norm_eps, dtype=dtype
         )
-        self.k_norm = _Gemma4VisionRMSNorm(
-            hidden_size=self.head_dim, eps=vision_config.rms_norm_eps, dtype=dtype
+        self.k_norm = Gemma4VisionRMSNorm(
+            hidden_size=self.hf_head_dim, eps=vision_config.rms_norm_eps, dtype=dtype
         )
-        self.v_norm = _Gemma4VisionRMSNorm(
-            hidden_size=self.head_dim,
+        self.v_norm = Gemma4VisionRMSNorm(
+            hidden_size=self.hf_head_dim,
             eps=vision_config.rms_norm_eps,
             dtype=dtype,
             has_weights=False,
@@ -346,7 +371,7 @@ class Gemma4VisionAttention(Attention):
             ):
                 self.register_buffer(name, pos_inf.clone())
 
-    def _head_norm(self, x: torch.Tensor, norm: _Gemma4VisionRMSNorm) -> torch.Tensor:
+    def _head_norm(self, x: torch.Tensor, norm: Gemma4VisionRMSNorm) -> torch.Tensor:
         # HF ``Gemma4RMSNorm`` is pure PyTorch and normalises over the last
         # dim, so we can pass the (..., head_dim) tensor through directly.
         return norm(x)
@@ -377,17 +402,54 @@ class Gemma4VisionAttention(Attention):
         k = k.view(num_tokens, self.num_key_value_heads, self.head_dim)
         v = v.view(num_tokens, self.num_key_value_heads, self.head_dim)
 
-        q = self._head_norm(q, self.q_norm)
-        k = self._head_norm(k, self.k_norm)
-        v = self._head_norm(v, self.v_norm)
+        # When ``head_dim`` was padded to satisfy the FMHA cubin set, the
+        # qkv_proj last ``head_dim_pad`` channels are produced by zero-padded
+        # weight rows (see ``Gemma4VisionModel.load_weights``) — slice them
+        # off before RMSNorm so the mean-of-squares averages over
+        # ``hf_head_dim`` (HF semantics), not the padded width.
+        if self.head_dim_pad > 0:
+            q_real = q[..., : self.hf_head_dim]
+            k_real = k[..., : self.hf_head_dim]
+            v_real = v[..., : self.hf_head_dim]
+        else:
+            q_real, k_real, v_real = q, k, v
+
+        q_real = self._head_norm(q_real, self.q_norm)
+        k_real = self._head_norm(k_real, self.k_norm)
+        v_real = self._head_norm(v_real, self.v_norm)
 
         cos, sin = position_embeddings
-        q = _apply_multidimensional_rope(q, cos, sin, position_ids, unsqueeze_dim=1)
-        k = _apply_multidimensional_rope(k, cos, sin, position_ids, unsqueeze_dim=1)
+        q_real = _apply_multidimensional_rope(q_real, cos, sin, position_ids, unsqueeze_dim=1)
+        k_real = _apply_multidimensional_rope(k_real, cos, sin, position_ids, unsqueeze_dim=1)
+
+        # Re-pad with zeros for the FMHA kernel. Zeros in q_pad/k_pad don't
+        # contribute to QK^T; zeros in v_pad produce zero output channels — so
+        # ``attn_output[..., hf_head_dim:]`` is identically 0 and o_proj's
+        # last padded columns (also zero) don't see real signal either way.
+        if self.head_dim_pad > 0:
+            pad_shape = q_real.shape[:-1] + (self.head_dim_pad,)
+            q = torch.cat([q_real, q_real.new_zeros(pad_shape)], dim=-1)
+            k = torch.cat([k_real, k_real.new_zeros(pad_shape)], dim=-1)
+            v = torch.cat([v_real, v_real.new_zeros(pad_shape)], dim=-1)
+        else:
+            q, k, v = q_real, k_real, v_real
 
         q = q.reshape(num_tokens, self.num_heads * self.head_dim)
         k = k.reshape(num_tokens, self.num_key_value_heads * self.head_dim)
         v = v.reshape(num_tokens, self.num_key_value_heads * self.head_dim)
+
+        # Defensive dtype cast: HF ``Gemma4RMSNorm.forward`` casts internals to
+        # fp32; RoPE / clamp paths can also promote. The FMHA dispatcher
+        # rejects non-bf16/half input ("Fall back to unfused MHA because of
+        # unsupported data type") and falls into the O(B × T²) unfused path.
+        # Casting q/k/v back to the projection weight dtype (matches model
+        # dtype, typically bf16; fp32 in unit tests) keeps the kernel
+        # dispatch on the FMHA path in production and is a no-op when the
+        # tower was constructed in fp32 anyway.
+        target_dtype = self.qkv_proj.weight.dtype
+        q = q.to(target_dtype)
+        k = k.to(target_dtype)
+        v = v.to(target_dtype)
 
         q, k, v = self.convert_qkv(q, k, v)
         attn_output = self.forward_impl(
@@ -429,22 +491,22 @@ class Gemma4VisionEncoderLayer(nn.Module):
             dtype=dtype,
         )
         self.mlp = Gemma4VisionMLP(vision_config, dtype, mapping)
-        self.input_layernorm = _Gemma4VisionRMSNorm(
+        self.input_layernorm = Gemma4VisionRMSNorm(
             hidden_size=vision_config.hidden_size,
             eps=vision_config.rms_norm_eps,
             dtype=dtype,
         )
-        self.post_attention_layernorm = _Gemma4VisionRMSNorm(
+        self.post_attention_layernorm = Gemma4VisionRMSNorm(
             hidden_size=vision_config.hidden_size,
             eps=vision_config.rms_norm_eps,
             dtype=dtype,
         )
-        self.pre_feedforward_layernorm = _Gemma4VisionRMSNorm(
+        self.pre_feedforward_layernorm = Gemma4VisionRMSNorm(
             hidden_size=vision_config.hidden_size,
             eps=vision_config.rms_norm_eps,
             dtype=dtype,
         )
-        self.post_feedforward_layernorm = _Gemma4VisionRMSNorm(
+        self.post_feedforward_layernorm = Gemma4VisionRMSNorm(
             hidden_size=vision_config.hidden_size,
             eps=vision_config.rms_norm_eps,
             dtype=dtype,
@@ -507,7 +569,7 @@ class Gemma4VisionEncoder(nn.Module):
         attn_metadata: AttentionMetadata,
         position_embeddings: Tuple[torch.Tensor, torch.Tensor],
         position_ids: torch.Tensor,
-    ) -> _VisionOutput:
+    ) -> VisionOutput:
         hidden_states = inputs_embeds
         for layer in self.layers:
             hidden_states = layer(
@@ -516,7 +578,7 @@ class Gemma4VisionEncoder(nn.Module):
                 position_embeddings=position_embeddings,
                 position_ids=position_ids,
             )
-        return _VisionOutput(last_hidden_state=hidden_states)
+        return VisionOutput(last_hidden_state=hidden_states)
 
 
 # ---------------------------------------------------------------------------
@@ -626,7 +688,7 @@ class Gemma4VisionModel(nn.Module):
         pixel_position_ids: (B, num_patches, 2) -- (x, y) per patch; -1 = padding
         output_length: post-pool token count (== num_patches // pooling_k**2)
 
-    Returns ``_VisionOutput`` with ``last_hidden_state`` of shape
+    Returns ``VisionOutput`` with ``last_hidden_state`` of shape
     ``(N_valid_tokens, hidden_size)`` (flat across the batch after pooler_mask strip).
     """
 
@@ -652,13 +714,22 @@ class Gemma4VisionModel(nn.Module):
 
         # SigLip-style context-only metadata: kv_cache_manager=None, no decode
         # phase. Re-prepared each forward with the actual per-image seq lens.
-        # Vision tower runs one image per call (mm forward loops per-image),
-        # so bounds are vision-scale, not LLM-scale. Using LLM max_num_tokens
-        # here makes the C++ attn workspace resize to TB-range and OOM
-        # (sized as max_num_requests * heads * max_num_tokens^2 * bytes).
+        # Vision tower is called once per LLM step across all images in the
+        # batch (``modeling_gemma4mm._get_image_features``), so the batch
+        # axis here is the cross-request image count.
+        #
+        # Sizing rationale: vision attention dispatches to the trtllm-gen
+        # FMHA kernel (see ``Gemma4VisionAttention``: dtype cast on q/k/v
+        # before ``forward_impl``; head_dim padded to an FMHA-supported
+        # cubin size in ``__init__`` + ``load_weights``). FMHA workspace is
+        # O(max_num_tokens × hidden_size) — linear, no batch² term — so we
+        # can safely pull the LLM-side ``max_num_requests`` (typically
+        # 8192) without OOM. ``max_num_tokens`` stays at a vision-scale
+        # 8192 (covers worst-case patch counts) — pulling the LLM-side
+        # value of 16384 would still bloat workspace 4× on no reason.
         self.metadata_cls = get_attention_backend(model_config.attn_backend).Metadata
         self.attn_metadata = self.metadata_cls(
-            max_num_requests=1,
+            max_num_requests=getattr(model_config, "max_num_requests", 8192) or 8192,
             max_num_tokens=8192,
             kv_cache_manager=None,
         )
@@ -680,7 +751,7 @@ class Gemma4VisionModel(nn.Module):
         pixel_values: torch.Tensor,
         pixel_position_ids: torch.Tensor,
         output_length: Optional[int] = None,
-    ) -> _VisionOutput:
+    ) -> VisionOutput:
         if output_length is None:
             k = self.config.pooling_kernel_size
             output_length = pixel_values.shape[-2] // (k * k)
@@ -727,7 +798,7 @@ class Gemma4VisionModel(nn.Module):
         hidden_states = hidden_states[pooler_mask]
         if self.standardize:
             hidden_states = (hidden_states - self.std_bias) * self.std_scale
-        return _VisionOutput(last_hidden_state=hidden_states)
+        return VisionOutput(last_hidden_state=hidden_states)
 
     def load_weights(self, weights: Dict[str, torch.Tensor]):
         # HF Gemma4ClippableLinear has nested ``.linear`` weights. We collapse
@@ -742,7 +813,13 @@ class Gemma4VisionModel(nn.Module):
         #   - Attention output clamps: q/k/v stay separate; o_proj input/output
         #     clamps move from ``self_attn.o_proj.{input,output}_{min,max}``
         #     into the attention module as ``o_{input,output}_{min,max}``.
+        #   - If the model's HF ``head_dim`` is not an FMHA-supported cubin
+        #     size (e.g. 72 for 26B/31B), zero-pad q/k/v/o_proj head dim to
+        #     the next supported size (e.g. 80) so the trtllm-gen FMHA
+        #     kernel can dispatch. Norm/RoPE math sees only the unpadded
+        #     channels (see ``Gemma4VisionAttention.forward``).
         remapped = self._remap_clamp_buffers(dict(weights))
+        remapped = self._pad_attention_head_dim(remapped)
         # Strip the HF ``.linear`` indirection inside our ClippableLinear
         # wrappers (MLP and patch_embedder.input_proj are also wrapped/standalone).
         # The attention's qkv_proj absorbs HF q_proj/k_proj/v_proj via
@@ -817,3 +894,78 @@ class Gemma4VisionModel(nn.Module):
                         remapped[f"{prefix}.o_{io}_{kind}"] = weights[src].clone()
                         remapped.pop(src, None)
         return remapped
+
+    def _pad_attention_head_dim(self, weights: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+        """Zero-pad q/k/v_proj and o_proj head dim from HF to FMHA-supported.
+
+        No-op when ``head_dim`` was already in the FMHA cubin set (E2B/E4B
+        vision: head_dim=64). For 26B/31B vision (head_dim=72), pads to 80
+        so the trtllm-gen FMHA dispatcher finds a matching kernel and
+        keeps workspace linear in seq_len.
+
+        Math invariant: zeros in the appended channels mean (a) qkv_proj
+        outputs zero on those channels (zero-rowed weight × any input = 0),
+        (b) softmax(QK^T) is the same since pad·pad=0 doesn't contribute,
+        (c) ``attn_output[..., hf:padded]`` is identically zero (V's pad
+        channels are zero), and (d) o_proj's zero-padded last columns × the
+        zero attn_output channels = 0. Net: byte-equivalent to the unpadded
+        HF math, plus 11% extra compute on the kernel side (80/72).
+        """
+        import re
+
+        first_attn = self.encoder.layers[0].self_attn
+        if getattr(first_attn, "head_dim_pad", 0) == 0:
+            return weights
+
+        hf_hd = first_attn.hf_head_dim
+        padded_hd = first_attn.head_dim
+        nh = first_attn.num_heads
+        nkv = first_attn.num_key_value_heads
+        pad_w = padded_hd - hf_hd
+
+        # HF keys at this point have already had ``.linear.`` stripped if the
+        # rename pattern landed first, but the rename happens INSIDE
+        # ``_load_weights_impl``. So we see the raw HF keys here:
+        #   self_attn.{q,k,v}_proj.linear.{weight,bias}
+        #   self_attn.o_proj.linear.{weight,bias}
+        qkv_re = re.compile(r"(.*self_attn\.)([qkv])_proj\.linear\.(weight|bias)$")
+        o_re = re.compile(r"(.*self_attn\.)o_proj\.linear\.(weight|bias)$")
+        out = dict(weights)
+        for k, v in list(weights.items()):
+            m = qkv_re.match(k)
+            if m is not None and m.group(3) == "weight":
+                # HF (sec=q): (nh × hf_hd, hidden_size)
+                # HF (sec=k,v): (nkv × hf_hd, hidden_size)
+                heads = nh if m.group(2) == "q" else nkv
+                w = v
+                assert w.shape[0] == heads * hf_hd, (
+                    f"Unexpected qkv shape {tuple(w.shape)} for {k} "
+                    f"(expected first dim = {heads}*{hf_hd})"
+                )
+                w = w.view(heads, hf_hd, -1)
+                zeros = w.new_zeros(heads, pad_w, w.shape[-1])
+                out[k] = torch.cat([w, zeros], dim=1).reshape(heads * padded_hd, -1)
+                continue
+            if m is not None and m.group(3) == "bias":
+                heads = nh if m.group(2) == "q" else nkv
+                b = v
+                assert b.shape[0] == heads * hf_hd
+                b = b.view(heads, hf_hd)
+                zeros = b.new_zeros(heads, pad_w)
+                out[k] = torch.cat([b, zeros], dim=1).reshape(heads * padded_hd)
+                continue
+            m_o = o_re.match(k)
+            if m_o is not None and m_o.group(2) == "weight":
+                # HF o_proj.weight: (hidden_size, nh × hf_hd) — pad the input dim.
+                w = v
+                assert w.shape[1] == nh * hf_hd, (
+                    f"Unexpected o_proj shape {tuple(w.shape)} for {k} "
+                    f"(expected second dim = {nh}*{hf_hd})"
+                )
+                w = w.view(-1, nh, hf_hd)
+                zeros = w.new_zeros(w.shape[0], nh, pad_w)
+                out[k] = torch.cat([w, zeros], dim=2).reshape(-1, nh * padded_hd)
+                continue
+            # o_proj.bias is shape (hidden_size,) — output dim, not head dim.
+            # No padding needed.
+        return out

--- a/tensorrt_llm/_torch/models/modeling_gemma4_vision.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4_vision.py
@@ -1,0 +1,807 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Native TRT-LLM Gemma4 vision tower.
+
+Replaces the HF ``AutoModel.from_config(config.vision_config)`` call in
+``modeling_gemma4mm.py`` so the vision encoder uses TRT-LLM building blocks
+(``Attention``, ``Linear``, ``RMSNorm``) instead of importing
+``transformers.Gemma4VisionModel``.
+
+Attention inherits from TRT-LLM ``Attention`` and runs through the standard
+backend dispatch (default ``FLASHINFER`` via ``Gemma4ForCausalLM`` model
+defaults). Vision is context-only — ``kv_cache_manager=None`` and a tower-local
+``attn_metadata`` are built per forward following the SigLip pattern.
+
+Architecture references (HF transformers 5.5.3 ``modeling_gemma4.py``):
+- ``Gemma4ClippableLinear`` @ ``:128``
+- ``Gemma4RMSNorm`` @ ``:157``
+- ``Gemma4VisionPatchEmbedder`` @ ``:539``
+- ``Gemma4VisionPooler`` @ ``:573``
+- ``Gemma4VisionMLP`` @ ``:632``
+- ``Gemma4VisionRotaryEmbedding`` @ ``:648``
+- ``apply_multidimensional_rope`` @ ``:802``
+- ``Gemma4VisionAttention`` @ ``:859``
+- ``Gemma4VisionEncoderLayer`` @ ``:928``
+- ``Gemma4VisionEncoder`` @ ``:972``
+- ``Gemma4VisionModel`` @ ``:1885``
+"""
+
+import math
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers.activations import ACT2FN
+
+from tensorrt_llm._utils import prefer_pinned
+
+from ..attention_backend.interface import (AttentionMetadata,
+                                           PredefinedAttentionMask)
+from ..attention_backend.utils import get_attention_backend
+from ..model_config import ModelConfig
+from ..modules.attention import Attention
+from ..modules.linear import Linear
+from ..modules.rms_norm import RMSNorm
+from .modeling_utils import _load_weights_impl
+
+
+@dataclass
+class _VisionOutput:
+    """Stand-in for ``transformers.BaseModelOutputWithPast`` (only field used)."""
+    last_hidden_state: torch.Tensor
+
+
+# ---------------------------------------------------------------------------
+# RoPE helpers (ported from transformers/models/gemma4/modeling_gemma4.py)
+# ---------------------------------------------------------------------------
+
+
+def _rotate_half(x: torch.Tensor) -> torch.Tensor:
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def _apply_rotary_pos_emb(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    unsqueeze_dim: int = 1,
+) -> torch.Tensor:
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    return (x * cos) + (_rotate_half(x) * sin)
+
+
+def _apply_multidimensional_rope(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    position_ids: torch.Tensor,
+    unsqueeze_dim: int = 2,
+) -> torch.Tensor:
+    """2D RoPE: split channels into ``ndim`` parts, rotate each with its own freqs."""
+    ndim = position_ids.shape[-1]
+    num_input_channels = x.shape[-1]
+    num_rotated_channels_per_dim = 2 * (num_input_channels // (2 * ndim))
+    if num_rotated_channels_per_dim <= 0:
+        raise ValueError(
+            "Invalid configuration: num_rotated_channels_per_dim must be > 0, "
+            f"got {num_rotated_channels_per_dim} (num_input_channels="
+            f"{num_input_channels}, ndim={ndim})"
+        )
+    split_sizes = [num_rotated_channels_per_dim] * ndim
+    x_parts = torch.split(x, split_sizes, dim=-1)
+    cos_parts = torch.split(cos, split_sizes, dim=-1)
+    sin_parts = torch.split(sin, split_sizes, dim=-1)
+    y_parts = [
+        _apply_rotary_pos_emb(
+            x=x_parts[k], cos=cos_parts[k], sin=sin_parts[k], unsqueeze_dim=unsqueeze_dim
+        )
+        for k in range(ndim)
+    ]
+    return torch.cat(y_parts, dim=-1)
+
+
+class Gemma4VisionRotaryEmbedding(nn.Module):
+    """Computes (cos, sin) for 2D RoPE; ``inv_freq`` is per-spatial-dim."""
+
+    inv_freq: torch.Tensor
+
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        base = config.rope_parameters["rope_theta"]
+        head_dim = getattr(config, "head_dim", None) or (
+            config.hidden_size // config.num_attention_heads
+        )
+        # Per-spatial-dim partitioning: HF allocates head_dim//2 channels per dim.
+        spatial_dim = head_dim // 2
+        inv_freq = 1.0 / (
+            base
+            ** (
+                torch.arange(0, spatial_dim, 2, dtype=torch.int64).to(dtype=torch.float)
+                / spatial_dim
+            )
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.attention_scaling = 1.0
+
+    @torch.no_grad()
+    def forward(
+        self, x: torch.Tensor, position_ids: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # position_ids: (B, N, ndim=2). Compute cos/sin independently per spatial dim
+        # and concatenate so apply_multidimensional_rope can split them back.
+        inv_freq_expanded = (
+            self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        )
+        all_cos, all_sin = [], []
+        for i in range(position_ids.shape[-1]):
+            dim_position_ids = position_ids[:, :, i]
+            dim_position_ids_expanded = dim_position_ids[:, None, :].float()
+            with torch.autocast(device_type=x.device.type, enabled=False):
+                freqs = (
+                    inv_freq_expanded.float() @ dim_position_ids_expanded.float()
+                ).transpose(1, 2)
+                emb = torch.cat((freqs, freqs), dim=-1)
+                cos = emb.cos() * self.attention_scaling
+                sin = emb.sin() * self.attention_scaling
+            all_cos.append(cos)
+            all_sin.append(sin)
+        cos = torch.cat(all_cos, dim=-1).to(dtype=x.dtype)
+        sin = torch.cat(all_sin, dim=-1).to(dtype=x.dtype)
+        return cos, sin
+
+
+# ---------------------------------------------------------------------------
+# Building blocks
+# ---------------------------------------------------------------------------
+
+
+class Gemma4VisionClippableLinear(nn.Module):
+    """TRT-LLM ``Linear`` + optional per-projection input/output clamping.
+
+    HF parity: ``Gemma4ClippableLinear`` registers four scalar buffers (sentinel
+    -inf / +inf so that an unloaded checkpoint behaves as a no-op). The buffers
+    are populated by the checkpoint when ``use_clipped_linears=True``.
+    """
+
+    def __init__(
+        self,
+        config,
+        in_features: int,
+        out_features: int,
+        dtype: torch.dtype,
+        mapping=None,
+    ) -> None:
+        super().__init__()
+        self.use_clipped_linears = bool(getattr(config, "use_clipped_linears", False))
+        self.linear = Linear(
+            in_features=in_features,
+            out_features=out_features,
+            bias=False,
+            dtype=dtype,
+            mapping=mapping,
+        )
+        if self.use_clipped_linears:
+            self.register_buffer("input_min", torch.tensor(-float("inf")))
+            self.register_buffer("input_max", torch.tensor(float("inf")))
+            self.register_buffer("output_min", torch.tensor(-float("inf")))
+            self.register_buffer("output_max", torch.tensor(float("inf")))
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self.use_clipped_linears:
+            hidden_states = torch.clamp(hidden_states, self.input_min, self.input_max)
+        hidden_states = self.linear(hidden_states)
+        if self.use_clipped_linears:
+            hidden_states = torch.clamp(hidden_states, self.output_min, self.output_max)
+        return hidden_states
+
+
+class Gemma4VisionMLP(nn.Module):
+    def __init__(self, config, dtype: torch.dtype, mapping=None):
+        super().__init__()
+        self.gate_proj = Gemma4VisionClippableLinear(
+            config, config.hidden_size, config.intermediate_size, dtype, mapping
+        )
+        self.up_proj = Gemma4VisionClippableLinear(
+            config, config.hidden_size, config.intermediate_size, dtype, mapping
+        )
+        self.down_proj = Gemma4VisionClippableLinear(
+            config, config.intermediate_size, config.hidden_size, dtype, mapping
+        )
+        self.act_fn = ACT2FN[config.hidden_activation]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+
+
+class Gemma4VisionAttention(Attention):
+    """Bidirectional attention with q/k/v RMSNorms and 2D RoPE.
+
+    Inherits ``Attention`` to participate in the TRT-LLM backend dispatch
+    (default ``FLASHINFER``). Vision is context-only and runs through
+    ``forward_impl`` with ``PredefinedAttentionMask.FULL`` and a tower-local
+    ``attn_metadata`` (``kv_cache_manager=None``).
+
+    The ``Attention`` base class uses a fused ``qkv_proj`` and a vanilla
+    ``o_proj``. To preserve HF Gemma4's ``ClippableLinear`` semantics we
+    register clamp buffers directly on this module and apply them around the
+    projections in ``forward``:
+      - ``qkv_input_{min,max}``: shared input clamp (HF stores 3 copies, one
+        per q/k/v; ``load_weights`` asserts they match and collapses to one).
+      - ``{q,k,v}_output_{min,max}``: per-section output clamp applied after
+        ``split_qkv``.
+      - ``o_input_{min,max}`` / ``o_output_{min,max}``: o_proj clamps.
+
+    HF Gemma4VisionAttention sets ``self.scaling = 1.0`` (no head-dim
+    rescaling). TRT-LLM uses ``qk_scale = 1 / (sqrt(head_dim) * q_scaling)``,
+    so we pass ``q_scaling = 1 / sqrt(head_dim)`` to neutralize the sqrt.
+    """
+
+    def __init__(self,
+                 model_config: ModelConfig,
+                 vision_config,
+                 layer_idx: int,
+                 dtype: torch.dtype):
+        head_dim = getattr(
+            vision_config,
+            "head_dim",
+            vision_config.hidden_size // vision_config.num_attention_heads,
+        )
+        q_scaling = 1.0 / math.sqrt(head_dim)
+        max_pe = getattr(vision_config, "max_position_embeddings", None) or (
+            getattr(vision_config, "position_embedding_size", 0) ** 2 or 4096
+        )
+        super().__init__(
+            hidden_size=vision_config.hidden_size,
+            num_attention_heads=vision_config.num_attention_heads,
+            num_key_value_heads=vision_config.num_key_value_heads,
+            max_position_embeddings=max_pe,
+            bias=False,
+            pos_embd_params=None,
+            rope_fusion=False,
+            layer_idx=layer_idx,
+            dtype=dtype,
+            dense_bias=False,
+            config=model_config,
+            q_scaling=q_scaling,
+            head_dim=head_dim,
+        )
+        self.vision_config = vision_config
+
+        # HF Gemma4RMSNorm is the plain variant (``x_normed * weight``, no
+        # ``(1+w)``). v_norm has ``with_scale=False`` (no learnable weight).
+        self.q_norm = RMSNorm(
+            hidden_size=self.head_dim, eps=vision_config.rms_norm_eps, dtype=dtype
+        )
+        self.k_norm = RMSNorm(
+            hidden_size=self.head_dim, eps=vision_config.rms_norm_eps, dtype=dtype
+        )
+        self.v_norm = RMSNorm(
+            hidden_size=self.head_dim,
+            eps=vision_config.rms_norm_eps,
+            dtype=dtype,
+            has_weights=False,
+        )
+
+        self.use_clipped_linears = bool(
+            getattr(vision_config, "use_clipped_linears", False))
+        if self.use_clipped_linears:
+            neg_inf = torch.tensor(-float("inf"))
+            pos_inf = torch.tensor(float("inf"))
+            for name in (
+                "qkv_input_min", "q_output_min", "k_output_min", "v_output_min",
+                "o_input_min", "o_output_min",
+            ):
+                self.register_buffer(name, neg_inf.clone())
+            for name in (
+                "qkv_input_max", "q_output_max", "k_output_max", "v_output_max",
+                "o_input_max", "o_output_max",
+            ):
+                self.register_buffer(name, pos_inf.clone())
+
+    def _head_norm(self, x: torch.Tensor, norm: RMSNorm) -> torch.Tensor:
+        # TRT-LLM ``RMSNorm`` may dispatch to ``flashinfer_rmsnorm`` which
+        # expects 2-D inputs — same pattern as ``QKNormRoPEAttention.apply_qk_norm``.
+        shape = x.shape
+        return norm(x.reshape(-1, self.head_dim)).reshape(shape)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        position_ids: torch.Tensor,
+        **kwargs,
+    ) -> torch.Tensor:
+        # Flat (num_tokens, hidden) layout — encoder flattens (B, N, H) before
+        # dispatching to attention.
+        if self.use_clipped_linears:
+            hidden_states = torch.clamp(
+                hidden_states, self.qkv_input_min, self.qkv_input_max
+            )
+
+        qkv = self.qkv_proj(hidden_states)
+        q, k, v = self.split_qkv(qkv)
+
+        if self.use_clipped_linears:
+            q = torch.clamp(q, self.q_output_min, self.q_output_max)
+            k = torch.clamp(k, self.k_output_min, self.k_output_max)
+            v = torch.clamp(v, self.v_output_min, self.v_output_max)
+
+        num_tokens = hidden_states.shape[0]
+        q = q.view(num_tokens, self.num_heads, self.head_dim)
+        k = k.view(num_tokens, self.num_key_value_heads, self.head_dim)
+        v = v.view(num_tokens, self.num_key_value_heads, self.head_dim)
+
+        q = self._head_norm(q, self.q_norm)
+        k = self._head_norm(k, self.k_norm)
+        v = self._head_norm(v, self.v_norm)
+
+        cos, sin = position_embeddings
+        q = _apply_multidimensional_rope(
+            q, cos, sin, position_ids, unsqueeze_dim=1
+        )
+        k = _apply_multidimensional_rope(
+            k, cos, sin, position_ids, unsqueeze_dim=1
+        )
+
+        q = q.reshape(num_tokens, self.num_heads * self.head_dim)
+        k = k.reshape(num_tokens, self.num_key_value_heads * self.head_dim)
+        v = v.reshape(num_tokens, self.num_key_value_heads * self.head_dim)
+
+        q, k, v = self.convert_qkv(q, k, v)
+        attn_output = self.forward_impl(
+            q=q,
+            k=k,
+            v=v,
+            attn_metadata=attn_metadata,
+            attention_mask=PredefinedAttentionMask.FULL,
+            attention_window_size=None,
+            attention_mask_data=None,
+            mrope_config=None,
+            attention_sinks=None,
+        )
+
+        if self.use_clipped_linears:
+            attn_output = torch.clamp(
+                attn_output, self.o_input_min, self.o_input_max
+            )
+        attn_output = self.o_proj(attn_output, layer_idx=self.layer_idx)
+        if self.use_clipped_linears:
+            attn_output = torch.clamp(
+                attn_output, self.o_output_min, self.o_output_max
+            )
+        return attn_output
+
+
+class Gemma4VisionEncoderLayer(nn.Module):
+    """Sandwich norm pattern: input → attn → post_attn → +res; pre_ffn → mlp → post_ffn → +res."""
+
+    def __init__(self,
+                 model_config: ModelConfig,
+                 vision_config,
+                 layer_idx: int,
+                 dtype: torch.dtype,
+                 mapping=None):
+        super().__init__()
+        self.self_attn = Gemma4VisionAttention(
+            model_config=model_config,
+            vision_config=vision_config,
+            layer_idx=layer_idx,
+            dtype=dtype,
+        )
+        self.mlp = Gemma4VisionMLP(vision_config, dtype, mapping)
+        self.input_layernorm = RMSNorm(
+            hidden_size=vision_config.hidden_size,
+            eps=vision_config.rms_norm_eps,
+            dtype=dtype,
+        )
+        self.post_attention_layernorm = RMSNorm(
+            hidden_size=vision_config.hidden_size,
+            eps=vision_config.rms_norm_eps,
+            dtype=dtype,
+        )
+        self.pre_feedforward_layernorm = RMSNorm(
+            hidden_size=vision_config.hidden_size,
+            eps=vision_config.rms_norm_eps,
+            dtype=dtype,
+        )
+        self.post_feedforward_layernorm = RMSNorm(
+            hidden_size=vision_config.hidden_size,
+            eps=vision_config.rms_norm_eps,
+            dtype=dtype,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        position_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(
+            hidden_states=hidden_states,
+            attn_metadata=attn_metadata,
+            position_embeddings=position_embeddings,
+            position_ids=position_ids,
+        )
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.pre_feedforward_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = self.post_feedforward_layernorm(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class Gemma4VisionEncoder(nn.Module):
+    """Encoder runs in flat ``(sum_valid_tokens, hidden_size)`` layout.
+
+    Padding (``pixel_position_ids == -1``) is dropped at the encoder entry so
+    every token participates in the same FULL attention block via cu_seqlens.
+    Mapping back to ``(B, N)`` for the pooler is the caller's job.
+    """
+
+    def __init__(self,
+                 model_config: ModelConfig,
+                 vision_config,
+                 dtype: torch.dtype,
+                 mapping=None):
+        super().__init__()
+        self.config = vision_config
+        self.rotary_emb = Gemma4VisionRotaryEmbedding(vision_config)
+        self.layers = nn.ModuleList([
+            Gemma4VisionEncoderLayer(
+                model_config=model_config,
+                vision_config=vision_config,
+                layer_idx=i,
+                dtype=dtype,
+                mapping=mapping,
+            ) for i in range(vision_config.num_hidden_layers)
+        ])
+
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+        position_ids: torch.Tensor,
+    ) -> _VisionOutput:
+        hidden_states = inputs_embeds
+        for layer in self.layers:
+            hidden_states = layer(
+                hidden_states=hidden_states,
+                attn_metadata=attn_metadata,
+                position_embeddings=position_embeddings,
+                position_ids=position_ids,
+            )
+        return _VisionOutput(last_hidden_state=hidden_states)
+
+
+# ---------------------------------------------------------------------------
+# Patch embedder + pooler (small, kept native)
+# ---------------------------------------------------------------------------
+
+
+class Gemma4VisionPatchEmbedder(nn.Module):
+    def __init__(self, config, dtype: torch.dtype, mapping=None):
+        super().__init__()
+        self.config = config
+        self.patch_size = config.patch_size
+        self.position_embedding_size = config.position_embedding_size
+        self.input_proj = Linear(
+            in_features=3 * self.patch_size**2,
+            out_features=config.hidden_size,
+            bias=False,
+            dtype=dtype,
+            mapping=mapping,
+        )
+        # (2, P, H) — one table per spatial axis, H = hidden_size.
+        self.position_embedding_table = nn.Parameter(
+            torch.ones(2, self.position_embedding_size, config.hidden_size, dtype=dtype)
+        )
+
+    def _position_embeddings(
+        self, pixel_position_ids: torch.Tensor, padding_positions: torch.Tensor
+    ) -> torch.Tensor:
+        clamped = pixel_position_ids.clamp(min=0)
+        one_hot = F.one_hot(clamped, num_classes=self.position_embedding_size)
+        one_hot = one_hot.permute(0, 2, 1, 3).to(self.position_embedding_table)
+        position_embeddings = one_hot @ self.position_embedding_table
+        position_embeddings = position_embeddings.sum(dim=1)
+        return torch.where(padding_positions.unsqueeze(-1), 0.0, position_embeddings)
+
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        pixel_position_ids: torch.Tensor,
+        padding_positions: torch.Tensor,
+    ) -> torch.Tensor:
+        # Gemma4 scales pixel inputs in model code (no normalization in the processor).
+        pixel_values = 2 * (pixel_values - 0.5)
+        hidden_states = self.input_proj(
+            pixel_values.to(self.input_proj.weight.dtype))
+        position_embeddings = self._position_embeddings(pixel_position_ids, padding_positions)
+        return hidden_states + position_embeddings
+
+
+class Gemma4VisionPooler(nn.Module):
+    """Optional 2D spatial pooling by patch positions."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.root_hidden_size = config.hidden_size**0.5
+
+    def _avg_pool_by_positions(
+        self, hidden_states: torch.Tensor, pixel_position_ids: torch.Tensor, length: int
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        input_seq_len = hidden_states.shape[1]
+        k = int((input_seq_len // length) ** 0.5)
+        k_squared = k**2
+        if k_squared * length != input_seq_len:
+            raise ValueError(
+                f"Cannot pool {hidden_states.shape} to {length}: {k=}^2 times "
+                f"{length=} must be {input_seq_len}."
+            )
+        clamped = pixel_position_ids.clamp(min=0)
+        max_x = clamped[..., 0].max(dim=-1, keepdim=True)[0] + 1
+        kernel_idxs = torch.div(clamped, k, rounding_mode="floor")
+        kernel_idxs = kernel_idxs[..., 0] + (max_x // k) * kernel_idxs[..., 1]
+        weights = F.one_hot(kernel_idxs.long(), length).float() / k_squared
+        output = weights.transpose(1, 2) @ hidden_states.float()
+        mask = torch.logical_not((weights == 0).all(dim=1))
+        return output.to(hidden_states.dtype), mask
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        pixel_position_ids: torch.Tensor,
+        padding_positions: torch.Tensor,
+        output_length: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if output_length > hidden_states.shape[1]:
+            raise ValueError(
+                f"Cannot output more soft tokens (requested {output_length}) than "
+                f"there are patches ({hidden_states.shape[1]})."
+            )
+        hidden_states = hidden_states.masked_fill(padding_positions.unsqueeze(-1), 0.0)
+        if hidden_states.shape[1] != output_length:
+            hidden_states, padding_positions = self._avg_pool_by_positions(
+                hidden_states, pixel_position_ids, output_length
+            )
+        hidden_states = hidden_states * self.root_hidden_size
+        return hidden_states, padding_positions
+
+
+# ---------------------------------------------------------------------------
+# Top-level vision tower
+# ---------------------------------------------------------------------------
+
+
+class Gemma4VisionModel(nn.Module):
+    """Gemma4 vision tower.
+
+    Input contract (preserved from HF ``Gemma4VisionModel.forward``):
+        pixel_values: (B, num_patches, 3 * patch_size**2)
+        pixel_position_ids: (B, num_patches, 2) -- (x, y) per patch; -1 = padding
+        output_length: post-pool token count (== num_patches // pooling_k**2)
+
+    Returns ``_VisionOutput`` with ``last_hidden_state`` of shape
+    ``(N_valid_tokens, hidden_size)`` (flat across the batch after pooler_mask strip).
+    """
+
+    def __init__(self, model_config: ModelConfig):
+        super().__init__()
+        self.model_config = model_config
+        self.config = model_config.pretrained_config
+        dtype = getattr(self.config, "torch_dtype", None) or torch.bfloat16
+        mapping = getattr(model_config, "mapping", None)
+
+        self.patch_embedder = Gemma4VisionPatchEmbedder(
+            self.config, dtype=dtype, mapping=mapping)
+        self.encoder = Gemma4VisionEncoder(
+            model_config=model_config,
+            vision_config=self.config,
+            dtype=dtype,
+            mapping=mapping,
+        )
+        self.pooler = Gemma4VisionPooler(self.config)
+        self.standardize = bool(getattr(self.config, "standardize", False))
+        if self.standardize:
+            self.register_buffer(
+                "std_bias", torch.zeros(self.config.hidden_size, dtype=dtype)
+            )
+            self.register_buffer(
+                "std_scale", torch.ones(self.config.hidden_size, dtype=dtype)
+            )
+
+        # SigLip-style context-only metadata: kv_cache_manager=None, no decode
+        # phase. Re-prepared each forward with the actual per-image seq lens.
+        self.metadata_cls = get_attention_backend(
+            model_config.attn_backend).Metadata
+        self.attn_metadata = self.metadata_cls(
+            max_num_requests=8192,
+            max_num_tokens=getattr(model_config, "max_num_tokens", 8192),
+            kv_cache_manager=None,
+        )
+
+    def _prepare_attn_metadata(self, seq_lens_cpu: torch.Tensor):
+        batch_size = int(seq_lens_cpu.numel())
+        prompt_lens = seq_lens_cpu.tolist()
+        self.attn_metadata.num_contexts = batch_size
+        self.attn_metadata.request_ids = list(range(1, batch_size + 1))
+        self.attn_metadata.prompt_lens = prompt_lens
+        self.attn_metadata.seq_lens = seq_lens_cpu.to(
+            dtype=torch.int, copy=True).pin_memory() if prefer_pinned() else \
+            seq_lens_cpu.to(dtype=torch.int, copy=True)
+        self.attn_metadata.max_seq_len = max(prompt_lens) if prompt_lens else 0
+        self.attn_metadata.prepare()
+        return self.attn_metadata
+
+    @torch.inference_mode()
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        pixel_position_ids: torch.Tensor,
+        output_length: Optional[int] = None,
+    ) -> _VisionOutput:
+        if output_length is None:
+            k = self.config.pooling_kernel_size
+            output_length = pixel_values.shape[-2] // (k * k)
+
+        # (B, N) bool: True = padding.
+        padding_positions = (pixel_position_ids == -1).all(dim=-1)
+        valid = ~padding_positions
+        B, N = padding_positions.shape
+
+        # Patch embed produces (B, N, H) including padded slots zeroed.
+        inputs_embeds = self.patch_embedder(
+            pixel_values, pixel_position_ids, padding_positions)
+        # Position embeddings (cos/sin) are (B, N, head_dim) per spatial dim.
+        position_embeddings_btn = self.encoder.rotary_emb(
+            inputs_embeds, pixel_position_ids)
+
+        # Flatten to (sum_valid, H) and drop padded tokens — encoder runs
+        # FULL attention with per-image cu_seqlens.
+        flat_embeds = inputs_embeds[valid]
+        cos_btn, sin_btn = position_embeddings_btn
+        flat_cos = cos_btn[valid]
+        flat_sin = sin_btn[valid]
+        flat_position_ids = pixel_position_ids[valid]
+        seq_lens_cpu = valid.sum(dim=-1).to(torch.int).cpu()
+
+        attn_metadata = self._prepare_attn_metadata(seq_lens_cpu)
+
+        enc_out = self.encoder(
+            inputs_embeds=flat_embeds,
+            attn_metadata=attn_metadata,
+            position_embeddings=(flat_cos, flat_sin),
+            position_ids=flat_position_ids,
+        )
+
+        # Scatter back to (B, N, H) for the pooler (padded slots → 0).
+        last = enc_out.last_hidden_state.new_zeros(B, N, inputs_embeds.shape[-1])
+        last[valid] = enc_out.last_hidden_state
+
+        hidden_states, pooler_mask = self.pooler(
+            hidden_states=last,
+            pixel_position_ids=pixel_position_ids,
+            padding_positions=padding_positions,
+            output_length=output_length,
+        )
+        # Strip padding tokens — flat (N_valid, H).
+        hidden_states = hidden_states[pooler_mask]
+        if self.standardize:
+            hidden_states = (hidden_states - self.std_bias) * self.std_scale
+        return _VisionOutput(last_hidden_state=hidden_states)
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]):
+        # HF Gemma4ClippableLinear has nested ``.linear`` weights. We collapse
+        # them as follows:
+        #   - MLP/o_proj/patch_embedder: ``Gemma4VisionClippableLinear`` /
+        #     plain TRT-LLM ``Linear`` — peel the ``.linear`` indirection
+        #     where it exists (for MLP/o_proj wrappers), and route to fused
+        #     ``qkv_proj`` for attention via ``_load_weights_impl``'s
+        #     ``params_map`` fusion.
+        #   - Attention input clamps: HF has 3 (q/k/v), we collapse to one
+        #     ``qkv_input_{min,max}`` after asserting they match.
+        #   - Attention output clamps: q/k/v stay separate; o_proj input/output
+        #     clamps move from ``self_attn.o_proj.{input,output}_{min,max}``
+        #     into the attention module as ``o_{input,output}_{min,max}``.
+        remapped = self._remap_clamp_buffers(dict(weights))
+        # Strip the HF ``.linear`` indirection inside our ClippableLinear
+        # wrappers (MLP and patch_embedder.input_proj are also wrapped/standalone).
+        # The attention's qkv_proj absorbs HF q_proj/k_proj/v_proj via
+        # ``params_map`` inside ``_load_weights_impl``.
+        pattern_mapping = {
+            # MLP wrappers: ``mlp.gate_proj.linear.weight`` → ``mlp.gate_proj.linear.weight``
+            # (no change needed — wrapper keeps ``.linear`` attr).
+            # Attention QKV: HF q_proj.linear.weight → q_proj.weight (so
+            # ``_load_weights_impl`` fusion sees q_proj/k_proj/v_proj).
+            r"(.*?self_attn\.)q_proj\.linear\.(weight|bias)$": r"\1q_proj.\2",
+            r"(.*?self_attn\.)k_proj\.linear\.(weight|bias)$": r"\1k_proj.\2",
+            r"(.*?self_attn\.)v_proj\.linear\.(weight|bias)$": r"\1v_proj.\2",
+            # Attention o_proj: peel ``.linear`` (base class has plain Linear).
+            r"(.*?self_attn\.)o_proj\.linear\.(weight|bias)$": r"\1o_proj.\2",
+            # patch_embedder.input_proj is a plain TRT-LLM Linear now.
+            r"(.*?patch_embedder\.)input_proj\.(weight|bias)$": r"\1input_proj.\2",
+        }
+        _load_weights_impl(self, remapped, params_map=pattern_mapping)
+
+        # ``_load_weights_impl`` only walks ``named_parameters``; it skips
+        # buffers. Copy clamp scalars and optional standardize buffers here.
+        for name, buf in self.named_buffers():
+            if name in remapped:
+                buf.data.copy_(remapped[name][:].to(buf.dtype).to(buf.device))
+
+    def _remap_clamp_buffers(self, weights: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+        """Rename HF clamp buffer keys onto our consolidated layout.
+
+        HF: ``encoder.layers.{i}.self_attn.{q,k,v}_proj.{input,output}_{min,max}``
+            ``encoder.layers.{i}.self_attn.o_proj.{input,output}_{min,max}``
+        Ours: ``encoder.layers.{i}.self_attn.qkv_input_{min,max}`` (collapsed,
+              must match across q/k/v)
+              ``encoder.layers.{i}.self_attn.{q,k,v}_output_{min,max}``
+              ``encoder.layers.{i}.self_attn.o_{input,output}_{min,max}``
+        """
+        import re
+        remapped = dict(weights)
+        # Find all attention prefixes by scanning for q_proj.input_min
+        prefix_re = re.compile(r"^(.*self_attn)\.q_proj\.input_min$")
+        prefixes = sorted({
+            m.group(1) for k in weights for m in [prefix_re.match(k)] if m
+        })
+        for prefix in prefixes:
+            # Collapse q/k/v input clamps → one qkv_input_*, asserting equality.
+            for kind in ("min", "max"):
+                q_key = f"{prefix}.q_proj.input_{kind}"
+                k_key = f"{prefix}.k_proj.input_{kind}"
+                v_key = f"{prefix}.v_proj.input_{kind}"
+                if q_key in weights and k_key in weights and v_key in weights:
+                    q_val = weights[q_key][:]
+                    k_val = weights[k_key][:]
+                    v_val = weights[v_key][:]
+                    if not (torch.equal(q_val, k_val) and torch.equal(k_val, v_val)):
+                        raise ValueError(
+                            f"Gemma4 vision clamp fusion: q/k/v input clamp "
+                            f"{kind} mismatch at {prefix}; cannot collapse to "
+                            f"fused qkv_input_{kind}.")
+                    remapped[f"{prefix}.qkv_input_{kind}"] = q_val
+                    remapped.pop(q_key, None)
+                    remapped.pop(k_key, None)
+                    remapped.pop(v_key, None)
+                # Per-projection output clamps: keep the values, rename the keys.
+                for sec in ("q", "k", "v"):
+                    src = f"{prefix}.{sec}_proj.output_{kind}"
+                    if src in weights:
+                        remapped[f"{prefix}.{sec}_output_{kind}"] = weights[src][:]
+                        remapped.pop(src, None)
+                # o_proj clamps: move into the attention module.
+                for io in ("input", "output"):
+                    src = f"{prefix}.o_proj.{io}_{kind}"
+                    if src in weights:
+                        remapped[f"{prefix}.o_{io}_{kind}"] = weights[src][:]
+                        remapped.pop(src, None)
+        return remapped

--- a/tensorrt_llm/_torch/models/modeling_gemma4_vision.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4_vision.py
@@ -46,7 +46,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from transformers.activations import ACT2FN
-from transformers.models.gemma4.modeling_gemma4 import Gemma4RMSNorm as _HFGemma4RMSNorm
 
 from tensorrt_llm._utils import maybe_pin_memory
 
@@ -58,13 +57,23 @@ from ..modules.linear import Linear
 from .modeling_utils import _load_weights_impl
 
 
-# Use HF's ``Gemma4RMSNorm`` directly instead of TRT-LLM's ``RMSNorm`` module.
-# TRT-LLM ``RMSNorm`` dispatches to ``flashinfer_rmsnorm`` whose CUTE kernel
-# rejects non-fp32 / non-contiguous strides and 1152-wide bf16 inputs from
-# SigLip. HF's class is pure PyTorch and handles ``with_scale=False`` (the
-# weightless ``v_norm`` case) via a flag.
-class Gemma4VisionRMSNorm(_HFGemma4RMSNorm):
-    """Kwarg + dtype adapter around HF ``Gemma4RMSNorm``."""
+class Gemma4VisionRMSNorm(nn.Module):
+    """Native plain RMSNorm (``w * x / rms(x)``) for the Gemma4 vision tower.
+
+    Re-implemented inline (not a thin adapter over
+    ``transformers.models.gemma4.Gemma4RMSNorm``) to keep this file free of
+    ``transformers.models.<family>`` imports — per the multimodal-onboarding
+    skill, upstream HF refactors of internal classes / signatures must not
+    silently break TRT-LLM modeling files.
+
+    Also distinct from ``..modules.rms_norm.RMSNorm`` (the TRT-LLM dispatch
+    site for ``flashinfer_rmsnorm``), whose CUTE kernel rejects non-fp32 /
+    non-contiguous strides and 1152-wide bf16 SigLip inputs. ``with_scale=False``
+    handles the weightless ``v_norm`` slot.
+
+    Math convention is Gemma4 / SigLip plain ``w * x / rms``, **not** the
+    Gemma3 LLM ``(1 + w) * x / rms`` variant.
+    """
 
     def __init__(
         self,
@@ -74,10 +83,21 @@ class Gemma4VisionRMSNorm(_HFGemma4RMSNorm):
         dtype: Optional[torch.dtype] = None,
         has_weights: bool = True,
     ):
-        super().__init__(hidden_size, eps=eps, with_scale=has_weights)
-        if dtype is not None and has_weights:
-            with torch.no_grad():
-                self.weight.data = self.weight.data.to(dtype)
+        super().__init__()
+        self.eps = eps
+        self.with_scale = has_weights
+        if has_weights:
+            self.weight = nn.Parameter(
+                torch.ones(hidden_size, dtype=dtype if dtype is not None else torch.float32)
+            )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # fp32 accumulator for numerical stability; cast back to input dtype.
+        x32 = x.float()
+        normed = x32 * torch.rsqrt(x32.pow(2).mean(-1, keepdim=True) + self.eps)
+        if self.with_scale:
+            normed = normed * self.weight.float()
+        return normed.to(x.dtype)
 
 
 @dataclass

--- a/tensorrt_llm/_torch/models/modeling_gemma4_vision.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4_vision.py
@@ -46,6 +46,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from transformers.activations import ACT2FN
+from transformers.models.gemma4.modeling_gemma4 import Gemma4RMSNorm as _HFGemma4RMSNorm
 
 from tensorrt_llm._utils import maybe_pin_memory
 
@@ -54,8 +55,29 @@ from ..attention_backend.utils import get_attention_backend
 from ..model_config import ModelConfig
 from ..modules.attention import Attention
 from ..modules.linear import Linear
-from ..modules.rms_norm import RMSNorm
 from .modeling_utils import _load_weights_impl
+
+
+# Use HF's ``Gemma4RMSNorm`` directly instead of TRT-LLM's ``RMSNorm`` module.
+# TRT-LLM ``RMSNorm`` dispatches to ``flashinfer_rmsnorm`` whose CUTE kernel
+# rejects non-fp32 / non-contiguous strides and 1152-wide bf16 inputs from
+# SigLip. HF's class is pure PyTorch and handles ``with_scale=False`` (the
+# weightless ``v_norm`` case) via a flag.
+class _Gemma4VisionRMSNorm(_HFGemma4RMSNorm):
+    """Kwarg + dtype adapter around HF ``Gemma4RMSNorm``."""
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int,
+        eps: float,
+        dtype: Optional[torch.dtype] = None,
+        has_weights: bool = True,
+    ):
+        super().__init__(hidden_size, eps=eps, with_scale=has_weights)
+        if dtype is not None and has_weights:
+            with torch.no_grad():
+                self.weight.data = self.weight.data.to(dtype)
 
 
 @dataclass
@@ -286,13 +308,13 @@ class Gemma4VisionAttention(Attention):
 
         # HF Gemma4RMSNorm is the plain variant (``x_normed * weight``, no
         # ``(1+w)``). v_norm has ``with_scale=False`` (no learnable weight).
-        self.q_norm = RMSNorm(
+        self.q_norm = _Gemma4VisionRMSNorm(
             hidden_size=self.head_dim, eps=vision_config.rms_norm_eps, dtype=dtype
         )
-        self.k_norm = RMSNorm(
+        self.k_norm = _Gemma4VisionRMSNorm(
             hidden_size=self.head_dim, eps=vision_config.rms_norm_eps, dtype=dtype
         )
-        self.v_norm = RMSNorm(
+        self.v_norm = _Gemma4VisionRMSNorm(
             hidden_size=self.head_dim,
             eps=vision_config.rms_norm_eps,
             dtype=dtype,
@@ -322,11 +344,10 @@ class Gemma4VisionAttention(Attention):
             ):
                 self.register_buffer(name, pos_inf.clone())
 
-    def _head_norm(self, x: torch.Tensor, norm: RMSNorm) -> torch.Tensor:
-        # TRT-LLM ``RMSNorm`` may dispatch to ``flashinfer_rmsnorm`` which
-        # expects 2-D inputs — same pattern as ``QKNormRoPEAttention.apply_qk_norm``.
-        shape = x.shape
-        return norm(x.reshape(-1, self.head_dim)).reshape(shape)
+    def _head_norm(self, x: torch.Tensor, norm: _Gemma4VisionRMSNorm) -> torch.Tensor:
+        # HF ``Gemma4RMSNorm`` is pure PyTorch and normalises over the last
+        # dim, so we can pass the (..., head_dim) tensor through directly.
+        return norm(x)
 
     def forward(
         self,
@@ -406,22 +427,22 @@ class Gemma4VisionEncoderLayer(nn.Module):
             dtype=dtype,
         )
         self.mlp = Gemma4VisionMLP(vision_config, dtype, mapping)
-        self.input_layernorm = RMSNorm(
+        self.input_layernorm = _Gemma4VisionRMSNorm(
             hidden_size=vision_config.hidden_size,
             eps=vision_config.rms_norm_eps,
             dtype=dtype,
         )
-        self.post_attention_layernorm = RMSNorm(
+        self.post_attention_layernorm = _Gemma4VisionRMSNorm(
             hidden_size=vision_config.hidden_size,
             eps=vision_config.rms_norm_eps,
             dtype=dtype,
         )
-        self.pre_feedforward_layernorm = RMSNorm(
+        self.pre_feedforward_layernorm = _Gemma4VisionRMSNorm(
             hidden_size=vision_config.hidden_size,
             eps=vision_config.rms_norm_eps,
             dtype=dtype,
         )
-        self.post_feedforward_layernorm = RMSNorm(
+        self.post_feedforward_layernorm = _Gemma4VisionRMSNorm(
             hidden_size=vision_config.hidden_size,
             eps=vision_config.rms_norm_eps,
             dtype=dtype,

--- a/tensorrt_llm/_torch/models/modeling_gemma4_vision.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4_vision.py
@@ -47,10 +47,9 @@ import torch.nn as nn
 import torch.nn.functional as F
 from transformers.activations import ACT2FN
 
-from tensorrt_llm._utils import prefer_pinned
+from tensorrt_llm._utils import maybe_pin_memory
 
-from ..attention_backend.interface import (AttentionMetadata,
-                                           PredefinedAttentionMask)
+from ..attention_backend.interface import AttentionMetadata, PredefinedAttentionMask
 from ..attention_backend.utils import get_attention_backend
 from ..model_config import ModelConfig
 from ..modules.attention import Attention
@@ -62,6 +61,7 @@ from .modeling_utils import _load_weights_impl
 @dataclass
 class _VisionOutput:
     """Stand-in for ``transformers.BaseModelOutputWithPast`` (only field used)."""
+
     last_hidden_state: torch.Tensor
 
 
@@ -156,9 +156,9 @@ class Gemma4VisionRotaryEmbedding(nn.Module):
             dim_position_ids = position_ids[:, :, i]
             dim_position_ids_expanded = dim_position_ids[:, None, :].float()
             with torch.autocast(device_type=x.device.type, enabled=False):
-                freqs = (
-                    inv_freq_expanded.float() @ dim_position_ids_expanded.float()
-                ).transpose(1, 2)
+                freqs = (inv_freq_expanded.float() @ dim_position_ids_expanded.float()).transpose(
+                    1, 2
+                )
                 emb = torch.cat((freqs, freqs), dim=-1)
                 cos = emb.cos() * self.attention_scaling
                 sin = emb.sin() * self.attention_scaling
@@ -255,11 +255,9 @@ class Gemma4VisionAttention(Attention):
     so we pass ``q_scaling = 1 / sqrt(head_dim)`` to neutralize the sqrt.
     """
 
-    def __init__(self,
-                 model_config: ModelConfig,
-                 vision_config,
-                 layer_idx: int,
-                 dtype: torch.dtype):
+    def __init__(
+        self, model_config: ModelConfig, vision_config, layer_idx: int, dtype: torch.dtype
+    ):
         head_dim = getattr(
             vision_config,
             "head_dim",
@@ -301,19 +299,26 @@ class Gemma4VisionAttention(Attention):
             has_weights=False,
         )
 
-        self.use_clipped_linears = bool(
-            getattr(vision_config, "use_clipped_linears", False))
+        self.use_clipped_linears = bool(getattr(vision_config, "use_clipped_linears", False))
         if self.use_clipped_linears:
             neg_inf = torch.tensor(-float("inf"))
             pos_inf = torch.tensor(float("inf"))
             for name in (
-                "qkv_input_min", "q_output_min", "k_output_min", "v_output_min",
-                "o_input_min", "o_output_min",
+                "qkv_input_min",
+                "q_output_min",
+                "k_output_min",
+                "v_output_min",
+                "o_input_min",
+                "o_output_min",
             ):
                 self.register_buffer(name, neg_inf.clone())
             for name in (
-                "qkv_input_max", "q_output_max", "k_output_max", "v_output_max",
-                "o_input_max", "o_output_max",
+                "qkv_input_max",
+                "q_output_max",
+                "k_output_max",
+                "v_output_max",
+                "o_input_max",
+                "o_output_max",
             ):
                 self.register_buffer(name, pos_inf.clone())
 
@@ -334,9 +339,7 @@ class Gemma4VisionAttention(Attention):
         # Flat (num_tokens, hidden) layout — encoder flattens (B, N, H) before
         # dispatching to attention.
         if self.use_clipped_linears:
-            hidden_states = torch.clamp(
-                hidden_states, self.qkv_input_min, self.qkv_input_max
-            )
+            hidden_states = torch.clamp(hidden_states, self.qkv_input_min, self.qkv_input_max)
 
         qkv = self.qkv_proj(hidden_states)
         q, k, v = self.split_qkv(qkv)
@@ -356,12 +359,8 @@ class Gemma4VisionAttention(Attention):
         v = self._head_norm(v, self.v_norm)
 
         cos, sin = position_embeddings
-        q = _apply_multidimensional_rope(
-            q, cos, sin, position_ids, unsqueeze_dim=1
-        )
-        k = _apply_multidimensional_rope(
-            k, cos, sin, position_ids, unsqueeze_dim=1
-        )
+        q = _apply_multidimensional_rope(q, cos, sin, position_ids, unsqueeze_dim=1)
+        k = _apply_multidimensional_rope(k, cos, sin, position_ids, unsqueeze_dim=1)
 
         q = q.reshape(num_tokens, self.num_heads * self.head_dim)
         k = k.reshape(num_tokens, self.num_key_value_heads * self.head_dim)
@@ -381,26 +380,24 @@ class Gemma4VisionAttention(Attention):
         )
 
         if self.use_clipped_linears:
-            attn_output = torch.clamp(
-                attn_output, self.o_input_min, self.o_input_max
-            )
+            attn_output = torch.clamp(attn_output, self.o_input_min, self.o_input_max)
         attn_output = self.o_proj(attn_output, layer_idx=self.layer_idx)
         if self.use_clipped_linears:
-            attn_output = torch.clamp(
-                attn_output, self.o_output_min, self.o_output_max
-            )
+            attn_output = torch.clamp(attn_output, self.o_output_min, self.o_output_max)
         return attn_output
 
 
 class Gemma4VisionEncoderLayer(nn.Module):
     """Sandwich norm pattern: input → attn → post_attn → +res; pre_ffn → mlp → post_ffn → +res."""
 
-    def __init__(self,
-                 model_config: ModelConfig,
-                 vision_config,
-                 layer_idx: int,
-                 dtype: torch.dtype,
-                 mapping=None):
+    def __init__(
+        self,
+        model_config: ModelConfig,
+        vision_config,
+        layer_idx: int,
+        dtype: torch.dtype,
+        mapping=None,
+    ):
         super().__init__()
         self.self_attn = Gemma4VisionAttention(
             model_config=model_config,
@@ -464,23 +461,22 @@ class Gemma4VisionEncoder(nn.Module):
     Mapping back to ``(B, N)`` for the pooler is the caller's job.
     """
 
-    def __init__(self,
-                 model_config: ModelConfig,
-                 vision_config,
-                 dtype: torch.dtype,
-                 mapping=None):
+    def __init__(self, model_config: ModelConfig, vision_config, dtype: torch.dtype, mapping=None):
         super().__init__()
         self.config = vision_config
         self.rotary_emb = Gemma4VisionRotaryEmbedding(vision_config)
-        self.layers = nn.ModuleList([
-            Gemma4VisionEncoderLayer(
-                model_config=model_config,
-                vision_config=vision_config,
-                layer_idx=i,
-                dtype=dtype,
-                mapping=mapping,
-            ) for i in range(vision_config.num_hidden_layers)
-        ])
+        self.layers = nn.ModuleList(
+            [
+                Gemma4VisionEncoderLayer(
+                    model_config=model_config,
+                    vision_config=vision_config,
+                    layer_idx=i,
+                    dtype=dtype,
+                    mapping=mapping,
+                )
+                for i in range(vision_config.num_hidden_layers)
+            ]
+        )
 
     def forward(
         self,
@@ -541,8 +537,7 @@ class Gemma4VisionPatchEmbedder(nn.Module):
     ) -> torch.Tensor:
         # Gemma4 scales pixel inputs in model code (no normalization in the processor).
         pixel_values = 2 * (pixel_values - 0.5)
-        hidden_states = self.input_proj(
-            pixel_values.to(self.input_proj.weight.dtype))
+        hidden_states = self.input_proj(pixel_values.to(self.input_proj.weight.dtype))
         position_embeddings = self._position_embeddings(pixel_position_ids, padding_positions)
         return hidden_states + position_embeddings
 
@@ -619,8 +614,7 @@ class Gemma4VisionModel(nn.Module):
         dtype = getattr(self.config, "torch_dtype", None) or torch.bfloat16
         mapping = getattr(model_config, "mapping", None)
 
-        self.patch_embedder = Gemma4VisionPatchEmbedder(
-            self.config, dtype=dtype, mapping=mapping)
+        self.patch_embedder = Gemma4VisionPatchEmbedder(self.config, dtype=dtype, mapping=mapping)
         self.encoder = Gemma4VisionEncoder(
             model_config=model_config,
             vision_config=self.config,
@@ -630,17 +624,12 @@ class Gemma4VisionModel(nn.Module):
         self.pooler = Gemma4VisionPooler(self.config)
         self.standardize = bool(getattr(self.config, "standardize", False))
         if self.standardize:
-            self.register_buffer(
-                "std_bias", torch.zeros(self.config.hidden_size, dtype=dtype)
-            )
-            self.register_buffer(
-                "std_scale", torch.ones(self.config.hidden_size, dtype=dtype)
-            )
+            self.register_buffer("std_bias", torch.zeros(self.config.hidden_size, dtype=dtype))
+            self.register_buffer("std_scale", torch.ones(self.config.hidden_size, dtype=dtype))
 
         # SigLip-style context-only metadata: kv_cache_manager=None, no decode
         # phase. Re-prepared each forward with the actual per-image seq lens.
-        self.metadata_cls = get_attention_backend(
-            model_config.attn_backend).Metadata
+        self.metadata_cls = get_attention_backend(model_config.attn_backend).Metadata
         self.attn_metadata = self.metadata_cls(
             max_num_requests=8192,
             max_num_tokens=getattr(model_config, "max_num_tokens", 8192),
@@ -653,9 +642,7 @@ class Gemma4VisionModel(nn.Module):
         self.attn_metadata.num_contexts = batch_size
         self.attn_metadata.request_ids = list(range(1, batch_size + 1))
         self.attn_metadata.prompt_lens = prompt_lens
-        self.attn_metadata.seq_lens = seq_lens_cpu.to(
-            dtype=torch.int, copy=True).pin_memory() if prefer_pinned() else \
-            seq_lens_cpu.to(dtype=torch.int, copy=True)
+        self.attn_metadata.seq_lens = maybe_pin_memory(seq_lens_cpu.to(dtype=torch.int, copy=True))
         self.attn_metadata.max_seq_len = max(prompt_lens) if prompt_lens else 0
         self.attn_metadata.prepare()
         return self.attn_metadata
@@ -677,11 +664,9 @@ class Gemma4VisionModel(nn.Module):
         B, N = padding_positions.shape
 
         # Patch embed produces (B, N, H) including padded slots zeroed.
-        inputs_embeds = self.patch_embedder(
-            pixel_values, pixel_position_ids, padding_positions)
+        inputs_embeds = self.patch_embedder(pixel_values, pixel_position_ids, padding_positions)
         # Position embeddings (cos/sin) are (B, N, head_dim) per spatial dim.
-        position_embeddings_btn = self.encoder.rotary_emb(
-            inputs_embeds, pixel_position_ids)
+        position_embeddings_btn = self.encoder.rotary_emb(inputs_embeds, pixel_position_ids)
 
         # Flatten to (sum_valid, H) and drop padded tokens — encoder runs
         # FULL attention with per-image cu_seqlens.
@@ -754,7 +739,7 @@ class Gemma4VisionModel(nn.Module):
         # buffers. Copy clamp scalars and optional standardize buffers here.
         for name, buf in self.named_buffers():
             if name in remapped:
-                buf.data.copy_(remapped[name][:].to(buf.dtype).to(buf.device))
+                buf.data.copy_(remapped[name].to(buf.dtype).to(buf.device))
 
     def _remap_clamp_buffers(self, weights: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
         """Rename HF clamp buffer keys onto our consolidated layout.
@@ -767,12 +752,11 @@ class Gemma4VisionModel(nn.Module):
               ``encoder.layers.{i}.self_attn.o_{input,output}_{min,max}``
         """
         import re
+
         remapped = dict(weights)
         # Find all attention prefixes by scanning for q_proj.input_min
         prefix_re = re.compile(r"^(.*self_attn)\.q_proj\.input_min$")
-        prefixes = sorted({
-            m.group(1) for k in weights for m in [prefix_re.match(k)] if m
-        })
+        prefixes = sorted({m.group(1) for k in weights for m in [prefix_re.match(k)] if m})
         for prefix in prefixes:
             # Collapse q/k/v input clamps → one qkv_input_*, asserting equality.
             for kind in ("min", "max"):
@@ -780,14 +764,15 @@ class Gemma4VisionModel(nn.Module):
                 k_key = f"{prefix}.k_proj.input_{kind}"
                 v_key = f"{prefix}.v_proj.input_{kind}"
                 if q_key in weights and k_key in weights and v_key in weights:
-                    q_val = weights[q_key][:]
-                    k_val = weights[k_key][:]
-                    v_val = weights[v_key][:]
+                    q_val = weights[q_key].clone()
+                    k_val = weights[k_key].clone()
+                    v_val = weights[v_key].clone()
                     if not (torch.equal(q_val, k_val) and torch.equal(k_val, v_val)):
                         raise ValueError(
                             f"Gemma4 vision clamp fusion: q/k/v input clamp "
                             f"{kind} mismatch at {prefix}; cannot collapse to "
-                            f"fused qkv_input_{kind}.")
+                            f"fused qkv_input_{kind}."
+                        )
                     remapped[f"{prefix}.qkv_input_{kind}"] = q_val
                     remapped.pop(q_key, None)
                     remapped.pop(k_key, None)
@@ -796,12 +781,12 @@ class Gemma4VisionModel(nn.Module):
                 for sec in ("q", "k", "v"):
                     src = f"{prefix}.{sec}_proj.output_{kind}"
                     if src in weights:
-                        remapped[f"{prefix}.{sec}_output_{kind}"] = weights[src][:]
+                        remapped[f"{prefix}.{sec}_output_{kind}"] = weights[src].clone()
                         remapped.pop(src, None)
                 # o_proj clamps: move into the attention module.
                 for io in ("input", "output"):
                     src = f"{prefix}.o_proj.{io}_{kind}"
                     if src in weights:
-                        remapped[f"{prefix}.o_{io}_{kind}"] = weights[src][:]
+                        remapped[f"{prefix}.o_{io}_{kind}"] = weights[src].clone()
                         remapped.pop(src, None)
         return remapped

--- a/tensorrt_llm/_torch/models/modeling_gemma4_vision.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4_vision.py
@@ -257,10 +257,12 @@ class Gemma4VisionMLP(nn.Module):
 class Gemma4VisionAttention(Attention):
     """Bidirectional attention with q/k/v RMSNorms and 2D RoPE.
 
-    Inherits ``Attention`` to participate in the TRT-LLM backend dispatch
-    (default ``FLASHINFER``). Vision is context-only and runs through
-    ``forward_impl`` with ``PredefinedAttentionMask.FULL`` and a tower-local
-    ``attn_metadata`` (``kv_cache_manager=None``).
+    Inherits ``Attention`` to participate in the TRT-LLM backend dispatch.
+    Vision sub_config is forced to ``attn_backend="TRTLLM"`` in
+    ``modeling_gemma4mm.get_sub_model_config`` (same pattern Qwen2.5-VL uses).
+    Vision is context-only and runs through ``forward_impl`` with
+    ``PredefinedAttentionMask.FULL`` and a tower-local ``attn_metadata``
+    (``kv_cache_manager=None``).
 
     The ``Attention`` base class uses a fused ``qkv_proj`` and a vanilla
     ``o_proj``. To preserve HF Gemma4's ``ClippableLinear`` semantics we
@@ -650,10 +652,14 @@ class Gemma4VisionModel(nn.Module):
 
         # SigLip-style context-only metadata: kv_cache_manager=None, no decode
         # phase. Re-prepared each forward with the actual per-image seq lens.
+        # Vision tower runs one image per call (mm forward loops per-image),
+        # so bounds are vision-scale, not LLM-scale. Using LLM max_num_tokens
+        # here makes the C++ attn workspace resize to TB-range and OOM
+        # (sized as max_num_requests * heads * max_num_tokens^2 * bytes).
         self.metadata_cls = get_attention_backend(model_config.attn_backend).Metadata
         self.attn_metadata = self.metadata_cls(
-            max_num_requests=8192,
-            max_num_tokens=getattr(model_config, "max_num_tokens", 8192),
+            max_num_requests=1,
+            max_num_tokens=8192,
             kv_cache_manager=None,
         )
 

--- a/tensorrt_llm/_torch/models/modeling_gemma4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4mm.py
@@ -15,8 +15,9 @@
 """Gemma4 multimodal model: multimodal embedder, input processor,
 and the Gemma4ForConditionalGeneration wrapper.
 
-Vision and audio towers use native transformers models via
-AutoModel.from_config() (requires transformers>=5.5.0).
+Vision tower is native TRT-LLM (``modeling_gemma4_vision.py``); audio tower
+still uses ``AutoModel.from_config()`` pending its own migration
+(requires transformers>=5.5.0).
 """
 
 import copy
@@ -48,6 +49,8 @@ from ...sampling_params import SamplingParams
 from ..attention_backend import AttentionMetadata
 from ..modules.linear import Linear
 from .modeling_gemma4 import Gemma4ForCausalLM
+from .modeling_gemma4_audio import Gemma4AudioModel
+from .modeling_gemma4_vision import Gemma4VisionModel
 from .modeling_multimodal_utils import find_input_mm_embeds, fuse_input_embeds
 from .modeling_utils import ModelConfig, filter_weights, register_auto_model
 
@@ -634,9 +637,12 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
         llm_model_config = self.get_sub_model_config(model_config_cp, "text_config")
         self.llm = Gemma4ForCausalLM(llm_model_config)
 
-        # --- Vision tower (native transformers, eager mode) ---
+        # --- Vision tower (native TRT-LLM, see modeling_gemma4_vision.py) ---
         if config.vision_config is not None:
-            self.vision_tower = AutoModel.from_config(config.vision_config).eval().to(self._device)
+            vision_model_config = self.get_sub_model_config(model_config_cp, "vision_config")
+            self.vision_tower = (
+                Gemma4VisionModel(vision_model_config).eval().to(self._device)
+            )
             vision_hidden = config.vision_config.hidden_size
             text_hidden = config.text_config.hidden_size
             vision_eps = config.vision_config.rms_norm_eps
@@ -723,8 +729,7 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
 
         if self.vision_tower is not None:
             vit_weights = filter_weights("vision_tower", stripped)
-            # Native transformers models use load_state_dict, not load_weights
-            self.vision_tower.load_state_dict(vit_weights, strict=False)
+            self.vision_tower.load_weights(vit_weights)
 
         if self.embed_vision is not None:
             embed_v_weights = filter_weights("embed_vision", stripped)

--- a/tensorrt_llm/_torch/models/modeling_gemma4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4mm.py
@@ -761,36 +761,44 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
         pixel_values: torch.Tensor,
         image_position_ids: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
+        # Single batched vision-tower call across all images in this LLM step.
+        # ``Gemma4VisionModel.forward`` flattens valid patches across the
+        # batch and runs FULL attention with per-image ``cu_seqlens`` via
+        # varlen ``attn_metadata`` (same pattern as Qwen2VL / LlavaNext).
+        # ``pixel_values`` arrives shape ``(B, max_patches, 3*patch_size**2)``
+        # already cross-request ``torch.cat``-ed in ``forward``, so all
+        # images share ``max_patches`` (image processor pads with -1
+        # sentinels in ``image_position_ids`` for variable image sizes).
         pooling_k2 = self._top_config.vision_config.pooling_kernel_size**2
         target_dtype = self.embed_vision.embedding_projection.weight.dtype
 
-        per_image_features = []
-        for i in range(pixel_values.shape[0]):
-            pv = pixel_values[i].unsqueeze(0)
-            pp = image_position_ids[i].unsqueeze(0) if image_position_ids is not None else None
+        batch_size, max_patches = pixel_values.shape[0], pixel_values.shape[1]
 
-            max_patches = pv.shape[1]
+        if image_position_ids is None:
+            # Square images with implicit row-major grid coordinates.
+            side = int(math.sqrt(max_patches))
+            grid = torch.stack(
+                torch.meshgrid(
+                    torch.arange(side, device=pixel_values.device),
+                    torch.arange(side, device=pixel_values.device),
+                    indexing="ij",
+                ),
+                dim=-1,
+            ).reshape(-1, 2)
+            image_position_ids = grid.unsqueeze(0).expand(batch_size, -1, -1)
 
-            if pp is None:
-                side = int(math.sqrt(max_patches))
-                pp = torch.stack(
-                    torch.meshgrid(
-                        torch.arange(side, device=pv.device),
-                        torch.arange(side, device=pv.device),
-                        indexing="ij",
-                    ),
-                    dim=-1,
-                ).reshape(1, -1, 2)
+        output_length = max_patches // pooling_k2
 
-            output_length = max_patches // pooling_k2
+        with torch.autocast(device_type="cuda", dtype=self.model_dtype):
+            output = self.vision_tower(
+                pixel_values, image_position_ids, output_length=output_length
+            )
+            # ``last_hidden_state`` is flat ``(N_valid_pool_tokens_total, hidden_size)``
+            # after pooler+strip; ``embed_vision`` is token-wise (RMSNorm +
+            # Linear), so shape doesn't matter for projection.
+            projected = self.embed_vision(output.last_hidden_state.to(target_dtype))
 
-            with torch.autocast(device_type="cuda", dtype=self.model_dtype):
-                output = self.vision_tower(pv, pp, output_length=output_length)
-                hidden = output.last_hidden_state
-                projected = self.embed_vision(hidden.unsqueeze(0).to(target_dtype)).squeeze(0)
-            per_image_features.append(projected)
-
-        return torch.cat(per_image_features, dim=0).contiguous()
+        return projected.contiguous()
 
     @nvtx_range("[Audio] process")
     def _get_audio_features(

--- a/tensorrt_llm/_torch/models/modeling_gemma4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4mm.py
@@ -16,8 +16,8 @@
 and the Gemma4ForConditionalGeneration wrapper.
 
 Vision tower is native TRT-LLM (``modeling_gemma4_vision.py``); audio tower
-still uses ``AutoModel.from_config()`` pending its own migration
-(requires transformers>=5.5.0).
+is native TRT-LLM (``modeling_gemma4_audio.py``). Both replace the previous
+``AutoModel.from_config()`` HF fallback (requires transformers>=5.5.0).
 """
 
 import copy
@@ -49,6 +49,7 @@ from ...sampling_params import SamplingParams
 from ..attention_backend import AttentionMetadata
 from ..modules.linear import Linear
 from .modeling_gemma4 import Gemma4ForCausalLM
+from .modeling_gemma4_audio import Gemma4AudioModel
 from .modeling_gemma4_vision import Gemma4VisionModel
 from .modeling_multimodal_utils import find_input_mm_embeds, fuse_input_embeds
 from .modeling_utils import ModelConfig, filter_weights, register_auto_model
@@ -62,7 +63,6 @@ if Version(transformers.__version__) < Version(_MIN_TRANSFORMERS_FOR_GEMMA4):
     )
 
 from transformers import (  # noqa: E402
-    AutoModel,
     AutoTokenizer,
     Gemma4Config,
     PretrainedConfig,
@@ -665,9 +665,10 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
             self.vision_tower = None
             self.embed_vision = None
 
-        # --- Audio tower (native transformers, eager mode) ---
+        # --- Audio tower (native TRT-LLM, see modeling_gemma4_audio.py) ---
         if config.audio_config is not None:
-            self.audio_tower = AutoModel.from_config(config.audio_config).eval().to(self._device)
+            audio_model_config = self.get_sub_model_config(model_config_cp, "audio_config")
+            self.audio_tower = Gemma4AudioModel(audio_model_config).eval().to(self._device)
             audio_hidden = getattr(
                 config.audio_config, "output_proj_dims", config.audio_config.hidden_size
             )
@@ -741,7 +742,7 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
 
         if self.audio_tower is not None:
             audio_weights = filter_weights("audio_tower", stripped)
-            self.audio_tower.load_state_dict(audio_weights, strict=False)
+            self.audio_tower.load_weights(audio_weights)
 
         if self.embed_audio is not None:
             embed_a_weights = filter_weights("embed_audio", stripped)

--- a/tensorrt_llm/_torch/models/modeling_gemma4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4mm.py
@@ -770,6 +770,24 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
     def infer_max_seq_len(self) -> int:
         return self.llm.infer_max_seq_len()
 
+    @property
+    def multimodal_data_device_paths(self) -> List[str]:
+        """Dotted paths in ``multimodal_data`` that the engine should ship to
+        GPU. Anything not listed stays CPU-resident — notably
+        ``image.image_seq_lens`` / ``video.image_seq_lens`` (Python
+        ``List[int]`` carrying per-image valid-patch counts, consumed
+        host-side by ``Gemma4VisionModel.forward`` to populate
+        ``attn_metadata.prompt_lens`` without a GPU→CPU sync).
+        """
+        return [
+            "image.pixel_values",
+            "image.image_position_ids",
+            "video.pixel_values",
+            "video.image_position_ids",
+            "audio.audio_features",
+            "audio.audio_features_mask",
+        ]
+
     @nvtx_range("[Vision] process")
     def _get_image_features(
         self,

--- a/tensorrt_llm/_torch/models/modeling_gemma4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4mm.py
@@ -49,7 +49,6 @@ from ...sampling_params import SamplingParams
 from ..attention_backend import AttentionMetadata
 from ..modules.linear import Linear
 from .modeling_gemma4 import Gemma4ForCausalLM
-from .modeling_gemma4_audio import Gemma4AudioModel
 from .modeling_gemma4_vision import Gemma4VisionModel
 from .modeling_multimodal_utils import find_input_mm_embeds, fuse_input_embeds
 from .modeling_utils import ModelConfig, filter_weights, register_auto_model
@@ -580,6 +579,13 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
             "attn_backend": "FLASHINFER",
         }
 
+    def _check_and_adjust_experts_implementation(self, *args, **kwargs):
+        # transformers 5.x ``PreTrainedModel.__init__`` calls this with an
+        # ``experts_implementation`` argument and fails for VL wrapper models
+        # that do not directly contain MoE layers. TRT-LLM manages expert
+        # implementations independently, so skip the check.
+        return None
+
     def __init__(self, model_config: ModelConfig[Gemma4Config]):
         if _is_disagg():
             raise NotImplementedError(
@@ -640,9 +646,7 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
         # --- Vision tower (native TRT-LLM, see modeling_gemma4_vision.py) ---
         if config.vision_config is not None:
             vision_model_config = self.get_sub_model_config(model_config_cp, "vision_config")
-            self.vision_tower = (
-                Gemma4VisionModel(vision_model_config).eval().to(self._device)
-            )
+            self.vision_tower = Gemma4VisionModel(vision_model_config).eval().to(self._device)
             vision_hidden = config.vision_config.hidden_size
             text_hidden = config.text_config.hidden_size
             vision_eps = config.vision_config.rms_norm_eps

--- a/tensorrt_llm/_torch/models/modeling_gemma4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4mm.py
@@ -503,6 +503,16 @@ class Gemma4InputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyInpu
             image_data: Dict = {"pixel_values": pixel_values}
             if image_position_ids is not None:
                 image_data["image_position_ids"] = image_position_ids
+                # Per-image valid-patch count, captured CPU-side from the
+                # ``-1`` padding sentinels in ``image_position_ids`` while
+                # both tensors are still host-resident (the processor runs
+                # on CPU; the executor pipeline moves them to GPU later).
+                # Persisting this as a ``List[int]`` lets the vision tower
+                # populate ``attn_metadata.prompt_lens`` directly without
+                # the ``valid.sum(-1).cpu()`` GPU→CPU sync each forward.
+                image_data["image_seq_lens"] = [
+                    int(s) for s in (image_position_ids != -1).all(dim=-1).sum(dim=-1).tolist()
+                ]
             mm_inner["image"] = image_data
         if input_features is not None:
             audio_data: Dict = {"audio_features": input_features}
@@ -524,6 +534,11 @@ class Gemma4InputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyInpu
             video_data: Dict = {"pixel_values": v}
             if vp is not None:
                 video_data["image_position_ids"] = vp
+                # See image branch above: CPU-side per-frame valid-patch count
+                # avoids the GPU→CPU sync inside the vision tower per forward.
+                video_data["image_seq_lens"] = [
+                    int(s) for s in (vp != -1).all(dim=-1).sum(dim=-1).tolist()
+                ]
             mm_inner["video"] = video_data
         multimodal_data = {"multimodal_data": mm_inner} if mm_inner else None
         return input_ids[0].to(torch.int32).tolist(), multimodal_data
@@ -760,6 +775,7 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
         self,
         pixel_values: torch.Tensor,
         image_position_ids: Optional[torch.Tensor] = None,
+        image_seq_lens: Optional[List[int]] = None,
     ) -> torch.Tensor:
         # Single batched vision-tower call across all images in this LLM step.
         # ``Gemma4VisionModel.forward`` flattens valid patches across the
@@ -791,7 +807,10 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
 
         with torch.autocast(device_type="cuda", dtype=self.model_dtype):
             output = self.vision_tower(
-                pixel_values, image_position_ids, output_length=output_length
+                pixel_values,
+                image_position_ids,
+                output_length=output_length,
+                image_seq_lens=image_seq_lens,
             )
             # ``last_hidden_state`` is flat ``(N_valid_pool_tokens_total, hidden_size)``
             # after pooler+strip; ``embed_vision`` is token-wise (RMSNorm +
@@ -845,12 +864,14 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
         # --- Extract image data ---
         pixel_values_list = []
         image_position_ids_list = []
+        image_seq_lens_extended: List[int] = []
         # --- Extract audio data ---
         audio_features_list = []
         audio_features_mask_list = []
         # --- Extract video data (treated as image frames at the tower) ---
         video_pixel_values_list = []
         video_position_ids_list = []
+        video_seq_lens_extended: List[int] = []
         for mp in multimodal_params:
             img_data = mp.multimodal_data.get("image", {})
             pv = img_data.get("pixel_values")
@@ -859,6 +880,9 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
                 pid = img_data.get("image_position_ids")
                 if pid is not None:
                     image_position_ids_list.append(pid)
+                seq_lens = img_data.get("image_seq_lens")
+                if seq_lens is not None:
+                    image_seq_lens_extended.extend(seq_lens)
 
             aud_data = mp.multimodal_data.get("audio", {})
             af = aud_data.get("audio_features")
@@ -875,6 +899,9 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
                 vpid = vid_data.get("image_position_ids")
                 if vpid is not None:
                     video_position_ids_list.append(vpid)
+                vsl = vid_data.get("image_seq_lens")
+                if vsl is not None:
+                    video_seq_lens_extended.extend(vsl)
 
         mm_embeds = []
         all_mm_token_ids = []
@@ -891,6 +918,11 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
             image_features = self._get_image_features(
                 pixel_values=pixel_values,
                 image_position_ids=image_position_ids,
+                image_seq_lens=(
+                    image_seq_lens_extended
+                    if len(image_seq_lens_extended) == pixel_values.shape[0]
+                    else None
+                ),
             )
             mm_embeds.append(image_features)
             all_mm_token_ids.append(self.image_token_ids)
@@ -910,6 +942,11 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
             video_features = self._get_image_features(
                 pixel_values=video_pixel_values,
                 image_position_ids=video_pos_ids,
+                image_seq_lens=(
+                    video_seq_lens_extended
+                    if len(video_seq_lens_extended) == video_pixel_values.shape[0]
+                    else None
+                ),
             )
             mm_embeds.append(video_features)
             if self.video_token_ids is not None:

--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -130,6 +130,7 @@ l0_b200:
   - unittest/_torch/modeling -k "modeling_gpt_oss"
   - unittest/_torch/modeling/test_modeling_exaone_moe.py
   - unittest/_torch/modeling/test_modeling_gemma4.py
+  - unittest/_torch/modeling/test_gemma4_multimodal.py
   - unittest/_torch/modeling/test_gemma4_e2e_dummy.py::test_e2e_text_26b_dummy
   - unittest/_torch/modeling/test_gemma4_e2e_dummy.py::test_e2e_text_e2b_dummy
   - unittest/_torch/modeling/test_gemma4_e2e_dummy.py::test_e2e_text_31b_dummy

--- a/tests/unittest/_torch/modeling/test_gemma4_multimodal.py
+++ b/tests/unittest/_torch/modeling/test_gemma4_multimodal.py
@@ -190,13 +190,20 @@ class TestGemma4VisionTower(unittest.TestCase):
 
     @torch.no_grad()
     def test_forward_random_weights(self):
-        """Random-weight forward returns ``(output_length, hidden_size)`` with no NaNs."""
-        # Use fp32: head_dim=32 with bf16 + trtllm-gen unfused MHA fallback
-        # produces NaNs for random Kaiming init. The test is a shape+sanity
-        # check, not a dtype-specific contract.
+        """Forward smoke test with HF-default-init weights.
+
+        Production loads weights via ``load_weights(hf_state_dict)``, so
+        seeding through an HF tower's ``state_dict`` is the right sanity
+        check. PyTorch-default init on TRT-LLM ``Linear`` / fused ``qkv_proj``
+        can saturate the TRTLLM attention kernel at this small head_dim and
+        produce NaN — that is a kernel-input contract, not a model bug, and
+        is already covered indirectly by the parity tests below.
+        """
         torch.manual_seed(0)
         vision_cfg = Gemma4VisionConfig(**SMALL_VISION_CONFIG)
+        hf_tower = HFGemma4VisionModel(vision_cfg).to("cuda").to(torch.float32).eval()
         tower = _build_trt_vision_tower(vision_cfg, dtype=torch.float32)
+        tower.load_weights(dict(hf_tower.state_dict()))
 
         pv, pos, output_length = _make_dummy_pixel_input(vision_cfg, dtype=torch.float32)
         with torch.inference_mode():

--- a/tests/unittest/_torch/modeling/test_gemma4_multimodal.py
+++ b/tests/unittest/_torch/modeling/test_gemma4_multimodal.py
@@ -12,13 +12,32 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests for the Gemma4 multimodal model components.
+"""Unit + E2E tests for the Gemma4 multimodal model components.
 
-Tests Gemma4MultimodalEmbedder, Gemma4ForConditionalGeneration,
-and Gemma4InputProcessor with HF reference comparison.
+Tier 0/1 (no LLM_MODELS_ROOT needed, GPU only):
+  - ``TestGemma4VisionTower`` — refactored TRT-LLM ``Gemma4VisionModel``
+    (Option B: ``Gemma4VisionAttention`` inherits ``Attention`` base, vision
+    runs through the TRTLLM attention backend, weights load via fused
+    ``qkv_proj`` + clamp-buffer remap).
+  - ``TestGemma4MultimodalEmbedder`` — RMSNorm + projection parity vs HF.
+  - ``TestGemma4ForConditionalGeneration`` — wrapper instantiation; verifies
+    that ``vision_tower`` is the refactored class (not HF ``AutoModel``).
+
+Tier 2 (LLM_MODELS_ROOT gated, real tokenizer/processor):
+  - ``TestGemma4InputProcessor`` — image/audio/video pre-processing.
+  - ``TestGemma4MultimodalE2E`` — full LLM+vision generate parity via the
+    shared ``TestModelingMultimodal`` skeleton (image / multi-image modalities).
+
+Audio-side tests (``TestGemma4InputProcessor.test_audio_*``) are intentionally
+left unchanged — audio tower refactor (Conformer migration) is a follow-up.
 """
 
+from __future__ import annotations
+
+import os
 import unittest
+from copy import deepcopy
+from typing import Dict, List, Type
 
 import pytest
 import torch
@@ -28,28 +47,44 @@ pytest.importorskip(
     "transformers", minversion="5.5.0", reason="Gemma4 requires transformers>=5.5.0"
 )
 
-from transformers import AutoModel, Gemma4Config, Gemma4TextConfig, Gemma4VisionConfig  # noqa: E402
+from transformers import Gemma4Config, Gemma4TextConfig, Gemma4VisionConfig  # noqa: E402
+from transformers import Gemma4ForConditionalGeneration as HFGemma4ForConditionalGeneration
+from transformers.models.gemma4.modeling_gemma4 import (  # noqa: E402
+    Gemma4MultimodalEmbedder as HFGemma4MultimodalEmbedder,
+)
+from transformers.models.gemma4.modeling_gemma4 import (  # noqa: E402
+    Gemma4VisionModel as HFGemma4VisionModel,
+)
 
 from tensorrt_llm._torch.model_config import ModelConfig  # noqa: E402
+from tensorrt_llm._torch.models.modeling_gemma4_vision import Gemma4VisionModel  # noqa: E402
 from tensorrt_llm._torch.models.modeling_gemma4mm import (  # noqa: E402
     Gemma4ForConditionalGeneration,
     Gemma4MultimodalEmbedder,
 )
 from tensorrt_llm.mapping import Mapping  # noqa: E402
 
-# Small vision config for testing
+# ---------------------------------------------------------------------------
+# Small configs for unit-level tests
+# ---------------------------------------------------------------------------
+
+# Real Gemma4 vision dims scaled down for speed. ``head_dim`` is the floor
+# imposed by MMHA (kernel rejects head_dim < 32). Keep hidden_size = heads *
+# head_dim so the fused ``qkv_proj`` shape stays consistent.
 SMALL_VISION_CONFIG = {
-    "hidden_size": 64,
-    "intermediate_size": 128,
+    "hidden_size": 128,
+    "intermediate_size": 256,
     "num_hidden_layers": 2,
     "num_attention_heads": 4,
     "num_key_value_heads": 4,
-    "head_dim": 16,
+    "head_dim": 32,
     "hidden_activation": "gelu_pytorch_tanh",
     "rms_norm_eps": 1e-6,
     "patch_size": 16,
     "pooling_kernel_size": 3,
     "position_embedding_size": 1024,
+    "use_clipped_linears": False,
+    "standardize": True,
     "model_type": "gemma4_vision",
 }
 
@@ -85,9 +120,459 @@ SMALL_TEXT_CONFIG = {
 }
 
 
-def _get_model_path():
-    import os
+def _make_dummy_pixel_input(vision_cfg, B=1, side=6, dtype=torch.float32, device="cuda"):
+    """Match the smoke ``gemma4_vision_smoke.py:make_dummy_input`` contract.
 
+    Returns ``(pixel_values, pixel_position_ids, output_length)`` where
+    ``output_length = side**2 // pooling_kernel_size**2``.
+    """
+    N = side * side
+    C = vision_cfg.patch_size**2 * 3
+    pixel_values = torch.randn(B, N, C, device=device, dtype=dtype)
+    pos = (
+        torch.stack(
+            torch.meshgrid(
+                torch.arange(side, device=device),
+                torch.arange(side, device=device),
+                indexing="ij",
+            ),
+            dim=-1,
+        )
+        .reshape(1, -1, 2)
+        .expand(B, -1, -1)
+        .contiguous()
+    )
+    output_length = N // (vision_cfg.pooling_kernel_size**2)
+    return pixel_values, pos, output_length
+
+
+def _build_trt_vision_tower(vision_cfg, dtype=torch.float32, device="cuda"):
+    """Build the refactored TRT-LLM ``Gemma4VisionModel`` with the TRTLLM attn backend.
+
+    ``get_sub_model_config`` in ``modeling_gemma4mm.py`` always picks
+    ``attn_backend="TRTLLM"`` for the vision tower, so unit tests mirror that.
+    """
+    mc = ModelConfig(
+        pretrained_config=vision_cfg,
+        mapping=Mapping(world_size=1, tp_size=1, rank=0),
+        attn_backend="TRTLLM",
+    )
+    return Gemma4VisionModel(mc).to(device).to(dtype).eval()
+
+
+# ---------------------------------------------------------------------------
+# Tier 0/1 — refactored vision tower
+# ---------------------------------------------------------------------------
+
+
+class TestGemma4VisionTower(unittest.TestCase):
+    """Refactored ``Gemma4VisionModel`` (Option B) — Attention base class path.
+
+    Covers:
+      - build via ``ModelConfig`` with TRTLLM backend
+      - random-weight forward (shape + NaN check)
+      - HF state_dict → ``load_weights`` weight fusion (q/k/v → qkv_proj)
+      - HF ↔ TRT forward parity (no clamp)
+    """
+
+    def test_build_from_model_config(self):
+        """``Gemma4VisionModel(ModelConfig)`` exposes the expected submodules."""
+        vision_cfg = Gemma4VisionConfig(**SMALL_VISION_CONFIG)
+        tower = _build_trt_vision_tower(vision_cfg, dtype=torch.bfloat16)
+
+        self.assertIsNotNone(tower.patch_embedder)
+        self.assertIsNotNone(tower.encoder)
+        self.assertIsNotNone(tower.pooler)
+        self.assertEqual(len(tower.encoder.layers), vision_cfg.num_hidden_layers)
+        # Standardize buffers must register when standardize=True (HF parity).
+        self.assertTrue(hasattr(tower, "std_bias"))
+        self.assertTrue(hasattr(tower, "std_scale"))
+
+    @torch.no_grad()
+    def test_forward_random_weights(self):
+        """Random-weight forward returns ``(output_length, hidden_size)`` with no NaNs."""
+        # Use fp32: head_dim=32 with bf16 + trtllm-gen unfused MHA fallback
+        # produces NaNs for random Kaiming init. The test is a shape+sanity
+        # check, not a dtype-specific contract.
+        torch.manual_seed(0)
+        vision_cfg = Gemma4VisionConfig(**SMALL_VISION_CONFIG)
+        tower = _build_trt_vision_tower(vision_cfg, dtype=torch.float32)
+
+        pv, pos, output_length = _make_dummy_pixel_input(vision_cfg, dtype=torch.float32)
+        with torch.inference_mode():
+            out = tower(pv, pos, output_length=output_length).last_hidden_state
+
+        self.assertEqual(out.shape, torch.Size([output_length, vision_cfg.hidden_size]))
+        self.assertFalse(out.isnan().any(), "Vision tower output contains NaN")
+
+    @torch.no_grad()
+    def test_load_weights_fuses_qkv(self):
+        """HF ``q_proj / k_proj / v_proj`` collapse into the fused ``qkv_proj``.
+
+        Validates the ``_load_weights_impl`` ``params_map`` regex
+        (``self_attn.q_proj.linear.weight`` → ``self_attn.q_proj.weight``) plus
+        the built-in qkv fusion (``qkv_proj`` ← stack(q,k,v)).
+        """
+        torch.manual_seed(0)
+        vision_cfg = Gemma4VisionConfig(**SMALL_VISION_CONFIG)
+        hf_tower = HFGemma4VisionModel(vision_cfg).to("cuda").to(torch.float32).eval()
+        trt_tower = _build_trt_vision_tower(vision_cfg)
+
+        trt_tower.load_weights(dict(hf_tower.state_dict()))
+
+        # Spot-check: fused qkv_proj.weight == vstack(q,k,v) from HF.
+        hf_sd = hf_tower.state_dict()
+        for i in range(vision_cfg.num_hidden_layers):
+            expected = torch.cat(
+                [
+                    hf_sd[f"encoder.layers.{i}.self_attn.q_proj.linear.weight"],
+                    hf_sd[f"encoder.layers.{i}.self_attn.k_proj.linear.weight"],
+                    hf_sd[f"encoder.layers.{i}.self_attn.v_proj.linear.weight"],
+                ],
+                dim=0,
+            )
+            got = trt_tower.encoder.layers[i].self_attn.qkv_proj.weight.data
+            torch.testing.assert_close(got.float(), expected.float(), atol=0, rtol=0)
+
+    @torch.no_grad()
+    def test_forward_parity_no_clamp(self):
+        """HF ↔ TRT forward parity with ``use_clipped_linears=False``.
+
+        Same shape/tolerance contract as ``gemma4_vision_smoke.py``
+        Tier 1 (atol/rtol=5e-2) — the smoke at real dims hit
+        diff.mean≈0.009; small dims should stay well inside.
+        """
+        torch.manual_seed(0)
+        cfg_dict = deepcopy(SMALL_VISION_CONFIG)
+        cfg_dict["use_clipped_linears"] = False
+        vision_cfg = Gemma4VisionConfig(**cfg_dict)
+
+        hf_tower = HFGemma4VisionModel(vision_cfg).to("cuda").to(torch.float32).eval()
+        trt_tower = _build_trt_vision_tower(vision_cfg)
+        trt_tower.load_weights(dict(hf_tower.state_dict()))
+
+        pv, pos, output_length = _make_dummy_pixel_input(vision_cfg)
+        with torch.inference_mode():
+            hf_out = hf_tower(pv, pos, output_length=output_length).last_hidden_state
+            trt_out = trt_tower(pv, pos, output_length=output_length).last_hidden_state
+
+        hf_flat = hf_out.reshape(-1, vision_cfg.hidden_size)
+        self.assertEqual(hf_flat.shape, trt_out.shape)
+        diff = (hf_flat - trt_out).abs()
+        atol, rtol = 5e-2, 5e-2
+        self.assertTrue(
+            torch.allclose(hf_flat, trt_out, atol=atol, rtol=rtol),
+            f"max diff={diff.max().item():.4f} mean diff={diff.mean().item():.4f}",
+        )
+
+
+class TestGemma4VisionTowerClamp(unittest.TestCase):
+    """``use_clipped_linears=True`` — exercises the clamp-buffer remap path.
+
+    HF lays out clamps as:
+      ``encoder.layers.{i}.self_attn.{q,k,v}_proj.{input,output}_{min,max}``
+      ``encoder.layers.{i}.self_attn.o_proj.{input,output}_{min,max}``
+    TRT-LLM collapses to:
+      ``encoder.layers.{i}.self_attn.qkv_input_{min,max}`` (shared, q/k/v must agree)
+      ``encoder.layers.{i}.self_attn.{q,k,v}_output_{min,max}``
+      ``encoder.layers.{i}.self_attn.o_{input,output}_{min,max}``
+    """
+
+    @torch.no_grad()
+    def test_clamp_buffers_remap_and_parity(self):
+        torch.manual_seed(0)
+        cfg_dict = deepcopy(SMALL_VISION_CONFIG)
+        cfg_dict["use_clipped_linears"] = True
+        vision_cfg = Gemma4VisionConfig(**cfg_dict)
+
+        hf_tower = HFGemma4VisionModel(vision_cfg).to("cuda").to(torch.float32).eval()
+        trt_tower = _build_trt_vision_tower(vision_cfg)
+
+        # Inject finite, non-default clamps into HF state_dict so the remap
+        # path has something concrete to copy (default is ±inf — a no-op).
+        # Same value on q/k/v so the fusion assertion in
+        # ``_remap_clamp_buffers`` is satisfied.
+        hf_sd = dict(hf_tower.state_dict())
+        QKV_LO, QKV_HI = -1.5, 1.5
+        Q_OUT_LO, Q_OUT_HI = -2.0, 2.0
+        K_OUT_LO, K_OUT_HI = -2.5, 2.5
+        V_OUT_LO, V_OUT_HI = -3.0, 3.0
+        O_IN_LO, O_IN_HI = -4.0, 4.0
+        O_OUT_LO, O_OUT_HI = -5.0, 5.0
+        for i in range(vision_cfg.num_hidden_layers):
+            prefix = f"encoder.layers.{i}.self_attn"
+            for sec in ("q", "k", "v"):
+                hf_sd[f"{prefix}.{sec}_proj.input_min"] = torch.tensor(QKV_LO)
+                hf_sd[f"{prefix}.{sec}_proj.input_max"] = torch.tensor(QKV_HI)
+            hf_sd[f"{prefix}.q_proj.output_min"] = torch.tensor(Q_OUT_LO)
+            hf_sd[f"{prefix}.q_proj.output_max"] = torch.tensor(Q_OUT_HI)
+            hf_sd[f"{prefix}.k_proj.output_min"] = torch.tensor(K_OUT_LO)
+            hf_sd[f"{prefix}.k_proj.output_max"] = torch.tensor(K_OUT_HI)
+            hf_sd[f"{prefix}.v_proj.output_min"] = torch.tensor(V_OUT_LO)
+            hf_sd[f"{prefix}.v_proj.output_max"] = torch.tensor(V_OUT_HI)
+            hf_sd[f"{prefix}.o_proj.input_min"] = torch.tensor(O_IN_LO)
+            hf_sd[f"{prefix}.o_proj.input_max"] = torch.tensor(O_IN_HI)
+            hf_sd[f"{prefix}.o_proj.output_min"] = torch.tensor(O_OUT_LO)
+            hf_sd[f"{prefix}.o_proj.output_max"] = torch.tensor(O_OUT_HI)
+
+        # Mirror the injected values into HF buffers so HF and TRT both clamp.
+        hf_tower.load_state_dict(hf_sd, strict=False)
+
+        trt_tower.load_weights(hf_sd)
+
+        # Buffers must now be live (non-inf) on TRT side.
+        for i in range(vision_cfg.num_hidden_layers):
+            attn = trt_tower.encoder.layers[i].self_attn
+            self.assertAlmostEqual(attn.qkv_input_min.item(), QKV_LO, places=5)
+            self.assertAlmostEqual(attn.qkv_input_max.item(), QKV_HI, places=5)
+            self.assertAlmostEqual(attn.q_output_min.item(), Q_OUT_LO, places=5)
+            self.assertAlmostEqual(attn.q_output_max.item(), Q_OUT_HI, places=5)
+            self.assertAlmostEqual(attn.k_output_min.item(), K_OUT_LO, places=5)
+            self.assertAlmostEqual(attn.k_output_max.item(), K_OUT_HI, places=5)
+            self.assertAlmostEqual(attn.v_output_min.item(), V_OUT_LO, places=5)
+            self.assertAlmostEqual(attn.v_output_max.item(), V_OUT_HI, places=5)
+            self.assertAlmostEqual(attn.o_input_min.item(), O_IN_LO, places=5)
+            self.assertAlmostEqual(attn.o_input_max.item(), O_IN_HI, places=5)
+            self.assertAlmostEqual(attn.o_output_min.item(), O_OUT_LO, places=5)
+            self.assertAlmostEqual(attn.o_output_max.item(), O_OUT_HI, places=5)
+
+        pv, pos, output_length = _make_dummy_pixel_input(vision_cfg)
+        with torch.inference_mode():
+            hf_out = hf_tower(pv, pos, output_length=output_length).last_hidden_state
+            trt_out = trt_tower(pv, pos, output_length=output_length).last_hidden_state
+
+        hf_flat = hf_out.reshape(-1, vision_cfg.hidden_size)
+        self.assertEqual(hf_flat.shape, trt_out.shape)
+        diff = (hf_flat - trt_out).abs()
+        atol, rtol = 5e-2, 5e-2
+        self.assertTrue(
+            torch.allclose(hf_flat, trt_out, atol=atol, rtol=rtol),
+            f"clamped parity max diff={diff.max().item():.4f} mean diff={diff.mean().item():.4f}",
+        )
+
+    def test_clamp_qkv_input_mismatch_raises(self):
+        """q/k/v input clamps must agree — collapse must not silently lose info."""
+        cfg_dict = deepcopy(SMALL_VISION_CONFIG)
+        cfg_dict["use_clipped_linears"] = True
+        vision_cfg = Gemma4VisionConfig(**cfg_dict)
+
+        hf_tower = HFGemma4VisionModel(vision_cfg).to("cuda").to(torch.float32).eval()
+        trt_tower = _build_trt_vision_tower(vision_cfg)
+
+        hf_sd = dict(hf_tower.state_dict())
+        # Set q/k/v input_min to *different* values for layer 0 — load must fail.
+        hf_sd["encoder.layers.0.self_attn.q_proj.input_min"] = torch.tensor(-1.0)
+        hf_sd["encoder.layers.0.self_attn.k_proj.input_min"] = torch.tensor(-1.1)
+        hf_sd["encoder.layers.0.self_attn.v_proj.input_min"] = torch.tensor(-1.0)
+        hf_sd["encoder.layers.0.self_attn.q_proj.input_max"] = torch.tensor(1.0)
+        hf_sd["encoder.layers.0.self_attn.k_proj.input_max"] = torch.tensor(1.0)
+        hf_sd["encoder.layers.0.self_attn.v_proj.input_max"] = torch.tensor(1.0)
+
+        with self.assertRaises(ValueError):
+            trt_tower.load_weights(hf_sd)
+
+
+# ---------------------------------------------------------------------------
+# Multimodal embedder (unchanged from skeleton — already covers the
+# refactored ``Gemma4MultimodalEmbedder``).
+# ---------------------------------------------------------------------------
+
+
+class TestGemma4MultimodalEmbedder(unittest.TestCase):
+    """Test the multimodal embedder projection layer."""
+
+    def test_embedder_instantiation(self):
+        """Embedder creates norm + projection with correct dimensions."""
+        embedder = Gemma4MultimodalEmbedder(
+            mm_hidden_size=64,
+            text_hidden_size=128,
+            eps=1e-6,
+            dtype=torch.bfloat16,
+        )
+        self.assertEqual(embedder.embedding_projection.weight.shape, torch.Size([128, 64]))
+
+    @torch.no_grad()
+    def test_embedder_forward(self):
+        """Embedder forward: norm → linear, output matches expected shape."""
+        embedder = (
+            Gemma4MultimodalEmbedder(
+                mm_hidden_size=64,
+                text_hidden_size=128,
+                dtype=torch.bfloat16,
+            )
+            .to("cuda")
+            .to(torch.bfloat16)
+        )
+        torch.nn.init.xavier_uniform_(embedder.embedding_projection.weight.data)
+
+        x = torch.randn(4, 64, device="cuda", dtype=torch.bfloat16)
+        with torch.inference_mode():
+            out = embedder(x)
+        self.assertEqual(out.shape, torch.Size([4, 128]))
+        self.assertFalse(out.isnan().any())
+
+    @torch.no_grad()
+    def test_embedder_matches_hf(self):
+        """Compare embedder output with HF Gemma4MultimodalEmbedder."""
+        vision_cfg = Gemma4VisionConfig(**SMALL_VISION_CONFIG)
+        text_cfg = Gemma4TextConfig(**SMALL_TEXT_CONFIG)
+        dtype = torch.bfloat16
+        device = "cuda"
+
+        hf_embedder = HFGemma4MultimodalEmbedder(vision_cfg, text_cfg).to(dtype).to(device).eval()
+
+        trt_embedder = Gemma4MultimodalEmbedder(
+            mm_hidden_size=vision_cfg.hidden_size,
+            text_hidden_size=text_cfg.hidden_size,
+            eps=vision_cfg.rms_norm_eps,
+            dtype=dtype,
+        ).to(device)
+
+        trt_embedder.embedding_projection.weight.data.copy_(
+            hf_embedder.embedding_projection.weight.data
+        )
+
+        x = torch.randn(4, vision_cfg.hidden_size, device=device, dtype=dtype)
+        with torch.inference_mode():
+            hf_out = hf_embedder(x)
+            trt_out = trt_embedder(x)
+
+        self.assertTrue(
+            torch.allclose(hf_out, trt_out, atol=1e-2),
+            f"Embedder max diff: {(hf_out - trt_out).abs().max()}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Vision + embedder end-to-end (no LLM, no real model required)
+# ---------------------------------------------------------------------------
+
+
+class TestGemma4VisionPipeline(unittest.TestCase):
+    """Full vision-pipeline parity: pixel_values → tower → embedder → text_hidden.
+
+    Replaces the pre-refactor ``test_vision_pipeline_matches_hf`` which built
+    the tower via ``AutoModel.from_config`` and the projection via
+    ``load_state_dict``. Both sides now use the refactored TRT-LLM tower +
+    embedder; weights flow through the production ``load_weights`` path.
+    """
+
+    @torch.no_grad()
+    def test_pipeline_matches_hf(self):
+        torch.manual_seed(0)
+        vision_cfg = Gemma4VisionConfig(**SMALL_VISION_CONFIG)
+        text_cfg = Gemma4TextConfig(**SMALL_TEXT_CONFIG)
+        dtype = torch.float32
+        device = "cuda"
+
+        # --- HF pipeline ---
+        hf_tower = HFGemma4VisionModel(vision_cfg).to(device).to(dtype).eval()
+        hf_embedder = HFGemma4MultimodalEmbedder(vision_cfg, text_cfg).to(device).to(dtype).eval()
+
+        # --- TRT-LLM pipeline ---
+        trt_tower = _build_trt_vision_tower(vision_cfg, dtype=dtype, device=device)
+        trt_tower.load_weights(dict(hf_tower.state_dict()))
+
+        trt_embedder = Gemma4MultimodalEmbedder(
+            mm_hidden_size=vision_cfg.hidden_size,
+            text_hidden_size=text_cfg.hidden_size,
+            eps=vision_cfg.rms_norm_eps,
+            dtype=dtype,
+        ).to(device)
+        trt_embedder.embedding_projection.weight.data.copy_(
+            hf_embedder.embedding_projection.weight.data
+        )
+
+        pv, pos, output_length = _make_dummy_pixel_input(
+            vision_cfg, B=1, side=6, dtype=dtype, device=device
+        )
+
+        with torch.inference_mode():
+            hf_hidden = hf_tower(pv, pos, output_length=output_length).last_hidden_state
+            hf_out = hf_embedder(hf_hidden)
+            trt_hidden = trt_tower(pv, pos, output_length=output_length).last_hidden_state
+            # Production ``_get_image_features`` adds a batch dim around the
+            # embedder call. Mirror that exactly so the projection's input
+            # shape contract is what production sees.
+            trt_out = trt_embedder(trt_hidden.unsqueeze(0)).squeeze(0)
+
+        # HF returns (B, output_length, H); TRT returns (N_valid, H). For B=1
+        # with no padding, N_valid == output_length, so the flattened shapes
+        # must match.
+        hf_flat = hf_out.reshape(-1, text_cfg.hidden_size)
+        self.assertEqual(hf_flat.shape, trt_out.shape)
+        diff = (hf_flat - trt_out).abs()
+        self.assertTrue(
+            torch.allclose(hf_flat, trt_out, atol=5e-2, rtol=5e-2),
+            f"Pipeline max diff={diff.max().item():.4f} mean diff={diff.mean().item():.4f}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multimodal wrapper (LLM + vision tower + embedder)
+# ---------------------------------------------------------------------------
+
+
+class TestGemma4ForConditionalGeneration(unittest.TestCase):
+    """Test the multimodal VLM wrapper."""
+
+    def test_instantiation_with_vision(self):
+        """VLM wrapper creates LLM + vision tower + embedder.
+
+        Asserts ``vision_tower`` is the refactored TRT-LLM ``Gemma4VisionModel``
+        (Option B), *not* the HF ``AutoModel`` placeholder used pre-refactor.
+        """
+        text_cfg = Gemma4TextConfig(**SMALL_TEXT_CONFIG)
+        vision_cfg = Gemma4VisionConfig(**SMALL_VISION_CONFIG)
+        config = Gemma4Config(
+            text_config=text_cfg,
+            vision_config=vision_cfg,
+            audio_config=None,
+        )
+
+        mc = ModelConfig(
+            pretrained_config=config,
+            mapping=Mapping(world_size=1, tp_size=1, rank=0),
+            attn_backend="FLASHINFER",
+        )
+        model = Gemma4ForConditionalGeneration(mc)
+
+        self.assertIsNotNone(model.llm)
+        self.assertIsNotNone(model.vision_tower)
+        self.assertIsNotNone(model.embed_vision)
+        self.assertIsNone(model.audio_tower)
+        self.assertIsNone(model.embed_audio)
+        # Regression guard for Option B: the vision tower must be the native
+        # TRT-LLM class, not ``transformers.AutoModel`` output.
+        self.assertIsInstance(model.vision_tower, Gemma4VisionModel)
+
+    def test_instantiation_without_vision(self):
+        """VLM wrapper works text-only when vision_config is None."""
+        text_cfg = Gemma4TextConfig(**SMALL_TEXT_CONFIG)
+        config = Gemma4Config(
+            text_config=text_cfg,
+            vision_config=None,
+            audio_config=None,
+        )
+
+        mc = ModelConfig(
+            pretrained_config=config,
+            mapping=Mapping(world_size=1, tp_size=1, rank=0),
+            attn_backend="FLASHINFER",
+        )
+        model = Gemma4ForConditionalGeneration(mc)
+
+        self.assertIsNotNone(model.llm)
+        self.assertIsNone(model.vision_tower)
+        self.assertIsNone(model.embed_vision)
+
+
+# ---------------------------------------------------------------------------
+# Input processor (real tokenizer/processor — gated on LLM_MODELS_ROOT)
+# ---------------------------------------------------------------------------
+
+
+def _get_model_path():
     llm_models_root = os.environ.get("LLM_MODELS_ROOT")
     if llm_models_root:
         return os.path.join(llm_models_root, "gemma4/gemma-4-26B-A4B-it")
@@ -98,8 +583,6 @@ MODEL_26B_PATH = _get_model_path()
 
 
 def _model_available():
-    import os
-
     if MODEL_26B_PATH is None:
         return False
     return os.path.isfile(os.path.join(MODEL_26B_PATH, "config.json"))
@@ -158,7 +641,6 @@ class TestGemma4InputProcessor(unittest.TestCase):
         proc = self._make_processor()
         img = Image.fromarray(np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8))
 
-        # Use chat template to properly format the prompt
         prompt = proc._processor.apply_chat_template(
             [
                 {
@@ -185,7 +667,7 @@ class TestGemma4InputProcessor(unittest.TestCase):
         self.assertIn("image", mm_data["multimodal_data"])
         img_data = mm_data["multimodal_data"]["image"]
         self.assertIn("pixel_values", img_data)
-        self.assertEqual(img_data["pixel_values"].dim(), 3)  # [num_images, patches, channels]
+        self.assertEqual(img_data["pixel_values"].dim(), 3)
 
     def test_image_token_expansion(self):
         """Chat template expands <image> placeholder to image tokens."""
@@ -218,7 +700,6 @@ class TestGemma4InputProcessor(unittest.TestCase):
 
         image_token_id = self.config.image_token_id
         image_count = sum(1 for t in input_ids if t == image_token_id)
-        # Image should be expanded to multiple image tokens
         self.assertGreater(image_count, 0, "Expected image tokens in expanded input_ids")
 
     def test_multiple_images(self):
@@ -254,7 +735,6 @@ class TestGemma4InputProcessor(unittest.TestCase):
 
         self.assertIsNotNone(mm_data)
         pv = mm_data["multimodal_data"]["image"]["pixel_values"]
-        # Two images should give batch dim of 2
         self.assertEqual(pv.shape[0], 2)
 
     def test_torch_tensor_image(self):
@@ -262,7 +742,6 @@ class TestGemma4InputProcessor(unittest.TestCase):
         from tensorrt_llm.sampling_params import SamplingParams
 
         proc = self._make_processor()
-        # Create a float tensor image (already rescaled)
         img_tensor = torch.randn(3, 224, 224)
 
         prompt = proc._processor.apply_chat_template(
@@ -302,7 +781,6 @@ class TestGemma4InputProcessor(unittest.TestCase):
         from tensorrt_llm.sampling_params import SamplingParams
 
         proc = self._make_processor()
-        # Synthetic 1-second mono audio at 16 kHz.
         audio = np.random.randn(16000).astype(np.float32)
 
         prompt = proc._processor.apply_chat_template(
@@ -330,7 +808,6 @@ class TestGemma4InputProcessor(unittest.TestCase):
         self.assertIn("audio", mm_data["multimodal_data"])
         audio_data = mm_data["multimodal_data"]["audio"]
         self.assertIn("audio_features", audio_data)
-        # (batch, frames, mel_bins)
         self.assertEqual(audio_data["audio_features"].dim(), 3)
 
     def test_audio_token_expansion(self):
@@ -374,7 +851,6 @@ class TestGemma4InputProcessor(unittest.TestCase):
 
         from tensorrt_llm._torch.models.modeling_gemma4mm import _normalize_audio_inputs
 
-        # Stereo input at 48 kHz -> mono at 16 kHz.
         sr_src = 48000
         dur_sec = 0.5
         stereo = np.random.randn(int(sr_src * dur_sec), 2).astype(np.float32)
@@ -383,7 +859,6 @@ class TestGemma4InputProcessor(unittest.TestCase):
         arr = normalized[0]
         self.assertEqual(arr.ndim, 1)
         self.assertEqual(arr.dtype, np.float32)
-        # 0.5 sec @ 16 kHz ≈ 8000 samples (resample_poly may differ by 1).
         self.assertAlmostEqual(arr.size, 8000, delta=4)
 
     def test_audio_input_torch_tensor(self):
@@ -414,13 +889,6 @@ class TestGemma4InputProcessor(unittest.TestCase):
     def test_video_processing_returns_pixel_values(self):
         """Video input bypasses HF Gemma4Processor and yields per-frame
         pixel_values + expanded video soft tokens in input_ids.
-
-        Regression for the ``merged_typed_dict.__init__() got an unexpected
-        keyword argument 'video_sizes'`` failure where calling
-        ``Gemma4Processor`` with ``videos=`` triggers strict-typed-dict
-        validation in transformers 5.5.x.  Our input processor sidesteps
-        this by calling the underlying ``video_processor`` directly and
-        expanding the placeholder manually.
         """
         import numpy as np
         from PIL import Image
@@ -431,13 +899,10 @@ class TestGemma4InputProcessor(unittest.TestCase):
         if not hasattr(proc._processor, "video_processor"):
             self.skipTest("Processor has no video_processor")
 
-        # 32 dummy 224x224 frames (matches Gemma4VideoProcessor.num_frames).
         frames = [
             Image.fromarray(np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8))
             for _ in range(32)
         ]
-        # Dataclass-like wrapper to exercise the ``getattr(v, 'frames', ...)``
-        # path used by the TRT-LLM video loader.
         VideoData = type("VideoData", (), {})
         vd = VideoData()
         vd.frames = frames
@@ -465,11 +930,9 @@ class TestGemma4InputProcessor(unittest.TestCase):
         self.assertIn("video", mm_data["multimodal_data"])
         video_data = mm_data["multimodal_data"]["video"]
         self.assertIn("pixel_values", video_data)
-        # Per-frame pixel_values: (num_frames, num_patches, channels)
         self.assertEqual(video_data["pixel_values"].dim(), 3)
         self.assertEqual(video_data["pixel_values"].shape[0], 32)
 
-        # The video_token id should appear in the expanded input_ids.
         video_token_id = self._video_token_id()
         if video_token_id is not None:
             self.assertGreater(
@@ -482,232 +945,180 @@ class TestGemma4InputProcessor(unittest.TestCase):
         return getattr(self.config, "video_token_id", None)
 
 
-class TestGemma4MultimodalEmbedder(unittest.TestCase):
-    """Test the multimodal embedder projection layer."""
-
-    def test_embedder_instantiation(self):
-        """Embedder creates norm + projection with correct dimensions."""
-        embedder = Gemma4MultimodalEmbedder(
-            mm_hidden_size=64,
-            text_hidden_size=128,
-            eps=1e-6,
-            dtype=torch.bfloat16,
-        )
-        self.assertEqual(embedder.embedding_projection.weight.shape, torch.Size([128, 64]))
-
-    @torch.no_grad()
-    def test_embedder_forward(self):
-        """Embedder forward: norm → linear, output matches expected shape."""
-        embedder = (
-            Gemma4MultimodalEmbedder(
-                mm_hidden_size=64,
-                text_hidden_size=128,
-                dtype=torch.bfloat16,
-            )
-            .to("cuda")
-            .to(torch.bfloat16)
-        )
-        # Initialize with non-zero weights to avoid zero-output edge cases
-        torch.nn.init.xavier_uniform_(embedder.embedding_projection.weight.data)
-
-        x = torch.randn(4, 64, device="cuda", dtype=torch.bfloat16)
-        with torch.inference_mode():
-            out = embedder(x)
-        self.assertEqual(out.shape, torch.Size([4, 128]))
-        self.assertFalse(out.isnan().any())
-
-    @torch.no_grad()
-    def test_embedder_matches_hf(self):
-        """Compare embedder output with HF Gemma4MultimodalEmbedder."""
-        from transformers.models.gemma4.modeling_gemma4 import (
-            Gemma4MultimodalEmbedder as HFEmbedder,
-        )
-
-        vision_cfg = Gemma4VisionConfig(**SMALL_VISION_CONFIG)
-        text_cfg = Gemma4TextConfig(**SMALL_TEXT_CONFIG)
-        dtype = torch.bfloat16
-        device = "cuda"
-
-        hf_embedder = HFEmbedder(vision_cfg, text_cfg).to(dtype).to(device).eval()
-
-        trt_embedder = Gemma4MultimodalEmbedder(
-            mm_hidden_size=vision_cfg.hidden_size,
-            text_hidden_size=text_cfg.hidden_size,
-            eps=vision_cfg.rms_norm_eps,
-            dtype=dtype,
-        ).to(device)
-
-        # Copy HF weights to TRT
-        trt_embedder.embedding_projection.weight.data.copy_(
-            hf_embedder.embedding_projection.weight.data
-        )
-
-        x = torch.randn(4, vision_cfg.hidden_size, device=device, dtype=dtype)
-        with torch.inference_mode():
-            hf_out = hf_embedder(x)
-            trt_out = trt_embedder(x)
-
-        self.assertTrue(
-            torch.allclose(hf_out, trt_out, atol=1e-2),
-            f"Embedder max diff: {(hf_out - trt_out).abs().max()}",
-        )
+# ---------------------------------------------------------------------------
+# Tier 2 — Full LLM+vision E2E via shared TestModelingMultimodal skeleton.
+# ---------------------------------------------------------------------------
+#
+# Reuses ``test_modeling_multimodal.TestModelingMultimodal`` (the abstract
+# base used by qwen3vl / nemotron_nano_v2_vl / etc.). Mirrors the qwen3vl
+# pattern: provide config + class hooks, gate on LLM_MODELS_ROOT.
+#
+# Audio scenarios are intentionally not included — audio tower refactor is
+# follow-up work.
 
 
-class TestGemma4VisionTower(unittest.TestCase):
-    """Test the vision tower (native transformers AutoModel)."""
+_GEMMA4_E2E_PATH = (
+    os.path.join(os.environ["LLM_MODELS_ROOT"], "gemma4/gemma-4-26B-A4B-it")
+    if os.environ.get("LLM_MODELS_ROOT")
+    else None
+)
 
-    def test_vision_tower_creation(self):
-        """Vision tower can be created from config."""
-        vision_cfg = Gemma4VisionConfig(**SMALL_VISION_CONFIG)
-        tower = AutoModel.from_config(vision_cfg)
-        self.assertIsNotNone(tower)
-        params = sum(p.numel() for p in tower.parameters())
-        self.assertGreater(params, 0)
 
-    @torch.no_grad()
-    def test_vision_tower_forward(self):
-        """Vision tower forward pass produces valid output with correct shape."""
-        vision_cfg = Gemma4VisionConfig(**SMALL_VISION_CONFIG)
-        dtype = torch.bfloat16
-        device = "cuda"
+def _gemma4_e2e_model_available() -> bool:
+    if _GEMMA4_E2E_PATH is None or not os.path.isfile(
+        os.path.join(_GEMMA4_E2E_PATH, "config.json")
+    ):
+        return False
+    # The shared multimodal skeleton's default `get_raw_test_inputs` reads
+    # ``{LLM_MODELS_ROOT}/multimodals/test_data/seashore.png``; gate on that
+    # too so the test reports skipped instead of failing in CI environments
+    # where multimodal test fixtures aren't mirrored.
+    test_img = os.path.join(
+        os.environ["LLM_MODELS_ROOT"],
+        "multimodals",
+        "test_data",
+        "seashore.png",
+    )
+    return os.path.isfile(test_img)
 
-        tower = AutoModel.from_config(vision_cfg).to(dtype).to(device).eval()
 
-        # 6x6 = 36 patches, pixel_values shape: [B, N_patches, patch_size^2 * 3]
-        B, side = 1, 6
-        N_patches = side * side
-        C_in = vision_cfg.patch_size**2 * 3  # 16*16*3 = 768
-        pixel_values = torch.randn(B, N_patches, C_in, device=device, dtype=dtype)
-        position_ids = torch.stack(
-            torch.meshgrid(
-                torch.arange(side, device=device),
-                torch.arange(side, device=device),
-                indexing="ij",
-            ),
-            dim=-1,
-        ).reshape(1, -1, 2)
+# Reduced-layer text+vision config for E2E. Real ``_name_or_path`` so the
+# input processor + tokenizer pick up the genuine Gemma4 processor files;
+# attention head_dim follows the existing dummy-config recipe in
+# ``test_gemma4_e2e_dummy.py`` (128 / 256 for FlashInfer compatibility).
+GEMMA4_E2E_CONFIG = {
+    "architectures": ["Gemma4ForConditionalGeneration"],
+    "model_type": "gemma4",
+    "torch_dtype": "bfloat16",
+    "tie_word_embeddings": True,
+    # HF Gemma4 (transformers 5.5.3) does not advertise SDPA support; pin
+    # to eager so PreTrainedModel.__init__ does not raise on dispatch check.
+    "_attn_implementation": "eager",
+    "image_token_id": 262145,
+    "audio_token_id": 262273,
+    "video_token_id": 262146,
+    "boi_token_index": 255999,
+    "eoi_token_index": 256000,
+    "boa_token_index": 256001,
+    "eoa_token_index": 256002,
+    "_name_or_path": _GEMMA4_E2E_PATH or "",
+    "text_config": {
+        "model_type": "gemma4_text",
+        "vocab_size": 262400,
+        "hidden_size": 1024,
+        "intermediate_size": 2048,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 8,
+        "num_key_value_heads": 4,
+        "head_dim": 128,
+        "global_head_dim": 256,
+        "num_global_key_value_heads": 4,
+        "hidden_activation": "gelu_pytorch_tanh",
+        "max_position_embeddings": 4096,
+        "rms_norm_eps": 1e-6,
+        "sliding_window": 1024,
+        "attention_k_eq_v": False,
+        "enable_moe_block": False,
+        "num_kv_shared_layers": 0,
+        "hidden_size_per_layer_input": 0,
+        "use_double_wide_mlp": False,
+        "final_logit_softcapping": None,
+        "torch_dtype": "bfloat16",
+        "tie_word_embeddings": True,
+        "attention_bias": False,
+        "attention_dropout": 0.0,
+        "rope_parameters": {
+            "sliding_attention": {"rope_type": "default", "rope_theta": 10000.0},
+            "full_attention": {"rope_type": "default", "rope_theta": 10000.0},
+        },
+    },
+    "vision_config": {
+        "model_type": "gemma4_vision",
+        "hidden_size": 1152,
+        "intermediate_size": 4304,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 16,
+        "num_key_value_heads": 16,
+        "head_dim": 72,
+        "hidden_activation": "gelu_pytorch_tanh",
+        "rms_norm_eps": 1e-6,
+        "patch_size": 16,
+        "pooling_kernel_size": 3,
+        "position_embedding_size": 10240,
+        "use_clipped_linears": False,
+        "standardize": True,
+        "torch_dtype": "bfloat16",
+    },
+}
 
-        pooling_k2 = vision_cfg.pooling_kernel_size**2
-        output_length = N_patches // pooling_k2
 
-        with torch.inference_mode():
-            out = tower(pixel_values, position_ids, output_length=output_length)
+@pytest.mark.skipif(
+    not _gemma4_e2e_model_available(),
+    reason=(
+        "LLM_MODELS_ROOT not set or Gemma4 model not available — "
+        "E2E generate parity requires real tokenizer/processor files."
+    ),
+)
+class TestGemma4MultimodalE2E(unittest.TestCase):
+    """Full LLM + vision parity via the shared multimodal skeleton.
 
-        hidden = out.last_hidden_state
-        self.assertEqual(hidden.shape, torch.Size([output_length, vision_cfg.hidden_size]))
-        self.assertFalse(hidden.isnan().any(), "Vision tower output contains NaN")
+    Implemented as a thin wrapper around ``TestModelingMultimodal`` so we
+    reuse the standardized context+generation phase, KV cache manager
+    setup, HF input loading, and tolerance/compare helpers.
+    """
 
-    @torch.no_grad()
-    def test_vision_pipeline_matches_hf(self):
-        """Full vision pipeline (tower → embedder) matches HF reference."""
-        from transformers.models.gemma4.modeling_gemma4 import (
-            Gemma4MultimodalEmbedder as HFEmbedder,
-        )
-        from transformers.models.gemma4.modeling_gemma4 import Gemma4VisionModel as HFVisionModel
+    # The actual abstract base + skeleton live in
+    # ``test_modeling_multimodal``. Importing it pulls in helpers that depend
+    # on ``utils.llm_data.llm_models_root`` — they only load when the gate
+    # above passes.
 
-        vision_cfg = Gemma4VisionConfig(**SMALL_VISION_CONFIG)
-        text_cfg = Gemma4TextConfig(**SMALL_TEXT_CONFIG)
-        dtype = torch.bfloat16
-        device = "cuda"
+    def test_image_scenarios(self):
+        from test_modeling_multimodal import MultimodalScenario, TestModelingMultimodal
 
-        # --- HF reference pipeline ---
-        hf_tower = HFVisionModel(vision_cfg).to(dtype).to(device).eval()
-        hf_embedder = HFEmbedder(vision_cfg, text_cfg).to(dtype).to(device).eval()
-
-        # --- TRT-LLM pipeline (same tower class + our embedder) ---
-        trt_tower = AutoModel.from_config(vision_cfg).to(dtype).to(device).eval()
-        trt_embedder = Gemma4MultimodalEmbedder(
-            mm_hidden_size=vision_cfg.hidden_size,
-            text_hidden_size=text_cfg.hidden_size,
-            eps=vision_cfg.rms_norm_eps,
-            dtype=dtype,
-        ).to(device)
-
-        # Copy weights: tower
-        trt_tower.load_state_dict(hf_tower.state_dict())
-        # Copy weights: embedder
-        trt_embedder.embedding_projection.weight.data.copy_(
-            hf_embedder.embedding_projection.weight.data
+        from tensorrt_llm._torch.models.checkpoints.hf.gemma4_weight_mapper import (
+            Gemma4HfWeightMapper,
         )
 
-        # Dummy input: 6x6 = 36 patches
-        side = 6
-        N_patches = side * side
-        C_in = vision_cfg.patch_size**2 * 3
-        pixel_values = torch.randn(1, N_patches, C_in, device=device, dtype=dtype)
-        position_ids = torch.stack(
-            torch.meshgrid(
-                torch.arange(side, device=device),
-                torch.arange(side, device=device),
-                indexing="ij",
-            ),
-            dim=-1,
-        ).reshape(1, -1, 2)
+        class _Gemma4E2EImpl(TestModelingMultimodal):
+            def get_model_config(self) -> Dict:
+                return deepcopy(GEMMA4_E2E_CONFIG)
 
-        pooling_k2 = vision_cfg.pooling_kernel_size**2
-        output_length = N_patches // pooling_k2
+            def get_trtllm_model_class(self) -> Type:
+                return Gemma4ForConditionalGeneration
 
-        with torch.inference_mode():
-            # HF pipeline
-            hf_hidden = hf_tower(pixel_values, position_ids, output_length=output_length)
-            hf_out = hf_embedder(hf_hidden.last_hidden_state)
+            def get_hf_model_class(self) -> Type:
+                return HFGemma4ForConditionalGeneration
 
-            # TRT-LLM pipeline
-            trt_hidden = trt_tower(pixel_values, position_ids, output_length=output_length)
-            trt_out = trt_embedder(trt_hidden.last_hidden_state.unsqueeze(0)).squeeze(0)
+            def get_weight_mapper_class(self) -> Type:
+                return Gemma4HfWeightMapper
 
-        self.assertEqual(hf_out.shape, trt_out.shape)
-        self.assertTrue(
-            torch.allclose(hf_out, trt_out, atol=1e-2),
-            f"Vision pipeline max diff: {(hf_out - trt_out).abs().max():.6f}",
-        )
+            def get_model_type(self) -> str:
+                return "gemma4"
 
+            def get_model_config_class(self) -> Type:
+                return Gemma4Config
 
-class TestGemma4ForConditionalGeneration(unittest.TestCase):
-    """Test the multimodal VLM wrapper."""
+            def get_scenarios(self) -> List[MultimodalScenario]:
+                # Single sanity-image scenario for the in-PR test list.
+                # CUDA-graph / chunked-prefill / kv-cache-reuse permutations
+                # are tracked separately in the integration test list.
+                return [
+                    MultimodalScenario(
+                        modality="image",
+                        use_cuda_graph=False,
+                        chunked_prefill=False,
+                        kv_cache_reuse=False,
+                    ),
+                ]
 
-    def test_instantiation_with_vision(self):
-        """VLM wrapper creates LLM + vision tower + embedder."""
-        text_cfg = Gemma4TextConfig(**SMALL_TEXT_CONFIG)
-        vision_cfg = Gemma4VisionConfig(**SMALL_VISION_CONFIG)
-        config = Gemma4Config(
-            text_config=text_cfg,
-            vision_config=vision_cfg,
-            audio_config=None,
-        )
-
-        mc = ModelConfig(
-            pretrained_config=config,
-            mapping=Mapping(world_size=1, tp_size=1, rank=0),
-            attn_backend="FLASHINFER",
-        )
-        model = Gemma4ForConditionalGeneration(mc)
-
-        self.assertIsNotNone(model.llm)
-        self.assertIsNotNone(model.vision_tower)
-        self.assertIsNotNone(model.embed_vision)
-        self.assertIsNone(model.audio_tower)
-        self.assertIsNone(model.embed_audio)
-
-    def test_instantiation_without_vision(self):
-        """VLM wrapper works text-only when vision_config is None."""
-        text_cfg = Gemma4TextConfig(**SMALL_TEXT_CONFIG)
-        config = Gemma4Config(
-            text_config=text_cfg,
-            vision_config=None,
-            audio_config=None,
-        )
-
-        mc = ModelConfig(
-            pretrained_config=config,
-            mapping=Mapping(world_size=1, tp_size=1, rank=0),
-            attn_backend="FLASHINFER",
-        )
-        model = Gemma4ForConditionalGeneration(mc)
-
-        self.assertIsNotNone(model.llm)
-        self.assertIsNone(model.vision_tower)
-        self.assertIsNone(model.embed_vision)
+        # TestModelingMultimodal is abstract — instantiate a dynamic
+        # subclass and run only ``test_all`` to keep the surface minimal.
+        runner = _Gemma4E2EImpl("test_all")
+        runner.setUp()
+        try:
+            runner.test_all()
+        finally:
+            runner.tearDown()
 
 
 if __name__ == "__main__":

--- a/tests/unittest/_torch/modeling/test_gemma4_multimodal.py
+++ b/tests/unittest/_torch/modeling/test_gemma4_multimodal.py
@@ -341,6 +341,48 @@ class TestGemma4VisionTower(unittest.TestCase):
             f"max diff={diff.max().item():.6f} mean diff={diff.mean().item():.6f}",
         )
 
+    @torch.no_grad()
+    def test_forward_image_seq_lens_kwarg_matches_default(self):
+        """``image_seq_lens`` kwarg path is byte-equivalent to the default.
+
+        The tower derives per-image seq_lens entirely on CPU — no GPU
+        reduction, no D2H sync. Two CPU branches:
+          - ``image_seq_lens`` is provided (production: ``Gemma4InputProcessor``
+            emits it alongside ``image_position_ids``)
+          - ``image_seq_lens is None`` and the dummy/test input has no ``-1``
+            padding → fall back to ``[N] * B`` (every patch valid)
+
+        For a full-grid synthetic input the two branches must produce
+        identical output, since the explicit list ``[N] * B`` is exactly
+        what the default fallback computes.
+        """
+        torch.manual_seed(0)
+        cfg_dict = deepcopy(SMALL_VISION_CONFIG)
+        cfg_dict["use_clipped_linears"] = False
+        vision_cfg = Gemma4VisionConfig(**cfg_dict)
+
+        hf_tower = HFGemma4VisionModel(vision_cfg).to("cuda").to(torch.float32).eval()
+        trt_tower = _build_trt_vision_tower(vision_cfg)
+        trt_tower.load_weights(dict(hf_tower.state_dict()))
+
+        B = 3
+        pv, pos, output_length = _make_dummy_pixel_input(vision_cfg, B=B)
+        full_seq_lens = [pos.shape[1]] * B
+
+        with torch.inference_mode():
+            default_path = trt_tower(pv, pos, output_length=output_length).last_hidden_state
+            explicit_path = trt_tower(
+                pv, pos, output_length=output_length, image_seq_lens=full_seq_lens
+            ).last_hidden_state
+
+        self.assertEqual(default_path.shape, explicit_path.shape)
+        diff = (default_path - explicit_path).abs()
+        self.assertTrue(
+            torch.allclose(default_path, explicit_path, atol=1e-4, rtol=0),
+            f"image_seq_lens kwarg path diverges from default-all-valid path: "
+            f"max diff={diff.max().item():.6f}",
+        )
+
 
 class TestGemma4VisionTowerClamp(unittest.TestCase):
     """``use_clipped_linears=True`` — exercises the clamp-buffer remap path.

--- a/tests/unittest/_torch/modeling/test_gemma4_multimodal.py
+++ b/tests/unittest/_torch/modeling/test_gemma4_multimodal.py
@@ -219,6 +219,10 @@ class TestGemma4VisionTower(unittest.TestCase):
         Validates the ``_load_weights_impl`` ``params_map`` regex
         (``self_attn.q_proj.linear.weight`` → ``self_attn.q_proj.weight``) plus
         the built-in qkv fusion (``qkv_proj`` ← stack(q,k,v)).
+
+        When ``head_dim`` is padded to an FMHA-supported size (e.g. 32 → 64,
+        72 → 80), the fused ``qkv_proj.weight`` has zero-padded tail channels
+        per head; comparison must apply the same zero-pad to the HF reference.
         """
         torch.manual_seed(0)
         vision_cfg = Gemma4VisionConfig(**SMALL_VISION_CONFIG)
@@ -227,17 +231,27 @@ class TestGemma4VisionTower(unittest.TestCase):
 
         trt_tower.load_weights(dict(hf_tower.state_dict()))
 
-        # Spot-check: fused qkv_proj.weight == vstack(q,k,v) from HF.
+        # Spot-check: fused qkv_proj.weight == vstack(zero-pad(q,k,v)) from HF.
         hf_sd = hf_tower.state_dict()
         for i in range(vision_cfg.num_hidden_layers):
-            expected = torch.cat(
-                [
-                    hf_sd[f"encoder.layers.{i}.self_attn.q_proj.linear.weight"],
-                    hf_sd[f"encoder.layers.{i}.self_attn.k_proj.linear.weight"],
-                    hf_sd[f"encoder.layers.{i}.self_attn.v_proj.linear.weight"],
-                ],
-                dim=0,
-            )
+            attn = trt_tower.encoder.layers[i].self_attn
+            nh = attn.num_heads
+            nkv = attn.num_key_value_heads
+            hf_hd = attn.hf_head_dim
+            padded_hd = attn.head_dim
+
+            def _pad_head_dim(t: torch.Tensor, heads: int) -> torch.Tensor:
+                # t: (heads * hf_hd, hidden) → (heads * padded_hd, hidden)
+                if padded_hd == hf_hd:
+                    return t
+                t = t.view(heads, hf_hd, -1)
+                zeros = t.new_zeros(heads, padded_hd - hf_hd, t.shape[-1])
+                return torch.cat([t, zeros], dim=1).reshape(heads * padded_hd, -1)
+
+            q = _pad_head_dim(hf_sd[f"encoder.layers.{i}.self_attn.q_proj.linear.weight"], nh)
+            k = _pad_head_dim(hf_sd[f"encoder.layers.{i}.self_attn.k_proj.linear.weight"], nkv)
+            v = _pad_head_dim(hf_sd[f"encoder.layers.{i}.self_attn.v_proj.linear.weight"], nkv)
+            expected = torch.cat([q, k, v], dim=0)
             got = trt_tower.encoder.layers[i].self_attn.qkv_proj.weight.data
             torch.testing.assert_close(got.float(), expected.float(), atol=0, rtol=0)
 
@@ -270,6 +284,61 @@ class TestGemma4VisionTower(unittest.TestCase):
         self.assertTrue(
             torch.allclose(hf_flat, trt_out, atol=atol, rtol=rtol),
             f"max diff={diff.max().item():.4f} mean diff={diff.mean().item():.4f}",
+        )
+
+    @torch.no_grad()
+    def test_forward_batched_matches_per_image_loop(self):
+        """B>1 single-call equivalence to per-image looped calls.
+
+        The caller ``_get_image_features`` was rewritten to feed all images
+        in one batched ``vision_tower`` call (varlen ``cu_seqlens`` attention).
+        This regression test guards that the batched path is numerically
+        equivalent to looping ``B=1`` calls and concatenating. If a future
+        change introduces cross-image leakage (e.g. shared attn_metadata
+        state not properly reset, or pooler bleeding across images), the
+        loop-vs-batched diff catches it.
+        """
+        torch.manual_seed(0)
+        cfg_dict = deepcopy(SMALL_VISION_CONFIG)
+        cfg_dict["use_clipped_linears"] = False
+        vision_cfg = Gemma4VisionConfig(**cfg_dict)
+
+        hf_tower = HFGemma4VisionModel(vision_cfg).to("cuda").to(torch.float32).eval()
+        trt_tower = _build_trt_vision_tower(vision_cfg)
+        trt_tower.load_weights(dict(hf_tower.state_dict()))
+
+        B = 3
+        pv_batched, pos_batched, output_length = _make_dummy_pixel_input(vision_cfg, B=B)
+
+        # Path 1 (legacy): per-image loop, B=1 each, then concat.
+        per_image = []
+        with torch.inference_mode():
+            for i in range(B):
+                out_i = trt_tower(
+                    pv_batched[i : i + 1],
+                    pos_batched[i : i + 1],
+                    output_length=output_length,
+                ).last_hidden_state
+                per_image.append(out_i)
+        looped = torch.cat(per_image, dim=0)
+
+        # Path 2 (new): single batched call.
+        with torch.inference_mode():
+            batched = trt_tower(
+                pv_batched, pos_batched, output_length=output_length
+            ).last_hidden_state
+
+        # Shape must match (both flat, N_valid_total = B * output_length when
+        # all images have full validity, as in this dummy input).
+        self.assertEqual(looped.shape, batched.shape)
+        # Values should be byte-equivalent (deterministic FULL attention on
+        # both paths, no cross-image bleed). Allow a small atol for tiny
+        # kernel-order tile reshuffles, but no rtol slack.
+        diff = (looped - batched).abs()
+        self.assertTrue(
+            torch.allclose(looped, batched, atol=1e-4, rtol=0),
+            f"Cross-image batched call diverges from per-image loop: "
+            f"max diff={diff.max().item():.6f} mean diff={diff.mean().item():.6f}",
         )
 
 
@@ -1126,6 +1195,131 @@ class TestGemma4MultimodalE2E(unittest.TestCase):
             runner.test_all()
         finally:
             runner.tearDown()
+
+
+class TestGemma4VisionHeadDimPadding(unittest.TestCase):
+    """Head_dim 72 (26B/31B vision) gets zero-padded to 80 so the trtllm-gen
+    FMHA dispatcher finds a matching cubin (sm100a ships H64/H80/H128/H256/H512;
+    no H72). qkv_proj/o_proj weights pad along the head dim; norm + RoPE run
+    on the unpadded HF channels; the padded last channels stay zero through
+    the kernel and don't contribute to the output (zero × anything = 0 in
+    both QK^T and softmax(QK^T)V).
+
+    Without this padding, vision attention falls into the unfused MHA path
+    (``Fall back to unfused MHA``) with O(B × T²) workspace, OOMing 26B/31B
+    MMMU at LLM-scale ``max_num_requests``.
+    """
+
+    HEAD_DIM_72_CONFIG = {
+        # nh=2, head_dim=72 → hidden_size=144. Small enough to run on CPU/GPU
+        # quickly while exercising the 72→80 padding path.
+        "hidden_size": 144,
+        "intermediate_size": 288,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 2,
+        "head_dim": 72,
+        "hidden_activation": "gelu_pytorch_tanh",
+        "rms_norm_eps": 1e-6,
+        "patch_size": 16,
+        "pooling_kernel_size": 3,
+        "position_embedding_size": 1024,
+        "use_clipped_linears": False,
+        "standardize": True,
+        "model_type": "gemma4_vision",
+    }
+
+    def test_attention_overrides_head_dim_to_80(self):
+        """``Gemma4VisionAttention`` should pad HF head_dim=72 to kernel
+        head_dim=80 at init; qkv_proj weight dim should reflect padded size."""
+        vision_cfg = Gemma4VisionConfig(**self.HEAD_DIM_72_CONFIG)
+        trt_tower = _build_trt_vision_tower(vision_cfg)
+        attn = trt_tower.encoder.layers[0].self_attn
+
+        self.assertEqual(attn.hf_head_dim, 72)
+        self.assertEqual(attn.head_dim, 80)
+        self.assertEqual(attn.head_dim_pad, 8)
+        # qkv_proj fused: q_size + 2*kv_size = nh*80 + 2*nkv*80 = (2 + 2*2)*80 = 480.
+        expected_qkv_out = (
+            vision_cfg.num_attention_heads + 2 * vision_cfg.num_key_value_heads
+        ) * attn.head_dim
+        self.assertEqual(attn.qkv_proj.weight.shape[0], expected_qkv_out)
+        # q_norm operates on unpadded HF head_dim (72).
+        self.assertEqual(attn.q_norm.weight.shape[0], 72)
+
+    def test_attention_no_pad_when_head_dim_supported(self):
+        """Head_dim already in FMHA cubin set (64) → padding is a no-op."""
+        cfg_dict = deepcopy(SMALL_VISION_CONFIG)
+        cfg_dict["head_dim"] = 64
+        cfg_dict["hidden_size"] = 64 * cfg_dict["num_attention_heads"]
+        vision_cfg = Gemma4VisionConfig(**cfg_dict)
+        trt_tower = _build_trt_vision_tower(vision_cfg)
+        attn = trt_tower.encoder.layers[0].self_attn
+
+        self.assertEqual(attn.hf_head_dim, 64)
+        self.assertEqual(attn.head_dim, 64)
+        self.assertEqual(attn.head_dim_pad, 0)
+
+    @torch.no_grad()
+    def test_load_weights_zero_pads_qkv_and_o_proj(self):
+        """Weight load should pad q/k/v_proj (rows) and o_proj (cols) head dim
+        72→80 with zeros; the appended slices must be exactly zero."""
+        vision_cfg = Gemma4VisionConfig(**self.HEAD_DIM_72_CONFIG)
+        hf_tower = HFGemma4VisionModel(vision_cfg).to("cuda").to(torch.float32).eval()
+        trt_tower = _build_trt_vision_tower(vision_cfg)
+        trt_tower.load_weights(dict(hf_tower.state_dict()))
+
+        nh = vision_cfg.num_attention_heads
+        for layer in trt_tower.encoder.layers:
+            qkv_w = layer.self_attn.qkv_proj.weight.data
+            # qkv_proj.weight shape: ((nh + 2*nkv) * 80, hidden_size).
+            # Reshape to (heads_total, 80, hidden); last 8 channels of each
+            # head must be exactly zero (zero-pad from load_weights).
+            heads_total = nh + 2 * vision_cfg.num_key_value_heads
+            qkv_w_3d = qkv_w.view(heads_total, 80, -1)
+            self.assertTrue(
+                torch.all(qkv_w_3d[:, 72:, :] == 0),
+                "qkv_proj.weight last 8 channels per head must be zero (padding)",
+            )
+
+            o_w = layer.self_attn.o_proj.weight.data
+            # o_proj.weight shape: (hidden_size, nh * 80) — pad last 8 cols per head.
+            o_w_3d = o_w.view(-1, nh, 80)
+            self.assertTrue(
+                torch.all(o_w_3d[:, :, 72:] == 0),
+                "o_proj.weight last 8 cols per head must be zero (padding)",
+            )
+
+    @torch.no_grad()
+    def test_forward_parity_head_dim_72(self):
+        """HF ↔ TRT forward parity at head_dim=72 with padding-to-80 dance.
+
+        The zero-pad math is mathematically equivalent to unpadded HF
+        computation: zeros in q/k don't contribute to QK^T, zeros in v
+        produce zero output channels, zeros in o_proj's last columns ignore
+        those zero channels. Same fp32 tolerance as the head_dim=32 parity
+        test (``test_forward_parity_no_clamp``).
+        """
+        vision_cfg = Gemma4VisionConfig(**self.HEAD_DIM_72_CONFIG)
+
+        hf_tower = HFGemma4VisionModel(vision_cfg).to("cuda").to(torch.float32).eval()
+        trt_tower = _build_trt_vision_tower(vision_cfg)
+        trt_tower.load_weights(dict(hf_tower.state_dict()))
+
+        pv, pos, output_length = _make_dummy_pixel_input(vision_cfg)
+        with torch.inference_mode():
+            hf_out = hf_tower(pv, pos, output_length=output_length).last_hidden_state
+            trt_out = trt_tower(pv, pos, output_length=output_length).last_hidden_state
+
+        hf_flat = hf_out.reshape(-1, vision_cfg.hidden_size)
+        self.assertEqual(hf_flat.shape, trt_out.shape)
+        diff = (hf_flat - trt_out).abs()
+        atol, rtol = 5e-2, 5e-2
+        self.assertTrue(
+            torch.allclose(hf_flat, trt_out, atol=atol, rtol=rtol),
+            f"head_dim=72 padded-to-80 diverges from HF: "
+            f"max diff={diff.max().item():.4f} mean diff={diff.mean().item():.4f}",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unittest/_torch/modeling/test_modeling_gemma4.py
+++ b/tests/unittest/_torch/modeling/test_modeling_gemma4.py
@@ -3020,5 +3020,188 @@ class TestGemma4PLEMultimodalGuards(unittest.TestCase):
             )
 
 
+class TestGemma4MMTowerRMSNormConvention(unittest.TestCase):
+    """Regression tests for the audio/vision RMSNorm convention silent bug.
+
+    Symptom (E4B CoVoST audio, jobs 2205710/2206264): BLEU dropped from
+    baseline 24.54 to 1.90 with no NaN, no crash, output dtype/shape unchanged
+    — purely a numerical convention error. Root cause: the inline audio
+    RMSNorm used Gemma3 LLM's ``(1 + w) * x / rms(x)`` formula. HF Gemma4
+    (audio + vision + LLM) uses plain ``w * x / rms(x)``. The fix replaces
+    both towers' RMSNorm with thin adapters inheriting
+    ``transformers.models.gemma4.modeling_gemma4.Gemma4RMSNorm``.
+
+    These tests guard against silent re-introduction of the wrong convention
+    and against drift from the HF implementation.
+    """
+
+    @staticmethod
+    def _rms_normalize(x: torch.Tensor, eps: float) -> torch.Tensor:
+        """Reference ``x / sqrt(mean(x^2) + eps)`` in fp32, cast back."""
+        return (x.float() * torch.rsqrt(x.float().pow(2).mean(dim=-1, keepdim=True) + eps)).to(
+            x.dtype
+        )
+
+    def test_audio_rmsnorm_inherits_from_hf_class(self):
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4RMSNorm as HFRMSNorm
+
+        from tensorrt_llm._torch.models.modeling_gemma4_audio import _Gemma4AudioRMSNorm
+
+        self.assertTrue(issubclass(_Gemma4AudioRMSNorm, HFRMSNorm))
+
+    def test_vision_rmsnorm_inherits_from_hf_class(self):
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4RMSNorm as HFRMSNorm
+
+        from tensorrt_llm._torch.models.modeling_gemma4_vision import _Gemma4VisionRMSNorm
+
+        self.assertTrue(issubclass(_Gemma4VisionRMSNorm, HFRMSNorm))
+
+    def test_audio_rmsnorm_uses_plain_w_not_one_plus_w(self):
+        """With ``weight=ones``, output must equal ``x/rms`` (plain ``w``),
+        NOT ``2*x/rms`` (Gemma3 ``(1+w)`` convention). This is the exact
+        failure mode that produced E4B BLEU=1.90."""
+        from tensorrt_llm._torch.models.modeling_gemma4_audio import _Gemma4AudioRMSNorm
+
+        hidden_size, eps = 16, 1e-6
+        norm = _Gemma4AudioRMSNorm(hidden_size=hidden_size, eps=eps)
+        with torch.no_grad():
+            norm.weight.fill_(1.0)
+        torch.manual_seed(0)
+        x = torch.randn(4, hidden_size)
+        expected_plain = self._rms_normalize(x, eps)
+        got = norm(x)
+        diff_plain = (got.float() - expected_plain.float()).abs().max().item()
+        diff_one_plus_w = (got.float() - 2 * expected_plain.float()).abs().max().item()
+        self.assertLess(
+            diff_plain,
+            1e-5,
+            f"audio RMSNorm should follow plain w*x/rms (max diff vs reference {diff_plain:.3e}); "
+            f"if this fails the implementation may have reverted to Gemma3 LLM's (1+w) variant.",
+        )
+        # Sanity: the wrong convention would produce a ~2x larger output.
+        self.assertGreater(diff_one_plus_w, 1e-2)
+
+    def test_vision_rmsnorm_uses_plain_w_not_one_plus_w(self):
+        from tensorrt_llm._torch.models.modeling_gemma4_vision import _Gemma4VisionRMSNorm
+
+        hidden_size, eps = 16, 1e-6
+        norm = _Gemma4VisionRMSNorm(hidden_size=hidden_size, eps=eps)
+        with torch.no_grad():
+            norm.weight.fill_(1.0)
+        torch.manual_seed(1)
+        x = torch.randn(4, hidden_size)
+        expected_plain = self._rms_normalize(x, eps)
+        got = norm(x)
+        diff = (got.float() - expected_plain.float()).abs().max().item()
+        self.assertLess(diff, 1e-5)
+
+    def test_vision_rmsnorm_weightless_variant_skips_scale(self):
+        """``has_weights=False`` maps to HF ``with_scale=False`` — the
+        ``v_norm`` slot in ``Gemma4VisionAttention``. Output is pure
+        ``x/rms`` regardless of any (non-existent) weight buffer."""
+        from tensorrt_llm._torch.models.modeling_gemma4_vision import _Gemma4VisionRMSNorm
+
+        hidden_size, eps = 16, 1e-6
+        norm = _Gemma4VisionRMSNorm(hidden_size=hidden_size, eps=eps, has_weights=False)
+        torch.manual_seed(2)
+        x = torch.randn(4, hidden_size)
+        expected = self._rms_normalize(x, eps)
+        got = norm(x)
+        self.assertLess((got.float() - expected.float()).abs().max().item(), 1e-5)
+
+    def test_audio_rmsnorm_matches_hf_class_with_same_weights(self):
+        """The adapter must be a behaviourally pure pass-through over HF's
+        ``Gemma4RMSNorm``: same weights → byte-identical output."""
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4RMSNorm as HFRMSNorm
+
+        from tensorrt_llm._torch.models.modeling_gemma4_audio import _Gemma4AudioRMSNorm
+
+        hidden_size, eps = 16, 1e-6
+        adapter = _Gemma4AudioRMSNorm(hidden_size=hidden_size, eps=eps)
+        hf = HFRMSNorm(hidden_size, eps=eps)
+        with torch.no_grad():
+            hf.weight.copy_(adapter.weight)
+        torch.manual_seed(3)
+        x = torch.randn(4, hidden_size)
+        self.assertTrue(torch.equal(adapter(x), hf(x)))
+
+    def test_audio_rmsnorm_dtype_kwarg_casts_weight(self):
+        from tensorrt_llm._torch.models.modeling_gemma4_audio import _Gemma4AudioRMSNorm
+
+        norm = _Gemma4AudioRMSNorm(hidden_size=8, eps=1e-6, dtype=torch.bfloat16)
+        self.assertEqual(norm.weight.dtype, torch.bfloat16)
+
+    def test_vision_rmsnorm_dtype_kwarg_casts_weight(self):
+        from tensorrt_llm._torch.models.modeling_gemma4_vision import _Gemma4VisionRMSNorm
+
+        norm = _Gemma4VisionRMSNorm(hidden_size=8, eps=1e-6, dtype=torch.bfloat16)
+        self.assertEqual(norm.weight.dtype, torch.bfloat16)
+
+    def test_vision_attention_uses_native_rmsnorm_adapter(self):
+        """Structural guard: ``Gemma4VisionAttention.q_norm/k_norm/v_norm``
+        must be instances of the HF-derived adapter, not TRT-LLM's
+        ``RMSNorm`` (which dispatches to flashinfer_rmsnorm and rejects
+        bf16 1152-wide SigLIP inputs)."""
+        import tensorrt_llm._torch.models.modeling_gemma4_vision as mv
+
+        # Static structural check via source — building a real VisionAttention
+        # requires a full SigLip config, but the call sites are simple.
+        src = open(mv.__file__).read()
+        # All q_norm/k_norm/v_norm/*_layernorm constructors should be the adapter.
+        forbidden_constructor = "RMSNorm(hidden_size=vision_config"
+        adapter_constructor = "_Gemma4VisionRMSNorm(hidden_size="
+        self.assertNotIn(
+            forbidden_constructor,
+            src,
+            "Vision tower must not construct TRT-LLM RMSNorm directly "
+            "— it dispatches to flashinfer_rmsnorm which rejects "
+            "bf16/non-contiguous SigLip inputs.",
+        )
+        self.assertIn(adapter_constructor, src)
+
+
+class TestGemma4AudioTowerStructure(unittest.TestCase):
+    """Smoke tests for the native Gemma4 audio tower module.
+
+    Full ``Gemma4AudioModel`` instantiation depends on a complete
+    ``Gemma4AudioConfig`` (mel bins, chunk sizes, conformer params); the
+    end-to-end behavioural check is the E4B CoVoST sbatch (job 2206264,
+    BLEU=24.69 ≥ baseline 24.54). These tests cover the module-level
+    invariants we want to guarantee at unit-test time.
+    """
+
+    def test_audio_module_exports_expected_classes(self):
+        """The native audio tower replaces ``AutoModel.from_config`` — the
+        ``Gemma4AudioModel`` + ``_Gemma4AudioRMSNorm`` symbols are part of
+        the contract with ``modeling_gemma4mm.py``."""
+        from tensorrt_llm._torch.models import modeling_gemma4_audio as ma
+
+        self.assertTrue(hasattr(ma, "Gemma4AudioModel"))
+        self.assertTrue(hasattr(ma, "_Gemma4AudioRMSNorm"))
+        # Audio layer is also referenced by load_weights / probe paths.
+        self.assertTrue(hasattr(ma, "Gemma4AudioLayer"))
+
+    def test_audio_module_does_not_import_trtllm_rmsnorm(self):
+        """The audio tower's RMSNorm path must NOT depend on
+        ``..modules.rms_norm.RMSNorm`` — that's the flashinfer_rmsnorm
+        dispatch site that rejects bf16 wide-channel inputs."""
+        from tensorrt_llm._torch.models import modeling_gemma4_audio as ma
+
+        src = open(ma.__file__).read()
+        self.assertNotIn("from ..modules.rms_norm import RMSNorm", src)
+        # Must import HF Gemma4RMSNorm (under its module-local alias).
+        self.assertIn("Gemma4RMSNorm", src)
+
+    def test_mm_wrapper_wires_native_audio_tower(self):
+        """``Gemma4ForConditionalGeneration`` must instantiate the native
+        ``Gemma4AudioModel`` (not fall back to ``AutoModel.from_config``)."""
+        from tensorrt_llm._torch.models import modeling_gemma4mm as mm
+
+        src = open(mm.__file__).read()
+        self.assertIn("Gemma4AudioModel(audio_model_config)", src)
+        # The previous HF fallback line must be gone.
+        self.assertNotIn("AutoModel.from_config(config.audio_config)", src)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unittest/_torch/modeling/test_modeling_gemma4.py
+++ b/tests/unittest/_torch/modeling/test_modeling_gemma4.py
@@ -3142,22 +3142,32 @@ class TestGemma4MMTowerRMSNormConvention(unittest.TestCase):
         must be instances of the HF-derived adapter, not TRT-LLM's
         ``RMSNorm`` (which dispatches to flashinfer_rmsnorm and rejects
         bf16 1152-wide SigLIP inputs)."""
+        import re
+
         import tensorrt_llm._torch.models.modeling_gemma4_vision as mv
 
         # Static structural check via source — building a real VisionAttention
         # requires a full SigLip config, but the call sites are simple.
         src = open(mv.__file__).read()
         # All q_norm/k_norm/v_norm/*_layernorm constructors should be the adapter.
-        forbidden_constructor = "RMSNorm(hidden_size=vision_config"
-        adapter_constructor = "_Gemma4VisionRMSNorm(hidden_size="
-        self.assertNotIn(
-            forbidden_constructor,
-            src,
+        # Use regex to tolerate the line-wrap that black/yapf inserts after the
+        # opening paren on long multi-arg calls.
+        forbidden_pattern = re.compile(
+            r"(?<!_Gemma4Vision)RMSNorm\s*\(\s*hidden_size=vision_config"
+        )
+        adapter_pattern = re.compile(r"_Gemma4VisionRMSNorm\s*\(\s*hidden_size=")
+        self.assertFalse(
+            forbidden_pattern.search(src),
             "Vision tower must not construct TRT-LLM RMSNorm directly "
             "— it dispatches to flashinfer_rmsnorm which rejects "
             "bf16/non-contiguous SigLip inputs.",
         )
-        self.assertIn(adapter_constructor, src)
+        self.assertTrue(
+            adapter_pattern.search(src),
+            "Vision tower must construct the HF-derived "
+            "``_Gemma4VisionRMSNorm`` adapter for q/k/v norms and "
+            "encoder layer norms.",
+        )
 
 
 class TestGemma4AudioTowerStructure(unittest.TestCase):

--- a/tests/unittest/_torch/modeling/test_modeling_gemma4.py
+++ b/tests/unittest/_torch/modeling/test_modeling_gemma4.py
@@ -3045,25 +3045,25 @@ class TestGemma4MMTowerRMSNormConvention(unittest.TestCase):
     def test_audio_rmsnorm_inherits_from_hf_class(self):
         from transformers.models.gemma4.modeling_gemma4 import Gemma4RMSNorm as HFRMSNorm
 
-        from tensorrt_llm._torch.models.modeling_gemma4_audio import _Gemma4AudioRMSNorm
+        from tensorrt_llm._torch.models.modeling_gemma4_audio import Gemma4AudioRMSNorm
 
-        self.assertTrue(issubclass(_Gemma4AudioRMSNorm, HFRMSNorm))
+        self.assertTrue(issubclass(Gemma4AudioRMSNorm, HFRMSNorm))
 
     def test_vision_rmsnorm_inherits_from_hf_class(self):
         from transformers.models.gemma4.modeling_gemma4 import Gemma4RMSNorm as HFRMSNorm
 
-        from tensorrt_llm._torch.models.modeling_gemma4_vision import _Gemma4VisionRMSNorm
+        from tensorrt_llm._torch.models.modeling_gemma4_vision import Gemma4VisionRMSNorm
 
-        self.assertTrue(issubclass(_Gemma4VisionRMSNorm, HFRMSNorm))
+        self.assertTrue(issubclass(Gemma4VisionRMSNorm, HFRMSNorm))
 
     def test_audio_rmsnorm_uses_plain_w_not_one_plus_w(self):
         """With ``weight=ones``, output must equal ``x/rms`` (plain ``w``),
         NOT ``2*x/rms`` (Gemma3 ``(1+w)`` convention). This is the exact
         failure mode that produced E4B BLEU=1.90."""
-        from tensorrt_llm._torch.models.modeling_gemma4_audio import _Gemma4AudioRMSNorm
+        from tensorrt_llm._torch.models.modeling_gemma4_audio import Gemma4AudioRMSNorm
 
         hidden_size, eps = 16, 1e-6
-        norm = _Gemma4AudioRMSNorm(hidden_size=hidden_size, eps=eps)
+        norm = Gemma4AudioRMSNorm(hidden_size=hidden_size, eps=eps)
         with torch.no_grad():
             norm.weight.fill_(1.0)
         torch.manual_seed(0)
@@ -3082,10 +3082,10 @@ class TestGemma4MMTowerRMSNormConvention(unittest.TestCase):
         self.assertGreater(diff_one_plus_w, 1e-2)
 
     def test_vision_rmsnorm_uses_plain_w_not_one_plus_w(self):
-        from tensorrt_llm._torch.models.modeling_gemma4_vision import _Gemma4VisionRMSNorm
+        from tensorrt_llm._torch.models.modeling_gemma4_vision import Gemma4VisionRMSNorm
 
         hidden_size, eps = 16, 1e-6
-        norm = _Gemma4VisionRMSNorm(hidden_size=hidden_size, eps=eps)
+        norm = Gemma4VisionRMSNorm(hidden_size=hidden_size, eps=eps)
         with torch.no_grad():
             norm.weight.fill_(1.0)
         torch.manual_seed(1)
@@ -3099,10 +3099,10 @@ class TestGemma4MMTowerRMSNormConvention(unittest.TestCase):
         """``has_weights=False`` maps to HF ``with_scale=False`` — the
         ``v_norm`` slot in ``Gemma4VisionAttention``. Output is pure
         ``x/rms`` regardless of any (non-existent) weight buffer."""
-        from tensorrt_llm._torch.models.modeling_gemma4_vision import _Gemma4VisionRMSNorm
+        from tensorrt_llm._torch.models.modeling_gemma4_vision import Gemma4VisionRMSNorm
 
         hidden_size, eps = 16, 1e-6
-        norm = _Gemma4VisionRMSNorm(hidden_size=hidden_size, eps=eps, has_weights=False)
+        norm = Gemma4VisionRMSNorm(hidden_size=hidden_size, eps=eps, has_weights=False)
         torch.manual_seed(2)
         x = torch.randn(4, hidden_size)
         expected = self._rms_normalize(x, eps)
@@ -3114,10 +3114,10 @@ class TestGemma4MMTowerRMSNormConvention(unittest.TestCase):
         ``Gemma4RMSNorm``: same weights → byte-identical output."""
         from transformers.models.gemma4.modeling_gemma4 import Gemma4RMSNorm as HFRMSNorm
 
-        from tensorrt_llm._torch.models.modeling_gemma4_audio import _Gemma4AudioRMSNorm
+        from tensorrt_llm._torch.models.modeling_gemma4_audio import Gemma4AudioRMSNorm
 
         hidden_size, eps = 16, 1e-6
-        adapter = _Gemma4AudioRMSNorm(hidden_size=hidden_size, eps=eps)
+        adapter = Gemma4AudioRMSNorm(hidden_size=hidden_size, eps=eps)
         hf = HFRMSNorm(hidden_size, eps=eps)
         with torch.no_grad():
             hf.weight.copy_(adapter.weight)
@@ -3126,15 +3126,15 @@ class TestGemma4MMTowerRMSNormConvention(unittest.TestCase):
         self.assertTrue(torch.equal(adapter(x), hf(x)))
 
     def test_audio_rmsnorm_dtype_kwarg_casts_weight(self):
-        from tensorrt_llm._torch.models.modeling_gemma4_audio import _Gemma4AudioRMSNorm
+        from tensorrt_llm._torch.models.modeling_gemma4_audio import Gemma4AudioRMSNorm
 
-        norm = _Gemma4AudioRMSNorm(hidden_size=8, eps=1e-6, dtype=torch.bfloat16)
+        norm = Gemma4AudioRMSNorm(hidden_size=8, eps=1e-6, dtype=torch.bfloat16)
         self.assertEqual(norm.weight.dtype, torch.bfloat16)
 
     def test_vision_rmsnorm_dtype_kwarg_casts_weight(self):
-        from tensorrt_llm._torch.models.modeling_gemma4_vision import _Gemma4VisionRMSNorm
+        from tensorrt_llm._torch.models.modeling_gemma4_vision import Gemma4VisionRMSNorm
 
-        norm = _Gemma4VisionRMSNorm(hidden_size=8, eps=1e-6, dtype=torch.bfloat16)
+        norm = Gemma4VisionRMSNorm(hidden_size=8, eps=1e-6, dtype=torch.bfloat16)
         self.assertEqual(norm.weight.dtype, torch.bfloat16)
 
     def test_vision_attention_uses_native_rmsnorm_adapter(self):
@@ -3152,10 +3152,8 @@ class TestGemma4MMTowerRMSNormConvention(unittest.TestCase):
         # All q_norm/k_norm/v_norm/*_layernorm constructors should be the adapter.
         # Use regex to tolerate the line-wrap that black/yapf inserts after the
         # opening paren on long multi-arg calls.
-        forbidden_pattern = re.compile(
-            r"(?<!_Gemma4Vision)RMSNorm\s*\(\s*hidden_size=vision_config"
-        )
-        adapter_pattern = re.compile(r"_Gemma4VisionRMSNorm\s*\(\s*hidden_size=")
+        forbidden_pattern = re.compile(r"(?<!Gemma4Vision)RMSNorm\s*\(\s*hidden_size=vision_config")
+        adapter_pattern = re.compile(r"Gemma4VisionRMSNorm\s*\(\s*hidden_size=")
         self.assertFalse(
             forbidden_pattern.search(src),
             "Vision tower must not construct TRT-LLM RMSNorm directly "
@@ -3165,7 +3163,7 @@ class TestGemma4MMTowerRMSNormConvention(unittest.TestCase):
         self.assertTrue(
             adapter_pattern.search(src),
             "Vision tower must construct the HF-derived "
-            "``_Gemma4VisionRMSNorm`` adapter for q/k/v norms and "
+            "``Gemma4VisionRMSNorm`` adapter for q/k/v norms and "
             "encoder layer norms.",
         )
 
@@ -3182,12 +3180,12 @@ class TestGemma4AudioTowerStructure(unittest.TestCase):
 
     def test_audio_module_exports_expected_classes(self):
         """The native audio tower replaces ``AutoModel.from_config`` — the
-        ``Gemma4AudioModel`` + ``_Gemma4AudioRMSNorm`` symbols are part of
+        ``Gemma4AudioModel`` + ``Gemma4AudioRMSNorm`` symbols are part of
         the contract with ``modeling_gemma4mm.py``."""
         from tensorrt_llm._torch.models import modeling_gemma4_audio as ma
 
         self.assertTrue(hasattr(ma, "Gemma4AudioModel"))
-        self.assertTrue(hasattr(ma, "_Gemma4AudioRMSNorm"))
+        self.assertTrue(hasattr(ma, "Gemma4AudioRMSNorm"))
         # Audio layer is also referenced by load_weights / probe paths.
         self.assertTrue(hasattr(ma, "Gemma4AudioLayer"))
 
@@ -3211,6 +3209,86 @@ class TestGemma4AudioTowerStructure(unittest.TestCase):
         self.assertIn("Gemma4AudioModel(audio_model_config)", src)
         # The previous HF fallback line must be gone.
         self.assertNotIn("AutoModel.from_config(config.audio_config)", src)
+
+
+class TestGemma4VisionCrossImageBatching(unittest.TestCase):
+    """Guards for the cross-image batched vision-tower call path.
+
+    The vision tower's inner ``forward`` already supports ``B>1`` via
+    varlen ``cu_seqlens``. The caller ``_get_image_features`` must feed
+    all images in one call (single ``vision_tower(pixel_values, ...)``
+    invocation), not loop one image at a time. Looping defeats the
+    varlen kernel and forces ``max_num_requests=1`` on the metadata,
+    serialising what should be a batched call.
+    """
+
+    def test_get_image_features_is_single_batched_call(self):
+        """``_get_image_features`` must call ``self.vision_tower`` exactly
+        once per invocation and must not contain a Python-level
+        ``for i in range(pixel_values.shape[0])`` loop.
+
+        Pattern matches LlavaNext / Qwen2VL / Qwen3VL / Nemotron-Nano
+        dynamic-resolution — all of which batch images in a single tower
+        call. Gemma4 was the outlier before this guard."""
+        import re
+
+        from tensorrt_llm._torch.models import modeling_gemma4mm as mm
+
+        src = open(mm.__file__).read()
+        # Locate the function body so we don't match unrelated for-loops elsewhere.
+        match = re.search(
+            r"def _get_image_features\(.*?\)(.*?)(?=\n    def |\nclass )",
+            src,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(
+            match, "Could not locate `_get_image_features` method in modeling_gemma4mm.py"
+        )
+        body = match.group(1)
+        self.assertNotRegex(
+            body,
+            r"for\s+\w+\s+in\s+range\(\s*pixel_values\.shape\[0\]\s*\)",
+            "Vision feature extraction must not loop one image at a time; "
+            "feed all images to ``self.vision_tower`` in a single batched call "
+            "to participate in varlen cu_seqlens attention.",
+        )
+        # Exactly one vision_tower call expected.
+        self.assertEqual(
+            body.count("self.vision_tower("),
+            1,
+            "`_get_image_features` should invoke ``self.vision_tower`` exactly once; "
+            "additional calls indicate the per-image loop has been re-introduced.",
+        )
+
+    def test_vision_attn_metadata_max_num_requests_is_not_one(self):
+        """The vision tower's ``attn_metadata`` was hardcoded to
+        ``max_num_requests=1`` while the caller loop fed one image per
+        forward. After lifting the loop, the bound must accept ``B>1``
+        cross-image batches (capped vision-scale, not LLM-scale, to keep
+        unfused-MHA workspace under control)."""
+        import re
+
+        from tensorrt_llm._torch.models import modeling_gemma4_vision as mv
+
+        src = open(mv.__file__).read()
+        # Find the Gemma4VisionModel.attn_metadata = self.metadata_cls(...) block.
+        m = re.search(
+            r"self\.attn_metadata\s*=\s*self\.metadata_cls\((.*?)\)",
+            src,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(
+            m, "Could not locate ``self.attn_metadata = self.metadata_cls(...)`` in vision tower."
+        )
+        block = m.group(1)
+        # Reject the legacy ``max_num_requests=1,`` literal.
+        self.assertNotRegex(
+            block,
+            r"max_num_requests\s*=\s*1\s*,",
+            "Vision tower ``max_num_requests`` must not be hardcoded to 1 — "
+            "the caller no longer loops per-image, so the metadata must allow "
+            "cross-image batching.",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unittest/_torch/modeling/test_modeling_gemma4.py
+++ b/tests/unittest/_torch/modeling/test_modeling_gemma4.py
@@ -3042,19 +3042,52 @@ class TestGemma4MMTowerRMSNormConvention(unittest.TestCase):
             x.dtype
         )
 
-    def test_audio_rmsnorm_inherits_from_hf_class(self):
-        from transformers.models.gemma4.modeling_gemma4 import Gemma4RMSNorm as HFRMSNorm
+    def test_audio_rmsnorm_does_not_import_hf_class(self):
+        """The audio tower's RMSNorm must be a native re-implementation, NOT
+        a subclass of ``transformers.models.gemma4.Gemma4RMSNorm`` — per the
+        multimodal-onboarding skill, importing
+        ``transformers.models.<family>`` couples the file to a specific HF
+        release and breaks silently on upstream refactors.
+        """
+        import torch.nn as nn
 
+        from tensorrt_llm._torch.models import modeling_gemma4_audio as ma
         from tensorrt_llm._torch.models.modeling_gemma4_audio import Gemma4AudioRMSNorm
 
-        self.assertTrue(issubclass(Gemma4AudioRMSNorm, HFRMSNorm))
+        # Direct ``nn.Module`` subclass, no HF in the MRO.
+        self.assertTrue(issubclass(Gemma4AudioRMSNorm, nn.Module))
+        mro_names = [c.__module__ + "." + c.__name__ for c in Gemma4AudioRMSNorm.__mro__]
+        self.assertFalse(
+            any("transformers.models.gemma4" in name for name in mro_names),
+            f"Gemma4AudioRMSNorm MRO must not include transformers.models.gemma4: {mro_names}",
+        )
+        # Module source must not import the HF RMSNorm class.
+        src = open(ma.__file__).read()
+        self.assertNotIn(
+            "from transformers.models.gemma4",
+            src,
+            "modeling_gemma4_audio.py must not import from transformers.models.gemma4",
+        )
 
-    def test_vision_rmsnorm_inherits_from_hf_class(self):
-        from transformers.models.gemma4.modeling_gemma4 import Gemma4RMSNorm as HFRMSNorm
+    def test_vision_rmsnorm_does_not_import_hf_class(self):
+        """Same as above for the vision tower."""
+        import torch.nn as nn
 
+        from tensorrt_llm._torch.models import modeling_gemma4_vision as mv
         from tensorrt_llm._torch.models.modeling_gemma4_vision import Gemma4VisionRMSNorm
 
-        self.assertTrue(issubclass(Gemma4VisionRMSNorm, HFRMSNorm))
+        self.assertTrue(issubclass(Gemma4VisionRMSNorm, nn.Module))
+        mro_names = [c.__module__ + "." + c.__name__ for c in Gemma4VisionRMSNorm.__mro__]
+        self.assertFalse(
+            any("transformers.models.gemma4" in name for name in mro_names),
+            f"Gemma4VisionRMSNorm MRO must not include transformers.models.gemma4: {mro_names}",
+        )
+        src = open(mv.__file__).read()
+        self.assertNotIn(
+            "from transformers.models.gemma4",
+            src,
+            "modeling_gemma4_vision.py must not import from transformers.models.gemma4",
+        )
 
     def test_audio_rmsnorm_uses_plain_w_not_one_plus_w(self):
         """With ``weight=ones``, output must equal ``x/rms`` (plain ``w``),


### PR DESCRIPTION
  ## Summary                                           
                                                                                                                                                                                                                    
  Per multimedia team's [PR](https://github.com/NVIDIA/TensorRT-LLM/pull/12932) feedback on the initial Gemma4 MM port, this PR replaces the temporary `AutoModel.from_config` HF fallback with **native TensorRT-LLM implementations** of the Gemma4 vision and audio
  (Conformer) towers, so that the multimodal path goes through TRT-LLM's own attention/MLP modules rather than re-entering HuggingFace at runtime.                                                                  
                                                    
  - **Native Gemma4 vision tower** (`modeling_gemma4_vision.py`) — replaces `AutoModel.from_config`; vision attention workspace now bound to the vision scale rather than inheriting the LM-side bound (avoids the  
  5589 GiB resize previously observed on 31B MMMU).         
  - **Native Gemma4 audio Conformer tower** (`modeling_gemma4_audio.py`) — replaces `AutoModel.from_config`; chunked local attention + rel-pos bias ported directly from the HF reference.
  - **HF Gemma4RMSNorm convention fix** (audio + vision) — Gemma4's MM-tower RMSNorm is the plain `w * x / rms`, **not** the Gemma3 LLM-side `(1 + w) * x / rms`. Wiring the correct norm convention is what brings 
  BLEU back into parity (E4B CoVoST2 1.90 → ~41.9 in earlier validation runs).
  - **`modeling_gemma4mm.py`** updated to import the native towers instead of the HF fallback.                                                                                                                      
  - **Test suite** `tests/unittest/_torch/multimodal/test_gemma4_multimodal.py` registered in `l0_b200.yml`, covering Tier 0/1/2 vision-tower parity plus the new RMSNorm regression tests.
  - Debug probes used during the port (`DEBUG_AUDIO_TOWER` env-gated stats) have been scrubbed before this commit; only Signed-off-by trailers in the history.                                                      
                                                                                                                                                                                                                    
  ## Alignment with HF tower baseline                       
                                                                                                                                                                                                                    
  The fix-mode (native towers) results have been **aligned with the HF-fallback baseline**. All completed fix-mode cells so far are within ±2pp of the HF baseline (well inside MMMU/CoVoST seed noise):                                                                                                                                         
                                                                                                                                                                                                                    
  | variant | task   | HF baseline | native fix | Δ      |                                                                                                                                                          
  |---------|--------|-------------|------------|--------|                                                                                                                                                          
  | E2B     | mmmu   | 42.67       | 42.11      | −0.56  |                                                                                                                                                          
  | E2B     | covost | 37.70 BLEU  | 37.78 BLEU | +0.08  |                                                                                                                                                          
  | E4B     | covost | 41.91 BLEU  | 41.91 BLEU | exact  |                                                                                                                                                          
  | 26B     | mmmu   | 58.33       | 58.56      | +0.23  |  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added native audio and vision tower implementations for Gemma4 multimodal model, replacing previous placeholder approach with optimized TensorRT-LLM components.

* **Tests**
  * Expanded test coverage for multimodal audio/vision components, including forward pass validation, weight loading parity, and end-to-end generation testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->