### PR TITLE
[None][fix] cold-start warmup for KV-aware ADP router

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -23,7 +23,7 @@ import random
 from abc import ABC, abstractmethod
 from collections import namedtuple
 from dataclasses import MISSING, astuple, dataclass, field, fields, replace
-from typing import TYPE_CHECKING, Dict, List, Tuple
+from typing import TYPE_CHECKING, Dict, List, Set, Tuple
 
 from tensorrt_llm.logger import logger
 
@@ -450,6 +450,9 @@ class KVCacheAwareADPRouter(ADPRouter):
         self.match_rate_threshold = match_rate_threshold
         self.fair_share_multiplier = fair_share_multiplier
         self._all_ranks_prefix_matches: List[Dict[int, int]] = []
+        # Cold-start warmup: ranks not yet targeted through this router.
+        # See ``route_requests``.
+        self._pending_warmup_ranks: Set[int] = set(range(self.dist.tp_size))
         # Requests still sending KV to GEN are invisible in active_requests;
         # fold them back in via the transfer manager (see create_rank_state).
         self.async_transfer_manager = async_transfer_manager
@@ -580,25 +583,37 @@ class KVCacheAwareADPRouter(ADPRouter):
 
         sorted_requests = sorted(new_requests, key=get_relax_value)
 
+        # Strict ``attention_dp_rank`` is honoured first; relaxed requests
+        # fall back to the smallest unwarmed rank until every rank has been
+        # targeted, seeding the shared system prompt before scoring would
+        # otherwise pin all traffic to the first warm rank.
         remaining_unscheduled = []
         for req_item in sorted_requests:
             scheduled = False
+            target_dp_rank = None
             scheduling_params = getattr(req_item.request, "py_scheduling_params", None)
             if scheduling_params is not None:
                 target_dp_rank = scheduling_params.attention_dp_rank
-                if (
-                    target_dp_rank is not None
-                    and all_ranks_num_active_requests[target_dp_rank] < max_num_active_requests
-                ):
-                    all_ranks_num_active_requests[target_dp_rank] += 1
-                    # Keep token tally in sync with the soft-balancing phase.
-                    effective = max(
-                        self._req_tokens(req_item) - self._match_len(target_dp_rank, req_item.id),
-                        0,
-                    )
-                    all_ranks_num_active_tokens[target_dp_rank] += effective
-                    scheduled = True
-                    all_ranks_new_requests[target_dp_rank].append(req_item)
+            if target_dp_rank is None and self._pending_warmup_ranks:
+                # Smallest-first: deterministic across DP ranks.
+                target_dp_rank = min(self._pending_warmup_ranks)
+            if (
+                target_dp_rank is not None
+                and all_ranks_num_active_requests[target_dp_rank] < max_num_active_requests
+            ):
+                all_ranks_num_active_requests[target_dp_rank] += 1
+                # Keep token tally in sync with the soft-balancing phase.
+                effective = max(
+                    self._req_tokens(req_item) - self._match_len(target_dp_rank, req_item.id),
+                    0,
+                )
+                all_ranks_num_active_tokens[target_dp_rank] += effective
+                scheduled = True
+                all_ranks_new_requests[target_dp_rank].append(req_item)
+            # Any targeted rank counts as warmed; cap-saturation also
+            # discards to avoid the synthesiser looping on a busy rank.
+            if target_dp_rank is not None:
+                self._pending_warmup_ranks.discard(target_dp_rank)
 
             if not scheduled:
                 remaining_unscheduled.append(req_item)

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -190,6 +190,7 @@ class ADPRouter(ABC):
                 load_balance_weight=attention_dp_config.kv_cache_routing_load_balance_weight,
                 match_rate_threshold=attention_dp_config.kv_cache_routing_match_rate_threshold,
                 fair_share_multiplier=attention_dp_config.kv_cache_routing_fair_share_multiplier,
+                cold_start_warmup=attention_dp_config.kv_cache_routing_cold_start_warmup,
                 async_transfer_manager=async_transfer_manager,
             )
 
@@ -442,6 +443,7 @@ class KVCacheAwareADPRouter(ADPRouter):
         load_balance_weight: float = 1.0,
         match_rate_threshold: float = 0.1,
         fair_share_multiplier: float = 2.0,
