### PR TITLE
[https://nvbugs/6021353][fix] Remove remote RPC shutdown entrypoint

### DIFF
--- a/tensorrt_llm/executor/rpc/rpc_client.py
+++ b/tensorrt_llm/executor/rpc/rpc_client.py
@@ -147,12 +147,7 @@ class RPCClient:
 
     def shutdown_server(self):
         """Shutdown the server."""
-        if self._server_stopped:
-            return
-
-        self._rpc_shutdown().remote()
-
-        self._server_stopped = True
+        raise RuntimeError("Remote RPC server shutdown is not supported.")
 
     def close(self):
         """Gracefully close the client, cleaning up background tasks."""

--- a/tensorrt_llm/executor/rpc/rpc_server.py
+++ b/tensorrt_llm/executor/rpc/rpc_server.py
@@ -61,7 +61,6 @@ class RPCServer:
 
         self._functions: Dict[str, Callable[..., Any]] = {
             # Some built-in methods for RPC server
-            "_rpc_shutdown": lambda: self.shutdown(is_remote_call=True),
             "_rpc_get_attr": lambda name: self.get_attr(name),
         }
 
@@ -324,7 +323,7 @@ class RPCServer:
             return False
 
         # Allow shutdown methods to proceed
-        if req.method_name in ["_rpc_shutdown", "shutdown"]:
+        if req.method_name in ["shutdown"]:
             return False
 
         # Send cancellation error for all other requests
@@ -363,7 +362,7 @@ class RPCServer:
 
             # shutdown methods depend on _num_pending_requests, so
             # they should not be counted
-            if req.method_name not in ["_rpc_shutdown", "shutdown"]:
+            if req.method_name not in ["shutdown"]:
                 self._num_pending_requests += 1
                 logger_debug(
                     f"[server] Worker received request {req}, pending: {self._num_pending_requests}"
@@ -419,8 +418,8 @@ class RPCServer:
                         )
 
             # Decrement pending count
-            if req.method_name not in ["_rpc_shutdown", "shutdown"]:
-                self._num_pending_requests -= 1
+                if req.method_name not in ["shutdown"]:
+                    self._num_pending_requests -= 1
 
     def _calculate_adjusted_timeout(self,
                                     req: RPCRequest,

--- a/tests/unittest/executor/test_rpc.py
+++ b/tests/unittest/executor/test_rpc.py
@@ -99,6 +99,18 @@ class TestRpcBasics:
         with RpcServerWrapper(App()) as server:
             assert server.address == server.addr
 
+    def test_rpc_shutdown_is_not_remote_callable(self):
+
+        class App:
+            pass
+
+        with RpcServerWrapper(App()) as server:
+            with RPCClient(server.addr, hmac_key=server.hmac_key) as client:
+                with pytest.raises(RPCError):
+                    client._rpc_shutdown().remote()
+                with pytest.raises(RuntimeError):
+                    client.shutdown_server()
+
     def test_rpc_with_error(self):
 
         class App:


### PR DESCRIPTION
Validation: python3 -m pytest tests/unittest/executor/test_rpc.py::TestRpcBasics::test_rpc_shutdown_is_not_remote_callable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote RPC server shutdown is no longer supported; attempting to shutdown a remote server now raises an error immediately.
  * RPC shutdown handling is now restricted to use only the standard shutdown method.

* **Tests**
  * Added test coverage to verify that remote shutdown attempts are properly rejected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->