### PR TITLE
[None][fix] disagg: echo prompt_token_ids on chat context-only response

### DIFF
--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -1000,6 +1000,9 @@ class OpenAIServer(_VideoRoutesMixin):
             post_processor, args = postproc_params.post_processor, postproc_params.postproc_args
             chat_response = post_processor(promise, args)
 
+        if disaggregated_params is not None and disaggregated_params.request_type == "context_only":
+            chat_response.prompt_token_ids = promise.prompt_token_ids
+
         if disaggregated_params is not None and chat_response.choices[
                 0].disaggregated_params is None:
             raise ValueError(

--- a/tensorrt_llm/serve/postprocess_handlers.py
+++ b/tensorrt_llm/serve/postprocess_handlers.py
@@ -222,6 +222,7 @@ def chat_stream_post_processor(rsp: GenerationResultBase,
         if finish_reason_sent[i]:
             continue
 
+        has_token_delta = bool(output.token_ids_diff)
         delta_text = output.text_diff
 
         delta_text, reasoning_delta_text = apply_reasoning_parser(
@@ -267,7 +268,10 @@ def chat_stream_post_processor(rsp: GenerationResultBase,
                             arguments=call_item.parameters,
                         ),
                     ))
-            if tool_calls or delta_text or reasoning_delta_text or output.finish_reason:
+            # Keep token-bearing chunks visible even when detokenization has no
+            # text to flush yet.
+            if (tool_calls or delta_text or reasoning_delta_text
+                    or output.finish_reason or has_token_delta):
                 delta_message = DeltaMessage(
                     content=delta_text,
                     reasoning_content=reasoning_delta_text,

--- a/tests/unittest/disaggregated/test_openai_disagg_service.py
+++ b/tests/unittest/disaggregated/test_openai_disagg_service.py
@@ -15,6 +15,7 @@
 import asyncio
 import json
 from types import SimpleNamespace
+from unittest import mock
 from unittest.mock import AsyncMock
 
 import pytest
@@ -30,6 +31,10 @@ from tensorrt_llm.llmapi.disagg_utils import (
 from tensorrt_llm.serve.disagg_auto_scaling import DisaggClusterManager, WorkerInfo
 from tensorrt_llm.serve.openai_disagg_service import OpenAIDisaggregatedService
 from tensorrt_llm.serve.openai_protocol import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionResponseChoice,
+    ChatMessage,
     CompletionRequest,
     CompletionResponse,
     CompletionResponseChoice,
@@ -94,10 +99,98 @@ def _make_completion_response(
     )
 
 
+def _make_chat_response(
+    finish_reason: str,
+    disagg_request_id: int = 42,
+    prompt_token_ids=None,
+) -> ChatCompletionResponse:
+    if prompt_token_ids is None:
+        prompt_token_ids = [1, 2, 3]
+    return ChatCompletionResponse(
+        model="test-model",
+        usage=UsageInfo(prompt_tokens=1, completion_tokens=1),
+        prompt_token_ids=prompt_token_ids,
+        choices=[
+            ChatCompletionResponseChoice(
+                index=0,
+                message=ChatMessage(role="assistant", content=""),
+                finish_reason=finish_reason,
+                disaggregated_params=DisaggregatedParams(
+                    request_type="context_only",
+                    disagg_request_id=disagg_request_id,
+                    ctx_request_id=disagg_request_id,
+                ),
+            )
+        ],
+    )
+
+
 async def _mock_streaming_response(chunks):
     for chunk in chunks:
         await asyncio.sleep(0)
         yield chunk
+
+
+def test_get_gen_request_uses_ctx_response_prompt_token_ids_for_chat():
+    service = _make_service("context_first")
+    ctx_prompt_token_ids = [101, 102, 103]
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[
+            {
+                "role": "user",
+                "content": "hello",
+            }
+        ],
+        prompt_token_ids=[1, 2, 3],
+    )
+    ctx_response = _make_chat_response(
+        finish_reason="length",
+        prompt_token_ids=ctx_prompt_token_ids,
+    )
+
+    gen_request = service._get_gen_request(request, ctx_response, 42)
+
+    assert gen_request.prompt_token_ids == ctx_prompt_token_ids
+    assert gen_request.disaggregated_params.request_type == "generation_only"
+
+
+@pytest.mark.asyncio
+async def test_create_chat_response_sets_prompt_token_ids_for_context_only():
+    from tensorrt_llm.serve.openai_server import OpenAIServer
+
+    prompt_token_ids = [101, 102, 103]
+
+    class FakePromise:
+        def __init__(self) -> None:
+            self.outputs = []
+            self.prompt_token_ids = prompt_token_ids
+
+        async def aresult(self):
+            return self
+
+    server = OpenAIServer.__new__(OpenAIServer)
+    server.generator = mock.MagicMock()
+    server.generator.args.num_postprocess_workers = 0
+    server._extract_metrics = mock.AsyncMock()
+
+    post_processor = mock.Mock(
+        return_value=_make_chat_response(
+            finish_reason="length",
+            prompt_token_ids=None,
+        )
+    )
+    postproc_params = SimpleNamespace(post_processor=post_processor, postproc_args=object())
+    disaggregated_params = SimpleNamespace(request_type="context_only", disagg_request_id=123)
+
+    response = await server._create_chat_response(
+        FakePromise(),
+        postproc_params,
+        raw_request=None,
+        disaggregated_params=disaggregated_params,
+    )
+
+    assert response.prompt_token_ids == prompt_token_ids
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

In disaggregated serving, the generation (GEN) worker can skip prompt tokenization when the incoming request already carries `prompt_token_ids` (the `LLM._preprocess` token-id fast path, taken for `generation_only` requests). The orchestrator already forwards `ctx_response.prompt_token_ids` to the GEN request in `_get_gen_request`.

However, for **chat** completions the context-only response never populated `ChatCompletionResponse.prompt_token_ids` — only the **completion** path did. The field exists on `ChatCompletionResponse` for exactly this purpose (*"Add prompt_tokens_ids to the response to remove the tokenization in the generation server in disaggregated serving"*) but was never wired for the chat path. As a result, for chat workloads the GEN worker re-tokenized the full prompt on every request.

## Fix

Populate `chat_response.prompt_token_ids = promise.prompt_token_ids` for context-only chat requests in `_create_chat_response`, mirroring the existing completion path. The GEN worker now reuses the context worker's exact token ids (also guaranteeing token / KV-cache parity) instead of independently re-tokenizing.
