### PR TITLE
[None][fix] Optimize cache-aware router backfill and validate worker handshake

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv4.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv4.py
@@ -2490,7 +2490,7 @@ class DeepseekV4Model(DecoderModel):
 class DeepseekV4ForCausalLM(SpecDecOneEngineForCausalLM[DeepseekV4Model, PretrainedConfig]):
     @classmethod
     def get_model_defaults(cls, llm_args: "TorchLlmArgs") -> dict:
-        return {"kv_cache_config": {"tokens_per_block": 128}}
+        return {"kv_cache_config": {"tokens_per_block": 128, "use_kv_cache_manager_v2": True}}
 
     def __init__(self, model_config: ModelConfig[PretrainedConfig]):
         self.mapping_with_cp = None

--- a/tensorrt_llm/llmapi/disagg_utils.py
+++ b/tensorrt_llm/llmapi/disagg_utils.py
@@ -239,6 +239,13 @@ def extract_router_config(server_cfg: dict) -> RouterConfig:
         if key in server_cfg:
             args[key] = server_cfg[key]
 
+    # tokens_per_block lives under kv_cache_config; the cache-aware router must
+    # use the same block size as the worker or block hashes never match. Carry
+    # the explicit server value over unless the router block already set it.
+    kv_cache_config = server_cfg.get("kv_cache_config") or {}
+    if "tokens_per_block" not in args and "tokens_per_block" in kv_cache_config:
+        args["tokens_per_block"] = kv_cache_config["tokens_per_block"]
+
     return RouterConfig(type=router_type, args=args)
 
 

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -1836,12 +1836,18 @@ class OpenAIServer(_VideoRoutesMixin):
     async def get_server_info(self) -> JSONResponse:
         content = {"disaggregated_params": self.generator.disaggregated_params}
         args = getattr(self.generator, "args", None)
-        kv_cache_config = getattr(args, "kv_cache_config", None)
-        if kv_cache_config is not None:
-            content[
-                "kv_cache_hash_algo"] = get_effective_kv_cache_event_hash_algo(
-                    kv_cache_config.kv_cache_event_hash_algo,
-                    kv_cache_config.use_kv_cache_manager_v2)
+        if args is not None:
+            if args.max_batch_size is not None:
+                content["max_batch_size"] = args.max_batch_size
+            kv_cache_config = args.kv_cache_config
+            if kv_cache_config is not None:
+                content[
+                    "kv_cache_hash_algo"] = get_effective_kv_cache_event_hash_algo(
+                        kv_cache_config.kv_cache_event_hash_algo,
+                        kv_cache_config.use_kv_cache_manager_v2)
+                if kv_cache_config.tokens_per_block is not None:
+                    content[
+                        "tokens_per_block"] = kv_cache_config.tokens_per_block
         return JSONResponse(content=content)
 
     async def openai_image_generation(self, request: ImageGenerationRequest,

--- a/tensorrt_llm/serve/router.py
+++ b/tensorrt_llm/serve/router.py
@@ -136,6 +136,7 @@ class KvCacheAwareServerState(ServerState):
         }
         self._kv_cache_hash_algo = KV_CACHE_HASH_ALGO_DEFAULT
         self._tokens_per_block = tokens_per_block
+        self._poll_task: Optional[asyncio.Task] = None
 
     @property
     def hash_algo(self) -> str:
@@ -165,8 +166,7 @@ class KvCacheAwareServerState(ServerState):
         hash_algo = self._resolve_hash_algo(hash_algo)
         self.set_hash_algo(hash_algo)
         block_table = self._block_table(hash_algo)
-        for block_hash in block_hashes:
-            block_table.add(block_hash)
+        block_table.update(block_hashes)
 
     def remove_blocks(self,
                       block_hashes: Iterable[BlockHash],
@@ -174,8 +174,7 @@ class KvCacheAwareServerState(ServerState):
         hash_algo = self._resolve_hash_algo(hash_algo)
         self.set_hash_algo(hash_algo)
         block_table = self._block_table(hash_algo)
-        for block_hash in block_hashes:
-            block_table.discard(block_hash)
+        block_table.difference_update(block_hashes)
 
     def update_with_events(self, events: Iterable[dict]):
         # event_raw: {"id": <id>, "data": <event body>}
@@ -236,6 +235,13 @@ class KvCacheAwareServerState(ServerState):
         except Exception as e:
             logger.warning(
                 f"Failed to poll KV cache events from {self._server}: {e}")
+
+    def schedule_poll_and_update(self, session=None) -> None:
+        # Coalesce: skip if a poll is already in-flight for this server.
+        # The strong ref on _poll_task keeps the task alive for the GC.
+        if self._poll_task is not None and not self._poll_task.done():
+            return
+        self._poll_task = asyncio.create_task(self.poll_and_update(session))
 
     def num_active_tokens(self):
         return self._num_active_tokens
@@ -950,6 +956,8 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
                  tokens_per_block: int = 32,
                  custom_tokenizer: Optional[str] = None,
                  backfill_block_hashes_on_finish: bool = False,
+                 load_weight: float = 1.0,
+                 load_cap: float = 0.8,
                  **kwargs):
         super().__init__(server_role, servers, metadata_server_cfg,
                          metadata_server, **kwargs)
@@ -957,20 +965,98 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
         self._init_load_balancing(servers, use_tokens)
         # TODO: use max_num_tokens? per server?
         self._max_batch_size = max_batch_size
+        self._load_weight = load_weight
+        self._load_cap = load_cap
         # Opt-in workaround for the disagg-gen path that doesn't emit
         # kv_cache_events. Stash hashes at routing, inject on finish.
         self._backfill_block_hashes_on_finish = backfill_block_hashes_on_finish
-        self._pending_block_hashes: dict[int, tuple[list, str]] = {}
+        self._inflight_backfill_hashes: dict[int, tuple[list[BlockHash],
+                                                        str]] = {}
 
     def _create_server_state(self, server: str) -> KvCacheAwareServerState:
         return KvCacheAwareServerState(server, self._use_tokens,
                                        self._tokens_per_block,
                                        lambda: self.session)
 
