### PR TITLE
[TRTLLM-12807][refactor] Declare FMHA backend capabilities

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/fmha.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha.py
@@ -15,7 +15,7 @@
 import weakref
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, ClassVar, Optional
+from typing import TYPE_CHECKING, ClassVar, Generic, Optional, TypeVar
 
 import torch
 
@@ -29,6 +29,8 @@ from .interface import AttentionForwardArgs, AttentionInputType
 
 if TYPE_CHECKING:
     from .trtllm import TrtllmAttention, TrtllmAttentionMetadata
+
+T = TypeVar("T")
 
 
 # ``AttentionForwardArgs`` fields that the fallback ``thop.attention`` call
@@ -53,13 +55,8 @@ _THOP_LITERALS: dict = {
 @dataclass(frozen=True, slots=True)
 class DTypeCombination:
     q: torch.dtype
-    kv_cache: DataType
+    kv_cache: Optional[DataType]
     output: torch.dtype
-
-
-class FmhaPhase(Enum):
-    context = "context"
-    generation = "generation"
 
 
 class FmhaFeature(Enum):
@@ -73,6 +70,53 @@ class FmhaFeature(Enum):
     skip_softmax_attention = "skip_softmax_attention"
     padded_input = "padded_input"
     position_shift = "position_shift"
+
+
+class FmhaQkvMode(Enum):
+    fused_qkv = "fused_qkv"
+    separate_qkv = "separate_qkv"
+    separate_qkv_sage = "separate_qkv_sage"
+
+
+class FmhaKvCacheUpdateMode(Enum):
+    update = "update"
+    no_update = "no_update"
+
+
+class MlaRopeLayout(Enum):
+    appended = "appended"
+    separate = "separate"
+
+
+def _accepted_value_name(value: object) -> str:
+    if isinstance(value, Enum):
+        return value.name
+    return str(value)
+
+
+@dataclass(frozen=True, slots=True)
+class AcceptedValues(Generic[T]):
+    values: frozenset[T] = field(default_factory=frozenset)
+
+    def accepts(self, value: T) -> bool:
+        return value in self.values
+
+    def describe(self) -> str:
+        return f"values={sorted(_accepted_value_name(value) for value in self.values)}"
+
+
+@dataclass(frozen=True, slots=True)
+class AcceptedFeatureSet:
+    values: frozenset[FmhaFeature] = field(default_factory=frozenset)
+
+    def accepts(self, features: frozenset[FmhaFeature]) -> bool:
+        return features <= self.values
+
+    def rejected(self, features: frozenset[FmhaFeature]) -> frozenset[FmhaFeature]:
+        return features - self.values
+
+    def describe(self) -> str:
+        return f"values={sorted(feature.value for feature in self.values)}"
 
 
 @dataclass(frozen=True, slots=True)
@@ -105,65 +149,137 @@ class AcceptedIntegerValues:
 class MlaGenerationCase:
     head_dim_qk: int
     head_dim_v: int
-    tokens_per_block: int
+    tokens_per_block: AcceptedIntegerValues
+
+    def accepts(self, head_dim_qk: int, head_dim_v: int, tokens_per_block: int) -> bool:
+        return (
+            self.head_dim_qk == head_dim_qk
+            and self.head_dim_v == head_dim_v
+            and self.tokens_per_block.accepts(tokens_per_block)
+        )
+
+    def describe(self) -> tuple[int, int, str]:
+        return (self.head_dim_qk, self.head_dim_v, self.tokens_per_block.describe())
 
 
-def _all_attention_input_types() -> frozenset[AttentionInputType]:
-    return frozenset(AttentionInputType)
+@dataclass(frozen=True, slots=True)
+class MlaContextCase:
+    kv_lora_rank: int
+    qk_nope_head_dim: int
+    qk_rope_head_dim: int
+    v_head_dim: int
+    mla_rope_layout: MlaRopeLayout
+    qkv_mode: FmhaQkvMode
+    runtime_features: AcceptedFeatureSet
+    required_runtime_features: frozenset[FmhaFeature] = field(default_factory=frozenset)
+
+    def accepts(self, context: "FmhaSupportContext") -> bool:
+        return (
+            self.kv_lora_rank == context.kv_lora_rank
+            and self.qk_nope_head_dim == context.qk_nope_head_dim
+            and self.qk_rope_head_dim == context.qk_rope_head_dim
+            and self.v_head_dim == context.v_head_dim
+            and self.mla_rope_layout == context.mla_rope_layout
+            and self.qkv_mode == context.qkv_mode
+            and self.runtime_features.accepts(context.runtime_features)
+            and self.required_runtime_features <= context.runtime_features
+        )
+
+    def describe(self) -> tuple[int, int, int, int, str, str, str, list[str]]:
+        return (
+            self.kv_lora_rank,
+            self.qk_nope_head_dim,
+            self.qk_rope_head_dim,
+            self.v_head_dim,
+            self.mla_rope_layout.value,
+            self.qkv_mode.value,
+            self.runtime_features.describe(),
+            sorted(feature.value for feature in self.required_runtime_features),
+        )
 
 
-def _all_attention_mask_types() -> frozenset[AttentionMaskType]:
-    return frozenset(AttentionMaskType)
+def _accepted_attention_input_type() -> AcceptedValues[AttentionInputType]:
+    return AcceptedValues(values=frozenset(AttentionInputType))
 
 
-def _all_position_embedding_types() -> frozenset[PositionEmbeddingType]:
-    return frozenset(PositionEmbeddingType)
+def _accepted_mask_type() -> AcceptedValues[AttentionMaskType]:
+    return AcceptedValues(values=frozenset(AttentionMaskType))
 
 
-def _all_fmha_phases() -> frozenset[FmhaPhase]:
-    return frozenset(FmhaPhase)
+def _accepted_position_embedding_type() -> AcceptedValues[PositionEmbeddingType]:
+    return AcceptedValues(values=frozenset(PositionEmbeddingType))
 
 
-def _all_fmha_features() -> frozenset[FmhaFeature]:
-    return frozenset(FmhaFeature)
+def _accepted_runtime_features() -> AcceptedFeatureSet:
+    return AcceptedFeatureSet(values=frozenset(FmhaFeature))
 
 
 def _positive_integers() -> AcceptedIntegerValues:
     return AcceptedIntegerValues(min_value=1)
 
 
+def _accepted_qkv_mode() -> AcceptedValues[FmhaQkvMode]:
+    return AcceptedValues(values=frozenset(FmhaQkvMode))
+
+
+def _accepted_kv_cache_update_mode() -> AcceptedValues[FmhaKvCacheUpdateMode]:
+    return AcceptedValues(values=frozenset(FmhaKvCacheUpdateMode))
+
+
+@dataclass(frozen=True, slots=True)
+class StandardPhaseCapabilities:
+    dtype_combinations: frozenset[DTypeCombination] = field(default_factory=frozenset)
+    head_size: AcceptedIntegerValues = field(default_factory=_positive_integers)
+    qkv_mode: AcceptedValues[FmhaQkvMode] = field(default_factory=_accepted_qkv_mode)
+    kv_cache_update_mode: AcceptedValues[FmhaKvCacheUpdateMode] = field(
+        default_factory=_accepted_kv_cache_update_mode
+    )
+    mask_type: AcceptedValues[AttentionMaskType] = field(default_factory=_accepted_mask_type)
+    position_embedding_type: AcceptedValues[PositionEmbeddingType] = field(
+        default_factory=_accepted_position_embedding_type
+    )
+    runtime_features: AcceptedFeatureSet = field(default_factory=_accepted_runtime_features)
+    phase_features: AcceptedFeatureSet = field(default_factory=_accepted_runtime_features)
+    required_runtime_features: frozenset[FmhaFeature] = field(default_factory=frozenset)
+
+
+@dataclass(frozen=True, slots=True)
+class MlaPhaseCapabilities:
+    dtype_combinations: frozenset[DTypeCombination] = field(default_factory=frozenset)
+    context_cases: frozenset[MlaContextCase] = field(default_factory=frozenset)
+    generation_cases: frozenset[MlaGenerationCase] = field(default_factory=frozenset)
+    qkv_mode: AcceptedValues[FmhaQkvMode] = field(default_factory=_accepted_qkv_mode)
+    kv_cache_update_mode: AcceptedValues[FmhaKvCacheUpdateMode] = field(
+        default_factory=_accepted_kv_cache_update_mode
+    )
+    mask_type: AcceptedValues[AttentionMaskType] = field(default_factory=_accepted_mask_type)
+    position_embedding_type: AcceptedValues[PositionEmbeddingType] = field(
+        default_factory=_accepted_position_embedding_type
+    )
+    runtime_features: AcceptedFeatureSet = field(default_factory=_accepted_runtime_features)
+    phase_features: AcceptedFeatureSet = field(default_factory=_accepted_runtime_features)
+    required_runtime_features: frozenset[FmhaFeature] = field(default_factory=frozenset)
+
+
 @dataclass(frozen=True, slots=True)
 class PhaseCapabilities:
-    dtype_combinations: frozenset[DTypeCombination] = field(default_factory=frozenset)
-    head_sizes: AcceptedIntegerValues = field(default_factory=_positive_integers)
-    mask_types: frozenset[AttentionMaskType] = field(default_factory=_all_attention_mask_types)
-    position_embedding_types: frozenset[PositionEmbeddingType] = field(
-        default_factory=_all_position_embedding_types
-    )
-    features: frozenset[FmhaFeature] = field(default_factory=_all_fmha_features)
-
-
-@dataclass(frozen=True, slots=True)
-class MlaCapabilities:
-    phases: frozenset[FmhaPhase] = field(default_factory=_all_fmha_phases)
-    generation_cases: frozenset[MlaGenerationCase] = field(default_factory=frozenset)
+    standard: Optional[StandardPhaseCapabilities] = None
+    mla: Optional[MlaPhaseCapabilities] = None
 
 
 @dataclass(frozen=True, slots=True)
 class FmhaCapabilities:
-    name: str
-    sm_versions: AcceptedIntegerValues = field(default_factory=AcceptedIntegerValues)
-    attention_input_types: frozenset[AttentionInputType] = field(
-        default_factory=_all_attention_input_types
+    sm: AcceptedIntegerValues = field(default_factory=AcceptedIntegerValues)
+    attention_input_type: AcceptedValues[AttentionInputType] = field(
+        default_factory=_accepted_attention_input_type
     )
-    runtime_features: frozenset[FmhaFeature] = field(default_factory=_all_fmha_features)
+    runtime_features: AcceptedFeatureSet = field(default_factory=_accepted_runtime_features)
     required_runtime_features: frozenset[FmhaFeature] = field(default_factory=frozenset)
     tokens_per_block: AcceptedIntegerValues = field(default_factory=_positive_integers)
-    generation_beam_widths: AcceptedIntegerValues = field(default_factory=_positive_integers)
-    generation_head_ratios: AcceptedIntegerValues = field(default_factory=_positive_integers)
+    beam_width: AcceptedIntegerValues = field(default_factory=_positive_integers)
+    num_heads_per_kv_head: AcceptedIntegerValues = field(default_factory=_positive_integers)
     context: PhaseCapabilities = field(default_factory=PhaseCapabilities)
     generation: PhaseCapabilities = field(default_factory=PhaseCapabilities)
-    mla: MlaCapabilities = field(default_factory=MlaCapabilities)
 
 
 @dataclass(frozen=True, slots=True)
@@ -184,7 +300,12 @@ class FmhaSupportContext:
     use_paged_kv_cache: bool
     is_mla_enable: bool
     kv_lora_rank: Optional[int]
+    qk_nope_head_dim: Optional[int]
     qk_rope_head_dim: Optional[int]
+    v_head_dim: Optional[int]
+    mla_rope_layout: Optional[MlaRopeLayout]
+    is_fused_qkv: bool
+    update_kv_cache: bool
     has_context_phase: bool
     has_generation_phase: bool
     is_cross_attention: bool
@@ -218,6 +339,39 @@ class FmhaSupportContext:
         return frozenset(features)
 
     @property
+    def qkv_mode(self) -> FmhaQkvMode:
+        if self.is_fused_qkv:
+            return FmhaQkvMode.fused_qkv
+        if self.use_sage_attention:
+            return FmhaQkvMode.separate_qkv_sage
+        return FmhaQkvMode.separate_qkv
+
+    @property
+    def kv_cache_update_mode(self) -> FmhaKvCacheUpdateMode:
+        if self.update_kv_cache:
+            return FmhaKvCacheUpdateMode.update
+        return FmhaKvCacheUpdateMode.no_update
+
+    @property
+    def dtype_combination(self) -> DTypeCombination:
+        output_dtype = self.output_dtype if self.output_dtype is not None else self.q_dtype
+        return DTypeCombination(self.q_dtype, self.kv_cache_dtype, output_dtype)
+
+    @property
+    def num_heads_per_kv_head(self) -> int:
+        return self.num_heads // self.num_kv_heads
+
+    @property
+    def head_dim_qk(self) -> Optional[int]:
+        if self.kv_lora_rank is None or self.qk_rope_head_dim is None:
+            return None
+        return self.kv_lora_rank + self.qk_rope_head_dim
+
+    @property
+    def head_dim_v(self) -> Optional[int]:
+        return self.kv_lora_rank
+
+    @property
     def phase_features(self) -> frozenset[FmhaFeature]:
         features: set[FmhaFeature] = set()
         if self.is_padded:
@@ -236,7 +390,6 @@ class FmhaSupportContext:
     ) -> "FmhaSupportContext":
         kv_cache_manager = metadata.kv_cache_manager
         kv_cache_dtype = kv_cache_manager.dtype if kv_cache_manager is not None else None
-        q_dtype = torch.float8_e4m3fn if kv_cache_dtype == DataType.NVFP4 else q.dtype
         output_dtype = forward_args.output.dtype if forward_args.output is not None else None
 
         attention_input_type = forward_args.attention_input_type
@@ -259,7 +412,7 @@ class FmhaSupportContext:
 
         return cls(
             sm=get_sm_version(),
-            q_dtype=q_dtype,
+            q_dtype=q.dtype,
             kv_cache_dtype=kv_cache_dtype,
             output_dtype=output_dtype,
             num_heads=attn.num_heads,
@@ -274,7 +427,18 @@ class FmhaSupportContext:
             use_paged_kv_cache=metadata.kv_cache_block_offsets is not None,
             is_mla_enable=attn.is_mla_enable,
             kv_lora_rank=attn.kv_lora_rank,
+            qk_nope_head_dim=attn.qk_nope_head_dim,
             qk_rope_head_dim=attn.qk_rope_head_dim,
+            v_head_dim=attn.v_head_dim,
+            mla_rope_layout=(
+                None
+                if attn.rope_append is None
+                else MlaRopeLayout.appended
+                if attn.rope_append
+                else MlaRopeLayout.separate
+            ),
+            is_fused_qkv=forward_args.is_fused_qkv,
+            update_kv_cache=forward_args.update_kv_cache,
             has_context_phase=has_context_phase,
             has_generation_phase=has_generation_phase,
             is_cross_attention=metadata.is_cross,
@@ -296,7 +460,7 @@ class BaseFmha:
 
     @property
     def name(self) -> str:
-        return self.capabilities.name
+        return type(self).__name__
 
     def _get_attention_layer(self) -> "TrtllmAttention":
         attention_layer = self._attention_layer_ref()
@@ -306,7 +470,7 @@ class BaseFmha:
 
     @classmethod
     def _not_supported(cls, reason: str) -> bool:
-        logger.debug("FMHA %s unsupported: %s", cls.capabilities.name, reason)
+        logger.debug("FMHA %s unsupported: %s", cls.__name__, reason)
         return False
 
     @classmethod
@@ -328,21 +492,183 @@ class BaseFmha:
 def _dtype_combo_supported(
     fmha_cls: type[BaseFmha],
     phase_name: str,
-    phase: PhaseCapabilities,
+    phase: StandardPhaseCapabilities | MlaPhaseCapabilities,
     context: FmhaSupportContext,
 ) -> bool:
     if not phase.dtype_combinations:
         return True
-    if context.kv_cache_dtype is None:
-        return fmha_cls._not_supported(f"[{phase_name}] missing KV cache dtype.")
-    output_dtype = context.output_dtype if context.output_dtype is not None else context.q_dtype
-    combo = DTypeCombination(context.q_dtype, context.kv_cache_dtype, output_dtype)
+    combo = context.dtype_combination
     if combo not in phase.dtype_combinations:
         return fmha_cls._not_supported(
             f"[{phase_name}] unsupported dtype combination: "
-            f"Q={context.q_dtype}, KV={context.kv_cache_dtype}, O={output_dtype}.",
+            f"Q={combo.q}, KV={combo.kv_cache}, O={combo.output}.",
         )
     return True
+
+
+def _common_phase_properties_supported(
+    fmha_cls: type[BaseFmha],
+    phase_name: str,
+    phase: StandardPhaseCapabilities | MlaPhaseCapabilities,
+    context: FmhaSupportContext,
+) -> bool:
+    if not phase.mask_type.accepts(context.mask_type):
+        return fmha_cls._not_supported(
+            f"[{phase_name}] mask type {context.mask_type.name} is not accepted. "
+            f"Accepted: {phase.mask_type.describe()}."
+        )
+    if not phase.position_embedding_type.accepts(context.position_embedding_type):
+        return fmha_cls._not_supported(
+            f"[{phase_name}] position embedding type {context.position_embedding_type.name} is not accepted. "
+            f"Accepted: {phase.position_embedding_type.describe()}."
+        )
+    unavailable_features = phase.phase_features.rejected(context.phase_features)
+    if unavailable_features:
+        return fmha_cls._not_supported(
+            f"[{phase_name}] feature(s) not accepted: "
+            f"{', '.join(sorted(feature.value for feature in unavailable_features))}."
+        )
+    unavailable_runtime_features = phase.runtime_features.rejected(context.runtime_features)
+    if unavailable_runtime_features:
+        return fmha_cls._not_supported(
+            f"[{phase_name}] runtime feature(s) are not accepted: "
+            f"{', '.join(sorted(feature.value for feature in unavailable_runtime_features))}."
+        )
+    missing_required_features = phase.required_runtime_features - context.runtime_features
+    if missing_required_features:
+        return fmha_cls._not_supported(
+            f"[{phase_name}] required runtime feature(s) are absent: "
+            f"{', '.join(sorted(feature.value for feature in missing_required_features))}."
+        )
+    return _dtype_combo_supported(fmha_cls, phase_name, phase, context)
+
+
+def _standard_phase_supported(
+    fmha_cls: type[BaseFmha],
+    phase_name: str,
+    phase: StandardPhaseCapabilities,
+    context: FmhaSupportContext,
+) -> bool:
+    if not phase.head_size.accepts(context.head_size):
+        return fmha_cls._not_supported(
+            f"[{phase_name}] head size {context.head_size} is not accepted. "
+            f"Accepted: {phase.head_size.describe()}."
+        )
+    if not phase.qkv_mode.accepts(context.qkv_mode):
+        return fmha_cls._not_supported(
+            f"[{phase_name}] QKV mode {context.qkv_mode.value} is not accepted. "
+            f"Accepted: {phase.qkv_mode.describe()}."
+        )
+    if not phase.kv_cache_update_mode.accepts(context.kv_cache_update_mode):
+        return fmha_cls._not_supported(
+            f"[{phase_name}] KV cache update mode {context.kv_cache_update_mode.value} is not accepted. "
+            f"Accepted: {phase.kv_cache_update_mode.describe()}."
+        )
+    return _common_phase_properties_supported(fmha_cls, phase_name, phase, context)
+
+
+def _mla_context_supported(
+    fmha_cls: type[BaseFmha],
+    phase_name: str,
+    phase: MlaPhaseCapabilities,
+    context: FmhaSupportContext,
+) -> bool:
+    missing_params = [
+        name
+        for name, value in (
+            ("kv_lora_rank", context.kv_lora_rank),
+            ("qk_nope_head_dim", context.qk_nope_head_dim),
+            ("qk_rope_head_dim", context.qk_rope_head_dim),
+            ("v_head_dim", context.v_head_dim),
+            ("mla_rope_layout", context.mla_rope_layout),
+        )
+        if value is None or (isinstance(value, int) and value <= 0)
+    ]
+    if missing_params:
+        return fmha_cls._not_supported(
+            f"[{phase_name}][MLA] missing required MLA parameter(s): {', '.join(missing_params)}.",
+        )
+
+    if not any(case.accepts(context) for case in phase.context_cases):
+        requested_case = (
+            context.kv_lora_rank,
+            context.qk_nope_head_dim,
+            context.qk_rope_head_dim,
+            context.v_head_dim,
+            context.mla_rope_layout.value,
+            context.qkv_mode.value,
+            sorted(feature.value for feature in context.runtime_features),
+        )
+        accepted_cases = sorted(case.describe() for case in phase.context_cases)
+        return fmha_cls._not_supported(
+            f"[{phase_name}][MLA] case {requested_case} is not accepted. Accepted: {accepted_cases}.",
+        )
+    return True
+
+
+def _mla_generation_supported(
+    fmha_cls: type[BaseFmha],
+    phase_name: str,
+    phase: MlaPhaseCapabilities,
+    context: FmhaSupportContext,
+) -> bool:
+    missing_params = [
+        name
+        for name, value in (
+            ("kv_lora_rank", context.kv_lora_rank),
+            ("qk_nope_head_dim", context.qk_nope_head_dim),
+            ("qk_rope_head_dim", context.qk_rope_head_dim),
+            ("v_head_dim", context.v_head_dim),
+        )
+        if value is None or value <= 0
+    ]
+    if missing_params:
+        return fmha_cls._not_supported(
+            f"[{phase_name}][MLA] missing required MLA parameter(s): {', '.join(missing_params)}.",
+        )
+    head_dim_qk = int(context.head_dim_qk)
+    head_dim_v = int(context.head_dim_v)
+    if context.head_size != head_dim_qk:
+        return fmha_cls._not_supported(
+            f"[{phase_name}][MLA] head_size ({context.head_size}) must match "
+            f"kv_lora_rank + qk_rope_head_dim ({head_dim_qk}).",
+        )
+
+    tokens_per_block = context.tokens_per_block or 0
+    if not any(
+        case.accepts(head_dim_qk, head_dim_v, tokens_per_block) for case in phase.generation_cases
+    ):
+        accepted_cases = sorted(case.describe() for case in phase.generation_cases)
+        return fmha_cls._not_supported(
+            f"[{phase_name}][MLA] case "
+            f"(head_dim_qk={head_dim_qk}, head_dim_v={head_dim_v}, tokens_per_block={tokens_per_block}) "
+            "is not accepted. "
+            f"Accepted: {accepted_cases}.",
+        )
+    return True
+
+
+def _mla_phase_supported(
+    fmha_cls: type[BaseFmha],
+    phase_name: str,
+    phase: MlaPhaseCapabilities,
+    context: FmhaSupportContext,
+) -> bool:
+    if not phase.qkv_mode.accepts(context.qkv_mode):
+        return fmha_cls._not_supported(
+            f"[{phase_name}][MLA] QKV mode {context.qkv_mode.value} "
+            f"is not accepted. Accepted: {phase.qkv_mode.describe()}."
+        )
+    if not phase.kv_cache_update_mode.accepts(context.kv_cache_update_mode):
+        return fmha_cls._not_supported(
+            f"[{phase_name}][MLA] KV cache update mode {context.kv_cache_update_mode.value} "
+            f"is not accepted. Accepted: {phase.kv_cache_update_mode.describe()}."
+        )
+    if not _common_phase_properties_supported(fmha_cls, f"{phase_name}][MLA", phase, context):
+        return False
+    if phase_name == "Context":
+        return _mla_context_supported(fmha_cls, phase_name, phase, context)
+    return _mla_generation_supported(fmha_cls, phase_name, phase, context)
 
 
 def _phase_supported(
@@ -351,86 +677,26 @@ def _phase_supported(
     phase: PhaseCapabilities,
     context: FmhaSupportContext,
 ) -> bool:
-    if not phase.head_sizes.accepts(context.head_size):
-        return fmha_cls._not_supported(
-            f"[{phase_name}] head size {context.head_size} is not accepted. "
-            f"Accepted: {phase.head_sizes.describe()}."
-        )
-    if context.mask_type not in phase.mask_types:
-        return fmha_cls._not_supported(
-            f"[{phase_name}] mask type {context.mask_type.name} is not accepted. "
-            f"Accepted: {[mask.name for mask in sorted(phase.mask_types, key=int)]}."
-        )
-    if context.position_embedding_type not in phase.position_embedding_types:
-        return fmha_cls._not_supported(
-            f"[{phase_name}] position embedding type {context.position_embedding_type.name} is not accepted. "
-            "Accepted: "
-            f"{[position.name for position in sorted(phase.position_embedding_types, key=int)]}."
-        )
-    unavailable_features = context.phase_features - phase.features
-    if unavailable_features:
-        return fmha_cls._not_supported(
-            f"[{phase_name}] feature(s) not accepted: "
-            f"{', '.join(sorted(feature.value for feature in unavailable_features))}."
-        )
-    return _dtype_combo_supported(fmha_cls, phase_name, phase, context)
-
-
-def _mla_generation_supported(fmha_cls: type[BaseFmha], context: FmhaSupportContext) -> bool:
-    mla = fmha_cls.capabilities.mla
-    missing_params = [
-        name
-        for name, value in (
-            ("kv_lora_rank", context.kv_lora_rank),
-            ("qk_rope_head_dim", context.qk_rope_head_dim),
-        )
-        if value is None or value <= 0
-    ]
-    if missing_params:
-        return fmha_cls._not_supported(
-            f"[Generation][MLA] missing required MLA parameter(s): {', '.join(missing_params)}.",
-        )
-
-    kv_rank = int(context.kv_lora_rank)
-    qk_rope_dim = int(context.qk_rope_head_dim)
-    head_dim_qk = kv_rank + qk_rope_dim
-    head_dim_v = kv_rank
-    if context.head_size != head_dim_qk:
-        return fmha_cls._not_supported(
-            f"[Generation][MLA] head_size ({context.head_size}) must match "
-            f"kv_lora_rank + qk_rope_head_dim ({head_dim_qk}).",
-        )
-
-    tokens_per_block = context.tokens_per_block or 0
-    generation_case = MlaGenerationCase(head_dim_qk, head_dim_v, tokens_per_block)
-    if mla.generation_cases and generation_case not in mla.generation_cases:
-        accepted_cases = sorted(
-            (
-                case.head_dim_qk,
-                case.head_dim_v,
-                case.tokens_per_block,
-            )
-            for case in mla.generation_cases
-        )
-        return fmha_cls._not_supported(
-            f"[Generation][MLA] case {generation_case} is not accepted. "
-            f"Accepted: {accepted_cases}.",
-        )
-    return True
+    if context.is_mla_enable:
+        if phase.mla is None:
+            return fmha_cls._not_supported(f"[{phase_name}][MLA] MLA is not supported.")
+        return _mla_phase_supported(fmha_cls, phase_name, phase.mla, context)
+    if phase.standard is None:
+        return fmha_cls._not_supported(f"[{phase_name}] standard attention is not supported.")
+    return _standard_phase_supported(fmha_cls, phase_name, phase.standard, context)
 
 
 def _fmha_supported_by_capabilities(fmha_cls: type[BaseFmha], context: FmhaSupportContext) -> bool:
     capabilities = fmha_cls.capabilities
 
-    if not capabilities.sm_versions.accepts(context.sm):
+    if not capabilities.sm.accepts(context.sm):
         return fmha_cls._not_supported(
-            f"SM{context.sm} is not accepted. Accepted: {capabilities.sm_versions.describe()}."
+            f"SM{context.sm} is not accepted. Accepted: {capabilities.sm.describe()}."
         )
-    if context.attention_input_type not in capabilities.attention_input_types:
+    if not capabilities.attention_input_type.accepts(context.attention_input_type):
         return fmha_cls._not_supported(
             f"attention input type {context.attention_input_type.name} is not accepted. "
-            "Accepted: "
-            f"{[input_type.name for input_type in sorted(capabilities.attention_input_types, key=int)]}."
+            f"Accepted: {capabilities.attention_input_type.describe()}."
         )
 
     runtime_features = context.runtime_features
@@ -440,7 +706,7 @@ def _fmha_supported_by_capabilities(fmha_cls: type[BaseFmha], context: FmhaSuppo
             "required runtime feature(s) are absent: "
             f"{', '.join(sorted(feature.value for feature in missing_required_features))}."
         )
-    unavailable_features = runtime_features - capabilities.runtime_features
+    unavailable_features = capabilities.runtime_features.rejected(runtime_features)
     if unavailable_features:
         return fmha_cls._not_supported(
             "runtime feature(s) are not accepted: "
@@ -457,35 +723,23 @@ def _fmha_supported_by_capabilities(fmha_cls: type[BaseFmha], context: FmhaSuppo
         )
 
     if context.has_context_phase:
-        if context.is_mla_enable and FmhaPhase.context not in capabilities.mla.phases:
-            return fmha_cls._not_supported(
-                "MLA context and mixed phases are not supported.",
-            )
-        if not context.is_mla_enable and not _phase_supported(
-            fmha_cls, "Context", capabilities.context, context
-        ):
+        if not _phase_supported(fmha_cls, "Context", capabilities.context, context):
             return False
 
     if context.has_generation_phase:
         if not _phase_supported(fmha_cls, "Generation", capabilities.generation, context):
             return False
-        if not capabilities.generation_beam_widths.accepts(context.beam_width):
+        if not capabilities.beam_width.accepts(context.beam_width):
             return fmha_cls._not_supported(
                 f"[Generation] beam width {context.beam_width} is not accepted. "
-                f"Accepted: {capabilities.generation_beam_widths.describe()}."
+                f"Accepted: {capabilities.beam_width.describe()}."
             )
         if not context.is_mla_enable:
-            heads_ratio = context.num_heads // context.num_kv_heads
-            if not capabilities.generation_head_ratios.accepts(heads_ratio):
+            if not capabilities.num_heads_per_kv_head.accepts(context.num_heads_per_kv_head):
                 return fmha_cls._not_supported(
-                    f"[Generation] heads ratio {heads_ratio} is not accepted. "
-                    f"Accepted: {capabilities.generation_head_ratios.describe()}."
+                    f"[Generation] num_heads_per_kv_head {context.num_heads_per_kv_head} is not accepted. "
+                    f"Accepted: {capabilities.num_heads_per_kv_head.describe()}."
                 )
-        if context.is_mla_enable:
-            if FmhaPhase.generation not in capabilities.mla.phases:
-                return fmha_cls._not_supported("[Generation][MLA] MLA generation is not supported.")
-            if not _mla_generation_supported(fmha_cls, context):
-                return False
 
     if context.use_paged_kv_cache:
         tokens_per_block = context.tokens_per_block or 0
@@ -497,7 +751,7 @@ def _fmha_supported_by_capabilities(fmha_cls: type[BaseFmha], context: FmhaSuppo
                 f"Accepted: {capabilities.tokens_per_block.describe()}."
             )
 
-    logger.debug("FMHA %s supported.", capabilities.name)
+    logger.debug("FMHA %s supported.", fmha_cls.__name__)
     return True
 
 
@@ -623,30 +877,421 @@ def call_thop_attention(
 
 
 class FallbackFmha(BaseFmha):
+    # Mirrors static thop / AttentionOp prechecks; tensor presence and env-sensitive
+    # checks stay in the backend call path.
     capabilities: ClassVar[FmhaCapabilities] = FmhaCapabilities(
-        name="fallback",
-        sm_versions=AcceptedIntegerValues(min_value=0),
-        attention_input_types=frozenset(AttentionInputType),
-        runtime_features=frozenset(FmhaFeature),
+        sm=AcceptedIntegerValues(min_value=0),
+        attention_input_type=AcceptedValues(
+            values=frozenset(
+                {
+                    AttentionInputType.mixed,
+                    AttentionInputType.context_only,
+                    AttentionInputType.generation_only,
+                }
+            )
+        ),
+        runtime_features=AcceptedFeatureSet(
+            values=frozenset(
+                {
+                    FmhaFeature.kv_cache_manager,
+                    FmhaFeature.paged_kv_cache,
+                    FmhaFeature.output_buffer,
+                    FmhaFeature.helix,
+                    FmhaFeature.sage_attention,
+                    FmhaFeature.sparse_attention,
+                    FmhaFeature.skip_softmax_attention,
+                }
+            )
+        ),
         required_runtime_features=frozenset(),
         tokens_per_block=AcceptedIntegerValues(min_value=1),
-        generation_beam_widths=AcceptedIntegerValues(min_value=1),
-        generation_head_ratios=AcceptedIntegerValues(min_value=1),
+        beam_width=AcceptedIntegerValues(min_value=1),
+        num_heads_per_kv_head=AcceptedIntegerValues(min_value=1),
         context=PhaseCapabilities(
-            head_sizes=AcceptedIntegerValues(min_value=1),
-            mask_types=frozenset(AttentionMaskType),
-            position_embedding_types=frozenset(PositionEmbeddingType),
-            features=frozenset(FmhaFeature),
+            standard=StandardPhaseCapabilities(
+                dtype_combinations=frozenset(
+                    {
+                        DTypeCombination(q_dtype, kv_cache_dtype, output_dtype)
+                        for kv_cache_dtype in (
+                            None,
+                            DataType.HALF,
+                            DataType.BF16,
+                            DataType.FLOAT,
+                            DataType.FP8,
+                            DataType.INT8,
+                        )
+                        for q_dtype, output_dtype in (
+                            (torch.float16, torch.float16),
+                            (torch.float16, torch.float8_e4m3fn),
+                            (torch.float16, torch.uint8),
+                            (torch.bfloat16, torch.bfloat16),
+                            (torch.bfloat16, torch.float8_e4m3fn),
+                            (torch.bfloat16, torch.uint8),
+                            (torch.float32, torch.float32),
+                        )
+                    }
+                    | {
+                        DTypeCombination(q_dtype, DataType.NVFP4, output_dtype)
+                        for q_dtype, output_dtype in (
+                            (torch.float16, torch.float16),
+                            (torch.float16, torch.float8_e4m3fn),
+                            (torch.float16, torch.uint8),
+                            (torch.bfloat16, torch.bfloat16),
+                            (torch.bfloat16, torch.float8_e4m3fn),
+                            (torch.bfloat16, torch.uint8),
+                        )
+                    }
+                ),
+                head_size=AcceptedIntegerValues(
+                    values=frozenset(
+                        {32, 48, 64, 72, 80, 96, 104, 112, 128, 144, 160, 192, 224, 256}
+                    )
+                ),
+                qkv_mode=AcceptedValues(
+                    values=frozenset({FmhaQkvMode.fused_qkv, FmhaQkvMode.separate_qkv_sage})
+                ),
+                kv_cache_update_mode=AcceptedValues(
+                    values=frozenset({FmhaKvCacheUpdateMode.update})
+                ),
+                mask_type=AcceptedValues(
+                    values=frozenset(
+                        {
+                            AttentionMaskType.padding,
+                            AttentionMaskType.causal,
+                            AttentionMaskType.sliding_window_causal,
+                            AttentionMaskType.bidirectional,
+                            AttentionMaskType.bidirectionalglm,
+                            AttentionMaskType.blocksparse,
+                            AttentionMaskType.custom_mask,
+                        }
+                    )
+                ),
+                position_embedding_type=AcceptedValues(
+                    values=frozenset(
+                        {
+                            PositionEmbeddingType.learned_absolute,
+                            PositionEmbeddingType.rope_gptj,
+                            PositionEmbeddingType.rope_gpt_neox,
+                            PositionEmbeddingType.long_rope,
+                            PositionEmbeddingType.alibi,
+                            PositionEmbeddingType.alibi_with_scale,
+                            PositionEmbeddingType.relative,
+                            PositionEmbeddingType.chatglm,
+                            PositionEmbeddingType.yarn,
+                            PositionEmbeddingType.mrope,
+                        }
+                    )
+                ),
+                runtime_features=AcceptedFeatureSet(
+                    values=frozenset(
+                        {
+                            FmhaFeature.kv_cache_manager,
+                            FmhaFeature.paged_kv_cache,
+                            FmhaFeature.output_buffer,
+                            FmhaFeature.helix,
+                            FmhaFeature.sage_attention,
+                            FmhaFeature.sparse_attention,
+                            FmhaFeature.skip_softmax_attention,
+                        }
+                    )
+                ),
+                phase_features=AcceptedFeatureSet(
+                    values=frozenset({FmhaFeature.padded_input, FmhaFeature.position_shift})
+                ),
+            ),
+            mla=MlaPhaseCapabilities(
+                dtype_combinations=frozenset(
+                    DTypeCombination(q_dtype, kv_cache_dtype, output_dtype)
+                    for kv_cache_dtype in (DataType.HALF, DataType.BF16, DataType.FP8)
+                    for q_dtype, output_dtype in (
+                        (torch.float16, torch.float16),
+                        (torch.float16, torch.float8_e4m3fn),
+                        (torch.bfloat16, torch.bfloat16),
+                        (torch.bfloat16, torch.float8_e4m3fn),
+                    )
+                ),
+                context_cases=frozenset(
+                    {
+                        MlaContextCase(
+                            512,
+                            128,
+                            64,
+                            128,
+                            MlaRopeLayout.appended,
+                            FmhaQkvMode.separate_qkv,
+                            AcceptedFeatureSet(
+                                values=frozenset(
+                                    {
+                                        FmhaFeature.kv_cache_manager,
+                                        FmhaFeature.paged_kv_cache,
+                                        FmhaFeature.output_buffer,
+                                    }
+                                )
+                            ),
+                        ),
+                        MlaContextCase(
+                            512,
+                            128,
+                            64,
+                            128,
+                            MlaRopeLayout.appended,
+                            FmhaQkvMode.fused_qkv,
+                            AcceptedFeatureSet(
+                                values=frozenset(
+                                    {
+                                        FmhaFeature.kv_cache_manager,
+                                        FmhaFeature.paged_kv_cache,
+                                        FmhaFeature.output_buffer,
+                                        FmhaFeature.sparse_attention,
+                                    }
+                                )
+                            ),
+                            frozenset({FmhaFeature.sparse_attention}),
+                        ),
+                        MlaContextCase(
+                            448,
+                            128,
+                            64,
+                            128,
+                            MlaRopeLayout.separate,
+                            FmhaQkvMode.separate_qkv,
+                            AcceptedFeatureSet(
+                                values=frozenset(
+                                    {
+                                        FmhaFeature.kv_cache_manager,
+                                        FmhaFeature.paged_kv_cache,
+                                        FmhaFeature.output_buffer,
+                                    }
+                                )
+                            ),
+                        ),
+                        MlaContextCase(
+                            448,
+                            128,
+                            64,
+                            128,
+                            MlaRopeLayout.separate,
+                            FmhaQkvMode.fused_qkv,
+                            AcceptedFeatureSet(
+                                values=frozenset(
+                                    {
+                                        FmhaFeature.kv_cache_manager,
+                                        FmhaFeature.paged_kv_cache,
+                                        FmhaFeature.output_buffer,
+                                        FmhaFeature.sparse_attention,
+                                    }
+                                )
+                            ),
+                            frozenset({FmhaFeature.sparse_attention}),
+                        ),
+                    }
+                ),
+                qkv_mode=AcceptedValues(
+                    values=frozenset({FmhaQkvMode.fused_qkv, FmhaQkvMode.separate_qkv})
+                ),
+                kv_cache_update_mode=AcceptedValues(
+                    values=frozenset({FmhaKvCacheUpdateMode.update})
+                ),
+                mask_type=AcceptedValues(
+                    values=frozenset(
+                        {
+                            AttentionMaskType.padding,
+                            AttentionMaskType.causal,
+                            AttentionMaskType.sliding_window_causal,
+                            AttentionMaskType.bidirectional,
+                            AttentionMaskType.bidirectionalglm,
+                            AttentionMaskType.blocksparse,
+                        }
+                    )
+                ),
+                position_embedding_type=AcceptedValues(
+                    values=frozenset(
+                        {
+                            PositionEmbeddingType.learned_absolute,
+                            PositionEmbeddingType.rope_gptj,
+                            PositionEmbeddingType.rope_gpt_neox,
+                            PositionEmbeddingType.long_rope,
+                            PositionEmbeddingType.alibi,
+                            PositionEmbeddingType.alibi_with_scale,
+                            PositionEmbeddingType.relative,
+                            PositionEmbeddingType.chatglm,
+                            PositionEmbeddingType.yarn,
+                            PositionEmbeddingType.mrope,
+                        }
+                    )
+                ),
+                runtime_features=AcceptedFeatureSet(
+                    values=frozenset(
+                        {
+                            FmhaFeature.kv_cache_manager,
+                            FmhaFeature.paged_kv_cache,
+                            FmhaFeature.output_buffer,
+                            FmhaFeature.sparse_attention,
+                        }
+                    )
+                ),
+                phase_features=AcceptedFeatureSet(values=frozenset()),
+                required_runtime_features=frozenset(
+                    {FmhaFeature.kv_cache_manager, FmhaFeature.paged_kv_cache}
+                ),
+            ),
         ),
         generation=PhaseCapabilities(
-            head_sizes=AcceptedIntegerValues(min_value=1),
-            mask_types=frozenset(AttentionMaskType),
-            position_embedding_types=frozenset(PositionEmbeddingType),
-            features=frozenset(FmhaFeature),
-        ),
-        mla=MlaCapabilities(
-            phases=frozenset(FmhaPhase),
-            generation_cases=frozenset(),
+            standard=StandardPhaseCapabilities(
+                dtype_combinations=frozenset(
+                    {
+                        DTypeCombination(q_dtype, kv_cache_dtype, output_dtype)
+                        for kv_cache_dtype in (
+                            None,
+                            DataType.HALF,
+                            DataType.BF16,
+                            DataType.FLOAT,
+                            DataType.FP8,
+                            DataType.INT8,
+                        )
+                        for q_dtype, output_dtype in (
+                            (torch.float16, torch.float16),
+                            (torch.float16, torch.float8_e4m3fn),
+                            (torch.float16, torch.uint8),
+                            (torch.bfloat16, torch.bfloat16),
+                            (torch.bfloat16, torch.float8_e4m3fn),
+                            (torch.bfloat16, torch.uint8),
+                            (torch.float32, torch.float32),
+                        )
+                    }
+                    | {
+                        DTypeCombination(q_dtype, DataType.NVFP4, output_dtype)
+                        for q_dtype, output_dtype in (
+                            (torch.float16, torch.float16),
+                            (torch.float16, torch.float8_e4m3fn),
+                            (torch.float16, torch.uint8),
+                            (torch.bfloat16, torch.bfloat16),
+                            (torch.bfloat16, torch.float8_e4m3fn),
+                            (torch.bfloat16, torch.uint8),
+                        )
+                    }
+                ),
+                head_size=AcceptedIntegerValues(
+                    values=frozenset(
+                        {32, 48, 64, 72, 80, 96, 104, 112, 128, 144, 160, 192, 224, 256}
+                    )
+                ),
+                qkv_mode=AcceptedValues(
+                    values=frozenset({FmhaQkvMode.fused_qkv, FmhaQkvMode.separate_qkv_sage})
+                ),
+                kv_cache_update_mode=AcceptedValues(
+                    values=frozenset({FmhaKvCacheUpdateMode.update})
+                ),
+                mask_type=AcceptedValues(
+                    values=frozenset(
+                        {
+                            AttentionMaskType.padding,
+                            AttentionMaskType.causal,
+                            AttentionMaskType.sliding_window_causal,
+                            AttentionMaskType.bidirectional,
+                            AttentionMaskType.bidirectionalglm,
+                            AttentionMaskType.blocksparse,
+                            AttentionMaskType.custom_mask,
+                        }
+                    )
+                ),
+                position_embedding_type=AcceptedValues(
+                    values=frozenset(
+                        {
+                            PositionEmbeddingType.learned_absolute,
+                            PositionEmbeddingType.rope_gptj,
+                            PositionEmbeddingType.rope_gpt_neox,
+                            PositionEmbeddingType.long_rope,
+                            PositionEmbeddingType.alibi,
+                            PositionEmbeddingType.alibi_with_scale,
+                            PositionEmbeddingType.relative,
+                            PositionEmbeddingType.chatglm,
+                            PositionEmbeddingType.yarn,
+                            PositionEmbeddingType.mrope,
+                        }
+                    )
+                ),
+                runtime_features=AcceptedFeatureSet(
+                    values=frozenset(
+                        {
+                            FmhaFeature.kv_cache_manager,
+                            FmhaFeature.paged_kv_cache,
+                            FmhaFeature.output_buffer,
+                            FmhaFeature.helix,
+                            FmhaFeature.sage_attention,
+                            FmhaFeature.sparse_attention,
+                            FmhaFeature.skip_softmax_attention,
+                        }
+                    )
+                ),
+                phase_features=AcceptedFeatureSet(
+                    values=frozenset({FmhaFeature.padded_input, FmhaFeature.position_shift})
+                ),
+            ),
+            mla=MlaPhaseCapabilities(
+                dtype_combinations=frozenset(
+                    DTypeCombination(q_dtype, kv_cache_dtype, output_dtype)
+                    for kv_cache_dtype in (DataType.HALF, DataType.BF16, DataType.FP8)
+                    for q_dtype, output_dtype in (
+                        (torch.float16, torch.float16),
+                        (torch.float16, torch.float8_e4m3fn),
+                        (torch.bfloat16, torch.bfloat16),
+                        (torch.bfloat16, torch.float8_e4m3fn),
+                    )
+                ),
+                generation_cases=frozenset(
+                    {
+                        MlaGenerationCase(576, 512, AcceptedIntegerValues(min_value=1)),
+                        MlaGenerationCase(512, 448, AcceptedIntegerValues(min_value=1)),
+                    }
+                ),
+                qkv_mode=AcceptedValues(values=frozenset({FmhaQkvMode.fused_qkv})),
+                kv_cache_update_mode=AcceptedValues(
+                    values=frozenset({FmhaKvCacheUpdateMode.update})
+                ),
+                mask_type=AcceptedValues(
+                    values=frozenset(
+                        {
+                            AttentionMaskType.padding,
+                            AttentionMaskType.causal,
+                            AttentionMaskType.sliding_window_causal,
+                            AttentionMaskType.bidirectional,
+                            AttentionMaskType.bidirectionalglm,
+                            AttentionMaskType.blocksparse,
+                        }
+                    )
+                ),
+                position_embedding_type=AcceptedValues(
+                    values=frozenset(
+                        {
+                            PositionEmbeddingType.learned_absolute,
+                            PositionEmbeddingType.rope_gptj,
+                            PositionEmbeddingType.rope_gpt_neox,
+                            PositionEmbeddingType.long_rope,
+                            PositionEmbeddingType.alibi,
+                            PositionEmbeddingType.alibi_with_scale,
+                            PositionEmbeddingType.relative,
+                            PositionEmbeddingType.chatglm,
+                            PositionEmbeddingType.yarn,
+                            PositionEmbeddingType.mrope,
+                        }
+                    )
+                ),
+                runtime_features=AcceptedFeatureSet(
+                    values=frozenset(
+                        {
+                            FmhaFeature.kv_cache_manager,
+                            FmhaFeature.paged_kv_cache,
+                            FmhaFeature.output_buffer,
+                            FmhaFeature.sparse_attention,
+                        }
+                    )
+                ),
+                phase_features=AcceptedFeatureSet(values=frozenset()),
+                required_runtime_features=frozenset(
+                    {FmhaFeature.kv_cache_manager, FmhaFeature.paged_kv_cache}
+                ),
+            ),
         ),
     )
 

--- a/tensorrt_llm/_torch/attention_backend/fmha.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha.py
@@ -1,0 +1,662 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import weakref
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TYPE_CHECKING, ClassVar, Optional
+
+import torch
+
+from tensorrt_llm._utils import get_sm_version
+from tensorrt_llm.bindings import DataType
+from tensorrt_llm.bindings.internal import thop
+from tensorrt_llm.functional import AttentionMaskType, PositionEmbeddingType
+from tensorrt_llm.logger import logger
+
+from .interface import AttentionForwardArgs, AttentionInputType
+
+if TYPE_CHECKING:
+    from .trtllm import TrtllmAttention, TrtllmAttentionMetadata
+
+
+# ``AttentionForwardArgs`` fields that the fallback ``thop.attention`` call
+# does not consume. Sync test requires every other field to map to a kwarg name,
+# a @property on the dataclass, or a field that some @property transitively
+# reads; entries here are exempt.
+_THOP_EXCLUDED_FIELDS: frozenset = frozenset(
+    {
+        "topk_indices",  # DSA-only
+        "attention_mask_data",  # custom-mask code path
+        "out_scale_sf",  # promoted into ``out_scale`` for NVFP4 output
+    }
+)
+
+# ``thop.attention`` kwargs hard-wired to a literal at the call site.
+_THOP_LITERALS: dict = {
+    "sparse_mla_topk_lens": None,
+    "compressed_kv_cache_pool_ptr": None,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class DTypeCombination:
+    q: torch.dtype
+    kv_cache: DataType
+    output: torch.dtype
+
+
+class FmhaPhase(Enum):
+    context = "context"
+    generation = "generation"
+
+
+class FmhaFeature(Enum):
+    kv_cache_manager = "kv_cache_manager"
+    paged_kv_cache = "paged_kv_cache"
+    output_buffer = "output_buffer"
+    cross_attention = "cross_attention"
+    helix = "helix"
+    sage_attention = "sage_attention"
+    sparse_attention = "sparse_attention"
+    skip_softmax_attention = "skip_softmax_attention"
+    padded_input = "padded_input"
+    position_shift = "position_shift"
+
+
+@dataclass(frozen=True, slots=True)
+class AcceptedIntegerValues:
+    values: frozenset[int] = field(default_factory=frozenset)
+    min_value: Optional[int] = None
+    max_value: Optional[int] = None
+
+    def accepts(self, value: int) -> bool:
+        if self.values and value not in self.values:
+            return False
+        if self.min_value is not None and value < self.min_value:
+            return False
+        if self.max_value is not None and value > self.max_value:
+            return False
+        return True
+
+    def describe(self) -> str:
+        accepted = []
+        if self.values:
+            accepted.append(f"values={sorted(self.values)}")
+        if self.min_value is not None:
+            accepted.append(f"min={self.min_value}")
+        if self.max_value is not None:
+            accepted.append(f"max={self.max_value}")
+        return ", ".join(accepted) if accepted else "any"
+
+
+@dataclass(frozen=True, slots=True)
+class MlaGenerationCase:
+    head_dim_qk: int
+    head_dim_v: int
+    tokens_per_block: int
+
+
+def _all_attention_input_types() -> frozenset[AttentionInputType]:
+    return frozenset(AttentionInputType)
+
+
+def _all_attention_mask_types() -> frozenset[AttentionMaskType]:
+    return frozenset(AttentionMaskType)
+
+
+def _all_position_embedding_types() -> frozenset[PositionEmbeddingType]:
+    return frozenset(PositionEmbeddingType)
+
+
+def _all_fmha_phases() -> frozenset[FmhaPhase]:
+    return frozenset(FmhaPhase)
+
+
+def _all_fmha_features() -> frozenset[FmhaFeature]:
+    return frozenset(FmhaFeature)
+
+
+def _positive_integers() -> AcceptedIntegerValues:
+    return AcceptedIntegerValues(min_value=1)
+
+
+@dataclass(frozen=True, slots=True)
+class PhaseCapabilities:
+    dtype_combinations: frozenset[DTypeCombination] = field(default_factory=frozenset)
+    head_sizes: AcceptedIntegerValues = field(default_factory=_positive_integers)
+    mask_types: frozenset[AttentionMaskType] = field(default_factory=_all_attention_mask_types)
+    position_embedding_types: frozenset[PositionEmbeddingType] = field(
+        default_factory=_all_position_embedding_types
+    )
+    features: frozenset[FmhaFeature] = field(default_factory=_all_fmha_features)
+
+
+@dataclass(frozen=True, slots=True)
+class MlaCapabilities:
+    phases: frozenset[FmhaPhase] = field(default_factory=_all_fmha_phases)
+    generation_cases: frozenset[MlaGenerationCase] = field(default_factory=frozenset)
+
+
+@dataclass(frozen=True, slots=True)
+class FmhaCapabilities:
+    name: str
+    sm_versions: AcceptedIntegerValues = field(default_factory=AcceptedIntegerValues)
+    attention_input_types: frozenset[AttentionInputType] = field(
+        default_factory=_all_attention_input_types
+    )
+    runtime_features: frozenset[FmhaFeature] = field(default_factory=_all_fmha_features)
+    required_runtime_features: frozenset[FmhaFeature] = field(default_factory=frozenset)
+    tokens_per_block: AcceptedIntegerValues = field(default_factory=_positive_integers)
+    generation_beam_widths: AcceptedIntegerValues = field(default_factory=_positive_integers)
+    generation_head_ratios: AcceptedIntegerValues = field(default_factory=_positive_integers)
+    context: PhaseCapabilities = field(default_factory=PhaseCapabilities)
+    generation: PhaseCapabilities = field(default_factory=PhaseCapabilities)
+    mla: MlaCapabilities = field(default_factory=MlaCapabilities)
+
+
+@dataclass(frozen=True, slots=True)
+class FmhaSupportContext:
+    sm: int
+    q_dtype: torch.dtype
+    kv_cache_dtype: Optional[DataType]
+    output_dtype: Optional[torch.dtype]
+    num_heads: int
+    num_kv_heads: int
+    head_size: int
+    attention_input_type: AttentionInputType
+    mask_type: AttentionMaskType
+    position_embedding_type: PositionEmbeddingType
+    beam_width: int
+    tokens_per_block: Optional[int]
+    has_kv_cache_manager: bool
+    use_paged_kv_cache: bool
+    is_mla_enable: bool
+    kv_lora_rank: Optional[int]
+    qk_rope_head_dim: Optional[int]
+    has_context_phase: bool
+    has_generation_phase: bool
+    is_cross_attention: bool
+    is_spec_decoding: bool
+    is_padded: bool
+    position_shift_enabled: bool
+    active_helix: bool
+    use_sage_attention: bool
+    has_sparse_attention: bool
+    has_skip_softmax_attention: bool
+
+    @property
+    def runtime_features(self) -> frozenset[FmhaFeature]:
+        features: set[FmhaFeature] = set()
+        if self.has_kv_cache_manager:
+            features.add(FmhaFeature.kv_cache_manager)
+        if self.use_paged_kv_cache:
+            features.add(FmhaFeature.paged_kv_cache)
+        if self.output_dtype is not None:
+            features.add(FmhaFeature.output_buffer)
+        if self.is_cross_attention:
+            features.add(FmhaFeature.cross_attention)
+        if self.active_helix:
+            features.add(FmhaFeature.helix)
+        if self.use_sage_attention:
+            features.add(FmhaFeature.sage_attention)
+        if self.has_sparse_attention:
+            features.add(FmhaFeature.sparse_attention)
+        if self.has_skip_softmax_attention:
+            features.add(FmhaFeature.skip_softmax_attention)
+        return frozenset(features)
+
+    @property
+    def phase_features(self) -> frozenset[FmhaFeature]:
+        features: set[FmhaFeature] = set()
+        if self.is_padded:
+            features.add(FmhaFeature.padded_input)
+        if self.position_shift_enabled:
+            features.add(FmhaFeature.position_shift)
+        return frozenset(features)
+
+    @classmethod
+    def build(
+        cls,
+        attn: "TrtllmAttention",
+        q: torch.Tensor,
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> "FmhaSupportContext":
+        kv_cache_manager = metadata.kv_cache_manager
+        kv_cache_dtype = kv_cache_manager.dtype if kv_cache_manager is not None else None
+        q_dtype = torch.float8_e4m3fn if kv_cache_dtype == DataType.NVFP4 else q.dtype
+        output_dtype = forward_args.output.dtype if forward_args.output is not None else None
+
+        attention_input_type = forward_args.attention_input_type
+        has_context_phase = attention_input_type != AttentionInputType.generation_only
+        has_generation_phase = attention_input_type != AttentionInputType.context_only
+
+        sparse_attention_config = attn.sparse_attention_config
+        has_skip_softmax_attention = (
+            getattr(sparse_attention_config, "algorithm", None) == "skip_softmax"
+        )
+        has_sparse_attention = (
+            sparse_attention_config is not None and not has_skip_softmax_attention
+        )
+
+        use_sage_attention = (
+            forward_args.sage_attn_num_elts_per_blk_q > 0
+            or forward_args.sage_attn_num_elts_per_blk_k > 0
+            or forward_args.sage_attn_num_elts_per_blk_v > 0
+        )
+
+        return cls(
+            sm=get_sm_version(),
+            q_dtype=q_dtype,
+            kv_cache_dtype=kv_cache_dtype,
+            output_dtype=output_dtype,
+            num_heads=attn.num_heads,
+            num_kv_heads=attn.num_kv_heads,
+            head_size=attn.head_dim,
+            attention_input_type=attention_input_type,
+            mask_type=AttentionMaskType(forward_args.mask_type),
+            position_embedding_type=PositionEmbeddingType(attn.position_embedding_type),
+            beam_width=metadata.beam_width,
+            tokens_per_block=metadata.tokens_per_block,
+            has_kv_cache_manager=kv_cache_manager is not None,
+            use_paged_kv_cache=metadata.kv_cache_block_offsets is not None,
+            is_mla_enable=attn.is_mla_enable,
+            kv_lora_rank=attn.kv_lora_rank,
+            qk_rope_head_dim=attn.qk_rope_head_dim,
+            has_context_phase=has_context_phase,
+            has_generation_phase=has_generation_phase,
+            is_cross_attention=metadata.is_cross,
+            is_spec_decoding=metadata.is_spec_decoding_enabled,
+            is_padded=False,
+            position_shift_enabled=False,
+            active_helix=metadata.helix_position_offsets is not None,
+            use_sage_attention=use_sage_attention,
+            has_sparse_attention=has_sparse_attention,
+            has_skip_softmax_attention=has_skip_softmax_attention,
+        )
+
+
+class BaseFmha:
+    capabilities: ClassVar[FmhaCapabilities]
+
+    def __init__(self, attention_layer: "TrtllmAttention") -> None:
+        self._attention_layer_ref = weakref.ref(attention_layer)
+
+    @property
+    def name(self) -> str:
+        return self.capabilities.name
+
+    def _get_attention_layer(self) -> "TrtllmAttention":
+        attention_layer = self._attention_layer_ref()
+        if attention_layer is None:
+            raise RuntimeError(f"{self.name} attention layer has been destroyed.")
+        return attention_layer
+
+    @classmethod
+    def _not_supported(cls, reason: str) -> bool:
+        logger.debug("FMHA %s unsupported: %s", cls.capabilities.name, reason)
+        return False
+
+    @classmethod
+    def is_supported(cls, context: FmhaSupportContext) -> bool:
+        return _fmha_supported_by_capabilities(cls, context)
+
+    def forward(
+        self,
+        attn: "TrtllmAttention",
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> None:
+        raise NotImplementedError
+
+
+def _dtype_combo_supported(
+    fmha_cls: type[BaseFmha],
+    phase_name: str,
+    phase: PhaseCapabilities,
+    context: FmhaSupportContext,
+) -> bool:
+    if not phase.dtype_combinations:
+        return True
+    if context.kv_cache_dtype is None:
+        return fmha_cls._not_supported(f"[{phase_name}] missing KV cache dtype.")
+    output_dtype = context.output_dtype if context.output_dtype is not None else context.q_dtype
+    combo = DTypeCombination(context.q_dtype, context.kv_cache_dtype, output_dtype)
+    if combo not in phase.dtype_combinations:
+        return fmha_cls._not_supported(
+            f"[{phase_name}] unsupported dtype combination: "
+            f"Q={context.q_dtype}, KV={context.kv_cache_dtype}, O={output_dtype}.",
+        )
+    return True
+
+
+def _phase_supported(
+    fmha_cls: type[BaseFmha],
+    phase_name: str,
+    phase: PhaseCapabilities,
+    context: FmhaSupportContext,
+) -> bool:
+    if not phase.head_sizes.accepts(context.head_size):
+        return fmha_cls._not_supported(
+            f"[{phase_name}] head size {context.head_size} is not accepted. "
+            f"Accepted: {phase.head_sizes.describe()}."
+        )
+    if context.mask_type not in phase.mask_types:
+        return fmha_cls._not_supported(
+            f"[{phase_name}] mask type {context.mask_type.name} is not accepted. "
+            f"Accepted: {[mask.name for mask in sorted(phase.mask_types, key=int)]}."
+        )
+    if context.position_embedding_type not in phase.position_embedding_types:
+        return fmha_cls._not_supported(
+            f"[{phase_name}] position embedding type {context.position_embedding_type.name} is not accepted. "
+            "Accepted: "
+            f"{[position.name for position in sorted(phase.position_embedding_types, key=int)]}."
+        )
+    unavailable_features = context.phase_features - phase.features
+    if unavailable_features:
+        return fmha_cls._not_supported(
+            f"[{phase_name}] feature(s) not accepted: "
+            f"{', '.join(sorted(feature.value for feature in unavailable_features))}."
+        )
+    return _dtype_combo_supported(fmha_cls, phase_name, phase, context)
+
+
+def _mla_generation_supported(fmha_cls: type[BaseFmha], context: FmhaSupportContext) -> bool:
+    mla = fmha_cls.capabilities.mla
+    missing_params = [
+        name
+        for name, value in (
+            ("kv_lora_rank", context.kv_lora_rank),
+            ("qk_rope_head_dim", context.qk_rope_head_dim),
+        )
+        if value is None or value <= 0
+    ]
+    if missing_params:
+        return fmha_cls._not_supported(
+            f"[Generation][MLA] missing required MLA parameter(s): {', '.join(missing_params)}.",
+        )
+
+    kv_rank = int(context.kv_lora_rank)
+    qk_rope_dim = int(context.qk_rope_head_dim)
+    head_dim_qk = kv_rank + qk_rope_dim
+    head_dim_v = kv_rank
+    if context.head_size != head_dim_qk:
+        return fmha_cls._not_supported(
+            f"[Generation][MLA] head_size ({context.head_size}) must match "
+            f"kv_lora_rank + qk_rope_head_dim ({head_dim_qk}).",
+        )
+
+    tokens_per_block = context.tokens_per_block or 0
+    generation_case = MlaGenerationCase(head_dim_qk, head_dim_v, tokens_per_block)
+    if mla.generation_cases and generation_case not in mla.generation_cases:
+        accepted_cases = sorted(
+            (
+                case.head_dim_qk,
+                case.head_dim_v,
+                case.tokens_per_block,
+            )
+            for case in mla.generation_cases
+        )
+        return fmha_cls._not_supported(
+            f"[Generation][MLA] case {generation_case} is not accepted. "
+            f"Accepted: {accepted_cases}.",
+        )
+    return True
+
+
+def _fmha_supported_by_capabilities(fmha_cls: type[BaseFmha], context: FmhaSupportContext) -> bool:
+    capabilities = fmha_cls.capabilities
+
+    if not capabilities.sm_versions.accepts(context.sm):
+        return fmha_cls._not_supported(
+            f"SM{context.sm} is not accepted. Accepted: {capabilities.sm_versions.describe()}."
+        )
+    if context.attention_input_type not in capabilities.attention_input_types:
+        return fmha_cls._not_supported(
+            f"attention input type {context.attention_input_type.name} is not accepted. "
+            "Accepted: "
+            f"{[input_type.name for input_type in sorted(capabilities.attention_input_types, key=int)]}."
+        )
+
+    runtime_features = context.runtime_features
+    missing_required_features = capabilities.required_runtime_features - runtime_features
+    if missing_required_features:
+        return fmha_cls._not_supported(
+            "required runtime feature(s) are absent: "
+            f"{', '.join(sorted(feature.value for feature in missing_required_features))}."
+        )
+    unavailable_features = runtime_features - capabilities.runtime_features
+    if unavailable_features:
+        return fmha_cls._not_supported(
+            "runtime feature(s) are not accepted: "
+            f"{', '.join(sorted(feature.value for feature in unavailable_features))}."
+        )
+
+    if context.num_heads <= 0:
+        return fmha_cls._not_supported("num_heads must be positive.")
+    if context.num_kv_heads <= 0:
+        return fmha_cls._not_supported("num_kv_heads must be positive.")
+    if context.num_heads % context.num_kv_heads != 0:
+        return fmha_cls._not_supported(
+            f"num_heads ({context.num_heads}) must be divisible by num_kv_heads ({context.num_kv_heads}).",
+        )
+
+    if context.has_context_phase:
+        if context.is_mla_enable and FmhaPhase.context not in capabilities.mla.phases:
+            return fmha_cls._not_supported(
+                "MLA context and mixed phases are not supported.",
+            )
+        if not context.is_mla_enable and not _phase_supported(
+            fmha_cls, "Context", capabilities.context, context
+        ):
+            return False
+
+    if context.has_generation_phase:
+        if not _phase_supported(fmha_cls, "Generation", capabilities.generation, context):
+            return False
+        if not capabilities.generation_beam_widths.accepts(context.beam_width):
+            return fmha_cls._not_supported(
+                f"[Generation] beam width {context.beam_width} is not accepted. "
+                f"Accepted: {capabilities.generation_beam_widths.describe()}."
+            )
+        if not context.is_mla_enable:
+            heads_ratio = context.num_heads // context.num_kv_heads
+            if not capabilities.generation_head_ratios.accepts(heads_ratio):
+                return fmha_cls._not_supported(
+                    f"[Generation] heads ratio {heads_ratio} is not accepted. "
+                    f"Accepted: {capabilities.generation_head_ratios.describe()}."
+                )
+        if context.is_mla_enable:
+            if FmhaPhase.generation not in capabilities.mla.phases:
+                return fmha_cls._not_supported("[Generation][MLA] MLA generation is not supported.")
+            if not _mla_generation_supported(fmha_cls, context):
+                return False
+
+    if context.use_paged_kv_cache:
+        tokens_per_block = context.tokens_per_block or 0
+        if tokens_per_block <= 0:
+            return fmha_cls._not_supported("tokens_per_block must be positive.")
+        if not capabilities.tokens_per_block.accepts(tokens_per_block):
+            return fmha_cls._not_supported(
+                f"tokens_per_block {tokens_per_block} is not accepted. "
+                f"Accepted: {capabilities.tokens_per_block.describe()}."
+            )
+
+    logger.debug("FMHA %s supported.", capabilities.name)
+    return True
+
+
+def call_thop_attention(
+    attn: "TrtllmAttention",
+    q: torch.Tensor,
+    k: Optional[torch.Tensor],
+    v: Optional[torch.Tensor],
+    metadata: "TrtllmAttentionMetadata",
+    forward_args: AttentionForwardArgs,
+) -> None:
+    # Every kwarg sources from ``attn`` / ``metadata`` / ``forward_args``
+    # (with ``forward_args.sparse`` for sparse-attn inputs) or a literal
+    # allowlisted in ``_THOP_LITERALS``. ``test_attention_op_sync.py``
+    # enforces this statically.
+    thop.attention(
+        q=q,
+        k=k,
+        v=v,
+        output=forward_args.output,
+        output_sf=forward_args.output_sf,
+        workspace_=metadata.effective_workspace,
+        # --- Per-step batch state (TrtllmAttentionMetadata) ---
+        sequence_length=metadata.kv_lens_cuda_runtime,
+        host_past_key_value_lengths=metadata.kv_lens_runtime,
+        host_total_kv_lens=metadata.host_total_kv_lens,
+        context_lengths=metadata.prompt_lens_cuda_runtime,
+        host_context_lengths=metadata.prompt_lens_cpu_runtime,
+        host_request_types=metadata.host_request_types_runtime,
+        max_context_q_len_override=metadata.max_context_q_len_override,
+        kv_cache_block_offsets=metadata.kv_cache_block_offsets,
+        host_kv_cache_pool_pointers=metadata.host_kv_cache_pool_pointers,
+        host_kv_cache_pool_mapping=metadata.host_kv_cache_pool_mapping,
+        cache_indirection=metadata.cache_indirection,
+        block_ids_per_seq=metadata.block_ids_per_seq,
+        tokens_per_block=metadata.tokens_per_block,
+        max_num_requests=metadata.max_num_requests,
+        beam_width=metadata.beam_width,
+        use_paged_context_fmha=metadata.use_paged_context_fmha,
+        helix_position_offsets=metadata.helix_position_offsets,
+        helix_is_inactive_rank=metadata.helix_is_inactive_rank,
+        is_spec_decoding_enabled=metadata.is_spec_decoding_enabled,
+        use_spec_decoding=metadata.use_spec_decoding,
+        is_spec_dec_tree=metadata.is_spec_dec_tree,
+        spec_decoding_generation_lengths=metadata.spec_decoding_generation_lengths,
+        spec_decoding_position_offsets_for_cpp=metadata.spec_decoding_position_offsets_for_cpp,
+        spec_decoding_packed_mask=metadata.spec_decoding_packed_mask,
+        spec_decoding_bl_tree_mask_offset=metadata.spec_decoding_bl_tree_mask_offset,
+        spec_decoding_bl_tree_mask=metadata.spec_decoding_bl_tree_mask,
+        spec_bl_tree_first_sparse_mask_offset_kv=metadata.spec_bl_tree_first_sparse_mask_offset_kv,
+        num_sparse_topk=metadata.num_sparse_topk,
+        flash_mla_tile_scheduler_metadata=metadata.flash_mla_tile_scheduler_metadata,
+        flash_mla_num_splits=metadata.flash_mla_num_splits,
+        num_contexts=metadata.num_contexts,
+        num_ctx_tokens=metadata.num_ctx_tokens,
+        max_context_length=metadata.max_context_length,
+        # --- Per-call (AttentionForwardArgs) ---
+        out_scale=forward_args.out_scale,
+        kv_scale_orig_quant=forward_args.kv_scale_orig_quant,
+        kv_scale_quant_orig=forward_args.kv_scale_quant_orig,
+        latent_cache=forward_args.latent_cache,
+        q_pe=forward_args.q_pe,
+        attention_sinks=forward_args.attention_sinks,
+        mask_type=forward_args.mask_type,
+        attention_input_type=int(forward_args.attention_input_type),
+        attention_window_size=forward_args.attention_window_size,
+        chunked_prefill_buffer_batch_size=forward_args.chunked_prefill_buffer_batch_size,
+        mrope_rotary_cos_sin=forward_args.mrope_rotary_cos_sin,
+        mrope_position_deltas=forward_args.mrope_position_deltas,
+        softmax_stats_tensor=forward_args.softmax_stats_tensor,
+        cu_q_seqlens=forward_args.cu_q_seqlens,
+        cu_kv_seqlens=forward_args.cu_kv_seqlens,
+        fmha_scheduler_counter=forward_args.fmha_scheduler_counter,
+        mla_bmm1_scale=forward_args.mla_bmm1_scale,
+        mla_bmm2_scale=forward_args.mla_bmm2_scale,
+        quant_q_buffer=forward_args.quant_q_buffer,
+        sage_attn_num_elts_per_blk_q=forward_args.sage_attn_num_elts_per_blk_q,
+        sage_attn_num_elts_per_blk_k=forward_args.sage_attn_num_elts_per_blk_k,
+        sage_attn_num_elts_per_blk_v=forward_args.sage_attn_num_elts_per_blk_v,
+        sage_attn_qk_int8=forward_args.sage_attn_qk_int8,
+        is_fused_qkv=forward_args.is_fused_qkv,
+        update_kv_cache=forward_args.update_kv_cache,
+        # --- Module config (TrtllmAttention) ---
+        rotary_inv_freq=attn.rotary_inv_freq,
+        rotary_cos_sin=attn.rotary_cos_sin,
+        predicted_tokens_per_seq=attn.predicted_tokens_per_seq,
+        local_layer_idx=attn.local_layer_idx,
+        num_heads=attn.num_heads,
+        num_kv_heads=attn.num_kv_heads,
+        head_size=attn.head_dim,
+        quant_mode=attn.quant_mode,
+        q_scaling=attn.q_scaling,
+        position_embedding_type=attn.position_embedding_type,
+        rope_dim=attn.rope_dim,
+        rope_base=attn.rope_base,
+        rope_scale_type=attn.rope_scale_type,
+        rope_scale=attn.rope_scale,
+        rope_short_m_scale=attn.rope_short_m_scale,
+        rope_long_m_scale=attn.rope_long_m_scale,
+        rope_max_positions=attn.rope_max_positions,
+        rope_original_max_positions=attn.rope_original_max_positions,
+        is_mla_enable=attn.is_mla_enable,
+        q_lora_rank=attn.q_lora_rank,
+        kv_lora_rank=attn.kv_lora_rank,
+        qk_nope_head_dim=attn.qk_nope_head_dim,
+        qk_rope_head_dim=attn.qk_rope_head_dim,
+        v_head_dim=attn.v_head_dim,
+        rope_append=attn.rope_append,
+        attention_chunk_size=attn.attention_chunk_size,
+        skip_softmax_threshold_scale_factor_prefill=attn.skip_softmax_threshold_scale_factor_prefill,
+        skip_softmax_threshold_scale_factor_decode=attn.skip_softmax_threshold_scale_factor_decode,
+        skip_softmax_stat=attn.skip_softmax_stat,
+        # --- Sparse-specific (AttentionForwardArgs.sparse) ---
+        sparse_kv_indices=forward_args.sparse.sparse_kv_indices,
+        sparse_kv_offsets=forward_args.sparse.sparse_kv_offsets,
+        sparse_attn_indices=forward_args.sparse.sparse_attn_indices,
+        sparse_attn_offsets=forward_args.sparse.sparse_attn_offsets,
+        sparse_attn_indices_block_size=forward_args.sparse.sparse_attn_indices_block_size,
+        # --- Literals intentionally None (see _THOP_LITERALS) ---
+        sparse_mla_topk_lens=None,
+        compressed_kv_cache_pool_ptr=None,
+    )
+
+
+class FallbackFmha(BaseFmha):
+    capabilities: ClassVar[FmhaCapabilities] = FmhaCapabilities(
+        name="fallback",
+        sm_versions=AcceptedIntegerValues(min_value=0),
+        attention_input_types=frozenset(AttentionInputType),
+        runtime_features=frozenset(FmhaFeature),
+        required_runtime_features=frozenset(),
+        tokens_per_block=AcceptedIntegerValues(min_value=1),
+        generation_beam_widths=AcceptedIntegerValues(min_value=1),
+        generation_head_ratios=AcceptedIntegerValues(min_value=1),
+        context=PhaseCapabilities(
+            head_sizes=AcceptedIntegerValues(min_value=1),
+            mask_types=frozenset(AttentionMaskType),
+            position_embedding_types=frozenset(PositionEmbeddingType),
+            features=frozenset(FmhaFeature),
+        ),
+        generation=PhaseCapabilities(
+            head_sizes=AcceptedIntegerValues(min_value=1),
+            mask_types=frozenset(AttentionMaskType),
+            position_embedding_types=frozenset(PositionEmbeddingType),
+            features=frozenset(FmhaFeature),
+        ),
+        mla=MlaCapabilities(
+            phases=frozenset(FmhaPhase),
+            generation_cases=frozenset(),
+        ),
+    )
+
+    def forward(
+        self,
+        attn: "TrtllmAttention",
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> None:
+        call_thop_attention(attn, q, k, v, metadata, forward_args)

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
     from ..speculative.interface import SpecMetadata
     from ..speculative.spec_tree_manager import SpecTreeManager
 
-from tensorrt_llm._torch.attention_backend import trtllm_gen
 from tensorrt_llm._utils import get_sm_version, maybe_pin_memory, prefer_pinned
 from tensorrt_llm.bindings.internal import thop
 from tensorrt_llm.functional import AttentionMaskType
@@ -20,34 +19,49 @@ from tensorrt_llm.models.modeling_utils import QuantConfig
 
 from ..utils import (compute_swizzled_sf_shape, get_global_attrs,
                      get_model_extra_attrs)
+from .fmha import BaseFmha, FallbackFmha, FmhaSupportContext
 from .interface import (AttentionBackend, AttentionForwardArgs,
                         AttentionInputType, AttentionMask, AttentionMetadata,
                         AttentionSparseArgs, KVCacheParams, MLAParams,
                         PositionalEmbeddingParams, PredefinedAttentionMask,
                         RopeParams, merge_attention_forward_args)
+from .trtllm_gen import FlashInferTrtllmGenFmha
 
-# Enable TRTLLM-Gen attention backend by default. Set
-# TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION=0 to force the thop.attention path.
-_TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION = (os.environ.get(
-    "TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION", "0") == "1")
+FMHA_LIBS: dict[str, type[BaseFmha]] = {
+    "flashinfer_trtllm_gen": FlashInferTrtllmGenFmha,
+    "fallback": FallbackFmha,
+}
 
-# ``AttentionForwardArgs`` fields that this backend does not consume.
-# Sync test (test_attention_op_sync.py) requires every other field to map to a
-# kwarg name, a @property on the dataclass, or a field that some @property
-# transitively reads; entries here are exempt.
-_THOP_EXCLUDED_FIELDS: frozenset = frozenset({
-    "topk_indices",  # DSA-only
-    "attention_mask_data",  # custom-mask code path
-    "out_scale_sf",  # promoted into ``out_scale`` in ``_run`` for NVFP4 path
+DEFAULT_ENABLED_FMHA_LIBS: frozenset[str] = frozenset({
+    "flashinfer_trtllm_gen",
+    "fallback",
 })
 
-# ``thop.attention`` kwargs hard-wired to a literal at the call site (no
-# rich object owns them). Sync test enforces both the kwarg name and the
-# literal value.
-_THOP_LITERALS: dict = {
-    "sparse_mla_topk_lens": None,
-    "compressed_kv_cache_pool_ptr": None,
-}
+
+def iter_enabled_fmha_libs() -> tuple[type[BaseFmha], ...]:
+    enabled = set(DEFAULT_ENABLED_FMHA_LIBS)
+    for token in os.environ.get("TLLM_FMHA_LIBS", "").split(","):
+        token = token.strip()
+        if not token:
+            continue
+        op = token[0]
+        name = token[1:]
+        if op not in {"+", "-"} or not name:
+            raise ValueError(f"Invalid TLLM_FMHA_LIBS token: {token}")
+        if name not in FMHA_LIBS:
+            raise ValueError(f"Unknown FMHA library: {name}")
+        if op == "+":
+            enabled.add(name)
+        else:
+            enabled.discard(name)
+
+    enabled.add("fallback")
+    ordered = [
+        fmha_cls for name, fmha_cls in FMHA_LIBS.items()
+        if name != "fallback" and name in enabled
+    ]
+    ordered.append(FMHA_LIBS["fallback"])
+    return tuple(ordered)
 
 
 @functools.cache
@@ -1398,13 +1412,15 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
             return self.sparse_attention_config.threshold_scale_factor_decode
         return None
 
-    def _get_trtllm_gen_backend(
-            self) -> trtllm_gen.FlashInferTrtllmGenAttention:
-        backend = getattr(self, "_trtllm_gen_backend", None)
+    def _get_fmha_backend(self, fmha_cls: type[BaseFmha]) -> BaseFmha:
+        backends = getattr(self, "_fmha_backends", None)
+        if backends is None:
+            backends = {}
+            self._fmha_backends = backends
+        backend = backends.get(fmha_cls.capabilities.name)
         if backend is None:
-            backend = trtllm_gen.FlashInferTrtllmGenAttention(
-                attention_layer=self, )
-            self._trtllm_gen_backend = backend
+            backend = fmha_cls(attention_layer=self)
+            backends[fmha_cls.capabilities.name] = backend
         return backend
 
     def _run(
@@ -1512,163 +1528,13 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
             assert metadata.kv_cache_manager is None
             assert metadata.num_contexts == metadata.num_seqs
 
-        helix_active = metadata.helix_position_offsets is not None
-        use_sage_attn = (forward_args.sage_attn_num_elts_per_blk_q > 0
-                         or forward_args.sage_attn_num_elts_per_blk_k > 0
-                         or forward_args.sage_attn_num_elts_per_blk_v > 0)
-
-        use_trtllm_gen = False
-        if _TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION:
-            trtllm_gen_backend = self._get_trtllm_gen_backend()
-            use_trtllm_gen = trtllm_gen_backend.is_supported(
-                q,
-                metadata=metadata,
-                forward_args=forward_args,
-                mask_type=int(forward_args.mask_type),
-                active_helix=helix_active,
-                use_sage_attn=use_sage_attn,
-            )[0]
-
-        if use_trtllm_gen:
-            trtllm_gen_backend.attention(
-                q,
-                metadata=metadata,
-                forward_args=forward_args,
-                mask_type=int(forward_args.mask_type),
-                use_paged_context_fmha=metadata.use_paged_context_fmha,
-            )
-        else:
-            # Every kwarg sources from ``self`` / ``metadata`` /
-            # ``forward_args`` (with ``forward_args.sparse`` for sparse-attn
-            # inputs) or a literal allowlisted in ``_THOP_LITERALS``.
-            # ``test_attention_op_sync.py`` enforces this statically.
-            thop.attention(
-                q=q,
-                k=k,
-                v=v,
-                output=forward_args.output,
-                output_sf=forward_args.output_sf,
-                workspace_=metadata.effective_workspace,
-
-                # --- Per-step batch state (TrtllmAttentionMetadata) ---
-                sequence_length=metadata.kv_lens_cuda_runtime,
-                host_past_key_value_lengths=metadata.kv_lens_runtime,
-                host_total_kv_lens=metadata.host_total_kv_lens,
-                context_lengths=metadata.prompt_lens_cuda_runtime,
-                host_context_lengths=metadata.prompt_lens_cpu_runtime,
-                host_request_types=metadata.host_request_types_runtime,
-                max_context_q_len_override=metadata.max_context_q_len_override,
-                kv_cache_block_offsets=metadata.kv_cache_block_offsets,
-                host_kv_cache_pool_pointers=metadata.
-                host_kv_cache_pool_pointers,
-                host_kv_cache_pool_mapping=metadata.host_kv_cache_pool_mapping,
-                cache_indirection=metadata.cache_indirection,
-                block_ids_per_seq=metadata.block_ids_per_seq,
-                tokens_per_block=metadata.tokens_per_block,
-                max_num_requests=metadata.max_num_requests,
-                beam_width=metadata.beam_width,
-                use_paged_context_fmha=metadata.use_paged_context_fmha,
-                helix_position_offsets=metadata.helix_position_offsets,
-                helix_is_inactive_rank=metadata.helix_is_inactive_rank,
-                is_spec_decoding_enabled=metadata.is_spec_decoding_enabled,
-                use_spec_decoding=metadata.use_spec_decoding,
-                is_spec_dec_tree=metadata.is_spec_dec_tree,
-                spec_decoding_generation_lengths=metadata.
-                spec_decoding_generation_lengths,
-                spec_decoding_position_offsets_for_cpp=metadata.
-                spec_decoding_position_offsets_for_cpp,
-                spec_decoding_packed_mask=metadata.spec_decoding_packed_mask,
-                spec_decoding_bl_tree_mask_offset=metadata.
-                spec_decoding_bl_tree_mask_offset,
-                spec_decoding_bl_tree_mask=metadata.spec_decoding_bl_tree_mask,
-                spec_bl_tree_first_sparse_mask_offset_kv=metadata.
-                spec_bl_tree_first_sparse_mask_offset_kv,
-                num_sparse_topk=metadata.num_sparse_topk,
-                flash_mla_tile_scheduler_metadata=metadata.
-                flash_mla_tile_scheduler_metadata,
-                flash_mla_num_splits=metadata.flash_mla_num_splits,
-                num_contexts=metadata.num_contexts,
-                num_ctx_tokens=metadata.num_ctx_tokens,
-                max_context_length=metadata.max_context_length,
-
-                # --- Per-call (AttentionForwardArgs) ---
-                out_scale=forward_args.out_scale,
-                kv_scale_orig_quant=forward_args.kv_scale_orig_quant,
-                kv_scale_quant_orig=forward_args.kv_scale_quant_orig,
-                latent_cache=forward_args.latent_cache,
-                q_pe=forward_args.q_pe,
-                attention_sinks=forward_args.attention_sinks,
-                mask_type=forward_args.mask_type,
-                attention_input_type=int(forward_args.attention_input_type),
-                attention_window_size=forward_args.attention_window_size,
-                chunked_prefill_buffer_batch_size=forward_args.
-                chunked_prefill_buffer_batch_size,
-                mrope_rotary_cos_sin=forward_args.mrope_rotary_cos_sin,
-                mrope_position_deltas=forward_args.mrope_position_deltas,
-                softmax_stats_tensor=forward_args.softmax_stats_tensor,
-                cu_q_seqlens=forward_args.cu_q_seqlens,
-                cu_kv_seqlens=forward_args.cu_kv_seqlens,
-                fmha_scheduler_counter=forward_args.fmha_scheduler_counter,
-                mla_bmm1_scale=forward_args.mla_bmm1_scale,
-                mla_bmm2_scale=forward_args.mla_bmm2_scale,
-                quant_q_buffer=forward_args.quant_q_buffer,
-                sage_attn_num_elts_per_blk_q=forward_args.
-                sage_attn_num_elts_per_blk_q,
-                sage_attn_num_elts_per_blk_k=forward_args.
-                sage_attn_num_elts_per_blk_k,
-                sage_attn_num_elts_per_blk_v=forward_args.
-                sage_attn_num_elts_per_blk_v,
-                sage_attn_qk_int8=forward_args.sage_attn_qk_int8,
-                is_fused_qkv=forward_args.is_fused_qkv,
-                update_kv_cache=forward_args.update_kv_cache,
-
-                # --- Module config (TrtllmAttention) ---
-                rotary_inv_freq=self.rotary_inv_freq,
-                rotary_cos_sin=self.rotary_cos_sin,
-                predicted_tokens_per_seq=self.predicted_tokens_per_seq,
-                local_layer_idx=self.local_layer_idx,
-                num_heads=self.num_heads,
-                num_kv_heads=self.num_kv_heads,
-                head_size=self.head_dim,
-                quant_mode=self.quant_mode,
-                q_scaling=self.q_scaling,
-                position_embedding_type=self.position_embedding_type,
-                rope_dim=self.rope_dim,
-                rope_base=self.rope_base,
-                rope_scale_type=self.rope_scale_type,
-                rope_scale=self.rope_scale,
-                rope_short_m_scale=self.rope_short_m_scale,
-                rope_long_m_scale=self.rope_long_m_scale,
-                rope_max_positions=self.rope_max_positions,
-                rope_original_max_positions=self.rope_original_max_positions,
-                is_mla_enable=self.is_mla_enable,
-                q_lora_rank=self.q_lora_rank,
-                kv_lora_rank=self.kv_lora_rank,
-                qk_nope_head_dim=self.qk_nope_head_dim,
-                qk_rope_head_dim=self.qk_rope_head_dim,
-                v_head_dim=self.v_head_dim,
-                rope_append=self.rope_append,
-                attention_chunk_size=self.attention_chunk_size,
-                skip_softmax_threshold_scale_factor_prefill=self.
-                skip_softmax_threshold_scale_factor_prefill,
-                skip_softmax_threshold_scale_factor_decode=self.
-                skip_softmax_threshold_scale_factor_decode,
-                skip_softmax_stat=self.skip_softmax_stat,
-
-                # --- Sparse-specific (AttentionForwardArgs.sparse) ---
-                sparse_kv_indices=forward_args.sparse.sparse_kv_indices,
-                sparse_kv_offsets=forward_args.sparse.sparse_kv_offsets,
-                sparse_attn_indices=forward_args.sparse.sparse_attn_indices,
-                sparse_attn_offsets=forward_args.sparse.sparse_attn_offsets,
-                sparse_attn_indices_block_size=forward_args.sparse.
-                sparse_attn_indices_block_size,
-
-                # --- Literals intentionally None (see _THOP_LITERALS) ---
-                # ``sparse_mla_topk_lens`` and ``compressed_kv_cache_pool_ptr``
-                # stay as literal ``None`` until DeepSeek V4 sparse-MLA lands.
-                sparse_mla_topk_lens=None,
-                compressed_kv_cache_pool_ptr=None,
-            )
+        support_context = FmhaSupportContext.build(self, q, metadata,
+                                                   forward_args)
+        for fmha_cls in iter_enabled_fmha_libs():
+            if fmha_cls.is_supported(support_context):
+                self._get_fmha_backend(fmha_cls).forward(
+                    self, q, k, v, metadata, forward_args)
+                break
 
         if self.print_skip_softmax_stat:
             total_blocks, skipped_blocks = self.skip_softmax_stat

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1417,10 +1417,10 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         if backends is None:
             backends = {}
             self._fmha_backends = backends
-        backend = backends.get(fmha_cls.capabilities.name)
+        backend = backends.get(fmha_cls)
         if backend is None:
             backend = fmha_cls(attention_layer=self)
-            backends[fmha_cls.capabilities.name] = backend
+            backends[fmha_cls] = backend
         return backend
 
     def _run(

--- a/tensorrt_llm/_torch/attention_backend/trtllm_gen.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm_gen.py
@@ -30,16 +30,20 @@ if IS_FLASHINFER_AVAILABLE:
     import flashinfer
 
 from tensorrt_llm._torch.attention_backend.fmha import (
+    AcceptedFeatureSet,
     AcceptedIntegerValues,
+    AcceptedValues,
     BaseFmha,
     DTypeCombination,
     FmhaCapabilities,
     FmhaFeature,
-    FmhaPhase,
+    FmhaKvCacheUpdateMode,
+    FmhaQkvMode,
     FmhaSupportContext,
-    MlaCapabilities,
     MlaGenerationCase,
+    MlaPhaseCapabilities,
     PhaseCapabilities,
+    StandardPhaseCapabilities,
 )
 from tensorrt_llm._torch.attention_backend.interface import AttentionForwardArgs, AttentionInputType
 from tensorrt_llm.bindings import DataType
@@ -64,105 +68,235 @@ _TRTLLM_GEN_REQUIRED_THOP_OPS = (
     "build_trtllm_gen_kv_cache_metadata",
 )
 
-_TRTLLM_GEN_CONTEXT_DTYPE_COMBINATIONS = frozenset(
-    {
-        DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.float8_e4m3fn),
-        DTypeCombination(torch.float16, DataType.HALF, torch.float16),
-        DTypeCombination(torch.bfloat16, DataType.BF16, torch.bfloat16),
-        DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.float16),
-        DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.bfloat16),
-        DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.float8_e4m3fn),
-        DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.float16),
-        DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.bfloat16),
-    }
-)
-
-_TRTLLM_GEN_GENERATION_DTYPE_COMBINATIONS = frozenset(
-    {
-        DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.float8_e4m3fn),
-        DTypeCombination(torch.float16, DataType.HALF, torch.float16),
-        DTypeCombination(torch.bfloat16, DataType.BF16, torch.bfloat16),
-        DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.float16),
-        DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.bfloat16),
-        DTypeCombination(torch.bfloat16, DataType.FP8, torch.bfloat16),
-        DTypeCombination(torch.float16, DataType.FP8, torch.float16),
-        DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.float8_e4m3fn),
-        DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.float16),
-        DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.bfloat16),
-    }
-)
-
-_TRTLLM_GEN_RUNTIME_FEATURES = frozenset(
-    {
-        FmhaFeature.kv_cache_manager,
-        FmhaFeature.paged_kv_cache,
-        FmhaFeature.output_buffer,
-    }
-)
-
-_TRTLLM_GEN_CONTEXT_HEAD_SIZES = frozenset(
-    {
-        # TRTLLM-GEN context kernels currently cover common power-of-two LLM head
-        # sizes. HeadDim=80 has a padded SMEM layout in the C++ export path but is
-        # not accepted here until the flashinfer package ships the matching context
-        # kernels for this path.
-        16,
-        32,
-        64,
-        128,
-        256,
-        512,
-    }
-)
-
-_TRTLLM_GEN_POSITION_EMBEDDING_TYPES = frozenset(
-    {
-        position_embedding_type
-        for position_embedding_type in PositionEmbeddingType
-        if not position_embedding_type.is_alibi()
-    }
-)
-
-_TRTLLM_GEN_CONTEXT_MASK_TYPES = frozenset(
-    {mask_type for mask_type in AttentionMaskType if mask_type != AttentionMaskType.custom_mask}
-)
-
-_TRTLLM_GEN_MLA_GENERATION_CASES = frozenset(
-    {
-        MlaGenerationCase(320, 256, 16),
-        MlaGenerationCase(320, 256, 32),
-        MlaGenerationCase(320, 256, 64),
-        MlaGenerationCase(576, 512, 16),
-        MlaGenerationCase(576, 512, 64),
-    }
-)
-
 FLASHINFER_TRTLLM_GEN_CAPABILITIES = FmhaCapabilities(
-    name="flashinfer_trtllm_gen",
-    sm_versions=AcceptedIntegerValues(values=frozenset({100, 103})),
-    attention_input_types=frozenset(AttentionInputType),
-    runtime_features=_TRTLLM_GEN_RUNTIME_FEATURES,
-    required_runtime_features=_TRTLLM_GEN_RUNTIME_FEATURES,
+    sm=AcceptedIntegerValues(values=frozenset({100, 103})),
+    attention_input_type=AcceptedValues(
+        values=frozenset(
+            {
+                AttentionInputType.mixed,
+                AttentionInputType.context_only,
+                AttentionInputType.generation_only,
+            }
+        )
+    ),
+    runtime_features=AcceptedFeatureSet(
+        values=frozenset(
+            {
+                FmhaFeature.kv_cache_manager,
+                FmhaFeature.paged_kv_cache,
+                FmhaFeature.output_buffer,
+            }
+        )
+    ),
+    required_runtime_features=frozenset(
+        {
+            FmhaFeature.kv_cache_manager,
+            FmhaFeature.paged_kv_cache,
+            FmhaFeature.output_buffer,
+        }
+    ),
     tokens_per_block=AcceptedIntegerValues(values=frozenset({16, 32, 64})),
-    generation_beam_widths=AcceptedIntegerValues(values=frozenset({1})),
-    generation_head_ratios=AcceptedIntegerValues(min_value=1, max_value=32),
+    beam_width=AcceptedIntegerValues(values=frozenset({1})),
+    num_heads_per_kv_head=AcceptedIntegerValues(min_value=1, max_value=32),
     context=PhaseCapabilities(
-        dtype_combinations=_TRTLLM_GEN_CONTEXT_DTYPE_COMBINATIONS,
-        head_sizes=AcceptedIntegerValues(values=_TRTLLM_GEN_CONTEXT_HEAD_SIZES),
-        mask_types=_TRTLLM_GEN_CONTEXT_MASK_TYPES,
-        position_embedding_types=_TRTLLM_GEN_POSITION_EMBEDDING_TYPES,
-        features=frozenset(),
+        standard=StandardPhaseCapabilities(
+            dtype_combinations=frozenset(
+                {
+                    DTypeCombination(torch.float16, DataType.HALF, torch.float16),
+                    DTypeCombination(torch.bfloat16, DataType.BF16, torch.bfloat16),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.float8_e4m3fn),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.float16),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.bfloat16),
+                    DTypeCombination(torch.float16, DataType.NVFP4, torch.float16),
+                    DTypeCombination(torch.float16, DataType.NVFP4, torch.float8_e4m3fn),
+                    DTypeCombination(torch.float16, DataType.NVFP4, torch.uint8),
+                    DTypeCombination(torch.bfloat16, DataType.NVFP4, torch.bfloat16),
+                    DTypeCombination(torch.bfloat16, DataType.NVFP4, torch.float8_e4m3fn),
+                    DTypeCombination(torch.bfloat16, DataType.NVFP4, torch.uint8),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.float8_e4m3fn),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.float16),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.bfloat16),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.uint8),
+                }
+            ),
+            head_size=AcceptedIntegerValues(values=frozenset({16, 32, 64, 128, 256, 512})),
+            qkv_mode=AcceptedValues(values=frozenset({FmhaQkvMode.fused_qkv})),
+            kv_cache_update_mode=AcceptedValues(values=frozenset({FmhaKvCacheUpdateMode.update})),
+            mask_type=AcceptedValues(
+                values=frozenset(
+                    {
+                        AttentionMaskType.padding,
+                        AttentionMaskType.causal,
+                        AttentionMaskType.sliding_window_causal,
+                        AttentionMaskType.bidirectional,
+                        AttentionMaskType.bidirectionalglm,
+                        AttentionMaskType.blocksparse,
+                    }
+                )
+            ),
+            position_embedding_type=AcceptedValues(
+                values=frozenset(
+                    {
+                        PositionEmbeddingType.learned_absolute,
+                        PositionEmbeddingType.rope_gptj,
+                        PositionEmbeddingType.rope_gpt_neox,
+                        PositionEmbeddingType.long_rope,
+                        PositionEmbeddingType.relative,
+                        PositionEmbeddingType.chatglm,
+                        PositionEmbeddingType.yarn,
+                        PositionEmbeddingType.mrope,
+                        PositionEmbeddingType.deferred,
+                    }
+                )
+            ),
+            runtime_features=AcceptedFeatureSet(
+                values=frozenset(
+                    {
+                        FmhaFeature.kv_cache_manager,
+                        FmhaFeature.paged_kv_cache,
+                        FmhaFeature.output_buffer,
+                    }
+                )
+            ),
+            phase_features=AcceptedFeatureSet(values=frozenset()),
+        ),
     ),
     generation=PhaseCapabilities(
-        dtype_combinations=_TRTLLM_GEN_GENERATION_DTYPE_COMBINATIONS,
-        head_sizes=AcceptedIntegerValues(min_value=1),
-        mask_types=frozenset(AttentionMaskType),
-        position_embedding_types=_TRTLLM_GEN_POSITION_EMBEDDING_TYPES,
-        features=frozenset(),
-    ),
-    mla=MlaCapabilities(
-        phases=frozenset({FmhaPhase.generation}),
-        generation_cases=_TRTLLM_GEN_MLA_GENERATION_CASES,
+        standard=StandardPhaseCapabilities(
+            dtype_combinations=frozenset(
+                {
+                    DTypeCombination(torch.float16, DataType.HALF, torch.float16),
+                    DTypeCombination(torch.bfloat16, DataType.BF16, torch.bfloat16),
+                    DTypeCombination(torch.float16, DataType.FP8, torch.float16),
+                    DTypeCombination(torch.bfloat16, DataType.FP8, torch.bfloat16),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.float8_e4m3fn),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.float16),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.bfloat16),
+                    DTypeCombination(torch.float16, DataType.NVFP4, torch.float16),
+                    DTypeCombination(torch.float16, DataType.NVFP4, torch.float8_e4m3fn),
+                    DTypeCombination(torch.float16, DataType.NVFP4, torch.uint8),
+                    DTypeCombination(torch.bfloat16, DataType.NVFP4, torch.bfloat16),
+                    DTypeCombination(torch.bfloat16, DataType.NVFP4, torch.float8_e4m3fn),
+                    DTypeCombination(torch.bfloat16, DataType.NVFP4, torch.uint8),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.float8_e4m3fn),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.float16),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.bfloat16),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.uint8),
+                }
+            ),
+            head_size=AcceptedIntegerValues(min_value=1),
+            qkv_mode=AcceptedValues(values=frozenset({FmhaQkvMode.fused_qkv})),
+            kv_cache_update_mode=AcceptedValues(values=frozenset({FmhaKvCacheUpdateMode.update})),
+            mask_type=AcceptedValues(
+                values=frozenset(
+                    {
+                        AttentionMaskType.padding,
+                        AttentionMaskType.causal,
+                        AttentionMaskType.sliding_window_causal,
+                        AttentionMaskType.bidirectional,
+                        AttentionMaskType.bidirectionalglm,
+                        AttentionMaskType.blocksparse,
+                        AttentionMaskType.custom_mask,
+                    }
+                )
+            ),
+            position_embedding_type=AcceptedValues(
+                values=frozenset(
+                    {
+                        PositionEmbeddingType.learned_absolute,
+                        PositionEmbeddingType.rope_gptj,
+                        PositionEmbeddingType.rope_gpt_neox,
+                        PositionEmbeddingType.long_rope,
+                        PositionEmbeddingType.relative,
+                        PositionEmbeddingType.chatglm,
+                        PositionEmbeddingType.yarn,
+                        PositionEmbeddingType.mrope,
+                        PositionEmbeddingType.deferred,
+                    }
+                )
+            ),
+            runtime_features=AcceptedFeatureSet(
+                values=frozenset(
+                    {
+                        FmhaFeature.kv_cache_manager,
+                        FmhaFeature.paged_kv_cache,
+                        FmhaFeature.output_buffer,
+                    }
+                )
+            ),
+            phase_features=AcceptedFeatureSet(values=frozenset()),
+        ),
+        mla=MlaPhaseCapabilities(
+            dtype_combinations=frozenset(
+                {
+                    DTypeCombination(torch.float16, DataType.HALF, torch.float16),
+                    DTypeCombination(torch.bfloat16, DataType.BF16, torch.bfloat16),
+                    DTypeCombination(torch.float16, DataType.FP8, torch.float16),
+                    DTypeCombination(torch.bfloat16, DataType.FP8, torch.bfloat16),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.float8_e4m3fn),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.float16),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.bfloat16),
+                    DTypeCombination(torch.float16, DataType.NVFP4, torch.float16),
+                    DTypeCombination(torch.float16, DataType.NVFP4, torch.float8_e4m3fn),
+                    DTypeCombination(torch.float16, DataType.NVFP4, torch.uint8),
+                    DTypeCombination(torch.bfloat16, DataType.NVFP4, torch.bfloat16),
+                    DTypeCombination(torch.bfloat16, DataType.NVFP4, torch.float8_e4m3fn),
+                    DTypeCombination(torch.bfloat16, DataType.NVFP4, torch.uint8),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.float8_e4m3fn),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.float16),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.bfloat16),
+                    DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.uint8),
+                }
+            ),
+            generation_cases=frozenset(
+                {
+                    MlaGenerationCase(
+                        320, 256, AcceptedIntegerValues(values=frozenset({16, 32, 64}))
+                    ),
+                    MlaGenerationCase(576, 512, AcceptedIntegerValues(values=frozenset({16, 64}))),
+                }
+            ),
+            qkv_mode=AcceptedValues(values=frozenset({FmhaQkvMode.fused_qkv})),
+            kv_cache_update_mode=AcceptedValues(values=frozenset({FmhaKvCacheUpdateMode.update})),
+            mask_type=AcceptedValues(
+                values=frozenset(
+                    {
+                        AttentionMaskType.padding,
+                        AttentionMaskType.causal,
+                        AttentionMaskType.sliding_window_causal,
+                        AttentionMaskType.bidirectional,
+                        AttentionMaskType.bidirectionalglm,
+                        AttentionMaskType.blocksparse,
+                        AttentionMaskType.custom_mask,
+                    }
+                )
+            ),
+            position_embedding_type=AcceptedValues(
+                values=frozenset(
+                    {
+                        PositionEmbeddingType.learned_absolute,
+                        PositionEmbeddingType.rope_gptj,
+                        PositionEmbeddingType.rope_gpt_neox,
+                        PositionEmbeddingType.long_rope,
+                        PositionEmbeddingType.relative,
+                        PositionEmbeddingType.chatglm,
+                        PositionEmbeddingType.yarn,
+                        PositionEmbeddingType.mrope,
+                        PositionEmbeddingType.deferred,
+                    }
+                )
+            ),
+            runtime_features=AcceptedFeatureSet(
+                values=frozenset(
+                    {
+                        FmhaFeature.kv_cache_manager,
+                        FmhaFeature.paged_kv_cache,
+                        FmhaFeature.output_buffer,
+                    }
+                )
+            ),
+            phase_features=AcceptedFeatureSet(values=frozenset()),
+        ),
     ),
 )
 

