### PR TITLE
[None][fix] adp router: gate in-transfer load accounting behind a config flag

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -118,6 +118,7 @@ class ADPRouter(ABC):
                 fair_share_multiplier=attention_dp_config.kv_cache_routing_fair_share_multiplier,
                 cold_start_warmup=attention_dp_config.kv_cache_routing_cold_start_warmup,
                 async_transfer_manager=async_transfer_manager,
+                account_for_in_transfer=attention_dp_config.kv_cache_routing_account_for_in_transfer,
             )
 
         return DefaultADPRouter(dist=dist)
@@ -367,6 +368,7 @@ class KVCacheAwareADPRouter(ADPRouter):
         fair_share_multiplier: float = 2.0,
         cold_start_warmup: bool = False,
         async_transfer_manager=None,
+        account_for_in_transfer: bool = False,
     ):
         super().__init__(dist)
         self.kv_cache_manager = kv_cache_manager
@@ -380,7 +382,12 @@ class KVCacheAwareADPRouter(ADPRouter):
             set(range(self.dist.mapping.dp_size)) if cold_start_warmup else set()
         )
         # Requests still sending KV to GEN are invisible in active_requests;
-        # fold them back in via the transfer manager (see create_rank_state).
+        # when ``account_for_in_transfer`` is True, fold them back in via the
+        # transfer manager (see create_rank_state). Disabled by default
+        # because counting them inflates num_active_requests reported to the
+        # inference loop, which then skips the idle-fetch wait and yields
+        # empty fetch cycles.
+        self.account_for_in_transfer = account_for_in_transfer
         self.async_transfer_manager = async_transfer_manager
 
     def create_rank_state(
@@ -400,8 +407,11 @@ class KVCacheAwareADPRouter(ADPRouter):
         n_active_for_state = len(active_requests)
 
         # Fold in requests mid KV-transfer to GEN; they are removed from
-        # active_requests but still counted as per-rank load.
-        if self.async_transfer_manager is not None:
+        # active_requests but still counted as per-rank load. Gated behind
+        # ``account_for_in_transfer`` because the inflated active count
+        # makes the inference loop's idle-fetch wait expire even when no
+        # request is actually runnable, causing empty fetch cycles.
+        if self.account_for_in_transfer and self.async_transfer_manager is not None:
             in_transfer = self.async_transfer_manager.requests_in_transfer()
             num_active_tokens += sum(_active_tokens(r) for r in in_transfer.values())
             n_active_for_state += len(in_transfer)

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -744,6 +744,19 @@ class AttentionDpConfig(StrictBaseModel):
         "scatter requests that would otherwise consolidate on a single warm "
         "rank, wasting prefill. Default False preserves pre-warmup routing. "
         "Only used when enable_kv_cache_aware_routing is True.")
+    kv_cache_routing_account_for_in_transfer: bool = Field(
+        default=False,
+        description=
+        "In-transfer load accounting in KV cache-aware routing. When True, "
+        "requests still streaming KV to the GEN worker (tracked by the "
+        "PyExecutor AsyncTransferManager but no longer in active_requests) "
+        "are folded back into the per-rank load reported via RankState. "
+        "This can improve balance under heavy disagg traffic but inflates "
+        "num_active_requests reported upstream, which lets the inference "
+        "loop's idle-fetch wait expire even when no requests are runnable "
+        "and causes empty fetch cycles. Default False preserves the prior "
+        "behaviour (fetch blocks when truly idle). "
+        "Only used when enable_kv_cache_aware_routing is True.")
 
     @model_validator(mode='after')
     def validate_attention_dp_config(self) -> 'AttentionDpConfig':


### PR DESCRIPTION
## Summary

`KVCacheAwareADPRouter.create_rank_state` folds requests still mid-KV-transfer to the GEN worker (tracked by `AsyncTransferManager`, removed from `active_requests`) back into the per-rank `num_active_tokens` / `num_active_requests` reported via `RankState`. This was added to improve cross-rank load balance on V3.2.

@JinLi-NVIDIA spotted the side effect: the inflated `num_active_requests` propagates up to the PyExecutor inference loop, which uses `total_num_active_requests == 0 and len(waiting_queue) == 0` as the gate between a 1200s heartbeat timeout (block) and a 0s non-blocking poll. With in-transfer requests counted, the loop never sees the truly-idle state, so `fetch_new_requests` stops blocking; rank 0 then reaches the broadcast path with an empty batch and every other rank gets padded with dummy requests on each idle iteration.

On V4 the load-balance benefit from this accounting is negligible (verified by @lancelly), so make it opt-in.