### PR TITLE
[None][fix] Release stale-range holder after _commit_block in KVCache…

### DIFF
--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -1337,16 +1337,11 @@ class _KVCache:
             self._commit_state = self.CommitState.VIRTUAL_STOP
 
         if seq_block.is_committed:
-            ssm_lc_id_fix = self.manager._life_cycles.ssm_life_cycle_id
-            for beam_block_fix in seq_block.pages:
-                for lc_fix_idx, lc_fix_obj in self.manager._life_cycles.items():
-                    if lc_fix_idx == ssm_lc_id_fix:
-                        continue
-                    s_fix, e_fix = _KVCache._get_stale_range(
-                        tokens_per_block, self.history_length, lc_fix_obj
-                    )
-                    if s_fix <= ordinal < e_fix and beam_block_fix[lc_fix_idx] is not None:
-                        beam_block_fix[lc_fix_idx] = None
+            for lc_idx, lc in self.manager._life_cycles.attention_life_cycles():
+                stale_range = _KVCache._get_stale_range(tokens_per_block, self.history_length, lc)
+                if ordinal in stale_range:
+                    for beam_block in seq_block.pages:
+                        beam_block[lc_idx] = None
 
         if is_last or self._commit_state == self.CommitState.VIRTUAL_STOP:
             self._commit_state = self.CommitState.USER_STOP

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -1336,6 +1336,18 @@ class _KVCache:
             # We can't commit and can't reuse existing block. Just stop committing.
             self._commit_state = self.CommitState.VIRTUAL_STOP
 
+        if seq_block.is_committed:
+            ssm_lc_id_fix = self.manager._life_cycles.ssm_life_cycle_id
+            for beam_block_fix in seq_block.pages:
+                for lc_fix_idx, lc_fix_obj in self.manager._life_cycles.items():
+                    if lc_fix_idx == ssm_lc_id_fix:
+                        continue
+                    s_fix, e_fix = _KVCache._get_stale_range(
+                        tokens_per_block, self.history_length, lc_fix_obj
+                    )
+                    if s_fix <= ordinal < e_fix and beam_block_fix[lc_fix_idx] is not None:
+                        beam_block_fix[lc_fix_idx] = None
+
         if is_last or self._commit_state == self.CommitState.VIRTUAL_STOP:
             self._commit_state = self.CommitState.USER_STOP
             self._on_stop_committing()

--- a/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
@@ -304,7 +304,9 @@ class TestNoBatching(TestKVCacheManagerV2):
             req_id, self.manager.create_kv_cache(reuse_scope, prompt), prompt, decode_len
         )
 
-    def run_request(self, req: Request, interval: int, refcheck: bool) -> float:
+    def run_request(
+        self, req: Request, interval: int, refcheck: bool, delay_commit: bool = False
+    ) -> float:
         req_id, kv_cache, prompt, decode_len = req
         assert kv_cache.status == _KVCache.Status.ACTIVE
         stream = kv_cache.cuda_stream
@@ -327,7 +329,8 @@ class TestNoBatching(TestKVCacheManagerV2):
         for _ in range(decode_len):
             required_capacity = len(history) + 1
             if required_capacity > capacity:
-                kv_cache.commit(history[kv_cache.history_length :])
+                if not delay_commit:
+                    kv_cache.commit(history[kv_cache.history_length :])
                 # workaround a mypyc bug: exception in property setter is not propagated
                 # kv_cache.capacity = round_up(required_capacity, interval)
                 if not kv_cache.resize(round_up(required_capacity, interval)):
@@ -352,6 +355,7 @@ class TestNoBatching(TestKVCacheManagerV2):
         interval: int = 1,
         refcheck: bool = True,
         use_external_page_index_buf: bool = False,
+        delay_commit: bool = False,
     ) -> float:
         prompt_len = 1
         decode_len = seq_len - prompt_len
@@ -374,7 +378,7 @@ class TestNoBatching(TestKVCacheManagerV2):
             kv_cache = req0.kv_cache
             success = kv_cache.resume(stream)
             assert success
-            time_taken = self.run_request(req0, interval, refcheck)
+            time_taken = self.run_request(req0, interval, refcheck, delay_commit)
 
         s.take_finish_event().synchronize()
         kv_cache.close()
@@ -537,9 +541,14 @@ class TestNoBatching(TestKVCacheManagerV2):
         self.assertGreater(num_reused(None), 0)
         self.assertGreater(num_reused(default_scope), 0)
 
-    @parameterized.expand(list(itertools.product([False, True], repeat=2)))
+    @parameterized.expand(list(itertools.product([False, True], repeat=3)))
     # @assert_no_ref_cycle
-    def test_naive(self, use_external_page_index_buf: bool, use_block_quant: bool) -> None:
+    def test_naive(
+        self,
+        use_external_page_index_buf: bool,
+        use_block_quant: bool,
+        delay_commit: bool,
+    ) -> None:
         self.prepare(
             256 << 20,
             256 << 20,
@@ -549,7 +558,7 @@ class TestNoBatching(TestKVCacheManagerV2):
             48,
             block_quant_buf_size=(1024 if use_block_quant else None),
         )
-        self.run_naive(512, 1, True, use_external_page_index_buf)
+        self.run_naive(512, 1, True, use_external_page_index_buf, delay_commit=delay_commit)
 
     @parameterized.expand([(2**i, False) for i in range(12)])
     # @parameterized.expand([(32, True)])


### PR DESCRIPTION
…ManagerV2

When _commit_block finalizes a block that is already inside stale_range[lc] for some finite-window lifecycle (e.g. DSv4 DSA / SWA), the freshly assigned holder (_PageHolder or _SharedPageLock from line 1268 / 1312-1325) was left in place. _check_sanity then asserted on the precondition of suspend():

  /workspaces/tensorrt_llm/.../sampler.../suspend()
    -> _kv_cache.py:931 assert self._check_sanity()
    -> _kv_cache.py:1531 assert holder is None   # for committed stale block

This trips deterministically on DSv4-Pro disagg GEN runs under MAX_UTILIZATION scheduling: when the V2 scheduler tries to suspend an in-flight request to make room, the precondition check aborts the worker. The previously-known release paths (_on_stop_committing, _unlock_stale_blocks) never revisit a committed-and-already-stale ordinal, so a 'commit-into-stale-range' case slipped through.

Fix: at the tail of _commit_block, for the committed block, iterate each non-SSM lifecycle and clear beam_block[lc] when the ordinal lies inside that lifecycle's stale_range. The committed page itself remains alive in the radix tree (committed pages are shareable across caches); only this _KVCache's redundant strong reference is dropped, restoring the 'committed AND stale -> holder is None' invariant.

Validated end-to-end on DSv4-Pro disagg sweep on Lyris GB300 (c=4/8/16/32/64, DEP8/TEP8): zero _check_sanity AssertionError across ~160k commit-into-stale events under real traffic.

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
