### PR TITLE
[None][perf] use native C++ BlockKeyHasher in disagg router to improve TTFT

### DIFF
--- a/tensorrt_llm/serve/router.py
+++ b/tensorrt_llm/serve/router.py
@@ -22,6 +22,10 @@ from typing import Awaitable, Callable, Dict, Iterable, List, Optional, Union
 import aiohttp
 from transformers import AutoTokenizer
 
+from tensorrt_llm.bindings.internal.batch_manager import \
+    BlockKey as _NativeBlockKey
+from tensorrt_llm.bindings.internal.batch_manager import \
+    BlockKeyHasher as _NativeBlockKeyHasher
 from tensorrt_llm.llmapi.disagg_utils import (MetadataServerConfig,
                                               RouterConfig, ServerRole)
 from tensorrt_llm.logger import logger
@@ -735,10 +739,16 @@ class LoadBalancingRouter(LoadBalancingMixin, Router):
 def block_key_hasher(token_ids: list[int],
                      parent_hash: Optional[int] = None,
                      cache_salt_id: Optional[int] = None) -> int:
-    return hash_v1_block_key(
-        token_ids,
-        parent_hash=0 if parent_hash is None else parent_hash,
-        cache_salt_id=cache_salt_id)
+    parent = 0 if parent_hash is None else parent_hash
+    # Fast path: the native C++ BlockKeyHasher is bit-exact with
+    # hash_v1_block_key and avoids the per-token Python loop. Its hash() binding
+    # takes no cache_salt_id, so fall back to Python only when a salt is set
+    # (rare opt-in; never in the unsalted agent/chat completion path).
+    if cache_salt_id is None:
+        return _NativeBlockKeyHasher.hash(_NativeBlockKey(token_ids), parent)
+    return hash_v1_block_key(token_ids,
+                             parent_hash=parent,
+                             cache_salt_id=cache_salt_id)
 
 
 def v2_sha256_block_hasher(token_ids: list[int],

--- a/tests/unittest/disaggregated/test_router.py
+++ b/tests/unittest/disaggregated/test_router.py
@@ -1,5 +1,6 @@
 import asyncio
 import copy
+import random
 import threading
 from unittest import mock
 
@@ -22,9 +23,35 @@ from tensorrt_llm.serve.router import (KV_CACHE_HASH_ALGO_V1,
                                        ConversationRouter, KvCacheAwareRouter,
                                        KvCacheAwareServerState,
                                        LoadBalancingRouter, RoundRobinRouter,
-                                       create_router)
+                                       block_key_hasher, create_router)
 
 # yapf: enable
+
+
+def test_native_block_key_hasher_matches_python_v1():
+    """Native C++ BlockKeyHasher must be bit-exact with hash_v1_block_key.
+
+    Covers single blocks and the chained per-block pattern used by
+    BlockHashMixin._compute_block_hashes.
+    """
+    random.seed(0)
+    for _ in range(500):
+        n = random.choice([1, 2, 31, 32, 33, 64, 97])
+        toks = [random.randint(0, 300000) for _ in range(n)]
+        parent = random.choice([None, 0, random.randint(1, 2**64 - 1)])
+        ref = hash_v1_block_key(toks,
+                                parent_hash=0 if parent is None else parent)
+        assert block_key_hasher(toks, parent) == ref
+
+    # chained per-block (the real _compute_block_hashes pattern)
+    toks = [random.randint(0, 300000) for _ in range(2000)]
+    parent = None
+    for t in range(0, len(toks) - 1, 32):
+        t_end = min(t + 32, len(toks) - 1)
+        h = block_key_hasher(toks[t:t_end], parent)
+        assert h == hash_v1_block_key(
+            toks[t:t_end], parent_hash=0 if parent is None else parent)
+        parent = h
 
 
 def _make_mock_aiohttp_session(return_value=None):


### PR DESCRIPTION
The bottleneck is CPU-side queueing in the orchestrator. It routes each request by hashing the prompt into KV-cache block keys; that hashing (hash_v1_block_key) is a pure-Python per-token loop. For ~39k-token agentic prompts it costs ~tens of ms, running on the orchestrator's single asyncio event loop, so it monopolizes one CPU core and serializes all concurrent requests → TTFT explodes with concurrency.
  
Fix: move block hashing to the native C++ hasher → the event loop de-saturates.
  
Impact (DSv4-Pro 1P1D DEP8, GB300, AgentPerf-V2), c128: TTFT p95 10.71s → 3.13s (−71%), throughput +50%, req/s +63% at the same concurrency. 

|  | baseline (bd, pre-fix) | fix | gain |
|---|---|---|---|
| **TTFT p95** | 10.71s | 3.13s | **3.4× (−7.6s, −71%)** |
| TTFT p50 | 6.50s | 1.56s | 4.2× |
| throughput | 3,533 tok/s | 5,308 tok/s | +50% |
| req/s | 10.2 | 16.6 | +63% |

SLO60 ceiling (p95 ≤ 5s & SSE p25 ≥ 60 tok/s) rises ~c72 → c160 (~4.5 → 10 users/GPU). 

| conc | cpg | TTFT p50 | p75 | **p95** | p99 | SSE p25 | SSE p50 | meas req | req/s | cache-hit | ISL | OSL | out tok/s | SLO60 |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| *c128 (yday, pre-fix)* | 8 | 6.50 | 8.15 | *10.71* | 12.71 | 60.9 | 71.9 | 20,867 | 10.18 | 96.7% | 39,341 | 348 | 3,533 | ❌ (TTFT) |
| **c128 (today, fix)** | 8 | 1.56 | 1.91 | **3.13** | 4.98 | 63.5 | 66.6 | 34,002 | 16.60 | 96.7% | 39,094 | 320 | 5,308 | ✅ |
| c144 | 9 | 1.73 | 2.11 | **3.61** | 5.62 | 61.2 | 64.4 | 35,105 | 17.67 | 96.7% | 39,593 | 320 | 5,649 | ✅ |
| c160 | 10 | 1.98 | 2.42 | **4.26** | 6.56 | 60.2 | 63.4 | 37,940 | 18.32 | 96.7% | 39,310 | 323 | 5,905 | ✅ **ceiling** |
| c176 | 11 | 2.21 | 2.79 | **5.42** | 9.38 | 58.0 | 61.4 | 39,109 | 18.80 | 96.7% | 40,075 | 318 | 5,953 | ❌ |
| c192 | 12 | 2.19 | 2.81 | **5.76** | 9.67 | 54.6 | 58.1 | 40,781 | 19.53 | 96.5% | 39,984 | 316 | 6,159 | ❌ |

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
