### PR TITLE
[TRTLLM-13246][feat] Wave 1: migrate aliases to setup_aliases and stage GMS RO load

### DIFF
--- a/tensorrt_llm/_torch/memory/gpu_memory_backend.py
+++ b/tensorrt_llm/_torch/memory/gpu_memory_backend.py
@@ -36,8 +36,16 @@ Operating modes:
   CUDA memory pool. After loading, weights are committed for read-only
   access by other workers and the client transitions to RO mode in place.
 - **RO (Read-Only)**: Subsequent workers zero-copy import already-committed
-  weights from the GMS pool. `post_load_weights()` must run BEFORE
-  materialization so that module aliases are set up correctly.
+  weights from the GMS pool. `setup_aliases()` must run BEFORE
+  materialization so that module aliases are set up correctly, while derived
+  state is refreshed after real tensors are bound. RO is validated for models
+  whose `post_load_weights()` is pure alias wiring; models that additionally
+  rely on plain Python attributes set inside `post_load_weights()` (rather
+  than registered `nn.Buffer` / `nn.Parameter` assignments) need to migrate
+  those side effects to `cache_derived_state()` or another path that runs on
+  RO readers. The GMS RO reader runs `setup_aliases()` before
+  `materialize_module()` and `cache_derived_state()` afterward; it does not
+  run `transform_weights()`.
 """
 
 from contextlib import contextmanager
@@ -477,7 +485,7 @@ class GMSBackend:
         by GPU pointers from the shared memory region — no data copies,
         no disk I/O, just CUDA VMM remapping. The model's submodule
         layout must already match the writer's at commit time, including
-        any aliases / derived buffers introduced by `post_load_weights`.
+        any aliases introduced by `setup_aliases`.
 
         Args:
             model: The `nn.Module` to materialize. Walks the full
@@ -489,11 +497,10 @@ class GMSBackend:
             RuntimeError: If `connect()` has not been called yet.
 
         Note:
-            `post_load_weights()` must be called on the model BEFORE
-            this method. The order ensures that any aliases / derived
-            parameters created by post-load hooks are present on the
-            module tree at materialization time, so they are bound to
-            the same GMS storage as their primary tensor.
+            `setup_aliases()` must be called on the model BEFORE this method.
+            The order ensures that any structural aliases created by post-load
+            hooks are present on the module tree at materialization time, so
+            they are bound to the same GMS storage as their primary tensor.
         """
         if self._client is None:
             raise RuntimeError("GMS client not connected. Call connect() first.")

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -1921,7 +1921,7 @@ class DeepseekV3ForCausalLM(SpecDecOneEngineForCausalLM[DeepseekV3Model,
         weight_loader = DeepseekV3WeightLoader(self)
         weight_loader.load_weights(weights)
 
-    def post_load_weights(self):
+    def setup_aliases(self) -> None:
         for idx, layer in enumerate(
                 self.model.layers[:self.config.num_hidden_layers]):
             if idx == self.config.num_hidden_layers - 1:

--- a/tensorrt_llm/_torch/models/modeling_exaone_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_exaone_moe.py
@@ -725,7 +725,7 @@ class ExaoneMoeForCausalLM(SpecDecOneEngineForCausalLM[ExaoneMoeModel, ExaoneMoe
             allow_partial_loading=allow_partial_loading,
         )
 
-    def post_load_weights(self):
+    def setup_aliases(self) -> None:
         # For the cross-layer residual+LN fusion.
         for idx, layer in enumerate(self.model.layers[: self.config.num_hidden_layers]):
             if idx == self.config.num_hidden_layers - 1:

--- a/tensorrt_llm/_torch/models/modeling_glm.py
+++ b/tensorrt_llm/_torch/models/modeling_glm.py
@@ -1074,7 +1074,7 @@ class Glm4MoeForCausalLM(SpecDecOneEngineForCausalLM[Glm4Model, PretrainedConfig
         weight_loader = Glm4WeightLoader(self)
         weight_loader.load_weights(weights, allow_partial_loading=allow_partial_loading)
 
-    def post_load_weights(self):
+    def setup_aliases(self) -> None:
         for idx, layer in enumerate(self.model.layers[: self.config.num_hidden_layers]):
             if idx == self.config.num_hidden_layers - 1:
                 layer.next_layer_layernorm = self.model.norm

--- a/tensorrt_llm/_torch/models/modeling_gpt_oss.py
+++ b/tensorrt_llm/_torch/models/modeling_gpt_oss.py
@@ -631,7 +631,7 @@ class GptOssForCausalLM(SpecDecOneEngineForCausalLM[Transformer, GptOssConfig]):
         else:
             self.load_hf_weights(weights)
 
-    def post_load_weights(self):
+    def setup_aliases(self) -> None:
         for idx, layer in enumerate(
                 self.model.block[:self.config.num_hidden_layers]):
             if idx == 0:

--- a/tensorrt_llm/_torch/models/modeling_llama.py
+++ b/tensorrt_llm/_torch/models/modeling_llama.py
@@ -484,7 +484,7 @@ class Llama4DecoderLayer(DecoderLayer):
         self.input_layernorm = RMSNorm(hidden_size=config.hidden_size,
                                        eps=config.rms_norm_eps,
                                        dtype=config.torch_dtype)
-        # When post_load_weights() chains layernorms across layers,
+        # When setup_aliases() chains layernorms across layers,
         # this flag is set to True to skip the input layernorm in
         # forward() since it is handled by the previous layer.
         self.skip_input_layernorm = False
@@ -709,7 +709,7 @@ class LlamaDecoderLayer(DecoderLayer):
             quantize_type="nvfp4"
             if not self.disable_nvfp4_layernorm_fusion and self.is_nvfp4
             and not (differ_pp_stage_with_previous_layer) else None)
-        # When post_load_weights() chains layernorms across layers,
+        # When setup_aliases() chains layernorms across layers,
         # this flag is set to True to skip the input layernorm in
         # forward() since it is handled by the previous layer.
         self.skip_input_layernorm = False
@@ -983,7 +983,7 @@ class Llama4Model(DecoderModel):
         self.norm = RMSNorm(hidden_size=config.hidden_size,
                             eps=config.rms_norm_eps,
                             dtype=config.torch_dtype)
-        # When post_load_weights() chains the final norm into the
+        # When setup_aliases() chains the final norm into the
         # last decoder layer, this flag is set to True to skip
         # applying it again in forward().
         self.skip_norm = False
@@ -1088,7 +1088,7 @@ class LlamaModel(DecoderModel):
         self.norm = RMSNorm(hidden_size=config.hidden_size,
                             eps=config.rms_norm_eps,
                             dtype=config.torch_dtype)
-        # When post_load_weights() chains the final norm into the
+        # When setup_aliases() chains the final norm into the
         # last decoder layer, this flag is set to True to skip
         # applying it again in forward().
         self.skip_norm = False
@@ -1140,7 +1140,7 @@ class LlamaForCausalLM(SpecDecOneEngineForCausalLM[LlamaModel, LlamaConfig]):
     ):
         super().__init__(LlamaModel(model_config), model_config)
 
-    def post_load_weights(self):
+    def setup_aliases(self) -> None:
         for idx, layer in enumerate(
                 self.model.layers[:self.config.num_hidden_layers]):
             if idx == self.config.num_hidden_layers - 1:
@@ -1564,7 +1564,7 @@ class Llama4ForConditionalGeneration(SpecDecOneEngineForCausalLM[Llama4Model,
             if had_mm_encoder:
                 self.mm_encoder = saved_mm_encoder
 
-    def post_load_weights(self):
+    def setup_aliases(self) -> None:
         for idx, layer in enumerate(
                 self.model.layers[:self.config.num_hidden_layers]):
             if idx == self.config.num_hidden_layers - 1:

--- a/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
@@ -417,7 +417,7 @@ class Qwen3MoeForCausalLM(SpecDecOneEngineForCausalLM[Qwen3MoEModel,
         )
         self.preload_weight_modules = self.model.preload_weight_modules
 
-    def post_load_weights(self):
+    def setup_aliases(self) -> None:
         for idx, layer in enumerate(
                 self.model.layers[:self.config.num_hidden_layers]):
             if idx == self.config.num_hidden_layers - 1:

--- a/tensorrt_llm/_torch/models/modeling_qwen3_next.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_next.py
@@ -980,7 +980,7 @@ class Qwen3NextForCausalLM(SpecDecOneEngineForCausalLM[Qwen3NextModel,
         new_weights = weight_mapper.preprocess_weights(weights)
         super().load_weights(new_weights, weight_mapper)
 
-    def post_load_weights(self):
+    def setup_aliases(self) -> None:
         for idx, layer in enumerate(
                 self.model.layers[:self.config.num_hidden_layers]):
             if idx == self.config.num_hidden_layers - 1:

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -485,8 +485,9 @@ class ModelLoader:
             # post_load_* hooks itself, so the shared post-load block below
             # must skip them. RW handles them inside `mem_pool_scope` so the
             # committed pool reflects the post-post_load layout; RO runs
-            # `module.post_load_weights()` before `materialize_module` to
-            # wire aliases prior to zero-copy mapping.
+            # `setup_aliases()` before `materialize_module` to wire aliases
+            # prior to zero-copy mapping, then refreshes derived state after
+            # real GMS tensors are bound.
             gms_post_load_handled = False
             if load_format == LoadFormat.AUTO:
                 # Pass model= so format-specific loaders (e.g. MX) can
@@ -717,22 +718,23 @@ class ModelLoader:
                         # Hook order:
                         #   1. `post_load_apply`: format-specific apply
                         #      work (e.g., MX preshard markers).
-                        #   2. Per-module `post_load_weights`: creates
-                        #      aliases/derived parameter attributes BEFORE
-                        #      `materialize_module` walks the final module
-                        #      tree (including `draft_model` for spec dec).
-                        #   3. `materialize_module`: zero-copy bind GMS
+                        #   2. Per-module `setup_aliases`: creates structural
+                        #      aliases BEFORE `materialize_module` walks the
+                        #      final module tree (including `draft_model` for
+                        #      spec dec).
+                        #   3. SourceIdentity gate: STRICT pre-materialize
+                        #      compatibility check (GMS has no disk fallback).
+                        #   4. `materialize_module`: zero-copy bind GMS
                         #      pool storage onto the model parameters.
-                        #   4. `post_load_publish`: any receiver-side
+                        #   5. Per-module `cache_derived_state`: recompute
+                        #      Python-side state from real, materialized
+                        #      tensors without re-running one-shot transforms.
+                        #   6. `post_load_publish`: any receiver-side
                         #      publish (no-op via the receiver guard).
                         checkpoint_loader.post_load_apply(
                             model, weights_preloaded=True)
 
-                        for module in model.modules():
-                            if hasattr(module,
-                                       'post_load_weights') and not getattr(
-                                           module, '_weights_removed', False):
-                                module.post_load_weights()
+                        self._setup_aliases(model)
 
                         # Pre-materialize compatibility gate. GMS has no
                         # disk-fallback path, so a mismatch raises under STRICT
@@ -740,6 +742,7 @@ class ModelLoader:
                         self._check_gms_source_identity(gms_backend)
 
                         gms_backend.materialize_module(model)
+                        self._walk_cache_state(model)
 
                         checkpoint_loader.post_load_publish(
                             model,
@@ -829,22 +832,24 @@ class ModelLoader:
 
     @staticmethod
     def _setup_aliases(model: DecoderModelForCausalLM) -> None:
-        """Run top-level structural alias setup if the model defines it.
+        """Run structural alias setup on eligible modules.
 
-        Alias wiring is a model-level concern. It is intentionally not a
-        recursive module walk, because migrated aliases are expected to be set
-        by the root model that owns the layer graph.
+        The walk is duck-typed so modules can opt in without inheriting a
+        shared base class. Modules whose weights were removed are skipped,
+        matching the legacy full post-load walk.
 
         Args:
-            model: Root decoder model whose top-level alias hook should run.
+            model: Root decoder model whose module tree should be visited.
 
         Returns:
             None.
         """
-        setup_aliases: Optional[Callable[[], None]] = getattr(
-            model, 'setup_aliases', None)
-        if setup_aliases is not None:
-            setup_aliases()
+        for module in model.modules():
+            setup_aliases: Optional[Callable[[], None]] = getattr(
+                module, 'setup_aliases', None)
+            if setup_aliases is not None and not getattr(
+                    module, '_weights_removed', False):
+                setup_aliases()
 
     @staticmethod
     def _walk_transform(model: DecoderModelForCausalLM) -> None:
@@ -935,8 +940,11 @@ class ModelLoader:
         """Reload model weights without running post-load hooks.
 
         Reload is used by incremental update paths that may provide only a
-        partial set of replacement weights. The owner of the update lifecycle is
-        responsible for running post-load processing once all bytes are present.
+        partial set of replacement weights. Full reloads reset transform guards
+        before rebinding fresh weights. Partial reloads keep existing transform
+        guards intact because untouched modules may already contain transformed
+        live weights. The owner of the update lifecycle is responsible for
+        running post-load processing once all bytes are present.
 
         Args:
             model: Model instance receiving the replacement weights.
@@ -952,6 +960,8 @@ class ModelLoader:
                 "Cannot reload weights: weight_mapper was not initialized. "
                 "This can happen when the initial load used GMS, MX P2P, or "
                 "VISION_ONLY, which bypass the standard weight mapping path.")
+        if not allow_partial_loading:
+            self._reset_weights_transformed(model)
         self._call_load_weights(model.load_weights,
                                 weights,
                                 self.weight_mapper,

--- a/tests/unittest/_torch/pyexecutor/test_model_loader_gms.py
+++ b/tests/unittest/_torch/pyexecutor/test_model_loader_gms.py
@@ -44,7 +44,13 @@ class _TinyModel(nn.Module):
     def load_weights(self, weights, mapper):
         self._events.append("load_weights")
 
-    def post_load_weights(self):
+    def setup_aliases(self) -> None:
+        self._events.append("setup_aliases")
+
+    def cache_derived_state(self) -> None:
+        self._events.append("cache_derived_state")
+
+    def post_load_weights(self) -> None:
         self._events.append("post_load_weights")
 
 
@@ -76,7 +82,9 @@ def _make_loader(monkeypatch, *, events, spec_config=None):
     loader._call_load_weights = MagicMock(
         side_effect=lambda fn, weights, mapper, **kwargs: fn(weights, mapper)
     )
-    loader._load_and_validate_config = MagicMock(return_value=SimpleNamespace(name="config"))
+    loader._load_and_validate_config = MagicMock(
+        return_value=SimpleNamespace(name="config", mapping=SimpleNamespace())
+    )
 
     monkeypatch.setattr(model_loader_mod, "timing", lambda *_args, **_kwargs: nullcontext())
     monkeypatch.setattr(model_loader_mod, "maybe_create_moe_load_balancer", _moe_context)
@@ -147,7 +155,7 @@ def _spec_config_needing_draft_weights():
         ),
         pytest.param(
             False,
-            ["post_load_weights", "materialize"],
+            ["setup_aliases", "materialize", "cache_derived_state"],
             id="ro",
         ),
     ],
@@ -161,8 +169,9 @@ def test_gms_load_branch(monkeypatch, is_rw, expected_events):
             (``_apply`` for meta materialization, ``to('cuda')``, weight
             load, ``post_load_weights``) inside the pool, then commits via
             ``finalize_write`` once the scope exits.
-        ro: the reader runs ``post_load_weights`` to wire module aliases
-            first, then GMS materializes weights via zero-copy mapping.
+        ro: the reader runs ``setup_aliases`` to wire module aliases, checks
+            identity compatibility, materializes weights via zero-copy mapping,
+            then refreshes derived state from real tensors.
     """
     events = []
     loader = _make_loader(monkeypatch, events=events)
@@ -196,11 +205,53 @@ def test_gms_load_branch(monkeypatch, is_rw, expected_events):
         backend.move_untracked_params.assert_called_once_with(model)
         backend.finalize_write.assert_called_once_with(model)
     else:
-        # RO: post_load_weights() must run before the GMS materialize
-        # step so module aliases are wired up before zero-copy mapping.
+        # RO: setup_aliases() must run before the GMS materialize step so
+        # module aliases are wired up before zero-copy mapping.
         checkpoint_loader.load_weights.assert_not_called()
         loader._call_load_weights.assert_not_called()
         backend.materialize_module.assert_called_once_with(model)
+
+
+def test_gms_ro_materializes_between_alias_setup_and_cache_state(monkeypatch):
+    events = []
+    loader = _make_loader(monkeypatch, events=events)
+    backend = _build_gms_backend(is_rw=False, events=events)
+    _install_gms_backend(monkeypatch, backend)
+
+    checkpoint_loader = MagicMock(name="checkpoint_loader")
+    checkpoint_loader.checkpoint_format = "HF"
+
+    def record(event):
+        def _append(*_args, **_kwargs):
+            events.append(event)
+
+        return _append
+
+    checkpoint_loader.post_load_apply.side_effect = record("post_load_apply")
+    checkpoint_loader.post_load_publish.side_effect = record("post_load_publish")
+
+    # The STRICT pre-materialize identity gate runs between alias setup and
+    # materialization; record it to pin the ordering without exercising the
+    # comparison logic, which is covered in test_source_identity.py.
+    monkeypatch.setattr(
+        model_loader_mod,
+        "check_weight_sharing_compatibility",
+        lambda *_args, **_kwargs: events.append("check_source_identity"),
+    )
+
+    loader.load("/ckpt", checkpoint_loader)
+
+    assert events == [
+        "post_load_apply",
+        "setup_aliases",
+        "check_source_identity",
+        "materialize",
+        "cache_derived_state",
+        "post_load_publish",
+    ]
+    assert "post_load_weights" not in events
+    checkpoint_loader.load_weights.assert_not_called()
+    backend.materialize_module.assert_called_once()
 
 
 def test_gms_rw_post_load_runs_inside_pool_before_finalize(monkeypatch):

--- a/tests/unittest/_torch/pyexecutor/test_model_loader_mx.py
+++ b/tests/unittest/_torch/pyexecutor/test_model_loader_mx.py
@@ -132,9 +132,30 @@ def test_mx_success_initializes_mapper_skips_weight_mapping_and_reload_works(mon
 
     # reload() uses self.weight_mapper unconditionally; MX success must
     # initialize it even though the initial load skipped _call_load_weights.
+    model._weights_transformed = True
+    model.linear._weights_transformed = True
     loader.reload(model, {"reloaded": MagicMock()})
     assert loader._call_load_weights.call_count == 1
+    assert model._weights_transformed is False
+    assert model.linear._weights_transformed is False
     assert events == ["post_load_weights", "load_weights"]
+
+
+def test_reload_partial_loading_preserves_weights_transformed_flags(monkeypatch):
+    events = []
+    loader = _make_loader(monkeypatch, events=events)
+    loader.weight_mapper = MagicMock(name="weight_mapper")
+    model = _TinyModel(events)
+    model._weights_transformed = True
+    model.linear._weights_transformed = True
+
+    loader.reload(model, {"reloaded": MagicMock()}, allow_partial_loading=True)
+
+    assert loader._call_load_weights.call_count == 1
+    assert loader._call_load_weights.call_args.kwargs["allow_partial_loading"] is True
+    assert model._weights_transformed is True
+    assert model.linear._weights_transformed is True
+    assert events == ["load_weights"]
 
 
 def test_mx_partial_fallback_merges_returned_weights(monkeypatch):
@@ -194,17 +215,17 @@ class _HookRecorder(nn.Module):
         if transformed is not None:
             self._weights_transformed = transformed
 
-    def setup_aliases(self):
+    def setup_aliases(self) -> None:
         self.events.append((self.name, "setup_aliases"))
 
-    def transform_weights(self):
+    def transform_weights(self) -> None:
         self.events.append((self.name, "transform_weights"))
         self._weights_transformed = True
 
-    def cache_derived_state(self):
+    def cache_derived_state(self) -> None:
         self.events.append((self.name, "cache_derived_state"))
 
-    def post_load_weights(self):
+    def post_load_weights(self) -> None:
         self.events.append((self.name, "post_load_weights"))
 
 
@@ -216,13 +237,17 @@ class _HookModel(_HookRecorder):
         self.removed_child = _HookRecorder("removed_child", events, removed=True)
 
 
-def test_staged_hook_setup_aliases_is_top_level_only():
+def test_staged_hook_setup_aliases_walks_skip_removed_modules():
     events = []
     model = _HookModel(events)
 
     ModelLoader._setup_aliases(model)
 
-    assert events == [("model", "setup_aliases")]
+    assert events == [
+        ("model", "setup_aliases"),
+        ("child", "setup_aliases"),
+        ("transformed_child", "setup_aliases"),
+    ]
 
 
 def test_staged_hook_walks_skip_removed_and_transformed_modules():


### PR DESCRIPTION
## Summary

Wave 1 of the staged post-load hooks rollout. The staged-hook contract landed in #14770, and #14878 has now merged, so this PR is a single Wave 1 commit on top of `main`.

This change migrates alias-only model hooks from `post_load_weights()` to `setup_aliases()` and cuts the GMS read-only (RO) load path over from the old meta-tensor workaround to the staged-hook protocol.

## What Changed

- Alias migration for 7 top-level model classes: `modeling_llama` (`LlamaForCausalLM`, `Llama4ForConditionalGeneration`), `modeling_deepseekv3`, `modeling_glm`, `modeling_exaone_moe`, `modeling_qwen3_moe`, `modeling_qwen3_next`, and `modeling_gpt_oss`. Their alias-only `post_load_weights()` bodies move verbatim into `setup_aliases()`, while standard load paths continue through the base `post_load_weights()` orchestrator.
- GMS RO ordering now runs staged hooks around zero-copy materialization:

```text
post_load_apply
  -> _setup_aliases(model)                  # recursive alias walk
  -> _check_gms_source_identity(gms_backend) # STRICT pre-materialize gate from #14878
  -> materialize_module(model)
  -> _walk_cache_state(model)
  -> post_load_publish
```

- GMS docs now describe alias setup before materialization and derived-state refresh after real tensors are bound.
- Full reload now resets existing `_weights_transformed` flags before rebinding fresh weights, while partial reload keeps existing transform guards intact for untouched modules.
- Tests cover the staged walkers, reload reset, and GMS RO ordering in `test_model_loader_gms.py` and `test_model_loader_mx.py`.

## Dependency / prerequisite stack

This PR is Wave 1 in the staged post-load hooks rollout. The foundation PRs #14770 and #14878 are already merged. The wave PRs should merge in sequence; after each upstream wave lands, rebase the next wave onto `main` so review and CI focus on that wave's delta.

Arrows point from prerequisite to dependent. PR numbers in graph nodes are clickable.

```mermaid
graph TD
    PR14770["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/14770'>#14770</a>: staged-hook contract (merged)"]
    PR14878["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/14878'>#14878</a>: GMS SourceIdentity gate (merged)"]
    PR15014["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15014'>#15014</a>: Wave 1 aliases + GMS RO load (this PR, open)"]
    PR15288["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15288'>#15288</a>: Wave 2 Linear/Attention transforms (draft)"]
    PR15386["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15386'>#15386</a>: Wave 3 MoE/Mamba staged hooks (draft)"]
    PR15387["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15387'>#15387</a>: Wave 4 MX receiver cutover (draft)"]
    PR15432["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15432'>#15432</a>: Wave 5 MX publisher + Llama receiver (draft)"]
    VERIFY["post-migration verification / demo (planned)"]

    PR14770 -->|satisfied| PR15014
    PR14878 -->|satisfied| PR15014
    PR15014 -->|blocking| PR15288
    PR15288 -->|blocking| PR15386
    PR15386 -->|blocking| PR15387
    PR15387 -->|blocking| PR15432
    PR15432 -.->|planned| VERIFY

    classDef merged fill:#dcfce7,stroke:#16a34a,color:#14532d;
    classDef inflight fill:#dbeafe,stroke:#2563eb,color:#1e3a8a;
    classDef draft fill:#ffedd5,stroke:#f97316,color:#7c2d12;
    classDef current fill:#ede9fe,stroke:#7c3aed,color:#3b0764,stroke-width:3px;
    classDef downstream fill:#f3f4f6,stroke:#6b7280,color:#374151,stroke-dasharray:5 5;
    linkStyle 0,1 stroke:#16a34a,stroke-width:2px;
    linkStyle 2,3,4,5 stroke:#ea580c,stroke-width:3px;
    linkStyle 6 stroke:#6b7280,stroke-width:2px,stroke-dasharray:5 5;

    class PR14770,PR14878 merged;
    class PR15288,PR15386,PR15387,PR15432 draft;
    class PR15014 current;
    class VERIFY downstream;
```

Immediate merge dependency for this PR: none beyond the already-merged #14770 and #14878 foundation PRs; downstream waves remain stacked on this branch until Wave 1 lands.


## Test Plan

- `pytest tests/unittest/_torch/pyexecutor/test_model_loader_gms.py tests/unittest/_torch/pyexecutor/test_model_loader_mx.py`
- Full L0 CI with `/bot run --disable-fail-fast` before review.
- Local checks completed: `git diff --check`, `py_compile` on changed Python files, and pre-commit. Local pytest was not available in this macOS shell.

## Next Steps

- Wave 2: migrate Linear/Attention transforms into `transform_weights()` with `_weights_transformed` guards.
- Wave 3: migrate MoE and Mamba transforms.
- Wave 4: MX publish-after-transform flip, receiver cutover, and per-model allow-list.

## PR Checklist

- [x] PR description clearly explains what and why.
- [x] Follows TRT-LLM coding guidelines to the best of my knowledge.
- [x] Test cases are provided for new code paths.
- [x] No public API changes.
- [x] No new dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal model initialization and layer alias resolution for improved stability during weight loading.
  * Optimized GPU memory management during model setup and state caching.
  * Updated model loading sequence for read-only GPU memory paths to ensure correct operation ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

