### PR TITLE
[None][feat] Weight trtllm-bench AR/AL averages by output length

### DIFF
--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -165,6 +165,7 @@ class StatsKeeper:
         num_accepted_draft_tokens = []
         draft_acceptance_rate = []
         acceptance_length = []
+        decoding_iterations = []
 
         for entry in self.requests.values():
             start_time = min(entry.start_timestamp, start_time)
@@ -193,6 +194,7 @@ class StatsKeeper:
                     float(num_draft_tokens[-1]))
                 acceptance_length.append(entry.num_total_output_tokens /
                                          (entry.decode_iteration + 1))
+                decoding_iterations.append(entry.decode_iteration + 1)
 
         global_acceptance_length = sum(
             output_tokens) / total_decoding_iterations
@@ -203,17 +205,21 @@ class StatsKeeper:
         num_accepted_draft_tokens_percentiles = PercentileStats.from_iterable(
             num_accepted_draft_tokens) if num_accepted_draft_tokens else None
         # Weight the per-request acceptance rate (AR) and acceptance length
-        # (AL) averages by output length. An equally-weighted mean would bias
-        # the result toward short requests, which run fewer decoding
-        # iterations; output-length weighting makes the .average a token-level
-        # mean so longer requests contribute proportionally. Percentiles are
-        # unaffected.
+        # (AL) averages by the number of decoding iterations the request ran.
+        # An equally-weighted mean would bias the result toward short requests,
+        # which run fewer decoding iterations; iteration weighting makes the
+        # .average a token-level mean so longer requests contribute
+        # proportionally. This also makes acceptance_length_percentiles.average
+        # equal the globally-computed acceptance_length
+        # (sum(output_tokens) / total_decoding_iterations), since AL_i =
+        # output_tokens_i / iterations_i and the weights cancel the per-request
+        # iterations. Percentiles are unaffected.
         draft_acceptance_rate_percentiles = PercentileStats.from_iterable(
             draft_acceptance_rate,
-            weights=output_tokens) if draft_acceptance_rate else None
+            weights=decoding_iterations) if draft_acceptance_rate else None
         acceptance_length_percentiles = PercentileStats.from_iterable(
             acceptance_length,
-            weights=output_tokens) if acceptance_length else None
+            weights=decoding_iterations) if acceptance_length else None
 
         requests = list(self.requests.values())
         stats = BenchmarkStatistics(

--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -207,6 +207,28 @@ class StatsKeeper:
         acceptance_length_percentiles = PercentileStats.from_iterable(
             acceptance_length) if acceptance_length else None
 
+        # Determine whether every request produced the same number of output
+        # tokens. When the output lengths differ, an equally-weighted mean over
+        # per-request AR/AL biases the result toward short requests (which run
+        # fewer decoding iterations). In that case report an output-length
+        # weighted average so longer requests contribute proportionally.
+        output_lengths_consistent = len(set(output_tokens)) <= 1
+        if not output_lengths_consistent:
+            total_output_tokens = sum(output_tokens)
+            if total_output_tokens > 0:
+                if draft_acceptance_rate_percentiles is not None:
+                    draft_acceptance_rate_percentiles.average = sum(
+                        w * v
+                        for w, v in zip(output_tokens,
+                                        draft_acceptance_rate,
+                                        strict=True)) / total_output_tokens
+                if acceptance_length_percentiles is not None:
+                    acceptance_length_percentiles.average = sum(
+                        w * v
+                        for w, v in zip(output_tokens,
+                                        acceptance_length,
+                                        strict=True)) / total_output_tokens
+
         requests = list(self.requests.values())
         stats = BenchmarkStatistics(
             num_requests=num_requests,

--- a/tensorrt_llm/bench/dataclasses/reporting.py
+++ b/tensorrt_llm/bench/dataclasses/reporting.py
@@ -202,32 +202,18 @@ class StatsKeeper:
             num_draft_tokens) if num_draft_tokens else None
         num_accepted_draft_tokens_percentiles = PercentileStats.from_iterable(
             num_accepted_draft_tokens) if num_accepted_draft_tokens else None
+        # Weight the per-request acceptance rate (AR) and acceptance length
+        # (AL) averages by output length. An equally-weighted mean would bias
+        # the result toward short requests, which run fewer decoding
+        # iterations; output-length weighting makes the .average a token-level
+        # mean so longer requests contribute proportionally. Percentiles are
+        # unaffected.
         draft_acceptance_rate_percentiles = PercentileStats.from_iterable(
-            draft_acceptance_rate) if draft_acceptance_rate else None
+            draft_acceptance_rate,
+            weights=output_tokens) if draft_acceptance_rate else None
         acceptance_length_percentiles = PercentileStats.from_iterable(
-            acceptance_length) if acceptance_length else None
-
-        # Determine whether every request produced the same number of output
-        # tokens. When the output lengths differ, an equally-weighted mean over
-        # per-request AR/AL biases the result toward short requests (which run
-        # fewer decoding iterations). In that case report an output-length
-        # weighted average so longer requests contribute proportionally.
-        output_lengths_consistent = len(set(output_tokens)) <= 1
-        if not output_lengths_consistent:
-            total_output_tokens = sum(output_tokens)
-            if total_output_tokens > 0:
-                if draft_acceptance_rate_percentiles is not None:
-                    draft_acceptance_rate_percentiles.average = sum(
-                        w * v
-                        for w, v in zip(output_tokens,
-                                        draft_acceptance_rate,
-                                        strict=True)) / total_output_tokens
-                if acceptance_length_percentiles is not None:
-                    acceptance_length_percentiles.average = sum(
-                        w * v
-                        for w, v in zip(output_tokens,
-                                        acceptance_length,
-                                        strict=True)) / total_output_tokens
+            acceptance_length,
+            weights=output_tokens) if acceptance_length else None
 
         requests = list(self.requests.values())
         stats = BenchmarkStatistics(

--- a/tensorrt_llm/bench/dataclasses/statistics.py
+++ b/tensorrt_llm/bench/dataclasses/statistics.py
@@ -108,9 +108,10 @@ class PercentileStats(BaseModel):
         When ``weights`` is provided, ``average`` is computed as a weighted
         mean (``sum(w * v) / sum(w)``) instead of an equally-weighted mean.
         This is used to weight per-request metrics (e.g. speculative decoding
-        acceptance rate / acceptance length) by output length so that longer
-        requests, which run more decoding iterations, contribute
-        proportionally. Percentiles, minimum and maximum are unaffected.
+        acceptance rate / acceptance length) by the number of decoding
+        iterations so that longer requests, which run more decoding iterations,
+        contribute proportionally. Percentiles, minimum and maximum are
+        unaffected.
         """
         length = len(values)
         sorted_values = sorted(values)

--- a/tensorrt_llm/bench/dataclasses/statistics.py
+++ b/tensorrt_llm/bench/dataclasses/statistics.py
@@ -100,15 +100,34 @@ class PercentileStats(BaseModel):
     average: float
 
     @classmethod
-    def from_iterable(cls, values: List[Any]) -> PercentileStats:
+    def from_iterable(cls,
+                      values: List[Any],
+                      weights: Optional[List[float]] = None) -> PercentileStats:
+        """Build percentile statistics from ``values``.
+
+        When ``weights`` is provided, ``average`` is computed as a weighted
+        mean (``sum(w * v) / sum(w)``) instead of an equally-weighted mean.
+        This is used to weight per-request metrics (e.g. speculative decoding
+        acceptance rate / acceptance length) by output length so that longer
+        requests, which run more decoding iterations, contribute
+        proportionally. Percentiles, minimum and maximum are unaffected.
+        """
         length = len(values)
         sorted_values = sorted(values)
+        if weights is not None:
+            total_weight = sum(weights)
+            average = (sum(w * v
+                           for w, v in zip(weights, values, strict=True)) /
+                       total_weight
+                       if total_weight > 0 else float(sum(values)) / length)
+        else:
+            average = float(sum(values)) / length
         return cls(
             p50=sorted_values[int(length * 0.50)],
             p90=sorted_values[int(length * 0.90)],
             p95=sorted_values[int(length * 0.95)],
             p99=sorted_values[int(length * 0.99)],
-            average=float(sum(values)) / length,
+            average=average,
             minimum=min(values),
             maximum=max(values),
         )

--- a/tests/unittest/others/test_bench_statistics.py
+++ b/tests/unittest/others/test_bench_statistics.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import pytest
 
+from tensorrt_llm.bench.dataclasses.reporting import PerfItemTuple, StatsKeeper
 from tensorrt_llm.bench.dataclasses.statistics import PercentileStats
 
 
@@ -24,8 +25,8 @@ from tensorrt_llm.bench.dataclasses.statistics import PercentileStats
         ([1.0, 2.0, 3.0, 4.0], None, 2.5),
         # Weighted mean: sum(w * v) / sum(w).
         ([0.5, 1.0], [1.0, 3.0], 0.875),
-        # trtllm-bench AR/AL case: the long (heavy) request pulls the average
-        # toward its value instead of being equally weighted (0.75 -> 0.63).
+        # The heavy (large-weight) value pulls the average toward itself
+        # instead of being equally weighted (0.75 -> 0.63).
         ([0.9, 0.6], [10, 90], 0.63),
         # Uniform weights reproduce the unweighted mean.
         ([2.0, 4.0, 6.0, 8.0], [5.0, 5.0, 5.0, 5.0], 5.0),
@@ -65,3 +66,48 @@ def test_mismatched_weights_length_raises():
     """zip(strict=True) rejects mismatched values/weights lengths."""
     with pytest.raises(ValueError):
         PercentileStats.from_iterable([1.0, 2.0, 3.0], weights=[1.0, 2.0])
+
+
+def _perf_item(rid, num_out, decoding_iteration):
+    """Build a final PerfItemTuple for a single request.
+
+    ``num_total_output_tokens`` is ``len(tokens)``, so ``tokens`` is sized to
+    ``num_out``; ``decoding_iteration`` maps onto ``RequestRecord.decode_iteration``.
+    """
+    return PerfItemTuple(
+        start_timestamp=0,
+        end_timestamp=1000,
+        request_id=rid,
+        num_input_tokens=8,
+        response_is_final=True,
+        error=False,
+        tokens=list(range(num_out)),
+        decoding_iteration=decoding_iteration,
+        time_on_first_token=100,
+    )
+
+
+def test_acceptance_length_weighted_by_iterations():
+    """AR/AL averages are weighted by per-request decoding iterations.
+
+    AL_i = num_total_output_tokens / (decode_iteration + 1), weighted by the
+    iteration count (decode_iteration + 1). A short request has high AL but few
+    iterations; a long request has low AL but many iterations, so it dominates.
+    """
+    keeper = StatsKeeper()
+    # short request: AL = 10 / 2 = 5.0 over 2 iterations
+    keeper.register_request_perf_item(_perf_item(0, num_out=10, decoding_iteration=1))
+    # long request: AL = 300 / 200 = 1.5 over 200 iterations
+    keeper.register_request_perf_item(_perf_item(1, num_out=300, decoding_iteration=199))
+
+    stats = keeper.generate_statistics_summary(max_draft_tokens=3, batch_size=1)
+
+    # iteration-weighted mean: weights are (decode_iteration + 1).
+    weighted = (2 * 5.0 + 200 * 1.5) / (2 + 200)
+    assert stats.acceptance_length_percentiles.average == pytest.approx(weighted)
+
+    # Design intent: under iteration weighting the per-request AL average
+    # equals the globally-computed acceptance_length
+    # (= sum(output_tokens) / total_decoding_iterations). This would fail under
+    # output-token weighting.
+    assert stats.acceptance_length_percentiles.average == pytest.approx(stats.acceptance_length)

--- a/tests/unittest/others/test_bench_statistics.py
+++ b/tests/unittest/others/test_bench_statistics.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+from tensorrt_llm.bench.dataclasses.statistics import PercentileStats
+
+
+@pytest.mark.parametrize(
+    "values, weights, expected_average",
+    [
+        # No weights -> plain arithmetic mean (backward compatible).
+        ([1.0, 2.0, 3.0, 4.0], None, 2.5),
+        # Weighted mean: sum(w * v) / sum(w).
+        ([0.5, 1.0], [1.0, 3.0], 0.875),
+        # trtllm-bench AR/AL case: the long (heavy) request pulls the average
+        # toward its value instead of being equally weighted (0.75 -> 0.63).
+        ([0.9, 0.6], [10, 90], 0.63),
+        # Uniform weights reproduce the unweighted mean.
+        ([2.0, 4.0, 6.0, 8.0], [5.0, 5.0, 5.0, 5.0], 5.0),
+        # Zero total weight must not divide by zero; fall back to plain mean.
+        ([1.0, 2.0, 3.0], [0.0, 0.0, 0.0], 2.0),
+    ],
+)
+def test_weighted_average(values, weights, expected_average):
+    stats = PercentileStats.from_iterable(values, weights=weights)
+    assert stats.average == pytest.approx(expected_average)
+
+
+def test_weights_only_affect_average():
+    """Weights adjust the average but never the percentiles/min/max."""
+    values = [1.0, 2.0, 3.0, 4.0]
+    weighted = PercentileStats.from_iterable(values, weights=[1.0, 100.0, 1.0, 1.0])
+    unweighted = PercentileStats.from_iterable(values)
+    assert weighted.average != pytest.approx(unweighted.average)
+    assert (
+        weighted.p50,
+        weighted.p90,
+        weighted.p95,
+        weighted.p99,
+        weighted.minimum,
+        weighted.maximum,
+    ) == (
+        unweighted.p50,
+        unweighted.p90,
+        unweighted.p95,
+        unweighted.p99,
+        unweighted.minimum,
+        unweighted.maximum,
+    )
+
+
+def test_mismatched_weights_length_raises():
+    """zip(strict=True) rejects mismatched values/weights lengths."""
+    with pytest.raises(ValueError):
+        PercentileStats.from_iterable([1.0, 2.0, 3.0], weights=[1.0, 2.0])


### PR DESCRIPTION
When requests produce different output lengths, an equally-weighted mean over per-request acceptance rate (AR) and acceptance length (AL) biases the reported average toward short requests, which run fewer decoding iterations. Detect inconsistent output lengths and, in that case, report an output-length weighted average for the AR/AL .average statistic so longer requests contribute proportionally. When all output lengths match, behavior is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of speculative decoding benchmark metrics reporting when requests produce varying output lengths by using output token count-weighted averaging instead of unweighted calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Summary
In `trtllm-bench`, the reported average acceptance rate (AR) and acceptance
length (AL) for speculative decoding were computed as an equally-weighted
mean over per-request values. When requests produce different output
lengths, this biases the average toward short requests (which run fewer
decoding iterations).

This PR detects whether all requests share the same output length. When
they do not, the AR/AL `.average` statistic is reported as an
output-length weighted mean — `Σ(output_i · value_i) / Σ(output_i)` — so
longer requests contribute proportionally. When all output lengths match,
behavior is unchanged.

## Changes
- `tensorrt_llm/bench/dataclasses/reporting.py`: compute
  `output_lengths_consistent` and override the AR/AL average with an
  output-length weighted mean when lengths differ.

## Test Coverage
N/A (statistics-only change; min/max/percentiles unchanged).


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
