### PR TITLE
[#14502][fix] nano-v3: swap leaked reasoning into content when enable_thinking=False

### DIFF
--- a/tensorrt_llm/llmapi/reasoning_parser.py
+++ b/tensorrt_llm/llmapi/reasoning_parser.py
@@ -308,12 +308,31 @@ class NemotronV3ReasoningParser(DeepSeekR1Parser):
                  *,
                  reasoning_at_start: bool = True,
                  chat_template_kwargs: Optional[dict[str, Any]] = None) -> None:
+        """Initialize the parser.
+
+        Two boolean flags are derived from ``chat_template_kwargs`` and gate
+        the "swap leaked reasoning into content" behavior in
+        ``_maybe_swap_content`` / ``parse_delta`` / ``finish``:
+
+        - ``_force_nonempty_content``: set when the caller passed
+          ``force_nonempty_content=True``. Power-user opt-in that forces the
+          swap whenever ``content`` is empty.
+        - ``_enable_thinking_is_false``: set when the caller passed
+          ``enable_thinking=False``. Triggers the same swap so OpenAI-style
+          clients (which render only ``content``) see a non-empty response
+          when the model leaks reasoning despite the thinking-off request.
+          Matches the HuggingFace ``SuperV3ReasoningParser`` shipped with
+          the model.
+        """
         self._force_nonempty_content = False
+        self._enable_thinking_is_false = False
         if isinstance(chat_template_kwargs, dict):
             reasoning_at_start = chat_template_kwargs.get(
                 "enable_thinking", reasoning_at_start)
             self._force_nonempty_content = chat_template_kwargs.get(
                 "force_nonempty_content", False) is True
+            self._enable_thinking_is_false = (
+                chat_template_kwargs.get("enable_thinking") is False)
         super().__init__(reasoning_at_start=reasoning_at_start,
                          chat_template_kwargs=chat_template_kwargs)
         self._tool_call_start = "<tool_call>"
@@ -326,14 +345,16 @@ class NemotronV3ReasoningParser(DeepSeekR1Parser):
 
     def _maybe_swap_content(
             self, result: ReasoningParserResult) -> ReasoningParserResult:
-        """When force_nonempty_content is set and content is empty, move
-        reasoning_content into content so the response always has content.
+        """When force_nonempty_content is set, or the caller requested
+        ``enable_thinking=False`` and the model leaked into reasoning anyway,
+        move reasoning_content into content so the response always has
+        content.
 
         Whitespace-only content (e.g. a newline after the closing think tag) is
         treated as empty so the swap still runs (NVBug 6060281)."""
         content = result.content or ""
-        if self._force_nonempty_content and not content.strip(
-        ) and result.reasoning_content:
+        if ((self._force_nonempty_content or self._enable_thinking_is_false)
+                and not content.strip() and result.reasoning_content):
             return ReasoningParserResult(content=result.reasoning_content,
                                          reasoning_content="")
         return result
@@ -357,7 +378,7 @@ class NemotronV3ReasoningParser(DeepSeekR1Parser):
             tool_idx = delta_text.find(self._tool_call_start)
             reasoning = remaining + delta_text[:tool_idx]
             content = delta_text[tool_idx:]
-            if self._force_nonempty_content:
+            if self._force_nonempty_content or self._enable_thinking_is_false:
                 self._found_closing_tag = True
                 self._accumulated_reasoning = ""
             return ReasoningParserResult(content=content,
@@ -365,7 +386,7 @@ class NemotronV3ReasoningParser(DeepSeekR1Parser):
 
         was_in_reasoning = self.in_reasoning
         result = super().parse_delta(delta_text)
-        if self._force_nonempty_content:
+        if self._force_nonempty_content or self._enable_thinking_is_false:
             if result.reasoning_content:
                 self._accumulated_reasoning += result.reasoning_content
             if was_in_reasoning and not self.in_reasoning:
@@ -387,7 +408,7 @@ class NemotronV3ReasoningParser(DeepSeekR1Parser):
         if self.in_reasoning and not self._found_closing_tag:
             remaining = self._buffer
             self._buffer = ""
-            if self._force_nonempty_content:
+            if self._force_nonempty_content or self._enable_thinking_is_false:
                 all_content = self._accumulated_reasoning + remaining
                 self._accumulated_reasoning = ""
                 self.in_reasoning = False

--- a/tests/unittest/llmapi/test_reasoning_parser.py
+++ b/tests/unittest/llmapi/test_reasoning_parser.py
@@ -349,6 +349,29 @@ TOOL_CALL_END = "</tool_call>"
          f"{TOOL_CALL}get_weather{TOOL_CALL_END}", "reasoning", {
              "enable_thinking": False
          }),
+        # GH issue #14502: when the caller asked for enable_thinking=False but
+        # the model leaks a complete <think>...</think> block anyway, the
+        # accidental reasoning should be swapped into content so OpenAI-style
+        # clients (which render only `content`) don't see an empty response.
+        (f"{R1_START}17 * 23 = 391{R1_END}", "17 * 23 = 391", "", {
+            "enable_thinking": False
+        }),
+        # Same fix, with a non-trivial reasoning body.
+        (f"{R1_START}some reasoning here{R1_END}", "some reasoning here", "", {
+            "enable_thinking": False
+        }),
+        # If the model leaks <think> but never emits </think>, partition leaves
+        # an empty `content` and the full body in `reasoning_content` — the
+        # fix still swaps it into content.
+        (f"{R1_START}unterminated answer", "unterminated answer", "", {
+            "enable_thinking": False
+        }),
+        # If content is already non-empty (model emitted some real content
+        # after a leaked think-block), the swap must NOT fire and the
+        # original split must be preserved.
+        (f"{R1_START}leak{R1_END} real content", " real content", "leak", {
+            "enable_thinking": False
+        }),
     ])
 def test_nano_v3_reasoning_parser(text: str, content: str,
                                   reasoning_context: str,
@@ -485,7 +508,15 @@ def test_nano_v3_reasoning_parser_stream(delta_texts: list, content: list,
         (["a", "b"], "", "", {
             "enable_thinking": False
         }),
-        ([f"{R1_START}a", "b"], "", "", {
+        # GH issue #14502: leaked <think> with no </think> at end of stream
+        # with enable_thinking=False — finish() now swaps the accumulated
+        # reasoning into content so OpenAI-style clients see a non-empty
+        # response. Previously returned empty content (the bug).
+        ([f"{R1_START}a", "b"], "ab", "", {
+            "enable_thinking": False
+        }),
+        # Same fix with a longer body.
+        ([f"{R1_START}answer", " is", " 391"], "answer is 391", "", {
             "enable_thinking": False
         }),
         (["a", "b"], "", "", {


### PR DESCRIPTION
## Description

Fixes #14502.

`NemotronV3ReasoningParser` returns empty `content` when the caller asks for `enable_thinking=False` but the model still emits reasoning tokens (either a full `<think>…</think>` block, or unterminated reasoning that the stream-end has to flush). OpenAI-compatible chat clients render only `content`, so the user sees a blank response.

The existing `force_nonempty_content=True` knob already does the right swap — this change extends that gate to also fire when `chat_template_kwargs.enable_thinking is False`. That matches the HuggingFace `SuperV3ReasoningParser` (the one shipped on the model card for `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4`), which gates its swap on either condition.

### What the change does

Four touch points, all inside `NemotronV3ReasoningParser` in `tensorrt_llm/llmapi/reasoning_parser.py`:

1. `__init__` — read `enable_thinking` from `chat_template_kwargs`, store `self._enable_thinking_is_false`
2. `_maybe_swap_content` — extend the swap gate to `(self._force_nonempty_content or self._enable_thinking_is_false)`
3. `parse_delta` — extend the accumulator gate (both the explicit-tool-call branch and the general-streaming branch) so reasoning deltas accumulate when `enable_thinking=False`
4. `finish` — extend the no-closing-tag swap gate, so a stream that ends mid-reasoning still produces non-empty content

The swap only fires when content is empty (or whitespace-only, per the existing NVBug 6060281 behavior). A model that emits real content after a leaked think-block keeps the original split.

### Behavior matrix

| Caller setting | Model behavior | Before this PR | After this PR |
|---|---|---|---|
| `enable_thinking=True` (default) | normal `<think>…</think>` | content / reasoning split | unchanged |
| `enable_thinking=False` | no `<think>` tag | `content` = full text | unchanged |
| `enable_thinking=False` | leaks `<think>X</think>` | `content=""`, `reasoning_content="X"` | `content="X"`, `reasoning_content=""` |
| `enable_thinking=False` | leaks `<think>X` (stream ends mid-reasoning) | `content=""`, `reasoning_content="X"` | `content="X"`, `reasoning_content=""` |
| `enable_thinking=False` | `<think>leak</think> real` | `content=" real"`, `reasoning_content="leak"` | unchanged (swap correctly does NOT fire) |
| `force_nonempty_content=True` | any | swap fires (existing) | unchanged (existing) |

## Test Coverage

`tests/unittest/llmapi/test_reasoning_parser.py`:

- **`test_nano_v3_reasoning_parser`** — 4 new parametrized cases covering the non-streaming swap for `enable_thinking=False` (complete `<think>…</think>`, unterminated `<think>…`, longer body, and the "don't over-fire when content already exists" guard)
- **`test_nano_v3_reasoning_parser_finish`** — 1 existing case (`[<think>a, b]` + `enable_thinking=False`) updated from the pre-fix expectation of empty content to `"ab"` (that case was documenting the bug); 1 new multi-delta case (`[<think>answer, " is", " 391"]` → `"answer is 391"`)

All existing `force_nonempty_content` paths and tool-call interactions remain unchanged.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## Related

- Issue #14502 — original bug report (HF SuperV3ReasoningParser comparison, repro script)
- NVBug 6060281 — `_maybe_swap_content` whitespace-only handling; preserved
- NVBug 6082303 — `<tool_call>` as implicit end-of-reasoning; extended same gate
