### PR TITLE
[None][fix] Fix host-RAM OOM during MEGAMOE weight load on small-host nodes

### DIFF
--- a/tensorrt_llm/_torch/mmap_utils.py
+++ b/tensorrt_llm/_torch/mmap_utils.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Host-memory ``madvise`` helpers for releasing mmap-backed page cache.
+
+These utilities advise the OS to drop the physical pages backing read-only
+mmap regions (e.g. safetensors shards) so the resident file cache cannot grow
+unbounded during weight load on host-memory-constrained nodes. They only emit
+a kernel *hint*: the data is re-faulted on demand and is never corrupted.
+"""
+
+import ctypes
+import mmap
+
+__all__ = [
+    "madvise_range",
+    "pageout_file_backed_regions",
+    "advise_tensor_pageout",
+]
+
+_MADV_DONTNEED = 4
+_MADV_PAGEOUT = 21
+_MADV_ADVICE_BY_MODE = {"dontneed": _MADV_DONTNEED, "pageout": _MADV_PAGEOUT}
+
+
+def madvise_range(addr: int, size: int, mode: str = "dontneed") -> None:
+    """Issue ``madvise(addr, size, advice)`` over a page-aligned address range.
+
+    Low-level shared wrapper around the ``libc.madvise`` syscall. ``addr`` and
+    ``size`` must already be page-aligned -- both mmap regions (from
+    ``/proc/self/maps``) and the clipped tensor ranges computed by
+    ``advise_tensor_pageout`` satisfy this.
+
+    Parameters
+    ----------
+    addr : int
+        Start address of the range.
+    size : int
+        Length of the range in bytes. A non-positive size is a no-op.
+    mode : str, optional
+        "dontneed" -> MADV_DONTNEED (immediate discard, default)
+        "pageout"  -> MADV_PAGEOUT  (asynchronous pageout, Linux 4.5+)
+
+    Raises
+    ------
+    ValueError
+        If an invalid mode is given.
+    OSError
+        If the madvise() syscall fails (errno will be included).
+    """
+    if size <= 0:
+        return
+    try:
+        advice = _MADV_ADVICE_BY_MODE[mode]
+    except KeyError:
+        raise ValueError("mode must be 'pageout' or 'dontneed'.")
+    libc = ctypes.CDLL("libc.so.6", use_errno=True)
+    ret = libc.madvise(ctypes.c_void_p(addr), ctypes.c_size_t(size),
+                       ctypes.c_int(advice))
+    if ret != 0:
+        err = ctypes.get_errno()
+        raise OSError(err, f"madvise() failed with errno={err}")
+
+
+def pageout_file_backed_regions(path_substring: str,
+                                mode: str = "dontneed") -> None:
+    """``madvise`` every mmap region whose backing file path matches a substring.
+
+    Scans ``/proc/self/maps`` and advises ``MADV_DONTNEED`` / ``MADV_PAGEOUT``
+    on each mapped region whose path contains ``path_substring``. Used to bound
+    the resident file-cache of large read-only mmaps (e.g. the safetensors
+    shards) during weight load on host-memory-constrained nodes. mmap regions
+    are always page-aligned, so the raw ``[start, end)`` bounds parsed from the
+    maps file are passed straight to ``madvise_range``. Best-effort: per-region
+    failures are swallowed so a transient unmap cannot abort the caller.
+    """
+    try:
+        maps = open("/proc/self/maps")
+    except OSError:
+        return
+    with maps:
+        for line in maps:
+            if path_substring not in line:
+                continue
+            start_hex, end_hex = line.split()[0].split("-")
+            start = int(start_hex, 16)
+            try:
+                madvise_range(start, int(end_hex, 16) - start, mode)
+            except OSError:
+                pass
+
+
+def advise_tensor_pageout(tensor, mode: str = "dontneed"):
+    """
+    Advise the OS to page out or discard the physical memory pages backing a CPU tensor.
+    This works only for tensors backed by an mmap'ed file or shared memory.
+
+    Parameters
+    ----------
+    tensor : torch.Tensor
+        A CPU tensor (usually created via torch.from_file() or numpy.memmap()).
+    mode : str, optional
+        "pageout"  -> use MADV_PAGEOUT (asynchronous pageout, Linux 4.5+)
+        "dontneed" -> use MADV_DONTNEED (immediate discard)
+
+    Raises
+    ------
+    ValueError
+        If the tensor is not on CPU or an invalid mode is given.
+    OSError
+        If the madvise() syscall fails (errno will be included).
+
+    Notes
+    -----
+    - Works only on Linux systems.
+    - This call only gives a *hint* to the kernel: the OS may decide to ignore it.
+    - Safe to call on mmap-backed tensors (data will be reloaded on next access).
+    - If called on a malloc-based tensor (not mmap), madvise() simply does nothing
+      and returns 0 (success) because the virtual address range is anonymous memory.
+      It does NOT crash or corrupt data.
+    """
+
+    if not tensor.device.type == "cpu":
+        raise ValueError("Only CPU tensors are supported.")
+
+    # Get raw pointer and size in bytes
+    ptr = tensor.data_ptr()
+    nbytes = tensor.numel() * tensor.element_size()
+
+    # Only operate on complete pages within the tensor's memory range
+    # to avoid affecting memory outside the tensor boundaries
+    page_size = mmap.PAGESIZE
+
+    # Round up to the first complete page boundary inside the tensor
+    start_aligned = (ptr + page_size - 1) & ~(page_size - 1)
+
+    # Round down to the last complete page boundary inside the tensor
+    end_aligned = (ptr + nbytes) & ~(page_size - 1)
+
+    # madvise only the complete pages fully inside the tensor's bounds.
+    madvise_range(start_aligned, end_aligned - start_aligned, mode)

--- a/tensorrt_llm/_torch/mmap_utils.py
+++ b/tensorrt_llm/_torch/mmap_utils.py
@@ -66,15 +66,13 @@ def madvise_range(addr: int, size: int, mode: str = "dontneed") -> None:
     except KeyError:
         raise ValueError("mode must be 'pageout' or 'dontneed'.")
     libc = ctypes.CDLL("libc.so.6", use_errno=True)
-    ret = libc.madvise(ctypes.c_void_p(addr), ctypes.c_size_t(size),
-                       ctypes.c_int(advice))
+    ret = libc.madvise(ctypes.c_void_p(addr), ctypes.c_size_t(size), ctypes.c_int(advice))
     if ret != 0:
         err = ctypes.get_errno()
         raise OSError(err, f"madvise() failed with errno={err}")
 
 
-def pageout_file_backed_regions(path_substring: str,
-                                mode: str = "dontneed") -> None:
+def pageout_file_backed_regions(path_substring: str, mode: str = "dontneed") -> None:
     """``madvise`` every mmap region whose backing file path matches a substring.
 
     Scans ``/proc/self/maps`` and advises ``MADV_DONTNEED`` / ``MADV_PAGEOUT``

