### PR TITLE
[https://nvbugs/6248764][fix] Normalize non-sliding KV windows to full attention in AutoDeploy

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/kvcache.py
@@ -432,6 +432,15 @@ class _InsertCachedOperator(BaseTransform):
                         # None sentinel: pass literal None positionally, no resource allocated.
                         cache_in_nodes.append(None)
                     else:
+                        # A window that can't slide within max_seq_len is functionally
+                        # full attention; normalize it to 0 so the layer shares the
+                        # full-attention pool instead of forking a redundant
+                        # single-window pool.
+                        if (
+                            isinstance(resource_handler, KVPagedResourceHandler)
+                            and resource_handler.sliding_window >= cm.info.max_seq_len
+                        ):
+                            resource_handler.sliding_window = 0
                         resource_name = cm.add_resource(k, resource_handler)
                         node = self._process_cache_node(gm, resource_name)
                         cache_in_nodes.append(node)

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -13,7 +13,6 @@ accuracy/test_llm_api.py::TestMistralNemo12B::test_fp8 SKIP (https://nvbugs/5413
 accuracy/test_llm_api_autodeploy.py::TestGemma4MoE::test_bf16 SKIP (https://nvbugs/6158397)
 accuracy/test_llm_api_autodeploy.py::TestGemmaE2B::test_gemma4_e2b_it SKIP (https://nvbugs/6194934)
 accuracy/test_llm_api_autodeploy.py::TestMiniMaxM2::test_finegrained_fp8 SKIP (https://nvbugs/6158397)
-accuracy/test_llm_api_autodeploy.py::TestModelRegistryAccuracy::test_autodeploy_from_registry[google_gemma-3-1b-it-False] SKIP (https://nvbugs/6248764)
 accuracy/test_llm_api_autodeploy.py::TestModelRegistryAccuracy::test_autodeploy_from_registry[mistralai_Ministral-8B-Instruct-2410-False] SKIP (https://nvbugs/6248769)
 accuracy/test_llm_api_autodeploy.py::TestModelRegistryAccuracy::test_autodeploy_from_registry[nvidia_Llama-3.1-8B-Instruct-NVFP4-True] SKIP (https://nvbugs/6245279)
 accuracy/test_llm_api_autodeploy.py::TestNemotronNanoV3::test_accuracy[bf16-4-trtllm] SKIP (https://nvbugs/6185150)


### PR DESCRIPTION
A KV-cache layer whose `sliding_window >= max_seq_len` can never slide and is functionally full attention. The AutoDeploy kvcache transform was keying pool grouping off the raw `sliding_window`, so such a layer forked its own pool and tripped the trtllm backend's uniform-cache requirement.

For `google/gemma-3-1b-it` at `max_seq_len=511`, the local layers' `sliding_window=512` produced a `window=512` pool alongside the global `window=511` pool, failing with: `KV resources are not uniform ... requires all KV caches to share a single pool`.

This normalizes `sliding_window` to `0` (full attention) when it is `>= max_seq_len` before grouping, so the layer shares the full-attention pool.

## Test coverage
- [x] Unwaives `test_autodeploy_from_registry[google_gemma-3-1b-it-False]`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed KV cache resource pool grouping for layers with large sliding windows.

* **Tests**
  * Resolved previously failing Gemma 3.1B autodeploy accuracy test.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/TensorRT-LLM/pull/14906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->