### PR TITLE
[TRTLLM-10947][perf] eagle3: use cudaMemcpy2DAsync custom op for hidden-state capture

### DIFF
--- a/cpp/tensorrt_llm/thop/CMakeLists.txt
+++ b/cpp/tensorrt_llm/thop/CMakeLists.txt
@@ -117,7 +117,8 @@ add_library(
   dsv3RopeOp.cpp
   fusedGemmAllreduceOp.cpp
   convertReqIndexToGlobalOp.cpp
-  trtllmGenQKVProcessOp.cpp)
+  trtllmGenQKVProcessOp.cpp
+  inplaceSliceCopyOp.cpp)
 set_property(TARGET th_common PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(
   th_common PRIVATE ${TORCH_LIBRARIES} th_utils ${Python3_LIBRARIES}

--- a/cpp/tensorrt_llm/thop/inplaceSliceCopyOp.cpp
+++ b/cpp/tensorrt_llm/thop/inplaceSliceCopyOp.cpp
@@ -33,6 +33,7 @@ void inplaceSliceCopy(at::Tensor& dest, at::Tensor const& src, int64_t dim1Start
 {
     CHECK_TH_CUDA(dest);
     CHECK_TH_CUDA(src);
+    TORCH_CHECK(dest.get_device() == src.get_device(), "dest and src must be on the same CUDA device");
     TORCH_CHECK(dest.is_contiguous(), "dest must be contiguous");
     TORCH_CHECK(src.is_contiguous(), "src must be contiguous");
     TORCH_CHECK(dest.dim() == 2, "dest must be 2-D");
@@ -41,6 +42,7 @@ void inplaceSliceCopy(at::Tensor& dest, at::Tensor const& src, int64_t dim1Start
 
     int64_t const numTokens = src.size(0);
     int64_t const sliceWidth = dim1End - dim1Start;
+    TORCH_CHECK(dim1Start >= 0, "dim1Start must be non-negative");
     TORCH_CHECK(sliceWidth > 0, "dim1End must be greater than dim1Start");
     TORCH_CHECK(numTokens <= dest.size(0), "numTokens exceeds dest row count");
     TORCH_CHECK(dim1End <= dest.size(1), "dim1End exceeds dest column count");

--- a/cpp/tensorrt_llm/thop/inplaceSliceCopyOp.cpp
+++ b/cpp/tensorrt_llm/thop/inplaceSliceCopyOp.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/thop/thUtils.h"
+
+#include <ATen/cuda/CUDAContext.h>
+#include <cuda_runtime_api.h>
+
+namespace tensorrt_llm::torch_ext
+{
+
+// Copy src[:, :] into dest[:numTokens, dim1Start:dim1End] using cudaMemcpy2D.
+// dest      : 2-D contiguous CUDA tensor, shape [destRows, destCols]
+// src       : 2-D contiguous CUDA tensor, shape [numTokens, sliceWidth] where sliceWidth == dim1End - dim1Start
+// dim1Start : first column index in dest to write into
+// dim1End   : one-past-last column index in dest to write into
+// numTokens is inferred from src.size(0)
+void inplaceSliceCopy(at::Tensor& dest, at::Tensor const& src, int64_t dim1Start, int64_t dim1End)
+{
+    CHECK_TH_CUDA(dest);
+    CHECK_TH_CUDA(src);
+    TORCH_CHECK(dest.is_contiguous(), "dest must be contiguous");
+    TORCH_CHECK(src.is_contiguous(), "src must be contiguous");
+    TORCH_CHECK(dest.dim() == 2, "dest must be 2-D");
+    TORCH_CHECK(src.dim() == 2, "src must be 2-D");
+    TORCH_CHECK(dest.scalar_type() == src.scalar_type(), "dest and src must have the same dtype");
+
+    int64_t const numTokens = src.size(0);
+    int64_t const sliceWidth = dim1End - dim1Start;
+    TORCH_CHECK(sliceWidth > 0, "dim1End must be greater than dim1Start");
+    TORCH_CHECK(numTokens <= dest.size(0), "numTokens exceeds dest row count");
+    TORCH_CHECK(dim1End <= dest.size(1), "dim1End exceeds dest column count");
+    TORCH_CHECK(src.size(1) == sliceWidth, "src column count must equal dim1End - dim1Start");
+
+    if (numTokens == 0 || sliceWidth == 0)
+    {
+        return;
+    }
+
+    int64_t const elemSize = dest.element_size();
+    int64_t const destPitch = dest.size(1) * elemSize; // bytes per dest row
+    int64_t const srcPitch = src.size(1) * elemSize;   // bytes per src row
+    int64_t const width = sliceWidth * elemSize;       // bytes to copy per row
+
+    char* destPtr = static_cast<char*>(dest.data_ptr()) + dim1Start * elemSize;
+    char const* srcPtr = static_cast<char const*>(src.data_ptr());
+
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream(dest.get_device());
+    TLLM_CUDA_CHECK(cudaMemcpy2DAsync(
+        destPtr, destPitch, srcPtr, srcPitch, width, static_cast<size_t>(numTokens), cudaMemcpyDeviceToDevice, stream));
+}
+
+} // namespace tensorrt_llm::torch_ext
+
+TORCH_LIBRARY_FRAGMENT(trtllm, m)
+{
+    // dest: destination tensor (mutated in-place)
+    // src:  source tensor (numTokens inferred from src.size(0))
+    // dim1_start: first column index in dest
+    // dim1_end:   one-past-last column index in dest
+    m.def("inplace_slice_copy(Tensor(a!) dest, Tensor src, int dim1_start, int dim1_end) -> ()");
+}
+
+TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
+{
+    m.impl("inplace_slice_copy", TORCH_FN(tensorrt_llm::torch_ext::inplaceSliceCopy));
+}

--- a/tensorrt_llm/_torch/compilation/utils.py
+++ b/tensorrt_llm/_torch/compilation/utils.py
@@ -118,6 +118,9 @@ def inplace_info():
         torch.ops.trtllm.cute_dsl_bf16_gemm_blackwell.default: {
             1: "output"
         },
+        torch.ops.trtllm.inplace_slice_copy.default: {
+            1: "dest"
+        }
     }
     if IS_CUDA_TILE_AVAILABLE:
         # cuda.tile availability depends on GPU capability thus runtime check.

--- a/tensorrt_llm/_torch/custom_ops/__init__.py
+++ b/tensorrt_llm/_torch/custom_ops/__init__.py
@@ -1,3 +1,5 @@
+import torch
+
 from ..cuda_tile_utils import IS_CUDA_TILE_AVAILABLE
 from ..cute_dsl_utils import IS_CUTLASS_DSL_AVAILABLE
 from ..flashinfer_utils import IS_FLASHINFER_AVAILABLE
@@ -10,6 +12,12 @@ from .userbuffers_custom_ops import add_to_ub, copy_to_userbuffers, matmul_to_ub
 # modules.attention and must be imported from there. They are not re-exported here to
 # avoid circular imports: custom_ops must not depend on modules.attention.
 
+
+def inplace_slice_copy(dest: torch.Tensor, src: torch.Tensor, dim1_start: int,
+                       dim1_end: int) -> None:
+    torch.ops.trtllm.inplace_slice_copy(dest, src, dim1_start, dim1_end)
+
+
 __all__ = [
     'IS_FLASHINFER_AVAILABLE',
     '_register_fake',
@@ -20,6 +28,7 @@ __all__ = [
     'copy_to_userbuffers',
     'matmul_to_ub',
     'IS_CUTLASS_DSL_AVAILABLE',
+    'inplace_slice_copy',
 ]
 
 if IS_FLASHINFER_AVAILABLE:

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -204,6 +204,10 @@ def _register_fake():
                                 dtype=scores_with_bias.dtype), scores.new_empty(
                                     shape, dtype=torch.int32)
 
+    @torch.library.register_fake("trtllm::inplace_slice_copy")
+    def _(dest, src, dim1_start, dim1_end):
+        pass
+
     @torch.library.register_fake("trtllm::indexer_topk_prefill")
     def _(logits, row_starts, row_ends, indices, index_topk):
         # In-place operation, no return value (void function)

--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Set
 import torch
 from torch import nn
 
+from tensorrt_llm._torch.custom_ops import inplace_slice_copy
 from tensorrt_llm._utils import prefer_pinned
 from tensorrt_llm.mapping import Mapping
 
@@ -436,13 +437,13 @@ class Eagle3OneModelSpecMetadata(SpecMetadata):
             layer_id: int,
             hidden_states: torch.Tensor,
             residual: Optional[torch.Tensor] = None) -> None:
+
         for i, captured_layer_id in enumerate(self.layers_to_capture):
             if captured_layer_id == layer_id:
-                num_tokens = hidden_states.shape[0]
                 to_save = hidden_states + residual if residual is not None else hidden_states
-                self.hidden_states[:num_tokens, i * self.hidden_size:(i + 1) *
-                                   self.hidden_size].copy_(to_save,
-                                                           non_blocking=True)
+                inplace_slice_copy(self.hidden_states, to_save,
+                                   i * self.hidden_size,
+                                   (i + 1) * self.hidden_size)
                 break
 
 

--- a/tests/unittest/_torch/thop/parallel_hw_agnostic/test_inplace_slice_copy.py
+++ b/tests/unittest/_torch/thop/parallel_hw_agnostic/test_inplace_slice_copy.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for trtllm::inplace_slice_copy.
+
+Verifies that the cudaMemcpy2DAsync-backed op produces the same result as a
+reference Python slice + Tensor.copy_, for the row-prefix / column-slice
+write pattern used in EAGLE3 hidden-state capture.
+"""
+
+import pytest
+import torch
+
+import tensorrt_llm  # noqa: F401
+
+
+def _reference(dest_shape, src, dim1_start, dim1_end, dtype):
+    dest = torch.zeros(dest_shape, dtype=dtype, device="cuda")
+    num_tokens = src.shape[0]
+    dest[:num_tokens, dim1_start:dim1_end].copy_(src)
+    return dest
+
+
+def _run(dest_shape, src, dim1_start, dim1_end, dtype):
+    dest = torch.zeros(dest_shape, dtype=dtype, device="cuda")
+    torch.ops.trtllm.inplace_slice_copy(dest, src, dim1_start, dim1_end)
+    return dest
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+def test_full_dest_full_width(dtype):
+    """num_tokens == dest.size(0) and slice == full dest width."""
+    dest_shape = (16, 64)
+    src = torch.randn(16, 64, dtype=dtype, device="cuda")
+    out = _run(dest_shape, src, 0, 64, dtype)
+    ref = _reference(dest_shape, src, 0, 64, dtype)
+    torch.testing.assert_close(out, ref)
+
+
+def test_partial_rows():
+    """num_tokens < dest.size(0): trailing rows must stay zero."""
+    dtype = torch.bfloat16
+    dest_shape = (32, 64)
+    src = torch.randn(8, 64, dtype=dtype, device="cuda")
+    out = _run(dest_shape, src, 0, 64, dtype)
+    ref = _reference(dest_shape, src, 0, 64, dtype)
+    torch.testing.assert_close(out, ref)
+    assert torch.all(out[8:] == 0)
+
+
+def test_column_slice_middle():
+    """Write to a middle column band; flanking columns must stay zero."""
+    dtype = torch.bfloat16
+    dest_shape = (16, 96)
+    src = torch.randn(16, 32, dtype=dtype, device="cuda")
+    out = _run(dest_shape, src, 32, 64, dtype)
+    ref = _reference(dest_shape, src, 32, 64, dtype)
+    torch.testing.assert_close(out, ref)
+    assert torch.all(out[:, :32] == 0)
+    assert torch.all(out[:, 64:] == 0)
+
+
+def test_layered_capture_pattern():
+    """Mimic EAGLE3 hidden-state capture: write each layer into its band."""
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, num_layers = 12, 48, 3
+    dest_shape = (24, hidden_size * num_layers)
+    srcs = [
+        torch.randn(num_tokens, hidden_size, dtype=dtype, device="cuda") for _ in range(num_layers)
+    ]
+
+    out = torch.zeros(dest_shape, dtype=dtype, device="cuda")
+    for i, s in enumerate(srcs):
+        torch.ops.trtllm.inplace_slice_copy(out, s, i * hidden_size, (i + 1) * hidden_size)
+
+    ref = torch.zeros(dest_shape, dtype=dtype, device="cuda")
+    for i, s in enumerate(srcs):
+        ref[:num_tokens, i * hidden_size : (i + 1) * hidden_size].copy_(s)
+
+    torch.testing.assert_close(out, ref)
+
+
+def test_empty_src_is_noop():
+    """num_tokens == 0 must not modify dest and must not raise."""
+    dtype = torch.bfloat16
+    dest_shape = (16, 64)
+    dest = torch.full(dest_shape, 7, dtype=dtype, device="cuda")
+    src = torch.empty(0, 32, dtype=dtype, device="cuda")
+    torch.ops.trtllm.inplace_slice_copy(dest, src, 16, 48)
+    assert torch.all(dest == 7)
+
+
+def test_dtype_mismatch_raises():
+    dest = torch.zeros(8, 32, dtype=torch.bfloat16, device="cuda")
+    src = torch.randn(8, 32, dtype=torch.float16, device="cuda")
+    with pytest.raises(RuntimeError):
+        torch.ops.trtllm.inplace_slice_copy(dest, src, 0, 32)
+
+
+def test_out_of_bounds_raises():
+    dtype = torch.bfloat16
+    dest = torch.zeros(8, 32, dtype=dtype, device="cuda")
+    src = torch.randn(8, 8, dtype=dtype, device="cuda")
+    with pytest.raises(RuntimeError):
+        torch.ops.trtllm.inplace_slice_copy(dest, src, 28, 36)

--- a/tests/unittest/_torch/thop/parallel_hw_agnostic/test_inplace_slice_copy.py
+++ b/tests/unittest/_torch/thop/parallel_hw_agnostic/test_inplace_slice_copy.py
@@ -114,3 +114,23 @@ def test_out_of_bounds_raises():
     src = torch.randn(8, 8, dtype=dtype, device="cuda")
     with pytest.raises(RuntimeError):
         torch.ops.trtllm.inplace_slice_copy(dest, src, 28, 36)
+
+
+def test_negative_dim1_start_raises():
+    """A negative dim1_start would underflow the dest pointer."""
+    dtype = torch.bfloat16
+    dest = torch.zeros(8, 32, dtype=dtype, device="cuda")
+    src = torch.randn(8, 8, dtype=dtype, device="cuda")
+    with pytest.raises(RuntimeError):
+        torch.ops.trtllm.inplace_slice_copy(dest, src, -8, 0)
+
+
+def test_device_mismatch_raises():
+    """dest and src on different CUDA devices must be rejected."""
+    if torch.cuda.device_count() < 2:
+        pytest.skip("requires >= 2 CUDA devices")
+    dtype = torch.bfloat16
+    dest = torch.zeros(8, 32, dtype=dtype, device="cuda:0")
+    src = torch.randn(8, 32, dtype=dtype, device="cuda:1")
+    with pytest.raises(RuntimeError):
+        torch.ops.trtllm.inplace_slice_copy(dest, src, 0, 32)


### PR DESCRIPTION
## Summary

Replaces the Python `slice + Tensor.copy_(non_blocking=True)` path in `Eagle3OneModelSpecMetadata.maybe_capture_hidden_states` with a new `trtllm::inplace_slice_copy` custom op backed by `cudaMemcpy2DAsync`.

The op:
- Writes `src[:numTokens, :]` into `dest[:numTokens, dim1_start:dim1_end]` in one device-to-device 2-D memcpy on the current PyTorch CUDA stream.
- Is registered with a Python `register_fake` (no-op) so it composes with `torch.compile` / FX tracing.
- Is added to the piecewise CUDA graph `inplace_map` (`dest` is the mutated argument) so the capture continues to inline the write rather than treating it as an external mutation.

## Motivation

On the Eagle3 capture path the previous code dispatched a Python `aten::slice` + `aten::copy_` per captured layer per step. Even with `non_blocking=True` these show up as host-side overhead on the compute timeline and prevent the copy from being fully absorbed into the surrounding CUDA-graph region. Lowering the write to a single `cudaMemcpy2DAsync` issued on the current stream removes those launches from the timeline.

## Performance

Measured on **H100** with the EAGLE3 hidden-state-capture repro used during development:

| Metric | Before | After |
|--------|--------|-------|
| TTFT   | 26.6938 ms | 25.4725 ms |
| TPOT   | 10.2400 ms | 7.92125 ms |

### nsys timeline

<img width="1276" height="321" alt="image" src="https://github.com/user-attachments/assets/45669813-344a-4d48-bf38-87768dd4f0d5" />

<img width="1104" height="326" alt="image" src="https://github.com/user-attachments/assets/bdf68afa-c2b3-484c-a5fa-edb48087a74f" />

## Test plan

- [x] New unit test `tests/unittest/_torch/thop/parallel_hw_agnostic/test_inplace_slice_copy.py` covers:
  - full-width copy across dtypes (bf16/fp16/fp32)
  - partial-row copy (trailing rows untouched)
  - mid-column slice (flanking columns untouched)
  - layered EAGLE3 capture pattern (multiple layer bands into one dest)
  - empty-src no-op
  - dtype-mismatch error path
  - out-of-bounds slice error path
- [x] EAGLE3 accuracy unchanged on the repro workload.
- CI: triggered via `/bot run` once this leaves draft.

## Files

- `cpp/tensorrt_llm/thop/inplaceSliceCopyOp.cpp` — new op (`cudaMemcpy2DAsync`)
- `cpp/tensorrt_llm/thop/CMakeLists.txt` — wire op into `th_common`
- `tensorrt_llm/_torch/custom_ops/__init__.py` — Python wrapper + export
- `tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py` — `register_fake`
- `tensorrt_llm/_torch/compilation/utils.py` — add to `inplace_info()` map
- `tensorrt_llm/_torch/speculative/eagle3.py` — call the op in `maybe_capture_hidden_states`
- `tests/unittest/_torch/thop/parallel_hw_agnostic/test_inplace_slice_copy.py` — new unit tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-place slice copy operation for efficient 2D tensor operations on GPU with support for arbitrary column slicing.
  * Integrated the new operation into speculative decoding for improved performance.

* **Tests**
  * Added comprehensive test coverage validating correctness, edge cases, and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14479?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->