### PR TITLE
[None][perf] Fuse sigmoid+mul+add shared-expert combine into one Trit…

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_qwen3_next.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_next.py
@@ -24,12 +24,13 @@ import torch
 if TYPE_CHECKING:
     from tensorrt_llm.llmapi.llm_args import TorchLlmArgs
 
-import torch.nn.functional as F
 from torch import nn
 from transformers import Qwen3NextConfig
 
 from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import \
     BaseWeightMapper
+from tensorrt_llm._torch.modules.fused_shared_expert import \
+    fused_sigmoid_gate_mul_add
 from tensorrt_llm._torch.modules.mamba.mamba2_metadata import Mamba2Metadata
 from tensorrt_llm._torch.pyexecutor.config_utils import \
     get_qwen3_hybrid_layer_types
@@ -38,7 +39,7 @@ from tensorrt_llm._utils import get_sm_version
 from ...logger import logger
 from ..attention_backend import AttentionMetadata
 from ..distributed import (AllReduce, AllReduceFusionOp, AllReduceParams,
-                           MoEAllReduce, MoEAllReduceParams)
+                           MoEAllReduce, MoEAllReduceParams, allgather)
 from ..model_config import ModelConfig
 from ..modules.decoder_layer import DecoderLayer
 from ..modules.embedding import Embedding
@@ -223,11 +224,10 @@ class Qwen3NextSparseMoeBlock(nn.Module):
                 hidden_states,
                 lora_params=lora_params,
             )
-            shared_expert_output = F.sigmoid(
-                self.shared_expert_gate(hidden_states)) * shared_expert_output
-            return shared_expert_output
+            shared_expert_gate_logits = self.shared_expert_gate(hidden_states)
+            return shared_expert_output, shared_expert_gate_logits
 
