### PR TITLE
[None][feat] Add ConversationAwareADPRouter: explicit conversation->rank affinity for attention DP

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -21,8 +21,8 @@ import heapq
 import math
 import random
 from abc import ABC, abstractmethod
-from collections import namedtuple
-from dataclasses import astuple, dataclass
+from collections import OrderedDict, namedtuple
+from dataclasses import MISSING, astuple, dataclass, field, fields, replace
 from typing import TYPE_CHECKING, Dict, List, Set, Tuple
 
 from tensorrt_llm.logger import logger
@@ -104,6 +104,21 @@ class ADPRouter(ABC):
             kv_cache_manager has block reuse enabled; DefaultADPRouter
             otherwise.
         """
+        if attention_dp_config is not None and getattr(
+            attention_dp_config, "kv_cache_routing_conversation_affinity", False
+        ):
+            # Explicit conversation_id -> rank affinity. Independent of the KV
+            # cache manager (works with or without block reuse, though it is
+            # most beneficial with reuse on), so it is checked before the
+            # KV-cache-aware path and takes precedence when both are enabled.
+            return ConversationAwareADPRouter(
+                dist=dist,
+                max_sessions=getattr(
+                    attention_dp_config, "kv_cache_routing_max_sessions", 1 << 16
+                ),
+                fair_share_multiplier=attention_dp_config.kv_cache_routing_fair_share_multiplier,
+            )
+
         if (
             attention_dp_config is not None
             and attention_dp_config.enable_kv_cache_aware_routing
@@ -650,6 +665,207 @@ class KVCacheAwareADPRouter(ADPRouter):
         logger.debug(
             f"[adp_router] new_reqs_per_rank="
             f"{[len(all_ranks_new_requests[r]) for r in range(tp_size)]}"
+        )
+
+        return all_ranks_new_requests, expected_num_active_requests
+
+
+class ConversationAwareADPRouter(ADPRouter):
+    """Conversation-affinity request router for attention data parallelism.
+
+    Routes the *first* request of each conversation round-robin across ranks,
+    then pins every later request carrying the same ``conversation_id`` to the
+    rank that served that conversation's first turn. This keeps a multi-turn
+    conversation's growing KV-cache prefix on a single rank (maximizing block
+    reuse, minimizing recompute and cross-rank migration) while still spreading
+    the birth of new conversations evenly.
+
+    Contrast with :class:`KVCacheAwareADPRouter`, which *infers* affinity from
+    probed prefix-match lengths: that affinity is lost as soon as a
+    conversation's blocks are evicted -- the request then re-routes by load and
+    the conversation "migrates" ranks. This router keeps an **explicit**
+    ``conversation_id -> rank`` map, so stickiness is deterministic and survives
+    cache eviction. It is inspired by the serve-level ConversationRouter
+    (``tensorrt_llm/serve/router.py``) and the first-turn-round-robin idea from
+    PR #14744, but applied at the intra-instance ADP-rank level.
+
+    ``conversation_id`` is read from
+    ``req.py_disaggregated_params.conversation_id`` (populated by the serve-side
+    conversation / KV-aware router from the ``X-Session-ID`` header; see
+    PR #14744). When it is absent -- header not sent, non-disaggregated, or the
+    serve-side propagation is not present -- the request falls back to
+    load-balanced round-robin and is *not* recorded, so behaviour degrades
+    gracefully to ``DefaultADPRouter``-style spreading.
+
+    Determinism: :meth:`route_requests` runs locally on every TP rank with no
+    broadcast, so the round-robin cursor and the conversation->rank map MUST
+    evolve identically on every rank. They do, because every rank processes the
+    same ``new_requests`` in the same order. Any divergence would deadlock the
+    distributed allgather protocol -- this is the same invariant the warmup /
+    first-turn-round-robin cursors rely on above.
+    """
+
+    # Default LRU cap on the conversation->rank map (entries are ~tens of
+    # bytes each). Bounds memory on long-running servers as conversations churn.
+    DEFAULT_MAX_SESSIONS = 1 << 16
+
+    def __init__(self, dist: "Distributed", max_sessions: int = DEFAULT_MAX_SESSIONS,
+                 fair_share_multiplier: float = 2.0):
+        super().__init__(dist)
+        # conversation_id -> rank, LRU-ordered (most-recently-routed last).
+        self._conv_to_rank: "OrderedDict[str, int]" = OrderedDict()
+        self._max_sessions = max(1, int(max_sessions))
+        # Loose per-rank cap = fair_share_multiplier * ceil fair-share. Sticky
+        # concentration is allowed up to this but NEVER beyond, so the returned
+        # expected_num_active_requests stays >= every rank's active count (the
+        # ADP invariant asserted in py_executor._pad_attention_dp_dummy_request).
+        self._fair_share_multiplier = max(1.0, float(fair_share_multiplier))
+        # Round-robin cursor for first-turn / unkeyed requests. Mutated
+        # identically on every rank (route_requests is deterministic), exactly
+        # like KVCacheAwareADPRouter._first_turn_rr_counter; divergence deadlocks.
+        self._rr_counter = 0
+
+    def create_rank_state(
+        self,
+        active_requests: list[LlmRequest],
+        new_requests: list[RequestQueueItem],
+    ) -> RankState:
+        if self.dist.has_cp_helix:
+            num_active_tokens = sum(req.total_input_len_cp for req in active_requests)
+        else:
+            num_active_tokens = sum(req.py_orig_prompt_len for req in active_requests)
+        return RankState(
+            rank=self.dist.tp_rank,
+            num_active_requests=len(active_requests),
+            num_active_tokens=num_active_tokens,
+        )
+
+    @staticmethod
+    def _conversation_id(req_item) -> "str | None":
+        """Return the request's conversation id, or None when unavailable.
+
+        Read from ``py_disaggregated_params.conversation_id`` (serve-side
+        propagated from the X-Session-ID header). Empty strings are treated as
+        absent so they fall through to the load-balanced path.
+        """
+        req = getattr(req_item, "request", None)
+        if req is None:
+            return None
+        disagg = getattr(req, "py_disaggregated_params", None)
+        if disagg is None:
+            return None
+        conv_id = getattr(disagg, "conversation_id", None)
+        return conv_id if conv_id else None
+
+    def _record_home(self, conv_id: str, rank: int) -> None:
+        """Bind/refresh a conversation's home rank with LRU eviction."""
+        self._conv_to_rank[conv_id] = rank
+        self._conv_to_rank.move_to_end(conv_id)
+        while len(self._conv_to_rank) > self._max_sessions:
+            self._conv_to_rank.popitem(last=False)
+
+    def route_requests(
+        self,
+        all_rank_states: list[RankState],
+        new_requests: list[RequestQueueItem],
+        max_num_active_requests: int,
+    ) -> Tuple[Dict[int, List[RequestQueueItem]], int]:
+        tp_size = len(all_rank_states)
+        all_ranks_new_requests: Dict[int, List[RequestQueueItem]] = {
+            s.rank: [] for s in all_rank_states
+        }
+        all_ranks_num_active_requests = [s.num_active_requests for s in all_rank_states]
+
+        def get_relax_value(req_item):
+            scheduling_params = getattr(req_item.request, "py_scheduling_params", None)
+            if scheduling_params is None:
+                return True
+            return scheduling_params.attention_dp_relax
+
+        sorted_requests = sorted(new_requests, key=get_relax_value)
+
+        # 1) Honour an explicit attention_dp_rank first (strict placement),
+        #    matching DefaultADPRouter / KVCacheAwareADPRouter.
+        remaining_unscheduled: List[RequestQueueItem] = []
+        for req_item in sorted_requests:
+            scheduling_params = getattr(req_item.request, "py_scheduling_params", None)
+            target_dp_rank = (
+                scheduling_params.attention_dp_rank if scheduling_params is not None else None
+            )
+            if (
+                target_dp_rank is not None
+                and all_ranks_num_active_requests[target_dp_rank] < max_num_active_requests
+            ):
+                all_ranks_num_active_requests[target_dp_rank] += 1
+                all_ranks_new_requests[target_dp_rank].append(req_item)
+            else:
+                remaining_unscheduled.append(req_item)
+
+        # 2) Loose per-rank cap = fair_share_multiplier * ceil fair-share
+        #    (mirrors KVCacheAwareADPRouter). BOTH new-conversation spreading and
+        #    sticky returns are capped at this, so no rank ever exceeds the
+        #    returned expected_num_active_requests -- exceeding it breaks the ADP
+        #    padding invariant (py_executor._pad_attention_dp_dummy_request) and
+        #    crashes the executor. The multiplier gives sticky concentration
+        #    slack before a conversation overflows off its home rank.
+        num_new_requests_all_ranks = len(remaining_unscheduled)
+        total_num_active_requests = sum(all_ranks_num_active_requests)
+        fair_share = (
+            total_num_active_requests + num_new_requests_all_ranks + tp_size - 1
+        ) // tp_size
+        expected_num_active_requests = max(
+            math.ceil(self._fair_share_multiplier * fair_share),
+            max(all_ranks_num_active_requests),
+        )
+
+        def _least_loaded(soft_cap: int) -> int:
+            """Lowest-active rank under soft_cap (deterministic), else global min."""
+            cands = [r for r in range(tp_size) if all_ranks_num_active_requests[r] < soft_cap]
+            if not cands:
+                cands = list(range(tp_size))
+            return min(cands, key=lambda r: (all_ranks_num_active_requests[r], r))
+
+        def _next_rr(soft_cap: int) -> int:
+            """Round-robin to the next rank under soft_cap; advance the cursor."""
+            for _ in range(tp_size):
+                r = self._rr_counter % tp_size
+                self._rr_counter = (self._rr_counter + 1) % tp_size
+                if all_ranks_num_active_requests[r] < soft_cap:
+                    return r
+            return _least_loaded(soft_cap)
+
+        for req_item in remaining_unscheduled:
+            conv_id = self._conversation_id(req_item)
+            rank = None
+
+            if conv_id is not None and conv_id in self._conv_to_rank:
+                home = self._conv_to_rank[conv_id]
+                # Sticky: return the conversation to its home rank while that
+                # rank is under `expected` (the loose fair-share*multiplier cap).
+                # Capping here -- NOT at the hard max_num_active_requests -- is
+                # required: a rank exceeding `expected` breaks the ADP padding
+                # invariant and crashes the executor.
+                if all_ranks_num_active_requests[home] < expected_num_active_requests:
+                    rank = home
+                    self._record_home(conv_id, home)  # LRU touch
+                # else: home saturated this batch -> fall through to overflow
+                # WITHOUT rebinding, so the conversation returns home next batch.
+
+            if rank is None:
+                # First turn of a new conversation, sticky-overflow, or no
+                # conversation_id -> round-robin spread under the soft cap.
+                rank = _next_rr(expected_num_active_requests)
+                if conv_id is not None and conv_id not in self._conv_to_rank:
+                    # Bind this new conversation's home to its first-turn rank.
+                    self._record_home(conv_id, rank)
+
+            all_ranks_new_requests[rank].append(req_item)
+            all_ranks_num_active_requests[rank] += 1
+
+        logger.debug(
+            f"[adp_router][conv] new_reqs_per_rank="
+            f"{[len(all_ranks_new_requests[r]) for r in range(tp_size)]} "
+            f"tracked_convs={len(self._conv_to_rank)}"
         )
 
         return all_ranks_new_requests, expected_num_active_requests

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -22,7 +22,7 @@ import math
 import random
 from abc import ABC, abstractmethod
 from collections import OrderedDict, namedtuple
-from dataclasses import MISSING, astuple, dataclass, field, fields, replace
+from dataclasses import astuple, dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
 from tensorrt_llm.logger import logger
@@ -104,8 +104,10 @@ class ADPRouter(ABC):
             kv_cache_manager has block reuse enabled; DefaultADPRouter
             otherwise.
         """
-        if (attention_dp_config is not None
-                and attention_dp_config.kv_cache_routing_conversation_affinity):
+        if (
+            attention_dp_config is not None
+            and attention_dp_config.kv_cache_routing_conversation_affinity
+        ):
             # Explicit conversation_id -> rank affinity. Independent of the KV
             # cache manager (works with or without block reuse, though it is
             # most beneficial with reuse on), so it is checked before the
@@ -297,15 +299,19 @@ class DefaultADPRouter(ADPRouter):
         sorted_requests = sorted(new_requests, key=get_relax_value)
 
         remaining_unscheduled = self._assign_explicit_dp_ranks(
-            sorted_requests, all_ranks_new_requests,
-            all_ranks_num_active_requests, max_num_active_requests,
+            sorted_requests,
+            all_ranks_new_requests,
+            all_ranks_num_active_requests,
+            max_num_active_requests,
         )
 
         num_new_requests_all_ranks = len(remaining_unscheduled)
         # Cap at max_num_active_requests so the per-rank target never
         # exceeds what the rank can physically schedule.
         expected_num_active_requests = self._expected_num_active_requests(
-            all_ranks_num_active_requests, num_new_requests_all_ranks, tp_size,
+            all_ranks_num_active_requests,
+            num_new_requests_all_ranks,
+            tp_size,
             hard_cap=max_num_active_requests,
         )
 
@@ -627,8 +633,11 @@ class KVCacheAwareADPRouter(ADPRouter):
         # affinity wins in the common case.
         num_new_requests_all_ranks = len(remaining_unscheduled)
         expected_num_active_requests = self._expected_num_active_requests(
-            all_ranks_num_active_requests, num_new_requests_all_ranks, tp_size,
-            multiplier=self.fair_share_multiplier, hard_cap=max_num_active_requests,
+            all_ranks_num_active_requests,
+            num_new_requests_all_ranks,
+            tp_size,
+            multiplier=self.fair_share_multiplier,
+            hard_cap=max_num_active_requests,
         )
         eligible_ranks = [
             rank
@@ -716,8 +725,12 @@ class ConversationAwareADPRouter(ADPRouter):
     # bytes each). Bounds memory on long-running servers as conversations churn.
     DEFAULT_MAX_SESSIONS = 1 << 16
 
-    def __init__(self, dist: "Distributed", max_sessions: int = DEFAULT_MAX_SESSIONS,
-                 fair_share_multiplier: float = 2.0):
+    def __init__(
+        self,
+        dist: "Distributed",
+        max_sessions: int = DEFAULT_MAX_SESSIONS,
+        fair_share_multiplier: float = 2.0,
+    ):
         super().__init__(dist)
         self._conv_to_rank: "OrderedDict[str, int]" = OrderedDict()
         self._max_sessions = max(1, int(max_sessions))
@@ -779,14 +792,18 @@ class ConversationAwareADPRouter(ADPRouter):
 
         # 1) Honour an explicit attention_dp_rank first (strict placement).
         remaining_unscheduled = self._assign_explicit_dp_ranks(
-            sorted_requests, all_ranks_new_requests,
-            all_ranks_num_active_requests, max_num_active_requests,
+            sorted_requests,
+            all_ranks_new_requests,
+            all_ranks_num_active_requests,
+            max_num_active_requests,
         )
 
         # 2) Loose soft cap for spreading new conversations across ranks; sticky
         #    returns may exceed it (hard cap), so it is re-bumped after the loop.
         expected_num_active_requests = self._expected_num_active_requests(
-            all_ranks_num_active_requests, len(remaining_unscheduled), tp_size,
+            all_ranks_num_active_requests,
+            len(remaining_unscheduled),
+            tp_size,
             multiplier=self._fair_share_multiplier,
         )
 

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -820,11 +820,17 @@ class ConversationAwareADPRouter(ADPRouter):
             if conv_id is not None and conv_id in self._conv_to_rank:
                 target_rank = self._conv_to_rank[conv_id]
                 # Sticky: return the conversation to its target rank while that
-                # rank is under `expected` (the loose fair-share*multiplier cap).
-                # Capping here -- NOT at the hard max_num_active_requests -- is
-                # required: a rank exceeding `expected` breaks the ADP padding
-                # invariant and crashes the executor.
-                if all_ranks_num_active_requests[target_rank] < expected_num_active_requests:
+                # rank is under the HARD cap (max_num_active_requests), NOT the
+                # soft fair-share `expected`. Stickiness intentionally wins over
+                # balance so a conversation's KV prefix stays resident on one
+                # rank -- capping sticky at the soft `expected` (~fair_share)
+                # displaces popular conversations as soon as their rank is
+                # moderately busy, causing rank migration -> prefix-cache miss ->
+                # worse TTFT (measured: cache hit drops below kv-aware). The hard
+                # cap can push a rank above the pre-loop `expected`; the returned
+                # value is re-bumped after the loop to keep the ADP padding
+                # invariant (_pad_attention_dp_dummy_request) satisfied.
+                if all_ranks_num_active_requests[target_rank] < max_num_active_requests:
                     rank = target_rank
                     self._record_target_rank(conv_id, target_rank)  # LRU touch
                 # else: target saturated this batch -> fall through to overflow
@@ -840,6 +846,14 @@ class ConversationAwareADPRouter(ADPRouter):
 
             all_ranks_new_requests[rank].append(req_item)
             all_ranks_num_active_requests[rank] += 1
+
+        # Sticky returns use the hard cap, so a rank may now exceed the pre-loop
+        # soft `expected`. Re-bump so the returned value covers the actual
+        # per-rank max -- _pad_attention_dp_dummy_request asserts
+        # expected >= len(active_requests) on every rank.
+        expected_num_active_requests = max(
+            expected_num_active_requests, max(all_ranks_num_active_requests)
+        )
 
         logger.debug(
             f"[adp_router][conv] new_reqs_per_rank="

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -720,7 +720,6 @@ class ConversationAwareADPRouter(ADPRouter):
                  fair_share_multiplier: float = 2.0):
         super().__init__(dist)
         self._conv_to_rank: "OrderedDict[str, int]" = OrderedDict()
-        # LRU cap on the conversation->rank map; oldest entries evicted beyond this.
         self._max_sessions = max(1, int(max_sessions))
         self._fair_share_multiplier = max(1.0, float(fair_share_multiplier))
         self._round_robin_cursor = 0
@@ -742,10 +741,6 @@ class ConversationAwareADPRouter(ADPRouter):
 
     @staticmethod
     def _conversation_id(req_item) -> "str | None":
-        # NOTE: req_item.request may be a raw tensorrt_llm.bindings.executor.Request
-        # (e.g. warmup/dummy requests) that lacks the Python-side
-        # py_disaggregated_params attribute -- getattr (not direct access) so those
-        # fall through to the load-balanced path instead of raising AttributeError.
         req = getattr(req_item, "request", None)
         if req is None:
             return None
@@ -788,10 +783,8 @@ class ConversationAwareADPRouter(ADPRouter):
             all_ranks_num_active_requests, max_num_active_requests,
         )
 
-        # 2) Loose per-rank cap = fair_share_multiplier * ceil(fair-share). BOTH
-        #    new-conversation spreading and sticky returns are capped at this, so
-        #    no rank exceeds expected_num_active_requests -- exceeding it breaks
-        #    the ADP padding invariant (py_executor._pad_attention_dp_dummy_request).
+        # 2) Loose soft cap for spreading new conversations across ranks; sticky
+        #    returns may exceed it (hard cap), so it is re-bumped after the loop.
         expected_num_active_requests = self._expected_num_active_requests(
             all_ranks_num_active_requests, len(remaining_unscheduled), tp_size,
             multiplier=self._fair_share_multiplier,
@@ -821,15 +814,9 @@ class ConversationAwareADPRouter(ADPRouter):
                 target_rank = self._conv_to_rank[conv_id]
                 # Sticky: return the conversation to its target rank while that
                 # rank is under the HARD cap (max_num_active_requests), NOT the
-                # soft fair-share `expected`. Stickiness intentionally wins over
-                # balance so a conversation's KV prefix stays resident on one
-                # rank -- capping sticky at the soft `expected` (~fair_share)
-                # displaces popular conversations as soon as their rank is
-                # moderately busy, causing rank migration -> prefix-cache miss ->
-                # worse TTFT (measured: cache hit drops below kv-aware). The hard
-                # cap can push a rank above the pre-loop `expected`; the returned
-                # value is re-bumped after the loop to keep the ADP padding
-                # invariant (_pad_attention_dp_dummy_request) satisfied.
+                # soft fair-share `expected`. Stickiness wins over balance so a
+                # conversation's KV prefix stays resident on one rank instead of
+                # migrating when the rank gets moderately busy.
                 if all_ranks_num_active_requests[target_rank] < max_num_active_requests:
                     rank = target_rank
                     self._record_target_rank(conv_id, target_rank)  # LRU touch

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -23,7 +23,7 @@ import random
 from abc import ABC, abstractmethod
 from collections import OrderedDict, namedtuple
 from dataclasses import MISSING, astuple, dataclass, field, fields, replace
-from typing import TYPE_CHECKING, Dict, List, Set, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple
 
 from tensorrt_llm.logger import logger
 
@@ -104,18 +104,15 @@ class ADPRouter(ABC):
             kv_cache_manager has block reuse enabled; DefaultADPRouter
             otherwise.
         """
-        if attention_dp_config is not None and getattr(
-            attention_dp_config, "kv_cache_routing_conversation_affinity", False
-        ):
+        if (attention_dp_config is not None
+                and attention_dp_config.kv_cache_routing_conversation_affinity):
             # Explicit conversation_id -> rank affinity. Independent of the KV
             # cache manager (works with or without block reuse, though it is
             # most beneficial with reuse on), so it is checked before the
             # KV-cache-aware path and takes precedence when both are enabled.
             return ConversationAwareADPRouter(
                 dist=dist,
-                max_sessions=getattr(
-                    attention_dp_config, "kv_cache_routing_max_sessions", 1 << 16
-                ),
+                max_sessions=attention_dp_config.kv_cache_routing_max_sessions,
                 fair_share_multiplier=attention_dp_config.kv_cache_routing_fair_share_multiplier,
             )
 
@@ -171,6 +168,58 @@ class ADPRouter(ABC):
         local_state = self.create_rank_state(active_requests, new_requests or [])
         responses = self.dist.tp_allgather(local_state.serialize())
         return [RankState.deserialize(data=resp) for resp in responses]
+
+    @staticmethod
+    def _assign_explicit_dp_ranks(
+        requests: List["RequestQueueItem"],
+        all_ranks_new_requests: Dict[int, List["RequestQueueItem"]],
+        all_ranks_num_active_requests: List[int],
+        max_num_active_requests: int,
+    ) -> List["RequestQueueItem"]:
+        """Place requests carrying an explicit ``attention_dp_rank`` on that rank
+        (while it is under ``max_num_active_requests``) and return the rest for
+        load-balanced assignment. Mutates the ``all_ranks_*`` accumulators in
+        place. Shared by Default and ConversationAware routers.
+        """
+        remaining: List["RequestQueueItem"] = []
+        for req_item in requests:
+            scheduling_params = getattr(req_item.request, "py_scheduling_params", None)
+            target_dp_rank = (
+                scheduling_params.attention_dp_rank if scheduling_params is not None else None
+            )
+            if (
+                target_dp_rank is not None
+                and all_ranks_num_active_requests[target_dp_rank] < max_num_active_requests
+            ):
+                all_ranks_num_active_requests[target_dp_rank] += 1
+                all_ranks_new_requests[target_dp_rank].append(req_item)
+            else:
+                remaining.append(req_item)
+        return remaining
+
+    @staticmethod
+    def _expected_num_active_requests(
+        all_ranks_num_active_requests: List[int],
+        num_new_requests: int,
+        tp_size: int,
+        *,
+        multiplier: float = 1.0,
+        hard_cap: Optional[int] = None,
+    ) -> int:
+        """Loose per-rank target = ``multiplier * ceil(fair-share)``, floored at the
+        busiest rank's current load and optionally capped at ``hard_cap``
+        (``max_num_active_requests``). It is the soft cap that bounds per-rank
+        assignment so no rank exceeds the returned value -- the ADP padding
+        invariant asserted in py_executor._pad_attention_dp_dummy_request.
+        """
+        fair_share = (
+            sum(all_ranks_num_active_requests) + num_new_requests + tp_size - 1
+        ) // tp_size
+        expected = max(
+            math.ceil(multiplier * fair_share),
+            max(all_ranks_num_active_requests),
+        )
+        return min(expected, hard_cap) if hard_cap is not None else expected
 
     @abstractmethod
     def route_requests(
@@ -247,28 +296,17 @@ class DefaultADPRouter(ADPRouter):
 
         sorted_requests = sorted(new_requests, key=get_relax_value)
 
-        remaining_unscheduled = []
-        for req_item in sorted_requests:
-            scheduled = False
-            scheduling_params = getattr(req_item.request, "py_scheduling_params", None)
-            if scheduling_params is not None:
-                target_dp_rank = scheduling_params.attention_dp_rank
-                if (
-                    target_dp_rank is not None
-                    and all_ranks_num_active_requests[target_dp_rank] < max_num_active_requests
-                ):
-                    all_ranks_num_active_requests[target_dp_rank] += 1
-                    scheduled = True
-                    all_ranks_new_requests[target_dp_rank].append(req_item)
-
-            if not scheduled:
-                remaining_unscheduled.append(req_item)
+        remaining_unscheduled = self._assign_explicit_dp_ranks(
+            sorted_requests, all_ranks_new_requests,
+            all_ranks_num_active_requests, max_num_active_requests,
+        )
 
         num_new_requests_all_ranks = len(remaining_unscheduled)
-        total_num_active_requests = sum(all_ranks_num_active_requests)
-        expected_num_active_requests = max(
-            (total_num_active_requests + num_new_requests_all_ranks + tp_size - 1) // tp_size,
-            max(all_ranks_num_active_requests),
+        # Cap at max_num_active_requests so the per-rank target never
+        # exceeds what the rank can physically schedule.
+        expected_num_active_requests = self._expected_num_active_requests(
+            all_ranks_num_active_requests, num_new_requests_all_ranks, tp_size,
+            hard_cap=max_num_active_requests,
         )
 
         all_ranks_new_requests = self._balance_requests_across_ranks(
@@ -588,13 +626,9 @@ class KVCacheAwareADPRouter(ADPRouter):
         # net against runaway concentration, still loose enough that cache
         # affinity wins in the common case.
         num_new_requests_all_ranks = len(remaining_unscheduled)
-        total_num_active_requests = sum(all_ranks_num_active_requests)
-        fair_share = (
-            total_num_active_requests + num_new_requests_all_ranks + tp_size - 1
-        ) // tp_size
-        expected_num_active_requests = max(
-            math.ceil(self.fair_share_multiplier * fair_share),
-            max(all_ranks_num_active_requests),
+        expected_num_active_requests = self._expected_num_active_requests(
+            all_ranks_num_active_requests, num_new_requests_all_ranks, tp_size,
+            multiplier=self.fair_share_multiplier, hard_cap=max_num_active_requests,
         )
         eligible_ranks = [
             rank
@@ -671,38 +705,11 @@ class KVCacheAwareADPRouter(ADPRouter):
 
 
 class ConversationAwareADPRouter(ADPRouter):
-    """Conversation-affinity request router for attention data parallelism.
-
-    Routes the *first* request of each conversation round-robin across ranks,
-    then pins every later request carrying the same ``conversation_id`` to the
-    rank that served that conversation's first turn. This keeps a multi-turn
-    conversation's growing KV-cache prefix on a single rank (maximizing block
-    reuse, minimizing recompute and cross-rank migration) while still spreading
-    the birth of new conversations evenly.
-
-    Contrast with :class:`KVCacheAwareADPRouter`, which *infers* affinity from
-    probed prefix-match lengths: that affinity is lost as soon as a
-    conversation's blocks are evicted -- the request then re-routes by load and
-    the conversation "migrates" ranks. This router keeps an **explicit**
-    ``conversation_id -> rank`` map, so stickiness is deterministic and survives
-    cache eviction. It is inspired by the serve-level ConversationRouter
-    (``tensorrt_llm/serve/router.py``) and the first-turn-round-robin idea from
-    PR #14744, but applied at the intra-instance ADP-rank level.
-
-    ``conversation_id`` is read from
-    ``req.py_disaggregated_params.conversation_id`` (populated by the serve-side
-    conversation / KV-aware router from the ``X-Session-ID`` header; see
-    PR #14744). When it is absent -- header not sent, non-disaggregated, or the
-    serve-side propagation is not present -- the request falls back to
-    load-balanced round-robin and is *not* recorded, so behaviour degrades
-    gracefully to ``DefaultADPRouter``-style spreading.
-
-    Determinism: :meth:`route_requests` runs locally on every TP rank with no
-    broadcast, so the round-robin cursor and the conversation->rank map MUST
-    evolve identically on every rank. They do, because every rank processes the
-    same ``new_requests`` in the same order. Any divergence would deadlock the
-    distributed allgather protocol -- this is the same invariant the warmup /
-    first-turn-round-robin cursors rely on above.
+    """Pins each conversation to a single attention-DP rank: the first request
+    of a conversation is round-robined, and every later request with the same
+    ``conversation_id`` returns to that rank, keeping the conversation's
+    KV-cache prefix on one rank. Falls back to load-balanced round-robin when no
+    ``conversation_id`` is present.
     """
 
     # Default LRU cap on the conversation->rank map (entries are ~tens of
@@ -712,18 +719,11 @@ class ConversationAwareADPRouter(ADPRouter):
     def __init__(self, dist: "Distributed", max_sessions: int = DEFAULT_MAX_SESSIONS,
                  fair_share_multiplier: float = 2.0):
         super().__init__(dist)
-        # conversation_id -> rank, LRU-ordered (most-recently-routed last).
         self._conv_to_rank: "OrderedDict[str, int]" = OrderedDict()
+        # LRU cap on the conversation->rank map; oldest entries evicted beyond this.
         self._max_sessions = max(1, int(max_sessions))
-        # Loose per-rank cap = fair_share_multiplier * ceil fair-share. Sticky
-        # concentration is allowed up to this but NEVER beyond, so the returned
-        # expected_num_active_requests stays >= every rank's active count (the
-        # ADP invariant asserted in py_executor._pad_attention_dp_dummy_request).
         self._fair_share_multiplier = max(1.0, float(fair_share_multiplier))
-        # Round-robin cursor for first-turn / unkeyed requests. Mutated
-        # identically on every rank (route_requests is deterministic), exactly
-        # like KVCacheAwareADPRouter._first_turn_rr_counter; divergence deadlocks.
-        self._rr_counter = 0
+        self._round_robin_cursor = 0
 
     def create_rank_state(
         self,
@@ -742,23 +742,16 @@ class ConversationAwareADPRouter(ADPRouter):
 
     @staticmethod
     def _conversation_id(req_item) -> "str | None":
-        """Return the request's conversation id, or None when unavailable.
-
-        Read from ``py_disaggregated_params.conversation_id`` (serve-side
-        propagated from the X-Session-ID header). Empty strings are treated as
-        absent so they fall through to the load-balanced path.
-        """
-        req = getattr(req_item, "request", None)
+        req = req_item.request
         if req is None:
             return None
-        disagg = getattr(req, "py_disaggregated_params", None)
-        if disagg is None:
+        disagg_params = req.py_disaggregated_params
+        if disagg_params is None:
             return None
-        conv_id = getattr(disagg, "conversation_id", None)
-        return conv_id if conv_id else None
+        return disagg_params.conversation_id or None
 
-    def _record_home(self, conv_id: str, rank: int) -> None:
-        """Bind/refresh a conversation's home rank with LRU eviction."""
+    def _record_target_rank(self, conv_id: str, rank: int) -> None:
+        """Bind/refresh the rank a conversation is pinned to (LRU-touch + evict)."""
         self._conv_to_rank[conv_id] = rank
         self._conv_to_rank.move_to_end(conv_id)
         while len(self._conv_to_rank) > self._max_sessions:
@@ -784,38 +777,19 @@ class ConversationAwareADPRouter(ADPRouter):
 
         sorted_requests = sorted(new_requests, key=get_relax_value)
 
-        # 1) Honour an explicit attention_dp_rank first (strict placement),
-        #    matching DefaultADPRouter / KVCacheAwareADPRouter.
-        remaining_unscheduled: List[RequestQueueItem] = []
-        for req_item in sorted_requests:
-            scheduling_params = getattr(req_item.request, "py_scheduling_params", None)
-            target_dp_rank = (
-                scheduling_params.attention_dp_rank if scheduling_params is not None else None
-            )
-            if (
-                target_dp_rank is not None
-                and all_ranks_num_active_requests[target_dp_rank] < max_num_active_requests
-            ):
-                all_ranks_num_active_requests[target_dp_rank] += 1
-                all_ranks_new_requests[target_dp_rank].append(req_item)
-            else:
-                remaining_unscheduled.append(req_item)
+        # 1) Honour an explicit attention_dp_rank first (strict placement).
+        remaining_unscheduled = self._assign_explicit_dp_ranks(
+            sorted_requests, all_ranks_new_requests,
+            all_ranks_num_active_requests, max_num_active_requests,
+        )
 
-        # 2) Loose per-rank cap = fair_share_multiplier * ceil fair-share
-        #    (mirrors KVCacheAwareADPRouter). BOTH new-conversation spreading and
-        #    sticky returns are capped at this, so no rank ever exceeds the
-        #    returned expected_num_active_requests -- exceeding it breaks the ADP
-        #    padding invariant (py_executor._pad_attention_dp_dummy_request) and
-        #    crashes the executor. The multiplier gives sticky concentration
-        #    slack before a conversation overflows off its home rank.
-        num_new_requests_all_ranks = len(remaining_unscheduled)
-        total_num_active_requests = sum(all_ranks_num_active_requests)
-        fair_share = (
-            total_num_active_requests + num_new_requests_all_ranks + tp_size - 1
-        ) // tp_size
-        expected_num_active_requests = max(
-            math.ceil(self._fair_share_multiplier * fair_share),
-            max(all_ranks_num_active_requests),
+        # 2) Loose per-rank cap = fair_share_multiplier * ceil(fair-share). BOTH
+        #    new-conversation spreading and sticky returns are capped at this, so
+        #    no rank exceeds expected_num_active_requests -- exceeding it breaks
+        #    the ADP padding invariant (py_executor._pad_attention_dp_dummy_request).
+        expected_num_active_requests = self._expected_num_active_requests(
+            all_ranks_num_active_requests, len(remaining_unscheduled), tp_size,
+            multiplier=self._fair_share_multiplier,
         )
 
         def _least_loaded(soft_cap: int) -> int:
@@ -828,8 +802,8 @@ class ConversationAwareADPRouter(ADPRouter):
         def _next_rr(soft_cap: int) -> int:
             """Round-robin to the next rank under soft_cap; advance the cursor."""
             for _ in range(tp_size):
-                r = self._rr_counter % tp_size
-                self._rr_counter = (self._rr_counter + 1) % tp_size
+                r = self._round_robin_cursor % tp_size
+                self._round_robin_cursor = (self._round_robin_cursor + 1) % tp_size
                 if all_ranks_num_active_requests[r] < soft_cap:
                     return r
             return _least_loaded(soft_cap)
@@ -839,25 +813,25 @@ class ConversationAwareADPRouter(ADPRouter):
             rank = None
 
             if conv_id is not None and conv_id in self._conv_to_rank:
-                home = self._conv_to_rank[conv_id]
-                # Sticky: return the conversation to its home rank while that
+                target_rank = self._conv_to_rank[conv_id]
+                # Sticky: return the conversation to its target rank while that
                 # rank is under `expected` (the loose fair-share*multiplier cap).
                 # Capping here -- NOT at the hard max_num_active_requests -- is
                 # required: a rank exceeding `expected` breaks the ADP padding
                 # invariant and crashes the executor.
-                if all_ranks_num_active_requests[home] < expected_num_active_requests:
-                    rank = home
-                    self._record_home(conv_id, home)  # LRU touch
-                # else: home saturated this batch -> fall through to overflow
-                # WITHOUT rebinding, so the conversation returns home next batch.
+                if all_ranks_num_active_requests[target_rank] < expected_num_active_requests:
+                    rank = target_rank
+                    self._record_target_rank(conv_id, target_rank)  # LRU touch
+                # else: target saturated this batch -> fall through to overflow
+                # WITHOUT rebinding, so the conversation returns next batch.
 
             if rank is None:
                 # First turn of a new conversation, sticky-overflow, or no
                 # conversation_id -> round-robin spread under the soft cap.
                 rank = _next_rr(expected_num_active_requests)
                 if conv_id is not None and conv_id not in self._conv_to_rank:
-                    # Bind this new conversation's home to its first-turn rank.
-                    self._record_home(conv_id, rank)
+                    # Bind this new conversation to its first-turn rank.
+                    self._record_target_rank(conv_id, rank)
 
             all_ranks_new_requests[rank].append(req_item)
             all_ranks_num_active_requests[rank] += 1

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -742,13 +742,18 @@ class ConversationAwareADPRouter(ADPRouter):
 
     @staticmethod
     def _conversation_id(req_item) -> "str | None":
-        req = req_item.request
+        # NOTE: req_item.request may be a raw tensorrt_llm.bindings.executor.Request
+        # (e.g. warmup/dummy requests) that lacks the Python-side
+        # py_disaggregated_params attribute -- getattr (not direct access) so those
+        # fall through to the load-balanced path instead of raising AttributeError.
+        req = getattr(req_item, "request", None)
         if req is None:
             return None
-        disagg_params = req.py_disaggregated_params
-        if disagg_params is None:
+        disagg = getattr(req, "py_disaggregated_params", None)
+        if disagg is None:
             return None
-        return disagg_params.conversation_id or None
+        conv_id = getattr(disagg, "conversation_id", None)
+        return conv_id if conv_id else None
 
     def _record_target_rank(self, conv_id: str, rank: int) -> None:
         """Bind/refresh the rank a conversation is pinned to (LRU-touch + evict)."""

--- a/tensorrt_llm/disaggregated_params.py
+++ b/tensorrt_llm/disaggregated_params.py
@@ -51,6 +51,10 @@ class DisaggregatedParams:
     ctx_dp_rank: Optional[int] = None
     ctx_info_endpoint: Optional[str] = None
     schedule_style: Optional[DisaggScheduleStyle] = None
+    # Multi-turn conversation id (from session headers such as X-Session-ID),
+    # carried through so worker-side consumers (e.g. the ADP router) can see
+    # the same id the disagg orchestrator routed on.
+    conversation_id: Optional[str] = None
 
     # E-P Disaggregated Params
     multimodal_embedding_handles: Optional[List[Dict[str, Any]]] = (

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -778,6 +778,28 @@ class AttentionDpConfig(StrictBaseModel):
         "and causes empty fetch cycles. Default False preserves the prior "
         "behaviour (fetch blocks when truly idle). "
         "Only used when enable_kv_cache_aware_routing is True.")
+    kv_cache_routing_conversation_affinity: bool = Field(
+        default=False,
+        description=
+        "Enable explicit conversation-affinity routing for attention DP. When "
+        "True, the first request of each conversation is round-robined across "
+        "ranks and every subsequent request carrying the same conversation_id "
+        "(read from disaggregated_params, populated from the X-Session-ID "
+        "header) is pinned to that conversation's first-turn rank. This keeps a "
+        "multi-turn conversation's KV-cache prefix on one rank (maximizing "
+        "block reuse, minimizing cross-rank migration). Unlike "
+        "enable_kv_cache_aware_routing (affinity inferred from prefix-match "
+        "length, which is lost when blocks are evicted), the conversation->rank "
+        "map is explicit and survives eviction. Falls back to load-balanced "
+        "round-robin when no conversation_id is available. Takes precedence "
+        "over enable_kv_cache_aware_routing when both are set.")
+    kv_cache_routing_max_sessions: int = Field(
+        default=65536,
+        description=
+        "LRU cap on the conversation->rank map used by conversation-affinity "
+        "routing. The oldest conversations are evicted once more than this many "
+        "are tracked, bounding memory on long-running servers. Only used when "
+        "kv_cache_routing_conversation_affinity is True.")
 
     @model_validator(mode='after')
     def validate_attention_dp_config(self) -> 'AttentionDpConfig':

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -1243,6 +1243,7 @@ def to_disaggregated_params(
         ctx_dp_rank=tllm_disagg_params.ctx_dp_rank,
         ctx_info_endpoint=tllm_disagg_params.ctx_info_endpoint,
         schedule_style=tllm_disagg_params.schedule_style,
+        conversation_id=tllm_disagg_params.conversation_id,
     )
 
 
@@ -1265,6 +1266,7 @@ def to_llm_disaggregated_params(
         ctx_dp_rank=disaggregated_params.ctx_dp_rank,
         ctx_info_endpoint=disaggregated_params.ctx_info_endpoint,
         schedule_style=disaggregated_params.schedule_style,
+        conversation_id=disaggregated_params.conversation_id,
     )
 
 

--- a/tests/unittest/_torch/executor/test_adp_router.py
+++ b/tests/unittest/_torch/executor/test_adp_router.py
@@ -14,6 +14,7 @@ from tensorrt_llm._torch.pyexecutor.request_utils import get_from_waiting_queue
 from tensorrt_llm._torch.pyexecutor.scheduler import FCFSWaitingQueue
 from tensorrt_llm._torch.pyexecutor.scheduler.adp_router import (
     ADPRouter,
+    ConversationAwareADPRouter,
     DefaultADPRouter,
     KVCacheAwareADPRouter,
     RankState,
@@ -988,3 +989,177 @@ class TestKVCacheAwareADPRouterRouting:
         )
         assert len(result_strict[0]) == 2
         assert sum(len(result_strict[r]) for r in range(1, tp_size)) == 6
+
+
+def _make_conv_request_item(
+    req_id,
+    conversation_id,
+    target_dp_rank=None,
+    attention_dp_relax=True,
+    num_tokens=10,
+):
+    """Mock RequestQueueItem carrying a conversation_id on disaggregated_params."""
+    item = MagicMock()
+    item.id = req_id
+    item.child_req_ids = None
+    scheduling_params = MagicMock()
+    scheduling_params.attention_dp_rank = target_dp_rank
+    scheduling_params.attention_dp_relax = attention_dp_relax
+    item.request = MagicMock()
+    item.request.py_scheduling_params = scheduling_params
+    item.request.input_token_ids = list(range(num_tokens))
+    item.request.py_orig_prompt_len = num_tokens
+    if conversation_id is None:
+        item.request.py_disaggregated_params = None
+    else:
+        disagg = MagicMock()
+        disagg.conversation_id = conversation_id
+        item.request.py_disaggregated_params = disagg
+    return item
+
+
+class TestConversationAwareADPRouter:
+    """Routing behavior of ConversationAwareADPRouter (explicit conv->rank)."""
+
+    @staticmethod
+    def _router(tp_size=4, max_sessions=1 << 16):
+        return ConversationAwareADPRouter(
+            dist=_mock_dist(tp_size=tp_size), max_sessions=max_sessions
+        )
+
+    @staticmethod
+    def _states(tp_size, active=None):
+        active = active or [0] * tp_size
+        return [
+            RankState(rank=r, num_active_requests=active[r], num_active_tokens=active[r] * 10)
+            for r in range(tp_size)
+        ]
+
+    @staticmethod
+    def _route(router, states, items, cap=1000):
+        assign, _ = router.route_requests(states, items, max_num_active_requests=cap)
+        pos = {}
+        for rank, lst in assign.items():
+            for it in lst:
+                pos[it.id] = rank
+        return pos
+
+    def test_interface_compliance(self):
+        assert isinstance(self._router(), ADPRouter)
+
+    def test_first_turn_round_robin(self):
+        """First request of each conversation spreads one-per-rank (RR)."""
+        router = self._router(tp_size=4)
+        items = [_make_conv_request_item(i, f"conv{i}") for i in range(4)]
+        pos = self._route(router, self._states(4), items)
+        assert sorted(pos.values()) == [0, 1, 2, 3]
+
+    def test_subsequent_turns_are_sticky(self):
+        """Later turns of a conversation return to its first-turn rank."""
+        router = self._router(tp_size=4)
+        convs = ["A", "B", "C", "D"]
+        first = [_make_conv_request_item(i, convs[i]) for i in range(4)]
+        pos1 = self._route(router, self._states(4), first)
+        home = {convs[i]: pos1[i] for i in range(4)}
+        # A new batch of second turns (fresh ids) for the same conversations.
+        second = [_make_conv_request_item(100 + i, convs[i]) for i in range(4)]
+        pos2 = self._route(router, self._states(4), second)
+        for i in range(4):
+            assert pos2[100 + i] == home[convs[i]]
+
+    def test_no_conversation_id_falls_back_and_is_not_recorded(self):
+        router = self._router(tp_size=4)
+        items = [_make_conv_request_item(i, None) for i in range(8)]
+        pos = self._route(router, self._states(4), items)
+        assert len(pos) == 8
+        # Nothing recorded for conversation-less requests.
+        assert dict(router._conv_to_rank) == {}
+        # Round-robin spread keeps ranks within one of each other.
+        counts = [sum(1 for v in pos.values() if v == r) for r in range(4)]
+        assert max(counts) - min(counts) <= 1
+
+    def test_routing_is_deterministic_across_ranks(self):
+        """Two independent instances (= two TP ranks) must agree exactly, or
+        the no-broadcast allgather protocol would deadlock."""
+        convs = ["A", "B", "C", None, "A", "B", "E", None, "C"]
+
+        def run():
+            router = self._router(tp_size=4)
+            items = [_make_conv_request_item(i, convs[i]) for i in range(len(convs))]
+            return self._route(router, self._states(4), items)
+
+        assert run() == run()
+
+    def test_lru_eviction_bounds_map(self):
+        router = self._router(tp_size=2, max_sessions=2)
+        items = [_make_conv_request_item(i, f"c{i}") for i in range(5)]
+        self._route(router, self._states(2), items)
+        assert len(router._conv_to_rank) == 2
+        assert set(router._conv_to_rank) == {"c3", "c4"}
+
+    def test_explicit_target_dp_rank_respected(self):
+        router = self._router(tp_size=4)
+        item = _make_conv_request_item(
+            1, "A", target_dp_rank=2, attention_dp_relax=False
+        )
+        pos = self._route(router, self._states(4), [item])
+        assert pos[1] == 2
+
+    def test_sticky_overflow_keeps_mapping(self):
+        """When the home rank is at the hard cap, the turn overflows but the
+        conversation stays mapped home (returns next batch)."""
+        router = self._router(tp_size=2)
+        # Seed conv A -> rank 0.
+        self._route(router, self._states(2), [_make_conv_request_item(1, "A")])
+        home = router._conv_to_rank["A"]
+        # Saturate the home rank, route A again -> must overflow off home...
+        states = self._states(2)
+        states[home] = RankState(rank=home, num_active_requests=5, num_active_tokens=50)
+        pos = self._route(router, states, [_make_conv_request_item(2, "A")], cap=5)
+        assert pos[2] != home
+        # ...but the mapping is unchanged so it can return home later.
+        assert router._conv_to_rank["A"] == home
+
+    def test_create_rank_state(self):
+        router = ConversationAwareADPRouter(dist=_mock_dist(tp_rank=2))
+        req1 = Mock(py_orig_prompt_len=100)
+        req2 = Mock(py_orig_prompt_len=50)
+        state = router.create_rank_state(active_requests=[req1, req2], new_requests=[])
+        assert state.rank == 2
+        assert state.num_active_requests == 2
+        assert state.num_active_tokens == 150
+
+    def test_factory_selects_conversation_router(self):
+        cfg = MagicMock()
+        cfg.kv_cache_routing_conversation_affinity = True
+        cfg.kv_cache_routing_max_sessions = 8
+        router = ADPRouter.create(
+            dist=_mock_dist(), kv_cache_manager=None, attention_dp_config=cfg
+        )
+        assert isinstance(router, ConversationAwareADPRouter)
+        assert router._max_sessions == 8
+
+    def test_factory_default_when_disabled(self):
+        cfg = MagicMock()
+        cfg.kv_cache_routing_conversation_affinity = False
+        cfg.enable_kv_cache_aware_routing = False
+        router = ADPRouter.create(
+            dist=_mock_dist(), kv_cache_manager=None, attention_dp_config=cfg
+        )
+        assert isinstance(router, DefaultADPRouter)
+
+    def test_returned_expected_covers_every_rank(self):
+        """Regression: returned expected_num_active_requests must be >= every
+        rank's post-assignment active count, else
+        py_executor._pad_attention_dp_dummy_request asserts and the executor
+        hangs. A sticky storm (one conversation hammered) must not push its home
+        rank past expected."""
+        router = self._router(tp_size=8)
+        states = self._states(8)
+        # 40 requests for the SAME conversation: with the old hard-cap sticky
+        # logic this concentrated > expected on the home rank and crashed.
+        items = [_make_conv_request_item(i, "A") for i in range(40)]
+        assign, expected = router.route_requests(states, items, max_num_active_requests=256)
+        final = [states[r].num_active_requests + len(assign[r]) for r in range(8)]
+        assert all(expected >= f for f in final), (expected, final)
+        assert sum(len(v) for v in assign.values()) == 40  # nothing dropped

--- a/tests/unittest/_torch/executor/test_adp_router.py
+++ b/tests/unittest/_torch/executor/test_adp_router.py
@@ -1099,9 +1099,7 @@ class TestConversationAwareADPRouter:
 
     def test_explicit_target_dp_rank_respected(self):
         router = self._router(tp_size=4)
-        item = _make_conv_request_item(
-            1, "A", target_dp_rank=2, attention_dp_relax=False
-        )
+        item = _make_conv_request_item(1, "A", target_dp_rank=2, attention_dp_relax=False)
         pos = self._route(router, self._states(4), [item])
         assert pos[1] == 2
 
@@ -1136,9 +1134,7 @@ class TestConversationAwareADPRouter:
         cfg = MagicMock()
         cfg.kv_cache_routing_conversation_affinity = True
         cfg.kv_cache_routing_max_sessions = 8
-        router = ADPRouter.create(
-            dist=_mock_dist(), kv_cache_manager=None, attention_dp_config=cfg
-        )
+        router = ADPRouter.create(dist=_mock_dist(), kv_cache_manager=None, attention_dp_config=cfg)
         assert isinstance(router, ConversationAwareADPRouter)
         assert router._max_sessions == 8
 
@@ -1146,9 +1142,7 @@ class TestConversationAwareADPRouter:
         cfg = MagicMock()
         cfg.kv_cache_routing_conversation_affinity = False
         cfg.enable_kv_cache_aware_routing = False
-        router = ADPRouter.create(
-            dist=_mock_dist(), kv_cache_manager=None, attention_dp_config=cfg
-        )
+        router = ADPRouter.create(dist=_mock_dist(), kv_cache_manager=None, attention_dp_config=cfg)
         assert isinstance(router, DefaultADPRouter)
 
     def test_returned_expected_covers_every_rank(self):

--- a/tests/unittest/_torch/executor/test_adp_router.py
+++ b/tests/unittest/_torch/executor/test_adp_router.py
@@ -1106,18 +1106,16 @@ class TestConversationAwareADPRouter:
         assert pos[1] == 2
 
     def test_sticky_overflow_keeps_mapping(self):
-        """When the home rank is saturated (>= the soft fair-share cap), the turn
-        overflows off home but the conversation stays mapped home (returns next
-        batch). Uses fair_share_multiplier=1.0 so the soft cap coincides with the
-        natural saturation point and the overflow path is exercised (with the
-        default mult=2 a lone hot rank's `expected` scales with its own load and
-        never saturates)."""
-        router = ConversationAwareADPRouter(
-            dist=_mock_dist(tp_size=2), fair_share_multiplier=1.0)
+        """When the home rank is saturated at the HARD cap (max_num_active_requests),
+        the turn overflows off home but the conversation stays mapped home (so it
+        returns home next batch once that rank has capacity). Stickiness uses the
+        hard cap -- not the soft fair-share -- so a conversation's KV prefix stays
+        resident on one rank in the common case."""
+        router = ConversationAwareADPRouter(dist=_mock_dist(tp_size=2))
         # Seed conv A -> rank 0.
         self._route(router, self._states(2), [_make_conv_request_item(1, "A")])
         home = router._conv_to_rank["A"]
-        # Saturate the home rank, route A again -> must overflow off home...
+        # Fill the home rank to the hard cap, route A again -> must overflow off home...
         states = self._states(2)
         states[home] = RankState(rank=home, num_active_requests=5, num_active_tokens=50)
         pos = self._route(router, states, [_make_conv_request_item(2, "A")], cap=5)
@@ -1161,8 +1159,10 @@ class TestConversationAwareADPRouter:
         rank past expected."""
         router = self._router(tp_size=8)
         states = self._states(8)
-        # 40 requests for the SAME conversation: with the old hard-cap sticky
-        # logic this concentrated > expected on the home rank and crashed.
+        # 40 requests for the SAME conversation: hard-cap stickiness concentrates
+        # all of them on the home rank, pushing it well past the pre-loop soft
+        # `expected`. The post-loop re-bump must lift `expected` to cover the home
+        # rank's actual count, else _pad_attention_dp_dummy_request asserts.
         items = [_make_conv_request_item(i, "A") for i in range(40)]
         assign, expected = router.route_requests(states, items, max_num_active_requests=256)
         final = [states[r].num_active_requests + len(assign[r]) for r in range(8)]

--- a/tests/unittest/_torch/executor/test_adp_router.py
+++ b/tests/unittest/_torch/executor/test_adp_router.py
@@ -1106,9 +1106,14 @@ class TestConversationAwareADPRouter:
         assert pos[1] == 2
 
     def test_sticky_overflow_keeps_mapping(self):
-        """When the home rank is at the hard cap, the turn overflows but the
-        conversation stays mapped home (returns next batch)."""
-        router = self._router(tp_size=2)
+        """When the home rank is saturated (>= the soft fair-share cap), the turn
+        overflows off home but the conversation stays mapped home (returns next
+        batch). Uses fair_share_multiplier=1.0 so the soft cap coincides with the
+        natural saturation point and the overflow path is exercised (with the
+        default mult=2 a lone hot rank's `expected` scales with its own load and
+        never saturates)."""
+        router = ConversationAwareADPRouter(
+            dist=_mock_dist(tp_size=2), fair_share_multiplier=1.0)
         # Seed conv A -> rank 0.
         self._route(router, self._states(2), [_make_conv_request_item(1, "A")])
         home = router._conv_to_rank["A"]

--- a/tests/unittest/disaggregated/test_disaggregated_params.py
+++ b/tests/unittest/disaggregated/test_disaggregated_params.py
@@ -56,6 +56,7 @@ def test_to_disaggregated_params():
         first_gen_tokens=[1, 2],
         ctx_dp_rank=5,
         ctx_info_endpoint="tcp://10.0.0.1:5000",
+        conversation_id="conv-abc",
     )
     openai_params = to_disaggregated_params(llm_params)
 
@@ -63,6 +64,7 @@ def test_to_disaggregated_params():
     assert openai_params.first_gen_tokens == [1, 2]
     assert openai_params.ctx_dp_rank == 5
     assert openai_params.ctx_info_endpoint == "tcp://10.0.0.1:5000"
+    assert openai_params.conversation_id == "conv-abc"
 
 
 def test_to_llm_disaggregated_params():
@@ -73,12 +75,30 @@ def test_to_llm_disaggregated_params():
         request_type="generation_only",
         ctx_dp_rank=2,
         ctx_info_endpoint="tcp://10.0.0.1:5000",
+        conversation_id="conv-xyz",
     )
     llm_params = to_llm_disaggregated_params(openai_params)
 
     assert llm_params.request_type == "generation_only"
     assert llm_params.ctx_dp_rank == 2
     assert llm_params.ctx_info_endpoint == "tcp://10.0.0.1:5000"
+    assert llm_params.conversation_id == "conv-xyz"
+
+
+def test_disaggregated_params_conversation_id():
+    """conversation_id defaults to None and survives the serve<->llm round-trip."""
+    from tensorrt_llm.serve.openai_protocol import DisaggregatedParams as OpenAIDisaggregatedParams
+    from tensorrt_llm.serve.openai_protocol import (to_disaggregated_params,
+                                                    to_llm_disaggregated_params)
+
+    assert DisaggregatedParams().conversation_id is None
+
+    # serve -> llm -> serve preserves the conversation id end to end.
+    openai_params = OpenAIDisaggregatedParams(request_type="context_only",
+                                              conversation_id="conv-roundtrip")
+    llm_params = to_llm_disaggregated_params(openai_params)
+    assert llm_params.conversation_id == "conv-roundtrip"
+    assert to_disaggregated_params(llm_params).conversation_id == "conv-roundtrip"
 
 
 @patch("tensorrt_llm.disaggregated_params.tllme")

--- a/tests/unittest/disaggregated/test_disaggregated_params.py
+++ b/tests/unittest/disaggregated/test_disaggregated_params.py
@@ -88,14 +88,17 @@ def test_to_llm_disaggregated_params():
 def test_disaggregated_params_conversation_id():
     """conversation_id defaults to None and survives the serve<->llm round-trip."""
     from tensorrt_llm.serve.openai_protocol import DisaggregatedParams as OpenAIDisaggregatedParams
-    from tensorrt_llm.serve.openai_protocol import (to_disaggregated_params,
-                                                    to_llm_disaggregated_params)
+    from tensorrt_llm.serve.openai_protocol import (
+        to_disaggregated_params,
+        to_llm_disaggregated_params,
+    )
 
     assert DisaggregatedParams().conversation_id is None
 
     # serve -> llm -> serve preserves the conversation id end to end.
-    openai_params = OpenAIDisaggregatedParams(request_type="context_only",
-                                              conversation_id="conv-roundtrip")
+    openai_params = OpenAIDisaggregatedParams(
+        request_type="context_only", conversation_id="conv-roundtrip"
+    )
     llm_params = to_llm_disaggregated_params(openai_params)
     assert llm_params.conversation_id == "conv-roundtrip"
     assert to_disaggregated_params(llm_params).conversation_id == "conv-roundtrip"


### PR DESCRIPTION
## What

Adds `ConversationAwareADPRouter`, an instance-level attention-DP router that:
- round-robins the **first** request of each conversation across DP ranks, then
- pins every **subsequent** request carrying the same `conversation_id` to that conversation's first-turn rank.

This keeps a multi-turn conversation's growing KV-cache prefix on a single rank — maximizing block reuse and minimizing recompute / cross-rank migration — while spreading the birth of new conversations evenly.

## Why / vs `KVCacheAwareADPRouter`

`KVCacheAwareADPRouter` *infers* affinity from probed prefix-match length. That affinity is **lost the moment a conversation's blocks are evicted**: the request then re-routes by load and the conversation can migrate ranks. `ConversationAwareADPRouter` keeps an **explicit `conversation_id -> rank` LRU map**, so stickiness is deterministic and survives eviction. It also does not require KV-cache block reuse to function (though it is most beneficial with it).

Inspired by the serve-level `ConversationRouter` (`tensorrt_llm/serve/router.py`) and the first-turn-round-robin idea from #14744, applied at the intra-instance ADP-rank level.

## How it is wired

- Selected via `AttentionDpConfig.kv_cache_routing_conversation_affinity` (takes precedence over `enable_kv_cache_aware_routing` when both are set). `kv_cache_routing_max_sessions` bounds the LRU map.
- `conversation_id` is read from `req.py_disaggregated_params.conversation_id` (serve-side propagated from the `X-Session-ID` header). When absent — header not sent, non-disaggregated, or propagation not present — the request falls back to load-balanced round-robin and is **not** recorded, so behavior **degrades gracefully** to `DefaultADPRouter`-style spreading.
- Deterministic across TP ranks: `route_requests` runs locally on every rank with no broadcast, so the round-robin cursor and the `conversation -> rank` map evolve identically (same `new_requests`, same order) — the same invariant the existing warmup cursor relies on. Divergence would deadlock the allgather protocol.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversation-aware KV cache routing: Subsequent turns of the same conversation are now automatically pinned to the same execution location, improving performance and maintaining state consistency.
  * New configuration options to enable conversation-aware routing and customize maximum concurrent conversation limits.

* **Tests**
  * Added comprehensive test coverage for conversation-aware routing behavior and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->