### PR TITLE
[None][fix] cold-start warmup for KV-aware ADP router (feat/deepseek_v4)

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -23,7 +23,7 @@ import random
 from abc import ABC, abstractmethod
 from collections import namedtuple
 from dataclasses import astuple, dataclass
-from typing import TYPE_CHECKING, Dict, List, Tuple
+from typing import TYPE_CHECKING, Dict, List, Set, Tuple
 
 from tensorrt_llm.logger import logger
 
@@ -372,6 +372,9 @@ class KVCacheAwareADPRouter(ADPRouter):
         self.match_rate_threshold = match_rate_threshold
         self.fair_share_multiplier = fair_share_multiplier
         self._all_ranks_prefix_matches: List[Dict[int, int]] = []
+        # Cold-start warmup: ranks not yet targeted through this router.
+        # See ``route_requests``.
+        self._pending_warmup_ranks: Set[int] = set(range(self.dist.tp_size))
         # Requests still sending KV to GEN are invisible in active_requests;
         # fold them back in via the transfer manager (see create_rank_state).
         self.async_transfer_manager = async_transfer_manager
@@ -502,25 +505,37 @@ class KVCacheAwareADPRouter(ADPRouter):
 
         sorted_requests = sorted(new_requests, key=get_relax_value)
 
+        # Strict ``attention_dp_rank`` is honoured first; relaxed requests
+        # fall back to the smallest unwarmed rank until every rank has been
+        # targeted, seeding the shared system prompt before scoring would
+        # otherwise pin all traffic to the first warm rank.
         remaining_unscheduled = []
         for req_item in sorted_requests:
             scheduled = False
+            target_dp_rank = None
             scheduling_params = getattr(req_item.request, "py_scheduling_params", None)
             if scheduling_params is not None:
                 target_dp_rank = scheduling_params.attention_dp_rank
-                if (
-                    target_dp_rank is not None
-                    and all_ranks_num_active_requests[target_dp_rank] < max_num_active_requests
-                ):
-                    all_ranks_num_active_requests[target_dp_rank] += 1
-                    # Keep token tally in sync with the soft-balancing phase.
-                    effective = max(
-                        self._req_tokens(req_item) - self._match_len(target_dp_rank, req_item.id),
-                        0,
-                    )
-                    all_ranks_num_active_tokens[target_dp_rank] += effective
-                    scheduled = True
-                    all_ranks_new_requests[target_dp_rank].append(req_item)
+            if target_dp_rank is None and self._pending_warmup_ranks:
+                # Smallest-first: deterministic across DP ranks.
+                target_dp_rank = min(self._pending_warmup_ranks)
+            if (
+                target_dp_rank is not None
+                and all_ranks_num_active_requests[target_dp_rank] < max_num_active_requests
+            ):
+                all_ranks_num_active_requests[target_dp_rank] += 1
+                # Keep token tally in sync with the soft-balancing phase.
+                effective = max(
+                    self._req_tokens(req_item) - self._match_len(target_dp_rank, req_item.id),
+                    0,
+                )
+                all_ranks_num_active_tokens[target_dp_rank] += effective
+                scheduled = True
+                all_ranks_new_requests[target_dp_rank].append(req_item)
+            # Any targeted rank counts as warmed; cap-saturation also
+            # discards to avoid the synthesiser looping on a busy rank.
+            if target_dp_rank is not None:
+                self._pending_warmup_ranks.discard(target_dp_rank)
 
             if not scheduled:
                 remaining_unscheduled.append(req_item)

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -116,6 +116,7 @@ class ADPRouter(ABC):
                 load_balance_weight=attention_dp_config.kv_cache_routing_load_balance_weight,
                 match_rate_threshold=attention_dp_config.kv_cache_routing_match_rate_threshold,
                 fair_share_multiplier=attention_dp_config.kv_cache_routing_fair_share_multiplier,
+                cold_start_warmup=attention_dp_config.kv_cache_routing_cold_start_warmup,
                 async_transfer_manager=async_transfer_manager,
             )
 
@@ -364,6 +365,7 @@ class KVCacheAwareADPRouter(ADPRouter):
         load_balance_weight: float = 1.0,
         match_rate_threshold: float = 0.1,
         fair_share_multiplier: float = 2.0,
+        cold_start_warmup: bool = False,
         async_transfer_manager=None,
     ):
         super().__init__(dist)
@@ -373,8 +375,10 @@ class KVCacheAwareADPRouter(ADPRouter):
         self.fair_share_multiplier = fair_share_multiplier
         self._all_ranks_prefix_matches: List[Dict[int, int]] = []
         # Cold-start warmup: ranks not yet targeted through this router.
