### PR TITLE
[None][chore] redact internal NVIDIA URLs from exec-slurm-compile skill

### DIFF
--- a/.claude/skills/exec-slurm-compile/SKILL.md
+++ b/.claude/skills/exec-slurm-compile/SKILL.md
@@ -25,7 +25,7 @@ The official Docker image tag for a given TensorRT-LLM version is recorded in th
 <repo_dir>/jenkins/current_image_tags.properties
 ```
 
-Read this file to find the current image URL (e.g., `urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:pytorch-25.12-py3-aarch64-ubuntu24.04-trt10.14.1.48-skip-tritondevel-202602011118-10901`).
+Read this file to find the current image URL. The format is `<registry-host>/<namespace>/tensorrt-llm:<tag>`, for example `<your-registry>/<your-namespace>/tensorrt-llm:pytorch-25.12-py3-aarch64-ubuntu24.04-trt10.14.1.48-skip-tritondevel-202602011118-10901`. Substitute `<your-registry>` and `<your-namespace>` with your own container registry coordinates.
 
 
 ## Pre-dumping the Container Image (enroot import)
@@ -59,7 +59,7 @@ The script submits an `sbatch` job that runs `enroot import docker://<image_url>
    cd <directory_where_sqsh_should_be_stored>
    <path_to>/enroot-import --partition cpu_datamover --debug <image_url>
    ```
-   **IMPORTANT:** Convert `urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:xxx` to `urm.nvidia.com#sw-tensorrt-docker/tensorrt-llm:xxx` to avoid credential issues.
+   **IMPORTANT:** Replace the first `/` after the registry host with `#` to avoid credential issues. For example, `<your-registry>/<your-namespace>/tensorrt-llm:xxx` becomes `<your-registry>#<your-namespace>/tensorrt-llm:xxx`.
 3. Wait for the import job to complete (`squeue -j <job_id>`).
 4. The resulting `.sqsh` file is the `container_image` used in the compile step.
 

--- a/.claude/skills/exec-slurm-compile/scripts/enroot-import
+++ b/.claude/skills/exec-slurm-compile/scripts/enroot-import
@@ -45,7 +45,8 @@ If you are having trouble, check:
 
    machine <your-registry> login <your-id> password <your-registry-read-token>
    machine nvcr.io login \$oauthtoken password <your-ngc-token>
-   machine authn.nvidia.com login \$oauthtoken password <your-ngc-token>
+   (and one line per additional auth host the registry redirects to, e.g.
+    \"machine <your-auth-host> login \$oauthtoken password <your-ngc-token>\")
 "
 
 getopt --test


### PR DESCRIPTION
## Summary

Fixes #13162.

The `exec-slurm-compile` skill in `.claude/skills/` references three internal NVIDIA infrastructure URLs that shouldn't be in a public-facing skill:

| File | Original | Replacement |
|---|---|---|
| `SKILL.md` (image URL example) | `urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:...` | `<your-registry>/<your-namespace>/tensorrt-llm:...` |
| `SKILL.md` (slash→hash conversion) | `urm.nvidia.com/sw-tensorrt-docker/tensorrt-llm:xxx` → `urm.nvidia.com#sw-tensorrt-docker/tensorrt-llm:xxx` | `<your-registry>/<your-namespace>/tensorrt-llm:xxx` → `<your-registry>#<your-namespace>/tensorrt-llm:xxx` |
| `scripts/enroot-import` (netrc example) | `machine authn.nvidia.com login $oauthtoken password <your-ngc-token>` | Generic note: *"(and one line per additional auth host the registry redirects to, e.g. `machine <your-auth-host> login $oauthtoken password <your-ngc-token>`)"* |

The structural guidance survives image URL format, the slash-to-hash conversion that avoids credential issues with enroot, and the netrc multiple-host pattern without naming internal NVIDIA hostnames.

Verified with `grep -rn "urm.nvidia.com\|authn.nvidia.com" .claude/skills/exec-slurm-compile/` returning nothing.

## Test plan

- [x] Skill file structure and instructional content unchanged (only hostnames swapped for placeholders)
- [x] No remaining `urm.nvidia.com` or `authn.nvidia.com` references in the skill directory
- [x] Diff is 2 files, +4/-3 lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved container image URL formatting guidance with clearer specifications for custom registry and namespace configurations
  * Enhanced enroot registry credential setup instructions with generalized examples supporting multiple authentication hosts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14538?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->