### PR TITLE
[https://nvbugs/6227472][fix] cap weight-prefetch threads to avoid NFS deadlock on large checkpoints

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import glob
-import multiprocessing
 import os
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, List
@@ -32,6 +31,12 @@ from tensorrt_llm._utils import (ENABLE_MULTI_DEVICE, local_mpi_barrier,
                                  local_mpi_comm, local_mpi_rank, local_mpi_size)
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
+
+# Prefetch warms the OS page cache with a fixed-size reusable buffer instead of
+# materializing whole multi-GB shards in Python, and caps per-rank fanout so
+# LOCAL_MPI_SIZE * workers stays under networked-storage (NFS) in-flight limits.
+_PREFETCH_CHUNK_SIZE = 8 * 1024 * 1024
+_MAX_PREFETCH_WORKERS_PER_RANK = 2
 
 
 @register_checkpoint_weight_loader("MX")
@@ -162,8 +167,10 @@ class HfWeightLoader(BaseWeightLoader):
     def _prefetch_one_file(self, file_name):
         if os.path.exists(file_name):
             logger.info(f"Prefetching {file_name} to memory...")
+            buffer = bytearray(_PREFETCH_CHUNK_SIZE)
             with open(file_name, 'rb') as f:
-                f.read()
+                while f.readinto(buffer):
+                    pass
             logger.info(f"Finished prefetching {file_name}.")
 
     def prefetch_files(self, file_names: List[str]):
@@ -177,7 +184,6 @@ class HfWeightLoader(BaseWeightLoader):
         if len(local_file_names) == 0:
             return
 
-        max_workers = min(multiprocessing.cpu_count() * 2, 16,
-                          len(local_file_names))
+        max_workers = min(_MAX_PREFETCH_WORKERS_PER_RANK, len(local_file_names))
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             list(executor.map(self._prefetch_one_file, local_file_names))

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -291,11 +291,8 @@ perf/test_perf.py::test_perf[t5-bench-float16-input_output_len:128,20-gpus:2] SK
 perf/test_perf.py::test_perf[t5-bench-float16-maxbs:1-input_output_len:128,20-gpus:2] SKIP
 perf/test_perf.py::test_perf[t5_base-plugin-float16-bs:8-input_output_len:60,20] SKIP # (https://nvidia.slack.com/archives/C059LSY62BT/p1704525727177449)
 perf/test_perf.py::test_perf[whisper_large_v3-bench-float16-input_output_len:128,20] SKIP
-perf/test_perf_sanity.py::test_e2e[aggr_upload-dynamo_k25_thinking_fp4_blackwell-k25_thinking_fp4_tep8_adp_2k1k] SKIP (https://nvbugs/6227472)
 perf/test_perf_sanity.py::test_e2e[aggr_upload-k25_thinking_fp4_2_nodes_grace_blackwell-k25_thinking_fp4_dep8_32k8k] SKIP (https://nvbugs/6236108)
 perf/test_perf_sanity.py::test_e2e[aggr_upload-k25_thinking_fp4_blackwell-k25_thinking_fp4_dep8_32k8k] SKIP (https://nvbugs/6236094)
-perf/test_perf_sanity.py::test_e2e[aggr_upload-k25_thinking_fp4_blackwell-k25_thinking_fp4_dep8_8k1k] SKIP (https://nvbugs/6227472)
-perf/test_perf_sanity.py::test_e2e[aggr_upload-k25_thinking_fp4_blackwell-k25_thinking_fp4_tep8_32k8k] SKIP (https://nvbugs/6227472)
 perf/test_perf_sanity.py::test_e2e[aggr_upload-llama3_1_8b_fp8_ad_hopper-llama3_1_8b_ad_ws1_1k1k] SKIP (https://nvbugs/6244474)
 perf/test_perf_sanity.py::test_e2e[aggr_upload-super_ad_blackwell-super_ad_ws1_1k1k] SKIP (https://nvbugs/6153575)
 perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb200_deepseek-r1-fp4_128k8k_con128_ctx1_pp8_gen1_dep16_eplb0_mtp1_ccb-NIXL] SKIP (https://nvbugs/6215844)

--- a/tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py
+++ b/tests/unittest/_torch/models/checkpoints/hf/test_weight_loader.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from tensorrt_llm._torch.models.checkpoints import HfWeightLoader
+from tensorrt_llm._torch.models.checkpoints.hf import weight_loader
 from tensorrt_llm.mapping import Mapping
 
 
@@ -97,3 +98,62 @@ def test_load_weights_ignores_consolidated_ckpt_when_sharded_ckpt_exists(
     load_weights_in_parallel.assert_called_once()
     loaded_weight_files = load_weights_in_parallel.call_args[0][0]
     assert set(loaded_weight_files) == expected_safetensor_filenames
+
+
+def test_prefetch_one_file_reads_in_bounded_chunks(monkeypatch):
+    class FakeFile:
+        def __init__(self):
+            self.remaining_bytes = 10
+            self.read_sizes = []
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def readinto(self, buffer):
+            self.read_sizes.append(len(buffer))
+            if self.remaining_bytes == 0:
+                return 0
+            read_size = min(len(buffer), self.remaining_bytes)
+            buffer[:read_size] = b"x" * read_size
+            self.remaining_bytes -= read_size
+            return read_size
+
+    fake_file = FakeFile()
+
+    monkeypatch.setattr(weight_loader.os.path, "exists", lambda _: True)
+    monkeypatch.setattr(weight_loader, "_PREFETCH_CHUNK_SIZE", 4)
+    monkeypatch.setattr("builtins.open", lambda *_, **__: fake_file)
+
+    HfWeightLoader()._prefetch_one_file("checkpoint.safetensors")
+
+    assert fake_file.read_sizes == [4, 4, 4, 4]
+
+
+def test_prefetch_files_caps_per_rank_workers(monkeypatch):
+    class FakeThreadPoolExecutor:
+        def __init__(self, max_workers):
+            self.max_workers = max_workers
+
+        def __enter__(self):
+            observed_max_workers.append(self.max_workers)
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def map(self, _func, file_names):
+            return [None for _ in file_names]
+
+    observed_max_workers = []
+    file_names = [f"model-{idx}.safetensors" for idx in range(4)]
+
+    monkeypatch.setattr(weight_loader, "ThreadPoolExecutor", FakeThreadPoolExecutor)
+    monkeypatch.setattr(weight_loader, "local_mpi_rank", lambda: 0)
+    monkeypatch.setattr(weight_loader, "local_mpi_size", lambda: 1)
+
+    HfWeightLoader().prefetch_files(file_names)
+
+    assert observed_max_workers == [weight_loader._MAX_PREFETCH_WORKERS_PER_RANK]


### PR DESCRIPTION
prefetch_files() previously launched min(cpu_count() * 2, 16) threads per rank to issue full-file f.read() of every safetensors shard. On multi-rank deployments (e.g. K2.5 NVFP4 / 550 GB / DEP8 / TEP8) this expanded to LOCAL_MPI_SIZE * 16 simultaneous multi-GB reads against the checkpoint directory. When the checkpoint lives on a networked filesystem (NFS), that read fanout saturates per-mount in-flight I/O limits and stalls in libc::read indefinitely -- the server never binds /health and the run times out at the pytest budget.

py-spy --native confirmed every rank stuck in
prefetch_files -> _prefetch_one_file -> libc::read, with the main process waiting in _start_executor_workers IPC poll for those workers to come back.

Cap per-rank concurrency at 2 so the worst-case in-flight read count becomes LOCAL_MPI_SIZE * 2. That stays well under typical NFS limits while keeping enough concurrency to mask per-file open/seek latency and preserve the OS page-cache warmup benefit on local SSD.

Reproduced and validated end-to-end on 8 x B300 (SM103) against the rc16-tagged commit (= the bug's "last passing" commit 4517988cb3): unpatched run hung at /health for >10 min with 0/14 prefetches finishing; patched run reached "Application startup complete" + /health 200 OK in 12 min 32 s.

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
