### PR TITLE
[None][fix] Avoid eager optional server and FlashInfer imports

### DIFF
--- a/tensorrt_llm/__init__.py
+++ b/tensorrt_llm/__init__.py
@@ -132,9 +132,35 @@ from .parameter import Parameter
 from .python_plugin import PluginBase
 from .sampling_params import SamplingParams
 from .version import __version__
-from .visual_gen import (ExtraParamSchema, VisualGen, VisualGenArgs,
-                         VisualGenMetrics, VisualGenOutput, VisualGenParams,
-                         VisualGenResult)
+
+_VISUAL_GEN_EXPORTS = {
+    'ExtraParamSchema',
+    'VisualGen',
+    'VisualGenArgs',
+    'VisualGenMetrics',
+    'VisualGenOutput',
+    'VisualGenParams',
+    'VisualGenResult',
+}
+
+_LLM_ARGS_EXPORTS = {'KvCacheConfig'}
+
+
+def __getattr__(name):
+    if name in _VISUAL_GEN_EXPORTS:
+        from . import visual_gen
+
+        value = getattr(visual_gen, name)
+        globals()[name] = value
+        return value
+    if name in _LLM_ARGS_EXPORTS:
+        from .llmapi.llm_args import KvCacheConfig
+
+        value = KvCacheConfig
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     'AutoConfig',

--- a/tensorrt_llm/_torch/modules/fused_moe/communication/communication_factory.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/communication/communication_factory.py
@@ -34,7 +34,6 @@ from .deep_ep import DeepEP
 from .deep_ep_low_latency import DeepEPLowLatency
 from .nvlink_one_sided import NVLinkOneSided
 from .nvlink_two_sided import NVLinkTwoSided
-from .nvlink_two_sided_flashinfer import NVLinkTwoSidedFlashinfer
 
 
 class CommunicationFactory:
@@ -151,6 +150,8 @@ class CommunicationFactory:
 
         try:
             if use_flashinfer:
