### PR TITLE
[https://nvbugs/6245861][fix] Skip ctx_request_id check when CTX produced terminal response

### DIFF
--- a/tensorrt_llm/serve/openai_disagg_service.py
+++ b/tensorrt_llm/serve/openai_disagg_service.py
@@ -388,23 +388,33 @@ class OpenAIDisaggregatedService(OpenAIService):
                     f"Context server returned {len(ctx_response.choices)} choices, expecting 1."
                 )
             choice = ctx_response.choices[0]
+            # If the CTX worker already produced a terminal response (e.g. an
+            # early EOS during prefill / MTP draft-token generation), the
+            # disagg KV-cache handoff to GEN will not happen — see
+            # _need_gen() and the ctx-only return path in
+            # _send_disagg_request_ctx_first. In that case ctx_request_id /
+            # disagg_request_id are only meaningful for the (skipped)
+            # handoff, so don't require them. Keep this condition in sync
+            # with _need_gen().
+            ctx_will_hand_off_to_gen = choice.finish_reason in ["length", "not_finished"]
             if choice.disaggregated_params is None:
                 raise ValueError(
                     f"Context server did not return disaggregated params."
                     f" finish_reason={choice.finish_reason!r}"
                 )
-            if choice.disaggregated_params.ctx_request_id is None:
-                raise ValueError(
-                    f"Invalid disaggregated params: ctx_request_id is None."
-                    f" finish_reason={choice.finish_reason!r},"
-                    f" disagg_request_id={choice.disaggregated_params.disagg_request_id!r}"
-                )
-            if choice.disaggregated_params.disagg_request_id is None:
-                raise ValueError(
-                    f"Invalid disaggregated params: disagg_request_id is None."
-                    f" finish_reason={choice.finish_reason!r},"
-                    f" ctx_request_id={choice.disaggregated_params.ctx_request_id!r}"
-                )
+            if ctx_will_hand_off_to_gen:
+                if choice.disaggregated_params.ctx_request_id is None:
+                    raise ValueError(
+                        f"Invalid disaggregated params: ctx_request_id is None."
+                        f" finish_reason={choice.finish_reason!r},"
+                        f" disagg_request_id={choice.disaggregated_params.disagg_request_id!r}"
+                    )
+                if choice.disaggregated_params.disagg_request_id is None:
+                    raise ValueError(
+                        f"Invalid disaggregated params: disagg_request_id is None."
+                        f" finish_reason={choice.finish_reason!r},"
+                        f" ctx_request_id={choice.disaggregated_params.ctx_request_id!r}"
+                    )
             return ctx_response
 
     async def _send_disagg_request_gen_first(


### PR DESCRIPTION
## Summary
Fix a rare HTTP 500 in the context_first DISAGG protocol when the CTX worker fully completes a request itself (e.g. MTP3 draft-token early EOS during prefill) before the disagg KV-cache handoff is initiated. Observed at 1/640 = 0.16% on DeepSeek-R1-0528-FP4-v2 (CTX×1 PP8, GEN×1 TP32, MTP3, NIXL) on GB200-LYRIS.

## Root cause
`tensorrt_llm/serve/openai_disagg_service.py:397` (`_verify_ctx_response`) unconditionally raises `ValueError` when `ctx_request_id is None` on a CTX response. But when CTX hits a terminal `finish_reason='stop'` during prefill/MTP, the disagg handoff to GEN is skipped (see `_need_gen()` and the ctx-only return path in `_send_disagg_request_ctx_first`), so the IDs that only matter for handoff are never populated.

Observed traceback (excerpt):
```
File "openai_disagg_service.py", line 145, in _send_disagg_request_ctx_first
    await self._verify_ctx_response(ctx_response)
File "openai_disagg_service.py", line 397, in _verify_ctx_response
    raise ValueError(
ValueError: Invalid disaggregated params: ctx_request_id is None. finish_reason='stop', disagg_request_id=548424870944926
```

## Fix
In `_verify_ctx_response`, gate the `ctx_request_id` / `disagg_request_id` non-None checks behind `finish_reason in ['length', 'not_finished']` — the same condition `_need_gen()` uses to decide whether the handoff path will run. The `disaggregated_params is None` sanity check stays unconditional. When CTX has produced a terminal response, verification now passes and the existing `_need_gen` short-circuit returns the CTX response directly to the client.

## Verification
No local cluster run; L0 in CI covers correctness for the handoff path. The change preserves the original error messages and the original semantics for the handoff case (only narrows when the checks apply).

## Bug
nvbugs/6245861