### PR TITLE
[https://nvbugs/6226933][fix] canonicalize multimodal cache-key serialization to prevent hash collisions

### DIFF
--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -18,6 +18,10 @@ from tensorrt_llm.logger import logger
 default_hasher = blake3
 _INT32_MAX = 2**31 - 1
 
+# Versioned tag prefixed to every content hash so the canonical, self-describing
+# serialization scheme can evolve without silently reusing stale cache keys.
+_HASH_SCHEME_TAG = b"trtllm.mm.hash.v1"
+
 
 def strip_mm_data_for_generation(mm_data: Dict[str, Any]) -> None:
     """Clear `mm_data` in place, retaining only `mrope_config.mrope_position_deltas`.
@@ -666,21 +670,10 @@ class MultimodalServerConfig():
 
 def _update_hash(hasher, item: object) -> None:
     """Hash the content of a multimodal item into the provided hasher."""
+    hasher.update(_HASH_SCHEME_TAG)
     if isinstance(item, BaseModalityData):
         item.update_hash(hasher)
         return
-    if isinstance(item, torch.Tensor):
-        item = item.detach().cpu().contiguous()
-        hasher.update(serialize_item(item))
-        return
-    if isinstance(item, list):
-        for element in item:
-            hasher.update(b"<frame>")
-            if isinstance(element, torch.Tensor):
-                element = element.detach().cpu().contiguous()
-            hasher.update(serialize_item(element))
-        return
-
     hasher.update(serialize_item(item))
 
 
@@ -711,7 +704,6 @@ def apply_mm_hashes(
 
     def _hash_item(item):
         """Hash only the content of a multimodal item (no UUID)."""
-        # TODO: possible hash collision w/ this simplified version (vllm/PR/17378)
         hasher = hash_lib()
         _update_hash(hasher, item)
         return hasher.hexdigest()

--- a/tensorrt_llm/inputs/multimodal_data.py
+++ b/tensorrt_llm/inputs/multimodal_data.py
@@ -117,6 +117,13 @@ def serialize_item(obj: object) -> bytes:
             parts.append(serialize_item(obj[key]))
         return b"".join(parts)
 
+    if isinstance(obj, np.generic):
+        # numpy scalar (e.g. np.int64 / np.float32 / np.bool_): normalize to the
+        # equivalent Python scalar and recurse, so numpy-typed values hash
+        # identically to their Python counterparts. In numpy 2.x these are not
+        # subclasses of Python int/float/bool, so they bypass the checks above.
+        return serialize_item(obj.item())
+
     raise ValueError(f"Unsupported object type: {type(obj)}")
 
 

--- a/tensorrt_llm/inputs/multimodal_data.py
+++ b/tensorrt_llm/inputs/multimodal_data.py
@@ -50,7 +50,7 @@ def serialize_item(obj: object) -> bytes:
     """Serialize a supported multimodal hash leaf to bytes.
 
     The encoding is canonical and self-describing: every value is
-    ``[1-byte type tag][typed metadata][length-prefixed payload]`` with all
+    `[1-byte type tag][typed metadata][length-prefixed payload]` with all
     multi-byte integers big-endian. This prevents cache-key hash collisions
     between distinct values that happen to share a raw byte payload (for
     example transposed image dimensions or reshaped arrays).
@@ -78,35 +78,24 @@ def serialize_item(obj: object) -> bytes:
             + _u32(height)
             + _len_prefixed(payload)
         )
-    if isinstance(obj, torch.Tensor):
-        tensor = obj.detach().cpu().contiguous()
-        payload = tensor.numpy().tobytes()
-        shape = tuple(tensor.shape)
+    if isinstance(obj, (torch.Tensor, np.ndarray)):
+        # The container (torch.Tensor vs np.ndarray) is not part of the content
+        # identity -- only dtype, shape, and raw bytes are. Normalize both to a
+        # contiguous NumPy array so identical content hashes identically.
+        if isinstance(obj, torch.Tensor):
+            obj = obj.detach().cpu().contiguous().numpy()
+        array = np.ascontiguousarray(obj)
         parts = [
             _u8(0x11),
-            _len_prefixed(str(tensor.dtype).encode("utf-8")),
-            _u8(len(shape)),
+            _len_prefixed(array.dtype.str.encode("utf-8")),
+            _u8(array.ndim),
         ]
