### PR TITLE
fix: Allow explicit device mapping configurations in quantization CLI

### DIFF
--- a/examples/quantization/quantize.py
+++ b/examples/quantization/quantize.py
@@ -28,9 +28,9 @@ if __name__ == "__main__":
         choices=['cuda', 'cpu'])
     parser.add_argument(
         "--device_map",
-        help="How to map the model on the devices",
+        help="How to map the model on the devices (e.g., auto, sequential, cpu, cuda, cuda:0). Note: 'gpu' is normalized to 'cuda' for backward-compatibility.",
         default="auto",
-        choices=["auto", "sequential", "cpu", "gpu"],
+        type=str,
     )
     parser.add_argument(
         '--calib_dataset',
@@ -147,6 +147,10 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    # Backward-compatibility shim: translates legacy "gpu" option into the explicit device name "cuda"
+    # so downstream logic expects a consistent device token.
+    if args.device_map == "gpu":
+        args.device_map = "cuda"
     # auto_quantize_bits check
     if args.autoq_format:
         lower_bound, upper_bound = 4 if '4' in args.autoq_format else 8, 16


### PR DESCRIPTION
### Description
Fixes a multi-device offloading crash (`RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!`) encountered on unified memory hardware setups like GB10 (Grace Blackwell) when running quantization workflows via `quantize.py`.

### Changes
- Removed the strict `choices` constraint from the `--device_map` argument parser inside `examples/quantization/quantize.py` to natively allow explicit device targets (e.g., `cuda`, `cuda:0`).
- Added internal conversion alignment string fallback mappings for runtime processing.

Closes #15021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended `--device_map` argument to accept flexible device specifications with automatic normalization.

* **Documentation**
  * Improved help text documenting available device targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->