### PR TITLE
[None][docs] fix incorrect auto sampler behavior description for beam search

### DIFF
--- a/docs/source/features/sampling.md
+++ b/docs/source/features/sampling.md
@@ -36,10 +36,7 @@ llm = LLM(model='nvidia/Llama-3.1-8B-Instruct-FP8',
           sampler_type="TRTLLMSampler")
 ```
 
-By default, the sampling backend is chosen to be `auto`. This will use:
-
-* TRTLLM Sampler when using Beam Search.
-* Torch Sampler otherwise.
+By default, the sampling backend is chosen to be `auto`. This will use Torch Sampler for all requests.
 
 Here is an example to run a model with basic usage of sampling parameters. This example prepares two identical prompts which will give different results due to the sampling parameters chosen:
 


### PR DESCRIPTION
## Summary

- `docs/source/features/sampling.md` incorrectly stated that the `auto` sampler mode uses `TRTLLMSampler` when beam search is enabled
- In practice, `auto` always selects `TorchSampler` for all requests, including beam search
- This contradicts both the field description in `llm_args.py:3810` ("Defaults to auto, which will use TorchSampler") and the actual sampler instantiation logic in `_torch/pyexecutor/_util.py:1821`

## Root Cause

The `auto` mode was historically documented as routing to `TRTLLMSampler` for beam search, but this behavior does not exist in the code. `TRTLLMSampler` is only used when explicitly set via `sampler_type="TRTLLMSampler"`, which is deprecated and scheduled for removal in release 1.4.

**Code evidence:**
- `tensorrt_llm/_torch/pyexecutor/_util.py:1821`: Only checks `if llm_args.sampler_type == SamplerType.TRTLLMSampler` — no auto-to-TRTLLM path for beam search
- `tensorrt_llm/llmapi/llm_args.py:3810`: Field description says "Defaults to auto, which will use TorchSampler"
- `tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py:843-844`: `if sampler_type == SamplerType.auto: sampler_type = SamplerType.TorchSampler`

## Test plan

- [x] Verify the updated description is consistent with `llm_args.py` field description
- [x] Verify no code path exists where `auto` + beam search selects `TRTLLMSampler`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sampling backend documentation to clarify that the `auto` mode defaults to using Torch Sampler for all requests, providing consistent behavior across sampling configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->