### PR TITLE
[TRTLLM-12498][feat] Add support for beam search in disaggregated serving

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -1905,7 +1905,19 @@ SizeType32 WindowBlockManager::onboardAndAllocateBlocks(
         }
     }
 
-    // Finalize matched token count (purge trailing placeholders for recurrent states)
+    // Finalize matched token count
+
+    // claimResult.totalMatchedTokens > claimResult.numSharedContextBlocks * mTokensPerBlock means that the KV block of
+    // the last matched tokens was not copied we need to regenerate the KV of the last matched tokens, so we round down
+    // the prepopulated prompt length to the last shared context block
+    if (claimResult.totalMatchedTokens > claimResult.numSharedContextBlocks * mTokensPerBlock)
+    {
+        TLLM_LOG_DEBUG("onboardAndAllocateBlocks - rounding down claimResult.totalMatchedTokens to %d",
+            claimResult.totalMatchedTokens);
+        claimResult.totalMatchedTokens = claimResult.numSharedContextBlocks * mTokensPerBlock;
+    }
+
+    // purge trailing placeholders for recurrent states
     auto numMatchedTokens = claimResult.totalMatchedTokens;
     if (isRecurrentState())
     {

--- a/tensorrt_llm/_torch/disaggregation/base/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/base/transfer.py
@@ -51,7 +51,8 @@ class KVSlice:
         total_blocks    = ceil(token_range.end / tpb)
         token_start_i   = (total_blocks - len(block_ids_per_layer_groups[i])) * tpb
     Cached prefix (full-attn or per-layer SWA) shows up only by shrinking the
-    block list.
+    block list. Beam search keeps this field 1-D: beam 0's blocks first,
+    followed by the final unshared block from each remaining beam.
 
     SWA stale_end uses the request prompt_len (on the session), not
     token_range.end — they differ for non-final slices.
@@ -104,6 +105,7 @@ class SessionArgsBase:
     params: DisaggregatedParams
     # Captured from LlmRequest.prompt_len; needed for SWA stale_end derivation.
     prompt_len: Optional[int] = None
+    beam_width: int = 1
 
 
 def get_unique_rid(request: LlmRequest) -> Optional[int]:

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -208,12 +208,14 @@ class KVSendTask(SendTaskBase):
         params: DisaggregatedParams,
         slice_id: int,
         prompt_len: Optional[int] = None,
+        beam_width: int = 1,
     ):
         super().__init__(params)
         self.slice_id = slice_id
         self.transferred_count = 0
         self._slice = kv_slice
         self._prompt_len = prompt_len
+        self._beam_width = beam_width
 
 
 class Sender(SenderBase):
@@ -645,6 +647,13 @@ class Sender(SenderBase):
             dst_block_ids[dst_skip : dst_skip + n_transfer],
         )
 
+    @staticmethod
+    def _beam0_block_count(block_ids: np.ndarray, total_blocks: int, beam_width: int) -> int:
+        """Return the number of beam-0 blocks in a packed 1-D beam layout."""
+        if beam_width <= 1 or block_ids.size <= total_blocks:
+            return block_ids.size
+        return max(0, block_ids.size - (beam_width - 1))
+
     @nvtx_range("_build_kv_write_meta")
     def _build_kv_write_meta(self, task: KVSendTask, req_info: RecvReqInfo) -> WriteMeta:
         peer_ri = self._registrar.get_peer_rank_info(req_info.instance_name, req_info.instance_rank)
@@ -701,16 +710,22 @@ class Sender(SenderBase):
                 # is implicit in their size. token_start = (total_blocks - n) * tpb.
                 slice_end = token_range.end if token_range is not None else 0
                 total_blocks = (slice_end + tpb - 1) // tpb
-                assert src_block_ids.size <= total_blocks, (
-                    f"src block list ({src_block_ids.size}) exceeds total slice "
+                src_beam0_blocks = Sender._beam0_block_count(
+                    src_block_ids, total_blocks, task._beam_width
+                )
+                dst_beam0_blocks = Sender._beam0_block_count(
+                    dst_block_ids, total_blocks, task._beam_width
+                )
+                assert src_beam0_blocks <= total_blocks, (
+                    f"src beam-0 block list ({src_beam0_blocks}) exceeds total slice "
                     f"blocks ({total_blocks}); slice_end={slice_end}, tpb={tpb}"
                 )
-                assert dst_block_ids.size <= total_blocks, (
-                    f"dst block list ({dst_block_ids.size}) exceeds total slice "
+                assert dst_beam0_blocks <= total_blocks, (
+                    f"dst beam-0 block list ({dst_beam0_blocks}) exceeds total slice "
                     f"blocks ({total_blocks}); slice_end={slice_end}, tpb={tpb}"
                 )
-                src_start = (total_blocks - src_block_ids.size) * tpb
-                dst_start = (total_blocks - dst_block_ids.size) * tpb
+                src_start = (total_blocks - src_beam0_blocks) * tpb
+                dst_start = (total_blocks - dst_beam0_blocks) * tpb
                 if req_info.dst_start_token is not None:
                     dst_start = max(dst_start, req_info.dst_start_token)
                 if window_size is not None:
@@ -1060,8 +1075,12 @@ class TxSession(TxSessionBase):
         aux_buffer: Optional[AuxBuffer] = None,
         timeout_s: Optional[float] = None,
         prompt_len: Optional[int] = None,
+        beam_width: int = 1,
     ):
-        super().__init__(sender, SessionArgsBase(params, prompt_len=prompt_len))
+        super().__init__(
+            sender,
+            SessionArgsBase(params, prompt_len=prompt_len, beam_width=beam_width),
+        )
         self._timeout_s = timeout_s
         self._need_aux = params.schedule_style == DisaggScheduleStyle.GENERATION_FIRST
         self._sender: Sender  # narrow base class type for Pylance
@@ -1111,7 +1130,13 @@ class TxSession(TxSessionBase):
         with self.lock:
             params = self._base_args.params
             slice_id = len(self.kv_tasks)
-            task = KVSendTask(slice, params, slice_id, prompt_len=self._base_args.prompt_len)
+            task = KVSendTask(
+                slice,
+                params,
+                slice_id,
+                prompt_len=self._base_args.prompt_len,
+                beam_width=self._base_args.beam_width,
+            )
             task._unique_rid = self.disagg_request_id
             self.kv_tasks.append(task)
             req_info_snapshot = dict(self._sender._get_req_info(task._unique_rid) or {})
@@ -1572,8 +1597,12 @@ class RxSession(RxSessionBase):
         aux_buffer: Optional[AuxBuffer] = None,
         timeout_s: Optional[float] = None,
         prompt_len: Optional[int] = None,
+        beam_width: int = 1,
     ):
-        super().__init__(receiver, SessionArgsBase(params, prompt_len=prompt_len))
+        super().__init__(
+            receiver,
+            SessionArgsBase(params, prompt_len=prompt_len, beam_width=beam_width),
+        )
         self._timeout_s = timeout_s
         self._need_aux = params.schedule_style == DisaggScheduleStyle.GENERATION_FIRST
         self._receiver: Receiver  # narrow base class type for Pylance
@@ -1963,6 +1992,7 @@ class TransferWorker:
             aux_buffer=self._aux_buffer,
             timeout_s=self._config.tx_timeout_s,
             prompt_len=request.prompt_len,
+            beam_width=request.py_beam_width,
         )
 
     def create_rx_session(self, request: LlmRequest) -> RxSession:
@@ -1975,6 +2005,7 @@ class TransferWorker:
             aux_buffer=self._aux_buffer,
             timeout_s=self._config.rx_timeout_s,
             prompt_len=request.prompt_len,
