### PR TITLE
[None][perf] mega_moe: use BLOCK_M=128 for prefill on SM100

### DIFF
--- a/3rdparty/fetch_content.json
+++ b/3rdparty/fetch_content.json
@@ -33,7 +33,8 @@
       "git_repository": "https://github.com/deepseek-ai/DeepGEMM",
       "git_tag": "67fc64863d43521080bf2005e6528d0fceee9510",
       "git_submodules_recurse": true,
-      "source_subdir": "dont-add-this-project-with-add-subdirectory"
+      "source_subdir": "dont-add-this-project-with-add-subdirectory",
+      "patch_file": "patches/deepgemm_megamoe_prefill_blockm128.patch"
     },
     {
       "name": "eigen",

--- a/3rdparty/patches/deepgemm_megamoe_prefill_blockm128.patch
+++ b/3rdparty/patches/deepgemm_megamoe_prefill_blockm128.patch
@@ -1,0 +1,16 @@
+--- a/csrc/jit_kernels/heuristics/mega_moe.hpp
++++ b/csrc/jit_kernels/heuristics/mega_moe.hpp
+@@ -77,8 +77,11 @@
+             // Medium batch size, Medium EP, decoding, e.g. 6/384 experts, EP16, bsz 256, or EP32, bsz128
+             return {2, 128, 32, 2};
+         } else {
+-            // Prefill, or large EP decoding
+-            return {2, 192, 32, 2};
++            // Prefill, or large EP decoding.
++            // BLOCK_M=128 is ~2.3x faster than 192 on SM100 (B300) for this fused
++            // mega-MoE GEMM, measured across rows/expert 128..1024 (per-layer variance
++            // also collapses, CV 22%->3-7%); 192 is an inefficient tile here. See PR.
++            return {2, 128, 32, 2};
+         }
+     }();
+ 


### PR DESCRIPTION
DeepGEMM's fused mega-MoE GEMM (sm100_fp8_fp4_mega_moe) selects BLOCK_M=192 for the prefill / large-tokens-per-expert regime in get_block_config_for_mega_moe. On SM100 (B300) BLOCK_M=128 is ~2.3x faster than 192 for this kernel and also collapses the per-layer execution-time variance (CV 22% -> 3-7%).

Measured on DeepSeek-V4-Pro ctx prefill (TP8/EP8, MEGAMOE_DEEPGEMM) across rows/expert 128..1024: per-call 3.81ms->1.57ms (8k) and 29.8ms->12.7ms (64k). The ratio is constant with token count (i.e. not padding), indicating 192 is an inefficient tile on Blackwell here.

Applied as a fetch-time patch to the pinned DeepGEMM commit, matching the existing xgrammar patch_file mechanism in fetch_content.json.

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
