### PR TITLE
[None][fix] Autotuner cache: merge instead of replace, atomic save

### DIFF
--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -359,6 +359,32 @@ class AutoTunerStatistics:
         return stats_str
 
 
+@contextlib.contextmanager
+def _exclusive_cache_lock(lock_path: Path):
+    """Cross-node-correct exclusive lock used by save_cache/load_cache.
+
+    POSIX byte-range lock (`fcntl.lockf`) held on a SEPARATE lockfile
+    (not the data file), which avoids the truncate / rename complications
+    of locking the file you're also rewriting. The lockfile is persistent;
+    the kernel releases the lock when the holding fd is closed — including
+    on process death, so there is no stale-lock cleanup path to maintain.
+
+    Both readers and writers use LOCK_EX: read/write frequencies on the
+    autotuner cache are similar and the simpler "always exclusive" model
+    avoids reader/writer-priority pitfalls on networked filesystems.
+    """
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.lockf(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            fcntl.lockf(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
 class AutoTunerProfilingCache:
     """AutoTunerCache for caching profiling results.
 
@@ -509,9 +535,28 @@ class AutoTunerProfilingCache:
         Note:
             The cache is saved in JSON format which provides human-readable output.
             Some type information may be lost for complex tactic objects.
+
+            Concurrency model:
+            * Cross-process mutual exclusion uses POSIX byte-range locks
+              (`fcntl.lockf`) on a SEPARATE lockfile next to the data
+              file. The lockfile is persistent (never unlinked); the
+              kernel auto-releases the lock when the holding fd is
+              closed, including on crash, so no stale-lock cleanup is
+              needed. Both readers and writers take LOCK_EX — read/write
+              frequencies are similar here and the simpler logic is
+              worth more than read parallelism.
+            * The data file itself is replaced atomically via
+              (write-to-tmp + fsync + rename). A writer killed at any
+              point leaves a discardable .tmp file; `file_path` is never
+              partially written, so concurrent readers always see a
+              fully-formed JSON document.
+            * The on-disk rank-specific dict is MERGED (not replaced)
+              with this writer's contribution so a concurrent writer
+              that loaded earlier does not get its entries clobbered.
         """
         file_path = Path(file_path)
         file_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = self._lock_path_for(file_path)
 
         try:
             # Partition cache into shared (non-INDEPENDENT) and rank-specific (INDEPENDENT)
@@ -520,18 +565,8 @@ class AutoTunerProfilingCache:
             serialized_shared_cache = self._serialize_cache_data(shared_cache)
             serialized_rank_cache = self._serialize_cache_data(rank_cache)
 
-            with open(file_path, 'a+') as f:
-                fcntl.flock(f, fcntl.LOCK_EX)
-                f.seek(0)
-                content = f.read()
-                if content.strip():
-                    current_cache = json.loads(content)
-                else:
-                    current_cache = {
-                        "metadata": self._serialize_metadata(),
-                    }
-                f.seek(0)
-                f.truncate()
+            with _exclusive_cache_lock(lock_path):
+                current_cache = self._read_existing_cache(file_path)
 
                 # Merge shared cache entries (non-INDEPENDENT ops)
                 if self.SHARED_CACHE_KEY not in current_cache:
@@ -539,16 +574,58 @@ class AutoTunerProfilingCache:
                 current_cache[self.SHARED_CACHE_KEY].update(
                     serialized_shared_cache)
 
-                # Save rank-specific cache entries (INDEPENDENT ops)
-                current_cache[f"rank_{rank}"] = serialized_rank_cache
+                # Merge rank-specific cache entries (INDEPENDENT ops).
+                # MUST be a merge (not assignment): a concurrent writer
+                # that committed its rank_{rank} contribution between
+                # this writer's load_cache and save_cache would otherwise
+                # be silently dropped by an `=` assignment that re-writes
+                # the slot with only this writer's in-memory cache.
+                rank_key = f"rank_{rank}"
+                if rank_key not in current_cache:
+                    current_cache[rank_key] = {}
+                current_cache[rank_key].update(serialized_rank_cache)
 
-                json.dump(current_cache, f, indent=2, default=str)
+                self._atomic_write_json(file_path, current_cache)
             logger.info(
                 f"[AutoTuner] Successfully saved cache to {file_path} using JSON format"
             )
         except Exception as e:
             logger.error(f"[AutoTuner] Failed to save cache with JSON: {e}")
             raise
+
+    @staticmethod
+    def _lock_path_for(file_path: Path) -> Path:
+        """Return the lockfile path that pairs with `file_path`."""
+        return file_path.with_name(file_path.name + ".lock")
+
+    def _read_existing_cache(self, file_path: Path) -> Dict[str, Any]:
+        """Read the data file (best-effort) under the caller's lock."""
+        if not file_path.exists():
+            return {"metadata": self._serialize_metadata()}
+        try:
+            with open(file_path, "r") as f:
+                content = f.read()
+            if not content.strip():
+                return {"metadata": self._serialize_metadata()}
+            return json.loads(content)
+        except (FileNotFoundError, json.JSONDecodeError) as e:
+            # An earlier writer from a pre-fix version may have left a
+            # corrupted file behind. Don't fail the current save — start
+            # from a fresh dict and overwrite atomically.
+            logger.warning(f"[AutoTuner] Could not parse existing cache at "
+                           f"{file_path}: {e!r}; starting from a fresh dict.")
+            return {"metadata": self._serialize_metadata()}
+
+    @staticmethod
+    def _atomic_write_json(file_path: Path, payload: Dict[str, Any]) -> None:
+        """Write `payload` to `file_path` atomically (tmp + fsync + rename)."""
+        tmp_path = file_path.with_name(
+            f".{file_path.name}.tmp.{os.getpid()}.{time.time_ns()}")
+        with open(tmp_path, "w") as f:
+            json.dump(payload, f, indent=2, default=str)
+            f.flush()
+            os.fsync(f.fileno())
+        os.rename(tmp_path, file_path)
 
     def load_cache(self, file_path: Union[str, Path], rank: int) -> None:
         """Load the profiling cache from disk in JSON format.
@@ -572,11 +649,13 @@ class AutoTunerProfilingCache:
         if not file_path.exists():
             raise FileNotFoundError(f"Cache file not found: {file_path}")
 
+        lock_path = self._lock_path_for(file_path)
         try:
-            with open(file_path, 'r') as f:
-                fcntl.flock(f, fcntl.LOCK_SH)
-                current_cache_contents = json.load(f)
-                self._deserialize_metadata(current_cache_contents["metadata"])
+            with _exclusive_cache_lock(lock_path):
+                with open(file_path, "r") as f:
+                    current_cache_contents = json.load(f)
+            self._deserialize_metadata(
+                current_cache_contents.get("metadata", {}))
 
             # Start with empty cache and independent ops set
             self.cache = {}


### PR DESCRIPTION
## Description

Two related fixes to `AutoTunerProfilingCache` (`tensorrt_llm/_torch/autotuner.py`) so concurrent jobs sharing `TLLM_AUTOTUNER_CACHE_PATH` stop losing work and the cache file is no longer corrupted by a writer killed mid-write.

### 1. Merge, do not replace, the per-rank dict on save

`current_cache[f"rank_{rank}"] = serialized_rank_cache` was wiping every other concurrent writer's `rank_{rank}` contribution and any preexisting on-disk entries the current process did not load.

Replaced with the same `setdefault(...).update(...)` pattern already used for the shared dict.

Verified by a 4-job synthetic stress (`cache-race-multi-job/`): **0 of 3 lost-update rounds after fix vs 3 of 3 before**.

### 2. Move locking off the data file and replace truncate+json.dump with write-tmp + fsync + os.rename

The previous code held `fcntl.flock(LOCK_EX)` on the data file in `'a+'` mode and did `seek + read + truncate + json.dump` in-place. Two real failure modes:

- A writer killed mid-`json.dump` (preempt / OOM / scancel / node failure) leaves a partially-written file and every subsequent reader fails with `JSONDecodeError`. Observed on a 60-job stress with a payload ~30 MB.
- `O_APPEND` from `'a+'` plus `truncate` semantics are filesystem-quirky and make the failure unrecoverable across nodes.

New design:
- `fcntl.lockf(LOCK_EX)` on a **separate** persistent lockfile next to the data file (POSIX byte-range lock; more portable across Lustre / NFS than BSD `flock(2)`). Lockfile is never unlinked; the kernel releases the lock on fd close including process death, so no stale-lock cleanup path is needed.
- The data file body is written to `<name>.tmp.<pid>.<ns>`, `fsync`'d, and then `os.rename`'d. A killed writer leaves only a discardable tmp file; the data file is never partially written, so concurrent readers always observe a fully-formed JSON document.

## Relation to PR #14458

The `TuningConfig.exclude_from_cache` flag and single-(runner, tactic) profile shortcut for JIT-driver ops were originally bundled here. They are now split into **PR #14458**, opened independently against `feat/deepseek_v4`. The two PRs do not depend on each other.

## Test Coverage

Validated end-to-end on lyris with the following stress harnesses (in this repo under `cache-race-multi-job/` and `cache-race-e2e-v3lite/`):

- **Synthetic per-writer race repro** — 4 SLURM jobs × 4 procs each, barrier-synchronised + 10 s hold inside `autotune()` so save_cache calls all overlap. Each writer tunes a unique op-name + payload so lost entries are detectable by counting. Before fix: 3 of 3 rounds dropped 3 of 4 writers' contributions; after fix: 0 of 3 rounds drop any writer.
- **Cross-node counter test** — 60 SLURM jobs × 4 procs × 50 iters incrementing one shared file. Counter ends at 12 000 / 12 000 with the new lockfile-based code, confirming POSIX byte-range locks serialise correctly cross-node on this Lustre.
- **Single-host RMW stress** — 16 procs × 300 iters of save_cache pattern. With the previous `'a+' + flock` design and the lock disabled, the file corrupts within the first 10 iterations (`JSONDecodeError: Extra data ...`). With the new design (separate lockfile + atomic rename) the file remains valid JSON across 9 600 RMW ops.
- **E2E DS-V3-Lite** — multi-job `trtllm-bench throughput --tp 4` runs sharing one `TLLM_AUTOTUNER_CACHE_PATH`. Every writer's contribution survives in the on-disk file; no crashes.

No new unit tests added in this PR (the existing `tests/unittest/_torch/misc/test_autotuner.py` has **zero coverage of save_cache / load_cache** — adding multi-writer coverage is a worthwhile follow-up but out of scope for this fix).

## PR Checklist

- [x] PR description clearly explains what and why.
- [x] PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of my knowledge.
- [x] No new dependencies introduced.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
