### PR TITLE
[None][feat] add KV cache reuse probe

### DIFF
--- a/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.pyi
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.pyi
@@ -167,7 +167,7 @@ class _KVCache:
         self,
         manager: "KVCacheManager",
         reuse_scope: ReuseScope,
-        input_tokens: Sequence[TokenIdExt] | None,
+        reuse_match: Any | None,
         id: Any,
         custom_priority_callback: Callable[[int, Any], Priority],
     ) -> None: ...
@@ -305,6 +305,11 @@ class KVCacheManager:
         id: Any = None,
         custom_priority_callback: Callable[[int, Any], Priority] = ...,
     ) -> _KVCache: ...
+    def probe_reuse(
+        self,
+        reuse_scope: ReuseScope | None = None,
+        input_tokens: Sequence[TokenIdExt] | None = None,
+    ) -> int: ...
     def resize(self, cache_level: CacheLevel, quota: int, best_efforts: bool = False) -> bool: ...
     def get_quota(self, cache_level: CacheLevel) -> int: ...
     @property

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_block_radix_tree.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_block_radix_tree.py
@@ -14,12 +14,12 @@
 # limitations under the License.
 
 import hashlib
-from typing import TYPE_CHECKING, Iterator, NamedTuple, Sequence, TypeVar, cast
+from typing import TYPE_CHECKING, Iterable, Iterator, NamedTuple, Sequence, TypeVar, cast
 
 from . import rawref
 from ._common import NDEBUG, BlockOrdinal, PageStatus, TokenId, TokenIdExt
 from ._life_cycle_registry import AttnLifeCycle, LifeCycle, LifeCycleId, LifeCycleRegistry
-from ._utils import TypedIndexList, chunked, div_up, filled_list, unwrap_rawref
+from ._utils import TypedIndexList, chunked, div_up, filled_list, find_index, unwrap_rawref
 
 if TYPE_CHECKING:
     from ._page import CommittedPage
@@ -48,6 +48,13 @@ class ReuseScope(NamedTuple):
                     "Did you forget to update to_bytes() when adding new non-int fields to ReuseScope?"
                 )
         return ret
+
+
+class ReuseMatch(NamedTuple):
+    """Volatile result of a KV cache prefix match."""
+
+    blocks: list["Block"]
+    num_tokens: int
 
 
 # id_offset is usually vocab_size
@@ -424,9 +431,22 @@ class BlockRadixTree:
         assert not self.next
         return ret
 
+    def _num_matched_tokens(self, matched: list[tuple[Block, int]]) -> int:
+        if not matched:
+            return 0
+        return self._tokens_per_block * (len(matched) - 1) + matched[-1][1]
+
+    @staticmethod
+    def _has_pages(block: Block, lc_list: Iterable[LifeCycleId]) -> bool:
+        return all(block.storage[lc] is not None for lc in lc_list)
+
+    @staticmethod
+    def _has_page(block: Block, lc: LifeCycleId) -> bool:
+        return block.storage[lc] is not None
+
     # yields tuples of (block, num_matched_tokens). num_matched_tokens should be equal to
     # tokens_per_block except the last one.
