### PR TITLE
[Draft][None][fix] MegaMoEDeepGemm: use engine max_num_tokens directly

### DIFF
--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -128,6 +128,9 @@ class ModelConfig(Generic[TConfig]):
     moe_max_num_tokens: Optional[int] = None
     moe_load_balancer: Optional[MoeLoadBalancerConfig] = None
 
+    # MEGAMOE_AUTO threshold on per-rank max_num_tokens.
+    megamoe_max_tokens_per_rank: int = 1024
+
     attn_backend: str = 'TRTLLM'
     moe_backend: str = 'CUTLASS'  # options can be CUTLASS, TRTLLM
     # IF true, disables FC2+finalize fusion in CUTLASS MoE backend

--- a/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 import os
-from typing import Dict, Optional, Type
+from typing import Dict, Optional, Tuple, Type
 
 import torch
 
@@ -129,6 +129,70 @@ def get_moe_cls(
                 "Falling back to CutlassFusedMoE.")
             return CutlassFusedMoE
         return MegaMoEDeepGemm
+    elif moe_backend.upper() == "MEGAMOE_AUTO":
+        # Pick MegaMoE for small per-rank batches (large DG num_experts_per_wave),
+        # TRTLLM-gen above the threshold. Disagg picks correctly per-worker via max_num_tokens.
+        threshold = getattr(model_config, "megamoe_max_tokens_per_rank", 1024)
+        per_rank_max = getattr(model_config, "max_num_tokens", None) or 0
+        prefer_mega = per_rank_max > 0 and per_rank_max <= threshold
+
+        # Mirrors the MEGAMOE_DEEPGEMM gate: quant, SM, bundled DG surface.
+        def _mega_capable() -> Tuple[bool, Optional[str]]:
+            if quant_config is None or not quant_config.quant_mode.has_w4a8_mxfp4_mxfp8(
+            ):
+                return False, "quant != W4A8_MXFP4_MXFP8"
+            pretrained = model_config.pretrained_config
+            pretrained_dtype = (getattr(pretrained, "torch_dtype",
+                                        torch.bfloat16)
+                                if pretrained is not None else torch.bfloat16)
+            pretrained_inter = None
+            if pretrained is not None:
+                pretrained_inter = getattr(pretrained, "moe_intermediate_size",
+                                           None)
+                if pretrained_inter is None:
+                    pretrained_inter = getattr(pretrained, "intermediate_size",
+                                               None)
+            return MegaMoEDeepGemm.can_implement(
+                QuantAlgo.W4A8_MXFP4_MXFP8,
+                dtype_activation=pretrained_dtype,
+                swiglu_gptoss_style=False,
+                hidden_size=getattr(pretrained, "hidden_size", None)
+                if pretrained is not None else None,
+                intermediate_size=pretrained_inter,
+            )
+
+        def _trtllm_gen_capable():
+            # Mirror the TRTLLM branch above's quant gate.
+            return quant_config is not None and (
+                quant_config.quant_mode.has_fp8_block_scales()
+                or quant_config.quant_mode.has_nvfp4()
+                or quant_config.quant_mode.has_w4a16_mxfp4()
+                or quant_config.quant_mode.has_w4a8_nvfp4_fp8()
+                or quant_config.quant_mode.has_w4a8_mxfp4_fp8()
+                or quant_config.quant_mode.has_w4a8_mxfp4_mxfp8())
+
+        if prefer_mega:
+            ok, reason = _mega_capable()
+            if ok:
+                logger.info(f"MEGAMOE_AUTO: max_num_tokens={per_rank_max} <= "
+                            f"megamoe_max_tokens_per_rank={threshold}, "
+                            f"selecting MegaMoEDeepGemm.")
+                return MegaMoEDeepGemm
+            logger.warning(
+                f"MEGAMOE_AUTO preferred MegaMoEDeepGemm "
+                f"(max_num_tokens={per_rank_max} <= {threshold}) but "
+                f"backend rejected current environment: {reason}. "
+                "Falling through to TRTLLMGenFusedMoE / CutlassFusedMoE.")
+        else:
+            logger.info(f"MEGAMOE_AUTO: max_num_tokens={per_rank_max} > "
+                        f"megamoe_max_tokens_per_rank={threshold}, "
+                        f"selecting TRTLLMGenFusedMoE.")
+        if _trtllm_gen_capable():
+            return TRTLLMGenFusedMoE
+        logger.warning(
+            "MEGAMOE_AUTO: TRTLLMGenFusedMoE rejected current quant "
+            f"config: {quant_config}. Falling back to CutlassFusedMoE.")
+        return CutlassFusedMoE
     else:
         raise ValueError(f"Unsupported moe backend: {moe_backend}")
 