--- a/tensorrt_llm/_torch/models/checkpoints/base_weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/base_weight_loader.py
@@ -99,7 +99,7 @@ class ConsumableWeightsDict:
                 try:
                     import torch
 
-                    from tensorrt_llm._torch.modules.fused_moe.moe_load_balancer import \
+                    from tensorrt_llm._torch.mmap_utils import \
                         advise_tensor_pageout
                     torch.cuda.synchronize()
                     for k in keys_to_delete:

--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -819,7 +819,32 @@ class DeepseekV4WeightLoader:
                 getattr(module, attr).data.copy_(weights[key][:])
             return True
 
+        # On host-memory-constrained nodes (e.g. cmh GB300: 900 GiB shared by 4
+        # ranks), reading the 805 GiB safetensors during load faults the model
+        # into the file-cache faster than it is reclaimed; 4 ranks' resident
+        # file pages (~205-246 GiB/rank) cross the cgroup limit and OOM-kill the
+        # step. After each MoE layer we MADV_DONTNEED the whole set of
+        # safetensors mmap regions so the resident file-cache cannot accumulate
+        # (read-only mmap -> pages re-faulted on demand, data-safe). Always on:
+        # on large-host nodes it just re-reads a few pages (negligible), on
+        # small-host nodes it is what keeps the load under the cgroup limit.
+
+        def _pageout_safetensors():
+            import ctypes as _ct
+            torch.cuda.synchronize()
+            try:
+                _libc = _ct.CDLL("libc.so.6", use_errno=True)
+                for _ln in open("/proc/self/maps"):
+                    if ".safetensors" in _ln:
+                        _a, _b = _ln.split()[0].split("-")
+                        _libc.madvise(_ct.c_void_p(int(_a, 16)),
+                                      _ct.c_size_t(int(_b, 16) - int(_a, 16)), 4)  # MADV_DONTNEED
+            except Exception:
+                pass
+
         for name, module in tqdm(all_named_modules.items(), desc="Loading weights"):
+            if name.endswith("experts.backend"):
+                _pageout_safetensors()
             if name.startswith("draft_model"):
                 continue
             names = name.split(".")

--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -793,8 +793,8 @@ class DeepseekV4WeightLoader:
         # ConsumableWeightsDict: deletes mmap-backed source tensors right
         # after each module finishes consuming them. Drops the OS page cache
         # pressure on safetensors files during the per-module loop, which is
-        # the dominant host RSS contributor on tight Grace LPDDR nodes (lyris
-        # GB300, 240 GiB) where 4-rank MEGAMOE mnt=16k otherwise blows past
+        # the dominant host RSS contributor on tight Grace LPDDR nodes (GB300,
+        # 240 GiB/rank) where 4-rank MEGAMOE mnt=16k otherwise blows past
         # the host budget. Mirrors DSv3's pattern at modeling_deepseekv3.py.
         can_mark_consumed = hasattr(weights, "mark_consumed")
 
@@ -819,7 +819,7 @@ class DeepseekV4WeightLoader:
                 getattr(module, attr).data.copy_(weights[key][:])
             return True
 
-        # On host-memory-constrained nodes (e.g. cmh GB300: 900 GiB shared by 4
+        # On host-memory-constrained nodes (e.g. GB300: 900 GiB shared by 4
         # ranks), reading the 805 GiB safetensors during load faults the model
         # into the file-cache faster than it is reclaimed; 4 ranks' resident
         # file pages (~205-246 GiB/rank) cross the cgroup limit and OOM-kill the

--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -831,14 +831,16 @@ class DeepseekV4WeightLoader:
 
         def _pageout_safetensors():
             import ctypes as _ct
