### PR TITLE
[https://nvbugs/6182617][fix] Restore K2.5 multimodal dep8 accuracy test on transformers 5.5.x

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_kimi_k25.py
+++ b/tensorrt_llm/_torch/models/modeling_kimi_k25.py
@@ -1052,6 +1052,13 @@ class KimiK25InputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyInp
             config, "media_placeholder_token_id", _MEDIA_PLACEHOLDER_TOKEN_ID
         )
 
+        # transformers 5.5.x ``AutoTokenizer`` may route K2.5 to the Rust
+        # fast backend, which BPE-splits ``<|media_pad|>`` / ``<|im_user|>``
+        # / etc. instead of mapping them to their canonical IDs. Force the
+        # K2.5 slow ``TikTokenTokenizer`` for deterministic tokenization.
+        # See NVBug 6182617.
+        self._ensure_k25_slow_tokenizer()
+
     @property
     def config(self) -> PretrainedConfig:
         return self._config
@@ -1167,6 +1174,35 @@ class KimiK25InputProcessor(BaseMultimodalInputProcessor, BaseMultimodalDummyInp
                 # Fallback: same as image token count for the first frame
                 total_tokens += self.get_num_tokens_per_image(image=chunk[0])
         return total_tokens
+
+    def _ensure_k25_slow_tokenizer(self) -> None:
+        """Override ``self._tokenizer`` and ``self._processor.tokenizer``
+        with the model's slow ``TikTokenTokenizer``.
+
+        Done unconditionally because transformers 5.5.x's ``AutoTokenizer``
+        sometimes returns a Rust fast backend that BPE-splits K2.5 special
+        tokens instead of preserving their canonical IDs. The slow class'
+        ``tokens_trie`` always splits them correctly. See NVBug 6182617.
+        """
+        from transformers.dynamic_module_utils import get_class_from_dynamic_module
+
+        slow_cls = get_class_from_dynamic_module(
+            "tokenization_kimi.TikTokenTokenizer",
+            self._model_path,
+        )
+        slow_tok = slow_cls.from_pretrained(self._model_path, trust_remote_code=True)
+
+        logger.info(
+            "K2.5 InputProcessor forcing slow TikTokenTokenizer "
+            "(originally %s). See NVBug 6182617.",
+            type(self._tokenizer).__name__,
+        )
+
+        self._tokenizer = slow_tok
+        # Image-only path uses ``self._processor.tokenizer`` (an
+        # independent instance from ``AutoProcessor``); swap it too.
+        if getattr(self._processor, "tokenizer", None) is not None:
+            self._processor.tokenizer = slow_tok
 
     @torch.inference_mode()
     def __call__(

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch_multimodal.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch_multimodal.py
@@ -524,9 +524,13 @@ class TestKimiK25(LlmapiAccuracyTestHarness):
     )
     def test_nvfp4(self, ep_size, attention_dp):
         """NVFP4 accuracy on MMMU benchmark (8x B200)."""
+        # Do not pass ``max_num_tokens`` here: keep it at the LLM default
+        # (8192) so the resolved ``moe_max_num_tokens`` stays at
+        # ``8192 * dp_size`` and the per-call fused_moe workspace fits
+        # within activation headroom. Raising it pushed the workspace
+        # past the fragmented allocator budget on dep8 (NVBug 6182617).
         with LLM(
             self.MODEL_PATH,
-            max_num_tokens=self.MAX_NUM_TOKENS,
             kv_cache_config=self.kv_cache_config,
             tensor_parallel_size=8,
             pipeline_parallel_size=1,

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -154,7 +154,7 @@ l0_dgx_b200:
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_dsa_host_cache_offload[host_cache_offload_mtp3_no_adp] TIMEOUT (60)
   - accuracy/test_disaggregated_serving.py::TestDeepSeekV32Exp::test_auto_dtype[False] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[tp8] TIMEOUT (60)
-  - accuracy/test_llm_api_pytorch_multimodal.py::TestKimiK25::test_nvfp4[dep8] TIMEOUT (60)
+  - accuracy/test_llm_api_pytorch_multimodal.py::TestKimiK25::test_nvfp4[dep8] TIMEOUT (120)
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_8gpus_mtp TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_8gpus_mtp_custom_op TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_8gpus[attention_dp_on-trtllm] TIMEOUT (60)

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -144,7 +144,6 @@ accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_fp8[latency] SKIP (h
 accuracy/test_llm_api_pytorch.py::TestQwen3_235B_A22B::test_fp8[throughput_latency] SKIP (https://nvbugs/6177390)
 accuracy/test_llm_api_pytorch.py::TestQwen3_8B::test_fp8_block_scales_early_first_token_response SKIP (https://nvbugs/6200128)
 accuracy/test_llm_api_pytorch_multimodal.py::TestGemma3_27BInstruct::test_fp8_prequantized SKIP (https://nvbugs/6189416)
-accuracy/test_llm_api_pytorch_multimodal.py::TestKimiK25::test_nvfp4[dep8] SKIP (https://nvbugs/6182617)
 accuracy/test_llm_api_pytorch_multimodal.py::TestMistralLarge3_675B::test_nvfp4_4gpus[latency_moe_trtllm] SKIP (https://nvbugs/6181383)
 accuracy/test_llm_api_pytorch_multimodal.py::TestQwen3VL::test_auto_dtype[forced_chunked_prefill] SKIP (https://nvbugs/6143787)
 accuracy/test_llm_api_pytorch_multimodal.py::TestQwen3VL_MOE::test_auto_dtype SKIP (https://nvbugs/6114464)


### PR DESCRIPTION
## Summary

- **Tokenizer fix**: force the K2.5 slow `TikTokenTokenizer` in the multimodal `InputProcessor`. transformers 5.5.x's `AutoTokenizer` routing for K2.5 sometimes returns the Rust fast backend, which BPE-splits K2.5 special tokens (`<|media_pad|>`, `<|im_user|>`, ...) instead of preserving their canonical IDs. This previously made the multimodal hashing path fall back with `Number of mm_embeds (N) does not match expected total (0)`.
- **Drop `max_num_tokens=16384` override on K2.5 dep8 multimodal**: with `attention_dp=True` on dep8 the resolved `moe_max_num_tokens` was `max_num_tokens * dp_size = 131072`, pushing the per-call `torch.ops.trtllm.fused_moe` workspace to ~24 GiB. Combined with PyTorch caching-allocator fragmentation from mid-run attention workspace resizes, this caused intermittent CUDA OOM. Falling back to the LLM default `max_num_tokens=8192` brings the workspace to ~12 GiB and keeps it within activation headroom.
- **Bump dep8 timeout 60 → 120 min**: K2.5 NVFP4 dep8 takes ~68 min at the smaller `max_num_tokens` (twice the prefill steps per long prompt). Matches the precedent set by `TestKimiK25::test_nvfp4[tp8]` on `l0_gb200_multi_nodes` (180 min) for K2.5 NVFP4 workloads.
- **Unwaive `TestKimiK25::test_nvfp4[dep8]`**: both failure modes (tokenizer mismatch, fused_moe OOM) are addressed; re-enable the test in pre-merge CI.

Resolves NVBug 6182617.

## Test plan

- [x] `pytest tests/unittest/_torch/modeling/test_modeling_kimi_k25.py` — 24/24 PASS (previously 10 failures around `placeholder_count` and multimodal embeddings).
- [x] HW verification on 8x B200: `pytest tests/integration/defs/accuracy/test_llm_api_pytorch_multimodal.py::TestKimiK25::test_nvfp4 -k dep8` — **PASSED**, MMMU accuracy **81.44** (within sample noise of transformers 5.3 baseline 80.889), 0 OOM, total runtime ~68 min.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tokenization behavior for Kimi K2.5 models to ensure proper token-id mapping and compatibility with recent dependency updates.

* **Tests**
  * Updated test configuration timeout and removed test waiver for K2.5 multimodal accuracy validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14392?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->