### PR TITLE
[TRTLLM-12534][fix] Nemotron Nano - properly account for text prompts in inflight batching with EVS on

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -2861,13 +2861,13 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         for multimodal_param, context_part in zip(multimodal_params, context_parts, strict=True):
             start = multimodal_param.input_ids_start_offset
             end = start + context_part.shape[0]
-            if end > input_ids.shape[0]:
+            if not (0 <= start <= end <= input_ids.shape[0]):
                 raise ValueError(
-                    f"EVS-adjusted context span ([{start}, {end})) exceeds "
-                    f"input_ids length ({input_ids.shape[0]}). This usually means "
-                    "a chunked multimodal request reached merge_evs_mm_embeds "
-                    "without multimodal_runtime metadata, or input_ids_start_offset "
-                    "was not set for this request."
+                    f"EVS-adjusted context span [{start}, {end}) is invalid for "
+                    f"input_ids of length {input_ids.shape[0]} (expected "
+                    "0 <= start <= end <= length). This usually means an incorrect "
+                    "input_ids_start_offset, or a chunked multimodal request reached "
+                    "merge_evs_mm_embeds without multimodal_runtime metadata."
                 )
             input_ids[start:end] = context_part.to(device=input_ids.device, dtype=input_ids.dtype)
 

--- a/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
+++ b/tensorrt_llm/_torch/models/modeling_nemotron_nano.py
@@ -2776,41 +2776,6 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         runtime.total_embeds_in_request = int(embed_mask_cumsum[-1])
         return context_ids[runtime.past_seen_token_num : runtime.chunk_end_pos]
 
