### PR TITLE
[None][perf] DSv4 MegaMoE: quantize activations directly into the DG SymmBuffer

### DIFF
--- a/cpp/tensorrt_llm/thop/mxFp8Quantize.cpp
+++ b/cpp/tensorrt_llm/thop/mxFp8Quantize.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,6 +102,74 @@ std::tuple<at::Tensor, at::Tensor> mxfp8_quantize(
 
     return {valMxFP8, scaleFP8SF};
 }
+
+// In-place variant of mxfp8_quantize: writes the quantized values + scale factors into the
+// caller-provided out_val / out_sf (e.g. a DeepGEMM SymmBuffer slice) instead of allocating.
+void mxfp8_quantize_out(
+    at::Tensor const& self, at::Tensor& out_val, at::Tensor& out_sf, bool isSfSwizzledLayout, int64_t alignment = 32)
+{
+    CHECK_TH_CUDA(self);
+    CHECK_CONTIGUOUS(self);
+    CHECK_TH_CUDA(out_val);
+    CHECK_CONTIGUOUS(out_val);
+    CHECK_TH_CUDA(out_sf);
+    CHECK_CONTIGUOUS(out_sf);
+    TORCH_CHECK(out_val.device() == self.device() && out_sf.device() == self.device(),
+        "out_val / out_sf must be on the same device as input");
+
+    static constexpr int SF_VEC_SIZE = 32;
+    TORCH_CHECK(alignment % SF_VEC_SIZE == 0, "alignment must be divisible by SF_VEC_SIZE = 32");
+
+    auto const& inputShape = self.sizes();
+    auto const& rank = inputShape.size();
+    TORCH_CHECK(rank >= 2, "Input should be >=2D tensor.");
+    int64_t m = 1;
+    for (size_t i = 0; i < rank - 1; i++)
+    {
+        m *= inputShape[i];
+    }
+    auto const k = inputShape[rank - 1];
+    TORCH_CHECK(k % SF_VEC_SIZE == 0, "k must be divisible by SF_VEC_SIZE = 32");
+    auto const padded_k = ((k + alignment - 1) / alignment) * alignment;
+
+    TORCH_CHECK(out_val.scalar_type() == at::ScalarType::Float8_e4m3fn, "out_val must be Float8_e4m3fn");
+    TORCH_CHECK(out_val.numel() >= m * padded_k, "out_val too small: need m*padded_k = ", m * padded_k,
+        " elements, got ", out_val.numel());
+
+    int64_t const SFSize = isSfSwizzledLayout ? tensorrt_llm::computeSwizzledLayoutSFSize(m, padded_k / SF_VEC_SIZE)
+                                              : tensorrt_llm::computeLinearLayoutSFSize(m, padded_k / SF_VEC_SIZE);
+    // SF is written as bytes (SF_DTYPE == uint8); require >= SFSize bytes (any out_sf dtype).
+    TORCH_CHECK(out_sf.nbytes() >= static_cast<size_t>(SFSize), "out_sf too small: need ", SFSize, " bytes, got ",
+        out_sf.nbytes());
+
+    const thread_local int mMultiProcessorCount = tensorrt_llm::common::getMultiProcessorCount();
+    auto const layout = isSfSwizzledLayout ? tensorrt_llm::QuantizationSFLayout::SWIZZLED
+                                           : tensorrt_llm::QuantizationSFLayout::LINEAR;
+
+#define LAUNCH_MXFP8_QUANTIZE_OUT_KERNEL(T)                                                                            \
+    tensorrt_llm::kernels::invokeMxFP8Quantization(1, m, k, padded_k, reinterpret_cast<T*>(self.data_ptr()),           \
+        reinterpret_cast<int64_t*>(out_val.data_ptr()), reinterpret_cast<int32_t*>(out_sf.data_ptr()), layout,         \
+        mMultiProcessorCount, at::cuda::getCurrentCUDAStream(self.get_device()));
+
+    if (self.scalar_type() == at::ScalarType::Half)
+    {
+        LAUNCH_MXFP8_QUANTIZE_OUT_KERNEL(half)
+    }
+    else if (self.scalar_type() == at::ScalarType::BFloat16)
+    {
+#ifdef ENABLE_BF16
+        LAUNCH_MXFP8_QUANTIZE_OUT_KERNEL(__nv_bfloat16)
+#else
+        C10_THROW_ERROR(NotImplementedError, "BFloat16 must be enabled to quantize an bf16 tensor to mxfp8.");
+#endif
+    }
+    else
+    {
+        C10_THROW_ERROR(NotImplementedError, "mxfp8_quantize_out only supports input tensor with dtypes fp16/bf16.");
+    }
+
+#undef LAUNCH_MXFP8_QUANTIZE_OUT_KERNEL
+}
 } // namespace torch_ext
 
 TRTLLM_NAMESPACE_END
