### PR TITLE
[https://nvbugs/6018046][fix] Lower throughput_pp4_mtp max_batch_size to 8

### DIFF
--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -2902,6 +2902,13 @@ class TestDeepSeekR1(LlmapiAccuracyTestHarness):
                          8,
                          "CUTLASS",
                          marks=pytest.mark.skip_less_mpi_world_size(8)),
+            # throughput_pp4_mtp (NVBug 6018046): on 4-GPU PP=4 + MTP, the
+            # per-bs CUDA-graph snapshot pool plus per-step activation and
+            # NCCL collective buffers consume the lazy cuBLAS Lt workspace
+            # headroom at bs=32, surfacing as mid-run
+            # CUBLAS_STATUS_EXECUTION_FAILED. Match the already-stable
+            # throughput_bs8_mtp configuration with bs=8; the default 0.70
+            # KV fraction is sufficient once bs is reduced.
             pytest.param(1,
                          4,
                          1,
@@ -2911,7 +2918,7 @@ class TestDeepSeekR1(LlmapiAccuracyTestHarness):
                          False,
                          True,
                          True,
-                         32,
+                         8,
                          "CUTLASS",
                          marks=pytest.mark.skip_less_mpi_world_size(4)),
         ],

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -22,7 +22,6 @@ accuracy/test_llm_api_autodeploy.py::TestQwen3_5_397B_MoE::test_bf16_small[4] SK
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput_mtp] SKIP (https://nvbugs/6215736)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput] SKIP (https://nvbugs/6084775)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_mtp] SKIP (https://nvbugs/6029882)
-accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_pp4_mtp] SKIP (https://nvbugs/6018046)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_tp4] SKIP (https://nvbugs/6215793)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1LongBenchV2::test_fp8_8gpus SKIP (https://nvbugs/6193778)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_dsa_host_cache_offload[host_cache_offload] SKIP (https://nvbugs/6185196)


### PR DESCRIPTION
## Summary

Fixes `TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_pp4_mtp]` (NVBug 6018046) by lowering `max_batch_size` from 32 to 8 to match the already-stable `throughput_bs8_mtp` configuration. The matching waiver entry is removed.

## Root cause

On 4-GPU PP=4 + MTP topology, `max_batch_size=32` causes the per-bs CUDA-graph snapshot pool (32 captured graphs) plus per-step activation and NCCL collective buffers to exhaust the physical headroom needed by the lazy `cudaMalloc` from cuBLAS Lt workspace (DeepseekV3 router GEMM, attention `o_proj`) on B300. With the default 0.70 KV cache fraction allocating ~100 GiB / rank, only ~3 GiB of physical free pool remains for cuBLAS Lt / NCCL workspaces, which is insufficient under sustained load. The failure manifests as mid-run `CUBLAS_STATUS_EXECUTION_FAILED` followed by an asynchronous illegal memory access.

## Relation to #14201

[#14201](https://github.com/NVIDIA/TensorRT-LLM/pull/14201) fixes the same bug by combining `max_batch_size 32→8` with `free_gpu_memory_fraction 0.70→0.50`. Through isolated controlled experiments I verified the KV-fraction change is not strictly required once `bs` is lowered:

| Experiment | bs | KV fraction | Result |
|---|---|---|---|
| `upstream/main` baseline | 32 | 0.70 | ❌ crash @ req 1254/4104 (router GEMM) |
| bs=16 only | 16 | 0.70 | ❌ crash @ req 1502/4104 (o_proj GEMM) |
| **This PR (3 runs)** | **8** | **0.70** | ✅ pass (531s / 543s / 735s) |
| #14201 (1 run) | 8 | 0.50 | ✅ pass (618s) |

At `bs=8` the per-bs CUDA-graph pool and per-step activation footprint shrink by 4x, restoring enough physical free pool for the lazy cuBLAS Lt / NCCL workspaces even at the default 0.70 KV fraction. This PR is therefore a minimal single-knob alternative to #14201.

## Test plan

- [x] `pytest accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_pp4_mtp]` passes 3/3 on B300 4-GPU
- [x] Waiver entry removed; no runtime / kernel / LLM-API code touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modified GPU testing configuration parameters, including batch size and KV cache memory allocation adjustments, to improve stability and compatibility when executing tests across multiple GPUs
  * Re-enabled a previously skipped multi-GPU test scenario, ensuring comprehensive test coverage for GPU testing configurations following improvements to GPU resource management and workspace handling compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->