### PR TITLE
[TRTLLM-13017][fix] disagg gen init: use prompt_len for SWA history_length

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
@@ -440,12 +440,14 @@ class KVCacheV2Scheduler(RequestScheduler):
             logger.debug("prepare_context failed for disagg gen init request %s", req.py_request_id)
             return ScheduleAction.SKIP, 0
 
-        # Prompt is already historic (processed by context server) — pass
-        # history_length so SWA layers skip pre-window block allocation.
+        # Whole prompt is already history on the ctx server; pass prompt_len
+        # so SWA stale range is non-empty at allocation time. context_current_position
+        # is still 0 here (only advanced in _prepare_disagg_gen_transmission_complete),
+        # so reading from it would degenerate history_length to 0 and defeat the fix.
         if not self.kv_cache_manager.resize_context(
             req,
             req.context_remaining_length + get_draft_token_length(req),
-            history_length=req.context_current_position,
+            history_length=req.prompt_len,
         ):
             return ScheduleAction.SKIP, 0
 

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_scheduler.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_scheduler.py
@@ -101,13 +101,18 @@ def make_encoder_request(request_id, encoder_output_len, lora_task_id=None):
 
 
 def make_disagg_request(
-    request_id, context_remaining_length=100, lora_task_id=None, num_draft_tokens=0
+    request_id,
+    context_remaining_length=100,
+    lora_task_id=None,
+    num_draft_tokens=0,
+    prompt_len=None,
 ):
     req = Mock()
     req.request_id = request_id
     req.py_request_id = request_id
     req.state_value = DISAGG_GEN_INIT
     req.context_remaining_length = context_remaining_length
+    req.prompt_len = prompt_len if prompt_len is not None else context_remaining_length
     req.is_context_init_state = False
     req.is_generation_in_progress_state = False
     req.is_first_context_chunk = True
@@ -1181,8 +1186,8 @@ class TestDisagg:
         mgr = make_kv_cache_manager(resize_context_fn=resize_fn)
         sched = make_scheduler(mgr, max_num_tokens=100)
         reqs = [
-            make_disagg_request(0, context_remaining_length=200),
-            make_disagg_request(1, context_remaining_length=512),
+            make_disagg_request(0, context_remaining_length=200, prompt_len=200),
+            make_disagg_request(1, context_remaining_length=512, prompt_len=512),
         ]
         sched.schedule_request(reqs, set())
         assert captured[0] == 200


### PR DESCRIPTION
For a disagg gen init request entering the V2 scheduler, context_current_position is still 0 — it is only advanced to prompt_len in _prepare_disagg_gen_transmission_complete after KV transfer completes. Passing history_length=context_current_position degenerates to history_length=0, the SWA stale range collapses to an empty interval, and pre-window blocks are still allocated before KV transfer — defeating the over-allocation fix from #13845/#14377.

Use req.prompt_len, which is known statically at scheduler time and correctly conveys that the entire prompt is history.

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
