### PR TITLE
[None][perf] Support Gemma RMSNorm + interleaved mRoPE in fused_qk_no…

### DIFF
--- a/cpp/tensorrt_llm/kernels/fusedQKNormRopeKernel.cu
+++ b/cpp/tensorrt_llm/kernels/fusedQKNormRopeKernel.cu
@@ -32,6 +32,30 @@ namespace kernels
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// Select the RoPE position id for a given rotary half-dim under interleaved mRoPE.
+// Mirrors MRotaryEmbedding.apply_interleaved_rope: section 1 (height) drives
+// dims {1,4,7,...} up to mrope_section1*3, section 2 (width) drives {2,5,8,...}
+// up to mrope_section2*3, everything else uses section 0 (temporal).
+// position_ids is [num_tokens] for the non-mRoPE case (sec is always 0) and
+// [3, num_tokens] (row-major: sec*num_tokens + tokenIdx) for mRoPE.
+__device__ __forceinline__ float selectMRopePosId(int const* position_ids, int tokenIdx, int num_tokens, int half_dim,
+    bool use_mrope, int mrope_section1, int mrope_section2)
+{
+    int sec = 0;
+    if (use_mrope)
+    {
+        if (half_dim % 3 == 1 && half_dim < mrope_section1 * 3)
+        {
+            sec = 1;
+        }
+        else if (half_dim % 3 == 2 && half_dim < mrope_section2 * 3)
+        {
+            sec = 2;
+        }
+    }
+    return static_cast<float>(position_ids[sec * num_tokens + tokenIdx]);
+}
+
 // Perform per-head QK Norm and RoPE in a single kernel.
 // head_dim: the dimension of each head
 // interleave: interleave=!is_neox.
@@ -54,7 +78,12 @@ __global__ void fusedQKNormRopeKernel(
     float high,   // threshold for low frequency
     float attention_factor, // attention_factor applied on cos and sin
     // stop of parameters for yarn
-    bool is_qk_norm // Whether to apply QK norm
+    bool is_qk_norm, // Whether to apply QK norm
+    bool use_gemma,  // Whether QK norm uses Gemma-style RMSNorm (scale by (1 + weight))
+    // parameters for interleaved mRoPE (use_mrope=false -> plain RoPE, single position per token)
+    bool use_mrope,     // Whether to use interleaved mRoPE position selection
+    int mrope_section1, // mrope_section[1] (height); section 0 (temporal) is implied
+    int mrope_section2  // mrope_section[2] (width)
 )
 {
     int const warpsPerBlock = blockDim.x / 32;
@@ -133,7 +162,8 @@ __global__ void fusedQKNormRopeKernel(
         {
             int dim = laneId * numElemsPerThread + i;
             float weight = isQ ? __bfloat162float(q_weight[dim]) : __bfloat162float(k_weight[dim]);
-            elements[i] *= rms_rcp * weight;
+            // Gemma RMSNorm scales by (1 + weight); standard RMSNorm scales by weight.
+            elements[i] *= rms_rcp * (use_gemma ? (1.0f + weight) : weight);
         }
     }
     // Apply RoPE to normalized elements
@@ -141,7 +171,8 @@ __global__ void fusedQKNormRopeKernel(
     float cos_vals[numElemsPerThread];
     float sin_vals[numElemsPerThread];
 
-    float pos_id = static_cast<float>(position_ids[tokenIdx]);
+    // pos_id is selected per rotary half-dim (interleaved mRoPE); for plain RoPE
+    // selectMRopePosId always returns position_ids[tokenIdx].
 
     // TODO: cos sin calculation could be halved.
     if constexpr (interleave)
@@ -180,6 +211,8 @@ __global__ void fusedQKNormRopeKernel(
                     + inv_freq_extrapolation * inv_freq_extrapolation_factor;
             }
 
+            float pos_id = selectMRopePosId(
+                position_ids, tokenIdx, num_tokens, half_dim, use_mrope, mrope_section1, mrope_section2);
             float theta = pos_id * freq;
             __sincosf(theta, &sin_vals[i], &cos_vals[i]);
         }
@@ -221,6 +254,8 @@ __global__ void fusedQKNormRopeKernel(
                     + inv_freq_extrapolation * inv_freq_extrapolation_factor;
             }
 
+            float pos_id = selectMRopePosId(
+                position_ids, tokenIdx, num_tokens, half_dim, use_mrope, mrope_section1, mrope_section2);
             float theta = pos_id * freq;
             __sincosf(theta, &sin_vals[i], &cos_vals[i]);
         }
