### PR TITLE
[None][feat] add DSV4 KV cache pool ratio config

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
@@ -769,35 +769,55 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
         max_seq_len = self.max_seq_len
         max_num_tokens = self._max_num_tokens
         max_draft_len = self._max_draft_len
-
-        # For aggregated serving in large batch size:
-        # Use 1 context request + (max_batch_size - 1) generation requests as
-        # the typical step. An all-generation typical_step over-provisions the
-        # compressed-cache pool at the expense of the SWA pool, starving the
-        # SWA pool and artificially capping the achievable batch size.
-        ctx_capacity = max_num_tokens if max_num_tokens is not None else max_seq_len
-        typical_step = BatchDesc(
-            kv_caches=[
-                KVCacheDesc(capacity=ctx_capacity, history_length=0),
-            ]
-            + [KVCacheDesc(capacity=max_seq_len, history_length=max_seq_len - max_draft_len - 1)]
-            * (max_batch_size - 1),
-        )
-
+        typical_step = None
         constraints = []
-        # Constraint 1: cuda graph generation warmup — one decode request that has
-        # accumulated to the tail of max_seq_len. Using history_length=max_seq_len-1
-        # (instead of 0) lets SWA / SSM pools collapse to their windowed working set,
-        # while full-cache pools still need max_seq_len/tokens_per_block blocks
-        # because they don't age.
-        constraints.append(
-            BatchDesc([KVCacheDesc(capacity=max_seq_len, history_length=max_seq_len - 1)])
-        )
+        if kv_cache_config.pool_ratio is None:
+            typical_seq_len = (
+                kv_cache_config.avg_seq_len
+                if kv_cache_config.avg_seq_len is not None
+                else max_seq_len
+            )
+            if typical_seq_len > max_seq_len:
+                raise ValueError(
+                    f"kv_cache_config.avg_seq_len ({typical_seq_len}) must be less than or "
+                    f"equal to max_seq_len ({max_seq_len})"
+                )
 
-        # Constraint 2: general / chunked-prefill warmup — one fresh context request
-        # at max_num_tokens (the per-iteration token budget).
-        if max_num_tokens is not None:
-            constraints.append(BatchDesc([KVCacheDesc(capacity=max_num_tokens, history_length=0)]))
+            # For aggregated serving in large batch size:
+            # Use 1 context request + (max_batch_size - 1) generation requests as
+            # the typical step. An all-generation typical_step over-provisions the
+            # compressed-cache pool at the expense of the SWA pool, starving the
+            # SWA pool and artificially capping the achievable batch size.
+            ctx_capacity = max_num_tokens if max_num_tokens is not None else typical_seq_len
+            generation_history_length = max(0, typical_seq_len - max_draft_len - 1)
+            typical_step = BatchDesc(
+                kv_caches=[
+                    KVCacheDesc(capacity=ctx_capacity, history_length=0),
+                ]
+                + [
+                    KVCacheDesc(
+                        capacity=typical_seq_len,
+                        history_length=generation_history_length,
+                    )
+                ]
+                * (max_batch_size - 1),
+            )
+
+            # Constraint 1: cuda graph generation warmup — one decode request that has
+            # accumulated to the tail of max_seq_len. Using history_length=max_seq_len-1
+            # (instead of 0) lets SWA / SSM pools collapse to their windowed working set,
+            # while full-cache pools still need max_seq_len/tokens_per_block blocks
+            # because they don't age.
+            constraints.append(
+                BatchDesc([KVCacheDesc(capacity=max_seq_len, history_length=max_seq_len - 1)])
+            )
+
+            # Constraint 2: general / chunked-prefill warmup — one fresh context request
+            # at max_num_tokens (the per-iteration token budget).
+            if max_num_tokens is not None:
+                constraints.append(
+                    BatchDesc([KVCacheDesc(capacity=max_num_tokens, history_length=0)])
+                )
 
         scratch_reuse_config = None
         if self.enable_swa_scratch_reuse:
@@ -816,6 +836,7 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             layers=layers,
             typical_step=typical_step,
             constraints=constraints,
+            initial_pool_ratio=kv_cache_config.pool_ratio,
         )
 
     def _init_indexer_dtype(self, sparse_attn_config: DeepSeekV4SparseAttentionConfig) -> None:

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -2476,6 +2476,7 @@ class KVCacheManagerV2(BaseResourceManager):
             max_util_for_resume=kv_cache_config.max_util_for_resume,
             enable_stats=self.enable_stats,
             swa_scratch_reuse=scratch_reuse_config,
