### PR TITLE
[None][fix] Route trtllm-bench and trtllm-serve tokenizer load through TransformersTokenizer

### DIFF
--- a/tensorrt_llm/bench/utils/data.py
+++ b/tensorrt_llm/bench/utils/data.py
@@ -16,13 +16,14 @@ import json
 from functools import partial
 from typing import List, TextIO, Tuple
 
-from transformers import AutoTokenizer, PreTrainedTokenizer
+from transformers import PreTrainedTokenizer
 
 from tensorrt_llm.bench.dataclasses.general import (DatasetMetadata,
                                                     InferenceRequest)
 from tensorrt_llm.bench.dataclasses.statistics import PercentileStats
 from tensorrt_llm.executor.request import LoRARequest
 from tensorrt_llm.inputs import default_multimodal_input_loader
+from tensorrt_llm.tokenizer.tokenizer import TransformersTokenizer
 
 
 class DatasetFormatError(ValueError):
@@ -62,9 +63,15 @@ def initialize_tokenizer(model_name: str,
                 f"Failed to load custom_tokenizer '{custom_tokenizer}'. "
                 "Expected alias or 'module.path.ClassName'.") from e
     else:
-        tokenizer = AutoTokenizer.from_pretrained(model_name,
-                                                  padding_side="left",
-                                                  trust_remote_code=True)
+        # Route through TransformersTokenizer so trtllm-bench inherits its
+        # post-load fixes -- in particular ``maybe_fix_byte_level_tokenizer``,
+        # which reloads DeepSeek-V3-style models that would otherwise come
+        # back with a Metaspace pre-tokenizer that silently strips spaces
+        # ("hello world" -> "helloworld") on transformers >= 5.x. Peel off
+        # the wrapper to return the raw HF tokenizer the rest of bench code
+        # expects.
+        tokenizer = TransformersTokenizer.from_pretrained(
+            model_name, padding_side="left", trust_remote_code=True).tokenizer
 
     if tokenizer.pad_token_id is None:
         tokenizer.add_special_tokens({"pad_token": "[PAD]"})

--- a/tensorrt_llm/serve/router.py
+++ b/tensorrt_llm/serve/router.py
@@ -20,7 +20,6 @@ from collections import OrderedDict
 from typing import Awaitable, Callable, Dict, Iterable, List, Optional, Union
 
 import aiohttp
-from transformers import AutoTokenizer
 
 from tensorrt_llm.bindings.internal.batch_manager import (BlockKey,
                                                           BlockKeyHasher)
@@ -695,15 +694,15 @@ class BlockHashMixin:
                 self._tokenizers[model] = load_custom_tokenizer(
                     self._custom_tokenizer, model)
             else:
-                from tensorrt_llm.tokenizer import \
-                    maybe_fix_byte_level_tokenizer
-                tokenizer = AutoTokenizer.from_pretrained(
-                    model, trust_remote_code=True)
-                # Work around Transformers 5.x LlamaTokenizer overriding
-                # tokenizer.json's ByteLevel pre-tokenizer with Metaspace,
-                # which silently strips spaces from prompts (see tokenizer.py).
-                self._tokenizers[model] = maybe_fix_byte_level_tokenizer(
-                    tokenizer, model, trust_remote_code=True)
+                # Route through TransformersTokenizer so block-hash routing
+                # inherits the same post-load fixes as the rest of TRT-LLM
+                # (e.g. maybe_fix_byte_level_tokenizer for DeepSeek-V3
+                # Metaspace bug, _fallback_to_fast_tokenizer for DeepSeek-V3.2
+                # AttributeError on transformers >= 5.x). Peel off .tokenizer
+                # to return the raw HF tokenizer used by _tokenize() below.
+                from tensorrt_llm.tokenizer import TransformersTokenizer
+                self._tokenizers[model] = TransformersTokenizer.from_pretrained(
+                    model, trust_remote_code=True).tokenizer
         return self._tokenizers[model]
 
     def _tokenize(self, request: OpenAIRequest) -> list[list[int]]:

--- a/tests/unittest/disaggregated/test_router.py
+++ b/tests/unittest/disaggregated/test_router.py
@@ -10,9 +10,9 @@ from tensorrt_llm.llmapi.disagg_utils import RouterConfig
 from tensorrt_llm.serve.openai_protocol import (ChatCompletionRequest,
                                                 CompletionRequest,
                                                 DisaggregatedParams)
