### PR TITLE
[None][doc] disagg: document multi-instance orchestrator scaling and session affinity

### DIFF
--- a/docs/source/features/disagg-serving.md
+++ b/docs/source/features/disagg-serving.md
@@ -233,6 +233,10 @@ Example (two-node deployment):
 - **Client entrypoint**
   - Send requests or use a load balancer forwarding to `node-a:8000` and `node-b:8000`
 
+The disaggregated server runs a single asyncio event loop that performs per-request routing and relays the streamed (SSE) response between the client and the generation server. At high concurrency this host-side loop — rather than the GPU workers — can become the latency bottleneck and inflate time-to-first-token. Because each instance is an independent, stateless front end over the shared context/generation pool (the instances do not coordinate with each other), running several of them parallelizes this host-side work without adding GPU nodes. The instances may run on separate nodes or be co-located on a single node on different ports.
+
+**Preserve session affinity for cache-aware routing.** Each instance keeps its own in-memory routing state — per-server load counters and, for cache-aware or conversation routing, the conversation-to-server mapping. If the load balancer spreads a single conversation's requests across different instances, those instances may route the requests to different context servers and lose KV-cache locality. Configure the load balancer (or client-side sharding) with session affinity so that all requests belonging to the same conversation reach the same disaggregated server instance.
+
 ## Environment Variables
 
 TRT-LLM uses some environment variables to control the behavior of disaggregated service.


### PR DESCRIPTION
The disaggregated-serving doc already has a **Multiple Instances** section describing how to run several `trtllm-serve disaggregated` instances over the same context/generation pool. This adds two things to that section:

1. **Rationale** — the disaggregated server runs a single asyncio event loop (per-request routing + SSE relay between client and generation server). At high concurrency this host-side loop, rather than the GPU workers, can become the latency bottleneck and inflate TTFT. Each instance is an independent, stateless front end over the shared backend (no inter-instance coordination), so running several parallelizes the host-side work without adding GPU nodes. Instances may be on separate nodes or co-located on one node on different ports.

2. **Session-affinity caveat** — each instance keeps its own in-memory routing state (per-server load counters and, for cache-aware/conversation routing, the conversation→server mapping). If a load balancer spreads one conversation across different instances, they may route it to different context servers and lose KV-cache locality. The load balancer (or client-side sharding) must use **session affinity** so a conversation always reaches the same instance.

Docs-only change to `docs/source/features/disagg-serving.md`.