+            initial_pool_ratio=kv_cache_config.pool_ratio,
             layers=[
                 AttentionLayerConfig(
                     layer_id=layer_id,

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2700,6 +2700,26 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
         "The maximum utilization of the KV cache for resume. Default is 95%. Only used when using KV cache manager v2 (experimental)."
     )
 
+    # This is a pure python field, not a pybind field. It is only for the Pytorch backend.
+    pool_ratio: Optional[List[float]] = Field(
+        default=None,
+        min_length=1,
+        status="prototype",
+        description=
+        "Initial pool ratios for KV cache manager v2. When used by DeepSeek-V4, "
+        "values map to KVCacheManagerV2 pool_group_id order and must sum to 1.0. "
+        "When set, DeepSeek-V4 uses this directly and avg_seq_len does not take effect."
+    )
+
+    # This is a pure python field, not a pybind field. It is only for the Pytorch backend.
+    avg_seq_len: Optional[PositiveInt] = Field(
+        default=None,
+        status="prototype",
+        description=
+        "Average sequence length used by DeepSeek-V4 to build the KV cache manager v2 "
+        "typical step. If unset, max_seq_len is used. This does not take effect when "
+        "pool_ratio is set.")
+
     def _to_pybind(self):
         config = _KvCacheConfig(
             enable_block_reuse=self.enable_block_reuse,
@@ -2776,6 +2796,19 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
         if not 0 <= v <= 1:
             raise ValueError(
                 "kv_cache_config.max_util_for_resume must be between 0 and 1")
+        return v
+
+    @field_validator('pool_ratio')
+    @classmethod
+    def validate_pool_ratio(cls, v: Optional[List[float]]):
+        if v is None:
+            return v
+        if any(r <= 0 for r in v):
+            raise ValueError(
+                "kv_cache_config.pool_ratio values must be positive")
+        if not math.isclose(sum(v), 1.0, rel_tol=0.0, abs_tol=1e-6):
+            raise ValueError(
+                "kv_cache_config.pool_ratio values must sum to 1.0")
         return v
 
 

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.pyi
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/__init__.pyi
@@ -171,6 +171,7 @@ class KVCacheManagerConfig:
     enable_partial_reuse: bool = True
     constraints: list[BatchDesc] = ...
     typical_step: BatchDesc | None = None
+    initial_pool_ratio: list[float] | None = None
     ssm_reuse_interval: int = 512
     swa_scratch_reuse: SwaScratchReuseConfig | None = None
     enable_stats: bool = True

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_config.py
@@ -223,6 +223,12 @@ class KVCacheManagerConfig:
     layer groups.
     """
 
+    initial_pool_ratio: list[float] | None = None
+    """
+    User-provided initial memory partitioning between pool groups. When set, this
+    takes precedence over typical_step and constraints for initial sizing.
+    """
+
     ssm_reuse_interval: int = 512
     """
     Interval (in tokens) at which SSM state is snapshotted for prefix reuse.

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache_manager.py
@@ -260,6 +260,7 @@ class KVCacheManager:
             config.swa_scratch_reuse,
             typical_batch=config.typical_step,
             constraints=config.constraints,
+            initial_pool_ratio=config.initial_pool_ratio,
             event_manager=event_manager,
         )
         self._living_kv_caches = set[rawref.ref[_KVCache]]()

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_storage_manager.py
@@ -211,6 +211,7 @@ class StorageManager:
         swa_scratch_reuse: SwaScratchReuseConfig | None,
         typical_batch: BatchDesc | None = None,
         constraints: list[BatchDesc] | None = None,
+        initial_pool_ratio: list[float] | None = None,
         event_manager: "KVCacheEventManager | None" = None,
     ) -> None:
         self.__rawref__ = rawref.NULL
@@ -237,12 +238,24 @@ class StorageManager:
         gpu_quota = config.cache_tiers[GPU_LEVEL].quota
         gpu_granularity = CacheLevelManager.cache_tier_granularity(CacheTier.GPU_MEM, gpu_quota)
 
+        constraints_for_min_slots = [] if initial_pool_ratio is not None else constraints or []
         self._min_slots = self._compute_min_slots_from_constraints(
-            constraints or [], tokens_per_block, swa_scratch_reuse
+            constraints_for_min_slots, tokens_per_block, swa_scratch_reuse
         )
 
