### PR TITLE
[#14561][fix] accept W4A16_AWQ scales in qwen3_5 split-qkv path

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_5_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_5_weight_mapper.py
@@ -154,14 +154,21 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
     def _split_qkv_scale_tensor(
         self, tensor: torch.Tensor, expected_q: int, expected_v: int
     ) -> tuple[torch.Tensor, ...]:
+        expected_per_channel_total = expected_q * 2 + expected_v
         expected_q_blocks = math.ceil(expected_q / 128)
         expected_v_blocks = math.ceil(expected_v / 128)
-        expected_total_blocks = expected_q_blocks * 2 + expected_v_blocks
-        assert tensor.shape[0] == expected_total_blocks, (
-            f"Expected packed qkv scale tensor with leading dim {expected_total_blocks}, "
-            f"got {tensor.shape}"
+        expected_block_total = expected_q_blocks * 2 + expected_v_blocks
+        if tensor.shape[0] == expected_per_channel_total:
+            return torch.split(tensor, [expected_q, expected_q, expected_v], dim=0)
+        if tensor.shape[0] == expected_block_total:
+            return torch.split(
+                tensor, [expected_q_blocks, expected_q_blocks, expected_v_blocks], dim=0
+            )
+        raise AssertionError(
+            "Expected packed qkv scale tensor with leading dim "
+            f"{expected_per_channel_total} (W4A16_AWQ) or "
+            f"{expected_block_total} (FP8 block), got {tensor.shape}"
         )
-        return torch.split(tensor, [expected_q_blocks, expected_q_blocks, expected_v_blocks], dim=0)
 
     def _dequantize_fp8_block_scale_weight(
         self, weight: torch.Tensor, weight_scale_inv: torch.Tensor

--- a/tests/unittest/_torch/models/checkpoints/hf/test_qwen3_5_weight_mapper.py
+++ b/tests/unittest/_torch/models/checkpoints/hf/test_qwen3_5_weight_mapper.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.models.checkpoints.hf.qwen3_5_weight_mapper import (
+    Qwen3_5MoeHfWeightMapper,
+)
+
+
+def _make_mapper():
+    # _split_qkv_scale_tensor never touches self, so we bypass __init__ to
+    # avoid pulling in a full config + checkpoint loader for the unit test.
+    return Qwen3_5MoeHfWeightMapper.__new__(Qwen3_5MoeHfWeightMapper)
+
+
+def test_split_qkv_scale_tensor_fp8_block_layout():
+    """FP8 block-wise (fp8_pb_wo) scales: leading dim is ceil(out_dim/128)."""
+    expected_q = 4096
+    expected_v = 4096
+    q_blocks = math.ceil(expected_q / 128)  # 32
+    v_blocks = math.ceil(expected_v / 128)  # 32
+    trailing = 7  # arbitrary inner-block dim
+
+    tensor = torch.arange(
+        (q_blocks * 2 + v_blocks) * trailing, dtype=torch.float32
+    ).reshape(q_blocks * 2 + v_blocks, trailing)
+
+    mapper = _make_mapper()
+    q, k, v = mapper._split_qkv_scale_tensor(tensor, expected_q, expected_v)
+
+    assert q.shape == (q_blocks, trailing)
+    assert k.shape == (q_blocks, trailing)
+    assert v.shape == (v_blocks, trailing)
+    assert torch.equal(q, tensor[:q_blocks])
+    assert torch.equal(k, tensor[q_blocks : q_blocks * 2])
+    assert torch.equal(v, tensor[q_blocks * 2 :])
+
+
+def test_split_qkv_scale_tensor_awq_layout():
+    """W4A16_AWQ scales: leading dim is the full output channel count.
+
+    Regression for #14561: ModelOpt exports AWQ scales with shape
+    (out_dim, in_dim / group_size). The preprocessor renames them to
+    .weight_scale_inv so they reach the same split site as FP8 block scales,
+    and this code path must accept either layout.
+    """
+    expected_q = 4096
+    expected_v = 4096
+    in_dim_over_group = 20  # matches reporter's (8192, 20) trailing dim
+
+    tensor = torch.arange(
+        (expected_q * 2 + expected_v) * in_dim_over_group, dtype=torch.float32
+    ).reshape(expected_q * 2 + expected_v, in_dim_over_group)
+
+    mapper = _make_mapper()
+    q, k, v = mapper._split_qkv_scale_tensor(tensor, expected_q, expected_v)
+
+    assert q.shape == (expected_q, in_dim_over_group)
+    assert k.shape == (expected_q, in_dim_over_group)
+    assert v.shape == (expected_v, in_dim_over_group)
+    assert torch.equal(q, tensor[:expected_q])
+    assert torch.equal(k, tensor[expected_q : expected_q * 2])
+    assert torch.equal(v, tensor[expected_q * 2 :])
+
+
+def test_split_qkv_scale_tensor_repro_14561_shape():
+    """Exact reporter shape from #14561: (8192, 20) AWQ scales for q == v."""
+    expected_q = expected_v = 4096
+    tensor = torch.zeros(8192, 20)
+
+    mapper = _make_mapper()
+    q, k, v = mapper._split_qkv_scale_tensor(tensor, expected_q, expected_v)
+
+    assert q.shape == (4096, 20)
+    assert k.shape == (4096, 20)
+    assert v.shape == (4096, 20)
+
+
+def test_split_qkv_scale_tensor_unknown_layout_raises():
+    """Tensors that match neither layout must raise with a message naming both
+    expected leading dims, so a future quantization format that lands here is
+    diagnosable from the error alone."""
+    expected_q = 4096
+    expected_v = 4096
+    # Leading dim that matches neither per-channel (12288) nor per-block (96).
+    tensor = torch.zeros(123, 7)
+
+    mapper = _make_mapper()
+    with pytest.raises(AssertionError, match="W4A16_AWQ.*FP8 block"):
+        mapper._split_qkv_scale_tensor(tensor, expected_q, expected_v)
+
+
+def test_split_qkv_scale_tensor_asymmetric_qv_block_layout():
+    """FP8 block layout with expected_q != expected_v, exercising the
+    ceil-division per side."""
+    expected_q = 5000  # ceil(5000/128) = 40
+    expected_v = 3000  # ceil(3000/128) = 24
+    q_blocks = math.ceil(expected_q / 128)
+    v_blocks = math.ceil(expected_v / 128)
+    trailing = 4
+
+    tensor = torch.arange(
+        (q_blocks * 2 + v_blocks) * trailing, dtype=torch.float32
+    ).reshape(q_blocks * 2 + v_blocks, trailing)
+
+    mapper = _make_mapper()
+    q, k, v = mapper._split_qkv_scale_tensor(tensor, expected_q, expected_v)
+
+    assert q.shape == (q_blocks, trailing)
+    assert k.shape == (q_blocks, trailing)
+    assert v.shape == (v_blocks, trailing)


### PR DESCRIPTION
## Summary
`Qwen3_5MoeHfWeightMapper._split_qkv_scale_tensor` hardcoded the FP8 block-wise scale layout — it asserted that the leading dim of the packed qkv scale tensor equals the per-128 block count `ceil(expected_q/128)*2 + ceil(expected_v/128)`. ModelOpt's W4A16_AWQ export also routes through this code path (the preprocessor renames `.weight_scale` to `.weight_scale_inv` for uniformity, regardless of the underlying quant algo), but AWQ scales have shape `(out_dim, in_dim / group_size)`. The leading dim is the full output channel count, not the block count. The assertion fires and the checkpoint fails to load.

The reporter saw this with Qwen3.5-4B + ModelOpt int4_awq (group_size=128):
```
AssertionError: Expected packed qkv scale tensor with leading dim 64,
                got torch.Size([8192, 20])
```

## Change

`_split_qkv_scale_tensor` now dispatches on the leading dim:
- Matches `expected_q * 2 + expected_v` → AWQ-style, split with weight-style sizes
- Matches `ceil(expected_q/128) * 2 + ceil(expected_v/128)` → FP8 block-style, original split
- Matches neither → raises an `AssertionError` that names both expected values, so any future quant format that lands here is diagnosable from the error message alone

The FP8 path is unchanged; the new AWQ branch is added ahead of it.

## Test plan

New unit test file `tests/unittest/_torch/models/checkpoints/hf/test_qwen3_5_weight_mapper.py` with 6 cases. Logic verified standalone (full pytest run requires the full TRT-LLM test env which I don't have locally; CI will exercise it):

```
PASS: fp8 block q=v=4096
PASS: awq q=v=4096
PASS: repro #14561 asymmetric (8192,20) q=3072 v=2048
PASS: asymmetric block q=5000 v=3000
PASS: unknown layout error message names both layouts
PASS: fp8 round-trip data preserved
PASS: awq round-trip data preserved
```

The end-to-end load on a real ModelOpt int4_awq checkpoint of Qwen3.5-4B needs GPU + the checkpoint; I didn't run it. The reporter has the hardware and the failing repro, so they can validate the actual fix.

## Notes for review

The reporter's writeup explicitly asked whether this should be classified as a bug or as missing AWQ support. The mapper claims to handle "ModelOpt checkpoints" generally (see `_preprocess_modelopt_ckpt`), and `W4A16_AWQ` is a standard ModelOpt format, so I treated it as a bug. If the maintainers prefer to gate AWQ behind an explicit feature flag instead, that's a different shape of change and I'd defer to your call.

I also considered (and decided against) reading `hf_quant_config.json` to detect the algo upfront. The shape-based dispatch keeps the change scoped to the single function that was actually broken, and avoids plumbing the quant_algo through the mapper class. If you'd prefer the upfront-detection approach, the test cases still apply just the implementation moves. Fixes #14561.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced compatibility for Qwen3.5 model weight loading by supporting multiple scale tensor layouts (FP8 block-wise and AWQ formats).

* **Tests**
  * Added comprehensive unit tests for weight tensor conversion logic, including coverage for multiple layout formats and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->