### PR TITLE
[None][perf] Replace Parakeet audio encoder with native trtllm layers

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_parakeet.py
+++ b/tensorrt_llm/_torch/models/modeling_parakeet.py
@@ -14,16 +14,28 @@
 # limitations under the License.
 
 from functools import cache
+import math
 from typing import Dict, NamedTuple, Optional
 
 import numpy as np
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from transformers import ParakeetEncoder as HFParakeetEncoder
 from transformers import ParakeetEncoderConfig, PretrainedConfig
+from transformers.activations import ACT2FN
 from transformers.audio_utils import mel_filter_bank
+from transformers.models.parakeet.modeling_parakeet import (
+    ParakeetEncoderRelPositionalEncoding as HFParakeetEncoderRelPositionalEncoding,
+)
+from transformers.models.parakeet.modeling_parakeet import (
+    ParakeetEncoderSubsamplingConv2D as HFParakeetEncoderSubsamplingConv2D,
+)
 
 from ...logger import logger
+from ..modules.attention import Attention
+from ..modules.layer_norm import LayerNorm
+from ..modules.linear import Linear
 from ..modules.rms_norm import RMSNorm
 
 EPSILON = 1e-5
@@ -169,7 +181,7 @@ class ParakeetExtractor:
         num_frames = torch.tensor(
             [cs // self.config.hop_length for cs in clip_sizes], dtype=torch.float
         )
-        n_tokens = HFParakeetEncoder._get_subsampling_output_length(self, num_frames)
+        n_tokens = ParakeetEncoder._get_subsampling_output_length(self, num_frames)
         return max(1, int(n_tokens.sum().item()))
 
     def _to_mono_tensor(
@@ -257,7 +269,7 @@ class ParakeetExtractor:
 
 
 # This config is the extractor's single source of truth. It also supplies the fields read by
-# `HFParakeetEncoder._get_subsampling_output_length`.
+# `ParakeetEncoder._get_subsampling_output_length`.
 class _ExtractorConfig(NamedTuple):
     feature_size: int
     sampling_rate: int
@@ -293,8 +305,8 @@ def _make_parakeet_encoder_config(
 ) -> ParakeetEncoderConfig:
     """Build a `ParakeetEncoderConfig` from the HF `sound_config`.
 
-    `HFParakeetEncoder` expects fields (`scale_input`, `attention_bias`, `max_position_embeddings`)
-    that are not present in the raw HF composite config, so we map/default them here.
+    Several fields required by `ParakeetEncoderConfig` are absent from the raw
+    HF composite config, so we map/default them here.
     """
     return ParakeetEncoderConfig(
         hidden_size=sound_config.hidden_size,
@@ -308,8 +320,6 @@ def _make_parakeet_encoder_config(
         subsampling_conv_kernel_size=sound_config.subsampling_conv_kernel_size,
         subsampling_conv_stride=sound_config.subsampling_conv_stride,
         num_mel_bins=sound_config.num_mel_bins,
-        # Fields required by HFParakeetEncoder but absent from the HF
-        # composite config — use the defaults from ParakeetEncoderConfig.
         scale_input=getattr(sound_config, "scale_input", False),
         attention_bias=getattr(sound_config, "attention_bias", False),
         max_position_embeddings=getattr(sound_config, "max_position_embeddings", 5000),
@@ -330,8 +340,8 @@ class ParakeetProjection(nn.Module):
     ):
         super().__init__()
         self.norm = RMSNorm(hidden_size=hidden_size, eps=eps, dtype=dtype)
-        self.linear1 = nn.Linear(hidden_size, projection_hidden_size, bias=bias, dtype=dtype)
-        self.linear2 = nn.Linear(projection_hidden_size, llm_hidden_size, bias=bias, dtype=dtype)
+        self.linear1 = Linear(hidden_size, projection_hidden_size, bias=bias, dtype=dtype)
+        self.linear2 = Linear(projection_hidden_size, llm_hidden_size, bias=bias, dtype=dtype)
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         hidden_states = self.norm(hidden_states)
@@ -339,6 +349,420 @@ class ParakeetProjection(nn.Module):
         hidden_states = torch.square(torch.nn.functional.relu(hidden_states))
         hidden_states = self.linear2(hidden_states)
         return hidden_states
+
+
+# ---------------------------------------------------------------------------
+# Native TRT-LLM encoder — attention built on trtllm.Attention
+# ---------------------------------------------------------------------------
+
+
+class ParakeetConformerAttention(Attention):
+    """Conformer self-attention built on trtllm.Attention.
+
+    qkv_proj and o_proj are inherited from trtllm.Attention (TP-sharded,
+    quantization-ready, fused QKV kernel).  The Transformer-XL relative
+    positional encoding (RPE) is computed here and injected into the parent's
+    logit_bias SDPA path via _forward_with_logit_bias, so we share the
+    attention backend infrastructure without re-implementing SDPA.
+
+    relative_k_proj, bias_u, and bias_v implement the content-position term;
+    the content-content term uses the standard QK product inside SDPA.
+    """
+
+    def __init__(
+        self,
+        config: ParakeetEncoderConfig,
+        layer_idx: int,
+        dtype: Optional[torch.dtype] = None,
+        model_config=None,
+    ):
+        head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        num_kv_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
+        super().__init__(
+            hidden_size=config.hidden_size,
+            num_attention_heads=config.num_attention_heads,
+            num_key_value_heads=num_kv_heads,
+            max_position_embeddings=None,
+            bias=config.attention_bias,
+            pos_embd_params=None,
+            rope_fusion=False,
+            layer_idx=layer_idx,
+            dtype=dtype,
+            dense_bias=config.attention_bias,
+            config=model_config,  # None → default ModelConfig (TP=1)
+            q_scaling=1.0,
+            head_dim=head_dim,
+        )
+        # Relative-position key projection: position_embeddings → [T_pos, H*d]
+        self.relative_k_proj = Linear(
+            config.hidden_size,
+            config.num_attention_heads * head_dim,
+            bias=False,
+            dtype=dtype,
+        )
+        # Transformer-XL global content bias added to q for the content-content term
+        self.bias_u = nn.Parameter(torch.zeros(self.num_heads, self.head_dim, dtype=dtype))
+        # Transformer-XL global positional bias added to q for content-position term
+        self.bias_v = nn.Parameter(torch.zeros(self.num_heads, self.head_dim, dtype=dtype))
+
+    @staticmethod
+    def _rel_shift(x: torch.Tensor) -> torch.Tensor:
+        """Shaw et al. relative shift. Appendix B of https://arxiv.org/abs/1901.02860."""
+        B, H, T, T_pos = x.shape
+        x = F.pad(x, (1, 0))
+        x = x.view(B, H, -1, T)
+        return x[:, :, 1:].view(B, H, T, T_pos)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_embeddings: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """
+        Args:
+            hidden_states:       [B, T, hidden_size]
+            attention_mask:      Optional [B, 1, T, T] bool mask; True = attend.
+            position_embeddings: [B, T_pos, hidden_size] relative position encodings.
+        Returns:
+            [B, T, hidden_size]
+        """
+        B, T, C = hidden_states.shape
+
+        # ── QKV projection (TP-sharded fused kernel from trtllm.Attention) ──
+        qkv = self.qkv_proj(hidden_states.reshape(-1, C))  # [B*T, (q+k+v)*d]
+        q, k, v = self.split_qkv(qkv)  # each [B*T, H_rank*d]
+
+        # Reshape to [B, H, T, d] for RPE computation
+        q = q.view(B, T, self.num_heads, self.head_dim).transpose(1, 2)
+        k = k.view(B, T, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+        v = v.view(B, T, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+
+        # ── Transformer-XL RPE: compute matrix_bd ────────────────────────────
+        scale = 1.0 / math.sqrt(self.head_dim)
+
+        # Content-position term: (q + bias_v) @ rel_k^T, then _rel_shift
+        q_v = q + self.bias_v.view(1, self.num_heads, 1, self.head_dim)
+        rel_k = self.relative_k_proj(position_embeddings.reshape(-1, C)).view(
+            B, -1, self.num_heads, self.head_dim
+        )  # [B, T_pos, H, d]
+        matrix_bd = q_v @ rel_k.permute(0, 2, 3, 1)  # [B, H, T, T_pos]
+        matrix_bd = self._rel_shift(matrix_bd)[..., :T] * scale  # [B, H, T, T]
+
+        # Fold in the padding mask (−∞ for masked/padded positions)
+        if attention_mask is not None:
+            matrix_bd = matrix_bd.masked_fill_(~attention_mask, float("-inf"))
+
+        # Content-content term: add bias_u to q; SDPA computes (q+bias_u)@k^T
+        q = q + self.bias_u.view(1, self.num_heads, 1, self.head_dim)
+
+        # ── SDPA via parent's logit_bias path ─────────────────────────────────
+        # Flatten back to packed [B*T, H*d] as expected by _forward_with_logit_bias
+        q = q.transpose(1, 2).reshape(B * T, self.q_size)
+        k = k.transpose(1, 2).reshape(B * T, self.kv_size)
+        v = v.transpose(1, 2).reshape(B * T, self.kv_size)
+
+        attn_output, _ = self._forward_with_logit_bias(q, k, v, B=B, T=T, logit_bias=matrix_bd)
+
+        # ── Output projection (TP row-parallel with AllReduce) ────────────────
+        return self.o_proj(attn_output).reshape(B, T, C)
+
+    def load_weights(self, weights: Dict[str, torch.Tensor], prefix: str = "") -> None:
+        """Load checkpoint weights.
+
+        The checkpoint stores q/k/v as separate projections; qkv_proj is fused.
+        """
+        self.qkv_proj.load_weights(
+            [
+                {"weight": weights[f"{prefix}q_proj.weight"]},
+                {"weight": weights[f"{prefix}k_proj.weight"]},
+                {"weight": weights[f"{prefix}v_proj.weight"]},
+            ]
+        )
+        self.o_proj.load_weights([{"weight": weights[f"{prefix}o_proj.weight"]}])
+        self.relative_k_proj.load_weights([{"weight": weights[f"{prefix}relative_k_proj.weight"]}])
+        self.bias_u.data.copy_(weights[f"{prefix}bias_u"])
+        self.bias_v.data.copy_(weights[f"{prefix}bias_v"])
+
+
+class ParakeetFeedForward(nn.Module):
+    """Conformer FFN: Linear(hidden→intermediate) → activation → Linear(intermediate→hidden)."""
+
+    def __init__(self, config: ParakeetEncoderConfig, dtype: Optional[torch.dtype] = None):
+        super().__init__()
+        self.linear1 = Linear(
+            config.hidden_size,
+            config.intermediate_size,
+            bias=bool(config.attention_bias),
+            dtype=dtype,
+        )
+        self.linear2 = Linear(
+            config.intermediate_size,
+            config.hidden_size,
+            bias=bool(config.attention_bias),
+            dtype=dtype,
+        )
+        self.activation = ACT2FN[config.hidden_act]
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.linear2(self.activation(self.linear1(hidden_states)))
+
+
+class ParakeetConvolutionModule(nn.Module):
+    """Conformer depthwise convolution module with trtllm.Linear pointwise projections.
+
+    Pointwise 1×1 convolutions use trtllm.Linear (operating on the last dim);
+    the depthwise Conv1d and BatchNorm remain as HF/PyTorch modules.
+    Checkpoint weights for pointwise_conv1/2 have shape [C_out, C_in, 1] and are
+    squeezed to [C_out, C_in] during load_weights.
+    """
+
+    def __init__(self, config: ParakeetEncoderConfig, dtype: Optional[torch.dtype] = None):
+        super().__init__()
+        channels = config.hidden_size
+        kernel_size = config.conv_kernel_size
+        self.activation = ACT2FN[getattr(config, "hidden_act", "silu")]
+        self.padding = (kernel_size - 1) // 2
+        self.pointwise_conv1 = Linear(
+            channels, 2 * channels, bias=config.convolution_bias, dtype=dtype
+        )
+        self.depthwise_conv = nn.Conv1d(
+            channels,
+            channels,
+            kernel_size,
+            stride=1,
+            padding=self.padding,
+            groups=channels,
+            bias=config.convolution_bias,
+        )
+        self.norm = nn.BatchNorm1d(channels)
+        self.pointwise_conv2 = Linear(channels, channels, bias=config.convolution_bias, dtype=dtype)
+        if dtype is not None:
+            self.depthwise_conv.to(dtype=dtype)
+            self.norm.to(dtype=dtype)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        # GLU via linear — no initial transpose needed
+        hidden_states = self.pointwise_conv1(hidden_states)  # [B, T, 2C]
+        hidden_states = nn.functional.glu(hidden_states, dim=-1)  # [B, T, C]
+
+        # Depthwise conv operates on [B, C, T]
+        hidden_states = hidden_states.transpose(1, 2)
+
+        if attention_mask is not None:
+            if attention_mask.dtype == torch.bool:
+                all_masked_rows = torch.all(~attention_mask, dim=2)
+            else:
+                all_masked_rows = torch.all(~(attention_mask == 0.0), dim=2)
+            hidden_states = hidden_states.masked_fill(all_masked_rows, 0.0)
+
+        hidden_states = self.depthwise_conv(hidden_states)
+        hidden_states = self.norm(hidden_states)
+        hidden_states = self.activation(hidden_states)
+
+        hidden_states = hidden_states.transpose(1, 2)  # [B, T, C]
+        return self.pointwise_conv2(hidden_states)
+
+
+class ParakeetConformerBlock(nn.Module):
+    """Conformer block with trtllm layers throughout.
+
+    All linear projections use trtllm.Linear; all normalization uses
+    trtllm.LayerNorm. Attribute names mirror HF ParakeetEncoderBlock so
+    checkpoint weight keys map 1-to-1 without remapping.
+    """
+
+    def __init__(
+        self,
+        config: ParakeetEncoderConfig,
+        layer_idx: int,
+        dtype: Optional[torch.dtype] = None,
+    ):
+        super().__init__()
+        self.feed_forward1 = ParakeetFeedForward(config, dtype=dtype)
+        self.self_attn = ParakeetConformerAttention(config, layer_idx, dtype=dtype)
+        self.conv = ParakeetConvolutionModule(config, dtype=dtype)
+        self.feed_forward2 = ParakeetFeedForward(config, dtype=dtype)
+        self.norm_feed_forward1 = LayerNorm(hidden_size=config.hidden_size, eps=1e-5, dtype=dtype)
+        self.norm_self_att = LayerNorm(hidden_size=config.hidden_size, eps=1e-5, dtype=dtype)
+        self.norm_conv = LayerNorm(hidden_size=config.hidden_size, eps=1e-5, dtype=dtype)
+        self.norm_feed_forward2 = LayerNorm(hidden_size=config.hidden_size, eps=1e-5, dtype=dtype)
+        self.norm_out = LayerNorm(hidden_size=config.hidden_size, eps=1e-5, dtype=dtype)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_embeddings: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        # FFN1 with 0.5 residual scaling (Conformer architecture)
+        residual = hidden_states
+        hidden_states = residual + 0.5 * self.feed_forward1(self.norm_feed_forward1(hidden_states))
+
+        # Self-attention with relative positional encoding
+        hidden_states = hidden_states + self.self_attn(
+            self.norm_self_att(hidden_states),
+            attention_mask=attention_mask,
+            position_embeddings=position_embeddings,
+        )
+
+        # Convolution module
+        hidden_states = hidden_states + self.conv(
+            self.norm_conv(hidden_states), attention_mask=attention_mask
+        )
+
+        # FFN2 with 0.5 residual scaling
+        hidden_states = hidden_states + 0.5 * self.feed_forward2(
+            self.norm_feed_forward2(hidden_states)
+        )
+
+        return self.norm_out(hidden_states)
+
+
+class ParakeetEncoder(nn.Module):
+    """Native TRT-LLM Conformer encoder.
+
+    Mirrors the structure and attribute names of HF ParakeetEncoder so that
+    checkpoint weight keys map without remapping.  All linear projections use
+    trtllm.Linear and all normalization uses trtllm.LayerNorm; only the
+    depthwise Conv1d, BatchNorm, and Conv2D subsampling remain as plain PyTorch.
+    """
+
+    def __init__(self, config: ParakeetEncoderConfig, dtype: Optional[torch.dtype] = None):
+        super().__init__()
+        self.config = config
+        self.input_scale = math.sqrt(config.hidden_size) if config.scale_input else 1.0
+        self.subsampling = HFParakeetEncoderSubsamplingConv2D(config)
+        self.encode_positions = HFParakeetEncoderRelPositionalEncoding(config)
+        self.layers = nn.ModuleList(
+            [
+                ParakeetConformerBlock(config, layer_idx=i, dtype=dtype)
+                for i in range(config.num_hidden_layers)
+            ]
+        )
+
+        if dtype is not None:
+            self.subsampling.to(dtype=dtype)
+            self.encode_positions.to(dtype=dtype)
+
+    def _get_subsampling_output_length(self, input_lengths: torch.Tensor) -> torch.Tensor:
+        cfg = self.config
+        num_layers = int(math.log2(cfg.subsampling_factor))
+        add_pad = (cfg.subsampling_conv_kernel_size - 1) // 2 * 2 - cfg.subsampling_conv_kernel_size
+        lengths = input_lengths
+        for _ in range(num_layers):
+            lengths = (
+                torch.div(lengths.to(torch.float) + add_pad, cfg.subsampling_conv_stride) + 1.0
+            )
+            lengths = torch.floor(lengths)
+        return lengths.to(torch.int)
+
+    def _build_attention_mask(self, attention_mask: torch.Tensor, seq_len: int) -> torch.Tensor:
+        """Convert 2-D input mask to 4-D additive attention mask after subsampling."""
+        output_lengths = self._get_subsampling_output_length(attention_mask.sum(-1))
+        output_mask = torch.arange(seq_len, device=attention_mask.device) < output_lengths[:, None]
+        mask_2d = output_mask.unsqueeze(1).expand(-1, seq_len, -1)
+        mask_2d = mask_2d & mask_2d.transpose(1, 2)
+        return mask_2d.unsqueeze(1)
+
+    def forward(
+        self,
+        input_features: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        hidden_states = self.subsampling(input_features, attention_mask)
+        hidden_states = hidden_states * self.input_scale
+        position_embeddings = self.encode_positions(hidden_states)
+
+        attn_mask_4d = None
+        if attention_mask is not None:
+            attn_mask_4d = self._build_attention_mask(attention_mask, hidden_states.shape[1])
+
+        for block in self.layers:
+            hidden_states = block(
+                hidden_states,
+                attention_mask=attn_mask_4d,
+                position_embeddings=position_embeddings,
+            )
+
+        return hidden_states
+
+    def load_weights(self, weights: Dict[str, torch.Tensor]) -> None:
+        """Load weights from a flat dict with keys relative to the encoder root.
+
+        ParakeetConformerAttention modules load their own weights (fused QKV from
+        separate q/k/v checkpoint keys).  All other trtllm.Linear modules are loaded
+        via their native API.  Remaining parameters (trtllm.LayerNorm, BatchNorm,
+        etc.) are loaded via state_dict — trtllm.LayerNorm uses the same weight/bias
+        parameter names as nn.LayerNorm so no remapping is needed.
+        """
+        trtllm_param_keys: set[str] = set()
+        # Track prefixes of attention modules whose sub-modules must be skipped.
+        attn_prefixes: list[str] = []
+
+        for mod_name, module in self.named_modules():
+            # Skip sub-modules of already-handled attention blocks: named_modules()
+            # recurses into ParakeetConformerAttention so qkv_proj/o_proj would
+            # otherwise fall through to the generic Linear branch below.
+            if any(mod_name.startswith(p) for p in attn_prefixes):
+                continue
+
+            if isinstance(module, ParakeetConformerAttention):
+                # Attention owns its own weight loading (fused QKV + relative_k_proj
+                # + bias_u/bias_v).  Prefix maps "layers.i.self_attn" → "layers.i.self_attn."
+                prefix = f"{mod_name}." if mod_name else ""
+                attn_prefixes.append(prefix)
+                module.load_weights(weights, prefix=prefix)
+                # Checkpoint keys (excluded from remaining dict):
+                for suffix in (
+                    "q_proj.weight",
+                    "k_proj.weight",
+                    "v_proj.weight",
+                    "o_proj.weight",
+                    "relative_k_proj.weight",
+                    "bias_u",
+                    "bias_v",
+                ):
+                    trtllm_param_keys.add(f"{prefix}{suffix}")
+                if module.qkv_proj.bias is not None:
+                    for sfx in ("q_proj.bias", "k_proj.bias", "v_proj.bias"):
+                        trtllm_param_keys.add(f"{prefix}{sfx}")
+                if module.o_proj.bias is not None:
+                    trtllm_param_keys.add(f"{prefix}o_proj.bias")
+                # Model parameter names (allowed as missing in load_state_dict):
+                # qkv_proj is fused in the model but split in the checkpoint.
+                trtllm_param_keys.add(f"{prefix}qkv_proj.weight")
+                if module.qkv_proj.bias is not None:
+                    trtllm_param_keys.add(f"{prefix}qkv_proj.bias")
+            elif isinstance(module, Linear):
+                w = weights[f"{mod_name}.weight"]
+                # Pointwise Conv1d weights are stored as [C_out, C_in, 1]; squeeze for Linear.
+                entry: Dict[str, torch.Tensor] = {"weight": w.squeeze(-1) if w.dim() == 3 else w}
+                bias_key = f"{mod_name}.bias"
+                if bias_key in weights:
+                    entry["bias"] = weights[bias_key]
+                module.load_weights([entry])
+                trtllm_param_keys.add(f"{mod_name}.weight")
+                trtllm_param_keys.add(bias_key)
+
+        remaining = {k: v for k, v in weights.items() if k not in trtllm_param_keys}
+        incompatible = self.load_state_dict(remaining, strict=False)
+
+        # Allowed gaps: trtllm weights (loaded above) and convolution bias keys
+        # absent in pre-transformers-5.0 checkpoints.
+        unexpected_missing = [
+            k
+            for k in incompatible.missing_keys
+            if k not in trtllm_param_keys and not ("_conv" in k and k.endswith(".bias"))
+        ]
+        if unexpected_missing:
+            raise KeyError(f"Missing encoder weights after loading: {unexpected_missing}")
 
 
 class ProjectedParakeet(nn.Module):
@@ -352,7 +776,7 @@ class ProjectedParakeet(nn.Module):
     ):
         super().__init__()
         encoder_config = _make_parakeet_encoder_config(sound_config)
-        self.encoder = HFParakeetEncoder(encoder_config).to(dtype=dtype)
+        self.encoder = ParakeetEncoder(encoder_config, dtype=dtype)
         self.projection = ParakeetProjection(
             hidden_size=sound_config.hidden_size,
             projection_hidden_size=sound_config.projection_hidden_size,
@@ -366,16 +790,11 @@ class ProjectedParakeet(nn.Module):
         input_features: torch.Tensor,
         attention_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        outputs = self.encoder(
-            input_features=input_features,
-            attention_mask=attention_mask,
-        )
-        hidden_states = outputs.last_hidden_state
-        return self.projection(hidden_states)
+        return self.projection(self.encoder(input_features, attention_mask))
 
     def load_weights(self, weights: Dict[str, torch.Tensor]) -> None:
-        encoder_weights = {}
-        projection_weights = {}
+        encoder_weights: Dict[str, torch.Tensor] = {}
+        projection_weights: Dict[str, torch.Tensor] = {}
         for key, value in weights.items():
             if key.startswith("sound_encoder.encoder."):
                 sub_key = key[len("sound_encoder.encoder.") :]
@@ -387,17 +806,16 @@ class ProjectedParakeet(nn.Module):
                 sub_key = key[len("sound_projection.") :]
                 projection_weights[sub_key] = value
 
-        # There was a bug in `transformers` prior to version 5.0, where the
-        # `ParakeetEncoderConvolutionModule` would ignore the value of `config.convolution_bias`
-        # and always use a bias.
-        incompatible_keys = self.encoder.load_state_dict(encoder_weights, strict=False)
-        non_conv_bias_keys = [
-            key
-            for key in incompatible_keys.missing_keys
-            if not ("_conv" in key and key.endswith(".bias"))
-        ]
-        if len(non_conv_bias_keys) > 0:
-            raise KeyError(
-                f"The following keys were missing from the checkpoint: {non_conv_bias_keys}."
-            )
-        self.projection.load_state_dict(projection_weights, strict=True)
+        self.encoder.load_weights(encoder_weights)
+
+        # projection.linear1/2 are trtllm.Linear; load them via their API.
+        # projection.norm (RMSNorm) is loaded via state_dict.
+        proj = self.projection
+        proj.linear1.load_weights([{"weight": projection_weights["linear1.weight"]}])
+        proj.linear2.load_weights([{"weight": projection_weights["linear2.weight"]}])
+        norm_weights = {
+            k: v
+            for k, v in projection_weights.items()
+            if not k.startswith("linear1.") and not k.startswith("linear2.")
+        }
+        proj.load_state_dict(norm_weights, strict=False)

--- a/tensorrt_llm/_torch/models/modeling_parakeet.py
+++ b/tensorrt_llm/_torch/models/modeling_parakeet.py
@@ -352,7 +352,7 @@ class ParakeetProjection(nn.Module):
 
 
 # ---------------------------------------------------------------------------
-# Native TRT-LLM encoder — attention built on trtllm.Attention
+# Conformer encoder
 # ---------------------------------------------------------------------------
 
 
@@ -465,7 +465,6 @@ class ParakeetConformerAttention(Attention):
 
         attn_output, _ = self._forward_with_logit_bias(q, k, v, B=B, T=T, logit_bias=matrix_bd)
 
-        # ── Output projection (TP row-parallel with AllReduce) ────────────────
         return self.o_proj(attn_output).reshape(B, T, C)
 
     def load_weights(self, weights: Dict[str, torch.Tensor], prefix: str = "") -> None:
@@ -510,10 +509,8 @@ class ParakeetFeedForward(nn.Module):
 
 
 class ParakeetConvolutionModule(nn.Module):
-    """Conformer depthwise convolution module with trtllm.Linear pointwise projections.
+    """Conformer depthwise convolution module.
 
-    Pointwise 1×1 convolutions use trtllm.Linear (operating on the last dim);
-    the depthwise Conv1d and BatchNorm remain as HF/PyTorch modules.
     Checkpoint weights for pointwise_conv1/2 have shape [C_out, C_in, 1] and are
     squeezed to [C_out, C_in] during load_weights.
     """
@@ -547,7 +544,6 @@ class ParakeetConvolutionModule(nn.Module):
         hidden_states: torch.Tensor,
         attention_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        # GLU via linear — no initial transpose needed
         hidden_states = self.pointwise_conv1(hidden_states)  # [B, T, 2C]
         hidden_states = nn.functional.glu(hidden_states, dim=-1)  # [B, T, C]
 
@@ -570,12 +566,7 @@ class ParakeetConvolutionModule(nn.Module):
 
 
 class ParakeetConformerBlock(nn.Module):
-    """Conformer block with trtllm layers throughout.
-
-    All linear projections use trtllm.Linear; all normalization uses
-    trtllm.LayerNorm. Attribute names mirror HF ParakeetEncoderBlock so
-    checkpoint weight keys map 1-to-1 without remapping.
-    """
+    """Conformer block: FFN → self-attention → convolution → FFN → layer norm."""
 
     def __init__(
         self,
@@ -601,23 +592,20 @@ class ParakeetConformerBlock(nn.Module):
         position_embeddings: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> torch.Tensor:
-        # FFN1 with 0.5 residual scaling (Conformer architecture)
+        # 0.5 residual scaling on both FFN halves is part of the Conformer design.
         residual = hidden_states
         hidden_states = residual + 0.5 * self.feed_forward1(self.norm_feed_forward1(hidden_states))
 
-        # Self-attention with relative positional encoding
         hidden_states = hidden_states + self.self_attn(
             self.norm_self_att(hidden_states),
             attention_mask=attention_mask,
             position_embeddings=position_embeddings,
         )
 
-        # Convolution module
         hidden_states = hidden_states + self.conv(
             self.norm_conv(hidden_states), attention_mask=attention_mask
         )
 
-        # FFN2 with 0.5 residual scaling
         hidden_states = hidden_states + 0.5 * self.feed_forward2(
             self.norm_feed_forward2(hidden_states)
         )
@@ -626,13 +614,7 @@ class ParakeetConformerBlock(nn.Module):
 
 
 class ParakeetEncoder(nn.Module):
-    """Native TRT-LLM Conformer encoder.
-
-    Mirrors the structure and attribute names of HF ParakeetEncoder so that
-    checkpoint weight keys map without remapping.  All linear projections use
-    trtllm.Linear and all normalization uses trtllm.LayerNorm; only the
-    depthwise Conv1d, BatchNorm, and Conv2D subsampling remain as plain PyTorch.
-    """
+    """Conformer encoder for Parakeet audio."""
 
     def __init__(self, config: ParakeetEncoderConfig, dtype: Optional[torch.dtype] = None):
         super().__init__()
@@ -698,9 +680,7 @@ class ParakeetEncoder(nn.Module):
 
         ParakeetConformerAttention modules load their own weights (fused QKV from
         separate q/k/v checkpoint keys).  All other trtllm.Linear modules are loaded
-        via their native API.  Remaining parameters (trtllm.LayerNorm, BatchNorm,
-        etc.) are loaded via state_dict — trtllm.LayerNorm uses the same weight/bias
-        parameter names as nn.LayerNorm so no remapping is needed.
+        via their native API.  Remaining parameters are loaded via state_dict.
         """
         trtllm_param_keys: set[str] = set()
         # Track prefixes of attention modules whose sub-modules must be skipped.
@@ -754,8 +734,7 @@ class ParakeetEncoder(nn.Module):
         remaining = {k: v for k, v in weights.items() if k not in trtllm_param_keys}
         incompatible = self.load_state_dict(remaining, strict=False)
 
-        # Allowed gaps: trtllm weights (loaded above) and convolution bias keys
-        # absent in pre-transformers-5.0 checkpoints.
+        # Allowed gaps: trtllm weights (loaded above) and optional convolution bias keys.
         unexpected_missing = [
             k
             for k in incompatible.missing_keys

--- a/tensorrt_llm/_torch/models/modeling_parakeet.py
+++ b/tensorrt_llm/_torch/models/modeling_parakeet.py
@@ -13,15 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from functools import cache
 import math
+from functools import cache
 from typing import Dict, NamedTuple, Optional
 
 import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from transformers import ParakeetEncoder as HFParakeetEncoder
 from transformers import ParakeetEncoderConfig, PretrainedConfig
 from transformers.activations import ACT2FN
 from transformers.audio_utils import mel_filter_bank

--- a/tensorrt_llm/_torch/models/modeling_parakeet.py
+++ b/tensorrt_llm/_torch/models/modeling_parakeet.py
@@ -33,6 +33,7 @@ from transformers.models.parakeet.modeling_parakeet import (
 )
 
 from ...logger import logger
+from ..model_config import ModelConfig
 from ..modules.attention import Attention
 from ..modules.layer_norm import LayerNorm
 from ..modules.linear import Linear
@@ -181,7 +182,12 @@ class ParakeetExtractor:
         num_frames = torch.tensor(
             [cs // self.config.hop_length for cs in clip_sizes], dtype=torch.float
         )
-        n_tokens = ParakeetEncoder._get_subsampling_output_length(self, num_frames)
+        n_tokens = _subsampling_output_length(
+            num_frames,
+            self.config.subsampling_factor,
+            self.config.subsampling_conv_kernel_size,
+            self.config.subsampling_conv_stride,
+        )
         return max(1, int(n_tokens.sum().item()))
 
     def _to_mono_tensor(
@@ -268,8 +274,23 @@ class ParakeetExtractor:
         return int(audio_tokens * self.config.subsampling_factor * self.config.hop_length)
 
 
+def _subsampling_output_length(
+    input_lengths: torch.Tensor,
+    subsampling_factor: int,
+    subsampling_conv_kernel_size: int,
+    subsampling_conv_stride: int,
+) -> torch.Tensor:
+    num_layers = int(math.log2(subsampling_factor))
+    add_pad = (subsampling_conv_kernel_size - 1) // 2 * 2 - subsampling_conv_kernel_size
+    lengths = input_lengths
+    for _ in range(num_layers):
+        lengths = torch.div(lengths.to(torch.float) + add_pad, subsampling_conv_stride) + 1.0
+        lengths = torch.floor(lengths)
+    return lengths.to(torch.int)
+
+
 # This config is the extractor's single source of truth. It also supplies the fields read by
-# `ParakeetEncoder._get_subsampling_output_length`.
+# `_subsampling_output_length`.
 class _ExtractorConfig(NamedTuple):
     feature_size: int
     sampling_rate: int
@@ -361,9 +382,8 @@ class ParakeetConformerAttention(Attention):
 
     qkv_proj and o_proj are inherited from trtllm.Attention (TP-sharded,
     quantization-ready, fused QKV kernel).  The Transformer-XL relative
-    positional encoding (RPE) is computed here and injected into the parent's
-    logit_bias SDPA path via _forward_with_logit_bias, so we share the
-    attention backend infrastructure without re-implementing SDPA.
+    positional encoding (RPE) is computed here and passed directly to
+    F.scaled_dot_product_attention as attn_mask.
 
     relative_k_proj, bias_u, and bias_v implement the content-position term;
     the content-content term uses the standard QK product inside SDPA.
@@ -374,7 +394,6 @@ class ParakeetConformerAttention(Attention):
         config: ParakeetEncoderConfig,
         layer_idx: int,
         dtype: Optional[torch.dtype] = None,
-        model_config=None,
     ):
         head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
         num_kv_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
@@ -389,7 +408,7 @@ class ParakeetConformerAttention(Attention):
             layer_idx=layer_idx,
             dtype=dtype,
             dense_bias=config.attention_bias,
-            config=model_config,  # None → default ModelConfig (TP=1)
+            config=ModelConfig(attn_backend="VANILLA"),
             q_scaling=1.0,
             head_dim=head_dim,
         )
@@ -430,7 +449,6 @@ class ParakeetConformerAttention(Attention):
         """
         B, T, C = hidden_states.shape
 
-        # ── QKV projection (TP-sharded fused kernel from trtllm.Attention) ──
         qkv = self.qkv_proj(hidden_states.reshape(-1, C))  # [B*T, (q+k+v)*d]
         q, k, v = self.split_qkv(qkv)  # each [B*T, H_rank*d]
 
@@ -457,14 +475,8 @@ class ParakeetConformerAttention(Attention):
         # Content-content term: add bias_u to q; SDPA computes (q+bias_u)@k^T
         q = q + self.bias_u.view(1, self.num_heads, 1, self.head_dim)
 
-        # ── SDPA via parent's logit_bias path ─────────────────────────────────
-        # Flatten back to packed [B*T, H*d] as expected by _forward_with_logit_bias
-        q = q.transpose(1, 2).reshape(B * T, self.q_size)
-        k = k.transpose(1, 2).reshape(B * T, self.kv_size)
-        v = v.transpose(1, 2).reshape(B * T, self.kv_size)
-
-        attn_output, _ = self._forward_with_logit_bias(q, k, v, B=B, T=T, logit_bias=matrix_bd)
-
+        out = F.scaled_dot_product_attention(q, k, v, attn_mask=matrix_bd, scale=scale)
+        attn_output = out.transpose(1, 2).reshape(B * T, self.q_size)
         return self.o_proj(attn_output).reshape(B, T, C)
 
     def load_weights(self, weights: Dict[str, torch.Tensor], prefix: str = "") -> None:
@@ -502,7 +514,7 @@ class ParakeetFeedForward(nn.Module):
             bias=bool(config.attention_bias),
             dtype=dtype,
         )
-        self.activation = ACT2FN[config.hidden_act]
+        self.activation = ACT2FN[getattr(config, "hidden_act", "silu")]
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         return self.linear2(self.activation(self.linear1(hidden_states)))
@@ -635,15 +647,12 @@ class ParakeetEncoder(nn.Module):
 
     def _get_subsampling_output_length(self, input_lengths: torch.Tensor) -> torch.Tensor:
         cfg = self.config
-        num_layers = int(math.log2(cfg.subsampling_factor))
-        add_pad = (cfg.subsampling_conv_kernel_size - 1) // 2 * 2 - cfg.subsampling_conv_kernel_size
-        lengths = input_lengths
-        for _ in range(num_layers):
-            lengths = (
-                torch.div(lengths.to(torch.float) + add_pad, cfg.subsampling_conv_stride) + 1.0
-            )
-            lengths = torch.floor(lengths)
-        return lengths.to(torch.int)
+        return _subsampling_output_length(
+            input_lengths,
+            cfg.subsampling_factor,
+            cfg.subsampling_conv_kernel_size,
+            cfg.subsampling_conv_stride,
+        )
 
     def _build_attention_mask(self, attention_mask: torch.Tensor, seq_len: int) -> torch.Tensor:
         """Convert 2-D input mask to 4-D additive attention mask after subsampling."""

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -798,7 +798,7 @@ class Attention(nn.Module):
         T: int,
         logit_bias: torch.Tensor,
     ) -> torch.Tensor:
-        """SDPA fallback for an arbitrary float additive logit bias (e.g. Conformer RPE).
+        """SDPA with an arbitrary float additive logit bias (e.g. Conformer RPE).
 
         Assumes q/k/v are already split (not fused) and in packed format
         [B*T, num_heads_per_rank * head_dim].  All sequences must have the

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -789,41 +789,6 @@ class Attention(nn.Module):
             return attn_output[0], attn_output[1]
         return attn_output, None
 
-    def _forward_with_logit_bias(
-        self,
-        q: torch.Tensor,
-        k: torch.Tensor,
-        v: torch.Tensor,
-        B: int,
-        T: int,
-        logit_bias: torch.Tensor,
-    ) -> torch.Tensor:
-        """SDPA with an arbitrary float additive logit bias (e.g. Conformer RPE).
-
-        Assumes q/k/v are already split (not fused) and in packed format
-        [B*T, num_heads_per_rank * head_dim].  All sequences must have the
-        same length T.  logit_bias has shape [B, num_heads, T, T].
-        """
-        q = q.view(B, T, self.num_heads, self.head_dim).transpose(1, 2)
-        k = k.view(B, T, self.num_key_value_heads,
-                   self.head_dim).transpose(1, 2)
-        v = v.view(B, T, self.num_key_value_heads,
-                   self.head_dim).transpose(1, 2)
-
-        if self.num_key_value_groups > 1:
-            k = k.repeat_interleave(self.num_key_value_groups, dim=1)
-            v = v.repeat_interleave(self.num_key_value_groups, dim=1)
-
-        scale = 1.0 / (math.sqrt(self.head_dim) * self.q_scaling)
-        out = torch.nn.functional.scaled_dot_product_attention(
-            q,
-            k,
-            v,
-            attn_mask=logit_bias,
-            scale=scale,
-        )
-        return out.transpose(1, 2).reshape(B * T, self.q_size), None
-
     def forward_impl(
         self,
         q: torch.Tensor,
@@ -836,23 +801,7 @@ class Attention(nn.Module):
         mrope_config: Optional[dict],
         attention_sinks: Optional[torch.Tensor] = None,
         has_lora: bool = False,
-        logit_bias: Optional[torch.Tensor] = None,
     ):
-        # Arbitrary float additive logit bias (e.g. Conformer RPE) — bypass all
-        # backends and run plain SDPA.  Caller must have already split q/k/v and
-        # applied any per-head biases.  Sequences must be uniform length.
-        if logit_bias is not None:
-            q, k, v = self.split_qkv(q, k, v)
-            N = attn_metadata.num_tokens
-            B = attn_metadata.num_contexts
-            q, k, v = q[:N], k[:N], v[:N]
-            return self._forward_with_logit_bias(q,
-                                                 k,
-                                                 v,
-                                                 B=B,
-                                                 T=N // B,
-                                                 logit_bias=logit_bias)
-
         mrope_rotary_cos_sin = None
         mrope_position_deltas = None
         if mrope_config is not None:
@@ -916,7 +865,6 @@ class Attention(nn.Module):
         attention_window_size: Optional[int] = None,
         attention_mask_data: Optional[torch.Tensor] = None,
         attention_sinks: Optional[torch.Tensor] = None,
-        logit_bias: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> torch.Tensor:
         """
@@ -932,12 +880,6 @@ class Attention(nn.Module):
             lora_params (Optional[dict]): The LoRA parameters.
             attention_window_size (Optional[int]): The attention window size.
             attention_mask_data (Optional[torch.Tensor]): The attention mask data.
-            logit_bias (Optional[torch.Tensor]): Optional float additive bias added to
-                attention logits before softmax, shape [B, num_heads, T, T].
-                When provided the standard backend is bypassed and plain SDPA is used.
-                Useful for non-causal encoders with custom relative positional encoding
-                (e.g. Conformer Transformer-XL RPE) that cannot be expressed as a
-                standard attention mask.  All sequences must have uniform length T.
         Returns:
             torch.Tensor: The output tensor.
         """
@@ -999,8 +941,7 @@ class Attention(nn.Module):
                                         attention_mask_data,
                                         mrope_config=mrope_config,
                                         attention_sinks=attention_sinks,
-                                        has_lora=bool(lora_params),
-                                        logit_bias=logit_bias)
+                                        has_lora=bool(lora_params))
 
         if self.attn_output_gate:
             gate = torch.sigmoid(gate)

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -789,6 +789,41 @@ class Attention(nn.Module):
             return attn_output[0], attn_output[1]
         return attn_output, None
 
+    def _forward_with_logit_bias(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        B: int,
+        T: int,
+        logit_bias: torch.Tensor,
+    ) -> torch.Tensor:
+        """SDPA fallback for an arbitrary float additive logit bias (e.g. Conformer RPE).
+
+        Assumes q/k/v are already split (not fused) and in packed format
+        [B*T, num_heads_per_rank * head_dim].  All sequences must have the
+        same length T.  logit_bias has shape [B, num_heads, T, T].
+        """
+        q = q.view(B, T, self.num_heads, self.head_dim).transpose(1, 2)
+        k = k.view(B, T, self.num_key_value_heads,
+                   self.head_dim).transpose(1, 2)
+        v = v.view(B, T, self.num_key_value_heads,
+                   self.head_dim).transpose(1, 2)
+
+        if self.num_key_value_groups > 1:
+            k = k.repeat_interleave(self.num_key_value_groups, dim=1)
+            v = v.repeat_interleave(self.num_key_value_groups, dim=1)
+
+        scale = 1.0 / (math.sqrt(self.head_dim) * self.q_scaling)
+        out = torch.nn.functional.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=logit_bias,
+            scale=scale,
+        )
+        return out.transpose(1, 2).reshape(B * T, self.q_size), None
+
     def forward_impl(
         self,
         q: torch.Tensor,
@@ -801,7 +836,23 @@ class Attention(nn.Module):
         mrope_config: Optional[dict],
         attention_sinks: Optional[torch.Tensor] = None,
         has_lora: bool = False,
+        logit_bias: Optional[torch.Tensor] = None,
     ):
+        # Arbitrary float additive logit bias (e.g. Conformer RPE) — bypass all
+        # backends and run plain SDPA.  Caller must have already split q/k/v and
+        # applied any per-head biases.  Sequences must be uniform length.
+        if logit_bias is not None:
+            q, k, v = self.split_qkv(q, k, v)
+            N = attn_metadata.num_tokens
+            B = attn_metadata.num_contexts
+            q, k, v = q[:N], k[:N], v[:N]
+            return self._forward_with_logit_bias(q,
+                                                 k,
+                                                 v,
+                                                 B=B,
+                                                 T=N // B,
+                                                 logit_bias=logit_bias)
+
         mrope_rotary_cos_sin = None
         mrope_position_deltas = None
         if mrope_config is not None:
@@ -865,6 +916,7 @@ class Attention(nn.Module):
         attention_window_size: Optional[int] = None,
         attention_mask_data: Optional[torch.Tensor] = None,
         attention_sinks: Optional[torch.Tensor] = None,
+        logit_bias: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> torch.Tensor:
         """
@@ -880,6 +932,12 @@ class Attention(nn.Module):
             lora_params (Optional[dict]): The LoRA parameters.
             attention_window_size (Optional[int]): The attention window size.
             attention_mask_data (Optional[torch.Tensor]): The attention mask data.
+            logit_bias (Optional[torch.Tensor]): Optional float additive bias added to
+                attention logits before softmax, shape [B, num_heads, T, T].
+                When provided the standard backend is bypassed and plain SDPA is used.
+                Useful for non-causal encoders with custom relative positional encoding
+                (e.g. Conformer Transformer-XL RPE) that cannot be expressed as a
+                standard attention mask.  All sequences must have uniform length T.
         Returns:
             torch.Tensor: The output tensor.
         """
@@ -941,7 +999,8 @@ class Attention(nn.Module):
                                         attention_mask_data,
                                         mrope_config=mrope_config,
                                         attention_sinks=attention_sinks,
-                                        has_lora=bool(lora_params))
+                                        has_lora=bool(lora_params),
+                                        logit_bias=logit_bias)
 
         if self.attn_output_gate:
             gate = torch.sigmoid(gate)


### PR DESCRIPTION
Replace HF ParakeetEncoderAttention with ParakeetConformerAttention subclassing trtllm.Attention, and convert all FFN/norm layers to trtllm.Linear/LayerNorm. Adds a logit_bias hook to trtllm.Attention for Transformer-XL RPE injection. 

#### Performance Speedup

| Scenario | Batch | HF mean | TRT mean | Speedup |
| :--- | :--- | :--- | :--- | :--- |
| 10-min audio | 20 clips | 47.0 ms | 45.9 ms | 1.02x |
| 30-min audio | 60 clips | 143.7 ms | 134.8 ms | 1.07x |

#### Numerical Accuracy vs. HF Reference
*(Same weights, same input)*

| Scenario | mean \|diff\| | cos sim median | tokens > 0.99 | tokens > 0.50 |
| :--- | :--- | :--- | :--- | :--- |
| 10-min (B=20) | 0.026 | 0.9957 | 68% | 99.7% |
| 30-min (B=60) | 0.025 | 0.9964 | 71% | 99.8% |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attention module now supports optional logit bias parameter for advanced attention masking and control.

* **Improvements**
  * Parakeet encoder implementation optimized with native TRT-LLM Conformer stack for enhanced performance and efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

Ran the layers against the base hugging-face transformers implementation and verified that the outputs were numerically identical.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
