### PR TITLE
[TRTLLM-12507][feat] Add routed-expert LoRA helpers

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
@@ -190,14 +190,12 @@ def resolve_moe_cls(
 
     # Routed-expert MoE LoRA runs only on CutlassFusedMoE with unquantized base
     # weights. Fail at construction time rather than silently dropping the LoRA
-    # contribution at runtime. Only the exact CutlassFusedMoE class runs the
-    # LoRA-capable kernel; its subclasses (CuteDsl/DeepGemm/...) reuse the class
-    # but run other kernels. Use identity, not isinstance, and surface the
-    # user's requested backend name in the error when it is not the Cutlass kernel.
-    resolved_backend = ("CUTLASS" if moe_cls is CutlassFusedMoE else
-                        model_config.moe_backend)
+    # contribution at runtime. The exact-Cutlass-kernel rule and error
+    # formatting live in `check_moe_lora_supported()`; we only hand it the
+    # resolved class and the originally requested backend name.
     check_moe_lora_supported(
-        moe_backend_name=resolved_backend,
+        moe_cls=moe_cls,
+        requested_moe_backend=model_config.moe_backend,
         lora_config=model_config.lora_config,
         quant_config=effective_quant_config,
         layer_idx=layer_idx,

--- a/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
@@ -9,6 +9,7 @@ from tensorrt_llm.logger import logger
 from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
 
 from ...model_config import ModelConfig
+from ...peft.lora.moe_utils import check_moe_lora_supported
 from ...utils import ActivationType, AuxStreamType
 from .configurable_moe import ConfigurableMoE
 from .fused_moe_cute_dsl import CuteDslFusedMoE
@@ -185,7 +186,22 @@ def resolve_moe_cls(
     if (moe_cls == TRTLLMGenFusedMoE and not has_quant
             and not TRTLLMGenFusedMoE._supports_flashinfer_bf16_routing_method(
                 routing_method)):
-        return CutlassFusedMoE
+        moe_cls = CutlassFusedMoE
+
+    # Routed-expert MoE LoRA runs only on CutlassFusedMoE with unquantized base
+    # weights. Fail at construction time rather than silently dropping the LoRA
+    # contribution at runtime. Only the exact CutlassFusedMoE class runs the
+    # LoRA-capable kernel; its subclasses (CuteDsl/DeepGemm/...) reuse the class
+    # but run other kernels. Use identity, not isinstance, and surface the
+    # user's requested backend name in the error when it is not the Cutlass kernel.
+    resolved_backend = ("CUTLASS" if moe_cls is CutlassFusedMoE else
+                        model_config.moe_backend)
+    check_moe_lora_supported(
+        moe_backend_name=resolved_backend,
+        lora_config=model_config.lora_config,
+        quant_config=effective_quant_config,
+        layer_idx=layer_idx,
+    )
 
     return moe_cls
 

--- a/tensorrt_llm/_torch/peft/lora/moe_utils.py
+++ b/tensorrt_llm/_torch/peft/lora/moe_utils.py
@@ -31,17 +31,29 @@ def has_moe_lora_targets(lora_config: LoraConfig | None) -> bool:
 
 def check_moe_lora_supported(
     *,
-    moe_backend_name: str,
+    moe_cls: type,
+    requested_moe_backend: str | None,
     lora_config: LoraConfig | None,
     quant_config,
     layer_idx: int | None = None,
 ) -> None:
-    """Raise `ValueError` if a routed-expert MoE LoRA cannot run on the chosen
+    """Raise `ValueError` if a routed-expert MoE LoRA cannot run on the resolved
     backend / quant combination.
 
+    This centralizes the MoE-LoRA support policy: callers (the MoE factory in
+    `create_moe.py`) only resolve the backend class and pass it in, while the
+    exact-Cutlass-kernel rule and error formatting live here next to the
+    quant/backend support matrix.
+
     Args:
-        moe_backend_name: The resolved `moe_backend` string (e.g. "CUTLASS",
-            "WIDEEP", "TRTLLM"). Comparison is case-insensitive.
+        moe_cls: The resolved MoE backend class returned by `get_moe_cls()` /
+            `resolve_moe_cls()`. Only the exact `CutlassFusedMoE` class runs the
+            LoRA-capable kernel; its subclasses (CuteDsl / DeepGemm / ...) reuse
+            the class but dispatch to other kernels, so identity (`is`) is used
+            rather than `isinstance`.
+        requested_moe_backend: The originally requested `moe_backend` string
+            (e.g. "CUTLASS", "WIDEEP", "TRTLLM"), surfaced in the error message
+            so the user sees the backend they asked for.
         lora_config: The model's `LoraConfig`, or None.
         quant_config: The model's `QuantConfig`, or None. We only reject when
             the layer is actually quantized. The per-layer `layer_quant_mode`
@@ -49,9 +61,9 @@ def check_moe_lora_supported(
             used for backend selection under mixed/per-layer quantization.
         layer_idx: Optional layer index for diagnostic messages.
 
-    Constraints (MVP):
-        - MoE backend MUST be CUTLASS.
-        - Base weight quantization MUST be off (no FP8 / FP4 / INT8 / INT4 / W4A8 ...).
+    Constraints:
+        - Resolved MoE backend must be the Cutlass kernel (`CutlassFusedMoE`).
+        - Base weight quantization must be off (no FP8, FP4, INT8, INT4, W4A8, etc.).
 
     Other constraints (alltoall, min-latency, FP4, CUDA-graph) are enforced at
     runtime; we do not pre-check them here because they depend on per-call
@@ -62,11 +74,15 @@ def check_moe_lora_supported(
 
     prefix = f"[layer_idx={layer_idx}] " if layer_idx is not None else ""
 
-    if (moe_backend_name or "").upper() != "CUTLASS":
+    # Lazy import to avoid a circular import: create_moe.py imports this module.
+    from tensorrt_llm._torch.modules.fused_moe.fused_moe_cutlass import CutlassFusedMoE
+
+    if moe_cls is not CutlassFusedMoE:
         raise ValueError(
-            f"{prefix}Routed-expert MoE LoRA requires moe_backend='CUTLASS'; got "
-            f"moe_backend={moe_backend_name!r}. Disable LoRA on MoE modules "
-            f"(remove {sorted(MOE_MODULE_SHARED_FLAG)} from "
+            f"{prefix}Routed-expert MoE LoRA requires the Cutlass MoE backend; "
+            f"got moe_backend={requested_moe_backend!r} (resolved to "
+            f"{getattr(moe_cls, '__name__', moe_cls)}). Disable LoRA on MoE "
+            f"modules (remove {sorted(MOE_MODULE_SHARED_FLAG)} from "
             "lora_config.lora_target_modules) or switch to the Cutlass MoE backend."
         )
 
@@ -86,10 +102,10 @@ def check_moe_lora_supported(
                 is_quantized = bool(quant_mode.has_any_quant())
         if is_quantized:
             raise ValueError(
-                f"{prefix}Routed-expert MoE LoRA MVP only supports unquantized "
+                f"{prefix}Routed-expert MoE LoRA only supports unquantized "
                 f"fp16/bf16 base weights; got quant_mode={quant_mode}. "
                 "FP8/FP4/INT4/INT8 base weights combined with MoE LoRA are not "
-                "supported yet."
+                "supported."
             )
 
 

--- a/tensorrt_llm/_torch/peft/lora/moe_utils.py
+++ b/tensorrt_llm/_torch/peft/lora/moe_utils.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Routed-expert (MoE) LoRA validation and synthetic-adapter tooling."""
+
+from collections.abc import Iterable
+from typing import Literal
+
+import torch
+
+from tensorrt_llm.lora_helper import MOE_MODULE_SHARED_FLAG, LoraConfig
+
+SharedSide = Literal["A", "B", None]
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def _normalize_targets(lora_target_modules: Iterable[str]) -> set[str]:
+    return {name.lower() for name in lora_target_modules or []}
+
+
+def has_moe_lora_targets(lora_config: LoraConfig | None) -> bool:
+    """Return True iff `lora_config` requests LoRA on any routed-expert MoE module."""
+    if lora_config is None:
+        return False
+    targets = _normalize_targets(lora_config.lora_target_modules)
+    return bool(MOE_MODULE_SHARED_FLAG.keys() & targets)
+
+
+def check_moe_lora_supported(
+    *,
+    moe_backend_name: str,
+    lora_config: LoraConfig | None,
+    quant_config,
+    layer_idx: int | None = None,
+) -> None:
+    """Raise `ValueError` if a routed-expert MoE LoRA cannot run on the chosen
+    backend / quant combination.
+
+    Args:
+        moe_backend_name: The resolved `moe_backend` string (e.g. "CUTLASS",
+            "WIDEEP", "TRTLLM"). Comparison is case-insensitive.
+        lora_config: The model's `LoraConfig`, or None.
+        quant_config: The model's `QuantConfig`, or None. We only reject when
+            the layer is actually quantized. The per-layer `layer_quant_mode`
+            is preferred over the global `quant_mode` so this matches the view
+            used for backend selection under mixed/per-layer quantization.
+        layer_idx: Optional layer index for diagnostic messages.
+
+    Constraints (MVP):
+        - MoE backend MUST be CUTLASS.
+        - Base weight quantization MUST be off (no FP8 / FP4 / INT8 / INT4 / W4A8 ...).
+
+    Other constraints (alltoall, min-latency, FP4, CUDA-graph) are enforced at
+    runtime; we do not pre-check them here because they depend on per-call
+    state that isn't available at factory time.
+    """
+    if not has_moe_lora_targets(lora_config):
+        return
+
+    prefix = f"[layer_idx={layer_idx}] " if layer_idx is not None else ""
+
+    if (moe_backend_name or "").upper() != "CUTLASS":
+        raise ValueError(
+            f"{prefix}Routed-expert MoE LoRA requires moe_backend='CUTLASS'; got "
+            f"moe_backend={moe_backend_name!r}. Disable LoRA on MoE modules "
+            f"(remove {sorted(MOE_MODULE_SHARED_FLAG)} from "
+            "lora_config.lora_target_modules) or switch to the Cutlass MoE backend."
+        )
+
+    if quant_config is not None:
+        # Prefer the per-layer quant mode so this check agrees with the
+        # backend-selection logic in create_moe.py, which also uses
+        # `layer_quant_mode`. Fall back to the global `quant_mode`.
+        quant_mode = getattr(quant_config, "layer_quant_mode", None)
+        if quant_mode is None:
+            quant_mode = getattr(quant_config, "quant_mode", None)
+        is_quantized = False
+        if quant_mode is not None and hasattr(quant_mode, "has_any_quant"):
+            try:
+                is_quantized = bool(quant_mode.has_any_quant(exclude_kv_cache=True))
+            except TypeError:
+                # Older signatures may not accept the kwarg; fall back.
+                is_quantized = bool(quant_mode.has_any_quant())
+        if is_quantized:
+            raise ValueError(
+                f"{prefix}Routed-expert MoE LoRA MVP only supports unquantized "
+                f"fp16/bf16 base weights; got quant_mode={quant_mode}. "
+                "FP8/FP4/INT4/INT8 base weights combined with MoE LoRA are not "
+                "supported yet."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Synthetic adapter tooling (unit tests)
+# ---------------------------------------------------------------------------
+
+
+def make_per_expert_lora(
+    num_experts: int,
+    rank: int,
+    in_dim: int,
+    out_dim: int,
+    *,
+    dtype: torch.dtype = torch.bfloat16,
+    device: torch.device = torch.device("cpu"),
+    shared_side: SharedSide = None,
+    seed: int | None = None,
+) -> dict[str, torch.Tensor]:
+    """Generate a (A, B) LoRA tensor pair for an MoE module.
+
+    Always returns shapes `A: [E, rank, in_dim]` and `B: [E, out_dim, rank]`,
+    suitable for `torch.stack(...)` in `tensorrt_llm/lora_manager.py`.
+
+    When `shared_side == "A"`, the same `[rank, in_dim]` matrix is replicated
+    across all `E` experts (load-time replication for shared-outer). Likewise
+    for `shared_side == "B"`. When `shared_side is None`, each expert gets
+    independent A and B matrices.
+
+    Args:
+        num_experts: number of experts in this MoE layer.
+        rank: LoRA rank for this module.
+        in_dim: input hidden size (e.g. `hidden_size` for moe_h_to_4h).
+        out_dim: output hidden size (e.g. `intermediate_size` for moe_h_to_4h).
+        dtype: tensor dtype.
+        device: tensor device.
+        shared_side: which side to replicate ("A", "B", or None).
+        seed: optional torch RNG seed for deterministic generation.
+
+    Returns:
+        Dict with keys "A" (shape [E, rank, in_dim]) and "B" (shape [E, out_dim, rank]).
+    """
+    if seed is not None:
+        gen = torch.Generator(device=device).manual_seed(seed)
+    else:
+        gen = None
+
+    def _randn(*shape):
+        return torch.randn(*shape, dtype=dtype, device=device, generator=gen)
+
+    if shared_side == "A":
+        shared_a = _randn(rank, in_dim)
+        a = shared_a.unsqueeze(0).expand(num_experts, -1, -1).contiguous()
+        b = _randn(num_experts, out_dim, rank)
+    elif shared_side == "B":
+        a = _randn(num_experts, rank, in_dim)
+        shared_b = _randn(out_dim, rank)
+        b = shared_b.unsqueeze(0).expand(num_experts, -1, -1).contiguous()
+    elif shared_side is None:
+        a = _randn(num_experts, rank, in_dim)
+        b = _randn(num_experts, out_dim, rank)
+    else:
+        raise ValueError(f"shared_side must be 'A', 'B', or None; got {shared_side!r}")
+
+    return {"A": a, "B": b}
+
+
+def reference_moe_lora_delta(
+    a_stacked: torch.Tensor,
+    b_stacked: torch.Tensor,
+    x: torch.Tensor,
+    token_to_expert: torch.Tensor,
+    *,
+    scale: float = 1.0,
+) -> torch.Tensor:
+    """Compute the reference LoRA delta `delta[t] = scale * (B[e_t] @ A[e_t] @ x[t])`
+    for a routed MoE layer, in eager PyTorch.
+
+    This is used by unit tests to check the fused MoE LoRA op against a
+    straightforward per-expert reference. Works for both per-expert and
+    shared-outer adapters as long as `a_stacked`/`b_stacked` are already
+    expanded to `[E, ...]`.
+
+    Args:
+        a_stacked: `[E, rank, in_dim]`
+        b_stacked: `[E, out_dim, rank]`
+        x:         `[num_tokens, in_dim]`
+        token_to_expert: `[num_tokens]` int tensor of expert indices.
+        scale: LoRA scale factor (`alpha / rank` for vanilla LoRA, `alpha / sqrt(rank)`
+            for rs-LoRA).
+
+    Returns:
+        Tensor of shape `[num_tokens, out_dim]`.
+    """
+    num_tokens = x.shape[0]
+    out_dim = b_stacked.shape[1]
+    output = torch.zeros(num_tokens, out_dim, dtype=x.dtype, device=x.device)
+    for t in range(num_tokens):
+        e = int(token_to_expert[t].item())
+        # (rank, in) @ (in,) -> (rank,)
+        mid = a_stacked[e] @ x[t]
+        # (out, rank) @ (rank,) -> (out,)
+        output[t] = scale * (b_stacked[e] @ mid)
+    return output

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -26,7 +26,8 @@ from tensorrt_llm.inputs.registry import (create_input_processor,
 from tensorrt_llm.llmapi.llm_args import (CudaGraphConfig, TorchCompileConfig,
                                           TorchLlmArgs)
 from tensorrt_llm.logger import logger
-from tensorrt_llm.lora_helper import LoraConfig
+from tensorrt_llm.lora_helper import (LoraConfig,
+                                      merge_moe_shared_flags_for_batch)
 from tensorrt_llm.lora_manager import LoraModelConfig
 from tensorrt_llm.mapping import CpType, Mapping
 
@@ -3750,12 +3751,15 @@ class PyTorchModelEngine(ModelEngine):
             peft_table = peft_cache_manager.get_and_reset_batch_peft_table(
             ) if peft_cache_manager is not None else None
             return peft_table and self._get_eager_lora_params_from_requests(
-                scheduled_requests, attn_metadata, peft_table)
+                scheduled_requests, attn_metadata, peft_table,
+                peft_cache_manager)
 
     def _get_eager_lora_params_from_requests(
-            self, scheduled_requests: ScheduledRequests,
+            self,
+            scheduled_requests: ScheduledRequests,
             attn_metadata: AttentionMetadata,
-            peft_table: Dict[int, list[TaskLayerModuleConfig]]):
+            peft_table: Dict[int, list[TaskLayerModuleConfig]],
+            peft_cache_manager: Optional[PeftCacheManager] = None):
         '''
         Eager mode LoRA parameter preparation logic.
 
@@ -3770,6 +3774,12 @@ class PyTorchModelEngine(ModelEngine):
                 }
             }
         }
+
+        When `peft_cache_manager` is supplied and the active LoRA uids share a
+        MoE side in common, `lora_params` also contains a top-level
+        `moe_shared_flags` dict consumed by the fused-MoE op. A side is marked
+        shared only when every active uid shares it; mixed batches fall back to
+        the per-expert read where adapters disagree.
         '''
         lora_params = {}
         tmp_lora_params = {}
@@ -3868,6 +3878,22 @@ class PyTorchModelEngine(ModelEngine):
             lora_params['host_request_types'] = host_request_types
             lora_params['prompt_lens_cpu'] = prompt_lens_cpu
             lora_params['num_seqs'] = num_seqs
+
+            # MoE shared-outer flags: translate the per-uid shared sides
+            # detected at load time into fused-MoE kernel flags and forward them
+            # into `lora_params`.
+            if peft_cache_manager is not None:
+                lora_manager = peft_cache_manager.get_lora_manager()
+                active_uids = sorted({
+                    str(req.lora_task_id)
+                    for req in request_list if req.lora_task_id is not None
+                })
+                moe_flags = merge_moe_shared_flags_for_batch(
+                    active_uids,
+                    lora_manager.get_moe_shared_flags,
+                )
+                if moe_flags is not None:
+                    lora_params['moe_shared_flags'] = moe_flags
 
         return lora_params
 

--- a/tensorrt_llm/lora_helper.py
+++ b/tensorrt_llm/lora_helper.py
@@ -13,11 +13,108 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+from collections.abc import Callable, Iterable
 from typing import Dict, List, Literal, Optional
 
 from pydantic import Field
 
 from tensorrt_llm.llmapi.utils import StrictBaseModel
+
+logger = logging.getLogger(__name__)
+
+# Routed-expert MoE LoRA modules supported by the MVP, each mapped to the one
+# kernel flag that marks its residual-stream side shared across experts (A for
+# the up-projections, B for the down-projection). The slot names are
+# counterintuitive: moe_h_to_4h is gate_proj (w1, silu side) and uses the
+# `gated` slot; moe_gate is up_proj (w3, linear side) and uses `fc1`. Must match
+# `slot_to_kernel` in `fused_moe_cutlass._extract_moe_lora_tensors`.
+MOE_MODULE_SHARED_FLAG: Dict[str, str] = {
+    "moe_h_to_4h": "gated_shared_a",
+    "moe_gate": "fc1_shared_a",
+    "moe_4h_to_h": "fc2_shared_b",
+}
+
+
+def all_false_moe_shared_flags() -> Dict[str, bool]:
+    """Return a fresh kernel flag dict, one key per module, all set to False.
+
+    The default for adapters with no shared side. Only each module's residual
+    side is representable, so the mirror flags (fc1_shared_b, fc2_shared_a,
+    gated_shared_b) are always false and omitted.
+    """
+    return {flag: False for flag in MOE_MODULE_SHARED_FLAG.values()}
+
+
+def moe_shared_sides_to_kernel_flags(
+        shared_sides: Dict[str, tuple]) -> Dict[str, bool]:
+    """Translate per-module shared sides into the kernel flag dict.
+
+    Only each module's residual-stream side (see `MOE_MODULE_SHARED_FLAG`) can be
+    shared; a detected non-canonical sharing (or an unknown module) is ignored.
+
+    Args:
+        shared_sides: Mapping from MoE LoRA module name to its (shared_a,
+            shared_b) pair, as detected by the LoRA loader.
+
+    Returns:
+        The kernel flag dict (see `all_false_moe_shared_flags`), each flag True iff that
+        module's residual side is shared across experts.
+    """
+    flags = all_false_moe_shared_flags()
+    for module_name, (shared_a, shared_b) in shared_sides.items():
+        flag_name = MOE_MODULE_SHARED_FLAG.get(module_name)
+        if flag_name is None:
+            continue
+        # Only the module's canonical residual side has a kernel flag, so we
+        # honor just that side (selected by the flag's `_a`/`_b` suffix). If
+        # both sides were detected shared, the non-canonical one collapses away
+        # here; reading it per-expert stays correct since its slices are equal.
+        if shared_a and shared_b:
+            logger.debug(
+                "MoE LoRA module '%s': both A and B sides detected shared; "
+                "honoring only the canonical side (%s).", module_name,
+                flag_name)
+        shared = shared_a if flag_name.endswith("_a") else shared_b
+        if shared:
+            flags[flag_name] = True
+    return flags
+
+
+def merge_moe_shared_flags_for_batch(
+    active_uids: Iterable[str],
+    get_flags: Callable[[str], Dict[str, bool]],
+) -> Optional[Dict[str, bool]]:
+    """Merge per-adapter MoE shared-outer flags for one fused-MoE call.
+
+    The op applies one global flag set per call, so a side is marked shared only
+    when every active adapter shares it (the intersection of the per-uid flags).
+    Where adapters disagree, that side falls back to the per-expert read, which
+    stays correct for all of them because shared sides are replicated per expert
+    in the LoRA cache. This lets a batch freely mix shared-outer and per-expert
+    adapters.
+
+    Args:
+        active_uids: LoRA task ids present in the current batch.
+        get_flags: Callable returning the kernel flag dict for a uid.
+
+    Returns:
+        The flag dict to set as `lora_params['moe_shared_flags']`, or None
+        when there are no active uids or no side is shared by all of them.
+    """
+    uids = list(active_uids)
+    if not uids:
+        return None
+    merged: Optional[Dict[str, bool]] = None
+    for uid in uids:
+        flags = get_flags(uid)
+        if merged is None:
+            merged = dict(flags)
+        else:
+            for key in merged:
+                merged[key] = merged[key] and flags.get(key, False)
+    assert merged is not None
+    return merged if any(merged.values()) else None
 
 
 def get_missing_qkv_modules_from_lora_modules(

--- a/tensorrt_llm/lora_helper.py
+++ b/tensorrt_llm/lora_helper.py
@@ -23,12 +23,12 @@ from tensorrt_llm.llmapi.utils import StrictBaseModel
 
 logger = logging.getLogger(__name__)
 
-# Routed-expert MoE LoRA modules supported by the MVP, each mapped to the one
-# kernel flag that marks its residual-stream side shared across experts (A for
-# the up-projections, B for the down-projection). The slot names are
-# counterintuitive: moe_h_to_4h is gate_proj (w1, silu side) and uses the
-# `gated` slot; moe_gate is up_proj (w3, linear side) and uses `fc1`. Must match
-# `slot_to_kernel` in `fused_moe_cutlass._extract_moe_lora_tensors`.
+# Routed-expert MoE LoRA modules, each mapped to the one kernel flag that marks
+# its residual-stream side shared across experts (A for the up-projections, B
+# for the down-projection). The slot names are counterintuitive: moe_h_to_4h is
+# gate_proj (w1, silu side) and uses the `gated` slot; moe_gate is up_proj (w3,
+# linear side) and uses `fc1`. Must match `slot_to_kernel` in
+# `fused_moe_cutlass._extract_moe_lora_tensors`.
 MOE_MODULE_SHARED_FLAG: Dict[str, str] = {
     "moe_h_to_4h": "gated_shared_a",
     "moe_gate": "fc1_shared_a",

--- a/tensorrt_llm/lora_manager.py
+++ b/tensorrt_llm/lora_manager.py
@@ -21,8 +21,10 @@ from ._utils import pad_vocab_size, release_gc, str_dtype_to_torch, torch_to_num
 from .layers.linear import ColumnLinear
 from .lora_helper import (
     LoraConfig,
+    all_false_moe_shared_flags,
     get_default_trtllm_modules_to_hf_modules,
     get_missing_qkv_modules_from_lora_modules,
+    moe_shared_sides_to_kernel_flags,
 )
 from .mapping import Mapping
 from .models.convert_utils import get_model_path, load_state_dict, split_matrix_tp
@@ -63,6 +65,19 @@ def _is_moe_module_weights(module_weights: Dict) -> bool:
     return all(isinstance(k, int) for k in module_weights.keys()) and all(
         isinstance(v, dict) for v in module_weights.values()
     )
+
+
+def _all_experts_identical(stacked: torch.Tensor) -> bool:
+    """Return True iff `stacked` has multiple experts and every slice is equal.
+
+    A stacked `[num_experts, ...]` LoRA matrix whose expert slices are all
+    identical is the "shared-outer" side of a routed-expert adapter once its
+    shared matrix has been replicated across experts. Fewer than two experts is
+    never treated as shared.
+    """
+    if stacked.ndim < 1 or stacked.shape[0] < 2:
+        return False
+    return bool((stacked == stacked[0]).all().item())
 
 
 def get_all_nemo_lora_weights(
@@ -732,6 +747,11 @@ class LoraManager(object):
 
         self._lora_uid_counter = 0
         self._lora_uid_to_low_ranks: Dict[str, Dict[int, Dict[str, int]]] = {}
+        # MoE routed-expert shared-outer kernel flags per adapter uid, built by
+        # the HF loader from the detected shared sides (see `lora_helper`). The
+        # per-request assembler in `model_engine.py` forwards them as
+        # `lora_params["moe_shared_flags"]` for the fused-MoE op.
+        self._uid_to_moe_shared_flags: dict[str, dict[str, bool]] = {}
         # When cpp_peft_cache_manager is provided (PyTorch backend), the C++
         # PeftCacheManager manages its own GPU cache with proper eviction.
         # The Python-side GPU tensors are only needed by the legacy TRT backend
@@ -1073,6 +1093,12 @@ class LoraManager(object):
             if uid not in self._cpp_lora_config:
                 self._cpp_lora_config[uid] = []  # Will be converted to tensor later
 
+            # Routed-expert MoE shared-outer detection. A shared-outer adapter
+            # shares one side (A or B) of a module across experts; once
+            # replicated per expert its expert slices are identical, which we
+            # detect from the stacked weights below and turn into kernel flags.
+            moe_shared_sides: dict[str, tuple[bool, bool]] = {}
+
             lora_model = load_state_dict(get_model_path(model_dir, "adapter_model"))
             if lora_model is None:
                 raise ValueError(f"Failed to load adapter_model from {model_dir}")
@@ -1125,6 +1151,21 @@ class LoraManager(object):
 
                         t_in = torch.stack(t_in_list)
                         t_out = torch.stack(t_out_list)
+
+                        # Detect shared-outer sides from the stacked weights. A
+                        # side counts as shared only when shared in every layer,
+                        # since the kernel flag is global per fused-MoE call.
+                        shared_a = _all_experts_identical(t_in)
+                        shared_b = _all_experts_identical(t_out)
+                        prev = moe_shared_sides.get(lora_module)
+                        if prev is None:
+                            moe_shared_sides[lora_module] = (shared_a, shared_b)
+                        else:
+                            moe_shared_sides[lora_module] = (
+                                prev[0] and shared_a,
+                                prev[1] and shared_b,
+                            )
+
                         for weights in module_weights.values():
                             if "mag" in weights:
                                 # TODO(oargov): this might work, but I had no MoE DoRA models to test
@@ -1196,6 +1237,23 @@ class LoraManager(object):
                         )
                     )
 
+            moe_shared_flags = moe_shared_sides_to_kernel_flags(moe_shared_sides)
+            self._uid_to_moe_shared_flags[uid] = moe_shared_flags
+            active = sorted(k for k, v in moe_shared_flags.items() if v)
+            if active:
+                logger.info(
+                    "MoE LoRA adapter '%s': detected shared-outer sides %s; "
+                    "the fused-MoE kernel will read one slice per shared side.",
+                    uid,
+                    active,
+                )
+            elif moe_shared_sides:
+                logger.debug(
+                    "MoE LoRA adapter '%s': no shared-outer side detected; "
+                    "using the per-expert path.",
+                    uid,
+                )
+
             max_weight_size = max(w.size(0) for w in self._cpp_lora_weights[uid])
             self._cpp_lora_weights[uid] = torch.stack(
                 [
@@ -1230,6 +1288,15 @@ class LoraManager(object):
     def uid_to_low_ranks(self, uid: str):
         assert isinstance(uid, str)
         return self._lora_uid_to_low_ranks[uid]
+
+    def get_moe_shared_flags(self, uid: str) -> dict[str, bool]:
+        """Return the fused-MoE shared-outer kernel flags for an adapter uid.
+
+        Returns all-False when no shared side was detected for the adapter, or
+        when the uid is unknown to this manager, preserving the default
+        per-expert kernel offset behavior. See `lora_helper` for the flags.
+        """
+        return dict(self._uid_to_moe_shared_flags.get(uid) or all_false_moe_shared_flags())
 
     def _generate_uid(self):
         while str(self._lora_uid_counter) in self._lora_uid_to_low_ranks:

--- a/tests/unittest/_torch/lora/test_moe_utils.py
+++ b/tests/unittest/_torch/lora/test_moe_utils.py
@@ -9,6 +9,7 @@ synthetic-adapter tooling, without any GPU or model-engine dependencies.
 import pytest
 import torch
 
+from tensorrt_llm._torch.modules.fused_moe.fused_moe_cutlass import CutlassFusedMoE
 from tensorrt_llm._torch.peft.lora.moe_utils import (
     check_moe_lora_supported,
     has_moe_lora_targets,
@@ -21,6 +22,10 @@ from tensorrt_llm.lora_helper import (
     merge_moe_shared_flags_for_batch,
     moe_shared_sides_to_kernel_flags,
 )
+
+
+class _NotCutlassMoE:
+    """Stand-in resolved backend class that is not the Cutlass kernel."""
 
 
 def test_moe_lora_module_names():
@@ -72,7 +77,8 @@ def test_has_moe_lora_targets_each_module(name):
 def test_check_no_lora_is_noop():
     # No LoRA at all; validator must not raise regardless of backend/quant.
     check_moe_lora_supported(
-        moe_backend_name="WIDEEP",
+        moe_cls=_NotCutlassMoE,
+        requested_moe_backend="WIDEEP",
         lora_config=None,
         quant_config=_FakeQuantConfig(True),
     )
@@ -82,7 +88,8 @@ def test_check_no_moe_lora_is_noop():
     # LoRA on attention only; validator must not reject any backend / quant.
     cfg = _FakeLoraConfig(["attn_q", "attn_k"])
     check_moe_lora_supported(
-        moe_backend_name="TRTLLM",
+        moe_cls=_NotCutlassMoE,
+        requested_moe_backend="TRTLLM",
         lora_config=cfg,
         quant_config=_FakeQuantConfig(True),
     )
@@ -92,7 +99,8 @@ def test_check_moe_lora_cutlass_unquantized_ok():
     cfg = _FakeLoraConfig(["moe_h_to_4h", "moe_4h_to_h", "moe_gate"])
     # No quant config -> definitely unquantized.
     check_moe_lora_supported(
-        moe_backend_name="CUTLASS",
+        moe_cls=CutlassFusedMoE,
+        requested_moe_backend="CUTLASS",
         lora_config=cfg,
         quant_config=None,
     )
@@ -102,7 +110,8 @@ def test_check_moe_lora_cutlass_unquantized_quant_mode_ok():
     # An explicit QuantConfig that reports no active quant should pass.
     cfg = _FakeLoraConfig(["moe_4h_to_h", "moe_gate"])
     check_moe_lora_supported(
-        moe_backend_name="cutlass",  # case-insensitive
+        moe_cls=CutlassFusedMoE,
+        requested_moe_backend="cutlass",
         lora_config=cfg,
         quant_config=_FakeQuantConfig(False),
     )
@@ -122,10 +131,13 @@ def test_check_moe_lora_cutlass_unquantized_quant_mode_ok():
     ],
 )
 def test_check_moe_lora_rejects_non_cutlass_backend(backend):
+    # Any resolved class other than the exact CutlassFusedMoE kernel is rejected;
+    # the requested backend name is surfaced in the error message.
     cfg = _FakeLoraConfig(["moe_gate", "moe_4h_to_h"])
-    with pytest.raises(ValueError, match="moe_backend='CUTLASS'"):
+    with pytest.raises(ValueError, match="Cutlass MoE backend"):
         check_moe_lora_supported(
-            moe_backend_name=backend,
+            moe_cls=_NotCutlassMoE,
+            requested_moe_backend=backend,
             lora_config=cfg,
             quant_config=None,
         )
@@ -135,7 +147,8 @@ def test_check_moe_lora_rejects_quantized_base():
     cfg = _FakeLoraConfig(["moe_gate", "moe_4h_to_h"])
     with pytest.raises(ValueError, match="unquantized fp16/bf16 base weights"):
         check_moe_lora_supported(
-            moe_backend_name="CUTLASS",
+            moe_cls=CutlassFusedMoE,
+            requested_moe_backend="CUTLASS",
             lora_config=cfg,
             quant_config=_FakeQuantConfig(True),
         )
@@ -145,7 +158,8 @@ def test_check_moe_lora_layer_idx_in_message():
     cfg = _FakeLoraConfig(["moe_gate", "moe_4h_to_h"])
     with pytest.raises(ValueError, match=r"\[layer_idx=7\]"):
         check_moe_lora_supported(
-            moe_backend_name="TRTLLM",
+            moe_cls=_NotCutlassMoE,
+            requested_moe_backend="TRTLLM",
             lora_config=cfg,
             quant_config=None,
             layer_idx=7,

--- a/tests/unittest/_torch/lora/test_moe_utils.py
+++ b/tests/unittest/_torch/lora/test_moe_utils.py
@@ -1,0 +1,351 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only unit tests for routed-expert MoE LoRA utilities.
+
+Covers validation, shared-outer kernel-flag translation/merge, and the
+synthetic-adapter tooling, without any GPU or model-engine dependencies.
+"""
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.peft.lora.moe_utils import (
+    check_moe_lora_supported,
+    has_moe_lora_targets,
+    make_per_expert_lora,
+    reference_moe_lora_delta,
+)
+from tensorrt_llm.lora_helper import (
+    MOE_MODULE_SHARED_FLAG,
+    all_false_moe_shared_flags,
+    merge_moe_shared_flags_for_batch,
+    moe_shared_sides_to_kernel_flags,
+)
+
+
+def test_moe_lora_module_names():
+    assert set(MOE_MODULE_SHARED_FLAG) == {"moe_h_to_4h", "moe_gate", "moe_4h_to_h"}
+
+
+# ---------- validation ----------
+
+
+class _FakeLoraConfig:
+    """Minimal stand-in for `LoraConfig` for tests that don't need pydantic."""
+
+    def __init__(self, lora_target_modules):
+        self.lora_target_modules = lora_target_modules
+
+
+class _FakeQuantMode:
+    def __init__(self, any_quant: bool):
+        self._any = any_quant
+
+    def has_any_quant(self, exclude_kv_cache: bool = False):
+        return self._any
+
+
+class _FakeQuantConfig:
+    def __init__(self, any_quant: bool):
+        self.quant_mode = _FakeQuantMode(any_quant)
+
+
+def test_has_moe_lora_targets_none():
+    assert has_moe_lora_targets(None) is False
+
+
+def test_has_moe_lora_targets_empty():
+    assert has_moe_lora_targets(_FakeLoraConfig([])) is False
+
+
+def test_has_moe_lora_targets_attn_only():
+    cfg = _FakeLoraConfig(["attn_q", "attn_k", "attn_v"])
+    assert has_moe_lora_targets(cfg) is False
+
+
+@pytest.mark.parametrize("name", sorted(MOE_MODULE_SHARED_FLAG))
+def test_has_moe_lora_targets_each_module(name):
+    cfg = _FakeLoraConfig(["attn_q", name])
+    assert has_moe_lora_targets(cfg) is True
+
+
+def test_check_no_lora_is_noop():
+    # No LoRA at all; validator must not raise regardless of backend/quant.
+    check_moe_lora_supported(
+        moe_backend_name="WIDEEP",
+        lora_config=None,
+        quant_config=_FakeQuantConfig(True),
+    )
+
+
+def test_check_no_moe_lora_is_noop():
+    # LoRA on attention only; validator must not reject any backend / quant.
+    cfg = _FakeLoraConfig(["attn_q", "attn_k"])
+    check_moe_lora_supported(
+        moe_backend_name="TRTLLM",
+        lora_config=cfg,
+        quant_config=_FakeQuantConfig(True),
+    )
+
+
+def test_check_moe_lora_cutlass_unquantized_ok():
+    cfg = _FakeLoraConfig(["moe_h_to_4h", "moe_4h_to_h", "moe_gate"])
+    # No quant config -> definitely unquantized.
+    check_moe_lora_supported(
+        moe_backend_name="CUTLASS",
+        lora_config=cfg,
+        quant_config=None,
+    )
+
+
+def test_check_moe_lora_cutlass_unquantized_quant_mode_ok():
+    # An explicit QuantConfig that reports no active quant should pass.
+    cfg = _FakeLoraConfig(["moe_4h_to_h", "moe_gate"])
+    check_moe_lora_supported(
+        moe_backend_name="cutlass",  # case-insensitive
+        lora_config=cfg,
+        quant_config=_FakeQuantConfig(False),
+    )
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [
+        "WIDEEP",
+        "TRITON",
+        "DEEPGEMM",
+        "VANILLA",
+        "DENSEGEMM",
+        "CUTEDSL",
+        "TRTLLM",
+        "MEGAMOE_DEEPGEMM",
+    ],
+)
+def test_check_moe_lora_rejects_non_cutlass_backend(backend):
+    cfg = _FakeLoraConfig(["moe_gate", "moe_4h_to_h"])
+    with pytest.raises(ValueError, match="moe_backend='CUTLASS'"):
+        check_moe_lora_supported(
+            moe_backend_name=backend,
+            lora_config=cfg,
+            quant_config=None,
+        )
+
+
+def test_check_moe_lora_rejects_quantized_base():
+    cfg = _FakeLoraConfig(["moe_gate", "moe_4h_to_h"])
+    with pytest.raises(ValueError, match="unquantized fp16/bf16 base weights"):
+        check_moe_lora_supported(
+            moe_backend_name="CUTLASS",
+            lora_config=cfg,
+            quant_config=_FakeQuantConfig(True),
+        )
+
+
+def test_check_moe_lora_layer_idx_in_message():
+    cfg = _FakeLoraConfig(["moe_gate", "moe_4h_to_h"])
+    with pytest.raises(ValueError, match=r"\[layer_idx=7\]"):
+        check_moe_lora_supported(
+            moe_backend_name="TRTLLM",
+            lora_config=cfg,
+            quant_config=None,
+            layer_idx=7,
+        )
+
+
+# ---------- moe_shared_sides_to_kernel_flags ----------
+
+
+def test_all_false_moe_shared_flags_has_three_canonical_keys():
+    flags = all_false_moe_shared_flags()
+    assert set(flags) == {"fc1_shared_a", "gated_shared_a", "fc2_shared_b"}
+    assert not any(flags.values())
+
+
+def test_moe_shared_sides_to_kernel_flags_empty():
+    assert moe_shared_sides_to_kernel_flags({}) == all_false_moe_shared_flags()
+
+
+def test_moe_shared_sides_to_kernel_flags_canonical():
+    shared_sides = {
+        "moe_h_to_4h": (True, False),
+        "moe_gate": (True, False),
+        "moe_4h_to_h": (False, True),
+    }
+    assert moe_shared_sides_to_kernel_flags(shared_sides) == {
+        "fc1_shared_a": True,
+        "gated_shared_a": True,
+        "fc2_shared_b": True,
+    }
+
+
+def test_moe_shared_sides_to_kernel_flags_ignores_unknown_module():
+    assert (
+        moe_shared_sides_to_kernel_flags({"attn_q": (True, True)}) == all_false_moe_shared_flags()
+    )
+
+
+def test_moe_shared_sides_to_kernel_flags_ignores_non_canonical_side():
+    # moe_gate shares its residual side via A; a detected B-share is ignored.
+    assert (
+        moe_shared_sides_to_kernel_flags({"moe_gate": (False, True)})
+        == all_false_moe_shared_flags()
+    )
+
+
+# ---------- merge_moe_shared_flags_for_batch ----------
+
+
+def test_merge_returns_none_for_no_uids():
+    assert merge_moe_shared_flags_for_batch([], lambda uid: all_false_moe_shared_flags()) is None
+
+
+def test_merge_returns_none_when_all_flags_false():
+    flags = all_false_moe_shared_flags()
+    assert merge_moe_shared_flags_for_batch(["a"], lambda uid: flags) is None
+
+
+def test_merge_single_uid_with_shared_flags():
+    expected = all_false_moe_shared_flags()
+    expected["gated_shared_a"] = True
+    assert merge_moe_shared_flags_for_batch(["uid-1"], lambda uid: expected) == expected
+
+
+def test_merge_multiple_uids_matching_flags():
+    expected = all_false_moe_shared_flags()
+    expected["fc2_shared_b"] = True
+    assert merge_moe_shared_flags_for_batch(["a", "b"], lambda uid: expected) == expected
+
+
+def test_merge_intersects_when_one_uid_shares_and_another_does_not():
+    # uid 'a' shares fc2_shared_b, uid 'b' shares nothing: the batch falls back
+    # to the per-expert read everywhere (intersection is all-False -> None).
+    flags_a = all_false_moe_shared_flags()
+    flags_a["fc2_shared_b"] = True
+    flags_b = all_false_moe_shared_flags()
+    result = merge_moe_shared_flags_for_batch(
+        ["a", "b"],
+        lambda uid: flags_a if uid == "a" else flags_b,
+    )
+    assert result is None
+
+
+def test_merge_drops_sides_not_shared_by_all():
+    # 'a' shares fc1_shared_a + fc2_shared_b; 'b' shares only fc1_shared_a.
+    # Only the common side (fc1_shared_a) survives the intersection.
+    flags_a = all_false_moe_shared_flags()
+    flags_a["fc1_shared_a"] = True
+    flags_a["fc2_shared_b"] = True
+    flags_b = all_false_moe_shared_flags()
+    flags_b["fc1_shared_a"] = True
+    expected = all_false_moe_shared_flags()
+    expected["fc1_shared_a"] = True
+    result = merge_moe_shared_flags_for_batch(
+        ["a", "b"],
+        lambda uid: flags_a if uid == "a" else flags_b,
+    )
+    assert result == expected
+
+
+# ---------- synthetic adapter tooling ----------
+
+
+def test_make_per_expert_lora_shapes_per_expert():
+    adapter = make_per_expert_lora(
+        num_experts=4, rank=8, in_dim=64, out_dim=128, shared_side=None, seed=0
+    )
+    assert adapter["A"].shape == (4, 8, 64)
+    assert adapter["B"].shape == (4, 128, 8)
+
+
+def test_make_per_expert_lora_shared_a_replicates():
+    adapter = make_per_expert_lora(
+        num_experts=3, rank=4, in_dim=32, out_dim=16, shared_side="A", seed=1
+    )
+    a, b = adapter["A"], adapter["B"]
+    assert a.shape == (3, 4, 32)
+    assert b.shape == (3, 16, 4)
+    # All expert slices of A must be identical (shared).
+    for e in range(1, 3):
+        torch.testing.assert_close(a[e], a[0])
+    # B slices must NOT all be identical (per-expert noise).
+    assert not torch.allclose(b[0], b[1])
+
+
+def test_make_per_expert_lora_shared_b_replicates():
+    adapter = make_per_expert_lora(
+        num_experts=2, rank=6, in_dim=16, out_dim=8, shared_side="B", seed=2
+    )
+    a, b = adapter["A"], adapter["B"]
+    assert a.shape == (2, 6, 16)
+    assert b.shape == (2, 8, 6)
+    torch.testing.assert_close(b[0], b[1])
+    assert not torch.allclose(a[0], a[1])
+
+
+def test_make_per_expert_lora_seed_reproducible():
+    a1 = make_per_expert_lora(2, 4, 8, 8, seed=42)
+    a2 = make_per_expert_lora(2, 4, 8, 8, seed=42)
+    torch.testing.assert_close(a1["A"], a2["A"])
+    torch.testing.assert_close(a1["B"], a2["B"])
+
+
+def test_make_per_expert_lora_invalid_shared_side():
+    with pytest.raises(ValueError, match="shared_side"):
+        make_per_expert_lora(2, 4, 8, 8, shared_side="C")
+
+
+def test_reference_moe_lora_delta_per_expert():
+    torch.manual_seed(0)
+    num_experts = 3
+    rank = 4
+    in_dim = 16
+    out_dim = 8
+    num_tokens = 5
+
+    adapter = make_per_expert_lora(
+        num_experts=num_experts,
+        rank=rank,
+        in_dim=in_dim,
+        out_dim=out_dim,
+        dtype=torch.float32,
+        shared_side=None,
+        seed=7,
+    )
+    x = torch.randn(num_tokens, in_dim, dtype=torch.float32)
+    token_to_expert = torch.tensor([0, 1, 2, 0, 1], dtype=torch.int32)
+
+    delta = reference_moe_lora_delta(adapter["A"], adapter["B"], x, token_to_expert)
+    assert delta.shape == (num_tokens, out_dim)
+    # Spot-check token 0: should equal B[0] @ A[0] @ x[0].
+    expected_t0 = adapter["B"][0] @ (adapter["A"][0] @ x[0])
+    torch.testing.assert_close(delta[0], expected_t0)
+
+
+def test_reference_moe_lora_delta_shared_outer_matches_per_expert_when_b_shared():
+    """When B is shared, every expert produces the same delta direction modulo
+    the per-expert A matrix. The reference helper must still pick the right
+    expert per token."""
+    torch.manual_seed(0)
+    num_experts = 2
+    rank = 4
+    in_dim = 8
+    out_dim = 6
+
+    adapter = make_per_expert_lora(
+        num_experts=num_experts,
+        rank=rank,
+        in_dim=in_dim,
+        out_dim=out_dim,
+        dtype=torch.float32,
+        shared_side="B",
+        seed=11,
+    )
+    x = torch.randn(3, in_dim, dtype=torch.float32)
+    token_to_expert = torch.tensor([0, 1, 0], dtype=torch.int32)
+
+    delta = reference_moe_lora_delta(adapter["A"], adapter["B"], x, token_to_expert, scale=2.0)
+    assert delta.shape == (3, out_dim)
+    # The B used for all tokens is the same matrix (shared); we just check the
+    # scale propagated.
+    expected_t0 = 2.0 * (adapter["B"][0] @ (adapter["A"][0] @ x[0]))
+    torch.testing.assert_close(delta[0], expected_t0)

--- a/tests/unittest/others/test_lora_manager.py
+++ b/tests/unittest/others/test_lora_manager.py
@@ -29,6 +29,7 @@ from unittest.mock import MagicMock
 import torch
 from safetensors.torch import save_file
 
+from tensorrt_llm.lora_helper import all_false_moe_shared_flags
 from tensorrt_llm.lora_manager import LoraManager
 from tensorrt_llm.mapping import Mapping
 
@@ -160,6 +161,155 @@ class TestLoraManagerRetainDeviceTensors(unittest.TestCase):
 
         self.assertEqual(len(manager._lora_weights), 0)
         self.assertEqual(len(manager._cpp_lora_weights), num_adapters)
+
+
+@dataclass
+class MockMoeModelConfig:
+    """Minimal model config for MoE LoRA tests.
+
+    Mirrors the fields `LoraManager.load_from_hf` reads, with a single MoE
+    up-projection target so the fixture stays small.
+    """
+
+    lora_target_modules: list = field(
+        default_factory=lambda: ["moe_h_to_4h", "moe_gate", "moe_4h_to_h"]
+    )
+    trtllm_modules_to_hf_modules: dict = field(
+        default_factory=lambda: {
+            "moe_h_to_4h": "w1",
+            "moe_4h_to_h": "w2",
+            "moe_gate": "w3",
+        }
+    )
+    hidden_size: int = 64
+    dtype: str = "float16"
+    swap_gate_up_proj_lora_b_weight: bool = False
+
+
+def _create_dummy_moe_hf_lora_adapter(
+    adapter_dir: Path,
+    hidden_size: int = 64,
+    intermediate_size: int = 128,
+    rank: int = 8,
+    num_layers: int = 2,
+    num_experts: int = 4,
+    make_shared_outer: bool = False,
+):
+    """Create a minimal HF-format MoE LoRA adapter on disk.
+
+    The on-disk weights are always materialized per-expert, as the C++ LoRA
+    cache row size requires. When `make_shared_outer` is True, the "outer" side
+    of each module is identical across experts (A for the up-projections w1/w3,
+    B for the down-projection w2), as a replicated shared-outer adapter looks on
+    disk.
+    """
+    config = {
+        "r": rank,
+        "lora_alpha": rank,
+        "target_modules": ["w1", "w2", "w3"],
+        "bias": "none",
+        "peft_type": "LORA",
+        "task_type": "CAUSAL_LM",
+    }
+    with open(adapter_dir / "adapter_config.json", "w") as f:
+        json.dump(config, f)
+
+    weights = {}
+    for layer_idx in range(num_layers):
+        # Per-layer shared "outer" matrices, cloned per expert so the on-disk
+        # slices are bit-identical without sharing storage.
+        if make_shared_outer:
+            shared_a = {
+                "w1": torch.randn(rank, hidden_size, dtype=torch.float16),
+                "w3": torch.randn(rank, hidden_size, dtype=torch.float16),
+            }
+            shared_b_w2 = torch.randn(hidden_size, rank, dtype=torch.float16)
+        for expert_idx in range(num_experts):
+            base = f"base_model.model.model.layers.{layer_idx}.mlp.experts.{expert_idx}"
+            # Up-projections (w1, w3): in_dim=hidden, out_dim=intermediate.
+            for module in ("w1", "w3"):
+                if make_shared_outer:
+                    a = shared_a[module].clone()
+                else:
+                    a = torch.randn(rank, hidden_size, dtype=torch.float16)
+                weights[f"{base}.{module}.lora_A.weight"] = a
+                weights[f"{base}.{module}.lora_B.weight"] = torch.randn(
+                    intermediate_size, rank, dtype=torch.float16
+                )
+            # Down-projection (w2): in_dim=intermediate, out_dim=hidden.
+            weights[f"{base}.w2.lora_A.weight"] = torch.randn(
+                rank, intermediate_size, dtype=torch.float16
+            )
+            if make_shared_outer:
+                b_w2 = shared_b_w2.clone()
+            else:
+                b_w2 = torch.randn(hidden_size, rank, dtype=torch.float16)
+            weights[f"{base}.w2.lora_B.weight"] = b_w2
+
+    save_file(weights, str(adapter_dir / "adapter_model.safetensors"))
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestLoraManagerMoeSharedFlags(unittest.TestCase):
+    """Tests for MoE shared-outer detection in the HF LoRA loader."""
+
+    def _create_manager(self):
+        # cpp_peft_cache_manager mocked so the manager skips the
+        # legacy-TRT retain-GPU-tensors path; matches PyTorch runtime usage.
+        mapping = Mapping(world_size=1, rank=0, tp_size=1)
+        model_config = MockMoeModelConfig()
+        return LoraManager(
+            mapping=mapping,
+            model_config=model_config,
+            cpp_peft_cache_manager=MagicMock(),
+        )
+
+    def test_per_expert_weights_yield_all_false_moe_shared_flags(self):
+        # Per-expert random weights: detection finds no shared side, so the
+        # flags stay all-False (the default per-expert kernel path).
+        manager = self._create_manager()
+        model_config = MockMoeModelConfig()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            adapter_dir = Path(tmpdir) / "adapter_per_expert"
+            adapter_dir.mkdir()
+            _create_dummy_moe_hf_lora_adapter(adapter_dir)
+            manager.load_from_hf(
+                model_dirs=[str(adapter_dir)],
+                model_config=model_config,
+                uids=["uid-per-expert"],
+            )
+        self.assertEqual(
+            manager.get_moe_shared_flags("uid-per-expert"), all_false_moe_shared_flags()
+        )
+
+    def test_unknown_uid_returns_all_false(self):
+        manager = self._create_manager()
+        self.assertEqual(manager.get_moe_shared_flags("never-loaded"), all_false_moe_shared_flags())
+
+    def test_shared_outer_flags_auto_detected_from_weights(self):
+        # The loader detects the shared-outer side from the replicated expert
+        # slices and builds the kernel flags.
+        manager = self._create_manager()
+        model_config = MockMoeModelConfig()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            adapter_dir = Path(tmpdir) / "adapter_shared_outer_auto"
+            adapter_dir.mkdir()
+            _create_dummy_moe_hf_lora_adapter(adapter_dir, make_shared_outer=True)
+            manager.load_from_hf(
+                model_dirs=[str(adapter_dir)],
+                model_config=model_config,
+                uids=["uid-auto"],
+            )
+        # Up-projections (w1=moe_h_to_4h, w3=moe_gate) share A -> gated/fc1
+        # _shared_a; down-projection (w2=moe_4h_to_h) shares B -> fc2_shared_b.
+        self.assertEqual(
+            manager.get_moe_shared_flags("uid-auto"),
+            {
+                "gated_shared_a": True,
+                "fc1_shared_a": True,
+                "fc2_shared_b": True,
+            },
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

This MR is in preparation for https://github.com/NVIDIA/TensorRT-LLM/pull/14763 where the goal is to support routed-expert LoRA on Cutlass FusedMoE backend.

**_Background:_**

- In routed-expert MoE LoRA, a **per-expert** adapter stores a separate low-rank pair (A and B) for every expert, so each expert can apply a different correction.
- A **shared-outer** adapter shares one matrix across all experts on the residual-stream side (typically A on the up/gate projections and B on the down projection) while the other side remains per-expert.
- The math per routed token is unchanged; only how weights are stored and indexed differs.

This MR lands Python helpers to auto-detect and validate "sharedness". A follow-up kernel/integration MR wires the fused-MoE op so that the shared side can be stored once without replication in the cache.

## Test Coverage

```
$ pytest tests/unittest/_torch/lora/test_moe_utils.py -s -v
$ pytest tests/unittest/others/test_lora_manager.py::TestLoraManagerMoeSharedFlags -s -v
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MoE LoRA (Mixture of Experts Low-Rank Adapters) support with flexible per-expert weight sharing configuration through metadata
  * Enforced validation to ensure MoE LoRA compatibility with CUTLASS backend only and prevent usage with quantized base weights

* **Tests**
  * Added comprehensive unit tests for MoE LoRA layout parsing, validation, and parameter generation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14764?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->