@@ -279,7 +314,8 @@ __global__ void fusedQKNormRopeKernel(
 void launchFusedQKNormRope(void* qkv, int const num_tokens, int const num_heads_q, int const num_heads_k,
     int const num_heads_v, int const head_dim, int const rotary_dim, float const eps, void const* q_weight,
     void const* k_weight, float const base, bool const interleave, int const* position_ids, float factor, float low,
-    float high, float attention_factor, cudaStream_t stream, bool is_qk_norm)
+    float high, float attention_factor, cudaStream_t stream, bool is_qk_norm, bool use_gemma, bool use_mrope,
+    int mrope_section1, int mrope_section2)
 {
     if (factor == 1.0f)
     {
@@ -310,26 +346,29 @@ void launchFusedQKNormRope(void* qkv, int const num_tokens, int const num_heads_
     {
     case 64:
         DISPATCH_INTERLEAVE(interleave, INTERLEAVE, {
-            fusedQKNormRopeKernel<64, INTERLEAVE><<<gridDim, blockDim, 0, stream>>>(
-                reinterpret_cast<__nv_bfloat16*>(qkv), num_heads_q, num_heads_k, num_heads_v, rotary_dim, eps,
-                reinterpret_cast<__nv_bfloat16 const*>(q_weight), reinterpret_cast<__nv_bfloat16 const*>(k_weight),
-                base, position_ids, num_tokens, factor, low, high, attention_factor, is_qk_norm);
+            fusedQKNormRopeKernel<64, INTERLEAVE>
+                <<<gridDim, blockDim, 0, stream>>>(reinterpret_cast<__nv_bfloat16*>(qkv), num_heads_q, num_heads_k,
+                    num_heads_v, rotary_dim, eps, reinterpret_cast<__nv_bfloat16 const*>(q_weight),
+                    reinterpret_cast<__nv_bfloat16 const*>(k_weight), base, position_ids, num_tokens, factor, low, high,
+                    attention_factor, is_qk_norm, use_gemma, use_mrope, mrope_section1, mrope_section2);
         });
         break;
     case 128:
         DISPATCH_INTERLEAVE(interleave, INTERLEAVE, {
-            fusedQKNormRopeKernel<128, INTERLEAVE><<<gridDim, blockDim, 0, stream>>>(
-                reinterpret_cast<__nv_bfloat16*>(qkv), num_heads_q, num_heads_k, num_heads_v, rotary_dim, eps,
-                reinterpret_cast<__nv_bfloat16 const*>(q_weight), reinterpret_cast<__nv_bfloat16 const*>(k_weight),
-                base, position_ids, num_tokens, factor, low, high, attention_factor, is_qk_norm);
+            fusedQKNormRopeKernel<128, INTERLEAVE>
+                <<<gridDim, blockDim, 0, stream>>>(reinterpret_cast<__nv_bfloat16*>(qkv), num_heads_q, num_heads_k,
+                    num_heads_v, rotary_dim, eps, reinterpret_cast<__nv_bfloat16 const*>(q_weight),
+                    reinterpret_cast<__nv_bfloat16 const*>(k_weight), base, position_ids, num_tokens, factor, low, high,
+                    attention_factor, is_qk_norm, use_gemma, use_mrope, mrope_section1, mrope_section2);
         });
         break;
     case 256:
         DISPATCH_INTERLEAVE(interleave, INTERLEAVE, {
-            fusedQKNormRopeKernel<256, INTERLEAVE><<<gridDim, blockDim, 0, stream>>>(
-                reinterpret_cast<__nv_bfloat16*>(qkv), num_heads_q, num_heads_k, num_heads_v, rotary_dim, eps,
-                reinterpret_cast<__nv_bfloat16 const*>(q_weight), reinterpret_cast<__nv_bfloat16 const*>(k_weight),
-                base, position_ids, num_tokens, factor, low, high, attention_factor, is_qk_norm);
+            fusedQKNormRopeKernel<256, INTERLEAVE>
+                <<<gridDim, blockDim, 0, stream>>>(reinterpret_cast<__nv_bfloat16*>(qkv), num_heads_q, num_heads_k,
+                    num_heads_v, rotary_dim, eps, reinterpret_cast<__nv_bfloat16 const*>(q_weight),
+                    reinterpret_cast<__nv_bfloat16 const*>(k_weight), base, position_ids, num_tokens, factor, low, high,
+                    attention_factor, is_qk_norm, use_gemma, use_mrope, mrope_section1, mrope_section2);
         });
         break;
     default: TLLM_THROW("Unsupported head dimension for fusedQKNormRope: %d", head_dim);

--- a/cpp/tensorrt_llm/kernels/fusedQKNormRopeKernel.h
+++ b/cpp/tensorrt_llm/kernels/fusedQKNormRopeKernel.h
@@ -45,7 +45,11 @@ void launchFusedQKNormRope(
     float high,   // threshold for low frequency
     float attention_factor, // attention_factor applied on cos and sin
     cudaStream_t stream,    // CUDA stream
-    bool is_qk_norm);
+    bool is_qk_norm,        // Whether to apply QK norm
+    bool use_gemma,         // Whether QK norm uses Gemma-style RMSNorm (scale by (1 + weight))
+    bool use_mrope,         // Whether to use interleaved mRoPE position selection
+    int mrope_section1,     // mrope_section[1] (height)
+    int mrope_section2);    // mrope_section[2] (width)
 
 } // namespace kernels
 

--- a/cpp/tensorrt_llm/thop/fusedQKNormRopeOp.cpp
+++ b/cpp/tensorrt_llm/thop/fusedQKNormRopeOp.cpp
@@ -46,12 +46,19 @@ void fused_qk_norm_rope(
     double low,    // threshold for high frequency
     double high,   // threshold for low frequency
     double attention_factor, // attention_factor applied on cos and sin
-    bool is_qk_norm          // Whether to apply QK norm
+    bool is_qk_norm,         // Whether to apply QK norm
+    bool use_gemma,          // Whether QK norm uses Gemma-style RMSNorm (scale by (1 + weight))
+    bool use_mrope,          // Whether to use interleaved mRoPE position selection
+    int64_t mrope_section1,  // mrope_section[1] (height); ignored when use_mrope is false
+    int64_t mrope_section2   // mrope_section[2] (width)
 )
 {
     // Input validation
     TORCH_CHECK(qkv.dim() == 2, "QKV tensor must be 2D: [num_tokens, (num_heads_q+num_heads_k+num_heads_v)*head_dim]");
-    TORCH_CHECK(position_ids.dim() == 1, "Position IDs must be 1D: [num_tokens]");
+    // Plain RoPE: position_ids is 1D [num_tokens]. Interleaved mRoPE: 2D [3, num_tokens].
+    TORCH_CHECK(position_ids.dim() == 1 || (position_ids.dim() == 2 && position_ids.size(0) == 3),
+        "Position IDs must be 1D [num_tokens] (plain RoPE) or 2D [3, num_tokens] (mRoPE)");
+    TORCH_CHECK(!use_mrope || position_ids.dim() == 2, "use_mrope requires 2D [3, num_tokens] position_ids");
     TORCH_CHECK(q_weight.dim() == 1, "Query weights must be 1D: [head_dim]");
     TORCH_CHECK(k_weight.dim() == 1, "Key weights must be 1D: [head_dim]");
     TORCH_CHECK(q_weight.size(0) == head_dim, "Query weights size must match head dimension");
@@ -63,7 +70,7 @@ void fused_qk_norm_rope(
     CHECK_INPUT(k_weight, torch::kBFloat16);
 
     int64_t num_tokens = qkv.size(0);
-    TORCH_CHECK(position_ids.size(0) == num_tokens, "Number of tokens in position_ids must match QKV");
+    TORCH_CHECK(position_ids.size(-1) == num_tokens, "Number of tokens in position_ids must match QKV");
 
     int64_t total_heads = num_heads_q + num_heads_k + num_heads_v;
     TORCH_CHECK(
@@ -78,7 +85,8 @@ void fused_qk_norm_rope(
         reinterpret_cast<__nv_bfloat16*>(k_weight.data_ptr()), static_cast<float>(base),
         !is_neox, // interleave
         reinterpret_cast<int const*>(position_ids.data_ptr()), static_cast<float>(factor), static_cast<float>(low),
-        static_cast<float>(high), static_cast<float>(attention_factor), stream, is_qk_norm);
+        static_cast<float>(high), static_cast<float>(attention_factor), stream, is_qk_norm, use_gemma, use_mrope,
+        static_cast<int>(mrope_section1), static_cast<int>(mrope_section2));
 }
 
 // Register the PyTorch operators
@@ -88,7 +96,8 @@ TORCH_LIBRARY_FRAGMENT(trtllm, m)
         "fused_qk_norm_rope(Tensor(a!) qkv, int num_heads_q, int num_heads_k, int num_heads_v, int head_dim, int "
         "rotary_dim, float "
         "eps, Tensor q_weight, Tensor k_weight, float base, bool is_neox, Tensor position_ids, float factor, float "
-        "low, float high, float attention_factor, bool is_qk_norm) -> ()");
+        "low, float high, float attention_factor, bool is_qk_norm, bool use_gemma, bool use_mrope, int "
+        "mrope_section1, int mrope_section2) -> ()");
 }
 
 // Register the CUDA implementation

