### PR TITLE
[None][perf] ConversationRouter: skip block-hash compute on sticky conversation_id routing

### DIFF
--- a/tensorrt_llm/serve/router.py
+++ b/tensorrt_llm/serve/router.py
@@ -1435,91 +1435,71 @@ class ConversationRouter(BlockHashMixin, LoadBalancingMixin, Router):
             exclude_server: Optional[str] = None) -> tuple[str, dict]:
         self._validate_servers_available()
 
-        # Pre-compute outside the lock (tokenization + hashing)
         conv_id = self._get_conversation_id(request)
+
+        # Explicit conversation_id: route by the session table alone and never
+        # touch request content. Block hashes are consumed only by the implicit
+        # prefix-match path below (requests with no conversation_id), so for a
+        # pinned session -- new or already-seen -- the GIL-bound
+        # _request_to_block_hashes is pure overhead that would serialize the
+        # single orchestrator event loop and cap dispatch throughput.
+        if conv_id:
+            weight = self._estimate_content_weight(request)
+            async with self._lock:
+                entry = self._session_table.get(conv_id)
+                if (entry is not None and entry[0] in self._server_state
+                        and entry[0] != exclude_server):
+                    # Sticky hit: keep the pinned server, refresh LRU only.
+                    server = entry[0]
+                    self._session_table.move_to_end(conv_id)
+                    await self._register_request(server, request)
+                    self._add_content_load(server, request, weight)
+                else:
+                    # New conversation_id (or its server is gone/excluded):
+                    # pin to the least-loaded server. Store no block hashes --
+                    # the trie is only read for conversation_id-less requests.
+                    server = self._select_least_loaded(exclude_server)
+                    if server is None:
+                        raise ValueError("No available servers after excluding "
+                                         f"{exclude_server}")
+                    await self._register_request(server, request)
+                    self._add_content_load(server, request, weight)
+                    self._update_session(conv_id, server, [])
+                return server, {
+                    "server_info": self._server_info.get(server, {})
+                }
+
+        # No conversation_id: content-based routing. Compute block hashes
+        # (outside the lock) for implicit prefix matching, else least-loaded.
         block_hashes = self._request_to_block_hashes(request)
         weight = self._estimate_content_weight(request, block_hashes)
 
         async with self._lock:
+            matched_id = self._find_matching_session(block_hashes,
+                                                     exclude_server)
+            if matched_id is not None:
+                server, _ = self._session_table[matched_id]
+                self._update_session(matched_id, server, block_hashes)
+                await self._register_request(server, request)
+                self._add_content_load(server, request, weight)
+                logger.debug(
+                    f"ConversationRouter: IMPLICIT match conv_id={matched_id} "
+                    f"-> server={server}, weight={weight}")
+                return server, {
+                    "server_info": self._server_info.get(server, {})
+                }
 
-            # 1. Explicit conversation_id — sticky routing.
-            #    Always honour session affinity when the server is alive
-            #    and not explicitly excluded.  No overload gate — the
-            #    server itself provides backpressure.
-            if conv_id and conv_id in self._session_table:
-                sticky_server, _ = self._session_table[conv_id]
-                if sticky_server not in self._server_state:
-                    logger.debug(
-                        f"ConversationRouter: STICKY MISS conv_id={conv_id} "
-                        f"-> server={sticky_server} NOT in server_state, "
-                        f"falling through to FALLBACK")
-                elif sticky_server == exclude_server:
-                    logger.debug(
-                        f"ConversationRouter: STICKY MISS conv_id={conv_id} "
-                        f"-> server={sticky_server} is exclude_server")
-                else:
-                    self._update_session(conv_id, sticky_server, block_hashes)
-                    await self._register_request(sticky_server, request)
-                    self._add_content_load(sticky_server, request, weight)
-                    loads = {
-                        s: self._get_content_load(s)
-                        for s in self._servers
-                    }
-                    logger.debug(
-                        f"ConversationRouter: STICKY conv_id={conv_id} "
-                        f"-> server={sticky_server}, "
-                        f"content_loads={loads}, weight={weight}")
-                    return sticky_server, {
-                        "server_info": self._server_info.get(sticky_server, {})
-                    }
-            elif conv_id:
-                logger.debug(f"ConversationRouter: NEW conv_id={conv_id} "
-                             f"not in session_table "
-                             f"(size={len(self._session_table)})")
-
-            # 2. Implicit block-hash prefix matching.
-            #    Always honour match when the server is alive.
-            matched_id = None
-            if not conv_id:
-                matched_id = self._find_matching_session(
-                    block_hashes, exclude_server)
-                if matched_id is not None:
-                    sticky_server, _ = self._session_table[matched_id]
-                    self._update_session(matched_id, sticky_server,
-                                         block_hashes)
-                    await self._register_request(sticky_server, request)
-                    self._add_content_load(sticky_server, request, weight)
-                    loads = {
-                        s: self._get_content_load(s)
-                        for s in self._servers
-                    }
-                    logger.debug(
-                        f"ConversationRouter: IMPLICIT match "
-                        f"conv_id={matched_id} -> server={sticky_server}, "
-                        f"content_loads={loads}, weight={weight}")
-                    return sticky_server, {
-                        "server_info": self._server_info.get(sticky_server, {})
-                    }
-
-            # 3. Fallback — least-loaded server for new sessions or
-            #    sessions whose sticky server is unavailable.
             server = self._select_least_loaded(exclude_server)
             if server is None:
                 raise ValueError(
                     f"No available servers after excluding {exclude_server}")
             await self._register_request(server, request)
             self._add_content_load(server, request, weight)
