### PR TITLE
[https://nvbugs/6221450][fix] AutoDeploy: Qwen3.5 400B NVFP4 accuracy regression fix

### DIFF
--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
@@ -29,33 +29,14 @@ transforms:
     enabled: true
   fuse_nvfp4_moe:
     backend: trtllm_gen
-  detect_sharding:
-    # for long input, tp8ep1 gives better performance
-    # dist_mapping: {moe_tp: 8, moe_ep: 1}
+  # Sharding is driven by the hint-based IR path (enable_sharder_ir.yaml); TP/EP
+  # plans come from the in-model sharding hints, so no detect_sharding config is
+  # needed. Only runtime distribution options are set here.
+  apply_sharding_hints:
+    # Symmetric-memory all-reduce (MULTIMEM); matches the pre-IR sharding perf.
     allreduce_strategy: SYMM_MEM
-    shard_all_unprocessed: true
-    simple_shard_filter: "lm_head"
-    sharding_dims: ['tp','ep', 'bmm']
-    # use only manual config for TP sharding
-    sharding_source: ['manual']
-    manual_config:
-      tp_plan:
-        # GDN layer
-        "in_proj_qkv": "delta"
-        # attention layer
-        "q_proj": "colwise"
-        "k_proj": "colwise"
-        "v_proj": "colwise"
-        "o_proj": "rowwise"
-        # lm_head: "gather" = column split + all_gather (not "colwise" which
-        # requires a LayerSubgraph and crashes for standalone unprocessed nodes)
-        "lm_head": "gather"
-        # replicating shared experts (keep them commented out)
-        # "shared_expert_gate_proj": "colwise"
-        # "shared_expert_up_proj": "colwise"
-        # "shared_expert_down_proj": "rowwise"
-        # gating layer should be replicated as well
-        # "gate": "gather"
+    # Replicate the shared expert instead of TP-sharding it (cheaper at this size).
+    shard_exclude_filter: ["shared_expert"]
   multi_stream_moe:
     stage: compile
     enabled: true

--- a/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
+++ b/examples/auto_deploy/model_registry/configs/qwen3.5_moe_400b.yaml
@@ -29,14 +29,10 @@ transforms:
     enabled: true
   fuse_nvfp4_moe:
     backend: trtllm_gen
-  # Sharding is driven by the hint-based IR path (enable_sharder_ir.yaml); TP/EP
-  # plans come from the in-model sharding hints, so no detect_sharding config is
-  # needed. Only runtime distribution options are set here.
   apply_sharding_hints:
-    # Symmetric-memory all-reduce (MULTIMEM); matches the pre-IR sharding perf.
     allreduce_strategy: SYMM_MEM
-    # Replicate the shared expert instead of TP-sharding it (cheaper at this size).
-    shard_exclude_filter: ["shared_expert"]
+    # Shared expert is excluded from sharding for performance purpose
+    shard_layers: ["moe", "delta", "mha"]
   multi_stream_moe:
     stage: compile
     enabled: true

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/linear/swiglu.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/linear/swiglu.py
@@ -51,6 +51,7 @@ def torch_swiglu_mlp(
     gate_bias: Optional[torch.Tensor],
     up_bias: Optional[torch.Tensor],
     down_bias: Optional[torch.Tensor],
+    layer_type: str = "unknown",
 ) -> torch.Tensor:
     """Standardized SwiGLU MLP operation.
 
@@ -86,6 +87,7 @@ def _(
     gate_bias: Optional[torch.Tensor],
     up_bias: Optional[torch.Tensor],
     down_bias: Optional[torch.Tensor],
+    layer_type: str = "unknown",
 ) -> torch.Tensor:
     """Fake implementation for tracing."""
     # Output shape is [..., hidden_size] where hidden_size = down_weight.shape[0]
@@ -159,6 +161,7 @@ def torch_nvfp4_swiglu_mlp(
     down_input_scale: torch.Tensor,
     down_weight_scale: torch.Tensor,
     down_alpha: torch.Tensor,
+    layer_type: str = "unknown",
 ) -> torch.Tensor:
     """NVFP4 quantized SwiGLU MLP operation (intermediate representation).
 
@@ -230,6 +233,7 @@ def _(
     down_input_scale: torch.Tensor,
     down_weight_scale: torch.Tensor,
     down_alpha: torch.Tensor,
+    layer_type: str = "unknown",
 ) -> torch.Tensor:
     """Fake implementation for tracing."""
     # Output shape: [..., hidden_size] where hidden_size = down_weight.shape[0]
@@ -323,6 +327,7 @@ def torch_finegrained_fp8_swiglu_mlp(
     gate_weight_scale: torch.Tensor,
     up_weight_scale: torch.Tensor,
     down_weight_scale: torch.Tensor,
+    layer_type: str = "unknown",
 ) -> torch.Tensor:
     """FineGrained FP8 quantized SwiGLU MLP operation (intermediate representation).
 
@@ -382,6 +387,7 @@ def _(
     gate_weight_scale: torch.Tensor,
     up_weight_scale: torch.Tensor,
     down_weight_scale: torch.Tensor,
+    layer_type: str = "unknown",
 ) -> torch.Tensor:
     """Fake implementation for tracing."""
     # Output shape: [..., hidden_size] where hidden_size = down_weight.shape[0]

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -765,8 +765,11 @@ class Qwen3_5MoeSparseMoeBlock(nn.Module):
             layer_type="moe",
         )
 
-        expert_output = expert_output + shared_expert_output
+        # The shared expert is replicated (excluded from TP sharding), so all-reduce
+        # the sharded routed-expert output first, then add the replicated shared
+        # output; adding before would scale it by the TP world size.
         expert_output = torch.ops.auto_deploy.all_reduce(expert_output, layer_type="moe")
+        expert_output = expert_output + shared_expert_output
 
         expert_output = expert_output.reshape(batch_size, sequence_length, hidden_dim)
         return expert_output

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -630,21 +630,21 @@ class Qwen3_5MoeMLP(nn.Module):
             self.gate_proj.weight,
             self.gate_proj.bias,
             tp_mode="colwise",
-            layer_type="moe",
+            layer_type="shared_expert",
         )
         up = torch.ops.auto_deploy.torch_linear_simple(
             x,
             self.up_proj.weight,
             self.up_proj.bias,
             tp_mode="colwise",
-            layer_type="moe",
+            layer_type="shared_expert",
         )
         return torch.ops.auto_deploy.torch_linear_simple(
             self.act_fn(gate) * up,
             self.down_proj.weight,
             self.down_proj.bias,
             tp_mode="rowwise",
-            layer_type="moe",
+            layer_type="shared_expert",
         )
 
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_swiglu.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/fuse_swiglu.py
@@ -22,6 +22,7 @@ This module provides two-stage transformation for SwiGLU MLP:
 The SwiGLU pattern is: silu(x @ gate.T) * (x @ up.T) @ down.T
 """
 
+from contextlib import contextmanager
 from typing import Tuple, Type
 
 import torch
@@ -47,7 +48,7 @@ from ...utils._graph import (
     eliminate_dead_code,
     get_attr_by_name,
 )
-from ...utils.node_utils import is_op
+from ...utils.node_utils import extract_op_args, is_op, set_op_args
 from ...utils.pattern_matcher import ADPatternMatcherPass, register_ad_pattern
 from ...utils.quantization_utils import ensure_tma_col_major
 from ..interface import (
@@ -57,6 +58,42 @@ from ..interface import (
     TransformInfo,
     TransformRegistry,
 )
+
+
+def _weight_key(node: Node):
+    """Stable key for a weight arg: the get_attr target FQN (survives node re-creation
+    during pattern replacement), falling back to node identity. ``args[1]`` is the
+    weight for both linear and SwiGLU ops."""
+    w = node.args[1] if len(node.args) > 1 else None
+    if not isinstance(w, Node):
+        return None
+    return w.target if w.op == "get_attr" else w
+
+
+@contextmanager
+def preserve_layer_types(gm: GraphModule, linear_op, fused_op):
+    """Carry the ``layer_type`` hint across a fusion that consumes ``linear_op`` nodes
+    and emits ``fused_op`` nodes (which would otherwise drop the hint).
+
+    Snapshots each source weight's ``layer_type`` before the rewrite, then re-applies
+    it to the fused node keyed by weight, so hint-driven sharding (``shard_layers``)
+    can still classify the fused node. Wrap the matcher's ``patterns.apply`` call.
+    """
+    wmap = {}
+    for n in gm.graph.nodes:
+        if is_op(n, linear_op):
+            [lt] = extract_op_args(n, "layer_type")
+            key = _weight_key(n)
+            if lt is not None and key is not None:
+                wmap[key] = lt
+    yield
+    if not wmap:
+        return
+    for n in gm.graph.nodes:
+        if is_op(n, fused_op):
+            key = _weight_key(n)
+            if key is not None and key in wmap:
+                set_op_args(n, layer_type=wmap[key])
 
 
 def _maybe_to_deepgemm_layout(
@@ -242,7 +279,12 @@ class MatchSwiGLUPattern(BaseTransform):
             dummy_args=dummy_args_with_bias,
         )
 
-        num_matches = patterns.apply(gm.graph)
+        with preserve_layer_types(
+            gm,
+            torch.ops.auto_deploy.torch_linear_simple.default,
+            torch.ops.auto_deploy.torch_swiglu_mlp.default,
+        ):
+            num_matches = patterns.apply(gm.graph)
 
         if num_matches > 0:
             gm.recompile()
@@ -554,7 +596,12 @@ class MatchNVFP4SwiGLUPattern(BaseTransform):
             dummy_args=dummy_args,
         )
 
-        num_matches = patterns.apply(gm.graph)
+        with preserve_layer_types(
+            gm,
+            torch.ops.auto_deploy.torch_fake_quant_nvfp4_linear.default,
+            torch.ops.auto_deploy.torch_nvfp4_swiglu_mlp.default,
+        ):
+            num_matches = patterns.apply(gm.graph)
 
         if num_matches > 0:
             gm.recompile()
@@ -835,7 +882,12 @@ class MatchFineGrainedFP8SwiGLUPattern(BaseTransform):
             dummy_args=dummy_args,
         )
 
