### PR TITLE
[None][perf] DSv4 MegaMoE: free mmap pages and segments during load

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/base_weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/base_weight_loader.py
@@ -81,11 +81,37 @@ class ConsumableWeightsDict:
             The number of keys deleted.
 
         Thread-safe: uses a lock to prevent concurrent modification issues.
+
+        Memory note: for mmap-backed CPU tensors (e.g. safetensors views), `del`
+        alone drops the Python refcount but leaves the underlying file-backed
+        pages resident in the kernel page cache. On host-memory-constrained
+        platforms (e.g. Grace LPDDR shared by 4 ranks) this causes RSS to grow
+        unboundedly during weight loading. We therefore advise MADV_DONTNEED on
+        each tensor's mmap region before deletion to actively release page
+        cache. A `torch.cuda.synchronize()` is issued first to drain any
+        in-flight H2D copies that may still read from these pages.
         """
         with self._lock:
             keys_to_delete = [
                 k for k in self._weights.keys() if k.startswith(prefix + ".")
             ]
+            if keys_to_delete:
+                try:
+                    import torch
+
+                    from tensorrt_llm._torch.modules.fused_moe.moe_load_balancer import \
+                        advise_tensor_pageout
+                    torch.cuda.synchronize()
+                    for k in keys_to_delete:
+                        t = self._weights[k]
+                        if isinstance(t,
+                                      torch.Tensor) and t.device.type == "cpu":
+                            try:
+                                advise_tensor_pageout(t, mode="dontneed")
+                            except (OSError, ValueError):
+                                pass
+                except ImportError:
+                    pass
             for key in keys_to_delete:
                 del self._weights[key]
             return len(keys_to_delete)

--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -790,6 +790,14 @@ class DeepseekV4WeightLoader:
         params_map = {"gate_up_proj": ["gate_proj", "up_proj"]}
         all_named_modules = dict(self.model.named_modules())
 
+        # ConsumableWeightsDict: deletes mmap-backed source tensors right
+        # after each module finishes consuming them. Drops the OS page cache
+        # pressure on safetensors files during the per-module loop, which is
+        # the dominant host RSS contributor on tight Grace LPDDR nodes (lyris
+        # GB300, 240 GiB) where 4-rank MEGAMOE mnt=16k otherwise blows past
+        # the host budget. Mirrors DSv3's pattern at modeling_deepseekv3.py.
+        can_mark_consumed = hasattr(weights, "mark_consumed")
+
         def load_flat_hc_weights(module, names: List[str]) -> bool:
             """Load mHC / HCHead from flat ckpt keys: ``<stem>_{fn,base,scale}``.
 
@@ -899,6 +907,8 @@ class DeepseekV4WeightLoader:
                                 .view(*attn_module.v_b_proj_dequant.shape)
                                 .to(attn_module.v_b_proj_dequant.dtype)
                             )
+                    if can_mark_consumed:
+                        weights.mark_consumed(name)
                 elif names[-1] == "kv_a_proj_with_mqa":
                     nvfp4_fused_a = (
                         self.model_config.get_quant_config().layer_quant_mode.has_nvfp4()
@@ -1031,6 +1041,11 @@ class DeepseekV4WeightLoader:
                         # For DeepseekV32: kv_a_proj_with_mqa is oversized
                         # to include indexer k weights, which is filled in post_load_weights.
                         module.weight.data[0 : fused_a.shape[0]].copy_(fused_a)
+                    if can_mark_consumed:
+                        parent_prefix = ".".join(names[:-1])
+                        weights.mark_consumed(f"{parent_prefix}.kv_a_proj_with_mqa")
+                        if not is_lite:
+                            weights.mark_consumed(f"{parent_prefix}.q_a_proj")
                 elif names[-1] in params_map:
                     module_weights = []
                     for new_name in params_map[names[-1]]:
@@ -1038,6 +1053,9 @@ class DeepseekV4WeightLoader:
                             filter_weights(".".join(names[:-1] + [new_name]), weights)
                         )
                     module.load_weights(weights=module_weights)
+                    if can_mark_consumed:
+                        for src_name in params_map[names[-1]]:
+                            weights.mark_consumed(".".join(names[:-1] + [src_name]))
                 elif names[-1] == "experts":
                     module_weights = filter_weights(name, weights)
                     module_weights = rename_moe_weight(
@@ -1049,6 +1067,8 @@ class DeepseekV4WeightLoader:
                         },
                     )
                     module.load_weights(weights=[module_weights])
+                    if can_mark_consumed:
+                        weights.mark_consumed(name)
                 elif names[-1] == "backend" and isinstance(module, MoE):
                     # Special case: ConfigurableMoE.backend (TRTLLMGenFusedMoE)
                     # Currently saved MoE weights don't include 'backend' in their names.
@@ -1067,6 +1087,8 @@ class DeepseekV4WeightLoader:
                         },
                     )
                     module.load_weights(weights=[module_weights])
+                    if can_mark_consumed:
+                        weights.mark_consumed(parent_name)
                 elif names[-1] == "self_attn":
                     if f"{name}.o_a_proj" in weights:
                         load_o_a_proj(name, module)
@@ -1111,6 +1133,8 @@ class DeepseekV4WeightLoader:
                     else:
                         for n, p in module.named_parameters():
                             p.data.copy_(module_weights[n][:])
+                    if can_mark_consumed:
+                        weights.mark_consumed(name)
 
 
 @torch.compile(options={"max-autotune": True})

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -499,6 +499,16 @@ class ModelLoader:
                 logger.info("moe_load_balancer finalize model done")
 
             torch.cuda.current_stream().synchronize()
+            # Reclaim segments freed during per-module post_load_weights (e.g.
+            # MegaMoE _transform_main_weights releases ~5-6 GiB of redundant
+            # weight Parameters via `.data = empty(0)` that PyTorch's caching
+            # allocator otherwise holds onto). Returning them to the driver
+            # gives downstream stages (KV cache estimation, attention workspace
+            # alloc, autotuner warmup symmetric-fabric setup) full visibility
+            # of free HBM. Single one-shot call after all modules are
+            # finalized; per-layer empty_cache here is unsafe because it can
+            # perturb NVLink barrier synchronization in multi-rank DG init.
+            torch.cuda.empty_cache()
 
         return model, moe_load_balancer
 


### PR DESCRIPTION
Fixes two distinct OOM modes hit when running DeepSeek-V4-Pro with DEP=4, MTP=1, `MEGAMOE_DEEPGEMM` backend and `max_num_tokens=16k`:

1. **CUDA OOM on B300/x86** — workspace alloc bonks because PyTorch's caching allocator holds ~5.7 GiB of freed-but-cached segments accumulated across 60 MoE layers of `_transform_main_weights`. On marginal-fit configs only 10-15 GiB free at workspace alloc time, so the cache hoarding eats the budget.
2. **Kernel SIGKILL on GB300 (Grace 240 GiB shared by 4 ranks)** — host RSS climbs unboundedly during `_call_load_weights`, kernel OOM-killer fires silently (no CUDA error, no Python traceback). Two contributors:
   - `DeepseekV4WeightLoader.load_weights` never called `ConsumableWeightsDict.mark_consumed`, so the full source dict stayed alive through the entire load loop (DSv3 had 14 sites; DSv4 had 0).
   - `mark_consumed` itself only `del`'d Python refs — mmap-backed safetensors pages stayed pinned in the kernel page cache, and 4-rank concurrent loading exhausted the 240 GiB Grace LPDDR before the kernel could reclaim.