-    async def _get_server_hash_algo(self, server: str) -> str:
-        server_info = self._server_info.get(server, {})
-        hash_algo = server_info.get("kv_cache_hash_algo")
-        return await self._server_state[server].get_hash_algo(hash_algo)
+    def _stash_backfill_on_route(self, request: OpenAIRequest,
+                                 block_hashes: list[list[BlockHash]],
+                                 hash_algo: str) -> None:
+        if not self._backfill_block_hashes_on_finish:
+            return
+        flat = [h for hl in block_hashes for h in hl]
+        self._inflight_backfill_hashes[id(request)] = (flat, hash_algo)
+
+    def _apply_backfill_on_finish(self, request: OpenAIRequest,
+                                  server: Optional[str], success: bool) -> None:
+        # Pop unconditionally to avoid leaks; apply only when eligible.
+        entry = self._inflight_backfill_hashes.pop(id(request), None)
+        if not (self._backfill_block_hashes_on_finish and success):
+            return
+        if entry is None:
+            return
+        if server is None or server not in self._server_state:
+            return
+        flat_block_hashes, hash_algo = entry
+        self._server_state[server].add_blocks(flat_block_hashes,
+                                              hash_algo=hash_algo)
+
+    def _get_server_hash_algo(self, server: str) -> str:
+        # Lock-free attribute read; state is seeded at handshake and refreshed
+        # by update_with_events.
+        return self._server_state[server].hash_algo
+
+    def _server_capacity(self, server: str) -> int:
+        # Per-server max_batch_size from /server_info; fallback for older workers.
+        info = self._server_info.get(server, {})
+        capacity = info.get("max_batch_size")
+        if capacity is not None and capacity > 0:
+            return capacity
+        return self._max_batch_size
+
+    async def _prepare_server(self, server: str):
+        await super()._prepare_server(server)
+        if server not in self._prepared_ready_servers:
+            return
+        info = self._server_info.get(server, {})
+        worker_tpb = info.get("tokens_per_block")
+        if worker_tpb is not None and worker_tpb != self._tokens_per_block:
+            # Block-hash chunking is router-side; a mismatch makes hashes never
+            # match the worker's KV cache. Fail fast.
+            self._prepared_ready_servers.discard(server)
+            self._server_info.pop(server, None)
+            raise RuntimeError(
+                f"tokens_per_block mismatch on {server}: "
+                f"router={self._tokens_per_block} worker={worker_tpb}. "
+                f"Align kv_cache_config.tokens_per_block to fix.")
+        worker_mbs = info.get("max_batch_size")
+        if worker_mbs is not None and worker_mbs != self._max_batch_size:
+            # Soft sanity: router will use the worker value via
+            # _server_capacity, but flag the disagreement so the operator
+            # notices an unintended config skew.
+            logger.warning(
+                f"max_batch_size mismatch on {server}: "
+                f"router_init={self._max_batch_size} worker={worker_mbs}. "
+                f"Router will use the worker value for load normalization.")
+        worker_algo = info.get("kv_cache_hash_algo")
+        known_algos = {
+            KV_CACHE_HASH_ALGO_V1,
+            KV_CACHE_HASH_ALGO_V2,
+            KV_CACHE_HASH_ALGO_V2_SHA256_64,
+        }
+        if worker_algo is None:
+            # Silent default would map a V2 worker's hashes to V1.
+            logger.warning(
+                f"{server} did not expose kv_cache_hash_algo in /server_info; "
+                f"router will assume {KV_CACHE_HASH_ALGO_DEFAULT}.")
+        elif worker_algo not in known_algos:
+            self._prepared_ready_servers.discard(server)
+            self._server_info.pop(server, None)
+            raise RuntimeError(
+                f"Unknown kv_cache_hash_algo on {server}: {worker_algo!r}. "
+                f"Router supports {sorted(known_algos)}.")
+        else:
+            # Persist once so per-request reads can skip the lock+await.
+            self._server_state[server].set_hash_algo(worker_algo)
 
     async def get_next_server(
             self,
@@ -986,7 +1072,7 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
                     f"No available servers after excluding {exclude_server}")
         cache_salt_id = self._get_request_cache_salt_id(request)
         hash_algo_by_server = {
-            server: await self._get_server_hash_algo(server)
+            server: self._get_server_hash_algo(server)
             for server in servers
         }
         # Tokenize + block-hash is CPU-bound (~50 ms p50 for a 40 k-token
@@ -1006,11 +1092,14 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
                     for hash_list in block_hashes) * self._tokens_per_block, 1)
             for hash_algo, block_hashes in block_hashes_by_algo.items()
         }
-        # select the server by (KV match - load)
-        # TODO: more options
+        # select the server by (KV match - load), bounded by load_cap
         workloads = [
             self._server_state[server].num_active_requests()
             for server in servers
+        ]
+        load_fractions = [
+            workloads[i] / self._server_capacity(servers[i])
+            for i in range(len(servers))
         ]
         scores = []
         matches = []
@@ -1022,11 +1111,17 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
             # https://github.com/ai-dynamo/dynamo/blob/main/docs/kv_cache_routing.md#kv-cache-routing-and-load-balancing
             matches.append(await self._server_state[server].matched_tokens(
                 block_hashes, hash_algo))
-            score = matches[-1] / padded_tokens - workloads[
-                i] / self._max_batch_size
+            score = matches[-1] / padded_tokens - self._load_weight * \
+                load_fractions[i]
             scores.append(score)
-        max_score = max(scores)
-        tied = [i for i, s in enumerate(scores) if s == max_score]
+        # Hard cap: drop overloaded servers; fall back to all if none remain.
+        candidate_idx = [
+            i for i, lf in enumerate(load_fractions) if lf < self._load_cap
+        ]
+        if not candidate_idx:
+            candidate_idx = list(range(len(servers)))
+        max_score = max(scores[i] for i in candidate_idx)
+        tied = [i for i in candidate_idx if scores[i] == max_score]
         winner = tied[self._rr_counter % len(tied)]
         self._rr_counter += 1
         server = servers[winner]
@@ -1034,9 +1129,7 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
         block_hashes = block_hashes_by_algo[hash_algo]
         async with self._lock:
             await self._register_request(server, request)
