### PR TITLE
[None][fix] tunable_fp4_quantize: rename misnamed kwarg + add real SF-swizzle control

### DIFF
--- a/cpp/tensorrt_llm/thop/fp4Quantize.cpp
+++ b/cpp/tensorrt_llm/thop/fp4Quantize.cpp
@@ -36,6 +36,7 @@ namespace torch_ext
 // nvfp4: sfVecSize = 16, sfUseUE8M0 = false
 // mxfp4: sfVecSize = 32, sfUseUE8M0 = true
 // alignment: sfVecSize
+// sfUseUE8M0: bool, if true, scale factors use UE8M0 format (MXFP4); otherwise UE4M3 (NVFP4).
 // isSfSwizzledLayout: bool, if true, the scale factors are stored in swizzled layout, otherwise in linear layout.
 // See QuantizationSFLayout enum for more details about the two layouts.
 // returns self_fp4, self_block_scale_factors

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -2417,11 +2417,22 @@ class Fp4QuantTactic(enum.IntEnum):
 
 
 def _fp4_quantize_dispatch(input: torch.Tensor, input_scale: torch.Tensor,
-                           scaling_vector_size: int,
+                           scaling_vector_size: int, sf_use_ue8m0: bool,
                            is_sf_swizzled_layout: bool,
                            tactic: int) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Dispatch FP4 quantization to TRTLLM or FlashInfer kernel."""
+    """Dispatch FP4 quantization to TRTLLM or FlashInfer kernel.
+
+    The two layout bools map straight through to the C++ ``fp4_quantize`` op
+    arguments of the same name. The earlier wrapper exposed only a single
+    ``is_sf_swizzled_layout`` kwarg that, in the TRTLLM branch, was actually
+    sent to the C++ ``sfUseUE8M0`` slot -- so the param name lied. This
+    dispatch is now explicit on both axes.
+    """
     if tactic == Fp4QuantTactic.FLASHINFER and IS_FLASHINFER_AVAILABLE:
+        # FlashInfer FP4 kernel does not support MXFP4 (UE8M0) scaling.
+        assert not sf_use_ue8m0, (
+            "FlashInfer FP4 tactic does not support sf_use_ue8m0=True; "
+            "force the TRTLLM tactic.")
         act_fp4, act_sf = _flashinfer_nvfp4_quantize(
             input,
             input_scale,
@@ -2439,7 +2450,7 @@ def _fp4_quantize_dispatch(input: torch.Tensor, input_scale: torch.Tensor,
         return act_fp4, act_sf
     else:
         return torch.ops.trtllm.fp4_quantize(input, input_scale,
-                                             scaling_vector_size,
+                                             scaling_vector_size, sf_use_ue8m0,
                                              is_sf_swizzled_layout)
 
 
@@ -2461,12 +2472,15 @@ class Fp4QuantKernelRunner(TunableRunner):
 
     def __init__(self,
                  scaling_vector_size: int = 16,
-                 is_sf_swizzled_layout: bool = False):
+                 sf_use_ue8m0: bool = False,
+                 is_sf_swizzled_layout: bool = True):
         self.scaling_vector_size = scaling_vector_size
+        self.sf_use_ue8m0 = sf_use_ue8m0
         self.is_sf_swizzled_layout = is_sf_swizzled_layout
 
     def unique_id(self):
-        return (self.scaling_vector_size, self.is_sf_swizzled_layout)
+        return (self.scaling_vector_size, self.sf_use_ue8m0,
+                self.is_sf_swizzled_layout)
 
     def get_valid_tactics(
         self,
@@ -2486,6 +2500,7 @@ class Fp4QuantKernelRunner(TunableRunner):
         input, input_scale = inputs
         act_fp4, act_sf = _fp4_quantize_dispatch(input, input_scale,
                                                  self.scaling_vector_size,
+                                                 self.sf_use_ue8m0,
                                                  self.is_sf_swizzled_layout,
                                                  tactic)
         return act_fp4
@@ -2496,7 +2511,8 @@ def tunable_fp4_quantize(
     input: torch.Tensor,
     input_scale: torch.Tensor,
     scaling_vector_size: int = 16,
-    is_sf_swizzled_layout: bool = False,
+    sf_use_ue8m0: bool = False,
+    is_sf_swizzled_layout: bool = True,
 ) -> List[torch.Tensor]:
     """FP4 quantization with autotuning between TRTLLM and FlashInfer kernels.
 
