### PR TITLE
[None][fix] Relax tokens_per_block mismatch check in dis-agg router

### DIFF
--- a/tensorrt_llm/_torch/disaggregation/native/mixers/attention/peer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/mixers/attention/peer.py
@@ -335,6 +335,25 @@ class AttentionPolicy:
             local != peer, f"{field} mismatch", field=field, local=local, peer=peer
         )
 
+    def _tpb_check(self, local: int, peer: int) -> bool:
+        if local == peer:
+            return False
+        larger, smaller = max(local, peer), min(local, peer)
+        if larger % smaller != 0:
+            logger.warning(
+                "AttentionPolicy: incompatible: tokens_per_block not divisible; local=%d peer=%d",
+                local,
+                peer,
+            )
+            return True
+        logger.warning(
+            "AttentionPolicy: tokens_per_block mismatch (local=%d, peer=%d); "
+            "KV transfer proceeds — ensure block boundaries align during transfer.",
+            local,
+            peer,
+        )
+        return False
+
     def check_peer_compatible(self, peer_ri: RankInfo) -> bool:
         a = self._ri.attention
         b = peer_ri.attention
@@ -348,7 +367,7 @@ class AttentionPolicy:
                 peer=peer_ri.cp_size,
             )
             or self._mismatch("element_bytes", a.element_bytes, b.element_bytes)
-            or self._mismatch("tokens_per_block", a.tokens_per_block, b.tokens_per_block)
+            or self._tpb_check(a.tokens_per_block, b.tokens_per_block)
             or self._mismatch("dims_per_head", a.dims_per_head, b.dims_per_head)
             or self._fail_if(
                 a.is_mla and (a.kv_heads_per_rank != 1 or b.kv_heads_per_rank != 1),

--- a/tensorrt_llm/serve/router.py
+++ b/tensorrt_llm/serve/router.py
@@ -1042,14 +1042,21 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
         info = self._server_info.get(server, {})
         worker_tpb = info.get("tokens_per_block")
         if worker_tpb is not None and worker_tpb != self._tokens_per_block:
-            # Block-hash chunking is router-side; a mismatch makes hashes never
-            # match the worker's KV cache. Fail fast.
-            self._prepared_ready_servers.discard(server)
-            self._server_info.pop(server, None)
-            raise RuntimeError(
-                f"tokens_per_block mismatch on {server}: "
-                f"router={self._tokens_per_block} worker={worker_tpb}. "
-                f"Align kv_cache_config.tokens_per_block to fix.")
+            larger = max(worker_tpb, self._tokens_per_block)
+            smaller = min(worker_tpb, self._tokens_per_block)
+            if larger % smaller != 0:
+                self._prepared_ready_servers.discard(server)
+                self._server_info.pop(server, None)
+                raise RuntimeError(
+                    f"tokens_per_block mismatch on {server}: "
+                    f"router={self._tokens_per_block} worker={worker_tpb} are not divisible. "
+                    f"Align kv_cache_config.tokens_per_block so that one evenly divides the other."
+                )
+            logger.warning(
+                "tokens_per_block mismatch on %s: router=%d worker=%d. "
+                "KV events from worker will not align with router block hashes; "
+                "use backfill_block_hashes_on_finish=true for best hit rate.",
+                server, self._tokens_per_block, worker_tpb)
         worker_algo = info.get("kv_cache_hash_algo")
         known_algos = {
             KV_CACHE_HASH_ALGO_V1,

--- a/tests/unittest/disaggregated/test_peer.py
+++ b/tests/unittest/disaggregated/test_peer.py
@@ -402,3 +402,33 @@ def test_peer_registrar_get_kv_map_head_mismatch():
     reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
     mapper = reg.get_kv_map(peer_ri, (0, 0), (0, 0))
     assert isinstance(mapper, HeadMismatchMapper)
+
+
+def test_peer_registrar_tpb_divisible_warns_but_compatible():
+    # local=16, peer=32: 32 % 16 == 0 → compatible with warning, register succeeds
+    self_rankinfo = make_rankinfo(instance_name="local", tokens_per_block=16)
+    reg = _make_peer_registrar(self_rankinfo)
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        instance_rank=5,
+        tokens_per_block=32,
+        layer_num_per_pp=[2],
+        page_table=make_page_table(),
+    )
+    reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)
+    assert reg.get_peer_rank_info(peer_ri.instance_name, peer_ri.instance_rank) is not None
+
+
+def test_peer_registrar_tpb_not_divisible_raises():
+    # local=16, peer=24: 24 % 16 != 0 → incompatible, register raises ValueError
+    self_rankinfo = make_rankinfo(instance_name="local", tokens_per_block=16)
+    reg = _make_peer_registrar(self_rankinfo)
+    peer_ri = make_rankinfo(
+        instance_name="peer",
+        instance_rank=6,
+        tokens_per_block=24,
+        layer_num_per_pp=[2],
+        page_table=make_page_table(),
+    )
+    with pytest.raises(ValueError):
+        reg.register(peer_ri.instance_name, peer_ri.instance_rank, peer_ri)

--- a/tests/unittest/disaggregated/test_router.py
+++ b/tests/unittest/disaggregated/test_router.py
@@ -946,7 +946,9 @@ async def test_kv_cache_aware_router_load_weight_scales_load_penalty(servers):
 
 
 @pytest.mark.asyncio
-async def test_kv_cache_aware_router_prepare_server_raises_on_tpb_mismatch():
+async def test_kv_cache_aware_router_prepare_server_warns_on_tpb_mismatch_divisible(
+):
+    # router=32, worker=64: 64 % 32 == 0 → warning only, server stays ready
     router = KvCacheAwareRouter(server_role=None,
                                 servers=["server-a"],
                                 tokens_per_block=32)
@@ -956,7 +958,26 @@ async def test_kv_cache_aware_router_prepare_server_raises_on_tpb_mismatch():
 
     with mock.patch.object(router, "_fetch_server_info",
                            side_effect=fake_fetch):
-        with pytest.raises(RuntimeError, match="tokens_per_block mismatch"):
+        await router._prepare_server("server-a")
+
+    assert "server-a" in router._prepared_ready_servers
+    assert router._server_info["server-a"]["tokens_per_block"] == 64
+
+
+@pytest.mark.asyncio
+async def test_kv_cache_aware_router_prepare_server_raises_on_tpb_not_divisible(
+):
+    # router=32, worker=48: 48 % 32 != 0 → RuntimeError, server removed
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=["server-a"],
+                                tokens_per_block=32)
+
+    async def fake_fetch(server, timeout):
+        return {"tokens_per_block": 48, "kv_cache_hash_algo": "v1_block_key"}
+
+    with mock.patch.object(router, "_fetch_server_info",
+                           side_effect=fake_fetch):
+        with pytest.raises(RuntimeError, match="not divisible"):
             await router._prepare_server("server-a")
 
     assert "server-a" not in router._prepared_ready_servers


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

Router and peer-compatibility checks previously rejected any tpb mismatch outright.  Smaller router tpb (e.g. 32/64) vs larger worker tpb (e.g. 128) gives higher KV cache-hit rate due to partial-last-block boundary effects, so the hard block should only apply when the values are not divisible.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