-            if self._backfill_block_hashes_on_finish:
-                self._pending_block_hashes[id(request)] = (block_hashes,
-                                                           hash_algo)
+            self._stash_backfill_on_route(request, block_hashes, hash_algo)
         return server, {
             "block_hashes": block_hashes,  # list[list[int | str]]
             "hash_algo": hash_algo,
@@ -1051,21 +1144,12 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
                              success: bool = True):
         async with self._lock:
             server = self._req_routing_table.pop(id(request), None)
-            # Pop unconditionally to avoid leaks; only use for backfill on success.
-            pending = self._pending_block_hashes.pop(id(request), None)
-            if not (self._backfill_block_hashes_on_finish and success):
-                pending = None
             if server is not None and server in self._server_state:
                 await self._server_state[server].decrement_load(request)
+        self._apply_backfill_on_finish(request, server, success)
         if server is not None and server in self._server_state:
-            # Inject just-served block_hashes into server state — see __init__ note.
-            if pending is not None:
-                block_hashes, hash_algo = pending
-                flat_hashes = (h for hash_list in block_hashes
-                               for h in hash_list)
-                self._server_state[server].add_blocks(flat_hashes,
-                                                      hash_algo=hash_algo)
-            await self._server_state[server].poll_and_update(session)
+            # Fire-and-forget; poll runs in background and coalesces per server.
+            self._server_state[server].schedule_poll_and_update(session)
 
     def _on_servers_updated(self, old_servers, new_servers):
         new_state = {}

--- a/tensorrt_llm/serve/router.py
+++ b/tensorrt_llm/serve/router.py
@@ -137,6 +137,8 @@ class KvCacheAwareServerState(ServerState):
         self._kv_cache_hash_algo = KV_CACHE_HASH_ALGO_DEFAULT
         self._tokens_per_block = tokens_per_block
         self._poll_task: Optional[asyncio.Task] = None
+        self._poll_pending: bool = False
+        self._poll_session = None
 
     @property
     def hash_algo(self) -> str:
@@ -237,11 +239,34 @@ class KvCacheAwareServerState(ServerState):
                 f"Failed to poll KV cache events from {self._server}: {e}")
 
     def schedule_poll_and_update(self, session=None) -> None:
-        # Coalesce: skip if a poll is already in-flight for this server.
+        # Coalesce concurrent polls into one in-flight task, but record that a
+        # fresh poll was requested so the running task re-polls once more before
+        # exiting. Without the re-arm, a poll requested by the LAST
+        # finish_request while a poll is already in flight would be dropped and
+        # its KV events stranded until the next request (which may never come).
         # The strong ref on _poll_task keeps the task alive for the GC.
+        self._poll_pending = True
+        self._poll_session = session
         if self._poll_task is not None and not self._poll_task.done():
             return
-        self._poll_task = asyncio.create_task(self.poll_and_update(session))
+        self._poll_task = asyncio.create_task(self._drain_poll_and_update())
+
+    async def _drain_poll_and_update(self) -> None:
+        while self._poll_pending:
+            self._poll_pending = False
+            await self.poll_and_update(self._poll_session)
+
+    async def cancel_poll_task(self) -> None:
+        # Cancel and await the background poll so shutdown leaves no orphaned
+        # task polling a closed session.
+        self._poll_pending = False
+        if self._poll_task is not None and not self._poll_task.done():
+            self._poll_task.cancel()
+            try:
+                await self._poll_task
+            except asyncio.CancelledError:
+                pass
+        self._poll_task = None
 
     def num_active_tokens(self):
         return self._num_active_tokens
@@ -957,7 +982,7 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
                  custom_tokenizer: Optional[str] = None,
                  backfill_block_hashes_on_finish: bool = False,
                  load_weight: float = 1.0,
-                 load_cap: float = 0.8,
+                 load_cap: float = float("inf"),
                  **kwargs):
         super().__init__(server_role, servers, metadata_server_cfg,
                          metadata_server, **kwargs)
@@ -977,6 +1002,11 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
         return KvCacheAwareServerState(server, self._use_tokens,
                                        self._tokens_per_block,
                                        lambda: self.session)
+
+    async def close(self):
+        for state in self._server_state.values():
+            await state.cancel_poll_task()
+        await super().close()
 
     def _stash_backfill_on_route(self, request: OpenAIRequest,
                                  block_hashes: list[list[BlockHash]],
@@ -1005,14 +1035,6 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
         # by update_with_events.
         return self._server_state[server].hash_algo
 
-    def _server_capacity(self, server: str) -> int:
-        # Per-server max_batch_size from /server_info; fallback for older workers.
-        info = self._server_info.get(server, {})
-        capacity = info.get("max_batch_size")
-        if capacity is not None and capacity > 0:
-            return capacity
-        return self._max_batch_size
-
     async def _prepare_server(self, server: str):
         await super()._prepare_server(server)
         if server not in self._prepared_ready_servers:
@@ -1028,15 +1050,6 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
                 f"tokens_per_block mismatch on {server}: "
                 f"router={self._tokens_per_block} worker={worker_tpb}. "
                 f"Align kv_cache_config.tokens_per_block to fix.")
-        worker_mbs = info.get("max_batch_size")
-        if worker_mbs is not None and worker_mbs != self._max_batch_size:
-            # Soft sanity: router will use the worker value via
-            # _server_capacity, but flag the disagreement so the operator
-            # notices an unintended config skew.
-            logger.warning(
-                f"max_batch_size mismatch on {server}: "
-                f"router_init={self._max_batch_size} worker={worker_mbs}. "
-                f"Router will use the worker value for load normalization.")
         worker_algo = info.get("kv_cache_hash_algo")
         known_algos = {
             KV_CACHE_HASH_ALGO_V1,
@@ -1098,8 +1111,7 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
             for server in servers
         ]
         load_fractions = [
-            workloads[i] / self._server_capacity(servers[i])
-            for i in range(len(servers))
+            workloads[i] / self._max_batch_size for i in range(len(servers))
         ]
         scores = []
         matches = []
@@ -1114,7 +1126,9 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
             score = matches[-1] / padded_tokens - self._load_weight * \
                 load_fractions[i]
             scores.append(score)
