### PR TITLE
[None][chore] Reduce mhc autotune tactics

### DIFF
--- a/tensorrt_llm/_torch/modules/mhc/mhc_cuda.py
+++ b/tensorrt_llm/_torch/modules/mhc/mhc_cuda.py
@@ -599,6 +599,33 @@ _FUSED_HC_ALL_FMA_TN_KS_TM = tuple(
 _FUSED_HC_BIGFUSE_BS = _BIGFUSE_BLOCK_SIZE_OPTIONS
 
 
+def _fused_hc_mma_ks_options(hidden_size: int) -> tuple[int, ...]:
+    return tuple(ks for ks in _FUSED_HC_HALF_MMA_KS if _fused_hc_mma_ks_supported(hidden_size, ks))
+
+
+def _fused_hc_target_mma_ks(hidden_size: int, M: int) -> int | None:
+    """Pick the measured splitK ridge for the MMA fused_hc paths."""
+    valid = _fused_hc_mma_ks_options(hidden_size)
+    if not valid:
+        return None
+    m_tiles = max(1, (M + 63) // 64)
+    target = max(1, 128 // m_tiles)
+    candidates = tuple(ks for ks in valid if ks <= target)
+    return candidates[-1] if candidates else valid[0]
+
+
+def _fused_hc_mma_bigfuse_bs_options(M: int) -> tuple[int, ...]:
+    # Historical sweeps: 512 wins through M=256, 256 wins at 512/2048/4096,
+    # and M=1024 is split between 128 and 512 depending on hidden/mode.
+    if M < 512:
+        return (512,)
+    if M == 1024:
+        return (128, 512)
+    if M >= 8192:
+        return (128, 256)
+    return (256,)
+
+
 def _fused_hc_call(
     backend_code: int,
     tile_n: int,
@@ -844,52 +871,51 @@ class MhcFusedHcRunner(TunableRunner):
     def get_valid_tactics(self, inputs, profile: OptimizationProfile, **kwargs):
         M = inputs[0].shape[0]
         tactics = []
-        # All four backends support the fused next-layer RMSNorm now (Path B/E
-        # in bigfuse, Path D/F in the all-in-one epilogue), so the autotuner
-        # explores the full tactic space regardless of norm_weight.
+        seen = set()
+
+        def add(tactic):
+            if tactic not in seen:
+                seen.add(tactic)
+                tactics.append(tactic)
+
+        # FMA variants only win at very small M. For M > 32, keep autotuning
+        # to MMA-only choices and avoid spending time on FMA tactics that do
+        # not win in the measured H=4096/7168 sweeps.
         # The MMA (tcgen05) paths require SM100+. On older archs only the FMA
-        # paths are compilable/runnable — we simply never emit MMA tactics.
-        mma_ks = tuple(
-            ks for ks in _FUSED_HC_HALF_MMA_KS if _fused_hc_mma_ks_supported(self.hidden_size, ks)
-        )
+        # paths are compilable/runnable, so we simply never emit MMA tactics.
+        mma_ks = _fused_hc_mma_ks_options(self.hidden_size)
         mma_ok = _fused_hc_mma_supported() and bool(mma_ks)
-        # Path F (fused_all_fma, 1-kernel FMA) — preferred at small M (<=32)
-        # where MMA can't fill BLOCK_M=64. Include for M <= 64 as the
-        # crossover is measured per-M.
-        if M <= 64:
+
+        if M <= 32:
             for tn, ks, tm in _FUSED_HC_ALL_FMA_TN_KS_TM:
                 # Skip grids that wildly oversubscribe SMs.
                 m_batches = (M + tm - 1) // tm
                 if m_batches * (self.n * (2 + self.n) // tn) * ks > 148 * 4:
                     continue
-                # fused_all_fma runs bigfuse inline — no bigfuse_bs tactic axis.
-                tactics.append(("fused_all_fma", tn, ks, 0, tm))
-        # Path D (fused_all_mma, 1-kernel TF32 MMA) — preferred at mid/large
-        # M (>=64). Include when M >= 48 to overlap with Path F at the
-        # crossover boundary.
-        if mma_ok and M >= 48:
-            for ks in mma_ks:
-                m_tiles = (M + 63) // 64
-                if m_tiles * ks > 148 * 4:
-                    continue
-                tactics.append(("fused_all_mma", 0, ks, 0, 1))
-        # Half-fused FMA path (2-kernel) — useful at smallish M; kept as a
-        # fallback option for the autotuner at small M.
-        if M <= 512:
+                add(("fused_all_fma", tn, ks, 0, tm))
             for tn, ks in _FUSED_HC_HALF_FMA_TN_KS:
                 if ks > 1 and M * (self.n * (2 + self.n) // tn) >= 148 * 2:
                     continue
                 for bs in _FUSED_HC_BIGFUSE_BS:
-                    tactics.append(("fused_half_fma", tn, ks, bs, 1))
-        # Half-fused MMA path (2-kernel) — always an option when tcgen05 is
-        # available.
-        if mma_ok:
-            for ks in mma_ks:
+                    add(("fused_half_fma", tn, ks, bs, 1))
+
+        if mma_ok and M >= 32:
+            ks = _fused_hc_target_mma_ks(self.hidden_size, M)
+            if ks is not None:
                 m_tiles = (M + 63) // 64
-                if m_tiles * ks > 148 * 4:
-                    continue
-                for bs in _FUSED_HC_BIGFUSE_BS:
-                    tactics.append(("fused_half_mma", 0, ks, bs, 1))
+                if m_tiles * ks <= 148 * 4:
+                    for bs in _fused_hc_mma_bigfuse_bs_options(M):
+                        add(("fused_half_mma", 0, ks, bs, 1))
+                    if M >= 64:
+                        add(("fused_all_mma", 0, ks, 0, 1))
+
+        if not mma_ok and M > 32:
+            # Pre-SM100 fallback: keep one supported half-FMA ladder.
+            bs = 512 if M < 512 else 256
+            for tn, ks in _FUSED_HC_HALF_FMA_TN_KS:
+                if ks == 1:
+                    add(("fused_half_fma", tn, ks, bs, 1))
+
         return tactics
 
     def forward(self, inputs, *, tactic=-1, **kwargs):

--- a/tests/integration/test_lists/test-db/l0_b200_ds.yml
+++ b/tests/integration/test_lists/test-db/l0_b200_ds.yml
@@ -17,6 +17,7 @@ l0_b200_ds:
   # ------------- DeepSeek-V4 unit tests (single B200) ---------------
   # Sparse-attention kernels + cache manager + compressor + indices_transform
   # + o_proj. Only path to V4 sparse-attention kernel coverage in CI.
+  - unittest/_torch/modules/test_mhc.py
   - unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_sparse_mla.py TIMEOUT (60)
   - unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py TIMEOUT (60)
   - unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_indices_transform.py TIMEOUT (60)

--- a/tests/unittest/_torch/modules/test_mhc.py
+++ b/tests/unittest/_torch/modules/test_mhc.py
@@ -978,6 +978,142 @@ def test_mhc_fused_hc_cuda_graph(n: int, hidden_size: int, hc_mult: int):
         )
 
 
+def _make_fused_hc_runner_case(n: int, hidden_size: int, hc_mult: int, seed: int):
+    from tensorrt_llm._torch.modules.mhc.mhc_cuda import MhcFusedHcRunner
+
+    pre_data = generate_pre_data(n=n, hc_mult=hc_mult, hidden_size=hidden_size)
+
+    torch.random.manual_seed(seed)
+    device = "cuda"
+    x_prev = torch.randn((n, hidden_size), dtype=torch.bfloat16, device=device) / hidden_size
+    residual_prev = (
+        torch.randn((n, hc_mult, hidden_size), dtype=torch.float, device=device) / hidden_size
+    ).bfloat16()
+    post_mix_prev = torch.randn((n, hc_mult, 1), dtype=torch.float32, device=device) * 0.1
+    comb_mix_prev = torch.randn((n, hc_mult, hc_mult), dtype=torch.float32, device=device) * 0.1
+
+    cur_module = mHC(
+        mult=hc_mult,
+        hidden_size=hidden_size,
+        sinkhorn_iters=pre_data["sinkhorn_repeat"],
+        dtype=None,
+        eps=pre_data["hc_pre_eps"],
+        norm_eps=pre_data["rms_eps"],
+        post_mult_value=pre_data["hc_post_mult_value"],
+    ).cuda()
+    cur_module.fn.copy_(pre_data["fn"])
+    cur_module.scale.copy_(pre_data["hc_scale"])
+    cur_module.base.copy_(pre_data["hc_base"])
+
+    runner = MhcFusedHcRunner(
+        n=hc_mult,
+        hidden_size=hidden_size,
+        rms_eps=pre_data["rms_eps"],
+        hc_pre_eps=pre_data["hc_pre_eps"],
+        hc_sinkhorn_eps=pre_data["hc_sinkhorn_eps"],
+        hc_post_mult_value=pre_data["hc_post_mult_value"],
+        sinkhorn_repeat=pre_data["sinkhorn_repeat"],
+    )
+
+    inputs = [
+        x_prev,
+        residual_prev.reshape(n, hc_mult, hidden_size).contiguous(),
+        post_mix_prev.reshape(n, hc_mult).contiguous(),
+        comb_mix_prev.reshape(n, hc_mult, hc_mult).contiguous(),
+        cur_module.fn,
+        cur_module.scale,
+        cur_module.base,
+    ]
+    return runner, inputs
+
+
+def _assert_graph_replay_matches_eager(runner, inputs, tactic):
+    runner(inputs=inputs, tactic=tactic)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_out = runner(inputs=inputs, tactic=tactic)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    for tensor in inputs[:4]:
+        tensor.mul_(1.0007)
+
+    eager_out = tuple(t.clone() for t in runner(inputs=inputs, tactic=tactic))
+    torch.cuda.synchronize()
+    graph.replay()
+    torch.cuda.synchronize()
+
+    for actual, expected, name in zip(
+        graph_out, eager_out, ("residual", "post_mix", "comb_mix", "layer_input")
+    ):
+        # splitK atomics are not bit-exact, but stale graph pointers or bad
+        # workspace reuse would diverge far beyond this bf16-scale tolerance.
+        torch.testing.assert_close(
+            actual,
+            expected,
+            rtol=3e-2,
+            atol=5e-2,
+            msg=f"fused_hc CUDA-graph replay mismatch in {name}; tactic={tactic}",
+        )
+
+
+@pytest.mark.parametrize("n", [64, 128])
+@pytest.mark.parametrize(
+    "tactic",
+    [
+        ("fused_half_mma", 0, 64, 512, 1),
+        ("fused_all_mma", 0, 64, 0, 1),
+    ],
+)
+def test_mhc_fused_hc_cuda_graph_high_splitk_tactics(n: int, tactic):
+    """Reduced autotune maps decode buckets to high-splitK MMA tactics.
+
+    Unlike the bit-exact ks=1 graph test above, this covers the actual
+    M=64/128 PR autotune path where splitK atomics and CUDA graph replay are
+    both active.
+    """
+    runner, inputs = _make_fused_hc_runner_case(n=n, hidden_size=4096, hc_mult=4, seed=41 + n)
+    _assert_graph_replay_matches_eager(runner, inputs, tactic)
+
+
+def test_mhc_fused_hc_cuda_graph_decode_buckets_then_prefill():
+    """Capture reduced-autotune decode buckets, then run the large prefill path.
+
+    The CI failure happened after CUDA graph warmup for decode buckets and on
+    the subsequent M=8192 warmup. This test keeps that ordering local to
+    fused_hc and covers both PR-selected M=8192 MMA tactics.
+    """
+    hidden_size = 4096
+    hc_mult = 4
+
+    for n in (128, 64):
+        for tactic in (
+            ("fused_half_mma", 0, 64, 512, 1),
+            ("fused_all_mma", 0, 64, 0, 1),
+        ):
+            runner, inputs = _make_fused_hc_runner_case(
+                n=n, hidden_size=hidden_size, hc_mult=hc_mult, seed=100 + n
+            )
+            _assert_graph_replay_matches_eager(runner, inputs, tactic)
+
+    runner, inputs = _make_fused_hc_runner_case(
+        n=8192, hidden_size=hidden_size, hc_mult=hc_mult, seed=8192
+    )
+    for tactic in (
+        ("fused_half_mma", 0, 1, 128, 1),
+        ("fused_half_mma", 0, 1, 256, 1),
+        ("fused_all_mma", 0, 1, 0, 1),
+    ):
+        outputs = runner(inputs=inputs, tactic=tactic)
+        torch.cuda.synchronize()
+        for output in outputs:
+            assert torch.isfinite(output.float()).all(), (
+                f"non-finite fused_hc output; tactic={tactic}"
+            )
+
+
 @pytest.mark.parametrize("m", [64, 128, 4096, 8192])
 @pytest.mark.parametrize("hidden_size", [4096, 7168])
 @pytest.mark.parametrize("hc_mult", [4])


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description


  ## Summary

  Reduce `MhcFusedHcRunner` autotune time by pruning fused mHC tactics that did not win in the measured H=4096/H=7168 sweeps.

  Changes:
  - Keep FMA backend tactics only for `M <= 32`
  - Use MMA-only candidates for `M > 32`
  - Collapse MMA tuning to the measured splitK / BigFuse ridge
  - Leave kernel implementations unchanged

  ## Impact

  For `M <= 4096` with the existing 39 M buckets:

  | hidden_size | Before | After | Reduction |
  |---:|---:|---:|---:|
  | 4096 | 1386 | 522 | 62.3% |
  | 7168 | 1680 | 522 | 68.9% |

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
