### PR TITLE
[https://nvbugs/5970614][fix] Sync CTA before PDL trigger in quantize_with_block_size

### DIFF
--- a/cpp/tensorrt_llm/kernels/quantization.cuh
+++ b/cpp/tensorrt_llm/kernels/quantization.cuh
@@ -897,6 +897,15 @@ quantize_with_block_size(
             }
         }
     }
+    // Fix for nvbugs/5970614 (https://nvbugspro.nvidia.com/bug/5970614).
+    // PDL completion is reported when every CTA has either exited or called
+    // this function at least once (per CUDA Programming Guide). Without a
+    // CTA-wide barrier, an early-finishing warp can trigger completion while
+    // other warps in the same CTA are still writing sf_out / out, allowing the
+    // downstream NVF4 GEMM consumer to read partial data once
+    // wait_on_dependent_grids returns. Drain the CTA's stores before trigger.
+    __syncthreads();
+    __threadfence();
     cudaTriggerProgrammaticLaunchCompletion();
 #endif
 }

--- a/cpp/tensorrt_llm/kernels/quantization.cuh
+++ b/cpp/tensorrt_llm/kernels/quantization.cuh
@@ -897,7 +897,6 @@ quantize_with_block_size(
             }
         }
     }
-    // Fix for nvbugs/5970614 (https://nvbugspro.nvidia.com/bug/5970614).
     // PDL completion is reported when every CTA has either exited or called
     // this function at least once (per CUDA Programming Guide). Without a
     // CTA-wide barrier, an early-finishing warp can trigger completion while

--- a/cpp/tensorrt_llm/kernels/quantization.cuh
+++ b/cpp/tensorrt_llm/kernels/quantization.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2023, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -932,9 +932,11 @@ quantize_with_block_size(
     // CTA-wide barrier, an early-finishing warp can trigger completion while
     // other warps in the same CTA are still writing sf_out / out, allowing the
     // downstream NVF4 GEMM consumer to read partial data once
-    // wait_on_dependent_grids returns. Drain the CTA's stores before trigger.
-    __syncthreads();
+    // wait_on_dependent_grids returns. Each thread first makes its own stores
+    // device-visible; the barrier then guarantees every thread has done so
+    // before any thread can reach the trigger.
     __threadfence();
+    __syncthreads();
     cudaTriggerProgrammaticLaunchCompletion();
 #endif
 }

--- a/cpp/tensorrt_llm/kernels/quantization.cuh
+++ b/cpp/tensorrt_llm/kernels/quantization.cuh
@@ -279,6 +279,34 @@ constexpr int CVT_ELTS_PER_THREAD = 8;
 constexpr int CVT_FP4_THREADS_PER_WARP = 32;
 constexpr int CVT_FP8_TO_FP4_ELTS_PER_THREAD = 16;
 
