### PR TITLE
[None][feat] Qwen3-VL: support per-request mm_processor_kwargs

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -228,6 +228,49 @@ class Qwen3VLInputProcessorBase(Qwen2VLInputProcessorBase):
             second_per_grid_ts,
         )
 
+    def _preprocess(
+        self,
+        text: Dict[str, Any],
+        mm_data: Dict[str, Any],
+        mm_processor_kwargs: Dict[str, Any],
+    ):
+        images = mm_data.get("image")
+        video_datas = mm_data.get("video")
+        if video_datas is not None:
+            videos = [video_data.frames for video_data in video_datas]
+        else:
+            videos = None
+        do_rescale = True
+        if images and isinstance(images[0], torch.Tensor):
+            do_rescale = False
+        if videos and isinstance(videos[0][0], torch.Tensor):
+            do_rescale = False
+
+        # Forward video metadata only when the caller opts into per-request kwargs;
+        # the default path pre-samples frames in the IO loader, so unconditional
+        # metadata triggers IndexError in HF's _decode_and_sample_videos.
+        video_metadata = (
+            [vd.metadata for vd in video_datas] if video_datas and mm_processor_kwargs else None
+        )
+
+        # num_frames and fps are mutually exclusive in the HF processor's sample_frames.
+        # If the caller set num_frames without fps, null fps explicitly so the class-level
+        # default fps=2 does not interfere.
+        proc_kwargs = dict(mm_processor_kwargs)
+        if "num_frames" in proc_kwargs and "fps" not in proc_kwargs:
+            proc_kwargs["fps"] = None
+
+        return self.processor(
+            text=[text],
+            images=images,
+            videos=videos,
+            padding=True,
+            do_rescale=do_rescale,
+            return_tensors="pt",
+            video_metadata=video_metadata,
+            **proc_kwargs,
+        )
+
     def get_num_tokens_per_video(
         self,
         *,

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -809,6 +809,12 @@ class ChatCompletionRequest(OpenAIBaseModel):
     agent_hierarchy: Optional[AgentHierarchy] = Field(
         default=None, description="Agent hierarchy ")
 
+    mm_processor_kwargs: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=
+        "Per-request kwargs forwarded to the multimodal HF processor (e.g. num_frames for video models).",
+    )
+
     # doc: end-chat-completion-extra-params
 
     def to_sampling_params(self,

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -1265,6 +1265,9 @@ class OpenAIServer(_VideoRoutesMixin):
                     "Passing 'multi_modal_data' and 'multi_modal_embeddings' at the same time is not supported."
                 )
 
+            if request.mm_processor_kwargs:
+                prompt["mm_processor_kwargs"] = request.mm_processor_kwargs
+
             postproc_args.reasoning_parser = self.generator.args.reasoning_parser
             postproc_args.tool_parser = self.tool_parser
             postproc_args.tool_call_id_type = self.tool_call_id_type

