### PR TITLE
[None][test] Add Nemotron-V3-Super NVFP4 single-GPU accuracy on SM120

### DIFF
--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -7112,6 +7112,47 @@ class TestNemotronV3Super(LlmapiAccuracyTestHarness):
             layer_updates_per_iter=0)
         self._run_nvfp4_4gpus_eplb(moe_backend, eplb_config, model_path)
 
+    @skip_pre_blackwell
+    @pytest.mark.skip_less_device_memory(90000)
+    @parametrize_with_ids("moe_backend", ["CUTLASS", "CUTEDSL"])
+    def test_nvfp4_1gpu(self, moe_backend):
+        model_path = f"{llm_models_root()}/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4"
+        # SM120 b12x hybrid keeps both weight layouts → shrink workspaces.
+        b12x_hybrid = moe_backend == "CUTEDSL" and get_sm_version() == 120
+        if b12x_hybrid:
+            max_batch_size = 4
+            max_num_tokens = 2048
+            free_gpu_memory_fraction = 0.4
+            cuda_graph_cfg = None
+        else:
+            max_batch_size = 32
+            max_num_tokens = 4096
+            free_gpu_memory_fraction = 0.6
+            cuda_graph_cfg = CudaGraphConfig(max_batch_size=max_batch_size,
+                                             enable_padding=True)
+        kv_cache_config = KvCacheConfig(
+            enable_block_reuse=False,
+            mamba_ssm_cache_dtype="float16",
+            free_gpu_memory_fraction=free_gpu_memory_fraction,
+        )
+        with LLM(
+                model_path,
+                kv_cache_config=kv_cache_config,
+                max_batch_size=max_batch_size,
+                max_num_tokens=max_num_tokens,
+                max_seq_len=4352,
+                tensor_parallel_size=1,
+                moe_expert_parallel_size=1,
+                pipeline_parallel_size=1,
+                enable_attention_dp=False,
+                cuda_graph_config=cuda_graph_cfg,
+                disable_overlap_scheduler=False,
+                moe_config=MoeConfig(backend=moe_backend),
+        ) as llm:
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm,
+                          extra_evaluator_kwargs=self.EXTRA_EVALUATOR_KWARGS)
+
     @pytest.mark.skip_less_device(4)
     @pytest.mark.skip_device_not_contain(["GB200"])
     @parametrize_with_ids("moe_backend", ["TRTLLM", "CUTLASS", "CUTEDSL"])

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -692,6 +692,8 @@ accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_fp8_4gpus[attention_
 accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_fp8_4gpus[attention_dp_off-python_mamba_cache]
 accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_fp8_4gpus[attention_dp_on-cpp_mamba_cache]
 accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_fp8_4gpus[attention_dp_on-python_mamba_cache]
+accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_1gpu[moe_backend=CUTLASS]
+accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_1gpu[moe_backend=CUTEDSL]
 accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_4gpu_mtp_ar
 accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_4gpus_online_eplb[moe_backend=CUTLASS]
 accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_4gpus_online_eplb[moe_backend=TRTLLM]

--- a/tests/integration/test_lists/test-db/l0_rtx_pro_6000.yml
+++ b/tests/integration/test_lists/test-db/l0_rtx_pro_6000.yml
@@ -56,6 +56,8 @@ l0_rtx_pro_6000:
   - accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_w4_1gpu[v1_kv_cache-True-True-cutlass-auto]
   - accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B::test_nvfp4[latency_moe_cutlass-torch_compile=False] # 8mins
   - accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B::test_nvfp4[latency_moe_cutlass-torch_compile=True] # 8 mins
+  - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_1gpu[moe_backend=CUTLASS]
+  - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_1gpu[moe_backend=CUTEDSL]
 
 - condition:
     ranges:


### PR DESCRIPTION
Adds TestNemotronV3Super.test_nvfp4_1gpu parametrized over moe_backend {CUTLASS, CUTEDSL} for the RTX PRO 6000 (SM120) lane. The CUTEDSL path routes to CuteDslB12xFusedMoE (hybrid CUTLASS-prefill / b12x-decode) on SM120; the CUTLASS variant is the pure-CUTLASS baseline.

The hybrid backend carries both weight layouts (~3 GiB extra at TP=1) so memory-side knobs (max_batch_size, max_num_tokens, free fraction, CUDA graphs) are reduced specifically when get_sm_version() == 120 + CUTEDSL. Greedy decoding keeps accuracy stable across these knobs.

Registers both parametrizations in l0_rtx_pro_6000.yml under post_merge / single-GPU.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added accuracy evaluation test for NVIDIA Nemotron 3 Super 120B model with NVFP4 quantization
  * Extended test coverage across multiple backend configurations on RTX Pro 6000 hardware

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14637?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
