### PR TITLE
[None][docs] pin setuptools<80 in pip installation commands

### DIFF
--- a/docs/source/installation/installation-guide.md
+++ b/docs/source/installation/installation-guide.md
@@ -65,7 +65,7 @@ image hosted on NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tensorrt-l
 Once all prerequisites are in place, TensorRT LLM can be installed as follows:
 
 ```bash
-pip3 install --ignore-installed pip setuptools wheel && pip3 install tensorrt_llm
+pip3 install --ignore-installed pip "setuptools<80" wheel && pip3 install tensorrt_llm
 ```
 
 > **Note:** The TensorRT LLM wheel on PyPI is built with PyTorch 2.10.0. This version may be incompatible with the NVIDIA NGC PyTorch container, which uses a more recent PyTorch build. If you are using the NGC PyTorch container, install the wheel built specifically for that container using the `+ngcpytorch{YYMM}` local version suffix, where `YYMM` is derived from the container tag (e.g., `pytorch:26.02` → `ngcpytorch2602`):
@@ -108,7 +108,7 @@ There are some known limitations when you pip install the pre-built TensorRT LLM
    ```bash
    CURRENT_TORCH_VERSION=$(python3 -c "import torch; print(torch.__version__)")
    echo "torch==$CURRENT_TORCH_VERSION" > /tmp/torch-constraint.txt
-   pip3 install --ignore-installed pip setuptools wheel && pip3 install tensorrt_llm -c /tmp/torch-constraint.txt
+   pip3 install --ignore-installed pip "setuptools<80" wheel && pip3 install tensorrt_llm -c /tmp/torch-constraint.txt
    ```
 
 ## Option 3: Build from Source


### PR DESCRIPTION
## Summary

- `requirements.txt:52` specifies `setuptools<80` as a constraint
- The installation guide's `pip install` commands used unpinned `setuptools`, which could install `setuptools>=80`
- When `pip` then installs `tensorrt_llm`, it would attempt to downgrade `setuptools` to satisfy the `<80` constraint — or fail with a dependency conflict in strict environments

## Changes

Updated both `pip install` commands in `docs/source/installation/installation-guide.md`:
1. Main install command (line 68)
2. Torch-constrained install command (line 111)

## Test plan

- [ ] Verify `pip3 install --ignore-installed pip "setuptools<80" wheel && pip3 install tensorrt_llm` installs successfully on a fresh Ubuntu 24.04 environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to specify setuptools version constraints when installing the pre-built wheel.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->