### PR TITLE
[https://nvbugs/6260890][test] Unwaive TestKimiK25::test_nvfp4[dep8]

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -74,7 +74,6 @@ accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_w4_4gpus[v2_kv_cache-ep4-cutl
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_w4_4gpus[v2_kv_cache-tp4-cutlass-auto] SKIP (https://nvbugs/5596343)
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_w4_chunked_prefill[cutlass-auto] SKIP (https://nvbugs/5596343)
 accuracy/test_llm_api_pytorch.py::TestKanana_Instruct::test_auto_dtype SKIP (https://nvbugs/6209806)
-accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[dep8] SKIP (https://nvbugs/6260890)
 accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[tp8] SKIP (https://nvbugs/6248837)
 accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[tp8_attn_dp] SKIP (https://nvbugs/6144270)
 accuracy/test_llm_api_pytorch.py::TestKimiK2::test_nvfp4[4gpus] SKIP (https://nvbugs/6261793)


### PR DESCRIPTION
## Description

Removes the waiver for `accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[dep8]` (NVBugs 6260890).

The waiver was added for an intermittent CUDA OOM at executor init (`model.to('cuda')`) on the GB200-8_GPUs-2_Nodes stage. Investigation shows this is an environment-driven failure: the model weights nearly fill the GB200 and a foreign process occupying GPU 0 in CI tips it over, rather than a model-memory regression. Local reproduction on a 2-node × 4× GB200 setup (50 runs) did not reproduce the OOM, and repair-bot could not reproduce on B200 either.

Unwaiving to let CI confirm; closing 6260890 on a clean run.

## Test Coverage

`accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[dep8]`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed a test waiver, enabling a previously skipped test case to run and be validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->