### PR TITLE
[None][feat] Introduce tokenizer cache and absolute block score

### DIFF
--- a/tensorrt_llm/serve/router.py
+++ b/tensorrt_llm/serve/router.py
@@ -827,40 +827,57 @@ class BlockHashMixin:
                     tokenizer, model, trust_remote_code=True)
         return self._tokenizers[model]
 
+    def _encode_with_prefix_cache(self, rendered: str, key: int,
+                                  tokenizer) -> list[int]:
+        cache = getattr(self, "_tok_prefix_cache", None)
+        if cache is None:
+            cache = self._tok_prefix_cache = OrderedDict()
+        entry = cache.get(key)
+        if entry is not None and len(rendered) > len(entry[0]) and \
+                rendered.startswith(entry[0]):
+            ids = entry[1] + tokenizer.encode(rendered[len(entry[0]):],
+                                              add_special_tokens=False)
+        else:
+            ids = tokenizer.encode(rendered, add_special_tokens=False)
+        cache[key] = (rendered, ids)
+        cache.move_to_end(key)
+        while len(cache) > 1024:
+            cache.popitem(last=False)
+        return ids
+
     def _tokenize(self, request: OpenAIRequest) -> list[list[int]]:
         # Handle ChatCompletionRequest (has messages, not prompt)
         if isinstance(request, ChatCompletionRequest):
             if request.prompt_token_ids is not None:
                 return [request.prompt_token_ids]
             tokenizer = self._get_tokenizer(request.model)
-            # Forward tools and chat_template_kwargs so custom tokenizers
-            # (e.g. DeepseekV32Tokenizer) render tool schemas and respect
-            # template flags like `thinking=true` when computing the prompt
-            # token ids used for cache-aware routing AND passed downstream
-            # (prompt_token_ids makes the worker skip re-tokenization).
             tool_dicts = (None if getattr(request, "tools", None) is None else [
                 tool.model_dump() if hasattr(tool, "model_dump") else tool
                 for tool in request.tools
             ])
             chat_template_kwargs = (request.chat_template_kwargs if getattr(
                 request, "chat_template_kwargs", None) else {})
