### PR TITLE
[None][feat] serve: expose is_first_turn from routers and propagate conversation_id to workers

### DIFF
--- a/tensorrt_llm/disaggregated_params.py
+++ b/tensorrt_llm/disaggregated_params.py
@@ -51,6 +51,10 @@ class DisaggregatedParams:
     ctx_dp_rank: Optional[int] = None
     ctx_info_endpoint: Optional[str] = None
     schedule_style: Optional[DisaggScheduleStyle] = None
+    # Multi-turn conversation id (from session headers such as X-Session-ID),
+    # carried through so worker-side consumers (e.g. the ADP router) can see
+    # the same id the disagg orchestrator routed on.
+    conversation_id: Optional[str] = None
 
     # E-P Disaggregated Params
     multimodal_embedding_handles: Optional[List[Dict[str, Any]]] = (

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -1243,6 +1243,7 @@ def to_disaggregated_params(
         ctx_dp_rank=tllm_disagg_params.ctx_dp_rank,
         ctx_info_endpoint=tllm_disagg_params.ctx_info_endpoint,
         schedule_style=tllm_disagg_params.schedule_style,
+        conversation_id=tllm_disagg_params.conversation_id,
     )
 
 
@@ -1265,6 +1266,7 @@ def to_llm_disaggregated_params(
         ctx_dp_rank=disaggregated_params.ctx_dp_rank,
         ctx_info_endpoint=disaggregated_params.ctx_info_endpoint,
         schedule_style=disaggregated_params.schedule_style,
+        conversation_id=disaggregated_params.conversation_id,
     )
 
 

--- a/tensorrt_llm/serve/router.py
+++ b/tensorrt_llm/serve/router.py
@@ -925,6 +925,19 @@ class BlockHashMixin:
         cache_salt = getattr(request, "cache_salt", None)
         return None if cache_salt is None else get_cache_salt_id(cache_salt)
 
+    @staticmethod
+    def _get_conversation_id(request: OpenAIRequest) -> Optional[str]:
+        """Return the explicit conversation id when present.
+
+        Populated upstream from session headers (``X-Session-ID``,
+        ``X-Correlation-ID``, ...) by
+        ``OpenAIDisaggServer._extract_conversation_id``.  Returns ``None``
+        when the client sent no session header.
+        """
+        if request.disaggregated_params is not None:
+            return request.disaggregated_params.conversation_id
+        return None
+
 
 class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
 
@@ -939,6 +952,7 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
                  max_batch_size: int = 64,
                  tokens_per_block: int = 32,
                  custom_tokenizer: Optional[str] = None,
+                 max_sessions: int = 100000,
                  backfill_block_hashes_on_finish: bool = False,
                  **kwargs):
         super().__init__(server_role, servers, metadata_server_cfg,
@@ -951,6 +965,30 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
         # kv_cache_events. Stash hashes at routing, inject on finish.
         self._backfill_block_hashes_on_finish = backfill_block_hashes_on_finish
         self._pending_block_hashes: dict[int, tuple[list, str]] = {}
+
+        # Conversation ids already routed by this instance, LRU-ordered.
+        # Membership lets us flag the first turn of a multi-turn session,
+        # mirroring ConversationRouter's session-table semantics.  Bounded
+        # so a long run does not grow this map without limit.
+        self._max_sessions = max_sessions
+        self._seen_conversations: OrderedDict[str, None] = OrderedDict()
+
+    def _record_conversation_turn(self, conv_id: Optional[str]) -> bool:
+        """Record *conv_id* and report whether this is its first turn.
+
+        Returns ``True`` the first time a non-empty conversation id is seen
+        by this router instance, ``False`` for subsequent turns or when no
+        conversation id is available.  Must be called while holding
+        ``self._lock``.
+        """
+        if not conv_id:
+            return False
+        is_first_turn = conv_id not in self._seen_conversations
+        self._seen_conversations[conv_id] = None
+        self._seen_conversations.move_to_end(conv_id)
+        while len(self._seen_conversations) > self._max_sessions:
+            self._seen_conversations.popitem(last=False)
+        return is_first_turn
 
     def _create_server_state(self, server: str) -> KvCacheAwareServerState:
         return KvCacheAwareServerState(server, self._use_tokens,
@@ -974,6 +1012,7 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
             if not servers:
                 raise ValueError(
                     f"No available servers after excluding {exclude_server}")
+        conv_id = self._get_conversation_id(request)
         cache_salt_id = self._get_request_cache_salt_id(request)
         hash_algo_by_server = {
             server: await self._get_server_hash_algo(server)
@@ -1023,15 +1062,19 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
         hash_algo = hash_algo_by_server[server]
         block_hashes = block_hashes_by_algo[hash_algo]
         async with self._lock:
+            is_first_turn = self._record_conversation_turn(conv_id)
             await self._register_request(server, request)
             if self._backfill_block_hashes_on_finish:
                 self._pending_block_hashes[id(request)] = (block_hashes,
                                                            hash_algo)
+        logger.debug(f"KvCacheAwareRouter: conv_id={conv_id} "
+                     f"is_first_turn={is_first_turn} -> server={server}")
         return server, {
             "block_hashes": block_hashes,  # list[list[int | str]]
             "hash_algo": hash_algo,
             "token_lists": token_lists,  # list[list[int]]
             "matches": matches,  # list[int]
+            "is_first_turn": is_first_turn,
             "server_info": self._server_info.get(server, {}),
         }
 
@@ -1384,11 +1427,6 @@ class ConversationRouter(BlockHashMixin, LoadBalancingMixin, Router):
 
     # ── routing helpers ──
 
-    def _get_conversation_id(self, request: OpenAIRequest) -> Optional[str]:
-        if request.disaggregated_params is not None:
-            return request.disaggregated_params.conversation_id
-        return None
-
     def _generate_implicit_id(self) -> str:
         self._implicit_id_counter += 1
         return f"conv_id:{self._disagg_node_id}_{self._implicit_id_counter}"
@@ -1432,6 +1470,11 @@ class ConversationRouter(BlockHashMixin, LoadBalancingMixin, Router):
 
         async with self._lock:
 
+            # First turn iff we have an explicit conversation id that this
+            # router instance has not routed before.  Computed before any
+            # session-table mutation so the three return paths agree.
+            is_first_turn = bool(conv_id) and conv_id not in self._session_table
+
             # 1. Explicit conversation_id — sticky routing.
             #    Always honour session affinity when the server is alive
             #    and not explicitly excluded.  No overload gate — the
@@ -1460,6 +1503,7 @@ class ConversationRouter(BlockHashMixin, LoadBalancingMixin, Router):
                         f"-> server={sticky_server}, "
                         f"content_loads={loads}, weight={weight}")
                     return sticky_server, {
+                        "is_first_turn": is_first_turn,
                         "server_info": self._server_info.get(sticky_server, {})
                     }
             elif conv_id:
@@ -1488,6 +1532,7 @@ class ConversationRouter(BlockHashMixin, LoadBalancingMixin, Router):
                         f"conv_id={matched_id} -> server={sticky_server}, "
                         f"content_loads={loads}, weight={weight}")
                     return sticky_server, {
+                        "is_first_turn": is_first_turn,
                         "server_info": self._server_info.get(sticky_server, {})
                     }
 
@@ -1507,9 +1552,13 @@ class ConversationRouter(BlockHashMixin, LoadBalancingMixin, Router):
             loads = {s: self._get_content_load(s) for s in self._servers}
             logger.debug(
                 f"ConversationRouter: FALLBACK conv_id={conv_id} "
-                f"-> server={server}, content_loads={loads}, weight={weight}")
+                f"is_first_turn={is_first_turn} -> server={server}, "
+                f"content_loads={loads}, weight={weight}")
 
