### PR TITLE
[#10710][feat] Make explicit CLI flags take precedence over --config / --extra_llm_api_options YAML

### DIFF
--- a/docs/source/commands/trtllm-serve/trtllm-serve.rst
+++ b/docs/source/commands/trtllm-serve/trtllm-serve.rst
@@ -317,7 +317,7 @@ Example output:
 Configuring with YAML Files
 ----------------------------
 
-You can configure various options of ``trtllm-serve`` using YAML files by setting the ``--config`` option to the path of a YAML file. The arguments in the file override the corresponding command line arguments.
+You can configure various options of ``trtllm-serve`` using YAML files by setting the ``--config`` option to the path of a YAML file. Explicit CLI flags take precedence over values in the YAML; un-set CLI flags fall back to the YAML.
 
 .. include:: ../../_includes/note_sections.rst
    :start-after: .. start-note-config-flag-alias

--- a/docs/source/release-notes.md
+++ b/docs/source/release-notes.md
@@ -26,6 +26,8 @@ All published functionality in the Release Notes has been fully tested and verif
 
 ### API Changes
 
+- `trtllm-serve`, `trtllm-eval`, `trtllm-bench`: explicit CLI flags now take precedence over values in `--config` / `--extra_llm_api_options` YAML files (was: YAML overrode CLI). Un-set CLI flags continue to fall back to the YAML, then to model-specific and built-in defaults.
+
 ### Fixed Issues
 
 ### Known Issues

--- a/tensorrt_llm/bench/benchmark/__init__.py
+++ b/tensorrt_llm/bench/benchmark/__init__.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, Optional, Set
 
 from pydantic import AliasChoices, BaseModel, Field
 
@@ -10,7 +10,33 @@ from tensorrt_llm.bench.benchmark.utils.processes import IterationWriter
 from tensorrt_llm.bench.build.build import get_model_config
 from tensorrt_llm.bench.dataclasses.configuration import RuntimeConfig
 from tensorrt_llm.bench.dataclasses.general import BenchmarkEnvironment
+from tensorrt_llm.commands.utils import \
+    collect_explicit_cli_keys as _collect_explicit_cli_keys
 from tensorrt_llm.logger import logger
+
+# Map trtllm-bench Click parameter names to the LlmArgs field name (or
+# merge-function CLI scalar name) used by `update_llm_args_with_extra_options`.
+# `--beam_width` is intentionally absent: it feeds SamplingParams, not
+# llm_args, so it must not participate in the CLI-vs-YAML precedence.
+_BENCH_CLICK_TO_LLM_ARG = {
+    "tp": "tensor_parallel_size",
+    "pp": "pipeline_parallel_size",
+    "ep": "moe_expert_parallel_size",
+    "cluster_size": "moe_cluster_parallel_size",
+    "kv_cache_free_gpu_mem_fraction": "free_gpu_memory_fraction",
+    "enable_chunked_context": "enable_chunked_prefill",
+}
+
+
+def collect_explicit_cli_keys() -> Set[str]:
+    """Return CLI flag names the user typed, translated to LlmArgs field names.
+
+    Thin trtllm-bench-specific wrapper around the shared
+    `tensorrt_llm.commands.utils.collect_explicit_cli_keys` helper.
+    """
+    return _collect_explicit_cli_keys(exclude=("extra_llm_api_options",
+                                               "config"),
+                                      translate=_BENCH_CLICK_TO_LLM_ARG)
 
 
 class GeneralExecSettings(BaseModel):

--- a/tensorrt_llm/bench/benchmark/low_latency.py
+++ b/tensorrt_llm/bench/benchmark/low_latency.py
@@ -24,7 +24,8 @@ from click_option_group import (MutuallyExclusiveOptionGroup, OptionGroup,
                                 optgroup)
 from huggingface_hub import snapshot_download
 
-from tensorrt_llm.bench.benchmark import (generate_json_report,
+from tensorrt_llm.bench.benchmark import (collect_explicit_cli_keys,
+                                          generate_json_report,
                                           get_general_cli_options, get_llm)
 from tensorrt_llm.bench.benchmark.utils.asynchronous import async_benchmark
 from tensorrt_llm.bench.benchmark.utils.general import generate_warmup_dataset
@@ -65,9 +66,9 @@ from tensorrt_llm.sampling_params import SamplingParams
     "extra_llm_api_options",
     type=str,
     default=None,
-    help=
-    "Path to a YAML file that overwrites the parameters specified by trtllm-bench. "
-    "Can be specified as either --config or --extra_llm_api_options.")
+    help="Path to a YAML configuration file. Explicit CLI flags take precedence "
+    "over values in this file. Can be specified as either --config or "
+    "--extra_llm_api_options.")
 @optgroup.option(
     "--backend",
     type=click.Choice(ALL_SUPPORTED_BACKENDS),
@@ -297,6 +298,7 @@ def latency_command(
     exec_settings["performance_options"]["multi_block_mode"] = True
 
     exec_settings["extra_llm_api_options"] = params.get("extra_llm_api_options")
+    exec_settings["explicit_cli_keys"] = collect_explicit_cli_keys()
 
     # Decoding Options
     if medusa_choices is not None:

--- a/tensorrt_llm/bench/benchmark/throughput.py
+++ b/tensorrt_llm/bench/benchmark/throughput.py
@@ -25,6 +25,7 @@ from click_option_group import (MutuallyExclusiveOptionGroup, OptionGroup,
 from huggingface_hub import snapshot_download
 
 from tensorrt_llm.bench.benchmark import (GeneralExecSettings,
+                                          collect_explicit_cli_keys,
                                           generate_json_report,
                                           get_general_cli_options, get_llm)
 from tensorrt_llm.bench.benchmark.utils.asynchronous import async_benchmark
@@ -81,9 +82,9 @@ from tensorrt_llm.sampling_params import SamplingParams
     "extra_llm_api_options",
     type=str,
     default=None,
-    help=
-    "Path to a YAML file that overwrites the parameters specified by trtllm-bench. "
-    "Can be specified as either --config or --extra_llm_api_options.")
+    help="Path to a YAML configuration file. Explicit CLI flags take precedence "
+    "over values in this file. Can be specified as either --config or "
+    "--extra_llm_api_options.")
 @optgroup.option("--sampler_options",
                  type=click.Path(exists=True,
                                  readable=True,
@@ -437,6 +438,7 @@ def throughput_command(
     # LlmArgs
     exec_settings["extra_llm_api_options"] = params.pop("extra_llm_api_options")
     exec_settings["iteration_log"] = options.iteration_log
+    exec_settings["explicit_cli_keys"] = collect_explicit_cli_keys()
 
     # Construct the runtime configuration dataclass.
     runtime_config = RuntimeConfig(**exec_settings)

--- a/tensorrt_llm/bench/dataclasses/configuration.py
+++ b/tensorrt_llm/bench/dataclasses/configuration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Set, Union
 
 from pydantic import (BaseModel, Field, PositiveFloat, field_validator,
                       model_validator)
@@ -36,6 +36,7 @@ class RuntimeConfig(BaseModel):
     backend: Literal["pytorch", "_autodeploy", None] = None
     extra_llm_api_options: Optional[str] = None
     iteration_log: Optional[Path] = None
+    explicit_cli_keys: Optional[Set[str]] = None
 
     def get_llm_args(self) -> Dict:
         model = self.engine_dir or self.model_path or self.model
@@ -86,7 +87,9 @@ class RuntimeConfig(BaseModel):
         llm_args["kv_cache_config"] = backend_cache_config | kv_cache_config
 
         updated_llm_args = update_llm_args_with_extra_options(
-            llm_args, self.extra_llm_api_options)
+            llm_args,
+            self.extra_llm_api_options,
+            explicit_cli_keys=self.explicit_cli_keys)
 
         if self.backend == "pytorch":
             cuda_graph_config = updated_llm_args.pop(

--- a/tensorrt_llm/commands/eval.py
+++ b/tensorrt_llm/commands/eval.py
@@ -27,6 +27,17 @@ from ..llmapi import BuildConfig, KvCacheConfig
 from ..llmapi.llm_utils import update_llm_args_with_extra_options
 from ..logger import logger, severity_map
 from ..usage import config as _telemetry_config
+from .utils import collect_explicit_cli_keys
+
+# Map Click parameter names to the LlmArgs field name (or merge-function CLI
+# scalar name) used by `update_llm_args_with_extra_options`.
+_CLICK_TO_LLM_ARG = {
+    "tp_size": "tensor_parallel_size",
+    "pp_size": "pipeline_parallel_size",
+    "ep_size": "moe_expert_parallel_size",
+    "kv_cache_free_gpu_memory_fraction": "free_gpu_memory_fraction",
+    "disable_kv_cache_reuse": "enable_block_reuse",
+}
 
 
 @click.group()
@@ -112,8 +123,9 @@ from ..usage import config as _telemetry_config
               "extra_llm_api_options",
               type=str,
               default=None,
-              help="Path to a YAML file that overwrites the parameters. "
-              "Can be specified as either --config or --extra_llm_api_options.")
+              help="Path to a YAML configuration file. Explicit CLI flags "
+              "take precedence over values in this file. Can be specified "
+              "as either --config or --extra_llm_api_options.")
 @click.option("--disable_kv_cache_reuse",
               is_flag=True,
               default=False,
@@ -131,6 +143,10 @@ def main(ctx, model: str, tokenizer: Optional[str],
          extra_llm_api_options: Optional[str], disable_kv_cache_reuse: bool,
          telemetry: bool):
     logger.set_level(log_level)
+
+    explicit_cli_keys = collect_explicit_cli_keys(
+        exclude=("extra_llm_api_options", "config"),
+        translate=_CLICK_TO_LLM_ARG)
 
     kv_cache_config = KvCacheConfig(
         free_gpu_memory_fraction=kv_cache_free_gpu_memory_fraction,
@@ -182,13 +198,10 @@ def main(ctx, model: str, tokenizer: Optional[str],
             param_hint="backend")
 
     if extra_llm_api_options is not None:
-        llm_args = update_llm_args_with_extra_options(llm_args,
-                                                      extra_llm_api_options)
-
-    # CLI --no-telemetry always wins over YAML config
-    if not telemetry:
-        llm_args["telemetry_config"] = llm_args["telemetry_config"].model_copy(
-            update={"disabled": True})
+        llm_args = update_llm_args_with_extra_options(
+            llm_args,
+            extra_llm_api_options,
+            explicit_cli_keys=explicit_cli_keys)
 
     profiler.start("trtllm init")
     llm = llm_cls(**llm_args)

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -11,7 +11,7 @@ import subprocess  # nosec B404
 import sys
 import uuid
 from pathlib import Path
-from typing import Any, Dict, Literal, Mapping, Optional, Sequence
+from typing import Any, Dict, Literal, Mapping, Optional, Sequence, Set
 
 import click
 import torch
@@ -23,7 +23,8 @@ from tensorrt_llm import LLM as PyTorchLLM
 from tensorrt_llm import MultimodalEncoder
 from tensorrt_llm._tensorrt_engine import LLM
 from tensorrt_llm._utils import mpi_rank
-from tensorrt_llm.commands.utils import get_is_diffusion_model
+from tensorrt_llm.commands.utils import (collect_explicit_cli_keys,
+                                         get_is_diffusion_model)
 from tensorrt_llm.executor.utils import LlmLauncherEnvs
 from tensorrt_llm.inputs.multimodal import MultimodalServerConfig
 from tensorrt_llm.llmapi import (BuildConfig, CapacitySchedulerPolicy,
@@ -119,13 +120,15 @@ def _signal_handler_cleanup_child(signum, frame):
     sys.exit(128 + signum)
 
 
-def is_non_default_or_required(param_name, value, backend):
+def is_non_default_or_required(param_name, value, backend, explicit_cli_keys):
     """
     Check if a parameter should be explicitly included in llm_args.
 
     Returns True if parameter is either:
     1. Always required (core params that must be present), OR
-    2. Different from its default value in the backend's LlmArgs class
+    2. Set explicitly on the CLI (its name or one of its constructor
+       scalars is in `explicit_cli_keys`), OR
+    3. Different from its default value in the backend's LlmArgs class
     """
     always_include = {
         "model", "backend", "tokenizer", "custom_tokenizer",
@@ -137,6 +140,20 @@ def is_non_default_or_required(param_name, value, backend):
 
     if value is None:
         return False
+
+    if param_name in explicit_cli_keys:
+        return True
+
+    # LlmArgs fields built from CLI scalars whose names differ from the field
+    # name (e.g. `--free_gpu_memory_fraction` constructs `kv_cache_config`).
+    cli_derived_fields = {
+        "kv_cache_config": ("free_gpu_memory_fraction", "kv_cache_dtype"),
+        "build_config":
+        ("max_batch_size", "max_num_tokens", "max_beam_width", "max_seq_len"),
+    }
+    if any(s in explicit_cli_keys
+           for s in cli_derived_fields.get(param_name, ())):
+        return True
 
     if backend == "tensorrt":
         llm_args_class = TrtLlmArgs
@@ -192,7 +209,10 @@ def get_llm_args(
         telemetry: bool = True,
         agent_percentage: float = 0.0,
         agent_types: Optional[str] = None,
+        explicit_cli_keys: Optional[Set[str]] = None,
         **llm_args_extra_dict: Any):
+
+    explicit_cli_keys = explicit_cli_keys or set()
 
     if gpus_per_node is None:
         gpus_per_node = device_count()
@@ -209,9 +229,6 @@ def get_llm_args(
             raise ValueError(f"Invalid cp_type: {cp_config['cp_type']}. " \
                              f"Must be one of: {', '.join([t.name for t in CpType])}")
 
-    kv_cache_default_fraction = KvCacheConfig.model_fields[
-        'free_gpu_memory_fraction'].default
-
     cli_maybe_overrides = {
         "model":
         model,
@@ -225,8 +242,7 @@ def get_llm_args(
         tokenizer or model,
         "kv_cache_config":
         KvCacheConfig(free_gpu_memory_fraction=free_gpu_memory_fraction,
-                      dtype=kv_cache_dtype) if free_gpu_memory_fraction
-        != kv_cache_default_fraction or kv_cache_dtype != "auto" else None,
+                      dtype=kv_cache_dtype),
         "cp_config":
         cp_config,
         "build_config":
@@ -291,7 +307,7 @@ def get_llm_args(
     llm_args = {
         param: value
         for param, value in cli_maybe_overrides.items()
-        if is_non_default_or_required(param, value, backend)
+        if is_non_default_or_required(param, value, backend, explicit_cli_keys)
     }
 
     return llm_args, llm_args_extra_dict
@@ -717,9 +733,9 @@ class ChoiceWithAlias(click.Choice):
     type=str,
     default=None,
     help=help_info_with_stability_tag(
-        "Path to a YAML file that overwrites the parameters specified by trtllm-serve. "
-        "Can be specified as either --config or --extra_llm_api_options.",
-        "prototype"))
+        "Path to a YAML configuration file. Explicit CLI flags take precedence "
+        "over values in this file. Can be specified as either --config or "
+        "--extra_llm_api_options.", "prototype"))
 @click.option(
     "--reasoning_parser",
     type=click.Choice(["auto"] + list(ReasoningParserFactory.keys())),
@@ -933,6 +949,9 @@ def serve(
                 f"Failed to import custom module from {custom_module_dir}: {e}")
             raise e
 
+    explicit_cli_keys = collect_explicit_cli_keys(
+        exclude=("extra_llm_api_options", "config"))
+
     def _serve_llm():
         nonlocal server_role
         llm_args, _ = get_llm_args(
@@ -964,19 +983,15 @@ def serve(
             video_pruning_rate=video_pruning_rate,
             telemetry=telemetry,
             agent_percentage=agent_percentage,
-            agent_types=agent_types)
+            agent_types=agent_types,
+            explicit_cli_keys=explicit_cli_keys)
 
         llm_args_extra_dict = {}
         if extra_llm_api_options is not None:
             with open(extra_llm_api_options, 'r') as f:
                 llm_args_extra_dict = yaml.safe_load(f)
-        llm_args = update_llm_args_with_extra_dict(llm_args,
-                                                   llm_args_extra_dict)
-
-        # CLI --no-telemetry always wins over YAML config
-        if not telemetry:
-            llm_args["telemetry_config"] = llm_args[
-                "telemetry_config"].model_copy(update={"disabled": True})
+        llm_args = update_llm_args_with_extra_dict(
+            llm_args, llm_args_extra_dict, explicit_cli_keys=explicit_cli_keys)
 
         metadata_server_cfg = parse_metadata_server_config_file(
             metadata_server_config_file)
@@ -1100,9 +1115,8 @@ def serve(
     "extra_encoder_options",
     type=str,
     default=None,
-    help=
-    "Path to a YAML file that overwrites the parameters specified by trtllm-serve. "
-    "Prefer --config over --extra_encoder_options.")
+    help="Path to a YAML configuration file. Explicit CLI flags take precedence "
+    "over values in this file. Prefer --config over --extra_encoder_options.")
 @click.option("--hf_revision",
               "--revision",
               "revision",
@@ -1143,6 +1157,9 @@ def serve_encoder(model: str, host: str, port: int, log_level: str,
         logger.warning(
             "--extra_encoder_options is deprecated, use --config instead.")
 
+    explicit_cli_keys = collect_explicit_cli_keys(
+        exclude=("extra_encoder_options", "config"))
+
     llm_args, _ = get_llm_args(
         model=model,
         max_batch_size=max_batch_size,
@@ -1152,19 +1169,15 @@ def serve_encoder(model: str, host: str, port: int, log_level: str,
         revision=revision,
         free_gpu_memory_fraction=free_gpu_memory_fraction,
         tensor_parallel_size=tensor_parallel_size,
-        telemetry=telemetry)
+        telemetry=telemetry,
+        explicit_cli_keys=explicit_cli_keys)
 
     encoder_args_extra_dict = {}
     if extra_encoder_options is not None:
         with open(extra_encoder_options, 'r') as f:
             encoder_args_extra_dict = yaml.safe_load(f)
-    encoder_args = update_llm_args_with_extra_dict(llm_args,
-                                                   encoder_args_extra_dict)
-
-    # CLI --no-telemetry always wins over YAML config
-    if not telemetry:
-        encoder_args["telemetry_config"] = encoder_args[
-            "telemetry_config"].model_copy(update={"disabled": True})
+    encoder_args = update_llm_args_with_extra_dict(
+        llm_args, encoder_args_extra_dict, explicit_cli_keys=explicit_cli_keys)
 
     metadata_server_cfg = parse_metadata_server_config_file(
         metadata_server_config_file)
@@ -1324,9 +1337,15 @@ def disaggregated_mpi_worker(config_file: Optional[str], log_level: str):
             DisaggLauncherEnvs.TLLM_DISAGG_INSTANCE_IDX)
         server_cfg = disagg_cfg.server_configs[int(instance_idx)]
 
-        llm_args, llm_args_extra_dict = get_llm_args(**server_cfg.other_args)
-        llm_args = update_llm_args_with_extra_dict(llm_args,
-                                                   llm_args_extra_dict)
+        # Treat every disagg-YAML field as user-set so default-valued fields
+        # (e.g. tensor_parallel_size: 1) are not silently dropped.
+        disagg_explicit_keys = set(server_cfg.other_args)
+        llm_args, llm_args_extra_dict = get_llm_args(
+            **server_cfg.other_args, explicit_cli_keys=disagg_explicit_keys)
+        llm_args = update_llm_args_with_extra_dict(
+            llm_args,
+            llm_args_extra_dict,
+            explicit_cli_keys=disagg_explicit_keys)
 
         # Ignore the non-LLM args
         llm_args.pop("router", None)
@@ -1349,9 +1368,15 @@ def disaggregated_mpi_worker(config_file: Optional[str], log_level: str):
             instance_idx)
         server_cfg = disagg_cfg.server_configs[instance_idx]
 
-        llm_args, llm_args_extra_dict = get_llm_args(**server_cfg.other_args)
-        llm_args = update_llm_args_with_extra_dict(llm_args,
-                                                   llm_args_extra_dict)
+        # Treat every disagg-YAML field as user-set so default-valued fields
+        # (e.g. tensor_parallel_size: 1) are not silently dropped.
+        disagg_explicit_keys = set(server_cfg.other_args)
+        llm_args, llm_args_extra_dict = get_llm_args(
+            **server_cfg.other_args, explicit_cli_keys=disagg_explicit_keys)
+        llm_args = update_llm_args_with_extra_dict(
+            llm_args,
+            llm_args_extra_dict,
+            explicit_cli_keys=disagg_explicit_keys)
 
         _launch_disaggregated_leader(sub_comm, instance_idx, config_file,
                                      log_level)

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -313,6 +313,29 @@ def get_llm_args(
     return llm_args, llm_args_extra_dict
 
 
+def _build_llm_args_from_disagg_server_cfg(other_args: Dict) -> Dict:
+    """Construct llm_args from a disaggregated server config's `other_args`.
+
+    `other_args` is a single source — there is no separate CLI / YAML
+    distinction here. Every key is user-set, so we pass all keys as
+    `explicit_cli_keys` to `get_llm_args` to bypass the value-based filter
+    that would otherwise drop fields equal to their LlmArgs class defaults
+    (e.g. `tensor_parallel_size: 1`).
+
+    Do NOT pass `explicit_cli_keys` to `update_llm_args_with_extra_dict`:
+    `llm_args_extra_dict` here is just the catch-all for kwargs that didn't
+    match `get_llm_args`'s named signature (e.g. `quant_config`,
+    `lora_config`, `pytorch_backend_config`) — it isn't a separate YAML
+    being overridden. Passing the explicit set would trigger the merge
+    function's "drop YAML keys claimed by explicit CLI" filter and
+    silently lose those kwargs.
+    """
+    disagg_explicit_keys = set(other_args)
+    llm_args, llm_args_extra_dict = get_llm_args(
+        **other_args, explicit_cli_keys=disagg_explicit_keys)
+    return update_llm_args_with_extra_dict(llm_args, llm_args_extra_dict)
+
+
 def launch_server(
         host: str,
         port: int,
@@ -1337,15 +1360,7 @@ def disaggregated_mpi_worker(config_file: Optional[str], log_level: str):
             DisaggLauncherEnvs.TLLM_DISAGG_INSTANCE_IDX)
         server_cfg = disagg_cfg.server_configs[int(instance_idx)]
 
-        # Treat every disagg-YAML field as user-set so default-valued fields
-        # (e.g. tensor_parallel_size: 1) are not silently dropped.
-        disagg_explicit_keys = set(server_cfg.other_args)
-        llm_args, llm_args_extra_dict = get_llm_args(
-            **server_cfg.other_args, explicit_cli_keys=disagg_explicit_keys)
-        llm_args = update_llm_args_with_extra_dict(
-            llm_args,
-            llm_args_extra_dict,
-            explicit_cli_keys=disagg_explicit_keys)
+        llm_args = _build_llm_args_from_disagg_server_cfg(server_cfg.other_args)
 
         # Ignore the non-LLM args
         llm_args.pop("router", None)
@@ -1368,15 +1383,10 @@ def disaggregated_mpi_worker(config_file: Optional[str], log_level: str):
             instance_idx)
         server_cfg = disagg_cfg.server_configs[instance_idx]
 
-        # Treat every disagg-YAML field as user-set so default-valued fields
-        # (e.g. tensor_parallel_size: 1) are not silently dropped.
-        disagg_explicit_keys = set(server_cfg.other_args)
-        llm_args, llm_args_extra_dict = get_llm_args(
-            **server_cfg.other_args, explicit_cli_keys=disagg_explicit_keys)
-        llm_args = update_llm_args_with_extra_dict(
-            llm_args,
-            llm_args_extra_dict,
-            explicit_cli_keys=disagg_explicit_keys)
+        # NOTE: the resulting llm_args is currently unused; _launch_disaggregated_leader
+        # does not take it. Keeping the call symmetric with the client branch above
+        # so any future use of llm_args here behaves the same way.
+        _build_llm_args_from_disagg_server_cfg(server_cfg.other_args)
 
         _launch_disaggregated_leader(sub_comm, instance_idx, config_file,
                                      log_level)

--- a/tensorrt_llm/commands/utils.py
+++ b/tensorrt_llm/commands/utils.py
@@ -2,6 +2,10 @@
 import json
 import logging
 import os
+from typing import Iterable, Mapping, Optional, Set
+
+import click
+from click.core import ParameterSource
 
 from tensorrt_llm._torch.visual_gen.config import ParallelConfig
 from tensorrt_llm.llmapi.utils import download_hf_partial
@@ -132,6 +136,29 @@ def get_visual_gen_model_type(model_path: str):
         f"Unknown VISUAL_GEN model type for model path: {model_path},"
         f"available models: {VISUAL_GEN_PARTIAL_MODEL_NAME_TO_MODEL_TYPE.keys()}"
     )
+
+
+def collect_explicit_cli_keys(
+    *,
+    exclude: Iterable[str] = (),
+    translate: Optional[Mapping[str, str]] = None,
+) -> Set[str]:
+    """Return CLI flag names the user typed on the command line.
+
+    Reads the active Click context and selects parameters whose source is
+    `ParameterSource.COMMANDLINE`. `exclude` removes meta flags that aren't
+    config keys (e.g. `extra_llm_api_options`, `config`). `translate` maps
+    each Click parameter name to the LlmArgs field name (or merge-function
+    CLI scalar name) used by `update_llm_args_with_extra_options`; entries
+    not present in the map pass through unchanged.
+    """
+    ctx = click.get_current_context()
+    explicit = {
+        name for name in ctx.params if ctx.get_parameter_source(name) == ParameterSource.COMMANDLINE
+    } - set(exclude)
+    if translate is None:
+        return explicit
+    return {translate.get(name, name) for name in explicit}
 
 
 def get_visual_gen_num_gpus(diffusion_config: dict) -> int:

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -4567,23 +4567,56 @@ class TorchLlmArgs(BaseLlmArgs):
 def update_llm_args_with_extra_dict(
         llm_args: Dict,
         llm_args_dict: Dict,
-        extra_llm_api_options: Optional[str] = None) -> Dict:
+        extra_llm_api_options: Optional[str] = None,
+        explicit_cli_keys: Optional[Set[str]] = None) -> Dict:
+    """Merge YAML overrides into a CLI-derived llm_args dict.
+
+    If `explicit_cli_keys` is provided, those CLI flag names override any
+    conflicting YAML values. CLI flags whose name does not match the
+    LlmArgs field name (e.g. `--free_gpu_memory_fraction` constructs
+    `kv_cache_config.free_gpu_memory_fraction`) are mapped to the nested
+    field they target.
+
+    If `explicit_cli_keys` is None, YAML wins on conflicts.
+    """
+    # CLI scalar -> nested KvCacheConfig field. Callers add the CLI scalar
+    # name to `explicit_cli_keys` to make it win over YAML's same-named
+    # field inside `kv_cache_config:`.
+    cli_to_kv_cache_field = {
+        "free_gpu_memory_fraction": "free_gpu_memory_fraction",
+        "kv_cache_dtype": "dtype",
+        "enable_block_reuse": "enable_block_reuse",
+    }
+    # Scalars that live both at the top level of LlmArgs and inside
+    # `build_config`. The build_config patch propagates the winning source
+    # to the nested location.
+    build_config_dual_loc_keys = (
+        "max_batch_size",
+        "max_num_tokens",
+        "max_beam_width",
+        "max_seq_len",
+    )
+
+    explicit_cli_keys = explicit_cli_keys or set()
 
     if 'hf_revision' in llm_args_dict:
         llm_args_dict.setdefault('revision', llm_args_dict.pop('hf_revision'))
 
     # Deep merge kv_cache_config to prevent partial YAML kv_cache_config from replacing the complete kv_cache_config
     if 'kv_cache_config' in llm_args and 'kv_cache_config' in llm_args_dict:
-        # Convert KvCacheConfig object to dict if necessary
         base_kv_config = llm_args['kv_cache_config']
         if isinstance(base_kv_config, KvCacheConfig):
             base_kv_config = base_kv_config.model_dump(exclude_unset=True)
-        llm_args_dict['kv_cache_config'] = base_kv_config | llm_args_dict[
-            'kv_cache_config']
+        merged = base_kv_config | llm_args_dict['kv_cache_config']
+        for cli_name, kv_field in cli_to_kv_cache_field.items():
+            if cli_name in explicit_cli_keys and kv_field in base_kv_config:
+                merged[kv_field] = base_kv_config[kv_field]
+        llm_args_dict['kv_cache_config'] = merged
 
     # Deep merge telemetry_config: YAML can override fields like `disabled`,
     # but `usage_context` is determined by the CLI entry point and must not
-    # be overridden by user config.
+    # be overridden by user config. When `--telemetry/--no-telemetry` was
+    # typed explicitly, CLI's `disabled` wins over YAML.
     if 'telemetry_config' in llm_args and 'telemetry_config' in llm_args_dict:
         yaml_tc = llm_args_dict['telemetry_config']
         if not isinstance(yaml_tc, (dict, TelemetryConfig)):
@@ -4597,7 +4630,18 @@ def update_llm_args_with_extra_dict(
             if isinstance(yaml_tc, TelemetryConfig):
                 yaml_tc = yaml_tc.model_dump(exclude_unset=True)
             yaml_tc.pop('usage_context', None)
-            llm_args_dict['telemetry_config'] = base_tc | yaml_tc
+            merged = base_tc | yaml_tc
+            if "telemetry" in explicit_cli_keys and 'disabled' in base_tc:
+                merged['disabled'] = base_tc['disabled']
+            llm_args_dict['telemetry_config'] = merged
+
+    # Drop YAML keys claimed by explicit CLI flags so the outer merge below
+    # cannot overwrite them.
+    if explicit_cli_keys:
+        llm_args_dict = {
+            k: v
+            for k, v in llm_args_dict.items() if k not in explicit_cli_keys
+        }
 
     field_mapping = {
         "quant_config": QuantConfig,
@@ -4617,8 +4661,9 @@ def update_llm_args_with_extra_dict(
     for field_name, field_type in field_mapping.items():
         if field_name in llm_args_dict:
             llm_args_dict[field_name] = field_type(**llm_args_dict[field_name])
-            extra_llm_str = f"because it's specified in {extra_llm_api_options}" if extra_llm_api_options else ""
-            logger.warning(f"Overriding {field_name} {extra_llm_str}")
+            if field_name in llm_args:
+                extra_llm_str = f" because it's specified in {extra_llm_api_options}" if extra_llm_api_options else ""
+                logger.info(f"YAML overrides {field_name}{extra_llm_str}")
 
     llm_args = llm_args | llm_args_dict
 
@@ -4628,28 +4673,35 @@ def update_llm_args_with_extra_dict(
         if isinstance(llm_args["build_config"], dict):
             llm_args["build_config"] = BuildConfig(**llm_args["build_config"])
 
-        for key in [
-                "max_batch_size",
-                "max_num_tokens",
-                "max_beam_width",
-                "max_seq_len",
-        ]:
-            if key in llm_args_dict:
+        # Propagate dual-location scalars into build_config: explicit CLI flag
+        # wins; otherwise YAML's top-level scalar; otherwise leave alone.
+        for key in build_config_dual_loc_keys:
+            if key in explicit_cli_keys and key in llm_args:
+                setattr(llm_args["build_config"], key, llm_args[key])
                 logger.info(
-                    f"Overriding {key} from build_config to {llm_args_dict[key]}"
+                    f"build_config.{key} set to {llm_args[key]} from explicit CLI flag"
                 )
+            elif key in llm_args_dict:
                 setattr(llm_args["build_config"], key, llm_args_dict[key])
+                logger.info(
+                    f"build_config.{key} set to {llm_args_dict[key]} from YAML top-level scalar"
+                )
 
     return llm_args
 
 
-def update_llm_args_with_extra_options(llm_args: Dict,
-                                       extra_llm_api_options: str) -> Dict:
+def update_llm_args_with_extra_options(
+        llm_args: Dict,
+        extra_llm_api_options: str,
+        explicit_cli_keys: Optional[Set[str]] = None) -> Dict:
     if extra_llm_api_options is not None:
         with open(extra_llm_api_options, 'r') as f:
             llm_args_dict = yaml.safe_load(f)
-            llm_args = update_llm_args_with_extra_dict(llm_args, llm_args_dict,
-                                                       extra_llm_api_options)
+            llm_args = update_llm_args_with_extra_dict(
+                llm_args,
+                llm_args_dict,
+                extra_llm_api_options,
+                explicit_cli_keys=explicit_cli_keys)
     return llm_args
 
 

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -4636,8 +4636,17 @@ def update_llm_args_with_extra_dict(
             llm_args_dict['telemetry_config'] = merged
 
     # Drop YAML keys claimed by explicit CLI flags so the outer merge below
-    # cannot overwrite them.
+    # cannot overwrite them. Warn only when the CLI value actually differs from
+    # the YAML value, so users who relied on the previous "YAML wins" behavior
+    # are notified that CLI now takes precedence.
     if explicit_cli_keys:
+        overridden = sorted(
+            k for k in llm_args_dict
+            if k in explicit_cli_keys and llm_args.get(k) != llm_args_dict[k])
+        if overridden:
+            logger.warning(
+                f"Explicit CLI flag(s) {overridden} override the value(s) set "
+                f"in the YAML config; CLI takes precedence.")
         llm_args_dict = {
             k: v
             for k, v in llm_args_dict.items() if k not in explicit_cli_keys
@@ -4674,13 +4683,23 @@ def update_llm_args_with_extra_dict(
             llm_args["build_config"] = BuildConfig(**llm_args["build_config"])
 
         # Propagate dual-location scalars into build_config: explicit CLI flag
-        # wins; otherwise YAML's top-level scalar; otherwise leave alone.
+        # wins; otherwise YAML's top-level scalar; otherwise leave alone. Warn
+        # only when the explicit CLI value actually differs from the YAML
+        # build_config value being replaced (a genuine override).
         for key in build_config_dual_loc_keys:
             if key in explicit_cli_keys and key in llm_args:
+                # Warn only on a genuine override of a YAML build_config value;
+                # otherwise just record where the value came from.
+                if getattr(llm_args["build_config"], key) != llm_args[key]:
+                    logger.warning(
+                        f"Explicit CLI flag --{key}={llm_args[key]} overrides "
+                        f"the value set in the YAML build_config; CLI takes "
+                        f"precedence.")
+                else:
+                    logger.info(
+                        f"build_config.{key} set to {llm_args[key]} from explicit CLI flag"
+                    )
                 setattr(llm_args["build_config"], key, llm_args[key])
-                logger.info(
-                    f"build_config.{key} set to {llm_args[key]} from explicit CLI flag"
-                )
             elif key in llm_args_dict:
                 setattr(llm_args["build_config"], key, llm_args_dict[key])
                 logger.info(

--- a/tests/unittest/llmapi/apps/_test_trtllm_serve_duplicated_args.py
+++ b/tests/unittest/llmapi/apps/_test_trtllm_serve_duplicated_args.py
@@ -22,8 +22,10 @@ def temp_extra_llm_api_options_file():
     temp_dir = tempfile.gettempdir()
     temp_file_path = os.path.join(temp_dir, "extra_llm_api_options.yaml")
     try:
+        # YAML attempts to override tensor_parallel_size; the CLI's --tp_size 1
+        # must win. max_num_tokens is YAML-only and should still be applied.
         extra_llm_api_options_dict = {
-            "tensor_parallel_size": 1,
+            "tensor_parallel_size": 99,
             "max_num_tokens": 16384,
         }
 
@@ -45,8 +47,10 @@ def example_root():
 @pytest.fixture(scope="module")
 def server(model_name: str, temp_extra_llm_api_options_file: str):
     model_path = get_model_path(model_name)
+    # If YAML's tensor_parallel_size: 99 won over the CLI, the server would
+    # fail to start; the server starting at TP=1 is the assertion.
     args = [
-        "--tp_size", "99", "--extra_llm_api_options",
+        "--tp_size", "1", "--extra_llm_api_options",
         temp_extra_llm_api_options_file
     ]
     with RemoteOpenAIServer(model_path, port=8000,

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -599,7 +599,14 @@ def test_update_llm_args_with_extra_dict_with_nested_dict():
 
 
 class TestTelemetryConfigPrecedence:
-    """Test that telemetry config follows: default < YAML < CLI precedence."""
+    """Telemetry-config precedence in the merge helper.
+
+    Two modes are exercised:
+    - `explicit_cli_keys is None` (legacy / programmatic): YAML wins on
+      conflicts; `usage_context` carve-out still applies.
+    - `explicit_cli_keys` provided (CLI mode): explicit keys win on
+      conflicts; see `TestExplicitCliKeysPrecedence` for that path.
+    """
 
     def test_default_telemetry_config_preserved_when_no_yaml(self):
         """Default telemetry_config survives YAML merge when YAML has none."""
@@ -660,8 +667,15 @@ class TestTelemetryConfigPrecedence:
         assert tc.usage_context == UsageContext.CLI_SERVE
         assert tc.disabled is True
 
-    def test_cli_disabled_overrides_yaml_enabled(self):
-        """CLI --telemetry-disabled wins over YAML disabled=false."""
+    def test_cli_disabled_overrides_yaml_enabled_legacy_fixup(self):
+        """Legacy post-merge fixup pattern (preserved for back-compat).
+
+        This exercises the pre-`explicit_cli_keys` flow where the CLI entry
+        point overrode `disabled` after the merge by hand. The CLI tools no
+        longer use this pattern (they pass `explicit_cli_keys={"telemetry"}`
+        instead — see `TestExplicitCliKeysPrecedence`), but third-party
+        callers may still build the merge this way.
+        """
         from tensorrt_llm.usage.config import TelemetryConfig, UsageContext
         base = {
             "model":
@@ -672,7 +686,6 @@ class TestTelemetryConfigPrecedence:
         }
         yaml_dict = {"telemetry_config": {"disabled": False}}
         merged = update_llm_args_with_extra_dict(base, yaml_dict)
-        # Simulate CLI --no-telemetry (as done in eval.py / serve.py)
         telemetry = False
         if not telemetry:
             merged["telemetry_config"] = merged["telemetry_config"].model_copy(
@@ -682,7 +695,7 @@ class TestTelemetryConfigPrecedence:
         assert tc.usage_context == UsageContext.CLI_EVAL
 
     def test_yaml_disabled_respected_when_cli_not_set(self):
-        """When CLI doesn't set --no-telemetry, YAML disabled=true is kept."""
+        """YAML disabled=true is honored when explicit_cli_keys is None."""
         from tensorrt_llm.usage.config import TelemetryConfig, UsageContext
         base = {
             "model":
@@ -693,11 +706,6 @@ class TestTelemetryConfigPrecedence:
         }
         yaml_dict = {"telemetry_config": {"disabled": True}}
         merged = update_llm_args_with_extra_dict(base, yaml_dict)
-        # CLI flag not set (--telemetry is default True) — no override
-        telemetry = True
-        if not telemetry:
-            merged["telemetry_config"] = merged["telemetry_config"].model_copy(
-                update={"disabled": True})
         tc = merged["telemetry_config"]
         assert tc.disabled is True
         assert tc.usage_context == UsageContext.CLI_SERVE
@@ -719,6 +727,219 @@ class TestTelemetryConfigPrecedence:
         assert isinstance(tc, TelemetryConfig)
         assert tc.usage_context == UsageContext.CLI_SERVE
         assert tc.disabled is False
+
+
+class TestExplicitCliKeysPrecedence:
+    """`explicit_cli_keys` makes the CLI side win over YAML on conflicts."""
+
+    def test_explicit_cli_key_wins_over_yaml_scalar(self):
+        base = {"model": "dummy", "tensor_parallel_size": 4}
+        yaml_dict = {"tensor_parallel_size": 8}
+        merged = update_llm_args_with_extra_dict(
+            base, yaml_dict, explicit_cli_keys={"tensor_parallel_size"})
+        assert merged["tensor_parallel_size"] == 4
+
+    def test_non_explicit_value_loses_to_yaml_scalar(self):
+        # Backward-compat: when explicit_cli_keys is None, today's "YAML wins"
+        # behavior is preserved.
+        base = {"model": "dummy", "tensor_parallel_size": 4}
+        yaml_dict = {"tensor_parallel_size": 8}
+        merged = update_llm_args_with_extra_dict(base, yaml_dict)
+        assert merged["tensor_parallel_size"] == 8
+
+    def test_kv_cache_config_explicit_field_wins_yaml_siblings_preserved(self):
+        # CLI builds a KvCacheConfig from --free_gpu_memory_fraction; YAML
+        # provides a partial kv_cache_config with sibling fields that should
+        # survive the merge.
+        base = {
+            "model": "dummy",
+            "kv_cache_config": KvCacheConfig(free_gpu_memory_fraction=0.85),
+        }
+        yaml_dict = {
+            "kv_cache_config": {
+                "free_gpu_memory_fraction": 0.5,
+                "enable_block_reuse": False,
+            }
+        }
+        merged = update_llm_args_with_extra_dict(
+            base, yaml_dict, explicit_cli_keys={"free_gpu_memory_fraction"})
+        kv = merged["kv_cache_config"]
+        assert kv.free_gpu_memory_fraction == 0.85
+        assert kv.enable_block_reuse is False
+
+    def test_build_config_tier_cli_wins(self):
+        # Tier 1: explicit CLI scalar wins over both top-level YAML and nested.
+        base = {
+            "model": "dummy",
+            "max_batch_size": 64,
+            "build_config": BuildConfig(max_batch_size=64),
+        }
+        yaml_dict = {
+            "max_batch_size": 256,
+            "build_config": {
+                "max_batch_size": 300
+            },
+        }
+        merged = update_llm_args_with_extra_dict(
+            base, yaml_dict, explicit_cli_keys={"max_batch_size"})
+        assert merged["max_batch_size"] == 64
+        assert merged["build_config"].max_batch_size == 64
+
+    def test_build_config_tier_yaml_top_level_wins(self):
+        # Tier 2: no explicit CLI, but YAML top-level scalar -> propagate to
+        # build_config (legacy behavior).
+        base = {
+            "model": "dummy",
+            "build_config": BuildConfig(max_batch_size=8),
+        }
+        yaml_dict = {"max_batch_size": 256}
+        merged = update_llm_args_with_extra_dict(base, yaml_dict)
+        assert merged["max_batch_size"] == 256
+        assert merged["build_config"].max_batch_size == 256
+
+    def test_build_config_tier_yaml_nested_only_leaves_alone(self):
+        # Tier 3: no explicit CLI, no top-level YAML scalar; nested YAML
+        # build_config is imported by the outer merge.
+        base = {
+            "model": "dummy",
+            "build_config": BuildConfig(max_batch_size=8),
+        }
+        yaml_dict = {"build_config": {"max_batch_size": 256}}
+        merged = update_llm_args_with_extra_dict(base, yaml_dict)
+        assert merged["build_config"].max_batch_size == 256
+
+    def test_telemetry_explicit_disabled_wins_over_yaml(self):
+        from tensorrt_llm.usage.config import TelemetryConfig, UsageContext
+        base = {
+            "model":
+            "dummy",
+            "telemetry_config":
+            TelemetryConfig(disabled=True,
+                            usage_context=UsageContext.CLI_SERVE),
+        }
+        yaml_dict = {"telemetry_config": {"disabled": False}}
+        merged = update_llm_args_with_extra_dict(
+            base, yaml_dict, explicit_cli_keys={"telemetry"})
+        assert merged["telemetry_config"].disabled is True
+
+    def test_kv_cache_dtype_explicit_wins_over_yaml(self):
+        # Mirrors the kv_cache_config tier-2 path for the second mapped CLI
+        # scalar (`--kv_cache_dtype` -> `kv_cache_config.dtype`).
+        base = {
+            "model": "dummy",
+            "kv_cache_config": KvCacheConfig(dtype="fp8"),
+        }
+        yaml_dict = {"kv_cache_config": {"dtype": "auto"}}
+        merged = update_llm_args_with_extra_dict(
+            base, yaml_dict, explicit_cli_keys={"kv_cache_dtype"})
+        assert merged["kv_cache_config"].dtype == "fp8"
+
+    def test_enable_block_reuse_explicit_wins_over_yaml(self):
+        # Mirrors the kv_cache_config tier-2 path for `--disable_kv_cache_reuse`,
+        # which translates to `enable_block_reuse` in explicit_cli_keys.
+        base = {
+            "model": "dummy",
+            "kv_cache_config": KvCacheConfig(enable_block_reuse=False),
+        }
+        yaml_dict = {"kv_cache_config": {"enable_block_reuse": True}}
+        merged = update_llm_args_with_extra_dict(
+            base, yaml_dict, explicit_cli_keys={"enable_block_reuse"})
+        assert merged["kv_cache_config"].enable_block_reuse is False
+
+
+class TestEvalTranslationMap:
+    """eval's _CLICK_TO_LLM_ARG via the shared helper."""
+
+    def _collect(self, click_param_names):
+        """Simulate a Click ctx with the given params explicitly set."""
+        import click as _click
+
+        from tensorrt_llm.commands import eval as eval_mod
+        from tensorrt_llm.commands.utils import collect_explicit_cli_keys
+
+        class _FakeCtx:
+            params = {name: object() for name in click_param_names}
+
+            @staticmethod
+            def get_parameter_source(name):
+                from click.core import ParameterSource
+                return ParameterSource.COMMANDLINE
+
+        original = _click.get_current_context
+        _click.get_current_context = lambda: _FakeCtx
+        try:
+            return collect_explicit_cli_keys(
+                exclude=("extra_llm_api_options", "config"),
+                translate=eval_mod._CLICK_TO_LLM_ARG)
+        finally:
+            _click.get_current_context = original
+
+    @pytest.mark.parametrize(
+        "click_name,expected",
+        [
+            ("tp_size", "tensor_parallel_size"),
+            ("pp_size", "pipeline_parallel_size"),
+            ("ep_size", "moe_expert_parallel_size"),
+            ("kv_cache_free_gpu_memory_fraction", "free_gpu_memory_fraction"),
+            ("disable_kv_cache_reuse", "enable_block_reuse"),
+            ("max_batch_size", "max_batch_size"),  # unmapped: identity
+        ])
+    def test_translation(self, click_name, expected):
+        assert expected in self._collect({click_name})
+
+    def test_meta_flags_excluded(self):
+        assert self._collect({"extra_llm_api_options", "config"}) == set()
+
+
+class TestBenchTranslationMap:
+    """`collect_explicit_cli_keys` in bench.benchmark rewrites Click param names."""
+
+    def _collect(self, click_param_names):
+        import click as _click
+
+        from tensorrt_llm.bench import benchmark as bench_mod
+
+        class _FakeCtx:
+            params = {name: object() for name in click_param_names}
+
+            @staticmethod
+            def get_parameter_source(name):
+                from click.core import ParameterSource
+                return ParameterSource.COMMANDLINE
+
+        # `bench_mod.collect_explicit_cli_keys()` calls `click.get_current_context()`.
+        original = _click.get_current_context
+        _click.get_current_context = lambda: _FakeCtx
+        try:
+            return bench_mod.collect_explicit_cli_keys()
+        finally:
+            _click.get_current_context = original
+
+    @pytest.mark.parametrize(
+        "click_name,expected",
+        [
+            ("tp", "tensor_parallel_size"),
+            ("pp", "pipeline_parallel_size"),
+            ("ep", "moe_expert_parallel_size"),
+            ("cluster_size", "moe_cluster_parallel_size"),
+            ("kv_cache_free_gpu_mem_fraction", "free_gpu_memory_fraction"),
+            ("enable_chunked_context", "enable_chunked_prefill"),
+            ("max_batch_size", "max_batch_size"),  # unmapped: identity
+        ])
+    def test_translation(self, click_name, expected):
+        assert expected in self._collect({click_name})
+
+    def test_beam_width_does_not_participate(self):
+        # `--beam_width` is a SamplingParams flag, not an llm_args field, so
+        # it must be left out of the translation map. Otherwise an explicit
+        # `--beam_width N` would silently drop YAML's `max_beam_width`
+        # without anything in llm_args to replace it.
+        explicit = self._collect({"beam_width"})
+        assert "max_beam_width" not in explicit
+        assert "beam_width" in explicit
+
+    def test_meta_flags_excluded(self):
+        assert self._collect({"extra_llm_api_options", "config"}) == set()
 
 
 class TestTorchLlmArgsCudaGraphSettings:
@@ -1386,89 +1607,121 @@ class TestStrictBaseModelArbitraryArgs:
 class TestServeDefaults:
 
     def test_serve_get_llm_args_preserves_model_defaults(self):
-        # Get llm_args with default values (simulating serve.py behavior)
+        # No explicit CLI flags: only required params and serve-side defaults
+        # reach the constructor; everything else is left for YAML / model
+        # defaults to provide.
         llm_args, _ = get_llm_args(
             model=llama_model_path,
             backend="pytorch",
-            # Don't pass parameters to test default behavior
         )
 
-        # Verify that required params are present
         assert "model" in llm_args
         assert "backend" in llm_args
         assert "postprocess_tokenizer_dir" in llm_args
 
-        # For PyTorch backend, build_config and scheduler_config should NOT be included
+        # PyTorch backend: build_config / scheduler_config stay None and are
+        # filtered out.
         assert "build_config" not in llm_args
         assert "scheduler_config" not in llm_args
 
-        # Test that when we DO pass values, they're included appropriately
+        # Explicit CLI flags survive the filter.
         llm_args_with_values, _ = get_llm_args(
             model=llama_model_path,
             backend="pytorch",
-            max_batch_size=128,  # Non-default value
-            tensor_parallel_size=4,  # Non-default value
+            max_batch_size=128,
+            tensor_parallel_size=4,
+            explicit_cli_keys={"max_batch_size", "tensor_parallel_size"},
         )
         assert llm_args_with_values.get("max_batch_size") == 128
         assert llm_args_with_values.get("tensor_parallel_size") == 4
 
     def test_serve_filters_default_values(self):
-        # Test with all defaults for PyTorch backend
+        # All defaults, no explicit CLI flags.
         llm_args, _ = get_llm_args(model=llama_model_path, backend="pytorch")
 
-        # Should only include required params
         assert "model" in llm_args
         assert "backend" in llm_args
         assert "postprocess_tokenizer_dir" in llm_args
 
-        # Should NOT include build_config or scheduler_config for PyTorch
         assert "build_config" not in llm_args
         assert "scheduler_config" not in llm_args
 
-        # Test with custom values
+        # Custom values survive only when listed in explicit_cli_keys.
         llm_args, _ = get_llm_args(
             model=llama_model_path,
             backend="pytorch",
-            max_batch_size=128,  # Non-default value
-            tensor_parallel_size=4,  # Non-default value
+            max_batch_size=128,
+            tensor_parallel_size=4,
+            explicit_cli_keys={"max_batch_size", "tensor_parallel_size"},
         )
 
-        # Custom values should be included
         assert llm_args.get("max_batch_size") == 128
         assert llm_args.get("tensor_parallel_size") == 4
 
     def test_serve_backend_specific_configs(self):
-        # Test PyTorch backend
+        # PyTorch backend: build_config / scheduler_config stay None and are
+        # filtered out.
         llm_args_pytorch, _ = get_llm_args(model=llama_model_path,
                                            backend="pytorch")
         assert "build_config" not in llm_args_pytorch
         assert "scheduler_config" not in llm_args_pytorch
 
-        # Test TensorRT backend
+        # TensorRT backend: both are non-None and differ from the LlmArgs
+        # class default, so the value-based filter keeps them.
         llm_args_trt, _ = get_llm_args(model=llama_model_path,
                                        backend="tensorrt")
         assert "build_config" in llm_args_trt
         assert "scheduler_config" in llm_args_trt
 
+    def test_serve_explicit_cli_default_value_wins_over_yaml(self):
+        """Typing --tensor_parallel_size 1 (the default) must beat YAML."""
+        llm_args, _ = get_llm_args(
+            model=llama_model_path,
+            backend="pytorch",
+            tensor_parallel_size=1,
+            explicit_cli_keys={"tensor_parallel_size"},
+        )
+        # The CLI value lands in llm_args because it is explicit.
+        assert llm_args["tensor_parallel_size"] == 1
+        merged = update_llm_args_with_extra_dict(
+            llm_args,
+            {"tensor_parallel_size": 8},
+            explicit_cli_keys={"tensor_parallel_size"},
+        )
+        assert merged["tensor_parallel_size"] == 1
+
     def test_serve_is_non_default_or_required_helper(self):
         # Test always_include parameters
-        assert is_non_default_or_required("model", "test-model", "pytorch")
-        assert is_non_default_or_required("backend", "pytorch", "pytorch")
+        assert is_non_default_or_required("model", "test-model", "pytorch",
+                                          set())
+        assert is_non_default_or_required("backend", "pytorch", "pytorch",
+                                          set())
         assert is_non_default_or_required("tokenizer", "test-tokenizer",
-                                          "pytorch")
+                                          "pytorch", set())
 
         # Test None values
-        assert not is_non_default_or_required("max_batch_size", None, "pytorch")
+        assert not is_non_default_or_required("max_batch_size", None, "pytorch",
+                                              set())
 
         # Test default values (should return False)
         assert not is_non_default_or_required("tensor_parallel_size", 1,
-                                              "pytorch")
+                                              "pytorch", set())
         assert not is_non_default_or_required("pipeline_parallel_size", 1,
-                                              "pytorch")
+                                              "pytorch", set())
 
         # Test non-default values (should return True)
-        assert is_non_default_or_required("tensor_parallel_size", 4, "pytorch")
-        assert is_non_default_or_required("max_batch_size", 128, "pytorch")
+        assert is_non_default_or_required("tensor_parallel_size", 4, "pytorch",
+                                          set())
+        assert is_non_default_or_required("max_batch_size", 128, "pytorch",
+                                          set())
+
+        # Test explicit CLI source overrides the default-equals-value check
+        assert is_non_default_or_required("tensor_parallel_size", 1, "pytorch",
+                                          {"tensor_parallel_size"})
+        # Test CLI-derived field (--free_gpu_memory_fraction -> kv_cache_config)
+        assert is_non_default_or_required("kv_cache_config", KvCacheConfig(),
+                                          "pytorch",
+                                          {"free_gpu_memory_fraction"})
 
 
 class TestPyTorchBackendModelDefaults:

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -942,6 +942,57 @@ class TestBenchTranslationMap:
         assert self._collect({"extra_llm_api_options", "config"}) == set()
 
 
+class TestDisaggLauncherKwargsPreservation:
+    """Regression tests for `_build_llm_args_from_disagg_server_cfg`.
+
+    The disagg launcher takes a single `server_cfg.other_args` dict and
+    must produce an llm_args dict that contains every user-set field —
+    including kwargs that fell through `get_llm_args`'s named signature
+    into its `**llm_args_extra_dict` catch-all (e.g. `quant_config`,
+    `lora_config`, `pytorch_backend_config`).
+    """
+
+    def test_extra_kwargs_survive(self):
+        from tensorrt_llm.commands.serve import \
+            _build_llm_args_from_disagg_server_cfg
+
+        other_args = {
+            "model": llama_model_path,
+            "backend": "pytorch",
+            "tensor_parallel_size": 1,
+            "gpus_per_node": 1,
+            # These do not match get_llm_args's named params; they go into
+            # **llm_args_extra_dict and must reach the LLM constructor.
+            "quant_config": {
+                "quant_algo": "FP8"
+            },
+            "lora_config": {
+                "lora_dir": ["/tmp/lora-test"]
+            },
+        }
+
+        final = _build_llm_args_from_disagg_server_cfg(other_args)
+
+        assert "quant_config" in final
+        assert "lora_config" in final
+        assert isinstance(final["quant_config"], QuantConfig)
+        assert isinstance(final["lora_config"], LoraConfig)
+
+    def test_default_valued_named_params_survive(self):
+        """A disagg-YAML field equal to its LlmArgs class default survives."""
+        from tensorrt_llm.commands.serve import \
+            _build_llm_args_from_disagg_server_cfg
+
+        other_args = {
+            "model": llama_model_path,
+            "backend": "pytorch",
+            "tensor_parallel_size": 1,  # equals LlmArgs class default
+            "gpus_per_node": 1,
+        }
+        final = _build_llm_args_from_disagg_server_cfg(other_args)
+        assert final.get("tensor_parallel_size") == 1
+
+
 class TestTorchLlmArgsCudaGraphSettings:
 
     def test_cuda_graph_batch_sizes_case_0(self):


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CLI/YAML override behavior documentation: explicit CLI flags now take precedence over YAML configuration values. Unset CLI flags fall back to YAML settings, then to defaults for `trtllm-serve`, `trtllm-eval`, and `trtllm-bench` commands.
  * Updated TensorRT-LLM Release 1.2 release notes to reflect the revised precedence rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->
Title
[#10710][feat] Make explicit CLI flags take precedence over --config / --extra_llm_api_options YAML
Body

@coderabbitai summary
## Description
Today, `--config` / `--extra_llm_api_options` YAML values silently override
explicit CLI flags in `trtllm-serve`, `trtllm-eval`, and `trtllm-bench`.
For example, `trtllm-serve <model> --tensor_parallel_size 4 --config foo.yaml`
with `tensor_parallel_size: 8` in `foo.yaml` runs at TP=8. This is
unconventional and inconsistent with AutoDeploy's documented
`CLI > YAML > defaults`. See #10710.
This PR flips the precedence to **explicit CLI > YAML > defaults**, using
`click.Context.get_parameter_source()` to detect which flags the user
typed. Un-set CLI flags still fall back to YAML.
Backward-compatible: programmatic callers of
`update_llm_args_with_extra_dict` (Triton backend, LLM API, third-party)
that don't pass the new `explicit_cli_keys` argument keep today's
behavior.

Why this is the right direction, briefly:
- **In-repo precedent.** AutoDeploy's config system already documents
  exactly this order — see `docs/source/features/auto_deploy/advanced/expert_configurations.md`:
  *"CLI Arguments (highest priority) > YAML Configs > Default Settings (lowest priority)."*
  This PR brings the rest of the CLI surface in line.
- **Conventional behavior.** kubectl, Helm, Hydra, Pydantic Settings,
  and ~every argparse-based Python CLI implement `CLI > config-file > defaults`.
  The current "YAML > CLI" is the surprise.
- **PR #11035 acknowledged the gap.** That PR added a value-based mitigation in `trtllm-serve`'s `is_non_default_or_required`, and the
  reviewers explicitly flagged the remaining limitation:
  *"CLI params can make this a bit tricky, since you need to
  distinguish between a CLI param being explicitly set vs. defaulting
  to a value."* This PR closes that gap with
  `click.Context.get_parameter_source()`.
## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->
`tests/unittest/llmapi/test_llm_args.py`:
- New: `TestExplicitCliKeysPrecedence`, `TestEvalTranslationMap`,
  `TestBenchTranslationMap` — cover precedence, deep-merges, build_config
  tiered rule, and per-tool Click-flag → LlmArgs translations.
- Existing `TestTelemetryConfigPrecedence` and
  `TestPyTorchBackendModelDefaults` pass unchanged (back-compat).

`tests/unittest/llmapi/apps/_test_trtllm_serve_duplicated_args.py`:
- flipped — `--tp_size 1` plus YAML `tensor_parallel_size: 99`; server
starting at TP=1 is the assertion that CLI wins.

`pytest tests/unittest/llmapi/test_llm_args.py -q`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [v ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
