### PR TITLE
[TRTLLM-13264][feat] Add native bias epilogue to NVFP4 GEMM

### DIFF
--- a/cpp/tensorrt_llm/common/cublasMMWrapper.cpp
+++ b/cpp/tensorrt_llm/common/cublasMMWrapper.cpp
@@ -570,16 +570,16 @@ float const* getBetaDevicePointer()
 // BlockScaleGemm Version 1: Default algorithm (uses first valid heuristic)
 void CublasMMWrapper::BlockScaleGemm(cublasOperation_t transa, cublasOperation_t transb, int const m, int const n,
     int const k, void const* A, int const lda, void const* B, int const ldb, void* C, int const ldc, void const* a_sf,
-    void const* b_sf, float const* alpha)
+    void const* b_sf, float const* alpha, void const* bias)
 {
     // Forward to the overloaded version with nullptr (use default algorithm)
-    BlockScaleGemm(transa, transb, m, n, k, A, lda, B, ldb, C, ldc, a_sf, b_sf, alpha, nullptr);
+    BlockScaleGemm(transa, transb, m, n, k, A, lda, B, ldb, C, ldc, a_sf, b_sf, alpha, nullptr, bias);
 }
 
 // BlockScaleGemm Version 2: Specified algorithm (unified implementation)
 void CublasMMWrapper::BlockScaleGemm(cublasOperation_t transa, cublasOperation_t transb, int const m, int const n,
     int const k, void const* A, int const lda, void const* B, int const ldb, void* C, int const ldc, void const* a_sf,
-    void const* b_sf, float const* alpha, cublasLtMatmulAlgo_t const* algo)
+    void const* b_sf, float const* alpha, cublasLtMatmulAlgo_t const* algo, void const* bias)
 {
     // Verify input data types (currently supports FP4, can be extended to more formats in the future)
     TLLM_CHECK_WITH_INFO(mAType == CUDA_R_4F_E2M1 && mBType == CUDA_R_4F_E2M1,
@@ -606,6 +606,11 @@ void CublasMMWrapper::BlockScaleGemm(cublasOperation_t transa, cublasOperation_t
 
     // Set block-wise scaling descriptors
     setScaleDescriptors(const_cast<void*>(a_sf), const_cast<void*>(b_sf));
+
+    if (bias != nullptr)
+    {
+        setBiasDescriptor(const_cast<void*>(bias));
+    }
 
     // Validate cuBLASLt handle
     TLLM_CHECK_WITH_INFO(mCublasLtHandle != nullptr, "cuBLASLt handle is null");

--- a/cpp/tensorrt_llm/common/cublasMMWrapper.h
+++ b/cpp/tensorrt_llm/common/cublasMMWrapper.h
@@ -92,12 +92,12 @@ public:
     // Uses default/heuristic algorithm
     void BlockScaleGemm(cublasOperation_t transa, cublasOperation_t transb, int const m, int const n, int const k,
         void const* A, int const lda, void const* B, int const ldb, void* C, int const ldc, void const* a_sf,
-        void const* b_sf, float const* alpha);
+        void const* b_sf, float const* alpha, void const* bias = nullptr);
 
-    // Uses specified algorithm (for autotuning)
+    // Uses specified algorithm (for autotuning). Optional `bias` fused via CUBLASLT_EPILOGUE_BIAS.
     void BlockScaleGemm(cublasOperation_t transa, cublasOperation_t transb, int const m, int const n, int const k,
         void const* A, int const lda, void const* B, int const ldb, void* C, int const ldc, void const* a_sf,
-        void const* b_sf, float const* alpha, cublasLtMatmulAlgo_t const* algo);
+        void const* b_sf, float const* alpha, cublasLtMatmulAlgo_t const* algo, void const* bias = nullptr);
 #endif
 
     void stridedBatchedGemm(cublasOperation_t transa, cublasOperation_t transb, int const m, int const n, int const k,

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp4_gemm/fp4_gemm_template.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp4_gemm/fp4_gemm_template.h
@@ -59,7 +59,7 @@ template <typename Arch, typename T, typename CTA_M_, typename CTA_N_, typename 
 size_t dispatchNVFP4xNVFP4GemmClusterShapeSm10x(T* D, void const* A, void const* B, void const* input_sf,
     void const* weight_sf, float const* global_sf, int m, int n, int k, int batch_count,
     tkc::CutlassGemmConfig gemmConfig, char* workspace, const size_t workspaceBytes, cudaStream_t stream,
-    int* occupancy = nullptr)
+    int* occupancy = nullptr, void const* bias = nullptr)
 {
 
     TLLM_LOG_DEBUG(__PRETTY_FUNCTION__);
@@ -69,42 +69,42 @@ size_t dispatchNVFP4xNVFP4GemmClusterShapeSm10x(T* D, void const* A, void const*
     case tkc::ClusterShape::ClusterShape_1x1x1:
         return genericFp4GemmKernelLauncher<Arch, T, CTA_M_, CTA_N_, CTA_K_, cute::Int<1>, cute::Int<1>, cute::Int<1>,
             _1SM>(D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes,
-            stream, occupancy);
+            stream, occupancy, bias);
         break;
     case tkc::ClusterShape::ClusterShape_2x1x1:
         return genericFp4GemmKernelLauncher<Arch, T, CTA_M_, CTA_N_, CTA_K_, cute::Int<2>, cute::Int<1>, cute::Int<1>,
             _2SM>(D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes,
-            stream, occupancy);
+            stream, occupancy, bias);
         break;
     case tkc::ClusterShape::ClusterShape_1x2x1:
         return genericFp4GemmKernelLauncher<Arch, T, CTA_M_, CTA_N_, CTA_K_, cute::Int<1>, cute::Int<2>, cute::Int<1>,
             _1SM>(D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes,
-            stream, occupancy);
+            stream, occupancy, bias);
         break;
     case tkc::ClusterShape::ClusterShape_2x2x1:
         return genericFp4GemmKernelLauncher<Arch, T, CTA_M_, CTA_N_, CTA_K_, cute::Int<2>, cute::Int<2>, cute::Int<1>,
             _2SM>(D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes,
-            stream, occupancy);
+            stream, occupancy, bias);
         break;
     case tkc::ClusterShape::ClusterShape_1x4x1:
         return genericFp4GemmKernelLauncher<Arch, T, CTA_M_, CTA_N_, CTA_K_, cute::Int<1>, cute::Int<4>, cute::Int<1>,
             _1SM>(D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes,
-            stream, occupancy);
+            stream, occupancy, bias);
         break;
     case tkc::ClusterShape::ClusterShape_4x2x1:
         return genericFp4GemmKernelLauncher<Arch, T, CTA_M_, CTA_N_, CTA_K_, cute::Int<4>, cute::Int<2>, cute::Int<1>,
             _2SM>(D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes,
-            stream, occupancy);
+            stream, occupancy, bias);
         break;
     case tkc::ClusterShape::ClusterShape_2x4x1:
         return genericFp4GemmKernelLauncher<Arch, T, CTA_M_, CTA_N_, CTA_K_, cute::Int<2>, cute::Int<4>, cute::Int<1>,
             _2SM>(D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes,
-            stream, occupancy);
+            stream, occupancy, bias);
         break;
     case tkc::ClusterShape::ClusterShape_4x4x1:
         return genericFp4GemmKernelLauncher<Arch, T, CTA_M_, CTA_N_, CTA_K_, cute::Int<4>, cute::Int<4>, cute::Int<1>,
             _2SM>(D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes,
-            stream, occupancy);
+            stream, occupancy, bias);
         break;
     default:
         throw std::runtime_error(
@@ -117,7 +117,7 @@ template <typename Arch, typename T>
 size_t dispatchNVFP4xNVFP4GemmCTAShapeSm10x(T* D, void const* A, void const* B, void const* input_sf,
     void const* weight_sf, float const* global_sf, int m, int n, int k, int batch_count,
     tkc::CutlassGemmConfig gemmConfig, char* workspace, const size_t workspaceBytes, cudaStream_t stream,
-    int* occupancy = nullptr)
+    int* occupancy = nullptr, void const* bias = nullptr)
 {
 
     TLLM_LOG_DEBUG(__PRETTY_FUNCTION__);
@@ -130,7 +130,7 @@ size_t dispatchNVFP4xNVFP4GemmCTAShapeSm10x(T* D, void const* A, void const* B, 
     case tkc::CutlassTileConfigSM100::CtaShape##M##x##N##x##K##B:                                                      \
         return dispatchNVFP4xNVFP4GemmClusterShapeSm10x<Arch, T, cute::Int<M>, cute::Int<N>, cute::Int<K>>(D, A, B,    \
             input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes, stream,       \
-            occupancy);
+            occupancy, bias);
 #define CTA_CASE_DEFAULT                                                                                               \
     case tkc::CutlassTileConfigSM100::Undefined:                                                                       \
         throw std::runtime_error("[TensorRT-LLM Error][FP4][dispatch_gemm_cta_shape] Gemm config undefined.");         \
@@ -175,7 +175,7 @@ template <typename T, typename CTA_M_, typename CTA_N_, typename CTA_K_>
 size_t dispatchNVFP4xNVFP4GemmClusterShapeSm120(T* D, void const* A, void const* B, void const* input_sf,
     void const* weight_sf, float const* global_sf, int m, int n, int k, int batch_count,
     tkc::CutlassGemmConfig gemmConfig, char* workspace, const size_t workspaceBytes, cudaStream_t stream,
-    int* occupancy = nullptr)
+    int* occupancy = nullptr, void const* bias = nullptr)
 {
 
     TLLM_LOG_DEBUG(__PRETTY_FUNCTION__);
@@ -185,7 +185,7 @@ size_t dispatchNVFP4xNVFP4GemmClusterShapeSm120(T* D, void const* A, void const*
     case tkc::ClusterShape::ClusterShape_1x1x1:
         return genericFp4GemmKernelLauncherSm120<T, CTA_M_, CTA_N_, CTA_K_, cute::Int<1>, cute::Int<1>, cute::Int<1>>(D,
             A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes, stream,
-            occupancy);
+            occupancy, bias);
         break;
     default:
         throw std::runtime_error(
@@ -198,7 +198,7 @@ template <typename T>
 size_t dispatchNVFP4xNVFP4GemmCTAShapeSm120(T* D, void const* A, void const* B, void const* input_sf,
     void const* weight_sf, float const* global_sf, int m, int n, int k, int batch_count,
     tkc::CutlassGemmConfig gemmConfig, char* workspace, const size_t workspaceBytes, cudaStream_t stream,
-    int* occupancy = nullptr)
+    int* occupancy = nullptr, void const* bias = nullptr)
 {
 
     TLLM_LOG_DEBUG(__PRETTY_FUNCTION__);
@@ -209,17 +209,17 @@ size_t dispatchNVFP4xNVFP4GemmCTAShapeSm120(T* D, void const* A, void const* B, 
     case tkc::CutlassTileConfigSM120::CtaShape128x128x128B:
         return dispatchNVFP4xNVFP4GemmClusterShapeSm120<T, cute::Int<128>, cute::Int<128>, cute::Int<128>>(D, A, B,
             input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes, stream,
-            occupancy);
+            occupancy, bias);
         break;
     case tkc::CutlassTileConfigSM120::CtaShape128x128x256B:
         return dispatchNVFP4xNVFP4GemmClusterShapeSm120<T, cute::Int<128>, cute::Int<128>, cute::Int<256>>(D, A, B,
             input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes, stream,
-            occupancy);
+            occupancy, bias);
         break;
     case tkc::CutlassTileConfigSM120::CtaShape256x128x128B:
         return dispatchNVFP4xNVFP4GemmClusterShapeSm120<T, cute::Int<256>, cute::Int<128>, cute::Int<128>>(D, A, B,
             input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes, stream,
-            occupancy);
+            occupancy, bias);
         break;
     case tkc::CutlassTileConfigSM120::Undefined:
         throw std::runtime_error("[TensorRT LLM Error][FP4][sm120][dispatch_gemm_cta_shape] Gemm config undefined.");
