### PR TITLE
[None][perf] PyExecutor: skip empty MPI collectives in _fetch_new_requests (+ probe hang-detector fix)

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3180,9 +3180,23 @@ class PyExecutor:
                 new_requests.extend(
                     self.executor_request_queue.get_from_request_queue(timeout))
 
-        # Broadcast requests and handle Python objects
-        new_requests, py_request_objects = self.request_broadcaster.broadcast(
-            new_requests)
+        # Probe rank 0's count via a small scalar broadcast so all ranks can
+        # symmetrically skip the heavy pickle broadcast when there is nothing
+        # to send. Matches the self.dist.broadcast(int, root=0) idiom already
+        # used elsewhere in PyExecutor.
+        if self.dist.rank == 0:
+            _new_request_count = len(new_requests)
+        else:
+            _new_request_count = 0
+        _new_request_count = self.dist.broadcast(_new_request_count, root=0)
+
+        if _new_request_count == 0:
+            new_requests = []
+            py_request_objects = None
+        else:
+            # Broadcast requests and handle Python objects
+            new_requests, py_request_objects = self.request_broadcaster.broadcast(
+                new_requests)
 
         # Validate and filter requests
         new_requests = self._handle_special_queue_items(new_requests)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3259,7 +3259,8 @@ class PyExecutor:
 
         # 6. Schedule requests across ranks (DP only)
         if self.enable_attention_dp:
-            if self.adp_router.needs_prefix_matches:
+            # Symmetric skip — after _pop_from_waiting_queue all ranks see identical new_requests.
+            if self.adp_router.needs_prefix_matches and new_requests:
                 self.adp_router.gather_prefix_matches(new_requests)
 
             all_ranks_new_requests, self.expected_num_active_requests = \

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3180,32 +3180,11 @@ class PyExecutor:
                 new_requests.extend(
                     self.executor_request_queue.get_from_request_queue(timeout))
 
-        # Probe rank 0's count via a small scalar broadcast so all ranks can
-        # symmetrically skip the heavy pickle broadcast when there is nothing
-        # to send. Matches the self.dist.broadcast(int, root=0) idiom already
-        # used elsewhere in PyExecutor.
-        if self.dist.rank == 0:
-            _new_request_count = len(new_requests)
-        else:
-            _new_request_count = 0
-        # Pause the hang detector around the probe broadcast. When the server is
-        # idle, rank 0 blocks in get_from_request_queue (already pause-wrapped
-        # above) waiting for the next request, so the non-root ranks legitimately
-        # wait here on the broadcast for an unbounded time. Without pausing, their
-        # 300s watchdog falsely trips at the warmup->serving boundary and tears
-        # the server down. This mirrors RequestBroadcaster.broadcast, whose
-        # non-root wait on the heavy broadcast this probe gates is likewise
-        # wrapped in hang_detector.pause().
-        with self.hang_detector.pause():
-            _new_request_count = self.dist.broadcast(_new_request_count, root=0)
-
-        if _new_request_count == 0:
-            new_requests = []
-            py_request_objects = None
-        else:
-            # Broadcast requests and handle Python objects
-            new_requests, py_request_objects = self.request_broadcaster.broadcast(
-                new_requests)
+        # Broadcast requests and handle Python objects. RequestBroadcaster probes
+        # the request count first and can skip the heavy payload broadcast on
+        # empty iterations.
+        new_requests, py_request_objects = self.request_broadcaster.broadcast(
+            new_requests)
 
         # Validate and filter requests
         new_requests = self._handle_special_queue_items(new_requests)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3188,7 +3188,16 @@ class PyExecutor:
             _new_request_count = len(new_requests)
         else:
             _new_request_count = 0
-        _new_request_count = self.dist.broadcast(_new_request_count, root=0)
+        # Pause the hang detector around the probe broadcast. When the server is
+        # idle, rank 0 blocks in get_from_request_queue (already pause-wrapped
+        # above) waiting for the next request, so the non-root ranks legitimately
+        # wait here on the broadcast for an unbounded time. Without pausing, their
+        # 300s watchdog falsely trips at the warmup->serving boundary and tears
+        # the server down. This mirrors RequestBroadcaster.broadcast, whose
+        # non-root wait on the heavy broadcast this probe gates is likewise
+        # wrapped in hang_detector.pause().
+        with self.hang_detector.pause():
+            _new_request_count = self.dist.broadcast(_new_request_count, root=0)
 
         if _new_request_count == 0:
             new_requests = []

--- a/tensorrt_llm/_torch/pyexecutor/request_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/request_utils.py
@@ -516,6 +516,15 @@ class RequestBroadcaster:
 
     def broadcast(self, new_requests: List) -> Tuple[List, Optional[Tuple]]:
         """Broadcast requests and Python objects across ranks."""
+        request_count = len(new_requests) if self.dist.rank == 0 else 0
+        # Idle non-root ranks can wait here while rank 0 blocks in the
+        # pause-wrapped request queue fetch, so keep the probe pause-wrapped too.
+        with self.hang_detector.pause():
+            request_count = self._broadcast_request_count(request_count)
+
+        if request_count == 0:
+            return [], None
+
         if self.dist.rank == 0:
             py_request_objects = self._collect_py_objects(new_requests)
         else:
@@ -531,6 +540,30 @@ class RequestBroadcaster:
                 )
 
         return new_requests, py_request_objects
