### PR TITLE
[https://nvbugs/6215218][fix] Add escape hatch for KV transfer timeout-triggered UAF in disagg

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3568,6 +3568,17 @@ class PyExecutor:
     def _check_kv_transfer_timeout(self):
         if not self.kv_cache_transceiver:
             return
+        # NVBug 6215218: the timeout-driven request-termination path can
+        # corrupt Python LlmRequest state under sustained high-concurrency
+        # disaggregated workloads, surfacing as SIGSEGV in
+        # `_PyObject_GenericGetAttrWithDict` or as
+        # `CUBLAS_STATUS_EXECUTION_FAILED` from a latched async CUDA error.
+        # Empirically, disabling this check eliminates the crash. Set
+        # `TRTLLM_DISABLE_KV_TRANSFER_TIMEOUT=1` as an escape hatch until
+        # the underlying use-after-free is properly fixed; legitimately
+        # stalled requests will then have to be cancelled by the caller.
+        if os.environ.get("TRTLLM_DISABLE_KV_TRANSFER_TIMEOUT") == "1":
+            return
         timeout_ms = self.kv_cache_transceiver.kv_transfer_timeout_ms
         if timeout_ms is None:
             return

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2787,8 +2787,12 @@ class CacheTransceiverConfig(StrictBaseModel, PybindMirror):
     kv_transfer_timeout_ms: Optional[PositiveInt] = Field(
         default=60000,
         description=
-        "Timeout in milliseconds for KV cache transfer. Requests exceeding this timeout will be cancelled."
-    )
+        "Timeout in milliseconds for KV cache transfer. Requests exceeding "
+        "this timeout will be cancelled. Set to None to disable the timeout "
+        "entirely. NOTE: the timeout-driven cancellation path has a known "
+        "use-after-free at high concurrency in disaggregated mode (NVBug "
+        "6215218); as a temporary workaround, set this to None or export "
+        "TRTLLM_DISABLE_KV_TRANSFER_TIMEOUT=1.")
 
     kv_transfer_sender_future_timeout_ms: Optional[PositiveInt] = Field(
         default=1000,


### PR DESCRIPTION
## Background

NVBug 6215218 reports that disaggregated serving of Kimi-K2.5-NVFP4
(ISL=OSL=1024, concurrency=16384) on GB200 (NVL72, aarch64, dep16)
crashes the CTX worker shortly after benchmark start. The CTX worker
dies with SIGSEGV (exit 139); the disagg server then fails all
subsequent requests with `aiohttp.ClientConnectorError` and the SLURM
job eventually times out. The same configuration runs cleanly on
`nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc12.post1` — so this is a
regression introduced between rc12.post1 and main.

## Empirical findings (lyris GB200 dep16, c=16384)

| Run | Image | Buffer | `kv_transfer_timeout_ms` | Result |
|---|---|---|---|---|
| BAD baseline | main `c7d609bd` (image `57a1b8`) | 16384 | 60000 | FAILED, cuBLAS cascade at 14724/16384 |
| GOOD baseline | `1.3.0rc12.post1` | 16384 | 60000 | DONE, 16384/16384 in 181 s |
| Reduced buffer | BAD | **4096** | 60000 | FAILED, Python SIGSEGV at 15036/16384 |
| Newer main | `9ec3c8` (May 23, 2 days after BAD) | 16384 | 60000 | FAILED, SIGSEGV preceded by `Terminating ... due to KV cache transfer timeout` |
| **This fix** | BAD | 16384 | **None** | **No crash, no errors, 16305/16384 (99.5%)** before SLURM wall-clock |

Two key observations:

1. **The crash is request-count-correlated (~90% of total)**, regardless of buffer size — it's a resource leak / use-after-free that accumulates per request, not a backpressure issue.
2. **The crash is always preceded** (in the runs that get there) by `[RANK X] Terminating ... request ... due to KV cache transfer timeout` in the CTX worker log. The SEGV stack is consistently `_PyObject_GenericGetAttrWithDict → PyObject_GetAttr → _PyEval_EvalFrameDefault` — classic Python attribute access on a freed object. Under different timing, the same race surfaces as `CUBLAS_STATUS_EXECUTION_FAILED` from `cublasLtMatmul` (latched async CUDA error on the stream from the same freed-pointer access).

## Summary

This patch adds an environment-variable escape hatch (`TRTLLM_DISABLE_KV_TRANSFER_TIMEOUT=1`) to `_check_kv_transfer_timeout` and documents the workaround in `CacheTransceiverConfig.kv_transfer_timeout_ms`. Users who hit the crash can disable the timeout via either:

- YAML config: `cache_transceiver_config.kv_transfer_timeout_ms: null` (already supported)
- Env var: `TRTLLM_DISABLE_KV_TRANSFER_TIMEOUT=1` (added by this PR)

## Why this is an interim fix

This is **not** a fix for the underlying use-after-free. It is an escape hatch so users hitting NVBug 6215218 can run their workloads while the proper repair lands. The real fix requires auditing the cancellation / cleanup chain that runs when a request is flagged `py_kv_transfer_timed_out=True`. Suspect code areas (introduced between `v1.3.0rc12.post1` and `c7d609bd`):

- `_flush_pending_transfer_responses` / `_pending_transfer_responses` — added in PR #13115 (TRTLLM-12015, *KV reuse in transceiver v2*). This is a TP gather collective that requires lockstep across DP ranks; a response queued for a soon-to-be-terminated request can outlive the request itself.
- `commit_blocks_for_reuse(req)` on `KvCacheTransceiver` — same PR. Per-request callback during transfer completion; verify pybind/nanobind INCREF discipline.
- `cancelled_reqs` tuple-result handling in `_check_disagg_gen_cache_transfer_status` — added in PR #12734 (TRTLLM-11635, *cancellation in transceiver v2*). Dereferences `req.py_request_id` / `is_child` / `parent_request_id` on objects coming back from C++; verify the list holds strong references.

A `git bisect` between `v1.3.0rc12.post1` and `c7d609bd` with the dep16 c=16384 repro as the pass/fail check would conclusively identify the introducing PR (~14 bisect steps).

## Impact assessment

- **Functional**: zero behavior change when the env var is unset and `kv_transfer_timeout_ms` is left at its default. Sets are purely opt-in.
- **Performance**: zero — one extra `os.environ.get` per `_check_kv_transfer_timeout` call (which is itself called from the executor event loop, not the hot path).
- **API**: schema field default unchanged. Only the description string is updated.

## Test plan

- [x] Empirically verified the workaround on lyris GB200 dep16 c=16384 (job `1907412`): bench progressed to 99.5% with zero CTX errors before SLURM wall-clock.
- [x] Pre-commit hooks pass on changed files.
- [ ] Reviewer to confirm the env-var approach is acceptable as an interim while the UAF repair is being scoped.

## Related

- NVBug: https://nvbugspro.nvidia.com/bug/6215218
- Suspect PRs introducing the regression window: #13115, #12734

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added workaround for KV-cache transfer timeout issues that could cause crashes in high-concurrency disaggregated workloads. Set `TRTLLM_DISABLE_KV_TRANSFER_TIMEOUT=1` or configure the timeout to `None` to resolve the issue.

* **Documentation**
  * Updated KV transfer timeout configuration documentation with known high-concurrency issue details and recommended solutions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->