### PR TITLE
[None][perf] Optimize DSv4 attention with overlapping computations: more overlap and cuteDSL kernel replace

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py
@@ -1075,12 +1075,44 @@ class DeepseekV4Indexer(Indexer):
         assert k_scale is not None, "FP8 blockwise indexer cache update requires scale tensor"
         self._update_k_cache(k_fp8, k_scale, metadata)
 
+    def precompute_aux(
+        self,
+        hidden_states: torch.Tensor,
+        metadata: DeepseekV4TrtllmAttentionMetadata,
+    ) -> Optional[Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]]:
+        """Pre-launch the qr-independent half of the indexer prepare phase.
+
+        Runs weights_proj + internal compressor + k_cache_update on
+        ``self.aux_stream`` and records ``weights_proj_event`` /
+        ``k_cache_update_event``.  The caller hands the returned tuple back to
+        ``forward()`` via the ``pre_aux`` kwarg, which makes the overlapped
+        prepare path skip its own aux-stream launch and consume these results
+        directly.
+
+        Returns ``None`` when multi-stream mode is off (caller should fall
+        back to the normal ``forward()`` call without ``pre_aux``).
+        """
+        if not (do_multi_stream() and self.aux_stream is not None):
+            return None
+        self.indexer_start_event.record()
+        with torch.cuda.stream(self.aux_stream):
+            self.indexer_start_event.wait()
+            weights = self.weights_proj(hidden_states)
+            self.weights_proj_event.record()
+            k_fp8, k_scale = self.compressor(hidden_states, metadata)
+            self._update_k_cache_if_needed(k_fp8, k_scale, metadata)
+            self.k_cache_update_event.record()
+        return (weights, k_fp8, k_scale)
+
     def _run_overlapped_indexer_prepare(
         self,
         qr: torch.Tensor,
         hidden_states: torch.Tensor,
         metadata: DeepseekV4TrtllmAttentionMetadata,
         position_ids: torch.Tensor,
+        pre_aux: Optional[
+            Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]
+        ] = None,
     ) -> Tuple[
         torch.Tensor, torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor], torch.Tensor
     ]:
@@ -1090,7 +1122,12 @@ class DeepseekV4Indexer(Indexer):
         the recorded launch point and owns weights projection, compressor, and
         the K-cache update.
 
-        Timeline:
+        When ``pre_aux`` is provided the aux-stream work has already been
+        launched (and ``weights_proj_event`` / ``k_cache_update_event``
+        recorded) by ``precompute_aux``; the aux-stream block here is skipped
+        and the precomputed tensors are consumed directly.
+
+        Timeline (pre_aux=None):
             current stream:
                 record indexer_start_event
                 q_proj + RoPE -> quant_q
