### PR TITLE
[TRTLLM-12507][feat] Cudagraph support for per-expert lora in Cutlass backend - Part 2

### DIFF
--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/include/moe_lora_device_path.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/include/moe_lora_device_path.h
@@ -33,13 +33,27 @@ struct MoeLoraDevicePathModule;
 
 // Function-pointer dispatch for the libtorch-dependent GEMM stage of the MoE
 // LoRA device path. The implementation lives in th_common (moeOp.cpp) because
-// the cudaGraph(SplitK)GroupedGemm wrappers allocate workspace via at::Tensor,
-// which cannot be linked from libmoe_gemm_src.a (that archive is also linked
-// into the TensorRT plugin, which must not depend on libtorch).
+// the underlying cudaGraph(SplitK)GroupedGemm wrappers allocate workspace via
+// at::Tensor, which is not linkable from libmoe_gemm_src.a (that archive ends
+// up inside the TensorRT plugin shared object, which deliberately does not
+// depend on libtorch).
 //
-// It repacks mod into a MoeLoraGemmGroupArrays, runs the problem builder, and
-// dispatches the in/out GEMMs, accumulating into output_base (which the caller
-// must initialize). data_type is the scalar dtype (fp16/bf16/fp32).
+// Contract:
+//   mod:                 per-module device-resident scratch produced by
+//                        launchMoeLoraPointerExpand. The implementation repacks
+//                        it into a MoeLoraGemmGroupArrays, calls the problem
+//                        builder, and dispatches the in/out GEMMs.
+//   num_permuted_tokens: length of the permuted-row tables in mod.
+//   in_hidden_size:      K of the in-GEMM (the input row stride).
+//   max_lora_rank:       workspace ldd and worst-case rank cap.
+//   dtype_bytes:         sizeof(scalar) for the LoRA tensors.
+//   splitk_slices:       split-K factor for the in-GEMM.
+//   input_base:          base of the input matrix (M rows of in_hidden_size).
+//   output_base:         base of the module's output buffer; the implementation
+//                        accumulates into it, so callers must initialize it.
+//   data_type:           scalar dtype expected by the GEMM wrappers
+//                        (fp16/bf16/fp32).
+//   stream:              CUDA stream to launch onto.
 using MoeLoraDeviceRunFn = void (*)(MoeLoraDevicePathModule const& mod, int64_t num_permuted_tokens,
     int64_t in_hidden_size, int64_t max_lora_rank, int64_t dtype_bytes, int64_t splitk_slices, void const* input_base,
     void* output_base, nvinfer1::DataType data_type, cudaStream_t stream);

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/include/moe_lora_slot_expand.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/include/moe_lora_slot_expand.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/common/config.h"
+
+#include <cstdint>
+#include <cuda_runtime.h>
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels::cutlass_kernels
+{
+
+// Device-side description of one LoRA module (fc1, fc2, or gated) for the
+// slot -> per-source-token expansion. All pointers refer to device memory.
+//
+// Inputs (indexed by adapter slot):
+//   slot_ranks: int32 [num_slots], per-slot LoRA rank (0 == slot inactive).
+//   slot_ptrs:  int64 [num_slots * 3], pointer bits laid out as
+//               (A_ptr, B_ptr, dora_ptr) per slot; dora is ignored.
+//
+// Outputs (indexed by source token, sized [num_tokens]):
+//   ranks_out: int32 [num_tokens], per-source-token LoRA rank.
+//   ptrs_out:  int64 [num_tokens * 2], per-source-token (A_ptr, B_ptr).
+//
+// These outputs match the (ranks_src, ptrs_src) inputs that
+// launchMoeLoraPointerExpand consumes, so its results feed directly into the
+// pointer-expand stage.
+struct MoeLoraSlotExpandModule
+{
+    int32_t const* slot_ranks = nullptr;
+    int64_t const* slot_ptrs = nullptr;
+    int32_t* ranks_out = nullptr;
+    int64_t* ptrs_out = nullptr;
+};
+
+// Device-side slot -> per-source-token expansion for routed-expert MoE LoRA.
+// For each source token t in [0, num_tokens), reads slot = token_to_slot[t]
+// and copies the slot's (rank, A_ptr, B_ptr) into the per-token output tables
+// for every module. Runs entirely on the stream with no host synchronization,
+// so it is safe to record into a CUDA graph: replaying it re-reads the
+// (in-place updated) device slot tables and token_to_slot, picking up new
+// adapter assignments without re-capture.
+//
+// token_to_slot: int32 [num_tokens] (device). Entries outside [0, num_slots)
+// are treated as inactive (rank 0, null pointers) rather than indexing out of
+// bounds.
+//
+// gated may be nullptr for non-gated activations; when non-null, the gated
+// module's outputs are produced in the same pass.
+void launchMoeLoraSlotExpand(int32_t const* token_to_slot, int64_t num_tokens, int64_t num_slots,
+    MoeLoraSlotExpandModule const& fc1, MoeLoraSlotExpandModule const& fc2, MoeLoraSlotExpandModule const* gated,
+    cudaStream_t stream);
+
+} // namespace kernels::cutlass_kernels
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_lora_slot_expand.cu
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_lora_slot_expand.cu
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/kernels/cutlass_kernels/include/moe_lora_slot_expand.h"
+
+#include "tensorrt_llm/common/assert.h"
+#include "tensorrt_llm/common/cudaUtils.h"
+
+#include <cstdint>
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels::cutlass_kernels
+{
+
+namespace
+{
+
+// Threads-per-block. The kernel is a small per-token gather (one slot lookup,
+// a handful of stores per module), so block size only affects occupancy. 256
+// is a safe default for the Hopper / Blackwell targets shared with the rest of
+// the MoE path.
+constexpr int kBlockSize = 256;
+
+// Per-module gather. Inlined into the main kernel so a single thread handles
+// fc1, fc2, and (optionally) gated for its token after one slot lookup.
+__device__ inline void slotExpandOneModule(MoeLoraSlotExpandModule const& mod, int64_t t, int32_t slot, bool valid_slot)
+{
+    if (valid_slot)
+    {
+        mod.ranks_out[t] = mod.slot_ranks[slot];
+        mod.ptrs_out[2 * t + 0] = mod.slot_ptrs[3 * slot + 0];
+        mod.ptrs_out[2 * t + 1] = mod.slot_ptrs[3 * slot + 1];
+    }
+    else
+    {
+        // Out-of-range slot: emit an inactive (rank 0, null pointer) entry so the
+        // downstream pointer-expand / grouped-GEMM treats this token as a no-op
+        // instead of indexing out of bounds.
+        mod.ranks_out[t] = 0;
+        mod.ptrs_out[2 * t + 0] = 0;
+        mod.ptrs_out[2 * t + 1] = 0;
+    }
+}
+
+// One thread per source token. Reads its adapter slot from token_to_slot and
+// scatters the slot's (rank, A_ptr, B_ptr) into the per-token output tables for
+// each module.
+__global__ void moeLoraSlotExpandKernel(int32_t const* __restrict__ token_to_slot, int64_t num_tokens,
+    int64_t num_slots, MoeLoraSlotExpandModule fc1, MoeLoraSlotExpandModule fc2, MoeLoraSlotExpandModule gated,
+    bool has_gated)
+{
+    int64_t const t = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (t >= num_tokens)
+    {
+        return;
+    }
+
+    int32_t const slot = token_to_slot[t];
+    bool const valid_slot = (slot >= 0) && (static_cast<int64_t>(slot) < num_slots);
+
+    slotExpandOneModule(fc1, t, slot, valid_slot);
+    slotExpandOneModule(fc2, t, slot, valid_slot);
+    if (has_gated)
+    {
+        slotExpandOneModule(gated, t, slot, valid_slot);
+    }
+}
+
+} // namespace
+
+void launchMoeLoraSlotExpand(int32_t const* token_to_slot, int64_t num_tokens, int64_t num_slots,
+    MoeLoraSlotExpandModule const& fc1, MoeLoraSlotExpandModule const& fc2, MoeLoraSlotExpandModule const* gated,
+    cudaStream_t stream)
+{
+    if (num_tokens <= 0)
+    {
+        return;
+    }
+    TLLM_CHECK_WITH_INFO(token_to_slot != nullptr, "token_to_slot must be non-null");
+    TLLM_CHECK_WITH_INFO(num_slots > 0, "num_slots must be positive");
+    TLLM_CHECK_WITH_INFO(
+        fc1.slot_ranks != nullptr && fc1.slot_ptrs != nullptr && fc1.ranks_out != nullptr && fc1.ptrs_out != nullptr,
+        "fc1 slot-expand module is missing a buffer");
+    TLLM_CHECK_WITH_INFO(
+        fc2.slot_ranks != nullptr && fc2.slot_ptrs != nullptr && fc2.ranks_out != nullptr && fc2.ptrs_out != nullptr,
+        "fc2 slot-expand module is missing a buffer");
+
+    bool const has_gated = gated != nullptr;
+    MoeLoraSlotExpandModule const gated_arg = has_gated ? *gated : MoeLoraSlotExpandModule{};
+
+    int64_t const grid = (num_tokens + kBlockSize - 1) / kBlockSize;
+    moeLoraSlotExpandKernel<<<static_cast<unsigned int>(grid), kBlockSize, 0, stream>>>(
+        token_to_slot, num_tokens, num_slots, fc1, fc2, gated_arg, has_gated);
+    sync_check_cuda_error(stream);
+}
+
+} // namespace kernels::cutlass_kernels
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/thop/moeOp.cpp
+++ b/cpp/tensorrt_llm/thop/moeOp.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,10 +21,12 @@
 #include "moe_kernels.h"
 #endif
 // Always include the public header for moe_gemm_kernels.h
-#include "cutlass/gemm_coord.h"
 #include "tensorrt_llm/kernels/cutlass_kernels/include/moe_gemm_kernels.h"
 #include "tensorrt_llm/kernels/cutlass_kernels/include/moe_lora_device_path.h"
 #include "tensorrt_llm/kernels/cutlass_kernels/include/moe_lora_problem_builder.h"
+#include "tensorrt_llm/kernels/cutlass_kernels/include/moe_lora_slot_expand.h"
+
+#include "cutlass/gemm_coord.h"
 
 #include "tensorrt_llm/common/config.h"
 #include "tensorrt_llm/common/cublasMMWrapper.h"
@@ -76,12 +78,14 @@ enum class MoeLoraRequestType : int32_t
 // ---------------------------------------------------------------------------
 // libtorch-bound implementation of MoeLoraDeviceRunFn.
 //
