### PR TITLE
[https://nvbugs/6104831][fix] disagg KV transfer timeout observation

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
+++ b/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
@@ -35,6 +35,7 @@
 #include <torch/custom_class.h>
 #include <torch/python.h>
 #include <type_traits>
+#include <unordered_set>
 #include <vector>
 
 using SizeType32 = tensorrt_llm::runtime::SizeType32;
@@ -278,6 +279,10 @@ private:
     std::unique_ptr<CacheReceiver> mCacheReceiver;
     std::vector<std::pair<LlmRequest*, std::future<void>>> mSenderFutures;
     std::vector<std::pair<LlmRequest*, std::future<void>>> mRequesterFutures;
+    // Per-rank dedup sets so a hung request produces at most one timeout
+    // warning. Erased on request completion.
+    std::unordered_set<LlmRequest::RequestIdType> mTimedOutSenderIds;
+    std::unordered_set<LlmRequest::RequestIdType> mTimedOutRequesterIds;
     mpi::MpiComm const* mMpiWorldComm{nullptr};
 
     std::shared_ptr<CacheTransceiverComm> mGroupComm;

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -429,6 +429,11 @@ void CacheTransceiver::requestAndReceiveAsync(LlmRequest* llmRequest)
 {
     TLLM_CHECK(llmRequest && llmRequest->isGenerationOnlyRequest());
 
+    // Stamp transfer-start eagerly so the deadline observation in
+    // checkGenTransferStatus sees a valid elapsed time even before the
+    // worker thread runs. The worker re-stamps later.
+    llmRequest->setKvCacheTransferStart(std::chrono::steady_clock::now());
+
     if (std::find_if(mRequesterFutures.begin(), mRequesterFutures.end(),
             [llmRequest](auto const& pair) { return pair.first->mRequestId == llmRequest->mRequestId; })
         != mRequesterFutures.end())
@@ -541,10 +546,17 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
 {
     bool blockAll = !atLeastRequestNum.has_value();
     std::optional<int> senderFutureTimeoutMs = std::nullopt;
-    // If blockAll is true, we want to block and not use a timeout
-    if (!blockAll && mCacheTransceiverConfig.has_value())
+    // Overall transfer deadline observation, applied in both polling and
+    // block-all modes so a stuck sender is flagged regardless of mode.
+    std::optional<int> kvTransferTimeoutMs = std::nullopt;
+    if (mCacheTransceiverConfig.has_value())
     {
-        senderFutureTimeoutMs = mCacheTransceiverConfig->getKvTransferSenderFutureTimeoutMs();
+        kvTransferTimeoutMs = mCacheTransceiverConfig->getKvTransferTimeoutMs();
+        // If blockAll is true, we want to block and not use a per-iteration timeout
+        if (!blockAll)
+        {
+            senderFutureTimeoutMs = mCacheTransceiverConfig->getKvTransferSenderFutureTimeoutMs();
+        }
     }
 
     auto syncComm = mCacheState->getParallelConfig().mEnableAttentionDP ? mGroupTPInDPComm : mGroupTensorParaComm;
@@ -602,6 +614,27 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
     for (auto it = mSenderFutures.begin(); it != mSenderFutures.end();)
     {
         auto& [request, future] = *it;
+        // Per-request deadline observation, deduped via mTimedOutSenderIds
+        // so a hung request produces at most one warning. Observe-only;
+        // the request is left in mSenderFutures so natural completion
+        // is still detected.
+        if (kvTransferTimeoutMs.has_value())
+        {
+            auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - request->getKvCacheTransferStart());
+            auto elapsedMs = static_cast<long>(elapsed.count());
+            if (elapsedMs > kvTransferTimeoutMs.value())
+            {
+                bool const firstTimeout = mTimedOutSenderIds.insert(request->mRequestId).second;
+                if (firstTimeout)
+                {
+                    TLLM_LOG_WARNING(
+                        "Context KV cache transfer for request %ld exceeded total timeout: "
+                        "elapsed %ld ms > limit %d ms. Observe-only; continuing to wait.",
+                        request->mRequestId, elapsedMs, kvTransferTimeoutMs.value());
+                }
+            }
+        }
         if (blockAll || (toCompleteIdSet.find(request->mRequestId) != toCompleteIdSet.end()))
         {
             try
@@ -616,6 +649,7 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                     {
                         request->setState(LlmRequestState::kDISAGG_CONTEXT_COMPLETE);
                     }
+                    mTimedOutSenderIds.erase(request->mRequestId);
                     it = mSenderFutures.erase(it);
                 }
                 else if (status == std::future_status::timeout)
@@ -631,6 +665,7 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
 
                     request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
                     requestsStatus.errorRequestIds.insert(request->mRequestId);
+                    mTimedOutSenderIds.erase(request->mRequestId);
                     it = mSenderFutures.erase(it);
                 }
             }
@@ -640,6 +675,7 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                     "Error occurred during context transfer for request %ld: %s", request->mRequestId, e.what());
                 request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
                 requestsStatus.errorRequestIds.insert(request->mRequestId);