--- a/tensorrt_llm/_torch/attention_backend/trtllm_gen.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm_gen.py
@@ -11,22 +11,13 @@ Architecture:
     - Attention: flashinfer trtllm-gen FMHA kernels, reading KV cache through
       the KV cache manager carried by attention metadata.
 
-Entry points:
-    FlashInferTrtllmGenAttention.is_supported()  - Check if trtllm-gen can handle the given config.
-    FlashInferTrtllmGenAttention.attention()      - Main attention method (called from TrtllmAttention.run).
-
-Example:
-    backend = FlashInferTrtllmGenAttention(attention_layer=...)
-    supported, reason = backend.is_supported(
-        q, metadata=..., forward_args=..., ...)
-    if supported:
-        backend.attention(q, metadata=..., forward_args=..., ...)
-    else:
-        Fallback to thop.attention()
+Entry point:
+    FlashInferTrtllmGenFmha.forward() - Main attention method selected by
+    TrtllmAttention's unified FMHA capability evaluator.
 """
 
 import math
-import weakref
+import os
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING, List, Optional, Tuple
@@ -38,13 +29,23 @@ from tensorrt_llm._torch.flashinfer_utils import IS_FLASHINFER_AVAILABLE, get_en
 if IS_FLASHINFER_AVAILABLE:
     import flashinfer
 
+from tensorrt_llm._torch.attention_backend.fmha import (
+    AcceptedIntegerValues,
+    BaseFmha,
+    DTypeCombination,
+    FmhaCapabilities,
+    FmhaFeature,
+    FmhaPhase,
+    FmhaSupportContext,
+    MlaCapabilities,
+    MlaGenerationCase,
+    PhaseCapabilities,
+)
 from tensorrt_llm._torch.attention_backend.interface import AttentionForwardArgs, AttentionInputType
-from tensorrt_llm._utils import get_sm_version, is_sm_100f
 from tensorrt_llm.bindings import DataType
 from tensorrt_llm.bindings.internal import thop
-from tensorrt_llm.functional import AttentionMaskType
+from tensorrt_llm.functional import AttentionMaskType, PositionEmbeddingType
 from tensorrt_llm.logger import logger
-from tensorrt_llm.models.modeling_utils import QuantConfig
 from tensorrt_llm.quantization.mode import QuantMode
 
 if TYPE_CHECKING:
@@ -54,283 +55,116 @@ if TYPE_CHECKING:
     )
 
 
-class TrtllmGenSupportChecker:
-    """
-    Validates if a configuration is supported by trtllm-gen backend.
+_TRTLLM_GEN_REQUIRED_THOP_OPS = (
+    "get_trtllm_gen_context_workspace_layout",
+    "get_trtllm_gen_generation_workspace_layout",
+    "trtllm_gen_context_preprocess",
+    "trtllm_gen_context_postprocess",
+    "trtllm_gen_generation_preprocess",
+    "build_trtllm_gen_kv_cache_metadata",
+)
 
