### PR TITLE
[None][feat] Support partial RoPE fusion for Hopper kernels in XQA for Laguna

### DIFF
--- a/cpp/kernels/xqa/defines.h
+++ b/cpp/kernels/xqa/defines.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -163,6 +163,14 @@ static_assert(SPEC_DEC, "SPEC_Q_SEQ_LEN should only be used when SPEC_DEC is ena
 #if SPEC_DEC
 #error "SPEC_DEC is not supported for USE_INPUT_KV"
 #endif
+#endif
+
+// Number of head elements RoPE is applied to (rotary_embedding_dim). Defaults to the full head
+// (HEAD_ELEMS) for full rotary; set smaller for partial rotary (partial_rotary_factor < 1). The
+// trailing [ROPE_ELEMS, HEAD_ELEMS) elements are passed through unrotated. Defined unconditionally
+// so validRopeElemsPerHead is well-formed even for kernels that do not apply RoPE in-kernel.
+#ifndef ROPE_ELEMS
+#define ROPE_ELEMS HEAD_ELEMS
 #endif
 
 // Output element type:

--- a/cpp/kernels/xqa/mha.h
+++ b/cpp/kernels/xqa/mha.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +30,12 @@ constexpr bool isMLA = IS_MLA;
 static_assert((isMLA || validElemsPerHead <= 256) && (sizeof(CacheElem) * validElemsPerHead) % 16 == 0);
 constexpr uint32_t headElems = validElemsPerHead <= 64 ? 64 : (validElemsPerHead <= 128 ? 128 : (isMLA ? 576 : 256));
 static_assert(headElems == 64 || headElems == 128 || headElems == 256 || headElems == 576, "not implemented");
+// Number of head elements RoPE is applied to. Equals validElemsPerHead for full rotary; smaller for
+// partial rotary, in which case [validRopeElemsPerHead, validElemsPerHead) is passed through unrotated.
+constexpr uint32_t validRopeElemsPerHead = ROPE_ELEMS;
+static_assert(validRopeElemsPerHead > 0 && validRopeElemsPerHead <= validElemsPerHead && validRopeElemsPerHead % 2 == 0
+        && (sizeof(CacheElem) * validRopeElemsPerHead) % 16 == 0,
+    "ROPE_ELEMS must be a positive, even multiple yielding 16B-aligned rope region and not exceed the head size");
 constexpr uint32_t beamWidth = BEAM_WIDTH;
 constexpr uint32_t headGrpSize = HEAD_GRP_SIZE;
 #if SPEC_DEC

--- a/cpp/kernels/xqa/mha.h
+++ b/cpp/kernels/xqa/mha.h
@@ -159,7 +159,7 @@ void launchHopperF8MHA(cudaDeviceProp const& prop, uint32_t nbKHeads,
 #if USE_INPUT_KV
     InputHead const* qkv,
 #if ROPE_STYLE != 0
-    Vec<float, validElemsPerHead> const* ropeCosSin,
+    Vec<float, validRopeElemsPerHead> const* ropeCosSin,
 #endif
 #else
     InputHead const* q,

--- a/cpp/kernels/xqa/mha_sm90.cu
+++ b/cpp/kernels/xqa/mha_sm90.cu
@@ -500,32 +500,44 @@ __device__ void finalizeAndWriteOut_sync(uint32_t warpRank, DstHead* dst, Shared
     uint32_t nbKHeads /* only for final result in spec dec. set to 1 for workspace*/, uint32_t ctaNbValidTokens);
 #endif
 
-inline constexpr uint32_t ropeNbPairsPerThrdImpl(uint32_t nbThrds)
+// nbElems is the number of head elements processed as pairs. The RoPE'd q/k path uses the rope region
+// (validRopeElemsPerHead); the V path and non-RoPE q/k path use the full head (validElemsPerHead).
+inline constexpr uint32_t ropeNbPairsPerThrdImpl(uint32_t nbThrds, uint32_t nbElems)
 {
-    auto const val = divUp(exactDiv(validElemsPerHead, 2), nbThrds);
+    auto const val = divUp(exactDiv(nbElems, 2), nbThrds);
     assert(val <= 32);
     return val <= 2 ? val : (val <= 4 ? 4 : (val <= 8 ? 8 : (val <= 16 ? 16 : 32)));
 }
 
-template <uint32_t nbThrds>
-inline constexpr uint32_t ropeNbPairsPerThrd = ropeNbPairsPerThrdImpl(nbThrds);
+template <uint32_t nbThrds, uint32_t nbElems = validElemsPerHead>
+inline constexpr uint32_t ropeNbPairsPerThrd = ropeNbPairsPerThrdImpl(nbThrds, nbElems);
 
-template <typename SrcElem, bool forNeox, uint32_t nbThrds, typename DstElem = float>
-__device__ Vec<Vec<DstElem, 2>, ropeNbPairsPerThrd<nbThrds>> loadHead(
-    Vec<SrcElem, validElemsPerHead> const& head, uint32_t tid);
+// nbElems selects how many leading head elements are processed (default: the full head). srcElems is
+// deduced from the argument: the q/k path passes a full head and only the first nbElems are read; the
+// cos/sin path passes an nbElems-sized buffer.
+template <typename SrcElem, bool forNeox, uint32_t nbThrds, typename DstElem = float,
+    uint32_t nbElems = validElemsPerHead, uint32_t srcElems = validElemsPerHead>
+__device__ Vec<Vec<DstElem, 2>, ropeNbPairsPerThrd<nbThrds, nbElems>> loadHead(
+    Vec<SrcElem, srcElems> const& head, uint32_t tid);
 template <bool forNeox, uint32_t nbPairsPerThrd>
 __device__ mha::conditional_t<forNeox, Vec<Vec<CacheElem, nbPairsPerThrd>, 2>, Vec<Vec<CacheElem, 2>, nbPairsPerThrd>>
 applyRoPE(Vec<Vec<float, 2>, nbPairsPerThrd> const& data, Vec<Vec<float, 2>, nbPairsPerThrd> const& ropeCosSin);
-template <bool forNeox, uint32_t nbThrds>
+template <bool forNeox, uint32_t nbThrds, uint32_t nbElems = validElemsPerHead>
 __device__ void storeRotatedPairsForKV(GMemCacheHead& dst,
-    mha::conditional_t<forNeox, Vec<Vec<CacheElem, ropeNbPairsPerThrd<nbThrds>>, 2>,
-        Vec<Vec<CacheElem, 2>, ropeNbPairsPerThrd<nbThrds>>> const& src,
+    mha::conditional_t<forNeox, Vec<Vec<CacheElem, ropeNbPairsPerThrd<nbThrds, nbElems>>, 2>,
+        Vec<Vec<CacheElem, 2>, ropeNbPairsPerThrd<nbThrds, nbElems>>> const& src,
     uint32_t tid);
-template <bool forNeox, uint32_t nbThrds>
+template <bool forNeox, uint32_t nbThrds, uint32_t nbElems = validElemsPerHead>
 __device__ void storeRotatedPairsForQ(SharedMem::QBuffer& dst,
-    mha::conditional_t<forNeox, Vec<Vec<CacheElem, ropeNbPairsPerThrd<nbThrds>>, 2>,
-        Vec<Vec<CacheElem, 2>, ropeNbPairsPerThrd<nbThrds>>> const& src,
+    mha::conditional_t<forNeox, Vec<Vec<CacheElem, ropeNbPairsPerThrd<nbThrds, nbElems>>, 2>,
+        Vec<Vec<CacheElem, 2>, ropeNbPairsPerThrd<nbThrds, nbElems>>> const& src,
     uint32_t row, uint32_t tid);
+// Partial-rotary helpers: copy the unrotated tail [validRopeElemsPerHead, validElemsPerHead) of a head
+// (no-ops when validRopeElemsPerHead == validElemsPerHead).
+template <uint32_t nbThrds>
+__device__ void storeUnrotatedTailForKV(GMemCacheHead& dst, InputHead const& src, float scale, uint32_t tid);
+template <uint32_t nbThrds>
+__device__ void storeUnrotatedTailForQ(SharedMem::QBuffer& dst, InputHead const& src, uint32_t row, uint32_t tid);
 
 class ScratchMem
 {
@@ -682,7 +694,7 @@ CUBIN_EXPORT __global__
 #if USE_INPUT_KV
             IOHead const* __restrict__ const qkv, // [nbReq][beamWidth][nbQHeads+nbKHeads+nbVHeads],
 #if ROPE_STYLE != 0
-            Vec<float, validElemsPerHead> const* __restrict__ const ropeCosSin, // [maxNbPosEmb]
+            Vec<float, validRopeElemsPerHead> const* __restrict__ const ropeCosSin, // [maxNbPosEmb]
 #endif
 #else
             IOHead const* __restrict__ const q, // [nbReq][beamWidth][nbQHeads],
@@ -1457,8 +1469,9 @@ CUBIN_EXPORT __global__
             smem.qBar.consumed.arrive_and_wait();
 #if ROPE_STYLE != 0
             auto const& ropeCosSinHead
-                = reinterpret_cast<Vec<float, validElemsPerHead> const&>(ropeCosSin[cacheSeqLen - 1]);
-            auto const cosSinPairs = loadHead<float, false, thrdsPerHead>(ropeCosSinHead, tid);
+                = reinterpret_cast<Vec<float, validRopeElemsPerHead> const&>(ropeCosSin[cacheSeqLen - 1]);
+            auto const cosSinPairs
+                = loadHead<float, false, thrdsPerHead, float, validRopeElemsPerHead>(ropeCosSinHead, tid);
 #endif
 #if ENABLE_PDL == 2
             acqBulk();
@@ -1474,10 +1487,17 @@ CUBIN_EXPORT __global__
 #if ROPE_STYLE == 0
                 auto const rotatedPairs = loadHead<InputElem, isNeox, thrdsPerHead, MathElem>(qData[idxHead], tid);
 #else
-                auto const pairs = loadHead<InputElem, isNeox, thrdsPerHead>(qData[idxHead], tid);
+                auto const pairs
+                    = loadHead<InputElem, isNeox, thrdsPerHead, float, validRopeElemsPerHead>(qData[idxHead], tid);
                 auto const rotatedPairs = applyRoPE<isNeox>(pairs, cosSinPairs);
 #endif
-                storeRotatedPairsForQ<isNeox, thrdsPerHead>(smem.q, rotatedPairs, idxHead, tid);
+                // nbElems == validRopeElemsPerHead for the rope region; for ROPE_STYLE == 0 this equals
+                // validElemsPerHead (full head), matching the loadHead above.
+                storeRotatedPairsForQ<isNeox, thrdsPerHead, validRopeElemsPerHead>(smem.q, rotatedPairs, idxHead, tid);
+#if ROPE_STYLE != 0
+                // Partial rotary: copy the unrotated tail of the head (no-op for full rotary).
+                storeUnrotatedTailForQ<thrdsPerHead>(smem.q, qData[idxHead], idxHead, tid);
+#endif
             }
 #else
             TinyPtr<IOHead const> const qData{q, headGrpSize * (nbKHeads * (beamWidth * ctaInputTokBeg) + idxHeadGrp)};
@@ -1543,12 +1563,18 @@ CUBIN_EXPORT __global__
                         kTilePartLoader.getHead(newTokenPos), convertedPairs, lane);
 #else
                     constexpr bool isNeox = (ROPE_STYLE == 1);
-                    auto const pairs = loadHead<InputElem, isNeox, warp_size>(inKHead, lane) * rcpKScale;
+                    auto const pairs
+                        = loadHead<InputElem, isNeox, warp_size, float, validRopeElemsPerHead>(inKHead, lane)
+                        * rcpKScale;
                     auto const& ropeCosSinHead
-                        = reinterpret_cast<Vec<float, validElemsPerHead> const&>(ropeCosSin[cacheSeqLen - 1]);
-                    auto const cosSinPairs = loadHead<float, false, warp_size>(ropeCosSinHead, lane);
+                        = reinterpret_cast<Vec<float, validRopeElemsPerHead> const&>(ropeCosSin[cacheSeqLen - 1]);
+                    auto const cosSinPairs
+                        = loadHead<float, false, warp_size, float, validRopeElemsPerHead>(ropeCosSinHead, lane);
                     auto const rotatedPairs = applyRoPE<isNeox>(pairs, cosSinPairs);
-                    storeRotatedPairsForKV<isNeox, warp_size>(kTilePartLoader.getHead(newTokenPos), rotatedPairs, lane);
+                    storeRotatedPairsForKV<isNeox, warp_size, validRopeElemsPerHead>(
+                        kTilePartLoader.getHead(newTokenPos), rotatedPairs, lane);
+                    // Partial rotary: copy the unrotated tail of the head (no-op for full rotary).
+                    storeUnrotatedTailForKV<warp_size>(kTilePartLoader.getHead(newTokenPos), inKHead, rcpKScale, lane);
 #endif
                     static_assert(inputSeqLen == 1);
                     __syncwarp();
@@ -3265,12 +3291,15 @@ __device__ inline void finalizeAndWriteOut_sync(uint32_t warpRank, DstHead* dst,
 }
 #endif
 
-template <typename SrcElem, bool forNeox, uint32_t nbThrds, typename DstElem>
-__device__ inline Vec<Vec<DstElem, 2>, ropeNbPairsPerThrd<nbThrds>> loadHead(
-    Vec<SrcElem, validElemsPerHead> const& head, uint32_t tid)
+template <typename SrcElem, bool forNeox, uint32_t nbThrds, typename DstElem, uint32_t nbElems, uint32_t srcElems>
+__device__ inline Vec<Vec<DstElem, 2>, ropeNbPairsPerThrd<nbThrds, nbElems>> loadHead(
+    Vec<SrcElem, srcElems> const& head, uint32_t tid)
 {
-    constexpr uint32_t nbPairs = exactDiv(validElemsPerHead, 2);
-    constexpr uint32_t nbPairsPerThrd = ropeNbPairsPerThrd<nbThrds>;
+    // Only the first nbElems elements are loaded; for NEOX the two halves sit at [0, nbElems/2) and
+    // [nbElems/2, nbElems). For the RoPE'd path nbElems == validRopeElemsPerHead (the rope region).
+    constexpr uint32_t nbPairs = exactDiv(nbElems, 2);
+    static_assert(srcElems >= nbElems);
+    constexpr uint32_t nbPairsPerThrd = ropeNbPairsPerThrd<nbThrds, nbElems>;
     constexpr uint32_t nbWorkingThrds = exactDiv(nbPairs, nbPairsPerThrd);
     bool const isWorkingThrd = (nbWorkingThrds == nbThrds || tid < nbWorkingThrds);
     static_assert(nbPairs % nbPairsPerThrd == 0);
@@ -3339,14 +3368,14 @@ applyRoPE(Vec<Vec<float, 2>, nbPairsPerThrd> const& data, Vec<Vec<float, 2>, nbP
     }
 }
 
-template <bool forNeox, uint32_t nbThrds>
+template <bool forNeox, uint32_t nbThrds, uint32_t nbElems>
 __device__ inline void storeRotatedPairsForKV(GMemCacheHead& dst,
-    mha::conditional_t<forNeox, Vec<Vec<CacheElem, ropeNbPairsPerThrd<nbThrds>>, 2>,
-        Vec<Vec<CacheElem, 2>, ropeNbPairsPerThrd<nbThrds>>> const& src,
+    mha::conditional_t<forNeox, Vec<Vec<CacheElem, ropeNbPairsPerThrd<nbThrds, nbElems>>, 2>,
+        Vec<Vec<CacheElem, 2>, ropeNbPairsPerThrd<nbThrds, nbElems>>> const& src,
     uint32_t tid)
 {
-    constexpr uint32_t nbPairs = exactDiv(validElemsPerHead, 2);
-    constexpr uint32_t nbPairsPerThrd = ropeNbPairsPerThrd<nbThrds>;
+    constexpr uint32_t nbPairs = exactDiv(nbElems, 2);
+    constexpr uint32_t nbPairsPerThrd = ropeNbPairsPerThrd<nbThrds, nbElems>;
     constexpr uint32_t nbWorkingThrds = exactDiv(nbPairs, nbPairsPerThrd);
     bool const isWorkingThrd = (nbWorkingThrds == nbThrds || tid < nbWorkingThrds);
     static_assert(nbPairs % nbPairsPerThrd == 0);
@@ -3366,14 +3395,14 @@ __device__ inline void storeRotatedPairsForKV(GMemCacheHead& dst,
     }
 }
 
-template <bool forNeox, uint32_t nbThrds>
+template <bool forNeox, uint32_t nbThrds, uint32_t nbElems>
 __device__ inline void storeRotatedPairsForQ(SharedMem::QBuffer& dst,
-    mha::conditional_t<forNeox, Vec<Vec<CacheElem, ropeNbPairsPerThrd<nbThrds>>, 2>,
-        Vec<Vec<CacheElem, 2>, ropeNbPairsPerThrd<nbThrds>>> const& src,
+    mha::conditional_t<forNeox, Vec<Vec<CacheElem, ropeNbPairsPerThrd<nbThrds, nbElems>>, 2>,
+        Vec<Vec<CacheElem, 2>, ropeNbPairsPerThrd<nbThrds, nbElems>>> const& src,
     uint32_t row, uint32_t tid)
 {
-    constexpr uint32_t nbPairs = exactDiv(validElemsPerHead, 2);
-    constexpr uint32_t nbPairsPerThrd = ropeNbPairsPerThrd<nbThrds>;
+    constexpr uint32_t nbPairs = exactDiv(nbElems, 2);
+    constexpr uint32_t nbPairsPerThrd = ropeNbPairsPerThrd<nbThrds, nbElems>;
     constexpr uint32_t nbWorkingThrds = exactDiv(nbPairs, nbPairsPerThrd);
     bool const isWorkingThrd = (nbWorkingThrds == nbThrds || tid < nbWorkingThrds);
     static_assert(nbPairs % nbPairsPerThrd == 0);
@@ -3436,6 +3465,58 @@ __device__ inline void storeRotatedPairsForQ(SharedMem::QBuffer& dst,
     }
 }
 
+// Copy the unrotated tail [validRopeElemsPerHead, validElemsPerHead) of a head into the (linear) K
+// cache, converting InputElem -> CacheElem and applying the kv-cache scale. No-op for full rotary.
+template <uint32_t nbThrds>
+__device__ inline void storeUnrotatedTailForKV(GMemCacheHead& dst, InputHead const& src, float scale, uint32_t tid)
+{
+    if constexpr (validRopeElemsPerHead < validElemsPerHead)
+    {
+        constexpr uint32_t tailElems = validElemsPerHead - validRopeElemsPerHead;
+        constexpr uint32_t nbIters = divUp(tailElems, nbThrds);
+#pragma unroll
+        for (uint32_t iter = 0; iter < nbIters; iter++)
+        {
+            uint32_t const e = validRopeElemsPerHead + tid + iter * nbThrds;
+            if (e >= validElemsPerHead)
+            {
+                break;
+            }
+            dst[e] = convert<CacheElem>(Vec<float, 1>{float(src[e]) * scale})[0];
+        }
+    }
+}
+
+// Copy the unrotated tail [validRopeElemsPerHead, validElemsPerHead) of a head into the swizzled Q
+// shared-memory buffer, converting InputElem -> CacheElem. Mirrors the byte->(part,grain) mapping in
+// storeRotatedPairsForQ so the GMMA sees a contiguous head. No-op for full rotary.
+template <uint32_t nbThrds>
+__device__ inline void storeUnrotatedTailForQ(SharedMem::QBuffer& dst, InputHead const& src, uint32_t row, uint32_t tid)
+{
+    if constexpr (validRopeElemsPerHead < validElemsPerHead)
+    {
+        constexpr uint32_t tailElems = validElemsPerHead - validRopeElemsPerHead;
+        constexpr uint32_t nbIters = divUp(tailElems, nbThrds);
+#pragma unroll
+        for (uint32_t iter = 0; iter < nbIters; iter++)
+        {
+            uint32_t const e = validRopeElemsPerHead + tid + iter * nbThrds;
+            if (e >= validElemsPerHead)
+            {
+                break;
+            }
+            CacheElem const val = convert<CacheElem>(Vec<float, 1>{float(src[e])})[0];
+            auto const byteOffset = BoundedVal<mathHeadBytes>{cacheElemSize * e};
+            uint32_t const idxPart = byteOffset.template divBy<qPartBytes>().get();
+            auto const byteOffsetInsidePart = byteOffset.template mod<qPartBytes>();
+            uint32_t const idxGrain = byteOffsetInsidePart.template divBy<grainBytes>().get();
+            uint32_t const byteOffsetInsideGrain = byteOffsetInsidePart.template mod<grainBytes>().get();
+            LdGrain& grain = dst[idxPart].template at<true>(row, idxGrain);
+            reinterpret_cast<CacheElem*>(reinterpret_cast<mha::byte*>(&grain) + byteOffsetInsideGrain)[0] = val;
+        }
+    }
+}
+
 #ifndef GENERATE_CUBIN
 uint32_t computeNbSubSeqPerSeqHopperF8MHA(
     cudaDeviceProp const& prop, uint32_t batchSize, uint32_t nbKHeads, uint32_t maxSeqLen)
@@ -3466,7 +3547,7 @@ void launchHopperF8MHA(cudaDeviceProp const& prop, uint32_t nbKHeads,
 #if USE_INPUT_KV
     InputHead const* qkv,
 #if ROPE_STYLE != 0
-    Vec<float, validElemsPerHead> const* ropeCosSin,
+    Vec<float, validRopeElemsPerHead> const* ropeCosSin,
 #endif
 #else
     InputHead const* q,

--- a/cpp/kernels/xqa/test/refAttention.h
+++ b/cpp/kernels/xqa/test/refAttention.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -103,14 +103,16 @@ Eigen::Matrix<float, headGrpSize, validElemsPerHead, Eigen::RowMajor> refAttenti
 #endif
 
 template <uint32_t ropeStyle>
-InputHead applyRoPE(InputHead const& head, Vec<float, validElemsPerHead> const& ropeCosSin)
+InputHead applyRoPE(InputHead const& head, Vec<float, validRopeElemsPerHead> const& ropeCosSin)
 {
     if constexpr (ropeStyle == 0)
     {
         return head;
     }
-    constexpr uint32_t nbPairs = exactDiv(validElemsPerHead, 2);
-    InputHead dst;
+    // Only the first validRopeElemsPerHead elements are rotated (the rope region); the trailing
+    // [validRopeElemsPerHead, validElemsPerHead) elements pass through unrotated (partial rotary).
+    constexpr uint32_t nbPairs = exactDiv(validRopeElemsPerHead, 2);
+    InputHead dst = head;
     constexpr bool isNeox = (ropeStyle == 1);
     for (uint32_t i = 0; i < nbPairs; i++)
     {

--- a/cpp/kernels/xqa/test/test.cpp
+++ b/cpp/kernels/xqa/test/test.cpp
@@ -307,12 +307,14 @@ void runTest(uint32_t batchSize, uint32_t seqLen, bool testPerf, bool refCheck, 
     std::unique_ptr<CUevent_st, cudaError (*)(cudaEvent_t)> const ticEv{tic, &cudaEventDestroy};
     std::unique_ptr<CUevent_st, cudaError (*)(cudaEvent_t)> const tocEv{toc, &cudaEventDestroy};
 
-    auto const ropeCosSin = ManagedMemBuf<Vec<float, validElemsPerKHead>>(seqLen);
+    // The cos/sin cache only covers the rope region (validRopeElemsPerHead elements per position);
+    // for full rotary this equals the head size, for partial rotary it is smaller.
+    auto const ropeCosSin = ManagedMemBuf<Vec<float, validRopeElemsPerHead>>(seqLen);
 #if USE_INPUT_KV && defined(ROPE_STYLE) && ROPE_STYLE
     for (uint32_t m = 0; m < seqLen; m++)
     {
         auto& pairs = ropeCosSin[m];
-        constexpr uint32_t nbPairs = exactDiv(validElemsPerKHead, 2);
+        constexpr uint32_t nbPairs = exactDiv(validRopeElemsPerHead, 2);
         for (uint32_t i = 0; i < nbPairs; i++)
         {
             float const theta = m * std::pow(1E4F, (-1.F / nbPairs) * i);
@@ -1506,9 +1508,9 @@ TEST(NVRTC, compile)
         "gmma.cuh", "gmma_impl.cuh", "barriers.cuh", "tma.h", "cuda_bf16.h", "cuda_bf16.hpp", "cuda_fp16.h",
         "cuda_fp16.hpp", "cuda_fp8.h", "cuda_fp8.hpp", "vector_types.h", "vector_functions.h", "device_types.h"};
     assert(headers_content.size() == headers_name.size());
-    auto test
-        = [&](int input_fp16, int cache_enum, int head_dim, int head_grp_size, bool use_paged_kv_cache,
-              int paged_kv_cache_layout, int beam_width, char const* source_file, int compileMajor, int compileMinor)
+    auto test = [&](int input_fp16, int cache_enum, int head_dim, int head_grp_size, bool use_paged_kv_cache,
+                    int paged_kv_cache_layout, int beam_width, char const* source_file, int compileMajor,
+                    int compileMinor, int rope_elems = 0)
     {
         std::string arch_flag = "-arch=sm_" + std::to_string(compileMajor) + std::to_string(compileMinor);
         if ((compileMajor == 9 || compileMajor == 10 || compileMajor == 12) && compileMinor == 0)
@@ -1540,6 +1542,7 @@ TEST(NVRTC, compile)
             options.push_back("-DROPE_STYLE=1");
             options.push_back("-DSLIDING_WINDOW=1");
             options.push_back("-DLOW_PREC_OUTPUT=1");
+            options.push_back("-DROPE_ELEMS=" + std::to_string(rope_elems != 0 ? rope_elems : head_dim));
         }
         std::vector<char const*> options_cstr;
         for (auto const& option : options)
@@ -1619,6 +1622,14 @@ TEST(NVRTC, compile)
                                 }
                                 test(input_fp16, cache_enum, head_dim, 8, use_paged_kv_cache, paged_kv_cache_layout,
                                     beam_width, source_file, major, minor);
+                                // Verify the partial-rotary in-kernel RoPE path also compiles (rope dim
+                                // = head_dim/2, a 16-multiple for these head dims) on the sm90 fused path.
+                                if (source_file == tensorrt_llm::kernels::mha_sm90_cu_content && cache_enum == 2
+                                    && (head_dim / 2) % 16 == 0)
+                                {
+                                    test(input_fp16, cache_enum, head_dim, 8, use_paged_kv_cache, paged_kv_cache_layout,
+                                        beam_width, source_file, major, minor, head_dim / 2);
+                                }
                             }
                         }
                     }

--- a/cpp/kernels/xqa/test/test.cpp
+++ b/cpp/kernels/xqa/test/test.cpp
@@ -310,16 +310,32 @@ void runTest(uint32_t batchSize, uint32_t seqLen, bool testPerf, bool refCheck, 
     // The cos/sin cache only covers the rope region (validRopeElemsPerHead elements per position);
     // for full rotary this equals the head size, for partial rotary it is smaller.
     auto const ropeCosSin = ManagedMemBuf<Vec<float, validRopeElemsPerHead>>(seqLen);
+#if USE_INPUT_KV && ROPE_STYLE != 0
+    auto const fullHeadRopeCosSin = ManagedMemBuf<Vec<float, validElemsPerHead>>(seqLen);
+#endif
 #if USE_INPUT_KV && defined(ROPE_STYLE) && ROPE_STYLE
     for (uint32_t m = 0; m < seqLen; m++)
     {
         auto& pairs = ropeCosSin[m];
+#if USE_INPUT_KV && ROPE_STYLE != 0
+        auto& fullHeadPairs = fullHeadRopeCosSin[m];
+        constexpr uint32_t nbFullHeadPairs = exactDiv(validElemsPerHead, 2);
+        for (uint32_t i = 0; i < nbFullHeadPairs; i++)
+        {
+            fullHeadPairs[i * 2] = 1.F;
+            fullHeadPairs[i * 2 + 1] = 0.F;
+        }
+#endif
         constexpr uint32_t nbPairs = exactDiv(validRopeElemsPerHead, 2);
         for (uint32_t i = 0; i < nbPairs; i++)
         {
             float const theta = m * std::pow(1E4F, (-1.F / nbPairs) * i);
             pairs[i * 2] = std::cos(theta);
             pairs[i * 2 + 1] = std::sin(theta);
+#if USE_INPUT_KV && ROPE_STYLE != 0
+            fullHeadPairs[i * 2] = pairs[i * 2];
+            fullHeadPairs[i * 2 + 1] = pairs[i * 2 + 1];
+#endif
         }
     }
 #endif
@@ -787,62 +803,115 @@ void runTest(uint32_t batchSize, uint32_t seqLen, bool testPerf, bool refCheck, 
     }();
     auto runKernel = [&]()
     {
-        auto const launchFunc = useQGMMA ? &launchHopperF8MHA : &launchMHA;
-
 #if SPEC_DEC
         SpecDecParams const specDecParams{.qSeqLen = qSeqLen,
             .qCuSeqLens = reinterpret_cast<uint32_t const*>(deviceCuQSeqLen),
             .mask = reinterpret_cast<MaskType const*>(devicePackedMask)};
 #endif
-        launchFunc(prop, nbKHeads,
+        if (useQGMMA)
+        {
+            launchHopperF8MHA(prop, nbKHeads,
 #if SLIDING_WINDOW
-            slidingWinSize,
+                slidingWinSize,
 #endif
-            qScale,
+                qScale,
 #if SPEC_DEC
-            &output[0][0][0][0],
+                &output[0][0][0][0],
 #else
-            &output[0][0][0],
+                &output[0][0][0],
 #endif
 #if LOW_PREC_OUTPUT
-            rcpOutScale.get(),
+                rcpOutScale.get(),
 #endif
 #if USE_INPUT_KV
-            &qkvHeads[0][0][0],
+                &qkvHeads[0][0][0],
 #if ROPE_STYLE != 0
-            ropeCosSin.get(),
+                ropeCosSin.get(),
 #endif
 #else
 #if SPEC_DEC
-            &qHeads[0][0][0][0],
+                &qHeads[0][0][0][0],
 #else
-            &qHeads[0][0][0],
+                &qHeads[0][0][0],
 #endif
 #endif
-            attentionSinksPtr,
+                attentionSinksPtr,
 #if PAGED_KV_CACHE_LAYOUT == 1 && USE_PAGED_KV_CACHE
-            cacheKHeads.get(), cacheVHeads.get(),
+                cacheKHeads.get(), cacheVHeads.get(),
 #else
-            cacheHeads.get(),
+                cacheHeads.get(),
 #endif
 #if USE_PAGED_KV_CACHE
-            pageListArg,
+                pageListArg,
 #endif
-            maxSeqLen, &seqLenList[0][0],
+                maxSeqLen, &seqLenList[0][0],
 #if BEAM_WIDTH > 1
-            beamSearchParams,
+                beamSearchParams,
 #endif
-            batchSize, kvCacheScale.get(),
+                batchSize, kvCacheScale.get(),
 #if SPEC_DEC
-            specDecParams,
+                specDecParams,
 #endif
 #if SKIP_SOFTMAX_ATTN
-            skipSoftmaxThresholdScaleFactor,
+                skipSoftmaxThresholdScaleFactor,
 #if SKIP_SOFTMAX_ATTN_BLOCK_STATS
-            kernelSkippedBlockCount.get(), kernelTotalBlockCount.get(),
+                kernelSkippedBlockCount.get(), kernelTotalBlockCount.get(),
 #endif
 #endif
-            semaphores.get(), scratch, stream);
+                semaphores.get(), scratch, stream);
+        }
+        else
+        {
+            launchMHA(prop, nbKHeads,
+#if SLIDING_WINDOW
+                slidingWinSize,
+#endif
+                qScale,
+#if SPEC_DEC
+                &output[0][0][0][0],
+#else
+                &output[0][0][0],
+#endif
+#if LOW_PREC_OUTPUT
+                rcpOutScale.get(),
+#endif
+#if USE_INPUT_KV
+                &qkvHeads[0][0][0],
+#if ROPE_STYLE != 0
+                fullHeadRopeCosSin.get(),
+#endif
+#else
+#if SPEC_DEC
+                &qHeads[0][0][0][0],
+#else
+                &qHeads[0][0][0],
+#endif
+#endif
+                attentionSinksPtr,
+#if PAGED_KV_CACHE_LAYOUT == 1 && USE_PAGED_KV_CACHE
+                cacheKHeads.get(), cacheVHeads.get(),
+#else
+                cacheHeads.get(),
+#endif
+#if USE_PAGED_KV_CACHE
+                pageListArg,
+#endif
+                maxSeqLen, &seqLenList[0][0],
+#if BEAM_WIDTH > 1
+                beamSearchParams,
+#endif
+                batchSize, kvCacheScale.get(),
+#if SPEC_DEC
+                specDecParams,
+#endif
+#if SKIP_SOFTMAX_ATTN
+                skipSoftmaxThresholdScaleFactor,
+#if SKIP_SOFTMAX_ATTN_BLOCK_STATS
+                kernelSkippedBlockCount.get(), kernelTotalBlockCount.get(),
+#endif
+#endif
+                semaphores.get(), scratch, stream);
+        }
         checkCuda(cudaGetLastError());
     };
 #endif

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplCommon.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplCommon.cpp
@@ -55,13 +55,13 @@ XQAKernelRuntimeHashKey getRuntimeHashKeyFromXQAParams(XQAParams const& xqaParam
     unsigned int kernel_m_tilesize = getKernelMTileSize(
         num_q_heads_over_kv, xqaParams.multi_query_tokens, qSeqLen, isXqaJit, supportQGMMA, supportMLA);
 
+    bool const includesRotaryDim = isXqaJit && jit::appliesRoPEInXqaKernel(xqaParams, supportQGMMA);
     // precompiled XQA does not use is_fp8_output as hashing key
     return {xqaParams.kv_cache_data_type, head_size, beam_width, kernel_num_q_heads_over_kv, kernel_m_tilesize,
         xqaParams.paged_kv_cache ? static_cast<unsigned int>(xqaParams.tokens_per_block) : 0, xqaParams.paged_kv_cache,
         xqaParams.multi_query_tokens, isXqaJit ? xqaParams.is_fp8_output : false,
         isXqaJit ? std::optional(xqaParams.position_embedding_type) : std::nullopt,
-        // Only the JIT path bakes the rotary dim into the cubin
-        isXqaJit ? std::optional<int>(xqaParams.rotary_embedding_dim) : std::nullopt};
+        includesRotaryDim ? std::optional<int>(xqaParams.rotary_embedding_dim) : std::nullopt};
 }
 
 } // namespace kernels

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplCommon.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplCommon.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,9 @@ XQAKernelRuntimeHashKey getRuntimeHashKeyFromXQAParams(XQAParams const& xqaParam
     return {xqaParams.kv_cache_data_type, head_size, beam_width, kernel_num_q_heads_over_kv, kernel_m_tilesize,
         xqaParams.paged_kv_cache ? static_cast<unsigned int>(xqaParams.tokens_per_block) : 0, xqaParams.paged_kv_cache,
         xqaParams.multi_query_tokens, isXqaJit ? xqaParams.is_fp8_output : false,
-        isXqaJit ? std::optional(xqaParams.position_embedding_type) : std::nullopt};
+        isXqaJit ? std::optional(xqaParams.position_embedding_type) : std::nullopt,
+        // Only the JIT path bakes the rotary dim into the cubin
+        isXqaJit ? std::optional<int>(xqaParams.rotary_embedding_dim) : std::nullopt};
 }
 
 } // namespace kernels

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplCommon.h
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplCommon.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,6 +70,11 @@ struct XQAKernelRuntimeHashKey
     bool multi_query_tokens;
     bool is_fp8_output;
     std::optional<PositionEmbeddingType> position_embedding_type;