+
             torch.cuda.synchronize()
             try:
                 _libc = _ct.CDLL("libc.so.6", use_errno=True)
                 for _ln in open("/proc/self/maps"):
                     if ".safetensors" in _ln:
                         _a, _b = _ln.split()[0].split("-")
-                        _libc.madvise(_ct.c_void_p(int(_a, 16)),
-                                      _ct.c_size_t(int(_b, 16) - int(_a, 16)), 4)  # MADV_DONTNEED
+                        _libc.madvise(
+                            _ct.c_void_p(int(_a, 16)), _ct.c_size_t(int(_b, 16) - int(_a, 16)), 4
+                        )  # MADV_DONTNEED
             except Exception:
                 pass
 

--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -830,19 +830,13 @@ class DeepseekV4WeightLoader:
         # small-host nodes it is what keeps the load under the cgroup limit.
 
         def _pageout_safetensors():
-            import ctypes as _ct
+            # Local import mirrors base_weight_loader's madvise call site and
+            # avoids importing the MoE load balancer at module import time.
+            from ..modules.fused_moe.moe_load_balancer import \
+                pageout_file_backed_regions
 
             torch.cuda.synchronize()
-            try:
-                _libc = _ct.CDLL("libc.so.6", use_errno=True)
-                for _ln in open("/proc/self/maps"):
-                    if ".safetensors" in _ln:
-                        _a, _b = _ln.split()[0].split("-")
-                        _libc.madvise(
-                            _ct.c_void_p(int(_a, 16)), _ct.c_size_t(int(_b, 16) - int(_a, 16)), 4
-                        )  # MADV_DONTNEED
-            except Exception:
-                pass
+            pageout_file_backed_regions(".safetensors", mode="dontneed")
 
         for name, module in tqdm(all_named_modules.items(), desc="Loading weights"):
             if name.endswith("experts.backend"):

--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -830,10 +830,7 @@ class DeepseekV4WeightLoader:
         # small-host nodes it is what keeps the load under the cgroup limit.
 
         def _pageout_safetensors():
-            # Local import mirrors base_weight_loader's madvise call site and
-            # avoids importing the MoE load balancer at module import time.
-            from ..modules.fused_moe.moe_load_balancer import \
-                pageout_file_backed_regions
+            from ..mmap_utils import pageout_file_backed_regions
 
             torch.cuda.synchronize()
             pageout_file_backed_regions(".safetensors", mode="dontneed")

--- a/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py
@@ -590,31 +590,6 @@ class MegaMoEDeepGemm(MoE):
     def create_weights(self):
         if self._weights_created:
             return
-        # The DG NVLink SymmBuffer is allocated in ``post_load_weights`` rather
-        # than here. Two reasons make deferral the only safe option:
-        #
-        # 1. EPLB sizing: ConfigurableMoE syncs the EPLB-derived attributes
-        #    (``num_slots``, ``expert_size_per_partition``, ...) onto the
-        #    backend AFTER ``__init__`` returns. Sizing the SymmBuffer any
-        #    earlier would use the placeholder ``num_slots = num_experts`` and
-        #    break EPLB at forward time (DeepGEMM asserts ``num_experts ==
-        #    num_experts_per_rank * num_ranks`` in ``mega.hpp``).
-        #
-        # 2. MetaInitMode: the rendezvous (``symm_mem.rendezvous`` + EP
-        #    ``barrier`` inside ``get_symm_buffer_for_mega_moe``) is a real
-        #    collective. ``create_weights`` runs under ``MetaInitMode`` on the
-        #    fast meta-init path, where a ``c10d.barrier`` on a meta tensor
-        #    raises ``MetaInitException`` — aborting meta-init and forcing the
-        #    slow regular-init fallback that materializes every weight on host
-        #    RAM, OOM-killing small-host nodes (e.g. GB300, ~900 GiB/node).
-        #
-        # ``post_load_weights`` runs in the same build-time lockstep window on
-        # every EP rank, after MetaInitMode has exited and before any forward /
-        # CUDA-graph capture, so deferring there unconditionally keeps the
-        # rendezvous safety invariant intact while sidestepping both hazards.
-        # Same unconditional-deferral idiom as the vision/sound encoders in
-        # ``modeling_nemotron_nano.py`` (constructed in ``load_weights``,
-        # outside MetaInitMode; see ``NemotronH_Nano_VL_V2.load_weights``).
         self.quant_method = self._get_quant_method()
         self.quant_method.create_weights(self)
         self._weights_created = True
@@ -627,13 +602,24 @@ class MegaMoEDeepGemm(MoE):
     def post_load_weights(self) -> None:
         if self.quant_method is None:
             self.create_weights()
