### PR TITLE
[TRTLLM-12648][test] implement disagg cancel stress metrics_thread

### DIFF
--- a/tests/integration/defs/stress_test/disagg_cancel/_testing.py
+++ b/tests/integration/defs/stress_test/disagg_cancel/_testing.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared helpers for ``disagg_cancel`` thread-body unit tests.
+
+Each thread (``log_scanner``, ``metrics``, ``injector``, ``canary``,
+``load``) is tested in isolation against a harness wired with
+placeholder ``WorkerLaunchSpec`` entries — no live disagg cluster.
+Per-thread tests only need to override the spec fields relevant to
+their thread, so this module exposes a single ``make_spec`` factory
+that fills in the rest, plus a minimal valid marathon YAML for the
+``DisaggCancellationStressHarness`` constructor.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from typing import Optional
+
+from .harness import WorkerLaunchSpec
+
+# Minimal valid marathon YAML for tests that only need the harness to
+# construct. Includes ``log_scan`` so the log-scanner thread has
+# patterns to compile; threads that don't read ``log_scan`` ignore it.
+DUMMY_YAML = textwrap.dedent(
+    """\
+    hostname: localhost
+    model: dummy
+    backend: pytorch
+    context_servers: {}
+    generation_servers: {}
+    stress_config:
+      duration_min: 1
+      kv_cache_manager: v1
+      transceiver: cpp
+      log_scan:
+        hard_zero_patterns:
+          - "Broken promise"
+          - "Segfault"
+          - "Poisoned .* cache transfer buffer"
+    """
+)
+
+
+def make_spec(
+    role: str,
+    index: int,
+    *,
+    port: int = 18000,
+    host: str = "localhost",
+    log_path: Optional[Path] = None,
+) -> WorkerLaunchSpec:
+    """``WorkerLaunchSpec`` factory for unit tests.
+
+    Callers override only the fields their thread reads (``log_path``
+    for the log scanner, ``host`` / ``port`` for the metrics scraper,
+    etc.); the rest are placeholders that ``setup_disagg_cluster``
+    would normally populate.
+
+    Args:
+        role: ``"ctx"`` or ``"gen"``. Surfaces in failure reasons.
+        index: Per-role index (``ctx_0``, ``gen_0``, ...).
+        port: TCP port for HTTP scraping. Default ``18000``; tests
+            that bind a real socket pass an OS-allocated port.
+        host: HTTP hostname; default ``"localhost"``.
+        log_path: File path the log scanner should tail, or ``None``
+            to simulate a worker launched with ``save_log=False``.
+    """
+    return WorkerLaunchSpec(
+        role=role,
+        index=index,
+        model_name="dummy",
+        worker_config={},
+        work_dir="/tmp",
+        port=port,
+        device="0",
+        env={},
+        log_path=str(log_path) if log_path is not None else None,
+        host=host,
+    )

--- a/tests/integration/defs/stress_test/disagg_cancel/harness.py
+++ b/tests/integration/defs/stress_test/disagg_cancel/harness.py
@@ -32,6 +32,8 @@ import logging
 import re
 import threading
 import time
+import urllib.error
+import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import IO, Any, Callable, Optional
@@ -167,6 +169,9 @@ class WorkerLaunchSpec:
     # ``None`` when launched with ``save_log=False`` (output inherits
     # pytest stdout); log_scanner skips ``None`` paths with a warning.
     log_path: Optional[str] = None
+    # Host for HTTP scraping (Prometheus / health). Multi-host setups
+    # set this from the YAML ``hostname:`` field at cluster-setup time.
+    host: str = "localhost"
 
 
 # ---------------------------------------------------------------------------
