### PR TITLE
[https://nvbugs/6269778][fix] Fix overallocation of draft KV cache

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -58,7 +58,7 @@ from ..speculative import (SpecMetadata, get_draft_kv_cache_manager,
                            get_num_extra_kv_tokens, get_spec_metadata,
                            prepare_attn_metadata_for_draft_replay,
                            restore_attn_metadata_after_draft_replay,
-                           update_spec_config_from_model_config)
+                           update_spec_config_from_loaded_model)
 from ..speculative.drafting_loops import BaseDraftingLoopWrapper
 from ..speculative.eagle3 import Eagle3ResourceManager, Eagle3SpecMetadata
 from ..speculative.spec_sampler_base import SampleStateTensorsSpec
@@ -498,9 +498,11 @@ class PyTorchModelEngine(ModelEngine):
             self.llm_args.attn_backend,
             sparse_attention_config=self.sparse_attention_config)
 
+        self.spec_metadata = None
         if self.is_spec_decode:
-            update_spec_config_from_model_config(self.spec_config,
-                                                 self.model.config)
+            if not self.is_draft_model:
+                update_spec_config_from_loaded_model(self.spec_config,
+                                                     self.model)
             max_num_draft_tokens = self.max_draft_loop_tokens * self.batch_size
             self.draft_tokens_cuda = torch.empty((max_num_draft_tokens, ),
                                                  dtype=torch.int,

--- a/tensorrt_llm/_torch/speculative/__init__.py
+++ b/tensorrt_llm/_torch/speculative/__init__.py
@@ -21,7 +21,9 @@ from .suffix_automaton import SuffixAutomatonManager
 from .utils import (get_draft_kv_cache_manager, get_num_extra_kv_tokens,
                     get_num_spec_layers, get_spec_decoder, get_spec_drafter,
                     get_spec_metadata, get_spec_resource_manager,
-                    get_spec_worker, update_spec_config_from_model_config)
+                    get_spec_worker, update_spec_config_from_draft_model_config,
+                    update_spec_config_from_loaded_model,
+                    update_spec_config_from_model_config)
 
 __all__ = [
     "DFlashSpecMetadata",
@@ -60,6 +62,8 @@ __all__ = [
     "prepare_attn_metadata_for_draft_replay",
     "restore_attn_metadata_after_draft_replay",
     "should_use_separate_draft_kv_cache",
+    "update_spec_config_from_draft_model_config",
+    "update_spec_config_from_loaded_model",
     "update_spec_config_from_model_config",
     "suggest_spec_config",
     "SpecTreeManager",

--- a/tensorrt_llm/_torch/speculative/utils.py
+++ b/tensorrt_llm/_torch/speculative/utils.py
@@ -341,9 +341,26 @@ def get_num_spec_layers(spec_config):
     if spec_config.spec_dec_mode.is_mtp_vanilla():
         return spec_config.num_nextn_predict_layers
     if spec_config.spec_dec_mode.is_eagle3_one_model():
-        num_eagle_layers = spec_config.num_eagle_layers
-        return num_eagle_layers if num_eagle_layers is not None else 1
+        num_draft_hidden_layers = spec_config._num_draft_hidden_layers
+        return num_draft_hidden_layers if num_draft_hidden_layers is not None else 1
     return 0
+
+
+def update_spec_config_from_draft_model_config(spec_config,
+                                               draft_pretrained_config) -> None:
+    """Populate Eagle draft-layer fields from the loaded draft model config."""
+    from tensorrt_llm.llmapi.llm_args import EagleDecodingConfig
+
+    if not isinstance(spec_config, EagleDecodingConfig):
+        return
+
+    num_layers = getattr(draft_pretrained_config, "num_hidden_layers", None)
+    if num_layers is None:
+        logger.warning(
+            "Draft model pretrained config is missing num_hidden_layers; "
+            "defaulting _num_draft_hidden_layers to 1.")
+        num_layers = 1
+    spec_config._num_draft_hidden_layers = num_layers
 
 
 def get_spec_worker(spec_config,
@@ -440,6 +457,15 @@ def update_spec_config_from_model_config(spec_config, model_config):
         spec_config.max_draft_len = effective_draft_len
 
     spec_config.max_total_draft_tokens = spec_config.max_draft_len
+
+
+def update_spec_config_from_loaded_model(spec_config, model) -> None:
+    """Populate spec config fields from loaded target and draft model configs."""
+    update_spec_config_from_model_config(spec_config, model.config)
+    draft_config = getattr(model, 'draft_config', None)
+    if draft_config is not None:
+        update_spec_config_from_draft_model_config(
+            spec_config, draft_config.pretrained_config)
 
 
 @dataclass

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -1596,8 +1596,9 @@ class EagleDecodingConfig(DecodingBaseConfig):
     num_eagle_layers: Optional[int] = Field(
         default=None,
         description=
-        "The number of eagle layers. Will not be used in pytorch flow, just for compatibility with TRT flow."
-    )
+        "Deprecated TensorRT-only field with different semantics from draft model "
+        "layer count. Do not use on the PyTorch backend.")
+    _num_draft_hidden_layers: Optional[int] = PrivateAttr(default=None)
     max_non_leaves_per_layer: Optional[int] = Field(
         default=None, description="The number of non-leaves in each layer.")
     eagle3_one_model: Optional[bool] = Field(

--- a/tests/unittest/_torch/speculative/hw_agnostic/test_get_num_spec_layers.py
+++ b/tests/unittest/_torch/speculative/hw_agnostic/test_get_num_spec_layers.py
@@ -1,0 +1,74 @@
+from tensorrt_llm._torch.speculative.utils import (
+    get_num_spec_layers,
+    update_spec_config_from_draft_model_config,
+    update_spec_config_from_loaded_model,
+)
+from tensorrt_llm.llmapi.llm_args import Eagle3DecodingConfig, MTPDecodingConfig
+
+
+class _DraftPretrainedConfig:
+    def __init__(self, num_hidden_layers: int):
+        self.num_hidden_layers = num_hidden_layers
+
+
+def test_get_num_spec_layers_eagle3_one_model_uses_draft_hidden_layers():
+    spec_config = Eagle3DecodingConfig(
+        max_draft_len=8,
+        speculative_model="/path/to/draft",
+        num_eagle_layers=8,
+    )
+    spec_config._num_draft_hidden_layers = 1
+
+    assert get_num_spec_layers(spec_config) == 1
+
+
+def test_get_num_spec_layers_eagle3_one_model_defaults_to_one():
+    spec_config = Eagle3DecodingConfig(
+        max_draft_len=8,
+        speculative_model="/path/to/draft",
+        num_eagle_layers=8,
+    )
+
+    assert get_num_spec_layers(spec_config) == 1
+
+
+def test_get_num_spec_layers_mtp_eagle_one_model():
+    spec_config = MTPDecodingConfig(max_draft_len=1)
+    assert get_num_spec_layers(spec_config) == 1
+
+
+def test_update_spec_config_from_draft_model_config():
+    spec_config = Eagle3DecodingConfig(
+        max_draft_len=8,
+        speculative_model="/path/to/draft",
+    )
+
+    update_spec_config_from_draft_model_config(spec_config, _DraftPretrainedConfig(3))
+
+    assert spec_config._num_draft_hidden_layers == 3
+    assert get_num_spec_layers(spec_config) == 3
+
+
+def test_update_spec_config_from_loaded_model():
+    spec_config = Eagle3DecodingConfig(
+        max_draft_len=8,
+        speculative_model="/path/to/draft",
+    )
+
+    class _Model:
+        class _Config:
+            num_hidden_layers = 32
+
+        config = _Config()
+        draft_config = type(
+            "DraftConfig",
+            (),
+            {
+                "pretrained_config": _DraftPretrainedConfig(2),
+            },
+        )()
+
+    update_spec_config_from_loaded_model(spec_config, _Model())
+
+    assert spec_config._num_draft_hidden_layers == 2
+    assert get_num_spec_layers(spec_config) == 2

--- a/tests/unittest/_torch/speculative/test_eagle3.py
+++ b/tests/unittest/_torch/speculative/test_eagle3.py
@@ -696,13 +696,10 @@ def test_multi_eagle3(use_one_model: bool):
             load_format="dummy",
         )
 
-        spec_config = Eagle3DecodingConfig(
-            max_draft_len=max_draft_len,
-            speculative_model=eagle_model_dir,
-            # Llama 3 does not support one model eagle.
-            eagle3_one_model=use_one_model,
-            num_eagle_layers=2,
-            load_format="dummy")
+        spec_config = Eagle3DecodingConfig(max_draft_len=max_draft_len,
+                                           speculative_model=eagle_model_dir,
+                                           eagle3_one_model=use_one_model,
+                                           load_format="dummy")
 
         llm_spec = LLM(**llm_common_config, speculative_config=spec_config)
 


### PR DESCRIPTION
## Description

<!--
Please explain the issue and the solution in short.
-->
EAGLE3 is allocating too much KV cache. The root cause is in `get_num_spec_layers()`. 

The number of spec layers currently resolves to `1 if num_eagle_layers is None else num_eagle_layers`. However, there is other logic that sets `num_eagle_layers = max_draft_len`. This is consistent with the TRT flow. There, `num_eagle_layers` was used to represent the depth of the drafting tree. Setting `num_eagle_layers = max_draft_len` when trees are used makes the PyTorch semantics consistent with the legacy TRT flow.

However, `num_eagle_layers` is a misleading variable name. It was accidentally used in `get_num_spec_layers()` when multi-layer eagle support was added. To fix this:

1. Make `get_num_spec_layers` use a new field, `_num_draft_hidden_layers`. This is an internal field that is populated with the draft config after model loading.
2. Kept `num_eagle_layers` around for now as a legacy TRT field. It is no longer used in the PyTorch flow. The semantics of this field are left unchanged.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->
Existing tests plus one new one.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced speculative decoding configuration for Eagle3 one-model setup, ensuring proper draft model layer count detection.

* **Tests**
  * Added comprehensive test suite for speculative decoding layer counting and configuration updates.

* **Documentation**
  * Clarified deprecation status and usage restrictions for a speculative decoding configuration field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->