+    // Rotary embedding dim (head elements RoPE is applied to). Only meaningful for the JIT path,
+    // where it selects between full- and partial-rotary cubins (which bake ROPE_ELEMS in). Left as
+    // std::nullopt for the precompiled path, whose kernels never apply RoPE in-kernel and are thus
+    // rotary-agnostic (RoPE handled by invokeQKVPreprocessing).
+    std::optional<int> rotary_embedding_dim;
 
     bool operator==(XQAKernelRuntimeHashKey const& other) const
     {
@@ -77,7 +82,8 @@ struct XQAKernelRuntimeHashKey
             && num_q_heads_per_kv == other.num_q_heads_per_kv && beam_size == other.beam_size
             && multi_query_tokens == other.multi_query_tokens && m_tilesize == other.m_tilesize
             && tokens_per_page == other.tokens_per_page && paged_kv_cache == other.paged_kv_cache
-            && is_fp8_output == other.is_fp8_output && position_embedding_type == other.position_embedding_type;
+            && is_fp8_output == other.is_fp8_output && position_embedding_type == other.position_embedding_type
+            && rotary_embedding_dim == other.rotary_embedding_dim;
     }
 };
 
@@ -109,6 +115,8 @@ struct XQAKernelRuntimeHasher
         key ^= s.is_fp8_output;
         key <<= 8;
         key ^= static_cast<int8_t>(s.position_embedding_type.value_or(static_cast<PositionEmbeddingType>(-1)));
