### PR TITLE
[None][feat] MNNVL Performance Optimization and FP8/NVFP4 Quant Fusion

### DIFF
--- a/cpp/tensorrt_llm/common/lamportUtils.cuh
+++ b/cpp/tensorrt_llm/common/lamportUtils.cuh
@@ -163,7 +163,14 @@ inline __device__ VolatilePackedLoad<float2> loadPackedVolatile<float2>(void con
 template <typename PackedType>
 inline __device__ bool isLamportDirty(VolatilePackedLoad<PackedType> const& value)
 {
-    return value.words[0] == kNEGZERO_FP32;
+    // The dirty sentinel is a raw word; typed fp compares can flush nearby bit patterns.
+    bool dirty = false;
+#pragma unroll
+    for (int i = 0; i < sizeof(PackedType) / sizeof(uint32_t); i++)
+    {
+        dirty |= value.words[i] == kNEGZERO_FP32;
+    }
+    return dirty;
 }
 
 // A helper class to get the correct base pointer for a given layout
@@ -255,10 +262,12 @@ public:
         {
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
             cg::cluster_group cluster = cg::this_cluster();
-            // We update the atomic counter per cluster.
-            int tid = cluster.thread_rank();
-            cluster.sync();
-            arriveCounter(tid);
+            __cluster_barrier_arrive();
+            if (cluster.block_rank() == 0 && threadIdx.x < kWARP_SIZE)
+            {
+                __cluster_barrier_wait();
+                arriveCounter(threadIdx.x);
+            }
 #else
             __syncthreads();
             arriveCounter(threadIdx.x);

--- a/cpp/tensorrt_llm/common/lamportUtils.cuh
+++ b/cpp/tensorrt_llm/common/lamportUtils.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ namespace common
 {
 
 constexpr uint16_t kNEGZERO_FP16 = 0x8000U;
+constexpr uint32_t kNEGZERO_FP32 = 0x80000000U;
+constexpr uint32_t kWARP_SIZE = 32U;
 
 template <typename T>
 union Fp16BitCast
@@ -83,7 +85,7 @@ static inline __device__ bool isNegZero(T val)
 
     if constexpr (std::is_same_v<T, float>)
     {
-        return val == 0.F && signbit(val);
+        return __float_as_uint(val) == kNEGZERO_FP32;
     }
     else if constexpr (std::is_same_v<T, __nv_bfloat16> || std::is_same_v<T, __nv_half>)
     {
@@ -121,6 +123,49 @@ constexpr __device__ __host__ PackedType getPackedLamportInit()
     return initValue.mPacked;
 }
 
+template <typename PackedType>
+union VolatilePackedLoad
+{
+    PackedType packed;
+    uint32_t words[sizeof(PackedType) / sizeof(uint32_t)];
+};
+
+template <typename PackedType>
+inline __device__ VolatilePackedLoad<PackedType> loadPackedVolatile(void const* ptr)
+{
+    static_assert(sizeof(PackedType) == 0, "loadPackedVolatile not specialized for this type");
+    return {};
+}
+
+template <>
+inline __device__ VolatilePackedLoad<float4> loadPackedVolatile<float4>(void const* ptr)
+{
+    VolatilePackedLoad<float4> returnValue;
+    asm volatile(
+        "ld.volatile.global.v4.u32 {%0, %1, %2, %3}, [%4];\n"
+        : "=r"(returnValue.words[0]), "=r"(returnValue.words[1]), "=r"(returnValue.words[2]), "=r"(returnValue.words[3])
+        : "l"(ptr)
+        : "memory");
+    return returnValue;
+}
+
+template <>
+inline __device__ VolatilePackedLoad<float2> loadPackedVolatile<float2>(void const* ptr)
+{
+    VolatilePackedLoad<float2> returnValue;
+    asm volatile("ld.volatile.global.v2.u32 {%0, %1}, [%2];\n"
+                 : "=r"(returnValue.words[0]), "=r"(returnValue.words[1])
+                 : "l"(ptr)
+                 : "memory");
+    return returnValue;
+}
+
+template <typename PackedType>
+inline __device__ bool isLamportDirty(VolatilePackedLoad<PackedType> const& value)
+{
+    return value.words[0] == kNEGZERO_FP32;
+}
+
 // A helper class to get the correct base pointer for a given layout
 struct LamportBufferLayout
 {
@@ -154,8 +199,8 @@ struct LamportBufferLayout
 namespace cg = cooperative_groups;
 
 // PackedType is the one used in kernel for Lamport buffer (LDG.128 or LDG.64)
-template <typename PackedType = float4>
-__device__ struct __attribute__((aligned(32))) LamportFlags
+template <typename PackedType = float4, bool UseCGA = false>
+struct __attribute__((aligned(32))) LamportFlags
 {
 public:
     __device__ explicit LamportFlags(uint32_t* bufferFlags, uint32_t numStages = 1)
@@ -206,17 +251,91 @@ public:
 
     __device__ void ctaArrive()
     {
-        int tid{0};
+        if constexpr (UseCGA)
+        {
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-
-        cg::cluster_group cluster = cg::this_cluster();
-        // We update the atomic counter per cluster
-        tid = cluster.thread_rank();
-        cluster.sync();
+            cg::cluster_group cluster = cg::this_cluster();
+            // We update the atomic counter per cluster.
+            int tid = cluster.thread_rank();
+            cluster.sync();
+            arriveCounter(tid);
 #else
-        tid = threadIdx.x;
-        __syncthreads();
+            __syncthreads();
+            arriveCounter(threadIdx.x);
 #endif
+        }
+        else
+        {
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 700))
+            uint32_t const barrierThreads
+                = ((static_cast<uint32_t>(blockDim.x) + kWARP_SIZE - 1U) / kWARP_SIZE) * kWARP_SIZE;
+            if (threadIdx.x < kWARP_SIZE)
+            {
+                asm volatile("barrier.cta.sync 1, %0;" ::"r"(barrierThreads) : "memory");
+                arriveCounter(threadIdx.x);
+            }
+            else
+            {
+                asm volatile("barrier.cta.arrive 1, %0;" ::"r"(barrierThreads) : "memory");
+            }
+#else
+            __syncthreads();
+            arriveCounter(threadIdx.x);
+#endif
+        }
+    }
+
+    __device__ void waitAndUpdate(uint4 bytesToClearPerStage)
+    {
+        bool isLastCtaT0{false};
+        int targetCount{0};
+        if constexpr (UseCGA)
+        {
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+            cg::grid_group grid = cg::this_grid();
+            // Use the first thread instead of the last thread as the last thread may exit early.
+            isLastCtaT0 = grid.thread_rank() == 0;
+            targetCount = grid.num_clusters();
+#else
+            isLastCtaT0 = threadIdx.x == 0 && blockIdx.x == 0 && blockIdx.y == 0 && blockIdx.z == 0;
+            targetCount = gridDim.x * gridDim.y * gridDim.z;
+#endif
+        }
+        else
+        {
+            isLastCtaT0 = threadIdx.x == 0 && blockIdx.x == 0 && blockIdx.y == 0 && blockIdx.z == 0;
+            targetCount = gridDim.x * gridDim.y * gridDim.z;
+        }
+        if (isLastCtaT0)
+        {
+            uint4* flagPtr = reinterpret_cast<uint4*>(mBufferFlagsPtr);
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 700))
+            uint32_t arrivedCount;
+            do
+            {
+                asm volatile("ld.acquire.gpu.global.u32 %0, [%1];"
+                             : "=r"(arrivedCount)
+                             : "l"(mFlagAccessPtr)
+                             : "memory");
+            } while (arrivedCount < static_cast<uint32_t>(targetCount));
+#else
+            while (*reinterpret_cast<uint32_t volatile*>(mFlagAccessPtr) < static_cast<uint32_t>(targetCount))
+            {
+            }
+#endif
+            // 'Current' becomes 'Dirty'
+            flagPtr[0] = {(mCurrentIndex + 1) % 3, // Current index
+                mCurrentIndex,                     // Dirty index
+                mCurBufferLayout.bytesPerBuffer,   // Buffer size
+                mCurBufferLayout.numStages};       // Dirty - Number of stages
+            flagPtr[1] = bytesToClearPerStage;
+            *mFlagAccessPtr = 0;
+        }
+    }
+
+private:
+    __device__ void arriveCounter(int tid)
+    {
         if (tid == 0)
         {
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000))
@@ -229,36 +348,6 @@ public:
         }
     }
 
-    __device__ void waitAndUpdate(uint4 bytesToClearPerStage)
-    {
-        bool isLastCtaT0{false};
-        int targetCount{0};
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-        cg::grid_group grid = cg::this_grid();
-        // Use the first thread instead of the last thread as the last thread may exit early
-        isLastCtaT0 = grid.thread_rank() == 0;
-        targetCount = grid.num_clusters();
-#else
-        isLastCtaT0 = threadIdx.x == 0 && blockIdx.x == 0 && blockIdx.y == 0;
-        targetCount = gridDim.x * gridDim.y;
-#endif
-        if (isLastCtaT0)
-        {
-            uint4* flagPtr = reinterpret_cast<uint4*>(mBufferFlagsPtr);
-            while (*reinterpret_cast<uint32_t volatile*>(mFlagAccessPtr) < targetCount)
-            {
-            }
-            // 'Current' becomes 'Dirty'
-            flagPtr[0] = {(mCurrentIndex + 1) % 3, // Current index
-                mCurrentIndex,                     // Dirty index
-                mCurBufferLayout.bytesPerBuffer,   // Buffer size
-                mCurBufferLayout.numStages};       // Dirty - Number of stages
-            flagPtr[1] = bytesToClearPerStage;
-            *mFlagAccessPtr = 0;
-        }
-    }
-
-private:
     uint32_t* mBufferFlagsPtr;
     uint32_t* mFlagAccessPtr;
 

--- a/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlAllreduceKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlAllreduceKernels.cu
@@ -206,10 +206,16 @@ inline __device__ __host__ T divUp(T m, T n)
     return (m + n - 1) / n;
 }
 
+inline bool requiresTwoAccessScaleGroup(ar_fusion::AllReduceFusionPattern pattern)
+{
+    return pattern == ar_fusion::AllReduceFusionPattern::kARResidualRMSNormFP4Quant
+        || pattern == ar_fusion::AllReduceFusionPattern::kARResidualRMSNormOutFP4Quant;
+}
+
 // A helper function to tune the grid configuration for fused oneshot and RMSNorm kernels.
 // Return (block_size, cluster_size, loads_per_thread).
 template <bool UseCluster>