-        # Compute init_ratio from typical_batch, constraints, or fallback.
-        if typical_batch is not None:
+        # Compute init_ratio from explicit config, typical_batch, constraints, or fallback.
+        if initial_pool_ratio is not None:
+            if len(initial_pool_ratio) != self.num_pool_groups:
+                raise ValueError(
+                    f"initial_pool_ratio length must match number of pool groups "
+                    f"({self.num_pool_groups}), got {len(initial_pool_ratio)}"
+                )
+            if any(r <= 0 for r in initial_pool_ratio):
+                raise ValueError("initial_pool_ratio values must be positive")
+            if not math.isclose(sum(initial_pool_ratio), 1.0, rel_tol=0.0, abs_tol=1e-6):
+                raise ValueError("initial_pool_ratio values must sum to 1.0")
+            init_ratio = cast(TypedIndexList[PoolGroupIndex, float], list(initial_pool_ratio))
+        elif typical_batch is not None:
             init_ratio = self.ratio_from_batch(
                 typical_batch, tokens_per_block, swa_scratch_reuse, gpu_granularity
             )

--- a/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
+++ b/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
@@ -31,7 +31,7 @@ from tensorrt_llm.bindings import DataType, SamplingConfig
 from tensorrt_llm.bindings.internal.batch_manager import CacheType as CacheTypeCpp
 from tensorrt_llm.llmapi.llm_args import DeepSeekV4SparseAttentionConfig, KvCacheConfig
 from tensorrt_llm.mapping import Mapping
-from tensorrt_llm.runtime.kv_cache_manager_v2 import PageIndexMode
+from tensorrt_llm.runtime.kv_cache_manager_v2 import GpuCacheTierConfig, PageIndexMode
 from tensorrt_llm.runtime.kv_cache_manager_v2._common import BAD_PAGE_INDEX
 
 _RequestCache = Dict[
@@ -70,6 +70,77 @@ def _view_fp8_as_uint8(buffer: torch.Tensor) -> torch.Tensor:
     if buffer.dtype == torch.float8_e4m3fn:
         return buffer.view(torch.uint8)
     return buffer
+
+
+def _build_deepseek_v4_cache_config_for_test(
+    kv_cache_config: KvCacheConfig,
+    *,
+    max_batch_size: int = 4,
+    max_seq_len: int = 1024,
+    max_num_tokens: int | None = 2048,
+    max_draft_len: int = 0,
+):
+    cache_manager = object.__new__(DeepseekV4CacheManager)
+    cache_manager.pp_layers = [0, 1, 2]
+    cache_manager._compress_ratios = [1, 4, 128]
+    cache_manager._swa_window_size = 128
+    cache_manager._max_draft_len = max_draft_len
+    cache_manager._max_num_tokens = max_num_tokens
+    cache_manager.compressed_block_sizes = [128, 32, 1]
+    cache_manager.index_head_dim = 128
+    cache_manager.head_dim = 512
+    cache_manager.tokens_per_block = 128
+    cache_manager.dtype = DataType.BF16
+    cache_manager._indexer_k_dtype = "fp8"
+    cache_manager.max_batch_size = max_batch_size
+    cache_manager.max_seq_len = max_seq_len
+    cache_manager.enable_stats = False
+    cache_manager.enable_swa_scratch_reuse = False
+    cache_manager.num_extra_kv_tokens = 0
+
+    return cache_manager._build_cache_config(
+        kv_cache_config,
+        tokens_per_block=128,
+        vocab_size=129280,
+        cache_tiers=[GpuCacheTierConfig(quota=1 << 30)],
+    )
+
+
+def test_deepseek_v4_pool_ratio_overrides_typical_step_and_constraints():
+    config = _build_deepseek_v4_cache_config_for_test(
+        KvCacheConfig(pool_ratio=[0.2, 0.3, 0.5], avg_seq_len=256)
+    )
+
+    assert config.initial_pool_ratio == [0.2, 0.3, 0.5]
+    assert config.typical_step is None
+    assert config.constraints == []
+
+
+def test_deepseek_v4_avg_seq_len_updates_typical_step():
+    config = _build_deepseek_v4_cache_config_for_test(
+        KvCacheConfig(avg_seq_len=256),
+        max_batch_size=3,
+        max_seq_len=1024,
+        max_num_tokens=2048,
+        max_draft_len=2,
+    )
+
+    assert config.initial_pool_ratio is None
+    assert config.typical_step is not None
+    assert config.typical_step.kv_caches[0].capacity == 2048
+    assert config.typical_step.kv_caches[0].history_length == 0
+    assert [kv.capacity for kv in config.typical_step.kv_caches[1:]] == [256, 256]
+    assert [kv.history_length for kv in config.typical_step.kv_caches[1:]] == [253, 253]
+    assert config.constraints[0].kv_caches[0].capacity == 1024
+    assert config.constraints[0].kv_caches[0].history_length == 1023
+
+
+def test_deepseek_v4_avg_seq_len_must_not_exceed_max_seq_len():
+    with pytest.raises(ValueError, match="avg_seq_len"):
+        _build_deepseek_v4_cache_config_for_test(
+            KvCacheConfig(avg_seq_len=2048),
+            max_seq_len=1024,
+        )
 
 
 @pytest.fixture(params=[False, True], ids=["scratch_reuse_disabled", "scratch_reuse_enabled"])

--- a/tests/unittest/disaggregated/test_cache_transceiver_single_process.py
+++ b/tests/unittest/disaggregated/test_cache_transceiver_single_process.py
@@ -125,6 +125,8 @@ class KvCacheConfigV2:
     enable_partial_reuse: bool = False
     copy_on_partial_reuse: bool = False
     dtype: str = "auto"
+    pool_ratio: Optional[List[float]] = None
+    avg_seq_len: Optional[int] = None
     max_util_for_resume: float = 0.95
 
 

--- a/tests/unittest/disaggregated/test_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_kv_transfer.py
@@ -60,6 +60,8 @@ class KvCacheConfigV2:
     enable_partial_reuse: bool = False
     copy_on_partial_reuse: bool = False
     dtype: str = "auto"
+    pool_ratio: Optional[List[float]] = None
+    avg_seq_len: Optional[int] = None
     # V2 specific field
     max_util_for_resume: float = 0.95
 

--- a/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
@@ -64,7 +64,9 @@ if not TYPE_CHECKING and find_spec("kv_cache_manager_v2") is not None:
     )
     from kv_cache_manager_v2._copy_engine import CopyTask, batched_copy
     from kv_cache_manager_v2._exceptions import OutOfPagesError