-        # Hard cap: drop overloaded servers; fall back to all if none remain.
+        # Optional hard cap: drop servers at/over load_cap; fall back to all if
+        # none remain. Disabled by default (load_cap=inf) to match the original
+        # score-only selection.
         candidate_idx = [
             i for i, lf in enumerate(load_fractions) if lf < self._load_cap
         ]

--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -244,6 +244,8 @@ l0_b200:
   - unittest/trt/attention/test_gpt_attention.py -k "trtllm_gen"
   - unittest/llmapi/test_llm_quant.py # 3.5 mins on B200
   - unittest/trt/functional/test_fp4_gemm.py # 3 mins on B200
+  - unittest/disaggregated/test_router.py
+  - unittest/disaggregated/test_openai_server_info.py
 - condition:
     ranges:
       system_gpu_count:

--- a/tests/unittest/_torch/modeling/test_modeling_deepseekv4.py
+++ b/tests/unittest/_torch/modeling/test_modeling_deepseekv4.py
@@ -154,7 +154,9 @@ def test_deepseek_v4_model_defaults_keep_tokens_per_block():
 
     defaults = DeepseekV4ForCausalLM.get_model_defaults(LlmArgs())
 
-    assert defaults == {"kv_cache_config": {"tokens_per_block": 128}}
+    assert defaults == {
+        "kv_cache_config": {"tokens_per_block": 128, "use_kv_cache_manager_v2": True}
+    }
 
 
 def test_deepseek_v4_weight_remap_for_mxfp4_routed_experts():

--- a/tests/unittest/disaggregated/test_disagg_utils.py
+++ b/tests/unittest/disaggregated/test_disagg_utils.py
@@ -142,6 +142,41 @@ def test_extract_router_config(sample_yaml_config):
     assert "max_num_tokens" not in gen_router_config.args
 
 