-        # Allocate the SymmBuffer and run its EP rendezvous now -- this is the
-        # sole allocation site (``create_weights`` deliberately defers it; see
-        # that method for the EPLB-sizing and MetaInitMode rationale). The model
-        # loader invokes this hook for every module in deterministic order on
-        # all EP ranks (lockstep), after MetaInitMode has exited and before
-        # forward / CUDA-graph capture. Idempotent — a no-op once the buffer
-        # exists.
+        # Allocate the DG NVLink SymmBuffer and run its EP rendezvous here
+        # rather than in create_weights, for two reasons:
+        #   1. EPLB sizing: ConfigurableMoE syncs the EPLB-derived attributes
+        #      (num_slots, expert_size_per_partition, ...) onto the backend only
+        #      after __init__. Sizing the buffer earlier would use the
+        #      placeholder num_slots = num_experts and break EPLB at forward
+        #      time (DeepGEMM asserts num_experts == num_experts_per_rank *
+        #      num_ranks in mega.hpp).
+        #   2. MetaInitMode: the rendezvous (symm_mem.rendezvous + EP barrier
+        #      inside get_symm_buffer_for_mega_moe) is a real collective, but
+        #      create_weights runs under MetaInitMode where a c10d.barrier on a
+        #      meta tensor raises MetaInitException — aborting meta-init and
+        #      forcing the slow regular-init fallback that materializes every
+        #      weight on host RAM and OOM-kills small-host nodes (e.g. GB300,
+        #      ~900 GiB/node).
+        # The loader invokes this hook for every module in deterministic order
+        # on all EP ranks (lockstep), after MetaInitMode has exited and before
+        # forward / CUDA-graph capture. Idempotent — a no-op once allocated.
         self._alloc_symm_buffer()
         self.quant_method.post_load_weights(self)
 

--- a/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py
@@ -53,6 +53,23 @@ __all__ = ["MegaMoEDeepGemm"]
 # a key would race on the same scratch buffers.
 _MEGA_MOE_SYMM_BUFFER_CACHE: Dict[tuple, object] = {}
 
+
+def _under_meta_init() -> bool:
+    """Return ``True`` iff we are inside a ``MetaInitMode`` dispatch context.
+
+    ``MetaInitMode`` (``tensorrt_llm._torch.models.modeling_utils``) redirects
+    ``aten.empty`` allocations to the ``meta`` device during lazy, no-alloc
+    model construction. A throwaway ``torch.empty`` therefore lands on ``meta``
+    iff the mode is active — a dependency-free probe that needs no import of
+    the (otherwise circularly-imported) ``MetaInitMode`` class.
+
+    Used to defer the SymmBuffer EP rendezvous out of ``create_weights`` (which
+    runs under MetaInitMode) into ``post_load_weights`` (which does not); see
+    ``MegaMoEDeepGemm.create_weights`` for the rationale.
+    """
+    return torch.empty(0).device.type == "meta"
+
+
 # ---- Fused MXFP8 per-token quant backends --------------------------------
 # We want: BF16 (m, H) → FP8 E4M3 (m, H) + packed-UE8M0 SF (m, H/32/4) int32.
 # Three candidates, in preference order:
@@ -602,7 +619,20 @@ class MegaMoEDeepGemm(MoE):
         # ``init_load_balancer=True`` path that runs ``create_weights``
         # from ``__init__``) reach this point on every EP rank in
         # lockstep, preserving the rendezvous safety invariant.
-        self._alloc_symm_buffer()
+        #
+        # BUT the rendezvous (``symm_mem.rendezvous`` + EP ``barrier`` inside
+        # ``get_symm_buffer_for_mega_moe``) is a real collective and MUST NOT
+        # run under ``MetaInitMode``: a ``c10d.barrier`` on a meta tensor
+        # raises ``MetaInitException``, which aborts the whole model's
+        # meta-init and forces the slow regular-init fallback — every weight is
+        # then materialized on host RAM, OOM-killing small-host nodes (e.g. cmh
+        # GB300, ~900 GiB/node). When constructed lazily under MetaInitMode we
+        # defer the rendezvous to ``post_load_weights`` (same build-time
+        # lockstep window, after MetaInitMode has exited and before any forward
+        # / CUDA-graph capture). Same deferral idiom as the vision/sound
+        # encoders in ``modeling_nemotron_nano.py``.
+        if not _under_meta_init():
+            self._alloc_symm_buffer()
         self.quant_method = self._get_quant_method()
         self.quant_method.create_weights(self)
         self._weights_created = True
@@ -615,6 +645,14 @@ class MegaMoEDeepGemm(MoE):
     def post_load_weights(self) -> None:
         if self.quant_method is None:
             self.create_weights()
+        # Perform the SymmBuffer EP rendezvous now if ``create_weights``
+        # deferred it because it ran under ``MetaInitMode``. The model loader
+        # invokes this hook for every module in deterministic order on all EP
+        # ranks (lockstep), after MetaInitMode has exited and before forward /
+        # CUDA-graph capture. Idempotent — a no-op once the buffer exists (e.g.
+        # the standalone ``init_load_balancer`` path that allocated it from
+        # ``__init__`` outside MetaInitMode).
+        self._alloc_symm_buffer()
         self.quant_method.post_load_weights(self)
 
     # ------------------------------------------------------------------

--- a/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py
@@ -54,22 +54,6 @@ __all__ = ["MegaMoEDeepGemm"]
 _MEGA_MOE_SYMM_BUFFER_CACHE: Dict[tuple, object] = {}
 
 
