### PR TITLE
[#14146][fix] Fix CuteDSL MoE generate_token_selected_experts ghost-token and multi-rank bugs

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -147,7 +147,8 @@ class GroupedGemmInputsHelper:
             selection_order_j = selection_orders[j].tolist()
             global_j = j + self.local_expert_offset
             prioritized = torch.nonzero(num_selected_experts <= (
-                self.top_k - (self.num_experts - global_j))).squeeze(-1).tolist()
+                self.top_k -
+                (self.num_experts - global_j))).squeeze(-1).tolist()
             if len(prioritized) > 0:
                 selection_order_j = prioritized + [
                     i for i in selection_order_j if i not in prioritized

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -142,9 +142,12 @@ class GroupedGemmInputsHelper:
             ]
 
         for j, num_tokens_j in enumerate(num_tokens_per_expert):
+            if num_tokens_j <= 0:
+                continue
             selection_order_j = selection_orders[j].tolist()
+            global_j = j + self.local_expert_offset
             prioritized = torch.nonzero(num_selected_experts <= (
-                self.top_k - (self.num_experts - j))).squeeze(-1).tolist()
+                self.top_k - (self.num_experts - global_j))).squeeze(-1).tolist()
             if len(prioritized) > 0:
                 selection_order_j = prioritized + [
                     i for i in selection_order_j if i not in prioritized


### PR DESCRIPTION
Fixes #14146.

Two bugs in tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py surfaced by the Flashinfer review on the issue.

First, when num_tokens_j is zero, the outer loop still entered the prioritization block, allowing ghost tokens to be selected for experts with no actual workload. This PR guards the iteration with an early continue.

Second, the multi-rank case compared the local index j directly against global expert IDs; on multi-rank deployments this silently elected the wrong experts. Translating local-to-global with self.local_expert_offset before the comparison resolves it.

Both diffs originate verbatim from the issue body.

Signed-off-by: Aditya Singh <adisin650@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed expert selection mechanism to properly handle experts with no assigned tokens
  * Corrected expert prioritization logic in token-expert routing for improved accuracy

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14428?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->