### PR TITLE
[None][feat] W4A8 NVFP4 FP8 partial update-weights support

### DIFF
--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -969,7 +969,7 @@ class ModelConfig(Generic[TConfig]):
         else:
             return None
 
-    def get_num_attention_layers(self) -> int:
+    def get_num_attention_layers(self, **_kwargs) -> int:
         """Number of full-attention layers in the model.
 
         Pure model property: independent of which KV cache manager will run.

--- a/tensorrt_llm/_torch/modules/gated_mlp.py
+++ b/tensorrt_llm/_torch/modules/gated_mlp.py
@@ -140,6 +140,13 @@ class GatedMLP(nn.Module):
                         f"GatedMLP._apply_activation: LoRA path active; forcing non-FP8 activation dtype bf16/fp16, layer_idx={self.layer_idx}"
                     )
                     return swiglu(x)
+                elif self.down_proj.force_dynamic_quantization:
+                    # Dynamic activation quantization: per-tensor input_scale is
+                    # not pre-computed (would be uninitialized memory), so swiglu
+                    # cannot pre-quantize to FP8 here. Emit bf16 and let
+                    # down_proj.apply do dynamic FP8 quantization with a
+                    # freshly-computed scale.
+                    return swiglu(x)
                 else:
                     return swiglu(x,
                                   quant_scale=self.down_proj.input_scale,

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -2114,8 +2114,7 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
         # Concat per-shard weight_scales in canonical order, then swizzle.
         weight_mode = module.weights_loading_config.weight_mode
         ordered_scales = [
-            module.tmp_w4a8_weight_scales[key]
-            for key in weight_mode.shard_keys
+            module.tmp_w4a8_weight_scales[key] for key in weight_mode.shard_keys
         ]
         weight_scale = torch.cat(ordered_scales, 0)
         weight_scale = fp4_utils.shuffle_matrix_sf_a(weight_scale,
@@ -2146,8 +2145,7 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
         gate_weight, up_weight = load_weights_fused_gate_up_helper(
             module, weights, allow_partial_loading=allow_partial_loading)
 
-        for shard_key, weight in zip(('gate', 'up'),
-                                     (gate_weight, up_weight)):
+        for shard_key, weight in zip(('gate', 'up'), (gate_weight, up_weight)):
             if weight is not None:
                 shard_offset, shard_size = module.fused_weight_shard_indices_mapping[
                     shard_key]
@@ -2172,8 +2170,7 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
         # Concat per-shard weight_scales in canonical order, then swizzle.
         weight_mode = module.weights_loading_config.weight_mode
         ordered_scales = [
-            module.tmp_w4a8_weight_scales[key]
-            for key in weight_mode.shard_keys
+            module.tmp_w4a8_weight_scales[key] for key in weight_mode.shard_keys
         ]
         weight_scale = torch.cat(ordered_scales, 0)
         weight_scale = fp4_utils.shuffle_matrix_sf_a(weight_scale,

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -372,8 +372,9 @@ class LinearMethodBase(ABC):
             raise ValueError(f'unsupported weight mode: {weight_mode}')
 
         kargs = {}
-        if isinstance(self, (UnquantizedLinearMethod,
-                             FP8BlockScalesLinearMethod, NVFP4LinearMethod)):
+        if isinstance(self,
+                      (UnquantizedLinearMethod, FP8BlockScalesLinearMethod,
+                       NVFP4LinearMethod, W4A8NVFP4FP8LinearMethod)):
             kargs['allow_partial_loading'] = allow_partial_loading
         load_fn(module, weights, **kargs)
 
@@ -1907,6 +1908,12 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
 
     def apply(self, module: Linear, input: torch.Tensor,
               bias: Optional[torch.Tensor]):
+        import sys as _sys
+        # Sync-free diagnostic (no .item() / .any()) — safe during CUDA graph capture.
+        print(
+            f"[APPLY-W4A8] in.shape={list(input.shape)} in.dtype={input.dtype} "
+            f"out={list(module.weight.shape)} fdq={getattr(module, 'force_dynamic_quantization', False)}",
+            file=_sys.stderr, flush=True)
         alpha = module.alpha
         if input.dtype != torch.float8_e4m3fn:
             if module.input_scale is not None and not module.force_dynamic_quantization:
@@ -1929,125 +1936,338 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
             output = output + bias
         return output
 
-    def load_weight_scales(
-        self,
-        weights: List[Dict],
-        tp_size: int = 1,
-        tp_rank: int = 0,
-        tp_mode: Optional[TensorParallelMode] = None,
-    ):
-        # For concatenated weights (qkv_proj / up_gate_proj), the global scaling factors and input scaling factors should be shared.
-        input_scale = None
-        weight_scale_2 = None
-        weight_scale = []
+    def load_weight_scales(self,
+                           module: Linear,
+                           weights: List[Dict],
+                           shard_keys: Optional[List[str]] = None):
+        """Load W4A8 NVFP4 FP8 scales from weights into module tmp attributes.
 
+        Supports partial loading: per-tensor scales are accumulated across
+        multiple calls and finalized in _finalize_w4a8_scales (called by
+        process_weights_after_loading_*). The block weight_scale is applied
+        eagerly in the vanilla path (single tensor, no concat needed) and
+        stashed per-shard in the fused paths.
+
+        Args:
+            module: Target Linear module
+            weights: List of weight dicts (one per shard for fused, one for vanilla)
+            shard_keys: Shard keys for fused weights (e.g., ['q','k','v'] or
+                ['gate','up']). None for vanilla (single weight).
+        """
         device = torch.device("cuda")
 
-        for w in weights:
-            if "input_scale" in w:
-                if input_scale is None:
-                    input_scale = w["input_scale"][...]
-                else:
-                    assert input_scale == w["input_scale"][
-                        ...], "The input_scale should be same for all the weights"
+        if shard_keys is not None:
+            # Fused: stash per-shard weight_scales; concat + swizzle in
+            # process_weights_after_loading_*.
+            if not hasattr(module, "tmp_w4a8_weight_scales"):
+                module.tmp_w4a8_weight_scales = {}
+            for shard_key, w in zip(shard_keys, weights):
+                if "weight_scale" in w:
+                    ws = load_weight_shard(w["weight_scale"],
+                                           module.tp_size,
+                                           module.tp_rank,
+                                           module.tp_mode,
+                                           device=device).contiguous()
+                    assert ws.dtype == torch.float8_e4m3fn
+                    module.tmp_w4a8_weight_scales[shard_key] = ws.view(
+                        fp4_utils.float4_sf_dtype)
+        else:
+            # Vanilla: single weight_scale, swizzle and copy directly.
+            w = weights[0]
             if "weight_scale" in w:
                 ws = load_weight_shard(w["weight_scale"],
-                                       tp_size,
-                                       tp_rank,
-                                       tp_mode,
+                                       module.tp_size,
+                                       module.tp_rank,
+                                       module.tp_mode,
                                        device=device).contiguous()
                 assert ws.dtype == torch.float8_e4m3fn
-                weight_scale.append(ws.view(dtype=fp4_utils.float4_sf_dtype))
+                ws = ws.view(fp4_utils.float4_sf_dtype)
+                ws = fp4_utils.shuffle_matrix_sf_a(ws, module.epilogue_tile_m,
+                                                   module.scaling_vector_size)
+                copy_weight(module.weight_scale, ws)
+
+        # Accumulate per-tensor scales across partial loads.
+        if not hasattr(module, "tmp_w4a8_input_scales_list"):
+            module.tmp_w4a8_input_scales_list = []
+        if not hasattr(module, "tmp_w4a8_weight_scale_2_list"):
+            module.tmp_w4a8_weight_scale_2_list = []
+        for w in weights:
+            if "input_scale" in w:
+                module.tmp_w4a8_input_scales_list.append(
+                    w["input_scale"][...].reshape([]))
             if "weight_scale_2" in w:
-                if weight_scale_2 is None:
-                    weight_scale_2 = w["weight_scale_2"][...]
-                else:
-                    assert weight_scale_2 == w["weight_scale_2"][...], (
-                        f"The weight_scale_2 should be same for all the weights: {weight_scale_2} vs. {w['weight_scale_2']}"
-                    )
+                module.tmp_w4a8_weight_scale_2_list.append(
+                    w["weight_scale_2"][...].reshape([]))
 
-        # TODO: ModelOpt's o_proj.weight_scale_2 is bfloat16, which should be float32
-        input_scale = input_scale.to(torch.float32)
-        weight_scale_2 = weight_scale_2.to(torch.float32)
-        alpha = input_scale * weight_scale_2
-        return input_scale, weight_scale, weight_scale_2, alpha
+    def _finalize_w4a8_scales(self, module: Linear):
+        """Finalize accumulated W4A8 per-tensor scales after all partial loads.
 
-    def load_weights_vanilla(self, module: Linear, weights: List[Dict]) -> None:
-        # FIXME: this depends on the kernel internals
-        load_weights_vanilla_helper(
-            module, weights,
-            lambda w: fp4_utils.shuffle_matrix_a(w, module.epilogue_tile_m))
+        Verifies consistency of input_scale / weight_scale_2 across shards
+        and returns (input_scale, weight_scale_2, alpha, inv_input_scale)
+        in float32. Callers (process_weights_after_loading_*) copy these
+        into the module, skipping entries that are None.
 