+        key <<= 9; // rotary dims are <= 256; 0 distinguishes the std::nullopt (precompiled) case
+        key ^= static_cast<size_t>(s.rotary_embedding_dim.value_or(0));
         return key;
     }
 };

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/compileEngine.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/compileEngine.cpp
@@ -57,7 +57,13 @@ CubinObj CompileEngine::compile() const
     tllmXqaJitProgram program;
     bool const useQGMMAKernel = supportConfigQGMMA(mXqaParams, mSM, true);
     tllmXqaJitRopeStyle ropeStyle = tllmXqaJitRopeStyle::TLLM_XQA_JIT_ROPE_NONE;
-    bool const applyRoPEInXqaKernel = !mXqaParams.multi_query_tokens && useQGMMAKernel
+    // The in-kernel RoPE path rotates the full head and indexes the cos/sin cache with a
+    // head_size stride, so it only supports full rotary (rotary_embedding_dim == head_size).
+    // For partial rotary (e.g. partial_rotary_factor < 1), fall back to the separate
+    // invokeQKVPreprocessing kernel, which honors rotary_embedding_dim. Must stay in sync with
+    // the same condition in decoderXQAImplJIT.cpp.
+    bool const isFullRotary = (mXqaParams.rotary_embedding_dim == mXqaParams.head_size);
+    bool const applyRoPEInXqaKernel = !mXqaParams.multi_query_tokens && useQGMMAKernel && isFullRotary
         && tensorrt_llm::common::contains({PositionEmbeddingType::kLONG_ROPE, PositionEmbeddingType::kROPE_GPT_NEOX,
                                               PositionEmbeddingType::kROPE_GPTJ},
             mXqaParams.position_embedding_type);

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/compileEngine.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/compileEngine.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,13 +57,14 @@ CubinObj CompileEngine::compile() const
     tllmXqaJitProgram program;
     bool const useQGMMAKernel = supportConfigQGMMA(mXqaParams, mSM, true);
     tllmXqaJitRopeStyle ropeStyle = tllmXqaJitRopeStyle::TLLM_XQA_JIT_ROPE_NONE;