-from tensorrt_llm.serve.router import (ConversationRouter, KvCacheAwareRouter,
-                                       LoadBalancingRouter, RoundRobinRouter,
-                                       create_router)
+from tensorrt_llm.serve.router import (BlockHashMixin, ConversationRouter,
+                                       KvCacheAwareRouter, LoadBalancingRouter,
+                                       RoundRobinRouter, create_router)
 
 
 def _make_mock_aiohttp_session(return_value=None):
@@ -858,3 +858,34 @@ def test_create_router_conversation():
     router = create_router(RouterConfig(type="conversation"),
                            ["server1", "server2"])
     assert isinstance(router, ConversationRouter)
+
+
+def test_block_hash_mixin_routes_through_transformers_tokenizer():
+    """``BlockHashMixin._get_tokenizer`` must call ``TransformersTokenizer.from_pretrained``.
+
+    Routing through ``TransformersTokenizer`` is what lets block-hash KV-cache
+    routing inherit the post-load fixes (``maybe_fix_byte_level_tokenizer`` for
+    DeepSeek-V3 Metaspace, ``_fallback_to_fast_tokenizer`` for DeepSeek-V3.2
+    on transformers >= 5.x). Without this routing, ``trtllm-serve`` would
+    tokenize prompts differently from the rest of TRT-LLM when computing
+    block hashes for cache hits.
+    """
+
+    class _Probe(BlockHashMixin):
+        pass
+
+    probe = _Probe()
+    probe._init_block_hashing()
+
+    inner = mock.MagicMock()
+    wrapper = mock.MagicMock(tokenizer=inner)
+    with mock.patch(
+            "tensorrt_llm.tokenizer.TransformersTokenizer.from_pretrained",
+            return_value=wrapper) as routed:
+        out = probe._get_tokenizer("dummy/model")
+
+    routed.assert_called_once_with("dummy/model", trust_remote_code=True)
+    # The cached tokenizer must be the raw HF tokenizer used by _tokenize,
+    # not the TransformersTokenizer wrapper.
+    assert out is inner
+    assert probe._tokenizers["dummy/model"] is inner

--- a/tests/unittest/others/test_bench_data.py
+++ b/tests/unittest/others/test_bench_data.py
@@ -13,10 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import io
+from unittest import mock
 
 import pytest
 
-from tensorrt_llm.bench.utils.data import DatasetFormatError, create_dataset_from_stream
+from tensorrt_llm.bench.utils.data import (
+    DatasetFormatError,
+    create_dataset_from_stream,
+    initialize_tokenizer,
+)
 
 
 class _FakeTokenizer:
@@ -36,3 +41,28 @@ def test_empty_stream_raises_dataset_format_error():
 
     with pytest.raises(DatasetFormatError, match="No data was read from the dataset stream"):
         create_dataset_from_stream(tokenizer, empty_stream)
+
+
+def test_initialize_tokenizer_routes_through_transformers_tokenizer():
+    """``initialize_tokenizer`` must call ``TransformersTokenizer.from_pretrained``.
+
+    Routing through ``TransformersTokenizer`` is what lets ``trtllm-bench``
+    inherit the post-load fixes (e.g. ``maybe_fix_byte_level_tokenizer``,
+    which prevents DeepSeek-V3 from loading with a Metaspace pre-tokenizer
+    that silently strips spaces -- "hello world" -> "helloworld" -- on
+    transformers >= 5.x). Without this routing the bench would see a
+    different tokenizer than the rest of TRT-LLM uses.
+    """
+    inner = mock.MagicMock()
+    inner.pad_token_id = 0  # already set => add_special_tokens not invoked
+    wrapper = mock.MagicMock(tokenizer=inner)
+
+    with mock.patch(
+        "tensorrt_llm.bench.utils.data.TransformersTokenizer.from_pretrained", return_value=wrapper
+    ) as routed:
+        out = initialize_tokenizer("dummy/model")
+
+    routed.assert_called_once_with("dummy/model", padding_side="left", trust_remote_code=True)
+    # Bench code uses the raw HF tokenizer (calls __call__, encode,
+    # add_special_tokens on it), so the wrapper must be peeled off.
+    assert out is inner