-        parts.extend(_u64(dim) for dim in shape)
-        parts.append(_len_prefixed(payload))
+        parts.extend(_u64(dim) for dim in array.shape)
+        parts.append(_len_prefixed(array.tobytes()))
         return b"".join(parts)
-    if isinstance(obj, np.ndarray):
-        contiguous = np.ascontiguousarray(obj)
-        payload = contiguous.tobytes()
-        shape = contiguous.shape
-        parts = [
-            _u8(0x12),
-            _len_prefixed(obj.dtype.str.encode("utf-8")),
-            _u8(len(shape)),
-        ]
-        parts.extend(_u64(dim) for dim in shape)
-        parts.append(_len_prefixed(payload))
-        return b"".join(parts)
-    if isinstance(obj, tuple):
-        parts = [_u8(0x21), _u64(len(obj))]
-        parts.extend(serialize_item(item) for item in obj)
-        return b"".join(parts)
-    if isinstance(obj, list):
+    if isinstance(obj, (tuple, list)):
+        # Ordered sequence; the container (tuple vs list) is not part of the
+        # content identity.
         parts = [_u8(0x20), _u64(len(obj))]
         parts.extend(serialize_item(item) for item in obj)
         return b"".join(parts)

--- a/tensorrt_llm/inputs/multimodal_data.py
+++ b/tensorrt_llm/inputs/multimodal_data.py
@@ -1,12 +1,22 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import struct
 from dataclasses import dataclass
 from typing import Any, Protocol
 
 import numpy as np
 import torch
 from PIL import Image
+
+# Video metadata fields that participate in the cache-key hash. These describe
+# how frames were sampled and therefore change the model-visible content.
+_VIDEO_HASH_METADATA_FIELDS = (
+    "frames_indices",
+    "fps",
+    "duration",
+    "total_num_frames",
+)
 
 
 class ContentHasher(Protocol):
@@ -16,28 +26,95 @@ class ContentHasher(Protocol):
         """Update the hash with raw bytes."""
 
 
+def _u8(value: int) -> bytes:
+    """Encode an unsigned 8-bit integer."""
+    return value.to_bytes(1, "big", signed=False)
+
+
+def _u32(value: int) -> bytes:
+    """Encode an unsigned 32-bit big-endian integer."""
+    return value.to_bytes(4, "big", signed=False)
+
+
+def _u64(value: int) -> bytes:
+    """Encode an unsigned 64-bit big-endian integer."""
+    return value.to_bytes(8, "big", signed=False)
+
+
+def _len_prefixed(payload: bytes) -> bytes:
+    """Encode a byte payload prefixed with its u64 length."""
+    return _u64(len(payload)) + payload
+
+
 def serialize_item(obj: object) -> bytes:
-    """Serialize a supported multimodal hash leaf to bytes."""
+    """Serialize a supported multimodal hash leaf to bytes.
+
+    The encoding is canonical and self-describing: every value is
+    ``[1-byte type tag][typed metadata][length-prefixed payload]`` with all
+    multi-byte integers big-endian. This prevents cache-key hash collisions
+    between distinct values that happen to share a raw byte payload (for
+    example transposed image dimensions or reshaped arrays).
+    """
     if isinstance(obj, str):
-        return obj.encode("utf-8")
+        return _u8(0x01) + _len_prefixed(obj.encode("utf-8"))
     if isinstance(obj, bytes):
-        return obj
-    if isinstance(obj, (int, float)):
-        return np.array(obj).tobytes()
+        return _u8(0x02) + _len_prefixed(obj)
+    # bool must be checked before int: bool is a subclass of int.
+    if isinstance(obj, bool):
+        return _u8(0x05) + _u8(1 if obj else 0)
+    if isinstance(obj, int):
+        nbytes = (obj.bit_length() + 8) // 8  # +1 sign bit, then ceil-divide.
+        return _u8(0x03) + _u8(nbytes) + obj.to_bytes(nbytes, "big", signed=True)
+    if isinstance(obj, float):
+        return _u8(0x04) + struct.pack(">d", obj)
 
     if isinstance(obj, Image.Image):
