### PR TITLE
[None][docs] Fix beamWidth default value and valid range in gpt-runtime.md

### DIFF
--- a/docs/source/legacy/advanced/gpt-runtime.md
+++ b/docs/source/legacy/advanced/gpt-runtime.md
@@ -177,7 +177,7 @@ value for a given parameter, the vector can be limited to a single element
 
 |      Name in TRT-LLM      |           Description           |      Data type      |      Range of value      |       Default value       |     Name in HF      |
 | :-----------------------: | :-----------------------------: | :-----------------: | :----------------------: | :-----------------------: | :-----------------: |
-|        `beamWidth`        | width for beam-search algorithm |         Int         |       \[0, 1024\]        | `0` (disable beam search) |    `beam_width`     |
+|        `beamWidth`        | width for beam-search algorithm |         Int         |       \[1, 1024\]        | `1` (greedy/sampling; beam search disabled) |    `beam_width`     |
 | `beamSearchDiversityRate` |  diversity of generated tokens  |    List\[Float\]    |     \[0, $+\infty$\)     |          `0.0f`           | `diversity_penalty` |
 |      `lengthPenalty`      |    penalize longer sequences    |    List\[Float\]    |     \[0, $+\infty$\)     |          `0.0f`           |  `length_penalty`   |
 |      `earlyStopping`      |      see description below      |     List\[Int\]     | \($-\infty$, $+\infty$\) |            `0`            |  `early_stopping`   |


### PR DESCRIPTION
## Background

`docs/source/legacy/advanced/gpt-runtime.md` documents `beamWidth` with an incorrect default value and an invalid minimum range. The table states:

```
| `beamWidth` | ... | [0, 1024] | `0` (disable beam search) |
```

However, the C++ source code tells a different story.

## Code Evidence

**`cpp/include/tensorrt_llm/runtime/samplingConfig.h`:**

```cpp
// Line 107 — default is 1, not 0:
explicit SamplingConfig(SizeType32 beamWidth = 1)

// Line 245 — 0 is explicitly invalid:
valid &= (beamWidth > 0);

// Line 249 — error message confirms 0 is rejected:
"Requested beam width %d is incorrect. Must be > 0. To de-activate beam searching set beamWidth to 1."
```

The code:
1. Defaults `beamWidth` to **1** (not 0)
2. Validates that `beamWidth > 0` — value **0 is INVALID** and triggers an error
3. Explicitly states that beam search is disabled by setting `beamWidth = 1`, not 0

## Changes

```diff
-|        `beamWidth`        | width for beam-search algorithm |         Int         |       \[0, 1024\]        | `0` (disable beam search) |
+|        `beamWidth`        | width for beam-search algorithm |         Int         |       \[1, 1024\]        | `1` (greedy/sampling; beam search disabled) |
```

- Correct the minimum range from `[0, 1024]` to `[1, 1024]`
- Correct the default from `0` to `1`
- Align the description with the error message in `samplingConfig.h`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `beamWidth` parameter documentation with revised default value, allowed range, and clarification on beam search behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->