### PR TITLE
[None][chore] Update flashinfer-python from 0.6.11.post1 to 0.6.12rc1

### DIFF
--- a/ATTRIBUTIONS-Python.md
+++ b/ATTRIBUTIONS-Python.md
@@ -5261,7 +5261,7 @@ For more information, please refer to <http://unlicense.org>
   - `Tracker`: https://github.com/tox-dev/py-filelock/issues
 
 
-## flashinfer-python (0.6.11.post1)
+## flashinfer-python (0.6.12rc1)
 
 ### Licenses
 License: `Apache-2.0`

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ ordered-set
 peft>=0.18.1,<0.19.0
 patchelf
 einops
-flashinfer-python==0.6.11.post1
+flashinfer-python @ git+https://github.com/flashinfer-ai/flashinfer.git@v0.6.12rc1#egg=flashinfer-python
 opencv-python-headless
 xgrammar==0.1.32
 llguidance==0.7.29

--- a/security_scanning/pyproject.toml
+++ b/security_scanning/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "peft (>=0.18.1,<0.19.0)",
     "patchelf (>=0.17.2.4,<0.18.0.0)",
     "einops (>=0.8.2,<0.9.0)",
-    "flashinfer-python (==0.6.11.post1)",
+    "flashinfer-python (==0.6.12rc1)",
     "opencv-python-headless (>=4.13.0.92,<5.0.0.0)",
     "xgrammar (==0.1.32)",
     "llguidance (==0.7.29)",


### PR DESCRIPTION
## Summary
- Bump flashinfer-python from 0.6.11.post1 to 0.6.12rc1
- 0.6.12rc1 is not yet published to PyPI, so `requirements.txt` pins to the GitHub tag via `git+https://github.com/flashinfer-ai/flashinfer.git@v0.6.12rc1`
- Updated version pins in `requirements.txt`, `security_scanning/pyproject.toml`, and `ATTRIBUTIONS-Python.md`
- `security_scanning/poetry.lock` intentionally left untouched (RC has no PyPI hashes); maintainers regenerate it separately

## Test plan
- [x] `pip install -r requirements.txt` installs successfully (requires building flashinfer from source)
- [x] `pytest tests/unittest/_torch/flashinfer/ -v`
- [x] `pytest tests/unittest/_torch/attention/test_flashinfer_attention.py -v`
- [x] CI pre-merge passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated flashinfer-python dependency to v0.6.12rc1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14512?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->