### PR TITLE
[TRTLLM-13141][feat] Add backend-agnostic SourceIdentity gate for weight sharing

### DIFF
--- a/tensorrt_llm/_torch/memory/gpu_memory_backend.py
+++ b/tensorrt_llm/_torch/memory/gpu_memory_backend.py
@@ -16,19 +16,19 @@
 """GPU Memory Backend protocol and GMS implementation.
 
 Defines a thin protocol that adapts the upstream GPU Memory Service
-(``gpu_memory_service`` from ``ai-dynamo/dynamo``) into TRT-LLM's
-``ModelLoader`` pipeline. The protocol intentionally exposes only the
+(`gpu_memory_service` from `ai-dynamo/dynamo`) into TRT-LLM's
+`ModelLoader` pipeline. The protocol intentionally exposes only the
 operations TRT-LLM needs at specific points in the loading lifecycle —
 all heavy lifting (CUDA VMM, FD passing, zero-copy tensor construction)
 is delegated to the GMS library's stable public Python primitives.
 
 Design notes:
-- We deliberately avoid the upstream ``setup_gms()`` monkey-patch entry
-  point. TRT-LLM owns the integration policy in ``ModelLoader``; this
+- We deliberately avoid the upstream `setup_gms()` monkey-patch entry
+  point. TRT-LLM owns the integration policy in `ModelLoader`; this
   backend is a thin adapter over the GMS library's primitive API.
 - The protocol has a single point of contact per concern, so when the
-  upstream GMS Python API drifts, only the methods on ``GMSBackend``
-  need to change — the call sites in ``model_loader.py`` are stable.
+  upstream GMS Python API drifts, only the methods on `GMSBackend`
+  need to change — the call sites in `model_loader.py` are stable.
 
 Operating modes:
 - **RW (Read-Write)**: First worker loads weights via the normal
@@ -36,7 +36,7 @@ Operating modes:
   CUDA memory pool. After loading, weights are committed for read-only
   access by other workers and the client transitions to RO mode in place.
 - **RO (Read-Only)**: Subsequent workers zero-copy import already-committed
-  weights from the GMS pool. ``post_load_weights()`` must run BEFORE
+  weights from the GMS pool. `post_load_weights()` must run BEFORE
   materialization so that module aliases are set up correctly.
 """
 
@@ -102,18 +102,18 @@ _MODE_ALIASES = ("rw", "ro", "auto")
 
 
 class GMSBackend:
-    """Concrete ``GPUMemoryBackend`` using ``gpu_memory_service`` (GMS).
+    """Concrete `GPUMemoryBackend` using `gpu_memory_service` (GMS).
 
     GMS is a multi-process GPU memory manager (out-of-process server,
     in-process clients) that lets multiple inference instances share weight
     bytes via CUDA VMM mappings and Unix-socket FD passing.
 
     This adapter calls the GMS library's stable per-call primitives
-    (``GMSClientMemoryManager`` + the helpers in
-    ``gpu_memory_service.client.torch.allocator`` and ``.module``) and
-    composes them into the methods TRT-LLM's ``ModelLoader`` invokes for
-    the ``LoadFormat.GMS`` branch. We intentionally do **not** use the
-    upstream ``setup_gms()`` monkey-patch — TRT-LLM owns the integration
+    (`GMSClientMemoryManager` + the helpers in
+    `gpu_memory_service.client.torch.allocator` and `.module`) and
+    composes them into the methods TRT-LLM's `ModelLoader` invokes for
+    the `LoadFormat.GMS` branch. We intentionally do **not** use the
+    upstream `setup_gms()` monkey-patch — TRT-LLM owns the integration
     policy and we keep the dependency surface narrow and explicit.
     """
 
@@ -130,14 +130,14 @@ class GMSBackend:
 
         Args:
             socket_path: Unix domain socket path for the per-GPU GMS daemon.
-                When ``None``, the default per-GPU UUID-keyed path from
-                ``gpu_memory_service.common.utils.get_socket_path`` is used
+                When `None`, the default per-GPU UUID-keyed path from
+                `gpu_memory_service.common.utils.get_socket_path` is used
                 (resolved lazily inside :meth:`connect`).
-            mapping: TRT-LLM distributed ``Mapping`` for TP/PP rank info.
-            mode: Operating mode — ``"auto"`` (RW first, RO after committed),
-                ``"rw"`` (require RW), or ``"ro"`` (require RO).
+            mapping: TRT-LLM distributed `Mapping` for TP/PP rank info.
+            mode: Operating mode — `"auto"` (RW first, RO after committed),
+                `"rw"` (require RW), or `"ro"` (require RO).
             tag: Logical tag identifying this weight set in the GMS server.
-                Default ``"weights"`` matches the GMS library convention.
+                Default `"weights"` matches the GMS library convention.
         """
         if mode not in _MODE_ALIASES:
             raise ValueError(f"GMS mode must be one of {_MODE_ALIASES}, got {mode!r}")
@@ -159,8 +159,8 @@ class GMSBackend:
     def connect(self) -> bool:
         """Connect to the per-GPU GMS daemon and acquire a session.
 
-        Returns ``True`` on success. On import failure (library not
-        installed) or socket failure, returns ``False`` and logs a warning
+        Returns `True` on success. On import failure (library not
+        installed) or socket failure, returns `False` and logs a warning
         — callers are expected to surface a useful error to the user.
         """
         try:
@@ -251,10 +251,10 @@ class GMSBackend:
         """Whether this client holds the writer lock for the GMS pool.
 
         Returns:
-            ``True`` if RW (writer) was granted, ``False`` if RO (reader)
-            was granted, ``None`` before :meth:`connect` has been called
+            `True` if RW (writer) was granted, `False` if RO (reader)
+            was granted, `None` before :meth:`connect` has been called
             successfully or after :meth:`cleanup` has run. Transitions
-            from ``True`` to ``False`` after :meth:`finalize_write`.
+            from `True` to `False` after :meth:`finalize_write`.
         """
         return self._is_rw
 
@@ -262,12 +262,12 @@ class GMSBackend:
         """Whether committed weights are available for RO materialization.
 
         Reports the granted lock type at the time of call, which only
-        becomes ``RO`` once a writer in this or another process has
-        published a finalized layout for ``tag``.
+        becomes `RO` once a writer in this or another process has
+        published a finalized layout for `tag`.
 
         Returns:
-            ``True`` if the granted lock is ``RO`` (committed weights
-            exist and can be zero-copy mapped); ``False`` otherwise,
+            `True` if the granted lock is `RO` (committed weights
+            exist and can be zero-copy mapped); `False` otherwise,
             including pre-connect, post-cleanup, and any error paths.
             Never raises — best-effort by design so callers can use it
             as a precondition check before invoking
@@ -293,23 +293,23 @@ class GMSBackend:
     ) -> Iterator[None]:
         """Context manager scoping CUDA allocations to the GMS pool.
 
-        All ``torch.empty`` / ``torch.zeros`` / etc. allocations inside
+        All `torch.empty` / `torch.zeros` / etc. allocations inside
         this scope are routed through the GMS pluggable allocator and
-        land in the shared memory region for the configured ``tag``.
+        land in the shared memory region for the configured `tag`.
         Allocations made via paths that bypass the active allocator
-        (e.g. C++ ops that call ``cudaMalloc`` directly) escape this
+        (e.g. C++ ops that call `cudaMalloc` directly) escape this
         scope and must be swept by :meth:`move_untracked_params`
         before :meth:`finalize_write` is called.
 
         Args:
             device: Target CUDA device. Defaults to
-                ``torch.device('cuda', current_device())``.
+                `torch.device('cuda', current_device())`.
 
         Yields:
-            ``None`` — the value is unused; this is a scoping context.
+            `None` — the value is unused; this is a scoping context.
 
         Raises:
-            RuntimeError: If ``connect()`` has not been called yet, or
+            RuntimeError: If `connect()` has not been called yet, or
                 if the granted lock is RO (only the writer may allocate
                 into the pool).
         """
@@ -332,23 +332,23 @@ class GMSBackend:
     def move_untracked_params(self, model: nn.Module) -> None:
         """Migrate parameters allocated outside the GMS pool into it.
 
-        Some parts of TRT-LLM's loading pipeline (e.g. ``post_load_weights``,
-        ``model.to("cuda")``) may allocate buffers outside the
-        ``mem_pool_scope`` context. ``finalize_write`` requires every
+        Some parts of TRT-LLM's loading pipeline (e.g. `post_load_weights`,
+        `model.to("cuda")`) may allocate buffers outside the
+        `mem_pool_scope` context. `finalize_write` requires every
         registered tensor to live in the GMS pool, so we copy any stray
         CUDA params into freshly created GMS mappings of the same size.
 
-        Mirrors ``gpu_memory_service.integrations.trtllm.model_loader.
-        _move_untracked_params`` so behavior matches the upstream
+        Mirrors `gpu_memory_service.integrations.trtllm.model_loader.
+        _move_untracked_params` so behavior matches the upstream
         reference integration.
 
         Args:
-            model: The ``nn.Module`` to scan for stray CUDA parameters.
-                Buffers (``tensor_type != 'parameter'``), CPU tensors,
+            model: The `nn.Module` to scan for stray CUDA parameters.
+                Buffers (`tensor_type != 'parameter'`), CPU tensors,
                 and tensors already backed by a GMS mapping are skipped.
 
         Raises:
-            RuntimeError: If ``connect()`` has not been called yet.
+            RuntimeError: If `connect()` has not been called yet.
         """
         # TODO(GMS-API): Clean up once the stable GMS API becomes available.
         if self._client is None:
@@ -369,9 +369,9 @@ class GMSBackend:
         #      original non-GMS storage and were missed by finalize_write.
         storage_to_gms_va: dict[int, int] = {}
 
-        # No torch.no_grad() guard: ``tensor.data = X`` bypasses autograd by
+        # No torch.no_grad() guard: `tensor.data = X` bypasses autograd by
         # definition (it's a data-attribute assignment, not an autograd-tracked
-        # operation), and ``replacement.copy_(tensor)`` is an in-place op on a
+        # operation), and `replacement.copy_(tensor)` is an in-place op on a
         # freshly created tensor with no autograd history. Model loading also
         # runs outside any grad-enabled context.
         for _name, tensor, tensor_type in _iter_module_tensors(model):
@@ -408,27 +408,27 @@ class GMSBackend:
     def finalize_write(self, model: nn.Module) -> int:
         """Register tensors, commit them, and transition this client to RO.
 
-        After this returns successfully, ``is_rw`` flips to ``False``
-        and other instances on the same node connecting in ``"auto"``
-        or ``"ro"`` mode will receive a zero-copy RO mapping of the
+        After this returns successfully, `is_rw` flips to `False`
+        and other instances on the same node connecting in `"auto"`
+        or `"ro"` mode will receive a zero-copy RO mapping of the
         committed layout. The transition is in-place: this client
         keeps the same socket connection.
 
-        Mirrors ``gpu_memory_service.integrations.common.utils.
-        finalize_gms_write``.
+        Mirrors `gpu_memory_service.integrations.common.utils.
+        finalize_gms_write`.
 
         Args:
-            model: The fully-loaded ``nn.Module`` whose CUDA parameters
+            model: The fully-loaded `nn.Module` whose CUDA parameters
                 will be registered with the GMS daemon. Every parameter
                 must already live in the GMS pool — call
                 :meth:`move_untracked_params` first to sweep strays
                 allocated outside :meth:`mem_pool_scope`.
 
         Returns:
-            Total bytes committed to the GMS pool for this ``tag``.
+            Total bytes committed to the GMS pool for this `tag`.
 
         Raises:
-            RuntimeError: If ``connect()`` has not been called yet, or
+            RuntimeError: If `connect()` has not been called yet, or
                 if the granted lock is RO (only the writer may commit).
         """
         if self._client is None:
@@ -461,9 +461,9 @@ class GMSBackend:
         that the writer's layout matches its own.
 
         Returns:
-            The writer's committed identity, or ``None`` when none is
-            available (the caller then proceeds without a pre-materialize
-            compatibility check).
+            The writer's committed identity, or `None` when none is
+            available. GMS RO treats a missing identity as incompatible and
+            rejects materialization.
         """
         # TODO(SOURCE-IDENTITY/GMS): persist the writer's serialized identity
         # in finalize_write and read it back here once the pool exposes a
@@ -477,19 +477,19 @@ class GMSBackend:
         by GPU pointers from the shared memory region — no data copies,
         no disk I/O, just CUDA VMM remapping. The model's submodule
         layout must already match the writer's at commit time, including
-        any aliases / derived buffers introduced by ``post_load_weights``.
+        any aliases / derived buffers introduced by `post_load_weights`.
 
         Args:
