### PR TITLE
[None][fix] Generalize FP8 checkpoint loading for Qwen3.5

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_5_weight_mapper.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/qwen3_5_weight_mapper.py
@@ -10,6 +10,9 @@ from tensorrt_llm._torch.models.checkpoints.hf.qwen3_next_weight_mapper import (
 )
 from tensorrt_llm._torch.models.modeling_utils import register_mapper
 from tensorrt_llm._torch.modules.fused_moe.interface import MoE, MoEWeightLoadingMode
+from tensorrt_llm.quantization import QuantAlgo
+
+_FP8_2D_BLOCK_SIZE = 128
 
 
 @register_mapper("HF", "Qwen3_5MoeForCausalLM")
@@ -45,7 +48,6 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
     """
 
     _SPLIT_PROJ_PATTERN = re.compile(r"^(.*\.linear_attn)\.in_proj_(qkv|q|k|v|z|b|a)\.(.+)$")
-    _SUPPORTED_SUFFIXES = {"weight", "bias", "weight_scale_inv"}
     _DENSE_MLP_PATTERN = re.compile(
         r"^((?:model|mtp)\.layers\.\d+\.mlp)\.(gate_proj|up_proj|down_proj|gate_up_proj)(\..+)$"
     )
@@ -60,26 +62,42 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
             normalized_weights[key] = tensor
         return normalized_weights
 
-    def _preprocess_modelopt_ckpt(self, weights: dict) -> tuple[bool, dict]:
-        nvfp4_prefixes = {
-            key[: -len(".weight_scale_2")] for key in weights if key.endswith(".weight_scale_2")
-        }
+    def _normalize_scale_names(self, weights: dict, quant_algo) -> tuple[dict, bool]:
+        # Canonicalize FP8 weight_scale layout so the Linear loader sees one
+        # shape per quant algo:
+        #   - FP8_BLOCK_SCALES: modelopt fp8_pb_wo stores weight_scale shaped
+        #     [blocks_out, 1, blocks_in, 1]; squeeze to [blocks_out, blocks_in]
+        #     and rename to weight_scale_inv. Returns is_modelopt_pb_wo=True
+        #     so the caller can keep modelopt's native FP8 path.
+        #   - FP8_PER_CHANNEL_PER_TOKEN: compressed-tensors stores weight_scale
+        #     shaped [out, 1]; squeeze to 1-D [out].
+
+        is_modelopt_pb_wo = False
+        if quant_algo not in (QuantAlgo.FP8_BLOCK_SCALES, QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN):
+            return weights, is_modelopt_pb_wo
 
         remapped_weights = {}
-        is_modelopt_ckpt = False
         for key, tensor in weights.items():
-            new_key = key
             if key.endswith(".weight_scale"):
-                is_modelopt_ckpt = True
-                prefix = key[: -len(".weight_scale")]
-                if prefix not in nvfp4_prefixes:
-                    new_key = f"{key}_inv"
-                    # modelopt fp8_pb_wo has 2 extra singleton dimensions
+                if quant_algo == QuantAlgo.FP8_BLOCK_SCALES and tensor.ndim == 4:
+                    assert tensor.shape[1] == 1 and tensor.shape[-1] == 1, (
+                        f"Expected scale shape [*, 1, *, 1] for {key}, got {tuple(tensor.shape)}"
+                    )
                     tensor = tensor.squeeze(1).squeeze(-1)
-            if new_key in remapped_weights:
-                raise ValueError(f"Duplicate remapped key found: {new_key}")
-            remapped_weights[new_key] = tensor
-        return is_modelopt_ckpt, remapped_weights
+                    # Rename so downstream packing and linear-attn dequant can
+                    # detect 2D-block scales by suffix alone.
+                    key = key[: -len("weight_scale")] + "weight_scale_inv"
+                    is_modelopt_pb_wo = True
+                elif (
+                    quant_algo == QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN
+                    and tensor.ndim == 2
+                    and tensor.shape[1] == 1
+                ):
+                    tensor = tensor.squeeze(-1)
+            if key in remapped_weights:
+                raise ValueError(f"Duplicate remapped key found: {key}")
+            remapped_weights[key] = tensor
+        return remapped_weights, is_modelopt_pb_wo
 
     def handle_special_instance_module(
         self,
@@ -154,8 +172,8 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
     def _split_qkv_scale_tensor(
         self, tensor: torch.Tensor, expected_q: int, expected_v: int
     ) -> tuple[torch.Tensor, ...]:
-        expected_q_blocks = math.ceil(expected_q / 128)
-        expected_v_blocks = math.ceil(expected_v / 128)
+        expected_q_blocks = math.ceil(expected_q / _FP8_2D_BLOCK_SIZE)
+        expected_v_blocks = math.ceil(expected_v / _FP8_2D_BLOCK_SIZE)
         expected_total_blocks = expected_q_blocks * 2 + expected_v_blocks
         assert tensor.shape[0] == expected_total_blocks, (
             f"Expected packed qkv scale tensor with leading dim {expected_total_blocks}, "
@@ -169,8 +187,8 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
         rows, cols = weight.shape
         expanded_scales = (
             weight_scale_inv.to(torch.float32)
-            .repeat_interleave(128, dim=0)
-            .repeat_interleave(128, dim=1)[:rows, :cols]
+            .repeat_interleave(_FP8_2D_BLOCK_SIZE, dim=0)
+            .repeat_interleave(_FP8_2D_BLOCK_SIZE, dim=1)[:rows, :cols]
         )
         target_dtype = getattr(self.config.pretrained_config, "torch_dtype", torch.bfloat16)
         if target_dtype is None:
@@ -216,12 +234,17 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
         expected_ba = config.linear_num_value_heads
 
         for (prefix, suffix), tensors in grouped_weights.items():
-            if suffix not in self._SUPPORTED_SUFFIXES:
-                raise NotImplementedError(
-                    "Qwen3.5 split linear-attention packing currently "
-                    f"supports only {sorted(self._SUPPORTED_SUFFIXES)} tensors, "
-                    f"but found unsupported suffix '{suffix}' for {prefix}"
-                )
+            # `weight_scale_inv` (loaded by FP8BlockScalesLinearMethod) is the
+            # only suffix stored in 2D-block format [ceil(out/block_size), ceil(in/block_size)];
+            # weight/bias/weight_scale all keep out_features as their leading dim.
+            if suffix == "weight_scale_inv":
+                row_q = math.ceil(expected_q / _FP8_2D_BLOCK_SIZE)
+                row_v = math.ceil(expected_v / _FP8_2D_BLOCK_SIZE)
+                row_ba = math.ceil(expected_ba / _FP8_2D_BLOCK_SIZE)
+                split_packed_qkv = self._split_qkv_scale_tensor
+            else:
+                row_q, row_v, row_ba = expected_q, expected_v, expected_ba
+                split_packed_qkv = self._split_qkv_tensor
 
             qkvz_keys = {"qkv", "q", "k", "v", "z"} & tensors.keys()
             if qkvz_keys:
@@ -230,14 +253,9 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
                     assert not missing, (
                         f"Missing split projections {sorted(missing)} for {prefix}.{suffix}"
                     )
-                    if suffix == "weight_scale_inv":
-                        q_tensor, k_tensor, v_tensor = self._split_qkv_scale_tensor(
-                            tensors["qkv"], expected_q, expected_v
-                        )
-                    else:
-                        q_tensor, k_tensor, v_tensor = self._split_qkv_tensor(
-                            tensors["qkv"], expected_q, expected_v
-                        )
+                    q_tensor, k_tensor, v_tensor = split_packed_qkv(
+                        tensors["qkv"], expected_q, expected_v
+                    )
                 else:
                     missing = {"q", "k", "v", "z"} - tensors.keys()
                     assert not missing, (
@@ -247,16 +265,10 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
                     k_tensor = tensors["k"]
                     v_tensor = tensors["v"]
 
-                if suffix == "weight":
-                    assert q_tensor.shape[0] == expected_q
-                    assert k_tensor.shape[0] == expected_q
-                    assert v_tensor.shape[0] == expected_v
-                    assert tensors["z"].shape[0] == expected_v
-                elif suffix == "weight_scale_inv":
-                    assert q_tensor.shape[0] == math.ceil(expected_q / 128)
-                    assert k_tensor.shape[0] == math.ceil(expected_q / 128)
-                    assert v_tensor.shape[0] == math.ceil(expected_v / 128)
-                    assert tensors["z"].shape[0] == math.ceil(expected_v / 128)
+                assert q_tensor.shape[0] == row_q
+                assert k_tensor.shape[0] == row_q
+                assert v_tensor.shape[0] == row_v
+                assert tensors["z"].shape[0] == row_v
 
                 packed_name = f"{prefix}.in_proj_qkvz.{suffix}"
                 assert packed_name not in packed_weights, (
@@ -274,8 +286,8 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
                 )
 
                 if suffix == "weight":
-                    assert tensors["b"].shape[0] == expected_ba
-                    assert tensors["a"].shape[0] == expected_ba
+                    assert tensors["b"].shape[0] == row_ba
+                    assert tensors["a"].shape[0] == row_ba
 
                 packed_name = f"{prefix}.in_proj_ba.{suffix}"
                 assert packed_name not in packed_weights, (
@@ -303,11 +315,15 @@ class Qwen3_5MoeHfWeightMapper(Qwen3NextHfWeightMapper):
         return remapped_weights
 
     def preprocess_weights(self, weights: dict) -> dict:
+        quant_algo = self.config.quant_config.quant_algo
+
         normalized_weights = self._normalize_weight_names(weights)
-        is_modelopt_ckpt, normalized_weights = self._preprocess_modelopt_ckpt(normalized_weights)
+        normalized_weights, is_modelopt_pb_wo = self._normalize_scale_names(
+            normalized_weights, quant_algo
+        )
 
         packed_weights = self._pack_split_projections(normalized_weights)
-        if not is_modelopt_ckpt:
+        if quant_algo == QuantAlgo.FP8_BLOCK_SCALES and not is_modelopt_pb_wo:
             packed_weights = self._dequantize_linear_attn_fp8_qkvz(packed_weights)
 
         if not getattr(self.config.pretrained_config, "num_experts", 0):

--- a/tensorrt_llm/_torch/models/modeling_qwen3_5.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_5.py
@@ -90,6 +90,10 @@ def _normalize_qwen35_exclude_modules(model_config):
         name = re.sub(r"\.in_proj_(q|k|v|z|qkv)(\b|\*)", ".in_proj_qkvz*", name)
         normalized.add(name)
 
+    # gdn_mixer uses Linear module for weight management of depthwise conv1d
+    # but conv1d is not a proper linear module and should be excluded from quant
+    normalized.add("*linear_attn.conv1d")
+
     qc.exclude_modules = sorted(normalized)
 
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Qwen3.5 model checkpoint handling with improved tensor normalization and packing support.

* **Improvements**
  * Refined FP8 quantization weight-scale loading for improved consistency across different loading modes.
  * Updated quantization exclusion rules for linear attention modules in model configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Fixes few ad-hoc handling of weight shapes for Qwen3.5 FP8 checkpoints. 
After this PR, both FP8 blockwise and FP8 rowwise (per-token per-channel) checkpoints will be loaded correctly.

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

Existing FP8 test cases for Qwen3.5

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
