### PR TITLE
[None][feat] adp_router: salt-aware probe_prefix_match_length on v1/v2 KV cache backends

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -677,11 +677,19 @@ class KVCacheManager(BaseResourceManager):
             device='cpu')
         self.blocks_per_window = blocks_per_window
 
-    def probe_prefix_match_length(self, input_tokens, lora_task_id=None):
+    def probe_prefix_match_length(self,
+                                  input_tokens,
+                                  lora_task_id=None,
+                                  cache_salt_id=None):
         """Probe the KV cache radix tree for prefix match length.
 
         Returns the number of prefix tokens already cached on this rank.
         Used by KVCacheAwareADPRouter for cache-aware routing.
+
+        ``cache_salt_id`` scopes the probe to the same per-request
+        namespace that ``_create_kv_cache`` uses; without it, salted
+        requests would be probed against the salt=None namespace and the
+        router would see the wrong match length.
         """
         if not self.enable_block_reuse:
             return 0
@@ -698,12 +706,16 @@ class KVCacheManager(BaseResourceManager):
             LlmRequest as CppLlmRequest
         block_key = BlockKey(tokens=input_tokens, lora_task_id=lora_task_id)
         unique_tokens = block_key.unique_tokens
+        # buildBlockKeys() on the C++ side pulls cache_salt_id off the
+        # request, so dummy_req must carry it for the probe namespace to
+        # match the real create_kv_cache path.
         dummy_req = CppLlmRequest(request_id=0,
                                   max_new_tokens=0,
                                   input_tokens=input_tokens,
                                   sampling_config=SamplingConfig(),
                                   is_streaming=False,
-                                  lora_task_id=lora_task_id)
+                                  lora_task_id=lora_task_id,
+                                  cache_salt_id=cache_salt_id)
         summary = self.impl.analyze_prefix_reuse(unique_tokens, dummy_req)
         return summary.reusable_blocks_all * self.tokens_per_block
 
@@ -2584,6 +2596,33 @@ class KVCacheManagerV2(BaseResourceManager):
         """Return True if *request_id* has a live, non-suspended KV cache."""
         kv_cache = self.kv_cache_map.get(request_id)
         return kv_cache is not None and kv_cache.is_active
+
+    def probe_prefix_match_length(self,
+                                  input_tokens,
+                                  lora_task_id=None,
+                                  cache_salt_id=None):
+        """Probe the v2 KV cache radix tree for prefix match length.
+
+        Returns the number of prefix tokens already cached on this rank,
+        without acquiring page ownership. Mirrors the v1 KVCacheManager
+        adapter so KVCacheAwareADPRouter works on both backends.
+
+        ``cache_salt_id`` (and ``lora_task_id``) must match the values
+        used by ``_create_kv_cache`` (which constructs
+        ``ReuseScope(lora_id=lora_task_id, salt=cache_salt_id)``).
+        Otherwise the probe queries the wrong reuse namespace and the
+        router sees an incorrect match length.
+        """
+        if not self.enable_block_reuse:
+            return 0
+        if not input_tokens:
+            return 0
+        from tensorrt_llm.runtime.kv_cache_manager_v2._block_radix_tree import \
+            ReuseScope
+        return self.impl.probe_reuse(
+            ReuseScope(lora_id=lora_task_id, salt=cache_salt_id),
+            input_tokens,
+        )
 
     def _effective_draft_len(self, req: LlmRequest) -> int:
         """Draft token length to use for next-step KV capacity calculation.

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -424,7 +424,14 @@ class KVCacheAwareADPRouter(ADPRouter):
             probe_tokens = input_tokens[:-1] if len(input_tokens) > 1 else []
             lora_config = getattr(req, "lora_config", None)
             lora_task_id = lora_config.task_id if lora_config is not None else None
-            match_len = self.kv_cache_manager.probe_prefix_match_length(probe_tokens, lora_task_id)
+            # cache_salt_id scopes block reuse on both v1 and v2 backends;
+            # passing None for non-salted requests is a no-op.
+            cache_salt_id = getattr(req, "cache_salt_id", None)
+            match_len = self.kv_cache_manager.probe_prefix_match_length(
+                probe_tokens,
+                lora_task_id,
+                cache_salt_id=cache_salt_id,
+            )
             local_matches.extend([req_item.id, match_len])
 
         all_data = self.dist.tp_allgather(local_matches)


### PR DESCRIPTION
## Summary

Make `KVCacheAwareADPRouter` work on `KVCacheManagerV2` (currently `AttributeError`s) and become salt-aware on `KVCacheManager` v1 (currently probes the wrong namespace for salted requests).

Before this change:

- **v2 KVCacheManagerV2** has no `probe_prefix_match_length`, so any v2 backend (DSV4 in particular) crashes with `AttributeError` in `adp_router.gather_prefix_matches` as soon as `attention_dp_config.enable_kv_cache_aware_routing=true`.
- **v1 KVCacheManager** has a probe but never forwarded `cache_salt_id` onto the dummy `LlmRequest`, so salted requests were probed against the `salt=None` namespace while `_create_kv_cache` wrote to the salted one. Router saw match_len=0 for everything that was actually warm.

After this change, both backends probe the same namespace their `_create_kv_cache` paths write to: `(lora_task_id, cache_salt_id)`.

## What's in this PR

- `tensorrt_llm/_torch/pyexecutor/resource_manager.py`:
  - Add `KVCacheManagerV2.probe_prefix_match_length(probe_tokens, lora_task_id, *, cache_salt_id=None)` that delegates to `KVCacheManager.probe_reuse(ReuseScope(lora_task_id, cache_salt_id))` (the probe API added in #14395).
  - Extend the v1 `probe_prefix_match_length` to accept `cache_salt_id` and pass it through to the C++ `LlmRequest` so `buildBlockKeys()` resolves the correct namespace.
- `tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py`:
  - In `gather_prefix_matches`, read `req.cache_salt_id` (defaulting to `None`) and forward it to the probe call.