### PR TITLE
[TRTLLM-12507][feat] Per-expert lora support with Cutlass backend

### DIFF
--- a/cpp/tensorrt_llm/thop/moeOp.cpp
+++ b/cpp/tensorrt_llm/thop/moeOp.cpp
@@ -24,9 +24,12 @@
 #include "tensorrt_llm/kernels/cutlass_kernels/include/moe_gemm_kernels.h"
 
 #include "tensorrt_llm/common/config.h"
+#include "tensorrt_llm/common/cublasMMWrapper.h"
+#include "tensorrt_llm/common/opUtils.h"
 #include "tensorrt_llm/common/workspace.h"
 #include "tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm.h"
 #include "tensorrt_llm/kernels/cutlass_kernels/include/cutlass_kernel_selector.h"
+#include "tensorrt_llm/kernels/lora/lora.h"
 #include "tensorrt_llm/runtime/torchUtils.h"
 #include "tensorrt_llm/thop/thUtils.h"
 
@@ -56,6 +59,14 @@ using MoeGemmId = CUTLASS_MOE_GEMM_NAMESPACE::MoeGemmId;
 // Always use public header as it is just utility functions and types
 using TmaWarpSpecializedGroupedGemmInput = tensorrt_llm::kernels::cutlass_kernels::TmaWarpSpecializedGroupedGemmInput;
 using profiler_backend = CUTLASS_MOE_GEMM_KERNELS_NAMESPACE::GemmProfilerBackend;
+
+// Mirrors tensorrt_llm::kernels::RequestType for the LoRA host_request_types layout.
+// kCONTEXT/kGENERATION encoding matches the rest of the LoRA stack (e.g. loraOp.cpp).
+enum class MoeLoraRequestType : int32_t
+{
+    kCONTEXT = 0,
+    kGENERATION = 1
+};
 
 class FusedMoeRunner : public torch::CustomClassHolder
 {
@@ -248,6 +259,12 @@ public:
             TORCH_CHECK(
                 cu_free_status == cudaSuccess, "Can't free profile workspace during FusedMoeRunner destruction.");
         }
+        if (mLoraMemcpyEvent != nullptr)
+        {
+            // Destruction is best-effort; do not throw from the destructor.
+            (void) cudaEventDestroy(mLoraMemcpyEvent);
+            mLoraMemcpyEvent = nullptr;
+        }
     }
 
     FusedMoeRunner(FusedMoeRunner const&) = delete;
@@ -260,6 +277,9 @@ public:
         std::lock_guard<std::mutex> lock(mMutex);
         mStreamWorkspaces.clear();
         freeProfileWorkspace();
+        // LoraImpl objects retain non-trivial cuBLAS state; drop the cache so the
+        // next LoRA call re-builds them. The shared cuBLAS wrapper is kept.
+        mLoraImplCache.clear();
     }
 
     torch::Tensor runMoe(torch::Tensor const& input, torch::Tensor const& token_selected_experts,
@@ -274,7 +294,18 @@ public:
         bool const enable_alltoall, bool min_latency_mode, torch::optional<c10::ArrayRef<int64_t>> const& profile_ids,
         torch::optional<int64_t> const& activation_type, torch::optional<int64_t> const& unpadded_hidden_size,
         torch::optional<int64_t> const& num_valid_tokens, torch::optional<torch::Tensor> const& out_tensor,
-        bool use_dynamic_fc2_scale = false)
+        bool use_dynamic_fc2_scale = false,
+        // Routed-expert LoRA inputs (all optional; presence of fc1_lora_ranks activates LoRA).
+        // Each *_ranks   : CPU int32  [num_seqs]
+        // Each *_weights : CPU int64  [num_seqs, 3]  -- (A_ptr, B_ptr, DoRA_ptr-unused)
+        torch::optional<torch::Tensor> const& fc1_lora_ranks = torch::nullopt,
+        torch::optional<torch::Tensor> const& fc1_lora_weight_ptrs = torch::nullopt,
+        torch::optional<torch::Tensor> const& fc2_lora_ranks = torch::nullopt,
+        torch::optional<torch::Tensor> const& fc2_lora_weight_ptrs = torch::nullopt,
+        torch::optional<torch::Tensor> const& gated_lora_ranks = torch::nullopt,
+        torch::optional<torch::Tensor> const& gated_lora_weight_ptrs = torch::nullopt,
+        torch::optional<torch::Tensor> const& host_request_types = torch::nullopt,
+        torch::optional<torch::Tensor> const& host_context_lengths = torch::nullopt, int64_t lora_max_low_rank = 0)
     {
         std::lock_guard<std::mutex> lock(mMutex);
         // Free the profile workspace to save memory
@@ -446,8 +477,46 @@ public:
             output = torch::empty(output_shape, input.options().dtype(mOutputDtype));
         }
 
+        // ===== Routed-expert LoRA setup =====
+        // LoRA is activated by the per-request schema (fc1_lora_ranks).
+        bool const lora_active = fc1_lora_ranks.has_value();
+        bool const is_gated_act = isGatedActivation(base_activation_type);
+        if (lora_active)
+        {
+            // Conservative rejections (min-latency, alltoall, quant, graph capture).
+            TORCH_CHECK(!min_latency_mode, "MoE LoRA is not supported in min-latency mode.");
+            TORCH_CHECK(!enable_alltoall,
+                "MoE LoRA is not supported with alltoall: the per-token adapter pointer arrays do not survive "
+                "cross-rank token reshuffling.");
+            TORCH_CHECK(mActivationDtype == c10::ScalarType::Half || mActivationDtype == c10::ScalarType::BFloat16,
+                "MoE LoRA only supports fp16 and bf16 activation dtypes.");
+            TORCH_CHECK(mWeightDtype == c10::ScalarType::Half || mWeightDtype == c10::ScalarType::BFloat16,
+                "MoE LoRA only supports unquantized fp16/bf16 expert weights.");
+            // CUDA-graph capture is incompatible with the kernel's LoRA path,
+            // which performs a host-side `cudaEventSynchronize` and CPU-side
+            // per-token pointer expansion inside `setupLoraWorkspace`. The
+            // event-synchronize cannot be recorded into a graph, so reject here
+            // with a clear message to avoid a segfault during capture.
+            TORCH_CHECK(!tensorrt_llm::common::isCapturing(stream),
+                "MoE LoRA is not supported under CUDA graph capture. The fused-MoE kernel's "
+                "LoRA path performs a host-side cudaEventSynchronize after a D2H pointer-expansion copy, "
+                "which is not capturable. Run the LoRA path eagerly, or disable MoE LoRA when capturing.");
+        }
+        // Build LoraParams up-front so we can compute the required cuBLAS workspace before allocation.
+        auto lora_params_opt = buildMoeLoraParams(fc1_lora_ranks, fc1_lora_weight_ptrs, fc2_lora_ranks,
+            fc2_lora_weight_ptrs, gated_lora_ranks, gated_lora_weight_ptrs, host_request_types, host_context_lengths,
+            /*num_tokens=*/num_rows, hidden_size, inter_size, mActivationDtype, lora_max_low_rank, is_gated_act);
+        size_t lora_workspace_size = 0;
+        if (lora_params_opt.has_value())
+        {
+            auto const lora_dtype = loraTypeFromActDtype(mActivationDtype);
+            lora_workspace_size = computeLoraWorkspaceSize(lora_params_opt->fc1_lora_impl,
+                lora_params_opt->fc2_lora_impl, num_rows, experts_per_token, lora_params_opt->num_reqs, lora_dtype);
+        }
+
         WorkspaceInfo const& workspace_info = getWorkspaceInfo(num_rows, hidden_size, inter_size, num_experts_total,
-            static_cast<int>(experts_per_token), base_activation_type, parallelism_config, min_latency_mode, stream);
+            static_cast<int>(experts_per_token), base_activation_type, parallelism_config, min_latency_mode, stream,
+            lora_active, lora_workspace_size);
 
         auto quant_params
             = getQuantParams(num_experts_on_rank, hidden_size, inter_size, quant_scales, base_activation_type);
@@ -474,8 +543,13 @@ public:
 
         kernels::MoeMinLatencyParams min_latency_params{};
 
-        // TODO: support lora in the future
-        ::tensorrt_llm::kernels::LoraParams lora_params{};
+        // LoraParams is either the populated one we just built or a default-constructed empty one (use_lora=false).
+        ::tensorrt_llm::kernels::LoraParams lora_params
+            = lora_params_opt.value_or(::tensorrt_llm::kernels::LoraParams{});
+        if (lora_active)
+        {
+            lora_params.workspace = workspace_info.lora_workspace;
+        }
 #ifdef USING_OSS_CUTLASS_MOE_GEMM
         mKernelRunner->runMoe(input.const_data_ptr(),
             input_sf.has_value() ? input_sf.value().const_data_ptr() : nullptr, swizzled_input_sf,
@@ -489,8 +563,8 @@ public:
             num_rows, num_valid_tokens.has_value() ? num_valid_tokens.value() : num_rows, hidden_size,
             unpadded_hidden_size_val, inter_size, num_experts_total, static_cast<int>(experts_per_token),
             static_cast<char*>(workspace_info.workspace.data_ptr()), output.data_ptr(),
-            static_cast<int*>(workspace_info.src_to_dest_map), parallelism_config, enable_alltoall, false, lora_params,
-            mUseDeepSeekFP8BlockScaling, min_latency_mode, min_latency_params, stream);
+            static_cast<int*>(workspace_info.src_to_dest_map), parallelism_config, enable_alltoall, lora_active,
+            lora_params, mUseDeepSeekFP8BlockScaling, min_latency_mode, min_latency_params, stream);
 #else
         mKernelRunner->runMoe(input.const_data_ptr(),
             input_sf.has_value() ? input_sf.value().const_data_ptr() : nullptr, swizzled_input_sf,
@@ -504,7 +578,7 @@ public:
             num_rows, num_valid_tokens.has_value() ? num_valid_tokens.value() : num_rows, hidden_size, inter_size,
             num_experts_total, static_cast<int>(experts_per_token),
             static_cast<char*>(workspace_info.workspace.data_ptr()), output.data_ptr(),
-            static_cast<int*>(workspace_info.src_to_dest_map), parallelism_config, false, lora_params,
+            static_cast<int*>(workspace_info.src_to_dest_map), parallelism_config, lora_active, lora_params,
             mUseDeepSeekFP8BlockScaling, min_latency_mode, min_latency_params, stream);
 #endif
 
@@ -795,6 +869,10 @@ private:
     {
         torch::Tensor workspace{};
         void* src_to_dest_map{};
+        // Cublas grouped-gemm scratch consumed by LoraImpl::run inside the MoE
+        // kernel's loraFC1/loraFC2 paths. Pointer aliases into `workspace`.
+        // nullptr when LoRA is inactive.
+        void* lora_workspace{};
     };
 
     std::mutex mMutex;
@@ -818,6 +896,27 @@ private:
     using Profile = tensorrt_llm::cutlass_extensions::CutlassGemmConfig;
     std::vector<Profile> mGemm1Profiles;
     std::vector<Profile> mGemm2Profiles;
+
+    // ===== Routed-expert LoRA state =====
+    // Lazily constructed on first LoRA call.
+    std::shared_ptr<tensorrt_llm::common::CublasMMWrapper> mLoraCublasWrapper;
+    // Cache of LoraImpl instances keyed by (hidden_size, inter_size, lora_dtype, max_rank).
+    // value.first  = fc1/gated impl (in=hidden, out=inter)
+    // value.second = fc2 impl       (in=inter,  out=hidden)
+    using LoraImplKey = std::tuple<int64_t, int64_t, c10::ScalarType, int>;
+    using LoraImplPtr = ::tensorrt_llm::kernels::LoraParams::LoraImplPtr;
+    std::map<LoraImplKey, std::pair<LoraImplPtr, LoraImplPtr>> mLoraImplCache;
+    // Sync event used by setupLoraWorkspace (kernel waits on this before reading
+    // host-side permuted_rows arrays). Created lazily.
+    cudaEvent_t mLoraMemcpyEvent = nullptr;
+    // Scratch storage for the per-token expanded LoRA pointer/rank arrays.
+    // Reused across calls; .clear() drops content but retains capacity.
+    std::vector<void const*> mLoraExpandFC1WeightPtrs;
+    std::vector<void const*> mLoraExpandFC2WeightPtrs;
+    std::vector<void const*> mLoraExpandGatedWeightPtrs;
+    std::vector<int32_t> mLoraExpandFC1Ranks;
+    std::vector<int32_t> mLoraExpandFC2Ranks;
+    std::vector<int32_t> mLoraExpandGatedRanks;
 
     void freeProfileWorkspace()
     {
@@ -858,15 +957,20 @@ private:
 
     WorkspaceInfo const& getWorkspaceInfo(int64_t const num_rows, int64_t const hidden_size, int64_t const inter_size,
         int num_experts, int experts_per_token, ActivationType activation_type,
-        kernels::MOEParallelismConfig const& parallelismConfig, bool min_latency_mode, cudaStream_t stream)
+        kernels::MOEParallelismConfig const& parallelismConfig, bool min_latency_mode, cudaStream_t stream,
+        bool use_lora = false, size_t lora_workspace_size = 0)
     {
         size_t moe_workspace_size = mKernelRunner->getWorkspaceSize(num_rows, hidden_size, inter_size, num_experts,
-            experts_per_token, activation_type, parallelismConfig, /* use_lora */ false, mUseDeepSeekFP8BlockScaling,
+            experts_per_token, activation_type, parallelismConfig, use_lora, mUseDeepSeekFP8BlockScaling,
             min_latency_mode, mUseW4GroupScaling);
         size_t src_to_dest_map_size = experts_per_token * num_rows * sizeof(int);
         auto& workspace_info = mStreamWorkspaces[stream];
 
         std::vector<size_t> workspaces{moe_workspace_size, src_to_dest_map_size};
+        if (use_lora && lora_workspace_size > 0)
+        {
+            workspaces.push_back(lora_workspace_size);
+        }
 
         int64_t const total_workspace_size = common::calculateTotalWorkspaceSize(workspaces.data(), workspaces.size());
 
@@ -891,8 +995,235 @@ private:
         }
         workspace_info.src_to_dest_map
             = common::nextWorkspacePtr(static_cast<int8_t*>(workspace_info.workspace.data_ptr()), moe_workspace_size);
+        if (use_lora && lora_workspace_size > 0)
+        {
+            workspace_info.lora_workspace
+                = common::nextWorkspacePtr(static_cast<int8_t*>(workspace_info.src_to_dest_map), src_to_dest_map_size);
+        }
+        else
+        {
+            workspace_info.lora_workspace = nullptr;
+        }
 
         return workspace_info;