-        # See ``route_requests``.
-        self._pending_warmup_ranks: Set[int] = set(range(self.dist.tp_size))
+        # Empty set disables warmup; see ``route_requests``.
+        self._pending_warmup_ranks: Set[int] = (
+            set(range(self.dist.tp_size)) if cold_start_warmup else set()
+        )
         # Requests still sending KV to GEN are invisible in active_requests;
         # fold them back in via the transfer manager (see create_rank_state).
         self.async_transfer_manager = async_transfer_manager

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -377,7 +377,7 @@ class KVCacheAwareADPRouter(ADPRouter):
         # Cold-start warmup: ranks not yet targeted through this router.
         # Empty set disables warmup; see ``route_requests``.
         self._pending_warmup_ranks: Set[int] = (
-            set(range(self.dist.tp_size)) if cold_start_warmup else set()
+            set(range(self.dist.mapping.dp_size)) if cold_start_warmup else set()
         )
         # Requests still sending KV to GEN are invisible in active_requests;
         # fold them back in via the transfer manager (see create_rank_state).
@@ -536,9 +536,8 @@ class KVCacheAwareADPRouter(ADPRouter):
                 all_ranks_num_active_tokens[target_dp_rank] += effective
                 scheduled = True
                 all_ranks_new_requests[target_dp_rank].append(req_item)
-            # Any targeted rank counts as warmed; cap-saturation also
-            # discards to avoid the synthesiser looping on a busy rank.
-            if target_dp_rank is not None:
+                # Only mark a rank as warmed once a request actually landed
+                # there; saturated picks stay pending for a later call.
                 self._pending_warmup_ranks.discard(target_dp_rank)
 
             if not scheduled:

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -725,6 +725,18 @@ class AttentionDpConfig(StrictBaseModel):
         "cache affinity can dominate while preventing runaway concentration "
         "on a single rank. Set to 1.0 for strict fair share. "
         "Only used when enable_kv_cache_aware_routing is True.")
+    kv_cache_routing_cold_start_warmup: bool = Field(
+        default=False,
+        description=
+        "Cold-start mitigation in KV cache-aware routing. When True, the "
+        "first tp_size relaxed requests after router init are round-robined "
+        "across ranks (bypassing cache-affinity scoring) so every rank "
+        "caches the shared system prompt before scoring would otherwise pin "
+        "all traffic to the first warm rank. Only useful when requests "
+        "share a long system prefix; for diverse-prompt workloads this can "
+        "scatter requests that would otherwise consolidate on a single warm "
+        "rank, wasting prefill. Default False preserves pre-warmup routing. "
+        "Only used when enable_kv_cache_aware_routing is True.")
 
     @model_validator(mode='after')
     def validate_attention_dp_config(self) -> 'AttentionDpConfig':

--- a/tests/unittest/_torch/executor/test_adp_router.py
+++ b/tests/unittest/_torch/executor/test_adp_router.py
@@ -855,6 +855,8 @@ class TestKVCacheAwareADPRouterRouting:
                 {0: 0, 1: 50},
             ]
         router._all_ranks_prefix_matches = prefix_matches
+        # Tests in this class exercise pure scoring; opt out of warmup.
+        router._pending_warmup_ranks = set()
         return router
 
     def _rank_states(self, tp_size, active_reqs=None, active_tokens=None):

--- a/tests/unittest/_torch/executor/test_adp_router.py
+++ b/tests/unittest/_torch/executor/test_adp_router.py
@@ -855,8 +855,6 @@ class TestKVCacheAwareADPRouterRouting:
                 {0: 0, 1: 50},
             ]
         router._all_ranks_prefix_matches = prefix_matches
-        # Tests in this class exercise pure scoring; opt out of warmup.
-        router._pending_warmup_ranks = set()
         return router
 
     def _rank_states(self, tp_size, active_reqs=None, active_tokens=None):

--- a/tests/unittest/_torch/executor/test_kvcache_aware_router.py
+++ b/tests/unittest/_torch/executor/test_kvcache_aware_router.py
@@ -206,6 +206,7 @@ class TestKVCacheAwareADPRouter:
         dist = _mock_dist(tp_rank=0, tp_size=2)
         mgr = _mock_kv_cache_manager()
         router = KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr)
+        router._pending_warmup_ranks = set()  # isolate scoring from warmup
 
         router._all_ranks_prefix_matches = [{1: 0}, {1: 0}]
 
