### PR TITLE
[None][fix] Fix KV cache grain slot refinement

### DIFF
--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage/_core.py
@@ -755,7 +755,7 @@ class CacheLevelStorage:
         slot_size_list: TypedIndexList[PoolIndex, int],
         granularity: int,
     ) -> tuple[int, int]:
-        """Distribute grains among pools within a pool group.
+        """Compute the maximum slots that fit in a pool group grain budget.
 
         Returns (num_slots, grains_consumed).
         """
@@ -779,9 +779,24 @@ class CacheLevelStorage:
             remaining_pg_grains -= pool_grains
         assert remaining_pg_grains == 0
         assert num_slots > 0
-        return num_slots, CacheLevelStorage._grains_for_slots(
-            num_slots, slot_size_list, granularity
-        )
+        _s2g = CacheLevelStorage._grains_for_slots
+        lo = num_slots
+        step = 1
+        hi = lo + step
+        while _s2g(hi, slot_size_list, granularity) <= pg_grains:
+            lo = hi
+            step *= 2
+            hi = lo + step
+        while lo + 1 < hi:
+            mid = (lo + hi) // 2
+            if _s2g(mid, slot_size_list, granularity) <= pg_grains:
+                lo = mid
+            else:
+                hi = mid
+        used = _s2g(lo, slot_size_list, granularity)
+        assert used <= pg_grains
+        assert _s2g(lo + 1, slot_size_list, granularity) > pg_grains
+        return lo, used
 
     @staticmethod
     def _grains_for_slots(

--- a/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
@@ -64,6 +64,7 @@ if not TYPE_CHECKING and find_spec("kv_cache_manager_v2") is not None:
     from kv_cache_manager_v2._copy_engine import CopyTask, batched_copy
     from kv_cache_manager_v2._exceptions import OutOfPagesError
     from kv_cache_manager_v2._life_cycle_registry import SsmLifeCycle
+    from kv_cache_manager_v2._storage._core import CacheLevelStorage
     from kv_cache_manager_v2._utils import (
         CachedCudaStream,
         HalfOpenRange,
@@ -115,6 +116,7 @@ else:
     from tensorrt_llm.runtime.kv_cache_manager_v2._copy_engine import CopyTask, batched_copy
     from tensorrt_llm.runtime.kv_cache_manager_v2._exceptions import OutOfPagesError
     from tensorrt_llm.runtime.kv_cache_manager_v2._life_cycle_registry import SsmLifeCycle
+    from tensorrt_llm.runtime.kv_cache_manager_v2._storage._core import CacheLevelStorage
     from tensorrt_llm.runtime.kv_cache_manager_v2._utils import (
         CachedCudaStream,
         HalfOpenRange,
@@ -185,6 +187,43 @@ def assert_no_ref_cycle(func):
         return result
 
     return wrapper
+
+
+class TestCacheLevelStorage(unittest.TestCase):
+    def test_grains_to_slots_refines_proportional_lower_bound(self) -> None:
+        granularity = 16 << 20
+        slot_size_list = [16_252_928, 4_063_232]
+        min_slots = 157
+
+        grains = CacheLevelStorage._grains_for_slots(min_slots, slot_size_list, granularity)
+        slots, used = CacheLevelStorage._grains_to_slots(grains, slot_size_list, granularity)
+
+        self.assertGreaterEqual(slots, min_slots)
+        self.assertLessEqual(used, grains)
+
+    def test_ratio_to_slot_count_list_preserves_min_slots(self) -> None:
+        granularity = 16 << 20
+        slot_size_lists = [
+            [16_252_928, 4_063_232],
+            [491_520, 126_720, 15_872],
+            [31_457_280, 7_864_320],
+        ]
+        min_slots = [157, 3907, 157]
+        total_min_grains = sum(
+            CacheLevelStorage._grains_for_slots(slots, sizes, granularity)
+            for slots, sizes in zip(min_slots, slot_size_lists)
+        )
+
+        slot_counts = CacheLevelStorage.ratio_to_slot_count_list(
+            total_min_grains * granularity,
+            slot_size_lists,
+            [0.2, 0.5, 0.3],
+            granularity,
+            min_slots,
+        )
+
+        for slot_count, min_slot in zip(slot_counts, min_slots):
+            self.assertGreaterEqual(slot_count, min_slot)
 
 
 def create_config(


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Optimized KV cache memory allocation algorithm for improved efficiency.

* **Tests**
  * Expanded test coverage for KV cache storage layer reliability and correctness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Fix KV cache pool-group grain-to-slot conversion so it returns the maximum feasible slot count for a grain budget. The old proportional split could under-count slots after a `_grains_for_slots` -> `_grains_to_slots` round trip, causing `min_slots` constraints to be violated.

The fix keeps the proportional result as a lower bound, expands the upper bound from that lower bound, then binary-searches for the exact maximum slot count. Boundary assertions document the invariant.

## Test Coverage

- `PYTHONPATH=/home/yaoy/tekit/tensorrt_llm/runtime python /home/yaoy/tekit/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py TestCacheLevelStorage -v`
- `git diff --check`
- `git commit -s` pre-commit hooks

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why.
- PR follows TRT-LLM CODING GUIDELINES to the best of your knowledge.
- Test cases are provided for new code paths.
- No API changes are introduced.
- No new dependencies are introduced.
- CODEOWNERS update is not needed.
- Documentation update is not needed.
- TAVA architecture diagram update is not needed.
- The reviewers assigned automatically or manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.