@@ -2508,14 +2524,21 @@ def tunable_fp4_quantize(
         input: Activation tensor [M, K] in bf16/fp16
         input_scale: Global scale factor tensor
         scaling_vector_size: Block size for scale factors (default: 16)
-        is_sf_swizzled_layout: Whether to use swizzled layout for scales
+        sf_use_ue8m0: When True, quantize with MXFP4 UE8M0 scaling
+            (sf_vec_size must be 32). Default False (NVFP4 with FP8 e4m3 SF).
+            FlashInfer tactic does not support True; selecting TRTLLM is
+            required in that mode.
+        is_sf_swizzled_layout: When True (default), emit the SWIZZLED 128x4
+            FP8 e4m3 scaling-factor layout that downstream ``nvfp4_gemm``
+            consumes. Set False only when the consumer wants the unswizzled
+            row-major layout.
 
     Returns:
         List of [act_fp4, act_sf] - quantized activation and scale factors
     """
     tuner = AutoTuner.get()
 
-    quant_runner = Fp4QuantKernelRunner(scaling_vector_size,
+    quant_runner = Fp4QuantKernelRunner(scaling_vector_size, sf_use_ue8m0,
                                         is_sf_swizzled_layout)
 
     _, best_tactic = tuner.choose_one(
@@ -2528,6 +2551,7 @@ def tunable_fp4_quantize(
     try:
         act_fp4, act_sf = _fp4_quantize_dispatch(input, input_scale,
                                                  scaling_vector_size,
+                                                 sf_use_ue8m0,
                                                  is_sf_swizzled_layout,
                                                  best_tactic)
     except Exception:
@@ -2536,6 +2560,7 @@ def tunable_fp4_quantize(
                            f"{input.shape}, falling back to TRTLLM kernel.")
             act_fp4, act_sf = _fp4_quantize_dispatch(input, input_scale,
                                                      scaling_vector_size,
+                                                     sf_use_ue8m0,
                                                      is_sf_swizzled_layout,
                                                      Fp4QuantTactic.TRTLLM)
         else:
@@ -2548,7 +2573,8 @@ def _(
     input: torch.Tensor,
     input_scale: torch.Tensor,
     scaling_vector_size: int = 16,
-    is_sf_swizzled_layout: bool = False,
+    sf_use_ue8m0: bool = False,
+    is_sf_swizzled_layout: bool = True,
 ) -> List[torch.Tensor]:
     """Fake implementation for torch.compile support.
 
@@ -2557,6 +2583,7 @@ def _(
     swizzled_layout=True in get_fp4_shape to match the actual output size.
     We also reshape FlashInfer's output to match in _fp4_quantize_dispatch.
     """
+    del sf_use_ue8m0, is_sf_swizzled_layout  # output shape independent of these
     output_shape, scale_shape = fp4_utils.get_fp4_shape(input.shape,
                                                         scaling_vector_size,
                                                         True)

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -2420,16 +2420,8 @@ def _fp4_quantize_dispatch(input: torch.Tensor, input_scale: torch.Tensor,
                            scaling_vector_size: int, sf_use_ue8m0: bool,
                            is_sf_swizzled_layout: bool,
                            tactic: int) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Dispatch FP4 quantization to TRTLLM or FlashInfer kernel.
-
-    The two layout bools map straight through to the C++ ``fp4_quantize`` op
-    arguments of the same name. The earlier wrapper exposed only a single
-    ``is_sf_swizzled_layout`` kwarg that, in the TRTLLM branch, was actually
-    sent to the C++ ``sfUseUE8M0`` slot -- so the param name lied. This
-    dispatch is now explicit on both axes.
-    """
+    """Dispatch FP4 quantization to TRTLLM or FlashInfer kernel."""
     if tactic == Fp4QuantTactic.FLASHINFER and IS_FLASHINFER_AVAILABLE:
-        # FlashInfer FP4 kernel does not support MXFP4 (UE8M0) scaling.
         assert not sf_use_ue8m0, (
             "FlashInfer FP4 tactic does not support sf_use_ue8m0=True; "
             "force the TRTLLM tactic.")
@@ -2488,7 +2480,8 @@ class Fp4QuantKernelRunner(TunableRunner):
         profile: OptimizationProfile,
     ) -> List[int]:
         tactics = [Fp4QuantTactic.TRTLLM]
-        if IS_FLASHINFER_AVAILABLE:
+        # FlashInfer FP4 kernel has no UE8M0 / MXFP4 mode.
+        if IS_FLASHINFER_AVAILABLE and not self.sf_use_ue8m0:
             tactics.append(Fp4QuantTactic.FLASHINFER)
         return tactics
 
@@ -2524,14 +2517,10 @@ def tunable_fp4_quantize(
         input: Activation tensor [M, K] in bf16/fp16
         input_scale: Global scale factor tensor
         scaling_vector_size: Block size for scale factors (default: 16)
-        sf_use_ue8m0: When True, quantize with MXFP4 UE8M0 scaling
-            (sf_vec_size must be 32). Default False (NVFP4 with FP8 e4m3 SF).
-            FlashInfer tactic does not support True; selecting TRTLLM is
-            required in that mode.
-        is_sf_swizzled_layout: When True (default), emit the SWIZZLED 128x4
-            FP8 e4m3 scaling-factor layout that downstream ``nvfp4_gemm``
-            consumes. Set False only when the consumer wants the unswizzled
-            row-major layout.
+        sf_use_ue8m0: MXFP4 (UE8M0 SF) when True; NVFP4 (UE4M3 SF) when
+            False. FlashInfer tactic does not support True.
+        is_sf_swizzled_layout: Emit SWIZZLED 128x4 FP8 e4m3 SF layout when
+            True (default).
 
     Returns:
         List of [act_fp4, act_sf] - quantized activation and scale factors
@@ -2583,7 +2572,7 @@ def _(
     swizzled_layout=True in get_fp4_shape to match the actual output size.
     We also reshape FlashInfer's output to match in _fp4_quantize_dispatch.
     """
-    del sf_use_ue8m0, is_sf_swizzled_layout  # output shape independent of these
+    del sf_use_ue8m0, is_sf_swizzled_layout
     output_shape, scale_shape = fp4_utils.get_fp4_shape(input.shape,
                                                         scaling_vector_size,
                                                         True)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected FP4 quantization dispatch to properly align scale factors between different inference backends

* **Enhancements**
  * Added configuration options for scale factor layout format and sizing to provide finer control over quantization behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Fixes a latent bug in `tunable_fp4_quantize` (added in PR #12126) where the Python wrapper's 4th kwarg, named `is_sf_swizzled_layout`, was misforwarded inside `_fp4_quantize_dispatch`. The TRTLLM dispatch branch passed it as the 4th positional argument to the 5-arg C++ `fp4_quantize` op, where the 4th slot is actually `sfUseUE8M0` (the MXFP4 toggle) and the 5th is `isSfSwizzledLayout`. As a result, three things were wrong: (1) the wrapper kwarg name lied about what it controlled; (2) the FlashInfer branch interpreted the same kwarg correctly as `do_shuffle` (swizzled), so the wrapper had divergent semantics across tactics; (3) callers had no way to actually control `isSfSwizzledLayout` — the C++ default `True` was always used.

The bug stayed latent because every existing call site passes positional `False` (production NVFP4 Linear in `tensorrt_llm/_torch/modules/linear.py`, plus the two cases in `tests/unittest/_torch/thop/parallel/test_fp4_quantize_flashinfer.py`), which lands as `sfUseUE8M0=False` (correct for NVFP4) and lets the C++ default `isSfSwizzledLayout=True` produce SWIZZLED output that downstream `nvfp4_gemm` consumes. Trying to flip the swizzled flag by passing `True` instead crashes with `RuntimeError: sfVecSize can only be 32, when sfUseUE8M0 is true` (the UE8M0 + sf_vec_size=16 combination is rejected by the C++ op).

The fix renames the 4th wrapper kwarg to `sf_use_ue8m0` (matching what the TRTLLM dispatch actually controls), adds a real 5th kwarg `is_sf_swizzled_layout: bool = True` (matching the C++ default), and threads both through the dispatch helper, `Fp4QuantKernelRunner`, and the fake registration. The FlashInfer branch now asserts `not sf_use_ue8m0` (FlashInfer has no MXFP4 path) and uses the new `is_sf_swizzled_layout` for `do_shuffle`. All existing call sites continue to pass positional `False`, which now binds to `sf_use_ue8m0=False` while `is_sf_swizzled_layout` falls back to the new default `True` — so each existing caller's effective C++ call is byte-identical to pre-fix.

## Test Coverage

- `tests/unittest/_torch/thop/parallel/test_fp4_quantize_flashinfer.py` (the wrapper's own op-level test, both `test_tunable_fp4_quantize_op` and `test_tunable_fp4_quantize_with_autotune`) — pass.
- LTX-2 transformer block tests (which exercise the production NVFP4 Linear path through this wrapper) — pass.

## PR Checklist

- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md).
- Test cases are provided for new code paths.
- Any new dependencies have been scanned for license and vulnerabilities.
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes.
- Documentation updated as needed.
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if significant design change.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