@@ -224,6 +225,7 @@ class TestKVCacheAwareADPRouter:
         dist = _mock_dist(tp_rank=0, tp_size=2)
         mgr = _mock_kv_cache_manager()
         router = KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr, load_balance_weight=10.0)
+        router._pending_warmup_ranks = set()  # isolate scoring from warmup
 
         router._all_ranks_prefix_matches = [{1: 80}, {1: 0}]
 
@@ -274,6 +276,7 @@ class TestKVCacheAwareADPRouter:
         # cap-relaxation behavior covered separately in
         # test_fair_share_multiplier_caps_per_rank.
         router = KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr, fair_share_multiplier=1.0)
+        router._pending_warmup_ranks = set()  # isolate scoring from warmup
 
         # Requests 1,2 have cache on rank 0; requests 3,4 have no cache
         router._all_ranks_prefix_matches = [
@@ -387,6 +390,112 @@ class TestKVCacheAwareADPRouter:
         assert result[0][0].id == 1
         assert len(result[1]) == 1
         assert result[1][0].id == 2
+
+
+# ---- Cold-start warmup tests for KVCacheAwareADPRouter ----
+
+
+class TestKVCacheAwareADPRouterWarmup:
+    """Cold-start round-robin warmup behaviour."""
+
+    def _make_router(self, tp_size):
+        dist = _mock_dist(tp_rank=0, tp_size=tp_size)
+        mgr = _mock_kv_cache_manager()
+        return KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr)
+
+    def _no_match(self, tp_size, req_ids):
+        return [{rid: 0 for rid in req_ids} for _ in range(tp_size)]
+
+    def _zero_states(self, tp_size):
+        return [
+            RankState(rank=r, num_active_requests=0, num_active_tokens=0) for r in range(tp_size)
+        ]
+
+    def test_pending_initialised_in_ctor(self):
+        """__init__ should populate ``_pending_warmup_ranks`` from dist.tp_size."""
+        router = self._make_router(tp_size=4)
+        assert router._pending_warmup_ranks == {0, 1, 2, 3}
+
+    def test_first_batch_round_robins_across_ranks(self):
+        """First tp_size relaxed requests dispatch to ranks 0..tp_size-1."""
+        tp_size = 4
+        router = self._make_router(tp_size=tp_size)
+        router._all_ranks_prefix_matches = self._no_match(tp_size, range(tp_size))
+        reqs = [_make_request_item(i, num_tokens=10) for i in range(tp_size)]
+        result, _ = router.route_requests(
+            self._zero_states(tp_size), reqs, max_num_active_requests=100
+        )
+        # Each rank gets exactly one request, in id order (smallest-first).
+        for r in range(tp_size):
+            assert len(result[r]) == 1
+            assert result[r][0].id == r
+        assert router._pending_warmup_ranks == set()
+
+    def test_warmup_persists_across_single_request_batches(self):
+        """Low-traffic sequential arrivals still cover every rank."""
+        tp_size = 3
+        router = self._make_router(tp_size=tp_size)
+        for batch in range(tp_size):
+            router._all_ranks_prefix_matches = self._no_match(tp_size, [batch])
+            result, _ = router.route_requests(
+                self._zero_states(tp_size),
+                [_make_request_item(batch, num_tokens=10)],
+                max_num_active_requests=100,
+            )
+            assert len(result[batch]) == 1
+            assert result[batch][0].id == batch
+        assert router._pending_warmup_ranks == set()
+
+    def test_strict_request_consumes_warmup_slot(self):
+        """A strict ``target_dp_rank`` discards that rank from the pending set,
+        so a relaxed follow-up in the same batch skips it."""
+        tp_size = 4
+        router = self._make_router(tp_size=tp_size)
+        router._all_ranks_prefix_matches = self._no_match(tp_size, [0, 1])
+        strict = _make_request_item(
+            req_id=0, num_tokens=10, target_dp_rank=2, attention_dp_relax=False
+        )
+        relaxed = _make_request_item(req_id=1, num_tokens=10)
+        result, _ = router.route_requests(
+            self._zero_states(tp_size), [strict, relaxed], max_num_active_requests=100
+        )
+        # Strict lands on its requested rank.
+        assert [r.id for r in result[2]] == [0]
+        # Relaxed picks the smallest still-pending rank (0), NOT rank 2 again.
+        assert [r.id for r in result[0]] == [1]
+        assert router._pending_warmup_ranks == {1, 3}
+
+    def test_cap_saturation_discards_busy_rank(self):
+        """A cap-saturated synthesised target is still removed from pending
+        so the synthesiser doesn't loop on the same busy rank."""
+        tp_size = 2
+        router = self._make_router(tp_size=tp_size)
+        router._all_ranks_prefix_matches = self._no_match(tp_size, [0])
+        # Rank 0 already at the cap (max_num_active_requests=1).
+        states = [
+            RankState(rank=0, num_active_requests=1, num_active_tokens=10),
+            RankState(rank=1, num_active_requests=0, num_active_tokens=0),
+        ]
+        router.route_requests(
+            states, [_make_request_item(0, num_tokens=10)], max_num_active_requests=1
+        )
+        assert 0 not in router._pending_warmup_ranks
+
+    def test_empty_pending_disables_warmup(self):
+        """Once pending is empty, routing reverts to pure scoring."""
+        tp_size = 2
+        router = self._make_router(tp_size=tp_size)
+        router._pending_warmup_ranks = set()  # simulate fully warmed router
+        # Req 1 has a cache hit only on rank 1; scoring (not warmup) should
+        # send it there.
+        router._all_ranks_prefix_matches = [{1: 0}, {1: 80}]
+        result, _ = router.route_requests(
+            self._zero_states(tp_size),
+            [_make_request_item(1, num_tokens=100)],
+            max_num_active_requests=100,
+        )
+        assert result[0] == []
+        assert [r.id for r in result[1]] == [1]
 
 
 # ---- Tests for V1 KVCacheManager.probe_prefix_match_length ----

