### PR TITLE
[https://nvbugs/6029882][test] Unwaive TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_mtp]

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -19,7 +19,6 @@ accuracy/test_llm_api_autodeploy.py::TestNemotronV2::test_fp8[True] SKIP (https:
 accuracy/test_llm_api_autodeploy.py::TestQwen3_5_397B_MoE::test_bf16_small[4] SKIP (https://nvbugs/6158397)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_fp8_blockscale[throughput_mtp_trtllm] SKIP (https://nvbugs/6191524)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput] SKIP (https://nvbugs/6084775)
-accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_mtp] SKIP (https://nvbugs/6029882)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_pp4_mtp] SKIP (https://nvbugs/6018046)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_tp4] SKIP (https://nvbugs/6215793)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1LongBenchV2::test_fp8_8gpus SKIP (https://nvbugs/6193778)


### PR DESCRIPTION
## Description

Removes the waiver for `accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_mtp]` (NVBugs 6029882, also tracked by 6261994).

The waiver was added for an intermittent CUDA OOM at executor init (`model.to('cuda')`) on the GB200-8_GPUs-2_Nodes stage. Investigation shows this is an environment-driven failure: the model weights nearly fill the GB200 and a foreign process occupying GPU 0 in CI tips it over, rather than a model-memory regression. Local reproduction on a 2-node × 4× GB200 setup (50 runs) did not reproduce the OOM, and repair-bot could not reproduce on B200 either. This matches the same fingerprint seen in the Kimi-K2.5 init-OOM bugs (6248837 / 6260890).

Unwaiving to let CI confirm; closing 6029882 and 6261994 on a clean run.

## Test Coverage

`accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus[throughput_mtp]`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Removed a test waiver entry to re-enable testing of a previously skipped scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->