### PR TITLE
[https://nvbugs/6189928][fix] Remove waives for DeepSeek-V3.2 FP4 perf sanity tests

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -299,8 +299,6 @@ perf/test_perf.py::test_perf[t5_base-plugin-float16-bs:8-input_output_len:60,20]
 perf/test_perf.py::test_perf[whisper_large_v3-bench-float16-input_output_len:128,20] SKIP
 perf/test_perf_sanity.py::test_e2e[aggr_upload-ctx_only-gb300_deepseek-r1-fp4_128k8k_con256_ctx1_pp4_gen1_dep8_eplb0_mtp1_ccb-NIXL] SKIP (https://nvbugs/6215810)
 perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_r1_fp4_v2_grace_blackwell-r1_fp4_v2_tep4_mtp3_1k8k] SKIP (https://nvbugs/6167060)
-perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_v32_fp4_blackwell-v32_fp4_dep8_mtp1_8k1k] SKIP (https://nvbugs/6190071)
-perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_v32_fp4_blackwell-v32_fp4_tep8_mtp3_8k1k] SKIP (https://nvbugs/6189928)
 perf/test_perf_sanity.py::test_e2e[aggr_upload-dynamo_k25_thinking_fp4_blackwell-k25_thinking_fp4_tep8_adp_2k1k] SKIP (https://nvbugs/6227472)
 perf/test_perf_sanity.py::test_e2e[aggr_upload-k25_thinking_fp4_blackwell-k25_thinking_fp4_dep8_8k1k] SKIP (https://nvbugs/6227472)
 perf/test_perf_sanity.py::test_e2e[aggr_upload-k25_thinking_fp4_blackwell-k25_thinking_fp4_tep8_32k8k] SKIP (https://nvbugs/6227472)


### PR DESCRIPTION
## Description

Removes the two SKIP waives added by #14357 for:

- `perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_v32_fp4_blackwell-v32_fp4_tep8_mtp3_8k1k]` (nvbugs/6189928)
- `perf/test_perf_sanity.py::test_e2e[aggr_upload-deepseek_v32_fp4_blackwell-v32_fp4_dep8_mtp1_8k1k]` (nvbugs/6190071)

Root cause was the transformers 5.3.0 → 5.5.3 upgrade in #13994: bare
`PreTrainedConfig` no longer exposes `max_position_embeddings`, so
`AutoTokenizer.from_pretrained(..., trust_remote_code=True)` against
`model_type=deepseek_v32` fell through to the bare config and raised
`AttributeError`. The `benchmark_serving` client subprocess died right
after argparse, before any tokenizer was constructed.

Fixed by #14293 (parent nvbugs/6185234), which registers `deepseek_v32`
and `kimi_k2` against the local `DeepseekV3Config` in transformers'
`CONFIG_MAPPING` at TRT-LLM import time. Pre-merge regression coverage
added in `tests/unittest/_torch/test_custom_config_registration.py`.

## Test Coverage

The two perf-sanity stages that own these tests:

- `DGX_B200-8_GPUs-PyTorch-PerfSanity-Post-Merge-1` (TEP8/MTP3)
- `DGX_B200-8_GPUs-PyTorch-PerfSanity-Post-Merge-4` (DEP8/MTP1)

## PR Checklist

- [x] PR description clearly explains what and why
- [x] No new code paths — waives.txt-only change
- [x] No API changes
- [x] No new dependencies
- [x] CODEOWNERS unchanged
- [x] No doc updates needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed two test waiver entries from the performance test list, allowing previously exempted test scenarios to resume execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->