@@ -240,7 +240,7 @@ template <typename T, typename CTA_M_, typename CTA_N_, typename CTA_K_>
 size_t dispatchMXFP8xMXFP4GemmClusterShapeSm100(T* D, void const* A, void const* B, void const* input_sf,
     void const* weight_sf, float const* global_sf, int m, int n, int k, int batch_count,
     tkc::CutlassGemmConfig gemmConfig, char* workspace, const size_t workspaceBytes, cudaStream_t stream,
-    int* occupancy = nullptr)
+    int* occupancy = nullptr, void const* bias = nullptr)
 {
 
     TLLM_LOG_DEBUG(__PRETTY_FUNCTION__);
@@ -250,27 +250,27 @@ size_t dispatchMXFP8xMXFP4GemmClusterShapeSm100(T* D, void const* A, void const*
     case tkc::ClusterShape::ClusterShape_2x1x1:
         return genericMXFP8xMXFP4GemmKernelLauncher<T, CTA_M_, CTA_N_, CTA_K_, cute::Int<2>, cute::Int<1>, cute::Int<1>,
             __2SM>(D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes,
-            stream, occupancy);
+            stream, occupancy, bias);
         break;
     case tkc::ClusterShape::ClusterShape_2x2x1:
         return genericMXFP8xMXFP4GemmKernelLauncher<T, CTA_M_, CTA_N_, CTA_K_, cute::Int<2>, cute::Int<2>, cute::Int<1>,
             __2SM>(D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes,
-            stream, occupancy);
+            stream, occupancy, bias);
         break;
     case tkc::ClusterShape::ClusterShape_4x2x1:
         return genericMXFP8xMXFP4GemmKernelLauncher<T, CTA_M_, CTA_N_, CTA_K_, cute::Int<4>, cute::Int<2>, cute::Int<1>,
             __2SM>(D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes,
-            stream, occupancy);
+            stream, occupancy, bias);
         break;
     case tkc::ClusterShape::ClusterShape_2x4x1:
         return genericMXFP8xMXFP4GemmKernelLauncher<T, CTA_M_, CTA_N_, CTA_K_, cute::Int<2>, cute::Int<4>, cute::Int<1>,
             __2SM>(D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes,
-            stream, occupancy);
+            stream, occupancy, bias);
         break;
     case tkc::ClusterShape::ClusterShape_4x4x1:
         return genericMXFP8xMXFP4GemmKernelLauncher<T, CTA_M_, CTA_N_, CTA_K_, cute::Int<4>, cute::Int<4>, cute::Int<1>,
             __2SM>(D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes,
-            stream, occupancy);
+            stream, occupancy, bias);
         break;
     default:
         throw std::runtime_error(
@@ -283,7 +283,7 @@ template <typename T>
 size_t dispatchMXFP8xMXFP4GemmCTAShapeSm100(T* D, void const* A, void const* B, void const* input_sf,
     void const* weight_sf, float const* global_sf, int m, int n, int k, int batch_count,
     tkc::CutlassGemmConfig gemmConfig, char* workspace, const size_t workspaceBytes, cudaStream_t stream,
-    int* occupancy = nullptr)
+    int* occupancy = nullptr, void const* bias = nullptr)
 {
 
     TLLM_LOG_DEBUG(__PRETTY_FUNCTION__);
@@ -292,22 +292,22 @@ size_t dispatchMXFP8xMXFP4GemmCTAShapeSm100(T* D, void const* A, void const* B, 
     case tkc::CutlassTileConfigSM100::CtaShape128x64x128B:
         return dispatchMXFP8xMXFP4GemmClusterShapeSm100<T, cute::Int<128>, cute::Int<64>, cute::Int<128>>(D, A, B,
             input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes, stream,
-            occupancy);
+            occupancy, bias);
         break;
     case tkc::CutlassTileConfigSM100::CtaShape128x256x128B:
         return dispatchMXFP8xMXFP4GemmClusterShapeSm100<T, cute::Int<128>, cute::Int<256>, cute::Int<128>>(D, A, B,
             input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes, stream,
-            occupancy);
+            occupancy, bias);
         break;
     case tkc::CutlassTileConfigSM100::CtaShape128x128x256B:
         return dispatchMXFP8xMXFP4GemmClusterShapeSm100<T, cute::Int<128>, cute::Int<128>, cute::Int<256>>(D, A, B,
             input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes, stream,
-            occupancy);
+            occupancy, bias);
         break;
     case tkc::CutlassTileConfigSM100::CtaShape128x256x256B:
         return dispatchMXFP8xMXFP4GemmClusterShapeSm100<T, cute::Int<128>, cute::Int<256>, cute::Int<256>>(D, A, B,
             input_sf, weight_sf, global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes, stream,
-            occupancy);
+            occupancy, bias);
         break;
     case tkc::CutlassTileConfigSM100::Undefined:
         throw std::runtime_error("[TensorRT LLM Error][FP4][dispatch_gemm_cta_shape] Gemm config undefined.");