-        input_scale, weight_scale, weight_scale_2, alpha = self.load_weight_scales(
-            weights,
-            tp_size=module.tp_size,
-            tp_rank=module.tp_rank,
-            tp_mode=module.tp_mode)
+        input_scale may be None when the checkpoint omits it (dynamic
+        activation quantization); in that case alpha and inv_input_scale
+        are also None and the kernel recomputes alpha at runtime from
+        weight_scale_2 and the per-call input amax.
+        """
+        input_scale_list = getattr(module, "tmp_w4a8_input_scales_list", [])
+        weight_scale_2_list = getattr(module, "tmp_w4a8_weight_scale_2_list",
+                                      [])
 
-        assert len(weights) == 1
-        weight_scale = weight_scale[0]
-        # Shuffle and Swizzle weight scale
-        weight_scale = fp4_utils.shuffle_matrix_sf_a(weight_scale,
-                                                     module.epilogue_tile_m,
-                                                     module.scaling_vector_size)
-        copy_weight(module.input_scale, input_scale)
-        copy_weight(module.inv_input_scale, 1.0 / input_scale)
-        copy_weight(module.weight_scale, weight_scale)
-        copy_weight(module.weight_scale_2, weight_scale_2)
-        copy_weight(module.alpha, alpha)
+        input_scale = None
+        if input_scale_list:
+            for s in input_scale_list[1:]:
+                assert torch.allclose(input_scale_list[0], s), \
+                    f"input_scale mismatch across shards: {input_scale_list}"
+            input_scale = input_scale_list[0].to(torch.float32)
 
-    def load_weights_fused_qkv_linear(self, module: Linear,
-                                      weights: List[Dict]) -> None:
+        weight_scale_2 = None
+        if weight_scale_2_list:
+            for s in weight_scale_2_list[1:]:
+                assert torch.allclose(weight_scale_2_list[0], s), \
+                    f"weight_scale_2 mismatch across shards: {weight_scale_2_list}"
+            weight_scale_2 = weight_scale_2_list[0].to(torch.float32)
+
+        if input_scale is not None and weight_scale_2 is not None:
+            alpha = input_scale * weight_scale_2
+            inv_input_scale = 1.0 / input_scale
+        else:
+            alpha = None
+            inv_input_scale = None
+        return input_scale, weight_scale_2, alpha, inv_input_scale
+
+    def _cleanup_w4a8_tmp_attrs(self, module: Linear):
+        """Clean up temporary attributes after process_weights_after_loading."""
+        for attr in ("tmp_w4a8_weight_scales", "tmp_w4a8_input_scales_list",
+                     "tmp_w4a8_weight_scale_2_list"):
+            if hasattr(module, attr):
+                delattr(module, attr)
+
+    def load_weights_vanilla(self,
+                             module: Linear,
+                             weights: List[Dict],
+                             allow_partial_loading: bool = False) -> None:
+        # Load raw FP4 weight into module.weight without shuffling; the
+        # shuffle happens in process_weights_after_loading_vanilla so that
+        # partial-loaded buckets (one full weight per bucket) and full loads
+        # share the same finalize path.
+        load_weights_vanilla_helper(module,
+                                    weights,
+                                    allow_partial_loading=allow_partial_loading)
+
+        self.load_weight_scales(module, weights, shard_keys=None)
+
+    def process_weights_after_loading_vanilla(self, module: Linear):
+        import sys as _sys
+        _has_tmp = hasattr(module, "tmp_w4a8_input_scales_list")
+        _w = module.weight if hasattr(module, "weight") else None
+        print(
+            f"[FIN-W4A8-V] enter has_tmp={_has_tmp} "
+            f"w.shape={list(_w.shape) if _w is not None else None} "
+            f"w.dtype={_w.dtype if _w is not None else None}",
+            file=_sys.stderr, flush=True)
+        if not _has_tmp:
+            print("[FIN-W4A8-V]   EARLY RETURN (no tmp)", file=_sys.stderr, flush=True)
+            return
+
+        # Shuffle weight on the fully-loaded tensor.
+        shuffled = fp4_utils.shuffle_matrix_a(module.weight,
+                                              module.epilogue_tile_m)
+        copy_weight(module.weight, shuffled)
+
+        # Finalize per-tensor scales. input_scale / alpha / inv_input_scale
+        # may be None for dynamic activation quantization.
+        input_scale, weight_scale_2, alpha, inv_input_scale = \
+            self._finalize_w4a8_scales(module)
+        print(
+            f"[FIN-W4A8-V] scales: input_scale={input_scale} "
+            f"weight_scale_2={weight_scale_2} alpha={alpha} inv_input_scale={inv_input_scale}",
+            file=_sys.stderr, flush=True)
+        if input_scale is not None:
+            copy_weight(module.input_scale, input_scale)
+        if inv_input_scale is not None:
+            copy_weight(module.inv_input_scale, inv_input_scale)
+        if weight_scale_2 is not None:
+            copy_weight(module.weight_scale_2, weight_scale_2)
+        if alpha is not None:
+            copy_weight(module.alpha, alpha)
+
+        # DEBUG: check final state
+        import torch as _t
+        _ws = module.weight_scale if hasattr(module, "weight_scale") else None
+        print(
+            f"[FIN-W4A8-V] post-finalize: "
+            f"w nan={_t.isnan(module.weight.float()).any().item()} "
+            f"ws.shape={list(_ws.shape) if _ws is not None else None} "
+            f"ws nan={_t.isnan(_ws.float()).any().item() if _ws is not None else None}",
+            file=_sys.stderr, flush=True)
+
+        self._cleanup_w4a8_tmp_attrs(module)
+
+    def load_weights_fused_qkv_linear(
+            self,
+            module: Linear,
+            weights: List[Dict],
+            allow_partial_loading: bool = False) -> None:
         q_weight, k_weight, v_weight = load_weights_fused_qkv_helper(
-            module, weights)
+            module, weights, allow_partial_loading=allow_partial_loading)
 
-        input_scale, weight_scales, weight_scale_2, alpha = self.load_weight_scales(
-            weights,
-            tp_size=module.tp_size,
-            tp_rank=module.tp_rank,
-            tp_mode=module.tp_mode)
-        # Swizzle weight scales after concatenation
-        weight_scale = torch.cat(weight_scales, 0)
-        # Shuffle and Swizzle weight scale
+        # Copy each available shard into module.weight at its shard offset,
+        # without shuffling. Shuffle happens in
+        # process_weights_after_loading_fused_qkv_linear after all shards
+        # are assembled.
+        for shard_key, weight in zip(('q', 'k', 'v'),
+                                     (q_weight, k_weight, v_weight)):
+            if weight is not None:
+                shard_offset, shard_size = module.fused_weight_shard_indices_mapping[
+                    shard_key]
+                copy_weight_shard(module.weight, weight, shard_offset,
+                                  shard_size)
+
+        weight_mode = module.weights_loading_config.weight_mode
+        self.load_weight_scales(module,
+                                weights[:3],
+                                shard_keys=weight_mode.shard_keys)
+
+    def process_weights_after_loading_fused_qkv_linear(self, module: Linear):
+        import sys as _sys
+        _has_tmp = hasattr(module, "tmp_w4a8_weight_scales")
+        _scales = getattr(module, "tmp_w4a8_weight_scales", None)
+        print(
+            f"[FIN-W4A8-QKV] enter has_tmp={_has_tmp} "
+            f"scale_keys={list(_scales.keys()) if _scales else None} "
+            f"w.shape={list(module.weight.shape)}",
+            file=_sys.stderr, flush=True)
+        if not _has_tmp:
+            print("[FIN-W4A8-QKV]   EARLY RETURN (no tmp)", file=_sys.stderr, flush=True)
+            return
+
+        # Pre-shuffle weight content
+        _w_pre = module.weight.flatten()[:16].cpu().tolist()
+        print(f"[FIN-W4A8-QKV] w pre-shuffle (first 16 uint8): {_w_pre}", file=_sys.stderr, flush=True)
+        # Per-shard scale stats
+        for _k in (_scales or {}):
+            _sv = _scales[_k]
+            _sv_f = _sv.view(torch.uint8).flatten()[:8].cpu().tolist()
+            print(f"[FIN-W4A8-QKV] tmp_weight_scale[{_k}] shape={list(_sv.shape)} first8(uint8)={_sv_f}", file=_sys.stderr, flush=True)
+
+        # Shuffle the fully-assembled fused weight.
+        shuffled = fp4_utils.shuffle_matrix_a(module.weight,
+                                              module.epilogue_tile_m)
+        copy_weight(module.weight, shuffled)
+        _w_post = module.weight.flatten()[:16].cpu().tolist()
+        print(f"[FIN-W4A8-QKV] w post-shuffle (first 16 uint8): {_w_post}", file=_sys.stderr, flush=True)
+
+        # Concat per-shard weight_scales in canonical order, then swizzle.
+        weight_mode = module.weights_loading_config.weight_mode
+        ordered_scales = [
+            module.tmp_w4a8_weight_scales[key]
+            for key in weight_mode.shard_keys
+        ]
+        weight_scale = torch.cat(ordered_scales, 0)
         weight_scale = fp4_utils.shuffle_matrix_sf_a(weight_scale,
                                                      module.epilogue_tile_m,
                                                      module.scaling_vector_size)
-        copy_weight(module.input_scale, input_scale)
-        copy_weight(module.inv_input_scale, 1.0 / input_scale)
         copy_weight(module.weight_scale, weight_scale)
-        copy_weight(module.weight_scale_2, weight_scale_2)
-        copy_weight(module.alpha, alpha)
+        _ws_post_u = module.weight_scale.view(torch.uint8).flatten()[:16].cpu().tolist()
+        _ws_post_f = module.weight_scale.view(torch.float8_e4m3fn).float().flatten()[:16].cpu().tolist()
+        print(f"[FIN-W4A8-QKV] weight_scale post-swizzle first16 u8={_ws_post_u} float={_ws_post_f}", file=_sys.stderr, flush=True)
 
-        fused_weight = torch.cat((q_weight, k_weight, v_weight))
-        fused_weight = fp4_utils.shuffle_matrix_a(fused_weight,
-                                                  module.epilogue_tile_m)
-        copy_weight(module.weight, fused_weight)
+        # Finalize per-tensor scales. input_scale / alpha / inv_input_scale
+        # may be None for dynamic activation quantization.
+        input_scale, weight_scale_2, alpha, inv_input_scale = \
+            self._finalize_w4a8_scales(module)
+        print(
+            f"[FIN-W4A8-QKV] scales: input_scale={input_scale} weight_scale_2={weight_scale_2} alpha={alpha} inv_input_scale={inv_input_scale}",
+            file=_sys.stderr, flush=True)
+        if input_scale is not None:
+            copy_weight(module.input_scale, input_scale)
+        if inv_input_scale is not None:
+            copy_weight(module.inv_input_scale, inv_input_scale)
+        if weight_scale_2 is not None:
+            copy_weight(module.weight_scale_2, weight_scale_2)
+        if alpha is not None:
+            copy_weight(module.alpha, alpha)
 
-    def load_weights_fused_gate_up_linear(self, module: Linear,
-                                          weights: List[Dict]) -> None:
+        import torch as _t
+        _ws = module.weight_scale if hasattr(module, "weight_scale") else None
+        print(
+            f"[FIN-W4A8-QKV] post: w nan={_t.isnan(module.weight.float()).any().item()} ws nan={_t.isnan(_ws.float()).any().item() if _ws is not None else None}",
+            file=_sys.stderr, flush=True)
+
+        self._cleanup_w4a8_tmp_attrs(module)
+
+    def load_weights_fused_gate_up_linear(
+            self,
+            module: Linear,
+            weights: List[Dict],
+            allow_partial_loading: bool = False) -> None:
         gate_weight, up_weight = load_weights_fused_gate_up_helper(
-            module, weights)
-        fused_weight = torch.cat((gate_weight, up_weight))
-        fused_weight = fp4_utils.shuffle_matrix_a(fused_weight,
-                                                  module.epilogue_tile_m)
-        copy_weight(module.weight, fused_weight)
+            module, weights, allow_partial_loading=allow_partial_loading)
 
-        input_scale, weight_scales, weight_scale_2, alpha = self.load_weight_scales(
-            weights,
-            tp_size=module.tp_size,
-            tp_rank=module.tp_rank,
-            tp_mode=module.tp_mode)
-        # Swizzle weight scales after concatenation
-        weight_scale = torch.cat(weight_scales, 0)
-        # Shuffle and Swizzle weight scale
+        for shard_key, weight in zip(('gate', 'up'),
+                                     (gate_weight, up_weight)):
+            if weight is not None:
+                shard_offset, shard_size = module.fused_weight_shard_indices_mapping[
+                    shard_key]
+                copy_weight_shard(module.weight, weight, shard_offset,
+                                  shard_size)
+
+        weight_mode = module.weights_loading_config.weight_mode
+        self.load_weight_scales(module,
+                                weights[:2],
+                                shard_keys=weight_mode.shard_keys)
+
+    def process_weights_after_loading_fused_gate_up_linear(
+            self, module: Linear):
+        import sys as _sys
+        _has_tmp = hasattr(module, "tmp_w4a8_weight_scales")
+        _scales = getattr(module, "tmp_w4a8_weight_scales", None)
+        print(
+            f"[FIN-W4A8-GU] enter has_tmp={_has_tmp} "
+            f"scale_keys={list(_scales.keys()) if _scales else None} "
+            f"w.shape={list(module.weight.shape)}",
+            file=_sys.stderr, flush=True)
+        if not _has_tmp:
+            print("[FIN-W4A8-GU]   EARLY RETURN (no tmp)", file=_sys.stderr, flush=True)
+            return
+
+        # Shuffle the fully-assembled fused weight.
+        shuffled = fp4_utils.shuffle_matrix_a(module.weight,
+                                              module.epilogue_tile_m)
+        copy_weight(module.weight, shuffled)
+
+        # Concat per-shard weight_scales in canonical order, then swizzle.
+        weight_mode = module.weights_loading_config.weight_mode
+        ordered_scales = [
+            module.tmp_w4a8_weight_scales[key]
+            for key in weight_mode.shard_keys
+        ]
+        weight_scale = torch.cat(ordered_scales, 0)
         weight_scale = fp4_utils.shuffle_matrix_sf_a(weight_scale,
                                                      module.epilogue_tile_m,
                                                      module.scaling_vector_size)
-        copy_weight(module.input_scale, input_scale)
-        copy_weight(module.inv_input_scale, 1.0 / input_scale)
         copy_weight(module.weight_scale, weight_scale)
-        copy_weight(module.weight_scale_2, weight_scale_2)
-        copy_weight(module.alpha, alpha)
+
+        # Finalize per-tensor scales. input_scale / alpha / inv_input_scale
+        # may be None for dynamic activation quantization.
+        input_scale, weight_scale_2, alpha, inv_input_scale = \
+            self._finalize_w4a8_scales(module)
+        print(
+            f"[FIN-W4A8-GU] scales: input_scale={input_scale} weight_scale_2={weight_scale_2} alpha={alpha} inv_input_scale={inv_input_scale}",
+            file=_sys.stderr, flush=True)
+        if input_scale is not None:
+            copy_weight(module.input_scale, input_scale)
+        if inv_input_scale is not None:
+            copy_weight(module.inv_input_scale, inv_input_scale)
+        if weight_scale_2 is not None:
+            copy_weight(module.weight_scale_2, weight_scale_2)
+        if alpha is not None:
+            copy_weight(module.alpha, alpha)
+
+        self._cleanup_w4a8_tmp_attrs(module)
 
 
 class W4A8MXFP4FP8LinearMethod(LinearMethodBase):
@@ -2873,7 +3093,29 @@ class Linear(nn.Module):
 
         self.rebuild_tensor_metadata = {}
 
+        # DEBUG-W4A8: log quant_config + chosen quant_method (TEMP; revert me)
+        import sys as _sys
+        _qc = self.quant_config
+        _qa = getattr(_qc, "quant_algo", None) if _qc is not None else None
+        _lqm = None
+        if _qc is not None:
+            try:
+                _lqm = _qc.layer_quant_mode
+            except Exception as _e:
+                _lqm = f"<error: {_e}>"
+        print(
+            f"[DBG-LIN] in={self.in_features} out={self.out_features} "
+            f"qc_is_none={_qc is None} quant_algo={_qa!r} "
+            f"layer_quant_mode={_lqm!r} "
+            f"has_any_quant={(_qc is not None and _lqm is not None and hasattr(_lqm, 'has_any_quant') and _lqm.has_any_quant(exclude_kv_cache=True))!r}",
+            file=_sys.stderr, flush=True)
+
         self.quant_method = self.get_quant_method(self.quant_config)
+
+        print(
+            f"[DBG-LIN]   → picked quant_method={type(self.quant_method).__name__}",
+            file=_sys.stderr, flush=True)
+
         self.quant_method.create_weights(self, self.in_features,
                                          self.out_features, self.has_bias,
                                          self.dtype)
@@ -3036,7 +3278,7 @@ class Linear(nn.Module):
         weight_mode = self.weights_loading_config.weight_mode
         if not isinstance(self.quant_method,
                           (UnquantizedLinearMethod, FP8BlockScalesLinearMethod,
-                           NVFP4LinearMethod)):
+                           NVFP4LinearMethod, W4A8NVFP4FP8LinearMethod)):
             assert allow_partial_loading is False, (
                 f"{type(self.quant_method).__name__} does not support "
                 "allow_partial_loading")
@@ -3047,6 +3289,13 @@ class Linear(nn.Module):
             allow_partial_loading=allow_partial_loading)
 
     def process_weights_after_loading(self):
+        import sys as _sys
+        _qm = type(self.quant_method).__name__
+        _wm = getattr(self.weights_loading_config, "weight_mode", None)
+        _wr = getattr(self, "_weights_removed", False)
+        print(
+            f"[LIN-PWAL] called: quant_method={_qm} weight_mode={_wm} _weights_removed={_wr}",
+            file=_sys.stderr, flush=True)
         self.quant_method.process_weights_after_loading(self)
 
     def post_load_weights(self):

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -1908,12 +1908,6 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
 
     def apply(self, module: Linear, input: torch.Tensor,
               bias: Optional[torch.Tensor]):
-        import sys as _sys
-        # Sync-free diagnostic (no .item() / .any()) — safe during CUDA graph capture.
-        print(
-            f"[APPLY-W4A8] in.shape={list(input.shape)} in.dtype={input.dtype} "
-            f"out={list(module.weight.shape)} fdq={getattr(module, 'force_dynamic_quantization', False)}",
-            file=_sys.stderr, flush=True)
         alpha = module.alpha
         if input.dtype != torch.float8_e4m3fn:
             if module.input_scale is not None and not module.force_dynamic_quantization:
@@ -2060,16 +2054,7 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
         self.load_weight_scales(module, weights, shard_keys=None)
 
     def process_weights_after_loading_vanilla(self, module: Linear):
-        import sys as _sys
-        _has_tmp = hasattr(module, "tmp_w4a8_input_scales_list")
-        _w = module.weight if hasattr(module, "weight") else None
-        print(
-            f"[FIN-W4A8-V] enter has_tmp={_has_tmp} "
-            f"w.shape={list(_w.shape) if _w is not None else None} "
-            f"w.dtype={_w.dtype if _w is not None else None}",
-            file=_sys.stderr, flush=True)
-        if not _has_tmp:
-            print("[FIN-W4A8-V]   EARLY RETURN (no tmp)", file=_sys.stderr, flush=True)
+        if not hasattr(module, "tmp_w4a8_input_scales_list"):
             return
 
         # Shuffle weight on the fully-loaded tensor.
@@ -2081,10 +2066,6 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
         # may be None for dynamic activation quantization.
         input_scale, weight_scale_2, alpha, inv_input_scale = \
             self._finalize_w4a8_scales(module)
-        print(
-            f"[FIN-W4A8-V] scales: input_scale={input_scale} "
-            f"weight_scale_2={weight_scale_2} alpha={alpha} inv_input_scale={inv_input_scale}",
-            file=_sys.stderr, flush=True)
         if input_scale is not None:
             copy_weight(module.input_scale, input_scale)
         if inv_input_scale is not None:
@@ -2093,16 +2074,6 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
             copy_weight(module.weight_scale_2, weight_scale_2)
         if alpha is not None:
             copy_weight(module.alpha, alpha)
-
-        # DEBUG: check final state
-        import torch as _t
-        _ws = module.weight_scale if hasattr(module, "weight_scale") else None
-        print(
-            f"[FIN-W4A8-V] post-finalize: "
-            f"w nan={_t.isnan(module.weight.float()).any().item()} "
-            f"ws.shape={list(_ws.shape) if _ws is not None else None} "
-            f"ws nan={_t.isnan(_ws.float()).any().item() if _ws is not None else None}",
-            file=_sys.stderr, flush=True)
 
         self._cleanup_w4a8_tmp_attrs(module)
 
@@ -2132,33 +2103,13 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
                                 shard_keys=weight_mode.shard_keys)
 
     def process_weights_after_loading_fused_qkv_linear(self, module: Linear):
-        import sys as _sys
-        _has_tmp = hasattr(module, "tmp_w4a8_weight_scales")
-        _scales = getattr(module, "tmp_w4a8_weight_scales", None)
-        print(
-            f"[FIN-W4A8-QKV] enter has_tmp={_has_tmp} "
-            f"scale_keys={list(_scales.keys()) if _scales else None} "
-            f"w.shape={list(module.weight.shape)}",
-            file=_sys.stderr, flush=True)
-        if not _has_tmp:
-            print("[FIN-W4A8-QKV]   EARLY RETURN (no tmp)", file=_sys.stderr, flush=True)
+        if not hasattr(module, "tmp_w4a8_weight_scales"):
             return
-
-        # Pre-shuffle weight content
-        _w_pre = module.weight.flatten()[:16].cpu().tolist()
-        print(f"[FIN-W4A8-QKV] w pre-shuffle (first 16 uint8): {_w_pre}", file=_sys.stderr, flush=True)
-        # Per-shard scale stats
-        for _k in (_scales or {}):
-            _sv = _scales[_k]
-            _sv_f = _sv.view(torch.uint8).flatten()[:8].cpu().tolist()
-            print(f"[FIN-W4A8-QKV] tmp_weight_scale[{_k}] shape={list(_sv.shape)} first8(uint8)={_sv_f}", file=_sys.stderr, flush=True)
 
         # Shuffle the fully-assembled fused weight.
         shuffled = fp4_utils.shuffle_matrix_a(module.weight,
                                               module.epilogue_tile_m)
         copy_weight(module.weight, shuffled)
-        _w_post = module.weight.flatten()[:16].cpu().tolist()
-        print(f"[FIN-W4A8-QKV] w post-shuffle (first 16 uint8): {_w_post}", file=_sys.stderr, flush=True)
 
         # Concat per-shard weight_scales in canonical order, then swizzle.
         weight_mode = module.weights_loading_config.weight_mode
@@ -2171,17 +2122,11 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
                                                      module.epilogue_tile_m,
                                                      module.scaling_vector_size)
         copy_weight(module.weight_scale, weight_scale)
-        _ws_post_u = module.weight_scale.view(torch.uint8).flatten()[:16].cpu().tolist()
-        _ws_post_f = module.weight_scale.view(torch.float8_e4m3fn).float().flatten()[:16].cpu().tolist()
-        print(f"[FIN-W4A8-QKV] weight_scale post-swizzle first16 u8={_ws_post_u} float={_ws_post_f}", file=_sys.stderr, flush=True)
 
         # Finalize per-tensor scales. input_scale / alpha / inv_input_scale
         # may be None for dynamic activation quantization.
         input_scale, weight_scale_2, alpha, inv_input_scale = \
             self._finalize_w4a8_scales(module)
-        print(
-            f"[FIN-W4A8-QKV] scales: input_scale={input_scale} weight_scale_2={weight_scale_2} alpha={alpha} inv_input_scale={inv_input_scale}",
-            file=_sys.stderr, flush=True)
         if input_scale is not None:
             copy_weight(module.input_scale, input_scale)
         if inv_input_scale is not None:
@@ -2190,12 +2135,6 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
             copy_weight(module.weight_scale_2, weight_scale_2)
         if alpha is not None:
             copy_weight(module.alpha, alpha)
-
-        import torch as _t
-        _ws = module.weight_scale if hasattr(module, "weight_scale") else None
-        print(
-            f"[FIN-W4A8-QKV] post: w nan={_t.isnan(module.weight.float()).any().item()} ws nan={_t.isnan(_ws.float()).any().item() if _ws is not None else None}",
-            file=_sys.stderr, flush=True)
 
         self._cleanup_w4a8_tmp_attrs(module)
 
@@ -2222,16 +2161,7 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
 
     def process_weights_after_loading_fused_gate_up_linear(
             self, module: Linear):
-        import sys as _sys
-        _has_tmp = hasattr(module, "tmp_w4a8_weight_scales")
-        _scales = getattr(module, "tmp_w4a8_weight_scales", None)
-        print(
-            f"[FIN-W4A8-GU] enter has_tmp={_has_tmp} "
-            f"scale_keys={list(_scales.keys()) if _scales else None} "
-            f"w.shape={list(module.weight.shape)}",
-            file=_sys.stderr, flush=True)
-        if not _has_tmp:
-            print("[FIN-W4A8-GU]   EARLY RETURN (no tmp)", file=_sys.stderr, flush=True)
+        if not hasattr(module, "tmp_w4a8_weight_scales"):
             return
 
         # Shuffle the fully-assembled fused weight.
@@ -2255,9 +2185,6 @@ class W4A8NVFP4FP8LinearMethod(LinearMethodBase):
         # may be None for dynamic activation quantization.
         input_scale, weight_scale_2, alpha, inv_input_scale = \
             self._finalize_w4a8_scales(module)
-        print(
-            f"[FIN-W4A8-GU] scales: input_scale={input_scale} weight_scale_2={weight_scale_2} alpha={alpha} inv_input_scale={inv_input_scale}",
-            file=_sys.stderr, flush=True)
         if input_scale is not None:
             copy_weight(module.input_scale, input_scale)
         if inv_input_scale is not None:
@@ -3093,29 +3020,7 @@ class Linear(nn.Module):
 
         self.rebuild_tensor_metadata = {}
 
-        # DEBUG-W4A8: log quant_config + chosen quant_method (TEMP; revert me)
-        import sys as _sys
-        _qc = self.quant_config
-        _qa = getattr(_qc, "quant_algo", None) if _qc is not None else None
-        _lqm = None
-        if _qc is not None:
-            try:
-                _lqm = _qc.layer_quant_mode
-            except Exception as _e:
-                _lqm = f"<error: {_e}>"
-        print(
-            f"[DBG-LIN] in={self.in_features} out={self.out_features} "
-            f"qc_is_none={_qc is None} quant_algo={_qa!r} "
-            f"layer_quant_mode={_lqm!r} "
-            f"has_any_quant={(_qc is not None and _lqm is not None and hasattr(_lqm, 'has_any_quant') and _lqm.has_any_quant(exclude_kv_cache=True))!r}",
-            file=_sys.stderr, flush=True)
-
         self.quant_method = self.get_quant_method(self.quant_config)
-
-        print(
-            f"[DBG-LIN]   → picked quant_method={type(self.quant_method).__name__}",
-            file=_sys.stderr, flush=True)
-
         self.quant_method.create_weights(self, self.in_features,
                                          self.out_features, self.has_bias,
                                          self.dtype)
@@ -3289,13 +3194,6 @@ class Linear(nn.Module):
             allow_partial_loading=allow_partial_loading)
 
     def process_weights_after_loading(self):
-        import sys as _sys
-        _qm = type(self.quant_method).__name__
-        _wm = getattr(self.weights_loading_config, "weight_mode", None)
-        _wr = getattr(self, "_weights_removed", False)
-        print(
-            f"[LIN-PWAL] called: quant_method={_qm} weight_mode={_wm} _weights_removed={_wr}",
-            file=_sys.stderr, flush=True)
         self.quant_method.process_weights_after_loading(self)
 
     def post_load_weights(self):

--- a/tests/unittest/_torch/ray_orchestrator/single_gpu/test_llm_update_weights.py
+++ b/tests/unittest/_torch/ray_orchestrator/single_gpu/test_llm_update_weights.py
@@ -5,6 +5,7 @@ from typing import Callable, List, Optional, Tuple
 
 import pytest
 import torch
+from torch import nn
 from torch.multiprocessing.reductions import reduce_tensor
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 from utils.llm_data import llm_models_root
@@ -416,15 +417,17 @@ class RefW4A8NVFP4FP8ModelWithIPCHandles(RefHFModel):
     Mirrors ``RefNVFP4ModelWithIPCHandles`` from the multi-GPU test file but:
     - uses block size 32 (vs NVFP4's 16) to match
       ``W4A8NVFP4FP8LinearMethod.scaling_vector_size``
-    - skips ``input_scale``: the W4A8 LLM is configured with
-      ``force_dynamic_quantization=True``, so the per-tensor input scale is
-      computed at runtime and does not need to be provided through IPC.
+    - calibrates per-Linear ``input_scale`` by hooking nn.Linear inputs
+      while the bf16 HF model runs the calibration prompts. The resulting
+      ``input_scale = amax/448`` is shipped via IPC alongside the FP4
+      weight + FP8 block scale + FP32 weight_scale_2.
 
     Provides IPC handles with keys ``weight`` (FP4 packed uint8),
-    ``weight_scale`` (FP8 per-block), and ``weight_scale_2`` (fp32
-    per-tensor). q/k/v and gate/up projections in a fusion group share a
-    unified ``weight_scale_2`` so the per-tensor cross-shard consistency
-    check inside ``_finalize_w4a8_scales`` passes.
+    ``weight_scale`` (FP8 per-block), ``weight_scale_2`` (fp32 per-tensor),
+    and ``input_scale`` (fp32 per-tensor, static). q/k/v and gate/up
+    projections in a fusion group share a unified ``weight_scale_2`` so
+    the per-tensor cross-shard consistency check inside
+    ``_finalize_w4a8_scales`` passes.
     """
 
     W4A8_BLOCK_SIZE = 32