+                mTimedOutSenderIds.erase(request->mRequestId);
                 it = mSenderFutures.erase(it);
             }
         }
@@ -655,6 +691,14 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
 void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastRequestNum)
 {
     bool blockAll = !atLeastRequestNum.has_value();
+    // Overall transfer deadline observation, symmetric with the
+    // checkContextTransferStatus implementation; mTimedOutRequesterIds
+    // dedups warnings.
+    std::optional<int> kvTransferTimeoutMs = std::nullopt;
+    if (mCacheTransceiverConfig.has_value())
+    {
+        kvTransferTimeoutMs = mCacheTransceiverConfig->getKvTransferTimeoutMs();
+    }
     std::vector<LlmRequest::RequestIdType> genTransferReadyRequestIds;
     for (auto&& [request, future] : mRequesterFutures)
     {
@@ -767,6 +811,25 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
     }
     for (auto it = mRequesterFutures.begin(); it != mRequesterFutures.end();)
     {
+        // Per-request deadline observation; symmetric with
+        // checkContextTransferStatus, deduped via mTimedOutRequesterIds.
+        if (kvTransferTimeoutMs.has_value())
+        {
+            auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - it->first->getKvCacheTransferStart());
+            auto elapsedMs = static_cast<long>(elapsed.count());
+            if (elapsedMs > kvTransferTimeoutMs.value())
+            {
+                bool const firstTimeout = mTimedOutRequesterIds.insert(it->first->mRequestId).second;
+                if (firstTimeout)
+                {
+                    TLLM_LOG_WARNING(
+                        "Generation KV cache transfer for request %ld exceeded total timeout: "
+                        "elapsed %ld ms > limit %d ms. Observe-only; continuing to wait.",
+                        it->first->mRequestId, elapsedMs, kvTransferTimeoutMs.value());
+                }
+            }
+        }
         if (blockAll || toCompleteIdSet.find(it->first->mRequestId) != toCompleteIdSet.end())
         {
             try
@@ -799,6 +862,7 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
                     "**** it->first->mRequestId: %ld, context request ID: %ld ******** get feature ***",
                     it->first->mRequestId, it->first->getContextPhaseParams().value().getReqId());
             }
+            mTimedOutRequesterIds.erase(it->first->mRequestId);
             it = mRequesterFutures.erase(it);
         }
         else

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -374,13 +374,6 @@ class PyExecutor:
         self.num_fetch_requests_cur_rank = 0
         self.num_fetch_requests = 0
         self.shutdown_event = threading.Event()
-        self._disagg_gen_init_prepared_ids: Dict[
-            ResourceManagerType, set[int]] = {
-                ResourceManagerType.KV_CACHE_MANAGER: set(),
-                ResourceManagerType.SPEC_RESOURCE_MANAGER: set(),
-                ResourceManagerType.DRAFT_KV_CACHE_MANAGER: set(),
-            }
-        self._disagg_gen_kv_recv_started_ids: set[int] = set()
 
         # Rolling acceptance tracking for spec decode (disable speculation if rolling acceptance is below threshold)
         spec_config = getattr(self.model_engine, 'spec_config', None)
@@ -3820,6 +3813,9 @@ class PyExecutor:
     @nvtx_range("_prepare_disagg_gen_init")
     def _prepare_disagg_gen_init(self, fitting_disagg_gen_init_requests):
         if fitting_disagg_gen_init_requests:
+            disagg_gen_init_to_prepare = ScheduledRequests()
+            disagg_gen_init_to_prepare.context_requests_last_chunk = fitting_disagg_gen_init_requests
+
             for resource_mgr_type in (
                     ResourceManagerType.KV_CACHE_MANAGER,
                     ResourceManagerType.SPEC_RESOURCE_MANAGER,
@@ -3827,22 +3823,9 @@ class PyExecutor:
                 if (resource_mgr_type in self.resource_manager.resource_managers
                         and self.resource_manager.
                         resource_managers[resource_mgr_type] is not None):
-                    prepared_ids = self._disagg_gen_init_prepared_ids[
-                        resource_mgr_type]
-                    resources_to_prepare = [
-                        req for req in fitting_disagg_gen_init_requests
-                        if req.py_request_id not in prepared_ids
-                    ]
-                    if not resources_to_prepare:
-                        continue
-
-                    disagg_gen_init_to_prepare = ScheduledRequests()
-                    disagg_gen_init_to_prepare.context_requests_last_chunk = resources_to_prepare
                     self.resource_manager.resource_managers[
                         resource_mgr_type].prepare_resources(
                             disagg_gen_init_to_prepare)
-                    for req in resources_to_prepare:
-                        prepared_ids.add(req.py_request_id)
 
             # Trigger KV cache exchange for new disagg_gen_init_requests
             self._recv_disagg_gen_cache(fitting_disagg_gen_init_requests)
@@ -3928,29 +3911,12 @@ class PyExecutor:
                 req.state = LlmRequestState.DISAGG_GENERATION_TRANS_COMPLETE
             return
 
-        recv_reqs = [
-            req for req in new_gen_reqs
-            if req.py_request_id not in self._disagg_gen_kv_recv_started_ids
-        ]
-
         if os.getenv("TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP") == "1":
-            for req in recv_reqs:
-                self._disagg_gen_kv_recv_started_ids.add(req.py_request_id)
-                try:
-                    self.kv_cache_transceiver.request_and_receive_sync(req)
-                except Exception:
-                    self._disagg_gen_kv_recv_started_ids.discard(
-                        req.py_request_id)
-                    raise
+            for req in new_gen_reqs:
+                self.kv_cache_transceiver.request_and_receive_sync(req)
         else:
-            for req in recv_reqs:
-                self._disagg_gen_kv_recv_started_ids.add(req.py_request_id)
-                try:
-                    self.kv_cache_transceiver.request_and_receive_async(req)
-                except Exception:
-                    self._disagg_gen_kv_recv_started_ids.discard(
-                        req.py_request_id)
-                    raise
+            for req in new_gen_reqs:
+                self.kv_cache_transceiver.request_and_receive_async(req)
 
         if self.kv_cache_transceiver.kv_transfer_timeout_ms is not None:
             for req in new_gen_reqs:
@@ -4398,10 +4364,6 @@ class PyExecutor:
 
         if self.gather_all_responses or self.dist.rank == 0:
             self.result_wait_queues.pop(request.py_request_id, None)
-
-        for prepared_ids in self._disagg_gen_init_prepared_ids.values():
-            prepared_ids.discard(request.py_request_id)
-        self._disagg_gen_kv_recv_started_ids.discard(request.py_request_id)
 
     def _is_request_in_transmission(self, request) -> bool:
         """Check if a request is currently in transmission state."""

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -374,6 +374,13 @@ class PyExecutor:
         self.num_fetch_requests_cur_rank = 0
         self.num_fetch_requests = 0
         self.shutdown_event = threading.Event()
+        self._disagg_gen_init_prepared_ids: Dict[
+            ResourceManagerType, set[int]] = {
+                ResourceManagerType.KV_CACHE_MANAGER: set(),
+                ResourceManagerType.SPEC_RESOURCE_MANAGER: set(),
+                ResourceManagerType.DRAFT_KV_CACHE_MANAGER: set(),
+            }
+        self._disagg_gen_kv_recv_started_ids: set[int] = set()
 
         # Rolling acceptance tracking for spec decode (disable speculation if rolling acceptance is below threshold)
         spec_config = getattr(self.model_engine, 'spec_config', None)
@@ -3813,9 +3820,6 @@ class PyExecutor:
     @nvtx_range("_prepare_disagg_gen_init")
     def _prepare_disagg_gen_init(self, fitting_disagg_gen_init_requests):
         if fitting_disagg_gen_init_requests:
-            disagg_gen_init_to_prepare = ScheduledRequests()
-            disagg_gen_init_to_prepare.context_requests_last_chunk = fitting_disagg_gen_init_requests
-
             for resource_mgr_type in (
                     ResourceManagerType.KV_CACHE_MANAGER,
                     ResourceManagerType.SPEC_RESOURCE_MANAGER,
@@ -3823,9 +3827,22 @@ class PyExecutor:
                 if (resource_mgr_type in self.resource_manager.resource_managers
                         and self.resource_manager.
                         resource_managers[resource_mgr_type] is not None):
+                    prepared_ids = self._disagg_gen_init_prepared_ids[
+                        resource_mgr_type]
+                    resources_to_prepare = [
+                        req for req in fitting_disagg_gen_init_requests
+                        if req.py_request_id not in prepared_ids
+                    ]
+                    if not resources_to_prepare:
+                        continue
+
+                    disagg_gen_init_to_prepare = ScheduledRequests()
+                    disagg_gen_init_to_prepare.context_requests_last_chunk = resources_to_prepare
                     self.resource_manager.resource_managers[
                         resource_mgr_type].prepare_resources(
                             disagg_gen_init_to_prepare)
+                    for req in resources_to_prepare:
+                        prepared_ids.add(req.py_request_id)
 
             # Trigger KV cache exchange for new disagg_gen_init_requests
             self._recv_disagg_gen_cache(fitting_disagg_gen_init_requests)
@@ -3911,12 +3928,29 @@ class PyExecutor:
                 req.state = LlmRequestState.DISAGG_GENERATION_TRANS_COMPLETE
             return
 
+        recv_reqs = [
+            req for req in new_gen_reqs
+            if req.py_request_id not in self._disagg_gen_kv_recv_started_ids
+        ]
+
         if os.getenv("TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP") == "1":
-            for req in new_gen_reqs:
-                self.kv_cache_transceiver.request_and_receive_sync(req)
+            for req in recv_reqs:
+                self._disagg_gen_kv_recv_started_ids.add(req.py_request_id)
+                try:
+                    self.kv_cache_transceiver.request_and_receive_sync(req)
+                except Exception:
+                    self._disagg_gen_kv_recv_started_ids.discard(
+                        req.py_request_id)
+                    raise
         else:
-            for req in new_gen_reqs:
-                self.kv_cache_transceiver.request_and_receive_async(req)
+            for req in recv_reqs:
+                self._disagg_gen_kv_recv_started_ids.add(req.py_request_id)
+                try:
+                    self.kv_cache_transceiver.request_and_receive_async(req)
+                except Exception:
+                    self._disagg_gen_kv_recv_started_ids.discard(
+                        req.py_request_id)
+                    raise
 
         if self.kv_cache_transceiver.kv_transfer_timeout_ms is not None:
             for req in new_gen_reqs:
@@ -4364,6 +4398,10 @@ class PyExecutor:
 
         if self.gather_all_responses or self.dist.rank == 0:
             self.result_wait_queues.pop(request.py_request_id, None)
+
+        for prepared_ids in self._disagg_gen_init_prepared_ids.values():
+            prepared_ids.discard(request.py_request_id)
+        self._disagg_gen_kv_recv_started_ids.discard(request.py_request_id)
 
     def _is_request_in_transmission(self, request) -> bool:
         """Check if a request is currently in transmission state."""


### PR DESCRIPTION
## Summary

Carves out the observe-only KV-transfer deadline diagnostics from PR #13713 into a smaller, mergeable change. No in-flight cancellation logic; no action is taken on timeout — the WARN is strictly diagnostic.

This PR originally also contained the Python recv-side dedup sets. That portion (A3 in PR #13713's component taxonomy) was reverted in commit `7589b865ff` to keep the scope minimal and to test whether the cross-rank divergence observed during PR #13713's CI is sensitive to A3.

## What this PR changes (all ports from PR #13713)

| Code name (per PR #13713) | What it is | Files |
|---|---|---|
| **A4** | `mTimedOutSenderIds` / `mTimedOutRequesterIds` dedup sets so the timeout WARN fires at most once per stuck request | `cacheTransceiver.h` |
| **A6** | Eager `setKvCacheTransferStart(now())` at the entry of `requestAndReceiveAsync` so the deadline observation sees a valid elapsed time even before the worker thread has stamped it | `cacheTransceiver.cpp` |
| **A7** | Observe-only timeout WARN sites in `checkContextTransferStatus` and `checkGenTransferStatus`. Emitted when the configured `kv_transfer_timeout_ms` is exceeded. No state transition, no eviction, no cancellation triggered. Dedup'd via A4. | `cacheTransceiver.cpp` |

## Issue these resolve independent of in-flight cancellation

Today a wedged disagg KV transfer (peer crash, network partition, slow disk) is silent — the request blocks indefinitely with no operator-visible signal identifying which request is stuck or for how long. This PR gives operators a triage anchor.

- The WARN is only emitted when the user has configured `kv_transfer_timeout_ms`.
- A4's dedup prevents the WARN from flooding the log on every poll iteration.
- A6 ensures the elapsed-time math is correct even on the first iteration after the request enters the futures vector, before the worker thread has had a chance to stamp the start time itself.

## What this PR explicitly excludes

| Code name (per PR #13713) | Why excluded |
|---|---|
| **A3** | Recv-side dedup sets (`_disagg_gen_init_prepared_ids` / `_disagg_gen_kv_recv_started_ids`). Reverted in commit `7589b865ff` because they exist primarily to make recv idempotent under the cancel-throw retry pattern, which is not in scope here. Without that pattern, the scheduler's state-based filter is sufficient. |
| **G1–G8** | All in-flight cancellation logic from PR #13713 (env var, `cancel_request`, `sendHolder.poison()`, `mInFlightCancelFlags`, deferred-cleanup paths, fail-closed checks, promise idempotency, etc.). |
| **A5** | Reordering of `setState` / `receiveAsync` / `emplace` in `requestAndReceiveAsync`. Upstream ordering preserved. |