--- a/tests/unittest/_torch/executor/test_kvcache_aware_router.py
+++ b/tests/unittest/_torch/executor/test_kvcache_aware_router.py
@@ -33,6 +33,9 @@ def _mock_dist(tp_rank=0, tp_size=1, has_cp_helix=False):
     dist = MagicMock()
     dist.tp_rank = tp_rank
     dist.tp_size = tp_size
+    # ADP scheduling assumes ``enable_attention_dp=True``, so ``dp_size``
+    # mirrors ``tp_size`` (see ``Mapping.dp_size``).
+    dist.mapping.dp_size = tp_size
     dist.has_cp_helix = has_cp_helix
     return dist
 
@@ -409,7 +412,7 @@ class TestKVCacheAwareADPRouterWarmup:
         ]
 
     def test_pending_initialised_in_ctor(self):
-        """``cold_start_warmup=True`` should populate ``_pending_warmup_ranks`` from dist.tp_size."""
+        """``cold_start_warmup=True`` should populate ``_pending_warmup_ranks`` from dist.mapping.dp_size."""
         router = self._make_router(tp_size=4)
         assert router._pending_warmup_ranks == {0, 1, 2, 3}
 
@@ -469,9 +472,9 @@ class TestKVCacheAwareADPRouterWarmup:
         assert [r.id for r in result[0]] == [1]
         assert router._pending_warmup_ranks == {1, 3}
 
-    def test_cap_saturation_discards_busy_rank(self):
-        """A cap-saturated synthesised target is still removed from pending
-        so the synthesiser doesn't loop on the same busy rank."""
+    def test_cap_saturation_keeps_rank_pending(self):
+        """A saturated warmup pick stays in ``_pending_warmup_ranks`` so a
+        later routing call can still seed it once load drops."""
         tp_size = 2
         router = self._make_router(tp_size=tp_size)
         router._all_ranks_prefix_matches = self._no_match(tp_size, [0])
@@ -483,7 +486,7 @@ class TestKVCacheAwareADPRouterWarmup:
         router.route_requests(
             states, [_make_request_item(0, num_tokens=10)], max_num_active_requests=1
         )
-        assert 0 not in router._pending_warmup_ranks
+        assert 0 in router._pending_warmup_ranks
 
     def test_empty_pending_disables_warmup(self):
         """Once pending is empty, routing reverts to pure scoring."""

--- a/tests/unittest/_torch/executor/test_kvcache_aware_router.py
+++ b/tests/unittest/_torch/executor/test_kvcache_aware_router.py
@@ -398,9 +398,7 @@ class TestKVCacheAwareADPRouterWarmup:
     def _make_router(self, tp_size):
         dist = _mock_dist(tp_rank=0, tp_size=tp_size)
         mgr = _mock_kv_cache_manager()
-        return KVCacheAwareADPRouter(
-            dist=dist, kv_cache_manager=mgr, cold_start_warmup=True
-        )
+        return KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr, cold_start_warmup=True)
 
     def _no_match(self, tp_size, req_ids):
         return [{rid: 0 for rid in req_ids} for _ in range(tp_size)]

