### PR TITLE
[#14588][fix] [AutoDeploy] Fix OOM of DeepSeek-R1 NVFP4 for tp=4

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -2297,7 +2297,15 @@ def _stack_nvfp4_cutlass_moe_weights(
             )
 
         node.replace_all_uses_with(new_node)
+        input_nodes = node.all_input_nodes
         graph.erase_node(node)
+        for input_node in input_nodes:
+            if input_node.op == "get_attr" and len(input_node.users) == 0:
+                graph.erase_node(input_node)
+        # Free per-layer to avoid accumulating ~ per_layer_weight_bytes across all MoE layers.
+        # Only pass weight lists; scales/alphas live as buffers under the same submodules and
+        # are removed together when delete_submodule(...) drops the owning module.
+        remove_original_experts(gm, [w1_list, w2_list, w3_list])
 
     # Clean up after processing all nodes
     # eliminate_dead_code will remove unused get_attr nodes, then delete_all_unused_submodules
@@ -2854,7 +2862,15 @@ def _stack_nvfp4_trtllm_gen_moe_weights(
             )
 
         node.replace_all_uses_with(new_node)
+        input_nodes = node.all_input_nodes
         graph.erase_node(node)
+        for input_node in input_nodes:
+            if input_node.op == "get_attr" and len(input_node.users) == 0:
+                graph.erase_node(input_node)
+        # Free per-layer to avoid accumulating ~ per_layer_weight_bytes across all MoE layers.
+        # Only pass weight lists; scales/alphas live as buffers under the same submodules and
+        # are removed together when delete_submodule(...) drops the owning module.
+        remove_original_experts(gm, [w1_list, w2_list, w3_list])
         fused_key_counter += 1
 
     eliminate_dead_code(gm)

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fused_moe.py
@@ -1593,17 +1593,19 @@ def remove_original_experts(gm: GraphModule, weight_lists: List[List[Node]]) -> 
     weight_lists_flat = [w for weights in weight_lists for w in weights]
 
     for w in weight_lists_flat:
-        w_param = get_attr_by_name(gm, w.target)
-        if w_param is not None:
-            owner_module, owner_module_path, param_name = get_submodule_of_param(gm, w.target)
-            owner_param = get_attr_by_name(owner_module, param_name)
-            if owner_param is w_param:
-                gm.delete_submodule(owner_module_path)
-            else:
-                # param w is not owned by owner_module, skip
-                continue
-        else:
+        # Experts may share an owning container (e.g. nn.ParameterList): deleting it for the
+        # first expert removes its siblings too, so later targets resolve to a missing attr.
+        try:
+            w_param = get_attr_by_name(gm, w.target)
+        except AttributeError:
             continue
+        if w_param is None:
+            continue
+        owner_module, owner_module_path, param_name = get_submodule_of_param(gm, w.target)
+        owner_param = get_attr_by_name(owner_module, param_name)
+        # delete_submodule requires a non-empty submodule path; root params can't be dropped this way.
+        if owner_param is w_param and owner_module_path:
+            gm.delete_submodule(owner_module_path)
 
 
 def _stack_fp8_moe_weights(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved GPU memory efficiency during Mixture of Experts model fusion by releasing per-layer expert weights earlier.
* **Bug Fixes**
  * Made expert-weight cleanup more robust to missing attributes and avoided unintended deletions of root-owned parameters, preventing accidental removal of shared buffers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
DeepSeek-R1 NVFP4 was crashing with OOM during AutoDeploy Engine build because of the unreleased original memory while stacking MoE experts. 
<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
