### PR TITLE
[None][fix] Time-weighted _avg_history_length to avoid commit-burst contamination

### DIFF
--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -82,7 +82,7 @@ from .._utils import (
     unwrap_rawref,
     value_or,
 )
-from ._moving_average import Average
+from ._moving_average import Average, TimeWeightedAverage
 
 if TYPE_CHECKING:
     from ._kv_cache_manager import KVCacheManager, ScratchDesc
@@ -224,7 +224,7 @@ class _KVCache:
     _finish_event: CachedCudaEvent | None
 
     _tokens_per_block: int
-    _avg_history_length: Average
+    _avg_history_length: TimeWeightedAverage
     _avg_capacity: Average
 
     _ssm_blocks: TypedIndexList[BeamIndex, TypedIndexList[LifeCycleId, BlockPage]]
@@ -276,9 +276,9 @@ class _KVCache:
         self.__rawref__ = rawref.NULL
         if input_tokens is not None:
             self._setup_for_reuse(input_tokens)
-        self._avg_history_length = Average()
+        self._avg_history_length = TimeWeightedAverage(self.history_length)
         self._avg_capacity = Average()
-        self._avg_history_length.update(self.history_length)
+        self._avg_capacity.update(self.capacity)
         manager._living_kv_caches.add(rawref.ref(self))
         manager._avg_reused_length.update(self.history_length)
         manager._num_created_kv_caches += 1
@@ -342,7 +342,6 @@ class _KVCache:
         assert NDEBUG or self._check_sanity()
         manager = self.manager
         if self.capacity > 0:
-            self._avg_capacity.update(self.capacity)
             manager._avg_sqr_capacity.update(self._avg_capacity.value**2)
             manager._avg_sqr_history_length.update(self._avg_history_length.value**2)
             manager._num_sampled_kv_caches += 1
@@ -351,6 +350,7 @@ class _KVCache:
             self._clear_blocks()
         self._status = self.Status.CLOSED
         manager._living_kv_caches.remove(self.__rawref__)
+        manager._num_closed_kv_caches += 1
 
     def __del__(self) -> None:
         self.close()

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
@@ -191,6 +191,7 @@ class KVCacheManager:
         "_target_ratio_list_gpu",
         "_target_ratio_list_other",
         "_num_created_kv_caches",
+        "_num_closed_kv_caches",
         "_num_sampled_kv_caches",
         "_last_adjustment_time",
         "_last_update_num_sampled_kv_caches",
@@ -213,6 +214,7 @@ class KVCacheManager:
     _target_ratio_list_gpu: TypedIndexList[PoolGroupIndex, float]
     _target_ratio_list_other: TypedIndexList[PoolGroupIndex, float]
     _num_created_kv_caches: int
+    _num_closed_kv_caches: int
     _num_sampled_kv_caches: int
     _last_adjustment_time: float
     _last_update_num_sampled_kv_caches: int
@@ -240,6 +242,7 @@ class KVCacheManager:
         self._target_ratio_list_gpu = self._current_gpu_ratio
         self._target_ratio_list_other = self._current_other_ratios
         self._num_created_kv_caches = 0
+        self._num_closed_kv_caches = 0
         self._num_sampled_kv_caches = 0
         self._last_adjustment_time = time.monotonic()
         self._last_update_num_sampled_kv_caches = 0

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_moving_average.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_moving_average.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
+
 
 class MovingAverage:
     __slots__ = ("decay", "avg", "weight", "num_updates")
@@ -54,3 +56,40 @@ class Average:
     @property
     def value(self) -> float:
         return self.sum / self.count
+
+
+class TimeWeightedAverage:
+    # Time-weighted lifetime mean of a piecewise-constant value. Each call to
+    # update() closes the prior segment by adding current_value * (now - t_last)
+    # to the integral, then sets current_value to the new sample. value reports
+    # integral / (now - t_init), including the still-open segment up to now.
+    # This matches the natural "average history length across the cache's life"
+    # semantic and is immune to commit-driven bursts of update() calls — many
+    # rapid samples contribute proportionally little because little wall time
+    # elapses between them.
+    __slots__ = ("integral", "current_value", "t_init", "t_last")
+    integral: float
+    current_value: float
+    t_init: float
+    t_last: float
+
+    def __init__(self, initial_value: int | float):
+        self.integral = 0.0
+        self.current_value = float(initial_value)
+        self.t_init = time.monotonic()
+        self.t_last = self.t_init
+
+    def update(self, value: int | float) -> None:
+        t_now = time.monotonic()
+        self.integral += self.current_value * (t_now - self.t_last)
+        self.current_value = float(value)
+        self.t_last = t_now
+
+    @property
+    def value(self) -> float:
+        t_now = time.monotonic()
+        integral = self.integral + self.current_value * (t_now - self.t_last)
+        elapsed = t_now - self.t_init
+        if elapsed <= 0.0:
+            return self.current_value
+        return integral / elapsed


### PR DESCRIPTION
## Summary

Follow-up to #14098 that addresses the same `_avg_history_length` contamination problem via a different mechanism.

#14098 removed `self._avg_history_length.update(history_length)` from `_KVCache.resize()`'s explicit-history branch because that branch is fired transitively by `commit()` → `history_length` setter → `resize(None, X)` (`_kv_cache.py:717-718` → `:678-682` → `:485`), oversampling commit-driven bumps and biasing the per-cache unweighted average. The side effect is that `_avg_history_length.value` is now frozen at the init seed for the rest of the cache's lifetime, which makes the per-cache stat redundant with `manager._avg_reused_length` (already updated with the same init value at line 283).

This PR keeps the update call in `resize()` and instead switches `_avg_history_length` from `Average` (unweighted append-mean) to a new `TimeWeightedAverage` that computes a time-weighted lifetime mean of `history_length`. Rapid commit-driven `update()` calls now contribute proportionally less weight because the elapsed wall-clock between them is small, so the metric is safe from commit-burst contamination while still tracking `history_length` over the cache's life.

## Time source

`TimeWeightedAverage` calls Python stdlib **`time.monotonic()`** in three places: `__init__` (records `t_init`), `update()` (closes the prior segment), and the `value` property (closes the open segment up to "now"). No new import dependency at the cache layer — `KVCacheManager.__init__` already calls `time.monotonic()` for `_last_adjustment_time`.

Measured cost:

| Op | Pure-Python | Notes |
|---|---|---|
| `time.monotonic()` | ~62 ns | VDSO on Linux, no syscall |
| `Average.update()` (PR baseline) | ~87 ns | for reference |
| `TimeWeightedAverage.update()` | ~133 ns | +46 ns vs `Average` |
| `TimeWeightedAverage.value` | ~127 ns | once per cache at `close()` |
| `TimeWeightedAverage` ctor | ~179 ns | once per cache at `__init__` |

Per request that generates ~1000 tokens this adds <50 µs total, <0.1% of request latency. Under mypyc compilation the surrounding Python overhead drops and `time.monotonic()` will dominate, with total `update()` cost dropping closer to ~80 ns.

## Inherited from #14098 (verbatim)

- Init seed for `_avg_capacity` in `_KVCache.__init__`
- Removal of redundant close-time `_avg_capacity.update()`
- New `KVCacheManager._num_closed_kv_caches` counter (slot, annotation, init=0), bumped at the tail of `_KVCache.close()`

## Summary by CodeRabbit

* **Refactor**
  * Improved KV cache statistics tracking to use time-weighted averaging for more accurate history length measurements.
  * Enhanced cache closure accounting for better lifecycle management and resource monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->