### PR TITLE
[TRTLLM-12507][feat] add lora_layout.json sidecar for shared-outer Mo…

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -3670,12 +3670,15 @@ class PyTorchModelEngine(ModelEngine):
             peft_table = peft_cache_manager.get_and_reset_batch_peft_table(
             ) if peft_cache_manager is not None else None
             return peft_table and self._get_eager_lora_params_from_requests(
-                scheduled_requests, attn_metadata, peft_table)
+                scheduled_requests, attn_metadata, peft_table,
+                peft_cache_manager)
 
     def _get_eager_lora_params_from_requests(
-            self, scheduled_requests: ScheduledRequests,
+            self,
+            scheduled_requests: ScheduledRequests,
             attn_metadata: AttentionMetadata,
-            peft_table: Dict[int, list[TaskLayerModuleConfig]]):
+            peft_table: Dict[int, list[TaskLayerModuleConfig]],
+            peft_cache_manager: Optional[PeftCacheManager] = None):
         '''
         Eager mode LoRA parameter preparation logic.
 
@@ -3690,6 +3693,12 @@ class PyTorchModelEngine(ModelEngine):
                 }
             }
         }
+
+        When ``peft_cache_manager`` is supplied and one or more active LoRA
+        uids carry a ``lora_layout.json`` sidecar, ``lora_params`` also
+        contains a top-level ``moe_shared_flags`` dict consumed by the
+        fused-MoE op. All active uids in a single batch must agree on the
+        flags; mismatches raise.
         '''
         lora_params = {}
         tmp_lora_params = {}
@@ -3788,6 +3797,32 @@ class PyTorchModelEngine(ModelEngine):
             lora_params['host_request_types'] = host_request_types
             lora_params['prompt_lens_cpu'] = prompt_lens_cpu
             lora_params['num_seqs'] = num_seqs
+
+            # MoE shared-outer flags: forward the per-uid kernel flags read
+            # from the optional ``lora_layout.json`` sidecar into
+            # ``lora_params``. The fused-MoE op zero-offsets the per-expert
+            # pointer arithmetic when a side is shared, so all active uids
+            # in a batch must agree on the flag pattern. Adapters without a
+            # sidecar yield all-False (the existing per-expert path).
+            if peft_cache_manager is not None:
+                lora_manager = peft_cache_manager.get_lora_manager()
+                active_uids = sorted({
+                    str(req.lora_task_id)
+                    for req in request_list if req.lora_task_id is not None
+                })
+                union_flags = None
+                for uid in active_uids:
+                    flags = lora_manager.get_moe_shared_flags(uid)
+                    if union_flags is None:
+                        union_flags = flags
+                    elif union_flags != flags:
+                        raise ValueError(
+                            "MoE LoRA shared-outer flags must match across "
+                            "all adapters in a batch; got mismatched flags "
+                            f"for active uids {active_uids}. The fused-MoE "
+                            "op applies one global flag set per call.")
+                if union_flags is not None and any(union_flags.values()):
+                    lora_params['moe_shared_flags'] = union_flags
 
         return lora_params
 

