### PR TITLE
[None][fix] Bypass FlashInfer SSD prefill to fix state dtype precision

### DIFF
--- a/tensorrt_llm/_torch/modules/mamba/ssd_combined.py
+++ b/tensorrt_llm/_torch/modules/mamba/ssd_combined.py
@@ -437,9 +437,16 @@ def mamba_chunk_scan_combined(
     # FlashInfer fused CUTLASS kernel on Blackwell (SM100+); both varlen and
     # non-varlen route here based on cu_seqlens. Falls back to Triton when the
     # MMA tile constraints on (chunk_size, dstate, headdim) aren't met.
+    #
+    # DISABLED: The FlashInfer SSD kernel hardcodes state_dtype=bf16 while the
+    # Triton path accumulates in fp32 (states_in_fp32=True), causing silent
+    # precision loss during prefill.
+    # TODO: Re-enable once _get_flashinfer_ssd_kernel uses state_dtype=float32.
+    _USE_FLASHINFER_SSD_PREFILL = False
     dstate = B.shape[-1]
     headdim = x.shape[-1]
-    flashinfer_eligible = (z is None and is_sm_100f())
+    flashinfer_eligible = (_USE_FLASHINFER_SSD_PREFILL and z is None
+                           and is_sm_100f())
     if flashinfer_eligible and _flashinfer_ssd_supported(
             chunk_size, dstate, headdim):
         return _mamba_chunk_scan_flashinfer_fwd(


### PR DESCRIPTION
The FlashInfer SSD prefill path (added in PR #12731) hardcodes state_dtype=bfloat16 in the SSDCombined kernel, while the Triton path accumulates states in float32 (states_in_fp32=True). This silently drops state accumulation precision on Blackwell (SM100+), which can cause accuracy drift for long sequences.

Disable the FlashInfer dispatch so mamba_chunk_scan_combined always uses the Triton SSD kernels for prefill. The FlashInfer code is preserved for re-enablement once state_dtype is fixed to float32.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Modified the SSD prefill execution path to use an alternative implementation instead of the previous optimization route.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
