### PR TITLE
[None][fix] Register Multimodal Placeholders for Qwen3.5 MoE VLM Serving

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py
@@ -55,12 +55,22 @@ from ..hf import (
 )
 
 try:
+    from tensorrt_llm.inputs.content_format import ContentFormat
     from tensorrt_llm.inputs.multimodal import MultimodalInput, apply_mm_hashes, hexdigest_to_int32
+    from tensorrt_llm.inputs.registry import (
+        MULTIMODAL_PLACEHOLDER_REGISTRY,
+        MultimodalPlaceholderMetadata,
+        MultimodalPlaceholderPlacement,
+    )
     from tensorrt_llm.inputs.utils import VideoData
 except ModuleNotFoundError:
+    ContentFormat = None
     MultimodalInput = None
     apply_mm_hashes = None
     hexdigest_to_int32 = None
+    MULTIMODAL_PLACEHOLDER_REGISTRY = None
+    MultimodalPlaceholderMetadata = None
+    MultimodalPlaceholderPlacement = None
     VideoData = None
 
 
@@ -3075,3 +3085,17 @@ AutoModelForCausalLMFactory.register_custom_model_cls(
     "Qwen3_5MoeConfig", Qwen3_5MoeForConditionalGeneration
 )
 Qwen3_5MoeFactory.register_custom_model_cls("Qwen3_5MoeConfig", Qwen3_5MoeForConditionalGeneration)
+
+if MULTIMODAL_PLACEHOLDER_REGISTRY is not None:
+    MULTIMODAL_PLACEHOLDER_REGISTRY.set_placeholder_metadata(
+        "qwen3_5_moe",
+        MultimodalPlaceholderMetadata(
+            placeholder_map={
+                "image": "<|vision_start|><|image_pad|><|vision_end|>",
+                "video": "<|vision_start|><|video_pad|><|vision_end|>",
+            },
+            placeholder_placement=MultimodalPlaceholderPlacement.BEFORE_TEXT,
+            placeholders_separator="",
+            content_format=ContentFormat.STRING,
+        ),
+    )

--- a/tensorrt_llm/_torch/pyexecutor/config_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/config_utils.py
@@ -267,6 +267,23 @@ def extract_mamba_kv_cache_params(
     )
 
 
+class _Qwen35MoeVLMConfig(transformers.Qwen3NextConfig):
+    """Thin subclass that restores the top-level model_type for Qwen3.5 MoE.
+
+    ``_Qwen35ConfigCompat`` normalizes the HF config into Qwen3NextConfig
+    (needed by the PyTorch backend model), but that loses the original
+    ``model_type``.  The serving layer needs ``model_type = "qwen3_5_moe"``
+    for ``MULTIMODAL_PLACEHOLDER_REGISTRY`` lookup; without it,
+    ``resolve_top_level_model_type`` returns ``"qwen3_next"`` and multimodal
+    requests fail with "Unknown modality".
+
+    To remove: when ``_Qwen35ConfigCompat`` is removed and the PyTorch backend
+    consumes ``Qwen3_5MoeConfig`` directly.
+    """
+
+    model_type = "qwen3_5_moe"
+
+
 class _Qwen35ConfigCompat:
     """Temporary shim that normalizes Qwen3.5 HF configs into Qwen3NextConfig.
 
@@ -457,8 +474,11 @@ def load_pretrained_config(model_name_or_path: str,
                                 "Qwen3_5ForCausalLM",
                                 "Qwen3_5ForConditionalGeneration",
                             )):
-        model_config = transformers.Qwen3NextConfig.from_dict(
-            _Qwen35ConfigCompat.normalize(config_dict))
+        normalized = _Qwen35ConfigCompat.normalize(config_dict)
+        if model_type in ("qwen3_5_moe", "qwen3_5_moe_text"):
+            model_config = _Qwen35MoeVLMConfig.from_dict(normalized)
+        else:
+            model_config = transformers.Qwen3NextConfig.from_dict(normalized)
     elif (model_type == "exaone4" and config_dict.get("sliding_window") is None
           and config_dict.get("layer_types") is None):
         # transformers 5.5.x Exaone4Config.__post_init__ first forces


### PR DESCRIPTION
## Summary
PR #12114 fixed model internals (mRoPE, chunked prefill, expert routing) but multimodal placeholders were not registers so the serving layer was unable to process multimodal requests. This change completes the fix for #12271.

- Register `MULTIMODAL_PLACEHOLDER_REGISTRY` entry for `qwen3_5_moe` in the AutoDeploy custom model, so the serving layer can resolve image/video placeholder tokens during chat message parsing
- Introduce `_Qwen35MoeVLMConfig` subclass in `config_utils.py` to preserve `model_type = "qwen3_5_moe"` through the config normalization path (`_Qwen35ConfigCompat` converts to `Qwen3NextConfig`, which loses the original model_type)
- Placeholder tokens (`<|vision_start|><|image_pad|><|vision_end|>`, `<|vision_start|><|video_pad|><|vision_end|>`) match the PyTorch backend's `qwen3_vl_moe` registration



## Test plan

- [x] `trtllm-serve <qwen3.5-35b-a3b> --backend=_autodeploy --config=<config.yaml>` starts without error
- [x] Text-only chat completions return correct output
- [x] Multimodal chat completions (image_url) return correct image descriptions
- [x] Dense Qwen3.5 variants (non-MoE) are unaffected by the config_utils change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Qwen3.5 Mixture of Experts (MoE) model variant.
  * Enhanced multimodal handling for Qwen3.5 MoE, including proper image and video placeholder token mapping and content formatting support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->