-            result = tokenizer.apply_chat_template(
+            rendered = tokenizer.apply_chat_template(
                 [
                     msg if isinstance(msg, dict) else dict(msg)
                     for msg in request.messages
                 ],
                 add_generation_prompt=request.add_generation_prompt,
-                tokenize=True,
+                tokenize=False,
                 return_dict=False,
                 tools=tool_dicts,
                 **chat_template_kwargs,
             )
-            # Some custom tokenizers (e.g. DeepseekV32Tokenizer) return a
-            # string from apply_chat_template even with tokenize=True.
-            # Encode to token IDs if needed.
-            if isinstance(result, str):
-                result = tokenizer.encode(result, add_special_tokens=False)
-            # Set prompt_token_ids so the worker server skips re-tokenization
+            if isinstance(rendered, str):
+                key = hash("".join(
+                    str(
+                        msg.get("content") if isinstance(msg, dict) else
+                        getattr(msg, "content", ""))
+                    for msg in request.messages[:2]))
+                result = self._encode_with_prefix_cache(rendered, key,
+                                                        tokenizer)
+            else:
+                result = list(rendered)
             request.prompt_token_ids = result
             return [result]
 
@@ -981,7 +998,7 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
                  tokens_per_block: int = 32,
                  custom_tokenizer: Optional[str] = None,
                  backfill_block_hashes_on_finish: bool = False,
-                 load_weight: float = 1.0,
+                 load_weight: float = 0.25,
                  load_cap: float = float("inf"),
                  **kwargs):
         super().__init__(server_role, servers, metadata_server_cfg,
@@ -1105,13 +1122,6 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
         token_lists, block_hashes_by_algo = await asyncio.to_thread(
             self._tokenize_and_compute_block_hashes_by_algo, request,
             hash_algo_by_server.values(), cache_salt_id)
-        padded_tokens_by_algo = {
-            hash_algo:
-            max(
-                sum(len(hash_list)
-                    for hash_list in block_hashes) * self._tokens_per_block, 1)
-            for hash_algo, block_hashes in block_hashes_by_algo.items()
-        }
         # select the server by (KV match - load), bounded by load_cap
         workloads = [
             self._server_state[server].num_active_requests()
@@ -1126,12 +1136,11 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
             server = servers[i]
             hash_algo = hash_algo_by_server[server]
             block_hashes = block_hashes_by_algo[hash_algo]
-            padded_tokens = padded_tokens_by_algo[hash_algo]
             # https://github.com/ai-dynamo/dynamo/blob/main/docs/kv_cache_routing.md#kv-cache-routing-and-load-balancing
             matches.append(await self._server_state[server].matched_tokens(
                 block_hashes, hash_algo))
-            score = matches[-1] / padded_tokens - self._load_weight * \
-                load_fractions[i]
+            score = matches[-1] / self._tokens_per_block - self._load_weight * \
+                workloads[i]
             scores.append(score)
         # Optional hard cap: drop servers at/over load_cap; fall back to all if
         # none remain. Disabled by default (load_cap=inf) to match the original

--- a/tests/unittest/disaggregated/test_router.py
+++ b/tests/unittest/disaggregated/test_router.py
@@ -1793,7 +1793,7 @@ def test_tokenize_without_tools_passes_none(router_class):
     assert kwargs["tools"] is None
     assert "thinking" not in kwargs
     # messages and add_generation_prompt must still flow through unchanged.
-    assert kwargs["tokenize"] is True
+    assert kwargs["tokenize"] is False
 
 
 def test_tokenize_preserves_empty_tools_list():
@@ -1855,3 +1855,140 @@ def test_tokenize_skipped_when_prompt_token_ids_already_set():
     assert out == [[10, 20, 30]]
     get_tok.assert_not_called()
     tok.apply_chat_template.assert_not_called()
+
+
+class _PrefixCacheFakeTokenizer:
+
+    _SPECIAL = {"<bos>": 1, "<sys>": 2, "<user>": 3, "<asst>": 4, "<eot>": 5}
+
+    def apply_chat_template(self,
+                            messages,
+                            add_generation_prompt=False,
+                            tokenize=False,
+                            return_dict=False,
+                            tools=None,
+                            **kwargs):
+        tag = {"system": "<sys>", "user": "<user>", "assistant": "<asst>"}
+        parts = ["<bos>"]
+        for m in messages:
+            role = m["role"] if isinstance(m, dict) else m.role
+            content = m["content"] if isinstance(m, dict) else m.content
+            parts.append(tag.get(role, "<user>") + str(content) + "<eot>")
+        if add_generation_prompt:
+            parts.append("<asst>")
+        return "".join(parts)
+
+    def encode(self, text, add_special_tokens=False):
+        ids = []
+        i = 0
+        n = len(text)
+        while i < n:
+            special = None
+            for token, tid in self._SPECIAL.items():
+                if text.startswith(token, i):
+                    special = (token, tid)
+                    break
+            if special is not None:
+                ids.append(special[1])
+                i += len(special[0])
+                continue
+            j = i
+            while j < n and not any(
+                    text.startswith(token, j) for token in self._SPECIAL):
+                j += 1
+            run = text[i:j]
+            ids.append(9000 + len(run))
+            ids.extend(ord(c) for c in run)
+            i = j
+        return ids
+
+
+def _grow_conversation():
+    convo = [{
+        "role": "system",
+        "content": "SYS " * 40
+    }, {
+        "role": "user",
+        "content": "hello " * 20
+    }]
+    yield [dict(m) for m in convo]
+    for turn in range(4):
+        convo.append({"role": "assistant", "content": f"resp{turn} " * 30})
+        convo.append({"role": "user", "content": f"q{turn} " * 12})
+        yield [dict(m) for m in convo]
+
+
+def test_prefix_cache_tokenize_matches_full_encode(servers):
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=servers,
+                                tokens_per_block=4)
+    tok = _PrefixCacheFakeTokenizer()
+    with mock.patch.object(router, "_get_tokenizer", return_value=tok):
+        for convo in _grow_conversation():
+            req = ChatCompletionRequest(model="mock", messages=convo)
+            rendered = tok.apply_chat_template(
+                convo,
+                add_generation_prompt=req.add_generation_prompt,
+                tokenize=False)
+            reference = tok.encode(rendered, add_special_tokens=False)
+            result = router._tokenize(req)[0]
+            assert result == reference
+            assert req.prompt_token_ids == reference
+
+
+def test_prefix_cache_tokenize_encodes_only_delta(servers):
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=servers,
+                                tokens_per_block=4)
+    tok = _PrefixCacheFakeTokenizer()
+    encoded_lengths = []
+    real_encode = tok.encode
+
+    def _recording_encode(text, add_special_tokens=False):
+        encoded_lengths.append(len(text))
+        return real_encode(text, add_special_tokens=add_special_tokens)
+
+    tok.encode = _recording_encode
+    with mock.patch.object(router, "_get_tokenizer", return_value=tok):
+        for index, convo in enumerate(_grow_conversation()):
+            encoded_lengths.clear()
+            req = ChatCompletionRequest(model="mock", messages=convo)
+            rendered = tok.apply_chat_template(
+                convo,
+                add_generation_prompt=req.add_generation_prompt,
+                tokenize=False)
+            router._tokenize(req)
+            assert encoded_lengths
+            if index >= 1:
+                assert min(encoded_lengths) < len(rendered)
+
+
+def test_prefix_cache_tokenize_falls_back_on_divergent_prefix(servers):
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=servers,
+                                tokens_per_block=4)
+    tok = _PrefixCacheFakeTokenizer()
+    convo_a = [{
+        "role": "system",
+        "content": "A " * 30
+    }, {
+        "role": "user",
+        "content": "alpha"
+    }]
+    convo_b = [{
+        "role": "system",
+        "content": "B " * 30
+    }, {
+        "role": "user",
+        "content": "beta"
+    }]
+    with mock.patch.object(router, "_get_tokenizer", return_value=tok):
+        for convo in (convo_a, convo_b, convo_a):
+            req = ChatCompletionRequest(model="mock",
+                                        messages=[dict(m) for m in convo])
+            rendered = tok.apply_chat_template(
+                [dict(m) for m in convo],
+                add_generation_prompt=req.add_generation_prompt,
+                tokenize=False)
+            reference = tok.encode(rendered, add_special_tokens=False)
+            assert router._tokenize(req)[0] == reference