--- a/tests/unittest/_torch/modeling/test_modeling_qwen3vl_preprocess.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen3vl_preprocess.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for Qwen3VLInputProcessorBase._preprocess kwargs handling.
+
+Covers the per-request ``mm_processor_kwargs`` plumbing added to Qwen3-VL:
+  * Video metadata from the IO loader is forwarded to the HF processor so
+    sample_frames sees the real source fps (rather than HF's 24 fps default).
+  * ``num_frames`` and ``fps`` are mutually exclusive in HF's sample_frames; if
+    the caller sets ``num_frames`` without ``fps``, ``_preprocess`` must
+    explicitly null ``fps`` so the processor's class-level ``fps=2`` default
+    does not interfere.
+  * The caller-supplied ``mm_processor_kwargs`` dict must not be mutated.
+
+The tests bind ``_preprocess`` to a stand-in object so they avoid the heavy
+``__init__`` (which would download an HF processor) and only exercise the new
+control-flow.
+"""
+
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from tensorrt_llm._torch.models import modeling_qwen3vl
+from tensorrt_llm._torch.models.modeling_qwen3vl import Qwen3VLInputProcessorBase
+
+
+@pytest.fixture(autouse=True)
+def _stub_bypass_validator(monkeypatch):
+    """Replace bypass_processor_output_validation with a no-op.
+
+    The real implementation rebinds ``validate_typed_dict`` across several
+    transformers internals; that side effect is irrelevant here and stubbing
+    it keeps the test focused on the kwargs-handling logic.
+    """
+    monkeypatch.setattr(
+        modeling_qwen3vl,
+        "bypass_processor_output_validation",
+        contextlib.nullcontext,
+    )
+
+
+def _fake_video(metadata):
+    """Minimal stand-in for VideoData: just needs ``.frames`` and ``.metadata``."""
+    # A single non-Tensor frame so the do_rescale branch stays in its default.
+    return SimpleNamespace(frames=[object()], metadata=metadata)
+
+
+def _call_preprocess(mm_data, mm_processor_kwargs):
+    fake_processor = MagicMock(return_value={})
+    fake_self = SimpleNamespace(processor=fake_processor)
+    Qwen3VLInputProcessorBase._preprocess(
+        fake_self,
+        "the prompt",
+        mm_data,
+        mm_processor_kwargs,
+    )
+    return fake_processor
+
+
+class TestVideoMetadataForwarding:
+    """The IO loader's per-video metadata reaches the HF processor."""
+
+    def test_metadata_for_each_video_forwarded(self):
+        """Multi-video case: list is built per-video, in order."""
+        md0 = {"total_num_frames": 64, "fps": 25.0, "duration": 2.5}
+        md1 = {"total_num_frames": 32, "fps": 30.0, "duration": 1.0}
+        mm_data = {"video": [_fake_video(md0), _fake_video(md1)]}
+
+        processor = _call_preprocess(mm_data, {})
+
+        kwargs = processor.call_args.kwargs
+        assert kwargs["video_metadata"] == [md0, md1]
+        assert len(kwargs["videos"]) == 2
+
+    def test_metadata_is_none_when_no_videos(self):
+        """Text-only case: the ``else None`` branch (not an empty list)."""
+        processor = _call_preprocess({}, {})
+        kwargs = processor.call_args.kwargs
+        assert kwargs["video_metadata"] is None
+        assert kwargs["videos"] is None
+
+
+class TestNumFramesFpsMutualExclusivity:
+    """Truth table over ("num_frames" present, "fps" present).
+
+    HF's Qwen3VLProcessor.sample_frames treats num_frames and fps as mutually
+    exclusive; the class-level default ``fps=2`` would otherwise win over the
+    caller's ``num_frames``. The fix injects ``fps=None`` only in the
+    (True, False) corner.
+    """
+
+    def test_num_frames_without_fps_injects_null_fps(self):
+        """(True, False): the corner the fix exists for."""
+        mm_data = {"video": [_fake_video({"fps": 30.0})]}
+
+        processor = _call_preprocess(mm_data, {"num_frames": 8})
+
+        kwargs = processor.call_args.kwargs
+        assert kwargs["num_frames"] == 8
+        assert "fps" in kwargs
+        assert kwargs["fps"] is None
+
+    def test_explicit_fps_is_preserved(self):
+        """(True, True): the fix must not trample a user-supplied fps."""
+        mm_data = {"video": [_fake_video({"fps": 30.0})]}
+
+        processor = _call_preprocess(mm_data, {"num_frames": 8, "fps": 4.0})
+
+        kwargs = processor.call_args.kwargs
+        assert kwargs["num_frames"] == 8
+        assert kwargs["fps"] == 4.0
+
+    def test_fps_only_passes_through_unchanged(self):
+        """(False, True): the condition must not fire for fps alone."""
+        processor = _call_preprocess({}, {"fps": 4.0})
+
+        kwargs = processor.call_args.kwargs
+        assert kwargs["fps"] == 4.0
+        assert "num_frames" not in kwargs
+
+    def test_no_kwargs_means_no_num_frames_no_fps(self):
+        """(False, False): the empty-kwargs case adds no spurious keys."""
+        processor = _call_preprocess({}, {})
+
+        kwargs = processor.call_args.kwargs
+        assert "num_frames" not in kwargs
+        assert "fps" not in kwargs
+
+
+class TestInputDictNotMutated:
+    """The caller's mm_processor_kwargs dict is copied, not mutated."""
+
+    def test_num_frames_only_dict_not_mutated(self):
+        original = {"num_frames": 8}
+        snapshot = dict(original)
+        _call_preprocess({}, original)
+        assert original == snapshot
+
+
+class TestUnrelatedKwargsForwarded:
+    """Keys unrelated to the num_frames/fps fix pass through verbatim."""
+
+    def test_unrelated_kwargs_reach_processor(self):
+        processor = _call_preprocess({}, {"num_frames": 8, "max_pixels": 1234})
+        assert processor.call_args.kwargs["max_pixels"] == 1234

--- a/tests/unittest/_torch/modeling/test_modeling_qwen3vl_preprocess.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen3vl_preprocess.py
@@ -28,29 +28,10 @@ The tests bind ``_preprocess`` to a stand-in object so they avoid the heavy
 control-flow.
 """
 
-import contextlib
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-import pytest
-
-from tensorrt_llm._torch.models import modeling_qwen3vl
 from tensorrt_llm._torch.models.modeling_qwen3vl import Qwen3VLInputProcessorBase
-
-
-@pytest.fixture(autouse=True)
-def _stub_bypass_validator(monkeypatch):
-    """Replace bypass_processor_output_validation with a no-op.
-
-    The real implementation rebinds ``validate_typed_dict`` across several
-    transformers internals; that side effect is irrelevant here and stubbing
-    it keeps the test focused on the kwargs-handling logic.
-    """
-    monkeypatch.setattr(
-        modeling_qwen3vl,
-        "bypass_processor_output_validation",
-        contextlib.nullcontext,
-    )
 
 
 def _fake_video(metadata):
@@ -72,23 +53,32 @@ def _call_preprocess(mm_data, mm_processor_kwargs):
 
 
 class TestVideoMetadataForwarding:
-    """The IO loader's per-video metadata reaches the HF processor."""
+    """``video_metadata`` is forwarded only when the caller passes
+    ``mm_processor_kwargs``."""
 
-    def test_metadata_for_each_video_forwarded(self):
-        """Multi-video case: list is built per-video, in order."""
+    def test_metadata_forwarded_when_opted_in(self):
+        """Opted-in path: list built per-video, in order."""
         md0 = {"total_num_frames": 64, "fps": 25.0, "duration": 2.5}
         md1 = {"total_num_frames": 32, "fps": 30.0, "duration": 1.0}
         mm_data = {"video": [_fake_video(md0), _fake_video(md1)]}
 
-        processor = _call_preprocess(mm_data, {})
+        processor = _call_preprocess(mm_data, {"fps": 2.0})
 
         kwargs = processor.call_args.kwargs
         assert kwargs["video_metadata"] == [md0, md1]
         assert len(kwargs["videos"]) == 2
 
+    def test_metadata_not_forwarded_with_empty_kwargs(self):
+        """Empty kwargs: videos present but metadata is not forwarded."""
+        mm_data = {"video": [_fake_video({"fps": 30.0})]}
+
+        processor = _call_preprocess(mm_data, {})
+
+        assert processor.call_args.kwargs["video_metadata"] is None
+
     def test_metadata_is_none_when_no_videos(self):
-        """Text-only case: the ``else None`` branch (not an empty list)."""
-        processor = _call_preprocess({}, {})
+        """No videos: metadata is None regardless of kwargs."""
+        processor = _call_preprocess({}, {"fps": 2.0})
         kwargs = processor.call_args.kwargs
         assert kwargs["video_metadata"] is None
         assert kwargs["videos"] is None

--- a/tests/unittest/llmapi/apps/test_openai_protocol_mm_processor_kwargs.py
+++ b/tests/unittest/llmapi/apps/test_openai_protocol_mm_processor_kwargs.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for ChatCompletionRequest.mm_processor_kwargs.
+
+This field carries per-request kwargs to the multimodal HF processor
+(e.g. ``num_frames`` for video models). The server reads it via
+``request.mm_processor_kwargs`` and attaches it to the prompt before
+dispatch, so the request schema is the authoritative contract.
+"""
+
+from tensorrt_llm.serve.openai_protocol import ChatCompletionRequest
+
+
+def _base_request(**extra):
+    return {
+        "model": "m",
+        "messages": [{"role": "user", "content": "hi"}],
+        **extra,
+    }
+
+
+class TestChatCompletionMmProcessorKwargs:
+    def test_default_is_none(self):
+        """Field is optional; absent → None (so the server's truthiness check skips it)."""
+        req = ChatCompletionRequest(**_base_request())
+        assert req.mm_processor_kwargs is None
+
+    def test_accepts_arbitrary_dict(self):
+        """Field is Dict[str, Any]; a populated dict round-trips unchanged."""
+        kwargs = {"num_frames": 8, "fps": None, "max_pixels": 1234}
+        req = ChatCompletionRequest(**_base_request(mm_processor_kwargs=kwargs))
+        assert req.mm_processor_kwargs == kwargs


### PR DESCRIPTION
Add `mm_processing_kwargs` field to the OpenAI request type and forward it through to the Qwen3-VL preprocessing so the user can request videos to be preprocessed at a specific FPS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for passing custom video processing parameters per request through the OpenAI API via a new `mm_processor_kwargs` field.

* **Improvements**
  * Enhanced video metadata handling in video preprocessing to provide better control over frame and frame rate configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Pipe `mm_processor_kwargs` through to the HF processor for Qwen3-VL so downstream video benchmarking can effectively measure metrics w.r.t video FPS accurately. 

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ x ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
