### PR TITLE
[None][fix] LTX-2 audio PE pad: use token-axis seq_dim=1 for token-major rope

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
@@ -1569,12 +1569,11 @@ class LTXModel(nn.Module):
                 audio_context, audio_context_mask, audio_positions, dtype
             )
             a_kv = [block.audio_attn2.project_kv(a_ctx) for block in self.transformer_blocks]
-            # Extend audio PE to padded length once at cache-build time.
-            # seq_dim per rope type: SPLIT cos [B,H,T,D] → 2, INTERLEAVED [B,T,D] → 1.
+            # cos/sin are token-major: token axis is dim 1 for both SPLIT and
+            # INTERLEAVED rope, matching `_make_pe_local`'s `cos[:, s:e]` shard.
             if self._audio_pad > 0:
-                pe_seq_dim = 2 if (a_pe is not None and a_pe[0].ndim == 4) else 1
-                a_pe = self._pad_pe(a_pe, self._audio_pad, seq_dim=pe_seq_dim)
-                a_cross_pe = self._pad_pe(a_cross_pe, self._audio_pad, seq_dim=pe_seq_dim)
+                a_pe = self._pad_pe(a_pe, self._audio_pad, seq_dim=1)
+                a_cross_pe = self._pad_pe(a_cross_pe, self._audio_pad, seq_dim=1)
 
         # Build sharded-local PE in the form the attention consumer expects.
         # fuse_qk_norm_rope=True (LTX-2 default) -> 2D [T_local, H*D] contiguous,

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_ulysses.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_ulysses.py
@@ -29,6 +29,7 @@ try:
         create_attention_metadata_state,
     )
     from tensorrt_llm._torch.visual_gen.mapping import VisualGenMapping
+    from tensorrt_llm._torch.visual_gen.models.ltx2.ltx2_core.rope import LTXRopeType
     from tensorrt_llm._utils import get_free_port
     from tensorrt_llm.models.modeling_utils import QuantConfig
     from tensorrt_llm.visual_gen.args import AttentionConfig, ParallelConfig, TorchCompileConfig
@@ -95,35 +96,33 @@ def run_test_in_distributed(world_size: int, test_fn: Callable, *fn_args):
 # Small AudioVideo config. ulysses_size=2 needs:
 # - num_attention_heads % 2 == 0 (video heads sharded by Ulysses)
 # - audio_num_attention_heads % 2 == 0 (audio heads sharded by Ulysses)
-# - head_dim ∈ {64, 128} to exercise the fused FA4 / vanilla rope path
+# - head_dim ∈ {64, 128} so LTX2Attention.forward() takes the fused-rope
+#   branch (otherwise eager fallback masks the cos/num_tokens check that
+#   exposes the audio-pad seq_dim regression).
 # cross_attention_dim must equal inner_dim (=num_heads * head_dim) because
 # caption_projection projects caption_channels → inner_dim and the result is
 # fed straight into block.attn2.to_k whose input dim = cross_attention_dim.
 # Same constraint applies to audio_*.
-# head_dim=32 deliberately falls outside {64, 128} so LTX2Attention.forward()
-# takes ``_forward_unfused`` and ``project_kv`` skips ``fused_dit_split_norm``.
-# That keeps the test runnable in dev images without the LTX-2 C++ extensions
-# while still exercising the v2a Ulysses + key_padding_mask code paths under
-# both VANILLA and FLASH_ATTN4 backends.
 _AV_CONFIG = dict(
     num_attention_heads=4,
-    attention_head_dim=32,
+    attention_head_dim=64,
     in_channels=16,
     out_channels=16,
     num_layers=2,
-    cross_attention_dim=128,  # = num_attention_heads * attention_head_dim
+    cross_attention_dim=256,  # = num_attention_heads * attention_head_dim
     caption_channels=64,
     norm_eps=1e-6,
     positional_embedding_max_pos=[4, 32, 32],
     timestep_scale_multiplier=1000,
     use_middle_indices_grid=True,
     audio_num_attention_heads=4,
-    audio_attention_head_dim=32,
+    audio_attention_head_dim=64,
     audio_in_channels=16,
     audio_out_channels=16,
-    audio_cross_attention_dim=128,  # = audio_num_attention_heads * audio_attention_head_dim
+    audio_cross_attention_dim=256,  # = audio_num_attention_heads * audio_attention_head_dim
     audio_positional_embedding_max_pos=[64],
     av_ca_timestep_scale_multiplier=1,
+    rope_type=LTXRopeType.SPLIT,
 )
 
 


