### PR TITLE
[None][chore] Update flashinfer-python from 0.6.12rc2 to 0.6.12

### DIFF
--- a/ATTRIBUTIONS-Python.md
+++ b/ATTRIBUTIONS-Python.md
@@ -5261,7 +5261,7 @@ For more information, please refer to <http://unlicense.org>
   - `Tracker`: https://github.com/tox-dev/py-filelock/issues
 
 
-## flashinfer-python (0.6.12rc2)
+## flashinfer-python (0.6.12)
 
 ### Licenses
 License: `Apache-2.0`

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ ordered-set
 peft>=0.18.1,<0.19.0
 patchelf
 einops
-flashinfer-python==0.6.12rc2
+flashinfer-python==0.6.12
 opencv-python-headless
 xgrammar==0.1.32
 llguidance==0.7.29

--- a/security_scanning/pyproject.toml
+++ b/security_scanning/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "peft (>=0.18.1,<0.19.0)",
     "patchelf (>=0.17.2.4,<0.18.0.0)",
     "einops (>=0.8.2,<0.9.0)",
-    "flashinfer-python (==0.6.12rc2)",
+    "flashinfer-python (==0.6.12)",
     "opencv-python-headless (>=4.13.0.92,<5.0.0.0)",
     "xgrammar (==0.1.32)",
     "llguidance (==0.7.29)",


### PR DESCRIPTION
## Summary
- Bump flashinfer-python from 0.6.12rc2 to 0.6.12 (latest stable)
- Updated version pins in `requirements.txt`, `security_scanning/pyproject.toml`, and `ATTRIBUTIONS-Python.md`
- `security_scanning/poetry.lock` intentionally left untouched (regenerated separately by maintainers)

## Test plan
- [x] `pip install -r requirements.txt` installs successfully
- [x] `pytest tests/unittest/_torch/flashinfer/ -v`
- [x] `pytest tests/unittest/_torch/attention/test_flashinfer_attention.py -v`
- [x] CI pre-merge passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated flashinfer-python dependency from version 0.6.12rc2 to stable release 0.6.12 across project configuration and documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->