+                from .nvlink_two_sided_flashinfer import NVLinkTwoSidedFlashinfer
+
                 strategy = NVLinkTwoSidedFlashinfer(
                     mapping,
                     num_experts,
@@ -249,6 +250,8 @@ class CommunicationFactory:
         # Create strategy - will raise RuntimeError if platform not supported
         if method in ["NVLINK_TWO_SIDED"]:
             if use_flashinfer:
+                from .nvlink_two_sided_flashinfer import NVLinkTwoSidedFlashinfer
+
                 return NVLinkTwoSidedFlashinfer(
                     mapping,
                     num_experts,

--- a/tensorrt_llm/_torch/modules/fused_moe/moe_scheduler.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/moe_scheduler.py
@@ -52,7 +52,6 @@ from tensorrt_llm._torch.utils import EventType, Fp4QuantizedTensor
 from tensorrt_llm.tools.layer_wise_benchmarks import get_calibrator
 
 from .communication import DeepEP, DeepEPLowLatency, NVLinkOneSided, NVLinkTwoSided
-from .communication.nvlink_two_sided_flashinfer import NVLinkTwoSidedFlashinfer
 from .fused_moe_cute_dsl import CuteDslFusedMoE
 from .fused_moe_cutlass import CutlassFusedMoE
 from .fused_moe_deepgemm import DeepGemmFusedMoE
@@ -184,7 +183,18 @@ class ExternalCommMoEScheduler(MoEScheduler):
     # NVLink-specific EPLB stat-gather paths)
     # ------------------------------------------------------------------
     def _is_using_nvlink_two_sided(self) -> bool:
-        return isinstance(self.moe.comm, (NVLinkTwoSided, NVLinkTwoSidedFlashinfer))
+        if isinstance(self.moe.comm, NVLinkTwoSided):
+            return True
+        if self.moe.comm is None:
+            return False
+        try:
+            from .communication.nvlink_two_sided_flashinfer import NVLinkTwoSidedFlashinfer
+        except ModuleNotFoundError as exc:
+            missing_module = exc.name or ""
+            if missing_module != "flashinfer" and not missing_module.startswith("flashinfer."):
+                raise
+            return False
+        return isinstance(self.moe.comm, NVLinkTwoSidedFlashinfer)
 
     def _is_using_nvlink_one_sided(self) -> bool:
         return isinstance(self.moe.comm, NVLinkOneSided)

--- a/tensorrt_llm/serve/__init__.py
+++ b/tensorrt_llm/serve/__init__.py
@@ -1,4 +1,30 @@
-from .openai_disagg_server import OpenAIDisaggServer
-from .openai_server import OpenAIServer
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 __all__ = ['OpenAIServer', 'OpenAIDisaggServer']
+
+
+def __getattr__(name):
+    if name == 'OpenAIServer':
+        from .openai_server import OpenAIServer
+
+        globals()[name] = OpenAIServer
+        return OpenAIServer
+    if name == 'OpenAIDisaggServer':
+        from .openai_disagg_server import OpenAIDisaggServer
+
+        globals()[name] = OpenAIDisaggServer
+        return OpenAIDisaggServer
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/unittest/test_lazy_imports.py
+++ b/tests/unittest/test_lazy_imports.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import sys
+import textwrap
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+def _run_import_check(script: str):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        path for path in [REPO_ROOT, env.get("PYTHONPATH", "")] if path
+    )
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        capture_output=True,
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        timeout=120,
+    )
+
+
+def test_top_level_import_does_not_eagerly_import_visual_gen():
+    result = _run_import_check("""
+        import sys
+        import tensorrt_llm
+        from tensorrt_llm.llmapi.llm_args import KvCacheConfig
+
+        assert "tensorrt_llm.visual_gen" not in sys.modules
+        assert tensorrt_llm.KvCacheConfig is KvCacheConfig
+
+        _ = tensorrt_llm.VisualGenParams
+        assert "tensorrt_llm.visual_gen" in sys.modules
+    """)
+    assert result.returncode == 0, result.stderr
+
+
+def test_serve_import_does_not_eagerly_import_server_modules():
+    result = _run_import_check("""
+        import sys
+        import tensorrt_llm.serve as serve
+
+        assert "tensorrt_llm.serve.openai_server" not in sys.modules
+        assert "tensorrt_llm.serve.openai_disagg_server" not in sys.modules
+
+        _ = serve.OpenAIServer
+        assert "tensorrt_llm.serve.openai_server" in sys.modules
+        _ = serve.OpenAIDisaggServer
+        assert "tensorrt_llm.serve.openai_disagg_server" in sys.modules
+    """)
+    assert result.returncode == 0, result.stderr
+
+
+def test_moe_communication_factory_does_not_eagerly_import_flashinfer_strategy():
+    result = _run_import_check("""
+        import sys
+        import tensorrt_llm
+        import tensorrt_llm._torch.modules.fused_moe.communication.communication_factory
+        import tensorrt_llm._torch.modules.fused_moe.moe_scheduler
+
+        assert (
+            "tensorrt_llm._torch.modules.fused_moe.communication."
+            "nvlink_two_sided_flashinfer"
+        ) not in sys.modules
+    """)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Summary
- Lazily resolve top-level VisualGen exports and the existing KvCacheConfig public export.
- Lazily import OpenAI server classes from tensorrt_llm.serve.
- Avoid importing the FlashInfer NVLink strategy unless the FlashInfer path is requested or already in use.
- Add regression coverage for the lazy import behavior.

Validation
- PYTHONPYCACHEPREFIX=/tmp/codex-pycache python3 -m py_compile tensorrt_llm/__init__.py tensorrt_llm/serve/__init__.py tensorrt_llm/_torch/modules/fused_moe/communication/communication_factory.py tensorrt_llm/_torch/modules/fused_moe/moe_scheduler.py tests/unittest/test_lazy_imports.py
- git diff --check
- python3 -m pytest tests/unittest/test_lazy_imports.py -q (blocked locally: macOS system Python has no pytest)

Notes
- Claude adversarial review found no remaining blockers after the FlashInfer scheduler import and KvCacheConfig export were fixed.