### PR TITLE
[None][fix] Restore DSv4 NVFP4 routed swiglu_limit on TRTLLM-Gen

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -1472,13 +1472,10 @@ class DeepseekV4MoE(nn.Module):
                 WideEPMoE,
                 DeepGemmFusedMoE,
             )
-            # NVFP4 routed-expert path: the TRTLLM-Gen fp4-block-scale fused-MoE
-            # cubin produces near-zero accuracy without bias even when
-            # swiglu_limit is supplied; drop the limit there until the cubin
-            # gains a no-bias clamp variant. MXFP4 variants are unaffected.
+            # WideEPMoE NVFP4 (NVFP4CutlassFusedMoEMethod) swiglu_limit path
+            # not re-validated end-to-end.
             kernel_requires_bias_for_swiglu_limit = (
-                moe_cls in (TRTLLMGenFusedMoE, WideEPMoE)
-                and experts_quant_config.quant_mode.has_nvfp4()
+                moe_cls is WideEPMoE and experts_quant_config.quant_mode.has_nvfp4()
             )
             if supports_swiglu_limit and not kernel_requires_bias_for_swiglu_limit:
                 moe_load_balancer_config = getattr(model_config, "moe_load_balancer", None)

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -3176,6 +3176,17 @@ class NVFP4TRTLLMGenFusedMoEBaseMethod(NVFP4FusedMoEMethod):
         # Finalize shared expert alphas and fc31_scale_c for online EPLB
         self._finalize_shared_expert_alphas(module)
 
+        # Cubin clamp / GLU bias inputs are consumed in the pre-dequant GEMM
+        # output domain (i.e. divided by fc31_alpha / fc2_alpha).
+        if getattr(module, 'w3_w1_bias', None) is not None:
+            module.w3_w1_bias.data.div_((module.fc31_alpha.data).view(-1, 1))
+        if getattr(module, 'w2_bias', None) is not None:
+            module.w2_bias.data.div_((module.fc2_alpha.data).view(-1, 1))
+        if getattr(module, 'swiglu_beta', None) is not None:
+            module.swiglu_beta.data.div_((module.fc31_alpha.data))
+        if getattr(module, 'swiglu_limit', None) is not None:
+            module.swiglu_limit.data.div_((module.fc31_alpha.data))
+
     def _shuffle_shared_expert_tensors(self,
                                        module: torch.nn.Module,
                                        num_elts_per_sf: int = 16):
@@ -3654,30 +3665,6 @@ class NVFP4TRTLLMGenFusedMoEMethod(NVFP4TRTLLMGenFusedMoEBaseMethod):
                 self._shuffle_w3_w1_weight(module,
                                            module.w3_w1_bias.data[expert_idx])
                 self._shuffle_w2_weight(module.w2_bias.data[expert_idx])
-
-    def process_weights_after_loading(self,
-                                      module: torch.nn.Module,
-                                      num_elts_per_sf: int = 16):
-        # Call parent to compute global input scales, alphas, and fc31_scale_c first
-        super().process_weights_after_loading(module,
-                                              num_elts_per_sf=num_elts_per_sf)
-
-        # Normalize biases to account for the global scale factors,
-        # matching the kernel's expectation (similar to test_moe.py logic).
-        # This must happen after alphas are finalized.
-        if module.w3_w1_bias is not None:
-            # gemm1_bias * gemm1_scales_global * hidden_states_scale_global
-            module.w3_w1_bias.data.div_((module.fc31_alpha.data).view(-1, 1))
-
-        if module.w2_bias is not None:
-            # gemm2_bias * c_global_sf * gemm2_scales_global
-            module.w2_bias.data.div_((module.fc2_alpha.data).view(-1, 1))
-
-        if module.swiglu_beta is not None:
-            module.swiglu_beta.data.div_((module.fc31_alpha.data))
-
-        if module.swiglu_limit is not None:
-            module.swiglu_limit.data.div_((module.fc31_alpha.data))
 
 
 class W4A8NVFP4FP8TRTLLMGenFusedMoEMethod(NVFP4TRTLLMGenFusedMoEBaseMethod):


### PR DESCRIPTION
Re-added `swiglu_limit` back for TRTLLM-Gen backend on NVFP4.