-    // The in-kernel RoPE path rotates the full head and indexes the cos/sin cache with a
-    // head_size stride, so it only supports full rotary (rotary_embedding_dim == head_size).
-    // For partial rotary (e.g. partial_rotary_factor < 1), fall back to the separate
-    // invokeQKVPreprocessing kernel, which honors rotary_embedding_dim. Must stay in sync with
-    // the same condition in decoderXQAImplJIT.cpp.
-    bool const isFullRotary = (mXqaParams.rotary_embedding_dim == mXqaParams.head_size);
-    bool const applyRoPEInXqaKernel = !mXqaParams.multi_query_tokens && useQGMMAKernel && isFullRotary
+    // The in-kernel RoPE path rotates the first rotary_embedding_dim elements of each head (the rope
+    // region) and copies the remaining elements unrotated, so it supports both full and partial rotary.
+    // It requires the rope region to be 16B-aligned for any supported cache dtype (rotary_embedding_dim
+    // a multiple of 16). Shapes that do not satisfy this fall back to invokeQKVPreprocessing, which also
+    // honors rotary_embedding_dim. Must stay in sync with the same condition in decoderXQAImplJIT.cpp.
+    bool const isSupportedRotary = mXqaParams.rotary_embedding_dim > 0
+        && mXqaParams.rotary_embedding_dim <= mXqaParams.head_size && mXqaParams.rotary_embedding_dim % 16 == 0;
+    bool const applyRoPEInXqaKernel = !mXqaParams.multi_query_tokens && useQGMMAKernel && isSupportedRotary
         && tensorrt_llm::common::contains({PositionEmbeddingType::kLONG_ROPE, PositionEmbeddingType::kROPE_GPT_NEOX,
                                               PositionEmbeddingType::kROPE_GPTJ},
             mXqaParams.position_embedding_type);
