### PR TITLE
[None][feat] Default DSv4 indexer K cache to FP4

### DIFF
--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -709,13 +709,14 @@ class ModelConfig(Generic[TConfig]):
                 index_topk = pretrained_config.index_topk
                 indexer_max_chunk_size = None
                 skip_indexer_for_short_seqs = True
-                # Defaults match DeepSeekSparseAttentionConfig field defaults.
+                # Defaults match DeepSeekV4SparseAttentionConfig field defaults.
                 use_cute_dsl_topk = False
                 use_cute_dsl_paged_mqa_logits = False
                 q_split_threshold = 8192
                 indexer_rope_interleave = False
                 enable_heuristic_topk = False
-                indexer_k_dtype = "fp8"
+                indexer_k_dtype = DeepSeekV4SparseAttentionConfig.model_fields[
+                    'indexer_k_dtype'].default
             indexer_config = {}
             indexer_config['index_n_heads'] = index_n_heads
             indexer_config['index_head_dim'] = index_head_dim

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -410,6 +410,13 @@ class DeepSeekSparseAttentionConfig(BaseSparseAttentionConfig):
 class DeepSeekV4SparseAttentionConfig(DeepSeekSparseAttentionConfig):
     """Configuration for DeepSeek-V4 Sparse Attention."""
     algorithm: Literal["deepseek_v4"] = "deepseek_v4"
+    indexer_k_dtype: Literal["fp8", "fp4"] = Field(
+        default="fp4",
+        description=
+        "Data type used for the indexer K cache. DeepSeek-V4 defaults to "
+        "`fp4` to reduce the per-token indexer K footprint on Blackwell+ "
+        "(SM>=100). Set to `fp8` for the legacy FP8 indexer K cache path.",
+    )
     skip_indexer_for_short_seqs: bool = Field(
         default=False,
         description=

--- a/tests/unittest/_torch/attention/sparse/deepseek_v4/test_compressor_module.py
+++ b/tests/unittest/_torch/attention/sparse/deepseek_v4/test_compressor_module.py
@@ -752,10 +752,12 @@ class CompressorWrapper:
         compress_ratios = [compress_ratio]
 
         # Create sparse attention config
+        indexer_k_dtype = "fp8" if self.kv_cache_dtype == "fp8_blockwise" else "fp4"
         sparse_attn_config = DeepSeekV4SparseAttentionConfig(
             index_head_dim=INDEX_HEAD_DIM,
             window_size=self.WINDOW_SIZE,
             compress_ratios=compress_ratios,
+            indexer_k_dtype=indexer_k_dtype,
         )
 
         # Create KV cache config

--- a/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
+++ b/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
@@ -95,7 +95,6 @@ class TestDeepseekV4CacheManager:
     # indexer quantization config
     indexer_dtype = DataType.FP8
     indexer_scale_dtype = DataType.FLOAT
-    indexer_quant_block_size = 128
 
     # cache manager specific param
     tokens_per_block = 128
@@ -172,14 +171,19 @@ class TestDeepseekV4CacheManager:
         tp_size: int = 1,
         enable_attention_dp: bool = False,
         spec_config: object | None = None,
+        indexer_k_dtype: str | None = None,
     ) -> Tuple[DeepseekV4CacheManager, DeepSeekV4SparseAttentionConfig]:
         """Helper to create a DeepseekV4CacheManager for testing."""
 
         # Create sparse attention config
+        config_kwargs = {}
+        if indexer_k_dtype is not None:
+            config_kwargs["indexer_k_dtype"] = indexer_k_dtype
         sparse_attn_config = DeepSeekV4SparseAttentionConfig(
             index_head_dim=self.index_head_dim,
             window_size=self.window_size,
             compress_ratios=compress_ratios,
+            **config_kwargs,
         )
 
         # Create KV cache config
@@ -303,15 +307,16 @@ class TestDeepseekV4CacheManager:
                 )
 
             if self._is_sparse_layer(ratio):
-                # indexer kv cache is blockwise FP8 quantized
+                # Indexer KV cache stores raw quantized bytes plus raw scale bytes.
                 indexer_dim = sparse_attn_config.index_head_dim
                 indexer_num_tokens = seq_len // ratio
