### PR TITLE
[https://nvbugs/6185234][fix] route load_hf_model_config via AutoConfig

### DIFF
--- a/tensorrt_llm/llmapi/llm_utils.py
+++ b/tensorrt_llm/llmapi/llm_utils.py
@@ -695,7 +695,14 @@ class ModelLoader:
             trust_remote_code: bool = True,
             **kwargs) -> Optional[transformers.PretrainedConfig]:
         try:
-            return transformers.PretrainedConfig.from_pretrained(
+            # Route via AutoConfig so model_types registered through
+            # transformers.models.auto.configuration_auto.CONFIG_MAPPING
+            # (e.g. deepseek_v32 / kimi_k2 via tensorrt_llm/_torch/configs/)
+            # are dispatched to their TRT-LLM-local config class. Calling
+            # PretrainedConfig.from_pretrained directly bypasses CONFIG_MAPPING
+            # and on transformers 5.5.x returns a bare PretrainedConfig that
+            # lacks attributes like max_position_embeddings.
+            return transformers.AutoConfig.from_pretrained(
                 model_dir, trust_remote_code=trust_remote_code, **kwargs)
         except Exception as e:
             logger.warning(

--- a/tests/unittest/_torch/test_custom_config_registration.py
+++ b/tests/unittest/_torch/test_custom_config_registration.py
@@ -50,3 +50,31 @@ def test_autoconfig_from_pretrained_resolves_to_local_config(tmp_path, model_typ
     cfg = AutoConfig.from_pretrained(str(model_dir))
     assert isinstance(cfg, DeepseekV3Config)
     assert cfg.max_position_embeddings == 16384
+
+
+@pytest.mark.parametrize("model_type", ["deepseek_v32", "kimi_k2"])
+def test_load_hf_model_config_uses_autoconfig_dispatch(tmp_path, model_type):
+    # ModelLoader.load_hf_model_config is the llmapi/llm_utils entry point used
+    # by trtllm-serve to pre-load HF model configs. On transformers 5.5.x it
+    # must dispatch via AutoConfig (which CONFIG_MAPPING.register affects), not
+    # directly via PretrainedConfig.from_pretrained — the latter bypasses the
+    # mapping and returns a bare PretrainedConfig without
+    # `max_position_embeddings`, causing downstream AttributeError on the V3.2
+    # disagg gen_only GB200 post-merge perf-sanity test.
+    from tensorrt_llm.llmapi.llm_utils import ModelLoader
+
+    model_dir = tmp_path / model_type
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": model_type,
+                "max_position_embeddings": 16384,
+            }
+        )
+    )
+
+    cfg = ModelLoader.load_hf_model_config(str(model_dir))
+    assert cfg is not None
+    assert isinstance(cfg, DeepseekV3Config)
+    assert cfg.max_position_embeddings == 16384


### PR DESCRIPTION
  ## Summary                                                                                                            
                                                                                                                        
  Follow-up to #14293. `ModelLoader.load_hf_model_config` in                                                            
  `tensorrt_llm/llmapi/llm_utils.py` was still calling                                                                  
  `transformers.PretrainedConfig.from_pretrained` directly, which bypasses                                              
  the `transformers.models.auto.configuration_auto.CONFIG_MAPPING` that                                                 
  #14293 registers `deepseek_v32` / `kimi_k2` into. On transformers 5.5.x                                               
  the base-class `from_pretrained` returns a bare `PretrainedConfig` that                                               
  lacks `max_position_embeddings`. Route through `AutoConfig.from_pretrained`                                           
  so the #14293 mapping applies.                                                                                        
                                                                                                                        
  ## Symptom and CI history                                                                                             
                                                                                                                        
  L0_PostMerge stage                                                                                                    
  `GB200-36_GPUs-9_Nodes-PyTorch-Disagg-PerfSanity-CTX1-NODE1-GPU4-GEN1-NODE8-GPU32-Post-Merge-9`,                      
  test `perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-v32-fp4_8k1k_con1024_ctx1_dep4_gen1_dep
  32_eplb256_mtp3_ccb-NIXL]`:                                                                                           
                                                                                                                       

  GEN_0.0.log:35 at build 2726 still shows:

  [TRT-LLM] [W] [llmapi] Failed to load hf model config from
    .../DeepSeek-V3.2-Exp-FP4-v2, encountered error:
    'PreTrainedConfig' object has no attribute 'max_position_embeddings'

  — because `PretrainedConfig.from_pretrained` doesn't consult `CONFIG_MAPPING`,
  so #14293's registration is moot for this call path. The function returns
  `None`, downstream uses a fallback path that doesn't match the V3.2 config
  shape, and on 9-node MPI weight-load workers eventually die mid-load with
  PMIX `-61 LOST_CONNECTION_TO_PEER`.

## Mechanism

  `transformers.PretrainedConfig.from_pretrained` (base class) does not
  dispatch through `CONFIG_MAPPING`. `AutoConfig.from_pretrained` does.
  Routing the call through `AutoConfig` is what `_torch/configs/__init__.py`
  already assumes for the rest of the codebase; this was the only remaining
  direct call to the base class in `tensorrt_llm/`.

  Verified standalone on transformers 5.5.3:
  - `PretrainedConfig.from_pretrained` → bare `PreTrainedConfig` (the bypass)
  - `AutoConfig.from_pretrained` → registered subclass with all attributes
    (the fix)

  ## Test plan

  - [x] Extended `tests/unittest/_torch/test_custom_config_registration.py`
        with `test_load_hf_model_config_uses_autoconfig_dispatch` that
        asserts `ModelLoader.load_hf_model_config` returns a
        `DeepseekV3Config` instance (not bare `PretrainedConfig`) for
        `deepseek_v32` and `kimi_k2` model_types.
  - [x] Standalone mechanism reproducer run on transformers 5.5.3 inside
        the post-merge container (srun job 2265026): both `PretrainedConfig`
        bypass and `AutoConfig` dispatch behavior confirmed.