@@ -111,6 +112,11 @@ CubinObj CompileEngine::compile() const
         // scratch in this case.
         /*use_input_kv=*/applyRoPEInXqaKernel,
         /*rope_style=*/ropeStyle,
+        // When applying RoPE in-kernel, pass the actual rotary dim
+        // Otherwise pass head_size so the (unused) ROPE_ELEMS is valid for static_asserts.
+        /*rotary_embedding_dim=*/
+        applyRoPEInXqaKernel ? static_cast<uint32_t>(mXqaParams.rotary_embedding_dim)
+                             : static_cast<uint32_t>(mXqaParams.head_size),
         /*is_spec_dec_tree=*/mXqaParams.is_spec_dec_tree,
         /*use_skip_softmax_attn=*/mXqaParams.skip_softmax_threshold_scale_factor != 0};
     if (context.kernel_type == TLLM_XQA_JIT_MLA)

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/compileEngine.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/compileEngine.cpp
@@ -57,17 +57,7 @@ CubinObj CompileEngine::compile() const
     tllmXqaJitProgram program;
     bool const useQGMMAKernel = supportConfigQGMMA(mXqaParams, mSM, true);
     tllmXqaJitRopeStyle ropeStyle = tllmXqaJitRopeStyle::TLLM_XQA_JIT_ROPE_NONE;