--- a/tensorrt_llm/lora_layout_sidecar.py
+++ b/tensorrt_llm/lora_layout_sidecar.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Parser for the optional ``lora_layout.json`` adapter sidecar.
+
+The sidecar lets routed-expert Mixture-of-Experts (MoE) LoRA adapters declare
+which side (``A`` or ``B``) of each module is shared across experts -- the
+"outer" / residual-stream side. The fused-MoE op honors these flags via
+``LoraParams::*_shared_a/b``, zero-offsetting the per-expert pointer
+arithmetic in the kernel's ``setupLoraWorkspace``.
+
+In this release the on-disk layout is unchanged: the loader still replicates
+the shared tensor across ``num_experts`` before packing it into the C++ LoRA
+cache (the cache row size is determined by ``LoraModule`` config, not by the
+packed blob). The sidecar establishes the convention end-to-end, propagating
+the flags from disk through the loader and per-request assembler into the
+fused-MoE op. A follow-up will switch the loader and C++ cache to native
+unreplicated storage for actual GPU-memory savings.
+
+Sidecar schema (all fields optional; missing modules default to per-expert):
+
+.. code-block:: json
+
+    {
+      "version": 1,
+      "moe_shared_outer": {
+        "moe_h_to_4h": {"shared_side": "A"},
+        "moe_gate":    {"shared_side": "A"},
+        "moe_4h_to_h": {"shared_side": "B"}
+      }
+    }
+"""
+import json
+import os
+from typing import Dict, Optional
+
+# Shared-side value for a single module: "A", "B", or None for per-expert.
+SharedSide = Optional[str]
+
+# Mapping from the TRT-LLM LoRA module name to the kernel-side module
+# prefix the fused-MoE op uses. Matches the slot mapping in
+# ``fused_moe_cutlass._extract_moe_lora_tensors``:
+#   moe_gate    -> fc1   (up projection)
+#   moe_4h_to_h -> fc2   (down projection)
+#   moe_h_to_4h -> gated (gate-side up projection in SwiGLU)
+MODULE_TO_KERNEL_PREFIX: Dict[str, str] = {
+    "moe_gate": "fc1",
+    "moe_4h_to_h": "fc2",
+    "moe_h_to_4h": "gated",
+}
+
+# Per-side boolean flags accepted by ``torch.ops.trtllm.fused_moe``.
+KERNEL_FLAG_KEYS = (
+    "fc1_shared_a",
+    "fc1_shared_b",
+    "fc2_shared_a",
+    "fc2_shared_b",
+    "gated_shared_a",
+    "gated_shared_b",
+)
+
+LORA_LAYOUT_FILENAME = "lora_layout.json"
+
+
+class LoraLayoutError(ValueError):
+    """Raised when ``lora_layout.json`` is present but malformed."""
+
+
+def all_false_flags() -> Dict[str, bool]:
+    """Return a fresh dict of the six kernel flag keys, all set to False.
+
+    Useful as a default for adapters with no ``lora_layout.json`` sidecar.
+    """
+    return {key: False for key in KERNEL_FLAG_KEYS}
+
+
+def load_lora_layout_sidecar(
+        model_dir: str) -> Optional[Dict[str, SharedSide]]:
+    """Read ``<model_dir>/lora_layout.json`` if it exists.
+
+    Args:
+        model_dir: Directory containing the adapter (alongside
+            ``adapter_config.json`` / ``adapter_model.*``).
+
+    Returns:
+        A dict mapping each present LoRA module name to its
+        ``shared_side`` ("A" or "B" or ``None``), or ``None`` when the
+        sidecar file is absent.
+
+    Raises:
+        LoraLayoutError: if the file is present but cannot be parsed
+        or violates the schema.
+    """
+    path = os.path.join(model_dir, LORA_LAYOUT_FILENAME)
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, "r") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        raise LoraLayoutError(f"Failed to parse {path}: {e}") from e
+    except OSError as e:
+        raise LoraLayoutError(f"Failed to read {path}: {e}") from e
+    return parse_lora_layout(data, source=path)
+
+
+def parse_lora_layout(data: Dict,
+                      source: str = "<dict>") -> Dict[str, SharedSide]:
+    """Validate a parsed sidecar dict and return its per-module map.
+
+    Unknown top-level keys are tolerated for forward compatibility, but
+    unknown module names under ``moe_shared_outer`` raise so that typos
+    or stale conventions surface early.
+
+    Args:
+        data: The decoded JSON object.
+        source: A diagnostic identifier used in error messages (file path
+            or ``"<dict>"`` when parsing in-memory).
+
+    Returns:
+        Dict mapping each present module name to its shared side.
+
+    Raises:
+        LoraLayoutError: on schema violations.
+    """
+    if not isinstance(data, dict):
+        raise LoraLayoutError(
+            f"{source}: top-level value must be a JSON object, got "
+            f"{type(data).__name__}.")
+    version = data.get("version", 1)
+    if version != 1:
+        raise LoraLayoutError(
+            f"{source}: unsupported lora_layout version {version!r}; only "
+            f"version 1 is recognized.")
+    moe = data.get("moe_shared_outer", {})
+    if not isinstance(moe, dict):
+        raise LoraLayoutError(
+            f"{source}: 'moe_shared_outer' must be a JSON object.")
+    result: Dict[str, SharedSide] = {}
+    for module_name, spec in moe.items():
+        if module_name not in MODULE_TO_KERNEL_PREFIX:
+            raise LoraLayoutError(
+                f"{source}: unknown MoE LoRA module {module_name!r}; "
+                f"supported: {sorted(MODULE_TO_KERNEL_PREFIX)}.")
+        if not isinstance(spec, dict):
+            raise LoraLayoutError(
+                f"{source}: 'moe_shared_outer[{module_name}]' must be a "
+                "JSON object.")
+        side = spec.get("shared_side")
+        if side not in ("A", "B", None):
+            raise LoraLayoutError(
+                f"{source}: 'moe_shared_outer[{module_name}].shared_side' "
+                f"must be 'A', 'B' or null; got {side!r}.")
+        result[module_name] = side
+    return result
+
+
+def layout_to_kernel_flags(
+        layout: Optional[Dict[str, SharedSide]]) -> Dict[str, bool]:
+    """Translate a per-module shared-side map into the six-bool dict
+    consumed by the fused-MoE op via ``lora_params["moe_shared_flags"]``.
+
+    Modules missing from ``layout`` (or an entirely missing layout) yield
+    all-False, preserving the default per-expert offset behavior.
+
+    Args:
+        layout: Per-module shared-side mapping (output of
+            :func:`load_lora_layout_sidecar` or
+            :func:`parse_lora_layout`), or ``None`` when no sidecar was
+            provided.
+
+    Returns:
+        Dict with the six keys defined by :data:`KERNEL_FLAG_KEYS`,
+        each ``True`` iff that side of that module is shared.
+    """
+    flags = all_false_flags()
+    if not layout:
+        return flags
+    for module_name, side in layout.items():
+        if side is None:
+            continue
+        prefix = MODULE_TO_KERNEL_PREFIX[module_name]
+        if side == "A":
+            flags[f"{prefix}_shared_a"] = True
+        elif side == "B":
+            flags[f"{prefix}_shared_b"] = True
+    return flags

--- a/tensorrt_llm/lora_manager.py
+++ b/tensorrt_llm/lora_manager.py
@@ -24,6 +24,15 @@ from .lora_helper import (
     get_default_trtllm_modules_to_hf_modules,
     get_missing_qkv_modules_from_lora_modules,
 )
+from .lora_layout_sidecar import (
+    all_false_flags as _moe_all_false_shared_flags,
+)
+from .lora_layout_sidecar import (
+    layout_to_kernel_flags as _moe_layout_to_kernel_flags,
+)
+from .lora_layout_sidecar import (
+    load_lora_layout_sidecar as _load_lora_layout_sidecar,
+)
 from .mapping import Mapping
 from .models.convert_utils import get_model_path, load_state_dict, split_matrix_tp
 
@@ -732,6 +741,13 @@ class LoraManager(object):
 
         self._lora_uid_counter = 0
         self._lora_uid_to_low_ranks: Dict[str, Dict[int, Dict[str, int]]] = {}
+        # MoE routed-expert shared-outer flags per adapter uid. Populated by
+        # the HF loader when an adapter ships a ``lora_layout.json`` sidecar;
+        # consumed by the per-request assembler in ``model_engine.py`` to set
+        # ``lora_params["moe_shared_flags"]`` for the fused-MoE op. Adapters
+        # without the sidecar get an all-False entry, matching pre-existing
+        # per-expert kernel behavior. See ``lora_layout_sidecar.py``.
+        self._uid_to_moe_shared_flags: Dict[str, Dict[str, bool]] = {}
         # When cpp_peft_cache_manager is provided (PyTorch backend), the C++
         # PeftCacheManager manages its own GPU cache with proper eviction.
         # The Python-side GPU tensors are only needed by the legacy TRT backend
@@ -1073,6 +1089,16 @@ class LoraManager(object):
             if uid not in self._cpp_lora_config:
                 self._cpp_lora_config[uid] = []  # Will be converted to tensor later
 
+            # Optional `lora_layout.json` sidecar declares which MoE LoRA
+            # modules use shared-outer storage (one side A or B shared across
+            # experts). The on-disk weight layout is unchanged in this release
+            # -- the loader still replicates shared sides to match the C++
+            # cache row size -- so the sidecar only sets per-uid kernel flags
+            # that the per-request assembler later forwards to fused-MoE.
+            moe_shared_layout = _load_lora_layout_sidecar(model_dir)
+            self._uid_to_moe_shared_flags[uid] = _moe_layout_to_kernel_flags(
+                moe_shared_layout)
+
             lora_model = load_state_dict(get_model_path(model_dir, "adapter_model"))
             if lora_model is None:
                 raise ValueError(f"Failed to load adapter_model from {model_dir}")
@@ -1230,6 +1256,24 @@ class LoraManager(object):
     def uid_to_low_ranks(self, uid: str):
         assert isinstance(uid, str)
         return self._lora_uid_to_low_ranks[uid]
+
+    def get_moe_shared_flags(self, uid: str) -> Dict[str, bool]:
+        """Return the six-bool fused-MoE shared-outer flag dict for an
+        adapter uid.
+
+        Returns all-False when ``uid`` was loaded without a
+        ``lora_layout.json`` sidecar or is unknown to this manager,
+        preserving the default per-expert kernel offset behavior.
+
+        The keys match the kwargs accepted by ``torch.ops.trtllm.fused_moe``
+        (``fc1_shared_a``, ``fc1_shared_b``, ``fc2_shared_a``,
+        ``fc2_shared_b``, ``gated_shared_a``, ``gated_shared_b``). See
+        ``lora_layout_sidecar.py`` for the schema.
+        """
+        flags = self._uid_to_moe_shared_flags.get(uid)
+        if flags is None:
+            return _moe_all_false_shared_flags()
+        return dict(flags)
 
     def _generate_uid(self):
         while str(self._lora_uid_counter) in self._lora_uid_to_low_ranks:

--- a/tests/unittest/_torch/lora/test_lora_layout_sidecar.py
+++ b/tests/unittest/_torch/lora/test_lora_layout_sidecar.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only unit tests for the ``lora_layout.json`` sidecar parser.
+
+These tests cover the parser surface that the HF LoRA loader uses to detect
+routed-expert MoE shared-outer adapters, without any GPU or model-engine
+dependencies.
+"""
+import json
+import os
+import tempfile
+
+import pytest
+
+from tensorrt_llm.lora_layout_sidecar import (KERNEL_FLAG_KEYS,
+                                              LORA_LAYOUT_FILENAME,
+                                              LoraLayoutError, all_false_flags,
+                                              layout_to_kernel_flags,
+                                              load_lora_layout_sidecar,
+                                              parse_lora_layout)
+
+
+# ---------- file-level loader ----------
+
+
+def test_load_returns_none_when_sidecar_missing():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Just an empty directory: no lora_layout.json.
+        assert load_lora_layout_sidecar(tmpdir) is None
+
+
+def test_load_parses_minimal_valid_sidecar():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        payload = {
+            "version": 1,
+            "moe_shared_outer": {
+                "moe_h_to_4h": {
+                    "shared_side": "A"
+                },
+                "moe_4h_to_h": {
+                    "shared_side": "B"
+                },
+            },
+        }
+        with open(os.path.join(tmpdir, LORA_LAYOUT_FILENAME), "w") as f:
+            json.dump(payload, f)
+        layout = load_lora_layout_sidecar(tmpdir)
+    assert layout == {"moe_h_to_4h": "A", "moe_4h_to_h": "B"}
+
+
+def test_load_raises_on_invalid_json():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, LORA_LAYOUT_FILENAME), "w") as f:
+            f.write("{ this is not json")
+        with pytest.raises(LoraLayoutError, match="Failed to parse"):
+            load_lora_layout_sidecar(tmpdir)
+
+
+# ---------- parse_lora_layout schema validation ----------
+
+
+def test_parse_rejects_non_dict_top_level():
+    with pytest.raises(LoraLayoutError, match="must be a JSON object"):
+        parse_lora_layout([], source="<test>")
+
+
+def test_parse_rejects_unsupported_version():
+    with pytest.raises(LoraLayoutError, match="unsupported lora_layout version"):
+        parse_lora_layout({"version": 2}, source="<test>")
+
+
+def test_parse_defaults_version_to_1():
+    out = parse_lora_layout({"moe_shared_outer": {}}, source="<test>")
+    assert out == {}
+
+
+def test_parse_rejects_non_dict_moe_section():
+    with pytest.raises(LoraLayoutError,
+                       match="'moe_shared_outer' must be a JSON object"):
+        parse_lora_layout({"moe_shared_outer": []}, source="<test>")
+
+
+def test_parse_rejects_unknown_module():
+    with pytest.raises(LoraLayoutError, match="unknown MoE LoRA module"):
+        parse_lora_layout(
+            {"moe_shared_outer": {
+                "attn_q": {
+                    "shared_side": "A"
+                }
+            }},
+            source="<test>",
+        )
+
+
+def test_parse_rejects_invalid_shared_side():
+    with pytest.raises(LoraLayoutError, match="must be 'A', 'B' or null"):
+        parse_lora_layout(
+            {
+                "moe_shared_outer": {
+                    "moe_h_to_4h": {
+                        "shared_side": "C"
+                    }
+                }
+            },
+            source="<test>",
+        )
+
+
+def test_parse_rejects_non_dict_module_spec():
+    with pytest.raises(LoraLayoutError, match="must be a JSON object"):
+        parse_lora_layout(
+            {"moe_shared_outer": {
+                "moe_h_to_4h": "A"
+            }},
+            source="<test>",
+        )
+
+
+def test_parse_accepts_null_shared_side():
+    out = parse_lora_layout(
+        {"moe_shared_outer": {
+            "moe_h_to_4h": {
+                "shared_side": None
+            }
+        }},
+        source="<test>",
+    )
+    assert out == {"moe_h_to_4h": None}
+
+
+def test_parse_tolerates_extra_top_level_keys():
+    # Forward-compat: extra top-level keys should not raise.
+    out = parse_lora_layout(
+        {
+            "version": 1,
+            "moe_shared_outer": {
+                "moe_gate": {
+                    "shared_side": "A"
+                }
+            },
+            "future_field": {
+                "anything": True
+            },
+        },
+        source="<test>",
+    )
+    assert out == {"moe_gate": "A"}
+
+
+# ---------- layout_to_kernel_flags ----------
+
+
+def test_all_false_flags_has_six_keys():
+    flags = all_false_flags()
+    assert set(flags.keys()) == set(KERNEL_FLAG_KEYS)
+    assert not any(flags.values())
+
+
+def test_layout_to_kernel_flags_none():
+    assert layout_to_kernel_flags(None) == all_false_flags()
+
+
+def test_layout_to_kernel_flags_empty():
+    assert layout_to_kernel_flags({}) == all_false_flags()
+
+
+def test_layout_to_kernel_flags_default_shared_outer_pattern():
+    # The "canonical" shared-outer assignment used by moe_layout helpers:
+    #   - up-projections (moe_h_to_4h, moe_gate): A shared (residual side)
+    #   - down-projection (moe_4h_to_h): B shared (residual side)
+    layout = {
+        "moe_h_to_4h": "A",
+        "moe_gate": "A",
+        "moe_4h_to_h": "B",
+    }
+    flags = layout_to_kernel_flags(layout)
+    assert flags == {
+        "fc1_shared_a": True,
+        "fc1_shared_b": False,
+        "fc2_shared_a": False,
+        "fc2_shared_b": True,
+        "gated_shared_a": True,
+        "gated_shared_b": False,
+    }
+
+
+def test_layout_to_kernel_flags_null_side_yields_no_flag():
+    flags = layout_to_kernel_flags({"moe_h_to_4h": None})
+    assert flags == all_false_flags()
+
+
+def test_layout_to_kernel_flags_only_partial_modules():
+    flags = layout_to_kernel_flags({"moe_4h_to_h": "B"})
+    expected = all_false_flags()
+    expected["fc2_shared_b"] = True
+    assert flags == expected

