### PR TITLE
[None][fix] Reuse batch_indices_cuda across CUDA graph captures in EAGLE3

### DIFF
--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -64,6 +64,11 @@ class Eagle3ResourceManager(BaseResourceManager):
             (max_num_tokens, self.hidden_size * config.num_capture_layers),
             dtype=self.dtype,
             device='cuda')
+        self.batch_indices_cuda = torch.empty(
+            [max_num_requests],
+            dtype=torch.int,
+            device='cuda',
+        )
         # sequence length, only used for metadata preparation
         self.seq_lens = {i: 0 for i in range(slot_size)}
         # start indices of each slot
@@ -131,9 +136,15 @@ class Eagle3OneModelDynamicTreeResourceManager(BaseResourceManager):
     """
 
     hidden_states: Optional[torch.Tensor] = None
+    batch_indices_cuda: Optional[torch.Tensor] = None
 
     def __init__(self, config: "EagleDecodingConfig", max_num_requests: int):
         self.max_num_requests = max_num_requests
+        self.batch_indices_cuda = torch.empty(
+            [max_num_requests],
+            dtype=torch.int,
+            device='cuda',
+        )
         self.spec_tree_manager = SpecTreeManager(
             max_num_requests=max_num_requests,
             use_dynamic_tree=config.use_dynamic_tree,
@@ -389,11 +400,20 @@ class Eagle3OneModelSpecMetadata(SpecMetadata):
                  self.hidden_size * len(self.layers_to_capture)),
                 dtype=self.dtype,
                 device='cuda')
-        self.batch_indices_cuda = torch.empty(
-            [self.max_num_requests],
-            dtype=torch.int,
-            device='cuda',
-        )
+        if (self.spec_resource_manager is not None
+                and self.spec_resource_manager.batch_indices_cuda is not None):
+            self.batch_indices_cuda = self.spec_resource_manager.batch_indices_cuda
+            assert self.batch_indices_cuda.shape[0] >= self.max_num_requests, (
+                f"batch_indices_cuda shape mismatch: "
+                f"{type(self.spec_resource_manager).__name__} has "
+                f"{self.batch_indices_cuda.shape}, but metadata expects "
+                f"at least ({self.max_num_requests},)")
+        else:
+            self.batch_indices_cuda = torch.empty(
+                [self.max_num_requests],
+                dtype=torch.int,
+                device='cuda',
+            )
 
         # Set tree flags based on config
         if self.use_dynamic_tree:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized CUDA memory allocation for speculative execution resource management to improve resource handling and reusability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Reuse batch_indices_cuda across CUDA graph captures in EAGLE3

This applies the same fix as https://github.com/NVIDIA/TensorRT-LLM/pull/13920 to batch_indices_cuda

## Test Coverage

Manually validates

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
