### PR TITLE
[None][fix] make bypass_processor_output_validation thread-safe

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
@@ -19,6 +19,7 @@
 import contextlib
 import math
 import os
+import threading
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 import torch
@@ -54,6 +55,16 @@ _PROCESSOR_OUTPUT_KEYS = frozenset({
     "mm_token_type_ids",
 })
 
+# Reference-counted state for ``bypass_processor_output_validation``. The
+# patch mutates process-global module attributes, so concurrent entries from
+# multiple worker threads (e.g. ``asyncio.to_thread(llm.preprocess, ...)``)
+# must share a single patch install/restore — otherwise each entering thread
+# captures the already-patched function as its "original" and stacks a new
+# wrapper on top, producing unbounded recursion and corrupted restore on exit.
+_bypass_lock = threading.Lock()
+_bypass_depth = 0
+_bypass_saved_originals: Optional[Dict[Any, Callable]] = None
+
 
 @contextlib.contextmanager
 def bypass_processor_output_validation():
@@ -78,9 +89,17 @@ def bypass_processor_output_validation():
     across transformers versions (5.3.x re-binds it on
     ``image_processing_utils_fast``; 5.5.x dropped that module and re-binds
     it on ``image_processing_utils`` instead), so we discover the binders
-    by ``hasattr`` rather than hard-coding the list. The originals are
-    restored on exit.
+    by ``hasattr`` rather than hard-coding the list.
+
+    Thread-safety: preprocessing is dispatched via ``asyncio.to_thread`` so
+    multiple workers can sit inside this context manager concurrently. The
+    install/restore is reference-counted under a lock — the first entrant
+    installs the wrapper (closing over the true original), later entrants
+    only bump the counter, and the last leaver restores. This avoids both
+    recursive wrapper stacking and out-of-order restore corruption.
     """
+    global _bypass_depth, _bypass_saved_originals
+
     import transformers.processing_utils as _pu
     import transformers.video_processing_utils as _vpu
 
@@ -97,24 +116,38 @@ def bypass_processor_output_validation():
         raise RuntimeError(
             "No transformers module exposes validate_typed_dict; "
             "cannot patch processor output validation.")
-    originals = {b: b.validate_typed_dict for b in binders}
-    base_orig = next(iter(originals.values()))
 
-    def _filtered_validate(schema, data):
-        if isinstance(data, dict):
-            data = {
-                k: v
-                for k, v in data.items() if k not in _PROCESSOR_OUTPUT_KEYS
+    with _bypass_lock:
+        if _bypass_depth == 0:
+            _bypass_saved_originals = {
+                b: b.validate_typed_dict
+                for b in binders
             }
-        return base_orig(schema, data)
+            base_orig = next(iter(_bypass_saved_originals.values()))
 
-    for b in binders:
-        b.validate_typed_dict = _filtered_validate
+            def _filtered_validate(schema, data):
+                if isinstance(data, dict):
+                    data = {
+                        k: v
+                        for k, v in data.items()
+                        if k not in _PROCESSOR_OUTPUT_KEYS
+                    }
+                return base_orig(schema, data)
+
+            for b in binders:
+                b.validate_typed_dict = _filtered_validate
+        _bypass_depth += 1
+
     try:
         yield
     finally:
-        for b, orig in originals.items():
-            b.validate_typed_dict = orig
+        with _bypass_lock:
+            _bypass_depth -= 1
+            if _bypass_depth == 0:
+                assert _bypass_saved_originals is not None
+                for b, orig in _bypass_saved_originals.items():
+                    b.validate_typed_dict = orig
+                _bypass_saved_originals = None
 
 
 def _get_uncached_multimodal_params(

--- a/tests/unittest/_torch/modeling/test_bypass_processor_output_validation.py
+++ b/tests/unittest/_torch/modeling/test_bypass_processor_output_validation.py
@@ -1,0 +1,206 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for ``bypass_processor_output_validation``.
+
+The context manager mutates module-level attributes on transformers modules,
+so concurrent entries from worker threads (preprocessing is dispatched via
+``asyncio.to_thread``) used to stack wrappers on top of each other. Under
+high video concurrency that produced hundreds of nested ``_filtered_validate``
+frames and ultimately a ``RecursionError`` (HTTP 400 to the client). It also
+corrupted the restore: if Thread A exited first it would restore the *real*
+function, then Thread B's ``finally`` would re-patch with a stale wrapper.
+
+These tests pin down both behaviors.
+"""
+
+import threading
+import time
+
+import pytest
+
+# Skip the whole module gracefully if transformers isn't importable in the
+# test environment — the bypass logic only matters when the binders exist.
+transformers = pytest.importorskip("transformers")
+
+from tensorrt_llm._torch.models.modeling_multimodal_utils import (  # noqa: E402
+    _PROCESSOR_OUTPUT_KEYS,
+    bypass_processor_output_validation,
+)
+
+
+def _binders():
+    import transformers.processing_utils as _pu
+    import transformers.video_processing_utils as _vpu
+
+    candidates = [_pu, _vpu]
+    for name in ("transformers.image_processing_utils", "transformers.image_processing_utils_fast"):
+        try:
+            candidates.append(__import__(name, fromlist=[""]))
+        except ImportError:
+            pass
+    return [b for b in candidates if hasattr(b, "validate_typed_dict")]
+
+
+def test_originals_restored_after_exit():
+    binders = _binders()
+    assert binders, "expected at least one transformers binder"
+    originals = {b: b.validate_typed_dict for b in binders}
+
+    with bypass_processor_output_validation():
+        for b in binders:
+            assert b.validate_typed_dict is not originals[b]
+
+    for b in binders:
+        assert b.validate_typed_dict is originals[b]
+
+
+def test_filter_strips_output_keys():
+    binders = _binders()
+    seen = {}
+
+    real = binders[0].validate_typed_dict
+
+    # Wrap the real validator just to capture what it actually receives.
+    def spy(schema, data):
+        seen["data"] = data
+        # Don't actually validate — we only care that the filter ran.
+        return None
+
+    for b in binders:
+        b.validate_typed_dict = spy
+    try:
+        with bypass_processor_output_validation():
+            wrapped = binders[0].validate_typed_dict
+            payload = {
+                "image_grid_thw": "leaked",
+                "video_grid_thw": "leaked",
+                "pixel_values": "leaked",
+                "legit_key": "keep",
+            }
+            wrapped(object(), payload)
+    finally:
+        for b in binders:
+            b.validate_typed_dict = real
+
+    assert "data" in seen
+    received = seen["data"]
+    for k in _PROCESSOR_OUTPUT_KEYS:
+        assert k not in received, f"{k} should have been filtered"
+    assert received.get("legit_key") == "keep"
+
+
+def test_concurrent_entry_does_not_stack_wrappers():
+    """The core regression: many threads inside the CM at once must not
+    stack wrappers (which previously produced unbounded recursion)."""
+    binders = _binders()
+    real_originals = {b: b.validate_typed_dict for b in binders}
+
+    num_threads = 64
+    barrier = threading.Barrier(num_threads)
+    observed_wrappers = [None] * num_threads
+    errors = []
+
+    def worker(idx):
+        try:
+            barrier.wait(timeout=10)
+            with bypass_processor_output_validation():
+                # All threads observe the *same* wrapper object.
+                observed_wrappers[idx] = binders[0].validate_typed_dict
+                # Keep everyone inside the CM simultaneously.
+                time.sleep(0.05)
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(num_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"workers raised: {errors}"
+    # The crucial assertion: a single shared wrapper, not a stack of them.
+    assert len(set(map(id, observed_wrappers))) == 1
+    # And it must not be the real function (i.e. the patch did apply).
+    assert observed_wrappers[0] is not real_originals[binders[0]]
+    # After everyone exits, originals are restored exactly.
+    for b in binders:
+        assert b.validate_typed_dict is real_originals[b]
+
+
+def test_concurrent_entry_does_not_recurse():
+    """If wrappers were stacked, calling the patched function would recurse
+    through N layers. Assert that the call stack stays shallow regardless of
+    how many threads are concurrently inside the CM."""
+    binders = _binders()
+    real = binders[0].validate_typed_dict
+
+    depths = []
+    depth_lock = threading.Lock()
+
+    def measuring_real(schema, data):
+        import sys
+
+        # Frame depth from this call upward, only counting frames that came
+        # from the bypass wrapper. We just record total depth and check it
+        # stays bounded.
+        frame = sys._getframe()
+        n = 0
+        while frame is not None:
+            if frame.f_code.co_name == "_filtered_validate":
+                n += 1
+            frame = frame.f_back
+        with depth_lock:
+            depths.append(n)
+        return None
+
+    for b in binders:
+        b.validate_typed_dict = measuring_real
+    try:
+        num_threads = 32
+        barrier = threading.Barrier(num_threads)
+
+        def worker():
+            barrier.wait(timeout=10)
+            with bypass_processor_output_validation():
+                binders[0].validate_typed_dict(object(), {"pixel_values": 1})
+
+        threads = [threading.Thread(target=worker) for _ in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        for b in binders:
+            b.validate_typed_dict = real
+
+    assert depths, "expected at least one validator call"
+    # With the fix, exactly one wrapper frame regardless of concurrency.
+    # Without the fix, this would be up to num_threads.
+    assert max(depths) == 1, f"wrapper stacking detected: depths={depths}"
+
+
+def test_sequential_reentry_restores_cleanly():
+    """Repeated enter/exit on a single thread must always restore the
+    original. (Guards against the counter / saved-originals state going
+    out of sync.)"""
+    binders = _binders()
+    originals = {b: b.validate_typed_dict for b in binders}
+    for _ in range(5):
+        with bypass_processor_output_validation():
+            for b in binders:
+                assert b.validate_typed_dict is not originals[b]
+        for b in binders:
+            assert b.validate_typed_dict is originals[b]


### PR DESCRIPTION
## Summary

`bypass_processor_output_validation()` in `tensorrt_llm/_torch/models/modeling_multimodal_utils.py` (introduced in #12829) is thread-unsafe. Preprocessing for multimodal serving is dispatched via `asyncio.to_thread(self.llm.preprocess, ...)`, so multiple worker threads can sit inside this context manager concurrently. The original implementation captured each entering thread's view of `validate_typed_dict` as its "original" and installed a new wrapper on top — under high concurrency this stacks wrappers indefinitely, producing unbounded recursion and corrupting the restore on out-of-order exit.

The customer-reported symptom on Qwen3-VL / cosmos3-reasoner at 256-concurrency video serving was a recursion-limit traceback that returned HTTP 400 to the client; the traceback showed `_filtered_validate` repeating 968–975 times before reaching the real `huggingface_hub.dataclasses.validate_typed_dict`.

### Fix

Reference-count the patch under a `threading.Lock`:
- First entrant captures the *true* originals and installs the single shared wrapper.
- Later entrants only bump a counter — no wrapper stacking, no re-snapshot of an already-patched function.
- Last leaver restores. The wrapper itself is unchanged.

This also fixes the secondary "restore corruption" bug where Thread A's `finally` could restore the real function while Thread B's stale `originals` snapshot would then re-patch with a dangling wrapper.

### Regression test

Added `tests/unittest/_torch/modeling/test_bypass_processor_output_validation.py`. Five tests, no GPU / no model weights needed:
- `test_originals_restored_after_exit` — basic invariant.
- `test_filter_strips_output_keys` — confirms `_PROCESSOR_OUTPUT_KEYS` are filtered before reaching the validator.
- `test_concurrent_entry_does_not_stack_wrappers` — 64 threads enter behind a `Barrier`; all must observe the same wrapper object.
- `test_concurrent_entry_does_not_recurse` — directly pins down the reporter's recursion symptom: walks `sys._getframe()` to count `_filtered_validate` frames; with the fix `max(depths) == 1` regardless of concurrency.
- `test_sequential_reentry_restores_cleanly` — guards the refcount state machine across repeated enter/exit.

## Test plan

- [x] New unit tests added (`tests/unittest/_torch/modeling/test_bypass_processor_output_validation.py`)
- [ ] Customer-reported repro: `aiperf profile -m qwen3_vl --concurrency 256 ... --video-*` against `trtllm-serve` no longer returns HTTP 400 with `RecursionError`
- [ ] Existing `test_modeling_multimodal.py` paths that use `bypass_processor_output_validation` still pass

## Background

Reported by Aswin Visva — fails the cosmos3-reasoner model at high video concurrency in the R16 TRT-LLM release. Suggest cherry-picking to the 1.3 release branch once merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test suite for validation handling, verifying correct behavior under concurrent usage, sequential re-entry, and multi-threading scenarios.

* **Improvements**
  * Enhanced internal validation handling with improved thread-safety mechanisms to support concurrent operations reliably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->