-        num_matches = patterns.apply(gm.graph)
+        with preserve_layer_types(
+            gm,
+            torch.ops.auto_deploy.torch_fake_quant_finegrained_fp8_linear.default,
+            torch.ops.auto_deploy.torch_finegrained_fp8_swiglu_mlp.default,
+        ):
+            num_matches = patterns.apply(gm.graph)
 
         if num_matches > 0:
             gm.recompile()

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py
@@ -889,11 +889,6 @@ class IRShardingConfig(TransformConfig):
         default=None,
         description="When set, only shard nodes whose layer_type hint is in this list.",
     )
-    shard_exclude_filter: Optional[List[str]] = Field(
-        default=None,
-        description="Substrings matched against a node's weight parameter keys; matching "
-        "nodes are left replicated (not TP-sharded), e.g. ['shared_expert'].",
-    )
     enable_attention_dp: bool = Field(default=False)
     dist_mapping: dict[str, int] = Field(default_factory=dict)
     dist_config: DistConfig = Field(default_factory=DistConfig)
@@ -924,13 +919,6 @@ class IRShardingConfig(TransformConfig):
 # =============================================================================
 # Standalone helpers
 # =============================================================================
-
-
-def _node_weight_keys_match(node: Node, patterns: List[str]) -> bool:
-    """True if any of *node*'s weight/bias/scale param keys contains a pattern substring."""
-    wn = extract_weight_nodes(node)
-    keys = [n.node_key for n in (*wn.weights, *wn.biases, *wn.scales)]
-    return any(pat in key for key in keys for pat in patterns)
 
 
 def _log_sharding_prelude(dc: DistConfig) -> None:
@@ -1104,7 +1092,6 @@ class ApplyShardingHints(BaseTransform):
             _log_sharding_result(dc, num_updates)
         else:
             shard_layers = self.config.shard_layers
-            exclude_filter = self.config.shard_exclude_filter
             num_skipped = 0
             all_dead_nodes = []
 
@@ -1122,11 +1109,6 @@ class ApplyShardingHints(BaseTransform):
                         if lt is not None and lt not in shard_layers:
                             num_skipped += 1
                             continue
-                    # Replicate (skip sharding) nodes excluded by config, e.g. the
-                    # shared expert, which is cheaper replicated than TP-sharded.
-                    if exclude_filter and _node_weight_keys_match(node, exclude_filter):
-                        num_skipped += 1
-                        continue
 
                     num_updates += shardable_node.apply(gm, dc, max_num_tokens)
 

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py
@@ -889,6 +889,11 @@ class IRShardingConfig(TransformConfig):
         default=None,
         description="When set, only shard nodes whose layer_type hint is in this list.",
     )
+    shard_exclude_filter: Optional[List[str]] = Field(
+        default=None,
+        description="Substrings matched against a node's weight parameter keys; matching "
+        "nodes are left replicated (not TP-sharded), e.g. ['shared_expert'].",
+    )
     enable_attention_dp: bool = Field(default=False)
     dist_mapping: dict[str, int] = Field(default_factory=dict)
     dist_config: DistConfig = Field(default_factory=DistConfig)
@@ -919,6 +924,13 @@ class IRShardingConfig(TransformConfig):
 # =============================================================================
 # Standalone helpers
 # =============================================================================
+
+
+def _node_weight_keys_match(node: Node, patterns: List[str]) -> bool:
+    """True if any of *node*'s weight/bias/scale param keys contains a pattern substring."""
+    wn = extract_weight_nodes(node)
+    keys = [n.node_key for n in (*wn.weights, *wn.biases, *wn.scales)]
+    return any(pat in key for key in keys for pat in patterns)
 
 
 def _log_sharding_prelude(dc: DistConfig) -> None:
@@ -1092,6 +1104,7 @@ class ApplyShardingHints(BaseTransform):
             _log_sharding_result(dc, num_updates)
         else:
             shard_layers = self.config.shard_layers