--- a/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py
@@ -283,22 +283,9 @@ class MegaMoEDeepGemm(MoE):
         self.swiglu_limit_scalar = swiglu_limit_scalar
         self.fast_math = fast_math
 
-        # Buffer sizing. MoE layers execute serially per forward; a single
-        # process-level pool sized to worst-case per-rank tokens serves all.
-        self.max_num_tokens = int(
-            getattr(model_config, "moe_max_num_tokens", 0)
-            or getattr(model_config, "max_num_tokens", 0)
-            or 4096
-        )
-        # Under attention DP, ``ModelConfig`` pre-multiplies
-        # ``moe_max_num_tokens`` by ``dp_size``. The DG SymmBuffer further
-        # scales the pool by ``num_ranks`` (= ep_size, which equals dp_size
-        # in the supported full-ADP topology asserted above). Without this
-        # divide the buffer is sized as ``dp_size * ep_size *
-        # max_num_tokens``, doubling the EP factor and exploding HBM (see
-        # ``layout::Workspace`` / ``get_num_max_pool_tokens`` in DG).
-        if self.use_dp and self.ep_size > 1:
-            self.max_num_tokens = max(1, (self.max_num_tokens + self.ep_size - 1) // self.ep_size)
+        # FUSED_COMM scheduler strips x to per-rank before run_moe, so the cap is
+        # the engine's max_num_tokens (not the dp_size-multiplied moe_max_num_tokens).
+        self.max_num_tokens = int(getattr(model_config, "max_num_tokens", 0) or 4096)
 
         # Resolve the EP ProcessGroup at module construction — creating a
         # group at forward time would be collective on a non-synchronous

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -529,6 +529,8 @@ class ModelLoader:
             max_seq_len=self.max_seq_len,
             moe_max_num_tokens=self.llm_args.moe_config.max_num_tokens,
             moe_load_balancer=self.llm_args.moe_config.load_balancer,
+            megamoe_max_tokens_per_rank=self.llm_args.moe_config.
+            megamoe_max_tokens_per_rank,
             lora_config=self.lora_config,
             allreduce_strategy=self.llm_args.allreduce_strategy,
             mm_encoder_only=self.llm_args.mm_encoder_only,

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -633,16 +633,25 @@ class MoeConfig(StrictBaseModel):
     """
     backend: Literal[
         "AUTO", "CUTLASS", "CUTEDSL", "WIDEEP", "TRTLLM", "DEEPGEMM",
-        "DENSEGEMM", "VANILLA", "TRITON", "MEGAMOE_DEEPGEMM"] = Field(
+        "DENSEGEMM", "VANILLA", "TRITON", "MEGAMOE_DEEPGEMM",
+        "MEGAMOE_AUTO"] = Field(
             default='AUTO',
-            description="MoE backend to use. "
-            "AUTO selects default backend based on model. It currently doesn\'t always give the best choice for all scenarios. The capabilities of auto selection will be improved in future releases."
+            description=
+            "MoE backend to use. AUTO selects default backend based on model. "
+            "MEGAMOE_AUTO picks MegaMoEDeepGemm when max_num_tokens <= megamoe_max_tokens_per_rank, else TRTLLMGenFusedMoE."
         )
 
     max_num_tokens: Optional[int] = Field(
         default=None,
         description=
         "If set, at most max_num_tokens tokens will be sent to torch.ops.trtllm.fused_moe at the same time. If the number of tokens exceeds max_num_tokens, the input tensors will be split into chunks and a for loop will be used."
+    )
+
+    megamoe_max_tokens_per_rank: int = Field(
+        default=1024,
+        description=
+        "MEGAMOE_AUTO threshold on per-rank max_num_tokens (under attention DP); at or below picks MegaMoEDeepGemm, above picks TRTLLMGenFusedMoE. "
+        "Default 1024 matches SGLang's SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK."
     )
 
     load_balancer: Optional[Union[object, str]] = Field(

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -3791,6 +3791,7 @@ class TestDeepSeekV4Flash(LlmapiAccuracyTestHarness):
             )),
         "TRTLLM",
         "MEGAMOE_DEEPGEMM",
+        "MEGAMOE_AUTO",
     ])
     def test_nvfp4_4gpus_static_eplb(self, moe_backend):
         eplb_config = _make_deepseekv4_eplb_config(self.MODEL_PATH,

--- a/tests/unittest/_torch/modules/moe/test_create_moe_factory.py
+++ b/tests/unittest/_torch/modules/moe/test_create_moe_factory.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the ``get_moe_cls`` factory branches, with focus on
+``MEGAMOE_AUTO``: threshold-based selection between MegaMoEDeepGemm and
+TRTLLMGenFusedMoE plus capability-gate fallback to CutlassFusedMoE.
+"""
+
+from types import SimpleNamespace
+from typing import Optional
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.modules.fused_moe.create_moe import get_moe_cls
+from tensorrt_llm._torch.modules.fused_moe.fused_moe_cutlass import CutlassFusedMoE
+from tensorrt_llm._torch.modules.fused_moe.fused_moe_trtllm_gen import TRTLLMGenFusedMoE
+from tensorrt_llm._torch.modules.fused_moe.mega_moe import MegaMoEDeepGemm
+from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
+
+
+def _make_model_config(
+    *,
+    moe_backend: str,
+    max_num_tokens: int,
+    megamoe_max_tokens_per_rank: int = 1024,
+    quant_algo: Optional[QuantAlgo] = QuantAlgo.W4A8_MXFP4_MXFP8,
+):
+    """Lightweight ModelConfig stand-in. ``get_moe_cls`` only reads a small
+    subset of attributes; SimpleNamespace avoids the full ModelConfig dataclass
+    contract while still exercising the factory."""
+    pretrained = SimpleNamespace(
+        hidden_size=7168,
+        intermediate_size=3072,
+        moe_intermediate_size=3072,
+        torch_dtype=torch.bfloat16,
+    )
+    quant_config = QuantConfig(quant_algo=quant_algo) if quant_algo is not None else QuantConfig()
+    return SimpleNamespace(
+        moe_backend=moe_backend,
+        max_num_tokens=max_num_tokens,
+        megamoe_max_tokens_per_rank=megamoe_max_tokens_per_rank,
+        quant_config=quant_config,
+        pretrained_config=pretrained,
+    )
+
+
+def _patch_mega_capable(monkeypatch, ok: bool, reason: str = "skipped"):
+    monkeypatch.setattr(
+        MegaMoEDeepGemm,
+        "can_implement",
+        classmethod(lambda cls, *a, **kw: (ok, None if ok else reason)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# MEGAMOE_AUTO — threshold-driven branch selection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "max_num_tokens, expected_cls",
+    [
+        (256, MegaMoEDeepGemm),  # well below threshold
+        (1024, MegaMoEDeepGemm),  # threshold boundary (inclusive)
+        (1025, TRTLLMGenFusedMoE),  # just above threshold
+        (8192, TRTLLMGenFusedMoE),  # typical CTX prefill shape
+    ],
+)
+def test_megamoe_auto_threshold(monkeypatch, max_num_tokens, expected_cls):
+    _patch_mega_capable(monkeypatch, ok=True)
+    cfg = _make_model_config(
+        moe_backend="MEGAMOE_AUTO",
+        max_num_tokens=max_num_tokens,
+    )
+    assert get_moe_cls(cfg) is expected_cls
+
+
+@pytest.mark.parametrize("max_num_tokens", [256, 2048, 4096])
+def test_megamoe_auto_custom_threshold(monkeypatch, max_num_tokens):
+    """User-provided ``megamoe_max_tokens_per_rank`` should override the 1024
+    default. With threshold 4096, all three shapes prefer MegaMoE."""
+    _patch_mega_capable(monkeypatch, ok=True)
+    cfg = _make_model_config(
+        moe_backend="MEGAMOE_AUTO",
+        max_num_tokens=max_num_tokens,
+        megamoe_max_tokens_per_rank=4096,
+    )
+    assert get_moe_cls(cfg) is MegaMoEDeepGemm
+
+
+# ---------------------------------------------------------------------------
+# MEGAMOE_AUTO — capability-gate fallback chains
+# ---------------------------------------------------------------------------
+
+
+def test_megamoe_auto_falls_through_when_mega_gate_fails(monkeypatch):
+    """Below-threshold path: if MegaMoE rejects (e.g. wrong SM), fall through
+    to TRTLLMGen rather than silently returning MegaMoE."""
+    _patch_mega_capable(monkeypatch, ok=False, reason="non-SM100")
+    cfg = _make_model_config(moe_backend="MEGAMOE_AUTO", max_num_tokens=512)
+    assert get_moe_cls(cfg) is TRTLLMGenFusedMoE
+
+
+def test_megamoe_auto_cutlass_when_both_gates_fail(monkeypatch):
+    """If both MegaMoE and TRTLLMGen reject, final fallback is Cutlass.
+    MegaMoE rejected via patched ``can_implement``; TRTLLMGen rejected via
+    a quant_config it does not support."""
+    _patch_mega_capable(monkeypatch, ok=False, reason="non-SM100")
+    cfg = _make_model_config(
+        moe_backend="MEGAMOE_AUTO",
+        max_num_tokens=512,
+        quant_algo=None,  # leaves QuantConfig() default; no FP8/NVFP4 mode
+    )
+    assert get_moe_cls(cfg) is CutlassFusedMoE
+
+
+def test_megamoe_auto_above_threshold_uses_trtllm_when_quant_supported(monkeypatch):
+    """Above-threshold path picks TRTLLMGen directly without consulting the
+    MegaMoE gate."""
+    # Stub MegaMoE.can_implement to True so we know the result is not from
+    # accidentally taking the below-threshold branch.
+    _patch_mega_capable(monkeypatch, ok=True)
+    cfg = _make_model_config(moe_backend="MEGAMOE_AUTO", max_num_tokens=8192)
+    assert get_moe_cls(cfg) is TRTLLMGenFusedMoE
+
+
+def test_megamoe_auto_above_threshold_falls_back_to_cutlass_when_quant_unsupported(monkeypatch):
+    """Above-threshold + TRTLLMGen-unsupported quant -> Cutlass."""
+    _patch_mega_capable(monkeypatch, ok=True)
+    cfg = _make_model_config(
+        moe_backend="MEGAMOE_AUTO",
+        max_num_tokens=8192,
+        quant_algo=None,
+    )
+    assert get_moe_cls(cfg) is CutlassFusedMoE
+
+
+# ---------------------------------------------------------------------------
+# MEGAMOE_AUTO — boundary: missing / zero max_num_tokens
+# ---------------------------------------------------------------------------
+
+
+def test_megamoe_auto_zero_max_num_tokens_picks_trtllm(monkeypatch):
+    """``max_num_tokens=0`` (unset / placeholder) treats the workload as
+    'too big to know', falling back to TRTLLMGen rather than MegaMoE."""
+    _patch_mega_capable(monkeypatch, ok=True)
+    cfg = _make_model_config(moe_backend="MEGAMOE_AUTO", max_num_tokens=0)
+    assert get_moe_cls(cfg) is TRTLLMGenFusedMoE


### PR DESCRIPTION
The MegaMoEDeepGemm wrapper previously read
``model_config.moe_max_num_tokens`` to size its DG SymmBuffer pool and then divided by ``ep_size`` (per #14213) to undo the auto-multiply that ``ModelConfig.__post_init__`` applies for allgather-based backends.

Under ``FUSED_COMM`` scheduler (always used by mega_moe), ``FusedCommMoEScheduler._strip_adp_padding`` slices ``x`` to the local rank's tokens before ``run_moe``, so the per-call ``x.shape[0]`` is bounded by the engine's per-instance ``max_num_tokens`` and never by ``dp_size * max_num_tokens``. The auto-multiply is therefore semantically wrong for mega_moe and the divide is a workaround for the wrong source.

Two failure modes of the multiply-then-divide dance:

1. If a deployed binary lacks the divide (e.g. binaries built before #14213 landed on this branch), the auto-multiplied value is used as- is, so the cubin's ``num_max_tokens_per_rank`` is baked at ``dp_size * engine.max_num_tokens`` instead of ``engine.max_num_tokens`` (e.g. 65664 vs 8448 on DSv4-Pro @ DEP=8). Measured cost on B300 DEP=8, balanced 8192 tok/rank: 4.03 ms -> 3.39 ms median per-call (-19%), plus the SymmBuffer pool drops from ~3.6 GB to ~470 MB (-7.6x).

2. If a user explicitly sets ``moe_config.max_num_tokens`` in yaml, ``__post_init__`` skips the auto-multiply, but the wrapper still divides, so the per-rank cap becomes ``yaml_value / ep_size`` (too small by ep_size). The line-667 runtime assert then fires for every request whose per-rank tokens exceed that.

Read ``model_config.max_num_tokens`` directly instead. The other consumers of ``moe_max_num_tokens`` (fused_moe_cutlass, fused_moe_deepgemm, communication_factory) keep the auto-multiplied value, which is correct for those allgather paths.

Test plan:
- ``pre-commit run`` clean on the modified file (ruff, ruff-format, codespell, copyright, DCO).
- TestDeepSeekV4Flash::test_nvfp4_4gpus_static_eplb[MEGAMOE_DEEPGEMM] on 4x B300 NVFP4 + static EPLB: PASSED. lm-eval GSM8K accuracy 95.262 vs reference 95.110 (threshold 91.907). Runtime ~15 min.
- bench_moe at 8192 tok/rank DEP=8 (--analysis kernels --iters 12 --warmup 2) confirms cubin params after fix: sm100_fp8_fp4_mega_moe_impl<8448, 7168, 3072, 384, 6, 2, 192, ..., 414720, 6635520, ...> with mega_moe per-call median 2.62 ms.

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
