### PR TITLE
[None][fix] Improve DSv4 disagg GEN KV pool sizing by accounting for handoff/admission pressure.

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 import os
 from collections import defaultdict
 from typing import Dict, List, Optional, Tuple
@@ -64,6 +65,21 @@ from .deepseek_v4 import (
 # Keep the env override so per-layer block tables can still be tested
 # without scratch-page remapping when needed.
 DSV4_ENABLE_SWA_SCRATCH_REUSE_ENV = "TRTLLM_DSV4_ENABLE_SWA_SCRATCH_REUSE"
+DSV4_GEN_HANDOFF_TYPICAL_STEP_REQUESTS_ENV = "TRTLLM_DSV4_GEN_HANDOFF_TYPICAL_STEP_REQUESTS"
+DSV4_GEN_HANDOFF_TYPICAL_STEP_DEFAULT_FRACTION = 0.25
+
+
+def _get_optional_non_negative_int_from_env(name: str) -> int | None:
+    value = os.environ.get(name)
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be a non-negative integer, got {value!r}") from exc
+    if parsed < 0:
+        raise ValueError(f"{name} must be a non-negative integer, got {parsed}")
+    return parsed
 
 
 def _estimate_bytes_per_token(
@@ -775,13 +791,44 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
         # the typical step. An all-generation typical_step over-provisions the
         # compressed-cache pool at the expense of the SWA pool, starving the
         # SWA pool and artificially capping the achievable batch size.
-        ctx_capacity = max_num_tokens if max_num_tokens is not None else max_seq_len
-        typical_step = BatchDesc(
-            kv_caches=[
+        #
+        # Disaggregated GEN needs additional SWA / compressor-state headroom:
+        # transferred prompts can temporarily occupy received full KV chains
+        # before they are trimmed down to the steady-state sliding window.
+        # Model that admission pressure as full-length handoff requests, and
+        # do not apply prefill scratch reuse to them because the received KV
+        # chains are real transferred pages rather than scratch prefill pages.
+        if self.is_disagg:
+            handoff_requests = _get_optional_non_negative_int_from_env(
+                DSV4_GEN_HANDOFF_TYPICAL_STEP_REQUESTS_ENV
+            )
+            if handoff_requests is None:
+                handoff_requests = math.ceil(
+                    max_batch_size * DSV4_GEN_HANDOFF_TYPICAL_STEP_DEFAULT_FRACTION
+                )
+            handoff_requests = min(handoff_requests, max_batch_size)
+            context_descs = [
+                KVCacheDesc(
+                    capacity=max_seq_len,
+                    history_length=0,
+                    allow_scratch_reuse=False,
+                )
+            ] * handoff_requests
+            logger.info(
+                f"[RANK {self.mapping.rank}] DeepseekV4CacheManager "
+                "using disagg GEN handoff typical_step reserve: "
+                f"requests={handoff_requests}, capacity={max_seq_len}"
+            )
+        else:
+            ctx_capacity = max_num_tokens if max_num_tokens is not None else max_seq_len
+            context_descs = [
                 KVCacheDesc(capacity=ctx_capacity, history_length=0),
             ]
+
+        typical_step = BatchDesc(
+            kv_caches=context_descs
             + [KVCacheDesc(capacity=max_seq_len, history_length=max_seq_len - max_draft_len - 1)]
-            * (max_batch_size - 1),
+            * (max_batch_size - len(context_descs)),
         )
 
         constraints = []

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.pyi
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.pyi
@@ -151,6 +151,7 @@ LayerConfig = AttentionLayerConfig | SsmLayerConfig
 class KVCacheDesc:
     capacity: int
     history_length: int
+    allow_scratch_reuse: bool = True
 
 @dataclass(slots=True)
 class BatchDesc:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
@@ -145,6 +145,7 @@ LayerConfig = AttentionLayerConfig | SsmLayerConfig
 class KVCacheDesc:
     capacity: int
     history_length: int
+    allow_scratch_reuse: bool = True
 
     def __post_init__(self) -> None:
         assert 0 <= self.history_length <= self.capacity

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -918,7 +918,7 @@ class StorageManager:
                 # Non-stale sys blocks for this request.
                 non_stale_sys = sys_blocks - len(intersect(stale, sys_range))
                 unique_non_stale = max(0, non_stale - non_stale_sys)
-                if swa_scratch_reuse is not None:
+                if swa_scratch_reuse is not None and kv.allow_scratch_reuse:
                     scratch = compute_scratch_range(
                         lc,
                         kv.history_length,

--- a/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
@@ -1956,6 +1956,42 @@ class TestInitRatioConfig(unittest.TestCase):
         mgr_no.shutdown()
         mgr_yes.shutdown()
 
+    def test_typical_step_can_disable_scratch_for_handoff_requests(self):
+        """Received disagg KV handoff chains must not use scratch sizing."""
+        multi = dict(num_windowed_layers=16, num_full_layers=16)
+        scratchable_step = BatchDesc(kv_caches=[KVCacheDesc(capacity=4096, history_length=0)] * 4)
+        handoff_step = BatchDesc(
+            kv_caches=[
+                KVCacheDesc(
+                    capacity=4096,
+                    history_length=0,
+                    allow_scratch_reuse=False,
+                )
+            ]
+            * 4
+        )
+
+        cfg_scratchable = self._make_config(
+            typical_step=scratchable_step,
+            enable_swa_scratch_reuse=True,
+            **multi,
+        )
+        cfg_handoff = self._make_config(
+            typical_step=handoff_step,
+            enable_swa_scratch_reuse=True,
+            **multi,
+        )
+        mgr_scratchable = KVCacheManager(cfg_scratchable)
+        mgr_handoff = KVCacheManager(cfg_handoff)
+        ratio_scratchable = mgr_scratchable._current_gpu_ratio
+        ratio_handoff = mgr_handoff._current_gpu_ratio
+
+        self.assertGreater(ratio_handoff[0], ratio_scratchable[0])
+        self.assertLess(ratio_handoff[1], ratio_scratchable[1])
+
+        mgr_scratchable.shutdown()
+        mgr_handoff.shutdown()
+
     def test_constraint_with_scratch_accounts_for_scratch(self):
         """Constraint clamping uses scratch-aware slot counts.
 


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Improve DeepSeek-V4 disaggregated GEN KV cache pool sizing by accounting for handoff/
  admission pressure.

  In DEP8/DEP8 disagg traffic, incoming transferred prompts can temporarily hold near-full
  KV chains in SWA / compressor-state pools before those chains are trimmed or evicted down
  to the steady-state sliding-window working set. The previous typical-step estimator
  modeled only the steady-state windowed usage for those pools, which can under-size Pool0/
  Pool2 and stall admission while Pool1 remains mostly idle.

  This patch models the DSv4 disagg GEN typical step as:

  Pool0/2 ~= N_handoff * max_seq_len
           + (max_batch_size - N_handoff) * window0/2

  It does this by adding KVCacheDesc.allow_scratch_reuse, keeping it True by default, and
  setting it to False only for synthetic handoff descriptors. That lets normal decode
  descriptors keep the existing scratch-adjusted/windowed sizing, while handoff descriptors
  are sized as real transferred KV pages.

  A single env knob can override the handoff request count:

  TRTLLM_DSV4_GEN_HANDOFF_TYPICAL_STEP_REQUESTS

  If unset, the default is ceil(0.25 * max_batch_size).

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