-        final_hidden_states, shared_expert_output = maybe_execute_in_parallel(
+        final_hidden_states, shared_expert_outputs = maybe_execute_in_parallel(
             _compute_routed_output,
             _compute_shared_output,
             self.event_dict[EventType.Main],
@@ -238,22 +238,23 @@ class Qwen3NextSparseMoeBlock(nn.Module):
         if not do_finalize:
             return final_hidden_states
 
+        shared_expert_output, shared_expert_gate_logits = shared_expert_outputs
         if not self.enable_attention_dp and self.mapping.tp_size > 1:
-            if isinstance(shared_expert_output, torch.Tensor):
-                output_tensor, _ = torch.ops.trtllm.allocate_output(
-                    final_hidden_states, self.allreduce.output_buffer_kind,
-                    self.mapping.tp_group)
-                final_hidden_states = torch.add(
-                    final_hidden_states,
-                    shared_expert_output,
-                    out=output_tensor,
-                )
-            else:
-                final_hidden_states = final_hidden_states + shared_expert_output
+            output_tensor, _ = torch.ops.trtllm.allocate_output(
+                final_hidden_states, self.allreduce.output_buffer_kind,
+                self.mapping.tp_group)
+            final_hidden_states = fused_sigmoid_gate_mul_add(
+                final_hidden_states,
+                shared_expert_gate_logits,
+                shared_expert_output,
+                output=output_tensor,
+            )
             final_hidden_states = self.allreduce(
                 final_hidden_states, all_reduce_params=all_reduce_params)
         else:
-            final_hidden_states = final_hidden_states + shared_expert_output
+            final_hidden_states = fused_sigmoid_gate_mul_add(
+                final_hidden_states, shared_expert_gate_logits,
+                shared_expert_output)
         return final_hidden_states.view(orig_shape)
 
 

--- a/tensorrt_llm/_torch/modules/fused_shared_expert.py
+++ b/tensorrt_llm/_torch/modules/fused_shared_expert.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fused shared-expert output combine for Qwen3-Next style MoE blocks.
+
+The model originally computes (per-token):
+
+    y = F.sigmoid(gate_proj(x)) * shared_expert(x)
+    final_hidden_states = final_hidden_states + y
+
+which produces three separate pointwise kernels (sigmoid, broadcast-mul, add)
+in a PyTorch trace. This module provides a single Triton kernel that fuses
+all three into one pass, writing into an optional output buffer or updating
+`final_hidden_states` in-place.
+"""
+
+import torch
+import triton  # type: ignore[import]
+import triton.language as tl  # type: ignore[import]
+
+
+@triton.jit
+def _sigmoid_gate_mul_add_kernel(
+    out_ptr,
+    final_ptr,
+    shared_ptr,
+    gate_ptr,
+    out_stride_row,
+    final_stride_row,
+    shared_stride_row,
+    HIDDEN: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    row = tl.program_id(axis=0).to(tl.int64)
+    col_block = tl.program_id(axis=1)
+
+    # Per-row gate scalar, sigmoid applied in fp32 for precision.
+    g = tl.load(gate_ptr + row).to(tl.float32)
+    s = tl.sigmoid(g)
+
+    out_base = row * out_stride_row
+    final_base = row * final_stride_row
+    shared_base = row * shared_stride_row
+    offsets = col_block * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < HIDDEN
+    # `final` and `shared` are read once and never reused — evict from L2 early
+    # to keep room for surrounding allreduce / attention tiles.
+    f = tl.load(final_ptr + final_base + offsets, mask=mask, eviction_policy="evict_first").to(
+        tl.float32
+    )
+    sh = tl.load(shared_ptr + shared_base + offsets, mask=mask, eviction_policy="evict_first").to(
+        tl.float32
+    )
+    result = f + s * sh
+    tl.store(out_ptr + out_base + offsets, result.to(out_ptr.dtype.element_ty), mask=mask)
+
+
+def fused_sigmoid_gate_mul_add(
+    final_hidden_states: torch.Tensor,
+    gate_logits: torch.Tensor,
+    shared_expert_output: torch.Tensor,
+    output: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute final + sigmoid(gate) * shared with one Triton kernel.
+
+    Args:
+        final_hidden_states: [num_tokens, hidden].
+        gate_logits: [num_tokens, 1] or [num_tokens] per-token scalar (pre-sigmoid).
+        shared_expert_output: [num_tokens, hidden], same dtype as final_hidden_states.
+        output: Optional output buffer. If omitted, final_hidden_states is updated in-place.
+
+    Returns:
+        The output tensor.
+    """
+    assert final_hidden_states.dim() == 2, (
+        f"final_hidden_states must be 2D, got {final_hidden_states.shape}"
+    )
+    assert shared_expert_output.shape == final_hidden_states.shape, (
+        f"shape mismatch: final={final_hidden_states.shape} shared={shared_expert_output.shape}"
+    )
+    assert final_hidden_states.dtype == shared_expert_output.dtype, (
+        f"dtype mismatch: final={final_hidden_states.dtype} shared={shared_expert_output.dtype}"
+    )
+    num_tokens = final_hidden_states.shape[0]
+    assert gate_logits.numel() == num_tokens, (
+        f"gate numel {gate_logits.numel()} must match num_tokens {num_tokens}"
+    )
+    if output is None:
+        output = final_hidden_states
+    else:
+        assert output.shape == final_hidden_states.shape, (
+            f"output shape mismatch: output={output.shape} final={final_hidden_states.shape}"
+        )
+        assert output.dtype == final_hidden_states.dtype, (
+            f"output dtype mismatch: output={output.dtype} final={final_hidden_states.dtype}"
+        )
+
+    if num_tokens == 0:
+        return output
+
+    # The kernel only requires the last dimension to be contiguous (stride==1).
+    # `allocate_output` may return symmetric-heap buffers whose row stride is
+    # padded beyond `hidden`, so do NOT require fully-contiguous tensors.
+    assert output.stride(-1) == 1, (
+        f"output last-dim must be contiguous, got stride={output.stride()}"
+    )
+    if final_hidden_states.stride(-1) != 1:
+        final_hidden_states = final_hidden_states.contiguous()
+    if shared_expert_output.stride(-1) != 1:
+        shared_expert_output = shared_expert_output.contiguous()
+    # Make gate dense before reshape — reshape may fail on non-contig tensors.
+    gate_flat = gate_logits.contiguous().reshape(-1)
+
+    num_tokens, hidden = final_hidden_states.shape
+    # Prefer a single program per row when hidden fits in one block (avoids
+    # redundant per-block gate loads and reduces launch grid). Cap at 8192 so
+    # we don't hit Triton's per-program register pressure for huge hiddens.
+    MAX_BLOCK = 8192
+    BLOCK_SIZE = min(triton.next_power_of_2(hidden), MAX_BLOCK)
+    BLOCK_SIZE = max(BLOCK_SIZE, 16)  # Triton requires power-of-2 >= 16
+    num_col_blocks = triton.cdiv(hidden, BLOCK_SIZE)
+
+    # Memory-bound pointwise — more warps improves coalesced bandwidth.
+    if BLOCK_SIZE >= 4096:
+        num_warps = 8
+    elif BLOCK_SIZE >= 1024:
+        num_warps = 4
+    else:
+        num_warps = 2
+
+    _sigmoid_gate_mul_add_kernel[(num_tokens, num_col_blocks)](
+        output,
+        final_hidden_states,
+        shared_expert_output,
+        gate_flat,
+        output.stride(0),
+        final_hidden_states.stride(0),
+        shared_expert_output.stride(0),
+        HIDDEN=hidden,
+        BLOCK_SIZE=BLOCK_SIZE,
+        num_warps=num_warps,
+        num_stages=3,
+    )
+    return output

--- a/tests/unittest/_torch/modules/test_fused_shared_expert.py
+++ b/tests/unittest/_torch/modules/test_fused_shared_expert.py
@@ -1,0 +1,218 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for fused_sigmoid_gate_mul_add Triton kernel.
+
+Covers the shape and dtype combinations actually used by Qwen3-Next /
+Qwen3.5 MoE blocks, and a few edge cases (num_tokens=1, hidden not a
+multiple of BLOCK_SIZE).
+"""
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.modules.fused_shared_expert import fused_sigmoid_gate_mul_add
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+def _reference(
+    final_hidden_states: torch.Tensor, gate_logits: torch.Tensor, shared_expert_output: torch.Tensor
+) -> torch.Tensor:
+    # Reference in fp32 to match the kernel's internal compute precision,
+    # then cast back to the I/O dtype.
+    gate_bcast = gate_logits.reshape(-1, 1).to(torch.float32)
+    s = torch.sigmoid(gate_bcast)
+    out = final_hidden_states.to(torch.float32) + s * shared_expert_output.to(torch.float32)
+    return out.to(final_hidden_states.dtype)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 2, 16, 64, 256])
+@pytest.mark.parametrize("hidden", [2048, 4096, 8192])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+@pytest.mark.parametrize("gate_shape_is_2d", [True, False])
+def test_fused_sigmoid_gate_mul_add(num_tokens, hidden, dtype, gate_shape_is_2d):
+    torch.manual_seed(42)
+    device = "cuda"
+
+    final = torch.randn(num_tokens, hidden, dtype=dtype, device=device)
+    shared = torch.randn(num_tokens, hidden, dtype=dtype, device=device)
+    if gate_shape_is_2d:
+        gate = torch.randn(num_tokens, 1, dtype=dtype, device=device)
+    else:
+        gate = torch.randn(num_tokens, dtype=dtype, device=device)
+
+    expected = _reference(final, gate, shared)
+
+    out = fused_sigmoid_gate_mul_add(final.clone(), gate, shared)
+
+    assert out.shape == final.shape
+    assert out.dtype == final.dtype
+
+    if dtype == torch.float32:
+        atol, rtol = 1e-5, 1e-5
+    else:  # bfloat16 / float16
+        atol, rtol = 2e-2, 2e-2
+    torch.testing.assert_close(out, expected, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize("hidden", [1, 7, 63, 1023, 1025, 3000])
+def test_fused_sigmoid_gate_mul_add_hidden_edge_cases(hidden):
+    """Hidden dims that are not multiples of the inner block must still work."""
+    torch.manual_seed(0)
+    num_tokens = 8
+    dtype = torch.bfloat16
+    device = "cuda"
+
+    final = torch.randn(num_tokens, hidden, dtype=dtype, device=device)
+    gate = torch.randn(num_tokens, 1, dtype=dtype, device=device)
+    shared = torch.randn(num_tokens, hidden, dtype=dtype, device=device)
+
+    expected = _reference(final, gate, shared)
+    out = fused_sigmoid_gate_mul_add(final.clone(), gate, shared)
+    torch.testing.assert_close(out, expected, atol=2e-2, rtol=2e-2)
+
+
+def test_fused_sigmoid_gate_mul_add_in_place_semantics():
+    """The kernel writes in-place to final_hidden_states; verify aliasing."""
+    torch.manual_seed(0)
+    num_tokens, hidden = 32, 4096
+    dtype = torch.bfloat16
+    device = "cuda"
+
+    final = torch.randn(num_tokens, hidden, dtype=dtype, device=device)
+    gate = torch.randn(num_tokens, 1, dtype=dtype, device=device)
+    shared = torch.randn(num_tokens, hidden, dtype=dtype, device=device)
+
+    expected = _reference(final, gate, shared)
+
+    # Returned tensor must be the same storage as the input.
+    final_orig = final
+    out = fused_sigmoid_gate_mul_add(final, gate, shared)
+    assert out.data_ptr() == final_orig.data_ptr(), (
+        "fused_sigmoid_gate_mul_add should update final_hidden_states in-place"
+    )
+    torch.testing.assert_close(out, expected, atol=2e-2, rtol=2e-2)
+
+
+def test_fused_sigmoid_gate_mul_add_output_buffer():
+    torch.manual_seed(0)
+    num_tokens, hidden = 32, 4096
+    dtype = torch.bfloat16
+    device = "cuda"
+
+    final = torch.randn(num_tokens, hidden, dtype=dtype, device=device)
+    gate = torch.randn(num_tokens, 1, dtype=dtype, device=device)
+    shared = torch.randn(num_tokens, hidden, dtype=dtype, device=device)
+    output = torch.empty_like(final)
+
+    expected = _reference(final, gate, shared)
+    out = fused_sigmoid_gate_mul_add(final, gate, shared, output=output)
+
+    assert out.data_ptr() == output.data_ptr()
+    torch.testing.assert_close(out, expected, atol=2e-2, rtol=2e-2)
+
+
+def test_fused_sigmoid_gate_mul_add_qwen35_shape():
+    """Exact shape used on Qwen3.5-397B ADP4 1k/1k (hidden=4096, B=64)."""
+    torch.manual_seed(0)
+    num_tokens, hidden = 64, 4096
+    dtype = torch.bfloat16
+    device = "cuda"
+
+    final = torch.randn(num_tokens, hidden, dtype=dtype, device=device)
+    gate = torch.randn(num_tokens, 1, dtype=dtype, device=device)
+    shared = torch.randn(num_tokens, hidden, dtype=dtype, device=device)
+
+    expected = _reference(final, gate, shared)
+    out = fused_sigmoid_gate_mul_add(final.clone(), gate, shared)
+    torch.testing.assert_close(out, expected, atol=2e-2, rtol=2e-2)
+
+
+def test_fused_sigmoid_gate_mul_add_non_contig_output():
+    # Simulates allocate_output's symmetric-heap buffer: stride(-1)==1 but
+    # row stride padded beyond hidden. The kernel must honor stride(0) and
+    # the wrapper must not require full contiguity on the output tensor.
+    torch.manual_seed(0)
+    num_tokens, hidden = 32, 4096
+    dtype = torch.bfloat16
+    device = "cuda"
+
+    padded = torch.empty(num_tokens, hidden + 64, dtype=dtype, device=device)
+    output = padded[:, :hidden]
+    assert output.stride(-1) == 1 and output.stride(0) > hidden
+    assert not output.is_contiguous()
+
+    final = torch.randn(num_tokens, hidden, dtype=dtype, device=device)
+    gate = torch.randn(num_tokens, 1, dtype=dtype, device=device)
+    shared = torch.randn(num_tokens, hidden, dtype=dtype, device=device)
+
+    expected = _reference(final, gate, shared)
+    out = fused_sigmoid_gate_mul_add(final, gate, shared, output=output)
+    assert out.data_ptr() == output.data_ptr()
+    torch.testing.assert_close(out, expected, atol=2e-2, rtol=2e-2)
+
+
+def test_fused_sigmoid_gate_mul_add_zero_tokens():
+    # Early-return path: num_tokens == 0 must not launch the kernel.
+    dtype = torch.bfloat16
+    device = "cuda"
+    final = torch.empty(0, 4096, dtype=dtype, device=device)
+    gate = torch.empty(0, 1, dtype=dtype, device=device)
+    shared = torch.empty(0, 4096, dtype=dtype, device=device)
+
+    out = fused_sigmoid_gate_mul_add(final, gate, shared)
+    assert out.shape == final.shape
+    assert out.dtype == final.dtype
+
+
+def test_fused_sigmoid_gate_mul_add_empty_strided_output():
+    # Same intent as the slice-based test, but uses empty_strided directly so
+    # the contract — "output may have stride(0) > hidden with stride(-1) == 1" —
+    # is expressed without relying on slicing semantics.
+    torch.manual_seed(0)
+    num_tokens, hidden = 32, 4096
+    dtype = torch.bfloat16
+    device = "cuda"
+
+    row_stride = hidden + 128
+    output = torch.empty_strided((num_tokens, hidden), (row_stride, 1), dtype=dtype, device=device)
+    assert output.stride() == (row_stride, 1)
+    assert not output.is_contiguous()
+
+    final = torch.randn(num_tokens, hidden, dtype=dtype, device=device)
+    gate = torch.randn(num_tokens, 1, dtype=dtype, device=device)
+    shared = torch.randn(num_tokens, hidden, dtype=dtype, device=device)
+
+    expected = _reference(final, gate, shared)
+    out = fused_sigmoid_gate_mul_add(final, gate, shared, output=output)
+    assert out.data_ptr() == output.data_ptr()
+    torch.testing.assert_close(out, expected, atol=2e-2, rtol=2e-2)
+
+
+def test_fused_sigmoid_gate_mul_add_large_hidden_multi_block():
+    # hidden > MAX_BLOCK (8192) — exercises num_col_blocks > 1 path.
+    torch.manual_seed(0)
+    num_tokens, hidden = 4, 12288
+    dtype = torch.bfloat16
+    device = "cuda"
+
+    final = torch.randn(num_tokens, hidden, dtype=dtype, device=device)
+    gate = torch.randn(num_tokens, 1, dtype=dtype, device=device)
+    shared = torch.randn(num_tokens, hidden, dtype=dtype, device=device)
+
+    expected = _reference(final, gate, shared)
+    out = fused_sigmoid_gate_mul_add(final.clone(), gate, shared)
+    torch.testing.assert_close(out, expected, atol=2e-2, rtol=2e-2)


### PR DESCRIPTION
…on kernel for qwen3.5

Replaces the three pointwise kernels used to combine the shared-expert
output back into the routed-expert output of Qwen3-Next / Qwen3.5 MoE
blocks with a single Triton kernel.

End-to-end serving impact (Qwen3.5-397B-A17B-NVFP4, 4x B300, TP=4 EP=4,
enable_attention_dp=true, max_seq_len=10240, trtllm-serve + benchmark_
serving, random ids, ignore-eos):

  ISL/OSL | bs  | Total tok/s         | TPOT mean (ms)
  --------+-----+---------------------+-------------------------
  1k/1k   | 256 | 19061 -> 19366 (+1.6%) | 25.12 -> 24.77 (-1.4%)
  1k/1k   |  32 |  3754 ->  3869 (+3.1%) | 16.54 -> 16.09 (-2.7%)
  8k/1k   | 256 | 49899 -> 50749 (+1.7%) | 39.28 -> 38.65 (-1.6%)
  8k/1k   |  32 | 14777 -> 15126 (+2.4%) | 18.07 -> 17.64 (-2.4%)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized Qwen3Next mixture-of-experts gating mechanism for improved inference performance through fused kernel operations.

* **Tests**
  * Added comprehensive unit tests validating shared-expert gating across diverse tensor shapes, data types, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->