### PR TITLE
[https://nvbugs/6255037][fix] Count DSA indexer K-cache correctly as UINT8 in KV cache size estimate

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -2652,26 +2652,25 @@ class DSACacheManager(KVCacheManager):
 
         num_attention_layers = KVCacheManager._resolve_num_attention_layers(
             model_config, mapping, num_layers)
+        # MLA latent K cache: stored at the KV cache dtype (BF16/FP8).
         mem_per_token *= num_attention_layers * head_dim
 
-        # 1 for K, others for indexer K cache
-        head_dim_factor = (indexer_data_dim +
-                           index_head_dim // quant_block_size * 4) / head_dim
-        kv_factor = 1 + head_dim_factor
-        mem_per_token *= kv_factor
+        # Indexer K cache: physically allocated as raw UINT8 in
+        # WindowBlockManager::allocatePools (poolDtype = kUINT8), so we assume
+        # 1 byte/element here -- it is NOT scaled by the KV cache dtype (unlike
+        # the latent above). The data-portion byte count already reflects fp8 vs
+        # fp4 via indexer_data_dim.
+        indexer_bytes_per_token = num_attention_layers * (
+            indexer_data_dim + index_head_dim // quant_block_size * 4)
+        mem_per_token += indexer_bytes_per_token
         return mem_per_token
 
     def get_cache_bytes_per_token(self):
         """Compute actual cache bytes per token from instance configuration."""
-        # self.kv_factor for K, others for indexer K cache.
-        # Under FP4 the indexer data portion is halved (two E2M1 codes per
-        # byte); scale bytes are unchanged.
-        indexer_data_dim = self.index_head_dim // 2 if self.use_fp4 else self.index_head_dim
-        head_dim_factor = (indexer_data_dim + self.index_head_dim //
-                           self.quant_block_size * 4) / self.head_dim
-        kv_factor = self.kv_factor + head_dim_factor
+        # MLA latent K cache: stored at the KV cache dtype (self.dtype). The
+        # indexer K cache is added separately below.
         cache_size_per_token = math.ceil(
-            kv_factor * sum(self.num_kv_heads_per_layer) * self.head_dim)
+            self.kv_factor * sum(self.num_kv_heads_per_layer) * self.head_dim)
 
         if self.dtype not in (DataType.FP8, DataType.HALF, DataType.BF16,
                               DataType.FLOAT, DataType.NVFP4):
@@ -2684,4 +2683,15 @@ class DSACacheManager(KVCacheManager):
                 cache_size_per_token,
                 quant_vector_size=16,
                 scaling_factor_dtype=DataType.FP8)
+
+        # Indexer K cache: physically allocated as raw UINT8 in
+        # WindowBlockManager::allocatePools (poolDtype = kUINT8), so we assume
+        # 1 byte/element here -- it is NOT scaled by the KV cache dtype (unlike
+        # the latent above). Under FP4 the indexer data portion is halved (two
+        # E2M1 codes per byte); the scale bytes are unchanged.
+        indexer_data_dim = self.index_head_dim // 2 if self.use_fp4 else self.index_head_dim
+        indexer_bytes_per_token = sum(self.num_kv_heads_per_layer) * (
+            indexer_data_dim + self.index_head_dim // self.quant_block_size * 4)
+        cache_size_bytes_per_token += indexer_bytes_per_token
+
         return cache_size_bytes_per_token


### PR DESCRIPTION
## Description

The log change mentioned by the bug description was caused by the following code, which I have changed from the upper to latter in my latest PR #13745 for supporting Gemma4 for AutoDeploy.

```cpp
  cpp/tensorrt_llm/batch_manager/kvCacheManager.cpp:3276:
  - cacheSizeBytes += cacheVolume * BufferDataType(mDataType).getSize();      // manager-wide dtype
  + cacheSizeBytes += cacheVolume * BufferDataType(poolDataType).getSize();   // per-pool: primaryPool->getDataType()
```

The test cases runs with BF16 MLA KV cache and UINT8 indexer K cache:
  - Old (everything ×2 B): 78 × (1152 + 132×2) = 78 × 1416 = 110,448 B/tok → exactly your kv size per token is 110448.
  - New (indexer at 1 B): 78 × (1152 + 132) = 78 × 1284 = 100,152 B/tok → matches the bad run's 133.44 GiB ÷ 1,430,656 = 100,150. 
  - The gap: phantom second byte on the indexer = 78 × 132 = 10,296 B/tok × 1,430,656 tok = 13.7 GiB ≈ the 147.32 − 133.44 = 13.9 GiB drop. 
This explains the reporting paged KV cache creation drop.

Given the above, this merge request accounts for token size correctly inside dsa.py.

With the MR, running `perf/test_perf.py::test_perf[glm_5_fp8-bench-pytorch-float8-maxbs:512-maxnt:2048-input_output_len:2000,500-ep:8-gpus:8]`, I see the improved KV cache blocks `49324` compared to the older `44708` (~10% increase).

```
[TRT-LLM] [I] [batchmgr][RANK 0] Max KV cache blocks per sequence: 79 [window size=2500], tokens per block=32, primary blocks=49324, secondary blocks=0, max sequence length=2500

[INFO] Running command for perf/test_perf.py::test_perf_metric_kv_cache_size[glm_5_fp8-bench-pytorch-float8-maxbs:512-maxnt:2048-input_output_len:2000,500-ep:8-gpus:8]
[INFO] Reusing cached logs for command index 2.
[INFO] Searching for metric perf/test_perf.py::test_perf_metric_kv_cache_size[glm_5_fp8-bench-pytorch-float8-maxbs:512-maxnt:2048-input_output_len:2000,500-ep:8-gpus:8] from output log of command 2 ...
[INFO] Use max value 147.22 out of [1.76, 1.76, 1.76, 1.76, 1.76, 1.76, 1.76, 1.76, 147.22, 147.22, 147.22, 147.22, 147.22, 147.22, 147.22, 147.22] for perf metric perf/test_perf.py::test_perf_metric_kv_cache_size[glm_5_fp8-bench-pytorch-float8-maxbs:512-maxnt:2048-input_output_len:2000,500-ep:8-gpus:8].
[INFO] pytorch/TRT model config: {'print_iter_log': True, 'cuda_graph_config': {'enable_padding': True}, 'enable_autotuner': False}
```

## Test Coverage

Tested locally. The QA CI should restore its KV cache allocation size to the reported after this MR is merged.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