### PR DESCRIPTION
This pull request introduces significant optimizations and improvements to the chat prompt tokenization logic in the router, focusing on efficiency and correctness. The main changes are the addition of a prefix-based tokenizer cache to avoid redundant work, adjustment of load balancing parameters, and updated tests to verify the new caching behavior.

**Tokenization and Caching Improvements:**

* Added a prefix-based tokenizer cache in `KvCacheAwareRouter` to efficiently encode chat prompts by reusing tokenized prefixes, reducing redundant computation for conversations that grow incrementally. (`tensorrt_llm/serve/router.py`, [tensorrt_llm/serve/router.pyR830-R880](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89R830-R880))
* Changed chat prompt rendering to always use `tokenize=False` in `apply_chat_template`, followed by explicit encoding, ensuring consistent handling of custom tokenizers and enabling prefix cache usage. (`tensorrt_llm/serve/router.py`, [tensorrt_llm/serve/router.pyR830-R880](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89R830-R880))
* Updated related tests and introduced new tests to verify prefix cache correctness, efficiency (encoding only the delta), and fallback behavior when conversation prefixes diverge. (`tests/unittest/disaggregated/test_router.py`, [tests/unittest/disaggregated/test_router.pyR1858-R1994](diffhunk://#diff-541e70439bf7d7b6a9f23cabd51cccf8475b27e05dc1f1669b5909acb5fae3c2R1858-R1994))

**Load Balancing and Routing Adjustments:**

* Lowered the default `load_weight` parameter from 1.0 to 0.25, adjusting server selection sensitivity to load in routing decisions. (`tensorrt_llm/serve/router.py`, [tensorrt_llm/serve/router.pyL984-R1001](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89L984-R1001))
* Simplified and corrected the server scoring formula for routing: removed unnecessary token padding logic and now use the number of matched tokens per block and actual workload directly. (`tensorrt_llm/serve/router.py`, [[1]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89L1108-L1114) [[2]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89L1129-R1143)

**Test Updates:**

* Updated existing tests to expect `tokenize=False` in chat template calls, reflecting the new tokenization workflow. (`tests/unittest/disaggregated/test_router.py`, [tests/unittest/disaggregated/test_router.pyL1796-R1796](diffhunk://#diff-541e70439bf7d7b6a9f23cabd51cccf8475b27e05dc1f1669b5909acb5fae3c2L1796-R1796))

These changes collectively improve the router's performance for long or growing conversations, ensure correctness with custom tokenizers, and refine load balancing behavior.

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
