### PR TITLE
[TRTLLMINF-89][feat] Make L0 retries timeout-budget aware

### DIFF
--- a/jenkins/Build.groovy
+++ b/jenkins/Build.groovy
@@ -504,6 +504,7 @@ def launchStages(pipeline, cpu_arch, enableFailFast, globalVars)
 
         echo "env.globalVars is: ${env.globalVars}"
         globalVars = trtllm_utils.updateMapWithJson(pipeline, globalVars, env.globalVars, "globalVars")
+        globalVars = trtllm_utils.initializeCiBudget(pipeline, globalVars, 24, 'HOURS', "Build-${cpu_arch}")
         globalVars[ACTION_INFO] = trtllm_utils.setupPipelineDescription(pipeline, globalVars[ACTION_INFO])
     }
 

--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -1692,6 +1692,7 @@ pipeline {
             steps
             {
                 script {
+                    globalVars = trtllm_utils.initializeCiBudget(this, globalVars, 24, 'HOURS', 'L0_MergeRequest')
                     preparation(this, testFilter, globalVars)
                     println globalVars
                     globalVars[ACTION_INFO] = trtllm_utils.setupPipelineDescription(this, globalVars[ACTION_INFO])

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1665,27 +1665,49 @@ def parseLongOrDefault(def value, long defaultValue)
     if (value == null) {
         return defaultValue
     }
+    if (value instanceof Number) {
+        return value.longValue()
+    }
     try {
-        return new BigDecimal(value.toString().trim()).longValue()
-    } catch (Exception ignored) {
+        return Long.parseLong(value.toString().trim())
+    } catch (NumberFormatException ignored) {
         return defaultValue
     }
 }
 
-def normalizeDurationLookupKey(String rawLine)
+long durationSecondsToMillis(def durationSeconds)
+{
+    if (durationSeconds == null) {
+        return 0L
+    }
+    double seconds
+    if (durationSeconds instanceof Number) {
+        seconds = durationSeconds.doubleValue()
+    } else {
+        seconds = Double.parseDouble(durationSeconds.toString().trim())
+    }
+    return Math.round(seconds * 1000D)
+}
+
+def durationLookupKeys(String rawLine)
 {
     if (rawLine == null) {
-        return null
+        return []
     }
     def testName = rawLine.trim()
     if (!testName || testName.startsWith("#")) {
-        return null
+        return []
     }
     testName = testName.replaceAll(/\s+(SKIP|TIMEOUT|ISOLATION)(\s*\([^)]*\))?.*$/, "").trim()
-    if (testName.startsWith("test_unittests.py::test_unittests_v2[") && testName.endsWith("]")) {
-        testName = testName.substring(testName.indexOf("[") + 1, testName.lastIndexOf("]"))
+    if (!testName) {
+        return []
     }
-    return testName ?: null
+    def keys = [testName]
+    def wrapperMatch = (testName =~ /^[^/]*test\w+\.py::(?:\w+::)*\w+\[(.+)\]$/)
+    if (wrapperMatch.matches()) {
+        keys << wrapperMatch[0][1]
+    }
+    return keys.unique()
 }
 
 def recordRenderedStageAttemptEstimate(pipeline, String llmSrc, String testListPath, String stageName, def renderedTestCount)
@@ -1703,13 +1725,13 @@ def recordRenderedStageAttemptEstimate(pipeline, String llmSrc, String testListP
         int totalCount = 0
         int missingCount = 0
         readFile(file: testListPath).readLines().each { line ->
-            def key = normalizeDurationLookupKey(line)
-            if (key) {
+            def keys = durationLookupKeys(line)
+            if (keys) {
                 totalCount++
-                def durationSeconds = durations[key]
+                def durationSeconds = keys.collect { durations[it] }.find { it != null }
                 if (durationSeconds != null) {
                     knownCount++
-                    knownMs += (new BigDecimal(durationSeconds.toString()) * 1000G).longValue()
+                    knownMs += durationSecondsToMillis(durationSeconds)
                 } else {
                     missingCount++
                 }

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2,7 +2,6 @@
 
 import java.lang.InterruptedException
 import groovy.transform.Field
-import groovy.json.JsonSlurper
 import groovy.json.JsonOutput
 import com.nvidia.bloom.KubernetesManager
 import com.nvidia.bloom.Constants
@@ -1527,6 +1526,11 @@ def runLLMTestlistOnSlurm(pipeline, platform, testList, config=VANILLA_CONFIG, p
              "but max retries (${effectiveMax}) exhausted after ${attempt} attempts. Failing."
         throw e
       }
+      if (!hasBudgetForInfraRetry(pipeline, stageName, InfraFailure.SLURM, c, attempt, effectiveMax, 60L * 1000L, true)) {
+        echo "[INFRA-RETRY] ${stageName}: Infrastructure failure (${c.detectedPattern}) is retryable, " +
+             "but remaining CI timeout budget is too small for another SLURM attempt. Failing without retry."
+        throw e
+      }
 
       echo "[INFRA-RETRY] ${stageName}: Infrastructure failure detected on attempt ${attempt}: " +
            "${c.detectedPattern}"
@@ -1640,6 +1644,8 @@ def globalVars = [
 
 class GlobalState {
     static def uploadResultStageNames = []
+    static def stageAttemptEstimateMs = [:]
+    static def stageAttemptEstimateDetails = [:]
 
     // HOST_NODE_NAME to starting port section map
     // This map maintains the next available starting port for each host node
@@ -1652,6 +1658,139 @@ class GlobalState {
     static final int BASE_PORT = 10000           // Base starting port
     static final int PORT_SECTION_SIZE = 1000    // Number of ports per section/stage
     static final int MAX_PORT = 32000            // Maximum port number to avoid system ports
+}
+
+def parseLongOrDefault(def value, long defaultValue)
+{
+    if (value == null) {
+        return defaultValue
+    }
+    try {
+        return new BigDecimal(value.toString().trim()).longValue()
+    } catch (Exception ignored) {
+        return defaultValue
+    }
+}
+
+def normalizeDurationLookupKey(String rawLine)
+{
+    if (rawLine == null) {
+        return null
+    }
+    def testName = rawLine.trim()
+    if (!testName || testName.startsWith("#")) {
+        return null
+    }
+    testName = testName.replaceAll(/\s+(SKIP|TIMEOUT|ISOLATION)(\s*\([^)]*\))?.*$/, "").trim()
+    if (testName.startsWith("test_unittests.py::test_unittests_v2[") && testName.endsWith("]")) {
+        testName = testName.substring(testName.indexOf("[") + 1, testName.lastIndexOf("]"))
+    }
+    return testName ?: null
+}
+
+def recordRenderedStageAttemptEstimate(pipeline, String llmSrc, String testListPath, String stageName, def renderedTestCount)
+{
+    long defaultUnknownMs = stageName.contains("-Perf") ? 20L * 60L * 1000L : 10L * 60L * 1000L
+    long renderedCount = parseLongOrDefault(renderedTestCount, 0L)
+    long estimatedMs = renderedCount * defaultUnknownMs
+    int knownCount = 0
+    int unknownCount = renderedCount as int
+
+    try {
+        def durationText = readFile(file: "${llmSrc}/tests/integration/defs/.test_durations")
+        def durations = new groovy.json.JsonSlurperClassic().parseText(durationText)
+        long knownMs = 0L
+        int totalCount = 0
+        int missingCount = 0
+        readFile(file: testListPath).readLines().each { line ->
+            def key = normalizeDurationLookupKey(line)
+            if (key) {
+                totalCount++
+                def durationSeconds = durations[key]
+                if (durationSeconds != null) {
+                    knownCount++
+                    knownMs += (new BigDecimal(durationSeconds.toString()) * 1000G).longValue()
+                } else {
+                    missingCount++
+                }
+            }
+        }
+        if (totalCount > 0) {
+            unknownCount = missingCount
+            estimatedMs = knownMs + (missingCount * defaultUnknownMs)
+        }
+    } catch (Exception e) {
+        echo "[CI-BUDGET] ${stageName}: failed to read .test_durations; using count-based estimate. Error: ${e.toString()}"
+    }
+
+    if (estimatedMs <= 0L && renderedCount > 0L) {
+        estimatedMs = renderedCount * defaultUnknownMs
+    }
+    GlobalState.stageAttemptEstimateMs[stageName] = estimatedMs
+    GlobalState.stageAttemptEstimateDetails[stageName] = [
+        renderedCount: renderedCount,
+        knownCount: knownCount,
+        unknownCount: unknownCount,
+    ]
+    echo "[CI-BUDGET] ${stageName}: recorded test runtime estimate " +
+         "${trtllm_utils.formatCiBudgetMillis(estimatedMs)} " +
+         "(rendered=${renderedCount}, known=${knownCount}, unknown=${unknownCount})"
+}
+
+long estimateStageRetryRuntimeMs(String stageName, String scope)
+{
+    long testEstimateMs = parseLongOrDefault(GlobalState.stageAttemptEstimateMs[stageName], 0L)
+    if (testEstimateMs > 0L) {
+        long overheadMs = scope == InfraFailure.SLURM ? 45L * 60L * 1000L : 30L * 60L * 1000L
+        return testEstimateMs + overheadMs
+    }
+    return scope == InfraFailure.SLURM ? 4L * 60L * 60L * 1000L : 2L * 60L * 60L * 1000L
+}
+
+long retrySafetyMarginMs(String scope)
+{
+    return scope == InfraFailure.SLURM ? 20L * 60L * 1000L : 15L * 60L * 1000L
+}
+
+int retryMaxForFailure(String scope, InfraFailure failure)
+{
+    if (failure.severity == InfraFailure.PERSISTENT) {
+        return 1
+    }
+    return scope == InfraFailure.SLURM ? SLURM_INFRA_RETRY_MAX : K8S_INFRA_RETRY_MAX
+}
+
+boolean hasBudgetForInfraRetry(def pipeline, String stageName, String scope, InfraFailure failure, int attempt, int effectiveMax, long backoffMs, boolean logDecision)
+{
+    if (attempt > effectiveMax) {
+        return false
+    }
+    long estimateMs = estimateStageRetryRuntimeMs(stageName, scope)
+    long safetyMs = retrySafetyMarginMs(scope)
+    return trtllm_utils.canSpendCiBudget(pipeline, [
+        globalVars: globalVars,
+        label: "infra-retry:${scope}:${stageName}:attempt-${attempt + 1}",
+        estimateMs: estimateMs,
+        backoffMs: backoffMs,
+        safetyMs: safetyMs,
+        logDecision: logDecision,
+    ])
+}
+
+boolean retryContextAllowsRetry(def pipeline, Map retryContext, Throwable error, boolean logDecision=false)
+{
+    if (retryContext == null || error == null) {
+        return false
+    }
+    String scope = retryContext.scope ?: InfraFailure.K8S
+    def classified = FailureClassifier.classify(error, scope)
+    if (!(classified instanceof InfraFailure)) {
+        return false
+    }
+    int attempt = parseLongOrDefault(retryContext.attempt, 1L) as int
+    int effectiveMax = retryMaxForFailure(scope, classified)
+    long backoffMs = parseLongOrDefault(retryContext.backoffMs, 60L * 1000L)
+    return hasBudgetForInfraRetry(pipeline, retryContext.stageName ?: "Unknown", scope, classified, attempt, effectiveMax, backoffMs, logDecision)
 }
 
 /**
@@ -1697,7 +1836,7 @@ def getHostNodeName() {
     ''', returnStdout: true).trim()
 }
 
-def cacheErrorAndUploadResult(stageName, taskRunner, finallyRunner, noResultIfSuccess=false, postTag="", boolean isFinalAttempt=true)
+def cacheErrorAndUploadResult(stageName, taskRunner, finallyRunner, noResultIfSuccess=false, postTag="", boolean isFinalAttempt=true, Map retryContext=null)
 {
     checkStageName([stageName])
     def Boolean stageIsInterrupted = false
@@ -1738,11 +1877,16 @@ def cacheErrorAndUploadResult(stageName, taskRunner, finallyRunner, noResultIfSu
             // (on a fresh pod) cannot remove. The tar artifact is still uploaded
             // for forensics; only the in-build test reporting is gated.
             boolean suppressTestReporting = false
-            if (!isFinalAttempt && stageIsFailed && caughtError != null) {
-                def c = FailureClassifier.classify(caughtError, InfraFailure.K8S)
-                if (c instanceof InfraFailure) {
+            if (stageIsFailed && caughtError != null) {
+                if (retryContext != null) {
+                    suppressTestReporting = retryContextAllowsRetry(null, retryContext, caughtError, false)
+                } else if (!isFinalAttempt) {
+                    def c = FailureClassifier.classify(caughtError, InfraFailure.K8S)
+                    suppressTestReporting = c instanceof InfraFailure
+                }
+                if (suppressTestReporting) {
                     suppressTestReporting = true
-                    echo "[INFRA-RETRY] ${stageName}${postTag}: suppressing synthetic stage-fail XML and junit() on intermediate retryable infra failure (${c.detectedPattern})"
+                    echo "[INFRA-RETRY] ${stageName}${postTag}: suppressing synthetic stage-fail XML and junit() because a retry is still planned"
                 }
             }
 
@@ -2394,6 +2538,7 @@ def renderTestDB(pipeline, testContext, llmSrc, stageName, preDefinedMakoOpts=nu
     def testDBLabel = (cbts != null && cbts.test_db_dir_override) ? "CBTS-narrowed [${cbts.scope}]" : "source"
     echo "renderTestDB: stage=${stageName} context=${testContext} test-db=${testDBLabel} dir=${testDBPath} -> ${testCount} tests"
     sh(script: "cat ${testList}")
+    recordRenderedStageAttemptEstimate(pipeline, llmSrc, testList, stageName, testCount)
 
     return testList
 }
@@ -3251,7 +3396,7 @@ def runLLMTestlistOnPlatformImpl(pipeline, platform, testList, config=VANILLA_CO
 // composed with an attempt tag by the helper) and `isFinalAttempt` (so this
 // function's `cacheErrorAndUploadResult` can suppress synthetic stage-fail XML
 // and junit() for intermediate retryable failures).
-def runLLMTestlistOnPlatform(pipeline, platform, testList, config=VANILLA_CONFIG, perfMode=false, stageName="Undefined", splitId=1, splits=1, skipInstallWheel=false, cpver="cp312", postTag="", typeCheck=false, boolean isFinalAttempt=true)
+def runLLMTestlistOnPlatform(pipeline, platform, testList, config=VANILLA_CONFIG, perfMode=false, stageName="Undefined", splitId=1, splits=1, skipInstallWheel=false, cpver="cp312", postTag="", typeCheck=false, boolean isFinalAttempt=true, Map retryContext=null)
 {
     def collapse = _cbtsMaybeCollapseSplits(stageName, splitId, splits)
     if (collapse.skip) {
@@ -3298,7 +3443,7 @@ def runLLMTestlistOnPlatform(pipeline, platform, testList, config=VANILLA_CONFIG
         // Copy CPP test result
         sh "cp ${llmSrc}/cpp/build_backup/*.xml ${stageName} || true"
         sh "ls -al ${stageName}/"
-    }, false, postTag, isFinalAttempt)
+    }, false, postTag, isFinalAttempt, retryContext)
 }
 
 
@@ -3546,7 +3691,7 @@ def runInKubernetes(pipeline, podSpec, containerName)
 // a fresh pod on each retry rather than
 // retrying the test body inside a dying pod.
 //
-// `runner` is invoked with `(attemptTag, isFinalAttempt)`. Callers append
+// `runner` is invoked with `(attemptTag, isFinalAttempt, retryContext)`. Callers append
 // `attemptTag` to any postTag they pass into cacheErrorAndUploadResult so each
 // attempt's tar and ensureStageResultNotUploaded guard key are unique;
 // `isFinalAttempt` lets cacheErrorAndUploadResult suppress synthetic stage-fail
@@ -3558,7 +3703,7 @@ def runKubernetesPodWithInfraRetry(pipeline, podSpec, containerName, String stag
     // DEBUG_MODE preserves the existing 2-hour-input human-inspection workflow
     // inside runLLMTestlistOnPlatform's finallyRunner: a single attempt only.
     if (testFilter[(DEBUG_MODE)]) {
-        trtllm_utils.launchKubernetesPod(pipeline, podSpec, containerName, { runner("", true) })
+        trtllm_utils.launchKubernetesPod(pipeline, podSpec, containerName, { runner("", true, null) })
         return
     }
 
@@ -3592,7 +3737,13 @@ def runKubernetesPodWithInfraRetry(pipeline, podSpec, containerName, String stag
             // another intermediate attempt.
             def effectiveMaxThisAttempt = (lastSeverity == InfraFailure.PERSISTENT) ? 1 : K8S_INFRA_RETRY_MAX
             boolean isFinalAttempt = (attempt > effectiveMaxThisAttempt)
-            trtllm_utils.launchKubernetesPod(pipeline, podSpec, containerName, { runner(attemptTag, isFinalAttempt) })
+            def retryContext = [
+                scope: InfraFailure.K8S,
+                stageName: stageName,
+                attempt: attempt,
+                backoffMs: 60L * 1000L,
+            ]
+            trtllm_utils.launchKubernetesPod(pipeline, podSpec, containerName, { runner(attemptTag, isFinalAttempt, retryContext) })
             if (attempt > 1) {
                 echo "[INFRA-RETRY] ${stageName}: Succeeded on attempt ${attempt}"
             }
@@ -3617,6 +3768,11 @@ def runKubernetesPodWithInfraRetry(pipeline, podSpec, containerName, String stag
             if (attempt > effectiveMax) {
                 echo "[INFRA-RETRY] ${stageName}: Infrastructure failure (${c.detectedPattern}) " +
                      "but max retries (${effectiveMax}) exhausted after ${attempt} attempts. Failing."
+                throw e
+            }
+            if (!hasBudgetForInfraRetry(pipeline, stageName, InfraFailure.K8S, c, attempt, effectiveMax, 60L * 1000L, true)) {
+                echo "[INFRA-RETRY] ${stageName}: Infrastructure failure (${c.detectedPattern}) is retryable, " +
+                     "but remaining CI timeout budget is too small for another K8s attempt. Failing without retry."
                 throw e
             }
 
@@ -3740,7 +3896,7 @@ def launchTestJobs(pipeline, testFilter)
         "RTXPro6000D-4_GPUs-PyTorch-Post-Merge-2": ["rtx-pro-6000d-x4", "l0_rtx_pro_6000", 2, 2, 4],
     ]
 
-    parallelJobs = x86TestConfigs.collectEntries{key, values -> [key, [createKubernetesPodConfig(LLM_DOCKER_IMAGE, values[0], "amd64", values[4] ?: 1, key.contains("-Perf-")), { attemptTag, isFinalAttempt ->
+    parallelJobs = x86TestConfigs.collectEntries{key, values -> [key, [createKubernetesPodConfig(LLM_DOCKER_IMAGE, values[0], "amd64", values[4] ?: 1, key.contains("-Perf-")), { attemptTag, isFinalAttempt, retryContext = null ->
         def config = VANILLA_CONFIG
         if (key.contains("single-device")) {
             config = SINGLE_DEVICE_CONFIG
@@ -3748,7 +3904,7 @@ def launchTestJobs(pipeline, testFilter)
         if (key.contains("llvm")) {
             config = LLVM_CONFIG
         }
-        runLLMTestlistOnPlatform(pipeline, values[0], values[1], config, key.contains("-Perf-"), key, values[2], values[3], false, "cp312", attemptTag, false, isFinalAttempt)
+        runLLMTestlistOnPlatform(pipeline, values[0], values[1], config, key.contains("-Perf-"), key, values[2], values[3], false, "cp312", attemptTag, false, isFinalAttempt, retryContext)
     }]]}
     fullSet = parallelJobs.keySet()
 
@@ -3815,7 +3971,7 @@ def launchTestJobs(pipeline, testFilter)
     )
     fullSet += x86SlurmTestConfigs.keySet()
 
-    parallelSlurmJobs = x86SlurmTestConfigs.collectEntries{key, values -> [key, [createKubernetesPodConfig(LLM_DOCKER_IMAGE, "slurm", "amd64"), { attemptTag, isFinalAttempt ->
+    parallelSlurmJobs = x86SlurmTestConfigs.collectEntries{key, values -> [key, [createKubernetesPodConfig(LLM_DOCKER_IMAGE, "slurm", "amd64"), { attemptTag, isFinalAttempt, retryContext = null ->
         // attemptTag comes from runKubernetesPodWithInfraRetry for the outer
         // dispatcher pod and is threaded into runLLMTestlistOnSlurm so the
         // inner SLURM retry can prefix its postTag with the outer attempt's
@@ -4031,12 +4187,12 @@ def launchTestJobs(pipeline, testFilter)
     fullSet += multiNodesSBSAConfigs.keySet()
 
     if (env.targetArch == AARCH64_TRIPLE) {
-        parallelJobs = SBSATestConfigs.collectEntries{key, values -> [key, [createKubernetesPodConfig(LLM_DOCKER_IMAGE, values[0], "arm64"), { attemptTag, isFinalAttempt ->
-            runLLMTestlistOnPlatform(pipeline, values[0], values[1], LINUX_AARCH64_CONFIG, false, key, values[2], values[3], false, "cp312", attemptTag, false, isFinalAttempt)
+        parallelJobs = SBSATestConfigs.collectEntries{key, values -> [key, [createKubernetesPodConfig(LLM_DOCKER_IMAGE, values[0], "arm64"), { attemptTag, isFinalAttempt, retryContext = null ->
+            runLLMTestlistOnPlatform(pipeline, values[0], values[1], LINUX_AARCH64_CONFIG, false, key, values[2], values[3], false, "cp312", attemptTag, false, isFinalAttempt, retryContext)
         }]]}
 
         // Add SBSA Slurm jobs
-        parallelSlurmJobs = SBSASlurmTestConfigs.collectEntries{key, values -> [key, [createKubernetesPodConfig(LLM_DOCKER_IMAGE, "slurm", "arm64"), { attemptTag, isFinalAttempt ->
+        parallelSlurmJobs = SBSASlurmTestConfigs.collectEntries{key, values -> [key, [createKubernetesPodConfig(LLM_DOCKER_IMAGE, "slurm", "arm64"), { attemptTag, isFinalAttempt, retryContext = null ->
             // attemptTag is threaded into runLLMTestlistOnSlurm as the outer
             // dispatcher pod's tag so the inner SLURM retry's postTag can't
             // collide with a previous dispatcher pod's upload. See the x86
@@ -4053,7 +4209,7 @@ def launchTestJobs(pipeline, testFilter)
         parallelJobs += parallelSlurmJobs
 
         // Add SBSA multi node Slurm jobs
-        parallelMultiNodesSBSAJobs = multiNodesSBSAConfigs.collectEntries{key, values -> [key, [createKubernetesPodConfig(LLM_DOCKER_IMAGE, "slurm", "arm64"), { attemptTag, isFinalAttempt ->
+        parallelMultiNodesSBSAJobs = multiNodesSBSAConfigs.collectEntries{key, values -> [key, [createKubernetesPodConfig(LLM_DOCKER_IMAGE, "slurm", "arm64"), { attemptTag, isFinalAttempt, retryContext = null ->
             def config = LINUX_AARCH64_CONFIG
             if (key.contains("single-device")) {
                 config = SINGLE_DEVICE_CONFIG
@@ -4081,12 +4237,12 @@ def launchTestJobs(pipeline, testFilter)
         docBuildConfigs = [:]
     }
 
-    docBuildJobs = docBuildConfigs.collectEntries{key, values -> [key, [values[0], { attemptTag, isFinalAttempt ->
+    docBuildJobs = docBuildConfigs.collectEntries{key, values -> [key, [values[0], { attemptTag, isFinalAttempt, retryContext = null ->
         // attemptTag uniquifies the upload-once guard key and tar filename per
         // pod-launch attempt; isFinalAttempt suppresses synthetic stage-fail XML
         // and junit() on intermediate retryable infra failures.
         stage("[${key}] Run") {
-            cacheErrorAndUploadResult("${key}", values[1], {}, true, attemptTag, isFinalAttempt)
+            cacheErrorAndUploadResult("${key}", values[1], {}, true, attemptTag, isFinalAttempt, retryContext)
         }
     }]]}
 
@@ -4214,7 +4370,7 @@ def launchTestJobs(pipeline, testFilter)
             if (checkPipStage) {
                 stage("Run LLMAPI Test") {
                     pipInstallSanitySpec = createKubernetesPodConfig(values[5], gpu_type, k8s_arch)
-                    runKubernetesPodWithInfraRetry(pipeline, pipInstallSanitySpec, "trt-llm", toStageName(values[1], key), { attemptTag, isFinalAttempt ->
+                    runKubernetesPodWithInfraRetry(pipeline, pipInstallSanitySpec, "trt-llm", toStageName(values[1], key), { attemptTag, isFinalAttempt, retryContext = null ->
                         echo "###### Prerequisites Start ######"
                         echoNodeAndGpuInfo(pipeline, toStageName(values[1], key))
                         // Clean up the pip constraint file from the base NGC PyTorch image.
@@ -4273,7 +4429,7 @@ def launchTestJobs(pipeline, testFilter)
                         }
                         withEnv(libEnv) {
                             sh "env | sort"
-                            runLLMTestlistOnPlatform(pipeline, gpu_type, "l0_sanity_check", config, false, toStageName(values[1], key), 1, 1, true, cpver, "-SubJob-RunTest" + attemptTag, true, isFinalAttempt)
+                            runLLMTestlistOnPlatform(pipeline, gpu_type, "l0_sanity_check", config, false, toStageName(values[1], key), 1, 1, true, cpver, "-SubJob-RunTest" + attemptTag, true, isFinalAttempt, retryContext)
                         }
                     })
                 }
@@ -4460,8 +4616,8 @@ def launchTestJobs(pipeline, testFilter)
                     echo "Skip - Passed in the previous pipelines."
                 }
             } else if (values instanceof List) {
-                runKubernetesPodWithInfraRetry(pipeline, values[0], "trt-llm", key, { attemptTag, isFinalAttempt ->
-                    values[1](attemptTag, isFinalAttempt)
+                runKubernetesPodWithInfraRetry(pipeline, values[0], "trt-llm", key, { attemptTag, isFinalAttempt, retryContext = null ->
+                    values[1](attemptTag, isFinalAttempt, retryContext)
                 })
             } else {
                 values()
@@ -4534,10 +4690,10 @@ def launchTestJobsForImagesSanityCheck(pipeline, globalVars) {
             stage(values.name) {
                 echo "Run ${values.name} sanity test."
                 imageSanitySpec = createKubernetesPodConfig(values.image, values.gpuType, values.k8sArch)
-                runKubernetesPodWithInfraRetry(pipeline, imageSanitySpec, "trt-llm", values.name, { attemptTag, isFinalAttempt ->
+                runKubernetesPodWithInfraRetry(pipeline, imageSanitySpec, "trt-llm", values.name, { attemptTag, isFinalAttempt, retryContext = null ->
                     sh "env | sort"
                     trtllm_utils.llmExecStepWithRetry(pipeline, script: "apt-get update && apt-get install -y git rsync curl")
-                    runLLMTestlistOnPlatform(pipeline, values.gpuType, "l0_sanity_check", values.config, false, values.name, 1, 1, true, null, "-SubJob-TestImage" + attemptTag, true, isFinalAttempt)
+                    runLLMTestlistOnPlatform(pipeline, values.gpuType, "l0_sanity_check", values.config, false, values.name, 1, 1, true, null, "-SubJob-TestImage" + attemptTag, true, isFinalAttempt, retryContext)
                 })
             }
         } else {
@@ -4592,6 +4748,7 @@ pipeline {
                     println testFilter
                     echo "env.globalVars is: ${env.globalVars}"
                     globalVars = trtllm_utils.updateMapWithJson(this, globalVars, env.globalVars, "globalVars")
+                    globalVars = trtllm_utils.initializeCiBudget(this, globalVars, 24, 'HOURS', 'L0_Test')
                     globalVars[ACTION_INFO] = trtllm_utils.setupPipelineDescription(this, globalVars[ACTION_INFO])
                 }
             }

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1703,7 +1703,7 @@ def durationLookupKeys(String rawLine)
         return []
     }
     def keys = [testName]
-    def wrapperMatch = (testName =~ /^[^/]*test\w+\.py::(?:\w+::)*\w+\[(.+)\]$/)
+    def wrapperMatch = (testName =~ '^(?:.*/)?test\\w+\\.py::(?:\\w+::)*\\w+\\[(.+)\\]$')
     if (wrapperMatch.matches()) {
         keys << wrapperMatch[0][1]
     }

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1660,108 +1660,28 @@ class GlobalState {
     static final int MAX_PORT = 32000            // Maximum port number to avoid system ports
 }
 
-def parseLongOrDefault(def value, long defaultValue)
-{
-    if (value == null) {
-        return defaultValue
-    }
-    if (value instanceof Number) {
-        return value.longValue()
-    }
-    try {
-        return Long.parseLong(value.toString().trim())
-    } catch (NumberFormatException ignored) {
-        return defaultValue
-    }
-}
-
-long durationSecondsToMillis(def durationSeconds)
-{
-    if (durationSeconds == null) {
-        return 0L
-    }
-    double seconds
-    if (durationSeconds instanceof Number) {
-        seconds = durationSeconds.doubleValue()
-    } else {
-        seconds = Double.parseDouble(durationSeconds.toString().trim())
-    }
-    return Math.round(seconds * 1000D)
-}
-
-def durationLookupKeys(String rawLine)
-{
-    if (rawLine == null) {
-        return []
-    }
-    def testName = rawLine.trim()
-    if (!testName || testName.startsWith("#")) {
-        return []
-    }
-    testName = testName.replaceAll(/\s+(SKIP|TIMEOUT|ISOLATION)(\s*\([^)]*\))?.*$/, "").trim()
-    if (!testName) {
-        return []
-    }
-    def keys = [testName]
-    def wrapperMatch = (testName =~ '^(?:.*/)?test\\w+\\.py::(?:\\w+::)*\\w+\\[(.+)\\]$')
-    if (wrapperMatch.matches()) {
-        keys << wrapperMatch[0][1]
-    }
-    return keys.unique()
-}
-
 def recordRenderedStageAttemptEstimate(pipeline, String llmSrc, String testListPath, String stageName, def renderedTestCount)
 {
-    long defaultUnknownMs = stageName.contains("-Perf") ? 20L * 60L * 1000L : 10L * 60L * 1000L
-    long renderedCount = parseLongOrDefault(renderedTestCount, 0L)
-    long estimatedMs = renderedCount * defaultUnknownMs
-    int knownCount = 0
-    int unknownCount = renderedCount as int
-
-    try {
-        def durationText = readFile(file: "${llmSrc}/tests/integration/defs/.test_durations")
-        def durations = new groovy.json.JsonSlurperClassic().parseText(durationText)
-        long knownMs = 0L
-        int totalCount = 0
-        int missingCount = 0
-        readFile(file: testListPath).readLines().each { line ->
-            def keys = durationLookupKeys(line)
-            if (keys) {
-                totalCount++
-                def durationSeconds = keys.collect { durations[it] }.find { it != null }
-                if (durationSeconds != null) {
-                    knownCount++
-                    knownMs += durationSecondsToMillis(durationSeconds)
-                } else {
-                    missingCount++
-                }
-            }
-        }
-        if (totalCount > 0) {
-            unknownCount = missingCount
-            estimatedMs = knownMs + (missingCount * defaultUnknownMs)
-        }
-    } catch (Exception e) {
-        echo "[CI-BUDGET] ${stageName}: failed to read .test_durations; using count-based estimate. Error: ${e.toString()}"
+    def estimate = trtllm_utils.estimateRenderedStageAttemptMillis(pipeline, llmSrc, testListPath, stageName, renderedTestCount)
+    if (estimate.error) {
+        echo "[CI-BUDGET] ${stageName}: failed to read .test_durations; using count-based estimate. Error: ${estimate.error}"
     }
 
-    if (estimatedMs <= 0L && renderedCount > 0L) {
-        estimatedMs = renderedCount * defaultUnknownMs
-    }
-    GlobalState.stageAttemptEstimateMs[stageName] = estimatedMs
+    GlobalState.stageAttemptEstimateMs[stageName] = estimate.estimatedMs
     GlobalState.stageAttemptEstimateDetails[stageName] = [
-        renderedCount: renderedCount,
-        knownCount: knownCount,
-        unknownCount: unknownCount,
+        renderedCount: estimate.renderedCount,
+        knownCount: estimate.knownCount,
+        unknownCount: estimate.unknownCount,
     ]
     echo "[CI-BUDGET] ${stageName}: recorded test runtime estimate " +
-         "${trtllm_utils.formatCiBudgetMillis(estimatedMs)} " +
-         "(rendered=${renderedCount}, known=${knownCount}, unknown=${unknownCount})"
+         "${trtllm_utils.formatCiBudgetMillis(estimate.estimatedMs)} " +
+         "(rendered=${estimate.renderedCount}, known=${estimate.knownCount}, unknown=${estimate.unknownCount})"
 }
 
 long estimateStageRetryRuntimeMs(String stageName, String scope)
 {
-    long testEstimateMs = parseLongOrDefault(GlobalState.stageAttemptEstimateMs[stageName], 0L)
+    Long testEstimateValue = trtllm_utils.parseCiBudgetLong(GlobalState.stageAttemptEstimateMs[stageName])
+    long testEstimateMs = testEstimateValue != null ? testEstimateValue : 0L
     if (testEstimateMs > 0L) {
         long overheadMs = scope == InfraFailure.SLURM ? 45L * 60L * 1000L : 30L * 60L * 1000L
         return testEstimateMs + overheadMs
@@ -1809,9 +1729,11 @@ boolean retryContextAllowsRetry(def pipeline, Map retryContext, Throwable error,
     if (!(classified instanceof InfraFailure)) {
         return false
     }
-    int attempt = parseLongOrDefault(retryContext.attempt, 1L) as int
+    Long parsedAttempt = trtllm_utils.parseCiBudgetLong(retryContext.attempt)
+    int attempt = parsedAttempt != null ? parsedAttempt as int : 1
     int effectiveMax = retryMaxForFailure(scope, classified)
-    long backoffMs = parseLongOrDefault(retryContext.backoffMs, 60L * 1000L)
+    Long parsedBackoffMs = trtllm_utils.parseCiBudgetLong(retryContext.backoffMs)
+    long backoffMs = parsedBackoffMs != null ? parsedBackoffMs : 60L * 1000L
     return hasBudgetForInfraRetry(pipeline, retryContext.stageName ?: "Unknown", scope, classified, attempt, effectiveMax, backoffMs, logDecision)
 }
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented CI budget tracking across pipeline stages to manage resource allocation (24-hour budget per pipeline run).
  * Enhanced infrastructure retry logic to respect remaining CI budget—retries are skipped if insufficient time remains.

* **Chores**
  * Updated pipeline initialization to track and enforce CI time budgets across merge request and test execution stages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Introduce a "CI time budget" into L0_MergeRequest, which is plumbed through to build sub-stages.

If a retry is triggered, it checks how much budget is left before rescheduling and if it determines there isn't enough time left, it fails the run gracefully.

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

N/A, this is a CI change

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
