### PR TITLE
[None][feat] Enhance CuteDSL NVF4 MOE

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -2136,7 +2136,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     sf_vec_size=self.scaling_vector_size,
                     mma_tiler_mn=mma_tiler_mn,
                     cluster_shape_mn=cluster_shape_mn,
-                    use_blkred=True,
                     raster_along_m=raster_along_m,
                 )
                 # Compute max active clusters on current device

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -1481,8 +1481,9 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
             # Get the first tile info
             tile_info = cute.make_rmem_tensor((5,), cutlass.Int32)
             tile_info_pipeline.consumer_wait(tile_info_consumer_state)
-            for idx in cutlass.range(5, unroll_full=True):
-                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            tile_info[0] = sInfo[(0, tile_info_consumer_state.index)]
+            tile_info[3] = sInfo[(3, tile_info_consumer_state.index)]
+            tile_info[4] = sInfo[(4, tile_info_consumer_state.index)]
             is_valid_tile = tile_info[3] == 1
             cute.arch.fence_proxy(
                 "async.shared",
@@ -1636,8 +1637,9 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                 # Advance to next tile
                 #
                 tile_info_pipeline.consumer_wait(tile_info_consumer_state)
-                for idx in cutlass.range(5, unroll_full=True):
-                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                tile_info[0] = sInfo[(0, tile_info_consumer_state.index)]
+                tile_info[3] = sInfo[(3, tile_info_consumer_state.index)]
+                tile_info[4] = sInfo[(4, tile_info_consumer_state.index)]
                 is_valid_tile = tile_info[3] == 1
                 cute.arch.fence_proxy(
                     "async.shared",
@@ -1677,10 +1679,10 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                 )
 
                 # Get the first tile info
-                valid_tile_info = cute.make_rmem_tensor((1,), cutlass.Int32)
+                tile_info = cute.make_rmem_tensor((5,), cutlass.Int32)
                 tile_info_pipeline.consumer_wait(tile_info_consumer_state)
-                valid_tile_info[0] = sInfo[(3, tile_info_consumer_state.index)]
-                is_valid_tile = valid_tile_info[0] == 1
+                tile_info[3] = sInfo[(3, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[3] == 1
                 cute.arch.fence_proxy(
                     "async.shared",
                     space="cta",
@@ -1714,8 +1716,8 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                     # Advance to next tile
                     #
                     tile_info_pipeline.consumer_wait(tile_info_consumer_state)
-                    valid_tile_info[0] = sInfo[(3, tile_info_consumer_state.index)]
-                    is_valid_tile = valid_tile_info[0] == 1
+                    tile_info[3] = sInfo[(3, tile_info_consumer_state.index)]
+                    is_valid_tile = tile_info[3] == 1
                     cute.arch.fence_proxy(
                         "async.shared",
                         space="cta",
@@ -1752,10 +1754,12 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
             )
 
             # Get the first tile info
-            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info = cute.make_rmem_tensor((5,), cutlass.Int32)
             tile_info_pipeline.consumer_wait(tile_info_consumer_state)
-            for idx in cutlass.range(4, unroll_full=True):
-                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            tile_info[0] = sInfo[(0, tile_info_consumer_state.index)]
+            tile_info[1] = sInfo[(1, tile_info_consumer_state.index)]
+            tile_info[2] = sInfo[(2, tile_info_consumer_state.index)]
+            tile_info[3] = sInfo[(3, tile_info_consumer_state.index)]
             is_valid_tile = tile_info[3] == 1
             cute.arch.fence_proxy(
                 "async.shared",
@@ -1817,8 +1821,10 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                 # Advance to next tile
                 #
                 tile_info_pipeline.consumer_wait(tile_info_consumer_state)
-                for idx in cutlass.range(4, unroll_full=True):
-                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                tile_info[0] = sInfo[(0, tile_info_consumer_state.index)]
+                tile_info[1] = sInfo[(1, tile_info_consumer_state.index)]
+                tile_info[2] = sInfo[(2, tile_info_consumer_state.index)]
+                tile_info[3] = sInfo[(3, tile_info_consumer_state.index)]
                 is_valid_tile = tile_info[3] == 1
                 cute.arch.fence_proxy(
                     "async.shared",
@@ -1916,10 +1922,12 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
             )
 
             # Get the first tile info from pipeline (scheduler has filtered out tiles >= num_non_exiting_tiles)
-            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info = cute.make_rmem_tensor((5,), cutlass.Int32)
             tile_info_pipeline.consumer_wait(tile_info_consumer_state)
-            for idx in cutlass.range(4, unroll_full=True):
-                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            tile_info[0] = sInfo[(0, tile_info_consumer_state.index)]
+            tile_info[1] = sInfo[(1, tile_info_consumer_state.index)]
+            tile_info[2] = sInfo[(2, tile_info_consumer_state.index)]
+            tile_info[3] = sInfo[(3, tile_info_consumer_state.index)]
             is_valid_tile = tile_info[3] == 1
             cute.arch.fence_proxy(
                 "async.shared",
@@ -2120,8 +2128,10 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                 # Advance to next tile
                 #
                 tile_info_pipeline.consumer_wait(tile_info_consumer_state)
-                for idx in cutlass.range(4, unroll_full=True):
-                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                tile_info[0] = sInfo[(0, tile_info_consumer_state.index)]
+                tile_info[1] = sInfo[(1, tile_info_consumer_state.index)]
+                tile_info[2] = sInfo[(2, tile_info_consumer_state.index)]
+                tile_info[3] = sInfo[(3, tile_info_consumer_state.index)]
                 is_valid_tile = tile_info[3] == 1
                 cute.arch.fence_proxy(
                     "async.shared",
@@ -2227,11 +2237,13 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
             )
 
             # Get the first tile info
-            tile_info = cute.make_rmem_tensor((4,), cutlass.Int32)
+            tile_info = cute.make_rmem_tensor((5,), cutlass.Int32)
 
             tile_info_pipeline.consumer_wait(tile_info_consumer_state)
-            for idx in cutlass.range(4, unroll_full=True):
-                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            tile_info[0] = sInfo[(0, tile_info_consumer_state.index)]
+            tile_info[1] = sInfo[(1, tile_info_consumer_state.index)]
+            tile_info[2] = sInfo[(2, tile_info_consumer_state.index)]
+            tile_info[3] = sInfo[(3, tile_info_consumer_state.index)]
             is_valid_tile = tile_info[3] == 1
             cute.arch.fence_proxy(
                 "async.shared",
@@ -2526,8 +2538,10 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                 # Advance to next tile
                 #
                 tile_info_pipeline.consumer_wait(tile_info_consumer_state)
-                for idx in cutlass.range(4, unroll_full=True):
-                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                tile_info[0] = sInfo[(0, tile_info_consumer_state.index)]
+                tile_info[1] = sInfo[(1, tile_info_consumer_state.index)]
+                tile_info[2] = sInfo[(2, tile_info_consumer_state.index)]
+                tile_info[3] = sInfo[(3, tile_info_consumer_state.index)]
                 is_valid_tile = tile_info[3] == 1
                 cute.arch.fence_proxy(
                     "async.shared",

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -1114,7 +1114,9 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
 
         # Pipeline Init: Initialize acc_pipeline (barrier) and states
         acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
-        num_acc_consumer_threads = len(self.epilog_warp_id) * (2 if use_2cta_instrs else 1)
+        num_acc_consumer_threads = (
+            len(self.epilog_warp_id) * self.threads_per_warp * (2 if use_2cta_instrs else 1)
+        )
         acc_pipeline_consumer_group = pipeline.CooperativeGroup(
             pipeline.Agent.Thread, num_acc_consumer_threads
         )
@@ -2343,8 +2345,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                         if real_subtile_idx == self.iter_acc_early_release_in_epilogue:
                             # Fence for TMEM load
                             cute.arch.fence_view_async_tmem_load()
-                            with cute.arch.elect_one():
-                                acc_pipeline.consumer_release(acc_consumer_state)
+                            acc_pipeline.consumer_release(acc_consumer_state)
                             acc_consumer_state.advance()
 
                     acc_vec_up = tTR_rAcc_up.load()
@@ -2518,8 +2519,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                 # Async arrive accumulator buffer empty
                 #
                 if cutlass.const_expr(not self.overlapping_accum):
-                    with cute.arch.elect_one():
-                        acc_pipeline.consumer_release(acc_consumer_state)
+                    acc_pipeline.consumer_release(acc_consumer_state)
                     acc_consumer_state.advance()
 
                 #

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -1298,8 +1298,10 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             # Get the first tile info from pipeline (scheduler has filtered out tiles >= num_non_exiting_tiles)
             tile_info = cute.make_rmem_tensor((5,), cutlass.Int32)
             tile_info_pipeline.consumer_wait(tile_info_consumer_state)
-            for idx in cutlass.range(5, unroll_full=True):
-                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            tile_info[0] = sInfo[(0, tile_info_consumer_state.index)]
+            tile_info[1] = sInfo[(1, tile_info_consumer_state.index)]
+            tile_info[2] = sInfo[(2, tile_info_consumer_state.index)]
+            tile_info[3] = sInfo[(3, tile_info_consumer_state.index)]
             is_valid_tile = tile_info[3] == 1
             cute.arch.fence_proxy(
                 "async.shared",
@@ -1391,8 +1393,10 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                 # Advance to next tile
                 #
                 tile_info_pipeline.consumer_wait(tile_info_consumer_state)
-                for idx in cutlass.range(5, unroll_full=True):
-                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                tile_info[0] = sInfo[(0, tile_info_consumer_state.index)]
+                tile_info[1] = sInfo[(1, tile_info_consumer_state.index)]
+                tile_info[2] = sInfo[(2, tile_info_consumer_state.index)]
+                tile_info[3] = sInfo[(3, tile_info_consumer_state.index)]
                 is_valid_tile = tile_info[3] == 1
                 cute.arch.fence_proxy(
                     "async.shared",
@@ -1477,8 +1481,10 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             # Get the first tile info from pipeline (scheduler has filtered out tiles >= num_non_exiting_tiles)
             tile_info = cute.make_rmem_tensor((5,), cutlass.Int32)
             tile_info_pipeline.consumer_wait(tile_info_consumer_state)
-            for idx in cutlass.range(5, unroll_full=True):
-                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            tile_info[0] = sInfo[(0, tile_info_consumer_state.index)]
+            tile_info[1] = sInfo[(1, tile_info_consumer_state.index)]
+            tile_info[2] = sInfo[(2, tile_info_consumer_state.index)]
+            tile_info[3] = sInfo[(3, tile_info_consumer_state.index)]
             is_valid_tile = tile_info[3] == 1
             cute.arch.fence_proxy(
                 "async.shared",
@@ -1628,8 +1634,10 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                 # Advance to next tile
                 #
                 tile_info_pipeline.consumer_wait(tile_info_consumer_state)
-                for idx in cutlass.range(5, unroll_full=True):
-                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                tile_info[0] = sInfo[(0, tile_info_consumer_state.index)]
+                tile_info[1] = sInfo[(1, tile_info_consumer_state.index)]
+                tile_info[2] = sInfo[(2, tile_info_consumer_state.index)]
+                tile_info[3] = sInfo[(3, tile_info_consumer_state.index)]
                 is_valid_tile = tile_info[3] == 1
                 cute.arch.fence_proxy(
                     "async.shared",
@@ -1656,8 +1664,9 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             )
             tile_info = cute.make_rmem_tensor((5,), cutlass.Int32)
             tile_info_pipeline.consumer_wait(tile_info_consumer_state)
-            for idx in cutlass.range(5, unroll_full=True):
-                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            tile_info[0] = sInfo[(0, tile_info_consumer_state.index)]
+            tile_info[2] = sInfo[(2, tile_info_consumer_state.index)]
+            tile_info[3] = sInfo[(3, tile_info_consumer_state.index)]
             is_valid_tile = tile_info[3] == 1
             cute.arch.fence_proxy("async.shared", space="cta")
             tile_info_pipeline.consumer_release(tile_info_consumer_state)
@@ -1692,8 +1701,9 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                 meta_producer_state.advance()
 
                 tile_info_pipeline.consumer_wait(tile_info_consumer_state)
-                for idx in cutlass.range(5, unroll_full=True):
-                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                tile_info[0] = sInfo[(0, tile_info_consumer_state.index)]
+                tile_info[2] = sInfo[(2, tile_info_consumer_state.index)]
+                tile_info[3] = sInfo[(3, tile_info_consumer_state.index)]
                 is_valid_tile = tile_info[3] == 1
                 cute.arch.fence_proxy("async.shared", space="cta")
                 tile_info_pipeline.consumer_release(tile_info_consumer_state)
@@ -1753,8 +1763,10 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             tile_info = cute.make_rmem_tensor((5,), cutlass.Int32)
 
             tile_info_pipeline.consumer_wait(tile_info_consumer_state)
-            for idx in cutlass.range(5, unroll_full=True):
-                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            tile_info[0] = sInfo[(0, tile_info_consumer_state.index)]
+            tile_info[1] = sInfo[(1, tile_info_consumer_state.index)]
+            tile_info[3] = sInfo[(3, tile_info_consumer_state.index)]
+            tile_info[4] = sInfo[(4, tile_info_consumer_state.index)]
             is_valid_tile = tile_info[3] == 1
             cute.arch.fence_proxy(
                 "async.shared",
@@ -1880,8 +1892,10 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                 # Advance to next tile
                 #
                 tile_info_pipeline.consumer_wait(tile_info_consumer_state)
-                for idx in cutlass.range(5, unroll_full=True):
-                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                tile_info[0] = sInfo[(0, tile_info_consumer_state.index)]
+                tile_info[1] = sInfo[(1, tile_info_consumer_state.index)]
+                tile_info[3] = sInfo[(3, tile_info_consumer_state.index)]
+                tile_info[4] = sInfo[(4, tile_info_consumer_state.index)]
                 is_valid_tile = tile_info[3] == 1
                 cute.arch.fence_proxy(
                     "async.shared",

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -1667,6 +1667,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             tile_info[0] = sInfo[(0, tile_info_consumer_state.index)]
             tile_info[2] = sInfo[(2, tile_info_consumer_state.index)]
             tile_info[3] = sInfo[(3, tile_info_consumer_state.index)]
+            tile_info[4] = sInfo[(4, tile_info_consumer_state.index)]
             is_valid_tile = tile_info[3] == 1
             cute.arch.fence_proxy("async.shared", space="cta")
             tile_info_pipeline.consumer_release(tile_info_consumer_state)
@@ -1681,19 +1682,27 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                 meta_stage = meta_producer_state.index
                 # Strided row assignment keeps the permuted_idx loads and smem
                 # stores coalesced (each fixed j: 32 lanes touch 32 contiguous
-                # rows). Padding rows hold -1; clamp the gather index in-bounds
-                # (branchless) -- the epilogue ignores padding rows via
-                # is_valid_row, so the value staged for them is irrelevant.
+                # rows). Rows beyond mn_limit are padding: their expanded_idx is
+                # not guaranteed to be in range, so gate the token_final_scales
+                # gather to token 0 for them (branchless) to keep it in-bounds.
+                # The epilogue ignores padding rows via its own is_valid_row, so
+                # the value staged for them is irrelevant.
                 for j in cutlass.range(
                     self.cta_tile_shape_mnk[0] // self.threads_per_warp,
                     unroll_full=True,
                 ):
                     r = meta_lane + j * self.threads_per_warp
-                    expanded_idx = permuted_idx_to_expanded_idx[tile_m_start + r]
+                    permuted_row = tile_m_start + r
+                    expanded_idx = permuted_idx_to_expanded_idx[permuted_row]
+                    # max(., 0) keeps topk_idx in-bounds for padding rows (-1);
+                    # the is_valid gate keeps token_idx in-bounds (padding rows
+                    # may hold out-of-range garbage, not just -1).
                     safe_idx = cutlass.max(expanded_idx, cutlass.Int32(0))
                     token_idx = safe_idx // topK
                     topk_idx = safe_idx % topK
-                    token_scale = token_final_scales[(token_idx, topk_idx)]
+                    is_valid_row = cutlass.Int32(permuted_row < tile_info[4])
+                    gather_tok = token_idx * is_valid_row
+                    token_scale = token_final_scales[(gather_tok, topk_idx)]
                     sMetaTokenIdx[(r, meta_stage)] = token_idx
                     sMetaScale[(r, meta_stage)] = alpha_val * token_scale
                 cute.arch.fence_proxy("async.shared", space="cta")
@@ -1704,6 +1713,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                 tile_info[0] = sInfo[(0, tile_info_consumer_state.index)]
                 tile_info[2] = sInfo[(2, tile_info_consumer_state.index)]
                 tile_info[3] = sInfo[(3, tile_info_consumer_state.index)]
+                tile_info[4] = sInfo[(4, tile_info_consumer_state.index)]
                 is_valid_tile = tile_info[3] == 1
                 cute.arch.fence_proxy("async.shared", space="cta")
                 tile_info_pipeline.consumer_release(tile_info_consumer_state)

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -257,9 +257,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                 self.meta_load_warp_id,
             )
         )
-        self.num_regs_uniform_warps = 64
-        self.num_regs_sched_warps = 64
-        self.num_regs_epilogue_warps = 216
 
         # Set barrier for cta sync, epilogue sync and tmem ptr sync
         self.cta_sync_barrier = pipeline.NamedBarrier(
@@ -1192,7 +1189,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         # Specialized Schedule warp
         #
         if warp_idx == self.sched_warp_id:
-            cute.arch.warpgroup_reg_dealloc(self.num_regs_sched_warps)
             #
             # Persistent tile scheduling loop
             #
@@ -1291,8 +1287,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         # Specialized TMA load warp
         #
         if warp_idx == self.tma_warp_id:
-            cute.arch.warpgroup_reg_dealloc(self.num_regs_uniform_warps)
-
             ab_producer_state = pipeline.make_pipeline_state(
                 pipeline.PipelineUserType.Producer, self.num_ab_stage
             )
@@ -1652,7 +1646,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         # Specialized metadata loader warp
         #
         if warp_idx == self.meta_load_warp_id:
-            cute.arch.warpgroup_reg_dealloc(self.num_regs_uniform_warps)
             meta_lane = tidx % self.threads_per_warp
 
             tile_info_consumer_state = pipeline.make_pipeline_state(

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -1756,8 +1756,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                 pipeline.PipelineUserType.Consumer, self.num_meta_stage
             )
 
-            token_idx = cutlass.Int32(0)
-
             # Get the first tile info
             tile_info = cute.make_rmem_tensor((5,), cutlass.Int32)
 
@@ -1773,15 +1771,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             tile_info_consumer_state.advance()
 
             while is_valid_tile:
-                mma_tile_coord_mnl = (
-                    tile_info[0] // cute.size(tiled_mma.thr_id.shape),
-                    tile_info[1],
-                    tile_info[2],
-                )
-                #
-                # Get alpha for current group
-                #
-
                 tile_m_start = tile_info[0] * self.cta_tile_shape_mnk[0]
                 permuted_row = tile_m_start + epi_tidx
                 is_valid_row = permuted_row < tile_info[4]
@@ -1866,7 +1855,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
 
                 # Whole-row async bulk reduce (smem -> global scatter-add).
                 if is_valid_row:
-                    coord_n = mma_tile_coord_mnl[1] * self.cta_tile_shape_mnk[1]
+                    coord_n = tile_info[1] * self.cta_tile_shape_mnk[1]
                     scatter_out_offset = cute.domain_offset((token_idx, coord_n, 0), out)
                     if cutlass.const_expr(self.out_dtype == cutlass.BFloat16):
                         blk_reduce_bf16(

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -238,6 +238,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         self.mma_warp_id = 4
         self.tma_warp_id = 5
         self.sched_warp_id = 6
+        self.meta_load_warp_id = 7
         self.threads_per_warp = 32
         self.threads_per_cta = self.threads_per_warp * len(
             (
@@ -245,6 +246,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                 self.mma_warp_id,
                 self.tma_warp_id,
                 self.sched_warp_id,
+                self.meta_load_warp_id,
             )
         )
         self.threads_wo_sched = self.threads_per_warp * len(
@@ -252,6 +254,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                 *self.epilog_warp_id,
                 self.mma_warp_id,
                 self.tma_warp_id,
+                self.meta_load_warp_id,
             )
         )
         self.num_regs_uniform_warps = 64
@@ -378,6 +381,17 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
 
         self.epi_tile_n = cute.size(self.epi_tile[1])
 
+        # Metadata loader pipeline depth (meta warp -> epilogue). Lets the loader
+        # prefetch the per-row {token_idx, combined_scale} ahead of the epilogue.
+        self.num_meta_stage = 2
+        # Per-row metadata smem held by the loader: token_idx (int32) +
+        # combined_scale (final_scale_dtype), cta_M rows per stage.
+        meta_smem_bytes = (
+            self.cta_tile_shape_mnk[0]
+            * self.num_meta_stage
+            * (4 + self.final_scale_dtype.width // 8)
+        )
+
         # Setup A/B/C/Scale stage count in shared memory and ACC stage count in tensor memory
         (
             self.num_acc_stage,
@@ -395,6 +409,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             self.sf_vec_size,
             self.num_smem_capacity,
             self.occupancy,
+            meta_smem_bytes,
         )
 
         # Compute A/B/C/Scale shared memory layout
@@ -701,6 +716,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             ab_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage * 2]
             acc_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage * 2]
             tile_info_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_tile_stage * 2]
+            meta_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_meta_stage * 2]
             tmem_dealloc_mbar_ptr: cutlass.Int64
             tmem_holding_buf: cutlass.Int32
             # (MMA, MMA_M, MMA_K, STAGE)
@@ -727,6 +743,18 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             sC: cute.struct.Align[
                 cute.struct.MemRange[self.out_dtype, cute.cosize(self.c_smem_layout_staged)],
                 self.buffer_align_bytes,
+            ]
+            meta_token_idx: cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Int32, self.cta_tile_shape_mnk[0] * self.num_meta_stage
+                ],
+                1,
+            ]
+            meta_scale: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.final_scale_dtype, self.cta_tile_shape_mnk[0] * self.num_meta_stage
+                ],
+                1,
             ]
 
         self.shared_storage = SharedStorage
@@ -935,6 +963,22 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             consumer_group=tile_info_pipeline_consumer_group,
         )
 
+        # Initialize metadata pipeline (meta loader warp -> epilogue warps)
+        meta_pipeline_producer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * 1,
+        )
+        meta_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread,
+            self.threads_per_warp * len(self.epilog_warp_id),
+        )
+        meta_pipeline = pipeline.PipelineAsync.create(
+            barrier_storage=storage.meta_mbar_ptr.data_ptr(),
+            num_stages=self.num_meta_stage,
+            producer_group=meta_pipeline_producer_group,
+            consumer_group=meta_pipeline_consumer_group,
+        )
+
         # Tensor memory dealloc barrier init
         tmem = utils.TmemAllocator(
             storage.tmem_holding_buf,
@@ -965,6 +1009,14 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         # (bidx, bidy, bidz, valid)
         info_layout = cute.make_layout((5, self.num_tile_stage), stride=(1, 5))
         sInfo = storage.sInfo.get_tensor(info_layout)
+
+        # Per-row finalize metadata staged by the meta loader warp: (row, stage)
+        meta_layout = cute.make_layout(
+            (self.cta_tile_shape_mnk[0], self.num_meta_stage),
+            stride=(1, self.cta_tile_shape_mnk[0]),
+        )
+        sMetaTokenIdx = storage.meta_token_idx.get_tensor(meta_layout)
+        sMetaScale = storage.meta_scale.get_tensor(meta_layout)
 
         #
         # Compute multicast mask for A/B buffer full
@@ -1597,6 +1649,65 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             acc_pipeline.producer_tail(acc_producer_state)
 
         #
+        # Specialized metadata loader warp
+        #
+        if warp_idx == self.meta_load_warp_id:
+            cute.arch.warpgroup_reg_dealloc(self.num_regs_uniform_warps)
+            meta_lane = tidx % self.threads_per_warp
+
+            tile_info_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_tile_stage
+            )
+            meta_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_meta_stage
+            )
+            tile_info = cute.make_rmem_tensor((5,), cutlass.Int32)
+            tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+            for idx in cutlass.range(5, unroll_full=True):
+                tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+            is_valid_tile = tile_info[3] == 1
+            cute.arch.fence_proxy("async.shared", space="cta")
+            tile_info_pipeline.consumer_release(tile_info_consumer_state)
+            tile_info_consumer_state.advance()
+
+            while is_valid_tile:
+                tile_m_start = tile_info[0] * self.cta_tile_shape_mnk[0]
+                expert_idx = tile_info[2]
+                alpha_val = alpha_tuple[0][expert_idx]
+
+                meta_pipeline.producer_acquire(meta_producer_state)
+                meta_stage = meta_producer_state.index
+                # Strided row assignment keeps the permuted_idx loads and smem
+                # stores coalesced (each fixed j: 32 lanes touch 32 contiguous
+                # rows). Padding rows hold -1; clamp the gather index in-bounds
+                # (branchless) -- the epilogue ignores padding rows via
+                # is_valid_row, so the value staged for them is irrelevant.
+                for j in cutlass.range(
+                    self.cta_tile_shape_mnk[0] // self.threads_per_warp,
+                    unroll_full=True,
+                ):
+                    r = meta_lane + j * self.threads_per_warp
+                    expanded_idx = permuted_idx_to_expanded_idx[tile_m_start + r]
+                    safe_idx = cutlass.max(expanded_idx, cutlass.Int32(0))
+                    token_idx = safe_idx // topK
+                    topk_idx = safe_idx % topK
+                    token_scale = token_final_scales[(token_idx, topk_idx)]
+                    sMetaTokenIdx[(r, meta_stage)] = token_idx
+                    sMetaScale[(r, meta_stage)] = alpha_val * token_scale
+                cute.arch.fence_proxy("async.shared", space="cta")
+                meta_pipeline.producer_commit(meta_producer_state)
+                meta_producer_state.advance()
+
+                tile_info_pipeline.consumer_wait(tile_info_consumer_state)
+                for idx in cutlass.range(5, unroll_full=True):
+                    tile_info[idx] = sInfo[(idx, tile_info_consumer_state.index)]
+                is_valid_tile = tile_info[3] == 1
+                cute.arch.fence_proxy("async.shared", space="cta")
+                tile_info_pipeline.consumer_release(tile_info_consumer_state)
+                tile_info_consumer_state.advance()
+            meta_pipeline.producer_tail(meta_producer_state)
+
+        #
         # Specialized epilogue warps
         #
         if warp_idx < self.mma_warp_id:
@@ -1641,9 +1752,11 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             tile_info_consumer_state = pipeline.make_pipeline_state(
                 pipeline.PipelineUserType.Consumer, self.num_tile_stage
             )
+            meta_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_meta_stage
+            )
 
             token_idx = cutlass.Int32(0)
