### PR TITLE
[https://nvbugs/6245861][fix] Allow ctx_request_id=None when context phase already emitted EOS

### DIFF
--- a/tensorrt_llm/serve/openai_disagg_service.py
+++ b/tensorrt_llm/serve/openai_disagg_service.py
@@ -393,7 +393,14 @@ class OpenAIDisaggregatedService(OpenAIService):
                     f"Context server did not return disaggregated params."
                     f" finish_reason={choice.finish_reason!r}"
                 )
-            if choice.disaggregated_params.ctx_request_id is None:
+            # When the context phase already produced an end-of-sequence
+            # token (finish_reason not in {"length", "not_finished"}), no
+            # generation phase will follow (see _need_gen), so the ctx
+            # server legitimately omits ctx_request_id since there is no
+            # kv-cache transfer to schedule. Only enforce the presence of
+            # ctx_request_id when a gen phase is expected.
+            gen_expected = choice.finish_reason in ("length", "not_finished", None)
+            if gen_expected and choice.disaggregated_params.ctx_request_id is None:
                 raise ValueError(
                     f"Invalid disaggregated params: ctx_request_id is None."
                     f" finish_reason={choice.finish_reason!r},"


### PR DESCRIPTION
## Description
Fix a regression in the disagg context-first path where `_verify_ctx_response` raises `ValueError: Invalid disaggregated params: ctx_request_id is None` for context responses that completed in the context phase (`finish_reason='stop'`). When the ctx phase already emits EOS, no generation phase follows (see `_need_gen`) and the ctx server legitimately returns `ctx_request_id=None` because there is no kv-cache transfer to schedule. The validator now only enforces `ctx_request_id` presence when a gen phase is actually expected (`finish_reason in {'length','not_finished', None}`), mirroring `_need_gen`.

## Root cause
`tensorrt_llm/serve/openai_disagg_service.py:397` `_verify_ctx_response` unconditionally raised when `disaggregated_params.ctx_request_id is None`. With `finish_reason='stop'` this is a legal completion-in-ctx-phase case, not an error — _need_gen returns False and the ctx response is returned as-is, so there is no kv-transfer to wire up.

## Test Coverage
Covered by existing disagg L0 CI (e.g. `disagg-e2e-gb200_deepseek-r1-fp4_128k8k_con64_ctx1_pp8_gen1_dep32_eplb0_mtp3_ccb-NIXL`) which previously hit this internal 500 once a request finished in the context phase.

## PR Checklist
- [x] Sign-off included in commit trailer.

## Bug
nvbugs/6245861

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved request validation in the disaggregated service to correctly handle sequences completing during context processing, while maintaining proper validation for sequences requiring subsequent generation phase processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->