### PR TITLE
[None][doc] Add CUTLASS DSL uninstall step to installation guide

### DIFF
--- a/docs/source/installation/installation-guide.md
+++ b/docs/source/installation/installation-guide.md
@@ -64,6 +64,13 @@ image hosted on NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/tensorrt-l
 
 Once all prerequisites are in place, TensorRT LLM can be installed as follows:
 
+Before installing the latest version, uninstall any previous CUTLASS DSL installation as described in the
+[CUTLASS DSL installation guide](https://docs.nvidia.com/cutlass/latest/media/docs/pythonDSL/quick_start.html#installation):
+
+```bash
+pip3 uninstall nvidia-cutlass-dsl nvidia-cutlass-dsl-libs-base nvidia-cutlass-dsl-libs-cu13
+```
+
 ```bash
 pip3 install --ignore-installed pip setuptools wheel && pip3 install tensorrt_llm
 ```


### PR DESCRIPTION
## Summary

- Adds a note to the installation guide instructing users to uninstall any previous CUTLASS DSL packages (`nvidia-cutlass-dsl`, `nvidia-cutlass-dsl-libs-base`, `nvidia-cutlass-dsl-libs-cu13`) before installing the latest TensorRT-LLM, linking to the upstream CUTLASS DSL quick-start instructions.
- Avoids version conflicts during `pip3 install tensorrt_llm` when an older CUTLASS DSL release is already present in the environment.

## Test plan

- [x] Render `docs/source/installation/installation-guide.md` and visually verify the new section appears before the `pip3 install tensorrt_llm` block.
- [x] Click through to the linked CUTLASS DSL quick-start page and confirm it resolves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linux `pip` installation instructions to explicitly require uninstalling any previously installed CUTLASS DSL components before installing the latest TensorRT LLM wheel, ensuring a clean installation process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->