### PR TITLE
[None][fix] Cherry-pick kv_cache_manager_v2 fixes to main

### DIFF
--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -69,6 +69,7 @@ from .._utils import (
     div_up,
     expect_type,
     filled_list,
+    intersect,
     make_typed,
     map_optional,
     stream_wait_events,
@@ -550,8 +551,13 @@ class _KVCache:
                     continue
                 stale_beg, stale_end = stale_ranges[lc]
                 if enable_scratch:
-                    num_scratch_blocks = len(scratch_ranges[lc])
-                    num_new_normal_blocks = (new_num_blocks - old_num_blocks) - num_scratch_blocks
+                    # Only newly added blocks consume slots below; scratch range may
+                    # extend before old_num_blocks when history_length < old_capacity.
+                    new_block_range = HalfOpenRange(old_num_blocks, new_num_blocks)
+                    num_new_blocks_using_scratch = len(
+                        intersect(scratch_ranges[lc], new_block_range)
+                    )
+                    num_new_normal_blocks = len(new_block_range) - num_new_blocks_using_scratch
                     num_new_slots[lc] = num_new_normal_blocks * beam_width
                 else:
                     if old_num_blocks < stale_beg:

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -1131,6 +1131,13 @@ class _KVCache:
             # We can't commit and can't reuse existing block. Just stop committing.
             self._commit_state = self.CommitState.VIRTUAL_STOP
 
+        if seq_block.is_committed:
+            for lc_idx, lc in self.manager._life_cycles.attention_life_cycles():
+                stale_range = _KVCache._get_stale_range(tokens_per_block, self.history_length, lc)
+                if ordinal in stale_range:
+                    for beam_block in seq_block.pages:
+                        beam_block[lc_idx] = None
+
         if is_last or self._commit_state == self.CommitState.VIRTUAL_STOP:
             self._commit_state = self.CommitState.USER_STOP
             self._on_stop_committing()

--- a/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
+++ b/tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py
@@ -343,7 +343,9 @@ class TestNoBatching(TestKVCacheManagerV2):
             req_id, self.manager.create_kv_cache(reuse_scope, prompt), prompt, decode_len
         )
 
-    def run_request(self, req: Request, interval: int, refcheck: bool) -> float:
+    def run_request(
+        self, req: Request, interval: int, refcheck: bool, delay_commit: bool = False
+    ) -> float:
         req_id, kv_cache, prompt, decode_len = req
         assert kv_cache.status == _KVCache.Status.ACTIVE
         stream = kv_cache.cuda_stream
@@ -366,7 +368,8 @@ class TestNoBatching(TestKVCacheManagerV2):
         for _ in range(decode_len):
             required_capacity = len(history) + 1
             if required_capacity > capacity:
-                kv_cache.commit(history[kv_cache.history_length :])
+                if not delay_commit:
+                    kv_cache.commit(history[kv_cache.history_length :])
                 # workaround a mypyc bug: exception in property setter is not propagated
                 # kv_cache.capacity = round_up(required_capacity, interval)
                 if not kv_cache.resize(round_up(required_capacity, interval)):
@@ -391,6 +394,7 @@ class TestNoBatching(TestKVCacheManagerV2):
         interval: int = 1,
         refcheck: bool = True,
         use_external_page_index_buf: bool = False,
+        delay_commit: bool = False,
     ) -> float:
         prompt_len = 1
         decode_len = seq_len - prompt_len
@@ -413,7 +417,7 @@ class TestNoBatching(TestKVCacheManagerV2):
             kv_cache = req0.kv_cache
             success = kv_cache.resume(stream)
             assert success
-            time_taken = self.run_request(req0, interval, refcheck)
+            time_taken = self.run_request(req0, interval, refcheck, delay_commit)
 
         s.take_finish_event().synchronize()
         kv_cache.close()
@@ -576,9 +580,14 @@ class TestNoBatching(TestKVCacheManagerV2):
         self.assertGreater(num_reused(None), 0)
         self.assertGreater(num_reused(default_scope), 0)
 
-    @parameterized.expand(list(itertools.product([False, True], repeat=2)))
+    @parameterized.expand(list(itertools.product([False, True], repeat=3)))
     # @assert_no_ref_cycle
-    def test_naive(self, use_external_page_index_buf: bool, use_block_quant: bool) -> None:
+    def test_naive(
+        self,
+        use_external_page_index_buf: bool,
+        use_block_quant: bool,
+        delay_commit: bool,
+    ) -> None:
         self.prepare(
             256 << 20,
             256 << 20,
@@ -588,7 +597,7 @@ class TestNoBatching(TestKVCacheManagerV2):
             48,
             block_quant_buf_size=(1024 if use_block_quant else None),
         )
-        self.run_naive(512, 1, True, use_external_page_index_buf)
+        self.run_naive(512, 1, True, use_external_page_index_buf, delay_commit=delay_commit)
 
     @parameterized.expand([(2**i, False) for i in range(12)])
     # @parameterized.expand([(32, True)])


### PR DESCRIPTION
@coderabbitai summary

## Description

Cherry-picks two merged `kv_cache_manager_v2` fixes from `feat/deepseek_v4` to `main`:

- `#14531` / `e4a5978ca1c81fe304559b251b826350f21b4d7c`: count only newly-added scratch blocks during resize.
- `#14478` / `210a290405ef9f262c49b0c5589f6657e156b012`: release stale-range holders after `_commit_block`.

## Test Coverage

Relevant coverage is in `tests/unittest/kv_cache_manager_v2_tests/test_kv_cache_manager_v2.py`, including the delayed commit path added by `#14478`. CI will cover this PR.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.