### PR TITLE
[#13082][fix] Add fail-fast FP4/MXFP4 GPU compatibility validation

### DIFF
--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -23,7 +23,9 @@ from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.quantization.functional import \
     preprocess_weights_for_mixed_gemm
-from tensorrt_llm.quantization.mode import QuantAlgo
+from tensorrt_llm.quantization.mode import (
+    QuantAlgo, get_mxfp4_support_error_message, get_sm_version_from_torch,
+    is_mxfp4_supported)
 from tensorrt_llm.quantization.utils.fp8_utils import (
     per_token_quant_and_transform, resmooth_to_fp8_e8m0,
     transform_sf_into_required_layout)
@@ -96,6 +98,28 @@ class TensorParallelMode(str, enum.Enum):
     @classmethod
     def flip(cls, mode):
         return cls.ROW if mode == cls.COLUMN else cls.COLUMN
+
+
+def _get_fp4_quant_mode(quant_config: Optional[QuantConfig]):
+    if quant_config is None:
+        return None
+
+    quant_mode = quant_config.layer_quant_mode
+    if (quant_mode.has_nvfp4() or quant_mode.has_w4a8_nvfp4_fp8()
+            or quant_mode.has_mxfp4()):
+        return quant_mode
+    return None
+
+
+def _validate_fp4_quant_config_support(
+        quant_config: Optional[QuantConfig]) -> None:
+    quant_mode = _get_fp4_quant_mode(quant_config)
+    if quant_mode is None:
+        return
+
+    sm = get_sm_version_from_torch()
+    if not is_mxfp4_supported(sm, quant_mode):
+        raise ValueError(get_mxfp4_support_error_message(sm, quant_mode))
 
 
 def load_weight_shard(
@@ -2952,6 +2976,7 @@ class Linear(nn.Module):
         if self._weights_created:
             return
 
+        _validate_fp4_quant_config_support(self.quant_config)
         self.rebuild_tensor_metadata = {}
 
         self.quant_method = self.get_quant_method(self.quant_config)

--- a/tensorrt_llm/quantization/mode.py
+++ b/tensorrt_llm/quantization/mode.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -481,3 +481,41 @@ class GroupwiseQuantAlgo:
     PRE_QUANT_SCALE = 4
     W4A8_ALPHA = 8
     INT8_WEIGHT = 16
+
+
+def get_sm_version_from_torch() -> Optional[int]:
+    try:
+        import torch
+    except ImportError:
+        return None
+
+    if not torch.cuda.is_available():
+        return None
+
+    major, minor = torch.cuda.get_device_capability(torch.device("cuda:0"))
+    return major * 10 + minor
+
+
+def is_mxfp4_supported(sm: Optional[int],
+                       quant_mode: Optional[QuantMode]) -> bool:
+    if quant_mode is None or sm is None:
+        return True
+
+    if quant_mode.has_w4a8_mxfp4_fp8():
+        return sm in (100, 103)
+    if quant_mode.has_w4a8_mxfp4_mxfp8():
+        return sm in (100, 103)
+    if quant_mode.has_w4a16_mxfp4():
+        return sm == 90
+    if quant_mode.has_w4a8_nvfp4_fp8():
+        return sm in (100, 103, 120, 121)
+    if quant_mode.has_nvfp4():
+        return sm in (100, 103, 120, 121)
+
+    return True
+
+
+def get_mxfp4_support_error_message(sm: Optional[int],
+                                    quant_mode: QuantMode) -> str:
+    sm_str = f"SM{sm}" if sm is not None else "unknown GPU"
+    return f"{quant_mode} is not supported on {sm_str}. Supported on newer architectures only."


### PR DESCRIPTION
Fixes #13082

## Description

Adds fail-fast validation for FP4/MXFP4 quantization modes on unsupported GPU architectures

Previously, unsupported FP4/MXFP4 execution paths could proceed into lower-level kernels or backend initialization and fail later with less actionable errors. This patch centralizes GPU support checks in `QuantMode` helpers and applies validation across custom ops, linear layers, and fused MoE backend creation

### Changes
- Add FP4/MXFP4 GPU support helpers in `quantization/mode.py`
- Validate FP4 runtime support before NVFP4 and W4A8 MXFP4 custom GEMMs
- Validate FP4 quant configs during linear weight creation
- Validate fused MoE backend support before backend construction
- Raise clear errors for unsupported architectures or missing FP4 metadata

This change is independent of VILA multimodal chunked prefill fixes

## Test Coverage

- Verified FP4/MXFP4 validation paths trigger early failures on unsupported GPU architectures
- Verified supported configurations continue through backend and kernel setup successfully
- Existing quantization and fused MoE test paths continue to pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified FP4/NVFP4 quantization support detection and validation across custom operators.
  * Improved MoE backend selection logic for more efficient model execution.
  * Streamlined GEMM execution pathways with unified buffer handling and removed legacy output buffer configuration parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->