@@ -343,14 +343,14 @@ template <typename T, FP4GemmType fp4GemmType>
 size_t CutlassFp4GemmRunner<T, fp4GemmType>::dispatchToArch(T* D, void const* A, void const* B, void const* input_sf,
     void const* weight_sf, float const* global_sf, int m, int n, int k, int batch_count,
     tkc::CutlassGemmConfig gemmConfig, char* workspace, const size_t workspaceBytes, cudaStream_t stream,
-    int* occupancy)
+    int* occupancy, void const* bias)
 {
     if constexpr (fp4GemmType == FP4GemmType::W4A8_MXFP4_MXFP8)
     {
         if (mSm == 100 || mSm == 103)
         {
             return dispatchMXFP8xMXFP4GemmCTAShapeSm100<T>(D, A, B, input_sf, weight_sf, global_sf, m, n, k,
-                batch_count, gemmConfig, workspace, workspaceBytes, stream, occupancy);
+                batch_count, gemmConfig, workspace, workspaceBytes, stream, occupancy, bias);
         }
         else
         {
@@ -364,21 +364,21 @@ size_t CutlassFp4GemmRunner<T, fp4GemmType>::dispatchToArch(T* D, void const* A,
         {
 #ifdef COMPILE_BLACKWELL_SM103_TMA_GEMMS
             return dispatchNVFP4xNVFP4GemmCTAShapeSm10x<cutlass::arch::Sm103, T>(D, A, B, input_sf, weight_sf,
-                global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes, stream, occupancy);
+                global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes, stream, occupancy, bias);
 #else
             return dispatchNVFP4xNVFP4GemmCTAShapeSm10x<cutlass::arch::Sm100, T>(D, A, B, input_sf, weight_sf,
-                global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes, stream, occupancy);
+                global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes, stream, occupancy, bias);
 #endif
         }
         else if (mSm == 100)
         {
             return dispatchNVFP4xNVFP4GemmCTAShapeSm10x<cutlass::arch::Sm100, T>(D, A, B, input_sf, weight_sf,
-                global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes, stream, occupancy);
+                global_sf, m, n, k, batch_count, gemmConfig, workspace, workspaceBytes, stream, occupancy, bias);
         }
         else if (mSm == 120 || mSm == 121)
         {
             return dispatchNVFP4xNVFP4GemmCTAShapeSm120<T>(D, A, B, input_sf, weight_sf, global_sf, m, n, k,
-                batch_count, gemmConfig, workspace, workspaceBytes, stream, occupancy);
+                batch_count, gemmConfig, workspace, workspaceBytes, stream, occupancy, bias);
         }
         else
         {
@@ -396,11 +396,12 @@ size_t CutlassFp4GemmRunner<T, fp4GemmType>::dispatchToArch(T* D, void const* A,
 template <typename T, FP4GemmType fp4GemmType>
 void CutlassFp4GemmRunner<T, fp4GemmType>::gemm(void* D, void const* A, void const* B, void const* input_sf,
     void const* weight_sf, float const* global_sf, int m, int n, int k, int batch_count,
-    tkc::CutlassGemmConfig gemmConfig, char* workspace, const size_t workspaceBytes, cudaStream_t stream)
+    tkc::CutlassGemmConfig gemmConfig, char* workspace, const size_t workspaceBytes, cudaStream_t stream,
+    void const* bias)
 {
     TLLM_LOG_DEBUG(__PRETTY_FUNCTION__);
     CutlassFp4GemmRunner<T, fp4GemmType>::dispatchToArch(reinterpret_cast<T*>(D), A, B, input_sf, weight_sf, global_sf,
-        m, n, k, batch_count, gemmConfig, workspace, workspaceBytes, stream);
+        m, n, k, batch_count, gemmConfig, workspace, workspaceBytes, stream, /*occupancy=*/nullptr, bias);
 }
 
 template <typename T, FP4GemmType fp4GemmType>

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp4_gemm/mxfp8_mxfp4_gemm_template_sm100.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp4_gemm/mxfp8_mxfp4_gemm_template_sm100.h
@@ -91,7 +91,7 @@ template <typename T, typename CTA_M, typename CTA_N, typename CTA_K, typename C
 size_t genericMXFP8xMXFP4GemmKernelLauncher(void* D, void const* A, void const* B, void const* input_sf,
     void const* weight_sf, float const* global_sf, int m, int n, int k, int batch_count,
     tkc::CutlassGemmConfig gemmConfig, char* workspace, const size_t workspaceBytes, cudaStream_t stream,
-    int* occupancy)
+    int* occupancy, void const* bias = nullptr)
 {
     throw std::runtime_error(
         "[TensorRT LLM Error][FP4 gemm Runner] TensorRT LLM is not compiled with support for this Architecture.");
@@ -114,7 +114,7 @@ struct DeviceGemmMXFP8xMXFP4GemmSm100
     using ElementB = cutlass::mx_float4_t<cutlass::float_e2m1_t>;
     using LayoutB = cutlass::layout::ColumnMajor;
     static constexpr int AlignmentB = 128;
-    /* // Input C */
+    /* // Input C: ElementC=void; per-N bias via LinCombPerColBias EVT. */
     using ElementC = void;
     using LayoutC = cutlass::layout::RowMajor;
     static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<OutElementType>::value;
@@ -131,7 +131,7 @@ struct DeviceGemmMXFP8xMXFP4GemmSm100
     using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<Arch, OperatorClass,
         MmaTileShape, ClusterShape, EpilogueTileType, ElementAccumulator, ElementCompute, ElementC, LayoutC, AlignmentC,
         OutElementType, LayoutC, AlignmentC, EpilogueSchedule,
-        cutlass::epilogue::fusion::LinearCombination<OutElementType, float, void, float>>::CollectiveOp;
+        cutlass::epilogue::fusion::LinCombPerColBias<OutElementType, float, OutElementType, void, float>>::CollectiveOp;
 
     using CollectiveMainloop =
         typename cutlass::gemm::collective::CollectiveBuilder<Arch, cutlass::arch::OpClassBlockScaledTensorOp, ElementA,
@@ -171,7 +171,8 @@ struct DeviceGemmMXFP8xMXFP4GemmSm100
 
 template <typename Gemm>
 typename Gemm::Arguments prepareGemmArgsSm100(void* D, void const* A, void const* B, void const* input_sf,
-    void const* weight_sf, float const* global_sf, int m, int n, int k, int batch_count, dim3 prefered_cga, int XSM)
+    void const* weight_sf, float const* global_sf, int m, int n, int k, int batch_count, dim3 prefered_cga, int XSM,
+    void const* bias = nullptr)
 {
     using Sm1xxBlkScaledConfig = typename Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
     using ElementA = typename Gemm::ElementA;
@@ -186,6 +187,7 @@ typename Gemm::Arguments prepareGemmArgsSm100(void* D, void const* A, void const
     operator_args.mode = cutlass::gemm::GemmUniversalMode::kGemm;
     auto& fusion_args = operator_args.epilogue.thread;
     fusion_args.alpha_ptr = static_cast<ElementCompute const*>(global_sf);
+    fusion_args.bias_ptr = static_cast<ElementD const*>(bias);
 
     operator_args.problem_shape = cute::make_shape(m, n, k, batch_count);
 
@@ -228,7 +230,7 @@ template <typename T, typename CTA_M, typename CTA_N, typename CTA_K, typename C
 size_t genericMXFP8xMXFP4GemmKernelLauncher(void* D, void const* A, void const* B, void const* input_sf,
     void const* weight_sf, float const* global_sf, int m, int n, int k, int batch_count,
     tkc::CutlassGemmConfig gemmConfig, char* workspace, const size_t workspaceBytes, cudaStream_t stream,
-    int* occupancy)
+    int* occupancy, void const* bias = nullptr)
 {
     using ElementOutput__ =
         typename cutlass::platform::conditional<cutlass::platform::is_same<T, half>::value, cutlass::half_t, T>::type;
@@ -243,7 +245,7 @@ size_t genericMXFP8xMXFP4GemmKernelLauncher(void* D, void const* A, void const* 
         typename DeviceGemmMXFP8xMXFP4GemmSm100<T, CTA_M, CTA_N, CTA_K, CGA_M, CGA_N, CGA_K, XSM_>::Gemm;
     MXFP8xMXFP4GemmOperator gemm;
     auto args = prepareGemmArgsSm100<MXFP8xMXFP4GemmOperator>(D, A, B, input_sf, weight_sf, global_sf, m, n, k,
-        batch_count, dim3(CGA_M{}, CGA_N{}, CGA_K{}), MXSMTypeAdapter<XSM_>::Scale);
+        batch_count, dim3(CGA_M{}, CGA_N{}, CGA_K{}), MXSMTypeAdapter<XSM_>::Scale, bias);
     /* // Check shared memory size; throw when SMEM exceeds */
     int smem_size = int(sizeof(typename MXFP8xMXFP4GemmOperator::GemmKernel::SharedStorage));
     static int mMaxSmemSize = tk::getMaxSharedMemoryPerBlockOptin();

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp4_gemm/nvfp4_nvfp4_gemm_template_sm100.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp4_gemm/nvfp4_nvfp4_gemm_template_sm100.h
@@ -108,7 +108,7 @@ template <typename Arch, typename T, typename CTA_M_, typename CTA_N_, typename 
     typename CGA_N_, typename CGA_K_, typename XSM_>
 size_t genericFp4GemmKernelLauncher(void* D, void const* A, void const* B, void const* input_sf, void const* weight_sf,
     float const* global_sf, int m, int n, int k, int batch_count, tkc::CutlassGemmConfig gemmConfig, char* workspace,
-    size_t const workspaceBytes, cudaStream_t stream, int* occupancy)
+    size_t const workspaceBytes, cudaStream_t stream, int* occupancy, void const* bias = nullptr)
 {
     static_assert(always_false<T>, "Kernel should be explicitly instantiated.");
     return 0;
@@ -122,7 +122,7 @@ size_t genericFp4GemmKernelLauncher(void* D, void const* A, void const* B, void 
         cute::Int<CTA_K_>, cute::Int<CGA_M_>, cute::Int<CGA_N_>, cute::Int<CGA_K_>, XSM_>(void* D, void const* A,      \
         void const* B, void const* input_sf, void const* weight_sf, float const* global_sf, int m, int n, int k,       \
         int batch_count, tkc::CutlassGemmConfig gemmConfig, char* workspace, const size_t workspaceBytes,              \
-        cudaStream_t stream, int* occupancy)                                                                           \
+        cudaStream_t stream, int* occupancy, void const* bias)                                                         \
     {                                                                                                                  \
         throw std::runtime_error(                                                                                      \
             "[TensorRT LLM Error][FP4 gemm Runner] TensorRT LLM is not compiled with support for this Architecture."); \
@@ -147,7 +147,7 @@ size_t genericFp4GemmKernelLauncher(void* D, void const* A, void const* B, void 
         using ElementB = ElementType;                                                                                  \
         using LayoutB = cutlass::layout::ColumnMajor;                                                                  \
         static constexpr int AlignmentB = 128 / cutlass::sizeof_bits<ElementType>::value;                              \
-        /* // Input C */                                                                                               \
+        /* // Input C: ElementC=void (no C-tile SMEM); per-N bias via LinCombPerColBias EVT below. */                  \
         using ElementC = void;                                                                                         \
         using LayoutC = cutlass::layout::RowMajor;                                                                     \
         static constexpr int AlignmentC = 128 / cutlass::sizeof_bits<OutElementType>::value;                           \
@@ -162,10 +162,12 @@ size_t genericFp4GemmKernelLauncher(void* D, void const* A, void const* B, void 
         using MainloopSchedule = SMTypeAdapter<Arch, XSM_>::MainloopSchedule;                                          \
         using MmaTileShape = cute::Shape<cute::Int<CTA_M_ * SMTypeAdapter<Arch, XSM_>::Scale>, cute::Int<CTA_N_>,      \
             cute::Int<CTA_K_*(std::is_same_v<Arch, cutlass::arch::Sm103> ? 3 : 1)>>;                                   \
+        /* D = alpha * Acc + bias[N]; bias_ptr=null resolves to null_default=0 (no-op). */                             \
         using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<Arch, OperatorClass,      \
             MmaTileShape, ClusterShape, EpilogueTileType, ElementAccumulator, ElementCompute, ElementC, LayoutC,       \
             AlignmentC, OutElementType, LayoutC, AlignmentC, EpilogueSchedule,                                         \
-            cutlass::epilogue::fusion::LinearCombination<OutElementType, float, void, float>>::CollectiveOp;           \
+            cutlass::epilogue::fusion::LinCombPerColBias<OutElementType, float, OutElementType, void,                  \
+                float>>::CollectiveOp;                                                                                 \
                                                                                                                        \
         using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<Arch,                         \
             cutlass::arch::OpClassBlockScaledTensorOp, cute::tuple<ElementA, SFType>, LayoutA, AlignmentA,             \
@@ -205,7 +207,7 @@ size_t genericFp4GemmKernelLauncher(void* D, void const* A, void const* B, void 
     typename Gemm::Arguments                                                                                           \
         prepareGemmArgs_##ARCH_##_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##_##CGA_M_##_##CGA_N_##_##CGA_K_##XSM_(void* D, \
             void const* A, void const* B, void const* input_sf, void const* weight_sf, float const* global_sf, int m,  \
-            int n, int k, int batch_count)                                                                             \
+            int n, int k, int batch_count, void const* bias = nullptr)                                                 \
     {                                                                                                                  \
         using Sm1xxBlkScaledConfig = typename Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;              \
         using ElementA = typename Gemm::ElementA;                                                                      \
@@ -220,6 +222,7 @@ size_t genericFp4GemmKernelLauncher(void* D, void const* A, void const* B, void 
         operator_args.mode = cutlass::gemm::GemmUniversalMode::kGemm;                                                  \
         auto& fusion_args = operator_args.epilogue.thread;                                                             \
         fusion_args.alpha_ptr = static_cast<ElementCompute const*>(global_sf);                                         \
+        fusion_args.bias_ptr = static_cast<ElementD const*>(bias);                                                     \
                                                                                                                        \
         operator_args.problem_shape = cute::make_shape(m, n, k, batch_count);                                          \
                                                                                                                        \
@@ -263,7 +266,7 @@ size_t genericFp4GemmKernelLauncher(void* D, void const* A, void const* B, void 
         cute::Int<CTA_K_>, cute::Int<CGA_M_>, cute::Int<CGA_N_>, cute::Int<CGA_K_>, XSM_>(void* D, void const* A,      \
         void const* B, void const* input_sf, void const* weight_sf, float const* global_sf, int m, int n, int k,       \
         int batch_count, tkc::CutlassGemmConfig gemmConfig, char* workspace, const size_t workspaceBytes,              \
-        cudaStream_t stream, int* occupancy)                                                                           \
+        cudaStream_t stream, int* occupancy, void const* bias)                                                         \
     {                                                                                                                  \
         using ElementOutput__ = typename cutlass::platform::conditional<cutlass::platform::is_same<T, half>::value,    \
             cutlass::half_t, T>::type;                                                                                 \
@@ -280,7 +283,7 @@ size_t genericFp4GemmKernelLauncher(void* D, void const* A, void const* B, void 
         Fp4GemmOperator gemm;                                                                                          \
         auto args                                                                                                      \
             = prepareGemmArgs_##ARCH_##_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##_##CGA_M_##_##CGA_N_##_##CGA_K_##XSM_<   \
-                Fp4GemmOperator>(D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count);                       \
+                Fp4GemmOperator>(D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, bias);                 \
         /* // Check shared memory size; throw when SMEM exceeds */                                                     \
         int smem_size = int(sizeof(typename Fp4GemmOperator::GemmKernel::SharedStorage));                              \
         static int mMaxSmemSize = tk::getMaxSharedMemoryPerBlockOptin();                                               \

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp4_gemm/nvfp4_nvfp4_gemm_template_sm120.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp4_gemm/nvfp4_nvfp4_gemm_template_sm120.h
@@ -52,7 +52,7 @@ template <typename T, typename CTA_M_, typename CTA_N_, typename CTA_K_, typenam
 size_t genericFp4GemmKernelLauncherSm120(void* D, void const* A, void const* B, void const* input_sf,
     void const* weight_sf, float const* global_sf, int m, int n, int k, int batch_count,
     tkc::CutlassGemmConfig gemmConfig, char* workspace, size_t const workspaceBytes, cudaStream_t stream,
-    int* occupancy)
+    int* occupancy, void const* bias = nullptr)
 {
     static_assert(always_false<T>, "Kernel should be explicitly instantiated.");
     return 0;
@@ -66,7 +66,7 @@ size_t genericFp4GemmKernelLauncherSm120(void* D, void const* A, void const* B, 
         cute::Int<CGA_M_>, cute::Int<CGA_N_>, cute::Int<CGA_K_>>(void* D, void const* A, void const* B,                \
         void const* input_sf, void const* weight_sf, float const* global_sf, int m, int n, int k, int batch_count,     \
         tkc::CutlassGemmConfig gemmConfig, char* workspace, const size_t workspaceBytes, cudaStream_t stream,          \
-        int* occupancy)                                                                                                \
+        int* occupancy, void const* bias)                                                                              \
     {                                                                                                                  \
         throw std::runtime_error(                                                                                      \
             "[TensorRT LLM Error][FP4 gemm Runner] TensorRT LLM is not compiled with support for this Architecture."); \
@@ -89,7 +89,7 @@ size_t genericFp4GemmKernelLauncherSm120(void* D, void const* A, void const* B, 
         using ElementB = cutlass::float_e2m1_t;                                                                        \
         using LayoutB = cutlass::layout::ColumnMajor;                                                                  \
         static constexpr int AlignmentB = 16 * 8 / cutlass::sizeof_bits<ElementB>::value;                              \
-        /* // Input C */                                                                                               \
+        /* // Input C: ElementC=void (no C-tile SMEM); per-N bias via LinCombPerColBias EVT. */                        \
         using ElementC = void;                                                                                         \
         using LayoutC = cutlass::layout::ColumnMajor;                                                                  \
         using LayoutD = cutlass::layout::RowMajor;                                                                     \
@@ -98,7 +98,7 @@ size_t genericFp4GemmKernelLauncherSm120(void* D, void const* A, void const* B, 
         using ElementPairA = cutlass::nv_float4_t<cutlass::float_e2m1_t>;                                              \
         using ElementPairB = cutlass::nv_float4_t<cutlass::float_e2m1_t>;                                              \
         using SFType = cutlass::float_ue4m3_t;                                                                         \
-        using FusionOperation = cutlass::epilogue::fusion::LinearCombination<ElementD, float, void, float>;            \
+        using FusionOperation = cutlass::epilogue::fusion::LinCombPerColBias<ElementD, float, ElementD, void, float>;  \
         using ElementCompute = float;                                                                                  \
         using ElementAccumulator = float;                                                                              \
         using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<Arch,                     \
@@ -144,7 +144,7 @@ size_t genericFp4GemmKernelLauncherSm120(void* D, void const* A, void const* B, 
     typename Gemm::Arguments                                                                                           \
         prepareGemmArgs_Sm120_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##_##CGA_M_##_##CGA_N_##_##CGA_K_(void* D,           \
             void const* A, void const* B, void const* input_sf, void const* weight_sf, float const* global_sf, int m,  \
-            int n, int k, int batch_count)                                                                             \
+            int n, int k, int batch_count, void const* bias = nullptr)                                                 \
     {                                                                                                                  \
         using Sm1xxBlkScaledConfig = typename Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;              \
         using ElementA = typename Gemm::ElementA;                                                                      \
@@ -159,6 +159,7 @@ size_t genericFp4GemmKernelLauncherSm120(void* D, void const* A, void const* B, 
         operator_args.mode = cutlass::gemm::GemmUniversalMode::kGemm;                                                  \
         auto& fusion_args = operator_args.epilogue.thread;                                                             \
         fusion_args.alpha_ptr = static_cast<ElementCompute const*>(global_sf);                                         \
+        fusion_args.bias_ptr = static_cast<ElementD const*>(bias);                                                     \
                                                                                                                        \
         operator_args.problem_shape = cute::make_shape(m, n, k, batch_count);                                          \
                                                                                                                        \
@@ -201,7 +202,7 @@ size_t genericFp4GemmKernelLauncherSm120(void* D, void const* A, void const* B, 
         cute::Int<CGA_M_>, cute::Int<CGA_N_>, cute::Int<CGA_K_>>(void* D, void const* A, void const* B,                \
         void const* input_sf, void const* weight_sf, float const* global_sf, int m, int n, int k, int batch_count,     \
         tkc::CutlassGemmConfig gemmConfig, char* workspace, const size_t workspaceBytes, cudaStream_t stream,          \
-        int* occupancy)                                                                                                \
+        int* occupancy, void const* bias)                                                                              \
     {                                                                                                                  \
         using ElementOutput__ = typename cutlass::platform::conditional<cutlass::platform::is_same<T, half>::value,    \
             cutlass::half_t, T>::type;                                                                                 \
@@ -216,7 +217,7 @@ size_t genericFp4GemmKernelLauncherSm120(void* D, void const* A, void const* B, 
             = DeviceGemmFp4GemmSm120_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##_##CGA_M_##_##CGA_N_##_##CGA_K_::Gemm;      \
         Fp4GemmOperator gemm;                                                                                          \
         auto args = prepareGemmArgs_Sm120_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##_##CGA_M_##_##CGA_N_##_##CGA_K_<       \
-            Fp4GemmOperator>(D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count);                           \
+            Fp4GemmOperator>(D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count, bias);                     \
         /* // Check shared memory size; throw when SMEM exceeds */                                                     \
         int smem_size = int(sizeof(typename Fp4GemmOperator::GemmKernel::SharedStorage));                              \
         static int mMaxSmemSize = tk::getMaxSharedMemoryPerBlockOptin();                                               \

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/include/fp4_gemm.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/include/fp4_gemm.h
@@ -54,7 +54,7 @@ public:
 
     virtual void gemm(void* D, void const* A, void const* B, void const* input_sf, void const* weight_sf,
         float const* global_sf, int m, int n, int k, int batch_count, tkc::CutlassGemmConfig gemmConfig,
-        char* workspace, const size_t workspaceBytes, cudaStream_t stream)
+        char* workspace, const size_t workspaceBytes, cudaStream_t stream, void const* bias = nullptr)
         = 0;
 
     // Returns desired workspace size in bytes.
@@ -78,7 +78,7 @@ public:
 
     void gemm(void* D, void const* A, void const* B, void const* input_sf, void const* weight_sf,
         float const* global_sf, int m, int n, int k, int batch_count, tkc::CutlassGemmConfig gemmConfig,
-        char* workspace, const size_t workspaceBytes, cudaStream_t stream) override;
+        char* workspace, const size_t workspaceBytes, cudaStream_t stream, void const* bias = nullptr) override;
 
     // Returns desired workspace size in bytes.
     size_t getWorkspaceSize(int const m, int const n, int const k, int const batch_count) override;
@@ -88,7 +88,8 @@ public:
 private:
     size_t dispatchToArch(T* D, void const* A, void const* B, void const* input_sf, void const* weight_sf,
         float const* global_sf, int m, int n, int k, int batch_count, tkc::CutlassGemmConfig gemmConfig,
-        char* workspace, const size_t workspaceBytes, cudaStream_t stream, int* occupancy = nullptr);
+        char* workspace, const size_t workspaceBytes, cudaStream_t stream, int* occupancy = nullptr,
+        void const* bias = nullptr);
 
     size_t getWorkspaceSizeImpl(int const m, int const n, int const k, int const batch_count);
 

--- a/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmNVFP4.cu
+++ b/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmNVFP4.cu
@@ -30,7 +30,7 @@ template <typename InputType, typename OutputType, typename ScaleType, SizeType3
     SizeType32 BLOCK_SIZE>
 __device__ void cudaCoreGemmImpl(InputType const* __restrict__ act, InputType const* __restrict__ weight,
     ScaleType const* __restrict__ scale_a, ScaleType const* __restrict__ scale_w, float const alpha,
-    OutputType* __restrict__ output, SizeType32 m, SizeType32 n, SizeType32 k)
+    OutputType* __restrict__ output, OutputType const* __restrict__ bias, SizeType32 m, SizeType32 n, SizeType32 k)
 {
     using VecType = int4;
 
@@ -63,6 +63,7 @@ __device__ void cudaCoreGemmImpl(InputType const* __restrict__ act, InputType co
     act += tile_id_m * k / 2;
     weight += tile_id_n * k / 2;
     output += tile_id_m * n + tile_id_n;
+    OutputType const* __restrict__ bias_tile = (bias != nullptr) ? bias + tile_id_n : nullptr;
 
     scale_a += tile_id_m * k / nvfp4_scale_granularity;
 
@@ -154,6 +155,10 @@ __device__ void cudaCoreGemmImpl(InputType const* __restrict__ act, InputType co
         {
             val += shmem[jj * TILE_M * TILE_N + ii];
         }
+        if (bias_tile != nullptr)
+        {
+            val += static_cast<float>(bias_tile[nid]);
+        }
         output[mid * n + nid] = static_cast<OutputType>(val);
     }
 
@@ -166,13 +171,13 @@ template <typename InputType, typename OutputType, typename ScaleType, SizeType3
     SizeType32 BLOCK_SIZE>
 __global__ void cudaCoreGemmFp4(InputType const* __restrict__ act, InputType const* __restrict__ weight,
     ScaleType const* __restrict__ scale_a, ScaleType const* __restrict__ scale_w, float const* alpha_ptr,
-    OutputType* __restrict__ output, SizeType32 m, SizeType32 n, SizeType32 k)
+    OutputType* __restrict__ output, OutputType const* __restrict__ bias, SizeType32 m, SizeType32 n, SizeType32 k)
 {
     float alpha = alpha_ptr[0];
     cudaCoreGemmImpl<InputType, OutputType, ScaleType, TILE_M, TILE_N, BLOCK_SIZE>(
         reinterpret_cast<InputType const*>(act), reinterpret_cast<InputType const*>(weight),
         reinterpret_cast<ScaleType const*>(scale_a), reinterpret_cast<ScaleType const*>(scale_w), alpha,
-        reinterpret_cast<OutputType*>(output), m, n, k);
+        reinterpret_cast<OutputType*>(output), reinterpret_cast<OutputType const*>(bias), m, n, k);
 }
 
 template <typename InputType, typename OutputType, typename ScaleType, SizeType32 TILE_M, SizeType32 TILE_N,
@@ -203,7 +208,8 @@ void cudaCoreGemmKernel(Params const& params, cudaStream_t stream)
                 cudaCoreGemmFp4<InputType, OutputType, ScaleType, TILE_M, TILE_N, BLOCK_SIZE>,
                 reinterpret_cast<InputType const*>(params.act), reinterpret_cast<InputType const*>(params.weight),
                 reinterpret_cast<ScaleType const*>(params.scale_a), reinterpret_cast<ScaleType const*>(params.scale_b),
-                params.alpha_ptr, reinterpret_cast<OutputType*>(params.output), params.m, params.n, params.k));
+                params.alpha_ptr, reinterpret_cast<OutputType*>(params.output),
+                reinterpret_cast<OutputType const*>(params.bias), params.m, params.n, params.k));
         }
     }
     else
@@ -213,7 +219,8 @@ void cudaCoreGemmKernel(Params const& params, cudaStream_t stream)
             cudaCoreGemmFp4<InputType, OutputType, ScaleType, TILE_M, TILE_N, BLOCK_SIZE><<<grid, block, 0, stream>>>(
                 reinterpret_cast<InputType const*>(params.act), reinterpret_cast<InputType const*>(params.weight),
                 reinterpret_cast<ScaleType const*>(params.scale_a), reinterpret_cast<ScaleType const*>(params.scale_b),
-                params.alpha_ptr, reinterpret_cast<OutputType*>(params.output), params.m, params.n, params.k);
+                params.alpha_ptr, reinterpret_cast<OutputType*>(params.output),
+                reinterpret_cast<OutputType const*>(params.bias), params.m, params.n, params.k);
         }
     }
 }

