### PR TITLE
[https://nvbugs/5979673][fix] Pin nixl-cu13==0.9.0 instead of nixl meta-package

### DIFF
--- a/tensorrt_llm/_torch/disaggregation/nixl/_agent_py.py
+++ b/tensorrt_llm/_torch/disaggregation/nixl/_agent_py.py
@@ -1,13 +1,32 @@
+import importlib
 import time
 from enum import Enum
-
-from nixl import nixl_agent, nixl_agent_config, nixl_xfer_handle
 
 from tensorrt_llm._utils import nvtx_range
 from tensorrt_llm.logger import logger
 
 # Import base classes for type compatibility
 from ..base.agent import BaseTransferAgent, RegMemoryDescs, TransferRequest, TransferStatus
+
+# The PyPI ``nixl`` meta-package provides a top-level ``nixl`` shim that
+# redirects to ``nixl_cu13`` or ``nixl_cu12``. When only ``nixl-cu13`` (or
+# ``nixl-cu12``) is installed without the meta-package, ``import nixl`` fails.
+# Try the CUDA-specific packages first, then fall back to the meta-package.
+_nixl_mod = None
+for _candidate in ("nixl_cu13", "nixl_cu12", "nixl"):
+    try:
+        _nixl_mod = importlib.import_module(_candidate)
+        break
+    except ImportError:
+        continue
+if _nixl_mod is None:
+    raise ImportError(
+        "Could not find a NIXL Python package. "
+        "Install ``nixl-cu13`` (CUDA 13) or ``nixl-cu12`` (CUDA 12)."
+    )
+nixl_agent = _nixl_mod.nixl_agent
+nixl_agent_config = _nixl_mod.nixl_agent_config
+nixl_xfer_handle = _nixl_mod.nixl_xfer_handle
 
 
 class TransferState(Enum):

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -362,7 +362,6 @@ unittest/auto_deploy/singlegpu/models/test_qwen3_5_moe.py::test_vlm_wrapper_delt
 unittest/auto_deploy/singlegpu/smoke/test_ad_build_small_single.py::test_build_ad[deepseek-ai/DeepSeek-V3-llm_extra_args10] SKIP (https://nvbugs/5888827)
 unittest/auto_deploy/standalone SKIP (https://nvbugs/6160629)
 unittest/auto_deploy/standalone/test_standalone_package.py::TestStandalonePackage::test_run_unit_tests SKIP (https://nvbugs/6160629)
-unittest/disaggregated/test_agent_multi_backends.py::test_run_with_different_env[1] SKIP (https://nvbugs/5979673)
 unittest/executor/test_rpc.py::TestRpcCorrectness::test_incremental_task_async SKIP (https://nvbugs/5741476)
 unittest/executor/test_rpc_proxy.py SKIP (https://nvbugs/5605741)
 unittest/executor/test_rpc_worker.py SKIP (https://nvbugs/5605741)


### PR DESCRIPTION
The `nixl` PyPI package became a meta-package whose only dependency is `nixl-cu12` with no version constraint, so `nixl==0.9.0` resolves to `nixl-cu12==<latest>` (currently 1.1.0). The 1.1.0 bindings reference a new 3-arg overload of `nixlAgent::prepXferDlist` (with `nixlAgentOptionalArgs`) that does not exist in the source-built 0.9.0 `libnixl.so` shipped in the container, causing the test_agent unit test to fail at import time with an undefined-symbol error.

Pin `nixl-cu13==0.9.0` directly so:
- the wheel's `_bindings.so` only depends on the 4-arg `prepXferDlist`, which matches both the wheel's bundled libnixl and the source-built 0.9.0 libnixl;
- the wheel variant aligns with the CUDA 13 container instead of cu12.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a development dependency to its CUDA 13–specific build to align dev tooling with CUDA 13 environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