-def _under_meta_init() -> bool:
-    """Return ``True`` iff we are inside a ``MetaInitMode`` dispatch context.
-
-    ``MetaInitMode`` (``tensorrt_llm._torch.models.modeling_utils``) redirects
-    ``aten.empty`` allocations to the ``meta`` device during lazy, no-alloc
-    model construction. A throwaway ``torch.empty`` therefore lands on ``meta``
-    iff the mode is active — a dependency-free probe that needs no import of
-    the (otherwise circularly-imported) ``MetaInitMode`` class.
-
-    Used to defer the SymmBuffer EP rendezvous out of ``create_weights`` (which
-    runs under MetaInitMode) into ``post_load_weights`` (which does not); see
-    ``MegaMoEDeepGemm.create_weights`` for the rationale.
-    """
-    return torch.empty(0).device.type == "meta"
-
-
 # ---- Fused MXFP8 per-token quant backends --------------------------------
 # We want: BF16 (m, H) → FP8 E4M3 (m, H) + packed-UE8M0 SF (m, H/32/4) int32.
 # Three candidates, in preference order:
@@ -606,33 +590,31 @@ class MegaMoEDeepGemm(MoE):
     def create_weights(self):
         if self._weights_created:
             return
-        # Allocate the DG NVLink SymmBuffer here (lazily) rather than from
-        # ``__init__`` because ConfigurableMoE only syncs the EPLB-derived
-        # attributes (``num_slots``, ``expert_size_per_partition``, ...)
-        # onto the backend AFTER backend ``__init__`` returns, just before
-        # calling ``backend.create_weights()``. Sizing the SymmBuffer in
-        # ``__init__`` would therefore use the placeholder
-        # ``num_slots = num_experts`` and break EPLB at forward time
-        # (DeepGEMM asserts ``num_experts == num_experts_per_rank *
-        # num_ranks`` in ``mega.hpp``). Both call sites (the
-        # ConfigurableMoE-driven path and the standalone
-        # ``init_load_balancer=True`` path that runs ``create_weights``
-        # from ``__init__``) reach this point on every EP rank in
-        # lockstep, preserving the rendezvous safety invariant.
+        # The DG NVLink SymmBuffer is allocated in ``post_load_weights`` rather
+        # than here. Two reasons make deferral the only safe option:
         #
-        # BUT the rendezvous (``symm_mem.rendezvous`` + EP ``barrier`` inside
-        # ``get_symm_buffer_for_mega_moe``) is a real collective and MUST NOT
-        # run under ``MetaInitMode``: a ``c10d.barrier`` on a meta tensor
-        # raises ``MetaInitException``, which aborts the whole model's
-        # meta-init and forces the slow regular-init fallback — every weight is
-        # then materialized on host RAM, OOM-killing small-host nodes (e.g. cmh
-        # GB300, ~900 GiB/node). When constructed lazily under MetaInitMode we
-        # defer the rendezvous to ``post_load_weights`` (same build-time
-        # lockstep window, after MetaInitMode has exited and before any forward
-        # / CUDA-graph capture). Same deferral idiom as the vision/sound
-        # encoders in ``modeling_nemotron_nano.py``.
-        if not _under_meta_init():
-            self._alloc_symm_buffer()
+        # 1. EPLB sizing: ConfigurableMoE syncs the EPLB-derived attributes
+        #    (``num_slots``, ``expert_size_per_partition``, ...) onto the
+        #    backend AFTER ``__init__`` returns. Sizing the SymmBuffer any
+        #    earlier would use the placeholder ``num_slots = num_experts`` and
+        #    break EPLB at forward time (DeepGEMM asserts ``num_experts ==
+        #    num_experts_per_rank * num_ranks`` in ``mega.hpp``).
+        #
+        # 2. MetaInitMode: the rendezvous (``symm_mem.rendezvous`` + EP
+        #    ``barrier`` inside ``get_symm_buffer_for_mega_moe``) is a real
+        #    collective. ``create_weights`` runs under ``MetaInitMode`` on the
+        #    fast meta-init path, where a ``c10d.barrier`` on a meta tensor
+        #    raises ``MetaInitException`` — aborting meta-init and forcing the
+        #    slow regular-init fallback that materializes every weight on host
+        #    RAM, OOM-killing small-host nodes (e.g. cmh GB300, ~900 GiB/node).
+        #
+        # ``post_load_weights`` runs in the same build-time lockstep window on
+        # every EP rank, after MetaInitMode has exited and before any forward /
+        # CUDA-graph capture, so deferring there unconditionally keeps the
+        # rendezvous safety invariant intact while sidestepping both hazards.
+        # Same unconditional-deferral idiom as the vision/sound encoders in
+        # ``modeling_nemotron_nano.py`` (constructed in ``load_weights``,
+        # outside MetaInitMode; see ``NemotronH_Nano_VL_V2.load_weights``).
         self.quant_method = self._get_quant_method()
         self.quant_method.create_weights(self)
         self._weights_created = True
@@ -645,13 +627,13 @@ class MegaMoEDeepGemm(MoE):
     def post_load_weights(self) -> None:
         if self.quant_method is None:
             self.create_weights()
