### PR TITLE
[None][docs] Fix broken _cpp_gen/executor.rst reference in executor.md

### DIFF
--- a/docs/source/legacy/advanced/executor.md
+++ b/docs/source/legacy/advanced/executor.md
@@ -7,7 +7,7 @@ asynchronously, with in-flight batching, and without the need to define callback
 
 A software component (referred to as "the client" in the text that follows) can interact
 with the executor using the API defined in the [`executor.h`](source:cpp/include/tensorrt_llm/executor/executor.h) file.
-For details about the API, refer to the {ref}`_cpp_gen/executor.rst`.
+For details about the API, refer to the [`executor.h`](source:cpp/include/tensorrt_llm/executor/executor.h) header file.
 
 The following sections provide an overview of the main classes defined in the Executor API.
 


### PR DESCRIPTION
## Background

`docs/source/legacy/advanced/executor.md` line 10 references `{ref}\`_cpp_gen/executor.rst\`` — a Sphinx cross-reference that resolves to a path that **does not exist** in the repository:

```
find docs/ -name "executor.rst"        # no results
find docs/ -name "_cpp_gen" -type d    # no results
```

The `_cpp_gen/` directory is likely auto-generated Doxygen/Exhale C++ API documentation that was never included in the source tree. The broken reference produces a Sphinx build warning and may render as a dead link for users.

## Changes

Replace the broken `{ref}` cross-reference with a direct link to `executor.h`, which is already used one line above in the same paragraph:

```diff
-For details about the API, refer to the {ref}`_cpp_gen/executor.rst`.
+For details about the API, refer to the [`executor.h`](source:cpp/include/tensorrt_llm/executor/executor.h) header file.
```

## Verification

Confirmed the `_cpp_gen/executor.rst` path does not exist anywhere in the repository:

```bash
$ find ~/Projects/trtllm/docs -name "executor.rst"
# (no output)
$ find ~/Projects/trtllm/docs -name "_cpp_gen" -type d
# (no output)
```

The `executor.h` file used as the replacement link exists at `cpp/include/tensorrt_llm/executor/executor.h` and is the canonical entry point for the Executor C++ API, as stated in the same paragraph.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated cross-references in executor documentation to enhance access to API reference materials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14492?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->