### PR TITLE
[None][fix] disagg-gen-init: pass context_current_position as history…

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
@@ -445,7 +445,7 @@ class KVCacheV2Scheduler(RequestScheduler):
         if not self.kv_cache_manager.resize_context(
             req,
             req.context_remaining_length + get_draft_token_length(req),
-            history_length=req.context_remaining_length,
+            history_length=req.context_current_position,
         ):
             return ScheduleAction.SKIP, 0
 


### PR DESCRIPTION
  ## Description

The V2 scheduler's `_try_schedule_disagg_gen_init` was passing `req.context_remaining_length` as `history_length` to `kv_cache_manager.resize_context`. That field is the prompt suffix still to be processed, not the historic prefix already in the cache.

When GEN-side block reuse hits a long matching prefix, `prepare_context` sets `req.context_current_position` to the number of reused tokens and the cache's `_history_length` to the same value. The subsequent `resize_context(...,
history_length=req.context_remaining_length)` then violates the "history length cannot be decreased" invariant in
`_KVCache.resize()` and aborts the GEN event loop.

Pass `req.context_current_position` instead, matching the cache's established history boundary in both reuse-hit and reuse-miss paths. The block comment above the call already states the right intent ("Prompt is already historic ... history_length so SWA layers skip pre-window block allocation"); only the field was wrong.

Reproduced on DSV4-Pro disagg smoke (1×CTX TEP8 + 1×GEN TEP8 on GB300, concurrency 2). With this fix the GEN side no longer raises "History length cannot be decreased".

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