-        return np.array(obj.convert("RGBA")).tobytes()
+        width, height = obj.size
+        payload = np.array(obj.convert("RGBA")).tobytes()
+        return (
+            _u8(0x10)
+            + _len_prefixed(obj.mode.encode("utf-8"))
+            + _u32(width)
+            + _u32(height)
+            + _len_prefixed(payload)
+        )
     if isinstance(obj, torch.Tensor):
-        return obj.numpy().tobytes()
+        tensor = obj.detach().cpu().contiguous()
+        payload = tensor.numpy().tobytes()
+        shape = tuple(tensor.shape)
+        parts = [
+            _u8(0x11),
+            _len_prefixed(str(tensor.dtype).encode("utf-8")),
+            _u8(len(shape)),
+        ]
+        parts.extend(_u64(dim) for dim in shape)
+        parts.append(_len_prefixed(payload))
+        return b"".join(parts)
     if isinstance(obj, np.ndarray):
-        return obj.tobytes()
-    if isinstance(obj, (tuple, list)):
-        container_tag = b"T" if isinstance(obj, tuple) else b"L"
-        parts = [container_tag, len(obj).to_bytes(8, "big", signed=False)]
-        for item in obj:
-            payload = serialize_item(item)
-            parts.append(len(payload).to_bytes(8, "big", signed=False))
-            parts.append(payload)
+        contiguous = np.ascontiguousarray(obj)
+        payload = contiguous.tobytes()
+        shape = contiguous.shape
+        parts = [
+            _u8(0x12),
+            _len_prefixed(obj.dtype.str.encode("utf-8")),
+            _u8(len(shape)),
+        ]
+        parts.extend(_u64(dim) for dim in shape)
+        parts.append(_len_prefixed(payload))
+        return b"".join(parts)
+    if isinstance(obj, tuple):
+        parts = [_u8(0x21), _u64(len(obj))]
+        parts.extend(serialize_item(item) for item in obj)
+        return b"".join(parts)
+    if isinstance(obj, list):
+        parts = [_u8(0x20), _u64(len(obj))]
+        parts.extend(serialize_item(item) for item in obj)
+        return b"".join(parts)
+    if isinstance(obj, dict):
+        parts = [_u8(0x22), _u64(len(obj))]
+        for key in sorted(obj):
+            parts.append(serialize_item(key))
+            parts.append(serialize_item(obj[key]))
         return b"".join(parts)
 
     raise ValueError(f"Unsupported object type: {type(obj)}")
@@ -65,11 +142,8 @@ class AudioData(BaseModalityData):
             self.sample_rate = int(self.sample_rate)
 
     def update_hash(self, hasher: ContentHasher) -> None:
-        samples = self.samples
-        if isinstance(samples, torch.Tensor):
-            samples = samples.detach().cpu().contiguous()
         hasher.update(b"<audio>")
-        hasher.update(serialize_item((samples, self.sample_rate)))
+        hasher.update(serialize_item((self.samples, self.sample_rate)))
 
 
 @dataclass
@@ -97,12 +171,12 @@ class VideoData(BaseModalityData):
             raise TypeError("metadata must be a dictionary")
 
     def update_hash(self, hasher: ContentHasher) -> None:
+        hasher.update(b"<video>")
+        # Sampling metadata is part of the model-visible cache identity.
+        meta = {k: self.metadata[k] for k in _VIDEO_HASH_METADATA_FIELDS if k in self.metadata}
+        hasher.update(serialize_item(meta))
         for frame in self.frames:
             hasher.update(b"<frame>")
-            if isinstance(frame, torch.Tensor):
-                frame = frame.detach().cpu().contiguous()
             hasher.update(serialize_item(frame))
