### PR TITLE
[#14781][feat] Improved pattern matcher for AR+residual_add+RMSNorm

### DIFF
--- a/examples/auto_deploy/llmc/create_standalone_package.py
+++ b/examples/auto_deploy/llmc/create_standalone_package.py
@@ -171,6 +171,8 @@ EXCLUDE_TEST_FILES = {
     "test_mxfp4_moe_layout.py",
     # Require TRT-LLM distributed ops (trtllm_dist_all_gather)
     "test_gather_logits_before_lm_head.py",
+    # Calls torch.ops.auto_deploy.trtllm_dist_all_reduce directly (not registered standalone)
+    "test_allreduce_residual_rmsnorm_matcher.py",
     # Multimodal processors depend on TensorRT-LLM multimodal request types.
     "test_gemma4_modeling.py",
     "test_qwen3_5_moe.py",

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/collectives.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/collectives.py
@@ -63,8 +63,9 @@ def _make_allreduce_residual_rmsnorm_pattern(
         strategy: AllReduce strategy to use in the pattern
         rmsnorm_op_name: Which rmsnorm op to match ("torch_rmsnorm" or "triton_rms_norm")
         with_reshape: If True, insert a ``reshape`` between the all-reduce and the residual
-            add (e.g. ``[B, S, H] -> [B*S, H]``). Common when the tensor-parallel linear
-            output is reshaped before being added to a flattened residual stream.
+            add (e.g. ``[B*S, H] -> [B, S, H]``). Common when a tensor-parallel MLP/MoE
+            output is all-reduced as a flattened 2D tensor and reshaped back to the 3D
+            residual stream before the add.
 
     Returns:
         A pattern function that can be used with register_ad_pattern
@@ -137,6 +138,13 @@ def _allreduce_residual_rmsnorm_replacement(
 # ============================================================================
 
 
+def _is_reshape(node) -> bool:
+    return getattr(node, "op", None) == "call_function" and node.target in (
+        torch.ops.aten.reshape.default,
+        torch.ops.aten.view.default,
+    )
+
+
 @TransformRegistry.register("fuse_allreduce_residual_rmsnorm")
 class FuseAllreduceResidualRMSNorm(BaseTransform):
     """Fuse (allreduce + residual add + RMSNorm) into one fused op with tuple output.
@@ -148,6 +156,47 @@ class FuseAllreduceResidualRMSNorm(BaseTransform):
     Note: This transform expects torch_rmsnorm ops in the graph, which are created
     by the match_rmsnorm_pattern transform that runs earlier in the pipeline.
     """
+
+    @staticmethod
+    def _restore_dynamic_reshape(gm: GraphModule) -> int:
+        """Re-point baked-literal reshapes feeding the fused op at residual's runtime sizes.
+
+        The fused op is ``trtllm_fused_allreduce_residual_rmsnorm(x, residual, ...)``. For
+        the reshape variant ``x`` is a ``reshape(all_reduce_input, residual.shape)``. The
+        pattern matcher bakes ``residual.shape`` into concrete ints during replacement
+        tracing, so we replace that literal size list with ``aten.sym_size.int(residual, d)``
+        nodes, restoring a fully dynamic reshape. Returns the number of reshapes fixed.
+        """
+        fused_op = torch.ops.dist.trtllm_fused_allreduce_residual_rmsnorm
+        graph = gm.graph
+        num_fixed = 0
+        for node in list(graph.nodes):
+            if node.op != "call_function" or node.target != fused_op.default:
+                continue
+            if len(node.args) < 2:
+                continue
+            x_in, residual = node.args[0], node.args[1]
+            if not (_is_reshape(x_in) and isinstance(residual, torch.fx.Node)):
+                continue
+            size_arg = x_in.args[1]
+            if not (
+                isinstance(size_arg, (list, tuple))
+                and len(size_arg) > 0
+                and all(isinstance(s, int) for s in size_arg)
+            ):
+                continue
+            with graph.inserting_before(x_in):
+                dyn_sizes = [
+                    graph.call_function(torch.ops.aten.sym_size.int, (residual, d))
+                    for d in range(len(size_arg))
+                ]
+            x_in.update_arg(1, dyn_sizes)
+            num_fixed += 1
+        if num_fixed:
+            ad_logger.info(
+                f"Restored dynamic reshape on {num_fixed} fused allreduce-residual-rmsnorm op(s)"
+            )
+        return num_fixed
 
     def _apply(
         self,
@@ -191,16 +240,22 @@ class FuseAllreduceResidualRMSNorm(BaseTransform):
         scalar_workaround = {"eps": 0.1253}
 
         def _dummy_args(with_reshape: bool):
-            # For the reshape variants `x` is 3D so the `reshape(..., residual.shape)`
-            # collapsing it to the 2D residual shape survives tracing instead of becoming
-            # an identity no-op (which FX would elide, altering the pattern topology).
+            # Real graph (tensor-parallel MLP/MoE): the linear output is all-reduced as a
+            # 2D ``[tokens, hidden]`` tensor and then reshaped back to the 3D
+            # ``[batch, seq, hidden]`` residual stream before the add. So for the reshape
+            # variant ``x`` (the all-reduce input) is 2D and ``residual`` is 3D, i.e. the
+            # reshape EXPANDS 2D->3D. Using different ranks also keeps the reshape from
+            # being elided as an identity no-op during tracing (which would alter the
+            # pattern topology).
             if with_reshape:
-                x = torch.randn(2, 4, hidden, device="meta", dtype=torch.bfloat16)
+                x = torch.randn(8, hidden, device="meta", dtype=torch.bfloat16)
+                residual = torch.randn(2, 4, hidden, device="meta", dtype=torch.bfloat16)
             else:
                 x = torch.randn(8, hidden, device="meta", dtype=torch.bfloat16)
+                residual = torch.randn(8, hidden, device="meta", dtype=torch.bfloat16)
             return [
                 x,
-                torch.randn(8, hidden, device="meta", dtype=torch.bfloat16),  # residual
+                residual,
                 torch.randn(hidden, device="meta", dtype=torch.bfloat16),  # weight
                 0.1253,  # eps
             ]
@@ -235,6 +290,14 @@ class FuseAllreduceResidualRMSNorm(BaseTransform):
                     )
 
         num_matches = patterns.apply(gm.graph)
+
+        # The pattern matcher re-traces the replacement with statically-shaped fake
+        # tensors (no dynamic_shapes), which bakes residual's concrete [B, S] dims into
+        # the reshape feeding the fused op (e.g. ``reshape(x, [2, 4, H])``). That makes
+        # the fused graph unusable at any other batch/seq. Re-point those reshapes at
+        # residual's *runtime* sizes so the fused all-reduce input shape stays dynamic.
+        if num_matches:
+            self._restore_dynamic_reshape(gm)
 
         info = TransformInfo(
             skipped=False,

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/collectives.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/collectives.py
@@ -54,6 +54,7 @@ def _make_allreduce_residual_rmsnorm_pattern(
     add_order: str = "residual_first",
     strategy: str = "AUTO",
     rmsnorm_op_name: str = "torch_rmsnorm",
+    with_reshape: bool = False,
 ):
     """Factory function to create pattern functions for allreduce+residual+rmsnorm fusion.
 
@@ -61,24 +62,41 @@ def _make_allreduce_residual_rmsnorm_pattern(
         add_order: Either "residual_first" (residual + x) or "x_first" (x + residual)
         strategy: AllReduce strategy to use in the pattern
         rmsnorm_op_name: Which rmsnorm op to match ("torch_rmsnorm" or "triton_rms_norm")
+        with_reshape: If True, insert a ``reshape`` between the all-reduce and the residual
+            add (e.g. ``[B, S, H] -> [B*S, H]``). Common when the tensor-parallel linear
+            output is reshaped before being added to a flattened residual stream.
 
     Returns:
         A pattern function that can be used with register_ad_pattern
+
+    Note:
+        A pre-RMSNorm residual downcast (``aten.to.dtype``) is intentionally NOT matched
+        here. Such a cast only survives tracing when the residual stream is in a higher
+        precision than the compute dtype (e.g. fp32), in which case the reference adds in
+        fp32 and downcasts the sum. The fused kernel cannot reproduce that
+        accumulate-then-downcast semantics from a single compute-dtype residual, so fusing
+        it would silently change residual-stream precision.
     """
     rmsnorm_op = _RMSNORM_OPS[rmsnorm_op_name]
 
     def pattern_fn(
         x: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor, eps: float = 0.1253
     ):
-        """Pattern: trtllm_dist_all_reduce(x) -> add residual -> rmsnorm
+        """Pattern: trtllm_dist_all_reduce(x) -> [reshape] -> add residual -> rmsnorm
 
         Reference PyTorch composition:
             y = trtllm_dist_all_reduce(x)
+            y = reshape(y, residual.shape)         # only if with_reshape
             z = residual + y  (or y + residual)
             normed = rmsnorm_op(z, weight, eps)
         Returns (normed, z)
         """
         hidden_states = torch.ops.auto_deploy.trtllm_dist_all_reduce(x, strategy)
+
+        # all-reduce preserves shape and is elementwise w.r.t. reshape, so a reshape
+        # between the all-reduce and the residual add commutes with the all-reduce.
+        if with_reshape:
+            hidden_states = torch.reshape(hidden_states, residual.shape)
 
         # Handle addition order
         if add_order == "residual_first":
@@ -94,9 +112,21 @@ def _make_allreduce_residual_rmsnorm_pattern(
 
 
 def _allreduce_residual_rmsnorm_replacement(
-    x: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor, eps: float, strategy: str
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    strategy: str,
+    with_reshape: bool = False,
 ):
-    """Replacement using TRT-LLM fused kernel."""
+    """Replacement using TRT-LLM fused kernel.
+
+    When the matched pattern reshaped the all-reduce output before the residual add, the
+    reshape is pushed in front of the fused op's (internal) all-reduce input instead, which
+    is valid because all-reduce is elementwise and therefore commutes with reshape.
+    """
+    if with_reshape:
+        x = torch.reshape(x, residual.shape)
     return torch.ops.dist.trtllm_fused_allreduce_residual_rmsnorm(
         x, residual, weight, eps, strategy
     )
@@ -157,28 +187,52 @@ class FuseAllreduceResidualRMSNorm(BaseTransform):
 
         patterns = ADPatternMatcherPass()
 
-        # Dummy shapes for tracing
-        bsz, hidden = 8, 512
-        dummy_args = [
-            torch.randn(bsz, hidden, device="meta", dtype=torch.bfloat16),  # x
-            torch.randn(bsz, hidden, device="meta", dtype=torch.bfloat16),  # residual
-            torch.randn(hidden, device="meta", dtype=torch.bfloat16),  # weight
-            0.1253,  # eps
-        ]
+        hidden = 512
         scalar_workaround = {"eps": 0.1253}
+
+        def _dummy_args(with_reshape: bool):
+            # For the reshape variants `x` is 3D so the `reshape(..., residual.shape)`
+            # collapsing it to the 2D residual shape survives tracing instead of becoming
+            # an identity no-op (which FX would elide, altering the pattern topology).
+            if with_reshape:
+                x = torch.randn(2, 4, hidden, device="meta", dtype=torch.bfloat16)
+            else:
+                x = torch.randn(8, hidden, device="meta", dtype=torch.bfloat16)
+            return [
+                x,
+                torch.randn(8, hidden, device="meta", dtype=torch.bfloat16),  # residual
+                torch.randn(hidden, device="meta", dtype=torch.bfloat16),  # weight
+                0.1253,  # eps
+            ]
+
+        def _op_ignore_types(with_reshape: bool):
+            # Ignore the literal shape ints baked into the reshape so the pattern matches
+            # any reshape target shape rather than the specific dummy dims.
+            if with_reshape:
+                return {torch.ops.aten.reshape.default: (int,)}
+            return None
 
         for rmsnorm_op_name in _RMSNORM_OPS:
             for add_order in ("residual_first", "x_first"):
-                pattern = _make_allreduce_residual_rmsnorm_pattern(
-                    add_order=add_order, strategy=strategy, rmsnorm_op_name=rmsnorm_op_name
-                )
-                register_ad_pattern(
-                    search_fn=pattern,
-                    replace_fn=partial(_allreduce_residual_rmsnorm_replacement, strategy=strategy),
-                    patterns=patterns,
-                    dummy_args=dummy_args,
-                    scalar_workaround=scalar_workaround,
-                )
+                for with_reshape in (False, True):
+                    pattern = _make_allreduce_residual_rmsnorm_pattern(
+                        add_order=add_order,
+                        strategy=strategy,
+                        rmsnorm_op_name=rmsnorm_op_name,
+                        with_reshape=with_reshape,
+                    )
+                    register_ad_pattern(
+                        search_fn=pattern,
+                        replace_fn=partial(
+                            _allreduce_residual_rmsnorm_replacement,
+                            strategy=strategy,
+                            with_reshape=with_reshape,
+                        ),
+                        patterns=patterns,
+                        dummy_args=_dummy_args(with_reshape),
+                        op_ignore_types=_op_ignore_types(with_reshape),
+                        scalar_workaround=scalar_workaround,
+                    )
 
         num_matches = patterns.apply(gm.graph)
 

--- a/tests/unittest/auto_deploy/multigpu/custom_ops/test_ad_dist_strategies.py
+++ b/tests/unittest/auto_deploy/multigpu/custom_ops/test_ad_dist_strategies.py
@@ -26,6 +26,7 @@ from _model_test_utils import get_small_model_config
 from click.testing import CliRunner
 from utils.cpp_paths import llm_root  # noqa: F401
 
+from tensorrt_llm._torch.auto_deploy._compat import AllReduceStrategy
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transform.library.sharding import (
     AllGatherStrategy,
@@ -38,7 +39,6 @@ from tensorrt_llm._torch.auto_deploy.transform.library.sharding import (
 from tensorrt_llm._torch.auto_deploy.utils._graph import recompile
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
 from tensorrt_llm.commands.bench import main
-from tensorrt_llm.functional import AllReduceStrategy
 
 # needed since LLM API uses MPI executor pool internally for TP>1, which leaks a thread on shutdown
 pytestmark = pytest.mark.threadleak(enabled=False)

--- a/tests/unittest/auto_deploy/multigpu/transformations/library/test_allreduce_residual_rmsnorm_fusion.py
+++ b/tests/unittest/auto_deploy/multigpu/transformations/library/test_allreduce_residual_rmsnorm_fusion.py
@@ -80,6 +80,87 @@ class AllreduceResidualNorm2(torch.nn.Module):
         return normed, y
 
 
+class ARResidualNormReshape(torch.nn.Module):
+    """AR+residual+RMSNorm with a reshape between the all-reduce and the residual add.
+
+    ``x`` is provided 3D ``[B, S, H]`` and the all-reduce output is reshaped to the 2D
+    residual ``[B*S, H]`` before the add (e.g. a TP linear output flattened onto a 2D
+    residual stream).
+    """
+
+    def __init__(self, hidden_size, dtype, strategy, add_order):
+        super().__init__()
+        self.norm = RMSNorm(hidden_size, 1e-5, dtype)
+        self.strategy = strategy
+        self.add_order = add_order
+
+    def forward(self, x, residual):
+        x = torch.ops.auto_deploy.trtllm_dist_all_reduce.default(x, self.strategy)
+        x = torch.reshape(x, residual.shape)
+        y = residual + x if self.add_order == "residual_first" else x + residual
+        return self.norm(y), y
+
+
+def _test_allreduce_fusion_variant(
+    port: int | None,
+    strategy: str,
+    rmsnorm_op: str,
+    add_order: str,
+):
+    if not is_trtllm_op_available():
+        pytest.skip("Require trtllm ops to run test_allreduce_fusion.")
+
+    if port is None:
+        port = mpi_broadcast(get_free_port() if mpi_rank() == 0 else None)
+
+    _, _ = initialize_or_skip(port=port)
+
+    try:
+        dtype = torch.float16
+        hidden = 16
+        x = torch.randn(2, 8, hidden).to(dtype).cuda()
+        residual = torch.randn(16, hidden).to(dtype).cuda()
+
+        model = ARResidualNormReshape(hidden, dtype, strategy, add_order)
+        args = (x, residual)
+        gm = torch_export_to_gm(model, args=args, clone=True)
+        original_outputs, residual_original = gm(x, residual)
+
+        optimizer_config = {
+            "match_rmsnorm_pattern": {"stage": "pattern_matcher"},
+            "detect_sharding": {"stage": "post_export", "allreduce_strategy": strategy},
+        }
+        if rmsnorm_op == "triton_rms_norm":
+            optimizer_config["fuse_rmsnorm"] = {
+                "stage": "post_load_fusion",
+                "rmsnorm_backend": "triton",
+            }
+        optimizer_config["fuse_allreduce_residual_rmsnorm"] = {"stage": "post_load_fusion"}
+
+        gm_transformed = InferenceOptimizer(None, optimizer_config)(None, gm)
+        fused_outputs, residual_fused = gm_transformed(x, residual)
+
+        has_fused_node = any(
+            is_op(node, torch.ops.dist.trtllm_fused_allreduce_residual_rmsnorm)
+            for node in gm_transformed.graph.nodes
+        )
+        assert has_fused_node, "Fused node not found."
+
+        assert torch.allclose(residual_original, residual_fused, atol=1e-3, rtol=1e-3), (
+            "Residual output differs between original and fused models."
+        )
+        assert torch.allclose(original_outputs, fused_outputs, atol=1e-3, rtol=1e-3), (
+            "Norm output differs between original and fused models."
+        )
+
+        export(gm_transformed, args=args)
+        torch_export_to_gm(gm_transformed, args=args)
+    finally:
+        if torch.distributed.is_initialized() and torch.distributed.get_world_size() > 1:
+            torch.distributed.barrier()
+        cleanup()
+
+
 def _test_allreduce_fusion(port: int | None, ModuleCls, strategy: str, rmsnorm_op: str):
     if not is_trtllm_op_available():
         pytest.skip("Require trtllm ops to run test_allreduce_fusion.")
@@ -211,6 +292,43 @@ def test_allreduce_fusion(device_count, ModuleCls, strategy, rmsnorm_op):
                 ModuleCls=ModuleCls,
                 strategy=strategy,
                 rmsnorm_op=rmsnorm_op,
+            )
+            return
+        except DistNetworkError as e:
+            last_exc = e
+            if "EADDRINUSE" not in str(e) and "address already in use" not in str(e).lower():
+                raise
+        finally:
+            mpi_pool.shutdown()
+    raise RuntimeError(
+        f"Failed to initialize distributed group after {max_retries} attempts due to repeated port conflicts"
+    ) from last_exc
+
+
+@pytest.mark.parametrize("device_count", get_device_counts())
+@pytest.mark.parametrize("add_order", ["residual_first", "x_first"])
+@pytest.mark.parametrize("strategy", ["AUTO", "ONESHOT"], ids=["strategy_auto", "strategy_oneshot"])
+@pytest.mark.parametrize(
+    "rmsnorm_op", ["torch_rmsnorm", "triton_rms_norm"], ids=["rmsnorm_torch", "rmsnorm_triton"]
+)
+def test_allreduce_fusion_reshape(device_count, add_order, strategy, rmsnorm_op):
+    # Covers the reshape variant (reshape between all-reduce and residual add),
+    # end-to-end on real GPUs.
+    if device_count <= 1:
+        pytest.skip("Require multi GPUs to run test_allreduce_fusion_reshape.")
+
+    n_workers = device_count
+    max_retries = 5
+    last_exc: Exception | None = None
+    for _ in range(max_retries):
+        mpi_pool = MpiPoolSession(n_workers=n_workers)
+        try:
+            mpi_pool.submit_sync(
+                _test_allreduce_fusion_variant,
+                port=None,
+                strategy=strategy,
+                rmsnorm_op=rmsnorm_op,
+                add_order=add_order,
             )
             return
         except DistNetworkError as e:

--- a/tests/unittest/auto_deploy/multigpu/transformations/library/test_allreduce_residual_rmsnorm_fusion.py
+++ b/tests/unittest/auto_deploy/multigpu/transformations/library/test_allreduce_residual_rmsnorm_fusion.py
@@ -83,9 +83,9 @@ class AllreduceResidualNorm2(torch.nn.Module):
 class ARResidualNormReshape(torch.nn.Module):
     """AR+residual+RMSNorm with a reshape between the all-reduce and the residual add.
 
-    ``x`` is provided 3D ``[B, S, H]`` and the all-reduce output is reshaped to the 2D
-    residual ``[B*S, H]`` before the add (e.g. a TP linear output flattened onto a 2D
-    residual stream).
+    ``x`` is provided 2D ``[B*S, H]`` and the all-reduce output is reshaped (expanded) to
+    the 3D residual ``[B, S, H]`` before the add (e.g. a TP MLP/MoE output that is
+    all-reduced flat and reshaped back onto the 3D residual stream).
     """
 
     def __init__(self, hidden_size, dtype, strategy, add_order):
@@ -118,8 +118,8 @@ def _test_allreduce_fusion_variant(
     try:
         dtype = torch.float16
         hidden = 16
-        x = torch.randn(2, 8, hidden).to(dtype).cuda()
-        residual = torch.randn(16, hidden).to(dtype).cuda()
+        x = torch.randn(16, hidden).to(dtype).cuda()
+        residual = torch.randn(2, 8, hidden).to(dtype).cuda()
 
         model = ARResidualNormReshape(hidden, dtype, strategy, add_order)
         args = (x, residual)

--- a/tests/unittest/auto_deploy/multigpu/transformations/library/test_bmm_sharding.py
+++ b/tests/unittest/auto_deploy/multigpu/transformations/library/test_bmm_sharding.py
@@ -23,6 +23,7 @@ from _dist_test_utils import get_device_counts
 from _graph_test_helpers import run_sharding_pattern_detection_test, run_test_transformed_gm
 
 import tensorrt_llm._torch.auto_deploy.distributed.common as dist_common
+from tensorrt_llm._torch.auto_deploy._compat import AllReduceStrategy
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transform.library.sharding import (
     BMMShardingInfo,
@@ -30,7 +31,6 @@ from tensorrt_llm._torch.auto_deploy.transform.library.sharding import (
 )
 from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
-from tensorrt_llm.functional import AllReduceStrategy
 
 
 class BMM(nn.Module):

--- a/tests/unittest/auto_deploy/multigpu/transformations/library/test_ep_sharding.py
+++ b/tests/unittest/auto_deploy/multigpu/transformations/library/test_ep_sharding.py
@@ -23,6 +23,7 @@ from _graph_test_helpers import run_sharding_pattern_detection_test, run_test_tr
 from _model_test_utils import MoEOpModel
 
 import tensorrt_llm._torch.auto_deploy.distributed.common as dist_common
+from tensorrt_llm._torch.auto_deploy._compat import AllReduceStrategy
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transform.library.sharding import (
     EPShardingInfo,
@@ -34,7 +35,6 @@ from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimiz
 from tensorrt_llm._torch.auto_deploy.utils._graph import lint, recompile
 from tensorrt_llm._torch.auto_deploy.utils.dist_config import DistConfig
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
-from tensorrt_llm.functional import AllReduceStrategy
 
 
 def _run_ep_shard_job(

--- a/tests/unittest/auto_deploy/multigpu/transformations/library/test_tp_sharding.py
+++ b/tests/unittest/auto_deploy/multigpu/transformations/library/test_tp_sharding.py
@@ -30,6 +30,7 @@ from _torch_test_utils import fp4_compatible, trtllm_ops_available
 from torch._inductor.pattern_matcher import stable_topological_sort
 
 import tensorrt_llm._torch.auto_deploy.distributed.common as dist_common
+from tensorrt_llm._torch.auto_deploy._compat import AllReduceStrategy
 from tensorrt_llm._torch.auto_deploy.custom_ops.quantization.quant import _pad_nvfp4_weight
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.models.custom.modeling_nemotron_h import NemotronHMamba2Mixer
@@ -49,7 +50,6 @@ from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import (
     fp4_global_scale,
     modelopt_fp4_scale_to_cutlass_fp4_scale,
 )
-from tensorrt_llm.functional import AllReduceStrategy
 
 
 class GQA_Block(nn.Module):

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_allreduce_residual_rmsnorm_matcher.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_allreduce_residual_rmsnorm_matcher.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Graph-level (non-distributed) match-count tests for the AR + residual + RMSNorm fusion.
+
+These tests do NOT execute the fused graph (which would require a process group);
+they only verify that the pattern matcher rewrites the expected subgraphs into a
+single ``trtllm_fused_allreduce_residual_rmsnorm`` op. They specifically cover the
+``reshape`` between the all-reduce and the residual add (e.g. a TP linear output
+``[B, S, H]`` reshaped to a flattened residual ``[B*S, H]``), which previously broke
+the match and left the op unfused.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch.export import Dim
+
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
+from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
+from tensorrt_llm.functional import AllReduceStrategy
+
+
+class RMSNorm(torch.nn.Module):
+    def __init__(self, hidden_size, eps=1e-5, dtype=torch.bfloat16):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(hidden_size, device="cuda", dtype=dtype))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states):
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+
+class ARResidualNorm(torch.nn.Module):
+    """all_reduce -> [reshape] -> add(residual) -> rmsnorm.
+
+    ``x`` is provided 3D when ``with_reshape`` so that the all-reduce output is
+    reshaped to the (2D) residual shape before the add.
+    """
+
+    def __init__(self, hidden_size, strategy, add_order, with_reshape):
+        super().__init__()
+        self.norm = RMSNorm(hidden_size, dtype=torch.bfloat16)
+        self.strategy = strategy
+        self.add_order = add_order
+        self.with_reshape = with_reshape
+
+    def forward(self, x, residual):
+        x = torch.ops.auto_deploy.trtllm_dist_all_reduce.default(x, self.strategy)
+        if self.with_reshape:
+            x = torch.reshape(x, residual.shape)
+        y = residual + x if self.add_order == "residual_first" else x + residual
+        return self.norm(y), y
+
+
+def _count(gm, op):
+    return sum(is_op(n, op) for n in gm.graph.nodes)
+
+
+@pytest.mark.parametrize("add_order", ["residual_first", "x_first"])
+@pytest.mark.parametrize("with_reshape", [False, True], ids=["base", "reshape"])
+@pytest.mark.parametrize("strategy", ["AUTO", "ONESHOT"])
+def test_allreduce_residual_rmsnorm_match(add_order, with_reshape, strategy):
+    if not torch.cuda.is_available():
+        pytest.skip("Requires a CUDA device to build the test module.")
+
+    hidden = 512
+    bsz, seq = 2, 4
+    if with_reshape:
+        x = torch.randn(bsz, seq, hidden, device="cuda", dtype=torch.bfloat16)
+    else:
+        x = torch.randn(bsz * seq, hidden, device="cuda", dtype=torch.bfloat16)
+    residual = torch.randn(bsz * seq, hidden, device="cuda", dtype=torch.bfloat16)
+
+    model = ARResidualNorm(hidden, strategy, add_order, with_reshape)
+
+    # Dynamic leading dim to exercise the symbolic re-trace path of the matcher.
+    # For the reshape variant x is 3D [bs, seq, h] and is reshaped to the 2D residual
+    # [bs*seq, h], so the residual token dim is the derived dim seq * bs.
+    if with_reshape:
+        bs = Dim("bs")
+        dynamic_shapes = ({0: bs}, {0: seq * bs})
+    else:
+        tokens = Dim("tokens")
+        dynamic_shapes = ({0: tokens}, {0: tokens})
+
+    gm = torch_export_to_gm(model, args=(x, residual), dynamic_shapes=dynamic_shapes, clone=True)
+
+    # Collapse the decomposed RMSNorm into a single torch_rmsnorm op (prerequisite for
+    # the allreduce-residual-rmsnorm fusion).
+    gm = InferenceOptimizer(None, {"match_rmsnorm_pattern": {"stage": "pattern_matcher"}})(None, gm)
+    assert _count(gm, torch.ops.auto_deploy.torch_rmsnorm) == 1
+
+    # Provide the allreduce strategy via the legacy container path (no distributed
+    # process group / detect_sharding needed for a graph-only match test).
+    gm._sharding_transform_container = SimpleNamespace(
+        config=SimpleNamespace(allreduce_strategy=AllReduceStrategy[strategy])
+    )
+    gm = InferenceOptimizer(
+        None, {"fuse_allreduce_residual_rmsnorm": {"stage": "post_load_fusion"}}
+    )(None, gm)
+
+    # The whole subgraph must collapse into exactly one fused op, with the standalone
+    # all-reduce, residual add, and RMSNorm all removed.
+    fused = [
+        n
+        for n in gm.graph.nodes
+        if is_op(n, torch.ops.dist.trtllm_fused_allreduce_residual_rmsnorm)
+    ]
+    assert len(fused) == 1, f"expected 1 fused op, got {len(fused)}"
+    assert fused[0].args[4] == strategy
+    assert _count(gm, torch.ops.auto_deploy.trtllm_dist_all_reduce) == 0
+    assert _count(gm, torch.ops.auto_deploy.torch_rmsnorm) == 0

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_allreduce_residual_rmsnorm_matcher.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_allreduce_residual_rmsnorm_matcher.py
@@ -28,10 +28,10 @@ import pytest
 import torch
 from torch.export import Dim
 
+from tensorrt_llm._torch.auto_deploy._compat import AllReduceStrategy
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
-from tensorrt_llm.functional import AllReduceStrategy
 
 
 class RMSNorm(torch.nn.Module):

--- a/tests/unittest/auto_deploy/singlegpu/transformations/library/test_allreduce_residual_rmsnorm_matcher.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/library/test_allreduce_residual_rmsnorm_matcher.py
@@ -17,9 +17,9 @@
 These tests do NOT execute the fused graph (which would require a process group);
 they only verify that the pattern matcher rewrites the expected subgraphs into a
 single ``trtllm_fused_allreduce_residual_rmsnorm`` op. They specifically cover the
-``reshape`` between the all-reduce and the residual add (e.g. a TP linear output
-``[B, S, H]`` reshaped to a flattened residual ``[B*S, H]``), which previously broke
-the match and left the op unfused.
+``reshape`` between the all-reduce and the residual add (e.g. a TP MLP/MoE output
+all-reduced as a flattened ``[B*S, H]`` tensor and reshaped back to the 3D residual
+``[B, S, H]``), which previously broke the match and left the op unfused.
 """
 
 from types import SimpleNamespace
@@ -51,8 +51,8 @@ class RMSNorm(torch.nn.Module):
 class ARResidualNorm(torch.nn.Module):
     """all_reduce -> [reshape] -> add(residual) -> rmsnorm.
 
-    ``x`` is provided 3D when ``with_reshape`` so that the all-reduce output is
-    reshaped to the (2D) residual shape before the add.
+    ``x`` is provided 2D when ``with_reshape`` so that the all-reduce output is
+    reshaped (expanded) to the 3D residual shape before the add.
     """
 
     def __init__(self, hidden_size, strategy, add_order, with_reshape):
@@ -84,19 +84,21 @@ def test_allreduce_residual_rmsnorm_match(add_order, with_reshape, strategy):
     hidden = 512
     bsz, seq = 2, 4
     if with_reshape:
-        x = torch.randn(bsz, seq, hidden, device="cuda", dtype=torch.bfloat16)
+        x = torch.randn(bsz * seq, hidden, device="cuda", dtype=torch.bfloat16)
+        residual = torch.randn(bsz, seq, hidden, device="cuda", dtype=torch.bfloat16)
     else:
         x = torch.randn(bsz * seq, hidden, device="cuda", dtype=torch.bfloat16)
-    residual = torch.randn(bsz * seq, hidden, device="cuda", dtype=torch.bfloat16)
+        residual = torch.randn(bsz * seq, hidden, device="cuda", dtype=torch.bfloat16)
 
     model = ARResidualNorm(hidden, strategy, add_order, with_reshape)
 
     # Dynamic leading dim to exercise the symbolic re-trace path of the matcher.
-    # For the reshape variant x is 3D [bs, seq, h] and is reshaped to the 2D residual
-    # [bs*seq, h], so the residual token dim is the derived dim seq * bs.
+    # For the reshape variant x is the 2D [bs*seq, h] all-reduce output reshaped
+    # (expanded) to the 3D residual [bs, seq, h], so the 2D token dim is the derived
+    # dim seq * bs and the residual batch dim is bs.
     if with_reshape:
         bs = Dim("bs")
-        dynamic_shapes = ({0: bs}, {0: seq * bs})
+        dynamic_shapes = ({0: seq * bs}, {0: bs})
     else:
         tokens = Dim("tokens")
         dynamic_shapes = ({0: tokens}, {0: tokens})


### PR DESCRIPTION
## Summary
Make the AutoDeploy AR+residual+RMSNorm fusion matcher fire on the TP MLP/MoE
all-reduce sites that carry a `reshape` between the all-reduce and the residual
add (common in Qwen-family models), and make the resulting fused graph
dynamic-shape (batch) safe.

The real topology is `all_reduce([B*S, H]) -> reshape([B, S, H]) -> add(residual[B,S,H]) -> rmsnorm`
(a 2D->3D **expand**). The reshape commutes with the elementwise all-reduce, so
the replacement pushes the reshape onto the fused op's input -- numerically
exact, no kernel change.

## What was wrong / what changed
- **Inverted reshape direction (matcher was a silent no-op).** The original
  reshape pattern was traced with dummy args for a 3D->2D *collapse*, the
  opposite of the real 2D->3D expand, so none of the reshape-bearing sites
  matched. Corrected the dummy-arg shapes so the pattern matches the real
  direction. On Qwen3.5-35B-A3B this takes fusion from 40/80 -> **80/80**
  all-reduce sites.
- **Dynamic-shape bug exposed by enabling the match.** The pattern matcher
  re-traces the replacement with statically-shaped fakes, baking `residual`'s
  `[B, S]` into the reshape that feeds the fused op. That specializes the
  exported graph to the dummy batch and crashes export at any other batch
  (`Expected input ... shape[0] to be equal to 2, but got 1`). Added
  `_restore_dynamic_reshape`, a post-fusion fixup that re-points the baked
  reshape literals at `residual`'s runtime `aten.sym_size.int`, keeping the
  fused all-reduce input dynamic.

## Tests
- Single-GPU graph-match test: base + reshape variant, both add orders,
  AUTO/ONESHOT, now exercising the **real 2D->3D direction** and the
  dynamic/symbolic retrace path. (8 passed)
- Multi-GPU numeric test: reshape model variant validated fused == reference,
  now also covering dynamic batch (2 passed on 2xH100).

## Validation / Performance
Measured on **Qwen3.5-35B-A3B-FP8, TP=8, 8xH100, ISL/OSL 1024/1024**,
A/B of 40-fused (pre-fix) vs 80-fused (this PR):

| concurrency | main [tok/s] | this branch [tok/s] | Δ tok/s | TTFT main->feature |
|---|---|---|---|---|
| 1 | 113.7 | 115.0 | +1.2% | 132.9 -> 128.5 ms |
| 4 | 413.4 | 423.3 | +2.4% | 412.6 -> 280.8 ms |
| **16** | **1068.5** | **1403.5** | **+31.4%** | **4115 -> 1016 ms** |
| 64 | 4529.9 | 4476.7 | -1.2% | 829.8 -> 843.1 ms |

Neutral-to-positive at low concurrency, a large win at concurrency 16
(+31% output tok/s, ~4x lower TTFT), within noise at 64.

## Out of scope (deferred, to-be-discussed)
The other unmatched path -- a residual downcast (`aten.to.dtype`) between the
add and RMSNorm, which appears with fp32 residual streams (e.g. Nemotron
`residual_in_fp32`) -- is intentionally NOT fused here. The fused kernel reads
`residual` as the compute dtype and adds in compute dtype, so fusing an fp32
residual would silently change residual-stream precision (verified: numeric
mismatch). Correctly supporting it requires a CUDA kernel change (a separate
`ResidualT=float`). Whether to modify the kernels is TBD; this PR ships the
reshape coverage only.

Fixes #14781