### PR TITLE
[None][perf] executor: in-process fast-path for rank-0 RPC submit

### DIFF
--- a/tensorrt_llm/executor/rpc_proxy_mixin.py
+++ b/tensorrt_llm/executor/rpc_proxy_mixin.py
@@ -12,7 +12,7 @@ from .request import GenerationRequest
 from .result import GenerationResult
 from .rpc import RPCClient
 from .rpc.rpc_common import get_unique_ipc_addr
-from .utils import ErrorResponse, is_llm_response
+from .utils import ErrorResponse, get_local_rpc_worker, is_llm_response
 
 
 class RpcExecutorMixin:
@@ -37,6 +37,15 @@ class RpcExecutorMixin:
         self.main_loop_task_obj = None
         self.main_loop = None
         self.main_loop_thread = None
+
+        # In-process RPC fast-path (opt-in). When the rank-0 worker is
+        # co-located in this process (MpiCommSession), submit() calls it
+        # directly instead of going through the loopback pickle/HMAC/ZMQ RPC,
+        # which otherwise burns the GIL on rank 0 in competition with the
+        # executor loop. Disabled by default; falls back to RPC when the worker
+        # is not local (e.g. spawn-proxy topology).
+        self._local_fastpath = os.getenv("TLLM_RPC_LOCAL_FASTPATH",
+                                         "0") == "1"
 
     def setup_mainloop(
         self, tasks: Optional[List[Callable]] = None, thread_name: str = "rpc_proxy_main_loop"
@@ -83,10 +92,8 @@ class RpcExecutorMixin:
         request.set_id(self._get_next_client_id())
         logprob_params = self._get_logprob_params(request)
 
-        # submit is a fire-and-forget operation, don't need to wait for response
-        with nvtx_range_debug("RPCExecutor.submit", color="green", category="Proxy"):
-            self.rpc_client.submit(request).remote(need_response=False)
-
+        # Register the result before sending so a response can never arrive for
+        # a client_id that is not yet tracked (see handle_responses()).
         result = GenerationResult(
             request,
             background_error_handler=self._handle_background_error,
@@ -95,6 +102,19 @@ class RpcExecutorMixin:
             logprob_params=logprob_params,
         )
         self._results[request.id] = result
+
+        # In-process fast-path: when the rank-0 worker lives in this process,
+        # call it directly and skip the loopback pickle / HMAC / ZMQ / dispatch.
+        # A miss (e.g. spawn-proxy topology) falls back to RPC automatically.
+        local_worker = (get_local_rpc_worker(self.rpc_addr)
+                        if self._local_fastpath else None)
+        if local_worker is not None:
+            with nvtx_range_debug("RPCExecutor.submit.local", color="green", category="Proxy"):
+                local_worker.submit(request)
+        else:
+            # submit is a fire-and-forget operation, don't need to wait for response
+            with nvtx_range_debug("RPCExecutor.submit", color="green", category="Proxy"):
+                self.rpc_client.submit(request).remote(need_response=False)
 
         return result
 

--- a/tensorrt_llm/executor/rpc_worker.py
+++ b/tensorrt_llm/executor/rpc_worker.py
@@ -19,6 +19,7 @@ from .base_worker import BaseWorker
 from .postproc_worker import PostprocWorkerConfig
 from .rpc import RPCServer
 from .rpc_worker_mixin import RpcWorkerMixin
+from .utils import register_local_rpc_worker, unregister_local_rpc_worker
 
 
 class RpcWorker(RpcWorkerMixin, BaseWorker):
@@ -164,11 +165,19 @@ class RpcWorker(RpcWorkerMixin, BaseWorker):
             logger_debug(f"[worker] RPC server {mpi_rank()} is started",
                          color="yellow")
 
+            # Expose the worker in-process so a co-located proxy
+            # (MpiCommSession) can bypass the loopback RPC for hot-path calls.
+            # In the spawn-proxy topology this runs in a different process than
+            # the proxy, so the proxy's registry stays empty and it falls back
+            # to RPC -- the decision is automatic per-process.
+            register_local_rpc_worker(rpc_addr, worker)
+
             # Step 3: Wait for the worker to shutdown
             logger_debug(
                 f"[worker] Worker {mpi_rank()} is waiting for shutdown event",
                 color="yellow")
             worker.shutdown_event.wait()
+            unregister_local_rpc_worker(rpc_addr)
             rpc_server.shutdown()
 
     def __enter__(self):

--- a/tensorrt_llm/executor/utils.py
+++ b/tensorrt_llm/executor/utils.py
@@ -48,6 +48,38 @@ def get_spawn_proxy_process_env() -> bool:
     return os.getenv(LlmLauncherEnvs.TLLM_SPAWN_PROXY_PROCESS) == "1"
 
 
+# ---------------------------------------------------------------------------
+# In-process rank-0 worker registry (RPC local fast-path).
+#
+# Under MpiCommSession the rank-0 RpcWorker runs in a thread of the proxy
+# process, yet the proxy still reaches it over a loopback ZMQ socket
+# (pickle + HMAC + dispatch) -- pure self-inflicted overhead that competes for
+# the GIL with the co-located executor loop. The worker registers itself here
+# keyed by its rpc_addr (which the proxy also knows), so the proxy can call it
+# directly. A lookup miss -- e.g. the spawn-proxy topology where the worker
+# lives in a different process, so this process's registry does not contain it
+# -- transparently falls back to RPC. This makes the local/remote decision
+# automatic per-process, with no explicit topology detection.
+# ---------------------------------------------------------------------------
+_local_rpc_workers: dict = {}
+_local_rpc_workers_lock = threading.Lock()
+
+
+def register_local_rpc_worker(rpc_addr: str, worker: Any) -> None:
+    with _local_rpc_workers_lock:
+        _local_rpc_workers[rpc_addr] = worker
+
+
+def unregister_local_rpc_worker(rpc_addr: str) -> None:
+    with _local_rpc_workers_lock:
+        _local_rpc_workers.pop(rpc_addr, None)
+
+
+def get_local_rpc_worker(rpc_addr: str) -> Optional[Any]:
+    with _local_rpc_workers_lock:
+        return _local_rpc_workers.get(rpc_addr)
+
+
 def create_mpi_comm_session(
         n_workers: int) -> RemoteMpiCommSessionClient | MpiPoolSession:
     assert mpi_rank(


### PR DESCRIPTION
## Problem

On the RPC executor path (`GenerationExecutorRpcProxy` / `RpcWorker`), **rank 0 is the sole RPC ingress** for the whole instance (`RpcWorkerMixin.start_rpc_server` binds the server only on `rank == 0`). Under `MpiCommSession` (the common mpirun/srun launch), the **rank-0 `RpcWorker` runs in a *thread of the proxy process*** (`MpiCommSession.submit` dispatches rank 0 to a local `ThreadPoolExecutor`; ranks 1..N-1 go through MPI).

Yet the proxy still reaches that **in-process** worker over a **loopback ZMQ socket**: every `submit` does `pickle` + HMAC on send, ZMQ round-trip, HMAC + `pickle.loads` on receive, and a `run_in_executor` dispatch — all on **rank 0's GIL**, competing with the co-located executor loop (`_executor_loop_overlap`). For a local worker this serialization is **pure self-inflicted overhead**, and since submit rate scales with concurrency it starves the executor loop at high load (visible in nsys as `RpcWorker.submit` holding the GIL while the worker loop waits, e.g. at c2048).

Note ranks 1..N-1 do **not** receive requests via this Python RPC — they are fed by the C++ executor's internal request broadcast — so the per-request Python pickle/HMAC/ZMQ is a *single* proxy→rank-0 loopback hop.

## Change

Add an **opt-in** in-process fast-path that lets the proxy call the rank-0 worker **directly**, skipping pickle / HMAC / ZMQ / dispatch entirely:

- **`utils.py`** — a per-process registry (`register/unregister/get_local_rpc_worker`) keyed by `rpc_addr`.
- **`rpc_worker.py`** — the rank-0 worker registers itself on start and unregisters on shutdown.
- **`rpc_proxy_mixin.py`** — `submit()` looks up the local worker by `self.rpc_addr` and, if present, calls `worker.submit(request)` directly; otherwise it uses RPC. The `GenerationResult` is now registered **before** dispatch so a response can never race ahead of result tracking.

The worker-side logic is unchanged (`RpcWorker.submit` → `BaseWorker.submit`), so result tracking, responses, abort, and stats all behave identically.

**The local/remote decision is automatic per-process**: the registry lives in the proxy's process, so in the spawn-proxy topology (worker in a different process) the lookup misses and it transparently falls back to RPC — no explicit topology detection.

## Scope / knobs

| Var | Default | Meaning |
|-----|---------|---------|
| `TLLM_RPC_LOCAL_FASTPATH` | `0` (off) | `1` enables the in-process submit fast-path |

**Disabled by default — no behavior change unless opted in.** Orthogonal to and stackable with batched submit (#15109): batching cuts the *count* of RPC ops; this removes the *per-op serialization* for the local worker.

This PR covers the **submit** hot path (Phase 1). The response stream (`fetch_responses`, O(C)/iter, also loopback-pickled today) can be moved to the same in-process path as a follow-up.

## What it does and does not remove

- Removes: `pickle`/HMAC/ZMQ/`run_in_executor` on the proxy→rank-0 submit hop (the GIL-heavy `pickle` is the main win; HMAC mostly releases the GIL).
- Does **not** remove: the enqueue's intrinsic Python cost (`list(prompt_token_ids)`, `GenerationResult`, dict bookkeeping) — those still run, now on the proxy thread (same process/GIL), and are addressed by separate changes.

## Test plan

- [ ] c2048 DeepSeek-V4 disagg GEN: nsys `python-gil` — worker0 GIL-wait per decode step, RPC vs fast-path; verify `RPCExecutor.submit.local` replaces the pickle/ZMQ ranges.
- [ ] TTFT / throughput / output-speed at c400 and c2048 (off vs on); stack with #15109.
- [ ] Correctness: streaming + non-streaming, abort, disaggregated gen-only; confirm RPC fallback in spawn-proxy topology.
- [ ] Audit reference-sharing: ensure neither proxy nor worker mutates the `GenerationRequest` after hand-off (no pickle copy on the local path).

> Draft — opening for early review / to run the A/B above.