-            token_scale = self.final_scale_dtype(0.0)
 
             # Get the first tile info
             tile_info = cute.make_rmem_tensor((5,), cutlass.Int32)
@@ -1669,13 +1782,15 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                 # Get alpha for current group
                 #
 
-                expert_idx = mma_tile_coord_mnl[2]
-                alpha_val = alpha_tuple[0][expert_idx]
-
                 tile_m_start = tile_info[0] * self.cta_tile_shape_mnk[0]
                 permuted_row = tile_m_start + epi_tidx
-                expanded_idx = permuted_idx_to_expanded_idx[permuted_row]
                 is_valid_row = permuted_row < tile_info[4]
+
+                # Read per-row finalize metadata prefetched by the meta loader
+                # warp (token_idx for scatter, combined_scale = alpha * token_scale).
+                meta_pipeline.consumer_wait(meta_consumer_state)
+                token_idx = sMetaTokenIdx[(epi_tidx, meta_consumer_state.index)]
+                meta_scale = sMetaScale[(epi_tidx, meta_consumer_state.index)]
 
                 # Get accumulator stage index
                 if cutlass.const_expr(self.overlapping_accum):
@@ -1702,12 +1817,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                 #
                 subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
 
-                if is_valid_row:
-                    token_idx = expanded_idx // topK
-                    topk_idx = expanded_idx % topK
-                    token_scale = token_final_scales[(token_idx, topk_idx)]
-                    alpha_val = alpha_val * token_scale
-
                 for subtile_idx in cutlass.range(subtile_cnt):
                     real_subtile_idx = subtile_idx
                     if cutlass.const_expr(self.overlapping_accum):
