### PR TITLE
[TRTLLM-12535][chore] Refactor fast path (token ID space) preprocessing logic out to the input preprocessor methods only

### DIFF
--- a/.claude/skills/trtllm-model-onboard-multimodal/SKILL.md
+++ b/.claude/skills/trtllm-model-onboard-multimodal/SKILL.md
@@ -31,7 +31,11 @@ metadata:
     asyncio.gather then decodes all media for one request in parallel.
 
 [2] Input pipeline  (asyncio.to_thread, off the event loop)
-    BaseMultimodalInputProcessor.__call__:
+    BaseMultimodalInputProcessor.__call__ dispatches by input shape: a text
+    prompt goes to the per-model call_with_text_prompt; prompt_token_ids +
+    mm_data goes to the base-class call_with_token_ids fast path (or is
+    detokenized back to call_with_text_prompt when the model opts out). The
+    per-model HF processing lives in call_with_text_prompt:
        HF AutoProcessor → pixel_values + token_ids
        mm-token layout (positions / lengths / special_token_offsets)
        (mRoPE) mrope_position_ids + deltas computed on CPU
@@ -79,7 +83,7 @@ metadata:
 When `@support_multimodal_disaggregated` is set and the deployment uses `TLLM_MULTIMODAL_DISAGGREGATED=1`:
 
 - **Encoder worker:** runs as a standalone `MultimodalEncoder` (`mm_encoder_only=True`). It executes only the multimodal encoder and ships `mm_embeddings` (+ mRoPE position ids/deltas) to prefill+decode workers as shared-tensor handles.
-- **Prefill+decode worker:** the model's `__init__` skips constructing `self.mm_encoder` when `_is_disagg()` is true; the input processor's `attach_multimodal_embeddings()` override binds the encoder handles into the request. For context-only requests, the engine re-clones mrope tensors so IPC handles outlive the encoder worker's freed memory — replicate that pattern for any new GPU-resident mm tensors.
+- **Prefill+decode worker:** the model's `__init__` skips constructing `self.mm_encoder` when `_is_disagg()` is true; the input processor's `_attach_multimodal_embeddings_impl()` override binds the encoder handles into the request (the base `attach_multimodal_embeddings` wrapper detokenizes tokenized inputs for non-fast-path VLMs, then delegates to your impl). For context-only requests, the engine re-clones mrope tensors so IPC handles outlive the encoder worker's freed memory — replicate that pattern for any new GPU-resident mm tensors.
 
 ### Templates to study
 
@@ -159,11 +163,11 @@ Three-arg **`torch.where(cond, x, y)`** is fine when **`cond`** is built only on
 
 CPU-bound work (decode / resize / normalize / mel-spectrogram / frame extraction) must not compete with GPU work, block the request loop, or serialize across requests.
 
-- HF AutoProcessor + image_processor + tokenizer run inside `BaseMultimodalInputProcessor.__call__` — *not* in the model worker.
+- HF AutoProcessor + image_processor + tokenizer run inside the input processor's `call_with_text_prompt` (dispatched from `__call__`) — *not* in the model worker.
 - URL/bytes media goes through `async_load_image` / `async_load_video` / `async_load_audio` (all wrap blocking decode in `asyncio.to_thread`). Never call `PIL.Image.open(...).load()` / `cv2.VideoCapture` / `soundfile.read` synchronously on the request hot path.
 - Pin host tensors before H2D with `prefer_pinned()` (False under Confidential Compute (CC), True otherwise). The engine pins `multimodal_data` automatically via `to_device(..., pin_memory=prefer_pinned())`.
 - **Declare `multimodal_data_device_paths`** on the model — list of dotted paths (e.g. `["image.pixel_values", "image.image_grid_thw", "video.pixel_values_videos", "video.video_grid_thw", "multimodal_embedding"]`) telling the engine which fields go to CUDA. Anything not listed stays on CPU.
-- Optional (refactor pending): `get_text_with_mm_placeholders` + `expand_prompt_token_ids_for_mm` enable the tokenized+MM fast path (`tokenized_multimodal_process`), skipping redundant detokenization. A cleaner alternative is being designed — skip unless you have a specific need.
+- Optional tokenized+MM fast path: set `supports_token_id_mm_expansion = True` (a `ClassVar`, default `False`) and implement `get_text_with_mm_placeholders` + `expand_prompt_token_ids_for_mm`. The base-class `__call__` then routes `prompt_token_ids + multi_modal_data` (no `prompt`) requests through `call_with_token_ids`, skipping redundant detokenization. When the flag is `False` (most VLMs), the base class detokenizes `prompt_token_ids → prompt` and re-runs `call_with_text_prompt`, so token-ID inputs still work — just less efficiently. Only LlavaNext + NanoV2VL opt in today.
 - Forward `mm_processor_kwargs` from `inputs.get("mm_processor_kwargs", {})` to the HF processor (callers tune things like video sample rate via this).
 
 ### Contract 3 — Large media via shared tensors, never raw pickle
@@ -302,7 +306,7 @@ class {Name}Model(PreTrainedModel):
 
 Subclass **both** `BaseMultimodalInputProcessor` (drives every real request) and `BaseMultimodalDummyInputsBuilder` (drives engine warmup / profiling — the base shrinks dummy image resolution until the synthetic prompt fits `input_seq_len`). Colocate in the modeling file. Reference: `Qwen3VLInputProcessorBase`.
 
-`__call__(inputs, sampling_params)` does:
+Implement `call_with_text_prompt(inputs, sampling_params)` — the per-model text-prompt path. **Don't override `__call__`**: the base class's concrete `__call__` dispatches here for text prompts, and also detokenizes `prompt_token_ids → prompt` and falls through to here for non-fast-path VLMs. `call_with_text_prompt` does:
 
 1. Pull `text_prompt`, `mm_data`, `mm_processor_kwargs` from `inputs`.
 2. `_preprocess(...)` — HF processor produces `pixel_values` / `pixel_values_videos` / `*_grid_thw` / `input_ids`.
@@ -311,9 +315,9 @@ Subclass **both** `BaseMultimodalInputProcessor` (drives every real request) and
 5. `_postprocess(input_ids)` rewrites HF's `image_token_id` / `video_token_id` to `tllm_multimodal_token_id = vocab_size + 1` (the OOV sentinel). Skip when `mm_data` is empty.
 6. Return `(prompt_token_ids_list, {"multimodal_data": multimodal_data})`.
 