+    }
+
+    // ===== LoRA helpers =====
+
+    // Lazy-construct the shared cuBLAS wrapper and the memcpy sync event used
+    // by the kernel's setupLoraWorkspace. Idempotent.
+    void ensureLoraInfra()
+    {
+        if (mLoraCublasWrapper == nullptr)
+        {
+            auto cublasHandle = ::tensorrt_llm::getCublasHandle();
+            auto cublasLtHandle = ::tensorrt_llm::getCublasLtHandle();
+            mLoraCublasWrapper = std::make_shared<::tensorrt_llm::common::CublasMMWrapper>(
+                cublasHandle, cublasLtHandle, /*allocator=*/nullptr, /*workspace=*/nullptr);
+        }
+        if (mLoraMemcpyEvent == nullptr)
+        {
+            TLLM_CUDA_CHECK(cudaEventCreateWithFlags(&mLoraMemcpyEvent, cudaEventDisableTiming));
+        }
+    }
+
+    // Map a torch dtype to the TRT-LLM nvinfer1::DataType expected by LoraImpl.
+    static nvinfer1::DataType loraTypeFromActDtype(c10::ScalarType dtype)
+    {
+        switch (dtype)
+        {
+        case c10::ScalarType::Half: return nvinfer1::DataType::kHALF;
+        case c10::ScalarType::Float: return nvinfer1::DataType::kFLOAT;
+#ifdef ENABLE_BF16
+        case c10::ScalarType::BFloat16: return nvinfer1::DataType::kBF16;
+#endif
+        default: C10_THROW_ERROR_FORMATTED(Error, "MoE LoRA only supports fp16/bf16/fp32 activation dtype.");
+        }
+    }
+
+    // Get or create the (fc1, fc2) LoraImpl pair for these shapes/dtype.
+    // fc1 impl runs (hidden -> inter) and is also used for the optional gated side.
+    // fc2 impl runs (inter -> hidden).
+    std::pair<LoraImplPtr, LoraImplPtr> getOrCreateLoraImpls(
+        int64_t hidden_size, int64_t inter_size, c10::ScalarType act_dtype, int max_low_rank)
+    {
+        LoraImplKey key{hidden_size, inter_size, act_dtype, max_low_rank};
+        auto it = mLoraImplCache.find(key);
+        if (it != mLoraImplCache.end())
+        {
+            return it->second;
+        }
+
+        ensureLoraInfra();
+        auto const lora_dtype = loraTypeFromActDtype(act_dtype);
+
+        auto fc1_impl = std::make_shared<::tensorrt_llm::kernels::LoraImpl>(
+            /*in_hidden_size=*/static_cast<int>(hidden_size),
+            /*out_hidden_sizes=*/std::vector<int>{static_cast<int>(inter_size)},
+            /*transA=*/false, /*transB=*/true, /*num_lora_modules=*/1, lora_dtype, max_low_rank, mLoraCublasWrapper);
+        auto fc2_impl = std::make_shared<::tensorrt_llm::kernels::LoraImpl>(
+            /*in_hidden_size=*/static_cast<int>(inter_size),
+            /*out_hidden_sizes=*/std::vector<int>{static_cast<int>(hidden_size)},
+            /*transA=*/false, /*transB=*/true, /*num_lora_modules=*/1, lora_dtype, max_low_rank, mLoraCublasWrapper);
+
+        // No profiler integration yet; cuBLAS auto-selects per call.
+        fc1_impl->setBestTactic(std::nullopt);
+        fc2_impl->setBestTactic(std::nullopt);
+
+        auto inserted = mLoraImplCache.emplace(key, std::make_pair(fc1_impl, fc2_impl));
+        return inserted.first->second;
+    }
+
+    // Expand per-request LoRA ranks and weight-pointer pairs into per-token arrays.
+    // Mirrors the convention in cpp/tensorrt_llm/thop/loraOp.cpp lines 97-127 and
+    // cpp/tensorrt_llm/plugins/mixtureOfExperts/mixtureOfExpertsPlugin.cpp.
+    //
+    // Inputs:
+    //   ranks:                 cpu int32 [num_seqs]
+    //   weight_ptrs:           cpu int64 [num_seqs, 3]  (A, B, optional-DoRA-magnitude; DoRA ignored)
+    //   host_request_types:    cpu int32 [num_seqs]      (0=CONTEXT/prefill, 1=GENERATION)
+    //   host_context_lengths:  cpu int32 [num_seqs]      (only read for CONTEXT requests)
+    //   num_tokens:            total tokens flowing through this op (used as a consistency check)
+    //
+    // Outputs the two `expand_*` vectors with shapes [num_tokens] / [num_tokens * 2].
+    void expandPerRequestLoraTo(torch::Tensor const& ranks, torch::Tensor const& weight_ptrs,
+        torch::Tensor const& host_request_types, torch::Tensor const& host_context_lengths, int64_t num_tokens,
+        std::vector<int32_t>& expand_ranks, std::vector<void const*>& expand_ptrs)
+    {
+        CHECK_CPU_INPUT(ranks, at::ScalarType::Int)
+        CHECK_CPU_INPUT(weight_ptrs, at::ScalarType::Long)
+        CHECK_CPU_INPUT(host_request_types, at::ScalarType::Int)
+        CHECK_CPU_INPUT(host_context_lengths, at::ScalarType::Int)
+
+        auto const num_seqs = static_cast<int64_t>(ranks.size(0));
+        TORCH_CHECK(weight_ptrs.dim() == 2 && weight_ptrs.size(0) == num_seqs && weight_ptrs.size(1) == 3,
+            "MoE LoRA weight_ptrs must have shape [num_seqs, 3] (A, B, optional DoRA); got ", weight_ptrs.sizes());
+        TORCH_CHECK(host_request_types.size(0) == num_seqs, "MoE LoRA host_request_types must match ranks length. Got ",
+            host_request_types.size(0), " vs ", num_seqs);
+        TORCH_CHECK(host_context_lengths.size(0) == num_seqs,
+            "MoE LoRA host_context_lengths must match ranks length. Got ", host_context_lengths.size(0), " vs ",
+            num_seqs);
+
+        auto const* rank_data = static_cast<int32_t const*>(ranks.data_ptr());
+        auto const* ptr_data = static_cast<int64_t const*>(weight_ptrs.data_ptr());
+        auto const* req_types = static_cast<int32_t const*>(host_request_types.data_ptr());
+        auto const* ctx_lens = static_cast<int32_t const*>(host_context_lengths.data_ptr());
+
+        expand_ranks.clear();
+        expand_ptrs.clear();
+        expand_ranks.reserve(num_tokens);
+        expand_ptrs.reserve(num_tokens * 2);
+
+        int64_t produced = 0;
+        for (int64_t req_id = 0; req_id < num_seqs; ++req_id)
+        {
+            int32_t const rank = rank_data[req_id];
+            void const* const a_ptr = reinterpret_cast<void const*>(ptr_data[req_id * 3 + 0]);
+            void const* const b_ptr = reinterpret_cast<void const*>(ptr_data[req_id * 3 + 1]);
+            // ptr_data[req_id * 3 + 2] is the optional DoRA magnitude vector pointer; ignored here
+            // (MoE+DoRA is rejected at load time, see tensorrt_llm/lora_manager.py).
+
+            auto const req_type = static_cast<MoeLoraRequestType>(req_types[req_id]);
+            int64_t const repeat
+                = (req_type == MoeLoraRequestType::kGENERATION) ? int64_t{1} : static_cast<int64_t>(ctx_lens[req_id]);
+            for (int64_t i = 0; i < repeat; ++i)
+            {
+                expand_ranks.push_back(rank);
+                expand_ptrs.push_back(a_ptr);
+                expand_ptrs.push_back(b_ptr);
+            }
+            produced += repeat;
+        }
+        TORCH_CHECK(produced == num_tokens, "MoE LoRA per-request expansion produced ", produced,
+            " tokens but op input has ", num_tokens, " tokens.");
+    }
+
+    // Build a populated LoraParams from the optional CPU tensors. Caller is
+    // responsible for setting `lora_params.workspace` (the cuBLAS scratch).
+    // Returns std::nullopt when LoRA is inactive (no fc1 ranks tensor).
+    // Mutates the mLoraExpand* member vectors.
+    std::optional<::tensorrt_llm::kernels::LoraParams> buildMoeLoraParams(
+        torch::optional<torch::Tensor> const& fc1_lora_ranks,
+        torch::optional<torch::Tensor> const& fc1_lora_weight_ptrs,
+        torch::optional<torch::Tensor> const& fc2_lora_ranks,
+        torch::optional<torch::Tensor> const& fc2_lora_weight_ptrs,
+        torch::optional<torch::Tensor> const& gated_lora_ranks,
+        torch::optional<torch::Tensor> const& gated_lora_weight_ptrs,
+        torch::optional<torch::Tensor> const& host_request_types,
+        torch::optional<torch::Tensor> const& host_context_lengths, int64_t num_tokens, int64_t hidden_size,
+        int64_t inter_size, c10::ScalarType act_dtype, int64_t lora_max_low_rank, bool is_gated_activation)
+    {
+        if (!fc1_lora_ranks.has_value())
+        {
+            return std::nullopt;
+        }
+        TORCH_CHECK(lora_max_low_rank > 0, "MoE LoRA requires lora_max_low_rank > 0; got ", lora_max_low_rank);
+
+        TORCH_CHECK(fc1_lora_weight_ptrs.has_value() && fc2_lora_ranks.has_value() && fc2_lora_weight_ptrs.has_value(),
+            "MoE LoRA requires fc1_lora_ranks/fc1_lora_weight_ptrs/fc2_lora_ranks/fc2_lora_weight_ptrs together.");
+        TORCH_CHECK(host_request_types.has_value() && host_context_lengths.has_value(),
+            "MoE LoRA requires host_request_types and host_context_lengths CPU tensors.");
+        // For gated activations (e.g. SwiGLU) the kernel's setupLoraWorkspace
+        // unconditionally dereferences `lora_params.gated_lora_ranks` /
+        // `gated_lora_weight_ptrs`, so the caller MUST provide them.
+        if (is_gated_activation)
+        {
+            TORCH_CHECK(gated_lora_ranks.has_value() && gated_lora_weight_ptrs.has_value(),
+                "MoE LoRA with a gated activation (e.g. SwiGLU) requires gated_lora_ranks and "
+                "gated_lora_weight_ptrs to be provided alongside fc1_lora_*. The fused-MoE kernel "
+                "expects three LoRA modules per layer: fc1 (up), gated (gate) and fc2 (down).");
+        }
+        else
+        {
+            TORCH_CHECK(!gated_lora_ranks.has_value(),
+                "MoE LoRA gated_lora_* is only supported for gated activations (e.g. SwiGLU).");
+        }
+
+        int64_t const num_seqs = fc1_lora_ranks->size(0);
+        bool const has_gated = is_gated_activation && gated_lora_ranks.has_value();
+
+        expandPerRequestLoraTo(*fc1_lora_ranks, *fc1_lora_weight_ptrs, *host_request_types, *host_context_lengths,
+            num_tokens, mLoraExpandFC1Ranks, mLoraExpandFC1WeightPtrs);
+        expandPerRequestLoraTo(*fc2_lora_ranks, *fc2_lora_weight_ptrs, *host_request_types, *host_context_lengths,
+            num_tokens, mLoraExpandFC2Ranks, mLoraExpandFC2WeightPtrs);
+        if (has_gated)
+        {
+            expandPerRequestLoraTo(*gated_lora_ranks, *gated_lora_weight_ptrs, *host_request_types,
+                *host_context_lengths, num_tokens, mLoraExpandGatedRanks, mLoraExpandGatedWeightPtrs);
+        }
+        else
+        {
+            mLoraExpandGatedRanks.clear();
+            mLoraExpandGatedWeightPtrs.clear();
+        }
+
+        auto impls = getOrCreateLoraImpls(hidden_size, inter_size, act_dtype, static_cast<int>(lora_max_low_rank));
+
+        ::tensorrt_llm::kernels::LoraParams lora_params{
+            static_cast<int>(num_seqs),
+            mLoraExpandFC1Ranks.data(),
+            mLoraExpandFC1WeightPtrs.data(),
+            mLoraExpandFC2Ranks.data(),
+            mLoraExpandFC2WeightPtrs.data(),
+            impls.first,
+            impls.second,
+            /*workspace=*/nullptr, // caller fills in
+            &mLoraMemcpyEvent,
+            has_gated ? mLoraExpandGatedRanks.data() : nullptr,
+            has_gated ? mLoraExpandGatedWeightPtrs.data() : nullptr,
+        };
+        return lora_params;
+    }
+
+    // Compute cuBLAS LoraImpl scratch size for the current call. Returns 0 when LoRA inactive.
+    size_t computeLoraWorkspaceSize(LoraImplPtr const& fc1_impl, LoraImplPtr const& fc2_impl, int64_t num_tokens,
+        int64_t experts_per_token, int64_t num_seqs, nvinfer1::DataType lora_dtype) const
+    {
+        int64_t const num_lora_tokens = num_tokens * experts_per_token;
+        // num_reqs upper-bounded by num_lora_tokens; mirrors plugin convention.
+        int64_t const num_reqs = std::min<int64_t>(num_seqs * experts_per_token, num_lora_tokens);
+        return std::max(fc1_impl->getWorkspaceSize(num_lora_tokens, num_reqs, lora_dtype),
+            fc2_impl->getWorkspaceSize(num_lora_tokens, num_reqs, lora_dtype));
     }
 
     kernels::QuantParams getQuantParams(int64_t const num_experts_on_rank, int64_t const hidden_size,

--- a/docs/source/features/lora.md
+++ b/docs/source/features/lora.md
@@ -10,6 +10,7 @@ LoRA (Low-Rank Adaptation) is a parameter-efficient fine-tuning technique that e
 3. [Advanced Usage](#advanced-usage)
    - [LoRA with Quantization](#lora-with-quantization)
    - [NeMo LoRA Format](#nemo-lora-format)
+   - [Routed-Expert MoE LoRA](#routed-expert-moe-lora)
    - [Cache Management](#cache-management)
 4. [TRTLLM serve with LoRA](#trtllm-serve-with-lora)
    - [YAML Configuration](#yaml-configuration)
@@ -134,6 +135,79 @@ lora_request = LoRARequest(
     lora_ckpt_source="nemo"
 )
 ```
+
+### Routed-Expert MoE LoRA
+
+LoRA can be applied to the routed-expert projections of a Mixture-of-Experts (MoE) layer in addition to the attention modules. The PyTorch backend's Cutlass MoE kernel fuses the LoRA application into the MoE forward pass, so multi-adapter batches run without an extra GEMM pass per layer.
+
+#### Supported configuration
+
+| Aspect | Supported |
+|---|---|
+| MoE backend | `CUTLASS` only (other backends raise an error at construction). |
+| Base-weight dtype | bf16 / fp16. Quantized base weights (FP8, NVFP4, INT4, INT8) are not yet supported. |
+| Adapter modules | `moe_h_to_4h` (gate side of SwiGLU), `moe_gate` (up side), `moe_4h_to_h` (down). At minimum, `moe_gate` and `moe_4h_to_h` must be present together. |
+| Adapter layout | Per-expert (stacked `[num_experts, ...]`). |
+| Multi-LoRA in flight | Yes. Reuses the existing slot manager. |
+| Execution paths | Eager only (CUDA-graph capture is rejected; see below). |
+| min-latency mode | Not supported with MoE LoRA. |
+| Alltoall (WideEP) | Not supported with MoE LoRA. |
+| DoRA on MoE modules | Not supported (and rejected at load time). |
+| `register_to_config` + `torch.compile` | Not supported with MoE LoRA. |
+
+#### Enabling routed-expert MoE LoRA
+
+```python
+from tensorrt_llm import LLM
+from tensorrt_llm.lora_manager import LoraConfig
+
+lora_config = LoraConfig(
+    lora_target_modules=[
+        "attn_q", "attn_k", "attn_v",  # optional: standard attention LoRA
+        "moe_gate",                    # up projection (required for MoE LoRA)
+        "moe_4h_to_h",                 # down projection (required for MoE LoRA)
+        "moe_h_to_4h",                 # gate projection (SwiGLU; optional)
+    ],
+    max_lora_rank=16,
+    max_loras=8,
+    max_cpu_loras=8,
+)
+
+llm = LLM(
+    model="/path/to/moe_base_model",
+    lora_config=lora_config,
+    # The MoE LoRA path requires the Cutlass backend. Other moe_backend values
+    # raise ValueError at construction.
+    moe_backend="CUTLASS",
+)
+```
+
+Adapters are loaded via `LoRARequest` exactly like attention-only LoRA; no API change.
+
+#### Adapter layout
+
+Each routed expert has its own `(A, B)` matrices, stored as stacked `[num_experts, rank, in_dim]` and `[num_experts, out_dim, rank]` tensors. This is the standard HuggingFace PEFT export shape for MoE LoRA; the MoE kernel reads each expert's slice at offset `expert_index * dim * rank`.
+
+A helper for assembling synthetic per-expert adapters (for unit tests and experimentation) is provided at `tensorrt_llm._torch.peft.lora.moe_layout`:
+
+```python
+from tensorrt_llm._torch.peft.lora.moe_layout import make_per_expert_lora
+
+fc1_adapter = make_per_expert_lora(
+    num_experts=8, rank=16, in_dim=2048, out_dim=5632,
+    dtype=torch.bfloat16,
+)
+# fc1_adapter["A"].shape == (8, 16, 2048)  -- independent per expert
+# fc1_adapter["B"].shape == (8, 5632, 16)  -- independent per expert
+```
+
+#### CUDA-graph decode
+
+MoE LoRA runs in eager mode. CUDA-graph capture of a LoRA-active routed-expert MoE layer is not supported: the fused MoE kernel's LoRA path performs a host-side `cudaEventSynchronize` after a device-to-host pointer-expansion copy, which is not capturable. When CUDA-graph decode is enabled and an MoE LoRA is active, the fused MoE op detects the capturing stream and raises a clear error, so disable CUDA-graph capture when running MoE LoRA.
+
+#### What is rejected, and where
+
+If you supply MoE LoRA on a non-Cutlass backend or with quantization, `create_moe` raises at construction with a message pointing at the offending setting. At runtime, the fused MoE op also rejects min-latency mode + LoRA, alltoall + LoRA, and CUDA-graph capture + LoRA.
 
 ### Cache Management
 

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -230,8 +230,19 @@ def fused_moe(
     unpadded_hidden_size: Optional[int] = None,
     out_tensor: Optional[torch.Tensor] = None,
     use_dynamic_fc2_scale: bool = False,
+    # Routed-expert LoRA inputs (all optional; presence of fc1_lora_ranks activates LoRA).
+    # Each *_ranks   : CPU int32  [num_seqs]
+    # Each *_weights : CPU int64  [num_seqs, 3]  -- (A_ptr, B_ptr, DoRA_ptr unused)
+    fc1_lora_ranks: Optional[torch.Tensor] = None,
+    fc1_lora_weight_ptrs: Optional[torch.Tensor] = None,
+    fc2_lora_ranks: Optional[torch.Tensor] = None,
+    fc2_lora_weight_ptrs: Optional[torch.Tensor] = None,
+    gated_lora_ranks: Optional[torch.Tensor] = None,
+    gated_lora_weight_ptrs: Optional[torch.Tensor] = None,
+    host_request_types: Optional[torch.Tensor] = None,
+    host_context_lengths: Optional[torch.Tensor] = None,
+    lora_max_low_rank: int = 0,
 ) -> List[torch.Tensor]:
-
     tuner = AutoTuner.get()
     # Only the non-alltoall case is considered for profiling in the warmup phase.
     # Therefore, to get the correct tactics during the actual inference, the inputs to the tuner should be the same as when not using alltoall.
@@ -291,17 +302,37 @@ def fused_moe(
         gemm_idx=2,
     )
 
+    lora_active = fc1_lora_ranks is not None
+    if min_latency_mode and lora_active:
+        # Mirror the C++ rejection so the error surfaces before the kernel allocates anything.
+        raise RuntimeError(
+            "MoE LoRA is not supported in min-latency mode. Disable min_latency_mode or pass no LoRA tensors."
+        )
     run_moe = moe_runner.fused_moe_runner.run_moe_min_latency if min_latency_mode else moe_runner.fused_moe_runner.run_moe
     try:
-        output = run_moe(input, token_selected_experts, token_final_scales,
-                         fc1_expert_weights, fc1_expert_biases,
-                         fc2_expert_weights, fc2_expert_biases, quant_scales,
-                         input_sf, swizzled_input_sf, swiglu_alpha, swiglu_beta,
-                         swiglu_limit, tp_size, tp_rank, ep_size, ep_rank,
-                         cluster_size, cluster_rank, enable_alltoall,
-                         min_latency_mode, [gemm_tactic_1, gemm_tactic_2],
-                         activation_type, unpadded_hidden_size,
-                         tuner_num_tokens, out_tensor, use_dynamic_fc2_scale)
+        if min_latency_mode:
+            output = run_moe(input, token_selected_experts, token_final_scales,
+                             fc1_expert_weights, fc1_expert_biases,
+                             fc2_expert_weights, fc2_expert_biases,
+                             quant_scales, input_sf, swizzled_input_sf,
+                             swiglu_alpha, swiglu_beta, swiglu_limit, tp_size,
+                             tp_rank, ep_size, ep_rank, cluster_size,
+                             cluster_rank, enable_alltoall, min_latency_mode,
+                             [gemm_tactic_1, gemm_tactic_2], activation_type,
+                             unpadded_hidden_size, tuner_num_tokens, out_tensor)
+        else:
+            output = run_moe(
+                input, token_selected_experts, token_final_scales,
+                fc1_expert_weights, fc1_expert_biases, fc2_expert_weights,
+                fc2_expert_biases, quant_scales, input_sf, swizzled_input_sf,
+                swiglu_alpha, swiglu_beta, swiglu_limit, tp_size, tp_rank,
+                ep_size, ep_rank, cluster_size, cluster_rank, enable_alltoall,
+                min_latency_mode, [gemm_tactic_1, gemm_tactic_2],
+                activation_type, unpadded_hidden_size, tuner_num_tokens,
+                out_tensor, use_dynamic_fc2_scale, fc1_lora_ranks,
+                fc1_lora_weight_ptrs, fc2_lora_ranks, fc2_lora_weight_ptrs,
+                gated_lora_ranks, gated_lora_weight_ptrs, host_request_types,
+                host_context_lengths, lora_max_low_rank)
     except RuntimeError as e:
         error_msg = str(e)
         if "DeepGEMM only supports Hopper" in error_msg:
@@ -356,7 +387,16 @@ def _(input: torch.Tensor,
       activation_type: ActivationType = ActivationType.Swiglu,
       unpadded_hidden_size: Optional[int] = None,
       out_tensor: Optional[torch.Tensor] = None,
-      use_dynamic_fc2_scale: bool = False):
+      use_dynamic_fc2_scale: bool = False,
+      fc1_lora_ranks: Optional[torch.Tensor] = None,
+      fc1_lora_weight_ptrs: Optional[torch.Tensor] = None,
+      fc2_lora_ranks: Optional[torch.Tensor] = None,
+      fc2_lora_weight_ptrs: Optional[torch.Tensor] = None,
+      gated_lora_ranks: Optional[torch.Tensor] = None,
+      gated_lora_weight_ptrs: Optional[torch.Tensor] = None,
+      host_request_types: Optional[torch.Tensor] = None,
+      host_context_lengths: Optional[torch.Tensor] = None,
+      lora_max_low_rank: int = 0):
     seq_len = input.shape[0]
     if use_int8_woq_per_channel:
         # Note: The weight shape for INT8 weight only quantization is different, i.e.,

--- a/tensorrt_llm/_torch/models/modeling_qwen_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen_moe.py
@@ -92,7 +92,8 @@ class QwenMoE(nn.Module):
             hidden_states,
             router_logits,
             all_rank_num_tokens=all_rank_num_tokens,
-            use_dp_padding=False)
+            use_dp_padding=False,
+            lora_params=lora_params)
 
         shared_expert_output = self.shared_expert(
             hidden_states,

--- a/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
@@ -541,6 +541,7 @@ class ConfigurableMoE(MoE):
         output_dtype: Optional[torch.dtype] = None,
         all_rank_num_tokens: Optional[List[int]] = None,
         use_dp_padding: Optional[bool] = None,
+        lora_params: Optional[Dict] = None,
         **kwargs,
     ) -> torch.Tensor:
         """Forward entry point.
@@ -576,6 +577,7 @@ class ConfigurableMoE(MoE):
             output_dtype=output_dtype,
             all_rank_num_tokens=all_rank_num_tokens,
             use_dp_padding=use_dp_padding,
+            lora_params=lora_params,
         )
 
         # DWDP: record compute and trigger next prefetch (per-layer, not per-chunk).

--- a/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/create_moe.py
@@ -9,6 +9,7 @@ from tensorrt_llm.logger import logger
 from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
 
 from ...model_config import ModelConfig
+from ...peft.lora.validation import check_moe_lora_supported
 from ...utils import ActivationType, AuxStreamType
 from .configurable_moe import ConfigurableMoE
 from .fused_moe_cute_dsl import CuteDslFusedMoE
@@ -185,7 +186,20 @@ def resolve_moe_cls(
     if (moe_cls == TRTLLMGenFusedMoE and not has_quant
             and not TRTLLMGenFusedMoE._supports_flashinfer_bf16_routing_method(
                 routing_method)):
-        return CutlassFusedMoE
+        moe_cls = CutlassFusedMoE
+
+    # Routed-expert LoRA is supported only on CutlassFusedMoE with unquantized
+    # base weights. Fail loudly here rather than at runtime if the user-selected
+    # backend cannot serve the LoRA request. Use the resolved class name, so a
+    # fallback to CutlassFusedMoE keeps LoRA supportable even when the user
+    # requested TRTLLM/CUTEDSL.
+    resolved_backend = "CUTLASS" if moe_cls is CutlassFusedMoE else model_config.moe_backend
+    check_moe_lora_supported(
+        moe_backend_name=resolved_backend,
+        lora_config=getattr(model_config, "lora_config", None),
+        quant_config=effective_quant_config,
+        layer_idx=layer_idx,
+    )
 
     return moe_cls
 

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
@@ -15,6 +15,7 @@ from tensorrt_llm.tools.layer_wise_benchmarks import get_calibrator
 from ...distributed import allgather
 from ...expert_statistic import ExpertStatistic
 from ...model_config import ModelConfig
+from ...peft.lora.layer import LoraModuleType
 from ...utils import (ActivationType, AuxStreamType, EventType,
                       Fp4QuantizedTensor)
 from .interface import AlltoallMethodType, MoE
@@ -354,9 +355,124 @@ class CutlassFusedMoE(MoE):
         # Finalize fusion should be disabled if Lora is used.
         self.use_fused_finalize = not model_config.moe_disable_finalize_fusion and model_config.lora_config is None
 
+        # Routed-expert LoRA is fused inside torch.ops.trtllm.fused_moe. This
+        # flag records whether the layer was configured with MoE LoRA targets,
+        # so forward_impl can reject stray lora_params instead of ignoring them.
+        self._moe_lora_enabled = self._has_moe_lora_targets(model_config)
+
         self._weights_created = False
         if not model_config.skip_create_weights_in_init:
             self.create_weights()
+
+    # ---- Routed-expert LoRA helpers ----
+
+    _MOE_LORA_MODULE_NAMES = ("moe_h_to_4h", "moe_4h_to_h", "moe_gate")
+
+    def _has_moe_lora_targets(self, model_config: ModelConfig) -> bool:
+        """Return True iff this MoE layer is in the routed-expert LoRA
+        target-module set. The LoRA application itself is fused into
+        `torch.ops.trtllm.fused_moe`; no submodule is registered.
+        """
+        lora_config = getattr(model_config, "lora_config", None)
+        if lora_config is None:
+            return False
+        targets = set(getattr(lora_config, "lora_target_modules", []) or [])
+        return any(name in targets for name in self._MOE_LORA_MODULE_NAMES)
+
+    def _extract_moe_lora_tensors(
+            self, lora_params: Optional[Dict]) -> Optional[Dict[str, object]]:
+        """Pick the MoE-side LoRA tensors out of the global `lora_params` dict
+        for this layer. Returns a dict with the kwargs expected by
+        `torch.ops.trtllm.fused_moe`, or None when no MoE LoRA applies.
+
+        Each entry is a CPU tensor:
+            *_lora_ranks         : int32  [num_seqs]
+            *_lora_weight_ptrs   : int64  [num_seqs, 3]   (A, B, DoRA_unused)
+            host_request_types   : int32  [num_seqs]      (0=CTX, 1=GEN)
+            host_context_lengths : int32  [num_seqs]
+            lora_max_low_rank    : int (max rank across the active modules)
+        """
+        if not lora_params:
+            return None
+        layer_params = lora_params.get(
+            self.layer_idx, {}) if self.layer_idx is not None else {}
+        if not layer_params:
+            return None
+
+        # Map each MoE LoRA module to the kernel's fc1 / gated / fc2 slot.
+        # The kernel applies fc1_lora to the gate (SiLU) half of the packed FC1
+        # output and gated_lora to the up (linear) half (see loraFC1 and
+        # doActivationKernel in moe_kernels.cu). With the canonical convention
+        # (moe_h_to_4h is w1 gate/SiLU, moe_gate is w3 up/linear, moe_4h_to_h is
+        # w2 down), this gives moe_h_to_4h to fc1, moe_gate to gated, and
+        # moe_4h_to_h to fc2.
+        slot_to_kernel = {
+            int(LoraModuleType.MOE_H_TO_4H): "fc1",
+            int(LoraModuleType.MOE_GATE): "gated",
+            int(LoraModuleType.MOE_4H_TO_H): "fc2",
+        }
+        kernel_ranks: Dict[str, Optional[torch.Tensor]] = {
+            "fc1": None,
+            "fc2": None,
+            "gated": None,
+        }
+        kernel_ptrs: Dict[str, Optional[torch.Tensor]] = {
+            "fc1": None,
+            "fc2": None,
+            "gated": None,
+        }
+        active_max_rank = 0
+        for module_id_int, slot in slot_to_kernel.items():
+            entry = layer_params.get(module_id_int)
+            if entry is None:
+                continue
+            kernel_ranks[slot] = entry["adapter_size"]
+            kernel_ptrs[slot] = entry["weight_pointers"]
+            try:
+                active_max_rank = max(active_max_rank,
+                                      int(entry["adapter_size"].max().item()))
+            except (RuntimeError, ValueError):
+                # Empty tensor; treat as no contribution.
+                pass
+
+        if all(v is None for v in kernel_ranks.values()):
+            return None
+
+        # The kernel always dereferences the fc1 and fc2 rank/pointer arrays
+        # (see setupLoraWorkspace in moe_kernels.cu), so moe_h_to_4h (fc1) and
+        # moe_4h_to_h (fc2) must both be present when MoE LoRA is active. The
+        # gated slot (moe_gate) is only read for gated activations and is
+        # checked in the C++ thop layer.
+        if kernel_ranks["fc1"] is None or kernel_ranks["fc2"] is None:
+            raise ValueError(
+                "MoE LoRA requires both `moe_h_to_4h` (gate/SiLU) and "
+                "`moe_4h_to_h` (down) in lora_target_modules; got modules: "
+                f"{[name for name in self._MOE_LORA_MODULE_NAMES if int(LoraModuleType.from_string(name)) in layer_params]}"
+            )
+
+        num_seqs = lora_params["num_seqs"]
+        return {
+            "fc1_lora_ranks":
+            kernel_ranks["fc1"][:num_seqs].contiguous(),
+            "fc1_lora_weight_ptrs":
+            kernel_ptrs["fc1"][:num_seqs].contiguous(),
+            "fc2_lora_ranks":
+            kernel_ranks["fc2"][:num_seqs].contiguous(),
+            "fc2_lora_weight_ptrs":
+            kernel_ptrs["fc2"][:num_seqs].contiguous(),
+            "gated_lora_ranks":
+            (kernel_ranks["gated"][:num_seqs].contiguous()
+             if kernel_ranks["gated"] is not None else None),
+            "gated_lora_weight_ptrs":
+            (kernel_ptrs["gated"][:num_seqs].contiguous()
+             if kernel_ptrs["gated"] is not None else None),
+            "host_request_types":
+            lora_params["host_request_types"][:num_seqs].contiguous(),
+            "host_context_lengths":
+            lora_params["prompt_lens_cpu"][:num_seqs].contiguous(),
+            "lora_max_low_rank":
+            active_max_rank,
+        }
 
     def _check_configs(self):
         assert self._weights_created
@@ -578,6 +694,7 @@ class CutlassFusedMoE(MoE):
         tuner_top_k: Optional[int] = None,
         moe_output: Optional[torch.Tensor] = None,
         enable_alltoall: Optional[bool] = None,
+        lora_params: Optional[Dict] = None,
     ) -> torch.Tensor:
         """
         Run MoE computation with Cutlass backend.
@@ -681,6 +798,10 @@ class CutlassFusedMoE(MoE):
             self, 'force_dynamic_quantization', False)
                                  and hasattr(self, 'fc2_weight_scale_2'))
 
+        lora_kwargs = self._extract_moe_lora_tensors(lora_params)
+        if lora_kwargs is None:
+            lora_kwargs = {}
+
         result = torch.ops.trtllm.fused_moe(
             x,
             token_selected_experts,
@@ -717,6 +838,7 @@ class CutlassFusedMoE(MoE):
             unpadded_hidden_size=self.unpadded_hidden_size,
             out_tensor=moe_output,
             use_dynamic_fc2_scale=use_dynamic_fc2_scale,
+            **lora_kwargs,
         )
         # When moe_output is provided, the result is written in-place and
         # fused_moe returns empty list to avoid aliasing constraint violation.
@@ -807,13 +929,14 @@ class CutlassFusedMoE(MoE):
         return result[0]
 
     def forward_chunk(
-            self,
-            x: Union[torch.Tensor, Fp4QuantizedTensor],
-            router_logits: torch.Tensor,
-            output_dtype: Optional[torch.dtype] = None,
-            all_rank_num_tokens: Optional[List[int]] = None,
-            use_dp_padding: Optional[bool] = None,
-            repeating_info: tuple = (True, True),
+        self,
+        x: Union[torch.Tensor, Fp4QuantizedTensor],
+        router_logits: torch.Tensor,
+        output_dtype: Optional[torch.dtype] = None,
+        all_rank_num_tokens: Optional[List[int]] = None,
+        use_dp_padding: Optional[bool] = None,
+        repeating_info: tuple = (True, True),
+        lora_params: Optional[Dict] = None,
     ) -> torch.Tensor:
         if isinstance(x, Fp4QuantizedTensor):
             assert output_dtype is not None
@@ -1013,6 +1136,7 @@ class CutlassFusedMoE(MoE):
             tuner_num_tokens=tuner_num_tokens,
             tuner_top_k=tuner_top_k,
             moe_output=moe_output,
+            lora_params=lora_params,
         )
 
         self._load_balancer_start_set_cpu_stage(is_last_call)
@@ -1067,9 +1191,21 @@ class CutlassFusedMoE(MoE):
         output_dtype: Optional[torch.dtype] = None,
         all_rank_num_tokens: Optional[List[int]] = None,
         use_dp_padding: Optional[bool] = None,
+        lora_params: Optional[Dict] = None,
         **kwargs,
     ) -> torch.Tensor:
         assert do_finalize, "CutlassFusedMoE does not support do_finalize=False"
+        if lora_params and not self._moe_lora_enabled and any(
+                int(LoraModuleType.from_string(name)) in lora_params.get(
+                    self.layer_idx, {})
+                for name in self._MOE_LORA_MODULE_NAMES):
+            # Caller passed MoE LoRA tensors but this layer was not configured
+            # for it. Surface a clear error rather than silently ignoring.
+            raise RuntimeError(
+                "Received MoE LoRA params for a CutlassFusedMoE layer that was "
+                "not configured with LoRA target modules. Ensure "
+                "`lora_config.lora_target_modules` includes the desired MoE modules."
+            )
         if self.use_dp and self.parallel_size > 1:
             assert all_rank_num_tokens is not None
             assert use_dp_padding is not None
@@ -1097,7 +1233,8 @@ class CutlassFusedMoE(MoE):
                 output_dtype,
                 all_rank_num_tokens=all_rank_num_tokens_padded,
                 use_dp_padding=use_dp_padding,
-                repeating_info=(is_first_call, is_last_call))
+                repeating_info=(is_first_call, is_last_call),
+                lora_params=lora_params)
             outputs = self.reducescatter_or_allreduce(
                 outputs,
                 all_rank_num_tokens=all_rank_num_tokens_padded,
@@ -1132,7 +1269,8 @@ class CutlassFusedMoE(MoE):
                     all_rank_num_tokens=all_rank_num_tokens_list[idx]
                     if self.use_dp else None,
                     use_dp_padding=use_dp_padding,
-                    repeating_info=(is_first_call, is_last_call))
+                    repeating_info=(is_first_call, is_last_call),
+                    lora_params=lora_params)
 
             def _reducescatter_or_allreduce(x_, idx):
                 return self.reducescatter_or_allreduce(

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
@@ -379,6 +379,19 @@ class CutlassFusedMoE(MoE):
         targets = set(getattr(lora_config, "lora_target_modules", []) or [])
         return any(name in targets for name in self._MOE_LORA_MODULE_NAMES)
 
+    def _moe_lora_active(self, lora_params: Optional[Dict]) -> bool:
+        """Return True when lora_params carries routed-expert MoE LoRA tensors
+        for this layer, meaning run_moe would fuse a LoRA delta.
+        """
+        if not lora_params or self.layer_idx is None:
+            return False
+        layer_params = lora_params.get(self.layer_idx, {})
+        if not layer_params:
+            return False
+        return any(
+            int(LoraModuleType.from_string(name)) in layer_params
+            for name in self._MOE_LORA_MODULE_NAMES)
+
     def _extract_moe_lora_tensors(
             self, lora_params: Optional[Dict]) -> Optional[Dict[str, object]]:
         """Pick the MoE-side LoRA tensors out of the global `lora_params` dict
@@ -1195,10 +1208,7 @@ class CutlassFusedMoE(MoE):
         **kwargs,
     ) -> torch.Tensor:
         assert do_finalize, "CutlassFusedMoE does not support do_finalize=False"
-        if lora_params and not self._moe_lora_enabled and any(
-                int(LoraModuleType.from_string(name)) in lora_params.get(
-                    self.layer_idx, {})
-                for name in self._MOE_LORA_MODULE_NAMES):
+        if not self._moe_lora_enabled and self._moe_lora_active(lora_params):
             # Caller passed MoE LoRA tensors but this layer was not configured
             # for it. Surface a clear error rather than silently ignoring.
             raise RuntimeError(
@@ -1223,6 +1233,17 @@ class CutlassFusedMoE(MoE):
         # in case of num_rows is larger than max_chunk_size, we need to split the input into multiple chunks
         num_chunks = (num_rows + self.moe_max_num_tokens -
                       1) // self.moe_max_num_tokens
+
+        if num_chunks > 1 and self._moe_lora_active(lora_params):
+            # Routed-expert MoE LoRA passes per-request adapter metadata that is
+            # not re-sliced per token-chunk, so multi-chunk execution would
+            # mismatch the kernel's per-token expansion. Reject with a clear
+            # message instead of failing inside the C++ op.
+            raise NotImplementedError(
+                f"Routed-expert MoE LoRA does not support multi-chunk execution "
+                f"(num_chunks={num_chunks}). Reduce the per-forward token count "
+                f"or increase `moe_max_num_tokens` so the MoE runs in a single "
+                f"chunk.")
 
         if num_chunks == 1:
             is_first_call = self.repeat_idx == 0

--- a/tensorrt_llm/_torch/modules/fused_moe/interface.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/interface.py
@@ -967,6 +967,19 @@ class MoE(nn.Module):
     ) -> Union[torch.Tensor, List[torch.Tensor]]:
         router_logits = self._maybe_get_perfect_router_logits(router_logits)
         if self.register_to_config and is_torch_compiling():
+            # Routed-expert MoE LoRA is fused into torch.ops.trtllm.fused_moe
+            # via lora_params, but the trtllm::moe_custom_op graph path used here
+            # cannot carry lora_params. Dropping it silently would apply no LoRA,
+            # so reject instead. _moe_lora_enabled is only set by backends that
+            # fuse MoE LoRA, so other backends are unaffected.
+            if getattr(self, "_moe_lora_enabled", False):
+                raise RuntimeError(
+                    "Routed-expert MoE LoRA is not supported together with "
+                    "`register_to_config` + `torch.compile` (the "
+                    "`trtllm::moe_custom_op` graph path cannot carry LoRA "
+                    "adapter pointers). Disable `register_to_config`/"
+                    "torch.compile for this model, or remove the MoE modules "
+                    "from `lora_config.lora_target_modules`.")
             hidden_states = x.fp4_tensor if isinstance(
                 x, Fp4QuantizedTensor) else x
             x_sf = x.scaling_factor if isinstance(x,

--- a/tensorrt_llm/_torch/modules/fused_moe/moe_scheduler.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/moe_scheduler.py
@@ -92,6 +92,7 @@ class MoEScheduler(ABC):
         output_dtype: Optional[torch.dtype],
         all_rank_num_tokens: Optional[List[int]],
         use_dp_padding: Optional[bool],
+        lora_params: Optional[Dict] = None,
     ) -> torch.Tensor: ...
 
 
@@ -131,6 +132,7 @@ class ExternalCommMoEScheduler(MoEScheduler):
         output_dtype: Optional[torch.dtype],
         all_rank_num_tokens: Optional[List[int]],
         use_dp_padding: Optional[bool],
+        lora_params: Optional[Dict] = None,
     ) -> torch.Tensor:
         moe = self.moe
 
@@ -148,6 +150,22 @@ class ExternalCommMoEScheduler(MoEScheduler):
         # ========== Step 2: Determine communication method ==========
         num_chunks = moe.calculate_num_chunks(all_rank_num_tokens_padded)
 
+        # Routed-expert MoE LoRA carries per-request adapter metadata that is
+        # not re-sliced per token-chunk, so multi-chunk execution would mismatch
+        # the kernel's per-token expansion. Reject here with a clear message
+        # instead of failing inside the C++ op.
+        if (
+            num_chunks > 1
+            and moe.backend.__class__ == CutlassFusedMoE
+            and moe.backend._moe_lora_active(lora_params)
+        ):
+            raise NotImplementedError(
+                f"Routed-expert MoE LoRA does not support multi-chunk execution "
+                f"(num_chunks={num_chunks}). Reduce the per-forward token count "
+                f"or increase `moe_max_num_tokens` so the MoE runs in a single "
+                f"chunk."
+            )
+
         # May fall back AllToAll -> AllGather; this is the only sanctioned
         # mutation of ``moe.comm`` from a scheduler.
         moe.determine_communication_method(all_rank_num_tokens_padded, num_chunks)
@@ -161,6 +179,7 @@ class ExternalCommMoEScheduler(MoEScheduler):
                 all_rank_num_tokens_padded,
                 use_dp_padding,
                 do_finalize,
+                lora_params=lora_params,
             )
         else:
             outputs = self._forward_multiple_chunks(
@@ -171,6 +190,7 @@ class ExternalCommMoEScheduler(MoEScheduler):
                 all_rank_num_tokens_padded,
                 use_dp_padding,
                 do_finalize,
+                lora_params=lora_params,
             )
 
         # ========== Step 4: Truncate DP padding ==========
@@ -274,6 +294,7 @@ class ExternalCommMoEScheduler(MoEScheduler):
         all_rank_num_tokens: List[int],
         use_dp_padding: Optional[bool],
         do_finalize: bool = True,
+        lora_params: Optional[Dict] = None,
     ) -> torch.Tensor:
         moe = self.moe
         is_first_call = moe.repeat_idx == 0
@@ -291,6 +312,7 @@ class ExternalCommMoEScheduler(MoEScheduler):
             is_last_call,
             do_finalize,
             workspace=workspace,
+            lora_params=lora_params,
         )
 
     def _forward_chunk_impl(
@@ -304,6 +326,7 @@ class ExternalCommMoEScheduler(MoEScheduler):
         is_last_call: bool,
         do_finalize: bool = True,
         workspace: Optional[dict] = None,
+        lora_params: Optional[Dict] = None,
     ) -> torch.Tensor:
         """Unified per-chunk execution flow for all external-comm backends.
 
@@ -474,7 +497,13 @@ class ExternalCommMoEScheduler(MoEScheduler):
             token_final_scales=token_final_scales,
             x_sf=x_sf,
             **self._get_backend_kwargs(
-                router_logits, do_finalize, all_rank_num_tokens, output_dtype, x, workspace
+                router_logits,
+                do_finalize,
+                all_rank_num_tokens,
+                output_dtype,
+                x,
+                workspace,
+                lora_params=lora_params,
             ),
         )
 
@@ -509,6 +538,7 @@ class ExternalCommMoEScheduler(MoEScheduler):
         all_rank_num_tokens: List[int],
         use_dp_padding: Optional[bool],
         do_finalize: bool = True,
+        lora_params: Optional[Dict] = None,
     ) -> torch.Tensor:
         """Multiple-chunk path with optional aux-stream overlap."""
         moe = self.moe
@@ -594,6 +624,7 @@ class ExternalCommMoEScheduler(MoEScheduler):
                             is_last_call,
                             do_finalize,
                             workspace=workspace_0,
+                            lora_params=lora_params,
                         )
                 else:
                     outputs = self._forward_chunk_impl(
@@ -606,6 +637,7 @@ class ExternalCommMoEScheduler(MoEScheduler):
                         is_last_call,
                         do_finalize,
                         workspace=workspace_1,
+                        lora_params=lora_params,
                     )
             else:
                 outputs = self._forward_chunk_impl(
@@ -618,6 +650,7 @@ class ExternalCommMoEScheduler(MoEScheduler):
                     is_last_call,
                     do_finalize,
                     workspace=workspace_0,
+                    lora_params=lora_params,
                 )
 
             if chunked_used[idx_chunk]:
@@ -685,6 +718,7 @@ class ExternalCommMoEScheduler(MoEScheduler):
         output_dtype: Optional[torch.dtype] = None,
         x: Optional[torch.Tensor] = None,
         workspace: Optional[dict] = None,
+        lora_params: Optional[Dict] = None,
     ) -> Dict:
         """Backend-specific kwargs for ``backend.run_moe`` (external-comm only).
 
@@ -692,10 +726,13 @@ class ExternalCommMoEScheduler(MoEScheduler):
         calls this helper, so all branches here are EXTERNAL_COMM backends.
 
         Backend-specific kwargs:
-            - Cutlass: is_sf_swizzled, enable_alltoall, tuner_*, moe_output
+            - Cutlass: is_sf_swizzled, enable_alltoall, tuner_*, moe_output, lora_params
             - CuteDSL: enable_alltoall, moe_output
             - DeepGemm: workspace
             - TRTLLMGen: router_logits, do_finalize, moe_output
+
+        Only CutlassFusedMoE.run_moe accepts lora_params (routed-expert MoE LoRA
+        is fused there), so it is set on the Cutlass branch alone.
         """
         moe = self.moe
         kwargs: Dict = {}
@@ -706,6 +743,7 @@ class ExternalCommMoEScheduler(MoEScheduler):
             supports_post_quant = moe.comm is not None and moe.comm.supports_post_quant_dispatch()
             kwargs["is_sf_swizzled"] = not supports_post_quant
             kwargs["output_dtype"] = output_dtype
+            kwargs["lora_params"] = lora_params
 
             # Tuner sees pre-alltoall token shapes so cached tactics from the
             # warmup (no-alltoall) phase still apply at runtime.
@@ -786,6 +824,7 @@ class FusedCommMoEScheduler(MoEScheduler):
         output_dtype: Optional[torch.dtype],
         all_rank_num_tokens: Optional[List[int]],
         use_dp_padding: Optional[bool],
+        lora_params: Optional[Dict] = None,
     ) -> torch.Tensor:
         """Sequential multi-chunk path for MegaMoE-style backends.
 
@@ -796,6 +835,15 @@ class FusedCommMoEScheduler(MoEScheduler):
         kernel for the cross-rank barrier.
         """
         del use_dp_padding  # MegaMoE has no host-side cross-rank shape alignment.
+
+        # Fused-comm (MegaMoE) backends cannot carry LoRA adapters; routed-expert
+        # MoE LoRA is supported only on the CUTLASS backend. Reject rather than
+        # silently ignore.
+        if lora_params:
+            raise NotImplementedError(
+                "Routed-expert MoE LoRA is not supported by the fused-comm "
+                "(MegaMoE) scheduler; only the CUTLASS backend supports it."
+            )
 
         if isinstance(x, Fp4QuantizedTensor):
             raise NotImplementedError(

--- a/tensorrt_llm/_torch/modules/fused_moe/ops/moe_op_cutlass.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/ops/moe_op_cutlass.py
@@ -204,16 +204,62 @@ class CutlassMoEOp(MoEOp):
         if not isinstance(quant_scales, list):
             quant_scales = list(quant_scales)
 
-        # Run the actual MoE computation
-        output = run_moe(x, token_selected_slots, token_final_scales,
-                         w3_w1_weight.view(weight_dtype), w3_w1_bias,
-                         w2_weight.view(weight_dtype), w2_bias, quant_scales,
-                         input_sf, swizzled_input_sf, swiglu_alpha, swiglu_beta,
-                         swiglu_limit, tp_size, tp_rank, ep_size, ep_rank,
-                         cluster_size, cluster_rank, use_all_to_all,
-                         min_latency_mode, self.gemm_tactics, activation_type,
-                         unpadded_hidden_size, tuner_num_tokens, None,
-                         use_dynamic_fc2_scale)
+        # The C++ run_moe and run_moe_min_latency bindings are TorchBind methods
+        # whose schemas do not honor C++ default arguments, so every positional
+        # argument must be supplied. run_moe has trailing routed-expert LoRA
+        # args; MoE LoRA is fused inside torch.ops.trtllm.fused_moe and never
+        # flows through this op path, so pass None or 0 for them.
+        # run_moe_min_latency takes no use_dynamic_fc2_scale or LoRA args, so its
+        # call stops at out_tensor.
+        if min_latency_mode:
+            output = run_moe(x, token_selected_slots, token_final_scales,
+                             w3_w1_weight.view(weight_dtype), w3_w1_bias,
+                             w2_weight.view(weight_dtype), w2_bias,
+                             quant_scales, input_sf, swizzled_input_sf,
+                             swiglu_alpha, swiglu_beta, swiglu_limit, tp_size,
+                             tp_rank, ep_size, ep_rank, cluster_size,
+                             cluster_rank, use_all_to_all, min_latency_mode,
+                             self.gemm_tactics, activation_type,
+                             unpadded_hidden_size, tuner_num_tokens, None)
+        else:
+            output = run_moe(
+                x,
+                token_selected_slots,
+                token_final_scales,
+                w3_w1_weight.view(weight_dtype),
+                w3_w1_bias,
+                w2_weight.view(weight_dtype),
+                w2_bias,
+                quant_scales,
+                input_sf,
+                swizzled_input_sf,
+                swiglu_alpha,
+                swiglu_beta,
+                swiglu_limit,
+                tp_size,
+                tp_rank,
+                ep_size,
+                ep_rank,
+                cluster_size,
+                cluster_rank,
+                use_all_to_all,
+                min_latency_mode,
+                self.gemm_tactics,
+                activation_type,
+                unpadded_hidden_size,
+                tuner_num_tokens,
+                None,
+                use_dynamic_fc2_scale,
+                # Routed-expert LoRA args, unused on this op path.
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                0)
 
         # Return output based on latency mode
         return output if min_latency_mode else [output]

--- a/tensorrt_llm/_torch/peft/lora/moe_layout.py
+++ b/tensorrt_llm/_torch/peft/lora/moe_layout.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Helpers for assembling routed-expert (per-expert) MoE LoRA adapters.
+
+Each expert gets its own (A, B) low-rank pair; the underlying MoE kernel
+offsets both A and B pointers by `expert_index * dim * rank` to read the
+per-expert slice. These utilities are used by the MoE LoRA unit tests to
+generate synthetic adapters and a reference forward pass.
+"""
+
+from typing import Dict, List, Optional
+
+import torch
+
+# Routed-expert MoE LoRA modules.
+MOE_LORA_MODULES: List[str] = ["moe_h_to_4h", "moe_4h_to_h", "moe_gate"]
+
+
+def make_per_expert_lora(
+    num_experts: int,
+    rank: int,
+    in_dim: int,
+    out_dim: int,
+    *,
+    dtype: torch.dtype = torch.bfloat16,
+    device: torch.device = torch.device("cpu"),
+    seed: Optional[int] = None,
+) -> Dict[str, torch.Tensor]:
+    """Generate a per-expert (A, B) LoRA tensor pair for an MoE module.
+
+    Returns shapes `A: [E, rank, in_dim]` and `B: [E, out_dim, rank]`, with an
+    independent low-rank pair per expert, suitable for `torch.stack(...)` in
+    `tensorrt_llm/lora_manager.py`.
+
+    Args:
+        num_experts: number of experts in this MoE layer.
+        rank: LoRA rank for this module.
+        in_dim: input hidden size (e.g. `hidden_size` for moe_h_to_4h).
+        out_dim: output hidden size (e.g. `intermediate_size` for moe_h_to_4h).
+        dtype: tensor dtype.
+        device: tensor device.
+        seed: optional torch RNG seed for deterministic generation.
+
+    Returns:
+        Dict with keys "A" (shape [E, rank, in_dim]) and "B" (shape [E, out_dim, rank]).
+    """
+    if seed is not None:
+        gen = torch.Generator(device=device).manual_seed(seed)
+    else:
+        gen = None
+
+    def _randn(*shape):
+        return torch.randn(*shape, dtype=dtype, device=device, generator=gen)
+
+    a = _randn(num_experts, rank, in_dim)
+    b = _randn(num_experts, out_dim, rank)
+    return {"A": a, "B": b}
+
+
+def reference_moe_lora_delta(
+    a_stacked: torch.Tensor,
+    b_stacked: torch.Tensor,
+    x: torch.Tensor,
+    token_to_expert: torch.Tensor,
+    *,
+    scale: float = 1.0,
+) -> torch.Tensor:
+    """Compute the reference LoRA delta `delta[t] = scale * (B[e_t] @ A[e_t] @ x[t])`
+    for a routed MoE layer, in eager PyTorch.
+
+    This is used by unit tests to check the fused MoE LoRA op against a
+    straightforward per-expert reference, with `a_stacked`/`b_stacked` given
+    in the `[E, ...]` stacked layout.
+
+    Args:
+        a_stacked: `[E, rank, in_dim]`
+        b_stacked: `[E, out_dim, rank]`
+        x:         `[num_tokens, in_dim]`
+        token_to_expert: `[num_tokens]` int tensor of expert indices.
+        scale: LoRA scale factor (`alpha / rank` for vanilla LoRA, `alpha / sqrt(rank)`
+            for rs-LoRA).
+
+    Returns:
+        Tensor of shape `[num_tokens, out_dim]`.
+    """
+    num_tokens = x.shape[0]
+    out_dim = b_stacked.shape[1]
+    output = torch.zeros(num_tokens, out_dim, dtype=x.dtype, device=x.device)
+    for t in range(num_tokens):
+        e = int(token_to_expert[t].item())
+        # (rank, in) @ (in,) -> (rank,)
+        mid = a_stacked[e] @ x[t]
+        # (out, rank) @ (rank,) -> (out,)
+        output[t] = scale * (b_stacked[e] @ mid)
+    return output
+
+
+def reference_swiglu_moe_lora(
+    x: torch.Tensor,
+    w3_w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_scores: torch.Tensor,
+    *,
+    fc1_a: torch.Tensor,
+    fc1_b: torch.Tensor,
+    gated_a: torch.Tensor,
+    gated_b: torch.Tensor,
+    fc2_a: torch.Tensor,
+    fc2_b: torch.Tensor,
+    scale: float = 1.0,
+) -> torch.Tensor:
+    """Hand-written eager PyTorch reference for a routed-expert SwiGLU MoE layer
+    with LoRA on all three projections.
+
+    Mirrors the math performed by `torch.ops.trtllm.fused_moe` when called
+    with the per-expert weight layout used by the unit tests:
+
+      * `w3_w1` packs the two FC1 GEMMs as `[E, 2 * inter_size, hidden]`
+        with the `up` (linear / non-silu) half at offset `[0, inter)` and
+        the `gate` (silu) half at offset `[inter, 2 * inter)`. This
+        matches the layout the kernel reads in `doActivationKernel`
+        (`moe_kernels.cu`: `linear_value = gemm_result[..0, inter)`,
+        `gate_value = gemm_result[..inter, 2 * inter)`,
+        `out = silu(gate_value) * linear_value`).
+      * `moe_h_to_4h` LoRA (passed via `fc1_*`) is added to the **gate**
+        half (silu side); `moe_gate` LoRA (`gated_*`) is added to the
+        **up** half (linear side). This matches the fan-out in
+        `CutlassMoeFCRunner::loraFC1`: `lora_gated_out` writes at offset
+        0 (linear/up) and `lora_fc1_result` writes at offset
+        `inter_size` (gate/silu).
+      * `moe_4h_to_h` LoRA (`fc2_*`) is added to the FC2 output before
+        the top-k weighted finalize sum.
+
+    The whole computation is run in fp32 internally to avoid the reference
+    itself being subject to bf16 reduction noise; the result is cast back to
+    `x.dtype` at the end.
+
+    Args:
+        x: `[num_tokens, hidden_size]` activations.
+        w3_w1: `[num_experts, 2 * inter_size, hidden_size]` packed FC1
+            weights with up half at `[0, inter)` and gate half at
+            `[inter, 2 * inter)`.
+        w2: `[num_experts, hidden_size, inter_size]` FC2 weights.
+        topk_ids: `[num_tokens, top_k]` int tensor of expert indices.
+        topk_scores: `[num_tokens, top_k]` float32 weights (already
+            normalized; the kernel multiplies the per-expert FC2 output by
+            these in the finalize step).
+        fc1_a / fc1_b: `moe_h_to_4h` (gate-side, silu) LoRA matrices,
+            `[E, rank, hidden]` and `[E, inter, rank]`.
+        gated_a / gated_b: `moe_gate` (up-side, linear) LoRA matrices,
+            `[E, rank, hidden]` and `[E, inter, rank]`.
+        fc2_a / fc2_b: `moe_4h_to_h` (down) LoRA matrices,
+            `[E, rank, inter]` and `[E, hidden, rank]`.
+        scale: Scalar applied uniformly to all three LoRA branches. Matches
+            the kernel's behavior of forwarding adapter A/B as-is (the
+            kernel itself does not multiply by an alpha factor; any alpha
+            scaling is expected to have been folded into the adapter at load
+            time).
+
+    Returns:
+        `[num_tokens, hidden_size]` tensor in `x.dtype`.
+    """
+    num_tokens, hidden_size = x.shape
+    num_experts, two_inter, hidden_check = w3_w1.shape
+    assert hidden_check == hidden_size, (
+        f"w3_w1 hidden dim mismatch: {hidden_check} vs {hidden_size}"
+    )
+    assert two_inter % 2 == 0, f"w3_w1 second dim must be 2 * inter_size, got {two_inter}"
+    inter_size = two_inter // 2
+    top_k = topk_ids.shape[-1]
+    out_dtype = x.dtype
+
+    f32 = torch.float32
+    x32 = x.to(f32)
+    # Up (linear, no silu) is the FIRST half; gate (silu) is the SECOND half.
+    w_up = w3_w1[:, :inter_size, :].to(f32)
+    w_gate = w3_w1[:, inter_size:, :].to(f32)
+    w_down = w2.to(f32)
+
+    fc1_a32 = fc1_a.to(f32)
+    fc1_b32 = fc1_b.to(f32)
+    gated_a32 = gated_a.to(f32)
+    gated_b32 = gated_b.to(f32)
+    fc2_a32 = fc2_a.to(f32)
+    fc2_b32 = fc2_b.to(f32)
+    scores32 = topk_scores.to(f32)
+
+    silu = torch.nn.functional.silu
+    out32 = torch.zeros(num_tokens, hidden_size, dtype=f32, device=x.device)
+
+    for t in range(num_tokens):
+        xt = x32[t]
+        for k in range(top_k):
+            e = int(topk_ids[t, k].item())
+            w = float(scores32[t, k].item())
+
+            gate_lin = w_gate[e] @ xt
+            gate_lora = scale * (fc1_b32[e] @ (fc1_a32[e] @ xt))
+            gate_v = gate_lin + gate_lora
+
+            up_lin = w_up[e] @ xt
+            up_lora = scale * (gated_b32[e] @ (gated_a32[e] @ xt))
+            up_v = up_lin + up_lora
+
+            inter_v = silu(gate_v) * up_v
+
+            down_lin = w_down[e] @ inter_v
+            down_lora = scale * (fc2_b32[e] @ (fc2_a32[e] @ inter_v))
+            down_v = down_lin + down_lora
+
+            out32[t] += w * down_v
+
+    return out32.to(out_dtype)

--- a/tensorrt_llm/_torch/peft/lora/validation.py
+++ b/tensorrt_llm/_torch/peft/lora/validation.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Validation helpers for routed-expert (MoE) LoRA.
+
+MoE LoRA is supported only on the Cutlass backend with unquantized fp16/bf16
+base weights. This module provides a single helper, `check_moe_lora_supported`,
+that callers (typically the MoE factory in `create_moe.py`) can invoke at
+construction time so that unsupported combinations fail loudly instead of
+silently dropping the LoRA contribution at runtime.
+
+Runtime-only rejections (min-latency mode, alltoall, FP4 base, CUDA-graph
+without slot pointers) are enforced in the C++ thop / runtime call paths and
+are NOT re-checked here.
+"""
+
+from typing import Iterable, Optional, Set
+
+from tensorrt_llm.lora_helper import LoraConfig
+
+# TRTLLM module names that map to routed-expert MoE projections.
+MOE_LORA_MODULE_NAMES: Set[str] = {"moe_h_to_4h", "moe_4h_to_h", "moe_gate"}
+
+
+def _normalize_targets(lora_target_modules: Iterable[str]) -> Set[str]:
+    return {name.lower() for name in lora_target_modules or []}
+
+
+def has_moe_lora_targets(lora_config: Optional[LoraConfig]) -> bool:
+    """Return True iff `lora_config` requests LoRA on any routed-expert MoE module."""
+    if lora_config is None:
+        return False
+    return bool(
+        MOE_LORA_MODULE_NAMES
+        & _normalize_targets(getattr(lora_config, "lora_target_modules", []) or [])
+    )
+
+
+def check_moe_lora_supported(
+    *,
+    moe_backend_name: str,
+    lora_config: Optional[LoraConfig],
+    quant_config,
+    layer_idx: Optional[int] = None,
+) -> None:
+    """Raise `ValueError` if a routed-expert MoE LoRA cannot run on the chosen
+    backend / quant combination.
+
+    Args:
+        moe_backend_name: The resolved `moe_backend` string (e.g. "CUTLASS",
+            "WIDEEP", "TRTLLM"). Comparison is case-insensitive.
+        lora_config: The model's `LoraConfig`, or None.
+        quant_config: The model's `QuantConfig`, or None. We only reject when
+            the layer is actually quantized (`quant_mode.has_any_quant`).
+        layer_idx: Optional layer index for diagnostic messages.
+
+    Constraints:
+        - MoE backend MUST be CUTLASS.
+        - Base weight quantization MUST be off (no FP8 / FP4 / INT8 / INT4 / W4A8 ...).
+
+    Other constraints (alltoall, min-latency, FP4, CUDA-graph) are enforced at
+    runtime; we do not pre-check them here because they depend on per-call
+    state that isn't available at factory time.
+    """
+    if not has_moe_lora_targets(lora_config):
+        return
+
+    prefix = f"[layer_idx={layer_idx}] " if layer_idx is not None else ""
+
+    if (moe_backend_name or "").upper() != "CUTLASS":
+        raise ValueError(
+            f"{prefix}Routed-expert MoE LoRA requires moe_backend='CUTLASS'; got "
+            f"moe_backend={moe_backend_name!r}. Disable LoRA on MoE modules "
+            f"(remove {sorted(MOE_LORA_MODULE_NAMES)} from "
+            "lora_config.lora_target_modules) or switch to the Cutlass MoE backend."
+        )
+
+    if quant_config is not None:
+        quant_mode = getattr(quant_config, "quant_mode", None)
+        is_quantized = False
+        if quant_mode is not None and hasattr(quant_mode, "has_any_quant"):
+            try:
+                is_quantized = bool(quant_mode.has_any_quant(exclude_kv_cache=True))
+            except TypeError:
+                # Older signatures may not accept the kwarg; fall back.
+                is_quantized = bool(quant_mode.has_any_quant())
+        if is_quantized:
+            raise ValueError(
+                f"{prefix}Routed-expert MoE LoRA only supports unquantized "
+                f"fp16/bf16 base weights; got quant_mode={quant_mode}. "
+                "FP8/FP4/INT4/INT8 base weights combined with MoE LoRA are not "
+                "supported."
+            )

--- a/tests/unittest/_torch/lora/test_moe_layout.py
+++ b/tests/unittest/_torch/lora/test_moe_layout.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the MoE LoRA layout helpers.
+
+These tests are CPU-only and exercise the synthetic-adapter generator that the
+end-to-end multi-LoRA tests will use.
+"""
+
+import torch
+
+from tensorrt_llm._torch.peft.lora.moe_layout import (
+    MOE_LORA_MODULES,
+    make_per_expert_lora,
+    reference_moe_lora_delta,
+)
+
+
+def test_module_list_complete():
+    # Sanity check: the canonical module names match the validator's set.
+    assert set(MOE_LORA_MODULES) == {"moe_h_to_4h", "moe_4h_to_h", "moe_gate"}
+
+
+def test_make_per_expert_lora_shapes_per_expert():
+    adapter = make_per_expert_lora(num_experts=4, rank=8, in_dim=64, out_dim=128, seed=0)
+    assert adapter["A"].shape == (4, 8, 64)
+    assert adapter["B"].shape == (4, 128, 8)
+    # Expert slices must be independent (per-expert noise).
+    assert not torch.allclose(adapter["A"][0], adapter["A"][1])
+    assert not torch.allclose(adapter["B"][0], adapter["B"][1])
+
+
+def test_make_per_expert_lora_seed_reproducible():
+    a1 = make_per_expert_lora(2, 4, 8, 8, seed=42)
+    a2 = make_per_expert_lora(2, 4, 8, 8, seed=42)
+    torch.testing.assert_close(a1["A"], a2["A"])
+    torch.testing.assert_close(a1["B"], a2["B"])
+
+
+def test_reference_moe_lora_delta_per_expert():
+    torch.manual_seed(0)
+    num_experts = 3
+    rank = 4
+    in_dim = 16
+    out_dim = 8
+    num_tokens = 5
+
+    adapter = make_per_expert_lora(
+        num_experts=num_experts,
+        rank=rank,
+        in_dim=in_dim,
+        out_dim=out_dim,
+        dtype=torch.float32,
+        seed=7,
+    )
+    x = torch.randn(num_tokens, in_dim, dtype=torch.float32)
+    token_to_expert = torch.tensor([0, 1, 2, 0, 1], dtype=torch.int32)
+
+    delta = reference_moe_lora_delta(adapter["A"], adapter["B"], x, token_to_expert)
+    assert delta.shape == (num_tokens, out_dim)
+    # Spot-check token 0: should equal B[0] @ A[0] @ x[0].
+    expected_t0 = adapter["B"][0] @ (adapter["A"][0] @ x[0])
+    torch.testing.assert_close(delta[0], expected_t0)
+
+    # Scale factor propagates linearly.
+    delta_scaled = reference_moe_lora_delta(
+        adapter["A"], adapter["B"], x, token_to_expert, scale=2.0
+    )
+    torch.testing.assert_close(delta_scaled[0], 2.0 * expected_t0)

--- a/tests/unittest/_torch/lora/test_moe_lora_extract.py
+++ b/tests/unittest/_torch/lora/test_moe_lora_extract.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only unit tests for CutlassFusedMoE._extract_moe_lora_tensors.
+
+This function maps the per-layer lora_params dict (keyed by LoraModuleType)
+onto the fc1, gated, and fc2 kwargs the fused MoE op expects. The op-level
+tests pass fc1 and gated tensors directly and do not exercise this mapping, so
+it is tested here in isolation.
+
+The mapping is correctness-critical: SwiGLU is asymmetric (SiLU gate side vs
+linear up side), so swapping moe_h_to_4h and moe_gate between the fc1 and gated
+slots silently produces wrong outputs. The canonical convention (moe_h_to_4h is
+w1 gate/SiLU, moe_gate is w3 up/linear) and the kernel both require:
+moe_h_to_4h to fc1, moe_gate to gated, moe_4h_to_h to fc2.
+"""
+
+import pytest
+import torch
+
+# These imports are pure-Python; skip cleanly if the package layout changes.
+fused_moe_cutlass = pytest.importorskip("tensorrt_llm._torch.modules.fused_moe.fused_moe_cutlass")
+lora_layer = pytest.importorskip("tensorrt_llm._torch.peft.lora.layer")
+
+CutlassFusedMoE = fused_moe_cutlass.CutlassFusedMoE
+LoraModuleType = lora_layer.LoraModuleType
+
+
+class _ExtractStub:
+    """Minimal stand-in for a CutlassFusedMoE instance.
+
+    _extract_moe_lora_tensors only reads self.layer_idx and the class attribute
+    self._MOE_LORA_MODULE_NAMES, so we can drive it via the unbound method
+    without constructing real weights or a GPU layer.
+    """
+
+    _MOE_LORA_MODULE_NAMES = CutlassFusedMoE._MOE_LORA_MODULE_NAMES
+
+    def __init__(self, layer_idx=0):
+        self.layer_idx = layer_idx
+
+
+def _extract(layer_idx, lora_params):
+    return CutlassFusedMoE._extract_moe_lora_tensors(_ExtractStub(layer_idx), lora_params)
+
+
+def _module_entry(rank: int, a_ptr: int, b_ptr: int, num_seqs: int = 1):
+    """Build a single module's lora_params entry with distinctive values."""
+    return {
+        "adapter_size": torch.full((num_seqs,), rank, dtype=torch.int32),
+        "weight_pointers": torch.tensor([[a_ptr, b_ptr, 0]] * num_seqs, dtype=torch.int64),
+    }
+
+
+def _make_lora_params(layer_idx, modules, num_seqs=1):
+    """Assemble a lora_params dict mirroring the runtime layout.
+
+    modules maps a LoraModuleType to (rank, a_ptr, b_ptr).
+    """
+    layer_dict = {
+        int(mod): _module_entry(rank, a_ptr, b_ptr, num_seqs)
+        for mod, (rank, a_ptr, b_ptr) in modules.items()
+    }
+    return {
+        "num_seqs": num_seqs,
+        "host_request_types": torch.zeros(num_seqs, dtype=torch.int32),
+        "prompt_lens_cpu": torch.ones(num_seqs, dtype=torch.int32),
+        layer_idx: layer_dict,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Routing correctness (the swap regression).
+# ---------------------------------------------------------------------------
+
+
+def test_extract_routes_modules_to_correct_kernel_slots():
+    """moe_h_to_4h -> fc1, moe_gate -> gated, moe_4h_to_h -> fc2.
+
+    Each module is given a distinctive (rank, A_ptr, B_ptr) triple so a swap
+    between any two slots is caught.
+    """
+    layer_idx = 0
+    modules = {
+        # (rank, A_ptr, B_ptr)
+        LoraModuleType.MOE_H_TO_4H: (4, 0x1110, 0x1111),  # -> fc1
+        LoraModuleType.MOE_GATE: (8, 0x3330, 0x3331),  # -> gated
+        LoraModuleType.MOE_4H_TO_H: (16, 0x2220, 0x2221),  # -> fc2
+    }
+    out = _extract(layer_idx, _make_lora_params(layer_idx, modules))
+    assert out is not None
+
+    # fc1 must carry moe_h_to_4h (gate / SiLU side).
+    assert int(out["fc1_lora_ranks"][0]) == 4
+    assert out["fc1_lora_weight_ptrs"][0].tolist() == [0x1110, 0x1111, 0]
+
+    # gated must carry moe_gate (up / linear side).
+    assert int(out["gated_lora_ranks"][0]) == 8
+    assert out["gated_lora_weight_ptrs"][0].tolist() == [0x3330, 0x3331, 0]
+
+    # fc2 must carry moe_4h_to_h (down projection).
+    assert int(out["fc2_lora_ranks"][0]) == 16
+    assert out["fc2_lora_weight_ptrs"][0].tolist() == [0x2220, 0x2221, 0]
+
+    # lora_max_low_rank is the max rank across the active modules.
+    assert out["lora_max_low_rank"] == 16
+
+
+def test_extract_does_not_swap_fc1_and_gated():
+    """Guard that moe_h_to_4h does not land in the gated slot and moe_gate does
+    not land in the fc1 slot."""
+    layer_idx = 2
+    modules = {
+        LoraModuleType.MOE_H_TO_4H: (5, 0xAAA0, 0xAAA1),
+        LoraModuleType.MOE_GATE: (6, 0xBBB0, 0xBBB1),
+        LoraModuleType.MOE_4H_TO_H: (7, 0xCCC0, 0xCCC1),
+    }
+    out = _extract(layer_idx, _make_lora_params(layer_idx, modules))
+    # A swap would route moe_h_to_4h pointers into the gated slot.
+    assert out["gated_lora_weight_ptrs"][0].tolist() != [0xAAA0, 0xAAA1, 0]
+    assert out["fc1_lora_weight_ptrs"][0].tolist() != [0xBBB0, 0xBBB1, 0]
+
+
+# ---------------------------------------------------------------------------
+# None / no-op cases.
+# ---------------------------------------------------------------------------
+
+
+def test_extract_none_params_returns_none():
+    assert _extract(0, None) is None
+    assert _extract(0, {}) is None
+
+
+def test_extract_no_layer_entry_returns_none():
+    # lora_params exists but has nothing for this layer_idx.
+    params = _make_lora_params(0, {LoraModuleType.MOE_H_TO_4H: (4, 0x10, 0x11)})
+    assert _extract(layer_idx=99, lora_params=params) is None
+
+
+def test_extract_attention_only_returns_none():
+    # A layer entry that only has (hypothetical) attention modules -> no MoE.
+    layer_idx = 0
+    params = {
+        "num_seqs": 1,
+        "host_request_types": torch.zeros(1, dtype=torch.int32),
+        "prompt_lens_cpu": torch.ones(1, dtype=torch.int32),
+        layer_idx: {
+            int(LoraModuleType.ATTENTION_Q): _module_entry(4, 0x10, 0x11),
+        },
+    }
+    assert _extract(layer_idx, params) is None
+
+
+# ---------------------------------------------------------------------------
+# Mandatory-module enforcement.
+# ---------------------------------------------------------------------------
+
+
+def test_extract_requires_fc1_module():
+    """fc1 slot (moe_h_to_4h) is mandatory: providing only gated + fc2 raises."""
+    layer_idx = 0
+    modules = {
+        LoraModuleType.MOE_GATE: (8, 0x30, 0x31),
+        LoraModuleType.MOE_4H_TO_H: (16, 0x20, 0x21),
+    }
+    with pytest.raises(ValueError, match="moe_h_to_4h"):
+        _extract(layer_idx, _make_lora_params(layer_idx, modules))
+
+
+def test_extract_requires_fc2_module():
+    """fc2 slot (moe_4h_to_h) is mandatory: providing only fc1 + gated raises."""
+    layer_idx = 0
+    modules = {
+        LoraModuleType.MOE_H_TO_4H: (4, 0x10, 0x11),
+        LoraModuleType.MOE_GATE: (8, 0x30, 0x31),
+    }
+    with pytest.raises(ValueError, match="moe_4h_to_h"):
+        _extract(layer_idx, _make_lora_params(layer_idx, modules))
+
+
+def test_extract_gated_optional_when_fc1_and_fc2_present():
+    """Without moe_gate, gated_* must be None but fc1/fc2 still populated."""
+    layer_idx = 0
+    modules = {
+        LoraModuleType.MOE_H_TO_4H: (4, 0x10, 0x11),
+        LoraModuleType.MOE_4H_TO_H: (16, 0x20, 0x21),
+    }
+    out = _extract(layer_idx, _make_lora_params(layer_idx, modules))
+    assert out is not None
+    assert out["gated_lora_ranks"] is None
+    assert out["gated_lora_weight_ptrs"] is None
+    assert int(out["fc1_lora_ranks"][0]) == 4
+    assert int(out["fc2_lora_ranks"][0]) == 16

--- a/tests/unittest/_torch/lora/test_moe_lora_model_path.py
+++ b/tests/unittest/_torch/lora/test_moe_lora_model_path.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Model-path plumbing tests for routed-expert MoE LoRA.
+
+The op-level tests exercise the fused_moe op and _extract_moe_lora_tensors in
+isolation, so they cannot catch a regression where lora_params never reaches
+the routed-expert call in the real model.forward to self.experts to
+CutlassFusedMoE.run_moe path.
+
+These CPU-only tests (no GPU or built C++ op required) assert, at each hop,
+that a non-empty lora_params is forwarded:
+
+  1. QwenMoE.forward to the routed self.experts call (legacy wrapper).
+  2. ConfigurableMoE.forward_impl to scheduler.forward (the default
+     ENABLE_CONFIGURABLE_MOE=1 path).
+  3. ExternalCommMoEScheduler._get_backend_kwargs to the CutlassFusedMoE
+     run_moe kwargs, and not to backends that cannot carry LoRA.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.models.modeling_qwen_moe import QwenMoE
+from tensorrt_llm._torch.modules.fused_moe.configurable_moe import ConfigurableMoE
+from tensorrt_llm._torch.modules.fused_moe.fused_moe_cutlass import CutlassFusedMoE
+from tensorrt_llm._torch.modules.fused_moe.fused_moe_deepgemm import DeepGemmFusedMoE
+from tensorrt_llm._torch.modules.fused_moe.moe_scheduler import ExternalCommMoEScheduler
+from tensorrt_llm._torch.peft.lora.layer import LoraModuleType
+
+# A unique sentinel so the assertions can verify object identity rather than
+# mere truthiness; any drop/replace along the chain fails the identity check.
+_LORA_PARAMS_SENTINEL = {"num_seqs": 1, "_marker": object()}
+
+
+def test_qwen_moe_forward_passes_lora_params_to_routed_experts():
+    """QwenMoE.forward must forward lora_params to the routed self.experts
+    call, not only to the shared expert."""
+    num_tokens, hidden_dim = 4, 8
+
+    hidden_states = torch.randn(num_tokens, hidden_dim)
+    router_logits = torch.randn(num_tokens, 2)
+    expert_out = torch.randn(num_tokens, hidden_dim)
+    shared_out = torch.randn(num_tokens, hidden_dim)
+
+    experts = MagicMock(return_value=expert_out)
+
+    # Call the unbound method against a lightweight stand-in so we do not need
+    # to construct real weights or CUDA streams.
+    fake_self = SimpleNamespace(
+        hidden_dim=hidden_dim,
+        gate=MagicMock(return_value=router_logits),
+        experts=experts,
+        shared_expert=MagicMock(return_value=shared_out),
+        shared_expert_gate=MagicMock(return_value=torch.zeros(num_tokens, 1)),
+    )
+    attn_metadata = SimpleNamespace(all_rank_num_tokens=[num_tokens])
+
+    QwenMoE.forward(
+        fake_self,
+        hidden_states,
+        attn_metadata,
+        lora_params=_LORA_PARAMS_SENTINEL,
+    )
+
+    experts.assert_called_once()
+    assert experts.call_args.kwargs.get("lora_params") is _LORA_PARAMS_SENTINEL, (
+        "QwenMoE.forward dropped lora_params on the routed-expert call; "
+        "routed-expert MoE LoRA would be silently disabled."
+    )
+
+
+def test_configurable_moe_forward_impl_forwards_lora_params_to_scheduler():
+    """ConfigurableMoE.forward_impl must forward lora_params to the scheduler
+    so routed-expert MoE LoRA is not dropped on the default
+    ENABLE_CONFIGURABLE_MOE=1 path."""
+    x = torch.randn(4, 8)
+    router_logits = torch.randn(4, 2)
+
+    scheduler = MagicMock()
+    scheduler.forward = MagicMock(return_value=torch.zeros_like(x))
+
+    fake_self = SimpleNamespace(
+        scheduler=scheduler,
+        enable_dwdp=False,
+        repeat_idx=0,
+        repeat_count=1,
+    )
+
+    ConfigurableMoE.forward_impl(
+        fake_self,
+        x,
+        router_logits,
+        lora_params=_LORA_PARAMS_SENTINEL,
+    )
+
+    scheduler.forward.assert_called_once()
+    assert scheduler.forward.call_args.kwargs.get("lora_params") is _LORA_PARAMS_SENTINEL, (
+        "ConfigurableMoE.forward_impl dropped lora_params before the scheduler; "
+        "routed-expert MoE LoRA would be silently disabled on the default path."
+    )
+
+
+def _make_external_comm_scheduler(backend_cls):
+    """Build an ExternalCommMoEScheduler whose moe.backend is an uninitialized
+    instance of backend_cls, sufficient for _get_backend_kwargs class dispatch
+    without constructing weights."""
+    backend = backend_cls.__new__(backend_cls)
+    moe = SimpleNamespace(
+        backend=backend,
+        comm=None,
+        enable_alltoall=False,
+        mapping=SimpleNamespace(tp_size=1),
+        routing_method=SimpleNamespace(top_k=2),
+    )
+    scheduler = ExternalCommMoEScheduler.__new__(ExternalCommMoEScheduler)
+    scheduler.moe = moe
+    return scheduler
+
+
+def test_scheduler_threads_lora_params_to_cutlass_run_moe_kwargs():
+    """_get_backend_kwargs must thread lora_params into the
+    CutlassFusedMoE.run_moe kwargs."""
+    scheduler = _make_external_comm_scheduler(CutlassFusedMoE)
+
+    kwargs = scheduler._get_backend_kwargs(
+        output_dtype=torch.bfloat16,
+        lora_params=_LORA_PARAMS_SENTINEL,
+    )
+
+    assert kwargs.get("lora_params") is _LORA_PARAMS_SENTINEL, (
+        "Scheduler dropped lora_params before CutlassFusedMoE.run_moe; "
+        "routed-expert MoE LoRA would be silently disabled."
+    )
+
+
+def test_scheduler_does_not_thread_lora_params_to_non_cutlass_backend():
+    """Only CutlassFusedMoE.run_moe accepts lora_params. Other backends must
+    not receive it, since it is not in their run_moe signature."""
+    scheduler = _make_external_comm_scheduler(DeepGemmFusedMoE)
+
+    kwargs = scheduler._get_backend_kwargs(
+        output_dtype=torch.bfloat16,
+        lora_params=_LORA_PARAMS_SENTINEL,
+    )
+
+    assert "lora_params" not in kwargs, (
+        "lora_params must only be forwarded to CutlassFusedMoE.run_moe; "
+        f"DeepGemmFusedMoE.run_moe does not accept it. Got kwargs: {list(kwargs)}"
+    )
+
+
+def _moe_lora_params_for_layer(layer_idx):
+    """A minimal lora_params carrying a routed-expert MoE module (moe_h_to_4h)
+    for layer_idx, enough for _moe_lora_active."""
+    module_id = int(LoraModuleType.from_string("moe_h_to_4h"))
+    return {
+        "num_seqs": 1,
+        layer_idx: {module_id: {"adapter_size": None, "weight_pointers": None}},
+    }
+
+
+def test_cutlass_moe_lora_active_detects_layer_modules():
+    """_moe_lora_active is the predicate the multi-chunk guard relies on: True
+    only when this layer has a routed-expert MoE LoRA module."""
+    backend = CutlassFusedMoE.__new__(CutlassFusedMoE)
+    backend.layer_idx = 3
+
+    assert backend._moe_lora_active(_moe_lora_params_for_layer(3)) is True
+    # No MoE modules for this layer, or empty params, means inactive.
+    assert backend._moe_lora_active(_moe_lora_params_for_layer(5)) is False
+    assert backend._moe_lora_active(None) is False
+    assert backend._moe_lora_active({"num_seqs": 1}) is False
+
+
+def test_scheduler_rejects_multichunk_with_moe_lora():
+    """The ConfigurableMoE scheduler must reject multi-chunk execution when
+    routed-expert MoE LoRA is active, with an actionable message rather than a
+    deep C++ kernel failure."""
+    backend = CutlassFusedMoE.__new__(CutlassFusedMoE)
+    backend.layer_idx = 0
+
+    moe = SimpleNamespace(
+        backend=backend,
+        calculate_num_chunks=lambda *_args, **_kw: 2,
+    )
+    scheduler = ExternalCommMoEScheduler.__new__(ExternalCommMoEScheduler)
+    scheduler.moe = moe
+
+    x = torch.randn(8, 4)
+    router_logits = torch.randn(8, 2)
+
+    with pytest.raises(NotImplementedError, match="multi-chunk"):
+        scheduler.forward(
+            x,
+            router_logits,
+            do_finalize=True,
+            output_dtype=torch.bfloat16,
+            all_rank_num_tokens=None,
+            use_dp_padding=False,
+            lora_params=_moe_lora_params_for_layer(0),
+        )

--- a/tests/unittest/_torch/lora/test_moe_lora_op.py
+++ b/tests/unittest/_torch/lora/test_moe_lora_op.py
@@ -1,0 +1,1040 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end smoke tests for the routed-expert MoE LoRA path through
+`torch.ops.trtllm.fused_moe`.
+
+These tests require:
+  - CUDA-capable GPU
+  - Built TensorRT-LLM C++ extension (so the `trtllm::fused_moe` op is registered).
+
+They do NOT attempt full numerical equivalence with a hand-written reference
+(SwiGLU + top-k routing makes that involved); instead they verify:
+  1. The op accepts the new LoRA tensors without raising.
+  2. With LoRA tensors present, the output differs from the no-LoRA baseline.
+  3. Per-expert adapters run and match a hand-written PyTorch reference.
+  4. The Python-side rejection (min_latency_mode + LoRA) fires correctly.
+"""
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.peft.lora.moe_layout import make_per_expert_lora, reference_swiglu_moe_lora
+
+_TRTLLM_AVAILABLE = hasattr(torch.ops, "trtllm") and hasattr(torch.ops.trtllm, "fused_moe")
+
+requires_cuda_and_op = pytest.mark.skipif(
+    not torch.cuda.is_available() or not _TRTLLM_AVAILABLE,
+    reason="Requires CUDA and built TensorRT-LLM C++ extension (torch.ops.trtllm.fused_moe).",
+)
+
+
+# ---------- shared fixtures ----------------------------------------------------
+
+
+def _build_base_inputs(num_tokens, hidden_size, inter_size, num_experts, top_k, dtype, device):
+    """Create base MoE inputs (no LoRA)."""
+    torch.manual_seed(0)
+    x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
+    w3_w1 = torch.randn(num_experts, 2 * inter_size, hidden_size, dtype=dtype, device=device) * 0.02
+    w2 = torch.randn(num_experts, hidden_size, inter_size, dtype=dtype, device=device) * 0.02
+    logits = torch.randn(num_tokens, num_experts, dtype=torch.float32, device=device)
+    topk_scores, topk_ids = torch.topk(logits, k=top_k, dim=-1)
+    topk_scores = torch.softmax(topk_scores, dim=-1)
+    # token_final_scales must be float32 (see CHECK_INPUT in moeOp.cpp::runMoe).
+    return x, w3_w1, w2, topk_ids.to(torch.int32), topk_scores.to(torch.float32)
+
+
+def _build_lora_request_buffers(
+    num_tokens, fc1_a, fc1_b, fc2_a, fc2_b, rank, lora_max_low_rank=None, gated_a=None, gated_b=None
+):
+    """Pack LoRA into the per-request CPU tensors that the C++ op expects.
+
+    Single-request multi-LoRA disabled here; one request covers all tokens.
+    For gated activations (e.g. SwiGLU) the kernel requires three LoRA
+    modules per layer (fc1 = up, gated = gate, fc2 = down). When `gated_a` /
+    `gated_b` are not provided, they default to the same buffers as fc1.
+    """
+    if lora_max_low_rank is None:
+        lora_max_low_rank = rank
+    if gated_a is None:
+        gated_a = fc1_a
+    if gated_b is None:
+        gated_b = fc1_b
+    num_seqs = 1
+    fc1_ranks = torch.tensor([rank], dtype=torch.int32, device="cpu")
+    fc2_ranks = torch.tensor([rank], dtype=torch.int32, device="cpu")
+    gated_ranks = torch.tensor([rank], dtype=torch.int32, device="cpu")
+    fc1_ptrs = torch.tensor(
+        [[fc1_a.data_ptr(), fc1_b.data_ptr(), 0]], dtype=torch.int64, device="cpu"
+    )
+    fc2_ptrs = torch.tensor(
+        [[fc2_a.data_ptr(), fc2_b.data_ptr(), 0]], dtype=torch.int64, device="cpu"
+    )
+    gated_ptrs = torch.tensor(
+        [[gated_a.data_ptr(), gated_b.data_ptr(), 0]], dtype=torch.int64, device="cpu"
+    )
+    host_request_types = torch.zeros(num_seqs, dtype=torch.int32, device="cpu")
+    host_context_lengths = torch.tensor([num_tokens], dtype=torch.int32, device="cpu")
+    return dict(
+        fc1_lora_ranks=fc1_ranks,
+        fc1_lora_weight_ptrs=fc1_ptrs,
+        fc2_lora_ranks=fc2_ranks,
+        fc2_lora_weight_ptrs=fc2_ptrs,
+        gated_lora_ranks=gated_ranks,
+        gated_lora_weight_ptrs=gated_ptrs,
+        host_request_types=host_request_types,
+        host_context_lengths=host_context_lengths,
+        lora_max_low_rank=lora_max_low_rank,
+    )
+
+
+def _call_fused_moe(x, w3_w1, w2, topk_ids, topk_scores, output_dtype, lora_kwargs=None):
+    common = dict(
+        input=x,
+        token_selected_experts=topk_ids,
+        token_final_scales=topk_scores,
+        fc1_expert_weights=w3_w1,
+        fc1_expert_biases=None,
+        fc2_expert_weights=w2,
+        fc2_expert_biases=None,
+        output_dtype=output_dtype,
+        quant_scales=[],
+    )
+    if lora_kwargs is not None:
+        common.update(lora_kwargs)
+    return torch.ops.trtllm.fused_moe(**common)
+
+
+# ---------- tests --------------------------------------------------------------
+
+
+@requires_cuda_and_op
+def test_moe_per_expert_lora_changes_output():
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, inter_size = 16, 128, 256
+    num_experts, top_k = 4, 2
+    rank = 8
+
+    x, w3_w1, w2, topk_ids, topk_scores = _build_base_inputs(
+        num_tokens, hidden_size, inter_size, num_experts, top_k, dtype, device
+    )
+
+    # Baseline (no LoRA).
+    out_baseline = _call_fused_moe(x, w3_w1, w2, topk_ids, topk_scores, output_dtype=dtype)[0]
+
+    fc1_adapter = make_per_expert_lora(
+        num_experts,
+        rank,
+        hidden_size,
+        inter_size,
+        dtype=dtype,
+        device=device,
+        seed=10,
+    )
+    fc2_adapter = make_per_expert_lora(
+        num_experts,
+        rank,
+        inter_size,
+        hidden_size,
+        dtype=dtype,
+        device=device,
+        seed=11,
+    )
+
+    lora_kwargs = _build_lora_request_buffers(
+        num_tokens,
+        fc1_adapter["A"],
+        fc1_adapter["B"],
+        fc2_adapter["A"],
+        fc2_adapter["B"],
+        rank=rank,
+    )
+
+    out_lora = _call_fused_moe(
+        x, w3_w1, w2, topk_ids, topk_scores, output_dtype=dtype, lora_kwargs=lora_kwargs
+    )[0]
+
+    assert out_lora.shape == out_baseline.shape
+    # The LoRA delta must move the output meaningfully (not bit-equal, not NaN).
+    assert torch.isfinite(out_lora).all()
+    diff = (out_lora.float() - out_baseline.float()).abs().mean().item()
+    assert diff > 1e-3, f"LoRA had no observable effect (mean abs diff={diff})"
+
+
+@requires_cuda_and_op
+def test_moe_lora_rejected_in_min_latency_mode():
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, inter_size = 8, 128, 256
+    num_experts, top_k = 4, 2
+    rank = 4
+
+    x, w3_w1, w2, topk_ids, topk_scores = _build_base_inputs(
+        num_tokens, hidden_size, inter_size, num_experts, top_k, dtype, device
+    )
+
+    fc1_adapter = make_per_expert_lora(
+        num_experts, rank, hidden_size, inter_size, dtype=dtype, device=device, seed=30
+    )
+    fc2_adapter = make_per_expert_lora(
+        num_experts, rank, inter_size, hidden_size, dtype=dtype, device=device, seed=31
+    )
+    lora_kwargs = _build_lora_request_buffers(
+        num_tokens,
+        fc1_adapter["A"],
+        fc1_adapter["B"],
+        fc2_adapter["A"],
+        fc2_adapter["B"],
+        rank=rank,
+    )
+
+    with pytest.raises(RuntimeError, match="MoE LoRA is not supported in min-latency mode"):
+        torch.ops.trtllm.fused_moe(
+            input=x,
+            token_selected_experts=topk_ids,
+            token_final_scales=topk_scores,
+            fc1_expert_weights=w3_w1,
+            fc1_expert_biases=None,
+            fc2_expert_weights=w2,
+            fc2_expert_biases=None,
+            output_dtype=dtype,
+            quant_scales=[],
+            min_latency_mode=True,
+            **lora_kwargs,
+        )
+
+
+@requires_cuda_and_op
+@pytest.mark.parametrize("missing_module", ["fc2", "host_request_types"])
+def test_moe_lora_rejects_incomplete_inputs(missing_module):
+    """Supplying fc1 LoRA but missing fc2 or host_request_types must raise."""
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, inter_size = 8, 128, 256
+    num_experts, top_k = 4, 2
+    rank = 4
+
+    x, w3_w1, w2, topk_ids, topk_scores = _build_base_inputs(
+        num_tokens, hidden_size, inter_size, num_experts, top_k, dtype, device
+    )
+
+    fc1_adapter = make_per_expert_lora(
+        num_experts, rank, hidden_size, inter_size, dtype=dtype, device=device, seed=40
+    )
+    fc2_adapter = make_per_expert_lora(
+        num_experts, rank, inter_size, hidden_size, dtype=dtype, device=device, seed=41
+    )
+    lora_kwargs = _build_lora_request_buffers(
+        num_tokens,
+        fc1_adapter["A"],
+        fc1_adapter["B"],
+        fc2_adapter["A"],
+        fc2_adapter["B"],
+        rank=rank,
+    )
+
+    if missing_module == "fc2":
+        lora_kwargs["fc2_lora_ranks"] = None
+        lora_kwargs["fc2_lora_weight_ptrs"] = None
+    elif missing_module == "host_request_types":
+        lora_kwargs["host_request_types"] = None
+
+    with pytest.raises(RuntimeError):
+        _call_fused_moe(
+            x, w3_w1, w2, topk_ids, topk_scores, output_dtype=dtype, lora_kwargs=lora_kwargs
+        )
+
+
+# -- External-reference parity tests for fused MoE + LoRA -------------------
+#
+# The tests below compare the fused
+# MoE op output against a hand-written PyTorch fp32 reference, which
+# catches reordering / mis-application of LoRA deltas that the same-kernel
+# tests cannot see.
+#
+# Empirically, `make_per_expert_lora` adapters drawn from N(0, 1) produce LoRA deltas
+# many orders of magnitude larger than the base weights at this shape,
+# and the SwiGLU + FC2 path amplifies the resulting intermediates to
+# magnitudes ~1e5 -- at which point bf16 reduction-order noise on a few
+# percent of lanes routinely exceeds an `atol=1.0` budget without there
+# being any kernel correctness bug. The fix is to scale the LoRA adapters
+# down so the legitimate output stays in O(1)-O(10), making `atol=1.0`
+# meaningful relative to bf16 noise. `_LORA_REFERENCE_SCALE` is that knob.
+#
+# If you bump the LoRA scale up here you should expect failures driven by
+# bf16 precision at the larger output range, not real kernel regressions;
+# either widen tolerances proportionally or stay under the threshold above.
+
+# Multiplied into both A and B of every reference-test LoRA adapter, so
+# dW = B@A scales as the square of this constant. Sized empirically so
+# that the most-amplified configuration (all three modules nonzero,
+# distinct adapters) produces output magnitudes O(10) at the
+# `num_tokens=16, hidden=128, inter=256, rank=8` shape used below.
+_LORA_REFERENCE_SCALE = 0.25
+
+
+def _make_per_expert_lora_scaled(*args, **kwargs):
+    """`make_per_expert_lora` followed by an in-place scale of A and B by
+    `_LORA_REFERENCE_SCALE`. See the section header above for the
+    rationale.
+    """
+    adapter = make_per_expert_lora(*args, **kwargs)
+    adapter["A"].mul_(_LORA_REFERENCE_SCALE)
+    adapter["B"].mul_(_LORA_REFERENCE_SCALE)
+    return adapter
+
+
+def _run_eager_vs_reference_check():
+    """Body of `test_moe_lora_eager_matches_pytorch_reference`."""
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, inter_size = 16, 128, 256
+    num_experts, top_k = 4, 2
+    rank = 8
+
+    x, w3_w1, w2, topk_ids, topk_scores = _build_base_inputs(
+        num_tokens, hidden_size, inter_size, num_experts, top_k, dtype, device
+    )
+
+    # Use distinct adapters on the gate/up/down projections so the test is
+    # actually exercising all three LoRA modules independently rather than
+    # relying on the gated-defaults-to-fc1 alias used by the smoke tests.
+    fc1_adapter = _make_per_expert_lora_scaled(
+        num_experts,
+        rank,
+        hidden_size,
+        inter_size,
+        dtype=dtype,
+        device=device,
+        seed=300,
+    )
+    gated_adapter = _make_per_expert_lora_scaled(
+        num_experts,
+        rank,
+        hidden_size,
+        inter_size,
+        dtype=dtype,
+        device=device,
+        seed=301,
+    )
+    fc2_adapter = _make_per_expert_lora_scaled(
+        num_experts,
+        rank,
+        inter_size,
+        hidden_size,
+        dtype=dtype,
+        device=device,
+        seed=302,
+    )
+
+    lora_kwargs = _build_lora_request_buffers(
+        num_tokens,
+        fc1_adapter["A"],
+        fc1_adapter["B"],
+        fc2_adapter["A"],
+        fc2_adapter["B"],
+        rank=rank,
+        gated_a=gated_adapter["A"],
+        gated_b=gated_adapter["B"],
+    )
+
+    out_op = _call_fused_moe(
+        x, w3_w1, w2, topk_ids, topk_scores, output_dtype=dtype, lora_kwargs=lora_kwargs
+    )[0]
+
+    out_ref = reference_swiglu_moe_lora(
+        x,
+        w3_w1,
+        w2,
+        topk_ids,
+        topk_scores,
+        fc1_a=fc1_adapter["A"],
+        fc1_b=fc1_adapter["B"],
+        gated_a=gated_adapter["A"],
+        gated_b=gated_adapter["B"],
+        fc2_a=fc2_adapter["A"],
+        fc2_b=fc2_adapter["B"],
+    )
+
+    assert torch.isfinite(out_op).all(), "fused_moe op produced NaN / Inf with LoRA active"
+    assert torch.isfinite(out_ref).all(), "PyTorch reference produced NaN / Inf"
+
+    op_max_mag = out_op.float().abs().max().item()
+    ref_max_mag = out_ref.float().abs().max().item()
+    abs_diff = (out_op.float() - out_ref.float()).abs()
+    max_abs = abs_diff.max().item()
+    rel_err = max_abs / max(op_max_mag, 1e-12)
+
+    # Always-printed diagnostic: pytest captures stdout and surfaces it on
+    # failure regardless of verbosity flags.
+    print(
+        f"[eager_vs_ref] op_max_mag={op_max_mag:.3e} "
+        f"ref_max_mag={ref_max_mag:.3e} max_abs_diff={max_abs:.3e} "
+        f"rel_err={rel_err:.3e}"
+    )
+
+    torch.testing.assert_close(
+        out_op,
+        out_ref,
+        rtol=5e-2,
+        atol=1.0,
+        msg=lambda m: (
+            f"{m}\nmax_abs_diff={max_abs:.3e}, op_max_mag={op_max_mag:.3e}, "
+            f"ref_max_mag={ref_max_mag:.3e}, rel_err={rel_err:.3e}."
+        ),
+    )
+
+
+@requires_cuda_and_op
+def test_moe_lora_eager_matches_pytorch_reference():
+    """Eager-mode fused MoE + LoRA parity vs an fp32 PyTorch reference at
+    the `num_tokens=16, hidden=128, inter=256, num_experts=4, top_k=2,
+    rank=8, bf16` shape with all three LoRA modules active and distinct.
+
+    Tolerance: `rtol=5e-2, atol=1.0`. LoRA adapters are scaled by
+    `_LORA_REFERENCE_SCALE` so the legitimate output stays in
+    O(1)-O(10); see the section header above for why that matters.
+    """
+    from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
+
+    MoERunner.runner_dict.clear()
+    try:
+        _run_eager_vs_reference_check()
+    finally:
+        MoERunner.runner_dict.clear()
+
+
+# ---------------------------------------------------------------------------
+# Bisection probes for fused MoE + LoRA correctness.
+#
+# These probes complement `test_moe_lora_eager_matches_pytorch_reference`
+# by exercising configurations that isolate parts of the kernel pipeline:
+#
+#   * no-LoRA       -> base FC1 + SwiGLU + FC2 + finalize, no LoRA path.
+#   * zero-LoRA     -> LoRA pipeline fully active but adapter weights zero;
+#                      isolates the pointer expansion / setupLoraWorkspace
+#                      plumbing from the LoRA delta computation itself.
+#   * only-{fc1,gated,fc2} -> exactly one LoRA module nonzero, others zero.
+#                              Pins regressions to a specific module's
+#                              LoRA-IN / LoRA-OUT GEMM and pointer slice.
+#   * pair-* / all-three-aliased -> multi-module configurations exercising
+#                                    cross-module LoRA delta interactions.
+#
+# All probes share the reference test's shape and the same fp32 PyTorch
+# reference, so a regression in any of them either localizes the failing
+# subset or stays masked behind a passing baseline.
+# ---------------------------------------------------------------------------
+
+
+def _run_no_lora_eager_vs_reference_check():
+    """Body of `test_moe_no_lora_eager_matches_pytorch_reference`. Same
+    shape and the same PyTorch fp32 reference as the LoRA test, but the op
+    is invoked WITHOUT the `lora_kwargs` so the entire LoRA pipeline is
+    inactive. Any garbage here pins the regression to the base MoE op,
+    not to the LoRA path.
+    """
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, inter_size = 16, 128, 256
+    num_experts, top_k = 4, 2
+
+    x, w3_w1, w2, topk_ids, topk_scores = _build_base_inputs(
+        num_tokens, hidden_size, inter_size, num_experts, top_k, dtype, device
+    )
+
+    out_op = _call_fused_moe(
+        x, w3_w1, w2, topk_ids, topk_scores, output_dtype=dtype, lora_kwargs=None
+    )[0]
+
+    # Reference WITHOUT LoRA: pass zero-stride zero-rank stand-in adapters so
+    # `reference_swiglu_moe_lora` collapses to plain SwiGLU MoE. We use rank=1
+    # zeros so the reference's dtype/shape promotions all stay valid.
+    rank0 = 1
+    z = torch.zeros
+    fc1_a = z(num_experts, rank0, hidden_size, dtype=dtype, device=device)
+    fc1_b = z(num_experts, inter_size, rank0, dtype=dtype, device=device)
+    gated_a = z(num_experts, rank0, hidden_size, dtype=dtype, device=device)
+    gated_b = z(num_experts, inter_size, rank0, dtype=dtype, device=device)
+    fc2_a = z(num_experts, rank0, inter_size, dtype=dtype, device=device)
+    fc2_b = z(num_experts, hidden_size, rank0, dtype=dtype, device=device)
+
+    out_ref = reference_swiglu_moe_lora(
+        x,
+        w3_w1,
+        w2,
+        topk_ids,
+        topk_scores,
+        fc1_a=fc1_a,
+        fc1_b=fc1_b,
+        gated_a=gated_a,
+        gated_b=gated_b,
+        fc2_a=fc2_a,
+        fc2_b=fc2_b,
+    )
+
+    assert torch.isfinite(out_op).all(), (
+        "fused_moe op produced NaN / Inf in the NO-LoRA configuration"
+    )
+    assert torch.isfinite(out_ref).all(), (
+        "PyTorch reference produced NaN / Inf in the NO-LoRA configuration"
+    )
+
+    op_max_mag = out_op.float().abs().max().item()
+    ref_max_mag = out_ref.float().abs().max().item()
+    abs_diff = (out_op.float() - out_ref.float()).abs()
+    max_abs = abs_diff.max().item()
+    rel_err = max_abs / max(op_max_mag, 1e-12)
+
+    print(
+        f"[no_lora] op_max_mag={op_max_mag:.3e} "
+        f"ref_max_mag={ref_max_mag:.3e} max_abs_diff={max_abs:.3e} "
+        f"rel_err={rel_err:.3e}"
+    )
+    torch.testing.assert_close(out_op, out_ref, rtol=5e-2, atol=1.0)
+
+
+def _run_zero_lora_eager_vs_reference_check():
+    """Body of `test_moe_zero_lora_eager_matches_pytorch_reference`. The
+    LoRA pipeline is fully active (pointer expansion, ranks, etc.) but the
+    adapter weights are zero, so the LoRA delta MUST be zero and the
+    expected output equals the no-LoRA reference. Any garbage here pins the
+    regression to LoRA control flow that runs even when the delta is zero.
+    """
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, inter_size = 16, 128, 256
+    num_experts, top_k = 4, 2
+    rank = 8
+
+    x, w3_w1, w2, topk_ids, topk_scores = _build_base_inputs(
+        num_tokens, hidden_size, inter_size, num_experts, top_k, dtype, device
+    )
+
+    z = torch.zeros
+    fc1_a = z(num_experts, rank, hidden_size, dtype=dtype, device=device)
+    fc1_b = z(num_experts, inter_size, rank, dtype=dtype, device=device)
+    gated_a = z(num_experts, rank, hidden_size, dtype=dtype, device=device)
+    gated_b = z(num_experts, inter_size, rank, dtype=dtype, device=device)
+    fc2_a = z(num_experts, rank, inter_size, dtype=dtype, device=device)
+    fc2_b = z(num_experts, hidden_size, rank, dtype=dtype, device=device)
+
+    lora_kwargs = _build_lora_request_buffers(
+        num_tokens, fc1_a, fc1_b, fc2_a, fc2_b, rank=rank, gated_a=gated_a, gated_b=gated_b
+    )
+
+    out_op = _call_fused_moe(
+        x, w3_w1, w2, topk_ids, topk_scores, output_dtype=dtype, lora_kwargs=lora_kwargs
+    )[0]
+
+    out_ref = reference_swiglu_moe_lora(
+        x,
+        w3_w1,
+        w2,
+        topk_ids,
+        topk_scores,
+        fc1_a=fc1_a,
+        fc1_b=fc1_b,
+        gated_a=gated_a,
+        gated_b=gated_b,
+        fc2_a=fc2_a,
+        fc2_b=fc2_b,
+    )
+
+    assert torch.isfinite(out_op).all(), "fused_moe op produced NaN / Inf with zero-LoRA"
+    assert torch.isfinite(out_ref).all(), "PyTorch reference produced NaN / Inf with zero-LoRA"
+
+    op_max_mag = out_op.float().abs().max().item()
+    ref_max_mag = out_ref.float().abs().max().item()
+    abs_diff = (out_op.float() - out_ref.float()).abs()
+    max_abs = abs_diff.max().item()
+    rel_err = max_abs / max(op_max_mag, 1e-12)
+
+    print(
+        f"[zero_lora] op_max_mag={op_max_mag:.3e} "
+        f"ref_max_mag={ref_max_mag:.3e} max_abs_diff={max_abs:.3e} "
+        f"rel_err={rel_err:.3e}"
+    )
+    torch.testing.assert_close(out_op, out_ref, rtol=5e-2, atol=1.0)
+
+
+@requires_cuda_and_op
+def test_moe_no_lora_eager_matches_pytorch_reference():
+    """Bisection probe: NO LoRA at the same shape as the LoRA reference test.
+    Confirms the base MoE op (FC1 + SwiGLU + FC2 + finalize) is healthy.
+    """
+    from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
+
+    MoERunner.runner_dict.clear()
+    try:
+        _run_no_lora_eager_vs_reference_check()
+    finally:
+        MoERunner.runner_dict.clear()
+
+
+@requires_cuda_and_op
+def test_moe_zero_lora_eager_matches_pytorch_reference():
+    """Bisection probe: LoRA pipeline fully active, adapter weights zero.
+    The LoRA delta is mathematically zero, so the output must equal the
+    no-LoRA reference. Isolates the pointer-expand / setupLoraWorkspace
+    plumbing from the LoRA delta computation itself.
+    """
+    from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
+
+    MoERunner.runner_dict.clear()
+    try:
+        _run_zero_lora_eager_vs_reference_check()
+    finally:
+        MoERunner.runner_dict.clear()
+
+
+# ---------------------------------------------------------------------------
+# Per-module LoRA bisection probes.
+#
+# Each probe activates exactly one LoRA module (others zero). A failure
+# pins the regression to a specific module's LoRA-IN/OUT GEMM, pointer
+# slice, or delta-application path:
+#
+#   * fc1 only   -> moe_h_to_4h LoRA (SwiGLU gate side, silu).
+#   * gated only -> moe_gate    LoRA (SwiGLU up side, linear).
+#   * fc2 only   -> moe_4h_to_h LoRA (down projection).
+#
+# Multiple modules fail simultaneously if the bug lives in the shared
+# LoRA driver / pointer-expansion path rather than a single module.
+# ---------------------------------------------------------------------------
+
+
+def _make_zero_per_expert_lora(num_experts, rank, in_dim, out_dim, dtype, device):
+    """Build a per-expert LoRA pair with the same shape contract as
+    `make_per_expert_lora` (A: `[E, rank, in_dim]`, B: `[E, out_dim, rank]`)
+    but with identically zero values. Used to "disable" a LoRA module while
+    keeping the LoRA pipeline plumbing fully active."""
+    return dict(
+        A=torch.zeros(num_experts, rank, in_dim, dtype=dtype, device=device),
+        B=torch.zeros(num_experts, out_dim, rank, dtype=dtype, device=device),
+    )
+
+
+def _run_per_module_lora_check(active_module: str):
+    """Body of the per-module bisection tests.
+
+    `active_module` is one of `"fc1"`, `"gated"`, `"fc2"`. The
+    selected module is initialized with `_make_per_expert_lora_scaled`
+    (same scale as the reference test); the other two are zero adapters
+    of matching shape, so their LoRA deltas are mathematically zero.
+    """
+    assert active_module in ("fc1", "gated", "fc2"), active_module
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, inter_size = 16, 128, 256
+    num_experts, top_k = 4, 2
+    rank = 8
+
+    x, w3_w1, w2, topk_ids, topk_scores = _build_base_inputs(
+        num_tokens, hidden_size, inter_size, num_experts, top_k, dtype, device
+    )
+
+    if active_module == "fc1":
+        fc1_adapter = _make_per_expert_lora_scaled(
+            num_experts,
+            rank,
+            hidden_size,
+            inter_size,
+            dtype=dtype,
+            device=device,
+            seed=300,
+        )
+    else:
+        fc1_adapter = _make_zero_per_expert_lora(
+            num_experts, rank, hidden_size, inter_size, dtype, device
+        )
+
+    if active_module == "gated":
+        gated_adapter = _make_per_expert_lora_scaled(
+            num_experts,
+            rank,
+            hidden_size,
+            inter_size,
+            dtype=dtype,
+            device=device,
+            seed=301,
+        )
+    else:
+        gated_adapter = _make_zero_per_expert_lora(
+            num_experts, rank, hidden_size, inter_size, dtype, device
+        )
+
+    if active_module == "fc2":
+        fc2_adapter = _make_per_expert_lora_scaled(
+            num_experts,
+            rank,
+            inter_size,
+            hidden_size,
+            dtype=dtype,
+            device=device,
+            seed=302,
+        )
+    else:
+        fc2_adapter = _make_zero_per_expert_lora(
+            num_experts, rank, inter_size, hidden_size, dtype, device
+        )
+
+    lora_kwargs = _build_lora_request_buffers(
+        num_tokens,
+        fc1_adapter["A"],
+        fc1_adapter["B"],
+        fc2_adapter["A"],
+        fc2_adapter["B"],
+        rank=rank,
+        gated_a=gated_adapter["A"],
+        gated_b=gated_adapter["B"],
+    )
+
+    out_op = _call_fused_moe(
+        x, w3_w1, w2, topk_ids, topk_scores, output_dtype=dtype, lora_kwargs=lora_kwargs
+    )[0]
+
+    out_ref = reference_swiglu_moe_lora(
+        x,
+        w3_w1,
+        w2,
+        topk_ids,
+        topk_scores,
+        fc1_a=fc1_adapter["A"],
+        fc1_b=fc1_adapter["B"],
+        gated_a=gated_adapter["A"],
+        gated_b=gated_adapter["B"],
+        fc2_a=fc2_adapter["A"],
+        fc2_b=fc2_adapter["B"],
+    )
+
+    assert torch.isfinite(out_op).all(), (
+        f"fused_moe op produced NaN / Inf with only-{active_module}-LoRA"
+    )
+    assert torch.isfinite(out_ref).all(), (
+        f"PyTorch reference produced NaN / Inf with only-{active_module}-LoRA"
+    )
+
+    op_max_mag = out_op.float().abs().max().item()
+    ref_max_mag = out_ref.float().abs().max().item()
+    abs_diff = (out_op.float() - out_ref.float()).abs()
+    max_abs = abs_diff.max().item()
+    rel_err = max_abs / max(op_max_mag, 1e-12)
+
+    print(
+        f"[only_{active_module}] op_max_mag={op_max_mag:.3e} "
+        f"ref_max_mag={ref_max_mag:.3e} max_abs_diff={max_abs:.3e} "
+        f"rel_err={rel_err:.3e}"
+    )
+    torch.testing.assert_close(out_op, out_ref, rtol=5e-2, atol=1.0)
+
+
+@requires_cuda_and_op
+def test_moe_only_fc1_lora_eager_matches_pytorch_reference():
+    """Per-module bisection: only `moe_h_to_4h` (fc1, gate-side, silu) LoRA
+    is active; `moe_gate` and `moe_4h_to_h` adapters are zeros.
+    """
+    from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
+
+    MoERunner.runner_dict.clear()
+    try:
+        _run_per_module_lora_check("fc1")
+    finally:
+        MoERunner.runner_dict.clear()
+
+
+@requires_cuda_and_op
+def test_moe_only_gated_lora_eager_matches_pytorch_reference():
+    """Per-module bisection: only `moe_gate` (gated, up-side, linear) LoRA
+    is active; `moe_h_to_4h` and `moe_4h_to_h` adapters are zeros.
+    """
+    from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
+
+    MoERunner.runner_dict.clear()
+    try:
+        _run_per_module_lora_check("gated")
+    finally:
+        MoERunner.runner_dict.clear()
+
+
+@requires_cuda_and_op
+def test_moe_only_fc2_lora_eager_matches_pytorch_reference():
+    """Per-module bisection: only `moe_4h_to_h` (fc2, down) LoRA is active;
+    `moe_h_to_4h` and `moe_gate` adapters are zeros.
+    """
+    from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
+
+    MoERunner.runner_dict.clear()
+    try:
+        _run_per_module_lora_check("fc2")
+    finally:
+        MoERunner.runner_dict.clear()
+
+
+# ---------------------------------------------------------------------------
+# Pairwise + alias bisection probes.
+#
+# Multi-module probes covering the cross-module LoRA delta interaction
+# space. The pair tests activate exactly two modules with distinct adapter
+# buffers and zero the third; the aliased test activates all three but
+# aliases `gated` to `fc1` (the default in `_build_lora_request_buffers`,
+# which reuses the fc1 buffers for the gated module).
+#
+#   * pair_fc1_gated_distinct: fc1 + gated distinct, fc2 zero
+#   * pair_fc1_fc2_distinct:   fc1 + fc2 distinct,    gated zero
+#   * pair_gated_fc2_distinct: gated + fc2 distinct,  fc1 zero
+#   * all_three_gated_aliased: all three active, with `gated == fc1`
+# ---------------------------------------------------------------------------
+
+
+def _run_pair_lora_check(active_pair):
+    """Body of the pairwise bisection tests.
+
+    `active_pair` is a 2-tuple of module names from
+    `{"fc1", "gated", "fc2"}`. Both selected modules use
+    `_make_per_expert_lora_scaled` with distinct seeds; the third module
+    is zeros of matching shape so its delta is identically zero.
+    """
+    assert len(active_pair) == 2 and set(active_pair).issubset({"fc1", "gated", "fc2"}), active_pair
+    active_set = set(active_pair)
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, inter_size = 16, 128, 256
+    num_experts, top_k = 4, 2
+    rank = 8
+
+    x, w3_w1, w2, topk_ids, topk_scores = _build_base_inputs(
+        num_tokens, hidden_size, inter_size, num_experts, top_k, dtype, device
+    )
+
+    if "fc1" in active_set:
+        fc1_adapter = _make_per_expert_lora_scaled(
+            num_experts,
+            rank,
+            hidden_size,
+            inter_size,
+            dtype=dtype,
+            device=device,
+            seed=300,
+        )
+    else:
+        fc1_adapter = _make_zero_per_expert_lora(
+            num_experts, rank, hidden_size, inter_size, dtype, device
+        )
+
+    if "gated" in active_set:
+        gated_adapter = _make_per_expert_lora_scaled(
+            num_experts,
+            rank,
+            hidden_size,
+            inter_size,
+            dtype=dtype,
+            device=device,
+            seed=301,
+        )
+    else:
+        gated_adapter = _make_zero_per_expert_lora(
+            num_experts, rank, hidden_size, inter_size, dtype, device
+        )
+
+    if "fc2" in active_set:
+        fc2_adapter = _make_per_expert_lora_scaled(
+            num_experts,
+            rank,
+            inter_size,
+            hidden_size,
+            dtype=dtype,
+            device=device,
+            seed=302,
+        )
+    else:
+        fc2_adapter = _make_zero_per_expert_lora(
+            num_experts, rank, inter_size, hidden_size, dtype, device
+        )
+
+    lora_kwargs = _build_lora_request_buffers(
+        num_tokens,
+        fc1_adapter["A"],
+        fc1_adapter["B"],
+        fc2_adapter["A"],
+        fc2_adapter["B"],
+        rank=rank,
+        gated_a=gated_adapter["A"],
+        gated_b=gated_adapter["B"],
+    )
+
+    out_op = _call_fused_moe(
+        x, w3_w1, w2, topk_ids, topk_scores, output_dtype=dtype, lora_kwargs=lora_kwargs
+    )[0]
+
+    out_ref = reference_swiglu_moe_lora(
+        x,
+        w3_w1,
+        w2,
+        topk_ids,
+        topk_scores,
+        fc1_a=fc1_adapter["A"],
+        fc1_b=fc1_adapter["B"],
+        gated_a=gated_adapter["A"],
+        gated_b=gated_adapter["B"],
+        fc2_a=fc2_adapter["A"],
+        fc2_b=fc2_adapter["B"],
+    )
+
+    pair_label = "+".join(active_pair)
+    assert torch.isfinite(out_op).all(), (
+        f"fused_moe op produced NaN / Inf with pair={pair_label}-LoRA"
+    )
+    assert torch.isfinite(out_ref).all(), (
+        f"PyTorch reference produced NaN / Inf with pair={pair_label}-LoRA"
+    )
+
+    op_max_mag = out_op.float().abs().max().item()
+    ref_max_mag = out_ref.float().abs().max().item()
+    abs_diff = (out_op.float() - out_ref.float()).abs()
+    max_abs = abs_diff.max().item()
+    rel_err = max_abs / max(op_max_mag, 1e-12)
+
+    print(
+        f"[pair={pair_label}] op_max_mag={op_max_mag:.3e} "
+        f"ref_max_mag={ref_max_mag:.3e} max_abs_diff={max_abs:.3e} "
+        f"rel_err={rel_err:.3e}"
+    )
+
+    torch.testing.assert_close(out_op, out_ref, rtol=5e-2, atol=1.0)
+
+
+@requires_cuda_and_op
+def test_moe_pair_fc1_gated_distinct_lora_eager_matches_pytorch_reference():
+    """Pairwise bisection: fc1 + gated active with DISTINCT adapter buffers,
+    fc2 zero.
+    """
+    from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
+
+    MoERunner.runner_dict.clear()
+    try:
+        _run_pair_lora_check(("fc1", "gated"))
+    finally:
+        MoERunner.runner_dict.clear()
+
+
+@requires_cuda_and_op
+def test_moe_pair_fc1_fc2_distinct_lora_eager_matches_pytorch_reference():
+    """Pairwise bisection: fc1 + fc2 active with distinct adapter buffers,
+    gated zero.
+    """
+    from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
+
+    MoERunner.runner_dict.clear()
+    try:
+        _run_pair_lora_check(("fc1", "fc2"))
+    finally:
+        MoERunner.runner_dict.clear()
+
+
+@requires_cuda_and_op
+def test_moe_pair_gated_fc2_distinct_lora_eager_matches_pytorch_reference():
+    """Pairwise bisection: gated + fc2 active with distinct adapter buffers,
+    fc1 zero.
+    """
+    from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
+
+    MoERunner.runner_dict.clear()
+    try:
+        _run_pair_lora_check(("gated", "fc2"))
+    finally:
+        MoERunner.runner_dict.clear()
+
+
+@requires_cuda_and_op
+def test_moe_all_three_lora_with_gated_aliased_to_fc1_eager_matches_pytorch_reference():
+    """Alias probe: all three LoRA modules active, with the gated buffers
+    being the same object as the fc1 buffers (the default in
+    `_build_lora_request_buffers`).
+    """
+    from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
+
+    MoERunner.runner_dict.clear()
+    try:
+        device = torch.device("cuda")
+        dtype = torch.bfloat16
+        num_tokens, hidden_size, inter_size = 16, 128, 256
+        num_experts, top_k = 4, 2
+        rank = 8
+
+        x, w3_w1, w2, topk_ids, topk_scores = _build_base_inputs(
+            num_tokens, hidden_size, inter_size, num_experts, top_k, dtype, device
+        )
+
+        fc1_adapter = _make_per_expert_lora_scaled(
+            num_experts,
+            rank,
+            hidden_size,
+            inter_size,
+            dtype=dtype,
+            device=device,
+            seed=300,
+        )
+        fc2_adapter = _make_per_expert_lora_scaled(
+            num_experts,
+            rank,
+            inter_size,
+            hidden_size,
+            dtype=dtype,
+            device=device,
+            seed=302,
+        )
+
+        # Deliberately do NOT pass gated_*: `_build_lora_request_buffers`
+        # then aliases `gated_a := fc1_a`, `gated_b := fc1_b`, matching the
+        # passing smoke-test pattern.
+        lora_kwargs = _build_lora_request_buffers(
+            num_tokens,
+            fc1_adapter["A"],
+            fc1_adapter["B"],
+            fc2_adapter["A"],
+            fc2_adapter["B"],
+            rank=rank,
+        )
+
+        out_op = _call_fused_moe(
+            x, w3_w1, w2, topk_ids, topk_scores, output_dtype=dtype, lora_kwargs=lora_kwargs
+        )[0]
+
+        out_ref = reference_swiglu_moe_lora(
+            x,
+            w3_w1,
+            w2,
+            topk_ids,
+            topk_scores,
+            fc1_a=fc1_adapter["A"],
+            fc1_b=fc1_adapter["B"],
+            gated_a=fc1_adapter["A"],
+            gated_b=fc1_adapter["B"],
+            fc2_a=fc2_adapter["A"],
+            fc2_b=fc2_adapter["B"],
+        )
+
+        assert torch.isfinite(out_op).all(), (
+            "fused_moe op produced NaN / Inf with gated aliased to fc1"
+        )
+        assert torch.isfinite(out_ref).all(), (
+            "PyTorch reference produced NaN / Inf with gated aliased to fc1"
+        )
+
+        op_max_mag = out_op.float().abs().max().item()
+        ref_max_mag = out_ref.float().abs().max().item()
+        abs_diff = (out_op.float() - out_ref.float()).abs()
+        max_abs = abs_diff.max().item()
+        rel_err = max_abs / max(op_max_mag, 1e-12)
+
+        print(
+            f"[all3_gated_alias_fc1] op_max_mag={op_max_mag:.3e} "
+            f"ref_max_mag={ref_max_mag:.3e} max_abs_diff={max_abs:.3e} "
+            f"rel_err={rel_err:.3e}"
+        )
+        torch.testing.assert_close(out_op, out_ref, rtol=5e-2, atol=1.0)
+    finally:
+        MoERunner.runner_dict.clear()

--- a/tests/unittest/_torch/lora/test_moe_lora_validator.py
+++ b/tests/unittest/_torch/lora/test_moe_lora_validator.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the routed-expert MoE LoRA validator."""
+
+import pytest
+
+from tensorrt_llm._torch.peft.lora.validation import (
+    MOE_LORA_MODULE_NAMES,
+    check_moe_lora_supported,
+    has_moe_lora_targets,
+)
+
+
+class _FakeLoraConfig:
+    """Minimal stand-in for `LoraConfig` for tests that don't need pydantic."""
+
+    def __init__(self, lora_target_modules):
+        self.lora_target_modules = lora_target_modules
+
+
+class _FakeQuantMode:
+    def __init__(self, any_quant: bool):
+        self._any = any_quant
+
+    def has_any_quant(self, exclude_kv_cache: bool = False):
+        return self._any
+
+
+class _FakeQuantConfig:
+    def __init__(self, any_quant: bool):
+        self.quant_mode = _FakeQuantMode(any_quant)
+
+
+def test_has_moe_lora_targets_none():
+    assert has_moe_lora_targets(None) is False
+
+
+def test_has_moe_lora_targets_empty():
+    assert has_moe_lora_targets(_FakeLoraConfig([])) is False
+
+
+def test_has_moe_lora_targets_attn_only():
+    cfg = _FakeLoraConfig(["attn_q", "attn_k", "attn_v"])
+    assert has_moe_lora_targets(cfg) is False
+
+
+@pytest.mark.parametrize("name", sorted(MOE_LORA_MODULE_NAMES))
+def test_has_moe_lora_targets_each_module(name):
+    cfg = _FakeLoraConfig(["attn_q", name])
+    assert has_moe_lora_targets(cfg) is True
+
+
+def test_check_no_lora_is_noop():
+    # No LoRA at all; validator must not raise regardless of backend/quant.
+    check_moe_lora_supported(
+        moe_backend_name="WIDEEP",
+        lora_config=None,
+        quant_config=_FakeQuantConfig(True),
+    )
+
+
+def test_check_no_moe_lora_is_noop():
+    # LoRA on attention only; validator must not reject any backend / quant.
+    cfg = _FakeLoraConfig(["attn_q", "attn_k"])
+    check_moe_lora_supported(
+        moe_backend_name="TRTLLM",
+        lora_config=cfg,
+        quant_config=_FakeQuantConfig(True),
+    )
+
+
+def test_check_moe_lora_cutlass_unquantized_ok():
+    cfg = _FakeLoraConfig(["moe_h_to_4h", "moe_4h_to_h", "moe_gate"])
+    # No quant config -> definitely unquantized.
+    check_moe_lora_supported(
+        moe_backend_name="CUTLASS",
+        lora_config=cfg,
+        quant_config=None,
+    )
+
+
+def test_check_moe_lora_cutlass_unquantized_quant_mode_ok():
+    # An explicit QuantConfig that reports no active quant should pass.
+    cfg = _FakeLoraConfig(["moe_4h_to_h", "moe_gate"])
+    check_moe_lora_supported(
+        moe_backend_name="cutlass",  # case-insensitive
+        lora_config=cfg,
+        quant_config=_FakeQuantConfig(False),
+    )
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [
+        "WIDEEP",
+        "TRITON",
+        "DEEPGEMM",
+        "VANILLA",
+        "DENSEGEMM",
+        "CUTEDSL",
+        "TRTLLM",
+        "MEGAMOE_DEEPGEMM",
+    ],
+)
+def test_check_moe_lora_rejects_non_cutlass_backend(backend):
+    cfg = _FakeLoraConfig(["moe_gate", "moe_4h_to_h"])
+    with pytest.raises(ValueError, match="moe_backend='CUTLASS'"):
+        check_moe_lora_supported(
+            moe_backend_name=backend,
+            lora_config=cfg,
+            quant_config=None,
+        )
+
+
+def test_check_moe_lora_rejects_quantized_base():
+    cfg = _FakeLoraConfig(["moe_gate", "moe_4h_to_h"])
+    with pytest.raises(ValueError, match="unquantized fp16/bf16 base weights"):
+        check_moe_lora_supported(
+            moe_backend_name="CUTLASS",
+            lora_config=cfg,
+            quant_config=_FakeQuantConfig(True),
+        )
+
+
+def test_check_moe_lora_layer_idx_in_message():
+    cfg = _FakeLoraConfig(["moe_gate", "moe_4h_to_h"])
+    with pytest.raises(ValueError, match=r"\[layer_idx=7\]"):
+        check_moe_lora_supported(
+            moe_backend_name="TRTLLM",
+            lora_config=cfg,
+            quant_config=None,
+            layer_idx=7,
+        )

--- a/tests/unittest/_torch/modules/moe/test_cutlass_moe_op_smoke.py
+++ b/tests/unittest/_torch/modules/moe/test_cutlass_moe_op_smoke.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Non-LoRA smoke test for the CutlassMoEOp op path.
+
+CutlassMoEOp.run_moe calls the TorchBind C++ method fused_moe_runner.run_moe.
+That method takes trailing routed-expert LoRA arguments, and TorchBind schemas
+do not honor C++ default-argument values, so every positional argument must be
+supplied by the caller. This op is what the WideEP and ConfigurableMoE paths
+select via MoEOpSelector, so a missing or extra argument here is a silent
+regression for a feature unrelated to LoRA.
+
+This test exercises that callsite on a single GPU (tp/ep/cluster = 1, the
+degenerate WideEP configuration) with unquantized bf16 weights and no LoRA,
+confirming the call succeeds and produces finite output.
+"""
+
+import pytest
+import torch
+
+_TRTLLM_AVAILABLE = hasattr(torch.ops, "trtllm") and hasattr(torch.ops.trtllm, "fused_moe")
+
+requires_cuda_and_op = pytest.mark.skipif(
+    not torch.cuda.is_available() or not _TRTLLM_AVAILABLE,
+    reason="Requires CUDA and built TensorRT-LLM C++ extension (torch.ops.trtllm.fused_moe).",
+)
+
+
+class _RoutingStub:
+    def __init__(self, top_k):
+        self.experts_per_token = top_k
+
+
+class _ModuleStub:
+    """Minimal stand-in for an MoE module exposing only the attributes that
+    CutlassMoEOp.finalize_tactic and compute_moe read."""
+
+    def __init__(self, w3_w1_weight, w2_weight, top_k, hidden_size, activation_type):
+        self.w3_w1_weight = w3_w1_weight
+        self.w2_weight = w2_weight
+        self.routing_method = _RoutingStub(top_k)
+
+        # Parallelism: single rank (degenerate WideEP).
+        self.tp_size = 1
+        self.tp_rank = 0
+        self.ep_size = 1
+        self.ep_rank = 0
+        self.cluster_size = 1
+        self.cluster_rank = 0
+
+        # SwiGLU params, unused here.
+        self.swiglu_alpha = None
+        self.swiglu_beta = None
+        self.swiglu_limit = None
+
+        # Quantization and layout flags, all off for unquantized bf16.
+        self.has_w4afp8 = False
+        self.has_w4a16_mxfp4 = False
+        self.has_deepseek_fp8_block_scales = False
+        self.has_int8_woq_per_channel = False
+        self.has_mxfp8_act_scaling = False
+        self.has_nvfp4 = False
+        self.force_dynamic_quantization = False
+
+        self.activation_type = activation_type
+        self.tune_max_num_tokens = 8192
+        self.unpadded_hidden_size = hidden_size
+
+
+@requires_cuda_and_op
+def test_cutlass_moe_op_run_moe_no_lora_smoke():
+    from tensorrt_llm._torch.modules.fused_moe.ops.moe_op_cutlass import CutlassMoEOp
+    from tensorrt_llm._torch.utils import ActivationType
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, inter_size = 8, 128, 256
+    num_experts, top_k = 4, 2
+
+    torch.manual_seed(0)
+    x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
+    # FC1 packs [up(w3); gate(w1)] -> [E, 2 * inter, hidden].
+    w3_w1_weight = (
+        torch.randn(num_experts, 2 * inter_size, hidden_size, dtype=dtype, device=device) * 0.02
+    )
+    w2_weight = torch.randn(num_experts, hidden_size, inter_size, dtype=dtype, device=device) * 0.02
+
+    logits = torch.randn(num_tokens, num_experts, dtype=torch.float32, device=device)
+    topk_scores, topk_ids = torch.topk(logits, k=top_k, dim=-1)
+    topk_scores = torch.softmax(topk_scores, dim=-1)
+
+    module = _ModuleStub(
+        w3_w1_weight=w3_w1_weight,
+        w2_weight=w2_weight,
+        top_k=top_k,
+        hidden_size=hidden_size,
+        activation_type=int(ActivationType.Swiglu),
+    )
+
+    op = CutlassMoEOp()
+    # No LoRA arguments: guards the run_moe callsite in moe_op_cutlass.py.
+    out = op.run_moe(
+        module=module,
+        input=x,
+        token_selected_slots=topk_ids.to(torch.int32),
+        token_final_scales=topk_scores.to(torch.float32),
+        w3_w1_weight=w3_w1_weight,
+        w3_w1_bias=None,
+        w2_weight=w2_weight,
+        w2_bias=None,
+        output_dtype=dtype,
+        quant_scales=[],
+        use_all_to_all=False,
+    )
+
+    # Non-min-latency run_moe returns a single-element list.
+    assert isinstance(out, list) and len(out) == 1
+    result = out[0]
+    assert result.shape == (num_tokens, hidden_size)
+    assert torch.isfinite(result).all()
+
+
+@requires_cuda_and_op
+def test_cutlass_moe_op_run_moe_no_lora_matches_fused_moe_op():
+    """The CutlassMoEOp path and the direct torch.ops.trtllm.fused_moe path
+    should produce the same result for an unquantized bf16 MoE with no LoRA,
+    since both ultimately call the same C++ run_moe."""
+    from tensorrt_llm._torch.modules.fused_moe.ops.moe_op_cutlass import CutlassMoEOp
+    from tensorrt_llm._torch.utils import ActivationType
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, inter_size = 8, 128, 256
+    num_experts, top_k = 4, 2
+
+    torch.manual_seed(1)
+    x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
+    w3_w1_weight = (
+        torch.randn(num_experts, 2 * inter_size, hidden_size, dtype=dtype, device=device) * 0.02
+    )
+    w2_weight = torch.randn(num_experts, hidden_size, inter_size, dtype=dtype, device=device) * 0.02
+    logits = torch.randn(num_tokens, num_experts, dtype=torch.float32, device=device)
+    topk_scores, topk_ids = torch.topk(logits, k=top_k, dim=-1)
+    topk_scores = torch.softmax(topk_scores, dim=-1).to(torch.float32)
+    topk_ids = topk_ids.to(torch.int32)
+
+    # Direct op reference.
+    ref = torch.ops.trtllm.fused_moe(
+        input=x,
+        token_selected_experts=topk_ids,
+        token_final_scales=topk_scores,
+        fc1_expert_weights=w3_w1_weight,
+        fc1_expert_biases=None,
+        fc2_expert_weights=w2_weight,
+        fc2_expert_biases=None,
+        output_dtype=dtype,
+        quant_scales=[],
+    )[0]
+
+    module = _ModuleStub(
+        w3_w1_weight=w3_w1_weight,
+        w2_weight=w2_weight,
+        top_k=top_k,
+        hidden_size=hidden_size,
+        activation_type=int(ActivationType.Swiglu),
+    )
+    out = CutlassMoEOp().run_moe(
+        module=module,
+        input=x,
+        token_selected_slots=topk_ids,
+        token_final_scales=topk_scores,
+        w3_w1_weight=w3_w1_weight,
+        w3_w1_bias=None,
+        w2_weight=w2_weight,
+        w2_bias=None,
+        output_dtype=dtype,
+        quant_scales=[],
+        use_all_to_all=False,
+    )[0]
+
+    torch.testing.assert_close(out, ref, rtol=5e-2, atol=1e-2)


### PR DESCRIPTION
## Description

This MR adds per-expert lora support in Pytorch workflow with Cutlass backend. Currently supports eager-only. Cudagraph support to be added in a follow-up MR.

## Test Coverage
```
$ pytest tests/unittest/_torch/lora/test_moe_layout.py -s -v
$ pytest tests/unittest/_torch/lora/test_moe_lora_validator.py -s -v
$ pytest tests/unittest/_torch/lora/test_moe_lora_extract.py -s -v
$ pytest tests/unittest/_torch/lora/test_moe_lora_op.py -s -v
$ pytest tests/unittest/_torch/modules/moe/test_cutlass_moe_op_smoke.py -s -v
$ pytest tests/unittest/_torch/lora/test_moe_lora_model_path.py -s -v
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added routed-expert LoRA support for Mixture-of-Experts layers, enabling low-rank adapter tuning on expert projections with CUTLASS backend support.

* **Documentation**
  * Added documentation for MoE LoRA including configuration options, supported backends, and runtime constraints.

* **Tests**
  * Added comprehensive test coverage for MoE LoRA validation, reference implementations, and CUDA operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->