### PR TITLE
[None][perf] AutoDeploy: fuse FP8 quant into allreduce+residual+RMSNorm

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/config/default.yaml
+++ b/tensorrt_llm/_torch/auto_deploy/config/default.yaml
@@ -212,6 +212,9 @@ transforms:
   fuse_allreduce_residual_rmsnorm:
     stage: post_load_fusion
     requires_shape_prop: true
+  fuse_allreduce_residual_rmsnorm_quant_fp8:
+    stage: post_load_fusion
+    enabled: false
   fuse_rmsnorm:
     stage: post_load_fusion
     rmsnorm_backend: flashinfer

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/distributed/trtllm_dist.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/distributed/trtllm_dist.py
@@ -200,6 +200,52 @@ def trtllm_fused_allreduce_residual_rmsnorm_fake(
     return torch.empty_like(tensor), torch.empty_like(tensor)
 
 
+# TRT-LLM fused allreduce + residual + RMSNorm + FP8 quant
+@torch.library.custom_op(
+    "dist::trtllm_fused_allreduce_residual_rmsnorm_quant_fp8",
+    mutates_args=(),
+    device_types="cuda",
+)
+def trtllm_fused_allreduce_residual_rmsnorm_quant_fp8(
+    tensor: torch.Tensor,
+    residual: torch.Tensor,
+    norm_weight: torch.Tensor,
+    scale: torch.Tensor,
+    eps: float,
+    strategy: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fused allreduce + residual + RMSNorm + FP8 quant using TRT-LLM kernel.
+
+    Returns (norm_quant_fp8, residual_out). ``scale`` is the per-tensor FP8
+    quantization scale used by the downstream FP8 linear.
+    """
+    all_reduce_params = AllReduceParams(
+        fusion_op=AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_FP8,
+        bias=None,
+        residual=residual,
+        norm_weight=norm_weight,
+        scale=scale,
+        eps=eps,
+    )
+    norm_quant, residual_out = trtllm_allreduce(
+        tensor, ReduceOp.SUM, strategy=strategy, all_reduce_params=all_reduce_params
+    )
+    return norm_quant, residual_out
+
+
+@trtllm_fused_allreduce_residual_rmsnorm_quant_fp8.register_fake
+def trtllm_fused_allreduce_residual_rmsnorm_quant_fp8_fake(
+    tensor: torch.Tensor,
+    residual: torch.Tensor,
+    norm_weight: torch.Tensor,
+    scale: torch.Tensor,
+    eps: float,
+    strategy: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    norm_quant = torch.empty(tensor.shape, dtype=torch.float8_e4m3fn, device=tensor.device)
+    return norm_quant, torch.empty_like(tensor)
+
+
 def is_trtllm_op_available():
     """Check if TRT-LLM ops are available and running with MPI."""
     return is_ompi()

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/collectives.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/collectives.py
@@ -19,15 +19,17 @@ when TRT-LLM is available (MPI mode) since it provides optimized fused kernels.
 The torch backend (demollm mode) does not benefit from fusion.
 """
 
+import operator
 from functools import partial
-from typing import Tuple
+from typing import Optional, Tuple
 
 import torch
-from torch.fx import GraphModule
+from torch.fx import GraphModule, Node
 
 from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
 from ...utils.logger import ad_logger
+from ...utils.node_utils import is_op
 from ...utils.pattern_matcher import ADPatternMatcherPass, register_ad_pattern
 from ..interface import BaseTransform, SharedConfig, TransformInfo, TransformRegistry
 
@@ -184,6 +186,140 @@ class FuseAllreduceResidualRMSNorm(BaseTransform):
 
         info = TransformInfo(
             skipped=False,
+            num_matches=num_matches,
+            is_clean=num_matches == 0,
+            has_valid_shapes=num_matches == 0,
+        )
+        return gm, info
+
+
+# ============================================================================
+# fuse_allreduce_residual_rmsnorm + downstream FP8 quant
+# ============================================================================
+
+
+def _get_single_norm_consumer(fused_node: Node) -> Optional[Node]:
+    """Return the unique downstream consumer of fused_node[0] when it's a single
+    trtllm_quant_fp8_linear with matching scalar input_scale; else None.
+
+    fused_node has 2 outputs: (norm, residual). We need to confirm getitem(0) is
+    the only consumer of the norm output, and that consumer is a single FP8
+    linear node.
+    """
+    norm_getitem: Optional[Node] = None
+    for user in fused_node.users:
+        if user.op == "call_function" and user.target is operator.getitem and len(user.args) >= 2:
+            idx = user.args[1]
+            if idx == 0:
+                if norm_getitem is not None:
+                    return None
+                norm_getitem = user
+
+    if norm_getitem is None:
+        return None
+    if len(norm_getitem.users) != 1:
+        return None
+    consumer = next(iter(norm_getitem.users))
+    if not is_op(consumer, torch.ops.auto_deploy.trtllm_quant_fp8_linear):
+        return None
+    return consumer
+
+
+@TransformRegistry.register("fuse_allreduce_residual_rmsnorm_quant_fp8")
+class FuseAllreduceResidualRMSNormQuantFP8(BaseTransform):
+    """Fuse (allreduce + residual + RMSNorm + FP8 quant) into one fused op.
+
+    Pattern (post ``fuse_allreduce_residual_rmsnorm``)::
+
+        fused = trtllm_fused_allreduce_residual_rmsnorm(x, residual, w, eps, strategy)
+        norm = fused[0]  # bf16
+        residual_out = fused[1]  # bf16
+        linear_out = trtllm_quant_fp8_linear(norm, w_fp8, bias, input_scale, ...)
+
+    The downstream FP8 linear internally calls ``static_quantize_e4m3_per_tensor``
+    to quantize ``norm`` to FP8 before the matmul. By folding that quantize into
+    the allreduce kernel (``AllReduceFusionOp.RESIDUAL_RMS_NORM_QUANT_FP8``) we
+    save one kernel launch per allreduce site - meaningful at small-batch
+    decode where launch count dominates allreduce wall time.
+    """
+
+    def _apply(
+        self,
+        gm: GraphModule,
+        cm: CachedSequenceInterface,
+        factory: ModelFactory,
+        shared_config: SharedConfig,
+    ) -> Tuple[GraphModule, TransformInfo]:
+        graph = gm.graph
+        num_matches = 0
+
+        fused_op_target = torch.ops.dist.trtllm_fused_allreduce_residual_rmsnorm.default
+        fused_quant_op_target = (
+            torch.ops.dist.trtllm_fused_allreduce_residual_rmsnorm_quant_fp8.default
+        )
+
+        for node in list(graph.nodes):
+            if node.op != "call_function" or node.target is not fused_op_target:
+                continue
+
+            linear_consumer = _get_single_norm_consumer(node)
+            if linear_consumer is None:
+                continue
+
+            # Extract scale from linear; quant_fp8_linear args:
+            # (input, weight_fp8, bias, input_scale, weight_scale, ...)
+            if len(linear_consumer.args) < 4:
+                continue
+            input_scale = linear_consumer.args[3]
+            if not isinstance(input_scale, Node):
+                continue
+
+            x_arg, residual_arg, weight_arg, eps_arg, strategy_arg = node.args
+
+            # Insert before the FP8 linear consumer. ``input_scale`` is a
+            # ``get_attr`` node defined upstream of the linear (the linear is
+            # what consumes it), so this position is safe for all operands and
+            # downstream of the original fused node's residual-only users.
+            with graph.inserting_before(linear_consumer):
+                fused_quant = graph.call_function(
+                    fused_quant_op_target,
+                    args=(
+                        x_arg,
+                        residual_arg,
+                        weight_arg,
+                        input_scale,
+                        eps_arg,
+                        strategy_arg,
+                    ),
+                )
+                new_norm = graph.call_function(operator.getitem, args=(fused_quant, 0))
+                new_residual = graph.call_function(operator.getitem, args=(fused_quant, 1))
+
+            # Rewire all users of the original getitem(0)/(1) to the new
+            # equivalents. Users of getitem(0) must consume the now-FP8 norm.
+            for user in list(node.users):
+                if user.op != "call_function" or user.target is not operator.getitem:
+                    continue
+                idx = user.args[1]
+                replacement = new_norm if idx == 0 else new_residual
+                user.replace_all_uses_with(replacement)
+                graph.erase_node(user)
+
+            # The lone consumer of the (now-FP8) norm is the FP8 linear. Tell
+            # it the output dtype explicitly so the op resolves the bf16
+            # accumulator without a bias hint.
+            new_kwargs = dict(linear_consumer.kwargs)
+            new_kwargs.setdefault("out_dtype", "bfloat16")
+            linear_consumer.kwargs = new_kwargs
+
+            graph.erase_node(node)
+            num_matches += 1
+
+        if num_matches > 0:
+            gm.recompile()
+
+        info = TransformInfo(
+            skipped=num_matches == 0,
             num_matches=num_matches,
             is_clean=num_matches == 0,
             has_valid_shapes=num_matches == 0,


### PR DESCRIPTION
Adds a new transform ``fuse_allreduce_residual_rmsnorm_quant_fp8`` that runs after ``fuse_allreduce_residual_rmsnorm`` and folds the downstream per-tensor FP8 input quantize into the AllReduce kernel by switching from ``AllReduceFusionOp.RESIDUAL_RMS_NORM`` to
``RESIDUAL_RMS_NORM_QUANT_FP8``. This matches what the PyTorch backend does for FP8 dense models (see ``modeling_llama.py``).

For each layer with TP > 1 we previously executed:
    allreduce + residual + rmsnorm  -> 1 fused kernel (bf16 out)
    static_quantize_e4m3_per_tensor -> 1 extra kernel (fp8 out)
    trtllm_fp8_prequant_linear      -> matmul
With the transform the first two become a single AllReduce-fused
kernel emitting FP8 directly into the next linear's input.

Llama-3.1-8B-Instruct-FP8 on B200 TP=2, ISL=OSL=1000 (vs PT-backend):
- c=1:   2.42 -> 2.32 ms (-0.10) -- AD now ahead of PT (2.35)
- c=2:   2.42 -> 2.32 ms (-0.10) -- AD ahead of PT (2.37)
- c=16:  2.85 -> 2.74 ms (-0.11) -- half of the residual gap
- c=256: 24.10 -> 27.01 ms (+2.91) -- regression

Because the FP8-fused AllReduce kernel trades launch savings for less-optimal large-batch work, the transform is left ``enabled: false`` in ``default.yaml`` and opt-in per registry yaml. Accuracy on MMLU/GSM8K is unchanged from the non-fused FP8 path.

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
