### PR TITLE
[None][fix] slice incremental decode from last emitted text

### DIFF
--- a/tensorrt_llm/tokenizer/tokenizer.py
+++ b/tensorrt_llm/tokenizer/tokenizer.py
@@ -412,14 +412,14 @@ class TransformersTokenizer(TokenizerBase):
             states = {}
         last_new_tokens = states.pop('last_new_tokens', [])
         pending_tokens = states.pop('pending_tokens', [])
-
-        if len(last_new_tokens) > 0:
-            last_new_text = self.convert_tokens_to_string(
-                last_new_tokens,
-                skip_special_tokens=skip_special_tokens,
-                spaces_between_special_tokens=spaces_between_special_tokens)
-        else:
-            last_new_text = ""
+        # Some BPE/tiktoken decoders can render a token differently by itself than
+        # in a longer token span. E.g. the tokenizer decodes token "B" as " the",
+        # but tokens "B", "C" together as "the cat". If the previous emitted text
+        # was "the", slicing "the cat" by len(" the") would produce "cat", and the
+        # stream would incorrectly assemble "thecat". The incremental delta must be
+        # sliced from the last emitted decoded text, not from a fresh standalone
+        # decode of last tokens.
+        last_decoded_text = states.pop('last_decoded_text', '')
 
         new_tokens = self.convert_ids_to_tokens(
             token_ids, skip_special_tokens=skip_special_tokens)
@@ -436,20 +436,25 @@ class TransformersTokenizer(TokenizerBase):
             last_new_tokens + pending_tokens,
             skip_special_tokens=skip_special_tokens,
             spaces_between_special_tokens=spaces_between_special_tokens)
-        if not flush and (len(curr_new_text.rstrip()) <= len(
-                last_new_text.rstrip()) or curr_new_text.endswith("�")):
+        if not flush and (len(curr_new_text) <= len(last_decoded_text)
+                          or curr_new_text.endswith("�")):
             return prev_text, {
                 'last_new_tokens': last_new_tokens,
-                'pending_tokens': pending_tokens
+                'pending_tokens': pending_tokens,
+                'last_decoded_text': last_decoded_text,
             }
 
-        # Remove the part of last_new_text
-        curr_new_text = curr_new_text[len(last_new_text):]
+        raw_curr_new_text = curr_new_text
+        curr_new_text = curr_new_text[len(last_decoded_text):]
         if clean_up_tokenization_spaces is None:
             clean_up_tokenization_spaces = self.clean_up_tokenization_spaces
         if clean_up_tokenization_spaces:
             curr_new_text = self.clean_up_tokenization(curr_new_text)
-        return prev_text + curr_new_text, {'last_new_tokens': pending_tokens}
+        return prev_text + curr_new_text, {
+            'last_new_tokens': pending_tokens,
+            'pending_tokens': [],
+            'last_decoded_text': raw_curr_new_text,
+        }
 
     def hf_decode_incrementally(
         self,

--- a/tests/unittest/llmapi/test_llm.py
+++ b/tests/unittest/llmapi/test_llm.py
@@ -372,6 +372,50 @@ def test_llm_with_kv_cache_retention_config():
         print(output)
 
 
+class _PrefixUnstableTokenizer:
+    all_special_tokens = []
+    clean_up_tokenization_spaces = False
+    is_fast = True
+
+    def get_added_vocab(self):
+        return {}
+
+    def convert_ids_to_tokens(self, ids, skip_special_tokens=False):
+        id_to_token = {1: 'C'}
+        return [id_to_token[id_] for id_ in ids]
+
+    def convert_tokens_to_string(self,
+                                 tokens,
+                                 skip_special_tokens=False,
+                                 spaces_between_special_tokens=True):
+        decoded_text = {
+            ('B', ): ' the',
+            ('B', 'C'): 'the cat',
+        }
+        return decoded_text[tuple(tokens)]
+
+    def clean_up_tokenization(self, out_string):
+        return out_string
+
+
+def test_trtllm_decode_incrementally_slices_from_previous_decoded_text():
+    tokenizer = TransformersTokenizer(_PrefixUnstableTokenizer())
+
+    decoded_text, states = tokenizer.trtllm_decode_incrementally(
+        [1],
+        prev_text='the',
+        states={
+            'last_new_tokens': ['B'],
+            'last_decoded_text': 'the',
+        },
+    )
+
+    assert decoded_text == 'the cat'
+    assert states['last_new_tokens'] == ['C']
+    assert states['pending_tokens'] == []
+    assert states['last_decoded_text'] == 'the cat'
+
+
 @pytest.mark.parametrize('backend', ["HF", "TRTLLM"])
 @pytest.mark.parametrize(
     'tokenizer_dir, clean_up_tokenization_spaces, threshold',


### PR DESCRIPTION
## Summary
We observed missing spaces in streaming chunks after detokenizations with Kimi-K2.5 when used stream_interval=8. Example (missing space between 'logs' and 'and'):
`{"id":"chatcmpl-c5ba8e658c5e48db94ae3308819586ba","choices":[{"delta":{"content":"Investigating snapshot build and verification: locating logs","reasoning_content":""},"index":0,"avg_decoded_tokens_per_iter":2.9772727489471436}],"created":1778888341,"model":"Kimi-K2.5-NVFP4","object":"chat.completion.chunk"}
{"id":"chatcmpl-c5ba8e658c5e48db94ae3308819586ba","choices":[{"delta":{"content":"and exploring the ml-infra-server snapshot pipeline.","reasoning_content":""},"index":0,"avg_decoded_tokens_per_iter":3.0833332538604736}],"created":1778888341,"model":"Kimi-K2.5-NVFP4","object":"chat.completion.chunk"}`

- Fix `trtllm_decode_incrementally` to slice new text from the last emitted decoded string (`last_decoded_text`) instead of re-decoding prior tokens in isolation.
- Prevents BPE/tiktoken streaming bugs where a token decodes differently alone vs in context (e.g. `"thecat"` instead of `"the cat"`).
- Add a unit test with a prefix-unstable mock tokenizer that reproduces the failure mode.

## Test plan
- [x] `pytest tests/unittest/llmapi/test_llm.py::test_trtllm_decode_incrementally_slices_from_previous_decoded_text -v`
- [x] `pytest tests/unittest/llmapi/test_llm.py::test_tokenizer_decode_incrementally -k "TinyLlama and TRTLLM" -v`
- [x] pre-commit on modified files
