### PR TITLE
[https://nvbugs/6217533][fix] Prevent eviction-queue heap corruption from duplicate releaseBlock

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/evictionPolicy.cpp
+++ b/cpp/tensorrt_llm/batch_manager/evictionPolicy.cpp
@@ -183,6 +183,15 @@ void LRUEvictionPolicy::releaseBlock(BlockPtr block, bool toFront)
     SizeType32 const cacheLevel = getCacheLevel(block);
     SizeType32 const id = block->getBlockId();
 
+    // A block occupies at most one free-queue slot. Releasing an already-queued block would
+    // insert a duplicate list node, orphaning the first and later double-freeing in claimBlock().
+    // Drop the duplicate release instead.
+    if (mFreeBlockIterators[id].has_value())
+    {
+        TLLM_LOG_WARNING("Block (id %d) released while already in the free queue; ignoring duplicate release", id);
+        return;
+    }
+
     // If there are no children, this is a leaf block. Insert into a queue.
     auto& q = mFreeQueues[cacheLevel][getPriorityIdx(block->getPriority())];
     if (toFront)

--- a/cpp/tests/unit_tests/batch_manager/evictionPolicyTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/evictionPolicyTest.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <set>
 #include <vector>
 
 namespace tk = tensorrt_llm::kernels;
@@ -116,6 +117,43 @@ TEST_F(LRUPolicyTest, ReleaseBlockTest)
     policy->releaseBlock(origPrimaryBlock);
 
     EXPECT_NE(origPrimaryBlock->getBlockId(), std::get<0>(policy->getFreeBlock(0))->getBlockId());
+}
+
+// A duplicate releaseBlock (same block released twice without an intervening claim) must not
+// insert a second free-queue node: pre-fix it double-counted the block and handed it out twice.
+TEST_F(LRUPolicyTest, DoubleReleaseDoesNotCorruptFreeQueue)
+{
+    constexpr SizeType32 kPrimaryLevel = 0;
+
+    // Claim a block so it leaves the free queue.
+    auto block = std::get<0>(policy->getFreeBlock(kPrimaryLevel));
+    policy->claimBlock(block);
+    auto const freeAfterClaim = policy->getNumFreeBlocks(kPrimaryLevel);
+
+    // Legitimate release: the block returns to the free queue exactly once.
+    policy->releaseBlock(block);
+    EXPECT_EQ(policy->getNumFreeBlocks(kPrimaryLevel), freeAfterClaim + 1);
+
+    // Buggy double release (no intervening claim). Must NOT add a duplicate queue entry.
+    policy->releaseBlock(block);
+    EXPECT_EQ(policy->getNumFreeBlocks(kPrimaryLevel), freeAfterClaim + 1)
+        << "duplicate release inflated the free-block count (orphaned duplicate queue node)";
+
+    // The queue must remain internally consistent.
+    EXPECT_TRUE(policy->verifyQueueIntegrity());
+
+    // Drain the primary queue: every block handed out must be distinct. A duplicate
+    // node would hand out `block` twice (and/or hand out an already-claimed block).
+    std::set<KVCacheBlock::IdType> seen;
+    auto const numFree = policy->getNumFreeBlocks(kPrimaryLevel);
+    for (SizeType32 i = 0; i < numFree; ++i)
+    {
+        auto handedOut = std::get<0>(policy->getFreeBlock(kPrimaryLevel));
+        EXPECT_TRUE(seen.insert(handedOut->getBlockId()).second)
+            << "free queue handed out block id " << handedOut->getBlockId() << " more than once";
+        policy->claimBlock(handedOut);
+    }
+    EXPECT_EQ(policy->getNumFreeBlocks(kPrimaryLevel), 0);
 }
 
 TEST_F(LRUPolicyTest, PooledPlaceholderReleaseReturnsToPlaceholderQueue)


### PR DESCRIPTION
LRUEvictionPolicy::releaseBlock inserted a new free-queue list node every time it was called, with no check for whether the block was already queued. A caller that releases a block already in the free queue -- e.g. WindowBlockManager::releaseBlocks iterating a sequence's allocated-block list and calling releaseBlock once per element whenever refcount==0, when a block appears more times than its reference count -- inserted a duplicate std::list node while mFreeBlockIterators[id] only remembered the latest one. The orphaned node kept the block in the free queue after it was claimed and handed to another sequence, aliasing an in-use block and double-freeing a list node. This surfaced as `free(): invalid next size (fast)` / SIGABRT deep in LRUEvictionPolicy::claimBlock on Kimi-K2.5-NVFP4 disaggregated context workers.

Enforce the eviction policy's invariant that a block occupies at most one free-queue slot: if mFreeBlockIterators[id] is already set, log a warning and return instead of inserting a duplicate. This converts the latent heap corruption into a safe, logged no-op regardless of which caller has the reference-count imbalance, while keeping the underlying imbalance observable for follow-up.

Add LRUPolicyTest.DoubleReleaseDoesNotCorruptFreeQueue, which reproduces the duplicate release: it fails before the fix (inflated free-block count and the same block handed out twice) and passes after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory management issue in the batch manager's eviction policy where duplicate operations on memory blocks could corrupt the internal free-queue structure and cause invalid memory behavior.

* **Tests**
  * Added regression test to ensure duplicate block operations are safely handled without queue structure corruption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
