### PR TITLE
[None][bug] DSA: read index_topk from checkpoint instead of the V4 default

### DIFF
--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -688,7 +688,16 @@ class ModelConfig(Generic[TConfig]):
             if sparse_attention_config:
                 index_n_heads = sparse_attention_config.index_n_heads or pretrained_config.index_n_heads
                 index_head_dim = sparse_attention_config.index_head_dim or pretrained_config.index_head_dim
-                index_topk = sparse_attention_config.index_topk or pretrained_config.index_topk
+                # index_topk needs an explicit-set check rather than `or`: the
+                # DeepSeekV4SparseAttentionConfig default (512) is truthy, so a
+                # plain `or` shadows the checkpoint's index_topk (e.g. Pro's
+                # 1024) whenever the user did not set it. Mirror the window_size
+                # handling below and consult model_fields_set. (index_n_heads /
+                # index_head_dim stay on `or` since their defaults are None.)
+                if 'index_topk' in sparse_attention_config.model_fields_set:
+                    index_topk = sparse_attention_config.index_topk
+                else:
+                    index_topk = pretrained_config.index_topk
                 indexer_max_chunk_size = sparse_attention_config.indexer_max_chunk_size
                 skip_indexer_for_short_seqs = sparse_attention_config.skip_indexer_for_short_seqs
                 # Pass-through DSA tuning flags so user-set values survive the
@@ -754,7 +763,13 @@ class ModelConfig(Generic[TConfig]):
                     if sparse_attention_config:
                         index_n_heads = sparse_attention_config.index_n_heads or pretrained_config.index_n_heads
                         index_head_dim = sparse_attention_config.index_head_dim or pretrained_config.index_head_dim
-                        index_topk = sparse_attention_config.index_topk or pretrained_config.index_topk
+                        # Explicit-set check (see V4 path above): only honor a
+                        # user-provided index_topk; otherwise take the
+                        # checkpoint value rather than a truthy subclass default.
+                        if 'index_topk' in sparse_attention_config.model_fields_set:
+                            index_topk = sparse_attention_config.index_topk
+                        else:
+                            index_topk = pretrained_config.index_topk
                         indexer_max_chunk_size = sparse_attention_config.indexer_max_chunk_size
                         skip_indexer_for_short_seqs = sparse_attention_config.skip_indexer_for_short_seqs
                         use_cute_dsl_topk = sparse_attention_config.use_cute_dsl_topk

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -395,6 +395,27 @@ class DeepSeekSparseAttentionConfig(BaseSparseAttentionConfig):
                         f"for non-Blackwell GPUs.")
         return self
 
+    @model_validator(mode="after")
+    def _warn_heuristic_topk_unsupported(self):
+        """Warn (not raise) when GVR Top-K is enabled with an index_topk the
+        kernel cannot accelerate.
+
+        The C++ ``indexer_topk_decode`` dispatcher silently falls back to the
+        radix Top-K path for unsupported K, so without this warning a user may
+        believe GVR is active when it is not. ``index_topk`` may still be None
+        here (it is filled from the checkpoint later), so only validate
+        concrete values.
+        """
+        supported_topk = (512, 1024, 2048)
+        if (self.enable_heuristic_topk and self.index_topk is not None
+                and self.index_topk not in supported_topk):
+            logger.warning(
+                f"enable_heuristic_topk=True but index_topk={self.index_topk} "
+                f"is not in the GVR-supported set {supported_topk}; the indexer "
+                f"will silently fall back to the radix Top-K path. Set "
+                f"index_topk to one of {supported_topk} to use GVR.")
+        return self
+
     def supports_backend(self, backend: str) -> bool:
         return backend == "pytorch"
 


### PR DESCRIPTION
## Summary

`DeepSeekV4SparseAttentionConfig` overrides `index_topk`'s default to a truthy `512` (the Flash value). `ModelConfig.from_pretrained` merges it with the checkpoint via:

```python
index_topk = sparse_attention_config.index_topk or pretrained_config.index_topk
```

The `or` short-circuits on the `512` default and **never reads the checkpoint's `index_topk`** whenever a user passes a `sparse_attention_config` without explicitly setting `index_topk` (e.g. only to enable GVR Top-K). **DeepSeek-V4 Pro** (checkpoint `index_topk=1024`) then silently runs the indexer at 512 — halving the Top-K with no error or warning. (DeepSeek-V4 Flash is unaffected because its native K equals the 512 default; DeepSeek-V3.2 is unaffected because its base config default is `None`.)

The same function already handles `window_size` correctly via `model_fields_set`; this PR applies the same pattern to `index_topk`.

## Changes