-    Implements all checks from the original C++ AttentionOp to determine
-    if trtllm-gen kernel can handle the attention computation.
-    """
-
-    # Supported data types
-    SUPPORTED_INPUT_DTYPES = {torch.float16, torch.bfloat16, torch.float8_e4m3fn}
-    SUPPORTED_KV_CACHE_DTYPES = {
-        DataType.HALF,
-        DataType.BF16,
-        DataType.FP8,
-        DataType.NVFP4,
+_TRTLLM_GEN_CONTEXT_DTYPE_COMBINATIONS = frozenset(
+    {
+        DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.float8_e4m3fn),
+        DTypeCombination(torch.float16, DataType.HALF, torch.float16),
+        DTypeCombination(torch.bfloat16, DataType.BF16, torch.bfloat16),
+        DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.float16),
+        DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.bfloat16),
+        DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.float8_e4m3fn),
+        DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.float16),
+        DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.bfloat16),
     }
-    SUPPORTED_OUT_DTYPES = {torch.float16, torch.bfloat16, torch.float8_e4m3fn}
+)
 
-    # Supported Q:KV:O dtype combinations for trtllm-gen kernels
-    # Format: (q_dtype: torch.dtype, kv_dtype: DataType, o_dtype: torch.dtype)
-    # Context phase supported combinations
-    SUPPORTED_DTYPE_COMBOS_CONTEXT = {
-        # e4m3:e4m3:e4m3
-        (torch.float8_e4m3fn, DataType.FP8, torch.float8_e4m3fn),
-        # fp16:fp16:fp16
-        (torch.float16, DataType.HALF, torch.float16),
-        # bf16:bf16:bf16
-        (torch.bfloat16, DataType.BF16, torch.bfloat16),
-        # e4m3:e4m3:fp16
-        (torch.float8_e4m3fn, DataType.FP8, torch.float16),
-        # e4m3:e4m3:bf16
-        (torch.float8_e4m3fn, DataType.FP8, torch.bfloat16),
-        # e4m3:nvfp4:*
-        (torch.float8_e4m3fn, DataType.NVFP4, torch.float8_e4m3fn),
-        (torch.float8_e4m3fn, DataType.NVFP4, torch.float16),
-        (torch.float8_e4m3fn, DataType.NVFP4, torch.bfloat16),
+_TRTLLM_GEN_GENERATION_DTYPE_COMBINATIONS = frozenset(
+    {
+        DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.float8_e4m3fn),
+        DTypeCombination(torch.float16, DataType.HALF, torch.float16),
+        DTypeCombination(torch.bfloat16, DataType.BF16, torch.bfloat16),
+        DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.float16),
+        DTypeCombination(torch.float8_e4m3fn, DataType.FP8, torch.bfloat16),
+        DTypeCombination(torch.bfloat16, DataType.FP8, torch.bfloat16),
+        DTypeCombination(torch.float16, DataType.FP8, torch.float16),
+        DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.float8_e4m3fn),
+        DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.float16),
+        DTypeCombination(torch.float8_e4m3fn, DataType.NVFP4, torch.bfloat16),
     }
+)
 
-    # Generation phase supported combinations (includes context + additional)
-    SUPPORTED_DTYPE_COMBOS_GENERATION = {
-        # All context combinations
-        (torch.float8_e4m3fn, DataType.FP8, torch.float8_e4m3fn),
-        (torch.float16, DataType.HALF, torch.float16),
-        (torch.bfloat16, DataType.BF16, torch.bfloat16),
-        (torch.float8_e4m3fn, DataType.FP8, torch.float16),
-        (torch.float8_e4m3fn, DataType.FP8, torch.bfloat16),
-        # Additional generation-only combinations
-        # bf16:e4m3:bf16
-        (torch.bfloat16, DataType.FP8, torch.bfloat16),
-        # fp16:e4m3:fp16
-        (torch.float16, DataType.FP8, torch.float16),
-        # e4m3:nvfp4:*
-        (torch.float8_e4m3fn, DataType.NVFP4, torch.float8_e4m3fn),
-        (torch.float8_e4m3fn, DataType.NVFP4, torch.float16),
-        (torch.float8_e4m3fn, DataType.NVFP4, torch.bfloat16),
+_TRTLLM_GEN_RUNTIME_FEATURES = frozenset(
+    {
+        FmhaFeature.kv_cache_manager,
+        FmhaFeature.paged_kv_cache,
+        FmhaFeature.output_buffer,
     }
+)
 
-    # Unsupported head sizes for context FMHA.
-    # 96 is excluded because trtllm-gen kernel library does not ship
-    # context kernels for headDim=96 (affects Phi-3 family models).
-    UNSUPPORTED_HEAD_SIZES_CONTEXT = {72, 80, 96}
-
-    # Maximum heads ratio for generation.
-    MAX_HEADS_RATIO_GENERATION = 32
-
-    # Minimum tokens per block, tokens_per_block < 8 is not supported by TRTLLM-GEN kernels.
-    MIN_TOKENS_PER_BLOCK = 8
-
-    # Supported tokens_per_block values for trtllm-gen kernels
-    SUPPORTED_TOKENS_PER_BLOCK = {16, 32, 64}
-
-    # MLA shapes accepted by FlashInfer's trtllm-gen wrapper/launcher. The decode API
-    # uses kv_lora_rank as headDimV and kv_lora_rank + qk_rope_head_dim as headDimQk.
-    SUPPORTED_MLA_GENERATION_HEAD_DIMS = {
-        (320, 256),
-        (576, 512),
+_TRTLLM_GEN_CONTEXT_HEAD_SIZES = frozenset(
+    {
+        # TRTLLM-GEN context kernels currently cover common power-of-two LLM head
+        # sizes. HeadDim=80 has a padded SMEM layout in the C++ export path but is
+        # not accepted here until the flashinfer package ships the matching context
+        # kernels for this path.
+        16,
+        32,
+        64,
+        128,
+        256,
+        512,
     }
+)
 
-    # Known FlashInfer package gap: this shape can pass the coarse checks but then fail
-    # in the TRTLLM-GEN launcher with "Missing TRTLLM-GEN kernel".
-    MISSING_MLA_GENERATION_KERNELS = {
-        (576, 512, 32),
+_TRTLLM_GEN_POSITION_EMBEDDING_TYPES = frozenset(
+    {
+        position_embedding_type
+        for position_embedding_type in PositionEmbeddingType
+        if not position_embedding_type.is_alibi()
     }
+)
 
-    @classmethod
-    def _check_mla_generation_support(
-        cls,
-        head_size: int,
-        tokens_per_block: int,
-        kv_lora_rank: Optional[int],
-        qk_rope_head_dim: Optional[int],
-    ) -> Tuple[bool, str]:
-        missing_params = [
-            name
-            for name, value in (
-                ("kv_lora_rank", kv_lora_rank),
-                ("qk_rope_head_dim", qk_rope_head_dim),
-            )
-            if value is None or value <= 0
-        ]
-        if missing_params:
-            return (
-                False,
-                f"[Generation][MLA] Missing required MLA parameter(s): {', '.join(missing_params)}.",
-            )
+_TRTLLM_GEN_CONTEXT_MASK_TYPES = frozenset(
+    {mask_type for mask_type in AttentionMaskType if mask_type != AttentionMaskType.custom_mask}
+)
 
-        kv_rank = int(kv_lora_rank)
-        qk_rope_dim = int(qk_rope_head_dim)
-        head_dim_qk = kv_rank + qk_rope_dim
-        head_dim_v = kv_rank
-        if head_size != head_dim_qk:
-            return (
-                False,
-                f"[Generation][MLA] head_size ({head_size}) must match "
-                f"kv_lora_rank + qk_rope_head_dim ({head_dim_qk}).",
-            )
+_TRTLLM_GEN_MLA_GENERATION_CASES = frozenset(
+    {
+        MlaGenerationCase(320, 256, 16),
+        MlaGenerationCase(320, 256, 32),
+        MlaGenerationCase(320, 256, 64),
+        MlaGenerationCase(576, 512, 16),
+        MlaGenerationCase(576, 512, 64),
+    }
+)
 
-        if (head_dim_qk, head_dim_v) not in cls.SUPPORTED_MLA_GENERATION_HEAD_DIMS:
-            supported = sorted(cls.SUPPORTED_MLA_GENERATION_HEAD_DIMS)
-            return (
-                False,
-                f"[Generation][MLA] Unsupported head dimensions: "
-                f"headDimQk={head_dim_qk}, headDimV={head_dim_v}. Supported: {supported}.",
-            )
-
-        if (head_dim_qk, head_dim_v, tokens_per_block) in cls.MISSING_MLA_GENERATION_KERNELS:
-            return (
-                False,
-                f"[Generation][MLA] Missing TRTLLM-GEN decode kernel for "
-                f"headDimQk={head_dim_qk}, headDimV={head_dim_v}, "
-                f"tokens_per_block={tokens_per_block}.",
-            )
-
-        return True, ""
-
-    @classmethod
-    def is_supported(
-        cls,
-        q_dtype: torch.dtype,
-        kv_cache_dtype: DataType,
-        num_heads: int,
-        num_kv_heads: int,
-        head_size: int,
-        attention_input_type: Optional[int] = None,
-        out_dtype: Optional[torch.dtype] = None,
-        mask_type: int = 1,
-        beam_width: int = 1,
-        tokens_per_block: Optional[int] = 64,
-        use_paged_kv_cache: bool = True,
-        is_mla_enable: bool = False,
-        kv_lora_rank: Optional[int] = None,
-        qk_rope_head_dim: Optional[int] = None,
-        cross_attention: bool = False,
-        is_spec_decoding: bool = False,
-        has_alibi: bool = False,
-        is_padded: bool = False,
-        position_shift_enabled: bool = False,
-        quant_config: Optional[QuantConfig] = None,
-        has_sparse_attention: bool = False,
-        has_skip_softmax_attention: bool = False,
-    ) -> Tuple[bool, str]:
-        if tokens_per_block is None:
-            tokens_per_block = 0
-        has_context_phase = True
-        has_generation_phase = True
-        if attention_input_type is not None:
-            attn_input_type = AttentionInputType(attention_input_type)
-            has_context_phase = attn_input_type != AttentionInputType.generation_only
-            has_generation_phase = attn_input_type != AttentionInputType.context_only
-
-        sm = get_sm_version()
-        if not is_sm_100f(sm):
-            return (False, f"trtllm-gen requires SM100 or SM103 (Blackwell). Current: SM{sm}.")
-
-        if has_skip_softmax_attention:
-            return (
-                False,
-                "Skip-softmax attention is not supported by trtllm-gen backend.",
-            )
-
-        if has_sparse_attention:
-            return False, "Sparse attention is not supported by trtllm-gen backend."
-        if is_mla_enable and has_context_phase:
-            return False, (
-                "MLA context and mixed phases fall back to thop.attention until "
-                "FlashInfer context support is ready."
-            )
-        if cross_attention:
-            return False, "Cross attention is not supported by trtllm-gen backend."
-
-        if q_dtype not in cls.SUPPORTED_INPUT_DTYPES:
-            return False, f"Input dtype {q_dtype} not supported. Supported: FP16, BF16, FP8 (E4M3)."
-        if kv_cache_dtype not in cls.SUPPORTED_KV_CACHE_DTYPES:
-            return (
-                False,
-                f"KV cache dtype {kv_cache_dtype} not supported. Supported: FP16, BF16, FP8, NVFP4.",
-            )
-        if out_dtype is not None and out_dtype not in cls.SUPPORTED_OUT_DTYPES:
-            return False, f"Output dtype {out_dtype} not supported. Supported: FP16, BF16, FP8."
-
-        assert num_heads > 0, "num_heads must be positive."
-        assert num_kv_heads > 0, "num_kv_heads must be positive."
-        if num_heads % num_kv_heads != 0:
-            return (
-                False,
-                f"num_heads ({num_heads}) must be divisible by num_kv_heads ({num_kv_heads}).",
-            )
-
-        o_dtype = out_dtype if out_dtype is not None else q_dtype
-
-        check_context_phase = has_context_phase and not is_mla_enable
-        if check_context_phase:
-            if head_size in cls.UNSUPPORTED_HEAD_SIZES_CONTEXT:
-                return False, f"[Context] Head size {head_size} is not supported."
-            try:
-                if AttentionMaskType(mask_type) == AttentionMaskType.custom_mask:
-                    return False, "[Context] Custom mask is not supported."
-            except ValueError:
-                return False, f"[Context] Invalid mask_type: {mask_type}."
-            if has_alibi:
-                return False, "[Context] ALiBi is not supported."
-            if is_padded:
-                return False, "[Context] Padded input is not supported."
-            if (q_dtype, kv_cache_dtype, o_dtype) not in cls.SUPPORTED_DTYPE_COMBOS_CONTEXT:
-                return False, (
-                    f"[Context] Unsupported dtype combination: Q={q_dtype}, KV={kv_cache_dtype}, O={o_dtype}."
-                )
-
-        if has_generation_phase:
-            if beam_width != 1:
-                return (
-                    False,
-                    f"[Generation] Beam search (beam_width={beam_width}) is not supported. Must be 1.",
-                )
-            if position_shift_enabled:
-                return False, "[Generation] Position shift is not supported."
-            if tokens_per_block < cls.MIN_TOKENS_PER_BLOCK:
-                return (
-                    False,
-                    f"[Generation] tokens_per_block ({tokens_per_block}) must be >= {cls.MIN_TOKENS_PER_BLOCK}.",
-                )
-            heads_ratio = num_heads // num_kv_heads
-            if not is_mla_enable and heads_ratio > cls.MAX_HEADS_RATIO_GENERATION:
-                return (
-                    False,
-                    f"[Generation] heads ratio ({heads_ratio}) exceeds maximum ({cls.MAX_HEADS_RATIO_GENERATION}).",
-                )
-            if has_alibi:
-                return False, "[Generation] ALiBi is not supported."
-            if (q_dtype, kv_cache_dtype, o_dtype) not in cls.SUPPORTED_DTYPE_COMBOS_GENERATION:
-                return False, (
-                    f"[Generation] Unsupported dtype combination: Q={q_dtype}, KV={kv_cache_dtype}, O={o_dtype}."
-                )
-            if is_mla_enable:
-                supported, reason = cls._check_mla_generation_support(
-                    head_size=head_size,
-                    tokens_per_block=tokens_per_block,
-                    kv_lora_rank=kv_lora_rank,
-                    qk_rope_head_dim=qk_rope_head_dim,
-                )
-                if not supported:
-                    return False, reason
-
-        if use_paged_kv_cache:
-            if tokens_per_block <= 0:
-                return False, "tokens_per_block must be positive."
-            if tokens_per_block & (tokens_per_block - 1) != 0:
-                return False, f"tokens_per_block ({tokens_per_block}) must be power of 2."
-            if tokens_per_block not in cls.SUPPORTED_TOKENS_PER_BLOCK:
-                supported = sorted(cls.SUPPORTED_TOKENS_PER_BLOCK)
-                return (
-                    False,
-                    f"tokens_per_block ({tokens_per_block}) is not supported "
-                    f"by trtllm-gen kernels. Supported: {supported}.",
-                )
-
-        return True, ""
+FLASHINFER_TRTLLM_GEN_CAPABILITIES = FmhaCapabilities(
+    name="flashinfer_trtllm_gen",
+    sm_versions=AcceptedIntegerValues(values=frozenset({100, 103})),
+    attention_input_types=frozenset(AttentionInputType),
+    runtime_features=_TRTLLM_GEN_RUNTIME_FEATURES,
+    required_runtime_features=_TRTLLM_GEN_RUNTIME_FEATURES,
+    tokens_per_block=AcceptedIntegerValues(values=frozenset({16, 32, 64})),
+    generation_beam_widths=AcceptedIntegerValues(values=frozenset({1})),
+    generation_head_ratios=AcceptedIntegerValues(min_value=1, max_value=32),
+    context=PhaseCapabilities(
+        dtype_combinations=_TRTLLM_GEN_CONTEXT_DTYPE_COMBINATIONS,
+        head_sizes=AcceptedIntegerValues(values=_TRTLLM_GEN_CONTEXT_HEAD_SIZES),
+        mask_types=_TRTLLM_GEN_CONTEXT_MASK_TYPES,
+        position_embedding_types=_TRTLLM_GEN_POSITION_EMBEDDING_TYPES,
+        features=frozenset(),
+    ),
+    generation=PhaseCapabilities(
+        dtype_combinations=_TRTLLM_GEN_GENERATION_DTYPE_COMBINATIONS,
+        head_sizes=AcceptedIntegerValues(min_value=1),
+        mask_types=frozenset(AttentionMaskType),
+        position_embedding_types=_TRTLLM_GEN_POSITION_EMBEDDING_TYPES,
+        features=frozenset(),
+    ),
+    mla=MlaCapabilities(
+        phases=frozenset({FmhaPhase.generation}),
+        generation_cases=_TRTLLM_GEN_MLA_GENERATION_CASES,
+    ),
+)
 
 
 @lru_cache(maxsize=128)
@@ -464,7 +298,7 @@ class EnqueueParams:
     """Per-call dynamic parameters for trtllm-gen attention.
 
     Layer-static properties (num_heads, head_size, rotary params, etc.) are