@@ -456,10 +459,19 @@ class RefW4A8NVFP4FP8ModelWithIPCHandles(RefHFModel):
     )
     _PROJ_TO_GROUP = {proj: group for group in FUSION_GROUPS for proj in group}
 
+    # 4 prompts used both for calibration and at test time (same input distribution).
+    CALIBRATION_PROMPTS = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+
     def __init__(
         self, model_dir: str, device_id: int = 0, num_hidden_layers: Optional[int] = None
     ):
         self.device_id = device_id
+        self.model_dir = model_dir
         config = AutoConfig.from_pretrained(model_dir)
         if num_hidden_layers is not None:
             config.num_hidden_layers = num_hidden_layers
@@ -468,8 +480,59 @@ class RefW4A8NVFP4FP8ModelWithIPCHandles(RefHFModel):
         ).to(f"cuda:{device_id}")
         self.all_weights = {}
         self._dequantized_weights = {}
+        # input_scales[<linear-name>.weight] = FP32 scalar (amax/448) used for static
+        # FP8 activation quantization. Filled by _calibrate_input_scales().
+        self.input_scales: dict = {}
         self.device_uuid = [get_device_uuid(i) for i in range(torch.cuda.device_count())]
+        self._calibrate_input_scales()
         self._quantize_and_replicate_weights()