-        return server, {"server_info": self._server_info.get(server, {})}
+        return server, {
+            "is_first_turn": is_first_turn,
+            "server_info": self._server_info.get(server, {})
+        }
 
     async def finish_request(self,
                              request: OpenAIRequest,

--- a/tests/unittest/disaggregated/test_disaggregated_params.py
+++ b/tests/unittest/disaggregated/test_disaggregated_params.py
@@ -56,6 +56,7 @@ def test_to_disaggregated_params():
         first_gen_tokens=[1, 2],
         ctx_dp_rank=5,
         ctx_info_endpoint="tcp://10.0.0.1:5000",
+        conversation_id="conv-abc",
     )
     openai_params = to_disaggregated_params(llm_params)
 
@@ -63,6 +64,7 @@ def test_to_disaggregated_params():
     assert openai_params.first_gen_tokens == [1, 2]
     assert openai_params.ctx_dp_rank == 5
     assert openai_params.ctx_info_endpoint == "tcp://10.0.0.1:5000"
+    assert openai_params.conversation_id == "conv-abc"
 
 
 def test_to_llm_disaggregated_params():
@@ -73,12 +75,30 @@ def test_to_llm_disaggregated_params():
         request_type="generation_only",
         ctx_dp_rank=2,
         ctx_info_endpoint="tcp://10.0.0.1:5000",