-std::tuple<int, int, int> adjustGridConfig(int numTokens, int dim, int eltsPerThread)
+std::tuple<int, int, int> adjustGridConfig(int numTokens, int dim, int eltsPerThread, int accessGroupSize = 1)
 {
     // Step 1: Start from the widest cluster we are willing to launch. The caller can request a no-CGA
     // fallback for multi-load RMSNorm rows, in which case the cluster width stays at one CTA.
@@ -221,9 +227,11 @@ std::tuple<int, int, int> adjustGridConfig(int numTokens, int dim, int eltsPerTh
     blockSize = divUp(threadsNeeded, clusterSize);
     if constexpr (UseCluster)
     {
-        // Step 2: Shrink the cluster until the hidden dimension partitions cleanly across CTAs.
-        // This keeps each CTA responsible for an integral chunk of packed elements.
-        while (threadsNeeded % clusterSize != 0 && clusterSize > 1)
+        // Step 2: Shrink the cluster until the hidden dimension partitions cleanly across CTAs
+        // and each CTA contains an integral packed-access group. NVFP4 scale generation uses a
+        // two-access group, so it must not straddle a CTA boundary.
+        while ((threadsNeeded % clusterSize != 0 || divUp(threadsNeeded, clusterSize) % accessGroupSize != 0)
+            && clusterSize > 1)
         {
             clusterSize /= 2;
         }
@@ -250,7 +258,8 @@ std::tuple<int, int, int> adjustGridConfig(int numTokens, int dim, int eltsPerTh
         {
             int const candidateClusterSize = clusterSize * 2;
             int const candidateBlockSize = divUp(threadsNeeded, candidateClusterSize);
-            if (candidateBlockSize < 64 || numTokens * candidateClusterSize > smCount)
+            if (candidateBlockSize < 64 || candidateBlockSize % accessGroupSize != 0
+                || numTokens * candidateClusterSize > smCount)
             {
                 break;
             }
@@ -292,6 +301,12 @@ std::tuple<int, int, int> adjustGridConfig(int numTokens, int dim, int eltsPerTh
                 break;
             }
         }
+        blockSize = divUp(threadsNeeded, clusterSize * loadsPerThread);
+    }
+
+    while (blockSize % accessGroupSize != 0 && loadsPerThread < 8)
+    {
+        loadsPerThread += 1;
         blockSize = divUp(threadsNeeded, clusterSize * loadsPerThread);
     }
 
@@ -699,6 +714,7 @@ __global__ void __launch_bounds__(1024) oneshotAllreduceFusionKernel(MnnvlAllRed
 }
 
 using detail::adjustGridConfig;
+using detail::requiresTwoAccessScaleGroup;
 
 void oneshotAllreduceFusionOp(AllReduceFusionParams const& params)
 {
@@ -708,8 +724,10 @@ void oneshotAllreduceFusionOp(AllReduceFusionParams const& params)
     int const numTokens = params.numTokens;
     int const tokenDim = params.tokenDim;
     int const eltsPerThread = sizeof(float4) / getDTypeSize(params.dType);
+    int const accessGroupSize = requiresTwoAccessScaleGroup(params.pattern) ? 2 : 1;
 
-    auto [blockSize, clusterSize, loadsPerThread] = adjustGridConfig<true>(numTokens, tokenDim, eltsPerThread);
+    auto [blockSize, clusterSize, loadsPerThread]
+        = adjustGridConfig<true>(numTokens, tokenDim, eltsPerThread, accessGroupSize);
     dim3 grid(numTokens, clusterSize, 1);
 
     TLLM_LOG_DEBUG(
@@ -1243,14 +1261,15 @@ void twoshotAllreduceFusionOp(AllReduceFusionParams const& params)
     // Launch the rmsnorm lamport kernel if fusion is enabled
     if (params.rmsNormFusion)
     {
-        auto gridConfig = adjustGridConfig<true>(numTokens, tokenDim, numEltsPerThread);
+        int const accessGroupSize = requiresTwoAccessScaleGroup(params.pattern) ? 2 : 1;
+        auto gridConfig = adjustGridConfig<true>(numTokens, tokenDim, numEltsPerThread, accessGroupSize);
         int rnBlockSize = std::get<0>(gridConfig);
         int rnClusterSize = std::get<1>(gridConfig);
         int rnLoadsPerThread = std::get<2>(gridConfig);
         bool rnUseCGA = rnClusterSize > 1 && rnLoadsPerThread == 1;
         if (!rnUseCGA)
         {
-            gridConfig = adjustGridConfig<false>(numTokens, tokenDim, numEltsPerThread);
+            gridConfig = adjustGridConfig<false>(numTokens, tokenDim, numEltsPerThread, accessGroupSize);
             rnBlockSize = std::get<0>(gridConfig);
             rnClusterSize = std::get<1>(gridConfig);
             rnLoadsPerThread = std::get<2>(gridConfig);

--- a/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlAllreduceKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlAllreduceKernels.cu
@@ -899,10 +899,6 @@ __global__ __launch_bounds__(128) void twoshotAllreduceKernel(MnnvlAllReduceKern
     T* broadcastBufR
         = reinterpret_cast<T*>(flag.getCurLamportBuf(params.inputPtrs[params.rank], MNNVLTwoShotStage::BROADCAST));
 
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-    cudaTriggerProgrammaticLaunchCompletion();
-#endif
-
     // =============================== Scatter ===============================
 
     // Load vectorized data
@@ -917,6 +913,10 @@ __global__ __launch_bounds__(128) void twoshotAllreduceKernel(MnnvlAllReduceKern
             &scatterBufDest[destTokenOffset * params.tokenDim * WorldSize + params.rank * params.tokenDim])[packedIdx]
             = val.packed;
     }
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    cudaTriggerProgrammaticLaunchCompletion();
+#endif
 
     flag.clearDirtyLamportBuf(params.inputPtrs[params.rank], MNNVLTwoShotStage::SCATTER);
 

--- a/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlAllreduceKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlAllreduceKernels.cu
@@ -388,6 +388,55 @@ inline __device__ void accumulatePacked(float (&accum)[kELTS_PER_THREAD], Packed
     }
 }
 
+template <uint8_t WorldSize, int kRankChunk, typename T, typename PackedType, int kELTS_PER_THREAD>
+inline __device__ void accumulateLamportRanksChunked(
+    float (&accum)[kELTS_PER_THREAD], T const* input, int token, int tokenDim, int packedIdx)
+{
+    static_assert(kRankChunk > 0);
+    static_assert(WorldSize % kRankChunk == 0);
+
+#pragma unroll
+    for (int i = 0; i < kELTS_PER_THREAD; i++)
+    {
+        accum[i] = 0.F;
+    }
+
+#pragma unroll 1
+    for (int rankBase = 0; rankBase < WorldSize; rankBase += kRankChunk)
+    {
+        float chunkAccum[kELTS_PER_THREAD];
+        while (1)
+        {
+            bool valid = true;
+#pragma unroll
+            for (int i = 0; i < kELTS_PER_THREAD; i++)
+            {
+                chunkAccum[i] = 0.F;
+            }
+#pragma unroll
+            for (int rr = 0; rr < kRankChunk; rr++)
+            {
+                int const r = rankBase + rr;
+                auto loaded = loadPackedVolatile<PackedType>(
+                    &input[token * tokenDim * WorldSize + r * tokenDim + packedIdx * kELTS_PER_THREAD]);
+                PackedVec<PackedType, T> value;
+                value.packed = loaded.packed;
+                valid &= !isLamportDirty(loaded);
+                accumulatePacked<T, PackedType, kELTS_PER_THREAD>(chunkAccum, value);
+            }
+            if (valid)
+            {
+                break;
+            }
+        }
+#pragma unroll
+        for (int i = 0; i < kELTS_PER_THREAD; i++)
+        {
+            accum[i] += chunkAccum[i];
+        }
+    }
+}
+
 template <int Rank, uint8_t LocalRank, typename T, typename PackedType, int kELTS_PER_THREAD>
 inline __device__ void accumulateOneshotRank(float (&accum)[kELTS_PER_THREAD],
     PackedVec<PackedType, T> const* remoteValues, PackedVec<PackedType, T> const& localValue)
@@ -521,6 +570,7 @@ using detail::divUp;
 using detail::copyF4;
 using detail::MnnvlAllReduceKernelParams;
 using detail::sanitizeLamportPayload;
+using detail::accumulateLamportRanksChunked;
 using detail::reduceOneshotDeterministicFastPath;
 using detail::writeEpilogueOutput;
 
@@ -607,40 +657,12 @@ __global__ void __launch_bounds__(1024) oneshotAllreduceFusionKernel(MnnvlAllRed
     }
     else
     {
-        PackedVec<PackedType, float> valuesLamport[WorldSize];
-        while (1)
-        {
-            bool valid = true;
-#pragma unroll
-            for (int r = 0; r < WorldSize; r++)
-            {
-                auto loaded = loadPackedVolatile<PackedType>(&stagePtrLocal[token * params.tokenDim * WorldSize
-                    + r * params.tokenDim + packedIdx * kELTS_PER_THREAD]);
-                valuesLamport[r].packed = loaded.packed;
-                valid &= !isLamportDirty(loaded);
-            }
-            if (valid)
-            {
-                break;
-            }
-        }
-
-        auto values = reinterpret_cast<PackedVec<PackedType, T>*>(valuesLamport);
+        // Chunk Lamport polling so only a bounded rank set is live at once, avoiding register spills for large
+        // world sizes.
+        constexpr int kRankChunk = 8;
         float accum[kELTS_PER_THREAD];
-#pragma unroll
-        for (int i = 0; i < kELTS_PER_THREAD; i++)
-        {
-            accum[i] = 0.F;
-        }
-#pragma unroll
-        for (int r = 0; r < WorldSize; r++)
-        {
-#pragma unroll
-            for (int i = 0; i < kELTS_PER_THREAD; i++)
-            {
-                accum[i] += cuda_cast<float, T>(values[r].elements[i]);
-            }
-        }
+        accumulateLamportRanksChunked<WorldSize, kRankChunk, T, PackedType, kELTS_PER_THREAD>(
+            accum, stagePtrLocal, token, params.tokenDim, packedIdx);
 #pragma unroll
         for (int i = 0; i < kELTS_PER_THREAD; i++)
         {
@@ -903,42 +925,15 @@ __global__ __launch_bounds__(128) void twoshotAllreduceKernel(MnnvlAllReduceKern
     if (inBounds && (token % WorldSize) == params.rank)
     {
         int localToken = token / WorldSize;
-        float accum[kELTS_PER_THREAD] = {0.F};
-
-        // Use float as we only check each float value for validity
-        PackedVec<PackedType, float> valuesLamport[WorldSize];
-        while (1)
-        {
-            bool valid = true;
-#pragma unroll
-            for (int r = 0; r < WorldSize; r++)
-            {
-                auto loaded = loadPackedVolatile<PackedType>(&scatterBufLocal[localToken * params.tokenDim * WorldSize
-                    + r * params.tokenDim + packedIdx * kELTS_PER_THREAD]);
-                valuesLamport[r].packed = loaded.packed;
-                valid &= !isLamportDirty(loaded);
-            }
-            if (valid)
-            {
-                break;
-            }
-        }
-
-        // Now we view it as the value for reduction
-        auto values = reinterpret_cast<PackedVec<PackedType, T>*>(valuesLamport);
-#pragma unroll
-        for (int r = 0; r < WorldSize; r++)
-        {
-
-#pragma unroll
-            for (int i = 0; i < kELTS_PER_THREAD; i++)
-            {
-                accum[i] += cuda_cast<float, T>(values[r].elements[i]);
-            }
-        }
 
         // Store vectorized result
         PackedVec<PackedType, T> packedAccum;
+        // Chunk Lamport polling so only a bounded rank set is live at once, avoiding register spills for large
+        // world sizes.
+        constexpr int kRankChunk = WorldSize < 16 ? WorldSize : 16;
+        float accum[kELTS_PER_THREAD];
+        accumulateLamportRanksChunked<WorldSize, kRankChunk, T, PackedType, kELTS_PER_THREAD>(
+            accum, scatterBufLocal, localToken, params.tokenDim, packedIdx);
 #pragma unroll
         for (int i = 0; i < kELTS_PER_THREAD; i++)
         {

--- a/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlAllreduceKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlAllreduceKernels.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,10 +38,12 @@ namespace kernels::mnnvl
 {
 
 using tensorrt_llm::common::isNegZero;
+using tensorrt_llm::common::isLamportDirty;
 using tensorrt_llm::common::LamportFlags;
 using tensorrt_llm::common::cuda_cast;
 using tensorrt_llm::common::getMultiProcessorCount;
 using tensorrt_llm::common::getDTypeSize;
+using tensorrt_llm::common::loadPackedVolatile;
 
 // Guard the helper function used for this kernel.
 namespace detail
@@ -84,31 +86,6 @@ template <typename PackedType, typename T>
 inline __device__ const PackedType loadPacked(T const* ptr)
 {
     return *reinterpret_cast<PackedType const*>(ptr);
-}
-
-template <typename PackedType>
-inline __device__ PackedType loadPackedVolatile(void const* ptr)
-{
-    static_assert(sizeof(PackedType) == 0, "Not implemented");
-    return PackedType{};
-}
-
-template <>
-inline __device__ float4 loadPackedVolatile<float4>(void const* ptr)
-{
-    float4 returnValue;
-    asm volatile("ld.volatile.global.v4.f32 {%0, %1, %2, %3}, [%4];\n"
-                 : "=f"(returnValue.x), "=f"(returnValue.y), "=f"(returnValue.z), "=f"(returnValue.w)
-                 : "l"(ptr));
-    return returnValue;
-}
-
-template <>
-inline __device__ float2 loadPackedVolatile<float2>(void const* ptr)
-{
-    float2 returnValue;
-    asm volatile("ld.volatile.global.v2.f32 {%0, %1}, [%2];\n" : "=f"(returnValue.x), "=f"(returnValue.y) : "l"(ptr));
-    return returnValue;
 }
 
 template <typename T_IN>
@@ -226,20 +203,19 @@ inline __device__ __host__ T divUp(T m, T n)
     return (m + n - 1) / n;
 }
 
-// A helper function to tune the grid configuration for fused oneshot and rmsnorm kernels
-// Return (block_size, cluster_size, loads_per_thread)
+// A helper function to tune the grid configuration for fused oneshot and rmsnorm kernels.
+// Return (block_size, cluster_size, loads_per_thread).
+template <bool UseCluster>
 std::tuple<int, int, int> adjustGridConfig(int numTokens, int dim, int eltsPerThread)
 {
-    static int SM = tensorrt_llm::common::getSMVersion();
-
-    int clusterSize = SM >= 90 ? 8 : 1;
+    int clusterSize = UseCluster ? 8 : 1;
     int blockSize = 128;
     // ========================== Adjust the grid configuration ==========================
     int threadsNeeded = divUp(dim, eltsPerThread);
     int loadsPerThread = 1;
 
     blockSize = divUp(threadsNeeded, clusterSize);
-    if (clusterSize > 1)
+    if constexpr (UseCluster)
     {
         while (threadsNeeded % clusterSize != 0 && clusterSize > 1)
         {
@@ -262,8 +238,7 @@ std::tuple<int, int, int> adjustGridConfig(int numTokens, int dim, int eltsPerTh
     // Trying to scale up use multiple loads or CGA
     while (blockSize > 1024)
     {
-        // Scale up with CGA if supported
-        if (SM >= 90)
+        if constexpr (UseCluster)
         {
             if (clusterSize < 8)
             {
@@ -271,12 +246,18 @@ std::tuple<int, int, int> adjustGridConfig(int numTokens, int dim, int eltsPerTh
             }
             else
             {
-                break;
+                if (loadsPerThread < 8)
+                {
+                    loadsPerThread += 1;
+                }
+                else
+                {
+                    break;
+                }
             }
         }
         else
         {
-
             if (loadsPerThread < 8)
             {
                 loadsPerThread += 1;
@@ -288,85 +269,127 @@ std::tuple<int, int, int> adjustGridConfig(int numTokens, int dim, int eltsPerTh
         }
         blockSize = divUp(threadsNeeded, clusterSize * loadsPerThread);
     }
+
+    if constexpr (UseCluster)
+    {
+        while (blockSize > 1024 && loadsPerThread < 8)
+        {
+            loadsPerThread += 1;
+            blockSize = divUp(threadsNeeded, clusterSize * loadsPerThread);
+        }
+    }
     return {blockSize, clusterSize, loadsPerThread};
+}
+
+template <typename T>
+struct MnnvlAllReduceKernelParams
+{
+    T* outputPtr;
+    T* residualOutPtr;
+    T const* shardPtr;
+    T const* residualInPtr;
+    T const* gammaPtr;
+    T** inputPtrs;
+    T* bufferInputPtr;
+    T* mcastPtr;
+    int numTokens;
+    int tokenDim;
+    int nRanks;
+    int rank;
+    float epsilon;
+    uint32_t* bufferFlags;
+    bool waitForResults;
+};
+
+template <typename PackedType, typename T>
+inline __device__ void sanitizeLamportPayload(PackedVec<PackedType, T>& value)
+{
+#pragma unroll
+    for (int i = 0; i < sizeof(PackedType) / sizeof(T); i++)
+    {
+        if (isNegZero(value.elements[i]))
+        {
+            value.elements[i] = cuda_cast<T, float>(0.F);
+        }
+    }
 }
 
 } // namespace detail
 
 using detail::PackedVec;
 using detail::loadPacked;
-using detail::loadPackedVolatile;
 using detail::blockReduceSum;
 using detail::divUp;
 using detail::copyF4;
+using detail::MnnvlAllReduceKernelParams;
+using detail::sanitizeLamportPayload;
 
-template <uint8_t WorldSize, typename T, bool RMSNormFusion = false, typename PackedType = float4>
-__global__ void __launch_bounds__(1024) oneshotAllreduceFusionKernel(T* outputPtr, T* prenormedPtr, T const* shardPtr,
-    T const* residualInPtr, T const* gammaPtr, T** inputPtrs, T* mcastPtr, int const numTokens, int const tokenDim,
-    float epsilon, int const rank, uint32_t* bufferFlags)
+template <uint8_t WorldSize, typename T, bool RMSNormFusion = false, bool StableReductionOrder = false,
+    typename PackedType = float4>
+__global__ void __launch_bounds__(1024) oneshotAllreduceFusionKernel(MnnvlAllReduceKernelParams<T> params)
 {
     constexpr int kELTS_PER_THREAD = sizeof(PackedType) / sizeof(T);
-    constexpr int kLAMPORT_ELTS_PER_PACKED = sizeof(PackedType) / sizeof(float);
     constexpr uint32_t kELT_SIZE = sizeof(T);
+    constexpr int kVALUES_TO_POLL = StableReductionOrder ? WorldSize : WorldSize - 1;
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
     namespace cg = cooperative_groups;
     cg::cluster_group cluster = cg::this_cluster();
     int packedIdx = cluster.thread_rank();
     int token = blockIdx.x;
-    int threadOffset = token * tokenDim + packedIdx * kELTS_PER_THREAD;
+    int threadOffset = token * params.tokenDim + packedIdx * kELTS_PER_THREAD;
 
     cudaGridDependencySynchronize();
 #else
     int packedIdx = blockIdx.y * blockDim.x + threadIdx.x;
     int token = blockIdx.x;
     // Offset w.r.t. the input shard
-    int threadOffset = token * tokenDim + packedIdx * kELTS_PER_THREAD;
+    int threadOffset = token * params.tokenDim + packedIdx * kELTS_PER_THREAD;
 #endif
 
     // We only use 1 stage for the oneshot allreduce
-    LamportFlags<PackedType> flag(bufferFlags, 1);
-    T* stagePtrMcast = reinterpret_cast<T*>(flag.getCurLamportBuf(mcastPtr, 0));
-    T* stagePtrLocal = reinterpret_cast<T*>(flag.getCurLamportBuf(inputPtrs[rank], 0));
-
-    if (packedIdx * kELTS_PER_THREAD >= tokenDim)
-    {
-        flag.clearDirtyLamportBuf(inputPtrs[rank], -1);
-        return;
-    }
+    LamportFlags<PackedType, true> flag(params.bufferFlags, 1);
+    T* stagePtrMcast = reinterpret_cast<T*>(flag.getCurLamportBuf(params.mcastPtr, 0));
+    T* stagePtrLocal = reinterpret_cast<T*>(flag.getCurLamportBuf(params.inputPtrs[params.rank], 0));
+    bool const inBounds = packedIdx * kELTS_PER_THREAD < params.tokenDim;
 
     // ==================== Broadcast tokens to each rank =============================
     PackedVec<PackedType, T> val;
-    val.packed = loadPacked<PackedType>(&shardPtr[threadOffset]);
-#pragma unroll
-    for (int i = 0; i < kELTS_PER_THREAD; i++)
+    if (inBounds)
     {
-        if (isNegZero(val.elements[i]))
-            val.elements[i] = cuda_cast<T, float>(0.f);
-    }
+        val.packed = loadPacked<PackedType>(&params.shardPtr[threadOffset]);
+        sanitizeLamportPayload(val);
 
-    reinterpret_cast<PackedType*>(&stagePtrMcast[token * tokenDim * WorldSize + rank * tokenDim])[packedIdx]
-        = val.packed;
+        reinterpret_cast<PackedType*>(
+            &stagePtrMcast[token * params.tokenDim * WorldSize + params.rank * params.tokenDim])[packedIdx]
+            = val.packed;
+    }
 
     flag.ctaArrive();
     // ======================= Lamport Sync and clear the output buffer from previous iteration
     // =============================
-    flag.clearDirtyLamportBuf(inputPtrs[rank], -1);
+    flag.clearDirtyLamportBuf(params.inputPtrs[params.rank], -1);
 
-    PackedVec<PackedType, float> valuesLamport[WorldSize];
+    if (!inBounds)
+    {
+        return;
+    }
+
+    PackedVec<PackedType, float> valuesLamport[kVALUES_TO_POLL];
     while (1)
     {
         bool valid = true;
 #pragma unroll
-        for (int r = 0; r < WorldSize; r++)
+        for (int r = 0; r < kVALUES_TO_POLL; r++)
         {
-            valuesLamport[r].packed = loadPackedVolatile<PackedType>(
-                &stagePtrLocal[token * tokenDim * WorldSize + r * tokenDim + packedIdx * kELTS_PER_THREAD]);
-
-#pragma unroll
-            for (int i = 0; i < kLAMPORT_ELTS_PER_PACKED; i++)
+            int rankToLoad = r;
+            if constexpr (!StableReductionOrder)
             {
-                valid &= !isNegZero(valuesLamport[r].elements[i]);
+                rankToLoad = (r + params.rank + 1) % WorldSize;
             }
+            auto loaded = loadPackedVolatile<PackedType>(&stagePtrLocal[token * params.tokenDim * WorldSize
+                + rankToLoad * params.tokenDim + packedIdx * kELTS_PER_THREAD]);
+            valuesLamport[r].packed = loaded.packed;
+            valid &= !isLamportDirty(loaded);
         }
         if (valid)
         {
@@ -382,11 +405,18 @@ __global__ void __launch_bounds__(1024) oneshotAllreduceFusionKernel(T* outputPt
 #pragma unroll
     for (int i = 0; i < kELTS_PER_THREAD; i++)
     {
-        accum[i] = cuda_cast<float, T>(values[0].elements[i]);
+        if constexpr (StableReductionOrder)
+        {
+            accum[i] = cuda_cast<float, T>(values[0].elements[i]);
+        }
+        else
+        {
+            accum[i] = cuda_cast<float, T>(val.elements[i]);
+        }
     }
 
 #pragma unroll
-    for (int r = 1; r < WorldSize; r++)
+    for (int r = StableReductionOrder ? 1 : 0; r < kVALUES_TO_POLL; r++)
     {
 #pragma unroll
         for (int i = 0; i < kELTS_PER_THREAD; i++)
@@ -407,12 +437,12 @@ __global__ void __launch_bounds__(1024) oneshotAllreduceFusionKernel(T* outputPt
     {
         // =============================== Residual ===============================
         PackedVec<PackedType, T> residualIn;
-        residualIn.packed = *reinterpret_cast<PackedType const*>(&residualInPtr[threadOffset]);
+        residualIn.packed = *reinterpret_cast<PackedType const*>(&params.residualInPtr[threadOffset]);
         packedAccum += residualIn;
-        *reinterpret_cast<PackedType*>(&prenormedPtr[threadOffset]) = packedAccum.packed;
+        *reinterpret_cast<PackedType*>(&params.residualOutPtr[threadOffset]) = packedAccum.packed;
         // =============================== Rmsnorm ================================
         PackedVec<PackedType, T> gamma;
-        gamma.packed = *reinterpret_cast<PackedType const*>(&gammaPtr[packedIdx * kELTS_PER_THREAD]);
+        gamma.packed = *reinterpret_cast<PackedType const*>(&params.gammaPtr[packedIdx * kELTS_PER_THREAD]);
 
         float threadSum = 0.F;
 #pragma unroll
@@ -446,7 +476,7 @@ __global__ void __launch_bounds__(1024) oneshotAllreduceFusionKernel(T* outputPt
             }
         }
 #endif
-        float rcpRms = rsqrtf(fullSum / tokenDim + epsilon);
+        float rcpRms = rsqrtf(fullSum / params.tokenDim + params.epsilon);
 #pragma unroll
         for (int i = 0; i < kELTS_PER_THREAD; i++)
         {
@@ -454,8 +484,8 @@ __global__ void __launch_bounds__(1024) oneshotAllreduceFusionKernel(T* outputPt
                 cuda_cast<float, T>(packedAccum.elements[i]) * rcpRms * cuda_cast<float, T>(gamma.elements[i]));
         }
     }
-    reinterpret_cast<PackedType*>(&outputPtr[threadOffset])[0] = packedAccum.packed;
-    flag.waitAndUpdate({static_cast<uint32_t>(numTokens * tokenDim * WorldSize * kELT_SIZE), 0, 0, 0});
+    reinterpret_cast<PackedType*>(&params.outputPtr[threadOffset])[0] = packedAccum.packed;
+    flag.waitAndUpdate({static_cast<uint32_t>(params.numTokens * params.tokenDim * WorldSize * kELT_SIZE), 0, 0, 0});
 }
 
 using detail::adjustGridConfig;
@@ -464,22 +494,24 @@ void oneshotAllreduceFusionOp(AllReduceFusionParams const& params)
 {
 
     static int const kSMVersion = tensorrt_llm::common::getSMVersion();
+    TLLM_CHECK_WITH_INFO(kSMVersion >= 90, "[MNNVL AllReduceOneShot] requires SM 90 or newer.");
     int const numTokens = params.numTokens;
     int const tokenDim = params.tokenDim;
     int const eltsPerThread = sizeof(float4) / getDTypeSize(params.dType);
 
-    auto [blockSize, clusterSize, loadsPerThread] = adjustGridConfig(numTokens, tokenDim, eltsPerThread);
+    auto [blockSize, clusterSize, loadsPerThread] = adjustGridConfig<true>(numTokens, tokenDim, eltsPerThread);
     dim3 grid(numTokens, clusterSize, 1);
+    bool const stableReductionOrder = tensorrt_llm::common::getEnvForceDeterministicAllReduce();
 
     TLLM_LOG_DEBUG(
         "[MNNVL AllReduceOneShot] Dispatch: grid size: (%d, %d, 1), block_size: %d, cluster_size: %d, "
-        "loads_per_thread: %d, "
+        "loads_per_thread: %d, stable_reduction_order: %d, "
         "threads_needed: %d",
-        numTokens, clusterSize, blockSize, clusterSize, loadsPerThread, divUp(tokenDim, eltsPerThread));
+        numTokens, clusterSize, blockSize, clusterSize, loadsPerThread, static_cast<int>(stableReductionOrder),
+        divUp(tokenDim, eltsPerThread));
 
     TLLM_CHECK_WITH_INFO(blockSize <= 1024 && loadsPerThread == 1,
-        "Hidden Dimension %d exceeds the maximum supported hidden dimension (%d)", tokenDim,
-        1024 * (kSMVersion >= 90 ? 8 : 1) * eltsPerThread);
+        "Hidden Dimension %d exceeds the maximum supported hidden dimension (%d)", tokenDim, 1024 * 8 * eltsPerThread);
 
     cudaLaunchAttribute attrs[2];
     attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
@@ -495,21 +527,34 @@ void oneshotAllreduceFusionOp(AllReduceFusionParams const& params)
         .dynamicSmemBytes = 0,
         .stream = params.stream,
         .attrs = attrs,
-        .numAttrs = kSMVersion >= 90 ? 2U : 1U,
+        .numAttrs = 2U,
     };
 
-#define LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, RMSNORM)                                                                \
-    TLLM_CUDA_CHECK(cudaLaunchKernelEx(&config, &oneshotAllreduceFusionKernel<WORLD_SIZE, T, RMSNORM>, output,         \
-        residualOut, input, residualIn, gamma, ucPtrs, mcPtr, numTokens, tokenDim, static_cast<float>(params.epsilon), \
-        params.rank, params.bufferFlags));
+#define LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, RMSNORM, STABLE_REDUCTION_ORDER)                                        \
+    TLLM_CUDA_CHECK(cudaLaunchKernelEx(                                                                                \
+        &config, &oneshotAllreduceFusionKernel<WORLD_SIZE, T, RMSNORM, STABLE_REDUCTION_ORDER>, kernelParams));
 #define DISPATCH_ALLREDUCE_KERNEL(WORLD_SIZE, T)                                                                       \
     if (params.rmsNormFusion)                                                                                          \
     {                                                                                                                  \
-        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, true);                                                                  \
+        if (stableReductionOrder)                                                                                      \
+        {                                                                                                              \
+            LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, true, true);                                                        \
+        }                                                                                                              \
+        else                                                                                                           \
+        {                                                                                                              \
+            LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, true, false);                                                       \
+        }                                                                                                              \
     }                                                                                                                  \
     else                                                                                                               \
     {                                                                                                                  \
-        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, false);                                                                 \
+        if (stableReductionOrder)                                                                                      \
+        {                                                                                                              \
+            LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, false, true);                                                       \
+        }                                                                                                              \
+        else                                                                                                           \
+        {                                                                                                              \
+            LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, false, false);                                                      \
+        }                                                                                                              \
     }
     // C++17 compatible alternative using a template function
     auto dispatchImpl = [&](auto* type_ptr) -> bool
@@ -522,6 +567,9 @@ void oneshotAllreduceFusionOp(AllReduceFusionParams const& params)
         T const* input = reinterpret_cast<T const*>(params.input);
         T const* residualIn = reinterpret_cast<T const*>(params.residualIn);
         T const* gamma = reinterpret_cast<T const*>(params.gamma);
+        MnnvlAllReduceKernelParams<T> kernelParams{output, residualOut, input, residualIn, gamma, ucPtrs,
+            reinterpret_cast<T*>(params.bufferPtrLocal), mcPtr, numTokens, tokenDim, params.nRanks, params.rank,
+            static_cast<float>(params.epsilon), params.bufferFlags, false};
 
         switch (params.nRanks)
         {
@@ -554,64 +602,56 @@ enum MNNVLTwoShotStage : uint8_t
 };
 
 template <uint8_t WorldSize, typename T, typename PackedType = float4>
-__global__ __launch_bounds__(128) void twoshotAllreduceKernel(T* outputPtr, T const* shardPtr, T** inputPtrs,
-    T* mcastPtr, uint32_t const numTokens, uint32_t const tokenDim, uint32_t const rank, uint32_t* bufferFlags,
-    bool const wait_for_results)
+__global__ __launch_bounds__(128) void twoshotAllreduceKernel(MnnvlAllReduceKernelParams<T> params)
 {
     constexpr int kELTS_PER_THREAD = sizeof(PackedType) / sizeof(T);
-    constexpr int kLAMPORT_ELTS_PER_PACKED = sizeof(PackedType) / sizeof(float);
     constexpr uint32_t kELT_SIZE = sizeof(T);
 
     int packedIdx = blockIdx.y * blockDim.x + threadIdx.x;
     int token = blockIdx.x;
     // Offset w.r.t. the input shard
-    int threadOffset = token * tokenDim + packedIdx * kELTS_PER_THREAD;
+    int threadOffset = token * params.tokenDim + packedIdx * kELTS_PER_THREAD;
 
     int destRank = token % WorldSize;
     int destTokenOffset = token / WorldSize;
+    bool const inBounds = packedIdx * kELTS_PER_THREAD < params.tokenDim;
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
     cudaGridDependencySynchronize();
 #endif
-    LamportFlags<PackedType> flag(bufferFlags, MNNVLTwoShotStage::NUM_STAGES);
+    LamportFlags<PackedType, false> flag(params.bufferFlags, MNNVLTwoShotStage::NUM_STAGES);
 
-    T* scatterBufLocal = reinterpret_cast<T*>(flag.getCurLamportBuf(inputPtrs[rank], MNNVLTwoShotStage::SCATTER));
-    T* scatterBufDest = reinterpret_cast<T*>(flag.getCurLamportBuf(inputPtrs[destRank], MNNVLTwoShotStage::SCATTER));
-    T* broadcastBufW = reinterpret_cast<T*>(flag.getCurLamportBuf(mcastPtr, MNNVLTwoShotStage::BROADCAST));
-    T* broadcastBufR = reinterpret_cast<T*>(flag.getCurLamportBuf(inputPtrs[rank], MNNVLTwoShotStage::BROADCAST));
+    T* scatterBufLocal
+        = reinterpret_cast<T*>(flag.getCurLamportBuf(params.inputPtrs[params.rank], MNNVLTwoShotStage::SCATTER));
+    T* scatterBufDest
+        = reinterpret_cast<T*>(flag.getCurLamportBuf(params.inputPtrs[destRank], MNNVLTwoShotStage::SCATTER));
+    T* broadcastBufW = reinterpret_cast<T*>(flag.getCurLamportBuf(params.mcastPtr, MNNVLTwoShotStage::BROADCAST));
+    T* broadcastBufR
+        = reinterpret_cast<T*>(flag.getCurLamportBuf(params.inputPtrs[params.rank], MNNVLTwoShotStage::BROADCAST));
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
     cudaTriggerProgrammaticLaunchCompletion();
 #endif
-    // Make sure the clear function is called before OOB thread exits
-    if (packedIdx * kELTS_PER_THREAD >= tokenDim)
-    {
-        flag.clearDirtyLamportBuf(inputPtrs[rank], -1);
-        return;
-    }
 
     // =============================== Scatter ===============================
 
     // Load vectorized data
     PackedVec<PackedType, T> val;
-    val.packed = loadPacked<PackedType>(&shardPtr[threadOffset]);
-#pragma unroll
-    for (int i = 0; i < kELTS_PER_THREAD; i++)
+    if (inBounds)
     {
-        if (isNegZero(val.elements[i]))
-        {
-            val.elements[i] = cuda_cast<T, float>(0.F);
-        }
+        val.packed = loadPacked<PackedType>(&params.shardPtr[threadOffset]);
+        sanitizeLamportPayload(val);
+
+        // Store vectorized data
+        reinterpret_cast<PackedType*>(
+            &scatterBufDest[destTokenOffset * params.tokenDim * WorldSize + params.rank * params.tokenDim])[packedIdx]
+            = val.packed;
     }
 
-    // Store vectorized data
-    reinterpret_cast<PackedType*>(&scatterBufDest[destTokenOffset * tokenDim * WorldSize + rank * tokenDim])[packedIdx]
-        = val.packed;
-
-    flag.clearDirtyLamportBuf(inputPtrs[rank], MNNVLTwoShotStage::SCATTER);
+    flag.clearDirtyLamportBuf(params.inputPtrs[params.rank], MNNVLTwoShotStage::SCATTER);
 
     // =============================== Reduction and Broadcast ===============================
 
-    if ((token % WorldSize) == rank)
+    if (inBounds && (token % WorldSize) == params.rank)
     {
         int localToken = token / WorldSize;
         float accum[kELTS_PER_THREAD] = {0.F};
@@ -624,15 +664,10 @@ __global__ __launch_bounds__(128) void twoshotAllreduceKernel(T* outputPtr, T co
 #pragma unroll
             for (int r = 0; r < WorldSize; r++)
             {
-                valuesLamport[r].packed = loadPackedVolatile<PackedType>(
-                    &scatterBufLocal[localToken * tokenDim * WorldSize + r * tokenDim + packedIdx * kELTS_PER_THREAD]);
-
-                // Check validity across all elements
-#pragma unroll
-                for (int i = 0; i < kLAMPORT_ELTS_PER_PACKED; i++)
-                {
-                    valid &= !isNegZero(valuesLamport[r].elements[i]);
-                }
+                auto loaded = loadPackedVolatile<PackedType>(&scatterBufLocal[localToken * params.tokenDim * WorldSize
+                    + r * params.tokenDim + packedIdx * kELTS_PER_THREAD]);
+                valuesLamport[r].packed = loaded.packed;
+                valid &= !isLamportDirty(loaded);
             }
             if (valid)
             {
@@ -660,32 +695,35 @@ __global__ __launch_bounds__(128) void twoshotAllreduceKernel(T* outputPtr, T co
         {
             packedAccum.elements[i] = cuda_cast<T, float>(accum[i]);
         }
-        reinterpret_cast<PackedType*>(&broadcastBufW[token * tokenDim])[packedIdx] = packedAccum.packed;
+        sanitizeLamportPayload(packedAccum);
+        reinterpret_cast<PackedType*>(&broadcastBufW[token * params.tokenDim])[packedIdx] = packedAccum.packed;
     }
 
-    flag.clearDirtyLamportBuf(inputPtrs[rank], MNNVLTwoShotStage::BROADCAST);
+    flag.clearDirtyLamportBuf(params.inputPtrs[params.rank], MNNVLTwoShotStage::BROADCAST);
 
     // Optionally wait for results if the next layer isn't doing the Lamport check
-    if (wait_for_results)
+    if (params.waitForResults)
     {
         // Update the atomic counter to indicate the block has read the offsets
         flag.ctaArrive();
 
-        PackedVec<PackedType, float> valLamport;
-        valLamport.packed = loadPackedVolatile<PackedType>(&broadcastBufR[threadOffset]);
-        while (isNegZero(valLamport.elements[0]))
+        if (inBounds)
         {
-            valLamport.packed = loadPackedVolatile<PackedType>(&broadcastBufR[threadOffset]);
-        }
-        if (outputPtr)
-        {
-            reinterpret_cast<PackedType*>(&outputPtr[threadOffset])[0] = valLamport.packed;
+            auto loaded = loadPackedVolatile<PackedType>(&broadcastBufR[threadOffset]);
+            while (isLamportDirty(loaded))
+            {
+                loaded = loadPackedVolatile<PackedType>(&broadcastBufR[threadOffset]);
+            }
+            if (params.outputPtr)
+            {
+                reinterpret_cast<PackedType*>(&params.outputPtr[threadOffset])[0] = loaded.packed;
+            }
         }
 
         // Update the buffer flags
-        flag.waitAndUpdate({static_cast<uint32_t>(divUp<uint32_t>(numTokens, WorldSize) * WorldSize * tokenDim
-                                * kELT_SIZE),                        // Clear Size for scatter stage
-            static_cast<uint32_t>(numTokens * tokenDim * kELT_SIZE), // Clear Size for broadcast stage
+        flag.waitAndUpdate({static_cast<uint32_t>(divUp<uint32_t>(params.numTokens, WorldSize) * WorldSize
+                                * params.tokenDim * kELT_SIZE),                    // Clear Size for scatter stage
+            static_cast<uint32_t>(params.numTokens * params.tokenDim * kELT_SIZE), // Clear Size for broadcast stage
             0, 0});
         // If not wait for results, we will rely on the following kernel to update the buffer
     }
@@ -697,13 +735,10 @@ __global__ __launch_bounds__(128) void twoshotAllreduceKernel(T* outputPtr, T co
 //      1. Use CGA if supported. It expands the hidden dimension to 8k x 8 = 64k.
 //      2. Set loads_per_thread >1. Which can be used if CGA is not supported. Note that this will be limited by the
 //      shared memory size and register count.
-template <typename T_IN, typename T_OUT, int LoadsPerThread = 1>
-__global__ __launch_bounds__(1024) void rmsNormLamport(T_IN* outputPreNorm, T_OUT* outputNorm, T_IN* bufferInput,
-    T_IN const* gamma, float epsilon, T_IN const* residual, uint32_t numTokens, uint32_t dim, uint32_t worldSize,
-    uint32_t* bufferFlags)
+template <typename T, bool UseCGA, int LoadsPerThread = 1>
+__global__ __launch_bounds__(1024) void rmsNormLamport(MnnvlAllReduceKernelParams<T> params)
 {
-    static_assert(std::is_same_v<T_IN, T_OUT>, "T_IN and T_OUT must be the same type");
-    static int const kELTS_PER_LOAD = sizeof(float4) / sizeof(T_IN);
+    static int const kELTS_PER_LOAD = sizeof(float4) / sizeof(T);
 
     uint32_t const token = blockIdx.x;
     uint32_t const blockSize = blockDim.x;
@@ -712,14 +747,18 @@ __global__ __launch_bounds__(1024) void rmsNormLamport(T_IN* outputPreNorm, T_OU
     uint32_t numThreads = blockSize;
     uint32_t clusterSize = 1;
     uint32_t blockOffset = 0;
+    if constexpr (UseCGA)
+    {
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-    namespace cg = cooperative_groups;
-    cg::cluster_group cluster = cg::this_cluster();
-    numThreads = cluster.num_threads();
-    clusterSize = cluster.num_blocks();
-    blockOffset = cluster.block_rank();
+        namespace cg = cooperative_groups;
+        cg::cluster_group cluster = cg::this_cluster();
+        numThreads = cluster.num_threads();
+        clusterSize = cluster.num_blocks();
+        blockOffset = cluster.block_rank();
 #endif
-    uint32_t const dimPadded = divUp(dim, kELTS_PER_LOAD * numThreads) * kELTS_PER_LOAD * numThreads;
+    }
+    uint32_t const dimPadded
+        = divUp(static_cast<uint32_t>(params.tokenDim), kELTS_PER_LOAD * numThreads) * kELTS_PER_LOAD * numThreads;
     uint32_t const elemsPerThread = dimPadded / numThreads;
     uint32_t const loadStride = blockSize;
 
@@ -727,14 +766,14 @@ __global__ __launch_bounds__(1024) void rmsNormLamport(T_IN* outputPreNorm, T_OU
     float rInput[LoadsPerThread * kELTS_PER_LOAD];
     uint32_t offsets[LoadsPerThread * kELTS_PER_LOAD];
 
-    uint32_t const smemBufferSize = blockSize * elemsPerThread * sizeof(T_IN);
-    T_IN* smemInput = (T_IN*) &smem[0];
-    T_IN* smemResidual = (T_IN*) &smem[smemBufferSize];
-    T_IN* smemGamma = (T_IN*) &smem[2 * smemBufferSize];
+    uint32_t const smemBufferSize = blockSize * elemsPerThread * sizeof(T);
+    T* smemInput = reinterpret_cast<T*>(&smem[0]);
+    T* smemResidual = reinterpret_cast<T*>(&smem[smemBufferSize]);
+    T* smemGamma = reinterpret_cast<T*>(&smem[2 * smemBufferSize]);
 
-    LamportFlags<float4> flag(bufferFlags, MNNVLTwoShotStage::NUM_STAGES);
-    T_IN* input = reinterpret_cast<T_IN*>(
-        flag.getCurLamportBuf(reinterpret_cast<void*>(bufferInput), MNNVLTwoShotStage::BROADCAST));
+    LamportFlags<float4, UseCGA> flag(params.bufferFlags, MNNVLTwoShotStage::NUM_STAGES);
+    T* input = reinterpret_cast<T*>(
+        flag.getCurLamportBuf(reinterpret_cast<void*>(params.bufferInputPtr), MNNVLTwoShotStage::BROADCAST));
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
     cudaTriggerProgrammaticLaunchCompletion();
@@ -742,8 +781,9 @@ __global__ __launch_bounds__(1024) void rmsNormLamport(T_IN* outputPreNorm, T_OU
     // The offset that current thread should load from. Note that the hidden dimension is split by CGA size and each
     // block loads a contiguous chunk;
     // The size of chunk that each block processes
-    uint32_t const blockChunkSize = divUp(dim, clusterSize * kELTS_PER_LOAD) * kELTS_PER_LOAD;
-    uint32_t const blockLoadOffset = token * dim + blockOffset * blockChunkSize;
+    uint32_t const blockChunkSize
+        = divUp(static_cast<uint32_t>(params.tokenDim), clusterSize * kELTS_PER_LOAD) * kELTS_PER_LOAD;
+    uint32_t const blockLoadOffset = token * params.tokenDim + blockOffset * blockChunkSize;
 
 #pragma unroll
     for (uint32_t i = 0; i < LoadsPerThread; i++)
@@ -757,9 +797,9 @@ __global__ __launch_bounds__(1024) void rmsNormLamport(T_IN* outputPreNorm, T_OU
     for (uint32_t i = 0; i < LoadsPerThread; i++)
     {
         uint32_t const threadLoadOffset = (i * loadStride + threadOffset) * kELTS_PER_LOAD;
-        if (blockOffset * blockChunkSize + threadLoadOffset < dim)
+        if (blockOffset * blockChunkSize + threadLoadOffset < static_cast<uint32_t>(params.tokenDim))
         {
-            copyF4(&smemResidual[threadLoadOffset], &residual[blockLoadOffset + threadLoadOffset]);
+            copyF4(&smemResidual[threadLoadOffset], &params.residualInPtr[blockLoadOffset + threadLoadOffset]);
         }
     }
     __pipeline_commit();
@@ -767,9 +807,9 @@ __global__ __launch_bounds__(1024) void rmsNormLamport(T_IN* outputPreNorm, T_OU
     for (uint32_t i = 0; i < LoadsPerThread; i++)
     {
         uint32_t const threadLoadOffset = (i * loadStride + threadOffset) * kELTS_PER_LOAD;
-        if (blockOffset * blockChunkSize + threadLoadOffset < dim)
+        if (blockOffset * blockChunkSize + threadLoadOffset < static_cast<uint32_t>(params.tokenDim))
         {
-            copyF4(&smemGamma[threadLoadOffset], &gamma[blockOffset * blockChunkSize + threadLoadOffset]);
+            copyF4(&smemGamma[threadLoadOffset], &params.gammaPtr[blockOffset * blockChunkSize + threadLoadOffset]);
         }
     }
     __pipeline_commit();
@@ -785,16 +825,16 @@ __global__ __launch_bounds__(1024) void rmsNormLamport(T_IN* outputPreNorm, T_OU
         {
             uint32_t threadLoadOffset = (i * loadStride + threadOffset) * kELTS_PER_LOAD;
 
-            if (blockOffset * blockChunkSize + threadLoadOffset < dim)
+            if (blockOffset * blockChunkSize + threadLoadOffset < static_cast<uint32_t>(params.tokenDim))
             {
 
                 float4* dst4 = reinterpret_cast<float4*>(&smemInput[threadLoadOffset]);
                 float4 const* src4 = reinterpret_cast<float4 const*>(&input[offsets[i]]);
 
-                float4 value = loadPackedVolatile<float4>(src4);
+                auto loaded = loadPackedVolatile<float4>(src4);
                 // Assume that the 16B were written atomically, so we only need to check one value
-                valid &= !isNegZero(value.x);
-                *dst4 = value;
+                valid &= !isLamportDirty(loaded);
+                *dst4 = loaded.packed;
             }
         }
     }
@@ -807,20 +847,21 @@ __global__ __launch_bounds__(1024) void rmsNormLamport(T_IN* outputPreNorm, T_OU
     for (int i = 0; i < LoadsPerThread; i++)
     {
         int threadLoadOffset = (i * loadStride + threadOffset) * kELTS_PER_LOAD;
-        if (blockOffset * blockChunkSize + threadLoadOffset < dim)
+        if (blockOffset * blockChunkSize + threadLoadOffset < static_cast<uint32_t>(params.tokenDim))
         {
-            PackedVec<float4, T_IN> inp{.packed = loadPacked<float4>(&smemInput[threadLoadOffset])};
-            PackedVec<float4, T_IN> res{.packed = loadPacked<float4>(&smemResidual[threadLoadOffset])};
+            PackedVec<float4, T> inp{.packed = loadPacked<float4>(&smemInput[threadLoadOffset])};
+            PackedVec<float4, T> res{.packed = loadPacked<float4>(&smemResidual[threadLoadOffset])};
 
-            PackedVec<float4, T_IN> inp_plus_res = inp + res;
+            PackedVec<float4, T> inp_plus_res = inp + res;
 #pragma unroll
             for (int j = 0; j < kELTS_PER_LOAD; j++)
             {
-                rInput[i * kELTS_PER_LOAD + j] = cuda_cast<float, T_IN>(inp_plus_res.elements[j]);
-                threadSum += cuda_cast<float, T_IN>(inp_plus_res.elements[j] * inp_plus_res.elements[j]);
+                rInput[i * kELTS_PER_LOAD + j] = cuda_cast<float, T>(inp_plus_res.elements[j]);
+                threadSum += cuda_cast<float, T>(inp_plus_res.elements[j] * inp_plus_res.elements[j]);
             }
 
-            *reinterpret_cast<float4*>(&outputPreNorm[blockLoadOffset + threadLoadOffset]) = inp_plus_res.packed;
+            *reinterpret_cast<float4*>(&params.residualOutPtr[blockLoadOffset + threadLoadOffset])
+                = inp_plus_res.packed;
         }
     }
 
@@ -830,49 +871,54 @@ __global__ __launch_bounds__(1024) void rmsNormLamport(T_IN* outputPreNorm, T_OU
 
     float fullSum = blockSum;
     // Use CGA Reduction if supported
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-    __shared__ float sharedVal[8];
-    int const numBlocks = cluster.num_blocks();
-    if (numBlocks > 1)
+    if constexpr (UseCGA)
     {
-        fullSum = 0.F;
-        // Need to reduce over the entire cluster
-        int const blockRank = cluster.block_rank();
-        if (threadIdx.x < numBlocks)
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+        __shared__ float sharedVal[8];
+        namespace cg = cooperative_groups;
+        cg::cluster_group cluster = cg::this_cluster();
+        int const numBlocks = cluster.num_blocks();
+        if (numBlocks > 1)
         {
-            cluster.map_shared_rank(&sharedVal[0], threadIdx.x)[blockRank] = blockSum;
+            fullSum = 0.F;
+            // Need to reduce over the entire cluster
+            int const blockRank = cluster.block_rank();
+            if (threadIdx.x < numBlocks)
+            {
+                cluster.map_shared_rank(&sharedVal[0], threadIdx.x)[blockRank] = blockSum;
+            }
+            // cluster.sync();
+            cluster.barrier_wait(cluster.barrier_arrive());
+            for (int i = 0; i < numBlocks; ++i)
+            {
+                fullSum += sharedVal[i];
+            }
         }
-        // cluster.sync();
-        cluster.barrier_wait(cluster.barrier_arrive());
-        for (int i = 0; i < numBlocks; ++i)
-        {
-            fullSum += sharedVal[i];
-        }
-    }
 #endif
+    }
 
-    float rcpRms = rsqrtf(fullSum / dim + epsilon);
+    float rcpRms = rsqrtf(fullSum / params.tokenDim + params.epsilon);
 
 #pragma unroll
     for (int i = 0; i < LoadsPerThread; i++)
     {
-        PackedVec<float4, T_OUT> r_out;
+        PackedVec<float4, T> r_out;
         uint32_t threadLoadOffset = (i * loadStride + threadOffset) * kELTS_PER_LOAD;
-        if (blockOffset * blockChunkSize + threadLoadOffset < dim)
+        if (blockOffset * blockChunkSize + threadLoadOffset < static_cast<uint32_t>(params.tokenDim))
         {
-            PackedVec<float4, T_IN> gamma = {.packed = loadPacked<float4>(&smemGamma[threadLoadOffset])};
+            PackedVec<float4, T> gamma = {.packed = loadPacked<float4>(&smemGamma[threadLoadOffset])};
 
 #pragma unroll
             for (uint32_t j = 0; j < kELTS_PER_LOAD; j++)
             {
-                r_out.elements[j] = cuda_cast<T_OUT, float>(
-                    cuda_cast<float, T_IN>(gamma.elements[j]) * rInput[i * kELTS_PER_LOAD + j] * rcpRms);
+                r_out.elements[j] = cuda_cast<T, float>(
+                    cuda_cast<float, T>(gamma.elements[j]) * rInput[i * kELTS_PER_LOAD + j] * rcpRms);
             }
 
-            *reinterpret_cast<float4*>(&outputNorm[blockLoadOffset + threadLoadOffset]) = r_out.packed;
+            *reinterpret_cast<float4*>(&params.outputPtr[blockLoadOffset + threadLoadOffset]) = r_out.packed;
         }
     }
-    constexpr int kELTS_SIZE = sizeof(T_IN);
+    constexpr int kELTS_SIZE = sizeof(T);
 
     // Issue ACQBLK at the end. Assuming preceding kernel will not modify the buffer_flags.
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
@@ -880,13 +926,15 @@ __global__ __launch_bounds__(1024) void rmsNormLamport(T_IN* outputPreNorm, T_OU
 #endif
 
     // Update the buffer pointers
-    flag.waitAndUpdate({static_cast<uint32_t>(divUp<uint32_t>(numTokens, worldSize) * worldSize * dim * kELTS_SIZE),
-        static_cast<uint32_t>(numTokens * dim * kELTS_SIZE), 0, 0});
+    flag.waitAndUpdate({static_cast<uint32_t>(divUp<uint32_t>(params.numTokens, params.nRanks) * params.nRanks
+                            * params.tokenDim * kELTS_SIZE),
+        static_cast<uint32_t>(params.numTokens * params.tokenDim * kELTS_SIZE), 0, 0});
 }
 
 void twoshotAllreduceFusionOp(AllReduceFusionParams const& params)
 {
     static int const kSMVersion = tensorrt_llm::common::getSMVersion();
+    TLLM_CHECK_WITH_INFO(kSMVersion >= 90, "[MNNVL AllReduceTwoShot] requires SM 90 or newer.");
     int const numTokens = params.numTokens;
     int const tokenDim = params.tokenDim;
     int const numEltsPerThread = sizeof(float4) / getDTypeSize(params.dType);
@@ -915,8 +963,7 @@ void twoshotAllreduceFusionOp(AllReduceFusionParams const& params)
         "[MNNVL AllReduceTwoShot] Dispatch: grid size: (%d, %d, 1), block_size: 128", numTokens, arNumBlocksPerToken);
 
 #define LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T)                                                                         \
-    TLLM_CUDA_CHECK(cudaLaunchKernelEx(&arConfig, &twoshotAllreduceKernel<WORLD_SIZE, T>, output, input, ucPtrs,       \
-        mcastPtr, numTokens, tokenDim, params.rank, params.bufferFlags, (!params.rmsNormFusion)));
+    TLLM_CUDA_CHECK(cudaLaunchKernelEx(&arConfig, &twoshotAllreduceKernel<WORLD_SIZE, T>, kernelParams));
     auto dispatchAR = [&](auto* type_ptr) -> bool
     {
         using T = std::remove_pointer_t<decltype(type_ptr)>;
@@ -924,6 +971,10 @@ void twoshotAllreduceFusionOp(AllReduceFusionParams const& params)
         T* mcastPtr = reinterpret_cast<T*>(params.multicastPtr);
         T* output = reinterpret_cast<T*>(params.output);
         T const* input = reinterpret_cast<T const*>(params.input);
+        MnnvlAllReduceKernelParams<T> kernelParams{output, reinterpret_cast<T*>(params.residualOut), input,
+            reinterpret_cast<T const*>(params.residualIn), reinterpret_cast<T const*>(params.gamma), ucPtrs,
+            reinterpret_cast<T*>(params.bufferPtrLocal), mcastPtr, numTokens, tokenDim, params.nRanks, params.rank,
+            static_cast<float>(params.epsilon), params.bufferFlags, !params.rmsNormFusion};
         switch (params.nRanks)
         {
         case 2: LAUNCH_ALLREDUCE_KERNEL(2, T); return true;
@@ -948,10 +999,18 @@ void twoshotAllreduceFusionOp(AllReduceFusionParams const& params)
     // Launch the rmsnorm lamport kernel if fusion is enabled
     if (params.rmsNormFusion)
     {
-        auto gridConfig = adjustGridConfig(numTokens, tokenDim, numEltsPerThread);
+        auto gridConfig = adjustGridConfig<true>(numTokens, tokenDim, numEltsPerThread);
         int rnBlockSize = std::get<0>(gridConfig);
         int rnClusterSize = std::get<1>(gridConfig);
         int rnLoadsPerThread = std::get<2>(gridConfig);
+        bool rnUseCGA = rnClusterSize > 1 && rnLoadsPerThread == 1;
+        if (!rnUseCGA)
+        {
+            gridConfig = adjustGridConfig<false>(numTokens, tokenDim, numEltsPerThread);
+            rnBlockSize = std::get<0>(gridConfig);
+            rnClusterSize = std::get<1>(gridConfig);
+            rnLoadsPerThread = std::get<2>(gridConfig);
+        }
 
         int rnNumThreads = rnClusterSize * rnBlockSize;
         dim3 rnGrid(numTokens, rnClusterSize, 1);
@@ -963,13 +1022,15 @@ void twoshotAllreduceFusionOp(AllReduceFusionParams const& params)
         rnConfig.attrs = rnAttrs;
         rnAttrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
         rnAttrs[0].val.programmaticStreamSerializationAllowed = tensorrt_llm::common::getEnvEnablePDL() ? 1 : 0;
-        rnAttrs[1].id = cudaLaunchAttributeClusterDimension;
-        rnAttrs[1].val.clusterDim.x = 1;
-        rnAttrs[1].val.clusterDim.y = rnClusterSize;
-        rnAttrs[1].val.clusterDim.z = 1;
-        rnConfig.numAttrs = (kSMVersion >= 90) ? 2U : 1U;
-
-        bool const rnUseCGA = kSMVersion >= 90 && rnClusterSize > 1;
+        rnConfig.numAttrs = 1U;
+        if (rnUseCGA)
+        {
+            rnAttrs[1].id = cudaLaunchAttributeClusterDimension;
+            rnAttrs[1].val.clusterDim.x = 1;
+            rnAttrs[1].val.clusterDim.y = rnClusterSize;
+            rnAttrs[1].val.clusterDim.z = 1;
+            rnConfig.numAttrs = 2U;
+        }
         int const dimPadded = divUp(tokenDim, numEltsPerThread * rnNumThreads) * numEltsPerThread * rnNumThreads;
         int const iters = dimPadded / rnNumThreads;
 
@@ -981,40 +1042,38 @@ void twoshotAllreduceFusionOp(AllReduceFusionParams const& params)
             "threads_needed: %d",
             numTokens, rnClusterSize, rnBlockSize, rnClusterSize, rnLoadsPerThread, divUp(tokenDim, numEltsPerThread));
 
-#define RUN_RMSNORM_KERNEL(T_IN, T_OUT, LOADS_PER_THREAD)                                                              \
+#define RUN_RMSNORM_KERNEL(T, USE_CGA, LOADS_PER_THREAD)                                                               \
     TLLM_CUDA_CHECK(cudaFuncSetAttribute(                                                                              \
-        &rmsNormLamport<T_IN, T_OUT, LOADS_PER_THREAD>, cudaFuncAttributeMaxDynamicSharedMemorySize, smemSize));       \
+        &rmsNormLamport<T, USE_CGA, LOADS_PER_THREAD>, cudaFuncAttributeMaxDynamicSharedMemorySize, smemSize));        \
     rnConfig.dynamicSmemBytes = smemSize;                                                                              \
-    TLLM_CUDA_CHECK(cudaLaunchKernelEx(&rnConfig, &rmsNormLamport<T_IN, T_OUT, LOADS_PER_THREAD>, residualOut, output, \
-        bufferInput, gamma, static_cast<float>(params.epsilon), residualIn, numTokens, tokenDim, params.nRanks,        \
-        params.bufferFlags));
+    TLLM_CUDA_CHECK(cudaLaunchKernelEx(&rnConfig, &rmsNormLamport<T, USE_CGA, LOADS_PER_THREAD>, kernelParams));
 
         // C++ 17 does not support capturing structured bindings
         auto dispatchRN = [&, rnLoadsPerThread](auto* type_ptr)
         {
-            using T_IN = std::remove_pointer_t<decltype(type_ptr)>;
-            using T_OUT = T_IN;
-            T_OUT* residualOut = reinterpret_cast<T_OUT*>(params.residualOut);
-            T_OUT* output = reinterpret_cast<T_OUT*>(params.output);
-            T_IN* bufferInput = reinterpret_cast<T_IN*>(params.bufferPtrLocal);
-            T_IN const* gamma = reinterpret_cast<T_IN const*>(params.gamma);
-            T_IN const* residualIn = reinterpret_cast<T_IN const*>(params.residualIn);
+            using T = std::remove_pointer_t<decltype(type_ptr)>;
+            MnnvlAllReduceKernelParams<T> kernelParams{reinterpret_cast<T*>(params.output),
+                reinterpret_cast<T*>(params.residualOut), reinterpret_cast<T const*>(params.input),
+                reinterpret_cast<T const*>(params.residualIn), reinterpret_cast<T const*>(params.gamma),
+                reinterpret_cast<T**>(params.bufferPtrsDev), reinterpret_cast<T*>(params.bufferPtrLocal),
+                reinterpret_cast<T*>(params.multicastPtr), numTokens, tokenDim, params.nRanks, params.rank,
+                static_cast<float>(params.epsilon), params.bufferFlags, false};
             if (rnUseCGA)
             {
-                RUN_RMSNORM_KERNEL(T_IN, T_OUT, 1);
+                RUN_RMSNORM_KERNEL(T, true, 1);
             }
             else
             {
                 switch (rnLoadsPerThread)
                 {
-                case 1: RUN_RMSNORM_KERNEL(T_IN, T_OUT, 1); break;
-                case 2: RUN_RMSNORM_KERNEL(T_IN, T_OUT, 2); break;
-                case 3: RUN_RMSNORM_KERNEL(T_IN, T_OUT, 3); break;
-                case 4: RUN_RMSNORM_KERNEL(T_IN, T_OUT, 4); break;
-                case 5: RUN_RMSNORM_KERNEL(T_IN, T_OUT, 5); break;
-                case 6: RUN_RMSNORM_KERNEL(T_IN, T_OUT, 6); break;
-                case 7: RUN_RMSNORM_KERNEL(T_IN, T_OUT, 7); break;
-                case 8: RUN_RMSNORM_KERNEL(T_IN, T_OUT, 8); break;
+                case 1: RUN_RMSNORM_KERNEL(T, false, 1); break;
+                case 2: RUN_RMSNORM_KERNEL(T, false, 2); break;
+                case 3: RUN_RMSNORM_KERNEL(T, false, 3); break;
+                case 4: RUN_RMSNORM_KERNEL(T, false, 4); break;
+                case 5: RUN_RMSNORM_KERNEL(T, false, 5); break;
+                case 6: RUN_RMSNORM_KERNEL(T, false, 6); break;
+                case 7: RUN_RMSNORM_KERNEL(T, false, 7); break;
+                case 8: RUN_RMSNORM_KERNEL(T, false, 8); break;
                 default: return false;
                 }
             }

--- a/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlAllreduceKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlAllreduceKernels.cu
@@ -23,6 +23,7 @@
 #include <cuda_pipeline.h>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 
 #include "tensorrt_llm/common/cudaTypeUtils.cuh"
 #include "tensorrt_llm/common/cudaUtils.h"
@@ -314,6 +315,115 @@ inline __device__ void sanitizeLamportPayload(PackedVec<PackedType, T>& value)
     }
 }
 
+template <int Rank, uint8_t WorldSize, uint8_t LocalRank, typename T, typename PackedType, int kELTS_PER_THREAD>
+inline __device__ bool pollOneshotRemoteRank(
+    PackedVec<PackedType, T>* remoteValues, T* stagePtrLocal, int token, int tokenDim, int packedIdx)
+{
+    if constexpr (Rank == LocalRank)
+    {
+        return true;
+    }
+    else
+    {
+        auto loaded = loadPackedVolatile<PackedType>(
+            &stagePtrLocal[token * tokenDim * WorldSize + Rank * tokenDim + packedIdx * kELTS_PER_THREAD]);
+        remoteValues[Rank].packed = loaded.packed;
+        return !isLamportDirty(loaded);
+    }
+}
+
+template <uint8_t WorldSize, uint8_t LocalRank, typename T, typename PackedType, int kELTS_PER_THREAD, int... Ranks>
+inline __device__ bool pollOneshotRemoteRanks(PackedVec<PackedType, T>* remoteValues, T* stagePtrLocal, int token,
+    int tokenDim, int packedIdx, std::integer_sequence<int, Ranks...>)
+{
+    bool valid = true;
+    ((valid &= pollOneshotRemoteRank<Ranks, WorldSize, LocalRank, T, PackedType, kELTS_PER_THREAD>(
+          remoteValues, stagePtrLocal, token, tokenDim, packedIdx)),
+        ...);
+    return valid;
+}
+
+template <typename T, typename PackedType, int kELTS_PER_THREAD>
+inline __device__ void accumulatePacked(float (&accum)[kELTS_PER_THREAD], PackedVec<PackedType, T> const& value)
+{
+#pragma unroll
+    for (int i = 0; i < kELTS_PER_THREAD; i++)
+    {
+        accum[i] += cuda_cast<float, T>(value.elements[i]);
+    }
+}
+
+template <int Rank, uint8_t LocalRank, typename T, typename PackedType, int kELTS_PER_THREAD>
+inline __device__ void accumulateOneshotRank(float (&accum)[kELTS_PER_THREAD],
+    PackedVec<PackedType, T> const* remoteValues, PackedVec<PackedType, T> const& localValue)
+{
+    if constexpr (Rank == LocalRank)
+    {
+        accumulatePacked<T, PackedType, kELTS_PER_THREAD>(accum, localValue);
+    }
+    else
+    {
+        accumulatePacked<T, PackedType, kELTS_PER_THREAD>(accum, remoteValues[Rank]);
+    }
+}
+
+template <uint8_t LocalRank, typename T, typename PackedType, int kELTS_PER_THREAD, int... Ranks>
+inline __device__ void accumulateOneshotRanks(float (&accum)[kELTS_PER_THREAD],
+    PackedVec<PackedType, T> const* remoteValues, PackedVec<PackedType, T> const& localValue,
+    std::integer_sequence<int, Ranks...>)
+{
+    (accumulateOneshotRank<Ranks, LocalRank, T, PackedType, kELTS_PER_THREAD>(accum, remoteValues, localValue), ...);
+}
+
+template <uint8_t WorldSize, uint8_t LocalRank, typename T, typename PackedType, int kELTS_PER_THREAD>
+inline __device__ void waitOneshotRemoteRanks(
+    PackedVec<PackedType, T>* remoteValues, T* stagePtrLocal, int token, int tokenDim, int packedIdx)
+{
+    static_assert(LocalRank < WorldSize);
+    while (1)
+    {
+        bool const valid = pollOneshotRemoteRanks<WorldSize, LocalRank, T, PackedType, kELTS_PER_THREAD>(
+            remoteValues, stagePtrLocal, token, tokenDim, packedIdx, std::make_integer_sequence<int, WorldSize>{});
+        if (valid)
+        {
+            break;
+        }
+    }
+}
+
+template <uint8_t WorldSize, uint8_t LocalRank, typename T, typename PackedType, int kELTS_PER_THREAD>
+inline __device__ PackedVec<PackedType, T> reduceOneshotDeterministic(
+    PackedVec<PackedType, T> const* remoteValues, PackedVec<PackedType, T> const& localValue)
+{
+    static_assert(LocalRank < WorldSize);
+    float accum[kELTS_PER_THREAD];
+#pragma unroll
+    for (int i = 0; i < kELTS_PER_THREAD; i++)
+    {
+        accum[i] = 0.F;
+    }
+    accumulateOneshotRanks<LocalRank, T, PackedType, kELTS_PER_THREAD>(
+        accum, remoteValues, localValue, std::make_integer_sequence<int, WorldSize>{});
+
+    PackedVec<PackedType, T> packedAccum;
+#pragma unroll
+    for (int i = 0; i < kELTS_PER_THREAD; i++)
+    {
+        packedAccum.elements[i] = cuda_cast<T, float>(accum[i]);
+    }
+    return packedAccum;
+}
+
+template <uint8_t WorldSize, uint8_t LocalRank, typename T, typename PackedType, int kELTS_PER_THREAD>
+inline __device__ PackedVec<PackedType, T> reduceOneshotDeterministicFastPath(
+    PackedVec<PackedType, T> const& localValue, T* stagePtrLocal, int token, int tokenDim, int packedIdx)
+{
+    PackedVec<PackedType, T> remoteValues[WorldSize];
+    waitOneshotRemoteRanks<WorldSize, LocalRank, T, PackedType, kELTS_PER_THREAD>(
+        remoteValues, stagePtrLocal, token, tokenDim, packedIdx);
+    return reduceOneshotDeterministic<WorldSize, LocalRank, T, PackedType, kELTS_PER_THREAD>(remoteValues, localValue);
+}
+
 } // namespace detail
 
 using detail::PackedVec;
@@ -323,14 +433,13 @@ using detail::divUp;
 using detail::copyF4;
 using detail::MnnvlAllReduceKernelParams;
 using detail::sanitizeLamportPayload;
+using detail::reduceOneshotDeterministicFastPath;
 
-template <uint8_t WorldSize, typename T, bool RMSNormFusion = false, bool StableReductionOrder = false,
-    typename PackedType = float4>
+template <uint8_t WorldSize, typename T, bool RMSNormFusion = false, typename PackedType = float4>
 __global__ void __launch_bounds__(1024) oneshotAllreduceFusionKernel(MnnvlAllReduceKernelParams<T> params)
 {
     constexpr int kELTS_PER_THREAD = sizeof(PackedType) / sizeof(T);
     constexpr uint32_t kELT_SIZE = sizeof(T);
-    constexpr int kVALUES_TO_POLL = StableReductionOrder ? WorldSize : WorldSize - 1;
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
     namespace cg = cooperative_groups;
     cg::cluster_group cluster = cg::this_cluster();
@@ -374,61 +483,78 @@ __global__ void __launch_bounds__(1024) oneshotAllreduceFusionKernel(MnnvlAllRed
         return;
     }
 
-    PackedVec<PackedType, float> valuesLamport[kVALUES_TO_POLL];
-    while (1)
-    {
-        bool valid = true;
-#pragma unroll
-        for (int r = 0; r < kVALUES_TO_POLL; r++)
-        {
-            int rankToLoad = r;
-            if constexpr (!StableReductionOrder)
-            {
-                rankToLoad = (r + params.rank + 1) % WorldSize;
-            }
-            auto loaded = loadPackedVolatile<PackedType>(&stagePtrLocal[token * params.tokenDim * WorldSize
-                + rankToLoad * params.tokenDim + packedIdx * kELTS_PER_THREAD]);
-            valuesLamport[r].packed = loaded.packed;
-            valid &= !isLamportDirty(loaded);
-        }
-        if (valid)
-        {
-            break;
-        }
-    }
-
-    auto values = reinterpret_cast<PackedVec<PackedType, T>*>(valuesLamport);
     // ======================= Reduction =============================
-    float accum[kELTS_PER_THREAD];
+    // Fully deterministic: every rank uses the exact same reduction order. For WorldSize <= 8, specialize the local
+    // slot so the fast path reuses `val` from registers without a dynamic `remoteValues[params.rank]` store. Larger
+    // world sizes use the compact fallback because the benefit is thin but specializing every rank significantly
+    // increases compile time.
     PackedVec<PackedType, T> packedAccum;
-
-#pragma unroll
-    for (int i = 0; i < kELTS_PER_THREAD; i++)
+    if constexpr (WorldSize <= 8)
     {
-        if constexpr (StableReductionOrder)
+        packedAccum = val;
+#define RUN_ONESHOT_LOCAL_RANK(LOCAL_RANK)                                                                             \
+    case LOCAL_RANK:                                                                                                   \
+        if constexpr (WorldSize > LOCAL_RANK)                                                                          \
+        {                                                                                                              \
+            packedAccum = reduceOneshotDeterministicFastPath<WorldSize, LOCAL_RANK, T, PackedType, kELTS_PER_THREAD>(  \
+                val, stagePtrLocal, token, params.tokenDim, packedIdx);                                                \
+        }                                                                                                              \
+        break
+
+        switch (params.rank)
         {
-            accum[i] = cuda_cast<float, T>(values[0].elements[i]);
+            RUN_ONESHOT_LOCAL_RANK(0);
+            RUN_ONESHOT_LOCAL_RANK(1);
+            RUN_ONESHOT_LOCAL_RANK(2);
+            RUN_ONESHOT_LOCAL_RANK(3);
+            RUN_ONESHOT_LOCAL_RANK(4);
+            RUN_ONESHOT_LOCAL_RANK(5);
+            RUN_ONESHOT_LOCAL_RANK(6);
+            RUN_ONESHOT_LOCAL_RANK(7);
         }
-        else
-        {
-            accum[i] = cuda_cast<float, T>(val.elements[i]);
-        }
+#undef RUN_ONESHOT_LOCAL_RANK
     }
-
-#pragma unroll
-    for (int r = StableReductionOrder ? 1 : 0; r < kVALUES_TO_POLL; r++)
+    else
     {
+        PackedVec<PackedType, float> valuesLamport[WorldSize];
+        while (1)
+        {
+            bool valid = true;
+#pragma unroll
+            for (int r = 0; r < WorldSize; r++)
+            {
+                auto loaded = loadPackedVolatile<PackedType>(&stagePtrLocal[token * params.tokenDim * WorldSize
+                    + r * params.tokenDim + packedIdx * kELTS_PER_THREAD]);
+                valuesLamport[r].packed = loaded.packed;
+                valid &= !isLamportDirty(loaded);
+            }
+            if (valid)
+            {
+                break;
+            }
+        }
+
+        auto values = reinterpret_cast<PackedVec<PackedType, T>*>(valuesLamport);
+        float accum[kELTS_PER_THREAD];
 #pragma unroll
         for (int i = 0; i < kELTS_PER_THREAD; i++)
         {
-            accum[i] += cuda_cast<float, T>(values[r].elements[i]);
+            accum[i] = 0.F;
         }
-    }
-
 #pragma unroll
-    for (int i = 0; i < kELTS_PER_THREAD; i++)
-    {
-        packedAccum.elements[i] = cuda_cast<T, float>(accum[i]);
+        for (int r = 0; r < WorldSize; r++)
+        {
+#pragma unroll
+            for (int i = 0; i < kELTS_PER_THREAD; i++)
+            {
+                accum[i] += cuda_cast<float, T>(values[r].elements[i]);
+            }
+        }
+#pragma unroll
+        for (int i = 0; i < kELTS_PER_THREAD; i++)
+        {
+            packedAccum.elements[i] = cuda_cast<T, float>(accum[i]);
+        }
     }
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
     cudaTriggerProgrammaticLaunchCompletion();
@@ -501,14 +627,11 @@ void oneshotAllreduceFusionOp(AllReduceFusionParams const& params)
 
     auto [blockSize, clusterSize, loadsPerThread] = adjustGridConfig<true>(numTokens, tokenDim, eltsPerThread);
     dim3 grid(numTokens, clusterSize, 1);
-    bool const stableReductionOrder = tensorrt_llm::common::getEnvForceDeterministicAllReduce();
 
     TLLM_LOG_DEBUG(
         "[MNNVL AllReduceOneShot] Dispatch: grid size: (%d, %d, 1), block_size: %d, cluster_size: %d, "
-        "loads_per_thread: %d, stable_reduction_order: %d, "
-        "threads_needed: %d",
-        numTokens, clusterSize, blockSize, clusterSize, loadsPerThread, static_cast<int>(stableReductionOrder),
-        divUp(tokenDim, eltsPerThread));
+        "loads_per_thread: %d, deterministic_reduction_order: 1, threads_needed: %d",
+        numTokens, clusterSize, blockSize, clusterSize, loadsPerThread, divUp(tokenDim, eltsPerThread));
 
     TLLM_CHECK_WITH_INFO(blockSize <= 1024 && loadsPerThread == 1,
         "Hidden Dimension %d exceeds the maximum supported hidden dimension (%d)", tokenDim, 1024 * 8 * eltsPerThread);
@@ -530,31 +653,16 @@ void oneshotAllreduceFusionOp(AllReduceFusionParams const& params)
         .numAttrs = 2U,
     };
 
-#define LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, RMSNORM, STABLE_REDUCTION_ORDER)                                        \
-    TLLM_CUDA_CHECK(cudaLaunchKernelEx(                                                                                \
-        &config, &oneshotAllreduceFusionKernel<WORLD_SIZE, T, RMSNORM, STABLE_REDUCTION_ORDER>, kernelParams));
+#define LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, RMSNORM)                                                                \
+    TLLM_CUDA_CHECK(cudaLaunchKernelEx(&config, &oneshotAllreduceFusionKernel<WORLD_SIZE, T, RMSNORM>, kernelParams));
 #define DISPATCH_ALLREDUCE_KERNEL(WORLD_SIZE, T)                                                                       \
     if (params.rmsNormFusion)                                                                                          \
     {                                                                                                                  \
-        if (stableReductionOrder)                                                                                      \
-        {                                                                                                              \
-            LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, true, true);                                                        \
-        }                                                                                                              \
-        else                                                                                                           \
-        {                                                                                                              \
-            LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, true, false);                                                       \
-        }                                                                                                              \
+        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, true);                                                                  \
     }                                                                                                                  \
     else                                                                                                               \
     {                                                                                                                  \
-        if (stableReductionOrder)                                                                                      \
-        {                                                                                                              \
-            LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, false, true);                                                       \
-        }                                                                                                              \
-        else                                                                                                           \
-        {                                                                                                              \
-            LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, false, false);                                                      \
-        }                                                                                                              \
+        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, false);                                                                 \
     }
     // C++17 compatible alternative using a template function
     auto dispatchImpl = [&](auto* type_ptr) -> bool

--- a/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlAllreduceKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlAllreduceKernels.cu
@@ -21,6 +21,7 @@
 #include <cuda/atomic>
 #include <cuda_bf16.h>
 #include <cuda_pipeline.h>
+#include <optional>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -32,6 +33,7 @@
 #include "tensorrt_llm/common/lamportUtils.cuh"
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/common/reduceKernelUtils.cuh"
+#include "tensorrt_llm/kernels/quantization.cuh"
 
 TRTLLM_NAMESPACE_BEGIN
 
@@ -293,6 +295,9 @@ struct MnnvlAllReduceKernelParams
     T** inputPtrs;
     T* bufferInputPtr;
     T* mcastPtr;
+    void* quantOutPtr;
+    void* scaleOutPtr;
+    float const* scaleFactorPtr;
     int numTokens;
     int tokenDim;
     int nRanks;
@@ -300,6 +305,7 @@ struct MnnvlAllReduceKernelParams
     float epsilon;
     uint32_t* bufferFlags;
     bool waitForResults;
+    QuantizationSFLayout layout;
 };
 
 template <typename PackedType, typename T>
@@ -424,6 +430,59 @@ inline __device__ PackedVec<PackedType, T> reduceOneshotDeterministicFastPath(
     return reduceOneshotDeterministic<WorldSize, LocalRank, T, PackedType, kELTS_PER_THREAD>(remoteValues, localValue);
 }
 
+template <ar_fusion::AllReduceFusionPattern Pattern, typename T, typename PackedType, int kELTS_PER_THREAD>
+inline __device__ void quantizeEpilogue(PackedVec<PackedType, T> const& value,
+    MnnvlAllReduceKernelParams<T> const& params, int packedAccessIdx, int accessIdInToken, int token)
+{
+    if constexpr (ar_fusion::GetQuantType<Pattern> == ar_fusion::QuantType::kFP4)
+    {
+        static_assert(kELTS_PER_THREAD == 8, "NVFP4 quantization expects eight elements per 16-byte access.");
+        constexpr int kSFVecSize = 16;
+        using QuantPackedVec = tensorrt_llm::kernels::PackedVec<T>;
+        QuantPackedVec packVal = *reinterpret_cast<QuantPackedVec const*>(&value.packed);
+        auto* sfOut = cvt_quant_get_sf_out_offset<uint32_t, 2>(std::nullopt /* batchIdx */, token, accessIdInToken,
+            std::nullopt /* numRows */, params.tokenDim / kSFVecSize, reinterpret_cast<uint32_t*>(params.scaleOutPtr),
+            params.layout);
+        reinterpret_cast<uint32_t*>(params.quantOutPtr)[packedAccessIdx]
+            = cvt_warp_fp16_to_fp4<T, kSFVecSize, false>(packVal, *params.scaleFactorPtr, sfOut);
+    }
+    else if constexpr (ar_fusion::GetQuantType<Pattern> == ar_fusion::QuantType::kFP8)
+    {
+        float const scale = 1.F / *params.scaleFactorPtr;
+        using PackedQuantizedType = std::conditional_t<std::is_same_v<T, float>, float, float2>;
+        PackedQuantizedType quantized;
+#pragma unroll
+        for (int i = 0; i < kELTS_PER_THREAD; ++i)
+        {
+            reinterpret_cast<__nv_fp8_e4m3*>(&quantized)[i]
+                = static_cast<__nv_fp8_e4m3>(static_cast<float>(value.elements[i]) * scale);
+        }
+        reinterpret_cast<PackedQuantizedType*>(params.quantOutPtr)[packedAccessIdx] = quantized;
+    }
+    else
+    {
+        static_assert(ar_fusion::GetQuantType<Pattern> == ar_fusion::QuantType::kNone, "Invalid quant type");
+    }
+}
+
+template <ar_fusion::AllReduceFusionPattern Pattern, typename T, typename PackedType, int kELTS_PER_THREAD>
+inline __device__ void writeEpilogueOutput(PackedVec<PackedType, T> const& value,
+    MnnvlAllReduceKernelParams<T> const& params, int threadOffset, int packedAccessIdx, int accessIdInToken, int token)
+{
+    if constexpr (ar_fusion::HasAllReduceOut<Pattern> || ar_fusion::HasNormOut<Pattern>)
+    {
+        if (params.outputPtr != nullptr)
+        {
+            reinterpret_cast<PackedType*>(&params.outputPtr[threadOffset])[0] = value.packed;
+        }
+    }
+    if constexpr (ar_fusion::GetQuantType<Pattern> != ar_fusion::QuantType::kNone)
+    {
+        quantizeEpilogue<Pattern, T, PackedType, kELTS_PER_THREAD>(
+            value, params, packedAccessIdx, accessIdInToken, token);
+    }
+}
+
 } // namespace detail
 
 using detail::PackedVec;
@@ -434,8 +493,11 @@ using detail::copyF4;
 using detail::MnnvlAllReduceKernelParams;
 using detail::sanitizeLamportPayload;
 using detail::reduceOneshotDeterministicFastPath;
+using detail::writeEpilogueOutput;
 
-template <uint8_t WorldSize, typename T, bool RMSNormFusion = false, typename PackedType = float4>
+template <uint8_t WorldSize, typename T,
+    ar_fusion::AllReduceFusionPattern Pattern = ar_fusion::AllReduceFusionPattern::kAllReduce,
+    typename PackedType = float4>
 __global__ void __launch_bounds__(1024) oneshotAllreduceFusionKernel(MnnvlAllReduceKernelParams<T> params)
 {
     constexpr int kELTS_PER_THREAD = sizeof(PackedType) / sizeof(T);
@@ -559,13 +621,19 @@ __global__ void __launch_bounds__(1024) oneshotAllreduceFusionKernel(MnnvlAllRed
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
     cudaTriggerProgrammaticLaunchCompletion();
 #endif
-    if constexpr (RMSNormFusion)
+    if constexpr (ar_fusion::HasResidual<Pattern>)
     {
         // =============================== Residual ===============================
         PackedVec<PackedType, T> residualIn;
         residualIn.packed = *reinterpret_cast<PackedType const*>(&params.residualInPtr[threadOffset]);
         packedAccum += residualIn;
-        *reinterpret_cast<PackedType*>(&params.residualOutPtr[threadOffset]) = packedAccum.packed;
+        if constexpr (ar_fusion::HasResidualOut<Pattern>)
+        {
+            *reinterpret_cast<PackedType*>(&params.residualOutPtr[threadOffset]) = packedAccum.packed;
+        }
+    }
+    if constexpr (ar_fusion::HasRMSNorm<Pattern>)
+    {
         // =============================== Rmsnorm ================================
         PackedVec<PackedType, T> gamma;
         gamma.packed = *reinterpret_cast<PackedType const*>(&params.gammaPtr[packedIdx * kELTS_PER_THREAD]);
@@ -610,7 +678,9 @@ __global__ void __launch_bounds__(1024) oneshotAllreduceFusionKernel(MnnvlAllRed
                 cuda_cast<float, T>(packedAccum.elements[i]) * rcpRms * cuda_cast<float, T>(gamma.elements[i]));
         }
     }
-    reinterpret_cast<PackedType*>(&params.outputPtr[threadOffset])[0] = packedAccum.packed;
+    int const packedAccessIdx = threadOffset / kELTS_PER_THREAD;
+    writeEpilogueOutput<Pattern, T, PackedType, kELTS_PER_THREAD>(
+        packedAccum, params, threadOffset, packedAccessIdx, packedIdx, token);
     flag.waitAndUpdate({static_cast<uint32_t>(params.numTokens * params.tokenDim * WorldSize * kELT_SIZE), 0, 0, 0});
 }
 
@@ -653,16 +723,54 @@ void oneshotAllreduceFusionOp(AllReduceFusionParams const& params)
         .numAttrs = 2U,
     };
 
-#define LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, RMSNORM)                                                                \
-    TLLM_CUDA_CHECK(cudaLaunchKernelEx(&config, &oneshotAllreduceFusionKernel<WORLD_SIZE, T, RMSNORM>, kernelParams));
-#define DISPATCH_ALLREDUCE_KERNEL(WORLD_SIZE, T)                                                                       \
-    if (params.rmsNormFusion)                                                                                          \
+#define LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, PATTERN)                                                                \
+    TLLM_CUDA_CHECK(cudaLaunchKernelEx(&config, &oneshotAllreduceFusionKernel<WORLD_SIZE, T, PATTERN>, kernelParams));
+#define DISPATCH_ALLREDUCE_PATTERN(WORLD_SIZE, T)                                                                      \
+    if (params.pattern == ar_fusion::AllReduceFusionPattern::kAllReduce)                                               \
     {                                                                                                                  \
-        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, true);                                                                  \
+        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, ar_fusion::AllReduceFusionPattern::kAllReduce);                         \
+    }                                                                                                                  \
+    else if (params.pattern == ar_fusion::AllReduceFusionPattern::kARResidualRMSNorm)                                  \
+    {                                                                                                                  \
+        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, ar_fusion::AllReduceFusionPattern::kARResidualRMSNorm);                 \
+    }                                                                                                                  \
+    else if (params.pattern == ar_fusion::AllReduceFusionPattern::kARResidualRMSNormFP8Quant)                          \
+    {                                                                                                                  \
+        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormFP8Quant);         \
+    }                                                                                                                  \
+    else if (params.pattern == ar_fusion::AllReduceFusionPattern::kARResidualRMSNormOutFP8Quant)                       \
+    {                                                                                                                  \
+        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormOutFP8Quant);      \
+    }                                                                                                                  \
+    else if (params.pattern == ar_fusion::AllReduceFusionPattern::kARResidualRMSNormFP4Quant)                          \
+    {                                                                                                                  \
+        if constexpr (!std::is_same_v<T, float>)                                                                       \
+        {                                                                                                              \
+            LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormFP4Quant);     \
+        }                                                                                                              \
+        else                                                                                                           \
+        {                                                                                                              \
+            TLLM_CHECK_WITH_INFO(false, "[MNNVL AllReduceOneShot] NVFP4 quantization does not support FP32 input.");   \
+        }                                                                                                              \
+    }                                                                                                                  \
+    else if (params.pattern == ar_fusion::AllReduceFusionPattern::kARResidualRMSNormOutFP4Quant)                       \
+    {                                                                                                                  \
+        if constexpr (!std::is_same_v<T, float>)                                                                       \
+        {                                                                                                              \
+            LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormOutFP4Quant);  \
+        }                                                                                                              \
+        else                                                                                                           \
+        {                                                                                                              \
+            TLLM_CHECK_WITH_INFO(false, "[MNNVL AllReduceOneShot] NVFP4 quantization does not support FP32 input.");   \
+        }                                                                                                              \
+    }                                                                                                                  \
+    else if (params.pattern == ar_fusion::AllReduceFusionPattern::kARRMSNorm)                                          \
+    {                                                                                                                  \
+        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, ar_fusion::AllReduceFusionPattern::kARRMSNorm);                         \
     }                                                                                                                  \
     else                                                                                                               \
     {                                                                                                                  \
-        LAUNCH_ALLREDUCE_KERNEL(WORLD_SIZE, T, false);                                                                 \
+        TLLM_CHECK_WITH_INFO(false, "[MNNVL AllReduceOneShot] Unsupported fusion pattern.");                           \
     }
     // C++17 compatible alternative using a template function
     auto dispatchImpl = [&](auto* type_ptr) -> bool
@@ -676,23 +784,24 @@ void oneshotAllreduceFusionOp(AllReduceFusionParams const& params)
         T const* residualIn = reinterpret_cast<T const*>(params.residualIn);
         T const* gamma = reinterpret_cast<T const*>(params.gamma);
         MnnvlAllReduceKernelParams<T> kernelParams{output, residualOut, input, residualIn, gamma, ucPtrs,
-            reinterpret_cast<T*>(params.bufferPtrLocal), mcPtr, numTokens, tokenDim, params.nRanks, params.rank,
-            static_cast<float>(params.epsilon), params.bufferFlags, false};
+            reinterpret_cast<T*>(params.bufferPtrLocal), mcPtr, params.quantOut, params.scaleOut, params.scaleFactor,
+            numTokens, tokenDim, params.nRanks, params.rank, static_cast<float>(params.epsilon), params.bufferFlags,
+            false, params.layout};
 
         switch (params.nRanks)
         {
             // FIXME: Do we need other world sizes?
-        case 2: DISPATCH_ALLREDUCE_KERNEL(2, T); return true;
-        case 4: DISPATCH_ALLREDUCE_KERNEL(4, T); return true;
-        case 8: DISPATCH_ALLREDUCE_KERNEL(8, T); return true;
-        case 16: DISPATCH_ALLREDUCE_KERNEL(16, T); return true;
-        case 32: DISPATCH_ALLREDUCE_KERNEL(32, T); return true;
-        case 64: DISPATCH_ALLREDUCE_KERNEL(64, T); return true;
+        case 2: DISPATCH_ALLREDUCE_PATTERN(2, T); return true;
+        case 4: DISPATCH_ALLREDUCE_PATTERN(4, T); return true;
+        case 8: DISPATCH_ALLREDUCE_PATTERN(8, T); return true;
+        case 16: DISPATCH_ALLREDUCE_PATTERN(16, T); return true;
+        case 32: DISPATCH_ALLREDUCE_PATTERN(32, T); return true;
+        case 64: DISPATCH_ALLREDUCE_PATTERN(64, T); return true;
         }
         return false;
     };
 #undef LAUNCH_ALLREDUCE_KERNEL
-#undef DISPATCH_ALLREDUCE_KERNEL
+#undef DISPATCH_ALLREDUCE_PATTERN
     bool launched = (params.dType == nvinfer1::DataType::kBF16 && dispatchImpl((__nv_bfloat16*) nullptr))
         || (params.dType == nvinfer1::DataType::kFLOAT && dispatchImpl((float*) nullptr))
         || (params.dType == nvinfer1::DataType::kHALF && dispatchImpl((__nv_half*) nullptr));
@@ -843,7 +952,7 @@ __global__ __launch_bounds__(128) void twoshotAllreduceKernel(MnnvlAllReduceKern
 //      1. Use CGA if supported. It expands the hidden dimension to 8k x 8 = 64k.
 //      2. Set loads_per_thread >1. Which can be used if CGA is not supported. Note that this will be limited by the
 //      shared memory size and register count.
-template <typename T, bool UseCGA, int LoadsPerThread = 1>
+template <typename T, ar_fusion::AllReduceFusionPattern Pattern, bool UseCGA, int LoadsPerThread = 1>
 __global__ __launch_bounds__(1024) void rmsNormLamport(MnnvlAllReduceKernelParams<T> params)
 {
     static int const kELTS_PER_LOAD = sizeof(float4) / sizeof(T);
@@ -901,16 +1010,19 @@ __global__ __launch_bounds__(1024) void rmsNormLamport(MnnvlAllReduceKernelParam
         offsets[i] = blockLoadOffset + threadLoadOffset;
     }
 
-#pragma unroll
-    for (uint32_t i = 0; i < LoadsPerThread; i++)
+    if constexpr (ar_fusion::HasResidual<Pattern>)
     {
-        uint32_t const threadLoadOffset = (i * loadStride + threadOffset) * kELTS_PER_LOAD;
-        if (blockOffset * blockChunkSize + threadLoadOffset < static_cast<uint32_t>(params.tokenDim))
+#pragma unroll
+        for (uint32_t i = 0; i < LoadsPerThread; i++)
         {
-            copyF4(&smemResidual[threadLoadOffset], &params.residualInPtr[blockLoadOffset + threadLoadOffset]);
+            uint32_t const threadLoadOffset = (i * loadStride + threadOffset) * kELTS_PER_LOAD;
+            if (blockOffset * blockChunkSize + threadLoadOffset < static_cast<uint32_t>(params.tokenDim))
+            {
+                copyF4(&smemResidual[threadLoadOffset], &params.residualInPtr[blockLoadOffset + threadLoadOffset]);
+            }
         }
+        __pipeline_commit();
     }
-    __pipeline_commit();
 #pragma unroll
     for (uint32_t i = 0; i < LoadsPerThread; i++)
     {
@@ -958,18 +1070,24 @@ __global__ __launch_bounds__(1024) void rmsNormLamport(MnnvlAllReduceKernelParam
         if (blockOffset * blockChunkSize + threadLoadOffset < static_cast<uint32_t>(params.tokenDim))
         {
             PackedVec<float4, T> inp{.packed = loadPacked<float4>(&smemInput[threadLoadOffset])};
-            PackedVec<float4, T> res{.packed = loadPacked<float4>(&smemResidual[threadLoadOffset])};
+            PackedVec<float4, T> inpPlusRes = inp;
+            if constexpr (ar_fusion::HasResidual<Pattern>)
+            {
+                PackedVec<float4, T> res{.packed = loadPacked<float4>(&smemResidual[threadLoadOffset])};
+                inpPlusRes = inp + res;
+                if constexpr (ar_fusion::HasResidualOut<Pattern>)
+                {
+                    *reinterpret_cast<float4*>(&params.residualOutPtr[blockLoadOffset + threadLoadOffset])
+                        = inpPlusRes.packed;
+                }
+            }
 
-            PackedVec<float4, T> inp_plus_res = inp + res;
 #pragma unroll
             for (int j = 0; j < kELTS_PER_LOAD; j++)
             {
-                rInput[i * kELTS_PER_LOAD + j] = cuda_cast<float, T>(inp_plus_res.elements[j]);
-                threadSum += cuda_cast<float, T>(inp_plus_res.elements[j] * inp_plus_res.elements[j]);
+                rInput[i * kELTS_PER_LOAD + j] = cuda_cast<float, T>(inpPlusRes.elements[j]);
+                threadSum += cuda_cast<float, T>(inpPlusRes.elements[j] * inpPlusRes.elements[j]);
             }
-
-            *reinterpret_cast<float4*>(&params.residualOutPtr[blockLoadOffset + threadLoadOffset])
-                = inp_plus_res.packed;
         }
     }
 
@@ -1023,7 +1141,10 @@ __global__ __launch_bounds__(1024) void rmsNormLamport(MnnvlAllReduceKernelParam
                     cuda_cast<float, T>(gamma.elements[j]) * rInput[i * kELTS_PER_LOAD + j] * rcpRms);
             }
 
-            *reinterpret_cast<float4*>(&params.outputPtr[blockLoadOffset + threadLoadOffset]) = r_out.packed;
+            int const accessIdInToken = (blockOffset * blockChunkSize + threadLoadOffset) / kELTS_PER_LOAD;
+            int const packedAccessIdx = (blockLoadOffset + threadLoadOffset) / kELTS_PER_LOAD;
+            writeEpilogueOutput<Pattern, T, float4, kELTS_PER_LOAD>(
+                r_out, params, blockLoadOffset + threadLoadOffset, packedAccessIdx, accessIdInToken, token);
         }
     }
     constexpr int kELTS_SIZE = sizeof(T);
@@ -1081,8 +1202,9 @@ void twoshotAllreduceFusionOp(AllReduceFusionParams const& params)
         T const* input = reinterpret_cast<T const*>(params.input);
         MnnvlAllReduceKernelParams<T> kernelParams{output, reinterpret_cast<T*>(params.residualOut), input,
             reinterpret_cast<T const*>(params.residualIn), reinterpret_cast<T const*>(params.gamma), ucPtrs,
-            reinterpret_cast<T*>(params.bufferPtrLocal), mcastPtr, numTokens, tokenDim, params.nRanks, params.rank,
-            static_cast<float>(params.epsilon), params.bufferFlags, !params.rmsNormFusion};
+            reinterpret_cast<T*>(params.bufferPtrLocal), mcastPtr, params.quantOut, params.scaleOut, params.scaleFactor,
+            numTokens, tokenDim, params.nRanks, params.rank, static_cast<float>(params.epsilon), params.bufferFlags,
+            !params.rmsNormFusion, params.layout};
         switch (params.nRanks)
         {
         case 2: LAUNCH_ALLREDUCE_KERNEL(2, T); return true;
@@ -1150,11 +1272,60 @@ void twoshotAllreduceFusionOp(AllReduceFusionParams const& params)
             "threads_needed: %d",
             numTokens, rnClusterSize, rnBlockSize, rnClusterSize, rnLoadsPerThread, divUp(tokenDim, numEltsPerThread));
 
-#define RUN_RMSNORM_KERNEL(T, USE_CGA, LOADS_PER_THREAD)                                                               \
-    TLLM_CUDA_CHECK(cudaFuncSetAttribute(                                                                              \
-        &rmsNormLamport<T, USE_CGA, LOADS_PER_THREAD>, cudaFuncAttributeMaxDynamicSharedMemorySize, smemSize));        \
+#define RUN_RMSNORM_KERNEL(T, PATTERN, USE_CGA, LOADS_PER_THREAD)                                                      \
+    TLLM_CUDA_CHECK(cudaFuncSetAttribute(&rmsNormLamport<T, PATTERN, USE_CGA, LOADS_PER_THREAD>,                       \
+        cudaFuncAttributeMaxDynamicSharedMemorySize, smemSize));                                                       \
     rnConfig.dynamicSmemBytes = smemSize;                                                                              \
-    TLLM_CUDA_CHECK(cudaLaunchKernelEx(&rnConfig, &rmsNormLamport<T, USE_CGA, LOADS_PER_THREAD>, kernelParams));
+    TLLM_CUDA_CHECK(                                                                                                   \
+        cudaLaunchKernelEx(&rnConfig, &rmsNormLamport<T, PATTERN, USE_CGA, LOADS_PER_THREAD>, kernelParams));
+
+#define DISPATCH_RMSNORM_PATTERN(T, USE_CGA, LOADS_PER_THREAD)                                                         \
+    if (params.pattern == ar_fusion::AllReduceFusionPattern::kARResidualRMSNorm)                                       \
+    {                                                                                                                  \
+        RUN_RMSNORM_KERNEL(T, ar_fusion::AllReduceFusionPattern::kARResidualRMSNorm, USE_CGA, LOADS_PER_THREAD);       \
+    }                                                                                                                  \
+    else if (params.pattern == ar_fusion::AllReduceFusionPattern::kARResidualRMSNormFP8Quant)                          \
+    {                                                                                                                  \
+        RUN_RMSNORM_KERNEL(                                                                                            \
+            T, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormFP8Quant, USE_CGA, LOADS_PER_THREAD);              \
+    }                                                                                                                  \
+    else if (params.pattern == ar_fusion::AllReduceFusionPattern::kARResidualRMSNormOutFP8Quant)                       \
+    {                                                                                                                  \
+        RUN_RMSNORM_KERNEL(                                                                                            \
+            T, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormOutFP8Quant, USE_CGA, LOADS_PER_THREAD);           \
+    }                                                                                                                  \
+    else if (params.pattern == ar_fusion::AllReduceFusionPattern::kARResidualRMSNormFP4Quant)                          \
+    {                                                                                                                  \
+        if constexpr (!std::is_same_v<T, float>)                                                                       \
+        {                                                                                                              \
+            RUN_RMSNORM_KERNEL(                                                                                        \
+                T, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormFP4Quant, USE_CGA, LOADS_PER_THREAD);          \
+        }                                                                                                              \
+        else                                                                                                           \
+        {                                                                                                              \
+            TLLM_CHECK_WITH_INFO(false, "[MNNVL AllReduceTwoShot] NVFP4 quantization does not support FP32 input.");   \
+        }                                                                                                              \
+    }                                                                                                                  \
+    else if (params.pattern == ar_fusion::AllReduceFusionPattern::kARResidualRMSNormOutFP4Quant)                       \
+    {                                                                                                                  \
+        if constexpr (!std::is_same_v<T, float>)                                                                       \
+        {                                                                                                              \
+            RUN_RMSNORM_KERNEL(                                                                                        \
+                T, ar_fusion::AllReduceFusionPattern::kARResidualRMSNormOutFP4Quant, USE_CGA, LOADS_PER_THREAD);       \
+        }                                                                                                              \
+        else                                                                                                           \
+        {                                                                                                              \
+            TLLM_CHECK_WITH_INFO(false, "[MNNVL AllReduceTwoShot] NVFP4 quantization does not support FP32 input.");   \
+        }                                                                                                              \
+    }                                                                                                                  \
+    else if (params.pattern == ar_fusion::AllReduceFusionPattern::kARRMSNorm)                                          \
+    {                                                                                                                  \
+        RUN_RMSNORM_KERNEL(T, ar_fusion::AllReduceFusionPattern::kARRMSNorm, USE_CGA, LOADS_PER_THREAD);               \
+    }                                                                                                                  \
+    else                                                                                                               \
+    {                                                                                                                  \
+        TLLM_CHECK_WITH_INFO(false, "[MNNVL AllReduceTwoShot] Unsupported RMSNorm fusion pattern.");                   \
+    }
 
         // C++ 17 does not support capturing structured bindings
         auto dispatchRN = [&, rnLoadsPerThread](auto* type_ptr)
@@ -1164,24 +1335,25 @@ void twoshotAllreduceFusionOp(AllReduceFusionParams const& params)
                 reinterpret_cast<T*>(params.residualOut), reinterpret_cast<T const*>(params.input),
                 reinterpret_cast<T const*>(params.residualIn), reinterpret_cast<T const*>(params.gamma),
                 reinterpret_cast<T**>(params.bufferPtrsDev), reinterpret_cast<T*>(params.bufferPtrLocal),
-                reinterpret_cast<T*>(params.multicastPtr), numTokens, tokenDim, params.nRanks, params.rank,
-                static_cast<float>(params.epsilon), params.bufferFlags, false};
+                reinterpret_cast<T*>(params.multicastPtr), params.quantOut, params.scaleOut, params.scaleFactor,
+                numTokens, tokenDim, params.nRanks, params.rank, static_cast<float>(params.epsilon), params.bufferFlags,
+                false, params.layout};
             if (rnUseCGA)
             {
-                RUN_RMSNORM_KERNEL(T, true, 1);
+                DISPATCH_RMSNORM_PATTERN(T, true, 1);
             }
             else
             {
                 switch (rnLoadsPerThread)
                 {
-                case 1: RUN_RMSNORM_KERNEL(T, false, 1); break;
-                case 2: RUN_RMSNORM_KERNEL(T, false, 2); break;
-                case 3: RUN_RMSNORM_KERNEL(T, false, 3); break;
-                case 4: RUN_RMSNORM_KERNEL(T, false, 4); break;
-                case 5: RUN_RMSNORM_KERNEL(T, false, 5); break;
-                case 6: RUN_RMSNORM_KERNEL(T, false, 6); break;
-                case 7: RUN_RMSNORM_KERNEL(T, false, 7); break;
-                case 8: RUN_RMSNORM_KERNEL(T, false, 8); break;
+                case 1: DISPATCH_RMSNORM_PATTERN(T, false, 1); break;
+                case 2: DISPATCH_RMSNORM_PATTERN(T, false, 2); break;
+                case 3: DISPATCH_RMSNORM_PATTERN(T, false, 3); break;
+                case 4: DISPATCH_RMSNORM_PATTERN(T, false, 4); break;
+                case 5: DISPATCH_RMSNORM_PATTERN(T, false, 5); break;
+                case 6: DISPATCH_RMSNORM_PATTERN(T, false, 6); break;
+                case 7: DISPATCH_RMSNORM_PATTERN(T, false, 7); break;
+                case 8: DISPATCH_RMSNORM_PATTERN(T, false, 8); break;
                 default: return false;
                 }
             }
