### PR TITLE
[None][fix] kv_cache_v2: fix SWA scratch on deferred-context revert under ADP balance

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/resource_manager.py
+++ b/tensorrt_llm/_torch/pyexecutor/resource_manager.py
@@ -2734,7 +2734,23 @@ class KVCacheManagerV2(BaseResourceManager):
             return
         if pre_cap >= kv_cache.capacity:
             return
-        if not kv_cache.resize(pre_cap):
+        if kv_cache.has_scratch_slots:
+            # Prefill grew past the SWA window and allocated scratch slots, so a
+            # plain capacity shrink is impossible: resize() refuses to shrink
+            # while scratch slots are live, and its SWA-scratch path assumes a
+            # generation-time window slide (history_length >= old_capacity -
+            # max_rewind_len) that a not-yet-forwarded context request does not
+            # satisfy. suspend() frees the scratch slots and releases all pages
+            # back to the pool for the defer window; the request is resumed via
+            # prepare_context() -> _resume_and_restore() on its next schedule,
+            # the same machinery used by generation and the pre_cap > 0 path.
+            kv_cache.suspend()
+            return
+        # No scratch slots: undo the pure capacity grow (history_length and SWA
+        # scratch are untouched by the grow) as a scratch-free shrink. Engaging
+        # SWA scratch reuse would assert the generation-time window-slide
+        # invariant above, which this deferred-context revert does not satisfy.
+        if not kv_cache.resize(pre_cap, allow_swa_scratch_reuse=False):
             raise RuntimeError(
                 f"Failed to revert KV cache capacity for context "
                 f"request {req.py_request_id} from "

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_core/_kv_cache.py
@@ -661,7 +661,13 @@ class _KVCache:
     # two APIs) where we use more pages than necessary for SWA layers. So we use a single API to avoid
     # this. Usually this is a concern only for prefill phase where we create many tokens in one step. For
     # other cases, we can just set the capacity and history_length properties instead.
-    def resize(self, capacity: int | None, history_length: int | None = None) -> bool:
+    def resize(
+        self,
+        capacity: int | None,
+        history_length: int | None = None,
+        *,
+        allow_swa_scratch_reuse: bool = True,
+    ) -> bool:
         assert self.status == self.Status.ACTIVE
         tokens_per_block = self.tokens_per_block
         assert div_up(self._capacity, tokens_per_block) == len(self._blocks)
@@ -678,8 +684,12 @@ class _KVCache:
         if capacity < history_length:
             raise ValueError("History length cannot be greater than capacity")
         manager = self.manager
-        # Scratch reuse: compute scratch ranges and slot delta
-        enable_scratch = self.enable_swa_scratch_reuse
+        # Scratch reuse: compute scratch ranges and slot delta.
+        # Callers undoing a pure capacity grow (see revert_allocate_context)
+        # pass allow_swa_scratch_reuse=False: the SWA scratch path asserts a
+        # generation-time window-slide invariant that a capacity revert does
+        # not satisfy, and there is no scratch state to preserve in that case.
+        enable_scratch = self.enable_swa_scratch_reuse and allow_swa_scratch_reuse
         if enable_scratch and capacity != self._capacity:
             max_rewind_len = self._swa_scratch_max_rewind_len()
             min_history_length = max(0, self._capacity - max_rewind_len)


### PR DESCRIPTION
## Summary

`revert_allocate_context()` undoes the per-iteration `resize_context()` capacity grow when attention-DP balance (`attention_dp_config.enable_balance`) or batch-waiting defers a context request after V2 scheduling. On sliding-window-attention (SWA) layers this collided with SWA scratch reuse and crashed DeepSeek-V4 DEP8 runs once `adp_balance` was enabled.

Two failure modes:
1. A freshly-deferred context (`history_length == 0`) tripped `resize()`'s SWA-scratch invariant `history_length >= old_capacity - max_rewind_len` (which only holds for a generation-time window slide) — e.g. `AssertionError: SWA scratch requires old_capacity - max_rewind_len (965) <= history_length (0) <= old_capacity (965)`.
2. A context whose prefill grew past the sliding window holds scratch slots, and `resize()` refuses to shrink while scratch slots are live.

## Fix

- `_KVCache.resize()` gains a keyword-only `allow_swa_scratch_reuse` (default `True`). The revert path passes `False` to perform a scratch-free capacity shrink, leaving the generation-time window-slide path untouched.
- `revert_allocate_context()` `suspend()`s caches that hold scratch slots — freeing the scratch slots and releasing pages back to the pool — and resumes them via `prepare_context()` / `_resume_and_restore()` on the next schedule (the same machinery generation and the existing `pre_cap > 0` revert already use).

`adp_balance` stays fully functional and deferred pages are still freed during the wait window (no KV-cache capacity regression).

## Test

DSv4 DEP8 (TP8/EP8, attention-DP), `adp_balance` (`timeout_iters=100`, `batching_wait_iters=20`), SWA, MTP0, NVFP4, bs128 / conc256 on GB200:

- **Before:** crashes in warmup with `SWA scratch requires ...`.
- **After:** the full benchmark completes (Total Token Throughput ~13.6k tok/s) with 0 SWA assertions and 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
