### PR TITLE
[None][perf] Add WAN skip-softmax recipe config

### DIFF
--- a/examples/visual_gen/configs/wan2.2-t2v-bf16-skip-softmax-8gpu.yaml
+++ b/examples/visual_gen/configs/wan2.2-t2v-bf16-skip-softmax-8gpu.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 8-GPU Wan 2.2 T2V BF16 recipe with skip-softmax sparse attention.
+# Requires a ModelOpt-calibrated checkpoint with sparse.yaml at checkpoint root.
+# The sparse.yaml artifact provides per-transformer calibration and
+# disabled-layer masks; this recipe sets TRT-LLM runtime knobs only.
+#
+# The WAN transformer uses block-level torch.compile by default, keeping GELU
+# in the compiled block path. Self-attention uses fused QK-Norm + RoPE.
+attention_config:
+  backend: TRTLLM
+  sparse_attention_config:
+    algorithm: skip_softmax
+    target_sparsity: 0.75
+    first_dense_steps: 16
+torch_compile_config:
+  enable: true
+parallel_config:
+  cfg_size: 2
+  ulysses_size: 4
+  parallel_vae_size: 8
+cuda_graph_config:
+  enable: false

--- a/tensorrt_llm/_torch/visual_gen/modules/attention.py
+++ b/tensorrt_llm/_torch/visual_gen/modules/attention.py
@@ -320,6 +320,29 @@ class Attention(nn.Module):
             k = self.norm_k(k)
         return q, k
 