@@ -306,6 +311,79 @@ def _compile_patterns(raw_patterns: list[Any]) -> list[tuple[str, re.Pattern[str
 
 
 # ---------------------------------------------------------------------------
+# Metrics-thread helpers
+# ---------------------------------------------------------------------------
+
+
+# Tolerates optional ``{labels}`` and trailing timestamp; captures value in group 1.
+_KV_CACHE_UTIL_RE = re.compile(
+    r"^trtllm_kv_cache_utilization(?:\{[^}]*\})?\s+([+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)"
+)
+
+
+def _parse_kv_cache_utilization(metrics_text: str) -> Optional[float]:
+    """Extract ``trtllm_kv_cache_utilization`` from a Prometheus exposition.
+
+    Skips ``# HELP`` / ``# TYPE`` lines. Returns the first matching
+    sample's value as a float, or ``None`` if no sample is present.
+
+    Args:
+        metrics_text: Body of an HTTP response from
+            ``/prometheus/metrics``.
+
+    Returns:
+        Float utilization in the range the worker exposes (typically
+        ``[0.0, 1.0]``), or ``None`` if the metric is absent.
+    """
+    for line in metrics_text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        m = _KV_CACHE_UTIL_RE.match(line)
+        if m is not None:
+            try:
+                return float(m.group(1))
+            except ValueError:
+                return None
+    return None
+
+
+def _fetch_kv_cache_utilization(
+    host: str, port: int, timeout_s: float
+) -> tuple[Optional[float], Optional[str]]:
+    """HTTP GET ``/prometheus/metrics`` and parse the KV-cache utilization.
+
+    All failures (connection refused, timeout, HTTP error, parse miss)
+    are folded into ``(None, error_string)`` rather than raising. The
+    metrics thread must not fail-fast on transient scrape misses — the
+    worker may be mid-restart, the metrics endpoint may not be wired
+    up on every backend, etc.
+
+    Args:
+        host: Worker hostname or IP.
+        port: Worker HTTP port.
+        timeout_s: Per-request timeout in seconds.
+
+    Returns:
+        Tuple ``(utilization, error)``. Exactly one is ``None``: on
+        success ``utilization`` is the gauge value and ``error`` is
+        ``None``; on failure ``utilization`` is ``None`` and ``error``
+        is a short string explaining why (for the timeseries record).
+    """
+    url = f"http://{host}:{port}/prometheus/metrics"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout_s) as response:
+            body = response.read().decode("utf-8", errors="replace")
+    except urllib.error.URLError as exc:
+        return None, f"url_error: {exc.reason}"
+    except (TimeoutError, OSError) as exc:
+        return None, f"io_error: {exc}"
+    util = _parse_kv_cache_utilization(body)
+    if util is None:
+        return None, "metric_absent"
+    return util, None
+
+
+# ---------------------------------------------------------------------------
 # Harness
 # ---------------------------------------------------------------------------
 
@@ -337,6 +415,8 @@ class DisaggCancellationStressHarness:
         yaml_path: Path,
         *,
         log_scanner_poll_interval_s: float = 0.5,
+        metrics_scrape_interval_s: float = 30.0,
+        metrics_scrape_timeout_s: float = 5.0,
     ) -> None:
         """Construct a marathon harness.
 
@@ -349,6 +429,14 @@ class DisaggCancellationStressHarness:
                 measurable load source on its own; tests pass a
                 smaller value (e.g. 0.02 s) to keep real-clock
                 latency bounded.
+            metrics_scrape_interval_s: Cadence (seconds) between
+                consecutive Prometheus scrapes of every worker.
+                Default 30 s matches the spec's KV-cache utilization
+                sampling rate; tests pass a smaller value.
+            metrics_scrape_timeout_s: Per-request HTTP timeout for
+                the metrics scrape. Short by design — a slow scrape
+                is recorded as a miss rather than blocking the
+                metrics thread past its next scheduled scrape.
 
         Raises:
             ValueError: If the YAML is malformed or its
@@ -364,12 +452,9 @@ class DisaggCancellationStressHarness:
         self._failure_reason: Optional[str] = None
         self._failure_lock = threading.Lock()
 
-        # Per-thread tunables. The default cadence is reactive enough
-        # for human-scale debugging (~0.5 s lag from log line to
-        # fail-fast) without becoming a measurable load source on its
-        # own; tests pass a smaller value via the constructor to keep
-        # real-clock latency bounded.
         self._log_scanner_poll_interval_s: float = log_scanner_poll_interval_s
+        self._metrics_scrape_interval_s: float = metrics_scrape_interval_s
+        self._metrics_scrape_timeout_s: float = metrics_scrape_timeout_s
 
         # Cluster + worker tracking (populated by setup()).
         self._cluster: Any = None  # tuple returned by setup_disagg_cluster
@@ -658,13 +743,59 @@ class DisaggCancellationStressHarness:
             logger.debug("[log_scanner] exiting; closed %d source(s)", len(sources))
 
     def _metrics_thread_body(self) -> None:
-        """Scrape ``/prometheus/metrics`` for KV-cache utilization at ~30 s cadence.
+        """Scrape Prometheus KV-cache utilization from every worker.
 
-        Stub: no-op. Real implementation parses
-        ``trtllm_kv_cache_utilization`` and appends timestamped
-        samples to ``self._kv_utilization_samples``.
+        Polls each ``WorkerLaunchSpec`` at
+        ``_metrics_scrape_interval_s`` cadence, parses
+        ``trtllm_kv_cache_utilization`` out of
+        ``/prometheus/metrics``, and appends a timestamped sample to
+        ``self._kv_utilization_samples``. Each sample records
+        ``timestamp``, ``role``, ``index``, ``host``, ``port``,
+        ``utilization`` (``float`` on success, ``None`` on scrape
+        miss), and ``error`` (``None`` on success, short string on
+        miss). Scrape misses are recorded — not fail-fast — because
+        the worker may be mid-restart from a SIGKILL injection, mid-
+        SIGSTOP pause, or the Prometheus endpoint may not be wired
+        for the active backend.
+
+        Exits when ``stop_event`` or ``failed_event`` is set. Honors
+        either signal between scrapes via ``stop_event.wait`` rather
+        than ``time.sleep`` to keep teardown latency bounded.
         """
-        logger.debug("[metrics_thread] stub — exiting immediately")
+        if not self._worker_specs:
+            logger.warning("[metrics_thread] no worker specs; exiting")
+            return
+
+        logger.info(
+            "[metrics_thread] scraping %d worker(s) every %.1fs",
+            len(self._worker_specs),
+            self._metrics_scrape_interval_s,
+        )
+
+        while not self.stop_event.is_set() and not self.failed_event.is_set():
+            scrape_start = time.monotonic()
+            for spec in self._worker_specs:
+                if self.stop_event.is_set() or self.failed_event.is_set():
+                    break
+                util, err = _fetch_kv_cache_utilization(
+                    spec.host, spec.port, self._metrics_scrape_timeout_s
+                )
+                self._kv_utilization_samples.append(
+                    {
+                        "timestamp": time.time(),
+                        "role": spec.role,
+                        "index": spec.index,
+                        "host": spec.host,
+                        "port": spec.port,
+                        "utilization": util,
+                        "error": err,
+                    }
+                )
+            remaining = self._metrics_scrape_interval_s - (time.monotonic() - scrape_start)
+            if remaining > 0.0:
+                self.stop_event.wait(timeout=remaining)
+
+        logger.debug("[metrics_thread] exiting; %d sample(s)", len(self._kv_utilization_samples))
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/tests/integration/defs/stress_test/disagg_cancel/test_log_scanner.py
+++ b/tests/integration/defs/stress_test/disagg_cancel/test_log_scanner.py
@@ -36,63 +36,12 @@ from typing import Callable
 
 import pytest
 
-from .harness import DisaggCancellationStressHarness, WorkerLaunchSpec, _LogSource
+from ._testing import DUMMY_YAML, make_spec
+from .harness import DisaggCancellationStressHarness, _LogSource
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
-
-
-_DUMMY_YAML = textwrap.dedent(
-    """\
-    hostname: localhost
-    model: dummy
-    backend: pytorch
-    context_servers: {}
-    generation_servers: {}
-    stress_config:
-      duration_min: 1
-      kv_cache_manager: v1
-      transceiver: cpp
-      log_scan:
-        hard_zero_patterns:
-          - "Broken promise"
-          - "Segfault"
-          - "Poisoned .* cache transfer buffer"
-    """
-)
-
-
-def _make_spec(role: str, index: int, log_path: Path | None) -> WorkerLaunchSpec:
-    """Tiny ``WorkerLaunchSpec`` factory for unit tests.
-
-    Only ``role`` / ``index`` / ``log_path`` are scanner-relevant —
-    the other fields are placeholders that would normally be set by
-    ``setup_disagg_cluster``.
-
-    Args:
-        role: Worker role tag, ``"ctx"`` or ``"gen"``. Surfaces in
-            failure reasons via ``_LogSource``.
-        index: Per-role index (``ctx_0``, ``gen_0``, ...). Surfaces
-            in failure reasons.
-        log_path: Path the scanner should tail, or ``None`` to
-            simulate ``save_log=False`` workers.
-
-    Returns:
-        A ``WorkerLaunchSpec`` with placeholder values for the
-        scanner-irrelevant fields.
-    """
-    return WorkerLaunchSpec(
-        role=role,
-        index=index,
-        model_name="dummy",
-        worker_config={},
-        work_dir="/tmp",
-        port=18000 + index,
-        device="0",
-        env={},
-        log_path=str(log_path) if log_path is not None else None,
-    )
 
 
 @pytest.fixture
@@ -109,7 +58,7 @@ def harness_with_two_workers(tmp_path: Path):
         so test wall-clock times stay bounded.
     """
     yaml_path = tmp_path / "stress.yaml"
-    yaml_path.write_text(_DUMMY_YAML)
+    yaml_path.write_text(DUMMY_YAML)
 
     # Tighten the scanner cadence so the tests finish quickly. The
     # default 0.5 s makes tests slow; 20 ms keeps real-clock latency
@@ -122,8 +71,8 @@ def harness_with_two_workers(tmp_path: Path):
     gen_log.touch()
 
     h._worker_specs = [
-        _make_spec("ctx", 0, ctx_log),
-        _make_spec("gen", 0, gen_log),
+        make_spec("ctx", 0, ctx_log),
+        make_spec("gen", 0, gen_log),
     ]
     return h, ctx_log, gen_log
 
@@ -360,7 +309,7 @@ def test_log_file_created_after_scanner_starts(harness_with_two_workers):
 
 def test_no_worker_specs_exits_immediately(tmp_path: Path):
     yaml_path = tmp_path / "stress.yaml"
-    yaml_path.write_text(_DUMMY_YAML)
+    yaml_path.write_text(DUMMY_YAML)
     h = DisaggCancellationStressHarness(yaml_path)
     # No specs at all.
 
@@ -374,11 +323,11 @@ def test_no_worker_specs_exits_immediately(tmp_path: Path):
 
 def test_specs_with_none_log_path_skip_gracefully(tmp_path: Path):
     yaml_path = tmp_path / "stress.yaml"
-    yaml_path.write_text(_DUMMY_YAML)
+    yaml_path.write_text(DUMMY_YAML)
     h = DisaggCancellationStressHarness(yaml_path)
     h._worker_specs = [
-        _make_spec("ctx", 0, None),
-        _make_spec("gen", 0, None),
+        make_spec("ctx", 0, None),
+        make_spec("gen", 0, None),
     ]
 
     t = threading.Thread(target=h._log_scanner_thread_body, daemon=True)
@@ -411,7 +360,7 @@ def test_no_hard_zero_patterns_exits_immediately(tmp_path: Path):
     h = DisaggCancellationStressHarness(yaml_path)
     ctx_log = tmp_path / "worker_ctx_18000.log"
     ctx_log.write_text("Broken promise: A\n")  # would match in normal config
-    h._worker_specs = [_make_spec("ctx", 0, ctx_log)]
+    h._worker_specs = [make_spec("ctx", 0, ctx_log)]
 
     t = threading.Thread(target=h._log_scanner_thread_body, daemon=True)
     t.start()
@@ -452,7 +401,7 @@ def test_invalid_regex_is_skipped_with_warning(tmp_path: Path, caplog):
     h = DisaggCancellationStressHarness(yaml_path, log_scanner_poll_interval_s=0.02)
     ctx_log = tmp_path / "worker_ctx_18000.log"
     ctx_log.write_text("Broken promise: A\n")
-    h._worker_specs = [_make_spec("ctx", 0, ctx_log)]
+    h._worker_specs = [make_spec("ctx", 0, ctx_log)]
 
     with caplog.at_level("ERROR"):
         fired = _run_scanner_until_failure_or_timeout(h)
@@ -494,7 +443,7 @@ def _consume_marks(seen: list[str]) -> Callable[[str], None]:
 
 
 def test_log_source_poll_returns_false_when_file_absent(tmp_path: Path):
-    spec = _make_spec("ctx", 0, tmp_path / "missing.log")
+    spec = make_spec("ctx", 0, tmp_path / "missing.log")
     src = _LogSource(spec=spec, path=Path(spec.log_path))  # type: ignore[arg-type]
     seen: list[str] = []
     assert src.poll([("X", re.compile("X"))], _consume_marks(seen)) is False
@@ -504,7 +453,7 @@ def test_log_source_poll_returns_false_when_file_absent(tmp_path: Path):
 def test_log_source_poll_returns_false_on_empty_read(tmp_path: Path):
     log = tmp_path / "empty.log"
     log.touch()
-    spec = _make_spec("gen", 0, log)
+    spec = make_spec("gen", 0, log)
     src = _LogSource(spec=spec, path=log)
     seen: list[str] = []
     assert src.poll([("X", re.compile("X"))], _consume_marks(seen)) is False
@@ -515,7 +464,7 @@ def test_log_source_poll_returns_false_on_empty_read(tmp_path: Path):
 def test_log_source_close_is_idempotent(tmp_path: Path):
     log = tmp_path / "x.log"
     log.write_text("hello\n")
-    spec = _make_spec("ctx", 0, log)
+    spec = make_spec("ctx", 0, log)
     src = _LogSource(spec=spec, path=log)
     src.poll([("X", re.compile("X"))], lambda r: None)
     src.close()

--- a/tests/integration/defs/stress_test/disagg_cancel/test_metrics_thread.py
+++ b/tests/integration/defs/stress_test/disagg_cancel/test_metrics_thread.py
@@ -1,0 +1,358 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for ``DisaggCancellationStressHarness._metrics_thread_body``.
+
+The metrics thread is testable without a real disagg cluster: stand
+up a tiny HTTP server in the test process that responds at
+``/prometheus/metrics``, point a ``WorkerLaunchSpec`` at it, run the
+thread for a few scrape intervals, and assert on the collected
+samples.
+
+Parse-only behaviour (handling of ``# HELP`` / ``# TYPE`` lines,
+labels, scientific notation, missing metric) is verified directly
+against the standalone parser; transport behaviour (timeouts,
+connection refused, restart-mid-scrape) is verified against the
+in-process HTTP server.
+"""
+
+from __future__ import annotations
+
+import socket
+import textwrap
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+from ._testing import DUMMY_YAML, make_spec
+from .harness import (
+    DisaggCancellationStressHarness,
+    WorkerLaunchSpec,
+    _fetch_kv_cache_utilization,
+    _parse_kv_cache_utilization,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+def _pick_port() -> int:
+    """Bind-and-release to get an OS-allocated free TCP port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _MetricsHandler(BaseHTTPRequestHandler):
+    """Serves a single configurable body at ``/prometheus/metrics``.
+
+    The body is read off the server instance (``server.metrics_body``)
+    on every request so tests can mutate it mid-run to simulate
+    utilization drift.
+    """
+
+    def do_GET(self) -> None:  # noqa: N802 — fixed by BaseHTTPRequestHandler
+        if self.path != "/prometheus/metrics":
+            self.send_response(404)
+            self.end_headers()
+            return
+        body: str = getattr(self.server, "metrics_body", "")
+        if body is None:
+            # Simulate a worker that's mid-restart: serve a 503 so the
+            # scraper records a miss rather than a parse failure.
+            self.send_response(503)
+            self.end_headers()
+            return
+        encoded = body.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; version=0.0.4")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def log_message(self, *_args, **_kwargs) -> None:  # silence test noise
+        pass
+
+
+@pytest.fixture
+def metrics_server():
+    """A single in-process HTTP server serving ``/prometheus/metrics``.
+
+    Yields ``(server, port)``. Tests mutate ``server.metrics_body`` to
+    change what the next scrape sees.
+    """
+    port = _pick_port()
+    server = HTTPServer(("127.0.0.1", port), _MetricsHandler)
+    # Default empty body; tests set this to drive scrape outcomes.
+    server.metrics_body = ""  # type: ignore[attr-defined]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server, port
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+
+
+def _make_harness(tmp_path: Path, specs: list[WorkerLaunchSpec]) -> DisaggCancellationStressHarness:
+    """Construct a harness with a minimal YAML and the given worker specs."""
+    yaml_path = tmp_path / "marathon.yaml"
+    yaml_path.write_text(DUMMY_YAML)
+    h = DisaggCancellationStressHarness(
+        yaml_path,
+        metrics_scrape_interval_s=0.05,
+        metrics_scrape_timeout_s=0.5,
+    )
+    h._worker_specs = list(specs)
+    return h
+
+
+def _run_metrics_thread_briefly(
+    harness: DisaggCancellationStressHarness, duration_s: float
+) -> None:
+    """Drive ``_metrics_thread_body`` for ``duration_s`` seconds then stop."""
+    thread = threading.Thread(target=harness._metrics_thread_body, daemon=True)
+    thread.start()
+    time.sleep(duration_s)
+    harness.stop_event.set()
+    thread.join(timeout=2.0)
+    assert not thread.is_alive(), "metrics thread failed to exit after stop_event"
+
+
+def _wait_until(predicate, *, timeout_s: float, poll_s: float = 0.01) -> None:
+    """Poll ``predicate`` until true or ``timeout_s`` elapses; assert on timeout."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(poll_s)
+    raise AssertionError(f"predicate did not become true within {timeout_s}s")
+
+
+# ---------------------------------------------------------------------------
+# Parser-only tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_simple_gauge_returns_float() -> None:
+    body = textwrap.dedent(
+        """\
+        # HELP trtllm_kv_cache_utilization KV cache utilization fraction.
+        # TYPE trtllm_kv_cache_utilization gauge
+        trtllm_kv_cache_utilization 0.42
+        """
+    )
+    assert _parse_kv_cache_utilization(body) == pytest.approx(0.42)
+
+
+def test_parse_gauge_with_labels_returns_float() -> None:
+    body = textwrap.dedent(
+        """\
+        # TYPE trtllm_kv_cache_utilization gauge
+        trtllm_kv_cache_utilization{instance="ctx_0",pool="kv"} 0.875
+        """
+    )
+    assert _parse_kv_cache_utilization(body) == pytest.approx(0.875)
+
+
+def test_parse_gauge_with_scientific_notation() -> None:
+    body = "trtllm_kv_cache_utilization 7.5e-2\n"
+    assert _parse_kv_cache_utilization(body) == pytest.approx(0.075)
+
+
+def test_parse_returns_none_when_metric_absent() -> None:
+    body = textwrap.dedent(
+        """\
+        # HELP trtllm_request_success_total Counter.
+        trtllm_request_success_total 17
+        """
+    )
+    assert _parse_kv_cache_utilization(body) is None
+
+
+def test_parse_skips_help_and_type_lines_with_same_prefix() -> None:
+    # The HELP/TYPE lines mention ``trtllm_kv_cache_utilization`` but
+    # are not data samples — must not be parsed as values.
+    body = textwrap.dedent(
+        """\
+        # HELP trtllm_kv_cache_utilization KV cache utilization 0.99 (this is a comment).
+        # TYPE trtllm_kv_cache_utilization gauge
+        """
+    )
+    assert _parse_kv_cache_utilization(body) is None
+
+
+def test_parse_returns_first_sample_when_multiple_present() -> None:
+    body = textwrap.dedent(
+        """\
+        trtllm_kv_cache_utilization{instance="ctx_0"} 0.10
+        trtllm_kv_cache_utilization{instance="gen_0"} 0.90
+        """
+    )
+    assert _parse_kv_cache_utilization(body) == pytest.approx(0.10)
+
+
+# ---------------------------------------------------------------------------
+# Fetch-only tests (in-process HTTP server)
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_success_returns_value_and_no_error(metrics_server) -> None:
+    server, port = metrics_server
+    server.metrics_body = "trtllm_kv_cache_utilization 0.31\n"
+    util, err = _fetch_kv_cache_utilization("127.0.0.1", port, timeout_s=1.0)
+    assert util == pytest.approx(0.31)
+    assert err is None
+
+
+def test_fetch_missing_metric_returns_none_with_metric_absent_error(metrics_server) -> None:
+    server, port = metrics_server
+    server.metrics_body = "trtllm_other_metric 99\n"
+    util, err = _fetch_kv_cache_utilization("127.0.0.1", port, timeout_s=1.0)
+    assert util is None
+    assert err == "metric_absent"
+
+
+def test_fetch_connection_refused_returns_url_error() -> None:
+    # Pick a port and don't bind it.
+    port = _pick_port()
+    util, err = _fetch_kv_cache_utilization("127.0.0.1", port, timeout_s=0.5)
+    assert util is None
+    assert err is not None and err.startswith("url_error")
+
+
+def test_fetch_http_503_returns_url_error(metrics_server) -> None:
+    server, port = metrics_server
+    server.metrics_body = None  # handler responds 503
+    util, err = _fetch_kv_cache_utilization("127.0.0.1", port, timeout_s=1.0)
+    assert util is None
+    assert err is not None and err.startswith("url_error")
+
+
+# ---------------------------------------------------------------------------
+# Thread-body integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_thread_records_sample_per_scrape(tmp_path, metrics_server) -> None:
+    server, port = metrics_server
+    server.metrics_body = "trtllm_kv_cache_utilization 0.25\n"
+    spec = make_spec("ctx", 0, host="127.0.0.1", port=port)
+    harness = _make_harness(tmp_path, [spec])
+
+    _run_metrics_thread_briefly(harness, duration_s=0.2)
+
+    assert len(harness._kv_utilization_samples) >= 2
+    for sample in harness._kv_utilization_samples:
+        assert sample["role"] == "ctx"
+        assert sample["index"] == 0
+        assert sample["host"] == "127.0.0.1"
+        assert sample["port"] == port
+        assert sample["utilization"] == pytest.approx(0.25)
+        assert sample["error"] is None
+        assert sample["timestamp"] > 0
+
+
+def test_thread_exits_immediately_when_no_specs(tmp_path) -> None:
+    harness = _make_harness(tmp_path, [])
+    thread = threading.Thread(target=harness._metrics_thread_body, daemon=True)
+    thread.start()
+    thread.join(timeout=2.0)
+    assert not thread.is_alive()
+    assert harness._kv_utilization_samples == []
+
+
+def test_thread_records_miss_when_scrape_fails(tmp_path) -> None:
+    # Worker port nobody is listening on → connection refused on every scrape.
+    port = _pick_port()
+    spec = make_spec("gen", 0, host="127.0.0.1", port=port)
+    harness = _make_harness(tmp_path, [spec])
+
+    _run_metrics_thread_briefly(harness, duration_s=0.15)
+
+    assert len(harness._kv_utilization_samples) >= 1
+    for sample in harness._kv_utilization_samples:
+        assert sample["utilization"] is None
+        assert sample["error"] is not None
+        assert sample["role"] == "gen"
+
+
+def test_thread_recovers_when_worker_starts_serving_mid_run(tmp_path, metrics_server) -> None:
+    server, port = metrics_server
+    server.metrics_body = None  # initial: handler 503s every request
+    spec = make_spec("ctx", 0, host="127.0.0.1", port=port)
+    harness = _make_harness(tmp_path, [spec])
+
+    thread = threading.Thread(target=harness._metrics_thread_body, daemon=True)
+    thread.start()
+    try:
+        # Drive the loop deterministically: wait until at least one miss has
+        # been recorded before flipping the handler to a success response.
+        _wait_until(
+            lambda: any(s["utilization"] is None for s in harness._kv_utilization_samples),
+            timeout_s=2.0,
+        )
+        server.metrics_body = "trtllm_kv_cache_utilization 0.50\n"
+        _wait_until(
+            lambda: any(s["utilization"] is not None for s in harness._kv_utilization_samples),
+            timeout_s=2.0,
+        )
+    finally:
+        harness.stop_event.set()
+        thread.join(timeout=2.0)
+
+    samples = harness._kv_utilization_samples
+    assert any(s["utilization"] is None for s in samples), "expected a miss before serving"
+    hits = [s for s in samples if s["utilization"] is not None]
+    assert hits and all(s["utilization"] == pytest.approx(0.50) for s in hits)
+
+
+def test_thread_scrapes_multiple_workers_per_cycle(tmp_path, metrics_server) -> None:
+    server, port = metrics_server
+    server.metrics_body = "trtllm_kv_cache_utilization 0.6\n"
+    specs = [
+        make_spec("ctx", 0, host="127.0.0.1", port=port),
+        make_spec("ctx", 1, host="127.0.0.1", port=port),
+        make_spec("gen", 0, host="127.0.0.1", port=port),
+    ]
+    harness = _make_harness(tmp_path, specs)
+
+    _run_metrics_thread_briefly(harness, duration_s=0.15)
+
+    # Each cycle should produce one sample per worker. We tolerate
+    # extra samples (timing-dependent) but require coverage of all
+    # three roles+indices.
+    seen = {(s["role"], s["index"]) for s in harness._kv_utilization_samples}
+    assert ("ctx", 0) in seen
+    assert ("ctx", 1) in seen
+    assert ("gen", 0) in seen
+
+
+def test_thread_exits_promptly_on_failed_event(tmp_path, metrics_server) -> None:
+    server, port = metrics_server
+    server.metrics_body = "trtllm_kv_cache_utilization 0.0\n"
+    spec = make_spec("ctx", 0, host="127.0.0.1", port=port)
+    harness = _make_harness(tmp_path, [spec])
+
+    thread = threading.Thread(target=harness._metrics_thread_body, daemon=True)
+    thread.start()
+    time.sleep(0.05)
+    harness.failed_event.set()
+    thread.join(timeout=2.0)
+    assert not thread.is_alive(), "metrics thread must exit on failed_event too"


### PR DESCRIPTION
## Summary

Second thread body in the disaggregated cancellation stress-test suite — the marathon-style (hours-running) harness that gates regressions of the bug class fixed by [PR #13713](https://github.com/NVIDIA/TensorRT-LLM/pull/13713). The skeleton + `log_scanner_thread` landed previously in [PR #14375](https://github.com/NVIDIA/TensorRT-LLM/pull/14375); this PR adds the `metrics_thread`.

**This PR ships:**

- **`metrics_thread` body** — scrapes every worker's `trtllm_kv_cache_utilization` gauge from `/prometheus/metrics` on a fixed cadence (default 30 s, ctor-configurable), and appends timestamped samples (`role`, `index`, `host`, `port`, `utilization`, `error`) to `_kv_utilization_samples` for the end-of-marathon leak-detection assertion. Transport / parse failures are recorded as misses (worker mid-restart from SIGKILL, mid-SIGSTOP pause, endpoint not wired for backend) rather than fail-fast — only the log scanner is fail-fast.
- **`_parse_kv_cache_utilization`** — pure-function Prometheus text-exposition parser: tolerates `# HELP` / `# TYPE` comments, label sets (`{instance="ctx_0",pool="kv"}`), and scientific notation.
- **`_fetch_kv_cache_utilization`** — `urllib`-based one-shot scrape that folds every transport error (URLError, HTTPError, TimeoutError, OSError) into a `(None, error_string)` return so the thread can never raise.
- **`WorkerLaunchSpec.host`** — new optional field (default `"localhost"`) so a future multi-host config can carry a non-localhost hostname through to the scraper without further API churn.
- **`metrics_scrape_interval_s` / `metrics_scrape_timeout_s`** — new ctor parameters on `DisaggCancellationStressHarness`, matching the existing `log_scanner_poll_interval_s` pattern. Tests pass small values for fast turnaround; the marathon uses defaults.
- **Shared test-helper module** (`_testing.py`) — `DUMMY_YAML` + `make_spec(role, index, *, port, host, log_path)` factored out of the two test files that had drifted into copy-paste. `test_log_scanner.py` is migrated in this PR (touches ~80 lines but removes ~80 lines of dup).

The thread sits inside the lifecycle wired up by PR #14375 — `start()` already spawns it, `stop()` joins it, `collect_results()` already returns `kv_utilization_samples`. PR #14375 left it as a no-op stub; this PR makes it actually scrape.

## PR chain plan

| PR | Adds | Marathon assertion it enables |
|----|------|------------------------------|
| [PR #14375](https://github.com/NVIDIA/TensorRT-LLM/pull/14375) | skeleton + `log_scanner` | hard-zero log patterns |
| **this PR** | **`metrics_thread`** | **KV-cache utilization growth bound** |
| next | `injector_thread` | SIGSTOP / SIGCONT / SIGKILL+respawn; `injection_events` count |
| next + 1 | `canary_thread` | canary error rate + token-equivalence + recovery time |
| next + 2 | `load_thread` + real `setup()` with `save_log=True` | sustained load over `duration_min`; **marathon entry point becomes a real marathon** |

The final PR also flips `setup_disagg_cluster` to `save_log=True` with explicit per-worker ports — at which point both the `log_scanner` (from PR #14375) and the `metrics_thread` (this PR) start scraping real worker endpoints. Today both correctly no-op when their inputs are absent: scanner skips `log_path=None` with a warning, scraper records scrape misses.

## Tests added

All deterministic, GPU-free, millisecond-scale. Under `tests/integration/defs/stress_test/disagg_cancel/`.

- **`test_metrics_thread.py`** — 16 unit tests across three layers:
  - **Parser-only (6)**: simple gauge, gauge with labels, scientific notation, missing metric, comment-line skipping, first-sample-wins on multi-sample exposition.
  - **Fetch-only (4)**: in-process `http.server.HTTPServer` validates success + missing-metric path; closed port validates connection-refused; `503` response validates HTTP error path.
  - **Thread-body integration (6)**: multi-cycle sample collection, exit-on-no-specs, scrape-miss recording on connection-refused, mid-run worker-recovery (initial `503` → later `200`, polled deterministically via a `_wait_until` helper rather than `time.sleep`), multi-worker per-cycle coverage, prompt exit on `failed_event`.
- **`test_log_scanner.py`** — migrated to use the new `_testing.py` helpers. No new assertions, no behaviour change; verifies via the existing 17 tests.

## Out of scope (deferred to later PRs in this chain)

- YAML schema wiring of `metrics_scrape_interval_s` / `metrics_scrape_timeout_s` (constructor-only for now; the marathon uses defaults).
- The remaining three thread bodies: `injector`, `canary`, `load`.
- Real `setup_disagg_cluster` invocation (cluster launch is still a stub, so `_worker_specs` is empty in the lifecycle smoke; the metrics thread correctly logs a warning and exits in that case).
- Registration in `qa/llm_function_stress.txt` for nightly / weekly CI.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.