--- a/tests/unittest/others/test_lora_manager.py
+++ b/tests/unittest/others/test_lora_manager.py
@@ -29,6 +29,7 @@ from unittest.mock import MagicMock
 import torch
 from safetensors.torch import save_file
 
+from tensorrt_llm.lora_layout_sidecar import LORA_LAYOUT_FILENAME, all_false_flags
 from tensorrt_llm.lora_manager import LoraManager
 from tensorrt_llm.mapping import Mapping
 
@@ -160,6 +161,189 @@ class TestLoraManagerRetainDeviceTensors(unittest.TestCase):
 
         self.assertEqual(len(manager._lora_weights), 0)
         self.assertEqual(len(manager._cpp_lora_weights), num_adapters)
+
+
+@dataclass
+class MockMoeModelConfig:
+    """Minimal model config for MoE LoRA tests.
+
+    Mirrors the fields ``LoraManager.load_from_hf`` reads but with a single
+    MoE up-projection target so the fixture stays small.
+    """
+
+    lora_target_modules: list = field(
+        default_factory=lambda: ["moe_h_to_4h", "moe_gate", "moe_4h_to_h"])
+    trtllm_modules_to_hf_modules: dict = field(
+        default_factory=lambda: {
+            "moe_h_to_4h": "w1",
+            "moe_4h_to_h": "w2",
+            "moe_gate": "w3",
+        })
+    hidden_size: int = 64
+    dtype: str = "float16"
+    swap_gate_up_proj_lora_b_weight: bool = False
+
+
+def _create_dummy_moe_hf_lora_adapter(
+    adapter_dir: Path,
+    hidden_size: int = 64,
+    intermediate_size: int = 128,
+    rank: int = 8,
+    num_layers: int = 2,
+    num_experts: int = 4,
+    layout_sidecar: dict = None,
+):
+    """Create a minimal HF-format MoE LoRA adapter on disk.
+
+    The on-disk weights are always materialized per-expert (the C++ LoRA
+    cache row size requires this in this release); the optional
+    ``layout_sidecar`` dict only marks per-side sharing for the runtime
+    kernel flags.
+    """
+    config = {
+        "r": rank,
+        "lora_alpha": rank,
+        "target_modules": ["w1", "w2", "w3"],
+        "bias": "none",
+        "peft_type": "LORA",
+        "task_type": "CAUSAL_LM",
+    }
+    with open(adapter_dir / "adapter_config.json", "w") as f:
+        json.dump(config, f)
+
+    weights = {}
+    for layer_idx in range(num_layers):
+        for expert_idx in range(num_experts):
+            base = (f"base_model.model.model.layers.{layer_idx}"
+                    f".mlp.experts.{expert_idx}")
+            # Up-projections (w1, w3): in_dim=hidden, out_dim=intermediate.
+            for module in ("w1", "w3"):
+                weights[f"{base}.{module}.lora_A.weight"] = torch.randn(
+                    rank, hidden_size, dtype=torch.float16)
+                weights[f"{base}.{module}.lora_B.weight"] = torch.randn(
+                    intermediate_size, rank, dtype=torch.float16)
+            # Down-projection (w2): in_dim=intermediate, out_dim=hidden.
+            weights[f"{base}.w2.lora_A.weight"] = torch.randn(
+                rank, intermediate_size, dtype=torch.float16)
+            weights[f"{base}.w2.lora_B.weight"] = torch.randn(
+                hidden_size, rank, dtype=torch.float16)
+
+    save_file(weights, str(adapter_dir / "adapter_model.safetensors"))
+
+    if layout_sidecar is not None:
+        with open(adapter_dir / LORA_LAYOUT_FILENAME, "w") as f:
+            json.dump(layout_sidecar, f)
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA required")
+class TestLoraManagerMoeSharedFlags(unittest.TestCase):
+    """Tests for ``lora_layout.json`` sidecar handling in the HF MoE loader."""
+
+    def _create_manager(self):
+        # cpp_peft_cache_manager mocked so the manager skips the
+        # legacy-TRT retain-GPU-tensors path; matches PyTorch runtime usage.
+        mapping = Mapping(world_size=1, rank=0, tp_size=1)
+        model_config = MockMoeModelConfig()
+        return LoraManager(
+            mapping=mapping,
+            model_config=model_config,
+            cpp_peft_cache_manager=MagicMock(),
+        )
+
+    def test_no_sidecar_yields_all_false_flags(self):
+        manager = self._create_manager()
+        model_config = MockMoeModelConfig()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            adapter_dir = Path(tmpdir) / "adapter_no_sidecar"
+            adapter_dir.mkdir()
+            _create_dummy_moe_hf_lora_adapter(adapter_dir)
+            manager.load_from_hf(
+                model_dirs=[str(adapter_dir)],
+                model_config=model_config,
+                uids=["uid-no-sidecar"],
+            )
+        self.assertEqual(manager.get_moe_shared_flags("uid-no-sidecar"),
+                         all_false_flags())
+
+    def test_sidecar_flags_propagate_to_manager(self):
+        manager = self._create_manager()
+        model_config = MockMoeModelConfig()
+        sidecar = {
+            "version": 1,
+            "moe_shared_outer": {
+                "moe_h_to_4h": {
+                    "shared_side": "A"
+                },
+                "moe_gate": {
+                    "shared_side": "A"
+                },
+                "moe_4h_to_h": {
+                    "shared_side": "B"
+                },
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            adapter_dir = Path(tmpdir) / "adapter_shared_outer"
+            adapter_dir.mkdir()
+            _create_dummy_moe_hf_lora_adapter(adapter_dir,
+                                              layout_sidecar=sidecar)
+            manager.load_from_hf(
+                model_dirs=[str(adapter_dir)],
+                model_config=model_config,
+                uids=["uid-shared"],
+            )
+        flags = manager.get_moe_shared_flags("uid-shared")
+        self.assertEqual(
+            flags,
+            {
+                "fc1_shared_a": True,
+                "fc1_shared_b": False,
+                "fc2_shared_a": False,
+                "fc2_shared_b": True,
+                "gated_shared_a": True,
+                "gated_shared_b": False,
+            },
+        )
+
+    def test_sidecar_does_not_change_cached_weights(self):
+        # Loading with vs without the sidecar should produce bit-identical
+        # `_cpp_lora_weights` rows: the sidecar is metadata-only in this
+        # release (still load-time replicated to match the C++ cache).
+        manager_a = self._create_manager()
+        manager_b = self._create_manager()
+        model_config = MockMoeModelConfig()
+        sidecar = {
+            "version": 1,
+            "moe_shared_outer": {
+                "moe_h_to_4h": {
+                    "shared_side": "A"
+                },
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            adapter_dir_a = Path(tmpdir) / "adapter_a"
+            adapter_dir_b = Path(tmpdir) / "adapter_b"
+            adapter_dir_a.mkdir()
+            adapter_dir_b.mkdir()
+            torch.manual_seed(0)
+            _create_dummy_moe_hf_lora_adapter(adapter_dir_a)
+            torch.manual_seed(0)
+            _create_dummy_moe_hf_lora_adapter(adapter_dir_b,
+                                              layout_sidecar=sidecar)
+            manager_a.load_from_hf(model_dirs=[str(adapter_dir_a)],
+                                   model_config=model_config,
+                                   uids=["uid-a"])
+            manager_b.load_from_hf(model_dirs=[str(adapter_dir_b)],
+                                   model_config=model_config,
+                                   uids=["uid-b"])
+        self.assertTrue(
+            torch.equal(manager_a.cpp_lora_weights["uid-a"],
+                        manager_b.cpp_lora_weights["uid-b"]))
+
+    def test_unknown_uid_returns_all_false(self):
+        manager = self._create_manager()
+        self.assertEqual(manager.get_moe_shared_flags("never-loaded"),
+                         all_false_flags())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…E LoRA

Establishes the user-facing convention for marking routed-expert MoE LoRA adapters as shared-outer and threads the resulting six-bool kernel-flag dict end-to-end (loader -> LoraManager -> per-request assembler -> fused-MoE op -> kernel). Without this, the Phase 6a kernel flag was reachable only from synthetic-tensor tests; with it, a real HF adapter directory can opt in by dropping a sidecar next to adapter_config.json.

Scope is intentionally metadata-only in this release: the C++ LoRA cache row size is determined by LoraModule::localTotalSize (which for MoE bakes in num_experts), so the loader still replicates shared sides into the cache. Setting the flag makes the kernel zero-offset and read one slice; not setting it makes the kernel read each (identical) slice. Output is bit-identical either way. The follow-up that shrinks the cache row and accepts truly unreplicated on-disk shapes becomes a focused C++ change with no Python API surface motion.

Mismatched flags across active LoRA uids in a single batch raise, since the fused-MoE op applies one global flag set per call.

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
