### PR TITLE
[https://nvbugs/6104831][fix] Port dataTransceiver shared_ptr<LlmRequest> lifetime fix

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -394,7 +394,7 @@ void CacheTransceiver::respondAndSendAsync(std::shared_ptr<LlmRequest> llmReques
         return;
     }
     setContextState(llmRequest.get());
-    auto future = mCacheSender->sendAsync(*llmRequest);
+    auto future = mCacheSender->sendAsync(llmRequest);
     mSenderFutures.emplace_back(std::move(llmRequest), std::move(future));
 }
 
@@ -410,7 +410,7 @@ void CacheTransceiver::respondAndSendLayerWise(
 
         llmRequest->setState(LlmRequestState::kDISAGG_CONTEXT_INIT_AND_TRANS);
         setContextState(llmRequest.get());
-        auto future = mCacheSender->sendAsync(*llmRequest);
+        auto future = mCacheSender->sendAsync(llmRequest);
         mSenderFutures.emplace_back(llmRequest, std::move(future));
     }
 }
@@ -419,7 +419,7 @@ void CacheTransceiver::requestAndReceiveSync(std::shared_ptr<LlmRequest> llmRequ
 {
     TLLM_CHECK(llmRequest && llmRequest->isGenerationOnlyRequest());
     {
-        auto future = mCacheReceiver->receiveAsync(*llmRequest);
+        auto future = mCacheReceiver->receiveAsync(llmRequest);
         future.get();
     }
     llmRequest->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_COMPLETE);
@@ -438,7 +438,7 @@ void CacheTransceiver::requestAndReceiveAsync(std::shared_ptr<LlmRequest> llmReq
         return;
     }
 
-    auto future = mCacheReceiver->receiveAsync(*llmRequest);
+    auto future = mCacheReceiver->receiveAsync(llmRequest);
     auto* requestPtr = llmRequest.get();
     mRequesterFutures.emplace_back(std::move(llmRequest), std::move(future));
     requestPtr->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_IN_PROGRESS);

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -296,16 +296,16 @@ public:
         }
     }
 
-    [[nodiscard]] std::future<void> sendAsync(LlmRequest& llmRequest)
+    [[nodiscard]] std::future<void> sendAsync(std::shared_ptr<LlmRequest> const& llmRequest)
     {
+        TLLM_CHECK(llmRequest != nullptr);
         std::promise<void> promise;
         auto future = promise.get_future();
-        llmRequest.setKvCacheTransferStart(LlmRequest::getSteadyClockNow());
+        llmRequest->setKvCacheTransferStart(LlmRequest::getSteadyClockNow());
         {
             {
                 std::scoped_lock lkResp(mSenderMutex);
-                mReadyResponses.emplace(
-                    llmRequest.mRequestId, Response{std::addressof(llmRequest), std::move(promise)});
+                mReadyResponses.emplace(llmRequest->mRequestId, Response{llmRequest, std::move(promise)});
             }
             std::unique_lock lkCond(mCondMutex);
             mAnyReady = true;
@@ -477,7 +477,9 @@ public:
 private:
     struct Response
     {
-        LlmRequest* mRequest;
+        // shared_ptr so this struct co-owns the request until the promise resolves;
+        // protects worker-side dereferences and the promise itself from premature destruction.
+        std::shared_ptr<LlmRequest> mRequest;
         std::promise<void> mPromise;
     };
 
@@ -511,7 +513,12 @@ private:
                 resp = std::move(resource.mSendQueue.front());
                 resource.mSendQueue.pop_front();
             }
-            sendAndRemoveResponse(resp.mRequest->mRequestId, std::move(resp));
+            // Sequence the read before the move: argument initializations
+            // are indeterminately sequenced, so inlining resp.mRequest->...
+            // alongside std::move(resp) is UB once mRequest is a shared_ptr.
+            TLLM_CHECK(resp.mRequest != nullptr);
+            auto const reqId = resp.mRequest->mRequestId;
+            sendAndRemoveResponse(reqId, std::move(resp));
         }
     }
 