-    def match(
+    def _match_token_path(
         self,
         reuse_scope: ReuseScope,
         tokens: Sequence[TokenIdExt],
@@ -452,6 +472,96 @@ class BlockRadixTree:
             if partial_block is not None:
                 block = partial_block
                 yield block, match_len
+
+    def _prune_match(self, matched: list[tuple[Block, int]]) -> list[tuple[Block, int]]:
+        tokens_per_block = self._tokens_per_block
+        assert all(b[1] == tokens_per_block for b in matched[:-1])
+
+        life_cycles = self._life_cycles
+
+        # check for full attention layers
+        attn_life_cycles = list(life_cycles.attention_life_cycles())
+        if any(lc.window_size is None for _, lc in attn_life_cycles):
+            lc_list = [lc_idx for lc_idx, lc in attn_life_cycles if lc.window_size is None]
+
+            def check_no_pages(b: tuple[Block, int]) -> bool:
+                return not BlockRadixTree._has_pages(b[0], lc_list)
+
+            n = find_index(matched, check_no_pages)
+            matched = matched[:n]
+
+        swa_life_cycles = tuple(
+            (lc_idx, lc) for lc_idx, lc in attn_life_cycles if lc.window_size is not None
+        )
+        # check for SWA sink
+        for lc_idx, lc in swa_life_cycles:
+
+            def check_no_page_lc(b: tuple[Block, int]) -> bool:
+                return not BlockRadixTree._has_page(b[0], lc_idx)
+
+            n = find_index(matched[: lc.num_sink_blocks], check_no_page_lc)
+            if n < lc.num_sink_blocks:
+                matched = matched[:n]
+        # Check SWA window and SSM snapshot constraints together,
+        # since SSM truncation can invalidate SWA invariants.
+        # SSM is checked first (intervals are large, so it prunes more).
+        ssm_lc_id = life_cycles.ssm_life_cycle_id
+        while matched:
+            # SSM truncation: truncate to the last block with an SSM snapshot
+            if ssm_lc_id is not None:
+                ssm_trunc = 0
+                for i in reversed(range(len(matched))):
+                    if matched[i][0].storage[ssm_lc_id] is not None:
+                        assert NDEBUG or matched[i][1] == self._tokens_per_block, (
+                            "SSM reuse snapshot must only be selected from a fully matched block"
+                        )
+                        ssm_trunc = i + 1
+                        break
+                matched = matched[:ssm_trunc]
+                if not matched:
+                    break
+            # SWA window check
+            num_tokens = self._num_matched_tokens(matched)
+            for lc_idx, lc in swa_life_cycles:
+                if lc.window_size is None:
+                    continue
+
+                def check_has_page_lc(b: tuple[Block, int]) -> bool:
+                    return BlockRadixTree._has_page(b[0], lc_idx)
+
+                n = find_index(reversed(matched), check_has_page_lc)
+                if n != 0:
+                    matched = matched[:-n]
+                    break
+                _, stale_end = lc.get_stale_range(num_tokens, tokens_per_block)
+
+                def has_no_page(b: tuple[Block, int]) -> bool:
+                    return not BlockRadixTree._has_page(b[0], lc_idx)
+
+                n = find_index(reversed(matched[stale_end:]), has_no_page)
+                if len(matched) - n > stale_end:
+                    matched = matched[: len(matched) - n - 1]
+                    break
+            else:
+                break
+        return matched
+
+    def match(
+        self,
+        reuse_scope: ReuseScope,
+        tokens: Sequence[TokenIdExt],
+        enable_partial_match: bool = False,
+    ) -> ReuseMatch:
+        """
+        Return the currently reusable prefix match without holding pages.
+
+        The result is volatile: callers that need to reuse the returned blocks must
+        acquire ownership of the pages before depending on them.
+        """
+        matched = self._prune_match(
+            list(self._match_token_path(reuse_scope, tokens, enable_partial_match))
+        )
+        return ReuseMatch([block for block, _ in matched], self._num_matched_tokens(matched))
 
     def _check_sanity(self) -> bool:
         raise NotImplementedError(

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -20,10 +20,10 @@ from collections.abc import Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from itertools import chain
-from typing import TYPE_CHECKING, Callable, ClassVar, Iterable, Iterator, NamedTuple, Type, cast
+from typing import TYPE_CHECKING, Callable, ClassVar, Iterator, NamedTuple, Type, cast
 
 from .. import rawref
-from .._block_radix_tree import Block, ReuseScope, RootBlock, UselessBlockError
+from .._block_radix_tree import Block, ReuseMatch, ReuseScope, RootBlock, UselessBlockError
 from .._common import (
     BAD_BLOCK_ORDINAL,
     BAD_PAGE_INDEX,
@@ -69,7 +69,6 @@ from .._utils import (
     div_up,
     expect_type,
     filled_list,
-    find_index,
     make_typed,
     map_optional,
     stream_wait_events,
@@ -241,7 +240,7 @@ class _KVCache:
         self,
         manager: "KVCacheManager",
         reuse_scope: ReuseScope,
-        input_tokens: Sequence[TokenIdExt] | None,
+        reuse_match: ReuseMatch | None,
         id: int | None,
         custom_priority_callback: Callable[[BlockOrdinal, LifeCycle], Priority],
     ):
@@ -274,8 +273,8 @@ class _KVCache:
             lambda _: list[ScratchSlotLock](), manager._storage.num_life_cycles
         )
         self.__rawref__ = rawref.NULL
-        if input_tokens is not None:
-            self._setup_for_reuse(input_tokens)
+        if reuse_match is not None:
+            self._setup_for_reuse(reuse_match)
         self._avg_history_length = Average()
         self._avg_capacity = Average()
         self._avg_history_length.update(self.history_length)
@@ -1392,92 +1391,25 @@ class _KVCache:
         beg, end = life_cycle.get_stale_range(history_length, tokens_per_block)
         return HalfOpenRange(BlockOrdinal(beg), BlockOrdinal(end))
 
-    def _setup_for_reuse(self, input_tokens: Sequence[TokenIdExt]) -> None:
+    def _get_matched_tokens(self, match: ReuseMatch) -> list[TokenIdExt]:
+        ret: list[TokenIdExt] = []
+        remaining = match.num_tokens
+        for block in match.blocks:
+            assert remaining > 0
+            num_block_tokens = min(remaining, len(block.tokens))
+            ret.extend(block.tokens[:num_block_tokens])
+            remaining -= num_block_tokens
+        assert remaining == 0
+        return ret
+
+    def _setup_for_reuse(self, match: ReuseMatch) -> None:
         manager = self.manager
-        matched = list(
-            manager._radix_tree.match(
-                self._reuse_scope, input_tokens or [], manager.enable_partial_match
-            )
-        )
+        matched = match.blocks
         tokens_per_block = manager.tokens_per_block
-        assert all(b[1] == tokens_per_block for b in matched[:-1])
-
-        def get_num_matched_tokens(_):  # @fixme: remove the _ parameter
-            return tokens_per_block * (len(matched) - 1) + matched[-1][1] if matched else 0
-
+        num_tokens = match.num_tokens
         life_cycles = manager._life_cycles
-
-        def has_pages(block: Block, lc_list: Iterable[LifeCycleId]) -> bool:
-            return all(block.storage[lc] is not None for lc in lc_list)
-
-        # check for full attention layers
-        attn_life_cycles = list(life_cycles.attention_life_cycles())
-        if any(lc.window_size is None for _, lc in attn_life_cycles):
-            lc_list = [lc_idx for lc_idx, lc in attn_life_cycles if lc.window_size is None]
-
-            def check_no_pages(b: tuple[Block, int]):
-                return not has_pages(b[0], lc_list)
-
-            n = find_index(matched, check_no_pages)
-            matched = matched[:n]
-
-        def has_page(block: Block, lc: LifeCycleId) -> bool:
-            return block.storage[lc] is not None
-
-        swa_life_cycles = tuple(
-            (lc_idx, lc) for lc_idx, lc in attn_life_cycles if lc.window_size is not None
-        )
-        # check for SWA sink
-        for lc_idx, lc in swa_life_cycles:
-
-            def check_no_page_lc(b: tuple[Block, int]):
-                return not has_page(b[0], lc_idx)
-
-            n = find_index(matched[: lc.num_sink_blocks], check_no_page_lc)
-            if n < lc.num_sink_blocks:
-                matched = matched[:n]
-        # Check SWA window and SSM snapshot constraints together,
-        # since SSM truncation can invalidate SWA invariants.
-        # SSM is checked first (intervals are large, so it prunes more).
         ssm_lc_id = life_cycles.ssm_life_cycle_id
-        num_tokens = 0
-        while matched:
-            # SSM truncation: truncate to the last block with an SSM snapshot
-            if ssm_lc_id is not None:
-                ssm_trunc = 0
-                for i in reversed(range(len(matched))):
-                    if matched[i][0].storage[ssm_lc_id] is not None:
-                        ssm_trunc = i + 1
-                        break
-                matched = matched[:ssm_trunc]
-                if not matched:
-                    break
-            # SWA window check
-            num_tokens = get_num_matched_tokens(matched)
-            for lc_idx, lc in swa_life_cycles:
-                if lc.window_size is None:
-                    continue
-
-                def check_has_page_lc(b: tuple[Block, int]):
-                    return has_page(b[0], lc_idx)
-
-                n = find_index(reversed(matched), check_has_page_lc)
-                if n != 0:
-                    matched = matched[:-n]
-                    break
-                _, stale_end = _KVCache._get_stale_range(tokens_per_block, num_tokens, lc)
-
-                def check_no_page_stale(b: tuple[Block, int]):
-                    return not has_page(b[0], lc_idx)
-
-                n = find_index(reversed(matched[stale_end:]), check_no_page_stale)
-                if len(matched) - n > stale_end:
-                    matched = matched[: len(matched) - n]
-                    break
-            else:
-                break
-        num_tokens = get_num_matched_tokens(matched)
-        self._committed_tokens = list(input_tokens[:num_tokens])
+        self._committed_tokens = self._get_matched_tokens(match)
         self._history_length = num_tokens
         self._capacity = num_tokens
         # fill self._blocks
@@ -1489,9 +1421,9 @@ class _KVCache:
                         lambda _: filled_list(cast(BlockPage, None), life_cycles.size),
                         self.beam_width,
                     ),
-                    b[0],
+                    block,
                 )
-                for b in matched
+                for block in matched
             ],
         )
 
