### PR TITLE
[https://nvbugs/6245861][fix] short-circuit _verify_ctx_response when CTX terminates early without KV handoff

### DIFF
--- a/tensorrt_llm/serve/openai_disagg_service.py
+++ b/tensorrt_llm/serve/openai_disagg_service.py
@@ -388,6 +388,18 @@ class OpenAIDisaggregatedService(OpenAIService):
                     f"Context server returned {len(ctx_response.choices)} choices, expecting 1."
                 )
             choice = ctx_response.choices[0]
+            # If CTX already terminated the request (e.g. EOS emitted during
+            # prefill / MTP draft), there is no KV handoff to verify — the
+            # response is complete and _need_gen() will short-circuit GEN.
+            # Only finish_reason in {"length", "not_finished"} implies a
+            # pending handoff to the gen server.
+            if choice.finish_reason not in ["length", "not_finished"]:
+                logger.debug(
+                    f"CTX response terminated early without KV handoff,"
+                    f" skipping disaggregated params verification."
+                    f" finish_reason={choice.finish_reason!r}"
+                )
+                return ctx_response
             if choice.disaggregated_params is None:
                 raise ValueError(
                     f"Context server did not return disaggregated params."


### PR DESCRIPTION
## Description

In `context_first` disaggregated serving, the CTX worker can finish a request entirely during prefill / MTP draft by emitting an EOS token before the KV-cache handoff is set up (observed on DeepSeek-R1 FP4 + MTP3 + NIXL, 1/640 = 0.16% of requests). The CTX response then carries `finish_reason='stop'` with `disaggregated_params.ctx_request_id=None` because no KV handoff is needed. `_verify_ctx_response` unconditionally required `ctx_request_id != None` and raised `ValueError`, surfacing as HTTP 500 to the client even though `_need_gen()` would otherwise correctly short-circuit the GEN call for this `finish_reason`.

## Root cause

`tensorrt_llm/serve/openai_disagg_service.py:397` — `_verify_ctx_response` only considered the `finish_reason='length'` / `'not_finished'` case (real KV handoff pending) and treated `ctx_request_id=None` as fatal in every other case.

```
ValueError: Invalid disaggregated params: ctx_request_id is None.
            finish_reason='stop', disagg_request_id=548424870944926
```

Regression from `7443f1d05f` (passed on `ee1fb68369`).

## Fix

In `_verify_ctx_response`, before checking `disaggregated_params`, return the CTX response unchanged when `choice.finish_reason not in ['length', 'not_finished']` — i.e. CTX has already terminated the request and there is no KV handoff to verify. This mirrors the semantic used by `_need_gen()`. A `logger.debug` records the early-termination short-circuit so it stays diagnosable.

## Test Coverage

L0 disagg perf-sanity test `disagg-e2e-gb200_deepseek-r1-fp4_128k8k_con64_ctx1_pp8_gen1_dep32_eplb0_mtp3_ccb-NIXL` covers this code path; no local cluster run.

## PR Checklist
- [x] Minimal targeted fix (single hunk, 12 lines)
- [x] No refactors / renames / drive-by edits
- [x] Matches existing file style (logger, f-strings, no docstring)

## Bug

nvbugs/6245861

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced request verification logic to skip unnecessary checks when the context server terminates requests prematurely, improving system efficiency and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->