### PR TITLE
[TRTLLM-13265][feat] Fuse LTX-2 Gate + Residual + Norm + AdaLN modulation(ShiftScale) + Quant kernels

### DIFF
--- a/cpp/tensorrt_llm/kernels/fusedDiTGateResidNormShiftScaleKernel.cu
+++ b/cpp/tensorrt_llm/kernels/fusedDiTGateResidNormShiftScaleKernel.cu
@@ -1,0 +1,1116 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "fusedDiTGateResidNormShiftScaleKernel.h"
+#include "tensorrt_llm/common/cudaUtils.h"
+#include "tensorrt_llm/common/reduceKernelUtils.cuh"
+#include "tensorrt_llm/kernels/quantization.cuh"
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_pipeline.h>
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels
+{
+
+namespace
+{
+
+__device__ __forceinline__ uint32_t cvta_to_smem(void const* ptr)
+{
+    return static_cast<uint32_t>(__cvta_generic_to_shared(const_cast<void*>(ptr)));
+}
+
+__device__ __forceinline__ void mbar_init(uint64_t* bar, uint32_t count)
+{
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900)
+    asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;" : : "r"(cvta_to_smem(bar)), "r"(count));
+#endif
+}
+
+__device__ __forceinline__ void mbar_arrive(uint64_t* bar)
+{
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900)
+    asm volatile("mbarrier.arrive.shared::cta.b64 _, [%0];" : : "r"(cvta_to_smem(bar)));
+#endif
+}
+
+__device__ __forceinline__ void mbar_arrive_expect_tx(uint64_t* bar, uint32_t tx_bytes)
+{
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900)
+    asm volatile("mbarrier.arrive.expect_tx.shared::cta.b64 _, [%0], %1;" : : "r"(cvta_to_smem(bar)), "r"(tx_bytes));
+#endif
+}
+
+__device__ __forceinline__ void mbar_wait(uint64_t* bar, uint32_t phase)
+{
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900)
+    asm volatile(
+        "{ .reg .pred P;                                                   \n"
+        "  WAIT: mbarrier.try_wait.parity.shared::cta.b64 P, [%0], %1;     \n"
+        "  @P bra DONE;                                                    \n"
+        "  bra WAIT;                                                       \n"
+        "  DONE: }"
+        :
+        : "r"(cvta_to_smem(bar)), "r"(phase));
+#endif
+}
+
+__device__ __forceinline__ void cp_async_bulk(void* smem_dst, void const* global_src, uint32_t bytes, uint64_t* bar)
+{
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900)
+    asm volatile(
+        "cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes [%0], [%1], %2, [%3];"
+        :
+        : "r"(cvta_to_smem(smem_dst)), "l"(reinterpret_cast<uint64_t>(global_src)), "r"(bytes), "r"(cvta_to_smem(bar))
+        : "memory");
+#endif
+}
+
+// Sync only the consumer warpgroup on named barrier 1; producer warp must not participate.
+__device__ __forceinline__ void bar_sync_consumer(int count)
+{
+    asm volatile("bar.sync 1, %0;" : : "r"(count));
+}
+
+// combine_modulator_chunk: combine 8 bf16 ts + 8 fp32 table into 8 bf16 (one uint4).
+// Matches PyTorch eager `_get_ada_values` semantics: narrow fp32 table to
+// bf16 FIRST, then bf16 hw add. Used for gate / scale / shift modulators alike.
+__device__ __forceinline__ uint4 combine_modulator_chunk(uint4 const& ts_v, float4 const& tbl_lo, float4 const& tbl_hi)
+{
+    __nv_bfloat162 const* ts_b2 = reinterpret_cast<__nv_bfloat162 const*>(&ts_v);
+    __nv_bfloat162 out_b2[4];
+    out_b2[0] = __hadd2(__float22bfloat162_rn(make_float2(tbl_lo.x, tbl_lo.y)), ts_b2[0]);
+    out_b2[1] = __hadd2(__float22bfloat162_rn(make_float2(tbl_lo.z, tbl_lo.w)), ts_b2[1]);
+    out_b2[2] = __hadd2(__float22bfloat162_rn(make_float2(tbl_hi.x, tbl_hi.y)), ts_b2[2]);
+    out_b2[3] = __hadd2(__float22bfloat162_rn(make_float2(tbl_hi.z, tbl_hi.w)), ts_b2[3]);
+    uint4 out_v;
+    *reinterpret_cast<__nv_bfloat162*>(reinterpret_cast<uint*>(&out_v) + 0) = out_b2[0];
+    *reinterpret_cast<__nv_bfloat162*>(reinterpret_cast<uint*>(&out_v) + 1) = out_b2[1];
+    *reinterpret_cast<__nv_bfloat162*>(reinterpret_cast<uint*>(&out_v) + 2) = out_b2[2];
+    *reinterpret_cast<__nv_bfloat162*>(reinterpret_cast<uint*>(&out_v) + 3) = out_b2[3];
+    return out_v;
+}
+
+} // anonymous namespace
+
+template <int D, int ROWS_PER_BLOCK, int BLOCK_SIZE, bool HAS_RESIDUAL, bool HAS_GATE, bool HAS_NORM,
+    bool HAS_SHIFT_SCALE, int NUM_OUT, bool HAS_QUANT>
+__global__ void fusedDiTGateResidNormShiftScaleKernel(AdaLNNormParams p)
+{
+    static_assert(NUM_OUT == 1 || NUM_OUT == 2, "NUM_OUT must be 1 or 2");
+    static_assert(!HAS_GATE || HAS_RESIDUAL, "HAS_GATE requires HAS_RESIDUAL");
+    static_assert(HAS_NORM || HAS_RESIDUAL, "HAS_NORM=false requires HAS_RESIDUAL (the only output is x_new)");
+    static_assert(HAS_NORM || !HAS_SHIFT_SCALE, "HAS_NORM=false implies HAS_SHIFT_SCALE=false");
+    static_assert(HAS_NORM || !HAS_QUANT, "HAS_NORM=false implies HAS_QUANT=false");
+
+    constexpr int THREADS_PER_ROW = BLOCK_SIZE / ROWS_PER_BLOCK;
+    constexpr int WARPS_PER_ROW = THREADS_PER_ROW / 32;
+    constexpr int CHUNK_ELEMS = 8; // uint4 = 8 bf16
+    constexpr int CHUNKS_PER_ROW = (D + THREADS_PER_ROW * CHUNK_ELEMS - 1) / (THREADS_PER_ROW * CHUNK_ELEMS);
+    constexpr int SF_VEC_SIZE = 16;
+    constexpr int SF_PER_ROW = D / SF_VEC_SIZE;
+
+    static_assert(D % CHUNK_ELEMS == 0, "D must be multiple of 8");
+    static_assert(D % SF_VEC_SIZE == 0, "D must be multiple of 16 (NVFP4 group size)");
+
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900)
+    asm volatile("griddepcontrol.wait;");
+#endif
+
+    int const tid = threadIdx.x;
+    int const row_in_block = tid / THREADS_PER_ROW;
+    int const lane_in_row = tid % THREADS_PER_ROW;
+    int const row_warp = lane_in_row >> 5;
+    int const row_lane = lane_in_row & 31;
+
+    int const tokenIdx = blockIdx.x * ROWS_PER_BLOCK + row_in_block;
+    bool const valid = (tokenIdx < p.num_tokens);
+    int const safeTokenIdx = valid ? tokenIdx : 0;
+
+    int const batchIdx = safeTokenIdx / p.tokens_per_batch;
+    int64_t const tokenBase = static_cast<int64_t>(safeTokenIdx) * D;
+
+    // Hybrid TMA / cp.async gating, picked empirically from paired bench on B200:
+    //   USE_TMA       : single-instruction cp.async.bulk for the X load. Wins on D=4096
+    //                   except when (HAS_QUANT && HAS_SHIFT_SCALE && NUM_OUT==1) where the
+    //                   kernel is HBM-light and the mbarrier setup cost exceeds the LSU
+    //                   saving. Disabled on D=2048 (audio path, 2-4us kernels).
+    //   USE_TMA_ATTN  : also TMA-bulk the residual `attn` tensor into smem. Only enabled
+    //                   on (USE_TMA && HAS_RESIDUAL && HAS_QUANT) -- bf16 paths regress
+    //                   because the per-thread LDG for attn was already overlapping
+    //                   the TMA-X load via different LSU pipes, while quant's heavy
+    //                   Phase 2 hides the extra mbarrier wait.
+    constexpr bool USE_TMA = (D >= 4096) && !(HAS_QUANT && HAS_SHIFT_SCALE && NUM_OUT == 1);
+    constexpr bool USE_TMA_ATTN = USE_TMA && HAS_RESIDUAL && HAS_QUANT;
+    constexpr int kAttnSmemBytes = USE_TMA_ATTN ? (ROWS_PER_BLOCK * D * static_cast<int>(sizeof(__nv_bfloat16))) : 0;
+
+    extern __shared__ __align__(16) unsigned char smem_raw[];
+    __nv_bfloat16* smem_x = reinterpret_cast<__nv_bfloat16*>(smem_raw);
+    __nv_bfloat16* smem_attn = reinterpret_cast<__nv_bfloat16*>(smem_raw + ROWS_PER_BLOCK * D * sizeof(__nv_bfloat16));
+    float* warp_sums = reinterpret_cast<float*>(smem_raw + ROWS_PER_BLOCK * D * sizeof(__nv_bfloat16) + kAttnSmemBytes);
+
+    // mbarrier in static SMEM (8B), only used when USE_TMA. Compiler elides when unused.
+    __shared__ alignas(8) uint64_t mbar;
+
+    // Phase 0a: load X -> SMEM. Either TMA bulk (1 instruction, mbarrier-synced) or
+    // cp.async (32 per-thread issues, __pipeline_commit/wait_prior synced).
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900)
+    if constexpr (USE_TMA)
+    {
+        constexpr uint32_t kXBytes = ROWS_PER_BLOCK * D * static_cast<uint32_t>(sizeof(__nv_bfloat16));
+        constexpr uint32_t kAttnBytes = USE_TMA_ATTN ? kXBytes : 0;
+        constexpr uint32_t kTotalBytes = kXBytes + kAttnBytes;
+        static_assert(kXBytes % 16 == 0, "cp.async.bulk requires nbBytes multiple of 16");
+        if (tid == 0)
+        {
+            asm volatile(
+                "mbarrier.init.shared.b64 [%0], 1;\n" ::"r"(static_cast<uint32_t>(__cvta_generic_to_shared(&mbar)))
+                : "memory");
+            asm volatile("mbarrier.arrive.expect_tx.shared.b64 _, [%0], %1;\n" ::"r"(
+                             static_cast<uint32_t>(__cvta_generic_to_shared(&mbar))),
+                         "r"(kTotalBytes)
+                         : "memory");
+            // Bulk load X.
+            asm volatile("cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes [%0], [%1], %2, [%3];\n" ::"l"(
+                             __cvta_generic_to_shared(smem_x + row_in_block * D)),
+                         "l"(reinterpret_cast<uint64_t>(p.x + tokenBase)), "r"(kXBytes),
+                         "l"(__cvta_generic_to_shared(&mbar))
+                         : "memory");
+            // Bulk load attn (only when USE_TMA_ATTN), into smem_attn slot.
+            if constexpr (USE_TMA_ATTN)
+            {
+                asm volatile(
+                    "cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes [%0], [%1], %2, [%3];\n" ::"l"(
+                        __cvta_generic_to_shared(smem_attn + row_in_block * D)),
+                    "l"(reinterpret_cast<uint64_t>(p.attn + tokenBase)), "r"(kAttnBytes),
+                    "l"(__cvta_generic_to_shared(&mbar))
+                    : "memory");
+            }
+        }
+        __syncthreads();
+    }
+    else
+#endif
+    {
+#pragma unroll
+        for (int chunk = 0; chunk < CHUNKS_PER_ROW; chunk++)
+        {
+            int const elemBase = chunk * THREADS_PER_ROW * CHUNK_ELEMS + lane_in_row * CHUNK_ELEMS;
+            if (elemBase >= D)
+                continue;
+            __pipeline_memcpy_async(smem_x + row_in_block * D + elemBase, p.x + tokenBase + elemBase, 16);
+        }
+        __pipeline_commit();
+    }
+
+    // Phase 0b: load gate / scale / shift modulators into register caches.
+    // Per-thread storage scaled by HAS_GATE / HAS_SHIFT_SCALE flags; compiler elides
+    // unused slots when the corresponding flag is false.
+    uint4 gate_cache[HAS_GATE ? CHUNKS_PER_ROW : 1];
+    uint4 scale_cache[HAS_SHIFT_SCALE ? NUM_OUT * CHUNKS_PER_ROW : 1];
+    uint4 shift_cache[HAS_SHIFT_SCALE ? NUM_OUT * CHUNKS_PER_ROW : 1];
+
+    if constexpr (HAS_GATE || HAS_SHIFT_SCALE)
+    {
+        int64_t const gateBase = HAS_GATE ? static_cast<int64_t>(batchIdx) * p.gate_ts_stride : 0;
+        int64_t scaleBase[NUM_OUT];
+        int64_t shiftBase[NUM_OUT];
+        if constexpr (HAS_SHIFT_SCALE)
+        {
+#pragma unroll
+            for (int k = 0; k < NUM_OUT; k++)
+            {
+                scaleBase[k] = static_cast<int64_t>(batchIdx) * p.scale_ts_stride[k];
+                shiftBase[k] = static_cast<int64_t>(batchIdx) * p.shift_ts_stride[k];
+            }
+        }
+#pragma unroll
+        for (int chunk = 0; chunk < CHUNKS_PER_ROW; chunk++)
+        {
+            int const elemBase = chunk * THREADS_PER_ROW * CHUNK_ELEMS + lane_in_row * CHUNK_ELEMS;
+            if (elemBase >= D)
+                continue;
+            if constexpr (HAS_GATE)
+            {
+                uint4 const ts_v = *reinterpret_cast<uint4 const*>(&p.gate_ts[gateBase + elemBase]);
+                float4 const tbl_lo = *reinterpret_cast<float4 const*>(&p.gate_table[elemBase + 0]);
+                float4 const tbl_hi = *reinterpret_cast<float4 const*>(&p.gate_table[elemBase + 4]);
+                gate_cache[chunk] = combine_modulator_chunk(ts_v, tbl_lo, tbl_hi);
+            }
+            if constexpr (HAS_SHIFT_SCALE)
+            {
+#pragma unroll
+                for (int k = 0; k < NUM_OUT; k++)
+                {
+                    uint4 const s_ts_v = *reinterpret_cast<uint4 const*>(&p.scale_ts[k][scaleBase[k] + elemBase]);
+                    float4 const s_tbl_lo = *reinterpret_cast<float4 const*>(&p.scale_table[k][elemBase + 0]);
+                    float4 const s_tbl_hi = *reinterpret_cast<float4 const*>(&p.scale_table[k][elemBase + 4]);
+                    scale_cache[k * CHUNKS_PER_ROW + chunk] = combine_modulator_chunk(s_ts_v, s_tbl_lo, s_tbl_hi);
+
+                    uint4 const h_ts_v = *reinterpret_cast<uint4 const*>(&p.shift_ts[k][shiftBase[k] + elemBase]);
+                    float4 const h_tbl_lo = *reinterpret_cast<float4 const*>(&p.shift_table[k][elemBase + 0]);
+                    float4 const h_tbl_hi = *reinterpret_cast<float4 const*>(&p.shift_table[k][elemBase + 4]);
+                    shift_cache[k * CHUNKS_PER_ROW + chunk] = combine_modulator_chunk(h_ts_v, h_tbl_lo, h_tbl_hi);
+                }
+            }
+        }
+    }
+
+    // Phase 0c: load attn into regs (HAS_RESIDUAL only). Either from smem (USE_TMA_ATTN —
+    // attn was bulk-loaded into smem_attn in Phase 0a) or directly from GMEM (cp.async path).
+    // The smem read happens AFTER the mbarrier wait, so smem_attn is guaranteed populated.
+    uint4 attn_reg[HAS_RESIDUAL ? CHUNKS_PER_ROW : 1];
+    if constexpr (HAS_RESIDUAL && !USE_TMA_ATTN)
+    {
+#pragma unroll
+        for (int chunk = 0; chunk < CHUNKS_PER_ROW; chunk++)
+        {
+            int const elemBase = chunk * THREADS_PER_ROW * CHUNK_ELEMS + lane_in_row * CHUNK_ELEMS;
+            if (elemBase >= D)
+                continue;
+            attn_reg[chunk] = *reinterpret_cast<uint4 const*>(&p.attn[tokenBase + elemBase]);
+        }
+    }
+
+    // Wait on Phase 0a load completion (TMA mbarrier OR cp.async pipeline, gated by USE_TMA).
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900)
+    if constexpr (USE_TMA)
+    {
+        uint32_t const mbar_smem = static_cast<uint32_t>(__cvta_generic_to_shared(&mbar));
+        asm volatile(
+            "{\n"
+            ".reg .pred P1;\n"
+            "WAIT_LOOP:\n"
+            "mbarrier.try_wait.parity.shared.b64 P1, [%0], 0;\n"
+            "@P1 bra DONE;\n"
+            "bra     WAIT_LOOP;\n"
+            "DONE:\n"
+            "}\n" ::"r"(mbar_smem)
+            : "memory");
+        __syncthreads();
+    }
+    else
+#endif
+    {
+        __pipeline_wait_prior(0);
+        __syncthreads();
+    }
+
+    // Phase 1: compute x_new and sum^2.
+    //   HAS_RESIDUAL=false:        x_new = x
+    //   HAS_RESIDUAL, !HAS_GATE:   x_new = x + attn
+    //   HAS_RESIDUAL,  HAS_GATE:   x_new = x + attn * gate
+    // x_new is cached in regs (xnew_cache) for Phase 2 to avoid a re-read; if
+    // HAS_RESIDUAL also write x_new to the separate x_out buffer so the downstream
+    // residual chain sees it (x stays read-only -- the op is functional).
+    uint4 xnew_cache[CHUNKS_PER_ROW];
+    float sum2 = 0.0f;
+#pragma unroll
+    for (int chunk = 0; chunk < CHUNKS_PER_ROW; chunk++)
+    {
+        int const elemBase = chunk * THREADS_PER_ROW * CHUNK_ELEMS + lane_in_row * CHUNK_ELEMS;
+        if (elemBase >= D)
+            continue;
+        uint4 const xv = *reinterpret_cast<uint4 const*>(&smem_x[row_in_block * D + elemBase]);
+        // USE_TMA_ATTN path: attn was TMA-bulk-loaded into smem_attn in Phase 0a;
+        // populate attn_reg from smem here (post-mbarrier-wait, data is valid).
+        if constexpr (USE_TMA_ATTN)
+        {
+            attn_reg[chunk] = *reinterpret_cast<uint4 const*>(&smem_attn[row_in_block * D + elemBase]);
+        }
+        uint const* xu = reinterpret_cast<uint const*>(&xv);
+        uint4 new_vec;
+        uint* nu = reinterpret_cast<uint*>(&new_vec);
+
+#pragma unroll
+        for (int i = 0; i < 4; i++)
+        {
+            float2 xf = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162 const*>(&xu[i]));
+            float2 nf;
+            if constexpr (HAS_RESIDUAL)
+            {
+                uint4 const av = attn_reg[chunk];
+                uint const* au = reinterpret_cast<uint const*>(&av);
+                float2 af = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162 const*>(&au[i]));
+                if constexpr (HAS_GATE)
+                {
+                    uint4 const gv = gate_cache[chunk];
+                    uint const* gu = reinterpret_cast<uint const*>(&gv);
+                    float2 gf = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162 const*>(&gu[i]));
+                    nf.x = xf.x + af.x * gf.x;
+                    nf.y = xf.y + af.y * gf.y;
+                }
+                else
+                {
+                    nf.x = xf.x + af.x;
+                    nf.y = xf.y + af.y;
+                }
+            }
+            else
+            {
+                nf = xf;
+            }
+            sum2 += nf.x * nf.x + nf.y * nf.y;
+            __nv_bfloat162 bf = __float22bfloat162_rn(nf);
+            reinterpret_cast<__nv_bfloat162&>(nu[i]) = bf;
+        }
+        xnew_cache[chunk] = new_vec;
+        if constexpr (HAS_RESIDUAL)
+        {
+            if (valid)
+                *reinterpret_cast<uint4*>(&p.x_out[tokenBase + elemBase]) = new_vec;
+        }
+    }
+
+    // HAS_NORM=false variant: x_new was written to p.x_out above (HAS_RESIDUAL is required when
+    // !HAS_NORM). Skip the rms reduce + Phase 2 shift_scale/store; the gate-residual fused result
+    // lives entirely in the x_out residual-stream buffer.
+    if constexpr (!HAS_NORM)
+    {
+        return;
+    }
+
+    // Per-row warp reduce + cross-warp reduce within the row.
+    sum2 = tensorrt_llm::common::warpReduceSum(sum2);
+    if (row_lane == 0)
+        warp_sums[row_in_block * WARPS_PER_ROW + row_warp] = sum2;
+    __syncthreads();
+    float total = 0.0f;
+#pragma unroll
+    for (int w = 0; w < WARPS_PER_ROW; w++)
+        total += warp_sums[row_in_block * WARPS_PER_ROW + w];
+    float const rms_rcp = rsqrtf(total / static_cast<float>(D) + p.eps);
+
+    // Pre-read sf_scale broadcast scalars (HAS_QUANT only).
+    float sf_scale_val[NUM_OUT];
+    if constexpr (HAS_QUANT)
+    {
+#pragma unroll
+        for (int k = 0; k < NUM_OUT; k++)
+            sf_scale_val[k] = (p.sf_scale[k] != nullptr) ? *p.sf_scale[k] : 1.0f;
+    }
+
+    // Phase 2: optional shift_scale + write outputs (NUM_OUT entries).
+#pragma unroll
+    for (int chunk = 0; chunk < CHUNKS_PER_ROW; chunk++)
+    {
+        int const elemBase = chunk * THREADS_PER_ROW * CHUNK_ELEMS + lane_in_row * CHUNK_ELEMS;
+        if (elemBase >= D)
+            continue;
+
+        uint4 const in_vec = xnew_cache[chunk];
+        uint const* x_uints = reinterpret_cast<uint const*>(&in_vec);
+
+        if constexpr (HAS_QUANT)
+        {
+            // FP4 quant path: fp32 shift_scale + max-abs scan + e2m1 pack. Inlining the
+            // max scan with shift_scale shares the pair-lane reduction with the FP4
+            // conversion (saves ~10us/call vs cvt_float_to_fp4_inline + separate scan).
+            float vals[NUM_OUT][8];
+            float localMax[NUM_OUT];
+#pragma unroll
+            for (int k = 0; k < NUM_OUT; k++)
+                localMax[k] = 0.0f;
+
+#pragma unroll
+            for (int i = 0; i < 4; i++)
+            {
+                float2 xv = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162 const*>(&x_uints[i]));
+                float const nx = xv.x * rms_rcp;
+                float const ny = xv.y * rms_rcp;
+#pragma unroll
+                for (int k = 0; k < NUM_OUT; k++)
+                {
+                    float yx;
+                    float yy;
+                    if constexpr (HAS_SHIFT_SCALE)
+                    {
+                        uint4 const sv = scale_cache[k * CHUNKS_PER_ROW + chunk];
+                        uint4 const hv = shift_cache[k * CHUNKS_PER_ROW + chunk];
+                        uint const* s_uints = reinterpret_cast<uint const*>(&sv);
+                        uint const* h_uints = reinterpret_cast<uint const*>(&hv);
+                        float2 sf = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162 const*>(&s_uints[i]));
+                        float2 hf = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162 const*>(&h_uints[i]));
+                        yx = nx * (1.0f + sf.x) + hf.x;
+                        yy = ny * (1.0f + sf.y) + hf.y;
+                    }
+                    else
+                    {
+                        yx = nx;
+                        yy = ny;
+                    }
+                    vals[k][2 * i + 0] = yx;
+                    vals[k][2 * i + 1] = yy;
+                    localMax[k] = fmaxf(localMax[k], fmaxf(fabsf(yx), fabsf(yy)));
+                }
+            }
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+            uint32_t fp4_packed[NUM_OUT];
+            uint8_t sfBytes[NUM_OUT];
+#pragma unroll
+            for (int k = 0; k < NUM_OUT; k++)
+            {
+                // Pair-lane max-abs across 16 elements (one SF block).
+                float const blockMax = fmaxf(__shfl_xor_sync(0xffffffff, localMax[k], 1), localMax[k]);
+                constexpr float kE2M1MaxRcp = 1.0f / 6.0f;
+                float const sfValue = sf_scale_val[k] * (blockMax * kE2M1MaxRcp);
+                __nv_fp8_e4m3 const sfFp8 = __nv_fp8_e4m3(sfValue);
+                sfBytes[k] = sfFp8.__x;
+                float const sfQuant = static_cast<float>(sfFp8);
+                float const outScale = (blockMax != 0.0f) ? (sf_scale_val[k] / sfQuant) : 0.0f;
+#pragma unroll
+                for (int i = 0; i < 8; i++)
+                    vals[k][i] *= outScale;
+                fp4_packed[k] = fp32_vec_to_e2m1(vals[k]);
+            }
+
+            int const colVecIdx = (chunk * THREADS_PER_ROW) + lane_in_row;
+            uint8_t* first_sf_ptr = cvt_quant_get_sf_out_offset<uint32_t, /*CVT_NUM_THREADS_PER_SF=*/2>(std::nullopt,
+                safeTokenIdx, colVecIdx, std::optional<int>(p.num_tokens), SF_PER_ROW, p.out_sf[0],
+                QuantizationSFLayout::SWIZZLED);
+            if (valid && first_sf_ptr != nullptr)
+            {
+                *first_sf_ptr = sfBytes[0];
+                if constexpr (NUM_OUT == 2)
+                {
+                    uint8_t* second_sf_ptr = cvt_quant_get_sf_out_offset<uint32_t, /*CVT_NUM_THREADS_PER_SF=*/2>(
+                        std::nullopt, safeTokenIdx, colVecIdx, std::optional<int>(p.num_tokens), SF_PER_ROW,
+                        p.out_sf[1], QuantizationSFLayout::SWIZZLED);
+                    *second_sf_ptr = sfBytes[1];
+                }
+            }
+            if (valid)
+            {
+                int64_t const fp4_row_off = static_cast<int64_t>(safeTokenIdx) * (D / 8);
+#pragma unroll
+                for (int k = 0; k < NUM_OUT; k++)
+                    p.out_fp4[k][fp4_row_off + colVecIdx] = fp4_packed[k];
+            }
+#endif
+        }
+        else
+        {
+            // bf16 shift_scale path: byte-matches eager apply_fused_*_shift_scale semantics.
+            //   normed_bf16 = bf16(x_new_fp32 * rms_rcp_fp32)
+            //   y_bf16      = bf16(normed_bf16 * bf16(1 + scale_bf16) + shift_bf16)   if HAS_SHIFT_SCALE
+            //   y_bf16      = normed_bf16                                              else
+            __nv_bfloat162 const one_b2 = __float2bfloat162_rn(1.0f);
+            uint4 out_vecs[NUM_OUT];
+#pragma unroll
+            for (int i = 0; i < 4; i++)
+            {
+                __nv_bfloat162 x_b2 = *reinterpret_cast<__nv_bfloat162 const*>(&x_uints[i]);
+                float2 xv = __bfloat1622float2(x_b2);
+                __nv_bfloat162 normed_b2 = __float22bfloat162_rn(make_float2(xv.x * rms_rcp, xv.y * rms_rcp));
+#pragma unroll
+                for (int k = 0; k < NUM_OUT; k++)
+                {
+                    uint* o_uints = reinterpret_cast<uint*>(&out_vecs[k]);
+                    if constexpr (HAS_SHIFT_SCALE)
+                    {
+                        uint4 const sv = scale_cache[k * CHUNKS_PER_ROW + chunk];
+                        uint4 const hv = shift_cache[k * CHUNKS_PER_ROW + chunk];
+                        uint const* s_uints = reinterpret_cast<uint const*>(&sv);
+                        uint const* h_uints = reinterpret_cast<uint const*>(&hv);
+                        __nv_bfloat162 s_b2 = *reinterpret_cast<__nv_bfloat162 const*>(&s_uints[i]);
+                        __nv_bfloat162 h_b2 = *reinterpret_cast<__nv_bfloat162 const*>(&h_uints[i]);
+                        __nv_bfloat162 one_p_s = __hadd2(one_b2, s_b2);
+                        __nv_bfloat162 y_b2 = __hadd2(__hmul2(normed_b2, one_p_s), h_b2);
+                        reinterpret_cast<__nv_bfloat162&>(o_uints[i]) = y_b2;
+                    }
+                    else
+                    {
+                        reinterpret_cast<__nv_bfloat162&>(o_uints[i]) = normed_b2;
+                    }
+                }
+            }
+            if (valid)
+            {
+#pragma unroll
+                for (int k = 0; k < NUM_OUT; k++)
+                    *reinterpret_cast<uint4*>(&p.out_bf16[k][tokenBase + elemBase]) = out_vecs[k];
+            }
+        }
+    }
+
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900)
+    asm volatile("griddepcontrol.launch_dependents;");
+#endif
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Pipelined variant: multi-row CTA + circular SMEM stages + 1 producer warp / 8 consumer warps.
+//
+// Pipeline:
+//   - Per-stage SMEM: [X (D bf16) | attn (D bf16) if HAS_RESIDUAL].
+//   - full_bar[NUM_STAGES]:  producer signals "TMA done".
+//   - empty_bar[NUM_STAGES]: consumers signal "slot reusable" (init=CONSUMER_WARPS arrives).
+//   - Producer warp (lane 0 active): wait empty_bar, issue cp.async.bulk for X (and attn when
+//     HAS_RESIDUAL), arrive full_bar with the expected tx-bytes.
+//   - Consumer warps: wait full_bar, compute x_new + sum^2, normalize + shift_scale + write,
+//     arrive empty_bar.
+//
+// Caller contract: tokens_per_batch >= R_CTA && tokens_per_batch % R_CTA == 0 so all R_CTA
+// rows in a CTA share batchIdx and modulator load amortizes once per CTA.
+template <int D, int R_CTA, int NUM_STAGES, bool HAS_RESIDUAL, bool HAS_GATE, bool HAS_SHIFT_SCALE, int NUM_OUT,
+    bool HAS_QUANT>
+__global__ __launch_bounds__(288, 2) void fusedDiTGateResidNormShiftScaleKernelPipelined(AdaLNNormParams p)
+{
+    static_assert(D == 4096, "Pipelined variant requires D=4096");
+    static_assert(R_CTA == 4, "Pipelined variant requires R_CTA=4");
+    static_assert(NUM_STAGES == 2 || NUM_STAGES == 3, "NUM_STAGES must be 2 or 3");
+    static_assert(NUM_OUT == 1 || NUM_OUT == 2, "NUM_OUT must be 1 or 2");
+    static_assert(!HAS_GATE || HAS_RESIDUAL, "HAS_GATE requires HAS_RESIDUAL");
+
+    constexpr int CONSUMER_WARPS = 8;
+    constexpr int CONSUMER_THREADS = CONSUMER_WARPS * 32;              // 256
+    constexpr int VEC_ELEMS = 8;                                       // bf16 per uint4
+    constexpr int VEC_PER_THREAD = D / (CONSUMER_THREADS * VEC_ELEMS); // 2 for D=4096
+    constexpr int SF_VEC_SIZE = 16;
+    constexpr int SF_PER_ROW = D / SF_VEC_SIZE;
+    static_assert(D % (CONSUMER_THREADS * VEC_ELEMS) == 0, "D must split evenly across 256 threads x 8 bf16");
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 900)
+    __trap(); // pipelined variant is sm_90+-only (TMA/mbarrier); never dispatched below Blackwell
+#endif
+
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900)
+    asm volatile("griddepcontrol.wait;");
+#endif
+
+    int const tid = threadIdx.x;
+    int const warp_id = tid / 32;
+    int const lane_id = tid % 32;
+    bool const is_producer = (warp_id == 0);
+    int const consumer_id = tid - 32;      // valid for warp_id >= 1
+    int const consumer_warp = warp_id - 1; // 0..7
+
+    int const base_token = blockIdx.x * R_CTA;
+    int const batchIdx = base_token / p.tokens_per_batch;
+
+    constexpr int kStageElems = HAS_RESIDUAL ? (2 * D) : D;
+    constexpr size_t kStageBytes = static_cast<size_t>(kStageElems) * sizeof(__nv_bfloat16);
+    extern __shared__ __align__(16) unsigned char smem_raw[];
+    __nv_bfloat16* smem_x_stage[NUM_STAGES];
+    __nv_bfloat16* smem_attn_stage[NUM_STAGES];
+#pragma unroll
+    for (int s = 0; s < NUM_STAGES; s++)
+    {
+        smem_x_stage[s] = reinterpret_cast<__nv_bfloat16*>(smem_raw + s * kStageBytes);
+        smem_attn_stage[s] = HAS_RESIDUAL ? (smem_x_stage[s] + D) : nullptr;
+    }
+    uint64_t* full_bar = reinterpret_cast<uint64_t*>(smem_raw + NUM_STAGES * kStageBytes);
+    uint64_t* empty_bar = full_bar + NUM_STAGES;
+    float* warp_sums = reinterpret_cast<float*>(empty_bar + NUM_STAGES);
+
+    if (tid == 0)
+    {
+#pragma unroll
+        for (int s = 0; s < NUM_STAGES; s++)
+        {
+            mbar_init(&full_bar[s], 1);
+            mbar_init(&empty_bar[s], CONSUMER_WARPS);
+        }
+    }
+
+    // Pre-load modulator caches into REGs once per CTA. All R_CTA rows share batchIdx.
+    constexpr int kScaleCacheSize = HAS_SHIFT_SCALE ? (NUM_OUT * VEC_PER_THREAD) : 1;
+    constexpr int kGateCacheSize = HAS_GATE ? VEC_PER_THREAD : 1;
+    uint4 scale_cache[kScaleCacheSize];
+    uint4 shift_cache[kScaleCacheSize];
+    uint4 gate_cache[kGateCacheSize];
+
+    if (!is_producer)
+    {
+        if constexpr (HAS_SHIFT_SCALE)
+        {
+#pragma unroll
+            for (int k = 0; k < NUM_OUT; k++)
+            {
+                int64_t const scaleBase = static_cast<int64_t>(batchIdx) * p.scale_ts_stride[k];
+                int64_t const shiftBase = static_cast<int64_t>(batchIdx) * p.shift_ts_stride[k];
+#pragma unroll
+                for (int v = 0; v < VEC_PER_THREAD; v++)
+                {
+                    int const elem = (v * CONSUMER_THREADS + consumer_id) * VEC_ELEMS;
+                    uint4 const s_ts = *reinterpret_cast<uint4 const*>(&p.scale_ts[k][scaleBase + elem]);
+                    float4 const s_tbl_lo = *reinterpret_cast<float4 const*>(&p.scale_table[k][elem + 0]);
+                    float4 const s_tbl_hi = *reinterpret_cast<float4 const*>(&p.scale_table[k][elem + 4]);
+                    scale_cache[k * VEC_PER_THREAD + v] = combine_modulator_chunk(s_ts, s_tbl_lo, s_tbl_hi);
+
+                    uint4 const h_ts = *reinterpret_cast<uint4 const*>(&p.shift_ts[k][shiftBase + elem]);
+                    float4 const h_tbl_lo = *reinterpret_cast<float4 const*>(&p.shift_table[k][elem + 0]);
+                    float4 const h_tbl_hi = *reinterpret_cast<float4 const*>(&p.shift_table[k][elem + 4]);
+                    shift_cache[k * VEC_PER_THREAD + v] = combine_modulator_chunk(h_ts, h_tbl_lo, h_tbl_hi);
+                }
+            }
+        }
+        if constexpr (HAS_GATE)
+        {
+            int64_t const gateBase = static_cast<int64_t>(batchIdx) * p.gate_ts_stride;
+#pragma unroll
+            for (int v = 0; v < VEC_PER_THREAD; v++)
+            {
+                int const elem = (v * CONSUMER_THREADS + consumer_id) * VEC_ELEMS;
+                uint4 const g_ts = *reinterpret_cast<uint4 const*>(&p.gate_ts[gateBase + elem]);
+                float4 const g_tbl_lo = *reinterpret_cast<float4 const*>(&p.gate_table[elem + 0]);
+                float4 const g_tbl_hi = *reinterpret_cast<float4 const*>(&p.gate_table[elem + 4]);
+                gate_cache[v] = combine_modulator_chunk(g_ts, g_tbl_lo, g_tbl_hi);
+            }
+        }
+    }
+
+    __syncthreads();
+
+    // Pre-fill empty_bar so producer's first iteration doesn't block.
+    if (!is_producer && lane_id == 0)
+    {
+#pragma unroll
+        for (int s = 0; s < NUM_STAGES; s++)
+            mbar_arrive(&empty_bar[s]);
+    }
+    __syncthreads();
+
+    uint32_t stage = 0;
+    uint32_t phase_full = 0;
+    uint32_t phase_empty = 0;
+    constexpr uint32_t kXBytes = D * sizeof(__nv_bfloat16);
+    constexpr uint32_t kAttnBytes = HAS_RESIDUAL ? kXBytes : 0;
+    constexpr uint32_t kTotalBytes = kXBytes + kAttnBytes;
+
+    if (is_producer)
+    {
+        if (lane_id == 0)
+        {
+#pragma unroll
+            for (int sub = 0; sub < R_CTA; sub++)
+            {
+                int const token = base_token + sub;
+                if (token >= p.num_tokens)
+                    break;
+                int64_t const tokenBase = static_cast<int64_t>(token) * D;
+                mbar_wait(&empty_bar[stage], phase_empty);
+                mbar_arrive_expect_tx(&full_bar[stage], kTotalBytes);
+                cp_async_bulk(smem_x_stage[stage], p.x + tokenBase, kXBytes, &full_bar[stage]);
+                if constexpr (HAS_RESIDUAL)
+                {
+                    cp_async_bulk(smem_attn_stage[stage], p.attn + tokenBase, kAttnBytes, &full_bar[stage]);
+                }
+                stage = stage + 1;
+                if (stage == NUM_STAGES)
+                {
+                    stage = 0;
+                    phase_empty ^= 1u;
+                }
+            }
+        }
+    }
+    else
+    {
+#pragma unroll
+        for (int sub = 0; sub < R_CTA; sub++)
+        {
+            int const token = base_token + sub;
+            bool const valid = (token < p.num_tokens);
+            int const safeToken = valid ? token : 0;
+            int64_t const tokenBase = static_cast<int64_t>(safeToken) * D;
+
+            mbar_wait(&full_bar[stage], phase_full);
+
+            // Phase 1: x_new = x [+ attn [* gate]]; cache x_new in regs, accumulate sum^2.
+            uint4 xnew_cache[VEC_PER_THREAD];
+            float sum2 = 0.0f;
+#pragma unroll
+            for (int v = 0; v < VEC_PER_THREAD; v++)
+            {
+                int const elem = (v * CONSUMER_THREADS + consumer_id) * VEC_ELEMS;
+                uint4 const xv = *reinterpret_cast<uint4 const*>(&smem_x_stage[stage][elem]);
+                uint const* xu = reinterpret_cast<uint const*>(&xv);
+                uint4 new_vec;
+                uint* nu = reinterpret_cast<uint*>(&new_vec);
+
+                if constexpr (HAS_RESIDUAL)
+                {
+                    uint4 const av = *reinterpret_cast<uint4 const*>(&smem_attn_stage[stage][elem]);
+                    uint const* au = reinterpret_cast<uint const*>(&av);
+                    if constexpr (HAS_GATE)
+                    {
+                        uint4 const gv = gate_cache[v];
+                        uint const* gu = reinterpret_cast<uint const*>(&gv);
+#pragma unroll
+                        for (int i = 0; i < 4; i++)
+                        {
+                            float2 xf = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162 const*>(&xu[i]));
+                            float2 af = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162 const*>(&au[i]));
+                            float2 gf = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162 const*>(&gu[i]));
+                            float2 nf;
+                            nf.x = xf.x + af.x * gf.x;
+                            nf.y = xf.y + af.y * gf.y;
+                            sum2 += nf.x * nf.x + nf.y * nf.y;
+                            reinterpret_cast<__nv_bfloat162&>(nu[i]) = __float22bfloat162_rn(nf);
+                        }
+                    }
+                    else
+                    {
+#pragma unroll
+                        for (int i = 0; i < 4; i++)
+                        {
+                            float2 xf = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162 const*>(&xu[i]));
+                            float2 af = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162 const*>(&au[i]));
+                            float2 nf;
+                            nf.x = xf.x + af.x;
+                            nf.y = xf.y + af.y;
+                            sum2 += nf.x * nf.x + nf.y * nf.y;
+                            reinterpret_cast<__nv_bfloat162&>(nu[i]) = __float22bfloat162_rn(nf);
+                        }
+                    }
+                }
+                else
+                {
+#pragma unroll
+                    for (int i = 0; i < 4; i++)
+                    {
+                        float2 xf = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162 const*>(&xu[i]));
+                        sum2 += xf.x * xf.x + xf.y * xf.y;
+                        reinterpret_cast<uint&>(nu[i]) = xu[i];
+                    }
+                }
+                xnew_cache[v] = new_vec;
+                // Write x_new to the separate p.x_out buffer when HAS_RESIDUAL (op stays functional).
+                if constexpr (HAS_RESIDUAL)
+                {
+                    if (valid)
+                        *reinterpret_cast<uint4*>(&p.x_out[tokenBase + elem]) = new_vec;
+                }
+            }
+
+            sum2 = tensorrt_llm::common::warpReduceSum(sum2);
+            if (lane_id == 0)
+                warp_sums[consumer_warp] = sum2;
+            bar_sync_consumer(CONSUMER_THREADS);
+
+            float total = 0.0f;
+#pragma unroll
+            for (int w = 0; w < CONSUMER_WARPS; w++)
+                total += warp_sums[w];
+            float const rms_rcp = rsqrtf(total / static_cast<float>(D) + p.eps);
+
+            // ---- Phase 2: normalize + (optional shift_scale) + write NUM_OUT outputs ----
+            float sf_scale_val[NUM_OUT];
+            if constexpr (HAS_QUANT)
+            {
+#pragma unroll
+                for (int k = 0; k < NUM_OUT; k++)
+                    sf_scale_val[k] = (p.sf_scale[k] != nullptr) ? *p.sf_scale[k] : 1.0f;
+            }
+
+            __nv_bfloat162 const one_b2 = __float2bfloat162_rn(1.0f);
+#pragma unroll
+            for (int v = 0; v < VEC_PER_THREAD; v++)
+            {
+                int const elem = (v * CONSUMER_THREADS + consumer_id) * VEC_ELEMS;
+                uint4 const in_vec = xnew_cache[v];
+                uint const* xu = reinterpret_cast<uint const*>(&in_vec);
+
+                if constexpr (HAS_QUANT)
+                {
+                    // Per-v NVFP4 path: fp32 shift_scale + max-abs scan + e2m1 pack.
+                    // Each thread covers 8 bf16 (one uint4) per v, half SF block.
+                    // Pair of adjacent lanes (lane ^ 1) shares one 16-element SF block.
+                    float vals[NUM_OUT][8];
+                    float localMax[NUM_OUT];
+#pragma unroll
+                    for (int k = 0; k < NUM_OUT; k++)
+                        localMax[k] = 0.0f;
+
+#pragma unroll
+                    for (int i = 0; i < 4; i++)
+                    {
+                        float2 xf = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162 const*>(&xu[i]));
+                        float const nx = xf.x * rms_rcp;
+                        float const ny = xf.y * rms_rcp;
+#pragma unroll
+                        for (int k = 0; k < NUM_OUT; k++)
+                        {
+                            float yx, yy;
+                            if constexpr (HAS_SHIFT_SCALE)
+                            {
+                                uint4 const sv = scale_cache[k * VEC_PER_THREAD + v];
+                                uint4 const hv = shift_cache[k * VEC_PER_THREAD + v];
+                                uint const* su = reinterpret_cast<uint const*>(&sv);
+                                uint const* hu = reinterpret_cast<uint const*>(&hv);
+                                float2 sf = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162 const*>(&su[i]));
+                                float2 hf = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162 const*>(&hu[i]));
+                                yx = nx * (1.0f + sf.x) + hf.x;
+                                yy = ny * (1.0f + sf.y) + hf.y;
+                            }
+                            else
+                            {
+                                yx = nx;
+                                yy = ny;
+                            }
+                            vals[k][2 * i + 0] = yx;
+                            vals[k][2 * i + 1] = yy;
+                            localMax[k] = fmaxf(localMax[k], fmaxf(fabsf(yx), fabsf(yy)));
+                        }
+                    }
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+                    uint32_t fp4_packed[NUM_OUT];
+                    uint8_t sfBytes[NUM_OUT];
+#pragma unroll
+                    for (int k = 0; k < NUM_OUT; k++)
+                    {
+                        // Pair-lane max-abs across 16 elements (one SF block).
+                        float const blockMax = fmaxf(__shfl_xor_sync(0xffffffff, localMax[k], 1), localMax[k]);
+                        constexpr float kE2M1MaxRcp = 1.0f / 6.0f;
+                        float const sfValue = sf_scale_val[k] * (blockMax * kE2M1MaxRcp);
+                        __nv_fp8_e4m3 const sfFp8 = __nv_fp8_e4m3(sfValue);
+                        sfBytes[k] = sfFp8.__x;
+                        float const sfQuant = static_cast<float>(sfFp8);
+                        float const outScale = (blockMax != 0.0f) ? (sf_scale_val[k] / sfQuant) : 0.0f;
+#pragma unroll
+                        for (int i = 0; i < 8; i++)
+                            vals[k][i] *= outScale;
+                        fp4_packed[k] = fp32_vec_to_e2m1(vals[k]);
+                    }
+
+                    // colVecIdx: one uint32 of packed FP4 per (v, thread). Pair of adjacent
+                    // lanes (lane ^ 1) shares one 16-element SF block (CVT_NUM_THREADS_PER_SF=2).
+                    int const colVecIdx = v * CONSUMER_THREADS + consumer_id;
+                    uint8_t* first_sf_ptr = cvt_quant_get_sf_out_offset<uint32_t, /*CVT_NUM_THREADS_PER_SF=*/2>(
+                        std::nullopt, safeToken, colVecIdx, std::optional<int>(p.num_tokens), SF_PER_ROW, p.out_sf[0],
+                        QuantizationSFLayout::SWIZZLED);
+                    if (valid && first_sf_ptr != nullptr)
+                    {
+                        *first_sf_ptr = sfBytes[0];
+                        if constexpr (NUM_OUT == 2)
+                        {
+                            uint8_t* second_sf_ptr
+                                = cvt_quant_get_sf_out_offset<uint32_t, /*CVT_NUM_THREADS_PER_SF=*/2>(std::nullopt,
+                                    safeToken, colVecIdx, std::optional<int>(p.num_tokens), SF_PER_ROW, p.out_sf[1],
+                                    QuantizationSFLayout::SWIZZLED);
+                            *second_sf_ptr = sfBytes[1];
+                        }
+                    }
+                    if (valid)
+                    {
+                        int64_t const fp4_row_off = static_cast<int64_t>(safeToken) * (D / 8);
+#pragma unroll
+                        for (int k = 0; k < NUM_OUT; k++)
+                            p.out_fp4[k][fp4_row_off + colVecIdx] = fp4_packed[k];
+                    }
+#endif
+                }
+                else
+                {
+                    uint4 out_vecs[NUM_OUT];
+#pragma unroll
+                    for (int i = 0; i < 4; i++)
+                    {
+                        __nv_bfloat162 x_b2 = *reinterpret_cast<__nv_bfloat162 const*>(&xu[i]);
+                        float2 xf = __bfloat1622float2(x_b2);
+                        __nv_bfloat162 normed = __float22bfloat162_rn(make_float2(xf.x * rms_rcp, xf.y * rms_rcp));
+#pragma unroll
+                        for (int k = 0; k < NUM_OUT; k++)
+                        {
+                            uint* o_u = reinterpret_cast<uint*>(&out_vecs[k]);
+                            if constexpr (HAS_SHIFT_SCALE)
+                            {
+                                uint4 const sv = scale_cache[k * VEC_PER_THREAD + v];
+                                uint4 const hv = shift_cache[k * VEC_PER_THREAD + v];
+                                uint const* su = reinterpret_cast<uint const*>(&sv);
+                                uint const* hu = reinterpret_cast<uint const*>(&hv);
+                                __nv_bfloat162 s_b2 = *reinterpret_cast<__nv_bfloat162 const*>(&su[i]);
+                                __nv_bfloat162 h_b2 = *reinterpret_cast<__nv_bfloat162 const*>(&hu[i]);
+                                __nv_bfloat162 one_p_s = __hadd2(one_b2, s_b2);
+                                __nv_bfloat162 y_b2 = __hadd2(__hmul2(normed, one_p_s), h_b2);
+                                reinterpret_cast<__nv_bfloat162&>(o_u[i]) = y_b2;
+                            }
+                            else
+                            {
+                                reinterpret_cast<__nv_bfloat162&>(o_u[i]) = normed;
+                            }
+                        }
+                    }
+                    if (valid)
+                    {
+#pragma unroll
+                        for (int k = 0; k < NUM_OUT; k++)
+                            *reinterpret_cast<uint4*>(&p.out_bf16[k][tokenBase + elem]) = out_vecs[k];
+                    }
+                }
+            }
+
+            bar_sync_consumer(CONSUMER_THREADS);
+            if (lane_id == 0)
+                mbar_arrive(&empty_bar[stage]);
+
+            stage = stage + 1;
+            if (stage == NUM_STAGES)
+            {
+                stage = 0;
+                phase_full ^= 1u;
+            }
+        }
+    }
+
+#if (defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900)
+    asm volatile("griddepcontrol.launch_dependents;");
+#endif
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Templated host launcher (compile-time variant flags) + a runtime-flag dispatch entry point that
+// maps the op's inferred flags onto the right specialization. Only the variants the dispatcher
+// references are instantiated. Consumed by LTX-2's transformer block.
+
+namespace
+{
+template <bool HAS_RESIDUAL, bool HAS_GATE, bool HAS_NORM, bool HAS_SHIFT_SCALE, int NUM_OUT, bool HAS_QUANT>
+void launchFusedDiTGateResidNormShiftScaleKernelImpl(AdaLNNormParams const& params, int hidden_dim, cudaStream_t stream)
+{
+    TLLM_CHECK_WITH_INFO(params.num_tokens >= 1, "num_tokens must be >= 1, got %d", params.num_tokens);
+    TLLM_CHECK_WITH_INFO(
+        params.tokens_per_batch >= 1, "tokens_per_batch must be >= 1, got %d", params.tokens_per_batch);
+    TLLM_CHECK_WITH_INFO(params.num_tokens % params.tokens_per_batch == 0,
+        "num_tokens (%d) must be divisible by tokens_per_batch (%d)", params.num_tokens, params.tokens_per_batch);
+
+    // Production tile selected via NCU sweep at D=4096, B=1, T=15360: 1-row/CTA, 256 threads/CTA
+    // gives 2 CTAs/SM (regs <= 80) and the highest per-element bench rate among {2r256, 1r256, 1r512}.
+    constexpr int ROWS_PER_BLOCK = 1;
+    constexpr int BLOCK_SIZE = 256;
+    constexpr int WARPS_PER_ROW = (BLOCK_SIZE / ROWS_PER_BLOCK) / 32;
+
+    cudaLaunchConfig_t cfg = {};
+    cfg.stream = stream;
+    cudaLaunchAttribute attrs[1] = {};
+    attrs[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attrs[0].val.programmaticStreamSerializationAllowed = 1;
+    cfg.attrs = attrs;
+    cfg.numAttrs = 1;
+
+    // Pipelined dispatch (multi-row CTA + circular TMA stages + warp specialization).
+    // Auto-selected on shapes where it wins; otherwise falls through to the default path below.
+    //   - hidden_dim == 4096 (video path; audio D=2048 has too small a grid to amortize the
+    //     warp-specialization overhead and bench-regresses)
+    //   - HAS_SHIFT_SCALE || !HAS_GATE (the HAS_GATE && !HAS_SHIFT_SCALE variant is HBM-bound and bench-regresses)
+    //   - tokens_per_batch >= 4 && % 4 == 0 (R_CTA=4 rows share batchIdx for per-CTA mod cache)
+    //   - num_tokens % 4 == 0 (whole grid must be R_CTA-aligned)
+    constexpr bool kPipelinedVariantOK = HAS_SHIFT_SCALE || !HAS_GATE;
+    if constexpr (kPipelinedVariantOK)
+    {
+        // NUM_STAGES chosen per HAS_QUANT: bf16 path is HBM-latency-bound so deeper pipeline
+        // (3 stages) helps; quant Phase 2 is compute-heavy and extra stages just add SMEM
+        // pressure without commensurate latency hiding.
+        constexpr int PIPE_NUM_STAGES = HAS_QUANT ? 2 : 3;
+        constexpr int PIPE_BLOCK_SIZE = 288;
+        constexpr int PIPE_D = 4096;
+        constexpr int PIPE_R_CTA = 4;
+        // Pipelined variant uses sm_90+ TMA/mbarrier; on older archs (sm_80/86/89) fall through to the
+        // V1 cp.async path below (functionally correct, just no TMA/pipelining). Cache the SM query --
+        // getSMVersion() issues cudaGetDevice + cudaDeviceGetAttribute, too costly on the per-launch path.
+        static int const kSmVersion = tensorrt_llm::common::getSMVersion();
+        if (kSmVersion >= 90 && hidden_dim == PIPE_D && (params.num_tokens % PIPE_R_CTA == 0)
+            && (params.tokens_per_batch >= PIPE_R_CTA) && (params.tokens_per_batch % PIPE_R_CTA == 0))
+        {
+            constexpr int pipe_stage_elems = HAS_RESIDUAL ? (2 * PIPE_D) : PIPE_D;
+            size_t const pipe_smem_bytes
+                = static_cast<size_t>(PIPE_NUM_STAGES) * pipe_stage_elems * sizeof(__nv_bfloat16)
+                + 2 * PIPE_NUM_STAGES * sizeof(uint64_t) + 8 * sizeof(float) + 16;
+            cudaLaunchConfig_t pipe_cfg = cfg;
+            pipe_cfg.gridDim = dim3((params.num_tokens + PIPE_R_CTA - 1) / PIPE_R_CTA);
+            pipe_cfg.blockDim = dim3(PIPE_BLOCK_SIZE);
+            pipe_cfg.dynamicSmemBytes = static_cast<int>(pipe_smem_bytes);
+            // Pipelined kernel is only built for HAS_NORM=true variants. The dispatch predicate
+            // above requires HAS_SHIFT_SCALE || !HAS_GATE which is satisfied only by HAS_NORM=true
+            // paths; the gate-residual-only variant (HAS_SHIFT_SCALE=false, HAS_GATE=true) fails the
+            // predicate and falls through to the default tile.
+            static_assert(HAS_NORM, "pipelined dispatch requires HAS_NORM");
+            auto* pipe_kp = fusedDiTGateResidNormShiftScaleKernelPipelined<PIPE_D, PIPE_R_CTA, PIPE_NUM_STAGES,
+                HAS_RESIDUAL, HAS_GATE, HAS_SHIFT_SCALE, NUM_OUT, HAS_QUANT>;
+            cudaFuncSetAttribute(
+                pipe_kp, cudaFuncAttributeMaxDynamicSharedMemorySize, static_cast<int>(pipe_smem_bytes));
+            cudaLaunchKernelEx(&pipe_cfg, pipe_kp, params);
+            return;
+        }
+    }
+
+#define LAUNCH(D_VAL)                                                                                                  \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        constexpr bool USE_TMA_HOST = (D_VAL >= 4096) && !(HAS_QUANT && HAS_SHIFT_SCALE && NUM_OUT == 1);              \
+        constexpr bool USE_TMA_ATTN_HOST = USE_TMA_HOST && HAS_RESIDUAL && HAS_QUANT;                                  \
+        int const attn_extra_bytes                                                                                     \
+            = USE_TMA_ATTN_HOST ? (ROWS_PER_BLOCK * D_VAL * static_cast<int>(sizeof(__nv_bfloat16))) : 0;              \
+        cfg.gridDim = dim3((params.num_tokens + ROWS_PER_BLOCK - 1) / ROWS_PER_BLOCK);                                 \
+        cfg.blockDim = dim3(BLOCK_SIZE);                                                                               \
+        cfg.dynamicSmemBytes = ROWS_PER_BLOCK * D_VAL * static_cast<int>(sizeof(__nv_bfloat16)) + attn_extra_bytes     \
+            + ROWS_PER_BLOCK * WARPS_PER_ROW * static_cast<int>(sizeof(float));                                        \
+        cudaLaunchKernelEx(&cfg,                                                                                       \
+            fusedDiTGateResidNormShiftScaleKernel<D_VAL, ROWS_PER_BLOCK, BLOCK_SIZE, HAS_RESIDUAL, HAS_GATE, HAS_NORM, \
+                HAS_SHIFT_SCALE, NUM_OUT, HAS_QUANT>,                                                                  \
+            params);                                                                                                   \
+    } while (0)
+
+    switch (hidden_dim)
+    {
+    case 2048: LAUNCH(2048); break;
+    case 4096: LAUNCH(4096); break;
+    default:
+        TLLM_THROW(
+            "Unsupported hidden_dim for fusedDiTGateResidNormShiftScaleKernel: %d (only 2048, 4096)", hidden_dim);
+    }
+#undef LAUNCH
+}
+
+} // anonymous namespace
+
+// Runtime-flag dispatch entry. The op has already validated (residual, gate, norm, shift_scale, quant)
+// against kSupportedVariants, so every line below is a direct "args == this tuple -> launch this tuple"
+// map: the compared flags and the template arguments are the same literals (no negation / elimination
+// ordering). NUM_OUT is fixed by the variant those flags select (2 only for the residual-no-gate dual);
+// gate_resid (no norm) is bf16-only, so it has no NVFP4 line. Only the tuples listed here are instantiated.
+void launchFusedDiTGateResidNormShiftScaleKernel(AdaLNNormParams const& params, bool residual, bool gate, bool norm,
+    bool shift_scale, bool quant, int hidden_dim, cudaStream_t stream)
+{
+#define DISPATCH(R, G, N, SS, NO, QUANT)                                                                               \
+    if (residual == (R) && gate == (G) && norm == (N) && shift_scale == (SS) && quant == (QUANT))                      \
+    return launchFusedDiTGateResidNormShiftScaleKernelImpl<R, G, N, SS, NO, QUANT>(params, hidden_dim, stream)
+
+    DISPATCH(false, false, true, true, 1, false); // rmsnorm_shift_scale
+    DISPATCH(false, false, true, true, 1, true);  // rmsnorm_shift_scale (NVFP4)
+    DISPATCH(true, false, true, true, 2, false);  // resid_rmsnorm_shift_scale_dual
+    DISPATCH(true, false, true, true, 2, true);   // resid_rmsnorm_shift_scale_dual (NVFP4)
+    DISPATCH(true, true, true, true, 1, false);   // gate_resid_rmsnorm_shift_scale
+    DISPATCH(true, true, true, true, 1, true);    // gate_resid_rmsnorm_shift_scale (NVFP4)
+    DISPATCH(true, true, true, false, 1, false);  // gate_resid_rmsnorm
+    DISPATCH(true, true, true, false, 1, true);   // gate_resid_rmsnorm (NVFP4)
+    DISPATCH(true, true, false, false, 1, false); // gate_resid (bf16-only)
+#undef DISPATCH
+
+    TLLM_THROW(
+        "Unsupported fusedDiTGateResidNormShiftScale variant: residual=%d gate=%d norm=%d shift_scale=%d "
+        "quant=%d (op-side validation should have rejected this)",
+        residual, gate, norm, shift_scale, quant);
+}
+
+} // namespace kernels
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/kernels/fusedDiTGateResidNormShiftScaleKernel.h
+++ b/cpp/tensorrt_llm/kernels/fusedDiTGateResidNormShiftScaleKernel.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TRTLLM_FUSEDDITGATERESIDNORMSHIFTSCALEKERNEL_H
+#define TRTLLM_FUSEDDITGATERESIDNORMSHIFTSCALEKERNEL_H
+
+#include "tensorrt_llm/common/config.h"
+#include <cstdint>
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels
+{
+
+// Single fused DiT pre-block kernel covering all AdaLN variants via template flags.
+//
+// Pipeline (compile-time selected, all "pluggable" except RmsNorm which is always on):
+//   1. Phase 0a -- cp.async x -> SMEM                                     (always)
+//   2. Phase 0b -- combine modulator (table, ts) pairs into bf16 caches:
+//        gate (if HAS_GATE)
+//        NUM_OUT scale + shift (if HAS_SHIFT_SCALE)
+//   3. Phase 0c -- load attn into reg cache                                (if HAS_RESIDUAL)
+//   4. Phase 1  -- x_new = x [+ attn [* gate]]; sum^2; write x_new to x_out if HAS_RESIDUAL
+//   5. Reduce   -- per-row warp + cross-warp reduce -> rms_rcp             (always)
+//   6. Phase 2  -- write NUM_OUT outputs:
+//        if HAS_SHIFT_SCALE: y[k] = (1 + scale[k]) * normed + shift[k]
+//        else           : y    = normed
+//        HAS_QUANT=false: bf16 store to out_bf16[k]
+//        HAS_QUANT=true : NVFP4 + 128x4 swizzled SF to (out_fp4[k], out_sf[k])
+//
+// Specializations used by LTX-2:
+//   rmsnorm_shift_scale:            HAS_RESIDUAL=false, HAS_GATE=false, HAS_SHIFT_SCALE=true,  NUM_OUT=1
+//   resid_rmsnorm_shift_scale_dual: HAS_RESIDUAL=true,  HAS_GATE=false, HAS_SHIFT_SCALE=true,  NUM_OUT=2
+//   gate_resid_rmsnorm_shift_scale: HAS_RESIDUAL=true,  HAS_GATE=true,  HAS_SHIFT_SCALE=true,  NUM_OUT=1
+//   gate_resid_rmsnorm:             HAS_RESIDUAL=true,  HAS_GATE=true,  HAS_SHIFT_SCALE=false, NUM_OUT=1
+//
+// HAS_GATE implies HAS_RESIDUAL (asserted at compile time).
+//
+// Modulator combine matches PyTorch eager `_get_all_ada_values` semantics:
+// narrow fp32 table to bf16 first, then bf16 hw add (`__hadd2`).
+//
+// Tile: production hardcoded to (ROWS_PER_BLOCK=1, BLOCK_SIZE=256). NCU sweep on B200 at
+// the production shape found 1r256 the best balance: 2r256 has too much per-thread register
+// pressure (12.5% theoretical occupancy on the dual-output bf16 variant); 1r512 reaches higher occupancy but its
+// 16-warp CTAs starve the SM warp schedulers and pay a heavier __syncthreads() barrier.
+//
+// Supported hidden_dim: 2048 (LTX-2 audio) and 4096 (LTX-2 video).
+
+struct AdaLNNormParams
+{
+    // === Input ===
+    __nv_bfloat16* x = nullptr;          // [num_tokens, D] bf16. Read-only.
+    __nv_bfloat16* x_out = nullptr;      // HAS_RESIDUAL: [num_tokens, D] bf16. x_new = x [+ attn [* gate]]
+                                         // written here (separate buffer -> op stays functional, no clone of x).
+    __nv_bfloat16 const* attn = nullptr; // HAS_RESIDUAL: [num_tokens, D] bf16
+
+    // === Gate modulator (HAS_GATE => HAS_RESIDUAL) ===
+    float const* gate_table = nullptr;      // [D] fp32, broadcast over batch
+    __nv_bfloat16 const* gate_ts = nullptr; // [batch, D] bf16
+    int gate_ts_stride = 0;                 // inner stride between batches
+
+    // === Affine modulators (HAS_SHIFT_SCALE) -- up to NUM_OUT={1,2} entries ===
+    float const* scale_table[2] = {nullptr, nullptr};
+    __nv_bfloat16 const* scale_ts[2] = {nullptr, nullptr};
+    int scale_ts_stride[2] = {0, 0};
+    float const* shift_table[2] = {nullptr, nullptr};
+    __nv_bfloat16 const* shift_ts[2] = {nullptr, nullptr};
+    int shift_ts_stride[2] = {0, 0};
+
+    // === Outputs (NUM_OUT entries) ===
+    __nv_bfloat16* out_bf16[2] = {nullptr, nullptr}; // HAS_QUANT=false
+    uint32_t* out_fp4[2] = {nullptr, nullptr};       // HAS_QUANT=true
+    uint32_t* out_sf[2] = {nullptr, nullptr};        // HAS_QUANT=true: SWIZZLED 128x4 SF
+    float const* sf_scale[2] = {nullptr, nullptr};   // HAS_QUANT=true: scalar broadcast
+
+    // === Shape ===
+    int num_tokens = 0;
+    int tokens_per_batch = 0;
+    float eps = 1e-6f;
+};
+
+// Launch the unified kernel. Pass the variant as runtime flags; the launcher maps them onto the
+// matching compile-time specialization (selects production tile 1r256, dispatches on hidden_dim).
+// The caller populates only the params relevant to the chosen variant; unused fields stay default.
+//
+// Supported hidden_dim: 2048, 4096. NUM_OUT is implied by the variant (2 for residual-no-gate dual,
+// else 1). gate_resid (norm=false) has no NVFP4-quant variant -- pass quant=false for it.
+void launchFusedDiTGateResidNormShiftScaleKernel(AdaLNNormParams const& params, bool residual, bool gate, bool norm,
+    bool shift_scale, bool quant, int hidden_dim, cudaStream_t stream);
+
+} // namespace kernels
+
+TRTLLM_NAMESPACE_END
+
+#endif // TRTLLM_FUSEDDITGATERESIDNORMSHIFTSCALEKERNEL_H

