### PR TITLE
[None][feat] Cache LTX2 merged LoRA weight

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
@@ -4,7 +4,6 @@
 
 import json
 import math
-import os
 import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Union
@@ -50,8 +49,6 @@ STAGE_2_DISTILLED_SIGMA_VALUES = [0.909375, 0.725, 0.421875, 0.0]
 _FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
 # Baseline BF16 peak memory ~75 GiB, saving BF16 weights snopshot total ~108 GiB.
 _BF16_WEIGHTS_SNAPSHOT_FREE_MEMORY_THRESHOLD_GIB = 115.0
-_LTX2_PERSISTENT_LORA_WEIGHTS_ENV = "TRTLLM_LTX2_PERSISTENT_LORA_WEIGHTS"
-_TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
 
 
 # ---------------------------------------------------------------------------
@@ -100,10 +97,6 @@ def _should_save_bf16_weights(
         f"{relation} {threshold_gib:.2f} GiB threshold"
     )
     return save_state
-
-
-def _persistent_lora_weights_enabled() -> bool:
-    return os.environ.get(_LTX2_PERSISTENT_LORA_WEIGHTS_ENV, "").strip().lower() in _TRUE_ENV_VALUES
 
 
 def _load_lora_deltas(
@@ -1010,26 +1003,25 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
             logger.info(
                 f"Distilled LoRA ready: {len(self._distilled_lora_deltas)} parameter deltas"
             )
-            if _persistent_lora_weights_enabled():
-                try:
-                    self._distilled_lora_weight_cache = _PersistentLoRAWeightCache.build(
-                        self.transformer,
-                        self._distilled_lora_deltas,
-                    )
-                except torch.cuda.OutOfMemoryError as exc:
-                    logger.warning(
-                        "Persistent LTX-2 LoRA weights disabled after CUDA OOM "
-                        f"during cache build: {exc}"
-                    )
-                    torch.cuda.empty_cache()
-                    self._distilled_lora_weight_cache = None
-                else:
-                    self._distilled_lora_weight_cache.bind_original()
-                    logger.info(
-                        "Persistent LTX-2 LoRA weights ready: "
-                        f"{self._distilled_lora_weight_cache.applied_count} params, "
-                        f"precision_counts={self._distilled_lora_weight_cache.precision_counts()}"
-                    )
+            try:
+                self._distilled_lora_weight_cache = _PersistentLoRAWeightCache.build(
+                    self.transformer,
+                    self._distilled_lora_deltas,
+                )
+            except torch.cuda.OutOfMemoryError as exc:
+                logger.warning(
+                    "Persistent LTX-2 LoRA weights disabled after CUDA OOM "
+                    f"during cache build: {exc}"
+                )
+                torch.cuda.empty_cache()
+                self._distilled_lora_weight_cache = None
+            else:
+                self._distilled_lora_weight_cache.bind_original()
+                logger.info(
+                    "Persistent LTX-2 LoRA weights ready: "
+                    f"{self._distilled_lora_weight_cache.applied_count} params, "
+                    f"precision_counts={self._distilled_lora_weight_cache.precision_counts()}"
+                )
 
     # ------------------------------------------------------------------
     # Inference entry point
@@ -1169,11 +1161,9 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
         # ================================================================
         # Stage 2: refinement denoising with distilled LoRA
         # ================================================================
-        # The default path merges LoRA per request and restores afterwards.
-        # When TRTLLM_LTX2_PERSISTENT_LORA_WEIGHTS is enabled, the resident
-        # cache already owns original and merged tensors. Stage 2 only rebinds
-        # pointers and FP4 quant_method state, so no per-request clone, merge, or
-        # unmerge math is needed.
+        # The persistent cache owns original and merged tensors when it can be
+        # built at load time. Stage 2 only rebinds pointers and FP4 quant_method
+        # state, so no per-request clone, merge, or unmerge math is needed.
         lora_cache = self._distilled_lora_weight_cache
         using_persistent_lora = lora_cache is not None
         saved_lora_state: Dict[str, Any] = {}

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
@@ -4,7 +4,9 @@
 
 import json
 import math
+import os
 import time
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Union
 
 import safetensors.torch
@@ -46,6 +48,8 @@ STAGE_2_DISTILLED_SIGMA_VALUES = [0.909375, 0.725, 0.421875, 0.0]
 _FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
 # Baseline BF16 peak memory ~75 GiB, saving BF16 weights snopshot total ~108 GiB.
 _BF16_WEIGHTS_SNAPSHOT_FREE_MEMORY_THRESHOLD_GIB = 115.0
+_LTX2_PERSISTENT_LORA_WEIGHTS_ENV = "TRTLLM_LTX2_PERSISTENT_LORA_WEIGHTS"
+_TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
 
 
 # ---------------------------------------------------------------------------
@@ -53,24 +57,35 @@ _BF16_WEIGHTS_SNAPSHOT_FREE_MEMORY_THRESHOLD_GIB = 115.0
 # ---------------------------------------------------------------------------
 
 
-def _get_free_gpu_memory_gib() -> Optional[float]:
-    """Return free memory on the current CUDA device, or ``None`` if unavailable."""
+def _get_free_gpu_memory_gib(
+    device: Optional[Union[torch.device, str, int]] = None,
+) -> Optional[float]:
+    """Return free memory on the requested CUDA device, or ``None`` if unavailable."""
     if not torch.cuda.is_available():
         return None
 
     try:
-        free_bytes, _ = torch.cuda.mem_get_info()
+        free_bytes, _ = torch.cuda.mem_get_info(device=device)
     except (RuntimeError, OSError) as exc:
-        logger.warning(f"Unable to query CUDA free memory for BF16 weight snapshots: {exc}")
+        logger.warning(
+            f"Unable to query CUDA free memory for BF16 weight snapshots on device {device}: {exc}"
+        )
         return None
 
     return free_bytes / (1024**3)
 
 
 def _should_save_bf16_weights(
+    device: Optional[Union[torch.device, str, int]] = None,
+    preload_free_gib: Optional[float] = None,
     threshold_gib: float = _BF16_WEIGHTS_SNAPSHOT_FREE_MEMORY_THRESHOLD_GIB,
 ) -> bool:
-    free_gib = _get_free_gpu_memory_gib()
+    free_gib = preload_free_gib
+    source = "pre-load"
+    if free_gib is None:
+        free_gib = _get_free_gpu_memory_gib(device=device)
+        source = "current"
+
     if free_gib is None:
         logger.debug("BF16 weight snapshots disabled: CUDA free memory is unavailable")
         return False
@@ -78,10 +93,15 @@ def _should_save_bf16_weights(
     save_state = free_gib > threshold_gib
     relation = ">" if save_state else "<="
     logger.debug(
-        f"BF16 weight snapshots {'enabled' if save_state else 'disabled'}: "
-        f"free GPU memory {free_gib:.2f} GiB {relation} {threshold_gib:.2f} GiB threshold"
+        f"BF16 weight snapshots {'enabled' if save_state else 'disabled'} "
+        f"on device {device}: {source} free GPU memory {free_gib:.2f} GiB "
+        f"{relation} {threshold_gib:.2f} GiB threshold"
     )
     return save_state
+
+
+def _persistent_lora_weights_enabled() -> bool:
+    return os.environ.get(_LTX2_PERSISTENT_LORA_WEIGHTS_ENV, "").strip().lower() in _TRUE_ENV_VALUES
 
 
 def _load_lora_deltas(
@@ -373,6 +393,10 @@ def _requantize_fp8_weight(
     return qw, scale
 
 
+def _scale_like(scale: torch.Tensor, reference: torch.Tensor) -> torch.Tensor:
+    return scale.to(device=reference.device, dtype=reference.dtype).reshape(reference.shape)
+
+
 def _apply_lora_deltas(
     module: torch.nn.Module,
     deltas: Dict[str, torch.Tensor],
@@ -408,6 +432,7 @@ def _apply_lora_deltas(
     applied = 0
     snapshot_required = 0
     saved_state: Dict[str, Any] = {}
+    applied_deltas: Dict[str, torch.Tensor] = {}
     # Build a lookup that maps *clean* parameter names to the actual
     # Parameter objects.  torch.compile wraps each block in an
     # OptimizedModule, inserting ``._orig_mod.`` into the parameter
@@ -425,110 +450,122 @@ def _apply_lora_deltas(
         clean = raw_name.replace("._orig_mod.", ".")
         module_dict[clean] = mod
 
-    for name, delta in deltas.items():
-        param_name = name if name in state else f"{name}.weight"
-        if param_name not in state:
-            continue
+    try:
+        for name, delta in deltas.items():
+            param_name = name if name in state else f"{name}.weight"
+            if param_name not in state:
+                continue
 
-        param = state[param_name]
-        base = param_name.rsplit(".weight", 1)[0]
+            param = state[param_name]
+            base = param_name.rsplit(".weight", 1)[0]
 
-        # --- same shape ---------------------------------------------------
-        if param.shape == delta.shape:
-            if param.dtype in _FP8_DTYPES:
-                # FP8: dequant → apply → requant
-                scale_key = f"{base}.weight_scale"
-                if scale_key not in state:
-                    raise RuntimeError(
-                        f"Cannot apply LoRA delta to FP8 param '{param_name}': missing {scale_key}."
+            # --- same shape ---------------------------------------------------
+            if param.shape == delta.shape:
+                if param.dtype in _FP8_DTYPES:
+                    # FP8: dequant -> apply -> requant
+                    scale_key = f"{base}.weight_scale"
+                    if scale_key not in state:
+                        raise RuntimeError(
+                            f"Cannot apply LoRA delta to FP8 param '{param_name}': missing {scale_key}."
+                        )
+                    ws_param = state[scale_key]
+                    out_f, in_f = delta.shape
+                    is_per_tensor = ws_param.data.numel() == 1
+                    is_packed = not is_per_tensor and _is_fp8_scale_packed(
+                        ws_param.data, out_f, in_f
                     )
+
+                    saved_state[param_name] = param.data.clone()
+                    saved_state[scale_key] = ws_param.data.clone()
+
+                    bf16 = _dequantize_fp8_weight(
+                        param.data,
+                        ws_param.data,
+                        packed=is_packed,
+                    )
+                    bf16.add_(delta.to(bf16.device, bf16.dtype), alpha=sign)
+
+                    qw, new_scale = _requantize_fp8_weight(
+                        bf16,
+                        repack=is_packed,
+                        per_tensor=is_per_tensor,
+                    )
+                    new_scale = _scale_like(new_scale, ws_param.data)
+                    param.data.copy_(qw)
+                    ws_param.data.copy_(new_scale)
+                    snapshot_required += 1
+                else:
+                    if save_bf16_weights and param.dtype == torch.bfloat16:
+                        saved_state[param_name] = param.data.clone()
+                        snapshot_required += 1
+                    # BF16: direct in-place addition, then restore by snapshot
+                    # copy when memory allows or by subtracting the delta.
+                    param.data.add_(
+                        delta.to(param.device, param.dtype),
+                        alpha=sign,
+                    )
+                applied_deltas[name] = delta
+                applied += 1
+
+            # --- packed FP4 (half last dim) -----------------------------------
+            elif (
+                param.ndim == 2
+                and delta.ndim == 2
+                and param.shape[0] == delta.shape[0]
+                and param.shape[1] * 2 == delta.shape[1]
+            ):
+                scale_key = f"{base}.weight_scale"
+                scale2_key = f"{base}.weight_scale_2"
+                if scale_key not in state or scale2_key not in state:
+                    raise RuntimeError(
+                        f"Cannot apply LoRA delta to quantized param "
+                        f"'{param_name}': missing {scale_key} or {scale2_key}."
+                    )
+
                 ws_param = state[scale_key]
-                out_f, in_f = delta.shape
-                is_per_tensor = ws_param.data.numel() == 1
-                is_packed = not is_per_tensor and _is_fp8_scale_packed(ws_param.data, out_f, in_f)
+                ws2_param = state[scale2_key]
+                out_features, in_features = delta.shape
 
                 saved_state[param_name] = param.data.clone()
                 saved_state[scale_key] = ws_param.data.clone()
+                saved_state[scale2_key] = ws2_param.data.clone()
 
-                bf16 = _dequantize_fp8_weight(
+                bf16 = _dequantize_fp4_weight(
                     param.data,
                     ws_param.data,
-                    packed=is_packed,
+                    ws2_param.data,
+                    out_features,
+                    in_features,
                 )
                 bf16.add_(delta.to(bf16.device, bf16.dtype), alpha=sign)
 
-                qw, new_scale = _requantize_fp8_weight(
-                    bf16,
-                    repack=is_packed,
-                    per_tensor=is_per_tensor,
-                )
-                param.data.copy_(qw)
-                ws_param.data.copy_(new_scale)
+                linear_mod = module_dict.get(base)
+                if linear_mod is None or not isinstance(linear_mod, Linear):
+                    raise RuntimeError(
+                        f"Packed FP4 LoRA merge: could not find Linear module at '{base}'."
+                    )
+
+                # Packed FP4: keep the LoRA-merged weight in BF16 for stage 2.
+                # This replaces packed FP4 storage (out, in//2) with BF16 storage
+                # (out, in) and swaps the parent Linear to plain F.linear.
+                param.data = bf16
+                saved_state[f"__quant_method__{base}"] = linear_mod.quant_method
+                linear_mod.quant_method = UnquantizedLinearMethod()
                 snapshot_required += 1
+                applied_deltas[name] = delta
+                applied += 1
             else:
-                if save_bf16_weights and param.dtype == torch.bfloat16:
-                    saved_state[param_name] = param.data.clone()
-                    snapshot_required += 1
-                # BF16: direct in-place addition, then restore by snapshot copy
-                # when memory allows. Other dense weights restore by subtraction.
-                param.data.add_(
-                    delta.to(param.device, param.dtype),
-                    alpha=sign,
+                logger.warning(
+                    f"Shape mismatch for LoRA param '{param_name}': "
+                    f"param={list(param.shape)}, delta={list(delta.shape)}. "
+                    f"Skipping."
                 )
-            applied += 1
-
-        # --- packed FP4 (half last dim) -----------------------------------
-        elif (
-            param.ndim == 2
-            and delta.ndim == 2
-            and param.shape[0] == delta.shape[0]
-            and param.shape[1] * 2 == delta.shape[1]
-        ):
-            scale_key = f"{base}.weight_scale"
-            scale2_key = f"{base}.weight_scale_2"
-            if scale_key not in state or scale2_key not in state:
-                raise RuntimeError(
-                    f"Cannot apply LoRA delta to quantized param "
-                    f"'{param_name}': missing {scale_key} or {scale2_key}."
-                )
-
-            ws_param = state[scale_key]
-            ws2_param = state[scale2_key]
-            out_features, in_features = delta.shape
-
-            saved_state[param_name] = param.data.clone()
-            saved_state[scale_key] = ws_param.data.clone()
-            saved_state[scale2_key] = ws2_param.data.clone()
-
-            bf16 = _dequantize_fp4_weight(
-                param.data,
-                ws_param.data,
-                ws2_param.data,
-                out_features,
-                in_features,
-            )
-            bf16.add_(delta.to(bf16.device, bf16.dtype), alpha=sign)
-
-            linear_mod = module_dict.get(base)
-            if linear_mod is None or not isinstance(linear_mod, Linear):
-                raise RuntimeError(
-                    f"Packed FP4 LoRA merge: could not find Linear module at '{base}'."
-                )
-
-            # Packed FP4: keep the LoRA-merged weight in BF16 for stage 2.
-            # This replaces packed FP4 storage (out, in//2) with BF16 storage
-            # (out, in) and swaps the parent Linear to plain F.linear.
-            param.data = bf16
-            saved_state[f"__quant_method__{base}"] = linear_mod.quant_method
-            linear_mod.quant_method = UnquantizedLinearMethod()
-            snapshot_required += 1
-            applied += 1
-        else:
-            logger.warning(
-                f"Shape mismatch for LoRA param '{param_name}': "
-                f"param={list(param.shape)}, delta={list(delta.shape)}. "
-                f"Skipping."
-            )
+    except Exception:
+        if saved_state:
+            _restore_lora_state(module, saved_state)
+        if applied_deltas:
+            _subtract_dense_lora_deltas(module, applied_deltas, saved_state)
+        raise
     return applied, saved_state, snapshot_required
 
 
@@ -620,6 +657,221 @@ def _restore_lora_state(
                 param.data = data
 
 
+@dataclass
+class _PersistentLoRAParamState:
+    param_name: str
+    precision: str
+    weight_param: torch.nn.Parameter
+    original_weight: torch.Tensor
+    merged_weight: torch.Tensor
+    scale_params: Dict[str, torch.nn.Parameter] = field(default_factory=dict)
+    original_scales: Dict[str, torch.Tensor] = field(default_factory=dict)
+    merged_scales: Dict[str, torch.Tensor] = field(default_factory=dict)
+    linear_module: Optional[Linear] = None
+    original_quant_method: Optional[Any] = None
+    merged_quant_method: Optional[Any] = None
+
+
+class _PersistentLoRAWeightCache:
+    """Keep unmerged and merged LoRA-touched weights resident.
+
+    The cache is opt-in and is used only for LTX-2 Stage 2 distilled LoRA.
+    It removes per-request merge/unmerge math by rebinding parameter storage to
+    precomputed resident tensors.  FP8 and FP4 keep exact original quantized
+    state.  FP4's merged state is BF16 and swaps the parent Linear to
+    UnquantizedLinearMethod, matching the existing per-request Stage 2 path.
+    """
+
+    def __init__(
+        self,
+        entries: List[_PersistentLoRAParamState],
+    ) -> None:
+        self._entries = entries
+        self._bound_state = "original"
+        self.applied_count = len(entries)
+
+    @staticmethod
+    def _module_state(
+        module: torch.nn.Module,
+    ) -> tuple[Dict[str, torch.nn.Parameter], Dict[str, torch.nn.Module]]:
+        state: Dict[str, torch.nn.Parameter] = {}
+        for raw_name, param in module.named_parameters():
+            clean = raw_name.replace("._orig_mod.", ".")
+            state[clean] = param
+
+        module_dict: Dict[str, torch.nn.Module] = {}
+        for raw_name, mod in module.named_modules():
+            clean = raw_name.replace("._orig_mod.", ".")
+            module_dict[clean] = mod
+
+        return state, module_dict
+
+    @classmethod
+    def build(
+        cls,
+        module: torch.nn.Module,
+        deltas: Dict[str, torch.Tensor],
+    ) -> "_PersistentLoRAWeightCache":
+        state, module_dict = cls._module_state(module)
+        entries: List[_PersistentLoRAParamState] = []
+
+        for name, delta in deltas.items():
+            param_name = name if name in state else f"{name}.weight"
+            if param_name not in state:
+                continue
+
+            param = state[param_name]
+            base = param_name.rsplit(".weight", 1)[0]
+
+            if param.shape == delta.shape:
+                if param.dtype in _FP8_DTYPES:
+                    scale_key = f"{base}.weight_scale"
+                    if scale_key not in state:
+                        raise RuntimeError(
+                            f"Cannot build persistent LoRA state for FP8 param "
+                            f"'{param_name}': missing {scale_key}."
+                        )
+
+                    ws_param = state[scale_key]
+                    out_f, in_f = delta.shape
+                    is_per_tensor = ws_param.data.numel() == 1
+                    is_packed = not is_per_tensor and _is_fp8_scale_packed(
+                        ws_param.data, out_f, in_f
+                    )
+
+                    bf16 = _dequantize_fp8_weight(
+                        param.data,
+                        ws_param.data,
+                        packed=is_packed,
+                    )
+                    bf16.add_(delta.to(bf16.device, bf16.dtype))
+                    qw, new_scale = _requantize_fp8_weight(
+                        bf16,
+                        repack=is_packed,
+                        per_tensor=is_per_tensor,
+                    )
+                    new_scale = _scale_like(new_scale, ws_param.data)
+
+                    entries.append(
+                        _PersistentLoRAParamState(
+                            param_name=param_name,
+                            precision="fp8",
+                            weight_param=param,
+                            original_weight=param.data,
+                            merged_weight=qw,
+                            scale_params={scale_key: ws_param},
+                            original_scales={scale_key: ws_param.data},
+                            merged_scales={scale_key: new_scale},
+                        )
+                    )
+                else:
+                    merged = param.data.clone()
+                    merged.add_(delta.to(merged.device, merged.dtype))
+                    precision = "bf16" if param.dtype == torch.bfloat16 else str(param.dtype)
+                    entries.append(
+                        _PersistentLoRAParamState(
+                            param_name=param_name,
+                            precision=precision,
+                            weight_param=param,
+                            original_weight=param.data,
+                            merged_weight=merged,
+                        )
+                    )
+                continue
+
+            if (
+                param.ndim == 2
+                and delta.ndim == 2
+                and param.shape[0] == delta.shape[0]
+                and param.shape[1] * 2 == delta.shape[1]
+            ):
+                scale_key = f"{base}.weight_scale"
+                scale2_key = f"{base}.weight_scale_2"
+                if scale_key not in state or scale2_key not in state:
+                    raise RuntimeError(
+                        f"Cannot build persistent LoRA state for packed FP4 param "
+                        f"'{param_name}': missing {scale_key} or {scale2_key}."
+                    )
+
+                ws_param = state[scale_key]
+                ws2_param = state[scale2_key]
+                out_features, in_features = delta.shape
+
+                bf16 = _dequantize_fp4_weight(
+                    param.data,
+                    ws_param.data,
+                    ws2_param.data,
+                    out_features,
+                    in_features,
+                )
+                bf16.add_(delta.to(bf16.device, bf16.dtype))
+
+                linear_mod = module_dict.get(base)
+                if linear_mod is None or not isinstance(linear_mod, Linear):
+                    raise RuntimeError(
+                        f"Packed FP4 persistent LoRA state: could not find "
+                        f"Linear module at '{base}'."
+                    )
+
+                entries.append(
+                    _PersistentLoRAParamState(
+                        param_name=param_name,
+                        precision="fp4",
+                        weight_param=param,
+                        original_weight=param.data,
+                        merged_weight=bf16,
+                        scale_params={
+                            scale_key: ws_param,
+                            scale2_key: ws2_param,
+                        },
+                        original_scales={
+                            scale_key: ws_param.data,
+                            scale2_key: ws2_param.data,
+                        },
+                        merged_scales={
+                            scale_key: ws_param.data,
+                            scale2_key: ws2_param.data,
+                        },
+                        linear_module=linear_mod,
+                        original_quant_method=linear_mod.quant_method,
+                        merged_quant_method=UnquantizedLinearMethod(),
+                    )
+                )
+                continue
+
+            logger.warning(
+                f"Shape mismatch for persistent LoRA param '{param_name}': "
+                f"param={list(param.shape)}, delta={list(delta.shape)}. "
+                f"Skipping."
+            )
+
+        return cls(entries)
+
+    def bind_original(self) -> None:
+        for entry in self._entries:
+            entry.weight_param.data = entry.original_weight
+            for scale_name, scale_param in entry.scale_params.items():
+                scale_param.data = entry.original_scales[scale_name]
+            if entry.linear_module is not None:
+                entry.linear_module.quant_method = entry.original_quant_method
+        self._bound_state = "original"
+
+    def bind_merged(self) -> None:
+        for entry in self._entries:
+            entry.weight_param.data = entry.merged_weight
+            for scale_name, scale_param in entry.scale_params.items():
+                scale_param.data = entry.merged_scales[scale_name]
+            if entry.linear_module is not None:
+                entry.linear_module.quant_method = entry.merged_quant_method
+        self._bound_state = "merged"
+
+    def precision_counts(self) -> Dict[str, int]:
+        counts: Dict[str, int] = {}
+        for entry in self._entries:
+            counts[entry.precision] = counts.get(entry.precision, 0) + 1
+        return counts
+
+
 # ---------------------------------------------------------------------------
 # Pipeline
 # ---------------------------------------------------------------------------
@@ -655,6 +907,9 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
         skip_components: Optional[list] = None,
         **kwargs,
     ) -> None:
+        # The BF16 snapshot threshold is a whole-pipeline capacity gate, so
+        # record it before loading model/runtime components that consume HBM.
+        self._bf16_snapshot_preload_free_gib = _get_free_gpu_memory_gib(device=device)
         super().load_standard_components(
             checkpoint_dir,
             device,
@@ -704,6 +959,7 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
 
         # --- Distilled LoRA (pre-compute deltas) ---
         self._distilled_lora_deltas: Dict[str, torch.Tensor] = {}
+        self._distilled_lora_weight_cache: Optional[_PersistentLoRAWeightCache] = None
         if distilled_lora_path:
             logger.info(f"Loading distilled LoRA from {distilled_lora_path}...")
             self._distilled_lora_deltas = _load_lora_deltas(
@@ -714,6 +970,26 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
             logger.info(
                 f"Distilled LoRA ready: {len(self._distilled_lora_deltas)} parameter deltas"
             )
+            if _persistent_lora_weights_enabled():
+                try:
+                    self._distilled_lora_weight_cache = _PersistentLoRAWeightCache.build(
+                        self.transformer,
+                        self._distilled_lora_deltas,
+                    )
+                except torch.cuda.OutOfMemoryError as exc:
+                    logger.warning(
+                        "Persistent LTX-2 LoRA weights disabled after CUDA OOM "
+                        f"during cache build: {exc}"
+                    )
+                    torch.cuda.empty_cache()
+                    self._distilled_lora_weight_cache = None
+                else:
+                    self._distilled_lora_weight_cache.bind_original()
+                    logger.info(
+                        "Persistent LTX-2 LoRA weights ready: "
+                        f"{self._distilled_lora_weight_cache.applied_count} params, "
+                        f"precision_counts={self._distilled_lora_weight_cache.precision_counts()}"
+                    )
 
     # ------------------------------------------------------------------
     # Inference entry point
@@ -852,26 +1128,40 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
         # ================================================================
         # Stage 2: refinement denoising with distilled LoRA
         # ================================================================
-        # For FP4 models (static-packed or dynamic), stage 2 always runs in
-        # BF16: the quant_method is swapped to UnquantizedLinearMethod inside
-        # _apply_lora_deltas and restored afterwards. FP8 handling is also
-        # unchanged and always restores from saved quantized state. BF16 weights
-        # save snapshots only when enough free GPU memory is available;
-        # otherwise they fall back to on-the-fly LoRA subtraction.
-        save_bf16_weights = _should_save_bf16_weights()
-        n, saved_lora_state, snapshot_required = _apply_lora_deltas(
-            self.transformer,
-            self._distilled_lora_deltas,
-            sign=1.0,
-            save_bf16_weights=save_bf16_weights,
-        )
-        logger.info(f"Merged distilled LoRA ({n} params) for stage 2 (BF16 weights)")
-
-        # Disable Ulysses for Stage 2: only rank 0 is active, so
-        # cross-rank collectives in the attention backend would hang.
-        self.transformer.set_ulysses_enabled(False)
+        # The default path merges LoRA per request and restores afterwards.
+        # When TRTLLM_LTX2_PERSISTENT_LORA_WEIGHTS is enabled, the resident
+        # cache already owns original and merged tensors. Stage 2 only rebinds
+        # pointers and FP4 quant_method state, so no per-request clone, merge, or
+        # unmerge math is needed.
+        lora_cache = self._distilled_lora_weight_cache
+        using_persistent_lora = lora_cache is not None
+        saved_lora_state: Dict[str, Any] = {}
+        snapshot_required = 0
+        n = 0
         stage2_start = time.time()
         try:
+            if using_persistent_lora:
+                lora_cache.bind_merged()
+                n = lora_cache.applied_count
+                logger.info(f"Bound persistent distilled LoRA ({n} params) for stage 2")
+            else:
+                transformer_device = next(self.transformer.parameters()).device
+                preload_free_gib = getattr(self, "_bf16_snapshot_preload_free_gib", None)
+                save_bf16_weights = _should_save_bf16_weights(
+                    device=transformer_device,
+                    preload_free_gib=preload_free_gib,
+                )
+                n, saved_lora_state, snapshot_required = _apply_lora_deltas(
+                    self.transformer,
+                    self._distilled_lora_deltas,
+                    sign=1.0,
+                    save_bf16_weights=save_bf16_weights,
+                )
+                logger.info(f"Merged distilled LoRA ({n} params) for stage 2 (BF16 weights)")
+
+            # Disable Ulysses for Stage 2: only rank 0 is active, so
+            # cross-rank collectives in the attention backend would hang.
+            self.transformer.set_ulysses_enabled(False)
             video_latents, audio_latents = self._refinement_denoise(
                 video_latents=video_latents,
                 audio_latents=audio_latents,
@@ -889,31 +1179,35 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
             stage2_denoise_time = time.time() - stage2_start
             logger.info(f"Stage 2 denoising time: {stage2_denoise_time:.2f}s (BF16 weights)")
             self.transformer.set_ulysses_enabled(True)
-            if snapshot_required and not saved_lora_state:
-                raise RuntimeError(
-                    "LoRA state was not saved; cannot safely restore stage 2 weights."
-                )
+            if using_persistent_lora:
+                lora_cache.bind_original()
+                logger.info("Re-bound persistent distilled LoRA original weights after stage 2")
+            else:
+                if snapshot_required and not saved_lora_state:
+                    raise RuntimeError(
+                        "LoRA state was not saved; cannot safely restore stage 2 weights."
+                    )
 
-            snapshot_restored = 0
-            if snapshot_required:
-                # Restore every LoRA-touched parameter from its snapshot. Packed
-                # FP4 also restores the original quant_method.
-                _restore_lora_state(self.transformer, saved_lora_state)
-                snapshot_restored = _count_saved_lora_weight_tensors(saved_lora_state)
+                snapshot_restored = 0
+                if snapshot_required:
+                    # Restore every LoRA-touched parameter from its snapshot. Packed
+                    # FP4 also restores the original quant_method.
+                    _restore_lora_state(self.transformer, saved_lora_state)
+                    snapshot_restored = _count_saved_lora_weight_tensors(saved_lora_state)
 
-            # BF16 weights that were not snapshotted, plus any other dense
-            # floating-point weights, are restored by subtracting LoRA deltas.
-            dense_restored = _subtract_dense_lora_deltas(
-                self.transformer,
-                self._distilled_lora_deltas,
-                saved_lora_state,
-            )
-            restored = snapshot_restored + dense_restored
-            if restored != n:
-                raise RuntimeError(
-                    f"Restored {restored} LoRA-touched weights after stage 2, but {n} were applied."
+                # BF16 weights that were not snapshotted are restored by
+                # subtracting LoRA deltas. FP8 and FP4 are exact snapshot restores.
+                dense_restored = _subtract_dense_lora_deltas(
+                    self.transformer,
+                    self._distilled_lora_deltas,
+                    saved_lora_state,
                 )
-            logger.info("Un-merged distilled LoRA after stage 2")
+                restored = snapshot_restored + dense_restored
+                if restored != n:
+                    raise RuntimeError(
+                        f"Restored {restored} LoRA-touched weights after stage 2, but {n} were applied."
+                    )
+                logger.info("Un-merged distilled LoRA after stage 2")
 
         # ================================================================
         # Decode

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
@@ -47,7 +47,7 @@ from .pipeline_ltx2 import (
 
 STAGE_2_DISTILLED_SIGMA_VALUES = [0.909375, 0.725, 0.421875, 0.0]
 _FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
-# Baseline BF16 peak memory ~75 GiB, saving BF16 weights snopshot total ~108 GiB.
+# Baseline BF16 peak memory ~75 GiB, saving BF16 weights snapshot total ~108 GiB.
 _BF16_WEIGHTS_SNAPSHOT_FREE_MEMORY_THRESHOLD_GIB = 115.0
 
 
@@ -670,7 +670,8 @@ class _PersistentLoRAParamState:
 class _PersistentLoRAWeightCache:
     """Keep unmerged and merged LoRA-touched weights resident.
 
-    The cache is opt-in and is used only for LTX-2 Stage 2 distilled LoRA.
+    The cache is built when distilled LoRA is loaded and used only for LTX-2
+    Stage 2 distilled LoRA.
     It removes per-request merge/unmerge math by rebinding parameter storage to
     precomputed resident tensors.  FP8 and FP4 keep exact original quantized
     state.  FP4's merged state is BF16 and swaps the parent Linear to
@@ -912,6 +913,29 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
     def _current_lora_cuda_graph_state(self) -> str:
         return getattr(self, "_lora_cuda_graph_state", "original")
 
+    def _is_cuda_graph_enabled(self) -> bool:
+        for config_name in ("pipeline_config", "model_config"):
+            config = getattr(self, config_name, None)
+            cuda_graph = getattr(config, "cuda_graph", None)
+            if getattr(cuda_graph, "enable", False):
+                return True
+        return False
+
+    def _assert_cuda_graph_safe_lora_bindings(self) -> None:
+        if not self._is_cuda_graph_enabled():
+            return
+        if not getattr(self, "_distilled_lora_deltas", {}):
+            return
+        if getattr(self, "_distilled_lora_weight_cache", None) is not None:
+            return
+
+        raise RuntimeError(
+            "LTX-2 two-stage CUDA graph requires persistent LoRA weights. "
+            "The non-persistent distilled LoRA path mutates parameter storage "
+            "and quantization state during Stage 2, which is not CUDA-graph safe. "
+            "Disable CUDA graph or ensure the persistent LoRA cache can be built."
+        )
+
     def _setup_cuda_graphs(self):
         """Wrap transformer.forward with a LoRA-state-aware CUDA graph key."""
         if not self.pipeline_config.cuda_graph.enable:
@@ -1022,6 +1046,7 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
                     f"{self._distilled_lora_weight_cache.applied_count} params, "
                     f"precision_counts={self._distilled_lora_weight_cache.precision_counts()}"
                 )
+        self._assert_cuda_graph_safe_lora_bindings()
 
     # ------------------------------------------------------------------
     # Inference entry point
@@ -1164,6 +1189,7 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
         # The persistent cache owns original and merged tensors when it can be
         # built at load time. Stage 2 only rebinds pointers and FP4 quant_method
         # state, so no per-request clone, merge, or unmerge math is needed.
+        self._assert_cuda_graph_safe_lora_bindings()
         lora_cache = self._distilled_lora_weight_cache
         using_persistent_lora = lora_cache is not None
         saved_lora_state: Dict[str, Any] = {}

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
@@ -914,14 +914,14 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
 
     def _setup_cuda_graphs(self):
         """Wrap transformer.forward with a LoRA-state-aware CUDA graph key."""
-        if not self.model_config.cuda_graph.enable:
+        if not self.pipeline_config.cuda_graph.enable:
             return
 
         runner = _LTX2TwoStageCUDAGraphRunner(
             CUDAGraphRunnerConfig(use_cuda_graph=True),
             self._current_lora_cuda_graph_state,
         )
-        compile_note = " (with torch.compile)" if self.model_config.torch_compile.enable else ""
+        compile_note = " (with torch.compile)" if self.pipeline_config.torch_compile.enable else ""
         logger.info(
             "CUDA graph runner: wrapping LTX-2 two-stage transformer.forward "
             f"with LoRA state key{compile_note}"

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
@@ -7,12 +7,13 @@ import math
 import os
 import time
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import safetensors.torch
 import torch
 
 from tensorrt_llm._torch.modules.linear import Linear, UnquantizedLinearMethod
+from tensorrt_llm._torch.visual_gen.cuda_graph_runner import CUDAGraphRunnerConfig
 from tensorrt_llm._torch.visual_gen.output import CudaPhaseTimer, PipelineOutput
 from tensorrt_llm._torch.visual_gen.pipeline_registry import register_pipeline
 from tensorrt_llm._torch.visual_gen.quantization.ops import quantize_fp8_blockwise, quantize_nvfp4
@@ -39,6 +40,7 @@ from .ltx2_core.upsampler import LatentUpsamplerConfigurator, upsample_video
 from .ltx2_core.video_vae import TilingConfig
 from .pipeline_ltx2 import (
     LTX2Pipeline,
+    _LTX2CUDAGraphRunner,
     _assert_resolution,
     _find_safetensors_files,
     _prefetch_ltx2_safetensors_files,
@@ -872,6 +874,24 @@ class _PersistentLoRAWeightCache:
         return counts
 
 
+class _LTX2TwoStageCUDAGraphRunner(_LTX2CUDAGraphRunner):
+    """CUDA graph runner keyed by LTX-2 two-stage LoRA weight state."""
+
+    def __init__(
+        self,
+        config: CUDAGraphRunnerConfig,
+        lora_state_getter: Callable[[], str],
+    ) -> None:
+        super().__init__(config)
+        self._lora_state_getter = lora_state_getter
+
+    def get_graph_key(self, *args, **kwargs):
+        return (
+            *super().get_graph_key(*args, **kwargs),
+            ("ltx2_two_stage_lora_state", self._lora_state_getter()),
+        )
+
+
 # ---------------------------------------------------------------------------
 # Pipeline
 # ---------------------------------------------------------------------------
@@ -895,6 +915,26 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
     @property
     def common_warmup_shapes(self) -> list:
         return [(512, 768, 121)]
+
+    def _current_lora_cuda_graph_state(self) -> str:
+        return getattr(self, "_lora_cuda_graph_state", "original")
+
+    def _setup_cuda_graphs(self):
+        """Wrap transformer.forward with a LoRA-state-aware CUDA graph key."""
+        if not self.model_config.cuda_graph.enable:
+            return
+
+        runner = _LTX2TwoStageCUDAGraphRunner(
+            CUDAGraphRunnerConfig(use_cuda_graph=True),
+            self._current_lora_cuda_graph_state,
+        )
+        compile_note = " (with torch.compile)" if self.model_config.torch_compile.enable else ""
+        logger.info(
+            "CUDA graph runner: wrapping LTX-2 two-stage transformer.forward "
+            f"with LoRA state key{compile_note}"
+        )
+        self.transformer.forward = runner.wrap(self.transformer.forward)
+        self._cuda_graph_runners["transformer"] = runner
 
     # ------------------------------------------------------------------
     # Component loading
@@ -1057,6 +1097,7 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
                  → decode.
         """
         # Optional prompt enhancement (applied once and reused for both stages).
+        self._lora_cuda_graph_state = "original"
         if enhance_prompt:
             logger.info("Enhancing prompt with Gemma3 (two-stage)...")
             prompt_text = prompt if isinstance(prompt, str) else prompt[0]
@@ -1138,10 +1179,12 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
         saved_lora_state: Dict[str, Any] = {}
         snapshot_required = 0
         n = 0
+        dense_lora_merge_completed = False
         stage2_start = time.time()
         try:
             if using_persistent_lora:
                 lora_cache.bind_merged()
+                self._lora_cuda_graph_state = "merged"
                 n = lora_cache.applied_count
                 logger.info(f"Bound persistent distilled LoRA ({n} params) for stage 2")
             else:
@@ -1157,6 +1200,8 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
                     sign=1.0,
                     save_bf16_weights=save_bf16_weights,
                 )
+                dense_lora_merge_completed = True
+                self._lora_cuda_graph_state = "merged"
                 logger.info(f"Merged distilled LoRA ({n} params) for stage 2 (BF16 weights)")
 
             # Disable Ulysses for Stage 2: only rank 0 is active, so
@@ -1181,8 +1226,9 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
             self.transformer.set_ulysses_enabled(True)
             if using_persistent_lora:
                 lora_cache.bind_original()
+                self._lora_cuda_graph_state = "original"
                 logger.info("Re-bound persistent distilled LoRA original weights after stage 2")
-            else:
+            elif dense_lora_merge_completed:
                 if snapshot_required and not saved_lora_state:
                     raise RuntimeError(
                         "LoRA state was not saved; cannot safely restore stage 2 weights."
@@ -1207,7 +1253,10 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
                     raise RuntimeError(
                         f"Restored {restored} LoRA-touched weights after stage 2, but {n} were applied."
                     )
+                self._lora_cuda_graph_state = "original"
                 logger.info("Un-merged distilled LoRA after stage 2")
+            else:
+                self._lora_cuda_graph_state = "original"
 
         # ================================================================
         # Decode

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
@@ -40,9 +40,9 @@ from .ltx2_core.upsampler import LatentUpsamplerConfigurator, upsample_video
 from .ltx2_core.video_vae import TilingConfig
 from .pipeline_ltx2 import (
     LTX2Pipeline,
-    _LTX2CUDAGraphRunner,
     _assert_resolution,
     _find_safetensors_files,
+    _LTX2CUDAGraphRunner,
     _prefetch_ltx2_safetensors_files,
 )
 

--- a/tests/integration/defs/examples/visual_gen/test_visual_gen.py
+++ b/tests/integration/defs/examples/visual_gen/test_visual_gen.py
@@ -66,6 +66,7 @@ FLUX_LPIPS_THRESHOLD = 0.05
 LTX2_LPIPS_NUM_FRAMES = 49
 LTX2_LPIPS_NUM_INFERENCE_STEPS = 8
 LTX2_LPIPS_THRESHOLD = 0.05
+LTX2_CUDA_GRAPH_LPIPS_THRESHOLD = 0.01
 
 WAN21_LPIPS_PROMPT = "A cat sitting on a windowsill"
 WAN21_LPIPS_NEGATIVE_PROMPT = None
@@ -511,9 +512,9 @@ def _generate_flux_lpips_image(model_path, output_path):
     save_image(generated_image, output_path)
 
 
-def _generate_ltx2_lpips_video(output_path):
+def _generate_ltx2_lpips_video(output_path, *, enable_cuda_graph=False):
     from tensorrt_llm._torch.visual_gen.pipeline_loader import PipelineLoader
-    from tensorrt_llm.visual_gen.args import VisualGenArgs
+    from tensorrt_llm.visual_gen.args import CudaGraphConfig, TorchCompileConfig, VisualGenArgs
 
     checkpoint_path = _lpips_model_path("LTX-2", "ltx-2-19b-dev.safetensors")
     text_encoder_path = _ltx2_lpips_text_encoder_path()
@@ -533,6 +534,8 @@ def _generate_ltx2_lpips_video(output_path):
                 "spatial_upsampler_path": spatial_upsampler_path,
                 "distilled_lora_path": distilled_lora_path,
             },
+            torch_compile_config=TorchCompileConfig(enable=False),
+            cuda_graph_config=CudaGraphConfig(enable=enable_cuda_graph),
         )
         pipeline = PipelineLoader(args).load(skip_warmup=True)
         try:
@@ -724,6 +727,24 @@ def test_ltx2_lpips_against_golden(tmp_path, ltx2_two_stage_bf16_video_path):
         ltx2_two_stage_bf16_video_path,
     )
     _assert_lpips_below_threshold(score, LTX2_LPIPS_THRESHOLD)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_ltx2_cuda_graph_lpips_matches_eager(tmp_path):
+    eager_path = tmp_path / "ltx2_eager_generated.mp4"
+    cuda_graph_path = tmp_path / "ltx2_cuda_graph_generated.mp4"
+
+    _generate_ltx2_lpips_video(eager_path, enable_cuda_graph=False)
+    _generate_ltx2_lpips_video(cuda_graph_path, enable_cuda_graph=True)
+    score = _run_lpips_eval(
+        tmp_path,
+        "ltx2_cuda_graph",
+        "video",
+        LTX2_T2V_PROMPT,
+        eager_path,
+        cuda_graph_path,
+    )
+    _assert_lpips_below_threshold(score, LTX2_CUDA_GRAPH_LPIPS_THRESHOLD)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")

--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -359,6 +359,7 @@ l0_b200:
   - examples/visual_gen/test_visual_gen.py::test_flux1_lpips_against_golden
   - examples/visual_gen/test_visual_gen.py::test_flux2_lpips_against_golden
   - examples/visual_gen/test_visual_gen.py::test_ltx2_lpips_against_golden
+  - examples/visual_gen/test_visual_gen.py::test_ltx2_cuda_graph_lpips_matches_eager
   - examples/visual_gen/test_visual_gen.py::test_wan21_t2v_lpips_against_golden
   - examples/visual_gen/test_visual_gen.py::test_wan22_t2v_lpips_against_golden
   - visual_gen/test_visual_gen_benchmark.py::test_offline_benchmark

--- a/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
@@ -16,6 +16,7 @@ Requires LTX-2 checkpoint. Does NOT require the LTX-2 reference code.
 import gc
 import json
 import os
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -1203,6 +1204,74 @@ class TestLTX2TwoStageLoRAHelpers:
         assert isinstance(runner, ltx2_two_stages._LTX2TwoStageCUDAGraphRunner)
         assert runner._lora_state_getter() == "original"
         assert pipeline.transformer.forward.__wrapped__.__self__ is pipeline.transformer
+
+    def test_cuda_graph_rejects_nonpersistent_lora_bindings(self):
+        """CUDA graph is valid only when distilled LoRA uses persistent bindings."""
+        pipeline = object.__new__(ltx2_two_stages.LTX2TwoStagesPipeline)
+        pipeline.pipeline_config = SimpleNamespace(
+            cuda_graph=SimpleNamespace(enable=True),
+        )
+        pipeline._distilled_lora_deltas = {"proj.weight": torch.ones(1)}
+        pipeline._distilled_lora_weight_cache = None
+
+        with pytest.raises(RuntimeError, match="requires persistent LoRA weights"):
+            pipeline._assert_cuda_graph_safe_lora_bindings()
+
+        pipeline._distilled_lora_weight_cache = object()
+        pipeline._assert_cuda_graph_safe_lora_bindings()
+
+        pipeline.pipeline_config.cuda_graph.enable = False
+        pipeline._distilled_lora_weight_cache = None
+        pipeline._assert_cuda_graph_safe_lora_bindings()
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_persistent_lora_cuda_graph_matches_eager_output(self):
+        """Persistent merged LoRA bindings should match eager output under CUDA graph."""
+
+        class TinyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(
+                    torch.tensor(
+                        [[1.0, 2.0], [3.0, 4.0]],
+                        device="cuda",
+                        dtype=torch.bfloat16,
+                    ),
+                    requires_grad=False,
+                )
+
+            def forward(self, x):
+                return F.linear(x, self.weight)
+
+        module = TinyModule()
+        delta = torch.full_like(module.weight, 0.5)
+        cache = ltx2_two_stages._PersistentLoRAWeightCache.build(
+            module,
+            {"weight": delta},
+        )
+        cache.bind_merged()
+
+        lora_state = {"value": "merged"}
+        runner = ltx2_two_stages._LTX2TwoStageCUDAGraphRunner(
+            ltx2_two_stages.CUDAGraphRunnerConfig(use_cuda_graph=True),
+            lambda: lora_state["value"],
+        )
+        graphed_forward = runner.wrap(module.forward)
+
+        with torch.inference_mode():
+            x = torch.randn((4, 2), device="cuda", dtype=torch.bfloat16)
+            eager = module(x).detach().clone()
+            graph_out = graphed_forward(x)
+            torch.cuda.synchronize()
+            assert torch.allclose(graph_out, eager, atol=1e-2, rtol=1e-2)
+
+            x2 = torch.randn((4, 2), device="cuda", dtype=torch.bfloat16)
+            eager2 = module(x2).detach().clone()
+            graph_out2 = graphed_forward(x2)
+            torch.cuda.synchronize()
+            assert torch.allclose(graph_out2, eager2, atol=1e-2, rtol=1e-2)
+
+        cache.bind_original()
 
     def test_persistent_bf16_cache_reuses_weight_storage(self):
         """Persistent BF16 cache swaps between the same original and merged tensors."""

--- a/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
@@ -1224,55 +1224,6 @@ class TestLTX2TwoStageLoRAHelpers:
         pipeline._distilled_lora_weight_cache = None
         pipeline._assert_cuda_graph_safe_lora_bindings()
 
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-    def test_persistent_lora_cuda_graph_matches_eager_output(self):
-        """Persistent merged LoRA bindings should match eager output under CUDA graph."""
-
-        class TinyModule(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.weight = torch.nn.Parameter(
-                    torch.tensor(
-                        [[1.0, 2.0], [3.0, 4.0]],
-                        device="cuda",
-                        dtype=torch.bfloat16,
-                    ),
-                    requires_grad=False,
-                )
-
-            def forward(self, x):
-                return F.linear(x, self.weight)
-
-        module = TinyModule()
-        delta = torch.full_like(module.weight, 0.5)
-        cache = ltx2_two_stages._PersistentLoRAWeightCache.build(
-            module,
-            {"weight": delta},
-        )
-        cache.bind_merged()
-
-        lora_state = {"value": "merged"}
-        runner = ltx2_two_stages._LTX2TwoStageCUDAGraphRunner(
-            ltx2_two_stages.CUDAGraphRunnerConfig(use_cuda_graph=True),
-            lambda: lora_state["value"],
-        )
-        graphed_forward = runner.wrap(module.forward)
-
-        with torch.inference_mode():
-            x = torch.randn((4, 2), device="cuda", dtype=torch.bfloat16)
-            eager = module(x).detach().clone()
-            graph_out = graphed_forward(x)
-            torch.cuda.synchronize()
-            assert torch.allclose(graph_out, eager, atol=1e-2, rtol=1e-2)
-
-            x2 = torch.randn((4, 2), device="cuda", dtype=torch.bfloat16)
-            eager2 = module(x2).detach().clone()
-            graph_out2 = graphed_forward(x2)
-            torch.cuda.synchronize()
-            assert torch.allclose(graph_out2, eager2, atol=1e-2, rtol=1e-2)
-
-        cache.bind_original()
-
     def test_persistent_bf16_cache_reuses_weight_storage(self):
         """Persistent BF16 cache swaps between the same original and merged tensors."""
 

--- a/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
@@ -27,7 +27,13 @@ from tensorrt_llm._torch.visual_gen.config import DiffusionPipelineConfig
 from tensorrt_llm._torch.visual_gen.models.ltx2 import pipeline_ltx2_two_stages as ltx2_two_stages
 from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2 import LTX2_FORCE_ONE_STAGE_ENV
 from tensorrt_llm._torch.visual_gen.pipeline_loader import PipelineComponent, PipelineLoader
-from tensorrt_llm.visual_gen.args import AttentionConfig, CacheDiTConfig, VisualGenArgs
+from tensorrt_llm.visual_gen.args import (
+    AttentionConfig,
+    CacheDiTConfig,
+    CudaGraphConfig,
+    TorchCompileConfig,
+    VisualGenArgs,
+)
 
 os.environ.setdefault("TLLM_DISABLE_MPI", "1")
 
@@ -1173,6 +1179,30 @@ class TestLTX2TwoStageLoRAHelpers:
         assert original_key != merged_key
         assert original_key[-1] == ("ltx2_two_stage_lora_state", "original")
         assert merged_key[-1] == ("ltx2_two_stage_lora_state", "merged")
+
+    def test_two_stage_cuda_graph_setup_uses_pipeline_config(self):
+        """CUDA graph setup runs before the two-stage model_config is assigned."""
+
+        class TinyTransformer:
+            def forward(self, *args, **kwargs):
+                return args, kwargs
+
+        pipeline = object.__new__(ltx2_two_stages.LTX2TwoStagesPipeline)
+        pipeline.pipeline_config = DiffusionPipelineConfig(
+            cuda_graph=CudaGraphConfig(enable=True),
+            torch_compile=TorchCompileConfig(enable=False),
+        )
+        pipeline.transformer = TinyTransformer()
+        pipeline._cuda_graph_runners = {}
+
+        assert not hasattr(pipeline, "model_config")
+
+        pipeline._setup_cuda_graphs()
+
+        runner = pipeline._cuda_graph_runners["transformer"]
+        assert isinstance(runner, ltx2_two_stages._LTX2TwoStageCUDAGraphRunner)
+        assert runner._lora_state_getter() == "original"
+        assert pipeline.transformer.forward.__wrapped__.__self__ is pipeline.transformer
 
     def test_persistent_bf16_cache_reuses_weight_storage(self):
         """Persistent BF16 cache swaps between the same original and merged tensors."""

--- a/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
@@ -23,7 +23,7 @@ import torch.nn.functional as F
 from test_common.llm_data import llm_models_root
 
 from tensorrt_llm._torch.modules.linear import Linear
-from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig, DiffusionPipelineConfig
+from tensorrt_llm._torch.visual_gen.config import DiffusionPipelineConfig
 from tensorrt_llm._torch.visual_gen.models.ltx2 import pipeline_ltx2_two_stages as ltx2_two_stages
 from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2 import LTX2_FORCE_ONE_STAGE_ENV
 from tensorrt_llm._torch.visual_gen.pipeline_loader import PipelineComponent, PipelineLoader

--- a/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
@@ -554,13 +554,13 @@ class TestTwoStageLoRAHelpers:
 
         gib = 1024**3
         monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
-        monkeypatch.setattr(torch.cuda, "mem_get_info", lambda: (116 * gib, 180 * gib))
+        monkeypatch.setattr(torch.cuda, "mem_get_info", lambda device=None: (116 * gib, 180 * gib))
         assert _should_save_bf16_weights()
 
-        monkeypatch.setattr(torch.cuda, "mem_get_info", lambda: (115 * gib, 180 * gib))
+        monkeypatch.setattr(torch.cuda, "mem_get_info", lambda device=None: (115 * gib, 180 * gib))
         assert not _should_save_bf16_weights()
 
-        def _raise_mem_query_error():
+        def _raise_mem_query_error(device=None):
             raise RuntimeError("mem_get_info failed")
 
         monkeypatch.setattr(torch.cuda, "mem_get_info", _raise_mem_query_error)

--- a/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
@@ -20,7 +20,8 @@ import torch.nn.functional as F
 from test_common.llm_data import llm_models_root
 
 from tensorrt_llm._torch.modules.linear import Linear
-from tensorrt_llm._torch.visual_gen.config import DiffusionPipelineConfig
+from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig, DiffusionPipelineConfig
+from tensorrt_llm._torch.visual_gen.models.ltx2 import pipeline_ltx2_two_stages as ltx2_two_stages
 from tensorrt_llm._torch.visual_gen.models.ltx2.pipeline_ltx2 import LTX2_FORCE_ONE_STAGE_ENV
 from tensorrt_llm._torch.visual_gen.pipeline_loader import PipelineComponent, PipelineLoader
 from tensorrt_llm.visual_gen.args import AttentionConfig, CacheDiTConfig, VisualGenArgs
@@ -1102,6 +1103,262 @@ def ltx2_two_stage_assets_exist():
             f"upsampler at {UPSAMPLER_PATH}, and LoRA at {LORA_PATH}."
         )
     return True
+
+
+class TestLTX2TwoStageLoRAHelpers:
+    """Test LTX-2 two-stage distilled LoRA helpers without model loading."""
+
+    def test_bf16_snapshot_gate_uses_preload_memory(self, monkeypatch):
+        """Pre-load memory is the whole-pipeline budget and wins over current memory."""
+        queried_devices = []
+
+        def fake_get_free_gpu_memory_gib(device=None):
+            queried_devices.append(device)
+            return 1.0
+
+        monkeypatch.setattr(
+            ltx2_two_stages,
+            "_get_free_gpu_memory_gib",
+            fake_get_free_gpu_memory_gib,
+        )
+
+        assert ltx2_two_stages._should_save_bf16_weights(
+            device="cuda:1",
+            preload_free_gib=120.0,
+            threshold_gib=115.0,
+        )
+        assert not ltx2_two_stages._should_save_bf16_weights(
+            device="cuda:1",
+            preload_free_gib=110.0,
+            threshold_gib=115.0,
+        )
+        assert queried_devices == []
+
+    def test_bf16_snapshot_gate_fallback_passes_device(self, monkeypatch):
+        """Fallback free-memory query must target the transformer's CUDA device."""
+        queried_devices = []
+
+        def fake_get_free_gpu_memory_gib(device=None):
+            queried_devices.append(device)
+            return 116.0
+
+        monkeypatch.setattr(
+            ltx2_two_stages,
+            "_get_free_gpu_memory_gib",
+            fake_get_free_gpu_memory_gib,
+        )
+
+        assert ltx2_two_stages._should_save_bf16_weights(
+            device="cuda:1",
+            preload_free_gib=None,
+            threshold_gib=115.0,
+        )
+        assert queried_devices == ["cuda:1"]
+
+    def test_persistent_bf16_cache_reuses_weight_storage(self):
+        """Persistent BF16 cache swaps between the same original and merged tensors."""
+
+        class TinyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(
+                    torch.tensor(
+                        [[1.0, 2.0], [3.0, 4.0]],
+                        dtype=torch.bfloat16,
+                    )
+                )
+
+        module = TinyModule()
+        original = module.weight.detach().clone()
+        delta = torch.full_like(module.weight, 0.5)
+
+        cache = ltx2_two_stages._PersistentLoRAWeightCache.build(
+            module,
+            {"weight": delta},
+        )
+        assert cache.applied_count == 1
+        assert cache.precision_counts() == {"bf16": 1}
+
+        original_ptr = module.weight.data_ptr()
+        cache.bind_merged()
+        merged_ptr = module.weight.data_ptr()
+        assert merged_ptr != original_ptr
+        assert torch.allclose(module.weight, original + delta)
+
+        cache.bind_original()
+        assert module.weight.data_ptr() == original_ptr
+        assert torch.equal(module.weight, original)
+
+        cache.bind_merged()
+        assert module.weight.data_ptr() == merged_ptr
+        assert torch.allclose(module.weight, original + delta)
+
+        cache.bind_original()
+        assert module.weight.data_ptr() == original_ptr
+        assert torch.equal(module.weight, original)
+
+    def test_persistent_fp8_cache_reuses_weight_and_scale_storage(self):
+        """Persistent FP8 cache swaps both quantized weight and scale storage."""
+
+        class TinyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.proj = torch.nn.Module()
+                bf16_weight = torch.tensor(
+                    [[1.0, 2.0], [3.0, 4.0]],
+                    dtype=torch.bfloat16,
+                )
+                weight_scale = torch.tensor(0.25, dtype=torch.float32)
+                self.proj.weight = torch.nn.Parameter(
+                    (bf16_weight.float() / weight_scale).to(torch.float8_e4m3fn),
+                    requires_grad=False,
+                )
+                self.proj.weight_scale = torch.nn.Parameter(
+                    weight_scale,
+                    requires_grad=False,
+                )
+
+        module = TinyModule()
+        original_weight = module.proj.weight.detach().clone()
+        original_scale = module.proj.weight_scale.detach().clone()
+        delta = torch.full((2, 2), 0.5, dtype=torch.bfloat16)
+
+        cache = ltx2_two_stages._PersistentLoRAWeightCache.build(
+            module,
+            {"proj.weight": delta},
+        )
+        assert cache.applied_count == 1
+        assert cache.precision_counts() == {"fp8": 1}
+
+        original_weight_ptr = module.proj.weight.data_ptr()
+        original_scale_ptr = module.proj.weight_scale.data_ptr()
+        cache.bind_merged()
+        merged_weight_ptr = module.proj.weight.data_ptr()
+        merged_scale_ptr = module.proj.weight_scale.data_ptr()
+        assert merged_weight_ptr != original_weight_ptr
+        assert merged_scale_ptr != original_scale_ptr
+        assert module.proj.weight.dtype == torch.float8_e4m3fn
+
+        cache.bind_original()
+        assert module.proj.weight.data_ptr() == original_weight_ptr
+        assert module.proj.weight_scale.data_ptr() == original_scale_ptr
+        assert torch.equal(module.proj.weight, original_weight)
+        assert torch.equal(module.proj.weight_scale, original_scale)
+
+        cache.bind_merged()
+        assert module.proj.weight.data_ptr() == merged_weight_ptr
+        assert module.proj.weight_scale.data_ptr() == merged_scale_ptr
+
+        cache.bind_original()
+        assert module.proj.weight.data_ptr() == original_weight_ptr
+        assert module.proj.weight_scale.data_ptr() == original_scale_ptr
+
+    def test_persistent_fp4_cache_swaps_quant_method_and_weight_storage(self, monkeypatch):
+        """Persistent FP4 cache binds merged BF16 weight and restores packed state."""
+
+        class TinyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.linear = Linear(
+                    2,
+                    2,
+                    bias=False,
+                    dtype=torch.bfloat16,
+                    skip_create_weights_in_init=True,
+                    reduce_output=False,
+                )
+                self.linear.weight = torch.nn.Parameter(
+                    torch.zeros((2, 1), dtype=torch.uint8),
+                    requires_grad=False,
+                )
+                self.linear.weight_scale = torch.nn.Parameter(
+                    torch.ones((128, 4), dtype=torch.uint8),
+                    requires_grad=False,
+                )
+                self.linear.weight_scale_2 = torch.nn.Parameter(
+                    torch.ones((), dtype=torch.float32),
+                    requires_grad=False,
+                )
+                self.linear.quant_method = object()
+
+        module = TinyModule()
+        original_quant_method = module.linear.quant_method
+        original_weight_ptr = module.linear.weight.data_ptr()
+        original_weight = module.linear.weight.detach().clone()
+        delta = torch.full((2, 2), 0.5, dtype=torch.bfloat16)
+
+        def fake_dequantize_fp4_weight(
+            packed_weight,
+            interleaved_scale,
+            weight_scale_2,
+            out_features,
+            in_features,
+        ):
+            assert packed_weight.data_ptr() == original_weight_ptr
+            assert out_features == 2
+            assert in_features == 2
+            return torch.ones((2, 2), dtype=torch.bfloat16)
+
+        monkeypatch.setattr(
+            ltx2_two_stages,
+            "_dequantize_fp4_weight",
+            fake_dequantize_fp4_weight,
+        )
+
+        cache = ltx2_two_stages._PersistentLoRAWeightCache.build(
+            module,
+            {"linear.weight": delta},
+        )
+        assert cache.applied_count == 1
+        assert cache.precision_counts() == {"fp4": 1}
+
+        cache.bind_merged()
+        merged_weight_ptr = module.linear.weight.data_ptr()
+        assert merged_weight_ptr != original_weight_ptr
+        assert module.linear.weight.dtype == torch.bfloat16
+        assert torch.equal(module.linear.weight, torch.ones_like(delta) + delta)
+        assert isinstance(module.linear.quant_method, ltx2_two_stages.UnquantizedLinearMethod)
+
+        cache.bind_original()
+        assert module.linear.weight.data_ptr() == original_weight_ptr
+        assert torch.equal(module.linear.weight, original_weight)
+        assert module.linear.quant_method is original_quant_method
+
+        cache.bind_merged()
+        assert module.linear.weight.data_ptr() == merged_weight_ptr
+        cache.bind_original()
+        assert module.linear.weight.data_ptr() == original_weight_ptr
+
+    def test_apply_lora_deltas_rolls_back_dense_weights_on_failure(self):
+        """A later merge failure must not leave earlier dense weights LoRA-merged."""
+
+        class TinyModule(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.good = torch.nn.Parameter(
+                    torch.tensor(
+                        [[1.0, 2.0], [3.0, 4.0]],
+                        dtype=torch.bfloat16,
+                    )
+                )
+                self.bad = torch.nn.Parameter(torch.zeros((2, 1), dtype=torch.bfloat16))
+
+        module = TinyModule()
+        original_good = module.good.detach().clone()
+        deltas = {
+            "good": torch.full_like(module.good, 0.5),
+            "bad": torch.ones((2, 2), dtype=torch.bfloat16),
+        }
+
+        with pytest.raises(RuntimeError, match="missing bad.weight_scale"):
+            ltx2_two_stages._apply_lora_deltas(
+                module,
+                deltas,
+                sign=1.0,
+                save_bf16_weights=False,
+            )
+
+        assert torch.equal(module.good, original_good)
 
 
 class TestLTX2TwoStagePipelineLoading:

--- a/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_ltx2_pipeline.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 """Integration tests for LTX2 pipelines.
 
 Tests cover:
@@ -1155,6 +1158,22 @@ class TestLTX2TwoStageLoRAHelpers:
         )
         assert queried_devices == ["cuda:1"]
 
+    def test_two_stage_cuda_graph_key_includes_lora_state(self):
+        """Original and merged LoRA bindings must not share CUDA graph keys."""
+        lora_state = {"value": "original"}
+        runner = ltx2_two_stages._LTX2TwoStageCUDAGraphRunner(
+            ltx2_two_stages.CUDAGraphRunnerConfig(use_cuda_graph=True),
+            lambda: lora_state["value"],
+        )
+
+        original_key = runner.get_graph_key(torch.empty(1, 2))
+        lora_state["value"] = "merged"
+        merged_key = runner.get_graph_key(torch.empty(1, 2))
+
+        assert original_key != merged_key
+        assert original_key[-1] == ("ltx2_two_stage_lora_state", "original")
+        assert merged_key[-1] == ("ltx2_two_stage_lora_state", "merged")
+
     def test_persistent_bf16_cache_reuses_weight_storage(self):
         """Persistent BF16 cache swaps between the same original and merged tensors."""
 
@@ -1221,6 +1240,10 @@ class TestLTX2TwoStageLoRAHelpers:
         module = TinyModule()
         original_weight = module.proj.weight.detach().clone()
         original_scale = module.proj.weight_scale.detach().clone()
+        original_bf16 = ltx2_two_stages._dequantize_fp8_weight(
+            original_weight,
+            original_scale,
+        )
         delta = torch.full((2, 2), 0.5, dtype=torch.bfloat16)
 
         cache = ltx2_two_stages._PersistentLoRAWeightCache.build(
@@ -1238,6 +1261,16 @@ class TestLTX2TwoStageLoRAHelpers:
         assert merged_weight_ptr != original_weight_ptr
         assert merged_scale_ptr != original_scale_ptr
         assert module.proj.weight.dtype == torch.float8_e4m3fn
+        merged_bf16 = ltx2_two_stages._dequantize_fp8_weight(
+            module.proj.weight,
+            module.proj.weight_scale,
+        )
+        assert torch.allclose(
+            merged_bf16,
+            original_bf16 + delta,
+            atol=1e-1,
+            rtol=1e-1,
+        )
 
         cache.bind_original()
         assert module.proj.weight.data_ptr() == original_weight_ptr
@@ -1350,7 +1383,7 @@ class TestLTX2TwoStageLoRAHelpers:
             "bad": torch.ones((2, 2), dtype=torch.bfloat16),
         }
 
-        with pytest.raises(RuntimeError, match="missing bad.weight_scale"):
+        with pytest.raises(RuntimeError, match=r"missing bad\.weight_scale"):
             ltx2_two_stages._apply_lora_deltas(
                 module,
                 deltas,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced persistent distilled LoRA weight caching system for visual generation, significantly reducing per-request merge and unmerge overhead.
  * Added precomputed weight storage for all LoRA deltas, improving performance.

* **Improvements**
  * Enhanced error handling with automatic rollback mechanisms for LoRA operations.
  * Improved memory management with explicit GPU device and free-memory tracking.

* **Tests**
  * Added comprehensive test coverage for LoRA weight caching behavior and failure recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

New feature to cache merged weights. Table below shows the impact to peak memory and resident memory

| Precision | Cache LoRA merged and unmerged weights | Resident memory after weights load | Peak GPU memory |
|---|---:|---:|---:|
| BF16 | no | 66.62 GiB | 107.98 GiB |
| BF16 | yes | 101.94 GiB | 107.38 GiB |
| FP8 | no | 51.09 GiB | 78.02 GiB |
| FP8 | yes | 71.70 GiB | 76.88 GiB |
| FP4 | no | 44.53 GiB | 85.36 GiB |
| FP4 | yes | 80.49 GiB | 85.26 GiB |


Perf with CUDA graph on BF16 768x1280 5s video

| Cache LoRA merged and unmerged weights | Generate s | Stage2 denoise s | CUDA graph captures |
|---|---:|---:|---:|
| off | 17.710 | 4.36 | 4 |                                                                                             
| on | 13.473 | 0.02 | 4 |

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