-        # Perform the SymmBuffer EP rendezvous now if ``create_weights``
-        # deferred it because it ran under ``MetaInitMode``. The model loader
-        # invokes this hook for every module in deterministic order on all EP
-        # ranks (lockstep), after MetaInitMode has exited and before forward /
-        # CUDA-graph capture. Idempotent — a no-op once the buffer exists (e.g.
-        # the standalone ``init_load_balancer`` path that allocated it from
-        # ``__init__`` outside MetaInitMode).
+        # Allocate the SymmBuffer and run its EP rendezvous now -- this is the
+        # sole allocation site (``create_weights`` deliberately defers it; see
+        # that method for the EPLB-sizing and MetaInitMode rationale). The model
+        # loader invokes this hook for every module in deterministic order on
+        # all EP ranks (lockstep), after MetaInitMode has exited and before
+        # forward / CUDA-graph capture. Idempotent — a no-op once the buffer
+        # exists.
         self._alloc_symm_buffer()
         self.quant_method.post_load_weights(self)
 
@@ -697,9 +679,9 @@ class MegaMoEDeepGemm(MoE):
         dg = self._dg
         buf = self._symm_buffer
         assert buf is not None, (
-            "MegaMoE SymmBuffer not allocated — _alloc_symm_buffer should "
-            "run unconditionally in __init__; check for a subclass that "
-            "skipped the parent constructor."
+            "MegaMoE SymmBuffer not allocated — _alloc_symm_buffer runs in "
+            "post_load_weights; ensure the model loader's post_load_weights "
+            "pass ran before forward (and was not skipped by _weights_removed)."
         )
         num_tokens = x.shape[0]
         assert num_tokens <= self.max_num_tokens, (

--- a/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py
@@ -606,7 +606,7 @@ class MegaMoEDeepGemm(MoE):
         #    fast meta-init path, where a ``c10d.barrier`` on a meta tensor
         #    raises ``MetaInitException`` — aborting meta-init and forcing the
         #    slow regular-init fallback that materializes every weight on host
-        #    RAM, OOM-killing small-host nodes (e.g. cmh GB300, ~900 GiB/node).
+        #    RAM, OOM-killing small-host nodes (e.g. GB300, ~900 GiB/node).
         #
         # ``post_load_weights`` runs in the same build-time lockstep window on
         # every EP rank, after MetaInitMode has exited and before any forward /

--- a/tensorrt_llm/_torch/modules/fused_moe/moe_load_balancer.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/moe_load_balancer.py
@@ -20,6 +20,77 @@ from ...distributed import AllReduce
 from ...utils import EventType
 from ..multi_stream_utils import do_multi_stream
 
+_MADV_DONTNEED = 4
+_MADV_PAGEOUT = 21
+_MADV_ADVICE_BY_MODE = {"dontneed": _MADV_DONTNEED, "pageout": _MADV_PAGEOUT}
+
+
+def madvise_range(addr: int, size: int, mode: str = "dontneed") -> None:
+    """Issue ``madvise(addr, size, advice)`` over a page-aligned address range.
+
+    Low-level shared wrapper around the ``libc.madvise`` syscall. ``addr`` and
+    ``size`` must already be page-aligned -- both mmap regions (from
+    ``/proc/self/maps``) and the clipped tensor ranges computed by
+    ``advise_tensor_pageout`` satisfy this.
+
+    Parameters
+    ----------
+    addr : int
+        Start address of the range.
+    size : int
+        Length of the range in bytes. A non-positive size is a no-op.
+    mode : str, optional
+        "dontneed" -> MADV_DONTNEED (immediate discard, default)
+        "pageout"  -> MADV_PAGEOUT  (asynchronous pageout, Linux 4.5+)
+
+    Raises
+    ------
+    ValueError
+        If an invalid mode is given.
+    OSError
+        If the madvise() syscall fails (errno will be included).
+    """
+    if size <= 0:
+        return
+    try:
+        advice = _MADV_ADVICE_BY_MODE[mode]
+    except KeyError:
+        raise ValueError("mode must be 'pageout' or 'dontneed'.")
+    libc = ctypes.CDLL("libc.so.6", use_errno=True)
+    ret = libc.madvise(ctypes.c_void_p(addr), ctypes.c_size_t(size),
+                       ctypes.c_int(advice))
+    if ret != 0:
+        err = ctypes.get_errno()
+        raise OSError(err, f"madvise() failed with errno={err}")
+
+
+def pageout_file_backed_regions(path_substring: str,
+                                mode: str = "dontneed") -> None:
+    """``madvise`` every mmap region whose backing file path matches a substring.
+
+    Scans ``/proc/self/maps`` and advises ``MADV_DONTNEED`` / ``MADV_PAGEOUT``
+    on each mapped region whose path contains ``path_substring``. Used to bound
+    the resident file-cache of large read-only mmaps (e.g. the safetensors
+    shards) during weight load on host-memory-constrained nodes. mmap regions
+    are always page-aligned, so the raw ``[start, end)`` bounds parsed from the
+    maps file are passed straight to ``madvise_range``. Best-effort: per-region
+    failures are swallowed so a transient unmap cannot abort the caller.
+    """
+    try:
+        maps = open("/proc/self/maps")
+    except OSError:
+        return
+    with maps:
+        for line in maps:
+            if path_substring not in line:
+                continue
+            start_hex, end_hex = line.split()[0].split("-")
+            start = int(start_hex, 16)
+            try:
+                madvise_range(start, int(end_hex, 16) - start, mode)
+            except OSError:
+                pass
+
 
 def advise_tensor_pageout(tensor, mode: str = "dontneed"):
     """
@@ -51,10 +122,6 @@ def advise_tensor_pageout(tensor, mode: str = "dontneed"):
       It does NOT crash or corrupt data.
     """
 
-    libc = ctypes.CDLL("libc.so.6", use_errno=True)
-    MADV_PAGEOUT = 21
-    MADV_DONTNEED = 4
-
     if not tensor.device.type == "cpu":
         raise ValueError("Only CPU tensors are supported.")
 
@@ -70,30 +137,10 @@ def advise_tensor_pageout(tensor, mode: str = "dontneed"):
     start_aligned = (ptr + page_size - 1) & ~(page_size - 1)
 
     # Round down to the last complete page boundary inside the tensor
-    end_ptr = ptr + nbytes
-    end_aligned = end_ptr & ~(page_size - 1)
+    end_aligned = (ptr + nbytes) & ~(page_size - 1)
 
-    # Calculate the size of complete pages within the tensor
-    size = end_aligned - start_aligned
-
-    # If there are no complete pages within the tensor, skip madvise
-    if size <= 0:
-        return
-
-    # Choose advice mode
-    if mode == "pageout":
-        advice = MADV_PAGEOUT
-    elif mode == "dontneed":
-        advice = MADV_DONTNEED
-    else:
-        raise ValueError("mode must be 'pageout' or 'dontneed'.")
-
-    # Perform madvise() only on complete pages within the tensor
-    ret = libc.madvise(ctypes.c_void_p(start_aligned), ctypes.c_size_t(size),
-                       ctypes.c_int(advice))
-    if ret != 0:
-        err = ctypes.get_errno()
-        raise OSError(err, f"madvise() failed with errno={err}")
+    # madvise only the complete pages fully inside the tensor's bounds.
+    madvise_range(start_aligned, end_aligned - start_aligned, mode)
 
 
 def _tensor_to_weight(t: torch.Tensor) -> _tbr.MoeWeight:

--- a/tensorrt_llm/_torch/modules/fused_moe/moe_load_balancer.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/moe_load_balancer.py
@@ -1,6 +1,4 @@
-import ctypes
 import gc
-import mmap
 import os
 import threading
 from contextlib import nullcontext
@@ -17,130 +15,9 @@ from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
 from ...distributed import AllReduce
+from ...mmap_utils import advise_tensor_pageout
 from ...utils import EventType
 from ..multi_stream_utils import do_multi_stream
-
-_MADV_DONTNEED = 4
-_MADV_PAGEOUT = 21
-_MADV_ADVICE_BY_MODE = {"dontneed": _MADV_DONTNEED, "pageout": _MADV_PAGEOUT}
-
-
-def madvise_range(addr: int, size: int, mode: str = "dontneed") -> None:
-    """Issue ``madvise(addr, size, advice)`` over a page-aligned address range.
-
-    Low-level shared wrapper around the ``libc.madvise`` syscall. ``addr`` and
-    ``size`` must already be page-aligned -- both mmap regions (from
-    ``/proc/self/maps``) and the clipped tensor ranges computed by
-    ``advise_tensor_pageout`` satisfy this.
-
-    Parameters
-    ----------
-    addr : int
-        Start address of the range.
-    size : int
-        Length of the range in bytes. A non-positive size is a no-op.
-    mode : str, optional
-        "dontneed" -> MADV_DONTNEED (immediate discard, default)
-        "pageout"  -> MADV_PAGEOUT  (asynchronous pageout, Linux 4.5+)
-
-    Raises
-    ------
-    ValueError
-        If an invalid mode is given.
-    OSError
-        If the madvise() syscall fails (errno will be included).
-    """
-    if size <= 0:
-        return
-    try:
-        advice = _MADV_ADVICE_BY_MODE[mode]
-    except KeyError:
-        raise ValueError("mode must be 'pageout' or 'dontneed'.")
-    libc = ctypes.CDLL("libc.so.6", use_errno=True)
-    ret = libc.madvise(ctypes.c_void_p(addr), ctypes.c_size_t(size),
-                       ctypes.c_int(advice))
-    if ret != 0:
-        err = ctypes.get_errno()
-        raise OSError(err, f"madvise() failed with errno={err}")
-
-
-def pageout_file_backed_regions(path_substring: str,
-                                mode: str = "dontneed") -> None:
-    """``madvise`` every mmap region whose backing file path matches a substring.
-
-    Scans ``/proc/self/maps`` and advises ``MADV_DONTNEED`` / ``MADV_PAGEOUT``
-    on each mapped region whose path contains ``path_substring``. Used to bound
-    the resident file-cache of large read-only mmaps (e.g. the safetensors
-    shards) during weight load on host-memory-constrained nodes. mmap regions
-    are always page-aligned, so the raw ``[start, end)`` bounds parsed from the
-    maps file are passed straight to ``madvise_range``. Best-effort: per-region
-    failures are swallowed so a transient unmap cannot abort the caller.
-    """
-    try:
-        maps = open("/proc/self/maps")
-    except OSError:
-        return
-    with maps:
-        for line in maps:
-            if path_substring not in line:
-                continue
-            start_hex, end_hex = line.split()[0].split("-")
-            start = int(start_hex, 16)
-            try:
-                madvise_range(start, int(end_hex, 16) - start, mode)
-            except OSError:
-                pass
-
-
-def advise_tensor_pageout(tensor, mode: str = "dontneed"):
-    """
-    Advise the OS to page out or discard the physical memory pages backing a CPU tensor.
-    This works only for tensors backed by an mmap'ed file or shared memory.
-
-    Parameters
-    ----------
-    tensor : torch.Tensor
-        A CPU tensor (usually created via torch.from_file() or numpy.memmap()).
-    mode : str, optional
-        "pageout"  -> use MADV_PAGEOUT (asynchronous pageout, Linux 4.5+)
-        "dontneed" -> use MADV_DONTNEED (immediate discard)
-
-    Raises
-    ------
-    ValueError
-        If the tensor is not on CPU or an invalid mode is given.
-    OSError
-        If the madvise() syscall fails (errno will be included).
-
-    Notes
-    -----
-    - Works only on Linux systems.
-    - This call only gives a *hint* to the kernel: the OS may decide to ignore it.
-    - Safe to call on mmap-backed tensors (data will be reloaded on next access).
-    - If called on a malloc-based tensor (not mmap), madvise() simply does nothing
-      and returns 0 (success) because the virtual address range is anonymous memory.
-      It does NOT crash or corrupt data.
-    """
-
-    if not tensor.device.type == "cpu":
-        raise ValueError("Only CPU tensors are supported.")
-
-    # Get raw pointer and size in bytes
-    ptr = tensor.data_ptr()
-    nbytes = tensor.numel() * tensor.element_size()
-
-    # Only operate on complete pages within the tensor's memory range
-    # to avoid affecting memory outside the tensor boundaries
-    page_size = mmap.PAGESIZE
-
-    # Round up to the first complete page boundary inside the tensor
-    start_aligned = (ptr + page_size - 1) & ~(page_size - 1)
-
-    # Round down to the last complete page boundary inside the tensor
-    end_aligned = (ptr + nbytes) & ~(page_size - 1)
-
-    # madvise only the complete pages fully inside the tensor's bounds.
-    madvise_range(start_aligned, end_aligned - start_aligned, mode)
 
 
 def _tensor_to_weight(t: torch.Tensor) -> _tbr.MoeWeight:

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -34,11 +34,11 @@ from tensorrt_llm.quantization.utils.fp4_utils import (
 from tensorrt_llm.quantization.utils.fp8_utils import (
     resmooth_to_fp8_e8m0, transform_sf_into_required_layout)
 
+from ...mmap_utils import advise_tensor_pageout
 from ...utils import (ActivationType, replace_parameter_and_save_metadata,
                       swizzle_sf, unswizzle_sf)
 from ..linear import TensorParallelMode, load_weight_shard
 from .interface import MoEWeightLoadingMode
-from .moe_load_balancer import advise_tensor_pageout
 
 # The declarations aligns with moe_kernels.h
 # pack inputs into int64, e.g. 4 x bf16 input values


### PR DESCRIPTION
## Problem

DeepSeek-V4-Pro with the `MEGAMOE_DEEPGEMM` MoE backend OOMs the **host** during weight load on memory-constrained nodes (e.g. GB300: ~900 GiB host shared by 4 ranks, tp4/ep4). There are two independent host-RAM issues, in two different phases — each alone still OOMs (verified), so both fixes are needed:

1. **Model construction.** `MegaMoEDeepGemm.create_weights()` runs the DeepGEMM SymmBuffer rendezvous (`symm_mem.rendezvous` + `c10d.barrier`, inside `get_symm_buffer_for_mega_moe`). Under `MetaInitMode` the barrier touches a meta tensor → `MetaInitException` → meta-init is aborted for the whole model and it falls back to regular init, materializing ~221 GiB/rank on host → OOM (~3.5 min in).

2. **Weight load.** Reading the safetensors mmap faults file pages into the page cache faster than they are reclaimed; 4 ranks × ~205–246 GiB resident crosses the cgroup limit → OOM (~5.7 min in). The per-tensor `MADV_DONTNEED` already in `ConsumableWeightsDict.mark_consumed` isn't aggressive enough against the interleaved per-expert read pattern.

## Fixes

- **`mega_moe_deepgemm.py`** — defer the SymmBuffer rendezvous out of `create_weights` (which runs under `MetaInitMode`) into `post_load_weights` (same build-time, all-EP-rank lockstep window, after MetaInitMode has exited). Keeps meta-init alive so weights stream straight to GPU. Idempotent → the standalone `init_load_balancer` path is unaffected. Mirrors the deferral idiom used by the vision/sound encoders in `modeling_nemotron_nano.py`.
- **`modeling_deepseekv4.py`** — after each MoE layer in `DeepseekV4WeightLoader.load_weights`, `MADV_DONTNEED` the full set of `.safetensors` mmap regions so resident file cache can't accumulate. The mappings are read-only, so dropped pages are simply re-faulted on demand (data-safe).

## Validation (GB300, single node, 4 ranks, tp4/ep4, offline EPLB, ISL 8192 / OSL 1)

| | before | after |
|---|---|---|
| result | OOM | COMPLETED |
| MaxRSS / rank | 246 GiB | ~103 GiB |
| host-anon peak | climbs to 217 GiB | plateaus ~9.7 GiB |
| CTX throughput | — | ~64,200 tok/s (reproducible across runs) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