### PR DESCRIPTION
## Summary

Two entry points were calling `AutoTokenizer.from_pretrained` directly, bypassing the post-load fixes wired into `TransformersTokenizer.from_pretrained`. Route both through the shared wrapper so they inherit the same fix list as the rest of TRT-LLM.

The transformers-version bump that fixes the Kimi K2/K2.5 mis-conversion (#14416, transformers PR https://github.com/huggingface/transformers/pull/45359) is being handled separately in #14456 — this PR is intentionally scoped to the routing problem.

## Sites this PR fixes

| Site | Used by | Status before this PR |
|---|---|---|
| `tensorrt_llm/bench/utils/data.py:initialize_tokenizer` | `trtllm-bench throughput / latency / build` | Raw `AutoTokenizer.from_pretrained`, **none** of the sibling fixes |
| `tensorrt_llm/serve/router.py:BlockHashMixin._get_tokenizer` | `trtllm-serve` with block-hash KV-cache routing (`KvCacheAwareRouter`, `ConversationRouter`) | Raw `AutoTokenizer.from_pretrained` followed by a **hand-inlined** `maybe_fix_byte_level_tokenizer` call — missed `_fallback_to_fast_tokenizer` and would drift from any future post-load fix added to the canonical path |

## Why this is needed even after #14456 lands

`TransformersTokenizer.from_pretrained` carries fixes that are independent of the Kimi issue and remain load-bearing on transformers >= 5.x:

| Sibling fix | Symptom without it |
|---|---|
| `maybe_fix_byte_level_tokenizer` | DeepSeek-V3-family models load with a Metaspace pre-tokenizer that silently strips spaces (`"hello world"` → `"helloworld"`). Affected callers tokenize on the wrong sequences. |
| `_fallback_to_fast_tokenizer` (PR #14261) | DeepSeek-V3.2 raises `AttributeError: max_position_embeddings` on transformers 5.x. The `--custom_tokenizer deepseek_v32` alias sidesteps this, but the routing means non-alias loads inherit the workaround too. |

## Call chains

**`trtllm-bench`**:
```
trtllm-bench → tensorrt_llm/commands/bench.py:main
  → throughput_command / latency_command / build_command
      → initialize_tokenizer(checkpoint_path, custom_tokenizer)   ← this PR
      → create_dataset_from_stream(tokenizer, stream, ...)
          for line in stream:  token_ids = tokenizer(prompt, ...)   ← drives every benchmark run
```

**`trtllm-serve`** (only when block-hash routing is active — `KvCacheAwareRouter` / `ConversationRouter`):
```
trtllm-serve → tensorrt_llm/commands/serve.py
  → BlockHashMixin._get_tokenizer(model)                          ← this PR
  → BlockHashMixin._tokenize(request)
      tokens = tokenizer(prompt, ...).input_ids
      block_hashes = [BlockKeyHasher.hash(BlockKey(...)) for ...]   ← drives cache-hit lookups
```

## What changes

- **`tensorrt_llm/bench/utils/data.py`** — `initialize_tokenizer` non-alias path: `TransformersTokenizer.from_pretrained(...).tokenizer` instead of `AutoTokenizer.from_pretrained(...)`. The `custom_tokenizer` alias path is untouched.

- **`tensorrt_llm/serve/router.py`** — `BlockHashMixin._get_tokenizer` non-alias path: same routing. Drops the hand-inlined `maybe_fix_byte_level_tokenizer` call (now inherited via the wrapper) and the top-level `from transformers import AutoTokenizer` import.

- **`tests/unittest/others/test_bench_data.py`** — `test_initialize_tokenizer_routes_through_transformers_tokenizer` pins the bench routing.

- **`tests/unittest/disaggregated/test_router.py`** — `test_block_hash_mixin_routes_through_transformers_tokenizer` pins the serve routing.

Both guard tests mock `TransformersTokenizer.from_pretrained` and assert: (a) it's called with the right kwargs, (b) the wrapper is peeled off before the raw HF tokenizer is returned.

## Test plan

- [x] `pytest tests/unittest/others/test_bench_data.py tests/unittest/disaggregated/test_router.py::test_block_hash_mixin_routes_through_transformers_tokenizer` — 3 passed in 2.33s
- [x] No change to the `--custom_tokenizer` alias paths in either entry point