-// The per-module GEMM dispatch for the device LoRA path: builds the per-token
-// problem descriptors on device via launchMoeLoraProblemBuilder, then
-// dispatches cudaGraph(SplitK)GroupedGemm. The latter allocates workspace via
-// at::Tensor, so this lives in th_common (which links libtorch); moe_kernels.cu
-// reaches it through LoraParams::device_path.run, keeping libmoe_gemm_src.a
-// (and the TensorRT plugin) libtorch-free.
+// This is the per-module GEMM dispatch the device LoRA path uses. It builds the
+// per-token problem descriptors on device via the libtorch-free
+// launchMoeLoraProblemBuilder, then dispatches cudaGraph(SplitK)GroupedGemm.
+// The latter allocates workspace via at::Tensor, so this function must live in
+// th_common, which links libtorch. moe_kernels.cu reaches it indirectly through
+// the function pointer stored in LoraParams::device_path.run; that indirection
+// keeps libmoe_gemm_src.a (also linked into the TensorRT plugin shared object)
+// free of a transitive dependency on libtorch.
 // ---------------------------------------------------------------------------
 inline void moeLoraDeviceRunImpl(::tensorrt_llm::kernels::cutlass_kernels::MoeLoraDevicePathModule const& mod,
     int64_t num_permuted_tokens, int64_t in_hidden_size, int64_t max_lora_rank, int64_t dtype_bytes,
@@ -123,11 +127,14 @@ inline void moeLoraDeviceRunImpl(::tensorrt_llm::kernels::cutlass_kernels::MoeLo
     // wrappers fall back to the smaller-tile family when min(K, N) < kMinKN.
     constexpr int kMinKN = 16;
 
-    ::tensorrt_llm::kernels::cudaGraphSplitKGroupedGemm(arrays.problem_sizes_in, static_cast<int>(num_permuted_tokens),
+    // In-GEMM (low-rank down-projection). Each problem is a single permuted
+    // token (M=1), so split-K over K offers no benefit. Use the plain grouped
+    // GEMM; the split-K grouped GEMM raises an illegal instruction on SM100 when
+    // reused within a process.
+    ::tensorrt_llm::kernels::cudaGraphGroupedGemm(arrays.problem_sizes_in, static_cast<int>(num_permuted_tokens),
         arrays.a_ptrs_in, arrays.b_ptrs_in, arrays.d_ptrs_in, arrays.d_ptrs_in, arrays.lda_in, arrays.ldb_in,
         arrays.ldd_in, arrays.ldd_in,
-        /*isLoraIn=*/true, data_type, static_cast<int>(splitk_slices), kMinKN, host_max_in, arrays.splitk_offsets,
-        stream);
+        /*isLoraIn=*/true, data_type, kMinKN, host_max_in, stream);
     sync_check_cuda_error(stream);
 
     ::tensorrt_llm::kernels::cudaGraphGroupedGemm(arrays.problem_sizes_out, static_cast<int>(num_permuted_tokens),
@@ -319,10 +326,11 @@ public:
         mGemm2Profiles = mKernelRunner->getTactics(MoeGemmId::GEMM_2);
         cuInit(0);
 
-        // Device-LoRA-path opt-in for the per-request schema. Any non-empty
-        // value other than "0"/"OFF"/"off" enables the capture-safe on-device
-        // LoRA path (pointer-expand + problem-builder + grouped-GEMM) instead of
-        // the legacy host-pointer path, matching LORA_USE_UNIFIED_GEMM.
+        // Device-LoRA-path opt-in for the per-request (eager) schema. Any
+        // non-empty value other than "0"/"OFF"/"off" enables it, matching
+        // LORA_USE_UNIFIED_GEMM. The slot-indexed (CUDA-graph) schema always
+        // uses the device path regardless, since the host path is not
+        // capturable (it does a host-side cudaEventSynchronize).
         if (char const* envv = std::getenv("TLLM_MOE_LORA_USE_DEVICE_PATH"))
         {
             std::string val(envv);
@@ -384,7 +392,20 @@ public:
         torch::optional<torch::Tensor> const& gated_lora_ranks = torch::nullopt,
         torch::optional<torch::Tensor> const& gated_lora_weight_ptrs = torch::nullopt,
         torch::optional<torch::Tensor> const& host_request_types = torch::nullopt,
-        torch::optional<torch::Tensor> const& host_context_lengths = torch::nullopt, int64_t lora_max_low_rank = 0)
+        torch::optional<torch::Tensor> const& host_context_lengths = torch::nullopt, int64_t lora_max_low_rank = 0,
+        // Slot-indexed CUDA-graph LoRA inputs (mutually exclusive with the per-request
+        // schema above). When fc1_slot_lora_ranks is provided, the per-token expansion
+        // is performed inside the op via token_to_slot[t] indexed into the slot tables.
+        //   slot_*_ranks       : CPU pinned int32 [max_lora_size]
+        //   slot_*_weight_ptrs : CPU pinned int64 [max_lora_size, 3]  (A, B, dora-ignored)
+        //   token_to_slot      : CPU pinned int32 [>= num_tokens]
+        torch::optional<torch::Tensor> const& fc1_slot_lora_ranks = torch::nullopt,
+        torch::optional<torch::Tensor> const& fc1_slot_lora_weight_ptrs = torch::nullopt,
+        torch::optional<torch::Tensor> const& fc2_slot_lora_ranks = torch::nullopt,
+        torch::optional<torch::Tensor> const& fc2_slot_lora_weight_ptrs = torch::nullopt,
+        torch::optional<torch::Tensor> const& gated_slot_lora_ranks = torch::nullopt,
+        torch::optional<torch::Tensor> const& gated_slot_lora_weight_ptrs = torch::nullopt,
+        torch::optional<torch::Tensor> const& token_to_slot = torch::nullopt)
     {
         std::lock_guard<std::mutex> lock(mMutex);
         // Free the profile workspace to save memory
@@ -558,10 +579,20 @@ public:
 
         // ===== Routed-expert LoRA setup =====
         // LoRA is activated by the per-request schema (fc1_lora_ranks).
-        bool const lora_active = fc1_lora_ranks.has_value();
+        bool const lora_per_request = fc1_lora_ranks.has_value();
+        bool const lora_slot_indexed = fc1_slot_lora_ranks.has_value();
+        bool const lora_active = lora_per_request || lora_slot_indexed;
         bool const is_gated_act = isGatedActivation(base_activation_type);
         if (lora_active)
         {
+            // The per-request and slot-indexed schemas are mutually exclusive:
+            // each drives a different token->adapter expansion inside
+            // buildMoeLoraParams, and supplying both is ambiguous. The Python
+            // wrapper (torch_custom_ops.fused_moe) rejects this too, but the op
+            // is public, so enforce it here as well for direct C++/op callers.
+            TORCH_CHECK(!(lora_per_request && lora_slot_indexed),
+                "MoE LoRA: the per-request (fc1_lora_ranks, ...) and slot-indexed (fc1_slot_lora_ranks, ..., "
+                "token_to_slot) input schemas are mutually exclusive. Provide exactly one, not both.");
             // Conservative rejections (min-latency, alltoall, quant, graph capture).
             TORCH_CHECK(!min_latency_mode, "MoE LoRA is not supported in min-latency mode.");
             TORCH_CHECK(!enable_alltoall,
@@ -571,22 +602,29 @@ public:
                 "MoE LoRA only supports fp16 and bf16 activation dtypes.");
             TORCH_CHECK(mWeightDtype == c10::ScalarType::Half || mWeightDtype == c10::ScalarType::BFloat16,
                 "MoE LoRA only supports unquantized fp16/bf16 expert weights.");
-            // CUDA-graph capture is only safe on the device LoRA path. The legacy
-            // host path performs a host-side cudaEventSynchronize and per-token
-            // pointer expansion in setupLoraWorkspace, plus host-side run-length
-            // encoding in LoraImpl::run, none of which is capturable. The device
-            // path (launchMoeLoraPointerExpand and runMoeLoraDeviceModule in
-            // moe_kernels.cu) runs entirely on the stream and is opted into via
-            // TLLM_MOE_LORA_USE_DEVICE_PATH.
-            TORCH_CHECK(mUseDeviceLoraPath || !tensorrt_llm::common::isCapturing(stream),
+            // CUDA-graph capture is only safe on the device LoRA path. The
+            // legacy host path performs a host-side cudaEventSynchronize and
+            // per-token pointer expansion in setupLoraWorkspace, plus host-side
+            // run-length encoding in LoraImpl::run, none of which is capturable.
+            // The device path (launchMoeLoraPointerExpand and
+            // runMoeLoraDeviceModule in moe_kernels.cu) runs entirely on the
+            // stream. The slot-indexed schema implies the device path (see the
+            // constructor's activation-story comment), so capture is allowed
+            // whenever the device path will be taken: env-var opt-in OR
+            // slot-indexed inputs.
+            bool const use_device_path = mUseDeviceLoraPath || lora_slot_indexed;
+            TORCH_CHECK(use_device_path || !tensorrt_llm::common::isCapturing(stream),
                 "MoE LoRA + CUDA graph capture requires the device LoRA path. The per-request schema runs "
                 "the legacy host path by default, which performs a host-side cudaEventSynchronize after a "
-                "D2H pointer-expansion copy and is not capturable. Set TLLM_MOE_LORA_USE_DEVICE_PATH=1, run "
-                "LoRA eagerly, or disable MoE LoRA when capturing.");
+                "D2H pointer-expansion copy and is not capturable. Use the slot-indexed schema (which always "
+                "takes the device path), set TLLM_MOE_LORA_USE_DEVICE_PATH=1, run LoRA eagerly, or disable "
+                "MoE LoRA when capturing.");
         }
         // Build LoraParams up-front so we can compute the required cuBLAS workspace before allocation.
         auto lora_params_opt = buildMoeLoraParams(fc1_lora_ranks, fc1_lora_weight_ptrs, fc2_lora_ranks,
             fc2_lora_weight_ptrs, gated_lora_ranks, gated_lora_weight_ptrs, host_request_types, host_context_lengths,
+            fc1_slot_lora_ranks, fc1_slot_lora_weight_ptrs, fc2_slot_lora_ranks, fc2_slot_lora_weight_ptrs,
+            gated_slot_lora_ranks, gated_slot_lora_weight_ptrs, token_to_slot,
             /*num_tokens=*/num_rows, hidden_size, inter_size, mActivationDtype, lora_max_low_rank, is_gated_act, stream,
             static_cast<int>(experts_per_token));
         size_t lora_workspace_size = 0;
@@ -1022,8 +1060,9 @@ private:
     int64_t mLoraExpandFC1Size = 0;
     int64_t mLoraExpandFC2Size = 0;
     int64_t mLoraExpandGatedSize = 0;
-    // Highest max_num_tokens we have allocated storage for. Grown lazily by
-    // buildMoeLoraParams; resizing reallocates and changes the buffer addresses.
+    // Highest max_num_tokens we have reserved storage for. Callers can bump this
+    // via reserveLoraHostBuffers() before CUDA graph capture so subsequent
+    // resizes do not reallocate and invalidate the captured copy addresses.
     int64_t mLoraHostBufCapacity = 0;
 
     // Set once a CUDA-graph capture has been observed on the LoRA path. After
@@ -1031,6 +1070,23 @@ private:
     // since a captured graph keeps replaying against the freed addresses.
     // Mutable so the const capture-safety check can record it.
     mutable bool mLoraCaptureObserved = false;
+
+    // ---- Slot-indexed (CUDA-graph) device-source buffers ----
+    // launchMoeLoraSlotExpand reads these device-resident slot tables and
+    // token_to_slot and writes the per-source-token (rank, A_ptr, B_ptr) tables
+    // into the mLoraExpand*Device mirrors above. A captured async H2D refreshes
+    // them each step from the caller's stable pinned-host buffers, so replaying
+    // the graph picks up new adapter assignments without re-capture.
+    // token_to_slot is sized at max_num_tokens; the slot tables at max_lora_size.
+    at::Tensor mLoraTokenToSlotDevice;    // [max_num_tokens]       int32
+    at::Tensor mLoraSlotFC1RanksDevice;   // [max_lora_size]        int32
+    at::Tensor mLoraSlotFC1PtrsDevice;    // [max_lora_size * 3]    int64
+    at::Tensor mLoraSlotFC2RanksDevice;   // [max_lora_size]        int32
+    at::Tensor mLoraSlotFC2PtrsDevice;    // [max_lora_size * 3]    int64
+    at::Tensor mLoraSlotGatedRanksDevice; // [max_lora_size]        int32
+    at::Tensor mLoraSlotGatedPtrsDevice;  // [max_lora_size * 3]    int64
+    // Highest max_lora_size we have reserved slot-table storage for.
+    int64_t mLoraSlotTableCapacity = 0;
 
     // Persistent device-resident scratch backing the capture-safe MoE LoRA
     // path. One LoraDevicePathBuffers per module (fc1, fc2, gated). All
@@ -1088,8 +1144,10 @@ private:
     bool mUseDeviceLoraPath = false;
 
     // Split-K slice count for the device-path low-rank in-GEMM. Mirrors the
-    // value LoraImpl uses internally so the device-path split-K scratch is sized
-    // identically.
+    // value LoraImpl uses internally so the device-path split-K workspace is
+    // sized identically. Shared between buildMoeLoraParams (lazy sizing) and
+    // reserveLoraHostBuffers (warmup pre-sizing) so both reserve the same
+    // amount of scratch.
     static constexpr int64_t kDevicePathSplitKSlices = 16;
 
     void freeProfileWorkspace()
@@ -1332,6 +1390,70 @@ private:
             " tokens but op input has ", num_tokens, " tokens.");
     }
 
+    // Pre-allocate the pinned-host and persistent-device LoRA expansion
+    // buffers at a fixed capacity. Required for CUDA-graph capture/replay
+    // safety: the captured stream records cudaMemcpyAsync at the source
+    // (pinned host) and destination (device) addresses observed during
+    // capture, so those addresses must remain valid for the lifetime of the
+    // graph, with no reallocation between captures.
+    //
+    // This method is public so it can be bound to Python; callers should
+    // invoke it once during warmup before any CUDA-graph capture that
+    // exercises routed-expert MoE LoRA. It is idempotent at or below the
+    // current capacity.
+public:
+    // Pre-size every MoE-LoRA scratch buffer to the worst case so no
+    // (re)allocation happens during CUDA-graph capture or replay: the
+    // pinned-host and device-mirror expansion buffers (max_num_tokens), the
+    // slot tables (max_lora_size), and the device grouped-GEMM scratch
+    // (max_num_tokens * experts_per_token). Idempotent and grow-only.
+    //
+    // Call once during warmup, before any graph capture that exercises MoE
+    // LoRA. experts_per_token is the routing top_k; max_lora_rank is the largest
+    // LoRA rank across adapters; max_lora_size is the adapter-slot pool size;
+    // has_gated is true for gated activations (e.g. SwiGLU).
+    void reserveLoraHostBuffers(
+        int64_t max_num_tokens, int64_t experts_per_token, int64_t max_lora_rank, int64_t max_lora_size, bool has_gated)
+    {
+        std::lock_guard<std::mutex> lock(mMutex);
+        TORCH_CHECK(max_num_tokens > 0, "max_num_tokens must be positive; got ", max_num_tokens);
+        TORCH_CHECK(experts_per_token > 0, "experts_per_token must be positive; got ", experts_per_token);
+        TORCH_CHECK(max_lora_size > 0, "max_lora_size must be positive; got ", max_lora_size);
+
+        // Host pinned + device-mirror expansion buffers (and the device
+        // token_to_slot mirror). Needed by both the legacy host path and the
+        // device path.
+        if (max_num_tokens > mLoraHostBufCapacity)
+        {
+            // Reserve is meant to run during warmup (before any capture). If a
+            // capture has already been observed, growing here would invalidate
+            // addresses baked into the captured graph, so route it through the
+            // same guard as the lazy growth paths.
+            checkLoraReallocSafeDuringCapture(/*stream=*/nullptr, max_num_tokens, mLoraHostBufCapacity);
+            ensureLoraExpandBuffers(max_num_tokens);
+            mLoraHostBufCapacity = max_num_tokens;
+        }
+
+        // Device-resident slot tables for the slot-indexed device-expand kernel.
+        if (max_lora_size > mLoraSlotTableCapacity)
+        {
+            checkLoraReallocSafeDuringCapture(/*stream=*/nullptr, max_lora_size, mLoraSlotTableCapacity);
+            ensureLoraSlotTableBuffers(max_lora_size);
+            mLoraSlotTableCapacity = max_lora_size;
+        }
+
+        // Device grouped-GEMM scratch. CUDA-graph (slot-indexed) MoE LoRA always
+        // takes the device path, so pre-size it unconditionally rather than
+        // gating on the env-var opt-in. Otherwise the first capture would
+        // trigger a lazy allocation that the in-capture realloc guard rejects.
+        TORCH_CHECK(max_lora_rank > 0, "max_lora_rank must be positive to reserve MoE-LoRA device scratch; got ",
+            max_lora_rank);
+        int64_t const dtype_bytes = static_cast<int64_t>(common::getDTypeSize(loraTypeFromActDtype(mActivationDtype)));
+        int64_t const capacity = max_num_tokens * experts_per_token;
+        ensureLoraDeviceScratch(capacity, max_lora_rank, dtype_bytes, kDevicePathSplitKSlices, has_gated);
+    }
+
+private:
     // Reallocating MoE-LoRA scratch hands out fresh addresses, which silently
     // invalidates any CUDA graph that baked in the old ones. Reject reallocation
     // both while capturing and after any capture has been observed, since an
@@ -1350,16 +1472,29 @@ private:
         }
         TORCH_CHECK(false, "MoE LoRA scratch (current capacity ", current, ") is too small for ", requested,
             capturing ? " entries during CUDA graph capture." : " entries after a CUDA graph capture was observed.",
-            " Growing it would invalidate addresses baked into already-captured graphs. Run the device LoRA path "
-            "eagerly through the worst-case shape before capture so the scratch is pre-sized.");
+            " Growing it would invalidate addresses baked into already-captured graphs. Call "
+            "FusedMoeRunner.reserve_lora_host_buffers() during warmup, before capture, with the engine's worst-case "
+            "shape.");
+    }
+
+    // Latch that a CUDA-graph capture has been observed as soon as any MoE LoRA
+    // call runs on a capturing stream, even when no buffer growth happens during
+    // that capture. This forbids later reallocation of buffers whose addresses
+    // are baked into the captured graph, which would corrupt replay.
+    void noteLoraCaptureState(cudaStream_t stream) const
+    {
+        if (stream != nullptr && tensorrt_llm::common::isCapturing(stream))
+        {
+            mLoraCaptureObserved = true;
+        }
     }
 
     // Internal helper: (re)allocate the six pinned-host + six device tensor
-    // pairs to hold capacity expanded tokens. Called by buildMoeLoraParams
-    // (lazy on first call at a given size). The (re)allocation drops the
-    // previous storage; callers must make sure any in-flight CUDA graph that
-    // references the old addresses has either been destroyed or never replays
-    // again.
+    // pairs to hold capacity expanded tokens. Called by reserveLoraHostBuffers
+    // (public warmup) and by buildMoeLoraParams (lazy on first capture-sized
+    // call). The (re)allocation drops the previous storage; callers must make
+    // sure any in-flight CUDA graph that references the old addresses has
+    // either been destroyed or never replays again.
     void ensureLoraExpandBuffers(int64_t capacity)
     {
         auto const pinned_int_opts = at::TensorOptions().dtype(at::kInt).pinned_memory(true);
@@ -1380,6 +1515,28 @@ private:
         mLoraExpandFC1WeightPtrsDevice = at::empty({capacity * 2}, dev_long_opts);
         mLoraExpandFC2WeightPtrsDevice = at::empty({capacity * 2}, dev_long_opts);
         mLoraExpandGatedWeightPtrsDevice = at::empty({capacity * 2}, dev_long_opts);
+
+        // Device token_to_slot mirror for the slot-indexed device-expand kernel.
+        // Sized with the expand buffers (one entry per source token).
+        mLoraTokenToSlotDevice = at::empty({capacity}, dev_int_opts);
+    }
+
+    // (Re)allocate the device-resident slot tables consumed by
+    // launchMoeLoraSlotExpand. Sized at the adapter-slot pool (max_lora_size).
+    // Idempotent / grow-only; reallocation drops previous storage, so callers
+    // must not grow this while a graph referencing the old addresses can still
+    // replay (the in-capture guard enforces this).
+    void ensureLoraSlotTableBuffers(int64_t max_lora_size)
+    {
+        auto const dev_int_opts = at::TensorOptions().dtype(at::kInt).device(at::kCUDA);
+        auto const dev_long_opts = at::TensorOptions().dtype(at::kLong).device(at::kCUDA);
+
+        mLoraSlotFC1RanksDevice = at::empty({max_lora_size}, dev_int_opts);
+        mLoraSlotFC2RanksDevice = at::empty({max_lora_size}, dev_int_opts);
+        mLoraSlotGatedRanksDevice = at::empty({max_lora_size}, dev_int_opts);
+        mLoraSlotFC1PtrsDevice = at::empty({max_lora_size * 3}, dev_long_opts);
+        mLoraSlotFC2PtrsDevice = at::empty({max_lora_size * 3}, dev_long_opts);
+        mLoraSlotGatedPtrsDevice = at::empty({max_lora_size * 3}, dev_long_opts);
     }
 
     // Allocate the per-module device-path scratch for the capture-safe LoRA
@@ -1530,86 +1687,257 @@ private:
         torch::optional<torch::Tensor> const& gated_lora_ranks,
         torch::optional<torch::Tensor> const& gated_lora_weight_ptrs,
         torch::optional<torch::Tensor> const& host_request_types,
