### PR TITLE
[https://nvbugs/6185248][test] Unwaive K2.5 thinking MTP3 perf sanity test

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -324,7 +324,6 @@ perf/test_perf.py::test_perf[t5-bench-float16-input_output_len:128,20-gpus:2] SK
 perf/test_perf.py::test_perf[t5-bench-float16-maxbs:1-input_output_len:128,20-gpus:2] SKIP
 perf/test_perf.py::test_perf[t5_base-plugin-float16-bs:8-input_output_len:60,20] SKIP # (https://nvidia.slack.com/archives/C059LSY62BT/p1704525727177449)
 perf/test_perf.py::test_perf[whisper_large_v3-bench-float16-input_output_len:128,20] SKIP
-perf/test_perf_sanity.py::test_e2e[aggr_upload-ctx_only-gb200_kimi-k25-thinking-fp4_8k1k_con4_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL] SKIP (https://nvbugs/6185248)
 perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_r1_fp4_v2_grace_blackwell-r1_fp4_v2_tep4_mtp3_1k8k] SKIP (https://nvbugs/6167060)
 perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_v32_fp4_blackwell-v32_fp4_dep8_mtp1_8k1k] SKIP (https://nvbugs/6190071)
 perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_v32_fp4_blackwell-v32_fp4_tep8_mtp3_8k1k] SKIP (https://nvbugs/6189928)


### PR DESCRIPTION
## Summary

Re-enables `test_perf_sanity.py::test_e2e[aggr_upload-ctx_only-gb200_kimi-k25-thinking-fp4_8k1k_con4_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL]`. The underlying defect tracked by nvbug 6185248 is already fixed on `main` by PR #14379; this PR only removes the waive entry that was added in parallel.

## Background

Nvbug [6185248](https://nvbugspro.nvidia.com/bug/6185248): `AttributeError: 'KimiK25ForConditionalGeneration' object has no attribute 'draft_config'` at `tensorrt_llm/_torch/pyexecutor/model_loader.py` when MTP speculative decoding is enabled. Root cause: PR #12788 refactored `KimiK25ForConditionalGeneration` into a composition pattern (`self.llm = DeepseekV3ForCausalLM(...)`), but the loader expected `draft_config` directly on the top-level model.

PR #14379 fixed this by adding `draft_config` / `draft_model` / `load_draft_weights` property forwarders on `KimiK25ForConditionalGeneration` (delegating to `self.llm`) and threading `**kwargs` through `KimiK25.forward` so `spec_metadata` reaches DeepseekV3's MTP forward path.

## Why a separate unwaive PR

The fix PR #14379 was merged but did not remove the waive line, due to the merge ordering between the fix PR and the waive PR:

| Time (UTC+8) | Event | Commit |
|---|---|---|
| 5/21 09:08 | PR #14379 (fix) opened, base = `b3fcf083` (waive does not exist yet on `main`) | — |
| 5/21 18:21 | PR #14405 (waive) merged → kimi waive line added to `main` | `736d580f80` |
| 5/22 09:34 | PR #14379 (fix) merged; diff only touches `modeling_kimi_k25.py` | `eb6ee930` |

Verification: `git merge-base --is-ancestor 736d580f80 b3fcf083` → `NO`. PR #14379's base predates the waive, so #14379's diff does not include an unwaive change. This PR removes the now-stale waive entry explicitly.