### PR TITLE
[None][fix] Disagg: handle ctx-only completion when ctx_request_id is None with terminal finish_reason

### DIFF
--- a/tensorrt_llm/serve/openai_disagg_service.py
+++ b/tensorrt_llm/serve/openai_disagg_service.py
@@ -394,6 +394,14 @@ class OpenAIDisaggregatedService(OpenAIService):
                     f" finish_reason={choice.finish_reason!r}"
                 )
             if choice.disaggregated_params.ctx_request_id is None:
+                # MTP early-termination edge case: the context phase may finish
+                # the whole request (e.g. EOS) before the KV-cache handoff is
+                # initiated, so ctx_request_id is never populated. When the ctx
+                # response is already a finished generation there is nothing to
+                # hand off to gen; treat it as a valid context-only completion
+                # (the caller short-circuits via _need_gen and returns it).
+                if choice.finish_reason not in (None, "length", "not_finished"):
+                    return ctx_response
                 raise ValueError(
                     f"Invalid disaggregated params: ctx_request_id is None."
                     f" finish_reason={choice.finish_reason!r},"

--- a/tests/unittest/disaggregated/test_openai_disagg_service.py
+++ b/tests/unittest/disaggregated/test_openai_disagg_service.py
@@ -442,6 +442,17 @@ class TestVerifyCtxResponseDiagnostics:
         result = await svc._verify_ctx_response(resp)
         assert result is resp
 
+    @pytest.mark.asyncio
+    async def test_finished_ctx_with_none_ctx_request_id_is_accepted(self):
+        # MTP early-termination: ctx phase finishes the whole request (EOS)
+        # before the KV-cache handoff, so ctx_request_id is never populated.
+        # A terminal finish_reason makes this a valid context-only completion.
+        svc = _make_service("context_first")
+        resp = _make_completion_response("done", finish_reason="stop", disagg_request_id=7)
+        resp.choices[0].disaggregated_params.ctx_request_id = None
+        result = await svc._verify_ctx_response(resp)
+        assert result is resp
+
 
 class TestFirstGenLogProbsSerializeRoundtrip:
     """Roundtrip tests for _serialize/_deserialize_first_gen_log_probs."""


### PR DESCRIPTION
## Description

Fixes a flaky HTTP 500 in disaggregated serving (nvbugs/6245861).

With MTP, the context/prefill worker occasionally finishes a request (EOS, `finish_reason='stop'`) before the KV-cache handoff to the GEN worker is initiated, so `ctx_request_id` is never populated — yet the response is a complete, valid answer. The previous code in `_verify_ctx_response` raised unconditionally in that case (`ValueError`), turning a valid context-only completion into an intermittent HTTP 500 (observed ~1/640–1/16384).

## Fix

- `tensorrt_llm/serve/openai_disagg_service.py`: short-circuit when `ctx_request_id is None` **and** the CTX choice has a terminal `finish_reason`, returning the context-only completion instead of raising (mirrors the existing `_need_gen` logic).
- `tests/unittest/disaggregated/test_openai_disagg_service.py`: regression test for the ctx-only terminal case.

## Test Coverage

Added unit test reproducing the `ctx_request_id=None` + terminal `finish_reason` path.

Regression introduced by 7443f1d05f.