-    // The in-kernel RoPE path rotates the first rotary_embedding_dim elements of each head (the rope
-    // region) and copies the remaining elements unrotated, so it supports both full and partial rotary.
-    // It requires the rope region to be 16B-aligned for any supported cache dtype (rotary_embedding_dim
-    // a multiple of 16). Shapes that do not satisfy this fall back to invokeQKVPreprocessing, which also
-    // honors rotary_embedding_dim. Must stay in sync with the same condition in decoderXQAImplJIT.cpp.
-    bool const isSupportedRotary = mXqaParams.rotary_embedding_dim > 0
-        && mXqaParams.rotary_embedding_dim <= mXqaParams.head_size && mXqaParams.rotary_embedding_dim % 16 == 0;
-    bool const applyRoPEInXqaKernel = !mXqaParams.multi_query_tokens && useQGMMAKernel && isSupportedRotary
-        && tensorrt_llm::common::contains({PositionEmbeddingType::kLONG_ROPE, PositionEmbeddingType::kROPE_GPT_NEOX,
-                                              PositionEmbeddingType::kROPE_GPTJ},
-            mXqaParams.position_embedding_type);
+    bool const applyRoPEInXqaKernel = appliesRoPEInXqaKernel(mXqaParams, useQGMMAKernel);
     if (applyRoPEInXqaKernel)
     {
         TLLM_CHECK(useQGMMAKernel);

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/decoderXQAImplJIT.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/decoderXQAImplJIT.cpp
@@ -247,19 +247,8 @@ void DecoderXQAImplJIT::runImpl(XQAParams const& xqaParams, KVCacheBuffer const&
     //  * If applyRoPEInXqaKernel is false, a separate kernel applies RoPE (see invokeQKVPreprocessing), then XQA kernel
     //  performs SDPA.
     //    In this case, xqa_q_input_ptr (see below) serves as the scratch space to store intermediate RoPE output.
-    // The in-kernel RoPE path rotates the first rotary_embedding_dim elements of each head (the rope
-    // region) and copies the remaining elements unrotated, so it supports both full and partial rotary.
-    // It requires the rope region to be 16B-aligned for any supported cache dtype (rotary_embedding_dim
-    // a multiple of 16). Shapes that do not satisfy this fall back to invokeQKVPreprocessing below, which
-    // also honors rotary_embedding_dim. Must stay in sync with the same condition in compileEngine.cpp so
-    // the compiled cubin and the runtime launch agree.
-    bool const isSupportedRotary = xqaParams.rotary_embedding_dim > 0
-        && xqaParams.rotary_embedding_dim <= xqaParams.head_size && xqaParams.rotary_embedding_dim % 16 == 0;
-    bool const applyRoPEInXqaKernel = isGMMAKernel && !isSpecDec && isSupportedRotary
-        && tensorrt_llm::common::contains({PositionEmbeddingType::kLONG_ROPE, PositionEmbeddingType::kROPE_GPT_NEOX,
-                                              PositionEmbeddingType::kROPE_GPTJ},
-            xqaParams.position_embedding_type)
-        && !xqaParams.isMLA();
+
+    bool const applyRoPEInXqaKernel = jit::appliesRoPEInXqaKernel(xqaParams, isGMMAKernel);
 
     unsigned int head_size = xqaParams.head_size;
     int num_q_heads = xqaParams.num_q_heads;

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/decoderXQAImplJIT.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/decoderXQAImplJIT.cpp
@@ -247,7 +247,13 @@ void DecoderXQAImplJIT::runImpl(XQAParams const& xqaParams, KVCacheBuffer const&
     //  * If applyRoPEInXqaKernel is false, a separate kernel applies RoPE (see invokeQKVPreprocessing), then XQA kernel
     //  performs SDPA.
     //    In this case, xqa_q_input_ptr (see below) serves as the scratch space to store intermediate RoPE output.
-    bool const applyRoPEInXqaKernel = isGMMAKernel && !isSpecDec
+    // The in-kernel RoPE path rotates the full head and indexes the cos/sin cache with a
+    // head_size stride, so it only supports full rotary (rotary_embedding_dim == head_size).
+    // For partial rotary (e.g. partial_rotary_factor < 1), fall back to invokeQKVPreprocessing
+    // below, which honors rotary_embedding_dim. Must stay in sync with the same condition in
+    // compileEngine.cpp so the compiled cubin and the runtime launch agree.
+    bool const isFullRotary = (xqaParams.rotary_embedding_dim == xqaParams.head_size);
+    bool const applyRoPEInXqaKernel = isGMMAKernel && !isSpecDec && isFullRotary
         && tensorrt_llm::common::contains({PositionEmbeddingType::kLONG_ROPE, PositionEmbeddingType::kROPE_GPT_NEOX,
                                               PositionEmbeddingType::kROPE_GPTJ},
             xqaParams.position_embedding_type)

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/decoderXQAImplJIT.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/decoderXQAImplJIT.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ XQAKernelRuntimeHashKey getRuntimeHashKeyFromKernelMeta(XQAKernelMetaInfo const&
 {
     return {kernelMeta.mKVDataType, kernelMeta.mHeadDim, kernelMeta.mBeamWidth, kernelMeta.mNumQHeadsOverKV,
         kernelMeta.mMTileSize, kernelMeta.mTokensPerPage, kernelMeta.mPagedKVCache, kernelMeta.mMultiQueryTokens, false,
-        std::nullopt};
+        std::nullopt, std::nullopt};
 }
 
 } // anonymous namespace
@@ -247,13 +247,15 @@ void DecoderXQAImplJIT::runImpl(XQAParams const& xqaParams, KVCacheBuffer const&
     //  * If applyRoPEInXqaKernel is false, a separate kernel applies RoPE (see invokeQKVPreprocessing), then XQA kernel
     //  performs SDPA.
     //    In this case, xqa_q_input_ptr (see below) serves as the scratch space to store intermediate RoPE output.
-    // The in-kernel RoPE path rotates the full head and indexes the cos/sin cache with a
-    // head_size stride, so it only supports full rotary (rotary_embedding_dim == head_size).
-    // For partial rotary (e.g. partial_rotary_factor < 1), fall back to invokeQKVPreprocessing
-    // below, which honors rotary_embedding_dim. Must stay in sync with the same condition in
-    // compileEngine.cpp so the compiled cubin and the runtime launch agree.
-    bool const isFullRotary = (xqaParams.rotary_embedding_dim == xqaParams.head_size);
-    bool const applyRoPEInXqaKernel = isGMMAKernel && !isSpecDec && isFullRotary
+    // The in-kernel RoPE path rotates the first rotary_embedding_dim elements of each head (the rope
+    // region) and copies the remaining elements unrotated, so it supports both full and partial rotary.
+    // It requires the rope region to be 16B-aligned for any supported cache dtype (rotary_embedding_dim
+    // a multiple of 16). Shapes that do not satisfy this fall back to invokeQKVPreprocessing below, which
+    // also honors rotary_embedding_dim. Must stay in sync with the same condition in compileEngine.cpp so
+    // the compiled cubin and the runtime launch agree.
+    bool const isSupportedRotary = xqaParams.rotary_embedding_dim > 0
+        && xqaParams.rotary_embedding_dim <= xqaParams.head_size && xqaParams.rotary_embedding_dim % 16 == 0;
+    bool const applyRoPEInXqaKernel = isGMMAKernel && !isSpecDec && isSupportedRotary
         && tensorrt_llm::common::contains({PositionEmbeddingType::kLONG_ROPE, PositionEmbeddingType::kROPE_GPT_NEOX,
                                               PositionEmbeddingType::kROPE_GPTJ},
             xqaParams.position_embedding_type)

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/kernelUtils.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/kernelUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,6 +81,25 @@ bool supportConfigCommon(XQAParams const& xqaParams, bool forConfigurePlugin)
 }
 
 } // anonymous namespace
+
+bool appliesRoPEInXqaKernel(XQAParams const& xqaParams, bool isQGMMAKernel)
+{
+    // In-kernel RoPE is only implemented by the Hopper QGMMA kernel, and only for non-spec-dec, non-MLA
+    // cases.
+    if (!isQGMMAKernel || xqaParams.multi_query_tokens || xqaParams.isMLA())
+    {
+        return false;
+    }
+    // The in-kernel RoPE rotates the first rotary_embedding_dim head elements and copies the rest
+    // unrotated; it requires the rope region to be 16B-aligned for any supported cache dtype
+    // (rotary_embedding_dim a multiple of 16). Unsupported shapes fall back to invokeQKVPreprocessing.
+    bool const isSupportedRotary = xqaParams.rotary_embedding_dim > 0
+        && xqaParams.rotary_embedding_dim <= xqaParams.head_size && xqaParams.rotary_embedding_dim % 16 == 0;
+    return isSupportedRotary
+        && tensorrt_llm::common::contains({PositionEmbeddingType::kLONG_ROPE, PositionEmbeddingType::kROPE_GPT_NEOX,
+                                              PositionEmbeddingType::kROPE_GPTJ},
+            xqaParams.position_embedding_type);
+}
 
 bool supportConfigQGMMA(XQAParams const& xqaParams, int SM, bool forConfigurePlugin)
 {

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/kernelUtils.h
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/kernelUtils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,8 @@ bool supportConfigHMMA(XQAParams const& xqaParams, int SM, bool forConfigurePlug
 bool supportConfigMLA(XQAParams const& xqaParams, int SM, bool forConfigurePlugin);
 bool supportConfigTllmGen(
     XQAParams const& xqaParams, int SM, bool forConfigurePlugin, TllmGenFmhaRunner const* tllmRunner);
+
+bool appliesRoPEInXqaKernel(XQAParams const& xqaParams, bool isQGMMAKernel);
 
 } // namespace jit
 } // namespace kernels

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/nvrtcWrapper/include/nvrtcWrapper.h
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/nvrtcWrapper/include/nvrtcWrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +63,11 @@ extern "C"
         bool fp8_output;
         bool use_input_kv;
         tllmXqaJitRopeStyle rope_style; // useful only when use_input_kv is true.
+
+        // Number of head elements RoPE is applied to (rotary_embedding_dim). Equals head_size for
+        // full rotary; smaller for partial rotary (partial_rotary_factor < 1). Useful only when
+        // rope_style != NONE; callers may leave it 0, in which case it defaults to head_size.
+        unsigned int rotary_embedding_dim;
 
         bool is_spec_dec_tree
             = true; // useful only when multi_query_tokens, should be true unless using linear tree in spec-dec.

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/nvrtcWrapper/src/nvrtcWrapper.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplJIT/nvrtcWrapper/src/nvrtcWrapper.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -188,6 +188,9 @@ tllmXqaJitStatus getMacroFlags(tllmXqaJitContext const* context, std::vector<std
     macros["LOW_PREC_OUTPUT"] = context->fp8_output ? "1" : "0";
     macros["USE_INPUT_KV"] = context->use_input_kv ? "1" : "0";
     macros["ROPE_STYLE"] = std::to_string(int(context->rope_style));
+    // Number of head elements RoPE is applied to. Defaults to head_size (full rotary) when unset.
+    macros["ROPE_ELEMS"]
+        = std::to_string(context->rotary_embedding_dim != 0 ? context->rotary_embedding_dim : head_size);
     macros["IS_SPEC_DEC_TREE"] = context->is_spec_dec_tree ? "1" : "0";
     macros["SKIP_SOFTMAX_ATTN"] = context->use_skip_softmax_attn ? "1" : "0";
 #ifdef SKIP_SOFTMAX_STAT

--- a/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplPrecompiled.cpp
+++ b/cpp/tensorrt_llm/kernels/decoderMaskedMultiheadAttention/decoderXQAImplPrecompiled.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ public:
             }
             XQAKernelRuntimeHashKey hash_key{kernelMeta.mKVDataType, kernelMeta.mHeadDim, kernelMeta.mBeamWidth,
                 kernelMeta.mNumQHeadsOverKV, kernelMeta.mMTileSize, kernelMeta.mTokensPerPage, kernelMeta.mPagedKVCache,
-                kernelMeta.mMultiQueryTokens, false, std::nullopt};
+                kernelMeta.mMultiQueryTokens, false, std::nullopt, std::nullopt};
 
             mFunctions.insert(std::make_pair(hash_key, funcInfo));
         }