+        cold_start_warmup: bool = False,
         async_transfer_manager=None,
     ):
         super().__init__(dist)
@@ -451,8 +453,10 @@ class KVCacheAwareADPRouter(ADPRouter):
         self.fair_share_multiplier = fair_share_multiplier
         self._all_ranks_prefix_matches: List[Dict[int, int]] = []
         # Cold-start warmup: ranks not yet targeted through this router.
-        # See ``route_requests``.
-        self._pending_warmup_ranks: Set[int] = set(range(self.dist.tp_size))
+        # Empty set disables warmup; see ``route_requests``.
+        self._pending_warmup_ranks: Set[int] = (
+            set(range(self.dist.tp_size)) if cold_start_warmup else set()
+        )
         # Requests still sending KV to GEN are invisible in active_requests;
         # fold them back in via the transfer manager (see create_rank_state).
         self.async_transfer_manager = async_transfer_manager

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -455,7 +455,7 @@ class KVCacheAwareADPRouter(ADPRouter):
         # Cold-start warmup: ranks not yet targeted through this router.
         # Empty set disables warmup; see ``route_requests``.
         self._pending_warmup_ranks: Set[int] = (
-            set(range(self.dist.tp_size)) if cold_start_warmup else set()
+            set(range(self.dist.mapping.dp_size)) if cold_start_warmup else set()
         )
         # Requests still sending KV to GEN are invisible in active_requests;
         # fold them back in via the transfer manager (see create_rank_state).
@@ -614,9 +614,8 @@ class KVCacheAwareADPRouter(ADPRouter):
                 all_ranks_num_active_tokens[target_dp_rank] += effective
                 scheduled = True
                 all_ranks_new_requests[target_dp_rank].append(req_item)