+def test_extract_router_config_propagates_tokens_per_block():
+    # tokens_per_block lives under kv_cache_config and must reach the router so
+    # block hashes match the worker's KV cache.
+    cfg = {
+        "router": {
+            "type": "kv_cache_aware"
+        },
+        "max_batch_size": 8,
+        "kv_cache_config": {
+            "tokens_per_block": 128
+        },
+    }
+    router_config = extract_router_config(cfg)
+    assert router_config.args["tokens_per_block"] == 128
+
+    # An explicit router-level value is not overwritten.
+    cfg2 = {
+        "router": {
+            "type": "kv_cache_aware",
+            "tokens_per_block": 64
+        },
+        "kv_cache_config": {
+            "tokens_per_block": 128
+        },
+    }
+    assert extract_router_config(cfg2).args["tokens_per_block"] == 64
+
+    # No kv_cache_config -> nothing propagated.
+    assert "tokens_per_block" not in extract_router_config({
+        "router": {
+            "type": "kv_cache_aware"
+        }
+    }).args
+
+
 def test_get_server_configs_dict():
     server_configs = [
         CtxGenServerConfig(type="ctx",

--- a/tests/unittest/disaggregated/test_openai_server_info.py
+++ b/tests/unittest/disaggregated/test_openai_server_info.py
@@ -22,13 +22,21 @@ from tensorrt_llm.runtime.kv_cache_hash import KV_CACHE_HASH_ALGO_V1, KV_CACHE_H
 from tensorrt_llm.serve.openai_server import OpenAIServer
 
 
-@pytest.mark.asyncio
-async def test_server_info_includes_effective_kv_cache_hash_algo():
+def _make_server(*, max_batch_size=None, kv_cache_config=None):
     server = object.__new__(OpenAIServer)
     server.generator = SimpleNamespace(
         disaggregated_params=None,
-        args=SimpleNamespace(kv_cache_config=KvCacheConfig()),
+        args=SimpleNamespace(
+            max_batch_size=max_batch_size,
+            kv_cache_config=kv_cache_config,
+        ),
     )
+    return server
+
+
+@pytest.mark.asyncio
+async def test_server_info_includes_effective_kv_cache_hash_algo():
+    server = _make_server(kv_cache_config=KvCacheConfig())
 
     response = await server.get_server_info()
     content = json.loads(response.body)
@@ -45,3 +53,30 @@ async def test_server_info_includes_effective_kv_cache_hash_algo():
     response = await server.get_server_info()
     content = json.loads(response.body)
     assert content["kv_cache_hash_algo"] == KV_CACHE_HASH_ALGO_V2
+
+
+@pytest.mark.asyncio
+async def test_server_info_includes_max_batch_size_for_router_normalization():
+    server = _make_server(max_batch_size=256, kv_cache_config=KvCacheConfig())
+
+    response = await server.get_server_info()
+    content = json.loads(response.body)
+    assert content["max_batch_size"] == 256
+
+
+@pytest.mark.asyncio
+async def test_server_info_omits_max_batch_size_when_none():
+    server = _make_server(max_batch_size=None, kv_cache_config=KvCacheConfig())
+
+    response = await server.get_server_info()
+    content = json.loads(response.body)
+    assert "max_batch_size" not in content
+
+
+@pytest.mark.asyncio
+async def test_server_info_includes_tokens_per_block_from_kv_cache_config():
+    server = _make_server(kv_cache_config=KvCacheConfig(tokens_per_block=64))
+
+    response = await server.get_server_info()
+    content = json.loads(response.body)
+    assert content["tokens_per_block"] == 64

--- a/tests/unittest/disaggregated/test_router.py
+++ b/tests/unittest/disaggregated/test_router.py
@@ -561,9 +561,11 @@ async def test_kv_cache_aware_router_uses_server_info_hash_algo(servers):
     router = KvCacheAwareRouter(server_role=None,
                                 servers=[servers[0]],
                                 tokens_per_block=tokens_per_block)
+    # _prepare_server seeds server state from the handshake; simulate it here.
     router._server_info[servers[0]] = {
         "kv_cache_hash_algo": KV_CACHE_HASH_ALGO_V2
     }
+    router._server_state[servers[0]].set_hash_algo(KV_CACHE_HASH_ALGO_V2)
 
     request = CompletionRequest(model="TinyLlama",
                                 prompt=copy.deepcopy(token_lists))
@@ -630,6 +632,8 @@ async def test_kv_cache_aware_router_finish_request_polls_events(servers):
                                 prompt=copy.deepcopy(token_lists))
     await router.get_next_server(request)
     await router.finish_request(request, session)
+    # Poll runs in a background task; await it before asserting.
+    await router._server_state[servers[0]]._poll_task
 
     assert session.post_url == f"http://{servers[0]}/kv_cache_events"
     assert await router._server_state[servers[0]].matched_tokens(
@@ -662,6 +666,421 @@ async def test_kv_cache_aware_router_finish_request_decrements_on_poll_error(
 
     assert router._server_state[servers[0]].num_active_requests() == 0
     assert id(request) not in router._req_routing_table
+
+
+def test_kv_cache_aware_server_state_add_blocks_set_update_fast_path():
+    state = KvCacheAwareServerState("server-x", tokens_per_block=4)
+    state.set_hash_algo(KV_CACHE_HASH_ALGO_V1)
+
+    state.add_blocks([1, 2, 3], hash_algo=KV_CACHE_HASH_ALGO_V1)
+    assert state._block_table(KV_CACHE_HASH_ALGO_V1) == {1, 2, 3}
+
+    state.add_blocks((h for h in [4, 5]), hash_algo=KV_CACHE_HASH_ALGO_V1)
+    assert state._block_table(KV_CACHE_HASH_ALGO_V1) == {1, 2, 3, 4, 5}
+
+    state.add_blocks([1, 1, 2], hash_algo=KV_CACHE_HASH_ALGO_V1)
+    assert state._block_table(KV_CACHE_HASH_ALGO_V1) == {1, 2, 3, 4, 5}
+
+    state.add_blocks([], hash_algo=KV_CACHE_HASH_ALGO_V1)
+    state.add_blocks(iter([]), hash_algo=KV_CACHE_HASH_ALGO_V1)
+    assert state._block_table(KV_CACHE_HASH_ALGO_V1) == {1, 2, 3, 4, 5}
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_server_state_schedule_poll_coalesces():
+    state = KvCacheAwareServerState("server-x", tokens_per_block=4)
+    ready = asyncio.Event()
+
+    async def slow_poll(session=None):
+        await ready.wait()
+
+    with mock.patch.object(state, "poll_and_update", side_effect=slow_poll):
+        state.schedule_poll_and_update(session=None)
+        first_task = state._poll_task
+        state.schedule_poll_and_update(session=None)
+        assert state._poll_task is first_task
+        ready.set()
+        await first_task
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_server_state_schedule_poll_relaunches_after_done(
+):
+    state = KvCacheAwareServerState("server-x", tokens_per_block=4)
+    calls = 0
+
+    async def fake_poll(session=None):
+        nonlocal calls
+        calls += 1
+
+    with mock.patch.object(state, "poll_and_update", side_effect=fake_poll):
+        state.schedule_poll_and_update(session=None)
+        await state._poll_task
+        first_task = state._poll_task
+        state.schedule_poll_and_update(session=None)
+        await state._poll_task
+        assert state._poll_task is not first_task
+
+    assert calls == 2
+
+
+def test_kv_cache_aware_server_state_remove_blocks_silent_on_missing():
+    state = KvCacheAwareServerState("server-x", tokens_per_block=4)
+    state.add_blocks([10, 20, 30], hash_algo=KV_CACHE_HASH_ALGO_V1)
+
+    state.remove_blocks([20, 99, 100], hash_algo=KV_CACHE_HASH_ALGO_V1)
+    assert state._block_table(KV_CACHE_HASH_ALGO_V1) == {10, 30}
+
+    state.remove_blocks([777, 888], hash_algo=KV_CACHE_HASH_ALGO_V1)
+    assert state._block_table(KV_CACHE_HASH_ALGO_V1) == {10, 30}
+
+    state.remove_blocks((h for h in [10]), hash_algo=KV_CACHE_HASH_ALGO_V1)
+    assert state._block_table(KV_CACHE_HASH_ALGO_V1) == {30}
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_backfill_stashes_flat_list_at_routing(
+        servers):
+    tokens_per_block = 4
+    token_lists = [[1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008]]
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=servers,
+                                use_tokens=False,
+                                max_batch_size=32,
+                                tokens_per_block=tokens_per_block,
+                                backfill_block_hashes_on_finish=True)
+
+    request = CompletionRequest(model="TinyLlama",
+                                prompt=copy.deepcopy(token_lists))
+    server, info = await router.get_next_server(request)
+
+    assert id(request) in router._inflight_backfill_hashes
+    stashed, stashed_algo = router._inflight_backfill_hashes[id(request)]
+    expected_flat = [h for hl in info["block_hashes"] for h in hl]
+    assert stashed == expected_flat
+    assert stashed and not isinstance(stashed[0], list)
+    assert stashed_algo == info["hash_algo"]
+
+    await router.finish_request(request)
+    assert id(request) not in router._inflight_backfill_hashes
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_backfill_inserts_blocks_on_finish(servers):
+    tokens_per_block = 4
+    token_lists = [[2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008]]
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=servers,
+                                use_tokens=False,
+                                max_batch_size=32,
+                                tokens_per_block=tokens_per_block,
+                                backfill_block_hashes_on_finish=True)
+
+    request = CompletionRequest(model="TinyLlama",
+                                prompt=copy.deepcopy(token_lists))
+    server, info = await router.get_next_server(request)
+    flat_expected = [h for hl in info["block_hashes"] for h in hl]
+    hash_algo = info["hash_algo"]
+
+    assert await router._server_state[server].matched_tokens(
+        info["block_hashes"], hash_algo=hash_algo) == 0
+
+    await router.finish_request(request)
+
+    assert router._server_state[server]._block_table(hash_algo).issuperset(
+        flat_expected)
+    assert await router._server_state[server].matched_tokens(
+        info["block_hashes"], hash_algo=hash_algo) == 8
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_backfill_disabled_skips_pending(servers):
+    tokens_per_block = 4
+    token_lists = [[3000, 3001, 3002, 3003, 3004, 3005, 3006, 3007, 3008]]
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=servers,
+                                use_tokens=False,
+                                max_batch_size=32,
+                                tokens_per_block=tokens_per_block)
+
+    request = CompletionRequest(model="TinyLlama",
+                                prompt=copy.deepcopy(token_lists))
+    server, info = await router.get_next_server(request)
+
+    assert router._inflight_backfill_hashes == {}
+
+    await router.finish_request(request)
+
+    assert await router._server_state[server].matched_tokens(
+        info["block_hashes"], hash_algo=info["hash_algo"]) == 0
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_backfill_drops_on_failure(servers):
+    tokens_per_block = 4
+    token_lists = [[4000, 4001, 4002, 4003, 4004, 4005, 4006, 4007, 4008]]
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=servers,
+                                use_tokens=False,
+                                max_batch_size=32,
+                                tokens_per_block=tokens_per_block,
+                                backfill_block_hashes_on_finish=True)
+
+    request = CompletionRequest(model="TinyLlama",
+                                prompt=copy.deepcopy(token_lists))
+    server, info = await router.get_next_server(request)
+    assert id(request) in router._inflight_backfill_hashes
+
+    await router.finish_request(request, success=False)
+
+    assert id(request) not in router._inflight_backfill_hashes
+    assert await router._server_state[server].matched_tokens(
+        info["block_hashes"], hash_algo=info["hash_algo"]) == 0
+
+
+def test_kv_cache_aware_router_server_capacity_uses_handshake(servers):
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=servers,
+                                use_tokens=False,
+                                max_batch_size=64,
+                                tokens_per_block=4)
+    router._server_info[servers[0]] = {"max_batch_size": 16}
+    router._server_info[servers[1]] = {"max_batch_size": 256}
+    # servers[2] has no handshake entry — should fall back to the router default.
+
+    assert router._server_capacity(servers[0]) == 16
+    assert router._server_capacity(servers[1]) == 256
+    assert router._server_capacity(servers[2]) == 64
+
+    router._server_info[servers[0]] = {"max_batch_size": 0}
+    assert router._server_capacity(servers[0]) == 64
+    router._server_info[servers[0]] = {"max_batch_size": None}
+    assert router._server_capacity(servers[0]) == 64
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_per_server_capacity_changes_decision(
+        servers):
+    tokens_per_block = 4
+    token_lists = [[7000] * 16]
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=servers,
+                                use_tokens=False,
+                                max_batch_size=64,
+                                tokens_per_block=tokens_per_block)
+    # Make all servers equally loaded with zero KV match — winner is decided
+    # purely by 1/capacity, so the largest capacity wins.
+    router._server_info[servers[0]] = {"max_batch_size": 8}
+    router._server_info[servers[1]] = {"max_batch_size": 256}
+    router._server_info[servers[2]] = {"max_batch_size": 32}
+    for server in servers:
+        router._server_state[server]._num_active_requests = 4
+
+    request = CompletionRequest(model="TinyLlama",
+                                prompt=copy.deepcopy(token_lists))
+    chosen, _ = await router.get_next_server(request)
+    assert chosen == servers[1]
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_load_cap_excludes_overloaded(servers):
+    tokens_per_block = 4
+    token_lists = [[5000] * 16]
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=servers,
+                                use_tokens=False,
+                                max_batch_size=10,
+                                tokens_per_block=tokens_per_block,
+                                load_cap=0.8)
+    router._server_state[servers[0]]._num_active_requests = 9
+    router._server_state[servers[1]]._num_active_requests = 9
+    router._server_state[servers[2]]._num_active_requests = 1
+
+    request = CompletionRequest(model="TinyLlama",
+                                prompt=copy.deepcopy(token_lists))
+    chosen, _ = await router.get_next_server(request)
+    assert chosen == servers[2]
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_load_cap_fallback_when_all_overloaded(
+        servers):
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=servers,
+                                use_tokens=False,
+                                max_batch_size=10,
+                                tokens_per_block=4,
+                                load_cap=0.5)
+    router._server_state[servers[0]]._num_active_requests = 8
+    router._server_state[servers[1]]._num_active_requests = 6
+    router._server_state[servers[2]]._num_active_requests = 9
+
+    request = CompletionRequest(model="TinyLlama", prompt=[[100] * 16])
+    chosen, _ = await router.get_next_server(request)
+    assert chosen == servers[1]
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_load_weight_scales_load_penalty(servers):
+    tokens_per_block = 4
+    token_lists = [[6000] * 16]
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=servers,
+                                use_tokens=False,
+                                max_batch_size=10,
+                                tokens_per_block=tokens_per_block,
+                                load_weight=5.0,
+                                load_cap=1.0)
+    block_hashes = router._compute_block_hashes(token_lists)
+    router._server_state[servers[0]].add_blocks(
+        [h for hl in block_hashes for h in hl])
+    router._server_state[servers[0]]._num_active_requests = 7
+    router._server_state[servers[1]]._num_active_requests = 1
+    router._server_state[servers[2]]._num_active_requests = 1
+
+    request = CompletionRequest(model="TinyLlama",
+                                prompt=copy.deepcopy(token_lists))
+    chosen, _ = await router.get_next_server(request)
+    assert chosen != servers[0]
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_prepare_server_raises_on_tpb_mismatch():
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=["server-a"],
+                                tokens_per_block=32)
+
+    async def fake_fetch(server, timeout):
+        return {"tokens_per_block": 64, "kv_cache_hash_algo": "v1_block_key"}
+
+    with mock.patch.object(router, "_fetch_server_info",
+                           side_effect=fake_fetch):
+        with pytest.raises(RuntimeError, match="tokens_per_block mismatch"):
+            await router._prepare_server("server-a")
+
+    assert "server-a" not in router._prepared_ready_servers
+    assert "server-a" not in router._server_info
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_prepare_server_keeps_on_tpb_match():
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=["server-a"],
+                                tokens_per_block=32)
+
+    async def fake_fetch(server, timeout):
+        return {"tokens_per_block": 32, "kv_cache_hash_algo": "v1_block_key"}
+
+    with mock.patch.object(router, "_fetch_server_info",
+                           side_effect=fake_fetch):
+        await router._prepare_server("server-a")
+
+    assert "server-a" in router._prepared_ready_servers
+    assert router._server_info["server-a"]["tokens_per_block"] == 32
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_prepare_server_keeps_when_worker_omits_tpb(
+):
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=["server-a"],
+                                tokens_per_block=32)
+
+    async def fake_fetch(server, timeout):
+        return {"kv_cache_hash_algo": "v1_block_key"}
+
+    with mock.patch.object(router, "_fetch_server_info",
+                           side_effect=fake_fetch):
+        await router._prepare_server("server-a")
+
+    assert "server-a" in router._prepared_ready_servers
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_prepare_server_warns_on_mbs_mismatch():
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=["server-a"],
+                                max_batch_size=64,
+                                tokens_per_block=32)
+
+    async def fake_fetch(server, timeout):
+        return {
+            "tokens_per_block": 32,
+            "max_batch_size": 256,
+            "kv_cache_hash_algo": "v1_block_key",
+        }
+
+    with mock.patch("tensorrt_llm.serve.router.logger") as mock_logger:
+        with mock.patch.object(router,
+                               "_fetch_server_info",
+                               side_effect=fake_fetch):
+            await router._prepare_server("server-a")
+
+    assert "server-a" in router._prepared_ready_servers
+    assert any("max_batch_size mismatch" in str(call.args[0])
+               for call in mock_logger.warning.call_args_list)
+    assert router._server_capacity("server-a") == 256
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_prepare_server_warns_on_missing_algo():
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=["server-a"],
+                                tokens_per_block=32)
+
+    async def fake_fetch(server, timeout):
+        return {"tokens_per_block": 32}
+
+    with mock.patch("tensorrt_llm.serve.router.logger") as mock_logger:
+        with mock.patch.object(router,
+                               "_fetch_server_info",
+                               side_effect=fake_fetch):
+            await router._prepare_server("server-a")
+
+    assert "server-a" in router._prepared_ready_servers
+    assert any("did not expose kv_cache_hash_algo" in str(call.args[0])
+               for call in mock_logger.warning.call_args_list)
+    assert router._get_server_hash_algo("server-a") == KV_CACHE_HASH_ALGO_V1
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_prepare_server_raises_on_unknown_algo():
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=["server-a"],
+                                tokens_per_block=32)
+
+    async def fake_fetch(server, timeout):
+        return {"tokens_per_block": 32, "kv_cache_hash_algo": "bogus_algo"}
+
+    with mock.patch.object(router, "_fetch_server_info",
+                           side_effect=fake_fetch):
+        with pytest.raises(RuntimeError, match="Unknown kv_cache_hash_algo"):
+            await router._prepare_server("server-a")
+
+    assert "server-a" not in router._prepared_ready_servers
+    assert "server-a" not in router._server_info
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_prepare_server_persists_algo_for_lock_free_read(
+):
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=["server-a"],
+                                tokens_per_block=32)
+
+    async def fake_fetch(server, timeout):
+        return {
+            "tokens_per_block": 32,
+            "kv_cache_hash_algo": KV_CACHE_HASH_ALGO_V2,
+        }
+
+    with mock.patch.object(router, "_fetch_server_info",
+                           side_effect=fake_fetch):
+        await router._prepare_server("server-a")
+
+    # Per-request read is now sync; no lock/await on the hot path.
+    assert router._get_server_hash_algo("server-a") == KV_CACHE_HASH_ALGO_V2
+    assert router._server_state["server-a"].hash_algo == KV_CACHE_HASH_ALGO_V2
 
 
 @pytest.mark.asyncio