--- a/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmNVFP4.h
+++ b/cpp/tensorrt_llm/kernels/weightOnlyBatchedGemv/cudaCoreGemmNVFP4.h
@@ -56,11 +56,13 @@ struct Params
     __nv_fp8_e4m3 const* scale_a;
     __nv_fp8_e4m3 const* scale_b;
     float const* alpha_ptr;
+    // Optional per-N bias broadcast: shape [n], same dtype as output. May be nullptr.
+    void const* bias;
 
     // used by torch flow
     Params(void const* _act, void const* _weight, void* _output, SizeType32 _m, SizeType32 _n, SizeType32 _k,
         __nv_fp8_e4m3 const* _scale_a, __nv_fp8_e4m3 const* _scale_b, cudaDataType_t _inputType,
-        cudaDataType_t _outputType, float const* _alpha_ptr)
+        cudaDataType_t _outputType, float const* _alpha_ptr, void const* _bias = nullptr)
         : act(_act)
         , weight(_weight)
         , output(_output)
@@ -72,6 +74,7 @@ struct Params
         , scale_a(_scale_a)
         , scale_b(_scale_b)
         , alpha_ptr(_alpha_ptr)
+        , bias(_bias)
     {
     }
 };

--- a/cpp/tensorrt_llm/thop/cublasFp4ScaledMM.cpp
+++ b/cpp/tensorrt_llm/thop/cublasFp4ScaledMM.cpp
@@ -79,7 +79,8 @@ inline cudaDataType_t getCudaDataType(at::ScalarType dtype)
 }
 
 void cublas_fp4_gemm_caller(torch::Tensor& out, torch::Tensor const& a, torch::Tensor const& b,
-    torch::Tensor const& scale_a, torch::Tensor const& scale_b, torch::Tensor const& alpha)
+    torch::Tensor const& scale_a, torch::Tensor const& scale_b, torch::Tensor const& alpha,
+    c10::optional<torch::Tensor> const& bias = c10::nullopt)
 {
     int32_t m = a.sizes()[0];
     int32_t n = b.sizes()[0];
@@ -144,11 +145,26 @@ void cublas_fp4_gemm_caller(torch::Tensor& out, torch::Tensor const& a, torch::T
     //   3. Passing dimensions as (n, m, k) instead of (m, n, k)
     //   4. Swapping scaling factors to match (b_sf_ptr, a_sf_ptr)
     // Note: beta is always 0 and is managed internally by BlockScaleGemm
+    void const* bias_ptr = nullptr;
+    if (bias.has_value() && bias->defined())
+    {
+        TLLM_CHECK_WITH_INFO(bias->is_cuda(), "bias must be a CUDA tensor for cuBLASLt epilogue");
+        TLLM_CHECK_WITH_INFO(
+            bias->device() == out.device(), "bias must reside on the same CUDA device as the GEMM output");
+        TLLM_CHECK_WITH_INFO(bias->is_contiguous(), "bias must be contiguous for cuBLASLt epilogue");
+        TLLM_CHECK_WITH_INFO(bias->dim() == 1 && bias->size(0) == n,
+            "bias must be a 1-D tensor of shape [N] matching the GEMM output dim");
+        TLLM_CHECK_WITH_INFO(
+            bias->scalar_type() == out.scalar_type(), "bias dtype must match output dtype for cuBLASLt epilogue");
+        bias_ptr = bias->data_ptr();
+    }
+
     cublasWrapper->BlockScaleGemm(CUBLAS_OP_T, CUBLAS_OP_N, n, m, k, b_ptr, k, // B matrix (swapped to first position)
         a_ptr, k,                                                              // A matrix (swapped to second position)
         out_ptr, n,                                                            // Output: C[m, n] in row-major
         b_sf_ptr, a_sf_ptr,                                                    // Scaling factors (also swapped)
-        alpha_ptr);                                                            // Uses default algorithm (nullptr)
+        alpha_ptr,                                                             // Uses default algorithm (nullptr)
+        bias_ptr);                                                             // Optional bias
 }
 
 } // namespace
