### PR TITLE
[None][fix] add nvfp4 to --kv_cache_dtype choices in quantize.py

### DIFF
--- a/examples/quantization/quantize.py
+++ b/examples/quantization/quantize.py
@@ -108,9 +108,9 @@ if __name__ == "__main__":
     parser.add_argument("--cp_size", type=int, default=1)
     parser.add_argument("--awq_block_size", type=int, default=128)
     parser.add_argument("--kv_cache_dtype",
-                        help="KV Cache dtype.",
+                        help="KV Cache dtype. Use 'nvfp4' only with --qformat fp8.",
                         default=None,
-                        choices=["int8", "fp8", None])
+                        choices=["int8", "fp8", "nvfp4", None])
     parser.add_argument("--quantize_lm_head",
                         action='store_true',
                         default=False)


### PR DESCRIPTION
## Summary

- `tensorrt_llm/quantization/quantize_by_modelopt.py` already supports `nvfp4` as a valid KV cache quantization format via `KV_QUANT_CFG_CHOICES["nvfp4"] = "NVFP4_KV_CFG"`
- However, `examples/quantization/quantize.py` only listed `["int8", "fp8", None]` in the `--kv_cache_dtype` argparse choices
- This caused argparse to reject `--kv_cache_dtype nvfp4` with an "invalid choice" error even though the underlying quantization code fully supports it

## Root Cause

The CLI wrapper was not updated when `nvfp4` KV cache support was added to the quantization backend.

**Code evidence:**
- `tensorrt_llm/quantization/quantize_by_modelopt.py:108-110`: `KV_QUANT_CFG_CHOICES = {"fp8": "FP8_KV_CFG", "nvfp4": "NVFP4_KV_CFG"}`
- `tensorrt_llm/quantization/mode.py`: `KV_CACHE_QUANT_ALGO_LIST = [QuantAlgo.FP8, QuantAlgo.INT8, QuantAlgo.NVFP4]`
- `examples/quantization/quantize.py:113`: `choices=["int8", "fp8", None]` — missing `"nvfp4"`

## Changes

- Added `"nvfp4"` to the `--kv_cache_dtype` choices
- Updated the help text to note that nvfp4 KV cache requires `--qformat fp8`

## Test plan

- [ ] Verify `python quantize.py --kv_cache_dtype nvfp4 --qformat fp8 ...` is accepted by argparse
- [ ] Verify that the nvfp4 KV cache quantization produces valid output checkpoints on Hopper/Blackwell GPUs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `nvfp4` as a KV cache data type option in quantization examples.

* **Documentation**
  * Updated help text to clarify constraints on `nvfp4` usage with quantization formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->