@@ -1196,6 +1368,7 @@ void twoshotAllreduceFusionOp(AllReduceFusionParams const& params)
             TLLM_CHECK_WITH_INFO(false, "[MNNVL AllReduceTwoShot] Failed to dispatch rmsnorm lamport kernel.");
         }
 #undef RUN_RMSNORM_KERNEL
+#undef DISPATCH_RMSNORM_PATTERN
     }
 }
 

--- a/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlAllreduceKernels.cu
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlAllreduceKernels.cu
@@ -206,39 +206,61 @@ inline __device__ __host__ T divUp(T m, T n)
     return (m + n - 1) / n;
 }
 
-// A helper function to tune the grid configuration for fused oneshot and rmsnorm kernels.
+// A helper function to tune the grid configuration for fused oneshot and RMSNorm kernels.
 // Return (block_size, cluster_size, loads_per_thread).
 template <bool UseCluster>
 std::tuple<int, int, int> adjustGridConfig(int numTokens, int dim, int eltsPerThread)
 {
+    // Step 1: Start from the widest cluster we are willing to launch. The caller can request a no-CGA
+    // fallback for multi-load RMSNorm rows, in which case the cluster width stays at one CTA.
     int clusterSize = UseCluster ? 8 : 1;
     int blockSize = 128;
-    // ========================== Adjust the grid configuration ==========================
     int threadsNeeded = divUp(dim, eltsPerThread);
     int loadsPerThread = 1;
 
     blockSize = divUp(threadsNeeded, clusterSize);
     if constexpr (UseCluster)
     {
+        // Step 2: Shrink the cluster until the hidden dimension partitions cleanly across CTAs.
+        // This keeps each CTA responsible for an integral chunk of packed elements.
         while (threadsNeeded % clusterSize != 0 && clusterSize > 1)
         {
             clusterSize /= 2;
         }
+        int const maxDivisibleClusterSize = clusterSize;
         blockSize = divUp(threadsNeeded, clusterSize);
+        // Step 3: If divisibility leaves each CTA too small, trade cluster width for at least
+        // a 128-thread CTA. This improves occupancy and avoids tiny CTAs when the row is narrow.
         while (blockSize < 128 && clusterSize >= 2)
         {
             blockSize *= 2;
             clusterSize /= 2;
         }
         int smCount = getMultiProcessorCount();
+        // Step 4: If the token grid already has enough CTAs to cover the GPU, reduce cluster
+        // width and make CTAs larger. This avoids over-partitioning one token across too many CTAs.
         while (numTokens * clusterSize > smCount && clusterSize > 1 && blockSize <= 512)
         {
             blockSize *= 2;
             clusterSize /= 2;
         }
+        // Step 5: If the token grid still underfills the GPU, restore cluster width up to the
+        // divisibility limit. We accept 64-thread CTAs here to expose more CTAs per token.
+        while (clusterSize < maxDivisibleClusterSize)
+        {
+            int const candidateClusterSize = clusterSize * 2;
+            int const candidateBlockSize = divUp(threadsNeeded, candidateClusterSize);
+            if (candidateBlockSize < 64 || numTokens * candidateClusterSize > smCount)
+            {
+                break;
+            }
+            clusterSize = candidateClusterSize;
+            blockSize = candidateBlockSize;
+        }
     }
 
-    // Trying to scale up use multiple loads or CGA
+    // Step 6: For very wide rows, first increase cluster width on SM90+ and then increase
+    // per-thread loads. The goal is to keep block_size within CUDA's 1024-thread limit.
     while (blockSize > 1024)
     {
         if constexpr (UseCluster)
@@ -273,14 +295,6 @@ std::tuple<int, int, int> adjustGridConfig(int numTokens, int dim, int eltsPerTh
         blockSize = divUp(threadsNeeded, clusterSize * loadsPerThread);
     }
 
-    if constexpr (UseCluster)
-    {
-        while (blockSize > 1024 && loadsPerThread < 8)
-        {
-            loadsPerThread += 1;
-            blockSize = divUp(threadsNeeded, clusterSize * loadsPerThread);
-        }
-    }
     return {blockSize, clusterSize, loadsPerThread};
 }
 

--- a/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlAllreduceKernels.h
+++ b/cpp/tensorrt_llm/kernels/communicationKernels/mnnvlAllreduceKernels.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #define TRTLLM_MNNVL_ALLREDUCE_KERNELS_H
 
 #include "tensorrt_llm/common/config.h"
+#include "tensorrt_llm/kernels/communicationKernels/allReduceFusionKernels.h"
 #include <NvInferRuntime.h>
 #include <cstdint>
 
@@ -48,6 +49,8 @@ struct AllReduceFusionParams
     void* multicastPtr;       //!< Multicast buffer pointer.
     uint32_t* bufferFlags;    //!< Synchronization flags for coordinating communication phases
     bool rmsNormFusion;       //!< Whether to fuse RMS normalization with the AllReduce operation
+    ar_fusion::AllReduceFusionPattern pattern
+        = ar_fusion::AllReduceFusionPattern::kAllReduce; //!< Fused epilogue pattern
 
     //! @}
 
@@ -59,9 +62,13 @@ struct AllReduceFusionParams
     void const* gamma;      //!< Gamma parameters for RMS normalization (used when rmsnormFusion=true)
     double epsilon;         //!< Epsilon value for RMS normalization numerical stability (used when rmsnormFusion=true)
 
-    void* residualOut;      //!< Output tensor for residual connection result (used when rmsnormFusion=true)
-    void* output;           //!< Final output tensor containing the AllReduce result
-    cudaStream_t stream;    //!< CUDA stream for asynchronous kernel execution
+    void* residualOut = nullptr;        //!< Output tensor for residual connection result (used when rmsnormFusion=true)
+    void* output = nullptr;             //!< Output tensor containing the AllReduce or RMSNorm result
+    void* quantOut = nullptr;           //!< Quantized RMSNorm output (used by quantized fusion patterns)
+    void* scaleOut = nullptr;           //!< NVFP4 scale-factor output (used by NVFP4 fusion patterns)
+    float const* scaleFactor = nullptr; //!< Quantization scale factor
+    QuantizationSFLayout layout = QuantizationSFLayout::SWIZZLED; //!< NVFP4 scale-factor layout
+    cudaStream_t stream;                                          //!< CUDA stream for asynchronous kernel execution
 
     //! @}
 };

