### PR TITLE
[None][fix] DSv4 fused FP8 Q-quant: q_pe must be 3D for thop.attention

### DIFF
--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1762,21 +1762,21 @@ class MLA(nn.Module):
             self._quant_scale_qkv = torch.tensor([1.0],
                                                  dtype=torch.float32,
                                                  device=q_proj.device)
-        # Allocate the interleaved [N, H*head_dim] FP8 buffer (nope filled by
-        # this op, rope slot left for applyMLARopeAndAssignQKVKernelOptContext) and the bf16 rope buffer.
+        # q_pe is 3D so thop.attention's sparse-MLA context branch passes its
+        # q_pe->dim() == 3 check; the kernel op consumes the flat 2D view.
         num_tokens = q_proj.shape[0]
         rope_dim = self.qk_head_dim - self.kv_lora_rank
         quant_q_buffer = q_proj.new_empty(
             (num_tokens, self.num_heads_tp * self.qk_head_dim),
             dtype=torch.float8_e4m3fn)
-        q_pe = q_proj.new_empty((num_tokens, self.num_heads_tp * rope_dim))
+        q_pe = q_proj.new_empty((num_tokens, self.num_heads_tp, rope_dim))
         torch.ops.trtllm.deepseek_v4_q_norm_fused_fp8(
             q_proj,
             quant_q_buffer,
-            q_pe,
+            q_pe.view(num_tokens, self.num_heads_tp * rope_dim),
             self.num_heads_tp,
             self.qk_head_dim,
-            self.kv_lora_rank,  # nope_dim
+            self.kv_lora_rank,
             float(self.q_b_layernorm.variance_epsilon),
             self._quant_scale_qkv,
         )

--- a/tests/integration/test_lists/test-db/l0_b200_ds.yml
+++ b/tests/integration/test_lists/test-db/l0_b200_ds.yml
@@ -25,6 +25,7 @@ l0_b200_ds:
   - unittest/_torch/attention/sparse/deepseek_v4/test_compressor_kernel.py TIMEOUT (90)
   - unittest/_torch/attention/sparse/deepseek_v4/test_compressor_module.py TIMEOUT (90)
   - unittest/_torch/attention/sparse/deepseek_v4/test_compressor_tf32.py TIMEOUT (15)
+  - unittest/_torch/custom_ops/test_deepseek_v4_q_norm.py TIMEOUT (15)
   # ------------- Disaggregated transfer component tests (single GPU) ---------------
   - unittest/disaggregated/test_agent.py
   - unittest/disaggregated/test_agent_multi_backends.py

--- a/tests/unittest/_torch/custom_ops/test_deepseek_v4_q_norm.py
+++ b/tests/unittest/_torch/custom_ops/test_deepseek_v4_q_norm.py
@@ -169,6 +169,42 @@ def test_deepseek_v4_q_norm_fused_fp8_zero_rows():
 
 
 @pytest.mark.parametrize("num_tokens", [1, 7, 129])
+def test_deepseek_v4_q_b_layernorm_fused_fp8_returns_3d_q_pe(num_tokens):
+    """Lock down the q_pe dim==3 contract expected by thop.attention's
+    sparse-MLA context branch (TORCH_CHECK(q_pe->dim() == 3))."""
+    import types
+    from types import SimpleNamespace
+
+    from tensorrt_llm._torch.modules.attention import MLA
+
+    num_heads = 16
+    qk_head_dim = 512
+    kv_lora_rank = 448
+    rope_dim = qk_head_dim - kv_lora_rank
+    stub = SimpleNamespace(
+        num_heads_tp=num_heads,
+        qk_head_dim=qk_head_dim,
+        kv_lora_rank=kv_lora_rank,
+        q_b_layernorm=SimpleNamespace(variance_epsilon=1e-6),
+    )
+    fused = types.MethodType(MLA._deepseek_v4_q_b_layernorm_fused_fp8, stub)
+    q_proj = torch.randn(
+        num_tokens, num_heads * qk_head_dim, dtype=torch.bfloat16, device="cuda"
+    ).contiguous()
+
+    placeholder_q, quant_q_buffer, q_pe, scale = fused(q_proj)
+
+    assert q_pe.shape == (num_tokens, num_heads, rope_dim)
+    assert q_pe.stride(2) == 1
+    assert q_pe.is_contiguous()
+    assert quant_q_buffer.shape == (num_tokens, num_heads * qk_head_dim)
+    assert quant_q_buffer.dtype == torch.float8_e4m3fn
+    assert placeholder_q.data_ptr() == q_proj.data_ptr()
+    assert scale.shape == (1,) and scale.dtype == torch.float32
+    assert float(scale.item()) == 1.0
+
+
+@pytest.mark.parametrize("num_tokens", [1, 7, 129])
 @pytest.mark.parametrize("num_heads", [1, 16, 128])
 def test_deepseek_v4_q_norm_fused_fp8_interleaved_layout(num_tokens, num_heads):
     """The per-head stride of `quant_q_out` is inferred from the buffer shape:


### PR DESCRIPTION
The fused-FP8 path in `_deepseek_v4_q_b_layernorm_fused_fp8` allocates `q_pe` as 2D `[N, H * rope_dim]` and stashes it on `self._fused_q_pe`. In `forward_absorption_context`, that 2D tensor is then forwarded verbatim as `q_pe` to `thop.attention`, which fails the `TORCH_CHECK(q_pe->dim() == 3)` guard in the
`is_context && op.mUseSparseAttention` branch (attentionOp.cpp:208). The non-fused path uses `q.view(-1, H, head_dim).split(...)` which yields a 3D `q_pe`, so the shape mismatch is fused-only.

The shape bug is latent under existing CI coverage because DSv4-Flash / DSv4-Flash-Base test configs don't set `kv_cache_quant_algo=fp8`, so `has_fp8_kv_cache=False` and the fused path is gated off in `_is_fused_q_fp8_quant_enabled`. Once anyone enables FP8 KV cache (a follow-up perf knob) the C++ TORCH_CHECK fires immediately.

Fix: allocate `q_pe` as 3D `[N, H, rope_dim]` to match the non-fused layout, and pass a flat `.view(N, H * rope_dim)` to `deepseek_v4_q_norm_fused_fp8` (whose 2D contract is unchanged). The storage is identical so the kernel writes the same memory; only the downstream consumer's tensor metadata sees a 3D shape.

Test: `test_deepseek_v4_q_b_layernorm_fused_fp8_returns_3d_q_pe` binds the method on a SimpleNamespace stub and asserts the returned q_pe is 3D, contiguous, with stride[2]==1. This fails on the pre-fix 2D allocation, locking down the contract going forward.

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