+        conversation_id="conv-xyz",
     )
     llm_params = to_llm_disaggregated_params(openai_params)
 
     assert llm_params.request_type == "generation_only"
     assert llm_params.ctx_dp_rank == 2
     assert llm_params.ctx_info_endpoint == "tcp://10.0.0.1:5000"
+    assert llm_params.conversation_id == "conv-xyz"
+
+
+def test_disaggregated_params_conversation_id():
+    """conversation_id defaults to None and survives the serve<->llm round-trip."""
+    from tensorrt_llm.serve.openai_protocol import DisaggregatedParams as OpenAIDisaggregatedParams
+    from tensorrt_llm.serve.openai_protocol import (to_disaggregated_params,
+                                                    to_llm_disaggregated_params)
+
+    assert DisaggregatedParams().conversation_id is None
+
+    # serve -> llm -> serve preserves the conversation id end to end.
+    openai_params = OpenAIDisaggregatedParams(request_type="context_only",
+                                              conversation_id="conv-roundtrip")
+    llm_params = to_llm_disaggregated_params(openai_params)
+    assert llm_params.conversation_id == "conv-roundtrip"
+    assert to_disaggregated_params(llm_params).conversation_id == "conv-roundtrip"
 
 
 @patch("tensorrt_llm.disaggregated_params.tllme")

--- a/tests/unittest/disaggregated/test_router.py
+++ b/tests/unittest/disaggregated/test_router.py
@@ -1244,6 +1244,107 @@ def test_create_router_conversation():
     assert isinstance(router, ConversationRouter)
 
 
+def _conv_completion_request(conv_id, length=100):
+    return CompletionRequest(
+        model="TinyLlama",
+        prompt=[[1000] * length],
+        disaggregated_params=DisaggregatedParams(
+            request_type="context_only",
+            conversation_id=conv_id,
+        ),
+    )
+
+
+def _conv_chat_request(conv_id, length=100):
+    return ChatCompletionRequest(
+        messages=[{
+            "role": "user",
+            "content": "the " * length
+        }],
+        model="TinyLlama",
+        disaggregated_params=DisaggregatedParams(
+            request_type="context_only",
+            conversation_id=conv_id,
+        ),
+    )
+
+
+def test_kv_cache_aware_router_record_conversation_turn(servers):
+    """The seen-conversation set flags only the first turn, and is bounded."""
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=servers,
+                                max_sessions=2)
+
+    # First sighting of a conversation id is the first turn.
+    assert router._record_conversation_turn("c1") is True
+    assert router._record_conversation_turn("c1") is False
+
+    # A missing conversation id is never reported as a first turn.
+    assert router._record_conversation_turn(None) is False
+    assert router._record_conversation_turn("") is False
+
+    # LRU eviction: with max_sessions=2, touching c2 then c3 evicts c1, so
+    # c1 looks "new" again while c3 stays known.
+    assert router._record_conversation_turn("c2") is True
+    assert router._record_conversation_turn("c3") is True
+    assert router._record_conversation_turn("c3") is False
+    assert router._record_conversation_turn("c1") is True
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_is_first_turn(servers,
+                                                   mock_aiohttp_session):
+    """get_next_server reports is_first_turn from the conversation seen-set."""
+    router = KvCacheAwareRouter(
+        server_role=None,
+        servers=servers,
+        use_tokens=False,
+        max_batch_size=32,
+        tokens_per_block=32,
+    )
+
+    _, info = await router.get_next_server(_conv_completion_request("c1"))
+    assert info["is_first_turn"] is True
+
+    _, info = await router.get_next_server(_conv_completion_request("c1"))
+    assert info["is_first_turn"] is False
+
+    _, info = await router.get_next_server(_conv_completion_request("c2"))
+    assert info["is_first_turn"] is True
+
+    # No conversation id -> cannot be classified as a first turn.
+    _, info = await router.get_next_server(
+        CompletionRequest(model="TinyLlama", prompt=[[1000] * 100]))
+    assert info["is_first_turn"] is False
+
+
+@pytest.mark.asyncio
+async def test_conversation_router_is_first_turn(servers, mock_aiohttp_session):
+    """ConversationRouter flags the first turn via session-table membership."""
+    router = ConversationRouter(server_role=None, servers=servers)
+
+    # First turn: conv_id not yet in the session table (FALLBACK path).
+    _, info = await router.get_next_server(_conv_chat_request("c1"))
+    assert info["is_first_turn"] is True
+
+    # Second turn of the same conversation: STICKY, not a first turn.
+    _, info = await router.get_next_server(_conv_chat_request("c1"))
+    assert info["is_first_turn"] is False
+
+    # A different conversation is a first turn again.
+    _, info = await router.get_next_server(_conv_chat_request("c2"))
+    assert info["is_first_turn"] is True
+
+    # No conversation id -> implicit/fallback, never reported as first turn.
+    _, info = await router.get_next_server(
+        ChatCompletionRequest(messages=[{
+            "role": "user",
+            "content": "unrelated " * 50
+        }],
+                              model="TinyLlama"))
+    assert info["is_first_turn"] is False
+
+
 # ---------------------------------------------------------------------------
 # _tokenize: tools + chat_template_kwargs forwarding (PR #13232)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR makes the multi-turn conversation id usable end to end in disaggregated serving and exposes a first-turn signal from the routers.

