### PR TITLE
feat(autodeploy): implement patch registry context and serialization …

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/export/export.py
+++ b/tensorrt_llm/_torch/auto_deploy/export/export.py
@@ -739,5 +739,36 @@ def torch_export_to_gm(
 
     # show exported graph
     ad_logger.debug("exported graph: " + str(egm))
-
+# === GRAFIA MODEL GRAPH EXPORTER FOR ISSUE #14153 ===
+    if getattr(torch, "_dynamo_grafia_enabled", False):
+        import json
+        ad_logger.info("Extracting computational graph for Grafia integration...")
+        
+        try:
+            grafia_graph = {"nodes": [], "edges": []}
+            
+            # Capture all execution nodes from the fx GraphModule
+            for node in egm.graph.nodes:
+                node_info = {
+                    "id": node.name,
+                    "op": str(node.op),
+                    "target": str(node.target)
+                }
+                grafia_graph["nodes"].append(node_info)
+                
+                # Map tracking dependencies (edges)
+                for user in node.users:
+                    grafia_graph["edges"].append({
+                        "source": node.name,
+                        "target": user.name
+                    })
+                    
+            # Write the payload to disk safely wrapped in exception handling
+            output_json_path = "./autodeploy_grafia_graph.json"
+            with open(output_json_path, "w") as f:
+                json.dump(grafia_graph, f, indent=4)
+            ad_logger.info(f"Grafia execution layout successfully exported to {output_json_path}")
+        except Exception as file_error:
+            # Prevent file I/O errors from cracking or stopping the main core model export
+            ad_logger.warning(f"Grafia graph visualization export skipped due to failure: {file_error}")
     return egm

--- a/tensorrt_llm/_torch/auto_deploy/export/interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/export/interface.py
@@ -292,3 +292,20 @@ def apply_export_patches(
     )
 
     yield from _apply_patches(patches)
+
+# === GRAFIA HOOK FOR ISSUE #14153 ===
+@ExportPatchRegistry.register("grafia_visualizer")
+class GrafiaVisualizerPatch(DisabledBaseExportPatch):
+    """Export patch to enable tracing context for Grafia graph generation."""
+    def _apply_patch(self):
+        import torch
+        # Store original state if it exists, otherwise default to False
+        self.original_values["grafia_enabled"] = getattr(torch, "_dynamo_grafia_enabled", False)
+        torch._dynamo_grafia_enabled = True
+        ad_logger.info("Grafia Visualizer Context Patch Applied.")
+
+    def _revert_patch(self):
+        import torch
+        # Safely restore the original state without breaking other contexts
+        torch._dynamo_grafia_enabled = self.original_values.get("grafia_enabled", False)
+        ad_logger.info("Grafia Visualizer Context Patch Reverted.")


### PR DESCRIPTION
### Description
This Pull Request delivers a fully integrated Proof of Concept (PoC) architecture for the unified **Grafia computational graph visualization pipeline**, actively resolving the open tracking card **#14153**.

### Changes Implemented
* **Export Patch Registration (`interface.py`)**: Registered a decoupled `grafia_visualizer` patch context manager inside the core auto-deploy registry framework, enabling seamless conditional execution triggers.
* **Graph Extraction & Serialization Engine (`export.py`)**: Implemented deep graph introspection hooks right before the functional compiled `GraphModule` exits to translate raw internal FX execution nodes and tracking edges data into a decoupled JSON layout file compatible with Grafia input specifications.

### How to Verify
Inject the runtime patch execution config within your model testing registry config dictionary layout context to verify JSON outputs:
```python
"patch_configs": {
    "grafia_visualizer": {"enabled": True}
}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Grafia graph visualization support to the export process (disabled by default).
  * Export operations now generate a JSON representation of the exported graph structure, including nodes and edges, for visualization purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->