### PR TITLE
[None][fix] kv_cache_manager_v2: count only newly-added scratch blocks in resize

### DIFF
--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -71,6 +71,7 @@ from .._utils import (
     div_up,
     expect_type,
     filled_list,
+    intersect,
     make_typed,
     map_optional,
     stream_wait_events,
@@ -706,7 +707,10 @@ class _KVCache:
                     continue
                 stale_beg, stale_end = stale_ranges[lc]
                 if enable_scratch:
-                    num_scratch_blocks = len(scratch_ranges[lc])
+                    # Only newly added blocks consume slots below; scratch range may
+                    # extend before old_num_blocks when history_length < old_capacity.
+                    new_block_range = HalfOpenRange(old_num_blocks, new_num_blocks)
+                    num_scratch_blocks = len(intersect(scratch_ranges[lc], new_block_range))
                     num_new_normal_blocks = (new_num_blocks - old_num_blocks) - num_scratch_blocks
                     num_new_slots[lc] = num_new_normal_blocks * beam_width
                 else:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -710,8 +710,10 @@ class _KVCache:
                     # Only newly added blocks consume slots below; scratch range may
                     # extend before old_num_blocks when history_length < old_capacity.
                     new_block_range = HalfOpenRange(old_num_blocks, new_num_blocks)
-                    num_scratch_blocks = len(intersect(scratch_ranges[lc], new_block_range))
-                    num_new_normal_blocks = (new_num_blocks - old_num_blocks) - num_scratch_blocks
+                    num_new_blocks_using_scratch = len(
+                        intersect(scratch_ranges[lc], new_block_range)
+                    )
+                    num_new_normal_blocks = len(new_block_range) - num_new_blocks_using_scratch
                     num_new_slots[lc] = num_new_normal_blocks * beam_width
                 else:
                     if old_num_blocks < stale_beg:


### PR DESCRIPTION
## Summary

Fixes `IndexError: pop from empty list` in `KVCache.resize()` when SWA scratch reuse is enabled and `history_length < old_capacity` (rewind window allowed since #14403). Reproduces with DSv4 + MTP + block_reuse.

## Root cause

In [`tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py`](tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py), the `enable_scratch` branch of `resize()` was computing new-slot demand from the **full** `scratch_ranges[lc]`:

```python
num_scratch_blocks = len(scratch_ranges[lc])
num_new_normal_blocks = (new_num_blocks - old_num_blocks) - num_scratch_blocks
num_new_slots[lc] = num_new_normal_blocks * beam_width
```

But the block construction loop below only iterates `[old_num_blocks, new_num_blocks)` and only those blocks pop slots:

```python
for ordinal in typed_range(old_num_blocks, new_num_blocks):
    ...
    if enable_scratch and ordinal in scratch_ranges[lc]:
        continue
    slot = slots[lc].pop()
```

`compute_scratch_range()` derives its lower bound from `history_length`, not from `old_capacity`. After #14403 (`Fix MTP by scratch reuse rewind`), `history_length` is allowed to be smaller than `old_capacity` by up to `max_rewind_len`, so `scratch_ranges[lc]` can start before `old_num_blocks`. When that happens, scratch blocks that sit in the **old** range are still subtracted from the allocation count but are never re-encountered in the construction loop, so the allocation under-requests by exactly that overlap and the loop's `slots[lc].pop()` underflows.

## Concrete example

```text
tokens_per_block = 128
old_capacity     = 1024  -> old_num_blocks = 8
new_capacity     = 1152  -> new_num_blocks = 9
history_length   = 896   -> input_range starts at block 7
scratch_ranges[lc] = [7, 8)        # block 7 is OLD, not newly added
newly added range  = [8, 9)        # construction loop iterates only block 8

old code:    num_new_slots = (9-8) - 1 = 0
loop pops:   block 8 needs 1 slot   -> IndexError
```

## Fix

Intersect `scratch_ranges[lc]` with `[old_num_blocks, new_num_blocks)` before counting, so the request matches what the loop will actually consume.

`_take_excess_scratch_slots` is intentionally unchanged — it sizes the scratch slot pool to serve the full scratch range, not just the newly-added portion.
