### PR TITLE
[None][perf] disagg: single-pass request serialization on orchestrator forward path

### DIFF
--- a/tensorrt_llm/serve/openai_client.py
+++ b/tensorrt_llm/serve/openai_client.py
@@ -181,11 +181,19 @@ class OpenAIHttpClient(OpenAIClient):
                 dp = getattr(request, "disaggregated_params", None)
                 if dp is not None and getattr(dp, "disagg_request_id", None) is not None:
                     dp.disagg_request_id = self._disagg_id_generator()
-            json_data = request.model_dump(exclude_unset=True, mode="json")
+            # Serialize once on the orchestrator's single event-loop thread:
+            # model_dump_json (pydantic-core) is ~2.3x faster than
+            # model_dump(mode="json") + aiohttp json= (json.dumps). Decodes to
+            # identical JSON (pydantic just emits compact UTF-8 vs spaced ASCII).
+            body = request.model_dump_json(exclude_unset=True)
             try:
                 lines_yielded = 0
                 start_time = get_steady_clock_now_in_seconds()
-                async with self._session.post(url, json=json_data) as http_response:
+                async with self._session.post(
+                    url,
+                    data=body,
+                    headers={"Content-Type": "application/json"},
+                ) as http_response:
                     content_type = http_response.headers.get("Content-Type", "")
                     if not is_stream and "text/event-stream" in content_type:
                         raise ValueError(


### PR DESCRIPTION
@coderabbitai summary

## Description

The disaggregated serving orchestrator (`trtllm-serve disaggregated`) runs on a
**single asyncio event loop**, so CPU-bound work in the per-request forward path
serializes all concurrent requests — i.e. it causes head-of-line blocking, which
is the dominant contributor to the **TTFT tail (p95)** under high concurrency.

`OpenAIHttpClient._post_with_retry` serialized the forward body in **two passes**:

```python
json_data = request.model_dump(exclude_unset=True, mode="json")  # pydantic -> dict
... self._session.post(url, json=json_data)                       # aiohttp json.dumps(dict) -> str
```

For agentic / multi-turn traffic the body is large (full chat history, plus the
~40k-token `prompt_token_ids` array on the generation leg), so this double
serialization is a meaningful chunk of per-request event-loop time. This PR does
it in **one pass** with `model_dump_json(...)` (pydantic-core / Rust), posted as a
pre-encoded body with an explicit `Content-Type`. This is what aiohttp's `json=`
does internally, minus the intermediate `dict` and the second `json.dumps`. The
output **decodes to identical JSON** — pydantic emits compact UTF-8 instead of
`json.dumps`'s spaced, `ensure_ascii` output, which any JSON parser decodes to the
same object (and is a slightly smaller body).

```python
body = request.model_dump_json(exclude_unset=True)
... self._session.post(url, data=body, headers={"Content-Type": "application/json"})
```
