### PR TITLE
[None][perf] Eliminate torch.where host sync in multimodal fuse_input_embeds path

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_gemma3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3vl.py
@@ -193,6 +193,8 @@ class Gemma3VLM(PreTrainedModel):
         self.image_token_ids = torch.tensor([config.image_token_index],
                                             dtype=torch.int32,
                                             device=self._device)
+        self._mm_token_ids = torch.tensor([config.image_token_index],
+                                          dtype=torch.int32)
 
         model_config_cp = copy.deepcopy(model_config)
         self.model_config = model_config_cp
@@ -323,4 +325,4 @@ class Gemma3VLM(PreTrainedModel):
 
     @property
     def mm_token_ids(self):
-        return self.image_token_ids
+        return self._mm_token_ids

--- a/tensorrt_llm/_torch/models/modeling_gemma3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma3vl.py
@@ -297,7 +297,8 @@ class Gemma3VLM(PreTrainedModel):
             input_ids=input_ids,
             mm_embeds=mm_embeds,
             mm_token_ids=self.image_token_ids,
-            **kwargs,
+            mm_token_indices=kwargs.get("mm_token_indices"),
+            text_token_indices=kwargs.get("text_token_indices"),
         )
         logits = self.llm.forward(
             attn_metadata=attn_metadata,

--- a/tensorrt_llm/_torch/models/modeling_gemma4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4mm.py
@@ -1034,7 +1034,8 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
             input_ids=input_ids,
             mm_embeds=mm_embeds,
             mm_token_ids=fuse_token_ids,
-            **kwargs,
+            mm_token_indices=kwargs.get("mm_token_indices"),
+            text_token_indices=kwargs.get("text_token_indices"),
         )
         logits = self.llm.forward(
             attn_metadata=attn_metadata,

--- a/tensorrt_llm/_torch/models/modeling_gemma4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4mm.py
@@ -638,6 +638,8 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
         _mm_ids = [self.image_token_ids]
         if self.audio_token_ids is not None:
             _mm_ids.append(self.audio_token_ids)
+        if self.video_token_ids is not None:
+            _mm_ids.append(self.video_token_ids)
         self._mm_token_ids = torch.cat(_mm_ids) if len(_mm_ids) > 1 else self.image_token_ids
 
         model_config_cp = copy.deepcopy(model_config)

--- a/tensorrt_llm/_torch/models/modeling_gemma4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4mm.py
@@ -635,6 +635,11 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
             else None
         )
 
+        _mm_ids = [self.image_token_ids]
+        if self.audio_token_ids is not None:
+            _mm_ids.append(self.audio_token_ids)
+        self._mm_token_ids = torch.cat(_mm_ids) if len(_mm_ids) > 1 else self.image_token_ids
+
         model_config_cp = copy.deepcopy(model_config)
         self.model_config = model_config_cp
 
@@ -1050,8 +1055,5 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
         return logits
 
     @property
-    def mm_token_ids(self):
-        ids = [self.image_token_ids]
-        if self.audio_token_ids is not None:
-            ids.append(self.audio_token_ids)
-        return torch.cat(ids) if len(ids) > 1 else self.image_token_ids
+    def mm_token_ids(self) -> torch.Tensor:
+        return self._mm_token_ids

--- a/tensorrt_llm/_torch/models/modeling_gemma4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4mm.py
@@ -635,12 +635,12 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
             else None
         )
 
-        _mm_ids = [self.image_token_ids]
-        if self.audio_token_ids is not None:
-            _mm_ids.append(self.audio_token_ids)
-        if self.video_token_ids is not None:
-            _mm_ids.append(self.video_token_ids)
-        self._mm_token_ids = torch.cat(_mm_ids) if len(_mm_ids) > 1 else self.image_token_ids
+        _mm_ids = [config.image_token_id]
+        if getattr(config, "audio_token_id", None) is not None:
+            _mm_ids.append(config.audio_token_id)
+        if getattr(config, "video_token_id", None) is not None:
+            _mm_ids.append(config.video_token_id)
+        self._mm_token_ids = torch.tensor(_mm_ids, dtype=torch.int32)
 
         model_config_cp = copy.deepcopy(model_config)
         self.model_config = model_config_cp

--- a/tensorrt_llm/_torch/models/modeling_hyperclovax.py
+++ b/tensorrt_llm/_torch/models/modeling_hyperclovax.py
@@ -1111,9 +1111,13 @@ class HCXVisionForCausalLM(PreTrainedModel):
             mm_embeds = find_input_mm_embeds(
                 mm_embeds, multimodal_params[:num_context_requests])
 