@@ -132,7 +132,7 @@ public:
             = {xqaParams.kv_cache_data_type, head_size, beam_width, kernel_num_q_heads_over_kv, m_tilesize,
                 xqaParams.paged_kv_cache ? static_cast<unsigned int>(xqaParams.tokens_per_block) : 0,
                 xqaParams.paged_kv_cache, xqaParams.multi_query_tokens, 0, /* xqa jit param is_fp8_output */
-                std::nullopt};
+                std::nullopt, /* position_embedding_type */ std::nullopt /* rotary_embedding_dim */};
         auto const findIter = mFunctions.find(hash_key);
         return findIter != mFunctions.end();
     }

--- a/tensorrt_llm/_torch/models/modeling_laguna.py
+++ b/tensorrt_llm/_torch/models/modeling_laguna.py
@@ -247,13 +247,6 @@ class LagunaAttention(QKNormRoPEAttention):
         self._use_gating = bool(gating)
         self._gate_per_head = gating == "per-head" or gating is True
 
-        # Temporary workaround: Hopper fails without unfused RoPE for Laguna
-        # While Blackwell has issues when RoPE is unfused.
-        # This check is to unblock Blackwell on main while we find proper fixes
-        # https://nvbugs/6211185
-        # rope_fusion = get_sm_version() in (100, 103)
-        rope_fusion = True
-
         # fuse_qk_norm_rope=False is required: the fused kernel reads
         # partial_rotary_factor and yarn params from pretrained_config
         # globally, ignoring per-layer RopeParams. Laguna has different