-        torch::optional<torch::Tensor> const& host_context_lengths, int64_t num_tokens, int64_t hidden_size,
+        torch::optional<torch::Tensor> const& host_context_lengths,
+        torch::optional<torch::Tensor> const& fc1_slot_lora_ranks,
+        torch::optional<torch::Tensor> const& fc1_slot_lora_weight_ptrs,
+        torch::optional<torch::Tensor> const& fc2_slot_lora_ranks,
+        torch::optional<torch::Tensor> const& fc2_slot_lora_weight_ptrs,
+        torch::optional<torch::Tensor> const& gated_slot_lora_ranks,
+        torch::optional<torch::Tensor> const& gated_slot_lora_weight_ptrs,
+        torch::optional<torch::Tensor> const& token_to_slot, int64_t num_tokens, int64_t hidden_size,
         int64_t inter_size, c10::ScalarType act_dtype, int64_t lora_max_low_rank, bool is_gated_activation,
         cudaStream_t stream, int experts_per_token)
     {
-        if (!fc1_lora_ranks.has_value())
+        bool const has_per_request = fc1_lora_ranks.has_value();
+        bool const has_slot_indexed = fc1_slot_lora_ranks.has_value();
+        if (!has_per_request && !has_slot_indexed)
         {
             return std::nullopt;
         }
         TORCH_CHECK(lora_max_low_rank > 0, "MoE LoRA requires lora_max_low_rank > 0; got ", lora_max_low_rank);
 
-        TORCH_CHECK(fc1_lora_weight_ptrs.has_value() && fc2_lora_ranks.has_value() && fc2_lora_weight_ptrs.has_value(),
-            "MoE LoRA requires fc1_lora_ranks/fc1_lora_weight_ptrs/fc2_lora_ranks/fc2_lora_weight_ptrs together.");
-        TORCH_CHECK(host_request_types.has_value() && host_context_lengths.has_value(),
-            "MoE LoRA requires host_request_types and host_context_lengths CPU tensors.");
-        // For gated activations (e.g. SwiGLU) the kernel's setupLoraWorkspace
-        // unconditionally dereferences gated_lora_ranks and gated_lora_weight_ptrs,
-        // so the caller must provide them.
-        if (is_gated_activation)
-        {
-            TORCH_CHECK(gated_lora_ranks.has_value() && gated_lora_weight_ptrs.has_value(),
-                "MoE LoRA with a gated activation (e.g. SwiGLU) requires gated_lora_ranks and "
-                "gated_lora_weight_ptrs to be provided alongside fc1_lora_*. The fused-MoE kernel "
-                "expects three LoRA modules per layer: fc1 (up), gated (gate) and fc2 (down).");
-        }
-        else
-        {
-            TORCH_CHECK(!gated_lora_ranks.has_value(),
-                "MoE LoRA gated_lora_* is only supported for gated activations (e.g. SwiGLU).");
-        }
+        // Latch capture state up front so that even a capture which needs no
+        // buffer growth still forbids later reallocation of these addresses.
+        noteLoraCaptureState(stream);
 
-        int64_t const num_seqs = fc1_lora_ranks->size(0);
-        bool const has_gated = is_gated_activation && gated_lora_ranks.has_value();
+        // num_seqs: for the per-request path, the actual request count; for the
+        // slot-indexed path, the active token count (each token is its own "seq"
+        // from the kernel's per-token-pointer-array perspective).
+        int64_t num_seqs = 0;
+        bool has_gated = false;
 
-        // Every per-request rank must fit within lora_max_low_rank, which sizes
-        // both the lowrank workspace and the max-problem hints. A larger rank
-        // would make the device path build GEMM problems wider than the
-        // allocated scratch and write out of bounds, so reject it up front.
-        auto validate_rank_tensor = [&](char const* name, torch::Tensor const& ranks_tensor)
+        if (has_per_request)
         {
-            CHECK_CPU_INPUT(ranks_tensor, at::ScalarType::Int)
-            auto const* rank_data = ranks_tensor.data_ptr<int32_t>();
-            for (int64_t i = 0; i < ranks_tensor.size(0); ++i)
+            TORCH_CHECK(
+                fc1_lora_weight_ptrs.has_value() && fc2_lora_ranks.has_value() && fc2_lora_weight_ptrs.has_value(),
+                "MoE LoRA requires fc1_lora_ranks/fc1_lora_weight_ptrs/fc2_lora_ranks/fc2_lora_weight_ptrs together.");
+            TORCH_CHECK(host_request_types.has_value() && host_context_lengths.has_value(),
+                "MoE LoRA requires host_request_types and host_context_lengths CPU tensors.");
+            // For gated activations (e.g. SwiGLU) the kernel's setupLoraWorkspace
+            // unconditionally dereferences gated_lora_ranks and
+            // gated_lora_weight_ptrs, so the caller must provide them.
+            if (is_gated_activation)
             {
-                TORCH_CHECK(rank_data[i] >= 0 && rank_data[i] <= lora_max_low_rank, name, "[", i, "]=", rank_data[i],
-                    " is outside [0, ", lora_max_low_rank, "].");
+                TORCH_CHECK(gated_lora_ranks.has_value() && gated_lora_weight_ptrs.has_value(),
+                    "MoE LoRA with a gated activation (e.g. SwiGLU) requires gated_lora_ranks and "
+                    "gated_lora_weight_ptrs to be provided alongside fc1_lora_*. The fused-MoE kernel "
+                    "expects three LoRA modules per layer: fc1 (gate/SiLU), gated (up/linear) and fc2 (down).");
             }
-        };
-        validate_rank_tensor("fc1_lora_ranks", *fc1_lora_ranks);
-        validate_rank_tensor("fc2_lora_ranks", *fc2_lora_ranks);
-        if (has_gated)
-        {
-            validate_rank_tensor("gated_lora_ranks", *gated_lora_ranks);
-        }
+            else
+            {
+                TORCH_CHECK(!gated_lora_ranks.has_value(),
+                    "MoE LoRA gated_lora_* is only supported for gated activations (e.g. SwiGLU).");
+            }
 
-        // Ensure pinned/device buffers can hold num_tokens entries.
-        // Idempotent at-or-below current capacity.
-        if (num_tokens > mLoraHostBufCapacity)
-        {
-            checkLoraReallocSafeDuringCapture(stream, num_tokens, mLoraHostBufCapacity);
-            ensureLoraExpandBuffers(num_tokens);
-            mLoraHostBufCapacity = num_tokens;
-        }
+            num_seqs = fc1_lora_ranks->size(0);
+            has_gated = is_gated_activation && gated_lora_ranks.has_value();
 
-        expandPerRequestLoraTo(*fc1_lora_ranks, *fc1_lora_weight_ptrs, *host_request_types, *host_context_lengths,
-            num_tokens, mLoraExpandFC1RanksPinned.data_ptr<int32_t>(),
-            mLoraExpandFC1WeightPtrsPinned.data_ptr<int64_t>());
-        expandPerRequestLoraTo(*fc2_lora_ranks, *fc2_lora_weight_ptrs, *host_request_types, *host_context_lengths,
-            num_tokens, mLoraExpandFC2RanksPinned.data_ptr<int32_t>(),
-            mLoraExpandFC2WeightPtrsPinned.data_ptr<int64_t>());
-        mLoraExpandFC1Size = num_tokens;
-        mLoraExpandFC2Size = num_tokens;
-        if (has_gated)
-        {
-            expandPerRequestLoraTo(*gated_lora_ranks, *gated_lora_weight_ptrs, *host_request_types,
-                *host_context_lengths, num_tokens, mLoraExpandGatedRanksPinned.data_ptr<int32_t>(),
-                mLoraExpandGatedWeightPtrsPinned.data_ptr<int64_t>());
-            mLoraExpandGatedSize = num_tokens;
+            // Every per-request rank must fit within lora_max_low_rank, which sizes
+            // both the lowrank workspace and the max-problem hints. A larger rank
+            // would make the device path build GEMM problems wider than the
+            // allocated scratch and write out of bounds, so reject it up front.
+            auto validate_rank_tensor = [&](char const* name, torch::Tensor const& ranks_tensor)
+            {
+                CHECK_CPU_INPUT(ranks_tensor, at::ScalarType::Int)
+                auto const* rank_data = ranks_tensor.data_ptr<int32_t>();
+                for (int64_t i = 0; i < ranks_tensor.size(0); ++i)
+                {
+                    TORCH_CHECK(rank_data[i] >= 0 && rank_data[i] <= lora_max_low_rank, name, "[", i,
+                        "]=", rank_data[i], " is outside [0, ", lora_max_low_rank, "].");
+                }
+            };
+            validate_rank_tensor("fc1_lora_ranks", *fc1_lora_ranks);
+            validate_rank_tensor("fc2_lora_ranks", *fc2_lora_ranks);
+            if (has_gated)
+            {
+                validate_rank_tensor("gated_lora_ranks", *gated_lora_ranks);
+            }
+
+            // Ensure pinned/device buffers can hold num_tokens entries.
+            // Reserve is idempotent at-or-below current capacity.
+            if (num_tokens > mLoraHostBufCapacity)
+            {
+                checkLoraReallocSafeDuringCapture(stream, num_tokens, mLoraHostBufCapacity);
+                ensureLoraExpandBuffers(num_tokens);
+                mLoraHostBufCapacity = num_tokens;
+            }
+
+            expandPerRequestLoraTo(*fc1_lora_ranks, *fc1_lora_weight_ptrs, *host_request_types, *host_context_lengths,
+                num_tokens, mLoraExpandFC1RanksPinned.data_ptr<int32_t>(),
+                mLoraExpandFC1WeightPtrsPinned.data_ptr<int64_t>());
+            expandPerRequestLoraTo(*fc2_lora_ranks, *fc2_lora_weight_ptrs, *host_request_types, *host_context_lengths,
+                num_tokens, mLoraExpandFC2RanksPinned.data_ptr<int32_t>(),
+                mLoraExpandFC2WeightPtrsPinned.data_ptr<int64_t>());
+            mLoraExpandFC1Size = num_tokens;
+            mLoraExpandFC2Size = num_tokens;
+            if (has_gated)
+            {
+                expandPerRequestLoraTo(*gated_lora_ranks, *gated_lora_weight_ptrs, *host_request_types,
+                    *host_context_lengths, num_tokens, mLoraExpandGatedRanksPinned.data_ptr<int32_t>(),
+                    mLoraExpandGatedWeightPtrsPinned.data_ptr<int64_t>());
+                mLoraExpandGatedSize = num_tokens;
+            }
+            else
+            {
+                mLoraExpandGatedSize = 0;
+            }
         }
         else
         {
+            // Slot-indexed (CUDA-graph) path. The token-level expansion is driven by
+            // token_to_slot and the per-slot LoRA tables.
+            TORCH_CHECK(fc1_slot_lora_weight_ptrs.has_value() && fc2_slot_lora_ranks.has_value()
+                    && fc2_slot_lora_weight_ptrs.has_value() && token_to_slot.has_value(),
+                "MoE LoRA slot-indexed mode requires fc1_slot_lora_ranks/fc1_slot_lora_weight_ptrs/"
+                "fc2_slot_lora_ranks/fc2_slot_lora_weight_ptrs/token_to_slot together.");
+            // For gated activations (e.g. SwiGLU) the kernel's setupLoraWorkspace
+            // unconditionally dereferences gated_lora_ranks and
+            // gated_lora_weight_ptrs, so the caller must provide the gated slot
+            // tables as well.
+            if (is_gated_activation)
+            {
+                TORCH_CHECK(gated_slot_lora_ranks.has_value() && gated_slot_lora_weight_ptrs.has_value(),
+                    "MoE LoRA slot-indexed mode with a gated activation requires gated_slot_lora_ranks and "
+                    "gated_slot_lora_weight_ptrs alongside fc1_slot_lora_*.");
+            }
+            else
+            {
+                TORCH_CHECK(!gated_slot_lora_ranks.has_value(),
+                    "MoE LoRA gated_slot_lora_* is only supported for gated activations.");
+            }
+            // Ensure pinned/device buffers can hold num_tokens entries.
+            // Idempotent at-or-below current capacity. Performed BEFORE the
+            // first H2D so that addresses are stable for any subsequent
+            // CUDA-graph capture; callers should invoke reserveLoraHostBuffers
+            // during warmup to avoid the lazy reallocation here.
+            if (num_tokens > mLoraHostBufCapacity)
+            {
+                checkLoraReallocSafeDuringCapture(stream, num_tokens, mLoraHostBufCapacity);
+                ensureLoraExpandBuffers(num_tokens);
+                mLoraHostBufCapacity = num_tokens;
+            }
+
+            num_seqs = num_tokens;
+            has_gated = is_gated_activation && gated_slot_lora_ranks.has_value();
+
+            // Slot tables and token_to_slot must be int32/int64 host tensors so
+            // the H2D element sizes are correct and the device kernel reads the
+            // expected types.
+            CHECK_CPU_INPUT((*token_to_slot), at::ScalarType::Int)
+            CHECK_CPU_INPUT((*fc1_slot_lora_ranks), at::ScalarType::Int)
+            CHECK_CPU_INPUT((*fc1_slot_lora_weight_ptrs), at::ScalarType::Long)
+            CHECK_CPU_INPUT((*fc2_slot_lora_ranks), at::ScalarType::Int)
+            CHECK_CPU_INPUT((*fc2_slot_lora_weight_ptrs), at::ScalarType::Long)
+
+            // These tensors are copied to device via async H2D. Under CUDA-graph
+            // capture the source must be pinned, otherwise the copy is not
+            // capturable and replay would read from a freed staging buffer. In
+            // eager mode pageable host memory is fine.
+            bool const slot_capturing = (stream != nullptr && tensorrt_llm::common::isCapturing(stream));
+            auto check_pinned = [slot_capturing](at::Tensor const& t, char const* name)
+            {
+                TORCH_CHECK(!slot_capturing || t.is_pinned(), "MoE LoRA ", name,
+                    " must be a pinned host tensor for captured async H2D copies.");
+            };
+            check_pinned(*token_to_slot, "token_to_slot");
+            check_pinned(*fc1_slot_lora_ranks, "fc1_slot_lora_ranks");
+            check_pinned(*fc1_slot_lora_weight_ptrs, "fc1_slot_lora_weight_ptrs");
+            check_pinned(*fc2_slot_lora_ranks, "fc2_slot_lora_ranks");
+            check_pinned(*fc2_slot_lora_weight_ptrs, "fc2_slot_lora_weight_ptrs");
+
+            int64_t const num_slots = fc1_slot_lora_ranks->size(0);
+            TORCH_CHECK(fc1_slot_lora_weight_ptrs->dim() == 2 && fc1_slot_lora_weight_ptrs->size(0) == num_slots
+                    && fc1_slot_lora_weight_ptrs->size(1) == 3,
+                "MoE LoRA fc1_slot_lora_weight_ptrs must have shape [max_lora_size, 3]; got ",
+                fc1_slot_lora_weight_ptrs->sizes());
+            TORCH_CHECK(fc2_slot_lora_ranks->size(0) == num_slots,
+                "MoE LoRA fc2_slot_lora_ranks must match fc1 max_lora_size (", num_slots, "); got ",
+                fc2_slot_lora_ranks->size(0));
+            // fc2 pointer table is copied as num_slots * 3 elements below, so its
+            // [max_lora_size, 3] shape must be validated before the raw H2D to
+            // avoid reading past the source allocation / misaligning slots.
+            TORCH_CHECK(fc2_slot_lora_weight_ptrs->dim() == 2 && fc2_slot_lora_weight_ptrs->size(0) == num_slots
+                    && fc2_slot_lora_weight_ptrs->size(1) == 3,
+                "MoE LoRA fc2_slot_lora_weight_ptrs must have shape [max_lora_size, 3]; got ",
+                fc2_slot_lora_weight_ptrs->sizes());
+            TORCH_CHECK(token_to_slot->size(0) >= num_tokens, "MoE LoRA token_to_slot length (", token_to_slot->size(0),
+                ") must be >= num_tokens (", num_tokens, ").");
+
+            // Ensure the device slot tables can hold num_slots entries.
+            if (num_slots > mLoraSlotTableCapacity)
+            {
+                checkLoraReallocSafeDuringCapture(stream, num_slots, mLoraSlotTableCapacity);
+                ensureLoraSlotTableBuffers(num_slots);
+                mLoraSlotTableCapacity = num_slots;
+            }
+
+            // Capture-safe device slot->token expansion. Copy the caller's stable
+            // pinned slot tables and token_to_slot into persistent device buffers
+            // via captured async H2D, then run launchMoeLoraSlotExpand to produce
+            // the per-source-token (rank, A, B) mirrors on-device. Both the copies
+            // and the kernel are recorded into the graph, so replaying picks up
+            // in-place slot-table / token_to_slot updates without re-capture
+            // (mirroring the attention-LoRA device tables).
+            auto h2d_slot = [&](at::Tensor const& src, at::Tensor& dst, int64_t numel)
+            {
+                TLLM_CUDA_CHECK(cudaMemcpyAsync(dst.data_ptr(), src.data_ptr(),
+                    static_cast<size_t>(numel) * src.element_size(), cudaMemcpyHostToDevice, stream));
+            };
+            h2d_slot(*token_to_slot, mLoraTokenToSlotDevice, num_tokens);
+            h2d_slot(*fc1_slot_lora_ranks, mLoraSlotFC1RanksDevice, num_slots);
+            h2d_slot(*fc1_slot_lora_weight_ptrs, mLoraSlotFC1PtrsDevice, num_slots * 3);
+            h2d_slot(*fc2_slot_lora_ranks, mLoraSlotFC2RanksDevice, num_slots);
+            h2d_slot(*fc2_slot_lora_weight_ptrs, mLoraSlotFC2PtrsDevice, num_slots * 3);
+            if (has_gated)
+            {
+                CHECK_CPU_INPUT((*gated_slot_lora_ranks), at::ScalarType::Int)
+                CHECK_CPU_INPUT((*gated_slot_lora_weight_ptrs), at::ScalarType::Long)
+                check_pinned(*gated_slot_lora_ranks, "gated_slot_lora_ranks");
+                check_pinned(*gated_slot_lora_weight_ptrs, "gated_slot_lora_weight_ptrs");
+                TORCH_CHECK(gated_slot_lora_ranks->size(0) == num_slots,
+                    "MoE LoRA gated_slot_lora_ranks must match fc1 max_lora_size (", num_slots, "); got ",
+                    gated_slot_lora_ranks->size(0));
+                TORCH_CHECK(gated_slot_lora_weight_ptrs->dim() == 2 && gated_slot_lora_weight_ptrs->size(0) == num_slots
+                        && gated_slot_lora_weight_ptrs->size(1) == 3,
+                    "MoE LoRA gated_slot_lora_weight_ptrs must have shape [max_lora_size, 3]; got ",
+                    gated_slot_lora_weight_ptrs->sizes());
+                h2d_slot(*gated_slot_lora_ranks, mLoraSlotGatedRanksDevice, num_slots);
+                h2d_slot(*gated_slot_lora_weight_ptrs, mLoraSlotGatedPtrsDevice, num_slots * 3);
+            }
+
+            namespace ck = ::tensorrt_llm::kernels::cutlass_kernels;
+            ck::MoeLoraSlotExpandModule fc1_slot_mod{mLoraSlotFC1RanksDevice.data_ptr<int32_t>(),
+                mLoraSlotFC1PtrsDevice.data_ptr<int64_t>(), mLoraExpandFC1RanksDevice.data_ptr<int32_t>(),
+                mLoraExpandFC1WeightPtrsDevice.data_ptr<int64_t>()};
+            ck::MoeLoraSlotExpandModule fc2_slot_mod{mLoraSlotFC2RanksDevice.data_ptr<int32_t>(),
+                mLoraSlotFC2PtrsDevice.data_ptr<int64_t>(), mLoraExpandFC2RanksDevice.data_ptr<int32_t>(),
+                mLoraExpandFC2WeightPtrsDevice.data_ptr<int64_t>()};
+            ck::MoeLoraSlotExpandModule gated_slot_mod{};
+            if (has_gated)
+            {
+                gated_slot_mod = ck::MoeLoraSlotExpandModule{mLoraSlotGatedRanksDevice.data_ptr<int32_t>(),
+                    mLoraSlotGatedPtrsDevice.data_ptr<int64_t>(), mLoraExpandGatedRanksDevice.data_ptr<int32_t>(),
+                    mLoraExpandGatedWeightPtrsDevice.data_ptr<int64_t>()};
+            }
+            ck::launchMoeLoraSlotExpand(mLoraTokenToSlotDevice.data_ptr<int32_t>(), num_tokens, num_slots, fc1_slot_mod,
+                fc2_slot_mod, has_gated ? &gated_slot_mod : nullptr, stream);
+
+            // The slot path fills the device mirrors directly via the kernel and
+            // always takes the device path, so the host per-token expand buffers
+            // are unused. Mark their live size 0 so the generic per-request H2D
+            // below is skipped and does not clobber the kernel output.
+            mLoraExpandFC1Size = 0;
+            mLoraExpandFC2Size = 0;
             mLoraExpandGatedSize = 0;
         }
 
@@ -1656,8 +1984,10 @@ private:
 
         // Device-LoRA-path scratch. Allocate the per-module device-resident
         // buffers and pack their pointers into lora_params.device_path. The
-        // device path is taken when the env-var opts in (TLLM_MOE_LORA_USE_DEVICE_PATH).
-        bool const use_device_path = mUseDeviceLoraPath;
+        // device path is taken when the env-var opts in (per-request eager
+        // testing) OR when the slot-indexed schema is used (CUDA-graph decode),
+        // since slot-indexed inputs always require the capture-safe device path.
+        bool const use_device_path = mUseDeviceLoraPath || has_slot_indexed;
         if (use_device_path)
         {
             int64_t const dtype_bytes = static_cast<int64_t>(common::getDTypeSize(loraTypeFromActDtype(act_dtype)));
@@ -2100,5 +2430,6 @@ TORCH_LIBRARY(trtllm, m)
         .def("get_tactic_num", &tensorrt_llm::torch_ext::FusedMoeRunner::getTacticNum)
         .def("run_moe", &tensorrt_llm::torch_ext::FusedMoeRunner::runMoe)
         .def("run_moe_min_latency", &tensorrt_llm::torch_ext::FusedMoeRunner::runMoeMinLantency)
+        .def("reserve_lora_host_buffers", &tensorrt_llm::torch_ext::FusedMoeRunner::reserveLoraHostBuffers)
         .def("clear_workspaces", &tensorrt_llm::torch_ext::FusedMoeRunner::clearWorkspaces);
 }

--- a/cpp/tests/unit_tests/kernels/CMakeLists.txt
+++ b/cpp/tests/unit_tests/kernels/CMakeLists.txt
@@ -98,6 +98,7 @@ add_gtest(moeLoadBalanceKernelTest moeLoadBalanceKernelTest.cpp)
 if(USING_OSS_CUTLASS_MOE_GEMM)
   add_gtest(moeLoraPointerExpandTest moeLoraPointerExpandTest.cu)
   add_gtest(moeLoraProblemBuilderTest moeLoraProblemBuilderTest.cu)
+  add_gtest(moeLoraSlotExpandTest moeLoraSlotExpandTest.cu)
 endif()
 
 add_gtest(eaglePackDataTest eaglePackDataTest.cpp)

--- a/cpp/tests/unit_tests/kernels/moeLoraSlotExpandTest.cu
+++ b/cpp/tests/unit_tests/kernels/moeLoraSlotExpandTest.cu
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/kernels/cutlass_kernels/include/moe_lora_slot_expand.h"
+
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <vector>
+
+namespace
+{
+
+using ::tensorrt_llm::kernels::cutlass_kernels::launchMoeLoraSlotExpand;
+using ::tensorrt_llm::kernels::cutlass_kernels::MoeLoraSlotExpandModule;
+
+// Host-side reference reproducing the slot -> per-source-token gather the
+// kernel performs. Entries whose slot is outside [0, num_slots) are emitted as
+// inactive (rank 0, null pointers), matching the kernel's valid_slot branch.
+struct RefModule
+{
+    std::vector<int32_t> slot_ranks; // [num_slots]
+    std::vector<int64_t> slot_ptrs;  // [num_slots * 3] (A, B, dora)
+    std::vector<int32_t> ranks_out;  // [num_tokens]
+    std::vector<int64_t> ptrs_out;   // [num_tokens * 2]
+};
+
+void cpuSlotExpand(std::vector<int32_t> const& token_to_slot, int64_t num_tokens, int64_t num_slots, RefModule& fc1,
+    RefModule& fc2, RefModule* gated)
+{
+    auto expand_one = [&](RefModule& mod)
+    {
+        mod.ranks_out.assign(num_tokens, 0);
+        mod.ptrs_out.assign(num_tokens * 2, 0);
+        for (int64_t t = 0; t < num_tokens; ++t)
+        {
+            int32_t const slot = token_to_slot[t];
+            bool const valid = (slot >= 0) && (static_cast<int64_t>(slot) < num_slots);
+            if (valid)
+            {
+                mod.ranks_out[t] = mod.slot_ranks[slot];
+                mod.ptrs_out[2 * t + 0] = mod.slot_ptrs[3 * slot + 0];
+                mod.ptrs_out[2 * t + 1] = mod.slot_ptrs[3 * slot + 1];
+            }
+        }
+    };
+    expand_one(fc1);
+    expand_one(fc2);
+    if (gated)
+    {
+        expand_one(*gated);
+    }
+}
+
+template <typename T>
+T* deviceUpload(std::vector<T> const& host)
+{
+    T* dev = nullptr;
+    auto const bytes = host.size() * sizeof(T);
+    if (bytes > 0)
+    {
+        TLLM_CUDA_CHECK(cudaMalloc(&dev, bytes));
+        TLLM_CUDA_CHECK(cudaMemcpy(dev, host.data(), bytes, cudaMemcpyHostToDevice));
+    }
+    return dev;
+}
+
+template <typename T>
+T* deviceAllocZero(size_t count)
+{
+    T* dev = nullptr;
+    auto const bytes = count * sizeof(T);
+    TLLM_CUDA_CHECK(cudaMalloc(&dev, bytes));
+    TLLM_CUDA_CHECK(cudaMemset(dev, 0, bytes));
+    return dev;
+}
+
+template <typename T>
+void deviceDownload(T* dev, std::vector<T>& host)
+{
+    if (host.empty())
+    {
+        return;
+    }
+    TLLM_CUDA_CHECK(cudaMemcpy(host.data(), dev, host.size() * sizeof(T), cudaMemcpyDeviceToHost));
+}
+
+class MoeLoraSlotExpandTest : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        TLLM_CUDA_CHECK(cudaStreamCreate(&mStream));
+    }
+
+    void TearDown() override
+    {
+        for (auto* p : mAllocations)
+        {
+            (void) cudaFree(p);
+        }
+        (void) cudaStreamDestroy(mStream);
+    }
+
+    template <typename T>
+    T* upload(std::vector<T> const& host)
+    {
+        T* p = deviceUpload(host);
+        if (p != nullptr)
+        {
+            mAllocations.push_back(p);
+        }
+        return p;
+    }
+
+    template <typename T>
+    T* allocZero(size_t count)
+    {
+        T* p = deviceAllocZero<T>(count);
+        mAllocations.push_back(p);
+        return p;
+    }
+
+    // Run the kernel against the CPU reference and assert the device outputs match.
+    void runAndCompare(std::vector<int32_t> const& token_to_slot, int64_t num_tokens, int64_t num_slots,
+        RefModule& fc1_ref, RefModule& fc2_ref, RefModule* gated_ref)
+    {
+        cpuSlotExpand(token_to_slot, num_tokens, num_slots, fc1_ref, fc2_ref, gated_ref);
+
+        auto* token_to_slot_dev = upload(token_to_slot);
+
+        auto build_module = [&](RefModule const& r)
+        {
+            MoeLoraSlotExpandModule m;
+            m.slot_ranks = upload(r.slot_ranks);
+            m.slot_ptrs = upload(r.slot_ptrs);
+            m.ranks_out = allocZero<int32_t>(num_tokens);
+            m.ptrs_out = allocZero<int64_t>(num_tokens * 2);
+            return m;
+        };
+
+        MoeLoraSlotExpandModule fc1_dev = build_module(fc1_ref);
+        MoeLoraSlotExpandModule fc2_dev = build_module(fc2_ref);
+        MoeLoraSlotExpandModule gated_dev{};
+        MoeLoraSlotExpandModule const* gated_dev_ptr = nullptr;
+        if (gated_ref != nullptr)
+        {
+            gated_dev = build_module(*gated_ref);
+            gated_dev_ptr = &gated_dev;
+        }
+
+        launchMoeLoraSlotExpand(token_to_slot_dev, num_tokens, num_slots, fc1_dev, fc2_dev, gated_dev_ptr, mStream);
+        TLLM_CUDA_CHECK(cudaStreamSynchronize(mStream));
+
+        auto compare = [&](RefModule const& ref_mod, MoeLoraSlotExpandModule const& dev_mod, char const* name)
+        {
+            std::vector<int32_t> host_ranks(num_tokens, 0);
+            std::vector<int64_t> host_ptrs(num_tokens * 2, 0);
+            deviceDownload(dev_mod.ranks_out, host_ranks);
+            deviceDownload(dev_mod.ptrs_out, host_ptrs);
+            for (int64_t t = 0; t < num_tokens; ++t)
+            {
+                EXPECT_EQ(host_ranks[t], ref_mod.ranks_out[t]) << name << " rank mismatch at t=" << t;
+                EXPECT_EQ(host_ptrs[2 * t + 0], ref_mod.ptrs_out[2 * t + 0]) << name << " A ptr mismatch at t=" << t;
+                EXPECT_EQ(host_ptrs[2 * t + 1], ref_mod.ptrs_out[2 * t + 1]) << name << " B ptr mismatch at t=" << t;
+            }
+        };
+
+        compare(fc1_ref, fc1_dev, "fc1");
+        compare(fc2_ref, fc2_dev, "fc2");
+        if (gated_ref != nullptr)
+        {
+            compare(*gated_ref, gated_dev, "gated");
+        }
+    }
+
+    cudaStream_t mStream{};
+    std::vector<void*> mAllocations;
+};
+
+// Build a "fake but distinct" pointer for slot s of module tag. Encoding
+// (tag, s, side) lets the test cheaply verify the kernel copies the right slot
+// row of slot_ptrs into the per-token output.
+int64_t fakePtr(int tag, int32_t s, int side)
+{
+    return (static_cast<int64_t>(tag) << 56) | (static_cast<int64_t>(side) << 48) | (static_cast<int64_t>(s + 1) << 32);
+}
+
+// Build a RefModule slot table: per-slot ranks plus (A, B, dora) pointer rows.
+// dora is set to a sentinel that must NOT appear in the output (the kernel
+// copies only A and B).
+RefModule buildSlotTable(int tag, std::vector<int32_t> const& ranks)
+{
+    RefModule m{};
+    m.slot_ranks = ranks;
+    m.slot_ptrs.resize(ranks.size() * 3);
+    for (int32_t s = 0; s < static_cast<int32_t>(ranks.size()); ++s)
+    {
+        m.slot_ptrs[3 * s + 0] = fakePtr(tag, s, /*side=*/0); // A
+        m.slot_ptrs[3 * s + 1] = fakePtr(tag, s, /*side=*/1); // B
+        m.slot_ptrs[3 * s + 2] = fakePtr(tag, s, /*side=*/2); // dora (ignored)
+    }
+    return m;
+}
+
+// Smallest non-trivial case: a handful of tokens mapping into 3 slots, no gated.
+TEST_F(MoeLoraSlotExpandTest, BasicMultiSlotNoGated)
+{
+    int64_t const num_slots = 3;
+    std::vector<int32_t> token_to_slot = {0, 1, 2, 0, 2, 1};
+    int64_t const num_tokens = static_cast<int64_t>(token_to_slot.size());
+
+    RefModule fc1 = buildSlotTable(/*tag=*/1, /*ranks=*/{2, 0, 4});
+    RefModule fc2 = buildSlotTable(/*tag=*/2, /*ranks=*/{1, 3, 0});
+
+    runAndCompare(token_to_slot, num_tokens, num_slots, fc1, fc2, /*gated=*/nullptr);
+}
+
+// Gated activation: three modules exercised in one pass.
+TEST_F(MoeLoraSlotExpandTest, GatedActivation)
+{
+    int64_t const num_slots = 4;
+    std::vector<int32_t> token_to_slot = {3, 0, 1, 2, 0, 3, 1};
+    int64_t const num_tokens = static_cast<int64_t>(token_to_slot.size());
+
+    RefModule fc1 = buildSlotTable(/*tag=*/1, {3, 0, 1, 4});
+    RefModule fc2 = buildSlotTable(/*tag=*/2, {1, 2, 0, 3});
+    RefModule gated = buildSlotTable(/*tag=*/3, {2, 4, 1, 0});
+
+    runAndCompare(token_to_slot, num_tokens, num_slots, fc1, fc2, &gated);
+}
+
+// Out-of-range and negative slots must produce inactive (rank 0, null ptr)
+// entries instead of indexing past the slot tables. This exercises the
+// valid_slot == false branch that the higher-level Python tests never hit.
+TEST_F(MoeLoraSlotExpandTest, OutOfRangeAndNegativeSlots)
+{
+    int64_t const num_slots = 2;
+    // -1 (negative), 2 and 5 (>= num_slots) are all inactive; 0 and 1 are valid.
+    std::vector<int32_t> token_to_slot = {0, -1, 1, 2, 5, 0};
+    int64_t const num_tokens = static_cast<int64_t>(token_to_slot.size());
+
+    RefModule fc1 = buildSlotTable(/*tag=*/1, {7, 9});
+    RefModule fc2 = buildSlotTable(/*tag=*/2, {3, 5});
+    RefModule gated = buildSlotTable(/*tag=*/3, {2, 6});
+
+    runAndCompare(token_to_slot, num_tokens, num_slots, fc1, fc2, &gated);
+}
+
+// Empty call (num_tokens == 0) must be a no-op and must not launch a kernel
+// with a zero grid.
+TEST_F(MoeLoraSlotExpandTest, EmptyIsNoOp)
+{
+    int64_t const num_slots = 2;
+    std::vector<int32_t> empty_token_to_slot;
+    RefModule fc1 = buildSlotTable(/*tag=*/1, {1, 2});
+    RefModule fc2 = buildSlotTable(/*tag=*/2, {3, 4});
+
+    auto* slot_ranks_fc1 = upload(fc1.slot_ranks);
+    auto* slot_ptrs_fc1 = upload(fc1.slot_ptrs);
+    auto* slot_ranks_fc2 = upload(fc2.slot_ranks);
+    auto* slot_ptrs_fc2 = upload(fc2.slot_ptrs);
+
+    MoeLoraSlotExpandModule fc1_dev{slot_ranks_fc1, slot_ptrs_fc1, nullptr, nullptr};
+    MoeLoraSlotExpandModule fc2_dev{slot_ranks_fc2, slot_ptrs_fc2, nullptr, nullptr};
+
+    launchMoeLoraSlotExpand(/*token_to_slot=*/nullptr, /*num_tokens=*/0, num_slots, fc1_dev, fc2_dev,
+        /*gated=*/nullptr, mStream);
+    TLLM_CUDA_CHECK(cudaStreamSynchronize(mStream));
+}
+
+} // namespace

