### PR TITLE
[None][fix] Disable DSv4 fused Q FP8 quant by default

### DIFF
--- a/cpp/tensorrt_llm/kernels/deepseekV4QNormKernel.cu
+++ b/cpp/tensorrt_llm/kernels/deepseekV4QNormKernel.cu
@@ -174,14 +174,22 @@ __global__ void deepseekV4QNormFusedKernel(T const* __restrict__ input, __nv_fp8
 
     sumSquares = warpReduceSum(sumSquares);
     float const normScale = rsqrtf(sumSquares / static_cast<float>(kHeadDim) + eps);
-    float const fp8Scale = normScale * quantScale;
 
     // First kPairsPerLane-1 iters land in the nope range -> FP8 STG.
+    //
+    // We deliberately round the post-norm value to T (bf16 or half) BEFORE
+    // applying quantScale so the FP8 cast sees the same input as the legacy
+    // two-kernel path (norm-bf16-store → reload → quant-scale → FP8). Skipping
+    // this round produces FP8 output that is mathematically more accurate but
+    // diverges from the bf16-trained MoE router; the resulting top-K drift
+    // costs ~9.5pp on GSM8K for DSv4-Flash and unbalances expert dispatch.
 #pragma unroll
     for (int i = 0; i < kPairsPerLane - 1; ++i)
     {
         int const pairIdx = i * kWarpSize + laneId;
-        float2 scaled{values[i].x * fp8Scale, values[i].y * fp8Scale};
+        auto const rounded = Vec2Traits<T>::fromFloat2(float2{values[i].x * normScale, values[i].y * normScale});
+        float2 reloaded = Vec2Traits<T>::toFloat2(rounded);
+        float2 scaled{reloaded.x * quantScale, reloaded.y * quantScale};
         nopeOutPair[pairIdx] = __nv_fp8x2_e4m3(scaled);
     }
 

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1740,8 +1740,9 @@ class MLA(nn.Module):
         # mixed/gen batches must take the legacy unfused path.
         # `TRTLLM_DISABLE_FUSED_Q_FP8_QUANT=1` is an opt-out kill switch for
         # debugging numerical drift between fused (skips bf16 round-trip) and
-        # legacy (bf16 store -> reload -> FP8) Q-quant paths.
-        if os.environ.get("TRTLLM_DISABLE_FUSED_Q_FP8_QUANT", "0") == "1":
+        # legacy (bf16 store -> reload -> FP8) Q-quant paths. Keep it disabled
+        # by default until DSv4 accuracy recovers on the fused path.
+        if os.environ.get("TRTLLM_DISABLE_FUSED_Q_FP8_QUANT", "1") == "1":
             return False
         if not self.is_deepseek_v4:
             return False

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1738,6 +1738,11 @@ class MLA(nn.Module):
         # Context-only batches: the fused path leaves a placeholder bf16 q_buf
         # that forward_generation_sparse_mla would read uninitialized, so
         # mixed/gen batches must take the legacy unfused path.
+        # `TRTLLM_DISABLE_FUSED_Q_FP8_QUANT=1` is an opt-out kill switch for
+        # debugging numerical drift between fused (skips bf16 round-trip) and
+        # legacy (bf16 store -> reload -> FP8) Q-quant paths.
+        if os.environ.get("TRTLLM_DISABLE_FUSED_Q_FP8_QUANT", "0") == "1":
+            return False
         if not self.is_deepseek_v4:
             return False
         if self.qk_head_dim != 512 or self.kv_lora_rank != 448:


### PR DESCRIPTION
@coderabbitai summary

## Description

This PR pulls in the DSv4 fused FP8 Q-quant precision fix from PR #14464 and changes `TRTLLM_DISABLE_FUSED_Q_FP8_QUANT` to default to `1`.

With this default, DSv4 uses the legacy unfused Q-quant path unless the fused path is explicitly enabled by setting `TRTLLM_DISABLE_FUSED_Q_FP8_QUANT=0`. This keeps the recovered GSM8K accuracy path as the default while preserving the fused implementation for follow-up debugging and validation.

## Test Coverage

- Ran `tmp/dsv4_bench/dsv4_pro_gsm8k.sh` on `7dcb4b4 + PR #14464` with `TRTLLM_DISABLE_FUSED_Q_FP8_QUANT=1`.
- Result: GSM8K average accuracy `96.25` (`flexible-extract`: `96.2092`, `strict-match`: `96.2851`).
- Ran `pre-commit run --files tensorrt_llm/_torch/modules/attention.py`.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.