### PR TITLE
[#15022][fix] Guided decoding (xgrammar) + EAGLE-3 + draft_len_schedule reaching 0 crashes during CUDA graph capture, "bitmask must have the same batch size as logits"

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/guided_decoder.py
+++ b/tensorrt_llm/_torch/pyexecutor/guided_decoder.py
@@ -263,7 +263,8 @@ class GuidedDecoder:
                     # the new_tokens buffer always holds the static max, but only
                     # `max_num_draft_tokens` slots are reserved this iteration.
                     for i, tid in enumerate(
-                            req.draft_tokens[:requests.max_num_draft_tokens], 1):
+                            req.draft_tokens[:requests.max_num_draft_tokens],
+                            1):
                         accepted = matcher.accept_token(tid)
                         if not accepted:
                             break

--- a/tensorrt_llm/_torch/pyexecutor/guided_decoder.py
+++ b/tensorrt_llm/_torch/pyexecutor/guided_decoder.py
@@ -259,8 +259,11 @@ class GuidedDecoder:
                     matcher.fill_next_token_bitmask(self.bitmask_host, offset)
                     self.token_mask_host[offset] = 1
                     self.num_guided_tokens[slot] += 1
-                    # Process draft tokens
-                    for i, tid in enumerate(req.draft_tokens, 1):
+                    # Process draft tokens. Bound by the layout's draft length:
+                    # the new_tokens buffer always holds the static max, but only
+                    # `max_num_draft_tokens` slots are reserved this iteration.
+                    for i, tid in enumerate(
+                            req.draft_tokens[:requests.max_num_draft_tokens], 1):
                         accepted = matcher.accept_token(tid)
                         if not accepted:
                             break
@@ -332,9 +335,13 @@ class GuidedDecoder:
             d2t=d2t)
 
     @nvtx_range("GuidedDecoder.add_batch")
-    def add_batch(self, scheduled_requests: ScheduledRequests) -> None:
+    def add_batch(self,
+                  scheduled_requests: ScheduledRequests,
+                  runtime_draft_len: Optional[int] = None) -> None:
+        num_draft_tokens = (self.max_num_draft_tokens
+                            if runtime_draft_len is None else runtime_draft_len)
         self.requests = GuidedRequests.from_scheduled_requests(
-            scheduled_requests, self.max_num_draft_tokens)
+            scheduled_requests, num_draft_tokens)
 
     @nvtx_range("GuideDecoder.build")
     def build(self) -> List[Tuple[int, str]]:
@@ -470,9 +477,14 @@ class CapturableGuidedDecoder(GuidedDecoder):
     @nvtx_range("GuidedDecoder.add_batch")
     def add_batch(self,
                   scheduled_requests: ScheduledRequests,
-                  new_tokens: Optional[torch.Tensor] = None) -> None:
+                  new_tokens: Optional[torch.Tensor] = None,
+                  runtime_draft_len: Optional[int] = None) -> None:
+        # See GuidedDecoder.add_batch: the layout must follow the runtime draft
+        # length so the captured graph's bitmask matches the target logits.
+        num_draft_tokens = (self.max_num_draft_tokens
+                            if runtime_draft_len is None else runtime_draft_len)
         self.requests = GuidedRequests.from_scheduled_requests(
-            scheduled_requests, self.max_num_draft_tokens)
+            scheduled_requests, num_draft_tokens)
         if new_tokens is not None:
             self.new_tokens.copy_(new_tokens.squeeze(-1), non_blocking=True)
         self.queue.put((self.requests, new_tokens is not None))

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2634,7 +2634,8 @@ class PyTorchModelEngine(ModelEngine):
         # Must be before the update of py_batch_idx
         if self.guided_decoder is not None:
             self.guided_decoder.add_batch(scheduled_requests,
-                                          new_tokens=new_tokens_device)
+                                          new_tokens=new_tokens_device,
+                                          runtime_draft_len=self.runtime_draft_len)
 
         if self._can_use_incremental_update(scheduled_requests,
                                             new_tokens_device,

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2633,9 +2633,10 @@ class PyTorchModelEngine(ModelEngine):
 
         # Must be before the update of py_batch_idx
         if self.guided_decoder is not None:
-            self.guided_decoder.add_batch(scheduled_requests,
-                                          new_tokens=new_tokens_device,
-                                          runtime_draft_len=self.runtime_draft_len)
+            self.guided_decoder.add_batch(
+                scheduled_requests,
+                new_tokens=new_tokens_device,
+                runtime_draft_len=self.runtime_draft_len)
 
         if self._can_use_incremental_update(scheduled_requests,
                                             new_tokens_device,


### PR DESCRIPTION
@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Addressing Issue #15022.

With dynamic draft length (`draft_len_schedule`), the model engine tracks this as `runtime_draft_len`:

[py_executor.py:2346-2362](https://github.com/chungen04/TensorRT-LLM/blob/e760fa2a9df60aa151c0350c64ba823d72655707/tensorrt_llm/_torch/pyexecutor/py_executor.py#L2342-L2362) per iteration, from the schedule
```
runtime_draft_len = get_draft_len_for_batch_size(... batch_size ...)
self.model_engine.runtime_draft_len = runtime_draft_len
```

When `runtime_draft_len` is, say, 1, the target model emits only 1 + 1 = 2 logit rows per generation request. But now, the guided decoder always laid out its bitmask for the static max 
[guided_decoder.py:335-337](https://github.com/NVIDIA/TensorRT-LLM/blob/3b2109310d8453815a1065f5c4a6204c1cf51384/tensorrt_llm/_torch/pyexecutor/guided_decoder.py#L335-L337)
```
def add_batch(self, scheduled_requests):
    self.requests = GuidedRequests.from_scheduled_requests(
        scheduled_requests, self.max_num_draft_tokens)   # <-- always the static max
```

So the guided decoder expected `max_num_draft_tokens + 1` rows per request, while the model produced only `runtime_draft_len + 1.`

That row count flows into num_bitmask_tokens:

[guided_decoder.py:110-116](https://github.com/NVIDIA/TensorRT-LLM/blob/3b2109310d8453815a1065f5c4a6204c1cf51384/tensorrt_llm/_torch/pyexecutor/guided_decoder.py#L110-L116)
```
def num_bitmask_tokens(self):
    return self.num_contexts + self.num_generations * (self.max_num_draft_tokens + 1)
```

and is then used to index both the bitmask and the logits tensor:

[guided_decoder.py:328-332 (_apply_bitmask)](https://github.com/NVIDIA/TensorRT-LLM/blob/3b2109310d8453815a1065f5c4a6204c1cf51384/tensorrt_llm/_torch/pyexecutor/guided_decoder.py#L328-L332)
```
torch.ops.trtllm.logits_bitmask(
    logits[:num_bitmask_tokens],                    # logits only has runtime_draft_len+1 rows/req
    self.bitmask[:num_bitmask_tokens, ...],
    token_mask=self.token_mask[:num_bitmask_tokens], ...)
```

Because `num_bitmask_tokens` (computed from the static max) is larger than the actual number of logit rows the model produced, the indexing reads past the end of logits and crash.

At #10860, it let `runtime_draft_len` drop below the static max per iteration, but `guided_decoder.py` was not updated. So after #10860, the guided decoder kept laying out its bitmask for `max_num_draft_tokens` while the target emitted only `runtime_draft_len + 1` rows per request.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
