### PR TITLE
[https://nvbugs/6245861][fix] Skip CTX-response disagg-params check when CTX already finished

### DIFF
--- a/tensorrt_llm/serve/openai_disagg_service.py
+++ b/tensorrt_llm/serve/openai_disagg_service.py
@@ -388,6 +388,14 @@ class OpenAIDisaggregatedService(OpenAIService):
                     f"Context server returned {len(ctx_response.choices)} choices, expecting 1."
                 )
             choice = ctx_response.choices[0]
+            # When the CTX response is already complete (finish_reason is not
+            # "length"/"not_finished"), no KV transfer to a GEN worker is
+            # required and the response is returned directly to the client
+            # (see _need_gen / _send_disagg_request_ctx_first). In that case
+            # ctx_request_id / disagg_request_id may legitimately be absent,
+            # so skip the strict null checks below.
+            if choice.finish_reason not in ["length", "not_finished"]:
+                return ctx_response
             if choice.disaggregated_params is None:
                 raise ValueError(
                     f"Context server did not return disaggregated params."


### PR DESCRIPTION
## Description

NVBug: nvbugs/6245861

Sporadic `HTTP 500` from the disagg server with:

```
ValueError: Invalid disaggregated params: ctx_request_id is None. finish_reason='stop', disagg_request_id=...
  at tensorrt_llm/serve/openai_disagg_service.py:397 in _verify_ctx_response
```

### Root cause

When the CTX worker fully completes generation in the context phase (e.g. very short prompts or early stop), it returns `finish_reason='stop'` and has no KV cache to hand off to a GEN worker, so `disaggregated_params.ctx_request_id` is legitimately `None`. The strict null-check in `_verify_ctx_response` (introduced in 7443f1d05f) raises `ValueError` unconditionally, but it runs **before** the existing `_need_gen` short-circuit in `_send_disagg_request_ctx_first` that already treats `finish_reason not in {'length','not_finished'}` as "CTX is the full answer, return directly". The verification therefore rejects a perfectly valid completion and returns HTTP 500 to the client.

### Fix

In `_verify_ctx_response`, short-circuit and return the CTX response when `finish_reason` is not `'length'`/`'not_finished'`, mirroring `_need_gen`'s existing semantics. The strict `ctx_request_id` / `disagg_request_id` null checks only apply when a KV handoff to GEN is actually required.

## Test Coverage

No local cluster run; L0 disagg CI covers correctness. The repro case (`disagg-e2e-gb200_deepseek-r1-fp4_128k8k_con64_ctx1_pp8_gen1_dep32_eplb0_mtp3_ccb-NIXL`) will exercise this path in scheduled CI.

## PR Checklist

- [x] Minimal change scoped to the regression
- [x] No refactor / no drive-by edits
- [x] DCO sign-off

## GitHub Bot Help

`/bot run` to retest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined context-response validation logic by implementing early termination when responses indicate completion status. This optimization eliminates unnecessary downstream validation checks, improving the efficiency and responsiveness of the service's response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->