### PR TITLE
[None][feat] Targeted warmup-waste cleanup

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -473,13 +473,6 @@ class PyTorchModelEngine(ModelEngine):
             raise e
 
         self.is_warmup = False
-        # Set to True by py_executor_creator around the first (estimation-pass)
-        # PyExecutor's warmup; the production PyExecutor's warmup runs with this
-        # back to False. Read by warmup() to skip step (d) max-shape
-        # pre-population during estimation - those blocks have no payoff because
-        # configure_kv_cache_capacity drops them via empty_cache() before
-        # measuring, and the estimation PyExecutor is torn down immediately
-        # after measurement without ever serving a request.
         self.is_estimation_pass = False
         self.previous_request_ids = []
         self.has_previous_device_draft = False
@@ -968,9 +961,7 @@ class PyTorchModelEngine(ModelEngine):
         # is decode-only and runs into issues with autotuner warmup.
         if not self.mapping.has_cp_helix():
             self._run_autotuner_warmup(resource_manager)
-            # Release the autotuner's exploration-mode intermediates. Each
-            # tunable op site allocates buffers per candidate tactic but only
-            # the cached best tactic is replayed during serving, so the
+            # Release the autotuner's exploration-mode intermediates. The
             # exploration leftovers are pure waste that hide tens of GiB from
             # non-torch allocators (cuBLAS handle workspace, UCX/NIXL,
             # NVSHMEM).

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -969,31 +969,17 @@ class PyTorchModelEngine(ModelEngine):
             torch.cuda.empty_cache()
         with self.cuda_graph_runner.allow_capture():
             self._run_cuda_graph_warmup(resource_manager)
-        # Step (d) max-shape pre-population pre-allocates the worst-case
-        # activation blocks so the first real iteration reuses them instead
-        # of paying a cudaMalloc cost. Skip when:
-        #   - is_estimation_pass: the estimation PyExecutor is torn down
-        #     immediately after configure_kv_cache_capacity (which calls
-        #     empty_cache()), so any pre-pop blocks are released before
-        #     measurement and never serve a request. Pure waste.
-        #   - TRTLLM_SKIP_MAX_SHAPE_WARMUP=1: opt-in for production workloads
-        #     that prefer maximum non-torch headroom (cuBLAS, UCX/NIXL,
-        #     NVSHMEM) over the ~tens-of-ms first-iter cudaMalloc saving.
         if can_run_general_warmup:
-            skip_for_estimation = self.is_estimation_pass
-            skip_for_envvar = (os.environ.get("TRTLLM_SKIP_MAX_SHAPE_WARMUP",
-                                              "0") == "1")
-            if not (skip_for_estimation or skip_for_envvar):
+            if not self.is_estimation_pass:
                 # Pre-populate the memory pool with max-shape allocations to
                 # reduce fragmentation at runtime.
                 warmup_requests_configs = self._get_max_shape_warmup_requests(
                     resource_manager)
                 self._general_warmup(resource_manager, warmup_requests_configs)
             else:
-                reason = ("estimation pass" if skip_for_estimation else
-                          "TRTLLM_SKIP_MAX_SHAPE_WARMUP=1")
                 logger.info(
-                    f"Skipping max-shape warmup pre-population ({reason})")
+                    "Skipping max-shape warmup pre-population (estimation pass)"
+                )
 
     def _general_warmup(self, resource_manager: ResourceManager,
                         warmup_requests_configs: List[Tuple[int, int]]):

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -473,6 +473,14 @@ class PyTorchModelEngine(ModelEngine):
             raise e
 
         self.is_warmup = False
