### PR TITLE
[https://nvbugs/6143883][fix] Preserve ip:port for trtllm-serve visual-gen

### DIFF
--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -560,23 +560,38 @@ def launch_visual_gen_server(
         visual_gen_args: Optional validated VisualGenArgs for model configuration.
         metadata_server_cfg: Optional metadata server configuration.
     """
-    logger.info(f"Initializing VisualGen ({model})")
+    # Reserve the listening (host, port) by binding the socket *before*
+    # constructing the VisualGen pipeline, then hand the bound socket to
+    # uvicorn. VisualGen initialization can take many minutes; if we deferred
+    # the bind until uvicorn started, anything else on the host could grab the
+    # port in that window and trtllm-serve would die at bind() time.
+    addr_info = socket.getaddrinfo(host, port, socket.AF_UNSPEC,
+                                   socket.SOCK_STREAM)
+    address_family = socket.AF_INET6 if all(
+        [info[0] == socket.AF_INET6 for info in addr_info]) else socket.AF_INET
+    with socket.socket(address_family, socket.SOCK_STREAM) as s:
+        try:
+            s.bind((host, port))
+        except OSError as e:
+            raise RuntimeError(f"Failed to bind socket to {host}:{port}: {e}")
 
-    visual_gen_model = VisualGen(model=model, args=visual_gen_args)
+        logger.info(f"Initializing VisualGen ({model})")
 
-    n_workers = visual_gen_model.args.parallel_config.n_workers
-    logger.info(f"World size: {n_workers}")
-    logger.info(f"CFG size: {visual_gen_model.args.parallel_config.cfg_size}")
-    logger.info(
-        f"Ulysses size: {visual_gen_model.args.parallel_config.ulysses_size}")
+        visual_gen_model = VisualGen(model=model, args=visual_gen_args)
 
-    server = OpenAIServer(generator=visual_gen_model,
-                          model=model,
-                          server_role=ServerRole.VISUAL_GEN,
-                          metadata_server_cfg=metadata_server_cfg,
-                          tool_parser=None)
-    _apply_fastapi_middlewares(server.app, middleware)
-    asyncio.run(server(host, port))
+        n_workers = visual_gen_model.args.parallel.n_workers
+        logger.info(f"World size: {n_workers}")
+        logger.info(f"CFG size: {visual_gen_model.args.parallel.dit_cfg_size}")
+        logger.info(
+            f"Ulysses size: {visual_gen_model.args.parallel.dit_ulysses_size}")
+
+        server = OpenAIServer(generator=visual_gen_model,
+                              model=model,
+                              server_role=ServerRole.VISUAL_GEN,
+                              metadata_server_cfg=metadata_server_cfg,
+                              tool_parser=None)
+        _apply_fastapi_middlewares(server.app, middleware)
+        asyncio.run(server(host, port, sockets=[s]))
 
 
 class ChoiceWithAlias(click.Choice):

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -579,11 +579,13 @@ def launch_visual_gen_server(
 
         visual_gen_model = VisualGen(model=model, args=visual_gen_args)
 
-        n_workers = visual_gen_model.args.parallel.n_workers
+        n_workers = visual_gen_model.args.parallel_config.n_workers
         logger.info(f"World size: {n_workers}")
-        logger.info(f"CFG size: {visual_gen_model.args.parallel.dit_cfg_size}")
         logger.info(
-            f"Ulysses size: {visual_gen_model.args.parallel.dit_ulysses_size}")
+            f"CFG size: {visual_gen_model.args.parallel_config.cfg_size}")
+        logger.info(
+            f"Ulysses size: {visual_gen_model.args.parallel_config.ulysses_size}"
+        )
 
         server = OpenAIServer(generator=visual_gen_model,
                               model=model,

--- a/tests/unittest/_torch/visual_gen/test_trtllm_serve_e2e.py
+++ b/tests/unittest/_torch/visual_gen/test_trtllm_serve_e2e.py
@@ -40,8 +40,6 @@ import pytest
 import requests
 import yaml
 
-from tensorrt_llm._utils import get_free_port
-
 # ---------------------------------------------------------------------------
 # Model paths
 # ---------------------------------------------------------------------------
@@ -69,6 +67,14 @@ _FLUX2_PATH = Path(_llm_models_root()) / "FLUX.2-dev"
 _PROJECT_ROOT = Path(__file__).resolve().parents[4]  # repo root
 _REF_IMAGE_PATH = _PROJECT_ROOT / "examples" / "visual_gen" / "cat_piano.png"
 
+# Use the CI-aware port allocator from tests/integration/defs/common.py so
+# parallel pytest sessions on the same OCI node fall into disjoint port
+# sections (CONTAINER_PORT_START / CONTAINER_PORT_NUM). It transparently falls
+# back to the plain free-port scan when those env vars are not set.
+_INTEGRATION_TESTS_DIR = _PROJECT_ROOT / "tests" / "integration"
+if str(_INTEGRATION_TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_INTEGRATION_TESTS_DIR))
+from defs.common import get_free_port_in_ci  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Remote server helper (follows RemoteOpenAIServer pattern)
@@ -94,7 +100,7 @@ class RemoteVisualGenServer:
         env: Optional[dict] = None,
     ) -> None:
         self.host = host
-        self.port = port if port is not None else get_free_port()
+        self.port = port if port is not None else get_free_port_in_ci()
         self._config_file: Optional[str] = None
         self.proc: Optional[subprocess.Popen] = None
 


### PR DESCRIPTION
The L0 Post-Merge test
unittest/_torch/visual_gen/test_trtllm_serve_e2e.py::TestWanTextToVideo::test_health flakes on DGX_B200 with "RuntimeError: Visual-gen server exited unexpectedly." Root cause is the same OCI port-conflict race that already hit the agg-LLM and disagg paths: there is a window between the test-side get_free_port() check and uvicorn's bind() inside trtllm-serve during which another container can grab the port. The visual-gen server makes the window much wider because VisualGen model initialization can take many minutes before uvicorn ever attempts to bind, so any colliding process almost always wins.

Apply the same socket-pre-binding pattern already adopted for the agg LLM server (nvbugs/5703953, PR #9646) and the disagg server (nvbugs/5727517, PR #9859): bind the listening socket before constructing VisualGen, then hand the bound socket to uvicorn via the existing OpenAIServer.__call__ sockets= parameter. This collapses the check-to-bind window from "model load time" to "a few syscalls".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Enhanced the visual generation server startup sequence to ensure socket binding completes before model initialization. This improves server startup reliability and prevents potential connection issues during the initialization process, providing more predictable server behavior during launch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
