### PR TITLE
[None][perf] executor: batch RPC submit to relieve rank-0 GIL contention

### DIFF
--- a/tensorrt_llm/executor/rpc_proxy.py
+++ b/tensorrt_llm/executor/rpc_proxy.py
@@ -79,6 +79,9 @@ class GenerationExecutorRpcProxy(RpcExecutorMixin, GenerationExecutor):
         tasks = [
             self._fetch_responses_loop_async,
         ]
+        # Drain partially-filled submit batches when batched submit is enabled.
+        if getattr(self, "_submit_batch_enabled", False):
+            tasks.append(self._submit_flush_loop_async)
         # Call mixin's setup_mainloop with custom tasks
         self.setup_mainloop(tasks=tasks, thread_name="rpc_proxy_main_loop")
 

--- a/tensorrt_llm/executor/rpc_proxy_mixin.py
+++ b/tensorrt_llm/executor/rpc_proxy_mixin.py
@@ -38,6 +38,23 @@ class RpcExecutorMixin:
         self.main_loop = None
         self.main_loop_thread = None
 
+        # --- batched submit (opt-in) ---
+        # rank 0 is the sole RPC ingress for the whole instance, so each request
+        # otherwise costs one pickle/HMAC + ZMQ round-trip + run_in_executor
+        # dispatch + GIL acquisition on rank 0, all competing with the
+        # co-located executor loop. That per-request overhead scales with
+        # concurrency and starves the loop at high load. When enabled, requests
+        # are coalesced into a single ``submit_batch`` RPC, collapsing those
+        # fixed per-request costs by ~the batch size. Disabled by default
+        # (TLLM_RPC_SUBMIT_BATCH_MAX=1) so behavior is unchanged unless opted in.
+        self._submit_batch_max = max(
+            1, int(os.getenv("TLLM_RPC_SUBMIT_BATCH_MAX", "1")))
+        self._submit_batch_delay_s = float(
+            os.getenv("TLLM_RPC_SUBMIT_BATCH_DELAY_MS", "0.5")) / 1e3
+        self._submit_batch_enabled = self._submit_batch_max > 1
+        self._submit_pending: List[GenerationRequest] = []
+        self._submit_pending_lock = threading.Lock()
+
     def setup_mainloop(
         self, tasks: Optional[List[Callable]] = None, thread_name: str = "rpc_proxy_main_loop"
     ):
@@ -83,10 +100,8 @@ class RpcExecutorMixin:
         request.set_id(self._get_next_client_id())
         logprob_params = self._get_logprob_params(request)
 
-        # submit is a fire-and-forget operation, don't need to wait for response
-        with nvtx_range_debug("RPCExecutor.submit", color="green", category="Proxy"):
-            self.rpc_client.submit(request).remote(need_response=False)
-
+        # Register the result *before* sending so a response can never arrive
+        # for a client_id that is not yet tracked (see handle_responses()).
         result = GenerationResult(
             request,
             background_error_handler=self._handle_background_error,
@@ -96,7 +111,59 @@ class RpcExecutorMixin:
         )
         self._results[request.id] = result
 
+        if self._submit_batch_enabled:
+            batch = None
+            with self._submit_pending_lock:
+                self._submit_pending.append(request)
+                if len(self._submit_pending) >= self._submit_batch_max:
+                    batch, self._submit_pending = self._submit_pending, []
+            # Size-triggered flush (steady state under load); stragglers are
+            # flushed by _submit_flush_loop_async().
+            if batch is not None:
+                self._send_submit_batch(batch)
+        else:
+            # submit is a fire-and-forget operation, don't need to wait for response
+            with nvtx_range_debug("RPCExecutor.submit", color="green", category="Proxy"):
+                self.rpc_client.submit(request).remote(need_response=False)
+
         return result
+
+    def _send_submit_batch(self, batch: "List[GenerationRequest]") -> None:
+        """Send a coalesced batch of requests to the worker via a single RPC.
+
+        Uses ``remote_future`` (non-blocking) so it is safe to call both from
+        request threads (size-triggered flush) and from the main loop
+        (time-triggered flush) without blocking either; the actual pickle/send
+        happens once on the RPC client's own loop/thread.
+        """
+        if not batch:
+            return
+        with nvtx_range_debug(f"RPCExecutor.submit_batch[{len(batch)}]",
+                              color="green",
+                              category="Proxy"):
+            self.rpc_client.submit_batch(batch).remote_future(
+                need_response=False)
+
+    async def _submit_flush_loop_async(self):
+        """Flush partially-filled submit batches after a short delay so low
+        concurrency / tail traffic is not held back by the size trigger."""
+        try:
+            while not self._shutdown_event.is_set():
+                await asyncio.sleep(self._submit_batch_delay_s)
+                batch = None
+                with self._submit_pending_lock:
+                    if self._submit_pending:
+                        batch, self._submit_pending = self._submit_pending, []
+                if batch is not None:
+                    self._send_submit_batch(batch)
+        except asyncio.CancelledError:
+            pass
+        finally:
+            # Best-effort drain of anything still pending at shutdown.
+            with self._submit_pending_lock:
+                batch, self._submit_pending = self._submit_pending, []
+            if batch:
+                self._send_submit_batch(batch)
 
     def handle_responses(self, responses: list[GenerationResult]) -> bool:
         async_queues = []

