### PR TITLE
[None][fix] Cache FP8 reload staging buffer to fix memory regression

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -624,12 +624,16 @@ class FusedMoEMethodBase(ABC):
 
     def pre_reload_weights(self, module: torch.nn.Module):
         for param_name, metadata in module.rebuild_tensor_metadata.items():
-            # Extract meta tensor from metadata dict
-            meta_tensor = metadata['meta']
-            param = torch.nn.Parameter(torch.empty_like(meta_tensor,
-                                                        device="cuda"),
-                                       requires_grad=False)
-            module.register_parameter(param_name, param)
+            # Reuse the cached staging buffer to avoid allocating a fresh
+            # original-shape FP8 tensor on every reload (memory regression fix).
+            # On the first call 'reload_buf' is absent so we allocate once and
+            # cache it; subsequent calls reuse the existing buffer.
+            if 'reload_buf' not in metadata:
+                meta_tensor = metadata['meta']
+                metadata['reload_buf'] = torch.nn.Parameter(
+                    torch.empty_like(meta_tensor, device="cuda"),
+                    requires_grad=False)
+            module.register_parameter(param_name, metadata['reload_buf'])
 
 
 class UnquantizedFusedMoEMethod(FusedMoEMethodBase):

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -455,11 +455,16 @@ class LinearMethodBase(ABC):
         Pre-reload weights for the linear layer.
         """
         for param_name, metadata in module.rebuild_tensor_metadata.items():
-            # Extract meta tensor from metadata dict
-            meta_tensor = metadata['meta']
-            param = Parameter(torch.empty_like(meta_tensor, device="cuda"),
-                              requires_grad=False)
-            module.register_parameter(param_name, param)
+            # Reuse the cached staging buffer to avoid allocating a fresh
+            # original-shape FP8 tensor on every reload (memory regression fix).
+            # On the first call 'reload_buf' is absent so we allocate once and
+            # cache it; subsequent calls reuse the existing buffer.
+            if 'reload_buf' not in metadata:
+                meta_tensor = metadata['meta']
+                metadata['reload_buf'] = Parameter(
+                    torch.empty_like(meta_tensor, device="cuda"),
+                    requires_grad=False)
+            module.register_parameter(param_name, metadata['reload_buf'])
 
 
 class UnquantizedLinearMethod(LinearMethodBase):


### PR DESCRIPTION
## Summary

PRs #10456 (partial FP8 weight update) and #11267 (CUDA-graph-compatible weight update) together introduced a memory regression in the FP8 weight refit path:

- `replace_parameter_and_save_metadata` (`tensorrt_llm/_torch/utils.py:489`) pins the **resmoothed FP8 tensor** alive via `metadata['param']` so the underlying device pointer is stable across refits — this is what makes the refit compatible with CUDA-graph capture (the captured graph references the resmoothed tensor's pointer). This pin is **necessary and must stay**.
- `LinearMethodBase.pre_reload_weights` (`tensorrt_llm/_torch/modules/linear.py`) and `FusedMoEMethodBase.pre_reload_weights` (`tensorrt_llm/_torch/modules/fused_moe/quantization.py`) each allocated a **fresh** original-shape FP8 staging buffer (`torch.empty_like(metadata['meta'])`) on every reload and `register_parameter`'d it as the module's weight. During reload the module transiently held both the pinned resmoothed tensor and the new staging buffer, doubling FP8 weight memory and causing OOM regressions.

## Fix

Mirror the first-call-vs-subsequent-call pattern already used by `replace_parameter_and_save_metadata`:

- First `pre_reload_weights` call for a param: allocate the staging `Parameter` once and cache it under a new metadata key `'reload_buf'`.
- Subsequent calls: reuse the cached `'reload_buf'` — no allocation.
- Either way, `register_parameter(param_name, <buf>)` is still called so the loader writes into the staging buffer before `post_load_weights` resmooths it into the pinned tensor.

Peak FP8 memory during refit is now constant (1× resmoothed + 1× original-shape staging) instead of growing per reload.

`metadata['param']` semantics are unchanged — the CUDA-graph pointer-stability guarantee added by #11267 is preserved.

This is safe for the partial-loading path (`allow_partial_loading=True`): the reused buffer holds the previous reload's values, which is strictly more defined than the prior `torch.empty_like` (uninitialized memory). `post_load_weights` resmooths the full buffer and `copy_`s the result into the pinned resmoothed tensor as before.

All MoE quant subclasses (FP8QDQ, DeepSeekFP8BlockScales, NVFP4, …) inherit `FusedMoEMethodBase.pre_reload_weights` and need no further edits.

## Test plan

- [ ] `pytest tests/unittest/_torch/pyexecutor/test_model_loader_mx.py -k reload`
- [ ] `pytest tests/unittest/_torch/ray_orchestrator/single_gpu/test_llm_update_weights.py`
- [ ] Manual memory check: run a CUDA-graph-enabled FP8 LLM init + at least two `update_weights()` refits; verify `torch.cuda.max_memory_allocated()` is flat across refits (was growing by ~1× FP8 weight size per refit before the fix).
- [ ] CUDA-graph compatibility: confirm pinned resmoothed tensor's `data_ptr()` for at least one `Linear.weight` and one MoE `w3_w1_weight` is unchanged across refits (compare `id(metadata['param'])` and `.data_ptr()` before/after `update_weights`).
- [ ] Re-run the `allow_partial_loading=True` FP8 test added in #10456 to confirm output equivalence with a full reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized weight reloading by caching CUDA staging buffers, reducing memory allocation overhead and improving performance during model reload cycles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->