## 1. Expose `is_first_turn` from the disagg routers

`get_next_server(...)` now returns `is_first_turn` in its metadata dict (and logs it at debug level) for:
- **`ConversationRouter`** — derived from session-table membership (no new state).
- **`KvCacheAwareRouter`** — which has no conversation tracking, so a small LRU-bounded `_seen_conversations` set (`max_sessions`, default 100000) + `_record_conversation_turn()` flags the first turn with matching semantics.

The conversation-id lookup is factored into a shared `BlockHashMixin._get_conversation_id` staticmethod (reads the serve-layer `disaggregated_params.conversation_id`, populated upstream from session headers such as `X-Session-ID` by `OpenAIDisaggServer._extract_conversation_id`); `ConversationRouter`'s duplicate copy is dropped.

`is_first_turn` is `False` when no conversation id is available (e.g. the client sent no `X-Session-ID` header) — i.e. "not known to be a first turn". Semantics match across both routers.

## 2. Propagate `conversation_id` to the executor / worker layer

Previously `conversation_id` existed **only** on the serve-layer `DisaggregatedParams` (`serve/openai_protocol.py`). The executor-layer `DisaggregatedParams` (`tensorrt_llm/disaggregated_params.py`, == `LlmDisaggregatedParams`) had no such field, and `to_llm_disaggregated_params()` did not copy it — so when a worker converted the incoming request (`openai_server.py` → `to_llm_disaggregated_params`), the id was silently dropped.

Net effect: worker-side consumers that read `request.py_disaggregated_params.conversation_id` (e.g. the ADP router) **always saw `None`**, even though the disagg orchestrator routed on a real conversation id.

Fix:
- Add `conversation_id` to the executor-layer `DisaggregatedParams`.
- Copy it through both `to_llm_disaggregated_params` and `to_disaggregated_params` so the serve↔executor round-trip preserves it.

Orchestrator-level routers are unaffected (they already read the serve layer directly, before this conversion).

## Test

- `tests/unittest/disaggregated/test_router.py`: LRU seen-set helper (first/subsequent/empty/eviction) and the `is_first_turn` output of `get_next_server` for both routers across turns / with no conversation id. Existing router tests are unaffected (they discard the metadata dict).
- `tests/unittest/disaggregated/test_disaggregated_params.py`: extend the converter tests to assert `conversation_id` propagates, plus a serve↔executor round-trip test.

> Opened as **draft**. Targets `feat/deepseek_v4`.