-            # Any targeted rank counts as warmed; cap-saturation also
-            # discards to avoid the synthesiser looping on a busy rank.
-            if target_dp_rank is not None:
+                # Only mark a rank as warmed once a request actually landed
+                # there; saturated picks stay pending for a later call.
                 self._pending_warmup_ranks.discard(target_dp_rank)
 
             if not scheduled:

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -107,9 +107,7 @@ def Field(default: Any = ...,
 
 
 class CudaGraphConfig(StrictBaseModel):
-    """
-    Configuration for CUDA graphs.
-    """
+    """Configuration for CUDA graphs."""
     # List of batch sizes to create CUDA graphs for.
     batch_sizes: Optional[List[int]] = Field(
         default=None,
@@ -253,9 +251,7 @@ class GuidedDecodingConfig(StrictBaseModel):
 
 
 class BaseSparseAttentionConfig(StrictBaseModel):
-    """
-    Configuration for sparse attention.
-    """
+    """Configuration for sparse attention."""
     algorithm: str
 
     seq_len_threshold: Optional[int] = Field(
@@ -285,9 +281,7 @@ class BaseSparseAttentionConfig(StrictBaseModel):
 
 
 class RocketSparseAttentionConfig(BaseSparseAttentionConfig):
-    """
-    Configuration for RocketKV sparse attention.
-    """
+    """Configuration for RocketKV sparse attention."""
     algorithm: Literal["rocket"] = "rocket"
     window_size: Optional[int] = Field(
         default=32, description="The window size for RocketKV.")
@@ -312,9 +306,7 @@ class RocketSparseAttentionConfig(BaseSparseAttentionConfig):
 
 
 class DeepSeekSparseAttentionConfig(BaseSparseAttentionConfig):
-    """
-    Configuration for DeepSeek Sparse Attention.
-    """
+    """Configuration for DeepSeek Sparse Attention."""
     algorithm: Literal["dsa"] = "dsa"
     index_n_heads: Optional[int] = Field(
         default=None, description="The number of heads for the indexer.")
@@ -405,9 +397,7 @@ class DeepSeekSparseAttentionConfig(BaseSparseAttentionConfig):
 
 
 class SkipSoftmaxAttentionConfig(BaseSparseAttentionConfig):
-    """
-    Configuration for skip softmax attention.
-    """
+    """Configuration for skip softmax attention."""
     algorithm: Literal["skip_softmax"] = "skip_softmax"
     threshold_scale_factor: Optional[Union[float, Dict[str, float]]] = Field(
         default=None,
@@ -563,9 +553,7 @@ class MoeLoadBalancerConfig(StrictBaseModel):
 
     def get_layer_initial_global_assignments(
             self, layer_idx: int) -> Optional[List[int]]:
-        """
-        Retrieves the initial global assignments for a specific layer.
-        """
+        """Retrieves the initial global assignments for a specific layer."""
         if self.initial_global_assignments is None:
             return None
 
@@ -589,9 +577,7 @@ class MoeLoadBalancerConfig(StrictBaseModel):
 
 
 class MoeConfig(StrictBaseModel):
-    """
-    Configuration for MoE.
-    """
+    """Configuration for MoE."""
     backend: Literal[
         "AUTO", "CUTLASS", "CUTEDSL", "WIDEEP", "TRTLLM", "DEEPGEMM",
         "DENSEGEMM", "VANILLA", "TRITON"] = Field(
@@ -634,9 +620,7 @@ TOKENIZER_ALIASES = {
 
 
 class Nvfp4GemmConfig(StrictBaseModel):
-    """
-    Configuration for NVFP4 GEMM backend selection.
-    """
+    """Configuration for NVFP4 GEMM backend selection."""
     allowed_backends: List[Nvfp4Backend] = Field(
         default_factory=lambda: ['cutlass', 'cublaslt', 'cuda_core'],
         min_length=1,
@@ -647,9 +631,7 @@ class Nvfp4GemmConfig(StrictBaseModel):
 
 
 class AttentionDpConfig(StrictBaseModel):
-    """
-    Configuration for attention DP.
-    """
+    """Configuration for attention DP."""
     enable_balance: bool = Field(default=False,
                                  description="Whether to enable balance.")
     timeout_iters: int = Field(
@@ -720,9 +702,7 @@ class AttentionDpConfig(StrictBaseModel):
 
 
 class CpConfig(StrictBaseModel):
-    """
-    Configuration for context parallelism.
-    """
+    """Configuration for context parallelism."""
     # TODO: given that multiple fields here are only used with specific cp_types, consider
     # making this a Pydantic discriminated union.
     cp_type: CpType = Field(default=CpType.ULYSSES,
@@ -828,9 +808,7 @@ class _ParallelConfig(StrictBaseModel):
 
 
 class CalibConfig(StrictBaseModel):
-    """
-    Calibration configuration.
-    """
+    """Calibration configuration."""
     device: Literal['cuda',
                     'cpu'] = Field(default='cuda',
                                    description="The device to run calibration.")
@@ -1110,9 +1088,7 @@ class KvCacheConnectorConfig(StrictBaseModel):
 
 
 class LayerwiseBenchmarksConfig(StrictBaseModel):
-    """
-    Configuration for layer-wise benchmarks calibration.
-    """
+    """Configuration for layer-wise benchmarks calibration."""
     calibration_mode: Literal["NONE", "MARK", "COLLECT"] = Field(
         default="NONE",
         description=
@@ -1496,9 +1472,7 @@ class UserProvidedDecodingConfig(DecodingBaseConfig):
 
 
 class NGramDecodingConfig(DecodingBaseConfig):
-    """
-    Configuration for NGram drafter speculative decoding.
-    """
+    """Configuration for NGram drafter speculative decoding."""
     decoding_type: Literal["NGram"] = "NGram"
     max_matching_ngram_size: PositiveInt = Field(
         default=2,
@@ -2020,8 +1994,7 @@ class ExecutorMemoryType(StrEnum):
 
 @dataclass
 class _SleepConfigDefaultFactory:
-    """Picklable replacement for ``lambda: default_mode`` in SleepConfig's defaultdict.
-    """
+    """Picklable replacement for ``lambda: default_mode`` in SleepConfig's defaultdict."""
 
     default_mode: Any
 
@@ -2030,8 +2003,7 @@ class _SleepConfigDefaultFactory:
 
 
 class SleepConfig(StrictBaseModel):
-    """Configuration for the LLM sleep/wakeup feature.
-    """
+    """Configuration for the LLM sleep/wakeup feature."""
 
     restore_modes: dict[
         ExecutorMemoryType, Literal["NONE", "MEMSET", "CPU", "PINNED"]
@@ -2275,9 +2247,7 @@ class PybindMirrorMeta(type(PybindMirror)):
 
 
 class PybindMirrorEnumMeta(EnumMeta, PybindMirrorMeta):
-    """
-    Combined metaclass for Enum and PybindMirror.  This is crucial.
-    """
+    """Combined metaclass for Enum and PybindMirror.  This is crucial."""
 
 
 @PybindMirror.mirror_pybind_enum(_BatchingType)
@@ -2381,9 +2351,7 @@ class SchedulerConfig(StrictBaseModel, PybindMirror):
 
 @PybindMirror.mirror_pybind_fields(_PeftCacheConfig)
 class PeftCacheConfig(StrictBaseModel, PybindMirror):
-    """
-    Configuration for the PEFT cache.
-    """
+    """Configuration for the PEFT cache."""
     num_host_module_layer: int = Field(
         default=0,
         description=
@@ -2451,9 +2419,7 @@ class PeftCacheConfig(StrictBaseModel, PybindMirror):
 
 @PybindMirror.mirror_pybind_fields(_LookaheadDecodingConfig)
 class LookaheadDecodingConfig(DecodingBaseConfig, PybindMirror):
-    """
-    Configuration for lookahead speculative decoding.
-    """
+    """Configuration for lookahead speculative decoding."""
 
     decoding_type: Literal["Lookahead"] = "Lookahead"
     max_window_size: PositiveInt = Field(
@@ -2556,9 +2522,7 @@ class ReorderRequestPolicyConfig(StrictBaseModel):
 
 @PybindMirror.mirror_pybind_fields(_KvCacheConfig)
 class KvCacheConfig(StrictBaseModel, PybindMirror):
-    """
-    Configuration for the KV cache.
-    """
+    """Configuration for the KV cache."""
     enable_block_reuse: bool = Field(
         default=True,
         description=
@@ -2771,9 +2735,7 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
 
 @PybindMirror.mirror_pybind_fields(_ExtendedRuntimePerfKnobConfig)
 class ExtendedRuntimePerfKnobConfig(StrictBaseModel, PybindMirror):
-    """
-    Configuration for extended runtime performance knobs.
-    """
+    """Configuration for extended runtime performance knobs."""
 
     multi_block_mode: bool = Field(
         default=True, description="Whether to use multi-block mode.")
@@ -2802,9 +2764,7 @@ class ExtendedRuntimePerfKnobConfig(StrictBaseModel, PybindMirror):
 
 @PybindMirror.mirror_pybind_fields(_CacheTransceiverConfig)
 class CacheTransceiverConfig(StrictBaseModel, PybindMirror):
-    """
-    Configuration for the cache transceiver.
-    """
+    """Configuration for the cache transceiver."""
 
     backend: Optional[Literal[
         "DEFAULT", "UCX", "NIXL", "MOONCAKE", "MPI"]] = Field(
@@ -2914,9 +2874,7 @@ class DwdpConfig(StrictBaseModel):
 
 
 class BaseLlmArgs(StrictBaseModel):
-    """
-    Base class for both TorchLlmArgs and TrtLlmArgs. It contains all the arguments that are common to both.
-    """
+    """Base class for both TorchLlmArgs and TrtLlmArgs. It contains all the arguments that are common to both."""
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
 
     # Explicit arguments
@@ -3431,9 +3389,7 @@ class TrtLlmArgs(BaseLlmArgs):
 
     @model_validator(mode="after")
     def init_build_config(self):
-        """
-        Creating a default BuildConfig if none is provided
-        """
+        """Creating a default BuildConfig if none is provided"""
         build_config = getattr(self, "build_config", None)
         if build_config is None:
             kwargs = {}
@@ -3758,9 +3714,7 @@ class SamplerType(StrEnum):
 
 
 class TorchCompileConfig(StrictBaseModel):
-    """
-    Configuration for torch.compile.
-    """
+    """Configuration for torch.compile."""
     enable_fullgraph: bool = Field(
         default=True,
         description="Enable full graph compilation in torch.compile.")

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -692,6 +692,18 @@ class AttentionDpConfig(StrictBaseModel):
         "cache affinity can dominate while preventing runaway concentration "
         "on a single rank. Set to 1.0 for strict fair share. "
         "Only used when enable_kv_cache_aware_routing is True.")
+    kv_cache_routing_cold_start_warmup: bool = Field(
+        default=False,
+        description=
+        "Cold-start mitigation in KV cache-aware routing. When True, the "
+        "first tp_size relaxed requests after router init are round-robined "
+        "across ranks (bypassing cache-affinity scoring) so every rank "
+        "caches the shared system prompt before scoring would otherwise pin "
+        "all traffic to the first warm rank. Only useful when requests "
+        "share a long system prefix; for diverse-prompt workloads this can "
+        "scatter requests that would otherwise consolidate on a single warm "
+        "rank, wasting prefill. Default False preserves pre-warmup routing. "
+        "Only used when enable_kv_cache_aware_routing is True.")
 
     @model_validator(mode='after')
     def validate_attention_dp_config(self) -> 'AttentionDpConfig':

--- a/tests/unittest/_torch/executor/test_adp_router.py
+++ b/tests/unittest/_torch/executor/test_adp_router.py
@@ -905,8 +905,6 @@ class TestKVCacheAwareADPRouterRouting:
                 {0: 0, 1: 50},
             ]
         router._all_ranks_prefix_matches = prefix_matches
-        # Tests in this class exercise pure scoring; opt out of warmup.
-        router._pending_warmup_ranks = set()
         return router
 
     def _rank_states(self, tp_size, active_reqs=None, active_tokens=None):

--- a/tests/unittest/_torch/executor/test_adp_router.py
+++ b/tests/unittest/_torch/executor/test_adp_router.py
@@ -905,6 +905,8 @@ class TestKVCacheAwareADPRouterRouting:
                 {0: 0, 1: 50},
             ]
         router._all_ranks_prefix_matches = prefix_matches
+        # Tests in this class exercise pure scoring; opt out of warmup.
+        router._pending_warmup_ranks = set()
         return router
 
     def _rank_states(self, tp_size, active_reqs=None, active_tokens=None):

--- a/tests/unittest/_torch/executor/test_kvcache_aware_router.py
+++ b/tests/unittest/_torch/executor/test_kvcache_aware_router.py
@@ -206,6 +206,7 @@ class TestKVCacheAwareADPRouter:
         dist = _mock_dist(tp_rank=0, tp_size=2)
         mgr = _mock_kv_cache_manager()
         router = KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr)
+        router._pending_warmup_ranks = set()  # isolate scoring from warmup
 
         router._all_ranks_prefix_matches = [{1: 0}, {1: 0}]
 
@@ -224,6 +225,7 @@ class TestKVCacheAwareADPRouter:
         dist = _mock_dist(tp_rank=0, tp_size=2)
         mgr = _mock_kv_cache_manager()
         router = KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr, load_balance_weight=10.0)
+        router._pending_warmup_ranks = set()  # isolate scoring from warmup
 
         router._all_ranks_prefix_matches = [{1: 80}, {1: 0}]
 
@@ -274,6 +276,7 @@ class TestKVCacheAwareADPRouter:
         # cap-relaxation behavior covered separately in
         # test_fair_share_multiplier_caps_per_rank.
         router = KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr, fair_share_multiplier=1.0)
+        router._pending_warmup_ranks = set()  # isolate scoring from warmup
 
         # Requests 1,2 have cache on rank 0; requests 3,4 have no cache
         router._all_ranks_prefix_matches = [
@@ -387,6 +390,112 @@ class TestKVCacheAwareADPRouter:
         assert result[0][0].id == 1
         assert len(result[1]) == 1
         assert result[1][0].id == 2
+
+
+# ---- Cold-start warmup tests for KVCacheAwareADPRouter ----
+
+
+class TestKVCacheAwareADPRouterWarmup:
+    """Cold-start round-robin warmup behaviour."""
+
+    def _make_router(self, tp_size):
+        dist = _mock_dist(tp_rank=0, tp_size=tp_size)
+        mgr = _mock_kv_cache_manager()
+        return KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr)
+
+    def _no_match(self, tp_size, req_ids):
+        return [{rid: 0 for rid in req_ids} for _ in range(tp_size)]
+
+    def _zero_states(self, tp_size):
+        return [
+            RankState(rank=r, num_active_requests=0, num_active_tokens=0) for r in range(tp_size)
+        ]
+
+    def test_pending_initialised_in_ctor(self):
+        """__init__ should populate ``_pending_warmup_ranks`` from dist.tp_size."""
+        router = self._make_router(tp_size=4)
+        assert router._pending_warmup_ranks == {0, 1, 2, 3}
+
+    def test_first_batch_round_robins_across_ranks(self):
+        """First tp_size relaxed requests dispatch to ranks 0..tp_size-1."""
+        tp_size = 4
+        router = self._make_router(tp_size=tp_size)
+        router._all_ranks_prefix_matches = self._no_match(tp_size, range(tp_size))
+        reqs = [_make_request_item(i, num_tokens=10) for i in range(tp_size)]
+        result, _ = router.route_requests(
+            self._zero_states(tp_size), reqs, max_num_active_requests=100
+        )
+        # Each rank gets exactly one request, in id order (smallest-first).
+        for r in range(tp_size):
+            assert len(result[r]) == 1
+            assert result[r][0].id == r
+        assert router._pending_warmup_ranks == set()
+
+    def test_warmup_persists_across_single_request_batches(self):
+        """Low-traffic sequential arrivals still cover every rank."""
+        tp_size = 3
+        router = self._make_router(tp_size=tp_size)
+        for batch in range(tp_size):
+            router._all_ranks_prefix_matches = self._no_match(tp_size, [batch])
+            result, _ = router.route_requests(
+                self._zero_states(tp_size),
+                [_make_request_item(batch, num_tokens=10)],
+                max_num_active_requests=100,
+            )
+            assert len(result[batch]) == 1
+            assert result[batch][0].id == batch
+        assert router._pending_warmup_ranks == set()
+
+    def test_strict_request_consumes_warmup_slot(self):
+        """A strict ``target_dp_rank`` discards that rank from the pending set,
+        so a relaxed follow-up in the same batch skips it."""
+        tp_size = 4
+        router = self._make_router(tp_size=tp_size)
+        router._all_ranks_prefix_matches = self._no_match(tp_size, [0, 1])
+        strict = _make_request_item(
+            req_id=0, num_tokens=10, target_dp_rank=2, attention_dp_relax=False
+        )
+        relaxed = _make_request_item(req_id=1, num_tokens=10)
+        result, _ = router.route_requests(
+            self._zero_states(tp_size), [strict, relaxed], max_num_active_requests=100
+        )
+        # Strict lands on its requested rank.
+        assert [r.id for r in result[2]] == [0]
+        # Relaxed picks the smallest still-pending rank (0), NOT rank 2 again.
+        assert [r.id for r in result[0]] == [1]
+        assert router._pending_warmup_ranks == {1, 3}
+
+    def test_cap_saturation_discards_busy_rank(self):
+        """A cap-saturated synthesised target is still removed from pending
+        so the synthesiser doesn't loop on the same busy rank."""
+        tp_size = 2
+        router = self._make_router(tp_size=tp_size)
+        router._all_ranks_prefix_matches = self._no_match(tp_size, [0])
+        # Rank 0 already at the cap (max_num_active_requests=1).
+        states = [
+            RankState(rank=0, num_active_requests=1, num_active_tokens=10),
+            RankState(rank=1, num_active_requests=0, num_active_tokens=0),
+        ]
+        router.route_requests(
+            states, [_make_request_item(0, num_tokens=10)], max_num_active_requests=1
+        )
+        assert 0 not in router._pending_warmup_ranks
+
+    def test_empty_pending_disables_warmup(self):
+        """Once pending is empty, routing reverts to pure scoring."""
+        tp_size = 2
+        router = self._make_router(tp_size=tp_size)
+        router._pending_warmup_ranks = set()  # simulate fully warmed router
+        # Req 1 has a cache hit only on rank 1; scoring (not warmup) should
+        # send it there.
+        router._all_ranks_prefix_matches = [{1: 0}, {1: 80}]
+        result, _ = router.route_requests(
+            self._zero_states(tp_size),
+            [_make_request_item(1, num_tokens=100)],
+            max_num_active_requests=100,
+        )
+        assert result[0] == []
+        assert [r.id for r in result[1]] == [1]
 
 
 # ---- Tests for V1 KVCacheManager.probe_prefix_match_length ----

--- a/tests/unittest/_torch/executor/test_kvcache_aware_router.py
+++ b/tests/unittest/_torch/executor/test_kvcache_aware_router.py
@@ -33,6 +33,9 @@ def _mock_dist(tp_rank=0, tp_size=1, has_cp_helix=False):
     dist = MagicMock()
     dist.tp_rank = tp_rank
     dist.tp_size = tp_size
+    # ADP scheduling assumes ``enable_attention_dp=True``, so ``dp_size``
+    # mirrors ``tp_size`` (see ``Mapping.dp_size``).
+    dist.mapping.dp_size = tp_size
     dist.has_cp_helix = has_cp_helix
     return dist
 
@@ -409,7 +412,7 @@ class TestKVCacheAwareADPRouterWarmup:
         ]
 
     def test_pending_initialised_in_ctor(self):
-        """``cold_start_warmup=True`` should populate ``_pending_warmup_ranks`` from dist.tp_size."""
+        """``cold_start_warmup=True`` should populate ``_pending_warmup_ranks`` from dist.mapping.dp_size."""
         router = self._make_router(tp_size=4)
         assert router._pending_warmup_ranks == {0, 1, 2, 3}
 
@@ -469,9 +472,9 @@ class TestKVCacheAwareADPRouterWarmup:
         assert [r.id for r in result[0]] == [1]
         assert router._pending_warmup_ranks == {1, 3}
 
-    def test_cap_saturation_discards_busy_rank(self):
-        """A cap-saturated synthesised target is still removed from pending
-        so the synthesiser doesn't loop on the same busy rank."""
+    def test_cap_saturation_keeps_rank_pending(self):
+        """A saturated warmup pick stays in ``_pending_warmup_ranks`` so a
+        later routing call can still seed it once load drops."""
         tp_size = 2
         router = self._make_router(tp_size=tp_size)
         router._all_ranks_prefix_matches = self._no_match(tp_size, [0])
@@ -483,7 +486,7 @@ class TestKVCacheAwareADPRouterWarmup:
         router.route_requests(
             states, [_make_request_item(0, num_tokens=10)], max_num_active_requests=1
         )
-        assert 0 not in router._pending_warmup_ranks
+        assert 0 in router._pending_warmup_ranks
 
     def test_empty_pending_disables_warmup(self):
         """Once pending is empty, routing reverts to pure scoring."""

--- a/tests/unittest/_torch/executor/test_kvcache_aware_router.py
+++ b/tests/unittest/_torch/executor/test_kvcache_aware_router.py
@@ -489,7 +489,8 @@ class TestKVCacheAwareADPRouterWarmup:
         """Once pending is empty, routing reverts to pure scoring."""
         tp_size = 2
         router = self._make_router(tp_size=tp_size)
-        router._pending_warmup_ranks = set()  # simulate fully warmed router
+        # Drain the warmup set to simulate a fully warmed router.
+        router._pending_warmup_ranks = set()
         # Req 1 has a cache hit only on rank 1; scoring (not warmup) should
         # send it there.
         router._all_ranks_prefix_matches = [{1: 0}, {1: 80}]

--- a/tests/unittest/_torch/executor/test_kvcache_aware_router.py
+++ b/tests/unittest/_torch/executor/test_kvcache_aware_router.py
@@ -206,7 +206,6 @@ class TestKVCacheAwareADPRouter:
         dist = _mock_dist(tp_rank=0, tp_size=2)
         mgr = _mock_kv_cache_manager()
         router = KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr)
-        router._pending_warmup_ranks = set()  # isolate scoring from warmup
 
         router._all_ranks_prefix_matches = [{1: 0}, {1: 0}]
 
@@ -225,7 +224,6 @@ class TestKVCacheAwareADPRouter:
         dist = _mock_dist(tp_rank=0, tp_size=2)
         mgr = _mock_kv_cache_manager()
         router = KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr, load_balance_weight=10.0)
-        router._pending_warmup_ranks = set()  # isolate scoring from warmup
 
         router._all_ranks_prefix_matches = [{1: 80}, {1: 0}]
 
@@ -276,7 +274,6 @@ class TestKVCacheAwareADPRouter:
         # cap-relaxation behavior covered separately in
         # test_fair_share_multiplier_caps_per_rank.
         router = KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr, fair_share_multiplier=1.0)
-        router._pending_warmup_ranks = set()  # isolate scoring from warmup
 
         # Requests 1,2 have cache on rank 0; requests 3,4 have no cache
         router._all_ranks_prefix_matches = [
@@ -401,7 +398,7 @@ class TestKVCacheAwareADPRouterWarmup:
     def _make_router(self, tp_size):
         dist = _mock_dist(tp_rank=0, tp_size=tp_size)
         mgr = _mock_kv_cache_manager()
-        return KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr)
+        return KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr, cold_start_warmup=True)
 
     def _no_match(self, tp_size, req_ids):
         return [{rid: 0 for rid in req_ids} for _ in range(tp_size)]
@@ -412,9 +409,16 @@ class TestKVCacheAwareADPRouterWarmup:
         ]
 
     def test_pending_initialised_in_ctor(self):
-        """__init__ should populate ``_pending_warmup_ranks`` from dist.tp_size."""
+        """``cold_start_warmup=True`` should populate ``_pending_warmup_ranks`` from dist.tp_size."""
         router = self._make_router(tp_size=4)
         assert router._pending_warmup_ranks == {0, 1, 2, 3}
+
+    def test_disabled_by_default(self):
+        """Default ``cold_start_warmup=False`` leaves the pending set empty."""
+        dist = _mock_dist(tp_rank=0, tp_size=4)
+        mgr = _mock_kv_cache_manager()
+        router = KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr)
+        assert router._pending_warmup_ranks == set()
 
     def test_first_batch_round_robins_across_ranks(self):
         """First tp_size relaxed requests dispatch to ranks 0..tp_size-1."""


### PR DESCRIPTION
## Summary

Cold-start mitigation for the KV-aware ADP router: round-robin the first relaxed requests across all ranks so every rank caches the (assumed shared) system prompt before cache-affinity scoring would otherwise pin all traffic to the first warm rank.

## Problem

With `match_rate_threshold=0.1` the cache-affinity gate stays ON for any system prompt longer than ~10% of a request. Once a single rank caches that prompt, the `(req_tokens - match_len)` term dominates the load term:

- Low-traffic sequential arrivals: each new request pins to the warm rank; other ranks never see the prompt.
- Eventual traffic spike: cold ranks pay the full prefill cost re-computing the same shared prompt.

## Fix

`KVCacheAwareADPRouter` tracks `_pending_warmup_ranks: Set[int]`:

- Initialised to `{0, ..., tp_size-1}` only when `cold_start_warmup=True`; otherwise an empty set.
- In `route_requests`, any `target_dp_rank` (explicit strict or synthesised warmup) discards its rank from the set. Relaxed requests with no explicit target synthesise `min(_pending_warmup_ranks)` while the set is non-empty.
- Strict pre-assignments count toward warmup naturally; cap-saturated ranks also discard so the synthesiser never loops on a busy rank.
- Once the set is empty, warmup is dormant forever and routing is pure scoring.

## Opt-in (default False)

The behaviour is gated by `AttentionDpConfig.kv_cache_routing_cold_start_warmup` (default `False`). The warmup is a win for workloads that share a long system prompt, but for diverse-prompt workloads it can scatter requests onto cold ranks and bypass cache-affinity scoring entirely for the first `tp_size` requests — wasting prefill work the scoring path would otherwise consolidate. Default `False` preserves pre-warmup routing; users who hit cold-start pinning opt in explicitly.

Test layout:

- `TestKVCacheAwareADPRouterWarmup` constructs its router with `cold_start_warmup=True` to exercise the new code path, plus a new `test_disabled_by_default` asserting the empty pending set when the flag is absent.
- Pre-existing scoring tests no longer need the `_pending_warmup_ranks = set()` opt-out (default is already off).