### PR TITLE
[None][fix] Cherry-pick PR #14276: Handle unset attention_dp_relax in ADP routers

### DIFF
--- a/tensorrt_llm/scheduling_params.py
+++ b/tensorrt_llm/scheduling_params.py
@@ -10,12 +10,13 @@ class SchedulingParams:
 
     Args:
         attention_dp_rank (int): The rank of target attention dp
-        attention_dp_relax (bool): Whether to allow the request to be scheduled to other attention dp for better throughput
+        attention_dp_relax (bool): Whether to allow the request to be scheduled to other attention dp for better
+            throughput. Defaults to True.
         agent_hierarchy (AgentHierarchy): Path of (agent_type, node_id) tuples
             identifying this request's position in an agent execution tree.
             Used by the batch scheduler for hierarchy-aware scheduling.
     """
 
     attention_dp_rank: Optional[int] = None
-    attention_dp_relax: Optional[bool] = None
+    attention_dp_relax: bool = True
     agent_hierarchy: Optional[AgentHierarchy] = None

--- a/tests/unittest/_torch/executor/test_adp_router.py
+++ b/tests/unittest/_torch/executor/test_adp_router.py
@@ -18,6 +18,7 @@ from tensorrt_llm._torch.pyexecutor.scheduler.adp_router import (
     KVCacheAwareADPRouter,
     RankState,
 )
+from tensorrt_llm.scheduling_params import SchedulingParams
 
 
 def _mock_dist(tp_rank=0, tp_size=1, has_cp_helix=False):
@@ -184,6 +185,23 @@ class TestDefaultADPRouter:
         result, _ = router.route_requests(states, [req], max_num_active_requests=2)
         assert len(result[0]) == 1
         assert len(result[1]) == 0
+
+    def test_default_attention_dp_relax_is_relaxed(self):
+        router = DefaultADPRouter(dist=_mock_dist())
+        states = [
+            RankState(rank=0, num_active_requests=0, num_active_tokens=0),
+            RankState(rank=1, num_active_requests=0, num_active_tokens=0),
+        ]
+        req_relax = _make_request_item(1, target_dp_rank=0)
+        req_relax.request.py_scheduling_params = SchedulingParams(attention_dp_rank=0)
+        req_strict = _make_request_item(2, target_dp_rank=0, attention_dp_relax=False)
+
+        result, _ = router.route_requests(
+            states, [req_relax, req_strict], max_num_active_requests=1
+        )
+
+        assert result[0] == [req_strict]
+        assert req_relax in result[1]
 
     def test_favors_less_loaded_rank(self):
         router = DefaultADPRouter(dist=_mock_dist())
@@ -875,6 +893,19 @@ class TestKVCacheAwareADPRouterRouting:
         result, _ = router.route_requests(self._rank_states(2), [req], max_num_active_requests=10)
         assert result[0] == []
         assert result[1] == [req]
+
+    def test_default_attention_dp_relax_is_relaxed(self):
+        router = self._make_router(tp_size=2)
+        req_relax = _make_request_item(1, target_dp_rank=0)
+        req_relax.request.py_scheduling_params = SchedulingParams(attention_dp_rank=0)
+        req_strict = _make_request_item(2, target_dp_rank=0, attention_dp_relax=False)
+
+        result, _ = router.route_requests(
+            self._rank_states(2), [req_relax, req_strict], max_num_active_requests=1
+        )
+
+        assert result[0] == [req_strict]
+        assert req_relax in result[1]
 
     def test_match_rate_threshold_gates_cache_affinity(self):
         """With rank 0 loaded but holding cache, and rank 1 idle with no


### PR DESCRIPTION
## Summary

Cherry-pick of upstream main PR #14276 ([3de344d384](https://github.com/NVIDIA/TensorRT-LLM/commit/3de344d384dc8cc57d57a032924aa8a49ff027dd)) onto the `feat/deepseek_v4` development branch.

**Why**: `feat/deepseek_v4` does not yet have PR #14276 (merged on `main` 2026-05-19). Without it, the `feat/deepseek_v4` line crashes at every Phase-transition point where the request batch contains multiple `SchedulingParams` objects with `attention_dp_relax = None`:

```
File ".../_torch/pyexecutor/scheduler/adp_router.py", line 517, in route_requests
    sorted_requests = sorted(new_requests, key=get_relax_value)
TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'
```

This was reproduced on an agg DSV4-Pro RWLT validation run (2 nodes × GB300, TP8/TEP8/MTP3) at the Phase 0 → Phase 1 transition (concurrency 1 → 4) — **all 8 ranks** crashed simultaneously on both `DefaultADPRouter.route_requests` (line 232) and `KVCacheAwareADPRouter.route_requests` (line 517), since both routers share the same `get_relax_value` helper that dereferences `scheduling_params.attention_dp_relax` which can be `None`.

The upstream fix in PR #14276 changes the root cause — the default value of `SchedulingParams.attention_dp_relax`:

```diff
-    attention_dp_relax: Optional[bool] = None
+    attention_dp_relax: bool = True
```

so the router's `sorted(...)` no longer sees `None` keys. Treating unset = "relaxed" (True) matches the semantics: an unset request has no specific rank preference and can be routed anywhere.