-    from kv_cache_manager_v2._life_cycle_registry import SsmLifeCycle
+    from kv_cache_manager_v2._life_cycle_registry import LifeCycleRegistry, SsmLifeCycle
+    from kv_cache_manager_v2._storage._config import create_storage_config
+    from kv_cache_manager_v2._storage_manager import StorageManager
     from kv_cache_manager_v2._utils import (
         CachedCudaStream,
         HalfOpenRange,
@@ -116,7 +118,12 @@ else:
     )
     from tensorrt_llm.runtime.kv_cache_manager_v2._copy_engine import CopyTask, batched_copy
     from tensorrt_llm.runtime.kv_cache_manager_v2._exceptions import OutOfPagesError
-    from tensorrt_llm.runtime.kv_cache_manager_v2._life_cycle_registry import SsmLifeCycle
+    from tensorrt_llm.runtime.kv_cache_manager_v2._life_cycle_registry import (
+        LifeCycleRegistry,
+        SsmLifeCycle,
+    )
+    from tensorrt_llm.runtime.kv_cache_manager_v2._storage._config import create_storage_config
+    from tensorrt_llm.runtime.kv_cache_manager_v2._storage_manager import StorageManager
     from tensorrt_llm.runtime.kv_cache_manager_v2._utils import (
         CachedCudaStream,
         HalfOpenRange,
@@ -1624,6 +1631,7 @@ class TestInitRatioConfig(unittest.TestCase):
         num_windowed_layers: int = 1,
         num_full_layers: int = 1,
         enable_swa_scratch_reuse: bool = False,
+        initial_pool_ratio: list[float] | None = None,
     ) -> KVCacheManagerConfig:
         """Create a config with two pool groups (windowed vs non-windowed).
 
@@ -1664,6 +1672,7 @@ class TestInitRatioConfig(unittest.TestCase):
             layers=layers,
             typical_step=typical_step,
             constraints=constraints or [],
+            initial_pool_ratio=initial_pool_ratio,
             swa_scratch_reuse=(SwaScratchReuseConfig() if enable_swa_scratch_reuse else None),
         )
 
@@ -1720,6 +1729,38 @@ class TestInitRatioConfig(unittest.TestCase):
         self.assertAlmostEqual(sum(ratio_constrained), 1.0, places=6)
         mgr_unconstrained.shutdown()
         mgr_constrained.shutdown()
+
+    def test_initial_pool_ratio_overrides_typical_step_and_constraints(self):
+        """Explicit initial_pool_ratio takes precedence over inferred sizing inputs."""
+        typical = BatchDesc(kv_caches=[KVCacheDesc(capacity=4096, history_length=4000)] * 32)
+        constraint = BatchDesc(kv_caches=[KVCacheDesc(capacity=256, history_length=128)] * 256)
+        cfg = self._make_config(
+            typical_step=typical,
+            constraints=[constraint],
+            initial_pool_ratio=[0.8, 0.2],
+        )
+        manager = KVCacheManager(cfg)
+        ratio = manager._current_gpu_ratio
+
+        self.assertGreater(ratio[0], ratio[1])
+        self.assertAlmostEqual(sum(ratio), 1.0, places=6)
+        manager.shutdown()
+
+    def test_initial_pool_ratio_length_must_match_pool_groups(self):
+        cfg = self._make_config(initial_pool_ratio=[1.0])
+        life_cycles = LifeCycleRegistry(cfg)
+        storage_config = create_storage_config(cfg)
+
+        with self.assertRaisesRegex(ValueError, "initial_pool_ratio length"):
+            StorageManager(
+                life_cycles,
+                storage_config,
+                cfg.tokens_per_block,
+                cfg.swa_scratch_reuse,
+                typical_batch=cfg.typical_step,
+                constraints=cfg.constraints,
+                initial_pool_ratio=cfg.initial_pool_ratio,
+            )
 
     @parameterized.expand([(0,), (64,), (50,), (256,)])
     def test_constraint_guarantees_batch_can_run(self, system_prompt_length: int):

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -325,6 +325,8 @@ def test_KvCacheConfig_declaration():
                            kv_cache_event_hash_algo="v2_sha256_64",
                            enable_partial_reuse=True,
                            copy_on_partial_reuse=True,
+                           pool_ratio=[0.25, 0.75],
+                           avg_seq_len=2048,
                            attention_dp_events_gather_period_ms=10)
 
     pybind_config = config._to_pybind()
@@ -338,6 +340,10 @@ def test_KvCacheConfig_declaration():
     assert pybind_config.secondary_offload_min_priority == 1
     assert pybind_config.event_buffer_max_size == 0
     assert config.kv_cache_event_hash_algo == "v2_sha256_64"
+    assert config.pool_ratio == [0.25, 0.75]
+    assert config.avg_seq_len == 2048
+    assert not hasattr(pybind_config, "pool_ratio")
+    assert not hasattr(pybind_config, "avg_seq_len")
     assert KvCacheConfig(
         kv_cache_event_hash_algo="auto").kv_cache_event_hash_algo == "auto"
     assert KvCacheConfig(kv_cache_event_hash_algo="v1_block_key"
@@ -345,6 +351,25 @@ def test_KvCacheConfig_declaration():
     assert pybind_config.enable_partial_reuse == True
     assert pybind_config.copy_on_partial_reuse == True
     assert pybind_config.attention_dp_events_gather_period_ms == 10
+
+
+@pytest.mark.parametrize("kwargs", [
+    {
+        "pool_ratio": []
+    },
+    {
+        "pool_ratio": [0.0, 1.0]
+    },
+    {
+        "pool_ratio": [0.25, 0.25]
+    },
+    {
+        "avg_seq_len": 0
+    },
+])
+def test_KvCacheConfig_pool_ratio_avg_seq_len_validation(kwargs):
+    with pytest.raises(ValidationError):
+        KvCacheConfig(**kwargs)
 
 
 def test_CapacitySchedulerPolicy():


### PR DESCRIPTION
@coderabbitai summary

## Description

Add DeepSeek-V4 KV cache configuration knobs for KV cache manager v2:

- `kv_cache_config.pool_ratio`: user-provided initial pool ratios. When set for DSV4, this is passed to KV cache manager v2 as `initial_pool_ratio` and bypasses typical-step and constraint-based initial sizing.
- `kv_cache_config.avg_seq_len`: average sequence length used by DSV4 typical-step construction. When unset, DSV4 continues to use `max_seq_len`.

The change also validates pool ratios, keeps the new LLM API fields out of the legacy pybind KV cache config, and adds a guard for partially constructed KV cache managers when constructor validation fails.

## Test Coverage

- Added LLM API validation coverage for `KvCacheConfig.pool_ratio` and `KvCacheConfig.avg_seq_len`.
- Added KV cache manager v2 coverage for explicit `initial_pool_ratio` overriding typical-step and constraints.
- Added DSV4 cache manager coverage for `pool_ratio`, `avg_seq_len`, and `avg_seq_len > max_seq_len` validation.
- Clean GB200 build on `gb-nvl-081-compute02` with `CUDA_ARCHITECTURES=100-real`.
- Editable install in `dsv4-pool-ratio-knob-jenkins-aarch64-jiaganc`; TensorRT-LLM import reports `1.3.0rc15`.
- Focused pytest run: `10 passed`.
- `git diff --check HEAD` passed.
- `python3 -m py_compile` passed for changed Python files and tests.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
