### PR TITLE
[None][feat] Dis-agg content-derived conversation affinity

### DIFF
--- a/tensorrt_llm/serve/openai_client.py
+++ b/tensorrt_llm/serve/openai_client.py
@@ -89,7 +89,7 @@ class OpenAIClient(ABC):
         """Finish the request in the router.
 
         ``success`` lets the router distinguish completed vs failed requests
-        (e.g. for cache backfill).
+        (e.g. for routed-block tracking).
         """
         ...
 

--- a/tensorrt_llm/serve/router.py
+++ b/tensorrt_llm/serve/router.py
@@ -803,16 +803,19 @@ class BlockHashMixin:
     """
 
     def _init_block_hashing(self,
-                            tokens_per_block: int = 32,
+                            tokens_per_block: Optional[int] = None,
                             custom_tokenizer: Optional[str] = None):
         env_tokens_per_block = os.environ.get(
             "TRTLLM_KVCACHE_AWARE_ROUTER_HASH_TOKENS_PER_BLOCK")
         if env_tokens_per_block is not None:
             tokens_per_block = int(env_tokens_per_block)
-        self._tokens_per_block = tokens_per_block
+        self._tpb_auto = tokens_per_block is None
+        self._tokens_per_block = 32 if tokens_per_block is None \
+            else tokens_per_block
         self._tokenizers: dict = {}
         self._custom_tokenizer = custom_tokenizer
         logger.info(f"BlockHashMixin: tokens_per_block={self._tokens_per_block}"
+                    f"{' (auto, adopts worker)' if self._tpb_auto else ''}"
                     f", custom_tokenizer={self._custom_tokenizer}")
 
     def _get_tokenizer(self, model: str):
@@ -1001,7 +1004,7 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
                  metadata_server: JsonDictionary = None,
                  use_tokens: bool = False,
                  max_batch_size: int = 64,
-                 tokens_per_block: int = 32,
+                 tokens_per_block: Optional[int] = None,
                  custom_tokenizer: Optional[str] = None,
                  track_routed_blocks: bool = True,
                  load_weight: float = 0.25,
@@ -1066,7 +1069,14 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
             return
         info = self._server_info.get(server, {})
         worker_tpb = info.get("tokens_per_block")
-        if worker_tpb is not None and worker_tpb != self._tokens_per_block:
+        if worker_tpb is not None and getattr(self, "_tpb_auto", False):
+            if worker_tpb != self._tokens_per_block:
+                logger.info(
+                    "router tokens_per_block unset: adopting worker's %d on %s",
+                    worker_tpb, server)
+                self._tokens_per_block = worker_tpb
+            self._tpb_auto = False
+        elif worker_tpb is not None and worker_tpb != self._tokens_per_block:
             larger = max(worker_tpb, self._tokens_per_block)
             smaller = min(worker_tpb, self._tokens_per_block)
             if larger % smaller != 0:

--- a/tensorrt_llm/serve/router.py
+++ b/tensorrt_llm/serve/router.py
@@ -1003,7 +1003,7 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
                  max_batch_size: int = 64,
                  tokens_per_block: int = 32,
                  custom_tokenizer: Optional[str] = None,
-                 backfill_block_hashes_on_finish: bool = False,
+                 track_routed_blocks: bool = True,
                  load_weight: float = 0.25,
                  load_cap: float = float("inf"),
                  **kwargs):
@@ -1015,11 +1015,8 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
         self._max_batch_size = max_batch_size
         self._load_weight = load_weight
         self._load_cap = load_cap
-        # Opt-in workaround for the disagg-gen path that doesn't emit
-        # kv_cache_events. Stash hashes at routing, inject on finish.
-        self._backfill_block_hashes_on_finish = backfill_block_hashes_on_finish
-        self._inflight_backfill_hashes: dict[int, tuple[list[BlockHash],
-                                                        str]] = {}
+        self._track_routed_blocks = track_routed_blocks
+        self._pending_routed_blocks: dict[int, tuple[list[BlockHash], str]] = {}
 
     def _create_server_state(self, server: str) -> KvCacheAwareServerState:
         return KvCacheAwareServerState(server, self._use_tokens,
@@ -1031,19 +1028,20 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
             await state.cancel_poll_task()
         await super().close()
 
-    def _stash_backfill_on_route(self, request: OpenAIRequest,
-                                 block_hashes: list[list[BlockHash]],
-                                 hash_algo: str) -> None:
-        if not self._backfill_block_hashes_on_finish:
+    def _stash_routed_blocks_on_route(self, request: OpenAIRequest,
+                                      block_hashes: list[list[BlockHash]],
+                                      hash_algo: str) -> None:
+        if not self._track_routed_blocks:
             return
         flat = [h for hl in block_hashes for h in hl]
-        self._inflight_backfill_hashes[id(request)] = (flat, hash_algo)
+        self._pending_routed_blocks[id(request)] = (flat, hash_algo)
 
-    def _apply_backfill_on_finish(self, request: OpenAIRequest,
-                                  server: Optional[str], success: bool) -> None:
+    def _apply_routed_blocks_on_finish(self, request: OpenAIRequest,
+                                       server: Optional[str],
+                                       success: bool) -> None:
         # Pop unconditionally to avoid leaks; apply only when eligible.
-        entry = self._inflight_backfill_hashes.pop(id(request), None)
-        if not (self._backfill_block_hashes_on_finish and success):
+        entry = self._pending_routed_blocks.pop(id(request), None)
+        if not (self._track_routed_blocks and success):
             return
         if entry is None:
             return
@@ -1057,6 +1055,10 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
         # Lock-free attribute read; state is seeded at handshake and refreshed
         # by update_with_events.
         return self._server_state[server].hash_algo
+
+    def _events_aligned(self, server: str) -> bool:
+        worker_tpb = self._server_info.get(server, {}).get("tokens_per_block")
+        return worker_tpb is None or worker_tpb == self._tokens_per_block
 
     async def _prepare_server(self, server: str):
         await super()._prepare_server(server)
@@ -1077,9 +1079,9 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
                 )
             logger.warning(
                 "tokens_per_block mismatch on %s: router=%d worker=%d. "
-                "KV events from worker will not align with router block hashes; "
-                "use backfill_block_hashes_on_finish=true for best hit rate.",
-                server, self._tokens_per_block, worker_tpb)
+                "KV events from worker cannot align with router block hashes; "
+                "skipping event polling and relying on routed-block tracking "
+                "for hit rate.", server, self._tokens_per_block, worker_tpb)
         worker_algo = info.get("kv_cache_hash_algo")
         known_algos = {
             KV_CACHE_HASH_ALGO_V1,
@@ -1202,7 +1204,7 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
         block_hashes = block_hashes_by_algo[hash_algo]
         async with self._lock:
             await self._register_request(server, request)
-            self._stash_backfill_on_route(request, block_hashes, hash_algo)
+            self._stash_routed_blocks_on_route(request, block_hashes, hash_algo)
         return server, {
             "block_hashes": block_hashes,  # list[list[int | str]]
             "hash_algo": hash_algo,
@@ -1219,8 +1221,9 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
             server = self._req_routing_table.pop(id(request), None)
             if server is not None and server in self._server_state:
                 await self._server_state[server].decrement_load(request)
-        self._apply_backfill_on_finish(request, server, success)
-        if server is not None and server in self._server_state:
+        self._apply_routed_blocks_on_finish(request, server, success)
+        if (server is not None and server in self._server_state
+                and self._events_aligned(server)):
             # Fire-and-forget; poll runs in background and coalesces per server.
             self._server_state[server].schedule_poll_and_update(session)
 

--- a/tensorrt_llm/serve/router.py
+++ b/tensorrt_llm/serve/router.py
@@ -53,6 +53,9 @@ BlockHash = Union[int, str]
 
 # Max number of conversations whose home-server pin is retained (LRU).
 ROUTE_AFFINITY_CACHE_SIZE = 50000
+# Leading token-id count folded into the affinity key so pre-tokenized
+# requests (placeholder message content) still key per conversation.
+ROUTE_AFFINITY_TOKEN_PREFIX = 256
 
 
 def get_request_num_tokens(request: OpenAIRequest) -> int:
@@ -1108,6 +1111,9 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
             content = (message.get("content") if isinstance(message, dict) else
                        getattr(message, "content", ""))
             parts.append(str(content))
+        token_ids = getattr(request, "prompt_token_ids", None)
+        if token_ids:
+            parts.append(str(list(token_ids[:ROUTE_AFFINITY_TOKEN_PREFIX])))
         return hash("".join(parts))
 
     async def get_next_server(

--- a/tensorrt_llm/serve/router.py
+++ b/tensorrt_llm/serve/router.py
@@ -51,6 +51,9 @@ truncate_sha256_hash_to_int64 = kv_cache_hash.truncate_sha256_hash_to_int64
 OpenAIRequest = Union[CompletionRequest, ChatCompletionRequest]
 BlockHash = Union[int, str]
 
+# Max number of conversations whose home-server pin is retained (LRU).
+ROUTE_AFFINITY_CACHE_SIZE = 50000
+
 
 def get_request_num_tokens(request: OpenAIRequest) -> int:
     if request.disaggregated_params is None or request.disaggregated_params.request_type == "context_only":
@@ -1095,6 +1098,18 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
             # Persist once so per-request reads can skip the lock+await.
             self._server_state[server].set_hash_algo(worker_algo)
 
+    @staticmethod
+    def _content_affinity_key(request: OpenAIRequest) -> Optional[int]:
+        messages = getattr(request, "messages", None)
+        if not messages:
+            return None
+        parts = []
+        for message in messages[:2]:
+            content = (message.get("content") if isinstance(message, dict) else
+                       getattr(message, "content", ""))
+            parts.append(str(content))
+        return hash("".join(parts))
+
     async def get_next_server(
             self,
             request: OpenAIRequest,
@@ -1150,11 +1165,33 @@ class KvCacheAwareRouter(BlockHashMixin, LoadBalancingMixin, Router):
         ]
         if not candidate_idx:
             candidate_idx = list(range(len(servers)))
-        max_score = max(scores[i] for i in candidate_idx)
-        tied = [i for i in candidate_idx if scores[i] == max_score]
-        winner = tied[self._rr_counter % len(tied)]
+        # Conversation affinity: pin all turns of a conversation (keyed by a
+        # content-derived prefix hash, no conversation-id header) to the server
+        # it first landed on, so a worker eviction shrinking the match score
+        # cannot scatter the conversation off its warm home. New conversations
+        # (no pin yet) fall through to the score, which balances them by load.
+        affinity = getattr(self, "_route_affinity", None)
+        if affinity is None:
+            affinity = self._route_affinity = OrderedDict()
+        conv_key = self._content_affinity_key(request)
+        winner = None
+        if conv_key is not None:
+            pinned = affinity.get(conv_key)
+            if pinned in servers:
+                pinned_idx = servers.index(pinned)
+                if pinned_idx in candidate_idx:
+                    winner = pinned_idx
+        if winner is None:
+            max_score = max(scores[i] for i in candidate_idx)
+            tied = [i for i in candidate_idx if scores[i] == max_score]
+            winner = tied[self._rr_counter % len(tied)]
         self._rr_counter += 1
         server = servers[winner]
+        if conv_key is not None:
+            affinity[conv_key] = server
+            affinity.move_to_end(conv_key)
+            while len(affinity) > ROUTE_AFFINITY_CACHE_SIZE:
+                affinity.popitem(last=False)
         hash_algo = hash_algo_by_server[server]
         block_hashes = block_hashes_by_algo[hash_algo]
         async with self._lock:

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_conditional_deepseek_v3_v2.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_conditional_deepseek_v3_v2.yaml
@@ -28,9 +28,9 @@ generation_servers:
   pipeline_parallel_size: 1
   router:
     type: kv_cache_aware
-    # disagg-gen path doesn't emit kv_cache_events; backfill router-side state from
+    # disagg-gen path doesn't emit kv_cache_events; track router-side state from
     # successfully-routed requests so conditional_disagg can actually trigger.
-    backfill_block_hashes_on_finish: true
+    track_routed_blocks: true
   kv_cache_config:
     enable_block_reuse: true
     enable_partial_reuse: true

--- a/tests/unittest/disaggregated/test_disagg_openai_client.py
+++ b/tests/unittest/disaggregated/test_disagg_openai_client.py
@@ -225,7 +225,7 @@ class TestOpenAIHttpClient:
             await openai_client.send_request(completion_request)
 
         # Should finish request on error with success=False so the router
-        # doesn't backfill cache state for a request that didn't complete.
+        # doesn't record routed-block cache state for a request that didn't complete.
         mock_router.finish_request.assert_called_once_with(
             completion_request, mock_session, success=False
         )

--- a/tests/unittest/disaggregated/test_router.py
+++ b/tests/unittest/disaggregated/test_router.py
@@ -1992,3 +1992,54 @@ def test_prefix_cache_tokenize_falls_back_on_divergent_prefix(servers):
                 tokenize=False)
             reference = tok.encode(rendered, add_special_tokens=False)
             assert router._tokenize(req)[0] == reference
+
+
+@pytest.mark.asyncio
+async def test_conversation_affinity_pins_across_load(servers):
+    router = KvCacheAwareRouter(server_role=None,
+                                servers=servers,
+                                tokens_per_block=4,
+                                load_weight=1.0)
+    tok = mock.MagicMock()
+    tok.apply_chat_template.return_value = [1, 2, 3, 4, 5, 6, 7, 8]
+    convo = [{
+        "role": "system",
+        "content": "S"
+    }, {
+        "role": "user",
+        "content": "u1"
+    }]
+    with mock.patch.object(router, "_get_tokenizer", return_value=tok):
+        req1 = ChatCompletionRequest(model="m",
+                                     messages=[dict(m) for m in convo])
+        home, _ = await router.get_next_server(req1)
+        # Saturate the home server so a fresh request would avoid it.
+        for _ in range(64):
+            await router._server_state[home].increment_load(
+                ChatCompletionRequest(model="m",
+                                      messages=[{
+                                          "role": "user",
+                                          "content": "x"
+                                      }]))
+        # Same conversation (same first-2-message content) -> pinned to home
+        # even though the score now favours the idle servers.
+        req2 = ChatCompletionRequest(model="m",
+                                     messages=[dict(m) for m in convo] +
+                                     [{
+                                         "role": "assistant",
+                                         "content": "a1"
+                                     }, {
+                                         "role": "user",
+                                         "content": "u2"
+                                     }])
+        assert (await router.get_next_server(req2))[0] == home
+        # A different conversation is free to avoid the saturated home.
+        req3 = ChatCompletionRequest(model="m",
+                                     messages=[{
+                                         "role": "system",
+                                         "content": "OTHER"
+                                     }, {
+                                         "role": "user",
+                                         "content": "v1"
+                                     }])
+        assert (await router.get_next_server(req3))[0] != home

--- a/tests/unittest/disaggregated/test_router.py
+++ b/tests/unittest/disaggregated/test_router.py
@@ -1020,6 +1020,44 @@ async def test_kv_cache_aware_router_prepare_server_keeps_when_worker_omits_tpb(
 
 
 @pytest.mark.asyncio
+async def test_kv_cache_aware_router_prepare_server_adopts_worker_tpb_when_unset(
+):
+    router = KvCacheAwareRouter(server_role=None, servers=["server-a"])
+    assert router._tpb_auto is True
+    assert router._tokens_per_block == 32
+
+    async def fake_fetch(server, timeout):
+        return {"tokens_per_block": 128, "kv_cache_hash_algo": "v1_block_key"}
+
+    with mock.patch.object(router, "_fetch_server_info",
+                           side_effect=fake_fetch):
+        await router._prepare_server("server-a")
+
+    assert "server-a" in router._prepared_ready_servers
+    assert router._tokens_per_block == 128
+    assert router._tpb_auto is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("worker_tpb", [32, 64, 128])
+async def test_kv_cache_aware_router_auto_tpb_equals_worker(worker_tpb):
+    router = KvCacheAwareRouter(server_role=None, servers=["server-a"])
+
+    async def fake_fetch(server, timeout):
+        return {
+            "tokens_per_block": worker_tpb,
+            "kv_cache_hash_algo": "v1_block_key"
+        }
+
+    with mock.patch.object(router, "_fetch_server_info",
+                           side_effect=fake_fetch):
+        await router._prepare_server("server-a")
+
+    assert router._tokens_per_block == worker_tpb
+    assert "server-a" in router._prepared_ready_servers
+
+
+@pytest.mark.asyncio
 async def test_kv_cache_aware_router_prepare_server_warns_on_missing_algo():
     router = KvCacheAwareRouter(server_role=None,
                                 servers=["server-a"],

--- a/tests/unittest/disaggregated/test_router.py
+++ b/tests/unittest/disaggregated/test_router.py
@@ -784,8 +784,7 @@ def test_kv_cache_aware_server_state_remove_blocks_silent_on_missing():
 
 
 @pytest.mark.asyncio
-async def test_kv_cache_aware_router_backfill_stashes_flat_list_at_routing(
-        servers):
+async def test_kv_cache_aware_router_tracks_routed_blocks_at_routing(servers):
     tokens_per_block = 4
     token_lists = [[1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008]]
     router = KvCacheAwareRouter(server_role=None,
@@ -793,25 +792,25 @@ async def test_kv_cache_aware_router_backfill_stashes_flat_list_at_routing(
                                 use_tokens=False,
                                 max_batch_size=32,
                                 tokens_per_block=tokens_per_block,
-                                backfill_block_hashes_on_finish=True)
+                                track_routed_blocks=True)
 
     request = CompletionRequest(model="TinyLlama",
                                 prompt=copy.deepcopy(token_lists))
     server, info = await router.get_next_server(request)
 
-    assert id(request) in router._inflight_backfill_hashes
-    stashed, stashed_algo = router._inflight_backfill_hashes[id(request)]
+    assert id(request) in router._pending_routed_blocks
+    stashed, stashed_algo = router._pending_routed_blocks[id(request)]
     expected_flat = [h for hl in info["block_hashes"] for h in hl]
     assert stashed == expected_flat
     assert stashed and not isinstance(stashed[0], list)
     assert stashed_algo == info["hash_algo"]
 
     await router.finish_request(request)
-    assert id(request) not in router._inflight_backfill_hashes
+    assert id(request) not in router._pending_routed_blocks
 
 
 @pytest.mark.asyncio
-async def test_kv_cache_aware_router_backfill_inserts_blocks_on_finish(servers):
+async def test_kv_cache_aware_router_inserts_routed_blocks_on_finish(servers):
     tokens_per_block = 4
     token_lists = [[2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008]]
     router = KvCacheAwareRouter(server_role=None,
@@ -819,7 +818,7 @@ async def test_kv_cache_aware_router_backfill_inserts_blocks_on_finish(servers):
                                 use_tokens=False,
                                 max_batch_size=32,
                                 tokens_per_block=tokens_per_block,
-                                backfill_block_hashes_on_finish=True)
+                                track_routed_blocks=True)
 
     request = CompletionRequest(model="TinyLlama",
                                 prompt=copy.deepcopy(token_lists))
@@ -839,20 +838,22 @@ async def test_kv_cache_aware_router_backfill_inserts_blocks_on_finish(servers):
 
 
 @pytest.mark.asyncio
-async def test_kv_cache_aware_router_backfill_disabled_skips_pending(servers):
+async def test_kv_cache_aware_router_routed_blocks_disabled_skips_pending(
+        servers):
     tokens_per_block = 4
     token_lists = [[3000, 3001, 3002, 3003, 3004, 3005, 3006, 3007, 3008]]
     router = KvCacheAwareRouter(server_role=None,
                                 servers=servers,
                                 use_tokens=False,
                                 max_batch_size=32,
-                                tokens_per_block=tokens_per_block)
+                                tokens_per_block=tokens_per_block,
+                                track_routed_blocks=False)
 
     request = CompletionRequest(model="TinyLlama",
                                 prompt=copy.deepcopy(token_lists))
     server, info = await router.get_next_server(request)
 
-    assert router._inflight_backfill_hashes == {}
+    assert router._pending_routed_blocks == {}
 
     await router.finish_request(request)
 
@@ -861,7 +862,7 @@ async def test_kv_cache_aware_router_backfill_disabled_skips_pending(servers):
 
 
 @pytest.mark.asyncio
-async def test_kv_cache_aware_router_backfill_drops_on_failure(servers):
+async def test_kv_cache_aware_router_drops_routed_blocks_on_failure(servers):
     tokens_per_block = 4
     token_lists = [[4000, 4001, 4002, 4003, 4004, 4005, 4006, 4007, 4008]]
     router = KvCacheAwareRouter(server_role=None,
@@ -869,16 +870,16 @@ async def test_kv_cache_aware_router_backfill_drops_on_failure(servers):
                                 use_tokens=False,
                                 max_batch_size=32,
                                 tokens_per_block=tokens_per_block,
-                                backfill_block_hashes_on_finish=True)
+                                track_routed_blocks=True)
 
     request = CompletionRequest(model="TinyLlama",
                                 prompt=copy.deepcopy(token_lists))
     server, info = await router.get_next_server(request)
-    assert id(request) in router._inflight_backfill_hashes
+    assert id(request) in router._pending_routed_blocks
 
     await router.finish_request(request, success=False)
 
-    assert id(request) not in router._inflight_backfill_hashes
+    assert id(request) not in router._pending_routed_blocks
     assert await router._server_state[server].matched_tokens(
         info["block_hashes"], hash_algo=info["hash_algo"]) == 0
 
@@ -1094,7 +1095,8 @@ async def test_kv_cache_aware_router(servers, mock_aiohttp_session):
                                 servers=servers,
                                 use_tokens=False,
                                 max_batch_size=32,
-                                tokens_per_block=32)
+                                tokens_per_block=32,
+                                track_routed_blocks=False)
     results = [await router.get_next_server(req) for req in requests]
     assigned_servers, infos = zip(*results)
     # Initial routing (empty caches): all 3 should get distinct servers


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the routing logic in `tensorrt_llm/serve/router.py`, focusing on more robust and configurable tracking of routed blocks, improved conversation affinity for server assignment, and enhanced flexibility in `tokens_per_block` configuration. It also updates related tests and documentation to reflect these changes.

**Routing and cache tracking improvements:**

* Replaces the `backfill_block_hashes_on_finish` mechanism with a more general `track_routed_blocks` option, renaming all related internal variables and methods for clarity and updating configuration and documentation accordingly. [[1]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89L998-R1009) [[2]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89L1012-R1022) [[3]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89L1028-R1047) [[4]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89L1179-R1236) [[5]](diffhunk://#diff-f4c5711479bf693b5ab20f1023fd977039e94778b23bf2f53b0188ddc9414e3dL31-R33) [[6]](diffhunk://#diff-a2b93119bc19d65ec304033d938ba1ed3352f9c1b2b0f986ff86adb9a61c5777L92-R92) [[7]](diffhunk://#diff-ea7772d27693965ba61ae5bab4ed2a21a8d69d5b2a9b4b4f192cf155afd8706bL228-R228)
* Updates tests to use the new `track_routed_blocks` option and renamed methods/attributes, ensuring correct behavior when enabled or disabled and on request failure. [[1]](diffhunk://#diff-541e70439bf7d7b6a9f23cabd51cccf8475b27e05dc1f1669b5909acb5fae3c2L787-R821) [[2]](diffhunk://#diff-541e70439bf7d7b6a9f23cabd51cccf8475b27e05dc1f1669b5909acb5fae3c2L842-R856) [[3]](diffhunk://#diff-541e70439bf7d7b6a9f23cabd51cccf8475b27e05dc1f1669b5909acb5fae3c2L864-R882) [[4]](diffhunk://#diff-541e70439bf7d7b6a9f23cabd51cccf8475b27e05dc1f1669b5909acb5fae3c2L1097-R1137)

**Conversation affinity and routing enhancements:**

* Implements conversation affinity by pinning all turns of a conversation (based on a content-derived hash) to the same server, improving cache hit rates and stability across requests; includes an LRU cache to limit memory usage. [[1]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89R54-R59) [[2]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89R1116-R1130) [[3]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89R1186-R1217)

**Tokens-per-block configuration flexibility:**

* Allows `tokens_per_block` to be set to `None` for automatic adoption from the first connected worker, with logic to handle mismatches and update the router's configuration accordingly; adds tests for this behavior. [[1]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89L800-R818) [[2]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89R1062-R1079) [[3]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89L1074-R1094) [[4]](diffhunk://#diff-541e70439bf7d7b6a9f23cabd51cccf8475b27e05dc1f1669b5909acb5fae3c2R1022-R1059)

**Other minor improvements:**

* Updates comments and log messages for clarity and accuracy throughout the codebase. [[1]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89L800-R818) [[2]](diffhunk://#diff-d15ddf320b458c2d0105338886f9db1464f10b08054d2d82b118edc182b2ca89L1074-R1094)

These changes collectively make the router more robust, configurable, and better aligned with real-world multi-turn conversation and server dynamics.

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