@@ -584,14 +591,23 @@ private:
             {
                 // TODO: if the generation does not require the kv cache, the request will
                 // not be removed from mCancelledRequests. This should be handled by timeout.
-                auto it = mReadyResponses.find(mCurrentRequest.value());
-                TLLM_CHECK(it != mReadyResponses.end());
+                auto const cancelledReqId = mCurrentRequest.value();
+                Response cancelledResponse;
                 {
                     std::scoped_lock lkResp(mSenderMutex);
+                    auto it = mReadyResponses.find(cancelledReqId);
+                    TLLM_CHECK(it != mReadyResponses.end());
+                    // Move out before erasing so the promise survives the
+                    // map cleanup and can be resolved (vs. destroyed unfulfilled,
+                    // which would surface as std::future_error: Broken promise).
+                    cancelledResponse = std::move(it->second);
                     mReadyResponses.erase(it);
-                    mCancelledRequests.erase(mCurrentRequest.value());
-                    mRemainSendCount.erase(mCurrentRequest.value());
+                    mCancelledRequests.erase(cancelledReqId);
+                    mRemainSendCount.erase(cancelledReqId);
                 }
+                cancelledResponse.mPromise.set_exception(std::make_exception_ptr(
+                    TLLM_REQUEST_EXCEPTION(cancelledReqId, common::RequestErrorCode::kNETWORK_ERROR,
+                        "KV cache transfer for request %zu was cancelled", cancelledReqId)));
                 mCurrentRequest = std::nullopt;
 
                 if (mReadyResponses.empty())
@@ -762,23 +778,27 @@ public:
         TLLM_CUDA_CHECK(cudaGetDevice(&mDeviceId));
     }
 
-    [[nodiscard]] std::future<void> receiveAsync(LlmRequest& llmRequest)
+    [[nodiscard]] std::future<void> receiveAsync(std::shared_ptr<LlmRequest> const& llmRequest)
     {
+        TLLM_CHECK(llmRequest != nullptr);
         // TODO: Modify the implementation here to avoid frequent thread creation.
-        return std::async(std::launch::async, &CacheReceiver::Impl::requestSync, this, std::ref(llmRequest));
+        // Capture by value so the async task owns a strong reference for its lifetime.
+        auto llmRequestCopy = llmRequest;
+        return std::async(std::launch::async, [this, llmRequestCopy]() { requestSync(*llmRequestCopy); });
     }
 
