### PR TITLE
[https://nvbugs/6204488][fix] Replace fixed disagg fill throttle with slow-start ramp

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2474,8 +2474,6 @@ class PyExecutor:
                 scheduled_batch)
             if can_forward:
                 self._benchmark_fill_phase_active = False
-                # Reseed the ramp so the next fill phase (e.g. post-warmup)
-                # starts at tp_size rather than at the previous ramp's tail.
                 self._fill_admit_cap = 0
             else:
                 time.sleep(0.1)
@@ -3214,12 +3212,6 @@ class PyExecutor:
         max_new_requests = total_max - total_num_active_requests
 
         # Benchmark disagg fill-phase admission throttle (slow-start ramp).
-        # Iter 0 caps at `tp_size`; doubles each iter; saturates at
-        # `total_max` in O(log2(total_max / tp_size)) iters.  The iter-0
-        # cap dampens the burst that trips PR #12206's fail-fast under
-        # transient ADP-router imbalance; the doubling avoids the long
-        # fill ramp a fixed `tp_size`/iter cap caused at high concurrency
-        # (regressed gen_only 1k1k post-merge configs by 7-13 %).
         if (self.is_benchmark_disagg and self._benchmark_fill_phase_active
                 and not self.is_warmup):
             if self._fill_admit_cap == 0:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -590,6 +590,10 @@ class PyExecutor:
         # normal dummy add-forward-terminate lifecycle handles taper-down.
         # Only relevant in benchmark disagg mode; False otherwise.
         self._benchmark_fill_phase_active = self.is_benchmark_disagg
+        # Slow-start admission cap for benchmark disagg fill (see
+        # _pop_from_waiting_queue).  0 = uninitialised; first throttled iter
+        # seeds it to tp_size and each subsequent iter doubles it.
+        self._fill_admit_cap: int = 0
 
         # Initialize disagg PP termination handler if needed
         self._disagg_pp_termination_handler = None
@@ -2470,6 +2474,9 @@ class PyExecutor:
                 scheduled_batch)
             if can_forward:
                 self._benchmark_fill_phase_active = False
+                # Reseed the ramp so the next fill phase (e.g. post-warmup)
+                # starts at tp_size rather than at the previous ramp's tail.
+                self._fill_admit_cap = 0
             else:
                 time.sleep(0.1)
                 return can_forward, True
@@ -3206,15 +3213,20 @@ class PyExecutor:
 
         max_new_requests = total_max - total_num_active_requests
 
-        # Benchmark disagg fill-phase admission throttle: a preloaded queue
-        # (concurrency == total_max) would otherwise pop all requests into
-        # DISAGG_GENERATION_INIT in one iter, tripping PR #12206's fail-fast
-        # under ADP-router imbalance and growing the recv-buffer fallback
-        # faster than transfers drain.  Cap at `tp_size` (≈ pre-#12208
-        # blocking fill rate).  Verified on Kimi-K2 8k1k ctx8/gen1 con=8192.
+        # Benchmark disagg fill-phase admission throttle (slow-start ramp).
+        # Iter 0 caps at `tp_size`; doubles each iter; saturates at
+        # `total_max` in O(log2(total_max / tp_size)) iters.  The iter-0
+        # cap dampens the burst that trips PR #12206's fail-fast under
+        # transient ADP-router imbalance; the doubling avoids the long
+        # fill ramp a fixed `tp_size`/iter cap caused at high concurrency
+        # (regressed gen_only 1k1k post-merge configs by 7-13 %).
         if (self.is_benchmark_disagg and self._benchmark_fill_phase_active
                 and not self.is_warmup):
-            max_new_requests = min(max_new_requests, self.dist.tp_size)
+            if self._fill_admit_cap == 0:
+                self._fill_admit_cap = self.dist.tp_size
+            else:
+                self._fill_admit_cap = min(self._fill_admit_cap * 2, total_max)
+            max_new_requests = min(max_new_requests, self._fill_admit_cap)
 
         return get_from_waiting_queue(
             waiting_queue,

--- a/tests/unittest/_torch/executor/test_benchmark_disagg.py
+++ b/tests/unittest/_torch/executor/test_benchmark_disagg.py
@@ -80,6 +80,7 @@ class MockBenchmarkExecutor:
             benchmark_req_queues_size > 0 and kv_cache_transceiver is not None
         )
         self._benchmark_fill_phase_active = self.is_benchmark_disagg