--- a/tensorrt_llm/executor/rpc_worker_mixin.py
+++ b/tensorrt_llm/executor/rpc_worker_mixin.py
@@ -55,6 +55,22 @@ class RpcWorkerMixin:
             logger_debug(f"[worker] Submitted request {request.id}", color="green")
             return result
 
+    def submit_batch(self, requests: "list[GenerationRequest]"):
+        """Submit a batch of requests received in a single RPC call.
+
+        rank 0 is the sole RPC ingress for the whole instance, so collapsing N
+        per-request ``submit`` calls into one amortizes the pickle/HMAC,
+        dispatch and GIL-acquisition overhead that otherwise scales with
+        concurrency and starves the executor loop (the co-located rank-0
+        worker). The C++ enqueue inside ``super().submit`` releases the GIL, so
+        the loop yields naturally between requests.
+        """
+        with nvtx_range_debug(f"RpcWorker.submit_batch[{len(requests)}]",
+                              color="blue",
+                              category="Worker"):
+            for request in requests:
+                super().submit(request)
+
     def fetch_responses(self, timeout: Optional[float] = None) -> list:
         """Fetch responses from the response queue (blocking)."""
         logger_debug(f"[worker] RpcWorker {self.rank} is fetching responses", color="yellow")


### PR DESCRIPTION
## Problem

On the RPC executor path (`GenerationExecutorRpcProxy` / `RpcWorker`), **rank 0 is the sole RPC ingress** for the whole instance (`RpcWorkerMixin.start_rpc_server` binds the server only on `rank == 0`) **and also runs the co-located rank-0 model worker**. Every request therefore pays, on rank 0:

- `pickle` + HMAC of the `GenerationRequest` (incl. `prompt_token_ids`) on send and the matching `pickle.loads` on receive,
- a ZMQ round-trip,
- a `run_in_executor` dispatch on the RPC server thread pool,
- and a GIL acquisition,

all competing with the executor loop on the **same** GIL. This per-request overhead scales with concurrency, so at high load the executor loop (worker0) gets starved. In nsys this shows up as `RpcWorker.submit` holding the GIL while the worker loop waits — mild at low concurrency (e.g. c400) but severe at high concurrency (e.g. c2048).

#14889 (avoid `deepcopy` of `prompt_token_ids` on enqueue) cut a per-request **constant**; it does not change how the cost scales with concurrency.

## Change

Add an **opt-in** batched-submit path that coalesces requests on the proxy into a single `submit_batch` RPC, collapsing the *fixed per-request* costs (RPC framing, pickle/HMAC call, ZMQ op, dispatch, GIL acquisition count) by ~the batch size:

- **`RpcWorkerMixin.submit_batch(requests)`** — enqueue a list of requests in one RPC. The C++ enqueue inside `super().submit()` releases the GIL, so the loop yields naturally between requests.
- **`RpcExecutorMixin`** — buffer requests and flush on **size** (`TLLM_RPC_SUBMIT_BATCH_MAX`) or after a short **delay** (`TLLM_RPC_SUBMIT_BATCH_DELAY_MS`). The time-triggered flush runs on the proxy main loop and uses `remote_future` (non-blocking) so it never blocks the loop or the response path.
- The `GenerationResult` is now registered **before** sending, so a response can never arrive for an untracked `client_id`.

This is orthogonal to (and stacks with) shrinking the per-request payload (e.g. shipping `prompt_token_ids` as a raw ZMQ frame instead of pickling) — batching cuts the *count*-based overheads, payload work cuts the *bytes*-based ones.

## Knobs (env)

| Var | Default | Meaning |
|-----|---------|---------|
| `TLLM_RPC_SUBMIT_BATCH_MAX` | `1` (disabled) | Max requests per coalesced RPC; `>1` enables batching |
| `TLLM_RPC_SUBMIT_BATCH_DELAY_MS` | `0.5` | Straggler-flush window for partially-filled batches |

**Disabled by default — no behavior change unless opted in.**

## Test plan

- [ ] A/B at high concurrency (c2048, DSeek-V4 disagg GEN): nsys `python-gil` — fraction of time worker0 spends in GIL-wait per decode step, with batching off vs on; sweep `TLLM_RPC_SUBMIT_BATCH_MAX` ∈ {8,16,32,64}.
- [ ] TTFT / throughput / output-speed at c400 and c2048 (off vs on).
- [ ] Correctness: streaming + non-streaming, abort, disaggregated gen-only.

> Draft — opening for early review / to run the A/B above.