-    read directly from ``FlashInferTrtllmGenAttention`` cached attributes
+    read directly from ``FlashInferTrtllmGenFmha`` cached attributes
     to avoid redundant copies on every forward call.
     """
 
@@ -503,10 +337,12 @@ class EnqueueParams:
     spec_decoding_packed_mask: Optional[torch.Tensor] = None
 
 
-class FlashInferTrtllmGenAttention:
+class FlashInferTrtllmGenFmha(BaseFmha):
     """
-    An attention backend using pure trtllm-gen kernels from flashinfer.
+    An FMHA implementation using pure trtllm-gen kernels from flashinfer.
     """
+
+    capabilities = FLASHINFER_TRTLLM_GEN_CAPABILITIES
 
     # Default KV layout for flashinfer
     # HND = [max_num_pages, kv_factor, num_kv_heads, page_size, head_dim]
@@ -515,12 +351,24 @@ class FlashInferTrtllmGenAttention:
     # block-table layout used by the fused preprocessing path.
     USE_SHARED_PAGED_KV_IDX = False
 
+    @classmethod
+    def is_supported(cls, context: FmhaSupportContext) -> bool:
+        if not super().is_supported(context):
+            return False
+        if os.environ.get("TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION", "0") != "1":
+            return cls._not_supported("disabled by TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION.")
+        if not IS_FLASHINFER_AVAILABLE:
+            return cls._not_supported("flashinfer package is not installed.")
+        missing_ops = cls._missing_fused_nanobind_ops()
+        if missing_ops:
+            return cls._not_supported(f"missing fused nanobind ops: {', '.join(missing_ops)}.")
+        return True
+
     def __init__(
         self,
         attention_layer: "TrtllmAttention",
     ):
-        self._attention_layer_ref = weakref.ref(attention_layer)
-        self._checker = TrtllmGenSupportChecker()
+        super().__init__(attention_layer)
         self._layout = self.DEFAULT_KV_LAYOUT
         # Read once so the hot path is not sensitive to later environment changes.
         self._enable_pdl = get_env_enable_pdl()
@@ -574,9 +422,6 @@ class FlashInferTrtllmGenAttention:
             attention_chunk_size=self._attention_chunk_size,
         )
 
-        # Cached is_supported() result.  None means not yet checked;
-        # a positive result is stable (model-static) and cached permanently.
-        self._support_result: Optional[Tuple[bool, str]] = None
         # Lazily set on the first attention() call from the query device.
         self._multi_processor_count: Optional[int] = None
 
@@ -584,12 +429,6 @@ class FlashInferTrtllmGenAttention:
     def layout(self) -> str:
         """KV cache layout."""
         return self._layout
-
-    def _get_attention_layer(self) -> "TrtllmAttention":
-        attention_layer = self._attention_layer_ref()
-        if attention_layer is None:
-            raise RuntimeError("trtllm-gen attention layer has been destroyed.")
-        return attention_layer
 
     def _get_kv_scale_params(
         self,
@@ -616,77 +455,6 @@ class FlashInferTrtllmGenAttention:
 
         return kv_scale_orig_quant, kv_scale_quant_orig
 
-    def is_supported(
-        self,
-        q: torch.Tensor,
-        *,
-        metadata: "TrtllmAttentionMetadata",
-        forward_args: AttentionForwardArgs,
-        mask_type: int,
-        active_helix: bool,
-        use_sage_attn: bool,
-    ) -> Tuple[bool, str]:
-        if use_sage_attn:
-            return False, "trtllm-gen does not support sage attention."
-        if active_helix:
-            return False, "trtllm-gen does not support helix parallelism."
-        # Return cached positive result after the first supported call.
-        if self._support_result is not None:
-            return self._support_result
-
-        if not IS_FLASHINFER_AVAILABLE:
-            return False, "flashinfer package is not installed."
-        kv_cache_manager = metadata.kv_cache_manager
-        if kv_cache_manager is None:
-            return False, "trtllm-gen requires a KVCacheManager."
-        use_paged_kv_cache = metadata.kv_cache_block_offsets is not None
-        if not use_paged_kv_cache:
-            return False, "trtllm-gen requires paged KV cache."
-
-        output = forward_args.output
-        if output is None:
-            return False, "trtllm-gen requires forward_args.output."
-
-        attention_layer = self._get_attention_layer()
-        sparse_attention_config = attention_layer.sparse_attention_config
-        has_skip_softmax_attention = (
-            getattr(sparse_attention_config, "algorithm", None) == "skip_softmax"
-        )
-        has_sparse_attention = (
-            sparse_attention_config is not None and not has_skip_softmax_attention
-        )
-        q_dtype = q.dtype
-        if kv_cache_manager.dtype == DataType.NVFP4:
-            q_dtype = torch.float8_e4m3fn
-
-        result = self._checker.is_supported(
-            q_dtype=q_dtype,
-            kv_cache_dtype=kv_cache_manager.dtype,
-            num_heads=self._num_heads,
-            num_kv_heads=self._num_kv_heads,
-            head_size=self._head_dim,
-            attention_input_type=int(forward_args.attention_input_type),
-            out_dtype=output.dtype,
-            mask_type=mask_type,
-            beam_width=metadata.beam_width,
-            tokens_per_block=metadata.tokens_per_block,
-            use_paged_kv_cache=use_paged_kv_cache,
-            is_mla_enable=self._is_mla_enable,
-            kv_lora_rank=self._kv_lora_rank,
-            qk_rope_head_dim=self._qk_rope_head_dim,
-            cross_attention=False,
-            is_spec_decoding=metadata.is_spec_decoding_enabled,
-            has_alibi=self._position_embedding_type in (4, 5),
-            is_padded=False,
-            position_shift_enabled=False,
-            quant_config=attention_layer.quant_config,
-            has_sparse_attention=has_sparse_attention,
-            has_skip_softmax_attention=has_skip_softmax_attention,
-        )
-        if result[0]:
-            self._support_result = result
-        return result
-
     @staticmethod
     @lru_cache(maxsize=None)
     def _get_multi_processor_count_for_device(device_index: int) -> int:
@@ -700,6 +468,23 @@ class FlashInferTrtllmGenAttention:
         if device_index is None:
             device_index = torch.cuda.current_device()
         return self._get_multi_processor_count_for_device(device_index)
+
+    def forward(
+        self,
+        attn: "TrtllmAttention",
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> None:
+        self.attention(
+            q,
+            metadata=metadata,
+            forward_args=forward_args,
+            mask_type=int(forward_args.mask_type),
+            use_paged_context_fmha=metadata.use_paged_context_fmha,
+        )
 
     def attention(
         self,
@@ -935,15 +720,7 @@ class FlashInferTrtllmGenAttention:
 
     @staticmethod
     def _missing_fused_nanobind_ops() -> List[str]:
-        required_ops = (
-            "get_trtllm_gen_context_workspace_layout",
-            "get_trtllm_gen_generation_workspace_layout",
-            "trtllm_gen_context_preprocess",
-            "trtllm_gen_context_postprocess",
-            "trtllm_gen_generation_preprocess",
-            "build_trtllm_gen_kv_cache_metadata",
-        )
-        return [op for op in required_ops if not hasattr(thop, op)]
+        return [op for op in _TRTLLM_GEN_REQUIRED_THOP_OPS if not hasattr(thop, op)]
 
     def _get_kv_cache_metadata(
         self,
@@ -1264,3 +1041,6 @@ class FlashInferTrtllmGenAttention:
             enable_pdl=self._enable_pdl,
             backend="trtllm-gen",
         )
+
+
+FlashInferTrtllmGenAttention = FlashInferTrtllmGenFmha

--- a/tests/unittest/_torch/attention_backend/test_attention_op_sync.py
+++ b/tests/unittest/_torch/attention_backend/test_attention_op_sync.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Static sync test for the inline ``thop.attention(...)`` call in
-``TrtllmAttention._run``.
+"""Static sync test for the ``thop.attention(...)`` call in
+``call_thop_attention``.
 
 That call is the single explicit-kwarg call site for the C++ ``thop.attention``
 binding. This test parses both the call site (Python AST) and the C++