### PR DESCRIPTION
## Summary

- Fix LTX-2 audio PE padding regression: `prepare_text_cache` was padding the head axis (dim 2) instead of the token axis (dim 1) for 4D positional embeddings, leaving `cos.shape[1]` short of the padded latent. The fused split-norm-rope kernel then trips its `cos_emb.size(0) == num_tokens` check at runtime with `cos=N` vs `num_tokens=N+1` (e.g. `cos=31, num_tokens=32` at WAN-style warmup; `cos=7, num_tokens=8` at the unit-test scale).
- Update the audio-padding unit test to default to `rope_type=SPLIT` so it actually exercises the production token-major rope layout. Previously the test fixture used `INTERLEAVED` (3D PE), which made the `ndim == 4 -> seq_dim=2` heuristic fall through to the correct `seq_dim=1` by accident and missed the regression entirely.

## Root cause

`a173175ac2 [None][perf] ltx2: switch SPLIT-rope cos/sin to token-major [B, T, H, D]` changed the SPLIT-rope layout from `[B, H, T, D]` to token-major `[B, T, H, D]` and removed all `swapaxes(1, 2)` plumbing; at the same time it correctly set `pe_seq_dim = 1` in the (then-existing) code that touched PE shape.

`b1dfd3094c [TRTLLM-12653][feat] LTX-2 Ulysses cross-attention for v2a with audio padding (#14044)` later introduced the `_pad_pe` helper plus its call site in `prepare_text_cache` to extend audio PE under Ulysses. The new call site picked `seq_dim` via:

```python
pe_seq_dim = 2 if (a_pe is not None and a_pe[0].ndim == 4) else 1
```

That heuristic is the pre-token-major convention (`[B, H, T, D]`). For the post-token-major SPLIT layout the actual seq axis is dim 1, so the pad grows the head axis instead and downstream `_make_pe_local`'s `cos[:, s:e]` still shards the un-padded token axis — exactly the off-by-`_audio_pad` we observe at runtime.

The existing `test_av_ulysses_audio_pad` did not catch this because:
1. `LTXModel` defaults `rope_type=LTXRopeType.INTERLEAVED`, and the test fixture left that default.
2. INTERLEAVED produces 3D PE, so the `ndim == 4` branch is never taken and the call lands on `seq_dim=1` by accident.

## Fix

`tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py`:

```python
# cos/sin are token-major: SPLIT rope -> [B, T, H, D]; INTERLEAVED -> [B, T, D].
# The token (seq) axis is dim 1 in both, matching `_make_pe_local`'s
# `cos[:, s:e]` shard.
if self._audio_pad > 0:
    a_pe = self._pad_pe(a_pe, self._audio_pad, seq_dim=1)
    a_cross_pe = self._pad_pe(a_cross_pe, self._audio_pad, seq_dim=1)
```

This matches `_make_pe_local`'s slicing on dim 1 and is uniform across SPLIT/INTERLEAVED.

`tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_ulysses.py`:

- Thread `rope_type_name` through `_logic_ltx2_av_ulysses_vs_single_gpu` and default to `"SPLIT"` so the audio-padding parity test exercises the production layout that motivated the original `_pad_pe` plumbing.
- Without the fix, `test_av_ulysses_audio_pad[VANILLA]` and `[FA4]` both fail with the expected `cos_emb.size(0) (7) must equal num_tokens (8)` mismatch (verified locally on dev image).
- With the fix, both pass.

## Test plan

- [x] `pytest tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_ulysses.py -v` (4 cases pass — no-pad / pad × VANILLA / FA4) on a 2-GPU dev image.
- [x] Reproduced the bug on tip of `main` with the new SPLIT-default test (fails with the production-side `cos_emb=N, num_tokens=N+1` message).
- [x] Confirmed both updated tests pass after the fix.

## PR Checklist

- [x] Please check this if you reviewed the [Coding Guidelines](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md)
- [x] PR title format follows the convention `[JIRA/NVBUG/None][type] description`
- [x] Test coverage updated; the regression test now defaults to the production rope layout
- [x] No documentation update needed; the fix is internal to LTX-2 audio padding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed padding inconsistency in audio text positional embeddings for LTX-2 visual generation.

* **Tests**
  * Enhanced test coverage for RoPE layout configurations in LTX-2 testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->