-
-            # Store session mapping.
-            if not conv_id:
-                conv_id = self._generate_implicit_id()
-            self._update_session(conv_id, server, block_hashes)
-            loads = {s: self._get_content_load(s) for s in self._servers}
-            logger.debug(
-                f"ConversationRouter: FALLBACK conv_id={conv_id} "
-                f"-> server={server}, content_loads={loads}, weight={weight}")
-
-        return server, {"server_info": self._server_info.get(server, {})}
+            implicit_id = self._generate_implicit_id()
+            self._update_session(implicit_id, server, block_hashes)
+            logger.debug(f"ConversationRouter: FALLBACK conv_id={implicit_id} "
+                         f"-> server={server}, weight={weight}")
+            return server, {"server_info": self._server_info.get(server, {})}
 
     async def finish_request(self,
                              request: OpenAIRequest,


### PR DESCRIPTION
## Description

`ConversationRouter.get_next_server` computed `_request_to_block_hashes(request)` **up front for every request, synchronously on the orchestrator's single asyncio event loop** — before the session table was ever consulted. But the request then routes via one of three branches:

1. **Explicit conv-id sticky** (the common case) — the decision is purely `session_table[conv_id] → server`; **the block hashes are never read.**
2. **Implicit prefix-match** (requests with *no* `conversation_id`) — the *only* branch that consumes the hashes.
3. **Fallback** — least-loaded server.

So for conv-id-pinned traffic the hashing is **computed and then discarded — redundant work on every request.** And it is not cheap: with `use_token_ids=False` it is `_extract_text` + per-character int conversion (`[ord(c) for c in ...]`) + block hashing, all GIL-bound — several ms for a ~40–80k-token agentic prompt. Because the loop is shared across all context/generation servers, this redundant hashing caps dispatch throughput **regardless of how many servers are added**: TTFT scaled super-linearly with *total* concurrency (≈1.7 s → 5.9 s → 137 s at concurrency 384 → 768 → 1536) while per-server load stayed constant, and the context servers' KV pools sat ~5% utilized (starved, not busy) — the signature of a shared per-loop ceiling, not per-server capacity.

**Fix:** when `conversation_id` is present, route by the session table alone and skip `_request_to_block_hashes` — both for an already-pinned session *and* for a brand-new `conversation_id` (pin it to the least-loaded server, recording no block hashes). Block hashes are computed only on the no-`conversation_id` path (implicit prefix-match → least-loaded fallback) that actually consumes them. No new config or environment variable; routing for requests without a `conversation_id` is unchanged.

(Conversation_id sessions are now recorded with no block hashes, so they don't populate the prefix-match trie — but that trie is read *only* for requests carrying no `conversation_id`, and is never consulted at all when every request is pinned. So no routing decision changes; in a mixed deployment a no-id request simply can't implicit-match a pinned session's content, degrading gracefully to least-loaded.)

## Measurements

Router dispatch microbench — real `get_next_server`, 128 concurrent requests, ~50k-token prompt, single event loop, before (hashes every request) vs after:

| path | before | after |
| --- | ---: | ---: |
| new `conversation_id` (first turn) | 185 req/s · loop blocked 691 ms | ~77,000 req/s · 5 ms |
| pinned (later turns) | 166 req/s · 770 ms | ~150,000 req/s · 6 ms |

~420× (new) / ~900× (pinned) faster, and the loop stays responsive. The hash is GIL-bound, so `asyncio.to_thread` does not help.

End-to-end — DeepSeek-V4 disaggregated (6 context + 1 generation server, conversation router, concurrency 768), fix vs baseline image (router.py-only delta):

| | TTFT p50 | throughput | gen batch occupancy |
| --- | ---: | ---: | ---: |
| before | 6.6 s | 425 tok/s/GPU | ~17/32 |
| after | 4.1 s | 488 tok/s/GPU | ~19/32 |

**−38% TTFT, +15% throughput.** Per-request decode speed and KV-cache hit rate are unchanged, as expected for a routing-only change. (Partial recovery: the generation engine is still under-fed at this scale — a separate downstream feeding bottleneck remains, independent of this routing fix.)

## Test Coverage

- `tests/unittest/disaggregated/test_router.py::test_conversation_router_session_affinity_and_fallbacks` exercises the `conversation_id` path end-to-end — session affinity (same id → same server, incl. the new-id pin on first sight), the exclude-server override, and the server-removal reroute. Implicit / fallback routing is covered by `test_conversation_router_prefix_and_token_id_paths`, `test_conversation_router_hash_skip_count`, and `test_conversation_router_load_balancing`. The routing **decision** is unchanged (only the unused block-hash computation is skipped), so existing coverage applies.
- Those four tests pass **4/4 identically** with the pre-fix router and with this patch — confirming routing behavior is preserved, not merely faster.
- Validated out-of-band with a standalone `get_next_server` microbench: with the fix the orchestrator event loop is no longer blocked by per-request hashing for pinned `conversation_id`s.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