+            exclude_filter = self.config.shard_exclude_filter
             num_skipped = 0
             all_dead_nodes = []
 
@@ -1109,6 +1122,11 @@ class ApplyShardingHints(BaseTransform):
                         if lt is not None and lt not in shard_layers:
                             num_skipped += 1
                             continue
+                    # Replicate (skip sharding) nodes excluded by config, e.g. the
+                    # shared expert, which is cheaper replicated than TP-sharded.
+                    if exclude_filter and _node_weight_keys_match(node, exclude_filter):
+                        num_skipped += 1
+                        continue
 
                     num_updates += shardable_node.apply(gm, dc, max_num_tokens)
 

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -17,7 +17,6 @@ accuracy/test_llm_api_autodeploy.py::TestModelRegistryAccuracy::test_autodeploy_
 accuracy/test_llm_api_autodeploy.py::TestNemotronNanoV3::test_accuracy[nvfp4-1-trtllm] SKIP (https://nvbugs/6200112)
 accuracy/test_llm_api_autodeploy.py::TestNemotronUltraV3::test_accuracy[nvfp4-8] SKIP (https://nvbugs/6248757)
 accuracy/test_llm_api_autodeploy.py::TestQwen3_5_397B_MoE::test_bf16_small[4] SKIP (https://nvbugs/6158397)
-accuracy/test_llm_api_autodeploy.py::TestQwen3_5_397B_MoE::test_nvfp4[8] SKIP (https://nvbugs/6211441)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput_mtp_trtllm] SKIP (https://nvbugs/6191524)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput] SKIP (https://nvbugs/6084775)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_mtp] SKIP (https://nvbugs/6029882)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable sharding exclusion filter enabling selective replication of model components during distributed sharding operations.

* **Bug Fixes**
  * Fixed operation ordering in sparse MoE expert output combination to correctly handle replicated components.

* **Chores**
  * Updated MoE model sharding configuration with new hint-driven strategy.
  * Re-enabled comprehensive model inference test coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
## Background / Motivation

Qwen3.5-397B-A17B-NVFP4 accuracy dropped to near 0 after PR#13478. 

## Root cause

The model was migrated to the hint-based IR sharding path in #13478
(`92c5030`, "Switch ... to sharding-IR canonical models"). That changed how the
MoE shared expert is handled:

- **Pre-IR (`detect_sharding`)**: the shared expert was **replicated** — it was
  intentionally left out of the manual `tp_plan` and excluded by
  `simple_shard_filter`, so it was never TP-sharded.
- **IR path (`apply_sharding_hints`)**: the shared expert is matched into a
  fused `torch_nvfp4_swiglu_mlp` op and **unconditionally TP-sharded**. The
  NVFP4 swiglu scale-sharding additionally deswizzled every projection's
  per-block `weight_scale` with the gate projection's shape, which is wrong for
  the differently-shaped `down_proj` scale — corrupting the shared-expert output.

A second, independent regression from the same migration: the IR path reads
`allreduce_strategy` from `apply_sharding_hints`, but the model only declared
`SYMM_MEM` under the (now-disabled) `detect_sharding`, so all-reduces silently
fell back to NCCL — a perf regression vs. the pre-IR path.

## Summary of changes

1. **Replicate the shared expert (correctness).** Add a `shard_exclude_filter`
   option to the IR sharder: nodes whose weight-parameter keys match a substring
   (e.g. `shared_expert`) are left replicated instead of TP-sharded — the same
   convention as the legacy `simple_shard_filter`. The Qwen3.5-MoE config uses
   `shard_exclude_filter: ["shared_expert"]`, restoring the pre-IR behavior. The
   MoE all-reduce is reordered so the replicated shared output is added *after*
   the routed all-reduce (adding before would scale it by the TP world size).

2. **Restore SYMM_MEM all-reduce (perf).** Set `allreduce_strategy: SYMM_MEM`
   under `apply_sharding_hints` so the IR path uses it, and remove the dead
   `detect_sharding` block (disabled on the IR path; superseded by in-model
   sharding hints).

## Validation

`accuracy/test_llm_api_autodeploy.py::TestQwen3_5_397B_MoE::test_nvfp4[8]`
(8×B200):

- **MMLU 26.8% → 86.4%**, GSM8K 96.0% — PASS.
- FX graph dumps confirm the shared expert is replicated and all all-reduces use
  SYMM_MEM (0 NCCL), matching the pre-IR baseline.

## Impact

- `shard_exclude_filter` defaults to `None` (no behavior change for other
  models); only Qwen3.5-MoE opts in.

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage
- Accuracy test is being covered by post-merge accuracy check for Qwen3.5. 

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