--- a/docs/source/features/lora.md
+++ b/docs/source/features/lora.md
@@ -146,10 +146,10 @@ LoRA can be applied to the routed-expert projections of a Mixture-of-Experts (Mo
 |---|---|
 | MoE backend | `CUTLASS` only (other backends raise an error at construction). |
 | Base-weight dtype | bf16 / fp16. Quantized base weights (FP8, NVFP4, INT4, INT8) are not yet supported. |
-| Adapter modules | `moe_h_to_4h` (gate side of SwiGLU), `moe_gate` (up side), `moe_4h_to_h` (down). At minimum, `moe_gate` and `moe_4h_to_h` must be present together. |
+| Adapter modules | `moe_h_to_4h` (gate side of SwiGLU), `moe_gate` (up side), `moe_4h_to_h` (down). `moe_h_to_4h` and `moe_4h_to_h` must both be present; `moe_gate` is optional (gated activations only). |
 | Adapter layout | Per-expert (stacked `[num_experts, ...]`). |
 | Multi-LoRA in flight | Yes. Reuses the existing slot manager. |
-| Execution paths | Eager only (CUDA-graph capture is rejected; see below). |
+| Execution paths | Eager, plus CUDA-graph capture/replay via the slot-indexed device path (see below). |
 | min-latency mode | Not supported with MoE LoRA. |
 | Alltoall (WideEP) | Not supported with MoE LoRA. |
 | DoRA on MoE modules | Not supported (and rejected at load time). |
@@ -164,9 +164,9 @@ from tensorrt_llm.lora_manager import LoraConfig
 lora_config = LoraConfig(
     lora_target_modules=[
         "attn_q", "attn_k", "attn_v",  # optional: standard attention LoRA
-        "moe_gate",                    # up projection (required for MoE LoRA)
+        "moe_h_to_4h",                 # gate/SiLU projection (required for MoE LoRA)
         "moe_4h_to_h",                 # down projection (required for MoE LoRA)
-        "moe_h_to_4h",                 # gate projection (SwiGLU; optional)
+        "moe_gate",                    # up/linear projection (optional; gated activations)
     ],
     max_lora_rank=16,
     max_loras=8,
@@ -203,11 +203,11 @@ fc1_adapter = make_per_expert_lora(
 
 #### CUDA-graph decode
 
-MoE LoRA runs in eager mode. CUDA-graph capture of a LoRA-active routed-expert MoE layer is not supported: the fused MoE kernel's LoRA path performs a host-side `cudaEventSynchronize` after a device-to-host pointer-expansion copy, which is not capturable. When CUDA-graph decode is enabled and an MoE LoRA is active, the fused MoE op detects the capturing stream and raises a clear error, so disable CUDA-graph capture when running MoE LoRA.
+CUDA-graph capture/replay of a LoRA-active routed-expert MoE layer is supported via the slot-indexed device path. In CUDA-graph decode, `CudaGraphLoraManager` drives a fully on-device slot→token expansion (no host-side `cudaEventSynchronize`), so the per-token `(rank, A, B)` tables are produced on the stream and reassigning a slot's adapter is reflected on replay without re-capture. The legacy per-request host path is not capturable: it performs a host-side `cudaEventSynchronize` after a device-to-host pointer-expansion copy, so when an MoE LoRA is active on that path the fused MoE op detects the capturing stream and raises a clear error.
 
 #### What is rejected, and where
 
-If you supply MoE LoRA on a non-Cutlass backend or with quantization, `create_moe` raises at construction with a message pointing at the offending setting. At runtime, the fused MoE op also rejects min-latency mode + LoRA, alltoall + LoRA, and CUDA-graph capture + LoRA.
+If you supply MoE LoRA on a non-Cutlass backend or with quantization, `create_moe` raises at construction with a message pointing at the offending setting. At runtime, the fused MoE op also rejects min-latency mode + LoRA, alltoall + LoRA, and CUDA-graph capture on the non-capturable per-request host path (use the slot-indexed device path for capture).
 
 ### Cache Management
 

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -232,7 +232,7 @@ def fused_moe(
     use_dynamic_fc2_scale: bool = False,
     # Routed-expert LoRA inputs (all optional; presence of fc1_lora_ranks activates LoRA).
     # Each *_ranks   : CPU int32  [num_seqs]
-    # Each *_weights : CPU int64  [num_seqs, 3]  -- (A_ptr, B_ptr, DoRA_ptr unused)
+    # Each *_weights : CPU int64  [num_seqs, 3], holding (A_ptr, B_ptr, DoRA_ptr); DoRA unused.
     fc1_lora_ranks: Optional[torch.Tensor] = None,
     fc1_lora_weight_ptrs: Optional[torch.Tensor] = None,
     fc2_lora_ranks: Optional[torch.Tensor] = None,
@@ -242,6 +242,16 @@ def fused_moe(
     host_request_types: Optional[torch.Tensor] = None,
     host_context_lengths: Optional[torch.Tensor] = None,
     lora_max_low_rank: int = 0,
+    # Slot-indexed CUDA-graph LoRA inputs (mutually exclusive with the per-request
+    # tensors above). When fc1_slot_lora_ranks is provided, the per-token expansion
+    # is performed inside the op via token_to_slot indexed into the slot tables.
+    fc1_slot_lora_ranks: Optional[torch.Tensor] = None,
+    fc1_slot_lora_weight_ptrs: Optional[torch.Tensor] = None,
+    fc2_slot_lora_ranks: Optional[torch.Tensor] = None,
+    fc2_slot_lora_weight_ptrs: Optional[torch.Tensor] = None,
+    gated_slot_lora_ranks: Optional[torch.Tensor] = None,
+    gated_slot_lora_weight_ptrs: Optional[torch.Tensor] = None,
+    token_to_slot: Optional[torch.Tensor] = None,
 ) -> List[torch.Tensor]:
     tuner = AutoTuner.get()
     # Only the non-alltoall case is considered for profiling in the warmup phase.
@@ -302,11 +312,17 @@ def fused_moe(
         gemm_idx=2,
     )
 
-    lora_active = fc1_lora_ranks is not None
+    lora_active = (fc1_lora_ranks is not None) or (fc1_slot_lora_ranks
+                                                   is not None)
     if min_latency_mode and lora_active:
         # Mirror the C++ rejection so the error surfaces before the kernel allocates anything.
         raise RuntimeError(
             "MoE LoRA is not supported in min-latency mode. Disable min_latency_mode or pass no LoRA tensors."
+        )
+    if (fc1_lora_ranks is not None) and (fc1_slot_lora_ranks is not None):
+        raise RuntimeError(
+            "MoE LoRA: per-request and slot-indexed input schemas are mutually exclusive. "
+            "Provide either (fc1_lora_ranks, ...) or (fc1_slot_lora_ranks, ..., token_to_slot), not both."
         )
     run_moe = moe_runner.fused_moe_runner.run_moe_min_latency if min_latency_mode else moe_runner.fused_moe_runner.run_moe
     try:
@@ -332,7 +348,10 @@ def fused_moe(
                 out_tensor, use_dynamic_fc2_scale, fc1_lora_ranks,
                 fc1_lora_weight_ptrs, fc2_lora_ranks, fc2_lora_weight_ptrs,
                 gated_lora_ranks, gated_lora_weight_ptrs, host_request_types,
-                host_context_lengths, lora_max_low_rank)
+                host_context_lengths, lora_max_low_rank, fc1_slot_lora_ranks,
+                fc1_slot_lora_weight_ptrs, fc2_slot_lora_ranks,
+                fc2_slot_lora_weight_ptrs, gated_slot_lora_ranks,
+                gated_slot_lora_weight_ptrs, token_to_slot)
     except RuntimeError as e:
         error_msg = str(e)
         if "DeepGEMM only supports Hopper" in error_msg:
@@ -396,7 +415,14 @@ def _(input: torch.Tensor,
       gated_lora_weight_ptrs: Optional[torch.Tensor] = None,
       host_request_types: Optional[torch.Tensor] = None,
       host_context_lengths: Optional[torch.Tensor] = None,
-      lora_max_low_rank: int = 0):
+      lora_max_low_rank: int = 0,
+      fc1_slot_lora_ranks: Optional[torch.Tensor] = None,
+      fc1_slot_lora_weight_ptrs: Optional[torch.Tensor] = None,
+      fc2_slot_lora_ranks: Optional[torch.Tensor] = None,
+      fc2_slot_lora_weight_ptrs: Optional[torch.Tensor] = None,
+      gated_slot_lora_ranks: Optional[torch.Tensor] = None,
+      gated_slot_lora_weight_ptrs: Optional[torch.Tensor] = None,
+      token_to_slot: Optional[torch.Tensor] = None):
     seq_len = input.shape[0]
     if use_int8_woq_per_channel:
         # Note: The weight shape for INT8 weight only quantization is different, i.e.,

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
@@ -15,7 +15,7 @@ from tensorrt_llm.tools.layer_wise_benchmarks import get_calibrator
 from ...distributed import allgather
 from ...expert_statistic import ExpertStatistic
 from ...model_config import ModelConfig
-from ...peft.lora.layer import LoraModuleType
+from ...peft.lora.layer import LoraModuleType, MoeLoraLayer
 from ...utils import (ActivationType, AuxStreamType, EventType,
                       Fp4QuantizedTensor)
 from .interface import AlltoallMethodType, MoE
@@ -360,6 +360,13 @@ class CutlassFusedMoE(MoE):
         # so forward_impl can reject stray lora_params instead of ignoring them.
         self._moe_lora_enabled = self._has_moe_lora_targets(model_config)
 
+        # Discovery-only marker submodule. The actual LoRA GEMMs are fused into
+        # torch.ops.trtllm.fused_moe; MoeLoraLayer exists purely so that
+        # CudaGraphLoraManager and the target-module validator can find this MoE
+        # layer via isinstance(child, LoraLayer) traversal and read its
+        # lora_module_types / output_hidden_sizes when building slot tables.
+        self.lora = self._maybe_make_lora_marker(model_config)
+
         self._weights_created = False
         if not model_config.skip_create_weights_in_init:
             self.create_weights()
@@ -378,6 +385,102 @@ class CutlassFusedMoE(MoE):
             return False
         targets = set(getattr(lora_config, "lora_target_modules", []) or [])
         return any(name in targets for name in self._MOE_LORA_MODULE_NAMES)
+
+    def _maybe_make_lora_marker(
+            self, model_config: ModelConfig) -> Optional[MoeLoraLayer]:
+        """Construct a MoeLoraLayer marker iff this MoE layer is in the LoRA
+        target-module set. The marker is a discovery-only submodule; the actual
+        LoRA application is fused into torch.ops.trtllm.fused_moe.
+
+        The output_hidden_sizes recorded here are the per-token outputs of the
+        LoRA-side GEMM (not per-expert weight shapes): MOE_H_TO_4H / MOE_GATE
+        produce intermediate_size, MOE_4H_TO_H produces hidden_size.
+        """
+        lora_config = getattr(model_config, "lora_config", None)
+        if lora_config is None:
+            return None
+        targets = set(getattr(lora_config, "lora_target_modules", []) or [])
+        active_modules: List[LoraModuleType] = []
+        active_out_sizes: List[int] = []
+        for name in self._MOE_LORA_MODULE_NAMES:
+            if name not in targets:
+                continue
+            module_type = LoraModuleType.from_string(name)
+            if name == "moe_4h_to_h":
+                active_out_sizes.append(self.hidden_size)
+            else:
+                active_out_sizes.append(self.intermediate_size)
+            active_modules.append(module_type)
+        if not active_modules:
+            return None
+        return MoeLoraLayer(active_modules, active_out_sizes)
+
+    def reserve_moe_lora_cuda_graph_workspace(self, max_num_tokens: int,
+                                              max_lora_rank: int,
+                                              max_lora_size: int) -> None:
+        """Pre-size the C++ FusedMoeRunner's MoE-LoRA scratch to the engine's
+        worst case so no (re)allocation happens during CUDA graph capture or
+        replay (which would dangle addresses baked into earlier graphs).
+
+        No-op for layers without MoE LoRA targets and for quantized layers (MoE
+        LoRA requires unquantized fp16/bf16); idempotent and grow-only. Call
+        during warmup, before any capture that exercises MoE LoRA;
+        CudaGraphLoraManager does this automatically.
+
+        Args:
+            max_num_tokens: Worst-case tokens in a captured forward
+                (max_batch_size * max_tokens_per_seq).
+            max_lora_rank: Largest LoRA rank across adapters.
+            max_lora_size: Adapter-slot pool size for the slot-indexed device tables.
+        """
+        if not self._moe_lora_enabled or max_num_tokens <= 0:
+            return
+        # MoE LoRA only runs on the unquantized fp16/bf16 path (the C++ op
+        # rejects quantized weights), so a quantized layer can never reach the
+        # LoRA scratch; skip and let the (impossible) runtime path error loudly.
+        if getattr(self, "has_any_quant", False):
+            return
+        # Weights must exist to read the runner's weight dtype. If they have not
+        # been created yet, skip; the lazy sizing + in-capture guard still
+        # protect correctness.
+        if getattr(self, "w3_w1_weight", None) is None:
+            return
+
+        from ...custom_ops.torch_custom_ops import MoERunner
+
+        # Build the MoERunner with the same instance key the functional
+        # torch.ops.trtllm.fused_moe op uses, so we reserve on the *same* cached
+        # C++ FusedMoeRunner that capture will use. For the unquantized LoRA
+        # path x/weight/output dtypes all equal self.dtype and every quant flag
+        # is False. If a runtime call ever uses a different key, the C++
+        # capture guard surfaces a clear error rather than corrupting replay.
+        weight_dtype = self.w3_w1_weight.dtype
+        runner = MoERunner(
+            x_dtype=self.dtype,
+            weight_dtype=weight_dtype,
+            output_dtype=self.dtype,
+            top_k=self.routing_method.experts_per_token,
+            tp_size=self.tp_size,
+            tp_rank=self.tp_rank,
+            ep_size=self.ep_size,
+            ep_rank=self.ep_rank,
+            cluster_size=self.cluster_size,
+            cluster_rank=self.cluster_rank,
+            use_deepseek_fp8_block_scale=False,
+            use_w4_group_scaling=False,
+            use_int8_woq_per_channel=False,
+            use_mxfp8_act_scaling=False,
+            min_latency_mode=False,
+            use_fused_finalize=self.use_fused_finalize,
+            activation_type=self.activation_type,
+        )
+        runner.fused_moe_runner.reserve_lora_host_buffers(
+            int(max_num_tokens),
+            int(self.routing_method.experts_per_token),
+            int(max_lora_rank),
+            int(max_lora_size),
+            bool(self.is_gated_activation),
+        )
 
     def _moe_lora_active(self, lora_params: Optional[Dict]) -> bool:
         """Return True when lora_params carries routed-expert MoE LoRA tensors
@@ -407,6 +510,11 @@ class CutlassFusedMoE(MoE):
         """
         if not lora_params:
             return None
+        # Slot-indexed (CUDA-graph decode) path: the per-token expansion is
+        # driven inside the op by token_to_slot indexed into stable slot
+        # tables owned by CudaGraphLoraParams (see _extract_moe_lora_tensors_cuda_graph).
+        if lora_params.get("use_cuda_graph_mode", False):
+            return self._extract_moe_lora_tensors_cuda_graph(lora_params)
         layer_params = lora_params.get(
             self.layer_idx, {}) if self.layer_idx is not None else {}
         if not layer_params:
@@ -485,6 +593,89 @@ class CutlassFusedMoE(MoE):
             lora_params["prompt_lens_cpu"][:num_seqs].contiguous(),
             "lora_max_low_rank":
             active_max_rank,
+        }
+
+    def _extract_moe_lora_tensors_cuda_graph(
+            self, lora_params: Dict) -> Optional[Dict[str, object]]:
+        """CUDA-graph slot-indexed extraction for routed-expert MoE LoRA.
+
+        Pulls per-module slot tables and token_to_slot out of
+        CudaGraphLoraParams and returns the slot-indexed kwargs accepted by
+        torch.ops.trtllm.fused_moe. Returns None when this layer does not
+        carry any MoE LoRA modules in the graph layer map.
+
+        Returned tensor addresses are stable across captures and replays: they
+        come from persistent pinned host buffers owned by CudaGraphLoraParams
+        and the per-module packed pointer cache. Uses the same module->kernel
+        slot convention as the per-request path (moe_h_to_4h -> fc1,
+        moe_gate -> gated, moe_4h_to_h -> fc2).
+        """
+        if self.layer_idx is None:
+            return None
+        cuda_graph_params = lora_params.get("cuda_graph_params")
+        if cuda_graph_params is None:
+            return None
+
+        slot_to_kernel = {
+            int(LoraModuleType.MOE_H_TO_4H): "fc1",
+            int(LoraModuleType.MOE_GATE): "gated",
+            int(LoraModuleType.MOE_4H_TO_H): "fc2",
+        }
+        slot_ranks: Dict[str, Optional[torch.Tensor]] = {
+            "fc1": None,
+            "fc2": None,
+            "gated": None,
+        }
+        slot_ptrs: Dict[str, Optional[torch.Tensor]] = {
+            "fc1": None,
+            "fc2": None,
+            "gated": None,
+        }
+        for module_id_int, slot in slot_to_kernel.items():
+            inputs = cuda_graph_params.get_moe_slot_inputs(
+                self.layer_idx, module_id_int)
+            if inputs is None:
+                continue
+            slot_ranks[slot], slot_ptrs[slot] = inputs
+
+        if slot_ranks["fc1"] is None or slot_ranks["fc2"] is None:
+            return None
+
+        num_seqs = lora_params["num_seqs"]
+        tokens_per_seq = getattr(cuda_graph_params, "max_tokens_per_seq", 1)
+        num_tokens = num_seqs * max(int(tokens_per_seq), 1)
+        token_to_slot = cuda_graph_params.token_to_slot_host[:
+                                                             num_tokens].contiguous(
+                                                             )
+
+        # Pass the global max LoRA rank, not the per-step active max: the device
+        # path uses it only to size the low-rank workspace strides baked into the
+        # captured graph, so the global max keeps them valid for any per-slot
+        # rank across replays. The actual per-token rank is read on-device from
+        # the slot table, so a smaller rank just runs a smaller GEMM.
+        max_rank = int(getattr(cuda_graph_params, "max_rank", 0))
+        if max_rank <= 0:
+            return None
+
+        return {
+            "fc1_slot_lora_ranks":
+            slot_ranks["fc1"].contiguous(),
+            "fc1_slot_lora_weight_ptrs":
+            slot_ptrs["fc1"].contiguous(),
+            "fc2_slot_lora_ranks":
+            slot_ranks["fc2"].contiguous(),
+            "fc2_slot_lora_weight_ptrs":
+            slot_ptrs["fc2"].contiguous(),
+            "gated_slot_lora_ranks":
+            (slot_ranks["gated"].contiguous()
+             if slot_ranks["gated"] is not None else None),
+            "gated_slot_lora_weight_ptrs":
+            (slot_ptrs["gated"].contiguous()
+             if slot_ptrs["gated"] is not None else None),
+            "token_to_slot":
+            token_to_slot,
+            "lora_max_low_rank":
+            max_rank,
         }
 
     def _check_configs(self):

--- a/tensorrt_llm/_torch/peft/lora/cuda_graph_lora_manager.py
+++ b/tensorrt_llm/_torch/peft/lora/cuda_graph_lora_manager.py
@@ -80,6 +80,37 @@ class CudaGraphLoraManager:
             max_tokens_per_seq=self.max_tokens_per_seq,
         )
 
