### PR TITLE
[None][perf] executor: avoid deepcopy of prompt_token_ids on enqueue

### DIFF
--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -1,4 +1,3 @@
-import copy
 import datetime
 import enum
 import json
@@ -431,7 +430,7 @@ class BaseWorker(GenerationExecutor):
         else:
             lora_config = None
 
-        prompt_token_ids = copy.deepcopy(request.prompt_token_ids)
+        prompt_token_ids = list(request.prompt_token_ids)
         prompt_tuning_config = None
         if request.prompt_adapter_request is not None:
             self._load_prompt_adapter(request.prompt_adapter_request)


### PR DESCRIPTION
## What
`_enqueue_request` deep-copied `request.prompt_token_ids` on every request. It's a flat list of token ids (immutable ints), so a shallow `list(...)` gives the same isolation far more cheaply — nothing downstream mutates the list in place (the prompt-adapter path rebuilds a new list; `tllm.Request` copies `input_token_ids` into its own C++ buffer). Also drops the now-unused `import copy`.
