### PR TITLE
[None][fix] mhc: disable PARALLEL distributed tuning for MhcFusedHc

### DIFF
--- a/tensorrt_llm/_torch/modules/mhc/mhc_cuda.py
+++ b/tensorrt_llm/_torch/modules/mhc/mhc_cuda.py
@@ -848,7 +848,8 @@ class MhcFusedHcRunner(TunableRunner):
             # comb_mix_prev (input[3]) dim 0 = M
             ConstraintSpec(input_idx=3, dim_idx=0, infer_shape=lambda shapes: shapes[0][0]),
         ),
-        distributed_tuning_strategy=DistributedTuningStrategy.PARALLEL,
+        # TODO: re-enable distributed_tuning_strategy=PARALLEL once
+        # _FusedHcWorkspaceCache no longer keys on chosen-tactic fields.
     )
 
     def __init__(


### PR DESCRIPTION
## Summary

PR #14458 enabled `distributed_tuning_strategy=DistributedTuningStrategy.PARALLEL` on both `MhcPreMappingRunner` and `MhcFusedHcRunner`. The MhcFusedHc setting triggers a **non-deterministic CUDA Illegal Memory Access** on TP=8 disagg GEN workers during the post-autotune max-batch CUDA-graph-capture step.

This PR keeps the MhcPre PARALLEL change (where the autotune saving comes from) and disables only the MhcFusedHc PARALLEL change (where the crash comes from).

## Reproduction (xqiao container `dsv4-435a0a-pr14458`, 3-node disagg, 1024-1024 dataset)

Observed on two recipes that ship the same container:
- `1024-1024/disagg_ctx1_gen1_tep8_batch256_eplb0_mtp0` (TP=8 GEN, max_batch=256)
- `8192-1024/disagg_ctx1_gen1_dep8_batch512_eplb384_mtp1` (DEP8 GEN, max_batch=512)

Crash signature: rank 6 `[executor] Failed to initialize executor: CUDA_ERROR_ILLEGAL_ADDRESS` at `mla_custom_op_inplace` (`attention.py:1022`), during warmup-2 at `Run warmup with 256 tokens, include 256 generation tokens` — the cuda-graph-capture step.

A/B/C/D matrix (TP=8 disagg, 3-node, max_batch=256):

| MhcPre PARALLEL | MhcFusedHc PARALLEL | result |
|---|---|---|
| ON | ON | 🔥 IMA in 2 of 3 reruns (A, A2 crashed; A3 passed by luck) |
| OFF | OFF | ✅ clean |
| OFF | **ON** | 🔥 IMA (C) |
| **ON** | OFF | ✅ clean (D — this PR's configuration) |

## Mechanism

`MhcFusedHcRunner.__init__` creates `self._ws_cache = _FusedHcWorkspaceCache(...)`. `forward()` then does:

```python
(residual_cur, post_mix_cur, ..., done_counter_ws) = self._ws_cache.get(
    B, num_k_splits, tile_m, x_prev.device)
```

The LRU is keyed on `(B, ws_ks=max(1, num_k_splits), m_batches, device)` — i.e. on the chosen tactic's `(num_k_splits, tile_m)` fields.

Under `PARALLEL`, `_maybe_parallelize_tactics` gives each rank `[t for idx, t in enumerate(tactics) if idx % tp_size == tp_rank]`. Each rank's local profiling populates the LRU with workspace entries **only for the tactics it measured**. After `_merge_cache_data` picks the global-best tactic per shape, ranks that **didn't** locally measure that tactic miss the workspace LRU at first replay and call `_alloc()` → `torch.empty(...)`. Because the post-autotune max-batch warmup is a CUDA-graph-capture stage, the fresh allocation lands in a region inconsistent with the captured snapshot, and the next collective kernel (here MLA attention) dereferences a stale pointer → IMA.

`MhcPreMappingRunner.forward()` does fresh `torch.empty(...)` every call keyed only on `(M, n, hidden_size)` — independent of tactic — so its per-rank allocation history is identical under PARALLEL. No divergence, no crash.

## Cost

`distributed_tuning_strategy=PARALLEL` on MhcFusedHc adds essentially no autotune saving on this recipe at TP=8:

| | GEN autotune block 1 | CTX autotune block 1 |
|---|---|---|
| both PARALLEL (PR #14458 HEAD) | 4m 42s | 8m 43s |
| only MhcPre PARALLEL (this PR) | 4m 46s | 9m 19s |
| both INDEPENDENT (full revert) | 4m 53s | 12m 42s |

The MhcPre PARALLEL change still buys ~27% CTX autotune reduction (12m 42s → 9m 19s). Disabling MhcFusedHc PARALLEL costs ~52 s of CTX autotune in the worst case, within JIT-compile noise.

## Follow-up

Re-enabling MhcFusedHc PARALLEL is feasible after `_FusedHcWorkspaceCache` is reworked. Two candidate fixes:
1. Drop tactic-dependent keying from the LRU (size workspace to max over all valid tactics; cost: bounded by the largest `(num_k_splits, tile_m)` combination).
2. Add a post-merge warmup hook that pre-populates each rank's LRU for the chosen tactic *before* the CUDA-graph-capture warmup begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
