### PR TITLE
[None][docs] remove stale prompt from quickstart_example.py output comment

### DIFF
--- a/examples/llm-api/quickstart_example.py
+++ b/examples/llm-api/quickstart_example.py
@@ -24,7 +24,6 @@ def main():
 
     # Got output like
     # Prompt: 'Hello, my name is', Generated text: '\n\nJane Smith. I am a student pursuing my degree in Computer Science at [university]. I enjoy learning new things, especially technology and programming'
-    # Prompt: 'The president of the United States is', Generated text: 'likely to nominate a new Supreme Court justice to fill the seat vacated by the death of Antonin Scalia. The Senate should vote to confirm the'
     # Prompt: 'The capital of France is', Generated text: 'Paris.'
     # Prompt: 'The future of AI is', Generated text: 'an exciting time for us. We are constantly researching, developing, and improving our platform to create the most advanced and efficient model available. We are'
 


### PR DESCRIPTION
## Summary

- `examples/llm-api/quickstart_example.py` contained a stale output comment showing a sample response for `'The president of the United States is'`
- This prompt does not exist in the current prompts list (`"Hello, my name is"`, `"The capital of France is"`, `"The future of AI is"`)
- The comment is a leftover from a previous version of the example when the prompts were different

## Test plan

- [x] Verify the remaining 3 output examples match the 3 prompts in the code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example outputs in the quickstart guide to reflect current API behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->