+            beam_width=request.py_beam_width,
         )
 
     def has_all_peer_req_infos_for_send(self, unique_rid: int) -> bool:

--- a/tensorrt_llm/_torch/disaggregation/resource/cache_reuse.py
+++ b/tensorrt_llm/_torch/disaggregation/resource/cache_reuse.py
@@ -95,8 +95,11 @@ class _CacheReuseAdapterV1(CacheReuseAdapter):
 
     def get_block_ids(self, req, group_idx, lg):  # noqa: ARG002
         first_layer = get_global_layer_ids(lg)[0]
+        beam_width = req.py_beam_width
         return np.asarray(
-            self._mgr.get_batch_cache_indices([req.py_request_id], layer_idx=first_layer)[0],
+            self._mgr.get_batch_cache_indices(
+                [req.py_request_id], layer_idx=first_layer, beam_width=beam_width
+            )[0],
             dtype=np.int64,
         )
 

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -185,26 +185,23 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
                 total_blocks = (req.prompt_len + tpb - 1) // tpb
                 stale_end = max(0, (req.prompt_len + 1 - window_size) // tpb)
                 expected_valid = max(0, total_blocks - stale_end)
-                if block_ids.size > expected_valid:
-                    block_ids = (
-                        block_ids[-expected_valid:]
-                        if expected_valid > 0
-                        else np.array([], dtype=np.int64)
-                    )
                 # Stale prefix already pruned above; skip reuse-hit blocks that
                 # land inside the window. Clamp to 0: ctx side has cached_per_lg
                 # synthetically 0, and a reuse hit may fall entirely inside the
                 # stale region (those blocks were already pruned, no extra skip).
                 cache_skip = max(0, cached_per_lg[idx] // tpb - stale_end)
             else:
+                total_blocks = (req.prompt_len + tpb - 1) // tpb
+                expected_valid = total_blocks
                 cache_skip = cached_per_lg[idx] // tpb
 
-            if cache_skip > 0:
-                block_ids = (
-                    block_ids[cache_skip:]
-                    if cache_skip < block_ids.size
-                    else np.array([], dtype=np.int64)
-                )
+            block_ids = self._trim_packed_beam_block_ids(
+                block_ids,
+                beam_width=req.py_beam_width,
+                total_blocks=total_blocks,
+                expected_valid=expected_valid,
+                cache_skip=cache_skip,
+            )
 
             groups.append(block_ids)
 
@@ -218,6 +215,56 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             mamba_state_index=mamba_state_index,
             token_range=token_range,
         )
+
+    @staticmethod
+    def _split_packed_beam_block_ids(
+        block_ids: np.ndarray,
+        beam_width: int,
+        total_blocks: int,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Split 1-D block IDs into beam-0 prefix and appended beam-tail blocks."""
+        if beam_width <= 1 or block_ids.size <= total_blocks:
+            return block_ids, np.array([], dtype=np.int64)
+        tail_count = min(beam_width - 1, block_ids.size - total_blocks)
+        if tail_count <= 0:
+            return block_ids, np.array([], dtype=np.int64)
+        return block_ids[:-tail_count], block_ids[-tail_count:]
+
+    @staticmethod
+    def _trim_packed_beam_block_ids(
+        block_ids: np.ndarray,
+        beam_width: int,
+        total_blocks: int,
+        expected_valid: int,
+        cache_skip: int,
+    ) -> np.ndarray:
+        """Trim/skip beam-0 blocks while preserving packed beam-tail blocks."""
+        if expected_valid <= 0:
+            return np.array([], dtype=np.int64)
+
+        beam0_block_ids, tail_block_ids = KvCacheTransceiverV2._split_packed_beam_block_ids(
+            block_ids, beam_width, total_blocks
+        )
+
+        if beam0_block_ids.size > expected_valid:
+            beam0_block_ids = (
+                beam0_block_ids[-expected_valid:]
+                if expected_valid > 0
+                else np.array([], dtype=np.int64)
+            )
+            if beam0_block_ids.size == 0:
+                tail_block_ids = np.array([], dtype=np.int64)
+
+        if cache_skip > 0:
+            if cache_skip < beam0_block_ids.size:
+                beam0_block_ids = beam0_block_ids[cache_skip:]
+            else:
+                beam0_block_ids = np.array([], dtype=np.int64)
+                tail_block_ids = np.array([], dtype=np.int64)
+
+        if tail_block_ids.size == 0:
+            return beam0_block_ids
+        return np.concatenate([beam0_block_ids, tail_block_ids])
 
     @staticmethod
     def _need_aux_transfer(req: LlmRequest) -> bool:

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -283,6 +283,7 @@ class PyResult:
         generation_logits_list: list[torch.Tensor] = field(default_factory=list)
         reset_log_probs: tuple[list[TokenLogprobs] | list[SimpleTokenLogprobs],
                                list[float] | None] | None = None
+        first_gen_log_probs: TokenLogprobs | None = None
         mm_embeddings: list[dict[str, Any] | None] = None
         mrope_position_ids: dict[str, Any] | None = None
         mrope_position_deltas: dict[str, Any] | None = None
@@ -326,6 +327,7 @@ class PyResult:
             use_chunked_generation_logits=use_chunked_generation_logits,
             chunk_size=self._chunk_size) if return_generation_logits else None
         self._log_probs = LogProbStorage() if return_log_probs else None
+        self._first_gen_log_probs: Optional[TokenLogprobs] = None
         self._mm_embeddings: Optional[List[Dict[str, Any]]] = None
         self._mrope_position_ids = None
         self._mrope_position_deltas = None
@@ -360,6 +362,8 @@ class PyResult:
                 self._generation_logits.append(generation_logits)
         if diff.reset_log_probs is not None:
             self._log_probs.set_log_probs(*diff.reset_log_probs)
+        if diff.first_gen_log_probs is not None:
+            self._first_gen_log_probs = diff.first_gen_log_probs
         if diff.mm_embeddings is not None:
             self._mm_embeddings = diff.mm_embeddings
         if diff.mrope_position_ids is not None:
@@ -457,6 +461,10 @@ class PyResult:
             self._log_probs.set_log_probs(log_probs, cum_log_probs)
             self.diff.reset_log_probs = (log_probs, cum_log_probs)
 
+    def set_first_gen_log_probs(self, log_probs: TokenLogprobs):
+        self._first_gen_log_probs = log_probs
+        self.diff.first_gen_log_probs = log_probs
+
     @property
     def context_logits(self) -> torch.Tensor | None:
         if self._context_logits is None or (storage := self._context_logits.get(
@@ -508,6 +516,10 @@ class PyResult:
         return self._log_probs.cum_log_probs
 
     @property
+    def first_gen_log_probs(self) -> TokenLogprobs | None:
+        return self._first_gen_log_probs
+
+    @property
     def mm_embedding_handles(self) -> List[Dict[str, Any]] | None:
         """Returns a list of SharedTensorContainer handles, one per multimodal item."""
         return self._mm_embeddings
@@ -553,9 +565,9 @@ class LlmResult:
     """LlmResult wraps `bindings.executor.Result` but detour some features to Python implementation"""
     py_result_properties = frozenset(
         ('context_logits', 'generation_logits', 'log_probs', 'cum_log_probs',
-         'mm_embedding_handles', 'additional_context_outputs',
-         'additional_generation_outputs', 'mrope_position_ids_handle',
-         'mrope_position_deltas_handle'))
+         'first_gen_log_probs', 'mm_embedding_handles',
+         'additional_context_outputs', 'additional_generation_outputs',
+         'mrope_position_ids_handle', 'mrope_position_deltas_handle'))
 
     def __init__(self,
                  result: Union[bytes, tensorrt_llm.bindings.executor.Result],

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -4046,10 +4046,92 @@ class PyExecutor:
                 ctx_draft_tokens = req.context_phase_params.draft_tokens
                 req.py_draft_tokens = [] if ctx_draft_tokens is None else ctx_draft_tokens
                 beam_width = req.py_beam_width
+                if not self._update_sampler_state_for_disagg_gen_request(
+                        req, beam_width, first_gen_tokens):
+                    continue
                 for beam in range(0, beam_width):
                     req.add_new_token(first_gen_tokens[beam], beam)
 
                 self._maybe_prepend_logprobs_and_logits(req, beam_width)
+
+    def _update_sampler_state_for_disagg_gen_request(self, req, beam_width,
+                                                     first_gen_tokens) -> bool:
+        """Update beam sampler state with context-side first-token data."""
+        if beam_width <= 1:
+            return True
+
+        def fail_request(message: str) -> bool:
+            logger.error(message)
+            req.state = LlmRequestState.DISAGG_TRANS_ERROR
+            return False
+
+        seq_slot = req.py_seq_slot
+        if seq_slot is None:
+            return fail_request(
+                "Cannot update sampler state for disagg beam request "
+                f"{req.py_request_id}: seq slot is not assigned.")
+
+        sampler_store = getattr(self.sampler, 'store', None)
+        beam_search_store = getattr(sampler_store, 'beam_search_store', None)
+        if beam_search_store is None:
+            return fail_request(
+                "Cannot update sampler state for disagg beam request "
+                f"{req.py_request_id}: sampler has no beam search store.")
+        if len(first_gen_tokens) < beam_width:
+            return fail_request(
+                "Invalid first_gen_tokens length for disagg beam "
+                f"request {req.py_request_id}: "
+                f"{len(first_gen_tokens)} < {beam_width}")
+
+        disagg_params = getattr(req, 'py_disaggregated_params', None)
+        if disagg_params is None:
+            return fail_request(
+                "No disaggregated params available for disagg beam "
+                f"request {req.py_request_id}.")
+
+        first_gen_log_probs = getattr(disagg_params, 'first_gen_log_probs',
+                                      None)
+        if first_gen_log_probs is None:
+            return fail_request(
+                "No first_gen_log_probs available for disagg beam "
+                f"request {req.py_request_id}.")
+
+        if len(first_gen_log_probs) != beam_width:
+            return fail_request(
+                "Invalid first_gen_log_probs length for disagg beam "
+                f"request {req.py_request_id}: "
+                f"{len(first_gen_log_probs)} != {beam_width}")
+
+        first_gen_scores = []
+        for beam_idx, (token_id, token_log_probs) in enumerate(
+                zip(first_gen_tokens[:beam_width], first_gen_log_probs)):
+            token_log_prob = token_log_probs.get(token_id)
+            if token_log_prob is None:
+                return fail_request(
+                    "Missing first_gen_log_probs entry for disagg beam "
+                    f"request {req.py_request_id}: beam={beam_idx}, "
+                    f"token_id={token_id}")
+            first_gen_scores.append(token_log_prob.logprob)
+
+        original_tokens = beam_search_store.original_tokens
+        first_gen_token_values = torch.tensor(first_gen_tokens[:beam_width],
+                                              device=original_tokens.device,
+                                              dtype=original_tokens.dtype)
+        original_tokens[seq_slot, :beam_width,
+                        req.prompt_len].copy_(first_gen_token_values)
+        cache_indirection = beam_search_store.cache_indirection
+        beam_idx_arange = torch.arange(beam_width,
+                                       device=original_tokens.device,
+                                       dtype=cache_indirection.dtype)
+        cache_indirection[seq_slot, :beam_width,
+                          req.prompt_len].copy_(beam_idx_arange)
+
+        cum_log_probs = beam_search_store.cum_log_probs
+        values = torch.tensor(first_gen_scores,
+                              device=cum_log_probs.device,
+                              dtype=cum_log_probs.dtype)
+        cum_log_probs[seq_slot, :beam_width].copy_(values)
+        return True
 
     def _maybe_prepend_logprobs_and_logits(self, req, beam_width):
         """Prepend logprobs and generation logits for first_gen_tokens
@@ -4060,10 +4142,7 @@ class PyExecutor:
 
         if getattr(disagg_params, 'first_gen_log_probs', None) is not None:
             if beam_width != 1:
-                logger.warning(
-                    "Skipping first_gen_log_probs prepend for "
-                    "request %s: beam_width=%s is not supported.",
-                    req.py_request_id, beam_width)
+                pass
             else:
                 req.py_result.append_log_probs(
                     [disagg_params.first_gen_log_probs])

--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -1558,7 +1558,9 @@ class KVCacheManager(BaseResourceManager):
         request_ids: List[int],
         layer_idx: Optional[int] = None,
         window_size: Optional[int] = None,
+        beam_width: Optional[int] = 1,
     ) -> List[List[int]]:
+        beam_width = beam_width or 1
         if window_size is None:
             if layer_idx is None:
                 if len(self.max_attention_window_vec) > 1:
@@ -1574,9 +1576,29 @@ class KVCacheManager(BaseResourceManager):
 
         result = self.impl.get_batch_cache_block_ids(request_ids, window_size)
         for i in range(len(result)):
-            assert (len(result[i])) == 1
-            result[i] = result[i][0]
+            beams = [list(beam) for beam in result[i]]
+            assert len(beams) == beam_width, (
+                f"Expected {beam_width} index arrays per request, got {len(beams)}"
+            )
+            result[i] = beams[
+                0] if beam_width == 1 else self._pack_beam_cache_indices(beams)
         return result
+
+    @staticmethod
+    def _pack_beam_cache_indices(beams: List[List[int]]) -> List[int]:
+        """Pack beam-search blocks into a flat beam-0 layout.
+
+        The first beam owns the shared prompt blocks. For every other beam,
+        append only the final block when it differs from beam 0's final block.
+        """
+        if not beams:
+            return []
+        packed = list(beams[0])
+        beam0_last = beams[0][-1] if beams[0] else None
+        for beam in beams[1:]:
+            if beam and beam[-1] != beam0_last:
+                packed.append(beam[-1])
+        return packed
 
     def get_num_free_blocks(self) -> int:
         if self.is_linear_attention:

--- a/tensorrt_llm/_torch/pyexecutor/sampler.py
+++ b/tensorrt_llm/_torch/pyexecutor/sampler.py
@@ -3700,6 +3700,26 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
                     self._prev_first_finish_reasons_host[req.py_seq_slot] = (
                         first_finish_reasons_host[req.py_seq_slot]
                     )
+                if req.is_context_only_request:
+                    beam_search_store = self.store.beam_search_store
+                    assert beam_search_store is not None
+                    assert req.py_seq_slot is not None
+                    beam_width = req.py_beam_width
+                    first_gen_scores = (
+                        beam_search_store.cum_log_probs[req.py_seq_slot, :beam_width]
+                        .detach()
+                        .cpu()
+                        .tolist()
+                    )
+                    first_gen_tokens = [
+                        new_tokens_list[0][req.py_seq_slot][beam_idx]
+                        for beam_idx in range(beam_width)
+                    ]
+                    first_gen_log_probs = [
+                        {token_id: Logprob(logprob=log_prob, rank=None)}
+                        for token_id, log_prob in zip(first_gen_tokens, first_gen_scores)
+                    ]
+                    req.py_result.set_first_gen_log_probs(first_gen_log_probs)
                 req.py_num_accepted_draft_tokens = 0
                 req.py_rewind_len = 0
             else:
@@ -4279,9 +4299,7 @@ class TorchSampler(Sampler[SampleStateTorch], AsyncWorkerMixin):
         new_tokens_cuda.view(-1, *new_tokens_cuda.shape[2:]).scatter_(
             0, batch_dest_indices_1d_cuda, batch_next_tokens_cuda_int
         )
-        new_tokens_host = self._copy_to_host(new_tokens_cuda)
-
-        return new_tokens_host
+        return self._copy_to_host(new_tokens_cuda)
 
     @staticmethod
     @torch.inference_mode()

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -532,9 +532,12 @@ class GenerationResultBase:
             # can prepend them.
             if (context_phase_params is not None
                     and self._disaggregated_params is not None):
-                first_gen_lp = [
-                    out.logprobs[0] for out in self._outputs if out.logprobs
-                ]
+                first_gen_lp = getattr(response_result, "first_gen_log_probs",
+                                       None)
+                if first_gen_lp is None:
+                    first_gen_lp = [
+                        out.logprobs[0] for out in self._outputs if out.logprobs
+                    ]
                 if first_gen_lp:
                     self._disaggregated_params.first_gen_log_probs = \
                         first_gen_lp

--- a/tensorrt_llm/serve/openai_disagg_service.py
+++ b/tensorrt_llm/serve/openai_disagg_service.py
@@ -383,28 +383,25 @@ class OpenAIDisaggregatedService(OpenAIService):
 
     async def _verify_ctx_response(self, ctx_response: UCompletionResponse) -> None:
         if ctx_response:
-            if len(ctx_response.choices) != 1:
-                raise ValueError(
-                    f"Context server returned {len(ctx_response.choices)} choices, expecting 1."
-                )
-            choice = ctx_response.choices[0]
-            if choice.disaggregated_params is None:
-                raise ValueError(
-                    f"Context server did not return disaggregated params."
-                    f" finish_reason={choice.finish_reason!r}"
-                )
-            if choice.disaggregated_params.ctx_request_id is None:
-                raise ValueError(
-                    f"Invalid disaggregated params: ctx_request_id is None."
-                    f" finish_reason={choice.finish_reason!r},"
-                    f" disagg_request_id={choice.disaggregated_params.disagg_request_id!r}"
-                )
-            if choice.disaggregated_params.disagg_request_id is None:
-                raise ValueError(
-                    f"Invalid disaggregated params: disagg_request_id is None."
-                    f" finish_reason={choice.finish_reason!r},"
-                    f" ctx_request_id={choice.disaggregated_params.ctx_request_id!r}"
-                )
+            for idx, choice in enumerate(ctx_response.choices):
+                choice = ctx_response.choices[idx]
+                if choice.disaggregated_params is None:
+                    raise ValueError(
+                        f"Context server choice {idx} did not return disaggregated params."
+                        f" finish_reason={choice.finish_reason!r}"
+                    )
+                if choice.disaggregated_params.ctx_request_id is None:
+                    raise ValueError(
+                        f"Invalid disaggregated params: ctx_request_id is None for choice {idx}."
+                        f" finish_reason={choice.finish_reason!r},"
+                        f" disagg_request_id={choice.disaggregated_params.disagg_request_id!r}"
+                    )
+                if choice.disaggregated_params.disagg_request_id is None:
+                    raise ValueError(
+                        f"Invalid disaggregated params: disagg_request_id is None for choice {idx}."
+                        f" finish_reason={choice.finish_reason!r},"
+                        f" ctx_request_id={choice.disaggregated_params.ctx_request_id!r}"
+                    )
             return ctx_response
 
     async def _send_disagg_request_gen_first(

--- a/tests/integration/defs/accuracy/test_disaggregated_serving.py
+++ b/tests/integration/defs/accuracy/test_disaggregated_serving.py
@@ -26,8 +26,8 @@ from tensorrt_llm.llmapi.tokenizer import load_hf_tokenizer
 from ..conftest import (get_device_count, llm_models_root, parametrize_with_ids,
                         skip_no_hopper, skip_pre_blackwell, skip_pre_hopper)
 from ..trt_test_alternative import popen
-from .accuracy_core import (GSM8K, MMLU, LlmapiAccuracyTestHarness,
-                            get_accuracy_task)
+from .accuracy_core import (GSM8K, MMLU, CnnDailymail,
+                            LlmapiAccuracyTestHarness, get_accuracy_task)
 
 
 class Result(GenerationResultBase):
@@ -114,6 +114,8 @@ def run_accuracy_test(llm: "DuckLLM",
                       extra_evaluator_kwargs: Optional[Dict[Union[str, type],
                                                             Dict[str,
                                                                  Any]]] = None,
+                      extra_acc_spec: Optional[str] = None,
+                      sampling_params: Optional[SamplingParams] = None,
                       timeout: int = DEFAULT_ACC_EVALUATION_TIMEOUT):
     start_time = time.time()
     for test_set in test_sets:
@@ -125,7 +127,10 @@ def run_accuracy_test(llm: "DuckLLM",
             kwargs = extra_evaluator_kwargs.get(test_set, {})
         else:
             kwargs = {}
-        task.evaluate(llm, extra_evaluator_kwargs=kwargs)
+        task.evaluate(llm,
+                      extra_acc_spec=extra_acc_spec,
+                      extra_evaluator_kwargs=kwargs,
+                      sampling_params=sampling_params)
     elapsed_time = time.time() - start_time
     if elapsed_time > timeout:
         pytest.fail(
@@ -404,8 +409,10 @@ def launch_disaggregated_llm(
                          streaming: bool):
             kwargs = {}
             if sampling_params is not None:
+                extra_body = {}
                 kwargs.update(
                     max_tokens=sampling_params.max_tokens,
+                    n=sampling_params.n,
                     # NB: 'LLM' (cf. SamplingParams) and OpenAI API
                     #     defaults differ (top_p=0 vs. top_p=1).
                     # FIXME: Because 'LLM' does not permit expressly setting
@@ -415,9 +422,10 @@ def launch_disaggregated_llm(
                     top_p=sampling_params.top_p,
                     stop=sampling_params.stop,
                     seed=sampling_params.seed)
+                if sampling_params.use_beam_search:
+                    extra_body.update(use_beam_search=True)
                 if (guided_decoding_params :=
                         sampling_params.guided_decoding) is not None:
-                    extra_body = {}
                     if (schema := guided_decoding_params.json) is not None:
                         extra_body.update(response_format={
                             "type": "json",
@@ -431,6 +439,7 @@ def launch_disaggregated_llm(
                         raise ValueError(
                             f"Unsupported guided decoding params: {guided_decoding_params}."
                         )
+                if extra_body:
                     kwargs.update(extra_body=extra_body)
 
             response = client.completions.create(model=model_name,
@@ -440,8 +449,8 @@ def launch_disaggregated_llm(
             result = Result(id=0,
                             sampling_params=sampling_params,
                             outputs=[
-                                CompletionOutput(text=response.choices[0].text,
-                                                 index=0)
+                                CompletionOutput(text=choice.text, index=idx)
+                                for idx, choice in enumerate(response.choices)
                             ])
             requested_output = RequestOutput._from_generation_result(
                 result, prompt=prompt)
@@ -631,6 +640,54 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
                                       ctx_server_config, gen_server_config,
                                       self.MODEL_PATH) as llm:
             run_accuracy_test(llm, self.MODEL_NAME, ["MMLU", "GSM8K"])
+
+    @skip_pre_hopper
+    @pytest.mark.skip_less_device(2)
+    def test_beam_search(self):
+        max_beam_width = 2
+        sampling_params = SamplingParams(n=max_beam_width,
+                                         best_of=max_beam_width,
+                                         use_beam_search=True)
+        kv_cache_config = {
+            "free_gpu_memory_fraction": 0.5,
+            "enable_block_reuse": True,
+            "enable_partial_reuse": True,
+            "use_kv_cache_manager_v2": False,
+        }
+        cache_transceiver_config = {
+            "backend": "NIXL",
+            "transceiver_runtime": "PYTHON",
+            "max_tokens_in_buffer": 4096,
+        }
+        ctx_server_config = {
+            "disable_overlap_scheduler": True,
+            "max_beam_width": max_beam_width,
+            "kv_cache_config": kv_cache_config,
+            "cache_transceiver_config": cache_transceiver_config,
+        }
+        gen_server_config = {
+            "disable_overlap_scheduler": True,
+            "max_beam_width": max_beam_width,
+            "kv_cache_config": kv_cache_config,
+            "cache_transceiver_config": cache_transceiver_config,
+        }
+        disaggregated_server_config = {
+            "hostname": "localhost",
+            "backend": "pytorch",
+            "context_servers": {
+                "num_instances": 1
+            },
+            "generation_servers": {
+                "num_instances": 1
+            }
+        }
+        with launch_disaggregated_llm(disaggregated_server_config,
+                                      ctx_server_config, gen_server_config,
+                                      self.MODEL_PATH) as llm:
+            run_accuracy_test(llm,
+                              self.MODEL_NAME, [CnnDailymail],
+                              extra_acc_spec=f"beam_width={max_beam_width}",
+                              sampling_params=sampling_params)
 
     @skip_pre_hopper
     @pytest.mark.skip_less_device(2)

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -279,6 +279,7 @@ l0_dgx_b200:
   - accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B::test_nvfp4[dep4_latency_moe_trtllm-torch_compile=True]
   - accuracy/test_llm_api_pytorch.py::TestQwen3_5_397B_A17B::test_nvfp4[tep4_cutedsl]
   - accuracy/test_llm_api_pytorch.py::TestQwen3_5_397B_A17B::test_nvfp4[tep4_trtllm]
+  - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_beam_search
   - accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_guided_decoding[xgrammar-mtp_nextn=0]
   - accuracy/test_disaggregated_serving.py::TestQwen3_30B_A3B::test_mixed_ctx_gen_model[ctxpp2gentp2]
   - accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_w4_4gpus[v1_kv_cache-tp4-cutlass-auto]

--- a/tests/unittest/_torch/sampler/test_beam_search.py
+++ b/tests/unittest/_torch/sampler/test_beam_search.py
@@ -18,6 +18,7 @@ import pathlib as _pl
 from contextlib import contextmanager, nullcontext
 from copy import deepcopy
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any, Callable, Generator, cast
 
 import pytest
@@ -27,7 +28,7 @@ from test_beam_search_util import (BeamSearchTestOutput, DummyConfigLoader,
 from utils.llm_data import llm_models_root
 from utils.util import assert_no_cuda_sync, force_ampere, run_test_with_warmup
 
-from tensorrt_llm import LLM, SamplingParams, TorchLlmArgs
+from tensorrt_llm import LLM, DisaggregatedParams, SamplingParams, TorchLlmArgs
 from tensorrt_llm._torch.models.checkpoints import HfCheckpointLoader
 from tensorrt_llm._torch.pyexecutor.llm_request import (LlmRequest,
                                                         SamplingConfig)
@@ -38,8 +39,10 @@ from tensorrt_llm._torch.pyexecutor.sampling_utils import (
     BEAM_SEARCH_PAD_TOKEN, BeamSearchMetadata, beam_search_sampling_batch)
 from tensorrt_llm.bindings.executor import FinishReason
 from tensorrt_llm.executor import RequestError
-from tensorrt_llm.executor.result import CompletionOutput, GenerationResult
-from tensorrt_llm.llmapi import CudaGraphConfig, KvCacheConfig
+from tensorrt_llm.executor.result import (CompletionOutput, GenerationResult,
+                                          Logprob)
+from tensorrt_llm.llmapi import (CacheTransceiverConfig, CudaGraphConfig,
+                                 KvCacheConfig)
 
 
 @pytest.fixture(scope="module")
@@ -83,6 +86,13 @@ def with_cuda_graph_and_overlap(request):
 
 
 def _build_llm(fixed_params, input_prompts, llm_kwargs: dict[str, Any]):
+    llm_kwargs = llm_kwargs.copy()
+    kv_cache_config = llm_kwargs.pop(
+        "kv_cache_config",
+        KvCacheConfig(
+            max_tokens=10000,  # pyright: ignore
+        ),
+    )
     if "max_batch_size" not in llm_kwargs:
         llm_kwargs = llm_kwargs | dict(
             max_batch_size=fixed_params["max_beam_width"] * len(
@@ -91,9 +101,7 @@ def _build_llm(fixed_params, input_prompts, llm_kwargs: dict[str, Any]):
         )
     return LLM(
         **llm_kwargs,
-        kv_cache_config=KvCacheConfig(
-            max_tokens=10000,  # pyright: ignore
-        ),
+        kv_cache_config=kv_cache_config,
         max_seq_len=32,
         max_beam_width=fixed_params["max_beam_width"],
     )
@@ -279,6 +287,31 @@ def validate_output(output: GenerationResult, input_prompt: list[int],
                              len(input_prompt), beam_idx)
 
 
+def validate_disagg_output(output: GenerationResult, input_prompt: list[int],
+                           sampling_params: SamplingParams) -> None:
+    """Validate disagg beam output without requiring full-run cache history."""
+    check_context_logits(output, sampling_params)
+    assert len(output.outputs) == sampling_params.n
+    expected_outputs = get_expected_outputs(
+        input_prompt[-1], num_iterations=sampling_params.max_tokens)
+
+    for beam_idx, beam_output in enumerate(output.outputs):
+        assert beam_output.finish_reason == "length"
+        check_generation_logits(beam_output, sampling_params, valid_tokens=None)
+        check_logprobs(beam_output, sampling_params, valid_tokens=None)
+        expected_token_ids = expected_outputs.outputs[beam_idx].tolist()
+        assert beam_output.token_ids == expected_token_ids, (
+            f"expected {expected_token_ids} token ids, "
+            f"got {beam_output.token_ids}")
+
+        assert beam_output.additional_generation_outputs is not None
+        cache_indirection = beam_output.additional_generation_outputs[
+            "cache_indirection"]
+        assert cache_indirection is not None
+        assert cache_indirection.shape[1] == sampling_params.best_of
+        assert cache_indirection.shape[0] == sampling_params.max_tokens - 1
+
+
 def validate_outputs(llm: LLM, input_prompts: list[list[int]],
                      sampling_params: SamplingParams,
                      monkeypatch: pytest.MonkeyPatch,
@@ -344,6 +377,51 @@ def validate_outputs(llm: LLM, input_prompts: list[list[int]],
         validate_output(output, input_prompts[output_idx], sampling_params)
 
 
+def validate_disagg_outputs(ctx_llm: LLM,
+                            gen_llm: LLM,
+                            input_prompts: list[list[int]],
+                            sampling_params: SamplingParams,
+                            request_id_base: int = 0) -> None:
+    """Run context-only then generation-only beam search and validate outputs."""
+
+    ctx_disagg_params = [
+        DisaggregatedParams(request_type="context_only",
+                            disagg_request_id=1000 + request_id_base + idx)
+        for idx in range(len(input_prompts))
+    ]
+    ctx_outputs = ctx_llm.generate(
+        deepcopy(input_prompts),
+        sampling_params=deepcopy(sampling_params),
+        disaggregated_params=ctx_disagg_params,
+        use_tqdm=False,
+    )
+    assert isinstance(ctx_outputs, list)
+    assert len(ctx_outputs) == len(input_prompts)
+
+    gen_disagg_params = []
+    for ctx_output in ctx_outputs:
+        disagg_params = ctx_output.disaggregated_params
+        assert disagg_params is not None
+        assert disagg_params.first_gen_tokens is not None
+        assert disagg_params.first_gen_log_probs is not None
+        assert len(disagg_params.first_gen_tokens) == sampling_params.best_of
+        assert len(disagg_params.first_gen_log_probs) == sampling_params.best_of
+        disagg_params.request_type = "generation_only"
+        gen_disagg_params.append(disagg_params)
+
+    gen_outputs = gen_llm.generate(
+        deepcopy(input_prompts),
+        sampling_params=deepcopy(sampling_params),
+        disaggregated_params=gen_disagg_params,
+        use_tqdm=False,
+    )
+    assert isinstance(gen_outputs, list)
+    assert len(gen_outputs) == len(input_prompts)
+    for output_idx, output in enumerate(gen_outputs):
+        validate_disagg_output(output, input_prompts[output_idx],
+                               sampling_params)
+
+
 ###########################################################################
 # End to end tests
 ###########################################################################
@@ -406,6 +484,63 @@ def test_beam_search_e2e(
         check_no_sync=single_process,
         monkeypatch=monkeypatch,
     )
+
+
+@pytest.mark.threadleak(enabled=False)
+def test_beam_search_disagg_e2e(
+    fixed_params,
+    input_prompts,
+    model_kwargs: dict[str, Any],
+) -> None:
+    if model_kwargs["sampler_type"] != "TorchSampler":
+        pytest.skip(
+            "Disaggregated beam score handoff is implemented for TorchSampler")
+
+    sampling_params = SamplingParams(
+        max_tokens=fixed_params["max_tokens"],
+        n=fixed_params["max_beam_width"],
+        best_of=fixed_params["max_beam_width"],
+        use_beam_search=True,
+        end_id=-1,
+        include_stop_str_in_output=True,
+        additional_model_outputs=["cache_indirection"],
+    )
+
+    disagg_kwargs = deepcopy(model_kwargs)
+    disagg_kwargs |= dict(
+        disable_overlap_scheduler=True,
+        cuda_graph_config=None,
+        kv_cache_config=KvCacheConfig(max_tokens=10000,
+                                      enable_block_reuse=True,
+                                      enable_partial_reuse=True,
+                                      use_kv_cache_manager_v2=True),
+        cache_transceiver_config=CacheTransceiverConfig(
+            backend="NIXL",
+            transceiver_runtime="PYTHON",
+            kv_transfer_timeout_ms=1000,
+            kv_transfer_sender_future_timeout_ms=1000,
+        ),
+    )
+
+    partial_reuse_prompts = [[1, 2, 3], [1, 5, 6]]
+
+    ctx_llm = _build_llm(fixed_params, partial_reuse_prompts, disagg_kwargs)
+    gen_llm = _build_llm(fixed_params, partial_reuse_prompts, disagg_kwargs)
+    try:
+        with ctx_llm, gen_llm:
+            validate_disagg_outputs(ctx_llm,
+                                    gen_llm,
+                                    partial_reuse_prompts[:1],
+                                    sampling_params,
+                                    request_id_base=0)
+            validate_disagg_outputs(ctx_llm,
+                                    gen_llm,
+                                    partial_reuse_prompts[1:],
+                                    sampling_params,
+                                    request_id_base=100)
+    finally:
+        ctx_llm.shutdown()
+        gen_llm.shutdown()
 
 
 ###########################################################################
@@ -607,6 +742,172 @@ def test_beam_search_sampling_batch_basic():
             torch.testing.assert_close(
                 predecessor_beams_result[seq_slot, beam_idx],
                 torch.tensor(predecessor_beam, dtype=torch.int32))
+
+
+def test_beam_search_sampling_batch_disagg_handoff():
+    """Test context-first disagg beam handoff seeds gen-side beam scores."""
+
+    test_params = GeneralTestParams()
+    batch_size = test_params.batch_size
+    beam_width = test_params.beam_width
+    vocab_size = test_params.vocab_size
+    max_batch_size = test_params.max_batch_size
+    prompt_len = test_params.prompt_len
+    temperature = 1.0
+
+    seq_slots = torch.arange(
+        batch_size, dtype=torch.int64) + (max_batch_size - batch_size) // 2
+    seq_offsets = torch.arange(max_batch_size, dtype=torch.int64) * beam_width
+    beam_idx_arange = torch.arange(beam_width, dtype=torch.int32)
+
+    def make_metadata(seq_len: int) -> BeamSearchMetadata:
+        return BeamSearchMetadata(
+            cache_indirection=torch.zeros(
+                (max_batch_size, beam_width, prompt_len + 2),
+                dtype=torch.int32),
+            cache_indirection_buffer=torch.full(
+                (max_batch_size, beam_width, prompt_len + 2),
+                -1,
+                dtype=torch.int32),
+            cum_log_probs=torch.zeros((max_batch_size, beam_width),
+                                      dtype=torch.float32),
+            seq_slots=seq_slots,
+            seq_lens=torch.full((batch_size, ), seq_len, dtype=torch.int32),
+            finished_beams=torch.zeros((max_batch_size, beam_width),
+                                       dtype=torch.int32),
+            new_log_probs=torch.zeros((max_batch_size, beam_width),
+                                      dtype=torch.float32),
+            predecessor_beams=torch.zeros((max_batch_size, beam_width),
+                                          dtype=torch.int32),
+            seq_offsets=seq_offsets,
+            beam_idx_arange=beam_idx_arange,
+        )
+
+    torch.manual_seed(43)
+    context_logits = torch.randn((batch_size, vocab_size), dtype=torch.float32)
+    generation_logits = torch.randn((batch_size * beam_width, vocab_size),
+                                    dtype=torch.float32)
+    for req_idx in range(batch_size):
+        context_logits[req_idx, req_idx * beam_width:req_idx * beam_width +
+                       beam_width] += torch.tensor([8.0, 7.0, 1.0])
+        for beam_idx in range(beam_width):
+            row = req_idx * beam_width + beam_idx
+            generation_logits[row, 10 + beam_idx] += 4.0 + beam_idx
+
+    # Baseline: one continuous request. Context produces first beams, then
+    # generation continues with beam_width input beams.
+    continuous_metadata = make_metadata(prompt_len)
+    first_tokens, _ = beam_search_sampling_batch(
+        logits=context_logits,
+        beam_width_in=1,
+        beam_width_out=beam_width,
+        beam_search_args=continuous_metadata,
+        temperature=temperature,
+        return_probs=False,
+    )
+    first_gen_scores = continuous_metadata.cum_log_probs[
+        seq_slots, :beam_width].clone()
+    assert first_tokens.shape == (batch_size, beam_width)
+
+    continuous_metadata.seq_lens = torch.full((batch_size, ),
+                                              prompt_len + 1,
+                                              dtype=torch.int32)
+    continuous_next_tokens, _ = beam_search_sampling_batch(
+        logits=generation_logits,
+        beam_width_in=beam_width,
+        beam_width_out=beam_width,
+        beam_search_args=continuous_metadata,
+        temperature=temperature,
+        return_probs=False,
+    )
+    continuous_cum_log_probs = continuous_metadata.cum_log_probs[
+        seq_slots, :beam_width].clone()
+    continuous_new_log_probs = continuous_metadata.new_log_probs[
+        seq_slots, :beam_width].clone()
+    continuous_predecessor_beams = continuous_metadata.predecessor_beams[
+        seq_slots, :beam_width].clone()
+    continuous_cache_indirection = continuous_metadata.cache_indirection[
+        seq_slots, :beam_width, :prompt_len + 2].clone()
+
+    # Disaggregated generation starts from reset sampler buffers, then seeds
+    # the first-token beam scores derived from context first_gen_log_probs.
+    from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
+
+    disagg_metadata = make_metadata(prompt_len + 1)
+    original_tokens = torch.zeros((max_batch_size, beam_width, prompt_len + 2),
+                                  dtype=torch.int32)
+    fake_executor = cast(
+        PyExecutor,
+        SimpleNamespace(sampler=SimpleNamespace(store=SimpleNamespace(
+            beam_search_store=SimpleNamespace(
+                original_tokens=original_tokens,
+                cache_indirection=disagg_metadata.cache_indirection,
+                cum_log_probs=disagg_metadata.cum_log_probs,
+            )))))
+    for req_idx, seq_slot in enumerate(seq_slots.tolist()):
+        first_gen_tokens = first_tokens[req_idx, :beam_width].tolist()
+        first_gen_log_probs = [{
+            token_id:
+            Logprob(logprob=float(first_gen_scores[req_idx, beam_idx].item()))
+        } for beam_idx, token_id in enumerate(first_gen_tokens)]
+        req = SimpleNamespace(
+            py_seq_slot=seq_slot,
+            py_request_id=req_idx,
+            prompt_len=prompt_len,
+            py_disaggregated_params=DisaggregatedParams(
+                request_type="generation_only",
+                first_gen_log_probs=first_gen_log_probs,
+            ),
+        )
+        PyExecutor._update_sampler_state_for_disagg_gen_request(
+            fake_executor, req, beam_width, first_gen_tokens)
+
+    expected_beam_indices = torch.arange(beam_width, dtype=torch.int32).expand(
+        batch_size, beam_width)
+    torch.testing.assert_close(
+        original_tokens[seq_slots, :beam_width, prompt_len], first_tokens)
+    torch.testing.assert_close(
+        disagg_metadata.cache_indirection[seq_slots, :beam_width, prompt_len],
+        expected_beam_indices)
+    torch.testing.assert_close(
+        disagg_metadata.cum_log_probs[seq_slots, :beam_width], first_gen_scores)
+    disagg_next_tokens, _ = beam_search_sampling_batch(
+        logits=generation_logits,
+        beam_width_in=beam_width,
+        beam_width_out=beam_width,
+        beam_search_args=disagg_metadata,
+        temperature=temperature,
+        return_probs=False,
+    )
+
+    torch.testing.assert_close(disagg_next_tokens, continuous_next_tokens)
+    torch.testing.assert_close(
+        disagg_metadata.cache_indirection[seq_slots, :beam_width, :prompt_len +
+                                          2], continuous_cache_indirection)
+    torch.testing.assert_close(
+        disagg_metadata.cum_log_probs[seq_slots, :beam_width],
+        continuous_cum_log_probs)
+    torch.testing.assert_close(
+        disagg_metadata.new_log_probs[seq_slots, :beam_width],
+        continuous_new_log_probs)
+    torch.testing.assert_close(
+        disagg_metadata.predecessor_beams[seq_slots, :beam_width],
+        continuous_predecessor_beams)
+
+    # This is the regression guard for disagg: if gen-side cum_log_probs remain
+    # reset after receiving first_gen_tokens, the next step is scored incorrectly.
+    unseeded_metadata = make_metadata(prompt_len + 1)
+    beam_search_sampling_batch(
+        logits=generation_logits,
+        beam_width_in=beam_width,
+        beam_width_out=beam_width,
+        beam_search_args=unseeded_metadata,
+        temperature=temperature,
+        return_probs=False,
+    )
+    assert not torch.allclose(
+        unseeded_metadata.cum_log_probs[seq_slots, :beam_width],
+        continuous_cum_log_probs)
 
 
 def create_default_request(test_params: GeneralTestParams) -> LlmRequest:

--- a/tests/unittest/disaggregated/test_cache_reuse_adapter.py
+++ b/tests/unittest/disaggregated/test_cache_reuse_adapter.py
@@ -19,8 +19,13 @@ import pytest
 
 from tensorrt_llm._torch.disaggregation.base.transfer import TokenRange
 from tensorrt_llm._torch.disaggregation.native.transfer import Sender
-from tensorrt_llm._torch.disaggregation.resource.cache_reuse import CacheReuseAdapter
-from tensorrt_llm._torch.disaggregation.resource.page import AttentionLayerGroup
+from tensorrt_llm._torch.disaggregation.resource.cache_reuse import (
+    CacheReuseAdapter,
+    _CacheReuseAdapterV1,
+)
+from tensorrt_llm._torch.disaggregation.resource.page import AttentionLayerGroup, LocalLayer
+from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
 
 # ---------------------------------------------------------------------------
 # _align_kv_blocks: contract unchanged.
@@ -95,6 +100,152 @@ class TestAlignKvBlocks:
 
 
 # ---------------------------------------------------------------------------
+# Packed 1-D beam block layout.
+# ---------------------------------------------------------------------------
+
+
+class TestPackedBeamBlockLayout:
+    """Verify beam search block IDs stay 1-D with only final tail blocks appended."""
+
+    def test_v1_adapter_uses_request_py_beam_width(self):
+        class _FakeMgr:
+            enable_block_reuse = True
+            tokens_per_block = 32
+
+            def __init__(self):
+                self.beam_width = None
+
+            def get_batch_cache_indices(self, request_ids, layer_idx=None, beam_width=1):
+                self.beam_width = beam_width
+                return [[10, 11, 12, 13]]
+
+        req = _FakeReq(prompt_len=7)
+        req.py_request_id = 1
+        req.py_beam_width = 4
+        req.sampling_config = _FakeSamplingConfig(beam_width=1)
+        mgr = _FakeMgr()
+
+        block_ids = _CacheReuseAdapterV1(mgr).get_block_ids(req, 0, _lg())
+
+        assert mgr.beam_width == 4
+        np.testing.assert_array_equal(block_ids, [10, 11, 12, 13])
+
+    def test_pack_beam_cache_indices_single_block_prompt_keeps_all_beams(self):
+        packed = KVCacheManager._pack_beam_cache_indices([[10], [10], [10], [10]])
+
+        assert packed == [10]
+
+    def test_pack_beam_cache_indices_appends_final_unshared_blocks(self):
+        packed = KVCacheManager._pack_beam_cache_indices(
+            [
+                [10, 11, 12],
+                [10, 11, 13],
+                [10, 11, 14],
+                [10, 11, 15],
+            ]
+        )
+
+        assert packed == [10, 11, 12, 13, 14, 15]
+
+    def test_pack_beam_cache_indices_skips_shared_final_blocks(self):
+        packed = KVCacheManager._pack_beam_cache_indices(
+            [
+                [10, 11, 12],
+                [10, 11, 12],
+                [10, 11, 13],
+            ]
+        )
+
+        assert packed == [10, 11, 12, 13]
+
+    def test_beam0_block_count_for_full_packed_prompt(self):
+        block_ids = np.array([10, 11, 12, 13, 14, 15], dtype=np.int64)
+
+        assert Sender._beam0_block_count(block_ids, total_blocks=3, beam_width=4) == 3
+
+    def test_beam0_block_count_after_cached_prefix_skip(self):
+        block_ids = np.array([12, 13, 14, 15], dtype=np.int64)
+
+        assert Sender._beam0_block_count(block_ids, total_blocks=3, beam_width=4) == 1
+
+    def test_beam0_block_count_for_single_beam_unchanged(self):
+        block_ids = np.array([10, 11, 12], dtype=np.int64)
+
+        assert Sender._beam0_block_count(block_ids, total_blocks=3, beam_width=1) == 3
+
+    def test_align_packed_single_block_prompt_keeps_all_beam_blocks(self):
+        src_block_ids = np.array([10, 10, 10, 10], dtype=np.int64)
+        dst_block_ids = np.array([20, 21, 22, 23], dtype=np.int64)
+        total_blocks = 1
+        tpb = 32
+        src_start = (total_blocks - Sender._beam0_block_count(src_block_ids, total_blocks, 4)) * tpb
+        dst_start = (total_blocks - Sender._beam0_block_count(dst_block_ids, total_blocks, 4)) * tpb
+
+        src, dst = Sender._align_kv_blocks(
+            src_block_ids,
+            dst_block_ids,
+            src_token_start=src_start,
+            dst_token_start=dst_start,
+            tokens_per_block=tpb,
+        )
+
+        np.testing.assert_array_equal(src, [10, 10, 10, 10])
+        np.testing.assert_array_equal(dst, [20, 21, 22, 23])
+
+    def test_trim_single_block_prompt_preserves_packed_beam_tails(self):
+        block_ids = np.array([10, 11, 12, 13], dtype=np.int64)
+
+        trimmed = KvCacheTransceiverV2._trim_packed_beam_block_ids(
+            block_ids,
+            beam_width=4,
+            total_blocks=1,
+            expected_valid=1,
+            cache_skip=0,
+        )
+
+        np.testing.assert_array_equal(trimmed, [10, 11, 12, 13])
+
+    def test_trim_long_prompt_preserves_valid_beam0_and_tails(self):
+        block_ids = np.array([10, 11, 12, 13, 14, 15], dtype=np.int64)
+
+        trimmed = KvCacheTransceiverV2._trim_packed_beam_block_ids(
+            block_ids,
+            beam_width=4,
+            total_blocks=3,
+            expected_valid=3,
+            cache_skip=0,
+        )
+
+        np.testing.assert_array_equal(trimmed, [10, 11, 12, 13, 14, 15])
+
+    def test_trim_swa_prefix_preserves_packed_beam_tails(self):
+        block_ids = np.array([10, 11, 12, 13, 14, 15, 16], dtype=np.int64)
+
+        trimmed = KvCacheTransceiverV2._trim_packed_beam_block_ids(
+            block_ids,
+            beam_width=4,
+            total_blocks=4,
+            expected_valid=2,
+            cache_skip=0,
+        )
+
+        np.testing.assert_array_equal(trimmed, [12, 13, 14, 15, 16])
+
+    def test_cache_skip_drops_tail_blocks_when_beam0_fully_cached(self):
+        block_ids = np.array([10, 11, 12, 13], dtype=np.int64)
+
+        trimmed = KvCacheTransceiverV2._trim_packed_beam_block_ids(
+            block_ids,
+            beam_width=4,
+            total_blocks=1,
+            expected_valid=1,
+            cache_skip=1,
+        )
+
+        assert trimmed.size == 0
+
+
+# ---------------------------------------------------------------------------
 # TokenRange dataclass invariants.
 # ---------------------------------------------------------------------------
 
@@ -150,8 +301,17 @@ class _FakeReq:
         self.prompt_len = prompt_len
 
 
+class _FakeSamplingConfig:
+    def __init__(self, beam_width: int):
+        self.beam_width = beam_width
+
+
 def _lg(window=None):
-    return AttentionLayerGroup(pool_group_idx=0, sliding_window_size=window)
+    return AttentionLayerGroup(
+        pool_group_idx=0,
+        sliding_window_size=window,
+        local_layers=[LocalLayer(local_layer_id=0, global_layer_id=0)],
+    )
 
 
 class TestAdapterPerLayerGroup:


### PR DESCRIPTION
## Description

Added support for beam search in disaggregated serving for the PyTorch backend. Previously, the disaggregated path effectively assumed `beam_width == 1`: the Python transfer path did not carry enough beam-aware block metadata, and the generation server did not receive enough first-token beam state to continue scoring from the context server handoff. This change removes those single-beam assumptions while keeping the transceiver block-id contract as a 1-D list.

Key changes:
- Added a packed 1-D block-id layout for beam search KV transfer:
  - beam 0 contributes the context block prefix;
  - the final per-beam tail blocks are appended to that prefix;
  - the transceiver continues to handle only 1-D block-id arrays.
- Made the Python KV transfer path beam-aware without introducing 2-D transceiver metadata:
  - request block tables are read with `req.py_beam_width`;
  - `KVCacheManager` packs per-beam cache indices into the 1-D beam-0-plus-tail layout;
  - `_create_kv_slice` trims sliding-window and cached-prefix blocks against the beam-0 prefix while preserving appended beam tails;
  - the native sender derives token starts from the beam-0 block count before aligning source and destination block ranges.
- Added first-token beam log probabilities to disaggregated metadata:
  - context-side beam search stores `first_gen_log_probs`;
  - executor result and OpenAI protocol serialization/deserialization carry those log probabilities with `first_gen_tokens`;
  - generation-side PyExecutor seeds TorchSampler beam cumulative log probabilities before continuing decoding.
- Seeded generation-side beam history from the context-side first generated tokens:
  - initializes `original_tokens` at `prompt_len`;
  - initializes `cache_indirection` so each first generated token is associated with the correct beam;
  - allows the generation-only server to continue beam history reconstruction as if the request had run continuously.
- Updated the disaggregated OpenAI test client to forward beam-search request fields:
  - sends `extra_body={"use_beam_search": True}`;
  - converts all returned choices into `CompletionOutput` objects instead of only choice 0.
- Added a disaggregated serving accuracy test for Llama 3.1 8B Instruct beam search using `CnnDailymail` and the existing `beam_width=2` reference.
- Enforced `claimResult.totalMatchedTokens <= claimResult.numSharedContextBlocks * mTokensPerBlock` so that the prepopulated prompt length only includes tokens whose KV blocks were onboarded for reuse.
  - This is needed for beam search because reusable context is rounded down to shared context blocks; `totalMatchedTokens` and `prepopulatedPromptLength` must match that block-level reuse boundary.


## Test Coverage

- Added `test_beam_search_sampling_batch_disagg_handoff` to compare continuous beam search against a simulated disaggregated handoff. It verifies that generation-side seeding from `first_gen_log_probs` produces the same next tokens, cumulative log probabilities, new log probabilities, and predecessor beams as the continuous path, and that leaving the scores unseeded fails to match.
- Added `test_beam_search_disagg_e2e` for context-only followed by generation-only beam search with the Python NIXL transceiver. The test validates generated beam outputs and `cache_indirection` shape.
- Added packed-layout unit tests for block packing, `py_beam_width` propagation, sender alignment, and `_create_kv_slice` trimming/cache-skip behavior.
- Extended the disaggregated serving accuracy test to run beam search with `max_beam_width=2`, Python NIXL KV transfer, and CNN/DailyMail `extra_acc_spec="beam_width=2"`.
- Added the beam-search disaggregated serving accuracy test to `l0_dgx_b200.yml`.

- [x] Please check this after reviewing the above items as appropriate for this PR.