+        # Pre-size routed-expert MoE-LoRA scratch on every MoE layer so the
+        # capture-safe device path never (re)allocates during graph capture.
+        # See CutlassFusedMoE.reserve_moe_lora_cuda_graph_workspace.
+        self._reserve_moe_lora_workspaces(model)
+
+    def _reserve_moe_lora_workspaces(self, model: torch.nn.Module) -> None:
+        """Reserve routed-expert MoE-LoRA scratch for all MoE layers up front.
+
+        Walks the model for MoE modules exposing
+        reserve_moe_lora_cuda_graph_workspace (duck-typed to avoid importing
+        backend-specific classes) and reserves their worst-case buffers. Must
+        happen before any CUDA graph capture so the buffer addresses baked into
+        the graph remain valid across replays.
+        """
+        # Worst-case tokens in a single captured forward.
+        max_num_tokens = self.max_batch_size * self.max_tokens_per_seq
+        reserved = 0
+        for _, module in model.named_modules():
+            reserve_fn = getattr(module, "reserve_moe_lora_cuda_graph_workspace", None)
+            if reserve_fn is None:
+                continue
+            reserve_fn(max_num_tokens, self.max_lora_rank, self.max_lora_size)
+            reserved += 1
+        if reserved:
+            logger.info(
+                f"Reserved routed-expert MoE-LoRA CUDA-graph workspace for "
+                f"{reserved} MoE layer(s) (max_num_tokens={max_num_tokens}, "
+                f"max_lora_rank={self.max_lora_rank}, "
+                f"max_lora_size={self.max_lora_size})."
+            )
+
     def _initialize_from_model(self, model: torch.nn.Module):
         """
         Initialize LoRALayerInfo from model.

--- a/tensorrt_llm/_torch/peft/lora/cuda_graph_lora_params.py
+++ b/tensorrt_llm/_torch/peft/lora/cuda_graph_lora_params.py
@@ -85,9 +85,19 @@ class CudaGraphLoraParams:
         # max_batch_size * max_tokens_per_seq) so all tokens of a sequence stay
         # together when sorted by slot.
         max_num_tokens = max_batch_size * max_tokens_per_seq
+        self.max_num_tokens = max_num_tokens
         self.sorted_ids = torch.zeros(max_num_tokens, dtype=torch.int64, device=device)
         self.sorted_ids_host = torch.zeros_like(
             self.sorted_ids, device="cpu", pin_memory=prefer_pinned()
+        )
+
+        # token_to_slot maps an *unsorted* token index to its adapter slot id.
+        # Used by the routed-expert MoE LoRA path to look up per-token rank /
+        # weight pointers from slot-indexed tables. Pinned host so the C++ op
+        # can dereference it directly and the address stays stable across CUDA
+        # graph captures and replays.
+        self.token_to_slot_host = torch.zeros(
+            max_num_tokens, dtype=torch.int32, device="cpu", pin_memory=prefer_pinned()
         )
 
         # persistent values for gen-only batch with cuda graph
@@ -211,6 +221,19 @@ class CudaGraphLoraParams:
         sorted_ids_host = self.sorted_ids_host[:num_tokens]
         sorted_ids_host.copy_(token_sorted_ids)
         self.sorted_ids[:num_tokens].copy_(sorted_ids_host, non_blocking=True)
+
+        # Populate token_to_slot for the routed-expert MoE LoRA path. Each
+        # sequence contributes tokens_per_seq tokens carrying its slot id.
+        # Update in place to preserve the pinned-host address (graph-capture safe).
+        slot_ids_t = torch.as_tensor(slot_ids, dtype=torch.int32)
+        if tokens_per_seq > 1:
+            token_slots = slot_ids_t.repeat_interleave(tokens_per_seq)
+        else:
+            token_slots = slot_ids_t
+        self.token_to_slot_host[:num_tokens].copy_(token_slots)
+        # Padding region is zeroed once at construction; leave it untouched so
+        # the address arithmetic in the C++ op never reads stale slot ids past
+        # the active num_tokens.
 
     def update_weight_pointers(
         self,
@@ -362,3 +385,62 @@ class CudaGraphLoraParams:
             LoraLayerParams for the specified layer, or None if layer has no LoRA modules
         """
         return self.layer_params.get(layer_key)