@@ -20,7 +20,7 @@ function declaration in ``attentionOp.h`` (text/regex), and enforces:
 
 1. Every C++ parameter name appears at the call site (and nothing extra).
 2. Every call-site kwarg sourced as ``root.attr[.attr...]`` resolves on
-   exactly one of ``self`` / ``metadata`` / ``forward_args``, and its
+   exactly one of ``attn`` / ``metadata`` / ``forward_args``, and its
    declared C++ type matches the source attribute's Python type at a
    coarse-category level (tensor / int / bool / float / list-of-X).
 3. Every dataclass field reachable from ``AttentionForwardArgs`` (including
@@ -42,18 +42,18 @@ import textwrap
 import typing
 from dataclasses import fields
 
-from tensorrt_llm._torch.attention_backend.interface import AttentionForwardArgs
-from tensorrt_llm._torch.attention_backend.trtllm import (
+from tensorrt_llm._torch.attention_backend.fmha import (
     _THOP_EXCLUDED_FIELDS,
     _THOP_LITERALS,
-    TrtllmAttention,
-    TrtllmAttentionMetadata,
+    call_thop_attention,
 )
+from tensorrt_llm._torch.attention_backend.interface import AttentionForwardArgs
+from tensorrt_llm._torch.attention_backend.trtllm import TrtllmAttention, TrtllmAttentionMetadata
 
 # Roots used as the LHS of attribute chains at the call site. Match the
-# parameter names inside ``TrtllmAttention._run``.
+# parameter names inside ``call_thop_attention``.
 _SOURCE_CLASSES = {
-    "self": TrtllmAttention,
+    "attn": TrtllmAttention,
     "metadata": TrtllmAttentionMetadata,
     "forward_args": AttentionForwardArgs,
 }
@@ -183,8 +183,8 @@ def _binding_types() -> dict[str, str]:
 
 
 def _parse_thop_attention_call() -> ast.Call:
-    """Locate the single ``thop.attention(...)`` call inside ``_run``."""
-    src = textwrap.dedent(inspect.getsource(TrtllmAttention._run))
+    """Locate the single ``thop.attention(...)`` call in ``call_thop_attention``."""
+    src = textwrap.dedent(inspect.getsource(call_thop_attention))
     tree = ast.parse(src)
     for node in ast.walk(tree):
         if (
@@ -195,7 +195,7 @@ def _parse_thop_attention_call() -> ast.Call:
             and node.func.value.id == "thop"
         ):
             return node
-    raise AssertionError("Could not find thop.attention(...) call in TrtllmAttention._run")
+    raise AssertionError("Could not find thop.attention(...) call in call_thop_attention")
 
 
 def _attribute_path(node: ast.AST) -> tuple[str, tuple[str, ...]] | None:
@@ -444,8 +444,8 @@ def _self_attrs_in_property(prop: property) -> set[str]:
 
 
 def _collect_chains(root: str) -> set[tuple[str, ...]]:
-    """All attribute paths in ``_run`` that start with ``Name(root).``."""
-    src = textwrap.dedent(inspect.getsource(TrtllmAttention._run))
+    """All attribute paths in ``call_thop_attention`` that start with ``Name(root).``."""
+    src = textwrap.dedent(inspect.getsource(call_thop_attention))
     chains: set[tuple[str, ...]] = set()
     for node in ast.walk(ast.parse(src)):
         if not isinstance(node, ast.Attribute):

--- a/tests/unittest/_torch/attention_backend/test_fmha_capabilities.py
+++ b/tests/unittest/_torch/attention_backend/test_fmha_capabilities.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.attention_backend.fmha import (
+    BaseFmha,
+    FallbackFmha,
+    FmhaFeature,
+    FmhaSupportContext,
+)
+from tensorrt_llm._torch.attention_backend.interface import AttentionInputType
+from tensorrt_llm._torch.attention_backend.trtllm import iter_enabled_fmha_libs
+from tensorrt_llm._torch.attention_backend.trtllm_gen import (
+    FLASHINFER_TRTLLM_GEN_CAPABILITIES,
+    FlashInferTrtllmGenFmha,
+)
+from tensorrt_llm.bindings import DataType
+from tensorrt_llm.functional import AttentionMaskType, PositionEmbeddingType
+
+
+class StaticFlashInferTrtllmGenFmha(BaseFmha):
+    capabilities = FLASHINFER_TRTLLM_GEN_CAPABILITIES
+
+
+def _context(**overrides) -> FmhaSupportContext:
+    values = dict(
+        sm=100,
+        q_dtype=torch.float16,
+        kv_cache_dtype=DataType.HALF,
+        output_dtype=torch.float16,
+        num_heads=16,
+        num_kv_heads=8,
+        head_size=64,
+        attention_input_type=AttentionInputType.context_only,
+        mask_type=AttentionMaskType.causal,
+        position_embedding_type=PositionEmbeddingType.rope_gpt_neox,
+        beam_width=1,
+        tokens_per_block=16,
+        has_kv_cache_manager=True,
+        use_paged_kv_cache=True,
+        is_mla_enable=False,
+        kv_lora_rank=None,
+        qk_rope_head_dim=None,
+        has_context_phase=True,
+        has_generation_phase=False,
+        is_cross_attention=False,
+        is_spec_decoding=False,
+        is_padded=False,
+        position_shift_enabled=False,
+        active_helix=False,
+        use_sage_attention=False,
+        has_sparse_attention=False,
+        has_skip_softmax_attention=False,
+    )
+    values.update(overrides)
+    return FmhaSupportContext(**values)
+
+
+def test_default_fmha_order(monkeypatch):
+    monkeypatch.delenv("TLLM_FMHA_LIBS", raising=False)
+    assert [fmha.capabilities.name for fmha in iter_enabled_fmha_libs()] == [
+        "flashinfer_trtllm_gen",
+        "fallback",
+    ]
+
+
+def test_fmha_env_delta_disables_flashinfer_but_keeps_fallback(monkeypatch):
+    monkeypatch.setenv("TLLM_FMHA_LIBS", "-flashinfer_trtllm_gen,-fallback")
+    assert [fmha.capabilities.name for fmha in iter_enabled_fmha_libs()] == ["fallback"]
+
+
+def test_fmha_env_delta_raises_unknown_name(monkeypatch):
+    monkeypatch.setenv("TLLM_FMHA_LIBS", "+does_not_exist")
+    with pytest.raises(ValueError, match="Unknown FMHA library"):
+        iter_enabled_fmha_libs()
+
+
+def test_flashinfer_fmha_uses_declarative_capabilities():
+    assert FlashInferTrtllmGenFmha.capabilities is FLASHINFER_TRTLLM_GEN_CAPABILITIES
+    assert FLASHINFER_TRTLLM_GEN_CAPABILITIES.context.head_sizes.values
+    assert FLASHINFER_TRTLLM_GEN_CAPABILITIES.mla.generation_cases
+    assert (576, 512, 32) not in {
+        (case.head_dim_qk, case.head_dim_v, case.tokens_per_block)
+        for case in FLASHINFER_TRTLLM_GEN_CAPABILITIES.mla.generation_cases
+    }
+
+
+def test_fallback_fmha_has_declarative_capabilities():
+    assert FallbackFmha.capabilities.runtime_features == frozenset(FmhaFeature)
+    assert FallbackFmha.capabilities.generation_head_ratios.min_value == 1
+    assert FallbackFmha.is_supported(
+        _context(
+            sm=90,
+            kv_cache_dtype=None,
+            output_dtype=None,
+            tokens_per_block=None,
+            has_kv_cache_manager=False,
+            use_paged_kv_cache=False,
+        )
+    )
+
+
+def test_flashinfer_capabilities_accept_supported_context():
+    assert StaticFlashInferTrtllmGenFmha.is_supported(_context())
+
+
+def test_flashinfer_capabilities_do_not_accept_context_head_size_without_kernel():
+    context = _context(head_size=96)
+    assert not StaticFlashInferTrtllmGenFmha.is_supported(context)
+
+
+def test_flashinfer_capabilities_do_not_accept_alibi():
+    context = _context(position_embedding_type=PositionEmbeddingType.alibi)
+    assert not StaticFlashInferTrtllmGenFmha.is_supported(context)
+
+
+def test_flashinfer_capabilities_do_not_accept_generation_beam_search():
+    context = _context(
+        attention_input_type=AttentionInputType.generation_only,
+        has_context_phase=False,
+        has_generation_phase=True,
+        beam_width=2,
+    )
+    assert not StaticFlashInferTrtllmGenFmha.is_supported(context)
+
+
+def test_flashinfer_capabilities_do_not_accept_mla_context_phase():
+    context = _context(
+        attention_input_type=AttentionInputType.mixed,
+        has_context_phase=True,
+        has_generation_phase=True,
+        is_mla_enable=True,
+        head_size=320,
+        kv_lora_rank=256,
+        qk_rope_head_dim=64,
+    )
+    assert not StaticFlashInferTrtllmGenFmha.is_supported(context)
+
+
+def test_flashinfer_capabilities_do_not_accept_tokens_per_block_without_kernel():
+    context = _context(
+        attention_input_type=AttentionInputType.generation_only,
+        has_context_phase=False,
+        has_generation_phase=True,
+        tokens_per_block=8,
+    )
+    assert not StaticFlashInferTrtllmGenFmha.is_supported(context)
+
+
+def test_flashinfer_capabilities_accept_declared_mla_generation_case():
+    context = _context(
+        attention_input_type=AttentionInputType.generation_only,
+        has_context_phase=False,
+        has_generation_phase=True,
+        is_mla_enable=True,
+        head_size=576,
+        kv_lora_rank=512,
+        qk_rope_head_dim=64,
+        tokens_per_block=64,
+    )
+    assert StaticFlashInferTrtllmGenFmha.is_supported(context)
+
+
+def test_flashinfer_capabilities_do_not_accept_undeclared_mla_generation_case():
+    context = _context(
+        attention_input_type=AttentionInputType.generation_only,
+        has_context_phase=False,
+        has_generation_phase=True,
+        is_mla_enable=True,
+        head_size=576,
+        kv_lora_rank=512,
+        qk_rope_head_dim=64,
+        tokens_per_block=32,
+    )
+    assert not StaticFlashInferTrtllmGenFmha.is_supported(context)
+
+
+def test_flashinfer_dynamic_checks_extend_base_support(monkeypatch):
+    monkeypatch.setenv("TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION", "0")
+    assert not FlashInferTrtllmGenFmha.is_supported(_context())

--- a/tests/unittest/_torch/attention_backend/test_fmha_capabilities.py
+++ b/tests/unittest/_torch/attention_backend/test_fmha_capabilities.py
@@ -20,6 +20,7 @@ from tensorrt_llm._torch.attention_backend.fmha import (
     FallbackFmha,
     FmhaFeature,
     FmhaSupportContext,
+    MlaRopeLayout,
 )
 from tensorrt_llm._torch.attention_backend.interface import AttentionInputType
 from tensorrt_llm._torch.attention_backend.trtllm import iter_enabled_fmha_libs
@@ -53,7 +54,12 @@ def _context(**overrides) -> FmhaSupportContext:
         use_paged_kv_cache=True,
         is_mla_enable=False,
         kv_lora_rank=None,
+        qk_nope_head_dim=None,
         qk_rope_head_dim=None,
+        v_head_dim=None,
+        mla_rope_layout=None,
+        is_fused_qkv=True,
+        update_kv_cache=True,
         has_context_phase=True,
         has_generation_phase=False,
         is_cross_attention=False,
@@ -71,15 +77,15 @@ def _context(**overrides) -> FmhaSupportContext:
 
 def test_default_fmha_order(monkeypatch):
     monkeypatch.delenv("TLLM_FMHA_LIBS", raising=False)
-    assert [fmha.capabilities.name for fmha in iter_enabled_fmha_libs()] == [
-        "flashinfer_trtllm_gen",
-        "fallback",
+    assert [fmha.__name__ for fmha in iter_enabled_fmha_libs()] == [
+        "FlashInferTrtllmGenFmha",
+        "FallbackFmha",
     ]
 
 
 def test_fmha_env_delta_disables_flashinfer_but_keeps_fallback(monkeypatch):
     monkeypatch.setenv("TLLM_FMHA_LIBS", "-flashinfer_trtllm_gen,-fallback")
-    assert [fmha.capabilities.name for fmha in iter_enabled_fmha_libs()] == ["fallback"]
+    assert [fmha.__name__ for fmha in iter_enabled_fmha_libs()] == ["FallbackFmha"]
 
 
 def test_fmha_env_delta_raises_unknown_name(monkeypatch):
@@ -90,17 +96,23 @@ def test_fmha_env_delta_raises_unknown_name(monkeypatch):
 
 def test_flashinfer_fmha_uses_declarative_capabilities():
     assert FlashInferTrtllmGenFmha.capabilities is FLASHINFER_TRTLLM_GEN_CAPABILITIES
-    assert FLASHINFER_TRTLLM_GEN_CAPABILITIES.context.head_sizes.values
-    assert FLASHINFER_TRTLLM_GEN_CAPABILITIES.mla.generation_cases
-    assert (576, 512, 32) not in {
-        (case.head_dim_qk, case.head_dim_v, case.tokens_per_block)
-        for case in FLASHINFER_TRTLLM_GEN_CAPABILITIES.mla.generation_cases
+    assert FLASHINFER_TRTLLM_GEN_CAPABILITIES.context.standard.head_size.values
+    assert FLASHINFER_TRTLLM_GEN_CAPABILITIES.generation.mla.generation_cases
+    assert (576, 512, "values=[16, 64]") in {
+        case.describe()
+        for case in FLASHINFER_TRTLLM_GEN_CAPABILITIES.generation.mla.generation_cases
     }
 
 
 def test_fallback_fmha_has_declarative_capabilities():
-    assert FallbackFmha.capabilities.runtime_features == frozenset(FmhaFeature)
-    assert FallbackFmha.capabilities.generation_head_ratios.min_value == 1
+    assert FmhaFeature.cross_attention not in FallbackFmha.capabilities.runtime_features.values
+    assert FallbackFmha.capabilities.context.standard.head_size.values == frozenset(
+        {32, 48, 64, 72, 80, 96, 104, 112, 128, 144, 160, 192, 224, 256}
+    )
+    assert PositionEmbeddingType.deferred not in (
+        FallbackFmha.capabilities.context.standard.position_embedding_type.values
+    )
+    assert FallbackFmha.capabilities.num_heads_per_kv_head.min_value == 1
     assert FallbackFmha.is_supported(
         _context(
             sm=90,
@@ -109,6 +121,83 @@ def test_fallback_fmha_has_declarative_capabilities():
             tokens_per_block=None,
             has_kv_cache_manager=False,
             use_paged_kv_cache=False,
+        )
+    )
+
+
+def test_fallback_capabilities_do_not_accept_standard_head_size_outside_thop_precheck():
+    assert not FallbackFmha.is_supported(_context(head_size=16))
+
+
+def test_fallback_capabilities_do_not_accept_deferred_position_embedding():
+    assert not FallbackFmha.is_supported(
+        _context(position_embedding_type=PositionEmbeddingType.deferred)
+    )
+
+
+def test_fallback_capabilities_do_not_accept_separate_qkv_without_sage_attention():
+    assert not FallbackFmha.is_supported(_context(is_fused_qkv=False))
+
+
+def test_fallback_capabilities_accept_separate_qkv_with_sage_attention():
+    assert FallbackFmha.is_supported(_context(is_fused_qkv=False, use_sage_attention=True))
+
+
+def test_fallback_capabilities_do_not_accept_undeclared_mla_context_dims():
+    assert not FallbackFmha.is_supported(
+        _context(
+            is_mla_enable=True,
+            kv_lora_rank=256,
+            qk_rope_head_dim=64,
+            qk_nope_head_dim=128,
+            v_head_dim=128,
+            mla_rope_layout=MlaRopeLayout.appended,
+        )
+    )
+
+
+def test_fallback_capabilities_accept_declared_mla_context_dims():
+    assert FallbackFmha.is_supported(
+        _context(
+            is_mla_enable=True,
+            is_fused_qkv=False,
+            head_size=576,
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+            qk_nope_head_dim=128,
+            v_head_dim=128,
+            mla_rope_layout=MlaRopeLayout.appended,
+        )
+    )
+
+
+def test_fallback_capabilities_do_not_accept_dense_mla_context_fused_qkv():
+    assert not FallbackFmha.is_supported(
+        _context(
+            is_mla_enable=True,
+            is_fused_qkv=True,
+            head_size=576,
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+            qk_nope_head_dim=128,
+            v_head_dim=128,
+            mla_rope_layout=MlaRopeLayout.appended,
+        )
+    )
+
+
+def test_fallback_capabilities_accept_sparse_mla_context_fused_qkv():
+    assert FallbackFmha.is_supported(
+        _context(
+            is_mla_enable=True,
+            is_fused_qkv=True,
+            has_sparse_attention=True,
+            head_size=576,
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+            qk_nope_head_dim=128,
+            v_head_dim=128,
+            mla_rope_layout=MlaRopeLayout.appended,
         )
     )
 
@@ -169,6 +258,8 @@ def test_flashinfer_capabilities_accept_declared_mla_generation_case():
         head_size=576,
         kv_lora_rank=512,
         qk_rope_head_dim=64,
+        qk_nope_head_dim=128,
+        v_head_dim=128,
         tokens_per_block=64,
     )
     assert StaticFlashInferTrtllmGenFmha.is_supported(context)
@@ -183,6 +274,8 @@ def test_flashinfer_capabilities_do_not_accept_undeclared_mla_generation_case():
         head_size=576,
         kv_lora_rank=512,
         qk_rope_head_dim=64,
+        qk_nope_head_dim=128,
+        v_head_dim=128,
         tokens_per_block=32,
     )
     assert not StaticFlashInferTrtllmGenFmha.is_supported(context)


### PR DESCRIPTION
@coderabbitai summary

## Description

Refactor TRTLLM FMHA backend selection so support checks are driven by declarative backend capabilities instead of per-library ad hoc `is_supported` logic.

This PR:
- Adds shared matcher primitives for scalar, enum-like, and feature-set capability fields.
- Keeps `FmhaSupportContext` as the request/context object while aligning overlapping field names with `FmhaCapabilities`.
- Splits phase-local standard and MLA capabilities, including conditional MLA context/generation cases.
- Moves `FallbackFmha` and FlashInfer TRTLLM-Gen support into explicit declarative capability declarations.
- Removes `FmhaCapabilities.name`; backend instances are cached by FMHA class while the `TLLM_FMHA_LIBS` registry keeps stable user-facing names.

## Test Coverage

- `python3 -m py_compile tensorrt_llm/_torch/attention_backend/fmha.py tensorrt_llm/_torch/attention_backend/trtllm_gen.py tensorrt_llm/_torch/attention_backend/trtllm.py tests/unittest/_torch/attention_backend/test_fmha_capabilities.py`
- `python3 -m ruff check tensorrt_llm/_torch/attention_backend/fmha.py tensorrt_llm/_torch/attention_backend/trtllm_gen.py tests/unittest/_torch/attention_backend/test_fmha_capabilities.py`
- `python3 -m ruff check --select F tensorrt_llm/_torch/attention_backend/trtllm.py`
- `git diff --check`

Attempted:
- `pytest tests/unittest/_torch/attention_backend/test_fmha_capabilities.py -q`

The focused pytest is blocked before collection in the local environment because `tensorrt_llm.bindings.internal.batch_manager.PoolConfiguration` is missing while importing `tests/unittest/conftest.py`.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.