### PR TITLE
[https://nvbugs/6229221][fix] Add a reasoning parser for qwen3_5

### DIFF
--- a/tensorrt_llm/llmapi/reasoning_parser.py
+++ b/tensorrt_llm/llmapi/reasoning_parser.py
@@ -98,6 +98,15 @@ class BaseReasoningParser(ABC):
 @register_reasoning_parser("deepseek-r1", reasoning_at_start=True)
 @register_reasoning_parser("laguna")
 @register_reasoning_parser("qwen3")
+# Qwen3.5 (and forced-thinking Qwen3 variants) use a chat template that
+# pre-injects `<think>\n` into the assistant prompt prefix, so the model
+# output begins inside the reasoning block with no opening tag to search
+# for. That requires `reasoning_at_start=True`. The existing `qwen3` key
+# keeps `reasoning_at_start=False` for back-compat, and `parse()` is
+# binary on this flag (it either requires `<think>` to be present in the
+# output, or assumes the output begins at the start of reasoning) - so
+# the two behaviors must be registered under separate keys.
+@register_reasoning_parser("qwen3_5", reasoning_at_start=True)
 @register_reasoning_parser("minimax_m2", reasoning_at_start=True)
 @register_reasoning_parser("minimax_m2_append_think", reasoning_at_start=True)
 class DeepSeekR1Parser(BaseReasoningParser):


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Qwen3.5 model with integrated reasoning capabilities in the TensorRT LLM API.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Qwen3.5 (and forced-thinking Qwen3 variants) use a chat template that pre-injects `<think>\n` into the assistant prompt prefix, so the model output begins inside the reasoning block with no opening tag to search for. That requires `reasoning_at_start=True`. The existing `qwen3` key keeps `reasoning_at_start=False` for back-compat, and `parse()` is binary on this flag (it either requires `<think>` to be present in the output, or assumes the output begins at the start of reasoning) - so the two behaviors must be registered under separate keys.

## Test Coverage

The following response doesn't have any `<think>` tags:

```
trtllm-serve $MODEL_NAME --trust_remote_code --reasoning_parser qwen3_5 --port 8000

curl -sS http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"Qwen/Qwen3-30B-A3B-Thinking-2507",
"messages":[{"role":"user","content":"What is 17 times 23? Think step by step."}],
"max_tokens":2048,"temperature":0}' | jq '.choices[0].message'
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
