### PR TITLE
qwen: Add support for Qwen3-Embedding models in encode_only mode

### DIFF
--- a/tensorrt_llm/models/qwen/config.py
+++ b/tensorrt_llm/models/qwen/config.py
@@ -35,6 +35,7 @@ class QWenConfig(PretrainedConfig):
                  num_labels: int = 1,
                  mlp_only_layers: Optional[list] = None,
                  decoder_sparse_step: int = 1,
+                 is_embedding: bool = False,
                  **kwargs):
         self.mlp_bias = mlp_bias
         self.attn_bias = attn_bias
@@ -45,6 +46,7 @@ class QWenConfig(PretrainedConfig):
         self.use_logn_attn = use_logn_attn
         self.mlp_only_layers = mlp_only_layers or []
         self.decoder_sparse_step = decoder_sparse_step
+        self.is_embedding = is_embedding
         if moe is None:
             # Legacy MOE config fields
             moe = MoeConfig(num_experts=kwargs.pop('moe_num_experts', 0),
@@ -112,7 +114,7 @@ class QWenConfig(PretrainedConfig):
             hf_config.architectures = ['Qwen2ForCausalLM']
 
         valid_types = ('qwen', 'qwen2', 'qwen2_moe', 'qwen2_llava_onevision',
-                       'qwen2_vl', 'qwen2_audio', 'qwen3', 'qwen3_moe')
+                       'qwen2_vl', 'qwen2_audio', 'qwen3', 'qwen3_moe', 'qwen3_embedding')
         assert qwen_type in valid_types, f"Unsupported Qwen type: {qwen_type}, only {valid_types} are acceptable."
         num_key_value_heads = getattr(hf_config, "num_key_value_heads",
                                       hf_config.num_attention_heads)
@@ -125,7 +127,7 @@ class QWenConfig(PretrainedConfig):
             hidden_act = "swiglu"
 
         # Qwen3 models have no attention bias, while legacy models have bias
-        if qwen_type in ('qwen3', 'qwen3_moe'):
+        if qwen_type in ('qwen3', 'qwen3_moe', 'qwen3_embedding'):
             attn_bias = False  # Qwen3 models have no attn bias
         else:
             attn_bias = True  # Legacy Qwen models have attn bias
@@ -141,9 +143,14 @@ class QWenConfig(PretrainedConfig):
             rms_norm_eps = hf_config.rms_norm_eps
             rotary_base = get_hf_rope_theta(hf_config, 100000.0)
 
+        
         num_labels = 1
         if hf_config.architectures[0] == "Qwen2ForSequenceClassification":
             num_labels = hf_config.num_labels
+
+        is_embedding = False
+        if hf_config.architectures[0] in ["Qwen2ForRewardModel", "Qwen2ForEmbedding", "Qwen3ForEmbedding"]:
+            is_embedding = True
 
         moe_num_experts = getattr(hf_config, "num_experts", 0)
         moe_top_k = getattr(hf_config, "num_experts_per_tok", 0)
@@ -208,4 +215,5 @@ class QWenConfig(PretrainedConfig):
             quantization=quant_config,
             num_labels=num_labels,
             tie_word_embeddings=tie_word_embeddings,
+            is_embedding=is_embedding,
             **kwargs)

--- a/tensorrt_llm/models/qwen/model.py
+++ b/tensorrt_llm/models/qwen/model.py
@@ -248,6 +248,8 @@ class QWenForCausalLM(DecoderModelForCausalLM):
                                        tp_group=config.mapping.tp_group,
                                        tp_size=config.mapping.tp_size,
                                        gather_output=True)
+            elif getattr(config, 'is_embedding', False):
+                lm_head = None
             else:
                 lm_head = ColumnLinear(config.hidden_size,
                                        vocab_size_padded,
@@ -376,6 +378,11 @@ class QWenForCausalLM(DecoderModelForCausalLM):
                     "lm_head": "language_model.lm_head",
                 }
             elif config.qwen_type == "qwen3":
+                custom_dict = {
+                    "q_layernorm": "q_norm",
+                    "k_layernorm": "k_norm",
+                }
+            elif getattr(config, 'is_embedding', False):
                 custom_dict = {
                     "q_layernorm": "q_norm",
                     "k_layernorm": "k_norm",


### PR DESCRIPTION

### Description
This PR introduces support for Qwen3-Embedding architectures within the Qwen model implementation. It enables `encode_only` mode by bypassing the language modeling head projection when an embedding or reward model architecture is detected.

### Changes
- **config.py**: Added `is_embedding` attribute to `QWenConfig` and auto-detection logic within `from_hugging_face` for mapping embedding-specific architectures (e.g., Qwen2ForRewardModel, Qwen2ForEmbedding, Qwen3ForEmbedding).
- **model.py**: Updated `QWenForCausalLM.__init__` to suppress `lm_head` allocation when `is_embedding` is active. Updated the `ModelWeightsLoader` custom dictionary to gracefully process layer normalization weights without requiring classification target bounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Qwen model support to include dedicated embedding architectures with specialized configuration handling.
  * Implemented automatic detection and proper initialization of embedding-only model variants during HuggingFace conversion.
  * Added optimized weight mapping for embedding model types to ensure correct model structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->