### PR TITLE
[None][fix] Disagg: handle ctx-only completion when ctx_request_id is None with terminal finish_reason

### DIFF
--- a/tensorrt_llm/serve/openai_disagg_service.py
+++ b/tensorrt_llm/serve/openai_disagg_service.py
@@ -394,6 +394,14 @@ class OpenAIDisaggregatedService(OpenAIService):
                     f" finish_reason={choice.finish_reason!r}"
                 )
             if choice.disaggregated_params.ctx_request_id is None:
+                # MTP early-termination edge case: the context phase may finish
+                # the whole request (e.g. EOS) before the KV-cache handoff is
+                # initiated, so ctx_request_id is never populated. When the ctx
+                # response is already a finished generation there is nothing to
+                # hand off to gen; treat it as a valid context-only completion
+                # (the caller short-circuits via _need_gen and returns it).
+                if choice.finish_reason not in (None, "length", "not_finished"):
+                    return ctx_response
                 raise ValueError(
                     f"Invalid disaggregated params: ctx_request_id is None."
                     f" finish_reason={choice.finish_reason!r},"

--- a/tests/unittest/disaggregated/test_openai_disagg_service.py
+++ b/tests/unittest/disaggregated/test_openai_disagg_service.py
@@ -442,6 +442,17 @@ class TestVerifyCtxResponseDiagnostics:
         result = await svc._verify_ctx_response(resp)
         assert result is resp
 
+    @pytest.mark.asyncio
+    async def test_finished_ctx_with_none_ctx_request_id_is_accepted(self):
+        # MTP early-termination: ctx phase finishes the whole request (EOS)
+        # before the KV-cache handoff, so ctx_request_id is never populated.
+        # A terminal finish_reason makes this a valid context-only completion.
+        svc = _make_service("context_first")
+        resp = _make_completion_response("done", finish_reason="stop", disagg_request_id=7)
+        resp.choices[0].disaggregated_params.ctx_request_id = None
+        result = await svc._verify_ctx_response(resp)
+        assert result is resp
+
 
 class TestFirstGenLogProbsSerializeRoundtrip:
     """Roundtrip tests for _serialize/_deserialize_first_gen_log_probs."""


### PR DESCRIPTION
## Summary
Fixes an intermittent HTTP 500 in context_first disaggregated serving (DeepSeek-R1-FP4, MTP3, NIXL KV transfer) where 1/640 requests failed. When the context/prefill worker finishes the whole request (EOS, `finish_reason='stop'`) before the KV-cache handoff to GEN is initiated, `ctx_request_id` is never populated. `_verify_ctx_response` then raised `ValueError` unconditionally, returning 500 for an otherwise-valid context-only completion.

## Root cause
`tensorrt_llm/serve/openai_disagg_service.py:397` — `_verify_ctx_response()` rejected any response with `ctx_request_id is None`, even when the context phase already produced a terminal `finish_reason`. Observed:
`ValueError: Invalid disaggregated params: ctx_request_id is None. finish_reason='stop', disagg_request_id=548424870944926`

## Fix
When `ctx_request_id is None`, only raise if generation still needs to continue (`finish_reason` in `None`/`'length'`/`'not_finished'`). A terminal `finish_reason` short-circuits and returns the ctx response as a valid context-only completion, mirroring `_need_gen` — which already returns `False` for terminal finish reasons, causing the caller to return the ctx response directly without contacting a GEN worker.

## Verification
Added a unit test (`test_finished_ctx_with_none_ctx_request_id_is_accepted`) covering the MTP early-termination edge case. No local cluster run; L0 in CI covers correctness.

## Bug
nvbugs/6245861