### PR TITLE
[None][fix] Fix kv cache manager v2 size estimation

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
@@ -802,8 +802,8 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             indexer_k_dtype=self._indexer_k_dtype,
         )
         (
-            decode_swa_size_per_token,
-            decode_swa_size_per_request,
+            generation_swa_size_per_token,
+            generation_swa_size_per_request,
         ) = _estimate_swa_cache_size(
             self.head_dim,
             self.index_head_dim,
@@ -819,13 +819,15 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             self._max_num_tokens if self._max_num_tokens is not None else max_tokens
         )
         context_tokens = min(max_tokens, max_context_tokens)
+        generation_tokens = max_tokens - context_tokens
         generation_quota = (
-            max_tokens * (non_sliding_attn_size_per_token + decode_swa_size_per_token)
-            + self.max_batch_size * decode_swa_size_per_request
+            max_tokens * non_sliding_attn_size_per_token
+            + generation_tokens * generation_swa_size_per_token
+            + self.max_batch_size * generation_swa_size_per_request
         )
-        context_quota = context_tokens * context_swa_size_per_token
+        context_extra_quota = context_tokens * context_swa_size_per_token
         padding = self._get_extra_quota_padding()
-        return int(generation_quota + context_quota + padding)
+        return int(generation_quota + context_extra_quota + padding)
 
     def _get_max_tokens_from_quota(self, quota: int) -> float:
         compress_ratios = [self._compress_ratios[layer] for layer in self.pp_layers]
@@ -837,7 +839,7 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             has_fp8_kv_cache,
             indexer_k_dtype=self._indexer_k_dtype,
         )
-        swa_size_per_token, swa_size_per_request = _estimate_swa_cache_size(
+        context_swa_size_per_token, _ = _estimate_swa_cache_size(
             self.head_dim,
             self.index_head_dim,
             compress_ratios,
@@ -848,14 +850,34 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             scratch=self.enable_swa_scratch_reuse,
             indexer_k_dtype=self._indexer_k_dtype,
         )
+        (
+            generation_swa_size_per_token,
+            generation_swa_size_per_request,
+        ) = _estimate_swa_cache_size(
+            self.head_dim,
+            self.index_head_dim,
+            compress_ratios,
+            has_fp8_kv_cache,
+            self.tokens_per_block,
+            self._swa_window_size,
+            context=False,
+            scratch=False,
+            indexer_k_dtype=self._indexer_k_dtype,
+        )
         padding = self._get_extra_quota_padding()
-        size_per_batch = self.max_batch_size * swa_size_per_request + padding
+        size_per_batch = self.max_batch_size * generation_swa_size_per_request + padding
         if quota < size_per_batch:
             return 0
-        size_per_token = non_sliding_attn_size_per_token + swa_size_per_token
-        if size_per_token == 0:
-            return float("inf")
-        return (quota - size_per_batch) / size_per_token
+        context_size_per_token = non_sliding_attn_size_per_token + context_swa_size_per_token
+        if self._max_num_tokens is None:
+            return (quota - size_per_batch) / context_size_per_token
+
+        context_limit_quota = self._max_num_tokens * context_size_per_token + size_per_batch
+        if quota <= context_limit_quota:
+            return (quota - size_per_batch) / context_size_per_token
+
+        generation_size_per_token = non_sliding_attn_size_per_token + generation_swa_size_per_token
+        return self._max_num_tokens + (quota - context_limit_quota) / generation_size_per_token
 
     def _build_cache_config(
         self,

--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
@@ -877,6 +877,8 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             return (quota - size_per_batch) / context_size_per_token
 
         generation_size_per_token = non_sliding_attn_size_per_token + generation_swa_size_per_token
+        if generation_size_per_token <= 0:
+            return float("inf")
         return self._max_num_tokens + (quota - context_limit_quota) / generation_size_per_token
 
     def _build_cache_config(

--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
@@ -98,7 +98,7 @@ def _estimate_swa_cache_size(
     tokens_per_block: int,
     swa_window_size: int | None,
     *,
-    prefill: bool,
+    context: bool,
     scratch: bool,
     indexer_k_dtype: str = "fp8",
 ) -> Tuple[int, int]:
@@ -130,7 +130,7 @@ def _estimate_swa_cache_size(
                 has_fp8_kv_cache,
                 indexer_k_dtype=indexer_k_dtype,
             )
-            if not prefill:
+            if not context:
                 size_per_request += window_tokens * token_bytes
             elif not scratch:
                 size_per_token += token_bytes
@@ -788,7 +788,7 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             indexer_k_dtype=self._indexer_k_dtype,
         )
         (
-            prefill_swa_size_per_token,
+            context_swa_size_per_token,
             _,
         ) = _estimate_swa_cache_size(
             self.head_dim,
@@ -797,7 +797,7 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             has_fp8_kv_cache,
             self.tokens_per_block,
             self._swa_window_size,
-            prefill=True,
+            context=True,
             scratch=self.enable_swa_scratch_reuse,
             indexer_k_dtype=self._indexer_k_dtype,
         )
@@ -811,21 +811,21 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             has_fp8_kv_cache,
             self.tokens_per_block,
             self._swa_window_size,
-            prefill=False,
+            context=False,
             scratch=False,
             indexer_k_dtype=self._indexer_k_dtype,
         )
-        max_prefill_tokens = (
+        max_context_tokens = (
             self._max_num_tokens if self._max_num_tokens is not None else max_tokens
         )
-        context_tokens = min(max_tokens, max_prefill_tokens)
+        context_tokens = min(max_tokens, max_context_tokens)
         generation_quota = (
             max_tokens * (non_sliding_attn_size_per_token + decode_swa_size_per_token)
             + self.max_batch_size * decode_swa_size_per_request
         )
-        context_overhead = context_tokens * prefill_swa_size_per_token
+        context_quota = context_tokens * context_swa_size_per_token
         padding = self._get_extra_quota_padding()
-        return int(generation_quota + context_overhead + padding)
+        return int(generation_quota + context_quota + padding)
 
     def _get_max_tokens_from_quota(self, quota: int) -> float:
         compress_ratios = [self._compress_ratios[layer] for layer in self.pp_layers]
@@ -844,18 +844,18 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             has_fp8_kv_cache,
             self.tokens_per_block,
             self._swa_window_size,
-            prefill=True,
+            context=True,
             scratch=self.enable_swa_scratch_reuse,
             indexer_k_dtype=self._indexer_k_dtype,
         )
         padding = self._get_extra_quota_padding()
-        size_per_request = self.max_batch_size * swa_size_per_request + padding
-        if quota < size_per_request:
+        size_per_batch = self.max_batch_size * swa_size_per_request + padding
+        if quota < size_per_batch:
             return 0
         size_per_token = non_sliding_attn_size_per_token + swa_size_per_token
         if size_per_token == 0:
             return float("inf")
-        return (quota - size_per_request) / size_per_token
+        return (quota - size_per_batch) / size_per_token
 
     def _build_cache_config(
         self,
@@ -1194,15 +1194,15 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
     def _get_context_bytes(self, request: llm_request.LlmRequest) -> int:
         prompt_len = max(0, request.prompt_len)
         total_tokens = prompt_len + self.num_extra_kv_tokens
-        return self._get_cache_bytes_for_tokens(total_tokens, prefill=True)
+        return self._get_cache_bytes_for_tokens(total_tokens, context=True)
 
     def _get_generation_bytes(self, request: llm_request.LlmRequest) -> int:
         prompt_len = max(0, request.prompt_len)
         max_new_tokens = max(0, request.max_new_tokens)
         total_tokens = prompt_len + max_new_tokens + self.num_extra_kv_tokens
-        return self._get_cache_bytes_for_tokens(total_tokens, prefill=False)
+        return self._get_cache_bytes_for_tokens(total_tokens, context=False)
 
-    def _get_cache_bytes_for_tokens(self, total_tokens: int, *, prefill: bool) -> int:
+    def _get_cache_bytes_for_tokens(self, total_tokens: int, *, context: bool) -> int:
         has_fp8_kv_cache = self.dtype == DataType.FP8
         compress_ratios = [self._compress_ratios[layer] for layer in self.pp_layers]
         non_sliding_attn_size_per_token = _estimate_non_sliding_attn_size_per_token(
@@ -1219,7 +1219,7 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             has_fp8_kv_cache,
             self.tokens_per_block,
             self._swa_window_size,
-            prefill=prefill,
+            context=context,
             scratch=self.enable_swa_scratch_reuse,
             indexer_k_dtype=self._indexer_k_dtype,
         )
@@ -1490,7 +1490,7 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             has_fp8_kv_cache,
             kwargs["tokens_per_block"],
             model_config.sparse_attention_config.window_size,
-            prefill=False,
+            context=False,
             scratch=False,
             indexer_k_dtype=indexer_k_dtype,
         )

--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
@@ -787,7 +787,10 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             has_fp8_kv_cache,
             indexer_k_dtype=self._indexer_k_dtype,
         )
-        swa_size_per_token, swa_size_per_request = _estimate_swa_cache_size(
+        (
+            prefill_swa_size_per_token,
+            _,
+        ) = _estimate_swa_cache_size(
             self.head_dim,
             self.index_head_dim,
             compress_ratios,
@@ -795,15 +798,34 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             self.tokens_per_block,
             self._swa_window_size,
             prefill=True,
-            scratch=getattr(self, "enable_swa_scratch_reuse", False),
+            scratch=self.enable_swa_scratch_reuse,
             indexer_k_dtype=self._indexer_k_dtype,
         )
-        padding = self._get_extra_quota_padding()
-        return int(
-            max_tokens * (full_attn_size_per_token + swa_size_per_token)
-            + self.max_batch_size * swa_size_per_request
-            + padding
+        (
+            decode_swa_size_per_token,
+            decode_swa_size_per_request,
+        ) = _estimate_swa_cache_size(
+            self.head_dim,
+            self.index_head_dim,
+            compress_ratios,
+            has_fp8_kv_cache,
+            self.tokens_per_block,
+            self._swa_window_size,
+            prefill=False,
+            scratch=False,
+            indexer_k_dtype=self._indexer_k_dtype,
         )
+        max_prefill_tokens = (
+            self._max_num_tokens if self._max_num_tokens is not None else max_tokens
+        )
+        context_tokens = min(max_tokens, max_prefill_tokens)
+        generation_quota = (
+            max_tokens * (full_attn_size_per_token + decode_swa_size_per_token)
+            + self.max_batch_size * decode_swa_size_per_request
+        )
+        context_overhead = context_tokens * prefill_swa_size_per_token
+        padding = self._get_extra_quota_padding()
+        return int(generation_quota + context_overhead + padding)
 
     def _get_max_tokens_from_quota(self, quota: int) -> float:
         compress_ratios = [self._compress_ratios[layer] for layer in self.pp_layers]
@@ -823,7 +845,7 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             self.tokens_per_block,
             self._swa_window_size,
             prefill=True,
-            scratch=getattr(self, "enable_swa_scratch_reuse", False),
+            scratch=self.enable_swa_scratch_reuse,
             indexer_k_dtype=self._indexer_k_dtype,
         )
         padding = self._get_extra_quota_padding()
@@ -1198,7 +1220,7 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             self.tokens_per_block,
             self._swa_window_size,
             prefill=prefill,
-            scratch=getattr(self, "enable_swa_scratch_reuse", False),
+            scratch=self.enable_swa_scratch_reuse,
             indexer_k_dtype=self._indexer_k_dtype,
         )
         return int(
@@ -1460,16 +1482,15 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             has_fp8_kv_cache,
             indexer_k_dtype=indexer_k_dtype,
         )
-        scratch = _enable_swa_scratch_reuse_from_env() and not kwargs.get("is_draft", False)
         swa_size_per_token, swa_size_per_request = _estimate_swa_cache_size(
             head_dim,
             index_head_dim,
             compress_ratios,
             has_fp8_kv_cache,
             kwargs["tokens_per_block"],
-            getattr(model_config.sparse_attention_config, "window_size", None),
-            prefill=True,
-            scratch=scratch,
+            model_config.sparse_attention_config.window_size,
+            prefill=False,
+            scratch=False,
             indexer_k_dtype=indexer_k_dtype,
         )
         max_batch_size = int(kwargs.get("max_batch_size") or 0)

