### PR TITLE
[TRTLLM-10004][chore] Enable NCCL symmetric zero-copy by default

### DIFF
--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -22,12 +22,12 @@ from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.plugin.plugin import CustomAllReduceHelper
 
 # Feature flag: GEMM→NCCL-window zero-copy (writes GEMM output directly into
-# the window buffer so the allreduce needs no extra copy).  Off by default
-# (0); set TLLM_NCCL_SYMMETRIC_ZERO_COPY=1 to enable.
+# the window buffer so the allreduce needs no extra copy).  On by default
+# (1); set TLLM_NCCL_SYMMETRIC_ZERO_COPY=0 to disable.
 # Evaluated once at import — O(1) module-global lookup on every call,
 # equivalent to a C++ static-bool cached env var.
 _NCCL_SYMMETRIC_ZERO_COPY: bool = (os.environ.get(
-    "TLLM_NCCL_SYMMETRIC_ZERO_COPY", "0") == "1")
+    "TLLM_NCCL_SYMMETRIC_ZERO_COPY", "1") == "1")
 
 _thread_local = threading.local()
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated default behavior for NCCL symmetric zero-copy operations to be enabled by default. Users can disable this behavior by setting an environment variable to `0` if needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14472?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

  ## Description

  This PR enables NCCL symmetric zero-copy AllReduce by default for the PyTorch distributed path.

  Previously, `TLLM_NCCL_SYMMETRIC_ZERO_COPY` defaulted to disabled unless explicitly set. This change flips the default so the zero-copy path is active by default, while preserving the existing opt-out behavior via:

  ```bash
  TLLM_NCCL_SYMMETRIC_ZERO_COPY=0
  ```
  Internal E2E throughput sweeps showed improvement on dense FP8 Llama models:

  - nvidia/Llama-3.3-70B-Instruct-FP8
  - nvidia/Llama-3.1-405B-Instruct-FP8

  The same sweeps did not show E2E throughput regression on the other measured models:

  - Qwen/Qwen2.5-72B-Instruct
  - mistralai/Mixtral-8x22B-Instruct-v0.1
  - deepseek-ai/DeepSeek-R1

  ## Test Coverage

  CI has been run with this settings before. And will be repeated.
  
  ## PR Checklist

  Please review the following before submitting your PR:

  - PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
  - PR Follows TRT-LLM CODING GUIDELINES (https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
  - Test cases are provided for new code paths (see test instructions (https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
  - If PR introduces API changes, an appropriate PR label is added - either api-compatible or api-breaking. For api-breaking, include BREAKING in the PR title.
  - Any new dependencies have been scanned for license and vulnerabilities
  - CODEOWNERS (https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
  - Documentation updated as needed
  - Update tava architecture diagram (https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
  - The reviewers assigned automatically/manually are appropriate for the PR.
  - [x] Please check this after reviewing the above items as appropriate for this PR.

  ## GitHub Bot Help

  To see a list of available CI bot commands, please comment /bot help.