+    @staticmethod
+    def _reshape_rope_for_fused_op(
+        freqs: torch.Tensor, num_heads: int, head_dim: int
+    ) -> torch.Tensor:
+        if freqs.ndim == 2:
+            return freqs.contiguous()
+
+        if freqs.shape[-1] != head_dim:
+            return freqs.reshape(-1, freqs.shape[-1]).contiguous()
+
+        if freqs.ndim >= 3 and freqs.shape[-2] == num_heads:
+            return freqs.reshape(-1, num_heads * head_dim).contiguous()
+
+        return freqs.reshape(-1, head_dim).contiguous()
+
+    @staticmethod
+    def _rope_tokens_per_batch(
+        freqs: torch.Tensor, batch_size: int, seq_len: int, num_txt_tokens: int
+    ) -> int:
+        if num_txt_tokens > 0 or freqs.shape[0] != batch_size * seq_len:
+            return seq_len
+        return 0
+
     def apply_packed_qk_norm_rope(
         self,
         qkv: torch.Tensor,
@@ -338,10 +361,17 @@ class Attention(nn.Module):
           - cos last dim = num_heads * head_dim      → per-token per-head cos (LTX-2 3D RoPE)
           - cos rows < num_tokens                    → kernel broadcasts via cos_seq_per_batch
 
-        Caller passes raw freqs_cos / freqs_sin (any rank); the op reshapes internally.
+        Caller passes raw freqs_cos / freqs_sin in broadcast form; flatten to
+        the 2D contract that the op validates.
         """
         B, S, D = qkv.shape
-        tokens_per_batch = S if num_txt_tokens > 0 else 0
+        freqs_cos = self._reshape_rope_for_fused_op(
+            freqs_cos, self.num_attention_heads, self.head_dim
+        )
+        freqs_sin = self._reshape_rope_for_fused_op(
+            freqs_sin, self.num_attention_heads, self.head_dim
+        )
+        tokens_per_batch = self._rope_tokens_per_batch(freqs_cos, B, S, num_txt_tokens)
         assert self.tp_size == 1, "fused_dit_split_norm_rope does not support TP"
         torch.ops.trtllm.fused_dit_qk_norm_rope(
             qkv.view(B * S, D),
@@ -376,9 +406,12 @@ class Attention(nn.Module):
           - cos last dim = num_heads * head_dim      → per-token per-head cos (LTX-2 3D RoPE)
           - cos rows < num_tokens                    → kernel broadcasts via cos_seq_per_batch
           - cos dtype bf16 or fp32                   → kernel upcasts bf16 to fp32 in registers
-        Caller passes raw cos/sin (any rank); the op reshapes internally.
+        Caller passes raw cos/sin in broadcast form; flatten to the 2D
+        contract that the op validates.
         """
         B, T, _ = tensor.shape
+        cos = self._reshape_rope_for_fused_op(cos, num_heads, self.head_dim)
+        sin = self._reshape_rope_for_fused_op(sin, num_heads, self.head_dim)
         assert self.tp_size == 1, "fused_dit_split_norm_rope does not support TP"
         torch.ops.trtllm.fused_dit_split_norm_rope(
             tensor.view(B * T, -1),

--- a/tensorrt_llm/_torch/visual_gen/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline.py
@@ -4,6 +4,7 @@ import time
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple, Type
 
 import torch
+import torch._inductor.config as inductor_config
 import torch.distributed as dist
 import torch.nn as nn
 from pydantic import Field
@@ -125,6 +126,7 @@ class BasePipeline(nn.Module):
         self._cuda_graph_runners: Dict[str, CUDAGraphRunner] = {}
         self._parallel_vae_enabled: bool = False
         self._warmed_up_shapes: Set[tuple] = set()
+        self._skip_softmax_enabled: Optional[bool] = None
 
         # Unified cache acceleration (TeaCache, Cache-DiT); see _setup_cache_acceleration
         self.cache_accelerator: Optional["CacheAccelerator"] = None
@@ -180,6 +182,13 @@ class BasePipeline(nn.Module):
             )
             return
 
+        sparse_cfg = self.model_config.attention.sparse_attention_config
+        if getattr(sparse_cfg, "first_dense_steps", 0) > 0:
+            raise ValueError(
+                "skip_softmax first_dense_steps is not supported with CUDA graph capture; "
+                "disable cuda_graph_config.enable or set first_dense_steps=0."
+            )
+
         if len(self.transformer_components) > 1:
             logger.info(
                 "CUDA graph runner: multiple transformer components, using shared graph pool"
@@ -197,6 +206,30 @@ class BasePipeline(nn.Module):
             logger.info(f"CUDA graph runner: wrapping {name}.forward")
             model.forward = runner.wrap(model.forward)
             self._cuda_graph_runners[name] = runner
+
+    def _set_skip_softmax_for_step(self, step_idx: int) -> None:
+        """Apply first-dense-step skip-softmax scheduling before a denoise step."""
+        from tensorrt_llm.visual_gen.sparse_attention import (
+            SkipSoftmaxConfig,
+            set_skip_softmax_enabled,
+        )
+
+        sparse_cfg = self.model_config.attention.sparse_attention_config
+        if not isinstance(sparse_cfg, SkipSoftmaxConfig):
+            return
+
+        should_enable = step_idx >= sparse_cfg.first_dense_steps
+        if self._skip_softmax_enabled == should_enable:
+            return
+
+        modified = set_skip_softmax_enabled(self, sparse_cfg, enabled=should_enable)
+        self._skip_softmax_enabled = should_enable
+        if self.rank == 0 and modified:
+            mode = "enabled" if should_enable else "disabled"
+            logger.info(
+                f"skip_softmax {mode} for denoise step {step_idx} "
+                f"(first_dense_steps={sparse_cfg.first_dense_steps}, backends={modified})"
+            )
 
     @property
     def rank(self):
@@ -529,6 +562,12 @@ class BasePipeline(nn.Module):
         For non-transformer components, compiles the entire module.
         """
         tc_config = self.model_config.torch_compile
+
+        # Make inductor round FP32<->BF16 casts like eager. Must be set before the
+        # first compiled forward (warmup), which inductor traces lazily. Closes most
+        # of the torch.compile-vs-eager quality gap on WAN at no latency cost.
+        if hasattr(inductor_config, "emulate_precision_casts"):
+            inductor_config.emulate_precision_casts = True
 
         # Using default as max-autotune mode takes more initialization time and
         # does not improve performance a lot.
@@ -1027,6 +1066,8 @@ class BasePipeline(nn.Module):
         for i, t in enumerate(timesteps):
             if prof_step_starts is not None and i in prof_step_starts and not self._is_warmup:
                 self._cuda_profiler_start()
+
+            self._set_skip_softmax_for_step(i)
 
             step_start = time.time()
 

--- a/tensorrt_llm/visual_gen/sparse_attention.py
+++ b/tensorrt_llm/visual_gen/sparse_attention.py
@@ -69,11 +69,13 @@ class SkipSoftmaxConfig(SkipSoftmaxAttentionConfig):
     """SkipSoftmax sparse attention configuration for visual generation.
 
     Extends the shared :class:`SkipSoftmaxAttentionConfig` from
-    ``tensorrt_llm.llmapi.llm_args`` (used by the LLM backend) without adding
-    any user-facing fields. The user-facing surface is exactly:
+    ``tensorrt_llm.llmapi.llm_args`` (used by the LLM backend) with
+    visual-generation-specific runtime scheduling. The user-facing surface is:
 
     - ``threshold_scale_factor`` — raw value, resolution-dependent.
     - ``target_sparsity`` — semantic target; needs calibration to resolve.
+    - ``first_dense_steps`` — initial denoising steps run dense before
+      skip-softmax is enabled.
 
     Calibration state (formula coefficients and per-layer overrides) is loaded
     from ModelOpt-produced artifacts (``sparse.yaml`` or checkpoint
@@ -86,6 +88,16 @@ class SkipSoftmaxConfig(SkipSoftmaxAttentionConfig):
     :meth:`SkipSoftmaxConfig.with_calibration`.
     """
 
+    first_dense_steps: int = PydanticField(
+        default=0,
+        ge=0,
+        description=(
+            "Number of initial visual-generation denoising steps that run dense "
+            "attention before enabling skip-softmax. This is a runtime schedule "
+            "knob; it does not affect threshold calibration."
+        ),
+    )
+
     _formula: Optional[SkipSoftmaxFormula] = PrivateAttr(default=None)
     _layer_overrides: Optional[Dict[str, float]] = PrivateAttr(default=None)
     _component_configs: Optional[Dict[str, "SkipSoftmaxConfig"]] = PrivateAttr(default=None)
@@ -97,6 +109,7 @@ class SkipSoftmaxConfig(SkipSoftmaxAttentionConfig):
         *,
         threshold_scale_factor: Optional[Union[float, Dict[str, float]]] = None,
         target_sparsity: Optional[Union[float, Dict[str, float]]] = None,
+        first_dense_steps: int = 0,
         formula: Optional[SkipSoftmaxFormula] = None,
         layer_overrides: Optional[Dict[str, float]] = None,
         component_configs: Optional[Dict[str, "SkipSoftmaxConfig"]] = None,
@@ -107,6 +120,8 @@ class SkipSoftmaxConfig(SkipSoftmaxAttentionConfig):
             kwargs["threshold_scale_factor"] = threshold_scale_factor
         if target_sparsity is not None:
             kwargs["target_sparsity"] = target_sparsity
+        if first_dense_steps:
+            kwargs["first_dense_steps"] = first_dense_steps
         cfg = cls(**kwargs)
         cfg._formula = formula
         cfg._layer_overrides = layer_overrides
@@ -123,6 +138,8 @@ class SkipSoftmaxConfig(SkipSoftmaxAttentionConfig):
             }.items()
             if v is not None
         }
+        if "first_dense_steps" in user_cfg.model_fields_set:
+            updates["first_dense_steps"] = user_cfg.first_dense_steps
         if not updates:
             return self
 
@@ -271,13 +288,33 @@ def _load_sparse_config_group_container(data: Dict[str, Any]) -> Optional[SkipSo
             {str(name): 0.0 for name in disabled} if disabled else None
         )
 
-        formula_kwargs = {k: prefill[k] for k in ("log_a", "a", "b") if k in prefill}
         return SkipSoftmaxConfig.with_calibration(
-            formula=SkipSoftmaxFormula(**formula_kwargs),
+            formula=SkipSoftmaxFormula(**_formula_kwargs_from_prefill(prefill)),
             layer_overrides=layer_overrides,
         )
 
     return None
+
+
+def _formula_kwargs_from_prefill(prefill: Dict[str, Any]) -> Dict[str, float]:
+    """Normalize ModelOpt prefill formula coefficients for ``SkipSoftmaxFormula``."""
+    if "log_a" in prefill:
+        log_a = float(prefill["log_a"])
+        if "a" in prefill:
+            a = float(prefill["a"])
+            if a <= 0:
+                raise ValueError(
+                    f"SkipSoftmaxFormula: 'a' must be positive (got {a}). "
+                    "Use 'log_a' directly if you need log(a) of a non-positive value."
+                )
+            if not math.isclose(math.log(a), log_a, rel_tol=1e-6, abs_tol=1e-12):
+                raise ValueError(
+                    "SkipSoftmaxFormula: 'a' and 'log_a' disagree in ModelOpt "
+                    f"calibration ({math.log(a)} != {log_a})."
+                )
+        return {"log_a": log_a, "b": float(prefill["b"])}
+
+    return {"a": float(prefill["a"]), "b": float(prefill["b"])}
 
 
 def load_sparse_config_from_yaml(yaml_path: str) -> Optional[SkipSoftmaxConfig]:
@@ -341,11 +378,11 @@ def auto_detect_sparse_attention_config(
 
     if "log_a" in prefill and "b" in prefill:
         return SkipSoftmaxConfig.with_calibration(
-            formula=SkipSoftmaxFormula(log_a=prefill["log_a"], b=prefill["b"]),
+            formula=SkipSoftmaxFormula(**_formula_kwargs_from_prefill(prefill)),
         )
     if "a" in prefill and "b" in prefill:
         return SkipSoftmaxConfig.with_calibration(
-            formula=SkipSoftmaxFormula(log_a=math.log(prefill["a"]), b=prefill["b"]),
+            formula=SkipSoftmaxFormula(**_formula_kwargs_from_prefill(prefill)),
         )
 
     return None
@@ -356,11 +393,26 @@ def apply_skip_softmax_overrides(model: "torch.nn.Module", skip_softmax: SkipSof
     if skip_softmax._layer_overrides is None and skip_softmax._component_configs is None:
         return 0
 
+    return set_skip_softmax_enabled(model, skip_softmax, enabled=True)
+
+
+def set_skip_softmax_enabled(
+    model: "torch.nn.Module",
+    skip_softmax: SkipSoftmaxConfig,
+    *,
+    enabled: bool,
+) -> int:
+    """Enable or disable skip-softmax on all constructed TRTLLM attention backends.
+
+    ``enabled=False`` clears the backend sparse config for dense attention.
+    ``enabled=True`` restores the calibrated per-layer threshold, including
+    ModelOpt disabled-layer overrides.
+    """
     from tensorrt_llm._torch.visual_gen.attention_backend.trtllm import TrtllmAttention
 
     modified = 0
     for name, module in model.named_modules():
-        threshold = skip_softmax.resolve_threshold(name)
+        threshold = skip_softmax.resolve_threshold(name) if enabled else None
         attn = getattr(module, "attn", None)
         targets = []
         if isinstance(attn, TrtllmAttention):
@@ -370,7 +422,7 @@ def apply_skip_softmax_overrides(model: "torch.nn.Module", skip_softmax: SkipSof
             targets.append(inner)
 
         for target in targets:
-            if threshold is not None:
+            if enabled and threshold is not None:
                 target.sparse_attention_config = SkipSoftmaxAttentionConfig(
                     threshold_scale_factor={"prefill": threshold, "decode": 0}
                 )

--- a/tests/unittest/_torch/visual_gen/test_attention_integration.py
+++ b/tests/unittest/_torch/visual_gen/test_attention_integration.py
@@ -227,6 +227,47 @@ def generate_rope_embeddings(
     return freqs_cos, freqs_sin
 
 
+def test_fused_rope_reshape_accepts_visual_gen_broadcast_layouts():
+    seq_len = 5
+    head_dim = 8
+    num_heads = 4
+
+    shd = torch.randn(1, seq_len, 1, head_dim)
+    hsd = torch.randn(1, 1, seq_len, head_dim)
+    per_head = torch.randn(seq_len, num_heads, head_dim)
+    combined = torch.randn(seq_len, num_heads * head_dim)
+
+    assert Attention._reshape_rope_for_fused_op(shd, num_heads, head_dim).shape == (
+        seq_len,
+        head_dim,
+    )
+    assert Attention._reshape_rope_for_fused_op(hsd, num_heads, head_dim).shape == (
+        seq_len,
+        head_dim,
+    )
+    assert Attention._reshape_rope_for_fused_op(per_head, num_heads, head_dim).shape == (
+        seq_len,
+        num_heads * head_dim,
+    )
+    assert Attention._reshape_rope_for_fused_op(combined, num_heads, head_dim).shape == (
+        seq_len,
+        num_heads * head_dim,
+    )
+
+
+def test_fused_rope_tokens_per_batch_marks_shared_batch_rope():
+    batch_size = 2
+    seq_len = 5
+    head_dim = 8
+
+    shared_rope = torch.randn(seq_len, head_dim)
+    expanded_rope = torch.randn(batch_size * seq_len, head_dim)
+
+    assert Attention._rope_tokens_per_batch(shared_rope, batch_size, seq_len, -1) == seq_len
+    assert Attention._rope_tokens_per_batch(expanded_rope, batch_size, seq_len, -1) == 0
+    assert Attention._rope_tokens_per_batch(expanded_rope, batch_size, seq_len, 2) == seq_len
+
+
 # ============================================================================
 # Test functions
 # ============================================================================

--- a/tests/unittest/_torch/visual_gen/test_skip_softmax_config.py
+++ b/tests/unittest/_torch/visual_gen/test_skip_softmax_config.py
@@ -14,6 +14,7 @@ from tensorrt_llm.visual_gen.sparse_attention import (
     SkipSoftmaxConfig,
     SkipSoftmaxFormula,
     apply_skip_softmax_overrides,
+    set_skip_softmax_enabled,
 )
 
 # =============================================================================
@@ -70,6 +71,7 @@ class TestSkipSoftmaxConfigConstruction:
                     "algorithm": "skip_softmax",
                     "threshold_scale_factor": 5000.0,
                     "target_sparsity": 0.5,
+                    "first_dense_steps": 16,
                 },
             }
         )
@@ -78,6 +80,7 @@ class TestSkipSoftmaxConfigConstruction:
         assert sc.algorithm == "skip_softmax"
         assert sc.threshold_scale_factor == 5000.0
         assert sc.target_sparsity == 0.5
+        assert sc.first_dense_steps == 16
 
     def test_attention_config_rejects_calibration_fields(self):
         """``formula`` and ``layer_overrides`` are not part of the user surface.
@@ -120,6 +123,24 @@ class TestSkipSoftmaxConfigConstruction:
         dumped = original.model_dump()
         rehydrated = AttentionConfig(**dumped)
         assert rehydrated.model_dump() == dumped
+
+    def test_public_overrides_preserve_first_dense_steps_when_omitted(self):
+        """ModelOpt calibration keeps its dense prefix unless the user sets one."""
+        loaded = SkipSoftmaxConfig.with_calibration(
+            target_sparsity=0.5,
+            first_dense_steps=12,
+            formula=SkipSoftmaxFormula(log_a=math.log(0.0003), b=7.5),
+        )
+        assert (
+            loaded._with_public_overrides(SkipSoftmaxConfig(target_sparsity=0.7)).first_dense_steps
+            == 12
+        )
+        assert (
+            loaded._with_public_overrides(
+                SkipSoftmaxConfig(target_sparsity=0.7, first_dense_steps=16)
+            ).first_dense_steps
+            == 16
+        )
 
     def test_attention_config_no_sparse(self):
         cfg = AttentionConfig(backend="VANILLA")
@@ -337,6 +358,51 @@ config_groups:
         # 'a' should be normalized to log_a = log(a)
         assert cfg._formula.log_a == pytest.approx(math.log(7e-5))
         assert cfg._formula.b == pytest.approx(7.929109)
+
+    def test_load_modelopt_yaml_accepts_consistent_a_and_log_a(self, tmp_path):
+        """ModelOpt may emit both 'a' and 'log_a'; accept them when consistent."""
+        from tensorrt_llm.visual_gen.sparse_attention import load_sparse_config_from_yaml
+
+        a = 2227.5528011152483
+        yaml_content = f"""
+config_groups:
+  group_0:
+    sparse_algo: softmax_skip
+    threshold_scale_factor:
+      formula: a * exp(b * target_sparsity)
+      prefill:
+        a: {a}
+        b: 4.300334457820109
+        log_a: {math.log(a)}
+"""
+        yaml_file = tmp_path / "sparse.yaml"
+        yaml_file.write_text(yaml_content)
+
+        cfg = load_sparse_config_from_yaml(str(yaml_file))
+        assert cfg is not None
+        assert cfg._formula.log_a == pytest.approx(math.log(a))
+        assert cfg._formula.b == pytest.approx(4.300334457820109)
+
+    def test_load_modelopt_yaml_rejects_inconsistent_a_and_log_a(self, tmp_path):
+        """Reject dual-format ModelOpt YAML if the two coefficients disagree."""
+        from tensorrt_llm.visual_gen.sparse_attention import load_sparse_config_from_yaml
+
+        yaml_content = """
+config_groups:
+  group_0:
+    sparse_algo: softmax_skip
+    threshold_scale_factor:
+      formula: a * exp(b * target_sparsity)
+      prefill:
+        a: 100.0
+        b: 4.0
+        log_a: 1.0
+"""
+        yaml_file = tmp_path / "sparse.yaml"
+        yaml_file.write_text(yaml_content)
+
+        with pytest.raises(ValueError, match="disagree"):
+            load_sparse_config_from_yaml(str(yaml_file))
 
     def test_load_consolidated_modelopt_yaml_component_map(self, tmp_path):
         """Load current ModelOpt YAML with separate component calibration."""
@@ -612,6 +678,22 @@ class TestApplySkipSoftmaxOverrides:
         model = self._make_mock_model()
         cfg = SkipSoftmaxConfig(threshold_scale_factor=5000.0)
         assert apply_skip_softmax_overrides(model, cfg) == 0
+
+    def test_set_skip_softmax_enabled_global_dense_prefix(self):
+        model = self._make_mock_model()
+        cfg = SkipSoftmaxConfig(threshold_scale_factor=5000.0)
+
+        n = set_skip_softmax_enabled(model, cfg, enabled=True)
+        assert n == 3
+        assert model.block0.attn.sparse_attention_config is not None
+        assert model.block1.attn.sparse_attention_config is not None
+        assert model.block2.attn.sparse_attention_config is not None
+
+        n = set_skip_softmax_enabled(model, cfg, enabled=False)
+        assert n == 3
+        assert model.block0.attn.sparse_attention_config is None
+        assert model.block1.attn.sparse_attention_config is None
+        assert model.block2.attn.sparse_attention_config is None
 
     def test_overrides_applied(self):
         model = self._make_mock_model()

--- a/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
+++ b/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
@@ -5,6 +5,7 @@
 
 import itertools
 import pickle
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -21,6 +22,7 @@ from tensorrt_llm.visual_gen.args import (
     TorchCompileConfig,
     VisualGenArgs,
 )
+from tensorrt_llm.visual_gen.sparse_attention import SkipSoftmaxConfig
 
 
 class TestVisualGenArgsStrictValidation:
@@ -106,6 +108,31 @@ class TestAttentionConfigQuantValidation:
         )
 
         assert attention.quant_attention_config is not None
+
+
+class TestVisualGenExampleConfigs:
+    def test_wan22_skip_softmax_bf16_recipe_config(self):
+        repo_root = Path(__file__).resolve().parents[4]
+        config_path = (
+            repo_root
+            / "examples"
+            / "visual_gen"
+            / "configs"
+            / "wan2.2-t2v-bf16-skip-softmax-8gpu.yaml"
+        )
+
+        args = VisualGenArgs.from_yaml(config_path)
+        sparse_cfg = args.attention_config.sparse_attention_config
+
+        assert args.attention_config.backend == "TRTLLM"
+        assert isinstance(sparse_cfg, SkipSoftmaxConfig)
+        assert sparse_cfg.target_sparsity == 0.75
+        assert sparse_cfg.first_dense_steps == 16
+        assert args.torch_compile_config.enable is True
+        assert args.parallel_config.cfg_size == 2
+        assert args.parallel_config.ulysses_size == 4
+        assert args.parallel_config.parallel_vae_size == 8
+        assert args.cuda_graph_config.enable is False
 
 
 class TestPipelineRegistryUnique:


### PR DESCRIPTION
## Summary
- Add an 8-GPU BF16 WAN skip-softmax recipe config using TRTLLM attention, target sparsity 0.75, and 16 dense warmup steps.
- Wire `first_dense_steps` into the VisualGen skip-softmax path so early denoising steps can run dense before sparse attention is enabled.
- Keep the recipe on the GI path for WAN GELU: block-level torch.compile remains enabled and GELU stays in the compiled transformer block path. Self-attention uses the existing fused QK-Norm + RoPE path.
- Keep the recipe config aligned with the current ModelOpt flow: use a checkpoint-root `sparse.yaml` for calibration/disabled-layer data, with `sparse_config_path` remaining as an advanced fallback.

## Follow-up measurement
- Detailed LPIPS and end-to-end timing results for this recipe will be added after the final validation sweep/report is ready.

## Testing
- `pre-commit run --files <changed files>`
- `python3 -m py_compile <changed Python files>`
- `git diff --check origin/main...HEAD`

Focused pytest was not run in this non-Docker shell because `mpi4py` could not load `libmpi`.