+
+    def get_moe_slot_inputs(
+        self,
+        layer_idx: int,
+        module_id: int,
+    ) -> Optional[Tuple[torch.Tensor, torch.Tensor]]:
+        """Return slot-indexed LoRA tables for an MoE module on a given layer.
+
+        Used by the routed-expert MoE LoRA path in CUDA-graph decode mode. The
+        returned tensors are pinned host views over the persistent buffers held
+        by this instance, so their data_ptr() is stable across CUDA graph
+        captures and replays.
+
+        Args:
+            layer_idx: Decoder layer index.
+            module_id: One of the MOE_H_TO_4H, MOE_4H_TO_H, or MOE_GATE
+                LoraModuleType int values.
+
+        Returns:
+            A tuple (slot_ranks_host, slot_weight_ptrs_host), where
+            slot_ranks_host is [max_lora_size] int32 (an alias to
+            self.slot_ranks_host), and slot_weight_ptrs_host is
+            [max_lora_size, 3] int64 with columns (A_ptr, B_ptr, dora_ptr).
+            dora_ptr is always 0, since DoRA with MoE is rejected upstream.
+            Returns None if (layer_idx, module_id) is not in this layer's map.
+        """
+        key = self.layer_module2key.get((layer_idx, module_id))
+        if key is None:
+            return None
+        layer_param = self.layer_params.get(key)
+        if layer_param is None:
+            return None
+        local_module_id = key.module_ids.index(module_id)
+        # Slice [max_lora_size] views for the requested module.
+        ptrs_a = layer_param.h_b_ptrs[local_module_id]
+        ptrs_b = layer_param.h_b_prime_ptrs[local_module_id]
+        # Pack into [max_lora_size, 3]. We allocate a new tensor here because
+        # the existing storage isn't laid out as (A, B, dora) per slot. To
+        # keep this graph-capture safe, cache the packed buffer per (layer_idx,
+        # module_id) so its address is stable across calls.
+        cache = getattr(self, "_moe_slot_ptrs_cache", None)
+        if cache is None:
+            cache = {}
+            self._moe_slot_ptrs_cache = cache
+        cache_key = (layer_idx, module_id)
+        packed = cache.get(cache_key)
+        if packed is None:
+            packed = torch.zeros(
+                (self.max_lora_size, 3),
+                dtype=torch.int64,
+                device="cpu",
+                pin_memory=prefer_pinned(),
+            )
+            cache[cache_key] = packed
+        # In-place update (graph-capture safe).
+        packed[:, 0].copy_(ptrs_a.to(torch.int64))
+        packed[:, 1].copy_(ptrs_b.to(torch.int64))
+        # Column 2 (dora) stays zero.
+        return self.slot_ranks_host, packed

--- a/tensorrt_llm/_torch/peft/lora/layer.py
+++ b/tensorrt_llm/_torch/peft/lora/layer.py
@@ -540,3 +540,25 @@ class LoraLayer(torch.nn.Module):
                                         device=x.device))
                 lora_output = torch.cat(lora_output, dim=-1)
                 return lora_output
+
+
+class MoeLoraLayer(LoraLayer):
+    """Marker LoraLayer for routed-expert MoE modules.
+
+    Routed-expert LoRA is *fused* into the MoE kernel
+    (torch.ops.trtllm.fused_moe with LoRA kwargs); the actual GEMMs are not
+    performed by LoraLayer.forward. This subclass exists so that
+    CudaGraphLoraManager._initialize_from_model and the LoRA target-module
+    validator can discover MoE LoRA layers via isinstance(module, LoraLayer)
+    and inspect their lora_module_types / output_hidden_sizes, without
+    altering the standalone LoraLayer call semantics elsewhere in the model.
+
+    Calling forward() directly is a programming error: the MoE module owns
+    LoRA application.
+    """
+
+    def forward(self, *args, **kwargs):
+        raise NotImplementedError(
+            "MoeLoraLayer is a discovery marker; routed-expert LoRA is applied "
+            "inside torch.ops.trtllm.fused_moe via the MoE module. Do not call "
+            "MoeLoraLayer.forward directly.")