@@ -176,10 +192,12 @@ public:
         return static_cast<int64_t>(num_algos);
     }
 
-    // Run GEMM with specified tactic (-1 for default/best)
+    // Run GEMM with specified tactic (-1 for default/best). Optional `bias`
+    // is fused via CUBLASLT_EPILOGUE_BIAS.
     at::Tensor runGemm(at::Tensor const& mat1, at::Tensor const& mat2, at::Tensor const& mat1_scale,
         at::Tensor const& mat2_scale, at::Tensor const& alpha, int64_t output_buffer_kind, int64_t tactic,
-        c10::optional<torch::List<int64_t>> group = c10::nullopt) const
+        c10::optional<torch::List<int64_t>> group = c10::nullopt,
+        c10::optional<torch::Tensor> bias = c10::nullopt) const
     {
         int m = mat1.size(0);
         int k_compressed = mat1.size(1);
@@ -221,7 +239,8 @@ public:
         // Execute GEMM (beta is always 0 and is managed internally)
         if (has_algo)
         {
-            cublas_fp4_gemm_caller_with_algo(out, mat1, mat2, mat1_scale, mat2_scale, alpha, *algo_ptr, mOutputDtype);
+            cublas_fp4_gemm_caller_with_algo(
+                out, mat1, mat2, mat1_scale, mat2_scale, alpha, *algo_ptr, mOutputDtype, bias);
         }
         else
         {
@@ -230,7 +249,7 @@ public:
                 "CublasLtFP4GemmRunner: No valid algorithm found (tactic=%ld, available=%zu), falling back to default "
                 "for shape (m=%d, n=%d, k=%d)",
                 tactic, cache.heuristics.size(), m, n, k);
-            cublas_fp4_gemm_caller(out, mat1, mat2, mat1_scale, mat2_scale, alpha);
+            cublas_fp4_gemm_caller(out, mat1, mat2, mat1_scale, mat2_scale, alpha, bias);
         }
 
         return out;
@@ -354,7 +373,8 @@ private:
     // Helper function to run GEMM with a specific algorithm
     static void cublas_fp4_gemm_caller_with_algo(torch::Tensor& out, torch::Tensor const& a, torch::Tensor const& b,
         torch::Tensor const& scale_a, torch::Tensor const& scale_b, torch::Tensor const& alpha,
-        cublasLtMatmulAlgo_t const& algo, at::ScalarType output_dtype)
+        cublasLtMatmulAlgo_t const& algo, at::ScalarType output_dtype,
+        c10::optional<torch::Tensor> const& bias = c10::nullopt)
     {
         int32_t m = a.sizes()[0];
         int32_t n = b.sizes()[0];
@@ -409,6 +429,20 @@ private:
         //   3. Passing dimensions as (n, m, k) instead of (m, n, k)
         //   4. Swapping scaling factors to match matrices (b_sf_ptr, a_sf_ptr)
 
+        void const* bias_ptr = nullptr;
+        if (bias.has_value() && bias->defined())
+        {
+            TLLM_CHECK_WITH_INFO(bias->is_cuda(), "bias must be a CUDA tensor for cuBLASLt epilogue");
+            TLLM_CHECK_WITH_INFO(
+                bias->device() == out.device(), "bias must reside on the same CUDA device as the GEMM output");
+            TLLM_CHECK_WITH_INFO(bias->is_contiguous(), "bias must be contiguous for cuBLASLt epilogue");
+            TLLM_CHECK_WITH_INFO(bias->dim() == 1 && bias->size(0) == n,
+                "bias must be a 1-D tensor of shape [N] matching the GEMM output dim");
+            TLLM_CHECK_WITH_INFO(
+                bias->scalar_type() == out.scalar_type(), "bias dtype must match output dtype for cuBLASLt epilogue");
+            bias_ptr = bias->data_ptr();
+        }
+
         // Use BlockScaleGemm with specified algorithm for autotuning
         // Note: beta is always 0 and is managed internally by BlockScaleGemm
         cublasWrapper->BlockScaleGemm(CUBLAS_OP_T, CUBLAS_OP_N, n, m, k, b_ptr,
@@ -417,7 +451,8 @@ private:
             out_ptr, n,         // Output: C[m, n] in row-major
             b_sf_ptr, a_sf_ptr, // Scaling factors (also swapped)
             alpha_ptr,          // Alpha
-            &algo);             // Use specified algorithm
+            &algo,              // Use specified algorithm
+            bias_ptr);          // Optional bias for CUBLASLT_EPILOGUE_BIAS
     }
 };
 

