### PR TITLE
[TRTLLM-12648][test] implement disagg cancellation canary thread

### DIFF
--- a/tests/integration/defs/stress_test/disagg_cancel/README.md
+++ b/tests/integration/defs/stress_test/disagg_cancel/README.md
@@ -19,14 +19,15 @@ land incrementally:
 | Thread | Status |
 |--------|--------|
 | `log_scanner_thread` | Implemented — hard-zero log fail-fast |
-| `metrics_thread` | Stub (Step 2) |
+| `metrics_thread` | Implemented — `trtllm_kv_cache_utilization` scraper |
 | `injector_thread` | Implemented — SIGSTOP/SIGCONT/SIGKILL + respawn |
-| `canary_thread` | Stub |
+| `canary_thread` | Implemented — greedy canaries + token-equivalence |
 | `load_thread` | Stub |
 
-Component-level coverage: `test_log_scanner.py`, `test_injector.py`.
-The parametrized marathon pytest still runs a lifecycle smoke until
-`setup()` launches a real cluster and the remaining threads are wired.
+Component-level coverage: `test_log_scanner.py`, `test_metrics_thread.py`,
+`test_injector.py`, `test_canary.py`. The parametrized marathon pytest
+still runs a lifecycle smoke until `setup()` launches a real cluster
+and the remaining thread (`load`) is wired.
 
 ## File layout
 
@@ -37,7 +38,9 @@ tests/integration/defs/stress_test/disagg_cancel/
 ├── harness.py                      (DisaggCancellationStressHarness)
 ├── test_disagg_cancel_stress.py    (pytest entry point)
 ├── test_log_scanner.py             (log_scanner unit tests)
+├── test_metrics_thread.py          (metrics_thread unit tests)
 ├── test_injector.py                (injector unit tests)
+├── test_canary.py                  (canary_thread unit tests)
 └── configs/
     ├── README.md                   (YAML schema + how to add a config)
     ├── marathon_cpp_v1_deepseek.yaml
@@ -74,15 +77,21 @@ cd /path/to/TensorRT-LLM
 
 export PYTHONPATH=tests/integration/defs:tests/integration/defs/disaggregated
 
+# Step 4 — canary thread (greedy canaries + token-equivalence)
+python3 -m pytest -c /dev/null -o addopts= \
+  --confcutdir=tests/integration/defs/stress_test \
+  tests/integration/defs/stress_test/disagg_cancel/test_canary.py -v
+
 # Step 3 — injector thread (SIGSTOP / SIGCONT / SIGKILL + respawn)
 python3 -m pytest -c /dev/null -o addopts= \
   --confcutdir=tests/integration/defs/stress_test \
   tests/integration/defs/stress_test/disagg_cancel/test_injector.py -v
 
-# Step 1 — log scanner (optional sanity alongside injector PR)
+# Steps 1-2 — log scanner + metrics (optional sanity)
 python3 -m pytest -c /dev/null -o addopts= \
   --confcutdir=tests/integration/defs/stress_test \
-  tests/integration/defs/stress_test/disagg_cancel/test_log_scanner.py -v
+  tests/integration/defs/stress_test/disagg_cancel/test_log_scanner.py \
+  tests/integration/defs/stress_test/disagg_cancel/test_metrics_thread.py -v
 
 # Marathon YAML parse/validate (includes stress_config.injections schedule)
 python3 -m pytest -c /dev/null -o addopts= \
@@ -95,9 +104,7 @@ All three together:
 ```bash
 python3 -m pytest -c /dev/null -o addopts= \
   --confcutdir=tests/integration/defs/stress_test \
-  tests/integration/defs/stress_test/disagg_cancel/test_injector.py \
-  tests/integration/defs/stress_test/disagg_cancel/test_log_scanner.py \
-  tests/integration/defs/stress_test/disagg_cancel/test_disagg_cancel_stress.py::test_all_marathon_yamls_parse_and_validate -q
+  tests/integration/defs/stress_test/disagg_cancel/ -q
 ```
 
 In a full TRT-LLM dev container/venv (with `transformers` installed),

