### PR TITLE
[None][perf] disagg: skip per-chunk JSON parse on streaming usage rewrite

### DIFF
--- a/tensorrt_llm/serve/openai_disagg_service.py
+++ b/tensorrt_llm/serve/openai_disagg_service.py
@@ -233,6 +233,11 @@ class OpenAIDisaggregatedService(OpenAIService):
         event: bytes,
         ctx_response: Optional[UCompletionResponse],
     ) -> bytes:
+        # Only the final chunk has a top-level `usage` to rewrite, but this ran
+        # json.loads on every relayed chunk. A usage field can't exist unless the
+        # bytes contain `"usage"`, so skip the parse when they don't.
+        if b'"usage"' not in event:
+            return event
         separator_match = self._sse_separator_index(event)
         separator = separator_match[1] if separator_match else b""
         event_body = event[: -len(separator)] if separator else event


### PR DESCRIPTION
@coderabbitai summary

## Description

In disaggregated serving the orchestrator relays the generation server's streaming
SSE response back to the client, and rewrites the `usage` object so the reported
`prompt_tokens` / `cached_tokens` reflect the **context** server (where prefill
actually happened) rather than the generation server.

`_rewrite_usage_sse_event_from_ctx` was invoked for **every** relayed SSE chunk and
ran `splitlines()` + `json.loads()` on each one — but a top-level `usage` object
only appears on the **final** chunk (and only when the client requested usage).
So for essentially every streamed output token the orchestrator did a full JSON
parse just to discover "no usage here, nothing to rewrite". On the orchestrator's
**single asyncio event loop** this is pure per-token overhead that serializes all
concurrent streams: ~5% of one core at high concurrency (~15k relayed tok/s).

This PR adds a cheap byte pre-filter before the parse:

```python
if b'"usage"' not in event:
    return event
```

A top-level `usage` field cannot exist unless the chunk bytes contain `"usage"`,
so chunks without it skip the `splitlines()` + `json.loads()` entirely and are
returned **verbatim** — byte-for-byte identical to the previous no-usage behavior.
The rewrite is never dropped (when a `usage` field exists, `"usage"` is present in
the bytes, so the chunk still takes the full path); a rare token whose content is
literally `"usage"` simply falls through and re-parses harmlessly (the nested
match is not a top-level key, so it returns unchanged).

**Measured** (`json.dumps`-shaped chat.completion.chunk, in-container aarch64):
`_rewrite_usage_sse_event_from_ctx` drops from **3.46 µs → 0.25 µs per chunk**
(~5% → ~0.4% of one core at 15.4k tok/s). Behavior is unchanged; this only avoids
work on chunks that have nothing to rewrite.
