### PR TITLE
[TRTLLM-12968][ci] Dedup executor unit tests on H100/B200

### DIFF
--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -90,7 +90,6 @@ l0_b200:
   - unittest/_torch/attention
   - unittest/_torch/compilation
   - unittest/_torch/debugger
-  - unittest/_torch/executor
   # ------------- modules (non-MoE) ---------------
   - unittest/_torch/modules/test_mla_helix.py
   - unittest/_torch/modules/test_fused_add_rms_norm_quant.py

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -207,7 +207,7 @@ l0_h100:
     - disaggregated/test_disaggregated_single_gpu.py::test_disaggregated_logits[True-TinyLlama-1.1B-Chat-v1.0]
     - disaggregated/test_disaggregated_single_gpu.py::test_disaggregated_logprobs[False-TinyLlama-1.1B-Chat-v1.0]
     - disaggregated/test_disaggregated_single_gpu.py::test_disaggregated_logprobs[True-TinyLlama-1.1B-Chat-v1.0]
-    - unittest/_torch/executor
+    - unittest/_torch/executor/test_overlap_scheduler.py
     - unittest/_torch/ray_orchestrator/single_gpu/test_cache_transceiver_comm.py
     - unittest/_torch/ray_orchestrator/single_gpu/test_llm_sleep.py
     - unittest/_torch/ray_orchestrator/single_gpu/test_llm_update_weights.py -m "part0"


### PR DESCRIPTION
## Summary

Remove redundant copies of `unittest/_torch/executor` from pre-merge L0 test lists. The directory tests executor-layer invariants (PyExecutor / scheduler / request queue / KV cache manager) that are HW-agnostic, so H100 MPI already provides sufficient coverage.

**Changes:**
- `l0_b200.yml`: drop `- unittest/_torch/executor`.
- `l0_h100.yml` (ray block): narrow `- unittest/_torch/executor` to `- unittest/_torch/executor/test_overlap_scheduler.py`.

`l0_h100.yml:21` (MPI orchestrator) keeps the entire directory — it is the authoritative copy.

## Rationale

**B200 copy is redundant.** A source-level scan of all 23 files shows 0 SM gating, 0 tier-specific parametrize, 0 kernel-arithmetic assertions (the 9 `allclose`/`assert_close` calls all check storage / position-id invariants), and 0 FP4/FP8 kernel runs. The SM-specific kernels exercised indirectly via the LLM forward path (TRTLLM attention, fused RMSNorm/RoPE/activation, BF16 linear, samplers) are independently covered by `_torch/{attention,thop,modules,sampler}` on both H100 and B200.

**H100-ray copy keeps `test_overlap_scheduler.py`.** It is the only file in the directory carrying `@pytest.mark.mpi_ray_parity`. Under `--run-ray`, conftest's `pytest_generate_tests` + `_maybe_force_ray` monkey-patches the module's `LLM` symbol to inject `orchestrator_type="ray"`, so this is the only test that genuinely exercises the Ray RPC path. Its assertions (`with_overlap == without_overlap` text equality, `cached_tokens` cold/hot counts) are behavioral invariants that the existing `examples/test_ray.py::test_llm_inference_async_ray` smoke (a `venv_check_call`-only test whose underlying script has zero `assert`) does NOT cover. The other 22 files use `Mock` / direct components / ZMQ primitives and have no orchestrator dependency.

## Pre-flight checks

- **waives.txt**: no entry touches the directory or the kept files.
- **OpenSearch 30-day failure history**: no B200- or ray-exclusive failure observed. The only cross-stage named failures came from PR 13926 build #39388, which broke on H100/B200/B300 simultaneously (a PyExecutor lifecycle regression already caught by the MPI copy we keep).
- **Other test lists**: `l0_b300.yml`, `l0_dgx_b300.yml`, `l0_gb300_multi_gpus.yml` (smoke / post_merge multi-GPU) and `l0_a10.yml` (5 individually-listed files) are unchanged.

## Expected effect

- **Coverage**: executor invariants stay on H100 MPI; SM-specific kernels stay on `_torch/{attention,thop,modules,sampler}` on both SKUs; Ray-path behavioral invariants stay via the surviving `test_overlap_scheduler.py`.
- **Pre-merge wallclock saved**: ~10000–11000 min/week (~7800 from B200, ~2500–3000 from the H100-ray shrink).
- **Signal quality**: narrowing the ray entry stops the wrapper-level noise that conflates executor failures with unrelated Ray-infra / PR-global regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test configurations to optimize coverage across different GPU hardware architectures
  * Adjusted B200 configuration by streamlining test selection for focused testing
  * Enhanced H100 test suite with additional overlap scheduler validation testing to ensure proper performance optimization across different hardware variants

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