-    [[nodiscard]] std::future<void> requestAndReceiveAsyncMultiThreads(LlmRequest& llmRequest)
+    [[nodiscard]] std::future<void> requestAndReceiveAsyncMultiThreads(std::shared_ptr<LlmRequest> const& llmRequest)
     {
+        TLLM_CHECK(llmRequest != nullptr);
         try
         {
             auto promise = std::make_unique<std::promise<void>>();
             auto future = promise->get_future();
-            TLLM_CHECK(llmRequest.getDataTransceiverState().getCommState().has_value());
+            TLLM_CHECK(llmRequest->getDataTransceiverState().getCommState().has_value());
             std::string processInfo = kDefaultProcessInfo;
             if (common::getEnvRequestKVCacheConcurrent())
             {
-                processInfo = llmRequest.getDataTransceiverState().getCommState()->toString();
+                processInfo = llmRequest->getDataTransceiverState().getCommState()->toString();
             }
             if (mInstanceToAsyncResource.find(processInfo) == mInstanceToAsyncResource.end())
             {
@@ -791,7 +811,7 @@ public:
             auto& asyncResource = mInstanceToAsyncResource.at(processInfo);
             {
                 std::unique_lock<std::mutex> lck(asyncResource->mMtxForQueue);
-                asyncResource->mRequestsQueue.emplace_back(std::addressof(llmRequest), std::move(promise));
+                asyncResource->mRequestsQueue.emplace_back(llmRequest, std::move(promise));
             }
             asyncResource->mCVforQueue.notify_all();
             return future;
@@ -1003,6 +1023,23 @@ public:
                 { return requestAndPromise.mRequest->mRequestId == llmRequest.mRequestId; });
             if (it != asyncResource->mRequestsQueue.end())
             {
+                // Resolve the promise before erasing so the future returned by
+                // receiveAsync surfaces a structured cancellation error rather
+                // than std::future_error: Broken promise from the destroyed promise.
+                if (it->mPromise)
+                {
+                    try
+                    {
+                        it->mPromise->set_exception(std::make_exception_ptr(
+                            TLLM_REQUEST_EXCEPTION(llmRequest.mRequestId, common::RequestErrorCode::kNETWORK_ERROR,
+                                "Generation KV cache request cancelled before send for request %zu",
+                                llmRequest.mRequestId)));
+                    }
+                    catch (std::future_error const&)
+                    {
+                        // Promise already satisfied; nothing to do.
+                    }
+                }
                 asyncResource->mRequestsQueue.erase(it);
                 isCancelled = true;
             }
@@ -1083,7 +1120,9 @@ private:
 
     struct RequestAndPromise
     {
-        LlmRequest* mRequest;
+        // shared_ptr so this struct co-owns the request until the promise resolves;
+        // protects worker-side dereferences and the promise itself from premature destruction.
+        std::shared_ptr<LlmRequest> mRequest;
         std::unique_ptr<std::promise<void>> mPromise;
 
         RequestAndPromise()
@@ -1092,8 +1131,8 @@ private:
         {
         }
 
-        RequestAndPromise(LlmRequest* request, std::unique_ptr<std::promise<void>>&& promise)
-            : mRequest(request)
+        RequestAndPromise(std::shared_ptr<LlmRequest> request, std::unique_ptr<std::promise<void>>&& promise)
+            : mRequest(std::move(request))
             , mPromise(std::move(promise))
         {
         }
@@ -1101,26 +1140,23 @@ private:
         RequestAndPromise(RequestAndPromise const&) = delete;
 
         RequestAndPromise(RequestAndPromise&& other) noexcept
-            : mRequest(other.mRequest)
+            : mRequest(std::move(other.mRequest))
             , mPromise(std::move(other.mPromise))
         {
-            other.mRequest = nullptr;
         }
 
         RequestAndPromise& operator=(RequestAndPromise&& other) noexcept
         {
             if (this != &other)
             {
-                mRequest = nullptr;
+                mRequest.reset();
                 if (mPromise)
                 {
                     mPromise.reset();
                 }
 
-                mRequest = other.mRequest;
+                mRequest = std::move(other.mRequest);
                 mPromise = std::move(other.mPromise);
-
-                other.mRequest = nullptr;
             }
             return *this;
         }
@@ -1228,7 +1264,7 @@ CacheSender::CacheSender(
 {
 }
 
-std::future<void> CacheSender::sendAsync(LlmRequest& llmRequest) const
+std::future<void> CacheSender::sendAsync(std::shared_ptr<LlmRequest> const& llmRequest) const
 {
     return mImpl->sendAsync(llmRequest);
 }
@@ -1277,7 +1313,7 @@ CacheReceiver::CacheReceiver(
 {
 }
 
-std::future<void> CacheReceiver::receiveAsync(LlmRequest& llmRequest) const
+std::future<void> CacheReceiver::receiveAsync(std::shared_ptr<LlmRequest> const& llmRequest) const
 {
     return mImpl->requestAndReceiveAsyncMultiThreads(llmRequest);
 }

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.h
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.h
@@ -256,10 +256,10 @@ public:
     CacheSender() = default;
 
     /// @brief Asynchronously respond to the request and send data.
-    /// @param llmRequest Request object. Its data should be ready when called, and the data for this request
-    /// should remain valid until future synchronization.
+    /// @param llmRequest Request object. Its data should be ready when called. shared_ptr so the async send
+    /// worker can extend the request's lifetime past the caller's reference.
     /// @return Once the data is fully sent, the future object will become valid.
-    [[nodiscard]] virtual std::future<void> sendAsync(LlmRequest& llmRequest) const;
+    [[nodiscard]] virtual std::future<void> sendAsync(std::shared_ptr<LlmRequest> const& llmRequest) const;
 
     /// @brief Return the internal communicator status.
     /// @return The communicator status.
@@ -319,10 +319,10 @@ public:
     CacheReceiver() = default;
 
     /// @brief Asynchronously send a request to receive data.
-    /// @param llmRequest Request object. Its data should be in an allocated but unwritten state when called, and the
-    /// data for this request should remain intact only after future synchronization.
+    /// @param llmRequest Request object. Its data should be in an allocated but unwritten state when called.
+    /// shared_ptr so the async receive worker can extend the request's lifetime past the caller's reference.
     /// @return Once the data is fully received, the future object will become valid.
-    [[nodiscard]] virtual std::future<void> receiveAsync(LlmRequest& llmRequest) const;
+    [[nodiscard]] virtual std::future<void> receiveAsync(std::shared_ptr<LlmRequest> const& llmRequest) const;
 
     virtual TransferSession sendRequestInfo(LlmRequest const& llmRequest);
 

--- a/cpp/tests/unit_tests/multi_gpu/cacheTransceiverTest.cpp
+++ b/cpp/tests/unit_tests/multi_gpu/cacheTransceiverTest.cpp
@@ -348,11 +348,11 @@ protected:
                     TLLM_CUDA_CHECK(cudaMemset(it->data(), llmRequest->getPromptLen(), it->getSizeInBytes()));
                 }
             }
-            mFutures.emplace_back(mSender->sendAsync(*llmRequest));
+            mFutures.emplace_back(mSender->sendAsync(llmRequest));
         }
         else
         {
-            auto future = mRequester->receiveAsync(*llmRequest);
+            auto future = mRequester->receiveAsync(llmRequest);
             future.get();
             TLLM_CUDA_CHECK(cudaDeviceSynchronize());
             auto blockRange = BlockRange::fromAllBlockIds(*mManager, llmRequest->mRequestId);
@@ -468,12 +468,13 @@ struct CPMetaData
 
 struct WrappedLlmRequest
 {
-    std::unique_ptr<LlmRequest> mLlmRequest;
+    // shared_ptr to match CacheSender::sendAsync / CacheReceiver::receiveAsync signatures.
+    std::shared_ptr<LlmRequest> mLlmRequest;
     std::optional<CPMetaData> mCPMetaData;
 
     using RequestIdType = LlmRequest::RequestIdType;
 
-    WrappedLlmRequest(std::unique_ptr<LlmRequest> llmRequest, std::optional<CPMetaData> cpMetaData)
+    WrappedLlmRequest(std::shared_ptr<LlmRequest> llmRequest, std::optional<CPMetaData> cpMetaData)
         : mLlmRequest(std::move(llmRequest))
         , mCPMetaData(std::move(cpMetaData))
     {
@@ -887,7 +888,7 @@ protected:
         auto stats = texec::ContextPhaseParams({}, mRequestId, state.release(), std::nullopt);
         request.setContextPhaseParams(std::move(stats));
 
-        auto llmRequestPtr = std::make_unique<LlmRequest>(mRequestId++, std::move(request));
+        auto llmRequestPtr = std::make_shared<LlmRequest>(mRequestId++, std::move(request));
         return std::make_unique<WrappedLlmRequest>(std::move(llmRequestPtr), cpMetaData);
     }
 
@@ -919,7 +920,7 @@ protected:
         state->setCacheState(cacheState);
         auto stats = texec::ContextPhaseParams({}, requestId, state.release(), std::nullopt);
         request.setContextPhaseParams(std::move(stats));
-        auto llmRequestPtr = std::make_unique<LlmRequest>(requestId, std::move(request));
+        auto llmRequestPtr = std::make_shared<LlmRequest>(requestId, std::move(request));
 
         return std::make_unique<WrappedLlmRequest>(std::move(llmRequestPtr), cpMetaData);
     }
@@ -973,7 +974,7 @@ protected:
         auto const onlyWindowSize = blockManager.getPoolWindowSize(0);
 
         blockManager.getBufferManager(onlyWindowSize).getStream().synchronize();
-        auto future = mSender->sendAsync(*llmRequest);
+        auto future = mSender->sendAsync(llmRequest);
         return future;
     }
 
@@ -984,7 +985,7 @@ protected:
         auto& llmRequest = request->mLlmRequest;
         mManager->addSequenceBatch(
             {{{llmRequest->mRequestId, llmRequest->getNumTokens(beamIdx), beamWidth}}}, {std::ref(*llmRequest)});
-        return mRequester->receiveAsync(*llmRequest);
+        return mRequester->receiveAsync(llmRequest);
     }
 
     void generationVerifyKVCache(std::shared_ptr<WrappedLlmRequest> const& request)


### PR DESCRIPTION
## Summary

Closes a UAF / Broken-promise gap in the disagg KV cache transfer that survived [PR #14768](https://github.com/NVIDIA/TensorRT-LLM/pull/14768) (the always-on-baseline tier-1 PR). PR #14768 ported the `shared_ptr<LlmRequest>` lifetime fix at the **outer** `CacheTransceiver` layer (interface + `mSenderFutures` / `mRequesterFutures`) but not at the **inner** `dataTransceiver` layer where the actual `std::promise<void>` lives. This PR ports just the inner-layer lifetime piece from [PR #13713](https://github.com/NVIDIA/TensorRT-LLM/pull/13713).

## What was missed in PR #14768

| Layer | What PR #14768 did | Was it enough? |
|---|---|---|
| **Outer** (`cacheTransceiver.{h,cpp}`) | Changed transceiver interface + `mSender`/`mRequesterFutures` storage to `shared_ptr<LlmRequest>` | ✅ Keeps the `LlmRequest` object alive |
| **Inner** (`dataTransceiver.{h,cpp}`) | **Unchanged.** `Response::mRequest` and `RequestAndPromise::mRequest` still raw pointers; `sendAsync(LlmRequest&)` / `receiveAsync(LlmRequest&)` still by reference; `std::async(&Impl::requestSync, this, std::ref(llmRequest))` captures by reference | ❌ The inner structures own the `std::promise<void>`; if they're destroyed during worker error cleanup or the async task races Python `_terminate_request`, the promise dies unfulfilled → `std::future_error: Broken promise` on the future side |

The outer-layer fix prevents the C++ worker from dereferencing a freed `LlmRequest`, but does nothing to prevent the inner `Response`/`RequestAndPromise` structures (which hold the promise) from being destroyed in the worker's error path. Under sustained real disagg load, peer drops and worker-side errors are routine; each destroys an inner structure and fires `Broken promise` on the corresponding future.

## Observed signature (internal incident report)

Recurring `~1.9 h` MTTF on a Qwen3-Coder-480B 4P2D disagg shadow running post-PR-#14768 image. One decode worker accumulates an `std::future_error: Broken promise` storm (concentrated on a single worker; peers idle), `trtllm_num_requests_running` climbs while peers stay at 0, dynamo canary health check fails, kubelet restarts the worker, serving recovers. Repeat. Across ~19 h: 19 decode-worker restarts on 2 workers, 4 NVCF instance replacements.

```text
[TRT-LLM] [E][batchmgr][RANK 1] Error occurred during generation transfer for request <id>:
  std::future_error: Broken promise
```

## What this PR changes

Pure lifetime fix at the inner layer — mirrors the relevant subset of PR #13713's dataTransceiver changes:

- `sendAsync(LlmRequest&)` → `sendAsync(std::shared_ptr<LlmRequest> const&)` (both `Impl` and public `CacheSender::sendAsync`)
- `receiveAsync(LlmRequest&)` → `receiveAsync(std::shared_ptr<LlmRequest> const&)` (both `Impl` and public `CacheReceiver::receiveAsync`)
  - **Critical**: the inner `std::async` now captures the `shared_ptr` by value in a lambda rather than `std::ref(llmRequest)` — closes the UAF where Python `_terminate_request` beats the async task
- `requestAndReceiveAsyncMultiThreads(LlmRequest&)` → `shared_ptr` analog
- `struct Response`: `LlmRequest*` → `std::shared_ptr<LlmRequest>`
- `struct RequestAndPromise`: `LlmRequest*` → `std::shared_ptr<LlmRequest>` (move-semantics tightened — no more null-out-raw-pointer dance)
- 4 callers in `cacheTransceiver.cpp` pass the already-`shared_ptr` `llmRequest` directly instead of dereferencing
- `cacheTransceiverTest.cpp` `WrappedLlmRequest` switched from `unique_ptr` to `shared_ptr` so the test infra compiles against the new signatures

## Out of scope (intentionally — preserving PR #14768's "always-on baseline" scope)

- In-flight cancel flag registry (`mInFlightCancelFlags` map, `getOrCreateInFlightCancelFlag`, per-request flag wiring) — that's the G* cancel surface, env-gated by `TRTLLM_DISAGG_ENABLE_INFLIGHT_CANCEL`
- Defensive non-`std::exception` catch on `response()` worker — orthogonal safety improvement, separable
- `set_exception` on cancelled-response promise destruction — cancel-path semantic improvement, lives with the cancel surface

These remain part of the broader cancellation follow-up tracked under TRTLLM-12721.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal memory safety for asynchronous cache transfer operations by implementing stronger request lifetime guarantees. Background cache transfer tasks now maintain proper ownership of requests throughout the entire async operation cycle, reducing the risk of resource cleanup issues in multi-threaded scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->