### PR TITLE
[https://nvbugs/6194552][fix] stabilize Triton Mamba softplus

### DIFF
--- a/tensorrt_llm/_torch/modules/mamba/softplus.py
+++ b/tensorrt_llm/_torch/modules/mamba/softplus.py
@@ -1,7 +1,7 @@
 # Adapted from https://github.com/state-spaces/mamba/blob/v2.2.4/mamba_ssm/ops/triton/softplus.py
 # Copyright (c) 2024, Tri Dao, Albert Gu.
 #
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,10 +26,13 @@ if TRITON3:
 
     @triton.jit
     def softplus(dt):
-        return tl.math.log(tl.math.exp(dt) + 1)
+        dt_clamped = tl.minimum(dt, 20.0)
+        return tl.where(dt <= 20.0, tl.math.log(tl.math.exp(dt_clamped) + 1),
+                        dt)
 
 else:
 
     @triton.jit
     def softplus(dt):
-        return tl.math.log1p(tl.exp(dt))
+        dt_clamped = tl.minimum(dt, 20.0)
+        return tl.where(dt <= 20.0, tl.math.log1p(tl.exp(dt_clamped)), dt)


### PR DESCRIPTION
## Description

Fix inf/NaN issue when dt's are large for mamba models.  Impacts replay code, and presumably other kernels like the triton MTP kernel that are not currently in use.

## Test Coverage
Nothing new.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