--- a/cpp/tensorrt_llm/thop/cudaNvfp4MM.cpp
+++ b/cpp/tensorrt_llm/thop/cudaNvfp4MM.cpp
@@ -36,7 +36,7 @@ namespace
 using tensorrt_llm::common::check;
 
 void cuda_core_nvfp4_gemm_caller(Tensor& out, Tensor const& a, Tensor const& b, Tensor const& scale_a,
-    Tensor const& scale_b, Tensor const& alpha, bool fast_acc = false)
+    Tensor const& scale_b, Tensor const& alpha, std::optional<at::Tensor> const& bias, bool fast_acc = false)
 {
     int32_t m = a.sizes()[0];
     int32_t n = b.sizes()[0];
@@ -67,9 +67,22 @@ void cuda_core_nvfp4_gemm_caller(Tensor& out, Tensor const& a, Tensor const& b, 
     cudaDataType_t alphaType = convert_torch_dtype(alpha.scalar_type());
     TORCH_CHECK(alphaType == CUDA_R_32F);
 
+    void const* bias_ptr = nullptr;
+    if (bias.has_value())
+    {
+        auto const& bias_tensor = *bias;
+        CHECK_TH_CUDA(bias_tensor);
+        TORCH_CHECK(bias_tensor.device() == out.device(), "bias must reside on the same CUDA device as the output");
+        TORCH_CHECK(bias_tensor.is_contiguous(), "bias must be contiguous");
+        TORCH_CHECK(bias_tensor.dim() == 1, "bias must be 1-D");
+        TORCH_CHECK(bias_tensor.sizes()[0] == n, "bias size must equal n=", n);
+        TORCH_CHECK(bias_tensor.scalar_type() == out.scalar_type(), "bias dtype must match output dtype");
+        bias_ptr = bias_tensor.data_ptr();
+    }
+
     tensorrt_llm::kernels::cuda_core_gemm_nvfp4::Params params(a_ptr, b_ptr, out_ptr, m, n, k,
         reinterpret_cast<__nv_fp8_e4m3 const*>(a_scale), reinterpret_cast<__nv_fp8_e4m3 const*>(b_scale), aType,
-        outType, reinterpret_cast<float const*>(alpha_ptr));
+        outType, reinterpret_cast<float const*>(alpha_ptr), bias_ptr);
     bool dispatched = tensorrt_llm::kernels::cuda_core_gemm_nvfp4::cudaCoreGemmDispatcher(params, stream);
     TORCH_CHECK(dispatched, "Failed to dispatch cudaCoreGemmLauncher");
 }
@@ -94,12 +107,10 @@ Tensor& cuda_core_nvfp4_gemm_out(Tensor const& mat_a, Tensor const& mat_b, Tenso
     TORCH_CHECK(mat_a.sizes()[1] == mat_b.sizes()[1]);
     TORCH_CHECK(mat_b.sizes()[0] == out.sizes()[1]);
 
-    TORCH_CHECK(!bias.has_value(), "bias is not support yet");
-
     TORCH_CHECK(scale_a.dtype() == SF_DTYPE);
     TORCH_CHECK(scale_b.dtype() == SF_DTYPE);
 
-    cuda_core_nvfp4_gemm_caller(out, mat_a, mat_b, scale_a, scale_b, alpha, true);
+    cuda_core_nvfp4_gemm_caller(out, mat_a, mat_b, scale_a, scale_b, alpha, bias, true);
     return out;
 }
 

--- a/cpp/tensorrt_llm/thop/fp4Gemm.cpp
+++ b/cpp/tensorrt_llm/thop/fp4Gemm.cpp
@@ -96,7 +96,7 @@ tkc::CutlassGemmConfig getDefaultGemmConfig(int64_t m, int64_t n, int64_t k, FP4
 template <typename T>
 void runGemm(at::Tensor& out, at::Tensor const& mat1, at::Tensor const& mat2, at::Tensor const& mat1Scale,
     at::Tensor const& mat2Scale, at::Tensor const& globalScale, int64_t m, int64_t n, int64_t k, int64_t batch_count,
-    tkc::CutlassGemmConfig const& gemmConfig, FP4GemmType fp4GemmType)
+    tkc::CutlassGemmConfig const& gemmConfig, FP4GemmType fp4GemmType, void const* bias_ptr = nullptr)
 {
     if (fp4GemmType == FP4GemmType::W4A8_MXFP4_MXFP8)
     {
@@ -107,7 +107,8 @@ void runGemm(at::Tensor& out, at::Tensor const& mat1, at::Tensor const& mat2, at
 
         gemmRunner.gemm(out.data_ptr(), mat1.const_data_ptr(), mat2.const_data_ptr(), mat1Scale.const_data_ptr(),
             mat2Scale.const_data_ptr(), globalScale.data_ptr<float>(), m, n, k, batch_count, gemmConfig,
-            reinterpret_cast<char*>(workspace.data_ptr()), wsBytes, at::cuda::getCurrentCUDAStream(mat1.get_device()));
+            reinterpret_cast<char*>(workspace.data_ptr()), wsBytes, at::cuda::getCurrentCUDAStream(mat1.get_device()),
+            bias_ptr);
     }
     else if (fp4GemmType == FP4GemmType::W4A4_NVFP4_NVFP4)
     {
@@ -118,7 +119,8 @@ void runGemm(at::Tensor& out, at::Tensor const& mat1, at::Tensor const& mat2, at
 
         gemmRunner.gemm(out.data_ptr(), mat1.const_data_ptr(), mat2.const_data_ptr(), mat1Scale.const_data_ptr(),
             mat2Scale.const_data_ptr(), globalScale.data_ptr<float>(), m, n, k, batch_count, gemmConfig,
-            reinterpret_cast<char*>(workspace.data_ptr()), wsBytes, at::cuda::getCurrentCUDAStream(mat1.get_device()));
+            reinterpret_cast<char*>(workspace.data_ptr()), wsBytes, at::cuda::getCurrentCUDAStream(mat1.get_device()),
+            bias_ptr);
     }
 }
 
@@ -133,7 +135,8 @@ void runGemm(at::Tensor& out, at::Tensor const& mat1, at::Tensor const& mat2, at
 at::Tensor fp4_bmm_impl(at::Tensor const& mat1, at::Tensor const& mat2, at::Tensor const& mat1Scale,
     at::Tensor const& mat2Scale, at::Tensor const& globalScale, FP4GemmType fp4GemmType,
     std::optional<c10::ScalarType> out_dtype, int64_t output_buffer_kind,
-    tkc::CutlassGemmConfig const* maybe_config = nullptr, c10::optional<torch::List<int64_t>> group = c10::nullopt)
+    tkc::CutlassGemmConfig const* maybe_config = nullptr, c10::optional<torch::List<int64_t>> group = c10::nullopt,
+    std::optional<at::Tensor> const& bias = std::nullopt)
 {
     if (fp4GemmType == FP4GemmType::W4A8_MXFP4_MXFP8)
     {
@@ -198,16 +201,31 @@ at::Tensor fp4_bmm_impl(at::Tensor const& mat1, at::Tensor const& mat2, at::Tens
     std::vector<int64_t> out_shape = mat1.dim() == 2 ? std::vector<int64_t>{m, n} : std::vector<int64_t>{b, m, n};
     auto [out, _] = torch_ext::allocate_output(
         out_shape, out_dtype.value(), mat1.device(), static_cast<torch_ext::BufferKind>(output_buffer_kind), group);
+
+    void const* bias_ptr = nullptr;
+    if (bias.has_value())
+    {
+        auto const& bias_tensor = *bias;
+        CHECK_TH_CUDA(bias_tensor);
+        TORCH_CHECK(bias_tensor.device() == out.device(), "bias must reside on the same CUDA device as the output");
+        TORCH_CHECK(bias_tensor.is_contiguous(), "bias must be contiguous");
+        TORCH_CHECK(bias_tensor.dim() == 1, "bias must be 1-D");
+        TORCH_CHECK(bias_tensor.sizes()[0] == n, "bias size must equal n=", n);
+        TORCH_CHECK(bias_tensor.scalar_type() == out.scalar_type(), "bias dtype must match output dtype");
+        bias_ptr = bias_tensor.const_data_ptr();
+    }
+
     switch (out_dtype.value())
     {
     case at::ScalarType::Half:
-        runGemm<half>(out, mat1, mat2, mat1Scale, mat2Scale, globalScale, m, n, k, b, config, fp4GemmType);
+        runGemm<half>(out, mat1, mat2, mat1Scale, mat2Scale, globalScale, m, n, k, b, config, fp4GemmType, bias_ptr);
         break;
     case at::ScalarType::BFloat16:
-        runGemm<__nv_bfloat16>(out, mat1, mat2, mat1Scale, mat2Scale, globalScale, m, n, k, b, config, fp4GemmType);
+        runGemm<__nv_bfloat16>(
+            out, mat1, mat2, mat1Scale, mat2Scale, globalScale, m, n, k, b, config, fp4GemmType, bias_ptr);
         break;
     case at::ScalarType::Float:
-        runGemm<float>(out, mat1, mat2, mat1Scale, mat2Scale, globalScale, m, n, k, b, config, fp4GemmType);
+        runGemm<float>(out, mat1, mat2, mat1Scale, mat2Scale, globalScale, m, n, k, b, config, fp4GemmType, bias_ptr);
         break;
     default: C10_THROW_ERROR(NotImplementedError, "out_dtype must be one of fp16/bf16/fp32.");
     }
@@ -278,7 +296,8 @@ public:
 
     at::Tensor runGemm(at::Tensor const& mat1, at::Tensor const& mat2, at::Tensor const& mat1Scale,
         at::Tensor const& mat2Scale, at::Tensor const& globalScale, int64_t output_buffer_kind, int64_t configIdx,
-        c10::optional<torch::List<int64_t>> group = c10::nullopt) const
+        c10::optional<torch::List<int64_t>> group = c10::nullopt,
+        std::optional<at::Tensor> const& bias = std::nullopt) const
     {
         tkc::CutlassGemmConfig const* config = nullptr;
         if (configIdx != -1)
@@ -287,7 +306,7 @@ public:
             config = &mConfigs.at(configIdx);
         }
         return fp4_bmm_impl(mat1, mat2, mat1Scale, mat2Scale, globalScale, mfp4GemmType, mOutputDtype,
-            output_buffer_kind, config, group);
+            output_buffer_kind, config, group, bias);
     }
 
     at::ScalarType getOutputDtype() const

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -529,6 +529,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
             self,
             inputs: List[torch.Tensor],
             tactic,
