### PR TITLE
[https://nvbugs/6248837][fix] Free worker GPU memory on executor shutdown

### DIFF
--- a/tensorrt_llm/executor/worker.py
+++ b/tensorrt_llm/executor/worker.py
@@ -132,6 +132,20 @@ class GenerationExecutorWorker(RpcWorkerMixin, BaseWorker):
         if torch.distributed.is_initialized():
             torch.distributed.destroy_process_group()
 
+        # Return this rank's GPU memory to the driver. Under an external MPI
+        # launch (mpirun/srun, e.g. CI), the worker process is long-lived and
+        # shared across successive LLM instances: a new GenerationExecutorWorker
+        # is built for each LLM, but the OS process -- and with it the CUDA
+        # context and PyTorch caching allocator -- persists. Setting
+        # `self.engine = None` above is not enough to free the GPU: reference
+        # cycles keep the model tensors alive until a later GC, and the allocator
+        # holds freed blocks as "reserved" instead of returning them. Without
+        # this, the previous model's ~weights-sized reservation carries into the
+        # next LLM built in this process and can OOM its load (e.g. back-to-back
+        # tests in one CI shard).
+        gc.collect()
+        torch.cuda.empty_cache()
+
         # Check if there are any errors from the threads before shutdown.
         self._handle_background_error()
 

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -65,7 +65,6 @@ accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_w4_4gpus[v2_kv_cache-ep4-cutl
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_w4_4gpus[v2_kv_cache-tp4-cutlass-auto] SKIP (https://nvbugs/5596343)
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_w4_chunked_prefill[cutlass-auto] SKIP (https://nvbugs/5596343)
 accuracy/test_llm_api_pytorch.py::TestKanana_Instruct::test_auto_dtype SKIP (https://nvbugs/6209806)
-accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[dep8] SKIP (https://nvbugs/6260890)
 accuracy/test_llm_api_pytorch.py::TestKimiK2::test_nvfp4[4gpus] SKIP (https://nvbugs/6368562)
 accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_bfloat16[attn_backend=FLASHINFER-torch_compile=True] SKIP (https://nvbugs/6305318)
 accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_bfloat16[attn_backend=TRTLLM-torch_compile=True] SKIP (https://nvbugs/6305318)

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -66,7 +66,6 @@ accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_w4_4gpus[v2_kv_cache-tp4-cutl
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_w4_chunked_prefill[cutlass-auto] SKIP (https://nvbugs/5596343)
 accuracy/test_llm_api_pytorch.py::TestKanana_Instruct::test_auto_dtype SKIP (https://nvbugs/6209806)
 accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[dep8] SKIP (https://nvbugs/6260890)
-accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[tp8] SKIP (https://nvbugs/6248837)
 accuracy/test_llm_api_pytorch.py::TestKimiK2::test_nvfp4[4gpus] SKIP (https://nvbugs/6368562)
 accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_bfloat16[attn_backend=FLASHINFER-torch_compile=True] SKIP (https://nvbugs/6305318)
 accuracy/test_llm_api_pytorch.py::TestLlama3_1_8BInstruct::test_bfloat16[attn_backend=TRTLLM-torch_compile=True] SKIP (https://nvbugs/6305318)

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -11,8 +11,6 @@ accuracy/test_llm_api_autodeploy.py::TestNemotronNanoV3::test_accuracy[bf16-4-at
 accuracy/test_llm_api_autodeploy.py::TestNemotronNanoV3::test_accuracy[fp8-4-attn_dp_off-trtllm] SKIP (https://nvbugs/6367792)
 accuracy/test_llm_api_autodeploy.py::TestNemotronNanoV3::test_accuracy[nvfp4-4-attn_dp_off-trtllm] SKIP (https://nvbugs/6367792)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput] SKIP (https://nvbugs/6379333)
-accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput_mtp] SKIP (https://nvbugs/6281818)
-accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput_mtp_trtllm] SKIP (https://nvbugs/6281818)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput] SKIP (https://nvbugs/6379333)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_mtp] SKIP (https://nvbugs/6379333)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_dsa_host_cache_offload[host_cache_offload] SKIP (https://nvbugs/6384136)


### PR DESCRIPTION
## Description

`accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[tp8]` intermittently OOMed at executor init (`model.to("cuda")`) on the `GB200-8_GPUs-2_Nodes` stage, yet passed when run alone. Root cause: **GPU memory was not released between tests that share a CI shard.**

A shard runs as one long-lived MPI job (8 ranks / 2 nodes) whose worker processes persist across all tests in the shard. `GenerationExecutorWorker.shutdown()` dropped the engine reference but never returned its GPU memory to the driver — reference cycles keep the model tensors alive until a later GC, and PyTorch's caching allocator holds the freed blocks as "reserved". So a large predecessor (DeepSeek-R1, ~110 GiB/GPU) left its weights resident in the workers, and the next large model (e.g. Kimi-K2.5, ~76 GiB/GPU) then OOMed on all 8 ranks with only ~73 GiB free. This also explains the flakiness: it only failed when a heavy test ran immediately before in the same shard.

### Fix
Force `gc.collect()` + `torch.cuda.empty_cache()` in `GenerationExecutorWorker.shutdown()` (after the engine and torch.distributed process group are torn down), so each worker returns the previous model's memory to the driver before the next LLM is built.

### Local vs CI debugging summary
A pre-`LLM()` `nvidia-smi` probe (diagnostic only, not in this PR) measured the device state at test start:

| | Local (run alone) | CI (after DeepSeek-R1, same shard) |
|---|---|---|
| GPU used before next model loads | ~3 MiB | ~114 GiB (held by a leftover worker `python3` process) |
| Free before next model loads | ~184 GiB | ~73 GiB |
| Result | PASS (50/50) | OOM on all 8 ranks |

After the fix, the worker-shutdown step returns that memory at the test→test handoff (`free 72.76 → 169.69 GiB`) and the previously-failing tests pass.

### Same-root-cause OOM tests
The same worker-shutdown OOM affected several GB200 2-node tests. Status in this PR:

| Test | nvbug | Action |
|---|---|---|
| `TestKimiK25::test_nvfp4[tp8]` | [6248837](https://nvbugspro.nvidia.com/bug/6248837) | **Unwaived** |
| `TestKimiK25::test_nvfp4[dep8]` | [6260890](https://nvbugspro.nvidia.com/bug/6260890) | **Unwaived** |
| `TestKimiK25::test_nvfp4[tp8_attn_dp]` | [6144270](https://nvbugspro.nvidia.com/bug/6144270) | **Unwaived** |
| `TestDeepSeekR1::test_fp8_blockscale[throughput_mtp]` | [6281818](https://nvbugspro.nvidia.com/bug/6281818) / [6293890](https://nvbugspro.nvidia.com/bug/6293890) | **Unwaived** |
| `TestDeepSeekR1::test_fp8_blockscale[throughput_mtp_trtllm]` | [6281818](https://nvbugspro.nvidia.com/bug/6281818) | **Unwaived** |
| `TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_mtp]` | [6261994](https://nvbugspro.nvidia.com/bug/6261994) / [6029882](https://nvbugspro.nvidia.com/bug/6029882) | Already unwaived on main by #14852 (6029882) — not touched here |

## Test Coverage

`TestKimiK25::test_nvfp4[tp8|dep8|tp8_attn_dp]` and `TestDeepSeekR1::test_fp8_blockscale[throughput_mtp|throughput_mtp_trtllm]` on the `GB200-8_GPUs-2_Nodes-PyTorch-*` stages.
