### PR TITLE
[#14225][perf] AutoDeploy MTP + ADP enablement and MoE all-to-all optimization

### DIFF
--- a/examples/auto_deploy/model_registry/configs/super_v3_mtp.yaml
+++ b/examples/auto_deploy/model_registry/configs/super_v3_mtp.yaml
@@ -1,29 +1,32 @@
-# Config for SuperV3 with MTP speculative decoding.
-#
+# Config for SuperV3 with MTP speculative decoding + attention-DP.
 runtime: trtllm
 compile_backend: torch-cudagraph
-max_batch_size: 64
-max_seq_len: 8192 # tunable
-max_num_tokens: 2048
+# For low-concurrency / latency-sensitive serving, lower max_batch_size to 16 for better latency.
+max_batch_size: 128
+max_seq_len: 65536 # tunable
 enable_chunked_prefill: false # TODO: Support chunked prefill w/ spec dec
 attn_backend: trtllm
 model_factory: AutoModelForCausalLM
 skip_loading_weights: false
 cuda_graph_config:
-  max_batch_size: 64
-  enable_padding: true
+  batch_sizes: [1, 2, 4, 8, 16, 24, 32, 64, 128]
 kv_cache_config:
   mamba_ssm_cache_dtype: auto
 speculative_config:
   decoding_type: MTP
   num_nextn_predict_layers: 6
   mtp_eagle_one_model: true
+attention_dp_config:
+  enable_balance: true
+  batching_wait_iters: 10
+  timeout_iters: 16
 transforms:
   compile_model:
     # MTP speculative decoding does not support piecewise CUDA graph capture yet.
     piecewise_enabled: false
   detect_sharding:
     allreduce_strategy: NCCL
+    enable_attention_dp: true
     # NOTE: add 'tp' to sharding dims only for high-throughput runs
     # For low-latency, keep mamba and attention replicated
     sharding_dims: ['ep', 'bmm']
@@ -46,10 +49,9 @@ transforms:
         # MoLE: latent projections: simple shard
         "fc1_latent_proj": "gather"
         "fc2_latent_proj": "gather"
-  # multi_stream_moe disabled - creates NaNs in target's sampled logits. TODO: investigate + fix
   multi_stream_moe:
     stage: compile
-    enabled: false
+    enabled: true
   fuse_mamba_a_log:
     stage: post_load_fusion
     enabled: true

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/attention_interface.py
@@ -410,7 +410,7 @@ class BatchInfo:
     Args:
         batch_info_host: The batch info tensor on the host.
 
-    The information is stored in a 15-element batch_info_host tensor as follows:
+    The information is stored in a 14-element batch_info_host tensor as follows:
 
     Slots 0-5 (batch composition):
     - [0] num_prefill: number of prefill requests
@@ -436,17 +436,10 @@ class BatchInfo:
     Slot 13 (replay mode flag, set once at runtime init):
     - [13] use_replay: 1 if SSM replay state-update path is active, 0 otherwise
 
-    Slot 14 (DP-aware token info, updated per forward when attention-DP is on):
-    - [14] max_dp_num_tokens: max(total_num_tokens) across all DP ranks for this
-      forward step. Equals local total_num_tokens when attention-DP is off.
-      Used by MoE all-to-all to size dispatch padding without over-padding to the
-      static config max_num_tokens. Mirrors base TRT-LLM's
-      ``runtime_max_tokens_per_rank`` from ``model_engine._get_all_rank_num_tokens``.
-
     All fields can be accessed and updated with the convenience functions below.
     """
 
-    _NUM_ELEMENTS = 15
+    _NUM_ELEMENTS = 14
 
     def __init__(self, batch_info_host: Optional[torch.Tensor] = None):
         if batch_info_host is None:
@@ -581,21 +574,6 @@ class BatchInfo:
 
     def is_use_replay(self) -> bool:
         return bool(self._batch_info[13])
-
-    # --- DP-aware token info (slot 14) writer ---
-
-    def update_max_dp_num_tokens(self, max_dp_num_tokens: int) -> None:
-        """Set the max-across-DP-ranks total token count for this forward.
-
-        When attention-DP is off, callers should write the local total_num_tokens
-        so consumers can read this slot uniformly without checking attn-DP state.
-        """
-        self._batch_info[14] = max_dp_num_tokens
-
-    # --- DP-aware token info (slot 14) reader ---
-
-    def get_max_dp_num_tokens(self) -> int:
-        return int(self._batch_info[14])
 
 
 class SequenceInfo:
@@ -1382,10 +1360,6 @@ class SequenceInfo:
             num_prefill_tokens = int(sl_host.sum()) - num_decode
             batch_info = [num_prefill, num_prefill_tokens, 0, 0, num_decode, num_decode]
         self.batch_info.update(batch_info)
-        # Default slot 14 (max_dp_num_tokens) to local total tokens; the executor
-        # overrides this with the cross-rank max via update_max_dp_num_tokens()
-        # when attention-DP is enabled.
-        self.batch_info.update_max_dp_num_tokens(self.batch_info.get_total_num_tokens())
 
         # check for updated input_pos (i.e. cache start position)
         if isinstance(input_pos, int):
@@ -1814,9 +1788,6 @@ class SequenceInfo:
         # update batch_info
         self.batch_info.update([0, 0, 0, 0, num_seq, num_seq])
         self.batch_info.update_tokens_gather_info(num_seq, False)
-        # Default slot 14 (max_dp_num_tokens) to local total tokens; the executor
-        # overrides this when attention-DP is on.
-        self.batch_info.update_max_dp_num_tokens(num_seq)
 
         # check if we need a d2h sync
         _REQUIRES_UPDATE = {

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/torch_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/torch_moe.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from functools import partial
-from typing import Callable, List, Optional
+from typing import Callable, List
 
 import torch
 import torch.nn.functional as F
@@ -287,7 +287,6 @@ def torch_moe(
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
     layer_type: str = "moe",
-    batch_info_host: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
     Unified Mixture-of-Experts (MoE) operator that uses a Mixtral-style dispatch
@@ -365,7 +364,6 @@ def torch_moe_fake(
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
     layer_type: str = "moe",
-    batch_info_host: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     return torch.empty_like(x)
 
@@ -456,7 +454,6 @@ def torch_quant_fp8_moe(
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
     layer_type: str = "moe",
-    batch_info_host: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
     FP8 MoE op using quantized linear operations. Computes a Mixture-of-Experts layer similar to the reference
@@ -577,7 +574,6 @@ def torch_quant_fp8_moe_fake(
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
     layer_type: str = "moe",
-    batch_info_host: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     return torch.empty_like(x)
 
@@ -605,7 +601,6 @@ def torch_quant_nvfp4_moe(
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
     layer_type: str = "moe",
-    batch_info_host: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
     FP4 MoE op using quantized linear operations.
@@ -742,7 +737,6 @@ def torch_quant_nvfp4_moe_fake(
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
     layer_type: str = "moe",
-    batch_info_host: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     return torch.empty_like(x)
 
@@ -814,7 +808,6 @@ def torch_quant_finegrained_fp8_moe(
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
     layer_type: str = "moe",
-    batch_info_host: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
     FineGrainedFP8 MoE op using block-wise FP8 quantized linear operations.
@@ -929,6 +922,5 @@ def torch_quant_finegrained_fp8_moe_fake(
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
     layer_type: str = "moe",
-    batch_info_host: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     return torch.empty_like(x)

--- a/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/custom_ops/fused_moe/trtllm_moe.py
@@ -23,10 +23,55 @@ from tensorrt_llm._utils import get_sm_version
 from tensorrt_llm.mapping import Mapping
 
 from ..._compat import ActivationType, is_sm_100f
+from ...utils.cuda_graph import cuda_graph_state
 from ...utils.dist_config import DistConfig
 from ..quantization.quant import TRTLLM_NVFP4_SCALING_VECTOR_SIZE
 
 _f32_scale_cache: dict = {}
+
+
+def _hybrid_runtime_max_tokens_per_rank(
+    local_num_tokens: int,
+    ep_size: int,
+    max_num_tokens: int,
+) -> int:
+    """Pick the MoE all-to-all per-rank token budget (dispatch/sanitize/combine/GEMM stride).
+
+    Hybrid of the cross-rank-max (per-layer ``.item()``) and static-``max_num_tokens``
+    strategies that avoids the pitfalls of each. Callers never pad ``x``: the dispatch kernel
+    writes only the real ``local_num_tokens`` rows and ``moe_a2a_sanitize_expert_ids``
+    invalidates the unfilled slots, so the returned value controls only the workspace stride /
+    recv-view / GEMM row count, not how many real rows are moved.
+
+    - **Capture / warm-up path** (decode/extend): use ``local_num_tokens``. Under attention-DP
+      every rank pads to the same ``cg_batch_size``, so the per-rank count already equals the
+      cross-rank max for the captured bucket, and at pure-decode replay it stays consistent.
+      It is a *shape*, not a device scalar, so there is **no per-layer ``.item()`` host read**
+      (the cost that made the cross-rank-max read regress at low concurrency). Mixed
+      prefill/decode — where a captured value would be stale — is routed to eager by
+      ``maybe_pad_for_cuda_graph`` via ``BypassCapturedGraphs()`` (#13718), so the captured
+      path only sees the uniform decode shape. The tight budget is taken only while the
+      resulting MoE-GEMM row count (``budget * ep_size``) stays in the fast small-M
+      ``bmm_E2m1`` tactic region; above the gate the trtllm-gen autotuner picks a
+      launch-latency-bound tactic, so fall back to the big-M
+      ``max_num_tokens`` budget.
+
+    - **Eager path** (prefill, or any step the bypass forced eager): use ``max_num_tokens``.
+      It is a constant every rank computes identically (layout agrees across ranks) and
+      involves no host sync. Prefill is compute-bound, so the fat recv view is amortized.
+    """
+    if torch.cuda.is_current_stream_capturing() or cuda_graph_state.in_warm_up():
+        budget = local_num_tokens
+        # Only take the tight budget while the MoE-GEMM row count (budget * ep_size) stays in
+        # the fast small-M trtllm-gen tactic region; above it the autotuner switches to a
+        # launch-latency-bound tactic.
+        # The threshold is on the FC1 grouped-GEMM's row dimension M, because that's what the
+        # trtllm-gen autotuner selects the kernel tactic from — and that M is budget × ep_size
+        # TODO: remove this WAR https://github.com/NVIDIA/TensorRT-LLM/issues/15167
+        # See: https://nvbugspro.nvidia.com/bug/6247543
+        if budget > 0 and budget * ep_size * 4 <= max_num_tokens:
+            return budget
+    return max_num_tokens
 
 
 def _router_use_tinygemm(x2d: torch.Tensor, weight: torch.Tensor, bias) -> bool:
@@ -208,7 +253,6 @@ def _run_moe_with_alltoall(
     use_deepseek_fp8_block_scale: bool = False,
     finegrained_fp8_block_scales: Tuple[torch.Tensor, torch.Tensor] | None = None,
     is_gated_mlp: bool = True,
-    batch_info_host: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """
     Execute MoE with all-to-all dispatch/combine pattern.
@@ -252,11 +296,6 @@ def _run_moe_with_alltoall(
             ``use_deepseek_fp8_block_scale`` internally.
         is_gated_mlp: Whether gated MLP is used. Needed by the Blackwell finegrained
             FP8 path to compute ``intermediate_size``.
-        batch_info_host: Pinned-host int tensor managed by ``BatchInfo``. When
-            provided, slot 14 (``max_dp_num_tokens``) is read at capture time as
-            ``runtime_max_tokens_per_rank`` (the cross-rank max of
-            ``total_num_tokens``, computed pre-forward by the AD shim via
-            ``tp_allgather``). When ``None``, falls back to ``max_num_tokens``.
 
     Returns:
         2-D output tensor ``(num_tokens, hidden_size)`` — the caller reshapes to the
@@ -269,18 +308,12 @@ def _run_moe_with_alltoall(
     local_num_experts = fc1_expert_weights.shape[0]
     global_num_experts = local_num_experts * mapping.moe_ep_size
 
-    # runtime_max_tokens_per_rank: max(total_num_tokens) across DP ranks.
-    # Mirrors base TRT-LLM's `runtime_max_tokens_per_rank = max(all_rank_num_tokens)`
-    # in fused_moe_cutlass.py / fused_moe_trtllm_gen.py. AD's shim writes slot 14
-    # pre-forward via `tp_allgather` of `total_num_tokens` (when attention-DP is on);
-    # nest_sequences seeds slot 14 with the local total as a safe default. See
-    # ``BatchInfo`` in attention_interface.py for the full slot layout.
-    if batch_info_host is not None:
-        runtime_max_tokens_per_rank = int(batch_info_host[14].item())
-        if runtime_max_tokens_per_rank <= 0:
-            runtime_max_tokens_per_rank = max_num_tokens
-    else:
-        runtime_max_tokens_per_rank = max_num_tokens
+    # Hybrid per-rank token budget: tight (= local count) under capture, static under eager.
+    # See _hybrid_runtime_max_tokens_per_rank.
+    local_num_tokens = x.shape[0]
+    runtime_max_tokens_per_rank = _hybrid_runtime_max_tokens_per_rank(
+        local_num_tokens, mapping.moe_ep_size, max_num_tokens
+    )
 
     # Workspace must be sized for the LARGEST element type used by dispatch or combine.
     # The input x may be quantized (fp8/fp4), but combine outputs in the model dtype
@@ -299,20 +332,10 @@ def _run_moe_with_alltoall(
 
     invalid_expert_id = global_num_experts
 
-    # Pad inputs to runtime_max_tokens_per_rank so all ranks send the same number
-    # of rows through dispatch.  Padding expert IDs must route to a VALID rank
-    # (the local rank's first expert), otherwise the dispatch kernel computes an
-    # out-of-bounds target rank.  Zero routing weights ensure padding tokens
-    # contribute nothing to the output.
-    local_num_tokens = x.shape[0]
-    pad_expert_id = mapping.moe_ep_rank * local_num_experts  # routes to local rank
-    pad_size = runtime_max_tokens_per_rank - local_num_tokens
-    if pad_size > 0:
-        x = torch.nn.functional.pad(x, (0, 0, 0, pad_size))  # pad rows with zeros
-        selected_experts = torch.nn.functional.pad(
-            selected_experts, (0, 0, 0, pad_size), value=pad_expert_id
-        )
-        routing_weights = torch.nn.functional.pad(routing_weights, (0, 0, 0, pad_size))
+    # Do NOT pad x to runtime_max_tokens_per_rank: the dispatch kernel writes only the real
+    # ``local_num_tokens`` rows per rank, and moe_a2a_sanitize_expert_ids marks the unfilled
+    # slots invalid so the downstream MoE GEMM skips them. ``runtime_max_tokens_per_rank``
+    # controls only the workspace stride / recv-view shape.
 
     # Build payload list: x, selected_experts, routing_weights
     payloads = [x.contiguous(), selected_experts.contiguous(), routing_weights.contiguous()]
@@ -443,7 +466,6 @@ def _run_trtllm_gen_nvfp4_moe_with_alltoall(
     mapping: Mapping,
     max_num_tokens: int,
     act_type: int,
-    batch_info_host: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Run TRTLLM-Gen NVFP4 MoE through the all-to-all dispatch/combine path."""
 
@@ -451,13 +473,12 @@ def _run_trtllm_gen_nvfp4_moe_with_alltoall(
     hidden_size = x.shape[-1]
     local_num_experts = int(fc1_expert_weights_fp4.shape[0])
     global_num_experts = local_num_experts * mapping.moe_ep_size
-    # See _run_moe_with_alltoall above for the slot-14 contract.
-    if batch_info_host is not None:
-        runtime_max_tokens_per_rank = int(batch_info_host[14].item())
-        if runtime_max_tokens_per_rank <= 0:
-            runtime_max_tokens_per_rank = max_num_tokens
-    else:
-        runtime_max_tokens_per_rank = max_num_tokens
+    # Hybrid per-rank token budget (see _hybrid_runtime_max_tokens_per_rank): tight local
+    # shape under capture, static max_num_tokens under eager; no slot-13 .item(), no x pad.
+    local_num_tokens = x.shape[0]
+    runtime_max_tokens_per_rank = _hybrid_runtime_max_tokens_per_rank(
+        local_num_tokens, mapping.moe_ep_size, max_num_tokens
+    )
 
     moe_a2a = _GlobalMoeAll2AllCache.get_alltoall(
         mapping=mapping,
@@ -470,16 +491,7 @@ def _run_trtllm_gen_nvfp4_moe_with_alltoall(
     )
 
     invalid_expert_id = global_num_experts
-    local_num_tokens = x.shape[0]
-    pad_expert_id = mapping.moe_ep_rank * local_num_experts
-    pad_size = runtime_max_tokens_per_rank - local_num_tokens
-    if pad_size > 0:
-        x = torch.nn.functional.pad(x, (0, 0, 0, pad_size))
-        selected_experts = torch.nn.functional.pad(
-            selected_experts, (0, 0, 0, pad_size), value=pad_expert_id
-        )
-        routing_weights = torch.nn.functional.pad(routing_weights, (0, 0, 0, pad_size))
-
+    # No x padding: dispatch writes only the real rows; sanitize invalidates the rest.
     recv_results = moe_a2a.dispatch(
         selected_experts,
         [x.contiguous(), selected_experts.contiguous(), routing_weights.contiguous()],
@@ -549,7 +561,6 @@ def trtllm_moe_fused(
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
-    batch_info_host: torch.Tensor | None = None,
 ) -> torch.Tensor:
     x_shape = x.shape
     x = x.view(-1, x_shape[-1])
@@ -595,7 +606,6 @@ def trtllm_moe_fused(
             activation_type=activation_type,
             mapping=mapping,
             max_num_tokens=max_num_tokens,
-            batch_info_host=batch_info_host,
         ).view(x_shape)
 
     # EP WITH ALL-REDUCE PATH: Expert IDs are in LOCAL coordinates (from sharding.py),
@@ -626,7 +636,6 @@ def trtllm_moe_fused_fake(
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
-    batch_info_host: torch.Tensor | None = None,
 ) -> torch.Tensor:
     return torch.empty_like(x)
 
@@ -666,7 +675,6 @@ def trtllm_quant_fp8_moe_fused(
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
-    batch_info_host: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """TensorRT-LLM Cutlass FP8 (W8A8) MoE for gated and non-gated MLP.
 
@@ -744,7 +752,6 @@ def trtllm_quant_fp8_moe_fused(
             activation_type=act_fn,
             mapping=mapping,
             max_num_tokens=max_num_tokens,
-            batch_info_host=batch_info_host,
         ).view(x_shape)
 
     # EP WITH ALL-REDUCE PATH: Expert IDs are in LOCAL coordinates.
@@ -782,7 +789,6 @@ def trtllm_quant_fp8_moe_fused_fake(
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
-    batch_info_host: torch.Tensor | None = None,
 ) -> torch.Tensor:
     _validate_mlp_style_and_act_fn(is_gated_mlp, act_fn)
     return torch.empty_like(x)
@@ -806,7 +812,6 @@ def trtllm_quant_nvfp4_moe_fused(
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
-    batch_info_host: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """TensorRT-LLM Cutlass NVFP4 W8A8 MoE for gated and non-gated MLP.
 
@@ -876,7 +881,6 @@ def trtllm_quant_nvfp4_moe_fused(
             mapping=mapping,
             max_num_tokens=max_num_tokens,
             nvfp4_act_global_scale=fc1_act_global_scale,
-            batch_info_host=batch_info_host,
         ).view(x.shape)
 
     # EP WITH ALL-REDUCE PATH: Expert IDs are in LOCAL coordinates.
@@ -923,7 +927,6 @@ def trtllm_quant_nvfp4_moe_fused_fake(
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
-    batch_info_host: torch.Tensor | None = None,
 ) -> torch.Tensor:
     return torch.empty_like(x)
 
@@ -942,7 +945,6 @@ def trtllm_quant_finegrained_fp8_moe_fused(
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
-    batch_info_host: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """TensorRT-LLM Cutlass FP8 Block Scale MoE for FineGrainedFP8 format.
 
@@ -1005,7 +1007,6 @@ def trtllm_quant_finegrained_fp8_moe_fused(
             max_num_tokens=max_num_tokens,
             finegrained_fp8_block_scales=(fc1_weight_scale, fc2_weight_scale),
             is_gated_mlp=is_gated_mlp,
-            batch_info_host=batch_info_host,
         ).view(x_shape)
 
     # EP WITH ALL-REDUCE PATH: Expert IDs are in LOCAL coordinates (from sharding.py),
@@ -1092,7 +1093,6 @@ def trtllm_quant_finegrained_fp8_moe_fused_fake(
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
-    batch_info_host: torch.Tensor | None = None,
 ) -> torch.Tensor:
     _validate_mlp_style_and_act_fn(is_gated_mlp, act_fn)
     return torch.empty_like(x)
@@ -1121,7 +1121,6 @@ def _trtllm_nvfp4_trtllm_gen_moe_impl(
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
-    batch_info_host: torch.Tensor | None = None,
 ) -> torch.Tensor:
     _validate_mlp_style_and_act_fn(is_gated_mlp, act_fn)
     if act_fn in (ActivationType.Gelu, ActivationType.Geglu):
@@ -1198,7 +1197,6 @@ def _trtllm_nvfp4_trtllm_gen_moe_impl(
             mapping=mapping,
             max_num_tokens=max_num_tokens,
             act_type=act_type,
-            batch_info_host=batch_info_host,
         )
         if final_hidden_states.shape[1] > x_shape[-1]:
             final_hidden_states = final_hidden_states[:, : x_shape[-1]].contiguous()
@@ -1271,7 +1269,6 @@ def trtllm_nvfp4_trtllm_gen_moe_fused(
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
-    batch_info_host: torch.Tensor | None = None,
 ) -> torch.Tensor:
     return _trtllm_nvfp4_trtllm_gen_moe_impl(
         x,
@@ -1296,7 +1293,6 @@ def trtllm_nvfp4_trtllm_gen_moe_fused(
         mapping_config=mapping_config,
         max_num_tokens=max_num_tokens,
         apply_routing_on_input=apply_routing_on_input,
-        batch_info_host=batch_info_host,
     )
 
 
@@ -1324,7 +1320,6 @@ def trtllm_nvfp4_trtllm_gen_moe_fused_fake(
     mapping_config: str = "",
     max_num_tokens: int = 0,
     apply_routing_on_input: bool = False,
-    batch_info_host: torch.Tensor | None = None,
 ) -> torch.Tensor:
     return torch.empty_like(x)
 

--- a/tensorrt_llm/_torch/auto_deploy/llm_args.py
+++ b/tensorrt_llm/_torch/auto_deploy/llm_args.py
@@ -497,6 +497,15 @@ class LlmArgs(DynamicYamlMixInForSettings, TorchLlmArgs, BaseSettings):
             `self.max_seq_len` so that all downstream consumers see the same value.
         """
 
+        # Resolve enable_attention_dp from the same source `init_dist_config`
+        # uses so the factory sees the same value the runtime will see.
+        # TODO remove it once this is fixed: https://github.com/NVIDIA/TensorRT-LLM/issues/13134
+        ash = self.transforms.get("apply_sharding_hints", {})
+        sharding_config = (
+            ash if ash.get("enabled", False) else self.transforms.get("detect_sharding", {})
+        )
+        enable_attention_dp = sharding_config.get("enable_attention_dp", False)
+
         # TODO (lucaslie): consider supporting Path objects in the model factory
         factory = ModelFactoryRegistry.get(self.model_factory)(
             model=str(self.model),
@@ -507,6 +516,7 @@ class LlmArgs(DynamicYamlMixInForSettings, TorchLlmArgs, BaseSettings):
             max_seq_len=self.max_seq_len,
             # Extra kwargs consumed by EagleOneModelFactory (ignored by others via **kwargs)
             sync_before_hidden_state_capture=self.attn_backend == "flashinfer",
+            enable_attention_dp=enable_attention_dp,
             speculative_config=self.speculative_config,
             speculative_model_kwargs=self.speculative_model_kwargs or None,
         )

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_eagle.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_eagle.py
@@ -811,6 +811,12 @@ class EagleWrapperConfig:
     load_lm_head_from_target: bool
     normalize_target_hidden_state: bool = False
     sync_before_hidden_state_capture: bool = False
+    # When attention-DP is enabled, each rank holds a different slice of the
+    # global batch and produces legitimately different per-rank tokens. The
+    # rank-0 token broadcast applied for TP-replication consistency (see
+    # `sample_greedy`) must be skipped in that mode to avoid overwriting
+    # peers' real samples.
+    enable_attention_dp: bool = False
 
 
 class EagleWrapper(nn.Module):
@@ -832,6 +838,7 @@ class EagleWrapper(nn.Module):
         self.load_lm_head_from_target = config.load_lm_head_from_target
         self.normalize_target_hidden_state = config.normalize_target_hidden_state
         self.sync_before_hidden_state_capture = config.sync_before_hidden_state_capture
+        self.enable_attention_dp = config.enable_attention_dp
 
     @property
     def _draft_inner_model(self):
@@ -897,12 +904,19 @@ class EagleWrapper(nn.Module):
 
     def sample_greedy(self, logits: torch.Tensor) -> torch.Tensor:
         ret = torch.argmax(logits, dim=-1)
-        # Broadcast rank 0's sampled tokens to all ranks. We have observed slight
-        # differences in logits across ranks. This can cause different acceptance patterns,
-        # inconsistent input_pos, and a hang. This synchronizes every
-        # validation step to prevent this. See:
+        # Under TP-replication, all ranks compute the same logits but small
+        # floating-point differences can drive different argmax results,
+        # producing divergent acceptance patterns / input_pos and an
+        # eventual hang. The broadcast below synchronizes rank 0's tokens
+        # to all ranks each validation step. See:
         # https://github.com/NVIDIA/TensorRT-LLM/issues/13134
-        broadcast(ret, src=0)
+        #
+        # Under attention-DP, each rank holds a *different* slice of the
+        # global batch so per-rank tokens are legitimately different;
+        # broadcasting would overwrite peers' real samples with rank 0's
+        # values and corrupt per-request state.
+        if not self.enable_attention_dp:
+            broadcast(ret, src=0)
         return ret
 
     def forward(self, cache_seq_interface: Optional[CachedSequenceInterface] = None, **kwargs):

--- a/tensorrt_llm/_torch/auto_deploy/models/eagle.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/eagle.py
@@ -287,6 +287,9 @@ class EagleOneModelFactory(ModelFactory):
         self.sync_before_hidden_state_capture = kwargs.get(
             "sync_before_hidden_state_capture", False
         )
+        # Plumbed from LlmArgs.create_factory(); informs EagleWrapper whether
+        # to skip the TP-replication token broadcast in sample_greedy.
+        self.enable_attention_dp = kwargs.get("enable_attention_dp", False)
         # For MTP, derive Eagle-pipeline fields from MTP-specific fields.
         if isinstance(speculative_config, MTPDecodingConfig):
             draft_model_path = speculative_config.speculative_model or model
@@ -335,6 +338,7 @@ class EagleOneModelFactory(ModelFactory):
                 draft_config, "normalize_target_hidden_state", False
             ),
             sync_before_hidden_state_capture=self.sync_before_hidden_state_capture,
+            enable_attention_dp=self.enable_attention_dp,
         )
 
         return EagleWrapper(

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -1057,20 +1057,6 @@ class ADEngine(ModelEngine):
         )
         self.iter_counter += 1
 
-        # Compute DP-aware max(total_num_tokens) and write to BatchInfo slot 14
-        # (``max_dp_num_tokens``). Mirrors base TRT-LLM's pattern in
-        # ``model_engine._get_all_rank_num_tokens``: MoE all-to-all needs the
-        # cross-rank max to size dispatch padding without over-padding to the
-        # static config ``max_num_tokens``. ``nest_sequences`` already
-        # initialized slot 14 to the local ``total_num_tokens``; this overrides
-        # with the cross-rank max only when attention-DP requires it.
-        if self.enable_attention_dp and self.dist_config.tp_size > 1:
-            assert self.dist is not None, "Distributed object is required for attention DP mode"
-            info = self.cache_seq_interface.info
-            local_total_num_tokens = info.batch_info.get_total_num_tokens()
-            all_rank_num_tokens = list(self.dist.tp_allgather(local_total_num_tokens))
-            info.batch_info.update_max_dp_num_tokens(max(all_rank_num_tokens))
-
         # compute outputs
         outputs = self._run_forward()
 
@@ -1315,6 +1301,14 @@ def create_autodeploy_executor(
             vocab_size_padded=vocab_size_padded,
         )
 
+    # Speculative-decoding draft sizes must be forwarded to PyExecutor so that the
+    # attention-DP dummy created in `_pad_attention_dp_dummy_request` is materialized
+    # with `py_draft_tokens = [1] * max_total_draft_tokens` instead of `[]`. An empty
+    # `py_draft_tokens` makes the dummy classify as decode in `_prepare_inputs` and
+    # trips the eagle wrapper's `assert num_decode == 0` under MTP + attention_dp.
+    max_draft_len = 0 if spec_config is None else spec_config.max_draft_len
+    max_total_draft_tokens = 0 if spec_config is None else spec_config.tokens_per_gen_step - 1
+
     # creating the executor object
     py_executor = PyExecutor(
         resource_manager,
@@ -1327,6 +1321,8 @@ def create_autodeploy_executor(
         max_input_len=ad_config.max_input_len,
         max_batch_size=ad_config.max_batch_size,
         max_beam_width=ad_config.max_beam_width,
+        max_draft_len=max_draft_len,
+        max_total_draft_tokens=max_total_draft_tokens,
         guided_decoder=guided_decoder,
         kv_cache_transceiver=kv_cache_transceiver,
         resource_governor_queue=resource_governor_queue,

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
@@ -1214,6 +1214,28 @@ class Sharding(BaseTransform):
             if ShardingDim.EP in config.sharding_dims:
                 ad_logger.info("Running autodeploy EP sharding heuristics")
                 info += detect_ep_shard(gm, transform_container)
+                # Under attention-DP, EP-sharding the draft submodel forces its
+                # MoE op into the alltoall path. Target and draft share a
+                # single process-wide MoeAlltoAll workspace + flag_val counter
+                # (singleton in MoeAlltoAll._WORKSPACE), so a misconfigured
+                # draft alltoall corrupts the workspace and the subsequent
+                # target alltoall calls hang or fault. Replicating the draft
+                # (no EP sharding, no alltoall) is the safe choice: the draft
+                # is small enough that the 4x weight memory is negligible,
+                # and each rank computes its local-batch slice locally with no
+                # cross-rank communication needed.
+                # TODO: https://github.com/NVIDIA/TensorRT-LLM/issues/15168
+                if (
+                    _is_draft
+                    and config.dist_config.enable_attention_dp
+                    and transform_container.ep_transforms
+                ):
+                    ad_logger.info(
+                        "Reverting %d EP sharding transform(s) on draft submodel "
+                        "under attention_dp (replicating instead).",
+                        len(transform_container.ep_transforms),
+                    )
+                    transform_container.ep_transforms.clear()
             if ShardingDim.BMM in config.sharding_dims:
                 # While BMM nodes are most likely used for MoE (e.g. LLama4),
                 # technically, this is a different transformation.
@@ -1327,17 +1349,6 @@ class ShardingTransformExecutor(BaseTransform):
             f"BMM={len(transforms.bmm_transforms)}, "
             f"RMSNorm={len(transforms.rmsnorm_transforms)}"
         )
-
-        # If there are EP transforms and we have a CachedSequenceInterface, ensure
-        # batch_info_host is added to the graph as a placeholder and activated on
-        # the SequenceInfo so the runtime DP-aware max_num_tokens (slot 14) flows
-        # into the MoE all-to-all op as a kwarg. _add_or_retrieve_input is
-        # idempotent — safe even if another transform (e.g.
-        # gather_logits_before_lm_head) already added the placeholder.
-        # When cm is None (e.g., unit tests that drive the sharding transform
-        # standalone), skip — the MoE op falls back to max_num_tokens.
-        if transforms.ep_transforms and cm is not None:
-            self._add_or_retrieve_input(gm, cm, "batch_info_host", init_val=True)
 
         with WeightBiasInfoCache():
             for tp_transform in transforms.weight_sharding_transforms:
@@ -1945,13 +1956,6 @@ def _insert_sharded_moe(
     # (Will be used inside the op to determine enable_alltoall and workspace size)
     mapping_config = config.dist_config.serialize()
 
-    # Look up batch_info_host placeholder if present. ShardingTransformExecutor
-    # ensures it's added/activated when there are EP transforms; if it's missing
-    # (e.g., a different code path bypasses the executor), the MoE op falls back
-    # to max_num_tokens for runtime padding.
-    batch_info_host_nodes = gm.graph.find_nodes(op="placeholder", target="batch_info_host")
-    batch_info_host_node = batch_info_host_nodes[0] if batch_info_host_nodes else None
-
     # Write back weight/scale list updates (applied above) and inject mapping args.
     # set_op_args uses the op schema to place values into kwargs or the correct
     # positional slot, avoiding manual index arithmetic.
@@ -1960,7 +1964,6 @@ def _insert_sharded_moe(
         node,
         mapping_config=mapping_config,
         max_num_tokens=config.max_num_tokens,
-        batch_info_host=batch_info_host_node,
     )
 
     if not enable_alltoall:

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding_ir.py
@@ -1283,11 +1283,14 @@ class MoEShardableNode(ShardableNode):
         # are harmless.
         batch_info_host_nodes = gm.graph.find_nodes(op="placeholder", target="batch_info_host")
         batch_info_host_node = batch_info_host_nodes[0] if batch_info_host_nodes else None
+        extra_kwargs = (
+            {"batch_info_host": batch_info_host_node} if batch_info_host_node is not None else {}
+        )
         set_op_args(
             self.node,
             mapping_config=dc.serialize(),
             max_num_tokens=max_num_tokens,
-            batch_info_host=batch_info_host_node,
+            **extra_kwargs,
         )
 
         ad_logger.debug(
@@ -1789,14 +1792,6 @@ class ApplyShardingHints(BaseTransform):
             )
 
         max_num_tokens = cm.info.max_num_tokens if (cm and cm.info) else 0
-
-        # When attention-DP is active with EP, the MoE all-to-all ops need
-        # runtime token counts (batch_info_host slot 14, ``max_dp_num_tokens``)
-        # to avoid over-padding.
-        # Add the placeholder before the node loop so MoEShardableNode.apply()
-        # can find and wire it into each MoE node.
-        if dc.enable_attention_dp and dc.moe_ep_size > 1 and cm is not None:
-            self._add_or_retrieve_input(gm, cm, "batch_info_host", init_val=True)
 
         num_updates = 0
         if self.config.simple_shard_only:

--- a/tensorrt_llm/_torch/auto_deploy/utils/cuda_graph.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/cuda_graph.py
@@ -32,8 +32,8 @@ class CudaGraphState:
 
     # Indicates that captured-graph wrappers must short-circuit to eager.
     # Set by ad_executor.maybe_pad_for_cuda_graph under attention-DP mixed mode
-    # so all ranks read kwargs (e.g. batch_info_host slot 14) consistently
-    # instead of using stale capture-time scalar kernel args. See
+    # so all ranks size the MoE all-to-all dispatch consistently from the live
+    # input shape instead of using stale capture-time scalar kernel args. See
     # BypassCapturedGraphs() below.
     BYPASS: bool = False
 
@@ -84,10 +84,10 @@ def BypassCapturedGraphs():
     when the cross-rank ``tp_allgather`` vote says some ranks must run eager (e.g.
     one rank is in prefill while others are in decode), all ranks enter this
     context for the call so captured graphs whose shapes happen to match are
-    bypassed too. Otherwise the captured kernel-launch args (notably the
-    ``int(batch_info_host[14].item())`` baked at capture time, where slot 14
-    holds ``max_dp_num_tokens`` per ``BatchInfo``) would diverge from the eager
-    ranks' fresh reads, corrupting the ``MoeAlltoAll`` collective.
+    bypassed too. Otherwise the captured kernel-launch args (notably the MoE
+    all-to-all ``runtime_max_tokens_per_rank``, derived from the capture-time
+    input shape) would diverge from the eager ranks' fresh reads, corrupting the
+    ``MoeAlltoAll`` collective.
     """
     cuda_graph_state.begin_bypass()
     try:

--- a/tensorrt_llm/_torch/auto_deploy/utils/multi_stream_utils.py
+++ b/tensorrt_llm/_torch/auto_deploy/utils/multi_stream_utils.py
@@ -238,10 +238,7 @@ def begin_aux_stream_passthrough(
     # record_stream is the idiomatic PyTorch solution for this cross-stream
     # liveness problem: it is a CPU-only allocator hint, never a GPU sync,
     # so it cannot deadlock with in-flight NCCL collectives.
-    # NOTE: skip during CUDA graph capture — passthrough partitions are
-    # reclassified as dynamic and won't be captured anyway.
-    if not torch.cuda.is_current_stream_capturing():
-        _record_stream_for_tensor_outputs(x, aux_stream)
+    _record_stream_for_tensor_outputs(x, aux_stream)
     torch.cuda.set_stream(aux_stream)
     # Make aux wait for the main-stream event before executing any work.
     aux_stream.wait_event(main_event)

--- a/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
+++ b/tests/integration/defs/accuracy/test_llm_api_autodeploy.py
@@ -819,6 +819,8 @@ class TestNemotronSuperV3(LlmapiAccuracyTestHarness):
                 **kwargs,
         ) as llm:
             _set_quant_config(llm, model_id)
+            # The NVFP4 Super V3 checkpoint is mixed precision; resolve gsm8k
+            # thresholds against the MIXED_PRECISION reference (matches test_accuracy).
             if model_id == "nvfp4":
                 llm.args.quant_config.quant_algo = QuantAlgo.MIXED_PRECISION
             print_memory_usage("after engine build")

--- a/tests/unittest/auto_deploy/multigpu/compile/test_bypass_captured_graphs.py
+++ b/tests/unittest/auto_deploy/multigpu/compile/test_bypass_captured_graphs.py
@@ -12,12 +12,12 @@ Guards both layers of the fix that landed in PR #13723 for the conc=32 NaN
 regression on MoE all-to-all under attention-DP:
 
   Level 1 (leaf): ``CapturedGraph.forward`` honours the
-    ``BypassCapturedGraphs()`` context manager. A Python int read inside the
-    captured graph (``int(host_tensor[0].item())``, mirroring
-    ``int(batch_info_host[14].item())`` in ``trtllm_moe.py``, where slot 14 of
-    ``BatchInfo`` is ``max_dp_num_tokens``) is baked into the captured
-    kernel-launch as a scalar argument. Replay reuses it regardless of
-    post-capture host updates. While inside ``BypassCapturedGraphs()`` (i.e.
+    ``BypassCapturedGraphs()`` context manager. A capture-time scalar read inside
+    the captured graph (``int(host_tensor[0].item())``, mirroring how the MoE
+    all-to-all op in ``trtllm_moe.py`` derives ``runtime_max_tokens_per_rank``
+    from the capture-time input shape) is baked into the captured kernel-launch as
+    a scalar argument. Replay reuses it regardless of post-capture host updates.
+    While inside ``BypassCapturedGraphs()`` (i.e.
     ``cuda_graph_state.in_bypass() == True``), the wrapper short-circuits to
     eager and reads the host fresh.
 
@@ -27,7 +27,7 @@ regression on MoE all-to-all under attention-DP:
     Captured graphs whose shapes happen to match are bypassed too — this is the
     actual cross-rank divergence the conc=32 NaN bug exposed when one rank ran
     prefill (eager) while another ran decode (replay) with a stale capture-time
-    ``max_dp_num_tokens``.
+    ``runtime_max_tokens_per_rank``.
 
 The cross-rank decision is propagated via the process-wide
 ``cuda_graph_state.BYPASS`` flag toggled by ``BypassCapturedGraphs()``, NOT by
@@ -53,7 +53,7 @@ from tensorrt_llm._torch.auto_deploy.utils.cuda_graph import BypassCapturedGraph
 
 
 class _SlotReadingModel(nn.Module):
-    """Mimics the ``int(batch_info_host[14].item())`` scalar read in the MoE A2A op.
+    """Mimics a capture-time scalar read baked into the MoE A2A op's kernel launch.
 
     The Python int returned by ``.item()`` is consumed as a kernel-launch
     argument by ``torch.full``; under cuda graph capture that argument value is
@@ -82,9 +82,8 @@ def _run_bypass_test(rank: int, world_size: int) -> None:
     capture_bs = [1, 2, 4]
 
     def get_args_kwargs(bs: int):
-        # Mimic ``SequenceInfo.set_capture_batch`` seeding ``max_dp_num_tokens``
-        # with the local total at capture time. Each captured graph thus bakes
-        # its own value.
+        # Mimic the MoE A2A op deriving its per-rank dispatch budget from the
+        # capture-time input shape. Each captured graph thus bakes its own value.
         host[0] = bs
         return (torch.zeros(bs, device=device),), {}
 

--- a/tests/unittest/auto_deploy/singlegpu/models/test_eagle.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_eagle.py
@@ -17,6 +17,7 @@
 
 from pathlib import Path
 from typing import Any, ClassVar, Dict
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -31,6 +32,7 @@ from tensorrt_llm._torch.auto_deploy.models.custom.modeling_eagle import (
     EagleConfig,
     EagleDrafterForCausalLM,
     EagleRMSNorm,
+    EagleWrapper,
 )
 from tensorrt_llm._torch.auto_deploy.models.eagle import EagleDrafterFactory
 from tensorrt_llm._torch.auto_deploy.models.factory import ModelFactoryRegistry
@@ -324,3 +326,51 @@ def test_infer_draft_hidden_size_from_exported_draft_graph(
     embd, in_eagle_drafter = infer_draft_embedding_size(gm, linear_nodes)
     assert embd == hidden_size
     assert in_eagle_drafter is expected_is_eagle
+
+
+###############################################################################
+# sample_greedy broadcast gating (regression for #13134 + attention-DP fix).
+#
+# - TP replication: argmax across ranks can diverge due to FP noise; the
+#   broadcast keeps acceptance patterns consistent.
+# - Attention-DP: each rank holds a different slice of the global batch, so
+#   per-rank tokens are legitimately different and the broadcast would
+#   corrupt peers' state. The gate is `EagleWrapperConfig.enable_attention_dp`,
+#   plumbed through to `EagleWrapper.enable_attention_dp`.
+###############################################################################
+
+
+def _make_bare_wrapper(enable_attention_dp: bool) -> EagleWrapper:
+    """Construct a minimally-initialized EagleWrapper for testing sample_greedy.
+
+    sample_greedy only reads self.enable_attention_dp; bypass __init__ to avoid
+    requiring a real target/draft submodule pair.
+    """
+    wrapper = EagleWrapper.__new__(EagleWrapper)
+    wrapper.enable_attention_dp = enable_attention_dp
+    return wrapper
+
+
+def test_sample_greedy_skips_broadcast_under_attention_dp():
+    wrapper = _make_bare_wrapper(enable_attention_dp=True)
+    logits = torch.tensor([[0.1, 0.9], [0.8, 0.2]])
+    with patch("tensorrt_llm._torch.auto_deploy.models.custom.modeling_eagle.broadcast") as mock_bc:
+        ret = wrapper.sample_greedy(logits)
+
+    mock_bc.assert_not_called()
+    assert ret.tolist() == [1, 0]
+
+
+def test_sample_greedy_broadcasts_under_tp_replication():
+    wrapper = _make_bare_wrapper(enable_attention_dp=False)
+    logits = torch.tensor([[0.1, 0.9], [0.8, 0.2]])
+    with patch("tensorrt_llm._torch.auto_deploy.models.custom.modeling_eagle.broadcast") as mock_bc:
+        ret = wrapper.sample_greedy(logits)
+
+    mock_bc.assert_called_once()
+    args, kwargs = mock_bc.call_args
+    # `broadcast(ret, src=0)` -- positional ret, src may be kwarg or positional.
+    assert args[0] is ret
+    src = kwargs.get("src", args[1] if len(args) > 1 else None)
+    assert src == 0
+    assert ret.tolist() == [1, 0]

--- a/tests/unittest/auto_deploy/singlegpu/shim/test_create_ad_executor.py
+++ b/tests/unittest/auto_deploy/singlegpu/shim/test_create_ad_executor.py
@@ -63,6 +63,8 @@ class MockPyExecutor:
     max_input_len: int
     max_batch_size: int
     max_beam_width: int
+    max_draft_len: int
+    max_total_draft_tokens: int
     guided_decoder: Any
     kv_cache_transceiver: Any = None
     resource_governor_queue: Any = None

--- a/tests/unittest/auto_deploy/singlegpu/utils/test_multi_stream_utils.py
+++ b/tests/unittest/auto_deploy/singlegpu/utils/test_multi_stream_utils.py
@@ -19,6 +19,7 @@ turns every passthrough / aux-stream impl into a pure pass-through that
 never touches the CUDA stream manager.
 """
 
+import pytest
 import torch
 
 from tensorrt_llm._torch.auto_deploy.utils import multi_stream_utils as msu
@@ -100,3 +101,49 @@ class TestDisableMultiStream:
 
         assert out == "ok"
         assert called == [((1, 2), {"key": "v"})]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+class TestRecordStreamDuringCudaGraphCapture:
+    """Regression guard for the multi-stream record_stream fix.
+
+    In the monolithic decode CUDA-graph path the aux-stream passthroughs are
+    captured (multi-stream stays enabled). ``begin_aux_stream_passthrough`` MUST
+    call ``record_stream`` on its tensor outputs *even during CUDA graph capture*,
+    otherwise the caching allocator frees ``x``'s block after the main stream's
+    last use and recycles it for a later allocation inside the same captured
+    graph, before the aux-stream shared-expert work has read it. That silently
+    corrupts the shared-expert input on replay -> garbage logits -> no-EOS
+    runaway generation (reproduced as 24/24 batch-1 requests running to
+    max_tokens on SuperV3-MTP with multi_stream_moe enabled).
+
+    A previous version skipped record_stream while capturing
+    (``if not torch.cuda.is_current_stream_capturing(): ...``). This test fails
+    if that guard is ever reintroduced.
+    """
+
+    def test_records_stream_even_while_capturing(self, monkeypatch):
+        device = torch.cuda.current_device()
+        msu.cuda_stream_manager.add_device(device)
+
+        recorded = []
+        monkeypatch.setattr(
+            msu, "_record_stream_for_tensor_outputs", lambda t, stream: recorded.append((t, stream))
+        )
+        # Simulate being inside CUDA graph capture without actually capturing,
+        # so the surrounding stream bookkeeping still executes normally.
+        monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+
+        x = torch.randn(8, device="cuda")
+        try:
+            out = msu.begin_aux_stream_passthrough(x, device=device)
+        finally:
+            # begin_aux switches the current stream to aux; restore the default.
+            torch.cuda.set_stream(torch.cuda.default_stream(device))
+
+        assert out is x
+        assert len(recorded) == 1, (
+            "begin_aux_stream_passthrough must call record_stream during CUDA "
+            "graph capture (regression of the multi-stream record_stream fix)"
+        )
+        assert recorded[0][0] is x


### PR DESCRIPTION
## Description

Optimizes the SuperV3 MTP + attention-DP path, building on the recently merged
MoE all-to-all stateful cache (#13718 / #13723) and the SSM-replay PR.

**MoE all-to-all per-rank token budget (`runtime_max_tokens_per_rank`)**
- Replaces the per-iteration cross-rank-max read (an `int(batch_info_host[14].item())`
  on a pinned-host tensor, fed by a per-forward `tp_allgather`) with a sync-free,
  shape-based budget via `_hybrid_runtime_max_tokens_per_rank`:
  - Under cuda-graph capture/warm-up the budget is `x.shape[0]` — uniform across DP
    ranks because `maybe_pad_for_cuda_graph` pads every rank to a common
    `cg_batch_size` and MTP tokens-per-seq is uniform — gated so the tight budget is
    only taken while the MoE-GEMM row count stays in the fast small-M tactic region.
  - In eager (prefill, or any step the mixed-mode bypass forces eager) it falls back
    to the static `max_num_tokens`, which every rank computes identically.
  - No per-layer host read, and no extra collective.
- Drops the now-dead `batch_info_host` DP-max plumbing: the slot-14 (`max_dp_num_tokens`)
  storage + accessors in `BatchInfo` (`_NUM_ELEMENTS` 15→14), the pre-forward
  `tp_allgather`+update in the AutoDeploy shim, the injection into the MoE op in both
  the dict-based (`sharding.py`) and IR-based (`sharding_ir.py`) sharding paths, and the
  corresponding op signatures in `trtllm_moe.py` / `torch_moe.py`.

**Scheduling / sharding**
- Keeps the draft-EP revert under attention-DP in sharding (replicate the draft model's
  MoE rather than EP-sharding it) to avoid the shared-workspace corruption that hangs the
  all-to-all at concurrency.

Mixed-mode cuda-graph bypass uses the process-wide `BypassCapturedGraphs()` context
manager (`cuda_graph_state.in_bypass()`), keeping all ranks consistent when one is in prefill.

## Perf Impact
see: https://github.com/NVIDIA/TensorRT-LLM/issues/14225#issuecomment-4601016969

## Test Coverage

- `tests/integration/defs/accuracy/test_llm_api_autodeploy.py::TestNemotronSuperV3::test_mtp[*]`
  and `::test_accuracy[*-4-attn_dp_on-trtllm]` (bf16/fp8/nvfp4) — exercise the MTP +
  attention-DP MoE all-to-all path.
- `tests/unittest/auto_deploy/multigpu/compile/test_bypass_captured_graphs.py` — guards the
  mixed-mode captured-graph bypass.
- New perf-sanity config + post-merge enrollment:
  `perf/test_perf_sanity.py::test_e2e[aggr_upload-super_mtp_ad_nvfp4_blackwell-super_mtp_ad_nvfp4_ws4_1k1k]`.
- Local e2e validation (4× GB200, TP4, BF16 SuperV3-MTP, attention-DP): builds end-to-end
  with no NaN / hang / all-to-all timeout; GSM8K 47/50 = 94.0%.

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added low-latency SuperV3 MTP configuration optimized for reduced serving latency.

* **Configuration Updates**
  * Enhanced SuperV3 MTP configuration with batch-size targets and attention-DP support.
  * Updated speculative decoding (Eagle) to properly handle attention-DP mode.

* **Performance Improvements**
  * Optimized MoE all-to-all dispatch to use actual token counts instead of padded estimates, reducing overhead.
  * Streamlined batch metadata handling for more efficient attention computation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->