### PR TITLE
[None][feat] Mixed-modality core + Qwen3VL adoption (1/3)

### DIFF
--- a/tensorrt_llm/_torch/models/mixed_modal_encode.py
+++ b/tensorrt_llm/_torch/models/mixed_modal_encode.py
@@ -1,0 +1,280 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Model-agnostic mixed-modality encode path: demux -> encode -> mux.
+
+A single-modality request is the degenerate (identity-permutation) case.
+Per-model code supplies (a) an extractor that walks each :class:`MultimodalParams`
+and yields :class:`ModalityItem` instances, and (b) per-modality encoder adapters
+that bridge a bucket of items to the model's existing encoder call. The pipeline
+is three free functions:
+
+  - `build_scatter_index` DEMULTIPLEXES the flat item list into per-modality
+    buckets and computes each item's batch-relative destination range.
+  - `encoder_dispatch` ENCODES one channel per active modality (one encoder
+    launch each).
+  - `scatter_to_prompt_order` MULTIPLEXES the per-modality outputs back into the
+    canonical prompt-ordered buffer.
+
+`encode_by_modality_and_scatter` is the model-facing orchestrator that chains the
+three and keeps the per-param `sum(rows) == total_embeds_in_request` cross-check.
+
+Every item owns exactly one prompt slot. There are no ghosts and no shared slots:
+an item's `rows` is both the number of rows its encoder emits and the size of its
+scatter destination range. Interleaved repeated modalities (`image -> video ->
+image`, `video(+audio)` promoted to a first-class `(audio, k)` item) are handled
+by the plain per-item scatter — no post-process re-placement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Mapping, NamedTuple
+
+import torch
+
+from tensorrt_llm.inputs.multimodal import MultimodalParams
+
+
+@dataclass(frozen=True, slots=True)
+class ModalityItem:
+    """One single-modality payload (one image, video, or audio) as a unit of
+    work in the mixed-modality encode pipeline.
+
+    Canonical six-field item: every item owns exactly one prompt slot
+    (`prompt_pos`) and its `rows` is both the encoder-output row count and its
+    scatter-destination footprint. There are no flags, no ghosts, and no shared
+    slots.
+
+    Fields:
+        src_param_idx: which request in the batch this item belongs to.
+        modality: which encoder bucket the item rides (image / video / audio).
+        mm_idx_per_modality: which blob in `multimodal_data[modality]` this item
+            is, used to slice the per-item encoder payload.
+        prompt_pos: this item's rank in the prompt-order stream; it OWNS this
+            slot, so each `prompt_pos` appears at most once per source param.
+        rows: encoder-output row count == this item's scatter footprint.
+        payload: the single-item encoder input (already sliced).
+
+    Placement (bucket slot, destination range) is derived by `build_scatter_index`
+    and is never stored on the item.
+    """
+
+    src_param_idx: int
+    modality: str
+    mm_idx_per_modality: int
+    prompt_pos: int
+    rows: int
+    payload: Mapping[str, Any]
+
+
+ItemExtractor = Callable[[int, MultimodalParams], Iterable[ModalityItem]]
+
+
+class ScatterIndices(NamedTuple):
+    """Batch index tensors that drive the per-modality scatter. Plain data."""
+
+    modality_slots: Dict[str, torch.Tensor]  # flat item indices per modality
+    dst_indices: Dict[str, torch.Tensor]  # destination rows per modality
+    param_lengths: torch.Tensor  # int64[num_params], rows per param
+    total_tokens: int
+    active_modalities: List[str]
+
+
+def build_scatter_index(items: List[ModalityItem], num_params: int) -> ScatterIndices:
+    """Partition items into per-modality buckets and compute batch-relative
+    Computes destination rows for each item. Each prompt slot is unique per request,
+    enforced by `MixedModalItemOrder.__post_init__`; only index calculations here.
+
+    Worked example (used in the inline comments below). Two requests with
+    interleaved modalities, num_params=2:
+
+        item  src_param  modality  prompt_pos  rows (encoder-output row count)
+          0       0        image       0         2
+          1       0        video       1         3
+          2       1        video       0         3
+          3       1        image       1         2
+
+    Canonical buffer (ordered by src_param, then prompt_pos), size 10:
+        req0: [img rows 0,1][vid rows 2,3,4]   req1: [vid rows 5,6,7][img rows 8,9]
+    """
+    n = len(items)
+    if n == 0:
+        return ScatterIndices({}, {}, torch.zeros(num_params, dtype=torch.int64), 0, [])
+
+    # One pass lifts Python ModalityItem fields into parallel int64 tensors (the
+    # Python-object -> tensor boundary); everything after is vectorized.
+    src = torch.tensor([it.src_param_idx for it in items], dtype=torch.int64)  # ex: [0,0,1,1]
+    rows = torch.tensor([it.rows for it in items], dtype=torch.int64)  # ex: [2,3,3,2]
+    pos = torch.tensor([it.prompt_pos for it in items], dtype=torch.int64)  # ex: [0,1,0,1]
+    active_modalities = list(
+        dict.fromkeys(it.modality for it in items)
+    )  # first-seen: [image, video]
+    code = {m: i for i, m in enumerate(active_modalities)}  # ex: {image:0, video:1}
+    mcode = torch.tensor([code[it.modality] for it in items], dtype=torch.int64)  # ex: [0,1,1,0]
+
+    # Per-param row totals. ex: [5,5] (req0: 2+3, req1: 3+2)
+    param_lengths = torch.zeros(num_params, dtype=torch.int64).scatter_add_(0, src, rows)
+
+    # Each item's destination start == exclusive prefix sum of `rows` in canonical
+    # (src_param, prompt_pos) order. The canonical buffer is items concatenated by
+    # param then by prompt order, so an item's start is the rows ordered before it.
+    # One argsort + one cumsum replaces the per-param sort-and-accumulate loop.
+    sort_key = src * (int(pos.max()) + 1) + pos  # ex: src*2+pos = [0,1,2,3]
+    order = torch.argsort(sort_key)  # ex: [0,1,2,3] (canonical item order)
+    excl_sorted = (
+        torch.cumsum(rows[order], dim=0) - rows[order]
+    )  # ex: [2,5,8,10]-[2,3,3,2]=[0,2,5,8]
+    dst_start = torch.empty(n, dtype=torch.int64)
+    dst_start[order] = excl_sorted  # unsort back to original item order. ex: [0,2,5,8]
+
+    # Buckets + destination rows. loop over distinct modalities ( <= 3)
+    # each body is a vectorized nonzero + _expand_ranges
+    # ex: image -> slots [0,3], starts [0,8], rows [2,2] -> dst [0,1,8,9]
+    #     video -> slots [1,2], starts [2,5], rows [3,3] -> dst [2,3,4,5,6,7]
+    modality_slots: Dict[str, torch.Tensor] = {}
+    dst_indices: Dict[str, torch.Tensor] = {}
+    for modality, c in code.items():
+        slots = (mcode == c).nonzero(as_tuple=True)[0]
+        modality_slots[modality] = slots
+        dst_indices[modality] = _expand_ranges(dst_start[slots], rows[slots])
+
+    return ScatterIndices(
+        modality_slots=modality_slots,
+        dst_indices=dst_indices,
+        param_lengths=param_lengths,
+        total_tokens=int(param_lengths.sum().item()),
+        active_modalities=active_modalities,
+    )
+
+
+def _expand_ranges(starts: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+    """Concatenate per-segment ranges ``[s, s + l)`` for paired (starts, lengths).
+
+    Vectorized equivalent of
+    ``torch.cat([torch.arange(s, s + l) for s, l in zip(starts, lengths)])``,
+    built with a single `repeat_interleave` + `arange`.
+    Both inputs are int64 1-D tensors of equal length; returns an empty
+    int64 tensor when there are no rows.
+    """
+    total = int(lengths.sum()) if lengths.numel() > 0 else 0
+    if total == 0:
+        return torch.empty(0, dtype=torch.int64)
+    # Exclusive prefix sum: each segment's start offset within the output.
+    seg_start_in_out = torch.cumsum(lengths, dim=0) - lengths
+    within = torch.arange(total, dtype=torch.int64) - seg_start_in_out.repeat_interleave(lengths)
+    base = starts.repeat_interleave(lengths)
+    return base + within
+
+
+# Adapter contract: given a bucket's items and the source-param list,
+# return one tensor of shape (sum(item.rows for item in items), hidden_dim)
+# with rows in bucket order (= order in index.modality_slots[modality]).
+ModalityEncoder = Callable[[List[ModalityItem], List[MultimodalParams]], torch.Tensor]
+
+
+def encoder_dispatch(
+    index: ScatterIndices,
+    items: List[ModalityItem],
+    encoders: Dict[str, ModalityEncoder],
+    multimodal_params: List[MultimodalParams],
+) -> Dict[str, torch.Tensor]:
+    """Run one encoder per active modality; return per-modality output tensors."""
+    outputs: Dict[str, torch.Tensor] = {}
+    for modality in index.active_modalities:
+        bucket_items = [items[i] for i in index.modality_slots[modality].tolist()]
+        out = encoders[modality](bucket_items, multimodal_params)
+        expected = index.dst_indices[modality].numel()  # == sum of this bucket's rows
+        if out.shape[0] != expected:
+            # ValueError (not assert): an assert is compiled out under
+            # `python -O`, which would let a row-count mismatch flow into a
+            # wrong-shaped `index_copy_` below and silently corrupt the scatter.
+            raise ValueError(
+                f"encoder for {modality!r} returned {out.shape[0]} rows; expected "
+                f"{expected} (sum of item rows)"
+            )
+        outputs[modality] = out
+    return outputs
+
+
+def scatter_to_prompt_order(
+    index: ScatterIndices,
+    outputs_by_modality: Dict[str, torch.Tensor],
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+    hidden_dim: int,
+) -> torch.Tensor:
+    """Place per-modality outputs into the canonical prompt-ordered buffer."""
+    if index.total_tokens == 0:
+        return torch.empty((0, hidden_dim), dtype=dtype, device=device)
+    final = torch.empty((index.total_tokens, hidden_dim), dtype=dtype, device=device)
+    for modality in index.active_modalities:
+        dst = index.dst_indices[modality].to(device)
+        final.index_copy_(0, dst, outputs_by_modality[modality])
+    return final
+
+
+def encode_by_modality_and_scatter(
+    multimodal_params: List[MultimodalParams],
+    encoders: Dict[str, ModalityEncoder],
+    extract: ItemExtractor,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+    hidden_dim: int,
+) -> torch.Tensor:
+    """Model-facing entry point: flatten -> build index -> dispatch -> scatter.
+
+    Returns a tensor of shape `(index.total_tokens, hidden_dim)` in canonical
+    layout (per-param slices in source-param order; each slice in prompt order).
+    Caller wraps in `[final]` to satisfy the `get_multimodal_embeddings`
+    single-tensor cache contract.
+
+    Keeps the per-param cross-check that a param's summed item rows match its
+    declared `total_embeds_in_request` (the param<->context seam; skipped when
+    runtime metadata is absent, as for lightweight unit-test stubs).
+    """
+    items: List[ModalityItem] = [
+        item
+        for param_idx, param in enumerate(multimodal_params)
+        for item in extract(param_idx, param)
+    ]
+    index = build_scatter_index(items, num_params=len(multimodal_params))
+
+    # Vectorized cross-check: per-param row sums vs declared totals, masking params
+    # whose runtime metadata is absent. Reuses index.param_lengths (no second
+    # accumulation loop); the per-param attr read is the Python-object boundary.
+    declared, present = [], []
+    for param in multimodal_params:
+        runtime = getattr(param, "multimodal_runtime", None)
+        total = getattr(runtime, "total_embeds_in_request", None) if runtime else None
+        declared.append(0 if total is None else int(total))
+        present.append(total is not None)
+    present_t = torch.tensor(present, dtype=torch.bool)
+    declared_t = torch.tensor(declared, dtype=torch.int64)
+    mismatch = present_t & (index.param_lengths != declared_t)
+    if bool(mismatch.any()):
+        bad = int(mismatch.nonzero(as_tuple=True)[0][0])
+        raise ValueError(
+            f"param {bad}: sum(rows)={int(index.param_lengths[bad])} != "
+            f"total_embeds_in_request={int(declared_t[bad])}"
+        )
+
+    if index.total_tokens == 0:
+        return torch.empty((0, hidden_dim), dtype=dtype, device=device)
+    outputs_by_modality = encoder_dispatch(index, items, encoders, multimodal_params)
+    return scatter_to_prompt_order(
+        index, outputs_by_modality, device=device, dtype=dtype, hidden_dim=hidden_dim
+    )

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -1,5 +1,6 @@
 import copy
 import re
+from collections.abc import Mapping as AbcMapping
 from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -13,6 +14,10 @@ from transformers.models.qwen3_vl.modeling_qwen3_vl import (
     Qwen3VLVisionPatchEmbed as HFQwen3VLVisionPatchEmbed,
 )
 
+from tensorrt_llm._torch.models.mixed_modal_encode import (
+    ModalityItem,
+    encode_by_modality_and_scatter,
+)
 from tensorrt_llm._torch.models.modeling_multimodal_utils import _is_disagg
 from tensorrt_llm.functional import PositionEmbeddingType
 from tensorrt_llm.mapping import Mapping
@@ -29,7 +34,13 @@ from ...inputs import (
     register_input_processor,
     support_multimodal_disaggregated,
 )
-from ...inputs.multimodal import MultimodalParams
+from ...inputs.multimodal import (
+    MixedModalItemOrder,
+    MultimodalParams,
+    compute_mm_embedding_lengths,
+    find_mm_token_lengths,
+    scan_prompt_order,
+)
 from ...logger import logger
 from ...sampling_params import SamplingParams
 from ..attention_backend import AttentionMetadata
@@ -57,6 +68,211 @@ from .modeling_utils import (
     register_auto_model,
     register_vision_encoder,
 )
+
+_QWEN_MODALITIES = ("image", "video")
+_QWEN_PLACEHOLDERS = {
+    "image": ("<|vision_start|><|image_pad|><|vision_end|>", "<|image_pad|>"),
+    "video": ("<|vision_start|><|video_pad|><|vision_end|>", "<|video_pad|>"),
+}
+
+# Per-modality aggregate-payload keys: the pixel tensor and the `[N, 3]` grid that
+# describes its `N` sub-items. The slicer carves a single sub-item out of each.
+_QWEN3VL_PIXEL_KEY = {"image": "pixel_values", "video": "pixel_values_videos"}
+_QWEN3VL_GRID_KEY = {"image": "image_grid_thw", "video": "video_grid_thw"}
+
+
+def _qwen3vl_grid_to_2d(grid_thw) -> torch.Tensor:
+    """Normalize a Qwen3VL grid tensor to shape `[N, 3]` (one row per sub-item)."""
+    grid = torch.as_tensor(grid_thw)
+    if grid.ndim == 1:
+        grid = grid.reshape(1, 3)
+    if grid.ndim != 2 or grid.shape[1] != 3:
+        raise ValueError(f"grid_thw must have shape [3] or [N, 3], got {tuple(grid.shape)}")
+    return grid
+
+
+def _qwen3vl_grid_token_count(grid_thw, spatial_merge_size: int) -> int:
+    """Post-merge token count summed over a Qwen3VL grid tensor.
+
+    A grid may carry MULTIPLE sub-items (`[N, 3]`); the visual encoder emits the
+    summed post-merge rows across all `N` sub-grids. The per-grid post-merge count
+    is `t * (h // merge) * (w // merge)`, matching the visual encoder's merger
+    output. This is the single source for the per-grid formula (used by the
+    per-item slicer and `get_num_tokens_per_video`).
+    """
+    m = int(spatial_merge_size)
+    grid = _qwen3vl_grid_to_2d(grid_thw)
+    return sum(int(t) * (int(h) // m) * (int(w) // m) for t, h, w in grid.tolist())
+
+
+def _qwen3vl_slice_payload(
+    param: MultimodalParams,
+    modality: str,
+    mm_idx_per_modality: int,
+    spatial_merge_size: Optional[int] = None,
+) -> AbcMapping[str, Any]:
+    """Carve one sub-item out of a Qwen3VL aggregate payload (image / video).
+
+    A Qwen3VL modality payload is an AGGREGATE: `pixel_values` (resp.
+    `pixel_values_videos`) is every sub-item's patches concatenated, and
+    `*_grid_thw` is the `[N, 3]` grid describing those `N` sub-items. This slices
+    `pixel_values` by the raw-patch prefix sum `Sigma prod(grid_thw[:i])` (raw
+    rows per sub-item are `t*h*w`) and pairs the slice with that sub-item's
+    single-row grid, so a bucket adapter's re-concatenation reproduces the
+    original aggregate.
+
+    When `spatial_merge_size` is unset (test-convention payloads carrying an
+    explicit `num_tokens`, or pure single-modality requests), the single-sub-item
+    payload is returned whole; slicing a multi-sub-item payload requires the grid
+    + merge size.
+    """
+    payload = (param.multimodal_data or {})[modality]
+    pixel_key = _QWEN3VL_PIXEL_KEY[modality]
+    grid_key = _QWEN3VL_GRID_KEY[modality]
+    grid = payload.get(grid_key)
+    if grid is None or spatial_merge_size is None:
+        # No grid (or no merge size): single-sub-item / test-convention path.
+        # The aggregate IS the single item; hand it back unchanged.
+        if mm_idx_per_modality != 0:
+            raise ValueError(
+                f"cannot slice sub-item {mm_idx_per_modality} of {modality!r} "
+                "without *_grid_thw and spatial_merge_size"
+            )
+        return payload
+    grid_2d = _qwen3vl_grid_to_2d(grid)
+    # Raw patch rows per sub-item = t*h*w; pixel slice is the i-th block.
+    raw_rows = [int(t) * int(h) * int(w) for t, h, w in grid_2d.tolist()]
+    start = sum(raw_rows[:mm_idx_per_modality])
+    stop = start + raw_rows[mm_idx_per_modality]
+    sliced = dict(payload)
+    sliced[pixel_key] = payload[pixel_key][start:stop]
+    sliced[grid_key] = grid_2d[mm_idx_per_modality : mm_idx_per_modality + 1]
+    # An aggregate `num_tokens` (test convention) describes the whole blob,
+    # not this single sub-item; drop it so the sliced payload is not
+    # mis-sized by a stale count.
+    sliced.pop("num_tokens", None)
+    return sliced
+
+
+def _qwen3vl_grid_rows(
+    param: MultimodalParams,
+    modality: str,
+    mm_idx_per_modality: int,
+    spatial_merge_size: Optional[int] = None,
+) -> int:
+    """Per-grid post-merge row count for one Qwen3VL sub-item.
+
+    `t*(h//m)*(w//m)` (the encoder-output row count == scatter footprint), the
+    Qwen3VL source of truth. Used as the fallback row source when the extractor
+    has no `MixedModalItemOrder` (pure single-modality); when a context is
+    present, per-item rows come from `ctx.embedding_lengths` instead. Falls back
+    to a test-convention `num_tokens` or `multimodal_runtime.total_embeds_in_request`
+    when the grid + merge size are unavailable.
+    """
+    payload = (param.multimodal_data or {})[modality]
+    grid = payload.get(_QWEN3VL_GRID_KEY[modality])
+    if spatial_merge_size is not None and grid is not None:
+        # Encoder-accurate per-sub-item post-merge count (the source of truth).
+        grid_2d = _qwen3vl_grid_to_2d(grid)
+        return _qwen3vl_grid_token_count(
+            grid_2d[mm_idx_per_modality : mm_idx_per_modality + 1],
+            spatial_merge_size,
+        )
+    # Test-convention / single-sub-item fallbacks (no grid+merge available).
+    if "num_tokens" in payload:
+        return int(payload["num_tokens"])
+    runtime = getattr(param, "multimodal_runtime", None)
+    total = getattr(runtime, "total_embeds_in_request", None) if runtime else None
+    if total is not None:
+        return int(total)
+    raise ValueError(
+        "Cannot determine row count for Qwen3VL payload; needs *_grid_thw + "
+        "spatial_merge_size, num_tokens, or "
+        "multimodal_runtime.total_embeds_in_request"
+    )
+
+
+def _qwen3vl_item_count(param: MultimodalParams, modality: str) -> int:
+    """Number of sub-items packed into a Qwen3VL aggregate modality payload.
+
+    The `*_grid_thw` grid carries one row per sub-item, so its row count is the
+    sub-item count (e.g. a 2-image prompt has a `[2, 3]` `image_grid_thw`).
+    Falls back to 1 when no grid is present (the test-convention single-item
+    payload carrying an explicit `num_tokens`).
+    """
+    payload = (param.multimodal_data or {})[modality]
+    grid = payload.get(_QWEN3VL_GRID_KEY[modality])
+    if grid is None:
+        return 1
+    return _qwen3vl_grid_to_2d(grid).shape[0]
+
+
+def _qwen3vl_extract_items(param_idx: int, param, spatial_merge_size: Optional[int] = None):
+    """Yield one canonical `ModalityItem` per Qwen3VL prompt slot.
+
+    Qwen3VL has only image and video modalities; no audio, no ghost items. The
+    extractor parses the two wire keys (`multimodal_item_order` +
+    `multimodal_embedding_lengths`) into one validated typed view at the point of
+    use via `MixedModalItemOrder.from_metadata`, then walks `ctx.order` and
+    emits one item per entry: each owns its prompt rank (`prompt_pos`), slices its
+    single-item payload out of the aggregate `pixel_values`/`*_grid_thw` blob, and
+    sizes its `rows` from the per-grid post-merge count (the encoder-output row
+    count == scatter footprint). Interleaved repeated modalities
+    (`image -> video -> image`) are just three slots scattered by `prompt_pos`; no
+    special case.
+
+    Option Y: no `MultimodalParams` field is added and the dict keys stay the wire
+    format; the context is built transiently here and lives only inside the
+    extractor. `from_metadata` returns None for pure single-modality requests (no
+    `multimodal_item_order` key); the modality-major default order is synthesized
+    in that case over the real per-modality sub-item counts, so a multi-item
+    single-modality request (e.g. 2 images) enumerates every sub-item.
+    """
+    multimodal_data = param.multimodal_data or {}
+    modality_types = [m for m in _QWEN_MODALITIES if multimodal_data.get(m) is not None]
+    if not modality_types:
+        return
+
+    # Build the transient encode context from the wire keys. `from_metadata`
+    # normalizes dict-form order entries (`{"modality": ..., "index": ...}`, as
+    # the runtime registry emits) and tuple-form entries alike to `(modality,
+    # index)` pairs, and validates length agreement with
+    # `multimodal_embedding_lengths`. A raw `tuple(pair)` over dict entries would
+    # yield the dict keys and silently collapse every item to default slot 0.
+    ctx = MixedModalItemOrder.from_metadata(
+        multimodal_data, multimodal_data.get("multimodal_embedding_lengths")
+    )
+    if ctx is not None:
+        order = ctx.order
+    else:
+        # Pure single-modality (no explicit prompt order metadata): synthesize
+        # the modality-major default order over the real per-modality sub-item
+        # counts (the `*_grid_thw` row count). A multi-item single-modality
+        # request (e.g. 2 images) must enumerate EVERY sub-item; a flat
+        # `(m, 0)` per modality would silently drop the 2nd+ item.
+        order = tuple(
+            (m, idx) for m in modality_types for idx in range(_qwen3vl_item_count(param, m))
+        )
+
+    for prompt_pos, (modality, mm_idx) in enumerate(order):
+        if multimodal_data.get(modality) is None:
+            continue
+        # Per-item rows come from the encode context's per-slot
+        # `embedding_lengths` (the single source of truth); the grid-derived
+        # count is the fallback for pure single-modality requests with no context.
+        rows = (
+            int(ctx.embedding_lengths[prompt_pos])
+            if ctx is not None
+            else _qwen3vl_grid_rows(param, modality, mm_idx, spatial_merge_size)
+        )
+        yield ModalityItem(
+            src_param_idx=param_idx,
+            modality=modality,
+            mm_idx_per_modality=mm_idx,
+            prompt_pos=prompt_pos,
+            rows=rows,
+            payload=_qwen3vl_slice_payload(param, modality, mm_idx, spatial_merge_size),
+        )
 
 
 class Qwen3VLInputProcessorBase(BaseMultimodalInputProcessor, BaseMultimodalDummyInputsBuilder):
@@ -110,6 +326,18 @@ class Qwen3VLInputProcessorBase(BaseMultimodalInputProcessor, BaseMultimodalDumm
     def get_vocab_size(self) -> int:
         """Return the vocab size of the model."""
         return self.config.text_config.vocab_size
+
+    def _get_mm_item_order_from_text(
+        self,
+        text_prompt: str,
+        mm_data: Dict[str, Any],
+    ) -> List[Tuple[str, int]]:
+        """Infer Qwen image/video item order from placeholder order in text."""
+        normalized = MixedModalItemOrder._normalize(mm_data)
+        expected_counts = {
+            modality: len(normalized.get(modality, [])) for modality in _QWEN_MODALITIES
+        }
+        return scan_prompt_order(text_prompt, _QWEN_PLACEHOLDERS, expected_counts)
 
     @classmethod
     def get_rope_index(
@@ -266,8 +494,7 @@ class Qwen3VLInputProcessorBase(BaseMultimodalInputProcessor, BaseMultimodalDumm
     ) -> int:
         merge = self.config.vision_config.spatial_merge_size
         if video_grid_thw is not None:
-            t, h, w = (int(x) for x in video_grid_thw)
-            return t * (h // merge) * (w // merge)
+            return _qwen3vl_grid_token_count(video_grid_thw, merge)
 
         # Must run the full processor: HF's Qwen3VLProcessor._get_num_multimodal_tokens
         # (what the base class default delegates to) raises on video-only calls
@@ -287,8 +514,7 @@ class Qwen3VLInputProcessorBase(BaseMultimodalInputProcessor, BaseMultimodalDumm
                 "get_num_tokens_per_video: HF processor returned no "
                 "video_grid_thw for the provided video."
             )
-        t, h, w = (int(x) for x in vgt[0].tolist())
-        return t * (h // merge) * (w // merge)
+        return _qwen3vl_grid_token_count(vgt, merge)
 
     def _preprocess(
         self, text: Dict[str, Any], mm_data: Dict[str, Any], mm_processor_kwargs: Dict[str, Any]
@@ -365,6 +591,14 @@ class Qwen3VLInputProcessorBase(BaseMultimodalInputProcessor, BaseMultimodalDumm
             processed_inputs = self._preprocess(text_prompt, mm_data, mm_processor_kwargs)
 
         multimodal_data = {}
+        normalized_mm_data = MixedModalItemOrder._normalize(mm_data)
+        modalities = [modality for modality in _QWEN_MODALITIES if normalized_mm_data.get(modality)]
+        item_order = None
+        if len(modalities) > 1:
+            item_order = self._get_mm_item_order_from_text(text_prompt, mm_data)
+            multimodal_data["multimodal_item_order"] = [
+                {"modality": modality, "index": idx} for modality, idx in item_order
+            ]
         pixel_values = processed_inputs.get("pixel_values", None)
         if pixel_values is not None:
             multimodal_data["image"] = {
@@ -391,6 +625,29 @@ class Qwen3VLInputProcessorBase(BaseMultimodalInputProcessor, BaseMultimodalDumm
         fused_input_ids = processed_inputs["input_ids"][0]
         if mm_data:
             fused_input_ids = self._postprocess(fused_input_ids)
+
+        # Mixed-modality (>1 distinct modality): bake the per-item embedding
+        # lengths alongside the item order so the non-hashing (direct preprocess)
+        # path produces the same metadata the registry hashing path does. Without
+        # this, the per-item extractor's
+        # MixedModalItemOrder.from_metadata(..., None) hits
+        # tuple(int(x) for x in None) -> TypeError. Computed AFTER fused_input_ids
+        # is finalized (post-_postprocess) and the image/video multimodal_data
+        # keys are populated, since find_mm_token_lengths reads video_grid_thw
+        # from multimodal_data["video"] and the embed mask is derived from the
+        # returned fused_input_ids.
+        if item_order is not None:
+            num_mm_tokens_by_key = find_mm_token_lengths(
+                mm_data, self, multimodal_data=multimodal_data
+            )
+            num_mm_tokens = MixedModalItemOrder.project_by_order(item_order, num_mm_tokens_by_key)
+            multimodal_data["multimodal_embedding_lengths"] = compute_mm_embedding_lengths(
+                fused_input_ids,
+                num_mm_tokens,
+                vocab_size=self.get_vocab_size(),
+                mm_token_ids=self.get_mm_token_ids(),
+                mm_special_token_ids=self.get_mm_special_token_ids(),
+            )
 
         return fused_input_ids.to(torch.int32).tolist(), {
             "multimodal_data": multimodal_data,
@@ -914,91 +1171,62 @@ class Qwen3VisionModelBase(nn.Module):
         self.visual.config.num_attention_heads = self.visual.config.num_heads
         _load_weights_impl(self.visual, converted_weights, params_map=pattern_mapping)
 
-    def _parse_and_batch_multimodal_data(
-        self, multimodal_params: List[MultimodalParams]
-    ) -> Tuple[Dict[str, Any], Dict[str, List[Any]]]:
-        pixel_values_list = []
-        pixel_values_videos_list = []
-        image_grid_thw_list = []
-        video_grid_thw_list = []
+    def _encode_visual_inputs(
+        self,
+        pixel_values: torch.Tensor,
+        grid_thw: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run the Qwen visual encoder and concatenate deepstack features."""
+        embeds, deepstack_embeds = self.visual(pixel_values.to(self.model_dtype), grid_thw=grid_thw)
+        return torch.cat([embeds] + deepstack_embeds, dim=1)
 
-        for multimodal_param in multimodal_params:
-            multimodal_data = multimodal_param.multimodal_data
-            # Process images if present
-            if multimodal_data.get("image") is not None:
-                pixel_values_list.append(multimodal_data["image"]["pixel_values"])
-                image_grid_thw_list.append(multimodal_data["image"]["image_grid_thw"])
+    def _image_encoder_adapter(self, items, multimodal_params):
+        """Stack per-item image pixel_values + grids, encode in one call."""
+        pixel_values = torch.cat([it.payload["pixel_values"] for it in items], dim=0)
+        grid = torch.cat([it.payload["image_grid_thw"] for it in items], dim=0)
+        return self._encode_visual_inputs(pixel_values, grid)
 
-            # Process videos if present
-            if multimodal_data.get("video") is not None:
-                pixel_values_videos_list.append(multimodal_data["video"]["pixel_values_videos"])
-                video_grid_thw_list.append(multimodal_data["video"]["video_grid_thw"])
+    def _video_encoder_adapter(self, items, multimodal_params):
+        """Stack per-item video pixel_values + grids, encode in one call."""
+        pixel_values = torch.cat([it.payload["pixel_values_videos"] for it in items], dim=0)
+        grid = torch.cat([it.payload["video_grid_thw"] for it in items], dim=0)
+        return self._encode_visual_inputs(pixel_values, grid)
 
-        # Concatenate tensors
-        mm_content_dict = {}
-        if pixel_values_list:
-            mm_content_dict["pixel_values"] = (
-                torch.cat(pixel_values_list, dim=0)
-                if len(pixel_values_list) > 1
-                else pixel_values_list[0]
-            )
-        if pixel_values_videos_list:
-            mm_content_dict["pixel_values_videos"] = (
-                torch.cat(pixel_values_videos_list, dim=0)
-                if len(pixel_values_videos_list) > 1
-                else pixel_values_videos_list[0]
-            )
+    def _plan_hidden_dim(self) -> int:
+        """Hidden width of the assembled visual embeddings.
 
-        # Prepare extra data
-        mm_extra_data = {}
-        if image_grid_thw_list:
-            mm_extra_data["image_grid_thw"] = (
-                torch.cat(image_grid_thw_list, dim=0)
-                if len(image_grid_thw_list) > 1
-                else image_grid_thw_list[0]
-            )
-        if video_grid_thw_list:
-            mm_extra_data["video_grid_thw"] = (
-                torch.cat(video_grid_thw_list, dim=0)
-                if len(video_grid_thw_list) > 1
-                else video_grid_thw_list[0]
-            )
-
-        return mm_content_dict, mm_extra_data
+        `_encode_visual_inputs` returns `torch.cat([embeds] + deepstack_embeds, dim=1)`.
+        Each merger (main + per-deepstack-level) projects to `vision_config.out_hidden_size`,
+        so the concatenated width is `out_hidden_size * (1 + num_deepstack_levels)`. This
+        mirrors the `expected_size` validation in `Qwen3VLInputProcessorBase`.
+        """
+        num_deepstack_levels = len(getattr(self.config, "deepstack_visual_indexes", []))
+        return int(self.config.out_hidden_size) * (1 + num_deepstack_levels)
 
     @torch.inference_mode()
     def forward(self, multimodal_params: List[MultimodalParams]) -> List[torch.Tensor]:
-        mm_content_data, mm_extra_data = self._parse_and_batch_multimodal_data(multimodal_params)
-        pixel_values = mm_content_data.get("pixel_values", None)
-        pixel_values_videos = mm_content_data.get("pixel_values_videos", None)
-
-        if pixel_values is not None and pixel_values_videos is not None:
-            raise ValueError("Currently only support single modality per request")
-
-        image_grid_thw = mm_extra_data.get("image_grid_thw", None)
-        video_grid_thw = mm_extra_data.get("video_grid_thw", None)
-
-        embeds = []
-        if pixel_values is not None:
-            pixel_values = pixel_values.to(self.model_dtype)
-            image_embeds, deepstack_image_embeds = self.visual(
-                pixel_values, grid_thw=image_grid_thw
-            )
-            # NOTE: We concatenate deepstack_embeds to mm_embeds
-            # The shape will be [seq_len, hidden_dim * (num_deepstack_layers + 1)]
-            mixed_image_embeds = torch.cat([image_embeds] + deepstack_image_embeds, dim=1)
-            embeds.append(mixed_image_embeds)
-
-        if pixel_values_videos is not None:
-            pixel_values_videos = pixel_values_videos.to(self.model_dtype)
-            video_embeds, deepstack_video_embeds = self.visual(
-                pixel_values_videos, grid_thw=video_grid_thw
-            )
-            # NOTE: We concatenate deepstack_embeds to mm_embeds
-            # The shape will be [seq_len, hidden_dim * (num_deepstack_layers + 1)]
-            mixed_video_embeds = torch.cat([video_embeds] + deepstack_video_embeds, dim=1)
-            embeds.append(mixed_video_embeds)
-        return embeds
+        if not multimodal_params:
+            return []
+        # Thread `spatial_merge_size` so the extractor can size aggregate
+        # (multi-sub-item) image/video payloads to their full post-merge row
+        # count via the grid, matching the visual encoder's output.
+        spatial_merge_size = self.config.spatial_merge_size
+        final = encode_by_modality_and_scatter(
+            multimodal_params=multimodal_params,
+            encoders={
+                "image": self._image_encoder_adapter,
+                "video": self._video_encoder_adapter,
+            },
+            extract=lambda param_idx, param: _qwen3vl_extract_items(
+                param_idx, param, spatial_merge_size=spatial_merge_size
+            ),
+            # Allocate the assembled embeddings on the visual encoder's device,
+            # with its (model) dtype.
+            device=next(self.visual.parameters()).device,
+            dtype=self.model_dtype,
+            hidden_dim=self._plan_hidden_dim(),
+        )
+        return [final] if final.shape[0] > 0 else []
 
 
 class Qwen3VLModelBase(PreTrainedModel):

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -3,7 +3,7 @@
 """Multimodal utilities for handling images and other media types in TensorRT-LLM."""
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -17,6 +17,11 @@ from tensorrt_llm.logger import logger
 # Default hasher
 default_hasher = blake3
 _INT32_MAX = 2**31 - 1
+_MULTIMODAL_RUN_METADATA_KEYS = (
+    "multimodal_item_run_cu_offsets",
+    "multimodal_run_positions",
+    "multimodal_run_lengths",
+)
 
 # Versioned tag prefixed to every content hash so the canonical, self-describing
 # serialization scheme can evolve without silently reusing stale cache keys.
@@ -40,6 +45,74 @@ def strip_mm_data_for_generation(mm_data: Dict[str, Any]) -> None:
     mm_data.clear()
     if mrope_deltas is not None:
         mm_data['mrope_config'] = {'mrope_position_deltas': mrope_deltas}
+
+
+def scan_prompt_order(
+    text: str,
+    placeholder_by_modality: Dict[str, Union[str, Iterable[str]]],
+    expected_counts: Dict[str, int],
+) -> List[Tuple[str, int]]:
+    """Walk a decoded prompt left-to-right and return its multimodal item order.
+
+    Shared scanner behind the per-model `_get_mm_item_order_from_text` hooks
+    (Nano and Qwen3VL): both compute item order from placeholder positions in the
+    decoded prompt; only the placeholder strings differ.
+
+    From a moving cursor, repeatedly pick the nearest next placeholder among
+    modalities still below `expected_counts`, append `(modality, running_index)`,
+    and advance the cursor past that placeholder. A modality may register several
+    placeholder spellings (e.g. a fused long form and a bare short form); on a
+    position tie the longer placeholder wins so the cursor clears the whole long
+    form rather than re-matching its short substring. Falsy placeholder strings
+    are skipped. At the end, raise `ValueError` if any modality's observed count
+    differs from its expected count.
+
+    Args:
+        text: The decoded prompt string to scan.
+        placeholder_by_modality: Maps each modality to one placeholder string or
+            an iterable of placeholder strings.
+        expected_counts: Maps each modality to the number of items expected.
+
+    Returns:
+        The `(modality, item_index)` entries in prompt placeholder order.
+    """
+    placeholders_by_modality: Dict[str, Tuple[str, ...]] = {}
+    for modality, placeholders in placeholder_by_modality.items():
+        if isinstance(placeholders, str):
+            placeholders = (placeholders, )
+        placeholders_by_modality[modality] = tuple(p for p in placeholders if p)
+
+    actual_counts = {modality: 0 for modality in expected_counts}
+    item_order: List[Tuple[str, int]] = []
+    cursor = 0
+    while cursor < len(text):
+        # Best match so far as (position, placeholder_len, modality); a smaller
+        # position wins, and a longer placeholder breaks a position tie.
+        next_match: Optional[Tuple[int, int, str]] = None
+        for modality, placeholders in placeholders_by_modality.items():
+            if actual_counts[modality] >= expected_counts.get(modality, 0):
+                continue
+            for placeholder in placeholders:
+                position = text.find(placeholder, cursor)
+                if position < 0:
+                    continue
+                if (next_match is None or position < next_match[0]
+                        or (position == next_match[0]
+                            and len(placeholder) > next_match[1])):
+                    next_match = (position, len(placeholder), modality)
+        if next_match is None:
+            break
+        position, placeholder_len, modality = next_match
+        item_order.append((modality, actual_counts[modality]))
+        actual_counts[modality] += 1
+        cursor = position + placeholder_len
+
+    for modality, expected in expected_counts.items():
+        if actual_counts[modality] != expected:
+            raise ValueError(
+                f"Expected {expected} {modality} placeholder(s), found "
+                f"{actual_counts[modality]} while resolving prompt order.")
+    return item_order
 
 
 @dataclass
@@ -259,13 +332,223 @@ class MultimodalInput:
                    multimodal_run_positions=mm_run_positions,
                    multimodal_run_lengths=mm_run_lengths)
 
-    def to_tensor(self) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Convert data to tensors"""
-        return (
-            # int32 to match the type in TRTLLM SizeType32
-            torch.tensor(self.multimodal_hashes, dtype=torch.int32),
-            torch.tensor(self.multimodal_positions, dtype=torch.int32),
-            torch.tensor(self.multimodal_lengths, dtype=torch.int32))
+
+_SUPPORTED_HASHING_MODALITIES = ("image", "video", "audio")
+
+
+@dataclass(frozen=True)
+class MixedModalItemOrder:
+    """Per-request mixed-modality encode bookkeeping (Python-only).
+
+    Holds the prompt-order spine and each item's encoder-output footprint, and
+    owns the full order lifecycle: parse (`order_from_metadata` /
+    `from_raw_entries`), resolve (`resolve_order`), validate
+    (`validate_order` + the order-only `__post_init__` checks), normalize
+    payload shape (`_normalize`), and project per-modality collections into
+    prompt order (`project_by_order` / `project_uuids_by_order`).
+
+    `MultimodalInput` owns the token-space layout that crosses to C++; this
+    owns the encode-space layout that stays in Python. Not a general bag:
+    exactly `order` + `embedding_lengths` belong on the instance. The prompt
+    position of item i is its index in `order`. Producers that only have the
+    bare prompt order (no per-item lengths yet) call the classmethods/
+    staticmethods directly and never build an instance.
+
+    Named for its discriminator 'prompt'-order spine: this subsystem has three
+    distinct orders (prompt, modality-grouped encode, per-request cache); the
+    `order` field is the prompt one.
+    """
+
+    order: Tuple[Tuple[str, int], ...]
+    embedding_lengths: Tuple[int, ...]
+
+    def __post_init__(self):
+        if len(self.order) != len(self.embedding_lengths):
+            raise ValueError(
+                f"order length ({len(self.order)}) != embedding_lengths length "
+                f"({len(self.embedding_lengths)})")
+        seen: set = set()
+        for modality, idx in self.order:
+            if (modality, idx) in seen:
+                raise ValueError(
+                    f"order references {modality}[{idx}] more than once; each "
+                    "item must be referenced exactly once")
+            seen.add((modality, idx))
+
+    # ---- Payload normalization ----
+
+    @staticmethod
+    def _normalize(mm_data: Dict[str, Any]) -> Dict[str, List[Any]]:
+        """Return modality payloads in list form for item-order validation.
+
+        `multi_modal_data` accepts both a single item and a list of items for a
+        modality, while ordering logic needs item counts and stable indexing.
+        This is not only defensive: it is the canonical boundary between
+        flexible user payload shape and the internal `(modality, item_index)`
+        ordering contract. Non-modality metadata entries are intentionally
+        ignored.
+        """
+        return {
+            modality: items if isinstance(items, list) else [items]
+            for modality, items in mm_data.items()
+            if modality in _SUPPORTED_HASHING_MODALITIES and items is not None
+        }
+
+    # ---- Order constructors (bare prompt-order tuples) ----
+
+    @staticmethod
+    def default_order(
+            mm_items: Dict[str, List[Any]]) -> Tuple[Tuple[str, int], ...]:
+        """Return deterministic modality-major order when no explicit order exists."""
+        return tuple((modality, idx) for modality, items in mm_items.items()
+                     for idx in range(len(items)))
+
+    @staticmethod
+    def from_raw_entries(entries: Iterable[Any], *,
+                         source: str) -> Tuple[Tuple[str, int], ...]:
+        """Normalize order metadata to `(modality, item_index)` pairs.
+
+        Accepted metadata shapes are `(modality, index)` pairs and dicts.
+        """
+        counters: Dict[str, int] = {}
+        item_order: List[Tuple[str, int]] = []
+        for entry in entries:
+            if isinstance(entry, dict):
+                modality = entry.get("modality", entry.get("type"))
+                item_index = entry.get("index", entry.get("item_index"))
+                if item_index is None:
+                    item_index = counters.get(modality, 0)
+            else:
+                try:
+                    modality, item_index = entry
+                except (TypeError, ValueError) as exc:
+                    raise ValueError(
+                        f"{source} entries must be (modality, index) pairs "
+                        "or dicts") from exc
+            if not isinstance(modality, str):
+                raise ValueError(
+                    f"{source} entry has non-string modality: {entry!r}")
+            item_index = int(item_index)
+            item_order.append((modality, item_index))
+            counters[modality] = max(counters.get(modality, 0), item_index + 1)
+        return tuple(item_order)
+
+    @classmethod
+    def order_from_metadata(
+        cls, multimodal_data: Optional[Dict[str, Any]]
+    ) -> Optional[Tuple[Tuple[str, int], ...]]:
+        """Extract the explicit prompt order from processed metadata.
+
+        Returns `None` when no ordering key is present, so callers can
+        distinguish 'absent' from 'empty'.
+        """
+        if not multimodal_data:
+            return None
+        if "multimodal_item_order" in multimodal_data:
+            return cls.from_raw_entries(
+                multimodal_data["multimodal_item_order"],
+                source="multimodal_item_order")
+        return None
+
+    @classmethod
+    def resolve_order(
+        cls,
+        mm_data: Dict[str, Any],
+        *,
+        multimodal_data: Optional[Dict[str, Any]] = None,
+    ) -> Tuple[Tuple[str, int], ...]:
+        """Resolve the prompt order for every multimodal item in a request.
+
+        Every mixed preprocess path bakes an explicit `multimodal_item_order`
+        into the processed metadata (the text paths always did; the token-id
+        fast path does after expanding from the real prompt token IDs), so this
+        is purely `metadata | default_order`: the baked order wins when present,
+        otherwise the deterministic modality-major default applies. Returns a
+        bare `(modality, index)` tuple; the producer pairs it with per-item
+        lengths separately (Option Y: the dict keys remain the wire format and a
+        full context is built only at the point of use).
+        """
+        mm_items = cls._normalize(mm_data)
+        order = cls.order_from_metadata(multimodal_data)
+        if order is None:
+            order = cls.default_order(mm_items)
+        cls.validate_order(order, mm_items)
+        return order
+
+    @classmethod
+    def from_metadata(
+            cls, multimodal_data: Optional[Dict[str, Any]],
+            embedding_lengths: Iterable[int]
+    ) -> Optional["MixedModalItemOrder"]:
+        """Pair the explicit prompt order (if any) with per-item lengths.
+
+        Returns `None` when no `multimodal_item_order` key is present, so the
+        per-item extractors can fall back to a synthesized default order.
+        """
+        order = cls.order_from_metadata(multimodal_data)
+        if order is None:
+            return None
+        return cls(order=order,
+                   embedding_lengths=tuple(int(x) for x in embedding_lengths))
+
+    # ---- Validation ----
+
+    @staticmethod
+    def validate_order(order: Tuple[Tuple[str, int], ...],
+                       mm_items: Dict[str, List[Any]]) -> None:
+        """Verify `order` references every multimodal item exactly once."""
+        # Track the distinct indices seen per modality (a set, not a count) so a
+        # repeated reference cannot masquerade as full coverage.
+        seen: Dict[str, set] = {modality: set() for modality in mm_items}
+        for modality, idx in order:
+            if modality not in mm_items:
+                raise ValueError(
+                    f"Multimodal item order references modality '{modality}', "
+                    f"but multi_modal_data only has {list(mm_items)}")
+            if idx < 0 or idx >= len(mm_items[modality]):
+                raise ValueError(
+                    f"Multimodal item order references {modality}[{idx}], "
+                    f"but that modality has {len(mm_items[modality])} item(s)")
+            if idx in seen[modality]:
+                raise ValueError(
+                    f"Multimodal item order references {modality}[{idx}] more "
+                    f"than once; each item must be referenced exactly once")
+            seen[modality].add(idx)
+        # With the range check above and per-modality uniqueness, matching the
+        # distinct-index count to len(items) guarantees exactly-once coverage by
+        # pigeonhole.
+        for modality, items in mm_items.items():
+            if len(seen[modality]) != len(items):
+                raise ValueError(
+                    f"Multimodal item order covers {len(seen[modality])} "
+                    f"{modality} item(s), expected {len(items)}")
+
+    # ---- Projections ----
+
+    @staticmethod
+    def project_by_order(order: Tuple[Tuple[str, int], ...],
+                         values_by_key: Dict[str, List[Any]]) -> List[Any]:
+        """Project per-modality values into prompt order (bare-order form)."""
+        return [values_by_key[modality][idx] for modality, idx in order]
+
+    @staticmethod
+    def project_uuids_by_order(
+        order: Tuple[Tuple[str, int], ...],
+        mm_uuids: Optional[Dict[str, List[Optional[str]]]],
+    ) -> Optional[List[Optional[str]]]:
+        """Project optional per-modality UUIDs into prompt order (bare-order form)."""
+        if mm_uuids is None:
+            return None
+        ordered: List[Optional[str]] = []
+        for modality, idx in order:
+            modality_uuids = mm_uuids.get(modality)
+            if modality_uuids is None:
+                ordered.append(None)
+                continue
+            if not isinstance(modality_uuids, list):
+                modality_uuids = [modality_uuids]
+            ordered.append(modality_uuids[idx])
+        return ordered
 
 
 @dataclass
@@ -329,6 +612,9 @@ class MultimodalRuntimeData:
 # Extend only after auditing each key's consumers.
 _CPU_ONLY_MULTIMODAL_DATA_KEYS = frozenset({
     "multimodal_embed_mask_cumsum",
+    "multimodal_embedding_lengths",
+    "multimodal_item_order",
+    *_MULTIMODAL_RUN_METADATA_KEYS,
 })
 
 
@@ -365,7 +651,8 @@ class MultimodalParams:
                 "video_height": torch.Tensor | List[int],
                 "video_width": torch.Tensor | List[int],
             },
-            "special_token_offsets": List[int],          # List of starting positions of special tokens in the union of all multimodal token chunks, if available
+            # List of starting positions of special tokens in the union of all multimodal token chunks, if available
+            "special_token_offsets": List[int],
             # ... other modalities
         }
     """
@@ -781,30 +1068,6 @@ def hexdigest_to_int32(hex_digest: str) -> List[int]:
     return result
 
 
-def int32_to_hexdigest(int32_values: List[int]) -> str:
-    """Convert 8 int32 values back to a 64-character hexadecimal digest.
-
-    This is the inverse of hexdigest_to_int32.
-
-    Args:
-        int32_values: List of 8 signed int32 values
-
-    Returns:
-        64-character hexadecimal string representing the 32-byte hash
-    """
-    if len(int32_values) != 8:
-        raise ValueError(f"Expected 8 int32 values, got {len(int32_values)}")
-
-    result = []
-    for value in int32_values:
-        # Convert signed int32 back to unsigned
-        if value < 0:
-            value = value + 0x100000000
-        # Format as 8 hex characters (zero-padded)
-        result.append(f'{value:08x}')
-    return ''.join(result)
-
-
 def find_mm_token_lengths(
     mm_data: Dict[str, Any],
     input_processor: Any,
@@ -831,8 +1094,9 @@ def find_mm_token_lengths(
     for modality, items in mm_items.items():
         if not hasattr(input_processor, f"get_num_tokens_per_{modality}"):
             raise AttributeError(
-                f"Input processor {type(input_processor).__name__} does not have 'get_num_tokens_per_{modality}' method required for multimodal hashing."
-            )
+                f"Input processor {type(input_processor).__name__} does not have "
+                f"'get_num_tokens_per_{modality}' method required for "
+                "multimodal hashing.")
 
         video_grid_thw_for_items = None
         if modality == "video" and video_grid_thw is not None:
@@ -896,6 +1160,9 @@ def find_mm_token_lengths(
 _MM_METADATA_ONLY_KEYS = frozenset({
     "mrope_config",
     "multimodal_embed_mask_cumsum",
+    "multimodal_embedding_lengths",
+    "multimodal_item_order",
+    *_MULTIMODAL_RUN_METADATA_KEYS,
     "special_token_offsets",
     "layout_metadata",
 })
@@ -1130,6 +1397,70 @@ def _find_mm_token_runs_from_mask(
         item_run_cu_offsets.append(len(run_positions))
 
     return item_run_cu_offsets, run_positions, run_lengths
+
+
+def _find_mm_embedding_lengths_from_masks(
+    mm_mask: torch.Tensor,
+    embed_mask: torch.Tensor,
+    num_mm_tokens: List[int],
+) -> List[int]:
+    """Compute per-item embedding-token counts from multimodal masks."""
+    if not torch.any(mm_mask):
+        return []
+
+    mm_positions = torch.where(mm_mask)[0]
+    lengths_t = torch.tensor(num_mm_tokens)
+    assert mm_positions.numel() == lengths_t.sum().item(), (
+        f"Number of multimodal tokens ({mm_positions.numel()}) does not match "
+        f"sum of per-unit lengths ({lengths_t.sum().item()}): "
+        f"num_mm_tokens={num_mm_tokens}")
+
+    embedding_lengths: List[int] = []
+    offset = 0
+    for item_length in num_mm_tokens:
+        item_positions = mm_positions[offset:offset + item_length]
+        offset += item_length
+        embedding_lengths.append(int(embed_mask[item_positions].sum().item()))
+    return embedding_lengths
+
+
+def compute_mm_embedding_lengths(
+    input_ids: Union[torch.Tensor, List[int], np.ndarray],
+    num_mm_tokens: List[int],
+    *,
+    vocab_size: Optional[int],
+    mm_token_ids: Optional[torch.Tensor],
+    mm_special_token_ids: Optional[torch.Tensor],
+) -> List[int]:
+    """Compute per-item multimodal embedding-token counts for one prompt.
+
+    Derives the embed mask from the provided vocab size / multimodal token id
+    predicates, then counts embed-slot tokens per logical item described by
+    `num_mm_tokens`. This is the single source of truth for the mask -> per-item
+    embedding-length derivation shared by the Nano and Qwen3-VL preprocess paths
+    and the registry hashing path.
+
+    Args:
+        input_ids: Prompt token ids (CPU-resident); coerced to a tensor.
+        num_mm_tokens: Per-item multimodal token counts in prompt order.
+        vocab_size: Tokenizer/model vocab size; positions >= this are embed
+            slots when `mm_token_ids` is not provided.
+        mm_token_ids: Optional explicit embed-slot token ids (takes precedence
+            over `vocab_size`).
+        mm_special_token_ids: Optional in-prompt framing token ids excluded from
+            the embed mask.
+
+    Returns:
+        Per-item embedding-token counts aligned with `num_mm_tokens`.
+    """
+    mm_mask, embed_mask, _ = _compute_mm_masks(
+        _as_cpu_tensor(input_ids),
+        vocab_size=vocab_size,
+        mm_token_ids=mm_token_ids,
+        mm_special_token_ids=mm_special_token_ids,
+    )
+    return _find_mm_embedding_lengths_from_masks(mm_mask, embed_mask,
+                                                 num_mm_tokens)
 
 
 def validate_mm_inputs(prompt_token_ids: Union[torch.Tensor, List[int],

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -1068,6 +1068,30 @@ def hexdigest_to_int32(hex_digest: str) -> List[int]:
     return result
 
 
+def int32_to_hexdigest(int32_values: List[int]) -> str:
+    """Convert 8 int32 values back to a 64-character hexadecimal digest.
+
+    This is the inverse of hexdigest_to_int32.
+
+    Args:
+        int32_values: List of 8 signed int32 values
+
+    Returns:
+        64-character hexadecimal string representing the 32-byte hash
+    """
+    if len(int32_values) != 8:
+        raise ValueError(f"Expected 8 int32 values, got {len(int32_values)}")
+
+    result = []
+    for value in int32_values:
+        # Convert signed int32 back to unsigned
+        if value < 0:
+            value = value + 0x100000000
+        # Format as 8 hex characters (zero-padded)
+        result.append(f'{value:08x}')
+    return ''.join(result)
+
+
 def find_mm_token_lengths(
     mm_data: Dict[str, Any],
     input_processor: Any,
@@ -1410,10 +1434,11 @@ def _find_mm_embedding_lengths_from_masks(
 
     mm_positions = torch.where(mm_mask)[0]
     lengths_t = torch.tensor(num_mm_tokens)
-    assert mm_positions.numel() == lengths_t.sum().item(), (
-        f"Number of multimodal tokens ({mm_positions.numel()}) does not match "
-        f"sum of per-unit lengths ({lengths_t.sum().item()}): "
-        f"num_mm_tokens={num_mm_tokens}")
+    if mm_positions.numel() != lengths_t.sum().item():
+        raise ValueError(
+            f"Number of multimodal tokens ({mm_positions.numel()}) does not match "
+            f"sum of per-unit lengths ({lengths_t.sum().item()}): "
+            f"num_mm_tokens={num_mm_tokens}")
 
     embedding_lengths: List[int] = []
     offset = 0
@@ -1440,9 +1465,18 @@ def compute_mm_embedding_lengths(
     embedding-length derivation shared by the Nano and Qwen3-VL preprocess paths
     and the registry hashing path.
 
+    Invariant: `num_mm_tokens` MUST be ordered to match the PHYSICAL left-to-right
+    prompt positions of the multimodal items. The mask helpers extract MM token
+    positions via `torch.where(mm_mask)[0]` (left-to-right) and slice them
+    sequentially by `num_mm_tokens`; any other ordering (e.g. modality-major)
+    silently mis-attributes token spans across items. Producers must project the
+    per-item counts through the resolved prompt-item order (see
+    `MixedModalItemOrder`) before calling this.
+
     Args:
         input_ids: Prompt token ids (CPU-resident); coerced to a tensor.
-        num_mm_tokens: Per-item multimodal token counts in prompt order.
+        num_mm_tokens: Per-item multimodal token counts in PHYSICAL left-to-right
+            prompt order (see Invariant above).
         vocab_size: Tokenizer/model vocab size; positions >= this are embed
             slots when `mm_token_ids` is not provided.
         mm_token_ids: Optional explicit embed-slot token ids (takes precedence

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -90,7 +90,12 @@ def scan_prompt_order(
         # position wins, and a longer placeholder breaks a position tie.
         next_match: Optional[Tuple[int, int, str]] = None
         for modality, placeholders in placeholders_by_modality.items():
-            if actual_counts[modality] >= expected_counts.get(modality, 0):
+            # A modality may appear in placeholder_by_modality without an entry
+            # in expected_counts (e.g. a model's full placeholder map paired with
+            # a per-request count subset). Treat its expected/actual counts as 0
+            # via `.get` so it is simply skipped rather than raising a KeyError.
+            if actual_counts.get(modality,
+                                 0) >= expected_counts.get(modality, 0):
                 continue
             for placeholder in placeholders:
                 position = text.find(placeholder, cursor)
@@ -477,17 +482,27 @@ class MixedModalItemOrder:
 
     @classmethod
     def from_metadata(
-            cls, multimodal_data: Optional[Dict[str, Any]],
-            embedding_lengths: Iterable[int]
+        cls, multimodal_data: Optional[Dict[str, Any]],
+        embedding_lengths: Optional[Iterable[int]]
     ) -> Optional["MixedModalItemOrder"]:
         """Pair the explicit prompt order (if any) with per-item lengths.
 
         Returns `None` when no `multimodal_item_order` key is present, so the
         per-item extractors can fall back to a synthesized default order.
+
+        Raises `ValueError` when an order IS present but `embedding_lengths` is
+        `None`: the two are baked together for a mixed-modality request, so a
+        present-order/missing-lengths metadata state is inconsistent. We surface
+        it explicitly here instead of letting `tuple(int(x) for x in None)` raise
+        an opaque `TypeError`.
         """
         order = cls.order_from_metadata(multimodal_data)
         if order is None:
             return None
+        if embedding_lengths is None:
+            raise ValueError(
+                "multimodal_item_order is present but multimodal_embedding_lengths "
+                "is missing; a mixed-modality request must bake both together.")
         return cls(order=order,
                    embedding_lengths=tuple(int(x) for x in embedding_lengths))
 

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -632,6 +632,42 @@ class BaseMultimodalInputProcessor(ABC):
                 self, 'temporal_patch_size') else 1
             return num_tokens_per_frame * num_frames // temporal_patch_size
 
+    def get_mm_item_order(
+        self,
+        prompt_token_ids: List[int],
+        mm_data: Dict[str, Any],
+    ) -> List[Tuple[str, int]]:
+        """Resolve the prompt-item order for the tokenized + multimodal fast path.
+
+        Used by `call_with_token_ids` for mixed-modality requests to derive the
+        logical `(modality, item_index)` order of multimodal items from their
+        placeholder positions in the real prompt. The default detokenizes the
+        prompt token ids and delegates to `_get_mm_item_order_from_text`; a
+        processor that enables the token-id fast path
+        (`supports_token_id_mm_expansion`) must provide that hook (or override
+        this method).
+        """
+        text_prompt = self.tokenizer.decode(prompt_token_ids,
+                                            skip_special_tokens=False)
+        return self._get_mm_item_order_from_text(text_prompt, mm_data)
+
+    def _get_mm_item_order_from_text(
+        self,
+        text_prompt: str,
+        mm_data: Dict[str, Any],
+    ) -> List[Tuple[str, int]]:
+        """Derive `(modality, item_index)` order by scanning placeholder text.
+
+        Base implementation raises; any processor that enables the tokenized +
+        multimodal fast path (`supports_token_id_mm_expansion=True`) for 2+
+        distinct modalities MUST override this to return the prompt-physical item
+        order (left-to-right placeholder appearance).
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} enables the tokenized multimodal fast path "
+            "but does not implement _get_mm_item_order_from_text(text_prompt, "
+            "mm_data) to resolve prompt-item order.")
+
 
 class BaseMultimodalDummyInputsBuilder(ABC):
     """Base class for generating dummy inputs. Specially for profiling."""

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -19,11 +19,17 @@ from ..logger import logger
 from ..sampling_params import SamplingParams
 from .content_format import ContentFormat
 from .data import TextPrompt
-from .multimodal import (MultimodalInput, _as_cpu_tensor, _compute_mm_masks,
+# yapf: disable
+from .multimodal import (_SUPPORTED_HASHING_MODALITIES, MixedModalItemOrder,
+                         MultimodalInput, _as_cpu_tensor, _compute_mm_masks,
+                         _find_mm_embedding_lengths_from_masks,
                          _find_mm_token_runs_from_mask,
                          _find_mm_token_start_pos_from_masks, apply_mm_hashes,
-                         default_hasher, find_mm_token_lengths,
-                         hexdigest_to_int32, validate_mm_inputs)
+                         compute_mm_embedding_lengths, default_hasher,
+                         find_mm_token_lengths, hexdigest_to_int32,
+                         validate_mm_inputs)
+
+# yapf: enable
 
 N = TypeVar("N", bound=Type[nn.Module])
 
@@ -99,7 +105,7 @@ class DefaultInputProcessor(InputProcessor):
                     inputs["prompt"],
                     add_special_tokens=sampling_params.add_special_tokens,
                     **kwargs)
-            except:
+            except Exception:
                 # Tiktoken path
                 token_ids = self.tokenizer.encode(
                     inputs["prompt"], allowed_special=toktoken_special_tokens)
@@ -111,7 +117,7 @@ class DefaultInputProcessor(InputProcessor):
                         inputs["query"],
                         add_special_tokens=sampling_params.add_special_tokens,
                         **kwargs)
-                except:
+                except Exception:
                     # Tiktoken path
                     query_token_ids = self.tokenizer.encode(
                         inputs["query"],
@@ -316,8 +322,7 @@ class BaseMultimodalInputProcessor(ABC):
             corresponding number of MM feature tokens. Returns the expanded
             token IDs and optional `mm_data_updates` — per-modality fields to
             merge into `extra_processed_inputs["multimodal_data"]` (e.g. video
-            `evs_ids` for Nano OMNI V3 rebuilt from the real prompt instead
-            of the dummy one).
+            `evs_ids` rebuilt from the real prompt instead of the dummy one).
         """
         if not self.supports_token_id_mm_expansion:
             raise NotImplementedError(
@@ -342,16 +347,46 @@ class BaseMultimodalInputProcessor(ABC):
             sampling_params,
         )
 
-        num_mm_tokens = _get_single_mm_token_lengths(
+        # Mixed-modality: resolve the logical prompt-item order and flatten the
+        # per-modality token-length lists into a single prompt-ordered list, so
+        # `expand_prompt_token_ids_for_mm` sees per-item counts across all
+        # modalities.
+        num_mm_tokens_by_key = find_mm_token_lengths(
             mm_data,
             self,
             multimodal_data=(extra_processed_inputs
                              or {}).get("multimodal_data"),
         )
-        if num_mm_tokens is None:
+        if not num_mm_tokens_by_key:
             raise ValueError(
                 "call_with_token_ids: find_mm_token_lengths returned no token "
                 "lengths for the provided multi_modal_data.")
+        # The dummy-placeholder pass ran the text path on synthetic placeholder
+        # text built modality-major by `get_text_with_mm_placeholders`, which for
+        # a mixed request bakes a stale modality-major `multimodal_item_order`
+        # into the processed metadata. Drop it: the real (possibly interleaved)
+        # order is derived below from the actual prompt token IDs and re-baked.
+        dummy_multimodal_data = (extra_processed_inputs
+                                 or {}).get("multimodal_data")
+        if dummy_multimodal_data is not None:
+            dummy_multimodal_data.pop("multimodal_item_order", None)
+        # Resolve the prompt-item order directly from the real prompt token IDs.
+        # Single-modality requests keep the deterministic modality-major order;
+        # mixed requests delegate to the model's own `get_mm_item_order` hook
+        # (the same scan the expand step uses), which walks the placeholder
+        # layout of the real prompt. The framework `resolve_order` is metadata-
+        # only, so it cannot derive this interleaved order — the model must.
+        mm_items = MixedModalItemOrder._normalize(mm_data)
+        if len(mm_items) <= 1:
+            item_order = MixedModalItemOrder.default_order(mm_items)
+        else:
+            item_order = MixedModalItemOrder.from_raw_entries(
+                self.get_mm_item_order(prompt_token_ids, mm_data),
+                source=f"{type(self).__name__}.get_mm_item_order",
+            )
+        MixedModalItemOrder.validate_order(item_order, mm_items)
+        num_mm_tokens = MixedModalItemOrder.project_by_order(
+            item_order, num_mm_tokens_by_key)
 
         expanded_ids, mm_data_updates = self.expand_prompt_token_ids_for_mm(
             prompt_token_ids,
@@ -370,6 +405,47 @@ class BaseMultimodalInputProcessor(ABC):
                 "multimodal_data", {})
             for modality, field_updates in mm_data_updates.items():
                 mm_container.setdefault(modality, {}).update(field_updates)
+
+        # Bake the resolved prompt-item order into the processed metadata so the
+        # hashing wrapper (and any downstream consumer) inherits the order
+        # derived from the real prompt token IDs, matching the wire format the
+        # text path produces. Replaces the stale dummy-text order dropped above.
+        mm_container = extra_processed_inputs.setdefault("multimodal_data", {})
+        mm_container["multimodal_item_order"] = [{
+            "modality": modality,
+            "index": idx,
+        } for modality, idx in item_order]
+
+        # Re-bake per-item embedding lengths in the real interleaved prompt
+        # order too. The dummy-placeholder pass ran the text path on synthetic
+        # modality-major placeholder text, so any `multimodal_embedding_lengths`
+        # the processor pre-baked there is in that stale modality-major order
+        # (the lengths-shaped twin of the stale `multimodal_item_order` dropped
+        # above). Consumers index lengths by the interleaved item order, so a
+        # surviving modality-major list reports the wrong item's row count.
+        # Recompute from the real expanded prompt IDs and the real-order
+        # `num_mm_tokens`, mirroring the hashing path's mask -> per-item length
+        # derivation. We re-bake (rather than pop-and-defer to that hashing
+        # recompute) because a non-hashing path can reach the consumer: when
+        # `multimodal_hashing_supported` is False (or a first hashing attempt
+        # raises), `process_prompt_maybe_hash` calls the processor directly and
+        # the hashing recompute never runs — popping there would leave lengths
+        # absent, re-introducing the None-lengths class the Qwen fix just closed.
+        # Skip when the processor exposes neither `vocab_size` nor
+        # `mm_token_ids` (no embed-mask predicate): such a processor cannot have
+        # baked mask-derived lengths to begin with, and `compute_mm_embedding_lengths`
+        # would have nothing to scan against (mirrors `maybe_compute_mm_embed_cumsum`).
+        vocab_size = self.get_vocab_size()
+        mm_token_ids = self.get_mm_token_ids()
+        if vocab_size is not None or mm_token_ids is not None:
+            mm_container["multimodal_embedding_lengths"] = (
+                compute_mm_embedding_lengths(
+                    expanded_ids,
+                    num_mm_tokens,
+                    vocab_size=vocab_size,
+                    mm_token_ids=mm_token_ids,
+                    mm_special_token_ids=self.get_mm_special_token_ids(),
+                ))
 
         return expanded_ids, extra_processed_inputs
 
@@ -476,9 +552,7 @@ class BaseMultimodalInputProcessor(ABC):
 
     @property
     def get_num_multimodal_tokens(self):
-        """
-        Get the Hugging Face processor's '_get_num_multimodal_tokens' method.
-        """
+        """Get the Hugging Face processor's '_get_num_multimodal_tokens' method."""
         if hasattr(self.processor, '_get_num_multimodal_tokens'):
             return self.processor._get_num_multimodal_tokens
         else:
@@ -560,9 +634,7 @@ class BaseMultimodalInputProcessor(ABC):
 
 
 class BaseMultimodalDummyInputsBuilder(ABC):
-    """
-    Base class for generating dummy inputs. Specially for profiling
-    """
+    """Base class for generating dummy inputs. Specially for profiling."""
 
     DEFAULT_IMAGE_MAX_DIM = 16384
     DEFAULT_IMAGE_MIN_DIM = 128
@@ -683,9 +755,7 @@ class MultimodalPlaceholderMetadata:
 
 
 class MultimodalPlaceholderRegistry:
-    """
-    Registry for the multimodal models to keep track of the placeholder information.
-    """
+    """Registry for the multimodal models to keep track of the placeholder information."""
 
     def __init__(self) -> None:
         self._multimodal_placeholder_by_model_type: Dict[
@@ -957,28 +1027,6 @@ def _process_multimodal_with_dummy_placeholders(
     return extra_processed_inputs
 
 
-def _get_single_mm_token_lengths(
-    mm_data: Dict[str, Any],
-    input_processor: BaseMultimodalInputProcessor,
-    *,
-    multimodal_data: Optional[Dict[str, Any]] = None,
-) -> Optional[List[int]]:
-    """Get the single set of MM token lengths (first value from find_mm_token_lengths). Returns None if empty."""
-    # TODO: Just like in multimodal_hashing_process, here we assume there is only one modality for now
-    num_mm_tokens_by_key = find_mm_token_lengths(
-        mm_data, input_processor, multimodal_data=multimodal_data)
-    if not num_mm_tokens_by_key:
-        return None
-    # find_mm_token_lengths returns Dict[modality, List[int]], e.g. {"image": [2928, 2928]}.
-    # We need the list of per-item lengths (for _find_mm_token_start_pos_from_masks). We take
-    # the first modality's list; multi-modality is not yet supported
-    # (see TODO in multimodal_hashing_process).
-    num_mm_tokens = next(iter(num_mm_tokens_by_key.values()))
-    if len(num_mm_tokens) <= 0:
-        return None
-    return num_mm_tokens
-
-
 def maybe_compute_mm_embed_cumsum(
     prompt_token_ids: List[int],
     extra_processed_inputs: Optional[ExtraProcessedInputs],
@@ -998,8 +1046,11 @@ def maybe_compute_mm_embed_cumsum(
     """
     if extra_processed_inputs is None:
         return
-    mm_data = extra_processed_inputs.get("multimodal_data")
-    if mm_data is None:
+    # The processed multimodal_data dict (NOT the raw multi_modal_data payload
+    # that `mm_data` denotes elsewhere); name it accordingly to avoid the
+    # same-name-opposite-meaning trap.
+    multimodal_data = extra_processed_inputs.get("multimodal_data")
+    if multimodal_data is None:
         return
 
     # Always backfill the bidirectional-MM gate first (cheap; instance attr
@@ -1011,12 +1062,12 @@ def maybe_compute_mm_embed_cumsum(
     # get_flashinfer_attention_mask's `cached_token_lens == 0` assert on
     # 26B/31B once an image block is split across chunks. Gemma4 sets this
     # per-instance from text_config.use_bidirectional_attention.
-    mm_data.setdefault(
+    multimodal_data.setdefault(
         "mm_bidirectional_blocks",
         bool(getattr(input_processor, "mm_bidirectional_blocks", False)),
     )
 
-    if "multimodal_embed_mask_cumsum" in mm_data:
+    if "multimodal_embed_mask_cumsum" in multimodal_data:
         return
 
     vocab_size = input_processor.get_vocab_size()
@@ -1035,7 +1086,7 @@ def maybe_compute_mm_embed_cumsum(
         mm_special_token_ids=input_processor.get_mm_special_token_ids(),
     )
     # Cache the int64 cumsum; request-invariant, read once per chunk.
-    mm_data["multimodal_embed_mask_cumsum"] = embed_mask.cumsum(
+    multimodal_data["multimodal_embed_mask_cumsum"] = embed_mask.cumsum(
         0, dtype=torch.int64)
 
 
@@ -1075,12 +1126,11 @@ def create_input_processor_with_hash(
         # Extract optional UUIDs (can be None, or dict with same structure as mm_data)
         mm_uuids = inputs.get('multi_modal_uuids', None)
 
-        mm_hashes, mm_uuid_list = apply_mm_hashes(mm_data, mm_uuids, hash_lib)
+        mm_hashes, _ = apply_mm_hashes(mm_data, mm_uuids, hash_lib)
 
         prompt_token_ids, extra_processed_inputs = input_processor(
             inputs, sampling_params)
 
-        # TODO: here we assume there is only one modality for now
         num_mm_tokens_by_key = find_mm_token_lengths(
             mm_data,
             input_processor,
@@ -1096,10 +1146,33 @@ def create_input_processor_with_hash(
             raise ValueError(
                 "multimodal hashing could not determine multimodal token "
                 "lengths for the provided input.")
-        num_mm_tokens = next(iter(num_mm_tokens_by_key.values()))
+        # Mixed-modality: resolve logical prompt-item order, then flatten the
+        # per-modality token-length lists into one prompt-ordered list
+        # (supersedes the single-modality next(iter(...)) assumption). The order
+        # is read from the processed metadata, which every preprocess path now
+        # bakes (text paths and the token-id fast path alike).
+        item_order = MixedModalItemOrder.resolve_order(
+            mm_data,
+            multimodal_data=(extra_processed_inputs
+                             or {}).get("multimodal_data"),
+        )
+        num_mm_tokens = MixedModalItemOrder.project_by_order(
+            item_order, num_mm_tokens_by_key)
         if len(num_mm_tokens) <= 0:
             raise ValueError("multimodal hashing produced an empty multimodal "
                              "token-length list.")
+
+        if extra_processed_inputs is None:
+            extra_processed_inputs = {}
+        multimodal_data = extra_processed_inputs.setdefault(
+            "multimodal_data", {})
+        multimodal_data.setdefault(
+            "multimodal_item_order",
+            [{
+                "modality": modality,
+                "index": idx,
+            } for modality, idx in item_order],
+        )
 
         vocab_size = input_processor.get_vocab_size()
         mm_ids = input_processor.get_mm_token_ids()
@@ -1116,6 +1189,11 @@ def create_input_processor_with_hash(
         if input_ids_tensor.numel() == 0:
             start_positions, start_special_token_positions = [], []
             item_run_cu_offsets, run_positions, run_lengths = [0], [], []
+            # Empty prompt has no embed slots; only fill the fallback if the
+            # processor didn't already pre-bake lengths (it won't here, but the
+            # guard keeps the two branches symmetric).
+            if "multimodal_embedding_lengths" not in multimodal_data:
+                multimodal_data["multimodal_embedding_lengths"] = []
         else:
             mm_mask, embed_mask, special_mask = _compute_mm_masks(
                 input_ids_tensor,
@@ -1123,21 +1201,31 @@ def create_input_processor_with_hash(
                 mm_token_ids=mm_ids,
                 mm_special_token_ids=mm_special_token_ids,
             )
-            extra_processed_inputs["multimodal_data"].setdefault(
-                "multimodal_embed_mask_cumsum",
-                embed_mask.cumsum(0, dtype=torch.int64))
+            multimodal_data.setdefault("multimodal_embed_mask_cumsum",
+                                       embed_mask.cumsum(0, dtype=torch.int64))
             start_positions, start_special_token_positions = (
                 _find_mm_token_start_pos_from_masks(mm_mask, special_mask,
                                                     num_mm_tokens))
             item_run_cu_offsets, run_positions, run_lengths = (
                 _find_mm_token_runs_from_mask(mm_mask, num_mm_tokens))
+            # The mask -> per-item embedding-length derivation is the only piece
+            # a processor may have pre-baked. Skip recomputing it
+            # when present; the masks above are still needed for start_positions,
+            # runs, and the embed cumsum, so _compute_mm_masks stays. Reuse those
+            # masks here rather than re-scanning via compute_mm_embedding_lengths.
+            if "multimodal_embedding_lengths" not in multimodal_data:
+                multimodal_data["multimodal_embedding_lengths"] = (
+                    _find_mm_embedding_lengths_from_masks(
+                        mm_mask, embed_mask, num_mm_tokens))
         # Store special token offsets if available
         if len(start_special_token_positions
                ) > 0 and mm_special_token_ids is not None:
-            extra_processed_inputs["multimodal_data"][
+            multimodal_data[
                 "special_token_offsets"] = start_special_token_positions
-        # flatten the hashes from dict to a single list
-        mm_hashes_flat = [h for hashes in mm_hashes.values() for h in hashes]
+        mm_hashes_flat = MixedModalItemOrder.project_by_order(
+            item_order, mm_hashes)
+        mm_uuid_list = MixedModalItemOrder.project_uuids_by_order(
+            item_order, mm_uuids)
         validate_mm_inputs(prompt_token_ids, mm_hashes_flat, start_positions,
                            num_mm_tokens)
         mm_hashes_int32 = [hexdigest_to_int32(h) for h in mm_hashes_flat
@@ -1154,14 +1242,14 @@ def create_input_processor_with_hash(
     ) -> Tuple[List[int], Optional[ExtraProcessedInputs]]:
         try_multimodal_hashing = False  # only used for first time
         use_multimodal_hashing = False  # used for subsequent calls
-        modalities = list(set(inputs['multi_modal_data'].keys())
-                          ) if 'multi_modal_data' in inputs else []
+        modalities = [
+            modality
+            for modality, data in inputs.get('multi_modal_data', {}).items()
+            if data is not None
+        ]
         if len(modalities) > 0:
-            # TODO: support multimodal hashing for multiple modalities within the same request.
-            if len(modalities) == 1 and modalities[0] in [
-                    'image', 'video', 'audio'
-            ]:
-                # only try multimodal hashing if the inputs only contain a single modality.
+            if all(modality in _SUPPORTED_HASHING_MODALITIES
+                   for modality in modalities):
                 if input_processor.multimodal_hashing_supported is not None:
                     use_multimodal_hashing = input_processor.multimodal_hashing_supported
                 else:

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -45,6 +45,9 @@ l0_a10:
   - unittest/inputs/test_content_format.py
   - unittest/inputs/test_url_validation.py
   - unittest/inputs/test_multimodal.py
+  - unittest/inputs/test_mixed_modal_encode_context.py
+  - unittest/inputs/test_registry_mixed_multimodal.py
+  - unittest/inputs/test_scan_prompt_order.py
   - unittest/others/test_convert_utils.py
   - unittest/others/test_lora_manager.py
   - unittest/others/test_lora_module_count.py

--- a/tests/integration/test_lists/test-db/l0_l40s.yml
+++ b/tests/integration/test_lists/test-db/l0_l40s.yml
@@ -23,6 +23,8 @@ l0_l40s:
   - unittest/_torch/modeling/test_modeling_qwen2_5vl.py::TestQwen2_5_VL::test_all
   - unittest/_torch/modeling/test_modeling_qwen3vl_moe.py::TestQwen3VLMoe::test_all
   - unittest/_torch/modeling/test_modeling_qwen3vl.py::TestQwen3VL::test_all
+  - unittest/_torch/modeling/test_mixed_modal_encode.py
+  - unittest/_torch/modeling/test_qwen3vl_encode_extractor.py
   - unittest/_torch/modeling/test_modeling_qwen3vl.py::test_qwen3vl_init_preserves_caller_quant_config
   - unittest/_torch/modeling/test_modeling_step3p7vl.py
   - test_e2e.py::test_ptp_scaffolding[DeepSeek-R1-Distill-Qwen-7B-DeepSeek-R1/DeepSeek-R1-Distill-Qwen-7B]

--- a/tests/unittest/_torch/modeling/_mm_encode_helpers.py
+++ b/tests/unittest/_torch/modeling/_mm_encode_helpers.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Shared stubs for the multimodal encode/extractor unit tests.
+
+These helpers are imported by the per-model extractor suites
+(`test_nano_encode_extractor`, `test_qwen3vl_encode_extractor`) and the
+backend-agnostic scatter suite (`test_mixed_modal_encode`) so the
+`MultimodalParams` stub and the by-param item extractor stay defined in
+exactly one place.
+"""
+
+from __future__ import annotations
+
+from tensorrt_llm.inputs.multimodal import MultimodalParams
+
+
+def _identity_extractor(items_by_param):
+    """Yield pre-built MultimodalItems keyed by source param index.
+
+    Mirrors the production extractor contract: `encode_by_modality_and_scatter`
+    invokes `extract(param_idx, param)` once for every param index in the
+    batch (`enumerate(multimodal_params)`), so a param that produces no
+    items must yield nothing rather than raising. Returning `[]` for an
+    absent key models that empty-yield case (a real extractor such as
+    `_nano_extract_items` yields nothing for an item-less param), so use
+    `.get(idx, [])` instead of `items_by_param[idx]`.
+    """
+
+    def extract(param_idx, _param):
+        yield from items_by_param.get(param_idx, [])
+
+    return extract
+
+
+def _make_param(multimodal_data: dict) -> MultimodalParams:
+    """Build a stub MultimodalParams for extractor unit tests."""
+    return MultimodalParams(
+        multimodal_input=None,
+        multimodal_data=multimodal_data,
+        multimodal_runtime=None,
+    )

--- a/tests/unittest/_torch/modeling/test_mixed_modal_encode.py
+++ b/tests/unittest/_torch/modeling/test_mixed_modal_encode.py
@@ -1,0 +1,615 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for tensorrt_llm._torch.models.mixed_modal_encode.
+
+Covers the demux -> encode -> mux pipeline: every `ModalityItem` owns exactly
+one prompt slot (`prompt_pos`), its `rows` is both the encoder-output footprint
+and the scatter-destination footprint, and there are no ghosts.
+`build_scatter_index` demultiplexes the flat item list into per-modality buckets
+(one encoder launch per active modality) and computes each item's destination
+range; `scatter_to_prompt_order` multiplexes the per-modality outputs back into
+the canonical prompt-ordered buffer.
+"""
+
+from __future__ import annotations
+
+import pytest
+from _mm_encode_helpers import _identity_extractor
+
+from tensorrt_llm._torch.models.mixed_modal_encode import (
+    ModalityItem,
+    build_scatter_index,
+    encode_by_modality_and_scatter,
+    scatter_to_prompt_order,
+)
+
+
+class _Runtime:
+    """Minimal stand-in for `MultimodalParams.multimodal_runtime` exposing the
+    single `total_embeds_in_request` field the cross-check reads."""
+
+    def __init__(self, total_embeds_in_request: int) -> None:
+        self.total_embeds_in_request = total_embeds_in_request
+
+
+class _ParamWithRuntime:
+    """Param stub carrying a `multimodal_runtime` so the `sum(rows) ==
+    total_embeds_in_request` cross-check has metadata to validate against."""
+
+    def __init__(self, total_embeds_in_request: int) -> None:
+        self.multimodal_runtime = _Runtime(total_embeds_in_request)
+
+
+class TestMultimodalItem:
+    def test_is_frozen(self):
+        item = ModalityItem(
+            src_param_idx=0,
+            modality="image",
+            mm_idx_per_modality=0,
+            prompt_pos=0,
+            rows=1,
+            payload={},
+        )
+        with pytest.raises(AttributeError):  # FrozenInstanceError from `@dataclass`(frozen=True)
+            item.src_param_idx = 99
+
+    def test_six_canonical_fields_only(self):
+        """The canonical item is exactly six fields: no `item_idx_in_param`,
+        no `token_count`/`encoder_token_count` split, no `metadata`, no flags."""
+        item = ModalityItem(
+            src_param_idx=1,
+            modality="video",
+            mm_idx_per_modality=2,
+            prompt_pos=3,
+            rows=7,
+            payload={"k": "v"},
+        )
+        assert item.src_param_idx == 1
+        assert item.modality == "video"
+        assert item.mm_idx_per_modality == 2
+        assert item.prompt_pos == 3
+        assert item.rows == 7
+        assert item.payload == {"k": "v"}
+        assert set(item.__slots__) == {
+            "src_param_idx",
+            "modality",
+            "mm_idx_per_modality",
+            "prompt_pos",
+            "rows",
+            "payload",
+        }
+
+
+def _flatten_items(items_by_param, num_params):
+    """Run the identity extractor over `num_params` param indices and flatten
+    the yielded items, mirroring `encode_by_modality_and_scatter`'s flatten."""
+    extract = _identity_extractor(items_by_param)
+    return [item for param_idx in range(num_params) for item in extract(param_idx, None)]
+
+
+def _interleaved_image_video_image_index():
+    """image -> video -> image interleaving within one param (repeated modality).
+
+    param0 prompt order: img_A(pos0, 5) | vid_X(pos1, 8) | img_B(pos2, 5).
+    Two image items at non-adjacent prompt positions exercises the repeated-
+    modality scatter: the image bucket holds img_A then img_B, but img_B's
+    destination is AFTER the video, not contiguous with img_A.
+    """
+    items_by_param = {
+        0: [
+            ModalityItem(0, "image", 0, 0, 5, {"id": "img_A"}),
+            ModalityItem(0, "video", 0, 1, 8, {"id": "vid_X"}),
+            ModalityItem(0, "image", 1, 2, 5, {"id": "img_B"}),
+        ],
+    }
+    return build_scatter_index(_flatten_items(items_by_param, 1), num_params=1)
+
+
+def _multi_video_audio_index():
+    """PRIMARY new case: image -> video(+audio) -> image -> video(+audio).
+
+    With the audio hoist, the embedded audio is a first-class `(audio, k)` item
+    at the next prompt rank, so a single param's prompt order is the plain
+    sequence:
+
+        (image,0) (video,0) (audio,0) (image,1) (video,1) (audio,1)
+
+    No ghost, no shared slot, no post-process. Every item owns its prompt slot.
+    """
+    items_by_param = {
+        0: [
+            ModalityItem(0, "image", 0, 0, 5, {"id": "img0"}),
+            ModalityItem(0, "video", 0, 1, 8, {"id": "vid0"}),
+            ModalityItem(0, "audio", 0, 2, 3, {"id": "aud0"}),
+            ModalityItem(0, "image", 1, 3, 5, {"id": "img1"}),
+            ModalityItem(0, "video", 1, 4, 8, {"id": "vid1"}),
+            ModalityItem(0, "audio", 1, 5, 3, {"id": "aud1"}),
+        ],
+    }
+    return build_scatter_index(_flatten_items(items_by_param, 1), num_params=1)
+
+
+class TestScatterIndexPartition:
+    def test_empty_batch(self):
+        index = build_scatter_index([], num_params=0)
+        assert index.total_tokens == 0
+        assert index.active_modalities == []
+
+    def test_interleaved_image_video_image(self):
+        index = _interleaved_image_video_image_index()
+        assert index.total_tokens == 18
+        assert set(index.active_modalities) == {"image", "video"}
+        assert index.param_lengths.tolist() == [18]
+        # Image bucket holds img_A (flat 0) then img_B (flat 2); video holds vid_X.
+        assert index.modality_slots["image"].tolist() == [0, 2]
+        assert index.modality_slots["video"].tolist() == [1]
+
+    def test_multi_video_audio_partition(self):
+        index = _multi_video_audio_index()
+        assert index.total_tokens == 32
+        assert set(index.active_modalities) == {"image", "video", "audio"}
+        assert index.param_lengths.tolist() == [32]
+        # Each modality bucket holds its two items in append (prompt) order.
+        assert index.modality_slots["image"].tolist() == [0, 3]
+        assert index.modality_slots["video"].tolist() == [1, 4]
+        assert index.modality_slots["audio"].tolist() == [2, 5]
+
+
+class TestRowsCrossCheck:
+    """`sum(rows)` for a param must equal its `total_embeds_in_request`.
+
+    The cross-check now lives in `encode_by_modality_and_scatter` (the
+    param<->context seam), so it is exercised through that orchestrator.
+    """
+
+    def _noop_encoders(self, hidden_dim):
+        def encoder(items, multimodal_params):
+            total_rows = sum(item.rows for item in items)
+            return torch.zeros((total_rows, hidden_dim), dtype=torch.float32)
+
+        return {m: encoder for m in ("image", "video", "audio")}
+
+    def test_rows_sum_matches_total_embeds_in_request(self):
+        # 5 + 8 + 5 == 18, matching _ParamWithRuntime(18); must not raise.
+        index = _interleaved_image_video_image_index()
+        assert index.param_lengths.tolist() == [18]
+
+    def test_rows_sum_mismatch_raises(self):
+        items_by_param = {
+            0: [
+                ModalityItem(0, "image", 0, 0, 5, {"id": "img_A"}),
+                ModalityItem(0, "image", 1, 1, 5, {"id": "img_B"}),
+            ],
+        }
+        # Declared total (11) != sum(rows) (10) -> fail-loud cross-check.
+        with pytest.raises(ValueError, match="total_embeds_in_request"):
+            encode_by_modality_and_scatter(
+                multimodal_params=[_ParamWithRuntime(11)],
+                encoders=self._noop_encoders(4),
+                extract=_identity_extractor(items_by_param),
+                device=torch.device("cpu"),
+                dtype=torch.float32,
+                hidden_dim=4,
+            )
+
+    def test_cross_check_skipped_without_runtime(self):
+        # Params lacking `multimodal_runtime` (plain stubs) must not trip the
+        # cross-check; the index still builds.
+        items_by_param = {0: [ModalityItem(0, "image", 0, 0, 5, {})]}
+        index = build_scatter_index(_flatten_items(items_by_param, 1), num_params=1)
+        assert index.total_tokens == 5
+
+
+class TestScatterIndexDstIndices:
+    def test_pure_image_single_param(self):
+        items_by_param = {
+            0: [ModalityItem(0, "image", 0, 0, 5, {"id": "img_A"})],
+        }
+        index = build_scatter_index(_flatten_items(items_by_param, 1), num_params=1)
+        assert index.dst_indices["image"].tolist() == [0, 1, 2, 3, 4]
+
+    def test_interleaved_image_video_image_scatters_by_prompt_pos(self):
+        index = _interleaved_image_video_image_index()
+        # Destinations follow prompt_pos within the single param:
+        #   img_A pos0 -> final[0:5]
+        #   vid_X pos1 -> final[5:13]
+        #   img_B pos2 -> final[13:18]   (AFTER the video, not contiguous w/ img_A)
+        # Image bucket order is [img_A, img_B]; dst concatenates their ranges.
+        assert index.dst_indices["image"].tolist() == [
+            0,
+            1,
+            2,
+            3,
+            4,  # img_A pos0
+            13,
+            14,
+            15,
+            16,
+            17,  # img_B pos2
+        ]
+        assert index.dst_indices["video"].tolist() == [5, 6, 7, 8, 9, 10, 11, 12]
+
+    def test_multi_video_audio_scatters_by_prompt_pos(self):
+        index = _multi_video_audio_index()
+        # prompt order: img0(0:5) vid0(5:13) aud0(13:16) img1(16:21) vid1(21:29) aud1(29:32)
+        assert index.dst_indices["image"].tolist() == [
+            0,
+            1,
+            2,
+            3,
+            4,  # img0 pos0
+            16,
+            17,
+            18,
+            19,
+            20,  # img1 pos3
+        ]
+        assert index.dst_indices["video"].tolist() == [
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,  # vid0 pos1
+            21,
+            22,
+            23,
+            24,
+            25,
+            26,
+            27,
+            28,  # vid1 pos4
+        ]
+        assert index.dst_indices["audio"].tolist() == [
+            13,
+            14,
+            15,  # aud0 pos2
+            29,
+            30,
+            31,  # aud1 pos5
+        ]
+
+
+import torch  # noqa: E402
+
+from tensorrt_llm._torch.models.mixed_modal_encode import _expand_ranges  # noqa: E402
+
+
+def _loop_expand_reference(starts, lengths):
+    """Reference: the original per-token ``rows.extend(range(...))`` loop."""
+    rows = []
+    for s, length in zip(starts, lengths, strict=True):
+        rows.extend(range(s, s + length))
+    return torch.tensor(rows, dtype=torch.int64)
+
+
+class TestExpandRangesVectorization:
+    """`_expand_ranges` must be byte-identical to the per-token loop it replaces."""
+
+    @pytest.mark.parametrize(
+        "starts,lengths",
+        [
+            ([], []),
+            ([7], [0]),  # zero-length segment
+            ([0], [5]),
+            ([0, 13], [5, 5]),  # interleaved image bucket shape (img_A, img_B)
+            ([5], [4]),
+            ([3, 100, 0, 50], [2, 0, 3, 1]),  # interleaved zero-length
+            ([0, 682], [682, 357]),  # the dynamic-res multi-image case (sums to 1039)
+        ],
+    )
+    def test_matches_loop_reference(self, starts, lengths):
+        vec = _expand_ranges(
+            torch.tensor(starts, dtype=torch.int64),
+            torch.tensor(lengths, dtype=torch.int64),
+        )
+        ref = _loop_expand_reference(starts, lengths)
+        assert vec.dtype == torch.int64
+        assert torch.equal(vec, ref), f"vec={vec.tolist()} ref={ref.tolist()}"
+
+
+def test_build_scatter_index_matches_naive_reference():
+    # P0: image,video,image interleaved; P1: single image.
+    items = [
+        ModalityItem(0, "image", 0, 0, 2, {}),
+        ModalityItem(0, "video", 0, 1, 3, {}),
+        ModalityItem(0, "image", 1, 2, 2, {}),
+        ModalityItem(1, "image", 0, 0, 4, {}),
+    ]
+    idx = build_scatter_index(items, num_params=2)
+    # Reference: canonical order = sort by (src, prompt_pos); each item's start is
+    # the running row count before it.
+    order = sorted(range(len(items)), key=lambda i: (items[i].src_param_idx, items[i].prompt_pos))
+    start, ref_start = 0, {}
+    for i in order:
+        ref_start[i] = start
+        start += items[i].rows
+    assert idx.total_tokens == start
+    for m in idx.active_modalities:
+        slots = idx.modality_slots[m].tolist()
+        expected = (
+            torch.cat([torch.arange(ref_start[i], ref_start[i] + items[i].rows) for i in slots])
+            if slots
+            else torch.empty(0, dtype=torch.int64)
+        )
+        assert torch.equal(idx.dst_indices[m], expected)
+
+
+class TestEncodeByModalityAndScatter:
+    def _make_fake_encoder(self, hidden_dim, call_log):
+        """Returns a fake encoder: row i in bucket = [i, i, ..., i] (hidden_dim copies)."""
+
+        def encoder(items, multimodal_params):
+            call_log.append(len(items))
+            total_rows = sum(item.rows for item in items)
+            return (
+                torch.arange(total_rows, dtype=torch.float32)
+                .view(-1, 1)
+                .expand(-1, hidden_dim)
+                .contiguous()
+            )
+
+        return encoder
+
+    def test_pure_single_modality_single_call(self):
+        call_log_image: list = []
+        H = 4
+        items_by_param = {
+            0: [ModalityItem(0, "image", 0, 0, 5, {})],
+            1: [ModalityItem(1, "image", 0, 0, 5, {})],
+        }
+        encoders = {"image": self._make_fake_encoder(H, call_log_image)}
+        final = encode_by_modality_and_scatter(
+            multimodal_params=[_ParamWithRuntime(5), _ParamWithRuntime(5)],
+            encoders=encoders,
+            extract=_identity_extractor(items_by_param),
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+            hidden_dim=H,
+        )
+        assert call_log_image == [2]  # ONE call, two items
+        assert final.shape == (10, H)
+        # Bucket rows 0..4 == item_0 (param 0), 5..9 == item_1 (param 1)
+        # Final: param 0 (rows 0..4) | param 1 (rows 5..9), each is item's prompt slot 0
+        assert final[0, 0].item() == 0
+        assert final[4, 0].item() == 4
+        assert final[5, 0].item() == 5
+        assert final[9, 0].item() == 9
+
+    def test_interleaved_repeated_image_single_call(self):
+        """image -> video -> image: ONE image encoder call (2 items), ONE video
+        call; img_B's rows scatter AFTER the video despite sharing the image
+        bucket with img_A."""
+        call_log_image: list = []
+        call_log_video: list = []
+        H = 4
+        items_by_param = {
+            0: [
+                ModalityItem(0, "image", 0, 0, 5, {"id": "img_A"}),
+                ModalityItem(0, "video", 0, 1, 8, {"id": "vid_X"}),
+                ModalityItem(0, "image", 1, 2, 5, {"id": "img_B"}),
+            ],
+        }
+        encoders = {
+            "image": self._make_fake_encoder(H, call_log_image),
+            "video": self._make_fake_encoder(H, call_log_video),
+        }
+        final = encode_by_modality_and_scatter(
+            multimodal_params=[_ParamWithRuntime(18)],
+            encoders=encoders,
+            extract=_identity_extractor(items_by_param),
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+            hidden_dim=H,
+        )
+        assert call_log_image == [2]  # img_A, img_B in ONE call
+        assert call_log_video == [1]  # vid_X
+        assert final.shape == (18, H)
+        # img_A -> final[0:5]: image bucket rows 0..4
+        assert final[0, 0].item() == 0
+        assert final[4, 0].item() == 4
+        # vid_X -> final[5:13]: video bucket rows 0..7
+        assert final[5, 0].item() == 0
+        assert final[12, 0].item() == 7
+        # img_B -> final[13:18]: image bucket rows 5..9 (AFTER the video)
+        assert final[13, 0].item() == 5
+        assert final[17, 0].item() == 9
+
+    def test_multi_video_audio_three_calls_no_post_process(self):
+        """PRIMARY: image->video(+audio)->image->video(+audio) assembles via
+        plain per-item scatter, one call per modality, NO post_process."""
+        call_log_image: list = []
+        call_log_video: list = []
+        call_log_audio: list = []
+        H = 4
+        items_by_param = {
+            0: [
+                ModalityItem(0, "image", 0, 0, 5, {"id": "img0"}),
+                ModalityItem(0, "video", 0, 1, 8, {"id": "vid0"}),
+                ModalityItem(0, "audio", 0, 2, 3, {"id": "aud0"}),
+                ModalityItem(0, "image", 1, 3, 5, {"id": "img1"}),
+                ModalityItem(0, "video", 1, 4, 8, {"id": "vid1"}),
+                ModalityItem(0, "audio", 1, 5, 3, {"id": "aud1"}),
+            ],
+        }
+        encoders = {
+            "image": self._make_fake_encoder(H, call_log_image),
+            "video": self._make_fake_encoder(H, call_log_video),
+            "audio": self._make_fake_encoder(H, call_log_audio),
+        }
+        final = encode_by_modality_and_scatter(
+            multimodal_params=[_ParamWithRuntime(32)],
+            encoders=encoders,
+            extract=_identity_extractor(items_by_param),
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+            hidden_dim=H,
+        )
+        assert call_log_image == [2]
+        assert call_log_video == [2]
+        assert call_log_audio == [2]
+        assert final.shape == (32, H)
+        # aud0 -> final[13:16]: audio bucket rows 0..2
+        assert final[13, 0].item() == 0
+        assert final[15, 0].item() == 2
+        # vid1 -> final[21:29]: video bucket rows 8..15
+        assert final[21, 0].item() == 8
+        assert final[28, 0].item() == 15
+        # aud1 -> final[29:32]: audio bucket rows 3..5
+        assert final[29, 0].item() == 3
+        assert final[31, 0].item() == 5
+
+    def test_empty_batch_returns_zero_size(self):
+        final = encode_by_modality_and_scatter(
+            multimodal_params=[],
+            encoders={},
+            extract=lambda i, p: iter([]),
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+            hidden_dim=4,
+        )
+        assert final.shape == (0, 4)
+
+    def test_bucket_shape_mismatch_raises_value_error(self):
+        """A wrong encoder row count must raise `ValueError` (not `assert`).
+
+        The dispatch row-count check is a `ValueError`, not an `assert`: an
+        `assert` is compiled out under `python -O`, which would let a row-count
+        mismatch flow into the scatter's `index_copy_` and silently corrupt the
+        output buffer. The error must still name the offending modality and the
+        observed vs expected row counts.
+        """
+        H = 4
+
+        def broken_encoder(items, multimodal_params):
+            return torch.zeros((1, H), dtype=torch.float32)  # wrong row count
+
+        items_by_param = {0: [ModalityItem(0, "image", 0, 0, 5, {})]}
+        with pytest.raises(ValueError, match="image"):
+            encode_by_modality_and_scatter(
+                multimodal_params=[object()],
+                encoders={"image": broken_encoder},
+                extract=_identity_extractor(items_by_param),
+                device=torch.device("cpu"),
+                dtype=torch.float32,
+                hidden_dim=H,
+            )
+
+    def _make_sentinel_encoder(self, hidden_dim):
+        """Fake encoder: every row of item ``k`` (in bucket order) is filled with
+        that item's ``payload["sentinel"]`` value (broadcast over hidden_dim).
+
+        Rows are emitted in ``modality_slots[modality]`` order (the adapter
+        contract), so the per-item sentinel block lets a test distinguish which
+        item a scattered row originated from — unlike an ``arange`` encoder whose
+        values track row POSITION rather than item identity.
+        """
+
+        def encoder(items, multimodal_params):
+            blocks = [
+                torch.full((item.rows, hidden_dim), float(item.payload["sentinel"]))
+                for item in items
+            ]
+            return torch.cat(blocks, dim=0) if blocks else torch.empty((0, hidden_dim))
+
+        return encoder
+
+    def test_repeated_modality_scatters_correct_item_rows(self):
+        """A repeated-modality bucket must scatter each item's OWN rows to its
+        own prompt slot.
+
+        param0: image @pos0 (5 rows) | audio @pos1 (4 rows) | image @pos2 (5 rows).
+        The image bucket order is [img_A, img_B]. img_A must land in final[0:5]
+        and img_B in final[9:14] (after the audio), each carrying its own
+        sentinel — not the other's.
+        """
+        H = 4
+        IMG_A, AUD, IMG_B = 10.0, 50.0, 90.0
+        items_by_param = {
+            0: [
+                ModalityItem(0, "image", 0, 0, 5, {"sentinel": IMG_A}),
+                ModalityItem(0, "audio", 0, 1, 4, {"sentinel": AUD}),
+                ModalityItem(0, "image", 1, 2, 5, {"sentinel": IMG_B}),
+            ]
+        }
+        encoders = {
+            "image": self._make_sentinel_encoder(H),
+            "audio": self._make_sentinel_encoder(H),
+        }
+        final = encode_by_modality_and_scatter(
+            multimodal_params=[_ParamWithRuntime(14)],
+            encoders=encoders,
+            extract=_identity_extractor(items_by_param),
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+            hidden_dim=H,
+        )
+        assert final.shape == (14, H)
+        assert torch.all(final[0:5] == IMG_A), f"final[0:5] should be img_A ({IMG_A})"
+        assert torch.all(final[5:9] == AUD), f"final[5:9] should be audio ({AUD})"
+        assert torch.all(final[9:14] == IMG_B), f"final[9:14] should be img_B ({IMG_B})"
+
+    def test_scatter_to_prompt_order_empty_index_returns_zero_size(self):
+        index = build_scatter_index([], num_params=0)
+        final = scatter_to_prompt_order(
+            index,
+            {},
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+            hidden_dim=4,
+        )
+        assert final.shape == (0, 4)
+
+
+class TestEncodeByModalityHighBatch:
+    def test_32_params_three_modalities_three_calls(self):
+        """High-throughput guard: <=3 encoder calls regardless of pure/mixed mix.
+
+        Direct regression guard against the per-mixed-param launch
+        anti-pattern. The pipeline must collapse 32 source params into one
+        encoder call per active modality.
+        """
+        H = 4
+        call_log_image: list = []
+        call_log_video: list = []
+        call_log_audio: list = []
+
+        def fake(call_log):
+            def enc(items, multimodal_params):
+                call_log.append(len(items))
+                total = sum(it.rows for it in items)
+                return torch.zeros((total, H), dtype=torch.float32)
+
+            return enc
+
+        items_by_param: dict = {}
+        # 16 pure-image params (4 tokens each)
+        for i in range(16):
+            items_by_param[i] = [ModalityItem(i, "image", 0, 0, 4, {})]
+        # 16 mixed image+audio params (image @ pos 0, audio @ pos 1)
+        for i in range(16, 32):
+            items_by_param[i] = [
+                ModalityItem(i, "image", 0, 0, 4, {}),
+                ModalityItem(i, "audio", 0, 1, 3, {}),
+            ]
+        encoders = {
+            "image": fake(call_log_image),
+            "audio": fake(call_log_audio),
+            "video": fake(call_log_video),  # registered but no items -> no call
+        }
+        encode_by_modality_and_scatter(
+            multimodal_params=[object()] * 32,
+            encoders=encoders,
+            extract=_identity_extractor(items_by_param),
+            device=torch.device("cpu"),
+            dtype=torch.float32,
+            hidden_dim=H,
+        )
+        # Exactly one image call (32 items) + one audio call (16 items) + zero video
+        assert call_log_image == [32], f"expected 1 image call with 32 items, got {call_log_image}"
+        assert call_log_audio == [16], f"expected 1 audio call with 16 items, got {call_log_audio}"
+        assert call_log_video == [], f"expected zero video calls, got {call_log_video}"
+        total_calls = len(call_log_image) + len(call_log_audio) + len(call_log_video)
+        assert total_calls <= 3

--- a/tests/unittest/_torch/modeling/test_modeling_qwen3vl.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen3vl.py
@@ -1,6 +1,7 @@
 import copy
 import os
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import List, Optional
 
 import pytest
@@ -13,8 +14,13 @@ from utils.llm_data import llm_models_root
 
 from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models.checkpoints.hf.qwen3vl_weight_mapper import Qwen3VLHfWeightMapper
-from tensorrt_llm._torch.models.modeling_qwen3vl import Qwen3VLInputProcessorBase, Qwen3VLModel
+from tensorrt_llm._torch.models.modeling_qwen3vl import (
+    Qwen3VisionModelBase,
+    Qwen3VLInputProcessorBase,
+    Qwen3VLModel,
+)
 from tensorrt_llm._utils import get_sm_version
+from tensorrt_llm.inputs.multimodal import MultimodalParams
 from tensorrt_llm.models.modeling_utils import QuantConfig
 from tensorrt_llm.quantization.mode import QuantAlgo
 
@@ -74,6 +80,141 @@ QWEN3_VL_8B_CONFIG = {
     "_attn_implementation": "flash_attention_2",
     "_name_or_path": str(os.path.join(llm_models_root(), "Qwen3", "Qwen3-VL-8B-Instruct")),
 }
+
+
+class _FakeQwenVisual(torch.nn.Module):
+    """Minimal stand-in for the real Qwen3VL visual encoder.
+
+    `Qwen3VisionModelBase._encode_visual_inputs` calls `self.visual(pixel_values,
+    grid_thw=...)` and concatenates `[embeds] + deepstack_embeds` along dim=1.
+    This fake returns the pixel values verbatim as `embeds` plus a single
+    deepstack level (`embeds + 100`), so the post-merger hidden width is 2.
+    It carries a dummy parameter so `_plan_device` (which reads
+    `next(self.visual.parameters()).device`) resolves to a real device.
+    """
+
+    def __init__(self):
+        super().__init__()
+        # Dummy parameter so `_plan_device()` can read a device off the encoder.
+        self.register_parameter("_anchor", torch.nn.Parameter(torch.zeros(1)))
+
+    def forward(self, pixel_values, grid_thw=None):
+        del grid_thw
+        base_embeds = pixel_values.to(torch.float32)
+        return base_embeds, [base_embeds + 100]
+
+
+def _make_qwen_vision_model_for_mixed_tests():
+    model = Qwen3VisionModelBase.__new__(Qwen3VisionModelBase)
+    torch.nn.Module.__init__(model)
+    model.model_dtype = torch.float32
+    model.visual = _FakeQwenVisual()
+    # `_plan_hidden_dim` = out_hidden_size * (1 + num_deepstack_levels). The fake
+    # emits 1 base column + 1 deepstack level, so out_hidden_size=1 and a single
+    # deepstack index gives the expected concatenated width of 2.
+    model.config = SimpleNamespace(
+        spatial_merge_size=2,
+        out_hidden_size=1,
+        deepstack_visual_indexes=[0],
+    )
+    return model
+
+
+def _qwen_image_video_param(include_order=True, include_lengths=True):
+    """A mixed image+video param exercising the assembly-based encode path.
+
+    The assembly extractor (`_qwen3vl_extract_items`) emits one item per modality and
+    orders them by `multimodal_item_order` (tuple form `(modality, index)`, which
+    is what `MultimodalPromptOrder` normalizes to). Per-item token counts come from the
+    explicit `num_tokens` payload key (test convention; mirrors the Task 13
+    extractor tests) so the assembled output is deterministic.
+    """
+    multimodal_data = {
+        "image": {
+            "pixel_values": torch.tensor([[1.0], [2.0], [3.0], [4.0]]),
+            # ONE image sub-grid whose post-merge row count is the source of
+            # truth: t*(h//m)*(w//m) = 1*(4//2)*(4//2) = 4, matching the 4-row
+            # pixel_values and num_tokens. (A 2-row grid would describe TWO
+            # images, but this param carries a single `(image, 0)` item.)
+            "image_grid_thw": torch.tensor([[1, 4, 4]]),
+            "num_tokens": 4,
+        },
+        "video": {
+            "pixel_values_videos": torch.tensor([[10.0], [11.0], [12.0]]),
+            "video_grid_thw": torch.tensor([[3, 2, 2]]),
+            "num_tokens": 3,
+        },
+    }
+    if include_order:
+        # Prompt order: video item first, then image item.
+        multimodal_data["multimodal_item_order"] = [("video", 0), ("image", 0)]
+    if include_lengths:
+        # Per-item encoder rows in PROMPT order (video=3, then image=4), aligned
+        # with `multimodal_item_order`. The producer emits this key alongside the
+        # order, and the refactored extractor sources per-item rows from it (via
+        # `MixedModalItemOrder.from_metadata`).
+        multimodal_data["multimodal_embedding_lengths"] = [3, 4]
+    else:
+        # Drop the explicit per-item counts so the token-count fallback chain has
+        # nothing to resolve (no num_tokens, no embedding lengths, no runtime).
+        del multimodal_data["image"]["num_tokens"]
+        del multimodal_data["video"]["num_tokens"]
+        multimodal_data["multimodal_embedding_lengths"] = None
+    return MultimodalParams(multimodal_data=multimodal_data)
+
+
+def test_qwen3vl_mixed_image_video_encoder_returns_single_tensor_in_prompt_order():
+    model = _make_qwen_vision_model_for_mixed_tests()
+
+    embeddings = model.forward([_qwen_image_video_param()])
+
+    # `forward` returns a single assembled tensor (the cache contract) whose rows
+    # are laid out in MultimodalPromptOrder order: the video item (3 rows) precedes the
+    # image item (4 rows), even though the extractor walks modalities image-first.
+    assert len(embeddings) == 1
+    expected = torch.tensor(
+        [
+            [10.0, 110.0],
+            [11.0, 111.0],
+            [12.0, 112.0],
+            [1.0, 101.0],
+            [2.0, 102.0],
+            [3.0, 103.0],
+            [4.0, 104.0],
+        ]
+    )
+    torch.testing.assert_close(embeddings[0], expected)
+
+
+# NOTE: the per-request uniqueness (`duplicate prompt_pos`) and the
+# length-agreement invariants previously exercised here against
+# `MixedModalityAssembly.from_params` now live in
+# `MixedModalItemOrder.__post_init__` and are covered by the context
+# construction tests (test_mixed_modal_encode_context.py) and the per-item
+# length-mismatch test in test_qwen3vl_encode_extractor.py.
+
+
+def test_qwen3vl_video_token_count_sums_multirow_grid():
+    processor = Qwen3VLInputProcessorBase.__new__(Qwen3VLInputProcessorBase)
+    processor._config = SimpleNamespace(vision_config=SimpleNamespace(spatial_merge_size=2))
+
+    num_tokens = processor.get_num_tokens_per_video(
+        video=[],
+        video_grid_thw=torch.tensor([[1, 4, 4], [2, 4, 4]]),
+    )
+
+    assert num_tokens == 12
+
+
+def test_qwen3vl_item_order_from_prompt_handles_image_video_interleave():
+    processor = Qwen3VLInputProcessorBase.__new__(Qwen3VLInputProcessorBase)
+
+    item_order = processor._get_mm_item_order_from_text(
+        "v <|vision_start|><|video_pad|><|vision_end|> i <|vision_start|><|image_pad|><|vision_end|>",
+        {"image": [object()], "video": [object()]},
+    )
+
+    assert item_order == [("video", 0), ("image", 0)]
 
 
 @dataclass(repr=False)

--- a/tests/unittest/_torch/modeling/test_qwen3vl_encode_extractor.py
+++ b/tests/unittest/_torch/modeling/test_qwen3vl_encode_extractor.py
@@ -1,0 +1,465 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Qwen3VL multimodal item extractor and bucket adapters.
+
+The extractor parses the two wire keys (`multimodal_item_order` +
+`multimodal_embedding_lengths`) into one transient `MixedModalItemOrder` via
+`from_metadata`, walks `ctx.order`, and yields one canonical six-field
+`ModalityItem` per prompt slot. A `ModalityItem` owns exactly one slot
+(`prompt_pos`); its `rows` is both the encoder-output row count and its scatter
+footprint. Per-item payload slicing (one image / one video out of an aggregate
+`pixel_values` + `*_grid_thw` blob) goes through `_qwen3vl_slice_payload`; the
+per-grid post-merge token count is `_qwen3vl_grid_rows`. When the extractor has a
+`MixedModalItemOrder`, rows come from `ctx.embedding_lengths`; the grid-row
+helper is the fallback for pure single-modality requests that carry no
+`multimodal_item_order` key (so `from_metadata` returns None and the extractor
+synthesizes the modality-major default order).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from _mm_encode_helpers import _make_param
+
+from tensorrt_llm._torch.models.mixed_modal_encode import ModalityItem
+from tensorrt_llm._torch.models.modeling_qwen3vl import (
+    Qwen3VisionModelBase,
+    Qwen3VLInputProcessorBase,
+    _qwen3vl_extract_items,
+    _qwen3vl_grid_rows,
+    _qwen3vl_slice_payload,
+)
+from tensorrt_llm.inputs.multimodal import MixedModalItemOrder
+from tensorrt_llm.sampling_params import SamplingParams
+
+
+class TestQwen3VLPayloadSlicer:
+    """The grid-row + slice helpers are the per-model source of truth for
+    Qwen3VL: `_qwen3vl_slice_payload` slices the aggregate `pixel_values` (+
+    `*_grid_thw`) blob into per-item encoder inputs by the raw-patch prefix sum
+    `Sigma prod(grid_thw[:i])`, and `_qwen3vl_grid_rows` reports the per-grid
+    post-merge token count `t * (h // merge) * (w // merge)`.
+    """
+
+    def test_rows_for_is_per_grid_post_merge_count(self):
+        # Two image sub-items: grids [1,16,16] and [1,8,8] at merge=4 ->
+        # 1*(16//4)*(16//4)=16 and 1*(8//4)*(8//4)=4 post-merge rows.
+        payload = {
+            "pixel_values": torch.randn(1 * 16 * 16 + 1 * 8 * 8, 1176),
+            "image_grid_thw": torch.tensor([[1, 16, 16], [1, 8, 8]]),
+        }
+        param = _make_param({"image": payload})
+        assert _qwen3vl_grid_rows(param, "image", 0, spatial_merge_size=4) == 16
+        assert _qwen3vl_grid_rows(param, "image", 1, spatial_merge_size=4) == 4
+
+    def test_slice_payload_slices_pixels_by_raw_patch_prefix_sum(self):
+        # Raw-patch rows per grid = t*h*w: 256 then 64. The first item's pixel
+        # slice is rows [0:256), the second is [256:320); each carries its own
+        # single-row `*_grid_thw`.
+        pv = torch.arange(320 * 2, dtype=torch.float32).reshape(320, 2)
+        payload = {
+            "pixel_values": pv,
+            "image_grid_thw": torch.tensor([[1, 16, 16], [1, 8, 8]]),
+        }
+        param = _make_param({"image": payload})
+
+        s0 = _qwen3vl_slice_payload(param, "image", 0, spatial_merge_size=4)
+        s1 = _qwen3vl_slice_payload(param, "image", 1, spatial_merge_size=4)
+        torch.testing.assert_close(s0["pixel_values"], pv[0:256])
+        torch.testing.assert_close(s1["pixel_values"], pv[256:320])
+        assert s0["image_grid_thw"].tolist() == [[1, 16, 16]]
+        assert s1["image_grid_thw"].tolist() == [[1, 8, 8]]
+
+    def test_slice_payload_video_uses_video_keys(self):
+        pv = torch.arange(64 * 2, dtype=torch.float32).reshape(64, 2)
+        payload = {
+            "pixel_values_videos": pv,
+            "video_grid_thw": torch.tensor([[1, 8, 8]]),
+        }
+        param = _make_param({"video": payload})
+
+        s0 = _qwen3vl_slice_payload(param, "video", 0, spatial_merge_size=4)
+        torch.testing.assert_close(s0["pixel_values_videos"], pv[0:64])
+        assert s0["video_grid_thw"].tolist() == [[1, 8, 8]]
+        # merge=4 -> 1*(8//4)*(8//4) = 4 post-merge rows.
+        assert _qwen3vl_grid_rows(param, "video", 0, spatial_merge_size=4) == 4
+
+
+class TestQwen3VLExtractItems:
+    @pytest.mark.parametrize(
+        "modality, payload, expected_rows",
+        [
+            (
+                "image",
+                {
+                    # 20 patches -> 5 tokens at merge=4
+                    "pixel_values": torch.randn(20, 1176),
+                    "image_grid_thw": torch.tensor([[1, 16, 16]]),
+                    "num_tokens": 5,  # explicit test convention, like Nano Task 7
+                },
+                5,
+            ),
+        ],
+        ids=["image"],
+    )
+    def test_pure_single_modality(self, modality, payload, expected_rows):
+        param = _make_param({modality: payload})
+        items = list(_qwen3vl_extract_items(0, param))
+        assert len(items) == 1
+        assert items[0].modality == modality
+        assert items[0].mm_idx_per_modality == 0
+        assert items[0].prompt_pos == 0
+        assert items[0].rows == expected_rows
+        assert items[0].src_param_idx == 0
+
+    def test_pure_single_modality_multi_item_enumerates_all(self):
+        # A SINGLE modality (image) carrying TWO sub-items, with NO
+        # `multimodal_item_order` key (a plain 2-image prompt on the
+        # direct/non-hashing path). `from_metadata` returns None, so the
+        # extractor synthesizes the modality-major default order. That default
+        # must enumerate EVERY sub-item (one per `*_grid_thw` row), not collapse
+        # to a single `(image, 0)` entry — otherwise the 2nd image is never
+        # sliced or encoded.
+        merge = 4
+        # grids [1,16,16] -> 16 post-merge rows (256 raw patches) and
+        #       [1, 8, 8] ->  4 post-merge rows ( 64 raw patches).
+        payload = {
+            "pixel_values": torch.randn(256 + 64, 1176),
+            "image_grid_thw": torch.tensor([[1, 16, 16], [1, 8, 8]]),
+        }
+        param = _make_param({"image": payload})
+        items = list(_qwen3vl_extract_items(0, param, spatial_merge_size=merge))
+        assert len(items) == 2
+        assert [(it.modality, it.mm_idx_per_modality, it.prompt_pos) for it in items] == [
+            ("image", 0, 0),
+            ("image", 1, 1),
+        ]
+        # Per-grid post-merge row counts (grid-driven fallback, no context).
+        assert [it.rows for it in items] == [16, 4]
+        # Each item carries its own sliced single-grid payload, so the bucket
+        # adapter re-concatenation reproduces the original aggregate.
+        assert items[0].payload["image_grid_thw"].tolist() == [[1, 16, 16]]
+        assert items[0].payload["pixel_values"].shape[0] == 256
+        assert items[1].payload["image_grid_thw"].tolist() == [[1, 8, 8]]
+        assert items[1].payload["pixel_values"].shape[0] == 64
+
+    @pytest.mark.parametrize(
+        "item_order",
+        [
+            # Tuple(pair)-form order entries.
+            [("video", 0), ("image", 0)],
+            # Dict-form order entries (as the runtime registry emits them).
+            # Regression guard for the tuple(pair) bug: the extractor must
+            # normalize dict-form order identically to tuple-form.
+            [{"modality": "video", "index": 0}, {"modality": "image", "index": 0}],
+        ],
+        ids=["tuple_form", "dict_form_regression"],
+    )
+    def test_mixed_image_video(self, item_order):
+        payload_image = {
+            "pixel_values": torch.randn(20, 1176),
+            "image_grid_thw": torch.tensor([[1, 16, 16]]),
+            "num_tokens": 5,
+        }
+        payload_video = {
+            "pixel_values_videos": torch.randn(32, 1176),
+            "video_grid_thw": torch.tensor([[2, 16, 16]]),
+            "num_tokens": 8,
+        }
+        param = _make_param(
+            {
+                "image": payload_image,
+                "video": payload_video,
+                "multimodal_item_order": item_order,
+                "multimodal_embedding_lengths": [8, 5],
+            }
+        )
+        items = list(_qwen3vl_extract_items(0, param))
+        assert len(items) == 2
+        # video at prompt slot 0, image at slot 1 — distinct, no collapse.
+        by_modality = {it.modality: it for it in items}
+        assert by_modality["video"].prompt_pos == 0
+        assert by_modality["image"].prompt_pos == 1
+        assert by_modality["video"].mm_idx_per_modality == 0
+        assert by_modality["image"].mm_idx_per_modality == 0
+        assert by_modality["video"].rows == 8
+        assert by_modality["image"].rows == 5
+
+    def test_image_video_image_row_order(self):
+        # Interleaved repeated modality: image -> video -> image. The trailing
+        # image (prompt slot 2) must land AFTER the video (slot 1), not folded
+        # into the leading image block. Each image sub-item is sliced out of the
+        # aggregate `pixel_values`/`image_grid_thw` by grid; `rows` is the
+        # per-grid post-merge count (grid-driven, the Qwen3VL source of truth).
+        merge = 4
+        # image grids: [1,16,16] -> 16 post-merge rows (256 raw patches);
+        #              [1, 8, 8] ->  4 post-merge rows ( 64 raw patches).
+        image_payload = {
+            "pixel_values": torch.randn(256 + 64, 1176),
+            "image_grid_thw": torch.tensor([[1, 16, 16], [1, 8, 8]]),
+        }
+        # video grid: [2,16,16] -> 2*(16//4)*(16//4) = 32 post-merge rows
+        #             (2*16*16 = 512 raw patches).
+        video_payload = {
+            "pixel_values_videos": torch.randn(512, 1176),
+            "video_grid_thw": torch.tensor([[2, 16, 16]]),
+        }
+        param = _make_param(
+            {
+                "image": image_payload,
+                "video": video_payload,
+                "multimodal_item_order": [
+                    {"modality": "image", "index": 0},
+                    {"modality": "video", "index": 0},
+                    {"modality": "image", "index": 1},
+                ],
+                # The transient MixedModalItemOrder requires the per-slot row
+                # counts alongside the order (length-agreement is validated in
+                # `__post_init__`). Rows still come from the grid via `rows_for`
+                # until Task 5b sources them from the context; these match.
+                "multimodal_embedding_lengths": [16, 32, 4],
+            }
+        )
+        items = list(_qwen3vl_extract_items(0, param, spatial_merge_size=merge))
+        assert len(items) == 3
+        # Items are emitted in prompt order, one per slot.
+        assert [(it.modality, it.mm_idx_per_modality, it.prompt_pos) for it in items] == [
+            ("image", 0, 0),
+            ("video", 0, 1),
+            ("image", 1, 2),
+        ]
+        # Per-grid post-merge row counts.
+        assert [it.rows for it in items] == [16, 32, 4]
+        # The trailing image carries its own sliced single-grid payload (not the
+        # leading image's), so the bucket adapter re-concatenation is faithful.
+        assert items[2].payload["image_grid_thw"].tolist() == [[1, 8, 8]]
+        assert items[2].payload["pixel_values"].shape[0] == 64
+        assert items[0].payload["image_grid_thw"].tolist() == [[1, 16, 16]]
+        assert items[0].payload["pixel_values"].shape[0] == 256
+
+    def test_mixed_order_length_mismatch_raises(self):
+        # The extractor now builds a transient MixedModalItemOrder from the
+        # two wire keys, so a `multimodal_item_order` whose length disagrees with
+        # `multimodal_embedding_lengths` is rejected at construction time (the
+        # context's `__post_init__` length-agreement check). The old
+        # `MultimodalPromptOrder.from_metadata` path ignored the lengths entirely
+        # and would have yielded items, so this guards the substitution.
+        payload_image = {
+            "pixel_values": torch.randn(20, 1176),
+            "image_grid_thw": torch.tensor([[1, 16, 16]]),
+            "num_tokens": 5,
+        }
+        payload_video = {
+            "pixel_values_videos": torch.randn(32, 1176),
+            "video_grid_thw": torch.tensor([[2, 16, 16]]),
+            "num_tokens": 8,
+        }
+        param = _make_param(
+            {
+                "image": payload_image,
+                "video": payload_video,
+                # 2-entry order, 1-entry lengths -> the typed view rejects it.
+                "multimodal_item_order": [("video", 0), ("image", 0)],
+                "multimodal_embedding_lengths": [8],
+            }
+        )
+        with pytest.raises(ValueError, match="embedding_lengths"):
+            list(_qwen3vl_extract_items(0, param))
+
+
+class TestQwen3VLBucketAdapters:
+    def _make_encoder_stub(self, encode_visual_inputs_return):
+        enc = MagicMock(spec=Qwen3VisionModelBase)
+        enc._encode_visual_inputs = MagicMock(return_value=encode_visual_inputs_return)
+        enc._image_encoder_adapter = Qwen3VisionModelBase._image_encoder_adapter.__get__(enc)
+        enc._video_encoder_adapter = Qwen3VisionModelBase._video_encoder_adapter.__get__(enc)
+        return enc
+
+    @pytest.mark.parametrize(
+        "adapter_attr, items, expected_grid_shape",
+        [
+            (
+                # Image bucket: two items stack into one (32, 1176) call with a
+                # (2, 3) grid (20 + 12 patches across two grid rows).
+                "_image_encoder_adapter",
+                [
+                    ModalityItem(
+                        0,
+                        "image",
+                        0,
+                        0,
+                        5,
+                        {
+                            "pixel_values": torch.randn(20, 1176),
+                            "image_grid_thw": torch.tensor([[1, 16, 16]]),
+                            "num_tokens": 5,
+                        },
+                    ),
+                    ModalityItem(
+                        1,
+                        "image",
+                        0,
+                        1,
+                        3,
+                        {
+                            "pixel_values": torch.randn(12, 1176),
+                            "image_grid_thw": torch.tensor([[1, 12, 12]]),
+                            "num_tokens": 3,
+                        },
+                    ),
+                ],
+                (2, 3),
+            ),
+            (
+                # Video bucket: one item -> (32, 1176) call with a (1, 3) grid.
+                "_video_encoder_adapter",
+                [
+                    ModalityItem(
+                        0,
+                        "video",
+                        0,
+                        0,
+                        8,
+                        {
+                            "pixel_values_videos": torch.randn(32, 1176),
+                            "video_grid_thw": torch.tensor([[2, 16, 16]]),
+                            "num_tokens": 8,
+                        },
+                    ),
+                ],
+                (1, 3),
+            ),
+        ],
+        ids=["image", "video"],
+    )
+    def test_adapter_stacks_pixel_values_and_grids(self, adapter_attr, items, expected_grid_shape):
+        H = 1024
+        out_tensor = torch.randn(8, H)  # total tokens across the bucket
+        enc = self._make_encoder_stub(out_tensor)
+        result = getattr(enc, adapter_attr)(items, [object()] * len(items))
+        # _encode_visual_inputs is called once with the concatenated tensors.
+        call_args = enc._encode_visual_inputs.call_args[0]
+        pixel_values_arg, grid_arg = call_args[0], call_args[1]
+        assert pixel_values_arg.shape == (32, 1176)
+        assert grid_arg.shape == expected_grid_shape
+        torch.testing.assert_close(result, out_tensor)
+
+
+# --- Mixed image+video preprocess writes embedding lengths (non-hashing path) --
+
+_QWEN_VOCAB_SIZE = 1000
+_QWEN_IMAGE_TOKEN_ID = 10
+_QWEN_VIDEO_TOKEN_ID = 11
+# spatial_merge_size = 2. Image grid [1, 4, 4] -> 1*(4//2)*(4//2) = 4 tokens.
+# Video grid [1, 2, 2] -> 1*(2//2)*(2//2) = 1 token.
+_QWEN_IMAGE_GRID = [[1, 4, 4]]
+_QWEN_VIDEO_GRID = [[1, 2, 2]]
+_QWEN_IMAGE_TOKENS = 4
+_QWEN_VIDEO_TOKENS = 1
+
+
+def _make_mixed_qwen_processor():
+    """Construct a Qwen3VL input processor that runs `call_with_text_prompt`
+    without model weights.
+
+    `__init__` loads an HF processor/tokenizer, so build via `__new__` and set
+    only the attributes the mixed preprocess path reads, stubbing `_preprocess`
+    (the HF call) and `get_mrope_config` (rope math, irrelevant to the lengths
+    metadata under test). The image token-count hook is stubbed to the grid
+    formula too, since the base default delegates to the HF processor.
+    """
+    proc = Qwen3VLInputProcessorBase.__new__(Qwen3VLInputProcessorBase)
+    proc._config = SimpleNamespace(
+        text_config=SimpleNamespace(vocab_size=_QWEN_VOCAB_SIZE, dtype=torch.float32),
+        vision_config=SimpleNamespace(spatial_merge_size=2),
+        image_token_id=_QWEN_IMAGE_TOKEN_ID,
+        video_token_id=_QWEN_VIDEO_TOKEN_ID,
+    )
+    proc._dtype = torch.float32
+    proc._processor = None
+    proc.tllm_multimodal_token_id = proc.get_vocab_size() + 1
+
+    # Prompt with image first then video, so the scanned item order is
+    # [(image, 0), (video, 0)].
+    text_prompt = (
+        "<|vision_start|><|image_pad|><|vision_end|> <|vision_start|><|video_pad|><|vision_end|>"
+    )
+    # Stubbed HF output: input_ids carry one image token then one video token
+    # (placeholders, pre-expansion is irrelevant — the embed mask keys off the
+    # post-_postprocess tllm_multimodal_token_id). The image block is 4 tokens
+    # and the video block is 1 token, matching the grid token counts.
+    input_ids = torch.tensor(
+        [
+            [
+                5,
+                *([_QWEN_IMAGE_TOKEN_ID] * _QWEN_IMAGE_TOKENS),
+                6,
+                *([_QWEN_VIDEO_TOKEN_ID] * _QWEN_VIDEO_TOKENS),
+                7,
+            ]
+        ]
+    )
+    processed = {
+        "input_ids": input_ids,
+        "pixel_values": torch.zeros(_QWEN_IMAGE_TOKENS, 1),
+        "image_grid_thw": torch.tensor(_QWEN_IMAGE_GRID),
+        "pixel_values_videos": torch.zeros(_QWEN_VIDEO_TOKENS, 1),
+        "video_grid_thw": torch.tensor(_QWEN_VIDEO_GRID),
+        "attention_mask": torch.ones_like(input_ids),
+    }
+    proc._preprocess = lambda text, mm_data, mm_processor_kwargs: processed
+    proc.get_mrope_config = lambda *args, **kwargs: {}
+    # The base get_num_tokens_per_image delegates to the HF processor; stub it to
+    # the grid formula so it works weightless. get_num_tokens_per_video already
+    # computes from the grid (no HF call needed).
+    proc.get_num_tokens_per_image = lambda *, image, **kwargs: _QWEN_IMAGE_TOKENS
+    return proc, text_prompt
+
+
+def test_qwen3vl_mixed_preprocess_writes_matching_embedding_lengths():
+    """Qwen3-VL mixed preprocess must bake multimodal_embedding_lengths.
+
+    Regression for the mixed-modality crash: the `len(modalities) > 1` branch
+    wrote `multimodal_item_order` but never `multimodal_embedding_lengths`, so on
+    the non-hashing (direct preprocess) path nobody filled it. The per-item
+    extractor then built a `MixedModalItemOrder` via
+    `from_metadata(..., multimodal_data.get("multimodal_embedding_lengths"))`,
+    hitting `tuple(int(x) for x in None)` -> TypeError. The fix makes the
+    preprocess path emit the SAME metadata the registry hashing path does.
+    """
+    proc, text_prompt = _make_mixed_qwen_processor()
+    inputs = {
+        "prompt": text_prompt,
+        "multi_modal_data": {
+            "image": [torch.zeros(3, 8, 8)],
+            "video": [[torch.zeros(3, 4, 4)]],
+        },
+    }
+
+    _, extra = proc.call_with_text_prompt(inputs, SamplingParams())
+    multimodal_data = extra["multimodal_data"]
+
+    # The mixed branch baked the prompt order: image first, then video.
+    assert multimodal_data["multimodal_item_order"] == [
+        {"modality": "image", "index": 0},
+        {"modality": "video", "index": 0},
+    ]
+    # The crash fix: per-item embedding lengths are present and in prompt order
+    # (image=4, then video=1). Embedding lengths are the embed-slot counts, which
+    # equal the per-item token budgets here (no framing specials on Qwen3-VL).
+    assert multimodal_data["multimodal_embedding_lengths"] == [
+        _QWEN_IMAGE_TOKENS,
+        _QWEN_VIDEO_TOKENS,
+    ]
+    # The lengths agree with what a transient MixedModalItemOrder expects
+    # (per-slot row counts aligned with the order) — i.e. the context the
+    # extractor builds via from_metadata constructs without error.
+    ctx = MixedModalItemOrder.from_metadata(
+        multimodal_data, multimodal_data["multimodal_embedding_lengths"]
+    )
+    assert ctx is not None
+    assert ctx.embedding_lengths == (_QWEN_IMAGE_TOKENS, _QWEN_VIDEO_TOKENS)

--- a/tests/unittest/_torch/multimodal/test_share_multiparams.py
+++ b/tests/unittest/_torch/multimodal/test_share_multiparams.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 import unittest
 
 import torch
@@ -94,6 +96,53 @@ class TestMultimodalParamsHandleConversion(unittest.TestCase):
                          self.image["image_height"])
         self.assertEqual(params.multimodal_data["image"]["image_width"],
                          self.image["image_width"])
+
+    def test_encode_context_keys_survive_handle_round_trip(self):
+        """The two encode-context wire keys survive the worker boundary.
+
+        `multimodal_item_order` and `multimodal_embedding_lengths` are CPU-only
+        plain-Python metadata (`_CPU_ONLY_MULTIMODAL_DATA_KEYS`); the encode
+        worker crosses the process boundary via `to_handle` (encode side) ->
+        pickle -> `to_tensor` (worker side). This guards that both keys round-trip
+        byte-identical for a SINGLE-modality param (the shape the B-lite producer
+        bake newly emits), riding alongside a real tensor that DOES go through the
+        shared-tensor handle conversion.
+        """
+        item_order = [
+            {
+                "modality": "image",
+                "index": 0
+            },
+            {
+                "modality": "image",
+                "index": 1
+            },
+        ]
+        embedding_lengths = [682, 357]
+
+        params = MultimodalParams()
+        params.multimodal_data = {
+            "image": {
+                "pixel_values": self.image["pixel_values"]
+            },
+            "multimodal_item_order": item_order,
+            "multimodal_embedding_lengths": embedding_lengths,
+        }
+
+        params.to_handle("multimodal_data")
+        params.to_tensor("multimodal_data")
+
+        # Both CPU-only ctx keys are unchanged across the round-trip.
+        self.assertEqual(params.multimodal_data["multimodal_item_order"],
+                         item_order)
+        self.assertEqual(params.multimodal_data["multimodal_embedding_lengths"],
+                         embedding_lengths)
+        # Sanity: the real tensor riding alongside still round-trips correctly.
+        self.assertIsInstance(params.multimodal_data["image"]["pixel_values"],
+                              torch.Tensor)
+        self.assertTrue(
+            torch.allclose(params.multimodal_data["image"]["pixel_values"],
+                           self.image["pixel_values"]))
 
 
 class TestMultimodalParamsDeviceTransfer(unittest.TestCase):

--- a/tests/unittest/inputs/test_mixed_modal_encode_context.py
+++ b/tests/unittest/inputs/test_mixed_modal_encode_context.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from tensorrt_llm.inputs.multimodal import MixedModalItemOrder
+
+
+def test_holds_order_and_embedding_lengths():
+    ctx = MixedModalItemOrder(
+        order=(("image", 0), ("video", 0), ("image", 1)),
+        embedding_lengths=(32, 48, 32),
+    )
+    assert ctx.order == (("image", 0), ("video", 0), ("image", 1))
+    assert ctx.embedding_lengths == (32, 48, 32)
+    # prompt_pos of item i is just its index in `order`.
+    assert ctx.order[2] == ("image", 1)
+
+
+def test_length_mismatch_raises():
+    with pytest.raises(ValueError, match="embedding_lengths"):
+        MixedModalItemOrder(order=(("image", 0),), embedding_lengths=(32, 48))
+
+
+def test_duplicate_reference_raises():
+    with pytest.raises(ValueError, match="more than once|duplicate"):
+        MixedModalItemOrder(order=(("image", 0), ("image", 0)), embedding_lengths=(32, 32))
+
+
+def test_default_order_is_modality_major():
+    order = MixedModalItemOrder.default_order({"image": ["a", "b"], "video": ["c"]})
+    assert order == (("image", 0), ("image", 1), ("video", 0))
+
+
+def test_from_metadata_pairs_order_with_lengths():
+    multimodal_data = {
+        "multimodal_item_order": [
+            {"modality": "image", "index": 0},
+            {"modality": "video", "index": 0},
+        ]
+    }
+    ctx = MixedModalItemOrder.from_metadata(multimodal_data, (32, 48))
+    assert ctx.order == (("image", 0), ("video", 0))
+    assert ctx.embedding_lengths == (32, 48)
+    assert MixedModalItemOrder.from_metadata({}, ()) is None
+
+
+# ---------------------------------------------------------------------------
+# Order resolution / normalization (absorbed from the deleted MultimodalPromptOrder).
+# `resolve_order` returns a bare prompt-order tuple; `from_metadata` pairs an
+# explicit order with `embedding_lengths`. `_normalize`, `from_raw_entries`,
+# `order_from_metadata`, and `validate_order` are the self-contained internals
+# the producer drives.
+# ---------------------------------------------------------------------------
+
+
+class TestOrderConstructors:
+    """Order-only constructors on MixedModalItemOrder (no embedding lengths)."""
+
+    def test_default_order_single_modality(self):
+        a, b, c = object(), object(), object()
+        assert MixedModalItemOrder.default_order({"image": [a, b, c]}) == (
+            ("image", 0),
+            ("image", 1),
+            ("image", 2),
+        )
+
+    def test_default_order_empty_returns_empty(self):
+        assert MixedModalItemOrder.default_order({}) == ()
+
+    def test_from_raw_entries_dict_form(self):
+        assert MixedModalItemOrder.from_raw_entries(
+            [{"modality": "image", "index": 1}, {"type": "video"}], source="x"
+        ) == (("image", 1), ("video", 0))
+
+    def test_from_raw_entries_tuple_form(self):
+        assert MixedModalItemOrder.from_raw_entries([("image", 0), ("video", 2)], source="x") == (
+            ("image", 0),
+            ("video", 2),
+        )
+
+    def test_from_raw_entries_rejects_unsupported_types(self):
+        with pytest.raises(ValueError):
+            MixedModalItemOrder.from_raw_entries([3.5], source="x")
+        with pytest.raises(ValueError):
+            MixedModalItemOrder.from_raw_entries([7], source="x")
+
+    def test_order_from_metadata_prefers_multimodal_item_order(self):
+        order = MixedModalItemOrder.order_from_metadata(
+            {
+                "multimodal_item_order": [
+                    {"modality": "image", "index": 1},
+                    {"type": "video"},
+                    ("image", 0),
+                ]
+            }
+        )
+        assert order == (("image", 1), ("video", 0), ("image", 0))
+
+    def test_order_from_metadata_returns_none_when_absent(self):
+        assert MixedModalItemOrder.order_from_metadata(None) is None
+        assert MixedModalItemOrder.order_from_metadata({}) is None
+        assert MixedModalItemOrder.order_from_metadata({"other": 1}) is None
+
+
+class TestNormalize:
+    """`_normalize` lifts modality payloads into list form for ordering."""
+
+    def test_normalize_wraps_scalars_and_drops_non_modalities(self):
+        a, b = object(), object()
+        assert MixedModalItemOrder._normalize(
+            {
+                "image": a,
+                "video": [b],
+                "extra": "ignored",
+                "audio": None,
+            }
+        ) == {"image": [a], "video": [b]}
+
+
+class TestResolveOrder:
+    """`resolve_order` reads explicit metadata when present, else the default order.
+
+    Every mixed preprocess path now bakes `multimodal_item_order` into the
+    processed metadata (the text paths always did; the token-id path does after
+    the Nano-token-id bake), so `resolve_order` no longer parses prompts: it is
+    purely `metadata | default_order`. There is no duck-typed `get_mm_item_order`
+    hook on the framework seam.
+    """
+
+    def test_uses_metadata_when_present(self):
+        a, b, c = object(), object(), object()
+        order = MixedModalItemOrder.resolve_order(
+            {"image": [a, b], "video": [c]},
+            multimodal_data={
+                "multimodal_item_order": [
+                    {"modality": "video", "index": 0},
+                    {"modality": "image", "index": 0},
+                    {"modality": "image", "index": 1},
+                ]
+            },
+        )
+        assert order == (("video", 0), ("image", 0), ("image", 1))
+
+    def test_uses_default_for_single_modality(self):
+        a, b = object(), object()
+        assert MixedModalItemOrder.resolve_order({"image": [a, b]}) == (
+            ("image", 0),
+            ("image", 1),
+        )
+
+    def test_uses_metadata_for_multi_modality(self):
+        a, b = object(), object()
+        # Multi-modality with explicit metadata: the baked order wins over the
+        # modality-major default (which would be image-then-video).
+        assert MixedModalItemOrder.resolve_order(
+            {"image": [a], "video": [b]},
+            multimodal_data={
+                "multimodal_item_order": [
+                    {"modality": "video", "index": 0},
+                    {"modality": "image", "index": 0},
+                ]
+            },
+        ) == (("video", 0), ("image", 0))
+
+    def test_falls_back_to_default_when_metadata_absent(self):
+        a, b = object(), object()
+        # No `multimodal_item_order` in metadata: fall back to the modality-major
+        # default order.
+        assert MixedModalItemOrder.resolve_order(
+            {"image": [a], "video": [b]}, multimodal_data=None
+        ) == (("image", 0), ("video", 0))
+
+
+class TestValidateOrder:
+    """`validate_order` is the static coverage check used by `resolve_order`."""
+
+    def test_rejects_unknown_modality(self):
+        a = object()
+        with pytest.raises(ValueError, match="modality 'audio'"):
+            MixedModalItemOrder.validate_order((("audio", 0),), {"image": [a]})
+
+    def test_rejects_out_of_bounds_index(self):
+        a = object()
+        with pytest.raises(ValueError, match=r"image\[5\]"):
+            MixedModalItemOrder.validate_order((("image", 5),), {"image": [a]})
+
+    def test_rejects_coverage_mismatch(self):
+        a, b = object(), object()
+        with pytest.raises(ValueError, match="expected 2"):
+            MixedModalItemOrder.validate_order((("image", 0),), {"image": [a, b]})
+
+    def test_rejects_duplicate_index(self):
+        a, b = object(), object()
+        with pytest.raises(ValueError, match=r"references image\[0\] more than once"):
+            MixedModalItemOrder.validate_order((("image", 0), ("image", 0)), {"image": [a, b]})
+
+
+class TestStaticProjections:
+    """Static projections drive the producer (which holds a bare order tuple)."""
+
+    def test_project_by_order_reorders_by_key(self):
+        assert MixedModalItemOrder.project_by_order(
+            (("image", 0), ("video", 0), ("image", 1)), {"image": [10, 11], "video": [20]}
+        ) == [10, 20, 11]
+
+    def test_project_uuids_by_order_passes_through_none(self):
+        assert MixedModalItemOrder.project_uuids_by_order((("image", 0),), None) is None
+
+    def test_project_uuids_by_order_handles_missing_modality(self):
+        assert MixedModalItemOrder.project_uuids_by_order(
+            (("image", 0), ("video", 0)), {"image": ["a"]}
+        ) == ["a", None]
+
+
+def test_resolve_order_for_single_modality():
+    """`resolve_order` returns the bare prompt-order tuple for a single modality."""
+    a, b = object(), object()
+    order = MixedModalItemOrder.resolve_order({"image": [a, b]})
+    assert order == (("image", 0), ("image", 1))

--- a/tests/unittest/inputs/test_mixed_modal_encode_context.py
+++ b/tests/unittest/inputs/test_mixed_modal_encode_context.py
@@ -44,6 +44,23 @@ def test_from_metadata_pairs_order_with_lengths():
     assert MixedModalItemOrder.from_metadata({}, ()) is None
 
 
+def test_from_metadata_order_present_but_lengths_none_raises_valueerror():
+    # Regression: an order present but embedding_lengths None (e.g. the base
+    # token-id path baked multimodal_item_order without
+    # multimodal_embedding_lengths) must raise a clear ValueError, not an opaque
+    # TypeError from `tuple(int(x) for x in None)`.
+    multimodal_data = {
+        "multimodal_item_order": [
+            {"modality": "image", "index": 0},
+            {"modality": "video", "index": 0},
+        ]
+    }
+    with pytest.raises(ValueError, match="multimodal_embedding_lengths"):
+        MixedModalItemOrder.from_metadata(multimodal_data, None)
+    # No order present: missing lengths is irrelevant; still returns None.
+    assert MixedModalItemOrder.from_metadata({}, None) is None
+
+
 # ---------------------------------------------------------------------------
 # Order resolution / normalization (absorbed from the deleted MultimodalPromptOrder).
 # `resolve_order` returns a bare prompt-order tuple; `from_metadata` pairs an

--- a/tests/unittest/inputs/test_multimodal.py
+++ b/tests/unittest/inputs/test_multimodal.py
@@ -1,11 +1,22 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-"""Tests for MultimodalRuntimeData cumsum math and the flat-mask producer."""
+"""Unit tests for `tensorrt_llm.inputs.multimodal`.
+
+Covers `MultimodalRuntimeData` cumsum math and the flat-mask producers
+(`maybe_compute_mm_embed_cumsum` and the `_compute_mm_masks` helpers). The
+prompt-order type now lives on `MixedModalItemOrder`; its tests are in
+`test_mixed_modal_encode_context.py`.
+"""
 
 import pytest
 import torch
 
-from tensorrt_llm.inputs.multimodal import MultimodalRuntimeData
+from tensorrt_llm.inputs.multimodal import (
+    MultimodalRuntimeData,
+    _compute_mm_masks,
+    _find_mm_embedding_lengths_from_masks,
+    compute_mm_embedding_lengths,
+)
 from tensorrt_llm.inputs.registry import maybe_compute_mm_embed_cumsum
 
 
@@ -33,6 +44,103 @@ def test_maybe_compute_mm_embed_cumsum_populates_py_multimodal_data():
         torch.tensor([0, 1, 2, 2, 3, 4, 5, 5], dtype=torch.int64),
         rtol=0,
         atol=0,
+    )
+
+
+def test_mixed_image_video_audio_masks_runs_embedding_lengths():
+    image_token = 100
+    video_token = 200
+    audio_token = 300
+    video_start = 201
+    video_end = 202
+    audio_start = 301
+    audio_end = 302
+    # 10 img img 11 | vid_start vid vid vid_end 12 | aud_start aud aud_end 13
+    input_ids = torch.tensor(
+        [
+            10,
+            image_token,
+            image_token,
+            11,
+            video_start,
+            video_token,
+            video_token,
+            video_end,
+            12,
+            audio_start,
+            audio_token,
+            audio_end,
+            13,
+        ]
+    )
+    num_mm_tokens = [2, 4, 3]
+
+    mm_mask, embed_mask, _ = _compute_mm_masks(
+        input_ids,
+        vocab_size=None,
+        mm_token_ids=torch.tensor([image_token, video_token, audio_token]),
+        mm_special_token_ids=torch.tensor([video_start, video_end, audio_start, audio_end]),
+    )
+
+    # Sole coverage of `_find_mm_embedding_lengths_from_masks` on a mixed
+    # request: embed-only tokens per item (specials excluded) are [2, 2, 1].
+    # The start-position / run helpers are covered in test_multimodal_runtime.py
+    # and test_llm_kv_cache_events.py.
+    embedding_lengths = _find_mm_embedding_lengths_from_masks(
+        mm_mask,
+        embed_mask,
+        num_mm_tokens,
+    )
+
+    assert embedding_lengths == [2, 2, 1]
+
+    # The public `compute_mm_embedding_lengths` wraps the same
+    # `_compute_mm_masks` -> `_find_mm_embedding_lengths_from_masks` derivation
+    # behind one entry point (shared by Nano, Qwen3-VL, and the registry). Given
+    # the same predicates it must reproduce the mask-level result, accepting raw
+    # `input_ids` (here a plain Python list) directly.
+    assert compute_mm_embedding_lengths(
+        input_ids.tolist(),
+        num_mm_tokens,
+        vocab_size=None,
+        mm_token_ids=torch.tensor([image_token, video_token, audio_token]),
+        mm_special_token_ids=torch.tensor([video_start, video_end, audio_start, audio_end]),
+    ) == [2, 2, 1]
+
+
+def test_compute_mm_embedding_lengths_vocab_size_path_counts_high_ids():
+    """The vocab_size route (no explicit mm_token_ids) counts ids >= vocab_size.
+
+    This mirrors the Qwen3-VL preprocess path, where placeholder tokens are
+    rewritten to `tllm_multimodal_token_id = vocab_size + 1` and there are no
+    framing specials. Two items (image then video) with embed counts 3 and 2.
+    """
+    vocab_size = 1000
+    mm_id = vocab_size + 1
+    # 10 mm mm mm 11 | 12 mm mm 13
+    input_ids = [10, mm_id, mm_id, mm_id, 11, 12, mm_id, mm_id, 13]
+    num_mm_tokens = [3, 2]
+
+    assert compute_mm_embedding_lengths(
+        input_ids,
+        num_mm_tokens,
+        vocab_size=vocab_size,
+        mm_token_ids=None,
+        mm_special_token_ids=None,
+    ) == [3, 2]
+
+
+def test_compute_mm_embedding_lengths_no_mm_tokens_returns_empty():
+    """No multimodal tokens -> empty per-item lengths (text-only prompt)."""
+    assert (
+        compute_mm_embedding_lengths(
+            [10, 11, 12],
+            [],
+            vocab_size=1000,
+            mm_token_ids=None,
+            mm_special_token_ids=None,
+        )
+        == []
     )
 
 

--- a/tests/unittest/inputs/test_registry_mixed_multimodal.py
+++ b/tests/unittest/inputs/test_registry_mixed_multimodal.py
@@ -1,0 +1,687 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+from typing import ClassVar
+
+import torch
+
+from tensorrt_llm.inputs.multimodal import MixedModalItemOrder, find_mm_token_lengths
+from tensorrt_llm.inputs.multimodal_data import AudioData, VideoData
+from tensorrt_llm.inputs.registry import (
+    BaseMultimodalInputProcessor,
+    create_input_processor_with_hash,
+)
+from tensorrt_llm.sampling_params import SamplingParams
+
+# Synthetic token-id scheme for the fake processors: per modality a placeholder
+# id (pre-expansion) and a feature id (post-expansion). Per-item token counts
+# are distinct per modality so a flatten in the wrong order is observable.
+_IMAGE_PLACEHOLDER_ID = 100
+_VIDEO_PLACEHOLDER_ID = 200
+_AUDIO_PLACEHOLDER_ID = 300
+_IMAGE_FEATURE_ID = 101
+_VIDEO_FEATURE_ID = 201
+_AUDIO_FEATURE_ID = 301
+_IMAGE_TOKENS = 2
+_VIDEO_TOKENS = 4
+_AUDIO_TOKENS = 3
+# Per-item token counts in image, video, audio prompt order.
+_MIXED_PROMPT_ORDER_TOKENS = [_IMAGE_TOKENS, _VIDEO_TOKENS, _AUDIO_TOKENS]
+
+
+class _FakeMixedProcessor:
+    def __init__(self):
+        self.multimodal_hashing_supported = None
+        self.lengths_seen_by_expander = None
+        self.video_call_kwargs = None
+
+    def __call__(self, inputs, sampling_params):
+        assert sampling_params is not None
+        multimodal_data = {
+            "image": {},
+            "video": {},
+            "audio": {},
+        }
+        prompt_token_ids = inputs.get("prompt_token_ids", [])
+        mm_data = inputs.get("multi_modal_data")
+        # When called with tokenized input + multimodal data, the processor
+        # itself expands placeholder tokens via `expand_prompt_token_ids_for_mm`,
+        # resolving per-item token counts in prompt order; the hashing wrapper
+        # then consumes the already-expanded ids.
+        if prompt_token_ids and mm_data:
+            lengths_by_key = find_mm_token_lengths(mm_data, self)
+            # The processor computes its own prompt-item order from the tokens
+            # (via its model-internal `get_mm_item_order` hook), mirroring how the
+            # real token-id fast path resolves order before expansion.
+            item_order = self.get_mm_item_order(prompt_token_ids, mm_data)
+            num_mm_tokens = MixedModalItemOrder.project_by_order(item_order, lengths_by_key)
+            prompt_token_ids, _ = self.expand_prompt_token_ids_for_mm(
+                prompt_token_ids,
+                num_mm_tokens,
+                hf_processor_mm_kwargs=inputs.get("mm_processor_kwargs"),
+                mm_data=mm_data,
+            )
+        return prompt_token_ids, {"multimodal_data": multimodal_data}
+
+    # Modality membership for placeholder and feature ids, so order parsing is
+    # tolerant of either pre- or post-expansion token ids.
+    _MODALITY_TOKEN_IDS: ClassVar[dict[str, set[int]]] = {
+        "image": {_IMAGE_PLACEHOLDER_ID, _IMAGE_FEATURE_ID},
+        "video": {_VIDEO_PLACEHOLDER_ID, _VIDEO_FEATURE_ID},
+        "audio": {_AUDIO_PLACEHOLDER_ID, _AUDIO_FEATURE_ID},
+    }
+
+    def get_mm_item_order(self, prompt_token_ids, mm_data):
+        # Derive prompt-item order from the first occurrence of each modality's
+        # tokens. Must work on both the original prompt (call_with_token_ids
+        # path) and the expanded prompt (hashing wrapper), so it keys off
+        # placeholder and feature ids alike.
+        first_pos = {}
+        for pos, tok in enumerate(prompt_token_ids):
+            for modality, ids in self._MODALITY_TOKEN_IDS.items():
+                if tok in ids and modality not in first_pos:
+                    first_pos[modality] = pos
+        ordered = sorted(first_pos, key=first_pos.get)
+        return [(modality, 0) for modality in ordered]
+
+    def expand_prompt_token_ids_for_mm(
+        self,
+        prompt_token_ids,
+        num_mm_tokens_per_placeholder,
+        hf_processor_mm_kwargs=None,
+        mm_data=None,
+    ):
+        assert hf_processor_mm_kwargs is None
+        assert mm_data is not None
+        self.lengths_seen_by_expander = list(num_mm_tokens_per_placeholder)
+        assert self.lengths_seen_by_expander == _MIXED_PROMPT_ORDER_TOKENS
+        return [
+            10,
+            _IMAGE_FEATURE_ID,
+            _IMAGE_FEATURE_ID,
+            11,
+            _VIDEO_FEATURE_ID,
+            _VIDEO_FEATURE_ID,
+            _VIDEO_FEATURE_ID,
+            _VIDEO_FEATURE_ID,
+            12,
+            _AUDIO_FEATURE_ID,
+            _AUDIO_FEATURE_ID,
+            _AUDIO_FEATURE_ID,
+            13,
+        ], None
+
+    def get_num_tokens_per_image(self, image):
+        return _IMAGE_TOKENS
+
+    def get_num_tokens_per_video(self, **kwargs):
+        self.video_call_kwargs = kwargs
+        return _VIDEO_TOKENS
+
+    def get_num_tokens_per_audio(self, audio):
+        return _AUDIO_TOKENS
+
+    def get_vocab_size(self):
+        return None
+
+    def get_mm_token_ids(self):
+        return torch.tensor([_IMAGE_FEATURE_ID, _VIDEO_FEATURE_ID, _AUDIO_FEATURE_ID])
+
+    def get_mm_special_token_ids(self):
+        return None
+
+
+def test_find_mm_token_lengths_preserves_all_modalities_and_video_audio():
+    """find_mm_token_lengths keeps every modality and threads VideoData audio to the per-video hook."""
+    processor = _FakeMixedProcessor()
+    video_audio = AudioData(samples=torch.ones(16000).numpy(), sample_rate=16000)
+    mm_data = {
+        "image": [torch.tensor([1])],
+        "video": [
+            VideoData(
+                frames=[torch.tensor([2])],
+                metadata={"fps": 30.0},
+                audio=video_audio,
+            )
+        ],
+        "audio": [torch.tensor([3])],
+    }
+
+    lengths = find_mm_token_lengths(mm_data, processor)
+
+    assert lengths == {
+        "image": [_IMAGE_TOKENS],
+        "video": [_VIDEO_TOKENS],
+        "audio": [_AUDIO_TOKENS],
+    }
+    assert torch.equal(processor.video_call_kwargs["video"][0], torch.tensor([2]))
+    assert processor.video_call_kwargs["video_metadata"] == {"fps": 30.0}
+    assert processor.video_call_kwargs["video_audio"] is video_audio
+
+
+def test_tokenized_wrapper_mixed_modalities_builds_metadata_for_all_items():
+    """Hashing wrapper expands every placeholder run and builds per-item metadata across all three modalities."""
+    processor = _FakeMixedProcessor()
+    wrapper = create_input_processor_with_hash(processor)
+    mm_data = {
+        "image": [torch.tensor([1])],
+        "video": [[torch.tensor([2])]],
+        "audio": [torch.tensor([3])],
+    }
+
+    prompt_token_ids, extra = wrapper(
+        {
+            "prompt_token_ids": [
+                10,
+                _IMAGE_PLACEHOLDER_ID,
+                11,
+                _VIDEO_PLACEHOLDER_ID,
+                12,
+                _AUDIO_PLACEHOLDER_ID,
+                13,
+            ],
+            "multi_modal_data": mm_data,
+            "multi_modal_uuids": {
+                "image": ["img-0"],
+                "video": ["vid-0"],
+                "audio": ["aud-0"],
+            },
+        },
+        SamplingParams(),
+    )
+
+    assert processor.lengths_seen_by_expander == _MIXED_PROMPT_ORDER_TOKENS
+    assert prompt_token_ids == [
+        10,
+        _IMAGE_FEATURE_ID,
+        _IMAGE_FEATURE_ID,
+        11,
+        _VIDEO_FEATURE_ID,
+        _VIDEO_FEATURE_ID,
+        _VIDEO_FEATURE_ID,
+        _VIDEO_FEATURE_ID,
+        12,
+        _AUDIO_FEATURE_ID,
+        _AUDIO_FEATURE_ID,
+        _AUDIO_FEATURE_ID,
+        13,
+    ]
+    mm_input = extra["multimodal_input"]
+    assert mm_input.multimodal_positions == [1, 4, 9]
+    assert mm_input.multimodal_lengths == _MIXED_PROMPT_ORDER_TOKENS
+    assert mm_input.multimodal_uuids == ["img-0", "vid-0", "aud-0"]
+    assert mm_input.multimodal_item_run_cu_offsets == [0, 1, 2, 3]
+    assert mm_input.multimodal_run_positions == [1, 4, 9]
+    assert mm_input.multimodal_run_lengths == _MIXED_PROMPT_ORDER_TOKENS
+    assert extra["multimodal_data"]["multimodal_embedding_lengths"] == _MIXED_PROMPT_ORDER_TOKENS
+
+
+def test_hashing_path_preserves_processor_baked_embedding_lengths():
+    """A processor that pre-bakes multimodal_embedding_lengths keeps its value.
+
+    Mirrors Nano, which computes per-item embedding lengths in its preprocess
+    (`compute_mm_embedding_lengths`) and writes them into multimodal_data. The
+    registry's missing-key guard must NOT recompute/overwrite them. We pre-bake a
+    deliberately distinct sentinel so an overwrite would be observable: the real
+    mask-derived value here is `_MIXED_PROMPT_ORDER_TOKENS` ([2, 4, 3]).
+    """
+    _SENTINEL_LENGTHS = [99, 98, 97]
+
+    class _PrebakedLengthsProcessor(_FakeMixedProcessor):
+        def __call__(self, inputs, sampling_params):
+            prompt_token_ids, extra = super().__call__(inputs, sampling_params)
+            extra["multimodal_data"]["multimodal_embedding_lengths"] = list(_SENTINEL_LENGTHS)
+            return prompt_token_ids, extra
+
+    processor = _PrebakedLengthsProcessor()
+    wrapper = create_input_processor_with_hash(processor)
+    mm_data = {
+        "image": [torch.tensor([1])],
+        "video": [[torch.tensor([2])]],
+        "audio": [torch.tensor([3])],
+    }
+
+    _, extra = wrapper(
+        {
+            "prompt_token_ids": [
+                10,
+                _IMAGE_PLACEHOLDER_ID,
+                11,
+                _VIDEO_PLACEHOLDER_ID,
+                12,
+                _AUDIO_PLACEHOLDER_ID,
+                13,
+            ],
+            "multi_modal_data": mm_data,
+        },
+        SamplingParams(),
+    )
+
+    # The processor-baked value survives unchanged (guard skips the recompute).
+    assert extra["multimodal_data"]["multimodal_embedding_lengths"] == _SENTINEL_LENGTHS
+    # Sanity: the registry would otherwise have derived the real mask value.
+    assert _SENTINEL_LENGTHS != _MIXED_PROMPT_ORDER_TOKENS
+
+
+def test_text_wrapper_single_video_uses_default_item_order():
+    """A single-modality (video-only) request bypasses get_mm_item_order and uses the default order."""
+
+    class _SingleVideoProcessor(_FakeMixedProcessor):
+        def __call__(self, inputs, sampling_params):
+            return [10] + [_VIDEO_FEATURE_ID] * _VIDEO_TOKENS + [13], {
+                "multimodal_data": {"video": {}}
+            }
+
+        def get_mm_item_order(self, prompt_token_ids, mm_data):
+            raise AssertionError("single-modality requests should not need prompt-order hooks")
+
+        def get_mm_token_ids(self):
+            return torch.tensor([_VIDEO_FEATURE_ID])
+
+    processor = _SingleVideoProcessor()
+    wrapper = create_input_processor_with_hash(processor)
+    prompt_token_ids, extra = wrapper(
+        {"prompt": "video prompt", "multi_modal_data": {"video": [[torch.tensor([2])]]}},
+        SamplingParams(),
+    )
+
+    assert prompt_token_ids == [10] + [_VIDEO_FEATURE_ID] * _VIDEO_TOKENS + [13]
+    assert extra["multimodal_input"].multimodal_positions == [1]
+    assert extra["multimodal_input"].multimodal_lengths == [_VIDEO_TOKENS]
+    assert extra["multimodal_data"]["multimodal_item_order"] == [{"modality": "video", "index": 0}]
+
+
+# Interleaved image, audio, image prompt with distinct per-item token counts, so
+# the flattened list is order-sensitive: only a prompt-order flatten yields
+# [2, 5, 3] (img0, audio0, img1); the old next(iter(...)) path returned just one
+# modality's bucket (images -> [2, 3]).
+_IMG0_TOKENS = 2
+_IMG1_TOKENS = 3
+_AUDIO0_TOKENS = 5
+
+# Prompt-item-ordered counts the real resolve().flatten() must hand the expand hook.
+_EXPECTED_PROMPT_ORDER_TOKENS = [_IMG0_TOKENS, _AUDIO0_TOKENS, _IMG1_TOKENS]
+
+# Image-only bucket the old single-modality path produced (dropping audio).
+_OLD_SINGLE_MODALITY_TOKENS = [_IMG0_TOKENS, _IMG1_TOKENS]
+
+
+class _FakeTokenIdMMProcessor(BaseMultimodalInputProcessor):
+    """Minimal `BaseMultimodalInputProcessor` for the tokenized fast path.
+
+    Drives `call_with_token_ids` on a mixed interleaved prompt (image, audio,
+    image), with the expand hook stubbed so the real find_mm_token_lengths +
+    resolve().flatten() run without a GPU/HF model.
+    """
+
+    # Opt in to the tokenized+MM fast path so `call_with_token_ids` runs.
+    supports_token_id_mm_expansion = True
+
+    def __init__(self):
+        # Bypass BaseMultimodalInputProcessor.__init__; set only the attributes
+        # the exercised path reads.
+        self._tokenizer = None
+        self._config = None
+        self._model_path = None
+        self._use_fast = True
+        self._trust_remote_code = True
+        self._multimodal_hashing_supported = None
+        # Captures the per-item token counts handed to the expand hook.
+        self.lengths_seen_by_expander = None
+
+    # --- abstract members (unused by the exercised path, stubbed minimally) ---
+    @property
+    def processor(self):
+        return None
+
+    @property
+    def tokenizer(self):
+        return self._tokenizer
+
+    @property
+    def config(self):
+        return self._config
+
+    @property
+    def dtype(self):
+        return torch.float32
+
+    def call_with_text_prompt(self, inputs, sampling_params):
+        # Invoked on the synthetic placeholder text prompt, so it must not
+        # re-enter the token-id path.
+        assert inputs.get("prompt") is not None
+        assert inputs.get("prompt_token_ids") is None
+        return [], {"multimodal_data": {"image": {}, "audio": {}}}
+
+    # --- tokenized+MM fast-path hooks ---
+    def get_text_with_mm_placeholders(self, mm_counts):
+        return "".join(f"<{modality}>" * count for modality, count in mm_counts.items())
+
+    def get_mm_item_order(self, prompt_token_ids, mm_data):
+        # Parse the interleaved prompt into (modality, index) in prompt order:
+        # image, audio, image -> [(image,0), (audio,0), (image,1)].
+        order = []
+        counters = {"image": 0, "audio": 0}
+        for tok in prompt_token_ids:
+            if tok == _IMAGE_PLACEHOLDER_ID:
+                order.append(("image", counters["image"]))
+                counters["image"] += 1
+            elif tok == _AUDIO_PLACEHOLDER_ID:
+                order.append(("audio", counters["audio"]))
+                counters["audio"] += 1
+        return order
+
+    def expand_prompt_token_ids_for_mm(
+        self,
+        prompt_token_ids,
+        num_mm_tokens_per_placeholder,
+        hf_processor_mm_kwargs=None,
+        mm_data=None,
+    ):
+        # Capture exactly what the resolve().flatten() step produced; this is
+        # the assertion target. Return a sentinel expanded list (the expansion
+        # arithmetic itself is out of scope here).
+        self.lengths_seen_by_expander = list(num_mm_tokens_per_placeholder)
+        assert mm_data is not None
+        return [-1], None
+
+    def get_num_tokens_per_image(self, *, image, **kwargs):
+        # img0 -> 2 tokens, img1 -> 3 tokens (distinct so order is observable).
+        return _IMG0_TOKENS if image.tolist() == [1] else _IMG1_TOKENS
+
+    def get_num_tokens_per_audio(self, *, audio, **kwargs):
+        return _AUDIO0_TOKENS
+
+
+def _mixed_interleaved_inputs():
+    """Tokenized inputs with two images straddling one audio (image, audio, image)."""
+    # mm_data is modality-major (image[0], image[1], audio[0]) but the prompt
+    # interleaves, so a prompt-order flatten must cross modalities.
+    mm_data = {
+        "image": [torch.tensor([1]), torch.tensor([2])],
+        "audio": [torch.tensor([3])],
+    }
+    prompt_token_ids = [
+        10,
+        _IMAGE_PLACEHOLDER_ID,  # image[0]
+        11,
+        _AUDIO_PLACEHOLDER_ID,  # audio[0]
+        12,
+        _IMAGE_PLACEHOLDER_ID,  # image[1]
+        13,
+    ]
+    return {
+        "prompt_token_ids": prompt_token_ids,
+        "multi_modal_data": mm_data,
+    }
+
+
+def test_call_with_token_ids_flattens_mixed_modalities_in_prompt_order():
+    """call_with_token_ids flattens mixed-modality counts in prompt-item order."""
+    # Interleaved image, audio, image: the per-item counts handed to the expand
+    # hook must be prompt-ordered across modalities, i.e. [img0, audio0, img1] =
+    # [2, 5, 3].
+    processor = _FakeTokenIdMMProcessor()
+    inputs = _mixed_interleaved_inputs()
+
+    expanded_ids, extra = processor.call_with_token_ids(inputs, SamplingParams())
+
+    # The expand hook ran on the real resolve().flatten() output, in prompt order.
+    assert processor.lengths_seen_by_expander == _EXPECTED_PROMPT_ORDER_TOKENS
+    # Sanity: this is provably NOT the order the old single-modality path gave.
+    assert processor.lengths_seen_by_expander != _OLD_SINGLE_MODALITY_TOKENS
+    # Result is the (sentinel) expanded ids the hook returned.
+    assert expanded_ids == [-1]
+    assert "multimodal_data" in extra
+    # The token-id path bakes the resolved prompt order into metadata as the
+    # top-level `multimodal_item_order` key (same wire format the text path
+    # uses), so the hashing wrapper inherits the correct order instead of
+    # re-resolving it from a stale dummy-text scan.
+    assert extra["multimodal_data"]["multimodal_item_order"] == [
+        {"modality": "image", "index": 0},
+        {"modality": "audio", "index": 0},
+        {"modality": "image", "index": 1},
+    ]
+
+
+# Embedding lengths the dummy-placeholder pass bakes in MODALITY-MAJOR order
+# (image[0], image[1], audio[0]) — mirroring Nano's `_process_mixed_modalities`,
+# which runs `compute_mm_embedding_lengths` on the synthetic modality-major
+# placeholder text. Deliberately distinct per item so an order mismatch is
+# observable, and deliberately != num_mm_tokens so a stale value is not silently
+# the same list as the count flatten.
+_STALE_MODALITY_MAJOR_EMBED_LENGTHS = [_IMG0_TOKENS, _IMG1_TOKENS, _AUDIO0_TOKENS]
+# The same per-item embedding lengths re-ordered to the REAL interleaved prompt
+# order (image[0], audio[0], image[1]) the consumer indexes by.
+_EXPECTED_PROMPT_ORDER_EMBED_LENGTHS = [_IMG0_TOKENS, _AUDIO0_TOKENS, _IMG1_TOKENS]
+
+
+class _FakeStaleLengthsProcessor(_FakeTokenIdMMProcessor):
+    """`_FakeTokenIdMMProcessor` whose dummy pass bakes stale lengths.
+
+    Mirrors Nano: the dummy-placeholder pass (driven by the modality-major
+    `get_text_with_mm_placeholders` text) bakes per-item embedding lengths in
+    modality-major order. For an interleaved real prompt the consumer indexes
+    those lengths by the interleaved item order, so a stale modality-major list
+    yields the wrong item's row count.
+    """
+
+    def call_with_text_prompt(self, inputs, sampling_params):
+        prompt_token_ids, extra = super().call_with_text_prompt(inputs, sampling_params)
+        # The dummy pass bakes lengths in modality-major order (image, image,
+        # audio) — stale w.r.t. the interleaved real prompt resolved later.
+        extra["multimodal_data"]["multimodal_embedding_lengths"] = list(
+            _STALE_MODALITY_MAJOR_EMBED_LENGTHS
+        )
+        return prompt_token_ids, extra
+
+    def expand_prompt_token_ids_for_mm(
+        self,
+        prompt_token_ids,
+        num_mm_tokens_per_placeholder,
+        hf_processor_mm_kwargs=None,
+        mm_data=None,
+    ):
+        # Build a realistic expanded prompt: each item's placeholder becomes the
+        # matching number of that modality's feature tokens, in the resolved
+        # (interleaved) prompt order. This lets the registry's mask-based
+        # re-bake of `multimodal_embedding_lengths` count real embed slots.
+        self.lengths_seen_by_expander = list(num_mm_tokens_per_placeholder)
+        assert mm_data is not None
+        feature_id = {"image": _IMAGE_FEATURE_ID, "audio": _AUDIO_FEATURE_ID}
+        # `item_order` for this prompt is image, audio, image (see
+        # `get_mm_item_order`); zip it with the resolved per-item counts.
+        order = self.get_mm_item_order(prompt_token_ids, mm_data)
+        expanded = [10]
+        for (modality, _), count in zip(order, num_mm_tokens_per_placeholder):
+            expanded.extend([feature_id[modality]] * count)
+            expanded.append(13)
+        return expanded, None
+
+    def get_vocab_size(self):
+        return None
+
+    def get_mm_token_ids(self):
+        return torch.tensor([_IMAGE_FEATURE_ID, _AUDIO_FEATURE_ID])
+
+    def get_mm_special_token_ids(self):
+        return None
+
+
+def test_call_with_token_ids_emits_embedding_lengths_in_prompt_order():
+    """call_with_token_ids re-bakes multimodal_embedding_lengths in prompt order.
+
+    Lengths-shaped twin of the item_order fix: the dummy-placeholder pass bakes a
+    stale MODALITY-MAJOR `multimodal_embedding_lengths` (image, image, audio).
+    `call_with_token_ids` re-bakes `multimodal_item_order` in the real interleaved
+    order (image, audio, image) but must ALSO emit `multimodal_embedding_lengths`
+    in that same real order, so a consumer indexing lengths by the interleaved
+    item order reads each item's true row count — not the stale modality-major
+    list.
+    """
+    processor = _FakeStaleLengthsProcessor()
+    inputs = _mixed_interleaved_inputs()
+
+    _, extra = processor.call_with_token_ids(inputs, SamplingParams())
+
+    embed_lengths = extra["multimodal_data"]["multimodal_embedding_lengths"]
+    # Lengths track the REAL interleaved prompt order (image, audio, image).
+    assert embed_lengths == _EXPECTED_PROMPT_ORDER_EMBED_LENGTHS
+    # Sanity: the stale modality-major value would have been observably wrong.
+    assert _STALE_MODALITY_MAJOR_EMBED_LENGTHS != _EXPECTED_PROMPT_ORDER_EMBED_LENGTHS
+    # And lengths align position-for-position with the re-baked item order.
+    item_order = extra["multimodal_data"]["multimodal_item_order"]
+    assert item_order == [
+        {"modality": "image", "index": 0},
+        {"modality": "audio", "index": 0},
+        {"modality": "image", "index": 1},
+    ]
+    assert len(embed_lengths) == len(item_order)
+
+
+# --- Single-modality token-id path: stale dummy-text lengths get re-baked ----
+#
+# Companion to the mixed-interleaved `test_call_with_token_ids_emits_embedding_
+# lengths_in_prompt_order`. A SINGLE-modality (multi-image) token-id request
+# never reorders across modalities -- `call_with_token_ids` takes the
+# `len(mm_items) <= 1` default-order branch -- but the producer-side bake (the
+# Nano text path's `multimodal_embedding_lengths`) runs on the synthetic
+# placeholder text, whose tiler can plan a DIFFERENT per-image row count than the
+# real prompt (Nano's dynamic-resolution image tiling is budget-adaptive). So the
+# dummy pass can leave per-item lengths whose COUNTS (not order) are stale w.r.t.
+# the real prompt. `call_with_token_ids` unconditionally re-bakes
+# `multimodal_embedding_lengths` from the REAL expanded prompt ids
+# (`compute_mm_embedding_lengths`, registry.py), so no separate pop of the stale
+# lengths is needed -- the re-bake overwrites them. This guards that re-bake for
+# the single-modality shape the B-lite producer bake newly emits.
+_IMG0_REAL_TOKENS = 2
+_IMG1_REAL_TOKENS = 4
+# Real per-image embed rows, in prompt order (the encoder's actual output rows).
+_REAL_IMAGE_EMBED_LENGTHS = [_IMG0_REAL_TOKENS, _IMG1_REAL_TOKENS]
+# Stale per-image lengths the dummy-placeholder pass baked (the dummy tiler
+# planned more rows than the real prompt). Deliberately distinct so an un-rebaked
+# stale value is observably wrong, and same length (2 items) so a wrong-COUNT
+# (not wrong-shape) regression is what is caught.
+_STALE_DUMMY_IMAGE_EMBED_LENGTHS = [7, 9]
+
+
+class _FakeSingleModalityStaleLengthsProcessor(BaseMultimodalInputProcessor):
+    """Single-modality (two-image) token-id processor with a stale dummy bake.
+
+    `call_with_text_prompt` (the dummy-placeholder pass) bakes a per-image
+    `multimodal_embedding_lengths` with the WRONG counts, mimicking Nano's
+    dummy-vs-real tiling divergence. `call_with_token_ids` must re-bake the real
+    counts from the expanded prompt ids.
+    """
+
+    supports_token_id_mm_expansion = True
+
+    def __init__(self):
+        # Bypass BaseMultimodalInputProcessor.__init__; set only what the
+        # exercised path reads.
+        self._tokenizer = None
+        self._config = None
+        self._model_path = None
+        self._use_fast = True
+        self._trust_remote_code = True
+        self._multimodal_hashing_supported = None
+
+    # --- abstract members (unused by the exercised path, stubbed minimally) ---
+    @property
+    def processor(self):
+        return None
+
+    @property
+    def tokenizer(self):
+        return self._tokenizer
+
+    @property
+    def config(self):
+        return self._config
+
+    @property
+    def dtype(self):
+        return torch.float32
+
+    def call_with_text_prompt(self, inputs, sampling_params):
+        # The dummy pass runs on synthetic placeholder text; it bakes stale
+        # per-image lengths (wrong counts) the token-id path must overwrite.
+        assert inputs.get("prompt") is not None
+        assert inputs.get("prompt_token_ids") is None
+        return [], {
+            "multimodal_data": {
+                "image": {},
+                "multimodal_embedding_lengths": list(_STALE_DUMMY_IMAGE_EMBED_LENGTHS),
+            }
+        }
+
+    def get_text_with_mm_placeholders(self, mm_counts):
+        return "".join(f"<{modality}>" * count for modality, count in mm_counts.items())
+
+    def expand_prompt_token_ids_for_mm(
+        self,
+        prompt_token_ids,
+        num_mm_tokens_per_placeholder,
+        hf_processor_mm_kwargs=None,
+        mm_data=None,
+    ):
+        # Expand each image placeholder into its REAL per-image feature-token run
+        # (img0 -> 2, img1 -> 4), so the registry's mask-based re-bake counts the
+        # real embed slots.
+        assert mm_data is not None
+        expanded = [10]
+        for count in num_mm_tokens_per_placeholder:
+            expanded.extend([_IMAGE_FEATURE_ID] * count)
+            expanded.append(13)
+        return expanded, None
+
+    def get_num_tokens_per_image(self, *, image, **kwargs):
+        # img0 -> 2 tokens, img1 -> 4 tokens (distinct so order/count is
+        # observable). Keyed off the per-image payload tensor value.
+        return _IMG0_REAL_TOKENS if image.tolist() == [1] else _IMG1_REAL_TOKENS
+
+    def get_vocab_size(self):
+        return None
+
+    def get_mm_token_ids(self):
+        return torch.tensor([_IMAGE_FEATURE_ID])
+
+    def get_mm_special_token_ids(self):
+        return None
+
+
+def test_call_with_token_ids_single_modality_rebakes_embedding_lengths():
+    """Single-modality token-id path re-bakes lengths from the real prompt.
+
+    The dummy-placeholder pass baked stale per-image lengths ([7, 9]).
+    `call_with_token_ids` must emit `multimodal_embedding_lengths` matching the
+    REAL per-image embed rows ([2, 4]) computed from the expanded prompt ids, not
+    the stale dummy bake -- and without a separate pop (the re-bake overwrites).
+    """
+    processor = _FakeSingleModalityStaleLengthsProcessor()
+    inputs = {
+        "prompt_token_ids": [
+            10,
+            _IMAGE_PLACEHOLDER_ID,  # image[0]
+            11,
+            _IMAGE_PLACEHOLDER_ID,  # image[1]
+            13,
+        ],
+        "multi_modal_data": {"image": [torch.tensor([1]), torch.tensor([2])]},
+    }
+
+    _, extra = processor.call_with_token_ids(inputs, SamplingParams())
+
+    embed_lengths = extra["multimodal_data"]["multimodal_embedding_lengths"]
+    # Lengths track the REAL per-image embed rows, not the stale dummy bake.
+    assert embed_lengths == _REAL_IMAGE_EMBED_LENGTHS
+    # Sanity: the stale dummy value would have been observably wrong.
+    assert _STALE_DUMMY_IMAGE_EMBED_LENGTHS != _REAL_IMAGE_EMBED_LENGTHS
+    # The single-modality order is the deterministic per-image default order.
+    item_order = extra["multimodal_data"]["multimodal_item_order"]
+    assert item_order == [
+        {"modality": "image", "index": 0},
+        {"modality": "image", "index": 1},
+    ]
+    # Lengths align position-for-position with the re-baked item order.
+    assert len(embed_lengths) == len(item_order)

--- a/tests/unittest/inputs/test_scan_prompt_order.py
+++ b/tests/unittest/inputs/test_scan_prompt_order.py
@@ -83,3 +83,18 @@ def test_falsy_placeholder_is_skipped():
     order = scan_prompt_order(text, placeholder_by_modality, expected_counts)
 
     assert order == [("image", 0)]
+
+
+def test_placeholder_modality_absent_from_expected_counts_is_skipped():
+    # Regression: placeholder_by_modality may carry a modality that has no entry
+    # in expected_counts (a model's full placeholder map paired with a
+    # per-request count subset). That modality is treated as expected-0 and
+    # skipped -- never a KeyError -- even when its placeholder appears in the
+    # text.
+    text = "a <IMG> b <VID> c"
+    placeholder_by_modality = {"image": "<IMG>", "video": "<VID>"}
+    expected_counts = {"image": 1}  # 'video' intentionally absent
+
+    order = scan_prompt_order(text, placeholder_by_modality, expected_counts)
+
+    assert order == [("image", 0)]

--- a/tests/unittest/inputs/test_scan_prompt_order.py
+++ b/tests/unittest/inputs/test_scan_prompt_order.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the shared `scan_prompt_order` placeholder walk.
+
+`scan_prompt_order` is the single left-to-right placeholder scanner that both
+Nano and Qwen3VL `_get_mm_item_order_from_text` delegate to. It walks the
+decoded prompt from a moving cursor, at each step picking the nearest next
+placeholder among modalities still below their expected count (longer
+placeholder wins on a position tie), appends `(modality, running_index)`, and
+advances the cursor past the match. At the end it raises `ValueError` if any
+modality's observed count disagrees with its expected count.
+"""
+
+import pytest
+
+from tensorrt_llm.inputs.multimodal import scan_prompt_order
+
+
+def test_mixed_image_video_audio_left_to_right():
+    # Interleaved image -> video -> audio with one item each, single placeholder
+    # per modality (the Nano shape). Order follows prompt position, not the
+    # modality iteration order of `placeholder_by_modality`.
+    text = "a <IMG> b <VID> c <SND> d"
+    placeholder_by_modality = {
+        "image": "<IMG>",
+        "video": "<VID>",
+        "audio": "<SND>",
+    }
+    expected_counts = {"image": 1, "video": 1, "audio": 1}
+
+    order = scan_prompt_order(text, placeholder_by_modality, expected_counts)
+
+    assert order == [("image", 0), ("video", 0), ("audio", 0)]
+
+
+def test_single_modality_two_items_running_index():
+    # A single modality carrying two items: running index increments 0, 1 in
+    # prompt order.
+    text = "x <IMG> y <IMG> z"
+    placeholder_by_modality = {"image": "<IMG>"}
+    expected_counts = {"image": 2}
+
+    order = scan_prompt_order(text, placeholder_by_modality, expected_counts)
+
+    assert order == [("image", 0), ("image", 1)]
+
+
+def test_count_mismatch_raises():
+    # Fewer placeholders in the text than expected -> ValueError at end of walk.
+    text = "only one <IMG> here"
+    placeholder_by_modality = {"image": "<IMG>"}
+    expected_counts = {"image": 2}
+
+    with pytest.raises(ValueError):
+        scan_prompt_order(text, placeholder_by_modality, expected_counts)
+
+
+def test_longer_placeholder_wins_at_same_position():
+    # Qwen3VL passes a long form and a short substring of it per modality. When
+    # both match at the same cursor position, the longer placeholder must win so
+    # the cursor advances past the whole long form (otherwise the short form
+    # would be re-matched and inflate the count). One long-form image followed by
+    # one bare short-form image -> exactly two image items.
+    text = "<vision_start><image_pad><vision_end> mid <image_pad>"
+    placeholder_by_modality = {
+        "image": ("<vision_start><image_pad><vision_end>", "<image_pad>"),
+    }
+    expected_counts = {"image": 2}
+
+    order = scan_prompt_order(text, placeholder_by_modality, expected_counts)
+
+    assert order == [("image", 0), ("image", 1)]
+
+
+def test_falsy_placeholder_is_skipped():
+    # A modality whose placeholder string is empty/falsy is skipped entirely
+    # (Nano's defensive `if not placeholder`), and contributes zero expected
+    # items so it does not trip the count check.
+    text = "p <IMG> q"
+    placeholder_by_modality = {"image": "<IMG>", "audio": ""}
+    expected_counts = {"image": 1, "audio": 0}
+
+    order = scan_prompt_order(text, placeholder_by_modality, expected_counts)
+
+    assert order == [("image", 0)]


### PR DESCRIPTION
## Summary

**PR 1 of 3** splitting the large `mixed-modality` feature branch into reviewable pieces. This PR lands the **model-agnostic core** and the **Qwen3VL** adoption only — no Nemotron Nano, no accuracy harness.

It adds support for **mixed-modality requests** (interleaved image / video / audio items within a single request):

- `MixedModalItemOrder` — the per-request logical item-order type (`tensorrt_llm/inputs/multimodal.py`)
- order threading through the input registry (`tensorrt_llm/inputs/registry.py`)
- a plan-based, model-agnostic encode engine: demux → encode → scatter (`tensorrt_llm/_torch/models/mixed_modal_encode.py`)
- Qwen3VL adoption of the plan-based path (`tensorrt_llm/_torch/models/modeling_qwen3vl.py`)
- unit tests for the order type, encode engine, and Qwen3VL encode path

<img width="5320" height="4800" alt="image" src="https://github.com/user-attachments/assets/d5faf77e-4c61-46c7-85e6-44f6b18aa732" />


### Stack (3 dependent PRs)

1. **(this PR)** core engine + Qwen3VL
2. Nemotron Nano adoption (dynamic image-token reconciliation, per-video EVS, audio-in-video) — builds on this
3. mixed-modality accuracy harness (evaluator + reference gates for both models)

Recommended merge order: 1 → 2 → 3.

## Test Plan

Validated on an H100-NVL against this PR's exact code:

- **Unit suite: 99 passed + 7 subtests** — `tests/unittest/inputs/{test_registry_mixed_multimodal,test_scan_prompt_order,test_mixed_modal_encode_context,test_multimodal}.py`, `tests/unittest/_torch/modeling/{test_mixed_modal_encode,test_qwen3vl_encode_extractor,test_modeling_qwen3vl}.py`, `tests/unittest/_torch/multimodal/test_share_multiparams.py` (incl. `TestQwen3VL::test_all`).
- **Qwen3VL mixed-modality accuracy** (harness lands in PR 3; run here against this PR's code to verify the feature end-to-end): `TestQwen3VL::test_mixed_modality[full_budget]` + `[forced_chunked_prefill]` → **2 passed**, evaluated accuracy **50.0 ≥ 45.0** reference floor. The task scores both the image-target and video-target deltas inside a single interleaved image+video request.

New encode unit tests registered in `l0_l40s.yml`.

## Notes

- **Draft / WIP** — first of a dependent stack; PR 2 (Nano) and PR 3 (accuracy harness) to follow. Best reviewed/merged in order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mixed-modality encode pipeline to support simultaneous image, video, and audio inputs in prompts
  * Enhanced Qwen3-VL model to process mixed image and video inputs with correct prompt ordering and embedding computation

* **Tests**
  * Added comprehensive test suite for mixed-modality encoding pipeline
  * Added integration tests validating Qwen3-VL mixed media processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->