### PR TITLE
[TRTLLM-12870][feat] Support num_images_per_prompt for FLUX pipelines

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux.py
@@ -255,6 +255,7 @@ class FluxPipeline(BasePipeline):
             guidance_scale=req.params.guidance_scale,
             seed=req.params.seed,
             max_sequence_length=req.params.max_sequence_length,
+            num_images_per_prompt=req.params.num_images_per_prompt,
         )
 
     @torch.inference_mode()
@@ -267,6 +268,7 @@ class FluxPipeline(BasePipeline):
         guidance_scale: float = 3.5,
         seed: int = 42,
         max_sequence_length: int = 512,
+        num_images_per_prompt: int = 1,
     ):
         """Generate image(s) from text prompt(s).
 
@@ -280,9 +282,13 @@ class FluxPipeline(BasePipeline):
             guidance_scale: Embedded guidance scale (3.5 for dev)
             seed: Random seed for reproducibility.
             max_sequence_length: Maximum text sequence length
+            num_images_per_prompt: Number of images to generate per prompt.
+                Each prompt's embeddings are repeated and independent noise is
+                sampled, producing N different images per prompt.
 
         Returns:
-            PipelineOutput with image tensor (B, H, W, C).
+            PipelineOutput with image tensor (B, H, W, C) where
+            B = len(prompt) * num_images_per_prompt.
         """
         pipeline_start = time.time()
         timer = CudaPhaseTimer()
@@ -291,7 +297,9 @@ class FluxPipeline(BasePipeline):
         # Determine batch size
         if isinstance(prompt, str):
             prompt = [prompt]
-        batch_size = len(prompt)
+        if num_images_per_prompt < 1:
+            raise ValueError(f"num_images_per_prompt must be >= 1, got {num_images_per_prompt}")
+        batch_size = len(prompt) * num_images_per_prompt
 
         generator = torch.Generator(device=self.device).manual_seed(seed)
 
@@ -302,6 +310,13 @@ class FluxPipeline(BasePipeline):
             prompt, max_sequence_length
         )
         logger.info(f"Prompt encoding completed in {time.time() - encode_start:.2f}s")
+
+        # Repeat embeddings for num_images_per_prompt (diffusers convention)
+        if num_images_per_prompt > 1:
+            prompt_embeds = prompt_embeds.repeat_interleave(num_images_per_prompt, dim=0)
+            pooled_prompt_embeds = pooled_prompt_embeds.repeat_interleave(
+                num_images_per_prompt, dim=0
+            )
 
         latents, latent_ids = self._prepare_latents(batch_size, height, width, generator)
         logger.info(f"Latents shape: {latents.shape}")

--- a/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/flux/pipeline_flux2.py
@@ -348,6 +348,7 @@ class Flux2Pipeline(BasePipeline):
             guidance_scale=req.params.guidance_scale,
             seed=req.params.seed,
             max_sequence_length=req.params.max_sequence_length,
+            num_images_per_prompt=req.params.num_images_per_prompt,
         )
 
     @torch.inference_mode()
@@ -360,6 +361,7 @@ class Flux2Pipeline(BasePipeline):
         guidance_scale: float = 3.5,
         seed: int = 42,
         max_sequence_length: int = 512,
+        num_images_per_prompt: int = 1,
     ):
         """Generate image(s) from text prompt(s).
 
@@ -373,9 +375,13 @@ class Flux2Pipeline(BasePipeline):
             guidance_scale: Embedded guidance scale
             seed: Random seed for reproducibility.
             max_sequence_length: Maximum text sequence length
+            num_images_per_prompt: Number of images to generate per prompt.
+                Each prompt's embeddings are repeated and independent noise is
+                sampled, producing N different images per prompt.
 
         Returns:
-            PipelineOutput with image tensor (B, H, W, C).
+            PipelineOutput with image tensor (B, H, W, C) where
+            B = len(prompt) * num_images_per_prompt.
         """
         pipeline_start = time.time()
         timer = CudaPhaseTimer()
@@ -384,7 +390,9 @@ class Flux2Pipeline(BasePipeline):
         # Determine batch size
         if isinstance(prompt, str):
             prompt = [prompt]
-        batch_size = len(prompt)
+        if num_images_per_prompt < 1:
+            raise ValueError(f"num_images_per_prompt must be >= 1, got {num_images_per_prompt}")
+        batch_size = len(prompt) * num_images_per_prompt
 
         generator = torch.Generator(device=self.device).manual_seed(seed)
 
@@ -393,6 +401,10 @@ class Flux2Pipeline(BasePipeline):
         encode_start = time.time()
         prompt_embeds, text_ids = self._encode_prompt(prompt, max_sequence_length)
         logger.info(f"Prompt encoding completed in {time.time() - encode_start:.2f}s")
+
+        # Repeat embeddings for num_images_per_prompt (diffusers convention)
+        if num_images_per_prompt > 1:
+            prompt_embeds = prompt_embeds.repeat_interleave(num_images_per_prompt, dim=0)
 
         latents, latent_ids = self._prepare_latents(batch_size, height, width, generator)
         logger.info(f"Latents shape: {latents.shape}")