--- a/tests/unittest/_torch/executor/test_kvcache_aware_router.py
+++ b/tests/unittest/_torch/executor/test_kvcache_aware_router.py
@@ -206,7 +206,6 @@ class TestKVCacheAwareADPRouter:
         dist = _mock_dist(tp_rank=0, tp_size=2)
         mgr = _mock_kv_cache_manager()
         router = KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr)
-        router._pending_warmup_ranks = set()  # isolate scoring from warmup
 
         router._all_ranks_prefix_matches = [{1: 0}, {1: 0}]
 
@@ -225,7 +224,6 @@ class TestKVCacheAwareADPRouter:
         dist = _mock_dist(tp_rank=0, tp_size=2)
         mgr = _mock_kv_cache_manager()
         router = KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr, load_balance_weight=10.0)
-        router._pending_warmup_ranks = set()  # isolate scoring from warmup
 
         router._all_ranks_prefix_matches = [{1: 80}, {1: 0}]
 
@@ -276,7 +274,6 @@ class TestKVCacheAwareADPRouter:
         # cap-relaxation behavior covered separately in
         # test_fair_share_multiplier_caps_per_rank.
         router = KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr, fair_share_multiplier=1.0)
-        router._pending_warmup_ranks = set()  # isolate scoring from warmup
 
         # Requests 1,2 have cache on rank 0; requests 3,4 have no cache
         router._all_ranks_prefix_matches = [
@@ -401,7 +398,9 @@ class TestKVCacheAwareADPRouterWarmup:
     def _make_router(self, tp_size):
         dist = _mock_dist(tp_rank=0, tp_size=tp_size)
         mgr = _mock_kv_cache_manager()
-        return KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr)
+        return KVCacheAwareADPRouter(
+            dist=dist, kv_cache_manager=mgr, cold_start_warmup=True
+        )
 
     def _no_match(self, tp_size, req_ids):
         return [{rid: 0 for rid in req_ids} for _ in range(tp_size)]
@@ -412,9 +411,16 @@ class TestKVCacheAwareADPRouterWarmup:
         ]
 
     def test_pending_initialised_in_ctor(self):
-        """__init__ should populate ``_pending_warmup_ranks`` from dist.tp_size."""
+        """``cold_start_warmup=True`` should populate ``_pending_warmup_ranks`` from dist.tp_size."""
         router = self._make_router(tp_size=4)
         assert router._pending_warmup_ranks == {0, 1, 2, 3}
+
+    def test_disabled_by_default(self):
+        """Default ``cold_start_warmup=False`` leaves the pending set empty."""
+        dist = _mock_dist(tp_rank=0, tp_size=4)
+        mgr = _mock_kv_cache_manager()
+        router = KVCacheAwareADPRouter(dist=dist, kv_cache_manager=mgr)
+        assert router._pending_warmup_ranks == set()
 
     def test_first_batch_round_robins_across_ranks(self):
         """First tp_size relaxed requests dispatch to ranks 0..tp_size-1."""
@@ -485,7 +491,8 @@ class TestKVCacheAwareADPRouterWarmup:
         """Once pending is empty, routing reverts to pure scoring."""
         tp_size = 2
         router = self._make_router(tp_size=tp_size)
-        router._pending_warmup_ranks = set()  # simulate fully warmed router
+        # Drain the warmup set to simulate a fully warmed router.
+        router._pending_warmup_ranks = set()
         # Req 1 has a cache hit only on rank 1; scoring (not warmup) should
         # send it there.
         router._all_ranks_prefix_matches = [{1: 0}, {1: 80}]


### PR DESCRIPTION
## Summary

Port of #14307 onto `feat/deepseek_v4`. Cold-start mitigation for the KV-aware ADP router: round-robin the first relaxed requests across all ranks so every rank caches the (assumed shared) system prompt before cache-affinity scoring would otherwise pin all traffic to the first warm rank.

This started as a straight cherry-pick of the original commit (with a trivial `dataclasses` import-line conflict resolution, since `feat/deepseek_v4` hasn't picked up unrelated main-branch extras).

## Problem

With `match_rate_threshold=0.1` the cache-affinity gate stays ON for any system prompt longer than ~10% of a request. Once a single rank caches that prompt, the `(req_tokens - match_len)` term dominates the load term:

- Low-traffic sequential arrivals: each new request pins to the warm rank; other ranks never see the prompt.
- Eventual traffic spike: cold ranks pay the full prefill cost re-computing the same shared prompt.