-**Optional overrides (refactor pending; skip unless needed):** `get_text_with_mm_placeholders(mm_counts)` + `expand_prompt_token_ids_for_mm(prompt_token_ids, num_mm_tokens, ...)` enable the tokenized fast path. A cleaner replacement is being designed.
+**Optional tokenized+MM fast path (skip unless needed):** set `supports_token_id_mm_expansion = True` (`ClassVar`) and implement `get_text_with_mm_placeholders(mm_counts)` + `expand_prompt_token_ids_for_mm(prompt_token_ids, num_mm_tokens, ...)`. The base-class `call_with_token_ids` then builds dummy placeholder text, runs `call_with_text_prompt` on it, expands the real token IDs, and merges any returned `mm_data_updates` (e.g. video `evs_ids`) into `multimodal_data`. Leave the flag `False` and the base class just detokenizes token-ID inputs and re-runs `call_with_text_prompt`. Only LlavaNext + NanoV2VL opt in today.
 
-**EPD override (if `@support_multimodal_disaggregated`):** `attach_multimodal_embeddings(inputs, multimodal_embedding, sampling_params)` consumes encoder outputs in the prefill+decode worker.
+**EPD override (if `@support_multimodal_disaggregated`):** override `_attach_multimodal_embeddings_impl(inputs, multimodal_embedding, sampling_params)` — **not** the `attach_multimodal_embeddings` wrapper — to consume encoder outputs in the prefill+decode worker. The base wrapper detokenizes tokenized inputs for non-fast-path VLMs before delegating to your impl.
 
 **Decorator stack** — bottom-up application; `register_vision_encoder` requires `register_auto_model` to have run first:
 