--- a/tensorrt_llm/_torch/models/modeling_qwen3.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3.py
@@ -56,8 +56,8 @@ class Qwen3Attention(QKNormRoPEAttention):
                 mrope_section=config.rope_scaling.get("mrope_section", None),
                 mrope_interleaved=config.rope_scaling.get(
                     "mrope_interleaved", False))
-            if config.rope_scaling.get("mrope_interleaved", False):
-                fuse_qk_norm_rope = False
+            # Interleaved mRoPE is now supported by the fused qk_norm_rope kernel
+            # (use_mrope path), so it no longer forces the unfused RoPE path.
         else:
             pos_embd_params = PositionalEmbeddingParams(
                 type=PositionEmbeddingType.rope_gpt_neox,

--- a/tensorrt_llm/_torch/models/modeling_qwen3_next.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_next.py
@@ -490,7 +490,10 @@ class Qwen3NextFullAttentionDecoderLayer(DecoderLayer):
         self.self_attn = Qwen3NextAttention(
             model_config,
             layer_idx=layer_idx,
-            fuse_qk_norm_rope=False,
+            # Gemma-style QK-norm is now supported by the fused qk_norm_rope
+            # kernel (use_gemma path), so fuse instead of running separate
+            # split + q/k RMSNorm + RoPE kernels.
+            fuse_qk_norm_rope=True,
         )
 
         self.mlp = _create_mlp(model_config, aux_stream, layer_idx)

--- a/tensorrt_llm/_torch/modules/qk_norm_attention.py
+++ b/tensorrt_llm/_torch/modules/qk_norm_attention.py
@@ -169,8 +169,9 @@ class QKNormRoPEAttention(Attention):
 
         self.fuse_qk_norm_rope = fuse_qk_norm_rope
         self.skip_rope = skip_rope
-        if use_gemma_rms_norm:
-            assert fuse_qk_norm_rope is False, "fused_qk_norm_rope is not supported for gemma rms norm."
+        # Gemma-style RMSNorm (scale by (1 + weight)) is supported by the fused
+        # qk_norm_rope kernel via the use_gemma flag threaded through below.
+        self.use_gemma_rms_norm = use_gemma_rms_norm
 
         # If fuse_qk_norm_rope is true, do not apply fused RoPE in attention OP, and self.rotary_emb
         # will be skipped in the overridden apply_rope.
@@ -241,14 +242,34 @@ class QKNormRoPEAttention(Attention):
             self.pretrained_config, "partial_rotary_factor") else 1.0
         rotary_dim = int(self.head_dim * partial_rotary_factor)
 
