### PR TITLE
[None][docs] Add W8A8 SmoothQuant (int8_sq) to quantization feature docs

### DIFF
--- a/docs/source/features/quantization.md
+++ b/docs/source/features/quantization.md
@@ -12,6 +12,7 @@ TensorRT LLM offers a variety of quantization recipes to optimize LLM inference.
 * FP8 Rowwise
 * FP8 KV Cache
 * NVFP4 KV Cache
+* W8A8 SmoothQuant (INT8)
 * W4A16 GPTQ
 * W4A8 GPTQ
 * W4A16 AWQ
@@ -85,6 +86,18 @@ scripts/huggingface_example.sh --model <huggingface_model_card> --quant fp8 --kv
 ```
 
 Note that currently TRT-LLM only supports FP8 weight/activation quantization when NVFP4 KV cache is enabled. Therefore, `--quant fp8` is required here.
+
+#### W8A8 SmoothQuant (INT8)
+
+W8A8 SmoothQuant (`int8_sq`) quantizes both weights and activations to INT8. It uses [SmoothQuant](https://arxiv.org/abs/2211.10438) to migrate quantization difficulty from activations to weights before applying per-channel or per-tensor INT8 quantization. Use the `quantize.py` script from `examples/quantization/`:
+
+```bash
+python examples/quantization/quantize.py \
+    --model_dir <huggingface_model_dir> \
+    --dtype float16 \
+    --qformat int8_sq \
+    --output_dir <output_dir>
+```
 
 ## Model Support Matrix
 

--- a/docs/source/features/quantization.md
+++ b/docs/source/features/quantization.md
@@ -89,7 +89,7 @@ Note that currently TRT-LLM only supports FP8 weight/activation quantization whe
 
 #### W8A8 SmoothQuant (INT8)
 
-W8A8 SmoothQuant (`int8_sq`) quantizes both weights and activations to INT8. It uses [SmoothQuant](https://arxiv.org/abs/2211.10438) to migrate quantization difficulty from activations to weights before applying per-channel or per-tensor INT8 quantization. Use the `quantize.py` script from `examples/quantization/`:
+W8A8 SmoothQuant (`int8_sq`) quantizes both weights and activations to INT8. It uses [SmoothQuant](https://arxiv.org/abs/2211.10438) to migrate quantization difficulty from activations to weights, then exports `W8A8_SQ_PER_CHANNEL` checkpoints with channel-wise INT8 weights and tensor-wise calibrated activation ranges. Use the `quantize.py` script from `examples/quantization/`:
 
 ```bash
 python examples/quantization/quantize.py \
@@ -101,28 +101,28 @@ python examples/quantization/quantize.py \
 
 ## Model Support Matrix
 