@@ -1730,9 +1839,9 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                             acc_pipeline.consumer_release(acc_consumer_state)
                             acc_consumer_state.advance()
 
-                    # Get vectorized accumulator and apply alpha scaling
+                    # Get vectorized accumulator and apply the combined finalize scale
                     acc_vec = tTR_rAcc.load()
-                    acc_vec_final = alpha_val * acc_vec
+                    acc_vec_final = meta_scale * acc_vec
 
                     tRS_rC.store(acc_vec_final.to(self.out_dtype))
                     if is_valid_row:
@@ -1781,6 +1890,10 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                 cute.arch.cp_async_bulk_commit_group()
                 cute.arch.cp_async_bulk_wait_group(0, read=True)
                 self.epilog_sync_barrier.arrive_and_wait()
+
+                # Release the prefetched metadata slot for this tile.
+                meta_pipeline.consumer_release(meta_consumer_state)
+                meta_consumer_state.advance()
 
                 # Advance to next tile
                 #
@@ -1900,6 +2013,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         sf_vec_size: int,
         num_smem_capacity: int,
         occupancy: int,
+        meta_smem_bytes: int,
     ) -> Tuple[int, int, int]:
         """Computes the number of stages for A/B/C operands based on heuristics.
 
@@ -1985,10 +2099,11 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
 
         # Calculate A/B stages:
         # Start with total smem per CTA (capacity / occupancy)
-        # Subtract reserved bytes and initial C stages bytes
+        # Subtract reserved bytes, initial C stages bytes, and the per-row
+        # metadata smem held by the loader warp
         # Divide remaining by bytes needed per A/B stage
         num_ab_stage = (
-            num_smem_capacity // occupancy - (mbar_helpers_bytes + c_bytes)
+            num_smem_capacity // occupancy - (mbar_helpers_bytes + c_bytes + meta_smem_bytes)
         ) // ab_bytes_per_stage
 
         return num_acc_stage, num_ab_stage, num_c_stage, num_tile_stage

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -39,15 +39,12 @@ from cutlass.cute.nvgpu import cpasync, tcgen05
 
 from .utils import (
     TRTLLM_ENABLE_PDL,
-    atomic_add_func,
     blk_reduce_bf16,
     blk_reduce_fp16,
     blk_reduce_fp32,
     griddepcontrol_launch_dependents,
     griddepcontrol_wait,
     is_power_of_2,
-    vectorized_atomic_add_bf16x8,
-    vectorized_atomic_add_fp32x2,
 )
 
 """
