### PR TITLE
[None][perf] disagg ctx: order prefill by uncached tokens, reusing the ADP router's per-rank prefix match

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3346,7 +3346,33 @@ class PyExecutor:
             if not _respond_if_invalid(request)
         ]
 
-        self.active_requests.extend(validated_requests)
+        # Order newly-activated context requests by uncached (non-prefix-cached)
+        # token count, heaviest-prefill first. The scheduler walks
+        # active_requests in list order, so this lets the requests that need the
+        # most prefill compute enter the context phase ahead of light,
+        # mostly-cached ones. The uncached estimate reuses
+        # ``py_prefix_match_length`` -- the prefix match the KV-cache-aware ADP
+        # router already computed for the rank this request was routed to -- so
+        # no extra radix-tree probe runs on the (host-bound) context server.
+        # Falls back to the full prompt length when the value is absent (e.g.
+        # non-KV-aware router), and is a no-op for generation-only requests.
+        def _uncached_tokens(req) -> int:
+            prompt_len = len(getattr(req, "input_token_ids", None) or [])
+            matched = getattr(req, "py_prefix_match_length", 0)
+            return max(0, prompt_len - matched)
+
+        context_requests = [
+            req for req in validated_requests
+            if not req.is_generation_only_request()
+        ]
+        other_requests = [
+            req for req in validated_requests
+            if req.is_generation_only_request()
+        ]
+        if len(context_requests) > 1:
+            context_requests.sort(key=_uncached_tokens, reverse=True)
+        self.active_requests.extend(context_requests)
+        self.active_requests.extend(other_requests)
         return validated_requests
 
     def _add_kv_cache_events(self):

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -542,6 +542,12 @@ class KVCacheAwareADPRouter(ADPRouter):
                 )
                 all_ranks_num_active_tokens[target_dp_rank] += effective
                 scheduled = True
+                # Expose the prefix match length for the rank this request is
+                # actually routed to, so the worker can reuse it (e.g. to order
+                # context prefill by uncached tokens) without re-probing.
+                if req_item.request is not None:
+                    req_item.request.py_prefix_match_length = self._match_len(
+                        target_dp_rank, req_item.id)
                 all_ranks_new_requests[target_dp_rank].append(req_item)
                 # Only mark a rank as warmed once a request actually landed
                 # there; saturated picks stay pending for a later call.
@@ -626,6 +632,11 @@ class KVCacheAwareADPRouter(ADPRouter):
                     best_score = score
                     best_rank = rank
 
+            # Expose the prefix match length for the rank this request is
+            # actually routed to, so the worker can reuse it (e.g. to order
+            # context prefill by uncached tokens) without re-probing.
+            if req_item.request is not None:
+                req_item.request.py_prefix_match_length = match_lens[best_rank]
             all_ranks_new_requests[best_rank].append(req_item)
             all_ranks_num_active_requests[best_rank] += 1
 


### PR DESCRIPTION
## What

Two pieces, on the **disaggregated context server**:

1. **Expose the routed-rank prefix match on the request** (`adp_router.py`).
   `KVCacheAwareADPRouter` already probes every new request's prefix-match length
   on every rank (`gather_prefix_matches`) and uses it to route. This stashes that
   value onto the request as `py_prefix_match_length` **at the routing decision** —
   using the match for the rank the request is *actually routed to* (`target_dp_rank`
   in the warmup path, `best_rank` in the scoring path). The match is **per-rank**, so
   a request must carry the match for the rank it lands on.

2. **Order context prefill by uncached tokens** (`py_executor.py`).
   In `_fetch_and_activate_new_requests`, sort newly-activated context requests by
   `uncached = prompt_len - py_prefix_match_length`, heaviest-prefill first, before
   extending `active_requests` (the V2 scheduler walks the list in order). No extra
   probe — it reuses the value from (1).

No-op for generation-only requests and for the non-KV-aware router (falls back to
full prompt length).

## Why

On a high-cache-hit disagg workload (DeepSeek-V4-Pro agentic-coding, ~96% prefix-cache
hit), the *uncached* token count — the work a prefill actually does — varies widely
per request. The hypothesis: letting the heaviest-prefill requests into the context
phase first improves time-to-first-token under chunked-prefill / token-budget pressure.

**Key implementation point (why this PR exists):** an earlier naive version probed the
radix tree a *second* time inside the activation hot path to get the uncached count.
On the context server — which is **host-bound** — that redundant probe measurably
slowed every prefill iter (CTX `host_step_time` mean +5–11%, p99 +13–27%) and **raised**
TTFT, swamping any ordering benefit. The router already computes this match for free,
so the fix is to **reuse the per-rank value** instead of recomputing it.