@@ -429,9 +433,9 @@ Follow `CONTRIBUTING.md`. Title `[JIRA/NVBUG/None][type] description`, `git comm
 
 **Input processor**
 - [ ] Subclasses both `BaseMultimodalInputProcessor` and `BaseMultimodalDummyInputsBuilder`.
-- [ ] `__call__` runs HF AutoProcessor + tokenizer, builds `multimodal_data` by modality, computes `mrope_config` on CPU, `_postprocess`-rewrites mm token ids to the OOV sentinel.
-- [ ] `mm_processor_kwargs` flow-through preserved. (Tokenized fast-path overrides — `get_text_with_mm_placeholders` / `expand_prompt_token_ids_for_mm` — are optional; a cleaner replacement is being designed.)
-- [ ] `attach_multimodal_embeddings` implemented if `@support_multimodal_disaggregated`.
+- [ ] `call_with_text_prompt` (not `__call__` — that's the base-class dispatcher) runs HF AutoProcessor + tokenizer, builds `multimodal_data` by modality, computes `mrope_config` on CPU, `_postprocess`-rewrites mm token ids to the OOV sentinel.
+- [ ] `mm_processor_kwargs` flow-through preserved. (Tokenized fast path is optional: set `supports_token_id_mm_expansion = True` + implement `get_text_with_mm_placeholders` / `expand_prompt_token_ids_for_mm`; otherwise the base class detokenizes token-ID inputs automatically.)
+- [ ] `_attach_multimodal_embeddings_impl` implemented (not the `attach_multimodal_embeddings` wrapper) if `@support_multimodal_disaggregated`.
 
 **Performance contracts**
 - [ ] Grep clean for Contract 1 bans (`.item()` / `.cpu()` / `.tolist()` / `torch.nonzero` / single-arg `torch.where` / value-dependent `if`, etc.) in modeling `forward` paths — elementwise `torch.where(cond, x, y)` with GPU-only `cond` is fine.

--- a/tensorrt_llm/_torch/models/modeling_gemma3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3vl.py
@@ -102,7 +102,7 @@ class Gemma3InputProcessor(BaseMultimodalInputProcessor,
         return input_ids, pixel_values
 
     @torch.inference_mode()
-    def call_with_txt_prompt(
+    def call_with_text_prompt(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
         input_ids, pixel_values = self._preprocess(inputs)

--- a/tensorrt_llm/_torch/models/modeling_gemma3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3vl.py
@@ -102,7 +102,7 @@ class Gemma3InputProcessor(BaseMultimodalInputProcessor,
         return input_ids, pixel_values
 
     @torch.inference_mode()
-    def __call__(
+    def call_with_txt_prompt(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
         input_ids, pixel_values = self._preprocess(inputs)

--- a/tensorrt_llm/_torch/models/modeling_gemma4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4mm.py
@@ -484,7 +484,7 @@ class Gemma4InputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyInpu
         )
 
     @torch.inference_mode()
-    def call_with_txt_prompt(
+    def call_with_text_prompt(
         self,
         inputs: TextPrompt,
         sampling_params: SamplingParams,

--- a/tensorrt_llm/_torch/models/modeling_gemma4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4mm.py
@@ -484,7 +484,7 @@ class Gemma4InputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyInpu
         )
 
     @torch.inference_mode()
-    def __call__(
+    def call_with_txt_prompt(
         self,
         inputs: TextPrompt,
         sampling_params: SamplingParams,

--- a/tensorrt_llm/_torch/models/modeling_hyperclovax.py
+++ b/tensorrt_llm/_torch/models/modeling_hyperclovax.py
@@ -756,7 +756,7 @@ class HCXVisionInputProcessor(BaseMultimodalDummyInputsBuilder,
         return input_ids, preprocessed_image
 
     @torch.inference_mode()
-    def call_with_txt_prompt(
+    def call_with_text_prompt(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
         text_prompt, mm_data, mm_processor_kwargs = inputs.get("prompt"), \

--- a/tensorrt_llm/_torch/models/modeling_hyperclovax.py
+++ b/tensorrt_llm/_torch/models/modeling_hyperclovax.py
@@ -756,7 +756,7 @@ class HCXVisionInputProcessor(BaseMultimodalDummyInputsBuilder,
         return input_ids, preprocessed_image
 
     @torch.inference_mode()
-    def __call__(
+    def call_with_txt_prompt(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
         text_prompt, mm_data, mm_processor_kwargs = inputs.get("prompt"), \

--- a/tensorrt_llm/_torch/models/modeling_kimi_k25.py
+++ b/tensorrt_llm/_torch/models/modeling_kimi_k25.py
@@ -1205,7 +1205,7 @@ class KimiK25InputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyInp
             self._processor.tokenizer = slow_tok
 
     @torch.inference_mode()
-    def __call__(
+    def call_with_txt_prompt(
         self,
         inputs: TextPrompt,
         sampling_params: SamplingParams,

--- a/tensorrt_llm/_torch/models/modeling_kimi_k25.py
+++ b/tensorrt_llm/_torch/models/modeling_kimi_k25.py
@@ -1205,7 +1205,7 @@ class KimiK25InputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyInp
             self._processor.tokenizer = slow_tok
 
     @torch.inference_mode()
-    def call_with_txt_prompt(
+    def call_with_text_prompt(
         self,
         inputs: TextPrompt,
         sampling_params: SamplingParams,

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -1434,7 +1434,7 @@ class Llama4InputProcessor(BaseMultimodalInputProcessor,
         return token_ids.tolist(), {"multimodal_data": multimodal_data}
 
     @torch.inference_mode()
-    def __call__(
+    def call_with_txt_prompt(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
         text_prompt, mm_data = inputs.get("prompt"), inputs.get(

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -1305,7 +1305,7 @@ class Llama4InputProcessor(BaseMultimodalInputProcessor,
     def dtype(self) -> torch.dtype:
         return self._dtype
 
-    def attach_multimodal_embeddings(
+    def _attach_multimodal_embeddings_impl(
         self, inputs: TextPrompt, multimodal_embedding: Dict[str,
                                                              List[Dict[str,
                                                                        Any]]],

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -1434,7 +1434,7 @@ class Llama4InputProcessor(BaseMultimodalInputProcessor,
         return token_ids.tolist(), {"multimodal_data": multimodal_data}
 
     @torch.inference_mode()
-    def call_with_txt_prompt(
+    def call_with_text_prompt(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
         text_prompt, mm_data = inputs.get("prompt"), inputs.get(

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -375,7 +375,7 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
         }
 
     @torch.inference_mode()
-    def __call__(
+    def call_with_txt_prompt(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
         text_prompt, mm_data = inputs.get("prompt"), inputs.get(

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -1,6 +1,6 @@
 import copy
 import os
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, ClassVar, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -37,6 +37,7 @@ DISAGG = os.getenv('TLLM_MULTIMODAL_DISAGGREGATED', '0') == '1'
 
 class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
                               BaseMultimodalDummyInputsBuilder):
+    supports_token_id_mm_expansion: ClassVar[bool] = True
 
     def __init__(self,
                  model_path: str,
@@ -375,7 +376,7 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
         }
 
     @torch.inference_mode()
-    def call_with_txt_prompt(
+    def call_with_text_prompt(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
         text_prompt, mm_data = inputs.get("prompt"), inputs.get(

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -329,7 +329,7 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
 
         return expanded_ids, mm_token_length, mm_token_offsets
 
-    def attach_multimodal_embeddings(
+    def _attach_multimodal_embeddings_impl(
         self, inputs: TextPrompt,
         multimodal_embedding: Dict[str, List[torch.Tensor]],
         sampling_params: SamplingParams

--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -414,7 +414,7 @@ class Mistral3InputProcessor(BaseMultimodalInputProcessor,
         return self._dtype
 
     @torch.inference_mode()
-    def __call__(
+    def call_with_txt_prompt(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], ExtraProcessedInputs | None]:
         images = inputs.get("multi_modal_data", {}).get("image")

--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -414,7 +414,7 @@ class Mistral3InputProcessor(BaseMultimodalInputProcessor,
         return self._dtype
 
     @torch.inference_mode()
-    def call_with_txt_prompt(
+    def call_with_text_prompt(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], ExtraProcessedInputs | None]:
         images = inputs.get("multi_modal_data", {}).get("image")

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -2128,7 +2128,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         return num_tokens_per_frame_lst
 
     @torch.inference_mode()
-    def __call__(
+    def call_with_txt_prompt(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
         text_prompt, mm_data = inputs.get("prompt"), inputs.get("multi_modal_data", {})

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -4,7 +4,7 @@ import math
 import os
 import re
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, ClassVar, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -879,6 +879,8 @@ class NanoV2VLVisionEncoder(transformers.PreTrainedModel):
 
 
 class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyInputsBuilder):
+    supports_token_id_mm_expansion: ClassVar[bool] = True
+
     def __init__(
         self,
         model_path: str,
@@ -2128,7 +2130,7 @@ class NanoV2VLInputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyIn
         return num_tokens_per_frame_lst
 
     @torch.inference_mode()
-    def call_with_txt_prompt(
+    def call_with_text_prompt(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
         text_prompt, mm_data = inputs.get("prompt"), inputs.get("multi_modal_data", {})

--- a/tensorrt_llm/_torch/models/modeling_phi4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_phi4mm.py
@@ -898,7 +898,7 @@ class Phi4MMInputProcessor(BaseMultimodalInputProcessor,
         return inputs
 
     @torch.inference_mode()
-    def __call__(
+    def call_with_txt_prompt(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
         text_prompt, mm_data = inputs.get("prompt"), inputs.get(

--- a/tensorrt_llm/_torch/models/modeling_phi4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_phi4mm.py
@@ -898,7 +898,7 @@ class Phi4MMInputProcessor(BaseMultimodalInputProcessor,
         return inputs
 
     @torch.inference_mode()
-    def call_with_txt_prompt(
+    def call_with_text_prompt(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
         text_prompt, mm_data = inputs.get("prompt"), inputs.get(

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -353,7 +353,7 @@ class Qwen2VLInputProcessorBase(BaseMultimodalInputProcessor,
 
     @nvtx_range("Qwen2VLInputProcessorBase forward()")
     @torch.inference_mode()
-    def __call__(
+    def call_with_txt_prompt(
         self,
         inputs: TextPrompt,
         sampling_params: SamplingParams,

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -353,7 +353,7 @@ class Qwen2VLInputProcessorBase(BaseMultimodalInputProcessor,
 
     @nvtx_range("Qwen2VLInputProcessorBase forward()")
     @torch.inference_mode()
-    def call_with_txt_prompt(
+    def call_with_text_prompt(
         self,
         inputs: TextPrompt,
         sampling_params: SamplingParams,

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -351,7 +351,7 @@ class Qwen3VLInputProcessorBase(BaseMultimodalInputProcessor, BaseMultimodalDumm
 
     @nvtx_range("Qwen3VLInputProcessorBase forward()")
     @torch.inference_mode()
-    def __call__(
+    def call_with_txt_prompt(
         self,
         inputs: TextPrompt,
         sampling_params: SamplingParams,

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -351,7 +351,7 @@ class Qwen3VLInputProcessorBase(BaseMultimodalInputProcessor, BaseMultimodalDumm
 
     @nvtx_range("Qwen3VLInputProcessorBase forward()")
     @torch.inference_mode()
-    def call_with_txt_prompt(
+    def call_with_text_prompt(
         self,
         inputs: TextPrompt,
         sampling_params: SamplingParams,

--- a/tensorrt_llm/_torch/models/modeling_vila.py
+++ b/tensorrt_llm/_torch/models/modeling_vila.py
@@ -1103,7 +1103,7 @@ class VilaInputProcessor(BaseMultimodalInputProcessor,
         return fused_input_ids, mm_features
 
     @torch.inference_mode()  # critical to minimize memory footprint
-    def call_with_txt_prompt(
+    def call_with_text_prompt(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
         """

--- a/tensorrt_llm/_torch/models/modeling_vila.py
+++ b/tensorrt_llm/_torch/models/modeling_vila.py
@@ -1103,7 +1103,7 @@ class VilaInputProcessor(BaseMultimodalInputProcessor,
         return fused_input_ids, mm_features
 
     @torch.inference_mode()  # critical to minimize memory footprint
-    def __call__(
+    def call_with_txt_prompt(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
         """

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -171,14 +171,64 @@ class BaseMultimodalInputProcessor(ABC):
         multimodal_embedding: Dict[str, List[torch.Tensor]],
         sampling_params: SamplingParams,
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
-        """
-        Handle externally provided multimodal input embeddings.
+        """Handle externally provided multimodal input embeddings.
 
-        While inputs["multi_modal_data"] is handled by __call__, this method is intended to process
-        inputs["multi_modal_embeddings"].
+        While inputs["multi_modal_data"] is handled by __call__, this method is
+        intended to process inputs["multi_modal_embeddings"].
+
+        Auto-detokenizes `prompt_token_ids` --> `prompt` for non-fast-path VLMs
+        before delegating to `_attach_multimodal_embeddings_impl`. Subclasses
+        override `_attach_multimodal_embeddings_impl` (not this wrapper).
+        """
+        if (inputs.get("prompt_token_ids") is not None
+                and inputs.get("prompt") is None
+                and not self.supports_token_id_mm_expansion):
+            inputs = self._detokenize_to_text_prompt(inputs, sampling_params)
+        return self._attach_multimodal_embeddings_impl(inputs,
+                                                       multimodal_embedding,
+                                                       sampling_params)
+
+    def _attach_multimodal_embeddings_impl(
+        self,
+        inputs: TextPrompt,
+        multimodal_embedding: Dict[str, List[torch.Tensor]],
+        sampling_params: SamplingParams,
+    ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
+        """Subclass hook for `attach_multimodal_embeddings`.
+
+        Subclasses that support `multi_modal_embeddings` override this method
+        rather than the wrapper `attach_multimodal_embeddings` itself.
+        Default raises NotImplementedError.
         """
         raise NotImplementedError(
             "Input processor does not support multimodal embedding input")
+
+    def _detokenize_to_text_prompt(
+        self,
+        inputs: TextPrompt,
+        sampling_params: SamplingParams,
+    ) -> TextPrompt:
+        """Decode `prompt_token_ids` to text and rebuild `inputs` as a TextPrompt.
+
+        Used by `__call__` and `attach_multimodal_embeddings` to normalize
+        tokenized inputs for non-fast-path VLMs before delegating to the
+        subclass-specific text-prompt path.
+
+        Also flips `sampling_params.add_special_tokens` to False so the
+        subclass's re-tokenization doesn't double-add BOS/EOS on top of the
+        ones already encoded in `prompt_token_ids`.
+        """
+        prompt = self.tokenizer.decode(inputs["prompt_token_ids"])
+        if sampling_params is not None and sampling_params.add_special_tokens:
+            logger.debug(
+                "Setting add_special_tokens to False because prompt_token_ids "
+                "were provided to generate. VLMs will re-encode the prompt.")
+            sampling_params.add_special_tokens = False
+        return TextPrompt(
+            prompt=prompt,
+            multi_modal_data=inputs.get("multi_modal_data"),
+            mm_processor_kwargs=inputs.get("mm_processor_kwargs") or {},
+        )
 
     @property
     @abstractmethod
@@ -210,14 +260,20 @@ class BaseMultimodalInputProcessor(ABC):
         """Dispatch between text-prompt and tokenized+MM fast paths.
 
         - Tokenized+MM fast path (`prompt_token_ids` set, `multi_modal_data` set,
-          no `prompt`): delegate to `call_with_token_ids`.
+          no `prompt`): if the subclass opts in via
+          `supports_token_id_mm_expansion`, delegate to `call_with_token_ids`;
+          otherwise detokenize first and fall through to `call_with_text_prompt`.
         - Else (text prompt with/without MM data, or tokenize-only requests):
           delegate to `call_with_text_prompt`.
         """
         if (inputs.get("prompt_token_ids") is not None
                 and inputs.get("multi_modal_data") is not None
                 and inputs.get("prompt") is None):
-            return self.call_with_token_ids(inputs, sampling_params)
+            if self.supports_token_id_mm_expansion:
+                return self.call_with_token_ids(inputs, sampling_params)
+            # Fast path not supported by this VLM — detokenize and fall through
+            # to the text-prompt path.
+            inputs = self._detokenize_to_text_prompt(inputs, sampling_params)
         return self.call_with_text_prompt(inputs, sampling_params)
 
     @abstractmethod

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -197,11 +197,102 @@ class BaseMultimodalInputProcessor(ABC):
         """The dtype for this model."""
         ...
 
-    @abstractmethod
     def __call__(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
+        """Dispatch between text-prompt and tokenized+MM fast paths.
+
+        - Tokenized+MM fast path (`prompt_token_ids` set, `multi_modal_data` set,
+          no `prompt`): delegate to `call_with_token_ids`, which builds dummy
+          placeholder text, runs `call_with_txt_prompt` on it to populate the
+          multimodal payload, then expands the real token IDs via
+          `expand_prompt_token_ids_for_mm`.
+        - Else (text prompt with/without MM data, or tokenize-only requests):
+          delegate to `call_with_txt_prompt`.
+
+        Non-fast-path VLMs are detokenized upstream in `llm.py`, so this
+        dispatcher only sees fast-path-eligible inputs in the first branch.
+        """
+        if (inputs.get("prompt_token_ids") is not None
+                and inputs.get("multi_modal_data") is not None
+                and inputs.get("prompt") is None):
+            return self.call_with_token_ids(inputs, sampling_params)
+        return self.call_with_txt_prompt(inputs, sampling_params)
+
+    @abstractmethod
+    def call_with_txt_prompt(
+        self, inputs: TextPrompt, sampling_params: SamplingParams
+    ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
+        """Process `inputs` containing a text `prompt` (and optionally `multi_modal_data`).
+
+        Subclasses implement this with the HF processor pipeline that turns
+        `(text_prompt, mm_data)` into `(token_ids, extra_processed_inputs)`.
+        """
         ...
+
+    def call_with_token_ids(
+        self, inputs: TextPrompt, sampling_params: SamplingParams
+    ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
+        """Fast path for `prompt_token_ids + multi_modal_data` without detokenizing.
+
+        Requires the subclass to implement `get_text_with_mm_placeholders` and
+        `expand_prompt_token_ids_for_mm`. Otherwise raises `NotImplementedError`
+        (callers should detokenize upstream — see `llm.py`).
+        """
+        get_text = getattr(self, "get_text_with_mm_placeholders", None)
+        expand_ids = getattr(self, "expand_prompt_token_ids_for_mm", None)
+        if get_text is None or expand_ids is None:
+            raise NotImplementedError(
+                f"{type(self).__name__} does not implement the tokenized+MM "
+                "fast path. Detokenize `prompt_token_ids` to a text prompt "
+                "before calling.")
+
+        prompt_token_ids = inputs["prompt_token_ids"]
+        mm_data = inputs["multi_modal_data"]
+        mm_counts = _mm_data_to_counts(mm_data)
+
+        # Run the HF processor / vision encoder on a synthetic placeholder
+        # prompt to populate `extra_processed_inputs["multimodal_data"]`. Some
+        # auxiliary streams (e.g. video evs_ids) computed against this dummy
+        # text are stale w.r.t. the real prompt and get overwritten below.
+        extra_processed_inputs = _process_multimodal_with_dummy_placeholders(
+            self,
+            mm_data,
+            mm_counts,
+            inputs.get("mm_processor_kwargs"),
+            sampling_params,
+        )
+
+        num_mm_tokens = _get_single_mm_token_lengths(
+            mm_data,
+            self,
+            multimodal_data=(extra_processed_inputs
+                             or {}).get("multimodal_data"),
+        )
+        if num_mm_tokens is None:
+            raise ValueError(
+                "call_with_token_ids: find_mm_token_lengths returned no token "
+                "lengths for the provided multi_modal_data.")
+
+        expanded_ids, mm_data_updates = expand_ids(
+            prompt_token_ids,
+            num_mm_tokens,
+            hf_processor_mm_kwargs=inputs.get("mm_processor_kwargs"),
+            mm_data=mm_data,
+        )
+
+        # Merge any model-specific auxiliary streams (e.g. video evs_ids for
+        # EVS-enabled runs) into extra_processed_inputs["multimodal_data"],
+        # overwriting the stale values produced from the dummy prompt above so
+        # downstream consumers (`merge_evs_mm_embeds` etc.) read the values
+        # rebuilt from the real prompt token IDs.
+        if mm_data_updates:
+            mm_container = extra_processed_inputs.setdefault(
+                "multimodal_data", {})
+            for modality, field_updates in mm_data_updates.items():
+                mm_container.setdefault(modality, {}).update(field_updates)
+
+        return expanded_ids, extra_processed_inputs
 
     @property
     def use_fast(self) -> bool:
@@ -879,90 +970,16 @@ def create_input_processor_with_hash(
         A wrapped processor that modifies prompts before processing.
     """
 
-    def tokenized_multimodal_process(
-        inputs: TextPrompt, sampling_params: SamplingParams
-    ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
-        """
-        Process prompt_token_ids and multi_modal_data without detokenizing.
-
-        Runs the input processor with dummy text placeholders for multi-modal slots,
-        then replaces placeholder token IDs with the actual feature token IDs and
-        delegates to multimodal_hashing_process.
-
-        Args:
-            inputs: TextPrompt with "prompt_token_ids" and "multi_modal_data" (and optional "mm_processor_kwargs").
-            sampling_params: Sampling parameters for the input processor.
-
-        Returns:
-            (prompt_token_ids, extra_processed_inputs) from multimodal_hashing_process.
-            ([], None) if multi-modal token lengths cannot be determined.
-        """
-        prompt_token_ids = inputs["prompt_token_ids"]
-        mm_data = inputs["multi_modal_data"]
-        mm_counts = _mm_data_to_counts(mm_data)
-        extra_processed_inputs = _process_multimodal_with_dummy_placeholders(
-            input_processor,
-            mm_data,
-            mm_counts,
-            inputs.get("mm_processor_kwargs"),
-            sampling_params,
-        )
-        num_mm_tokens = _get_single_mm_token_lengths(
-            mm_data,
-            input_processor,
-            multimodal_data=(extra_processed_inputs
-                             or {}).get("multimodal_data"),
-        )
-        if num_mm_tokens is None:
-            raise ValueError(
-                "tokenized_multimodal_process: find_mm_token_lengths returned "
-                "no token lengths for the provided multi_modal_data.")
-
-        expanded_ids, mm_data_updates = input_processor.expand_prompt_token_ids_for_mm(
-            prompt_token_ids,
-            num_mm_tokens,
-            hf_processor_mm_kwargs=inputs.get("mm_processor_kwargs"),
-            mm_data=mm_data,
-        )
-
-        # Merge any model-specific auxiliary streams (e.g. video evs_ids for
-        # EVS-enabled runs) into extra_processed_inputs["multimodal_data"].
-        # The dummy-placeholder pass above produced these against the synthetic
-        # placeholder text, so they're stale w.r.t. the real prompt; overwrite
-        # them with the values rebuilt from `prompt_token_ids` here so
-        # `merge_evs_mm_embeds` picks up the correct stream at LLM forward time.
-        if mm_data_updates:
-            mm_container = extra_processed_inputs.setdefault(
-                "multimodal_data", {})
-            for modality, field_updates in mm_data_updates.items():
-                mm_container.setdefault(modality, {}).update(field_updates)
-
-        return multimodal_hashing_process(
-            inputs,
-            sampling_params,
-            precomputed_token_ids=expanded_ids,
-            precomputed_extra=extra_processed_inputs,
-            precomputed_num_mm_tokens=num_mm_tokens,
-        )
-
     def multimodal_hashing_process(
-        inputs: TextPrompt,
-        sampling_params: SamplingParams,
-        *,
-        precomputed_token_ids: Optional[List[int]] = None,
-        precomputed_extra: Optional[ExtraProcessedInputs] = None,
-        precomputed_num_mm_tokens: Optional[List[int]] = None,
+        inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
         """
         Process multimodal hashing for media tokens if possible.
 
-        precomputed_token_ids and precomputed_extra must be provided together or
-        both be None. When both are provided (tokenized+MM path), skips the
-        input_processor call and uses them; when both are None, calls input_processor.
-
-        precomputed_num_mm_tokens is optional and independent: if provided, skips
-        the otherwise-duplicate find_mm_token_lengths call (the tokenized+MM path
-        already computes it upstream to expand the prompt).
+        Delegates the raw `(token_ids, extra_processed_inputs)` production to
+        the input processor's `__call__` (which itself dispatches between the
+        text-prompt and tokenized+MM fast paths), then computes hashes,
+        positions, and masks on top.
 
         Supports optional user-provided UUIDs via 'multi_modal_uuids' in inputs.
         When a UUID is provided for a multimodal item, it will be used as the
@@ -976,30 +993,19 @@ def create_input_processor_with_hash(
 
         mm_hashes, mm_uuid_list = apply_mm_hashes(mm_data, mm_uuids, hash_lib)
 
-        if precomputed_token_ids is not None and precomputed_extra is not None:
-            prompt_token_ids = precomputed_token_ids
-            extra_processed_inputs = precomputed_extra
-        elif precomputed_token_ids is None and precomputed_extra is None:
-            prompt_token_ids, extra_processed_inputs = input_processor(
-                inputs, sampling_params)
-        else:
-            raise ValueError(
-                "precomputed_token_ids and precomputed_extra must be provided "
-                "together or both be None; got one without the other.")
+        prompt_token_ids, extra_processed_inputs = input_processor(
+            inputs, sampling_params)
 
-        if precomputed_num_mm_tokens is not None:
-            num_mm_tokens = precomputed_num_mm_tokens
-        else:
-            # TODO: here we assume there is only one modality for now
-            num_mm_tokens_by_key = find_mm_token_lengths(
-                mm_data,
-                input_processor,
-                multimodal_data=(extra_processed_inputs
-                                 or {}).get("multimodal_data"),
-            )
-            if not num_mm_tokens_by_key:
-                return [], None
-            num_mm_tokens = next(iter(num_mm_tokens_by_key.values()))
+        # TODO: here we assume there is only one modality for now
+        num_mm_tokens_by_key = find_mm_token_lengths(
+            mm_data,
+            input_processor,
+            multimodal_data=(extra_processed_inputs
+                             or {}).get("multimodal_data"),
+        )
+        if not num_mm_tokens_by_key:
+            return [], None
+        num_mm_tokens = next(iter(num_mm_tokens_by_key.values()))
         if len(num_mm_tokens) <= 0:
             return [], None
 
@@ -1050,15 +1056,6 @@ def create_input_processor_with_hash(
                 mm_hashes_int32, start_positions, num_mm_tokens, mm_uuid_list,
                 item_run_cu_offsets, run_positions, run_lengths)
         return prompt_token_ids, extra_processed_inputs
-
-    def process_tokenized_prompt_maybe_hash(
-        inputs: TextPrompt, sampling_params: SamplingParams
-    ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
-        try:
-            return tokenized_multimodal_process(inputs, sampling_params)
-        except Exception as e:
-            logger.warning(f"Tokenized+MM path failed: {e}")
-            raise
 
     def process_prompt_maybe_hash(
         inputs: TextPrompt, sampling_params: SamplingParams
@@ -1116,21 +1113,11 @@ def create_input_processor_with_hash(
     def input_processor_wrapper(
         inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
-        # Tokenized prompt + multi_modal_data path: requires the optional hooks.
-        # If the processor lacks them, fall through to the regular prompt path.
-        has_tokenized_multimodal_prompt = (
-            inputs.get("prompt_token_ids") is not None
-            and inputs.get("multi_modal_data") is not None
-            and inputs.get("prompt") is None
-            and hasattr(input_processor, "get_text_with_mm_placeholders")
-            and hasattr(input_processor, "expand_prompt_token_ids_for_mm"))
-
-        if has_tokenized_multimodal_prompt:
-            prompt_token_ids, extra_processed_inputs = (
-                process_tokenized_prompt_maybe_hash(inputs, sampling_params))
-        else:
-            prompt_token_ids, extra_processed_inputs = (
-                process_prompt_maybe_hash(inputs, sampling_params))
+        # The input processor's __call__ dispatches between the text-prompt
+        # and tokenized+MM fast paths internally; this wrapper only adds
+        # hashing/masking/cumsum on top.
+        prompt_token_ids, extra_processed_inputs = process_prompt_maybe_hash(
+            inputs, sampling_params)
 
         maybe_compute_mm_embed_cumsum(prompt_token_ids, extra_processed_inputs,
                                       input_processor)

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -881,6 +881,7 @@ def _get_single_mm_token_lengths(
     multimodal_data: Optional[Dict[str, Any]] = None,
 ) -> Optional[List[int]]:
     """Get the single set of MM token lengths (first value from find_mm_token_lengths). Returns None if empty."""
+    # TODO: Just like in multimodal_hashing_process, here we assume there is only one modality for now
     num_mm_tokens_by_key = find_mm_token_lengths(
         mm_data, input_processor, multimodal_data=multimodal_data)
     if not num_mm_tokens_by_key:
@@ -1003,11 +1004,19 @@ def create_input_processor_with_hash(
             multimodal_data=(extra_processed_inputs
                              or {}).get("multimodal_data"),
         )
+        # Raise (rather than returning ([], None)) so process_prompt_maybe_hash
+        # treats this as a failed hashing attempt: it falls back to the basic
+        # input processor and caches multimodal_hashing_supported=False instead
+        # of marking hashing as supported and forwarding an empty prompt
+        # downstream.
         if not num_mm_tokens_by_key:
-            return [], None
+            raise ValueError(
+                "multimodal hashing could not determine multimodal token "
+                "lengths for the provided input.")
         num_mm_tokens = next(iter(num_mm_tokens_by_key.values()))
         if len(num_mm_tokens) <= 0:
-            return [], None
+            raise ValueError("multimodal hashing produced an empty multimodal "
+                             "token-length list.")
 
         vocab_size = input_processor.get_vocab_size()
         mm_ids = input_processor.get_mm_token_ids()

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -131,9 +131,10 @@ class BaseMultimodalInputProcessor(ABC):
     models. Specific processors can override these methods if they need custom logic.
 
     Optional tokenized+MM fast path: to support prompt_token_ids + multi_modal_data
-    without detokenizing, implement get_text_with_mm_placeholders(mm_counts) and
+    without detokenizing, set the `supports_token_id_mm_expansion` class flag to
+    True and implement both get_text_with_mm_placeholders(mm_counts) and
     expand_prompt_token_ids_for_mm(prompt_token_ids, num_mm_tokens_per_placeholder, ...).
-    If these are not implemented, the pipeline detokenizes the text prompt first and then
+    If the flag is False, the pipeline detokenizes the text prompt first and then
     processes the multimodal inputs.
     """
 
@@ -144,6 +145,12 @@ class BaseMultimodalInputProcessor(ABC):
     # Default False: most VLMs (Llava, Qwen-VL) use causal attention over MM
     # tokens and tolerate splitting. Gemma4 sets True.
     mm_bidirectional_blocks: ClassVar[bool] = False
+
+    # Whether the subclass implements the tokenized+MM fast path — i.e. both
+    # `get_text_with_mm_placeholders` and `expand_prompt_token_ids_for_mm`.
+    # When True, `__call__` may route `prompt_token_ids + multi_modal_data`
+    # inputs to `call_with_token_ids` instead of detokenizing upstream.
+    supports_token_id_mm_expansion: ClassVar[bool] = False
 
     def __init__(self,
                  model_path,
@@ -203,24 +210,18 @@ class BaseMultimodalInputProcessor(ABC):
         """Dispatch between text-prompt and tokenized+MM fast paths.
 
         - Tokenized+MM fast path (`prompt_token_ids` set, `multi_modal_data` set,
-          no `prompt`): delegate to `call_with_token_ids`, which builds dummy
-          placeholder text, runs `call_with_txt_prompt` on it to populate the
-          multimodal payload, then expands the real token IDs via
-          `expand_prompt_token_ids_for_mm`.
+          no `prompt`): delegate to `call_with_token_ids`.
         - Else (text prompt with/without MM data, or tokenize-only requests):
-          delegate to `call_with_txt_prompt`.
-
-        Non-fast-path VLMs are detokenized upstream in `llm.py`, so this
-        dispatcher only sees fast-path-eligible inputs in the first branch.
+          delegate to `call_with_text_prompt`.
         """
         if (inputs.get("prompt_token_ids") is not None
                 and inputs.get("multi_modal_data") is not None
                 and inputs.get("prompt") is None):
             return self.call_with_token_ids(inputs, sampling_params)
-        return self.call_with_txt_prompt(inputs, sampling_params)
+        return self.call_with_text_prompt(inputs, sampling_params)
 
     @abstractmethod
-    def call_with_txt_prompt(
+    def call_with_text_prompt(
         self, inputs: TextPrompt, sampling_params: SamplingParams
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
         """Process `inputs` containing a text `prompt` (and optionally `multi_modal_data`).
@@ -235,17 +236,38 @@ class BaseMultimodalInputProcessor(ABC):
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
         """Fast path for `prompt_token_ids + multi_modal_data` without detokenizing.
 
-        Requires the subclass to implement `get_text_with_mm_placeholders` and
-        `expand_prompt_token_ids_for_mm`. Otherwise raises `NotImplementedError`
-        (callers should detokenize upstream — see `llm.py`).
+        Builds dummy placeholder text, runs `call_with_text_prompt` on it to populate the
+        multimodal payload, then expands the real token IDs via
+        `expand_prompt_token_ids_for_mm`.
+
+        Requires the subclass to opt in via the `supports_token_id_mm_expansion`
+        class flag and implement both of the following hooks; otherwise raises
+        `NotImplementedError`:
+
+        - `get_text_with_mm_placeholders(mm_counts: Dict[str, int]) -> str`
+            Build a minimal placeholder text for the given per-modality item
+            counts. Used to drive the HF processor / vision encoder without the
+            real prompt.
+        - `expand_prompt_token_ids_for_mm(
+              prompt_token_ids: List[int],
+              num_mm_tokens_per_placeholder: List[int],
+              *,
+              hf_processor_mm_kwargs: Optional[Dict[str, Any]] = None,
+              mm_data: Optional[Dict[str, Any]] = None,
+          ) -> Tuple[List[int], Optional[Dict[str, Dict[str, Any]]]]`
+            Replace each MM placeholder token in `prompt_token_ids` with the
+            corresponding number of MM feature tokens. Returns the expanded
+            token IDs and optional `mm_data_updates` — per-modality fields to
+            merge into `extra_processed_inputs["multimodal_data"]` (e.g. video
+            `evs_ids` for Nano OMNI V3 rebuilt from the real prompt instead
+            of the dummy one).
         """
-        get_text = getattr(self, "get_text_with_mm_placeholders", None)
-        expand_ids = getattr(self, "expand_prompt_token_ids_for_mm", None)
-        if get_text is None or expand_ids is None:
+        if not self.supports_token_id_mm_expansion:
             raise NotImplementedError(
                 f"{type(self).__name__} does not implement the tokenized+MM "
-                "fast path. Detokenize `prompt_token_ids` to a text prompt "
-                "before calling.")
+                "fast path (supports_token_id_mm_expansion is False). "
+                "Detokenize `prompt_token_ids` to a text prompt before calling."
+            )
 
         prompt_token_ids = inputs["prompt_token_ids"]
         mm_data = inputs["multi_modal_data"]
@@ -274,7 +296,7 @@ class BaseMultimodalInputProcessor(ABC):
                 "call_with_token_ids: find_mm_token_lengths returned no token "
                 "lengths for the provided multi_modal_data.")
 
-        expanded_ids, mm_data_updates = expand_ids(
+        expanded_ids, mm_data_updates = self.expand_prompt_token_ids_for_mm(
             prompt_token_ids,
             num_mm_tokens,
             hf_processor_mm_kwargs=inputs.get("mm_processor_kwargs"),

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -17,10 +17,8 @@ from tqdm import tqdm
 from transformers import PreTrainedTokenizerBase
 
 from tensorrt_llm._utils import mpi_disabled
-from tensorrt_llm.inputs.data import TextPrompt
 from tensorrt_llm.inputs.multimodal import MultimodalInput, MultimodalParams
-from tensorrt_llm.inputs.registry import (BaseMultimodalInputProcessor,
-                                          DefaultInputProcessor)
+from tensorrt_llm.inputs.registry import BaseMultimodalInputProcessor
 from tensorrt_llm.llmapi import tracing
 from tensorrt_llm.metrics.enums import MetricNames
 
@@ -549,34 +547,10 @@ class BaseLLM:
         """
         inputs = prompt_inputs(inputs)
 
-        # A fast path for token IDs & MM data is available for a VLM if the input processor has the following methods.
-        # TODO: Once all the VLMs support the fast path, remove this flag and modify the remaining logic accordingly.
-        use_token_ids_for_mm_placeholders = (
-            hasattr(self.input_processor, "get_text_with_mm_placeholders")
-            and hasattr(self.input_processor, "expand_prompt_token_ids_for_mm"))
-
-        # This IF branch is applicable, whenever:
-        # - multimodal data is present (whether through embeddings or as preprocessed data), AND
-        # - token IDs are present, AND
-        # - two methods defining the placeholder token IDs expansion logic are not available.
-        if not inputs.get("prompt") and inputs.get("prompt_token_ids") and (
-                inputs.get("multi_modal_data")
-                or inputs.get("multi_modal_embeddings")) and not isinstance(
-                    self.input_processor, DefaultInputProcessor
-                ) and not use_token_ids_for_mm_placeholders:
-            # VLMs need to process/tokenize the prompt in their own way,
-            # if they don't have the fast path for token IDs & MM data implemented yet.
-            # TODO: Once all the VLMs support the fast path, we can remove this detokenization step entirely.
-            prompt = self.tokenizer.decode(inputs['prompt_token_ids'])
-            inputs = TextPrompt(
-                prompt=prompt,
-                multi_modal_data=inputs.get("multi_modal_data"),
-                mm_processor_kwargs=inputs.get("mm_processor_kwargs") or {})
-            if sampling_params.add_special_tokens:
-                logger.debug(
-                    "Setting add_special_tokens to False because prompt_token_ids were provided to generate. VLMs will re-encode the prompt."
-                )
-                sampling_params.add_special_tokens = False
+        # Detokenization for non-fast-path VLMs (prompt_token_ids + MM payload,
+        # no prompt) is handled inside BaseMultimodalInputProcessor.__call__
+        # and BaseMultimodalInputProcessor.attach_multimodal_embeddings, gated
+        # on the `supports_token_id_mm_expansion` class flag.
 
         is_mm_disagg = (disaggregated_params is not None
                         and disaggregated_params.multimodal_embedding_handles

--- a/tests/unittest/_torch/multimodal/test_multimodal_runtime.py
+++ b/tests/unittest/_torch/multimodal/test_multimodal_runtime.py
@@ -781,7 +781,7 @@ class _FakeMultimodalInputProcessor(BaseMultimodalInputProcessor):
     def dtype(self):
         return torch.float32
 
-    def __call__(self, inputs, sampling_params):
+    def call_with_text_prompt(self, inputs, sampling_params):
         raise NotImplementedError("This fake only supports token queries.")
 
     def get_vocab_size(self):


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified text-prompt multimodal input interfaces across many vision/multimodal model processors (Gemma3VL, Gemma4MM, HyperClovaX, Kimi K25, Llama4, LLaVA-Next, Mistral3, Nemotron Nano, Phi4MM, Qwen2VL, Qwen3VL, VILA).
  * Reorganized input-processor registry to simplify multimodal prompt handling and dispatch logic for tokenized and text-based inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

## Summary

Encapsulate the VLM tokenized+MM fast path inside `BaseMultimodalInputProcessor` so the registry no longer hosts model-specific stitching logic, and so `llm.py` no longer carries the tokenized-input detokenization guard.

## Why

Previously the fast path (handling `prompt_token_ids + multi_modal_data` without detokenizing) was spread across three layers: a detokenization guard in `llm.py`, a `tokenized_multimodal_process` block in `registry.py`, and per-model hooks (`get_text_with_mm_placeholders`, `expand_prompt_token_ids_for_mm`) on the input processors. The registry - a generic, model-agnostic component - ended up merging model-specific auxiliary streams (e.g. Nano V3 Omni's video `evs_ids`) and carrying a three-armed dispatch in `multimodal_hashing_process` for precomputed-vs-not inputs.

## What changed

- **`BaseMultimodalInputProcessor`** now owns the dispatch:
  - A concrete `__call__` that routes `prompt_token_ids + multi_modal_data` (no `prompt`) to the fast path when the subclass opts in, and otherwise detokenizes and falls through to the text path.
  - An abstract `call_with_text_prompt` - the renamed existing `__call__` on every subclass (the per-model HF-processor path).
  - A concrete `call_with_token_ids` that builds the dummy placeholder text, runs `call_with_text_prompt` on it to populate the multimodal payload, calls `expand_prompt_token_ids_for_mm`, and merges any returned `mm_data_updates` into `extra_processed_inputs["multimodal_data"]`. Raises `NotImplementedError` if the subclass hasn't opted into the fast path.
  - A `supports_token_id_mm_expansion` class flag (`ClassVar[bool]`, default `False`; `True` on LlavaNext + NanoV2VL) that gates the fast path - replacing the old `hasattr`-based probe.
  - A `_detokenize_to_text_prompt` helper (decode `prompt_token_ids` → text, preserve `multi_modal_data` / `mm_processor_kwargs`, flip `add_special_tokens` off) used by both `__call__` and `attach_multimodal_embeddings`.
  - `attach_multimodal_embeddings` is now a Template Method wrapper: it detokenizes for non-fast-path VLMs, then delegates to a new `_attach_multimodal_embeddings_impl` hook that subclasses override.
- **`create_input_processor_with_hash`** is simplified: `tokenized_multimodal_process` and `process_tokenized_prompt_maybe_hash` are deleted, `multimodal_hashing_process` collapses to a single `input_processor(...)` call (and now raises rather than returning an empty prompt when MM token lengths can't be determined, so the caller falls back instead of silently caching hashing-supported), and `input_processor_wrapper` no longer branches on tokenized-MM input shape.
- **All twelve `BaseMultimodalInputProcessor` subclasses** (LlavaNext, NanoV2VL, Llama4, Mistral3, Vila, Qwen2VL, Qwen3VL, Gemma3, Gemma4, Phi4MM, KimiK25, HCXVision) have `__call__` renamed to `call_with_text_prompt`. LlavaNext and Llama4 additionally rename their `attach_multimodal_embeddings` override to `_attach_multimodal_embeddings_impl`.
- **`llm.py`** no longer carries the tokenized-input detokenization guard - the fallback now lives in `BaseMultimodalInputProcessor` (`__call__` and `attach_multimodal_embeddings`), gated on `supports_token_id_mm_expansion`. This keeps the detokenize decision in one place and applies it uniformly to both entry points.

## Test Coverage

Ran individual `curl` requests against Nano Omni V3 for the following scenarios:
- image
- audio
- video
- audio-from-video

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
