### PR TITLE
[TRTLLM-12720][feat] Add SM120 NVFP4 W4A16 support 

### DIFF
--- a/cpp/include/tensorrt_llm/common/quantization.h
+++ b/cpp/include/tensorrt_llm/common/quantization.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,6 +134,11 @@ public:
         return QuantMode(BaseType(1u) << 16);
     }
 
+    static constexpr QuantMode w4a16Nvfp4() noexcept
+    {
+        return QuantMode(BaseType(1u) << 17);
+    }
+
     constexpr BaseType value() const noexcept
     {
         return mValue;
@@ -222,6 +227,11 @@ public:
     constexpr bool hasW4a16Mxfp4() const noexcept
     {
         return isSet(w4a16Mxfp4());
+    }
+
+    constexpr bool hasW4a16Nvfp4() const noexcept
+    {
+        return isSet(w4a16Nvfp4());
     }
 
     constexpr bool hasKvCacheQuant() const noexcept
@@ -418,6 +428,10 @@ public:
         {
             quantMode = fromDescription(false, false, false, false, false, false, false, false, false, false, false,
                 false, false, false, false, true);
+        }
+        else if (quantAlgo == "W4A16_NVFP4")
+        {
+            quantMode = w4a16Nvfp4();
         }
 
         if (kvCacheQuantAlgo == "INT8")

--- a/cpp/kernels/xqa/mha.cu
+++ b/cpp/kernels/xqa/mha.cu
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -2538,6 +2538,7 @@ CUBIN_EXPORT __global__
 
         // merge results from different warp groups
         SharedMem::XSmemBuffer* smemOutTile = mergeAndSaveOutTile(outTile, inputElemSize == 2 && cacheElemSize == 1);
+        bool writeOutput = !isMultiBlock;
         if (isMultiBlock)
         {
             static_assert(ctaShapeInWarps.y == 1, "not implemented");
@@ -2612,6 +2613,7 @@ CUBIN_EXPORT __global__
             bool const isLastCta = mbsmem.isLastCta;
             if (isLastCta)
             {
+                writeOutput = true;
                 MultiBlockSMem::MBBuf& mbbuf = mbsmem.storage[warpIdx.y];
                 SMemWarpRowMax& smemRowMax = reinterpret_cast<SMemWarpRowMax&>(smem);
                 // get row max.
@@ -2700,7 +2702,7 @@ CUBIN_EXPORT __global__
                 smemOutTile = mergeAndSaveOutTile(mergedOutTile, false);
             }
         }
-        if (warpGrpIdx == 0)
+        if (warpGrpIdx == 0 && writeOutput)
         {
 #if SPEC_DEC
             copyOutputToGlobalMem(warp, &output[reqSeqOffset * nbQHeads], nbQHeads, headGrpSize,

--- a/cpp/tensorrt_llm/common/attentionOp.cpp
+++ b/cpp/tensorrt_llm/common/attentionOp.cpp
@@ -232,8 +232,9 @@ bool AttentionOp::convertMMHAParamsToXQAParams(tensorrt_llm::kernels::XQAParams&
     {
         xqaParams.kv_cache_data_type = xqaParams.data_type;
     }
+    // SM120/121 ship FP8 paged-KV XQA cubins with multi-block support.
     if (xqaParams.kv_cache_data_type == DATA_TYPE_INT8
-        || (xqaParams.kv_cache_data_type == DATA_TYPE_E4M3 && (mSM < kSM_90 || mSM >= kSM_120)))
+        || (xqaParams.kv_cache_data_type == DATA_TYPE_E4M3 && mSM < kSM_90))
     {
         xqaParams.multi_block_mode = false;
     }

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/w4a16_nvfp4_gemm/w4a16_nvfp4_gemm_sm120.cuh
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/w4a16_nvfp4_gemm/w4a16_nvfp4_gemm_sm120.cuh
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "cutlass/cutlass.h"
+#include "cutlass/epilogue/thread/linear_combination.h"
+#include "cutlass/epilogue/thread/scale_type.h"
+#include "cutlass/gemm/device/gemm.h"
+#include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/common/logger.h"
+#include "tensorrt_llm/kernels/weightOnlyBatchedGemv/cutlassGemmW4A16NVFP4.h"
+#include "tensorrt_llm/kernels/weightOnlyBatchedGemv/nvfp4ScaleLayout.h"
+
+#include <cuda_bf16.h>
+#include <cuda_fp4.h>
+#include <cuda_fp8.h>
+
+#include <algorithm>
+#include <cstddef>
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels
+{
+namespace cutlass_gemm_w4a16_nvfp4
+{
+namespace sm120
+{
+namespace
+{
+
+using SizeType32 = tensorrt_llm::runtime::SizeType32;
+
+__device__ float loadNvfp4Weight(uint8_t const* weight, __nv_fp8_e4m3 const* weightScale, float const weightGlobalScale,
+    SizeType32 nIdx, SizeType32 kIdx, SizeType32 k)
+{
+    size_t const packedOffset = (static_cast<size_t>(nIdx) * static_cast<size_t>(k) + static_cast<size_t>(kIdx)) / 2;
+    uint8_t const packed = weight[packedOffset];
+    __nv_fp4_storage_t const nibble = (kIdx % 2 == 0) ? (packed & 0x0FU) : (packed >> 4U);
+    half const weightValue = static_cast<half>(__nv_cvt_fp4_to_halfraw(nibble, __NV_E2M1));
+
+    SizeType32 const scaleIdx = w4a16_nvfp4::getScaleIndex(nIdx, kIdx / w4a16_nvfp4::kScaleGranularity, k);
+    float const scale = static_cast<float>(weightScale[scaleIdx]);
+    return __half2float(weightValue) * scale * weightGlobalScale;
+}
+
+__global__ void dequantizeWeightToBf16ColumnMajor(__nv_bfloat16* dequantizedWeight, uint8_t const* weight,
+    __nv_fp8_e4m3 const* weightScale, float const* weightGlobalScale, SizeType32 n, SizeType32 k)
+{
+    size_t const total = static_cast<size_t>(n) * static_cast<size_t>(k);
+    float const globalScale = weightGlobalScale[0];
+    for (size_t idx
+         = static_cast<size_t>(blockIdx.x) * static_cast<size_t>(blockDim.x) + static_cast<size_t>(threadIdx.x);
+         idx < total; idx += static_cast<size_t>(gridDim.x) * static_cast<size_t>(blockDim.x))
+    {
+        SizeType32 const nIdx = static_cast<SizeType32>(idx / static_cast<size_t>(k));
+        SizeType32 const kIdx = static_cast<SizeType32>(idx % static_cast<size_t>(k));
+        size_t const dequantizedOffset = static_cast<size_t>(kIdx) + static_cast<size_t>(nIdx) * static_cast<size_t>(k);
+        dequantizedWeight[dequantizedOffset]
+            = __float2bfloat16(loadNvfp4Weight(weight, weightScale, globalScale, nIdx, kIdx, k));
+    }
+}
+
+void dequantizeWeight(Params const& params, __nv_bfloat16* dequantizedWeight, cudaStream_t stream)
+{
+    constexpr SizeType32 kBlockSize = 256;
+    constexpr SizeType32 kMaxGridSize = 65535;
+    size_t const total = static_cast<size_t>(params.n) * static_cast<size_t>(params.k);
+    auto const gridSize = static_cast<SizeType32>(
+        std::min((total + static_cast<size_t>(kBlockSize) - 1) / static_cast<size_t>(kBlockSize),
+            static_cast<size_t>(kMaxGridSize)));
+    dequantizeWeightToBf16ColumnMajor<<<gridSize, kBlockSize, 0, stream>>>(dequantizedWeight,
+        reinterpret_cast<uint8_t const*>(params.weight), reinterpret_cast<__nv_fp8_e4m3 const*>(params.weightScale),
+        params.weightGlobalScale, params.n, params.k);
+    TLLM_CUDA_CHECK(cudaGetLastError());
+}
+
+bool runCutlassBf16Gemm(Params const& params, __nv_bfloat16 const* dequantizedWeight, cudaStream_t stream)
+{
+    using ElementA = cutlass::bfloat16_t;
+    using ElementB = cutlass::bfloat16_t;
+    using ElementOutput = cutlass::bfloat16_t;
+    using ElementAccumulator = float;
+    using ElementCompute = float;
+    using LayoutA = cutlass::layout::RowMajor;
+    using LayoutB = cutlass::layout::ColumnMajor;
+    using LayoutOutput = cutlass::layout::RowMajor;
+    using ThreadblockShape = cutlass::gemm::GemmShape<128, 128, 32>;
+    using WarpShape = cutlass::gemm::GemmShape<64, 64, 32>;
+    using InstructionShape = cutlass::gemm::GemmShape<16, 8, 16>;
+    using EpilogueOp
+        = cutlass::epilogue::thread::LinearCombination<ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
+            ElementAccumulator, ElementCompute, cutlass::epilogue::thread::ScaleType::OnlyAlphaScaling>;
+    using Gemm = cutlass::gemm::device::Gemm<ElementA, LayoutA, ElementB, LayoutB, ElementOutput, LayoutOutput,
+        ElementAccumulator, cutlass::arch::OpClassTensorOp, cutlass::arch::Sm80, ThreadblockShape, WarpShape,
+        InstructionShape, EpilogueOp, cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<8>, 4, 8, 8>;
+
+    typename Gemm::Arguments arguments({params.m, params.n, params.k},
+        {reinterpret_cast<ElementA const*>(params.act), params.k},
+        {reinterpret_cast<ElementB const*>(dequantizedWeight), params.k},
+        {reinterpret_cast<ElementOutput const*>(params.output), params.n},
+        {reinterpret_cast<ElementOutput*>(params.output), params.n}, {ElementCompute(1), ElementCompute(0)}, 1);
+
+    Gemm gemm;
+    cutlass::Status status = gemm.can_implement(arguments);
+    if (status != cutlass::Status::kSuccess)
+    {
+        TLLM_LOG_WARNING("w4a16_nvfp4 transient BF16 CUTLASS GEMM cannot implement shape m=%d n=%d k=%d: %s", params.m,
+            params.n, params.k, cutlass::cutlassGetStatusString(status));
+        return false;
+    }
+
+    size_t const workspaceBytes = Gemm::get_workspace_size(arguments);
+    void* workspace = nullptr;
+    if (workspaceBytes > 0)
+    {
+        TLLM_CUDA_CHECK(cudaMallocAsync(&workspace, workspaceBytes, stream));
+    }
+
+    status = gemm.initialize(arguments, workspace, stream);
+    if (status == cutlass::Status::kSuccess)
+    {
+        status = gemm.run(stream);
+    }
+
+    if (workspace != nullptr)
+    {
+        TLLM_CUDA_CHECK(cudaFreeAsync(workspace, stream));
+    }
+
+    if (status != cutlass::Status::kSuccess)
+    {
+        TLLM_LOG_WARNING("w4a16_nvfp4 transient BF16 CUTLASS GEMM failed for shape m=%d n=%d k=%d: %s", params.m,
+            params.n, params.k, cutlass::cutlassGetStatusString(status));
+        return false;
+    }
+    TLLM_CUDA_CHECK(cudaGetLastError());
+    return true;
+}
+
+bool runTransientDequantCutlassGemm(Params const& params, cudaStream_t stream)
+{
+    void* dequantizedWeight = nullptr;
+    size_t const dequantizedBytes
+        = static_cast<size_t>(params.n) * static_cast<size_t>(params.k) * sizeof(__nv_bfloat16);
+    TLLM_CUDA_CHECK(cudaMallocAsync(&dequantizedWeight, dequantizedBytes, stream));
+    dequantizeWeight(params, reinterpret_cast<__nv_bfloat16*>(dequantizedWeight), stream);
+    bool const dispatched
+        = runCutlassBf16Gemm(params, reinterpret_cast<__nv_bfloat16 const*>(dequantizedWeight), stream);
+    TLLM_CUDA_CHECK(cudaFreeAsync(dequantizedWeight, stream));
+    return dispatched;
+}
+
+} // namespace
+
+inline bool dispatch(Params const& params, cudaStream_t stream)
+{
+    if (params.inputType == CUDA_R_16BF && params.outputType == CUDA_R_16BF)
+    {
+        return runTransientDequantCutlassGemm(params, stream);
+    }
+    return false;
+}
+
+} // namespace sm120
+} // namespace cutlass_gemm_w4a16_nvfp4
+} // namespace kernels
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmW4A16NVFP4.cu
+++ b/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmW4A16NVFP4.cu
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cutlass/numeric_conversion.h"
+#include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/common/logger.h"
+#include "tensorrt_llm/kernels/cutlass_kernels/cutlass_type_conversion.h"
+#include "tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmW4A16NVFP4.h"
+
+#include <cub/cub.cuh>
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels
+{
+namespace cuda_core_gemm_w4a16_nvfp4
+{
+namespace
+{
+
+template <typename T>
+__device__ float toFloat(T value)
+{
+    return static_cast<float>(value);
+}
+
+template <>
+__device__ float toFloat<half>(half value)
+{
+    return __half2float(value);
+}
+
+template <>
+__device__ float toFloat<__nv_bfloat16>(__nv_bfloat16 value)
+{
+    return __bfloat162float(value);
+}
+
+} // namespace
+
+template <typename ActType, typename OutputType, typename ScaleType, SizeType32 kTileM, SizeType32 kTileN,
+    SizeType32 kBlockSize>
+__device__ void cudaCoreGemmImpl(ActType const* __restrict__ act, __nv_fp4_e2m1 const* __restrict__ weight,
+    ScaleType const* __restrict__ weightScale, float const weightGlobalScale, OutputType* __restrict__ output,
+    SizeType32 m, SizeType32 n, SizeType32 k)
+{
+    using VecType = int4;
+    using ScaleVecType = __nv_fp8x2_e4m3;
+    using CvtWeightType =
+        typename tensorrt_llm::kernels::cutlass_kernels::TllmToCutlassTypeAdapter<__nv_fp4_e2m1>::type;
+    using Converter = cutlass::NumericArrayConverter<float, CvtWeightType, 8>;
+    using CvtSrcType = typename Converter::source_type;
+    using CvtResType = typename Converter::result_type;
+
+    static constexpr SizeType32 kNvfp4ScaleGranularity = 16;
+    static constexpr SizeType32 kStepK = 32;
+    static constexpr SizeType32 kStepKScale = kStepK / kNvfp4ScaleGranularity;
+    static constexpr SizeType32 kTileK = kStepK * kBlockSize;
+    static constexpr SizeType32 kCvtCount = static_cast<SizeType32>(sizeof(VecType) / sizeof(CvtSrcType));
+
+    static_assert(kStepK % kNvfp4ScaleGranularity == 0);
+
+    auto const tileIdM = static_cast<SizeType32>(blockIdx.x * kTileM);
+    auto const tileIdN = static_cast<SizeType32>(blockIdx.y * kTileN);
+    auto const tid = static_cast<SizeType32>(threadIdx.x);
+    (void) m;
+
+    float tileAct[kStepK];
+    float tileWeight[kTileN * kStepK];
+    float tileWeightScale[kTileN * kStepKScale];
+    float acc[kTileM * kTileN];
+
+#pragma unroll
+    for (SizeType32 i = 0; i < kTileM * kTileN; ++i)
+    {
+        acc[i] = 0.0F;
+    }
+
+    act += tileIdM * k;
+    weight += tileIdN * k / 2;
+    output += tileIdM * n + tileIdN;
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    cudaGridDependencySynchronize();
+#endif
+
+    SizeType32 const numColsSf = k / kNvfp4ScaleGranularity;
+    SizeType32 const numSfTilesK = (numColsSf + 4 - 1) / 4;
+
+    for (SizeType32 idxK = tid * kStepK; idxK < k; idxK += kTileK)
+    {
+#pragma unroll
+        for (SizeType32 j = 0; j < kTileN; ++j)
+        {
+            auto tileWeightQuantized = reinterpret_cast<VecType const*>(weight + (j * k + idxK) / 2)[0];
+#pragma unroll
+            for (SizeType32 cvtIdx = 0; cvtIdx < kCvtCount; ++cvtIdx)
+            {
+                reinterpret_cast<CvtResType*>(tileWeight)[j * kCvtCount + cvtIdx]
+                    = Converter::convert(reinterpret_cast<CvtSrcType*>(&tileWeightQuantized)[cvtIdx]);
+            }
+        }
+
+#pragma unroll
+        for (SizeType32 j = 0; j < kTileN; ++j)
+        {
+            SizeType32 const rowIdx = tileIdN + j;
+            SizeType32 const colIdx = idxK / kNvfp4ScaleGranularity;
+            SizeType32 const tileOffset = ((rowIdx / 128) * numSfTilesK + colIdx / 4) * 512;
+            SizeType32 const dstIdx = tileOffset + (rowIdx % 32) * 16 + ((rowIdx % 128) / 32) * 4 + colIdx % 4;
+            auto const tileWeightScaleFp8x2 = reinterpret_cast<ScaleVecType const*>(weightScale + dstIdx)[0];
+            char2 const tmp = reinterpret_cast<char2 const&>(tileWeightScaleFp8x2);
+            tileWeightScale[j * kStepKScale + 0] = static_cast<float>(reinterpret_cast<__nv_fp8_e4m3 const&>(tmp.x));
+            tileWeightScale[j * kStepKScale + 1] = static_cast<float>(reinterpret_cast<__nv_fp8_e4m3 const&>(tmp.y));
+        }
+
+#pragma unroll
+        for (SizeType32 i = 0; i < kTileM; ++i)
+        {
+#pragma unroll
+            for (SizeType32 l = 0; l < kStepK; ++l)
+            {
+                tileAct[l] = toFloat(act[i * k + idxK + l]);
+            }
+
+#pragma unroll
+            for (SizeType32 j = 0; j < kTileN; ++j)
+            {
+#pragma unroll
+                for (SizeType32 l = 0; l < kStepK; ++l)
+                {
+                    float const scaledWeight = tileWeight[j * kStepK + l]
+                        * tileWeightScale[j * kStepKScale + l / kNvfp4ScaleGranularity] * weightGlobalScale;
+                    acc[i * kTileN + j] = fma(tileAct[l], scaledWeight, acc[i * kTileN + j]);
+                }
+            }
+        }
+    }
+
+    using WarpReduce = cub::WarpReduce<float>;
+    static constexpr SizeType32 kWarpSize = 32;
+    static constexpr SizeType32 kWarpNum = kBlockSize / kWarpSize;
+    SizeType32 const warpId = tid / kWarpSize;
+    SizeType32 const laneId = tid % kWarpSize;
+    __shared__ float shmem[kTileM * kTileN * kWarpNum];
+    __shared__ typename WarpReduce::TempStorage tempStorage[kWarpNum];
+
+#pragma unroll
+    for (SizeType32 mi = 0; mi < kTileM; ++mi)
+    {
+#pragma unroll
+        for (SizeType32 ni = 0; ni < kTileN; ++ni)
+        {
+            float const val = WarpReduce(tempStorage[warpId]).Sum(acc[mi * kTileN + ni]);
+            if (laneId == 0)
+            {
+                shmem[mi * kTileN + ni + warpId * kTileM * kTileN] = val;
+            }
+        }
+    }
+    __syncthreads();
+
+    for (SizeType32 ii = tid; ii < kTileM * kTileN; ii += kBlockSize)
+    {
+        SizeType32 const mid = ii / kTileN;
+        SizeType32 const nid = ii % kTileN;
+        float val = 0.0F;
+#pragma unroll
+        for (SizeType32 jj = 0; jj < kWarpNum; ++jj)
+        {
+            val += shmem[jj * kTileM * kTileN + ii];
+        }
+        output[mid * n + nid] = static_cast<OutputType>(val);
+    }
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    cudaTriggerProgrammaticLaunchCompletion();
+#endif
+}
+
+template <typename ActType, typename OutputType, typename ScaleType, SizeType32 kTileM, SizeType32 kTileN,
+    SizeType32 kBlockSize>
+__global__ void cudaCoreGemm(ActType const* __restrict__ act, __nv_fp4_e2m1 const* __restrict__ weight,
+    ScaleType const* __restrict__ weightScale, float const* weightGlobalScale, OutputType* __restrict__ output,
+    SizeType32 m, SizeType32 n, SizeType32 k)
+{
+    cudaCoreGemmImpl<ActType, OutputType, ScaleType, kTileM, kTileN, kBlockSize>(
+        act, weight, weightScale, weightGlobalScale[0], output, m, n, k);
+}
+
+template <typename ActType, typename OutputType, typename ScaleType, SizeType32 kTileM, SizeType32 kTileN,
+    SizeType32 kBlockSize>
+void cudaCoreGemmKernel(Params const& params, cudaStream_t stream)
+{
+    dim3 const block(kBlockSize);
+    dim3 const grid(params.m / kTileM, params.n / kTileN);
+    cudaCoreGemm<ActType, OutputType, ScaleType, kTileM, kTileN, kBlockSize><<<grid, block, 0, stream>>>(
+        reinterpret_cast<ActType const*>(params.act), reinterpret_cast<__nv_fp4_e2m1 const*>(params.weight),
+        reinterpret_cast<ScaleType const*>(params.weightScale), params.weightGlobalScale,
+        reinterpret_cast<OutputType*>(params.output), params.m, params.n, params.k);
+}
+
+template <typename ActType, typename OutputType, typename ScaleType, int kTileM, int kTileN, int kBlockSize>
+bool cudaCoreGemmTemplateCaller(Params const& params, cudaStream_t stream)
+{
+    constexpr int kCudaCoreGemmTemplateMaxM = 16;
+    if (params.m == kTileM)
+    {
+        cudaCoreGemmKernel<ActType, OutputType, ScaleType, kTileM, kTileN, kBlockSize>(params, stream);
+        return true;
+    }
+    if constexpr (kTileM < kCudaCoreGemmTemplateMaxM)
+    {
+        return cudaCoreGemmTemplateCaller<ActType, OutputType, ScaleType, kTileM + 1, kTileN, kBlockSize>(
+            params, stream);
+    }
+    return false;
+}
+
+template <typename ActType, typename OutputType, typename ScaleType = __nv_fp8_e4m3>
+bool cudaCoreGemmLauncher(Params const& params, cudaStream_t stream)
+{
+    return cudaCoreGemmTemplateCaller<ActType, OutputType, ScaleType, 1, 2, 128>(params, stream);
+}
+
+template <typename ActType>
+bool dispatchOutputType(Params const& params, cudaStream_t stream)
+{
+    if (params.outputType == CUDA_R_16F)
+    {
+        return cudaCoreGemmLauncher<ActType, half>(params, stream);
+    }
+    if (params.outputType == CUDA_R_16BF)
+    {
+        return cudaCoreGemmLauncher<ActType, __nv_bfloat16>(params, stream);
+    }
+    if (params.outputType == CUDA_R_32F)
+    {
+        return cudaCoreGemmLauncher<ActType, float>(params, stream);
+    }
+    return false;
+}
+
+bool cudaCoreGemmDispatcher(Params const& params, cudaStream_t stream)
+{
+    bool dispatched = true;
+    int const smVersion = tensorrt_llm::common::getSMVersion();
+    if (smVersion != 120 && smVersion != 121)
+    {
+        dispatched = false;
+    }
+    else if (params.n % 2 != 0 || params.k % 32 != 0)
+    {
+        dispatched = false;
+    }
+    else if (params.m < 1 || params.m > 16)
+    {
+        dispatched = false;
+    }
+    else if (params.weightScale == nullptr || params.weightGlobalScale == nullptr)
+    {
+        dispatched = false;
+    }
+    else if (params.inputType == CUDA_R_16F)
+    {
+        dispatched = dispatchOutputType<half>(params, stream);
+    }
+    else if (params.inputType == CUDA_R_16BF)
+    {
+        dispatched = dispatchOutputType<__nv_bfloat16>(params, stream);
+    }
+    else
+    {
+        dispatched = false;
+    }
+
+    if (!dispatched)
+    {
+        TLLM_LOG_WARNING(
+            "tensorrt_llm::kernels::cuda_core_gemm_w4a16_nvfp4::cudaCoreGemmDispatcher [NOT DISPATCHED], "
+            "inputType=%d, outputType=%d, m=%d, n=%d, k=%d, sm=%d",
+            params.inputType, params.outputType, params.m, params.n, params.k, smVersion);
+    }
+    return dispatched;
+}
+
+} // namespace cuda_core_gemm_w4a16_nvfp4
+} // namespace kernels
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmW4A16NVFP4.cu
+++ b/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmW4A16NVFP4.cu
@@ -19,6 +19,7 @@
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/kernels/cutlass_kernels/cutlass_type_conversion.h"
 #include "tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmW4A16NVFP4.h"
+#include "tensorrt_llm/kernels/weightOnlyBatchedGemv/nvfp4ScaleLayout.h"
 
 #include <cub/cub.cuh>
 
@@ -65,13 +66,12 @@ __device__ void cudaCoreGemmImpl(ActType const* __restrict__ act, __nv_fp4_e2m1 
     using CvtSrcType = typename Converter::source_type;
     using CvtResType = typename Converter::result_type;
 
-    static constexpr SizeType32 kNvfp4ScaleGranularity = 16;
     static constexpr SizeType32 kStepK = 32;
-    static constexpr SizeType32 kStepKScale = kStepK / kNvfp4ScaleGranularity;
+    static constexpr SizeType32 kStepKScale = kStepK / w4a16_nvfp4::kScaleGranularity;
     static constexpr SizeType32 kTileK = kStepK * kBlockSize;
     static constexpr SizeType32 kCvtCount = static_cast<SizeType32>(sizeof(VecType) / sizeof(CvtSrcType));
 
-    static_assert(kStepK % kNvfp4ScaleGranularity == 0);
+    static_assert(kStepK % w4a16_nvfp4::kScaleGranularity == 0);
 
     auto const tileIdM = static_cast<SizeType32>(blockIdx.x * kTileM);
     auto const tileIdN = static_cast<SizeType32>(blockIdx.y * kTileN);
@@ -97,9 +97,6 @@ __device__ void cudaCoreGemmImpl(ActType const* __restrict__ act, __nv_fp4_e2m1 
     cudaGridDependencySynchronize();
 #endif
 
-    SizeType32 const numColsSf = k / kNvfp4ScaleGranularity;
-    SizeType32 const numSfTilesK = (numColsSf + 4 - 1) / 4;
-
     for (SizeType32 idxK = tid * kStepK; idxK < k; idxK += kTileK)
     {
 #pragma unroll
@@ -118,9 +115,8 @@ __device__ void cudaCoreGemmImpl(ActType const* __restrict__ act, __nv_fp4_e2m1 
         for (SizeType32 j = 0; j < kTileN; ++j)
         {
             SizeType32 const rowIdx = tileIdN + j;
-            SizeType32 const colIdx = idxK / kNvfp4ScaleGranularity;
-            SizeType32 const tileOffset = ((rowIdx / 128) * numSfTilesK + colIdx / 4) * 512;
-            SizeType32 const dstIdx = tileOffset + (rowIdx % 32) * 16 + ((rowIdx % 128) / 32) * 4 + colIdx % 4;
+            SizeType32 const colIdx = idxK / w4a16_nvfp4::kScaleGranularity;
+            SizeType32 const dstIdx = w4a16_nvfp4::getScaleIndex(rowIdx, colIdx, k);
             auto const tileWeightScaleFp8x2 = reinterpret_cast<ScaleVecType const*>(weightScale + dstIdx)[0];
             char2 const tmp = reinterpret_cast<char2 const&>(tileWeightScaleFp8x2);
             tileWeightScale[j * kStepKScale + 0] = static_cast<float>(reinterpret_cast<__nv_fp8_e4m3 const&>(tmp.x));
@@ -143,7 +139,7 @@ __device__ void cudaCoreGemmImpl(ActType const* __restrict__ act, __nv_fp4_e2m1 
                 for (SizeType32 l = 0; l < kStepK; ++l)
                 {
                     float const scaledWeight = tileWeight[j * kStepK + l]
-                        * tileWeightScale[j * kStepKScale + l / kNvfp4ScaleGranularity] * weightGlobalScale;
+                        * tileWeightScale[j * kStepKScale + l / w4a16_nvfp4::kScaleGranularity] * weightGlobalScale;
                     acc[i * kTileN + j] = fma(tileAct[l], scaledWeight, acc[i * kTileN + j]);
                 }
             }

--- a/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmW4A16NVFP4.cu
+++ b/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmW4A16NVFP4.cu
@@ -211,6 +211,7 @@ void cudaCoreGemmKernel(Params const& params, cudaStream_t stream)
         reinterpret_cast<ActType const*>(params.act), reinterpret_cast<__nv_fp4_e2m1 const*>(params.weight),
         reinterpret_cast<ScaleType const*>(params.weightScale), params.weightGlobalScale,
         reinterpret_cast<OutputType*>(params.output), params.m, params.n, params.k);
+    TLLM_CUDA_CHECK(cudaGetLastError());
 }
 
 template <typename ActType, typename OutputType, typename ScaleType, int kTileM, int kTileN, int kBlockSize>
@@ -233,7 +234,18 @@ bool cudaCoreGemmTemplateCaller(Params const& params, cudaStream_t stream)
 template <typename ActType, typename OutputType, typename ScaleType = __nv_fp8_e4m3>
 bool cudaCoreGemmLauncher(Params const& params, cudaStream_t stream)
 {
-    return cudaCoreGemmTemplateCaller<ActType, OutputType, ScaleType, 1, 2, 128>(params, stream);
+    constexpr int kDefaultTileN = 2;
+    constexpr int kWideTileN = 4;
+    constexpr int kMaxGridDimY = 65535;
+    if (params.n / kDefaultTileN <= kMaxGridDimY)
+    {
+        return cudaCoreGemmTemplateCaller<ActType, OutputType, ScaleType, 1, kDefaultTileN, 128>(params, stream);
+    }
+    if (params.n % kWideTileN == 0 && params.n / kWideTileN <= kMaxGridDimY)
+    {
+        return cudaCoreGemmTemplateCaller<ActType, OutputType, ScaleType, 1, kWideTileN, 128>(params, stream);
+    }
+    return false;
 }
 
 template <typename ActType>

--- a/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmW4A16NVFP4.h
+++ b/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmW4A16NVFP4.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/common/config.h"
+#include "tensorrt_llm/runtime/common.h"
+
+#include <NvInferRuntime.h>
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+#include <cuda_runtime_api.h>
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels
+{
+namespace cuda_core_gemm_w4a16_nvfp4
+{
+using SizeType32 = tensorrt_llm::runtime::SizeType32;
+
+struct Params
+{
+    void const* act;
+    void const* weight;
+    void const* weightScale;
+    float const* weightGlobalScale;
+    void* output;
+    SizeType32 m, n, k;
+    cudaDataType_t inputType;
+    cudaDataType_t outputType;
+
+    Params(void const* act_, void const* weight_, void const* weightScale_, float const* weightGlobalScale_,
+        void* output_, SizeType32 m_, SizeType32 n_, SizeType32 k_, cudaDataType_t inputType_,
+        cudaDataType_t outputType_)
+        : act(act_)
+        , weight(weight_)
+        , weightScale(weightScale_)
+        , weightGlobalScale(weightGlobalScale_)
+        , output(output_)
+        , m(m_)
+        , n(n_)
+        , k(k_)
+        , inputType(inputType_)
+        , outputType(outputType_)
+    {
+    }
+};
+
+bool cudaCoreGemmDispatcher(Params const& params, cudaStream_t stream);
+
+} // namespace cuda_core_gemm_w4a16_nvfp4
+} // namespace kernels
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/cutlassGemmW4A16NVFP4.cu
+++ b/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/cutlassGemmW4A16NVFP4.cu
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/common/logger.h"
+#include "tensorrt_llm/kernels/cutlass_kernels/w4a16_nvfp4_gemm/w4a16_nvfp4_gemm_sm120.cuh"
+#include "tensorrt_llm/kernels/weightOnlyBatchedGemv/cutlassGemmW4A16NVFP4.h"
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels
+{
+namespace cutlass_gemm_w4a16_nvfp4
+{
+namespace
+{
+
+bool isSupported(Params const& params)
+{
+    int const smVersion = tensorrt_llm::common::getSMVersion();
+    return (smVersion == 120 || smVersion == 121) && params.inputType == CUDA_R_16BF && params.outputType == CUDA_R_16BF
+        && params.m > 16 && params.n > 0 && params.k > 0 && params.n % 32 == 0 && params.k % 32 == 0
+        && params.weightScale != nullptr && params.weightGlobalScale != nullptr;
+}
+
+} // namespace
+
+bool cutlassGemmDispatcher(Params const& params, cudaStream_t stream)
+{
+    if (!isSupported(params))
+    {
+        int const smVersion = tensorrt_llm::common::getSMVersion();
+        TLLM_LOG_WARNING(
+            "tensorrt_llm::kernels::cutlass_gemm_w4a16_nvfp4::cutlassGemmDispatcher [NOT DISPATCHED], "
+            "inputType=%d, outputType=%d, m=%d, n=%d, k=%d, sm=%d",
+            params.inputType, params.outputType, params.m, params.n, params.k, smVersion);
+        return false;
+    }
+
+    return sm120::dispatch(params, stream);
+}
+
+} // namespace cutlass_gemm_w4a16_nvfp4
+} // namespace kernels
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/cutlassGemmW4A16NVFP4.h
+++ b/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/cutlassGemmW4A16NVFP4.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmW4A16NVFP4.h"
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels
+{
+namespace cutlass_gemm_w4a16_nvfp4
+{
+
+using Params = tensorrt_llm::kernels::cuda_core_gemm_w4a16_nvfp4::Params;
+
+bool cutlassGemmDispatcher(Params const& params, cudaStream_t stream);
+
+} // namespace cutlass_gemm_w4a16_nvfp4
+} // namespace kernels
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/nvfp4ScaleLayout.h
+++ b/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/nvfp4ScaleLayout.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/common/config.h"
+#include "tensorrt_llm/runtime/common.h"
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels
+{
+namespace w4a16_nvfp4
+{
+
+using SizeType32 = tensorrt_llm::runtime::SizeType32;
+
+static constexpr SizeType32 kScaleGranularity = 16;
+static constexpr SizeType32 kScaleRowsPerTile = 128;
+static constexpr SizeType32 kPackedScaleColsPerTile = 4;
+static constexpr SizeType32 kScaleTileElements = 512;
+
+__host__ __device__ inline SizeType32 getScaleIndex(SizeType32 rowIdx, SizeType32 scaleColIdx, SizeType32 k)
+{
+    SizeType32 const numScaleCols = k / kScaleGranularity;
+    SizeType32 const numScaleColTiles = (numScaleCols + kPackedScaleColsPerTile - 1) / kPackedScaleColsPerTile;
+    SizeType32 const tileOffset
+        = ((rowIdx / kScaleRowsPerTile) * numScaleColTiles + scaleColIdx / kPackedScaleColsPerTile)
+        * kScaleTileElements;
+    return tileOffset + (rowIdx % 32) * 16 + ((rowIdx % kScaleRowsPerTile) / 32) * 4
+        + scaleColIdx % kPackedScaleColsPerTile;
+}
+
+} // namespace w4a16_nvfp4
+} // namespace kernels
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/nanobind/bindings.cpp
+++ b/cpp/tensorrt_llm/nanobind/bindings.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -273,6 +273,7 @@ NB_MODULE(TRTLLM_NB_MODULE, m)
 
         .def_prop_ro("has_w4a8_mxfp4_mxfp8", &tc::QuantMode::hasW4a8Mxfp4Mxfp8)
         .def_prop_ro("has_w4a16_mxfp4", &tc::QuantMode::hasW4a16Mxfp4)
+        .def_prop_ro("has_w4a16_nvfp4", &tc::QuantMode::hasW4a16Nvfp4)
 
         .def_prop_ro("has_kv_cache_quant", &tc::QuantMode::hasKvCacheQuant)
         .def_static("from_description", &tc::QuantMode::fromDescription, nb::arg("quantize_weights"),

--- a/cpp/tensorrt_llm/thop/CMakeLists.txt
+++ b/cpp/tensorrt_llm/thop/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(
   cublasFp4ScaledMM.cpp
   cudaNvfp4MM.cpp
   cudaScaledMM.cpp
+  w4a16Nvfp4Gemm.cpp
   dynamicDecodeOp.cpp
   fmhaPackMaskOp.cpp
   fp8Op.cpp

--- a/cpp/tensorrt_llm/thop/w4a16Nvfp4Gemm.cpp
+++ b/cpp/tensorrt_llm/thop/w4a16Nvfp4Gemm.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmW4A16NVFP4.h"
+#include "tensorrt_llm/thop/thUtils.h"
+
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/extension.h>
+
+using torch::Tensor;
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace torch_ext
+{
+namespace
+{
+
+void checkActDtype(Tensor const& act)
+{
+    TORCH_CHECK(act.scalar_type() == torch::kFloat16 || act.scalar_type() == torch::kBFloat16,
+        "w4a16_nvfp4_gemm only supports FP16/BF16 activations, got ", act.scalar_type());
+}
+
+void w4a16Nvfp4GemmCaller(
+    Tensor& out, Tensor const& act, Tensor const& weight, Tensor const& weightScale, Tensor const& weightScale2)
+{
+    auto const m = static_cast<int32_t>(act.sizes()[0]);
+    auto const k = static_cast<int32_t>(act.sizes()[1]);
+    auto const n = static_cast<int32_t>(weight.sizes()[0]);
+    TORCH_CHECK(weight.sizes()[1] * 2 == k, "weight shape [N, K/2] must match activation shape [M, K]");
+
+    auto stream = at::cuda::getCurrentCUDAStream(act.get_device());
+
+    auto* actPtr = static_cast<void const*>(act.data_ptr());
+    auto* weightPtr = static_cast<void const*>(weight.data_ptr());
+    auto* weightScalePtr = static_cast<void const*>(weightScale.data_ptr());
+    auto* weightScale2Ptr = static_cast<float const*>(weightScale2.data_ptr());
+    auto* outPtr = static_cast<void*>(out.data_ptr());
+
+    auto const inputType = convert_torch_dtype(act.scalar_type());
+    auto const outType = convert_torch_dtype(out.scalar_type());
+
+    tensorrt_llm::kernels::cuda_core_gemm_w4a16_nvfp4::Params params(
+        actPtr, weightPtr, weightScalePtr, weightScale2Ptr, outPtr, m, n, k, inputType, outType);
+    bool const dispatched = tensorrt_llm::kernels::cuda_core_gemm_w4a16_nvfp4::cudaCoreGemmDispatcher(params, stream);
+    TORCH_CHECK(dispatched, "Failed to dispatch w4a16_nvfp4_gemm CUDA-core kernel");
+}
+
+} // namespace
+
+Tensor& w4a16_nvfp4_gemm_out(Tensor const& act, Tensor const& weight, Tensor const& weightScale,
+    Tensor const& weightScale2, std::optional<c10::ScalarType> outDtype, std::optional<Tensor> const& bias, Tensor& out)
+{
+    CHECK_TH_CUDA(act);
+    CHECK_CONTIGUOUS(act);
+    checkActDtype(act);
+    CHECK_INPUT(weight, FLOAT4_E2M1X2);
+    CHECK_INPUT(weightScale, SF_DTYPE);
+    CHECK_INPUT(weightScale2, torch::kFloat32);
+    CHECK_TH_CUDA(out);
+    CHECK_CONTIGUOUS(out);
+
+    TORCH_CHECK(act.dim() == 2 && weight.dim() == 2 && out.dim() == 2);
+    TORCH_CHECK(act.sizes()[0] == out.sizes()[0]);
+    TORCH_CHECK(weight.sizes()[0] == out.sizes()[1]);
+    TORCH_CHECK(weight.sizes()[1] * 2 == act.sizes()[1]);
+    TORCH_CHECK(weightScale2.numel() == 1, "weight_scale_2 must be a scalar tensor");
+    TORCH_CHECK(!bias.has_value(), "w4a16_nvfp4_gemm does not support bias");
+    TORCH_CHECK(!outDtype.has_value() || out.scalar_type() == outDtype.value());
+
+    w4a16Nvfp4GemmCaller(out, act, weight, weightScale, weightScale2);
+    return out;
+}
+
+Tensor w4a16_nvfp4_gemm(Tensor const& act, Tensor const& weight, Tensor const& weightScale, Tensor const& weightScale2,
+    std::optional<c10::ScalarType> outDtype, std::optional<Tensor> const& bias)
+{
+    TORCH_CHECK(act.dim() == 2 && weight.dim() == 2);
+    auto const outDtypeValue = outDtype.value_or(act.scalar_type());
+    std::vector<int64_t> outputSize = {act.sizes()[0], weight.sizes()[0]};
+    Tensor out = at::empty(outputSize, act.options().dtype(outDtypeValue));
+    return w4a16_nvfp4_gemm_out(act, weight, weightScale, weightScale2, outDtype, bias, out);
+}
+
+} // namespace torch_ext
+
+TRTLLM_NAMESPACE_END
+
+TORCH_LIBRARY_FRAGMENT(trtllm, m)
+{
+    m.def(
+        "w4a16_nvfp4_gemm(Tensor act, Tensor weight, Tensor weight_scale, Tensor weight_scale_2, ScalarType? "
+        "out_dtype, Tensor? bias=None) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
+{
+    m.impl("w4a16_nvfp4_gemm", &tensorrt_llm::torch_ext::w4a16_nvfp4_gemm);
+}

--- a/cpp/tensorrt_llm/thop/w4a16Nvfp4Gemm.cpp
+++ b/cpp/tensorrt_llm/thop/w4a16Nvfp4Gemm.cpp
@@ -15,10 +15,14 @@
  */
 
 #include "tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmW4A16NVFP4.h"
+#include "tensorrt_llm/kernels/weightOnlyBatchedGemv/cutlassGemmW4A16NVFP4.h"
+#include "tensorrt_llm/kernels/weightOnlyBatchedGemv/nvfp4ScaleLayout.h"
 #include "tensorrt_llm/thop/thUtils.h"
 
 #include <ATen/cuda/CUDAContext.h>
 #include <torch/extension.h>
+
+#include <algorithm>
 
 using torch::Tensor;
 
@@ -35,9 +39,36 @@ void checkActDtype(Tensor const& act)
         "w4a16_nvfp4_gemm only supports FP16/BF16 activations, got ", act.scalar_type());
 }
 
+int64_t padUp(int64_t value, int64_t alignment)
+{
+    return ((value + alignment - 1) / alignment) * alignment;
+}
+
+size_t getCudaDataTypeSize(cudaDataType_t dataType)
+{
+    switch (dataType)
+    {
+    case CUDA_R_16F:
+    case CUDA_R_16BF: return 2;
+    case CUDA_R_32F: return 4;
+    default: return 0;
+    }
+}
+
+void checkWeightScaleSize(Tensor const& weightScale, int64_t n, int64_t k)
+{
+    using namespace tensorrt_llm::kernels::w4a16_nvfp4;
+    TORCH_CHECK(
+        k % kScaleGranularity == 0, "K must be divisible by ", kScaleGranularity, " for W4A16 NVFP4 GEMM, got K=", k);
+    int64_t const expectedNumel = padUp(n, kScaleRowsPerTile) * padUp(k / kScaleGranularity, kPackedScaleColsPerTile);
+    TORCH_CHECK(weightScale.numel() >= expectedNumel, "weight_scale has too few elements for W4A16 NVFP4 GEMM: got ",
+        weightScale.numel(), ", expected at least ", expectedNumel, " for N=", n, " K=", k);
+}
+
 void w4a16Nvfp4GemmCaller(
     Tensor& out, Tensor const& act, Tensor const& weight, Tensor const& weightScale, Tensor const& weightScale2)
 {
+    constexpr int32_t kCudaCoreMaxM = 16;
     auto const m = static_cast<int32_t>(act.sizes()[0]);
     auto const k = static_cast<int32_t>(act.sizes()[1]);
     auto const n = static_cast<int32_t>(weight.sizes()[0]);
@@ -56,8 +87,53 @@ void w4a16Nvfp4GemmCaller(
 
     tensorrt_llm::kernels::cuda_core_gemm_w4a16_nvfp4::Params params(
         actPtr, weightPtr, weightScalePtr, weightScale2Ptr, outPtr, m, n, k, inputType, outType);
-    bool const dispatched = tensorrt_llm::kernels::cuda_core_gemm_w4a16_nvfp4::cudaCoreGemmDispatcher(params, stream);
-    TORCH_CHECK(dispatched, "Failed to dispatch w4a16_nvfp4_gemm CUDA-core kernel");
+    bool dispatched = false;
+    if (m <= kCudaCoreMaxM)
+    {
+        dispatched = tensorrt_llm::kernels::cuda_core_gemm_w4a16_nvfp4::cudaCoreGemmDispatcher(params, stream);
+    }
+    else
+    {
+        size_t const inputElementSize = getCudaDataTypeSize(inputType);
+        size_t const outputElementSize = getCudaDataTypeSize(outType);
+        dispatched = inputElementSize != 0 && outputElementSize != 0;
+        for (int32_t start = 0; dispatched && start < m; start += kCudaCoreMaxM)
+        {
+            int32_t const chunkM = std::min(kCudaCoreMaxM, m - start);
+            auto const* chunkActPtr
+                = static_cast<char const*>(actPtr) + static_cast<size_t>(start) * k * inputElementSize;
+            auto* chunkOutPtr = static_cast<char*>(outPtr) + static_cast<size_t>(start) * n * outputElementSize;
+            tensorrt_llm::kernels::cuda_core_gemm_w4a16_nvfp4::Params chunkParams(
+                chunkActPtr, weightPtr, weightScalePtr, weightScale2Ptr, chunkOutPtr, chunkM, n, k, inputType, outType);
+            dispatched = tensorrt_llm::kernels::cuda_core_gemm_w4a16_nvfp4::cudaCoreGemmDispatcher(chunkParams, stream);
+        }
+    }
+    TORCH_CHECK(dispatched, "Failed to dispatch w4a16_nvfp4_gemm kernel");
+}
+
+void w4a16Nvfp4CutlassGemmCaller(
+    Tensor& out, Tensor const& act, Tensor const& weight, Tensor const& weightScale, Tensor const& weightScale2)
+{
+    auto const m = static_cast<int32_t>(act.sizes()[0]);
+    auto const k = static_cast<int32_t>(act.sizes()[1]);
+    auto const n = static_cast<int32_t>(weight.sizes()[0]);
+    TORCH_CHECK(weight.sizes()[1] * 2 == k, "weight shape [N, K/2] must match activation shape [M, K]");
+
+    auto stream = at::cuda::getCurrentCUDAStream(act.get_device());
+
+    auto* actPtr = static_cast<void const*>(act.data_ptr());
+    auto* weightPtr = static_cast<void const*>(weight.data_ptr());
+    auto* weightScalePtr = static_cast<void const*>(weightScale.data_ptr());
+    auto* weightScale2Ptr = static_cast<float const*>(weightScale2.data_ptr());
+    auto* outPtr = static_cast<void*>(out.data_ptr());
+
+    auto const inputType = convert_torch_dtype(act.scalar_type());
+    auto const outType = convert_torch_dtype(out.scalar_type());
+
+    tensorrt_llm::kernels::cutlass_gemm_w4a16_nvfp4::Params params(
+        actPtr, weightPtr, weightScalePtr, weightScale2Ptr, outPtr, m, n, k, inputType, outType);
+    bool const dispatched = tensorrt_llm::kernels::cutlass_gemm_w4a16_nvfp4::cutlassGemmDispatcher(params, stream);
+    TORCH_CHECK(dispatched, "Failed to dispatch w4a16_nvfp4_cutlass_gemm kernel");
 }
 
 } // namespace
@@ -78,6 +154,7 @@ Tensor& w4a16_nvfp4_gemm_out(Tensor const& act, Tensor const& weight, Tensor con
     TORCH_CHECK(act.sizes()[0] == out.sizes()[0]);
     TORCH_CHECK(weight.sizes()[0] == out.sizes()[1]);
     TORCH_CHECK(weight.sizes()[1] * 2 == act.sizes()[1]);
+    checkWeightScaleSize(weightScale, weight.sizes()[0], act.sizes()[1]);
     TORCH_CHECK(weightScale2.numel() == 1, "weight_scale_2 must be a scalar tensor");
     TORCH_CHECK(!bias.has_value(), "w4a16_nvfp4_gemm does not support bias");
     TORCH_CHECK(!outDtype.has_value() || out.scalar_type() == outDtype.value());
@@ -96,6 +173,29 @@ Tensor w4a16_nvfp4_gemm(Tensor const& act, Tensor const& weight, Tensor const& w
     return w4a16_nvfp4_gemm_out(act, weight, weightScale, weightScale2, outDtype, bias, out);
 }
 
+Tensor w4a16_nvfp4_cutlass_gemm(Tensor const& act, Tensor const& weight, Tensor const& weightScale,
+    Tensor const& weightScale2, std::optional<c10::ScalarType> outDtype, std::optional<Tensor> const& bias)
+{
+    CHECK_TH_CUDA(act);
+    CHECK_CONTIGUOUS(act);
+    checkActDtype(act);
+    CHECK_INPUT(weight, FLOAT4_E2M1X2);
+    CHECK_INPUT(weightScale, SF_DTYPE);
+    CHECK_INPUT(weightScale2, torch::kFloat32);
+
+    TORCH_CHECK(act.dim() == 2 && weight.dim() == 2);
+    TORCH_CHECK(weight.sizes()[1] * 2 == act.sizes()[1]);
+    checkWeightScaleSize(weightScale, weight.sizes()[0], act.sizes()[1]);
+    TORCH_CHECK(weightScale2.numel() == 1, "weight_scale_2 must be a scalar tensor");
+    TORCH_CHECK(!bias.has_value(), "w4a16_nvfp4_cutlass_gemm does not support bias");
+
+    auto const outDtypeValue = outDtype.value_or(act.scalar_type());
+    std::vector<int64_t> outputSize = {act.sizes()[0], weight.sizes()[0]};
+    Tensor out = at::empty(outputSize, act.options().dtype(outDtypeValue));
+    w4a16Nvfp4CutlassGemmCaller(out, act, weight, weightScale, weightScale2);
+    return out;
+}
+
 } // namespace torch_ext
 
 TRTLLM_NAMESPACE_END
@@ -105,9 +205,13 @@ TORCH_LIBRARY_FRAGMENT(trtllm, m)
     m.def(
         "w4a16_nvfp4_gemm(Tensor act, Tensor weight, Tensor weight_scale, Tensor weight_scale_2, ScalarType? "
         "out_dtype, Tensor? bias=None) -> Tensor");
+    m.def(
+        "w4a16_nvfp4_cutlass_gemm(Tensor act, Tensor weight, Tensor weight_scale, Tensor weight_scale_2, ScalarType? "
+        "out_dtype, Tensor? bias=None) -> Tensor");
 }
 
 TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
 {
     m.impl("w4a16_nvfp4_gemm", &tensorrt_llm::torch_ext::w4a16_nvfp4_gemm);
+    m.impl("w4a16_nvfp4_cutlass_gemm", &tensorrt_llm::torch_ext::w4a16_nvfp4_cutlass_gemm);
 }

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -1054,6 +1054,16 @@ def _register_fake():
         del weight_scale, weight_scale_2, bias
         return act.new_empty((act.shape[0], weight.shape[0]), dtype=out_dtype)
 
+    @torch.library.register_fake("trtllm::w4a16_nvfp4_cutlass_gemm")
+    def _(act: torch.Tensor,
+          weight: torch.Tensor,
+          weight_scale: torch.Tensor,
+          weight_scale_2: torch.Tensor,
+          out_dtype: Optional[torch.dtype],
+          bias: Optional[torch.Tensor] = None):
+        del weight_scale, weight_scale_2, bias
+        return act.new_empty((act.shape[0], weight.shape[0]), dtype=out_dtype)
+
     @torch.library.register_fake("trtllm::mla_rope_generation")
     def _(
         fused_q: torch.Tensor,

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -1044,6 +1044,16 @@ def _register_fake():
         n = mat_b.shape[0]
         return mat_a.new_empty((m, n), dtype=out_dtype)
 
+    @torch.library.register_fake("trtllm::w4a16_nvfp4_gemm")
+    def _(act: torch.Tensor,
+          weight: torch.Tensor,
+          weight_scale: torch.Tensor,
+          weight_scale_2: torch.Tensor,
+          out_dtype: Optional[torch.dtype],
+          bias: Optional[torch.Tensor] = None):
+        del weight_scale, weight_scale_2, bias
+        return act.new_empty((act.shape[0], weight.shape[0]), dtype=out_dtype)
+
     @torch.library.register_fake("trtllm::mla_rope_generation")
     def _(
         fused_q: torch.Tensor,

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -312,6 +312,22 @@ class ModelConfig(Generic[TConfig]):
 
         return "CUTLASS"
 
+    def resolve_moe_backend_after_quant_config(
+            moe_backend: str, architecture: str,
+            quant_config: QuantConfig) -> str:
+        """Resolve AUTO moe_backend after quantization metadata is known."""
+        if moe_backend.upper() != "AUTO":
+            return moe_backend
+
+        is_nemotron_h = architecture in ("NemotronHForCausalLM",
+                                         "NemotronHPuzzleForCausalLM")
+        is_w4a16_nvfp4 = quant_config.quant_algo in (QuantAlgo.W4A16_NVFP4,
+                                                     "W4A16_NVFP4")
+        if is_nemotron_h and is_w4a16_nvfp4 and get_sm_version() in (120, 121):
+            return "FLASHINFER_NVFP4SM12X"
+
+        return ModelConfig.resolve_moe_backend(moe_backend, architecture)
+
     @staticmethod
     def load_modelopt_quant_config(quant_config_file, checkpoint_dir,
                                    moe_backend, hf_quant_config=None):
@@ -692,6 +708,11 @@ class ModelConfig(Generic[TConfig]):
         quant_config = QuantConfig()
         layer_quant_config = None
         requested_moe_backend = kwargs.get('moe_backend', 'AUTO')
+<<<<<<< HEAD
+=======
+        moe_backend = requested_moe_backend
+        # Resolve AUTO to specific backend based on model architecture
+>>>>>>> ff309a699b (fix cuda core w4a16)
         architecture = pretrained_config.architectures[
             0] if pretrained_config.architectures else ""
         # Use an architecture-only backend hint for quant config parsing. Some
@@ -735,6 +756,9 @@ class ModelConfig(Generic[TConfig]):
             architecture,
             quant_config=quant_config,
         )
+
+        kwargs['moe_backend'] = cls.resolve_moe_backend_after_quant_config(
+            requested_moe_backend, architecture, quant_config)
 
         model_config = cls(pretrained_config=pretrained_config,
                            quant_config=quant_config,

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -23,8 +23,8 @@ from tensorrt_llm.llmapi.llm_args import (DeepSeekSparseAttentionConfig,
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantConfig
-from tensorrt_llm.models.quant_config_utils import \
-    update_quant_config_from_compressed_tensors, is_w4a16_nvfp4_hf_quant_config
+from tensorrt_llm.models.quant_config_utils import (
+    is_w4a16_nvfp4_hf_quant_config, update_quant_config_from_compressed_tensors)
 from tensorrt_llm.quantization.mode import QuantAlgo
 from tensorrt_llm.quantization.modelopt_config import (
     is_modelopt_quant_config, read_modelopt_quant_config,
@@ -366,8 +366,8 @@ class ModelConfig(Generic[TConfig]):
         if 'pre_quant_scale' in json_quant_configs:
             quant_config.pre_quant_scale = json_quant_configs['pre_quant_scale']
 
-        if (quant_config.quant_algo in (QuantAlgo.NVFP4, "NVFP4") and
-                is_w4a16_nvfp4_hf_quant_config(hf_quant_config)):
+        if (quant_config.quant_algo in (QuantAlgo.NVFP4, "NVFP4")
+                and is_w4a16_nvfp4_hf_quant_config(hf_quant_config)):
             quant_config.quant_algo = QuantAlgo.W4A16_NVFP4
             quant_config.group_size = 16
             quant_config.exclude_modules = hf_quant_config.get(

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -24,7 +24,7 @@ from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantConfig
 from tensorrt_llm.models.quant_config_utils import \
-    update_quant_config_from_compressed_tensors
+    update_quant_config_from_compressed_tensors, is_w4a16_nvfp4_hf_quant_config
 from tensorrt_llm.quantization.mode import QuantAlgo
 from tensorrt_llm.quantization.modelopt_config import (
     is_modelopt_quant_config, read_modelopt_quant_config,
@@ -314,16 +314,16 @@ class ModelConfig(Generic[TConfig]):
 
     @staticmethod
     def load_modelopt_quant_config(quant_config_file, checkpoint_dir,
-                                   moe_backend):
+                                   moe_backend, hf_quant_config=None):
         with open(quant_config_file) as f:
             quant_config_dict = json.load(f)
         return ModelConfig._build_modelopt_quant_config(
             read_modelopt_quant_config(quant_config_dict), checkpoint_dir,
-            moe_backend)
+            moe_backend, hf_quant_config)
 
     @staticmethod
     def _build_modelopt_quant_config(json_quant_configs, checkpoint_dir,
-                                     moe_backend):
+                                     moe_backend, hf_quant_config=None):
         """Build (quant_config, layer_quant_config) from a normalized modelopt 'quantization' inner dict.
 
         ``json_quant_configs`` should be a dict as produced by
@@ -347,6 +347,13 @@ class ModelConfig(Generic[TConfig]):
             quant_config.has_zero_point = json_quant_configs['has_zero_point']
         if 'pre_quant_scale' in json_quant_configs:
             quant_config.pre_quant_scale = json_quant_configs['pre_quant_scale']
+
+        if (quant_config.quant_algo in (QuantAlgo.NVFP4, "NVFP4") and
+                is_w4a16_nvfp4_hf_quant_config(hf_quant_config)):
+            quant_config.quant_algo = QuantAlgo.W4A16_NVFP4
+            quant_config.group_size = 16
+            quant_config.exclude_modules = hf_quant_config.get(
+                "ignore", quant_config.exclude_modules)
 
         if quant_config.quant_algo == QuantAlgo.MIXED_PRECISION:
             json_extended_quant_configs: dict = {}
@@ -536,6 +543,7 @@ class ModelConfig(Generic[TConfig]):
         new_algo = os.environ.get("OVERRIDE_QUANT_ALGO", None)
         supported_algos = {
             "W4A16_MXFP4": QuantAlgo.W4A16_MXFP4,
+            "W4A16_NVFP4": QuantAlgo.W4A16_NVFP4,
             "W4A8_MXFP4_MXFP8": QuantAlgo.W4A8_MXFP4_MXFP8,
             "W4A8_MXFP4_FP8": QuantAlgo.W4A8_MXFP4_FP8,
         }
@@ -692,6 +700,9 @@ class ModelConfig(Generic[TConfig]):
         moe_backend_hint = cls.resolve_moe_backend(requested_moe_backend,
                                                    architecture)
 
+        hf_quant_config = getattr(pretrained_config, "quantization_config",
+                                  None)
+
         # quantized ckpt in modelopt format
         if quant_config_file := cached_file(checkpoint_dir,
                                             'hf_quant_config.json'):
@@ -706,7 +717,7 @@ class ModelConfig(Generic[TConfig]):
                 source_file="hf_quant_config.json",
             )
             quant_config, layer_quant_config = cls._build_modelopt_quant_config(
-                normalized, checkpoint_dir, moe_backend_hint)
+                normalized, checkpoint_dir, moe_backend_hint, hf_quant_config=hf_quant_config)
         # quantized ckpt in other formats
         elif getattr(pretrained_config, "quantization_config",
                      None) is not None:

--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -319,18 +319,18 @@ class ModelConfig(Generic[TConfig]):
         if moe_backend.upper() != "AUTO":
             return moe_backend
 
-        is_nemotron_h = architecture in ("NemotronHForCausalLM",
-                                         "NemotronHPuzzleForCausalLM")
         is_w4a16_nvfp4 = quant_config.quant_algo in (QuantAlgo.W4A16_NVFP4,
                                                      "W4A16_NVFP4")
-        if is_nemotron_h and is_w4a16_nvfp4 and get_sm_version() in (120, 121):
-            return "FLASHINFER_NVFP4SM12X"
+        if is_w4a16_nvfp4 and get_sm_version() in (120, 121):
+            return "CUTEDSL"
 
         return ModelConfig.resolve_moe_backend(moe_backend, architecture)
 
     @staticmethod
-    def load_modelopt_quant_config(quant_config_file, checkpoint_dir,
-                                   moe_backend, hf_quant_config=None):
+    def load_modelopt_quant_config(quant_config_file,
+                                   checkpoint_dir,
+                                   moe_backend,
+                                   hf_quant_config=None):
         with open(quant_config_file) as f:
             quant_config_dict = json.load(f)
         return ModelConfig._build_modelopt_quant_config(
@@ -338,8 +338,10 @@ class ModelConfig(Generic[TConfig]):
             moe_backend, hf_quant_config)
 
     @staticmethod
-    def _build_modelopt_quant_config(json_quant_configs, checkpoint_dir,
-                                     moe_backend, hf_quant_config=None):
+    def _build_modelopt_quant_config(json_quant_configs,
+                                     checkpoint_dir,
+                                     moe_backend,
+                                     hf_quant_config=None):
         """Build (quant_config, layer_quant_config) from a normalized modelopt 'quantization' inner dict.
 
         ``json_quant_configs`` should be a dict as produced by
@@ -708,11 +710,6 @@ class ModelConfig(Generic[TConfig]):
         quant_config = QuantConfig()
         layer_quant_config = None
         requested_moe_backend = kwargs.get('moe_backend', 'AUTO')
-<<<<<<< HEAD
-=======
-        moe_backend = requested_moe_backend
-        # Resolve AUTO to specific backend based on model architecture
->>>>>>> ff309a699b (fix cuda core w4a16)
         architecture = pretrained_config.architectures[
             0] if pretrained_config.architectures else ""
         # Use an architecture-only backend hint for quant config parsing. Some
@@ -738,7 +735,10 @@ class ModelConfig(Generic[TConfig]):
                 source_file="hf_quant_config.json",
             )
             quant_config, layer_quant_config = cls._build_modelopt_quant_config(
-                normalized, checkpoint_dir, moe_backend_hint, hf_quant_config=hf_quant_config)
+                normalized,
+                checkpoint_dir,
+                moe_backend_hint,
+                hf_quant_config=hf_quant_config)
         # quantized ckpt in other formats
         elif getattr(pretrained_config, "quantization_config",
                      None) is not None:
@@ -750,12 +750,6 @@ class ModelConfig(Generic[TConfig]):
         elif quant_config_file := cached_file(checkpoint_dir, 'dtypes.json'):
             quant_config, layer_quant_config = cls.load_quant_config_from_dtypes_json(
                 quant_config_file, moe_backend_hint)
-
-        kwargs['moe_backend'] = cls.resolve_moe_backend(
-            requested_moe_backend,
-            architecture,
-            quant_config=quant_config,
-        )
 
         kwargs['moe_backend'] = cls.resolve_moe_backend_after_quant_config(
             requested_moe_backend, architecture, quant_config)

--- a/tensorrt_llm/_torch/models/checkpoints/hf/nemotron_h_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/nemotron_h_weight_mapper.py
@@ -5,6 +5,7 @@ from tensorrt_llm._torch.models.checkpoints.hf.weight_mapper import \
     HfWeightMapper
 from tensorrt_llm._torch.models.modeling_utils import register_mapper
 from tensorrt_llm._torch.utils import split
+from tensorrt_llm.quantization.mode import QuantAlgo
 
 
 @register_mapper("HF", "NemotronHPuzzleForCausalLM")
@@ -40,10 +41,23 @@ class NemotronHHfWeightMapper(HfWeightMapper):
             w = torch.concat(w).contiguous()
             return w
 
-        is_nvfp4 = self.config.quant_config.quant_algo == "NVFP4"
+        quant_algo = getattr(self.config.quant_config, "quant_algo", None)
+        is_nvfp4 = quant_algo in (QuantAlgo.NVFP4, QuantAlgo.W4A16_NVFP4,
+                                  "NVFP4", "W4A16_NVFP4")
         n_groups = config.n_groups
         d_state = config.ssm_state_size
         nheads = config.mamba_num_heads
+
+        def _canonicalize_quant_key(key: str) -> str:
+            replacements = {
+                ".weight_packed": ".weight",
+                ".weight_global_scale": ".weight_scale_2",
+                ".input_global_scale": ".input_scale_2",
+            }
+            for suffix, replacement in replacements.items():
+                if key.endswith(suffix):
+                    return f"{key[:-len(suffix)]}{replacement}"
+            return key
 
         new_weights = {}
         for name, _ in weights.items():
@@ -69,6 +83,8 @@ class NemotronHHfWeightMapper(HfWeightMapper):
 
             if "A_log" in key:
                 key = key.replace("A_log", "A")
+
+            key = _canonicalize_quant_key(key)
 
             if ("mixer.in_proj" in key
                     or "mixer.out_proj" in key) and "_scale" in key:

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -31,6 +31,7 @@ from tensorrt_llm._torch.utils import ActivationType, relu2
 from tensorrt_llm._utils import get_sm_version
 from tensorrt_llm.logger import logger
 from tensorrt_llm.lora_helper import LoraConfig
+from tensorrt_llm.quantization.mode import QuantAlgo
 
 from ..attention_backend import AttentionMetadata
 from ..distributed import AllReduce, AllReduceFusionOp, AllReduceParams
@@ -155,6 +156,28 @@ class TransformerLayer(Attention):
                                **kwargs)
 
 
+def _get_nemotron_h_moe_model_config(
+        model_config: ModelConfig[PretrainedConfig],
+        layer_idx: int) -> ModelConfig[PretrainedConfig]:
+    # Per-expert mixed precision config is more specific than the global config.
+    if model_config.quant_config_dict is not None:
+        experts_prefix = f"model.layers.{layer_idx}.mixer.experts."
+        for key, cfg in model_config.quant_config_dict.items():
+            if key.startswith(experts_prefix):
+                return replace(model_config, quant_config=cfg)
+
+    quant_config = model_config.quant_config
+    if (quant_config is not None and quant_config.quant_algo
+            in (QuantAlgo.W4A16_NVFP4, "W4A16_NVFP4")):
+        moe_quant_config = quant_config.model_copy(deep=True)
+        moe_quant_config.quant_algo = QuantAlgo.NVFP4
+        moe_quant_config.__dict__.pop("quant_mode", None)
+        moe_quant_config.__dict__.pop("layer_quant_mode", None)
+        return replace(model_config, quant_config=moe_quant_config)
+
+    return model_config
+
+
 # Ref code: https://huggingface.co/nvidia/Nemotron-Nano-3-30B-A3.5B-dev-1024/blob/main/modeling_nemotron_h.py#L818
 class NemotronHMOE(nn.Module):
 
@@ -240,18 +263,8 @@ class NemotronHMOE(nn.Module):
             moe_backend=model_config.moe_backend,
         )
 
-        # For MIXED_PRECISION models, the global quant_config has quant_algo=MIXED_PRECISION
-        # which maps to QuantMode(0) (no quant). This would cause the MoE backend to select
-        # UnquantizedFusedMoEMethod and allocate BF16 weight buffers, causing a shape mismatch
-        # when loading NVFP4/W4A8_NVFP4_FP8 quantized expert weights.
-        # Look up the per-expert quant config from quant_config_dict and use it for create_moe.
-        moe_model_config = model_config
-        if model_config.quant_config_dict is not None:
-            experts_prefix = f"model.layers.{layer_idx}.mixer.experts."
-            for key, cfg in model_config.quant_config_dict.items():
-                if key.startswith(experts_prefix):
-                    moe_model_config = replace(model_config, quant_config=cfg)
-                    break
+        moe_model_config = _get_nemotron_h_moe_model_config(
+            model_config, layer_idx)
 
         # Setup MoE experts.
         self.experts = create_moe(
@@ -1117,14 +1130,16 @@ class NemotronHMTP(nn.Module):
                                        layer_idx: int):
         """
         Get quantization config for MTP sublayer.
-        The MTP layer in the nvfp4 checkpoint is unquantized. Because the TRTLLM
-        moe_backend only supports fp8/fp4 quantization, we need to override
-        the quant_config for the MTP layer.
+        The Nano3.5 NVFP4 W4A16 checkpoint stores the MTP body tensors in BF16.
+        The shared MTP head still receives the checkpoint-backed lm_head, so its
+        logits path keeps the lm_head precision instead of inheriting this
+        sublayer override.
         """
         from tensorrt_llm.models.modeling_utils import QuantConfig
 
         quant_config = model_config.quant_config
-        # MTP layers are always unquantized, force quant_algo=None
+        # This checkpoint's MTP body is unquantized, so force quant_algo=None
+        # only for the MTP sublayers constructed here.
         if quant_config is None:
             return None
         return QuantConfig(

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -168,7 +168,8 @@ def _get_nemotron_h_moe_model_config(
 
     quant_config = model_config.quant_config
     if (quant_config is not None and quant_config.quant_algo
-            in (QuantAlgo.W4A16_NVFP4, "W4A16_NVFP4")):
+            in (QuantAlgo.W4A16_NVFP4, "W4A16_NVFP4")
+            and model_config.moe_backend.upper() != "FLASHINFER_NVFP4SM12X"):
         moe_quant_config = quant_config.model_copy(deep=True)
         moe_quant_config.quant_algo = QuantAlgo.NVFP4
         moe_quant_config.__dict__.pop("quant_mode", None)
@@ -1103,14 +1104,20 @@ class NemotronHMTP(nn.Module):
 
             sublayer_quant_config = self._get_mtp_sublayer_quant_config(
                 model_config, self.layer_idx)
+            sublayer_moe_backend = model_config.moe_backend
+            if (sublayer_quant_config is None
+                    or sublayer_quant_config.quant_algo is None):
+                sublayer_moe_backend = "CUTLASS"
 
             # Create a model_config copy with quant_config overridden and
             # spec_config cleared. All other fields (use_cuda_graph,
-            # moe_backend, moe_max_num_tokens, etc.) must be inherited
-            # so MoE layers are configured correctly for CUDA graph
-            # capture and communication (e.g., DeepEP).
+            # moe_max_num_tokens, etc.) must be inherited so MoE layers are
+            # configured correctly for CUDA graph capture and communication
+            # (e.g., DeepEP). BF16 MTP body layers cannot use the NVFP4-only
+            # FlashInfer MoE backend, so route those sublayers to CUTLASS.
             sublayer_model_config = replace(model_config,
                                             quant_config=sublayer_quant_config,
+                                            moe_backend=sublayer_moe_backend,
                                             spec_config=None)
 
             self.layers[str(step_rel_idx)] = NemotronHMTPDecoderLayer(

--- a/tensorrt_llm/_torch/models/modeling_nemotron_h.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_h.py
@@ -169,7 +169,7 @@ def _get_nemotron_h_moe_model_config(
     quant_config = model_config.quant_config
     if (quant_config is not None and quant_config.quant_algo
             in (QuantAlgo.W4A16_NVFP4, "W4A16_NVFP4")
-            and model_config.moe_backend.upper() != "FLASHINFER_NVFP4SM12X"):
+            and model_config.moe_backend.upper() != "CUTEDSL"):
         moe_quant_config = quant_config.model_copy(deep=True)
         moe_quant_config.quant_algo = QuantAlgo.NVFP4
         moe_quant_config.__dict__.pop("quant_mode", None)
@@ -1113,8 +1113,8 @@ class NemotronHMTP(nn.Module):
             # spec_config cleared. All other fields (use_cuda_graph,
             # moe_max_num_tokens, etc.) must be inherited so MoE layers are
             # configured correctly for CUDA graph capture and communication
-            # (e.g., DeepEP). BF16 MTP body layers cannot use the NVFP4-only
-            # FlashInfer MoE backend, so route those sublayers to CUTLASS.
+            # (e.g., DeepEP). BF16 MTP body layers cannot use NVFP4-only MoE
+            # backends, so route those sublayers to CUTLASS.
             sublayer_model_config = replace(model_config,
                                             quant_config=sublayer_quant_config,
                                             moe_backend=sublayer_moe_backend,

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -18,6 +18,7 @@ from tensorrt_llm.models.convert_utils import split_matrix_tp
 
 from ...logger import logger
 from ...models.modeling_utils import QuantConfig
+from ...quantization.mode import QuantAlgo
 from ..attention_backend import AttentionMetadata
 from ..distributed.communicator import pp_recv_tensors, pp_send_tensors
 from ..model_config import ModelConfig, TConfig
@@ -368,16 +369,20 @@ class DecoderModelForCausalLM(nn.Module,
         self.pp_rank = config.mapping.pp_rank
         self.pp_size = config.mapping.pp_size
         self.has_custom_lm_head = False
+        lm_head_quant_config = None
+        if (config.quant_config is not None and config.quant_config.quant_algo
+                in (QuantAlgo.W4A16_NVFP4, "W4A16_NVFP4") and not config.
+                quant_config.is_module_excluded_from_quantization("lm_head")):
+            lm_head_quant_config = config.quant_config
 
         if config.mapping.enable_attention_dp and not config.mapping.enable_lm_head_tp_in_adp:
             self.lm_head = LMHead(
                 vocab_size,
                 hidden_size,
                 dtype=config.pretrained_config.torch_dtype,
+                quant_config=lm_head_quant_config,
             )
         else:
-            # TODO(zhenhuanc): Currently lm_head Linear will not accept QuantConfig
-            # will considering per layer QuantConfig in the future.
             if (hasattr(config, 'lora_config')
                     and config.lora_config is not None
                     and len(config.lora_config.lora_dir) == 1):
@@ -399,6 +404,7 @@ class DecoderModelForCausalLM(nn.Module,
                 reduce_output=False,
                 use_custom_cublas_mm=getattr(model, 'use_custom_cublas_mm',
                                              False),
+                quant_config=lm_head_quant_config,
             )
 
             if self.has_custom_lm_head:

--- a/tensorrt_llm/_torch/modules/embedding.py
+++ b/tensorrt_llm/_torch/modules/embedding.py
@@ -9,6 +9,7 @@ from tensorrt_llm.functional import AllReduceParams
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.math_utils import ceil_div
 
+from ...models.modeling_utils import QuantConfig
 from ..distributed import allgather
 from .linear import Linear, TensorParallelMode
 
@@ -22,6 +23,8 @@ class LMHead(Linear):
         dtype (Optional[torch.dtype]): type of the parameters.
         mapping (Optional[Mapping]): parallelism configuration.
             If not provided, the embedding is not parallelized.
+        quant_config (Optional[QuantConfig]): quantization configuration for
+            the lm head projection.
     """
 
     def __init__(
@@ -34,6 +37,7 @@ class LMHead(Linear):
         gather_output: bool = False,
         reduce_output: bool = True,
         use_custom_cublas_mm: bool = False,
+        quant_config: Optional[QuantConfig] = None,
     ):
         local_in_features = embedding_dim
         local_out_features = num_embeddings
@@ -66,6 +70,7 @@ class LMHead(Linear):
             gather_output=gather_output,
             reduce_output=reduce_output,
             use_custom_cublas_mm=use_custom_cublas_mm,
+            quant_config=quant_config,
         )
 
         if tensor_parallel_mode == TensorParallelMode.ROW:
@@ -76,9 +81,10 @@ class LMHead(Linear):
         self.num_embeddings = num_embeddings
         self.embedding_dim = embedding_dim
 
-        weight_shape = (self.out_features, self.in_features)
-        self.weight = Parameter(torch.empty(weight_shape, dtype=dtype))
-        self.register_parameter("bias", None)
+        if not self.has_any_quant:
+            weight_shape = (self.out_features, self.in_features)
+            self.weight = Parameter(torch.empty(weight_shape, dtype=dtype))
+            self.register_parameter("bias", None)
 
     @property
     def vocab_size_padded(self) -> int:
@@ -126,7 +132,7 @@ class LMHead(Linear):
                      weights: List[Dict],
                      allow_partial_loading: bool = False):
         original_weight = None
-        if self.tp_mode == TensorParallelMode.COLUMN:
+        if self.tp_mode == TensorParallelMode.COLUMN and not self.has_any_quant:
             if self.tp_rank == self.tp_size - 1 and self.padding_size > 0:
                 original_weight = self.weight.data.zero_()
                 self.weight.data = self.weight[:-self.padding_size, :]

--- a/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
@@ -43,12 +43,15 @@ def get_moe_cls(
     elif moe_backend.upper() == "CUTEDSL":
         if quant_config is not None and (
                 quant_config.quant_mode.has_fp8_block_scales()
-                or quant_config.quant_mode.has_nvfp4()):
-            # On SM120 / SM121 + NVFP4 the cuteDSL family member is the
+                or quant_config.quant_mode.has_nvfp4()
+                or quant_config.quant_mode.has_w4a16_nvfp4()):
+            # On SM120 / SM121 + NVFP4/W4A16_NVFP4 the cuteDSL family member is the
             # hybrid CUTLASS-prefill / FlashInfer NVFP4 MoE decode backend
             # (CuteDslB12xFusedMoE). Prefer it when flashinfer is importable;
             # otherwise fall through to CuteDslFusedMoE for SM100 / SM103.
-            if quant_config.quant_mode.has_nvfp4():
+            has_nvfp4 = quant_config.quant_mode.has_nvfp4()
+            has_w4a16_nvfp4 = quant_config.quant_mode.has_w4a16_nvfp4()
+            if has_nvfp4 or has_w4a16_nvfp4:
                 from tensorrt_llm._utils import get_sm_version
                 sm_version = get_sm_version()
                 if sm_version in CuteDslB12xFusedMoE._SUPPORTED_SM_VERSIONS:
@@ -64,13 +67,24 @@ def get_moe_cls(
                     except ImportError:
                         logger.warning(
                             "CuteDslB12xFusedMoE eligible (SM%d + NVFP4) "
-                            "but flashinfer is not importable; using CuteDslFusedMoE.",
+                            "but flashinfer is not importable; using %s.",
                             sm_version,
+                            "CutlassFusedMoE"
+                            if has_w4a16_nvfp4 else "CuteDslFusedMoE",
                         )
+                        if has_w4a16_nvfp4:
+                            return CutlassFusedMoE
+                elif has_w4a16_nvfp4:
+                    logger.warning(
+                        "CuteDslB12xFusedMoE requires SM120/121 for W4A16_NVFP4 "
+                        "(got SM%d). Using CutlassFusedMoE.",
+                        sm_version,
+                    )
+                    return CutlassFusedMoE
             return CuteDslFusedMoE
         else:
             logger.warning(
-                f"{layer_prefix}CuteDslFusedMoE only supports fp8_block_scales and nvfp4. "
+                f"{layer_prefix}CuteDslFusedMoE only supports fp8_block_scales, nvfp4, and w4a16_nvfp4. "
                 f"Check out details in quant_config: {quant_config}. Using CutlassFusedMoE instead."
             )
             return CutlassFusedMoE

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cute_dsl_b12x.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cute_dsl_b12x.py
@@ -44,24 +44,25 @@ _ACTIVATION_MAP = {
 
 
 class CuteDslB12xFusedMoE(CuteDslFusedMoE):
-    """Hybrid CUTLASS-prefill / b12x-decode NVFP4 fused-MoE backend for SM120 / SM121.
+    """B12x NVFP4 fused-MoE backend for SM120 / SM121.
 
     Member of the cuteDSL backend family: the decode kernel
     (``flashinfer.B12xMoEWrapper.run``) is JIT-compiled CuTe DSL, so the
     backend slots in next to :class:`CuteDslFusedMoE` (which targets SM100 /
-    SM103). The hybrid prefill path still routes through the C++ CUTLASS
-    NVFP4 GroupGEMM via explicit :class:`CutlassFusedMoE` method calls; the
-    parent class on the MRO does not change which kernels execute, only
-    where the b12x backend sits in the family.
+    SM103). Plain NVFP4 prefill can route through the C++ CUTLASS NVFP4
+    GroupGEMM via explicit :class:`CutlassFusedMoE` method calls; the parent
+    class on the MRO does not change which kernels execute, only where the
+    b12x backend sits in the family.
 
     Composition (see ``MOE_DEVELOPER_GUIDE.md`` for the full explainer):
 
-    - **Prefill (``m >= _PREFILL_VIA_CUTLASS_THRESHOLD``)** explicitly
+    - **NVFP4 prefill (``m >= _PREFILL_VIA_CUTLASS_THRESHOLD``)** explicitly
       invokes :class:`CutlassFusedMoE` NVFP4 GroupGEMM. The b12x kernel's
       12-CTA-per-token MMA pattern is suboptimal at large ``m``.
     - **Decode (``m <  _PREFILL_VIA_CUTLASS_THRESHOLD``)** dispatches to
       FlashInfer's ``B12xMoEWrapper.run`` — a kernel purpose-built for
       ``m=1`` / small routed-row counts.
+    - **W4A16_NVFP4** stays on the b12x path for both prefill and decode.
 
     NVFP4 weights are loaded via :class:`NVFP4CuteDslB12xFusedMoEMethod`
     (an :class:`NVFP4CutlassFusedMoEMethod` subclass returned by
@@ -79,8 +80,9 @@ class CuteDslB12xFusedMoE(CuteDslFusedMoE):
     The backend hard-rejects EP (b12x has no dispatch / combine kernel),
     MoE alltoall, ``Fp4QuantizedTensor`` input, ``swiglu_gptoss_style``
     biased SwiGLU, and activations outside ``{Relu2, Swiglu}``. It is
-    selected on the ``CUTEDSL`` MoE path when SM120 / SM121 + NVFP4 +
-    flashinfer-importable gates pass (see ``create_moe.get_moe_cls``).
+    selected on the ``CUTEDSL`` MoE path when SM120 / SM121 + NVFP4 or
+    W4A16_NVFP4 + flashinfer-importable gates pass (see
+    ``create_moe.get_moe_cls``).
     """
 
     # SM versions on which the FlashInfer b12x NVFP4 MoE kernel is available.
@@ -105,9 +107,9 @@ class CuteDslB12xFusedMoE(CuteDslFusedMoE):
         if sm_version not in cls._SUPPORTED_SM_VERSIONS:
             sm_list = "/".join(f"SM{v}" for v in sorted(cls._SUPPORTED_SM_VERSIONS))
             return _warn_and_return(f"CuteDslB12xFusedMoE requires {sm_list}, got SM{sm_version}")
-        if quant_algo != QuantAlgo.NVFP4:
+        if quant_algo not in {QuantAlgo.NVFP4, QuantAlgo.W4A16_NVFP4}:
             return _warn_and_return(
-                f"CuteDslB12xFusedMoE only supports NVFP4 quantization "
+                f"CuteDslB12xFusedMoE only supports NVFP4 or W4A16_NVFP4 quantization "
                 f"(got quant_algo={quant_algo})"
             )
         if dtype_activation not in {torch.float16, torch.bfloat16}:
@@ -158,7 +160,10 @@ class CuteDslB12xFusedMoE(CuteDslFusedMoE):
         if (
             self.quant_config is not None
             and self.quant_config.layer_quant_mode.has_any_quant(exclude_kv_cache=True)
-            and self.quant_config.layer_quant_mode.has_nvfp4()
+            and (
+                self.quant_config.layer_quant_mode.has_nvfp4()
+                or self.quant_config.layer_quant_mode.has_w4a16_nvfp4()
+            )
         ):
             from .quantization import NVFP4CuteDslB12xFusedMoEMethod
 
@@ -167,9 +172,12 @@ class CuteDslB12xFusedMoE(CuteDslFusedMoE):
 
     def _route_to_cutlass(self, x) -> bool:
         """Return ``True`` iff this call should fall back to the inherited
-        CUTLASS path (prefill chunk). ``Fp4QuantizedTensor`` inputs always
-        stay on the b12x path (which rejects them) so the existing error
-        message is preserved."""
+        CUTLASS path (NVFP4 prefill chunk). ``Fp4QuantizedTensor`` inputs
+        always stay on the b12x path (which rejects them) so the existing
+        error message is preserved."""
+        quant_config = getattr(self, "quant_config", None)
+        if quant_config is not None and quant_config.layer_quant_mode.has_w4a16_nvfp4():
+            return False
         return isinstance(x, torch.Tensor) and x.shape[0] >= self._PREFILL_VIA_CUTLASS_THRESHOLD
 
     # ``post_load_weights`` is inherited from ``CutlassFusedMoE`` and
@@ -190,12 +198,12 @@ class CuteDslB12xFusedMoE(CuteDslFusedMoE):
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
         """Hybrid dispatch entrypoint for activation handling.
 
-        Prefill chunks (``x.shape[0] >= _PREFILL_VIA_CUTLASS_THRESHOLD``) take
-        the inherited :meth:`CutlassFusedMoE.quantize_input` path so the
-        downstream ``run_moe`` can call CUTLASS NVFP4 GroupGEMM. Decode
-        chunks pass through unchanged because b12x quantizes activations
-        internally (consumes a bf16 / fp16 ``x`` and produces its own scale
-        factors).
+        NVFP4 prefill chunks take the inherited
+        :meth:`CutlassFusedMoE.quantize_input` path so the downstream
+        ``run_moe`` can call CUTLASS NVFP4 GroupGEMM. Decode chunks and
+        W4A16_NVFP4 chunks pass through unchanged because b12x quantizes
+        activations internally (consumes a bf16 / fp16 ``x`` and produces its
+        own scale factors).
         """
         if self._route_to_cutlass(x):
             return CutlassFusedMoE.quantize_input(

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
@@ -368,6 +368,7 @@ class CutlassFusedMoE(MoE):
         if self.quant_config and self.quant_config.quant_mode.has_any_quant(
                 exclude_kv_cache=True):
             if not (self.quant_config.quant_mode.has_nvfp4()
+                    | self.quant_config.quant_mode.has_w4a16_nvfp4()
                     | self.quant_config.quant_mode.has_fp8_block_scales()
                     | self.quant_config.quant_mode.has_fp8_qdq()
                     | self.quant_config.quant_mode.is_weight_only()
@@ -531,7 +532,8 @@ class CutlassFusedMoE(MoE):
                 return FP8QDQFusedMoEMethod()
             elif self.quant_config.layer_quant_mode.has_fp8_block_scales():
                 return DeepSeekFP8BlockScalesFusedMoEMethod()
-            elif self.quant_config.layer_quant_mode.has_nvfp4():
+            elif (self.quant_config.layer_quant_mode.has_nvfp4()
+                  or self.quant_config.layer_quant_mode.has_w4a16_nvfp4()):
                 return NVFP4CutlassFusedMoEMethod()
             elif self.quant_config.layer_quant_mode.is_int4_weight_only_per_group(
             ):

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -3020,6 +3020,10 @@ class NVFP4CuteDslB12xFusedMoEMethod(NVFP4CutlassFusedMoEMethod):
         # layers across the model share one wrapper-owned output buffer.
         from .fused_moe_cute_dsl_b12x import _SHARED_MOE_OUTPUT_BUF
 
+        quant_config = getattr(module, "quant_config", None)
+        is_w4a16_nvfp4 = (quant_config is not None
+                          and quant_config.layer_quant_mode.has_w4a16_nvfp4())
+
         num_local_experts = module.w3_w1_weight.shape[0]
         # Tensor shapes use the *padded* per-rank dims because TP partitions
         # may pad ``intermediate_size`` up to a kernel-friendly boundary.
@@ -3069,11 +3073,28 @@ class NVFP4CuteDslB12xFusedMoEMethod(NVFP4CutlassFusedMoEMethod):
                                               k=w2_in_dim,
                                               num_groups=num_local_experts)
 
-        w1_alpha_b12x = ((1.0 / module.fc31_input_scale).expand(
-            module.num_experts).to(torch.float32).contiguous())
-        w2_alpha_b12x = ((1.0 / module.fc2_input_scale).expand(
-            module.num_experts).to(torch.float32).contiguous())
-        fc2_input_scale_b12x = (1.0 / module.fc2_input_scale).to(torch.float32)
+        if is_w4a16_nvfp4:
+            # W4A16 path: BF16/FP16 activations multiplied by FP4 weights.
+            # There is no online activation quantization, so the wrapper uses
+            # ``w*_alpha`` only as FC1/FC2 epilogue dequant multipliers.
+            # Since we still un-normalize FP8 block scales by weight_scale_2
+            # above, alpha is unity. ``fc2_input_scale`` is ignored in this
+            # FlashInfer mode.
+            alpha_device = module.w3_w1_weight.device
+            w1_alpha_b12x = torch.ones(module.num_experts,
+                                       dtype=torch.float32,
+                                       device=alpha_device)
+            w2_alpha_b12x = torch.ones(module.num_experts,
+                                       dtype=torch.float32,
+                                       device=alpha_device)
+            fc2_input_scale_b12x = None
+        else:
+            w1_alpha_b12x = ((1.0 / module.fc31_input_scale).expand(
+                module.num_experts).to(torch.float32).contiguous())
+            w2_alpha_b12x = ((1.0 / module.fc2_input_scale).expand(
+                module.num_experts).to(torch.float32).contiguous())
+            fc2_input_scale_b12x = (1.0 / module.fc2_input_scale).to(
+                torch.float32)
 
         # TRT-LLM packs 16 FP4 values per int64. flashinfer's internal
         # ``view(torch.float4_e2m1fn_x2)`` requires byte-contiguous storage
@@ -3096,14 +3117,21 @@ class NVFP4CuteDslB12xFusedMoEMethod(NVFP4CutlassFusedMoEMethod):
                 f"{ActivationType(module.activation_type).name}; "
                 f"supported: {supported}.")
 
+        # The model config may carry the logical intermediate size while the
+        # NVFP4 weight tensors are padded for kernel alignment, e.g. Nano3.5
+        # uses 1856 logical channels and 1920 stored channels. FlashInfer's
+        # CUDA-graph workspace must match the stored tensors.
+        b12x_intermediate_size = w2_in_dim
+
         module.b12x_wrapper = B12xMoEWrapper(
             num_experts=module.num_experts,
             top_k=module.routing_method.experts_per_token,
             hidden_size=module.hidden_size,
-            intermediate_size=module.intermediate_size_per_partition,
+            intermediate_size=b12x_intermediate_size,
             use_cuda_graph=getattr(module, "_b12x_use_cuda_graph", False),
             max_num_tokens=module.moe_max_num_tokens,
             activation=self._ACTIVATION_MAP[module.activation_type],
+            quant_mode="w4a16" if is_w4a16_nvfp4 else "nvfp4",
         )
 
         # Replace the wrapper's per-instance output buffer with a shared one.
@@ -3124,10 +3152,11 @@ class NVFP4CuteDslB12xFusedMoEMethod(NVFP4CutlassFusedMoEMethod):
 
         logger.info_once(
             f"NVFP4CuteDslB12xFusedMoEMethod active: hidden={module.hidden_size}, "
-            f"intermediate={module.intermediate_size_per_partition}, "
+            f"intermediate={b12x_intermediate_size}, "
             f"experts={module.num_experts}, top_k="
             f"{module.routing_method.experts_per_token}, "
-            f"activation={self._ACTIVATION_MAP[module.activation_type]}.",
+            f"activation={self._ACTIVATION_MAP[module.activation_type]}, "
+            f"quant_mode={'w4a16' if is_w4a16_nvfp4 else 'nvfp4'}.",
             key="cute_dsl_b12x_moe_active",
         )
 

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -3053,16 +3053,20 @@ class NVFP4CuteDslB12xFusedMoEMethod(NVFP4CutlassFusedMoEMethod):
         w2_w_scale_2 = (module.fc2_alpha * module.fc2_input_scale).to(
             torch.float32)
 
-        w1_sf_fp8_norm = module.w3_w1_weight_scale.view(
-            torch.float8_e4m3fn).float()
-        w2_sf_fp8_norm = module.w2_weight_scale.view(
-            torch.float8_e4m3fn).float()
+        w1_sf_fp8_src = module.w3_w1_weight_scale.view(torch.float8_e4m3fn)
+        w2_sf_fp8_src = module.w2_weight_scale.view(torch.float8_e4m3fn)
+        w1_sf_fp8_norm = w1_sf_fp8_src.float()
+        w2_sf_fp8_norm = w2_sf_fp8_src.float()
 
-        # Broadcast per-expert scalar over the trailing dims (E, *).
-        bcast1 = w1_w_scale_2.view(-1, *([1] * (w1_sf_fp8_norm.dim() - 1)))
-        bcast2 = w2_w_scale_2.view(-1, *([1] * (w2_sf_fp8_norm.dim() - 1)))
-        w1_sf_fp8 = (w1_sf_fp8_norm * bcast1).to(torch.float8_e4m3fn)
-        w2_sf_fp8 = (w2_sf_fp8_norm * bcast2).to(torch.float8_e4m3fn)
+        if is_w4a16_nvfp4:
+            w1_sf_fp8 = w1_sf_fp8_src
+            w2_sf_fp8 = w2_sf_fp8_src
+        else:
+            # Broadcast per-expert scalar over the trailing dims (E, *).
+            bcast1 = w1_w_scale_2.view(-1, *([1] * (w1_sf_fp8_norm.dim() - 1)))
+            bcast2 = w2_w_scale_2.view(-1, *([1] * (w2_sf_fp8_norm.dim() - 1)))
+            w1_sf_fp8 = (w1_sf_fp8_norm * bcast1).to(torch.float8_e4m3fn)
+            w2_sf_fp8 = (w2_sf_fp8_norm * bcast2).to(torch.float8_e4m3fn)
 
         w1_sf_b12x = convert_sf_to_mma_layout(w1_sf_fp8,
                                               m=w3w1_out_dim,
@@ -3075,18 +3079,18 @@ class NVFP4CuteDslB12xFusedMoEMethod(NVFP4CutlassFusedMoEMethod):
 
         if is_w4a16_nvfp4:
             # W4A16 path: BF16/FP16 activations multiplied by FP4 weights.
-            # There is no online activation quantization, so the wrapper uses
-            # ``w*_alpha`` only as FC1/FC2 epilogue dequant multipliers.
-            # Since we still un-normalize FP8 block scales by weight_scale_2
-            # above, alpha is unity. ``fc2_input_scale`` is ignored in this
-            # FlashInfer mode.
-            alpha_device = module.w3_w1_weight.device
-            w1_alpha_b12x = torch.ones(module.num_experts,
-                                       dtype=torch.float32,
-                                       device=alpha_device)
-            w2_alpha_b12x = torch.ones(module.num_experts,
-                                       dtype=torch.float32,
-                                       device=alpha_device)
+            # FlashInfer's W4A16 packer expects the ModelOpt scale contract:
+            # normalized FP8 block scales plus per-expert ``weight_global_scale``.
+            # TRT-LLM stores the reciprocal as ``weight_scale_2``; recover the
+            # ModelOpt value from the already computed dequant scale.
+            def _to_modelopt_global_scale(scale: torch.Tensor) -> torch.Tensor:
+                global_scale = torch.zeros_like(scale, dtype=torch.float32)
+                valid = scale > 0
+                global_scale[valid] = scale[valid].reciprocal()
+                return global_scale.contiguous()
+
+            w1_alpha_b12x = _to_modelopt_global_scale(w1_w_scale_2)
+            w2_alpha_b12x = _to_modelopt_global_scale(w2_w_scale_2)
             fc2_input_scale_b12x = None
         else:
             w1_alpha_b12x = ((1.0 / module.fc31_input_scale).expand(

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -1864,6 +1864,25 @@ class NVFP4LinearMethod(LinearMethodBase):
 class W4A16NVFP4LinearMethod(NVFP4LinearMethod):
 
     CUDA_CORE_MAX_M: ClassVar[int] = 16
+    CUTLASS3_ENV: ClassVar[str] = "TRTLLM_W4A16_NVFP4_CUTLASS3"
+
+    def _can_use_cutlass3_w4a16_prefill(self, module: Linear,
+                                        input: torch.Tensor, m: int) -> bool:
+        if os.environ.get(self.CUTLASS3_ENV, "0") != "1":
+            return False
+        if m <= self.CUDA_CORE_MAX_M:
+            return False
+        if get_sm_version() not in (120, 121):
+            return False
+        if input.dtype != torch.bfloat16:
+            return False
+        if module.dtype != torch.bfloat16:
+            return False
+        if input.shape[-1] % 32 != 0:
+            return False
+        if module.weight.shape[0] % 32 != 0:
+            return False
+        return True
 
     def create_weights(self, module: Linear, in_features: int,
                        out_features: int, bias: bool, dtype: torch.dtype):
@@ -1957,8 +1976,8 @@ class W4A16NVFP4LinearMethod(NVFP4LinearMethod):
             m = math.prod(input.shape[:-1])
         else:
             m = input.shape[0]
-        if m > self.CUDA_CORE_MAX_M:
-            return super().apply(module, input, bias)
+        use_cutlass3_prefill = self._can_use_cutlass3_w4a16_prefill(
+            module, input, m)
 
         original_shape = None
         if input.dim() > 2:
@@ -1969,7 +1988,9 @@ class W4A16NVFP4LinearMethod(NVFP4LinearMethod):
             assert input.dtype == module.pre_quant_scale.dtype, "Input dtype and pre_quant_scale dtype must match"
             input = input * module.pre_quant_scale
 
-        output = torch.ops.trtllm.w4a16_nvfp4_gemm(
+        gemm_op = (torch.ops.trtllm.w4a16_nvfp4_cutlass_gemm if
+                   use_cutlass3_prefill else torch.ops.trtllm.w4a16_nvfp4_gemm)
+        output = gemm_op(
             input,
             module.weight,
             module.weight_scale,

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -1863,6 +1863,8 @@ class NVFP4LinearMethod(LinearMethodBase):
 
 class W4A16NVFP4LinearMethod(NVFP4LinearMethod):
 
+    CUDA_CORE_MAX_M: ClassVar[int] = 16
+
     def create_weights(self, module: Linear, in_features: int,
                        out_features: int, bias: bool, dtype: torch.dtype):
         module.scaling_vector_size = 16
@@ -1899,8 +1901,65 @@ class W4A16NVFP4LinearMethod(NVFP4LinearMethod):
         else:
             module.register_parameter("bias", None)
 
+    def _process_weights_without_static_activation_scale(
+            self, module: Linear, process_fn):
+        original_input_scale = module.input_scale
+        original_inv_input_scale = module.inv_input_scale
+        original_alpha = module.alpha
+        had_scalar_alpha = hasattr(module, "scalar_alpha")
+        original_scalar_alpha = getattr(module, "scalar_alpha", None)
+
+        device = module.weight_scale_2.device
+        module.input_scale = Parameter(torch.empty([1],
+                                                   dtype=torch.float32,
+                                                   device=device),
+                                       requires_grad=False)
+        module.inv_input_scale = Parameter(torch.empty([1],
+                                                       dtype=torch.float32,
+                                                       device=device),
+                                           requires_grad=False)
+        module.alpha = Parameter(torch.empty([1],
+                                             dtype=torch.float32,
+                                             device=device),
+                                 requires_grad=False)
+        try:
+            process_fn(module)
+        finally:
+            module.input_scale = original_input_scale
+            module.inv_input_scale = original_inv_input_scale
+            module.alpha = original_alpha
+            if had_scalar_alpha:
+                module.scalar_alpha = original_scalar_alpha
+            elif hasattr(module, "scalar_alpha"):
+                delattr(module, "scalar_alpha")
+
+    def process_weights_after_loading_vanilla(self, module: Linear):
+        self._process_weights_without_static_activation_scale(
+            module,
+            super().process_weights_after_loading_vanilla)
+
+    def process_weights_after_loading_fused_qkv_linear(self, module: Linear):
+        self._process_weights_without_static_activation_scale(
+            module,
+            super().process_weights_after_loading_fused_qkv_linear)
+
+    def process_weights_after_loading_fused_gate_up_linear(
+            self, module: Linear):
+        self._process_weights_without_static_activation_scale(
+            module,
+            super().process_weights_after_loading_fused_gate_up_linear)
+
     def apply(self, module: Linear, input: torch.Tensor,
               bias: Optional[torch.Tensor]):
+        if input.dim() == 1:
+            m = 1
+        elif input.dim() > 2:
+            m = math.prod(input.shape[:-1])
+        else:
+            m = input.shape[0]
+        if m > self.CUDA_CORE_MAX_M:
+            return super().apply(module, input, bias)
+
         original_shape = None
         if input.dim() > 2:
             original_shape = input.shape

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -1861,6 +1861,75 @@ class NVFP4LinearMethod(LinearMethodBase):
                     module.rebuild_tensor_metadata)
 
 
+class W4A16NVFP4LinearMethod(NVFP4LinearMethod):
+
+    def create_weights(self, module: Linear, in_features: int,
+                       out_features: int, bias: bool, dtype: torch.dtype):
+        module.scaling_vector_size = 16
+        assert in_features % module.scaling_vector_size == 0, (
+            f"in_features {in_features} must be divisible by scaling_vector_size {module.scaling_vector_size}"
+        )
+
+        module.weight = Parameter(torch.empty([out_features, in_features // 2],
+                                              dtype=fp4_utils.float4_e2m1x2),
+                                  requires_grad=False)
+
+        nrows = fp4_utils.pad_up(out_features, 128)
+        ncols = fp4_utils.pad_up(in_features // module.scaling_vector_size, 4)
+        module.weight_scale = Parameter(torch.empty(
+            [nrows * ncols], dtype=fp4_utils.float4_sf_dtype),
+                                        requires_grad=False)
+
+        module.weight_scale_2 = Parameter(torch.empty([1], dtype=torch.float32),
+                                          requires_grad=False)
+
+        module.input_scale = None
+        module.inv_input_scale = None
+        module.alpha = None
+        module.pre_quant_scale = None
+
+        module.kv_scales = Parameter(torch.ones(3, dtype=torch.float32),
+                                     requires_grad=False)
+        module.inv_kv_scales = Parameter(torch.ones(3, dtype=torch.float32),
+                                         requires_grad=False)
+
+        if bias:
+            module.bias = Parameter(torch.empty((out_features), dtype=dtype),
+                                    requires_grad=False)
+        else:
+            module.register_parameter("bias", None)
+
+    def apply(self, module: Linear, input: torch.Tensor,
+              bias: Optional[torch.Tensor]):
+        original_shape = None
+        if input.dim() > 2:
+            original_shape = input.shape
+            input = input.reshape(-1, input.shape[-1])
+
+        if module.pre_quant_scale is not None:
+            assert input.dtype == module.pre_quant_scale.dtype, "Input dtype and pre_quant_scale dtype must match"
+            input = input * module.pre_quant_scale
+
+        output = torch.ops.trtllm.w4a16_nvfp4_gemm(
+            input,
+            module.weight,
+            module.weight_scale,
+            module.weight_scale_2,
+            module.dtype,
+            bias=None,
+        )
+
+        if output.shape[-1] > module.out_features:
+            output = output[..., :module.out_features].contiguous()
+
+        if original_shape is not None:
+            output = output.reshape(*original_shape[:-1], output.shape[-1])
+
+        if bias is not None:
+            output = output + bias
+        return output
+
+
 class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
 
     def create_weights(self, module: Linear, in_features: int,
@@ -2720,6 +2789,8 @@ def get_quant_method(quant_config: Optional[QuantConfig] = None):
             return NVFP4ARCLinearMethod()
         else:
             return NVFP4LinearMethod()
+    if quant_config.layer_quant_mode.has_w4a16_nvfp4():
+        return W4A16NVFP4LinearMethod()
     if quant_config.layer_quant_mode.has_w4a8_nvfp4_fp8():
         return W4A8NVFP4FP8LinearMethod()
     if quant_config.layer_quant_mode.has_w4a8_mxfp4_fp8():

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -1927,6 +1927,8 @@ class W4A16NVFP4LinearMethod(NVFP4LinearMethod):
         original_alpha = module.alpha
         had_scalar_alpha = hasattr(module, "scalar_alpha")
         original_scalar_alpha = getattr(module, "scalar_alpha", None)
+        has_weight_global_scale = bool(
+            getattr(module, "tmp_nvfp4_weight_scale_2_list", []))
 
         device = module.weight_scale_2.device
         module.input_scale = Parameter(torch.empty([1],
@@ -1943,6 +1945,8 @@ class W4A16NVFP4LinearMethod(NVFP4LinearMethod):
                                  requires_grad=False)
         try:
             process_fn(module)
+            if has_weight_global_scale:
+                self._convert_weight_global_scale_to_dequant_scale(module)
         finally:
             module.input_scale = original_input_scale
             module.inv_input_scale = original_inv_input_scale
@@ -1951,6 +1955,14 @@ class W4A16NVFP4LinearMethod(NVFP4LinearMethod):
                 module.scalar_alpha = original_scalar_alpha
             elif hasattr(module, "scalar_alpha"):
                 delattr(module, "scalar_alpha")
+
+    @staticmethod
+    def _convert_weight_global_scale_to_dequant_scale(module: Linear):
+        weight_scale_2 = module.weight_scale_2.data.float()
+        dequant_scale = torch.zeros_like(weight_scale_2)
+        nonzero = weight_scale_2 != 0
+        dequant_scale[nonzero] = weight_scale_2[nonzero].reciprocal()
+        copy_weight(module.weight_scale_2, dequant_scale)
 
     def process_weights_after_loading_vanilla(self, module: Linear):
         self._process_weights_without_static_activation_scale(

--- a/tensorrt_llm/models/quant_config_utils.py
+++ b/tensorrt_llm/models/quant_config_utils.py
@@ -18,6 +18,7 @@ from typing import Any, Mapping
 from tensorrt_llm.models.modeling_utils import QuantConfig
 from tensorrt_llm.quantization.mode import QuantAlgo
 
+
 def is_w4a16_nvfp4_hf_quant_config(hf_quant_config):
     if hf_quant_config is None:
         return False
@@ -30,10 +31,13 @@ def is_w4a16_nvfp4_hf_quant_config(hf_quant_config):
         return False
     weights_quant_config = group_config.get("weights", {})
     inputs_quant_config = group_config.get("input_activations")
-    return (hf_quant_config.get("format") == "nvfp4-pack-quantized"
-            and weights_quant_config.get("num_bits") == 4
-            and weights_quant_config.get("group_size") == 16
-            and inputs_quant_config is None)
+    return (
+        hf_quant_config.get("format") == "nvfp4-pack-quantized"
+        and weights_quant_config.get("num_bits") == 4
+        and weights_quant_config.get("group_size") == 16
+        and inputs_quant_config is None
+    )
+
 
 def update_quant_config_from_compressed_tensors(
     quant_config: QuantConfig, hf_quant_config: Mapping[str, Any]

--- a/tensorrt_llm/models/quant_config_utils.py
+++ b/tensorrt_llm/models/quant_config_utils.py
@@ -18,6 +18,22 @@ from typing import Any, Mapping
 from tensorrt_llm.models.modeling_utils import QuantConfig
 from tensorrt_llm.quantization.mode import QuantAlgo
 
+def is_w4a16_nvfp4_hf_quant_config(hf_quant_config):
+    if hf_quant_config is None:
+        return False
+    config_groups = hf_quant_config.get("config_groups")
+    if config_groups is None:
+        return False
+
+    group_config = config_groups.get("group_0")
+    if group_config is None:
+        return False
+    weights_quant_config = group_config.get("weights", {})
+    inputs_quant_config = group_config.get("input_activations")
+    return (hf_quant_config.get("format") == "nvfp4-pack-quantized"
+            and weights_quant_config.get("num_bits") == 4
+            and weights_quant_config.get("group_size") == 16
+            and inputs_quant_config is None)
 
 def update_quant_config_from_compressed_tensors(
     quant_config: QuantConfig, hf_quant_config: Mapping[str, Any]
@@ -32,7 +48,10 @@ def update_quant_config_from_compressed_tensors(
     weights_quant_strategy = weights_quant_config["strategy"]
     inputs_quant_strategy = inputs_quant_config["strategy"]
 
-    if weights_quant_config["num_bits"] == 8:
+    if is_w4a16_nvfp4_hf_quant_config(hf_quant_config):
+        quant_config.quant_algo = QuantAlgo.W4A16_NVFP4
+        quant_config.group_size = 16
+    elif weights_quant_config["num_bits"] == 8:
         if weights_quant_strategy == "channel":
             if inputs_quant_strategy != "token":
                 raise ValueError(f"Unsupported inputs_quant_strategy: {inputs_quant_strategy}.")

--- a/tensorrt_llm/quantization/mode.py
+++ b/tensorrt_llm/quantization/mode.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,6 +44,7 @@ class QuantAlgo(StrEnum, metaclass=BaseEnumMeta):
     W4A8_MXFP4_FP8 = auto()
     W4A8_MXFP4_MXFP8 = auto()
     W4A16_MXFP4 = auto()
+    W4A16_NVFP4 = auto()
     NVFP4_AWQ = auto()
     NVFP4_ARC = auto()
     NO_QUANT = auto()
@@ -99,6 +100,7 @@ class QuantMode(IntFlag):
     W4A8_MXFP4_FP8 = auto()
     W4A8_MXFP4_MXFP8 = auto()
     W4A16_MXFP4 = auto()
+    W4A16_NVFP4 = auto()
 
     # The smallest power-of-two that is not used by a flag. Do not call auto() after that line.
     COUNT = auto()
@@ -196,6 +198,9 @@ class QuantMode(IntFlag):
     def has_w4a16_mxfp4(self):
         return self._any(self.W4A16_MXFP4)
 
+    def has_w4a16_nvfp4(self):
+        return self._any(self.W4A16_NVFP4)
+
     def has_mxfp4(self):
         return self._any(self.W4A8_MXFP4_FP8 | self.W4A8_MXFP4_MXFP8
                          | self.W4A16_MXFP4)
@@ -214,6 +219,7 @@ class QuantMode(IntFlag):
                               | self.W4A8_NVFP4_FP8
                               | self.W4A8_MXFP4_FP8
                               | self.W4A16_MXFP4
+                              | self.W4A16_NVFP4
                               | self.W4A8_MXFP4_MXFP8)
         if exclude_kv_cache:
             return has_quant
@@ -253,7 +259,8 @@ class QuantMode(IntFlag):
                          use_w4a8_qserve=False,
                          use_w4a8_mxfp4_fp8=False,
                          use_w4a8_mxfp4_mxfp8=False,
-                         use_w4a16_mxfp4=False):
+                         use_w4a16_mxfp4=False,
+                         use_w4a16_nvfp4=False):
 
         def raise_error():
             raise ValueError(f"Unsupported combination of QuantMode args: "
@@ -272,7 +279,8 @@ class QuantMode(IntFlag):
                              f"{use_w4a8_qserve=}, "
                              f"{use_w4a8_mxfp4_fp8=}, "
                              f"{use_w4a8_mxfp4_mxfp8=}, "
-                             f"{use_w4a16_mxfp4=}")
+                             f"{use_w4a16_mxfp4=}, "
+                             f"{use_w4a16_nvfp4=}")
 
         # We must quantize weights when we quantize activations.
         if quantize_activations and not quantize_weights:
@@ -338,6 +346,9 @@ class QuantMode(IntFlag):
 
         if use_w4a16_mxfp4:
             mode = mode | QuantMode.W4A16_MXFP4
+
+        if use_w4a16_nvfp4:
+            mode = mode | QuantMode.W4A16_NVFP4
 
         return mode
 
@@ -426,6 +437,8 @@ class QuantMode(IntFlag):
             quant_mode = QuantMode.from_description(use_w4a8_mxfp4_mxfp8=True)
         elif quant_algo == QuantAlgo.W4A16_MXFP4:
             quant_mode = QuantMode.from_description(use_w4a16_mxfp4=True)
+        elif quant_algo == QuantAlgo.W4A16_NVFP4:
+            quant_mode = QuantMode.from_description(use_w4a16_nvfp4=True)
         else:
             quant_mode = QuantMode(0)
 

--- a/tests/unittest/_torch/modeling/test_modeling_nemotron_h_moe_quant.py
+++ b/tests/unittest/_torch/modeling/test_modeling_nemotron_h_moe_quant.py
@@ -20,12 +20,14 @@ import torch
 from torch import nn
 
 from tensorrt_llm._torch.model_config import ModelConfig
-from tensorrt_llm._torch.models.modeling_nemotron_h import NemotronHMOE
+from tensorrt_llm._torch.models.modeling_nemotron_h import NemotronHMOE, NemotronHMTP
 from tensorrt_llm._torch.utils import AuxStreamType
 from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
 
 
-def _make_nemotron_h_moe_config(quant_config: QuantConfig) -> ModelConfig:
+def _make_nemotron_h_moe_config(
+    quant_config: QuantConfig, moe_backend: str = "CUTLASS"
+) -> ModelConfig:
     return ModelConfig(
         pretrained_config=SimpleNamespace(
             hidden_size=16,
@@ -41,7 +43,7 @@ def _make_nemotron_h_moe_config(quant_config: QuantConfig) -> ModelConfig:
             topk_group=1,
             torch_dtype=torch.float16,
         ),
-        moe_backend="CUTLASS",
+        moe_backend=moe_backend,
         quant_config=quant_config,
     )
 
@@ -72,3 +74,71 @@ def test_nemotron_h_moe_uses_w4a4_nvfp4_expert_config_for_w4a16_checkpoint():
     assert moe_quant_config.exclude_modules == ["lm_head"]
     assert moe_quant_config.mamba_ssm_cache_dtype == torch.float32
     assert model_config.quant_config.quant_algo == QuantAlgo.W4A16_NVFP4
+
+
+def test_nemotron_h_moe_preserves_w4a16_config_for_flashinfer_sm12x():
+    quant_config = QuantConfig(
+        quant_algo=QuantAlgo.W4A16_NVFP4, group_size=16, exclude_modules=["lm_head"]
+    )
+    model_config = _make_nemotron_h_moe_config(quant_config, moe_backend="FLASHINFER_NVFP4SM12X")
+    captured = {}
+
+    def fake_create_moe(**kwargs):
+        captured["model_config"] = kwargs["model_config"]
+        return nn.Identity()
+
+    with patch(
+        "tensorrt_llm._torch.models.modeling_nemotron_h.create_moe", side_effect=fake_create_moe
+    ):
+        with patch("torch.cuda.Event", side_effect=lambda: object()):
+            aux_stream_dict = {AuxStreamType.MoeShared: None}
+            NemotronHMOE(model_config=model_config, layer_idx=1, aux_stream_dict=aux_stream_dict)
+
+    moe_quant_config = captured["model_config"].quant_config
+    assert moe_quant_config is quant_config
+    assert moe_quant_config.quant_algo == QuantAlgo.W4A16_NVFP4
+
+
+def test_nemotron_h_mtp_bf16_body_uses_cutlass_moe_backend():
+    quant_config = QuantConfig(
+        quant_algo=QuantAlgo.W4A16_NVFP4, group_size=16, exclude_modules=["lm_head"]
+    )
+    model_config = ModelConfig(
+        pretrained_config=SimpleNamespace(
+            mtp_hybrid_override_pattern="*E",
+            torch_dtype=torch.bfloat16,
+        ),
+        moe_backend="FLASHINFER_NVFP4SM12X",
+        quant_config=quant_config,
+    )
+    captured = []
+
+    def fake_decoder_layer(**kwargs):
+        captured.append(kwargs)
+        return nn.Identity()
+
+    with patch(
+        "tensorrt_llm._torch.models.modeling_nemotron_h.NemotronHMTPDecoderLayer",
+        side_effect=fake_decoder_layer,
+    ):
+        with patch(
+            "tensorrt_llm._torch.models.modeling_nemotron_h.DeepseekV3MTPHead",
+            side_effect=lambda model_config: nn.Identity(),
+        ):
+            with patch(
+                "tensorrt_llm._torch.models.modeling_nemotron_h.get_sm_version",
+                return_value=121,
+            ):
+                NemotronHMTP(
+                    model_config=model_config,
+                    layer_idx=52,
+                    aux_stream_dict={},
+                )
+
+    assert len(captured) == 2
+    for layer_kwargs in captured:
+        sublayer_model_config = layer_kwargs["model_config"]
+        assert sublayer_model_config.quant_config.quant_algo is None
+        assert sublayer_model_config.moe_backend == "CUTLASS"
+    assert model_config.quant_config.quant_algo == QuantAlgo.W4A16_NVFP4
+    assert model_config.moe_backend == "FLASHINFER_NVFP4SM12X"

--- a/tests/unittest/_torch/modeling/test_modeling_nemotron_h_moe_quant.py
+++ b/tests/unittest/_torch/modeling/test_modeling_nemotron_h_moe_quant.py
@@ -76,11 +76,11 @@ def test_nemotron_h_moe_uses_w4a4_nvfp4_expert_config_for_w4a16_checkpoint():
     assert model_config.quant_config.quant_algo == QuantAlgo.W4A16_NVFP4
 
 
-def test_nemotron_h_moe_preserves_w4a16_config_for_flashinfer_sm12x():
+def test_nemotron_h_moe_preserves_w4a16_config_for_cutedsl_sm12x():
     quant_config = QuantConfig(
         quant_algo=QuantAlgo.W4A16_NVFP4, group_size=16, exclude_modules=["lm_head"]
     )
-    model_config = _make_nemotron_h_moe_config(quant_config, moe_backend="FLASHINFER_NVFP4SM12X")
+    model_config = _make_nemotron_h_moe_config(quant_config, moe_backend="CUTEDSL")
     captured = {}
 
     def fake_create_moe(**kwargs):
@@ -108,7 +108,7 @@ def test_nemotron_h_mtp_bf16_body_uses_cutlass_moe_backend():
             mtp_hybrid_override_pattern="*E",
             torch_dtype=torch.bfloat16,
         ),
-        moe_backend="FLASHINFER_NVFP4SM12X",
+        moe_backend="CUTEDSL",
         quant_config=quant_config,
     )
     captured = []
@@ -141,4 +141,4 @@ def test_nemotron_h_mtp_bf16_body_uses_cutlass_moe_backend():
         assert sublayer_model_config.quant_config.quant_algo is None
         assert sublayer_model_config.moe_backend == "CUTLASS"
     assert model_config.quant_config.quant_algo == QuantAlgo.W4A16_NVFP4
-    assert model_config.moe_backend == "FLASHINFER_NVFP4SM12X"
+    assert model_config.moe_backend == "CUTEDSL"

--- a/tests/unittest/_torch/modeling/test_modeling_nemotron_h_moe_quant.py
+++ b/tests/unittest/_torch/modeling/test_modeling_nemotron_h_moe_quant.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from torch import nn
+
+from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.models.modeling_nemotron_h import NemotronHMOE
+from tensorrt_llm._torch.utils import AuxStreamType
+from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
+
+
+def _make_nemotron_h_moe_config(quant_config: QuantConfig) -> ModelConfig:
+    return ModelConfig(
+        pretrained_config=SimpleNamespace(
+            hidden_size=16,
+            intermediate_size=32,
+            mlp_bias=False,
+            moe_intermediate_size=64,
+            moe_latent_size=None,
+            n_group=1,
+            n_routed_experts=4,
+            n_shared_experts=0,
+            num_experts_per_tok=1,
+            routed_scaling_factor=1.0,
+            topk_group=1,
+            torch_dtype=torch.float16,
+        ),
+        moe_backend="CUTLASS",
+        quant_config=quant_config,
+    )
+
+
+def test_nemotron_h_moe_uses_w4a4_nvfp4_expert_config_for_w4a16_checkpoint():
+    quant_config = QuantConfig(
+        quant_algo=QuantAlgo.W4A16_NVFP4, group_size=16, exclude_modules=["lm_head"]
+    )
+    quant_config.mamba_ssm_cache_dtype = torch.float32
+    model_config = _make_nemotron_h_moe_config(quant_config)
+    captured = {}
+
+    def fake_create_moe(**kwargs):
+        captured["model_config"] = kwargs["model_config"]
+        return nn.Identity()
+
+    with patch(
+        "tensorrt_llm._torch.models.modeling_nemotron_h.create_moe", side_effect=fake_create_moe
+    ):
+        with patch("torch.cuda.Event", side_effect=lambda: object()):
+            aux_stream_dict = {AuxStreamType.MoeShared: None}
+            NemotronHMOE(model_config=model_config, layer_idx=1, aux_stream_dict=aux_stream_dict)
+
+    moe_quant_config = captured["model_config"].quant_config
+    assert moe_quant_config is not quant_config
+    assert moe_quant_config.quant_algo == QuantAlgo.NVFP4
+    assert moe_quant_config.group_size == 16
+    assert moe_quant_config.exclude_modules == ["lm_head"]
+    assert moe_quant_config.mamba_ssm_cache_dtype == torch.float32
+    assert model_config.quant_config.quant_algo == QuantAlgo.W4A16_NVFP4

--- a/tests/unittest/_torch/models/checkpoints/hf/test_nemotron_h_weight_mapper.py
+++ b/tests/unittest/_torch/models/checkpoints/hf/test_nemotron_h_weight_mapper.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import torch
+
+from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.models.checkpoints.hf.nemotron_h_weight_mapper import (
+    NemotronHHfWeightMapper,
+)
+from tensorrt_llm.mapping import Mapping
+from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
+
+
+def _make_mapper() -> NemotronHHfWeightMapper:
+    mapper = NemotronHHfWeightMapper()
+    mapper._config = ModelConfig(
+        pretrained_config=SimpleNamespace(
+            mamba_head_dim=1,
+            mamba_num_heads=1,
+            n_groups=1,
+            num_hidden_layers=52,
+            ssm_state_size=1,
+        ),
+        mapping=Mapping(),
+        moe_backend="CUTLASS",
+        quant_config=QuantConfig(quant_algo=QuantAlgo.W4A16_NVFP4),
+    )
+    return mapper
+
+
+def test_nemotron_h_mapper_canonicalizes_w4a16_nvfp4_checkpoint_keys():
+    mapper = _make_mapper()
+    weights = {
+        "lm_head.weight_packed": torch.empty((8, 4), dtype=torch.uint8),
+        "lm_head.weight_scale": torch.empty((8, 1), dtype=torch.float8_e4m3fn),
+        "lm_head.weight_global_scale": torch.tensor(0.25, dtype=torch.float32),
+    }
+
+    mapped = mapper.preprocess_weights(weights)
+
+    assert "lm_head.weight" in mapped
+    assert "lm_head.weight_scale" in mapped
+    assert "lm_head.weight_scale_2" in mapped
+    assert "lm_head.weight_packed" not in mapped
+    assert "lm_head.weight_global_scale" not in mapped
+    assert mapped["lm_head.weight"] is weights["lm_head.weight_packed"]
+    assert mapped["lm_head.weight_scale_2"] is weights["lm_head.weight_global_scale"]
+
+
+def test_nemotron_h_mapper_handles_scalar_w4a16_nvfp4_moe_global_scales():
+    mapper = _make_mapper()
+    prefix = "backbone.layers.1.mixer.experts.0.up_proj"
+    weights = {
+        f"{prefix}.weight_packed": torch.empty((8, 4), dtype=torch.uint8),
+        f"{prefix}.weight_scale": torch.empty((8, 1), dtype=torch.float8_e4m3fn),
+        f"{prefix}.weight_global_scale": torch.tensor(0.25, dtype=torch.float32),
+    }
+
+    mapped = mapper.preprocess_weights(weights)
+
+    assert "model.layers.1.mixer.experts.0.w1.weight" in mapped
+    assert "model.layers.1.mixer.experts.0.w3.weight" in mapped
+    assert "model.layers.1.mixer.experts.0.w1.weight_scale_2" in mapped
+    assert "model.layers.1.mixer.experts.0.w3.weight_scale_2" in mapped
+    assert mapped["model.layers.1.mixer.experts.0.w3.weight"].shape == (0, 4)
+    assert mapped["model.layers.1.mixer.experts.0.w3.weight_scale_2"].shape == ()

--- a/tests/unittest/_torch/models/checkpoints/hf/test_nemotron_h_weight_mapper.py
+++ b/tests/unittest/_torch/models/checkpoints/hf/test_nemotron_h_weight_mapper.py
@@ -55,10 +55,16 @@ def test_nemotron_h_mapper_canonicalizes_w4a16_nvfp4_checkpoint_keys():
     assert "lm_head.weight" in mapped
     assert "lm_head.weight_scale" in mapped
     assert "lm_head.weight_scale_2" in mapped
+    assert "lm_head.input_scale" in mapped
     assert "lm_head.weight_packed" not in mapped
     assert "lm_head.weight_global_scale" not in mapped
     assert mapped["lm_head.weight"] is weights["lm_head.weight_packed"]
-    assert mapped["lm_head.weight_scale_2"] is weights["lm_head.weight_global_scale"]
+    torch.testing.assert_close(
+        mapped["lm_head.weight_scale_2"], torch.tensor(4.0, dtype=torch.float32)
+    )
+    torch.testing.assert_close(
+        mapped["lm_head.input_scale"], torch.tensor([1.0], dtype=torch.float32)
+    )
 
 
 def test_nemotron_h_mapper_handles_scalar_w4a16_nvfp4_moe_global_scales():

--- a/tests/unittest/_torch/modules/moe/test_cute_dsl_b12x_moe_backend.py
+++ b/tests/unittest/_torch/modules/moe/test_cute_dsl_b12x_moe_backend.py
@@ -23,6 +23,8 @@ correctness of the b12x kernel is covered by end-to-end model tests on
 SM120/SM121 hardware.
 """
 
+import sys
+import types
 from unittest.mock import patch
 
 import pytest
@@ -33,6 +35,11 @@ from tensorrt_llm._torch.modules.fused_moe.create_moe import get_moe_cls
 from tensorrt_llm._torch.modules.fused_moe.fused_moe_cute_dsl import CuteDslFusedMoE
 from tensorrt_llm._torch.modules.fused_moe.fused_moe_cute_dsl_b12x import CuteDslB12xFusedMoE
 from tensorrt_llm._torch.modules.fused_moe.fused_moe_cutlass import CutlassFusedMoE
+from tensorrt_llm._torch.modules.fused_moe.quantization import (
+    NVFP4CuteDslB12xFusedMoEMethod,
+    NVFP4CutlassFusedMoEMethod,
+)
+from tensorrt_llm._torch.utils import ActivationType
 from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
 
 _FUSED_MOE_MODULE = "tensorrt_llm._torch.modules.fused_moe.fused_moe_cute_dsl_b12x"
@@ -55,10 +62,10 @@ def test_can_implement_accepts_supported_sm_with_nvfp4(sm_version):
     assert reason is None
 
 
-@pytest.mark.parametrize("sm_version", sorted(FlashInferNvfp4Sm12xFusedMoE._SUPPORTED_SM_VERSIONS))
+@pytest.mark.parametrize("sm_version", sorted(CuteDslB12xFusedMoE._SUPPORTED_SM_VERSIONS))
 def test_can_implement_accepts_supported_sm_with_w4a16_nvfp4(sm_version):
     with patch(f"{_FUSED_MOE_MODULE}.get_sm_version", return_value=sm_version):
-        ok, reason = FlashInferNvfp4Sm12xFusedMoE.can_implement(QuantAlgo.W4A16_NVFP4)
+        ok, reason = CuteDslB12xFusedMoE.can_implement(QuantAlgo.W4A16_NVFP4)
     assert ok
     assert reason is None
 
@@ -138,12 +145,33 @@ def test_get_moe_cls_cutedsl_returns_plain_cutedsl_on_unsupported_sm():
     assert cls is CuteDslFusedMoE
 
 
+def test_get_moe_cls_cutedsl_returns_cutlass_for_w4a16_nvfp4_on_unsupported_sm():
+    """CUTEDSL + W4A16_NVFP4 + non-SM120/121 → CutlassFusedMoE."""
+    cfg = ModelConfig()
+    cfg.moe_backend = "CUTEDSL"
+    cfg.quant_config = QuantConfig(quant_algo=QuantAlgo.W4A16_NVFP4)
+    with patch("tensorrt_llm._utils.get_sm_version", return_value=100):
+        cls = get_moe_cls(cfg)
+    assert cls is CutlassFusedMoE
+
+
 @pytest.mark.parametrize("sm_version", sorted(CuteDslB12xFusedMoE._SUPPORTED_SM_VERSIONS))
 def test_get_moe_cls_cutedsl_selects_b12x_on_supported_sm(sm_version):
     """CUTEDSL + NVFP4 + SM120/121 + flashinfer importable → CuteDslB12xFusedMoE."""
     cfg = ModelConfig()
     cfg.moe_backend = "CUTEDSL"
     cfg.quant_config = QuantConfig(quant_algo=QuantAlgo.NVFP4)
+    with patch("tensorrt_llm._utils.get_sm_version", return_value=sm_version):
+        cls = get_moe_cls(cfg)
+    assert cls is CuteDslB12xFusedMoE
+
+
+@pytest.mark.parametrize("sm_version", sorted(CuteDslB12xFusedMoE._SUPPORTED_SM_VERSIONS))
+def test_get_moe_cls_cutedsl_selects_b12x_for_w4a16_nvfp4_on_supported_sm(sm_version):
+    """CUTEDSL + W4A16_NVFP4 + SM120/121 + flashinfer importable → CuteDslB12xFusedMoE."""
+    cfg = ModelConfig()
+    cfg.moe_backend = "CUTEDSL"
+    cfg.quant_config = QuantConfig(quant_algo=QuantAlgo.W4A16_NVFP4)
     with patch("tensorrt_llm._utils.get_sm_version", return_value=sm_version):
         cls = get_moe_cls(cfg)
     assert cls is CuteDslB12xFusedMoE
@@ -168,15 +196,6 @@ def test_get_moe_cls_cutedsl_falls_back_to_plain_cutedsl_when_flashinfer_missing
     with patch("tensorrt_llm._utils.get_sm_version", return_value=120):
         cls = get_moe_cls(cfg)
     assert cls is CuteDslFusedMoE
-
-
-def test_get_moe_cls_returns_flashinfer_for_w4a16_nvfp4_on_supported_sm():
-    cfg = ModelConfig()
-    cfg.moe_backend = "FLASHINFER_NVFP4SM12X"
-    cfg.quant_config = QuantConfig(quant_algo=QuantAlgo.W4A16_NVFP4)
-    with patch("tensorrt_llm._utils.get_sm_version", return_value=120):
-        cls = get_moe_cls(cfg)
-    assert cls is FlashInferNvfp4Sm12xFusedMoE
 
 
 # --------------------------------------------------------------------------
@@ -215,6 +234,98 @@ def test_dispatch_decode_shape_takes_b12x():
     stub = _RoutePredicateStub()
     x = torch.empty(1, 1024)
     assert stub._route_to_cutlass(x) is False
+
+
+def test_w4a16_nvfp4_prefill_quantize_input_stays_on_b12x():
+    moe = object.__new__(CuteDslB12xFusedMoE)
+    moe.quant_config = QuantConfig(quant_algo=QuantAlgo.W4A16_NVFP4)
+    x = torch.empty(CuteDslB12xFusedMoE._PREFILL_VIA_CUTLASS_THRESHOLD, 1024)
+
+    with patch.object(
+        CutlassFusedMoE,
+        "quantize_input",
+        side_effect=AssertionError("W4A16_NVFP4 prefill must not route through CUTLASS"),
+    ):
+        out, out_sf = CuteDslB12xFusedMoE.quantize_input(moe, x)
+
+    assert out is x
+    assert out_sf is None
+
+
+def test_w4a16_nvfp4_post_load_constructs_b12x_w4a16_wrapper(monkeypatch):
+    class _RoutingMethod:
+        experts_per_token = 4
+
+    class _FakeB12xWrapper:
+        calls = []
+
+        def __init__(self, **kwargs):
+            self._moe_output = None
+            self.calls.append(kwargs)
+
+    def _convert_sf_to_mma_layout(scales, *, m, k, num_groups):
+        return scales
+
+    flashinfer = types.ModuleType("flashinfer")
+    flashinfer.B12xMoEWrapper = _FakeB12xWrapper
+    cute_dsl = types.ModuleType("flashinfer.cute_dsl")
+    utils = types.ModuleType("flashinfer.cute_dsl.utils")
+    utils.convert_sf_to_mma_layout = _convert_sf_to_mma_layout
+    monkeypatch.setitem(sys.modules, "flashinfer", flashinfer)
+    monkeypatch.setitem(sys.modules, "flashinfer.cute_dsl", cute_dsl)
+    monkeypatch.setitem(sys.modules, "flashinfer.cute_dsl.utils", utils)
+
+    num_experts = 2
+    hidden_size = 128
+    logical_intermediate_size = 1856
+    padded_intermediate_size = 1920
+    module = torch.nn.Module()
+    module.num_experts = num_experts
+    module.hidden_size = hidden_size
+    module.intermediate_size_per_partition = logical_intermediate_size
+    module.moe_max_num_tokens = 8
+    module.routing_method = _RoutingMethod()
+    module.activation_type = ActivationType.Swiglu
+    module.quant_config = QuantConfig(quant_algo=QuantAlgo.W4A16_NVFP4)
+    module.w3_w1_weight = torch.empty(
+        num_experts,
+        2 * padded_intermediate_size,
+        hidden_size // 16,
+        dtype=torch.int64,
+    )
+    module.w2_weight = torch.empty(
+        num_experts,
+        hidden_size,
+        padded_intermediate_size // 16,
+        dtype=torch.int64,
+    )
+    module.w3_w1_weight_scale = torch.ones(
+        num_experts,
+        2 * padded_intermediate_size,
+        hidden_size // 16,
+        dtype=torch.float8_e4m3fn,
+    )
+    module.w2_weight_scale = torch.ones(
+        num_experts,
+        hidden_size,
+        padded_intermediate_size // 16,
+        dtype=torch.float8_e4m3fn,
+    )
+    module.fc31_alpha = torch.ones(num_experts)
+    module.fc2_alpha = torch.ones(num_experts)
+    module.fc31_input_scale = torch.ones(())
+    module.fc2_input_scale = torch.ones(())
+
+    with patch.object(NVFP4CutlassFusedMoEMethod, "post_load_weights", return_value=None):
+        NVFP4CuteDslB12xFusedMoEMethod().post_load_weights(module)
+
+    assert _FakeB12xWrapper.calls
+    wrapper_kwargs = _FakeB12xWrapper.calls[0]
+    assert wrapper_kwargs.get("quant_mode") == "w4a16", wrapper_kwargs
+    assert wrapper_kwargs["intermediate_size"] == padded_intermediate_size
+    assert module._b12x_weights["fc2_input_scale"] is None
+    assert torch.equal(module._b12x_weights["w1_alpha"], torch.ones(num_experts))
+    assert torch.equal(module._b12x_weights["w2_alpha"], torch.ones(num_experts))
 
 
 def test_dispatch_rejects_non_tensor():

--- a/tests/unittest/_torch/modules/moe/test_cute_dsl_b12x_moe_backend.py
+++ b/tests/unittest/_torch/modules/moe/test_cute_dsl_b12x_moe_backend.py
@@ -252,7 +252,7 @@ def test_w4a16_nvfp4_prefill_quantize_input_stays_on_b12x():
     assert out_sf is None
 
 
-def test_w4a16_nvfp4_post_load_constructs_b12x_w4a16_wrapper(monkeypatch):
+def test_w4a16_nvfp4_post_load_uses_modelopt_scale_contract(monkeypatch):
     class _RoutingMethod:
         experts_per_token = 4
 
@@ -299,22 +299,24 @@ def test_w4a16_nvfp4_post_load_constructs_b12x_w4a16_wrapper(monkeypatch):
         padded_intermediate_size // 16,
         dtype=torch.int64,
     )
-    module.w3_w1_weight_scale = torch.ones(
+    w3_w1_weight_scale = torch.ones(
         num_experts,
         2 * padded_intermediate_size,
         hidden_size // 16,
         dtype=torch.float8_e4m3fn,
     )
-    module.w2_weight_scale = torch.ones(
+    w2_weight_scale = torch.ones(
         num_experts,
         hidden_size,
         padded_intermediate_size // 16,
         dtype=torch.float8_e4m3fn,
     )
-    module.fc31_alpha = torch.ones(num_experts)
-    module.fc2_alpha = torch.ones(num_experts)
-    module.fc31_input_scale = torch.ones(())
-    module.fc2_input_scale = torch.ones(())
+    module.w3_w1_weight_scale = w3_w1_weight_scale.clone()
+    module.w2_weight_scale = w2_weight_scale.clone()
+    module.fc31_alpha = torch.tensor([0.25, 0.5], dtype=torch.float32)
+    module.fc2_alpha = torch.tensor([0.125, 0.25], dtype=torch.float32)
+    module.fc31_input_scale = torch.tensor(2.0, dtype=torch.float32)
+    module.fc2_input_scale = torch.tensor(4.0, dtype=torch.float32)
 
     with patch.object(NVFP4CutlassFusedMoEMethod, "post_load_weights", return_value=None):
         NVFP4CuteDslB12xFusedMoEMethod().post_load_weights(module)
@@ -324,8 +326,22 @@ def test_w4a16_nvfp4_post_load_constructs_b12x_w4a16_wrapper(monkeypatch):
     assert wrapper_kwargs.get("quant_mode") == "w4a16", wrapper_kwargs
     assert wrapper_kwargs["intermediate_size"] == padded_intermediate_size
     assert module._b12x_weights["fc2_input_scale"] is None
-    assert torch.equal(module._b12x_weights["w1_alpha"], torch.ones(num_experts))
-    assert torch.equal(module._b12x_weights["w2_alpha"], torch.ones(num_experts))
+    assert torch.equal(
+        module._b12x_weights["w1_weight_sf"].float(),
+        w3_w1_weight_scale.float(),
+    )
+    assert torch.equal(
+        module._b12x_weights["w2_weight_sf"].float(),
+        w2_weight_scale.float(),
+    )
+    assert torch.allclose(
+        module._b12x_weights["w1_alpha"],
+        torch.tensor([2.0, 1.0], dtype=torch.float32),
+    )
+    assert torch.allclose(
+        module._b12x_weights["w2_alpha"],
+        torch.tensor([2.0, 1.0], dtype=torch.float32),
+    )
 
 
 def test_dispatch_rejects_non_tensor():

--- a/tests/unittest/_torch/modules/moe/test_cute_dsl_b12x_moe_backend.py
+++ b/tests/unittest/_torch/modules/moe/test_cute_dsl_b12x_moe_backend.py
@@ -55,6 +55,14 @@ def test_can_implement_accepts_supported_sm_with_nvfp4(sm_version):
     assert reason is None
 
 
+@pytest.mark.parametrize("sm_version", sorted(FlashInferNvfp4Sm12xFusedMoE._SUPPORTED_SM_VERSIONS))
+def test_can_implement_accepts_supported_sm_with_w4a16_nvfp4(sm_version):
+    with patch(f"{_FUSED_MOE_MODULE}.get_sm_version", return_value=sm_version):
+        ok, reason = FlashInferNvfp4Sm12xFusedMoE.can_implement(QuantAlgo.W4A16_NVFP4)
+    assert ok
+    assert reason is None
+
+
 @pytest.mark.parametrize(
     "quant_algo",
     [
@@ -160,6 +168,15 @@ def test_get_moe_cls_cutedsl_falls_back_to_plain_cutedsl_when_flashinfer_missing
     with patch("tensorrt_llm._utils.get_sm_version", return_value=120):
         cls = get_moe_cls(cfg)
     assert cls is CuteDslFusedMoE
+
+
+def test_get_moe_cls_returns_flashinfer_for_w4a16_nvfp4_on_supported_sm():
+    cfg = ModelConfig()
+    cfg.moe_backend = "FLASHINFER_NVFP4SM12X"
+    cfg.quant_config = QuantConfig(quant_algo=QuantAlgo.W4A16_NVFP4)
+    with patch("tensorrt_llm._utils.get_sm_version", return_value=120):
+        cls = get_moe_cls(cfg)
+    assert cls is FlashInferNvfp4Sm12xFusedMoE
 
 
 # --------------------------------------------------------------------------

--- a/tests/unittest/_torch/modules/test_w4a16_nvfp4_linear.py
+++ b/tests/unittest/_torch/modules/test_w4a16_nvfp4_linear.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from tensorrt_llm._torch.modules.embedding import LMHead
+from tensorrt_llm._torch.modules.linear import W4A16NVFP4LinearMethod, get_quant_method
+from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
+
+
+def test_get_quant_method_returns_w4a16_nvfp4_linear_method():
+    quant_config = QuantConfig(quant_algo=QuantAlgo.W4A16_NVFP4)
+
+    method = get_quant_method(quant_config)
+
+    assert isinstance(method, W4A16NVFP4LinearMethod)
+
+
+def test_w4a16_nvfp4_linear_uses_high_precision_activation_without_fp4_quantize():
+    method = W4A16NVFP4LinearMethod()
+    input_tensor = torch.ones((2, 4), dtype=torch.bfloat16)
+    bias = torch.tensor([1.0, 2.0, 3.0], dtype=torch.bfloat16)
+    module = SimpleNamespace(
+        weight=torch.empty((5, 2), dtype=torch.uint8),
+        weight_scale=torch.empty((128 * 4,), dtype=torch.uint8),
+        weight_scale_2=torch.tensor([0.25], dtype=torch.float32),
+        dtype=torch.bfloat16,
+        out_features=3,
+        pre_quant_scale=None,
+    )
+    captured = {}
+
+    def fake_w4a16_nvfp4_gemm(
+        input_arg, weight, weight_scale, weight_scale_2, out_dtype, bias=None
+    ):
+        captured["input"] = input_arg
+        captured["weight"] = weight
+        captured["weight_scale"] = weight_scale
+        captured["weight_scale_2"] = weight_scale_2
+        captured["out_dtype"] = out_dtype
+        captured["bias"] = bias
+        return torch.ones((input_arg.shape[0], weight.shape[0]), dtype=out_dtype)
+
+    def fail_fp4_quantize(*args, **kwargs):
+        raise AssertionError("W4A16 NVFP4 must not quantize activations")
+
+    with patch("torch.ops.trtllm.w4a16_nvfp4_gemm", side_effect=fake_w4a16_nvfp4_gemm, create=True):
+        with patch("torch.ops.trtllm.fp4_quantize", side_effect=fail_fp4_quantize, create=True):
+            output = method.apply(module, input_tensor, bias)
+
+    assert captured["input"] is input_tensor
+    assert captured["weight"] is module.weight
+    assert captured["weight_scale"] is module.weight_scale
+    assert captured["weight_scale_2"] is module.weight_scale_2
+    assert captured["out_dtype"] is torch.bfloat16
+    assert captured["bias"] is None
+    expected = torch.tensor([[2.0, 3.0, 4.0], [2.0, 3.0, 4.0]], dtype=torch.bfloat16)
+    torch.testing.assert_close(output, expected)
+
+
+def test_w4a16_nvfp4_linear_restores_high_rank_input_shape():
+    method = W4A16NVFP4LinearMethod()
+    input_tensor = torch.ones((2, 3, 4), dtype=torch.float16)
+    module = SimpleNamespace(
+        weight=torch.empty((7, 2), dtype=torch.uint8),
+        weight_scale=torch.empty((128 * 4,), dtype=torch.uint8),
+        weight_scale_2=torch.tensor([0.5], dtype=torch.float32),
+        dtype=torch.float16,
+        out_features=5,
+        pre_quant_scale=None,
+    )
+
+    def fake_w4a16_nvfp4_gemm(
+        input_arg, weight, weight_scale, weight_scale_2, out_dtype, bias=None
+    ):
+        assert input_arg.shape == (6, 4)
+        return torch.ones((input_arg.shape[0], weight.shape[0]), dtype=out_dtype)
+
+    with patch("torch.ops.trtllm.w4a16_nvfp4_gemm", side_effect=fake_w4a16_nvfp4_gemm, create=True):
+        output = method.apply(module, input_tensor, bias=None)
+
+    assert output.shape == (2, 3, 5)
+
+
+def test_lm_head_uses_w4a16_nvfp4_quant_method_for_packed_lm_head():
+    quant_config = QuantConfig(quant_algo=QuantAlgo.W4A16_NVFP4)
+
+    lm_head = LMHead(
+        num_embeddings=3, embedding_dim=16, dtype=torch.float16, quant_config=quant_config
+    )
+
+    assert isinstance(lm_head.quant_method, W4A16NVFP4LinearMethod)
+    assert lm_head.weight.dtype == torch.uint8
+    assert lm_head.weight.shape == (3, 8)
+    assert lm_head.weight_scale.shape == (128 * 4,)
+    assert lm_head.weight_scale_2.shape == (1,)
+
+
+def test_lm_head_w4a16_nvfp4_forward_dispatches_to_dense_op():
+    quant_config = QuantConfig(quant_algo=QuantAlgo.W4A16_NVFP4)
+    lm_head = LMHead(
+        num_embeddings=3, embedding_dim=16, dtype=torch.float16, quant_config=quant_config
+    )
+    input_tensor = torch.ones((2, 16), dtype=torch.float16)
+    captured = {}
+
+    def fake_w4a16_nvfp4_gemm(
+        input_arg, weight, weight_scale, weight_scale_2, out_dtype, bias=None
+    ):
+        captured["input"] = input_arg
+        captured["weight"] = weight
+        captured["weight_scale"] = weight_scale
+        captured["weight_scale_2"] = weight_scale_2
+        captured["out_dtype"] = out_dtype
+        captured["bias"] = bias
+        return torch.ones((input_arg.shape[0], weight.shape[0]), dtype=out_dtype)
+
+    with patch("torch.ops.trtllm.w4a16_nvfp4_gemm", side_effect=fake_w4a16_nvfp4_gemm, create=True):
+        output = lm_head(input_tensor)
+
+    assert captured["input"] is input_tensor
+    assert captured["weight"] is lm_head.weight
+    assert captured["weight_scale"] is lm_head.weight_scale
+    assert captured["weight_scale_2"] is lm_head.weight_scale_2
+    assert captured["out_dtype"] is torch.float16
+    assert captured["bias"] is None
+    assert output.shape == (2, 3)

--- a/tests/unittest/_torch/modules/test_w4a16_nvfp4_linear.py
+++ b/tests/unittest/_torch/modules/test_w4a16_nvfp4_linear.py
@@ -97,6 +97,96 @@ def test_w4a16_nvfp4_linear_restores_high_rank_input_shape():
     assert output.shape == (2, 3, 5)
 
 
+def test_w4a16_nvfp4_linear_falls_back_to_w4a4_nvfp4_for_large_m():
+    method = W4A16NVFP4LinearMethod()
+    input_tensor = torch.ones((17, 16), dtype=torch.bfloat16)
+    module = SimpleNamespace(
+        weight=torch.empty((5, 8), dtype=torch.uint8),
+        weight_scale=torch.empty((128 * 4,), dtype=torch.uint8),
+        weight_scale_2=torch.tensor([0.5], dtype=torch.float32),
+        dtype=torch.bfloat16,
+        out_features=3,
+        pre_quant_scale=None,
+        input_scale=None,
+        alpha=None,
+        force_dynamic_quantization=False,
+        scaling_vector_size=16,
+        nvfp4_allowed_backends=["cuda_core"],
+        all_reduce=None,
+        mapping=None,
+    )
+    captured = {}
+
+    def fail_w4a16_gemm(*args, **kwargs):
+        raise AssertionError("large-M dense fallback must not call w4a16_nvfp4_gemm")
+
+    def fake_fp4_quantize(input_arg, input_scale, scaling_vector_size, is_sf_swizzled):
+        captured["quant_input"] = input_arg
+        captured["input_scale"] = input_scale
+        captured["scaling_vector_size"] = scaling_vector_size
+        captured["is_sf_swizzled"] = is_sf_swizzled
+        return torch.empty(
+            (input_arg.shape[0], input_arg.shape[1] // 2), dtype=torch.uint8
+        ), torch.empty((input_arg.shape[0], 4), dtype=torch.uint8)
+
+    def fake_nvfp4_gemm(
+        act_fp4,
+        weight,
+        act_sf,
+        weight_scale,
+        alpha,
+        out_dtype,
+        output_buffer_kind=0,
+        allowed_backends="",
+        group=None,
+    ):
+        captured["act_fp4"] = act_fp4
+        captured["weight"] = weight
+        captured["act_sf"] = act_sf
+        captured["weight_scale"] = weight_scale
+        captured["alpha"] = alpha
+        captured["out_dtype"] = out_dtype
+        captured["allowed_backends"] = allowed_backends
+        captured["group"] = group
+        return torch.ones((act_fp4.shape[0], weight.shape[0]), dtype=out_dtype)
+
+    with patch("torch.ops.trtllm.w4a16_nvfp4_gemm", side_effect=fail_w4a16_gemm, create=True):
+        with patch("torch.ops.trtllm.fp4_quantize", side_effect=fake_fp4_quantize, create=True):
+            with patch("torch.ops.trtllm.nvfp4_gemm", side_effect=fake_nvfp4_gemm, create=True):
+                output = method.apply(module, input_tensor, bias=None)
+
+    assert captured["quant_input"] is input_tensor
+    assert captured["scaling_vector_size"] == 16
+    assert captured["is_sf_swizzled"] is False
+    assert captured["weight"] is module.weight
+    assert captured["weight_scale"] is module.weight_scale
+    assert captured["out_dtype"] is torch.bfloat16
+    assert captured["allowed_backends"] == "cuda_core"
+    assert captured["group"] is None
+    assert output.shape == (17, 3)
+
+
+def test_w4a16_nvfp4_post_load_ignores_checkpoint_activation_scale():
+    method = W4A16NVFP4LinearMethod()
+    module = SimpleNamespace(
+        input_scale=None,
+        inv_input_scale=None,
+        alpha=None,
+        weight_scale_2=torch.empty([1], dtype=torch.float32),
+        tmp_nvfp4_input_scales_list=[torch.tensor(1.0, dtype=torch.float32)],
+        tmp_nvfp4_weight_scale_2_list=[torch.tensor(0.25, dtype=torch.float32)],
+    )
+
+    method.process_weights_after_loading_vanilla(module)
+
+    assert module.input_scale is None
+    assert module.inv_input_scale is None
+    assert module.alpha is None
+    torch.testing.assert_close(module.weight_scale_2, torch.tensor([0.25], dtype=torch.float32))
+    assert not hasattr(module, "tmp_nvfp4_input_scales_list")
+    assert not hasattr(module, "tmp_nvfp4_weight_scale_2_list")
+
+
 def test_lm_head_uses_w4a16_nvfp4_quant_method_for_packed_lm_head():
     quant_config = QuantConfig(quant_algo=QuantAlgo.W4A16_NVFP4)
 

--- a/tests/unittest/_torch/modules/test_w4a16_nvfp4_linear.py
+++ b/tests/unittest/_torch/modules/test_w4a16_nvfp4_linear.py
@@ -13,14 +13,121 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 import torch
 
+import tensorrt_llm.quantization.utils.fp4_utils as fp4_utils
 from tensorrt_llm._torch.modules.embedding import LMHead
-from tensorrt_llm._torch.modules.linear import W4A16NVFP4LinearMethod, get_quant_method
+from tensorrt_llm._torch.modules.linear import (
+    W4A16NVFP4LinearMethod,
+    get_quant_method,
+    get_sm_version,
+)
 from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
+
+
+def _run_w4a16_cutlass3_reference_case(m: int, n: int, k: int, dtype: torch.dtype) -> None:
+    assert k % 32 == 0
+    assert n % 32 == 0
+    act, weight, weight_scale, weight_scale_2 = _make_w4a16_nvfp4_case(m, n, k, dtype)
+
+    expected = torch.empty((m, n), device="cuda", dtype=dtype)
+    for start in range(0, m, 16):
+        stop = min(start + 16, m)
+        expected[start:stop, :] = torch.ops.trtllm.w4a16_nvfp4_gemm(
+            act[start:stop, :],
+            weight,
+            weight_scale,
+            weight_scale_2,
+            dtype,
+            bias=None,
+        )
+
+    actual = torch.ops.trtllm.w4a16_nvfp4_cutlass_gemm(
+        act,
+        weight,
+        weight_scale,
+        weight_scale_2,
+        dtype,
+        bias=None,
+    )
+    torch.testing.assert_close(actual, expected, atol=0.08, rtol=0.08)
+
+
+def _make_w4a16_nvfp4_case(m: int, n: int, k: int, dtype: torch.dtype):
+    act = torch.randn((m, k), device="cuda", dtype=dtype)
+    weight = torch.empty((n, k // 2), device="cuda", dtype=fp4_utils.float4_e2m1x2)
+    weight_u8 = torch.randint(
+        0,
+        256,
+        (n, k // 2),
+        device="cuda",
+        dtype=torch.uint8,
+    )
+    weight.copy_(weight_u8.view(fp4_utils.float4_e2m1x2))
+
+    scale_cols = fp4_utils.pad_up(k // 16, 4)
+    scale_rows = fp4_utils.pad_up(n, 128)
+    weight_scale_linear = torch.randint(
+        1,
+        120,
+        (scale_rows, scale_cols),
+        device="cuda",
+        dtype=torch.uint8,
+    )
+    weight_scale = torch.ops.trtllm.block_scale_interleave(weight_scale_linear).view(
+        fp4_utils.float4_sf_dtype
+    )
+    weight_scale_2 = torch.ones((1,), device="cuda", dtype=torch.float32)
+    return act, weight, weight_scale, weight_scale_2
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or get_sm_version() not in (120, 121),
+    reason="requires CUDA SM120/121",
+)
+@pytest.mark.parametrize(
+    "shape",
+    [(32, 256, 256), (128, 512, 1024), (256, 1024, 2048)],
+)
+def test_w4a16_nvfp4_cutlass3_bf16_matches_cuda_core(shape):
+    m, n, k = shape
+    _run_w4a16_cutlass3_reference_case(m, n, k, torch.bfloat16)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or get_sm_version() not in (120, 121),
+    reason="requires CUDA SM120/121",
+)
+def test_w4a16_nvfp4_gemm_large_m_chunks_cuda_core():
+    m, n, k = 32, 64, 64
+    act, weight, weight_scale, weight_scale_2 = _make_w4a16_nvfp4_case(m, n, k, torch.bfloat16)
+    expected = torch.empty((m, n), device="cuda", dtype=torch.bfloat16)
+    for start in range(0, m, 16):
+        stop = min(start + 16, m)
+        expected[start:stop, :] = torch.ops.trtllm.w4a16_nvfp4_gemm(
+            act[start:stop, :],
+            weight,
+            weight_scale,
+            weight_scale_2,
+            torch.bfloat16,
+            bias=None,
+        )
+
+    actual = torch.ops.trtllm.w4a16_nvfp4_gemm(
+        act,
+        weight,
+        weight_scale,
+        weight_scale_2,
+        torch.bfloat16,
+        bias=None,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=0.08, rtol=0.08)
 
 
 def test_get_quant_method_returns_w4a16_nvfp4_linear_method():
@@ -97,7 +204,7 @@ def test_w4a16_nvfp4_linear_restores_high_rank_input_shape():
     assert output.shape == (2, 3, 5)
 
 
-def test_w4a16_nvfp4_linear_falls_back_to_w4a4_nvfp4_for_large_m():
+def test_w4a16_nvfp4_linear_uses_chunked_w4a16_op_for_large_m():
     method = W4A16NVFP4LinearMethod()
     input_tensor = torch.ones((17, 16), dtype=torch.bfloat16)
     module = SimpleNamespace(
@@ -107,62 +214,194 @@ def test_w4a16_nvfp4_linear_falls_back_to_w4a4_nvfp4_for_large_m():
         dtype=torch.bfloat16,
         out_features=3,
         pre_quant_scale=None,
-        input_scale=None,
-        alpha=None,
-        force_dynamic_quantization=False,
-        scaling_vector_size=16,
-        nvfp4_allowed_backends=["cuda_core"],
-        all_reduce=None,
-        mapping=None,
     )
     captured = {}
 
-    def fail_w4a16_gemm(*args, **kwargs):
-        raise AssertionError("large-M dense fallback must not call w4a16_nvfp4_gemm")
-
-    def fake_fp4_quantize(input_arg, input_scale, scaling_vector_size, is_sf_swizzled):
-        captured["quant_input"] = input_arg
-        captured["input_scale"] = input_scale
-        captured["scaling_vector_size"] = scaling_vector_size
-        captured["is_sf_swizzled"] = is_sf_swizzled
-        return torch.empty(
-            (input_arg.shape[0], input_arg.shape[1] // 2), dtype=torch.uint8
-        ), torch.empty((input_arg.shape[0], 4), dtype=torch.uint8)
-
-    def fake_nvfp4_gemm(
-        act_fp4,
-        weight,
-        act_sf,
-        weight_scale,
-        alpha,
-        out_dtype,
-        output_buffer_kind=0,
-        allowed_backends="",
-        group=None,
+    def fake_w4a16_nvfp4_gemm(
+        input_arg, weight, weight_scale, weight_scale_2, out_dtype, bias=None
     ):
-        captured["act_fp4"] = act_fp4
+        captured["input"] = input_arg
         captured["weight"] = weight
-        captured["act_sf"] = act_sf
         captured["weight_scale"] = weight_scale
-        captured["alpha"] = alpha
+        captured["weight_scale_2"] = weight_scale_2
         captured["out_dtype"] = out_dtype
-        captured["allowed_backends"] = allowed_backends
-        captured["group"] = group
-        return torch.ones((act_fp4.shape[0], weight.shape[0]), dtype=out_dtype)
+        captured["bias"] = bias
+        return torch.ones((input_arg.shape[0], weight.shape[0]), dtype=out_dtype)
 
-    with patch("torch.ops.trtllm.w4a16_nvfp4_gemm", side_effect=fail_w4a16_gemm, create=True):
-        with patch("torch.ops.trtllm.fp4_quantize", side_effect=fake_fp4_quantize, create=True):
-            with patch("torch.ops.trtllm.nvfp4_gemm", side_effect=fake_nvfp4_gemm, create=True):
-                output = method.apply(module, input_tensor, bias=None)
+    def fail_fp4_quantize(*args, **kwargs):
+        raise AssertionError("large-M W4A16 path must not quantize activations")
 
-    assert captured["quant_input"] is input_tensor
-    assert captured["scaling_vector_size"] == 16
-    assert captured["is_sf_swizzled"] is False
+    with patch("torch.ops.trtllm.w4a16_nvfp4_gemm", side_effect=fake_w4a16_nvfp4_gemm, create=True):
+        with patch("torch.ops.trtllm.fp4_quantize", side_effect=fail_fp4_quantize, create=True):
+            output = method.apply(module, input_tensor, bias=None)
+
+    assert captured["input"] is input_tensor
     assert captured["weight"] is module.weight
     assert captured["weight_scale"] is module.weight_scale
+    assert captured["weight_scale_2"] is module.weight_scale_2
     assert captured["out_dtype"] is torch.bfloat16
-    assert captured["allowed_backends"] == "cuda_core"
-    assert captured["group"] is None
+    assert output.shape == (17, 3)
+
+
+def test_w4a16_nvfp4_linear_uses_cutlass3_op_for_large_bf16_m_when_enabled():
+    method = W4A16NVFP4LinearMethod()
+    input_tensor = torch.ones((17, 32), dtype=torch.bfloat16)
+    module = SimpleNamespace(
+        weight=torch.empty((32, 16), dtype=torch.uint8),
+        weight_scale=torch.empty((128 * 4,), dtype=torch.uint8),
+        weight_scale_2=torch.tensor([0.5], dtype=torch.float32),
+        dtype=torch.bfloat16,
+        out_features=3,
+        pre_quant_scale=None,
+    )
+    captured = {}
+
+    def fake_w4a16_nvfp4_cutlass_gemm(
+        input_arg, weight, weight_scale, weight_scale_2, out_dtype, bias=None
+    ):
+        captured["input"] = input_arg
+        captured["weight"] = weight
+        captured["weight_scale"] = weight_scale
+        captured["weight_scale_2"] = weight_scale_2
+        captured["out_dtype"] = out_dtype
+        captured["bias"] = bias
+        return torch.ones((input_arg.shape[0], weight.shape[0]), dtype=out_dtype)
+
+    def fail_w4a16_gemm(*args, **kwargs):
+        raise AssertionError("CUTLASS3 W4A16 prefill must not call the default W4A16 op")
+
+    def fail_fp4_quantize(*args, **kwargs):
+        raise AssertionError("CUTLASS3 W4A16 prefill must not quantize activations")
+
+    with patch.dict(os.environ, {"TRTLLM_W4A16_NVFP4_CUTLASS3": "1"}):
+        with patch("tensorrt_llm._torch.modules.linear.get_sm_version", return_value=120):
+            with patch(
+                "torch.ops.trtllm.w4a16_nvfp4_gemm", side_effect=fail_w4a16_gemm, create=True
+            ):
+                with patch(
+                    "torch.ops.trtllm.w4a16_nvfp4_cutlass_gemm",
+                    side_effect=fake_w4a16_nvfp4_cutlass_gemm,
+                    create=True,
+                ):
+                    with patch(
+                        "torch.ops.trtllm.fp4_quantize", side_effect=fail_fp4_quantize, create=True
+                    ):
+                        output = method.apply(module, input_tensor, bias=None)
+
+    assert captured["input"] is input_tensor
+    assert captured["weight"] is module.weight
+    assert captured["weight_scale"] is module.weight_scale
+    assert captured["weight_scale_2"] is module.weight_scale_2
+    assert captured["out_dtype"] is torch.bfloat16
+    assert captured["bias"] is None
+    assert output.shape == (17, 3)
+
+
+def test_w4a16_nvfp4_linear_cutlass3_restores_high_rank_input_shape():
+    method = W4A16NVFP4LinearMethod()
+    input_tensor = torch.ones((2, 9, 32), dtype=torch.bfloat16)
+    bias = torch.tensor([1.0, 2.0, 3.0], dtype=torch.bfloat16)
+    module = SimpleNamespace(
+        weight=torch.empty((32, 16), dtype=torch.uint8),
+        weight_scale=torch.empty((128 * 4,), dtype=torch.uint8),
+        weight_scale_2=torch.tensor([0.5], dtype=torch.float32),
+        dtype=torch.bfloat16,
+        out_features=3,
+        pre_quant_scale=None,
+    )
+    captured = {}
+
+    def fake_w4a16_nvfp4_cutlass_gemm(
+        input_arg, weight, weight_scale, weight_scale_2, out_dtype, bias=None
+    ):
+        captured["input_shape"] = input_arg.shape
+        return torch.ones((input_arg.shape[0], weight.shape[0]), dtype=out_dtype)
+
+    def fail_w4a16_gemm(*args, **kwargs):
+        raise AssertionError("large-M CUTLASS3 path must not call the default W4A16 op")
+
+    with patch.dict(os.environ, {"TRTLLM_W4A16_NVFP4_CUTLASS3": "1"}):
+        with patch("tensorrt_llm._torch.modules.linear.get_sm_version", return_value=120):
+            with patch(
+                "torch.ops.trtllm.w4a16_nvfp4_gemm", side_effect=fail_w4a16_gemm, create=True
+            ):
+                with patch(
+                    "torch.ops.trtllm.w4a16_nvfp4_cutlass_gemm",
+                    side_effect=fake_w4a16_nvfp4_cutlass_gemm,
+                    create=True,
+                ):
+                    output = method.apply(module, input_tensor, bias=bias)
+
+    assert captured["input_shape"] == (18, 32)
+    assert output.shape == (2, 9, 3)
+    expected = torch.tensor([2.0, 3.0, 4.0], dtype=torch.bfloat16).expand(2, 9, 3)
+    torch.testing.assert_close(output, expected)
+
+
+def test_w4a16_nvfp4_cutlass3_prefill_requires_supported_shape():
+    method = W4A16NVFP4LinearMethod()
+    input_tensor = torch.ones((17, 32), dtype=torch.bfloat16)
+    module = SimpleNamespace(
+        weight=torch.empty((6, 16), dtype=torch.uint8),
+        dtype=torch.bfloat16,
+    )
+
+    with patch.dict(os.environ, {"TRTLLM_W4A16_NVFP4_CUTLASS3": "1"}):
+        with patch("tensorrt_llm._torch.modules.linear.get_sm_version", return_value=120):
+            assert not method._can_use_cutlass3_w4a16_prefill(module, input_tensor, m=17)
+
+
+def test_w4a16_nvfp4_linear_cutlass3_unsupported_shape_uses_default_w4a16_op():
+    method = W4A16NVFP4LinearMethod()
+    input_tensor = torch.ones((17, 32), dtype=torch.bfloat16)
+    module = SimpleNamespace(
+        weight=torch.empty((6, 16), dtype=torch.uint8),
+        weight_scale=torch.empty((128 * 4,), dtype=torch.uint8),
+        weight_scale_2=torch.tensor([0.5], dtype=torch.float32),
+        dtype=torch.bfloat16,
+        out_features=3,
+        pre_quant_scale=None,
+    )
+    captured = {}
+
+    def fake_w4a16_nvfp4_gemm(
+        input_arg, weight, weight_scale, weight_scale_2, out_dtype, bias=None
+    ):
+        captured["input"] = input_arg
+        captured["weight"] = weight
+        captured["weight_scale"] = weight_scale
+        captured["weight_scale_2"] = weight_scale_2
+        captured["out_dtype"] = out_dtype
+        captured["bias"] = bias
+        return torch.ones((input_arg.shape[0], weight.shape[0]), dtype=out_dtype)
+
+    def fail_cutlass_gemm(*args, **kwargs):
+        raise AssertionError("unsupported CUTLASS3 shape must use the default W4A16 op")
+
+    def fail_fp4_quantize(*args, **kwargs):
+        raise AssertionError("unsupported CUTLASS3 W4A16 path must not quantize activations")
+
+    with patch.dict(os.environ, {"TRTLLM_W4A16_NVFP4_CUTLASS3": "1"}):
+        with patch("tensorrt_llm._torch.modules.linear.get_sm_version", return_value=120):
+            with patch(
+                "torch.ops.trtllm.w4a16_nvfp4_gemm", side_effect=fake_w4a16_nvfp4_gemm, create=True
+            ):
+                with patch(
+                    "torch.ops.trtllm.w4a16_nvfp4_cutlass_gemm",
+                    side_effect=fail_cutlass_gemm,
+                    create=True,
+                ):
+                    with patch(
+                        "torch.ops.trtllm.fp4_quantize", side_effect=fail_fp4_quantize, create=True
+                    ):
+                        output = method.apply(module, input_tensor, bias=None)
+
+    assert captured["input"] is input_tensor
+    assert captured["bias"] is None
+    assert captured["weight"] is module.weight
+    assert captured["weight_scale"] is module.weight_scale
+    assert captured["weight_scale_2"] is module.weight_scale_2
+    assert captured["out_dtype"] is torch.bfloat16
     assert output.shape == (17, 3)
 
 
@@ -201,7 +440,7 @@ def test_lm_head_uses_w4a16_nvfp4_quant_method_for_packed_lm_head():
     assert lm_head.weight_scale_2.shape == (1,)
 
 
-def test_lm_head_w4a16_nvfp4_forward_dispatches_to_dense_op():
+def test_lm_head_w4a16_nvfp4_forward_dispatches_to_w4a16_op():
     quant_config = QuantConfig(quant_algo=QuantAlgo.W4A16_NVFP4)
     lm_head = LMHead(
         num_embeddings=3, embedding_dim=16, dtype=torch.float16, quant_config=quant_config

--- a/tests/unittest/_torch/modules/test_w4a16_nvfp4_linear.py
+++ b/tests/unittest/_torch/modules/test_w4a16_nvfp4_linear.py
@@ -421,7 +421,7 @@ def test_w4a16_nvfp4_post_load_ignores_checkpoint_activation_scale():
     assert module.input_scale is None
     assert module.inv_input_scale is None
     assert module.alpha is None
-    torch.testing.assert_close(module.weight_scale_2, torch.tensor([0.25], dtype=torch.float32))
+    torch.testing.assert_close(module.weight_scale_2, torch.tensor([4.0], dtype=torch.float32))
     assert not hasattr(module, "tmp_nvfp4_input_scales_list")
     assert not hasattr(module, "tmp_nvfp4_weight_scale_2_list")
 

--- a/tests/unittest/_torch/test_model_config.py
+++ b/tests/unittest/_torch/test_model_config.py
@@ -200,3 +200,27 @@ def test_load_modelopt_quant_config_respects_hf_w4a16_metadata(tmp_path):
     assert quant_config.group_size == 16
     assert quant_config.exclude_modules == ["mtp.layers.0.mixer.q_proj"]
     assert layer_quant_config is None
+
+
+def test_auto_moe_backend_selects_flashinfer_for_nemotron_h_w4a16_sm12x():
+    quant_config = QuantConfig(quant_algo=QuantAlgo.W4A16_NVFP4, group_size=16)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("tensorrt_llm._torch.model_config.get_sm_version", lambda: 121)
+        moe_backend = ModelConfig.resolve_moe_backend_after_quant_config(
+            "AUTO", "NemotronHForCausalLM", quant_config
+        )
+
+    assert moe_backend == "FLASHINFER_NVFP4SM12X"
+
+
+def test_auto_moe_backend_keeps_cutlass_for_nemotron_h_w4a16_on_other_sm():
+    quant_config = QuantConfig(quant_algo=QuantAlgo.W4A16_NVFP4, group_size=16)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("tensorrt_llm._torch.model_config.get_sm_version", lambda: 100)
+        moe_backend = ModelConfig.resolve_moe_backend_after_quant_config(
+            "AUTO", "NemotronHForCausalLM", quant_config
+        )
+
+    assert moe_backend == "CUTLASS"

--- a/tests/unittest/_torch/test_model_config.py
+++ b/tests/unittest/_torch/test_model_config.py
@@ -1,3 +1,4 @@
+import json
 import types
 
 import pytest
@@ -7,6 +8,7 @@ from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.pyexecutor.model_loader import validate_and_set_kv_cache_quant
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
+from tensorrt_llm.quantization.mode import QuantMode
 
 
 def make_pretrained_config(
@@ -116,3 +118,85 @@ def test_validate_and_set_kv_cache_quant_rejects_invalid_dtype():
     model_config = _make_model_config_with_kv_quant(QuantAlgo.FP8)
     with pytest.raises(ValueError, match="Accepted types are"):
         validate_and_set_kv_cache_quant(model_config, "invalid_dtype")
+
+
+def test_quant_mode_distinguishes_w4a16_nvfp4_from_w4a4_nvfp4():
+    w4a4_mode = QuantMode.from_quant_algo(QuantAlgo.NVFP4)
+    assert w4a4_mode.has_nvfp4()
+    assert not w4a4_mode.has_w4a16_nvfp4()
+
+    w4a16_mode = QuantMode.from_quant_algo(QuantAlgo.W4A16_NVFP4)
+    assert w4a16_mode.has_w4a16_nvfp4()
+    assert not w4a16_mode.has_nvfp4()
+    assert w4a16_mode.has_any_quant(exclude_kv_cache=True)
+
+
+def test_load_hf_quant_config_detects_nvfp4_w4a16_compressed_tensors():
+    hf_quant_config = {
+        "quant_method": "compressed-tensors",
+        "format": "nvfp4-pack-quantized",
+        "ignore": ["mtp.layers"],
+        "config_groups": {
+            "group_0": {
+                "targets": ["Linear", "lm_head"],
+                "weights": {
+                    "type": "float",
+                    "num_bits": 4,
+                    "strategy": "group",
+                    "group_size": 16,
+                },
+                "input_activations": None,
+            },
+        },
+    }
+
+    quant_config, layer_quant_config = ModelConfig.load_hf_quant_config(
+        hf_quant_config, moe_backend="CUTLASS"
+    )
+
+    assert quant_config.quant_algo == QuantAlgo.W4A16_NVFP4
+    assert quant_config.group_size == 16
+    assert quant_config.exclude_modules == ["mtp.layers"]
+    assert layer_quant_config is None
+
+
+def test_load_modelopt_quant_config_respects_hf_w4a16_metadata(tmp_path):
+    modelopt_quant_config = {
+        "quantization": {
+            "quant_algo": "NVFP4",
+            "kv_cache_quant_algo": None,
+            "group_size": 16,
+            "exclude_modules": ["mtp*"],
+        }
+    }
+    hf_quant_config = {
+        "quant_method": "compressed-tensors",
+        "format": "nvfp4-pack-quantized",
+        "ignore": ["mtp.layers.0.mixer.q_proj"],
+        "config_groups": {
+            "group_0": {
+                "targets": ["Linear", "lm_head"],
+                "weights": {
+                    "type": "float",
+                    "num_bits": 4,
+                    "strategy": "tensor_group",
+                    "group_size": 16,
+                },
+                "input_activations": None,
+            },
+        },
+    }
+    quant_config_file = tmp_path / "hf_quant_config.json"
+    quant_config_file.write_text(json.dumps(modelopt_quant_config), encoding="utf-8")
+
+    quant_config, layer_quant_config = ModelConfig.load_modelopt_quant_config(
+        str(quant_config_file),
+        str(tmp_path),
+        moe_backend="CUTLASS",
+        hf_quant_config=hf_quant_config,
+    )
+
+    assert quant_config.quant_algo == QuantAlgo.W4A16_NVFP4
+    assert quant_config.group_size == 16
+    assert quant_config.exclude_modules == ["mtp.layers.0.mixer.q_proj"]
+    assert layer_quant_config is None

--- a/tests/unittest/_torch/test_model_config.py
+++ b/tests/unittest/_torch/test_model_config.py
@@ -202,25 +202,33 @@ def test_load_modelopt_quant_config_respects_hf_w4a16_metadata(tmp_path):
     assert layer_quant_config is None
 
 
-def test_auto_moe_backend_selects_flashinfer_for_nemotron_h_w4a16_sm12x():
+@pytest.mark.parametrize(
+    "architecture",
+    ["NemotronHForCausalLM", "Qwen3MoeForCausalLM", "SomeOtherForCausalLM"],
+)
+def test_auto_moe_backend_selects_cutedsl_for_w4a16_sm12x(architecture):
     quant_config = QuantConfig(quant_algo=QuantAlgo.W4A16_NVFP4, group_size=16)
 
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr("tensorrt_llm._torch.model_config.get_sm_version", lambda: 121)
         moe_backend = ModelConfig.resolve_moe_backend_after_quant_config(
-            "AUTO", "NemotronHForCausalLM", quant_config
+            "AUTO", architecture, quant_config
         )
 
-    assert moe_backend == "FLASHINFER_NVFP4SM12X"
+    assert moe_backend == "CUTEDSL"
 
 
-def test_auto_moe_backend_keeps_cutlass_for_nemotron_h_w4a16_on_other_sm():
+@pytest.mark.parametrize(
+    "architecture",
+    ["NemotronHForCausalLM", "Qwen3MoeForCausalLM", "SomeOtherForCausalLM"],
+)
+def test_auto_moe_backend_keeps_cutlass_for_w4a16_on_other_sm(architecture):
     quant_config = QuantConfig(quant_algo=QuantAlgo.W4A16_NVFP4, group_size=16)
 
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr("tensorrt_llm._torch.model_config.get_sm_version", lambda: 100)
         moe_backend = ModelConfig.resolve_moe_backend_after_quant_config(
-            "AUTO", "NemotronHForCausalLM", quant_config
+            "AUTO", architecture, quant_config
         )
 
     assert moe_backend == "CUTLASS"


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
Adds SM120/SM121 NVFP4 support for Nemotron-H style W4A16 paths and FlashInfer b12x MoE.                                                                                                                                                                  
                                                                                                                                                                                                                                                            
  Key changes:                                                                                                                                                                                                                                              
  - Add W4A16 NVFP4 model/config/loader plumbing, including compressed-tensors weight mapping and LMHead quant handling.
  - Add FlashInfer NVFP4 SM12x MoE backend with b12x routing.
  - Add W4A16 NVFP4 linear support:
    - cuda-core decode/default path for small-M, e.g. decode
    - transient dequant CUTLASS for large-M, e.g. prefill
    - torch custom op registration and focused unit coverage

  ## Test Plan

  - `cmake --build . --target kernels_src th_common -j 8`
    - Passed in `tensorrt_llm-nvfp4-w4a16-build-pamelap`
  - `pytest -q tests/unittest/_torch/modules/test_w4a16_nvfp4_linear.py`
    - Passed: `15 passed`
<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
