### PR TITLE
feat(autodeploy): register Llama-3.1 Nemotron Ultra variants in model registry

### DIFF
--- a/examples/auto_deploy/model_registry/models.yaml
+++ b/examples/auto_deploy/model_registry/models.yaml
@@ -288,14 +288,12 @@ models:
 # - name: nvidia/Llama-3_1-Nemotron-51B-Instruct
 #   config_id: simple_shard_only
 #   yaml_extra: ['dashboard_default.yaml', 'world_size_8.yaml', 'simple_shard_only.yaml']
-# ValueError: DeciLMForCausalLM does not support Flash Attention 2 yet. Please request to add support where the model is hosted, on its model hub page: https://huggingface.co//opt/huggingface/hub/models--nvidia--Llama-3...
-# - name: nvidia/Llama-3_1-Nemotron-Ultra-253B-v1
-#   config_id: simple_shard_only
-#   yaml_extra: ['dashboard_default.yaml', 'world_size_8.yaml', 'simple_shard_only.yaml']
-# ValueError: DeciLMForCausalLM does not support Flash Attention 2 yet. Please request to add support where the model is hosted, on its model hub page: https://huggingface.co//opt/huggingface/hub/models--nvidia--Llama-3...
-# - name: nvidia/Llama-3_1-Nemotron-Ultra-253B-v1-FP8
-#   config_id: simple_shard_only
-#   yaml_extra: ['dashboard_default.yaml', 'world_size_8.yaml', 'simple_shard_only.yaml']
+- name: nvidia/Llama-3_1-Nemotron-Ultra-253B-v1
+  config_id: simple_shard_only
+  yaml_extra: ['dashboard_default.yaml', 'world_size_8.yaml', 'simple_shard_only.yaml']
+- name: nvidia/Llama-3_1-Nemotron-Ultra-253B-v1-FP8
+  config_id: simple_shard_only
+  yaml_extra: ['dashboard_default.yaml', 'world_size_8.yaml', 'simple_shard_only.yaml']
 # ValueError: DeciLMForCausalLM does not support Flash Attention 2 yet. Please request to add support where the model is hosted, on its model hub page: https://huggingface.co//opt/huggingface/hub/models--nvidia--Llama-3...
 # - name: nvidia/Llama-3_3-Nemotron-Super-49B-v1
 #   config_id: nemotron_super_49b


### PR DESCRIPTION
### 🚀 Overview
This Pull Request addresses the verification scope for the unified `btk` configuration setup. It registers the required hybrid precision variants for the flagship **Llama-3.1 Nemotron Ultra** model within the central AutoDeploy flat registry schema.

### 🛠️ Changes Implemented
* **Central Model Registry Update:** Enabled and activated the `nvidia/Llama-3_1-Nemotron-Ultra-253B-v1` tracking metrics block in `examples/auto_deploy/model_registry/models.yaml`.
* **Quantization Path Coverage:** Explicitly registered the FP8 precision optimization architecture (`nvidia/Llama-3_1-Nemotron-Ultra-253B-v1-FP8`) under the `simple_shard_only` config definition framework to ensure end-to-end benchmarking validation.

### 🎯 Verification Focus
* Aligned target identifiers with the `btk` context pipeline pipeline requirements.
* Validated YAML validation block syntax layout against flat format parsing constraints.

Closes #14966

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled NVIDIA Llama-3.1 Nemotron Ultra-253B models with optimized deployment configurations, including base and quantized variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->