@@ -1108,19 +1145,23 @@ class DeepseekV4Indexer(Indexer):
             weights_proj --------------------> weight_scale
             compressor -> update_k_cache ----> final wait
         """
-        self.indexer_start_event.record()
+        if pre_aux is None:
+            self.indexer_start_event.record()
 
-        q = self._qk_projection_and_rope(qr, position_ids)
+            q = self._qk_projection_and_rope(qr, position_ids)
 
-        with torch.cuda.stream(self.aux_stream):
-            self.indexer_start_event.wait()
+            with torch.cuda.stream(self.aux_stream):
+                self.indexer_start_event.wait()
 
-            weights = self.weights_proj(hidden_states)
-            self.weights_proj_event.record()
+                weights = self.weights_proj(hidden_states)
+                self.weights_proj_event.record()
 
-            k_fp8, k_scale = self.compressor(hidden_states, metadata)
-            self._update_k_cache_if_needed(k_fp8, k_scale, metadata)
-            self.k_cache_update_event.record()
+                k_fp8, k_scale = self.compressor(hidden_states, metadata)
+                self._update_k_cache_if_needed(k_fp8, k_scale, metadata)
+                self.k_cache_update_event.record()
+        else:
+            weights, k_fp8, k_scale = pre_aux
+            q = self._qk_projection_and_rope(qr, position_ids)
 
         q_fp8, q_scale = self._quantize_q(q)
 
@@ -1167,12 +1208,20 @@ class DeepseekV4Indexer(Indexer):
         hidden_states: torch.Tensor,
         metadata: DeepseekV4TrtllmAttentionMetadata,
         position_ids: torch.Tensor,
+        pre_aux: Optional[
+            Tuple[torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]
+        ] = None,
     ):
         if do_multi_stream() and self.aux_stream is not None:
             q_fp8, q_scale, k_fp8, k_scale, weights = self._run_overlapped_indexer_prepare(
-                qr, hidden_states, metadata, position_ids
+                qr,
+                hidden_states,
+                metadata,
+                position_ids,
+                pre_aux=pre_aux,
             )
         else:
+            assert pre_aux is None, "pre_aux requires multi-stream mode"
             q_fp8, q_scale, k_fp8, k_scale, weights = self._run_serial_indexer_prepare(
                 qr, hidden_states, metadata, position_ids
             )

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1174,6 +1174,39 @@ def fp8_block_scaling_bmm_out(
         raise NotImplementedError(f"SM{sm_version} is not supported")
 
 
+_q_b_proj_cute_dsl_import_ok: Optional[bool] = None
+
+
+def _q_b_proj_cute_dsl_bf16(q: torch.Tensor,
+                            weight: torch.Tensor) -> torch.Tensor:
+    """BF16 dense GEMM via CuTe DSL.
+
+    Computes ``q @ weight.T`` for [M, K] @ [N, K]^T -> [M, N].
+
+    Delegates to ``torch.ops.trtllm.cute_dsl_bf16_gemm_blackwell`` (which
+    runs its own autotune over (use_2cta, mma_tiler, cluster_shape)). Falls
+    back to ``torch.nn.functional.linear`` if CuTe DSL is unavailable.
+    """
+    global _q_b_proj_cute_dsl_import_ok
+    if _q_b_proj_cute_dsl_import_ok is None:
+        try:
+            from ..cute_dsl_utils import IS_CUTLASS_DSL_AVAILABLE
+            _q_b_proj_cute_dsl_import_ok = IS_CUTLASS_DSL_AVAILABLE
+        except Exception:
+            _q_b_proj_cute_dsl_import_ok = False
+    if not _q_b_proj_cute_dsl_import_ok or not is_sm_100f():
+        return torch.nn.functional.linear(q, weight)
+
+    assert q.dtype == torch.bfloat16 and weight.dtype == torch.bfloat16, \
+        "q_b_proj cute_dsl path requires bfloat16 inputs"
+    q = q.contiguous()
+    weight = weight.contiguous()
+    m, n = q.shape[0], weight.shape[0]
+    out = q.new_empty((m, n), dtype=torch.bfloat16)
+    torch.ops.trtllm.cute_dsl_bf16_gemm_blackwell(q, weight, out)
+    return out
+
+
 class MLA(nn.Module):
 
     def __init__(
@@ -2306,7 +2339,36 @@ class MLA(nn.Module):
         qr = q
         latent_cache = torch.concat([compressed_kv, k_pe], dim=-1)
 
+        # CuTe DSL path for q_b_proj (hardware-default cluster count).
+        # Restricted to DSv4 CSA layers with compress_ratio=4 so the kernel
+        # swap only kicks in where the prologue overlap is exercised — other
+        # layers keep the cuBLAS path. Set TRTLLM_MLA_Q_B_PROJ_USE_CUTE_DSL=0
+        # to disable. Bias / quantization not handled.
+        _use_q_b_cute = (self.has_dsv4_indexer and os.environ.get(
+            "TRTLLM_MLA_Q_B_PROJ_USE_CUTE_DSL", "1") == "1"
+                         and self.q_b_proj.bias is None
+                         and self.q_b_proj.weight.dtype == torch.bfloat16)
+
         def _q_branch():
+            # CuTe DSL bf16 path is bench-only and intentionally bypasses the
+            # FP8-fused-quant branch (weights are bf16, so the fused FP8 path
+            # would never apply anyway — but assert to make the contract
+            # explicit and catch any future config drift).
+            if _use_q_b_cute:
+                assert not self._is_fused_q_fp8_quant_enabled(
+                    num_generations=num_generations), (
+                        "CuTe DSL q_b_proj path is incompatible with the "
+                        "fused FP8 q-quant branch")
+                q_proj = _q_b_proj_cute_dsl_bf16(q, self.q_b_proj.weight)
+                # Cross-iter cleanup: forward_absorption_* downstream gates
+                # the fused-FP8 attention path on these attrs being non-None
+                # (see _fused_quant_q_buffer/_fused_q_pe readers below). The
+                # FP8 path can't actually trigger when weights are bf16, but
+                # clear them anyway so a stale buffer from a different code
+                # path can never silently re-enable fusion.
+                self._fused_quant_q_buffer = None
+                self._fused_q_pe = None
+                return self._deepseek_v4_q_b_layernorm(q_proj)
             q_proj = self.q_b_proj(q)
             if self._is_fused_q_fp8_quant_enabled(
                     num_generations=num_generations):

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1484,10 +1484,12 @@ class MLA(nn.Module):
             and config.sparse_attention_config.compress_ratios[layer_idx] == 4)
         self.indexer_stream = None
         self.indexer_aux_stream = None
+        self.compressor_stream = None
         if self.has_dsv4_indexer and aux_stream is not None:
             self.indexer_stream = torch.cuda.Stream(device=aux_stream.device)
             self.indexer_aux_stream = torch.cuda.Stream(
                 device=aux_stream.device)
+            self.compressor_stream = torch.cuda.Stream(device=aux_stream.device)
         mqa_aux_stream = (self.indexer_aux_stream if self.indexer_aux_stream
                           is not None else aux_stream)
 
@@ -1521,6 +1523,7 @@ class MLA(nn.Module):
         self.aux_stream = aux_stream
         self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
         self.dsv4_overlap_start_event = torch.cuda.Event()
+        self.dsv4_compressor_start_event = torch.cuda.Event()
         self.dsv4_compressor_event = torch.cuda.Event()
         self.dsv4_indexer_event = torch.cuda.Event()
 
@@ -2247,6 +2250,47 @@ class MLA(nn.Module):
         if position_ids is not None:
             position_ids = position_ids[..., :num_tokens]
 
+        # TRTLLM_MLA_EXTRA_OVERLAP=1 reorders the V4 attention prologue so the
+        # outer compressor and the ratio-4 indexer can execute concurrently
+        # with q_b_proj + q_b_layernorm. The indexer is launched on a
+        # dedicated stream and still uses a different aux stream for its
+        # internal q-proj/weights-proj split.
+        _v4_extra_overlap = (os.environ.get("TRTLLM_MLA_EXTRA_OVERLAP", "1")
+                             == "1" and self.compressor is not None
+                             and self.aux_stream is not None)
+        _use_indexer_overlap = (_v4_extra_overlap and do_multi_stream()
+                                and self.indexer is not None
+                                and self.indexer_stream is not None)
+
+        # Pre-launch the outer compressor on compressor_stream BEFORE
+        # kv_a_proj_with_mqa. The compressor only reads hidden_states +
+        # attn_metadata, so it has no data dependency on the kv_a_proj GEMM or
+        # the downstream q_a/kv_a LN split. A dedicated stream (not aux_stream)
+        # keeps kv_a_layernorm free to run on aux_stream in parallel.
+        # _q_branch will be queued onto this same stream further down so it
+        # runs strictly serial after the compressor; dsv4_compressor_event is
+        # recorded only at the end of _q_branch, gating the caller's downstream
+        # waits on both compressor + _q_branch completion.
+        if _use_indexer_overlap:
+            self.dsv4_compressor_start_event.record()
+            with torch.cuda.stream(self.compressor_stream):
+                self.dsv4_compressor_start_event.wait()
+                self.compressor(hidden_states, attn_metadata)
+
+        # Pre-launch the qr-independent half of the indexer prepare phase
+        # (weights_proj + internal compressor + k_cache_update) on the
+        # indexer's aux stream (self.indexer_aux_stream — wired into the
+        # indexer module as its aux_stream). Only reads hidden_states +
+        # attn_metadata, so it can overlap with the kv_a_proj → LN → split
+        # chain on the caller stream and the outer compressor on
+        # compressor_stream. The returned tuple is fed back into
+        # self.indexer() via pre_aux so the later _indexer_branch skips its
+        # own aux-stream launch.
+        _indexer_pre_aux = None
+        if _use_indexer_overlap:
+            _indexer_pre_aux = self.indexer.precompute_aux(
+                hidden_states, attn_metadata)
+
         q, kv = self.kv_a_proj_with_mqa(hidden_states).split(
             [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim], -1)
 
@@ -2261,15 +2305,6 @@ class MLA(nn.Module):
             [self.kv_lora_rank, self.qk_rope_head_dim], -1)
         qr = q
         latent_cache = torch.concat([compressed_kv, k_pe], dim=-1)
-
-        # TRTLLM_MLA_EXTRA_OVERLAP=1 reorders the V4 attention prologue so the
-        # outer compressor and the ratio-4 indexer can execute concurrently
-        # with q_b_proj + q_b_layernorm. The indexer is launched on a
-        # dedicated stream and still uses a different aux stream for its
-        # internal q-proj/weights-proj split.
-        _v4_extra_overlap = (os.environ.get("TRTLLM_MLA_EXTRA_OVERLAP", "1")
-                             == "1" and self.compressor is not None
-                             and self.aux_stream is not None)
 
         def _q_branch():
             q_proj = self.q_b_proj(q)
@@ -2295,21 +2330,20 @@ class MLA(nn.Module):
                 hidden_states,
                 attn_metadata,
                 position_ids,
+                pre_aux=_indexer_pre_aux,
             )
 
         topk_indices = None
         indexer_ran = False
         if _v4_extra_overlap:
-            use_indexer_overlap = (do_multi_stream()
-                                   and self.indexer is not None
-                                   and self.indexer_stream is not None)
-            if use_indexer_overlap:
+            if _use_indexer_overlap:
+                # Compressor + indexer-aux are already in flight from the
+                # pre-launch block above; the indexer-aux tail events
+                # (weights_proj_event, k_cache_update_event) were recorded
+                # there. The outer compressor's tail (dsv4_compressor_event)
+                # is deferred to AFTER _q_branch so the single wait below
+                # gates the caller on both compressor + _q_branch.
                 self.dsv4_overlap_start_event.record()
-
-                with torch.cuda.stream(self.aux_stream):
-                    self.dsv4_overlap_start_event.wait()
-                    _compressor_branch()
-                    self.dsv4_compressor_event.record()
 
                 with torch.cuda.stream(self.indexer_stream):
                     self.dsv4_overlap_start_event.wait()
@@ -2317,7 +2351,17 @@ class MLA(nn.Module):
                     indexer_ran = True
                     self.dsv4_indexer_event.record()
 
-                q = _q_branch()
+                # _q_branch reads qr (post-q_a_layernorm), so it must wait
+                # for dsv4_overlap_start_event before running. Queuing it on
+                # compressor_stream (already holding the outer compressor)
+                # makes compressor → q_b_proj → q_b_layernorm a serial chain
+                # on a single stream, freeing the caller stream from the
+                # heaviest GEMM during the prologue window.
+                with torch.cuda.stream(self.compressor_stream):
+                    self.dsv4_overlap_start_event.wait()
+                    q = _q_branch()
+                    self.dsv4_compressor_event.record()
+
                 self.dsv4_compressor_event.wait()
                 self.dsv4_indexer_event.wait()
             else:


### PR DESCRIPTION
Two prologue optimizations on the DSv4 CSA (compressed sparse attention, `compress_ratio=4`) layer. Other DSv4 layer types are untouched.

**1. Pre-launch the compressor and the qr-independent half of the indexer.**
The outer `compressor` and the indexer's `weights_proj` + internal compression + K-cache update only depend on `hidden_states` / `attn_metadata`, so they no longer need to wait for `kv_a_proj_with_mqa`. They are now launched at the very start of `forward_impl_with_deepseek_v4`, each on its own stream:

- the outer compressor on a new dedicated `compressor_stream`;
- the indexer's qr-independent half on `indexer_aux_stream` via a new `IndexerCachePrefill.precompute_aux` (the precomputed `(weights, k_fp8, k_scale)` is fed back into `indexer()` through a `pre_aux` kwarg so the later `_indexer_branch` skips its own aux-stream launch).

`q_b_proj` + `q_b_layernorm` are then queued onto the same `compressor_stream` strictly serial after the compressor, giving a `(compressor → q_b)` chain that runs concurrently with the indexer on `indexer_stream` and with the `kv_a_proj` → LN chain on the caller stream. Gated by `TRTLLM_MLA_EXTRA_OVERLAP`. [[1]](diffhunk://#diff-1b26d90f33800a00d76f464e52840aca4576b5570d30308b9f22f2b2eca5f66eR1078-R1115) [[2]](diffhunk://#diff-94d88f20ca4a510ea0879428279cc50121223458ccae6090ceba391d1e32a371R1524-R1529) [[3]](diffhunk://#diff-94d88f20ca4a510ea0879428279cc50121223458ccae6090ceba391d1e32a371R2290-R2331) [[4]](diffhunk://#diff-94d88f20ca4a510ea0879428279cc50121223458ccae6090ceba391d1e32a371R2391-R2400)

**2. Swap the `q_b_proj` GEMM kernel so the indexer can actually overlap.**
Even with (1) in place, the cuBLAS `q_b_proj` GEMM consumed nearly all SMs while running, crowding out the indexer kernels on `indexer_stream` and producing a *pseudo* serialization (no real data dep, just SM contention) — so the indexer never truly overlapped.

This PR adds `_q_b_proj_cute_dsl_bf16`, a CSA-only path that swaps `q_b_proj` from `nn.Linear` (cuBLAS) to `torch.ops.trtllm.cute_dsl_bf16_gemm_blackwell`. The CuTe DSL kernel leaves enough SM headroom for the indexer to actually overlap, which is what removes the pseudo serialization. Gated by the new `TRTLLM_MLA_Q_B_PROJ_USE_CUTE_DSL` (default-on; set to `0` to fall back to cuBLAS). The CuTe DSL BF16 GEMM runner / kernel are also extended with an explicit `max_active_clusters` parameter so callers can cap the launch grid for the same kind of SM-budget tuning in the future. [[1]](diffhunk://#diff-94d88f20ca4a510ea0879428279cc50121223458ccae6090ceba391d1e32a371R1177-R1213) [[2]](diffhunk://#diff-94d88f20ca4a510ea0879428279cc50121223458ccae6090ceba391d1e32a371L2265-R2367) [[3]](diffhunk://#diff-5caca2bc89186fb8d40180c5378c4523f0b8e95fadd692bea0b26fccea70477fR6716-R6727) [[4]](diffhunk://#diff-5caca2bc89186fb8d40180c5378c4523f0b8e95fadd692bea0b26fccea70477fR6815-R6827)

---

## Performance — DSv4 CSA attention (single-layer microbenchmark)

**Scope of this PR.** The multi-stream prologue reorder and the CuTe DSL `q_b_proj` path are both behind code branches that only fire on the **CSA (compressed sparse attention) layer** of DSv4. Non-CSA DSv4 attention layers go through the unchanged path and are not affected by this PR — the numbers below therefore only characterize the CSA layer's behavior.

**Setup**

- **Hardware**: 1× NVIDIA B200.
- **Workload**: decode-step microbenchmark of a single DSv4 CSA layer — `num_heads=128`, TP=1, sparse ratio = 4, KV-cache prefill length = 1024 tokens. Sweeps batch size from 1 to 512.
- **What "time" means in the table**: mean per-iter latency of the **whole CSA-layer attention forward** (RMSNorm → `kv_a_proj` / compressor / `q_b_proj` / indexer prologue → FMHA → output projection), measured via CUDA events — **not** the prologue alone.
- **Env**:
  - `TRTLLM_MLA_EXTRA_OVERLAP=1` on both sides. Baseline runs the original prologue layout under this gate (`compressor` on `aux_stream`, `indexer` on `indexer_stream`, `q_b_proj` on the caller stream); opt runs the new layout (`compressor` pre-launched on a dedicated `compressor_stream` before `kv_a_proj`, indexer aux pre-launched via `precompute_aux`, `q_b_proj` queued on `compressor_stream` after the compressor).
  - `TRTLLM_MLA_Q_B_PROJ_USE_CUTE_DSL=1` — a new env introduced by this PR (default-on). Active on the opt side; switches the CSA-layer `q_b_proj` from the `nn.Linear` cuBLAS path to `torch.ops.trtllm.cute_dsl_bf16_gemm_blackwell`. Baseline has no such switch and always uses cuBLAS for `q_b_proj`. Set to `0` to fall back to cuBLAS even on the opt build.
- **Methodology**: 50 warmup + 100 measured iters per shape, no nsys.
- **Compared revisions**: `feat/deepseek_v4` HEAD immediately before this PR's two `[perf]` commits, vs. the same HEAD with this PR applied (multi-stream prologue reorder + CuTe DSL BF16 `q_b_proj`). Both runs back-to-back on the same machine.

**Results — mean whole-attention per-iter latency (ms), CSA layer**

| batch | baseline | **opt** | Δ ms | Δ % |
|---:|---:|---:|---:|---:|
| 1   | 0.091 | **0.087** | -0.004 | **-4.4 %** |
| 2   | 0.099 | **0.088** | -0.011 | **-11.1 %** |
| 4   | 0.105 | **0.092** | -0.013 | **-12.4 %** |
| 8   | 0.101 | **0.097** | -0.004 | **-4.0 %** |
| 16  | 0.102 | **0.099** | -0.003 | **-2.9 %** |
| 32  | 0.112 | **0.105** | -0.007 | **-6.3 %** |
| 64  | 0.113 | **0.103** | -0.010 | **-8.8 %** |
| 128 | 0.145 | **0.130** | -0.015 | **-10.3 %** |
| 192 | 0.163 | **0.156** | -0.007 | **-4.3 %** |
| 256 | 0.183 | **0.169** | -0.014 | **-7.7 %** |
| 320 | 0.210 | **0.209** | -0.001 | **-0.5 %** |
| 384 | 0.229 | **0.223** | -0.006 | **-2.6 %** |
| 448 | 0.255 | **0.248** | -0.007 | **-2.7 %** |
| 512 | 0.276 | **0.268** | -0.008 | **-2.9 %** |

**Observations**

- No regression across the swept range.
- Largest gains (-10 % to -12 %) at b=2 / 4 / 128 where the prologue dominates the iteration.
- Narrows to -1 % to -3 % at b ≥ 320 as FMHA scales with batch and amortizes the (batch-independent) prologue savings.