--- a/tests/integration/defs/stress_test/disagg_cancel/harness.py
+++ b/tests/integration/defs/stress_test/disagg_cancel/harness.py
@@ -595,37 +595,21 @@ def _fetch_kv_cache_utilization(
 def _load_canary_prompts(path: Path) -> list[dict[str, Any]]:
     """Load and validate the canary prompts JSON.
 
-    Expected schema (produced by the Step 6 reference generator)::
+    Schema (Step 6 reference generator):
+        {"prompts": [{"prompt": str,
+                      "reference_token_ids": [int, ...]?,
+                      "reference_text": str?}, ...]}
 
-        {
-            "prompts": [
-                {
-                    "prompt": "<deterministic prompt text>",
-                    "reference_token_ids": [int, ...],  # greedy-decode reference
-                    "reference_text": "<optional detokenized text>",
-                },
-                ...,
-            ]
-        }
-
-    Args:
-        path: Path to ``stress_canary_prompts.json`` (resolved by the
-            caller relative to the marathon YAML directory).
-
-    Returns:
-        The list of prompt entries (``prompts``). Each entry is a dict
-        with at least a ``prompt`` key; ``reference_token_ids`` is
-        optional but required for token-equivalence checking.
+    Strict validation here keeps a malformed reference from raising
+    `TypeError` inside the daemon canary thread (which would
+    silently freeze `_canary_records`).
 
     Raises:
         OSError: If the file cannot be opened.
-        ValueError: If the JSON is malformed, the top-level object is
-            not a mapping, ``prompts`` is missing/not a list, any
-            entry lacks a string ``prompt``, or any entry's
-            ``reference_token_ids`` is present but not a list of
-            ints. Strict validation here keeps a malformed reference
-            from later raising ``TypeError`` inside the daemon canary
-            thread (which would silently freeze ``_canary_records``).
+        ValueError: On malformed JSON, top-level not a mapping,
+            missing/non-list `prompts`, entry without a string
+            `prompt`, or `reference_token_ids` present but not a
+            list of ints.
     """
     with path.open("r", encoding="utf-8") as f:
         try:
@@ -661,36 +645,20 @@ def _send_canary_request(
     seed: int,
     timeout_s: float,
 ) -> tuple[Optional[list[int]], Optional[str], Optional[str]]:
-    """POST a greedy, deterministic completion to ``/v1/completions``.
+    """POST a greedy, deterministic completion to `/v1/completions`.
 
-    Requests ``detokenize=False`` so the server returns generated
-    ``token_ids`` on ``choices[0]`` for token-equivalence checking
-    (see ``CompletionResponseChoice.token_ids`` in
-    ``tensorrt_llm/serve/openai_protocol.py``). Greedy determinism is
-    requested via ``temperature=0.0`` plus a fixed ``seed``.
-
-    All failures (HTTP error, connection refused, timeout, malformed
-    body) are folded into ``(None, None, error_string)`` rather than
-    raising — the canary thread records an error and continues; only
-    the log scanner is fail-fast.
-
-    Args:
-        server_url: Disagg server base URL, e.g. ``http://host:port``.
-        model: Model name for the OpenAI request envelope.
-        prompt: Prompt text to send.
-        max_tokens: Maximum generated tokens.
-        seed: Fixed seed for greedy determinism.
-        timeout_s: Per-request HTTP timeout in seconds.
+    Requests `detokenize=False` so the response carries generated
+    `token_ids` on `choices[0]` (see
+    `CompletionResponseChoice.token_ids` in
+    `tensorrt_llm/serve/openai_protocol.py`); `temperature=0.0` and
+    a fixed `seed` request greedy determinism.
 
     Returns:
-        Tuple ``(token_ids, text, error)``. On success ``error`` is
-        ``None`` and ``token_ids`` carries the generated tokens
-        (``text`` may also be present); on failure ``token_ids`` is
-        ``None`` and ``error`` is a short reason string. A 200 response
-        that omits ``token_ids`` (e.g. the server ignored
-        ``detokenize=False``) is folded into a ``missing_token_ids``
-        error so the marathon gate counts it as a server-side problem
-        rather than miscounting it as a token-equivalence mismatch.
+        `(token_ids, text, error)`. On success `error is None`. Any
+        failure — HTTP error, connection refused, timeout, malformed
+        body, or a 200 response that omits `token_ids` — folds into
+        a short `error` string so the canary thread records and
+        continues (only the log scanner is fail-fast).
     """
     url = f"{server_url.rstrip('/')}/v1/completions"
     payload = {
@@ -710,7 +678,7 @@ def _send_canary_request(
         with urllib.request.urlopen(req, timeout=timeout_s) as response:
             body = response.read().decode("utf-8", errors="replace")
     except urllib.error.HTTPError as exc:
-        # HTTPError is a subclass of URLError — catch it first.
+        # HTTPError subclasses URLError — catch it first.
         return None, None, f"http_error: {exc.code}"
     except urllib.error.URLError as exc:
         return None, None, f"url_error: {exc.reason}"
@@ -729,11 +697,7 @@ def _send_canary_request(
 
 
 def _tokens_equivalent(returned: Optional[list[int]], reference: Optional[list[int]]) -> bool:
-    """Return True iff ``returned`` exactly matches the ``reference`` token IDs.
-
-    A ``None`` on either side (no tokens returned, or no reference
-    recorded) is treated as not-equivalent.
-    """
+    """True iff `returned` exactly matches `reference`; `None` on either side is non-equivalent."""
     if returned is None or reference is None:
         return False
     return list(returned) == list(reference)
@@ -763,9 +727,9 @@ class DisaggCancellationStressHarness:
     subprocess-control injector, the file-tailing log scanner, the
     HTTP/Prometheus metrics scraper, and the HTTP canary client
     failure-isolated and debugged independently. The metrics and
-    canary threads use blocking ``urllib`` for their low-rate request
+    canary threads use blocking `urllib` for their low-rate request
     streams; the load thread runs its own asyncio event loop
-    internally (wrapping ``run_cancel_stress_test``).
+    internally (wrapping `run_cancel_stress_test`).
     """
 
     def __init__(
@@ -802,15 +766,13 @@ class DisaggCancellationStressHarness:
                 injector thread while waiting for the next scheduled
                 event. Tests pass a smaller value to keep wall-clock
                 latency bounded.
-            canary_request_timeout_s: Per-request HTTP timeout for a
-                canary completion. A slow/hung request is recorded as
-                an error rather than blocking the canary stream
-                indefinitely.
-            canary_interval_s: Optional override (seconds) for the gap
-                between consecutive canary requests. ``None`` (default)
-                derives the interval from ``canary.rate_per_min`` in
-                the YAML (``60 / rate_per_min``); tests pass a small
-                value to keep wall-clock latency bounded.
+            canary_request_timeout_s: Per-request HTTP timeout for
+                one canary completion; a slow/hung request becomes
+                an error rather than blocking the canary stream.
+            canary_interval_s: Optional override (seconds) for the
+                gap between requests. `None` derives from
+                `canary.rate_per_min` (`60 / rate_per_min`); tests
+                pass a small value.
 
         Raises:
             ValueError: If the YAML is malformed or its
@@ -839,10 +801,9 @@ class DisaggCancellationStressHarness:
         self._tracked_workers: list[_TrackedWorker] = []
         self._marathon_start_monotonic: float = 0.0
 
-        # Disagg-server front-end endpoint the canary client targets.
-        # Populated by setup() once setup_disagg_cluster returns (or by
-        # tests via bind_server_endpoint). None until then; the canary
-        # thread logs a warning and exits if it is still None.
+        # Disagg-server front-end the canary targets; populated by
+        # setup() or bind_server_endpoint(). None until then — the
+        # canary thread warns and exits.
         self._server_url: Optional[str] = None
         self._model_name: Optional[str] = None
 
@@ -898,17 +859,12 @@ class DisaggCancellationStressHarness:
         self._worker_specs = list(ctx_specs) + list(gen_specs)
 
     def bind_server_endpoint(self, server_url: str, model_name: str) -> None:
-        """Register the disagg server front-end the canary client targets.
+        """Register the disagg server front-end for the canary client.
 
-        Called by ``setup()`` once ``setup_disagg_cluster`` returns the
-        server host/port. Until this is called, the canary thread logs
-        a warning and exits (the lifecycle smoke has no live server).
-
-        Args:
-            server_url: Base URL of the disagg server, e.g.
-                ``http://localhost:8000``.
-            model_name: Model name to put in the OpenAI request
-                envelope (the disagg server routes regardless).
+        Called by `setup()` (or tests). Until called, the canary
+        thread warns and exits — the lifecycle smoke has no live
+        server. `model_name` goes in the OpenAI envelope only; the
+        disagg server routes regardless.
         """
         self._server_url = server_url
         self._model_name = model_name
@@ -1087,36 +1043,22 @@ class DisaggCancellationStressHarness:
         self.stop_event.set()
 
     def _canary_thread_body(self) -> None:
-        """Send greedy-decode canaries and check token-equivalence.
+        """Send greedy canaries and append per-request records to `_canary_records`.
 
-        Loads ``canary.prompts_file`` (resolved relative to the
-        marathon YAML), then sends deterministic greedy completions to
-        the disagg server's ``/v1/completions`` at
-        ``canary.rate_per_min`` cadence (overridable via the
-        ``canary_interval_s`` ctor param for tests). Each response is
-        compared against the recorded ``reference_token_ids`` and a
-        per-request record is appended to ``self._canary_records``::
+        Each record: `{timestamp, elapsed_s, prompt_index, success,
+        token_equivalent, latency_s, error}`. `token_equivalent` is
+        True/False when a reference is recorded and the check is
+        enabled, else None. Failures are recorded — not fail-fast —
+        because errors during bursts/injections are expected; the
+        end-of-marathon gates (error rate, recovery time) are
+        computed from these records later.
 
-            {timestamp, elapsed_s, prompt_index, success, token_equivalent, latency_s, error}
-
-        ``success`` is ``True`` when the HTTP request returned without
-        error. ``token_equivalent`` is ``True``/``False`` when a
-        reference is available and the check is enabled, else ``None``
-        (request failed, checking disabled, or no reference recorded).
-        Request failures are recorded — not fail-fast — because errors
-        during bursts / injections are expected; the end-of-marathon
-        gates (error rate, recovery time) are computed from these
-        records by the load thread / pytest assertion in a later step.
-
-        Exits when ``stop_event`` or ``failed_event`` is set. The
-        between-request wait only observes ``stop_event``, so a
-        ``failed_event`` fired mid-interval is acted on at the next
-        request boundary (worst-case lag = one canary interval). The
-        metrics thread has the same characteristic; a shared
-        ``wait_for_any([stop_event, failed_event], ...)`` helper is
-        deferred to a follow-up PR. No-ops with a warning if the
-        server endpoint or prompts file is absent (the lifecycle
-        smoke before ``setup()`` is wired).
+        Exits on `stop_event` or `failed_event`. The between-request
+        wait only observes `stop_event`, so `failed_event` is acted
+        on at the next request boundary (max lag = one interval);
+        the metrics thread has the same gap, a shared `wait_for_any`
+        helper is deferred to a follow-up PR. Warns and exits if the
+        server endpoint or prompts file is absent.
         """
         canary_cfg = self.config.raw.get("canary") or {}
         if not self._server_url:

--- a/tests/integration/defs/stress_test/disagg_cancel/harness.py
+++ b/tests/integration/defs/stress_test/disagg_cancel/harness.py
@@ -620,8 +620,12 @@ def _load_canary_prompts(path: Path) -> list[dict[str, Any]]:
     Raises:
         OSError: If the file cannot be opened.
         ValueError: If the JSON is malformed, the top-level object is
-            not a mapping, ``prompts`` is missing/not a list, or any
-            entry lacks a string ``prompt``.
+            not a mapping, ``prompts`` is missing/not a list, any
+            entry lacks a string ``prompt``, or any entry's
+            ``reference_token_ids`` is present but not a list of
+            ints. Strict validation here keeps a malformed reference
+            from later raising ``TypeError`` inside the daemon canary
+            thread (which would silently freeze ``_canary_records``).
     """
     with path.open("r", encoding="utf-8") as f:
         try:
@@ -637,6 +641,14 @@ def _load_canary_prompts(path: Path) -> list[dict[str, Any]]:
         if not isinstance(entry, dict) or not isinstance(entry.get("prompt"), str):
             raise ValueError(
                 f"canary prompts file {path}: prompts[{i}] must be an object with a string 'prompt'"
+            )
+        ref = entry.get("reference_token_ids")
+        if ref is not None and (
+            not isinstance(ref, list) or not all(isinstance(t, int) for t in ref)
+        ):
+            raise ValueError(
+                f"canary prompts file {path}: prompts[{i}].reference_token_ids "
+                "must be a list of ints (or omitted)"
             )
     return prompts
 
@@ -673,8 +685,12 @@ def _send_canary_request(
     Returns:
         Tuple ``(token_ids, text, error)``. On success ``error`` is
         ``None`` and ``token_ids`` carries the generated tokens
-        (``text`` may also be present); on failure ``token_ids`` and
-        ``text`` are ``None`` and ``error`` is a short reason string.
+        (``text`` may also be present); on failure ``token_ids`` is
+        ``None`` and ``error`` is a short reason string. A 200 response
+        that omits ``token_ids`` (e.g. the server ignored
+        ``detokenize=False``) is folded into a ``missing_token_ids``
+        error so the marathon gate counts it as a server-side problem
+        rather than miscounting it as a token-equivalence mismatch.
     """
     url = f"{server_url.rstrip('/')}/v1/completions"
     payload = {
@@ -707,6 +723,8 @@ def _send_canary_request(
         return None, None, f"parse_error: {exc}"
     token_ids = choice.get("token_ids") if isinstance(choice, dict) else None
     text = choice.get("text") if isinstance(choice, dict) else None
+    if token_ids is None:
+        return None, text, "missing_token_ids"
     return token_ids, text, None
 
 
@@ -1090,10 +1108,15 @@ class DisaggCancellationStressHarness:
         gates (error rate, recovery time) are computed from these
         records by the load thread / pytest assertion in a later step.
 
-        Exits when ``stop_event`` or ``failed_event`` is set, honoring
-        either signal between requests via ``stop_event.wait``. No-ops
-        with a warning if the server endpoint or prompts file is
-        absent (the lifecycle smoke before ``setup()`` is wired).
+        Exits when ``stop_event`` or ``failed_event`` is set. The
+        between-request wait only observes ``stop_event``, so a
+        ``failed_event`` fired mid-interval is acted on at the next
+        request boundary (worst-case lag = one canary interval). The
+        metrics thread has the same characteristic; a shared
+        ``wait_for_any([stop_event, failed_event], ...)`` helper is
+        deferred to a follow-up PR. No-ops with a warning if the
+        server endpoint or prompts file is absent (the lifecycle
+        smoke before ``setup()`` is wired).
         """
         canary_cfg = self.config.raw.get("canary") or {}
         if not self._server_url:
@@ -1115,19 +1138,23 @@ class DisaggCancellationStressHarness:
             logger.warning("[canary] prompts file %s has no prompts; exiting", prompts_path)
             return
 
-        rate_per_min = float(canary_cfg.get("rate_per_min", 5) or 5)
         if self._canary_interval_s is not None:
             interval_s = self._canary_interval_s
         else:
-            interval_s = 60.0 / rate_per_min if rate_per_min > 0 else 12.0
+            rate_per_min = float(canary_cfg.get("rate_per_min") or 0)
+            if rate_per_min <= 0:
+                logger.warning(
+                    "[canary] canary.rate_per_min is missing/zero/negative; defaulting to 5/min"
+                )
+                rate_per_min = 5.0
+            interval_s = 60.0 / rate_per_min
         max_tokens = int(canary_cfg.get("max_tokens", 128))
         seed = int(canary_cfg.get("seed", 42))
         check_token_equiv = bool(canary_cfg.get("check_token_equivalent", True))
         model = self._model_name or "canary"
 
         logger.info(
-            "[canary] %.1f req/min (interval %.2fs) over %d prompt(s) to %s",
-            rate_per_min,
+            "[canary] interval %.2fs over %d prompt(s) to %s",
             interval_s,
             len(prompts),
             self._server_url,
@@ -1140,7 +1167,7 @@ class DisaggCancellationStressHarness:
             entry = prompts[prompt_index]
             idx += 1
             reference = entry.get("reference_token_ids")
-            token_ids, _text, err = _send_canary_request(
+            token_ids, _, err = _send_canary_request(
                 self._server_url,
                 model,
                 entry["prompt"],

--- a/tests/integration/defs/stress_test/disagg_cancel/harness.py
+++ b/tests/integration/defs/stress_test/disagg_cancel/harness.py
@@ -28,6 +28,7 @@ suite matures.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import random
@@ -587,6 +588,140 @@ def _fetch_kv_cache_utilization(
 
 
 # ---------------------------------------------------------------------------
+# Canary helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_canary_prompts(path: Path) -> list[dict[str, Any]]:
+    """Load and validate the canary prompts JSON.
+
+    Expected schema (produced by the Step 6 reference generator)::
+
+        {
+            "prompts": [
+                {
+                    "prompt": "<deterministic prompt text>",
+                    "reference_token_ids": [int, ...],  # greedy-decode reference
+                    "reference_text": "<optional detokenized text>",
+                },
+                ...,
+            ]
+        }
+
+    Args:
+        path: Path to ``stress_canary_prompts.json`` (resolved by the
+            caller relative to the marathon YAML directory).
+
+    Returns:
+        The list of prompt entries (``prompts``). Each entry is a dict
+        with at least a ``prompt`` key; ``reference_token_ids`` is
+        optional but required for token-equivalence checking.
+
+    Raises:
+        OSError: If the file cannot be opened.
+        ValueError: If the JSON is malformed, the top-level object is
+            not a mapping, ``prompts`` is missing/not a list, or any
+            entry lacks a string ``prompt``.
+    """
+    with path.open("r", encoding="utf-8") as f:
+        try:
+            doc = json.load(f)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"canary prompts file {path} is not valid JSON: {exc}") from exc
+    if not isinstance(doc, dict) or "prompts" not in doc:
+        raise ValueError(f"canary prompts file {path} must be an object with a 'prompts' list")
+    prompts = doc["prompts"]
+    if not isinstance(prompts, list):
+        raise ValueError(f"canary prompts file {path}: 'prompts' must be a list")
+    for i, entry in enumerate(prompts):
+        if not isinstance(entry, dict) or not isinstance(entry.get("prompt"), str):
+            raise ValueError(
+                f"canary prompts file {path}: prompts[{i}] must be an object with a string 'prompt'"
+            )
+    return prompts
+
+
+def _send_canary_request(
+    server_url: str,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    seed: int,
+    timeout_s: float,
+) -> tuple[Optional[list[int]], Optional[str], Optional[str]]:
+    """POST a greedy, deterministic completion to ``/v1/completions``.
+
+    Requests ``detokenize=False`` so the server returns generated
+    ``token_ids`` on ``choices[0]`` for token-equivalence checking
+    (see ``CompletionResponseChoice.token_ids`` in
+    ``tensorrt_llm/serve/openai_protocol.py``). Greedy determinism is
+    requested via ``temperature=0.0`` plus a fixed ``seed``.
+
+    All failures (HTTP error, connection refused, timeout, malformed
+    body) are folded into ``(None, None, error_string)`` rather than
+    raising — the canary thread records an error and continues; only
+    the log scanner is fail-fast.
+
+    Args:
+        server_url: Disagg server base URL, e.g. ``http://host:port``.
+        model: Model name for the OpenAI request envelope.
+        prompt: Prompt text to send.
+        max_tokens: Maximum generated tokens.
+        seed: Fixed seed for greedy determinism.
+        timeout_s: Per-request HTTP timeout in seconds.
+
+    Returns:
+        Tuple ``(token_ids, text, error)``. On success ``error`` is
+        ``None`` and ``token_ids`` carries the generated tokens
+        (``text`` may also be present); on failure ``token_ids`` and
+        ``text`` are ``None`` and ``error`` is a short reason string.
+    """
+    url = f"{server_url.rstrip('/')}/v1/completions"
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+        "seed": seed,
+        "stream": False,
+        "detokenize": False,
+    }
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}, method="POST"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as response:
+            body = response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        # HTTPError is a subclass of URLError — catch it first.
+        return None, None, f"http_error: {exc.code}"
+    except urllib.error.URLError as exc:
+        return None, None, f"url_error: {exc.reason}"
+    except (TimeoutError, OSError) as exc:
+        return None, None, f"io_error: {exc}"
+    try:
+        obj = json.loads(body)
+        choice = obj["choices"][0]
+    except (json.JSONDecodeError, KeyError, IndexError, TypeError) as exc:
+        return None, None, f"parse_error: {exc}"
+    token_ids = choice.get("token_ids") if isinstance(choice, dict) else None
+    text = choice.get("text") if isinstance(choice, dict) else None
+    return token_ids, text, None
+
+
+def _tokens_equivalent(returned: Optional[list[int]], reference: Optional[list[int]]) -> bool:
+    """Return True iff ``returned`` exactly matches the ``reference`` token IDs.
+
+    A ``None`` on either side (no tokens returned, or no reference
+    recorded) is treated as not-equivalent.
+    """
+    if returned is None or reference is None:
+        return False
+    return list(returned) == list(reference)
+
+
+# ---------------------------------------------------------------------------
 # Harness
 # ---------------------------------------------------------------------------
 
@@ -607,10 +742,12 @@ class DisaggCancellationStressHarness:
       wind down promptly.
 
     Thread-based composition (rather than asyncio) keeps the
-    subprocess-control injector, the file-tailing log scanner, and
-    the HTTP/Prometheus metrics scraper failure-isolated and debugged
-    independently. The load and canary threads each run their own
-    asyncio event loops internally for HTTP I/O.
+    subprocess-control injector, the file-tailing log scanner, the
+    HTTP/Prometheus metrics scraper, and the HTTP canary client
+    failure-isolated and debugged independently. The metrics and
+    canary threads use blocking ``urllib`` for their low-rate request
+    streams; the load thread runs its own asyncio event loop
+    internally (wrapping ``run_cancel_stress_test``).
     """
 
     def __init__(
@@ -621,6 +758,8 @@ class DisaggCancellationStressHarness:
         metrics_scrape_interval_s: float = 30.0,
         metrics_scrape_timeout_s: float = 5.0,
         injector_poll_interval_s: float = 1.0,
+        canary_request_timeout_s: float = 10.0,
+        canary_interval_s: Optional[float] = None,
     ) -> None:
         """Construct a marathon harness.
 
@@ -645,6 +784,15 @@ class DisaggCancellationStressHarness:
                 injector thread while waiting for the next scheduled
                 event. Tests pass a smaller value to keep wall-clock
                 latency bounded.
+            canary_request_timeout_s: Per-request HTTP timeout for a
+                canary completion. A slow/hung request is recorded as
+                an error rather than blocking the canary stream
+                indefinitely.
+            canary_interval_s: Optional override (seconds) for the gap
+                between consecutive canary requests. ``None`` (default)
+                derives the interval from ``canary.rate_per_min`` in
+                the YAML (``60 / rate_per_min``); tests pass a small
+                value to keep wall-clock latency bounded.
 
         Raises:
             ValueError: If the YAML is malformed or its
@@ -664,12 +812,21 @@ class DisaggCancellationStressHarness:
         self._metrics_scrape_interval_s: float = metrics_scrape_interval_s
         self._metrics_scrape_timeout_s: float = metrics_scrape_timeout_s
         self._injector_poll_interval_s: float = injector_poll_interval_s
+        self._canary_request_timeout_s: float = canary_request_timeout_s
+        self._canary_interval_s: Optional[float] = canary_interval_s
 
         # Cluster + worker tracking (populated by setup()).
         self._cluster: Any = None  # tuple returned by setup_disagg_cluster
         self._worker_specs: list[WorkerLaunchSpec] = []
         self._tracked_workers: list[_TrackedWorker] = []
         self._marathon_start_monotonic: float = 0.0
+
+        # Disagg-server front-end endpoint the canary client targets.
+        # Populated by setup() once setup_disagg_cluster returns (or by
+        # tests via bind_server_endpoint). None until then; the canary
+        # thread logs a warning and exits if it is still None.
+        self._server_url: Optional[str] = None
+        self._model_name: Optional[str] = None
 
         # Thread handles (populated by start()).
         self._load_thread: Optional[threading.Thread] = None
@@ -721,6 +878,22 @@ class DisaggCancellationStressHarness:
             for spec, wrapper in zip(gen_specs, gen_workers, strict=True)
         ]
         self._worker_specs = list(ctx_specs) + list(gen_specs)
+
+    def bind_server_endpoint(self, server_url: str, model_name: str) -> None:
+        """Register the disagg server front-end the canary client targets.
+
+        Called by ``setup()`` once ``setup_disagg_cluster`` returns the
+        server host/port. Until this is called, the canary thread logs
+        a warning and exits (the lifecycle smoke has no live server).
+
+        Args:
+            server_url: Base URL of the disagg server, e.g.
+                ``http://localhost:8000``.
+            model_name: Model name to put in the OpenAI request
+                envelope (the disagg server routes regardless).
+        """
+        self._server_url = server_url
+        self._model_name = model_name
 
     def start(self) -> None:
         """Spawn the five worker threads. Returns immediately.
@@ -896,13 +1069,105 @@ class DisaggCancellationStressHarness:
         self.stop_event.set()
 
     def _canary_thread_body(self) -> None:
-        """Send greedy-decode canaries, check token-equivalence.
+        """Send greedy-decode canaries and check token-equivalence.
 
-        Stub: no-op. Real implementation loads
-        ``stress_canary_prompts.json``, sends 5 reqs/min, asserts
-        token IDs match the recorded reference.
+        Loads ``canary.prompts_file`` (resolved relative to the
+        marathon YAML), then sends deterministic greedy completions to
+        the disagg server's ``/v1/completions`` at
+        ``canary.rate_per_min`` cadence (overridable via the
+        ``canary_interval_s`` ctor param for tests). Each response is
+        compared against the recorded ``reference_token_ids`` and a
+        per-request record is appended to ``self._canary_records``::
+
+            {timestamp, elapsed_s, prompt_index, success, token_equivalent, latency_s, error}
+
+        ``success`` is ``True`` when the HTTP request returned without
+        error. ``token_equivalent`` is ``True``/``False`` when a
+        reference is available and the check is enabled, else ``None``
+        (request failed, checking disabled, or no reference recorded).
+        Request failures are recorded — not fail-fast — because errors
+        during bursts / injections are expected; the end-of-marathon
+        gates (error rate, recovery time) are computed from these
+        records by the load thread / pytest assertion in a later step.
+
+        Exits when ``stop_event`` or ``failed_event`` is set, honoring
+        either signal between requests via ``stop_event.wait``. No-ops
+        with a warning if the server endpoint or prompts file is
+        absent (the lifecycle smoke before ``setup()`` is wired).
         """
-        logger.debug("[canary_thread] stub — exiting immediately")
+        canary_cfg = self.config.raw.get("canary") or {}
+        if not self._server_url:
+            logger.warning("[canary] no server endpoint bound (setup() not wired); exiting")
+            return
+        prompts_file = canary_cfg.get("prompts_file")
+        if not prompts_file:
+            logger.warning("[canary] no canary.prompts_file in config; exiting")
+            return
+        prompts_path = Path(prompts_file)
+        if not prompts_path.is_absolute():
+            prompts_path = self.yaml_path.parent / prompts_path
+        try:
+            prompts = _load_canary_prompts(prompts_path)
+        except (OSError, ValueError) as exc:
+            logger.warning("[canary] cannot load prompts %s: %s; exiting", prompts_path, exc)
+            return
+        if not prompts:
+            logger.warning("[canary] prompts file %s has no prompts; exiting", prompts_path)
+            return
+
+        rate_per_min = float(canary_cfg.get("rate_per_min", 5) or 5)
+        if self._canary_interval_s is not None:
+            interval_s = self._canary_interval_s
+        else:
+            interval_s = 60.0 / rate_per_min if rate_per_min > 0 else 12.0
+        max_tokens = int(canary_cfg.get("max_tokens", 128))
+        seed = int(canary_cfg.get("seed", 42))
+        check_token_equiv = bool(canary_cfg.get("check_token_equivalent", True))
+        model = self._model_name or "canary"
+
+        logger.info(
+            "[canary] %.1f req/min (interval %.2fs) over %d prompt(s) to %s",
+            rate_per_min,
+            interval_s,
+            len(prompts),
+            self._server_url,
+        )
+
+        idx = 0
+        while not self.stop_event.is_set() and not self.failed_event.is_set():
+            send_start = time.monotonic()
+            prompt_index = idx % len(prompts)
+            entry = prompts[prompt_index]
+            idx += 1
+            reference = entry.get("reference_token_ids")
+            token_ids, _text, err = _send_canary_request(
+                self._server_url,
+                model,
+                entry["prompt"],
+                max_tokens,
+                seed,
+                self._canary_request_timeout_s,
+            )
+            success = err is None
+            token_equivalent: Optional[bool] = None
+            if success and check_token_equiv and reference is not None:
+                token_equivalent = _tokens_equivalent(token_ids, reference)
+            self._canary_records.append(
+                {
+                    "timestamp": time.time(),
+                    "elapsed_s": time.monotonic() - self._marathon_start_monotonic,
+                    "prompt_index": prompt_index,
+                    "success": success,
+                    "token_equivalent": token_equivalent,
+                    "latency_s": time.monotonic() - send_start,
+                    "error": err,
+                }
+            )
+            remaining = interval_s - (time.monotonic() - send_start)
+            if remaining > 0.0:
+                self.stop_event.wait(timeout=remaining)
+
+        logger.debug("[canary] exiting; %d record(s)", len(self._canary_records))
 
     def _injector_thread_body(self) -> None:
         """Fire SIGSTOP / SIGCONT / SIGKILL+respawn on the configured schedule.

--- a/tests/integration/defs/stress_test/disagg_cancel/test_canary.py
+++ b/tests/integration/defs/stress_test/disagg_cancel/test_canary.py
@@ -69,6 +69,10 @@ class _CompletionsHandler(BaseHTTPRequestHandler):
       status code is sent (e.g. 503 to simulate a worker mid-restart).
     - ``server.raw_body``: if set (str), sent verbatim as a 200 body
       (used to exercise the malformed-JSON parse path).
+
+    Each request's parsed JSON body is appended to
+    ``server.request_bodies`` so tests can assert on the wire format
+    (e.g. ``temperature``, ``seed``, ``detokenize``).
     """
 
     def do_POST(self) -> None:  # noqa: N802 — fixed by BaseHTTPRequestHandler
@@ -77,8 +81,11 @@ class _CompletionsHandler(BaseHTTPRequestHandler):
             self.end_headers()
             return
         length = int(self.headers.get("Content-Length", 0))
-        if length:
-            self.rfile.read(length)  # drain request body
+        body = self.rfile.read(length) if length else b""
+        try:
+            self.server.request_bodies.append(json.loads(body))  # type: ignore[attr-defined]
+        except (json.JSONDecodeError, AttributeError):
+            pass
 
         status = getattr(self.server, "status", 200)
         if status != 200:
@@ -123,6 +130,7 @@ def completions_server():
     server.text = "ok"  # type: ignore[attr-defined]
     server.status = 200  # type: ignore[attr-defined]
     server.raw_body = None  # type: ignore[attr-defined]
+    server.request_bodies = []  # type: ignore[attr-defined]
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
@@ -253,6 +261,25 @@ def test_load_prompts_entry_missing_prompt_raises(tmp_path: Path) -> None:
         _load_canary_prompts(path)
 
 
+def test_load_prompts_reference_token_ids_non_list_raises(tmp_path: Path) -> None:
+    path = _write_prompts(tmp_path, [{"prompt": "p", "reference_token_ids": 123}])
+    with pytest.raises(ValueError, match="reference_token_ids"):
+        _load_canary_prompts(path)
+
+
+def test_load_prompts_reference_token_ids_non_int_element_raises(tmp_path: Path) -> None:
+    path = _write_prompts(tmp_path, [{"prompt": "p", "reference_token_ids": [1, "two"]}])
+    with pytest.raises(ValueError, match="reference_token_ids"):
+        _load_canary_prompts(path)
+
+
+def test_load_prompts_reference_token_ids_omitted_is_allowed(tmp_path: Path) -> None:
+    # Schema permits omission — token-equivalence then records ``None``.
+    path = _write_prompts(tmp_path, [{"prompt": "p"}])
+    prompts = _load_canary_prompts(path)
+    assert prompts == [{"prompt": "p"}]
+
+
 # ---------------------------------------------------------------------------
 # Token-equivalence helper tests
 # ---------------------------------------------------------------------------
@@ -317,6 +344,47 @@ def test_send_malformed_body_returns_parse_error(completions_server) -> None:
     )
     assert token_ids is None
     assert err is not None and err.startswith("parse_error")
+
+
+def test_send_missing_token_ids_returns_error(completions_server) -> None:
+    # Server returns a 200 response whose ``choices[0]`` carries no
+    # ``token_ids`` (e.g. it ignored ``detokenize=False``). Must be
+    # reported as a server-side error rather than miscounted as a
+    # token-equivalence mismatch downstream.
+    server, port = completions_server
+    server.token_ids = None
+    server.text = "hi"
+    token_ids, text, err = _send_canary_request(
+        f"http://127.0.0.1:{port}", "m", "prompt", max_tokens=8, seed=42, timeout_s=1.0
+    )
+    assert token_ids is None
+    assert text == "hi"
+    assert err == "missing_token_ids"
+
+
+def test_send_wire_format_includes_greedy_determinism_knobs(completions_server) -> None:
+    # Pin the on-wire request shape so a future ``_send_canary_request``
+    # change can't silently drop ``temperature=0.0`` / ``seed`` /
+    # ``detokenize=False`` (any of which would invalidate the
+    # token-equivalence contract).
+    server, port = completions_server
+    _send_canary_request(
+        f"http://127.0.0.1:{port}",
+        "test-model",
+        "the prompt",
+        max_tokens=11,
+        seed=7,
+        timeout_s=1.0,
+    )
+    assert len(server.request_bodies) == 1
+    body = server.request_bodies[0]
+    assert body["model"] == "test-model"
+    assert body["prompt"] == "the prompt"
+    assert body["max_tokens"] == 11
+    assert body["temperature"] == 0.0
+    assert body["seed"] == 7
+    assert body["stream"] is False
+    assert body["detokenize"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -445,13 +513,66 @@ def test_thread_exits_when_prompts_file_missing(tmp_path, completions_server) ->
 
 
 def test_thread_exits_promptly_on_failed_event(tmp_path, completions_server) -> None:
+    # The between-request wait only observes ``stop_event``, so the
+    # thread acts on ``failed_event`` at the next request boundary.
+    # Bound the lag to one canary interval (here 20 ms) by asserting
+    # that no more than one extra record is appended after the event
+    # fires — this would catch a future regression that fully
+    # re-enters the request loop after fail-fast.
     server, port = completions_server
     _write_prompts(tmp_path, [{"prompt": "p", "reference_token_ids": [1, 2, 3]}])
     h = _make_harness(tmp_path, server_url=f"http://127.0.0.1:{port}")
 
     thread = threading.Thread(target=h._canary_thread_body, daemon=True)
     thread.start()
-    time.sleep(0.05)
+    _wait_until(lambda: len(h._canary_records) >= 1, timeout_s=2.0)
+    pre = len(h._canary_records)
     h.failed_event.set()
     thread.join(timeout=2.0)
     assert not thread.is_alive(), "canary thread must exit on failed_event too"
+    assert len(h._canary_records) - pre <= 1, (
+        "thread re-entered request loop after failed_event "
+        f"(records grew by {len(h._canary_records) - pre})"
+    )
+
+
+def test_thread_exits_when_prompts_list_empty(tmp_path, completions_server) -> None:
+    # Empty ``prompts`` list is a recoverable misconfiguration, not a
+    # crash; the thread logs a warning and exits without appending
+    # any records.
+    server, port = completions_server
+    _write_prompts(tmp_path, [])
+    h = _make_harness(tmp_path, server_url=f"http://127.0.0.1:{port}")
+
+    thread = threading.Thread(target=h._canary_thread_body, daemon=True)
+    thread.start()
+    thread.join(timeout=2.0)
+    assert not thread.is_alive()
+    assert h._canary_records == []
+
+
+def test_thread_resolves_absolute_prompts_path(tmp_path, completions_server) -> None:
+    # When the YAML's ``prompts_file`` is an absolute path, the
+    # harness must NOT join it against ``yaml_path.parent``; verify
+    # by placing the prompts file outside the YAML directory and
+    # confirming the thread loads it and produces records.
+    server, port = completions_server
+    server.token_ids = [1, 2, 3]
+    outside_dir = tmp_path / "elsewhere"
+    outside_dir.mkdir()
+    prompts_path = outside_dir / "abs_prompts.json"
+    prompts_path.write_text(
+        json.dumps({"prompts": [{"prompt": "p", "reference_token_ids": [1, 2, 3]}]}),
+        encoding="utf-8",
+    )
+    h = _make_harness(
+        tmp_path,
+        prompts_file=str(prompts_path),  # absolute
+        server_url=f"http://127.0.0.1:{port}",
+    )
+
+    _run_canary_thread_briefly(h, duration_s=0.15)
+
+    assert len(h._canary_records) >= 1
+    assert all(rec["success"] is True for rec in h._canary_records)
+    assert all(rec["token_equivalent"] is True for rec in h._canary_records)

--- a/tests/integration/defs/stress_test/disagg_cancel/test_canary.py
+++ b/tests/integration/defs/stress_test/disagg_cancel/test_canary.py
@@ -1,0 +1,457 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for ``DisaggCancellationStressHarness._canary_thread_body``.
+
+The canary thread is testable without a real disagg cluster: stand up
+a tiny HTTP server in the test process that answers
+``POST /v1/completions`` with a configurable ``token_ids`` payload,
+point the harness at it via ``bind_server_endpoint``, run the thread
+for a few intervals, and assert on the collected ``_canary_records``.
+
+Prompt-loader and token-equivalence behaviour are verified directly
+against the standalone helpers; transport behaviour (success, HTTP
+error, connection refused, malformed body) is verified against the
+in-process HTTP server.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import textwrap
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+from .harness import (
+    DisaggCancellationStressHarness,
+    _load_canary_prompts,
+    _send_canary_request,
+    _tokens_equivalent,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+def _pick_port() -> int:
+    """Bind-and-release to get an OS-allocated free TCP port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+class _CompletionsHandler(BaseHTTPRequestHandler):
+    """Answers ``POST /v1/completions`` with a configurable payload.
+
+    The response is read off the server instance on every request so
+    tests can mutate it mid-run:
+
+    - ``server.token_ids``: list returned as ``choices[0].token_ids``.
+    - ``server.text``: string returned as ``choices[0].text``.
+    - ``server.status``: if not 200, an empty error response with that
+      status code is sent (e.g. 503 to simulate a worker mid-restart).
+    - ``server.raw_body``: if set (str), sent verbatim as a 200 body
+      (used to exercise the malformed-JSON parse path).
+    """
+
+    def do_POST(self) -> None:  # noqa: N802 — fixed by BaseHTTPRequestHandler
+        if self.path != "/v1/completions":
+            self.send_response(404)
+            self.end_headers()
+            return
+        length = int(self.headers.get("Content-Length", 0))
+        if length:
+            self.rfile.read(length)  # drain request body
+
+        status = getattr(self.server, "status", 200)
+        if status != 200:
+            self.send_response(status)
+            self.end_headers()
+            return
+
+        raw_body = getattr(self.server, "raw_body", None)
+        if raw_body is not None:
+            encoded = raw_body.encode("utf-8")
+        else:
+            payload = {
+                "choices": [
+                    {
+                        "token_ids": getattr(self.server, "token_ids", None),
+                        "text": getattr(self.server, "text", ""),
+                    }
+                ]
+            }
+            encoded = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def log_message(self, *_args, **_kwargs) -> None:  # silence test noise
+        pass
+
+
+@pytest.fixture
+def completions_server():
+    """In-process HTTP server answering ``POST /v1/completions``.
+
+    Yields ``(server, port)``. Tests mutate ``server.token_ids`` /
+    ``server.text`` / ``server.status`` / ``server.raw_body`` to drive
+    request outcomes.
+    """
+    port = _pick_port()
+    server = HTTPServer(("127.0.0.1", port), _CompletionsHandler)
+    server.token_ids = [1, 2, 3]  # type: ignore[attr-defined]
+    server.text = "ok"  # type: ignore[attr-defined]
+    server.status = 200  # type: ignore[attr-defined]
+    server.raw_body = None  # type: ignore[attr-defined]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server, port
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+
+
+def _write_prompts(tmp_path: Path, entries: list[dict]) -> Path:
+    """Write a ``stress_canary_prompts.json``-shaped file and return its path."""
+    path = tmp_path / "stress_canary_prompts.json"
+    path.write_text(json.dumps({"prompts": entries}), encoding="utf-8")
+    return path
+
+
+_CANARY_YAML = textwrap.dedent(
+    """\
+    hostname: localhost
+    model: dummy
+    backend: pytorch
+    context_servers: {{}}
+    generation_servers: {{}}
+    stress_config:
+      duration_min: 1
+      kv_cache_manager: v1
+      transceiver: cpp
+      canary:
+        prompts_file: {prompts_file}
+        rate_per_min: 5
+        max_tokens: 8
+        seed: 42
+        check_token_equivalent: {check_equiv}
+    """
+)
+
+
+def _make_harness(
+    tmp_path: Path,
+    *,
+    prompts_file: str = "stress_canary_prompts.json",
+    check_equiv: bool = True,
+    server_url: str | None = "http://127.0.0.1:1",
+) -> DisaggCancellationStressHarness:
+    """Construct a canary harness with a small interval and bound endpoint."""
+    yaml_path = tmp_path / "marathon.yaml"
+    yaml_path.write_text(
+        _CANARY_YAML.format(
+            prompts_file=prompts_file,
+            check_equiv="true" if check_equiv else "false",
+        )
+    )
+    h = DisaggCancellationStressHarness(
+        yaml_path,
+        canary_interval_s=0.02,
+        canary_request_timeout_s=1.0,
+    )
+    if server_url is not None:
+        h.bind_server_endpoint(server_url, "test-model")
+    return h
+
+
+def _run_canary_thread_briefly(h: DisaggCancellationStressHarness, duration_s: float) -> None:
+    """Drive ``_canary_thread_body`` for ``duration_s`` seconds then stop."""
+    thread = threading.Thread(target=h._canary_thread_body, daemon=True)
+    thread.start()
+    time.sleep(duration_s)
+    h.stop_event.set()
+    thread.join(timeout=2.0)
+    assert not thread.is_alive(), "canary thread failed to exit after stop_event"
+
+
+def _wait_until(predicate, *, timeout_s: float, poll_s: float = 0.01) -> None:
+    """Poll ``predicate`` until true or ``timeout_s`` elapses; assert on timeout."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(poll_s)
+    raise AssertionError(f"predicate did not become true within {timeout_s}s")
+
+
+# ---------------------------------------------------------------------------
+# Prompt-loader tests
+# ---------------------------------------------------------------------------
+
+
+def test_load_prompts_valid(tmp_path: Path) -> None:
+    path = _write_prompts(
+        tmp_path,
+        [
+            {"prompt": "hello", "reference_token_ids": [1, 2]},
+            {"prompt": "world", "reference_token_ids": [3, 4], "reference_text": "w"},
+        ],
+    )
+    prompts = _load_canary_prompts(path)
+    assert len(prompts) == 2
+    assert prompts[0]["prompt"] == "hello"
+    assert prompts[1]["reference_token_ids"] == [3, 4]
+
+
+def test_load_prompts_invalid_json_raises(tmp_path: Path) -> None:
+    path = tmp_path / "bad.json"
+    path.write_text("{not valid json", encoding="utf-8")
+    with pytest.raises(ValueError, match="not valid JSON"):
+        _load_canary_prompts(path)
+
+
+def test_load_prompts_missing_prompts_key_raises(tmp_path: Path) -> None:
+    path = tmp_path / "p.json"
+    path.write_text(json.dumps({"items": []}), encoding="utf-8")
+    with pytest.raises(ValueError, match="'prompts' list"):
+        _load_canary_prompts(path)
+
+
+def test_load_prompts_prompts_not_a_list_raises(tmp_path: Path) -> None:
+    path = tmp_path / "p.json"
+    path.write_text(json.dumps({"prompts": {"prompt": "x"}}), encoding="utf-8")
+    with pytest.raises(ValueError, match="must be a list"):
+        _load_canary_prompts(path)
+
+
+def test_load_prompts_entry_missing_prompt_raises(tmp_path: Path) -> None:
+    path = tmp_path / "p.json"
+    path.write_text(json.dumps({"prompts": [{"reference_token_ids": [1]}]}), encoding="utf-8")
+    with pytest.raises(ValueError, match="string 'prompt'"):
+        _load_canary_prompts(path)
+
+
+# ---------------------------------------------------------------------------
+# Token-equivalence helper tests
+# ---------------------------------------------------------------------------
+
+
+def test_tokens_equivalent_exact_match() -> None:
+    assert _tokens_equivalent([1, 2, 3], [1, 2, 3]) is True
+
+
+def test_tokens_equivalent_mismatch() -> None:
+    assert _tokens_equivalent([1, 2, 3], [1, 2, 4]) is False
+    assert _tokens_equivalent([1, 2], [1, 2, 3]) is False
+
+
+def test_tokens_equivalent_none_is_false() -> None:
+    assert _tokens_equivalent(None, [1, 2]) is False
+    assert _tokens_equivalent([1, 2], None) is False
+    assert _tokens_equivalent(None, None) is False
+
+
+# ---------------------------------------------------------------------------
+# Send-request tests (in-process HTTP server)
+# ---------------------------------------------------------------------------
+
+
+def test_send_success_returns_token_ids(completions_server) -> None:
+    server, port = completions_server
+    server.token_ids = [10, 20, 30]
+    server.text = "hi"
+    token_ids, text, err = _send_canary_request(
+        f"http://127.0.0.1:{port}", "m", "prompt", max_tokens=8, seed=42, timeout_s=1.0
+    )
+    assert err is None
+    assert token_ids == [10, 20, 30]
+    assert text == "hi"
+
+
+def test_send_http_503_returns_http_error(completions_server) -> None:
+    server, port = completions_server
+    server.status = 503
+    token_ids, text, err = _send_canary_request(
+        f"http://127.0.0.1:{port}", "m", "prompt", max_tokens=8, seed=42, timeout_s=1.0
+    )
+    assert token_ids is None and text is None
+    assert err is not None and err.startswith("http_error: 503")
+
+
+def test_send_connection_refused_returns_url_error() -> None:
+    port = _pick_port()  # nobody listening
+    token_ids, _text, err = _send_canary_request(
+        f"http://127.0.0.1:{port}", "m", "prompt", max_tokens=8, seed=42, timeout_s=0.5
+    )
+    assert token_ids is None
+    assert err is not None and err.startswith("url_error")
+
+
+def test_send_malformed_body_returns_parse_error(completions_server) -> None:
+    server, port = completions_server
+    server.raw_body = "{not json"
+    token_ids, _text, err = _send_canary_request(
+        f"http://127.0.0.1:{port}", "m", "prompt", max_tokens=8, seed=42, timeout_s=1.0
+    )
+    assert token_ids is None
+    assert err is not None and err.startswith("parse_error")
+
+
+# ---------------------------------------------------------------------------
+# Thread-body integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_thread_records_token_equivalent_true_on_match(tmp_path, completions_server) -> None:
+    server, port = completions_server
+    server.token_ids = [1, 2, 3]
+    _write_prompts(tmp_path, [{"prompt": "p", "reference_token_ids": [1, 2, 3]}])
+    h = _make_harness(tmp_path, server_url=f"http://127.0.0.1:{port}")
+
+    _run_canary_thread_briefly(h, duration_s=0.15)
+
+    assert len(h._canary_records) >= 1
+    for rec in h._canary_records:
+        assert rec["success"] is True
+        assert rec["token_equivalent"] is True
+        assert rec["error"] is None
+        assert rec["prompt_index"] == 0
+        assert rec["timestamp"] > 0
+        assert rec["latency_s"] >= 0
+
+
+def test_thread_records_token_equivalent_false_on_mismatch(tmp_path, completions_server) -> None:
+    server, port = completions_server
+    server.token_ids = [9, 9, 9]
+    _write_prompts(tmp_path, [{"prompt": "p", "reference_token_ids": [1, 2, 3]}])
+    h = _make_harness(tmp_path, server_url=f"http://127.0.0.1:{port}")
+
+    _run_canary_thread_briefly(h, duration_s=0.15)
+
+    assert len(h._canary_records) >= 1
+    assert all(rec["success"] is True for rec in h._canary_records)
+    assert all(rec["token_equivalent"] is False for rec in h._canary_records)
+
+
+def test_thread_token_equivalent_none_when_no_reference(tmp_path, completions_server) -> None:
+    server, port = completions_server
+    server.token_ids = [1, 2, 3]
+    _write_prompts(tmp_path, [{"prompt": "p"}])  # no reference_token_ids
+    h = _make_harness(tmp_path, server_url=f"http://127.0.0.1:{port}")
+
+    _run_canary_thread_briefly(h, duration_s=0.15)
+
+    assert len(h._canary_records) >= 1
+    assert all(rec["success"] is True for rec in h._canary_records)
+    assert all(rec["token_equivalent"] is None for rec in h._canary_records)
+
+
+def test_thread_token_equivalent_none_when_check_disabled(tmp_path, completions_server) -> None:
+    server, port = completions_server
+    server.token_ids = [1, 2, 3]
+    _write_prompts(tmp_path, [{"prompt": "p", "reference_token_ids": [1, 2, 3]}])
+    h = _make_harness(tmp_path, check_equiv=False, server_url=f"http://127.0.0.1:{port}")
+
+    _run_canary_thread_briefly(h, duration_s=0.15)
+
+    assert len(h._canary_records) >= 1
+    assert all(rec["token_equivalent"] is None for rec in h._canary_records)
+
+
+def test_thread_records_error_when_server_down(tmp_path) -> None:
+    port = _pick_port()  # nobody listening
+    _write_prompts(tmp_path, [{"prompt": "p", "reference_token_ids": [1]}])
+    h = _make_harness(tmp_path, server_url=f"http://127.0.0.1:{port}")
+
+    _run_canary_thread_briefly(h, duration_s=0.15)
+
+    assert len(h._canary_records) >= 1
+    for rec in h._canary_records:
+        assert rec["success"] is False
+        assert rec["token_equivalent"] is None
+        assert rec["error"] is not None
+
+
+def test_thread_round_robins_prompts(tmp_path, completions_server) -> None:
+    server, port = completions_server
+    server.token_ids = [1]
+    _write_prompts(
+        tmp_path,
+        [
+            {"prompt": "p0", "reference_token_ids": [1]},
+            {"prompt": "p1", "reference_token_ids": [1]},
+            {"prompt": "p2", "reference_token_ids": [1]},
+        ],
+    )
+    h = _make_harness(tmp_path, server_url=f"http://127.0.0.1:{port}")
+
+    thread = threading.Thread(target=h._canary_thread_body, daemon=True)
+    thread.start()
+    try:
+        _wait_until(lambda: len(h._canary_records) >= 4, timeout_s=2.0)
+    finally:
+        h.stop_event.set()
+        thread.join(timeout=2.0)
+
+    seen = {rec["prompt_index"] for rec in h._canary_records}
+    assert {0, 1, 2}.issubset(seen)
+
+
+def test_thread_exits_when_no_server_url(tmp_path) -> None:
+    _write_prompts(tmp_path, [{"prompt": "p", "reference_token_ids": [1]}])
+    h = _make_harness(tmp_path, server_url=None)  # endpoint not bound
+
+    thread = threading.Thread(target=h._canary_thread_body, daemon=True)
+    thread.start()
+    thread.join(timeout=2.0)
+    assert not thread.is_alive()
+    assert h._canary_records == []
+
+
+def test_thread_exits_when_prompts_file_missing(tmp_path, completions_server) -> None:
+    server, port = completions_server
+    # Reference a prompts file that does not exist on disk.
+    h = _make_harness(
+        tmp_path, prompts_file="does_not_exist.json", server_url=f"http://127.0.0.1:{port}"
+    )
+
+    thread = threading.Thread(target=h._canary_thread_body, daemon=True)
+    thread.start()
+    thread.join(timeout=2.0)
+    assert not thread.is_alive()
+    assert h._canary_records == []
+
+
+def test_thread_exits_promptly_on_failed_event(tmp_path, completions_server) -> None:
+    server, port = completions_server
+    _write_prompts(tmp_path, [{"prompt": "p", "reference_token_ids": [1, 2, 3]}])
+    h = _make_harness(tmp_path, server_url=f"http://127.0.0.1:{port}")
+
+    thread = threading.Thread(target=h._canary_thread_body, daemon=True)
+    thread.start()
+    time.sleep(0.05)
+    h.failed_event.set()
+    thread.join(timeout=2.0)
+    assert not thread.is_alive(), "canary thread must exit on failed_event too"

--- a/tests/integration/defs/stress_test/disagg_cancel/test_canary.py
+++ b/tests/integration/defs/stress_test/disagg_cancel/test_canary.py
@@ -12,18 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests for ``DisaggCancellationStressHarness._canary_thread_body``.
+"""Unit tests for `DisaggCancellationStressHarness._canary_thread_body`.
 
-The canary thread is testable without a real disagg cluster: stand up
-a tiny HTTP server in the test process that answers
-``POST /v1/completions`` with a configurable ``token_ids`` payload,
-point the harness at it via ``bind_server_endpoint``, run the thread
-for a few intervals, and assert on the collected ``_canary_records``.
-
-Prompt-loader and token-equivalence behaviour are verified directly
-against the standalone helpers; transport behaviour (success, HTTP
-error, connection refused, malformed body) is verified against the
-in-process HTTP server.
+Loader and token-equivalence helpers run directly. Transport and
+thread behavior run against an in-process HTTP server that answers
+`POST /v1/completions` with configurable payloads.
 """
 
 from __future__ import annotations
@@ -51,28 +44,18 @@ from .harness import (
 
 
 def _pick_port() -> int:
-    """Bind-and-release to get an OS-allocated free TCP port."""
+    """Bind-and-release to return an OS-allocated free TCP port."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
 
 
 class _CompletionsHandler(BaseHTTPRequestHandler):
-    """Answers ``POST /v1/completions`` with a configurable payload.
+    """Answers `POST /v1/completions`.
 
-    The response is read off the server instance on every request so
-    tests can mutate it mid-run:
-
-    - ``server.token_ids``: list returned as ``choices[0].token_ids``.
-    - ``server.text``: string returned as ``choices[0].text``.
-    - ``server.status``: if not 200, an empty error response with that
-      status code is sent (e.g. 503 to simulate a worker mid-restart).
-    - ``server.raw_body``: if set (str), sent verbatim as a 200 body
-      (used to exercise the malformed-JSON parse path).
-
-    Each request's parsed JSON body is appended to
-    ``server.request_bodies`` so tests can assert on the wire format
-    (e.g. ``temperature``, ``seed``, ``detokenize``).
+    Tests mutate `server.token_ids` / `text` / `status` / `raw_body`
+    to drive outcomes and read `server.request_bodies` for
+    wire-format assertions.
     """
 
     def do_POST(self) -> None:  # noqa: N802 — fixed by BaseHTTPRequestHandler
@@ -118,12 +101,7 @@ class _CompletionsHandler(BaseHTTPRequestHandler):
 
 @pytest.fixture
 def completions_server():
-    """In-process HTTP server answering ``POST /v1/completions``.
-
-    Yields ``(server, port)``. Tests mutate ``server.token_ids`` /
-    ``server.text`` / ``server.status`` / ``server.raw_body`` to drive
-    request outcomes.
-    """
+    """In-process HTTP server answering `POST /v1/completions`; yields `(server, port)`."""
     port = _pick_port()
     server = HTTPServer(("127.0.0.1", port), _CompletionsHandler)
     server.token_ids = [1, 2, 3]  # type: ignore[attr-defined]
@@ -142,7 +120,6 @@ def completions_server():
 
 
 def _write_prompts(tmp_path: Path, entries: list[dict]) -> Path:
-    """Write a ``stress_canary_prompts.json``-shaped file and return its path."""
     path = tmp_path / "stress_canary_prompts.json"
     path.write_text(json.dumps({"prompts": entries}), encoding="utf-8")
     return path
@@ -195,7 +172,7 @@ def _make_harness(
 
 
 def _run_canary_thread_briefly(h: DisaggCancellationStressHarness, duration_s: float) -> None:
-    """Drive ``_canary_thread_body`` for ``duration_s`` seconds then stop."""
+    """Drive `_canary_thread_body` for `duration_s` then stop."""
     thread = threading.Thread(target=h._canary_thread_body, daemon=True)
     thread.start()
     time.sleep(duration_s)
@@ -204,8 +181,15 @@ def _run_canary_thread_briefly(h: DisaggCancellationStressHarness, duration_s: f
     assert not thread.is_alive(), "canary thread failed to exit after stop_event"
 
 
+def _run_until_self_exit(h: DisaggCancellationStressHarness) -> None:
+    """Spawn the thread and wait for it to exit on its own (warn-and-return paths)."""
+    thread = threading.Thread(target=h._canary_thread_body, daemon=True)
+    thread.start()
+    thread.join(timeout=2.0)
+    assert not thread.is_alive()
+
+
 def _wait_until(predicate, *, timeout_s: float, poll_s: float = 0.01) -> None:
-    """Poll ``predicate`` until true or ``timeout_s`` elapses; assert on timeout."""
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
         if predicate():
@@ -233,51 +217,41 @@ def test_load_prompts_valid(tmp_path: Path) -> None:
     assert prompts[1]["reference_token_ids"] == [3, 4]
 
 
-def test_load_prompts_invalid_json_raises(tmp_path: Path) -> None:
-    path = tmp_path / "bad.json"
-    path.write_text("{not valid json", encoding="utf-8")
-    with pytest.raises(ValueError, match="not valid JSON"):
-        _load_canary_prompts(path)
-
-
-def test_load_prompts_missing_prompts_key_raises(tmp_path: Path) -> None:
-    path = tmp_path / "p.json"
-    path.write_text(json.dumps({"items": []}), encoding="utf-8")
-    with pytest.raises(ValueError, match="'prompts' list"):
-        _load_canary_prompts(path)
-
-
-def test_load_prompts_prompts_not_a_list_raises(tmp_path: Path) -> None:
-    path = tmp_path / "p.json"
-    path.write_text(json.dumps({"prompts": {"prompt": "x"}}), encoding="utf-8")
-    with pytest.raises(ValueError, match="must be a list"):
-        _load_canary_prompts(path)
-
-
-def test_load_prompts_entry_missing_prompt_raises(tmp_path: Path) -> None:
-    path = tmp_path / "p.json"
-    path.write_text(json.dumps({"prompts": [{"reference_token_ids": [1]}]}), encoding="utf-8")
-    with pytest.raises(ValueError, match="string 'prompt'"):
-        _load_canary_prompts(path)
-
-
-def test_load_prompts_reference_token_ids_non_list_raises(tmp_path: Path) -> None:
-    path = _write_prompts(tmp_path, [{"prompt": "p", "reference_token_ids": 123}])
-    with pytest.raises(ValueError, match="reference_token_ids"):
-        _load_canary_prompts(path)
-
-
-def test_load_prompts_reference_token_ids_non_int_element_raises(tmp_path: Path) -> None:
-    path = _write_prompts(tmp_path, [{"prompt": "p", "reference_token_ids": [1, "two"]}])
-    with pytest.raises(ValueError, match="reference_token_ids"):
-        _load_canary_prompts(path)
-
-
 def test_load_prompts_reference_token_ids_omitted_is_allowed(tmp_path: Path) -> None:
-    # Schema permits omission — token-equivalence then records ``None``.
     path = _write_prompts(tmp_path, [{"prompt": "p"}])
-    prompts = _load_canary_prompts(path)
-    assert prompts == [{"prompt": "p"}]
+    assert _load_canary_prompts(path) == [{"prompt": "p"}]
+
+
+@pytest.mark.parametrize(
+    "raw_content,match",
+    [
+        pytest.param("{not valid json", "not valid JSON", id="malformed-json"),
+        pytest.param(json.dumps({"items": []}), "'prompts' list", id="missing-prompts-key"),
+        pytest.param(
+            json.dumps({"prompts": {"prompt": "x"}}), "must be a list", id="prompts-not-list"
+        ),
+        pytest.param(
+            json.dumps({"prompts": [{"reference_token_ids": [1]}]}),
+            "string 'prompt'",
+            id="entry-missing-prompt",
+        ),
+        pytest.param(
+            json.dumps({"prompts": [{"prompt": "p", "reference_token_ids": 123}]}),
+            "reference_token_ids",
+            id="reftokens-not-list",
+        ),
+        pytest.param(
+            json.dumps({"prompts": [{"prompt": "p", "reference_token_ids": [1, "two"]}]}),
+            "reference_token_ids",
+            id="reftokens-non-int-element",
+        ),
+    ],
+)
+def test_load_prompts_invalid_raises(tmp_path: Path, raw_content: str, match: str) -> None:
+    path = tmp_path / "p.json"
+    path.write_text(raw_content, encoding="utf-8")
+    with pytest.raises(ValueError, match=match):
+        _load_canary_prompts(path)
 
 
 # ---------------------------------------------------------------------------
@@ -347,10 +321,8 @@ def test_send_malformed_body_returns_parse_error(completions_server) -> None:
 
 
 def test_send_missing_token_ids_returns_error(completions_server) -> None:
-    # Server returns a 200 response whose ``choices[0]`` carries no
-    # ``token_ids`` (e.g. it ignored ``detokenize=False``). Must be
-    # reported as a server-side error rather than miscounted as a
-    # token-equivalence mismatch downstream.
+    # 200 with `choices[0]` lacking `token_ids` is a server problem,
+    # not a token-equivalence mismatch downstream.
     server, port = completions_server
     server.token_ids = None
     server.text = "hi"
@@ -363,10 +335,8 @@ def test_send_missing_token_ids_returns_error(completions_server) -> None:
 
 
 def test_send_wire_format_includes_greedy_determinism_knobs(completions_server) -> None:
-    # Pin the on-wire request shape so a future ``_send_canary_request``
-    # change can't silently drop ``temperature=0.0`` / ``seed`` /
-    # ``detokenize=False`` (any of which would invalidate the
-    # token-equivalence contract).
+    # Pin the wire shape so a future change can't silently drop
+    # `temperature=0.0` / `seed` / `detokenize=False`.
     server, port = completions_server
     _send_canary_request(
         f"http://127.0.0.1:{port}",
@@ -392,60 +362,33 @@ def test_send_wire_format_includes_greedy_determinism_knobs(completions_server) 
 # ---------------------------------------------------------------------------
 
 
-def test_thread_records_token_equivalent_true_on_match(tmp_path, completions_server) -> None:
+@pytest.mark.parametrize(
+    "server_tokens,ref_tokens,check_equiv,expected",
+    [
+        pytest.param([1, 2, 3], [1, 2, 3], True, True, id="match"),
+        pytest.param([9, 9, 9], [1, 2, 3], True, False, id="mismatch"),
+        pytest.param([1, 2, 3], None, True, None, id="no-reference"),
+        pytest.param([1, 2, 3], [1, 2, 3], False, None, id="check-disabled"),
+    ],
+)
+def test_thread_records_token_equivalent(
+    tmp_path, completions_server, server_tokens, ref_tokens, check_equiv, expected
+) -> None:
     server, port = completions_server
-    server.token_ids = [1, 2, 3]
-    _write_prompts(tmp_path, [{"prompt": "p", "reference_token_ids": [1, 2, 3]}])
-    h = _make_harness(tmp_path, server_url=f"http://127.0.0.1:{port}")
+    server.token_ids = server_tokens
+    entry: dict = {"prompt": "p"}
+    if ref_tokens is not None:
+        entry["reference_token_ids"] = ref_tokens
+    _write_prompts(tmp_path, [entry])
+    h = _make_harness(tmp_path, check_equiv=check_equiv, server_url=f"http://127.0.0.1:{port}")
 
     _run_canary_thread_briefly(h, duration_s=0.15)
 
     assert len(h._canary_records) >= 1
     for rec in h._canary_records:
         assert rec["success"] is True
-        assert rec["token_equivalent"] is True
         assert rec["error"] is None
-        assert rec["prompt_index"] == 0
-        assert rec["timestamp"] > 0
-        assert rec["latency_s"] >= 0
-
-
-def test_thread_records_token_equivalent_false_on_mismatch(tmp_path, completions_server) -> None:
-    server, port = completions_server
-    server.token_ids = [9, 9, 9]
-    _write_prompts(tmp_path, [{"prompt": "p", "reference_token_ids": [1, 2, 3]}])
-    h = _make_harness(tmp_path, server_url=f"http://127.0.0.1:{port}")
-
-    _run_canary_thread_briefly(h, duration_s=0.15)
-
-    assert len(h._canary_records) >= 1
-    assert all(rec["success"] is True for rec in h._canary_records)
-    assert all(rec["token_equivalent"] is False for rec in h._canary_records)
-
-
-def test_thread_token_equivalent_none_when_no_reference(tmp_path, completions_server) -> None:
-    server, port = completions_server
-    server.token_ids = [1, 2, 3]
-    _write_prompts(tmp_path, [{"prompt": "p"}])  # no reference_token_ids
-    h = _make_harness(tmp_path, server_url=f"http://127.0.0.1:{port}")
-
-    _run_canary_thread_briefly(h, duration_s=0.15)
-
-    assert len(h._canary_records) >= 1
-    assert all(rec["success"] is True for rec in h._canary_records)
-    assert all(rec["token_equivalent"] is None for rec in h._canary_records)
-
-
-def test_thread_token_equivalent_none_when_check_disabled(tmp_path, completions_server) -> None:
-    server, port = completions_server
-    server.token_ids = [1, 2, 3]
-    _write_prompts(tmp_path, [{"prompt": "p", "reference_token_ids": [1, 2, 3]}])
-    h = _make_harness(tmp_path, check_equiv=False, server_url=f"http://127.0.0.1:{port}")
-
-    _run_canary_thread_briefly(h, duration_s=0.15)
-
-    assert len(h._canary_records) >= 1
-    assert all(rec["token_equivalent"] is None for rec in h._canary_records)
+        assert rec["token_equivalent"] is expected
 
 
 def test_thread_records_error_when_server_down(tmp_path) -> None:
@@ -489,37 +432,33 @@ def test_thread_round_robins_prompts(tmp_path, completions_server) -> None:
 
 def test_thread_exits_when_no_server_url(tmp_path) -> None:
     _write_prompts(tmp_path, [{"prompt": "p", "reference_token_ids": [1]}])
-    h = _make_harness(tmp_path, server_url=None)  # endpoint not bound
-
-    thread = threading.Thread(target=h._canary_thread_body, daemon=True)
-    thread.start()
-    thread.join(timeout=2.0)
-    assert not thread.is_alive()
+    h = _make_harness(tmp_path, server_url=None)
+    _run_until_self_exit(h)
     assert h._canary_records == []
 
 
 def test_thread_exits_when_prompts_file_missing(tmp_path, completions_server) -> None:
-    server, port = completions_server
-    # Reference a prompts file that does not exist on disk.
+    _, port = completions_server
     h = _make_harness(
         tmp_path, prompts_file="does_not_exist.json", server_url=f"http://127.0.0.1:{port}"
     )
+    _run_until_self_exit(h)
+    assert h._canary_records == []
 
-    thread = threading.Thread(target=h._canary_thread_body, daemon=True)
-    thread.start()
-    thread.join(timeout=2.0)
-    assert not thread.is_alive()
+
+def test_thread_exits_when_prompts_list_empty(tmp_path, completions_server) -> None:
+    _, port = completions_server
+    _write_prompts(tmp_path, [])
+    h = _make_harness(tmp_path, server_url=f"http://127.0.0.1:{port}")
+    _run_until_self_exit(h)
     assert h._canary_records == []
 
 
 def test_thread_exits_promptly_on_failed_event(tmp_path, completions_server) -> None:
-    # The between-request wait only observes ``stop_event``, so the
-    # thread acts on ``failed_event`` at the next request boundary.
-    # Bound the lag to one canary interval (here 20 ms) by asserting
-    # that no more than one extra record is appended after the event
-    # fires — this would catch a future regression that fully
-    # re-enters the request loop after fail-fast.
-    server, port = completions_server
+    # The between-request wait only observes `stop_event`; verify
+    # `failed_event` is acted on within one canary interval (records
+    # grow by at most one after the event fires).
+    _, port = completions_server
     _write_prompts(tmp_path, [{"prompt": "p", "reference_token_ids": [1, 2, 3]}])
     h = _make_harness(tmp_path, server_url=f"http://127.0.0.1:{port}")
 
@@ -529,33 +468,12 @@ def test_thread_exits_promptly_on_failed_event(tmp_path, completions_server) -> 
     pre = len(h._canary_records)
     h.failed_event.set()
     thread.join(timeout=2.0)
-    assert not thread.is_alive(), "canary thread must exit on failed_event too"
-    assert len(h._canary_records) - pre <= 1, (
-        "thread re-entered request loop after failed_event "
-        f"(records grew by {len(h._canary_records) - pre})"
-    )
-
-
-def test_thread_exits_when_prompts_list_empty(tmp_path, completions_server) -> None:
-    # Empty ``prompts`` list is a recoverable misconfiguration, not a
-    # crash; the thread logs a warning and exits without appending
-    # any records.
-    server, port = completions_server
-    _write_prompts(tmp_path, [])
-    h = _make_harness(tmp_path, server_url=f"http://127.0.0.1:{port}")
-
-    thread = threading.Thread(target=h._canary_thread_body, daemon=True)
-    thread.start()
-    thread.join(timeout=2.0)
     assert not thread.is_alive()
-    assert h._canary_records == []
+    assert len(h._canary_records) - pre <= 1
 
 
 def test_thread_resolves_absolute_prompts_path(tmp_path, completions_server) -> None:
-    # When the YAML's ``prompts_file`` is an absolute path, the
-    # harness must NOT join it against ``yaml_path.parent``; verify
-    # by placing the prompts file outside the YAML directory and
-    # confirming the thread loads it and produces records.
+    # Absolute `prompts_file` must NOT be joined against `yaml_path.parent`.
     server, port = completions_server
     server.token_ids = [1, 2, 3]
     outside_dir = tmp_path / "elsewhere"
@@ -566,9 +484,7 @@ def test_thread_resolves_absolute_prompts_path(tmp_path, completions_server) -> 
         encoding="utf-8",
     )
     h = _make_harness(
-        tmp_path,
-        prompts_file=str(prompts_path),  # absolute
-        server_url=f"http://127.0.0.1:{port}",
+        tmp_path, prompts_file=str(prompts_path), server_url=f"http://127.0.0.1:{port}"
     )
 
     _run_canary_thread_briefly(h, duration_s=0.15)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stress testing harness now includes canary workload capability to detect potential runtime issues through deterministic completion testing.
  * Added configurable parameters for request timeouts and inter-request intervals.
  * New method to bind the stress test harness to server endpoints.

* **Documentation**
  * Updated test documentation to reflect canary and metrics thread implementation.

* **Tests**
  * Added comprehensive integration test suite for canary functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Summary

Fourth thread body in the disaggregated cancellation stress-test suite — the marathon-style (hours-running) harness that gates regressions of the bug class fixed by PR #13713. The skeleton + `log_scanner_thread` landed in PR #14375, the `metrics_thread` in PR #14807, and the `injector_thread` in PR #14920; this PR adds the `canary_thread`.

**This PR ships:**

* **`canary_thread` body** — loads `canary.prompts_file` (resolved relative to the marathon YAML), then sends deterministic greedy completions to the disagg server's `/v1/completions` at `canary.rate_per_min` cadence and appends a per-request record to `_canary_records`: `{timestamp, elapsed_s, prompt_index, success, token_equivalent, latency_s, error}`. Request failures are recorded — **not** fail-fast — because error spikes during bursts / injections are expected; only the log scanner is fail-fast. The end-of-marathon gates (canary error rate, recovery time) are computed from these records in a later step.
* **`_send_canary_request`** — `urllib` POST with `temperature=0.0` + fixed `seed` for greedy determinism and `detokenize=False` so the response carries generated `token_ids` on `choices[0]` (see `CompletionResponseChoice.token_ids` in `tensorrt_llm/serve/openai_protocol.py`). Every transport/parse failure (HTTP error, connection refused, timeout, malformed body) folds into `(None, None, error_string)`.
* **`_load_canary_prompts`** — validates the `stress_canary_prompts.json` schema (`{"prompts": [{"prompt", "reference_token_ids", "reference_text?"}, ...]}`) and raises a clear `ValueError` on malformed input.
* **`_tokens_equivalent`** — exact token-ID list equality; a `None` on either side (no tokens returned, or no reference recorded) is non-equivalent.
* **`bind_server_endpoint(server_url, model_name)`** — registers the disagg front-end the canary targets, mirroring `bind_tracked_workers`. Called by `setup()` once `setup_disagg_cluster` returns; settable by tests today.
* **`canary_request_timeout_s` / `canary_interval_s`** — new ctor parameters on `DisaggCancellationStressHarness`, matching the existing per-thread tunable pattern (`log_scanner_poll_interval_s`, `metrics_scrape_interval_s`, `injector_poll_interval_s`). Tests pass small values; the marathon derives the interval from `canary.rate_per_min`.
The thread sits inside the lifecycle wired up by PR #14375 — `start()` already spawns it, `stop()` joins it, `collect_results()` already returns `canary_records`. Previous PRs left it as a no-op stub; this PR makes it actually send canaries.

## PR chain plan

| PR | Adds | Marathon assertion it enables |
| --- | --- | --- |
| [PR #14375](https://github.com/NVIDIA/TensorRT-LLM/pull/14375) | skeleton + log_scanner | hard-zero log patterns |
| [PR #14807](https://github.com/NVIDIA/TensorRT-LLM/pull/14807) | metrics_thread | KV-cache utilization growth bound |
| [PR #14920](https://github.com/NVIDIA/TensorRT-LLM/pull/14920) | injector_thread | SIGSTOP / SIGCONT / SIGKILL+respawn; injection_events count |
| **this PR** | **canary_thread** | **canary correctness (token-equivalence) + error-rate / recovery-time inputs** |
| next | load_thread + real setup() with save_log=True | sustained load over duration_min; **marathon entry point becomes a real marathon** |

The final PR flips `setup_disagg_cluster` to launch workers with explicit per-worker ports + `save_log=True` and calls `bind_tracked_workers()` / `bind_server_endpoint()` — at which point the canary thread streams against a live server. Today it correctly no-ops when its inputs are absent: with the cluster launch still stubbed, no server endpoint is bound and the thread logs a warning and exits.

## Why `urllib`, not asyncio

The class docstring previously said the canary thread would run its own asyncio loop. At 5 req/min (one request at a time) asyncio buys nothing and complicates testing, so the canary uses blocking `urllib` like the merged `metrics_thread` — which makes it unit-testable against an in-process `http.server`. The class docstring is updated accordingly; the load thread (next PR) still runs asyncio internally via `run_cancel_stress_test`.

## Tests added

All deterministic, GPU-free, second-scale. Under `tests/integration/defs/stress_test/disagg_cancel/`.
* **`test_canary.py`** — 21 unit tests across three layers:
   * **Loader (5)**: valid file; invalid JSON / missing `prompts` / non-list `prompts` / entry missing string `prompt` all raise `ValueError`.
   * **Token-equivalence (3)**: exact match, mismatch (value + length), `None`-on-either-side.
   * **Send-request (4, in-process HTTP server)**: success returns `token_ids`; HTTP 503 → `http_error`; connection refused → `url_error`; malformed body → `parse_error`.
   * **Thread-body integration (9)**: `token_equivalent` True/False/None (match / mismatch / no-reference / check disabled), error recorded when server down, prompt round-robin, and prompt exit on no endpoint / missing prompts file / `failed_event`.

Run locally (no GPU, no cluster):
```bash
    PYTHONPATH=tests/integration/defs:tests/integration/defs/disaggregated \
    python3 -m pytest -c /dev/null -o addopts= \
      --confcutdir=tests/integration/defs/stress_test \
      tests/integration/defs/stress_test/disagg_cancel/test_canary.py -v
```

## Out of scope (deferred to later PRs in this chain)

* The remaining `load_thread` body + real `setup_disagg_cluster` invocation (cluster launch is still a stub, so no server endpoint is bound in the lifecycle smoke; the canary thread logs a warning and exits).
* End-of-marathon gate computation from `_canary_records` (overall error rate < 1%, per-injection-window < 10%, recovery time < 30 s).
* `configs/stress_canary_prompts.json` + `tools/generate_canary_references.py` (Step 6 — one-shot greedy-decode reference generation).
* YAML schema wiring of `canary_request_timeout_s` / `canary_interval_s` (constructor-only for now; the marathon derives cadence from `canary.rate_per_min`).
* Registration in `tests/integration/test_lists/qa/llm_function_stress.txt` for nightly / weekly CI.


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