@@ -266,7 +259,6 @@ class LagunaAttention(QKNormRoPEAttention):
             bias=getattr(config, "qkv_bias", False) or getattr(config, "attention_bias", False),
             pos_embd_params=pos_embd_params,
             fuse_qk_norm_rope=False,
-            rope_fusion=rope_fusion,
             layer_idx=layer_idx,
             dtype=config.torch_dtype,
             dense_bias=False,

--- a/tensorrt_llm/_torch/models/modeling_laguna.py
+++ b/tensorrt_llm/_torch/models/modeling_laguna.py
@@ -21,7 +21,6 @@ import torch.nn.functional as F
 from torch import nn
 from transformers import PretrainedConfig
 
-from tensorrt_llm._utils import get_sm_version
 from tensorrt_llm.functional import PositionEmbeddingType, RotaryScalingType
 
 from ..attention_backend import AttentionMetadata
@@ -252,7 +251,8 @@ class LagunaAttention(QKNormRoPEAttention):
         # While Blackwell has issues when RoPE is unfused.
         # This check is to unblock Blackwell on main while we find proper fixes
         # https://nvbugs/6211185
-        rope_fusion = get_sm_version() in (100, 103)
+        # rope_fusion = get_sm_version() in (100, 103)
+        rope_fusion = True
 
         # fuse_qk_norm_rope=False is required: the fused kernel reads
         # partial_rotary_factor and yarn params from pretrained_config

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -137,6 +137,7 @@ l0_h100:
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_scales_cuda_graph_padding[mtp_nextn=0]
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_fp8_block_scales_cuda_graph_padding[mtp_nextn=2]
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Nano::test_fp8
+  - accuracy/test_llm_api_pytorch.py::TestLagunaXS::test_fp8
   - test_e2e.py::test_trtllm_bench_pytorch_backend_sanity[meta-llama/Llama-3.1-8B-llama-3.1-8b-False-False]
   - test_e2e.py::test_trtllm_bench_pytorch_backend_sanity[meta-llama/Llama-3.1-8B-llama-3.1-8b-instruct-hf-fp8-True-True]
   - disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_fp8_tp1_single_gpu[DeepSeek-V3-Lite-fp8]


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for partial rotary position embeddings, enabling fine-grained control over which head elements apply rotary position encoding.

* **Improvements**
  * Simplified Laguna model attention configuration by removing device-specific workarounds.

* **Tests**
  * Added H100 accuracy test for PyTorch Laguna model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Description

Poolside Laguna-XS previously required a workaround to disable rope fusion in order to get correct outputs on Hopper. The root cause was that the underlying kernel did not support partial RoPE, and so was not correct for the Laguna model. This PR adds the required changes to support fused partial RoPE.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