+        # Set to True by py_executor_creator around the first (estimation-pass)
+        # PyExecutor's warmup; the production PyExecutor's warmup runs with this
+        # back to False. Read by warmup() to skip step (d) max-shape
+        # pre-population during estimation - those blocks have no payoff because
+        # configure_kv_cache_capacity drops them via empty_cache() before
+        # measuring, and the estimation PyExecutor is torn down immediately
+        # after measurement without ever serving a request.
+        self.is_estimation_pass = False
         self.previous_request_ids = []
         self.has_previous_device_draft = False
         self.previous_accepted_tokens_cuda = torch.empty((self.batch_size, ),
@@ -972,21 +980,29 @@ class PyTorchModelEngine(ModelEngine):
             self._run_cuda_graph_warmup(resource_manager)
         # Step (d) max-shape pre-population pre-allocates the worst-case
         # activation blocks so the first real iteration reuses them instead
-        # of paying a cudaMalloc cost. The blocks themselves are legitimate
-        # first-iter working set, but on workloads that prefer maximum
-        # non-torch headroom over the ~tens-of-ms first-iter saving (e.g.
-        # disaggregated context workers running near the GPU-memory limit),
-        # TRTLLM_SKIP_MAX_SHAPE_WARMUP=1 disables this pass.
-        if can_run_general_warmup and os.environ.get(
-                "TRTLLM_SKIP_MAX_SHAPE_WARMUP", "0") != "1":
-            # Pre-populate the memory pool with max-shape allocations to reduce
-            # fragmentation at runtime.
-            warmup_requests_configs = self._get_max_shape_warmup_requests(
-                resource_manager)
-            self._general_warmup(resource_manager, warmup_requests_configs)
-        elif can_run_general_warmup:
-            logger.info("Skipping max-shape warmup pre-population "
-                        "(TRTLLM_SKIP_MAX_SHAPE_WARMUP=1)")
+        # of paying a cudaMalloc cost. Skip when:
+        #   - is_estimation_pass: the estimation PyExecutor is torn down
+        #     immediately after configure_kv_cache_capacity (which calls
+        #     empty_cache()), so any pre-pop blocks are released before
+        #     measurement and never serve a request. Pure waste.
+        #   - TRTLLM_SKIP_MAX_SHAPE_WARMUP=1: opt-in for production workloads
+        #     that prefer maximum non-torch headroom (cuBLAS, UCX/NIXL,
+        #     NVSHMEM) over the ~tens-of-ms first-iter cudaMalloc saving.
+        if can_run_general_warmup:
+            skip_for_estimation = self.is_estimation_pass
+            skip_for_envvar = (os.environ.get("TRTLLM_SKIP_MAX_SHAPE_WARMUP",
+                                              "0") == "1")
+            if not (skip_for_estimation or skip_for_envvar):
+                # Pre-populate the memory pool with max-shape allocations to
+                # reduce fragmentation at runtime.
+                warmup_requests_configs = self._get_max_shape_warmup_requests(
+                    resource_manager)
+                self._general_warmup(resource_manager, warmup_requests_configs)
+            else:
+                reason = ("estimation pass" if skip_for_estimation else
+                          "TRTLLM_SKIP_MAX_SHAPE_WARMUP=1")
+                logger.info(
+                    f"Skipping max-shape warmup pre-population ({reason})")
 
     def _general_warmup(self, resource_manager: ResourceManager,
                         warmup_requests_configs: List[Tuple[int, int]]):

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -473,7 +473,6 @@ class PyTorchModelEngine(ModelEngine):
             raise e
 
         self.is_warmup = False
-        self.is_estimation_pass = False
         self.previous_request_ids = []
         self.has_previous_device_draft = False
         self.previous_accepted_tokens_cuda = torch.empty((self.batch_size, ),
@@ -970,16 +969,11 @@ class PyTorchModelEngine(ModelEngine):
         with self.cuda_graph_runner.allow_capture():
             self._run_cuda_graph_warmup(resource_manager)
         if can_run_general_warmup:
-            if not self.is_estimation_pass:
-                # Pre-populate the memory pool with max-shape allocations to
-                # reduce fragmentation at runtime.
-                warmup_requests_configs = self._get_max_shape_warmup_requests(
-                    resource_manager)
-                self._general_warmup(resource_manager, warmup_requests_configs)
-            else:
-                logger.info(
-                    "Skipping max-shape warmup pre-population (estimation pass)"
-                )
+            # Pre-populate the memory pool with max-shape allocations to reduce
+            # fragmentation at runtime.
+            warmup_requests_configs = self._get_max_shape_warmup_requests(
+                resource_manager)
+            self._general_warmup(resource_manager, warmup_requests_configs)
 
     def _general_warmup(self, resource_manager: ResourceManager,
                         warmup_requests_configs: List[Tuple[int, int]]):

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -960,14 +960,33 @@ class PyTorchModelEngine(ModelEngine):
         # is decode-only and runs into issues with autotuner warmup.
         if not self.mapping.has_cp_helix():
             self._run_autotuner_warmup(resource_manager)
+            # Release the autotuner's exploration-mode intermediates. Each
+            # tunable op site allocates buffers per candidate tactic but only
+            # the cached best tactic is replayed during serving, so the
+            # exploration leftovers are pure waste that hide tens of GiB from
+            # non-torch allocators (cuBLAS handle workspace, UCX/NIXL,
+            # NVSHMEM).
+            gc.collect()
+            torch.cuda.empty_cache()
         with self.cuda_graph_runner.allow_capture():
             self._run_cuda_graph_warmup(resource_manager)
-        if can_run_general_warmup:
+        # Step (d) max-shape pre-population pre-allocates the worst-case
+        # activation blocks so the first real iteration reuses them instead
+        # of paying a cudaMalloc cost. The blocks themselves are legitimate
+        # first-iter working set, but on workloads that prefer maximum
+        # non-torch headroom over the ~tens-of-ms first-iter saving (e.g.
+        # disaggregated context workers running near the GPU-memory limit),
+        # TRTLLM_SKIP_MAX_SHAPE_WARMUP=1 disables this pass.
+        if can_run_general_warmup and os.environ.get(
+                "TRTLLM_SKIP_MAX_SHAPE_WARMUP", "0") != "1":
             # Pre-populate the memory pool with max-shape allocations to reduce
             # fragmentation at runtime.
             warmup_requests_configs = self._get_max_shape_warmup_requests(
                 resource_manager)
             self._general_warmup(resource_manager, warmup_requests_configs)
+        elif can_run_general_warmup:
+            logger.info("Skipping max-shape warmup pre-population "
+                        "(TRTLLM_SKIP_MAX_SHAPE_WARMUP=1)")
 
     def _general_warmup(self, resource_manager: ResourceManager,
                         warmup_requests_configs: List[Tuple[int, int]]):

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -992,6 +992,16 @@ def create_py_executor(
 
         del py_executor  # free before constructing new
         gc.collect()
+        # teardown_managers() above released the first PyExecutor's live
+        # torch tensors (KV manager, sampler, scheduler state). Python
+        # references drop but PyTorch's caching allocator keeps the
+        # underlying cudaMalloc'd blocks in its free pool, and the second
+        # PyExecutor's step (a) empty_cache only reclaims blocks matching
+        # its own allocations - the rest stay parked across the entire
+        # second warmup. Release them to the driver before the production
+        # KV pool is allocated so non-torch allocators (cuBLAS, UCX/NIXL,
+        # NVSHMEM) see the headroom.
+        torch.cuda.empty_cache()
 
         with allocation_scope(ExecutorMemoryType.KV_CACHE):
             # Before estimating KV cache size, a minimal KV cache has been allocated using

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -935,6 +935,14 @@ def create_py_executor(
             if estimating_kv_cache else ExecutorMemoryType.EXTRA_RESOURCES):
         # run gc.collect() to free memory of the previous py_executor, avoid cudaFree overlap with cuda graph capture
         gc.collect()
+        # Tell model_engine.warmup() to skip step (d) max-shape pre-population
+        # during the estimation pass - the pre-pop blocks are released by
+        # configure_kv_cache_capacity's empty_cache() before measurement
+        # anyway, and the estimation PyExecutor is torn down immediately
+        # after measurement. Production pass clears the flag below.
+        model_engine.is_estimation_pass = estimating_kv_cache
+        if draft_model_engine is not None:
+            draft_model_engine.is_estimation_pass = estimating_kv_cache
         py_executor = create_py_executor_instance(
             dist=dist,
             resources=resources,
@@ -1018,6 +1026,11 @@ def create_py_executor(
 
             # run gc.collect() to free memory of the previous py_executor, avoid cudaFree overlap with cuda graph capture
             gc.collect()
+            # Production pass: step (d) max-shape pre-population is valuable
+            # here because the blocks are reused on the first real iteration.
+            model_engine.is_estimation_pass = False
+            if draft_model_engine is not None:
+                draft_model_engine.is_estimation_pass = False
             py_executor = create_py_executor_instance(
                 dist=dist,
                 resources=resources,

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -935,11 +935,6 @@ def create_py_executor(
             if estimating_kv_cache else ExecutorMemoryType.EXTRA_RESOURCES):
         # run gc.collect() to free memory of the previous py_executor, avoid cudaFree overlap with cuda graph capture
         gc.collect()
-        # Tell model_engine.warmup() to skip step (d) max-shape pre-population
-        # during the estimation pass - the pre-pop blocks are released by
-        # configure_kv_cache_capacity's empty_cache() before measurement
-        # anyway, and the estimation PyExecutor is torn down immediately
-        # after measurement. Production pass clears the flag below.
         model_engine.is_estimation_pass = estimating_kv_cache
         if draft_model_engine is not None:
             draft_model_engine.is_estimation_pass = estimating_kv_cache
@@ -1000,15 +995,6 @@ def create_py_executor(
 
         del py_executor  # free before constructing new
         gc.collect()
-        # teardown_managers() above released the first PyExecutor's live
-        # torch tensors (KV manager, sampler, scheduler state). Python
-        # references drop but PyTorch's caching allocator keeps the
-        # underlying cudaMalloc'd blocks in its free pool, and the second
-        # PyExecutor's step (a) empty_cache only reclaims blocks matching
-        # its own allocations - the rest stay parked across the entire
-        # second warmup. Release them to the driver before the production
-        # KV pool is allocated so non-torch allocators (cuBLAS, UCX/NIXL,
-        # NVSHMEM) see the headroom.
         torch.cuda.empty_cache()
 
         with allocation_scope(ExecutorMemoryType.KV_CACHE):

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -935,9 +935,6 @@ def create_py_executor(
             if estimating_kv_cache else ExecutorMemoryType.EXTRA_RESOURCES):
         # run gc.collect() to free memory of the previous py_executor, avoid cudaFree overlap with cuda graph capture
         gc.collect()
-        model_engine.is_estimation_pass = estimating_kv_cache
-        if draft_model_engine is not None:
-            draft_model_engine.is_estimation_pass = estimating_kv_cache
         py_executor = create_py_executor_instance(
             dist=dist,
             resources=resources,
@@ -1012,11 +1009,6 @@ def create_py_executor(
 
             # run gc.collect() to free memory of the previous py_executor, avoid cudaFree overlap with cuda graph capture
             gc.collect()
-            # Production pass: step (d) max-shape pre-population is valuable
-            # here because the blocks are reused on the first real iteration.
-            model_engine.is_estimation_pass = False
-            if draft_model_engine is not None:
-                draft_model_engine.is_estimation_pass = False
             py_executor = create_py_executor_instance(
                 dist=dist,
                 resources=resources,

--- a/tests/unittest/_torch/executor/test_pytorch_model_engine_warmup.py
+++ b/tests/unittest/_torch/executor/test_pytorch_model_engine_warmup.py
@@ -3,16 +3,15 @@
 Locks in two of the three warmup-cleanup changes:
   - Change 1: gc.collect() + torch.cuda.empty_cache() fire immediately after
     _run_autotuner_warmup (step b) - releases autotuner exploration leftovers.
-  - Change 3: TRTLLM_SKIP_MAX_SHAPE_WARMUP=1 skips the step (d) max-shape
-    pre-population pass and emits a skip log; any other value (or absence)
-    leaves step (d) running.
+  - Change 3: step (d) max-shape pre-population is automatically skipped when
+    PyTorchModelEngine.is_estimation_pass is True, and runs unconditionally
+    in the production pass.
 
 The third change (torch.cuda.empty_cache() after teardown_managers()
 is covered end-to-end by integration tests rather than unit-tested here.
 """
 
 import contextlib
-import os
 import unittest
 from dataclasses import dataclass
 from unittest.mock import patch
@@ -124,18 +123,12 @@ class _Tracker:
 
 
 def _run_warmup_tracked(
-    model_engine, resource_manager, *, env_var=None, force_helix_cp=False, capture_logs=False
+    model_engine, resource_manager, *, force_helix_cp=False, capture_logs=False
 ):
     """Patch the four warmup helpers + empty_cache + MoERunner.clear and run
-    model_engine.warmup(). Optionally set env var, force helix CP, capture
-    logs. Returns (call_order_list, log_records_or_None)."""
+    model_engine.warmup(). Optionally force helix CP and capture logs.
+    Returns (call_order_list, log_records_or_None)."""
     tracker = _Tracker()
-
-    env_ctx = (
-        patch.dict(os.environ, {"TRTLLM_SKIP_MAX_SHAPE_WARMUP": env_var})
-        if env_var is not None
-        else _clear_env_var_ctx("TRTLLM_SKIP_MAX_SHAPE_WARMUP")
-    )
     helix_ctx = (
         patch.object(model_engine.mapping, "has_cp_helix", return_value=True)
         if force_helix_cp
@@ -143,7 +136,6 @@ def _run_warmup_tracked(
     )
 
     with (
-        env_ctx,
         helix_ctx,
         patch.object(model_engine, "_general_warmup", side_effect=tracker("general_warmup")),
         patch.object(model_engine, "_run_autotuner_warmup", side_effect=tracker("autotuner")),
@@ -160,18 +152,6 @@ def _run_warmup_tracked(
             return tracker.calls, logs
         model_engine.warmup(resource_manager)
         return tracker.calls, None
-
-
-@contextlib.contextmanager
-def _clear_env_var_ctx(name: str):
-    """Context that ensures `name` is unset for its duration."""
-    sentinel = object()
-    original = os.environ.pop(name, sentinel)
-    try:
-        yield
-    finally:
-        if original is not sentinel:
-            os.environ[name] = original
 
 
 @contextlib.contextmanager
@@ -239,51 +219,11 @@ class TestWarmupCleanup(unittest.TestCase):
             calls.count("empty_cache"), 0, f"Helix CP should skip all warmup cleanup; got {calls}"
         )
 
-    # ---- Change 3: step (d) env-var gate ----
-
-    def test_step_d_runs_when_env_var_unset(self):
-        """Default: env var unset -> step (d) runs (2 general_warmup calls)."""
-        model_engine, resource_manager = _build_engine_and_resource_manager()
-        calls, _ = _run_warmup_tracked(model_engine, resource_manager)
-        self.assertEqual(
-            calls.count("general_warmup"),
-            2,
-            f"Expected step (a) + step (d) general_warmup; got {calls}",
-        )
-
-    def test_step_d_skipped_when_env_var_is_one(self):
-        """Change 3: TRTLLM_SKIP_MAX_SHAPE_WARMUP=1 skips step (d) and logs."""
-        model_engine, resource_manager = _build_engine_and_resource_manager()
-        calls, logs = _run_warmup_tracked(
-            model_engine, resource_manager, env_var="1", capture_logs=True
-        )
-        self.assertEqual(
-            calls.count("general_warmup"), 1, f"Expected only step (a) general_warmup; got {calls}"
-        )
-        self.assertTrue(
-            any("Skipping max-shape warmup pre-population" in m for m in logs),
-            f"Expected skip log; got logs={logs}",
-        )
-
-    def test_step_d_runs_for_env_var_values_other_than_one(self):
-        """Gate semantics: only literal '1' disables step (d).
-        Any other value (including truthy strings like 'true') still runs it."""
-        for val in ["0", "", "true", "yes", "2", "on"]:
-            with self.subTest(env_value=val):
-                model_engine, resource_manager = _build_engine_and_resource_manager()
-                calls, _ = _run_warmup_tracked(model_engine, resource_manager, env_var=val)
-                self.assertEqual(
-                    calls.count("general_warmup"),
-                    2,
-                    f"env={val!r}: expected 2 general_warmup; got {calls}",
-                )
-
     # ---- Estimation-pass step (d) skip ----
 
     def test_step_d_skipped_in_estimation_pass(self):
         """Estimation-pass optimization: when is_estimation_pass=True,
-        step (d) is skipped even if the env var is unset, and the skip log
-        reports the estimation reason."""
+        step (d) is skipped and a skip log is emitted."""
         model_engine, resource_manager = _build_engine_and_resource_manager()
         model_engine.is_estimation_pass = True
         calls, logs = _run_warmup_tracked(model_engine, resource_manager, capture_logs=True)
@@ -298,9 +238,9 @@ class TestWarmupCleanup(unittest.TestCase):
         )
 
     def test_step_d_runs_when_is_estimation_pass_false(self):
-        """Default attribute value is False, so step (d) runs normally."""
+        """Production pass (is_estimation_pass=False, the default): both
+        step (a) and step (d) run for max-shape memory-pool pre-population."""
         model_engine, resource_manager = _build_engine_and_resource_manager()
-        # Explicit assertion: the attribute exists and defaults to False.
         self.assertFalse(model_engine.is_estimation_pass)
         calls, _ = _run_warmup_tracked(model_engine, resource_manager)
         self.assertEqual(

--- a/tests/unittest/_torch/executor/test_pytorch_model_engine_warmup.py
+++ b/tests/unittest/_torch/executor/test_pytorch_model_engine_warmup.py
@@ -1,10 +1,7 @@
 """Unit tests for warmup-cleanup behavior in PyTorchModelEngine.warmup().
 
-Locks in:
-  - gc.collect() + torch.cuda.empty_cache() fire immediately after
-    _run_autotuner_warmup (step b) - releases autotuner exploration leftovers.
-  - Step (d) max-shape pre-population runs unconditionally so the first real
-    iteration reuses the cached blocks instead of paying a cudaMalloc cost.
+Locks in that gc.collect() + torch.cuda.empty_cache() fire immediately after
+_run_autotuner_warmup (step b) to release autotuner exploration leftovers.
 
 The torch.cuda.empty_cache() after teardown_managers() in py_executor_creator
 is covered end-to-end by integration tests rather than unit-tested here.
@@ -177,8 +174,6 @@ def _capture_tllm_logs():
 class TestWarmupCleanup(unittest.TestCase):
     """Lock in warmup-cleanup behavior introduced by PR #14609 (Plan B)."""
 
-    # ---- Change 1: step (b) cleanup ----
-
     def test_empty_cache_fires_immediately_after_autotuner(self):
         """Change 1 placement: empty_cache must be the call right after
         _run_autotuner_warmup."""
@@ -216,20 +211,6 @@ class TestWarmupCleanup(unittest.TestCase):
         self.assertNotIn("autotuner", calls, f"Helix CP should skip autotuner; got {calls}")
         self.assertEqual(
             calls.count("empty_cache"), 0, f"Helix CP should skip all warmup cleanup; got {calls}"
-        )
-
-    # ---- Step (d) runs unconditionally ----
-
-    def test_step_d_runs_unconditionally(self):
-        """Step (d) max-shape pre-population must run on every warmup so the
-        first real serving iteration reuses the cached blocks instead of
-        paying a cudaMalloc cost."""
-        model_engine, resource_manager = _build_engine_and_resource_manager()
-        calls, _ = _run_warmup_tracked(model_engine, resource_manager)
-        self.assertEqual(
-            calls.count("general_warmup"),
-            2,
-            f"Expected step (a) + step (d) general_warmup calls; got {calls}",
         )
 
 

--- a/tests/unittest/_torch/executor/test_pytorch_model_engine_warmup.py
+++ b/tests/unittest/_torch/executor/test_pytorch_model_engine_warmup.py
@@ -1,0 +1,283 @@
+"""Unit tests for warmup-cleanup behavior in PyTorchModelEngine.warmup().
+
+Locks in two of the three warmup-cleanup changes:
+  - Change 1: gc.collect() + torch.cuda.empty_cache() fire immediately after
+    _run_autotuner_warmup (step b) - releases autotuner exploration leftovers.
+  - Change 3: TRTLLM_SKIP_MAX_SHAPE_WARMUP=1 skips the step (d) max-shape
+    pre-population pass and emits a skip log; any other value (or absence)
+    leaves step (d) running.
+
+The third change (torch.cuda.empty_cache() after teardown_managers()
+is covered end-to-end by integration tests rather than unit-tested here.
+"""
+
+import contextlib
+import os
+import unittest
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import torch
+
+import tensorrt_llm
+from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.pyexecutor.model_engine import PyTorchModelEngine
+from tensorrt_llm._torch.pyexecutor.resource_manager import (
+    KVCacheManager,
+    ResourceManager,
+    ResourceManagerType,
+)
+from tensorrt_llm.bindings.executor import KvCacheConfig
+from tensorrt_llm.llmapi import CudaGraphConfig
+from tensorrt_llm.llmapi.llm_args import TorchLlmArgs
+from tensorrt_llm.mapping import Mapping
+
+
+# Minimal fixtures mirroring sibling test_pytorch_model_engine.py — duplicated
+# rather than imported to keep this file self-contained and avoid sibling-test
+# import fragility.
+@dataclass
+class _Config:
+    torch_dtype: torch.dtype
+    num_key_value_heads: int = 16
+    num_attention_heads: int = 16
+    hidden_size: int = 256
+    architectures: list = None
+
+    @property
+    def head_dim(self) -> int:
+        return self.hidden_size // self.num_attention_heads
+
+
+class _DummyModel(torch.nn.Module):
+    def __init__(self, dtype: torch.dtype):
+        super().__init__()
+        self.model_config = ModelConfig(pretrained_config=_Config(torch_dtype=dtype))
+
+    def infer_max_seq_len(self):
+        return 2048
+
+    @property
+    def config(self):
+        return self.model_config.pretrained_config
+
+    def forward(self, *args, **kwargs):
+        # Never actually called in these tests (the warmup helpers that would
+        # invoke forward are all patched), but must exist for engine init.
+        batch_size = kwargs["input_ids"].size(0)
+        return {"logits": torch.randn((batch_size, 10), device="cuda")}
+
+
+class _DummyModelEngine(PyTorchModelEngine):
+    def __init__(self, llm_args: TorchLlmArgs, dtype: torch.dtype):
+        mapping = Mapping(
+            world_size=tensorrt_llm.mpi_world_size(),
+            tp_size=tensorrt_llm.mpi_world_size(),
+            rank=tensorrt_llm.mpi_rank(),
+        )
+        super().__init__(
+            model_path="dummy", mapping=mapping, model=_DummyModel(dtype), llm_args=llm_args
+        )
+
+
+def _build_engine_and_resource_manager():
+    tokens_per_block = 1
+    max_tokens = 258
+    num_layers = 1
+    batch_size = 13
+    llm_args = TorchLlmArgs(
+        model="dummy",
+        max_batch_size=batch_size,
+        max_num_tokens=max_tokens,
+        cuda_graph_config=CudaGraphConfig(
+            enable_padding=True, batch_sizes=[1, 2, 4, 8, 16, 32, 64, 128]
+        ),
+    )
+    model_engine = _DummyModelEngine(llm_args, torch.half)
+    kv_cache_manager = KVCacheManager(
+        KvCacheConfig(max_tokens=max_tokens),
+        tensorrt_llm.bindings.internal.batch_manager.CacheType.SELF,
+        num_layers=num_layers,
+        num_kv_heads=model_engine.model.config.num_key_value_heads,
+        head_dim=model_engine.model.config.head_dim,
+        tokens_per_block=tokens_per_block,
+        max_seq_len=max_tokens,
+        max_batch_size=batch_size,
+        mapping=Mapping(world_size=1, tp_size=1, rank=0),
+        dtype=tensorrt_llm.bindings.DataType.HALF,
+    )
+    resource_manager = ResourceManager({ResourceManagerType.KV_CACHE_MANAGER: kv_cache_manager})
+    return model_engine, resource_manager
+
+
+class _Tracker:
+    """Records method-call order via mock side_effects."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, name):
+        def _wrapped(*args, **kwargs):
+            self.calls.append(name)
+
+        return _wrapped
+
+
+def _run_warmup_tracked(
+    model_engine, resource_manager, *, env_var=None, force_helix_cp=False, capture_logs=False
+):
+    """Patch the four warmup helpers + empty_cache + MoERunner.clear and run
+    model_engine.warmup(). Optionally set env var, force helix CP, capture
+    logs. Returns (call_order_list, log_records_or_None)."""
+    tracker = _Tracker()
+
+    env_ctx = (
+        patch.dict(os.environ, {"TRTLLM_SKIP_MAX_SHAPE_WARMUP": env_var})
+        if env_var is not None
+        else _clear_env_var_ctx("TRTLLM_SKIP_MAX_SHAPE_WARMUP")
+    )
+    helix_ctx = (
+        patch.object(model_engine.mapping, "has_cp_helix", return_value=True)
+        if force_helix_cp
+        else contextlib.nullcontext()
+    )
+
+    with (
+        env_ctx,
+        helix_ctx,
+        patch.object(model_engine, "_general_warmup", side_effect=tracker("general_warmup")),
+        patch.object(model_engine, "_run_autotuner_warmup", side_effect=tracker("autotuner")),
+        patch.object(model_engine, "_run_cuda_graph_warmup", side_effect=tracker("cuda_graph")),
+        patch("torch.cuda.empty_cache", side_effect=tracker("empty_cache")),
+        patch(
+            "tensorrt_llm._torch.custom_ops.torch_custom_ops.MoERunner.clear_all_workspaces",
+            side_effect=tracker("moe_clear"),
+        ),
+    ):
+        if capture_logs:
+            with _capture_tllm_logs() as logs:
+                model_engine.warmup(resource_manager)
+            return tracker.calls, logs
+        model_engine.warmup(resource_manager)
+        return tracker.calls, None
+
+
+@contextlib.contextmanager
+def _clear_env_var_ctx(name: str):
+    """Context that ensures `name` is unset for its duration."""
+    sentinel = object()
+    original = os.environ.pop(name, sentinel)
+    try:
+        yield
+    finally:
+        if original is not sentinel:
+            os.environ[name] = original
+
+
+@contextlib.contextmanager
+def _capture_tllm_logs():
+    """Capture logger.info calls emitted from the model_engine module.
+
+    tensorrt_llm.logger.logger is a custom Singleton (not a stdlib
+    logging.Logger) and does not route through stdlib logging by default,
+    so a logging.Handler attached to logging.getLogger("tensorrt_llm")
+    sees nothing. Patch the logger.info bound on the model_engine module
+    directly so we observe exactly the messages warmup() emits.
+    """
+    from tensorrt_llm._torch.pyexecutor import model_engine as _me_mod
+
+    records = []
+
+    def _record(*msg):
+        records.append(" ".join(str(m) for m in msg))
+
+    with patch.object(_me_mod.logger, "info", side_effect=_record):
+        yield records
+
+
+class TestWarmupCleanup(unittest.TestCase):
+    """Lock in warmup-cleanup behavior introduced by PR #14609 (Plan B)."""
+
+    # ---- Change 1: step (b) cleanup ----
+
+    def test_empty_cache_fires_immediately_after_autotuner(self):
+        """Change 1 placement: empty_cache must be the call right after
+        _run_autotuner_warmup."""
+        model_engine, resource_manager = _build_engine_and_resource_manager()
+        calls, _ = _run_warmup_tracked(model_engine, resource_manager)
+
+        self.assertIn("autotuner", calls)
+        autotuner_idx = calls.index("autotuner")
+        self.assertLess(
+            autotuner_idx + 1, len(calls), f"Expected something after autotuner; got {calls}"
+        )
+        self.assertEqual(
+            calls[autotuner_idx + 1],
+            "empty_cache",
+            f"Expected empty_cache right after autotuner; got {calls}",
+        )
+
+    def test_empty_cache_count_under_default(self):
+        """Default warmup should call empty_cache exactly twice:
+        once at the end of step (a) (pre-existing) and once after step (b)
+        (Change 1)."""
+        model_engine, resource_manager = _build_engine_and_resource_manager()
+        calls, _ = _run_warmup_tracked(model_engine, resource_manager)
+        self.assertEqual(
+            calls.count("empty_cache"),
+            2,
+            f"Expected exactly 2 empty_cache calls; got order={calls}",
+        )
+
+    def test_step_b_cleanup_skipped_with_helix_cp(self):
+        """With Helix CP, can_run_general_warmup is False AND step (b) is
+        gated off -> no empty_cache calls inside warmup()."""
+        model_engine, resource_manager = _build_engine_and_resource_manager()
+        calls, _ = _run_warmup_tracked(model_engine, resource_manager, force_helix_cp=True)
+        self.assertNotIn("autotuner", calls, f"Helix CP should skip autotuner; got {calls}")
+        self.assertEqual(
+            calls.count("empty_cache"), 0, f"Helix CP should skip all warmup cleanup; got {calls}"
+        )
+
+    # ---- Change 3: step (d) env-var gate ----
+
+    def test_step_d_runs_when_env_var_unset(self):
+        """Default: env var unset -> step (d) runs (2 general_warmup calls)."""
+        model_engine, resource_manager = _build_engine_and_resource_manager()
+        calls, _ = _run_warmup_tracked(model_engine, resource_manager)
+        self.assertEqual(
+            calls.count("general_warmup"),
+            2,
+            f"Expected step (a) + step (d) general_warmup; got {calls}",
+        )
+
+    def test_step_d_skipped_when_env_var_is_one(self):
+        """Change 3: TRTLLM_SKIP_MAX_SHAPE_WARMUP=1 skips step (d) and logs."""
+        model_engine, resource_manager = _build_engine_and_resource_manager()
+        calls, logs = _run_warmup_tracked(
+            model_engine, resource_manager, env_var="1", capture_logs=True
+        )
+        self.assertEqual(
+            calls.count("general_warmup"), 1, f"Expected only step (a) general_warmup; got {calls}"
+        )
+        self.assertTrue(
+            any("Skipping max-shape warmup pre-population" in m for m in logs),
+            f"Expected skip log; got logs={logs}",
+        )
+
+    def test_step_d_runs_for_env_var_values_other_than_one(self):
+        """Gate semantics: only literal '1' disables step (d).
+        Any other value (including truthy strings like 'true') still runs it."""
+        for val in ["0", "", "true", "yes", "2", "on"]:
+            with self.subTest(env_value=val):
+                model_engine, resource_manager = _build_engine_and_resource_manager()
+                calls, _ = _run_warmup_tracked(model_engine, resource_manager, env_var=val)
+                self.assertEqual(
+                    calls.count("general_warmup"),
+                    2,
+                    f"env={val!r}: expected 2 general_warmup; got {calls}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittest/_torch/executor/test_pytorch_model_engine_warmup.py
+++ b/tests/unittest/_torch/executor/test_pytorch_model_engine_warmup.py
@@ -1,13 +1,12 @@
 """Unit tests for warmup-cleanup behavior in PyTorchModelEngine.warmup().
 
-Locks in two of the three warmup-cleanup changes:
-  - Change 1: gc.collect() + torch.cuda.empty_cache() fire immediately after
+Locks in:
+  - gc.collect() + torch.cuda.empty_cache() fire immediately after
     _run_autotuner_warmup (step b) - releases autotuner exploration leftovers.
-  - Change 3: step (d) max-shape pre-population is automatically skipped when
-    PyTorchModelEngine.is_estimation_pass is True, and runs unconditionally
-    in the production pass.
+  - Step (d) max-shape pre-population runs unconditionally so the first real
+    iteration reuses the cached blocks instead of paying a cudaMalloc cost.
 
-The third change (torch.cuda.empty_cache() after teardown_managers()
+The torch.cuda.empty_cache() after teardown_managers() in py_executor_creator
 is covered end-to-end by integration tests rather than unit-tested here.
 """
 
@@ -219,34 +218,18 @@ class TestWarmupCleanup(unittest.TestCase):
             calls.count("empty_cache"), 0, f"Helix CP should skip all warmup cleanup; got {calls}"
         )
 
-    # ---- Estimation-pass step (d) skip ----
+    # ---- Step (d) runs unconditionally ----
 
-    def test_step_d_skipped_in_estimation_pass(self):
-        """Estimation-pass optimization: when is_estimation_pass=True,
-        step (d) is skipped and a skip log is emitted."""
+    def test_step_d_runs_unconditionally(self):
+        """Step (d) max-shape pre-population must run on every warmup so the
+        first real serving iteration reuses the cached blocks instead of
+        paying a cudaMalloc cost."""
         model_engine, resource_manager = _build_engine_and_resource_manager()
-        model_engine.is_estimation_pass = True
-        calls, logs = _run_warmup_tracked(model_engine, resource_manager, capture_logs=True)
-        self.assertEqual(
-            calls.count("general_warmup"),
-            1,
-            f"Expected only step (a) general_warmup during estimation; got {calls}",
-        )
-        self.assertTrue(
-            any("estimation pass" in m for m in logs),
-            f"Expected estimation-pass skip log; got logs={logs}",
-        )
-
-    def test_step_d_runs_when_is_estimation_pass_false(self):
-        """Production pass (is_estimation_pass=False, the default): both
-        step (a) and step (d) run for max-shape memory-pool pre-population."""
-        model_engine, resource_manager = _build_engine_and_resource_manager()
-        self.assertFalse(model_engine.is_estimation_pass)
         calls, _ = _run_warmup_tracked(model_engine, resource_manager)
         self.assertEqual(
             calls.count("general_warmup"),
             2,
-            f"Expected step (a) + step (d) when is_estimation_pass=False; got {calls}",
+            f"Expected step (a) + step (d) general_warmup calls; got {calls}",
         )
 
 

--- a/tests/unittest/_torch/executor/test_pytorch_model_engine_warmup.py
+++ b/tests/unittest/_torch/executor/test_pytorch_model_engine_warmup.py
@@ -278,6 +278,37 @@ class TestWarmupCleanup(unittest.TestCase):
                     f"env={val!r}: expected 2 general_warmup; got {calls}",
                 )
 
+    # ---- Estimation-pass step (d) skip ----
+
+    def test_step_d_skipped_in_estimation_pass(self):
+        """Estimation-pass optimization: when is_estimation_pass=True,
+        step (d) is skipped even if the env var is unset, and the skip log
+        reports the estimation reason."""
+        model_engine, resource_manager = _build_engine_and_resource_manager()
+        model_engine.is_estimation_pass = True
+        calls, logs = _run_warmup_tracked(model_engine, resource_manager, capture_logs=True)
+        self.assertEqual(
+            calls.count("general_warmup"),
+            1,
+            f"Expected only step (a) general_warmup during estimation; got {calls}",
+        )
+        self.assertTrue(
+            any("estimation pass" in m for m in logs),
+            f"Expected estimation-pass skip log; got logs={logs}",
+        )
+
+    def test_step_d_runs_when_is_estimation_pass_false(self):
+        """Default attribute value is False, so step (d) runs normally."""
+        model_engine, resource_manager = _build_engine_and_resource_manager()
+        # Explicit assertion: the attribute exists and defaults to False.
+        self.assertFalse(model_engine.is_estimation_pass)
+        calls, _ = _run_warmup_tracked(model_engine, resource_manager)
+        self.assertEqual(
+            calls.count("general_warmup"),
+            2,
+            f"Expected step (a) + step (d) when is_estimation_pass=False; got {calls}",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
_Background:_

In current [PyTorchModelEngine.warmup()](https://github.com/NVIDIA/TensorRT-LLM/blame/main/tensorrt_llm/_torch/pyexecutor/model_engine.py#L832-L858) runs four phases sequentially:

| Step | Function | Purpose | Cleanup after? |
|---|---|---|---|
| **(a)** | `_general_warmup(full_general_warmup_requests)` | torch.compile graph specialization across key shapes: `(1,0)`, `(1,1)`, `(max_ctx,0)`, `(max_bs,max_bs)`, `(2,0)` | **Yes**  - `MoERunner.clear_all_workspaces()` + `gc.collect()` + `torch.cuda.empty_cache()` |
| **(b)** | `_run_autotuner_warmup` | Runs one max-ctx forward under `autotune()` context to explore tactics and cache best per op | No |
| **(c)** | `_run_cuda_graph_warmup` | Captures CUDA graphs for batch sizes listed in `cuda_graph_config.batch_sizes`; no-op when `cuda_graph_config: null` | No (graph mempool is isolated anyway) |
| **(d)** | `_general_warmup(max_shape_warmup_requests)` | Pre-populates default mempool with worst-case activation blocks: `(max_ctx,0)` and `(max_bs,max_bs)` - aims to avoid first-iter `cudaMalloc` | No |

_Issue:_
* Step (b) - autotuner mode
In autotune mode allocates the activation tensors N times over at every tunable site (with possibly different shapes per tactic). After the forward returns, all those buffers go back to the caching allocator's free pool  - that's ~25 GiB of "fragmented exploration leftovers" specially for a long-context (~131k) workload.
* Step (d) - production mode
When step (d) allocates, the caching allocator looks in the pool. Some of step (b)'s leftover blocks happen to match -> reused. Many don't -> cudaMalloc request for fresh blocks. Step (b)'s mismatched leftovers stay parked in the pool. Which left another ~24 GiB memory.
* First PyExecutor teardown - between estimation and production passes
After the first PyExecutor's warmup completes and configure_kv_cache_capacity drops slack memory via empty_cache, teardown_managers() frees the live torch tensors (KV manager, sampler, scheduler state) - Python references drop but PyTorch's caching allocator keeps the underlying cudaMalloc'd blocks in its free pool. No empty_cache follows the teardown, so the second PyExecutor's step (a) empty_cache only reclaims blocks matching its own allocations -> the rest stay parked across the entire second warmup. Which left another ~26 GiB memory.

_In short found on the memory waste for 131k context length in deepseek r1 model:_
*  ~25 GiB  step (b) autotuner exploration leftovers  <- genuine waste, no reuse value
\+ ~24 GiB  step (d) max-shape pre-pop                   <- matches real serving, would be reused
\+ ~26 GiB  first-PyExecutor teardown carryover      <- live tensors freed but blocks still cached
= ~75 GiB  total invisible-to-non-torch

_Fix:_

* Add clean up for Step (b)
* Add clean up for PyExecutor teardown 
* Skip Step (d) in first kv cache estimation phase
* Add env-var to skip Step (d) which leaves large headroom for kv cache, the tread-off is extra latency for TTFT

_On workloads of disaggregated context workers with long fixed-length prefills, no CUDA graphs, PyExecutor warmup leaves tens of GiB of caching-allocator slack that non-torch allocators (cuBLAS handle workspace, UCX/NIXL transfer buffers, NVSHMEM) cannot see.  WHICH IS WASTE OF MEMORY RESOURCE!_

_Minor_

There is a debate of whether we should keep step (d) in KV cache estimation warmup phase since its cache will be destroyed in [here](https://github.com/NVIDIA/TensorRT-LLM/blob/main/tensorrt_llm/_torch/pyexecutor/_util.py#L615C1-L616C45), but there is a concern it will impact the KV cache estimation accurately. So I will not remove step (d) in this estimation phase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment variable `TRTLLM_SKIP_MAX_SHAPE_WARMUP` to control the warmup behavior during model initialization, allowing users to skip max-shape memory pre-population when set to `"1"`. When enabled, CUDA cache is cleared after warmup to optimize memory allocation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14609?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