--- a/tests/unittest/_torch/lora/test_moe_lora_cuda_graph_params.py
+++ b/tests/unittest/_torch/lora/test_moe_lora_cuda_graph_params.py
@@ -1,0 +1,216 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for the routed-expert MoE LoRA *CUDA-graph slot-table*
+Python wiring.
+
+The op-level tests (`test_moe_lora_op.py`, `test_moe_lora_device_path.py`)
+exercise `torch.ops.trtllm.fused_moe` with hand-built slot kwargs, bypassing the
+plumbing that actually produces those kwargs at decode time. These tests cover
+that glue end-to-end on the Python side, without model weights or the built C++
+op:
+
+  * `CudaGraphLoraParams.get_moe_slot_inputs` packs the per-module
+    (A, B, dora) slot-pointer table and aliases the shared per-slot rank table.
+  * `CutlassFusedMoE._extract_moe_lora_tensors_cuda_graph` threads those tables
+    plus `token_to_slot` into the slot-indexed kwargs the op consumes, applying
+    the moe_h_to_4h->fc1 / moe_gate->gated / moe_4h_to_h->fc2 mapping and the
+    global `max_rank`.
+
+`CudaGraphLoraParams` allocates pinned host buffers and moves a small tensor to
+CUDA at construction, so these require a GPU, but no weights and no
+`trtllm::fused_moe` op.
+"""
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.modules.fused_moe.fused_moe_cutlass import CutlassFusedMoE
+from tensorrt_llm._torch.peft.lora.cuda_graph_lora_params import CudaGraphLoraParams
+from tensorrt_llm._torch.peft.lora.layer import LoraModuleType
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="CudaGraphLoraParams allocates pinned/CUDA buffers; requires a GPU.",
+)
+
+_HIDDEN = 128
+_INTER = 256
+
+
+class _ExtractStub:
+    """Minimal stand-in for a CutlassFusedMoE so the unbound extraction method
+    can run without constructing a full MoE layer. The method only reads
+    `self.layer_idx`."""
+
+    def __init__(self, layer_idx):
+        self.layer_idx = layer_idx
+
+
+def _make_params(max_lora_size=2, max_rank=8, max_batch_size=2, layer_idx=0):
+    """Build a CudaGraphLoraParams carrying one MoE layer with all three
+    routed-expert modules (fc1=moe_h_to_4h, gated=moe_gate, fc2=moe_4h_to_h)."""
+    module_ids = (
+        int(LoraModuleType.MOE_H_TO_4H),
+        int(LoraModuleType.MOE_GATE),
+        int(LoraModuleType.MOE_4H_TO_H),
+    )
+    key = CudaGraphLoraParams.LoraLayerKey(layer_idx=layer_idx, module_ids=module_ids)
+    layer_info = {
+        key: CudaGraphLoraParams.LoraLayerInfo(
+            module_num=3,
+            # fc1/gated produce intermediate_size, fc2 produces hidden_size.
+            output_sizes=[_INTER, _INTER, _HIDDEN],
+        )
+    }
+    params = CudaGraphLoraParams(
+        max_batch_size=max_batch_size,
+        max_lora_size=max_lora_size,
+        max_rank=max_rank,
+        layer_info=layer_info,
+    )
+    return params, key, module_ids
+
+
+def _fake_ptr(module_id, slot, side):
+    """Distinct non-zero int64 pointer bits per (module, slot, A/B side)."""
+    return (int(module_id) << 40) | (int(slot) << 8) | int(side)
+
+
+def _populate_pointers(params, key, module_ids, rank):
+    """Fill per-module A/B host pointer tables and the shared per-slot rank
+    table, mimicking what the PEFT cache manager would do for occupied slots."""
+    layer_param = params.layer_params[key]
+    for local_id, module_id in enumerate(module_ids):
+        for slot in range(params.max_lora_size):
+            layer_param.h_b_ptrs[local_id, slot] = _fake_ptr(module_id, slot, 0)
+            layer_param.h_b_prime_ptrs[local_id, slot] = _fake_ptr(module_id, slot, 1)
+    for slot in range(params.max_lora_size):
+        params.slot_ranks_host[slot] = rank
+
+
+@requires_cuda
+def test_get_moe_slot_inputs_packs_pointers_and_aliases_ranks():
+    rank = 8
+    params, key, module_ids = _make_params(max_lora_size=2, max_rank=rank)
+    _populate_pointers(params, key, module_ids, rank)
+
+    for module_id in module_ids:
+        out = params.get_moe_slot_inputs(layer_idx=0, module_id=module_id)
+        assert out is not None
+        ranks_host, packed = out
+        # Ranks are the shared per-slot table aliased (not a per-module copy).
+        assert ranks_host is params.slot_ranks_host
+        assert packed.shape == (params.max_lora_size, 3)
+        for slot in range(params.max_lora_size):
+            assert packed[slot, 0].item() == _fake_ptr(module_id, slot, 0)  # A
+            assert packed[slot, 1].item() == _fake_ptr(module_id, slot, 1)  # B
+            assert packed[slot, 2].item() == 0  # dora always zero
+
+    # Unknown (layer, module) returns None rather than raising.
+    assert (
+        params.get_moe_slot_inputs(layer_idx=0, module_id=int(LoraModuleType.ATTENTION_QKV)) is None
+    )
+    assert (
+        params.get_moe_slot_inputs(layer_idx=99, module_id=int(LoraModuleType.MOE_H_TO_4H)) is None
+    )
+
+
+@requires_cuda
+def test_get_moe_slot_inputs_packed_buffer_is_address_stable():
+    """The packed (A, B, dora) buffer must be cached per (layer, module) so its
+    data_ptr() is stable across calls, which is required for CUDA-graph capture."""
+    rank = 4
+    params, key, module_ids = _make_params(max_lora_size=2, max_rank=rank)
+    _populate_pointers(params, key, module_ids, rank)
+
+    mid = int(LoraModuleType.MOE_H_TO_4H)
+    _, packed_first = params.get_moe_slot_inputs(layer_idx=0, module_id=mid)
+    first_ptr = packed_first.data_ptr()
+
+    # Reassign a slot's pointers in place and re-extract; same backing buffer.
+    params.layer_params[key].h_b_ptrs[0, 0] = _fake_ptr(mid, 0, 0) + 777
+    _, packed_second = params.get_moe_slot_inputs(layer_idx=0, module_id=mid)
+    assert packed_second.data_ptr() == first_ptr
+    assert packed_second[0, 0].item() == _fake_ptr(mid, 0, 0) + 777
+
+
+@requires_cuda
+def test_extract_moe_lora_tensors_cuda_graph_wires_slot_tables():
+    """End-to-end Python wiring: get_moe_slot_inputs -> the slot-indexed kwargs
+    that torch.ops.trtllm.fused_moe consumes."""
+    rank = 8
+    num_seqs = 2
+    params, key, module_ids = _make_params(max_lora_size=2, max_rank=rank, max_batch_size=num_seqs)
+    _populate_pointers(params, key, module_ids, rank)
+    # token 0 -> slot 1, token 1 -> slot 0.
+    params.update_sorted_indices([1, 0])
+
+    lora_params = {
+        "use_cuda_graph_mode": True,
+        "cuda_graph_params": params,
+        "num_seqs": num_seqs,
+    }
+    kwargs = CutlassFusedMoE._extract_moe_lora_tensors_cuda_graph(_ExtractStub(0), lora_params)
+    assert kwargs is not None
+
+    # max_rank is the global cap, not a per-step value.
+    assert kwargs["lora_max_low_rank"] == rank
+
+    # All three modules present, mapped to their kernel slots.
+    for kernel, module_id in (
+        ("fc1", int(LoraModuleType.MOE_H_TO_4H)),
+        ("gated", int(LoraModuleType.MOE_GATE)),
+        ("fc2", int(LoraModuleType.MOE_4H_TO_H)),
+    ):
+        ranks = kwargs[f"{kernel}_slot_lora_ranks"]
+        ptrs = kwargs[f"{kernel}_slot_lora_weight_ptrs"]
+        assert ranks.shape == (params.max_lora_size,)
+        assert ptrs.shape == (params.max_lora_size, 3)
+        for slot in range(params.max_lora_size):
+            assert ranks[slot].item() == rank
+            assert ptrs[slot, 0].item() == _fake_ptr(module_id, slot, 0)
+            assert ptrs[slot, 1].item() == _fake_ptr(module_id, slot, 1)
+
+    # token_to_slot is sliced to the live token count and matches the routing.
+    token_to_slot = kwargs["token_to_slot"]
+    assert token_to_slot.shape == (num_seqs,)
+    assert token_to_slot[0].item() == 1
+    assert token_to_slot[1].item() == 0
+
+
+@requires_cuda
+def test_extract_returns_none_without_layer_or_required_modules():
+    rank = 8
+    params, _, _ = _make_params(max_rank=rank)
+
+    # layer_idx None -> no MoE LoRA for this layer.
+    none_layer = CutlassFusedMoE._extract_moe_lora_tensors_cuda_graph(
+        _ExtractStub(None), {"cuda_graph_params": params, "num_seqs": 1}
+    )
+    assert none_layer is None
+
+    # No cuda_graph_params -> None.
+    assert (
+        CutlassFusedMoE._extract_moe_lora_tensors_cuda_graph(_ExtractStub(0), {"num_seqs": 1})
+        is None
+    )
+
+    # A layer that only carries fc1 (missing fc2) must bail out: the in-GEMM and
+    # out-GEMM are both required for a routed-expert LoRA delta.
+    fc1_only_key = CudaGraphLoraParams.LoraLayerKey(
+        layer_idx=0, module_ids=(int(LoraModuleType.MOE_H_TO_4H),)
+    )
+    fc1_only = CudaGraphLoraParams(
+        max_batch_size=1,
+        max_lora_size=1,
+        max_rank=rank,
+        layer_info={
+            fc1_only_key: CudaGraphLoraParams.LoraLayerInfo(module_num=1, output_sizes=[_INTER])
+        },
+    )
+    assert (
+        CutlassFusedMoE._extract_moe_lora_tensors_cuda_graph(
+            _ExtractStub(0), {"cuda_graph_params": fc1_only, "num_seqs": 1}
+        )
+        is None
+    )

--- a/tests/unittest/_torch/lora/test_moe_lora_device_path.py
+++ b/tests/unittest/_torch/lora/test_moe_lora_device_path.py
@@ -1,17 +1,26 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for the *device path* of routed-expert MoE LoRA in
+"""Tests for the capture-safe *device path* of routed-expert MoE LoRA in
 `torch.ops.trtllm.fused_moe`.
 
-The device path (opted into for the per-request schema via
-`TLLM_MOE_LORA_USE_DEVICE_PATH=1`) performs the per-token pointer expansion,
-problem building, and grouped GEMMs entirely on the CUDA stream via the new
-on-device kernels, instead of the legacy host-pointer LoRA path. This test
-checks device-path eager correctness vs. both the legacy host path and an fp32
-PyTorch reference, exercising the pointer-expand / problem-builder /
-grouped-GEMM kernels.
+The device path (selected by the slot-indexed input schema, or by
+`TLLM_MOE_LORA_USE_DEVICE_PATH=1` for the per-request schema) performs the
+per-token pointer expansion, problem building, and grouped GEMMs entirely on
+the CUDA stream, so it is safe to record into a CUDA graph. These tests cover
+the surface the eager-only tests in `test_moe_lora_op.py` cannot reach:
 
-It requires a CUDA GPU and the built `trtllm::fused_moe` op.
+  1. Device-path eager correctness vs. the legacy host path and an fp32
+     PyTorch reference (exercises the new on-device kernels).
+  2. CUDA-graph capture + replay of the device path (slot-indexed schema),
+     verified against the eager result.
+  3. Multi-adapter routing within a single capture (token_to_slot mixing two
+     adapter slots).
+  4. Slot reassignment under replay: the slot -> per-token expansion runs
+     on-device fed by captured H2D copies of the stable pinned slot tables, so
+     reassigning a slot's adapter in place is reflected on replay WITHOUT
+     re-capture (mirroring attention LoRA and the normal decode loop).
+
+They require a CUDA GPU and the built `trtllm::fused_moe` op.
 """
 
 import pytest
@@ -29,14 +38,18 @@ requires_cuda_and_op = pytest.mark.skipif(
 
 @pytest.fixture(autouse=True)
 def _isolate_moe_runner_cache():
-    """Give every test a fresh cached FusedMoeRunner and release device scratch
-    afterward.
+    """Give every test a fresh cached FusedMoeRunner and release captured graphs
+    / device scratch afterward.
 
-    The device path is selected per-runner at construction from
-    TLLM_MOE_LORA_USE_DEVICE_PATH, and the runner is cached at module level by
-    MoERunner. Clearing the cache before each test forces a fresh runner that
-    re-reads the env var; clearing + empty_cache afterward releases the
-    per-runner device scratch so it cannot alias later allocations.
+    The MoE LoRA device path keeps persistent per-runner scratch (slot tables,
+    pointer arrays, low-rank workspace) on the module-level MoERunner cache, and
+    these tests leak the CUDA graphs they capture. Without isolation, a test that
+    grows the cached runner's slot tables (e.g. max_lora_size 1 -> 2) while an
+    earlier test's captured graph still references the old device scratch
+    corrupts that scratch, producing an illegal memory access in the next
+    forward (see TRTLLM-12507). Clearing the cache before each test forces a
+    fresh runner; clearing + empty_cache afterward releases the leaked graph
+    pools so they cannot alias later allocations.
     """
     from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
 
@@ -106,6 +119,33 @@ def _per_request_kwargs(num_tokens, adapters, rank):
     )
 
 
+def _slot_kwargs(token_to_slot, adapter_sets, rank):
+    """Slot-indexed schema. `adapter_sets` is a list (one per slot) of adapter
+    dicts; `token_to_slot` maps each token to a slot index. Pinned host tensors
+    so the op can dereference them and the addresses stay stable across capture.
+    """
+    max_lora_size = len(adapter_sets)
+
+    def _ptrs(key):
+        return torch.tensor(
+            [[a[key]["A"].data_ptr(), a[key]["B"].data_ptr(), 0] for a in adapter_sets],
+            dtype=torch.int64,
+            device="cpu",
+        ).pin_memory()
+
+    ranks = torch.full((max_lora_size,), rank, dtype=torch.int32, device="cpu").pin_memory()
+    return dict(
+        fc1_slot_lora_ranks=ranks,
+        fc1_slot_lora_weight_ptrs=_ptrs("fc1"),
+        fc2_slot_lora_ranks=ranks,
+        fc2_slot_lora_weight_ptrs=_ptrs("fc2"),
+        gated_slot_lora_ranks=ranks,
+        gated_slot_lora_weight_ptrs=_ptrs("gated"),
+        token_to_slot=token_to_slot.to(torch.int32).cpu().pin_memory(),
+        lora_max_low_rank=rank,
+    )
+
+
 def _call_fused_moe(x, w3_w1, w2, topk_ids, topk_scores, output_dtype, lora_kwargs):
     common = dict(
         input=x,
@@ -136,6 +176,20 @@ def _reference(x, w3_w1, w2, topk_ids, topk_scores, adapters):
         fc2_a=adapters["fc2"]["A"],
         fc2_b=adapters["fc2"]["B"],
     )
+
+
+def _reference_multi_slot(x, w3_w1, w2, topk_ids, topk_scores, adapter_sets, token_to_slot):
+    """Per-token reference where token t uses adapter_sets[token_to_slot[t]].
+
+    The LoRA delta and base MoE are fully per-token independent, so we evaluate
+    the single-adapter reference once per slot over the whole input and gather
+    each token's row from the reference computed with its slot's adapter.
+    """
+    per_slot = [_reference(x, w3_w1, w2, topk_ids, topk_scores, a) for a in adapter_sets]
+    out = torch.empty_like(per_slot[0])
+    for t in range(x.shape[0]):
+        out[t] = per_slot[int(token_to_slot[t].item())][t]
+    return out
 
 
 @requires_cuda_and_op
@@ -182,3 +236,289 @@ def test_device_path_eager_matches_host_and_reference(monkeypatch):
     # Host vs device path are different reduction orders but should agree
     # within the same bf16 tolerance.
     torch.testing.assert_close(out_device, out_host, rtol=_RTOL, atol=_ATOL)