+// Membermask for the __shfl_xor_sync butterfly among the NUM_THREADS_PER_SF
+// lanes that share one scale factor. The xor-1/xor-2 exchange never crosses
+// this aligned lane group, so only the group has to converge on the shuffle.
+//
+// Do not widen the mask to the full warp. A sync shuffle waits until every
+// lane named in the mask reaches the same call site, but here not every lane
+// of a warp gets there: in quantize_with_block_size, lanes that drew padding
+// columns (or ran out of columns) skip the cvt call and go wait at the CTA
+// barrier at the end of the kernel. If the data/padding boundary cuts through
+// a warp, a full-warp shuffle deadlocks against that barrier. A full mask can
+// also name lanes that were never launched, because blockDim is not always a
+// multiple of 32 (e.g. 200 threads leave the last warp with only 8 lanes);
+// that is undefined behavior.
+//
+// The group mask is always safe: blockDim and every column boundary (data,
+// padded, SF-padded) are multiples of the group size, so the lanes of one
+// group always reach the same set of shuffle calls together.
+template <int NUM_THREADS_PER_SF>
+inline __device__ uint32_t cvt_sf_group_shfl_mask()
+{
+    static_assert(NUM_THREADS_PER_SF == 2 || NUM_THREADS_PER_SF == 4, "Unsupported SF group size.");
+    constexpr uint32_t groupSize = static_cast<uint32_t>(NUM_THREADS_PER_SF);
+    constexpr uint32_t groupMask = (1U << groupSize) - 1U;
+    uint32_t laneId = 0;
+    asm("mov.u32 %0, %%laneid;" : "=r"(laneId));
+    return groupMask << (laneId & ~(groupSize - 1U));
+}
+
 // Convert 8 float32 values into 8 e2m1 values (represented as one uint32_t).
 inline __device__ uint32_t fp32_vec_to_e2m1(float (&array)[8])
 {
@@ -439,10 +467,11 @@ __device__ uint32_t cvt_warp_fp16_to_fp4(PackedVec<Type>& vec, float SFScaleVal,
 
     constexpr int CVT_NUM_THREADS_PER_SF = SF_VEC_SIZE / CVT_ELTS_PER_THREAD;
     // Get the absolute maximum among all 16 values (two threads for 16, four threads for 32).
-    localMax = cuda_max(__shfl_xor_sync(uint32_t(-1), localMax, 1), localMax);
+    uint32_t const sfGroupMask = cvt_sf_group_shfl_mask<CVT_NUM_THREADS_PER_SF>();
+    localMax = cuda_max(__shfl_xor_sync(sfGroupMask, localMax, 1), localMax);
     if constexpr (CVT_NUM_THREADS_PER_SF == 4)
     {
-        localMax = cuda_max(__shfl_xor_sync(uint32_t(-1), localMax, 2), localMax);
+        localMax = cuda_max(__shfl_xor_sync(sfGroupMask, localMax, 2), localMax);
     }
     // Get the final absolute maximum values.
     float vecMax = float(cuda_max(localMax.x, localMax.y));
@@ -540,7 +569,7 @@ __device__ uint64_t cvt_warp_fp8_to_fp4(PackedVec<Type>& vec, float SFScaleVal, 
     if constexpr (CVT_NUM_THREADS_PER_SF == 2)
     {
         // For block 32, we need to reduce the local max across two threads.
-        localMax = __hmax2(__shfl_xor_sync(uint32_t(-1), localMax, 1), localMax);
+        localMax = __hmax2(__shfl_xor_sync(cvt_sf_group_shfl_mask<CVT_NUM_THREADS_PER_SF>(), localMax, 1), localMax);
     }
 
     // Get the final absolute maximum values.
@@ -616,10 +645,11 @@ __device__ uint64_t cvt_warp_fp16_to_mxfp8(PackedVec<Type>& vec, uint8_t* SFout)
 
     constexpr int CVT_NUM_THREADS_PER_SF = SF_VEC_SIZE / CVT_ELTS_PER_THREAD;
     // Get the absolute maximum among all 16 values (two threads for 16, four threads for 32).
-    localMax = cuda_max(__shfl_xor_sync(uint32_t(-1), localMax, 1), localMax);
+    uint32_t const sfGroupMask = cvt_sf_group_shfl_mask<CVT_NUM_THREADS_PER_SF>();
+    localMax = cuda_max(__shfl_xor_sync(sfGroupMask, localMax, 1), localMax);
     if constexpr (CVT_NUM_THREADS_PER_SF == 4)
     {
-        localMax = cuda_max(__shfl_xor_sync(uint32_t(-1), localMax, 2), localMax);
+        localMax = cuda_max(__shfl_xor_sync(sfGroupMask, localMax, 2), localMax);
     }
     // Get the final absolute maximum values.
     float vecMax = float(cuda_max(localMax.x, localMax.y));

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -198,7 +198,6 @@ examples/visual_gen/test_visual_gen_multi_gpu.py::test_wan22_t2v_lpips_against_g
 full:A100/disaggregated/test_workers.py::test_workers_conditional_disaggregation_deepseek_v3_lite_bf16[DeepSeek-V3-Lite-bf16] SKIP (https://nvbugs/6329052)
 full:A100X/llmapi/test_llm_examples.py::test_llmapi_speculative_decoding_mtp SKIP (https://nvbugs/6287561)
 full:A100X/unittest/llmapi/test_llm_pytorch.py -m "part0" SKIP (https://nvbugs/6416249)
-full:B200/accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_pp4_mtp] SKIP (https://nvbugs/5970614)
 full:B200/accuracy/test_llm_api_pytorch.py::TestMiniMaxM3::test_auto_dtype[tp_size=8-ep_size=8] SKIP (https://nvbugs/6384747)
 full:B200/disaggregated/test_disaggregated.py::test_disaggregated_overlap_gen_first[ctx_pp4-TinyLlama-1.1B-Chat-v1.0] SKIP (https://nvbugs/6344107)
 full:B200/disaggregated/test_disaggregated.py::test_disaggregated_stress_test[input8k-output1k-conc512-gpt_oss_120b_eagle_trtllm_stress] SKIP (https://nvbugs/6413724)


### PR DESCRIPTION
## Summary

Fixes a PDL (Programmatic Dependent Launch) race in `quantize_with_block_size` that intermittently corrupts NVFP4 GEMM outputs and degrades GSM8K accuracy for DeepSeek-R1 NVFP4 on GB300 + PP=4 + MTP (nvbug 5970614).

`cudaTriggerProgrammaticLaunchCompletion()` only signals that the CTA has reached the trigger point — it does **not** flush prior stores to global memory. Memory visibility for the secondary kernel must be provided either by the producer (a fence before the trigger) or by the consumer (`wait_on_dependent_grids()` before its first dependent load). In the current NVFP4 path neither side does so: the producer lacks a fence, and the sm103 blockscaled GEMM's `main_sf_load` warp branch is missing the corresponding `wait_on_dependent_grids()` (tracked separately in [NVIDIA/cutlass#3279](https://github.com/NVIDIA/cutlass/pull/3279)).

Compounding this, PDL completion is reported per-CTA at-least-once: a single warp reaching the trigger marks its whole CTA as "trigger reached", even if peer warps in the same CTA are still writing `sf_out` / `out`. Once every CTA has been marked, the driver launches the secondary kernel, which TMA-loads partial data — NaNs then propagate through the DeepSeek-R1 forward and corrupt output tokens.

Fix: insert `__threadfence(); __syncthreads();` immediately before the trigger. Each thread first makes its own stores device-visible; the barrier then guarantees every thread has done so before any thread can signal PDL completion.

## In-tree precedent

This mirrors an existing pattern in [`cpp/tensorrt_llm/kernels/fusedLayernormKernels/ws_layernorm.cuh:865-867`](https://github.com/NVIDIA/TensorRT-LLM/blob/main/cpp/tensorrt_llm/kernels/fusedLayernormKernels/ws_layernorm.cuh#L865-L867), which uses a barrier plus `membar.gl` (`__threadfence()` is the CUDA intrinsic for `membar.gl`) before the same `cudaTriggerProgrammaticLaunchCompletion()` call. Per review, this PR places the fence *before* the barrier — the strictly stronger order: barrier release then already implies every thread's stores are device-visible, without relying on post-barrier fence timing.

## Evidence

The race was characterized on `release/1.2`, where the timing window reproduces it deterministically enough to measure. A cache-bypass `ld.global.cv.u8` probe on the SF buffer detects `0x7f` poison fill (from the `cudaMallocAsync` pool) as a direct race indicator:

| Config | GSM8K | Poison probe |
|---|---:|---|
| Baseline (no fix) | 91.93 (**FAIL**, threshold 92.217) | **2.31%** (~74k / 3.2M samples) |
| With this fix | 95.34 (**PASS**, ref 95.42) | **0 / 2.4M** |

On `main` the race is **latent**: the GSM8K test no longer fails even without this fix (10/10 PASS, mean 94.95 ± 0.25 with autotuner off; with the fix mean 95.14 ± 0.19). Code/scheduler changes since `release/1.2` appear to have narrowed the producer-to-consumer window enough that the race no longer trips the GSM8K threshold — but the underlying defect is unchanged, and any future change that widens the window (cutlass bump, scheduler reordering, kernel fusion) can re-expose it.

The full investigation branch — probes, race-rate measurement, per-run logs — lives on my fork at [`tianyuxbear/TensorRT-LLM:fix/5970614-bak`](https://github.com/tianyuxbear/TensorRT-LLM/tree/fix/5970614-bak), which is based on `release/1.2` (where the race is deterministically reproducible).

The probe code used to measure the race is **not** part of this PR; it was a one-off diagnostic inside the cutlass consumer.

## Test-case waive removed by this PR

On `main` the affected test case (`TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_pp4_mtp]`) is waived in `tests/integration/test_lists/waives.txt` under this very nvbug (5970614). Since this PR fixes the underlying race, it also removes the waive so CI validates the fix end to end on the real reproducer.

Historical note: the deterministic accuracy gap in the Evidence section was measured on `release/1.2`, where the producer-to-consumer timing window reproduces the race reliably; on `main` the race is latent for this shape, so the unwaived run primarily guards against future changes re-widening the window.

## Companion cutlass fix

The consumer-side fix at [NVIDIA/cutlass#3279](https://github.com/NVIDIA/cutlass/pull/3279) addresses the missing `wait_on_dependent_grids()` in the sm103 blockscaled GEMM `main_sf_load` warp branch (the other half of the race described in Summary). Either fix alone closes the race; both are correct individually:

- The cutlass fix protects every PDL producer routed through that GEMM.
- This producer-side fix protects every PDL consumer downstream of `quantize_with_block_size`, regardless of which cutlass revision trtllm pulls in.

## Follow-up fix: shuffle-mask deadlock exposed by the barrier

The first full CI run of this PR hung 19 test cases on Blackwell stages (B200/B300) — all hangs, no accuracy failures:

| Failed cases | Failure mode |
|---|---|
| 13x `test_fp8_quantize.py::test_mxfp8_quantize_alignment_torch_device[*-1568-*]` | Deterministic kernel hang (B300 timed out at `a_fp8.cpu()` after 2400 s; B200 xdist workers mass-crashed) |
| 4x `TestGPTOSS::test_w4_1gpu[*]` / `test_dummy_load_format` | Hang inside `LLM(...)` init during the first warmup forward |
| 2x `test_indexer_topk.py::test_indexer_topk_prefill[*]` | Collateral only: no quantize calls inside; they shared the GPU wedged by the hung kernel, and both pass standalone |

**Root cause.** The cvt helpers called from `quantize_with_block_size`'s thread-strided column loop reduce the per-SF absmax with a full-warp `__shfl_xor_sync(0xffffffff, ...)` — but the shuffle is only reached on the real-data branch of the loop body; lanes that draw padding columns just store zeros and skip it. When the data/padding boundary cuts through a warp, only part of that warp reaches the shuffle: MXFP8 k=1568 / alignment=64 gives blockDim=200 with 196 data-column threads (196 = 6x32+4, splitting warp 6 at lane 4); the GPT-OSS MoE activation quant (hidden=2880, weight alignment 256) gives blockDim=384 with 360 data-column threads (360 = 11x32+8, splitting warp 11 at lane 8). Before this PR that was benign: the padding lanes **exited** the kernel after their stores, and exited lanes satisfy sync collectives on sm_70+, so the data lanes' full-warp shuffle completed. With the new `__syncthreads()`, the padding lanes are instead parked **alive** at the barrier: the shuffle waits for lanes held at the barrier, the barrier waits for lanes held at the shuffle — a deterministic circular wait. The barrier did not create the bug; it removed the exit-semantics cover from a latent over-wide membermask.

**Fix.** Narrow the shuffle membermask to the 2-/4-lane scale-factor group (new `cvt_sf_group_shfl_mask()` helper; 5 call sites across `cvt_warp_fp16_to_fp4` / `cvt_warp_fp8_to_fp4` / `cvt_warp_fp16_to_mxfp8`). The xor-1/xor-2 butterfly never exchanges data outside the aligned group, so the mask now names exactly the lanes that must converge. Group lanes always share a trip count because blockDim and the column-thread count are both multiples of the group size (guaranteed by the `k % sfVecSize == 0` checks at the op layer). This is a strictly weaker convergence precondition with bit-identical numerics — the membermask never selects shuffle sources, so callers of these helpers in other kernels are unaffected.

**Local verification (single B200).** All 19 failed CI cases rerun after the fix: **19/19 pass, 0 timeouts**. The deterministic hang case `[64-True-dtype0-1568-1]` completes in 0.08 s (previously 2400 s timeout). GPT-OSS 120B GSM8K scores **89.23 vs the 85.0 reference** across all three w4_1gpu variants — the mask change preserves quantization numerics end to end.

**Why the DeepSeek-R1 e2e never hit this.** The deadlock requires the boundary of the shuffle-participation set (which lanes reach the cvt call) to cut through the middle of a warp. DeepSeek-R1 (hidden=7168) has no padding columns at all (7168 is already SF-layout-aligned), and its only boundary is the loop-stride one: blockDim=512 with 896 data-column threads, so the second stride covers threads 0..383 — 384 is an exact multiple of 32, whole warps diverge together, and every warp's full-mask shuffle stayed convergent. Neither the release/1.2 race experiments nor the DeepSeek CI case could ever expose the hazard; it takes shapes like k=1568 (alignment unit tests) or hidden=2880 (GPT-OSS MoE) to land a boundary mid-warp.

## Risk

- **Surface**: one producer kernel (`quantize_with_block_size`, NVFP4 / FP8 / MXFP8 paths) plus the shuffle membermasks in the shared cvt helpers (strictly weaker convergence requirement, identical data movement).
- **Per-CTA cost**: one `__syncthreads()` + one `__threadfence()` at the very end of the kernel (cold path). No effect on PDL launch overlap — the trigger still happens; it just happens after the CTA has drained.
- No API or behavior change for callers.