-        # Extend this to include metadata if fields such as sampled frame
-        # indices become part of the model-visible cache identity.
         if self.audio is not None:
             self.audio.update_hash(hasher)

--- a/tests/unittest/llmapi/test_llm_kv_cache_events.py
+++ b/tests/unittest/llmapi/test_llm_kv_cache_events.py
@@ -20,7 +20,8 @@ from tensorrt_llm.bindings.internal.testing import \
 from tensorrt_llm.inputs.multimodal import (MultimodalInput,
                                             _find_mm_token_runs_from_mask,
                                             apply_mm_hashes)
-from tensorrt_llm.inputs.multimodal_data import AudioData, VideoData
+from tensorrt_llm.inputs.multimodal_data import (AudioData, VideoData,
+                                                 serialize_item)
 from tensorrt_llm.llmapi import KvCacheConfig
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.sampling_params import SamplingParams
@@ -321,11 +322,7 @@ def test_apply_mm_hashes_uuid_content_combined():
 
 
 def _make_video(frames, audio_samples=None, sample_rate=16000, metadata=None):
-    """Build a VideoData from frames with optional audio and metadata.
-
-    Module-level helper shared by the mm-hash tests (lifted from the former
-    local closure in test_apply_mm_hashes_video_audio_affects_hash).
-    """
+    """Module-level helper shared by the mm-hash tests."""
     audio = None
     if audio_samples is not None:
         audio = AudioData(samples=audio_samples, sample_rate=sample_rate)
@@ -370,7 +367,6 @@ def test_apply_mm_hashes_video_audio_affects_hash():
 
 
 def test_apply_mm_hashes_image_dims_distinguished():
-    """Nvbug 6226933: same-fill images of transposed dims must not collide."""
     img_tall = Image.new("RGBA", (30, 100), (10, 20, 30, 40))
     img_wide = Image.new("RGBA", (100, 30), (10, 20, 30, 40))
 
@@ -381,7 +377,6 @@ def test_apply_mm_hashes_image_dims_distinguished():
 
 
 def test_apply_mm_hashes_ndarray_shape_distinguished():
-    """Nvbug 6226933: ndarrays with same bytes but different shapes differ."""
     base = np.arange(12, dtype=np.uint8)
     arr_2x6 = base.reshape(2, 6, 1)
     arr_3x4 = base.reshape(3, 4, 1)
@@ -397,7 +392,6 @@ def test_apply_mm_hashes_ndarray_shape_distinguished():
 
 
 def test_apply_mm_hashes_tensor_shape_distinguished():
-    """Nvbug 6226933: tensors with same data but different shapes differ."""
     data = torch.arange(3 * 224 * 224, dtype=torch.float32)
     t_chw = data.reshape(3, 224, 224)
     t_nchw = data.reshape(1, 3, 224, 224)
@@ -409,7 +403,6 @@ def test_apply_mm_hashes_tensor_shape_distinguished():
 
 
 def test_apply_mm_hashes_video_metadata_distinguished():