@@ -206,7 +203,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         sf_vec_size: int,
         mma_tiler_mn: Tuple[int, int],
         cluster_shape_mn: Tuple[int, int],
-        use_blkred: bool = False,
         raster_along_m: bool = False,
     ):
         """Initializes the configuration for a Blackwell blockscaled dense GEMM kernel.
@@ -236,9 +232,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         self.mma_tiler = (*mma_tiler_mn, 1)
 
         self.cta_group = tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
-
-        # Block reduce configuration
-        self.use_blkred = use_blkred
 
         self.occupancy = 1
         self.epilog_warp_id = (0, 1, 2, 3)
@@ -402,7 +395,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             self.sf_vec_size,
             self.num_smem_capacity,
             self.occupancy,
-            self.use_blkred,
         )
 
         # Compute A/B/C/Scale shared memory layout
@@ -732,11 +724,10 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                 self.buffer_align_bytes,
             ]
 
-            if cutlass.const_expr(self.use_blkred):
-                sC: cute.struct.Align[
-                    cute.struct.MemRange[self.out_dtype, cute.cosize(self.c_smem_layout_staged)],
-                    self.buffer_align_bytes,
-                ]
+            sC: cute.struct.Align[
+                cute.struct.MemRange[self.out_dtype, cute.cosize(self.c_smem_layout_staged)],
+                self.buffer_align_bytes,
+            ]
 
         self.shared_storage = SharedStorage
 
@@ -914,7 +905,9 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
 
         # Initialize acc_pipeline (barrier) and states
         acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
-        num_acc_consumer_threads = len(self.epilog_warp_id) * (2 if use_2cta_instrs else 1)
+        num_acc_consumer_threads = (
+            len(self.epilog_warp_id) * self.threads_per_warp * (2 if use_2cta_instrs else 1)
+        )
         acc_pipeline_consumer_group = pipeline.CooperativeGroup(
             pipeline.Agent.Thread, num_acc_consumer_threads
         )
@@ -967,8 +960,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         # (granularity_n, repeat_n), (granularity_k, repeat_k), num_scale_stage)
         sSFB = storage.sSFB.get_tensor(sfb_smem_layout_staged)
 
-        if cutlass.const_expr(self.use_blkred):
-            sC = storage.sC.get_tensor(c_smem_layout_staged)
+        sC = storage.sC.get_tensor(c_smem_layout_staged)
 
         # (bidx, bidy, bidz, valid)
         info_layout = cute.make_layout((5, self.num_tile_stage), stride=(1, 5))
@@ -1638,10 +1630,9 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             )
 
             tTR_rC = cute.make_rmem_tensor(tTR_rAcc.shape, self.out_dtype)
-            if cutlass.const_expr(self.use_blkred):
-                tiled_copy_r2s, tRS_rC, tRS_sC = self.epilog_smem_copy_and_partition(
-                    epi_tidx, tTR_rC, sC, tiled_copy_t2r
-                )
+            tiled_copy_r2s, tRS_rC, tRS_sC = self.epilog_smem_copy_and_partition(
+                epi_tidx, tTR_rC, sC, tiled_copy_t2r
+            )
 
             acc_consumer_state = pipeline.make_pipeline_state(
                 pipeline.PipelineUserType.Consumer, self.num_acc_stage
@@ -1736,96 +1727,60 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                         if subtile_idx == self.iter_acc_early_release_in_epilogue:
                             # Fence for TMEM load
                             cute.arch.fence_view_async_tmem_load()
-                            with cute.arch.elect_one():
-                                acc_pipeline.consumer_release(acc_consumer_state)
+                            acc_pipeline.consumer_release(acc_consumer_state)
                             acc_consumer_state.advance()
 
                     # Get vectorized accumulator and apply alpha scaling
                     acc_vec = tTR_rAcc.load()
                     acc_vec_final = alpha_val * acc_vec
 
-                    if cutlass.const_expr(self.use_blkred):
-                        tRS_rC.store(acc_vec_final.to(self.out_dtype))
-                        if is_valid_row:
-                            cute.copy(
-                                tiled_copy_r2s,
-                                tRS_rC,
-                                tRS_sC[(None, None, real_subtile_idx, None)],
-                            )
-                    else:
-                        tTR_rC.store(acc_vec_final.to(self.out_dtype))
-                        if is_valid_row:
-                            rOut_epi = cute.make_tensor(tTR_rC.iterator, epi_layout)
+                    tRS_rC.store(acc_vec_final.to(self.out_dtype))
+                    if is_valid_row:
+                        cute.copy(
+                            tiled_copy_r2s,
+                            tRS_rC,
+                            tRS_sC[(None, None, real_subtile_idx, None)],
+                        )
 
-                            base_coord_n = mma_tile_coord_mnl[1] * self.cta_tile_shape_mnk[
-                                1
-                            ] + real_subtile_idx * cute.size(tTR_rC)
-
-                            scatter_out = cute.domain_offset(
-                                (token_idx, 0, 0),
-                                out,  # Use original tensor to get real pointer
-                            )
-
-                            for index in cutlass.range(self.epi_loop_size, unroll_full=True):
-                                coord_n = base_coord_n + index * self.element_offset
-                                scatter_out_offset = cute.domain_offset(
-                                    (0, coord_n, 0), scatter_out
-                                )
-                                if cutlass.const_expr(self.out_dtype == cutlass.BFloat16):
-                                    rOut_epi_packed = rOut_epi[index, None, None]
-                                    vectorized_atomic_add_bf16x8(
-                                        rOut_epi_packed, scatter_out_offset
-                                    )
-                                elif cutlass.const_expr(self.out_dtype == cutlass.Float32):
-                                    rOut_epi_packed = rOut_epi[index, None]
-                                    vectorized_atomic_add_fp32x2(
-                                        rOut_epi_packed, scatter_out_offset
-                                    )
-                                else:
-                                    rOut_epi_packed = rOut_epi[index]
-                                    atomic_add_func(rOut_epi_packed, scatter_out_offset)
-
-                if cutlass.const_expr(self.use_blkred):
-                    cute.arch.fence_proxy(
-                        "async.shared",
-                        space="cta",
-                    )
+                # Make all R2S smem writes visible to the async bulk-reduce proxy.
+                cute.arch.fence_proxy(
+                    "async.shared",
+                    space="cta",
+                )
                 #
                 # Async arrive accumulator buffer empty
                 #
                 if cutlass.const_expr(not self.overlapping_accum):
                     cute.arch.fence_view_async_tmem_load()
-                    with cute.arch.elect_one():
-                        acc_pipeline.consumer_release(acc_consumer_state)
+                    acc_pipeline.consumer_release(acc_consumer_state)
                     acc_consumer_state.advance()
 
-                if cutlass.const_expr(self.use_blkred):
-                    cute.arch.fence_proxy(
-                        "async.shared",
-                        space="cta",
-                    )
-                    if is_valid_row:
-                        coord_n = mma_tile_coord_mnl[1] * self.cta_tile_shape_mnk[1]
-                        scatter_out_offset = cute.domain_offset((token_idx, coord_n, 0), out)
-                        if cutlass.const_expr(self.out_dtype == cutlass.BFloat16):
-                            blk_reduce_bf16(
-                                scatter_out_offset,
-                                sC[epi_tidx, None, 0],
-                                cutlass.Int32(self.copy_size),
-                            )
-                        elif cutlass.const_expr(self.out_dtype == cutlass.Float32):
-                            blk_reduce_fp32(
-                                scatter_out_offset,
-                                sC[epi_tidx, None, 0],
-                                cutlass.Int32(self.copy_size),
-                            )
-                        elif cutlass.const_expr(self.out_dtype == cutlass.Float16):
-                            blk_reduce_fp16(
-                                scatter_out_offset,
-                                sC[epi_tidx, None, 0],
-                                cutlass.Int32(self.copy_size),
-                            )
-                    self.epilog_sync_barrier.arrive_and_wait()
+                # Whole-row async bulk reduce (smem -> global scatter-add).
+                if is_valid_row:
+                    coord_n = mma_tile_coord_mnl[1] * self.cta_tile_shape_mnk[1]
+                    scatter_out_offset = cute.domain_offset((token_idx, coord_n, 0), out)
+                    if cutlass.const_expr(self.out_dtype == cutlass.BFloat16):
+                        blk_reduce_bf16(
+                            scatter_out_offset,
+                            sC[epi_tidx, None, 0],
+                            cutlass.Int32(self.copy_size),
+                        )
+                    elif cutlass.const_expr(self.out_dtype == cutlass.Float32):
+                        blk_reduce_fp32(
+                            scatter_out_offset,
+                            sC[epi_tidx, None, 0],
+                            cutlass.Int32(self.copy_size),
+                        )
+                    elif cutlass.const_expr(self.out_dtype == cutlass.Float16):
+                        blk_reduce_fp16(
+                            scatter_out_offset,
+                            sC[epi_tidx, None, 0],
+                            cutlass.Int32(self.copy_size),
+                        )
+
+                cute.arch.cp_async_bulk_commit_group()
+                cute.arch.cp_async_bulk_wait_group(0, read=True)
+                self.epilog_sync_barrier.arrive_and_wait()
 
                 # Advance to next tile
                 #
@@ -1945,7 +1900,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         sf_vec_size: int,
         num_smem_capacity: int,
         occupancy: int,
-        use_blkred: bool,
     ) -> Tuple[int, int, int]:
         """Computes the number of stages for A/B/C operands based on heuristics.
 