-            model: The ``nn.Module`` to materialize. Walks the full
-                module tree (including submodules like ``draft_model``
+            model: The `nn.Module` to materialize. Walks the full
+                module tree (including submodules like `draft_model`
                 added for speculative decoding) and rebinds matching
                 parameters to GMS-backed storage.
 
         Raises:
-            RuntimeError: If ``connect()`` has not been called yet.
+            RuntimeError: If `connect()` has not been called yet.
 
         Note:
-            ``post_load_weights()`` must be called on the model BEFORE
+            `post_load_weights()` must be called on the model BEFORE
             this method. The order ensures that any aliases / derived
             parameters created by post-load hooks are present on the
             module tree at materialization time, so they are bound to
@@ -520,18 +520,18 @@ class GMSBackend:
 
         Idempotent: a second call after a successful cleanup is a no-op
         because the client handle is dropped. Best-effort: any failure
-        in upstream ``client.close()`` or ``evict_gms_client_memory_manager``
-        is logged (warning for the outer error, debug for ``close()``)
-        and swallowed so callers — including ``__del__`` paths in
-        ``ModelLoader`` and ``PyTorchModelEngine`` — never raise from
+        in upstream `client.close()` or `evict_gms_client_memory_manager`
+        is logged (warning for the outer error, debug for `close()`)
+        and swallowed so callers — including `__del__` paths in
+        `ModelLoader` and `PyTorchModelEngine` — never raise from
         teardown.
 
         After return:
-            - The local client handle is unset (``_client is None``).
+            - The local client handle is unset (`_client is None`).
             - A subsequent :meth:`connect` may re-establish a fresh
               session against the same daemon.
             - GMS-backed CUDA mappings remain alive on-device for any
-              other process holding an RO lock on this ``tag``.
+              other process holding an RO lock on this `tag`.
         """
         if self._client is None:
             return
@@ -559,19 +559,19 @@ class GMSBackend:
 def _ptr_in_gms(gms_client, ptr: int) -> bool:
     """Whether a raw CUDA pointer falls inside an existing GMS mapping.
 
-    Mirrors ``gpu_memory_service.integrations.trtllm.model_loader._ptr_in_gms``.
-    Tolerates absence of the ``_mappings`` attribute on older GMS
-    releases by returning ``False`` (treating the pointer as "untracked"
+    Mirrors `gpu_memory_service.integrations.trtllm.model_loader._ptr_in_gms`.
+    Tolerates absence of the `_mappings` attribute on older GMS
+    releases by returning `False` (treating the pointer as "untracked"
     so the caller's stray-handling path runs).
 
     Args:
-        gms_client: A connected ``GMSClientMemoryManager``.
-        ptr: A raw CUDA virtual address (``tensor.data_ptr()`` or a
+        gms_client: A connected `GMSClientMemoryManager`.
+        ptr: A raw CUDA virtual address (`tensor.data_ptr()` or a
             storage base pointer).
 
     Returns:
-        ``True`` if ``ptr`` lies inside any mapping the client tracks
-        for any tag, ``False`` otherwise. Never raises.
+        `True` if `ptr` lies inside any mapping the client tracks
+        for any tag, `False` otherwise. Never raises.
     """
     mappings = getattr(gms_client, "_mappings", None)
     if not mappings:
@@ -585,18 +585,18 @@ def _ptr_in_gms(gms_client, ptr: int) -> bool:
 
 
 def _storage_nbytes(tensor: torch.Tensor) -> int:
-    """Bytes owned by ``tensor``'s underlying storage, including any padding.
+    """Bytes owned by `tensor`'s underlying storage, including any padding.
 
     Used to size GMS mappings created in :meth:`GMSBackend.move_untracked_params`
     so the replacement allocation matches the original storage exactly,
     not the (possibly smaller) view the tensor exposes.
 
     Args:
-        tensor: Any CUDA ``torch.Tensor``. View-vs-base distinction is
+        tensor: Any CUDA `torch.Tensor`. View-vs-base distinction is
             intentional: we always want the whole storage size.
 
     Returns:
-        Total bytes of the underlying ``UntypedStorage``.
+        Total bytes of the underlying `UntypedStorage`.
     """
     storage = tensor.untyped_storage()
     return int(storage.nbytes())

--- a/tensorrt_llm/_torch/memory/gpu_memory_backend.py
+++ b/tensorrt_llm/_torch/memory/gpu_memory_backend.py
@@ -46,6 +46,7 @@ from typing import Iterator, Optional, Protocol, runtime_checkable
 import torch
 from torch import nn
 
+from tensorrt_llm._torch.weight_sharing import SourceIdentity
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
@@ -76,6 +77,10 @@ class GPUMemoryBackend(Protocol):
 
     def materialize_module(self, model: nn.Module) -> None:
         """Zero-copy import committed weights into model params (RO path)."""
+        ...
+
+    def get_source_identity(self) -> Optional["SourceIdentity"]:
+        """Return the writer's committed SourceIdentity, if available (RO)."""
         ...
 
     def finalize_write(self, model: nn.Module) -> int:
@@ -448,6 +453,22 @@ class GMSBackend:
     # ------------------------------------------------------------------
     # RO path: zero-copy import committed weights into model params
     # ------------------------------------------------------------------
+
+    def get_source_identity(self) -> Optional[SourceIdentity]:
+        """Return the writer's committed :class:`SourceIdentity`, if available.
+
+        An RO reader uses this to verify, before :meth:`materialize_module`,
+        that the writer's layout matches its own.
+
+        Returns:
+            The writer's committed identity, or ``None`` when none is
+            available (the caller then proceeds without a pre-materialize
+            compatibility check).
+        """
+        # TODO(SOURCE-IDENTITY/GMS): persist the writer's serialized identity
+        # in finalize_write and read it back here once the pool exposes a
+        # metadata channel. This is the single seam the RO gate depends on.
+        return None
 
     def materialize_module(self, model: nn.Module) -> None:
         """Zero-copy import committed weights into model params (RO path).

--- a/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
@@ -42,6 +42,11 @@ from tensorrt_llm._torch.models.checkpoints.base_weight_loader import BaseWeight
 from tensorrt_llm._torch.models.checkpoints.base_weight_mapper import BaseWeightMapper
 from tensorrt_llm._torch.models.checkpoints.hf.checkpoint_loader import HfCheckpointLoader
 from tensorrt_llm._torch.models.modeling_utils import register_checkpoint_loader
+from tensorrt_llm._torch.weight_sharing import (
+    IdentityCheckPolicy,
+    SourceIdentity,
+    check_source_identity,
+)
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
@@ -124,6 +129,9 @@ class MXCheckpointLoader(HfCheckpointLoader):
         self._model_name = str(model_name) if model_name is not None else None
         self._query_timeout_s = query_timeout_s
         self._p2p_succeeded = False
+        # Receiver's local SourceIdentity, supplied per load_weights() call by
+        # ModelLoader; the authority for the pre-transfer compatibility gate.
+        self._local_source_identity: Optional[SourceIdentity] = None
 
     @property
     def checkpoint_format(self) -> str:
@@ -196,6 +204,8 @@ class MXCheckpointLoader(HfCheckpointLoader):
             disk loading for some or all weights.
         """
         model = kwargs.pop("model", None)
+        # Popped here so it never leaks into the disk-fallback signature.
+        self._local_source_identity = kwargs.pop("source_identity", None)
         self._p2p_succeeded = False
 
         if self._mx_server_url is None or model is None:
@@ -224,6 +234,16 @@ class MXCheckpointLoader(HfCheckpointLoader):
                 "modelexpress_client/python). Falling back to disk loading."
             )
             return self._fallback_to_disk(checkpoint_dir, mapping, **kwargs)
+
+        # Pre-transfer compatibility gate: on mismatch, skip the transfer
+        # before any RDMA work starts and fall back to disk.
+        if not self._source_identity_compatible(checkpoint_dir, MxClient, _build_trtllm_identity):
+            return self._fallback_to_disk(
+                checkpoint_dir,
+                mapping,
+                reason="source SourceIdentity incompatible with receiver",
+                **kwargs,
+            )
 
         timeout_override = self._resolve_query_timeout_override(
             checkpoint_dir,
@@ -316,6 +336,68 @@ class MXCheckpointLoader(HfCheckpointLoader):
         finally:
             if client is not None and hasattr(client, "close"):
                 client.close()
+
+    def _source_identity_compatible(
+        self, checkpoint_dir: str, MxClient: Type[Any], build_identity: Callable[..., Any]
+    ) -> bool:
+        """Whether the MX source's identity is compatible with this receiver.
+
+        Compares the receiver's local :class:`SourceIdentity` against the
+        publisher's via ``check_source_identity`` with the ``WARN_FALLBACK``
+        policy.
+
+        Args:
+            checkpoint_dir: The checkpoint directory identifying the source.
+            MxClient: The MX discovery client type (forwarded to the fetch
+                seam).
+            build_identity: Builder used to derive the publisher identity
+                (forwarded to the fetch seam).
+
+        Returns:
+            ``True`` to proceed with P2P -- when no local identity was supplied
+            (legacy callers), the publisher's identity cannot be fetched yet
+            (disk fallback still guards correctness), or the identities are
+            compatible. ``False`` only on a verified mismatch.
+        """
+        local_identity = self._local_source_identity
+        if local_identity is None:
+            return True
+
+        source_identity = self._fetch_source_identity(checkpoint_dir, MxClient, build_identity)
+        if source_identity is None:
+            logger.warning_once(
+                "MX source SourceIdentity unavailable; proceeding with P2P "
+                "without a pre-transfer compatibility check (disk fallback "
+                "still guards correctness). Tracked by SOURCE-IDENTITY/MX-2.",
+                key="mx_source_identity_unavailable",
+            )
+            return True
+
+        decision = check_source_identity(
+            local_identity,
+            source_identity,
+            IdentityCheckPolicy.WARN_FALLBACK,
+        )
+        return decision.should_share
+
+    def _fetch_source_identity(
+        self, checkpoint_dir: str, MxClient: Type[Any], build_identity: Callable[..., Any]
+    ) -> Optional[SourceIdentity]:
+        """Fetch the publisher's serialized :class:`SourceIdentity`.
+
+        Args:
+            checkpoint_dir: The checkpoint directory identifying the source.
+            MxClient: The MX discovery client type.
+            build_identity: Builder used to derive the publisher identity.
+
+        Returns:
+            The publisher's identity, or ``None`` when it cannot be fetched
+            yet (the gate is then inert; disk fallback guards correctness).
+        """
+        # TODO(SOURCE-IDENTITY/MX-2): read the publisher's identity from the MX
+        # metadata channel (get_metadata / WorkerMetadata) once upstream
+        # exposes a field for it. This is the single seam the gate depends on.
+        return None
 
     def _resolve_publish_name(self, checkpoint_dir: Optional[str]) -> str:
         return _resolve_mx_model_name(self._model_name, checkpoint_dir)

--- a/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
@@ -15,17 +15,17 @@
 
 """MX (ModelExpress) checkpoint loader.
 
-Thin adapter on top of the upstream ``modelexpress`` Python client
-(``ai-dynamo/modelexpress``). All NIXL/RDMA mechanics (agent setup,
+Thin adapter on top of the upstream `modelexpress` Python client
+(`ai-dynamo/modelexpress`). All NIXL/RDMA mechanics (agent setup,
 tensor registration, source-target name matching, dtype-cast handling,
-PVC fallback, etc.) live in the upstream ``MxLiveWeightLoader`` and
-``publish_model_params`` helpers — we only call them at the right
+PVC fallback, etc.) live in the upstream `MxLiveWeightLoader` and
+`publish_model_params` helpers — we only call them at the right
 points in TRT-LLM's loading lifecycle.
 
 When no MX server is reachable (or the upstream library is not
 installed), this loader transparently falls back to standard
 HuggingFace checkpoint loading (disk -> CPU -> GPU) by way of its
-``HfCheckpointLoader`` base class.
+`HfCheckpointLoader` base class.
 """
 
 import os
@@ -45,14 +45,14 @@ from tensorrt_llm._torch.models.modeling_utils import register_checkpoint_loader
 from tensorrt_llm._torch.weight_sharing import (
     IdentityCheckPolicy,
     SourceIdentity,
-    check_source_identity,
+    check_weight_sharing_compatibility,
 )
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
-# Defensive default for the upstream ``MX_SOURCE_QUERY_TIMEOUT`` env var.
-# The upstream ``MxLiveWeightLoader`` polls the MX server every 5 s for up
-# to ``MX_SOURCE_QUERY_TIMEOUT`` seconds (default 3600 = 1 hour) waiting
+# Defensive default for the upstream `MX_SOURCE_QUERY_TIMEOUT` env var.
+# The upstream `MxLiveWeightLoader` polls the MX server every 5 s for up
+# to `MX_SOURCE_QUERY_TIMEOUT` seconds (default 3600 = 1 hour) waiting
 # for a source. On a cold cluster (no donor up yet), this means the very
 # first replica blocks for an hour before falling back to disk. We cap
 # the default at 30 s so first-replica startup degrades gracefully; users
@@ -83,19 +83,19 @@ def _temporary_env(key: str, value: Optional[str]):
 class MXCheckpointLoader(HfCheckpointLoader):
     """Checkpoint loader for MX (ModelExpress) P2P weight transfer.
 
-    When an MX server is reachable AND the upstream ``modelexpress``
+    When an MX server is reachable AND the upstream `modelexpress`
     library is installed, weights are transferred directly from a
     source instance via NIXL/RDMA, bypassing disk I/O. The source
-    publishes its weights *before* ``post_load_weights()`` runs so
+    publishes its weights *before* `post_load_weights()` runs so
     targets receive raw loaded state and can run their own
     post-load transforms.
 
     When the MX server or library is unavailable, this loader
     transparently falls back to standard HuggingFace checkpoint
-    loading via the parent ``HfCheckpointLoader``.
+    loading via the parent `HfCheckpointLoader`.
 
     All transport-level mechanics (NIXL, dtype casts, source matching,
-    fallback) are delegated to ``modelexpress.trtllm_live_transfer``
+    fallback) are delegated to `modelexpress.trtllm_live_transfer`
     so that this class stays a thin adapter — when the MX wire
     protocol or transport evolves, only the upstream library needs
     to track it.
@@ -121,10 +121,10 @@ class MXCheckpointLoader(HfCheckpointLoader):
         # _checkpoint_format directly does not see a stale value.
         self._checkpoint_format = "MX"
         self._mx_server_url = mx_server_url
-        # ``model_name`` is the human-readable identity to publish/look up
+        # `model_name` is the human-readable identity to publish/look up
         # under on the MX server. Typically the user-supplied
-        # ``llm_args.model`` (a Hub ID like ``"Qwen/Qwen2.5-72B-Instruct"``
-        # or a local path). ``publish_as_source()`` resolves it via
+        # `llm_args.model` (a Hub ID like `"Qwen/Qwen2.5-72B-Instruct"`
+        # or a local path). `publish_as_source()` resolves it via
         # :func:`_resolve_mx_model_name` (with HF-snapshot path fallback).
         self._model_name = str(model_name) if model_name is not None else None
         self._query_timeout_s = query_timeout_s
@@ -146,9 +146,9 @@ class MXCheckpointLoader(HfCheckpointLoader):
     def model_name(self) -> Optional[str]:
         """Explicit model identity passed to the constructor (if any).
 
-        Note this is the *as-configured* value (e.g. ``llm_args.model``),
+        Note this is the *as-configured* value (e.g. `llm_args.model`),
         not the final resolved identity that ends up in the published
-        ``MODEL_NAME``. The full resolution (with env var and basename
+        `MODEL_NAME`. The full resolution (with env var and basename
         fallbacks) happens inside :meth:`publish_as_source`.
         """
         return self._model_name
@@ -160,27 +160,27 @@ class MXCheckpointLoader(HfCheckpointLoader):
     def is_weights_preloaded(self) -> bool:
         """Whether the last :meth:`load_weights` call wired weights directly into the model.
 
-        Reports the result of the most recent ``load_weights()`` invocation
-        on this loader instance. ``ModelLoader`` consults this signal to
+        Reports the result of the most recent `load_weights()` invocation
+        on this loader instance. `ModelLoader` consults this signal to
         decide whether to run the standard weight-mapping pipeline:
 
-        - ``True``: MX P2P transfer succeeded; weights already live in
+        - `True`: MX P2P transfer succeeded; weights already live in
           model parameter buffers via direct writes from the upstream
-          ``MxLiveWeightLoader``. The mapping pipeline is skipped for
+          `MxLiveWeightLoader`. The mapping pipeline is skipped for
           all parameters covered by P2P.
-        - ``False``: either P2P was never attempted (no MX server URL,
+        - `False`: either P2P was never attempted (no MX server URL,
           no model reference, library missing) or it failed and we
           fell back to disk; weights still need to flow through
-          ``model.load_weights(...)`` via the standard mapper.
+          `model.load_weights(...)` via the standard mapper.
 
         Note this is a per-loader-instance flag, not a global one. The
-        flag is reset to ``False`` at the start of each ``load_weights``
+        flag is reset to `False` at the start of each `load_weights`
         call, so the value is only meaningful immediately after a
         successful call.
 
         Returns:
-            ``True`` iff the last ``load_weights`` populated the model
-            via P2P; ``False`` before any call and on any fallback path.
+            `True` iff the last `load_weights` populated the model
+            via P2P; `False` before any call and on any fallback path.
         """
         return self._p2p_succeeded
 
@@ -188,14 +188,14 @@ class MXCheckpointLoader(HfCheckpointLoader):
         """Load weights, preferring MX P2P transfer when available.
 
         Delegates the actual transfer to the upstream
-        ``modelexpress.trtllm_live_transfer.MxLiveWeightLoader``,
+        `modelexpress.trtllm_live_transfer.MxLiveWeightLoader`,
         which handles NIXL setup, source discovery, name matching,
         dtype casting, and PVC fallback for size-mismatched tensors.
 
         Args:
             checkpoint_dir: Path to the HF checkpoint directory.
             mapping: Distributed mapping configuration.
-            **kwargs: Additional keyword arguments. When ``model`` is
+            **kwargs: Additional keyword arguments. When `model` is
                 passed it is used as the target for direct P2P writes.
 
         Returns:
@@ -297,7 +297,7 @@ class MXCheckpointLoader(HfCheckpointLoader):
     def _resolve_query_timeout_override(
         self, checkpoint_dir: str, MxClient: Type[Any], build_identity: Callable[..., Any]
     ) -> Optional[str]:
-        """Return temporary ``MX_SOURCE_QUERY_TIMEOUT`` override, if any."""
+        """Return temporary `MX_SOURCE_QUERY_TIMEOUT` override, if any."""
         if self._query_timeout_s is not None:
             return str(self._query_timeout_s)
 
@@ -343,7 +343,7 @@ class MXCheckpointLoader(HfCheckpointLoader):
         """Whether the MX source's identity is compatible with this receiver.
 
         Compares the receiver's local :class:`SourceIdentity` against the
-        publisher's via ``check_source_identity`` with the ``WARN_FALLBACK``
+        publisher's via `check_weight_sharing_compatibility` with the `WARN_FALLBACK`
         policy.
 
         Args:
@@ -354,13 +354,13 @@ class MXCheckpointLoader(HfCheckpointLoader):
                 (forwarded to the fetch seam).
 
         Returns:
-            ``True`` to proceed with P2P only when both identities are present
-            and compatible. ``False`` when either identity is missing or the
+            `True` to proceed with P2P only when both identities are present
+            and compatible. `False` when either identity is missing or the
             identities mismatch, so the caller falls back to disk loading.
         """
         local_identity = self._local_source_identity
         source_identity = self._fetch_source_identity(checkpoint_dir, MxClient, build_identity)
-        decision = check_source_identity(
+        decision = check_weight_sharing_compatibility(
             local_identity,
             source_identity,
             IdentityCheckPolicy.WARN_FALLBACK,
@@ -378,7 +378,7 @@ class MXCheckpointLoader(HfCheckpointLoader):
             build_identity: Builder used to derive the publisher identity.
 
         Returns:
-            The publisher's identity, or ``None`` when it cannot be fetched
+            The publisher's identity, or `None` when it cannot be fetched
             yet (the compatibility gate then rejects P2P and falls back).
         """
         # TODO(SOURCE-IDENTITY/MX-2): read the publisher's identity from the MX
@@ -406,21 +406,21 @@ class MXCheckpointLoader(HfCheckpointLoader):
     ) -> None:
         """Publish this instance's weights so other ranks can pull via P2P.
 
-        Called by the integration in ``model_loader.py`` *before*
-        ``post_load_weights()`` so targets receive raw loaded state and
+        Called by the integration in `model_loader.py` *before*
+        `post_load_weights()` so targets receive raw loaded state and
         can apply their own post-load transforms.
 
         Delegates to the upstream
-        ``modelexpress.trtllm_live_transfer.publish_model_params``
+        `modelexpress.trtllm_live_transfer.publish_model_params`
         helper, which handles the per-rank NIXL setup, tensor
         registration, and gRPC publish.
 
         Args:
             model: The model whose weights to publish.
             checkpoint_dir: Checkpoint directory. Used as a last-resort
-                fallback for resolving the ``MODEL_NAME`` identity when
-                neither ``model_name`` was passed to the constructor nor
-                ``MODEL_NAME`` is set in the environment.
+                fallback for resolving the `MODEL_NAME` identity when
+                neither `model_name` was passed to the constructor nor
+                `MODEL_NAME` is set in the environment.
         """
 
         if self._mx_server_url is None:
@@ -515,14 +515,14 @@ def _resolve_mx_model_name(model_name_arg: Optional[str], checkpoint_dir: Option
 
     Resolution order (first non-empty wins):
 
-    1. ``model_name_arg`` — the explicit value passed at construction
-       time (typically ``llm_args.model``: a Hub ID like
-       ``"Qwen/Qwen2.5-72B-Instruct"`` or a local path).
-    2. ``MODEL_NAME`` env var — upstream's existing convention.
-    3. ``checkpoint_dir`` basename, with HF-snapshot path fallback so
-       ``.../models--<org>--<name>/snapshots/<sha>/`` resolves to
-       ``"<org>/<name>"`` instead of the commit hash.
-    4. Literal ``"unknown"`` — matches upstream's own sentinel.
+    1. `model_name_arg` — the explicit value passed at construction
+       time (typically `llm_args.model`: a Hub ID like
+       `"Qwen/Qwen2.5-72B-Instruct"` or a local path).
+    2. `MODEL_NAME` env var — upstream's existing convention.
+    3. `checkpoint_dir` basename, with HF-snapshot path fallback so
+       `.../models--<org>--<name>/snapshots/<sha>/` resolves to
+       `"<org>/<name>"` instead of the commit hash.
+    4. Literal `"unknown"` — matches upstream's own sentinel.
     """
     candidate = model_name_arg or os.environ.get("MODEL_NAME") or checkpoint_dir
     if not candidate:
@@ -533,18 +533,18 @@ def _resolve_mx_model_name(model_name_arg: Optional[str], checkpoint_dir: Option
 def _normalize_model_identity(s: str) -> str:
     """Convert a model identifier to a stable, human-readable name.
 
-    Hub IDs (``"org/name"``) and arbitrary user-provided strings are
+    Hub IDs (`"org/name"`) and arbitrary user-provided strings are
     returned unchanged. Filesystem paths are reduced to a basename, with
-    HuggingFace cache snapshot layouts (``snapshots/<commit-sha>/``)
-    walked up to recover the original ``"org/name"`` identity.
+    HuggingFace cache snapshot layouts (`snapshots/<commit-sha>/`)
+    walked up to recover the original `"org/name"` identity.
     """
     if not s:
         return "unknown"
 
-    # Heuristic: a Hub ID is bare ``"name"`` or ``"org/name"``. Anything
+    # Heuristic: a Hub ID is bare `"name"` or `"org/name"`. Anything
     # that starts with a path separator/expansion or contains more than
     # one "/" is treated as a path. Single-"/" strings remain ambiguous;
-    # avoid an NFS ``exists`` probe for common Hub IDs and only touch the
+    # avoid an NFS `exists` probe for common Hub IDs and only touch the
     # filesystem when the string has explicit local-path syntax.
     looks_like_path = s.startswith(("/", "./", "../", "~")) or s.count("/") > 1
     if not looks_like_path:
@@ -553,9 +553,9 @@ def _normalize_model_identity(s: str) -> str:
     p = Path(s).expanduser()
     name = p.name
     if name and "snapshots" in p.parts:
-        # HF cache layout: ``.../models--<org>--<name>/snapshots/<sha>/``.
-        # Walk up to find the ``models--<org>--<name>`` directory and
-        # un-mangle it back to ``"<org>/<name>"``.
+        # HF cache layout: `.../models--<org>--<name>/snapshots/<sha>/`.
+        # Walk up to find the `models--<org>--<name>` directory and
+        # un-mangle it back to `"<org>/<name>"`.
         for ancestor in p.parents:
             if ancestor.name.startswith("models--"):
                 return ancestor.name[len("models--") :].replace("--", "/")

--- a/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
@@ -354,25 +354,12 @@ class MXCheckpointLoader(HfCheckpointLoader):
                 (forwarded to the fetch seam).
 
         Returns:
-            ``True`` to proceed with P2P -- when no local identity was supplied
-            (legacy callers), the publisher's identity cannot be fetched yet
-            (publisher metadata is not wired yet), or the identities are
-            compatible. ``False`` only on a verified mismatch.
+            ``True`` to proceed with P2P only when both identities are present
+            and compatible. ``False`` when either identity is missing or the
+            identities mismatch, so the caller falls back to disk loading.
         """
         local_identity = self._local_source_identity
-        if local_identity is None:
-            return True
-
         source_identity = self._fetch_source_identity(checkpoint_dir, MxClient, build_identity)
-        if source_identity is None:
-            logger.warning_once(
-                "MX source SourceIdentity unavailable; proceeding with P2P "
-                "without SourceIdentity enforcement. Publisher metadata is "
-                "not wired yet; tracked by SOURCE-IDENTITY/MX-2.",
-                key="mx_source_identity_unavailable",
-            )
-            return True
-
         decision = check_source_identity(
             local_identity,
             source_identity,
@@ -392,7 +379,7 @@ class MXCheckpointLoader(HfCheckpointLoader):
 
         Returns:
             The publisher's identity, or ``None`` when it cannot be fetched
-            yet (the gate is then inert).
+            yet (the compatibility gate then rejects P2P and falls back).
         """
         # TODO(SOURCE-IDENTITY/MX-2): read the publisher's identity from the MX
         # metadata channel (get_metadata / WorkerMetadata) once upstream

--- a/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
@@ -356,7 +356,7 @@ class MXCheckpointLoader(HfCheckpointLoader):
         Returns:
             ``True`` to proceed with P2P -- when no local identity was supplied
             (legacy callers), the publisher's identity cannot be fetched yet
-            (disk fallback still guards correctness), or the identities are
+            (publisher metadata is not wired yet), or the identities are
             compatible. ``False`` only on a verified mismatch.
         """
         local_identity = self._local_source_identity
@@ -367,8 +367,8 @@ class MXCheckpointLoader(HfCheckpointLoader):
         if source_identity is None:
             logger.warning_once(
                 "MX source SourceIdentity unavailable; proceeding with P2P "
-                "without a pre-transfer compatibility check (disk fallback "
-                "still guards correctness). Tracked by SOURCE-IDENTITY/MX-2.",
+                "without SourceIdentity enforcement. Publisher metadata is "
+                "not wired yet; tracked by SOURCE-IDENTITY/MX-2.",
                 key="mx_source_identity_unavailable",
             )
             return True
@@ -392,7 +392,7 @@ class MXCheckpointLoader(HfCheckpointLoader):
 
         Returns:
             The publisher's identity, or ``None`` when it cannot be fetched
-            yet (the gate is then inert; disk fallback guards correctness).
+            yet (the gate is then inert).
         """
         # TODO(SOURCE-IDENTITY/MX-2): read the publisher's identity from the MX
         # metadata channel (get_metadata / WorkerMetadata) once upstream
@@ -440,8 +440,8 @@ class MXCheckpointLoader(HfCheckpointLoader):
             return
 
         try:
-            from modelexpress.trtllm_live_transfer import (  # type: ignore[import-not-found]
-                publish_model_params,
+            from modelexpress.trtllm_live_transfer import (
+                publish_model_params,  # type: ignore[import-not-found]
             )
         except ImportError:
             logger.debug("modelexpress library not installed; skipping MX publish.")

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -317,6 +317,17 @@ class ModelLoader:
 
         return llm_args
 
+    @staticmethod
+    def _needs_source_identity(checkpoint_loader: BaseCheckpointLoader,
+                               load_format: LoadFormat) -> bool:
+        """Whether this load path can consume a SourceIdentity gate.
+
+        Keep ordinary loading a strict no-op: SourceIdentity is currently used
+        only by MX (pre-transfer fallback gate) and GMS (pre-materialize
+        strict gate), so default HF/AUTO paths should not even build one.
+        """
+        return load_format == LoadFormat.GMS or checkpoint_loader.checkpoint_format == "MX"
+
     def load(
         self,
         checkpoint_dir: str,
@@ -352,17 +363,21 @@ class ModelLoader:
                 model = AutoModelForCausalLM.from_config(config)
                 is_meta_init = False
 
-            # Receiver's local SourceIdentity, built once from the final
-            # ModelConfig and the freshly constructed module. The module's
-            # realized parameter/buffer (shape, dtype) map is the layout ground
-            # truth; building it here (post-construction, pre-weight-load)
-            # gives producer and consumer a common, comparable lifecycle point.
-            self._source_identity = SourceIdentity.from_model_config(
-                config,
-                model,
-                model_name=str(
-                    getattr(self.llm_args, "model", None) or checkpoint_dir),
-            )
+            self._source_identity: Optional[SourceIdentity] = None
+            if self._needs_source_identity(checkpoint_loader, load_format):
+                # Receiver's local SourceIdentity, built once from the final
+                # ModelConfig and the freshly constructed module. The module's
+                # realized parameter/buffer (shape, dtype) map is the layout
+                # ground truth; building it here (post-construction,
+                # pre-weight-load) gives producer and consumer a common,
+                # comparable lifecycle point.
+                self._source_identity = SourceIdentity.from_model_config(
+                    config,
+                    model,
+                    model_name=str(
+                        getattr(self.llm_args, "model", None)
+                        or checkpoint_dir),
+                )
 
             memo = dict()
 

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -353,10 +353,13 @@ class ModelLoader:
                 is_meta_init = False
 
             # Receiver's local SourceIdentity, built once from the final
-            # ModelConfig after model construction has applied any in-place
-            # layout-affecting config mutations.
+            # ModelConfig and the freshly constructed module. The module's
+            # realized parameter/buffer (shape, dtype) map is the layout ground
+            # truth; building it here (post-construction, pre-weight-load)
+            # gives producer and consumer a common, comparable lifecycle point.
             self._source_identity = SourceIdentity.from_model_config(
                 config,
+                model,
                 model_name=str(
                     getattr(self.llm_args, "model", None) or checkpoint_dir),
             )
@@ -690,19 +693,7 @@ class ModelLoader:
                         # Pre-materialize compatibility gate. GMS has no
                         # disk-fallback path, so a mismatch raises under STRICT
                         # rather than falling back.
-                        source_identity = gms_backend.get_source_identity()
-                        if source_identity is not None:
-                            check_source_identity(
-                                self._source_identity,
-                                source_identity,
-                                IdentityCheckPolicy.STRICT,
-                            )
-                        else:
-                            logger.warning(
-                                "GMS RO: writer SourceIdentity unavailable; "
-                                "materializing without SourceIdentity "
-                                "enforcement. Publisher metadata is not wired "
-                                "yet; tracked by SOURCE-IDENTITY/GMS.")
+                        self._check_gms_source_identity(gms_backend)
 
                         gms_backend.materialize_module(model)
 
@@ -771,6 +762,36 @@ class ModelLoader:
             torch.cuda.current_stream().synchronize()
 
         return model, moe_load_balancer
+
+    def _check_gms_source_identity(self, gms_backend) -> None:
+        """Pre-materialize SourceIdentity gate for the GMS read-only path.
+
+        GMS has no disk-fallback path, so a verified mismatch raises under
+        ``STRICT`` rather than falling back. When the writer's identity is not
+        available (publisher metadata not wired yet), the gate is inert and
+        materialization proceeds without enforcement.
+
+        Args:
+            gms_backend: The connected GMS backend (RO role) exposing
+                ``get_source_identity()``.
+
+        Raises:
+            SourceIdentityMismatchError: When the writer's identity is
+                available and incompatible with this receiver's identity.
+        """
+        source_identity = gms_backend.get_source_identity()
+        if source_identity is None:
+            logger.warning(
+                "GMS RO: writer SourceIdentity unavailable; materializing "
+                "without SourceIdentity enforcement. Publisher metadata is "
+                "not wired yet; tracked by SOURCE-IDENTITY/GMS.")
+            return
+
+        check_source_identity(
+            self._source_identity,
+            source_identity,
+            IdentityCheckPolicy.STRICT,
+        )
 
     @staticmethod
     def _setup_aliases(model: DecoderModelForCausalLM) -> None:

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -781,10 +781,8 @@ class ModelLoader:
     def _check_gms_source_identity(self, gms_backend) -> None:
         """Pre-materialize SourceIdentity gate for the GMS read-only path.
 
-        GMS has no disk-fallback path, so a verified mismatch raises under
-        ``STRICT`` rather than falling back. When the writer's identity is not
-        available (publisher metadata not wired yet), the gate is inert and
-        materialization proceeds without enforcement.
+        GMS has no disk-fallback path, so a missing or mismatched identity
+        raises under ``STRICT`` rather than falling back.
 
         Args:
             gms_backend: The connected GMS backend (RO role) exposing
@@ -794,17 +792,9 @@ class ModelLoader:
             SourceIdentityMismatchError: When the writer's identity is
                 available and incompatible with this receiver's identity.
         """
-        source_identity = gms_backend.get_source_identity()
-        if source_identity is None:
-            logger.warning(
-                "GMS RO: writer SourceIdentity unavailable; materializing "
-                "without SourceIdentity enforcement. Publisher metadata is "
-                "not wired yet; tracked by SOURCE-IDENTITY/GMS.")
-            return
-
         check_source_identity(
             self._source_identity,
-            source_identity,
+            gms_backend.get_source_identity(),
             IdentityCheckPolicy.STRICT,
         )
 

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -9,6 +9,9 @@ import torch
 
 from tensorrt_llm._torch.models.checkpoints.base_checkpoint_loader import (
     AutoCheckpointMapper, BaseCheckpointLoader)
+from tensorrt_llm._torch.weight_sharing import (IdentityCheckPolicy,
+                                                SourceIdentity,
+                                                check_source_identity)
 from tensorrt_llm._utils import str_dtype_to_torch
 from tensorrt_llm.llmapi.llm_args import (ExecutorMemoryType,
                                           ModelExpressConfig, TorchLlmArgs)
@@ -333,6 +336,16 @@ class ModelLoader:
                                                 checkpoint_loader)
         load_format = self.llm_args.load_format
 
+        # Receiver's local SourceIdentity, built once from the resolved
+        # ModelConfig + Mapping. The authority for every weight-sharing
+        # compatibility gate (MX P2P, GMS RO) downstream.
+        self._source_identity = SourceIdentity.from_model_config(
+            config,
+            rank=self.mapping.rank,
+            model_name=str(
+                getattr(self.llm_args, "model", None) or checkpoint_dir),
+        )
+
         with timing("Model init total"), maybe_create_moe_load_balancer(
                 config, self.mapping) as moe_load_balancer:
             try:
@@ -437,6 +450,8 @@ class ModelLoader:
                 load_weights_kwargs: dict = {
                     "mapping": self.mapping,
                     "model": model,
+                    # Generic loaders ignore it; MXCheckpointLoader pops it.
+                    "source_identity": self._source_identity,
                 }
 
                 if hasattr(model, 'llm_checkpoint_dir'):
@@ -553,7 +568,8 @@ class ModelLoader:
                             weights = checkpoint_loader.load_weights(
                                 weight_source,
                                 mapping=self.mapping,
-                                model=model)
+                                model=model,
+                                source_identity=self._source_identity)
 
                             # ``weights`` may be:
                             #   - non-empty dict: standard mapping pipeline runs
@@ -671,6 +687,22 @@ class ModelLoader:
                                        'post_load_weights') and not getattr(
                                            module, '_weights_removed', False):
                                 module.post_load_weights()
+
+                        # Pre-materialize compatibility gate. GMS has no
+                        # disk-fallback path, so a mismatch raises under STRICT
+                        # rather than falling back.
+                        source_identity = gms_backend.get_source_identity()
+                        if source_identity is not None:
+                            check_source_identity(
+                                self._source_identity,
+                                source_identity,
+                                IdentityCheckPolicy.STRICT,
+                            )
+                        else:
+                            logger.warning(
+                                "GMS RO: writer SourceIdentity unavailable; "
+                                "materializing without a compatibility check. "
+                                "Tracked by SOURCE-IDENTITY/GMS.")
 
                         gms_backend.materialize_module(model)
 

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -9,9 +9,8 @@ import torch
 
 from tensorrt_llm._torch.models.checkpoints.base_checkpoint_loader import (
     AutoCheckpointMapper, BaseCheckpointLoader)
-from tensorrt_llm._torch.weight_sharing import (IdentityCheckPolicy,
-                                                SourceIdentity,
-                                                check_source_identity)
+from tensorrt_llm._torch.weight_sharing import (
+    IdentityCheckPolicy, SourceIdentity, check_weight_sharing_compatibility)
 from tensorrt_llm._utils import str_dtype_to_torch
 from tensorrt_llm.llmapi.llm_args import (ExecutorMemoryType,
                                           ModelExpressConfig, TorchLlmArgs)
@@ -116,7 +115,7 @@ def initialize_dummy_weights(
     """
 
     def _get_random_min_max(dtype: torch.dtype) -> Tuple[int, int]:
-        """Return safe (min, max) bounds for uniform sampling of ``dtype``."""
+        """Return safe (min, max) bounds for uniform sampling of `dtype`."""
         # These values are not necessarily the largest possible min/max,
         # they need to be small enough to avoid NaNs.
         if dtype in (torch.float8_e4m3fn, torch.int8):
@@ -264,7 +263,7 @@ class ModelLoader:
             max_seq_len: The maximum sequence length.
             lora_config: Configuration for LoRA.
             model_weights_memory_tag: When set, parameter allocations during
-                ``load()`` are placed under a separate virtual-memory tag so
+                `load()` are placed under a separate virtual-memory tag so
                 they can be released/materialized independently of buffers.
             model_weights_restore_mode: RestoreMode for the model weights
                 virtual-memory scope.
@@ -454,9 +453,9 @@ class ModelLoader:
             weights_preloaded = False
             # Set when either GMS RW or GMS RO branch has already run the
             # post_load_* hooks itself, so the shared post-load block below
-            # must skip them. RW handles them inside ``mem_pool_scope`` so the
+            # must skip them. RW handles them inside `mem_pool_scope` so the
             # committed pool reflects the post-post_load layout; RO runs
-            # ``module.post_load_weights()`` before ``materialize_module`` to
+            # `module.post_load_weights()` before `materialize_module` to
             # wire aliases prior to zero-copy mapping.
             gms_post_load_handled = False
             if load_format == LoadFormat.AUTO:
@@ -509,15 +508,15 @@ class ModelLoader:
                 # GPU Memory Service path: weight tensors live in a
                 # node-shared GPU memory pool so multiple TRT-LLM instances
                 # zero-copy share the same weight bytes. Two roles:
-                #   - RW (writer): opens ``mem_pool_scope`` BEFORE meta-
+                #   - RW (writer): opens `mem_pool_scope` BEFORE meta-
                 #     materialization and to(cuda), runs the entire model
                 #     bring-up (load + draft load + post_load_*) inside the
-                #     pool, then commits via ``finalize_write`` so RO peers
+                #     pool, then commits via `finalize_write` so RO peers
                 #     receive the post-post_load layout.
                 #   - RO (reader): zero-copy materializes weights from the
-                #     pool into the model via ``materialize_module``; no
+                #     pool into the model via `materialize_module`; no
                 #     disk I/O, no per-instance copies.
-                # Imported lazily so the optional ``gpu_memory_service``
+                # Imported lazily so the optional `gpu_memory_service`
                 # dependency only loads when GMS is actually selected.
                 from tensorrt_llm._torch.memory import GMSBackend
 
@@ -535,10 +534,10 @@ class ModelLoader:
 
                 self._gms_backend = gms_backend
                 try:
-                    # ``is_rw`` is ``Optional[bool]`` on the GPU memory backend
+                    # `is_rw` is `Optional[bool]` on the GPU memory backend
                     # protocol: True = RW lock granted, False = RO lock granted,
-                    # None = unset. After a successful ``connect()`` it must be
-                    # True or False; ``None`` is treated as an adapter bug and
+                    # None = unset. After a successful `connect()` it must be
+                    # True or False; `None` is treated as an adapter bug and
                     # surfaces as a hard error rather than silently falling
                     # through to the RO path.
                     if gms_backend.is_rw is True:
@@ -553,7 +552,7 @@ class ModelLoader:
                         with gms_backend.mem_pool_scope(torch.device("cuda")):
                             # Materialize meta tensors inside the pool. Local
                             # memo because the outer one was deleted (and the
-                            # outer ``init_meta_tensor`` branch is gated off
+                            # outer `init_meta_tensor` branch is gated off
                             # for GMS so it never ran).
                             if is_meta_init:
                                 gms_memo: dict = {}
@@ -588,18 +587,18 @@ class ModelLoader:
                                 model=model,
                                 source_identity=self._source_identity)
 
-                            # ``weights`` may be:
+                            # `weights` may be:
                             #   - non-empty dict: standard mapping pipeline runs
-                            #   - empty/None + ``is_weights_preloaded()=True``:
+                            #   - empty/None + `is_weights_preloaded()=True`:
                             #     the loader populated the model directly
                             #     (e.g. MX P2P), so no mapping is needed
-                            #   - empty/None + ``is_weights_preloaded()=False``:
+                            #   - empty/None + `is_weights_preloaded()=False`:
                             #     loader returned nothing AND didn't preload —
                             #     the model would be committed in an
                             #     uninitialized state, so abort. Per-tensor
                             #     partial loads (missing keys in a non-empty
                             #     dict) are caught downstream by
-                            #     ``model.load_weights`` strict checking.
+                            #     `model.load_weights` strict checking.
                             weights_preloaded = checkpoint_loader.is_weights_preloaded(
                             )
                             if weights:
@@ -677,24 +676,24 @@ class ModelLoader:
                     elif gms_backend.is_rw is False:
                         # RO path: weights are coming from a GMS donor that
                         # has already committed the post-post_load layout, so
-                        # the receiver flags ``weights_preloaded=True`` on the
-                        # checkpoint-loader hooks. ``MXCheckpointLoader.post_load_publish``
+                        # the receiver flags `weights_preloaded=True` on the
+                        # checkpoint-loader hooks. `MXCheckpointLoader.post_load_publish`
                         # (and any other format-aware loader) honors this flag
                         # to early-return and not re-publish, while still
-                        # letting ``post_load_apply`` perform any
+                        # letting `post_load_apply` perform any
                         # receiver-side per-format work (e.g., marking
                         # presharded modules).
                         #
                         # Hook order:
-                        #   1. ``post_load_apply``: format-specific apply
+                        #   1. `post_load_apply`: format-specific apply
                         #      work (e.g., MX preshard markers).
-                        #   2. Per-module ``post_load_weights``: creates
+                        #   2. Per-module `post_load_weights`: creates
                         #      aliases/derived parameter attributes BEFORE
-                        #      ``materialize_module`` walks the final module
-                        #      tree (including ``draft_model`` for spec dec).
-                        #   3. ``materialize_module``: zero-copy bind GMS
+                        #      `materialize_module` walks the final module
+                        #      tree (including `draft_model` for spec dec).
+                        #   3. `materialize_module`: zero-copy bind GMS
                         #      pool storage onto the model parameters.
-                        #   4. ``post_load_publish``: any receiver-side
+                        #   4. `post_load_publish`: any receiver-side
                         #      publish (no-op via the receiver guard).
                         checkpoint_loader.post_load_apply(
                             model, weights_preloaded=True)
@@ -758,14 +757,14 @@ class ModelLoader:
                 self._walk_full_post_load(model)
 
             # TODO(GMS-MOE-LB): when the (MoE, GMS) combination is enabled,
-            # ``register_weight_slots_after_to_cuda`` and ``finalize_model``
-            # must run INSIDE ``mem_pool_scope`` and BEFORE ``finalize_write``
+            # `register_weight_slots_after_to_cuda` and `finalize_model`
+            # must run INSIDE `mem_pool_scope` and BEFORE `finalize_write`
             # so MoE allocations become part of the committed layout that
             # RO peers receive. Today they run outside the pool and after
             # commit, which would silently produce a broken MoE routing
             # state on RO peers — that combination is REJECTED at config
-            # time by ``TorchLlmArgs.validate_gms_moe_compat`` in
-            # ``tensorrt_llm/llmapi/llm_args.py``. When implementing the
+            # time by `TorchLlmArgs.validate_gms_moe_compat` in
+            # `tensorrt_llm/llmapi/llm_args.py`. When implementing the
             # follow-up, drop the validator gate AFTER moving these calls
             # into the pool scope.
             if isinstance(moe_load_balancer, MoeLoadBalancer):
@@ -782,17 +781,17 @@ class ModelLoader:
         """Pre-materialize SourceIdentity gate for the GMS read-only path.
 
         GMS has no disk-fallback path, so a missing or mismatched identity
-        raises under ``STRICT`` rather than falling back.
+        raises under `STRICT` rather than falling back.
 
         Args:
             gms_backend: The connected GMS backend (RO role) exposing
-                ``get_source_identity()``.
+                `get_source_identity()`.
 
         Raises:
             SourceIdentityMismatchError: When the writer's identity is
                 available and incompatible with this receiver's identity.
         """
-        check_source_identity(
+        check_weight_sharing_compatibility(
             self._source_identity,
             gms_backend.get_source_identity(),
             IdentityCheckPolicy.STRICT,
@@ -823,7 +822,7 @@ class ModelLoader:
 
         The walk is duck-typed so modules can opt in without inheriting a shared
         base class. Modules whose weights were removed are skipped, and modules
-        already marked ``_weights_transformed`` are left untouched until an
+        already marked `_weights_transformed` are left untouched until an
         orchestrator resets the flag after rebinding fresh weight bytes.
 
         Args:
@@ -865,7 +864,7 @@ class ModelLoader:
     def _walk_full_post_load(model: DecoderModelForCausalLM) -> None:
         """Run the backward-compatible post-load hook on eligible modules.
 
-        This preserves the previous ``ModelLoader`` behavior for standard load
+        This preserves the previous `ModelLoader` behavior for standard load
         paths while staged-hook migration proceeds incrementally.
 
         Args:
@@ -911,7 +910,7 @@ class ModelLoader:
 
         Args:
             model: Model instance receiving the replacement weights.
-            weights: Checkpoint weights to pass to ``model.load_weights``.
+            weights: Checkpoint weights to pass to `model.load_weights`.
             allow_partial_loading: Whether missing replacement weights are
                 allowed by models that support partial loading.
 
@@ -932,18 +931,18 @@ class ModelLoader:
     def cleanup(self) -> None:
         """Release backend resources acquired during :meth:`load`.
 
-        Currently the only backend held by ``ModelLoader`` is the
-        optional GMS client, established by the ``LoadFormat.GMS``
+        Currently the only backend held by `ModelLoader` is the
+        optional GMS client, established by the `LoadFormat.GMS`
         branch. Releasing it disconnects from the GMS daemon and evicts
         the per-tag client registry entry; weights remain alive
         on-device for any other process holding an RO lock on the same
-        ``tag``.
+        `tag`.
 
         Idempotent: a second call after a successful cleanup is a no-op
         because the backend handle is dropped. Best-effort: any failure
-        in the underlying ``GMSBackend.cleanup()`` is swallowed there
+        in the underlying `GMSBackend.cleanup()` is swallowed there
         and logged, so this method never raises — safe to call from
-        :meth:`PyTorchModelEngine.cleanup` and ``__del__`` paths.
+        :meth:`PyTorchModelEngine.cleanup` and `__del__` paths.
         """
         if self._gms_backend is not None:
             self._gms_backend.cleanup()

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -336,16 +336,6 @@ class ModelLoader:
                                                 checkpoint_loader)
         load_format = self.llm_args.load_format
 
-        # Receiver's local SourceIdentity, built once from the resolved
-        # ModelConfig + Mapping. The authority for every weight-sharing
-        # compatibility gate (MX P2P, GMS RO) downstream.
-        self._source_identity = SourceIdentity.from_model_config(
-            config,
-            rank=self.mapping.rank,
-            model_name=str(
-                getattr(self.llm_args, "model", None) or checkpoint_dir),
-        )
-
         with timing("Model init total"), maybe_create_moe_load_balancer(
                 config, self.mapping) as moe_load_balancer:
             try:
@@ -361,6 +351,15 @@ class ModelLoader:
                 )
                 model = AutoModelForCausalLM.from_config(config)
                 is_meta_init = False
+
+            # Receiver's local SourceIdentity, built once from the final
+            # ModelConfig after model construction has applied any in-place
+            # layout-affecting config mutations.
+            self._source_identity = SourceIdentity.from_model_config(
+                config,
+                model_name=str(
+                    getattr(self.llm_args, "model", None) or checkpoint_dir),
+            )
 
             memo = dict()
 
@@ -701,8 +700,9 @@ class ModelLoader:
                         else:
                             logger.warning(
                                 "GMS RO: writer SourceIdentity unavailable; "
-                                "materializing without a compatibility check. "
-                                "Tracked by SOURCE-IDENTITY/GMS.")
+                                "materializing without SourceIdentity "
+                                "enforcement. Publisher metadata is not wired "
+                                "yet; tracked by SOURCE-IDENTITY/GMS.")
 
                         gms_backend.materialize_module(model)
 

--- a/tensorrt_llm/_torch/weight_sharing/__init__.py
+++ b/tensorrt_llm/_torch/weight_sharing/__init__.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Backend-agnostic weight-sharing utilities (MX, GMS, ...)."""
+
+from tensorrt_llm._torch.weight_sharing.source_identity import (
+    SOURCE_IDENTITY_FORMAT_VERSION,
+    IdentityCheckDecision,
+    IdentityCheckPolicy,
+    IdentityMatchResult,
+    SourceIdentity,
+    SourceIdentityMismatchError,
+    check_source_identity,
+)
+
+__all__ = [
+    "SOURCE_IDENTITY_FORMAT_VERSION",
+    "SourceIdentity",
+    "IdentityMatchResult",
+    "IdentityCheckPolicy",
+    "IdentityCheckDecision",
+    "SourceIdentityMismatchError",
+    "check_source_identity",
+]

--- a/tensorrt_llm/_torch/weight_sharing/__init__.py
+++ b/tensorrt_llm/_torch/weight_sharing/__init__.py
@@ -21,7 +21,7 @@ from tensorrt_llm._torch.weight_sharing.source_identity import (
     IdentityMatchResult,
     SourceIdentity,
     SourceIdentityMismatchError,
-    check_source_identity,
+    check_weight_sharing_compatibility,
 )
 
 __all__ = [
@@ -31,5 +31,5 @@ __all__ = [
     "IdentityCheckPolicy",
     "IdentityCheckDecision",
     "SourceIdentityMismatchError",
-    "check_source_identity",
+    "check_weight_sharing_compatibility",
 ]

--- a/tensorrt_llm/_torch/weight_sharing/source_identity.py
+++ b/tensorrt_llm/_torch/weight_sharing/source_identity.py
@@ -39,9 +39,10 @@ Layered design
 --------------
 The fingerprint is split so comparison can be selective:
 
-* **global fingerprint** -- model revision/architecture/dtype, quantization,
-  backend selection, fusion flags, and the parallel *sizes* (TP/PP/EP/CP).
-  This part must be identical across every rank of a deployment.
+* **global fingerprint** -- the realized parameter/buffer ``(shape, dtype)``
+  layout plus architecture identity, quantization, backend selection, fusion
+  flags, and the parallel *sizes* (TP/PP/EP/CP). This part must be identical
+  across every rank of a deployment.
 * **shard fingerprint** -- this rank's TP/PP/EP/CP *rank* slice. Receiver rank
   ``N`` must align with the source rank that produced shard ``N``.
 
@@ -60,6 +61,8 @@ from typing import TYPE_CHECKING, Any, List, Optional
 from tensorrt_llm.logger import logger
 
 if TYPE_CHECKING:
+    from torch import nn
+
     from tensorrt_llm._torch.model_config import ModelConfig
     from tensorrt_llm.mapping import Mapping
 
@@ -68,29 +71,36 @@ if TYPE_CHECKING:
 # never match.
 SOURCE_IDENTITY_FORMAT_VERSION = 1
 
-# Pretrained-config fields that directly affect parameter shapes, module
-# topology, or dtype for common TRT-LLM model families. Keep this projection
-# intentionally narrow: unrelated HF config metadata must not block sharing.
-_MODEL_LAYOUT_FIELDS = (
-    "architectures",
-    "model_type",
-    "torch_dtype",
-    "vocab_size",
-    "hidden_size",
-    "intermediate_size",
-    "num_hidden_layers",
-    "num_attention_heads",
-    "num_key_value_heads",
-    "head_dim",
-    "tie_word_embeddings",
-    "num_experts",
-    "num_local_experts",
-    "num_experts_per_tok",
-    "n_routed_experts",
-    "n_shared_experts",
-    "moe_intermediate_size",
-    "decoder_sparse_step",
-)
+
+def _named_tensor_layout(model: Optional["nn.Module"]) -> Optional[dict]:
+    """Project a module's realized parameter/buffer layout for hashing.
+
+    The realized ``(shape, dtype)`` of every parameter and buffer *is* the
+    ground truth for how a model's weights are laid out in memory -- far more
+    reliable than a hand-maintained allowlist of config fields, and naturally
+    backend-agnostic. It also captures runtime dtype overrides (which a
+    pretrained-config projection would miss) since it reads the constructed
+    module's actual tensors.
+
+    Args:
+        model: The constructed (pre- or post-load) ``nn.Module``, or ``None``.
+
+    Returns:
+        A mapping of tensor name to ``[shape, dtype]``, or ``None`` when no
+        module is available.
+    """
+    if model is None:
+        return None
+    layout: dict = {}
+    for accessor in ("named_parameters", "named_buffers"):
+        iter_fn = getattr(model, accessor, None)
+        if not callable(iter_fn):
+            continue
+        for name, tensor in iter_fn():
+            if tensor is None:
+                continue
+            layout[name] = [list(tensor.shape), str(tensor.dtype)]
+    return layout
 
 
 def _canonical_hash(obj: Any) -> str:
@@ -198,6 +208,7 @@ class SourceIdentity:
     def from_model_config(
         cls,
         model_config: "ModelConfig",
+        model: Optional["nn.Module"] = None,
         *,
         model_name: Optional[str] = None,
     ) -> "SourceIdentity":
@@ -205,7 +216,14 @@ class SourceIdentity:
 
         Args:
             model_config: The resolved torch-backend ``ModelConfig`` whose
-                layout-affecting choices are fingerprinted.
+                quantization, backend, and parallel choices are fingerprinted.
+            model: The constructed ``nn.Module``. Its realized parameter and
+                buffer ``(shape, dtype)`` map is the layout ground truth for
+                the model fingerprint. Both producer and consumer must build
+                the identity at the same lifecycle point (model construction,
+                before weight load) so the projection is comparable. When
+                ``None``, the model fingerprint degrades to architecture
+                metadata only.
             model_name: Human-readable model identity used by discovery layers
                 (e.g. the MX server's source catalog). Does not affect the
                 compatibility fingerprints.
@@ -223,7 +241,7 @@ class SourceIdentity:
 
         return cls(
             format_version=SOURCE_IDENTITY_FORMAT_VERSION,
-            model_fingerprint=cls._build_model_fingerprint(model_config),
+            model_fingerprint=cls._build_model_fingerprint(model_config, model),
             quant_fingerprint=cls._build_quant_fingerprint(model_config),
             backend_fingerprint=cls._build_backend_fingerprint(model_config),
             parallel_fingerprint=cls._build_parallel_fingerprint(mapping),
@@ -237,26 +255,33 @@ class SourceIdentity:
         )
 
     @staticmethod
-    def _build_model_fingerprint(model_config: "ModelConfig") -> str:
-        """Hash layout-affecting model architecture fields.
+    def _build_model_fingerprint(model_config: "ModelConfig", model: Optional["nn.Module"]) -> str:
+        """Hash the realized weight layout plus a model-identity guard.
+
+        The layout is taken from the constructed module's parameter and buffer
+        ``(shape, dtype)`` map -- the ground truth for how weights are laid out
+        in memory. ``architectures``/``model_type`` are folded in as a cheap
+        guard so two unrelated models that happen to share identical tensor
+        shapes (a layout collision) still fingerprint differently.
 
         Args:
             model_config: The resolved torch-backend ``ModelConfig``.
+            model: The constructed ``nn.Module`` (may be ``None``).
 
         Returns:
-            A hex digest covering a narrow allowlist of pretrained-config
-            fields that affect parameter layout.
+            A hex digest covering the realized parameter/buffer layout and the
+            model's architecture identity.
         """
         pretrained = getattr(model_config, "pretrained_config", None)
-        if pretrained is None:
-            return _canonical_hash(None)
-        payload = {name: getattr(pretrained, name, None) for name in _MODEL_LAYOUT_FIELDS}
-        get_text_config = getattr(pretrained, "get_text_config", None)
-        if callable(get_text_config):
-            text_config = get_text_config()
-            payload["text_config"] = {
-                name: getattr(text_config, name, None) for name in _MODEL_LAYOUT_FIELDS
-            }
+        payload = {
+            "architectures": (
+                list(getattr(pretrained, "architectures", None) or [])
+                if pretrained is not None
+                else None
+            ),
+            "model_type": getattr(pretrained, "model_type", None) if pretrained else None,
+            "params": _named_tensor_layout(model),
+        }
         return _canonical_hash(payload)
 
     @staticmethod

--- a/tensorrt_llm/_torch/weight_sharing/source_identity.py
+++ b/tensorrt_llm/_torch/weight_sharing/source_identity.py
@@ -22,10 +22,10 @@ consumer built identities and agree on every layout-affecting choice before the
 receiver consumes shared weights.
 
 The identity is intentionally decoupled from any specific weight-sharing
-technology (neither MX nor GMS appears here). Both consume it identically::
+technology (neither MX nor GMS appears here). Both consume it identically:
 
     local = SourceIdentity.from_model_config(model_config)
-    decision = check_source_identity(local, source_identity, policy)
+    decision = check_weight_sharing_compatibility(local, source_identity, policy)
     if decision.should_share:
         ...  # pull / materialize shared weights
     else:
@@ -40,15 +40,23 @@ Layered design
 --------------
 The fingerprint is split so comparison can be selective:
 
-* **global fingerprint** -- the realized parameter/buffer ``(shape, dtype)``
-  layout plus architecture identity, quantization, backend selection, fusion
-  flags, and the parallel *sizes* (TP/PP/EP/CP). This part must be identical
-  across every rank of a deployment.
-* **shard fingerprint** -- this rank's TP/PP/EP/CP *rank* slice. Receiver rank
-  ``N`` must align with the source rank that produced shard ``N``.
+* **global fingerprint** -- rank-invariant model identity, quantization,
+  backend selection, fusion flags, and parallel *sizes* (TP/PP/EP/CP).
+* **shard fingerprint** -- this rank's TP/PP/EP/CP *rank* slice plus the
+  realized local parameter/buffer `(shape, dtype)` layout. Receiver rank `N`
+  must align with the source rank that produced shard `N`.
 
 A caller that wants *enforced* sharing across otherwise-divergent runs can skip
-the global comparison (``compare_global=False``) and trust the source.
+the global comparison (`compare_global=False`) and trust the source.
+
+Adding fields
+-------------
+Add rank-invariant choices to one of the global builders below
+(`_build_model_fingerprint`, `_build_quant_fingerprint`,
+`_build_backend_fingerprint`, or `_build_parallel_fingerprint`). Add anything
+that can differ by rank or changes this rank's tensor names/shapes/dtypes to
+`_build_shard_fingerprint`. Add a focused unit test that mutates only the new
+field and verifies the expected fingerprint (`*_fingerprint`) mismatches.
 """
 
 from __future__ import annotations
@@ -72,22 +80,29 @@ if TYPE_CHECKING:
 # never match.
 SOURCE_IDENTITY_FORMAT_VERSION = 1
 
+_PRETRAINED_METADATA_FIELDS = frozenset(
+    {
+        "_name_or_path",
+        "auto_map",
+        "custom_pipelines",
+        "repository_url",
+        "transformers_version",
+    }
+)
+
 
 def _named_tensor_layout(model: Optional["nn.Module"]) -> Optional[dict]:
     """Project a module's realized parameter/buffer layout for hashing.
 
-    The realized ``(shape, dtype)`` of every parameter and buffer *is* the
-    ground truth for how a model's weights are laid out in memory -- far more
-    reliable than a hand-maintained allowlist of config fields, and naturally
-    backend-agnostic. It also captures runtime dtype overrides (which a
-    pretrained-config projection would miss) since it reads the constructed
-    module's actual tensors.
+    The realized `(shape, dtype)` of every parameter and buffer is the local
+    rank's weight layout. This catches shape-affecting config fields and
+    runtime dtype overrides without a hand-maintained model-field allowlist.
 
     Args:
-        model: The constructed (pre- or post-load) ``nn.Module``, or ``None``.
+        model: The constructed (pre- or post-load) `nn.Module`, or `None`.
 
     Returns:
-        A mapping of tensor name to ``[shape, dtype]``, or ``None`` when no
+        A mapping of tensor name to `[shape, dtype]`, or `None` when no
         module is available.
     """
     if model is None:
@@ -104,10 +119,29 @@ def _named_tensor_layout(model: Optional["nn.Module"]) -> Optional[dict]:
     return layout
 
 
+def _pretrained_config_payload(pretrained: Any) -> Any:
+    """Project rank-invariant pretrained config fields for hashing.
+
+    Args:
+        pretrained: A HuggingFace-style config object or `None`.
+
+    Returns:
+        A dict with metadata-only fields removed, or `None`.
+    """
+    if pretrained is None:
+        return None
+
+    to_dict = getattr(pretrained, "to_dict", None)
+    payload = to_dict() if callable(to_dict) else dict(getattr(pretrained, "__dict__", {}))
+    for name in _PRETRAINED_METADATA_FIELDS:
+        payload.pop(name, None)
+    return payload
+
+
 def _canonical_hash(obj: Any) -> str:
     """Compute a stable SHA-256 hash of an arbitrary JSON-able object.
 
-    Keys are sorted and non-JSON-serializable values fall back to ``str`` so
+    Keys are sorted and non-JSON-serializable values fall back to `str` so
     enums, dtypes, and similar config values hash deterministically.
 
     Args:
@@ -125,11 +159,11 @@ def _quant_to_dict(quant_config: Any) -> Any:
     """Project a quantization config to a JSON-able value for hashing.
 
     Args:
-        quant_config: A ``QuantConfig`` (pydantic model), an object exposing
-            ``to_dict``, or ``None``.
+        quant_config: A `QuantConfig` (pydantic model), an object exposing
+            `to_dict`, or `None`.
 
     Returns:
-        ``None`` when no config is given, the config's dict projection when one
+        `None` when no config is given, the config's dict projection when one
         is available, otherwise its string representation.
     """
     if quant_config is None:
@@ -157,10 +191,10 @@ class IdentityMatchResult:
 class IdentityCheckPolicy(Enum):
     """How a receiver reacts to an identity mismatch.
 
-    * ``WARN_FALLBACK`` (default): log a warning and fall back to non-shared
+    * `WARN_FALLBACK` (default): log a warning and fall back to non-shared
       loading. Never raises.
-    * ``STRICT``: raise :class:`SourceIdentityMismatchError` on mismatch.
-    * ``ENFORCE``: always share regardless of concrete-identity mismatch (the
+    * `STRICT`: raise :class:`SourceIdentityMismatchError` on mismatch.
+    * `ENFORCE`: always share regardless of concrete-identity mismatch (the
       caller explicitly trusts the source, e.g. enforced cross-run sharing).
       Still requires both local and source identities to be present. Logs at
       debug.
@@ -177,7 +211,7 @@ class SourceIdentityMismatchError(RuntimeError):
 
 @dataclass(frozen=True)
 class IdentityCheckDecision:
-    """Result of :func:`check_source_identity`."""
+    """Result of :func:`check_weight_sharing_compatibility`."""
 
     should_share: bool
     match_result: IdentityMatchResult
@@ -197,8 +231,7 @@ class SourceIdentity:
     # --- per-rank part (rank N must align with source rank N) ---
     rank: int
     shard_fingerprint: str
-    # Plaintext discovery descriptor for layers needing cleartext rather than
-    # hashes (e.g. MX ``list_sources``). Not compared by matches().
+    # Cleartext discovery descriptor (e.g. MX `list_sources`); not compared.
     model_name: Optional[str] = None
     tp_size: int = 1
     pp_size: int = 1
@@ -218,22 +251,20 @@ class SourceIdentity:
         """Build an identity from a torch-backend :class:`ModelConfig`.
 
         Args:
-            model_config: The resolved torch-backend ``ModelConfig`` whose
+            model_config: The resolved torch-backend `ModelConfig` whose
                 quantization, backend, and parallel choices are fingerprinted.
-            model: The constructed ``nn.Module``. Its realized parameter and
-                buffer ``(shape, dtype)`` map is the layout ground truth for
-                the model fingerprint. Both producer and consumer must build
-                the identity at the same lifecycle point (model construction,
-                before weight load) so the projection is comparable. When
-                ``None``, the model fingerprint degrades to architecture
-                metadata only.
+            model: The constructed `nn.Module`. Its realized parameter/buffer
+                `(shape, dtype)` map is included in the shard fingerprint.
+                Producer and consumer must build the identity at the same
+                lifecycle point (model construction, before weight load). When
+                `None`, the shard fingerprint contains no tensor-layout data.
             model_name: Human-readable model identity used by discovery layers
                 (e.g. the MX server's source catalog). Does not affect the
                 compatibility fingerprints.
 
         Returns:
             A fully populated :class:`SourceIdentity` for
-            ``model_config.mapping.rank``.
+            `model_config.mapping.rank`.
         """
         mapping = model_config.mapping
         rank = getattr(mapping, "rank", 0)
@@ -244,12 +275,12 @@ class SourceIdentity:
 
         return cls(
             format_version=SOURCE_IDENTITY_FORMAT_VERSION,
-            model_fingerprint=cls._build_model_fingerprint(model_config, model),
+            model_fingerprint=cls._build_model_fingerprint(model_config),
             quant_fingerprint=cls._build_quant_fingerprint(model_config),
             backend_fingerprint=cls._build_backend_fingerprint(model_config),
             parallel_fingerprint=cls._build_parallel_fingerprint(mapping),
             rank=rank,
-            shard_fingerprint=cls._build_shard_fingerprint(mapping),
+            shard_fingerprint=cls._build_shard_fingerprint(mapping, model),
             model_name=model_name,
             tp_size=getattr(mapping, "tp_size", 1),
             pp_size=getattr(mapping, "pp_size", 1),
@@ -258,44 +289,29 @@ class SourceIdentity:
         )
 
     @staticmethod
-    def _build_model_fingerprint(model_config: "ModelConfig", model: Optional["nn.Module"]) -> str:
-        """Hash the realized weight layout plus a model-identity guard.
+    def _build_model_fingerprint(model_config: "ModelConfig") -> str:
+        """Hash rank-invariant model configuration fields.
 
-        The layout is taken from the constructed module's parameter and buffer
-        ``(shape, dtype)`` map -- the ground truth for how weights are laid out
-        in memory. ``architectures``/``model_type`` are folded in as a cheap
-        guard so two unrelated models that happen to share identical tensor
-        shapes (a layout collision) still fingerprint differently.
+        Rank-local tensor layout belongs to `_build_shard_fingerprint`.
 
         Args:
-            model_config: The resolved torch-backend ``ModelConfig``.
-            model: The constructed ``nn.Module`` (may be ``None``).
+            model_config: The resolved torch-backend `ModelConfig`.
 
         Returns:
-            A hex digest covering the realized parameter/buffer layout and the
-            model's architecture identity.
+            A hex digest covering model architecture and topology choices.
         """
         pretrained = getattr(model_config, "pretrained_config", None)
-        payload = {
-            "architectures": (
-                list(getattr(pretrained, "architectures", None) or [])
-                if pretrained is not None
-                else None
-            ),
-            "model_type": getattr(pretrained, "model_type", None) if pretrained else None,
-            "params": _named_tensor_layout(model),
-        }
-        return _canonical_hash(payload)
+        return _canonical_hash(_pretrained_config_payload(pretrained))
 
     @staticmethod
     def _build_quant_fingerprint(model_config: "ModelConfig") -> str:
         """Hash the quantization configuration.
 
         Args:
-            model_config: The resolved torch-backend ``ModelConfig``.
+            model_config: The resolved torch-backend `ModelConfig`.
 
         Returns:
-            A hex digest covering ``quant_config``, ``quant_config_dict``, and
+            A hex digest covering `quant_config`, `quant_config_dict`, and
             the dynamic-quantization flag.
         """
         payload = {
@@ -315,7 +331,7 @@ class SourceIdentity:
         """Hash the kernel-backend and fusion selections.
 
         Args:
-            model_config: The resolved torch-backend ``ModelConfig``.
+            model_config: The resolved torch-backend `ModelConfig`.
 
         Returns:
             A hex digest covering attention/MoE backends, allowed GEMM
@@ -351,7 +367,7 @@ class SourceIdentity:
         """Hash the parallel layout *sizes* (identical across all ranks).
 
         Args:
-            mapping: The deployment ``Mapping``.
+            mapping: The deployment `Mapping`.
 
         Returns:
             A hex digest covering TP/PP/CP/EP sizes and attention-DP settings.
@@ -375,16 +391,18 @@ class SourceIdentity:
         return _canonical_hash(payload)
 
     @staticmethod
-    def _build_shard_fingerprint(mapping: "Mapping") -> str:
-        """Hash the per-rank slice this rank owns of the parallel layout.
+    def _build_shard_fingerprint(mapping: "Mapping", model: Optional["nn.Module"]) -> str:
+        """Hash this rank's parallel slice and realized tensor layout.
 
         Args:
-            mapping: The deployment ``Mapping``.
+            mapping: The deployment `Mapping`.
+            model: The constructed `nn.Module` (may be `None`).
 
         Returns:
-            A hex digest covering the rank's TP/PP/CP/EP rank indices.
+            A hex digest covering this rank's TP/PP/CP/EP rank indices and
+            local parameter/buffer `(shape, dtype)` layout.
         """
-        payload = {"rank": getattr(mapping, "rank", 0)}
+        payload = {"rank": getattr(mapping, "rank", 0), "params": _named_tensor_layout(model)}
         for attr in ("tp_rank", "pp_rank", "cp_rank", "moe_tp_rank", "moe_ep_rank"):
             try:
                 payload[attr] = getattr(mapping, attr, None)
@@ -410,17 +428,17 @@ class SourceIdentity:
     def matches(
         self, other: "SourceIdentity", *, compare_global: bool = True, compare_shard: bool = True
     ) -> IdentityMatchResult:
-        """Compare this identity against ``other``.
+        """Compare this identity against `other`.
 
         Args:
             other: The identity to compare against (typically the source's).
             compare_global: Compare the rank-independent config fingerprint.
-                Set ``False`` for enforced sharing across divergent runs.
+                Set `False` for enforced sharing across divergent runs.
             compare_shard: Compare the per-rank shard fingerprint.
 
         Returns:
-            An :class:`IdentityMatchResult` whose ``matched`` flag is ``True``
-            only when every compared field agrees; ``mismatched_fields`` lists
+            An :class:`IdentityMatchResult` whose `matched` flag is `True`
+            only when every compared field agrees; `mismatched_fields` lists
             the field names that diverged.
         """
         mismatched: List[str] = []
@@ -449,8 +467,9 @@ class SourceIdentity:
         """Project the identity to a plain JSON-able dict.
 
         Returns:
-            A dict carrying every field, suitable for storage by a publisher
-            and reconstruction via :meth:`from_dict`.
+            A dict carrying every field, suitable for publisher metadata and
+            reconstruction via :meth:`from_dict`. Callers that need JSON can
+            serialize this dict at the boundary.
         """
         return {
             "format_version": self.format_version,
@@ -492,28 +511,8 @@ class SourceIdentity:
             dtype=data.get("dtype"),
         )
 
-    def to_json(self) -> str:
-        """Serialize the identity to a canonical JSON string.
 
-        Returns:
-            A deterministic (sorted-key) JSON encoding of :meth:`to_dict`.
-        """
-        return json.dumps(self.to_dict(), sort_keys=True)
-
-    @classmethod
-    def from_json(cls, payload: str) -> "SourceIdentity":
-        """Reconstruct an identity from its :meth:`to_json` encoding.
-
-        Args:
-            payload: A JSON string previously produced by :meth:`to_json`.
-
-        Returns:
-            The reconstructed :class:`SourceIdentity`.
-        """
-        return cls.from_dict(json.loads(payload))
-
-
-def check_source_identity(
+def check_weight_sharing_compatibility(
     local: Optional[SourceIdentity],
     source: Optional[SourceIdentity],
     policy: IdentityCheckPolicy = IdentityCheckPolicy.WARN_FALLBACK,
@@ -521,19 +520,19 @@ def check_source_identity(
     compare_global: bool = True,
     compare_shard: bool = True,
 ) -> IdentityCheckDecision:
-    """Decide whether a receiver may consume ``source``'s shared weights.
+    """Decide whether a receiver may consume `source`'s shared weights.
 
     Args:
-        local: The receiver's own identity. ``None`` means the receiver did not
+        local: The receiver's own identity. `None` means the receiver did not
             build an identity and cannot safely consume shared weights.
-        source: The producer's identity to validate against. ``None`` means the
+        source: The producer's identity to validate against. `None` means the
             producer identity is unavailable and cannot be verified.
         policy: How to react to a mismatch (see :class:`IdentityCheckPolicy`).
         compare_global: Compare the rank-independent config fingerprint.
         compare_shard: Compare the per-rank shard fingerprint.
 
     Returns:
-        An :class:`IdentityCheckDecision` whose ``should_share`` flag tells the
+        An :class:`IdentityCheckDecision` whose `should_share` flag tells the
         caller whether to consume the shared weights or fall back.
 
     Raises:

--- a/tensorrt_llm/_torch/weight_sharing/source_identity.py
+++ b/tensorrt_llm/_torch/weight_sharing/source_identity.py
@@ -17,9 +17,9 @@
 A :class:`SourceIdentity` is a serializable fingerprint of configuration choices
 that affect how a model's weights are laid out in memory. It exists so that a
 *receiver* of pre-laid-out weights (e.g. MX peer-to-peer transfer, or a GMS
-read-only materialize) can verify, **once a producer identity is available**,
-that the producer ("source") and the consumer agree on every layout-affecting
-choice before the receiver consumes shared weights.
+read-only materialize) can verify that both the producer ("source") and the
+consumer built identities and agree on every layout-affecting choice before the
+receiver consumes shared weights.
 
 The identity is intentionally decoupled from any specific weight-sharing
 technology (neither MX nor GMS appears here). Both consume it identically::
@@ -33,7 +33,8 @@ technology (neither MX nor GMS appears here). Both consume it identically::
 
 The current MX and GMS call sites build the local receiver identity and expose a
 single fetch seam for publisher metadata. Until those publisher metadata seams
-are wired to real stored identities, the comparison is not enforced.
+are wired to real stored identities, missing source metadata rejects sharing
+(MX falls back to disk; GMS raises because it has no disk fallback path).
 
 Layered design
 --------------
@@ -159,8 +160,10 @@ class IdentityCheckPolicy(Enum):
     * ``WARN_FALLBACK`` (default): log a warning and fall back to non-shared
       loading. Never raises.
     * ``STRICT``: raise :class:`SourceIdentityMismatchError` on mismatch.
-    * ``ENFORCE``: always share regardless of mismatch (the caller explicitly
-      trusts the source, e.g. enforced cross-run sharing). Logs at debug.
+    * ``ENFORCE``: always share regardless of concrete-identity mismatch (the
+      caller explicitly trusts the source, e.g. enforced cross-run sharing).
+      Still requires both local and source identities to be present. Logs at
+      debug.
     """
 
     WARN_FALLBACK = "warn_fallback"
@@ -511,8 +514,8 @@ class SourceIdentity:
 
 
 def check_source_identity(
-    local: SourceIdentity,
-    source: SourceIdentity,
+    local: Optional[SourceIdentity],
+    source: Optional[SourceIdentity],
     policy: IdentityCheckPolicy = IdentityCheckPolicy.WARN_FALLBACK,
     *,
     compare_global: bool = True,
@@ -521,8 +524,10 @@ def check_source_identity(
     """Decide whether a receiver may consume ``source``'s shared weights.
 
     Args:
-        local: The receiver's own identity.
-        source: The producer's identity to validate against.
+        local: The receiver's own identity. ``None`` means the receiver did not
+            build an identity and cannot safely consume shared weights.
+        source: The producer's identity to validate against. ``None`` means the
+            producer identity is unavailable and cannot be verified.
         policy: How to react to a mismatch (see :class:`IdentityCheckPolicy`).
         compare_global: Compare the rank-independent config fingerprint.
         compare_shard: Compare the per-rank shard fingerprint.
@@ -535,6 +540,26 @@ def check_source_identity(
         SourceIdentityMismatchError: Under :attr:`IdentityCheckPolicy.STRICT`
             when the identities are incompatible.
     """
+    if local is None or source is None:
+        missing_fields: List[str] = []
+        if local is None:
+            missing_fields.append("local_identity")
+        if source is None:
+            missing_fields.append("source_identity")
+        result = IdentityMatchResult(matched=False, mismatched_fields=missing_fields)
+        message = (
+            "SourceIdentity unavailable for fields "
+            f"{missing_fields}; receiver cannot verify source weight layout."
+        )
+        if policy is IdentityCheckPolicy.STRICT:
+            raise SourceIdentityMismatchError(message)
+
+        if policy is IdentityCheckPolicy.ENFORCE:
+            logger.warning(f"{message} Cannot enforce shared weight loading.")
+        else:
+            logger.warning(f"{message} Falling back to non-shared weight loading.")
+        return IdentityCheckDecision(should_share=False, match_result=result, policy=policy)
+
     if policy is IdentityCheckPolicy.ENFORCE:
         result = local.matches(source, compare_global=False, compare_shard=False)
         if not result.matched:

--- a/tensorrt_llm/_torch/weight_sharing/source_identity.py
+++ b/tensorrt_llm/_torch/weight_sharing/source_identity.py
@@ -14,29 +14,26 @@
 # limitations under the License.
 """Backend-agnostic source identity for weight-sharing receivers.
 
-A :class:`SourceIdentity` is a serializable fingerprint of every configuration
-choice that affects how a model's weights are laid out in memory. It exists so
-that a *receiver* of pre-laid-out weights (e.g. MX peer-to-peer transfer, or a
-GMS read-only materialize) can verify, **before** it consumes shared weights,
+A :class:`SourceIdentity` is a serializable fingerprint of configuration choices
+that affect how a model's weights are laid out in memory. It exists so that a
+*receiver* of pre-laid-out weights (e.g. MX peer-to-peer transfer, or a GMS
+read-only materialize) can verify, **once a producer identity is available**,
 that the producer ("source") and the consumer agree on every layout-affecting
-choice. If they disagree, the receiver must not consume the shared weights and
-should fall back (e.g. plain disk loading).
+choice before the receiver consumes shared weights.
 
 The identity is intentionally decoupled from any specific weight-sharing
 technology (neither MX nor GMS appears here). Both consume it identically::
 
-    local = SourceIdentity.from_model_config(model_config, rank=mapping.rank)
+    local = SourceIdentity.from_model_config(model_config)
     decision = check_source_identity(local, source_identity, policy)
     if decision.should_share:
         ...  # pull / materialize shared weights
     else:
         ...  # fall back to disk loading
 
-Intended (out-of-tree, not wired here) integration points:
-  * MX checkpoint loader: build the local identity and compare it against the
-    publisher's stored identity *before* starting the P2P transfer.
-  * GMS read-only reader: compare against the catalog's stored identity
-    *before* ``materialize_module``.
+The current MX and GMS call sites build the local receiver identity and expose a
+single fetch seam for publisher metadata. Until those publisher metadata seams
+are wired to real stored identities, the comparison is not enforced.
 
 Layered design
 --------------
@@ -71,6 +68,30 @@ if TYPE_CHECKING:
 # never match.
 SOURCE_IDENTITY_FORMAT_VERSION = 1
 
+# Pretrained-config fields that directly affect parameter shapes, module
+# topology, or dtype for common TRT-LLM model families. Keep this projection
+# intentionally narrow: unrelated HF config metadata must not block sharing.
+_MODEL_LAYOUT_FIELDS = (
+    "architectures",
+    "model_type",
+    "torch_dtype",
+    "vocab_size",
+    "hidden_size",
+    "intermediate_size",
+    "num_hidden_layers",
+    "num_attention_heads",
+    "num_key_value_heads",
+    "head_dim",
+    "tie_word_embeddings",
+    "num_experts",
+    "num_local_experts",
+    "num_experts_per_tok",
+    "n_routed_experts",
+    "n_shared_experts",
+    "moe_intermediate_size",
+    "decoder_sparse_step",
+)
+
 
 def _canonical_hash(obj: Any) -> str:
     """Compute a stable SHA-256 hash of an arbitrary JSON-able object.
@@ -104,7 +125,7 @@ def _quant_to_dict(quant_config: Any) -> Any:
         return None
     model_dump = getattr(quant_config, "model_dump", None)
     if callable(model_dump):
-        return model_dump(mode="json")
+        return model_dump(mode="python")
     to_dict = getattr(quant_config, "to_dict", None)
     if callable(to_dict):
         return to_dict()
@@ -178,7 +199,6 @@ class SourceIdentity:
         cls,
         model_config: "ModelConfig",
         *,
-        rank: Optional[int] = None,
         model_name: Optional[str] = None,
     ) -> "SourceIdentity":
         """Build an identity from a torch-backend :class:`ModelConfig`.
@@ -186,22 +206,20 @@ class SourceIdentity:
         Args:
             model_config: The resolved torch-backend ``ModelConfig`` whose
                 layout-affecting choices are fingerprinted.
-            rank: The rank to fingerprint. Defaults to
-                ``model_config.mapping.rank``; pass explicitly to build an
-                identity for a rank other than the current one.
             model_name: Human-readable model identity used by discovery layers
                 (e.g. the MX server's source catalog). Does not affect the
                 compatibility fingerprints.
 
         Returns:
-            A fully populated :class:`SourceIdentity` for ``rank``.
+            A fully populated :class:`SourceIdentity` for
+            ``model_config.mapping.rank``.
         """
         mapping = model_config.mapping
-        if rank is None:
-            rank = getattr(mapping, "rank", 0)
+        rank = getattr(mapping, "rank", 0)
 
         pretrained = getattr(model_config, "pretrained_config", None)
-        dtype = str(getattr(pretrained, "torch_dtype", None))
+        torch_dtype = getattr(pretrained, "torch_dtype", None)
+        dtype = None if torch_dtype is None else str(torch_dtype)
 
         return cls(
             format_version=SOURCE_IDENTITY_FORMAT_VERSION,
@@ -210,7 +228,7 @@ class SourceIdentity:
             backend_fingerprint=cls._build_backend_fingerprint(model_config),
             parallel_fingerprint=cls._build_parallel_fingerprint(mapping),
             rank=rank,
-            shard_fingerprint=cls._build_shard_fingerprint(mapping, rank),
+            shard_fingerprint=cls._build_shard_fingerprint(mapping),
             model_name=model_name,
             tp_size=getattr(mapping, "tp_size", 1),
             pp_size=getattr(mapping, "pp_size", 1),
@@ -220,27 +238,25 @@ class SourceIdentity:
 
     @staticmethod
     def _build_model_fingerprint(model_config: "ModelConfig") -> str:
-        """Hash the model architecture, config, and dtype.
+        """Hash layout-affecting model architecture fields.
 
         Args:
             model_config: The resolved torch-backend ``ModelConfig``.
 
         Returns:
-            A hex digest covering the pretrained config, architectures, and
-            ``torch_dtype``.
+            A hex digest covering a narrow allowlist of pretrained-config
+            fields that affect parameter layout.
         """
         pretrained = getattr(model_config, "pretrained_config", None)
         if pretrained is None:
             return _canonical_hash(None)
-        payload: dict = {}
-        to_dict = getattr(pretrained, "to_dict", None)
-        if callable(to_dict):
-            try:
-                payload["config"] = to_dict()
-            except Exception:  # noqa: BLE001 - config dumping is best-effort
-                payload["config"] = str(pretrained)
-        payload["architectures"] = getattr(pretrained, "architectures", None)
-        payload["torch_dtype"] = str(getattr(pretrained, "torch_dtype", None))
+        payload = {name: getattr(pretrained, name, None) for name in _MODEL_LAYOUT_FIELDS}
+        get_text_config = getattr(pretrained, "get_text_config", None)
+        if callable(get_text_config):
+            text_config = get_text_config()
+            payload["text_config"] = {
+                name: getattr(text_config, name, None) for name in _MODEL_LAYOUT_FIELDS
+            }
         return _canonical_hash(payload)
 
     @staticmethod
@@ -331,17 +347,16 @@ class SourceIdentity:
         return _canonical_hash(payload)
 
     @staticmethod
-    def _build_shard_fingerprint(mapping: "Mapping", rank: int) -> str:
+    def _build_shard_fingerprint(mapping: "Mapping") -> str:
         """Hash the per-rank slice this rank owns of the parallel layout.
 
         Args:
             mapping: The deployment ``Mapping``.
-            rank: The rank whose shard is fingerprinted.
 
         Returns:
             A hex digest covering the rank's TP/PP/CP/EP rank indices.
         """
-        payload = {"rank": rank}
+        payload = {"rank": getattr(mapping, "rank", 0)}
         for attr in ("tp_rank", "pp_rank", "cp_rank", "moe_tp_rank", "moe_ep_rank"):
             try:
                 payload[attr] = getattr(mapping, attr, None)

--- a/tensorrt_llm/_torch/weight_sharing/source_identity.py
+++ b/tensorrt_llm/_torch/weight_sharing/source_identity.py
@@ -1,0 +1,519 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Backend-agnostic source identity for weight-sharing receivers.
+
+A :class:`SourceIdentity` is a serializable fingerprint of every configuration
+choice that affects how a model's weights are laid out in memory. It exists so
+that a *receiver* of pre-laid-out weights (e.g. MX peer-to-peer transfer, or a
+GMS read-only materialize) can verify, **before** it consumes shared weights,
+that the producer ("source") and the consumer agree on every layout-affecting
+choice. If they disagree, the receiver must not consume the shared weights and
+should fall back (e.g. plain disk loading).
+
+The identity is intentionally decoupled from any specific weight-sharing
+technology (neither MX nor GMS appears here). Both consume it identically::
+
+    local = SourceIdentity.from_model_config(model_config, rank=mapping.rank)
+    decision = check_source_identity(local, source_identity, policy)
+    if decision.should_share:
+        ...  # pull / materialize shared weights
+    else:
+        ...  # fall back to disk loading
+
+Intended (out-of-tree, not wired here) integration points:
+  * MX checkpoint loader: build the local identity and compare it against the
+    publisher's stored identity *before* starting the P2P transfer.
+  * GMS read-only reader: compare against the catalog's stored identity
+    *before* ``materialize_module``.
+
+Layered design
+--------------
+The fingerprint is split so comparison can be selective:
+
+* **global fingerprint** -- model revision/architecture/dtype, quantization,
+  backend selection, fusion flags, and the parallel *sizes* (TP/PP/EP/CP).
+  This part must be identical across every rank of a deployment.
+* **shard fingerprint** -- this rank's TP/PP/EP/CP *rank* slice. Receiver rank
+  ``N`` must align with the source rank that produced shard ``N``.
+
+A caller that wants *enforced* sharing across otherwise-divergent runs can skip
+the global comparison (``compare_global=False``) and trust the source.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, Any, List, Optional
+
+from tensorrt_llm.logger import logger
+
+if TYPE_CHECKING:
+    from tensorrt_llm._torch.model_config import ModelConfig
+    from tensorrt_llm.mapping import Mapping
+
+# Bump when the fingerprint projection changes in a way that makes previously
+# stored identities incomparable. Two identities with different format versions
+# never match.
+SOURCE_IDENTITY_FORMAT_VERSION = 1
+
+
+def _canonical_hash(obj: Any) -> str:
+    """Compute a stable SHA-256 hash of an arbitrary JSON-able object.
+
+    Keys are sorted and non-JSON-serializable values fall back to ``str`` so
+    enums, dtypes, and similar config values hash deterministically.
+
+    Args:
+        obj: Any JSON-serializable object (or one whose values stringify
+            deterministically).
+
+    Returns:
+        The hex-encoded SHA-256 digest of the canonical JSON encoding.
+    """
+    payload = json.dumps(obj, sort_keys=True, default=str, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _quant_to_dict(quant_config: Any) -> Any:
+    """Project a quantization config to a JSON-able value for hashing.
+
+    Args:
+        quant_config: A ``QuantConfig`` (pydantic model), an object exposing
+            ``to_dict``, or ``None``.
+
+    Returns:
+        ``None`` when no config is given, the config's dict projection when one
+        is available, otherwise its string representation.
+    """
+    if quant_config is None:
+        return None
+    model_dump = getattr(quant_config, "model_dump", None)
+    if callable(model_dump):
+        return model_dump(mode="json")
+    to_dict = getattr(quant_config, "to_dict", None)
+    if callable(to_dict):
+        return to_dict()
+    return str(quant_config)
+
+
+@dataclass(frozen=True)
+class IdentityMatchResult:
+    """Outcome of comparing two :class:`SourceIdentity` instances."""
+
+    matched: bool
+    mismatched_fields: List[str] = field(default_factory=list)
+
+    def __bool__(self) -> bool:
+        return self.matched
+
+
+class IdentityCheckPolicy(Enum):
+    """How a receiver reacts to an identity mismatch.
+
+    * ``WARN_FALLBACK`` (default): log a warning and fall back to non-shared
+      loading. Never raises.
+    * ``STRICT``: raise :class:`SourceIdentityMismatchError` on mismatch.
+    * ``ENFORCE``: always share regardless of mismatch (the caller explicitly
+      trusts the source, e.g. enforced cross-run sharing). Logs at debug.
+    """
+
+    WARN_FALLBACK = "warn_fallback"
+    STRICT = "strict"
+    ENFORCE = "enforce"
+
+
+class SourceIdentityMismatchError(RuntimeError):
+    """Raised under :attr:`IdentityCheckPolicy.STRICT` on a mismatch."""
+
+
+@dataclass(frozen=True)
+class IdentityCheckDecision:
+    """Result of :func:`check_source_identity`."""
+
+    should_share: bool
+    match_result: IdentityMatchResult
+    policy: IdentityCheckPolicy
+
+
+@dataclass(frozen=True)
+class SourceIdentity:
+    """Serializable, layered fingerprint of a weight source's layout choices."""
+
+    format_version: int
+    # --- global parts (must match across all ranks) ---
+    model_fingerprint: str
+    quant_fingerprint: str
+    backend_fingerprint: str
+    parallel_fingerprint: str
+    # --- per-rank part (rank N must align with source rank N) ---
+    rank: int
+    shard_fingerprint: str
+    # Plaintext discovery descriptor for layers needing cleartext rather than
+    # hashes (e.g. MX ``list_sources``). Not compared by matches().
+    model_name: Optional[str] = None
+    tp_size: int = 1
+    pp_size: int = 1
+    ep_size: int = -1
+    dtype: Optional[str] = None
+
+    # ---- construction --------------------------------------------------
+
+    @classmethod
+    def from_model_config(
+        cls,
+        model_config: "ModelConfig",
+        *,
+        rank: Optional[int] = None,
+        model_name: Optional[str] = None,
+    ) -> "SourceIdentity":
+        """Build an identity from a torch-backend :class:`ModelConfig`.
+
+        Args:
+            model_config: The resolved torch-backend ``ModelConfig`` whose
+                layout-affecting choices are fingerprinted.
+            rank: The rank to fingerprint. Defaults to
+                ``model_config.mapping.rank``; pass explicitly to build an
+                identity for a rank other than the current one.
+            model_name: Human-readable model identity used by discovery layers
+                (e.g. the MX server's source catalog). Does not affect the
+                compatibility fingerprints.
+
+        Returns:
+            A fully populated :class:`SourceIdentity` for ``rank``.
+        """
+        mapping = model_config.mapping
+        if rank is None:
+            rank = getattr(mapping, "rank", 0)
+
+        pretrained = getattr(model_config, "pretrained_config", None)
+        dtype = str(getattr(pretrained, "torch_dtype", None))
+
+        return cls(
+            format_version=SOURCE_IDENTITY_FORMAT_VERSION,
+            model_fingerprint=cls._build_model_fingerprint(model_config),
+            quant_fingerprint=cls._build_quant_fingerprint(model_config),
+            backend_fingerprint=cls._build_backend_fingerprint(model_config),
+            parallel_fingerprint=cls._build_parallel_fingerprint(mapping),
+            rank=rank,
+            shard_fingerprint=cls._build_shard_fingerprint(mapping, rank),
+            model_name=model_name,
+            tp_size=getattr(mapping, "tp_size", 1),
+            pp_size=getattr(mapping, "pp_size", 1),
+            ep_size=getattr(mapping, "moe_ep_size", -1),
+            dtype=dtype,
+        )
+
+    @staticmethod
+    def _build_model_fingerprint(model_config: "ModelConfig") -> str:
+        """Hash the model architecture, config, and dtype.
+
+        Args:
+            model_config: The resolved torch-backend ``ModelConfig``.
+
+        Returns:
+            A hex digest covering the pretrained config, architectures, and
+            ``torch_dtype``.
+        """
+        pretrained = getattr(model_config, "pretrained_config", None)
+        if pretrained is None:
+            return _canonical_hash(None)
+        payload: dict = {}
+        to_dict = getattr(pretrained, "to_dict", None)
+        if callable(to_dict):
+            try:
+                payload["config"] = to_dict()
+            except Exception:  # noqa: BLE001 - config dumping is best-effort
+                payload["config"] = str(pretrained)
+        payload["architectures"] = getattr(pretrained, "architectures", None)
+        payload["torch_dtype"] = str(getattr(pretrained, "torch_dtype", None))
+        return _canonical_hash(payload)
+
+    @staticmethod
+    def _build_quant_fingerprint(model_config: "ModelConfig") -> str:
+        """Hash the quantization configuration.
+
+        Args:
+            model_config: The resolved torch-backend ``ModelConfig``.
+
+        Returns:
+            A hex digest covering ``quant_config``, ``quant_config_dict``, and
+            the dynamic-quantization flag.
+        """
+        payload = {
+            "quant_config": _quant_to_dict(getattr(model_config, "quant_config", None)),
+            "quant_config_dict": {
+                name: _quant_to_dict(qc)
+                for name, qc in (getattr(model_config, "quant_config_dict", None) or {}).items()
+            },
+            "force_dynamic_quantization": getattr(
+                model_config, "force_dynamic_quantization", False
+            ),
+        }
+        return _canonical_hash(payload)
+
+    @staticmethod
+    def _build_backend_fingerprint(model_config: "ModelConfig") -> str:
+        """Hash the kernel-backend and fusion selections.
+
+        Args:
+            model_config: The resolved torch-backend ``ModelConfig``.
+
+        Returns:
+            A hex digest covering attention/MoE backends, allowed GEMM
+            backends, fusion flags, and the all-reduce strategy.
+        """
+        payload = {
+            "attn_backend": getattr(model_config, "attn_backend", None),
+            "moe_backend": getattr(model_config, "moe_backend", None),
+            "nvfp4_gemm_allowed_backends": sorted(
+                getattr(model_config, "nvfp4_gemm_allowed_backends", []) or []
+            ),
+            "moe_disable_finalize_fusion": getattr(
+                model_config, "moe_disable_finalize_fusion", False
+            ),
+            "use_low_precision_moe_combine": getattr(
+                model_config, "use_low_precision_moe_combine", False
+            ),
+            "enable_min_latency": getattr(model_config, "enable_min_latency", False),
+            "allreduce_strategy": str(getattr(model_config, "allreduce_strategy", None)),
+            "use_cute_dsl_blockscaling_mm": getattr(
+                model_config, "use_cute_dsl_blockscaling_mm", False
+            ),
+            "use_cute_dsl_blockscaling_bmm": getattr(
+                model_config, "use_cute_dsl_blockscaling_bmm", False
+            ),
+            "use_cute_dsl_bf16_bmm": getattr(model_config, "use_cute_dsl_bf16_bmm", False),
+            "use_cute_dsl_bf16_gemm": getattr(model_config, "use_cute_dsl_bf16_gemm", False),
+        }
+        return _canonical_hash(payload)
+
+    @staticmethod
+    def _build_parallel_fingerprint(mapping: "Mapping") -> str:
+        """Hash the parallel layout *sizes* (identical across all ranks).
+
+        Args:
+            mapping: The deployment ``Mapping``.
+
+        Returns:
+            A hex digest covering TP/PP/CP/EP sizes and attention-DP settings.
+        """
+        payload = {
+            attr: getattr(mapping, attr, None)
+            for attr in (
+                "world_size",
+                "gpus_per_node",
+                "tp_size",
+                "pp_size",
+                "cp_size",
+                "moe_tp_size",
+                "moe_ep_size",
+                "moe_cluster_size",
+                "attn_tp_size",
+                "attn_cp_size",
+                "enable_attention_dp",
+            )
+        }
+        return _canonical_hash(payload)
+
+    @staticmethod
+    def _build_shard_fingerprint(mapping: "Mapping", rank: int) -> str:
+        """Hash the per-rank slice this rank owns of the parallel layout.
+
+        Args:
+            mapping: The deployment ``Mapping``.
+            rank: The rank whose shard is fingerprinted.
+
+        Returns:
+            A hex digest covering the rank's TP/PP/CP/EP rank indices.
+        """
+        payload = {"rank": rank}
+        for attr in ("tp_rank", "pp_rank", "cp_rank", "moe_tp_rank", "moe_ep_rank"):
+            try:
+                payload[attr] = getattr(mapping, attr, None)
+            except Exception:  # noqa: BLE001 - some rank props compute lazily
+                payload[attr] = None
+        return _canonical_hash(payload)
+
+    # ---- comparison ----------------------------------------------------
+
+    @property
+    def global_fingerprint(self) -> str:
+        """Single hash of all global (rank-independent) parts."""
+        return _canonical_hash(
+            {
+                "format_version": self.format_version,
+                "model": self.model_fingerprint,
+                "quant": self.quant_fingerprint,
+                "backend": self.backend_fingerprint,
+                "parallel": self.parallel_fingerprint,
+            }
+        )
+
+    def matches(
+        self, other: "SourceIdentity", *, compare_global: bool = True, compare_shard: bool = True
+    ) -> IdentityMatchResult:
+        """Compare this identity against ``other``.
+
+        Args:
+            other: The identity to compare against (typically the source's).
+            compare_global: Compare the rank-independent config fingerprint.
+                Set ``False`` for enforced sharing across divergent runs.
+            compare_shard: Compare the per-rank shard fingerprint.
+
+        Returns:
+            An :class:`IdentityMatchResult` whose ``matched`` flag is ``True``
+            only when every compared field agrees; ``mismatched_fields`` lists
+            the field names that diverged.
+        """
+        mismatched: List[str] = []
+
+        if self.format_version != other.format_version:
+            mismatched.append("format_version")
+
+        if compare_global:
+            for name in (
+                "model_fingerprint",
+                "quant_fingerprint",
+                "backend_fingerprint",
+                "parallel_fingerprint",
+            ):
+                if getattr(self, name) != getattr(other, name):
+                    mismatched.append(name)
+
+        if compare_shard and self.shard_fingerprint != other.shard_fingerprint:
+            mismatched.append("shard_fingerprint")
+
+        return IdentityMatchResult(matched=not mismatched, mismatched_fields=mismatched)
+
+    # ---- serialization (publisher stores, receiver reconstructs) -------
+
+    def to_dict(self) -> dict:
+        """Project the identity to a plain JSON-able dict.
+
+        Returns:
+            A dict carrying every field, suitable for storage by a publisher
+            and reconstruction via :meth:`from_dict`.
+        """
+        return {
+            "format_version": self.format_version,
+            "model_fingerprint": self.model_fingerprint,
+            "quant_fingerprint": self.quant_fingerprint,
+            "backend_fingerprint": self.backend_fingerprint,
+            "parallel_fingerprint": self.parallel_fingerprint,
+            "rank": self.rank,
+            "shard_fingerprint": self.shard_fingerprint,
+            "model_name": self.model_name,
+            "tp_size": self.tp_size,
+            "pp_size": self.pp_size,
+            "ep_size": self.ep_size,
+            "dtype": self.dtype,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SourceIdentity":
+        """Reconstruct an identity from its :meth:`to_dict` projection.
+
+        Args:
+            data: A dict previously produced by :meth:`to_dict`.
+
+        Returns:
+            The reconstructed :class:`SourceIdentity`.
+        """
+        return cls(
+            format_version=data["format_version"],
+            model_fingerprint=data["model_fingerprint"],
+            quant_fingerprint=data["quant_fingerprint"],
+            backend_fingerprint=data["backend_fingerprint"],
+            parallel_fingerprint=data["parallel_fingerprint"],
+            rank=data["rank"],
+            shard_fingerprint=data["shard_fingerprint"],
+            model_name=data.get("model_name"),
+            tp_size=data.get("tp_size", 1),
+            pp_size=data.get("pp_size", 1),
+            ep_size=data.get("ep_size", -1),
+            dtype=data.get("dtype"),
+        )
+
+    def to_json(self) -> str:
+        """Serialize the identity to a canonical JSON string.
+
+        Returns:
+            A deterministic (sorted-key) JSON encoding of :meth:`to_dict`.
+        """
+        return json.dumps(self.to_dict(), sort_keys=True)
+
+    @classmethod
+    def from_json(cls, payload: str) -> "SourceIdentity":
+        """Reconstruct an identity from its :meth:`to_json` encoding.
+
+        Args:
+            payload: A JSON string previously produced by :meth:`to_json`.
+
+        Returns:
+            The reconstructed :class:`SourceIdentity`.
+        """
+        return cls.from_dict(json.loads(payload))
+
+
+def check_source_identity(
+    local: SourceIdentity,
+    source: SourceIdentity,
+    policy: IdentityCheckPolicy = IdentityCheckPolicy.WARN_FALLBACK,
+    *,
+    compare_global: bool = True,
+    compare_shard: bool = True,
+) -> IdentityCheckDecision:
+    """Decide whether a receiver may consume ``source``'s shared weights.
+
+    Args:
+        local: The receiver's own identity.
+        source: The producer's identity to validate against.
+        policy: How to react to a mismatch (see :class:`IdentityCheckPolicy`).
+        compare_global: Compare the rank-independent config fingerprint.
+        compare_shard: Compare the per-rank shard fingerprint.
+
+    Returns:
+        An :class:`IdentityCheckDecision` whose ``should_share`` flag tells the
+        caller whether to consume the shared weights or fall back.
+
+    Raises:
+        SourceIdentityMismatchError: Under :attr:`IdentityCheckPolicy.STRICT`
+            when the identities are incompatible.
+    """
+    if policy is IdentityCheckPolicy.ENFORCE:
+        result = local.matches(source, compare_global=False, compare_shard=False)
+        if not result.matched:
+            logger.debug(
+                f"SourceIdentity ENFORCE: sharing despite mismatch in {result.mismatched_fields}."
+            )
+        return IdentityCheckDecision(should_share=True, match_result=result, policy=policy)
+
+    result = local.matches(source, compare_global=compare_global, compare_shard=compare_shard)
+    if result.matched:
+        return IdentityCheckDecision(should_share=True, match_result=result, policy=policy)
+
+    message = (
+        "SourceIdentity mismatch on fields "
+        f"{result.mismatched_fields}; receiver and source disagree on "
+        "weight layout."
+    )
+    if policy is IdentityCheckPolicy.STRICT:
+        raise SourceIdentityMismatchError(message)
+
+    logger.warning(f"{message} Falling back to non-shared weight loading.")
+    return IdentityCheckDecision(should_share=False, match_result=result, policy=policy)

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -40,6 +40,7 @@ l0_a10:
   # test list either).
   - unittest/_torch/models/checkpoints/hf/test_weight_loader.py
   - unittest/_torch/models/checkpoints/hf/test_checkpoint_loader.py
+  - unittest/_torch/weight_sharing
   - unittest/inputs/test_chat_template_dispatch.py
   - unittest/inputs/test_content_format.py
   - unittest/inputs/test_url_validation.py

--- a/tests/unittest/_torch/pyexecutor/test_model_loader_mx.py
+++ b/tests/unittest/_torch/pyexecutor/test_model_loader_mx.py
@@ -70,7 +70,9 @@ def _make_loader(monkeypatch, *, events, spec_config=None):
     loader._call_load_weights = MagicMock(
         side_effect=lambda fn, weights, mapper, **kwargs: fn(weights, mapper)
     )
-    loader._load_and_validate_config = MagicMock(return_value=SimpleNamespace(name="config"))
+    loader._load_and_validate_config = MagicMock(
+        return_value=SimpleNamespace(name="config", mapping=SimpleNamespace())
+    )
 
     monkeypatch.setattr(model_loader_mod, "timing", lambda *_args, **_kwargs: nullcontext())
     monkeypatch.setattr(model_loader_mod, "maybe_create_moe_load_balancer", _moe_context)

--- a/tests/unittest/_torch/weight_sharing/_source_identity_fakes.py
+++ b/tests/unittest/_torch/weight_sharing/_source_identity_fakes.py
@@ -167,9 +167,53 @@ class FakeModelConfig:
         self.use_cute_dsl_bf16_gemm = False
 
 
+class _FakeTensor:
+    """Stand-in for a parameter/buffer exposing only ``shape`` and ``dtype``."""
+
+    def __init__(self, shape: Sequence[int], dtype: str):
+        self.shape = tuple(shape)
+        self.dtype = dtype
+
+
+class FakeModel:
+    """Minimal stand-in for an ``nn.Module`` exposing named tensors.
+
+    Parameter shapes are derived from the pretrained config so that
+    layout-affecting fields (``hidden_size`` etc.) change the realized layout
+    fingerprint, mirroring how real modules behave. ``dtype`` models a runtime
+    compute-dtype override that a config-only projection would miss.
+    """
+
+    def __init__(self, pretrained_config: FakePretrainedConfig, *, dtype: str = "torch.bfloat16"):
+        hidden = int(getattr(pretrained_config, "hidden_size", 4096))
+        vocab = int(getattr(pretrained_config, "vocab_size", 32000))
+        intermediate = int(getattr(pretrained_config, "intermediate_size", 11008))
+        self._params = {
+            "embed_tokens.weight": _FakeTensor((vocab, hidden), dtype),
+            "mlp.gate_proj.weight": _FakeTensor((intermediate, hidden), dtype),
+            "mlp.down_proj.weight": _FakeTensor((hidden, intermediate), dtype),
+        }
+        self._buffers = {
+            "rotary.inv_freq": _FakeTensor((hidden // 2,), "torch.float32"),
+        }
+
+    def named_parameters(self):
+        return list(self._params.items())
+
+    def named_buffers(self):
+        return list(self._buffers.items())
+
+
+def identity_from(config: FakeModelConfig, *, model_name: Optional[str] = None) -> SourceIdentity:
+    """Build a :class:`SourceIdentity` from a fake config and derived model."""
+    return SourceIdentity.from_model_config(
+        config, FakeModel(config.pretrained_config), model_name=model_name
+    )
+
+
 def make_identity(
     *, attn_backend: str = "TRTLLM", rank: int = 0, model_name: str = "m"
 ) -> SourceIdentity:
     """Build a :class:`SourceIdentity` from a fake config for ``rank``."""
     cfg = FakeModelConfig(mapping=FakeMapping(rank=rank, tp_rank=rank), attn_backend=attn_backend)
-    return SourceIdentity.from_model_config(cfg, model_name=model_name)
+    return identity_from(cfg, model_name=model_name)

--- a/tests/unittest/_torch/weight_sharing/_source_identity_fakes.py
+++ b/tests/unittest/_torch/weight_sharing/_source_identity_fakes.py
@@ -16,7 +16,7 @@
 
 These expose only the attributes the fingerprint projection reads, so the
 tests touch no real model, GPU, or weights. Used by both
-``test_source_identity.py`` and ``test_mx_source_identity_gate.py``.
+`test_source_identity.py` and `test_mx_source_identity_gate.py`.
 """
 
 from typing import Optional, Sequence
@@ -52,7 +52,7 @@ class FakePretrainedConfig:
 
 
 class FakeQuantConfig:
-    """Minimal stand-in for a pydantic ``QuantConfig``."""
+    """Minimal stand-in for a pydantic `QuantConfig`."""
 
     def __init__(self, quant_algo: str = "FP8", kv_cache_quant_algo: Optional[str] = None):
         self.quant_algo = quant_algo
@@ -86,9 +86,9 @@ class FakeQuantConfigWithPythonOnlyField(FakeQuantConfig):
 
 
 class FakeMapping:
-    """Minimal stand-in for ``Mapping`` exposing layout attributes only.
+    """Minimal stand-in for `Mapping` exposing layout attributes only.
 
-    ``world_size`` defaults to ``tp_size * pp_size`` when not given.
+    `world_size` defaults to `tp_size * pp_size` when not given.
     """
 
     def __init__(
@@ -132,9 +132,9 @@ class FakeMapping:
 
 
 class FakeModelConfig:
-    """Minimal stand-in for a torch-backend ``ModelConfig``.
+    """Minimal stand-in for a torch-backend `ModelConfig`.
 
-    ``quant_config`` defaults to a :class:`FakeQuantConfig`; pass ``None``
+    `quant_config` defaults to a :class:`FakeQuantConfig`; pass `None`
     explicitly to fingerprint an unquantized model.
     """
 
@@ -168,7 +168,7 @@ class FakeModelConfig:
 
 
 class _FakeTensor:
-    """Stand-in for a parameter/buffer exposing only ``shape`` and ``dtype``."""
+    """Stand-in for a parameter/buffer exposing only `shape` and `dtype`."""
 
     def __init__(self, shape: Sequence[int], dtype: str):
         self.shape = tuple(shape)
@@ -176,11 +176,11 @@ class _FakeTensor:
 
 
 class FakeModel:
-    """Minimal stand-in for an ``nn.Module`` exposing named tensors.
+    """Minimal stand-in for an `nn.Module` exposing named tensors.
 
     Parameter shapes are derived from the pretrained config so that
-    layout-affecting fields (``hidden_size`` etc.) change the realized layout
-    fingerprint, mirroring how real modules behave. ``dtype`` models a runtime
+    layout-affecting fields (`hidden_size` etc.) change the realized layout
+    fingerprint, mirroring how real modules behave. `dtype` models a runtime
     compute-dtype override that a config-only projection would miss.
     """
 
@@ -214,6 +214,6 @@ def identity_from(config: FakeModelConfig, *, model_name: Optional[str] = None) 
 def make_identity(
     *, attn_backend: str = "TRTLLM", rank: int = 0, model_name: str = "m"
 ) -> SourceIdentity:
-    """Build a :class:`SourceIdentity` from a fake config for ``rank``."""
+    """Build a :class:`SourceIdentity` from a fake config for `rank`."""
     cfg = FakeModelConfig(mapping=FakeMapping(rank=rank, tp_rank=rank), attn_backend=attn_backend)
     return identity_from(cfg, model_name=model_name)

--- a/tests/unittest/_torch/weight_sharing/_source_identity_fakes.py
+++ b/tests/unittest/_torch/weight_sharing/_source_identity_fakes.py
@@ -30,16 +30,25 @@ class FakePretrainedConfig:
     """Minimal stand-in for a HF pretrained config."""
 
     def __init__(
-        self, architectures: Sequence[str] = ("LlamaForCausalLM",), torch_dtype: str = "bf16"
+        self,
+        architectures: Sequence[str] = ("LlamaForCausalLM",),
+        torch_dtype: str = "bf16",
+        **attrs,
     ):
         self.architectures = list(architectures)
         self.torch_dtype = torch_dtype
+        for name, value in attrs.items():
+            setattr(self, name, value)
 
     def to_dict(self) -> dict:
-        return {
+        payload = {
             "architectures": self.architectures,
             "torch_dtype": self.torch_dtype,
         }
+        payload.update(
+            {name: value for name, value in self.__dict__.items() if name not in payload}
+        )
+        return payload
 
 
 class FakeQuantConfig:
@@ -54,6 +63,26 @@ class FakeQuantConfig:
             "quant_algo": self.quant_algo,
             "kv_cache_quant_algo": self.kv_cache_quant_algo,
         }
+
+
+class FakeQuantConfigWithPythonOnlyField(FakeQuantConfig):
+    """Quant config whose JSON dump fails but Python dump succeeds."""
+
+    def __init__(
+        self,
+        quant_algo: str = "FP8",
+        kv_cache_quant_algo: Optional[str] = None,
+        dtype: object = "torch.float16",
+    ):
+        super().__init__(quant_algo=quant_algo, kv_cache_quant_algo=kv_cache_quant_algo)
+        self.dtype = dtype
+
+    def model_dump(self, mode: str = "json") -> dict:
+        if mode == "json":
+            raise TypeError("Unable to serialize unknown type: torch.dtype")
+        payload = super().model_dump(mode=mode)
+        payload["dtype"] = self.dtype
+        return payload
 
 
 class FakeMapping:

--- a/tests/unittest/_torch/weight_sharing/_source_identity_fakes.py
+++ b/tests/unittest/_torch/weight_sharing/_source_identity_fakes.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared lightweight fakes for SourceIdentity unit tests.
+
+These expose only the attributes the fingerprint projection reads, so the
+tests touch no real model, GPU, or weights. Used by both
+``test_source_identity.py`` and ``test_mx_source_identity_gate.py``.
+"""
+
+from typing import Optional, Sequence
+
+from tensorrt_llm._torch.weight_sharing import SourceIdentity
+
+_UNSET = object()
+
+
+class FakePretrainedConfig:
+    """Minimal stand-in for a HF pretrained config."""
+
+    def __init__(
+        self, architectures: Sequence[str] = ("LlamaForCausalLM",), torch_dtype: str = "bf16"
+    ):
+        self.architectures = list(architectures)
+        self.torch_dtype = torch_dtype
+
+    def to_dict(self) -> dict:
+        return {
+            "architectures": self.architectures,
+            "torch_dtype": self.torch_dtype,
+        }
+
+
+class FakeQuantConfig:
+    """Minimal stand-in for a pydantic ``QuantConfig``."""
+
+    def __init__(self, quant_algo: str = "FP8", kv_cache_quant_algo: Optional[str] = None):
+        self.quant_algo = quant_algo
+        self.kv_cache_quant_algo = kv_cache_quant_algo
+
+    def model_dump(self, mode: str = "json") -> dict:
+        return {
+            "quant_algo": self.quant_algo,
+            "kv_cache_quant_algo": self.kv_cache_quant_algo,
+        }
+
+
+class FakeMapping:
+    """Minimal stand-in for ``Mapping`` exposing layout attributes only.
+
+    ``world_size`` defaults to ``tp_size * pp_size`` when not given.
+    """
+
+    def __init__(
+        self,
+        *,
+        rank: int = 0,
+        tp_size: int = 8,
+        pp_size: int = 1,
+        cp_size: int = 1,
+        moe_tp_size: int = 1,
+        moe_ep_size: int = 1,
+        moe_cluster_size: int = -1,
+        attn_tp_size: int = -1,
+        attn_cp_size: int = -1,
+        enable_attention_dp: bool = False,
+        gpus_per_node: int = 8,
+        world_size: Optional[int] = None,
+        tp_rank: int = 0,
+        pp_rank: int = 0,
+        cp_rank: int = 0,
+        moe_tp_rank: int = 0,
+        moe_ep_rank: int = 0,
+    ):
+        self.rank = rank
+        self.world_size = world_size if world_size is not None else tp_size * pp_size
+        self.tp_size = tp_size
+        self.pp_size = pp_size
+        self.cp_size = cp_size
+        self.moe_tp_size = moe_tp_size
+        self.moe_ep_size = moe_ep_size
+        self.moe_cluster_size = moe_cluster_size
+        self.attn_tp_size = attn_tp_size
+        self.attn_cp_size = attn_cp_size
+        self.enable_attention_dp = enable_attention_dp
+        self.gpus_per_node = gpus_per_node
+        self.tp_rank = tp_rank
+        self.pp_rank = pp_rank
+        self.cp_rank = cp_rank
+        self.moe_tp_rank = moe_tp_rank
+        self.moe_ep_rank = moe_ep_rank
+
+
+class FakeModelConfig:
+    """Minimal stand-in for a torch-backend ``ModelConfig``.
+
+    ``quant_config`` defaults to a :class:`FakeQuantConfig`; pass ``None``
+    explicitly to fingerprint an unquantized model.
+    """
+
+    def __init__(
+        self,
+        *,
+        mapping: Optional[FakeMapping] = None,
+        pretrained_config: Optional[FakePretrainedConfig] = None,
+        quant_config=_UNSET,
+        attn_backend: str = "TRTLLM",
+        moe_backend: str = "CUTLASS",
+    ):
+        self.mapping = mapping or FakeMapping()
+        self.pretrained_config = (
+            pretrained_config if pretrained_config is not None else FakePretrainedConfig()
+        )
+        self.quant_config = FakeQuantConfig() if quant_config is _UNSET else quant_config
+        self.quant_config_dict = None
+        self.force_dynamic_quantization = False
+        self.attn_backend = attn_backend
+        self.moe_backend = moe_backend
+        self.nvfp4_gemm_allowed_backends = ["cutlass", "cublaslt", "cuda_core"]
+        self.moe_disable_finalize_fusion = False
+        self.use_low_precision_moe_combine = False
+        self.enable_min_latency = False
+        self.allreduce_strategy = "AUTO"
+        self.use_cute_dsl_blockscaling_mm = False
+        self.use_cute_dsl_blockscaling_bmm = False
+        self.use_cute_dsl_bf16_bmm = False
+        self.use_cute_dsl_bf16_gemm = False
+
+
+def make_identity(
+    *, attn_backend: str = "TRTLLM", rank: int = 0, model_name: str = "m"
+) -> SourceIdentity:
+    """Build a :class:`SourceIdentity` from a fake config for ``rank``."""
+    cfg = FakeModelConfig(mapping=FakeMapping(rank=rank, tp_rank=rank), attn_backend=attn_backend)
+    return SourceIdentity.from_model_config(cfg, model_name=model_name)

--- a/tests/unittest/_torch/weight_sharing/test_gms_source_identity_gate.py
+++ b/tests/unittest/_torch/weight_sharing/test_gms_source_identity_gate.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Exercise the real GMS read-only pre-materialize SourceIdentity gate.
+
+These tests drive ``ModelLoader._check_gms_source_identity`` directly -- the
+single decision point the GMS RO path consults before ``materialize_module``.
+Unlike MX, GMS has no disk fallback, so a verified mismatch must *raise* under
+``STRICT`` rather than fall back. The ``ModelLoader`` is constructed via
+``__new__`` to bypass its heavy ``__init__``; the GMS backend is a stub
+exposing only ``get_source_identity`` so no GMS pool, GPU, or model is touched.
+"""
+
+import pytest
+from _source_identity_fakes import make_identity as _identity
+
+from tensorrt_llm._torch.pyexecutor.model_loader import ModelLoader
+from tensorrt_llm._torch.weight_sharing import SourceIdentityMismatchError
+
+
+class _FakeGMSBackend:
+    """Minimal GMS backend stub exposing only the gate's fetch seam."""
+
+    def __init__(self, source_identity):
+        self._source_identity = source_identity
+
+    def get_source_identity(self):
+        return self._source_identity
+
+
+def _new_loader(local_identity):
+    """Construct a loader bypassing heavy base __init__, wire the local id."""
+    loader = ModelLoader.__new__(ModelLoader)
+    loader._source_identity = local_identity
+    return loader
+
+
+def test_gate_passes_on_matching_identity():
+    local = _identity(attn_backend="TRTLLM")
+    writer = _identity(attn_backend="TRTLLM")
+    loader = _new_loader(local)
+    # Compatible writer: the gate is a no-op (no raise).
+    loader._check_gms_source_identity(_FakeGMSBackend(writer))
+
+
+def test_gate_raises_on_mismatch():
+    local = _identity(attn_backend="TRTLLM")
+    writer = _identity(attn_backend="FLASHINFER")
+    loader = _new_loader(local)
+    # No disk fallback for GMS: an incompatible writer must raise.
+    with pytest.raises(SourceIdentityMismatchError):
+        loader._check_gms_source_identity(_FakeGMSBackend(writer))
+
+
+def test_gate_inert_when_writer_identity_unavailable():
+    # Publisher metadata not wired yet (get_source_identity returns None);
+    # the gate is inert and materialization proceeds without enforcement.
+    local = _identity()
+    loader = _new_loader(local)
+    loader._check_gms_source_identity(_FakeGMSBackend(None))

--- a/tests/unittest/_torch/weight_sharing/test_gms_source_identity_gate.py
+++ b/tests/unittest/_torch/weight_sharing/test_gms_source_identity_gate.py
@@ -27,6 +27,14 @@ from _source_identity_fakes import make_identity as _identity
 
 from tensorrt_llm._torch.pyexecutor.model_loader import ModelLoader
 from tensorrt_llm._torch.weight_sharing import SourceIdentityMismatchError
+from tensorrt_llm.llmapi.llm_args import LoadFormat
+
+
+class _FakeCheckpointLoader:
+    """Minimal checkpoint-loader stub exposing ``checkpoint_format``."""
+
+    def __init__(self, checkpoint_format):
+        self.checkpoint_format = checkpoint_format
 
 
 class _FakeGMSBackend:
@@ -44,6 +52,14 @@ def _new_loader(local_identity):
     loader = ModelLoader.__new__(ModelLoader)
     loader._source_identity = local_identity
     return loader
+
+
+def test_source_identity_is_only_needed_for_mx_or_gms():
+    # Default HF/AUTO loading should be a strict no-op: no SourceIdentity
+    # construction, no tensor-layout traversal, no behavior change.
+    assert not ModelLoader._needs_source_identity(_FakeCheckpointLoader("HF"), LoadFormat.AUTO)
+    assert ModelLoader._needs_source_identity(_FakeCheckpointLoader("MX"), LoadFormat.AUTO)
+    assert ModelLoader._needs_source_identity(_FakeCheckpointLoader("HF"), LoadFormat.GMS)
 
 
 def test_gate_passes_on_matching_identity():

--- a/tests/unittest/_torch/weight_sharing/test_gms_source_identity_gate.py
+++ b/tests/unittest/_torch/weight_sharing/test_gms_source_identity_gate.py
@@ -79,9 +79,10 @@ def test_gate_raises_on_mismatch():
         loader._check_gms_source_identity(_FakeGMSBackend(writer))
 
 
-def test_gate_inert_when_writer_identity_unavailable():
+def test_gate_raises_when_writer_identity_unavailable():
     # Publisher metadata not wired yet (get_source_identity returns None);
-    # the gate is inert and materialization proceeds without enforcement.
+    # GMS has no disk fallback, so unverified sharing must raise.
     local = _identity()
     loader = _new_loader(local)
-    loader._check_gms_source_identity(_FakeGMSBackend(None))
+    with pytest.raises(SourceIdentityMismatchError):
+        loader._check_gms_source_identity(_FakeGMSBackend(None))

--- a/tests/unittest/_torch/weight_sharing/test_gms_source_identity_gate.py
+++ b/tests/unittest/_torch/weight_sharing/test_gms_source_identity_gate.py
@@ -14,12 +14,12 @@
 # limitations under the License.
 """Exercise the real GMS read-only pre-materialize SourceIdentity gate.
 
-These tests drive ``ModelLoader._check_gms_source_identity`` directly -- the
-single decision point the GMS RO path consults before ``materialize_module``.
+These tests drive `ModelLoader._check_gms_source_identity` directly -- the
+single decision point the GMS RO path consults before `materialize_module`.
 Unlike MX, GMS has no disk fallback, so a verified mismatch must *raise* under
-``STRICT`` rather than fall back. The ``ModelLoader`` is constructed via
-``__new__`` to bypass its heavy ``__init__``; the GMS backend is a stub
-exposing only ``get_source_identity`` so no GMS pool, GPU, or model is touched.
+`STRICT` rather than fall back. The `ModelLoader` is constructed via
+`__new__` to bypass its heavy `__init__`; the GMS backend is a stub
+exposing only `get_source_identity` so no GMS pool, GPU, or model is touched.
 """
 
 import pytest
@@ -31,7 +31,7 @@ from tensorrt_llm.llmapi.llm_args import LoadFormat
 
 
 class _FakeCheckpointLoader:
-    """Minimal checkpoint-loader stub exposing ``checkpoint_format``."""
+    """Minimal checkpoint-loader stub exposing `checkpoint_format`."""
 
     def __init__(self, checkpoint_format):
         self.checkpoint_format = checkpoint_format

--- a/tests/unittest/_torch/weight_sharing/test_mx_source_identity_gate.py
+++ b/tests/unittest/_torch/weight_sharing/test_mx_source_identity_gate.py
@@ -64,7 +64,7 @@ def test_gate_proceeds_when_no_local_identity():
 
 def test_gate_proceeds_when_source_identity_unavailable():
     # Publisher identity not yet fetchable (upstream metadata channel pending);
-    # gate is inert and the transfer proceeds (disk fallback guards correctness).
+    # gate is inert and the transfer proceeds without SourceIdentity enforcement.
     local = _identity()
     loader = _new_loader(local, None, fetched=False)
     assert loader._source_identity_compatible("ckpt", _STUB_CLIENT, _STUB_BUILD) is True

--- a/tests/unittest/_torch/weight_sharing/test_mx_source_identity_gate.py
+++ b/tests/unittest/_torch/weight_sharing/test_mx_source_identity_gate.py
@@ -14,11 +14,11 @@
 # limitations under the License.
 """Exercise the real MX checkpoint loader pre-transfer SourceIdentity gate.
 
-These tests drive ``MXCheckpointLoader._source_identity_compatible`` directly —
-the single decision point the MX ``load_weights`` path consults before starting
-a P2P transfer. Upstream ``modelexpress`` is never imported: the discovery
+These tests drive `MXCheckpointLoader._source_identity_compatible` directly —
+the single decision point the MX `load_weights` path consults before starting
+a P2P transfer. Upstream `modelexpress` is never imported: the discovery
 client / identity builder are passed as stubs, and the publisher-identity fetch
-seam is patched, so the gate logic runs against real ``SourceIdentity`` objects
+seam is patched, so the gate logic runs against real `SourceIdentity` objects
 without any model, GPU, or RDMA.
 """
 

--- a/tests/unittest/_torch/weight_sharing/test_mx_source_identity_gate.py
+++ b/tests/unittest/_torch/weight_sharing/test_mx_source_identity_gate.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Exercise the real MX checkpoint loader pre-transfer SourceIdentity gate.
+
+These tests drive ``MXCheckpointLoader._source_identity_compatible`` directly —
+the single decision point the MX ``load_weights`` path consults before starting
+a P2P transfer. Upstream ``modelexpress`` is never imported: the discovery
+client / identity builder are passed as stubs, and the publisher-identity fetch
+seam is patched, so the gate logic runs against real ``SourceIdentity`` objects
+without any model, GPU, or RDMA.
+"""
+
+from _source_identity_fakes import FakeMapping
+from _source_identity_fakes import make_identity as _identity
+
+from tensorrt_llm._torch.models.checkpoints.mx.checkpoint_loader import MXCheckpointLoader
+
+
+def _new_loader(local_identity, source_identity, fetched=True):
+    """Construct a loader bypassing heavy base __init__, wire the seams."""
+    loader = MXCheckpointLoader.__new__(MXCheckpointLoader)
+    loader._local_source_identity = local_identity
+    # Patch the single fetch seam to return the publisher identity (or None).
+    loader._fetch_source_identity = lambda *a, **k: source_identity if fetched else None
+    return loader
+
+
+# MxClient / build_identity are only forwarded to the (patched) fetch seam.
+_STUB_CLIENT = object()
+_STUB_BUILD = object()
+
+
+def test_gate_proceeds_on_matching_identity():
+    local = _identity(attn_backend="TRTLLM")
+    source = _identity(attn_backend="TRTLLM")
+    loader = _new_loader(local, source)
+    assert loader._source_identity_compatible("ckpt", _STUB_CLIENT, _STUB_BUILD) is True
+
+
+def test_gate_falls_back_on_mismatch():
+    local = _identity(attn_backend="TRTLLM")
+    source = _identity(attn_backend="FLASHINFER")
+    loader = _new_loader(local, source)
+    assert loader._source_identity_compatible("ckpt", _STUB_CLIENT, _STUB_BUILD) is False
+
+
+def test_gate_proceeds_when_no_local_identity():
+    # Legacy callers that don't supply an identity must not be gated.
+    loader = _new_loader(None, _identity())
+    assert loader._source_identity_compatible("ckpt", _STUB_CLIENT, _STUB_BUILD) is True
+
+
+def test_gate_proceeds_when_source_identity_unavailable():
+    # Publisher identity not yet fetchable (upstream metadata channel pending);
+    # gate is inert and the transfer proceeds (disk fallback guards correctness).
+    local = _identity()
+    loader = _new_loader(local, None, fetched=False)
+    assert loader._source_identity_compatible("ckpt", _STUB_CLIENT, _STUB_BUILD) is True
+
+
+def test_fetch_source_identity_returns_none_until_upstream_wired():
+    # The seam currently returns None by contract; this pins that behavior so
+    # the day it is wired to real MX metadata, the change is deliberate.
+    loader = MXCheckpointLoader.__new__(MXCheckpointLoader)
+    assert loader._fetch_source_identity("ckpt", _STUB_CLIENT, _STUB_BUILD) is None
+
+
+def test_load_weights_pops_source_identity_kwarg():
+    # source_identity must be consumed by load_weights and never leak into the
+    # HfCheckpointLoader disk-fallback signature. With no server URL configured
+    # the loader takes the disk-fallback path; we only assert the kwarg is
+    # stored and not forwarded.
+    loader = MXCheckpointLoader.__new__(MXCheckpointLoader)
+    loader._mx_server_url = None
+    loader._p2p_succeeded = False
+    captured = {}
+
+    def fake_fallback(checkpoint_dir, mapping, *, reason=None, **kwargs):
+        captured["kwargs"] = kwargs
+        return {}
+
+    loader._fallback_to_disk = fake_fallback
+    identity = _identity()
+    loader.load_weights("ckpt", mapping=FakeMapping(), model=None, source_identity=identity)
+    assert loader._local_source_identity is identity
+    assert "source_identity" not in captured["kwargs"]
+    assert "model" not in captured["kwargs"]

--- a/tests/unittest/_torch/weight_sharing/test_mx_source_identity_gate.py
+++ b/tests/unittest/_torch/weight_sharing/test_mx_source_identity_gate.py
@@ -56,18 +56,18 @@ def test_gate_falls_back_on_mismatch():
     assert loader._source_identity_compatible("ckpt", _STUB_CLIENT, _STUB_BUILD) is False
 
 
-def test_gate_proceeds_when_no_local_identity():
-    # Legacy callers that don't supply an identity must not be gated.
+def test_gate_falls_back_when_no_local_identity():
+    # MX must not consume shared weights unless the receiver identity exists.
     loader = _new_loader(None, _identity())
-    assert loader._source_identity_compatible("ckpt", _STUB_CLIENT, _STUB_BUILD) is True
+    assert loader._source_identity_compatible("ckpt", _STUB_CLIENT, _STUB_BUILD) is False
 
 
-def test_gate_proceeds_when_source_identity_unavailable():
+def test_gate_falls_back_when_source_identity_unavailable():
     # Publisher identity not yet fetchable (upstream metadata channel pending);
-    # gate is inert and the transfer proceeds without SourceIdentity enforcement.
+    # reject P2P and fall back to disk rather than sharing unverified weights.
     local = _identity()
     loader = _new_loader(local, None, fetched=False)
-    assert loader._source_identity_compatible("ckpt", _STUB_CLIENT, _STUB_BUILD) is True
+    assert loader._source_identity_compatible("ckpt", _STUB_CLIENT, _STUB_BUILD) is False
 
 
 def test_fetch_source_identity_returns_none_until_upstream_wired():

--- a/tests/unittest/_torch/weight_sharing/test_source_identity.py
+++ b/tests/unittest/_torch/weight_sharing/test_source_identity.py
@@ -35,7 +35,7 @@ from tensorrt_llm._torch.weight_sharing import (
     IdentityCheckPolicy,
     SourceIdentity,
     SourceIdentityMismatchError,
-    check_source_identity,
+    check_weight_sharing_compatibility,
 )
 
 
@@ -62,12 +62,13 @@ def test_backend_mismatch_flags_global():
     assert "backend_fingerprint" in result.mismatched_fields
 
 
-def test_model_layout_field_mismatch_flags_global():
+def test_model_layout_field_mismatch_flags_global_and_shard():
     a = identity_from(FakeModelConfig(pretrained_config=FakePretrainedConfig(hidden_size=4096)))
     b = identity_from(FakeModelConfig(pretrained_config=FakePretrainedConfig(hidden_size=8192)))
     result = a.matches(b)
     assert not result.matched
     assert "model_fingerprint" in result.mismatched_fields
+    assert "shard_fingerprint" in result.mismatched_fields
 
 
 def test_non_layout_model_metadata_does_not_affect_match():
@@ -76,7 +77,7 @@ def test_non_layout_model_metadata_does_not_affect_match():
     assert a.matches(b).matched
 
 
-def test_param_dtype_override_flags_global():
+def test_param_dtype_override_flags_shard():
     # Same config, but the constructed module realizes a different compute
     # dtype (a runtime override). A config-only projection would miss this;
     # the realized-layout fingerprint catches it.
@@ -89,7 +90,7 @@ def test_param_dtype_override_flags_global():
     )
     result = a.matches(b)
     assert not result.matched
-    assert "model_fingerprint" in result.mismatched_fields
+    assert "shard_fingerprint" in result.mismatched_fields
 
 
 def test_cross_architecture_same_shapes_flags_global():
@@ -164,7 +165,7 @@ def test_enforced_sharing_skips_global():
 
 def test_serialization_roundtrip():
     a = identity_from(FakeModelConfig())
-    restored = SourceIdentity.from_json(a.to_json())
+    restored = SourceIdentity.from_dict(a.to_dict())
     assert restored == a
     assert a.matches(restored).matched
 
@@ -172,7 +173,7 @@ def test_serialization_roundtrip():
 def test_check_warn_fallback_on_mismatch():
     local = identity_from(FakeModelConfig(attn_backend="TRTLLM"))
     source = identity_from(FakeModelConfig(attn_backend="FLASHINFER"))
-    decision = check_source_identity(local, source, IdentityCheckPolicy.WARN_FALLBACK)
+    decision = check_weight_sharing_compatibility(local, source, IdentityCheckPolicy.WARN_FALLBACK)
     assert decision.should_share is False
     assert not decision.match_result.matched
 
@@ -180,13 +181,13 @@ def test_check_warn_fallback_on_mismatch():
 def test_check_warn_fallback_on_match():
     local = identity_from(FakeModelConfig())
     source = identity_from(FakeModelConfig())
-    decision = check_source_identity(local, source, IdentityCheckPolicy.WARN_FALLBACK)
+    decision = check_weight_sharing_compatibility(local, source, IdentityCheckPolicy.WARN_FALLBACK)
     assert decision.should_share is True
 
 
 def test_check_warn_fallback_on_missing_identity():
     source = identity_from(FakeModelConfig())
-    decision = check_source_identity(None, source, IdentityCheckPolicy.WARN_FALLBACK)
+    decision = check_weight_sharing_compatibility(None, source, IdentityCheckPolicy.WARN_FALLBACK)
     assert decision.should_share is False
     assert decision.match_result.mismatched_fields == ["local_identity"]
 
@@ -195,19 +196,19 @@ def test_check_strict_raises_on_mismatch():
     local = identity_from(FakeModelConfig(attn_backend="TRTLLM"))
     source = identity_from(FakeModelConfig(attn_backend="FLASHINFER"))
     with pytest.raises(SourceIdentityMismatchError):
-        check_source_identity(local, source, IdentityCheckPolicy.STRICT)
+        check_weight_sharing_compatibility(local, source, IdentityCheckPolicy.STRICT)
 
 
 def test_check_strict_raises_on_missing_source_identity():
     local = identity_from(FakeModelConfig())
     with pytest.raises(SourceIdentityMismatchError):
-        check_source_identity(local, None, IdentityCheckPolicy.STRICT)
+        check_weight_sharing_compatibility(local, None, IdentityCheckPolicy.STRICT)
 
 
 def test_check_enforce_shares_despite_mismatch():
     local = identity_from(FakeModelConfig(attn_backend="TRTLLM"))
     source = identity_from(FakeModelConfig(attn_backend="FLASHINFER"))
-    decision = check_source_identity(local, source, IdentityCheckPolicy.ENFORCE)
+    decision = check_weight_sharing_compatibility(local, source, IdentityCheckPolicy.ENFORCE)
     assert decision.should_share is True
 
 

--- a/tests/unittest/_torch/weight_sharing/test_source_identity.py
+++ b/tests/unittest/_torch/weight_sharing/test_source_identity.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the backend-agnostic SourceIdentity fingerprint.
+
+Mock-based: no real model or weights are touched. Fakes expose only the
+attributes that the fingerprint projection reads.
+"""
+
+import copy
+
+import pytest
+from _source_identity_fakes import FakeMapping, FakeModelConfig, FakeQuantConfig
+
+from tensorrt_llm._torch.weight_sharing import (
+    IdentityCheckPolicy,
+    SourceIdentity,
+    SourceIdentityMismatchError,
+    check_source_identity,
+)
+
+
+def test_identical_configs_match():
+    a = SourceIdentity.from_model_config(FakeModelConfig())
+    b = SourceIdentity.from_model_config(FakeModelConfig())
+    result = a.matches(b)
+    assert result.matched
+    assert result.mismatched_fields == []
+    assert bool(result) is True
+
+
+def test_rank_defaults_from_mapping():
+    cfg = FakeModelConfig(mapping=FakeMapping(rank=3, tp_rank=3))
+    identity = SourceIdentity.from_model_config(cfg)
+    assert identity.rank == 3
+
+
+def test_backend_mismatch_flags_global():
+    a = SourceIdentity.from_model_config(FakeModelConfig(attn_backend="TRTLLM"))
+    b = SourceIdentity.from_model_config(FakeModelConfig(attn_backend="FLASHINFER"))
+    result = a.matches(b)
+    assert not result.matched
+    assert "backend_fingerprint" in result.mismatched_fields
+
+
+def test_quant_mismatch_flags_global():
+    a = SourceIdentity.from_model_config(
+        FakeModelConfig(quant_config=FakeQuantConfig(quant_algo="FP8"))
+    )
+    b = SourceIdentity.from_model_config(
+        FakeModelConfig(quant_config=FakeQuantConfig(quant_algo="NVFP4"))
+    )
+    result = a.matches(b)
+    assert not result.matched
+    assert "quant_fingerprint" in result.mismatched_fields
+
+
+def test_parallel_size_mismatch_flags_global():
+    a = SourceIdentity.from_model_config(FakeModelConfig(mapping=FakeMapping(tp_size=8)))
+    b = SourceIdentity.from_model_config(FakeModelConfig(mapping=FakeMapping(tp_size=4)))
+    result = a.matches(b)
+    assert not result.matched
+    assert "parallel_fingerprint" in result.mismatched_fields
+
+
+def test_shard_mismatch_only():
+    # Same global layout, different per-rank slice.
+    a = SourceIdentity.from_model_config(FakeModelConfig(mapping=FakeMapping(rank=0, tp_rank=0)))
+    b = SourceIdentity.from_model_config(FakeModelConfig(mapping=FakeMapping(rank=1, tp_rank=1)))
+    result = a.matches(b)
+    assert not result.matched
+    assert result.mismatched_fields == ["shard_fingerprint"]
+    # Global parts still agree.
+    assert a.global_fingerprint == b.global_fingerprint
+
+
+def test_compare_global_only_ignores_shard():
+    a = SourceIdentity.from_model_config(FakeModelConfig(mapping=FakeMapping(rank=0, tp_rank=0)))
+    b = SourceIdentity.from_model_config(FakeModelConfig(mapping=FakeMapping(rank=1, tp_rank=1)))
+    assert a.matches(b, compare_shard=False).matched
+
+
+def test_enforced_sharing_skips_global():
+    # Divergent runs (different model + backend) but enforced sharing trusts
+    # the source by skipping the global comparison.
+    a = SourceIdentity.from_model_config(FakeModelConfig(attn_backend="TRTLLM"))
+    b = SourceIdentity.from_model_config(FakeModelConfig(attn_backend="FLASHINFER"))
+    assert a.matches(b, compare_global=False, compare_shard=False).matched
+
+
+def test_serialization_roundtrip():
+    a = SourceIdentity.from_model_config(FakeModelConfig())
+    restored = SourceIdentity.from_json(a.to_json())
+    assert restored == a
+    assert a.matches(restored).matched
+
+
+def test_check_warn_fallback_on_mismatch():
+    local = SourceIdentity.from_model_config(FakeModelConfig(attn_backend="TRTLLM"))
+    source = SourceIdentity.from_model_config(FakeModelConfig(attn_backend="FLASHINFER"))
+    decision = check_source_identity(local, source, IdentityCheckPolicy.WARN_FALLBACK)
+    assert decision.should_share is False
+    assert not decision.match_result.matched
+
+
+def test_check_warn_fallback_on_match():
+    local = SourceIdentity.from_model_config(FakeModelConfig())
+    source = SourceIdentity.from_model_config(FakeModelConfig())
+    decision = check_source_identity(local, source, IdentityCheckPolicy.WARN_FALLBACK)
+    assert decision.should_share is True
+
+
+def test_check_strict_raises_on_mismatch():
+    local = SourceIdentity.from_model_config(FakeModelConfig(attn_backend="TRTLLM"))
+    source = SourceIdentity.from_model_config(FakeModelConfig(attn_backend="FLASHINFER"))
+    with pytest.raises(SourceIdentityMismatchError):
+        check_source_identity(local, source, IdentityCheckPolicy.STRICT)
+
+
+def test_check_enforce_shares_despite_mismatch():
+    local = SourceIdentity.from_model_config(FakeModelConfig(attn_backend="TRTLLM"))
+    source = SourceIdentity.from_model_config(FakeModelConfig(attn_backend="FLASHINFER"))
+    decision = check_source_identity(local, source, IdentityCheckPolicy.ENFORCE)
+    assert decision.should_share is True
+
+
+def test_format_version_mismatch_never_matches():
+    a = SourceIdentity.from_model_config(FakeModelConfig())
+    b = (
+        copy.replace(a, format_version=a.format_version + 1)
+        if hasattr(copy, "replace")
+        else SourceIdentity(
+            format_version=a.format_version + 1,
+            model_fingerprint=a.model_fingerprint,
+            quant_fingerprint=a.quant_fingerprint,
+            backend_fingerprint=a.backend_fingerprint,
+            parallel_fingerprint=a.parallel_fingerprint,
+            rank=a.rank,
+            shard_fingerprint=a.shard_fingerprint,
+        )
+    )
+    result = a.matches(b)
+    assert not result.matched
+    assert "format_version" in result.mismatched_fields

--- a/tests/unittest/_torch/weight_sharing/test_source_identity.py
+++ b/tests/unittest/_torch/weight_sharing/test_source_identity.py
@@ -23,10 +23,12 @@ import copy
 import pytest
 from _source_identity_fakes import (
     FakeMapping,
+    FakeModel,
     FakeModelConfig,
     FakePretrainedConfig,
     FakeQuantConfig,
     FakeQuantConfigWithPythonOnlyField,
+    identity_from,
 )
 
 from tensorrt_llm._torch.weight_sharing import (
@@ -38,8 +40,8 @@ from tensorrt_llm._torch.weight_sharing import (
 
 
 def test_identical_configs_match():
-    a = SourceIdentity.from_model_config(FakeModelConfig())
-    b = SourceIdentity.from_model_config(FakeModelConfig())
+    a = identity_from(FakeModelConfig())
+    b = identity_from(FakeModelConfig())
     result = a.matches(b)
     assert result.matched
     assert result.mismatched_fields == []
@@ -48,62 +50,88 @@ def test_identical_configs_match():
 
 def test_rank_defaults_from_mapping():
     cfg = FakeModelConfig(mapping=FakeMapping(rank=3, tp_rank=3))
-    identity = SourceIdentity.from_model_config(cfg)
+    identity = identity_from(cfg)
     assert identity.rank == 3
 
 
 def test_backend_mismatch_flags_global():
-    a = SourceIdentity.from_model_config(FakeModelConfig(attn_backend="TRTLLM"))
-    b = SourceIdentity.from_model_config(FakeModelConfig(attn_backend="FLASHINFER"))
+    a = identity_from(FakeModelConfig(attn_backend="TRTLLM"))
+    b = identity_from(FakeModelConfig(attn_backend="FLASHINFER"))
     result = a.matches(b)
     assert not result.matched
     assert "backend_fingerprint" in result.mismatched_fields
 
 
 def test_model_layout_field_mismatch_flags_global():
-    a = SourceIdentity.from_model_config(
-        FakeModelConfig(pretrained_config=FakePretrainedConfig(hidden_size=4096))
-    )
-    b = SourceIdentity.from_model_config(
-        FakeModelConfig(pretrained_config=FakePretrainedConfig(hidden_size=8192))
-    )
+    a = identity_from(FakeModelConfig(pretrained_config=FakePretrainedConfig(hidden_size=4096)))
+    b = identity_from(FakeModelConfig(pretrained_config=FakePretrainedConfig(hidden_size=8192)))
     result = a.matches(b)
     assert not result.matched
     assert "model_fingerprint" in result.mismatched_fields
 
 
 def test_non_layout_model_metadata_does_not_affect_match():
+    a = identity_from(FakeModelConfig(pretrained_config=FakePretrainedConfig(repository_url="old")))
+    b = identity_from(FakeModelConfig(pretrained_config=FakePretrainedConfig(repository_url="new")))
+    assert a.matches(b).matched
+
+
+def test_param_dtype_override_flags_global():
+    # Same config, but the constructed module realizes a different compute
+    # dtype (a runtime override). A config-only projection would miss this;
+    # the realized-layout fingerprint catches it.
+    cfg = FakeModelConfig()
     a = SourceIdentity.from_model_config(
-        FakeModelConfig(pretrained_config=FakePretrainedConfig(repository_url="old"))
+        cfg, FakeModel(cfg.pretrained_config, dtype="torch.bfloat16")
     )
     b = SourceIdentity.from_model_config(
-        FakeModelConfig(pretrained_config=FakePretrainedConfig(repository_url="new"))
+        cfg, FakeModel(cfg.pretrained_config, dtype="torch.float16")
     )
+    result = a.matches(b)
+    assert not result.matched
+    assert "model_fingerprint" in result.mismatched_fields
+
+
+def test_cross_architecture_same_shapes_flags_global():
+    # Two models with identical tensor shapes but different architectures must
+    # not be considered layout-compatible (guards against shape collisions).
+    a = identity_from(
+        FakeModelConfig(pretrained_config=FakePretrainedConfig(architectures=("LlamaForCausalLM",)))
+    )
+    b = identity_from(
+        FakeModelConfig(
+            pretrained_config=FakePretrainedConfig(architectures=("MistralForCausalLM",))
+        )
+    )
+    result = a.matches(b)
+    assert not result.matched
+    assert "model_fingerprint" in result.mismatched_fields
+
+
+def test_no_model_degrades_to_architecture_only():
+    # Without a module, the fingerprint still builds (architecture-only) and
+    # two identical configs still match.
+    a = SourceIdentity.from_model_config(FakeModelConfig(), None)
+    b = SourceIdentity.from_model_config(FakeModelConfig(), None)
     assert a.matches(b).matched
 
 
 def test_quant_mismatch_flags_global():
-    a = SourceIdentity.from_model_config(
-        FakeModelConfig(quant_config=FakeQuantConfig(quant_algo="FP8"))
-    )
-    b = SourceIdentity.from_model_config(
-        FakeModelConfig(quant_config=FakeQuantConfig(quant_algo="NVFP4"))
-    )
+    a = identity_from(FakeModelConfig(quant_config=FakeQuantConfig(quant_algo="FP8")))
+    b = identity_from(FakeModelConfig(quant_config=FakeQuantConfig(quant_algo="NVFP4")))
     result = a.matches(b)
     assert not result.matched
     assert "quant_fingerprint" in result.mismatched_fields
 
 
 def test_quant_model_dump_uses_python_mode():
-    identity = SourceIdentity.from_model_config(
-        FakeModelConfig(quant_config=FakeQuantConfigWithPythonOnlyField())
-    )
+    identity = identity_from(FakeModelConfig(quant_config=FakeQuantConfigWithPythonOnlyField()))
     assert identity.quant_fingerprint
 
 
 def test_parallel_size_mismatch_flags_global():
-    a = SourceIdentity.from_model_config(FakeModelConfig(mapping=FakeMapping(tp_size=8)))
-    b = SourceIdentity.from_model_config(FakeModelConfig(mapping=FakeMapping(tp_size=4)))
+    a = identity_from(FakeModelConfig(mapping=FakeMapping(tp_size=8)))
+    b = identity_from(FakeModelConfig(mapping=FakeMapping(tp_size=4)))
     result = a.matches(b)
     assert not result.matched
     assert "parallel_fingerprint" in result.mismatched_fields
@@ -111,8 +139,8 @@ def test_parallel_size_mismatch_flags_global():
 
 def test_shard_mismatch_only():
     # Same global layout, different per-rank slice.
-    a = SourceIdentity.from_model_config(FakeModelConfig(mapping=FakeMapping(rank=0, tp_rank=0)))
-    b = SourceIdentity.from_model_config(FakeModelConfig(mapping=FakeMapping(rank=1, tp_rank=1)))
+    a = identity_from(FakeModelConfig(mapping=FakeMapping(rank=0, tp_rank=0)))
+    b = identity_from(FakeModelConfig(mapping=FakeMapping(rank=1, tp_rank=1)))
     result = a.matches(b)
     assert not result.matched
     assert result.mismatched_fields == ["shard_fingerprint"]
@@ -121,57 +149,57 @@ def test_shard_mismatch_only():
 
 
 def test_compare_global_only_ignores_shard():
-    a = SourceIdentity.from_model_config(FakeModelConfig(mapping=FakeMapping(rank=0, tp_rank=0)))
-    b = SourceIdentity.from_model_config(FakeModelConfig(mapping=FakeMapping(rank=1, tp_rank=1)))
+    a = identity_from(FakeModelConfig(mapping=FakeMapping(rank=0, tp_rank=0)))
+    b = identity_from(FakeModelConfig(mapping=FakeMapping(rank=1, tp_rank=1)))
     assert a.matches(b, compare_shard=False).matched
 
 
 def test_enforced_sharing_skips_global():
     # Divergent runs (different model + backend) but enforced sharing trusts
     # the source by skipping the global comparison.
-    a = SourceIdentity.from_model_config(FakeModelConfig(attn_backend="TRTLLM"))
-    b = SourceIdentity.from_model_config(FakeModelConfig(attn_backend="FLASHINFER"))
+    a = identity_from(FakeModelConfig(attn_backend="TRTLLM"))
+    b = identity_from(FakeModelConfig(attn_backend="FLASHINFER"))
     assert a.matches(b, compare_global=False, compare_shard=False).matched
 
 
 def test_serialization_roundtrip():
-    a = SourceIdentity.from_model_config(FakeModelConfig())
+    a = identity_from(FakeModelConfig())
     restored = SourceIdentity.from_json(a.to_json())
     assert restored == a
     assert a.matches(restored).matched
 
 
 def test_check_warn_fallback_on_mismatch():
-    local = SourceIdentity.from_model_config(FakeModelConfig(attn_backend="TRTLLM"))
-    source = SourceIdentity.from_model_config(FakeModelConfig(attn_backend="FLASHINFER"))
+    local = identity_from(FakeModelConfig(attn_backend="TRTLLM"))
+    source = identity_from(FakeModelConfig(attn_backend="FLASHINFER"))
     decision = check_source_identity(local, source, IdentityCheckPolicy.WARN_FALLBACK)
     assert decision.should_share is False
     assert not decision.match_result.matched
 
 
 def test_check_warn_fallback_on_match():
-    local = SourceIdentity.from_model_config(FakeModelConfig())
-    source = SourceIdentity.from_model_config(FakeModelConfig())
+    local = identity_from(FakeModelConfig())
+    source = identity_from(FakeModelConfig())
     decision = check_source_identity(local, source, IdentityCheckPolicy.WARN_FALLBACK)
     assert decision.should_share is True
 
 
 def test_check_strict_raises_on_mismatch():
-    local = SourceIdentity.from_model_config(FakeModelConfig(attn_backend="TRTLLM"))
-    source = SourceIdentity.from_model_config(FakeModelConfig(attn_backend="FLASHINFER"))
+    local = identity_from(FakeModelConfig(attn_backend="TRTLLM"))
+    source = identity_from(FakeModelConfig(attn_backend="FLASHINFER"))
     with pytest.raises(SourceIdentityMismatchError):
         check_source_identity(local, source, IdentityCheckPolicy.STRICT)
 
 
 def test_check_enforce_shares_despite_mismatch():
-    local = SourceIdentity.from_model_config(FakeModelConfig(attn_backend="TRTLLM"))
-    source = SourceIdentity.from_model_config(FakeModelConfig(attn_backend="FLASHINFER"))
+    local = identity_from(FakeModelConfig(attn_backend="TRTLLM"))
+    source = identity_from(FakeModelConfig(attn_backend="FLASHINFER"))
     decision = check_source_identity(local, source, IdentityCheckPolicy.ENFORCE)
     assert decision.should_share is True
 
 
 def test_format_version_mismatch_never_matches():
-    a = SourceIdentity.from_model_config(FakeModelConfig())
+    a = identity_from(FakeModelConfig())
     b = (
         copy.replace(a, format_version=a.format_version + 1)
         if hasattr(copy, "replace")

--- a/tests/unittest/_torch/weight_sharing/test_source_identity.py
+++ b/tests/unittest/_torch/weight_sharing/test_source_identity.py
@@ -184,11 +184,24 @@ def test_check_warn_fallback_on_match():
     assert decision.should_share is True
 
 
+def test_check_warn_fallback_on_missing_identity():
+    source = identity_from(FakeModelConfig())
+    decision = check_source_identity(None, source, IdentityCheckPolicy.WARN_FALLBACK)
+    assert decision.should_share is False
+    assert decision.match_result.mismatched_fields == ["local_identity"]
+
+
 def test_check_strict_raises_on_mismatch():
     local = identity_from(FakeModelConfig(attn_backend="TRTLLM"))
     source = identity_from(FakeModelConfig(attn_backend="FLASHINFER"))
     with pytest.raises(SourceIdentityMismatchError):
         check_source_identity(local, source, IdentityCheckPolicy.STRICT)
+
+
+def test_check_strict_raises_on_missing_source_identity():
+    local = identity_from(FakeModelConfig())
+    with pytest.raises(SourceIdentityMismatchError):
+        check_source_identity(local, None, IdentityCheckPolicy.STRICT)
 
 
 def test_check_enforce_shares_despite_mismatch():

--- a/tests/unittest/_torch/weight_sharing/test_source_identity.py
+++ b/tests/unittest/_torch/weight_sharing/test_source_identity.py
@@ -21,7 +21,13 @@ attributes that the fingerprint projection reads.
 import copy
 
 import pytest
-from _source_identity_fakes import FakeMapping, FakeModelConfig, FakeQuantConfig
+from _source_identity_fakes import (
+    FakeMapping,
+    FakeModelConfig,
+    FakePretrainedConfig,
+    FakeQuantConfig,
+    FakeQuantConfigWithPythonOnlyField,
+)
 
 from tensorrt_llm._torch.weight_sharing import (
     IdentityCheckPolicy,
@@ -54,6 +60,28 @@ def test_backend_mismatch_flags_global():
     assert "backend_fingerprint" in result.mismatched_fields
 
 
+def test_model_layout_field_mismatch_flags_global():
+    a = SourceIdentity.from_model_config(
+        FakeModelConfig(pretrained_config=FakePretrainedConfig(hidden_size=4096))
+    )
+    b = SourceIdentity.from_model_config(
+        FakeModelConfig(pretrained_config=FakePretrainedConfig(hidden_size=8192))
+    )
+    result = a.matches(b)
+    assert not result.matched
+    assert "model_fingerprint" in result.mismatched_fields
+
+
+def test_non_layout_model_metadata_does_not_affect_match():
+    a = SourceIdentity.from_model_config(
+        FakeModelConfig(pretrained_config=FakePretrainedConfig(repository_url="old"))
+    )
+    b = SourceIdentity.from_model_config(
+        FakeModelConfig(pretrained_config=FakePretrainedConfig(repository_url="new"))
+    )
+    assert a.matches(b).matched
+
+
 def test_quant_mismatch_flags_global():
     a = SourceIdentity.from_model_config(
         FakeModelConfig(quant_config=FakeQuantConfig(quant_algo="FP8"))
@@ -64,6 +92,13 @@ def test_quant_mismatch_flags_global():
     result = a.matches(b)
     assert not result.matched
     assert "quant_fingerprint" in result.mismatched_fields
+
+
+def test_quant_model_dump_uses_python_mode():
+    identity = SourceIdentity.from_model_config(
+        FakeModelConfig(quant_config=FakeQuantConfigWithPythonOnlyField())
+    )
+    assert identity.quant_fingerprint
 
 
 def test_parallel_size_mismatch_flags_global():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added weight-sharing compatibility verification system with source identity tracking for distributed weight-loading scenarios (MX checkpoints, GMS storage).
  * Introduces pre-transfer compatibility checks to validate safe weight sharing across configurations before attempting transfers.

* **Tests**
  * Added comprehensive test coverage for weight-sharing compatibility system, identity fingerprinting, matching behavior, and policy enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

This PR introduces a **backend-agnostic `SourceIdentity`** — a serializable, layered fingerprint of every configuration choice that affects how a model's weights are laid out in memory — and wires it into the two weight-sharing receiver paths so a consumer can verify layout compatibility **before** consuming shared weights.

**Motivation.** Weight-sharing receivers (MX peer-to-peer transfer, GMS read-only materialize) currently consume pre-laid-out weights without validating that the producer ("source") and consumer agree on the layout-affecting configuration (model/arch/dtype, quantization, kernel backends/fusion, and parallel layout). A mismatch can silently produce incorrect results. This adds a single, shared compatibility gate.

**What's added (`tensorrt_llm/_torch/weight_sharing/`):**
- `SourceIdentity`: a frozen dataclass split into a **global** fingerprint (model, quant, backend, parallel *sizes* — must match across all ranks) and a **per-rank shard** fingerprint (this rank's TP/PP/EP/CP slice). Built once from `ModelConfig` + `Mapping` via `SourceIdentity.from_model_config(...)`. Fully serializable (`to_dict`/`from_dict`/`to_json`/`from_json`) so a publisher can store it and a receiver can reconstruct it.
- `check_source_identity(local, source, policy)` with three policies:
  - `WARN_FALLBACK` (default): warn and fall back to non-shared loading on mismatch.
  - `STRICT`: raise `SourceIdentityMismatchError` on mismatch.
  - `ENFORCE`: share regardless (caller explicitly trusts the source, e.g. enforced cross-run sharing).
- A `format_version` guard so incompatible fingerprint projections never match.

**Integration points:**
- **`ModelLoader`** (`pyexecutor/model_loader.py`): builds the receiver's local `SourceIdentity` once, early, and threads it through the weight-load path as the single authority for all downstream gates.
- **MX checkpoint loader** (`models/checkpoints/mx/checkpoint_loader.py`): a **pre-transfer P2P gate** — on mismatch it skips the transfer before any RDMA work starts and falls back to disk (no bandwidth/slot/buffer wasted), using `WARN_FALLBACK`.
- **GMS RO path** (`memory/gpu_memory_backend.py`): a **pre-materialize gate** — GMS has no disk-fallback path, so a mismatch raises under `STRICT`.

**Scope / follow-ups.** The publisher-side identity fetch is intentionally stubbed behind single seams (`MXCheckpointLoader._fetch_source_identity`, `GMSBackend.get_source_identity`), both currently returning `None` (gate is inert; existing disk fallback still guards correctness). They are tracked by `SOURCE-IDENTITY/MX-2` and `SOURCE-IDENTITY/GMS`, to be wired once upstream exposes a metadata channel to carry the serialized identity.
This PR is **not** an API change — it adds an internal `_torch` utility and gate logic; no public `LlmArgs`/API signatures change. Runtime behavior is unchanged until the publisher seams are wired, except that an explicit, verifiable mismatch now falls back (MX) or raises (GMS) instead of silently proceeding.

## Test Coverage

New unit tests under `tests/unittest/_torch/weight_sharing/` (mock-based — no real model, GPU, or RDMA; shared fakes in `_source_identity_fakes.py` to avoid duplication):
- `test_source_identity.py` — fingerprint logic: identical-config match; per-field mismatch detection (backend, quant, parallel-size, shard); `compare_global`/`compare_shard` selectivity; enforced sharing skips global; serialization round-trip; all three `check_source_identity` policies; `format_version` mismatch never matches.
- `test_mx_source_identity_gate.py` — drives the real `MXCheckpointLoader._source_identity_compatible` gate: proceeds on match, falls back on mismatch, proceeds when no local identity (legacy callers), proceeds when the publisher identity is unavailable, the fetch seam returns `None` by contract, and `load_weights` consumes the `source_identity` kwarg without leaking it into the disk-fallback signature.


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
