### PR TITLE
[TRTLLM-12901][fix] cap per-rank max_num_active_requests by max_num_tokens under attention DP

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -65,6 +65,7 @@ from .mamba_cache_manager import BaseMambaCacheManager, MambaHybridCacheManager
 from .model_engine import ModelEngine
 from .perf_metrics_manager import PerfMetricsManager
 from .request_utils import (RequestBroadcaster, attach_py_objects_to_requests,
+                            derive_attention_dp_per_rank_request_cap,
                             get_from_waiting_queue, merge_requests)
 from .resource_manager import (KVCacheManagerV2, ResourceManager,
                                ResourceManagerType, request_context)
@@ -416,6 +417,28 @@ class PyExecutor:
         self.max_input_len = max_input_len
         # _executor_loop private data
         self.max_num_active_requests = model_engine.get_max_num_sequences()
+        # nvbug-6133201: under attention DP, tighten the per-rank request
+        # cap so per-rank gen-phase step-token load cannot exceed
+        # max_num_tokens. No-op for correctly-sized configs.
+        if self.enable_attention_dp:
+            derived_cap = derive_attention_dp_per_rank_request_cap(
+                base_cap=self.max_num_active_requests,
+                max_num_tokens=self.max_num_tokens,
+                max_total_draft_tokens=self.max_total_draft_tokens,
+            )
+            if derived_cap < self.max_num_active_requests:
+                step_tokens_per_req = 1 + max(self.max_total_draft_tokens, 0)
+                required_max_num_tokens = (self.max_num_active_requests *
+                                           step_tokens_per_req)
+                logger.warning(
+                    f"[PyExecutor] enable_attention_dp: max_num_tokens="
+                    f"{self.max_num_tokens} cannot fit max_batch_size="
+                    f"{self.max_num_active_requests} at {step_tokens_per_req} "
+                    f"step-tokens each; capping per-rank max_num_active_requests "
+                    f"to {derived_cap}. Raise max_num_tokens to "
+                    f"{required_max_num_tokens} to run at the declared "
+                    f"max_batch_size.")
+            self.max_num_active_requests = derived_cap
         self.active_requests: List[LlmRequest] = []
         self.expected_num_active_requests = 0
         # TODO: Remove PP size == 1 gate for disagg + block reuse with PP > 1.

--- a/tensorrt_llm/_torch/pyexecutor/request_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/request_utils.py
@@ -70,6 +70,33 @@ def attach_py_objects_to_requests(requests: List, py_request_objects: Tuple) -> 
                     setattr(item.request, attr_name, py_obj)
 
 
