### PR TITLE
[None][fix] Hide trailing EOS from generated text

### DIFF
--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -378,6 +378,8 @@ class GenerationResultBase:
 
         if sequence_is_finished:
             if finish_reasons[src_idx] == tllm.FinishReason.END_ID:
+                # Keep the trailing EOS in token_ids; the detokenizer hides
+                # it from text. stop_reason stays None to mark "natural EOS".
                 output.finish_reason = 'stop'
             elif finish_reasons[src_idx] == tllm.FinishReason.STOP_WORDS:
                 output.finish_reason = 'stop'
@@ -734,22 +736,36 @@ class DetokenizedGenerationResultBase(GenerationResultBase):
             'spaces_between_special_tokens':
             self.sampling_params.spaces_between_special_tokens
         }
+        end_id = self.sampling_params.end_id
+        include_stop = self.sampling_params.include_stop_str_in_output
+
         if self.sampling_params.detokenize and self.tokenizer is not None:
             for beam_output in self.outputs:
                 beam_output._last_text_len = len(beam_output.text)
+                # Hide trailing EOS from decoded text without mutating
+                # token_ids (matches vLLM). stop_reason is None gates on
+                # END_ID; STOP_WORDS sets it and was stripped upstream.
+                trim_eos = (beam_output.finish_reason == 'stop'
+                            and beam_output.stop_reason is None
+                            and not include_stop and end_id is not None)
                 if hasattr(
                         self.tokenizer, 'decode_incrementally'
                 ) and self._streaming and not self.sampling_params.use_beam_search:
+                    diff = beam_output.token_ids_diff
+                    if trim_eos and diff and diff[-1] == end_id:
+                        diff = diff[:-1]
                     beam_output.text, beam_output._incremental_states = self.tokenizer.decode_incrementally(
-                        beam_output.token_ids_diff,
+                        diff,
                         prev_text=beam_output.text,
                         states=beam_output._incremental_states,
                         flush=self._done,
                         stream_interval=self.sampling_params._stream_interval,
                         **kwargs)
                 else:
-                    beam_output.text = self.tokenizer.decode(
-                        beam_output.token_ids, **kwargs)
+                    tids = beam_output.token_ids
+                    if trim_eos and tids and tids[-1] == end_id:
+                        tids = tids[:-1]
+                    beam_output.text = self.tokenizer.decode(tids, **kwargs)
 
                 is_generating = not self._done
                 is_finished_with_stop_or_length = (


### PR DESCRIPTION
## Summary

When a request stopped on the natural EOS (`FinishReason.END_ID`), TRT-LLM previously relied solely on `skip_special_tokens=True` to keep the EOS string out of `output.text`. Whenever a caller set `skip_special_tokens=False` (e.g. some tool / structured-output parsers that need raw special tokens), or whenever the tokenizer did not flag the EOS id as a special token, the EOS string leaked into the OpenAI response text. vLLM does not exhibit this because it always slices the trailing stop token from the detokenized text. Observed on Nemotron-Super-V3 (EOS = `<|im_end|>`, id 11).

## Before vs After

**Repro** (programmatic; the example file is untouched):

```python
from tensorrt_llm import LLM, SamplingParams

llm = LLM(model="<path-to-Nemotron-Super-V3>",
          tensor_parallel_size=4, trust_remote_code=True)

prompt = llm.tokenizer.apply_chat_template(
    [{"role": "user", "content": "The capital of France is"}],
    tokenize=False, add_generation_prompt=True,
)
out = llm.generate(prompt, SamplingParams(
    max_tokens=128,
    skip_special_tokens=False,   # forces the EOS-leak code path
)).outputs[0]
print("text tail:", repr(out.text[-80:]))
print("last token_ids:", out.token_ids[-8:])
```

**Before fix** — `<|im_end|>` leaks into `output.text`:

```text
[0] text tail: "...started to introduce yourself but didn't finish the sentence. What is your name?<|im_end|>"
    last token_ids: [19286, 1046, 5675, 1395, 2143, 2564, 1063, 11]

[1] text tail: '...I should provide the answer directly.</think>The capital of France is **Paris**.<|im_end|>'
    last token_ids: [8961, 1307, 5498, 1395, 1603, 42572, 12617, 11]
```

**After fix** — `output.text` is clean, `output.token_ids` is unchanged:

```text
[0] text tail: "...started to introduce yourself but didn't finish the sentence. What is your name?"
    last token_ids: [19286, 1046, 5675, 1395, 2143, 2564, 1063, 11]   # id 11 still here

[1] text tail: '...I should provide the answer directly.</think>The capital of France is **Paris**.'
    last token_ids: [8961, 1307, 5498, 1395, 1603, 42572, 12617, 11]  # id 11 still here
```

Invariants preserved:
- `output.token_ids[-1] == sampling_params.end_id` whenever the request ended on natural EOS — useful for distinguishing "ended on EOS" (`stop_reason is None` + tail id matches `end_id`) from "ended on a configured stop_token_id" (`stop_reason` set). Matches vLLM.
- `len(output.token_ids) == len(output.logprobs)` for callers that requested logprobs.

**Default-path control** (the unchanged case where the EOS happens to be a tokenizer-marked special token AND `skip_special_tokens=True`):

```text
text tail: "...What is your name?"            # same as before fix
last token_ids: [..., 1063, 11]                # same as before fix
```

— i.e. no regression on the previously-working default path; the fix only changes behavior on the path that was leaking.

## Files changed

`tensorrt_llm/executor/result.py` only (+19 / −3 lines):
- `GenerationResultBase._handle_sequence` END_ID branch: comment only (no behavior change here).
- `DetokenizedGenerationResultBase._handle_response`: before each `tokenizer.decode` / `decode_incrementally` call, exclude the trailing `end_id` from the slice when:
  - `finish_reason == 'stop'`
  - `stop_reason is None`
  - `not include_stop_str_in_output`
  - the local list (`token_ids` or `token_ids_diff`) ends with `end_id`

  `output.token_ids` is left intact.

The pre-existing `STOP_WORDS` branch already strips its matched ids from `output.token_ids` upstream, so the new slice is a no-op for that path (its `stop_reason` is non-`None`, which gates the check off).

## Test plan

- [x] Re-ran Nemotron-Super-V3 (TP=4, B300, NVFP4) with both `skip_special_tokens=True` (default) and `skip_special_tokens=False`. Before fix: EOS leaks into text under `False`. After fix: no leak under either setting; `output.token_ids` ends with `end_id` in both cases.
- [x] Length-capped requests (no EOS reached) are unchanged in both `text` and `token_ids`.
- [x] Existing `test_generate_with_stop_words` (`tests/unittest/llmapi/test_llm.py:835`) covers the `end_id=stop_id` path with `similar(..., threshold=0.8)`. The fix only tightens the match (text no longer contains the trailing end_id glyph).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved end-of-sequence token handling in text generation to ensure EOS tokens are properly hidden from decoded output text while maintaining internal accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