--- a/cpp/tensorrt_llm/thop/CMakeLists.txt
+++ b/cpp/tensorrt_llm/thop/CMakeLists.txt
@@ -76,6 +76,7 @@ add_library(
   fusedDiTSplitNormOp.cpp
   ulyssesPostUnscatterOp.cpp
   ulyssesPermuteScatterOp.cpp
+  fusedDiTGateResidNormShiftScaleOp.cpp
   fusedAddRMSNormQuant.cpp
   fusedActivationQuant.cpp
   fusedGatedRMSNormQuant.cpp

--- a/cpp/tensorrt_llm/thop/fusedDiTGateResidNormShiftScaleOp.cpp
+++ b/cpp/tensorrt_llm/thop/fusedDiTGateResidNormShiftScaleOp.cpp
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/kernels/fusedDiTGateResidNormShiftScaleKernel.h"
+#include "tensorrt_llm/thop/thUtils.h"
+
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/extension.h>
+
+#include <optional>
+#include <vector>
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace torch_ext
+{
+
+namespace
+{
+// Validate a (table, ts) modulator pair against x's last dim and row count;
+// returns the per-row ts stride (handles both flat [B, D] and [B, T_t, K, D] unbind views).
+int check_modulator(
+    torch::Tensor const& table, torch::Tensor const& ts, int64_t hidden_dim, int64_t n_rows, char const* name)
+{
+    TORCH_CHECK(table.dim() == 1 && table.size(0) == hidden_dim, name, "_table must be 1-D [D]");
+    CHECK_TYPE(table, torch::kFloat32);
+    TORCH_CHECK(table.is_contiguous(), name, "_table must be contiguous");
+    TORCH_CHECK(ts.size(-1) == hidden_dim, name, "_ts last dim must equal x last dim");
+    CHECK_TYPE(ts, torch::kBFloat16);
+    TORCH_CHECK(ts.stride(-1) == 1, name, "_ts must have inner-dim stride 1");
+    TORCH_CHECK(ts.numel() / hidden_dim == n_rows, name, "_ts row count mismatch");
+    return static_cast<int>((n_rows > 1) ? ts.stride(-2) : hidden_dim);
+}
+
+// The AdaLN variants the fused kernel actually supports. The op infers the flags from which
+// optional args the caller provides; any combination NOT in this table is rejected up front
+// (clear error) before dispatch. num_out is the user-facing output count: 0 = gate-residual only
+// (no norm output; x_new is the result), 1 = single output, 2 = dual. quant_ok=false => only a
+// bf16 instantiation exists (no NVFP4-quant kernel for that variant).
+struct FusedDiTVariant
+{
+    bool residual;
+    bool gate;
+    bool norm;
+    bool shift_scale;
+    int64_t num_out;
+    bool quant_ok;
+    char const* name;
+};
+
+constexpr FusedDiTVariant kSupportedVariants[] = {
+    {false, false, true, true, 1, true, "rmsnorm_shift_scale"},
+    {true, false, true, true, 2, true, "resid_rmsnorm_shift_scale_dual"},
+    {true, true, true, true, 1, true, "gate_resid_rmsnorm_shift_scale"},
+    {true, true, true, false, 1, true, "gate_resid_rmsnorm"},
+    {true, true, false, false, 0, false, "gate_resid"},
+};
+} // namespace
+
+// Unified fused DiT pre-block op. Covers every AdaLN variant of the single underlying
+// kernel (launchFusedDiTGateResidNormShiftScaleKernel) -- residual add, gate multiply, weightless RMSNorm,
+// (single or dual) shift_scale affine modulation, and inline NVFP4 quant -- with all
+// flags inferred from which optional arguments are provided. Replaces the former five
+// ops (nine registrations) that each dispatched to this same kernel.
+//
+// Inferred flags:
+//   has_residual    = attn.has_value()
+//   has_gate        = gate_table.has_value()   (requires gate_ts; implies residual)
+//   has_shift_scale = !scale_table.empty()     (scale/shift lists of length num_out)
+//   has_quant       = !sf_scale.empty()        (sf_scale list of length num_out)
+//   has_norm        = num_out >= 1             (num_out == 0 => gate-residual only)
+//
+// Each modulator is built inline by the kernel from its (table_fp32[D], ts_bf16[B, D]) pair:
+//   m[b, d] = table[d].to(bf16) + ts[b, d]   (bf16 narrow first, bf16 hw add).
+//
+// Functional (no aliasing): for residual variants the kernel reads x (read-only) and writes the
+// new residual stream x_new = x [+ attn [* gate]] into a SEPARATE fresh buffer (returned as
+// output[0]); x is never mutated and never copied. This keeps the op alias-free (a mutable
+// Tensor(a!) input + Tensor[] return is unsupported by torch.compile functionalization) with no
+// clone overhead. Callers rebind x from the returned x_new.
+//
+// Returns (x_new prepended iff residual):
+//   residual, num_out == 0  : {x_new}                          (gate-residual only)
+//   residual, bf16          : {x_new, out_0, ..., out_{N-1}}
+//   residual, quant         : {x_new, fp4_0, sf_0, ..., fp4_{N-1}, sf_{N-1}}  (128x4 SWIZZLED SF)
+//   no-residual (KA), bf16  : {out_0}
+//   no-residual (KA), quant : {fp4_0, sf_0}
+std::vector<torch::Tensor> fused_dit_gate_resid_norm_shift_scale(torch::Tensor x,
+    std::optional<torch::Tensor> const& attn, std::optional<torch::Tensor> const& gate_table,
+    std::optional<torch::Tensor> const& gate_ts, std::optional<std::vector<torch::Tensor>> const& scale_table_opt,
+    std::optional<std::vector<torch::Tensor>> const& scale_ts_opt,
+    std::optional<std::vector<torch::Tensor>> const& shift_table_opt,
+    std::optional<std::vector<torch::Tensor>> const& shift_ts_opt,
+    std::optional<std::vector<torch::Tensor>> const& sf_scale_opt, double eps, int64_t num_out)
+{
+    // Optional list args default to None at the call site (callers pass only the features they
+    // use); treat an absent list as empty here so the rest of the impl is unchanged.
+    static std::vector<torch::Tensor> const kEmpty;
+    auto const& scale_table = scale_table_opt.has_value() ? *scale_table_opt : kEmpty;
+    auto const& scale_ts = scale_ts_opt.has_value() ? *scale_ts_opt : kEmpty;
+    auto const& shift_table = shift_table_opt.has_value() ? *shift_table_opt : kEmpty;
+    auto const& shift_ts = shift_ts_opt.has_value() ? *shift_ts_opt : kEmpty;
+    auto const& sf_scale = sf_scale_opt.has_value() ? *sf_scale_opt : kEmpty;
+
+    bool const has_residual = attn.has_value();
+    bool const has_gate = gate_table.has_value();
+    bool const has_shift_scale = !scale_table.empty();
+    bool const has_quant = !sf_scale.empty();
+    bool const has_norm = num_out >= 1;
+
+    TORCH_CHECK(x.dim() >= 2, "x must have at least 2 dims; got ", x.dim());
+    CHECK_INPUT(x, torch::kBFloat16);
+    int64_t const hidden_dim = x.size(-1);
+    int64_t const num_tokens = x.numel() / hidden_dim;
+
+    // Validate the inferred flag combination against the supported-variant table before dispatch.
+    FusedDiTVariant const* variant = nullptr;
+    for (auto const& v : kSupportedVariants)
+    {
+        if (v.residual == has_residual && v.gate == has_gate && v.norm == has_norm && v.shift_scale == has_shift_scale
+            && v.num_out == num_out)
+        {
+            variant = &v;
+            break;
+        }
+    }
+    TORCH_CHECK(variant != nullptr,
+        "fused_dit_gate_resid_norm_shift_scale: unsupported flag combination (residual=", has_residual,
+        ", gate=", has_gate, ", norm=", has_norm, ", shift_scale=", has_shift_scale, ", num_out=", num_out,
+        "). Supported: rmsnorm_shift_scale, resid_rmsnorm_shift_scale_dual, gate_resid_rmsnorm_shift_scale, "
+        "gate_resid_rmsnorm, gate_resid.");
+    TORCH_CHECK(!has_quant || variant->quant_ok, "fused_dit_gate_resid_norm_shift_scale: variant '", variant->name,
+        "' has no NVFP4-quant instantiation");
+    TORCH_CHECK(!has_gate || gate_ts.has_value(), "gate requires gate_ts");
+    if (has_shift_scale)
+    {
+        TORCH_CHECK(static_cast<int64_t>(scale_table.size()) == num_out
+                && static_cast<int64_t>(scale_ts.size()) == num_out
+                && static_cast<int64_t>(shift_table.size()) == num_out
+                && static_cast<int64_t>(shift_ts.size()) == num_out,
+            "scale/shift table+ts lists must each have length num_out=", num_out);
+    }
+    if (has_quant)
+    {
+        TORCH_CHECK(
+            static_cast<int64_t>(sf_scale.size()) == num_out, "sf_scale list must have length num_out=", num_out);
+        TORCH_CHECK(hidden_dim % 16 == 0, "hidden_dim must be divisible by 16 (NVFP4 group size)");
+    }
+
+    // Row count comes from gate_ts (gated variants) or scale_ts[0] (no-gate variants);
+    // every valid combination provides at least one of them.
+    int64_t n_rows = 1;
+    if (has_gate)
+    {
+        n_rows = gate_ts->numel() / hidden_dim;
+    }
+    else if (has_shift_scale)
+    {
+        n_rows = scale_ts[0].numel() / hidden_dim;
+    }
+    TORCH_CHECK(num_tokens % n_rows == 0, "num_tokens (", num_tokens, ") must be divisible by n_rows (", n_rows, ")");
+    int64_t const tokens_per_batch = num_tokens / n_rows;
+
+    // Functional (no Tensor(a!) alias): for residual variants the kernel reads x (read-only) and
+    // writes the new residual stream x_new into a SEPARATE fresh buffer (params.x_out), returned as
+    // output[0]. No clone/copy of x -- alias-free for torch.compile (a mutable input + Tensor[]
+    // return is unsupported) AND strictly cheaper than an in-place op's auto_functionalize clone.
+    // Callers rebind x from the returned x_new (they never relied on in-place).
+    std::vector<torch::Tensor> outs;
+
+    tensorrt_llm::kernels::AdaLNNormParams params;
+    params.x = reinterpret_cast<__nv_bfloat16*>(x.data_ptr());
+    if (has_residual)
+    {
+        torch::Tensor x_new = torch::empty_like(x);
+        params.x_out = reinterpret_cast<__nv_bfloat16*>(x_new.data_ptr());
+        outs.push_back(std::move(x_new));
+    }
+    params.num_tokens = static_cast<int>(num_tokens);
+    params.tokens_per_batch = static_cast<int>(tokens_per_batch);
+    params.eps = static_cast<float>(eps);
+
+    if (has_residual)
+    {
+        torch::Tensor const& a = attn.value();
+        TORCH_CHECK(a.dim() >= 2 && a.sizes() == x.sizes(), "x and attn shape mismatch");
+        CHECK_INPUT(a, torch::kBFloat16);
+        params.attn = reinterpret_cast<__nv_bfloat16 const*>(a.data_ptr());
+    }
+    if (has_gate)
+    {
+        params.gate_ts_stride = check_modulator(gate_table.value(), gate_ts.value(), hidden_dim, n_rows, "gate");
+        params.gate_table = reinterpret_cast<float const*>(gate_table->data_ptr());
+        params.gate_ts = reinterpret_cast<__nv_bfloat16 const*>(gate_ts->data_ptr());
+    }
+    if (has_shift_scale)
+    {
+        for (int64_t k = 0; k < num_out; ++k)
+        {
+            params.scale_ts_stride[k] = check_modulator(scale_table[k], scale_ts[k], hidden_dim, n_rows, "scale");
+            params.shift_ts_stride[k] = check_modulator(shift_table[k], shift_ts[k], hidden_dim, n_rows, "shift");
+            params.scale_table[k] = reinterpret_cast<float const*>(scale_table[k].data_ptr());
+            params.scale_ts[k] = reinterpret_cast<__nv_bfloat16 const*>(scale_ts[k].data_ptr());
+            params.shift_table[k] = reinterpret_cast<float const*>(shift_table[k].data_ptr());
+            params.shift_ts[k] = reinterpret_cast<__nv_bfloat16 const*>(shift_ts[k].data_ptr());
+        }
+    }
+
+    // Allocate norm outputs and wire them into params (NUM_OUT entries; appended after x_new).
+    if (has_norm && !has_quant)
+    {
+        for (int64_t k = 0; k < num_out; ++k)
+        {
+            torch::Tensor o = torch::empty_like(x);
+            params.out_bf16[k] = reinterpret_cast<__nv_bfloat16*>(o.data_ptr());
+            outs.push_back(std::move(o));
+        }
+    }
+    else if (has_norm && has_quant)
+    {
+        auto opt_u8 = torch::TensorOptions().dtype(torch::kUInt8).device(x.device());
+        int64_t const sf_cols = hidden_dim / 16;
+        int64_t const padded_rows = (num_tokens + 127) / 128 * 128;
+        int64_t const padded_cols = (sf_cols + 3) / 4 * 4;
+        for (int64_t k = 0; k < num_out; ++k)
+        {
+            TORCH_CHECK(sf_scale[k].numel() >= 1, "sf_scale must contain at least 1 element");
+            CHECK_TYPE(sf_scale[k], torch::kFloat32);
+            torch::Tensor fp4 = torch::empty({num_tokens, hidden_dim / 2}, opt_u8);
+            torch::Tensor sf = torch::empty({padded_rows * padded_cols}, opt_u8);
+            params.out_fp4[k] = reinterpret_cast<uint32_t*>(fp4.data_ptr());
+            params.out_sf[k] = reinterpret_cast<uint32_t*>(sf.data_ptr());
+            params.sf_scale[k] = reinterpret_cast<float const*>(sf_scale[k].data_ptr());
+            outs.push_back(std::move(fp4));
+            outs.push_back(std::move(sf));
+        }
+    }
+
+    auto stream = at::cuda::getCurrentCUDAStream(x.get_device());
+    int const hd = static_cast<int>(hidden_dim);
+    // Hand the validated flags to the launcher, which maps them onto the kernel's compile-time
+    // specialization (the runtime->template dispatch lives in the kernel module, not here).
+    tensorrt_llm::kernels::launchFusedDiTGateResidNormShiftScaleKernel(
+        params, has_residual, has_gate, has_norm, has_shift_scale, has_quant, hd, stream);
+
+    return outs;
+}
+
+TORCH_LIBRARY_FRAGMENT(trtllm, m)
+{
+    m.def(
+        "fused_dit_gate_resid_norm_shift_scale("
+        "Tensor x, Tensor? attn=None, Tensor? gate_table=None, Tensor? gate_ts=None, "
+        "Tensor[]? scale_table=None, Tensor[]? scale_ts=None, Tensor[]? shift_table=None, Tensor[]? shift_ts=None, "
+        "Tensor[]? sf_scale=None, float eps=1e-6, int num_out=1) -> Tensor[]");
+}
+
+TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
+{
+    m.impl("fused_dit_gate_resid_norm_shift_scale", &fused_dit_gate_resid_norm_shift_scale);
+}
+
+} // namespace torch_ext
+
+TRTLLM_NAMESPACE_END

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -1283,6 +1283,52 @@ def _register_fake():
         output_sf = input.new_empty((scale_shape, ), dtype=torch.uint8)
         return output_fp4, output_sf
 
+    @torch.library.register_fake(
+        "trtllm::fused_dit_gate_resid_norm_shift_scale")
+    def _(x,
+          attn=None,
+          gate_table=None,
+          gate_ts=None,
+          scale_table=None,
+          scale_ts=None,
+          shift_table=None,
+          shift_ts=None,
+          sf_scale=None,
+          eps=1e-6,
+          num_out=1):
+        """Fake/meta for the unified fused DiT pre-block op (residual + gate +
+        RMSNorm + (dual) shift_scale + optional NVFP4 quant). Fully functional:
+        x is not mutated; for residual variants the new residual stream x_new is
+        returned as output[0] (callers rebind). All outputs are freshly allocated.
+        Optional list args default to None when the caller omits them.
+
+        Returns (x_new prepended iff residual; mirrors the CUDA op):
+          residual, num_out==0  -> [x_new]                                 (gate-residual only)
+          residual, bf16        -> [x_new, out_0, ..., out_{N-1}]
+          residual, quant       -> [x_new, fp4_0, sf_0, ..., fp4_{N-1}, sf_{N-1}]
+          no-residual, bf16     -> [out_0, ..., out_{N-1}]
+          no-residual, quant    -> [fp4_0, sf_0, ..., fp4_{N-1}, sf_{N-1}]   (128x4 SWIZZLED SF)
+        """
+        outs = []
+        if attn is not None:  # residual: x_new = output[0]
+            outs.append(torch.empty_like(x))
+        if num_out <= 0:
+            return outs
+        if not sf_scale:  # None (omitted) or empty -> bf16 outputs
+            outs.extend(torch.empty_like(x) for _ in range(num_out))
+            return outs
+        D = x.shape[-1]
+        M = 1
+        for d in x.shape[:-1]:
+            M *= d
+        _, scale_shape = fp4_utils.get_fp4_shape((M, D),
+                                                 16,
+                                                 is_swizzled_layout=True)
+        for _ in range(num_out):
+            outs.append(x.new_empty((M, D // 2), dtype=torch.uint8))
+            outs.append(x.new_empty((scale_shape, ), dtype=torch.uint8))
+        return outs
+
     @torch.library.register_fake("trtllm::convert_req_index_to_global")
     def _(req_id: torch.Tensor, block_table: torch.Tensor,
           token_indices: torch.Tensor, block_size: int, num_topk_tokens: int,

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/ltx2_core/utils_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/ltx2_core/utils_ltx2.py
@@ -2,7 +2,63 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 # SPDX-License-Identifier: LicenseRef-LTX-2
 
+from typing import Optional
+
 import torch
+
+from tensorrt_llm._torch.utils import Fp4QuantizedTensor
+
+# NVFP4 fused-quant AdaLN: every fused AdaLN CUDA kernel below has a ``_quant``
+# template specialization that emits packed FP4 + per-16-elem FP8 (e4m3) scale
+# factors (128x4 SWIZZLED layout) directly. Call sites pass ``fp4_input_scale``
+# (the calibrated NVFP4 ``input_scale`` of the downstream Linear) to dispatch
+# to the quant variant; passing ``None`` runs the bf16-output variant.
+
+
+def get_nvfp4_input_scale(linear) -> Optional[torch.Tensor]:
+    """Return the calibrated NVFP4 ``input_scale`` for a Linear-like module, or
+    None if the module isn't NVFP4-quantized or hasn't been calibrated.
+
+    Used by call sites to dispatch the fused-quant variant of the AdaLN wrappers
+    when the downstream Linear can consume a pre-quantized Fp4QuantizedTensor.
+    """
+    input_scale = getattr(linear, "input_scale", None)
+    if input_scale is None:
+        return None
+    # Need scaling_vector_size == 16 (NVFP4 group). Other configs not supported.
+    if getattr(linear, "scaling_vector_size", None) != 16:
+        return None
+    # The downstream Linear must be able to CONSUME a pre-quantized FP4 tensor. It cannot when it
+    # has to quantize activations locally: an NVFP4_AWQ pre_quant_scale must be folded into the (bf16)
+    # input first, or dynamic quantization recomputes input_scale per forward. In those cases our FP4
+    # output is rejected by NVFP4LinearMethod._input_prepare ("FP4 output was not disabled in the
+    # previous layer"); mirror that guard here and fall back to the bf16-output variant.
+    if getattr(linear, "pre_quant_scale", None) is not None:
+        return None
+    if getattr(linear, "force_dynamic_quantization", False):
+        return None
+    return input_scale
+
+
+def get_nvfp4_self_attn_input_scale(attn) -> Optional[torch.Tensor]:
+    """NVFP4 ``input_scale`` for fusing quant into a self-attention block's AdaLN, or None.
+
+    FUSE_QKV exposes a fused ``qkv_proj``; SEPARATE_QKV (which async-Ulysses
+    ``Attention.forward_async`` requires) exposes ``to_q``/``to_k``/``to_v`` instead. In
+    SEPARATE_QKV the three projections share ONE input quant only when
+    ``_maybe_share_qkv_quantize`` holds (modelopt calibrates q/k/v to the same input_scale);
+    there ``to_q``'s scale is the correct one for a single pre-quantized AdaLN output, which
+    ``forward_async`` then feeds to all three (0 extra quant launches). When there is no
+    ``qkv_proj`` and sharing is not eligible, return None so the AdaLN stays bf16 and each
+    projection quantizes itself. ``get_nvfp4_input_scale`` further returns None when the chosen
+    projection can't consume external FP4 (no input_scale / pre_quant_scale / forced-dynamic).
+    """
+    qkv_proj = getattr(attn, "qkv_proj", None)
+    if qkv_proj is not None:
+        return get_nvfp4_input_scale(qkv_proj)
+    if getattr(attn, "_maybe_share_qkv_quantize", False):
+        return get_nvfp4_input_scale(getattr(attn, "to_q", None))
+    return None
 
 
 def to_velocity(
@@ -33,3 +89,358 @@ def rms_norm(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
     Must match the reference: torch.nn.functional.rms_norm.
     """
     return torch.nn.functional.rms_norm(x, (x.shape[-1],), weight=None, eps=eps)
+
+
+# Hidden dims supported by the fused AdaLN CUDA kernels. Resolved once at
+# block construction into a boolean flag; call sites do not introspect tensors.
+# Non-matching shapes/dtypes raise from the kernel's TLLM_CHECK -- this module
+# does no runtime input validation.
+_FUSED_ADALN_SUPPORTED_DIMS = (2048, 4096)
+
+
+def is_fused_adaln_supported_dim(dim: int) -> bool:
+    return dim in _FUSED_ADALN_SUPPORTED_DIMS
+
+
+def _maybe_reshape_fp4(out_fp4: torch.Tensor, orig_shape: torch.Size, D: int) -> torch.Tensor:
+    """Reshape the kernel's flat [M, D/2] FP4 output back to the caller's
+    original rank (e.g. [B, S, D/2]) when the input was higher rank.
+    """
+    if len(orig_shape) != 2:
+        return out_fp4.reshape(*orig_shape[:-1], D // 2)
+    return out_fp4
+
+
+def apply_fused_rmsnorm_shift_scale(
+    x: torch.Tensor,
+    scale_table: torch.Tensor,
+    scale_ts: torch.Tensor,
+    shift_table: torch.Tensor,
+    shift_ts: torch.Tensor,
+    eps: float,
+    fuse: bool,
+    *,
+    fp4_input_scale: Optional[torch.Tensor] = None,
+) -> "torch.Tensor | Fp4QuantizedTensor":
+    """Fused RMSNorm + AdaLN affine modulation.
+
+    Modulator is composed inline by the C++ op:
+        scale[b, t, d] = scale_table[d] + scale_ts[b, t, d]
+        shift[b, t, d] = shift_table[d] + shift_ts[b, t, d]
+        out            = rms_norm(x) * (1 + scale) + shift
+
+    Returns bf16 when ``fp4_input_scale is None``, else an ``Fp4QuantizedTensor``
+    holding the packed FP4 + 128x4 SWIZZLED SF.
+
+    ``fuse`` is the top-level dispatch knob: when False, runs the eager torch
+    expression (always bf16 output; Linear handles its own quant -- see the
+    autotuner-bug note below). Resolve ``fuse`` once at module construction.
+    """
+    D = x.size(-1)
+
+    if not fuse:
+        # Eager fallback returns bf16 even when fp4_input_scale is provided: routing
+        # through tunable_fp4_quantize hits a known FP4 tactic bug on the audio
+        # CFG-doubled shape (252, 2048) -- "sfVecSize can only be 32, when sfUseUE8M0
+        # is true" -- that crashes pipeline load. Linear's internal quantize path
+        # bypasses the autotuner and works.
+        del fp4_input_scale
+        scale = scale_table.to(scale_ts.dtype) + scale_ts
+        shift = shift_table.to(shift_ts.dtype) + shift_ts
+        return rms_norm(x, eps=eps) * (1 + scale) + shift
+
+    assert x.is_contiguous(), "x must be contiguous (fused kernel assumes flat row layout)"
+
+    if fp4_input_scale is None:
+        (out,) = torch.ops.trtllm.fused_dit_gate_resid_norm_shift_scale(
+            x.view(-1, D),
+            scale_table=[scale_table],
+            scale_ts=[scale_ts],
+            shift_table=[shift_table],
+            shift_ts=[shift_ts],
+            eps=eps,
+        )
+        return out.view_as(x)
+
+    out_fp4, out_sf = torch.ops.trtllm.fused_dit_gate_resid_norm_shift_scale(
+        x.view(-1, D),
+        scale_table=[scale_table],
+        scale_ts=[scale_ts],
+        shift_table=[shift_table],
+        shift_ts=[shift_ts],
+        sf_scale=[fp4_input_scale],
+        eps=eps,
+    )
+    out_fp4 = _maybe_reshape_fp4(out_fp4, x.shape, D)
+    return Fp4QuantizedTensor(out_fp4, out_sf)
+
+
+def apply_shift_scale(
+    x_normed: torch.Tensor,
+    scale: torch.Tensor,
+    shift: torch.Tensor,
+) -> torch.Tensor:
+    """Affine-only AdaLN modulation: ``x_normed * (1 + scale) + shift``.
+
+    Used for the LTX-2 output head and rare cross-attention rms-precomputed
+    fallback sites (fires once per inference / never in the hot path). Always
+    runs eager -- the dedicated CUDA kernel was deleted because the saving on
+    these rare call sites did not justify the maintenance burden.
+    """
+    return x_normed * (1 + scale) + shift
+
+
+def apply_fused_gate_resid_rmsnorm_shift_scale(
+    x: torch.Tensor,
+    attn: torch.Tensor,
+    gate_table: torch.Tensor,
+    gate_ts: torch.Tensor,
+    scale_table: torch.Tensor,
+    scale_ts: torch.Tensor,
+    shift_table: torch.Tensor,
+    shift_ts: torch.Tensor,
+    eps: float,
+    fuse: bool,
+    *,
+    fp4_input_scale: Optional[torch.Tensor] = None,
+) -> "tuple[torch.Tensor, torch.Tensor] | tuple[torch.Tensor, Fp4QuantizedTensor]":
+    """Fused gate-residual + RMSNorm + shift_scale:
+    ``x_new = x + attn * gate``; ``normed = rms_norm(x_new)``;
+    ``out = (1+scale)*normed + shift``.
+
+    Each modulator is built inline by the C++ op:
+        gate[b,t,d]  = gate_table[d]  + gate_ts[b,t,d]
+        scale[b,t,d] = scale_table[d] + scale_ts[b,t,d]
+        shift[b,t,d] = shift_table[d] + shift_ts[b,t,d]
+
+    Returns ``(x_new, out_shift_scaled)``. The op is functional: ``x`` is read-only
+    and ``x_new`` is a fresh buffer (callers rebind ``x`` to the result).
+
+    When ``fp4_input_scale`` is provided, the second tuple element is an
+    ``Fp4QuantizedTensor`` holding packed FP4 + 128x4 SWIZZLED SF instead of bf16.
+    """
+    D = x.size(-1)
+
+    if not fuse:
+        # Eager fallback: bf16 output (see apply_fused_rmsnorm_shift_scale autotuner-bug note).
+        del fp4_input_scale
+        gate = gate_table.to(gate_ts.dtype) + gate_ts
+        scale = scale_table.to(scale_ts.dtype) + scale_ts
+        shift = shift_table.to(shift_ts.dtype) + shift_ts
+        x_new = x + attn * gate
+        normed = rms_norm(x_new, eps=eps)
+        return x_new, normed * (1 + scale) + shift
+
+    assert x.is_contiguous(), "x must be contiguous (fused kernel assumes flat row layout)"
+    assert attn.is_contiguous(), "attn must be contiguous"
+
+    if fp4_input_scale is None:
+        x_new, out = torch.ops.trtllm.fused_dit_gate_resid_norm_shift_scale(
+            x.view(-1, D),
+            attn=attn.view(-1, D),
+            gate_table=gate_table,
+            gate_ts=gate_ts,
+            scale_table=[scale_table],
+            scale_ts=[scale_ts],
+            shift_table=[shift_table],
+            shift_ts=[shift_ts],
+            eps=eps,
+        )
+        return x_new.view_as(x), out.view_as(x)
+
+    x_new, out_fp4, out_sf = torch.ops.trtllm.fused_dit_gate_resid_norm_shift_scale(
+        x.view(-1, D),
+        attn=attn.view(-1, D),
+        gate_table=gate_table,
+        gate_ts=gate_ts,
+        scale_table=[scale_table],
+        scale_ts=[scale_ts],
+        shift_table=[shift_table],
+        shift_ts=[shift_ts],
+        sf_scale=[fp4_input_scale],
+        eps=eps,
+    )
+    out_fp4 = _maybe_reshape_fp4(out_fp4, x.shape, D)
+    return x_new.view_as(x), Fp4QuantizedTensor(out_fp4, out_sf)
+
+
+def apply_fused_gate_resid_rmsnorm(
+    x: torch.Tensor,
+    attn_out: torch.Tensor,
+    gate_table: torch.Tensor,
+    gate_ts: torch.Tensor,
+    eps: float,
+    fuse: bool,
+    *,
+    fp4_input_scale: Optional[torch.Tensor] = None,
+) -> "tuple[torch.Tensor, torch.Tensor] | tuple[torch.Tensor, Fp4QuantizedTensor]":
+    """Fused gate-residual + RMSNorm (no shift_scale):
+    ``x_new = x + attn_out * gate``; ``normed = rms_norm(x_new)``; optional
+    NVFP4 quant of ``normed``.
+
+    Gate modulator is composed inline by the C++ op from a (table, ts) pair:
+        gate[b, t, d] = gate_table[d].to(bf16) + gate_ts[b, t, d]
+    The kernel folds the broadcast-add prep AND the ``attn * gate`` mul into Phase 0b.
+
+    Used between MSA self-attn and text cross-attn. Any perturbation mask is applied
+    to ``attn_out`` BEFORE this call (mask is commutative with the gate multiply).
+
+    Returns ``(x_new, normed)`` (or ``(x_new, Fp4QuantizedTensor)`` when
+    ``fp4_input_scale`` is provided). The op is functional: ``x`` is read-only
+    and ``x_new`` is a fresh buffer (callers rebind ``x`` to the result).
+    """
+    D = x.size(-1)
+
+    if not fuse:
+        # Eager fallback: bf16 output (see apply_fused_rmsnorm_shift_scale autotuner-bug note).
+        del fp4_input_scale
+        gate = gate_table.to(gate_ts.dtype) + gate_ts
+        x_new = x + attn_out * gate
+        return x_new, rms_norm(x_new, eps=eps)
+
+    assert x.is_contiguous(), "x must be contiguous (fused kernel assumes flat row layout)"
+    assert attn_out.is_contiguous(), "attn_out must be contiguous"
+
+    if fp4_input_scale is not None:
+        # Quant variant: residual_add + gate_mul + rms_norm + NVFP4 quant in one kernel.
+        # Kernel returns flat [num_tokens, D/2] FP4; reshape back to caller's
+        # rank so downstream (e.g. attn2 Q-norm) sees the same [B, S, D/2].
+        x_new, out_fp4, out_sf = torch.ops.trtllm.fused_dit_gate_resid_norm_shift_scale(
+            x.view(-1, D),
+            attn=attn_out.view(-1, D),
+            gate_table=gate_table,
+            gate_ts=gate_ts,
+            sf_scale=[fp4_input_scale],
+            eps=eps,
+        )
+        out_fp4 = _maybe_reshape_fp4(out_fp4, x.shape, D)
+        return x_new.view_as(x), Fp4QuantizedTensor(out_fp4, out_sf)
+
+    # bf16 variant: residual_add + gate_mul + rms_norm, no quant.
+    x_new, out = torch.ops.trtllm.fused_dit_gate_resid_norm_shift_scale(
+        x.view(-1, D), attn=attn_out.view(-1, D), gate_table=gate_table, gate_ts=gate_ts, eps=eps
+    )
+    return x_new.view_as(x), out.view_as(x)
+
+
+def apply_fused_gate_resid(
+    x: torch.Tensor,
+    attn_out: torch.Tensor,
+    gate_table: torch.Tensor,
+    gate_ts: torch.Tensor,
+    fuse: bool,
+) -> torch.Tensor:
+    """Fused gate-residual (no RMSNorm, no shift_scale):
+    ``gate[b,d] = gate_table[d].to(bf16) + gate_ts[b,d]``
+    ``x_new   = x + attn_out * gate``
+
+    Used by the FFN output gate site: ``vx = vx + ff(vx_scaled) * vgate_mlp``,
+    where ``(gate_table, gate_ts)`` is the pair-form of the FFN gate modulator
+    (slot 5 of the AdaLN table). Functional: ``x`` is read-only; ``x_new`` is a fresh buffer.
+    """
+    D = x.size(-1)
+
+    if not fuse:
+        # Eager fallback: gate = gate_table + gate_ts is [B, T_t, D]; reshape x/attn to
+        # [B, T, D] (T via -1 to stay torch.compile-safe under symbolic shapes) so the
+        # per-batch gate broadcasts over the T tokens. ``view(B, -1, D)`` avoids the
+        # static reshape of the symbolic T_t dim that a ``gate_ts.view(B, D)`` would force.
+        gate = gate_table.to(gate_ts.dtype) + gate_ts
+        B = gate_ts.shape[0]
+        return (x.view(B, -1, D) + attn_out.view(B, -1, D) * gate).view_as(x)
+
+    assert x.is_contiguous(), "x must be contiguous (fused kernel assumes flat row layout)"
+    assert attn_out.is_contiguous(), "attn_out must be contiguous"
+    # num_out=0 -> gate-residual only (no norm): op returns [x_new] (x + attn_out * gate).
+    (x_new,) = torch.ops.trtllm.fused_dit_gate_resid_norm_shift_scale(
+        x.view(-1, D), attn=attn_out.view(-1, D), gate_table=gate_table, gate_ts=gate_ts, num_out=0
+    )
+    return x_new.view_as(x)
+
+
+def apply_fused_resid_rmsnorm_shift_scale_dual(
+    x: torch.Tensor,
+    attn2_out: torch.Tensor,
+    scale1_table: torch.Tensor,
+    scale1_ts: torch.Tensor,
+    shift1_table: torch.Tensor,
+    shift1_ts: torch.Tensor,
+    scale2_table: torch.Tensor,
+    scale2_ts: torch.Tensor,
+    shift2_table: torch.Tensor,
+    shift2_ts: torch.Tensor,
+    eps: float,
+    fuse: bool,
+    *,
+    fp4_input_scale1: Optional[torch.Tensor] = None,
+    fp4_input_scale2: Optional[torch.Tensor] = None,
+) -> (
+    "tuple[torch.Tensor, torch.Tensor, torch.Tensor] "
+    "| tuple[torch.Tensor, Fp4QuantizedTensor, Fp4QuantizedTensor]"
+):
+    """Fused residual + RMSNorm + dual shift_scale:
+    ``x_new = x + attn2_out``; ``normed = rms_norm(x_new)``;
+    ``out1 = (1+scale1)*normed + shift1``; ``out2 = (1+scale2)*normed + shift2``.
+
+    Each modulator is built inline by the C++ op:
+        m[b,t,d] = m_table[d].to(bf16) + m_ts[b,t,d]    (bf16 narrow first, bf16 add)
+
+    Returns ``(x_new, out1, out2)``. The op is functional: ``x`` is read-only
+    and ``x_new`` is a fresh buffer (callers rebind ``x`` to the result).
+
+    When both ``fp4_input_scale1`` and ``fp4_input_scale2`` are provided, the
+    second and third tuple elements are ``Fp4QuantizedTensor`` (FP4 + SWIZZLED SF).
+    Both must be either present or absent together (the kernel takes both or neither).
+    """
+    D = x.size(-1)
+
+    if not fuse:
+        # Eager fallback: bf16 outputs (see apply_fused_rmsnorm_shift_scale autotuner-bug note).
+        del fp4_input_scale1, fp4_input_scale2
+        scale1 = scale1_table.to(scale1_ts.dtype) + scale1_ts
+        shift1 = shift1_table.to(shift1_ts.dtype) + shift1_ts
+        scale2 = scale2_table.to(scale2_ts.dtype) + scale2_ts
+        shift2 = shift2_table.to(shift2_ts.dtype) + shift2_ts
+        x_new = x + attn2_out
+        normed = rms_norm(x_new, eps=eps)
+        return x_new, normed * (1 + scale1) + shift1, normed * (1 + scale2) + shift2
+
+    assert x.is_contiguous(), "x must be contiguous (fused kernel assumes flat row layout)"
+    assert attn2_out.is_contiguous(), "attn2_out must be contiguous"
+
+    if fp4_input_scale1 is None and fp4_input_scale2 is None:
+        x_new, out1, out2 = torch.ops.trtllm.fused_dit_gate_resid_norm_shift_scale(
+            x.view(-1, D),
+            attn=attn2_out.view(-1, D),
+            scale_table=[scale1_table, scale2_table],
+            scale_ts=[scale1_ts, scale2_ts],
+            shift_table=[shift1_table, shift2_table],
+            shift_ts=[shift1_ts, shift2_ts],
+            eps=eps,
+            num_out=2,
+        )
+        return x_new.view_as(x), out1.view_as(x), out2.view_as(x)
+
+    assert fp4_input_scale1 is not None and fp4_input_scale2 is not None, (
+        "dual fp4: both input_scales must be provided or both absent"
+    )
+    x_new, out1_fp4, out1_sf, out2_fp4, out2_sf = (
+        torch.ops.trtllm.fused_dit_gate_resid_norm_shift_scale(
+            x.view(-1, D),
+            attn=attn2_out.view(-1, D),
+            scale_table=[scale1_table, scale2_table],
+            scale_ts=[scale1_ts, scale2_ts],
+            shift_table=[shift1_table, shift2_table],
+            shift_ts=[shift1_ts, shift2_ts],
+            sf_scale=[fp4_input_scale1, fp4_input_scale2],
+            eps=eps,
+            num_out=2,
+        )
+    )
+    out1_fp4 = _maybe_reshape_fp4(out1_fp4, x.shape, D)
+    out2_fp4 = _maybe_reshape_fp4(out2_fp4, x.shape, D)
+    return (
+        x_new.view_as(x),
+        Fp4QuantizedTensor(out1_fp4, out1_sf),
+        Fp4QuantizedTensor(out2_fp4, out2_sf),
+    )

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
@@ -49,7 +49,18 @@ from .ltx2_core.transformer_args import (
     TransformerArgs,
     TransformerArgsPreprocessor,
 )
-from .ltx2_core.utils_ltx2 import rms_norm
+from .ltx2_core.utils_ltx2 import (
+    apply_fused_gate_resid,
+    apply_fused_gate_resid_rmsnorm,
+    apply_fused_gate_resid_rmsnorm_shift_scale,
+    apply_fused_resid_rmsnorm_shift_scale_dual,
+    apply_fused_rmsnorm_shift_scale,
+    apply_shift_scale,
+    get_nvfp4_input_scale,
+    get_nvfp4_self_attn_input_scale,
+    is_fused_adaln_supported_dim,
+    rms_norm,
+)
 from .text_cache import TextCache
 
 if TYPE_CHECKING:
@@ -560,6 +571,14 @@ class BasicAVTransformerBlock(nn.Module):
         self._sharder = SequenceSharder.from_vgm(vgm)
         self._audio_is_sharded = False
 
+        # Whether to dispatch AdaLN modulation to the fused CUDA kernels. Resolved
+        # once at construction; call sites just consult the flag. The kernels are
+        # bf16 + hidden_dim in {2048, 4096}; non-matching cases raise at the C++
+        # boundary -- this flag is the only Python-side guard.
+        video_supports_fused_adaln = video is None or is_fused_adaln_supported_dim(video.dim)
+        audio_supports_fused_adaln = audio is None or is_fused_adaln_supported_dim(audio.dim)
+        self._fuse_adaln = video_supports_fused_adaln and audio_supports_fused_adaln
+
         if video is not None:
             self._init_video_modules(video, rope_type, norm_eps, config, idx)
 
@@ -701,15 +720,41 @@ class BasicAVTransformerBlock(nn.Module):
         timestep: torch.Tensor,
         indices: slice,
     ) -> tuple[torch.Tensor, ...]:
+        """Combined-form AdaLN values for the slots in ``indices``. Returns one bf16
+        ``[batch_size, T, D]`` tensor per slot (broadcast-add of ``scale_shift_table``
+        cast to bf16 + ``timestep`` reshaped to per-slot views, then unbound on the
+        slot axis).
+        """
         num_ada_params = scale_shift_table.shape[0]
-        ada_values = (
+        return (
             scale_shift_table[indices]
             .unsqueeze(0)
             .unsqueeze(0)
             .to(device=timestep.device, dtype=timestep.dtype)
             + timestep.reshape(batch_size, timestep.shape[1], num_ada_params, -1)[:, :, indices, :]
         ).unbind(dim=2)
-        return ada_values
+
+    @staticmethod
+    def _get_ada_table_ts_pairs(
+        scale_shift_table: torch.Tensor,
+        batch_size: int,
+        timestep: torch.Tensor,
+        indices: slice,
+    ) -> tuple[tuple[torch.Tensor, torch.Tensor], ...]:
+        """Pair-form companion to ``_get_ada_values``: returns one ``(table_slice, ts_slice)``
+        pair per slot in ``indices`` without materializing the broadcast-add. Consumers that
+        fuse the add into a downstream kernel (Phase 0b of the fused C++ ops) accept the pair
+        directly; the broadcast-add then becomes dead code and is DCE'd by Inductor when no
+        combined-form slot from the same range is consumed elsewhere.
+
+        Returns a tuple of (table_slice fp32 [D], ts_slice bf16 [B, T, D]) per slot.
+        """
+        num_ada_params = scale_shift_table.shape[0]
+        ts_reshaped = timestep.reshape(batch_size, timestep.shape[1], num_ada_params, -1)
+        return tuple(
+            (scale_shift_table[i], ts_reshaped[:, :, i, :])
+            for i in range(*indices.indices(num_ada_params))
+        )
 
     @staticmethod
     def _get_av_ca_ada_values(
@@ -744,6 +789,38 @@ class BasicAVTransformerBlock(nn.Module):
         ss_chunks = [t.squeeze(2) for t in ss_vals]
         gate_chunks = [t.squeeze(2) for t in gate_vals]
         return (*ss_chunks, *gate_chunks)
+
+    @staticmethod
+    def _get_av_ca_ada_table_ts_pairs(
+        scale_shift_table: torch.Tensor,
+        batch_size: int,
+        scale_shift_timestep: torch.Tensor,
+        gate_timestep: torch.Tensor,
+        num_scale_shift_values: int = 4,
+    ) -> tuple[tuple[torch.Tensor, torch.Tensor], ...]:
+        """Pair-form companion to ``_get_av_ca_ada_values``: returns one
+        ``(table_slice fp32 [D], ts_slice bf16 [B, T, D])`` pair per slot. The first
+        ``num_scale_shift_values`` slots use ``scale_shift_timestep``; the remaining
+        slots use ``gate_timestep``. Consumers that fuse the broadcast-add into a
+        downstream kernel accept the pair directly.
+        """
+        num_ada_params = scale_shift_table.shape[0]
+        num_gate_values = num_ada_params - num_scale_shift_values
+        ss_table = scale_shift_table[:num_scale_shift_values, :]
+        gate_table = scale_shift_table[num_scale_shift_values:, :]
+        ss_ts_reshaped = scale_shift_timestep.reshape(
+            batch_size, scale_shift_timestep.shape[1], num_scale_shift_values, -1
+        )
+        gate_ts_reshaped = gate_timestep.reshape(
+            batch_size, gate_timestep.shape[1], num_gate_values, -1
+        )
+        ss_pairs = tuple(
+            (ss_table[i], ss_ts_reshaped[:, :, i, :]) for i in range(num_scale_shift_values)
+        )
+        gate_pairs = tuple(
+            (gate_table[i], gate_ts_reshaped[:, :, i, :]) for i in range(num_gate_values)
+        )
+        return (*ss_pairs, *gate_pairs)
 
     # -- Sequence-parallel helpers for AV cross-attention ----------------------
 
@@ -788,72 +865,127 @@ class BasicAVTransformerBlock(nn.Module):
             perturbations, BatchedPerturbationConfig
         )
 
+        # Cross-block attention outputs are always parked in ``*_attn_raw`` slots so
+        # that the next block's fused kernel can absorb the residual add into its own
+        # first stage. Consumers bifurcate on ``... is not None``; producers always
+        # defer (the only fast-path that wins is the one where the next fused kernel
+        # exists). The AV-CA-skipped cleanup below handles single-modality models
+        # where the consumer block doesn't run at all.
+        av_ca_runs = run_a2v or run_v2a
+        text_v_attn_raw = None
+        text_a_attn_raw = None
+        a2v_attn_raw = None
+        v2a_attn_raw = None
+
         # --- Video self-attention + text cross-attention ---
         if run_vx:
             skip_v_self = has_perturbations and perturbations.all_in_batch(
                 PerturbationType.SKIP_VIDEO_SELF_ATTN, self.idx
             )
-            vshift_msa, vscale_msa, vgate_msa = self._get_ada_values(
-                self.scale_shift_table, vx.shape[0], video.timesteps, slice(0, 3)
-            )
             if not skip_v_self:
-                norm_vx = rms_norm(vx, eps=self.norm_eps) * (1 + vscale_msa) + vshift_msa
-                v_self_out = (
-                    self.attn1(
-                        norm_vx,
-                        pe=video.positional_embeddings,
-                        timestep=video.timesteps,
-                    )
-                    * vgate_msa
+                # MSA modulators in pair form: slot 0 = shift_msa, 1 = scale_msa, 2 = gate_msa.
+                (
+                    (vshift_msa_table, vshift_msa_ts),
+                    (vscale_msa_table, vscale_msa_ts),
+                    (vgate_msa_table, vgate_msa_ts),
+                ) = self._get_ada_table_ts_pairs(
+                    self.scale_shift_table, vx.shape[0], video.timesteps, slice(0, 3)
+                )
+                norm_vx = apply_fused_rmsnorm_shift_scale(
+                    vx,
+                    vscale_msa_table,
+                    vscale_msa_ts,
+                    vshift_msa_table,
+                    vshift_msa_ts,
+                    self.norm_eps,
+                    self._fuse_adaln,
+                    fp4_input_scale=get_nvfp4_self_attn_input_scale(self.attn1),
+                )
+                v_attn_raw = self.attn1(
+                    norm_vx, pe=video.positional_embeddings, timestep=video.timesteps
                 )
                 if has_perturbations and perturbations.any_in_batch(
                     PerturbationType.SKIP_VIDEO_SELF_ATTN, self.idx
                 ):
-                    v_self_out = v_self_out * perturbations.mask_like(
-                        PerturbationType.SKIP_VIDEO_SELF_ATTN, self.idx, v_self_out
+                    # Mask commutes with the gate mul: (attn * mask) * gate == attn * (gate * mask).
+                    v_attn_raw = v_attn_raw * perturbations.mask_like(
+                        PerturbationType.SKIP_VIDEO_SELF_ATTN, self.idx, v_attn_raw
                     )
-                vx = vx + v_self_out
-            vx = vx + self.attn2(
-                rms_norm(vx, eps=self.norm_eps),
+                # Fused gate-residual + RMSNorm (+ optional FP4 quant):
+                # vx <- vx + v_attn_raw * gate_msa; rms_norm; optional FP4 quant.
+                vx, attn2_q_input = apply_fused_gate_resid_rmsnorm(
+                    vx,
+                    v_attn_raw,
+                    vgate_msa_table,
+                    vgate_msa_ts,
+                    self.norm_eps,
+                    self._fuse_adaln,
+                    fp4_input_scale=get_nvfp4_input_scale(self.attn2.to_q),
+                )
+            else:
+                attn2_q_input = rms_norm(vx, eps=self.norm_eps)
+            text_v_attn_raw = self.attn2(
+                attn2_q_input,
                 context=video.context,
                 pre_projected_kv=text_kv_video,
                 timestep=video.timesteps,
             )
-            del vshift_msa, vscale_msa, vgate_msa
 
         # --- Audio self-attention + text cross-attention ---
         if run_ax:
             skip_a_self = has_perturbations and perturbations.all_in_batch(
                 PerturbationType.SKIP_AUDIO_SELF_ATTN, self.idx
             )
-            ashift_msa, ascale_msa, agate_msa = self._get_ada_values(
-                self.audio_scale_shift_table, ax.shape[0], audio.timesteps, slice(0, 3)
-            )
             if not skip_a_self:
-                norm_ax = rms_norm(ax, eps=self.norm_eps) * (1 + ascale_msa) + ashift_msa
-                a_self_out = (
-                    self.audio_attn1(
-                        norm_ax,
-                        pe=audio.positional_embeddings,
-                        key_padding_mask=audio.audio_padding_mask,
-                        timestep=audio.timesteps,
-                    )
-                    * agate_msa
+                # MSA modulators in pair form: slot 0 = shift_msa, 1 = scale_msa, 2 = gate_msa.
+                (
+                    (ashift_msa_table, ashift_msa_ts),
+                    (ascale_msa_table, ascale_msa_ts),
+                    (agate_msa_table, agate_msa_ts),
+                ) = self._get_ada_table_ts_pairs(
+                    self.audio_scale_shift_table, ax.shape[0], audio.timesteps, slice(0, 3)
+                )
+                norm_ax = apply_fused_rmsnorm_shift_scale(
+                    ax,
+                    ascale_msa_table,
+                    ascale_msa_ts,
+                    ashift_msa_table,
+                    ashift_msa_ts,
+                    self.norm_eps,
+                    self._fuse_adaln,
+                    fp4_input_scale=get_nvfp4_self_attn_input_scale(self.audio_attn1),
+                )
+                a_attn_raw = self.audio_attn1(
+                    norm_ax,
+                    pe=audio.positional_embeddings,
+                    key_padding_mask=audio.audio_padding_mask,
+                    timestep=audio.timesteps,
                 )
                 if has_perturbations and perturbations.any_in_batch(
                     PerturbationType.SKIP_AUDIO_SELF_ATTN, self.idx
                 ):
-                    a_self_out = a_self_out * perturbations.mask_like(
-                        PerturbationType.SKIP_AUDIO_SELF_ATTN, self.idx, a_self_out
+                    a_attn_raw = a_attn_raw * perturbations.mask_like(
+                        PerturbationType.SKIP_AUDIO_SELF_ATTN, self.idx, a_attn_raw
                     )
-                ax = ax + a_self_out
-            ax = ax + self.audio_attn2(
-                rms_norm(ax, eps=self.norm_eps),
+                # Fused gate-residual + RMSNorm (+ optional FP4 quant):
+                # ax <- ax + a_attn_raw * gate_msa; rms_norm; optional FP4 quant.
+                ax, audio_attn2_q_input = apply_fused_gate_resid_rmsnorm(
+                    ax,
+                    a_attn_raw,
+                    agate_msa_table,
+                    agate_msa_ts,
+                    self.norm_eps,
+                    self._fuse_adaln,
+                    fp4_input_scale=get_nvfp4_input_scale(self.audio_attn2.to_q),
+                )
+            else:
+                audio_attn2_q_input = rms_norm(ax, eps=self.norm_eps)
+            text_a_attn_raw = self.audio_attn2(
+                audio_attn2_q_input,
                 context=audio.context,
                 pre_projected_kv=text_kv_audio,
                 timestep=audio.timesteps,
             )
-            del ashift_msa, ascale_msa, agate_msa
 
         # --- Bidirectional audio ↔ video cross-attention ---
         if run_a2v or run_v2a:
@@ -864,39 +996,120 @@ class BasicAVTransformerBlock(nn.Module):
                 PerturbationType.SKIP_V2A_CROSS_ATTN, self.idx
             )
 
-            vx_norm3 = rms_norm(vx, eps=self.norm_eps)
-            ax_norm3 = rms_norm(ax, eps=self.norm_eps)
+            # Fused residual + RMSNorm + dual shift_scale (per modality) consumes
+            # the deferred text-attn residual. Fallback when text_*_attn_raw is None
+            # (residual already added in place): do RMSNorm + two individual shift_scale calls.
+            if text_v_attn_raw is not None:
+                # Pass NVFP4 input_scales to also emit packed FP4 + 128x4 SWIZZLED SF
+                # for the downstream cross-attn Q/K projections (the wrapper handles
+                # None vs not-None uniformly and falls back gracefully when fuse=False).
+                # Pair-form for the AV CA video table: 4 ss pairs (cross_scale_shift_timestep)
+                # plus 1 gate pair (cross_gate_timestep). The fused kernel consumes the 4 ss
+                # pairs; the gate pair is unused here (the a2v cross-attn output is not gated).
+                (
+                    (v_scale_a2v_table, v_scale_a2v_ts),
+                    (v_shift_a2v_table, v_shift_a2v_ts),
+                    (v_scale_v2a_table, v_scale_v2a_ts),
+                    (v_shift_v2a_table, v_shift_v2a_ts),
+                    _,
+                ) = self._get_av_ca_ada_table_ts_pairs(
+                    self.scale_shift_table_a2v_ca_video,
+                    vx.shape[0],
+                    video.cross_scale_shift_timestep,
+                    video.cross_gate_timestep,
+                )
+                vx, vx_scaled_a2v, vx_scaled_v2a = apply_fused_resid_rmsnorm_shift_scale_dual(
+                    vx,
+                    text_v_attn_raw,
+                    v_scale_a2v_table,
+                    v_scale_a2v_ts,
+                    v_shift_a2v_table,
+                    v_shift_a2v_ts,
+                    v_scale_v2a_table,
+                    v_scale_v2a_ts,
+                    v_shift_v2a_table,
+                    v_shift_v2a_ts,
+                    self.norm_eps,
+                    fuse=self._fuse_adaln,
+                    fp4_input_scale1=get_nvfp4_input_scale(self.audio_to_video_attn.to_q),
+                    fp4_input_scale2=get_nvfp4_input_scale(self.video_to_audio_attn.to_k),
+                )
+            else:
+                # Combined-form modulators only needed on the eager fallback; the gate
+                # output is unused (the gated residual is folded into the next fused kernel).
+                (
+                    scale_ca_video_a2v,
+                    shift_ca_video_a2v,
+                    scale_ca_video_v2a,
+                    shift_ca_video_v2a,
+                    _,
+                ) = self._get_av_ca_ada_values(
+                    self.scale_shift_table_a2v_ca_video,
+                    vx.shape[0],
+                    video.cross_scale_shift_timestep,
+                    video.cross_gate_timestep,
+                )
+                vx_norm3 = rms_norm(vx, eps=self.norm_eps)
+                vx_scaled_a2v = apply_shift_scale(vx_norm3, scale_ca_video_a2v, shift_ca_video_a2v)
+                vx_scaled_v2a = apply_shift_scale(vx_norm3, scale_ca_video_v2a, shift_ca_video_v2a)
 
-            (
-                scale_ca_audio_a2v,
-                shift_ca_audio_a2v,
-                scale_ca_audio_v2a,
-                shift_ca_audio_v2a,
-                gate_out_v2a,
-            ) = self._get_av_ca_ada_values(
-                self.scale_shift_table_a2v_ca_audio,
-                ax.shape[0],
-                audio.cross_scale_shift_timestep,
-                audio.cross_gate_timestep,
-            )
+            if text_a_attn_raw is not None:
+                # Dual-shift_scale for the audio side (a2v consumes ax K side, v2a consumes ax Q side).
+                # Pair-form for the AV CA audio table: 4 ss pairs (cross_scale_shift_timestep)
+                # plus 1 gate pair (cross_gate_timestep). The fused kernel consumes the 4 ss
+                # pairs; the gate pair is unused here (the v2a cross-attn output is not gated).
+                (
+                    (a_scale_a2v_table, a_scale_a2v_ts),
+                    (a_shift_a2v_table, a_shift_a2v_ts),
+                    (a_scale_v2a_table, a_scale_v2a_ts),
+                    (a_shift_v2a_table, a_shift_v2a_ts),
+                    _,
+                ) = self._get_av_ca_ada_table_ts_pairs(
+                    self.scale_shift_table_a2v_ca_audio,
+                    ax.shape[0],
+                    audio.cross_scale_shift_timestep,
+                    audio.cross_gate_timestep,
+                )
+                ax, ax_scaled_a2v, ax_scaled_v2a = apply_fused_resid_rmsnorm_shift_scale_dual(
+                    ax,
+                    text_a_attn_raw,
+                    a_scale_a2v_table,
+                    a_scale_a2v_ts,
+                    a_shift_a2v_table,
+                    a_shift_a2v_ts,
+                    a_scale_v2a_table,
+                    a_scale_v2a_ts,
+                    a_shift_v2a_table,
+                    a_shift_v2a_ts,
+                    self.norm_eps,
+                    fuse=self._fuse_adaln,
+                    fp4_input_scale1=get_nvfp4_input_scale(self.audio_to_video_attn.to_k),
+                    fp4_input_scale2=get_nvfp4_input_scale(self.video_to_audio_attn.to_q),
+                )
+            else:
+                # Combined-form modulators only needed on the eager fallback; the gate
+                # output is unused (the gated residual is folded into the next fused kernel).
+                (
+                    scale_ca_audio_a2v,
+                    shift_ca_audio_a2v,
+                    scale_ca_audio_v2a,
+                    shift_ca_audio_v2a,
+                    _,
+                ) = self._get_av_ca_ada_values(
+                    self.scale_shift_table_a2v_ca_audio,
+                    ax.shape[0],
+                    audio.cross_scale_shift_timestep,
+                    audio.cross_gate_timestep,
+                )
+                ax_norm3 = rms_norm(ax, eps=self.norm_eps)
+                ax_scaled_a2v = apply_shift_scale(ax_norm3, scale_ca_audio_a2v, shift_ca_audio_a2v)
+                ax_scaled_v2a = apply_shift_scale(ax_norm3, scale_ca_audio_v2a, shift_ca_audio_v2a)
 
-            (
-                scale_ca_video_a2v,
-                shift_ca_video_a2v,
-                scale_ca_video_v2a,
-                shift_ca_video_v2a,
-                gate_out_a2v,
-            ) = self._get_av_ca_ada_values(
-                self.scale_shift_table_a2v_ca_video,
-                vx.shape[0],
-                video.cross_scale_shift_timestep,
-                video.cross_gate_timestep,
-            )
-
+            # a2v / v2a outputs are parked in ``*_attn_raw`` (see above). Per-batch SKIP
+            # perturbation masks are pre-multiplied onto the attn output here, since the
+            # kernel takes no mask input. Math is preserved: (attn * mask) * gate ==
+            # (attn * gate) * mask because mask is per-batch and gate is per-feature.
             if run_a2v and not skip_a2v:
-                vx_scaled = vx_norm3 * (1 + scale_ca_video_a2v) + shift_ca_video_a2v
-                ax_scaled = ax_norm3 * (1 + scale_ca_audio_a2v) + shift_ca_audio_a2v
-
                 # Project-before-gather: K/V projections run on sharded data
                 # so they benefit from Ulysses scaling.  RoPE is applied to K
                 # inside project_kv on the sharded shard (RoPE commutes with
@@ -907,34 +1120,27 @@ class BasicAVTransformerBlock(nn.Module):
                 # key_padding_mask zeros attention on the audio pad slots that
                 # configure_audio_ulysses appended to make T_a divisible by U.
                 k_a2v, v_a2v = self.audio_to_video_attn.project_kv(
-                    ax_scaled, pe=audio.cross_positional_embeddings
+                    ax_scaled_a2v, pe=audio.cross_positional_embeddings
                 )
                 if self._audio_is_sharded:
                     k_a2v = self._sp_all_gather(k_a2v)
                     v_a2v = self._sp_all_gather(v_a2v)
 
-                a2v_out = (
-                    self.audio_to_video_attn(
-                        vx_scaled,
-                        pre_projected_kv=(k_a2v, v_a2v),
-                        pe=video.cross_positional_embeddings,
-                        key_padding_mask=audio.audio_padding_mask,
-                        timestep=video.timesteps,
-                    )
-                    * gate_out_a2v
+                a2v_attn_raw = self.audio_to_video_attn(
+                    vx_scaled_a2v,
+                    pre_projected_kv=(k_a2v, v_a2v),
+                    pe=video.cross_positional_embeddings,
+                    key_padding_mask=audio.audio_padding_mask,
+                    timestep=video.timesteps,
                 )
                 if has_perturbations and perturbations.any_in_batch(
                     PerturbationType.SKIP_A2V_CROSS_ATTN, self.idx
                 ):
-                    a2v_out = a2v_out * perturbations.mask_like(
-                        PerturbationType.SKIP_A2V_CROSS_ATTN, self.idx, a2v_out
+                    a2v_attn_raw = a2v_attn_raw * perturbations.mask_like(
+                        PerturbationType.SKIP_A2V_CROSS_ATTN, self.idx, a2v_attn_raw
                     )
-                vx = vx + a2v_out
 
             if run_v2a and not skip_v2a:
-                ax_scaled = ax_norm3 * (1 + scale_ca_audio_v2a) + shift_ca_audio_v2a
-                vx_scaled = vx_norm3 * (1 + scale_ca_video_v2a) + shift_ca_video_v2a
-
                 # v2a: when the Ulysses wrapper is active, K/V (video, large)
                 # stay seq-sharded and the wrapper handles Q + K|V + output
                 # a2a internally. RoPE is applied to K in project_kv on the
@@ -947,7 +1153,7 @@ class BasicAVTransformerBlock(nn.Module):
                 # is_ulysses_active() — _audio_is_sharded can be true under
                 # Attention2D where no wrapper was built.
                 k_v2a, v_v2a = self.video_to_audio_attn.project_kv(
-                    vx_scaled, pe=video.cross_positional_embeddings
+                    vx_scaled_v2a, pe=video.cross_positional_embeddings
                 )
                 if not self.video_to_audio_attn.is_ulysses_active() and self._sharder.is_active:
                     # Fallback: wrapper inactive → all-gather sharded video
@@ -955,38 +1161,120 @@ class BasicAVTransformerBlock(nn.Module):
                     k_v2a = self._sp_all_gather(k_v2a)
                     v_v2a = self._sp_all_gather(v_v2a)
 
-                v2a_out = (
-                    self.video_to_audio_attn(
-                        ax_scaled,
-                        pre_projected_kv=(k_v2a, v_v2a),
-                        pe=audio.cross_positional_embeddings,
-                        timestep=audio.timesteps,
-                    )
-                    * gate_out_v2a
+                v2a_attn_raw = self.video_to_audio_attn(
+                    ax_scaled_v2a,
+                    pre_projected_kv=(k_v2a, v_v2a),
+                    pe=audio.cross_positional_embeddings,
+                    timestep=audio.timesteps,
                 )
                 if has_perturbations and perturbations.any_in_batch(
                     PerturbationType.SKIP_V2A_CROSS_ATTN, self.idx
                 ):
-                    v2a_out = v2a_out * perturbations.mask_like(
-                        PerturbationType.SKIP_V2A_CROSS_ATTN, self.idx, v2a_out
+                    v2a_attn_raw = v2a_attn_raw * perturbations.mask_like(
+                        PerturbationType.SKIP_V2A_CROSS_ATTN, self.idx, v2a_attn_raw
                     )
-                ax = ax + v2a_out
+
+        # AV cross-attn was skipped entirely (single-modality model): the
+        # deferred text-attn residuals never got consumed. Apply them now so
+        # the FFN sees the correct vx / ax.
+        if not av_ca_runs:
+            if text_v_attn_raw is not None:
+                vx = vx + text_v_attn_raw
+            if text_a_attn_raw is not None:
+                ax = ax + text_a_attn_raw
 
         # --- Video FFN ---
         if run_vx:
-            vshift_mlp, vscale_mlp, vgate_mlp = self._get_ada_values(
-                self.scale_shift_table, vx.shape[0], video.timesteps, slice(3, None)
+            # MLP modulators: slot 3 (shift_mlp), 4 (scale_mlp) feed the fused kernel as
+            # pair form; slot 5 (gate_mlp) is also pair-form so the final gate-residual
+            # add `vx + ff(vx_scaled) * vgate_mlp` can run as a single fused kernel via
+            # apply_fused_gate_resid (kernel composes gate = table.to(bf16) + ts inline).
+            (
+                (vshift_mlp_table, vshift_mlp_ts),
+                (vscale_mlp_table, vscale_mlp_ts),
+                (vgate_mlp_table, vgate_mlp_ts),
+            ) = self._get_ada_table_ts_pairs(
+                self.scale_shift_table, vx.shape[0], video.timesteps, slice(3, 6)
             )
-            vx_scaled = rms_norm(vx, eps=self.norm_eps) * (1 + vscale_mlp) + vshift_mlp
-            vx = vx + self.ff(vx_scaled) * vgate_mlp
+            if a2v_attn_raw is not None:
+                # Fused gate-residual + RMSNorm + shift_scale consumes the
+                # deferred a2v residual: vx <- vx + a2v_attn_raw*gate; rms_norm;
+                # (1+scale)*normed+shift. Gate = AV CA table[4] + cross_gate_timestep.
+                v_gate_a2v_table = self.scale_shift_table_a2v_ca_video[4]
+                v_gate_a2v_ts = video.cross_gate_timestep
+                vx, vx_scaled = apply_fused_gate_resid_rmsnorm_shift_scale(
+                    vx,
+                    a2v_attn_raw,
+                    v_gate_a2v_table,
+                    v_gate_a2v_ts,
+                    vscale_mlp_table,
+                    vscale_mlp_ts,
+                    vshift_mlp_table,
+                    vshift_mlp_ts,
+                    self.norm_eps,
+                    fuse=self._fuse_adaln,
+                    fp4_input_scale=get_nvfp4_input_scale(self.ff.up_proj),
+                )
+            else:
+                # No media cross-attn residual to consume: pure RMSNorm + shift_scale.
+                vx_scaled = apply_fused_rmsnorm_shift_scale(
+                    vx,
+                    vscale_mlp_table,
+                    vscale_mlp_ts,
+                    vshift_mlp_table,
+                    vshift_mlp_ts,
+                    self.norm_eps,
+                    self._fuse_adaln,
+                    fp4_input_scale=get_nvfp4_input_scale(self.ff.up_proj),
+                )
+            vx = apply_fused_gate_resid(
+                vx, self.ff(vx_scaled), vgate_mlp_table, vgate_mlp_ts, self._fuse_adaln
+            )
 
         # --- Audio FFN ---
         if run_ax:
-            ashift_mlp, ascale_mlp, agate_mlp = self._get_ada_values(
-                self.audio_scale_shift_table, ax.shape[0], audio.timesteps, slice(3, None)
+            # MLP modulators: slot 5 (gate_mlp) shares the pair-form fetch so the final
+            # gate-residual add runs as a single fused kernel via apply_fused_gate_resid.
+            (
+                (ashift_mlp_table, ashift_mlp_ts),
+                (ascale_mlp_table, ascale_mlp_ts),
+                (agate_mlp_table, agate_mlp_ts),
+            ) = self._get_ada_table_ts_pairs(
+                self.audio_scale_shift_table, ax.shape[0], audio.timesteps, slice(3, 6)
             )
-            ax_scaled = rms_norm(ax, eps=self.norm_eps) * (1 + ascale_mlp) + ashift_mlp
-            ax = ax + self.audio_ff(ax_scaled) * agate_mlp
+            if v2a_attn_raw is not None:
+                # Fused gate-residual + RMSNorm + shift_scale consumes the
+                # deferred v2a residual: ax <- ax + v2a_attn_raw*gate; rms_norm;
+                # (1+scale)*normed+shift. Gate = AV CA audio table[4] + cross_gate_timestep.
+                a_gate_v2a_table = self.scale_shift_table_a2v_ca_audio[4]
+                a_gate_v2a_ts = audio.cross_gate_timestep
+                ax, ax_scaled = apply_fused_gate_resid_rmsnorm_shift_scale(
+                    ax,
+                    v2a_attn_raw,
+                    a_gate_v2a_table,
+                    a_gate_v2a_ts,
+                    ascale_mlp_table,
+                    ascale_mlp_ts,
+                    ashift_mlp_table,
+                    ashift_mlp_ts,
+                    self.norm_eps,
+                    fuse=self._fuse_adaln,
+                    fp4_input_scale=get_nvfp4_input_scale(self.audio_ff.up_proj),
+                )
+            else:
+                ax_scaled = apply_fused_rmsnorm_shift_scale(
+                    ax,
+                    ascale_mlp_table,
+                    ascale_mlp_ts,
+                    ashift_mlp_table,
+                    ashift_mlp_ts,
+                    self.norm_eps,
+                    self._fuse_adaln,
+                    fp4_input_scale=get_nvfp4_input_scale(self.audio_ff.up_proj),
+                )
+            ax = apply_fused_gate_resid(
+                ax, self.audio_ff(ax_scaled), agate_mlp_table, agate_mlp_ts, self._fuse_adaln
+            )
 
         return (
             replace(video, x=vx) if video is not None else None,
@@ -1128,6 +1416,16 @@ class LTXModel(BaseDiffusionModel):
             self.audio_num_attention_heads = audio_num_attention_heads
             self.audio_inner_dim = audio_num_attention_heads * audio_attention_head_dim
             self._init_audio(audio_in_channels, audio_out_channels, caption_channels, norm_eps)
+
+        # Fused AdaLN modulation flag: True iff every inner_dim in this model
+        # matches the kernel's supported set. Threaded into output-head paths.
+        video_supports_fused_adaln = (
+            not model_type.is_video_enabled()
+        ) or is_fused_adaln_supported_dim(self.inner_dim)
+        audio_supports_fused_adaln = (
+            not model_type.is_audio_enabled()
+        ) or is_fused_adaln_supported_dim(self.audio_inner_dim)
+        self._fuse_adaln = video_supports_fused_adaln and audio_supports_fused_adaln
 
         if model_type.is_video_enabled() and model_type.is_audio_enabled():
             cross_pe_max_pos = max(
@@ -1675,7 +1973,7 @@ class LTXModel(BaseDiffusionModel):
         )
         shift, scale = scale_shift_values[:, :, 0], scale_shift_values[:, :, 1]
         x = norm_out(x)
-        x = x * (1 + scale) + shift
+        x = apply_shift_scale(x, scale, shift)
         return proj_out(x)
 
     # -- Forward -------------------------------------------------------------

--- a/tensorrt_llm/_torch/visual_gen/modules/attention.py
+++ b/tensorrt_llm/_torch/visual_gen/modules/attention.py
@@ -523,12 +523,15 @@ class Attention(nn.Module):
 
     def forward(
         self,
-        hidden_states: torch.Tensor,
+        hidden_states: torch.Tensor | Fp4QuantizedTensor,
         encoder_hidden_states: Optional[torch.Tensor] = None,
         freqs: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
         timestep: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        assert hidden_states.ndim == 3, "hidden_states must be a 3D tensor"
+        # hidden_states may be [B, S, H] or an Fp4QuantizedTensor from an upstream
+        # fused norm+quant kernel; downstream Linear accepts either.
+        if not isinstance(hidden_states, Fp4QuantizedTensor):
+            assert hidden_states.ndim == 3, "hidden_states must be a 3D tensor"
         batch_size, seq_len = hidden_states.shape[:2]
         kv_seq_len = (
             encoder_hidden_states.shape[1] if encoder_hidden_states is not None else seq_len
@@ -611,7 +614,7 @@ class Attention(nn.Module):
                 "forward() for sync execution."
             )
 
-        B, S, _ = hidden_states.shape
+        B, S = hidden_states.shape[:2]
         H = self.num_attention_heads
         KV = self.num_key_value_heads
         D = self.head_dim
@@ -620,13 +623,16 @@ class Attention(nn.Module):
         # has no async analog here.
         use_fused = self.fuse_qk_norm_rope and freqs is not None and self.qk_norm
 
-        # SEPARATE_QKV self-attn 3x fp4_quantize dedup: pre-quantize hidden_states
-        # once and pass the shared Fp4QuantizedTensor to to_q/to_k/to_v via Linear's
-        # Fp4QuantizedTensor shortcut. Saves 2 of 3 fp4_quantize launches per layer.
-        # Eligibility is structural (set in __init__); runtime gate checks that the
-        # checkpoint loaded an input_scale (some attn Linears can be excluded from
-        # NVFP4 per checkpoint config — e.g. LTX-2 transformer_blocks.10.attn1).
-        if self._maybe_share_qkv_quantize and getattr(self.to_q, "input_scale", None) is not None:
+        # SEPARATE_QKV self-attn shares ONE input quant across to_q/to_k/to_v (never 3):
+        #   * hidden_states already an Fp4QuantizedTensor -> an upstream fused norm+quant AdaLN
+        #     pre-quantized it once (with to_q.input_scale); reuse it directly -> 0 quant here.
+        #   * else eligible -> quantize once and share the Fp4QuantizedTensor -> 1 quant here.
+        #   * else -> bf16, each Linear quantizes its own (non-NVFP4 / NVFP4-excluded layers).
+        # Eligibility is structural (set in __init__); the runtime gate checks the checkpoint
+        # loaded an input_scale (some attn Linears are NVFP4-excluded -- e.g. LTX-2 blocks.10.attn1).
+        if isinstance(hidden_states, Fp4QuantizedTensor):
+            qkv_input = hidden_states
+        elif self._maybe_share_qkv_quantize and getattr(self.to_q, "input_scale", None) is not None:
             x_2d = hidden_states.reshape(-1, hidden_states.shape[-1])
             fp4, sf = torch.ops.trtllm.tunable_fp4_quantize(
                 x_2d, self.to_q.input_scale, self.to_q.scaling_vector_size, False

--- a/tests/unittest/_torch/thop/parallel/test_fused_dit_gate_resid_norm_shift_scale.py
+++ b/tests/unittest/_torch/thop/parallel/test_fused_dit_gate_resid_norm_shift_scale.py
@@ -1,0 +1,814 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for the LTX-2 fused DiT norm kernel family (cpp/tensorrt_llm/kernels/fusedDiTGateResidNormShiftScaleKernel.cu)
+# -- one warp-specialized Blackwell kernel, specialized by template flags
+# (HAS_GATE / HAS_RESIDUAL / HAS_NORM / HAS_SHIFT_SCALE / NUM_OUT / HAS_QUANT).
+# Each op composes its AdaLN modulators inline from (table_fp32 [D], ts_bf16 [B, D]) pairs
+# via a bf16-narrow-first hw add, matching the PyTorch eager `_get_ada_values` combine.
+#
+# Ops covered (bf16 + NVFP4 `_quant` variant unless noted):
+#   fused_dit_rmsnorm_shift_scale                RMSNorm -> (1 + s) * n + h
+#   fused_dit_resid_rmsnorm_shift_scale_dual     resid -> RMSNorm -> two shift_scale outputs
+#   fused_dit_gate_resid_rmsnorm_shift_scale     gate-resid -> RMSNorm -> shift_scale
+#   fused_dit_gate_resid_rmsnorm                 gate-resid -> RMSNorm
+#   fused_dit_gate_resid                         gate-resid only (bf16, no norm)
+
+import pytest
+import torch
+import torch.nn.functional as F
+from utils.util import skip_pre_blackwell
+
+import tensorrt_llm  # noqa: F401  -- triggers libth_common.so load (registers trtllm ops)
+
+# Fused DiT AdaLN kernels use TMA + inline NVFP4 quant -> require Blackwell (sm100).
+pytestmark = skip_pre_blackwell
+
+
+# ---------------------------------------------------------------------------
+# Thin per-variant adapters over the single unified `trtllm::fused_dit_gate_resid_norm_shift_scale`
+# op. Flags are inferred from which args are provided (attn => residual,
+# gate_table => gate, non-empty scale list => shift_scale, non-empty sf_scale
+# => quant, num_out>=1 => norm). The op is FUNCTIONAL: for residual variants it
+# returns the new residual stream x_new as output[0]; these adapters copy x_new
+# back into x so each test's in-place expectation (x <- x + attn[*gate]) holds,
+# and return only the norm output(s) -- keeping the test bodies unchanged.
+# ---------------------------------------------------------------------------
+def _call_rmsnorm_shift_scale(x, scale_table, scale_ts, shift_table, shift_ts, eps):
+    (out,) = torch.ops.trtllm.fused_dit_gate_resid_norm_shift_scale(
+        x,
+        scale_table=[scale_table],
+        scale_ts=[scale_ts],
+        shift_table=[shift_table],
+        shift_ts=[shift_ts],
+        eps=eps,
+    )
+    return out
+
+
+def _call_rmsnorm_shift_scale_quant(x, scale_table, scale_ts, shift_table, shift_ts, sf_scale, eps):
+    return torch.ops.trtllm.fused_dit_gate_resid_norm_shift_scale(
+        x,
+        scale_table=[scale_table],
+        scale_ts=[scale_ts],
+        shift_table=[shift_table],
+        shift_ts=[shift_ts],
+        sf_scale=[sf_scale],
+        eps=eps,
+    )
+
+
+def _call_resid_rmsnorm_shift_scale_dual(
+    x, attn, s1t, s1ts, sh1t, sh1ts, s2t, s2ts, sh2t, sh2ts, eps
+):
+    x_new, o1, o2 = torch.ops.trtllm.fused_dit_gate_resid_norm_shift_scale(
+        x,
+        attn=attn,
+        scale_table=[s1t, s2t],
+        scale_ts=[s1ts, s2ts],
+        shift_table=[sh1t, sh2t],
+        shift_ts=[sh1ts, sh2ts],
+        eps=eps,
+        num_out=2,
+    )
+    x.copy_(x_new)
+    return o1, o2
+
+
+def _call_resid_rmsnorm_shift_scale_dual_quant(
+    x, attn, s1t, s1ts, sh1t, sh1ts, s2t, s2ts, sh2t, sh2ts, sf1, sf2, eps
+):
+    x_new, f0, s0, f1, s1 = torch.ops.trtllm.fused_dit_gate_resid_norm_shift_scale(
+        x,
+        attn=attn,
+        scale_table=[s1t, s2t],
+        scale_ts=[s1ts, s2ts],
+        shift_table=[sh1t, sh2t],
+        shift_ts=[sh1ts, sh2ts],
+        sf_scale=[sf1, sf2],
+        eps=eps,
+        num_out=2,
+    )
+    x.copy_(x_new)
+    return f0, s0, f1, s1
+
+
+def _call_gate_resid_rmsnorm_shift_scale(x, attn, gt, gts, st, sts, sht, shts, eps):
+    x_new, out = torch.ops.trtllm.fused_dit_gate_resid_norm_shift_scale(
+        x,
+        attn=attn,
+        gate_table=gt,
+        gate_ts=gts,
+        scale_table=[st],
+        scale_ts=[sts],
+        shift_table=[sht],
+        shift_ts=[shts],
+        eps=eps,
+    )
+    x.copy_(x_new)
+    return out
+
+
+def _call_gate_resid_rmsnorm_shift_scale_quant(x, attn, gt, gts, st, sts, sht, shts, sf_scale, eps):
+    x_new, fp4, sf = torch.ops.trtllm.fused_dit_gate_resid_norm_shift_scale(
+        x,
+        attn=attn,
+        gate_table=gt,
+        gate_ts=gts,
+        scale_table=[st],
+        scale_ts=[sts],
+        shift_table=[sht],
+        shift_ts=[shts],
+        sf_scale=[sf_scale],
+        eps=eps,
+    )
+    x.copy_(x_new)
+    return fp4, sf
+
+
+def _call_gate_resid_rmsnorm(x, attn, gt, gts, eps):
+    x_new, out = torch.ops.trtllm.fused_dit_gate_resid_norm_shift_scale(
+        x, attn=attn, gate_table=gt, gate_ts=gts, eps=eps
+    )
+    x.copy_(x_new)
+    return out
+
+
+def _call_gate_resid_rmsnorm_quant(x, attn, gt, gts, sf_scale, eps):
+    x_new, fp4, sf = torch.ops.trtllm.fused_dit_gate_resid_norm_shift_scale(
+        x, attn=attn, gate_table=gt, gate_ts=gts, sf_scale=[sf_scale], eps=eps
+    )
+    x.copy_(x_new)
+    return fp4, sf
+
+
+def _call_gate_resid(x, attn, gt, gts):
+    # num_out=0 => gate-residual only (no norm): op returns [x_new] = x + attn * gate.
+    (x_new,) = torch.ops.trtllm.fused_dit_gate_resid_norm_shift_scale(
+        x, attn=attn, gate_table=gt, gate_ts=gts, num_out=0
+    )
+    x.copy_(x_new)
+    return x
+
+
+# Shared gate-residual input builder (gate_resid and gate_resid_rmsnorm use identical inputs).
+def _make_gate_resid_inputs(num_tokens, hidden_dim, batch_size, seed):
+    torch.manual_seed(seed)
+    device = "cuda"
+    x = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device=device) * 0.1
+    attn = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device=device) * 0.1
+    gate_table = torch.randn(hidden_dim, dtype=torch.float32, device=device) * 0.3
+    gate_ts = torch.randn(batch_size, hidden_dim, dtype=torch.bfloat16, device=device) * 0.3
+    return x, attn, gate_table, gate_ts
+
+
+# =====================================================================================
+# fused_dit_rmsnorm_shift_scale  (RMSNorm + AdaLN affine-modulation)
+#   Signature: x, scale_table (fp32 [D]), scale_ts (bf16 [B, T, D]),
+#                 shift_table (fp32 [D]), shift_ts (bf16 [B, T, D]), [sf_scale,] eps
+#   Kernel composes the modulator inline: scale[d] = scale_table[d] + scale_ts[b, d].
+# =====================================================================================
+@torch.inference_mode()
+def _ref_rmsnorm_shift_scale(
+    x_2d, scale_table, scale_ts, shift_table, shift_ts, tokens_per_batch, eps
+):
+    """Reference matching production semantics (apply_fused_rmsnorm_shift_scale
+    eager fallback in utils_ltx2.py + _get_ada_values modulator combine):
+
+    Phase 0b: scale_bf16 = scale_table.to(bf16) + scale_ts  (bf16 narrow, bf16 hw add)
+    Phase 1:  normed     = rms_norm(x)                      (bf16 in / out)
+    Phase 2:  out        = normed * (1 + scale_bf16) + shift_bf16   (all bf16)
+    """
+    B = scale_ts.shape[0]
+    D = x_2d.shape[-1]
+    x_3d = x_2d.view(B, tokens_per_batch, D)
+    normed = torch.nn.functional.rms_norm(x_3d, (D,), weight=None, eps=eps)
+    scale_bf16 = scale_table.to(torch.bfloat16).view(1, 1, D) + scale_ts.view(B, 1, D)
+    shift_bf16 = shift_table.to(torch.bfloat16).view(1, 1, D) + shift_ts.view(B, 1, D)
+    out = normed * (1 + scale_bf16) + shift_bf16
+    return out.view(-1, D)
+
+
+@pytest.mark.parametrize("hidden_dim", [2048, 4096])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("tokens_per_batch", [1, 16, 512])
+def test_rmsnorm_shift_scale_shapes(hidden_dim, batch_size, tokens_per_batch):
+    device = "cuda"
+    torch.random.manual_seed(42)
+
+    num_tokens = batch_size * tokens_per_batch
+    x = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device=device)
+    scale_table = torch.randn(hidden_dim, dtype=torch.float32, device=device) * 0.5
+    scale_ts = torch.randn(batch_size, hidden_dim, dtype=torch.bfloat16, device=device) * 0.5
+    shift_table = torch.randn(hidden_dim, dtype=torch.float32, device=device) * 0.5
+    shift_ts = torch.randn(batch_size, hidden_dim, dtype=torch.bfloat16, device=device) * 0.5
+    eps = 1e-6
+
+    out = _call_rmsnorm_shift_scale(x, scale_table, scale_ts, shift_table, shift_ts, eps)
+    ref = _ref_rmsnorm_shift_scale(
+        x, scale_table, scale_ts, shift_table, shift_ts, tokens_per_batch, eps
+    )
+    # Kernel uses pure bf16 hw `__hadd2`/`__hmul2`; PyTorch eager uses bf16
+    # with fp32-accumulator internally. Diff is ~1 bf16 ULP per element on
+    # rare tail samples (max abs ~0.012 at value ~1). Cosine vs eager >0.999.
+    torch.testing.assert_close(out, ref, rtol=2e-2, atol=2e-2)
+
+
+def test_rmsnorm_shift_scale_ltx2_video_shape():
+    """LTX-2 video: B=1, S=12288, D=4096."""
+    device = "cuda"
+    torch.random.manual_seed(0)
+    B, S, D = 1, 12288, 4096
+    x = torch.randn(B * S, D, dtype=torch.bfloat16, device=device)
+    scale_table = torch.randn(D, dtype=torch.float32, device=device) * 0.5
+    scale_ts = torch.randn(B, D, dtype=torch.bfloat16, device=device) * 0.5
+    shift_table = torch.randn(D, dtype=torch.float32, device=device) * 0.5
+    shift_ts = torch.randn(B, D, dtype=torch.bfloat16, device=device) * 0.5
+
+    out = _call_rmsnorm_shift_scale(x, scale_table, scale_ts, shift_table, shift_ts, 1e-6)
+    ref = _ref_rmsnorm_shift_scale(x, scale_table, scale_ts, shift_table, shift_ts, S, 1e-6)
+    torch.testing.assert_close(out, ref, rtol=2e-2, atol=2e-2)
+
+
+def test_rmsnorm_shift_scale_ltx2_audio_shape():
+    """LTX-2 audio: B=1, S=504, D=2048."""
+    device = "cuda"
+    torch.random.manual_seed(0)
+    B, S, D = 1, 504, 2048
+    x = torch.randn(B * S, D, dtype=torch.bfloat16, device=device)
+    scale_table = torch.randn(D, dtype=torch.float32, device=device) * 0.5
+    scale_ts = torch.randn(B, D, dtype=torch.bfloat16, device=device) * 0.5
+    shift_table = torch.randn(D, dtype=torch.float32, device=device) * 0.5
+    shift_ts = torch.randn(B, D, dtype=torch.bfloat16, device=device) * 0.5
+
+    out = _call_rmsnorm_shift_scale(x, scale_table, scale_ts, shift_table, shift_ts, 1e-6)
+    ref = _ref_rmsnorm_shift_scale(x, scale_table, scale_ts, shift_table, shift_ts, S, 1e-6)
+    torch.testing.assert_close(out, ref, rtol=2e-2, atol=2e-2)
+
+
+def test_rmsnorm_shift_scale_rejects_non_contiguous():
+    device = "cuda"
+    B, S, D = 2, 16, 4096
+    base = torch.randn(B * S, 2 * D, dtype=torch.bfloat16, device=device)
+    x_view = base[:, :D]
+    assert not x_view.is_contiguous()
+    scale_table = torch.randn(D, dtype=torch.float32, device=device)
+    scale_ts = torch.randn(B, D, dtype=torch.bfloat16, device=device)
+    shift_table = torch.randn(D, dtype=torch.float32, device=device)
+    shift_ts = torch.randn(B, D, dtype=torch.bfloat16, device=device)
+    with pytest.raises(RuntimeError, match=r"contiguous"):
+        _call_rmsnorm_shift_scale(x_view, scale_table, scale_ts, shift_table, shift_ts, 1e-6)
+
+
+@pytest.mark.parametrize("hidden_dim", [2048, 4096])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("K", [5, 6])
+def test_rmsnorm_shift_scale_strided_ts(hidden_dim, batch_size, K):
+    """scale_ts / shift_ts may be unbind views of a [B, T_t, K, D] timestep tensor --
+    row stride is K*D, inner stride is 1. Kernel must produce identical output."""
+    device = "cuda"
+    torch.random.manual_seed(7)
+    D = hidden_dim
+    T_t = 1
+    tokens_per_batch = 16
+    num_tokens = batch_size * tokens_per_batch
+
+    x = torch.randn(num_tokens, D, dtype=torch.bfloat16, device=device)
+    ts = torch.randn(batch_size, T_t, K, D, dtype=torch.bfloat16, device=device) * 0.5
+    scale_table = torch.randn(D, dtype=torch.float32, device=device) * 0.5
+    shift_table = torch.randn(D, dtype=torch.float32, device=device) * 0.5
+
+    chunks = ts.unbind(dim=2)
+    scale_ts_view, shift_ts_view = chunks[0], chunks[1]
+    # Layout check: unbind dim=2 of a [B, T_t, K, D] contig tensor yields views with
+    # strides (T_t*K*D, K*D, 1). is_contiguous() is True for shapes with size-1 dims
+    # (B=T_t=1) since PyTorch ignores their strides; check stride pattern directly.
+    assert scale_ts_view.stride() == (T_t * K * D, K * D, 1)
+    if batch_size > 1:
+        assert not scale_ts_view.squeeze(1).is_contiguous()
+
+    out_strided = _call_rmsnorm_shift_scale(
+        x, scale_table, scale_ts_view.squeeze(1), shift_table, shift_ts_view.squeeze(1), 1e-6
+    )
+    out_contig = _call_rmsnorm_shift_scale(
+        x,
+        scale_table,
+        scale_ts_view.squeeze(1).contiguous(),
+        shift_table,
+        shift_ts_view.squeeze(1).contiguous(),
+        1e-6,
+    )
+    torch.testing.assert_close(out_strided, out_contig, rtol=0.0, atol=0.0)
+
+
+def test_rmsnorm_shift_scale_rejects_unsupported_dim():
+    device = "cuda"
+    D = 1024  # not in {2048, 4096}
+    x = torch.randn(8, D, dtype=torch.bfloat16, device=device)
+    scale_table = torch.randn(D, dtype=torch.float32, device=device)
+    scale_ts = torch.randn(1, D, dtype=torch.bfloat16, device=device)
+    shift_table = torch.randn(D, dtype=torch.float32, device=device)
+    shift_ts = torch.randn(1, D, dtype=torch.bfloat16, device=device)
+    with pytest.raises(RuntimeError):
+        _call_rmsnorm_shift_scale(x, scale_table, scale_ts, shift_table, shift_ts, 1e-6)
+
+
+@pytest.mark.parametrize("hidden_dim", [2048, 4096])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("tokens_per_batch", [126, 128])
+def test_rmsnorm_shift_scale_fp4_quant(hidden_dim, batch_size, tokens_per_batch):
+    """NVFP4 variant: end-to-end GEMM quality (cosine > 0.98) vs the bf16
+    F.linear reference, matching the canonical FP4 test pattern."""
+    device = "cuda"
+    torch.manual_seed(7)
+    num_tokens = batch_size * tokens_per_batch
+    out_dim = 1024
+    eps = 1e-6
+
+    x = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device=device) * 0.1
+    scale_table = torch.randn(hidden_dim, dtype=torch.float32, device=device) * 0.3
+    scale_ts = torch.randn(batch_size, hidden_dim, dtype=torch.bfloat16, device=device) * 0.3
+    shift_table = torch.randn(hidden_dim, dtype=torch.float32, device=device) * 0.3
+    shift_ts = torch.randn(batch_size, hidden_dim, dtype=torch.bfloat16, device=device) * 0.3
+    W = torch.randn(out_dim, hidden_dim, dtype=torch.bfloat16, device=device) * 0.05
+
+    # bf16 reference: fused-kernel bf16 output -> F.linear with random W.
+    out_bf16 = _call_rmsnorm_shift_scale(x, scale_table, scale_ts, shift_table, shift_ts, eps)
+    D_ref = F.linear(out_bf16, W)
+
+    sf_scale_x = (448.0 * 6.0) / out_bf16.abs().max().float()
+    sf_scale_w = (448.0 * 6.0) / W.abs().max().float()
+
+    # FP4 path: packed FP4 + SWIZZLED 1x16 FP8 SF directly.
+    out_fp4, out_sf = _call_rmsnorm_shift_scale_quant(
+        x, scale_table, scale_ts, shift_table, shift_ts, sf_scale_x, eps
+    )
+
+    # Weight quantize: trtllm.fp4_quantize defaults (sfUseUE8M0=False,
+    # isSfSwizzledLayout=True) match the quant kernel's SWIZZLED SF layout.
+    W_fp4, W_sf = torch.ops.trtllm.fp4_quantize(W, sf_scale_w, 16)
+
+    alpha = 1.0 / (sf_scale_x * sf_scale_w).float()
+    C = torch.ops.trtllm.nvfp4_gemm(out_fp4, W_fp4, out_sf, W_sf, alpha, torch.bfloat16)
+
+    assert F.cosine_similarity(C.flatten().float(), D_ref.flatten().float(), dim=0).item() > 0.98
+
+
+# =====================================================================================
+# fused_dit_resid_rmsnorm_shift_scale_dual
+#   bf16  -> (out_dir1, out_dir2);  quant -> (fp4_dir1, sf_dir1, fp4_dir2, sf_dir2)
+#   Post-attn2 site: residual_add(x, attn2_out) -> rms_norm -> two independent
+#   (1+s)*normed+h modulations, feeding the FFN up_proj (dir1) and AV cross-attn to_q (dir2).
+#   The 4 modulators are composed inline from (table_fp32 [D], ts_bf16 [B, D]) pairs.
+# =====================================================================================
+@torch.inference_mode()
+def _ref_resid_dual(
+    x_2d,
+    attn_2d,
+    s1_table,
+    s1_ts,
+    h1_table,
+    h1_ts,
+    s2_table,
+    s2_ts,
+    h2_table,
+    h2_ts,
+    tokens_per_batch,
+    eps,
+):
+    """Reference matching production semantics (apply_fused_resid_rms_shift_scale_dual_a
+    eager fallback + _get_av_ca_ada_values combine):
+       x_new      = x + attn                                  (bf16)
+       normed     = rms_norm(x_new)                           (bf16)
+       m_bf16     = m_table.to(bf16) + m_ts                   (bf16 narrow, bf16 add)
+       out_dir_k  = normed * (1 + s_bf16_k) + h_bf16_k        (all bf16)"""
+    B = s1_ts.shape[0]
+    D = x_2d.shape[-1]
+    x_3d = x_2d.view(B, tokens_per_batch, D)
+    a_3d = attn_2d.view(B, tokens_per_batch, D)
+    x_new = x_3d + a_3d
+    normed = torch.nn.functional.rms_norm(x_new, (D,), weight=None, eps=eps)
+    s1_bf16 = s1_table.to(torch.bfloat16).view(1, 1, D) + s1_ts.view(B, 1, D)
+    h1_bf16 = h1_table.to(torch.bfloat16).view(1, 1, D) + h1_ts.view(B, 1, D)
+    s2_bf16 = s2_table.to(torch.bfloat16).view(1, 1, D) + s2_ts.view(B, 1, D)
+    h2_bf16 = h2_table.to(torch.bfloat16).view(1, 1, D) + h2_ts.view(B, 1, D)
+    o1 = normed * (1 + s1_bf16) + h1_bf16
+    o2 = normed * (1 + s2_bf16) + h2_bf16
+    return (
+        o1.view(-1, D),
+        o2.view(-1, D),
+        x_new.view(-1, D),
+    )
+
+
+def _make_resid_dual_inputs(num_tokens, hidden_dim, batch_size, seed):
+    torch.manual_seed(seed)
+    device = "cuda"
+    x = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device=device) * 0.1
+    attn2 = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device=device) * 0.1
+    s1_table = torch.randn(hidden_dim, dtype=torch.float32, device=device) * 0.3
+    s1_ts = torch.randn(batch_size, hidden_dim, dtype=torch.bfloat16, device=device) * 0.3
+    h1_table = torch.randn(hidden_dim, dtype=torch.float32, device=device) * 0.3
+    h1_ts = torch.randn(batch_size, hidden_dim, dtype=torch.bfloat16, device=device) * 0.3
+    s2_table = torch.randn(hidden_dim, dtype=torch.float32, device=device) * 0.3
+    s2_ts = torch.randn(batch_size, hidden_dim, dtype=torch.bfloat16, device=device) * 0.3
+    h2_table = torch.randn(hidden_dim, dtype=torch.float32, device=device) * 0.3
+    h2_ts = torch.randn(batch_size, hidden_dim, dtype=torch.bfloat16, device=device) * 0.3
+    return x, attn2, s1_table, s1_ts, h1_table, h1_ts, s2_table, s2_ts, h2_table, h2_ts
+
+
+@pytest.mark.parametrize("hidden_dim", [2048, 4096])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("tokens_per_batch", [16, 512])
+def test_resid_rmsnorm_shift_scale_dual_bf16(hidden_dim, batch_size, tokens_per_batch):
+    """bf16 variant: dual outputs match eager fp32 reference; x is mutated in place."""
+    num_tokens = batch_size * tokens_per_batch
+    (x, attn2, s1_table, s1_ts, h1_table, h1_ts, s2_table, s2_ts, h2_table, h2_ts) = (
+        _make_resid_dual_inputs(num_tokens, hidden_dim, batch_size, seed=42)
+    )
+    eps = 1e-6
+
+    ref_o1, ref_o2, ref_x_new = _ref_resid_dual(
+        x,
+        attn2,
+        s1_table,
+        s1_ts,
+        h1_table,
+        h1_ts,
+        s2_table,
+        s2_ts,
+        h2_table,
+        h2_ts,
+        tokens_per_batch,
+        eps,
+    )
+
+    x_impl = x.clone()
+    o1, o2 = _call_resid_rmsnorm_shift_scale_dual(
+        x_impl, attn2, s1_table, s1_ts, h1_table, h1_ts, s2_table, s2_ts, h2_table, h2_ts, eps
+    )
+
+    # Tolerance: same as the gate-residual variant -- bf16-narrow-first kernel vs fp32 ref differs at the
+    # bf16 ULP edge; longer-S reductions can push 1 element over the tighter 5e-3.
+    # Kernel uses pure bf16 hw `__hadd2`/`__hmul2` shift_scale; production eager uses bf16
+    # with fp32-accumulator internally. ~1 bf16 ULP per element on rare tail samples.
+    torch.testing.assert_close(o1, ref_o1, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(o2, ref_o2, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(x_impl, ref_x_new, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize("hidden_dim", [2048, 4096])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("tokens_per_batch", [126, 128])
+def test_resid_rmsnorm_shift_scale_dual_fp4_quant(hidden_dim, batch_size, tokens_per_batch):
+    """NVFP4 variant: both quantized outputs (dir1 -> FFN up_proj, dir2 -> AV cross-attn
+    to_q) pass end-to-end GEMM cosine > 0.98 vs the bf16 F.linear reference."""
+    num_tokens = batch_size * tokens_per_batch
+    out_dim = 1024
+    (x, attn2, s1_table, s1_ts, h1_table, h1_ts, s2_table, s2_ts, h2_table, h2_ts) = (
+        _make_resid_dual_inputs(num_tokens, hidden_dim, batch_size, seed=7)
+    )
+    eps = 1e-6
+
+    torch.manual_seed(13)
+    W1 = torch.randn(out_dim, hidden_dim, dtype=torch.bfloat16, device="cuda") * 0.05
+    W2 = torch.randn(out_dim, hidden_dim, dtype=torch.bfloat16, device="cuda") * 0.05
+
+    # bf16 reference: fused-kernel bf16 outputs -> F.linear with random W1 / W2.
+    x_bf16 = x.clone()
+    o1_bf16, o2_bf16 = _call_resid_rmsnorm_shift_scale_dual(
+        x_bf16, attn2, s1_table, s1_ts, h1_table, h1_ts, s2_table, s2_ts, h2_table, h2_ts, eps
+    )
+    D1_ref = F.linear(o1_bf16, W1)
+    D2_ref = F.linear(o2_bf16, W2)
+
+    sf_scale_x1 = (448.0 * 6.0) / o1_bf16.abs().max().float()
+    sf_scale_x2 = (448.0 * 6.0) / o2_bf16.abs().max().float()
+    sf_scale_w1 = (448.0 * 6.0) / W1.abs().max().float()
+    sf_scale_w2 = (448.0 * 6.0) / W2.abs().max().float()
+
+    # FP4 path: dual quant in one kernel.
+    x_fp4 = x.clone()
+    o1_fp4, o1_sf, o2_fp4, o2_sf = _call_resid_rmsnorm_shift_scale_dual_quant(
+        x_fp4,
+        attn2,
+        s1_table,
+        s1_ts,
+        h1_table,
+        h1_ts,
+        s2_table,
+        s2_ts,
+        h2_table,
+        h2_ts,
+        sf_scale_x1,
+        sf_scale_x2,
+        eps,
+    )
+
+    # Weight quantize: trtllm.fp4_quantize defaults (sfUseUE8M0=False,
+    # isSfSwizzledLayout=True) match the quant kernel's SWIZZLED SF layout.
+    W1_fp4, W1_sf = torch.ops.trtllm.fp4_quantize(W1, sf_scale_w1, 16)
+    W2_fp4, W2_sf = torch.ops.trtllm.fp4_quantize(W2, sf_scale_w2, 16)
+
+    alpha1 = 1.0 / (sf_scale_x1 * sf_scale_w1).float()
+    alpha2 = 1.0 / (sf_scale_x2 * sf_scale_w2).float()
+    C1 = torch.ops.trtllm.nvfp4_gemm(o1_fp4, W1_fp4, o1_sf, W1_sf, alpha1, torch.bfloat16)
+    C2 = torch.ops.trtllm.nvfp4_gemm(o2_fp4, W2_fp4, o2_sf, W2_sf, alpha2, torch.bfloat16)
+
+    assert F.cosine_similarity(C1.flatten().float(), D1_ref.flatten().float(), dim=0).item() > 0.98
+    assert F.cosine_similarity(C2.flatten().float(), D2_ref.flatten().float(), dim=0).item() > 0.98
+
+
+# =====================================================================================
+# fused_dit_gate_resid_rmsnorm_shift_scale  (+ _quant)
+#   gate-residual -> RMSNorm -> shift_scale. Each modulator (gate, scale, shift) is built
+#   inline from a (table, ts) pair, eliminating the upstream broadcast-add Triton prep kernel.
+# =====================================================================================
+@torch.inference_mode()
+def _ref_gate_resid_ss(
+    x_2d,
+    attn_2d,
+    gate_table,
+    gate_ts,
+    scale_table,
+    scale_ts,
+    shift_table,
+    shift_ts,
+    tokens_per_batch,
+    eps,
+):
+    """Reference matching production semantics (apply_fused_gate_resid_shift_scale
+    eager fallback + _get_ada_values combine):
+       gate_bf16 = gate_table.to(bf16) + gate_ts                  (bf16 narrow, bf16 add)
+       x_new     = x + attn * gate_bf16                            (bf16)
+       normed    = rms_norm(x_new)                                 (bf16)
+       s_bf16    = scale_table.to(bf16) + scale_ts                 (bf16)
+       h_bf16    = shift_table.to(bf16) + shift_ts                 (bf16)
+       out       = normed * (1 + s_bf16) + h_bf16                  (all bf16)
+    """
+    B = gate_ts.shape[0]
+    D = x_2d.shape[-1]
+    x_3d = x_2d.view(B, tokens_per_batch, D)
+    a_3d = attn_2d.view(B, tokens_per_batch, D)
+    gate_bf16 = gate_table.to(torch.bfloat16).view(1, 1, D) + gate_ts.view(B, 1, D)
+    scale_bf16 = scale_table.to(torch.bfloat16).view(1, 1, D) + scale_ts.view(B, 1, D)
+    shift_bf16 = shift_table.to(torch.bfloat16).view(1, 1, D) + shift_ts.view(B, 1, D)
+    x_new = x_3d + a_3d * gate_bf16
+    normed = torch.nn.functional.rms_norm(x_new, (D,), weight=None, eps=eps)
+    out = normed * (1 + scale_bf16) + shift_bf16
+    return out.view(-1, D), x_new.view(-1, D)
+
+
+def _make_gate_resid_ss_inputs(num_tokens, hidden_dim, batch_size, seed):
+    torch.manual_seed(seed)
+    device = "cuda"
+    x = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device=device) * 0.1
+    attn = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device=device) * 0.1
+    gate_table = torch.randn(hidden_dim, dtype=torch.float32, device=device) * 0.3
+    gate_ts = torch.randn(batch_size, hidden_dim, dtype=torch.bfloat16, device=device) * 0.3
+    scale_table = torch.randn(hidden_dim, dtype=torch.float32, device=device) * 0.3
+    scale_ts = torch.randn(batch_size, hidden_dim, dtype=torch.bfloat16, device=device) * 0.3
+    shift_table = torch.randn(hidden_dim, dtype=torch.float32, device=device) * 0.3
+    shift_ts = torch.randn(batch_size, hidden_dim, dtype=torch.bfloat16, device=device) * 0.3
+    return x, attn, gate_table, gate_ts, scale_table, scale_ts, shift_table, shift_ts
+
+
+@pytest.mark.parametrize("hidden_dim", [2048, 4096])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("tokens_per_batch", [16, 512])
+def test_gate_resid_rmsnorm_shift_scale_bf16(hidden_dim, batch_size, tokens_per_batch):
+    """bf16 variant: trtllm kernel matches eager fp32 reference within tolerance,
+    and mutates x in place to (x + attn * gate)."""
+    num_tokens = batch_size * tokens_per_batch
+    x, attn, gate_table, gate_ts, scale_table, scale_ts, shift_table, shift_ts = (
+        _make_gate_resid_ss_inputs(num_tokens, hidden_dim, batch_size, seed=42)
+    )
+    eps = 1e-6
+
+    ref_out, ref_x_new = _ref_gate_resid_ss(
+        x,
+        attn,
+        gate_table,
+        gate_ts,
+        scale_table,
+        scale_ts,
+        shift_table,
+        shift_ts,
+        tokens_per_batch,
+        eps,
+    )
+
+    x_impl = x.clone()
+    out = _call_gate_resid_rmsnorm_shift_scale(
+        x_impl, attn, gate_table, gate_ts, scale_table, scale_ts, shift_table, shift_ts, eps
+    )
+
+    # Tolerance bumped vs old test: kernel now narrows table->bf16 then bf16-add
+    # (PyTorch eager `_get_ada_values` semantics) which differs from the
+    # all-fp32 reference at the bf16 ULP boundary; the longer-S reductions amplify
+    # the per-element diff slightly. Still well within bf16 noise.
+    # Kernel uses pure bf16 hw `__hadd2`/`__hmul2` shift_scale; production eager uses bf16
+    # with fp32-accumulator internally. ~1 bf16 ULP per element on rare tail samples.
+    torch.testing.assert_close(out, ref_out, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(x_impl, ref_x_new, rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize("hidden_dim", [2048, 4096])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("tokens_per_batch", [126, 128])
+def test_gate_resid_rmsnorm_shift_scale_fp4_quant(hidden_dim, batch_size, tokens_per_batch):
+    """NVFP4 variant: end-to-end GEMM quality (cosine > 0.98) vs the bf16
+    F.linear reference, matching the canonical FP4 test pattern."""
+    num_tokens = batch_size * tokens_per_batch
+    out_dim = 1024
+    x, attn, gate_table, gate_ts, scale_table, scale_ts, shift_table, shift_ts = (
+        _make_gate_resid_ss_inputs(num_tokens, hidden_dim, batch_size, seed=7)
+    )
+    eps = 1e-6
+
+    # bf16 reference: compute the fused kernel.s bf16 output, then F.linear with random W.
+    torch.manual_seed(13)
+    W = torch.randn(out_dim, hidden_dim, dtype=torch.bfloat16, device="cuda") * 0.05
+
+    x_bf16 = x.clone()
+    out_bf16 = _call_gate_resid_rmsnorm_shift_scale(
+        x_bf16, attn, gate_table, gate_ts, scale_table, scale_ts, shift_table, shift_ts, eps
+    )
+    D_ref = F.linear(out_bf16, W)
+
+    # Per-tensor inverse-amax sf_scale (the NVFP4 "global scale", SF2) for A and B.
+    sf_scale_x = (448.0 * 6.0) / out_bf16.abs().max().float()
+    sf_scale_w = (448.0 * 6.0) / W.abs().max().float()
+
+    # FP4 path: produces packed FP4 + SWIZZLED 1x16 FP8 SF directly.
+    x_fp4 = x.clone()
+    out_fp4, out_sf = _call_gate_resid_rmsnorm_shift_scale_quant(
+        x_fp4,
+        attn,
+        gate_table,
+        gate_ts,
+        scale_table,
+        scale_ts,
+        shift_table,
+        shift_ts,
+        sf_scale_x,
+        eps,
+    )
+
+    # Weight quantized via trtllm.fp4_quantize (defaults: sfUseUE8M0=False,
+    # isSfSwizzledLayout=True) -- matches the quant kernel's SWIZZLED SF layout.
+    W_fp4, W_sf = torch.ops.trtllm.fp4_quantize(W, sf_scale_w, 16)
+
+    alpha = 1.0 / (sf_scale_x * sf_scale_w).float()
+    C = torch.ops.trtllm.nvfp4_gemm(out_fp4, W_fp4, out_sf, W_sf, alpha, torch.bfloat16)
+
+    assert F.cosine_similarity(C.flatten().float(), D_ref.flatten().float(), dim=0).item() > 0.98
+
+
+# =====================================================================================
+# fused_dit_gate_resid_rmsnorm  (+ _quant)
+#   gate[d]    = gate_table[d].to(bf16) + gate_ts[b, d]    (bf16 narrow, bf16 hw add)
+#   x_new[n,d] = x[n,d] + attn_out[n,d] * gate[d]          (in-place)
+#   normed     = rms_norm(x_new)
+#   (fp4, sf)  = nvfp4_quantize(normed, sf_scale)            (quant variant)
+#   out_bf16   = bf16(normed)                                (bf16 variant)
+# =====================================================================================
+@torch.inference_mode()
+def _ref_gate_resid_rmsnorm(x_2d, attn_2d, gate_table, gate_ts, tokens_per_batch, eps):
+    """Reference matching kernel: gate built bf16-narrow-first to match
+    PyTorch eager `_get_ada_values[2]`. Returns (normed_bf16, x_new_bf16)."""
+    B = gate_ts.shape[0]
+    D = x_2d.shape[-1]
+    x_3d = x_2d.view(B, tokens_per_batch, D).float()
+    a_3d = attn_2d.view(B, tokens_per_batch, D).float()
+    gate_bf16 = gate_table.to(torch.bfloat16).view(1, 1, D) + gate_ts.view(B, 1, D)
+    x_new = x_3d + a_3d * gate_bf16.float()
+    var = x_new.pow(2).mean(-1, keepdim=True)
+    normed = x_new * torch.rsqrt(var + eps)
+    return normed.view(-1, D).to(x_2d.dtype), x_new.view(-1, D).to(x_2d.dtype)
+
+
+@pytest.mark.parametrize("hidden_dim", [2048, 4096])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("tokens_per_batch", [16, 126])
+def test_gate_resid_rmsnorm_bf16(hidden_dim, batch_size, tokens_per_batch):
+    """bf16 variant: output matches reference; x mutated in place to x + attn * gate."""
+    num_tokens = batch_size * tokens_per_batch
+    x, attn, gate_table, gate_ts = _make_gate_resid_inputs(
+        num_tokens, hidden_dim, batch_size, seed=42
+    )
+    eps = 1e-6
+
+    ref_normed, ref_x_new = _ref_gate_resid_rmsnorm(
+        x, attn, gate_table, gate_ts, tokens_per_batch, eps
+    )
+
+    x_impl = x.clone()
+    out = _call_gate_resid_rmsnorm(x_impl, attn, gate_table, gate_ts, eps)
+
+    # Tolerance: same as the shift_scale variants -- bf16-narrow-first kernel vs fp32 ref differs at the
+    # bf16 ULP edge; longer-S reductions can push 1 element over the tighter 5e-3.
+    torch.testing.assert_close(out, ref_normed, rtol=2e-2, atol=1e-2)
+    torch.testing.assert_close(x_impl, ref_x_new, rtol=2e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("hidden_dim", [2048, 4096])
+@pytest.mark.parametrize("batch_size", [1, 2])
+def test_gate_resid_rmsnorm_quant_fp4(hidden_dim, batch_size):
+    """NVFP4 variant: end-to-end GEMM quality (cosine > 0.98) vs the bf16
+    F.linear reference. Also verifies in-place mutation: x <- x + attn * gate."""
+    tokens_per_batch = 126
+    num_tokens = batch_size * tokens_per_batch
+    out_dim = 1024
+    eps = 1e-6
+
+    x, attn, gate_table, gate_ts = _make_gate_resid_inputs(
+        num_tokens, hidden_dim, batch_size, seed=7
+    )
+    torch.manual_seed(13)
+    W = torch.randn(out_dim, hidden_dim, dtype=torch.bfloat16, device="cuda") * 0.05
+
+    # bf16 reference (eager): x_new = x + attn * gate; normed = rms_norm(x_new); D_ref = F.linear(normed, W).
+    normed_bf16, x_new_ref = _ref_gate_resid_rmsnorm(
+        x, attn, gate_table, gate_ts, tokens_per_batch, eps
+    )
+    D_ref = F.linear(normed_bf16, W)
+
+    sf_scale_x = (448.0 * 6.0) / normed_bf16.abs().max().float()
+    sf_scale_w = (448.0 * 6.0) / W.abs().max().float()
+
+    # bf16 op: in-place x <- x + attn * gate, produces (fp4, sf) of normed.
+    x_fp4 = x.clone()
+    out_fp4, out_sf = _call_gate_resid_rmsnorm_quant(
+        x_fp4, attn, gate_table, gate_ts, sf_scale_x, eps
+    )
+
+    # In-place mutation check (loose tolerance: bf16 mul accumulates noise).
+    torch.testing.assert_close(x_fp4, x_new_ref, rtol=2e-2, atol=1e-2)
+
+    # Weight quantize via canonical trtllm.fp4_quantize (matches SWIZZLED SF layout).
+    W_fp4, W_sf = torch.ops.trtllm.fp4_quantize(W, sf_scale_w, 16)
+
+    alpha = 1.0 / (sf_scale_x * sf_scale_w).float()
+    C = torch.ops.trtllm.nvfp4_gemm(out_fp4, W_fp4, out_sf, W_sf, alpha, torch.bfloat16)
+
+    assert F.cosine_similarity(C.flatten().float(), D_ref.flatten().float(), dim=0).item() > 0.98
+
+
+def test_gate_resid_rmsnorm_quant_rejects_unsupported_dim():
+    """hidden_dim outside {2048, 4096} raises."""
+    device = "cuda"
+    D = 1024  # not supported
+    x = torch.randn(8, D, dtype=torch.bfloat16, device=device)
+    attn = torch.randn(8, D, dtype=torch.bfloat16, device=device)
+    gate_table = torch.randn(D, dtype=torch.float32, device=device)
+    gate_ts = torch.randn(1, D, dtype=torch.bfloat16, device=device)
+    sf_scale = torch.tensor([1.0], dtype=torch.float32, device=device)
+    with pytest.raises(RuntimeError):
+        _call_gate_resid_rmsnorm_quant(x, attn, gate_table, gate_ts, sf_scale, 1e-6)
+
+
+# =====================================================================================
+# fused_dit_gate_resid  (bf16-only, no RMSNorm, no shift_scale)
+#   x <- x + attn_out * (gate_table.to(bf16) + gate_ts), in-place.
+#   Used at the FFN output gate site (`vx = vx + ff(vx_scaled) * vgate_mlp`).
+# =====================================================================================
+@torch.inference_mode()
+def _ref_gate_resid(x_2d, attn_2d, gate_table, gate_ts, tokens_per_batch):
+    """gate_bf16 = gate_table.to(bf16) + gate_ts; x_new = x + attn * gate_bf16 (per-batch gate)."""
+    B = gate_ts.shape[0]
+    D = x_2d.shape[-1]
+    x_3d = x_2d.view(B, tokens_per_batch, D)
+    a_3d = attn_2d.view(B, tokens_per_batch, D)
+    gate_bf16 = gate_table.to(torch.bfloat16).view(1, 1, D) + gate_ts.view(B, 1, D)
+    return (x_3d + a_3d * gate_bf16).view(-1, D)
+
+
+@pytest.mark.parametrize("hidden_dim", [2048, 4096])
+@pytest.mark.parametrize("batch_size", [1, 2])
+@pytest.mark.parametrize("tokens_per_batch", [16, 512])
+def test_gate_resid_bf16(hidden_dim, batch_size, tokens_per_batch):
+    """trtllm kernel matches the eager reference and mutates x in place."""
+    num_tokens = batch_size * tokens_per_batch
+    x, attn, gate_table, gate_ts = _make_gate_resid_inputs(
+        num_tokens, hidden_dim, batch_size, seed=42
+    )
+
+    ref = _ref_gate_resid(x, attn, gate_table, gate_ts, tokens_per_batch)
+
+    x_impl = x.clone()
+    out = _call_gate_resid(x_impl, attn, gate_table, gate_ts)
+
+    # pure bf16 __hfma2 vs bf16 eager: ~1 bf16 ULP on rare tail samples.
+    torch.testing.assert_close(out, ref, rtol=2e-2, atol=2e-2)
+    # op returns the same (mutated) tensor as x_impl.
+    assert out.data_ptr() == x_impl.data_ptr()
+    torch.testing.assert_close(x_impl, ref, rtol=2e-2, atol=2e-2)
+
+
+def test_gate_resid_rejects_non_contiguous():
+    """The in-place kernel requires contiguous x / attn_out."""
+    x, attn, gate_table, gate_ts = _make_gate_resid_inputs(32, 4096, batch_size=1, seed=0)
+    x_nc = x.transpose(0, 1).transpose(0, 1)[:, ::2]  # non-contiguous view
+    with pytest.raises((RuntimeError, AssertionError)):
+        _call_gate_resid(x_nc, attn[:, ::2], gate_table[::2], gate_ts[:, ::2])


### PR DESCRIPTION
## Description

Fuses LTX-2 NVFP4 transformer block's AdaLN modulation patterns into a single templated CUDA kernel. Replaces torch.compile-generated Triton prep kernels plus standalone bf16-to-fp4 quantize kernels with one fused launch per modulation site. The kernel is shape-polymorphic across video and audio tokens and composes six behaviors via templates: residual add, gate weighting, RMSNorm, AdaLN shift_scale, single vs dual shift_scale output, and inline fp4 quantization with per-block scale factors.

## Patterns Replaced

Each block modulation pattern becomes one cpp op (the modulating ones also have a `_quant` variant that emits FP4 + per-block SF inline):

| Op | Pattern | Use site |
|---|---|---|
| `fused_dit_rmsnorm_shift_scale[_quant]` | RmsNorm → shift_scale(shift, scale) | KA: post-pre-norm |
| `fused_dit_resid_rmsnorm_shift_scale_dual[_quant]` | Residual → RmsNorm → 2× independent shift_scale | KB: attention out, dual branches |
| `fused_dit_gate_resid_rmsnorm_shift_scale[_quant]` | Gate·Residual → RmsNorm → shift_scale | KC: FFN input, gated |
| `fused_dit_gate_resid_rmsnorm[_quant]` | Gate·Residual → RmsNorm (no shift_scale) | KD: tail of block |
| `fused_dit_gate_resid` | Gate·Residual (no RmsNorm, no shift_scale) | FFN output gate (`vx + ff(vx_scaled)·gate`) |

## Design

One templated kernel `fusedDiTGateResidNormShiftScaleKernel<D, ROWS_PER_BLOCK, BLOCK_SIZE, HAS_RESIDUAL, HAS_GATE, HAS_NORM, HAS_SHIFT_SCALE, NUM_OUT, HAS_QUANT>` (`cpp/tensorrt_llm/kernels/fusedDiTNormKernel.cu`). Six compile-time flags compose the block-prefix pipeline; 9 explicit `launchFusedDiTNorm` instantiations cover every call site:

| Variant | RESID | GATE | NORM | SHIFT_SCALE | NUM_OUT | dtypes | Pattern / use site |
|---|---|---|---|---|---|---|---|
| KA | ✗ | ✗ | ✓ | ✓ | 1 | bf16, fp4 | RmsNorm → shift_scale (post-pre-norm) |
| KB | ✓ | ✗ | ✓ | ✓ | 2 | bf16, fp4 | resid → RmsNorm → 2× shift_scale (attn out) |
| KC | ✓ | ✓ | ✓ | ✓ | 1 | bf16, fp4 | gate·resid → RmsNorm → shift_scale (FFN in) |
| KD | ✓ | ✓ | ✓ | ✗ | 1 | bf16, fp4 | gate·resid → RmsNorm (block tail) |
| gate_resid | ✓ | ✓ | ✗ | ✗ | 1 | bf16 | gate·resid (FFN out) |

Modulators are passed as `(table, ts)` pair-form and composed **inline** in-kernel — fp32 table narrowed to bf16 then one `__hadd2` — so no separate prep kernel runs. FP4 variants emit packed FP4 + 128×4 swizzled SF inline (no standalone quantize launch).

## Tile + load tactics (auto-dispatched by shape — no env var, no caller knob)

`launchFusedDiTNorm` picks one of two tiles and one of two X-load mechanisms from `(D, variant, token alignment)` at launch:

| Shape / variant | Tile | X load | Why this tactic |
|---|---|---|---|
| **video D=4096, KA/KB/KC** | Pipelined — 4-row/288t, warp-specialized, circular TMA | TMA bulk | large grid amortizes warp-spec setup; 4-row CTA reuses one modulator fetch ×4; multi-stage SMEM hides HBM latency |
| **video D=4096, KD + gate_resid** | Default — 1-row/256t | TMA bulk | no shift_scale → compute-light/HBM-bound; warp-spec overhead doesn't pay, but a single bulk load still frees the LSU |
| **audio D=2048, all** | Default — 1-row/256t | cp.async | grid too small (T≈252) and kernels are 2–4 µs → mbarrier setup cost exceeds cp.async's per-thread issue |

**Pipeline depth** (pipelined only): bf16 = **3 stages** (HBM-latency-bound, deeper hides more), fp4 = **2 stages** (Phase-2 quant is compute-heavy; extra stages only add SMEM pressure).

**attn load** (default tile): also TMA-bulk when `HAS_RESIDUAL && HAS_QUANT` (KD-quant) — its load overlaps the heavy quant Phase 2; bf16 keeps per-thread LDG (already overlaps the TMA-X load on a separate LSU pipe).

Auto-dispatch predicate for the pipelined tile (all must hold): `D==4096`, variant has `HAS_SHIFT_SCALE || !HAS_GATE` (KA/KB/KC; KD and gate_resid fail it), and `num_tokens % 4 == 0 && tokens_per_batch ≥ 4 && tokens_per_batch % 4 == 0`. Default tile is 1-row/256t, chosen by NCU sweep (2 CTAs/SM at ≤80 regs, best per-element rate among {2r256, 1r256, 1r512}).

**Pipelined vs default mechanics:**

| | Default | Pipelined |
|---|---|---|
| CTA | 1 row × 256t | 4 rows × 288t (`__launch_bounds__(288,2)`) |
| Warps | uniform 8 × 32 | 1 producer + 8 consumer (warp-specialized) |
| SMEM | single-buffered TMA load | circular 2–3 stages, mbarrier-driven |
| Sync | `__syncthreads()` | `mbarrier.try_wait.parity` + consumer-only `bar.sync 1, 256` |
| Modulator cache | per-row | per-batch, reused across 4 rows |

**Perf** (CUDA-Graph, true SM time, video D=4096): pipelined is −10…−25% vs default on KA/KB/KC bf16, −11…−15% on fp4. KD and audio always use the default tile.

## Per-kernel Microbenchmark

Pure GPU time via CUDA Graph capture + replay. V1 = (B=1, T=15360, D=4096), V2 = (B=2, T=15360, D=4096). `cpp` = this PR's fused kernel (auto-selected variant per the dispatch predicate above); `compile` = `torch.compile` of an equivalent eager expression that ends in `torch.ops.trtllm.tunable_fp4_quantize` with `is_sf_swizzled_layout=True` (matches the production Linear path). bf16 outputs verified by cosine ≥ 0.99 against an fp32 reference; FP4 outputs verified at the unit-test layer. Bench harness: `tmp/feature/ltx2-adaln-refactor/bench_kabcd_vs_compile.py`.

| Variant | Shape | cpp (μs) | compile (μs) | speedup |
|---|---|---|---|---|
| KA-quant | V1 | 73 | 117 | 1.60× |
| KA-quant | V2 | 144 | 241 | 1.68× |
| KB-quant | V1 | 146 | 231 | 1.59× |
| KB-quant | V2 | 281 | 494 | 1.76× |
| KC-quant | V1 | 96 | 149 | 1.55× |
| KC-quant | V2 | 187 | 307 | 1.65× |
| KD-quant | V1 | 71 | 129 | 1.82× |
| KD-quant | V2 | 143 | 265 | 1.85× |

## End-to-end (LTX-2 single-stage, 1 GPU, audio+video, guidance_scale=1.0, 768×1280×121 frames, 40 denoise steps)

5-run average, warmup excluded. B200. Denoise per-step is the pipeline's own `Denoising done` loop timing (40 steps, **excludes** VAE decode + text encode); full E2E is the whole `generate()` wall including VAE + text encode.

| | OFF (torch.compile baseline) | ON (this PR) | Δ | Gain |
|---|---|---|---|---|
| denoise loop, 40 steps (ms) | 13746 | 13184 | -562 ms | **-4.09%** |
| denoise per-step (ms) | 343.7 | 329.6 | -14.1 ms | **-4.09%** |
| full E2E incl VAE (ms) | 18955 | 18282 | -673 ms | -3.55% |

The fused AdaLN kernels touch only the denoise loop, so the -4.09% denoise gain is the kernel-level signal; the full-E2E -3.55% is diluted by the fixed VAE decode + text encode cost shared by both arms.

## Per-step kernel A/B (nsys, step 10, ON vs OFF, CUDA-Graph node trace)

Net change in the kernels this PR touches (AdaLN modulation + inline FP4 quant). GEMM, attention (cuDNN SDPA), and QK/split-norm kernels are excluded — this PR does not touch them. torch.compile triton-numbering suffixes (`_view_N`) are stripped before aggregation so renumbered-but-identical kernels match.

| Category | Count | GPU time (ms) |
|---|---|---|
| **Added** — fused C++ AdaLN kernels (default + pipelined) | 480 | +26.1 |
| **Removed** — torch.compile triton rms-norm/shift_scale prep | 480 | -26.9 |
| **Changed** — `quantize_with_block_size` (FP4 quant now inline) | 840 → 336 | -17.9 |
| **Net (touched region)** | — | **-17.6 ms/step** |

The dominant win is the FP4 quantize collapsing from 840 to 336 launches: the KA/KB/KC/KD quant variants now emit packed FP4 + per-block SF **inline** inside the fused kernel, eliminating 504 standalone `quantize_with_block_size` launches plus their bf16 round-trips through HBM. The ~480 added fused kernels are roughly time-neutral against the ~480 triton rms/shift_scale prep kernels they replace.

## Test Coverage

Four unit tests under `tests/unittest/_torch/thop/parallel_hw_agnostic/` exercise each op against an eager PyTorch reference. The `hidden_dim ∈ {2048, 4096} × batch_size ∈ {1, 2} × tokens_per_batch` parametrize sweep covers both the default tile and the pipelined variant naturally (no env-var injection):

- `test_fused_dit_rmsnorm_shift_scale.py` (KA bf16 + quant; bf16 tpb ∈ {1, 16, 512}, quant tpb ∈ {126, 128})
- `test_fused_dit_resid_rmsnorm_shift_scale_dual.py` (KB bf16 + quant; bf16 tpb ∈ {16, 512}, quant tpb ∈ {126, 128})
- `test_fused_dit_gate_resid_rmsnorm_shift_scale.py` (KC bf16 + quant; bf16 tpb ∈ {16, 512}, quant tpb ∈ {126, 128})
- `test_fused_dit_gate_resid_rmsnorm_quant.py` (KD bf16 + quant; KD always uses the default tile)

The `tpb=126` cases exercise the default tile (`126 % 4 = 2`); `tpb={16, 128, 512}` exercise the pipelined variant on D=4096 KA/KB/KC.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.

## Output equivalence (LPIPS: fused vs eager)

To confirm the fused AdaLN kernels are output-preserving, two LTX-2 videos were generated with identical seed / prompt / `guidance_scale=4.0` / 768×1280×121 / 40 steps and torch.compile **off**, differing only in fused AdaLN **on** (this PR) vs the **eager fallback** (the pre-PR path these kernels replace). LPIPS (AlexNet) over the decoded frames: **mean 0.140** (min 0.114, max 0.191) across 121 frames.

That sits in the benign fused-vs-eager band: diffusion sampling is chaotic, so any bf16-level numerical difference accumulates to ~0.1 LPIPS of "same scene, fine-detail drift" rather than a quality change. The montage below (5 frames spread across the clip; **left = eager / pre-PR**, **right = fused / this PR**, with per-frame and mean LPIPS) shows identical scene, pose, composition, and quality with no artifacts. This is in addition to the 86 unit tests that check each variant against an eager reference.

![LTX-2 fused-vs-eager LPIPS montage — mean 0.140 over 121 frames](https://raw.githubusercontent.com/luyiyun1021/TensorRT-LLM/lpips-assets/lpips_cmp_prepost_scored.png)

**Drift attribution.** A per-stage decomposition (verified on B200, both the D=2048 V1 and D=4096 pipelined paths) shows the ~0.14 is entirely the AdaLN **affine rounding**: the kernel evaluates `(1 + scale)·normed + shift` as a single-rounding fused multiply-add (nvcc contracts `__hmul2` + `__hadd2` into one HFMA2), whereas eager bf16 rounds twice (mul→round→add→round), so ~26% of elements differ by exactly 1 bf16 ULP. The RMSNorm stage — including the `rsqrtf` intrinsic and the fp32 reduction — is **bit-identical** to eager. The single-rounding result is closer to fp32, so the kernel is marginally *more* accurate here, not regressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fused RMSNorm + optional residual/gate/modulation kernels with BF16 and NVFP4 (FP4+scale) output modes, exposed as new CUDA-backed operators for faster inference.
  * Model runtime: optional fusion toggle and FP4-aware pathways; attention and linear modules now accept/propagate FP4-quantized tensors.

* **Tests**
  * Added end-to-end unit tests covering BF16 and NVFP4 variants, shape/stride checks, and quantized GEMM correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