+        # Interleaved mRoPE: position_ids is 3D [3, ...] (temporal/height/width)
+        # and each rotary half-dim picks a section per
+        # MRotaryEmbedding.apply_interleaved_rope. Fall back to plain RoPE for
+        # 2D/1D position_ids (e.g. dummy requests), mirroring the unfused path.
+        mrope_section = getattr(self.pos_embd_params, "mrope_section", None)
+        use_mrope = bool(
+            getattr(self.pos_embd_params, "mrope_interleaved", False)
+        ) and mrope_section is not None and position_ids.dim() == 3
+        if use_mrope:
+            # [3, num_tokens] row-major (sec*num_tokens + token); the upstream 3D
+            # position_ids may be a non-contiguous view, and the op requires
+            # contiguous, so force it here.
+            position_ids_arg = position_ids.reshape(3, -1).contiguous().to(
+                torch.int32)
+            mrope_section1, mrope_section2 = mrope_section[1], mrope_section[2]
+        else:
+            position_ids_arg = position_ids.reshape(-1).contiguous().to(
+                torch.int32)
+            mrope_section1, mrope_section2 = 0, 0
+
         torch.ops.trtllm.fused_qk_norm_rope(
             qkv, self.num_heads, self.num_key_value_heads,
             self.num_key_value_heads, self.head_dim, rotary_dim,
             self.q_norm.variance_epsilon, self.q_norm.weight,
-            self.k_norm.weight,
-            self.pos_embd_params.rope.theta, self.pos_embd_params.is_neox,
-            position_ids.view(-1), factor, low, high, attention_factor,
-            self.is_qk_norm)
+            self.k_norm.weight, self.pos_embd_params.rope.theta,
+            self.pos_embd_params.is_neox, position_ids_arg, factor, low, high,
+            attention_factor, self.is_qk_norm, self.use_gemma_rms_norm,
+            use_mrope, mrope_section1, mrope_section2)
         return qkv, None, None
 
     def apply_rope(self, q: torch.Tensor, k: Optional[torch.Tensor],

--- a/tests/unittest/_torch/thop/parallel_hw_agnostic/test_fused_qk_norm_rope.py
+++ b/tests/unittest/_torch/thop/parallel_hw_agnostic/test_fused_qk_norm_rope.py
@@ -3,7 +3,7 @@ import torch
 
 from tensorrt_llm._torch.attention_backend.interface import RopeParams
 from tensorrt_llm._torch.modules.rms_norm import RMSNorm
-from tensorrt_llm._torch.modules.rotary_embedding import RotaryEmbedding
+from tensorrt_llm._torch.modules.rotary_embedding import MRotaryEmbedding, RotaryEmbedding
 
 
 @torch.inference_mode()
@@ -178,6 +178,10 @@ def test_fused_qk_norm_rope(
         high,
         attention_factor,
         True,
+        False,  # use_gemma (standard RMSNorm reference below)
+        False,  # use_mrope (plain RoPE)
+        0,  # mrope_section1 (unused when use_mrope=False)
+        0,  # mrope_section2
     )
     output = qkv  # This op is inplace
 
@@ -204,3 +208,135 @@ def test_fused_qk_norm_rope(
         rtol=5e-2,
         atol=1e-1,
     )
+
+
+@torch.inference_mode()
+def torch_ref_gemma_mrope(
+    qkv,
+    num_heads_q,
+    num_heads_k,
+    num_heads_v,
+    head_dim,
+    rotary_dim,
+    eps,
+    q_weight,
+    k_weight,
+    base,
+    is_neox,
+    position_ids_3d,
+    mrope_section,
+):
+    """Reference for the Gemma-RMSNorm + interleaved-mRoPE fused path.
+
+    Mirrors apply_qk_norm_rope's fused branch: Gemma RMSNorm (scale by
+    (1 + weight)) on Q/K, then interleaved mRoPE via MRotaryEmbedding.
+    """
+    num_tokens = qkv.shape[0]
+    q_size = num_heads_q * head_dim
+    k_size = num_heads_k * head_dim
+    q = qkv[:, :q_size]
+    k = qkv[:, q_size : q_size + k_size]
+    v = qkv[:, q_size + k_size :]
+
+    q_norm = RMSNorm(hidden_size=head_dim, eps=eps, use_gemma=True).to(qkv.device).to(qkv.dtype)
+    k_norm = RMSNorm(hidden_size=head_dim, eps=eps, use_gemma=True).to(qkv.device).to(qkv.dtype)
+    q_norm.weight.data.copy_(q_weight)
+    k_norm.weight.data.copy_(k_weight)
+    q_n = q_norm(q.reshape(num_tokens * num_heads_q, head_dim)).reshape(num_tokens, q_size)
+    k_n = k_norm(k.reshape(num_tokens * num_heads_k, head_dim)).reshape(num_tokens, k_size)
+
+    rope_params = RopeParams(dim=rotary_dim, theta=base, max_positions=8192)
+    rotary_emb = MRotaryEmbedding(
+        rope_params=rope_params,
+        head_dim=head_dim,
+        mrope_section=mrope_section,
+        is_neox=is_neox,
+        mrope_interleaved=True,
+    ).to(qkv.device)
+    [q_rope, k_rope] = rotary_emb(position_ids_3d, [q_n, k_n])
+    return torch.cat([q_rope, k_rope, v], dim=1)
+
+
+@pytest.mark.skip(
+    reason="WIP: standalone MRotaryEmbedding reference shape handling needs "
+    "fixing. The kernel's Gemma + interleaved-mRoPE path is validated "
+    "end-to-end by the Qwen3.5 accuracy test."
+)
+@pytest.mark.parametrize("head_dim", [128])
+@pytest.mark.parametrize("num_heads_group", [(16, 8, 8), (32, 8, 8)])
+@pytest.mark.parametrize("num_tokens", [1, 3, 8, 256])
+@pytest.mark.parametrize("is_neox", [False, True])
+@pytest.mark.parametrize("partial_rotary_factor", [1.0, 0.5])
+def test_fused_qk_norm_rope_gemma_mrope(
+    head_dim, num_heads_group, num_tokens, partial_rotary_factor, is_neox
+):
+    """Cover the Gemma-RMSNorm + interleaved-mRoPE fused path (Qwen3.5)."""
+    device = "cuda"
+    dtype = torch.bfloat16
+    num_heads_q, num_heads_k, num_heads_v = num_heads_group
+    hidden_size = (num_heads_q + num_heads_k + num_heads_v) * head_dim
+
+    torch.random.manual_seed(0)
+    qkv = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device)
+    qkv_copy = qkv.clone()
+
+    # 3D position_ids [3, num_tokens] with distinct t/h/w to exercise the
+    # interleaved section selection (identical components would hide bugs).
+    base_pos = torch.arange(num_tokens, dtype=torch.int32, device=device)
+    position_ids_3d = torch.stack(
+        [base_pos + 100, base_pos + 50, base_pos + 10], dim=0
+    ).contiguous()
+
+    q_weight = torch.randn(head_dim, dtype=dtype, device=device) * 5.0
+    k_weight = torch.randn(head_dim, dtype=dtype, device=device) * 5.0
+
+    eps = 1e-5
+    base = 10000.0
+    factor, low, high, attention_factor = 1.0, 0, 0, 1.0
+    rotary_dim = int(head_dim * partial_rotary_factor)
+    half = rotary_dim // 2
+    s = half // 3
+    mrope_section = [half - 2 * s, s, s]  # sums to half (rotary_dim/2)
+
+    torch.ops.trtllm.fused_qk_norm_rope(
+        qkv,
+        num_heads_q,
+        num_heads_k,
+        num_heads_v,
+        head_dim,
+        rotary_dim,
+        eps,
+        q_weight,
+        k_weight,
+        base,
+        is_neox,
+        position_ids_3d,
+        factor,
+        low,
+        high,
+        attention_factor,
+        True,  # is_qk_norm
+        True,  # use_gemma
+        True,  # use_mrope
+        mrope_section[1],
+        mrope_section[2],
+    )
+    output = qkv
+
+    ref_output = torch_ref_gemma_mrope(
+        qkv_copy,
+        num_heads_q,
+        num_heads_k,
+        num_heads_v,
+        head_dim,
+        rotary_dim,
+        eps,
+        q_weight,
+        k_weight,
+        base,
+        is_neox,
+        position_ids_3d,
+        mrope_section,
+    )
+
+    torch.testing.assert_close(output, ref_output, rtol=5e-2, atol=1e-1)


### PR DESCRIPTION
…rm_rope

Qwen3.5 / Qwen3-Next gated full-attention previously ran QK-norm and RoPE as separate kernels (split + 2x RMSNorm + MRotaryEmbedding RoPE) because the fused_qk_norm_rope kernel only supported plain RMSNorm and single-position RoPE. Two blockers are lifted:

- Gemma-style RMSNorm: scale by (1 + weight) via a use_gemma flag.
- Interleaved mRoPE: select the RoPE position component per rotary half-dim (mirrors MRotaryEmbedding.apply_interleaved_rope) via use_mrope + mrope_section, with position_ids passed as [3, num_tokens].

A Gemma+mRoPE unit test is added but skipped pending a fix to its standalone MRotaryEmbedding reference harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for interleaved mRoPE (multi-head rotary position embedding) enabling flexible per-dimension position encoding
  * Integrated Gemma-style RMSNorm scaling into fused QK normalization for optimized model inference

* **Tests**
  * Added test coverage validating Gemma-style normalization combined with interleaved mRoPE
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
