### PR TITLE
[#13561][feat] AutoDeploy: enable MLIR elementwise fusion and trtllm_gen MoE on Nano NVFP4

### DIFF
--- a/examples/auto_deploy/model_registry/configs/nano_v3.yaml
+++ b/examples/auto_deploy/model_registry/configs/nano_v3.yaml
@@ -1,18 +1,11 @@
-runtime: trtllm
-compile_backend: torch-cudagraph
 max_batch_size: 384
 max_seq_len: 65536 # tunable
 enable_chunked_prefill: true
 attn_backend: trtllm
-model_factory: AutoModelForCausalLM
-skip_loading_weights: false
 cuda_graph_config:
   batch_sizes: [1, 2, 4, 8, 16, 24, 32, 64, 128, 256, 320, 384]
 kv_cache_config:
   free_gpu_memory_fraction: 0.88
-  # tunable mamba cache dtype
-  # --> use float32 for accuracy and default (auto) for speed
-  mamba_ssm_cache_dtype: auto
 transforms:
   detect_sharding:
     allreduce_strategy: SYMM_MEM
@@ -42,7 +35,6 @@ transforms:
         "fc1_latent_proj": "gather"
         "fc2_latent_proj": "gather"
   multi_stream_moe:
-    stage: compile
     enabled: true
   gather_logits_before_lm_head:
     # TODO: fix https://github.com/NVIDIA/TensorRT-LLM/issues/9878 to enable by default
@@ -57,7 +49,4 @@ transforms:
   fuse_nvfp4_moe:
     backend: trtllm_gen
   mlir_elementwise_fusion:
-    stage: post_load_fusion
     enabled: true
-    run_shape_prop: false
-    bypass_ops: []

--- a/examples/auto_deploy/model_registry/configs/nano_v3.yaml
+++ b/examples/auto_deploy/model_registry/configs/nano_v3.yaml
@@ -54,3 +54,10 @@ transforms:
     backend: flashinfer_ssm
   compile_model:
     piecewise_enabled: true
+  fuse_nvfp4_moe:
+    backend: trtllm_gen
+  mlir_elementwise_fusion:
+    stage: post_load_fusion
+    enabled: true
+    run_shape_prop: false
+    bypass_ops: []

--- a/tensorrt_llm/_torch/auto_deploy/mlir/dialect.py
+++ b/tensorrt_llm/_torch/auto_deploy/mlir/dialect.py
@@ -91,6 +91,7 @@ _TORCH_TO_MLIR_DTYPE = {
     torch.float8_e4m3fn: Float8E4M3FNType,
     torch.float8_e5m2: Float8E5M2Type,
     torch.int8: lambda: IntegerType(8),
+    torch.uint8: lambda: IntegerType(8),  # NVFP4 packs FP4 into uint8 buffers
     torch.int16: lambda: IntegerType(16),
     torch.int32: lambda: IntegerType(32),
     torch.int64: lambda: IntegerType(64),


### PR DESCRIPTION
Two changes that together deliver **+26.7% gen tokens/sec/user** on
  Nemotron-Nano-30B-A3B-NVFP4 at concurrency=1 ISL=OSL=1000 on B200×2 (TP=2):

  - **`tensorrt_llm/_torch/auto_deploy/mlir/dialect.py`** — add a `torch.uint8 → IntegerType(8)` entry in `_TORCH_TO_MLIR_DTYPE`. Without it, the FX→MLIR converter bails out on any graph containing NVFP4 weights
  (NVFP4 packs two FP4 values per uint8 byte), and `mlir_elementwise_fusion` skips the whole graph.

  - **`examples/auto_deploy/model_registry/configs/nano_v3.yaml`** — enable two YAML knobs:
    - `mlir_elementwise_fusion: enabled: true` — replaces ~70 `vectorized_elementwise_kernel` and ~50 cutlass RMSNorm launches per iter with fused Triton kernels generated from discovered subgraphs.
    - `fuse_nvfp4_moe.backend: trtllm_gen` — removes the cutlass GroupedGEMM kernels (~62 launches/iter) that the default `cutlass` backend emits and that account for the majority of AD's GPU-side gap vs the
  PyTorch backend.

  Neither change adds new code paths. `mlir_elementwise_fusion` already exists in `transform/library/` (registered in `default.yaml` as `enabled: false`); `fuse_nvfp4_moe.backend` already accepts `trtllm_gen` per
   `_torch/auto_deploy/transform/library/fused_moe.py:2868`. The YAML just flips them on for this model.


  ## Measurement

  Same workload, same hardware, branch HEAD vs branch base:

  | metric | before | after | delta |
  |---|---|---|---|
  | gen tokens/sec/user (aiperf) | 330.29 | **418.55** | **+26.7%** |
  | inter-token latency | 3.03 ms | 2.39 ms | −640 µs |
  | graph cumulative kernel time / iter / device | 2,958 µs | 2,404 µs | −554 µs |
  | graph kernel count / iter / device | 861 | 705 | −156 |

  PT-FP8 reference on the same hardware is 437.65 tps/user; AD-NVFP4 with this PR lands 4.4% behind that ceiling. The residual is mostly NVFP4-vs-FP8 precision overhead (~90 µs/iter of
  `quantize_with_block_size`-style work) and remaining launch-count differences.

  ## Where the analysis lives

  `mlir_elementwise_fusion`'s effect was verified with `nsys --cuda-graph-trace=node`:
  - Rank 0 replaces 98/121 discovered fusible subgraphs (rank 1: 75/98).
  - `vectorized_elementwise_kernel` drops 173.8 → 104.6 per iter per device.
  - `kernel_cutlass_...RMSNormKernel` drops 52.6 → 0 (replaced by `fused_kernel_*` triton).

  `fuse_nvfp4_moe.backend: trtllm_gen` removes the `void cutlass::device_kernel<...GroupProblemShape...>` GroupedGEMM launches that were 62/iter in the cutlass path. Switching also reduces
  `vectorized_elementwise_kernel` by 22/iter and `unrolled_elementwise_kernel` by 22/iter (these were also being inserted around the cutlass MoE call). Net cumulative graph time savings: 487 µs/iter/dev.

  ## Compatibility / fallback

  - `mlir_elementwise_fusion` requires `pip install xdsl` (already shipped in the standard AD-PyTorch container). When `xdsl` is not importable, the transform's `if not HAS_XDSL` guard makes it skip cleanly — no
  crash, no perf regression vs current.
  - The uint8 dtype mapping is purely additive. It treats `torch.uint8` as a signless `IntegerType(8)` (same backing MLIR type as `torch.int8`). The fusion pipeline does not emit elementwise ops directly on the
  uint8-packed NVFP4 weights, so the reverse-mapping ambiguity between int8 and uint8 never triggers.
  - For non-NVFP4 models on this YAML (none exist for Nano, but in principle), `mlir_elementwise_fusion` runs normally and `fuse_nvfp4_moe` is a no-op.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for NVFP4 quantization format in model registry configurations.
  * Introduced new model optimization strategies including advanced fusion techniques for improved inference performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14554?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