-    """Nvbug 6226933: VideoData metadata participates in the hash."""
     frames = [
         Image.new("RGB", (2, 2), (10, 20, 30)),
         Image.new("RGB", (2, 2), (40, 50, 60)),
@@ -447,11 +440,8 @@ def test_apply_mm_hashes_video_metadata_distinguished():
 
 
 def test_apply_mm_hashes_video_metadata_numpy_scalars():
-    """Nvbug 6226933: numpy-typed video metadata hashes without crashing.
-
-    It matches the equivalent Python-typed metadata (numpy 2.x scalars such as
-    np.int64/np.float32/np.bool_ are not subclasses of Python int/float/bool).
-    """
+    # numpy 2.x scalars (np.int64/np.float32/np.bool_) are not subclasses of
+    # Python int/float/bool; numpy-typed metadata must hash like Python-typed.
     frames = [Image.new("RGB", (2, 2), (10, 20, 30))]
     meta_py = {
         "fps": 30.0,
@@ -475,7 +465,6 @@ def test_apply_mm_hashes_video_metadata_numpy_scalars():
 
 
 def test_apply_mm_hashes_videodata_vs_framelist_distinguished():
-    """Nvbug 6226933: VideoData(frames) and a bare frame list must differ."""
     frames = [
         Image.new("RGB", (2, 2), (10, 20, 30)),
         Image.new("RGB", (2, 2), (40, 50, 60)),
@@ -489,7 +478,6 @@ def test_apply_mm_hashes_videodata_vs_framelist_distinguished():
 
 
 def test_apply_mm_hashes_identical_inputs_match():
-    """Identical inputs (and copies) hash identically across types."""
     img = Image.new("RGBA", (8, 12), (1, 2, 3, 4))
     img_copy = Image.new("RGBA", (8, 12), (1, 2, 3, 4))
     h_img, _ = apply_mm_hashes({"image": [img]})
@@ -519,6 +507,23 @@ def test_apply_mm_hashes_identical_inputs_match():
     h_v, _ = apply_mm_hashes({"video": [video]})
     h_v_copy, _ = apply_mm_hashes({"video": [video_copy]})
     assert h_v["video"][0] == h_v_copy["video"][0]
+
+
+def test_serialize_item_array_container_agnostic():
+    # A torch.Tensor and an np.ndarray with identical dtype/shape/bytes are the
+    # same multimodal content, so the container type is not part of the hash
+    # identity. Shape and dtype still distinguish.
+    tensor = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4)
+    array = np.arange(24, dtype=np.float32).reshape(2, 3, 4)
+    assert serialize_item(tensor) == serialize_item(array)
+    assert serialize_item(tensor.reshape(4, 3, 2)) != serialize_item(array)
+    assert serialize_item(np.arange(24, dtype=np.int64)) != serialize_item(
+        np.arange(24, dtype=np.float64))
+
+
+def test_serialize_item_sequence_container_agnostic():
+    # A tuple and a list with identical elements are the same ordered sequence.
+    assert serialize_item((1, 2.0, b"x")) == serialize_item([1, 2.0, b"x"])
 
 
 def test_apply_mm_hashes_audio_data_deterministic():

--- a/tests/unittest/llmapi/test_llm_kv_cache_events.py
+++ b/tests/unittest/llmapi/test_llm_kv_cache_events.py
@@ -446,6 +446,34 @@ def test_apply_mm_hashes_video_metadata_distinguished():
     assert h_a["video"][0] != h_total["video"][0]
 
 
+def test_apply_mm_hashes_video_metadata_numpy_scalars():
+    """Nvbug 6226933: numpy-typed video metadata hashes without crashing.
+
+    It matches the equivalent Python-typed metadata (numpy 2.x scalars such as
+    np.int64/np.float32/np.bool_ are not subclasses of Python int/float/bool).
+    """
+    frames = [Image.new("RGB", (2, 2), (10, 20, 30))]
+    meta_py = {
+        "fps": 30.0,
+        "duration": 2.0,
+        "frames_indices": [0, 5],
+        "total_num_frames": 100,
+    }
+    meta_np = {
+        "fps": np.float32(30.0),
+        "duration": np.float64(2.0),
+        "frames_indices": [np.int64(0), np.int64(5)],
+        "total_num_frames": np.int64(100),
+    }
+
+    h_py, _ = apply_mm_hashes(
+        {"video": [_make_video(frames, metadata=meta_py)]})
+    h_np, _ = apply_mm_hashes(
+        {"video": [_make_video(frames, metadata=meta_np)]})
+
+    assert h_np["video"][0] == h_py["video"][0]
+
+
 def test_apply_mm_hashes_videodata_vs_framelist_distinguished():
     """Nvbug 6226933: VideoData(frames) and a bare frame list must differ."""
     frames = [

--- a/tests/unittest/llmapi/test_llm_kv_cache_events.py
+++ b/tests/unittest/llmapi/test_llm_kv_cache_events.py
@@ -320,6 +320,20 @@ def test_apply_mm_hashes_uuid_content_combined():
         "Different UUID + same content should produce different hashes"
 
 
+def _make_video(frames, audio_samples=None, sample_rate=16000, metadata=None):
+    """Build a VideoData from frames with optional audio and metadata.
+
+    Module-level helper shared by the mm-hash tests (lifted from the former
+    local closure in test_apply_mm_hashes_video_audio_affects_hash).
+    """
+    audio = None
+    if audio_samples is not None:
+        audio = AudioData(samples=audio_samples, sample_rate=sample_rate)
+    return VideoData(frames=frames,
+                     metadata={} if metadata is None else metadata,
+                     audio=audio)
+
+
 def test_apply_mm_hashes_video_audio_affects_hash():
     """VideoData hashes include extracted audio when it affects model inputs."""
     frames = [
@@ -330,31 +344,153 @@ def test_apply_mm_hashes_video_audio_affects_hash():
     audio_a_copy = audio_a.copy()
     audio_b = np.array([0.0, 0.25, -0.5, -1.0], dtype=np.float32)
 
-    def make_video(audio_samples=None, sample_rate=16000):
-        audio = None
-        if audio_samples is not None:
-            audio = AudioData(samples=audio_samples, sample_rate=sample_rate)
-        return VideoData(frames=frames, metadata={}, audio=audio)
-
-    hashes_a, _ = apply_mm_hashes({"video": [make_video(audio_a)]})
-    hashes_a_copy, _ = apply_mm_hashes({"video": [make_video(audio_a_copy)]})
-    hashes_b, _ = apply_mm_hashes({"video": [make_video(audio_b)]})
+    hashes_a, _ = apply_mm_hashes({"video": [_make_video(frames, audio_a)]})
+    hashes_a_copy, _ = apply_mm_hashes(
+        {"video": [_make_video(frames, audio_a_copy)]})
+    hashes_b, _ = apply_mm_hashes({"video": [_make_video(frames, audio_b)]})
     hashes_a_different_rate, _ = apply_mm_hashes(
-        {"video": [make_video(audio_a, sample_rate=8000)]})
-    hashes_no_audio, _ = apply_mm_hashes({"video": [make_video()]})
+        {"video": [_make_video(frames, audio_a, sample_rate=8000)]})
+    hashes_no_audio, _ = apply_mm_hashes({"video": [_make_video(frames)]})
     hashes_frame_list, _ = apply_mm_hashes({"video": [frames]})
 
     assert hashes_a["video"][0] == hashes_a_copy["video"][0]
     assert hashes_a["video"][0] != hashes_b["video"][0]
     assert hashes_a["video"][0] != hashes_a_different_rate["video"][0]
-    assert hashes_no_audio["video"][0] == hashes_frame_list["video"][0]
+    # nvbug 6226933: a VideoData (with metadata={} and no audio) and a bare
+    # frame list are now hashed under distinct, self-describing schemes, so the
+    # former intentional collision is removed -- they must differ.
+    assert hashes_no_audio["video"][0] != hashes_frame_list["video"][0]
 
     mm_uuids = {"video": ["shared-video-id"]}
-    hashes_uuid_a, _ = apply_mm_hashes({"video": [make_video(audio_a)]},
-                                       mm_uuids)
-    hashes_uuid_b, _ = apply_mm_hashes({"video": [make_video(audio_b)]},
-                                       mm_uuids)
+    hashes_uuid_a, _ = apply_mm_hashes(
+        {"video": [_make_video(frames, audio_a)]}, mm_uuids)
+    hashes_uuid_b, _ = apply_mm_hashes(
+        {"video": [_make_video(frames, audio_b)]}, mm_uuids)
     assert hashes_uuid_a["video"][0] != hashes_uuid_b["video"][0]
+
+
+def test_apply_mm_hashes_image_dims_distinguished():
+    """Nvbug 6226933: same-fill images of transposed dims must not collide."""
+    img_tall = Image.new("RGBA", (30, 100), (10, 20, 30, 40))
+    img_wide = Image.new("RGBA", (100, 30), (10, 20, 30, 40))
+
+    hashes_tall, _ = apply_mm_hashes({"image": [img_tall]})
+    hashes_wide, _ = apply_mm_hashes({"image": [img_wide]})
+
+    assert hashes_tall["image"][0] != hashes_wide["image"][0]
+
+
+def test_apply_mm_hashes_ndarray_shape_distinguished():
+    """Nvbug 6226933: ndarrays with same bytes but different shapes differ."""
+    base = np.arange(12, dtype=np.uint8)
+    arr_2x6 = base.reshape(2, 6, 1)
+    arr_3x4 = base.reshape(3, 4, 1)
+    arr_6x2 = base.reshape(6, 2, 1)
+
+    h_2x6, _ = apply_mm_hashes({"image": [arr_2x6]})
+    h_3x4, _ = apply_mm_hashes({"image": [arr_3x4]})
+    h_6x2, _ = apply_mm_hashes({"image": [arr_6x2]})
+
+    assert h_2x6["image"][0] != h_3x4["image"][0]
+    assert h_2x6["image"][0] != h_6x2["image"][0]
+    assert h_3x4["image"][0] != h_6x2["image"][0]
+
+
+def test_apply_mm_hashes_tensor_shape_distinguished():
+    """Nvbug 6226933: tensors with same data but different shapes differ."""
+    data = torch.arange(3 * 224 * 224, dtype=torch.float32)
+    t_chw = data.reshape(3, 224, 224)
+    t_nchw = data.reshape(1, 3, 224, 224)
+
+    h_chw, _ = apply_mm_hashes({"image": [t_chw]})
+    h_nchw, _ = apply_mm_hashes({"image": [t_nchw]})
+
+    assert h_chw["image"][0] != h_nchw["image"][0]
+
+
+def test_apply_mm_hashes_video_metadata_distinguished():
+    """Nvbug 6226933: VideoData metadata participates in the hash."""
+    frames = [
+        Image.new("RGB", (2, 2), (10, 20, 30)),
+        Image.new("RGB", (2, 2), (40, 50, 60)),
+    ]
+    meta_a = {
+        "fps": 30.0,
+        "duration": 2.0,
+        "frames_indices": [0, 1],
+        "total_num_frames": 60,
+    }
+    meta_fps = {**meta_a, "fps": 24.0}
+    meta_duration = {**meta_a, "duration": 3.0}
+    meta_indices = {**meta_a, "frames_indices": [0, 2]}
+    meta_total = {**meta_a, "total_num_frames": 90}
+
+    h_a, _ = apply_mm_hashes({"video": [_make_video(frames, metadata=meta_a)]})
+    h_a_copy, _ = apply_mm_hashes(
+        {"video": [_make_video(frames, metadata=dict(meta_a))]})
+    h_fps, _ = apply_mm_hashes(
+        {"video": [_make_video(frames, metadata=meta_fps)]})
+    h_duration, _ = apply_mm_hashes(
+        {"video": [_make_video(frames, metadata=meta_duration)]})
+    h_indices, _ = apply_mm_hashes(
+        {"video": [_make_video(frames, metadata=meta_indices)]})
+    h_total, _ = apply_mm_hashes(
+        {"video": [_make_video(frames, metadata=meta_total)]})
+
+    # Same frames + same metadata -> deterministic / equal.
+    assert h_a["video"][0] == h_a_copy["video"][0]
+    # Each differing metadata field changes the hash.
+    assert h_a["video"][0] != h_fps["video"][0]
+    assert h_a["video"][0] != h_duration["video"][0]
+    assert h_a["video"][0] != h_indices["video"][0]
+    assert h_a["video"][0] != h_total["video"][0]
+
+
+def test_apply_mm_hashes_videodata_vs_framelist_distinguished():
+    """Nvbug 6226933: VideoData(frames) and a bare frame list must differ."""
+    frames = [
+        Image.new("RGB", (2, 2), (10, 20, 30)),
+        Image.new("RGB", (2, 2), (40, 50, 60)),
+    ]
+    video = _make_video(frames, audio_samples=None)
+
+    h_video, _ = apply_mm_hashes({"video": [video]})
+    h_list, _ = apply_mm_hashes({"video": [list(frames)]})
+
+    assert h_video["video"][0] != h_list["video"][0]
+
+
+def test_apply_mm_hashes_identical_inputs_match():
+    """Identical inputs (and copies) hash identically across types."""
+    img = Image.new("RGBA", (8, 12), (1, 2, 3, 4))
+    img_copy = Image.new("RGBA", (8, 12), (1, 2, 3, 4))
+    h_img, _ = apply_mm_hashes({"image": [img]})
+    h_img_copy, _ = apply_mm_hashes({"image": [img_copy]})
+    assert h_img["image"][0] == h_img_copy["image"][0]
+
+    tensor = torch.arange(24, dtype=torch.float32).reshape(2, 3, 4)
+    h_t, _ = apply_mm_hashes({"image": [tensor]})
+    h_t_copy, _ = apply_mm_hashes({"image": [tensor.clone()]})
+    assert h_t["image"][0] == h_t_copy["image"][0]
+
+    arr = np.arange(24, dtype=np.uint8).reshape(2, 3, 4)
+    h_arr, _ = apply_mm_hashes({"image": [arr]})
+    h_arr_copy, _ = apply_mm_hashes({"image": [arr.copy()]})
+    assert h_arr["image"][0] == h_arr_copy["image"][0]
+
+    frames = [
+        Image.new("RGB", (2, 2), (10, 20, 30)),
+        Image.new("RGB", (2, 2), (40, 50, 60)),
+    ]
+    audio = np.array([0.0, 0.25, -0.5], dtype=np.float32)
+    meta = {"fps": 30.0, "frames_indices": [0, 1]}
+    video = _make_video(frames, audio_samples=audio, metadata=meta)
+    video_copy = _make_video(frames,
+                             audio_samples=audio.copy(),
+                             metadata=dict(meta))
+    h_v, _ = apply_mm_hashes({"video": [video]})
+    h_v_copy, _ = apply_mm_hashes({"video": [video_copy]})
+    assert h_v["video"][0] == h_v_copy["video"][0]
 
 
 def test_apply_mm_hashes_audio_data_deterministic():


### PR DESCRIPTION
## Problem
Multimodal KV-cache block reuse (`enable_block_reuse=True` by default) keys cache blocks on a BLAKE3 content hash of each multimodal item (`apply_mm_hashes`). The serialization feeding that hash omitted semantic structure, so semantically different inputs produced identical bytes and therefore identical cache keys, which can cause incorrect cross-request KV-cache reuse / cache poisoning for multimodal serving. Reported in #14603.

On `main`, the following distinct inputs collided to the same hash:
- PIL images with transposed dimensions (e.g. 30×100 vs 100×30)
- ndarrays/tensors sharing raw bytes but differing in shape/dtype (e.g. `(3,224,224)` vs `(1,3,224,224)`)
- `VideoData` differing only in sampling metadata (fps / duration / frames_indices / total_num_frames)
- a `VideoData` (no audio) vs a plain list of the same frames

## Fix
Make multimodal serialization canonical and self-describing — every value is encoded as `[type tag][typed metadata][length-prefixed payload]`:
- images encode mode + width + height
- tensors and ndarrays encode dtype + shape
- lists, tuples and dicts get distinct, length-framed encodings (dict keys sorted); ints are width/sign-unambiguous and `bool` is distinct from `int`
- `VideoData` carries a modality tag and includes its sampling metadata in the hash; `AudioData` binds samples to sample_rate
- the per-item hash is prefixed with a versioned scheme tag, and the two previously-divergent list-framing paths are unified

## Tests
Adds CPU-only regression tests in `tests/unittest/llmapi/test_llm_kv_cache_events.py` covering each collision class (transposed image dims, reshaped ndarray, reshaped tensor, video-metadata sensitivity, and VideoData-vs-frame-list), plus a positive determinism test (identical inputs still match). Updates one existing assertion that had encoded the VideoData-vs-list collision as expected behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced multimodal content caching with improved, collision-resistant hashing for better consistency across cache key evolution.

* **Tests**
  * Expanded test coverage for multimodal hashing to validate correct behavior across various data types and metadata scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->