-| Model          |  NVFP4  | MXFP4  | FP8(per tensor)| FP8(block scaling) | FP8(rowwise) | FP8 KV Cache | NVFP4 KV Cache | W4A8 AWQ  | W4A16 AWQ | W4A8 GPTQ  | W4A16 GPTQ |
-| :------------- | :---:   | :---:  | :---: | :---: | :---: | :---: |:---:| :-------: | :-------: | :--------: | :--------: |
-| BERT           |   .     |   .    |   .   |   .   |   .   |   Y   |  .  |     .     |     .     |     .      |     .      |
-| DeepSeek-R1    |   Y     |   .    |   .   |   Y   |   .   |   Y   |  .  |     .     |     .     |     .      |     .      |
-| EXAONE         |   .     |   .    |   Y   |   .   |   .   |   Y   |  .  |     Y     |     Y     |     .      |     .      |
-| Gemma 3        |   .     |   .    |   Y   |   .   |   .   |   Y   |  .  |     Y     |     Y     |     .      |     .      |
-| GPT-OSS        |   .     |   Y    |   .   |   .   |   .   |   Y   |  .  |     .     |     .     |     .      |     .      |
-| LLaMA          |   Y     |   .    |   Y   |   .   |   .   |   Y   |  .  |     .     |     Y     |     .      |     Y      |
-| LLaMA-v2       |   Y     |   .    |   Y   |   .   |   .   |   Y   |  Y  |     Y     |     Y     |     .      |     Y      |
-| LLaMA 3        |   .     |   .    |   .   |   .   |   Y   |   Y   |  Y  |     Y     |     .     |     .      |     .      |
-| LLaMA 4        |   Y     |   .    |   Y   |   .   |   .   |   Y   |  .  |     .     |     .     |     .      |     .      |
-| Mistral        |   .     |   .    |   Y   |   .   |   .   |   Y   |  .  |     .     |     Y     |     .      |     .      |
-| Mixtral        |   Y     |   .    |   Y   |   .   |   .   |   Y   |  .  |     .     |     .     |     .      |     .      |
-| Phi            |   .     |   .    |   .   |   .   |   .   |   Y   |  .  |     Y     |     .     |     .      |     .      |
-| Qwen           |   .     |   .    |   .   |   .   |   .   |   Y   |  .  |     Y     |     Y     |     .      |     Y      |
-| Qwen-2/2.5     |   Y     |   .    |   Y   |   .   |   .   |   Y   |  .  |     Y     |     Y     |     .      |     Y      |
-| Qwen-3         |   Y     |   .    |   Y   |   .   |   .   |   Y   |  Y  |     .     |     Y     |     .      |     Y      |
-| BLIP2-OPT      |   .     |   .    |   .   |   .   |   .   |   Y   |  .  |     .     |     .     |     .      |     .      |
-| BLIP2-T5       |   .     |   .    |   .   |   .   |   .   |   Y   |  .  |     .     |     .     |     .      |     .      |
-| LLaVA          |   .     |   .    |   Y   |   .   |   .   |   Y   |  .  |     .     |     Y     |     .      |     Y      |
-| VILA           |   .     |   .    |   Y   |   .   |   .   |   Y   |  .  |     .     |     Y     |     .      |     Y      |
-| Nougat         |   .     |   .    |   .   |   .   |   .   |   Y   |  .  |     .     |     .     |     .      |     .      |
+| Model          |  NVFP4  | MXFP4  | FP8(per tensor)| FP8(block scaling) | FP8(rowwise) | FP8 KV Cache | NVFP4 KV Cache | W8A8 SQ | W4A8 AWQ  | W4A16 AWQ | W4A8 GPTQ  | W4A16 GPTQ |
+| :------------- | :---:   | :---:  | :---: | :---: | :---: | :---: |:---:| :-----: | :-------: | :-------: | :--------: | :--------: |
+| BERT           |   .     |   .    |   .   |   .   |   .   |   Y   |  .  |    .    |     .     |     .     |     .      |     .      |
+| DeepSeek-R1    |   Y     |   .    |   .   |   Y   |   .   |   Y   |  .  |    .    |     .     |     .     |     .      |     .      |
+| EXAONE         |   .     |   .    |   Y   |   .   |   .   |   Y   |  .  |    .    |     Y     |     Y     |     .      |     .      |
+| Gemma 3        |   .     |   .    |   Y   |   .   |   .   |   Y   |  .  |    Y    |     Y     |     Y     |     .      |     .      |
+| GPT-OSS        |   .     |   Y    |   .   |   .   |   .   |   Y   |  .  |    .    |     .     |     .     |     .      |     .      |
+| LLaMA          |   Y     |   .    |   Y   |   .   |   .   |   Y   |  .  |    Y    |     .     |     Y     |     .      |     Y      |
+| LLaMA-v2       |   Y     |   .    |   Y   |   .   |   .   |   Y   |  Y  |    Y    |     Y     |     Y     |     .      |     Y      |
+| LLaMA 3        |   .     |   .    |   .   |   .   |   Y   |   Y   |  Y  |    Y    |     Y     |     .     |     .      |     .      |
+| LLaMA 4        |   Y     |   .    |   Y   |   .   |   .   |   Y   |  .  |    .    |     .     |     .     |     .      |     .      |
+| Mistral        |   .     |   .    |   Y   |   .   |   .   |   Y   |  .  |    Y    |     .     |     Y     |     .      |     .      |
+| Mixtral        |   Y     |   .    |   Y   |   .   |   .   |   Y   |  .  |    .    |     .     |     .     |     .      |     .      |
+| Phi            |   .     |   .    |   .   |   .   |   .   |   Y   |  .  |    .    |     Y     |     .     |     .      |     .      |
+| Qwen           |   .     |   .    |   .   |   .   |   .   |   Y   |  .  |    Y    |     Y     |     Y     |     .      |     Y      |
+| Qwen-2/2.5     |   Y     |   .    |   Y   |   .   |   .   |   Y   |  .  |    Y    |     Y     |     Y     |     .      |     Y      |
+| Qwen-3         |   Y     |   .    |   Y   |   .   |   .   |   Y   |  Y  |    Y    |     .     |     Y     |     .      |     Y      |
+| BLIP2-OPT      |   .     |   .    |   .   |   .   |   .   |   Y   |  .  |    .    |     .     |     .     |     .      |     .      |
+| BLIP2-T5       |   .     |   .    |   .   |   .   |   .   |   Y   |  .  |    .    |     .     |     .     |     .      |     .      |
+| LLaVA          |   .     |   .    |   Y   |   .   |   .   |   Y   |  .  |    Y    |     .     |     Y     |     .      |     Y      |
+| VILA           |   .     |   .    |   Y   |   .   |   .   |   Y   |  .  |    Y    |     .     |     Y     |     .      |     Y      |
+| Nougat         |   .     |   .    |   .   |   .   |   .   |   Y   |  .  |    .    |     .     |     .     |     .      |     .      |
 
 
 ```{note}
@@ -133,13 +133,13 @@ The language component decides which quantization methods are supported by a giv
 
 ## Hardware Support Matrix
 
-| Model          |  NVFP4  | MXFP4  | FP8(per tensor)| FP8(block scaling) | FP8(rowwise) | FP8 KV Cache | NVFP4 KV Cache | W4A8 AWQ  | W4A16 AWQ | W4A8 GPTQ  | W4A16 GPTQ |
-| :------------- | :---:   | :---:  | :---: | :---: | :---: | :---: | :---: | :-------: | :-------: | :--------: | :--------: |
-| Blackwell(sm120)       |   Y     |   Y    |   Y   |   .   |   .   |   Y   |   .   |     .     |     .     |     .      |     .      |
-| Blackwell(sm100/103)       |   Y     |   Y    |   Y   |   Y   |   .   |   Y   |   Y   |     Y     |     Y     |     Y      |     Y      |
-| Hopper           |   .     |   .    |   Y   |   Y   |   Y   |   Y   |   .   |     Y     |     Y     |     Y      |     Y      |
-| Ada Lovelace          |   .     |   .    |   Y   |   .   |   .   |   Y   |   .   |     Y     |     Y     |     Y      |     Y      |
-| Ampere         |   .     |   .    |   .   |   .   |   .   |   Y   |   .   |     .     |     Y     |     .      |     Y      |
+| Model          |  NVFP4  | MXFP4  | FP8(per tensor)| FP8(block scaling) | FP8(rowwise) | FP8 KV Cache | NVFP4 KV Cache | W8A8 SQ | W4A8 AWQ  | W4A16 AWQ | W4A8 GPTQ  | W4A16 GPTQ |
+| :------------- | :---:   | :---:  | :---: | :---: | :---: | :---: | :---: | :-----: | :-------: | :-------: | :--------: | :--------: |
+| Blackwell(sm120)       |   Y     |   Y    |   Y   |   .   |   .   |   Y   |   .   |    .    |     .     |     .     |     .      |     .      |
+| Blackwell(sm100/103)       |   Y     |   Y    |   Y   |   Y   |   .   |   Y   |   Y   |    .    |     Y     |     Y     |     Y      |     Y      |
+| Hopper           |   .     |   .    |   Y   |   Y   |   Y   |   Y   |   .   |    Y    |     Y     |     Y     |     Y      |     Y      |
+| Ada Lovelace          |   .     |   .    |   Y   |   .   |   .   |   Y   |   .   |    Y    |     Y     |     Y     |     Y      |     Y      |
+| Ampere         |   .     |   .    |   .   |   .   |   .   |   Y   |   .   |    Y    |     .     |     Y     |     .      |     Y      |
 
 ```{note}
 FP8 block wise scaling GEMM kernels for sm100/103 are using MXFP8 recipe (E4M3 act/weight and UE8M0 act/weight scale), which is slightly different from SM90 FP8 recipe (E4M3 act/weight and FP32 act/weight scale).