+
+    def _calibrate_input_scales(self):
+        """Run the HF model on a few prompts, hooking every nn.Linear's input
+        to collect per-tensor amax. ``input_scale = amax / 448`` (FP8 e4m3fn max).
+
+        Stored under the same key the weight uses (``<name>.weight`` →
+        ``<name>.input_scale``) so the IPC handle can ship them alongside the
+        FP4 weights for static activation quantization on the LLM side.
+        """
+        amax: dict = {}
+        hooks = []
+
+        def make_hook(linear_name):
+            def hook(_mod, inputs):
+                x = inputs[0]
+                # inputs may be a tuple (x, ...) for some Linear subclasses; first elem is the activation.
+                if not isinstance(x, torch.Tensor):
+                    return
+                cur = x.detach().float().abs().amax().item()
+                amax[linear_name] = max(amax.get(linear_name, 0.0), cur)
+            return hook
+
+        for name, mod in self.model.named_modules():
+            if isinstance(mod, nn.Linear):
+                hooks.append(mod.register_forward_pre_hook(make_hook(name)))
+
+        tokenizer = AutoTokenizer.from_pretrained(self.model_dir)
+        device = f"cuda:{self.device_id}"
+        self.model.eval()
+        with torch.no_grad():
+            for prompt in self.CALIBRATION_PROMPTS:
+                ids = torch.tensor(
+                    [tokenizer.encode(prompt)], dtype=torch.long, device=device
+                )
+                self.model(ids)
+        for h in hooks:
+            h.remove()
+        del tokenizer
+
+        # Convert amax to input_scale (FP32 scalar) on CUDA so IPC reduce_tensor works.
+        for linear_name, a in amax.items():
+            if a <= 0.0:
+                # No tokens routed through this expert during calibration — fall back to 1.0
+                a = 1.0
+            self.input_scales[f"{linear_name}.weight"] = torch.tensor(
+                a / 448.0, dtype=torch.float32, device=device
+            )
 
     @staticmethod
     def _unfuse_moe_expert_params(all_params):
