### PR TITLE
[None][fix] DSv4 fused FP8 Q-quant: round to bf16 before FP8 cast to …

### DIFF
--- a/cpp/tensorrt_llm/kernels/deepseekV4QNormKernel.cu
+++ b/cpp/tensorrt_llm/kernels/deepseekV4QNormKernel.cu
@@ -174,14 +174,22 @@ __global__ void deepseekV4QNormFusedKernel(T const* __restrict__ input, __nv_fp8
 
     sumSquares = warpReduceSum(sumSquares);
     float const normScale = rsqrtf(sumSquares / static_cast<float>(kHeadDim) + eps);
-    float const fp8Scale = normScale * quantScale;
 
     // First kPairsPerLane-1 iters land in the nope range -> FP8 STG.
+    //
+    // We deliberately round the post-norm value to T (bf16 or half) BEFORE
+    // applying quantScale so the FP8 cast sees the same input as the legacy
+    // two-kernel path (norm-bf16-store → reload → quant-scale → FP8). Skipping
+    // this round produces FP8 output that is mathematically more accurate but
+    // diverges from the bf16-trained MoE router; the resulting top-K drift
+    // costs ~9.5pp on GSM8K for DSv4-Flash and unbalances expert dispatch.
 #pragma unroll
     for (int i = 0; i < kPairsPerLane - 1; ++i)
     {
         int const pairIdx = i * kWarpSize + laneId;
-        float2 scaled{values[i].x * fp8Scale, values[i].y * fp8Scale};
+        auto const rounded = Vec2Traits<T>::fromFloat2(float2{values[i].x * normScale, values[i].y * normScale});
+        float2 reloaded = Vec2Traits<T>::toFloat2(rounded);
+        float2 scaled{reloaded.x * quantScale, reloaded.y * quantScale};
         nopeOutPair[pairIdx] = __nv_fp8x2_e4m3(scaled);
     }
 

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1738,6 +1738,11 @@ class MLA(nn.Module):
         # Context-only batches: the fused path leaves a placeholder bf16 q_buf
         # that forward_generation_sparse_mla would read uninitialized, so
         # mixed/gen batches must take the legacy unfused path.
+        # `TRTLLM_DISABLE_FUSED_Q_FP8_QUANT=1` is an opt-out kill switch for
+        # debugging numerical drift between fused (skips bf16 round-trip) and
+        # legacy (bf16 store -> reload -> FP8) Q-quant paths.
+        if os.environ.get("TRTLLM_DISABLE_FUSED_Q_FP8_QUANT", "0") == "1":
+            return False
         if not self.is_deepseek_v4:
             return False
         if self.qk_head_dim != 512 or self.kv_lora_rank != 448:


### PR DESCRIPTION
…match legacy precision

PR #14250 fused the Q RMS-norm and the FP8 cast of the nope segment into a single kernel, eliminating the bf16 store/reload between norm and the standalone FP8-quant kernel that the legacy two-kernel path used. The fused kernel computed
  `e4m3_cast(post_norm_fp32 * normScale * quantScale)`
directly, which is mathematically more accurate but no longer matches the bf16-trained DSv4 MoE router input distribution: ~3% of FP8 nope elements flip vs the legacy bit pattern, ~12-15% of tokens then end up on a different expert top-K, and the routing imbalance plus A2A combine wait time was already enough to drive +4% e2e latency on ctx 8k/1k.

End-to-end, the accuracy regression turned out to be far worse than the perf signal suggested. DSv4-Flash 200-sample GSM8K, FP8 KV cache:
  - fused (broken): strict-match 83.50% / flexible-extract 84.50%
  - legacy        : strict-match 93.00% / flexible-extract 93.00%
i.e. -9.5pp directly attributable to the fused FP8 Q-quant skipping the
bf16 round.

Fix: round the post-norm fp32 value to T (bf16 or half) BEFORE applying quantScale and casting to FP8, matching the legacy bit pattern exactly while keeping fusion's perf win (no extra gmem round trip, no extra kernel launch). On DSv4-Pro full GSM8K (1319 samples, TP=8 EP=8, MTP=1) with the fix:
  - flexible-extract: 93.10% (+/- 0.70)
  - strict-match    : 92.49% (+/- 0.73)
i.e. fully recovered to legacy parity.

Also add `TRTLLM_DISABLE_FUSED_Q_FP8_QUANT=1` env override on `_is_fused_q_fp8_quant_enabled` to force the legacy two-kernel path, useful for future debugging of numerical drift between the two implementations.

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
