### PR TITLE
[TRTLLM-12941][fix] Selective retry for transient TCP races in disagg HTTP client

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3492,8 +3492,9 @@ class PyExecutor:
             elapsed_time = (current_time - req.py_kv_transfer_start_time) * 1000
             if elapsed_time > timeout_ms and not req.py_kv_transfer_timed_out:
                 logger.warning(
-                    f"Terminating {type} request {req.py_request_id} due to KV cache transfer timeout"
-                )
+                    f"Terminating {type} request {req.py_request_id} due to KV "
+                    f"cache transfer timeout: elapsed {elapsed_time:.0f}ms > "
+                    f"kv_transfer_timeout_ms={timeout_ms}ms")
                 req.py_kv_transfer_timed_out = True
 
         for req in self.async_transfer_manager.requests_in_transfer().values():

--- a/tensorrt_llm/serve/openai_client.py
+++ b/tensorrt_llm/serve/openai_client.py
@@ -164,7 +164,13 @@ class OpenAIHttpClient(OpenAIClient):
         hooks: Optional[ResponseHooks] = None,
     ) -> AsyncGenerator[Any, None]:
         is_stream = request.stream
-        for attempt in range(self._max_retries + 1):
+        # Loop range must cover the transient-TCP extended budget (up to 5)
+        # so the conditional raise inside the except block can actually decide
+        # to keep retrying.  Non-transient errors still raise on the first
+        # attempt that reaches self._max_retries.
+        _TRANSIENT_TCP_BUDGET = 5
+        loop_max = max(self._max_retries, _TRANSIENT_TCP_BUDGET) + 1
+        for attempt in range(loop_max):
             # Regenerate disagg_request_id on retry to avoid ID collision on workers
             if attempt > 0 and self._disagg_id_generator is not None:
                 dp = getattr(request, "disaggregated_params", None)
@@ -215,15 +221,27 @@ class OpenAIHttpClient(OpenAIClient):
                         traceback.format_exc(),
                     )
                     raise
-                if attempt == self._max_retries:
+                # Selective retry budget: ServerDisconnectedError and
+                # ConnectionResetError are transient TCP races (typically at
+                # burst start when client keepalive vs server keepalive race).
+                # Give them an extended retry budget while preserving the
+                # original fail-fast for genuine upstream errors.
+                is_transient_tcp = isinstance(
+                    e,
+                    (aiohttp.ServerDisconnectedError, ConnectionResetError),
+                )
+                effective_max = self._max_retries
+                if is_transient_tcp:
+                    effective_max = max(self._max_retries, _TRANSIENT_TCP_BUDGET)
+                if attempt >= effective_max:
                     logger.error(
-                        f"Client error to {url}: {e} - last retry {attempt} of {self._max_retries}"
+                        f"Client error to {url}: {e} - last retry {attempt} of {effective_max}"
                         "failed",
                         traceback.format_exc(),
                     )
                     raise
                 logger.error(
-                    f"{self._role} client error to {url}: {e} - retry {attempt} of {self._max_retries}",
+                    f"{self._role} client error to {url}: {e} - retry {attempt} of {effective_max}",
                     traceback.format_exc(),
                 )
                 await asyncio.sleep(self._retry_interval_sec)

--- a/tests/unittest/disaggregated/test_disagg_openai_client.py
+++ b/tests/unittest/disaggregated/test_disagg_openai_client.py
@@ -414,3 +414,146 @@ class TestDisaggIdRegenOnRetry:
             await client.send_request(req)
 
         assert req.disaggregated_params.disagg_request_id == 42