@@ -1500,20 +1432,18 @@ class _KVCache:
         for lc_idx, lc in life_cycles.items():
             if lc_idx == ssm_lc_id:
                 continue  # SSM is handled separately below
-            stale_start, stale_end = _KVCache._get_stale_range(
-                tokens_per_block, get_num_matched_tokens(matched), lc
-            )
+            stale_start, stale_end = _KVCache._get_stale_range(tokens_per_block, num_tokens, lc)
             for ordinal in chain(
                 typed_range(stale_start), typed_range(stale_end, BlockOrdinal(len(matched)))
             ):
                 block = self._block(ordinal, beam_idx)
-                holder = unwrap_rawref(unwrap_optional(matched[ordinal][0].storage[lc_idx])).hold()
+                holder = unwrap_rawref(unwrap_optional(matched[ordinal].storage[lc_idx])).hold()
                 # For partial blocks (last block, not full), we defer the copy to first resume().
                 # Just store the holder of the original committed page for now.
                 block[lc_idx] = holder
         # SSM reuse: hold the snapshot from the last matched block. Copy is deferred to first resume().
         if ssm_lc_id is not None and matched:
-            snapshot_block = matched[-1][0]
+            snapshot_block = matched[-1]
             snapshot_ref = snapshot_block.storage[ssm_lc_id]
             assert snapshot_ref is not None, (
                 "Last matched block must have SSM snapshot after truncation"

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from typing import Iterable, Iterator, cast
 
 from .. import rawref
-from .._block_radix_tree import BlockRadixTree, ReuseScope
+from .._block_radix_tree import BlockRadixTree, ReuseMatch, ReuseScope
 from .._common import (
     BAD_PAGE_INDEX,
     GPU_LEVEL,
@@ -361,13 +361,38 @@ class KVCacheManager:
         if reuse_scope is None:
             reuse_scope = ReuseScope()
         assert type(reuse_scope) is ReuseScope
+        reuse_match = (
+            self._match_reuse(reuse_scope, input_tokens) if input_tokens is not None else None
+        )
         return _KVCache(
             self,
             reuse_scope,
-            input_tokens,
+            reuse_match,
             id,
             custom_priority_callback,
         )
+
+    def _match_reuse(
+        self, reuse_scope: ReuseScope, input_tokens: Sequence[TokenIdExt]
+    ) -> ReuseMatch:
+        return self._radix_tree.match(reuse_scope, input_tokens, self.enable_partial_match)
+
+    def probe_reuse(
+        self,
+        reuse_scope: ReuseScope | None = None,
+        input_tokens: Sequence[TokenIdExt] | None = None,
+    ) -> int:
+        """
+        Return the currently reusable prefix length without holding pages.
+
+        The returned length is advisory because no page ownership is acquired.
+        """
+        if reuse_scope is None:
+            reuse_scope = ReuseScope()
+        assert type(reuse_scope) is ReuseScope
+        if input_tokens is None:
+            input_tokens = ()
+        return self._match_reuse(reuse_scope, input_tokens).num_tokens
 
     def resize(self, cache_level: CacheLevel, quota: int, best_efforts: bool = False) -> bool:
         """

--- a/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
@@ -515,10 +515,12 @@ class TestNoBatching(TestKVCacheManagerV2):
             kv_cache.close()
 
         def num_reused(reuse_scope: ReuseScope | None) -> int:
+            probed = self.manager.probe_reuse(reuse_scope, tokens[:-1])
             kv_cache = self.manager.create_kv_cache(reuse_scope, tokens[:-1])
             self.assertEqual(kv_cache._reuse_scope, reuse_scope or default_scope)
             ret = kv_cache.num_committed_tokens
             kv_cache.close()
+            self.assertEqual(probed, ret)
             return ret
 
         commit_for(scoped)

--- a/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_salting.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_salting.py
@@ -15,6 +15,7 @@
 """Pure unit tests for KV cache reuse scopes."""
 
 import unittest
+from collections.abc import Iterator
 from importlib.util import find_spec
 from typing import TYPE_CHECKING, cast
 
@@ -38,6 +39,13 @@ else:
 
 class _EmptyLifeCycles:
     size = 0
+
+    @property
+    def ssm_life_cycle_id(self) -> None:
+        return None
+
+    def attention_life_cycles(self) -> Iterator[tuple[object, object]]:
+        return iter(())
 
 
 class TestReuseScope(unittest.TestCase):
@@ -75,9 +83,17 @@ class TestReuseScope(unittest.TestCase):
         root = tree.add_or_get_existing(scope)
         block = Block(tokens, root)
 
-        self.assertEqual(list(tree.match(scope, tokens)), [(block, len(tokens))])
-        self.assertEqual(list(tree.match(other_scope, tokens)), [])
-        self.assertEqual(list(tree.match(other_scope, tokens[:1], enable_partial_match=True)), [])
+        match = tree.match(scope, tokens)
+        self.assertEqual(match.blocks, [block])
+        self.assertEqual(match.num_tokens, len(tokens))
+
+        match = tree.match(other_scope, tokens)
+        self.assertEqual(match.blocks, [])
+        self.assertEqual(match.num_tokens, 0)
+
+        match = tree.match(other_scope, tokens[:1], enable_partial_match=True)
+        self.assertEqual(match.blocks, [])
+        self.assertEqual(match.num_tokens, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:
- Move full KV cache reuse matching and pruning into BlockRadixTree.
- Have KVCacheManager create a ReuseMatch before constructing _KVCache.
- Add KVCacheManager.probe_reuse() for advisory prefix-match length without holding pages.
- Update reuse salting and reuse-scope tests.

Tests:
- ruff check _block_radix_tree.py _core/_kv_cache.py _core/_kv_cache_manager.py __init__.pyi tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_salting.py tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
- ruff format --check _block_radix_tree.py _core/_kv_cache.py _core/_kv_cache_manager.py __init__.pyi tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_salting.py tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
- PYTHONPYCACHEPREFIX=/tmp/kvcm_pycache python -m py_compile _block_radix_tree.py _core/_kv_cache.py _core/_kv_cache_manager.py tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_salting.py tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
- PYTHONPATH=/home/yaoy/tekit/tensorrt_llm/runtime PYTHONPYCACHEPREFIX=/tmp/kvcm_pycache python tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_salting.py -v
- PYTHONPATH=/home/yaoy/tekit/tensorrt_llm/runtime PYTHONPYCACHEPREFIX=/tmp/kvcm_pycache python tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py TestNoBatching.test_reuse_scope_isolates_reuse -v
- CUDA_VISIBLE_DEVICES=4 PYTHONPATH=/home/yaoy/tekit/tensorrt_llm/runtime PYTHONPYCACHEPREFIX=/tmp/kvcm_pycache python tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py -v: passed, 61 tests run, 12 skipped