+def derive_attention_dp_per_rank_request_cap(
+    base_cap: int,
+    max_num_tokens: Optional[int],
+    max_total_draft_tokens: int,
+) -> int:
+    """Cap per-rank requests at ``max_num_tokens // (1 + max_total_draft_tokens)``
+    so gen-phase per-step token load cannot exceed ``max_num_tokens`` under
+    attention DP, where no component otherwise enforces a per-rank token cap
+    (nvbug-6133201). Each gen request occupies ``1 + max_total_draft_tokens``
+    token slots per step. Mirrors the CUDA graph batch-size cap at
+    ``model_engine._filter_cuda_graph_batch_sizes``.
+
+    Args:
+        base_cap: Per-rank request cap from ``get_max_num_sequences()``.
+        max_num_tokens: ``LlmArgs.max_num_tokens``; ``None`` disables tightening.
+        max_total_draft_tokens: Draft tokens per gen request (0 without spec
+            decoding); negative values are clamped to 0.
+
+    Returns:
+        The tighter of ``base_cap`` and ``max_num_tokens // step_tokens``.
+    """
+    if max_num_tokens is None:
+        return base_cap
+    step_tokens_per_req = 1 + max(max_total_draft_tokens, 0)
+    return min(base_cap, max_num_tokens // step_tokens_per_req)
+
+
 def can_process_attention_dp_request(
     req_item, all_ranks_num_active_requests: List[int], max_num_active_requests: int
 ) -> bool:

--- a/tests/unittest/_torch/executor/test_request_utils.py
+++ b/tests/unittest/_torch/executor/test_request_utils.py
@@ -13,6 +13,7 @@ import pytest
 from tensorrt_llm._torch.pyexecutor.executor_request_queue import RequestQueueItem
 from tensorrt_llm._torch.pyexecutor.request_utils import (
     can_process_attention_dp_request,
+    derive_attention_dp_per_rank_request_cap,
     get_from_waiting_queue,
     merge_helix_requests,
     merge_requests,
@@ -379,3 +380,83 @@ def test_can_process_attention_dp_request(attention_dp_config):
     assert not can_process_attention_dp_request(
         req_no_capacity, all_ranks_full, max_num_active_requests
     )
+
+
+# --------------------------------------------------------------------------
+# nvbug-6133201: per-rank gen-phase step-token cap via tightened
+# per-rank request cap.
+# --------------------------------------------------------------------------
+# Under enable_attention_dp the global Python scheduler caps tokens
+# cluster-wide and the ADP router caps per-rank requests, but no
+# component caps per-rank gen-phase step-tokens.  PyExecutor tightens
+# the per-rank request cap to
+# ``max_num_tokens // (1 + max_total_draft_tokens)`` so per-rank step-
+# token load cannot exceed max_num_tokens by construction.
+
+
+class TestDeriveAttentionDpPerRankRequestCap:
+    """Unit tests for ``derive_attention_dp_per_rank_request_cap``.
+
+    The fix for nvbug-6133201 is the cap arithmetic implemented in this
+    helper; PyExecutor calls it once at ``__init__`` and the result
+    flows through the existing ``max_num_active_requests`` plumbing.
+    """
+
+    def test_no_tightening_when_max_num_tokens_is_none(self):
+        # LlmArgs.max_num_tokens == None -> helper is a no-op.
+        assert (
+            derive_attention_dp_per_rank_request_cap(
+                base_cap=128, max_num_tokens=None, max_total_draft_tokens=3
+            )
+            == 128
+        )
+
+    def test_nvbug_6133201_failing_config(self):
+        # nvbug-6133201 numbers: max_batch_size=128,
+        # max_total_draft_tokens=3 (MTP3), max_num_tokens=256.
+        # Per-rank step-token cost per req = 1 + 3 = 4.
+        # Effective cap = 256 // 4 = 64; per-rank load at saturation
+        # 64 * 4 = 256 = max_num_tokens, so the per-rank assert in
+        # model_engine.py cannot trip on gen-phase accumulation.
+        assert (
+            derive_attention_dp_per_rank_request_cap(
+                base_cap=128, max_num_tokens=256, max_total_draft_tokens=3
+            )
+            == 64
+        )
+
+    def test_no_tightening_when_arithmetic_already_fits(self):
+        # Correctly-sized LlmArgs (max_batch_size * (1+max_total_draft_tokens)
+        # <= max_num_tokens): cap == base_cap, no behavioral change.
+        assert (
+            derive_attention_dp_per_rank_request_cap(
+                base_cap=128, max_num_tokens=512, max_total_draft_tokens=3
+            )
+            == 128
+        )
+        assert (
+            derive_attention_dp_per_rank_request_cap(
+                base_cap=128, max_num_tokens=4096, max_total_draft_tokens=3
+            )
+            == 128
+        )
+
+    def test_no_spec_decoding(self):
+        # max_total_draft_tokens == 0: step-token cost per req == 1,
+        # effective cap == max_num_tokens.
+        assert (
+            derive_attention_dp_per_rank_request_cap(
+                base_cap=128, max_num_tokens=64, max_total_draft_tokens=0
+            )
+            == 64
+        )
+
+    def test_negative_max_total_draft_tokens_clamped(self):
+        # Defensive: a stray negative value must not yield div-by-zero
+        # or a negative cap.
+        assert (
+            derive_attention_dp_per_rank_request_cap(
+                base_cap=128, max_num_tokens=256, max_total_draft_tokens=-5
+            )
+            == 128
+        )


### PR DESCRIPTION
## Summary

Under `enable_attention_dp=true`, the per-rank assert at `model_engine.py` (`total_num_tokens <= max_num_tokens`) is the only safeguard against per-rank gen-phase step-token overflow. If `max_batch_size * (1 + max_total_draft_tokens) > max_num_tokens`, decode steady-state trips the assert and silently deadlocks the rank (HTTP keeps returning 200 OK, no decode tokens; nvbug-6133201).

This PR tightens `PyExecutor.max_num_active_requests` at init to `min(model_engine.get_max_num_sequences(), max_num_tokens // (1 + max_total_draft_tokens))`, mirroring the existing CUDA-graph batch-size derivation at `model_engine._filter_cuda_graph_batch_sizes`. Per-rank step-token load can no longer exceed `max_num_tokens` by construction.

- **Correctly-sized configs:** no-op (derived cap == base cap).
- **Misconfigured configs:** cap tightens + a `logger.warning` at init names the field values involved and the minimum `max_num_tokens` needed to restore the declared `max_batch_size`. Deployers self-diagnose at startup instead of silently running at reduced throughput.

Context-phase prompt tokens remain bounded by the existing cluster-wide scheduler at `scheduler.py`; this PR addresses only the gen-phase per-rank overflow path.

## Test plan

- [x] 5 unit tests for the cap derivation helper (`tests/unittest/_torch/executor/test_request_utils.py::TestDeriveAttentionDpPerRankRequestCap`): no-tightening, failing-config, correctly-sized, no-spec-decoding, defensive-clamp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic request capacity safeguard for Attention Distributed Parallel processing to prevent token buffer overflow and maintain stability under concurrent request loads.

* **Tests**
  * Added comprehensive unit tests validating request capacity derivation across multiple configurations and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14481?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->