--- a/tests/unittest/_torch/visual_gen/test_flux_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_flux_pipeline.py
@@ -865,6 +865,95 @@ class TestFluxBatchGeneration:
         assert mse > 100, f"Batch images are too similar (MSE={mse:.1f}), seeding may be broken"
         print(f"\n[Batch FLUX.2] Inter-image MSE = {mse:.1f} (images differ as expected)")
 
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_flux1_num_images_per_prompt(self, flux1_pipeline):
+        """FLUX.1 num_images_per_prompt: single prompt with N>1 produces N images."""
+        prompt = "a sunset over mountains"
+        num_images = 3
+
+        result = flux1_pipeline.forward(
+            prompt=prompt,
+            height=256,
+            width=256,
+            num_inference_steps=4,
+            seed=42,
+            num_images_per_prompt=num_images,
+        )
+        assert result.image.dim() == 4, f"Expected 4D, got {result.image.shape}"
+        assert result.image.shape[0] == num_images, (
+            f"Expected {num_images} images, got {result.image.shape[0]}"
+        )
+        assert result.image.shape[1:] == (256, 256, 3)
+
+        # Images should differ (independent noise samples)
+        mse_01 = ((result.image[0].float() - result.image[1].float()) ** 2).mean().item()
+        mse_02 = ((result.image[0].float() - result.image[2].float()) ** 2).mean().item()
+        assert mse_01 > 100, f"Images 0,1 too similar (MSE={mse_01:.1f})"
+        assert mse_02 > 100, f"Images 0,2 too similar (MSE={mse_02:.1f})"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_flux2_num_images_per_prompt(self, flux2_pipeline):
+        """FLUX.2 num_images_per_prompt: single prompt with N>1 produces N images."""
+        prompt = "a cat on a roof"
+        num_images = 2
+
+        result = flux2_pipeline.forward(
+            prompt=prompt,
+            height=256,
+            width=256,
+            num_inference_steps=4,
+            seed=42,
+            num_images_per_prompt=num_images,
+        )
+        assert result.image.dim() == 4, f"Expected 4D, got {result.image.shape}"
+        assert result.image.shape == (num_images, 256, 256, 3), (
+            f"Unexpected shape: {result.image.shape}"
+        )
+
+        # Images should differ (independent noise samples)
+        mse = ((result.image[0].float() - result.image[1].float()) ** 2).mean().item()
+        assert mse > 100, f"Images too similar (MSE={mse:.1f}), seeding may be broken"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_flux1_num_images_per_prompt_batch(self, flux1_pipeline):
+        """FLUX.1 num_images_per_prompt with batch: 2 prompts * 2 images = 4 outputs."""
+        prompts = ["a sunset over mountains", "a cat on a roof"]
+        num_images = 2
+
+        result = flux1_pipeline.forward(
+            prompt=prompts,
+            height=256,
+            width=256,
+            num_inference_steps=4,
+            seed=42,
+            num_images_per_prompt=num_images,
+        )
+        expected_batch = len(prompts) * num_images
+        assert result.image.shape[0] == expected_batch, (
+            f"Expected {expected_batch} images, got {result.image.shape[0]}"
+        )
+        assert result.image.shape[1:] == (256, 256, 3)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_flux2_num_images_per_prompt_batch(self, flux2_pipeline):
+        """FLUX.2 num_images_per_prompt with batch: 2 prompts * 2 images = 4 outputs."""
+        prompts = ["a sunset over mountains", "a cat on a roof"]
+        num_images = 2
+
+        result = flux2_pipeline.forward(
+            prompt=prompts,
+            height=256,
+            width=256,
+            num_inference_steps=4,
+            seed=42,
+            num_images_per_prompt=num_images,
+        )
+        expected_batch = len(prompts) * num_images
+        assert result.image.shape[0] == expected_batch, (
+            f"Expected {expected_batch} images, got {result.image.shape[0]}"
+        )
+        assert result.image.shape[1:] == (256, 256, 3)
+
 
 # =============================================================================
 # Multi-GPU Parallelism Tests (Ulysses sequence parallelism)


### PR DESCRIPTION
## Summary

Implement `num_images_per_prompt` support for both `FluxPipeline` (FLUX.1) and `Flux2Pipeline` (FLUX.2), matching the diffusers convention.

## Problem

`num_images_per_prompt` is accepted in `VisualGenParams` and wired from the serving layer (`request.n`), but the Flux `infer()`/`forward()` methods never pass it through — batch size comes only from `len(prompt)`.

## Solution

Following the diffusers pattern:
- Effective batch = `len(prompts) * num_images_per_prompt`
- Text embeddings are repeated N times via `repeat_interleave(N, dim=0)`
- N independent noise samples are created (latents generated with expanded batch_size)
- Produces exactly N different images per prompt

## Changes

- `pipeline_flux.py`: Pass `num_images_per_prompt` through `infer()` → `forward()`, expand batch size, repeat `prompt_embeds` and `pooled_prompt_embeds`
- `pipeline_flux2.py`: Same pattern (no `pooled_prompt_embeds` in FLUX.2)
- `test_flux_pipeline.py`: Add tests for single-prompt N>1, batch+N>1 scenarios

## Testing

- `test_flux1_num_images_per_prompt`: single prompt, N=3 → 3 distinct images
- `test_flux2_num_images_per_prompt`: single prompt, N=2 → 2 distinct images
- `test_flux1_num_images_per_prompt_batch`: 2 prompts × N=2 → 4 images


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FLUX pipelines now support generating multiple images per prompt with the new `num_images_per_prompt` parameter (default: 1). Users can specify how many unique images to generate for each input prompt, including batch scenarios.

* **Tests**
  * Added comprehensive test cases validating multi-image generation for both FLUX.1 and FLUX.2 pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->