### PR TITLE
[None][docs] Add deprecation notice to legacy support-matrix.md

### DIFF
--- a/docs/source/legacy/reference/support-matrix.md
+++ b/docs/source/legacy/reference/support-matrix.md
@@ -1,5 +1,9 @@
 # Support Matrix
 
+```{deprecated}
+This page is outdated and no longer maintained. Please refer to the up-to-date [Supported Models](../../models/supported-models.md) page instead.
+```
+
 TensorRT-LLM optimizes the performance of a range of well-known models on NVIDIA GPUs. The following sections provide a list of supported GPU architectures as well as important features implemented in TensorRT-LLM.
 
 ## Models (PyTorch Backend)


### PR DESCRIPTION
## Background

`docs/source/legacy/reference/support-matrix.md` is a legacy page that is still publicly accessible and indexed, but it lacks any indication that it is outdated. Users landing on this page may act on stale information — for example, the page is missing 15+ architectures that are present in the current `docs/source/models/supported-models.md`.

Compared with the current supported-models page, the legacy support-matrix is missing entries like: Llama 4, Qwen 3, Gemma 3, Phi 4, DeepSeek-R1, EXAONE 4.0, and many others.

## Changes

Added a `{deprecated}` admonition at the top of the page, pointing users to the up-to-date `docs/source/models/supported-models.md` page:

```md
\`\`\`{deprecated}
This page is outdated and no longer maintained. Please refer to the up-to-date [Supported Models](../../models/supported-models.md) page instead.
\`\`\`
```

This follows the Sphinx `{deprecated}` directive convention and renders visibly in the built documentation without removing or altering any existing content on the page.

## Verification

Confirmed the legacy page has no deprecation notice:
```bash
$ head -5 docs/source/legacy/reference/support-matrix.md
# Support Matrix
TensorRT-LLM optimizes the performance of a range of well-known models...
```

Confirmed the current page exists at the linked path:
```bash
$ ls docs/source/models/supported-models.md
docs/source/models/supported-models.md
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Marked the legacy support matrix documentation as deprecated, with a notice directing users to the updated "Supported Models" reference page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->