### PR TITLE
[None][fix] Disable MegaMoE DeepGEMM fast-math under sparse attention

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py
@@ -282,7 +282,16 @@ class MegaMoEDeepGemm(MoE):
         self.apply_router_weight_on_input = apply_router_weight_on_input
         self.activation = activation
         self.swiglu_limit_scalar = swiglu_limit_scalar
-        self.fast_math = fast_math
+        # fast-math is non-associative (token-layout-dependent rounding); under sparse attention the
+        # MTP draft/verify passes then diverge via the sparse top-k, so drafts are always rejected.
+        # Force fast-math off when sparse attention is active; the dense path keeps it.
+        self.fast_math = fast_math and (model_config.sparse_attention_config is None)
+        if fast_math and model_config.sparse_attention_config is not None:
+            logger.warning_once(
+                "MegaMoE: forcing DeepGEMM fast_math=False because sparse attention is active "
+                "(fast-math's layout-dependent rounding breaks MTP draft acceptance).",
+                key="megamoe_fast_math_off_sparse",
+            )
 
         # Buffer sizing. MoE layers execute serially per forward; a single
         # process-level pool sized to worst-case per-rank tokens serves all.


### PR DESCRIPTION
@coderabbitai summary

## Description

### Issue
On `feat/deepseek_v4`, combining **deepseek_v4 sparse attention** with the **MEGAMOE_DEEPGEMM** MoE backend deterministically breaks MTP speculative decoding: every draft token is rejected, so MTP delivers no speedup. Each component is healthy on its own — the bug is specifically the megamoe x sparse interaction.

### Effect (DeepSeek-V4-Pro, GB300, MTP3, ~39k ISL, gen-only serving)
decoded tokens/iter = MTP acceptance (1.0 means every draft rejected; ~2.8 is healthy MTP3):

| Config | decoded tokens/iter |
|---|---|
| TRTLLM + sparse | 2.7 - 2.9 (healthy) |
| MEGAMOE_DEEPGEMM, no sparse | 2.69 (healthy) |
| **MEGAMOE_DEEPGEMM + sparse — before** | **1.02 (every draft rejected)** |
| **MEGAMOE_DEEPGEMM + sparse — after this fix** | **2.74 - 2.78 (restored)** |

### Root cause
MegaMoE's DeepGEMM `fast_math` path is non-associative, so its rounding depends on the per-call token layout. Under MTP the draft pass (`N*(1+max_draft_len)` tokens) and the verify pass (`N` tokens) have different token layouts, so the same hidden states produce slightly different MoE outputs across the two passes. The deepseek_v4 sparse indexer's hard top-k then amplifies that epsilon into a *different attended-KV set*, so the verify-pass logits' argmax diverges from the drafted tokens and the drafts are rejected. The dense (non-sparse) path and the TRTLLM MoE backend are layout-invariant, so they are unaffected.

### Fix
Disable DeepGEMM fast-math whenever sparse attention is configured (`model_config.sparse_attention_config is not None`); a one-time `logger.warning_once` records when it is force-disabled. The dense path keeps fast-math, so there is no perf impact outside sparse attention.

## Test Coverage

Validated on DeepSeek-V4-Pro (GB300, MTP3, ~39k ISL, gen-only) — see the Effect table above: MEGAMOE_DEEPGEMM + sparse goes from 1.02 (broken) to 2.74-2.78 (restored), while the controls (TRTLLM+sparse, megamoe-without-sparse) are unchanged. The change only gates an existing perf flag on the already-present `sparse_attention_config`; no new code path is added.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