@@ -111,9 +179,13 @@ TORCH_LIBRARY_FRAGMENT(trtllm, m)
     m.def(
         "mxfp8_quantize(Tensor input, bool swizzedLayout=True, int alignment=32) "
         "-> (Tensor, Tensor)");
+    m.def(
+        "mxfp8_quantize_out(Tensor input, Tensor(a!) out_val, Tensor(b!) out_sf, "
+        "bool swizzedLayout=True, int alignment=32) -> ()");
 }
 
 TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
 {
     m.impl("mxfp8_quantize", &tensorrt_llm::torch_ext::mxfp8_quantize);
+    m.impl("mxfp8_quantize_out", &tensorrt_llm::torch_ext::mxfp8_quantize_out);
 }

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -361,6 +361,20 @@ def _register_fake():
         scale_fp8_sf = input.new_empty((sf_size, ), dtype=torch.uint8)
         return val_mxfp8, scale_fp8_sf
 
+    # Register only when the op is in the loaded binary (the source tree may predate it).
+    if hasattr(torch.ops.trtllm, "mxfp8_quantize_out"):
+
+        @torch.library.register_fake("trtllm::mxfp8_quantize_out")
+        def _(
+            input: torch.Tensor,
+            out_val: torch.Tensor,
+            out_sf: torch.Tensor,
+            swizzled_layout: bool = True,
+            alignment: int = 32,
+        ):
+            # In-place: writes into out_val / out_sf, returns nothing.
+            return None
+
     @torch.library.register_fake("trtllm::mxe4m3_mxe2m1_block_scale_moe_runner")
     def _(
         routing_logits: Optional[torch.Tensor],

--- a/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py
@@ -112,6 +112,10 @@ def _quantize_bf16_to_fp8_ue8m0(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Te
     return _FUSED_PER_TOKEN_CAST(x)
 
 
+def _inplace_quant_into_symm_available() -> bool:
+    return hasattr(torch.ops, "trtllm") and hasattr(torch.ops.trtllm, "mxfp8_quantize_out")
+
+
 class MegaMoEDeepGemm(MoE):
     """MoE backend wrapping DeepGEMM's fused ``fp8_fp4_mega_moe`` kernel."""
 
@@ -631,6 +635,16 @@ class MegaMoEDeepGemm(MoE):
         """
         del post_quant_comm  # MegaMoE runs pre-quant comm via DG SymmBuffer
         x_bf16 = x.to(torch.bfloat16).contiguous()
+        buf = self._symm_buffer
+        n = x_bf16.shape[0]
+        if (
+            _inplace_quant_into_symm_available()
+            and buf is not None
+            and 0 < n <= self.max_num_tokens
+        ):
+            # Quantize directly into the SymmBuffer so run_moe can skip the staging copy.
+            torch.ops.trtllm.mxfp8_quantize_out(x_bf16, buf.x[:n], buf.x_sf[:n], False, 32)
+            return buf.x[:n], buf.x_sf[:n]
         return _quantize_bf16_to_fp8_ue8m0(x_bf16)
 
     def run_moe(
@@ -670,8 +684,10 @@ class MegaMoEDeepGemm(MoE):
         )
 
         if num_tokens > 0:
-            buf.x[:num_tokens].copy_(x)
-            buf.x_sf[:num_tokens].copy_(x_sf)
+            # Skip the staging copy if quantize_input already wrote x in-place into buf.x.
+            if x.data_ptr() != buf.x.data_ptr():
+                buf.x[:num_tokens].copy_(x)
+                buf.x_sf[:num_tokens].copy_(x_sf)
             buf.topk_idx[:num_tokens].copy_(token_selected_experts.to(torch.int64))
             buf.topk_weights[:num_tokens].copy_(token_final_scales.to(torch.float32))
 


### PR DESCRIPTION
MegaMoEDeepGemm.run_moe stages the per-token MXFP8 activations and scale factors into the DeepGEMM NVLink SymmBuffer with a buf.x.copy_(x) / buf.x_sf.copy_(x_sf) on every MoE layer — after quantize_input has already produced them in freshly-allocated tensors.

This PR adds an out-variant op trtllm::mxfp8_quantize_out that writes the quantizer result directly into caller-provided output tensors (same kernel as mxfp8_quantize, only the output buffer differs). quantize_input now quantizes straight into buf.x / buf.x_sf, and run_moe skips the staging copy when its input already aliases the SymmBuffer (detected via data_ptr), falling back to the previous quantize+copy path otherwise (e.g. on a binary that predates the op).