+        self._fill_admit_cap = 0
         self.enable_attention_dp = enable_attention_dp
         self.num_fetch_requests = num_fetch_requests
         self.is_warmup = is_warmup
@@ -500,6 +501,7 @@ class TestPrepareAndScheduleBatchNoBlock:
         ex.kv_cache_transceiver = Mock()
         ex.is_benchmark_disagg = True
         ex._benchmark_fill_phase_active = True
+        ex._fill_admit_cap = 0
         ex.enable_attention_dp = False
         ex.num_fetch_requests = 0
         ex.dist = Mock(rank=0, tp_size=1)
@@ -535,15 +537,20 @@ class TestPrepareAndScheduleBatchNoBlock:
 
 
 class TestBenchmarkFillAdmissionFlowControl:
-    """Verify benchmark disagg fill admits requests gradually.
+    """Verify benchmark disagg fill admits requests via a slow-start ramp.
 
-    The failing wide-EP Kimi case has ``benchmark_req_queues_size`` equal to
-    ``tp_size * max_batch_size``.  Without an explicit fill-phase cap, GEN can
-    admit the entire benchmark queue in one iteration, prepare too many KV
-    receives before the first forward pass, and hit process-level memory
-    pressure.  The desired invariant is non-blocking flow control: each
-    executor iteration should still return to the outer loop, but it should
-    only admit a small bounded number of new requests during the fill phase.
+    The failing wide-EP Kimi-K2-Thinking case has ``benchmark_req_queues_size``
+    equal to ``tp_size * max_batch_size``.  Without throttling, GEN admits
+    the entire benchmark queue in iter 0, placing every request in
+    DISAGG_GENERATION_INIT simultaneously and tripping PR #12206's
+    insufficient-KV fail-fast under transient ADP-router imbalance.  The
+    desired invariant is non-blocking flow control with a *brief* ramp:
+    iter 0 caps at ``tp_size``, the cap doubles each subsequent iter, and
+    saturates at ``total_max`` within ceil(log2(total_max/tp_size)) iters.
+    A fixed ``tp_size``/iter cap (the original PR #13347 fix) regressed
+    high-concurrency post-merge configs by stretching fill into a slow
+    ramp; the doubling preserves the iter-0 burst protection without that
+    regression.
     """
 
     @staticmethod
@@ -554,6 +561,7 @@ class TestBenchmarkFillAdmissionFlowControl:
         ex.enable_attention_dp = True
         ex.is_benchmark_disagg = True
         ex._benchmark_fill_phase_active = fill_phase_active
+        ex._fill_admit_cap = 0
         ex.benchmark_req_queues_size = 32
         ex.num_fetch_requests = 0
         ex.max_num_active_requests = 8
@@ -562,9 +570,23 @@ class TestBenchmarkFillAdmissionFlowControl:
         ex.dist.tp_size = tp_size
         return ex
 
+    @staticmethod
+    def _expected_ramp(tp_size: int, total_max: int) -> list:
+        """Build the expected admission-cap sequence: tp_size, 2*tp_size, ...,
+        clamped to total_max, then steady at total_max."""
+        seq = []
+        cap = tp_size
+        while cap < total_max:
+            seq.append(cap)
+            cap = min(cap * 2, total_max)
+        seq.append(total_max)
+        return seq
+
     @pytest.mark.parametrize("tp_size", [1, 4, 32])
     @patch("tensorrt_llm._torch.pyexecutor.py_executor.get_from_waiting_queue")
-    def test_fill_phase_caps_admission_to_tp_size(self, mock_get_from_waiting_queue, tp_size):
+    def test_first_iter_caps_at_tp_size(self, mock_get_from_waiting_queue, tp_size):
+        """Iter 0 of the ramp must still cap at tp_size — this is the
+        load-bearing iter-0 burst protection (PR #12206 fail-fast)."""
         ex = self._make_executor(tp_size=tp_size)
         waiting_queue = Mock()
         all_ranks_num_active_requests = [0] * tp_size
@@ -578,12 +600,45 @@ class TestBenchmarkFillAdmissionFlowControl:
         mock_get_from_waiting_queue.assert_called_once()
         _, max_new_requests = mock_get_from_waiting_queue.call_args.args[:2]
 
-        assert max_new_requests == ex.dist.tp_size, (
-            "Benchmark disagg fill should admit at most tp_size requests per "
-            "executor iteration.  Using full global capacity would admit "
-            "tp_size * max_batch_size requests at once and recreate the "
-            "fill-phase memory-pressure failure."
+        assert max_new_requests == tp_size, (
+            "Iter 0 of the benchmark-fill admission ramp must cap at tp_size "
+            "to protect against the simultaneous-DISAGG_GENERATION_INIT burst "
+            "that trips PR #12206's fail-fast under ADP router imbalance."
         )
+        assert ex._fill_admit_cap == tp_size
+
+    @pytest.mark.parametrize("tp_size", [1, 4, 8, 32])
+    @patch("tensorrt_llm._torch.pyexecutor.py_executor.get_from_waiting_queue")
+    def test_ramp_doubles_each_iter_and_saturates_at_total_max(
+        self, mock_get_from_waiting_queue, tp_size
+    ):
+        """Each subsequent fill-phase iter doubles the admission cap, and the
+        cap saturates at ``total_max`` (never exceeds the global capacity)."""
+        ex = self._make_executor(tp_size=tp_size)
+        total_max = ex.dist.tp_size * ex.max_num_active_requests
+        expected = self._expected_ramp(tp_size, total_max)
+
+        observed = []
+        # Walk a few iters past saturation to confirm the cap stays put.
+        for _ in range(len(expected) + 3):
+            ex._pop_from_waiting_queue(
+                Mock(),
+                total_num_active_requests=0,
+                all_ranks_num_active_requests=[0] * tp_size,
+            )
+            _, max_new_requests = mock_get_from_waiting_queue.call_args.args[:2]
+            observed.append(max_new_requests)
+
+        # The ramp matches tp_size, 2*tp_size, ..., total_max.
+        assert observed[: len(expected)] == expected, (
+            f"ramp mismatch: expected {expected}, observed {observed}"
+        )
+        # Cap stays at total_max thereafter.
+        assert all(c == total_max for c in observed[len(expected) - 1 :])
+        # Convergence is logarithmic in total_max / tp_size.
+        # (Allow +1 for the saturating final entry.)
+        max_iters = (total_max // tp_size).bit_length() + 1
+        assert len(expected) <= max_iters
 
     @patch("tensorrt_llm._torch.pyexecutor.py_executor.get_from_waiting_queue")
     def test_no_fill_phase_uses_full_available_capacity(self, mock_get_from_waiting_queue):
@@ -600,6 +655,62 @@ class TestBenchmarkFillAdmissionFlowControl:
         _, max_new_requests = mock_get_from_waiting_queue.call_args.args[:2]
 
         assert max_new_requests == ex.dist.tp_size * ex.max_num_active_requests
+        assert ex._fill_admit_cap == 0, (
+            "When fill phase is inactive, the slow-start cap must remain "
+            "untouched so a future fill phase starts the ramp from tp_size."
+        )
+
+    @patch("tensorrt_llm._torch.pyexecutor.py_executor.get_from_waiting_queue")
+    def test_ramp_state_resets_when_fill_phase_ends(self, mock_get_from_waiting_queue):
+        """After the fill gate opens (``_fill_admit_cap`` reset to 0 by
+        ``_check_benchmark_disagg_gate``), a *subsequent* fill phase starts
+        the ramp from tp_size again rather than wherever the previous ramp
+        ended.  Matters for back-to-back benchmarks (e.g. after warmup)."""
+        ex = self._make_executor(tp_size=4)
+
+        # Walk a couple of iters into the ramp.
+        for _ in range(3):
+            ex._pop_from_waiting_queue(
+                Mock(),
+                total_num_active_requests=0,
+                all_ranks_num_active_requests=[0] * 4,
+            )
+        assert ex._fill_admit_cap > 4
+
+        # Simulate the gate-open path that ``_check_benchmark_disagg_gate``
+        # takes when fill completes.
+        ex._benchmark_fill_phase_active = False
+        ex._fill_admit_cap = 0
+
+        # New fill phase starts; the next throttled iter must reseed at tp_size.
+        ex._benchmark_fill_phase_active = True
+        ex._pop_from_waiting_queue(
+            Mock(),
+            total_num_active_requests=0,
+            all_ranks_num_active_requests=[0] * 4,
+        )
+        _, max_new_requests = mock_get_from_waiting_queue.call_args.args[:2]
+        assert max_new_requests == 4
+        assert ex._fill_admit_cap == 4
+
+    @patch("tensorrt_llm._torch.pyexecutor.py_executor.get_from_waiting_queue")
+    def test_warmup_skips_throttle(self, mock_get_from_waiting_queue):
+        """Warmup must bypass the slow-start ramp so warmup iters are not
+        artificially throttled and ``_fill_admit_cap`` stays unchanged."""
+        ex = self._make_executor(tp_size=4)
+        # Bypass the is_warmup property setter (which also pokes model_engine,
+        # not present on this stub).
+        ex._is_warmup = True
+
+        ex._pop_from_waiting_queue(
+            Mock(),
+            total_num_active_requests=0,
+            all_ranks_num_active_requests=[0] * 4,
+        )
+
+        _, max_new_requests = mock_get_from_waiting_queue.call_args.args[:2]
+        assert max_new_requests == ex.dist.tp_size * ex.max_num_active_requests
+        assert ex._fill_admit_cap == 0
 
 
 # ---------------------------------------------------------------------------
@@ -793,6 +904,7 @@ class TestFailFastDuringBenchmarkFill:
         ex.kv_cache_transceiver = Mock()
         ex.is_benchmark_disagg = True
         ex._benchmark_fill_phase_active = fill_phase_active
+        ex._fill_admit_cap = 0
         ex.enable_attention_dp = False
         ex.num_fetch_requests = num_fetch_requests
         ex.dist = Mock(rank=0, tp_size=1)
@@ -937,6 +1049,7 @@ class TestFillPhaseEndToEnd:
         ex.kv_cache_transceiver = _make_transceiver(transfer_complete=False)
         ex.is_benchmark_disagg = True
         ex._benchmark_fill_phase_active = True
+        ex._fill_admit_cap = 0
         ex.enable_attention_dp = True
         ex.num_fetch_requests = 0
         ex.max_num_active_requests = self.MAX_BATCH_SIZE

--- a/tests/unittest/_torch/executor/test_benchmark_disagg.py
+++ b/tests/unittest/_torch/executor/test_benchmark_disagg.py
@@ -17,11 +17,11 @@
 In benchmark disagg mode the GEN executor must defer the forward pass
 until all benchmark requests have completed KV transfer.  These tests
 cover:
-- State-based ``_is_benchmark_disagg_fill_complete`` predicate
-- ``can_forward`` gating initialisation and transitions
+- State-based `_is_benchmark_disagg_fill_complete` predicate
+- `can_forward` gating initialisation and transitions
 - ADP dummy suppression during fill vs taper-down
 - ADP router imbalance regression (nvbug 6071070)
-- Non-blocking behaviour of ``_prepare_and_schedule_batch``
+- Non-blocking behaviour of `_prepare_and_schedule_batch`
 """
 
 from unittest.mock import Mock, patch
@@ -56,8 +56,8 @@ def _make_transceiver(transfer_complete: bool = True) -> Mock:
 
 class MockBenchmarkExecutor:
     """Minimal stub mirroring the PyExecutor attributes used by
-    ``_is_benchmark_disagg_fill_complete``, ``_check_benchmark_disagg_gate``,
-    and the ``can_forward`` gate.
+    `_is_benchmark_disagg_fill_complete`, `_check_benchmark_disagg_gate`,
+    and the `can_forward` gate.
 
     Binds the real production methods so tests exercise actual logic
     without needing a fully-initialised executor.
@@ -362,7 +362,7 @@ class TestCheckBenchmarkDisaggGate:
 
 class MockPadDummyExecutor:
     """Stub mirroring the PyExecutor attributes used by
-    ``_pad_attention_dp_dummy_request``.
+    `_pad_attention_dp_dummy_request`.
     """
 
     def __init__(
@@ -488,7 +488,7 @@ class TestPadAttentionDpDummyBenchmarkDisagg:
 class TestPrepareAndScheduleBatchNoBlock:
     """_prepare_and_schedule_batch must not block on request fetching.
 
-    NOTE: This test uses ``object.__new__(PyExecutor)`` to bypass __init__
+    NOTE: This test uses `object.__new__(PyExecutor)` to bypass __init__
     and manually sets internal attributes.  Keep the attribute list in sync
     with the method's implementation.
     """
@@ -537,21 +537,7 @@ class TestPrepareAndScheduleBatchNoBlock:
 
 
 class TestBenchmarkFillAdmissionFlowControl:
-    """Verify benchmark disagg fill admits requests via a slow-start ramp.
-
-    The failing wide-EP Kimi-K2-Thinking case has ``benchmark_req_queues_size``
-    equal to ``tp_size * max_batch_size``.  Without throttling, GEN admits
-    the entire benchmark queue in iter 0, placing every request in
-    DISAGG_GENERATION_INIT simultaneously and tripping PR #12206's
-    insufficient-KV fail-fast under transient ADP-router imbalance.  The
-    desired invariant is non-blocking flow control with a *brief* ramp:
-    iter 0 caps at ``tp_size``, the cap doubles each subsequent iter, and
-    saturates at ``total_max`` within ceil(log2(total_max/tp_size)) iters.
-    A fixed ``tp_size``/iter cap (the original PR #13347 fix) regressed
-    high-concurrency post-merge configs by stretching fill into a slow
-    ramp; the doubling preserves the iter-0 burst protection without that
-    regression.
-    """
+    """Verify benchmark disagg fill admits requests via a slow-start ramp."""
 
     @staticmethod
     def _make_executor(tp_size: int = 4, fill_phase_active: bool = True):
@@ -613,7 +599,7 @@ class TestBenchmarkFillAdmissionFlowControl:
         self, mock_get_from_waiting_queue, tp_size
     ):
         """Each subsequent fill-phase iter doubles the admission cap, and the
-        cap saturates at ``total_max`` (never exceeds the global capacity)."""
+        cap saturates at `total_max` (never exceeds the global capacity)."""
         ex = self._make_executor(tp_size=tp_size)
         total_max = ex.dist.tp_size * ex.max_num_active_requests
         expected = self._expected_ramp(tp_size, total_max)
@@ -662,8 +648,8 @@ class TestBenchmarkFillAdmissionFlowControl:
 
     @patch("tensorrt_llm._torch.pyexecutor.py_executor.get_from_waiting_queue")
     def test_ramp_state_resets_when_fill_phase_ends(self, mock_get_from_waiting_queue):
-        """After the fill gate opens (``_fill_admit_cap`` reset to 0 by
-        ``_check_benchmark_disagg_gate``), a *subsequent* fill phase starts
+        """After the fill gate opens (`_fill_admit_cap` reset to 0 by
+        `_check_benchmark_disagg_gate`), a *subsequent* fill phase starts
         the ramp from tp_size again rather than wherever the previous ramp
         ended.  Matters for back-to-back benchmarks (e.g. after warmup)."""
         ex = self._make_executor(tp_size=4)
@@ -677,7 +663,7 @@ class TestBenchmarkFillAdmissionFlowControl:
             )
         assert ex._fill_admit_cap > 4
 
-        # Simulate the gate-open path that ``_check_benchmark_disagg_gate``
+        # Simulate the gate-open path that `_check_benchmark_disagg_gate`
         # takes when fill completes.
         ex._benchmark_fill_phase_active = False
         ex._fill_admit_cap = 0
@@ -696,7 +682,7 @@ class TestBenchmarkFillAdmissionFlowControl:
     @patch("tensorrt_llm._torch.pyexecutor.py_executor.get_from_waiting_queue")
     def test_warmup_skips_throttle(self, mock_get_from_waiting_queue):
         """Warmup must bypass the slow-start ramp so warmup iters are not
-        artificially throttled and ``_fill_admit_cap`` stays unchanged."""
+        artificially throttled and `_fill_admit_cap` stays unchanged."""
         ex = self._make_executor(tp_size=4)
         # Bypass the is_warmup property setter (which also pokes model_engine,
         # not present on this stub).
@@ -885,7 +871,7 @@ class TestFailFastDuringBenchmarkFill:
 
     This covers the CI regression where the fill-phase guard suppressed the
     fail-fast forever and
-    ``test_disaggregated_benchmark_gen_only_insufficient_kv`` timed out.
+    `test_disaggregated_benchmark_gen_only_insufficient_kv` timed out.
     """
 
     def _make_executor(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced request admission logic during fill phases with a slow-start ramping mechanism for improved performance and throughput control.

* **Tests**
  * Added comprehensive test coverage for slow-start admission behavior, including ramp initialization, iteration scaling, and phase transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Summary
PR #13347's fixed `tp_size`/iter cap on benchmark disagg fill admission stretched fill into a long ramp at high concurrency (`con/tp_size` iterations), regressing post-merge perf-sanity gen-only configs by **7–13 %** on output token throughput across DeepSeek-R1, GPT-OSS, and Kimi-K2.5 1k1k configurations on B200 / GB200 / GB300.
This PR replaces the fixed cap with a doubling **slow-start ramp**:
- Iter 0 still admits at most `tp_size` requests — the load-bearing iter-0 burst protection against PR #12206's insufficient-KV fail-fast under transient ADP-router imbalance.
- Each subsequent iter doubles the cap.
- Cap saturates at `total_max` within `ceil(log2(total_max / tp_size))` iters (~10 iters / ~1 s for con=4096, tp=8).
Net effect:
- Original Kimi-K2-Thinking 8k1k ctx8/gen1 con=8192 repro continues to pass — iter 0 caps at `tp_size` exactly as before.
- High-concurrency 1k1k post-merge configs no longer pay 7–13 % wall-clock overhead.

## Test Coverage

**Unit tests** — `tests/unittest/_torch/executor/test_benchmark_disagg.py`
- `TestBenchmarkFillAdmissionFlowControl` (rewritten) — five tests pinning the ramp shape:
  - `test_first_iter_caps_at_tp_size` (iter-0 burst protection invariant, parametrized `tp_size ∈ {1, 4, 32}`).
  - `test_ramp_doubles_each_iter_and_saturates_at_total_max` (full ramp shape across iters, parametrized `tp_size ∈ {1, 4, 8, 32}`; also asserts `O(log2)` convergence).
  - `test_no_fill_phase_uses_full_available_capacity` (throttle disengages once the gate opens).
  - `test_ramp_state_resets_when_fill_phase_ends` (back-to-back benchmarks restart at `tp_size`).
  - `test_warmup_skips_throttle` (warmup bypasses the ramp).
- `TestFillPhaseEndToEnd::test_full_lifecycle` (existing) — Phase 0 still asserts iter-0 admission caps at `TP_SIZE`, confirming the ramp's first iter matches the original fixed-cap behavior the lifecycle was written against.
**Integration tests** — `tests/integration/defs/disaggregated/test_disaggregated.py::test_disaggregated_benchmark_gen_only_insufficient_kv`. This was the test that exercised PR #13347's original repro; the slow-start preserves its iter-0 behavior so it remains green.


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