--- a/tests/unittest/disaggregated/test_router.py
+++ b/tests/unittest/disaggregated/test_router.py
@@ -724,6 +724,51 @@ async def test_kv_cache_aware_server_state_schedule_poll_relaunches_after_done(
     assert calls == 2
 
 
+@pytest.mark.asyncio
+async def test_kv_cache_aware_server_state_schedule_poll_rearms_pending():
+    # A poll requested while one is in flight must re-run once more so the last
+    # finish_request can never strand its events behind a coalesced poll.
+    state = KvCacheAwareServerState("server-x", tokens_per_block=4)
+    calls = 0
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def slow_poll(session=None):
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+
+    with mock.patch.object(state, "poll_and_update", side_effect=slow_poll):
+        state.schedule_poll_and_update(session=None)
+        await started.wait()  # first poll is now actually in flight
+        started.clear()
+        # Second request arrives while the first poll is still blocked.
+        state.schedule_poll_and_update(session=None)
+        release.set()
+        await state._poll_task
+
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_server_state_cancel_poll_task():
+    state = KvCacheAwareServerState("server-x", tokens_per_block=4)
+    started = asyncio.Event()
+
+    async def blocking_poll(session=None):
+        started.set()
+        await asyncio.Event().wait()
+
+    with mock.patch.object(state, "poll_and_update", side_effect=blocking_poll):
+        state.schedule_poll_and_update(session=None)
+        await started.wait()
+        await state.cancel_poll_task()
+
+    assert state._poll_task is None
+    assert state._poll_pending is False
+
+
 def test_kv_cache_aware_server_state_remove_blocks_silent_on_missing():
     state = KvCacheAwareServerState("server-x", tokens_per_block=4)
     state.add_blocks([10, 20, 30], hash_algo=KV_CACHE_HASH_ALGO_V1)
@@ -838,50 +883,6 @@ async def test_kv_cache_aware_router_backfill_drops_on_failure(servers):
         info["block_hashes"], hash_algo=info["hash_algo"]) == 0
 
 