+            bias: Optional[torch.Tensor] = None,
             **kwargs,
         ) -> torch.Tensor:
             """
@@ -542,6 +543,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     inputs[3]: Weight scale tensor of shape (n, k//16), dtype: fp8.
                     inputs[4]: Alpha scaling factor. dtype: float32.
                 tactic: Tiling and cluster strategy, typically a tuple (mma_tiler_mn, cluster_shape_mn).
+                bias: Optional per-N bias [N]. Added post-GEMM inside the
+                    custom op (native CuTeDSL epilogue fusion is a follow-up).
 
             Returns:
                 torch.Tensor: Output tensor of shape (m, n), dtype: bf16.
@@ -758,6 +761,12 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             if swap_ab:
                 c_tensor = c_tensor.permute(1, 0)
+            if bias is not None:
+                if bias.ndim != 1 or bias.shape[0] != c_tensor.shape[-1]:
+                    raise ValueError(
+                        f"bias must be a 1-D tensor of shape [N]={c_tensor.shape[-1]}, "
+                        f"got shape {tuple(bias.shape)}")
+                c_tensor = c_tensor + bias
             return c_tensor
 
     # a/b: fp4, scale: fp8, output: bf16

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -558,9 +558,10 @@ class FP4GemmRunner(TunableRunner):
         self,
         inputs: List[torch.Tensor],
         tactic: int = -1,
+        bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         mat1, mat2, mat1_scale, mat2_scale, global_scale = inputs
-        return self.fp4_gemm_runner.run_gemm(
+        out = self.fp4_gemm_runner.run_gemm(
             mat1,
             mat2,
             mat1_scale,
@@ -569,7 +570,9 @@ class FP4GemmRunner(TunableRunner):
             self.output_buffer_kind,
             tactic,
             self.group,
+            bias,
         )
+        return out
 
 
 class CublasLtFP4GemmRunner(TunableRunner):
@@ -621,6 +624,7 @@ class CublasLtFP4GemmRunner(TunableRunner):
         self,
         inputs: List[torch.Tensor],
         tactic: int = -1,
+        bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         mat1, mat2, mat1_scale, mat2_scale, alpha = inputs
         result = self.cublaslt_runner.run_gemm(
@@ -632,6 +636,7 @@ class CublasLtFP4GemmRunner(TunableRunner):
             self.output_buffer_kind,
             tactic,
             self.group,
+            bias,
         )
         return result
 
@@ -688,6 +693,7 @@ class CudaCoreNVFP4Runner(TunableRunner):
         self,
         inputs: List[torch.Tensor],
         tactic: int = -1,
+        bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         act_fp4, weight, act_sf, weight_scale, alpha = inputs
 
@@ -697,14 +703,13 @@ class CudaCoreNVFP4Runner(TunableRunner):
         act_sf_unswizzled = torch.ops.trtllm.block_scale_interleave_reverse(
             act_sf.view((m + 128 - 1) // 128 * 128, -1))
 
-        # Call CUDA Core NVFP4 GEMM
         result = torch.ops.trtllm.cuda_core_nvfp4_gemm(
             act_fp4,
             weight,
             scale_a=act_sf_unswizzled,
             scale_b=weight_scale,
             alpha=alpha,
-            bias=None,
+            bias=bias,
             out_dtype=self.output_dtype,
             output_buffer_kind=self.output_buffer_kind,
             group=self.group,
@@ -714,15 +719,19 @@ class CudaCoreNVFP4Runner(TunableRunner):
 
 @torch.library.custom_op("trtllm::nvfp4_gemm_cublaslt", mutates_args=())
 def nvfp4_gemm_cublaslt(
-        act_fp4: torch.Tensor,
-        weight: torch.Tensor,
-        act_sf: torch.Tensor,
-        weight_scale: torch.Tensor,
-        alpha: torch.Tensor,
-        output_dtype: torch.dtype,
-        output_buffer_kind: int = int(BufferKind.DEFAULT),
+    act_fp4: torch.Tensor,
+    weight: torch.Tensor,
+    act_sf: torch.Tensor,
+    weight_scale: torch.Tensor,
+    alpha: torch.Tensor,
+    output_dtype: torch.dtype,
+    output_buffer_kind: int = int(BufferKind.DEFAULT),
+    bias: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """cuBLASLt-based NVFP4 GEMM with heuristic-based auto-tuning.
+
+    Args:
+        bias: Optional per-N bias [N], fused via CUBLASLT_EPILOGUE_BIAS.
 
     Note:
         This function is primarily used internally by nvfp4_gemm.