@@ -607,11 +670,26 @@ class RefW4A8NVFP4FP8ModelWithIPCHandles(RefHFModel):
             torch.bfloat16,
         )
 
-        return [
+        entries = [
             (name, packed_uint8),
             (name + "_scale", block_scale_fp8),
             (name + "_scale_2", weight_scale_2),
         ]
+        # Static activation quantization: ship per-tensor input_scale calibrated
+        # offline. Required for the MoE TRTLLMGen W4A8 NVFP4 FP8 path
+        # (fused_moe_trtllm_gen.py: it calls
+        # ``static_quantize_e4m3_per_tensor(x, 1.0/fc31_input_scale)`` with no
+        # dynamic-quant fallback). Dense W4A8NVFP4FP8LinearMethod consumes the
+        # same key via load_weight_scales and stashes it in
+        # tmp_w4a8_input_scales_list for the alpha computation in finalize.
+        # Key format: replace ``.weight`` suffix with ``.input_scale``, mirroring
+        # how modelopt-emitted checkpoints carry these per-Linear tensors.
+        if name.endswith(".weight") and name in self.input_scales:
+            entries.append(
+                (name.replace(".weight", ".input_scale"),
+                 self.input_scales[name].clone())
+            )
+        return entries
 
     def get_weight_ipc_handles_serialized(
         self,
@@ -650,6 +728,10 @@ def test_llm_update_weights_w4a8_nvfp4_fp8(model_dir):
     )
     tokenizer = AutoTokenizer.from_pretrained(model_dir)
     kv_cache_config = KvCacheConfig(enable_block_reuse=True, free_gpu_memory_fraction=0.1)
+    # TRTLLM (trtllm_gen) is the only MoE backend with a W4A8_NVFP4_FP8 dispatch
+    # case today (W4A8NVFP4FP8TRTLLMGenFusedMoEMethod). Cutlass / DeepGemm
+    # backends do not (would hit "Unsupported quantization mode: [16384]").
+    moe_config = MoeConfig(backend="TRTLLM")
     with LLM(
         model=model_dir,
         ray_worker_extension_cls="tensorrt_llm.llmapi.rlhf_utils.WorkerExtension",
@@ -657,7 +739,6 @@ def test_llm_update_weights_w4a8_nvfp4_fp8(model_dir):
         load_format="dummy",
         pipeline_parallel_size=1,
         kv_cache_config=kv_cache_config,
-        force_dynamic_quantization=True,
         model_kwargs={
             "num_hidden_layers": num_hidden_layers,
             "quantization_config": {
@@ -667,6 +748,7 @@ def test_llm_update_weights_w4a8_nvfp4_fp8(model_dir):
                 "exclude_modules": ["*mlp.gate", "lm_head"],
             },
         },
+        moe_config=moe_config,
     ) as llm:
         prompts_texts = [
             "Hello, my name is",
@@ -706,6 +788,9 @@ def test_llm_partial_update_weights_w4a8_nvfp4_fp8(model_dir):
     )
     tokenizer = AutoTokenizer.from_pretrained(model_dir)
     kv_cache_config = KvCacheConfig(enable_block_reuse=True, free_gpu_memory_fraction=0.1)
+    # See note in test_llm_update_weights_w4a8_nvfp4_fp8: only TRTLLM (trtllm_gen)
+    # MoE backend has a W4A8_NVFP4_FP8 dispatch case today.
+    moe_config = MoeConfig(backend="TRTLLM")
     with LLM(
         model=model_dir,
         ray_worker_extension_cls="tensorrt_llm.llmapi.rlhf_utils.WorkerExtension",
@@ -713,7 +798,6 @@ def test_llm_partial_update_weights_w4a8_nvfp4_fp8(model_dir):
         load_format="dummy",
         pipeline_parallel_size=1,
         kv_cache_config=kv_cache_config,
-        force_dynamic_quantization=True,
         model_kwargs={
             "num_hidden_layers": num_hidden_layers,
             "quantization_config": {
@@ -723,6 +807,7 @@ def test_llm_partial_update_weights_w4a8_nvfp4_fp8(model_dir):
                 "exclude_modules": ["*mlp.gate", "lm_head"],
             },
         },
+        moe_config=moe_config,
     ) as llm:
         prompts_texts = [
             "Hello, my name is",

--- a/tests/unittest/_torch/ray_orchestrator/single_gpu/test_llm_update_weights.py
+++ b/tests/unittest/_torch/ray_orchestrator/single_gpu/test_llm_update_weights.py
@@ -16,12 +16,9 @@ from tensorrt_llm import LLM
 from tensorrt_llm._torch.utils import get_device_uuid
 from tensorrt_llm.llmapi import KvCacheConfig, MoeConfig, SamplingParams
 
-
 # E2M1 boundary midpoints — round to nearest E2M1 magnitude:
 #   0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0  (ord 0..7)
-_E2M1_BOUNDS = torch.tensor(
-    [0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0], dtype=torch.float32
-)
+_E2M1_BOUNDS = torch.tensor([0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0], dtype=torch.float32)
 
 
 def _quantize_w4a8_canonical(
@@ -52,7 +49,7 @@ def _quantize_w4a8_canonical(
     # C++ uses ``scaleExp = floor(log2(amax)) - 2``; scale = 2^scaleExp ~= amax/4.
     scale_exp = (torch.floor(torch.log2(block_amax)).long() - 2).clamp(min=-6, max=7)
     # FP8 E4M3 byte: sign=0 (1 bit), exp (4 bits, bias 7), mantissa (3 bits)=0.
-    e4m3_byte = (((scale_exp + 7) & 0xFF).to(torch.uint8) << 3)  # [n, k/block]
+    e4m3_byte = ((scale_exp + 7) & 0xFF).to(torch.uint8) << 3  # [n, k/block]
     block_scale_fp8 = e4m3_byte.view(torch.float8_e4m3fn)
     # Recompute FP4 against the (mantissa-zero) power-of-2 scale.
     scale_float = torch.pow(2.0, scale_exp.float())
@@ -64,6 +61,7 @@ def _quantize_w4a8_canonical(
     fp4 = ((sign_bit << 3) | ord_val).flatten(start_dim=-2)  # [n, k] uint8
     fp4_packed = ((fp4[..., 1::2] & 0x0F) << 4) | (fp4[..., 0::2] & 0x0F)
     return fp4_packed.to(torch.uint8), block_scale_fp8, weight_scale_2
+
 
 # Ray-backed LLM teardown spawns the executor main-loop, GC and log/error
 # listener threads in ray-core. These are torn down only when ``ray.shutdown()``
@@ -368,8 +366,7 @@ def test_llm_update_weights_with_quant_config(model_dir, fp8_model_dir, kv_cache
 
 # E2M1 lookup table for the 16 FP4 values, used by the W4A8 reference dequantize.
 _E2M1_VALUES = torch.tensor(
-    [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
-     -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+    [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
     dtype=torch.float32,
 )
 
@@ -401,9 +398,7 @@ def _dequantize_nvfp4_block32(
 
     vals = _E2M1_VALUES.to(device)[idx]  # [N, K], float32
 
-    scale_real = (s1.to(torch.float32) * scale_2.to(torch.float32)).view(
-        n, k // block_size, 1
-    )
+    scale_real = (s1.to(torch.float32) * scale_2.to(torch.float32)).view(n, k // block_size, 1)
     vals = vals.view(n, k // block_size, block_size) * scale_real
     return vals.view(n, k).to(orig_dtype)
 
@@ -467,9 +462,7 @@ class RefW4A8NVFP4FP8ModelWithIPCHandles(RefHFModel):
         "The future of AI is",
     ]
 
-    def __init__(
-        self, model_dir: str, device_id: int = 0, num_hidden_layers: Optional[int] = None
-    ):
+    def __init__(self, model_dir: str, device_id: int = 0, num_hidden_layers: Optional[int] = None):
         self.device_id = device_id
         self.model_dir = model_dir
         config = AutoConfig.from_pretrained(model_dir)
@@ -506,6 +499,7 @@ class RefW4A8NVFP4FP8ModelWithIPCHandles(RefHFModel):
                     return
                 cur = x.detach().float().abs().amax().item()
                 amax[linear_name] = max(amax.get(linear_name, 0.0), cur)
+
             return hook
 
         for name, mod in self.model.named_modules():
@@ -517,9 +511,7 @@ class RefW4A8NVFP4FP8ModelWithIPCHandles(RefHFModel):
         self.model.eval()
         with torch.no_grad():
             for prompt in self.CALIBRATION_PROMPTS:
-                ids = torch.tensor(
-                    [tokenizer.encode(prompt)], dtype=torch.long, device=device
-                )
+                ids = torch.tensor([tokenizer.encode(prompt)], dtype=torch.long, device=device)
                 self.model(ids)
         for h in hooks:
             h.remove()
@@ -686,8 +678,7 @@ class RefW4A8NVFP4FP8ModelWithIPCHandles(RefHFModel):
         # how modelopt-emitted checkpoints carry these per-Linear tensors.
         if name.endswith(".weight") and name in self.input_scales:
             entries.append(
-                (name.replace(".weight", ".input_scale"),
-                 self.input_scales[name].clone())
+                (name.replace(".weight", ".input_scale"), self.input_scales[name].clone())
             )
         return entries
 
@@ -723,9 +714,7 @@ class RefW4A8NVFP4FP8ModelWithIPCHandles(RefHFModel):
 def test_llm_update_weights_w4a8_nvfp4_fp8(model_dir):
     model_dir = str(llm_models_root() / model_dir)
     num_hidden_layers = 1
-    hf_model = RefW4A8NVFP4FP8ModelWithIPCHandles(
-        model_dir, num_hidden_layers=num_hidden_layers
-    )
+    hf_model = RefW4A8NVFP4FP8ModelWithIPCHandles(model_dir, num_hidden_layers=num_hidden_layers)
     tokenizer = AutoTokenizer.from_pretrained(model_dir)
     kv_cache_config = KvCacheConfig(enable_block_reuse=True, free_gpu_memory_fraction=0.1)
     # TRTLLM (trtllm_gen) is the only MoE backend with a W4A8_NVFP4_FP8 dispatch
@@ -783,9 +772,7 @@ def test_llm_update_weights_w4a8_nvfp4_fp8(model_dir):
 def test_llm_partial_update_weights_w4a8_nvfp4_fp8(model_dir):
     model_dir = str(llm_models_root() / model_dir)
     num_hidden_layers = 1
-    hf_model = RefW4A8NVFP4FP8ModelWithIPCHandles(
-        model_dir, num_hidden_layers=num_hidden_layers
-    )
+    hf_model = RefW4A8NVFP4FP8ModelWithIPCHandles(model_dir, num_hidden_layers=num_hidden_layers)
     tokenizer = AutoTokenizer.from_pretrained(model_dir)
     kv_cache_config = KvCacheConfig(enable_block_reuse=True, free_gpu_memory_fraction=0.1)
     # See note in test_llm_update_weights_w4a8_nvfp4_fp8: only TRTLLM (trtllm_gen)

--- a/tests/unittest/_torch/ray_orchestrator/single_gpu/test_llm_update_weights.py
+++ b/tests/unittest/_torch/ray_orchestrator/single_gpu/test_llm_update_weights.py
@@ -12,11 +12,57 @@ from utils.torch_ref import RefHFModel
 from utils.util import getSMVersion, skip_pre_blackwell, skip_pre_hopper
 
 from tensorrt_llm import LLM
-from tensorrt_llm._torch.auto_deploy.custom_ops.quantization.torch_quant import (
-    _quantize_nvfp4,
-)
 from tensorrt_llm._torch.utils import get_device_uuid
 from tensorrt_llm.llmapi import KvCacheConfig, MoeConfig, SamplingParams
+
+
+# E2M1 boundary midpoints — round to nearest E2M1 magnitude:
+#   0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0  (ord 0..7)
+_E2M1_BOUNDS = torch.tensor(
+    [0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0], dtype=torch.float32
+)
+
+
+def _quantize_w4a8_canonical(
+    weight_float: torch.Tensor,
+    block_size: int,
+    weight_scale_2: torch.Tensor,
+):
+    """W4A8 NVFP4 FP8 quantization compatible with ``fp4_fp8_gemm_trtllmgen``.
+
+    Reproduces the convention emitted by the C++ op
+    ``float_to_e2m1_and_ufp8sf_scale`` (which the kernel was developed
+    against):
+    - per-block FP8 scale is stored as a *pure power of 2* (E4M3 byte with
+      mantissa bits zeroed). The exponent is ``floor(log2(block_amax)) - 2``
+      after scaling the input up by ``448 / amax_weight``.
+    - per-tensor ``weight_scale_2`` is ``amax_weight / 448`` (NOT
+      ``amax_weight / (6 * 448)`` as in modelopt 0.x / auto_deploy
+      ``_quantize_nvfp4``).
+    - FP4 values are recomputed AGAINST the power-of-2 block scale so the
+      stored ``(packed_fp4, fp8_scale)`` pair is self-consistent.
+    """
+    n, k = weight_float.shape
+    assert k % block_size == 0
+    a_global_sf = 1.0 / weight_scale_2  # = 448 / amax_weight
+    scaled = weight_float * a_global_sf  # values in ~[-448, 448]
+    scaled_blocked = scaled.view(n, k // block_size, block_size)
+    block_amax = scaled_blocked.abs().amax(dim=-1).clamp(min=1e-20)  # [n, k/block]
+    # C++ uses ``scaleExp = floor(log2(amax)) - 2``; scale = 2^scaleExp ~= amax/4.
+    scale_exp = (torch.floor(torch.log2(block_amax)).long() - 2).clamp(min=-6, max=7)
+    # FP8 E4M3 byte: sign=0 (1 bit), exp (4 bits, bias 7), mantissa (3 bits)=0.
+    e4m3_byte = (((scale_exp + 7) & 0xFF).to(torch.uint8) << 3)  # [n, k/block]
+    block_scale_fp8 = e4m3_byte.view(torch.float8_e4m3fn)
+    # Recompute FP4 against the (mantissa-zero) power-of-2 scale.
+    scale_float = torch.pow(2.0, scale_exp.float())
+    scaled_norm = (scaled_blocked / scale_float.unsqueeze(-1)).clamp(min=-6.0, max=6.0)
+    abs_val = scaled_norm.abs()
+    sign_bit = (scaled_norm < 0).to(torch.uint8)
+    bounds = _E2M1_BOUNDS.to(weight_float.device)
+    ord_val = (abs_val.unsqueeze(-1) > bounds).sum(dim=-1).to(torch.uint8).clamp(max=7)
+    fp4 = ((sign_bit << 3) | ord_val).flatten(start_dim=-2)  # [n, k] uint8
+    fp4_packed = ((fp4[..., 1::2] & 0x0F) << 4) | (fp4[..., 0::2] & 0x0F)
+    return fp4_packed.to(torch.uint8), block_scale_fp8, weight_scale_2
 
 # Ray-backed LLM teardown spawns the executor main-loop, GC and log/error
 # listener threads in ray-core. These are torn down only when ``ray.shutdown()``
@@ -528,7 +574,9 @@ class RefW4A8NVFP4FP8ModelWithIPCHandles(RefHFModel):
 
     def _quantize_fusion_group(self, group: tuple, projs: dict) -> List[tuple]:
         all_amaxes = [v.float().abs().amax() for _, v in projs.values()]
-        unified_scale_2 = torch.stack(all_amaxes).amax() / (6.0 * 448.0)
+        # weight_scale_2 = amax/448 (NOT amax/(6*448)) — matches the convention
+        # the kernel's canonical quantizer (float_to_e2m1_and_ufp8sf_scale) uses.
+        unified_scale_2 = torch.stack(all_amaxes).amax() / 448.0
 
         results = []
         for proj_type in group:
@@ -545,13 +593,11 @@ class RefW4A8NVFP4FP8ModelWithIPCHandles(RefHFModel):
     ) -> List[tuple]:
         weight_float = weight.float()
         if weight_scale_2 is None:
-            weight_scale_2 = weight_float.abs().amax().float() / (6.0 * 448.0)
+            weight_scale_2 = weight_float.abs().amax().float() / 448.0
 
-        packed_weight, block_scale = _quantize_nvfp4(
+        packed_uint8, block_scale_fp8, _ws2 = _quantize_w4a8_canonical(
             weight_float, self.W4A8_BLOCK_SIZE, weight_scale_2
         )
-        packed_uint8 = packed_weight.to(torch.uint8)
-        block_scale_fp8 = block_scale.to(torch.float8_e4m3fn)
 
         self._dequantized_weights[name] = _dequantize_nvfp4_block32(
             packed_uint8,

--- a/tests/unittest/_torch/ray_orchestrator/single_gpu/test_llm_update_weights.py
+++ b/tests/unittest/_torch/ray_orchestrator/single_gpu/test_llm_update_weights.py
@@ -9,9 +9,12 @@ from torch.multiprocessing.reductions import reduce_tensor
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 from utils.llm_data import llm_models_root
 from utils.torch_ref import RefHFModel
-from utils.util import getSMVersion, skip_pre_hopper
+from utils.util import getSMVersion, skip_pre_blackwell, skip_pre_hopper
 
 from tensorrt_llm import LLM
+from tensorrt_llm._torch.auto_deploy.custom_ops.quantization.torch_quant import (
+    _quantize_nvfp4,
+)
 from tensorrt_llm._torch.utils import get_device_uuid
 from tensorrt_llm.llmapi import KvCacheConfig, MoeConfig, SamplingParams
 
@@ -314,3 +317,401 @@ def test_llm_update_weights_with_quant_config(model_dir, fp8_model_dir, kv_cache
 
         llm_logits, ref_logits = run_generate(llm, hf_model, prompts, sampling_params)
         compare_logits(llm_logits, ref_logits)
+
+
+# E2M1 lookup table for the 16 FP4 values, used by the W4A8 reference dequantize.
+_E2M1_VALUES = torch.tensor(
+    [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+     -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+    dtype=torch.float32,
+)
+
+
+def _dequantize_nvfp4_block32(
+    quantized_t: torch.Tensor,  # [N, K/2] uint8 (packed E2M1x2)
+    scale_1: torch.Tensor,  # per-block FP8 scale (flat or shaped)
+    scale_2: torch.Tensor,  # per-tensor fp32 scale
+    orig_shape: tuple,
+    orig_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Dequantize NVFP4-packed weight with block size 32.
+
+    The W4A8 NVFP4 FP8 path uses a 32-element block, whereas the existing
+    ``_dequantize_nvfp4`` helper from ``auto_deploy.torch_quant`` hardcodes
+    block size 16, so we need a local copy here.
+    """
+    device = quantized_t.device
+    n, k = orig_shape
+    block_size = 32
+    num_blocks = n * (k // block_size)
+    s1 = scale_1.reshape(-1)[:num_blocks]
+
+    high = (quantized_t >> 4) & 0x0F
+    low = quantized_t & 0x0F
+    idx = torch.empty(n, (k // 2) * 2, dtype=torch.long, device=device)
+    idx[..., 0::2] = low.long()
+    idx[..., 1::2] = high.long()
+
+    vals = _E2M1_VALUES.to(device)[idx]  # [N, K], float32
+
+    scale_real = (s1.to(torch.float32) * scale_2.to(torch.float32)).view(
+        n, k // block_size, 1
+    )
+    vals = vals.view(n, k // block_size, block_size) * scale_real
+    return vals.view(n, k).to(orig_dtype)
+
+
+class RefW4A8NVFP4FP8ModelWithIPCHandles(RefHFModel):
+    """Reference model that loads bf16 weights from HuggingFace, quantizes
+    them to the W4A8 NVFP4 FP8 weight format (FP4 packed weight + FP8 block
+    scale + fp32 weight_scale_2), and keeps a round-tripped bf16 model for
+    HF reference inference.
+
+    Mirrors ``RefNVFP4ModelWithIPCHandles`` from the multi-GPU test file but:
+    - uses block size 32 (vs NVFP4's 16) to match
+      ``W4A8NVFP4FP8LinearMethod.scaling_vector_size``
+    - skips ``input_scale``: the W4A8 LLM is configured with
+      ``force_dynamic_quantization=True``, so the per-tensor input scale is
+      computed at runtime and does not need to be provided through IPC.
+
+    Provides IPC handles with keys ``weight`` (FP4 packed uint8),
+    ``weight_scale`` (FP8 per-block), and ``weight_scale_2`` (fp32
+    per-tensor). q/k/v and gate/up projections in a fusion group share a
+    unified ``weight_scale_2`` so the per-tensor cross-shard consistency
+    check inside ``_finalize_w4a8_scales`` passes.
+    """
+
+    W4A8_BLOCK_SIZE = 32
+
+    EXCLUDE_PATTERNS = [
+        "embed_tokens",
+        "lm_head",
+        "layernorm",
+        "norm",
+        "ln_",
+        "embeddings",
+        "mlp.gate.weight",
+    ]
+    INCLUDE_PATTERNS = [
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "o_proj",
+        "gate_proj",
+        "up_proj",
+        "down_proj",
+        "fc1",
+        "fc2",
+        "mlp",
+    ]
+    FUSION_GROUPS = (
+        ("q_proj", "k_proj", "v_proj"),
+        ("gate_proj", "up_proj"),
+    )
+    _PROJ_TO_GROUP = {proj: group for group in FUSION_GROUPS for proj in group}
+
+    def __init__(
+        self, model_dir: str, device_id: int = 0, num_hidden_layers: Optional[int] = None
+    ):
+        self.device_id = device_id
+        config = AutoConfig.from_pretrained(model_dir)
+        if num_hidden_layers is not None:
+            config.num_hidden_layers = num_hidden_layers
+        self.model = AutoModelForCausalLM.from_pretrained(
+            model_dir, config=config, torch_dtype=torch.bfloat16, attn_implementation="eager"
+        ).to(f"cuda:{device_id}")
+        self.all_weights = {}
+        self._dequantized_weights = {}
+        self.device_uuid = [get_device_uuid(i) for i in range(torch.cuda.device_count())]
+        self._quantize_and_replicate_weights()
+
+    @staticmethod
+    def _unfuse_moe_expert_params(all_params):
+        """Same MoE-expert unfusing logic as ``RefNVFP4ModelWithIPCHandles``."""
+        unfused = []
+        refuse_map: dict = {}
+        for name, p in all_params:
+            if name.endswith(".experts.gate_up_proj") and p.dim() == 3:
+                prefix = name[: -len("gate_up_proj")]
+                num_experts = p.shape[0]
+                half = p.shape[1] // 2
+                for i in range(num_experts):
+                    g_name = f"{prefix}{i}.gate_proj.weight"
+                    u_name = f"{prefix}{i}.up_proj.weight"
+                    unfused.append((g_name, p[i, :half, :].clone()))
+                    unfused.append((u_name, p[i, half:, :].clone()))
+                    refuse_map[g_name] = (name, i, "gate")
+                    refuse_map[u_name] = (name, i, "up")
+            elif name.endswith(".experts.down_proj") and p.dim() == 3:
+                prefix = name[: -len("down_proj")]
+                num_experts = p.shape[0]
+                for i in range(num_experts):
+                    d_name = f"{prefix}{i}.down_proj.weight"
+                    unfused.append((d_name, p[i].clone()))
+                    refuse_map[d_name] = (name, i, "down")
+            else:
+                unfused.append((name, p))
+        return unfused, refuse_map
+
+    def _quantize_and_replicate_weights(self):
+        all_params = [
+            (name, param.detach().clone()) for name, param in self.model.named_parameters()
+        ]
+        all_params, moe_refuse_map = self._unfuse_moe_expert_params(all_params)
+
+        fusion_buffer: dict = {}
+        model_weights = []
+
+        for name, p in all_params:
+            if not self._should_quantize(name):
+                model_weights.append((name, p))
+                continue
+
+            proj_type, group = self._get_proj_info(name)
+            if proj_type is not None:
+                layer_prefix = name[: name.index(proj_type)].rstrip(".")
+                buf_key = (layer_prefix, group)
+                fusion_buffer.setdefault(buf_key, {})[proj_type] = (name, p)
+                if all(proj in fusion_buffer[buf_key] for proj in group):
+                    projs = fusion_buffer.pop(buf_key)
+                    model_weights.extend(self._quantize_fusion_group(group, projs))
+            else:
+                model_weights.extend(self._quantize_single_weight(name, p))
+
+        assert not fusion_buffer, f"Incomplete fusion groups: {list(fusion_buffer.keys())}"
+
+        self.all_weights[self.device_id] = model_weights
+        for i in range(torch.cuda.device_count()):
+            if i != self.device_id:
+                self.all_weights[i] = [(n, p.to(f"cuda:{i}")) for n, p in model_weights]
+
+        with torch.no_grad():
+            param_dict = dict(self.model.named_parameters())
+            for name, dequant_weight in self._dequantized_weights.items():
+                if name in param_dict:
+                    param_dict[name].copy_(dequant_weight)
+                elif name in moe_refuse_map:
+                    fused_name, expert_idx, kind = moe_refuse_map[name]
+                    fused = param_dict[fused_name]
+                    if kind == "gate":
+                        half = fused.shape[1] // 2
+                        fused[expert_idx, :half, :].copy_(dequant_weight)
+                    elif kind == "up":
+                        half = fused.shape[1] // 2
+                        fused[expert_idx, half:, :].copy_(dequant_weight)
+                    else:
+                        fused[expert_idx].copy_(dequant_weight)
+        del self._dequantized_weights
+
+    @classmethod
+    def _should_quantize(cls, name: str) -> bool:
+        if not name.endswith(".weight"):
+            return False
+        name_lower = name.lower()
+        for pattern in cls.EXCLUDE_PATTERNS:
+            if pattern in name_lower:
+                return False
+        for pattern in cls.INCLUDE_PATTERNS:
+            if pattern in name_lower:
+                return True
+        return False
+
+    @classmethod
+    def _get_proj_info(cls, name: str):
+        for proj, group in cls._PROJ_TO_GROUP.items():
+            if proj in name:
+                return proj, group
+        return None, None
+
+    def _quantize_single_weight(self, name: str, weight: torch.Tensor) -> List[tuple]:
+        return list(self._do_quantize(name, weight))
+
+    def _quantize_fusion_group(self, group: tuple, projs: dict) -> List[tuple]:
+        all_amaxes = [v.float().abs().amax() for _, v in projs.values()]
+        unified_scale_2 = torch.stack(all_amaxes).amax() / (6.0 * 448.0)
+
+        results = []
+        for proj_type in group:
+            if proj_type in projs:
+                name, weight = projs[proj_type]
+                results.extend(self._do_quantize(name, weight, unified_scale_2))
+        return results
+
+    def _do_quantize(
+        self,
+        name: str,
+        weight: torch.Tensor,
+        weight_scale_2: Optional[torch.Tensor] = None,
+    ) -> List[tuple]:
+        weight_float = weight.float()
+        if weight_scale_2 is None:
+            weight_scale_2 = weight_float.abs().amax().float() / (6.0 * 448.0)
+
+        packed_weight, block_scale = _quantize_nvfp4(
+            weight_float, self.W4A8_BLOCK_SIZE, weight_scale_2
+        )
+        packed_uint8 = packed_weight.to(torch.uint8)
+        block_scale_fp8 = block_scale.to(torch.float8_e4m3fn)
+
+        self._dequantized_weights[name] = _dequantize_nvfp4_block32(
+            packed_uint8,
+            block_scale_fp8,
+            weight_scale_2,
+            weight_float.shape,
+            torch.bfloat16,
+        )
+
+        return [
+            (name, packed_uint8),
+            (name + "_scale", block_scale_fp8),
+            (name + "_scale_2", weight_scale_2),
+        ]
+
+    def get_weight_ipc_handles_serialized(
+        self,
+        device_ids: Optional[List[int]] = None,
+        weight_filter: Optional[Callable[[str], bool]] = None,
+    ):
+        ret = {}
+        device_list = list(range(torch.cuda.device_count())) if device_ids is None else device_ids
+        for device in device_list:
+            all_handles = []
+            for item in self.all_weights[device]:
+                name, p = item
+                if weight_filter is not None and not weight_filter(name):
+                    continue
+                handle = reduce_tensor(p)
+                all_handles.append((name, handle))
+            serialized = base64.b64encode(pickle.dumps(all_handles)).decode("utf-8")
+            ret[self.device_uuid[device]] = serialized
+        return ret
+
+
+@skip_pre_blackwell
+@pytest.mark.parametrize(
+    "model_dir",
+    [
+        "Qwen3/Qwen3-8B-Base",
+        "Qwen3-30B-A3B-Base",
+    ],
+)
+@pytest.mark.part3
+def test_llm_update_weights_w4a8_nvfp4_fp8(model_dir):
+    model_dir = str(llm_models_root() / model_dir)
+    num_hidden_layers = 1
+    hf_model = RefW4A8NVFP4FP8ModelWithIPCHandles(
+        model_dir, num_hidden_layers=num_hidden_layers
+    )
+    tokenizer = AutoTokenizer.from_pretrained(model_dir)
+    kv_cache_config = KvCacheConfig(enable_block_reuse=True, free_gpu_memory_fraction=0.1)
+    with LLM(
+        model=model_dir,
+        ray_worker_extension_cls="tensorrt_llm.llmapi.rlhf_utils.WorkerExtension",
+        tensor_parallel_size=1,
+        load_format="dummy",
+        pipeline_parallel_size=1,
+        kv_cache_config=kv_cache_config,
+        force_dynamic_quantization=True,
+        model_kwargs={
+            "num_hidden_layers": num_hidden_layers,
+            "quantization_config": {
+                "producer": {"name": "modelopt"},
+                "quant_algo": "W4A8_NVFP4_FP8",
+                "group_size": 32,
+                "exclude_modules": ["*mlp.gate", "lm_head"],
+            },
+        },
+    ) as llm:
+        prompts_texts = [
+            "Hello, my name is",
+            "The president of the United States is",
+            "The capital of France is",
+            "The future of AI is",
+        ]
+        prompts = [tokenizer.encode(prompt) for prompt in prompts_texts]
+        del tokenizer
+        sampling_params = SamplingParams(
+            temperature=0, return_generation_logits=True, max_tokens=1024
+        )
+
+        ipc_handles = hf_model.get_weight_ipc_handles_serialized([0])
+        llm._collective_rpc("update_weights", (ipc_handles,))
+        llm._collective_rpc("update_weights", (None,))
+
+        llm_logits, ref_logits = run_generate(llm, hf_model, prompts, sampling_params)
+        # Looser threshold: W4A8 logits are compared against a BF16 reference.
+        compare_logits(llm_logits, ref_logits, threshold=0.8)
+
+
+@skip_pre_blackwell
+@pytest.mark.parametrize(
+    "model_dir",
+    [
+        "Qwen3/Qwen3-8B-Base",
+        "Qwen3-30B-A3B-Base",
+    ],
+)
+@pytest.mark.part4
+def test_llm_partial_update_weights_w4a8_nvfp4_fp8(model_dir):
+    model_dir = str(llm_models_root() / model_dir)
+    num_hidden_layers = 1
+    hf_model = RefW4A8NVFP4FP8ModelWithIPCHandles(
+        model_dir, num_hidden_layers=num_hidden_layers
+    )
+    tokenizer = AutoTokenizer.from_pretrained(model_dir)
+    kv_cache_config = KvCacheConfig(enable_block_reuse=True, free_gpu_memory_fraction=0.1)
+    with LLM(
+        model=model_dir,
+        ray_worker_extension_cls="tensorrt_llm.llmapi.rlhf_utils.WorkerExtension",
+        tensor_parallel_size=1,
+        load_format="dummy",
+        pipeline_parallel_size=1,
+        kv_cache_config=kv_cache_config,
+        force_dynamic_quantization=True,
+        model_kwargs={
+            "num_hidden_layers": num_hidden_layers,
+            "quantization_config": {
+                "producer": {"name": "modelopt"},
+                "quant_algo": "W4A8_NVFP4_FP8",
+                "group_size": 32,
+                "exclude_modules": ["*mlp.gate", "lm_head"],
+            },
+        },
+    ) as llm:
+        prompts_texts = [
+            "Hello, my name is",
+            "The president of the United States is",
+            "The capital of France is",
+            "The future of AI is",
+        ]
+        prompts = [tokenizer.encode(prompt) for prompt in prompts_texts]
+        del tokenizer
+
+        sampling_params = SamplingParams(
+            temperature=0, return_generation_logits=True, max_tokens=1024
+        )
+
+        def common_filter(filter_name: str) -> Callable[[str], bool]:
+            def filter_fn(name: str) -> bool:
+                return name.endswith(filter_name)
+
+            return filter_fn
+
+        layer_prefix_pattern = re.compile(r"^model\.layers\.\d+\.")
+        filter_set = set()
+        for name, _ in hf_model.all_weights[hf_model.device_id]:
+            suffix = layer_prefix_pattern.sub("", name)
+            filter_set.add(suffix)
+        filter_list = list(filter_set)
+
+        for filter_name in filter_list:
+            weight_filter = common_filter(filter_name=filter_name)
+            ipc_handles = hf_model.get_weight_ipc_handles_serialized(
+                [0], weight_filter=weight_filter
+            )
+            llm._collective_rpc("update_weights", (ipc_handles,))
+        llm._collective_rpc("update_weights", (None,))
+
+        llm_logits, ref_logits = run_generate(llm, hf_model, prompts, sampling_params)
+        # Looser threshold: W4A8 logits are compared against a BF16 reference.
+        compare_logits(llm_logits, ref_logits, threshold=0.8)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dynamic quantization handling for SwiGLU activation path to compute scales correctly
  * Improved partial weight loading support for W4A8 quantization method

* **Refactor**
  * Refactored quantization scale loading and processing logic for better robustness

* **Tests**
  * Added comprehensive test coverage for W4A8 NVFP4 FP8 quantization, including full and partial weight update scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Adds partial-update-weights (RLHF / `update_weights` flow) support for `W4A8NVFP4FP8LinearMethod` and tests covering both dense (`Qwen3-8B-Base`) and MoE (`Qwen3-30B-A3B-Base`) Qwen3 models.

## Test Coverage

`tests/unittest/_torch/ray_orchestrator/single_gpu/test_llm_update_weights.py`

Add `test_llm_update_weights_w4a8_nvfp4_fp8` and `test_llm_partial_update_weights_w4a8_nvfp4_fp8`, parametrized over `Qwen3-8B-Base` (dense) and `Qwen3-30B-A3B-Base` (MoE). `@skip_pre_blackwell` (sm100+ only).

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