-def test_kv_cache_aware_router_server_capacity_uses_handshake(servers):
-    router = KvCacheAwareRouter(server_role=None,
-                                servers=servers,
-                                use_tokens=False,
-                                max_batch_size=64,
-                                tokens_per_block=4)
-    router._server_info[servers[0]] = {"max_batch_size": 16}
-    router._server_info[servers[1]] = {"max_batch_size": 256}
-    # servers[2] has no handshake entry — should fall back to the router default.
-
-    assert router._server_capacity(servers[0]) == 16
-    assert router._server_capacity(servers[1]) == 256
-    assert router._server_capacity(servers[2]) == 64
-
-    router._server_info[servers[0]] = {"max_batch_size": 0}
-    assert router._server_capacity(servers[0]) == 64
-    router._server_info[servers[0]] = {"max_batch_size": None}
-    assert router._server_capacity(servers[0]) == 64
-
-
-@pytest.mark.asyncio
-async def test_kv_cache_aware_router_per_server_capacity_changes_decision(
-        servers):
-    tokens_per_block = 4
-    token_lists = [[7000] * 16]
-    router = KvCacheAwareRouter(server_role=None,
-                                servers=servers,
-                                use_tokens=False,
-                                max_batch_size=64,
-                                tokens_per_block=tokens_per_block)
-    # Make all servers equally loaded with zero KV match — winner is decided
-    # purely by 1/capacity, so the largest capacity wins.
-    router._server_info[servers[0]] = {"max_batch_size": 8}
-    router._server_info[servers[1]] = {"max_batch_size": 256}
-    router._server_info[servers[2]] = {"max_batch_size": 32}
-    for server in servers:
-        router._server_state[server]._num_active_requests = 4
-
-    request = CompletionRequest(model="TinyLlama",
-                                prompt=copy.deepcopy(token_lists))
-    chosen, _ = await router.get_next_server(request)
-    assert chosen == servers[1]
-
-
 @pytest.mark.asyncio
 async def test_kv_cache_aware_router_load_cap_excludes_overloaded(servers):
     tokens_per_block = 4
