### PR TITLE
[TRTLLM-13302][feat] Register NVIDIA Wan2.2-T2V quantized checkpoints

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/cosmos3/pipeline_cosmos3.py
+++ b/tensorrt_llm/_torch/visual_gen/models/cosmos3/pipeline_cosmos3.py
@@ -57,8 +57,8 @@ TRTLLM_DISABLE_COSMOS3_GUARDRAILS = os.environ.get("TRTLLM_DISABLE_COSMOS3_GUARD
     hf_ids=[
         "nvidia/Cosmos3-Nano",
         "nvidia/Cosmos3-Super",
-        "nvidia/Cosmos3-Super-Text2Image",
         "nvidia/Cosmos3-Super-Image2Video",
+        "nvidia/Cosmos3-Super-Text2Image",
     ],
     doc="Cosmos3 Omnimodal world models.",
 )

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
@@ -85,6 +85,8 @@ WAN_DEFAULT_NEGATIVE_PROMPT = (
         "Wan-AI/Wan2.1-T2V-14B-Diffusers",
         "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
         "Wan-AI/Wan2.2-TI2V-5B-Diffusers",
+        "nvidia/Wan2.2-T2V-A14B-Diffusers-FP8",
+        "nvidia/Wan2.2-T2V-A14B-Diffusers-NVFP4",
     ],
     doc="Wan 2.1 & 2.2 text-to-video family.",
 )

--- a/tensorrt_llm/visual_gen/visual_gen.py
+++ b/tensorrt_llm/visual_gen/visual_gen.py
@@ -680,11 +680,18 @@ class VisualGen:
     def supported_models(cls) -> List[str]:
         """Return canonical HuggingFace model IDs of every registered pipeline.
 
-        Fine-tunes inherit the parent's Diffusers ``_class_name`` and dispatch
-        automatically without needing to appear in this list. The result is
-        a fresh list — mutating it does not affect the underlying registry.
+        The returned list is a *subset* of the variants each pipeline can
+        actually run. It typically contains the original official upstream
+        checkpoints and well-known optimized checkpoints (e.g. NVIDIA NVFP4 /
+        FP8 quantizations published on HuggingFace). Other variants —
+        community fine-tunes and quantizations not enumerated here — inherit
+        the parent's Diffusers ``_class_name`` and dispatch automatically
+        without needing to appear in this list.
+
+        IDs are returned sorted alphabetically for stable, easy-to-scan
+        output.
         """
-        return [hf_id for entry in PIPELINE_REGISTRY.values() for hf_id in entry.hf_ids]
+        return sorted(hf_id for entry in PIPELINE_REGISTRY.values() for hf_id in entry.hf_ids)
 
     @classmethod
     @set_api_status("prototype")

--- a/tensorrt_llm/visual_gen/visual_gen.py
+++ b/tensorrt_llm/visual_gen/visual_gen.py
@@ -683,13 +683,12 @@ class VisualGen:
         The returned list is a *subset* of the variants each pipeline can
         actually run. It typically contains the original official upstream
         checkpoints and well-known optimized checkpoints (e.g. NVIDIA NVFP4 /
-        FP8 quantizations published on HuggingFace). Other variants —
-        community fine-tunes and quantizations not enumerated here — inherit
-        the parent's Diffusers ``_class_name`` and dispatch automatically
-        without needing to appear in this list.
+        FP8 quantizations published on HuggingFace) that have been tested.
+        Other variants — community fine-tunes and quantizations not
+        enumerated here while some of them may run if no model architecture
+        changes.
 
-        IDs are returned sorted alphabetically for stable, easy-to-scan
-        output.
+        IDs are returned sorted alphabetically for stable.
         """
         return sorted(hf_id for entry in PIPELINE_REGISTRY.values() for hf_id in entry.hf_ids)
 


### PR DESCRIPTION
## Description

Adds the NVIDIA Model Optimizer-quantized Wan2.2-T2V-A14B checkpoints from the
[Inference Optimized Checkpoints collection](https://huggingface.co/collections/nvidia/inference-optimized-checkpoints-with-model-optimizer)
to `WanPipeline.hf_ids` so they surface in `VisualGen.supported_models()` and have a canonical
`VisualGen.pipeline_config(...)` entry:
- `nvidia/Wan2.2-T2V-A14B-Diffusers-NVFP4`
- `nvidia/Wan2.2-T2V-A14B-Diffusers-FP8`

Also clarifies what `VisualGen.supported_models()` actually returns. The intent of the list has been
ambiguous — it does not, and cannot, enumerate every checkpoint a pipeline can run, since community
fine-tunes and re-quantized variants are routed automatically via the Diffusers `_class_name` in
`model_index.json`. The docstring now states the list is a *subset* of supported variants, typically
the official upstream checkpoints plus well-known optimized checkpoints (e.g. NVIDIA NVFP4 / FP8).
The result is also returned sorted for stable, easy-to-scan output; uniqueness is already enforced by
`tests/unittest/_torch/visual_gen/test_visual_gen_args.py::TestPipelineRegistryUnique`.

A sweep of the NVIDIA inference-optimized-checkpoints collection at submission time found no other
image/video-gen models compatible with an existing VisualGen pipeline: the FLUX.1-dev-onnx entry is
ONNX-only and does not fit `FluxPipeline`, and no NVIDIA quant variants are currently published for
`Flux2Pipeline`, `LTX2Pipeline`, `Cosmos3OmniMoTPipeline`, `QwenImagePipeline`, or
`WanImageToVideoPipeline`. Revisit when new checkpoints land.

## Test Coverage

- Existing `TestPipelineRegistryUnique` tests (`test_no_duplicate_hf_ids`, `test_supported_models_no_duplicates`) cover the new entries automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two Wan2.2 A14B Diffusers model variants with NVFP4 and FP8 precision.

* **Documentation**
  * Updated supported models list to return results in deterministic alphabetical order for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->