+
+
+class TestSelectiveTransientTcpRetry:
+    """Selective retry budget for transient TCP race symptoms.
+
+    ServerDisconnectedError and ConnectionResetError (which include
+    aiohttp.ClientConnectionResetError via MRO) get an extended retry budget
+    of up to 5 attempts; all other client errors keep the original
+    max_retries fail-fast behaviour.
+    """
+
+    def _ok_response(self):
+        return CompletionResponse(
+            id="cmpl-1",
+            object="text_completion",
+            created=0,
+            model="m",
+            choices=[CompletionResponseChoice(index=0, text="ok", finish_reason="stop")],
+            usage=UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+
+    def _mock_http_ok(self, body):
+        r = AsyncMock()
+        r.status = 200
+        r.headers = {"Content-Type": "application/json"}
+        r.json = AsyncMock(return_value=body.model_dump())
+        r.__aenter__ = AsyncMock(return_value=r)
+        r.__aexit__ = AsyncMock()
+        return r
+
+    def _make_client(self, session, max_retries=1):
+        from prometheus_client.registry import REGISTRY
+
+        REGISTRY._names_to_collectors = {}
+        REGISTRY._collector_to_names = {}
+        router = AsyncMock(spec=Router)
+        router.servers = ["localhost:8000"]
+        router.get_next_server = AsyncMock(return_value=("localhost:8000", None))
+        router.finish_request = AsyncMock()
+        return OpenAIHttpClient(
+            router=router,
+            role=ServerRole.CONTEXT,
+            timeout_secs=10,
+            max_retries=max_retries,
+            retry_interval_sec=0,
+            session=session,
+        )
+
+    def _make_request(self):
+        return CompletionRequest(
+            model="m",
+            prompt="hi",
+            stream=False,
+            disaggregated_params=DisaggregatedParams(
+                request_type="context_only", disagg_request_id=1
+            ),
+        )
+
+    @pytest.mark.asyncio
+    async def test_server_disconnected_gets_extra_retries(self):
+        """ServerDisconnectedError: even with max_retries=1, retry up to 5."""
+        session = AsyncMock(spec=aiohttp.ClientSession)
+        client = self._make_client(session, max_retries=1)
+
+        # 4 disconnect failures then success on the 5th attempt
+        session.post.side_effect = [
+            aiohttp.ServerDisconnectedError(),
+            aiohttp.ServerDisconnectedError(),
+            aiohttp.ServerDisconnectedError(),
+            aiohttp.ServerDisconnectedError(),
+            self._mock_http_ok(self._ok_response()),
+        ]
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await client.send_request(self._make_request())
+
+        # 1 original + 4 retries = 5 total attempts (extra budget kicked in)
+        assert session.post.call_count == 5
+
+    @pytest.mark.asyncio
+    async def test_connection_reset_gets_extra_retries(self):
+        """ConnectionResetError: same extra budget as ServerDisconnectedError."""
+        session = AsyncMock(spec=aiohttp.ClientSession)
+        client = self._make_client(session, max_retries=1)
+
+        session.post.side_effect = [
+            ConnectionResetError(),
+            ConnectionResetError(),
+            self._mock_http_ok(self._ok_response()),
+        ]
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await client.send_request(self._make_request())
+
+        # 1 original + 2 retries = 3 total attempts (within extra budget)
+        assert session.post.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_other_client_error_keeps_fail_fast(self):
+        """Generic aiohttp.ClientError still respects max_retries (=1)."""
+        session = AsyncMock(spec=aiohttp.ClientSession)
+        client = self._make_client(session, max_retries=1)
+
+        session.post.side_effect = aiohttp.ClientError("transient non-tcp")
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(aiohttp.ClientError):
+                await client.send_request(self._make_request())
+
+        # Original + 1 retry = 2 attempts, NOT promoted to 5
+        assert session.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_max_retries_zero_still_gets_transient_tcp_budget(self):
+        """Even when max_retries=0, transient TCP races still retry up to 5."""
+        session = AsyncMock(spec=aiohttp.ClientSession)
+        client = self._make_client(session, max_retries=0)
+
+        session.post.side_effect = [
+            aiohttp.ServerDisconnectedError(),
+            self._mock_http_ok(self._ok_response()),
+        ]
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            await client.send_request(self._make_request())
+
+        assert session.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_transient_tcp_capped_at_5_when_max_retries_smaller(self):
+        """If transient TCP keeps failing, give up after the extended budget."""
+        session = AsyncMock(spec=aiohttp.ClientSession)
+        client = self._make_client(session, max_retries=1)
+
+        # Always raise — must give up after extended (1 + 5) = 6 attempts
+        session.post.side_effect = aiohttp.ServerDisconnectedError()
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(aiohttp.ServerDisconnectedError):
+                await client.send_request(self._make_request())
+
+        # 1 original + 5 retries
+        assert session.post.call_count == 6


### PR DESCRIPTION
When a disagg proxy reuses a TCP connection right at the moment the upstream worker's keep-alive timer expires, aiohttp surfaces the race as ServerDisconnectedError or ConnectionResetError.  Under burst load (e.g. concurrency=8192 at bench start) the proxy's asyncio event loop also delays its own 1s keep-alive timer past the worker's 5s timer, flipping the "client closes first" invariant and triggering hundreds of these errors within the first minute before the connection pool stabilises.

Instead of bumping the global max_retries (which would mask genuine upstream errors with retry loops), give the two TCP-level race exceptions an extended budget of 5 retries while preserving the original fail-fast behaviour for everything else (ClientResponseError, ServerTimeoutError, etc).

Also include elapsed time vs configured timeout in the KV cache transfer timeout warning so the failure mode is self-explanatory.

Adds 5 targeted unit tests covering: extra budget for both race exceptions, fail-fast retained for other client errors, transient budget applied even when max_retries=0, and termination after the extended budget is exhausted.

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