- **`model_config.py`**: gate the `index_topk` merge on `'index_topk' in sparse_attention_config.model_fields_set` on both the V4 and the V3.2/GLM indexer paths, so an explicit user value wins while the checkpoint value is used otherwise. The public field default stays `512` (api-stability default snapshots unchanged). `index_n_heads`/`index_head_dim` keep `or` since their defaults are `None`.
- **`llm_args.py`**: add a `model_validator` that **warns** (does not raise) when `enable_heuristic_topk=True` with `index_topk ∉ {512, 1024, 2048}`, since the C++ `indexer_topk_decode` dispatcher silently falls back to the radix Top-K path — without the warning a misconfigured run looks like GVR is active.

## Test Coverage

Added CPU-only unit tests (no GPU / checkpoint required) in the two canonical homes.

**`tests/unittest/_torch/test_model_config.py`** — `index_topk` checkpoint-merge contract (5 tests):
- `test_v4_pro_index_topk_falls_back_to_checkpoint` — GVR-only V4 config (no explicit `index_topk`) resolves to the checkpoint's `1024`, and asserts the old `or` merge wrongly produced `512` (the bug).
- `test_v4_explicit_index_topk_wins_over_checkpoint` — an explicit user value (`512`) is honored over checkpoint `1024`.
- `test_v4_flash_index_topk_unaffected` — Flash (checkpoint `512`) is a no-op.
- `test_v32_index_topk_falls_back_to_checkpoint` — V3.2/GLM (base default `None`) still flows the checkpoint value; documents it was never affected by the `or`.
- `test_model_fields_set_root_cause` — pins the exact Pydantic mechanism: the V4 truthy `512` default is absent from `model_fields_set` unless set explicitly.

**`tests/unittest/llmapi/test_llm_args.py`** — `TestDeepSeekHeuristicTopkValidator` for the new `_warn_heuristic_topk_unsupported` validator (6 tests, incl. parametrized supported set):
- warns on `index_topk=777` + `enable_heuristic_topk=True`;
- silent on `index_topk ∈ {512, 1024, 2048}`;
- silent when `enable_heuristic_topk=False`;
- silent when `index_topk` is `None` (not yet resolved from the checkpoint).

> The production merge lives in the nested `update_sparse_attention_indexer_config` inside `ModelConfig.from_pretrained` (not importable; an end-to-end run needs a real checkpoint + quant config). The merge test therefore mirrors the production expression against the **real** config classes and asserts the `model_fields_set` invariant the fix relies on, with a comment to keep it in sync.

### Local results (verified)

- `pytest tests/unittest/_torch/test_model_config.py tests/unittest/llmapi/test_llm_args.py::TestDeepSeekHeuristicTopkValidator` → **25 passed**.
- `pytest tests/unittest/api_stability` (llm) → **35 passed** (public `index_topk` default `512` unchanged).
- pre-commit (ruff / ruff-format / isort / autoflake / codespell / …): **clean**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Runtime verification (end-to-end, B300 × 8)

DeepSeek-V4 **Pro** + DEP + GVR heuristic Top-K (`enable_heuristic_topk=True`) + MTP=3, exercising the `index_topk=1024` dispatch path on Pro:

| Axis | Value |
|---|---|
| Model | DSv4 Pro (checkpoint `index_topk=1024`) |
| Mode | DEP (TP=8, EP=8, `enable_attention_dp=true`) |
| GVR | ON (`enable_heuristic_topk=true`, top-K=1024 path) |
| MTP | 3 |
| ISL / OSL | 64K / 8K tokens |
| Batch size / concurrency | 8 |
| Platform | 8× B300 SXM6 |

Steady-state decode iter log (iter 987–1001):
- `host_step_time` ≈ **18.3 ms/step**
- `num_generation_tokens` = **4/step** (MTP=3; 3/3 draft tokens accepted each step)
- Effective TPOT ≈ **4.6 ms/output token**

The heuristic Top-K path ran without falling back to radix, confirming the fix correctly routes Pro to the `index_topk=1024` kernel dispatch.

### GSM8K accuracy verification (Pro + MTP=3 + GVR top-K=1024, TEP and DEP, B300 × 8)

End-to-end accuracy on full GSM8K (1319 problems, 5-shot, instruct mode) with the fix applied:

| Mode | flexible-extract | strict-match | Average |
|---|---|---|---|
| **TEP** (TP=8, EP=8) | 96.59 | 96.66 | **96.63** |
| **DEP** (TP=8, EP=8, `enable_attention_dp=true`) | 96.51 | 96.51 | **96.51** |
| Δ (TEP − DEP) | +0.08 pp | +0.15 pp | **+0.12 pp** |

Reference baselines: in-tree YAML 95.11 (B200 TP=8, no CUDA Graph, no MTP); B300 TP=4 default-config 95.38.

Both TEP and DEP exceed the references by >1 pp. The TEP–DEP delta (0.12 pp) is within the ±0.5 pp standard error — no accuracy regression from enabling attention data-parallelism. The fix correctly routes Pro to `index_topk=1024` in both parallelism modes without impacting correctness.
🤖 Generated with [Claude Code](https://claude.com/claude-code)