@@ -1969,8 +1923,6 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         :type num_smem_capacity: int
         :param occupancy: Target number of CTAs per SM (occupancy).
         :type occupancy: int
-        :param use_blkred: Whether to use block reduce.
-        :type use_blkred: bool
 
         :return: A tuple containing the computed number of stages for:
                  (ACC stages, A/B operand stages, C stages)
@@ -2035,14 +1987,9 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         # Start with total smem per CTA (capacity / occupancy)
         # Subtract reserved bytes and initial C stages bytes
         # Divide remaining by bytes needed per A/B stage
-        if cutlass.const_expr(use_blkred):
-            num_ab_stage = (
-                num_smem_capacity // occupancy - (mbar_helpers_bytes + c_bytes)
-            ) // ab_bytes_per_stage
-        else:
-            num_ab_stage = (
-                num_smem_capacity // occupancy - mbar_helpers_bytes
-            ) // ab_bytes_per_stage
+        num_ab_stage = (
+            num_smem_capacity // occupancy - (mbar_helpers_bytes + c_bytes)
+        ) // ab_bytes_per_stage
 
         return num_acc_stage, num_ab_stage, num_c_stage, num_tile_stage
 

--- a/tests/scripts/cute_dsl_kernels/run_blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/tests/scripts/cute_dsl_kernels/run_blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Redistribution and use in source and binary forms, with or without
@@ -507,7 +507,6 @@ def run(
     topK: int = 8,
     seq_len: int = 4096,
     raster_along_m: bool = False,
-    use_blkred: bool = False,
     use_cupti: bool = False,
     **kwargs,
 ):