--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
@@ -90,20 +90,22 @@ def _estimate_full_attn_size_per_token(
     return total_bytes
 
 
-def _estimate_swa_size_per_request(
+def _estimate_swa_cache_size(
     head_dim: int,
     index_head_dim: int,
     compress_ratios: List[int],
     has_fp8_kv_cache,
-    tokens_per_block: int | None,
+    tokens_per_block: int,
     swa_window_size: int | None,
+    *,
+    prefill: bool,
+    scratch: bool,
     indexer_k_dtype: str = "fp8",
-) -> int:
-    if tokens_per_block is None:
-        return 0
-
+) -> Tuple[int, int]:
     tokens_per_block = int(tokens_per_block)
-    total_bytes = 0
+    size_per_token = 0
+    size_per_request = 0
+    scratch_keys = set()
     for compress_ratio in compress_ratios:
         for attn_type in DEEPSEEK_V4_SLIDING_ATTENTION:
             if not compress_ratio_has_attention(compress_ratio, attn_type):
@@ -120,7 +122,7 @@ def _estimate_swa_size_per_request(
             window_tokens = (
                 (int(window_size) + tokens_per_block - 1) // tokens_per_block
             ) * tokens_per_block
-            total_bytes += window_tokens * _get_attn_bytes_per_token(
+            token_bytes = _get_attn_bytes_per_token(
                 head_dim,
                 index_head_dim,
                 compress_ratio,
@@ -128,7 +130,18 @@ def _estimate_swa_size_per_request(
                 has_fp8_kv_cache,
                 indexer_k_dtype=indexer_k_dtype,
             )
-    return total_bytes
+            if not prefill:
+                size_per_request += window_tokens * token_bytes
+            elif not scratch:
+                size_per_token += token_bytes
+            else:
+                scratch_key = (int(window_size), token_bytes)
+                if scratch_key in scratch_keys:
+                    size_per_request += window_tokens * token_bytes
+                else:
+                    scratch_keys.add(scratch_key)
+                    size_per_token += token_bytes
+    return size_per_token, size_per_request
 
 
 def _get_attn_bytes_per_token(
@@ -774,18 +787,20 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             has_fp8_kv_cache,
             indexer_k_dtype=self._indexer_k_dtype,
         )
-        swa_size_per_request = _estimate_swa_size_per_request(
+        swa_size_per_token, swa_size_per_request = _estimate_swa_cache_size(
             self.head_dim,
             self.index_head_dim,
             compress_ratios,
             has_fp8_kv_cache,
             self.tokens_per_block,
             self._swa_window_size,
+            prefill=True,
+            scratch=getattr(self, "enable_swa_scratch_reuse", False),
             indexer_k_dtype=self._indexer_k_dtype,
         )
         padding = self._get_extra_quota_padding()
         return int(
-            max_tokens * full_attn_size_per_token
+            max_tokens * (full_attn_size_per_token + swa_size_per_token)
             + self.max_batch_size * swa_size_per_request
             + padding
         )
@@ -800,22 +815,25 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             has_fp8_kv_cache,
             indexer_k_dtype=self._indexer_k_dtype,
         )
-        swa_size_per_request = _estimate_swa_size_per_request(
+        swa_size_per_token, swa_size_per_request = _estimate_swa_cache_size(
             self.head_dim,
             self.index_head_dim,
             compress_ratios,
             has_fp8_kv_cache,
             self.tokens_per_block,
             self._swa_window_size,
+            prefill=True,
+            scratch=getattr(self, "enable_swa_scratch_reuse", False),
             indexer_k_dtype=self._indexer_k_dtype,
         )
         padding = self._get_extra_quota_padding()
-        intercept = self.max_batch_size * swa_size_per_request + padding
-        if quota < intercept:
+        size_per_request = self.max_batch_size * swa_size_per_request + padding
+        if quota < size_per_request:
             return 0
-        if full_attn_size_per_token == 0:
+        size_per_token = full_attn_size_per_token + swa_size_per_token
+        if size_per_token == 0:
             return float("inf")
-        return (quota - intercept) / full_attn_size_per_token
+        return (quota - size_per_request) / size_per_token
 
     def _build_cache_config(
         self,
@@ -1154,15 +1172,15 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
     def _get_context_bytes(self, request: llm_request.LlmRequest) -> int:
         prompt_len = max(0, request.prompt_len)
         total_tokens = prompt_len + self.num_extra_kv_tokens
-        return self._get_cache_bytes_for_tokens(total_tokens)
+        return self._get_cache_bytes_for_tokens(total_tokens, prefill=True)
 
     def _get_generation_bytes(self, request: llm_request.LlmRequest) -> int:
         prompt_len = max(0, request.prompt_len)
         max_new_tokens = max(0, request.max_new_tokens)
         total_tokens = prompt_len + max_new_tokens + self.num_extra_kv_tokens
-        return self._get_cache_bytes_for_tokens(total_tokens)
+        return self._get_cache_bytes_for_tokens(total_tokens, prefill=False)
 
-    def _get_cache_bytes_for_tokens(self, total_tokens: int) -> int:
+    def _get_cache_bytes_for_tokens(self, total_tokens: int, *, prefill: bool) -> int:
         has_fp8_kv_cache = self.dtype == DataType.FP8
         compress_ratios = [self._compress_ratios[layer] for layer in self.pp_layers]
         full_attn_size_per_token = _estimate_full_attn_size_per_token(
@@ -1172,16 +1190,20 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             has_fp8_kv_cache,
             indexer_k_dtype=self._indexer_k_dtype,
         )
-        swa_size_per_request = _estimate_swa_size_per_request(
+        swa_size_per_token, swa_size_per_request = _estimate_swa_cache_size(
             self.head_dim,
             self.index_head_dim,
             compress_ratios,
             has_fp8_kv_cache,
             self.tokens_per_block,
             self._swa_window_size,
+            prefill=prefill,
+            scratch=getattr(self, "enable_swa_scratch_reuse", False),
             indexer_k_dtype=self._indexer_k_dtype,
         )
-        return int(total_tokens * full_attn_size_per_token + swa_size_per_request)
+        return int(
+            total_tokens * (full_attn_size_per_token + swa_size_per_token) + swa_size_per_request
+        )
 
     def get_needed_resource_to_completion(self, request: llm_request.LlmRequest) -> int:
         if self._is_generation_request(request):
@@ -1438,17 +1460,20 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             has_fp8_kv_cache,
             indexer_k_dtype=indexer_k_dtype,
         )
-        swa_size_per_request = _estimate_swa_size_per_request(
+        scratch = _enable_swa_scratch_reuse_from_env() and not kwargs.get("is_draft", False)
+        swa_size_per_token, swa_size_per_request = _estimate_swa_cache_size(
             head_dim,
             index_head_dim,
             compress_ratios,
             has_fp8_kv_cache,
-            kwargs.get("tokens_per_block"),
+            kwargs["tokens_per_block"],
             getattr(model_config.sparse_attention_config, "window_size", None),
+            prefill=True,
+            scratch=scratch,
             indexer_k_dtype=indexer_k_dtype,
         )
         max_batch_size = int(kwargs.get("max_batch_size") or 0)
-        return full_attn_size_per_token, swa_size_per_request * max_batch_size
+        return full_attn_size_per_token + swa_size_per_token, swa_size_per_request * max_batch_size
 
     def check_invalid_values_in_kv_cache(self, fill_with_zero: bool = False) -> bool:
         some_checks_unavailable = False

--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
@@ -53,7 +53,7 @@ from tensorrt_llm.runtime.kv_cache_manager_v2._common import BAD_PAGE_INDEX
 
 from .compressor import KVCacheDtype
 from .deepseek_v4 import (
-    DEEPSEEK_V4_FULL_ATTENTION,
+    DEEPSEEK_V4_NON_SLIDING_ATTENTION,
     DEEPSEEK_V4_SLIDING_ATTENTION,
     DEEPSEEK_V4_SPARSE_RATIO,
     DeepseekV4AttentionType,
@@ -68,7 +68,7 @@ from .deepseek_v4 import (
 DSV4_ENABLE_SWA_SCRATCH_REUSE_ENV = "TRTLLM_DSV4_ENABLE_SWA_SCRATCH_REUSE"
 
 
-def _estimate_full_attn_size_per_token(
+def _estimate_non_sliding_attn_size_per_token(
     head_dim: int,
     index_head_dim: int,
     compress_ratios: List[int],
@@ -77,7 +77,7 @@ def _estimate_full_attn_size_per_token(
 ) -> int:
     total_bytes = 0
     for compress_ratio in compress_ratios:
-        for attn_type in DEEPSEEK_V4_FULL_ATTENTION:
+        for attn_type in DEEPSEEK_V4_NON_SLIDING_ATTENTION:
             if compress_ratio_has_attention(compress_ratio, attn_type):
                 total_bytes += _get_attn_bytes_per_token(
                     head_dim,
@@ -780,7 +780,7 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
     def _get_quota_from_max_tokens(self, max_tokens: int) -> int:
         compress_ratios = [self._compress_ratios[layer] for layer in self.pp_layers]
         has_fp8_kv_cache = self.dtype == DataType.FP8
-        full_attn_size_per_token = _estimate_full_attn_size_per_token(
+        non_sliding_attn_size_per_token = _estimate_non_sliding_attn_size_per_token(
             self.head_dim,
             self.index_head_dim,
             compress_ratios,
@@ -820,7 +820,7 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
         )
         context_tokens = min(max_tokens, max_prefill_tokens)
         generation_quota = (
-            max_tokens * (full_attn_size_per_token + decode_swa_size_per_token)
+            max_tokens * (non_sliding_attn_size_per_token + decode_swa_size_per_token)
             + self.max_batch_size * decode_swa_size_per_request
         )
         context_overhead = context_tokens * prefill_swa_size_per_token
@@ -830,7 +830,7 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
     def _get_max_tokens_from_quota(self, quota: int) -> float:
         compress_ratios = [self._compress_ratios[layer] for layer in self.pp_layers]
         has_fp8_kv_cache = self.dtype == DataType.FP8
-        full_attn_size_per_token = _estimate_full_attn_size_per_token(
+        non_sliding_attn_size_per_token = _estimate_non_sliding_attn_size_per_token(
             self.head_dim,
             self.index_head_dim,
             compress_ratios,
@@ -852,7 +852,7 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
         size_per_request = self.max_batch_size * swa_size_per_request + padding
         if quota < size_per_request:
             return 0
-        size_per_token = full_attn_size_per_token + swa_size_per_token
+        size_per_token = non_sliding_attn_size_per_token + swa_size_per_token
         if size_per_token == 0:
             return float("inf")
         return (quota - size_per_request) / size_per_token
@@ -1162,7 +1162,7 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
         """Get the average cache bytes per token for DeepSeek-V4."""
         has_fp8_kv_cache = self.dtype == DataType.FP8
         compress_ratios = [self._compress_ratios[layer] for layer in self.pp_layers]
-        return _estimate_full_attn_size_per_token(
+        return _estimate_non_sliding_attn_size_per_token(
             self.head_dim,
             self.index_head_dim,
             compress_ratios,
@@ -1205,7 +1205,7 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
     def _get_cache_bytes_for_tokens(self, total_tokens: int, *, prefill: bool) -> int:
         has_fp8_kv_cache = self.dtype == DataType.FP8
         compress_ratios = [self._compress_ratios[layer] for layer in self.pp_layers]
-        full_attn_size_per_token = _estimate_full_attn_size_per_token(
+        non_sliding_attn_size_per_token = _estimate_non_sliding_attn_size_per_token(
             self.head_dim,
             self.index_head_dim,
             compress_ratios,
@@ -1224,7 +1224,8 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             indexer_k_dtype=self._indexer_k_dtype,
         )
         return int(
-            total_tokens * (full_attn_size_per_token + swa_size_per_token) + swa_size_per_request
+            total_tokens * (non_sliding_attn_size_per_token + swa_size_per_token)
+            + swa_size_per_request
         )
 
     def get_needed_resource_to_completion(self, request: llm_request.LlmRequest) -> int:
@@ -1475,7 +1476,7 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
         else:
             has_fp8_kv_cache = False
         indexer_k_dtype = model_config.sparse_attention_config.indexer_k_dtype
-        full_attn_size_per_token = _estimate_full_attn_size_per_token(
+        non_sliding_attn_size_per_token = _estimate_non_sliding_attn_size_per_token(
             head_dim,
             index_head_dim,
             compress_ratios,
@@ -1494,7 +1495,10 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             indexer_k_dtype=indexer_k_dtype,
         )
         max_batch_size = int(kwargs.get("max_batch_size") or 0)
-        return full_attn_size_per_token + swa_size_per_token, swa_size_per_request * max_batch_size
+        return (
+            non_sliding_attn_size_per_token + swa_size_per_token,
+            swa_size_per_request * max_batch_size,
+        )
 
     def check_invalid_values_in_kv_cache(self, fill_with_zero: bool = False) -> bool:
         some_checks_unavailable = False

--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
@@ -53,6 +53,7 @@ from tensorrt_llm.runtime.kv_cache_manager_v2._common import BAD_PAGE_INDEX
 
 from .compressor import KVCacheDtype
 from .deepseek_v4 import (
+    DEEPSEEK_V4_FULL_ATTENTION,
     DEEPSEEK_V4_SLIDING_ATTENTION,
     DEEPSEEK_V4_SPARSE_RATIO,
     DeepseekV4AttentionType,
@@ -67,28 +68,66 @@ from .deepseek_v4 import (
 DSV4_ENABLE_SWA_SCRATCH_REUSE_ENV = "TRTLLM_DSV4_ENABLE_SWA_SCRATCH_REUSE"
 
 
-def _estimate_bytes_per_token(
+def _estimate_full_attn_size_per_token(
     head_dim: int,
     index_head_dim: int,
     compress_ratios: List[int],
     has_fp8_kv_cache,
-    attn_types: set[DeepseekV4AttentionType] | None = None,
     indexer_k_dtype: str = "fp8",
 ) -> int:
     total_bytes = 0
-    for ratio in compress_ratios:
-        for attn in DeepseekV4AttentionType:
-            if attn_types is not None and attn not in attn_types:
-                continue
-            if compress_ratio_has_attention(ratio, attn):
+    for compress_ratio in compress_ratios:
+        for attn_type in DEEPSEEK_V4_FULL_ATTENTION:
+            if compress_ratio_has_attention(compress_ratio, attn_type):
                 total_bytes += _get_attn_bytes_per_token(
                     head_dim,
                     index_head_dim,
-                    ratio,
-                    attn,
+                    compress_ratio,
+                    attn_type,
                     has_fp8_kv_cache,
                     indexer_k_dtype=indexer_k_dtype,
                 )
+    return total_bytes
+
+
+def _estimate_swa_size_per_request(
+    head_dim: int,
+    index_head_dim: int,
+    compress_ratios: List[int],
+    has_fp8_kv_cache,
+    tokens_per_block: int | None,
+    swa_window_size: int | None,
+    indexer_k_dtype: str = "fp8",
+) -> int:
+    if tokens_per_block is None:
+        return 0
+
+    tokens_per_block = int(tokens_per_block)
+    total_bytes = 0
+    for compress_ratio in compress_ratios:
+        for attn_type in DEEPSEEK_V4_SLIDING_ATTENTION:
+            if not compress_ratio_has_attention(compress_ratio, attn_type):
+                continue
+            if attn_type == DeepseekV4AttentionType.SWA:
+                if swa_window_size is None:
+                    continue
+                window_size = swa_window_size
+            else:
+                state_factor = 2 if is_overlap_compressor(compress_ratio) else 1
+                window_size = state_factor * compress_ratio
+            if window_size <= 0:
+                continue
+            window_tokens = (
+                (int(window_size) + tokens_per_block - 1) // tokens_per_block
+            ) * tokens_per_block
+            total_bytes += window_tokens * _get_attn_bytes_per_token(
+                head_dim,
+                index_head_dim,
+                compress_ratio,
+                attn_type,
+                has_fp8_kv_cache,
+                indexer_k_dtype=indexer_k_dtype,
+            )
     return total_bytes
 
 
@@ -721,11 +760,62 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
             kv_cache.get_scratch_desc(pool_id),
         )
 
-    def _get_cache_quota(self, max_tokens: int) -> int:
-        quota = int(max_tokens * self.get_cache_bytes_per_token())
-        # Add extra quota to ensure sufficient space for small max_tokens cases.
-        quota += len(DeepseekV4AttentionType) * (2 << 20)
-        return quota
+    def _get_extra_quota_padding(self) -> int:
+        """Ensure each attention type has minimal space when max_tokens is small."""
+        return len(DeepseekV4AttentionType) * (2 << 20)
+
+    def _get_quota_from_max_tokens(self, max_tokens: int) -> int:
+        compress_ratios = [self._compress_ratios[layer] for layer in self.pp_layers]
+        has_fp8_kv_cache = self.dtype == DataType.FP8
+        full_attn_size_per_token = _estimate_full_attn_size_per_token(
+            self.head_dim,
+            self.index_head_dim,
+            compress_ratios,
+            has_fp8_kv_cache,
+            indexer_k_dtype=self._indexer_k_dtype,
+        )
+        swa_size_per_request = _estimate_swa_size_per_request(
+            self.head_dim,
+            self.index_head_dim,
+            compress_ratios,
+            has_fp8_kv_cache,
+            self.tokens_per_block,
+            self._swa_window_size,
+            indexer_k_dtype=self._indexer_k_dtype,
+        )
+        padding = self._get_extra_quota_padding()
+        return int(
+            max_tokens * full_attn_size_per_token
+            + self.max_batch_size * swa_size_per_request
+            + padding
+        )
+
+    def _get_max_tokens_from_quota(self, quota: int) -> float:
+        compress_ratios = [self._compress_ratios[layer] for layer in self.pp_layers]
+        has_fp8_kv_cache = self.dtype == DataType.FP8
+        full_attn_size_per_token = _estimate_full_attn_size_per_token(
+            self.head_dim,
+            self.index_head_dim,
+            compress_ratios,
+            has_fp8_kv_cache,
+            indexer_k_dtype=self._indexer_k_dtype,
+        )
+        swa_size_per_request = _estimate_swa_size_per_request(
+            self.head_dim,
+            self.index_head_dim,
+            compress_ratios,
+            has_fp8_kv_cache,
+            self.tokens_per_block,
+            self._swa_window_size,
+            indexer_k_dtype=self._indexer_k_dtype,
+        )
+        padding = self._get_extra_quota_padding()
+        intercept = self.max_batch_size * swa_size_per_request + padding
+        if quota < intercept:
+            return 0
+        if full_attn_size_per_token == 0:
+            return float("inf")
+        return (quota - intercept) / full_attn_size_per_token
 
     def _build_cache_config(
         self,
@@ -1032,7 +1122,7 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
         """Get the average cache bytes per token for DeepSeek-V4."""
         has_fp8_kv_cache = self.dtype == DataType.FP8
         compress_ratios = [self._compress_ratios[layer] for layer in self.pp_layers]
-        return _estimate_bytes_per_token(
+        return _estimate_full_attn_size_per_token(
             self.head_dim,
             self.index_head_dim,
             compress_ratios,
@@ -1064,33 +1154,34 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
     def _get_context_bytes(self, request: llm_request.LlmRequest) -> int:
         prompt_len = max(0, request.prompt_len)
         total_tokens = prompt_len + self.num_extra_kv_tokens
-        return total_tokens * self.get_cache_bytes_per_token()
+        return self._get_cache_bytes_for_tokens(total_tokens)
 
     def _get_generation_bytes(self, request: llm_request.LlmRequest) -> int:
         prompt_len = max(0, request.prompt_len)
         max_new_tokens = max(0, request.max_new_tokens)
         total_tokens = prompt_len + max_new_tokens + self.num_extra_kv_tokens
+        return self._get_cache_bytes_for_tokens(total_tokens)
+
+    def _get_cache_bytes_for_tokens(self, total_tokens: int) -> int:
         has_fp8_kv_cache = self.dtype == DataType.FP8
-        total_bytes = 0
-        for layer in self.pp_layers:
-            compress_ratio = self._compress_ratios[layer]
-            for attn_type in DeepseekV4AttentionType:
-                if not compress_ratio_has_attention(compress_ratio, attn_type):
-                    continue
-                token_bytes = _get_attn_bytes_per_token(
-                    self.head_dim,
-                    self.index_head_dim,
-                    compress_ratio,
-                    attn_type,
-                    has_fp8_kv_cache,
-                    indexer_k_dtype=self._indexer_k_dtype,
-                )
-                attn_tokens = total_tokens
-                window_size = self._get_window_size(compress_ratio, attn_type)
-                if window_size is not None:
-                    attn_tokens = window_size
-                total_bytes += attn_tokens * token_bytes
-        return total_bytes
+        compress_ratios = [self._compress_ratios[layer] for layer in self.pp_layers]
+        full_attn_size_per_token = _estimate_full_attn_size_per_token(
+            self.head_dim,
+            self.index_head_dim,
+            compress_ratios,
+            has_fp8_kv_cache,
+            indexer_k_dtype=self._indexer_k_dtype,
+        )
+        swa_size_per_request = _estimate_swa_size_per_request(
+            self.head_dim,
+            self.index_head_dim,
+            compress_ratios,
+            has_fp8_kv_cache,
+            self.tokens_per_block,
+            self._swa_window_size,
+            indexer_k_dtype=self._indexer_k_dtype,
+        )
+        return int(total_tokens * full_attn_size_per_token + swa_size_per_request)
 
     def get_needed_resource_to_completion(self, request: llm_request.LlmRequest) -> int:
         if self._is_generation_request(request):
@@ -1340,13 +1431,24 @@ class DeepseekV4CacheManager(KVCacheManagerV2):
         else:
             has_fp8_kv_cache = False
         indexer_k_dtype = model_config.sparse_attention_config.indexer_k_dtype
-        return _estimate_bytes_per_token(
+        full_attn_size_per_token = _estimate_full_attn_size_per_token(
             head_dim,
             index_head_dim,
             compress_ratios,
             has_fp8_kv_cache,
             indexer_k_dtype=indexer_k_dtype,
         )
+        swa_size_per_request = _estimate_swa_size_per_request(
+            head_dim,
+            index_head_dim,
+            compress_ratios,
+            has_fp8_kv_cache,
+            kwargs.get("tokens_per_block"),
+            getattr(model_config.sparse_attention_config, "window_size", None),
+            indexer_k_dtype=indexer_k_dtype,
+        )
+        max_batch_size = int(kwargs.get("max_batch_size") or 0)
+        return full_attn_size_per_token, swa_size_per_request * max_batch_size
 
     def check_invalid_values_in_kv_cache(self, fill_with_zero: bool = False) -> bool:
         some_checks_unavailable = False

--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/cache_manager.py
@@ -135,7 +135,7 @@ def _estimate_swa_cache_size(
             elif not scratch:
                 size_per_token += token_bytes
             else:
-                scratch_key = (int(window_size), token_bytes)
+                scratch_key = (attn_type, compress_ratio)
                 if scratch_key in scratch_keys:
                     size_per_request += window_tokens * token_bytes
                 else:

--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py
@@ -62,7 +62,7 @@ assert tuple(attn_type.value for attn_type in DEEPSEEK_V4_SLIDING_ATTENTION) == 
     range(len(DEEPSEEK_V4_SLIDING_ATTENTION))
 )
 
-DEEPSEEK_V4_FULL_ATTENTION = (
+DEEPSEEK_V4_NON_SLIDING_ATTENTION = (
     DeepseekV4AttentionType.COMPRESS,
     DeepseekV4AttentionType.INDEXER_COMPRESS,
 )

--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py
@@ -62,6 +62,11 @@ assert tuple(attn_type.value for attn_type in DEEPSEEK_V4_SLIDING_ATTENTION) == 
     range(len(DEEPSEEK_V4_SLIDING_ATTENTION))
 )
 
+DEEPSEEK_V4_FULL_ATTENTION = (
+    DeepseekV4AttentionType.COMPRESS,
+    DeepseekV4AttentionType.INDEXER_COMPRESS,
+)
+
 
 def is_overlap_compressor(compress_ratio: int) -> bool:
     """

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -102,9 +102,10 @@ def get_kv_cache_manager_cls(model_config: ModelConfig,
 # KVCacheManager.get_cache_size_per_token may return either an ``int``
 # (legacy proportional model ``bytes = slope * tokens``) or an affine
 # ``(slope, intercept)`` tuple (CppMambaHybridCacheManager, where mamba
-# state introduces a per-batch fixed cost).  CacheCost normalizes both
-# shapes so the rest of the file does plain attribute access and method
-# calls instead of branching on type.
+# state introduces a per-batch fixed cost).  KVCacheManagerV2 reports
+# sliding-window attention fixed cost in the tuple intercept.  CacheCost
+# normalizes the combined shape so the rest of the file does plain attribute
+# access and method calls instead of branching on type.
 
 
 @dataclasses.dataclass(frozen=True)
@@ -246,8 +247,10 @@ class KvCacheCreator:
                 model_config,
                 self._mapping,
                 tokens_per_block=self._tokens_per_block,
+                max_seq_len=self._max_seq_len,
                 max_batch_size=self._max_batch_size,
                 kv_cache_config=self._kv_cache_config,
+                spec_config=self._speculative_config,
                 **extra_kwargs))
 
     def _get_kv_size_per_token(self) -> CacheCost:

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -188,6 +188,7 @@ class KvCacheCreator:
         self._mapping = mapping
         self._kv_cache_config = kv_cache_config
         self._max_kv_tokens_in = self._kv_cache_config.max_tokens
+        self._max_gpu_total_bytes_in = self._kv_cache_config.max_gpu_total_bytes
         self._max_num_tokens = max_num_tokens
         self._max_beam_width = max_beam_width
         self._kv_connector_manager = kv_connector_manager
@@ -204,6 +205,8 @@ class KvCacheCreator:
         self._execution_stream = execution_stream
         self._kv_cache_manager_cls = self._get_model_kv_cache_manager_cls(
             model_engine)
+        self._is_kv_cache_manager_v2 = issubclass(self._kv_cache_manager_cls,
+                                                  KVCacheManagerV2)
         self._draft_config = draft_config
         self._skip_est = skip_est
 
@@ -490,7 +493,7 @@ class KvCacheCreator:
         # heterogeneous layer_types) uses MambaHybridCacheManager and would
         # have its max_tokens estimate inflated incorrectly otherwise.
         num_pool_groups = 1
-        if self._kv_cache_manager_cls == KVCacheManagerV2:
+        if self._is_kv_cache_manager_v2:
             model_cfg = self._model_engine.model.model_config.pretrained_config
             layer_types = getattr(model_cfg, "layer_types", None)
             if isinstance(layer_types, (list, tuple)):
@@ -503,18 +506,22 @@ class KvCacheCreator:
                     set(self._kv_cache_config.max_attention_window))
         num_cache_blocks *= num_pool_groups
 
-        free_mem, total_mem = torch.cuda.mem_get_info()
+        # Multiply by beam width, to prevent rescaling of the max_seq_len caused by the influence of beam width during the preparation for kv_cache_estimation
+        max_num_tokens_for_estimation = (
+            num_cache_blocks * self._tokens_per_block *
+            self._dummy_reqs[0].sampling_config.beam_width)
+        # V2 capacity is controlled by max_gpu_total_bytes; max_tokens only
+        # describes the dummy workload needed for estimation.
+        if self._is_kv_cache_manager_v2:
+            return max_num_tokens_for_estimation
+
+        free_mem, _ = torch.cuda.mem_get_info()
         max_memory = self._kv_cache_config.free_gpu_memory_fraction * free_mem
         kv_size_per_token = self._get_kv_size_per_token()
         max_num_tokens_in_memory = (
             kv_size_per_token.tokens_for_budget(max_memory) //
             self._tokens_per_block * self._tokens_per_block)
-
-        # Multiply by beam width, to prevent rescaling of the max_seq_len caused by the influence of beam width during the preparation for kv_cache_estimation
-        return min(
-            num_cache_blocks * self._tokens_per_block *
-            self._dummy_reqs[0].sampling_config.beam_width,
-            max_num_tokens_in_memory)
+        return min(max_num_tokens_for_estimation, max_num_tokens_in_memory)
 
     def try_prepare_estimation(self) -> bool:
         """Prepare for possible KV cache capacity estimation.
@@ -528,9 +535,20 @@ class KvCacheCreator:
         if 'cp_type' not in self._mapping.cp_config:
             estimating_kv_cache = True
             estimate_max_tokens = self._get_token_num_for_estimation()
-            self._kv_cache_config.max_tokens = min(
-                estimate_max_tokens, self._kv_cache_config.max_tokens
-            ) if self._kv_cache_config.max_tokens is not None else estimate_max_tokens
+            if self._is_kv_cache_manager_v2:
+                free_mem, _ = torch.cuda.mem_get_info()
+                max_gpu_total_bytes = int(
+                    self._kv_cache_config.free_gpu_memory_fraction * free_mem)
+                if (self._max_gpu_total_bytes_in is not None
+                        and self._max_gpu_total_bytes_in > 0):
+                    max_gpu_total_bytes = min(max_gpu_total_bytes,
+                                              self._max_gpu_total_bytes_in)
+                self._kv_cache_config.max_gpu_total_bytes = max_gpu_total_bytes
+                self._kv_cache_config.max_tokens = self._max_kv_tokens_in
+            else:
+                self._kv_cache_config.max_tokens = min(
+                    estimate_max_tokens, self._kv_cache_config.max_tokens
+                ) if self._kv_cache_config.max_tokens is not None else estimate_max_tokens
         model_config = self._model_engine.model.model_config
         if model_config.attn_backend == "VANILLA":
             logger.info(
@@ -642,7 +660,7 @@ class KvCacheCreator:
         # This leaves max_tokens as a user-defined constraint.
 
         # ---------------------------handle max_tokens---------------------------------
-        if issubclass(self._kv_cache_manager_cls, KVCacheManagerV2):
+        if self._is_kv_cache_manager_v2:
             # KVCacheManagerV2 doesn't rely on max_tokens to control capacity, so restore user provided value
             self._kv_cache_config.max_tokens = self._max_kv_tokens_in
         else:
@@ -673,11 +691,12 @@ class KvCacheCreator:
 
         # ---------------------------handle max_gpu_total_bytes---------------------------------
         # if user provided max_gpu_total_bytes, set max memory from max_gpu_total_bytes
-        if self._kv_cache_config.max_gpu_total_bytes > 0:
+        if (self._max_gpu_total_bytes_in is not None
+                and self._max_gpu_total_bytes_in > 0):
             kv_cache_max_memory = min(kv_cache_max_memory,
-                                      self._kv_cache_config.max_gpu_total_bytes)
+                                      self._max_gpu_total_bytes_in)
             logger.info(
-                f"max_gpu_total_bytes={self._kv_cache_config.max_gpu_total_bytes / (GB):.2f} GiB is provided. New max memory is {kv_cache_max_memory / (GB):.2f} GiB"
+                f"max_gpu_total_bytes={self._max_gpu_total_bytes_in / (GB):.2f} GiB is provided. New max memory is {kv_cache_max_memory / (GB):.2f} GiB"
             )
 
         logger.info(
@@ -946,13 +965,14 @@ class KvCacheCreator:
 
         # For V2 with separate one-model draft KV cache, split the total budget
         # between target and draft before creating either manager.
-        # Only split for the final managers, not during estimation — estimation
-        # uses max_tokens-based logic and must not have its config mutated.
+        # Only split for the final managers, not during estimation. Estimation
+        # uses a single temporary max_gpu_total_bytes budget for the target model
+        # and must not split that config between target and draft.
         # Two-model draft is excluded: V2 does not support two-model mode.
         draft_kv_cache_config = None
         if (not estimating_kv_cache
                 and self._should_create_separate_draft_kv_cache()
-                and issubclass(self._kv_cache_manager_cls, KVCacheManagerV2)):
+                and self._is_kv_cache_manager_v2):
             draft_kv_cache_config = self._split_kv_cache_budget_for_draft()
 
         # Also split for V1 VSWA. The VSWA pool is sized directly from
@@ -965,7 +985,7 @@ class KvCacheCreator:
             or self._should_create_separate_draft_kv_cache())  # one-model
         if (not estimating_kv_cache and has_draft
                 and draft_kv_cache_config is None
-                and not issubclass(self._kv_cache_manager_cls, KVCacheManagerV2)
+                and not self._is_kv_cache_manager_v2
                 and is_vswa_enabled(self._kv_cache_config)):
             draft_kv_cache_config = self._split_kv_cache_budget_for_draft()
 
@@ -980,7 +1000,7 @@ class KvCacheCreator:
 
         # Two-model speculative decoding: draft model has separate engine
         if self._draft_model_engine is not None:
-            if issubclass(self._kv_cache_manager_cls, KVCacheManagerV2):
+            if self._is_kv_cache_manager_v2:
                 assert draft_kv_cache_config is None, (
                     "KVCacheManagerV2 does not support two-model speculative "
                     "decoding with separate draft KV cache budget splitting.")

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -1884,7 +1884,7 @@ def _estimate_full_attn_size_per_token(
 
 def _estimate_swa_cache_size(layer_sizes: Sequence[int],
                              attention_windows: Sequence[Optional[int]],
-                             tokens_per_block: int, *, prefill: bool,
+                             tokens_per_block: int, *, context: bool,
                              scratch: bool) -> Tuple[int, int]:
     tokens_per_block = int(tokens_per_block)
     size_per_token = 0
@@ -1894,7 +1894,7 @@ def _estimate_swa_cache_size(layer_sizes: Sequence[int],
         if window_size is not None and window_size > 0:
             window_tokens = math.ceil(
                 window_size / tokens_per_block) * tokens_per_block
-            if not prefill:
+            if not context:
                 size_per_request += window_tokens * layer_size
             elif not scratch:
                 size_per_token += layer_size
@@ -2377,19 +2377,35 @@ class KVCacheManagerV2(BaseResourceManager):
         )
         full_attn_size_per_token = _estimate_full_attn_size_per_token(
             layer_sizes, attention_windows)
-        swa_size_per_token, swa_size_per_request = _estimate_swa_cache_size(
+        context_swa_size_per_token, _ = _estimate_swa_cache_size(
             layer_sizes,
             attention_windows,
             self.tokens_per_block,
-            prefill=True,
-            scratch=getattr(self, "enable_swa_scratch_reuse", False))
-        size_per_request = self.max_batch_size * swa_size_per_request
-        if quota < size_per_request:
+            context=True,
+            scratch=self.enable_swa_scratch_reuse)
+        (
+            generation_swa_size_per_token,
+            generation_swa_size_per_request,
+        ) = _estimate_swa_cache_size(layer_sizes,
+                                     attention_windows,
+                                     self.tokens_per_block,
+                                     context=False,
+                                     scratch=False)
+        size_per_batch = self.max_batch_size * generation_swa_size_per_request
+        if quota < size_per_batch:
             return 0
-        size_per_token = full_attn_size_per_token + swa_size_per_token
-        if size_per_token <= 0:
+        context_size_per_token = full_attn_size_per_token + context_swa_size_per_token
+        context_limit_quota = self.max_num_tokens * context_size_per_token + size_per_batch
+        if quota <= context_limit_quota:
+            if context_size_per_token <= 0:
+                return float('inf')
+            return (quota - size_per_batch) / context_size_per_token
+
+        generation_size_per_token = full_attn_size_per_token + generation_swa_size_per_token
+        if generation_size_per_token <= 0:
             return float('inf')
-        return (quota - size_per_request) / size_per_token
+        return self.max_num_tokens + (
+            quota - context_limit_quota) / generation_size_per_token
 
     def _get_quota_from_max_tokens(self, max_tokens: int) -> int:
         layer_sizes, attention_windows = self._get_runtime_cache_size_layer_components(
@@ -2397,30 +2413,29 @@ class KVCacheManagerV2(BaseResourceManager):
         full_attn_size_per_token = _estimate_full_attn_size_per_token(
             layer_sizes, attention_windows)
         (
-            prefill_swa_size_per_token,
+            context_swa_size_per_token,
             _,
         ) = _estimate_swa_cache_size(layer_sizes,
                                      attention_windows,
                                      self.tokens_per_block,
-                                     prefill=True,
-                                     scratch=getattr(
-                                         self, "enable_swa_scratch_reuse",
-                                         False))
+                                     context=True,
+                                     scratch=self.enable_swa_scratch_reuse)
         (
-            decode_swa_size_per_token,
-            decode_swa_size_per_request,
+            generation_swa_size_per_token,
+            generation_swa_size_per_request,
         ) = _estimate_swa_cache_size(layer_sizes,
                                      attention_windows,
                                      self.tokens_per_block,
-                                     prefill=False,
+                                     context=False,
                                      scratch=False)
         context_tokens = min(max_tokens, self.max_num_tokens)
+        generation_tokens = max_tokens - context_tokens
         generation_quota = (
-            max_tokens *
-            (full_attn_size_per_token + decode_swa_size_per_token) +
-            self.max_batch_size * decode_swa_size_per_request)
-        context_overhead = context_tokens * prefill_swa_size_per_token
-        return int(generation_quota + context_overhead)
+            max_tokens * full_attn_size_per_token +
+            generation_tokens * generation_swa_size_per_token +
+            self.max_batch_size * generation_swa_size_per_request)
+        context_extra_quota = context_tokens * context_swa_size_per_token
+        return int(generation_quota + context_extra_quota)
 
     def _get_event_num_blocks_per_cache_level(
         self,
@@ -3913,7 +3928,7 @@ class KVCacheManagerV2(BaseResourceManager):
             layer_sizes,
             attention_windows,
             kwargs["tokens_per_block"],
-            prefill=False,
+            context=False,
             scratch=False)
         max_batch_size = int(kwargs.get("max_batch_size") or 0)
         return (full_attn_size_per_token + swa_size_per_token,

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -2038,6 +2038,7 @@ class KVCacheManagerV2(BaseResourceManager):
         self.tokens_per_block = tokens_per_block
         self.max_seq_len = max_seq_len
         self.max_batch_size = max_batch_size
+        self.max_num_tokens = max_num_tokens
         self.kv_factor = 1 if kv_cache_type == CacheTypeCpp.SELFKONLY else 2
         from ..speculative import get_num_extra_kv_tokens
         self.num_extra_kv_tokens = get_num_extra_kv_tokens(spec_config)
@@ -2395,15 +2396,31 @@ class KVCacheManagerV2(BaseResourceManager):
         )
         full_attn_size_per_token = _estimate_full_attn_size_per_token(
             layer_sizes, attention_windows)
-        swa_size_per_token, swa_size_per_request = _estimate_swa_cache_size(
-            layer_sizes,
-            attention_windows,
-            self.tokens_per_block,
-            prefill=True,
-            scratch=getattr(self, "enable_swa_scratch_reuse", False))
-        return int(max_tokens *
-                   (full_attn_size_per_token + swa_size_per_token) +
-                   self.max_batch_size * swa_size_per_request)
+        (
+            prefill_swa_size_per_token,
+            _,
+        ) = _estimate_swa_cache_size(layer_sizes,
+                                     attention_windows,
+                                     self.tokens_per_block,
+                                     prefill=True,
+                                     scratch=getattr(
+                                         self, "enable_swa_scratch_reuse",
+                                         False))
+        (
+            decode_swa_size_per_token,
+            decode_swa_size_per_request,
+        ) = _estimate_swa_cache_size(layer_sizes,
+                                     attention_windows,
+                                     self.tokens_per_block,
+                                     prefill=False,
+                                     scratch=False)
+        context_tokens = min(max_tokens, self.max_num_tokens)
+        generation_quota = (
+            max_tokens *
+            (full_attn_size_per_token + decode_swa_size_per_token) +
+            self.max_batch_size * decode_swa_size_per_request)
+        context_overhead = context_tokens * prefill_swa_size_per_token
+        return int(generation_quota + context_overhead)
 
     def _get_event_num_blocks_per_cache_level(
         self,
@@ -3896,9 +3913,8 @@ class KVCacheManagerV2(BaseResourceManager):
             layer_sizes,
             attention_windows,
             kwargs["tokens_per_block"],
-            prefill=True,
-            scratch=kwargs.get("enable_swa_scratch_reuse", False)
-            and not kwargs.get("is_draft", False))
+            prefill=False,
+            scratch=False)
         max_batch_size = int(kwargs.get("max_batch_size") or 0)
         return (full_attn_size_per_token + swa_size_per_token,
                 swa_size_per_request * max_batch_size)

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -1882,20 +1882,30 @@ def _estimate_full_attn_size_per_token(
         if window_size is None or window_size <= 0)
 
 
-def _estimate_swa_size_per_request(layer_sizes: Sequence[int],
-                                   attention_windows: Sequence[Optional[int]],
-                                   tokens_per_block: Optional[int]) -> int:
-    if tokens_per_block is None:
-        return 0
-
+def _estimate_swa_cache_size(layer_sizes: Sequence[int],
+                             attention_windows: Sequence[Optional[int]],
+                             tokens_per_block: int, *, prefill: bool,
+                             scratch: bool) -> Tuple[int, int]:
     tokens_per_block = int(tokens_per_block)
-    swa_size_per_request = 0
+    size_per_token = 0
+    size_per_request = 0
+    scratch_keys = set()
     for layer_size, window_size in zip(layer_sizes, attention_windows):
         if window_size is not None and window_size > 0:
             window_tokens = math.ceil(
                 window_size / tokens_per_block) * tokens_per_block
-            swa_size_per_request += window_tokens * layer_size
-    return swa_size_per_request
+            if not prefill:
+                size_per_request += window_tokens * layer_size
+            elif not scratch:
+                size_per_token += layer_size
+            else:
+                scratch_key = (int(window_size), layer_size)
+                if scratch_key in scratch_keys:
+                    size_per_request += window_tokens * layer_size
+                else:
+                    scratch_keys.add(scratch_key)
+                    size_per_token += layer_size
+    return size_per_token, size_per_request
 
 
 def _get_static_cache_size_layer_components(
@@ -2366,23 +2376,33 @@ class KVCacheManagerV2(BaseResourceManager):
         )
         full_attn_size_per_token = _estimate_full_attn_size_per_token(
             layer_sizes, attention_windows)
-        swa_size_per_request = _estimate_swa_size_per_request(
-            layer_sizes, attention_windows, self.tokens_per_block)
-        intercept = self.max_batch_size * swa_size_per_request
-        if quota < intercept:
+        swa_size_per_token, swa_size_per_request = _estimate_swa_cache_size(
+            layer_sizes,
+            attention_windows,
+            self.tokens_per_block,
+            prefill=True,
+            scratch=getattr(self, "enable_swa_scratch_reuse", False))
+        size_per_request = self.max_batch_size * swa_size_per_request
+        if quota < size_per_request:
             return 0
-        if full_attn_size_per_token <= 0:
+        size_per_token = full_attn_size_per_token + swa_size_per_token
+        if size_per_token <= 0:
             return float('inf')
-        return (quota - intercept) / full_attn_size_per_token
+        return (quota - size_per_request) / size_per_token
 
     def _get_quota_from_max_tokens(self, max_tokens: int) -> int:
         layer_sizes, attention_windows = self._get_runtime_cache_size_layer_components(
         )
         full_attn_size_per_token = _estimate_full_attn_size_per_token(
             layer_sizes, attention_windows)
-        swa_size_per_request = _estimate_swa_size_per_request(
-            layer_sizes, attention_windows, self.tokens_per_block)
-        return int(max_tokens * full_attn_size_per_token +
+        swa_size_per_token, swa_size_per_request = _estimate_swa_cache_size(
+            layer_sizes,
+            attention_windows,
+            self.tokens_per_block,
+            prefill=True,
+            scratch=getattr(self, "enable_swa_scratch_reuse", False))
+        return int(max_tokens *
+                   (full_attn_size_per_token + swa_size_per_token) +
                    self.max_batch_size * swa_size_per_request)
 
     def _get_event_num_blocks_per_cache_level(
@@ -3870,12 +3890,18 @@ class KVCacheManagerV2(BaseResourceManager):
                                  **kwargs):
         layer_sizes, attention_windows = _get_static_cache_size_layer_components(
             model_config, mapping, num_layers=num_layers, **kwargs)
-        slope = _estimate_full_attn_size_per_token(layer_sizes,
-                                                   attention_windows)
-        swa_size_per_request = _estimate_swa_size_per_request(
-            layer_sizes, attention_windows, kwargs.get("tokens_per_block"))
+        full_attn_size_per_token = _estimate_full_attn_size_per_token(
+            layer_sizes, attention_windows)
+        swa_size_per_token, swa_size_per_request = _estimate_swa_cache_size(
+            layer_sizes,
+            attention_windows,
+            kwargs["tokens_per_block"],
+            prefill=True,
+            scratch=kwargs.get("enable_swa_scratch_reuse", False)
+            and not kwargs.get("is_draft", False))
         max_batch_size = int(kwargs.get("max_batch_size") or 0)
-        return slope, swa_size_per_request * max_batch_size
+        return (full_attn_size_per_token + swa_size_per_token,
+                swa_size_per_request * max_batch_size)
 
     def update_context_resources(self, scheduled_batch: ScheduledRequests):
         """Update KV cache for context requests in the current batch.

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -1873,6 +1873,96 @@ class KVCacheManager(BaseResourceManager):
         self.impl.reset_reuse_state()
 
 
+def _estimate_full_attn_size_per_token(
+        layer_sizes: Sequence[int],
+        attention_windows: Sequence[Optional[int]]) -> int:
+    return sum(
+        layer_size
+        for layer_size, window_size in zip(layer_sizes, attention_windows)
+        if window_size is None or window_size <= 0)
+
+
+def _estimate_swa_size_per_request(layer_sizes: Sequence[int],
+                                   attention_windows: Sequence[Optional[int]],
+                                   tokens_per_block: Optional[int]) -> int:
+    if tokens_per_block is None:
+        return 0
+
+    tokens_per_block = int(tokens_per_block)
+    swa_size_per_request = 0
+    for layer_size, window_size in zip(layer_sizes, attention_windows):
+        if window_size is not None and window_size > 0:
+            window_tokens = math.ceil(
+                window_size / tokens_per_block) * tokens_per_block
+            swa_size_per_request += window_tokens * layer_size
+    return swa_size_per_request
+
+
+def _get_static_cache_size_layer_components(
+        model_config: ModelConfigPython,
+        mapping: Mapping,
+        num_layers: Optional[int] = None,
+        **kwargs) -> Tuple[List[int], List[Optional[int]]]:
+    config = model_config.pretrained_config
+    max_seq_len = kwargs.get("max_seq_len")
+    kv_cache_config = kwargs.get("kv_cache_config")
+
+    num_key_value_heads = getattr(config, 'num_key_value_heads',
+                                  config.num_attention_heads)
+    if isinstance(num_key_value_heads, Iterable):
+        num_key_value_heads = sum(num_key_value_heads) / len(
+            num_key_value_heads)
+
+    mla = hasattr(config, "kv_lora_rank") and config.kv_lora_rank is not None
+    if mla:
+        head_dim = config.kv_lora_rank + config.qk_rope_head_dim
+        kv_factor = 1
+    else:
+        tp_size = 1 if mapping.enable_attention_dp else mapping.tp_size
+        head_dim = getattr(config, "head_dim", None)
+        if not isinstance(head_dim, int):
+            head_dim = config.hidden_size // config.num_attention_heads
+        head_dim = head_dim * num_key_value_heads // tp_size
+        kv_factor = 2
+
+    cache_size_per_token = kv_factor * head_dim
+    quant_config = model_config.quant_config
+    if quant_config is not None and quant_config.quant_mode.has_fp8_kv_cache():
+        layer_size = cache_size_per_token
+    elif quant_config is not None and quant_config.quant_mode.has_fp4_kv_cache(
+    ):
+        layer_size = (math.ceil(cache_size_per_token / 2) +
+                      math.ceil(cache_size_per_token / 16))
+    else:
+        assert quant_config is None or (
+            not quant_config.quant_mode.has_kv_cache_quant()
+        ), "Quantized kv cache is not expected"
+        layer_size = cache_size_per_token * 2
+
+    num_attention_layers = KVCacheManager._resolve_num_attention_layers(
+        model_config, mapping, num_layers)
+    layer_sizes = [layer_size] * num_attention_layers
+    window_pattern = (kv_cache_config.max_attention_window
+                      if kv_cache_config is not None else None)
+
+    def get_window_size(layer_idx: int) -> Optional[int]:
+        if window_pattern is None or not isinstance(window_pattern,
+                                                    (list, tuple)):
+            return None
+        window_size = window_pattern[layer_idx % len(window_pattern)]
+        if window_size is None or window_size <= 0:
+            return None
+        window_size = int(window_size)
+        if max_seq_len is not None and window_size == int(max_seq_len):
+            return None
+        return window_size
+
+    attention_windows = [
+        get_window_size(layer_idx) for layer_idx in range(num_attention_layers)
+    ]
+    return layer_sizes, attention_windows
+
+
 class KVCacheManagerV2(BaseResourceManager):
 
     def __init__(
@@ -2073,10 +2163,12 @@ class KVCacheManagerV2(BaseResourceManager):
         # bytes_per_token varies across PP ranks (different local layers).
         if mapping.world_size > 1:
             dist = Distributed.get(mapping)
-            bytes_per_token = self.get_cache_bytes_per_token()
-            max_tokens = quota / bytes_per_token
+            max_tokens = self._get_max_tokens_from_quota(quota)
             max_tokens = dist.allreduce(max_tokens, op=ReduceOp.MIN)
-            quota = max_tokens * bytes_per_token
+            # inf max_tokens means all layers are swa and in all ranks quota can fit all swa cache
+            # in this case, we dont have to modify quota
+            if not math.isinf(max_tokens):
+                quota = self._get_quota_from_max_tokens(max_tokens)
 
         logger.info(
             f"KV cache manager v2 device quota set to {quota / (1 << 30)}GiB")
@@ -2255,8 +2347,43 @@ class KVCacheManagerV2(BaseResourceManager):
 
         self._log_kv_cache_pool_lifecycle_mapping()
 
+    def _get_runtime_cache_size_layer_components(
+            self) -> Tuple[List[int], List[Optional[int]]]:
+        layer_sizes = []
+        attention_windows = []
+        pattern_len = len(self.max_attention_window_vec)
+        for local_layer_idx in range(self.num_local_layers):
+            layer_sizes.append(
+                self.get_layer_bytes_per_token(local_layer_idx=local_layer_idx,
+                                               data_role=Role.ALL))
+            attention_windows.append(
+                self.max_attention_window_vec[self.pp_layers[local_layer_idx] %
+                                              pattern_len])
+        return layer_sizes, attention_windows
+
+    def _get_max_tokens_from_quota(self, quota: int) -> float:
+        layer_sizes, attention_windows = self._get_runtime_cache_size_layer_components(
+        )
+        full_attn_size_per_token = _estimate_full_attn_size_per_token(
+            layer_sizes, attention_windows)
+        swa_size_per_request = _estimate_swa_size_per_request(
+            layer_sizes, attention_windows, self.tokens_per_block)
+        intercept = self.max_batch_size * swa_size_per_request
+        if quota < intercept:
+            return 0
+        if full_attn_size_per_token <= 0:
+            return float('inf')
+        return (quota - intercept) / full_attn_size_per_token
+
     def _get_quota_from_max_tokens(self, max_tokens: int) -> int:
-        return int(max_tokens * self.get_cache_bytes_per_token())
+        layer_sizes, attention_windows = self._get_runtime_cache_size_layer_components(
+        )
+        full_attn_size_per_token = _estimate_full_attn_size_per_token(
+            layer_sizes, attention_windows)
+        swa_size_per_request = _estimate_swa_size_per_request(
+            layer_sizes, attention_windows, self.tokens_per_block)
+        return int(max_tokens * full_attn_size_per_token +
+                   self.max_batch_size * swa_size_per_request)
 
     def _get_event_num_blocks_per_cache_level(
         self,
@@ -3741,42 +3868,14 @@ class KVCacheManagerV2(BaseResourceManager):
                                  mapping: Mapping,
                                  num_layers: Optional[int] = None,
                                  **kwargs):
-        # get kv cache dtype bytes
-        mem_per_token = 2
-        quant_config = model_config.quant_config
-        if quant_config is not None and quant_config.quant_mode.has_fp8_kv_cache(
-        ):
-            mem_per_token = 1
-
-        # get num key value heads
-        config = model_config.pretrained_config
-        num_key_value_heads = getattr(config, 'num_key_value_heads',
-                                      config.num_attention_heads)
-        if isinstance(num_key_value_heads, Iterable):
-            num_key_value_heads = sum(num_key_value_heads) / len(
-                num_key_value_heads)
-
-        # get head dim
-        mla = hasattr(config,
-                      "kv_lora_rank") and config.kv_lora_rank is not None
-        if mla:
-            head_dim = config.kv_lora_rank + config.qk_rope_head_dim
-            kv_factor = 1
-        else:
-            tp_size = 1 if mapping.enable_attention_dp else mapping.tp_size
-            head_dim = getattr(config, "head_dim", None)
-            if not isinstance(head_dim, int):
-                head_dim = config.hidden_size // config.num_attention_heads
-            head_dim = head_dim * num_key_value_heads // tp_size
-            kv_factor = 2
-
-        num_attention_layers = KVCacheManager._resolve_num_attention_layers(
-            model_config, mapping, num_layers)
-        mem_per_token *= num_attention_layers * head_dim
-
-        # K and V
-        mem_per_token *= kv_factor
-        return mem_per_token
+        layer_sizes, attention_windows = _get_static_cache_size_layer_components(
+            model_config, mapping, num_layers=num_layers, **kwargs)
+        slope = _estimate_full_attn_size_per_token(layer_sizes,
+                                                   attention_windows)
+        swa_size_per_request = _estimate_swa_size_per_request(
+            layer_sizes, attention_windows, kwargs.get("tokens_per_block"))
+        max_batch_size = int(kwargs.get("max_batch_size") or 0)
+        return slope, swa_size_per_request * max_batch_size
 
     def update_context_resources(self, scheduled_batch: ScheduledRequests):
         """Update KV cache for context requests in the current batch.

--- a/tests/integration/defs/accuracy/test_disaggregated_serving.py
+++ b/tests/integration/defs/accuracy/test_disaggregated_serving.py
@@ -54,6 +54,7 @@ DEFAULT_TEST_TIMEOUT = 3600
 DEFAULT_SERVER_WAITING_TIMEOUT = 2100
 # Timeout for the accuracy evaluation
 DEFAULT_ACC_EVALUATION_TIMEOUT = 1500
+DEEPSEEKV4_TEST_MAX_BATCH_SIZE = 128
 
 
 @functools.lru_cache(maxsize=1)
@@ -2326,6 +2327,7 @@ class TestDeepSeekV4Flash(LlmapiAccuracyTestHarness):
             "tensor_parallel_size": 2,
             "moe_expert_parallel_size": 2,
             "disable_overlap_scheduler": True,
+            "max_batch_size": DEEPSEEKV4_TEST_MAX_BATCH_SIZE,
             "max_seq_len": 4096,
             "kv_cache_config": {
                 "free_gpu_memory_fraction": 0.5,
@@ -2337,6 +2339,7 @@ class TestDeepSeekV4Flash(LlmapiAccuracyTestHarness):
             "moe_expert_parallel_size": 2,
             "enable_attention_dp": True,
             "disable_overlap_scheduler": True,
+            "max_batch_size": DEEPSEEKV4_TEST_MAX_BATCH_SIZE,
             "max_seq_len": 4096,
             "moe_config": {
                 "backend": "TRTLLM",
@@ -2377,6 +2380,7 @@ class TestDeepSeekV4Flash(LlmapiAccuracyTestHarness):
             "tensor_parallel_size": 2,
             "moe_expert_parallel_size": 2,
             "disable_overlap_scheduler": True,
+            "max_batch_size": DEEPSEEKV4_TEST_MAX_BATCH_SIZE,
             "max_seq_len": 4096,
             "kv_cache_config": {
                 "free_gpu_memory_fraction": 0.5,
@@ -2388,6 +2392,7 @@ class TestDeepSeekV4Flash(LlmapiAccuracyTestHarness):
             "moe_expert_parallel_size": 2,
             "enable_attention_dp": True,
             "disable_overlap_scheduler": True,
+            "max_batch_size": DEEPSEEKV4_TEST_MAX_BATCH_SIZE,
             "max_seq_len": 4096,
             "moe_config": {
                 "backend": "TRTLLM",
@@ -2455,7 +2460,7 @@ class TestDeepSeekV4FlashBase(LlmapiAccuracyTestHarness):
             "moe_expert_parallel_size": 2,
             "enable_attention_dp": True,
             "disable_overlap_scheduler": True,
-            "max_batch_size": 16,
+            "max_batch_size": DEEPSEEKV4_TEST_MAX_BATCH_SIZE,
             "max_num_tokens": 4096,
             "max_seq_len": 4096,
             "moe_config": {

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -3724,6 +3724,9 @@ def _make_deepseekv4_eplb_config(model_path, layer_updates_per_iter, ep_size=8):
         layer_updates_per_iter=0)
 
 
+DEEPSEEKV4_TEST_MAX_BATCH_SIZE = 128
+
+
 def _run_deepseekv4_eplb(model_name,
                          model_path,
                          moe_backend,
@@ -3745,6 +3748,7 @@ def _run_deepseekv4_eplb(model_name,
              moe_expert_parallel_size=tensor_parallel_size,
              kv_cache_config=kv_cache_config,
              enable_attention_dp=True,
+             max_batch_size=DEEPSEEKV4_TEST_MAX_BATCH_SIZE,
              max_seq_len=4096,
              **pytorch_config,
              speculative_config=mtp_config) as llm:
@@ -3772,6 +3776,7 @@ class TestDeepSeekV4Flash(LlmapiAccuracyTestHarness):
                  moe_expert_parallel_size=4,
                  moe_config=MoeConfig(backend="TRTLLM"),
                  enable_attention_dp=True,
+                 max_batch_size=DEEPSEEKV4_TEST_MAX_BATCH_SIZE,
                  max_seq_len=4096,
                  kv_cache_config=kv_cache_config) as llm:
             task = MMLU(self.MODEL_NAME)
@@ -3842,6 +3847,7 @@ class TestDeepSeekV4FlashBase(LlmapiAccuracyTestHarness):
                  moe_expert_parallel_size=4,
                  moe_config=MoeConfig(backend=moe_backend),
                  enable_attention_dp=True,
+                 max_batch_size=DEEPSEEKV4_TEST_MAX_BATCH_SIZE,
                  max_seq_len=4096,
                  kv_cache_config=kv_cache_config) as llm:
             task = MMLU(self.MODEL_NAME)
@@ -3858,11 +3864,12 @@ class TestDeepSeekV4FlashBase(LlmapiAccuracyTestHarness):
                  tensor_parallel_size=4,
                  moe_expert_parallel_size=4,
                  moe_config=MoeConfig(backend="WIDEEP"),
-                 cuda_graph_config=CudaGraphConfig(max_batch_size=16,
-                                                   enable_padding=True),
+                 cuda_graph_config=CudaGraphConfig(
+                     max_batch_size=DEEPSEEKV4_TEST_MAX_BATCH_SIZE,
+                     enable_padding=True),
                  enable_attention_dp=True,
                  enable_chunked_prefill=True,
-                 max_batch_size=16,
+                 max_batch_size=DEEPSEEKV4_TEST_MAX_BATCH_SIZE,
                  max_num_tokens=128,
                  max_seq_len=4096,
                  kv_cache_config=kv_cache_config) as llm:

--- a/tests/unittest/_torch/attention/sparse/deepseek_v4/test_compressor_module.py
+++ b/tests/unittest/_torch/attention/sparse/deepseek_v4/test_compressor_module.py
@@ -790,7 +790,7 @@ class CompressorWrapper:
             dtype=cache_dtype,
             compressor_dtype=DataType.FLOAT,  # State caches always use FP32
             vocab_size=self.VOCAB_SIZE,
-            max_num_tokens=MAX_SEQ + MAX_BATCH,
+            max_num_tokens=MAX_SEQ * MAX_BATCH,
             sparse_attn_config=sparse_attn_config,
         )
 

--- a/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
+++ b/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
@@ -60,6 +60,7 @@ def test_cache_size_estimation_uses_model_attention_layer_count():
     size_per_token = DeepseekV4CacheManager.get_cache_size_per_token(
         FakeModelConfig(),
         Mapping(world_size=1, rank=0, tp_size=1, pp_size=1),
+        tokens_per_block=128,
         is_disagg=True,
     )
 
@@ -68,7 +69,7 @@ def test_cache_size_estimation_uses_model_attention_layer_count():
     assert cost.intercept == 0
 
 
-def test_cache_size_estimation_returns_swa_fixed_cost_as_intercept():
+def test_cache_size_estimation_models_prefill_swa_scratch(monkeypatch):
     class FakeModelConfig:
         sparse_attention_config = SimpleNamespace(
             index_head_dim=128,
@@ -85,6 +86,7 @@ def test_cache_size_estimation_returns_swa_fixed_cost_as_intercept():
         def get_num_attention_layers(self) -> int:
             return len(self.sparse_attention_config.compress_ratios)
 
+    monkeypatch.setenv(DSV4_ENABLE_SWA_SCRATCH_REUSE_ENV, "1")
     size_per_token = DeepseekV4CacheManager.get_cache_size_per_token(
         FakeModelConfig(),
         Mapping(world_size=1, rank=0, tp_size=1, pp_size=1),
@@ -99,13 +101,24 @@ def test_cache_size_estimation_returns_swa_fixed_cost_as_intercept():
         max_batch_size=2,
     )
 
-    cost = CacheCost.from_raw(size_per_token)
-    assert cost.slope == 0
-    assert cost.intercept > 0
-    assert CacheCost.from_raw(short_seq_size_per_token) == cost
+    scratch_cost = CacheCost.from_raw(size_per_token)
+    assert scratch_cost.slope > 0
+    assert scratch_cost.intercept == 2 * 128 * scratch_cost.slope
+    assert CacheCost.from_raw(short_seq_size_per_token) == scratch_cost
+
+    monkeypatch.setenv(DSV4_ENABLE_SWA_SCRATCH_REUSE_ENV, "0")
+    no_scratch_size_per_token = DeepseekV4CacheManager.get_cache_size_per_token(
+        FakeModelConfig(),
+        Mapping(world_size=1, rank=0, tp_size=1, pp_size=1),
+        tokens_per_block=128,
+        max_batch_size=2,
+    )
+    no_scratch_cost = CacheCost.from_raw(no_scratch_size_per_token)
+    assert no_scratch_cost.slope == 2 * scratch_cost.slope
+    assert no_scratch_cost.intercept == 0
 
 
-def test_quota_from_max_tokens_models_swa_as_fixed_cost():
+def test_quota_from_max_tokens_models_prefill_swa_scratch():
     manager = object.__new__(DeepseekV4CacheManager)
     manager.pp_layers = [0, 1]
     manager._compress_ratios = [1, 1]
@@ -118,15 +131,27 @@ def test_quota_from_max_tokens_models_swa_as_fixed_cost():
     manager.tokens_per_block = 128
     manager.max_batch_size = 2
 
+    manager.enable_swa_scratch_reuse = True
     small_quota = manager._get_quota_from_max_tokens(1)
     large_quota = manager._get_quota_from_max_tokens(4096)
+    scratch_delta = large_quota - small_quota
 
-    assert small_quota == large_quota
+    assert small_quota < large_quota
     assert small_quota > manager._get_extra_quota_padding()
-    assert manager._get_max_tokens_from_quota(small_quota) == float("inf")
+    assert manager._get_max_tokens_from_quota(small_quota) == 1
+    assert manager._get_max_tokens_from_quota(large_quota) == 4096
+
+    manager.enable_swa_scratch_reuse = False
+    no_scratch_small_quota = manager._get_quota_from_max_tokens(1)
+    no_scratch_large_quota = manager._get_quota_from_max_tokens(4096)
+    no_scratch_delta = no_scratch_large_quota - no_scratch_small_quota
+
+    assert no_scratch_small_quota < no_scratch_large_quota
+    assert no_scratch_delta == 2 * scratch_delta
+    assert manager._get_max_tokens_from_quota(no_scratch_large_quota) == 4096
 
 
-def test_needed_resource_uses_full_slope_and_fixed_swa_cost():
+def test_needed_resource_uses_prefill_swa_scratch_slope():
     manager = object.__new__(DeepseekV4CacheManager)
     manager.pp_layers = [0, 1]
     manager._compress_ratios = [4, 4]
@@ -137,6 +162,7 @@ def test_needed_resource_uses_full_slope_and_fixed_swa_cost():
     manager._swa_window_size = 128
     manager.tokens_per_block = 128
     manager.num_extra_kv_tokens = 0
+    manager.enable_swa_scratch_reuse = True
 
     context_request = SimpleNamespace(
         is_context_init_state=True,
@@ -145,6 +171,15 @@ def test_needed_resource_uses_full_slope_and_fixed_swa_cost():
         is_disagg_generation_init_state=False,
         state=LlmRequestState.CONTEXT_INIT,
         prompt_len=10,
+        max_new_tokens=100,
+    )
+    longer_context_request = SimpleNamespace(
+        is_context_init_state=True,
+        is_generation_in_progress_state=False,
+        is_generation_to_complete_state=False,
+        is_disagg_generation_init_state=False,
+        state=LlmRequestState.CONTEXT_INIT,
+        prompt_len=11,
         max_new_tokens=100,
     )
     generation_request = SimpleNamespace(
@@ -156,16 +191,26 @@ def test_needed_resource_uses_full_slope_and_fixed_swa_cost():
         prompt_len=10,
         max_new_tokens=20,
     )
+    longer_generation_request = SimpleNamespace(
+        is_context_init_state=False,
+        is_generation_in_progress_state=True,
+        is_generation_to_complete_state=False,
+        is_disagg_generation_init_state=False,
+        state=LlmRequestState.GENERATION_IN_PROGRESS,
+        prompt_len=10,
+        max_new_tokens=21,
+    )
 
     full_attn_size_per_token = manager.get_cache_bytes_per_token()
     context_bytes = manager.get_needed_resource_to_completion(context_request)
+    longer_context_bytes = manager.get_needed_resource_to_completion(longer_context_request)
     generation_bytes = manager.get_needed_resource_to_completion(generation_request)
+    longer_generation_bytes = manager.get_needed_resource_to_completion(longer_generation_request)
 
     assert full_attn_size_per_token > 0
     assert context_bytes > context_request.prompt_len * full_attn_size_per_token
-    assert generation_bytes - context_bytes == (
-        generation_request.max_new_tokens * full_attn_size_per_token
-    )
+    assert longer_context_bytes - context_bytes > full_attn_size_per_token
+    assert longer_generation_bytes - generation_bytes == full_attn_size_per_token
 
 
 def _view_fp8_as_uint8(buffer: torch.Tensor) -> torch.Tensor:

--- a/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
+++ b/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
@@ -24,6 +24,7 @@ from tensorrt_llm._torch.disaggregation.resource.kv_extractor import (
     build_page_table_from_manager,
 )
 from tensorrt_llm._torch.disaggregation.resource.page import MapperKind
+from tensorrt_llm._torch.pyexecutor._util import CacheCost
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest, LlmRequestState
 from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
 from tensorrt_llm._utils import binding_to_torch_dtype
@@ -62,7 +63,109 @@ def test_cache_size_estimation_uses_model_attention_layer_count():
         is_disagg=True,
     )
 
-    assert size_per_token > 0
+    cost = CacheCost.from_raw(size_per_token)
+    assert cost.slope > 0
+    assert cost.intercept == 0
+
+
+def test_cache_size_estimation_returns_swa_fixed_cost_as_intercept():
+    class FakeModelConfig:
+        sparse_attention_config = SimpleNamespace(
+            index_head_dim=128,
+            compress_ratios=[1, 1],
+            indexer_k_dtype="fp8",
+            window_size=128,
+        )
+        pretrained_config = SimpleNamespace(
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+        )
+        quant_config = None
+
+        def get_num_attention_layers(self) -> int:
+            return len(self.sparse_attention_config.compress_ratios)
+
+    size_per_token = DeepseekV4CacheManager.get_cache_size_per_token(
+        FakeModelConfig(),
+        Mapping(world_size=1, rank=0, tp_size=1, pp_size=1),
+        tokens_per_block=128,
+        max_batch_size=2,
+    )
+    short_seq_size_per_token = DeepseekV4CacheManager.get_cache_size_per_token(
+        FakeModelConfig(),
+        Mapping(world_size=1, rank=0, tp_size=1, pp_size=1),
+        tokens_per_block=128,
+        max_seq_len=1,
+        max_batch_size=2,
+    )
+
+    cost = CacheCost.from_raw(size_per_token)
+    assert cost.slope == 0
+    assert cost.intercept > 0
+    assert CacheCost.from_raw(short_seq_size_per_token) == cost
+
+
+def test_quota_from_max_tokens_models_swa_as_fixed_cost():
+    manager = object.__new__(DeepseekV4CacheManager)
+    manager.pp_layers = [0, 1]
+    manager._compress_ratios = [1, 1]
+    manager.dtype = DataType.BF16
+    manager.head_dim = 512 + 64
+    manager.index_head_dim = 128
+    manager._indexer_k_dtype = "fp8"
+    manager._swa_window_size = 128
+    manager._max_draft_len = 0
+    manager.tokens_per_block = 128
+    manager.max_batch_size = 2
+
+    small_quota = manager._get_quota_from_max_tokens(1)
+    large_quota = manager._get_quota_from_max_tokens(4096)
+
+    assert small_quota == large_quota
+    assert small_quota > manager._get_extra_quota_padding()
+    assert manager._get_max_tokens_from_quota(small_quota) == float("inf")
+
+
+def test_needed_resource_uses_full_slope_and_fixed_swa_cost():
+    manager = object.__new__(DeepseekV4CacheManager)
+    manager.pp_layers = [0, 1]
+    manager._compress_ratios = [4, 4]
+    manager.dtype = DataType.BF16
+    manager.head_dim = 512 + 64
+    manager.index_head_dim = 128
+    manager._indexer_k_dtype = "fp8"
+    manager._swa_window_size = 128
+    manager.tokens_per_block = 128
+    manager.num_extra_kv_tokens = 0
+
+    context_request = SimpleNamespace(
+        is_context_init_state=True,
+        is_generation_in_progress_state=False,
+        is_generation_to_complete_state=False,
+        is_disagg_generation_init_state=False,
+        state=LlmRequestState.CONTEXT_INIT,
+        prompt_len=10,
+        max_new_tokens=100,
+    )
+    generation_request = SimpleNamespace(
+        is_context_init_state=False,
+        is_generation_in_progress_state=True,
+        is_generation_to_complete_state=False,
+        is_disagg_generation_init_state=False,
+        state=LlmRequestState.GENERATION_IN_PROGRESS,
+        prompt_len=10,
+        max_new_tokens=20,
+    )
+
+    full_attn_size_per_token = manager.get_cache_bytes_per_token()
+    context_bytes = manager.get_needed_resource_to_completion(context_request)
+    generation_bytes = manager.get_needed_resource_to_completion(generation_request)
+
+    assert full_attn_size_per_token > 0
+    assert context_bytes > context_request.prompt_len * full_attn_size_per_token
+    assert generation_bytes - context_bytes == (
+        generation_request.max_new_tokens * full_attn_size_per_token
+    )
 
 
 def _view_fp8_as_uint8(buffer: torch.Tensor) -> torch.Tensor:

--- a/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
+++ b/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
@@ -201,16 +201,16 @@ def test_needed_resource_uses_prefill_swa_scratch_slope():
         max_new_tokens=21,
     )
 
-    full_attn_size_per_token = manager.get_cache_bytes_per_token()
+    non_sliding_attn_size_per_token = manager.get_cache_bytes_per_token()
     context_bytes = manager.get_needed_resource_to_completion(context_request)
     longer_context_bytes = manager.get_needed_resource_to_completion(longer_context_request)
     generation_bytes = manager.get_needed_resource_to_completion(generation_request)
     longer_generation_bytes = manager.get_needed_resource_to_completion(longer_generation_request)
 
-    assert full_attn_size_per_token > 0
-    assert context_bytes > context_request.prompt_len * full_attn_size_per_token
-    assert longer_context_bytes - context_bytes > full_attn_size_per_token
-    assert longer_generation_bytes - generation_bytes == full_attn_size_per_token
+    assert non_sliding_attn_size_per_token > 0
+    assert context_bytes > context_request.prompt_len * non_sliding_attn_size_per_token
+    assert longer_context_bytes - context_bytes > non_sliding_attn_size_per_token
+    assert longer_generation_bytes - generation_bytes == non_sliding_attn_size_per_token
 
 
 def _view_fp8_as_uint8(buffer: torch.Tensor) -> torch.Tensor:

--- a/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
+++ b/tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py
@@ -47,6 +47,7 @@ def test_cache_size_estimation_uses_model_attention_layer_count():
             index_head_dim=128,
             compress_ratios=[1, 4, 1, 128],
             indexer_k_dtype="fp8",
+            window_size=128,
         )
         pretrained_config = SimpleNamespace(
             kv_lora_rank=512,
@@ -69,65 +70,17 @@ def test_cache_size_estimation_uses_model_attention_layer_count():
     assert cost.intercept == 0
 
 
-def test_cache_size_estimation_models_prefill_swa_scratch(monkeypatch):
-    class FakeModelConfig:
-        sparse_attention_config = SimpleNamespace(
-            index_head_dim=128,
-            compress_ratios=[1, 1],
-            indexer_k_dtype="fp8",
-            window_size=128,
-        )
-        pretrained_config = SimpleNamespace(
-            kv_lora_rank=512,
-            qk_rope_head_dim=64,
-        )
-        quant_config = None
-
-        def get_num_attention_layers(self) -> int:
-            return len(self.sparse_attention_config.compress_ratios)
-
-    monkeypatch.setenv(DSV4_ENABLE_SWA_SCRATCH_REUSE_ENV, "1")
-    size_per_token = DeepseekV4CacheManager.get_cache_size_per_token(
-        FakeModelConfig(),
-        Mapping(world_size=1, rank=0, tp_size=1, pp_size=1),
-        tokens_per_block=128,
-        max_batch_size=2,
-    )
-    short_seq_size_per_token = DeepseekV4CacheManager.get_cache_size_per_token(
-        FakeModelConfig(),
-        Mapping(world_size=1, rank=0, tp_size=1, pp_size=1),
-        tokens_per_block=128,
-        max_seq_len=1,
-        max_batch_size=2,
-    )
-
-    scratch_cost = CacheCost.from_raw(size_per_token)
-    assert scratch_cost.slope > 0
-    assert scratch_cost.intercept == 2 * 128 * scratch_cost.slope
-    assert CacheCost.from_raw(short_seq_size_per_token) == scratch_cost
-
-    monkeypatch.setenv(DSV4_ENABLE_SWA_SCRATCH_REUSE_ENV, "0")
-    no_scratch_size_per_token = DeepseekV4CacheManager.get_cache_size_per_token(
-        FakeModelConfig(),
-        Mapping(world_size=1, rank=0, tp_size=1, pp_size=1),
-        tokens_per_block=128,
-        max_batch_size=2,
-    )
-    no_scratch_cost = CacheCost.from_raw(no_scratch_size_per_token)
-    assert no_scratch_cost.slope == 2 * scratch_cost.slope
-    assert no_scratch_cost.intercept == 0
-
-
-def test_quota_from_max_tokens_models_prefill_swa_scratch():
+def test_quota_from_max_tokens_models_context_swa_scratch():
     manager = object.__new__(DeepseekV4CacheManager)
     manager.pp_layers = [0, 1]
-    manager._compress_ratios = [1, 1]
+    manager._compress_ratios = [4, 4]
     manager.dtype = DataType.BF16
     manager.head_dim = 512 + 64
     manager.index_head_dim = 128
     manager._indexer_k_dtype = "fp8"
     manager._swa_window_size = 128
     manager._max_draft_len = 0
+    manager._max_num_tokens = 1024
     manager.tokens_per_block = 128
     manager.max_batch_size = 2
 
@@ -147,11 +100,11 @@ def test_quota_from_max_tokens_models_prefill_swa_scratch():
     no_scratch_delta = no_scratch_large_quota - no_scratch_small_quota
 
     assert no_scratch_small_quota < no_scratch_large_quota
-    assert no_scratch_delta == 2 * scratch_delta
+    assert no_scratch_delta > scratch_delta
     assert manager._get_max_tokens_from_quota(no_scratch_large_quota) == 4096
 
 
-def test_needed_resource_uses_prefill_swa_scratch_slope():
+def test_needed_resource_uses_context_swa_scratch_slope():
     manager = object.__new__(DeepseekV4CacheManager)
     manager.pp_layers = [0, 1]
     manager._compress_ratios = [4, 4]

--- a/tests/unittest/_torch/executor/test_kv_cache_estimation.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_estimation.py
@@ -304,7 +304,7 @@ def test_pool_scaling_prevents_mmmu_pro_underestimation():
     assert per_pool_tokens >= max_seq_len
 
 
-def test_v2_cache_size_per_token_returns_full_slope_and_swa_intercept():
+def test_v2_cache_size_per_token_models_prefill_swa_scratch():
     class FakeModelConfig:
         quant_config = None
         pretrained_config = SimpleNamespace(
@@ -314,24 +314,36 @@ def test_v2_cache_size_per_token_returns_full_slope_and_swa_intercept():
         )
 
         def get_num_attention_layers(self):
-            return 2
+            return 3
 
     mapping = Mock(enable_attention_dp=False, tp_size=1)
-    mapping.pp_layers.return_value = [0, 1]
+    mapping.pp_layers.return_value = [0, 1, 2]
 
-    size_per_token = CacheCost.from_raw(
+    no_scratch_size_per_token = CacheCost.from_raw(
         KVCacheManagerV2.get_cache_size_per_token(
             FakeModelConfig(),
             mapping,
             tokens_per_block=64,
-            max_seq_len=1024,
+            max_seq_len=4096,
             max_batch_size=3,
-            kv_cache_config=KvCacheConfig(max_attention_window=[2048, 1024]),
+            kv_cache_config=KvCacheConfig(max_attention_window=[2048, 2048, 4096]),
+        )
+    )
+    scratch_size_per_token = CacheCost.from_raw(
+        KVCacheManagerV2.get_cache_size_per_token(
+            FakeModelConfig(),
+            mapping,
+            tokens_per_block=64,
+            max_seq_len=4096,
+            max_batch_size=3,
+            kv_cache_config=KvCacheConfig(max_attention_window=[2048, 2048, 4096]),
+            enable_swa_scratch_reuse=True,
         )
     )
 
     # Per layer: K+V * kv_heads * head_dim * bf16 bytes = 2 * 2 * 8 * 2.
-    assert size_per_token == CacheCost(slope=64, intercept=3 * 2048 * 64)
+    assert no_scratch_size_per_token == CacheCost(slope=3 * 64)
+    assert scratch_size_per_token == CacheCost(slope=2 * 64, intercept=3 * 2048 * 64)
 
 
 def test_creator_uses_v2_affine_cache_cost():
@@ -353,17 +365,26 @@ def test_creator_uses_v2_affine_cache_cost():
     assert cost == CacheCost(slope=20, intercept=21)
 
 
-def test_v2_quota_from_max_tokens_models_swa_as_fixed_cost():
+def test_v2_quota_from_max_tokens_models_prefill_swa_scratch():
     manager = object.__new__(KVCacheManagerV2)
-    manager.num_local_layers = 2
-    manager.pp_layers = [0, 1]
-    manager.max_attention_window_vec = [128, None]
+    manager.num_local_layers = 3
+    manager.pp_layers = [0, 1, 2]
+    manager.max_attention_window_vec = [128, 128, None]
     manager.tokens_per_block = 64
     manager.max_batch_size = 4
-    manager.get_layer_bytes_per_token = lambda local_layer_idx, data_role: [10, 20][local_layer_idx]
+    manager.get_layer_bytes_per_token = lambda local_layer_idx, data_role: [10, 10, 20][
+        local_layer_idx
+    ]
 
-    assert manager._get_quota_from_max_tokens(1000) == 4 * 128 * 10 + 1000 * 20
-    assert manager._get_max_tokens_from_quota(4 * 128 * 10 + 1000 * 20) == 1000
+    manager.enable_swa_scratch_reuse = False
+    no_scratch_quota = manager._get_quota_from_max_tokens(1000)
+    assert no_scratch_quota == 1000 * 40
+    assert manager._get_max_tokens_from_quota(no_scratch_quota) == 1000
+
+    manager.enable_swa_scratch_reuse = True
+    scratch_quota = manager._get_quota_from_max_tokens(1000)
+    assert scratch_quota == 4 * 128 * 10 + 1000 * 30
+    assert manager._get_max_tokens_from_quota(scratch_quota) == 1000
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittest/_torch/executor/test_kv_cache_estimation.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_estimation.py
@@ -78,6 +78,7 @@ def _make_creator(
     # behavior; production sets this in __init__ via
     # _get_model_kv_cache_manager_cls(), which we bypass here.
     c._kv_cache_manager_cls = KVCacheManagerV2
+    c._is_kv_cache_manager_v2 = True
 
     return c
 
@@ -304,7 +305,7 @@ def test_pool_scaling_prevents_mmmu_pro_underestimation():
     assert per_pool_tokens >= max_seq_len
 
 
-def test_v2_cache_size_per_token_models_prefill_swa_scratch():
+def test_v2_cache_size_per_token_models_generation_swa_cost():
     class FakeModelConfig:
         quant_config = None
         pretrained_config = SimpleNamespace(
@@ -342,8 +343,9 @@ def test_v2_cache_size_per_token_models_prefill_swa_scratch():
     )
 
     # Per layer: K+V * kv_heads * head_dim * bf16 bytes = 2 * 2 * 8 * 2.
-    assert no_scratch_size_per_token == CacheCost(slope=3 * 64)
-    assert scratch_size_per_token == CacheCost(slope=2 * 64, intercept=3 * 2048 * 64)
+    expected = CacheCost(slope=64, intercept=3 * 2 * 2048 * 64)
+    assert no_scratch_size_per_token == expected
+    assert scratch_size_per_token == expected
 
 
 def test_creator_uses_v2_affine_cache_cost():
@@ -365,26 +367,29 @@ def test_creator_uses_v2_affine_cache_cost():
     assert cost == CacheCost(slope=20, intercept=21)
 
 
-def test_v2_quota_from_max_tokens_models_prefill_swa_scratch():
+def test_v2_quota_from_max_tokens_models_context_swa_scratch():
     manager = object.__new__(KVCacheManagerV2)
     manager.num_local_layers = 3
     manager.pp_layers = [0, 1, 2]
     manager.max_attention_window_vec = [128, 128, None]
     manager.tokens_per_block = 64
     manager.max_batch_size = 4
+    manager.max_num_tokens = 1000
     manager.get_layer_bytes_per_token = lambda local_layer_idx, data_role: [10, 10, 20][
         local_layer_idx
     ]
 
+    max_tokens = 1200
+
     manager.enable_swa_scratch_reuse = False
-    no_scratch_quota = manager._get_quota_from_max_tokens(1000)
-    assert no_scratch_quota == 1000 * 40
-    assert manager._get_max_tokens_from_quota(no_scratch_quota) == 1000
+    no_scratch_quota = manager._get_quota_from_max_tokens(max_tokens)
+    assert no_scratch_quota == (max_tokens * 20 + manager.max_num_tokens * 20 + 4 * 2 * 128 * 10)
+    assert manager._get_max_tokens_from_quota(no_scratch_quota) == max_tokens
 
     manager.enable_swa_scratch_reuse = True
-    scratch_quota = manager._get_quota_from_max_tokens(1000)
-    assert scratch_quota == 4 * 128 * 10 + 1000 * 30
-    assert manager._get_max_tokens_from_quota(scratch_quota) == 1000
+    scratch_quota = manager._get_quota_from_max_tokens(max_tokens)
+    assert scratch_quota == (max_tokens * 20 + manager.max_num_tokens * 10 + 4 * 2 * 128 * 10)
+    assert manager._get_max_tokens_from_quota(scratch_quota) == max_tokens
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittest/_torch/executor/test_kv_cache_estimation.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_estimation.py
@@ -7,12 +7,14 @@ produces tp_size duplicate requests, but the scheduler distributes them
 share, not all copies.
 """
 
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
 
 from tensorrt_llm._torch.pyexecutor._util import CacheCost, KvCacheCreator
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManagerV2
+from tensorrt_llm.llmapi.llm_args import KvCacheConfig
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -300,6 +302,68 @@ def test_pool_scaling_prevents_mmmu_pro_underestimation():
     per_pool_tokens = total_tokens // 2  # 2 pool groups
     # Must be enough to hold a max_seq_len request per pool.
     assert per_pool_tokens >= max_seq_len
+
+
+def test_v2_cache_size_per_token_returns_full_slope_and_swa_intercept():
+    class FakeModelConfig:
+        quant_config = None
+        pretrained_config = SimpleNamespace(
+            hidden_size=32,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+        )
+
+        def get_num_attention_layers(self):
+            return 2
+
+    mapping = Mock(enable_attention_dp=False, tp_size=1)
+    mapping.pp_layers.return_value = [0, 1]
+
+    size_per_token = CacheCost.from_raw(
+        KVCacheManagerV2.get_cache_size_per_token(
+            FakeModelConfig(),
+            mapping,
+            tokens_per_block=64,
+            max_seq_len=1024,
+            max_batch_size=3,
+            kv_cache_config=KvCacheConfig(max_attention_window=[2048, 1024]),
+        )
+    )
+
+    # Per layer: K+V * kv_heads * head_dim * bf16 bytes = 2 * 2 * 8 * 2.
+    assert size_per_token == CacheCost(slope=64, intercept=3 * 2048 * 64)
+
+
+def test_creator_uses_v2_affine_cache_cost():
+    class FakeV2Manager(KVCacheManagerV2):
+        @staticmethod
+        def get_cache_size_per_token(model_config, mapping, **kwargs):
+            return 20, 21
+
+    creator = object.__new__(KvCacheCreator)
+    creator._mapping = Mock()
+    creator._tokens_per_block = 64
+    creator._max_seq_len = 1024
+    creator._max_batch_size = 3
+    creator._kv_cache_config = KvCacheConfig()
+    creator._speculative_config = None
+
+    cost = creator._per_manager_cache_cost(FakeV2Manager, Mock())
+
+    assert cost == CacheCost(slope=20, intercept=21)
+
+
+def test_v2_quota_from_max_tokens_models_swa_as_fixed_cost():
+    manager = object.__new__(KVCacheManagerV2)
+    manager.num_local_layers = 2
+    manager.pp_layers = [0, 1]
+    manager.max_attention_window_vec = [128, None]
+    manager.tokens_per_block = 64
+    manager.max_batch_size = 4
+    manager.get_layer_bytes_per_token = lambda local_layer_idx, data_role: [10, 20][local_layer_idx]
+
+    assert manager._get_quota_from_max_tokens(1000) == 4 * 128 * 10 + 1000 * 20
+    assert manager._get_max_tokens_from_quota(4 * 128 * 10 + 1000 * 20) == 1000
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

This PR fixes DeepSeek V4 KV cache capacity estimation by modeling SWA KV cache as a fixed cost and accounting for SWA scratch usage in runtime quota estimates.

Latest updates refine KV cache manager V2 capacity handling:
- Use `max_gpu_total_bytes` rather than `max_tokens` as the V2 capacity control during estimation.
- Treat `get_cache_size_per_token` as decode-token accounting for general V2 and DeepSeek V4.
- Size quota from generation tokens first, then add only the extra context/prefill overhead bounded by `max_num_tokens`.
- Remove fallback `getattr` access for required DeepSeek V4 cache manager/config attributes.

## Test Coverage

Relevant coverage is in `tests/unittest/_torch/attention/sparse/deepseek_v4/test_deepseek_v4_cache_manager.py`.

Pre-commit hooks passed when committing the latest update. Full tests were not run locally after the rebase.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.