### PR TITLE
[None][docs] use requirements-dev.txt for dev environment setup in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,10 @@
 
 TensorRT-LLM Coding Style can be found [in this document](CODING_GUIDELINES.md).
 
-We use `pre-commit` for automatic code formatting and validation. Install the `pre-commit` package in your local Python environment.
+We use `pre-commit` for automatic code formatting and validation. Install the development dependencies (including `pre-commit` and `mypy`) from `requirements-dev.txt`:
 
 ```bash
-pip install pre-commit mypy
+pip install -r requirements-dev.txt
 pre-commit install
 ```
 


### PR DESCRIPTION
## Summary

- `CONTRIBUTING.md` instructed contributors to run `pip install pre-commit mypy` without a version pin
- `requirements-dev.txt` pins `mypy==1.19.1` along with other required dev tools (typeguard, ruff, bandit, etc.)
- Using an unpinned `mypy` install could result in a different mypy version than CI uses, causing type check failures that are hard to reproduce locally

## Changes

Replace the ad-hoc install command with `pip install -r requirements-dev.txt` to ensure contributors use the same tool versions as CI.

## Test plan

- [ ] Verify `pip install -r requirements-dev.txt && pre-commit install` sets up a working dev environment
- [ ] Verify `mypy --version` reports `1.19.1` after installation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local development setup instructions to install development dependencies via a requirements file instead of individual package installation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->