@@ -742,24 +751,27 @@ def nvfp4_gemm_cublaslt(
         [nvfp4_gemm_runner],
         nvfp4_gemm_runner.tuning_config,
         [act_fp4, weight, act_sf, weight_scale, alpha],
+        bias=bias,
     )
 
     result = nvfp4_gemm_runner(
         inputs=[act_fp4, weight, act_sf, weight_scale, alpha],
-        tactic=best_tactic)
+        tactic=best_tactic,
+        bias=bias)
 
     return result
 
 
 @nvfp4_gemm_cublaslt.register_fake
 def _(
-        act_fp4: torch.Tensor,
-        weight: torch.Tensor,
-        act_sf: torch.Tensor,
-        weight_scale: torch.Tensor,
-        alpha: torch.Tensor,
-        output_dtype: torch.dtype,
-        output_buffer_kind: int = int(BufferKind.DEFAULT),
+    act_fp4: torch.Tensor,
+    weight: torch.Tensor,
+    act_sf: torch.Tensor,
+    weight_scale: torch.Tensor,
+    alpha: torch.Tensor,
+    output_dtype: torch.dtype,
+    output_buffer_kind: int = int(BufferKind.DEFAULT),
+    bias: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     return act_fp4.new_empty((act_fp4.size(0), weight.size(0)),
                              dtype=output_dtype)
@@ -767,15 +779,20 @@ def _(
 
 @torch.library.custom_op("trtllm::nvfp4_gemm_cutlass", mutates_args=())
 def nvfp4_gemm_cutlass(
-        act_fp4: torch.Tensor,
-        weight: torch.Tensor,
-        act_sf: torch.Tensor,
-        weight_scale: torch.Tensor,
-        alpha: torch.Tensor,
-        output_dtype: torch.dtype,
-        output_buffer_kind: int = int(BufferKind.DEFAULT),
+    act_fp4: torch.Tensor,
+    weight: torch.Tensor,
+    act_sf: torch.Tensor,
+    weight_scale: torch.Tensor,
+    alpha: torch.Tensor,
+    output_dtype: torch.dtype,
+    output_buffer_kind: int = int(BufferKind.DEFAULT),
+    bias: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """CUTLASS-based NVFP4 GEMM with auto-tuning.
+
+    Args:
+        bias: Optional per-N bias [N], fused via the CUTLASS
+            LinCombPerColBias epilogue.
 
     Note:
         This function is primarily used internally by nvfp4_gemm.
@@ -794,22 +811,25 @@ def nvfp4_gemm_cutlass(
         [nvfp4_gemm_runner],
         nvfp4_gemm_runner.tuning_config,
         [act_fp4, weight, act_sf, weight_scale, alpha],
+        bias=bias,
     )
 
     return nvfp4_gemm_runner(
         inputs=[act_fp4, weight, act_sf, weight_scale, alpha],
-        tactic=best_tactic)
+        tactic=best_tactic,
+        bias=bias)
 
 
 @nvfp4_gemm_cutlass.register_fake
 def _(
-        act_fp4: torch.Tensor,
-        weight: torch.Tensor,
-        act_sf: torch.Tensor,
-        weight_scale: torch.Tensor,
-        alpha: torch.Tensor,
-        output_dtype: torch.dtype,
-        output_buffer_kind: int = int(BufferKind.DEFAULT),
+    act_fp4: torch.Tensor,
+    weight: torch.Tensor,
+    act_sf: torch.Tensor,
+    weight_scale: torch.Tensor,
+    alpha: torch.Tensor,
+    output_dtype: torch.dtype,
+    output_buffer_kind: int = int(BufferKind.DEFAULT),
+    bias: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     return act_fp4.new_empty((act_fp4.size(0), weight.size(0)),
                              dtype=output_dtype)
@@ -961,6 +981,7 @@ class NVFP4GemmUnifiedRunner(TunableRunner):
         tactic: Union[
             Tuple,
             int] = -1,  # tuple: (backend name, sub_tactic_id), or int: -1 for fallback
+        bias: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> torch.Tensor:
         # Handle fallback tactic on cache miss
@@ -977,22 +998,27 @@ class NVFP4GemmUnifiedRunner(TunableRunner):
             return CudaCoreNVFP4Runner(self.output_buffer_kind,
                                        self.output_dtype,
                                        group=self.group)(inputs,
-                                                         tactic=sub_tactic)
+                                                         tactic=sub_tactic,
+                                                         bias=bias)
         elif backend == "cutlass":
             return FP4GemmRunner(fp4_utils.FP4GemmType.W4A4_NVFP4_NVFP4,
                                  self.output_buffer_kind,
                                  self.output_dtype,
-                                 group=self.group)(inputs, tactic=sub_tactic)
+                                 group=self.group)(inputs,
+                                                   tactic=sub_tactic,
+                                                   bias=bias)
         elif backend == "cublaslt":
             return CublasLtFP4GemmRunner(self.output_buffer_kind,
                                          self.output_dtype,
                                          group=self.group)(inputs,
-                                                           tactic=sub_tactic)
+                                                           tactic=sub_tactic,
+                                                           bias=bias)
         elif backend == "cutedsl":
             return CuteDSLNVFP4BlackwellRunner(self.output_dtype,
                                                self.output_buffer_kind,
                                                self.group)(inputs,
-                                                           tactic=sub_tactic)
+                                                           tactic=sub_tactic,
+                                                           bias=bias)
         else:
             raise ValueError(f"Invalid tactic: {tactic}")
 
@@ -1008,6 +1034,7 @@ def nvfp4_gemm(
     output_buffer_kind: int = int(BufferKind.DEFAULT),
     allowed_backends: str = "cutlass,cublaslt,cuda_core",
     group: Optional[List[int]] = None,
+    bias: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Unified NVFP4 GEMM with automatic backend selection.
 
@@ -1077,6 +1104,7 @@ def nvfp4_gemm(
             NVFP4GemmUnifiedRunner.
             tuning_config,  # All runners use the same tuning_config
             [act_fp4, weight, act_sf, weight_scale, alpha],
+            bias=bias,
         )
     except IndexError as e:
         # Provide more helpful error message
@@ -1091,6 +1119,7 @@ def nvfp4_gemm(
     return runner(
         inputs=[act_fp4, weight, act_sf, weight_scale, alpha],
         tactic=best_tactic,
+        bias=bias,
     )
 
 
@@ -1105,6 +1134,7 @@ def _(
     output_buffer_kind: int = int(BufferKind.DEFAULT),
     allowed_backends: str = "cutlass,cublaslt,cuda_core",
     group: Optional[List[int]] = None,
+    bias: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Fake implementation for torch.compile support."""
     return act_fp4.new_empty((act_fp4.size(0), weight.size(0)),

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -1404,6 +1404,11 @@ class NVFP4LinearMethod(LinearMethodBase):
         group = (module.mapping.tp_group
                  if output_buffer_kind == int(BufferKind.NCCL_WINDOW)
                  and module.mapping is not None else None)
+        # Fuse bias inside the GEMM op when N is unpadded and the output is a
+        # plain buffer; otherwise fall back to post-op `out + bias` below.
+        fuse_bias_in_gemm = (bias is not None
+                             and output_buffer_kind == int(BufferKind.DEFAULT)
+                             and module.weight.shape[0] == module.out_features)
         output = torch.ops.trtllm.nvfp4_gemm(
             act_fp4,
             module.weight,
@@ -1413,7 +1418,8 @@ class NVFP4LinearMethod(LinearMethodBase):
             module.dtype,
             output_buffer_kind=output_buffer_kind,
             allowed_backends=allowed_backends_str,
-            group=group)
+            group=group,
+            bias=bias if fuse_bias_in_gemm else None)
         # Take the dim of out_features if padded. Make sure the output is contiguous
         if output.shape[-1] > module.out_features:
             output = output[..., :module.out_features].contiguous()
@@ -1421,7 +1427,7 @@ class NVFP4LinearMethod(LinearMethodBase):
         if original_shape is not None:
             output = output.reshape(*original_shape[:-1], output.shape[-1])
 
-        if bias is not None:
+        if bias is not None and not fuse_bias_in_gemm:
             output = output + bias
         return output
 

--- a/tests/unittest/_torch/thop/parallel/test_fp4_linear.py
+++ b/tests/unittest/_torch/thop/parallel/test_fp4_linear.py
@@ -767,3 +767,53 @@ if __name__ == "__main__":
     #     nvfp4_gemm_perf_test(torch.bfloat16, m, 7168, 65792)
     #     nvfp4_gemm_perf_test(torch.bfloat16, m, 227368, 2560, test_ref=False)
     #     nvfp4_gemm_perf_test(torch.bfloat16, m, 2560, 113664)
+
+
+def _make_nvfp4_inputs_for_bias_test(m, n, k, dtype=torch.bfloat16):
+    """Quantize random bf16 act+weight; return (act_fp4, weight_fp4, act_sf, weight_sf, alpha)."""
+    torch.manual_seed(0)
+    act = torch.randn(m, k, dtype=dtype, device="cuda")
+    weight = torch.randn(n, k, dtype=dtype, device="cuda")
+    act_gs = torch.tensor([1.0], dtype=torch.float32, device="cuda")
+    w_gs = torch.tensor([1.0], dtype=torch.float32, device="cuda")
+    act_fp4, act_sf = torch.ops.trtllm.fp4_quantize(act, act_gs, 16, False,
+                                                    True)
+    w_fp4, w_sf = torch.ops.trtllm.fp4_quantize(weight, w_gs, 16, False, True)
+    alpha = (1.0 / act_gs * 1.0 / w_gs).to(torch.float32).reshape(())
+    return act_fp4, w_fp4, act_sf, w_sf, alpha
+
+
+@skip_pre_blackwell
+@pytest.mark.parametrize("backend", ["cutlass", "cublaslt", "cuda_core"])
+@pytest.mark.parametrize("mnk", [(8, 4096, 4096), (252, 2048, 2048),
+                                 (1024, 4096, 4096), (4096, 6144, 4096)])
+def test_fp4_gemm_bias_per_backend(backend, mnk):
+    """Per-backend numerical parity: nvfp4_gemm(bias=B) ≈ nvfp4_gemm(bias=None) + B."""
+    m, n, k = mnk
+    if backend == "cuda_core" and m > 8:
+        pytest.skip("cuda_core backend only supports M <= 8")
+
+    act_fp4, w_fp4, act_sf, w_sf, alpha = _make_nvfp4_inputs_for_bias_test(
+        m, n, k)
+    bias = torch.randn(n, dtype=torch.bfloat16, device="cuda") * 0.5
+
+    out_no_bias = torch.ops.trtllm.nvfp4_gemm(act_fp4,
+                                              w_fp4,
+                                              act_sf,
+                                              w_sf,
+                                              alpha,
+                                              torch.bfloat16,
+                                              allowed_backends=backend)
+    ref = out_no_bias + bias
+
+    out_fused = torch.ops.trtllm.nvfp4_gemm(act_fp4,
+                                            w_fp4,
+                                            act_sf,
+                                            w_sf,
+                                            alpha,
+                                            torch.bfloat16,
+                                            allowed_backends=backend,
+                                            bias=bias)
+
+    # bf16 1-ULP at cast boundary (~0.0039) — fused vs gemm+add differs by ULP-level rounding.
+    torch.testing.assert_close(out_fused, ref, rtol=1e-2, atol=5e-3)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional bias tensor support to FP4 and NVFP4 GEMM operations for improved performance
  * Bias can now be fused directly into linear layer computations across supported backends

* **Tests**
  * Added comprehensive test suite validating bias-aware GEMM behavior across multiple hardware configurations and backends
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Adds a native per-N bias epilogue to the NVFP4 GEMM path so the bias-add is fused inside the GEMM kernel instead of being emitted as a separate downstream `aten.add`. Three backend implementations:

- **CUTLASS** (`nvfp4_*_gemm_template_sm{100,120}.h`, `mxfp8_mxfp4_gemm_template_sm100.h`): EVT swapped to `cutlass::epilogue::fusion::LinCombPerColBias<Out, float, Out, void, float>`. `ElementSource=void` keeps the C tile out of SMEM; bias enters via `Sm90RowBroadcast<Stride<_0,_1,_*>>` and `bias_ptr=null` resolves to `null_default=0` for the no-bias case.
- **cuBLASLt** (`cublasMMWrapper.{cpp,h}`, `cublasFp4ScaledMM.cpp`): `CUBLASLT_EPILOGUE_BIAS` + `CUBLASLT_MATMUL_DESC_BIAS_POINTER`.
- **cuda_core** (`cudaCoreGemmNVFP4.cu`): per-N `bias_tile[nid]` add at the final warp-reduce store.

Python side: `nvfp4_gemm`, `nvfp4_gemm_cutlass`, `nvfp4_gemm_cublaslt`, `cuda_core_nvfp4_gemm` and the CuteDSL runner accept `Optional[Tensor] bias`; `Linear` passes bias inline when N is unpadded and the output buffer is `DEFAULT` (otherwise falls back to post-op `out + bias` for correctness). CuteDSL backend keeps a Python-level fallback `c + bias`; native CuteDSL epilogue fusion is a follow-up.

## Test Coverage

`tests/unittest/_torch/thop/parallel_hw_agnostic/test_nvfp4_gemm_bias.py` (4 tests):

- per-backend bias parity vs legacy `gemm(...) + bias` for cutlass / cublaslt / cuda_core
- `bias=None` bit-equality with bias-omitted call (no behavior change for callers that don't opt in)
- unified `nvfp4_gemm` auto-select with bias
- shape-mismatch sentinel (bias must actually be applied, not silently dropped)

### Kernel-level microbench (B200, CUDA Graph mode — pure kernel time)

`fused` = `nvfp4_gemm(bias=bias)`, `unfused` = `nvfp4_gemm(bias=None) + bias`.

| Backend | Shape (M, N, K) | Fused (µs) | Unfused (µs) | Speedup |
|---|---|---|---|---|
| cutlass | 128, 2048, 2048 | 11.71 | 15.78 | 1.35× |
| cutlass | 1024, 4096, 4096 | 17.82 | 28.10 | 1.58× |
| cutlass | 4096, 2048, 8192 | 40.38 | 58.82 | 1.46× |
| cutlass | 16384, 2048, 4096 | 72.06 | 157.06 | **2.18×** |
| cublaslt | 128, 2048, 2048 | 8.51 | 11.68 | 1.37× |
| cublaslt | 1024, 4096, 4096 | 13.73 | 24.00 | 1.75× |
| cublaslt | 4096, 2048, 8192 | 30.11 | 46.50 | 1.54× |
| cublaslt | 16384, 2048, 4096 | 56.67 | 134.51 | **2.37×** |
| cuda_core | 4, 2048, 2048 | 11.68 | 13.76 | 1.18× |

Larger M scales the win — the unfused path's standalone `torch.add` does a full 2D output read+write that the fused epilogue absorbs.

### LTX-2 e2e (1 GPU B200, 768×1280, 121 frames, 40 steps, torch.compile + CUDA Graph, 3 iters)

| | avg (s) | min (s) | per-step (ms) |
|---|---|---|---|
| baseline (origin/main) | 19.390 | 19.364 | 484.75 |
| this PR | 19.142 | 19.083 | 478.54 |
| **delta** | **−0.248 s** | **−0.281 s** | **−6.21 ms** |

**−1.28% e2e on LTX-2**.

## PR Checklist

- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md).
- Test cases are provided for new code paths.
- Any new dependencies have been scanned for license and vulnerabilities.
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes.
- Documentation updated as needed.
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if significant design change.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