@@ -536,7 +535,6 @@ def run(
     :param seq_len: Sequence length for MoE, used by fused finalize,
             need to know the sequence length to do finalize correctly.
     :param raster_along_m: If True, raster along M dimension for tile scheduler.
-    :param use_blkred: If True, enable block reduction.
     :param use_cupti (bool, optional): If True, uses CUPTI to measure execution time.
             Defaults to False.
     """
@@ -561,7 +559,6 @@ def run(
     print(f"Skip reference checking: {skip_ref_check}")
     print(f"Use TMA prefetch: {'True'}")
     print(f"Raster along M: {raster_along_m}")
-    print(f"Use blkred: {use_blkred}")
     print(f"Use CUPTI: {'True' if use_cupti else 'False'}")
 
     # Unpack parameters
@@ -655,7 +652,6 @@ def run(
         sf_vec_size,
         mma_tiler_mn,
         cluster_shape_mn,
-        use_blkred=use_blkred,
         raster_along_m=raster_along_m,
     )
 
@@ -1055,13 +1051,6 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--use_blkred",
-        action="store_true",
-        default=False,
-        help="Enable block reduction (default: False)",
-    )
-
-    parser.add_argument(
         "--use_cupti",
         action="store_true",
         default=False,
@@ -1107,7 +1096,6 @@ if __name__ == "__main__":
         args.topk,
         args.seq_len,
         args.raster_along_m,
-        args.use_blkred,
         args.use_cupti,
     )
     print("exec_time: ", exec_time)

--- a/tests/scripts/cute_dsl_kernels/run_blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/tests/scripts/cute_dsl_kernels/run_blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -680,7 +680,6 @@ def run(
         current_stream,
         permuted_idx_to_expanded_idx,
         token_final_scales,
-        options="--opt-level 2",
     )
 
     # Compute reference result

--- a/tests/scripts/cute_dsl_kernels/run_dense_blockscaled_gemm_persistent.py
+++ b/tests/scripts/cute_dsl_kernels/run_dense_blockscaled_gemm_persistent.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
 # Redistribution and use in source and binary forms, with or without
@@ -306,6 +306,10 @@ def run(
     # Initialize Stream
     current_stream = cutlass_torch.default_stream()
 
+    # alpha: kernel expects a single-element device tensor (uses alpha[0])
+    alpha_torch = torch.ones((1,), dtype=torch.float32).cuda()
+    alpha_tensor = from_dlpack(alpha_torch).mark_layout_dynamic()
+
     # Compile gemm kernel
     compiled_gemm = cute.compile(
         gemm,
@@ -314,7 +318,7 @@ def run(
         sfa_tensor,
         sfb_tensor,
         c_tensor,
-        1.0,  # alpha
+        alpha_tensor,  # alpha
         max_active_clusters,
         current_stream,
         options="--opt-level 2",
@@ -323,7 +327,9 @@ def run(
     # Compute reference result
     if not skip_ref_check:
         # Execute kernel once for reference checking
-        compiled_gemm(a_tensor, b_tensor, sfa_tensor, sfb_tensor, c_tensor, 1.0, current_stream)
+        compiled_gemm(
+            a_tensor, b_tensor, sfa_tensor, sfb_tensor, c_tensor, alpha_tensor, current_stream
+        )
         print("Verifying results...")
         res_a = torch.einsum("mkl,mkl->mkl", a_ref, sfa_ref)
         res_b = torch.einsum("nkl,nkl->nkl", b_ref, sfb_ref)
@@ -386,7 +392,7 @@ def run(
         _, sfa_tensor, _ = create_scale_factor_tensor(batch, m, k, sf_vec_size, sf_dtype)
         _, sfb_tensor, _ = create_scale_factor_tensor(batch, n, k, sf_vec_size, sf_dtype)
         return cute.testing.JitArguments(
-            a_tensor, b_tensor, sfa_tensor, sfb_tensor, c_tensor, 1.0, current_stream
+            a_tensor, b_tensor, sfa_tensor, sfb_tensor, c_tensor, alpha_tensor, current_stream
         )
 
     workspace_count = 1


### PR DESCRIPTION
@coderabbitai 

FC1: fix acc early release by changing acc release pipeline threads
FC2: Removing non bulk reduction path and add commit/wait group for functionality completeness, separate a new warp for epilogue meta data loading

Others: fix dense blockscaled gemm test scripts

## CuteDSL MoE fc1/fc2 perf — baseline vs this PR

**Platform:** NVIDIA **B200** (driver 610.43.02, 183 GB), nvidia-cutlass-dsl **4.5.2**
**Measurement:** CuteDSL standalone test scripts, cupti + cold-L2, warmup 10 / 50 iters, per-case (each case's variants run back-to-back to control clock drift). NVFP4 inputs; **fc1 output NVFP4**, **fc2 output BF16**.
**Compare:** `baseline` = pre-optimization (merge-base `a50b5e2d`, fc2 `use_blkred=True`) vs **`this PR`** (`21a34e20`).

### DeepSeek V3 (hidden 7168 / inner 2048)

| phase | config (tok/exp × experts, tiler/cluster) | kernel | baseline (µs) | this PR (µs) | Δ | speedup |
|-------|-------------------------------------------|--------|--------------:|-------------:|------:|--------:|
| gen | 128 × 8, 128×128 1×1 | fc1 | 38.41 | 38.32 | −0.2% | 1.00× |
| gen | 128 × 8, 128×128 1×1 | fc2 | 19.10 | 18.48 | −3.3% | 1.03× |
| ctx | 1024 × 64, 256×256 2×1 | fc1 | 682.64 | 664.90 | −2.6% | 1.03× |
| ctx | 1024 × 64, 256×256 2×1 | fc2 | 409.61 | 403.22 | −1.6% | 1.02× |

### Hunyuan V3 (hidden 4096 / inner 1536)

| phase | config (tok/exp × experts, tiler/cluster) | kernel | baseline (µs) | this PR (µs) | Δ | speedup |
|-------|-------------------------------------------|--------|--------------:|-------------:|------:|--------:|
| ctx | 1050 × 192, 256×256 2×1 | fc1 | 1160.88 | 1082.20 | **−6.8%** | **1.07×** |
| ctx | 1050 × 192, 256×256 2×1 | fc2 | 729.15 | 680.03 | **−6.7%** | **1.07×** |

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized kernel pipeline synchronization for block-scaled GEMM operations.
  * Simplified kernel configuration by removing the `use_blkred` parameter; shared storage and epilogue processing now use a unified code path.
  * Improved shared-memory allocation and accumulator buffer management in finalize-fusion kernels.

* **Chores**
  * Updated test scripts to reflect API changes and adjusted kernel invocation parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->