### PR TITLE
[None][fix] DSv4: drop duplicate indexer_k_dtype kwarg on V4 sparse attn

### DIFF
--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -794,7 +794,6 @@ class ModelConfig(Generic[TConfig]):
                     if checkpoint_window_size is None:
                         checkpoint_window_size = getattr(
                             pretrained_config, 'sliding_window', None)
-                    indexer_k_dtype = sparse_attention_config.indexer_k_dtype if sparse_attention_config else 'fp8'
                     if sparse_attention_config:
                         compress_ratios = sparse_attention_config.compress_ratios
                         window_size = sparse_attention_config.window_size
@@ -838,7 +837,6 @@ class ModelConfig(Generic[TConfig]):
                         'sparse_attention_config'] = DeepSeekV4SparseAttentionConfig(
                             compress_ratios=compress_ratios,
                             window_size=window_size,
-                            indexer_k_dtype=indexer_k_dtype,
                             **indexer_config)
             else:
                 raise ValueError(


### PR DESCRIPTION
indexer_k_dtype is already populated inside indexer_config by update_sparse_attention_indexer_config (which sources it from sparse_attention_config.indexer_k_dtype, falling back to the "fp8" default). Passing it again as an explicit kwarg to DeepSeekV4SparseAttentionConfig while also expanding **indexer_config triggers a duplicate keyword argument TypeError during executor init. Drop the explicit kwarg and let **indexer_config provide the value.

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