-    @staticmethod
-    def _validate_evs_context_batch(
-        ctx_params: List[MultimodalParams],
-        num_context_requests: int,
-    ) -> None:
-        """Reject EVS video mixed with text-only context requests.
-
-        Args:
-            ctx_params: Multimodal params associated with current context
-                requests. Today this list contains only context requests with
-                multimodal content.
-            num_context_requests: Total number of current context requests in
-                the flattened forward batch, including text-only requests.
-
-        Raises:
-            ValueError: If an EVS video context is batched together with a
-                text-only context request.
-        """
-        has_video = any(
-            param.has_content() and param.multimodal_data.get("modality_type") == "video"
-            for param in ctx_params
-        )
-        has_text_only_context = len(ctx_params) < num_context_requests or any(
-            not param.has_content() for param in ctx_params
-        )
-        if has_video and has_text_only_context:
-            # TODO(TRTLLM-12534): Remove this guard once merge_evs_mm_embeds writes each
-            # multimodal context chunk using its flattened input_ids offset
-            # instead of assuming a contiguous multimodal prefix.
-            raise ValueError(
-                "EVS video requests cannot be inflight-batched with text-only "
-                "context requests yet. merge_evs_mm_embeds currently assumes "
-                "multimodal context chunks form a contiguous input_ids prefix."
-            )
-
     def _check_encoders_exist(self, raw_ctx_params: List[MultimodalParams]) -> None:
         """Check encoders needed by raw inputs exist.
 
@@ -2882,24 +2847,29 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
 
         if not context_parts:
             return input_ids
-        context_ids = torch.cat(context_parts, dim=0)
-        # -> [num_tokens, ]
 
-        # Special handling for inflight-batching.
-        # Assume input ids format is [context_ids, generation_ids].
-        # Under chunked prefill, multimodal_runtime narrows context_ids to the current
-        # context chunk so decode ids after it are preserved.
-        if context_ids.shape[0] > input_ids.shape[0]:
-            raise ValueError(
-                "EVS-adjusted context length "
-                f"({context_ids.shape[0]}) exceeds input_ids length "
-                f"({input_ids.shape[0]}). This usually means a chunked "
-                "multimodal request reached merge_evs_mm_embeds without "
-                "multimodal_runtime metadata."
-            )
-        context_ids = context_ids.to(device=input_ids.device, dtype=input_ids.dtype)
-        input_ids[: context_ids.shape[0]] = context_ids
-        del context_ids
+        # Write each request's EVS-adjusted token IDs into its own span of the
+        # flattened input_ids. Multimodal context requests are not necessarily a
+        # contiguous prefix: text-only context requests carry no multimodal_params
+        # (so they never appear here) yet still occupy input_ids, and they may
+        # precede or sit between multimodal ones. Each write therefore starts at
+        # the request's recorded flattened offset. The merge is length-preserving
+        # (the slot was pre-sized to the post-EVS retained count), so every span
+        # ends exactly where the next request begins and `input_ids` is never
+        # grown. Under chunked prefill, multimodal_runtime narrows each context
+        # part to the current chunk so decode ids after it are preserved.
+        for multimodal_param, context_part in zip(multimodal_params, context_parts, strict=True):
+            start = multimodal_param.input_ids_start_offset
+            end = start + context_part.shape[0]
+            if end > input_ids.shape[0]:
+                raise ValueError(
+                    f"EVS-adjusted context span ([{start}, {end})) exceeds "
+                    f"input_ids length ({input_ids.shape[0]}). This usually means "
+                    "a chunked multimodal request reached merge_evs_mm_embeds "
+                    "without multimodal_runtime metadata, or input_ids_start_offset "
+                    "was not set for this request."
+                )
+            input_ids[start:end] = context_part.to(device=input_ids.device, dtype=input_ids.dtype)
 
         return input_ids
 
@@ -3142,8 +3112,6 @@ class NemotronH_Nano_VL_V2(transformers.PreTrainedModel):
         mm_embedding = []
         if len(multimodal_params) > 0:
             ctx_params = multimodal_params[:num_context_requests]
-            if self.video_pruning_rate > 0:
-                self._validate_evs_context_batch(ctx_params, num_context_requests)
             raw_ctx_params = [param for param in ctx_params if has_raw_multimodal_payload(param)]
             # Raw image/video/audio tensors: run local encoder.
             if raw_ctx_params:

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2687,15 +2687,19 @@ class PyTorchModelEngine(ModelEngine):
             position_ids.extend(
                 range(begin_compute, begin_compute + len(prompt_tokens)))
 
+            # Start offset of this request's (current-chunk) tokens within the
+            # flattened input_ids. Recorded on multimodal_params below so models
+            # that rewrite token IDs in place write into the request's own span
+            # rather than assuming a contiguous multimodal prefix.
+            context_start_idx = len(input_ids)
             # Track position for updating the inputs of draft model
             if self.is_draft_model and num_accepted_tokens_device is not None:
-                start_idx = len(input_ids)
                 input_ids.extend(prompt_tokens)
                 end_idx = len(input_ids)
                 slot_idx = req_id_to_old_request[
                     request.py_request_id].py_seq_slot
                 context_input_ids_positions.append(
-                    (start_idx, end_idx - 1,
+                    (context_start_idx, end_idx - 1,
                      slot_idx))  # end_idx-1 is the last token position
             else:
                 input_ids.extend(prompt_tokens)
@@ -2731,7 +2735,8 @@ class PyTorchModelEngine(ModelEngine):
 
             multimodal_params = MultimodalParams(
                 multimodal_data=request.py_multimodal_data,
-                multimodal_runtime=py_multimodal_runtime)
+                multimodal_runtime=py_multimodal_runtime,
+                input_ids_start_offset=context_start_idx)
             if multimodal_params.has_content():
                 if self.use_mrope:
                     mrope_pos_ids = multimodal_params.multimodal_data[
@@ -3529,6 +3534,9 @@ class PyTorchModelEngine(ModelEngine):
 
         for request in scheduled_requests.context_requests:
             prompt_tokens = request.get_tokens(0)
+            # Start offset of this request's tokens within the flattened
+            # input_ids (see _prepare_tp_inputs for rationale).
+            context_start_idx = len(input_ids)
             input_ids.extend(prompt_tokens)
             request_ids.append(request.py_request_id)
             if request.position_ids is None:
@@ -3545,7 +3553,8 @@ class PyTorchModelEngine(ModelEngine):
             # Multimodal
             if request.py_multimodal_data is not None:
                 multimodal_params = MultimodalParams(
-                    multimodal_data=request.py_multimodal_data, )
+                    multimodal_data=request.py_multimodal_data,
+                    input_ids_start_offset=context_start_idx)
                 multimodal_params.to_device("multimodal_data",
                                             "cuda",
                                             pin_memory=prefer_pinned())

--- a/tensorrt_llm/inputs/multimodal.py
+++ b/tensorrt_llm/inputs/multimodal.py
@@ -467,6 +467,12 @@ class MultimodalParams:
                            during KV cache scenarios. Contains information about cached
                            tokens, multimodal token positions, and lengths for efficient
                            processing during inference.
+        input_ids_start_offset: Start index of this request's (current-chunk) tokens
+                           within the flattened `input_ids` of the current forward pass
+                           (0 by default). Populated for context requests by the model
+                           engine and consumed by models that rewrite token IDs in place
+                           (e.g. Nemotron Nano EVS) so each request writes into its own
+                           span instead of assuming a contiguous multimodal prefix.
 
     Structure of multimodal_data:
         {
@@ -496,6 +502,7 @@ class MultimodalParams:
     multimodal_input: Optional[MultimodalInput] = None
     multimodal_data: Optional[Dict[str, Any]] = field(default_factory=dict)
     multimodal_runtime: Optional[MultimodalRuntimeData] = None
+    input_ids_start_offset: int = 0
 
     def __post_init__(self):
         """Ensure default values are properly set."""

--- a/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
+++ b/tests/unittest/_torch/modeling/test_nemotron_nano_preprocessing.py
@@ -873,7 +873,7 @@ def _make_runtime(past_seen_token_num: int, chunk_end_pos: int, prompt_len: int)
     )
 
 
-def _make_mm_param(modality: str, evs_ids, runtime=None):
+def _make_mm_param(modality: str, evs_ids, runtime=None, input_ids_start_offset=0):
     """Build a MultimodalParams for merge_evs_mm_embeds."""
     return MultimodalParams(
         multimodal_data={
@@ -881,21 +881,12 @@ def _make_mm_param(modality: str, evs_ids, runtime=None):
             modality: {"evs_ids": evs_ids},
         },
         multimodal_runtime=runtime,
+        input_ids_start_offset=input_ids_start_offset,
     )
 
 
 class TestMergeEvsMMEmbeds:
     """Tests for `NemotronH_Nano_VL_V2.merge_evs_mm_embeds`."""
-
-    def test_evs_video_with_text_only_context_raises(self):
-        """Reject batches where text-only context chunks would shift EVS writes."""
-        params = [_make_mm_param("video", torch.tensor([_VIDEO_CTX_ID], dtype=torch.long))]
-
-        with pytest.raises(ValueError, match="text-only context requests"):
-            NemotronH_Nano_VL_V2._validate_evs_context_batch(
-                params,
-                num_context_requests=2,
-            )
 
     def test_single_video_two_tubelets(self):
         """Each video_context_token_id placeholder is replaced with the right count."""
@@ -950,9 +941,11 @@ class TestMergeEvsMMEmbeds:
             ],
             dtype=torch.long,
         )
+        # Video span = text + <start> img_ctx*4 <end> <start> img_ctx*2 <end> = 11
+        # tokens, so the image request starts at flattened offset 11.
         params = [
-            _make_mm_param("video", video_evs),
-            _make_mm_param("image", image_evs),
+            _make_mm_param("video", video_evs, input_ids_start_offset=0),
+            _make_mm_param("image", image_evs, input_ids_start_offset=11),
         ]
         num_tokens_in_videos = [torch.tensor([4, 2]), image_evs]
         input_ids = torch.zeros(20, dtype=torch.long)
@@ -991,9 +984,11 @@ class TestMergeEvsMMEmbeds:
             [_SOUND_START, _SOUND_CTX_ID, _SOUND_CTX_ID, _SOUND_END],
             dtype=torch.long,
         )
+        # Video span = text + <start> img_ctx*2 <end> = 5 tokens, so the audio
+        # request starts at flattened offset 5.
         params = [
-            _make_mm_param("video", video_evs),
-            _make_mm_param("audio", audio_evs),
+            _make_mm_param("video", video_evs, input_ids_start_offset=0),
+            _make_mm_param("audio", audio_evs, input_ids_start_offset=5),
         ]
         num_tokens_in_videos = [torch.tensor([2]), None]
         input_ids = torch.zeros(20, dtype=torch.long)
@@ -1123,6 +1118,142 @@ class TestMergeEvsMMEmbeds:
         assert runtime.num_cached_mm_tokens == 0
         assert runtime.num_mm_tokens_in_chunk == 2
         assert runtime.total_embeds_in_request == 9
+
+    def test_text_only_before_evs_video_no_clobber(self):
+        """A text-only context request before the EVS video must not be clobbered."""
+        model = _make_merge_model()
+        # Single tubelet placeholder -> [IMG_START, IMG_CTX*3, IMG_END] = 5 tokens.
+        evs_ids = torch.tensor([_IMG_START, _VIDEO_CTX_ID, _IMG_END], dtype=torch.long)
+        param = _make_mm_param("video", evs_ids, input_ids_start_offset=4)
+        num_tokens_in_videos = [torch.tensor([3])]
+        # batch: [A text-only(4)][B video chunk(5)][decode(2)]
+        text_prefix = torch.tensor([101, 102, 103, 104], dtype=torch.long)
+        decode_tail = torch.tensor([900, 901], dtype=torch.long)
+        input_ids = torch.cat(
+            [text_prefix.clone(), torch.zeros(5, dtype=torch.long), decode_tail.clone()]
+        )
+
+        result = NemotronH_Nano_VL_V2.merge_evs_mm_embeds(
+            model, num_tokens_in_videos, [param], input_ids
+        )
+
+        expected_video = torch.tensor(
+            [_IMG_START] + [_IMG_CTX_ID] * 3 + [_IMG_END], dtype=torch.long
+        )
+        assert (result[:4] == text_prefix).all()
+        assert (result[4:9] == expected_video).all()
+        assert (result[9:] == decode_tail).all()
+
+    def test_text_only_after_evs_video_no_clobber(self):
+        """A text-only context request after the EVS video must not be clobbered."""
+        model = _make_merge_model()
+        evs_ids = torch.tensor([_IMG_START, _VIDEO_CTX_ID, _IMG_END], dtype=torch.long)
+        param = _make_mm_param("video", evs_ids, input_ids_start_offset=0)
+        num_tokens_in_videos = [torch.tensor([3])]
+        # batch: [A video chunk(5)][B text-only(3)][decode(1)]
+        text_suffix = torch.tensor([201, 202, 203], dtype=torch.long)
+        decode_tail = torch.tensor([900], dtype=torch.long)
+        input_ids = torch.cat(
+            [torch.zeros(5, dtype=torch.long), text_suffix.clone(), decode_tail.clone()]
+        )
+
+        result = NemotronH_Nano_VL_V2.merge_evs_mm_embeds(
+            model, num_tokens_in_videos, [param], input_ids
+        )
+
+        expected_video = torch.tensor(
+            [_IMG_START] + [_IMG_CTX_ID] * 3 + [_IMG_END], dtype=torch.long
+        )
+        assert (result[:5] == expected_video).all()
+        assert (result[5:8] == text_suffix).all()
+        assert (result[8:] == decode_tail).all()
+
+    def test_multiple_evs_requests_with_text_only_interspersed(self):
+        """Multimodal requests write their own spans with text-only requests between."""
+        model = _make_merge_model()
+        # B: video, single tubelet placeholder -> 5-token span after expansion.
+        video_evs = torch.tensor([_IMG_START, _VIDEO_CTX_ID, _IMG_END], dtype=torch.long)
+        # D: image, 4-token passthrough (distinct from any special token id).
+        image_evs = torch.tensor([60, 61, 62, 63], dtype=torch.long)
+        # batch: [A text-only(3)][B video(5)][C text-only(2)][D image(4)][decode(1)]
+        b_param = _make_mm_param("video", video_evs, input_ids_start_offset=3)
+        d_param = _make_mm_param("image", image_evs, input_ids_start_offset=10)
+        num_tokens_in_videos = [torch.tensor([3]), image_evs]
+        a_text = torch.tensor([1, 2, 3], dtype=torch.long)
+        c_text = torch.tensor([4, 5], dtype=torch.long)
+        decode = torch.tensor([900], dtype=torch.long)
+        input_ids = torch.cat(
+            [
+                a_text.clone(),
+                torch.zeros(5, dtype=torch.long),
+                c_text.clone(),
+                torch.zeros(4, dtype=torch.long),
+                decode.clone(),
+            ]
+        )
+
+        result = NemotronH_Nano_VL_V2.merge_evs_mm_embeds(
+            model, num_tokens_in_videos, [b_param, d_param], input_ids
+        )
+
+        expected_b = torch.tensor([_IMG_START] + [_IMG_CTX_ID] * 3 + [_IMG_END], dtype=torch.long)
+        assert (result[0:3] == a_text).all()
+        assert (result[3:8] == expected_b).all()
+        assert (result[8:10] == c_text).all()
+        assert (result[10:14] == image_evs).all()
+        assert (result[14:] == decode).all()
+
+    def test_chunked_prefill_with_preceding_text_only(self):
+        """Chunked prefill with a preceding text-only request writes only the chunk."""
+        model = _make_merge_model()
+        evs_ids = torch.tensor(
+            [
+                _TEXT_TOKEN,
+                _IMG_START,
+                _VIDEO_CTX_ID,
+                _IMG_END,
+                88,
+                _IMG_START,
+                _VIDEO_CTX_ID,
+                _IMG_END,
+                77,
+            ],
+            dtype=torch.long,
+        )
+        full_context = torch.tensor(
+            [_TEXT_TOKEN, _IMG_START]
+            + [_IMG_CTX_ID] * 3
+            + [_IMG_END, 88, _IMG_START]
+            + [_IMG_CTX_ID] * 2
+            + [_IMG_END, 77],
+            dtype=torch.long,
+        )
+        runtime = _make_runtime(
+            past_seen_token_num=4,
+            chunk_end_pos=9,
+            prompt_len=len(full_context),
+        )
+        # 3-token text-only context request precedes the video; the video's
+        # current chunk (full_context[4:9], 5 tokens) starts at flattened offset 3.
+        param = _make_mm_param("video", evs_ids, runtime=runtime, input_ids_start_offset=3)
+        num_tokens_in_videos = [torch.tensor([3, 2])]
+        text_prefix = torch.tensor([101, 102, 103], dtype=torch.long)
+        generation_tail = torch.tensor([700, 701], dtype=torch.long)
+        input_ids = torch.cat(
+            [text_prefix.clone(), torch.zeros(5, dtype=torch.long), generation_tail.clone()]
+        )
+
+        result = NemotronH_Nano_VL_V2.merge_evs_mm_embeds(
+            model, num_tokens_in_videos, [param], input_ids
+        )
+
+        expected_chunk = full_context[4:9]
+        assert (result[:3] == text_prefix).all()
+        assert (result[3:8] == expected_chunk).all()
+        assert (result[8:] == generation_tail).all()
+        assert runtime.num_cached_mm_tokens == 2
+        assert runtime.num_mm_tokens_in_chunk == 2
+        assert runtime.total_embeds_in_request == 5
 
 
 class TestProcessVideoPromptsEvs:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multimodal video context handling in Nemotron Nano V2VL models.
  * Fixed token-positioning so mixed text-only and multimodal requests in a batch no longer overwrite each other.
  * Ensured multimodal embeddings are placed accurately within flattened token sequences.
  * Removed an overly-restrictive batch validation that rejected certain multimodal batching patterns.

* **Tests**
  * Added regression tests covering interspersed multimodal/text contexts and chunked-prefill scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

## Problem

`merge_evs_mm_embeds` wrote each request's EVS-adjusted token IDs at a fixed offset 0:

```python
input_ids[: context_ids.shape[0]] = context_ids
```

This assumes multimodal context requests are a contiguous prefix of the flattened `input_ids`. With in-flight batching that's false - any text-only context request scheduled ahead of the EVS one gets silently clobbered (independent of chunked prefill). A guard (`_validate_evs_context_batch`) merely *rejected* such batches as a stopgap.

```
batch layout:  [ A text-only ] [ B EVS video ] [ decode ]
write target:  input_ids[0 : len(B)]
result:        B's IDs land on top of A  (A clobbered)
```

## Fix

Record where each request begins in the flattened `input_ids` (known in the model engine as `len(input_ids)` before the buffer is extended) on a new `MultimodalParams.input_ids_start_offset`, and write each request into its own span:

```python
for multimodal_param, context_part in zip(multimodal_params, context_parts, strict=True):
    start = multimodal_param.input_ids_start_offset
    input_ids[start : start + context_part.shape[0]] = context_part
```

Safe because the merge is **length-preserving**: the slot is pre-sized to the post-EVS token count and EVS only redistributes tokens across tubelets, never growing the span. The `_validate_evs_context_batch` guard is removed.

```
batch layout:  [ A text-only ] [ B EVS video ] [ decode ]
write target:  input_ids[len(A) : len(A) + len(B)]
result:        only B's span written  (A and decode untouched)
```

## Changes

- `inputs/multimodal.py` - add `input_ids_start_offset: int = 0` to `MultimodalParams`.
- `_torch/pyexecutor/model_engine.py` - record the offset in both context-prep paths.
- `_torch/models/modeling_nemotron_nano.py` - per-request offset writes; drop `_validate_evs_context_batch`.

## Test Coverage

`test_nemotron_nano_preprocessing.py::TestMergeEvsMMEmbeds` - replaced the rejection test with positive coverage: text-only before/after, interspersed multi-request, and chunked prefill with a preceding text-only request.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