-        input_ids, input_embeds = fuse_input_embeds(self.llm.model.embed_tokens,
-                                                    input_ids, mm_embeds,
-                                                    **kwargs)
+        input_ids, input_embeds = fuse_input_embeds(
+            self.llm.model.embed_tokens,
+            input_ids,
+            mm_embeds,
+            mm_token_indices=kwargs.get("mm_token_indices"),
+            text_token_indices=kwargs.get("text_token_indices"),
+        )
         output_prob = self.llm.forward(
             attn_metadata=attn_metadata,
             input_ids=input_ids,

--- a/tensorrt_llm/_torch/models/modeling_kimi_k25.py
+++ b/tensorrt_llm/_torch/models/modeling_kimi_k25.py
@@ -1581,6 +1581,9 @@ class KimiK25ForConditionalGeneration(PreTrainedModel):
         self._media_placeholder_token_id = getattr(
             config, "media_placeholder_token_id", _MEDIA_PLACEHOLDER_TOKEN_ID
         )
+        # Backing storage for the ``mm_token_ids`` property below — built once
+        # here so the executor doesn't re-allocate per step.
+        self._mm_token_ids = torch.tensor([self._media_placeholder_token_id], dtype=torch.int32)
 
         # Align model config with the LLM backbone's text_config.
         # The executor reads eos_token_id and other generation params from
@@ -1632,12 +1635,12 @@ class KimiK25ForConditionalGeneration(PreTrainedModel):
     @property
     def mm_token_ids(self) -> torch.Tensor:
         """Surface the in-vocab media placeholder to the model engine so
-        ``_prepare_multimodal_indices`` produces correct MM/text masks.
-        Without this, the executor falls back to the OOV (``>= vocab_size``)
-        predicate and misses Kimi's placeholder, forcing ``fuse_input_embeds``
-        through the ``torch.where`` host-sync path on GPU input_ids.
+        ``_prepare_multimodal_indices`` selects the ``torch.isin`` predicate
+        instead of the OOV (``>= vocab_size``) fallback (which would miss
+        Kimi's placeholder and force ``fuse_input_embeds`` through the
+        ``torch.where`` host-sync path on GPU input_ids).
         """
-        return torch.tensor([self._media_placeholder_token_id], dtype=torch.int32)
+        return self._mm_token_ids
 
     def load_weights(self, weights) -> None:
         """Load vision + projector + LLM weights from checkpoint."""
@@ -1701,8 +1704,7 @@ class KimiK25ForConditionalGeneration(PreTrainedModel):
             # `fuse_input_embeds` itself, so the explicit check is no longer
             # needed.
             if len(mm_embeds) > 0:
-                mm_token_ids = self.mm_token_ids.to(input_ids.device,
-                                                    dtype=input_ids.dtype)
+                mm_token_ids = self.mm_token_ids.to(input_ids.device, dtype=input_ids.dtype)
         input_ids, inputs_embeds = fuse_input_embeds(
             self.llm.model.embed_tokens,
             input_ids,

--- a/tensorrt_llm/_torch/models/modeling_kimi_k25.py
+++ b/tensorrt_llm/_torch/models/modeling_kimi_k25.py
@@ -1629,6 +1629,16 @@ class KimiK25ForConditionalGeneration(PreTrainedModel):
             "multimodal_embedding",
         ]
 
+    @property
+    def mm_token_ids(self) -> torch.Tensor:
+        """Surface the in-vocab media placeholder to the model engine so
+        ``_prepare_multimodal_indices`` produces correct MM/text masks.
+        Without this, the executor falls back to the OOV (``>= vocab_size``)
+        predicate and misses Kimi's placeholder, forcing ``fuse_input_embeds``
+        through the ``torch.where`` host-sync path on GPU input_ids.
+        """
+        return torch.tensor([self._media_placeholder_token_id], dtype=torch.int32)
+
     def load_weights(self, weights) -> None:
         """Load vision + projector + LLM weights from checkpoint."""
         # Create vision encoder if it was skipped during meta init.
@@ -1671,17 +1681,10 @@ class KimiK25ForConditionalGeneration(PreTrainedModel):
         multimodal_params = multimodal_params or []
         mm_embeds: List[torch.Tensor] = []
         mm_token_ids = None
-        fuse_kwargs = kwargs
 
         if len(multimodal_params) > 0:
             if DISAGG:
                 raise NotImplementedError("Disaggregated inference not yet supported for K2.5.")
-            # fuse_input_embeds doesn't accept the mm_*_indices kwargs.
-            fuse_kwargs = {
-                k: v
-                for k, v in kwargs.items()
-                if k not in ("mm_token_indices", "text_token_indices")
-            }
             mm_ctx_params = multimodal_params[: attn_metadata.num_contexts]
             mm_embeds = get_multimodal_embeddings(
                 encoder_forward_fn=self.mm_encoder.forward,
@@ -1689,27 +1692,24 @@ class KimiK25ForConditionalGeneration(PreTrainedModel):
             )
             mm_embeds = find_input_mm_embeds(mm_embeds, mm_ctx_params)
 
+            # The executor's `_prepare_multimodal_indices` now sees Kimi's
+            # in-vocab placeholder via `self.mm_token_ids` and emits indices
+            # that match `find_input_mm_embeds`'s active-chunk slice. The
+            # previous `(input_ids == placeholder).sum().item()` guard was a
+            # host sync used to detect chunked-prefill / KV-reuse mismatches;
+            # that mismatch surfaces as a row-count error inside
+            # `fuse_input_embeds` itself, so the explicit check is no longer
+            # needed.
             if len(mm_embeds) > 0:
-                placeholder_id = self._media_placeholder_token_id
-                if int((input_ids == placeholder_id).sum().item()) == 0:
-                    logger.warning(
-                        "Vision embeddings computed but no placeholder tokens "
-                        "found in input_ids — embeddings discarded."
-                    )
-                    mm_embeds = []
-                else:
-                    mm_token_ids = torch.tensor(
-                        [placeholder_id],
-                        dtype=input_ids.dtype,
-                        device=input_ids.device,
-                    )
-
+                mm_token_ids = self.mm_token_ids.to(input_ids.device,
+                                                    dtype=input_ids.dtype)
         input_ids, inputs_embeds = fuse_input_embeds(
             self.llm.model.embed_tokens,
             input_ids,
             mm_embeds,
             mm_token_ids=mm_token_ids,
-            **fuse_kwargs,
+            mm_token_indices=kwargs.get("mm_token_indices"),
+            text_token_indices=kwargs.get("text_token_indices"),
         )
 
         return self.llm.forward(

--- a/tensorrt_llm/_torch/models/modeling_kimi_k25.py
+++ b/tensorrt_llm/_torch/models/modeling_kimi_k25.py
@@ -1695,13 +1695,13 @@ class KimiK25ForConditionalGeneration(PreTrainedModel):
             )
             mm_embeds = find_input_mm_embeds(mm_embeds, mm_ctx_params)
 
-            # The executor's `_prepare_multimodal_indices` now sees Kimi's
-            # in-vocab placeholder via `self.mm_token_ids` and emits indices
-            # that match `find_input_mm_embeds`'s active-chunk slice. The
-            # previous `(input_ids == placeholder).sum().item()` guard was a
+            # The executor's ``_prepare_multimodal_indices`` now sees Kimi's
+            # in-vocab placeholder via ``self.mm_token_ids`` and emits indices
+            # that match ``find_input_mm_embeds``'s active-chunk slice. The
+            # previous ``(input_ids == placeholder).sum().item()`` guard was a
             # host sync used to detect chunked-prefill / KV-reuse mismatches;
             # that mismatch surfaces as a row-count error inside
-            # `fuse_input_embeds` itself, so the explicit check is no longer
+            # ``fuse_input_embeds`` itself, so the explicit check is no longer
             # needed.
             if len(mm_embeds) > 0:
                 mm_token_ids = self.mm_token_ids.to(input_ids.device, dtype=input_ids.dtype)

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -1528,9 +1528,13 @@ class Llama4ForConditionalGeneration(SpecDecOneEngineForCausalLM[Llama4Model,
                     for multimodal_param in multimodal_params
                 ]
 
-        input_ids, inputs_embeds = fuse_input_embeds(self.model.embed_tokens,
-                                                     input_ids, mm_embeds,
-                                                     **kwargs)
+        input_ids, inputs_embeds = fuse_input_embeds(
+            self.model.embed_tokens,
+            input_ids,
+            mm_embeds,
+            mm_token_indices=kwargs.get("mm_token_indices"),
+            text_token_indices=kwargs.get("text_token_indices"),
+        )
         return super().forward(attn_metadata,
                                input_ids,
                                position_ids,

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -1293,6 +1293,15 @@ class Llama4InputProcessor(BaseMultimodalInputProcessor,
     def tokenizer(self) -> AutoTokenizer:
         return self._tokenizer
 
+    def get_mm_token_ids(self) -> Optional[torch.Tensor]:
+        """Surface the in-vocab image placeholder so
+        ``maybe_compute_mm_embed_cumsum`` builds ``embed_mask_cumsum`` via
+        ``torch.isin(input_ids, mm_token_ids)`` instead of the OOV
+        ``>= vocab_size`` fallback (which would miss all positions now that
+        the OOV remap in __call__/load_tokenizer is gone).
+        """
+        return torch.tensor([self.image_token_index], dtype=torch.int32)
+
     @property
     def model_path(self) -> str:
         return self._model_path
@@ -1425,8 +1434,9 @@ class Llama4InputProcessor(BaseMultimodalInputProcessor,
             **kwargs)
         token_ids = text_inputs.input_ids.squeeze()
 
-        # Replace image token indices with out-of-vocabulary tokens
-        token_ids[token_ids == self.image_token_index] = self.vocab_size + 1
+        # Keep image_token_index in-vocab so the model engine can locate mm
+        # positions via ``torch.isin(input_ids, mm_token_ids)`` without the
+        # legacy ``vocab_size + 1`` remap.
         # Concatenate all multimodal embeddings
         multimodal_data = {}
         multimodal_data["multimodal_embedding"] = torch.cat(mm_embeddings,
@@ -1464,8 +1474,8 @@ class Llama4InputProcessor(BaseMultimodalInputProcessor,
             **truncate_kwargs)
         if images:
             token_ids = processed["input_ids"].squeeze()
-            # for fuse_input_embeds
-            token_ids[token_ids == self.image_token_index] = self.vocab_size + 1
+            # Keep image_token_index in-vocab; mm positions are located by
+            # the model engine via ``torch.isin(input_ids, mm_token_ids)``.
 
             multimodal_data = {}
             multimodal_data["image"] = {
@@ -1506,6 +1516,20 @@ class Llama4ForConditionalGeneration(SpecDecOneEngineForCausalLM[Llama4Model,
         if not DISAGG:
             self.mm_encoder = Llama4VisionEncoder(full_model_config)
 
+        # Surface the in-vocab image placeholder to the model engine's
+        # ``_prepare_multimodal_indices`` so it selects the ``torch.isin``
+        # predicate. Read from ``full_model_config`` (the top-level Llama4Config
+        # holds ``image_token_index``; the text-only swapped config above does
+        # not).
+        self._mm_token_ids = torch.tensor(
+            [full_model_config.pretrained_config.image_token_index],
+            dtype=torch.int32,
+        )
+
+    @property
+    def mm_token_ids(self) -> torch.Tensor:
+        return self._mm_token_ids
+
     def forward(
         self,
         attn_metadata: AttentionMetadata,
@@ -1532,6 +1556,7 @@ class Llama4ForConditionalGeneration(SpecDecOneEngineForCausalLM[Llama4Model,
             self.model.embed_tokens,
             input_ids,
             mm_embeds,
+            mm_token_ids=self.mm_token_ids,
             mm_token_indices=kwargs.get("mm_token_indices"),
             text_token_indices=kwargs.get("text_token_indices"),
         )

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -86,6 +86,15 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
     def dtype(self) -> torch.dtype:
         return self._dtype
 
+    def get_mm_token_ids(self) -> Optional[torch.Tensor]:
+        """Surface the in-vocab image placeholder so
+        ``maybe_compute_mm_embed_cumsum`` builds ``embed_mask_cumsum`` via
+        ``torch.isin(input_ids, mm_token_ids)`` instead of the OOV
+        ``>= vocab_size`` fallback (which would miss all positions now that
+        the OOV remap in _expand/_postprocess/__call__ is gone).
+        """
+        return torch.tensor([self.image_token_index], dtype=torch.int32)
+
     def get_text_with_mm_placeholders(self, mm_counts: Dict[str, int]) -> str:
         """
         Return minimal placeholder text for the given multimodal item counts,
@@ -122,7 +131,11 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
             mm_token_offsets (List[int]): Offset (position) in the expanded sequence where each MM token group (for each placeholder) begins.
         """
         image_token_id = self.config.image_token_index
-        placeholder_id = self.vocab_size + 1
+        # Keep the placeholder in-vocab so the model engine can locate mm
+        # positions via ``torch.isin(input_ids, mm_token_ids)``. The previous
+        # ``vocab_size + 1`` OOV remap is no longer needed — the model class
+        # exposes ``mm_token_ids = [image_token_index]`` to the engine.
+        placeholder_id = image_token_id
 
         expanded: List[int] = []
         mm_token_lengths: List[int] = []
@@ -237,10 +250,15 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
             [mm_token_positions, mm_token_positions + 1]).unique()
         input_ids_splits = list(input_ids.tensor_split(mm_split_positions.cpu(
         )))  # len(input_ids_splits) = num_segments after mm tokens are isolated
+        # Use the in-vocab image_token_index repeated mm_total_length times
+        # (instead of unique arange(vocab_size, vocab_size + L) OOV IDs).
+        # ``fuse_input_embeds`` only needs a predicate that distinguishes mm vs
+        # text positions, not unique per-position IDs.
         mm_ids_splits = list(
-            torch.arange(self.vocab_size,
-                         self.vocab_size + mm_total_length,
-                         device=input_ids.device).split(mm_lengths_per_split)
+            torch.full((mm_total_length, ),
+                       self.config.image_token_index,
+                       dtype=input_ids.dtype,
+                       device=input_ids.device).split(mm_lengths_per_split)
         )  # len(mm_ids_splits) = num_mm_segments
 
         for i, mm_ids in enumerate(mm_ids_splits):
@@ -403,10 +421,9 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
             images=images,
             do_rescale=not (images and isinstance(images[0], torch.Tensor)),
             return_tensors="pt")
-        # Postprocess
+        # Keep image_token_index in-vocab; mm positions are located by
+        # the model engine via ``torch.isin(input_ids, mm_token_ids)``.
         fused_input_ids = processed_values['input_ids'][0]
-        fused_input_ids[fused_input_ids ==
-                        self.image_token_index] = self.vocab_size + 1
 
         multimodal_data = {}
         multimodal_data["image"] = {
@@ -651,8 +668,18 @@ class LlavaNextModel(PreTrainedModel):
 
         self.llm = AutoModelForCausalLM.from_config(llm_model_config)
 
+        # Surface the in-vocab image placeholder to the model engine's
+        # ``_prepare_multimodal_indices``.
+        self._mm_token_ids = torch.tensor(
+            [model_config.pretrained_config.image_token_index],
+            dtype=torch.int32)
+
         self.model_config = model_config
         self.post_config()
+
+    @property
+    def mm_token_ids(self) -> torch.Tensor:
+        return self._mm_token_ids
 
     def load_weights(self, weights, weight_mapper: BaseWeightMapper):
         if isinstance(weight_mapper, LlavaNextHfWeightMapper):
@@ -718,6 +745,7 @@ class LlavaNextModel(PreTrainedModel):
             self.llm.model.embed_tokens,
             input_ids,
             mm_embeds,
+            mm_token_ids=self.mm_token_ids,
             mm_token_indices=kwargs.get("mm_token_indices"),
             text_token_indices=kwargs.get("text_token_indices"),
         )

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -87,12 +87,7 @@ class LlavaNextInputProcessor(BaseMultimodalInputProcessor,
         return self._dtype
 
     def get_mm_token_ids(self) -> Optional[torch.Tensor]:
-        """Surface the in-vocab image placeholder so
-        ``maybe_compute_mm_embed_cumsum`` builds ``embed_mask_cumsum`` via
-        ``torch.isin(input_ids, mm_token_ids)`` instead of the OOV
-        ``>= vocab_size`` fallback (which would miss all positions now that
-        the OOV remap in _expand/_postprocess/__call__ is gone).
-        """
+        """Return in-vocab multimodal placeholder token IDs."""
         return torch.tensor([self.image_token_index], dtype=torch.int32)
 
     def get_text_with_mm_placeholders(self, mm_counts: Dict[str, int]) -> str:

--- a/tensorrt_llm/_torch/models/modeling_llava_next.py
+++ b/tensorrt_llm/_torch/models/modeling_llava_next.py
@@ -715,7 +715,12 @@ class LlavaNextModel(PreTrainedModel):
             mm_embeds = find_input_mm_embeds(
                 mm_embeds, multimodal_params[:num_context_requests])
         input_ids, inputs_embeds = fuse_input_embeds(
-            self.llm.model.embed_tokens, input_ids, mm_embeds, **kwargs)
+            self.llm.model.embed_tokens,
+            input_ids,
+            mm_embeds,
+            mm_token_indices=kwargs.get("mm_token_indices"),
+            text_token_indices=kwargs.get("text_token_indices"),
+        )
         logits = self.llm.forward(attn_metadata, input_ids, position_ids,
                                   inputs_embeds, return_context_logits)
         return logits

--- a/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
@@ -352,6 +352,13 @@ def find_input_mm_embeds(
         - Handles chunked prefill by considering chunk boundaries and current chunk tokens
         - Example: if a request has 8 MM embed rows, 2 cached rows, and 3 rows
           in the current chunk, this keeps rows [2:5].
+        - This function reads only CPU-resident counts from
+          ``MultimodalParams.multimodal_runtime`` and never touches GPU
+          tensors, so it does not introduce host-device synchronization.
+          The companion ``torch.where`` host sync sits in ``fuse_input_embeds``
+          (via ``filter_mm_token_from_input_ids``) and is avoided by routing
+          executor-precomputed ``mm_token_indices`` / ``text_token_indices``
+          through to that call — see the contract there.
     """
     if not isinstance(mm_embeds, list):
         raise TypeError("mm_embeds must be a list")
@@ -470,7 +477,17 @@ def fuse_input_embeds(
         - Example: len(torch.cat(mm_embeds)) must match len(mm_token_indices);
           for chunked prefill, pass only the current chunk's mm_embeds or
           explicit indices for the active MM token positions.
-        - This function may involve host-device synchronization if indices are not provided and filtering is performed. See filter_mm_token_from_input_ids for details.
+        - Sync-free contract: passing both ``text_token_indices`` and
+          ``mm_token_indices`` skips the GPU ``torch.where`` host sync. The
+          executor (``model_engine._prepare_inputs`` /
+          ``_prepare_tp_inputs_no_cache``) precomputes them on a CPU
+          ``input_ids`` copy via ``_prepare_multimodal_indices`` (which uses
+          ``filter_mm_token_from_input_ids`` against ``self.model.mm_token_ids``
+          when present, else the OOV fallback ``>= vocab_size``) and ships
+          them as pinned async H2D tensors in the inputs dict. VLM forwards
+          are expected to forward these explicitly rather than relying on a
+          ``**kwargs`` splat — if they don't, this function falls back to the
+          host-syncing ``filter_mm_token_from_input_ids`` on GPU ``input_ids``.
     """
     if len(mm_embeds) == 0:
         if extra_embeds is not None and len(extra_embeds) > 0:

--- a/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
@@ -488,6 +488,15 @@ def fuse_input_embeds(
           are expected to forward these explicitly rather than relying on a
           ``**kwargs`` splat — if they don't, this function falls back to the
           host-syncing ``filter_mm_token_from_input_ids`` on GPU ``input_ids``.
+        - In-vocab fast path: when ``mm_token_ids`` is provided, the caller is
+          declaring that mm placeholder IDs are real vocabulary entries. In
+          that case the text path skips its ``index_select`` + ``torch.empty``
+          + text scatter and embeds the full ``input_ids`` once, overwriting
+          mm rows afterwards. This is the path taken by every VLM currently
+          in tree EXCEPT Hyperclovax, which keeps the legacy ``vocab_size + 1``
+          OOV remap in its input processor and therefore passes
+          ``mm_token_ids=None`` so the OOV branch is taken — embedding an OOV
+          id would be out-of-bounds.
     """
     if len(mm_embeds) == 0:
         if extra_embeds is not None and len(extra_embeds) > 0:
@@ -508,11 +517,24 @@ def fuse_input_embeds(
             f"Multimodal token count mismatch: found {len(mm_token_indices)} image tokens in input_ids "
             f"but received {mm_embed.shape[0]} image embeddings.")
 
-    text_embed = embedding_layer(input_ids[text_token_indices])
-    input_embeds = torch.empty(input_ids.shape[0],
-                               mm_embed.shape[-1],
-                               device=text_embed.device,
-                               dtype=text_embed.dtype)
+    if mm_token_ids is not None:
+        # In-vocab fast path: caller declared mm tokens are real vocabulary
+        # IDs, so a single full embedding lookup is safe. Saves the
+        # ``index_select`` over text positions, the ``torch.empty`` alloc, and
+        # the text scatter (~2 GPU kernels per VLM forward) at the cost of
+        # ~mm-fraction extra embedding lookups whose result is overwritten.
+        input_embeds = embedding_layer(input_ids)
+    else:
+        # OOV path: input_ids holds placeholder IDs >= num_embeddings at mm
+        # positions (e.g. ``vocab_size + 1``), so embedding the full sequence
+        # would be out-of-bounds. Gather only the in-vocab text positions and
+        # scatter into a fresh buffer.
+        text_embed = embedding_layer(input_ids[text_token_indices])
+        input_embeds = torch.empty(input_ids.shape[0],
+                                   mm_embed.shape[-1],
+                                   device=text_embed.device,
+                                   dtype=text_embed.dtype)
+        input_embeds[text_token_indices, :] = text_embed
     if extra_embeds is not None and len(extra_embeds) > 0:
         # only support single modality for deepstack features for now
         for i, extra_feature in enumerate(extra_embeds):
@@ -525,7 +547,6 @@ def fuse_input_embeds(
             extra_embed[mm_token_indices, :] = extra_feature
             extra_embeds[i] = extra_embed
 
-    input_embeds[text_token_indices, :] = text_embed
     input_embeds[mm_token_indices, :] = mm_embed.to(dtype=input_embeds.dtype,
                                                     device=input_embeds.device)
     if extra_embeds is not None and len(extra_embeds) > 0:

--- a/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
@@ -422,7 +422,10 @@ def filter_mm_token_from_input_ids(
     Args:
         input_ids: shape [text_total_length + mm_total_length].
         vocab_size: size of the model's vocabulary
-        mm_token_ids: possible token ids for multimodal tokens, if known. If not known and set to None, it is assumed that the multimodal tokens are out-of-vocabulary tokens i.e. the `input_ids` contains tokens >= vocab_size that represent the multimodal tokens.
+        mm_token_ids: possible token ids for multimodal tokens, if known. If
+            not known and set to None, it is assumed that the multimodal tokens
+            are out-of-vocabulary tokens i.e. the ``input_ids`` contains tokens
+            >= vocab_size that represent the multimodal tokens.
     Note:
         Example: input_ids=[1, 55, 2, 101], vocab_size=100, and
         mm_token_ids=[55] returns mm_token_indices=[1]; token 101 is text

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -2638,7 +2638,7 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         self.sound_context_token_id = getattr(config, "sound_context_token_id", None)
         self.post_config()
         # Expose the in-vocab context tokens to the model engine so
-        # `_prepare_multimodal_indices` selects the torch.isin predicate
+        # ``_prepare_multimodal_indices`` selects the torch.isin predicate
         # instead of the OOV fallback. Without this, the executor produces
         # empty mm_token_indices (img/sound IDs are < vocab_size), and the
         # propagated indices then trip the count-equality check inside

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -2637,6 +2637,16 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         self.video_context_token_id = config.video_context_token_id
         self.sound_context_token_id = getattr(config, "sound_context_token_id", None)
         self.post_config()
+        # Expose the in-vocab context tokens to the model engine so
+        # `_prepare_multimodal_indices` selects the torch.isin predicate
+        # instead of the OOV fallback. Without this, the executor produces
+        # empty mm_token_indices (img/sound IDs are < vocab_size), and the
+        # propagated indices then trip the count-equality check inside
+        # fuse_input_embeds against the encoder-provided rows.
+        _mm_token_ids = [self.img_context_token_id]
+        if self.sound_context_token_id is not None:
+            _mm_token_ids.append(self.sound_context_token_id)
+        self.mm_token_ids = torch.tensor(_mm_token_ids, dtype=torch.int32)
         self.is_loaded = True
         # Use config value if explicitly set (EVS enabled), otherwise default to 0.0 (EVS disabled)
         self.video_pruning_rate = (
@@ -3181,14 +3191,13 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
 
             mm_embedding = find_input_mm_embeds(mm_embedding, ctx_params)
 
-        mm_token_ids_list = [self.img_context_token_id]
-        if self.sound_context_token_id is not None:
-            mm_token_ids_list.append(self.sound_context_token_id)
         input_ids, input_embeds = fuse_input_embeds(
             self.llm.model.embed_tokens,
             input_ids,
             mm_embedding,
-            mm_token_ids=torch.tensor(mm_token_ids_list, dtype=torch.int32),
+            mm_token_ids=self.mm_token_ids,
+            mm_token_indices=kwargs.get("mm_token_indices"),
+            text_token_indices=kwargs.get("text_token_indices"),
         )
 
         output_prob = self.llm.forward(

--- a/tensorrt_llm/_torch/models/modeling_phi4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_phi4mm.py
@@ -1095,7 +1095,8 @@ class Phi4MMForCausalLM(transformers.PreTrainedModel):
             input_ids,
             mm_embedding,
             mm_token_ids=self.mm_token_ids,
-            **kwargs,
+            mm_token_indices=kwargs.get("mm_token_indices"),
+            text_token_indices=kwargs.get("text_token_indices"),
         )
 
         output_prob = self.llm.forward(

--- a/tensorrt_llm/_torch/models/modeling_phi4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_phi4mm.py
@@ -1026,10 +1026,17 @@ class Phi4MMForCausalLM(transformers.PreTrainedModel):
         weights = updated_weights
         self.llm.load_weights(weights)
 
-        # Move mm_token_ids to the correct device.
         self.mm_token_ids = torch.tensor(
-            [_IMAGE_SPECIAL_TOKEN_ID, _AUDIO_SPECIAL_TOKEN_ID],
-            device=self.device)
+            [_IMAGE_SPECIAL_TOKEN_ID, _AUDIO_SPECIAL_TOKEN_ID])
+
+    @property
+    def mm_token_ids(self) -> torch.Tensor:
+        return self._mm_token_ids
+
+    @mm_token_ids.setter
+    def mm_token_ids(self, token_ids: torch.Tensor) -> None:
+        self._mm_token_ids = token_ids.to("cpu")
+        self._mm_token_ids_device = token_ids.to(self.device)
 
     @property
     def vocab_size_padded(self) -> int:
@@ -1075,7 +1082,7 @@ class Phi4MMForCausalLM(transformers.PreTrainedModel):
         if len(multimodal_params) > 0:
             if not _is_mm_disagg():
                 encoder_kwargs = {
-                    "mm_token_ids": self.mm_token_ids,
+                    "mm_token_ids": self._mm_token_ids_device,
                 }
                 mm_embedding = get_multimodal_embeddings(
                     encoder_forward_fn=self.hf_phi4mm_model.forward,
@@ -1094,7 +1101,7 @@ class Phi4MMForCausalLM(transformers.PreTrainedModel):
             self.llm.model.embed_tokens,
             input_ids,
             mm_embedding,
-            mm_token_ids=self.mm_token_ids,
+            mm_token_ids=self._mm_token_ids_device,
             mm_token_indices=kwargs.get("mm_token_indices"),
             text_token_indices=kwargs.get("text_token_indices"),
         )

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -187,7 +187,6 @@ class Qwen2VLInputProcessorBase(BaseMultimodalInputProcessor,
             use_fast=self.use_fast,
             trust_remote_code=trust_remote_code)
 
-        self.tllm_multimodal_token_id = self.get_vocab_size() + 1
         # temporal patch size for video frames
         self.temporal_patch_size = getattr(self.config.vision_config,
                                            'temporal_patch_size', 1)
@@ -443,18 +442,26 @@ class Qwen2VLInputProcessorBase(BaseMultimodalInputProcessor,
                               **mm_processor_kwargs)
 
     def _postprocess(self, input_ids: torch.IntTensor) -> torch.IntTensor:
-        token_ids = [
-            tid
-            for attr in ("image_token_id", "vision_token_id", "video_token_id")
-            if (tid := getattr(self.config, attr, None)) is not None
-        ]
-        if token_ids:
-            ids_tensor = torch.tensor(token_ids,
-                                      device=input_ids.device,
-                                      dtype=input_ids.dtype)
-            input_ids[torch.isin(input_ids,
-                                 ids_tensor)] = self.tllm_multimodal_token_id
+        # Keep image / vision / video placeholders in-vocab; the model engine
+        # locates mm positions via ``torch.isin(input_ids, mm_token_ids)`` and
+        # the previous ``vocab_size + 1`` OOV remap is no longer needed.
         return input_ids
+
+    def get_mm_token_ids(self) -> Optional[torch.Tensor]:
+        """Surface the in-vocab image / vision / video placeholder IDs so that
+        ``maybe_compute_mm_embed_cumsum`` builds ``embed_mask_cumsum`` via
+        ``torch.isin(input_ids, mm_token_ids)`` instead of the OOV
+        ``>= vocab_size`` fallback (which would miss all positions now that the
+        ``_postprocess`` OOV remap is gone).
+        """
+        ids = [
+            tid for tid in (
+                getattr(self.config, 'image_token_id', None),
+                getattr(self.config, 'vision_token_id', None),
+                getattr(self.config, 'video_token_id', None),
+            ) if tid is not None
+        ]
+        return torch.tensor(ids, dtype=torch.int32) if ids else None
 
     def get_mrope_config(
             self,
@@ -530,12 +537,11 @@ class Qwen2VLInputProcessorBase(BaseMultimodalInputProcessor,
         prompt_token_ids = build_disagg_prefill_multimodal_inputs(
             inputs, mm_handles).prompt_token_ids
 
+        # ``build_disagg_prefill_multimodal_inputs`` already emits the in-vocab
+        # ``image_token_id`` at mm positions (no legacy OOV remap), so
+        # ``mrope_input_ids`` is fed to ``get_mrope_config`` as-is.
         mrope_input_ids = torch.tensor(prompt_token_ids,
                                        dtype=torch.long).unsqueeze(0)
-        mrope_input_ids = mrope_input_ids.clone()
-        multimodal_token_id = self.tllm_multimodal_token_id
-        mrope_input_ids[mrope_input_ids ==
-                        multimodal_token_id] = self.config.image_token_id
         spatial_merge_size = self.config.vision_config.spatial_merge_size
         image_grid_thw = torch.tensor(
             [
@@ -1421,6 +1427,23 @@ class Qwen2VLModelBase(PreTrainedModel):
         else:
             self.mm_encoder = None
 
+        # Surface the in-vocab image / vision / video placeholder IDs to the
+        # model engine's ``_prepare_multimodal_indices`` so it selects the
+        # ``torch.isin`` predicate. Filter out None — some Qwen2-VL variants
+        # only define a subset of these.
+        _mm_ids = [
+            tid for tid in (
+                getattr(self.config, 'image_token_id', None),
+                getattr(self.config, 'vision_token_id', None),
+                getattr(self.config, 'video_token_id', None),
+            ) if tid is not None
+        ]
+        self._mm_token_ids = torch.tensor(_mm_ids, dtype=torch.int32)
+
+    @property
+    def mm_token_ids(self) -> torch.Tensor:
+        return self._mm_token_ids
+
     def init_mrope_embedding(self, model_config: ModelConfig[PretrainedConfig]):
         config = model_config.pretrained_config
         # For VL configs (Qwen2_5_VLConfig), hidden_size etc. live in
@@ -1535,6 +1558,7 @@ class Qwen2VLModelBase(PreTrainedModel):
             self.llm.model.embed_tokens,
             input_ids,
             mm_embeds,
+            mm_token_ids=self.mm_token_ids,
             mm_token_indices=kwargs.get("mm_token_indices"),
             text_token_indices=kwargs.get("text_token_indices"),
         )
@@ -1649,7 +1673,10 @@ class Qwen2_5VLInputProcessorBase(Qwen2VLInputProcessorBase):
         final_length = len(input_ids) - num_images + total_mm_tokens
         # Create output tensor
         expanded_ids = torch.empty(final_length, dtype=input_ids.dtype)
-        placeholder_id = self.tllm_multimodal_token_id
+        # Use the in-vocab image_token_id as the placeholder repeated mm_token_num
+        # times, so the model engine can locate mm positions via
+        # ``torch.isin(input_ids, mm_token_ids)`` without the legacy OOV remap.
+        placeholder_id = image_token_index
 
         # Fill the expanded sequence
         write_pos = 0

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -1531,9 +1531,13 @@ class Qwen2VLModelBase(PreTrainedModel):
                 mrope_delta_read_seq_slots=kwargs.get(
                     "mrope_delta_read_seq_slots"))
 
-        input_ids, input_embeds = fuse_input_embeds(self.llm.model.embed_tokens,
-                                                    input_ids, mm_embeds,
-                                                    **kwargs)
+        input_ids, input_embeds = fuse_input_embeds(
+            self.llm.model.embed_tokens,
+            input_ids,
+            mm_embeds,
+            mm_token_indices=kwargs.get("mm_token_indices"),
+            text_token_indices=kwargs.get("text_token_indices"),
+        )
         output_prob = self.llm.forward(
             attn_metadata=attn_metadata,
             input_ids=input_ids,

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -74,13 +74,13 @@ def _expand_prompt_token_ids_for_mm_handoff(
     image_token_id: int,
     video_token_id: int,
     vision_start_token_id: int,
-    placeholder_id: int,
 ) -> DisaggPrefillMultimodalInputs:
     """Expand Qwen3-VL image/video placeholders and emit sparse MM layout.
 
     Qwen handoff has one coarse <image_pad> or <video_pad> token per item.
     This helper expands that one token to the number of embedding rows in the
-    handoff handle, then returns the sparse layout metadata.
+    handoff handle using the original in-vocab placeholder token, then returns
+    the sparse layout metadata.
 
     Agg gets this expansion from Qwen's HF processor taking raw images/videos
     as inputs. Reusing that would be wasteful here, hence this helper that
@@ -128,7 +128,7 @@ def _expand_prompt_token_ids_for_mm_handoff(
         run_start = write_pos - 1 if has_leading_special else write_pos
         prompt_mm_length = mm_token_num + int(has_leading_special)
 
-        expanded_ids[write_pos : write_pos + mm_token_num] = placeholder_id
+        expanded_ids[write_pos : write_pos + mm_token_num] = token_id
         mm_token_offsets.append(run_start)
         mm_token_lengths.append(prompt_mm_length)
         multimodal_embedding_lengths.append(mm_token_num)
@@ -353,7 +353,6 @@ class Qwen3VLInputProcessorBase(Qwen2VLInputProcessorBase):
             image_token_id=self.config.image_token_id,
             video_token_id=self.config.video_token_id,
             vision_start_token_id=self.config.vision_start_token_id,
-            placeholder_id=self.tllm_multimodal_token_id,
         )
 
 
@@ -1150,7 +1149,23 @@ class Qwen3VLModelBase(PreTrainedModel):
                 persistent=False,
             )
 
+        # Surface the in-vocab image / video placeholder IDs to the model
+        # engine's ``_prepare_multimodal_indices`` so it selects the
+        # ``torch.isin`` predicate.
+        _mm_ids = [
+            tid
+            for tid in (
+                getattr(config, "image_token_id", None),
+                getattr(config, "video_token_id", None),
+            )
+            if tid is not None
+        ]
+        self._mm_token_ids = torch.tensor(_mm_ids, dtype=torch.int32)
         self.post_config()
+
+    @property
+    def mm_token_ids(self) -> torch.Tensor:
+        return self._mm_token_ids
 
     def post_config(self):
         # use llm.config as config for pytorch model engine
@@ -1293,6 +1308,7 @@ class Qwen3VLModelBase(PreTrainedModel):
             text_token_indices, mm_token_indices = filter_mm_token_from_input_ids(
                 input_ids,
                 vocab_size=self.llm.model.embed_tokens.num_embeddings,
+                mm_token_ids=self.mm_token_ids,
             )
 
         # Expand the per-level deepstack mm embeddings into the pre-allocated

--- a/tensorrt_llm/_torch/models/modeling_vila.py
+++ b/tensorrt_llm/_torch/models/modeling_vila.py
@@ -1266,7 +1266,8 @@ class VilaModel(PreTrainedModel):
             self.llm.model.embed_tokens,
             input_ids,
             mm_embeds,
-            **kwargs,
+            mm_token_indices=kwargs.get("mm_token_indices"),
+            text_token_indices=kwargs.get("text_token_indices"),
         )
         logits = self.llm.forward(attn_metadata=attn_metadata,
                                   input_ids=input_ids,

--- a/tensorrt_llm/_torch/models/modeling_vila.py
+++ b/tensorrt_llm/_torch/models/modeling_vila.py
@@ -69,13 +69,16 @@ def _validate_vila_mm_alignment(
     input_ids: torch.IntTensor,
     embedding_layer: Embedding,
     mm_embeds: List[torch.Tensor],
+    mm_token_ids: Optional[torch.IntTensor] = None,
 ) -> Tuple[torch.IntTensor, torch.IntTensor]:
-    # VILA expands multimodal placeholders into out-of-vocab ids during
-    # preprocessing, so counting OOV ids here gives the active multimodal span
-    # for the current chunk. Reuse the indices for fusion to avoid an extra sync.
+    # VILA expands multimodal placeholders into the in-vocab media token id
+    # during preprocessing, so counting positions that match ``mm_token_ids``
+    # (via ``torch.isin``) gives the active multimodal span for the current
+    # chunk. Reuse the indices for fusion to avoid an extra sync.
     text_token_indices, mm_token_indices = filter_mm_token_from_input_ids(
         input_ids=input_ids,
         vocab_size=embedding_layer.num_embeddings,
+        mm_token_ids=mm_token_ids,
     )
     expected_tokens = mm_token_indices.shape[0]
     actual_embeds = sum(embed.shape[0] for embed in mm_embeds)
@@ -1281,6 +1284,7 @@ class VilaModel(PreTrainedModel):
                     input_ids=input_ids,
                     embedding_layer=self.llm.model.embed_tokens,
                     mm_embeds=mm_embeds,
+                    mm_token_ids=self.mm_token_ids,
                 )
 
         if text_token_indices is not None and mm_token_indices is not None:

--- a/tensorrt_llm/_torch/models/modeling_vila.py
+++ b/tensorrt_llm/_torch/models/modeling_vila.py
@@ -1046,7 +1046,7 @@ class VilaInputProcessor(BaseMultimodalInputProcessor,
         mm_tokens = torch.tensor([*self.tokenizer.media_token_ids.values()
                                   ]).to(input_ids.device)
         mm_token_positions = torch.where(torch.isin(input_ids, mm_tokens))[0]
-        num_medias = num_mm_tokens = len(mm_token_positions)
+        num_medias = num_mm_tokens = mm_token_positions.numel()
         if num_medias > 1 and isinstance(mm_features, torch.Tensor):
             mm_features = list(
                 mm_features.split(mm_features.shape[0] // num_medias))
@@ -1120,7 +1120,7 @@ class VilaInputProcessor(BaseMultimodalInputProcessor,
                     dim=1)
             mm_ids_splits[i] = mm_ids.flatten()
 
-        ## replace mm token ids with the expanded out-of-vocab ids
+        ## replace mm token ids with the expanded multimodal ids
         mm_split_idx = 0
         for i, split in enumerate(input_ids_splits):
             if torch.isin(split, mm_tokens).any().item():

--- a/tensorrt_llm/_torch/models/modeling_vila.py
+++ b/tensorrt_llm/_torch/models/modeling_vila.py
@@ -940,6 +940,16 @@ class VilaInputProcessor(BaseMultimodalInputProcessor,
     def dtype(self) -> torch.dtype:
         return self._dtype
 
+    def get_mm_token_ids(self) -> Optional[torch.Tensor]:
+        """Surface the in-vocab media token IDs so
+        ``maybe_compute_mm_embed_cumsum`` builds ``embed_mask_cumsum`` via
+        ``torch.isin(input_ids, mm_token_ids)`` instead of the OOV
+        ``>= vocab_size`` fallback (which would miss all positions now that
+        the OOV remap in _postprocess is gone).
+        """
+        media_ids = list(self.tokenizer.media_token_ids.values())
+        return torch.tensor(media_ids, dtype=torch.int32) if media_ids else None
+
     def model_path(self) -> str:
         return self._model_path
 
@@ -1069,15 +1079,19 @@ class VilaInputProcessor(BaseMultimodalInputProcessor,
         assert mm_hidden_dim == self.config.hidden_size, "Multimodal embedding_dim must match model hidden_size"
 
         ## split input_ids into segments by isolating mm tokens
-        vocab_size = len(self.tokenizer)  # vocab including special tokens
         mm_split_positions = torch.cat(
             [mm_token_positions, mm_token_positions + 1]).unique()
         input_ids_splits = list(input_ids.tensor_split(mm_split_positions.cpu(
         )))  # len(input_ids_splits) = num_segments after mm tokens are isolated
+        # Use the first in-vocab media token id repeated mm_total_length times
+        # instead of unique arange(vocab_size, vocab_size + L) OOV IDs — only
+        # the predicate that distinguishes mm vs text matters downstream
+        # (fuse_input_embeds uses ``torch.isin(input_ids, mm_token_ids)``).
         mm_ids_splits = list(
-            torch.arange(vocab_size,
-                         vocab_size + mm_total_length,
-                         device=input_ids.device).split(mm_lengths_per_split)
+            torch.full((mm_total_length, ),
+                       int(mm_tokens[0]),
+                       dtype=input_ids.dtype,
+                       device=input_ids.device).split(mm_lengths_per_split)
         )  # len(mm_ids_splits) = num_mm_segments
 
         # prepend & append start/end tokens around mm ids
@@ -1218,7 +1232,17 @@ class VilaModel(PreTrainedModel):
         device = kwargs.get("device", "cuda")
         self.llm.to(device=device, dtype=self.model_dtype)
 
+        # Surface the in-vocab media token IDs (image, video, ...) to the
+        # model engine's ``_prepare_multimodal_indices``. ``init_llm`` populates
+        # ``self.tokenizer.media_token_ids`` as ``{name: id}``.
+        media_ids = list(self.tokenizer.media_token_ids.values())
+        self._mm_token_ids = torch.tensor(media_ids, dtype=torch.int32)
+
         self.post_config()
+
+    @property
+    def mm_token_ids(self) -> torch.Tensor:
+        return self._mm_token_ids
 
     @torch.inference_mode()
     def forward(
@@ -1266,6 +1290,7 @@ class VilaModel(PreTrainedModel):
             self.llm.model.embed_tokens,
             input_ids,
             mm_embeds,
+            mm_token_ids=self.mm_token_ids,
             mm_token_indices=kwargs.get("mm_token_indices"),
             text_token_indices=kwargs.get("text_token_indices"),
         )

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2431,6 +2431,7 @@ class PyTorchModelEngine(ModelEngine):
         *,
         mm_token_indices_cpu: torch.Tensor,
         text_token_indices_cpu: torch.Tensor,
+        extra_mm_token_indices_cpu: Optional[torch.Tensor] = None,
         num_ctx_tokens: int,
         total_num_tokens: int,
     ) -> None:
@@ -2438,9 +2439,12 @@ class PyTorchModelEngine(ModelEngine):
         ``inputs`` so ``fuse_input_embeds`` can skip its ``torch.where`` host
         sync. If ``total_num_tokens > num_ctx_tokens`` (KV-cache path with
         extend/draft tokens appended after the indices were computed), the
-        post-context positions are by construction text and are appended to
-        ``text_token_indices_cpu`` via a CPU ``arange``/``cat`` (cheaper than
-        rebuilding via a bool mask + ``torch.where``)."""
+        post-context positions are appended as text except known multimodal
+        placeholders from first-draft prompt tails."""
+        if extra_mm_token_indices_cpu is not None and extra_mm_token_indices_cpu.numel(
+        ) > 0:
+            mm_token_indices_cpu = torch.cat(
+                [mm_token_indices_cpu, extra_mm_token_indices_cpu])
         mm_token_indices_cpu = maybe_pin_memory(mm_token_indices_cpu)
         inputs['mm_token_indices'] = mm_token_indices_cpu.to("cuda",
                                                              non_blocking=True)
@@ -2448,6 +2452,13 @@ class PyTorchModelEngine(ModelEngine):
             extra_text = torch.arange(num_ctx_tokens,
                                       total_num_tokens,
                                       dtype=text_token_indices_cpu.dtype)
+            if extra_mm_token_indices_cpu is not None and extra_mm_token_indices_cpu.numel(
+            ) > 0:
+                extra_text_mask = torch.ones(extra_text.numel(),
+                                             dtype=torch.bool)
+                extra_text_mask[extra_mm_token_indices_cpu -
+                                num_ctx_tokens] = False
+                extra_text = extra_text[extra_text_mask]
             text_token_indices_cpu = torch.cat(
                 [text_token_indices_cpu, extra_text])
         text_token_indices_cpu = maybe_pin_memory(text_token_indices_cpu)
@@ -3193,6 +3204,7 @@ class PyTorchModelEngine(ModelEngine):
         extend_dummy_requests = []
         generation_requests = []
         first_draft_requests = []
+        first_draft_mm_token_indices = []
         # Collect generation request IDs during categorization to avoid
         # a separate iteration over scheduled_requests.generation_requests later.
         all_gen_request_ids = []
@@ -3309,6 +3321,13 @@ class PyTorchModelEngine(ModelEngine):
                 all_prompt_tokens) - self.original_max_draft_len - 1
             end_compute = begin_compute + self.original_max_draft_len + 1
             prompt_tokens = all_prompt_tokens[begin_compute:end_compute]
+            first_draft_start_idx = len(position_ids)
+            if mm_token_indices is not None:
+                _, prompt_mm_token_indices = self._prepare_multimodal_indices(
+                    prompt_tokens)
+                if prompt_mm_token_indices.numel() > 0:
+                    first_draft_mm_token_indices.append(
+                        prompt_mm_token_indices + first_draft_start_idx)
             position_ids.extend(
                 range(begin_compute, begin_compute + len(prompt_tokens)))
 
@@ -3951,10 +3970,15 @@ class PyTorchModelEngine(ModelEngine):
                     [item[1] for item in all_rank_num_tokens])
 
         if mm_token_indices is not None:
+            if first_draft_mm_token_indices:
+                extra_mm_token_indices = torch.cat(first_draft_mm_token_indices)
+            else:
+                extra_mm_token_indices = None
             self._ship_multimodal_indices(
                 inputs,
                 mm_token_indices_cpu=mm_token_indices,
                 text_token_indices_cpu=text_token_indices_ctx,
+                extra_mm_token_indices_cpu=extra_mm_token_indices,
                 num_ctx_tokens=num_ctx_tokens,
                 total_num_tokens=total_num_tokens,
             )

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -3988,6 +3988,18 @@ class PyTorchModelEngine(ModelEngine):
         num_tokens = len(input_ids)
         assert num_tokens <= self.max_num_tokens, (
             "num_tokens should be less than or equal to max_num_tokens")
+        # Compute MM/text token indices on CPU input_ids so that
+        # fuse_input_embeds can skip its torch.where host sync. Must run before
+        # the input_ids list is rebound to a tensor below. Skipped in
+        # mm_encoder_only mode, where self.model is the vision encoder whose
+        # config has no vocab_size (and the encoder forward doesn't consume
+        # these indices anyway).
+        if (len(multimodal_params_list) > 0
+                and not getattr(self.llm_args, "mm_encoder_only", False)):
+            _, mm_token_indices_cpu = self._prepare_multimodal_indices(
+                input_ids)
+        else:
+            mm_token_indices_cpu = None
         input_ids = torch.tensor(input_ids,
                                  dtype=torch.int,
                                  pin_memory=prefer_pinned())
@@ -4056,6 +4068,17 @@ class PyTorchModelEngine(ModelEngine):
             "multimodal_params": multimodal_params_list,
             'resource_manager': resource_manager,
         }
+
+        if mm_token_indices_cpu is not None:
+            # Build the text complement on CPU and async H2D both to keep
+            # fuse_input_embeds off the torch.where host-sync fallback.
+            mask = torch.ones(num_tokens, dtype=torch.bool)
+            mask[mm_token_indices_cpu] = False
+            mm_idx = maybe_pin_memory(mm_token_indices_cpu)
+            inputs['mm_token_indices'] = mm_idx.to("cuda", non_blocking=True)
+            text_idx = maybe_pin_memory(torch.where(mask)[0])
+            inputs['text_token_indices'] = text_idx.to("cuda",
+                                                       non_blocking=True)
 
         if bool(lora_params):
             inputs['lora_params'] = lora_params

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2425,6 +2425,35 @@ class PyTorchModelEngine(ModelEngine):
             "skip_cross_kv_projection": skip_cross_kv_projection,
         }
 
+    def _ship_multimodal_indices(
+        self,
+        inputs: dict,
+        *,
+        mm_token_indices_cpu: torch.Tensor,
+        text_token_indices_cpu: torch.Tensor,
+        num_ctx_tokens: int,
+        total_num_tokens: int,
+    ) -> None:
+        """Pin and async-copy executor-precomputed MM/text token indices into
+        ``inputs`` so ``fuse_input_embeds`` can skip its ``torch.where`` host
+        sync. If ``total_num_tokens > num_ctx_tokens`` (KV-cache path with
+        extend/draft tokens appended after the indices were computed), the
+        post-context positions are by construction text and are appended to
+        ``text_token_indices_cpu`` via a CPU ``arange``/``cat`` (cheaper than
+        rebuilding via a bool mask + ``torch.where``)."""
+        mm_token_indices_cpu = maybe_pin_memory(mm_token_indices_cpu)
+        inputs['mm_token_indices'] = mm_token_indices_cpu.to("cuda",
+                                                             non_blocking=True)
+        if total_num_tokens > num_ctx_tokens:
+            extra_text = torch.arange(num_ctx_tokens,
+                                      total_num_tokens,
+                                      dtype=text_token_indices_cpu.dtype)
+            text_token_indices_cpu = torch.cat(
+                [text_token_indices_cpu, extra_text])
+        text_token_indices_cpu = maybe_pin_memory(text_token_indices_cpu)
+        inputs['text_token_indices'] = text_token_indices_cpu.to(
+            "cuda", non_blocking=True)
+
     def _can_use_incremental_update(
             self, scheduled_requests: ScheduledRequests,
             new_tokens_device: Optional[torch.Tensor],
@@ -3144,13 +3173,19 @@ class PyTorchModelEngine(ModelEngine):
 
             request.py_batch_idx = request.py_seq_slot
 
-        if len(multimodal_params_list) > 0:
-            # discard the text token indices as it only includes context tokens at this moment
-            _, mm_token_indices = self._prepare_multimodal_indices(input_ids)
-        else:
-            mm_token_indices = None
         num_ctx_requests = scheduled_requests.num_context_requests
         num_ctx_tokens = len(input_ids)
+        if len(multimodal_params_list) > 0:
+            # input_ids holds only context tokens here; extend/draft tokens are
+            # appended below and are by construction text, so we reuse the
+            # CPU-side text_token_indices and just extend it with the
+            # post-context arange instead of recomputing via a bool mask +
+            # torch.where over the full range.
+            text_token_indices_ctx, mm_token_indices = \
+                self._prepare_multimodal_indices(input_ids)
+        else:
+            text_token_indices_ctx = None
+            mm_token_indices = None
 
         # Requests with draft tokens are treated like extend requests. Dummy extend requests should be
         # at the end of extend_requests.
@@ -3916,13 +3951,13 @@ class PyTorchModelEngine(ModelEngine):
                     [item[1] for item in all_rank_num_tokens])
 
         if mm_token_indices is not None:
-            mask = torch.ones(total_num_tokens, dtype=torch.bool)
-            mask[mm_token_indices] = False
-            mm_idx = maybe_pin_memory(mm_token_indices)
-            inputs['mm_token_indices'] = mm_idx.to("cuda", non_blocking=True)
-            text_idx = maybe_pin_memory(torch.where(mask)[0])
-            inputs['text_token_indices'] = text_idx.to("cuda",
-                                                       non_blocking=True)
+            self._ship_multimodal_indices(
+                inputs,
+                mm_token_indices_cpu=mm_token_indices,
+                text_token_indices_cpu=text_token_indices_ctx,
+                num_ctx_tokens=num_ctx_tokens,
+                total_num_tokens=total_num_tokens,
+            )
 
         num_generation_tokens = len(generation_requests) + len(
             extend_requests) + sum(draft_lens) + len(first_draft_requests)
@@ -3990,15 +4025,18 @@ class PyTorchModelEngine(ModelEngine):
             "num_tokens should be less than or equal to max_num_tokens")
         # Compute MM/text token indices on CPU input_ids so that
         # fuse_input_embeds can skip its torch.where host sync. Must run before
-        # the input_ids list is rebound to a tensor below. Skipped in
-        # mm_encoder_only mode, where self.model is the vision encoder whose
-        # config has no vocab_size (and the encoder forward doesn't consume
-        # these indices anyway).
+        # the input_ids list is rebound to a tensor below. Skipped when
+        # ``self.model`` is a vision encoder (no ``config.vocab_size`` to filter
+        # against, and its forward doesn't consume the indices anyway); this
+        # is a structural check on the model rather than a flag lookup, so it
+        # naturally extends to any future "LLM-less" engine setup.
+        _model_config = getattr(self.model, "config", None)
         if (len(multimodal_params_list) > 0
-                and not getattr(self.llm_args, "mm_encoder_only", False)):
-            _, mm_token_indices_cpu = self._prepare_multimodal_indices(
-                input_ids)
+                and getattr(_model_config, "vocab_size", None) is not None):
+            text_token_indices_cpu, mm_token_indices_cpu = \
+                self._prepare_multimodal_indices(input_ids)
         else:
+            text_token_indices_cpu = None
             mm_token_indices_cpu = None
         input_ids = torch.tensor(input_ids,
                                  dtype=torch.int,
@@ -4070,15 +4108,15 @@ class PyTorchModelEngine(ModelEngine):
         }
 
         if mm_token_indices_cpu is not None:
-            # Build the text complement on CPU and async H2D both to keep
-            # fuse_input_embeds off the torch.where host-sync fallback.
-            mask = torch.ones(num_tokens, dtype=torch.bool)
-            mask[mm_token_indices_cpu] = False
-            mm_idx = maybe_pin_memory(mm_token_indices_cpu)
-            inputs['mm_token_indices'] = mm_idx.to("cuda", non_blocking=True)
-            text_idx = maybe_pin_memory(torch.where(mask)[0])
-            inputs['text_token_indices'] = text_idx.to("cuda",
-                                                       non_blocking=True)
+            # No extend/draft tokens in the no-cache path, so num_tokens covers
+            # the full range and the helper's arange/cat branch is skipped.
+            self._ship_multimodal_indices(
+                inputs,
+                mm_token_indices_cpu=mm_token_indices_cpu,
+                text_token_indices_cpu=text_token_indices_cpu,
+                num_ctx_tokens=num_tokens,
+                total_num_tokens=num_tokens,
+            )
 
         if bool(lora_params):
             inputs['lora_params'] = lora_params

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2431,7 +2431,6 @@ class PyTorchModelEngine(ModelEngine):
         *,
         mm_token_indices_cpu: torch.Tensor,
         text_token_indices_cpu: torch.Tensor,
-        extra_mm_token_indices_cpu: Optional[torch.Tensor] = None,
         num_ctx_tokens: int,
         total_num_tokens: int,
     ) -> None:
@@ -2439,12 +2438,8 @@ class PyTorchModelEngine(ModelEngine):
         ``inputs`` so ``fuse_input_embeds`` can skip its ``torch.where`` host
         sync. If ``total_num_tokens > num_ctx_tokens`` (KV-cache path with
         extend/draft tokens appended after the indices were computed), the
-        post-context positions are appended as text except known multimodal
-        placeholders from first-draft prompt tails."""
-        if extra_mm_token_indices_cpu is not None and extra_mm_token_indices_cpu.numel(
-        ) > 0:
-            mm_token_indices_cpu = torch.cat(
-                [mm_token_indices_cpu, extra_mm_token_indices_cpu])
+        post-context positions are appended as text. Current speculative decode
+        paths do not append multimodal placeholders after the context tokens."""
         mm_token_indices_cpu = maybe_pin_memory(mm_token_indices_cpu)
         inputs['mm_token_indices'] = mm_token_indices_cpu.to("cuda",
                                                              non_blocking=True)
@@ -2452,13 +2447,6 @@ class PyTorchModelEngine(ModelEngine):
             extra_text = torch.arange(num_ctx_tokens,
                                       total_num_tokens,
                                       dtype=text_token_indices_cpu.dtype)
-            if extra_mm_token_indices_cpu is not None and extra_mm_token_indices_cpu.numel(
-            ) > 0:
-                extra_text_mask = torch.ones(extra_text.numel(),
-                                             dtype=torch.bool)
-                extra_text_mask[extra_mm_token_indices_cpu -
-                                num_ctx_tokens] = False
-                extra_text = extra_text[extra_text_mask]
             text_token_indices_cpu = torch.cat(
                 [text_token_indices_cpu, extra_text])
         text_token_indices_cpu = maybe_pin_memory(text_token_indices_cpu)
@@ -3204,7 +3192,6 @@ class PyTorchModelEngine(ModelEngine):
         extend_dummy_requests = []
         generation_requests = []
         first_draft_requests = []
-        first_draft_mm_token_indices = []
         # Collect generation request IDs during categorization to avoid
         # a separate iteration over scheduled_requests.generation_requests later.
         all_gen_request_ids = []
@@ -3321,13 +3308,6 @@ class PyTorchModelEngine(ModelEngine):
                 all_prompt_tokens) - self.original_max_draft_len - 1
             end_compute = begin_compute + self.original_max_draft_len + 1
             prompt_tokens = all_prompt_tokens[begin_compute:end_compute]
-            first_draft_start_idx = len(position_ids)
-            if mm_token_indices is not None:
-                _, prompt_mm_token_indices = self._prepare_multimodal_indices(
-                    prompt_tokens)
-                if prompt_mm_token_indices.numel() > 0:
-                    first_draft_mm_token_indices.append(
-                        prompt_mm_token_indices + first_draft_start_idx)
             position_ids.extend(
                 range(begin_compute, begin_compute + len(prompt_tokens)))
 
@@ -3970,15 +3950,10 @@ class PyTorchModelEngine(ModelEngine):
                     [item[1] for item in all_rank_num_tokens])
 
         if mm_token_indices is not None:
-            if first_draft_mm_token_indices:
-                extra_mm_token_indices = torch.cat(first_draft_mm_token_indices)
-            else:
-                extra_mm_token_indices = None
             self._ship_multimodal_indices(
                 inputs,
                 mm_token_indices_cpu=mm_token_indices,
                 text_token_indices_cpu=text_token_indices_ctx,
-                extra_mm_token_indices_cpu=extra_mm_token_indices,
                 num_ctx_tokens=num_ctx_tokens,
                 total_num_tokens=total_num_tokens,
             )

--- a/tests/unittest/_torch/modeling/test_modeling_llava_next.py
+++ b/tests/unittest/_torch/modeling/test_modeling_llava_next.py
@@ -115,7 +115,7 @@ def test_llava_next_expand_prompt_token_ids_for_mm():
 
     image_token_id = LLAVA_NEXT_7B_CONFIG["image_token_index"]
     # In-vocab contract: placeholders stay as the real image_token_id (no legacy
-    # `vocab_size + 1` OOV remap); the model engine locates mm positions via
+    # ``vocab_size + 1`` OOV remap); the model engine locates mm positions via
     # torch.isin(input_ids, mm_token_ids).
     placeholder_id = image_token_id
 

--- a/tests/unittest/_torch/modeling/test_modeling_llava_next.py
+++ b/tests/unittest/_torch/modeling/test_modeling_llava_next.py
@@ -114,8 +114,10 @@ def test_llava_next_expand_prompt_token_ids_for_mm():
     input_processor = create_input_processor(model_path, tokenizer=tokenizer)
 
     image_token_id = LLAVA_NEXT_7B_CONFIG["image_token_index"]
-    vocab_size = LLAVA_NEXT_7B_CONFIG["vocab_size"]
-    placeholder_id = vocab_size + 1
+    # In-vocab contract: placeholders stay as the real image_token_id (no legacy
+    # `vocab_size + 1` OOV remap); the model engine locates mm positions via
+    # torch.isin(input_ids, mm_token_ids).
+    placeholder_id = image_token_id
 
     # prompt_token_ids: two image placeholders with text tokens in between
     prompt_token_ids = [1, 2, image_token_id, 3, image_token_id, 4]

--- a/tests/unittest/_torch/modeling/test_modeling_vila.py
+++ b/tests/unittest/_torch/modeling/test_modeling_vila.py
@@ -1,7 +1,9 @@
 import unittest
 from copy import deepcopy
+from types import SimpleNamespace
 from typing import Any
 
+import pytest
 import torch
 from parameterized import parameterized
 from utils.llm_data import llm_models_root
@@ -10,8 +12,8 @@ import tensorrt_llm
 from tensorrt_llm._torch.attention_backend.utils import get_attention_backend
 from tensorrt_llm._torch.metadata import KVCacheParams
 from tensorrt_llm._torch.model_config import ModelConfig
-from tensorrt_llm._torch.models.modeling_vila import (VilaConfig, VilaModel,
-                                                      fuse_input_embeds)
+from tensorrt_llm._torch.models.modeling_vila import (
+    VilaConfig, VilaModel, _validate_vila_mm_alignment, fuse_input_embeds)
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
 from tensorrt_llm.bindings.executor import KvCacheConfig
 from tensorrt_llm.mapping import Mapping
@@ -695,3 +697,41 @@ class TestVila(unittest.TestCase):
 
         position_ids = torch.cat(position_ids).unsqueeze(0)
         return model, input_ids, position_ids, past_seen_tokens, attn_metadata, kv_cache_manager
+
+
+def test_validate_vila_mm_alignment_locates_in_vocab_media_tokens():
+    """VILA expands media placeholders to the in-vocab media token id, so the
+    alignment check must locate them via ``mm_token_ids`` (torch.isin). With the
+    legacy OOV (``>= vocab_size``) predicate it would find zero positions and
+    raise a spurious count mismatch."""
+    vocab_size = 100
+    media_token_id = 42
+    # text, 3 in-vocab media tokens, text
+    input_ids = torch.tensor(
+        [1, media_token_id, media_token_id, media_token_id, 2], dtype=torch.int)
+    embedding_layer = SimpleNamespace(num_embeddings=vocab_size)
+    mm_embeds = [torch.zeros(3, 8)]
+    mm_token_ids = torch.tensor([media_token_id], dtype=torch.int32)
+
+    text_token_indices, mm_token_indices = _validate_vila_mm_alignment(
+        input_ids=input_ids,
+        embedding_layer=embedding_layer,
+        mm_embeds=mm_embeds,
+        mm_token_ids=mm_token_ids,
+    )
+
+    torch.testing.assert_close(mm_token_indices.cpu(), torch.tensor([1, 2, 3]))
+    torch.testing.assert_close(text_token_indices.cpu(), torch.tensor([0, 4]))
+
+
+def test_validate_vila_mm_alignment_raises_on_count_mismatch():
+    """A genuine token/embed count mismatch must still raise."""
+    input_ids = torch.tensor([1, 42, 42, 2], dtype=torch.int)
+    embedding_layer = SimpleNamespace(num_embeddings=100)
+    with pytest.raises(ValueError, match="Multimodal token count mismatch"):
+        _validate_vila_mm_alignment(
+            input_ids=input_ids,
+            embedding_layer=embedding_layer,
+            mm_embeds=[torch.zeros(5, 8)],  # 5 embeds != 2 media tokens
+            mm_token_ids=torch.tensor([42], dtype=torch.int32),
+        )

--- a/tests/unittest/_torch/multimodal/test_external_embedding.py
+++ b/tests/unittest/_torch/multimodal/test_external_embedding.py
@@ -272,7 +272,9 @@ def test_qwen_vl_attach_multimodal_embeddings_builds_mrope_config(
         SamplingParams(),
     )
 
-    placeholder_id = processor.tllm_multimodal_token_id
+    # In-vocab contract: placeholders stay as the real image_token_id (no
+    # legacy OOV remap); the model engine locates mm positions via torch.isin.
+    placeholder_id = config.image_token_id
     assert prompt_token_ids == [
         7,
         config.vision_start_token_id,

--- a/tests/unittest/_torch/multimodal/test_fuse_input_embeds.py
+++ b/tests/unittest/_torch/multimodal/test_fuse_input_embeds.py
@@ -316,10 +316,11 @@ def test_fuse_input_embeds_calls_filter_when_indices_missing(device):
 
 @pytest.mark.parametrize("device", ["cpu"] +
                          (["cuda"] if torch.cuda.is_available() else []))
-def test_fuse_input_embeds_kwargs_precedence_over_sentinel_and_ids(device):
+def test_fuse_input_embeds_in_vocab_fast_path_matches_oov(device):
     """
-    Ensure that when kwargs provide precomputed indices, they take precedence
-    over both OOV-sentinel filtering and explicit mm_token_ids.
+    In-vocab fast path: when ``mm_token_ids`` is provided, fuse_input_embeds
+    embeds the full ``input_ids`` and overwrites mm rows. The result must
+    match the OOV-style gather+scatter path bit-for-bit on an in-vocab input.
     """
     hidden = 8
     vocab_size = 40
@@ -327,34 +328,81 @@ def test_fuse_input_embeds_kwargs_precedence_over_sentinel_and_ids(device):
                          hidden_size=hidden,
                          device=device)
 
-    # Use vocab_size+1 as OOV sentinel
-    oov_sentinel = vocab_size + 1
-    input_ids = torch.tensor([0, oov_sentinel, 1, oov_sentinel, 2],
+    mm_placeholder = 17
+    input_ids = torch.tensor([0, mm_placeholder, 1, mm_placeholder, 2],
+                             dtype=torch.long,
+                             device=device)
+    text_idx = torch.tensor([0, 2, 4], dtype=torch.long, device=device)
+    mm_idx = torch.tensor([1, 3], dtype=torch.long, device=device)
+    mm_emb = torch.randn(mm_idx.shape[0], hidden, device=device)
+    mm_token_ids = torch.tensor([mm_placeholder],
+                                dtype=torch.long,
+                                device=device)
+
+    # OOV-style path (mm_token_ids=None): gather text positions + scatter
+    _, out_embeds_oov = fuse_input_embeds(
+        emb,
+        input_ids,
+        mm_embeds=[mm_emb],
+        mm_token_ids=None,
+        text_token_indices=text_idx,
+        mm_token_indices=mm_idx,
+    )
+
+    # In-vocab fast path (mm_token_ids set): full embed + scatter mm
+    _, out_embeds_fast = fuse_input_embeds(
+        emb,
+        input_ids,
+        mm_embeds=[mm_emb],
+        mm_token_ids=mm_token_ids,
+        text_token_indices=text_idx,
+        mm_token_indices=mm_idx,
+    )
+
+    torch.testing.assert_close(out_embeds_fast, out_embeds_oov)
+
+
+@pytest.mark.parametrize("device", ["cpu"] +
+                         (["cuda"] if torch.cuda.is_available() else []))
+def test_fuse_input_embeds_kwargs_precedence_over_mm_token_ids(device):
+    """
+    When precomputed indices are provided, they take precedence over
+    ``mm_token_ids`` for filtering. Callers that pass ``mm_token_ids`` are
+    declaring mm tokens are in-vocab (the in-vocab fast path), so we exercise
+    this here with in-vocab placeholders rather than the (unsupported) OOV
+    sentinel + ``mm_token_ids`` combination.
+    """
+    hidden = 8
+    vocab_size = 40
+    emb = make_embedding(num_embeddings=vocab_size,
+                         hidden_size=hidden,
+                         device=device)
+
+    # In-vocab mm placeholder ID
+    mm_placeholder = 17
+    input_ids = torch.tensor([0, mm_placeholder, 1, mm_placeholder, 2],
                              dtype=torch.long,
                              device=device)
 
-    # Precompute correct indices (kwargs path)
-    text_idx, mm_idx = filter_mm_token_from_input_ids(input_ids,
-                                                      vocab_size=vocab_size,
-                                                      mm_token_ids=None)
+    # Hand-pick the correct precomputed indices
+    text_idx = torch.tensor([0, 2, 4], dtype=torch.long, device=device)
+    mm_idx = torch.tensor([1, 3], dtype=torch.long, device=device)
     mm_emb = torch.randn(mm_idx.shape[0], hidden, device=device)
 
     # Provide a deliberately incorrect mm_token_ids to ensure it is ignored
-    bad_mm_token_ids = torch.tensor(
-        [0], dtype=torch.long,
-        device=device)  # would misclassify index 0 as mm if used
+    # for filtering. It also signals "in-vocab safe" so the fast path is taken.
+    bad_mm_token_ids = torch.tensor([0], dtype=torch.long, device=device)
 
     out_ids, out_embeds = fuse_input_embeds(
         emb,
         input_ids,
         mm_embeds=[mm_emb],
-        mm_token_ids=
-        bad_mm_token_ids,  # should be ignored because indices are provided
+        mm_token_ids=bad_mm_token_ids,
         text_token_indices=text_idx,
         mm_token_indices=mm_idx,
     )
 
-    # Validate outputs
+    # Validate outputs: precomputed indices must win over bad_mm_token_ids
     assert out_ids is None
     assert out_embeds is not None
     assert out_embeds.shape == (input_ids.numel(), hidden)

--- a/tests/unittest/_torch/multimodal/test_fuse_input_embeds.py
+++ b/tests/unittest/_torch/multimodal/test_fuse_input_embeds.py
@@ -1,6 +1,9 @@
+from unittest import mock
+
 import pytest
 import torch
 
+import tensorrt_llm._torch.models.modeling_multimodal_utils as multimodal_utils
 from tensorrt_llm._torch.models.modeling_multimodal_utils import (
     filter_mm_token_from_input_ids, find_input_mm_embeds, fuse_input_embeds)
 from tensorrt_llm._torch.modules.embedding import Embedding
@@ -238,6 +241,77 @@ def test_fuse_input_embeds_empty_multimodal_params_falls_through(device):
     assert out_ids is None
     assert out_embeds is not None
     assert out_embeds.shape == (input_ids.numel(), hidden)
+
+
+@pytest.mark.parametrize("device", ["cpu"] +
+                         (["cuda"] if torch.cuda.is_available() else []))
+def test_fuse_input_embeds_skips_filter_when_indices_provided(device):
+    """
+    Sync-free contract: when both ``text_token_indices`` and
+    ``mm_token_indices`` are passed in, ``fuse_input_embeds`` must NOT call
+    ``filter_mm_token_from_input_ids`` (which is the source of the torch.where
+    host sync on GPU input_ids).
+    """
+    hidden = 8
+    vocab_size = 40
+    emb = make_embedding(num_embeddings=vocab_size,
+                         hidden_size=hidden,
+                         device=device)
+
+    input_ids = torch.tensor([0, 1, 41, 2, 42, 3, 43, 4],
+                             dtype=torch.long,
+                             device=device)
+    text_idx, mm_idx = filter_mm_token_from_input_ids(input_ids,
+                                                      vocab_size=vocab_size)
+    mm_emb = torch.randn(mm_idx.shape[0], hidden, device=device)
+
+    with mock.patch.object(
+            multimodal_utils,
+            "filter_mm_token_from_input_ids",
+            wraps=multimodal_utils.filter_mm_token_from_input_ids) as spy:
+        fuse_input_embeds(
+            emb,
+            input_ids,
+            mm_embeds=[mm_emb],
+            mm_token_ids=None,
+            text_token_indices=text_idx,
+            mm_token_indices=mm_idx,
+        )
+    spy.assert_not_called()
+
+
+@pytest.mark.parametrize("device", ["cpu"] +
+                         (["cuda"] if torch.cuda.is_available() else []))
+def test_fuse_input_embeds_calls_filter_when_indices_missing(device):
+    """
+    Negative half of the sync-free contract: when indices are absent the
+    function falls back to ``filter_mm_token_from_input_ids`` (the host-sync
+    path). Pairs with the test above so a regression that silently drops the
+    sync-free fast path is caught.
+    """
+    hidden = 8
+    vocab_size = 40
+    emb = make_embedding(num_embeddings=vocab_size,
+                         hidden_size=hidden,
+                         device=device)
+
+    input_ids = torch.tensor([0, 1, 41, 2, 42, 3, 43, 4],
+                             dtype=torch.long,
+                             device=device)
+    _, mm_idx = filter_mm_token_from_input_ids(input_ids, vocab_size=vocab_size)
+    mm_emb = torch.randn(mm_idx.shape[0], hidden, device=device)
+
+    with mock.patch.object(
+            multimodal_utils,
+            "filter_mm_token_from_input_ids",
+            wraps=multimodal_utils.filter_mm_token_from_input_ids) as spy:
+        fuse_input_embeds(
+            emb,
+            input_ids,
+            mm_embeds=[mm_emb],
+            mm_token_ids=None,
+        )
+    spy.assert_called_once()
 
 
 @pytest.mark.parametrize("device", ["cpu"] +

--- a/tests/unittest/_torch/multimodal/test_qwen3vl_disagg_prompt.py
+++ b/tests/unittest/_torch/multimodal/test_qwen3vl_disagg_prompt.py
@@ -15,7 +15,6 @@ _VISION_START_TOKEN_ID = 151652
 _VISION_END_TOKEN_ID = 151653
 _IMAGE_TOKEN_ID = 151655
 _VIDEO_TOKEN_ID = 151656
-_PLACEHOLDER_ID = 200000
 
 
 class _FakeTokenizer:
@@ -41,19 +40,20 @@ def test_qwen3vl_disagg_video_prompt_expands_video_placeholder():
     processor._tokenizer = _FakeTokenizer(
         [11, _VISION_START_TOKEN_ID, _VIDEO_TOKEN_ID, _VISION_END_TOKEN_ID, 12]
     )
-    processor.tllm_multimodal_token_id = _PLACEHOLDER_ID
 
     handoff = processor.build_disagg_prefill_multimodal_inputs(
         {"prompt": "video prompt"},
         [{"tensor_size": (3, 16)}],
     )
 
+    # In-vocab contract: the video placeholder expands to the real
+    # _VIDEO_TOKEN_ID (no legacy OOV remap).
     assert handoff.prompt_token_ids == [
         11,
         _VISION_START_TOKEN_ID,
-        _PLACEHOLDER_ID,
-        _PLACEHOLDER_ID,
-        _PLACEHOLDER_ID,
+        _VIDEO_TOKEN_ID,
+        _VIDEO_TOKEN_ID,
+        _VIDEO_TOKEN_ID,
         _VISION_END_TOKEN_ID,
         12,
     ]
@@ -89,19 +89,19 @@ def test_qwen3vl_disagg_mixed_prompt_layout_preserves_item_order():
         image_token_id=_IMAGE_TOKEN_ID,
         video_token_id=_VIDEO_TOKEN_ID,
         vision_start_token_id=_VISION_START_TOKEN_ID,
-        placeholder_id=_PLACEHOLDER_ID,
     )
 
+    # In-vocab contract: placeholders expand to the real image / video token ids.
     assert handoff.prompt_token_ids == [
         _VISION_START_TOKEN_ID,
-        _PLACEHOLDER_ID,
-        _PLACEHOLDER_ID,
+        _IMAGE_TOKEN_ID,
+        _IMAGE_TOKEN_ID,
         _VISION_END_TOKEN_ID,
         42,
         _VISION_START_TOKEN_ID,
-        _PLACEHOLDER_ID,
-        _PLACEHOLDER_ID,
-        _PLACEHOLDER_ID,
+        _VIDEO_TOKEN_ID,
+        _VIDEO_TOKEN_ID,
+        _VIDEO_TOKEN_ID,
         _VISION_END_TOKEN_ID,
     ]
     assert handoff.multimodal_lengths == [3, 4]
@@ -123,7 +123,6 @@ def test_qwen3vl_disagg_prompt_layout_requires_handle_per_placeholder():
             image_token_id=2,
             video_token_id=4,
             vision_start_token_id=1,
-            placeholder_id=99,
         )
 
 


### PR DESCRIPTION
@coderabbitai summary

  ## Description

  VLM `fuse_input_embeds` falls back to `filter_mm_token_from_input_ids` when the MM/text token indices are missing. On GPU `input_ids` that filter's `torch.where` forces a **host-device synchronization on every VLM forward step**. This PR removes that sync and the legacy out-of-vocab (OOV) placeholder workaround that made it necessary.

  **What changed**

  1. **Sync-free index plumbing (`model_engine`)**
     - `_prepare_multimodal_indices` computes `text_token_indices` / `mm_token_indices`
       on a **CPU** `input_ids` copy.
     - New `_ship_multimodal_indices` helper (shared by `_prepare_tp_inputs` and
       `_prepare_tp_inputs_no_cache`) pins and async-H2D-copies them into the inputs
       dict. The KV-cache path reuses the CPU `text_token_indices` and extends it with
       an `arange` for the post-context range instead of allocating `torch.ones(N, bool)`
       + rebuilding via `torch.where`.
     - The `mm_encoder_only` flag guard is replaced with a structural
       `hasattr(model.config, 'vocab_size')` check.

  2. **In-vocab `mm_token_ids` contract (drop OOV remap)**
     - Removes the `token_ids[mask] = vocab_size + 1` remap in **Llama4, LLaVA-Next,
       Qwen2-VL, Qwen2.5-VL, Qwen3-VL, VILA** input processors.
     - Each model exposes `mm_token_ids` so the executor's `_prepare_multimodal_indices`
       and `maybe_compute_mm_embed_cumsum` locate MM positions via
       `torch.isin(input_ids, mm_token_ids)` instead of the OOV `>= vocab_size` predicate.
     - **Kimi K25 / Gemma4-MM** cache the tensor (`_mm_token_ids`) behind an `@property`
       to avoid per-step `torch.tensor` / `torch.cat` allocations.

  3. **`fuse_input_embeds` fast path** — when `mm_token_ids` is provided (in-vocab
     caller), embed the full `input_ids` once and overwrite the MM rows instead of the
     gather + `torch.empty` + text-scatter path.

  4. VLM forwards now extract the indices from `kwargs` and pass them **explicitly** to
     `fuse_input_embeds` rather than relying on a `**kwargs` splat.

  **Not converted:** Hyperclovax stays on the OOV path (no in-vocab content placeholder
  in its config); the OOV branch in `filter_mm_token_from_input_ids` /
  `fuse_input_embeds` is retained as the Hyperclovax-only fallback.

  ### Performance — per VLM forward step

  The change trades a small **CPU** predicate cost for the removal of GPU work and, more
  importantly, a host-device sync on the critical path:

  | Path | Before | After |
  |------|--------|-------|
  | MM/text index compute | GPU `torch.where` on `input_ids` → **host sync** | CPU predicate + async H2D (no sync) |
  | KV-cache text complement | `torch.ones(N, bool)` + `torch.where` | reuse CPU indices + `arange`/`cat` |
  | `fuse_input_embeds` | gather + `torch.empty` alloc + text-scatter | single embed + MM-row overwrite |

  Net per VLM forward step: **−1 host-device sync, −2 GPU kernels, −1 device alloc**, at
  the cost of a CPU `torch.isin` predicate over `input_ids` whose result is shipped async.