+
+    def _broadcast_request_count(self, request_count: int) -> int:
+        """Broadcast rank 0's request count using the same PP route as requests."""
+        if self.dist.world_size == 1:
+            return request_count
+
+        if not self.dist.has_pp:
+            return self.dist.broadcast(request_count, root=0)
+
+        if self.dist.is_first_pp_rank:
+            with nvtx_range("tp_broadcast_request_count"):
+                request_count = self.dist.tp_cp_broadcast(request_count, root=0)
+
+        tag = self.dist.pp_size + 1  # Avoid the heavy request payload tag.
+
+        if not self.dist.is_first_pp_rank:
+            with nvtx_range("recv_request_count_from_prev_pp"):
+                request_count = self.dist.recv_object(self.dist.prev_pp_rank, tag)
+
+        if not self.dist.is_last_pp_rank:
+            with nvtx_range("send_request_count_to_next_pp"):
+                self.dist.send_object(request_count, self.dist.next_pp_rank, tag)
+
+        return request_count
 
     def _collect_py_objects(self, new_requests: List) -> Tuple:
         """Collect Python-only objects from requests."""


### PR DESCRIPTION
## Summary

Three changes to `PyExecutor._fetch_new_requests` that cut empty-iter MPI collective overhead on the host critical path, plus a hang-detector fix for the new probe.

**Commits:**
1. `[perf] skip empty gather_prefix_matches` (F1) — guard the KV-cache-aware prefix-match allgather on `new_requests` being non-empty.
2. `[perf] probe before heavy request broadcast` (F2) — broadcast a 1-int probe of rank-0's count before the pickle-heavy `request_broadcaster.broadcast()` so all ranks symmetrically skip when there is nothing to send.
3. `[fix] pause hang detector around request-count probe` — wrap F2's probe broadcast in `hang_detector.pause()` (see "Hang-detector fix" below).

Both skips are rank-symmetric (they branch on data already identical across ranks after the prior `_pop_from_waiting_queue` / probe), so they cannot deadlock.

## Measurements

DSv4-Pro, CTX-only, agentperf-v2, DEP=4 + attention-DP + KV-cache-aware routing, c=128, 1 node x 4 GB200.

| Variant | tot tok/s | delta vs baseline |
| --- | ---: | ---: |
| baseline | 811,856 | - |
| F1+F2 | 854,886 | +5.3% |
| **F1+F2+probe-pause (this PR)** | **847,621 (mean of 3)** | **+4.4%** |
| F1+F2 + PR #14889 | 920,670 | +13.4% |

The probe-pause commit only touches the idle watchdog path, so steady-state throughput is unchanged from F1+F2 (the +4.4% vs +5.3% is run-to-run variance, ±2-3%).

Per-NVTX-range (100 captured iters, rank 0):

| range | baseline | F1+F2 |
| --- | ---: | ---: |
| `_fetch_new_requests` (parent) | 16,384 ms | 13,956 ms (-14.8%) |
| `broadcast_payload` (heavy pickle) | 5,821 ms | 4,478 ms |
| `adp_gather_prefix_matches` | 6,887 ms | 6,267 ms |

## Hang-detector fix (commit 3) — important for disagg

F2's probe `self.dist.broadcast(_new_request_count, root=0)` was NOT wrapped in `hang_detector.pause()`. When the server is idle, rank 0 blocks in `get_from_request_queue(timeout=None)` (which IS pause-wrapped) waiting for the next request, while the non-root ranks skip the fetch and block on the probe broadcast waiting for rank 0. With the probe un-paused, the non-root ranks' 300s hang-detector watchdog falsely trips at the warmup->serving boundary and shuts the server down.

Pre-PR, that same non-root idle wait happened inside `RequestBroadcaster.broadcast` -> `_broadcast_requests`, whose non-root path is wrapped in `hang_detector.pause()`. F2 moved the wait out of a paused region; commit 3 restores it.

Reproduced on a DSv4-Pro disagg GEN server (DEP8). A/B on the same cluster, same workload, identical except the one-line wrap:

| | F2 only | F2 + pause-fix |
| --- | --- | --- |
| GEN watchdog hang | ranks 1-7 hang on `comm.Bcast` at the probe; server self-terminates | no hang |

## Why F1 / F2 are safe

After `_pop_from_waiting_queue`, every rank holds an identical `new_requests` list (deterministic pop from a globally-broadcast waiting_queue), so `len(new_requests) == 0` (F1) and the probe count (F2) are rank-symmetric: all ranks either skip together or execute together. On F2's skip path `py_request_objects` is `None`; downstream `attach_py_objects_to_requests` is already guarded by `if py_request_objects`. F2's probe uses the same `self.dist.broadcast(int, root=0)` idiom as the pre-existing `_sync_and_process_resource_governor_queue`.

## Test plan

- [x] CTX-only DSv4-Pro c128: +4.4% mean over 3 runs, no regression vs F1+F2; cache hit rate unchanged.
- [x] nsys event count confirms F1+F2 fire on the empty-iter windows.
- [x] disagg GEN A/B: pause-fix eliminates the warmup->serving watchdog hang.
- [x] CI: PyExecutor + ADP router unit tests.

## Related

Companion 1-line [PR #14889](https://github.com/NVIDIA/TensorRT-LLM/pull/14889) (`copy.deepcopy` -> `list()`) gives +11.7% on the same workload; F1+F2 stacks with it for +13.4%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