-                num_scales = indexer_dim // self.indexer_quant_block_size
+                indexer_k_dtype = sparse_attn_config.indexer_k_dtype
+                value_dim, scale_dim, scale_dtype = self._indexer_cache_layout(indexer_k_dtype)
                 indexer_values = self._rand_tensor(
-                    (indexer_num_tokens, indexer_dim), torch.uint8, device
+                    (indexer_num_tokens, value_dim), torch.uint8, device
                 )
                 indexer_scales = self._rand_tensor(
-                    (indexer_num_tokens, num_scales), torch.float32, device
+                    (indexer_num_tokens, scale_dim), scale_dtype, device
                 )
                 cache[layer, DeepseekV4AttentionType.INDEXER_COMPRESS] = (
                     indexer_values,
@@ -330,32 +335,41 @@ class TestDeepseekV4CacheManager:
 
         return cache
 
-    def _split_blockwise_buffer(self, buffer: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Split a blockwise FP8 quantized buffer into value and scale buffers.
+    def _indexer_cache_layout(self, indexer_k_dtype: str) -> Tuple[int, int, torch.dtype]:
+        if indexer_k_dtype == "fp8":
+            return self.index_head_dim, self.index_head_dim // 128, torch.float32
+        if indexer_k_dtype == "fp4":
+            return self.index_head_dim // 2, self.index_head_dim // 32, torch.uint8
+        raise ValueError(f"Unsupported indexer_k_dtype {indexer_k_dtype!r}")
+
+    def _split_blockwise_buffer(
+        self,
+        buffer: torch.Tensor,
+        indexer_k_dtype: str,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Split an indexer K cache buffer into value and scale buffers.
 
         Args:
-            buffer: The blockwise FP8 quantized buffer (shape: [num_blocks, tokens_per_block, bytes_per_token])
+            buffer: The raw indexer K cache buffer.
 
         Returns:
             Tuple of (value_buffer, scale_buffer)
         """
         num_blocks, tokens_per_block, bytes_per_token = buffer.shape
         bytes_per_block = bytes_per_token * tokens_per_block
+        value_dim, scale_dim, scale_dtype = self._indexer_cache_layout(indexer_k_dtype)
+        scale_bytes = scale_dim * scale_dtype.itemsize
 
         # Get value buffer
-        value_shape = (num_blocks, tokens_per_block, self.index_head_dim)
-        value_stride = (bytes_per_block, self.index_head_dim, 1)
+        value_shape = (num_blocks, tokens_per_block, value_dim)
+        value_stride = (bytes_per_block, value_dim, 1)
         value_buffer = buffer.as_strided(value_shape, value_stride, 0).view(torch.uint8)
 
         # Get scale buffer
-        scale_dim = self.index_head_dim // self.indexer_quant_block_size
-        scale_bytes = scale_dim * 4  # float32 = 4 bytes
         scale_shape = (num_blocks, tokens_per_block, scale_bytes)
         scale_stride = (bytes_per_block, scale_bytes, 1)
-        scale_offset = self.index_head_dim * tokens_per_block
-        scale_buffer = buffer.as_strided(scale_shape, scale_stride, scale_offset).view(
-            torch.float32
-        )
+        scale_offset = value_dim * tokens_per_block
+        scale_buffer = buffer.as_strided(scale_shape, scale_stride, scale_offset).view(scale_dtype)
 
         return value_buffer, scale_buffer
 
@@ -601,8 +615,9 @@ class TestDeepseekV4CacheManager:
 
             buffer = _view_fp8_as_uint8(cache_manager.get_buffers(layer_idx, attn_type))
             if attn_type == DeepseekV4AttentionType.INDEXER_COMPRESS:
-                # indexer compress is blockwise FP8 quantized
-                values_buffer, scales_buffer = self._split_blockwise_buffer(buffer)
+                values_buffer, scales_buffer = self._split_blockwise_buffer(
+                    buffer, cache_manager._indexer_k_dtype
+                )
                 self._prefill_write_paged_cache(
                     buffer=values_buffer,
                     block_indices=page_indices,
@@ -656,7 +671,9 @@ class TestDeepseekV4CacheManager:
 
             buffer = _view_fp8_as_uint8(cache_manager.get_buffers(layer_idx, attn_type))
             if attn_type == DeepseekV4AttentionType.INDEXER_COMPRESS:
-                values_buffer, scales_buffer = self._split_blockwise_buffer(buffer)
+                values_buffer, scales_buffer = self._split_blockwise_buffer(
+                    buffer, cache_manager._indexer_k_dtype
+                )
                 self._decode_write_paged_cache(
                     buffer=values_buffer,
                     block_indices=block_indices,
@@ -734,7 +751,9 @@ class TestDeepseekV4CacheManager:
 
                 buffer = _view_fp8_as_uint8(cache_manager.get_buffers(layer, attn_type))
                 if attn_type == DeepseekV4AttentionType.INDEXER_COMPRESS:
-                    values_buffer, scales_buffer = self._split_blockwise_buffer(buffer)
+                    values_buffer, scales_buffer = self._split_blockwise_buffer(
+                        buffer, cache_manager._indexer_k_dtype
+                    )
                     values = self._read_paged_cache(
                         buffer=values_buffer,
                         block_indices=page_indices,
@@ -830,7 +849,7 @@ class TestDeepseekV4CacheManager:
                 )
 
     def test_indexer_cache_layout_default(self):
-        """Indexer compressor cache: FP8 blockwise (128 fp8 + per-128 fp32 scale)."""
+        """DeepSeek-V4 defaults to FP4 indexer K cache on Blackwell+."""
         cache_manager, _ = self._create_deepseek_v4_cache_manager(
             tokens_per_block=self.tokens_per_block,
             max_batch_size=1,
@@ -838,6 +857,25 @@ class TestDeepseekV4CacheManager:
             compress_ratios=[4],
             dtype=DataType.BF16,
             compressor_dtype=DataType.FLOAT,
+        )
+        try:
+            buffer = cache_manager.get_buffers(0, DeepseekV4AttentionType.INDEXER_COMPRESS)
+            assert buffer.dtype == torch.uint8
+            assert buffer.shape[-1] == 64 + 4
+            assert cache_manager.quant_block_size == 32
+        finally:
+            cache_manager.shutdown()
+
+    def test_indexer_cache_layout_fp8(self):
+        """The legacy FP8 blockwise indexer K cache remains available."""
+        cache_manager, _ = self._create_deepseek_v4_cache_manager(
+            tokens_per_block=self.tokens_per_block,
+            max_batch_size=1,
+            max_seq_len=512,
+            compress_ratios=[4],
+            dtype=DataType.BF16,
+            compressor_dtype=DataType.FLOAT,
+            indexer_k_dtype="fp8",
         )
         try:
             buffer = cache_manager.get_buffers(0, DeepseekV4AttentionType.INDEXER_COMPRESS)

--- a/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_fp4_indexer.py
+++ b/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_fp4_indexer.py
@@ -40,9 +40,9 @@ from tensorrt_llm.llmapi.llm_args import (
 # ---------------------------------------------------------------------------
 
 
-def test_indexer_k_dtype_default_is_fp8():
+def test_indexer_k_dtype_default_is_fp4():
     cfg = DeepSeekV4SparseAttentionConfig()
-    assert cfg.indexer_k_dtype == "fp8"
+    assert cfg.indexer_k_dtype == "fp4"
 
 
 def test_indexer_k_dtype_accepts_fp4():

--- a/tests/unittest/_torch/attention/sparse/test_sparse_mla_forward.py
+++ b/tests/unittest/_torch/attention/sparse/test_sparse_mla_forward.py
@@ -2198,12 +2198,13 @@ def test_forward_sparse_mla_unified(batch_name, kv_cache_dtype: str,
                 )
 
         if sparse_attn_algo == "deepseek_v4":
+            min_topk_overlap = 0.90 if sparse_config.indexer_k_dtype == "fp4" else 0.95
             topk_mismatch = get_deepseek_v4_topk_mismatch(
                 topk_indices_local, reference_topk_indices_local)
             topk_overlap_mismatch = get_deepseek_v4_topk_overlap_mismatch(
                 topk_indices_local,
                 reference_topk_indices_local,
-                min_overlap=0.95,
+                min_overlap=min_topk_overlap,
             )
             if topk_overlap_mismatch is not None:
                 if topk_mismatch is not None:
@@ -2213,7 +2214,7 @@ def test_forward_sparse_mla_unified(batch_name, kv_cache_dtype: str,
                 print("  ✓ Indexer top-k matches independent reference")
             else:
                 print("  ✓ Indexer top-k overlap with independent "
-                      "reference is at least 0.95")
+                      f"reference is at least {min_topk_overlap}")
                 print(f"  ! {topk_mismatch}")
 
         if (sparse_attn_algo == "deepseek_v4"

--- a/tests/unittest/_torch/attention/sparse/test_sparse_mla_forward.py
+++ b/tests/unittest/_torch/attention/sparse/test_sparse_mla_forward.py
@@ -2198,7 +2198,13 @@ def test_forward_sparse_mla_unified(batch_name, kv_cache_dtype: str,
                 )
 
         if sparse_attn_algo == "deepseek_v4":
-            min_topk_overlap = 0.90 if sparse_config.indexer_k_dtype == "fp4" else 0.95
+            if sparse_config.indexer_k_dtype == "fp4":
+                # FP4 indexer K cache is expected to have lower top-k overlap
+                # with the bf16 reference, especially in the long-context mixed
+                # batch that validates routing rather than exact output.
+                min_topk_overlap = 0.85 if batch_name == "large_mixed_deepseek_v4" else 0.90
+            else:
+                min_topk_overlap = 0.95
             topk_mismatch = get_deepseek_v4_topk_mismatch(
                 topk_indices_local, reference_topk_indices_local)
             topk_overlap_mismatch = get_deepseek_v4_topk_overlap_mismatch(

--- a/tests/unittest/_torch/attention/sparse/test_sparse_mla_forward.py
+++ b/tests/unittest/_torch/attention/sparse/test_sparse_mla_forward.py
@@ -30,7 +30,8 @@ from tensorrt_llm._torch.attention_backend.interface import (
     AttentionBackend, PositionalEmbeddingParams, RopeParams)
 from tensorrt_llm._torch.attention_backend.sparse.deepseek_v4 import \
     DeepseekV4CacheManager
-from tensorrt_llm._torch.attention_backend.sparse.dsa import DSACacheManager
+from tensorrt_llm._torch.attention_backend.sparse.dsa import (HAS_FAST_HADAMARD,
+                                                              DSACacheManager)
 from tensorrt_llm._torch.attention_backend.utils import get_attention_backend
 from tensorrt_llm._torch.metadata import KVCacheParams
 from tensorrt_llm._torch.model_config import ModelConfig
@@ -46,6 +47,8 @@ from tensorrt_llm.models.modeling_utils import QuantConfig
 from tensorrt_llm.quantization.mode import QuantAlgo
 
 from .deepseek_v4.test_compressor_module import RefCompressor
+from .deepseek_v4.test_compressor_module import \
+    rotate_activation as ref_rotate_activation
 
 # DSACacheManager creates background ThreadPoolExecutor threads.
 pytestmark = pytest.mark.threadleak(enabled=False)
@@ -280,6 +283,78 @@ def _topk_from_scores(scores: torch.Tensor, topk_tokens: int) -> torch.Tensor:
     return row
 
 
+def _ceil_pow2_scale(amax: torch.Tensor, max_value_inv: float,
+                     min_amax: float) -> torch.Tensor:
+    scaled = torch.clamp(amax.float(), min=min_amax) * max_value_inv
+    bits = scaled.contiguous().view(torch.int32)
+    exp_part = ((bits >> 23) & 0xFF) - 127
+    has_mantissa = (bits & 0x7FFFFF).ne(0).to(torch.int32)
+    log2_ceil = exp_part + has_mantissa
+    pow2_bits = (log2_ceil + 127) << 23
+    return pow2_bits.view(torch.float32)
+
+
+def _e2m1_nibbles_reference(x: torch.Tensor,
+                            round_ties_to_even: bool) -> torch.Tensor:
+    thresholds = torch.tensor([0.0, 0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0],
+                              device=x.device)
+    abs_x = x.abs().clamp(max=6.0)
+    idx = torch.zeros_like(abs_x, dtype=torch.uint8)
+    for level_idx in range(1, 8):
+        take_upper = abs_x > thresholds[level_idx]
+        if round_ties_to_even:
+            take_upper = take_upper | ((abs_x == thresholds[level_idx]) &
+                                       (level_idx % 2 == 0))
+        idx = torch.where(take_upper, torch.full_like(idx, level_idx), idx)
+    sign = torch.signbit(x).to(torch.uint8) << 3
+    return idx | sign
+
+
+def _mxfp4_quant_dequant_reference(
+    x: torch.Tensor,
+    *,
+    round_ties_to_even: bool,
+    min_amax: float,
+    block_size: int = 32,
+) -> torch.Tensor:
+    assert x.shape[-1] % block_size == 0
+    fp4_values = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0],
+                              device=x.device,
+                              dtype=torch.float32)
+    orig_shape = x.shape
+    blocks = x.float().reshape(-1, x.shape[-1] // block_size, block_size)
+    scale = _ceil_pow2_scale(blocks.abs().amax(dim=-1, keepdim=True), 1.0 / 6.0,
+                             min_amax)
+    nibbles = _e2m1_nibbles_reference(blocks / scale, round_ties_to_even)
+    value_idx = (nibbles & 0x07).to(torch.int64)
+    values = fp4_values[value_idx]
+    values = torch.where((nibbles & 0x08) != 0, -values, values)
+    return (values * scale).reshape(orig_shape)
+
+
+def _maybe_rotate_for_fp4_indexer(x: torch.Tensor) -> torch.Tensor:
+    if not HAS_FAST_HADAMARD:
+        return x
+    return ref_rotate_activation(x)
+
+
+def _prepare_fp4_indexer_q_reference(q: torch.Tensor) -> torch.Tensor:
+    q = _maybe_rotate_for_fp4_indexer(q)
+    # DSv4 Q uses fused_cat_fp4, whose E2M1 thresholds round ties down.
+    return _mxfp4_quant_dequant_reference(q,
+                                          round_ties_to_even=False,
+                                          min_amax=1.0e-12)
+
+
+def _prepare_fp4_indexer_k_reference(k: torch.Tensor) -> torch.Tensor:
+    k = _maybe_rotate_for_fp4_indexer(k)
+    fp4_min_amax = 6.0 * torch.finfo(torch.float32).tiny
+    # The compressor kernel uses the hardware E2M1 cast, which is RNE.
+    return _mxfp4_quant_dequant_reference(k,
+                                          round_ties_to_even=True,
+                                          min_amax=fp4_min_amax)
+
+
 def _reference_indexer_scores(q: torch.Tensor, k: torch.Tensor,
                               weights: torch.Tensor,
                               softmax_scale: float) -> torch.Tensor:
@@ -317,6 +392,9 @@ def calculate_reference_deepseek_v4_topk_indices(
     apply_rotary_emb(q_ref[..., -indexer.rope_dim:],
                      freqs_cis[position_ids.long()])
     q_ref = q_ref.squeeze(0)
+    use_fp4_indexer = indexer.indexer_k_dtype == "fp4"
+    if use_fp4_indexer:
+        q_ref = _prepare_fp4_indexer_q_reference(q_ref)
 
     weights = F.linear(hidden_states, indexer.weights_proj.weight)
     weights = weights.float() * (indexer.n_heads**-0.5)
@@ -337,10 +415,14 @@ def calculate_reference_deepseek_v4_topk_indices(
 
         if compressed_kv is not None:
             compressed_kv = compressed_kv.squeeze(0)
+            compressed_kv_for_scores = (
+                _prepare_fp4_indexer_k_reference(compressed_kv)
+                if use_fp4_indexer else compressed_kv)
             for token_idx in range(seq_len):
                 valid_len = (token_idx + 1) // compress_ratio
+                k_for_scores = compressed_kv_for_scores[:valid_len]
                 scores = _reference_indexer_scores(q_ref[offset + token_idx],
-                                                   compressed_kv[:valid_len],
+                                                   k_for_scores,
                                                    weights[offset + token_idx],
                                                    indexer.softmax_scale)
                 topk_indices[offset + token_idx] = _topk_from_scores(
@@ -382,8 +464,11 @@ def calculate_reference_deepseek_v4_topk_indices(
         if compressed_kv is None or valid_len == 0:
             continue
 
+        compressed_kv_for_scores = (
+            _prepare_fp4_indexer_k_reference(compressed_kv)
+            if use_fp4_indexer else compressed_kv)
         scores = _reference_indexer_scores(q_ref[token_idx],
-                                           compressed_kv[:valid_len],
+                                           compressed_kv_for_scores[:valid_len],
                                            weights[token_idx],
                                            indexer.softmax_scale)
         topk_indices[token_idx] = _topk_from_scores(scores, topk_tokens)
@@ -2198,13 +2283,7 @@ def test_forward_sparse_mla_unified(batch_name, kv_cache_dtype: str,
                 )
 
         if sparse_attn_algo == "deepseek_v4":
-            if sparse_config.indexer_k_dtype == "fp4":
-                # FP4 indexer K cache is expected to have lower top-k overlap
-                # with the bf16 reference, especially in the long-context mixed
-                # batch that validates routing rather than exact output.
-                min_topk_overlap = 0.85 if batch_name == "large_mixed_deepseek_v4" else 0.90
-            else:
-                min_topk_overlap = 0.95
+            min_topk_overlap = 0.95
             topk_mismatch = get_deepseek_v4_topk_mismatch(
                 topk_indices_local, reference_topk_indices_local)
             topk_overlap_mismatch = get_deepseek_v4_topk_overlap_mismatch(

--- a/tests/unittest/_torch/attention/sparse/test_sparse_mla_forward.py
+++ b/tests/unittest/_torch/attention/sparse/test_sparse_mla_forward.py
@@ -1952,9 +1952,9 @@ def test_forward_sparse_mla_unified(batch_name, kv_cache_dtype: str,
             max_batch_size=1,
             max_seq_len=max_seqlen,
         )
-        # HF DS4 reference does not apply Hadamard rotation in the attention or
-        # indexer compressor path.  TRTLLM may rotate both Q and K before FP8
-        # indexer scoring, but the independent oracle below follows HF math.
+        # The base DS4 compressor references follow HF math without Hadamard
+        # rotation. FP4 indexer scoring separately applies the TRTLLM Q/K
+        # rotation and MXFP4 QDQ before computing reference top-k.
         ref_compressor = RefCompressor(ref_args,
                                        compress_ratios[layer_idx],
                                        pretrained_config.head_size,

--- a/tests/unittest/_torch/modeling/test_modeling_deepseekv4.py
+++ b/tests/unittest/_torch/modeling/test_modeling_deepseekv4.py
@@ -617,6 +617,26 @@ def test_deepseek_v4_sparse_ratios_prefer_checkpoint_defaults(tmp_path, monkeypa
     assert model_config.sparse_attention_config.window_size == 128
 
 
+def test_deepseek_v4_model_config_defaults_to_fp4_indexer(tmp_path, monkeypatch):
+    checkpoint_ratios = [128, 128, 4, 128, 4, 128, 0, 4]
+    config = DeepseekV4Config(
+        architectures=["DeepseekV4ForCausalLM"],
+        num_hidden_layers=len(checkpoint_ratios),
+        compress_ratios=checkpoint_ratios,
+    )
+    monkeypatch.setattr(
+        "tensorrt_llm._torch.model_config.load_pretrained_config", lambda *args, **kwargs: config
+    )
+
+    model_config = ModelConfig.from_pretrained(
+        str(tmp_path),
+        attn_backend="TRTLLM",
+        moe_backend="TRTLLM",
+    )
+
+    assert model_config.sparse_attention_config.indexer_k_dtype == "fp4"
+
+
 def test_deepseek_v4_sparse_ratios_keep_checkpoint_length_without_mtp(tmp_path, monkeypatch):
     checkpoint_ratios = [128, 128] + [4, 128] * 29 + [0, 4]
     config = DeepseekV4Config(

--- a/tests/unittest/disaggregated/test_deepseek_v4_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_deepseek_v4_kv_transfer.py
@@ -53,7 +53,6 @@ MAX_SEQ_LEN = 512
 MAX_BATCH_SIZE = 16
 VOCAB_SIZE = 129280
 NUM_KV_HEADS = 1
-INDEXER_QUANT_BLOCK_SIZE = 128
 
 
 # DeepSeek-V4 specific ratios (mirrors module constants)
@@ -407,32 +406,43 @@ def _expected_valid_blocks(
 
 def _split_blockwise_buffer(
     buffer: torch.Tensor,
+    indexer_k_dtype: str,
     index_head_dim: int = INDEX_HEAD_DIM,
-    quant_block_size: int = INDEXER_QUANT_BLOCK_SIZE,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Split a blockwise FP8 quantized buffer into value and scale buffers.
+    """Split an indexer K cache buffer into value and scale buffers.
 
     Args:
         buffer: shape [num_blocks, tokens_per_block, bytes_per_token]
+        indexer_k_dtype: "fp8" or "fp4".
 
     Returns:
-        (values_buffer, scales_buffer) where values are uint8 and scales are float32
+        (values_buffer, scales_buffer) with raw uint8 values and dtype-specific scales.
     """
     num_blocks, tokens_per_block, bytes_per_token = buffer.shape
     bytes_per_block = bytes_per_token * tokens_per_block
 
+    if indexer_k_dtype == "fp8":
+        value_dim = index_head_dim
+        scale_dim = index_head_dim // 128
+        scale_dtype = torch.float32
+    elif indexer_k_dtype == "fp4":
+        value_dim = index_head_dim // 2
+        scale_dim = index_head_dim // 32
+        scale_dtype = torch.uint8
+    else:
+        raise ValueError(f"Unsupported indexer_k_dtype {indexer_k_dtype!r}")
+    scale_bytes = scale_dim * scale_dtype.itemsize
+
     # Value buffer
-    value_shape = (num_blocks, tokens_per_block, index_head_dim)
-    value_stride = (bytes_per_block, index_head_dim, 1)
+    value_shape = (num_blocks, tokens_per_block, value_dim)
+    value_stride = (bytes_per_block, value_dim, 1)
     value_buffer = buffer.as_strided(value_shape, value_stride, 0).view(torch.uint8)
 
     # Scale buffer
-    scale_dim = index_head_dim // quant_block_size
-    scale_bytes = scale_dim * 4  # float32 = 4 bytes
     scale_shape = (num_blocks, tokens_per_block, scale_bytes)
     scale_stride = (bytes_per_block, scale_bytes, 1)
-    scale_offset = index_head_dim * tokens_per_block
-    scale_buffer = buffer.as_strided(scale_shape, scale_stride, scale_offset).view(torch.float32)
+    scale_offset = value_dim * tokens_per_block
+    scale_buffer = buffer.as_strided(scale_shape, scale_stride, scale_offset).view(scale_dtype)
 
     return value_buffer, scale_buffer
 
@@ -458,7 +468,7 @@ def _read_cache_data(
         return torch.tensor([]), None
 
     if attn_type == DeepseekV4AttentionType.INDEXER_COMPRESS:
-        values_buf, scales_buf = _split_blockwise_buffer(buffer)
+        values_buf, scales_buf = _split_blockwise_buffer(buffer, mgr._indexer_k_dtype)
         return values_buf[indices], scales_buf[indices]
 
     return buffer[indices], None


### PR DESCRIPTION
@coderabbitai summary

## Description

Change the DeepSeek-V4 sparse attention config so `indexer_k_dtype` defaults to `fp4`. This makes the DSv4 indexer K cache use the lower-footprint FP4 path by default on Blackwell+, while keeping `fp8` available for the legacy path.

## Test Coverage

- `python -m py_compile tensorrt_llm/llmapi/llm_args.py tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_fp4_indexer.py`
- `pre-commit run --files tensorrt_llm/llmapi/llm_args.py tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_fp4_indexer.py`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.