--- a/cpp/tensorrt_llm/thop/allreduceOp.cpp
+++ b/cpp/tensorrt_llm/thop/allreduceOp.cpp
@@ -1927,9 +1927,9 @@ std::vector<torch::Tensor> mnnvlFusionAllReduce(torch::Tensor& input, torch::opt
     allreduce_params.rmsNormFusion = hasRmsNormFusion;
     allreduce_params.stream = at::cuda::getCurrentCUDAStream(input.get_device());
 
-    // Threshold to switch between one-shot and two-shot allreduce kernel
-    // Empirical value, MSG size * World size
-    constexpr size_t kOneShotSizeThreshold = 16 * 4 * 8192;
+    // Threshold to switch between one-shot and two-shot allreduce kernel.
+    // Empirical value from the MNNVL sweep, matching FlashInfer's byte threshold.
+    constexpr size_t kOneShotSizeThreshold = 64 * 1024 * 8 * 2;
 
     if (numTokens * hiddenDim * allreduce_params.nRanks * input.itemsize() <= kOneShotSizeThreshold)
     {

--- a/cpp/tensorrt_llm/thop/allreduceOp.cpp
+++ b/cpp/tensorrt_llm/thop/allreduceOp.cpp
@@ -1810,11 +1810,13 @@ std::vector<torch::Tensor> mnnvlFusionAllReduce(torch::Tensor& input, torch::opt
     TORCH_CHECK(
         mcast_mem != nullptr, "[mnnvlFusionAllReduce] comm_buffer must be obtained from a mcastBuffer instance.");
     TORCH_CHECK(input.is_contiguous(), "[mnnvlFusionAllReduce] input must be contiguous");
-    TORCH_CHECK(input.dim() == 2, "[mnnvlFusionAllReduce] input must be a 2D tensor");
+    TORCH_CHECK(input.dim() >= 2, "[mnnvlFusionAllReduce] input must have at least 2 dimensions");
 
+    // Treat input as a flat (numTokens, hiddenDim) buffer for the kernel while preserving the
+    // original N-D shape for the returned tensors (via empty_like / input.sizes() below).
     auto const eltsPerThread = sizeof(float4) / input.itemsize();
-    auto const hiddenDim = input.size(1);
-    auto const numTokens = input.size(0);
+    auto const hiddenDim = input.size(-1);
+    auto const numTokens = input.numel() / hiddenDim;
     TORCH_CHECK(hiddenDim % eltsPerThread == 0,
         "[mnnvlFusionAllReduce] Hidden dimension must be divisible by " + std::to_string(eltsPerThread) + ", got "
             + std::to_string(hiddenDim));

--- a/cpp/tensorrt_llm/thop/allreduceOp.cpp
+++ b/cpp/tensorrt_llm/thop/allreduceOp.cpp
@@ -1473,7 +1473,7 @@ private:
 #endif // ENABLE_MULTI_DEVICE
 
 void preallocateNCCLWindowBuffer(
-    torch::Tensor const& input, torch::List<int64_t> const& group, const int64_t buffersPerSize)
+    torch::Tensor const& input, torch::List<int64_t> const& group, int64_t const buffersPerSize)
 {
 #if ENABLE_MULTI_DEVICE
     if (buffersPerSize <= 0 || group.size() == 0 || input.numel() == 0 || input.size(0) == 0)
@@ -1496,15 +1496,15 @@ void preallocateNCCLWindowBuffer(
 
     using tensorrt_llm::common::nccl_util::NCCLWindowAllocator;
     auto& allocator = NCCLWindowAllocator::getInstance();
-    const ncclComm_t comm = *commPtr;
+    ncclComm_t const comm = *commPtr;
 
-    const int64_t numTokens = input.size(0);
-    const int64_t elementsPerToken = input.numel() / numTokens;
+    int64_t const numTokens = input.size(0);
+    int64_t const elementsPerToken = input.numel() / numTokens;
     if (elementsPerToken <= 0)
     {
         return;
     }
-    const size_t bufferSize = static_cast<size_t>(numTokens) * static_cast<size_t>(elementsPerToken)
+    size_t const bufferSize = static_cast<size_t>(numTokens) * static_cast<size_t>(elementsPerToken)
         * static_cast<size_t>(input.element_size());
     if (bufferSize == 0)
     {
@@ -1757,14 +1757,60 @@ std::vector<torch::Tensor> moe_finalize_allreduce(torch::Tensor const& input,
     return {norm_out};
 }
 
+namespace
+{
+
+using MnnvlFusionPattern = tensorrt_llm::kernels::ar_fusion::AllReduceFusionPattern;
+
+MnnvlFusionPattern getMnnvlFusionPattern(AllReduceFusionOp fusionOp)
+{
+    switch (fusionOp)
+    {
+    case AllReduceFusionOp::NONE: return MnnvlFusionPattern::kAllReduce;
+    case AllReduceFusionOp::RESIDUAL_RMS_NORM: return MnnvlFusionPattern::kARResidualRMSNorm;
+    case AllReduceFusionOp::RESIDUAL_RMS_NORM_QUANT_FP8: return MnnvlFusionPattern::kARResidualRMSNormFP8Quant;
+    case AllReduceFusionOp::RESIDUAL_RMS_NORM_QUANT_NVFP4: return MnnvlFusionPattern::kARResidualRMSNormFP4Quant;
+    case AllReduceFusionOp::RESIDUAL_RMS_NORM_OUT_QUANT_FP8: return MnnvlFusionPattern::kARResidualRMSNormOutFP8Quant;
+    case AllReduceFusionOp::RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4: return MnnvlFusionPattern::kARResidualRMSNormOutFP4Quant;
+    default:
+        TORCH_CHECK(
+            false, "[mnnvlFusionAllReduce] Unsupported fusion operation: " + tensorrt_llm::kernels::toString(fusionOp));
+    }
+    return MnnvlFusionPattern::kAllReduce;
+}
+
+bool isMnnvlQuantFusionOp(AllReduceFusionOp fusionOp)
+{
+    return fusionOp == AllReduceFusionOp::RESIDUAL_RMS_NORM_QUANT_FP8
+        || fusionOp == AllReduceFusionOp::RESIDUAL_RMS_NORM_OUT_QUANT_FP8
+        || fusionOp == AllReduceFusionOp::RESIDUAL_RMS_NORM_QUANT_NVFP4
+        || fusionOp == AllReduceFusionOp::RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4;
+}
+
+bool isMnnvlNvfp4FusionOp(AllReduceFusionOp fusionOp)
+{
+    return fusionOp == AllReduceFusionOp::RESIDUAL_RMS_NORM_QUANT_NVFP4
+        || fusionOp == AllReduceFusionOp::RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4;
+}
+
+bool hasMnnvlNormOutput(AllReduceFusionOp fusionOp)
+{
+    return fusionOp == AllReduceFusionOp::RESIDUAL_RMS_NORM
+        || fusionOp == AllReduceFusionOp::RESIDUAL_RMS_NORM_OUT_QUANT_FP8
+        || fusionOp == AllReduceFusionOp::RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4;
+}
+
+} // namespace
+
 std::vector<torch::Tensor> mnnvlFusionAllReduce(torch::Tensor& input, torch::optional<torch::Tensor> const& gamma,
     torch::optional<torch::Tensor> const& residual_in, torch::optional<double> epsilon, torch::Tensor& comm_buffer,
-    torch::Tensor& buffer_flags, bool rmsnorm_fusion)
+    torch::Tensor& buffer_flags, bool rmsnorm_fusion, torch::optional<torch::Tensor> const& scale, int64_t fusion_op_)
 {
     auto* mcast_mem = tensorrt_llm::common::findMcastDevMemBuffer(comm_buffer.data_ptr());
     TORCH_CHECK(
         mcast_mem != nullptr, "[mnnvlFusionAllReduce] comm_buffer must be obtained from a mcastBuffer instance.");
     TORCH_CHECK(input.is_contiguous(), "[mnnvlFusionAllReduce] input must be contiguous");
+    TORCH_CHECK(input.dim() == 2, "[mnnvlFusionAllReduce] input must be a 2D tensor");
 
     auto const eltsPerThread = sizeof(float4) / input.itemsize();
     auto const hiddenDim = input.size(1);
@@ -1773,9 +1819,73 @@ std::vector<torch::Tensor> mnnvlFusionAllReduce(torch::Tensor& input, torch::opt
         "[mnnvlFusionAllReduce] Hidden dimension must be divisible by " + std::to_string(eltsPerThread) + ", got "
             + std::to_string(hiddenDim));
 
+    auto fusionOp = static_cast<AllReduceFusionOp>(int8_t(fusion_op_));
+    if (fusionOp == AllReduceFusionOp::NONE && rmsnorm_fusion)
+    {
+        fusionOp = AllReduceFusionOp::RESIDUAL_RMS_NORM;
+    }
+    auto const pattern = getMnnvlFusionPattern(fusionOp);
+    bool const hasRmsNormFusion = fusionOp != AllReduceFusionOp::NONE;
+
     auto const dtype = tensorrt_llm::runtime::TorchUtils::dataType(input.scalar_type());
-    torch::Tensor output = torch::empty_like(input);
+    torch::Tensor reduceOut;
+    torch::Tensor normOut;
     torch::Tensor residualOut;
+    torch::Tensor quantOut;
+    torch::Tensor scaleOut;
+
+    if (hasRmsNormFusion)
+    {
+        TORCH_CHECK(residual_in.has_value() && gamma.has_value() && epsilon.has_value(),
+            "[mnnvlFusionAllReduce] residual_in, gamma, and epsilon must be provided for RMSNorm fusion");
+        TORCH_CHECK(residual_in.value().is_contiguous(), "[mnnvlFusionAllReduce] residual_in must be contiguous");
+        TORCH_CHECK(gamma.value().is_contiguous(), "[mnnvlFusionAllReduce] gamma must be contiguous");
+
+        residualOut = torch::empty_like(residual_in.value());
+        if (hasMnnvlNormOutput(fusionOp))
+        {
+            normOut = torch::empty_like(input);
+        }
+    }
+    else
+    {
+        reduceOut = torch::empty_like(input);
+    }
+
+    if (isMnnvlQuantFusionOp(fusionOp))
+    {
+        TORCH_CHECK(scale.has_value(), "[mnnvlFusionAllReduce] scale is required for quantized fusion");
+        TORCH_CHECK(scale.value().scalar_type() == torch::kFloat32,
+            "[mnnvlFusionAllReduce] scale must have dtype float32 for quantized fusion");
+        TORCH_CHECK(scale.value().is_contiguous(), "[mnnvlFusionAllReduce] scale must be contiguous");
+
+        if (fusionOp == AllReduceFusionOp::RESIDUAL_RMS_NORM_QUANT_FP8
+            || fusionOp == AllReduceFusionOp::RESIDUAL_RMS_NORM_OUT_QUANT_FP8)
+        {
+            quantOut = at::detail::empty_cuda(input.sizes(), torch::kFloat8_e4m3fn, input.device(), std::nullopt);
+        }
+        else if (isMnnvlNvfp4FusionOp(fusionOp))
+        {
+            int64_t constexpr kSfVecSize = 16;
+            TORCH_CHECK(input.scalar_type() == torch::kFloat16 || input.scalar_type() == torch::kBFloat16,
+                "[mnnvlFusionAllReduce] NVFP4 quantization requires FP16 or BF16 input");
+            TORCH_CHECK(hiddenDim % kSfVecSize == 0,
+                "[mnnvlFusionAllReduce] hidden dimension must be divisible by 16 for NVFP4 quantization");
+
+            std::vector<int64_t> quantShape(input.sizes().begin(), input.sizes().end());
+            quantShape.back() /= 2;
+            quantOut = at::detail::empty_cuda(quantShape, FLOAT4_E2M1X2, input.device(), std::nullopt);
+            scaleOut
+                = at::detail::empty_cuda({tensorrt_llm::computeSwizzledLayoutSFSize(numTokens, hiddenDim / kSfVecSize)},
+                    SF_DTYPE, input.device(), std::nullopt);
+        }
+        else
+        {
+            TORCH_CHECK(false,
+                "[mnnvlFusionAllReduce] Unsupported quantized fusion operation: "
+                    + tensorrt_llm::kernels::toString(fusionOp));
+        }
+    }
 
     auto allreduce_params = tensorrt_llm::kernels::mnnvl::AllReduceFusionParams();
     allreduce_params.nRanks = mcast_mem->getWorldSize();
@@ -1788,29 +1898,34 @@ std::vector<torch::Tensor> mnnvlFusionAllReduce(torch::Tensor& input, torch::opt
     allreduce_params.multicastPtr = mcast_mem->getMulticastPtr();
     allreduce_params.bufferFlags = reinterpret_cast<uint32_t*>(buffer_flags.mutable_data_ptr());
     allreduce_params.input = input.const_data_ptr();
-    allreduce_params.output = output.mutable_data_ptr();
+    allreduce_params.pattern = pattern;
+    allreduce_params.layout = tensorrt_llm::QuantizationSFLayout::SWIZZLED;
 
-    if (rmsnorm_fusion)
+    if (fusionOp == AllReduceFusionOp::NONE)
     {
-        TORCH_CHECK(residual_in.has_value() && gamma.has_value() && epsilon.has_value(),
-            "[mnnvlFusionAllReduce] residual_in, gamma, and epsilon must be provided for rmsnorm fusion");
-        TORCH_CHECK(residual_in.value().is_contiguous(), "[mnnvlFusionAllReduce] residual_in must be contiguous");
-        TORCH_CHECK(gamma.value().is_contiguous(), "[mnnvlFusionAllReduce] gamma must be contiguous");
+        allreduce_params.output = reduceOut.mutable_data_ptr();
+    }
+    else
+    {
+        allreduce_params.output = normOut.defined() ? normOut.mutable_data_ptr() : nullptr;
 
         allreduce_params.residualIn = residual_in.value().const_data_ptr();
         allreduce_params.gamma = gamma.value().const_data_ptr();
         allreduce_params.epsilon = static_cast<float>(epsilon.value());
         allreduce_params.rmsNormFusion = true;
 
-        residualOut = torch::empty_like(residual_in.value());
         allreduce_params.residualOut = residualOut.mutable_data_ptr();
     }
-    else
+
+    if (isMnnvlQuantFusionOp(fusionOp))
     {
-        allreduce_params.rmsNormFusion = false;
+        allreduce_params.quantOut = quantOut.mutable_data_ptr();
+        allreduce_params.scaleOut = scaleOut.defined() ? scaleOut.mutable_data_ptr() : nullptr;
+        allreduce_params.scaleFactor = scale.value().data_ptr<float>();
     }
 
-    allreduce_params.stream = at::cuda::getCurrentCUDAStream(output.get_device());
+    allreduce_params.rmsNormFusion = hasRmsNormFusion;
+    allreduce_params.stream = at::cuda::getCurrentCUDAStream(input.get_device());
 
     // Threshold to switch between one-shot and two-shot allreduce kernel
     // Empirical value, MSG size * World size
@@ -1825,7 +1940,19 @@ std::vector<torch::Tensor> mnnvlFusionAllReduce(torch::Tensor& input, torch::opt
         tensorrt_llm::kernels::mnnvl::twoshotAllreduceFusionOp(allreduce_params);
     }
 
-    return {output, residualOut};
+    switch (fusionOp)
+    {
+    case AllReduceFusionOp::NONE: return {reduceOut};
+    case AllReduceFusionOp::RESIDUAL_RMS_NORM: return {normOut, residualOut};
+    case AllReduceFusionOp::RESIDUAL_RMS_NORM_QUANT_FP8: return {quantOut, residualOut};
+    case AllReduceFusionOp::RESIDUAL_RMS_NORM_OUT_QUANT_FP8: return {normOut, quantOut, residualOut};
+    case AllReduceFusionOp::RESIDUAL_RMS_NORM_QUANT_NVFP4: return {quantOut, scaleOut, residualOut};
+    case AllReduceFusionOp::RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4: return {normOut, quantOut, scaleOut, residualOut};
+    default:
+        TORCH_CHECK(
+            false, "[mnnvlFusionAllReduce] Unsupported fusion operation: " + tensorrt_llm::kernels::toString(fusionOp));
+    }
+    return {};
 }
 
 torch::Tensor minimax_allreduce_rms(torch::Tensor const& input, torch::Tensor const& norm_weight,
@@ -1925,8 +2052,9 @@ TRTLLM_NAMESPACE_END
 TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
     m.def(
-        "mnnvl_fusion_allreduce(Tensor input, Tensor? residual, Tensor? gamma, "
-        "float? epsilon, Tensor(a!) comm_buffer, Tensor buffer_flags, bool rmsnorm_fusion) -> "
+        "mnnvl_fusion_allreduce(Tensor input, Tensor? gamma, Tensor? residual, "
+        "float? epsilon, Tensor(a!) comm_buffer, Tensor buffer_flags, bool rmsnorm_fusion, "
+        "Tensor? scale=None, int fusion_op=0) -> "
         "Tensor[]");
     m.def(
         "allreduce("

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -80,14 +80,43 @@ def _register_fake():
 
     # MNNVL Allreduce
     @torch.library.register_fake("trtllm::mnnvl_fusion_allreduce")
-    def _(input, residual, gamma, epsilon, buffer, buffer_flags,
-          rmsnorm_fusion):
-        output = input.new_empty(input.shape)
-        if rmsnorm_fusion:
-            residual_out = residual.new_empty(residual.shape)
-        else:
-            residual_out = None
-        return [output, residual_out]
+    def _(input,
+          gamma,
+          residual,
+          epsilon,
+          buffer,
+          buffer_flags,
+          rmsnorm_fusion,
+          scale=None,
+          fusion_op: int = 0):
+        from tensorrt_llm.functional import AllReduceFusionOp
+        op = AllReduceFusionOp(fusion_op)
+        if op == AllReduceFusionOp.NONE and rmsnorm_fusion:
+            op = AllReduceFusionOp.RESIDUAL_RMS_NORM
+
+        if op == AllReduceFusionOp.NONE:
+            return [torch.empty_like(input)]
+        if op == AllReduceFusionOp.RESIDUAL_RMS_NORM:
+            return [torch.empty_like(input), torch.empty_like(residual)]
+        if op == AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_FP8:
+            quant_out = torch.empty_like(input, dtype=torch.float8_e4m3fn)
+            return [quant_out, torch.empty_like(residual)]
+        if op == AllReduceFusionOp.RESIDUAL_RMS_NORM_OUT_QUANT_FP8:
+            norm_out = torch.empty_like(input)
+            quant_out = torch.empty_like(input, dtype=torch.float8_e4m3fn)
+            return [norm_out, quant_out, torch.empty_like(residual)]
+        if op == AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_NVFP4:
+            fp4_shape, scale_shape = fp4_utils.get_fp4_shape(input.shape, 16)
+            quant_fp4 = input.new_empty(fp4_shape, dtype=torch.uint8)
+            scale_fp4 = input.new_empty(scale_shape, dtype=torch.uint8)
+            return [quant_fp4, scale_fp4, torch.empty_like(residual)]
+        if op == AllReduceFusionOp.RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4:
+            fp4_shape, scale_shape = fp4_utils.get_fp4_shape(input.shape, 16)
+            norm_out = torch.empty_like(input)
+            quant_fp4 = input.new_empty(fp4_shape, dtype=torch.uint8)
+            scale_fp4 = input.new_empty(scale_shape, dtype=torch.uint8)
+            return [norm_out, quant_fp4, scale_fp4, torch.empty_like(residual)]
+        return [torch.empty_like(input)]
 
     @torch.library.register_fake("trtllm::moe_allreduce")
     def _(residual, norm_weight, device_num_experts, scale_input,

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -524,8 +524,9 @@ class MNNVLAllReduce(nn.Module):
 
     This class handles the MNNVL-specific allreduce operations, which can be more efficient
     for certain operations when using NVLink for multi-node communication. The oneshot kernel
-    uses a cyclic remote-rank reduction order by default; set
-    ``FORCE_ALL_REDUCE_DETERMINISTIC=1`` to use stable rank-order reduction.
+    is deterministic across ranks. For TP sizes up to 8, it uses a rank-specialized
+    fast path that keeps the local value in registers and volatile-loads only peers
+    from the Lamport buffer. Larger world sizes use a compact deterministic fallback.
     """
     allreduce_mnnvl_workspaces: Dict[Mapping, Dict] = {}
 

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -523,7 +523,9 @@ class MNNVLAllReduce(nn.Module):
     """A specialized AllReduce implementation for Multi-Node NVLink communication.
 
     This class handles the MNNVL-specific allreduce operations, which can be more efficient
-    for certain operations when using NVLink for multi-node communication.
+    for certain operations when using NVLink for multi-node communication. The oneshot kernel
+    uses a cyclic remote-rank reduction order by default; set
+    ``FORCE_ALL_REDUCE_DETERMINISTIC=1`` to use stable rank-order reduction.
     """
     allreduce_mnnvl_workspaces: Dict[Mapping, Dict] = {}
 

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -621,7 +621,7 @@ class MNNVLAllReduce(nn.Module):
         buffer_flags = workspace["buffer_flags"]
 
         if fusion_op == AllReduceFusionOp.NONE:
-            output, _ = torch.ops.trtllm.mnnvl_fusion_allreduce(
+            output, = torch.ops.trtllm.mnnvl_fusion_allreduce(
                 input,
                 None,  # gamma
                 None,  # residual
@@ -631,18 +631,50 @@ class MNNVLAllReduce(nn.Module):
                 False,  # rmsnorm_fusion
             )
             return output.view(shape)
-        # Fallback to use other allreduce if hidden_size is not supported
-        elif fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM:
-            output, residual_out = torch.ops.trtllm.mnnvl_fusion_allreduce(
-                input,
-                all_reduce_params.norm_weight,  # gamma
-                all_reduce_params.residual,  # residual
-                all_reduce_params.eps,  # epsilon
-                buffer_base,  # comm_buffer
-                buffer_flags,  # buffer_flags
-                True,  # rmsnorm_fusion
-            )
+
+        supported_fusion_ops = (
+            AllReduceFusionOp.RESIDUAL_RMS_NORM,
+            AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_FP8,
+            AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_NVFP4,
+            AllReduceFusionOp.RESIDUAL_RMS_NORM_OUT_QUANT_FP8,
+            AllReduceFusionOp.RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4,
+        )
+        if fusion_op not in supported_fusion_ops:
+            return None
+
+        outputs = torch.ops.trtllm.mnnvl_fusion_allreduce(
+            input,
+            all_reduce_params.norm_weight,  # gamma
+            all_reduce_params.residual,  # residual
+            all_reduce_params.eps,  # epsilon
+            buffer_base,  # comm_buffer
+            buffer_flags,  # buffer_flags
+            True,  # rmsnorm_fusion
+            all_reduce_params.scale,  # scale
+            int(fusion_op),
+        )
+
+        if fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM:
+            output, residual_out = outputs
             return output.view(shape), residual_out.view(shape)
+        if fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_FP8:
+            quant_out, residual_out = outputs
+            return quant_out.view(shape), residual_out.view(shape)
+        if fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM_OUT_QUANT_FP8:
+            output, quant_out, residual_out = outputs
+            return output.view(shape), quant_out.view(shape), residual_out.view(
+                shape)
+
+        fp4_shape = (*shape[:-1], shape[-1] // 2)
+        if fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_NVFP4:
+            quant_out, scale_out, residual_out = outputs
+            return quant_out.view(fp4_shape), scale_out, residual_out.view(
+                shape)
+        if fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4:
+            output, quant_out, scale_out, residual_out = outputs
+            return (output.view(shape), quant_out.view(fp4_shape), scale_out,
+                    residual_out.view(shape))
+
         return None
 
 

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -29,6 +29,8 @@ from tensorrt_llm.plugin.plugin import CustomAllReduceHelper
 _NCCL_SYMMETRIC_ZERO_COPY: bool = (os.environ.get(
     "TLLM_NCCL_SYMMETRIC_ZERO_COPY", "1") == "1")
 
+_MNNVL_ONE_SHOT_THRESHOLD_BYTES = 64 * 1024 * 8 * 2
+
 _thread_local = threading.local()
 
 
@@ -566,8 +568,9 @@ class MNNVLAllReduce(nn.Module):
     def get_required_workspace_size(num_tokens: int, hidden_dim: int,
                                     group_size: int, dtype: torch.dtype) -> int:
         elem_size = torch.tensor([], dtype=dtype).element_size()
-        # This should match the heuristic in allreduceOp.cpp
-        is_one_shot = num_tokens * hidden_dim * group_size * elem_size <= 64 * 1024 * 8
+        # This should match the heuristic in allreduceOp.cpp.
+        is_one_shot = (num_tokens * hidden_dim * group_size * elem_size
+                       <= _MNNVL_ONE_SHOT_THRESHOLD_BYTES)
         if is_one_shot:
             # For one-shot, each rank needs to store num_tokens * group_size tokens
             workspace_size = num_tokens * hidden_dim * group_size * elem_size

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -532,6 +532,14 @@ class MNNVLAllReduce(nn.Module):
     """
     allreduce_mnnvl_workspaces: Dict[Mapping, Dict] = {}
 
+    SUPPORTED_FUSION_OPS: frozenset[AllReduceFusionOp] = frozenset({
+        AllReduceFusionOp.RESIDUAL_RMS_NORM,
+        AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_FP8,
+        AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_NVFP4,
+        AllReduceFusionOp.RESIDUAL_RMS_NORM_OUT_QUANT_FP8,
+        AllReduceFusionOp.RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4,
+    })
+
     def __init__(self, mapping: Mapping, dtype: torch.dtype):
         super().__init__()
         self.mapping = mapping
@@ -589,17 +597,18 @@ class MNNVLAllReduce(nn.Module):
         """Forward pass for MNNVL AllReduce.
 
         Args:
-            input (torch.Tensor): Input tensor to be reduced
-            all_reduce_params (Optional[AllReduceParams]): Parameters for fused operations
+            input (torch.Tensor): Input tensor to be reduced; last dim is the hidden dimension.
+            all_reduce_params (Optional[AllReduceParams]): Parameters for fused operations.
 
         Returns:
-            Union[torch.Tensor, Tuple[torch.Tensor, ...]]: Reduced tensor(s)
+            Union[torch.Tensor, Tuple[torch.Tensor, ...]]: Reduced tensor(s). Output tensors
+            preserve the input's N-D shape (NVFP4 quant output has its last dim halved; the
+            NVFP4 scale-factor output is 1-D).
         """
 
         fusion_op = all_reduce_params.fusion_op
-        shape = input.shape
-        input = input.view(-1, shape[-1])
-        (num_tokens, hidden_dim) = input.shape
+        hidden_dim = input.shape[-1]
+        num_tokens = input.numel() // hidden_dim
 
         workspace_size_bytes = self.get_required_workspace_size(
             num_tokens, hidden_dim, self.mapping.tp_size, self.dtype)
@@ -623,26 +632,8 @@ class MNNVLAllReduce(nn.Module):
         # The buffer flags is tied to the buffer and used to save the state of the buffer
         buffer_flags = workspace["buffer_flags"]
 
-        if fusion_op == AllReduceFusionOp.NONE:
-            output, = torch.ops.trtllm.mnnvl_fusion_allreduce(
-                input,
-                None,  # gamma
-                None,  # residual
-                1e-6,  # epsilon
-                buffer_base,  # comm_buffer
-                buffer_flags,  # buffer_flags
-                False,  # rmsnorm_fusion
-            )
-            return output.view(shape)
-
-        supported_fusion_ops = (
-            AllReduceFusionOp.RESIDUAL_RMS_NORM,
-            AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_FP8,
-            AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_NVFP4,
-            AllReduceFusionOp.RESIDUAL_RMS_NORM_OUT_QUANT_FP8,
-            AllReduceFusionOp.RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4,
-        )
-        if fusion_op not in supported_fusion_ops:
+        is_fusion = fusion_op != AllReduceFusionOp.NONE
+        if is_fusion and fusion_op not in MNNVLAllReduce.SUPPORTED_FUSION_OPS:
             return None
 
         outputs = torch.ops.trtllm.mnnvl_fusion_allreduce(
@@ -652,33 +643,11 @@ class MNNVLAllReduce(nn.Module):
             all_reduce_params.eps,  # epsilon
             buffer_base,  # comm_buffer
             buffer_flags,  # buffer_flags
-            True,  # rmsnorm_fusion
+            is_fusion,  # rmsnorm_fusion
             all_reduce_params.scale,  # scale
             int(fusion_op),
         )
-
-        if fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM:
-            output, residual_out = outputs
-            return output.view(shape), residual_out.view(shape)
-        if fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_FP8:
-            quant_out, residual_out = outputs
-            return quant_out.view(shape), residual_out.view(shape)
-        if fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM_OUT_QUANT_FP8:
-            output, quant_out, residual_out = outputs
-            return output.view(shape), quant_out.view(shape), residual_out.view(
-                shape)
-
-        fp4_shape = (*shape[:-1], shape[-1] // 2)
-        if fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_NVFP4:
-            quant_out, scale_out, residual_out = outputs
-            return quant_out.view(fp4_shape), scale_out, residual_out.view(
-                shape)
-        if fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4:
-            output, quant_out, scale_out, residual_out = outputs
-            return (output.view(shape), quant_out.view(fp4_shape), scale_out,
-                    residual_out.view(shape))
-
-        return None
+        return tuple(outputs) if is_fusion else outputs[0]
 
 
 class AllReduce(nn.Module):

--- a/tests/unittest/_torch/multi_gpu/test_mnnvl_allreduce.py
+++ b/tests/unittest/_torch/multi_gpu/test_mnnvl_allreduce.py
@@ -21,6 +21,7 @@ import cloudpickle
 import pytest
 import torch
 from mpi4py import MPI
+from utils.util import skip_pre_blackwell
 
 import tensorrt_llm
 import tensorrt_llm.bindings.internal.userbuffers as ub
@@ -53,6 +54,21 @@ NCCL_SYMMETRIC_SEQ_LEN_CASES = tuple(seq_len for seq_len in SEQ_LEN_CASES
 HIDDEN_SIZES = (8, 2880, 7168, 7176, 8192, 16384)
 DTYPES = (torch.bfloat16, )
 FUSION_CASES = (True, False)
+QUANT_DTYPES = (torch.float16, torch.bfloat16)
+QUANT_SEQ_LEN_CASES = (16, 2048)
+QUANT_HIDDEN_SIZE = 128
+QUANT_FUSION_OPS = (
+    pytest.param(AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_FP8,
+                 id="residual_rms_norm_quant_fp8"),
+    pytest.param(AllReduceFusionOp.RESIDUAL_RMS_NORM_OUT_QUANT_FP8,
+                 id="residual_rms_norm_out_quant_fp8"),
+    pytest.param(AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_NVFP4,
+                 id="residual_rms_norm_quant_nvfp4",
+                 marks=skip_pre_blackwell),
+    pytest.param(AllReduceFusionOp.RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4,
+                 id="residual_rms_norm_out_quant_nvfp4",
+                 marks=skip_pre_blackwell),
+)
 
 
 def _seq_len_id(seq_len: tuple[int, ...]):
@@ -74,6 +90,44 @@ def rms_norm(x: torch.Tensor, weight: torch.Tensor = None, eps: float = 1e-6):
     if weight is not None:
         y = y * weight
     return y
+
+
+def fp8_quant(input: torch.Tensor, scale: torch.Tensor):
+    finfo = torch.finfo(torch.float8_e4m3fn)
+    inv_scale = scale.reciprocal()
+    qinput = (input.float() * inv_scale).clamp(min=finfo.min, max=finfo.max)
+    return qinput.to(torch.float8_e4m3fn)
+
+
+def dequant(input: torch.Tensor, scale: torch.Tensor, dtype: torch.dtype):
+    return (input.to(torch.float32) * scale).to(dtype)
+
+
+def dequant_nvfp4(quant: torch.Tensor, scale_out: torch.Tensor,
+                  global_scale: torch.Tensor):
+    import torch
+    return torch.ops.tensorrt_llm.e2m1_and_ufp8sf_scale_to_float_v2(
+        quant.cpu(), scale_out.cpu(), 1 / global_scale.cpu(), 16, 1, True)
+
+
+def check_quant_accuracy(a: torch.Tensor, b: torch.Tensor, atol: float,
+                         rtol: float, percent: float):
+    assert a.shape == b.shape
+    assert a.dtype == b.dtype
+    a = a.to(torch.float32)
+    b = b.to(torch.float32)
+    left = torch.abs(a - b)
+    right = atol + rtol * torch.abs(b)
+    count = torch.sum(left > right)
+    mismatch_percent = float(count / a.numel())
+    if not mismatch_percent < 1 - percent:
+        raise AssertionError(
+            f"Mismatch percentage is {mismatch_percent:f} for rtol {rtol:f}")
+
+
+def fp4_quantize(input: torch.Tensor, scale: torch.Tensor):
+    import torch
+    return torch.ops.trtllm.fp4_quantize(input, scale, 16, False)
 
 
 def run_single_rank(
@@ -111,6 +165,168 @@ def run_single_rank(
         traceback.print_exc()
         raise
     return True
+
+
+def run_quant_single_rank(
+    tensor_parallel_size,
+    single_rank_forward_func,
+    input,
+    residual,
+    norm_weight,
+    scale,
+    eps,
+    dtype,
+    fusion_op,
+    reference_norm,
+    reference_residual,
+):
+    rank = tensorrt_llm.mpi_rank()
+    torch.cuda.set_device(rank)
+    try:
+        single_rank_forward_func(input, residual, norm_weight, scale, eps,
+                                 dtype, tensor_parallel_size, rank, fusion_op,
+                                 reference_norm, reference_residual)
+    except Exception:
+        traceback.print_exc()
+        raise
+    return True
+
+
+def run_reject_single_rank(tensor_parallel_size, single_rank_forward_func,
+                           input, residual, norm_weight, scale):
+    rank = tensorrt_llm.mpi_rank()
+    torch.cuda.set_device(rank)
+    try:
+        single_rank_forward_func(input, residual, norm_weight, scale,
+                                 tensor_parallel_size, rank)
+    except Exception:
+        traceback.print_exc()
+        raise
+    return True
+
+
+@torch.inference_mode()
+def mnnvl_quant_fusion_forward(
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    norm_weight: torch.Tensor,
+    scale: torch.Tensor,
+    eps: float,
+    dtype: torch.dtype,
+    tensor_parallel_size: int,
+    tensor_parallel_rank: int,
+    fusion_op: AllReduceFusionOp,
+    reference_norm: torch.Tensor,
+    reference_residual: torch.Tensor,
+):
+    input = input.cuda()
+    residual = residual.cuda()
+    norm_weight = norm_weight.cuda()
+    scale = scale.cuda()
+    reference_norm = reference_norm.cuda()
+    reference_residual = reference_residual.cuda()
+
+    os.environ["TLLM_TEST_MNNVL"] = "1"
+    MPI.COMM_WORLD.barrier()
+
+    allreduce = AllReduce(
+        mapping=Mapping(
+            world_size=tensor_parallel_size,
+            tp_size=tensor_parallel_size,
+            rank=tensor_parallel_rank,
+        ),
+        strategy=AllReduceStrategy.MNNVL,
+        dtype=dtype,
+    )
+
+    output = allreduce(
+        input,
+        all_reduce_params=AllReduceParams(
+            fusion_op=fusion_op,
+            residual=residual,
+            norm_weight=norm_weight,
+            scale=scale,
+            eps=eps,
+        ),
+    )
+
+    if fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_FP8:
+        quant_out, residual_out = output
+        calc_output = dequant(quant_out, scale, dtype)
+        ref_output = dequant(fp8_quant(reference_norm, scale), scale, dtype)
+    elif fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM_OUT_QUANT_FP8:
+        norm_out, quant_out, residual_out = output
+        torch.testing.assert_close(norm_out,
+                                   reference_norm,
+                                   rtol=0.05,
+                                   atol=0.15)
+        calc_output = dequant(quant_out, scale, dtype)
+        ref_output = dequant(fp8_quant(reference_norm, scale), scale, dtype)
+    elif fusion_op == AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_NVFP4:
+        quant_out, scale_out, residual_out = output
+        ref_quant, ref_scale_out = fp4_quantize(reference_norm.clone(), scale)
+        calc_output = dequant_nvfp4(quant_out, scale_out, scale).cuda()
+        ref_output = dequant_nvfp4(ref_quant, ref_scale_out, scale).cuda()
+    else:
+        norm_out, quant_out, scale_out, residual_out = output
+        torch.testing.assert_close(norm_out,
+                                   reference_norm,
+                                   rtol=0.05,
+                                   atol=0.15)
+        ref_quant, ref_scale_out = fp4_quantize(reference_norm.clone(), scale)
+        calc_output = dequant_nvfp4(quant_out, scale_out, scale).cuda()
+        ref_output = dequant_nvfp4(ref_quant, ref_scale_out, scale).cuda()
+
+    check_quant_accuracy(calc_output,
+                         ref_output,
+                         atol=0.05,
+                         rtol=0.15,
+                         percent=0.99)
+    torch.testing.assert_close(residual_out,
+                               reference_residual,
+                               rtol=0.05,
+                               atol=0.15)
+
+
+@torch.inference_mode()
+def mnnvl_nvfp4_reject_fp32_forward(
+    input: torch.Tensor,
+    residual: torch.Tensor,
+    norm_weight: torch.Tensor,
+    scale: torch.Tensor,
+    tensor_parallel_size: int,
+    tensor_parallel_rank: int,
+):
+    input = input.cuda()
+    residual = residual.cuda()
+    norm_weight = norm_weight.cuda()
+    scale = scale.cuda()
+
+    os.environ["TLLM_TEST_MNNVL"] = "1"
+    MPI.COMM_WORLD.barrier()
+
+    allreduce = AllReduce(
+        mapping=Mapping(
+            world_size=tensor_parallel_size,
+            tp_size=tensor_parallel_size,
+            rank=tensor_parallel_rank,
+        ),
+        strategy=AllReduceStrategy.MNNVL,
+        dtype=torch.float32,
+    )
+
+    with pytest.raises(RuntimeError,
+                       match="NVFP4 quantization requires FP16 or BF16"):
+        allreduce(
+            input,
+            all_reduce_params=AllReduceParams(
+                fusion_op=AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_NVFP4,
+                residual=residual,
+                norm_weight=norm_weight,
+                scale=scale,
+                eps=1e-5,
+            ),
+        )
 
 
 @torch.inference_mode()
@@ -276,6 +492,87 @@ def test_mnnvl_row_linear_residual_norm_fusion(seq_len, hidden_size, dtype,
     _run_row_linear_residual_norm_fusion(seq_len, hidden_size, dtype,
                                          AllReduceStrategy.MNNVL, fusion,
                                          mpi_pool_executor)
+
+
+def _make_quant_scale(reference_norm: torch.Tensor,
+                      fusion_op: AllReduceFusionOp) -> torch.Tensor:
+    amax = reference_norm.abs().max().float().clamp_min(1e-6)
+    if fusion_op in (AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_NVFP4,
+                     AllReduceFusionOp.RESIDUAL_RMS_NORM_OUT_QUANT_NVFP4):
+        return ((448 * 6) / amax).to(torch.float32)
+    return (amax / 448).to(torch.float32)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2,
+                    reason="needs 2 GPUs to run this test")
+@pytest.mark.parametrize("seq_len",
+                         QUANT_SEQ_LEN_CASES,
+                         ids=lambda x: f"seqlen:{x}")
+@pytest.mark.parametrize("dtype", QUANT_DTYPES, ids=_dtype_id)
+@pytest.mark.parametrize("fusion_op", QUANT_FUSION_OPS)
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
+def test_mnnvl_quant_fusion(seq_len, dtype, fusion_op, mpi_pool_executor):
+    torch.manual_seed(42)
+    tensor_parallel_size = mpi_pool_executor.num_workers
+    hidden_size = QUANT_HIDDEN_SIZE
+    eps = 1e-5
+
+    x = torch.randn((tensor_parallel_size, seq_len, hidden_size), dtype=dtype)
+    residual = torch.randn((seq_len, hidden_size), dtype=dtype)
+    norm_weight = torch.randn((hidden_size, ), dtype=dtype)
+    reference_residual = torch.sum(x, dim=0) + residual
+    reference_norm = rms_norm(reference_residual.to(torch.float32), norm_weight,
+                              eps).to(dtype)
+    scale = _make_quant_scale(reference_norm, fusion_op)
+
+    results = mpi_pool_executor.map(
+        run_quant_single_rank,
+        *zip(*[(
+            tensor_parallel_size,
+            mnnvl_quant_fusion_forward,
+            x[i, :, :],
+            residual,
+            norm_weight,
+            scale,
+            eps,
+            dtype,
+            fusion_op,
+            reference_norm,
+            reference_residual,
+        ) for i in range(tensor_parallel_size)]),
+    )
+    for r in results:
+        assert r is True
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2,
+                    reason="needs 2 GPUs to run this test")
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
+def test_mnnvl_nvfp4_rejects_fp32_before_launch(mpi_pool_executor):
+    torch.manual_seed(42)
+    tensor_parallel_size = mpi_pool_executor.num_workers
+    seq_len = 16
+    hidden_size = QUANT_HIDDEN_SIZE
+    dtype = torch.float32
+
+    x = torch.randn((tensor_parallel_size, seq_len, hidden_size), dtype=dtype)
+    residual = torch.randn((seq_len, hidden_size), dtype=dtype)
+    norm_weight = torch.randn((hidden_size, ), dtype=dtype)
+    scale = torch.tensor(1.0, dtype=torch.float32)
+
+    results = mpi_pool_executor.map(
+        run_reject_single_rank,
+        *zip(*[(
+            tensor_parallel_size,
+            mnnvl_nvfp4_reject_fp32_forward,
+            x[i, :, :],
+            residual,
+            norm_weight,
+            scale,
+        ) for i in range(tensor_parallel_size)]),
+    )
+    for r in results:
+        assert r is True
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2,

--- a/tests/unittest/_torch/multi_gpu/test_mnnvl_allreduce.py
+++ b/tests/unittest/_torch/multi_gpu/test_mnnvl_allreduce.py
@@ -55,8 +55,16 @@ HIDDEN_SIZES = (8, 2880, 7168, 7176, 8192, 16384)
 DTYPES = (torch.bfloat16, )
 FUSION_CASES = (True, False)
 QUANT_DTYPES = (torch.float16, torch.bfloat16)
-QUANT_SEQ_LEN_CASES = (16, 2048)
-QUANT_HIDDEN_SIZE = 128
+QUANT_HIDDEN_SIZE = 2880
+# Quant fusion uses tp=2 and 2-byte inputs in this test. The first two shapes
+# cover one-shot and two-shot at the same real hidden size; the wide hidden-size
+# case also crosses the two-shot threshold while keeping the fused RMSNorm stage
+# on the CGA grid-policy path.
+QUANT_SHAPE_CASES = (
+    pytest.param(16, 2880, id="oneshot_m16_n2880"),
+    pytest.param(2048, 2880, id="twoshot_m2048_n2880"),
+    pytest.param(32, 16384, id="twoshot_cga_m32_n16384"),
+)
 QUANT_FUSION_OPS = (
     pytest.param(AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_FP8,
                  id="residual_rms_norm_quant_fp8"),
@@ -505,16 +513,14 @@ def _make_quant_scale(reference_norm: torch.Tensor,
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2,
                     reason="needs 2 GPUs to run this test")
-@pytest.mark.parametrize("seq_len",
-                         QUANT_SEQ_LEN_CASES,
-                         ids=lambda x: f"seqlen:{x}")
+@pytest.mark.parametrize("seq_len, hidden_size", QUANT_SHAPE_CASES)
 @pytest.mark.parametrize("dtype", QUANT_DTYPES, ids=_dtype_id)
 @pytest.mark.parametrize("fusion_op", QUANT_FUSION_OPS)
 @pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
-def test_mnnvl_quant_fusion(seq_len, dtype, fusion_op, mpi_pool_executor):
+def test_mnnvl_quant_fusion(seq_len, hidden_size, dtype, fusion_op,
+                            mpi_pool_executor):
     torch.manual_seed(42)
     tensor_parallel_size = mpi_pool_executor.num_workers
-    hidden_size = QUANT_HIDDEN_SIZE
     eps = 1e-5
 
     x = torch.randn((tensor_parallel_size, seq_len, hidden_size), dtype=dtype)

--- a/tests/unittest/_torch/multi_gpu/test_mnnvl_allreduce.py
+++ b/tests/unittest/_torch/multi_gpu/test_mnnvl_allreduce.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +21,6 @@ import cloudpickle
 import pytest
 import torch
 from mpi4py import MPI
-from mpi4py.futures import MPIPoolExecutor
 
 import tensorrt_llm
 import tensorrt_llm.bindings.internal.userbuffers as ub
@@ -36,6 +35,38 @@ MPI.pickle.__init__(
     cloudpickle.loads,
     pickle.HIGHEST_PROTOCOL,
 )
+
+# needed since we reuse the mpi executor pool, first test running will leak a thread
+pytestmark = pytest.mark.threadleak(enabled=False)
+
+SEQ_LEN_CASES = (
+    (1, ),
+    (4, ),
+    (15, ),
+    (32, ),
+    (128, ),
+    (31, 11, 27, 4),  # Switching one/two shot in MNNVL
+    (12, 2048),  # reallocate workspace in MNNVL
+)
+NCCL_SYMMETRIC_SEQ_LEN_CASES = tuple(seq_len for seq_len in SEQ_LEN_CASES
+                                     if 2048 not in seq_len)
+HIDDEN_SIZES = (8, 2880, 7168, 7176, 8192, 16384)
+DTYPES = (torch.bfloat16, )
+FUSION_CASES = (True, False)
+
+
+def _seq_len_id(seq_len: tuple[int, ...]):
+    return f"seqlen:{list(seq_len)}"
+
+
+def _dtype_id(dtype: torch.dtype):
+    return f"dtype:{torch.finfo(dtype).dtype}"
+
+
+def _max_nccl_symmetric_buffer_size(dtype: torch.dtype):
+    max_seq_len = max(max(seq_len) for seq_len in NCCL_SYMMETRIC_SEQ_LEN_CASES)
+    return max_seq_len * max(HIDDEN_SIZES) * torch.empty(
+        (), dtype=dtype).element_size()
 
 
 def rms_norm(x: torch.Tensor, weight: torch.Tensor = None, eps: float = 1e-6):
@@ -57,6 +88,7 @@ def run_single_rank(
     fused_add_norm,
     reference_output_list,
     strategy,
+    max_userbuffers_size,
 ):
     rank = tensorrt_llm.mpi_rank()
     torch.cuda.set_device(rank)
@@ -73,6 +105,7 @@ def run_single_rank(
             fused_add_norm,
             reference_output_list,
             strategy,
+            max_userbuffers_size,
         )
     except Exception:
         traceback.print_exc()
@@ -93,6 +126,7 @@ def row_linear_residual_norm_fusion_forward(
     fusion: bool,
     reference_output_list: list[tuple[torch.Tensor, ...]],
     strategy: AllReduceStrategy,
+    max_userbuffers_size: int | None,
 ):
 
     # Move all tensors to GPU
@@ -105,10 +139,12 @@ def row_linear_residual_norm_fusion_forward(
     ]
 
     if strategy == AllReduceStrategy.NCCL_SYMMETRIC:
-        ub.initialize_userbuffers_manager(
-            tensor_parallel_size, 1, 1, tensor_parallel_rank,
-            torch.cuda.device_count(),
-            x_list[0].nelement() * x_list[0].element_size())
+        os.environ.pop("TLLM_TEST_MNNVL", None)
+        assert max_userbuffers_size is not None
+        ub.initialize_userbuffers_manager(tensor_parallel_size, 1, 1,
+                                          tensor_parallel_rank,
+                                          torch.cuda.device_count(),
+                                          max_userbuffers_size)
     elif strategy == AllReduceStrategy.MNNVL:
         os.environ["TLLM_TEST_MNNVL"] = "1"
 
@@ -143,61 +179,40 @@ def row_linear_residual_norm_fusion_forward(
             output = allreduce(input)
             return (output, )
 
-    # Process each sequence length using the same AllReduce instance
-    for i, (x, residual, reference_output) in enumerate(
-            zip(x_list, residual_list, reference_output_list)):
-        output = func(x.clone(), residual.clone(), norm_weight, eps, fusion)
+    try:
+        # Process each sequence length using the same AllReduce instance
+        for i, (x, residual, reference_output) in enumerate(
+                zip(x_list, residual_list, reference_output_list)):
+            output = func(x.clone(), residual.clone(), norm_weight, eps, fusion)
 
-        torch.testing.assert_close(
-            output[0],
-            reference_output[0],
-            rtol=0.05,
-            atol=0.15,
-        )
-
-        if fusion:
             torch.testing.assert_close(
-                output[1],
-                reference_output[1],
+                output[0],
+                reference_output[0],
                 rtol=0.05,
                 atol=0.15,
             )
 
+            if fusion:
+                torch.testing.assert_close(
+                    output[1],
+                    reference_output[1],
+                    rtol=0.05,
+                    atol=0.15,
+                )
+    finally:
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
 
-@pytest.mark.skipif(torch.cuda.device_count() < 2,
-                    reason="needs 2 GPUs to run this test")
-@pytest.mark.parametrize(
-    "seq_len",
-    [
-        [1],
-        [4],
-        [15],
-        [32],
-        [128],
-        [31, 11, 27, 4],  # Switching one/two shot in MNNVL
-        [12, 2048],  # reallocate workspace in MNNVL
-    ],  # Test for max_num_token fallback
-    ids=lambda x: f"seqlen:{x}",
-)
-@pytest.mark.parametrize("hidden_size", [8, 2880, 7168, 7176, 8192, 16384],
-                         ids=lambda x: f"hidden:{x}")
-@pytest.mark.parametrize("dtype", [torch.bfloat16],
-                         ids=lambda x: f"dtype:{torch.finfo(x).dtype}")
-@pytest.mark.parametrize(
-    "strategy", [AllReduceStrategy.MNNVL, AllReduceStrategy.NCCL_SYMMETRIC],
-    ids=lambda x: f"strategy:{x}")
-@pytest.mark.parametrize(
-    "fusion",
-    [True, False],
-    ids=["fusion", "no_fusion"],
-)
-def test_row_linear_residual_norm_fusion(seq_len, hidden_size, dtype, strategy,
-                                         fusion):
-    if strategy == AllReduceStrategy.NCCL_SYMMETRIC and 2048 in seq_len:
-        pytest.skip("https://nvbugspro.nvidia.com/bug/5573856")
 
+def _run_row_linear_residual_norm_fusion(seq_len,
+                                         hidden_size,
+                                         dtype,
+                                         strategy,
+                                         fusion,
+                                         mpi_pool_executor,
+                                         max_userbuffers_size=None):
     torch.manual_seed(42)
-    tensor_parallel_size = 2
+    tensor_parallel_size = mpi_pool_executor.num_workers
 
     # Create norm_weight once (same for all sequence lengths)
     norm_weight = torch.randn((hidden_size, ), dtype=dtype)
@@ -223,26 +238,66 @@ def test_row_linear_residual_norm_fusion(seq_len, hidden_size, dtype, strategy,
         residual_list.append(residual)
         reference_output_list.append(reference_output)
 
-    with MPIPoolExecutor(max_workers=tensor_parallel_size) as executor:
-        results = executor.map(
-            run_single_rank,
-            *zip(*[
-                (
-                    tensor_parallel_size,
-                    row_linear_residual_norm_fusion_forward,
-                    [
-                        x[i, :, :] for x in x_list
-                    ],  # Extract the i-th rank's data from each sequence length
-                    residual_list,
-                    norm_weight,
-                    eps,
-                    hidden_size,
-                    dtype,
-                    fusion,
-                    reference_output_list,
-                    strategy,
-                ) for i in range(tensor_parallel_size)
-            ]),
-        )
-        for r in results:
-            assert r is True
+    results = mpi_pool_executor.map(
+        run_single_rank,
+        *zip(*[
+            (
+                tensor_parallel_size,
+                row_linear_residual_norm_fusion_forward,
+                [x[i, :, :] for x in x_list
+                 ],  # Extract the i-th rank's data from each sequence length
+                residual_list,
+                norm_weight,
+                eps,
+                hidden_size,
+                dtype,
+                fusion,
+                reference_output_list,
+                strategy,
+                max_userbuffers_size,
+            ) for i in range(tensor_parallel_size)
+        ]),
+    )
+    for r in results:
+        assert r is True
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2,
+                    reason="needs 2 GPUs to run this test")
+@pytest.mark.parametrize("seq_len", SEQ_LEN_CASES, ids=_seq_len_id)
+@pytest.mark.parametrize("hidden_size",
+                         HIDDEN_SIZES,
+                         ids=lambda x: f"hidden:{x}")
+@pytest.mark.parametrize("dtype", DTYPES, ids=_dtype_id)
+@pytest.mark.parametrize("fusion", FUSION_CASES, ids=["fusion", "no_fusion"])
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
+def test_mnnvl_row_linear_residual_norm_fusion(seq_len, hidden_size, dtype,
+                                               fusion, mpi_pool_executor):
+    _run_row_linear_residual_norm_fusion(seq_len, hidden_size, dtype,
+                                         AllReduceStrategy.MNNVL, fusion,
+                                         mpi_pool_executor)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2,
+                    reason="needs 2 GPUs to run this test")
+@pytest.mark.parametrize("seq_len",
+                         NCCL_SYMMETRIC_SEQ_LEN_CASES,
+                         ids=_seq_len_id)
+@pytest.mark.parametrize("hidden_size",
+                         HIDDEN_SIZES,
+                         ids=lambda x: f"hidden:{x}")
+@pytest.mark.parametrize("dtype", DTYPES, ids=_dtype_id)
+@pytest.mark.parametrize("fusion", FUSION_CASES, ids=["fusion", "no_fusion"])
+@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
+def test_nccl_symmetric_row_linear_residual_norm_fusion(seq_len, hidden_size,
+                                                        dtype, fusion,
+                                                        mpi_pool_executor):
+    _run_row_linear_residual_norm_fusion(
+        seq_len,
+        hidden_size,
+        dtype,
+        AllReduceStrategy.NCCL_SYMMETRIC,
+        fusion,
+        mpi_pool_executor,
+        max_userbuffers_size=_max_nccl_symmetric_buffer_size(dtype),
+    )


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced multi-node allreduce operations with cooperative group cluster support and deterministic reduction optimizations.

* **Improvements**
  * Optimized allreduce kernels with architecture-specific enhancements and updated synchronization mechanisms for better performance.

* **Tests**
  * Expanded test coverage with dedicated MNNVL and NCCL symmetric allreduce test suites and improved parametrization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



## Description

### tl;dr
Porting flashinfer-ai/flashinfer#3385 and flashinfer-ai/flashinfer#3304; Revise MNNVL Allreduce unittest to reuse mpi pool to speedup unittest (15mins+ -> 2mins)
### Details

- Use bitwise comparison in lamport polling to avoid subnormal number hang issue.
- Use named barrier and cluster barrier instead of a sync.
- Avoid loading local buffer again in oneshot, use template-based fash path for world size <= 8; __Gauranteed the reduction order is deterministic and identical across all ranks.__
- Adjust grid dispatch policy to use more SMs at the cost of single SM occupancy for small batch sizes.
- Add FP8/NVFP4 quant fusion support and corresponding accuracy validation in unit test; use 1% mismatch tolerance. for NVFP4 result
- Reuse mpi pool in unit test to speedup the test, now a full MNNVL AR unit test takes ~1.5mins

### Performance Change 
[report.html](https://github.com/user-attachments/files/28165570/report.html)


## Test Coverage

tests/unittest/_torch/multi_gpu/test_mnnvl_allreduce.py

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
