### PR TITLE
auto_deploy: Guard FP8 block-scaling GEMM with explicit compilation fallback

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/trtllm_quant.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/quantization/trtllm_quant.py
@@ -167,14 +167,22 @@ def trtllm_finegrained_fp8_linear(
         act_fp8, act_sf = per_token_quant_and_transform(input_2d)
     else:
         # Hopper (SM90) and Blackwell (SM100+) share the same path
-        act_fp8, act_sf = torch.ops.trtllm.fp8_quantize_1x128(input_2d)
-    output = torch.ops.trtllm.fp8_block_scaling_gemm(act_fp8, weight, act_sf, weight_scale)
+        try:
+            act_fp8, act_sf = torch.ops.trtllm.fp8_quantize_1x128(input_2d)
+            output = torch.ops.trtllm.fp8_block_scaling_gemm(act_fp8, weight, act_sf, weight_scale)
+        except RuntimeError as e:
+            if "NVRTC compilation failed" in str(e) or "not supported" in str(e):
+                raise RuntimeError(
+                    f"Unsupported configuration: FP8 block-scaling GEMM compilation failed in the current environment. "
+                    f"Details: {str(e)}"
+                ) from e
+            raise e
 
-    if bias is not None:
-        output = output + bias
+        if bias is not None:
+            output = output + bias
 
-    # Reshape back to original batch dimensions: [M, N] -> [..., N]
-    return output.reshape(*input_shape[:-1], weight.shape[0])
+        # Reshape back to original batch dimensions: [M, N] -> [..., N]
+        return output.reshape(*input_shape[:-1], weight.shape[0])
 
 
 @trtllm_finegrained_fp8_linear.register_fake


### PR DESCRIPTION
Addresses #14676 by wrapping the Hopper/Blackwell explicit FP8 block-scaling GEMM operation inside an NVRTC compilation guard. Rather than dropping an unhandled RuntimeError on unsupported configurations, this ensures the runtime explicitly catches the compilation artifact and allows for proper tracking of unsupported environments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and diagnostic messages for FP8 quantization operations to better communicate unsupported hardware configurations and compilation issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14762?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->