+
+
+def _warmup_and_capture(call_fn, warmup_iters=3):
+    """Warm up `call_fn` (so workspaces/tactics are allocated and LoRA scratch
+    is sized outside capture), then capture it into a CUDA graph. Returns
+    (graph, captured_output)."""
+    for _ in range(warmup_iters):
+        call_fn()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = call_fn()
+    return graph, captured
+
+
+@requires_cuda_and_op
+def test_device_path_cuda_graph_replay_matches_eager():
+    """Slot-indexed schema auto-selects the device path; capturing the op into a
+    CUDA graph and replaying must reproduce the eager device-path output.
+    """
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, inter_size = 16, 128, 256
+    num_experts, top_k, rank = 4, 2, 8
+
+    x, w3_w1, w2, topk_ids, topk_scores = _build_base_inputs(
+        num_tokens, hidden_size, inter_size, num_experts, top_k, dtype, device
+    )
+    adapters = _make_adapter_set(
+        num_experts, rank, hidden_size, inter_size, dtype, device, base_seed=400
+    )
+    token_to_slot = torch.zeros(num_tokens, dtype=torch.int32)
+    slot_kwargs = _slot_kwargs(token_to_slot, [adapters], rank)
+
+    def call():
+        return _call_fused_moe(x, w3_w1, w2, topk_ids, topk_scores, dtype, dict(slot_kwargs))
+
+    out_eager = call().clone()
+
+    graph, captured = _warmup_and_capture(call)
+    graph.replay()
+    torch.cuda.synchronize()
+    out_replay = captured.clone()
+
+    out_ref = _reference(x, w3_w1, w2, topk_ids, topk_scores, adapters)
+    assert torch.isfinite(out_replay).all()
+    # Replay reproduces the captured device-path computation bit-for-bit.
+    torch.testing.assert_close(out_replay, out_eager, rtol=0, atol=0)
+    torch.testing.assert_close(out_replay, out_ref, rtol=_RTOL, atol=_ATOL)
+
+
+@requires_cuda_and_op
+def test_device_path_cuda_graph_multi_adapter():
+    """Two adapter slots routed per-token via token_to_slot, captured + replayed.
+    Validates the device path threads each token's slot through the on-device
+    pointer expansion correctly.
+    """
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, inter_size = 16, 128, 256
+    num_experts, top_k, rank = 4, 2, 8
+
+    x, w3_w1, w2, topk_ids, topk_scores = _build_base_inputs(
+        num_tokens, hidden_size, inter_size, num_experts, top_k, dtype, device
+    )
+    adapter_a = _make_adapter_set(
+        num_experts, rank, hidden_size, inter_size, dtype, device, base_seed=500
+    )
+    adapter_b = _make_adapter_set(
+        num_experts, rank, hidden_size, inter_size, dtype, device, base_seed=600
+    )
+    # Even tokens -> slot 0 (adapter_a), odd tokens -> slot 1 (adapter_b).
+    token_to_slot = (torch.arange(num_tokens) % 2).to(torch.int32)
+    slot_kwargs = _slot_kwargs(token_to_slot, [adapter_a, adapter_b], rank)
+
+    def call():
+        return _call_fused_moe(x, w3_w1, w2, topk_ids, topk_scores, dtype, dict(slot_kwargs))
+
+    graph, captured = _warmup_and_capture(call)
+    graph.replay()
+    torch.cuda.synchronize()
+    out_replay = captured.clone()
+
+    out_ref = _reference_multi_slot(
+        x, w3_w1, w2, topk_ids, topk_scores, [adapter_a, adapter_b], token_to_slot
+    )
+    assert torch.isfinite(out_replay).all()
+    torch.testing.assert_close(out_replay, out_ref, rtol=_RTOL, atol=_ATOL)
+
+
+@requires_cuda_and_op
+def test_device_path_reserve_prevents_growth_across_captures():
+    """Production-mirroring positive test: pre-reserve worst-case LoRA scratch on
+    the cached runner, then capture two graphs on the SAME runner at growing slot
+    counts (1 then 2). Because reserve pre-sized to the worst case
+    (max_lora_size == 2) before any capture, neither capture reallocates the
+    device scratch, so both graphs coexist and replay correctly with no illegal
+    memory access.
+
+    This is the invariant CudaGraphLoraManager.reserve_moe_lora_cuda_graph_workspace
+    guarantees in the real decode loop, where one cached FusedMoeRunner is shared
+    across all captured batch-size graphs. It is the positive counterpart to the
+    per-test isolation fixture: without reserve, growing the slot tables 1 -> 2 on
+    a runner that already captured a graph corrupts the device scratch
+    (TRTLLM-12507).
+    """
+    from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
+    from tensorrt_llm._torch.utils import ActivationType
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, inter_size = 16, 128, 256
+    num_experts, top_k, rank = 4, 2, 8
+    max_lora_size = 2
+
+    x, w3_w1, w2, topk_ids, topk_scores = _build_base_inputs(
+        num_tokens, hidden_size, inter_size, num_experts, top_k, dtype, device
+    )
+
+    # Build (and cache) the FusedMoeRunner with the same instance key the op uses
+    # for the unquantized bf16 path: (x_dtype, weight_dtype, output_dtype) plus
+    # all-False quant flags. Then pre-reserve worst-case device scratch for
+    # max_lora_size == 2 before any capture.
+    runner = MoERunner(
+        x_dtype=dtype,
+        weight_dtype=w3_w1.dtype,
+        output_dtype=dtype,
+        top_k=top_k,
+        tp_size=1,
+        tp_rank=0,
+        ep_size=1,
+        ep_rank=0,
+        cluster_size=1,
+        cluster_rank=0,
+        use_deepseek_fp8_block_scale=False,
+        use_w4_group_scaling=False,
+        use_int8_woq_per_channel=False,
+        use_mxfp8_act_scaling=False,
+        min_latency_mode=False,
+        use_fused_finalize=True,
+        activation_type=int(ActivationType.Swiglu),
+    )
+    runner.fused_moe_runner.reserve_lora_host_buffers(
+        num_tokens,  # max_num_tokens
+        top_k,  # experts_per_token
+        rank,  # max_lora_rank
+        max_lora_size,  # max_lora_size
+        True,  # has_gated (SwiGLU)
+    )
+
+    adapter_a = _make_adapter_set(
+        num_experts, rank, hidden_size, inter_size, dtype, device, base_seed=900
+    )
+    adapter_b = _make_adapter_set(
+        num_experts, rank, hidden_size, inter_size, dtype, device, base_seed=1000
+    )
+
+    # Capture #1: a single active slot.
+    tts1 = torch.zeros(num_tokens, dtype=torch.int32)
+    sk1 = _slot_kwargs(tts1, [adapter_a], rank)
+    graph1, captured1 = _warmup_and_capture(
+        lambda: _call_fused_moe(x, w3_w1, w2, topk_ids, topk_scores, dtype, dict(sk1))
+    )
+
+    # Capture #2: two active slots on the SAME cached runner, with no cache clear
+    # in between. reserve pre-sized the slot tables to 2, so this must NOT
+    # reallocate scratch (which would invalidate graph1).
+    tts2 = (torch.arange(num_tokens) % 2).to(torch.int32)
+    sk2 = _slot_kwargs(tts2, [adapter_a, adapter_b], rank)
+    graph2, captured2 = _warmup_and_capture(
+        lambda: _call_fused_moe(x, w3_w1, w2, topk_ids, topk_scores, dtype, dict(sk2))
+    )
+
+    # Both captured graphs coexist; replay each and verify it reproduces its own
+    # adapter routing (each graph re-runs its recorded H2D + slot-expand).
+    graph1.replay()
+    graph2.replay()
+    torch.cuda.synchronize()
+
+    out1 = captured1.clone()
+    out2 = captured2.clone()
+
+    ref1 = _reference(x, w3_w1, w2, topk_ids, topk_scores, adapter_a)
+    ref2 = _reference_multi_slot(x, w3_w1, w2, topk_ids, topk_scores, [adapter_a, adapter_b], tts2)
+    assert torch.isfinite(out1).all()
+    assert torch.isfinite(out2).all()
+    torch.testing.assert_close(out1, ref1, rtol=_RTOL, atol=_ATOL)
+    torch.testing.assert_close(out2, ref2, rtol=_RTOL, atol=_ATOL)
+
+
+def _set_slot_ptrs_inplace(slot_kwargs, adapters, slot_index=0):
+    """Overwrite one slot's (A, B) pointer rows for all three modules in place,
+    preserving the pinned-tensor storage (and thus the data_ptr the captured
+    H2D reads from)."""
+    for kernel, mod in (("fc1", "fc1"), ("fc2", "fc2"), ("gated", "gated")):
+        row = torch.tensor(
+            [adapters[mod]["A"].data_ptr(), adapters[mod]["B"].data_ptr(), 0],
+            dtype=torch.int64,
+            device="cpu",
+        )
+        slot_kwargs[f"{kernel}_slot_lora_weight_ptrs"][slot_index].copy_(row)
+
+
+@requires_cuda_and_op
+def test_device_path_slot_reassignment_reflected_on_replay():
+    """In-place slot reassignment must be reflected on replay WITHOUT recapture.
+
+    The slot -> per-token expansion runs on-device (launchMoeLoraSlotExpand)
+    fed by captured H2D copies of the stable pinned slot tables. Because both
+    the copies and the expansion kernel are recorded into the graph, mutating a
+    slot's adapter pointers in place (same pinned storage) and replaying picks
+    up the new adapter, mirroring attention LoRA and the normal decode loop
+    where requests/adapters change across steps under one captured graph.
+    """
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, inter_size = 16, 128, 256
+    num_experts, top_k, rank = 4, 2, 8
+
+    x, w3_w1, w2, topk_ids, topk_scores = _build_base_inputs(
+        num_tokens, hidden_size, inter_size, num_experts, top_k, dtype, device
+    )
+    adapter_a = _make_adapter_set(
+        num_experts, rank, hidden_size, inter_size, dtype, device, base_seed=700
+    )
+    adapter_b = _make_adapter_set(
+        num_experts, rank, hidden_size, inter_size, dtype, device, base_seed=800
+    )
+
+    token_to_slot = torch.zeros(num_tokens, dtype=torch.int32)
+    # One slot whose pointers we will reassign in place.
+    slot_kwargs = _slot_kwargs(token_to_slot, [adapter_a], rank)
+
+    def call():
+        return _call_fused_moe(x, w3_w1, w2, topk_ids, topk_scores, dtype, dict(slot_kwargs))
+
+    out_ref_a = _reference(x, w3_w1, w2, topk_ids, topk_scores, adapter_a)
+    out_ref_b = _reference(x, w3_w1, w2, topk_ids, topk_scores, adapter_b)
+    # Sanity: the two adapters produce meaningfully different outputs.
+    assert (out_ref_a.float() - out_ref_b.float()).abs().mean().item() > 1e-2
+
+    # Correctness of the device-path numerics is covered by
+    # test_device_path_cuda_graph_replay_matches_eager and
+    # test_device_path_eager_matches_host_and_reference. This test targets the
+    # *reassignment* invariant, and uses a precision-robust discriminative check
+    # rather than a tight element-wise match: these randomly-drawn adapters push
+    # the SwiGLU + FC2 intermediates large enough that a few percent of output
+    # lanes fall into bf16 catastrophic cancellation (the device path is
+    # bit-identical to the host path there; both diverge from the fp32 reference
+    # only on those lanes), so an element-wise reference match is not meaningful.
+    # Instead assert that the replayed output tracks whichever adapter is
+    # currently assigned (closer in mean to its own reference than to the other)
+    # and flips when the slot is reassigned in place, all without recapture.
+    def _mean_abs(p, q):
+        return (p.float() - q.float()).abs().mean().item()
+
+    signal = _mean_abs(out_ref_a, out_ref_b)
+    assert signal > 1.0, f"adapters not distinguishable enough (signal={signal:.3e})"
+
+    graph, captured = _warmup_and_capture(call)
+    graph.replay()
+    torch.cuda.synchronize()
+    out_a = captured.clone()
+    assert torch.isfinite(out_a).all()
+    # Replay reflects the currently-assigned adapter (a).
+    assert _mean_abs(out_a, out_ref_a) < _mean_abs(out_a, out_ref_b)
+
+    # Reassign slot 0 to adapter_b *in place* (same pinned tensor storage), then
+    # replay WITHOUT re-capturing. The captured H2D + device slot-expand re-run
+    # on replay, so the output must now reflect adapter_b.
+    _set_slot_ptrs_inplace(slot_kwargs, adapter_b, slot_index=0)
+    graph.replay()
+    torch.cuda.synchronize()
+    out_b = captured.clone()
+    assert torch.isfinite(out_b).all()
+    # Reassignment took effect (output changed substantially) and now tracks b.
+    assert _mean_abs(out_b, out_a) > 0.5 * signal
+    assert _mean_abs(out_b, out_ref_b) < _mean_abs(out_b, out_ref_a)
+
+    # And switching back is likewise reflected, confirming it is not a one-shot.
+    _set_slot_ptrs_inplace(slot_kwargs, adapter_a, slot_index=0)
+    graph.replay()
+    torch.cuda.synchronize()
+    out_a2 = captured.clone()
+    assert torch.isfinite(out_a2).all()
+    assert _mean_abs(out_a2, out_ref_a) < _mean_abs(out_a2, out_ref_b)

--- a/tests/unittest/_torch/lora/test_moe_lora_op.py
+++ b/tests/unittest/_torch/lora/test_moe_lora_op.py
@@ -88,6 +88,49 @@ def _build_lora_request_buffers(
     )
 
 
+def _build_lora_slot_buffers(
+    num_tokens, fc1_a, fc1_b, fc2_a, fc2_b, rank, lora_max_low_rank=None, gated_a=None, gated_b=None
+):
+    """Pack LoRA into the slot-indexed CPU tensors used by the CUDA-graph path.
+
+    Uses a single adapter slot (max_lora_size == 1) and routes every token
+    to slot 0 via token_to_slot. The per-token expansion the op performs
+    from these tables is identical to the single-request per-request path, so
+    the two schemas must produce bit-identical kernel inputs (and outputs).
+    """
+    if lora_max_low_rank is None:
+        lora_max_low_rank = rank
+    if gated_a is None:
+        gated_a = fc1_a
+    if gated_b is None:
+        gated_b = fc1_b
+    max_lora_size = 1
+    fc1_slot_ranks = torch.tensor([rank], dtype=torch.int32, device="cpu")
+    fc2_slot_ranks = torch.tensor([rank], dtype=torch.int32, device="cpu")
+    gated_slot_ranks = torch.tensor([rank], dtype=torch.int32, device="cpu")
+    fc1_slot_ptrs = torch.tensor(
+        [[fc1_a.data_ptr(), fc1_b.data_ptr(), 0]], dtype=torch.int64, device="cpu"
+    )
+    fc2_slot_ptrs = torch.tensor(
+        [[fc2_a.data_ptr(), fc2_b.data_ptr(), 0]], dtype=torch.int64, device="cpu"
+    )
+    gated_slot_ptrs = torch.tensor(
+        [[gated_a.data_ptr(), gated_b.data_ptr(), 0]], dtype=torch.int64, device="cpu"
+    )
+    token_to_slot = torch.zeros(num_tokens, dtype=torch.int32, device="cpu")
+    assert max_lora_size == fc1_slot_ranks.size(0)
+    return dict(
+        fc1_slot_lora_ranks=fc1_slot_ranks,
+        fc1_slot_lora_weight_ptrs=fc1_slot_ptrs,
+        fc2_slot_lora_ranks=fc2_slot_ranks,
+        fc2_slot_lora_weight_ptrs=fc2_slot_ptrs,
+        gated_slot_lora_ranks=gated_slot_ranks,
+        gated_slot_lora_weight_ptrs=gated_slot_ptrs,
+        token_to_slot=token_to_slot,
+        lora_max_low_rank=lora_max_low_rank,
+    )
+
+
 def _call_fused_moe(x, w3_w1, w2, topk_ids, topk_scores, output_dtype, lora_kwargs=None):
     common = dict(
         input=x,
@@ -160,6 +203,115 @@ def test_moe_per_expert_lora_changes_output():
     assert torch.isfinite(out_lora).all()
     diff = (out_lora.float() - out_baseline.float()).abs().mean().item()
     assert diff > 1e-3, f"LoRA had no observable effect (mean abs diff={diff})"
+
+
+@requires_cuda_and_op
+def test_moe_lora_slot_indexed_matches_per_request(monkeypatch):
+    """The slot-indexed (CUDA-graph) input schema must produce bit-identical
+    output to the per-request schema for the same adapter, since both expand to
+    the same per-token (rank, A_ptr, B_ptr) arrays inside the op.
+
+    The slot-indexed schema always takes the capture-safe device path, so for an
+    apples-to-apples bit-exact comparison we force the per-request schema onto
+    the device path too (TLLM_MOE_LORA_USE_DEVICE_PATH=1). Both then share the
+    pointer-expand + grouped-GEMM kernels, so identical per-token tables yield
+    bit-identical output.
+    """
+    from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, inter_size = 16, 128, 256
+    num_experts, top_k = 4, 2
+    rank = 8
+
+    x, w3_w1, w2, topk_ids, topk_scores = _build_base_inputs(
+        num_tokens, hidden_size, inter_size, num_experts, top_k, dtype, device
+    )
+
+    fc1_adapter = make_per_expert_lora(
+        num_experts, rank, hidden_size, inter_size, dtype=dtype, device=device, seed=10
+    )
+    fc2_adapter = make_per_expert_lora(
+        num_experts, rank, inter_size, hidden_size, dtype=dtype, device=device, seed=11
+    )
+
+    per_request_kwargs = _build_lora_request_buffers(
+        num_tokens,
+        fc1_adapter["A"],
+        fc1_adapter["B"],
+        fc2_adapter["A"],
+        fc2_adapter["B"],
+        rank=rank,
+    )
+    slot_kwargs = _build_lora_slot_buffers(
+        num_tokens,
+        fc1_adapter["A"],
+        fc1_adapter["B"],
+        fc2_adapter["A"],
+        fc2_adapter["B"],
+        rank=rank,
+    )
+
+    # Force both schemas onto the device path, via a fresh runner.
+    monkeypatch.setenv("TLLM_MOE_LORA_USE_DEVICE_PATH", "1")
+    MoERunner.runner_dict.clear()
+    try:
+        out_per_request = _call_fused_moe(
+            x, w3_w1, w2, topk_ids, topk_scores, output_dtype=dtype, lora_kwargs=per_request_kwargs
+        )[0]
+        out_slot = _call_fused_moe(
+            x, w3_w1, w2, topk_ids, topk_scores, output_dtype=dtype, lora_kwargs=slot_kwargs
+        )[0]
+    finally:
+        MoERunner.runner_dict.clear()
+
+    assert torch.isfinite(out_slot).all()
+    # Identical per-token kernel inputs => bit-identical output.
+    torch.testing.assert_close(out_slot, out_per_request, rtol=0, atol=0)
+
+
+@requires_cuda_and_op
+def test_moe_lora_rejects_mixed_per_request_and_slot_indexed():
+    """Supplying both the per-request and slot-indexed schemas in one call is
+    ambiguous and must be rejected before the kernel runs.
+    """
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, inter_size = 8, 128, 256
+    num_experts, top_k = 4, 2
+    rank = 8
+
+    x, w3_w1, w2, topk_ids, topk_scores = _build_base_inputs(
+        num_tokens, hidden_size, inter_size, num_experts, top_k, dtype, device
+    )
+    fc1_adapter = make_per_expert_lora(
+        num_experts, rank, hidden_size, inter_size, dtype=dtype, device=device, seed=10
+    )
+    fc2_adapter = make_per_expert_lora(
+        num_experts, rank, inter_size, hidden_size, dtype=dtype, device=device, seed=11
+    )
+    mixed = _build_lora_request_buffers(
+        num_tokens,
+        fc1_adapter["A"],
+        fc1_adapter["B"],
+        fc2_adapter["A"],
+        fc2_adapter["B"],
+        rank=rank,
+    )
+    mixed.update(
+        _build_lora_slot_buffers(
+            num_tokens,
+            fc1_adapter["A"],
+            fc1_adapter["B"],
+            fc2_adapter["A"],
+            fc2_adapter["B"],
+            rank=rank,
+        )
+    )
+
+    with pytest.raises((RuntimeError, ValueError)):
+        _call_fused_moe(x, w3_w1, w2, topk_ids, topk_scores, output_dtype=dtype, lora_kwargs=mixed)
 
 
 @requires_cuda_and_op


### PR DESCRIPTION
## Description

This is Part 2 of routed-expert MoE LoRA on the CUTLASS backend, building on the device path merged in Part 1 (#14923). It makes the device path fully CUDA-graph capturable with per-request adapters under a single persistent graph:

- Adds an on-device slot -> token expansion kernel (moe_lora_slot_expand.cu/.h) that runs every replay, materializing the per-source-token (rank, A_ptr, B_ptr) tables from persistent device slot tables + token_to_slot.
- `moeOp.cpp`: slot-indexed input schema, persistent device slot-table buffers sized via reserve_lora_host_buffers, captured async H2D from stable pinned buffers, and auto-enabling the device path for the slot-indexed schema.
- Python wiring (`cuda_graph_lora_params.py`, `cuda_graph_lora_manager.py`, `fused_moe_cutlass.py`, `layer.py`): produces the slot-indexed `fused_moe` kwargs at decode time and packs the per-module pointer tables behind a fixed cache.

## Test Coverage

```
$ ./cpp/build/tests/unit_tests/kernels/moeLoraSlotExpandTest
$ pytest tests/unittest/_torch/lora/test_moe_lora_op.py -s -v
$ pytest tests/unittest/_torch/lora/test_moe_lora_device_path.py -s -v
$ pytest tests/unittest/_torch/lora/test_moe_lora_cuda_graph_params.py -s -v
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added slot-indexed LoRA routing for Mixture of Experts layers, enabling efficient multi-adapter support in CUDA graphs.
  * Added buffer pre-reservation mechanism for stable CUDA graph replay.
  * Extended MoE LoRA operator to support both per-request and slot-indexed input schemas.

* **Documentation**
  * Updated routed-expert MoE LoRA configuration guidance.

* **Tests**
  * Added comprehensive unit and integration tests for slot-indexed LoRA routing and CUDA graph capture scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->