### PR TITLE
[None][test] Waive qwen3_30b_a3b_fp8 pd_disagg mm-encoder test on single-GPU (NIXL setup failure)

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -338,6 +338,7 @@ unittest/_torch/multi_gpu/test_user_buffers.py::test_user_buffers_pass[2-fp16-_t
 unittest/_torch/multi_gpu/test_user_buffers.py::test_user_buffers_pass[2-fp16-_tokens16-_hidden512] SKIP (https://nvbugs/6266259)
 unittest/_torch/multi_gpu/test_user_buffers.py::test_user_buffers_pass[2-fp16-_tokens256-_hidden32] SKIP (https://nvbugs/6266259)
 unittest/_torch/multi_gpu/test_user_buffers.py::test_user_buffers_pass[2-fp16-_tokens256-_hidden512] SKIP (https://nvbugs/6266259)
+unittest/_torch/multimodal/test_mm_encoder_standalone.py::test_single_request_chat_multiple_images[pd_disagg-qwen3_30b_a3b_fp8] SKIP (https://nvbugs/6269683)
 unittest/_torch/thop/serial/test_moe.py::TestMoeFp4::test_no_autotune[use_score_as_input-RoutingDSv3-swiglu-1024-1024-1] SKIP (https://nvbugs/5908070)
 unittest/_torch/thop/serial/test_moe.py::TestMoeFp4::test_no_autotune[use_score_as_input-RoutingRenormalize_qwen_next-swiglu-1024-1024-150] SKIP (https://nvbugs/5908070)
 unittest/_torch/thop/serial/test_moe.py::TestMoeFp4::test_no_autotune[use_score_as_input-RoutingRenormalize_topk_4-swiglu-1024-1024-150] SKIP (https://nvbugs/5908070)


### PR DESCRIPTION
## Summary

Waive `test_mm_encoder_standalone.py::test_single_request_chat_multiple_images[pd_disagg-qwen3_30b_a3b_fp8]`, which fails fleet-wide on the **pre-merge `DGX_B200-PyTorch` single-GPU** stage.

**NVBug:** https://nvbugs/6269683

## Failure

At test setup, constructing the `pd_disagg` LLM's disaggregated KV-cache transfer agent hits a hard NIXL assertion:

```
RuntimeError: [TensorRT-LLM][ERROR] Assertion failed: status == NIXL_SUCCESS
  (.../executor/cache_transmission/nixl_utils/transferAgent.cpp:614)
  AgentConnectionManager::AgentConnectionManager(...) -> CacheTransceiver::CacheTransceiver(...)
RuntimeError: Executor worker returned error
```

i.e. NIXL `registerMem` fails while pinning the transceiver's transfer buffers during executor-worker construction on a single GPU. The sibling `no_pd_disagg` / `raw_inputs` sub-cases pass (they never build a NIXL `CacheTransceiver`).

## Exact failing builds (CI Report)

Not specific to any one PR — the same case fails identically across many unrelated pipelines (stage `DGX_B200-PyTorch`, single-GPU):

- PR #13978, build 41402 — http://tensorrt-llm.tensorrt-llm-ci-report.sc2-paas.nvidia.com/?job=%2FLLM%2Fmain%2FL0_MergeRequest_PR&build=41402
- PR #13925, build 41352 — http://tensorrt-llm.tensorrt-llm-ci-report.sc2-paas.nvidia.com/?job=%2FLLM%2Fmain%2FL0_MergeRequest_PR&build=41352
- PR #14841, build 41381 — http://tensorrt-llm.tensorrt-llm-ci-report.sc2-paas.nvidia.com/?job=%2FLLM%2Fmain%2FL0_MergeRequest_PR&build=41381
- PR #14398, build 41375 — http://tensorrt-llm.tensorrt-llm-ci-report.sc2-paas.nvidia.com/?job=%2FLLM%2Fmain%2FL0_MergeRequest_PR&build=41375
- **Post-merge (main)**, `L0_PostMerge` build 2759 — http://tensorrt-llm.tensorrt-llm-ci-report.sc2-paas.nvidia.com/?job=%2FLLM%2Fmain%2FL0_PostMerge&build=2759
- This PR (#13864), build 41351 — http://tensorrt-llm.tensorrt-llm-ci-report.sc2-paas.nvidia.com/?job=%2FLLM%2Fmain%2FL0_MergeRequest_PR&build=41351

Also observed on #14599 (41365), #14524 (41373), #14941 (41337), #14908 (41360), #14948 (41357), #12958 (41363); related `Hang detected on rank 0 in PyExecutor` on #14812/#14891. Passes only intermittently (~1/3, node-dependent) — consistent with single-GPU NIXL EPD-disagg not being reliably supported on the `DGX_B200` single-GPU nodes (no IB/RoCE fabric and/or memory pressure from the multi-instance disagg fixture).

## Scope

- One-line `waives.txt` entry; no source/product changes.
- Stopgap until the single-GPU NIXL EPD-disagg path is fixed, or the `pd_disagg` variant is gated to multi-GPU (tracked in https://nvbugs/6269683).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to skip a specific test case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->