### PR DESCRIPTION
## Background

`docs/source/features/quantization.md` lists the supported quantization recipes but **W8A8 SmoothQuant (`int8_sq`) is completely absent** from the page despite being fully implemented.

## Code Evidence

**`tensorrt_llm/quantization/mode.py`** defines five W8A8 SmoothQuant variants:

```python
# Lines 30-34
W8A8_SQ_PER_CHANNEL = auto()
W8A8_SQ_PER_TENSOR_PLUGIN = auto()
W8A8_SQ_PER_CHANNEL_PER_TOKEN_PLUGIN = auto()
W8A8_SQ_PER_CHANNEL_PER_TENSOR_PLUGIN = auto()
W8A8_SQ_PER_TENSOR_PER_TOKEN_PLUGIN = auto()

# Line 61 — included in ModelOpt flow:
MODELOPT_FLOW_QUANTIZATIONS = {W4A16_AWQ, FP8, W8A8_SQ_PER_CHANNEL, W4A8_AWQ}
```

**`examples/quantization/quantize.py`** exposes `int8_sq` as a supported `--qformat` choice (line 74) and includes it in the auto-quantization algorithm options (line 135).

A simple `grep` confirms the docs page has no mention at all:
```bash
$ grep -i "W8A8\|SmoothQuant\|int8_sq" docs/source/features/quantization.md
# (no output)
```

## Changes

1. Added `W8A8 SmoothQuant (INT8)` to the recipe overview list
2. Added a usage subsection under "Offline Quantization with ModelOpt" showing how to use `int8_sq` via `quantize.py`

This brings the docs in line with the existing W4A16 AWQ / W4A8 AWQ / FP8 entries on the same page, which all have usage examples showing the `quantize.py` invocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for W8A8 SmoothQuant (INT8) as a new quantization recipe option
  * Includes detailed explanation of what the technique achieves and how it works
  * Provides step-by-step offline quantization example with command reference for users
  * Enhances documentation coverage for TensorRT-LLM quantization capabilities and available techniques

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14494?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->