@@ -994,32 +995,6 @@ async def test_kv_cache_aware_router_prepare_server_keeps_when_worker_omits_tpb(
         await router._prepare_server("server-a")
 
     assert "server-a" in router._prepared_ready_servers
-
-
-@pytest.mark.asyncio
-async def test_kv_cache_aware_router_prepare_server_warns_on_mbs_mismatch():
-    router = KvCacheAwareRouter(server_role=None,
-                                servers=["server-a"],
-                                max_batch_size=64,
-                                tokens_per_block=32)
-
-    async def fake_fetch(server, timeout):
-        return {
-            "tokens_per_block": 32,
-            "max_batch_size": 256,
-            "kv_cache_hash_algo": "v1_block_key",
-        }
-
-    with mock.patch("tensorrt_llm.serve.router.logger") as mock_logger:
-        with mock.patch.object(router,
-                               "_fetch_server_info",
-                               side_effect=fake_fetch):
-            await router._prepare_server("server-a")
-
-    assert "server-a" in router._prepared_ready_servers
-    assert any("max_batch_size mismatch" in str(call.args[0])
-               for call in mock_logger.warning.call_args_list)
-    assert router._server_capacity("server-a") == 256
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the disaggregated router and server logic, focusing on more robust configuration propagation, improved load balancing, and enhanced test coverage. The most significant changes ensure that critical configuration parameters such as `tokens_per_block` are consistently propagated, optimize how the router manages polling and block hash updates, and enhance how server information is reported and tested.

**Configuration propagation and consistency:**

- Ensured that `tokens_per_block` from `kv_cache_config` is propagated to the router configuration if not already set at the router level, preventing block hash mismatches between router and worker. Added corresponding unit tests to verify this behavior. [[1]](diffhunk://#diff-7fda676775df6cc3c9283e98377059dae42058266d892295632513d96a48ea47R242-R248) [[2]](diffhunk://#diff-cbf5affadeb44cb7e96e61786c36cb5d4137a2dae5b0c33ea8c0641a30185f82R145-R179)

**Router logic and load balancing improvements:**

- Refactored the router's block hash management to use more efficient set operations, improved background polling by coalescing concurrent polls, and ensured proper cancellation of background tasks on shutdown. Updated the backfill mechanism for block hashes to be more robust and leak-free. [[1]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89R139-R141) [[2]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89L168-R179) [[3]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89R241-R270) [[4]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89R984-R1072) [[5]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89L989-R1088) [[6]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89L1009-R1115) [[7]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89L1025-R1146) [[8]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89L1054-R1166)

- Enhanced load balancing by introducing `load_weight` and `load_cap` parameters, allowing more flexible server selection based on both KV cache matches and server load. [[1]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89R984-R1072) [[2]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89L1009-R1115) [[3]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89L1025-R1146)

**Server info reporting and testing:**

- Updated the OpenAI server info endpoint to include `max_batch_size` and `tokens_per_block` when available, and expanded test coverage to verify these fields are correctly reported or omitted as appropriate. [[1]](diffhunk://#diff-2eb783dbd719ea8b2067105279f5a50460168065912d0efd2a3b2cdc0b3a78e5L1839-R1850) [[2]](diffhunk://#diff-a966d0173a2dffb70e65e3aca7e6fc24f6d08fb2ca3cb3c129cad4cf7c7facecL25-R39) [[3]](diffhunk://#diff-a966d0173a2dffb70e65e3aca7e6fc24f6d08fb2ca3cb3c129cad4cf7c7facecR56-R82)

**Model defaults and test updates:**

- Updated `DeepseekV4ForCausalLM.get_model_defaults` to include `use_kv_cache_manager_v2` in the returned configuration, and adjusted tests to reflect this change. [[1]](diffhunk://#diff-0f7aa1642c837a4ed5f8f25b70fa300f736f2f158d5fbc6673975551307dc699L2493-R2493) [[2]](diffhunk://#diff-b308c96adac4cce5c88a427bd0209860a3870d1e224d50fd214ff501edad7c19L157-R159)

**Test infrastructure:**

- Added new integration and unit tests to ensure correct router and server behavior, including proper propagation of configuration and correct background polling. [[1]](diffhunk://#diff-67b0bc41d11c399840db6c377717de86f2e298b3367f83e481bed25f76752b72R247-R248) [[2]](diffhunk://#diff-541e70439bf7d7b6a9f23cabd51cccf8475b27e05dc1f1669b5909acb5fae3c2R564-R568) [[3]](diffhunk://#diff-541e70439bf7d7b6a9f23cabd51cccf8475b27e05dc1f1669b5909acb5fae3c2R635-R636)

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
