### PR TITLE
[#12933][fix] release orphaned KV-cache blocks in storeContextBlocks

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -1195,6 +1195,14 @@ public:
     //!          are already in the trie when they are replaced with placeholders.
     void storeContextBlocks(GenerationRequest& sequence, LlmRequest const& llmRequest);
 
+    //! \brief Release orphaned blocks for a request whose sequence was removed before
+    //!        storeContextBlocks could register them in the reuse trie.
+    //! \details Returns blocks to the eviction policy free pool WITHOUT inserting them
+    //!          into the radix trie, preventing stale KV-cache data from being recycled
+    //!          to new requests (which would cause cascading empty-completion corruption).
+    //!          No-op if removeSequence already cleaned up this request.
+    void releaseOrphanedBlocks(LlmRequest::RequestIdType requestId);
+
     //! \brief Store blocks in the reuse trie.
     //! \param blockKeys Key of each block.
     //! \param blocks Block pointers (beam 0 only). OOW slots contain placeholder blocks
@@ -1819,6 +1827,12 @@ public:
 
     //! \brief Store context blocks
     void storeContextBlocks(GenerationRequest& sequence, LlmRequest const& llmRequest);
+
+    //! \brief Release orphaned blocks across all window managers for a request whose
+    //!        sequence was removed before its context blocks were stored for reuse.
+    //! \details Delegates to each WindowBlockManager::releaseOrphanedBlocks. Prevents
+    //!          stale KV blocks from poisoning the reuse trie under enable_block_reuse.
+    void releaseOrphanedBlocks(LlmRequest::RequestIdType requestId);
 
     //! \brief Store newest block for reuse
     void storeNewBlock(GenerationRequest& sequence, OptionalRef<LlmRequest const> llmRequest);

--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -1337,6 +1337,14 @@ private:
 
     // List of allocated blocks for each sequences
     std::unordered_map<LlmRequest::RequestIdType, std::vector<BlockPtr>> mAllocatedBlocksPerSeq;
+    // Guards mutation of mAllocatedBlocksPerSeq (extract/erase) and the associated
+    // per-block refcount + eviction-policy release. The normal teardown path
+    // (releaseBlocks, driven by removeSequence) and the orphaned-block reclamation path
+    // (releaseOrphanedBlocks, driven by storeContextBlocks when the sequence was already
+    // removed) can run concurrently for the same request; without this lock both could
+    // extract() the same node and double-decrement refcounts. Leaf lock: never held while
+    // calling into storeBlocks()/the reuse trie (mLookupTree mutex) to avoid lock inversion.
+    mutable std::mutex mAllocatedBlocksMtx;
 
     // Pool per unique numKvHeads in the model
     std::vector<KVCacheBlockPool> mPools;

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -3822,7 +3822,64 @@ void KVCacheManager::storeContextBlocks(LlmRequest const& llmRequest)
     }
     else
     {
-        // TLLM_LOG_WARNING("[kv cache manager] storeContextBlocks: Can not find sequence for request %lu", requestId);
+        // The sequence was removed (warmup teardown, TRT overlap with MTP, or early
+        // termination) before storeContextBlocks could register its blocks in the reuse
+        // trie. The blocks are still allocated on GPU with stale KV data.
+        //
+        // If we leave them untracked, the eviction policy will eventually recycle them
+        // to new requests via the radix trie. Those requests will read garbage context,
+        // output immediate EOS, and cascade the corruption through the entire trie until
+        // the engine is restarted.
+        //
+        // Fix: release orphaned blocks to the free pool WITHOUT storing them for reuse.
+        TLLM_LOG_WARNING(
+            "[kv cache manager] storeContextBlocks: Can not find sequence for request %lu. "
+            "Releasing orphaned blocks to prevent KV-cache corruption under block reuse.",
+            requestId);
+
+        mBlockManager.releaseOrphanedBlocks(requestId);
+    }
+}
+
+void BlockManager::releaseOrphanedBlocks(RequestIdType requestId)
+{
+    for (auto& [_, manager] : mWindowBlockManagers)
+    {
+        manager.releaseOrphanedBlocks(requestId);
+    }
+}
+
+void WindowBlockManager::releaseOrphanedBlocks(RequestIdType requestId)
+{
+    // Extract the block tracking for this request. If removeSequence already
+    // cleaned it up, this returns an empty node and we're done (no double-free).
+    auto node = mAllocatedBlocksPerSeq.extract(requestId);
+    if (node.empty())
+    {
+        return;
+    }
+
+    auto& allocatedBlocks = node.mapped();
+    TLLM_LOG_DEBUG(
+        "%s::releaseOrphanedBlocks - Releasing %zu orphaned blocks for request %lu "
+        "(blocks contain stale KV data, NOT stored for reuse)",
+        mLogPrefix.c_str(), allocatedBlocks.size(), requestId);
+
+    // Release blocks WITHOUT storing them in the reuse trie. This is the same
+    // cleanup as the no-reuse path in releaseBlocks() above: decrement refcounts
+    // and return zero-ref blocks to the eviction policy free pool. We deliberately
+    // skip storeBlocks() — the data is stale and must not poison the trie.
+    for (auto it = allocatedBlocks.rbegin(); it != allocatedBlocks.rend(); ++it)
+    {
+        auto& block = *it;
+        if (block->hasRefs())
+        {
+            block->decRefCount();
+        }
+        if (!block->hasRefs())
+        {
+            mEvictionPolicy->releaseBlock(block);
+        }
     }
 }
 

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -3065,8 +3065,30 @@ std::optional<KVCacheBlock::IdType> WindowBlockManager::releaseBlocks(
     TLLM_LOG_DEBUG("%s::releaseBlocks - requestId=%lu, llmRequest.id=%s", mLogPrefix.c_str(), requestId,
         llmRequest.has_value() ? std::to_string(llmRequest->mRequestId).c_str() : "null");
     std::optional<KVCacheBlock::IdType> lastStoredId = std::nullopt;
-    auto node = mAllocatedBlocksPerSeq.extract(requestId);
-    TLLM_CHECK(node);
+    // Claim this request's blocks under mAllocatedBlocksMtx so the extract() cannot race
+    // releaseOrphanedBlocks(), which can run concurrently for the same request (see that
+    // method and the mutex declaration). extract() is the single atomic claim point: the
+    // winner gets the node and proceeds to release the blocks below; a concurrent
+    // releaseOrphanedBlocks() then sees an empty node and bails, so the refcount loop here
+    // operates on a node no other path can hold. The lock is released before storeBlocks()
+    // and the eviction work so it stays a leaf lock (no inversion with the reuse trie).
+    decltype(mAllocatedBlocksPerSeq)::node_type node;
+    {
+        std::scoped_lock<std::mutex> lock(mAllocatedBlocksMtx);
+        node = mAllocatedBlocksPerSeq.extract(requestId);
+    }
+    // A concurrent releaseOrphanedBlocks() for the same request may have already claimed
+    // and released these blocks (it fires when storeContextBlocks finds the sequence gone,
+    // which happens after removeSequence extracts mSequences but before it reaches here).
+    // In that case the node is empty and there is nothing left to release — return without
+    // aborting. Whichever path wins the extract() is the single owner; the other no-ops.
+    if (node.empty())
+    {
+        TLLM_LOG_DEBUG("%s::releaseBlocks - blocks for request %lu already released "
+                       "(claimed by releaseOrphanedBlocks); nothing to do",
+            mLogPrefix.c_str(), requestId);
+        return lastStoredId;
+    }
     auto& allocatedBlocks = node.mapped();
     if (llmRequest.has_value() && !isRecurrentState()) // only store context blocks for recurrent states
     {
@@ -3853,6 +3875,13 @@ void WindowBlockManager::releaseOrphanedBlocks(RequestIdType requestId)
 {
     // Extract the block tracking for this request. If removeSequence already
     // cleaned it up, this returns an empty node and we're done (no double-free).
+    // The lock serializes against releaseBlocks(): both extract() the same node and
+    // mutate the same block refcounts, and they can run concurrently for one request
+    // (storeContextBlocks's orphan path fires precisely when a teardown removed the
+    // sequence). Without it, the concurrent extract() races on the map and the refcount
+    // updates double-decrement. Held only over the map + refcount work, never over
+    // storeBlocks()/the reuse trie, so it stays a leaf lock.
+    std::scoped_lock<std::mutex> lock(mAllocatedBlocksMtx);
     auto node = mAllocatedBlocksPerSeq.extract(requestId);
     if (node.empty())
     {

--- a/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
+++ b/cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp
@@ -3084,8 +3084,9 @@ std::optional<KVCacheBlock::IdType> WindowBlockManager::releaseBlocks(
     // aborting. Whichever path wins the extract() is the single owner; the other no-ops.
     if (node.empty())
     {
-        TLLM_LOG_DEBUG("%s::releaseBlocks - blocks for request %lu already released "
-                       "(claimed by releaseOrphanedBlocks); nothing to do",
+        TLLM_LOG_DEBUG(
+            "%s::releaseBlocks - blocks for request %lu already released "
+            "(claimed by releaseOrphanedBlocks); nothing to do",
             mLogPrefix.c_str(), requestId);
         return lastStoredId;
     }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential data corruption issue in the key-value cache system that occurred when sequences were removed before their context blocks were registered. The system now properly releases orphaned cache blocks, preventing stale data from being incorrectly reused in subsequent operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> related to #12933 

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

When a sequence is removed (warmup teardown, TRT overlap with MTP, or early termination) before KVCacheManager::storeContextBlocks can register its blocks in the reuse trie, the blocks were left allocated on GPU with stale KV data and untracked. Under enable_block_reuse the eviction policy later recycles those blocks to new requests via the radix trie, which then read garbage context, emit immediate EOS, and cascade the corruption through the trie until the engine is restarted. This manifests as silent empty completions (HTTP 200, zero tokens) under high-concurrency ramps.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Fix: in the orphaned-sequence branch, release the blocks to the eviction policy free pool WITHOUT storing them for reuse. Adds BlockManager::releaseOrphanedBlocks (fans out over window managers) and WindowBlockManager::releaseOrphanedBlocks (extracts the per-request block list, decrements refcounts, releases zero-ref blocks). Mirrors the no-reuse cleanup in releaseBlocks(); deliberately skips storeBlocks() so stale data cannot poison the trie. No-op if removeSequence already cleaned up the request.

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
