### PR TITLE
[TRTLLM-12648][test] implement disagg cancellation load thread

### DIFF
--- a/tests/integration/defs/stress_test/disagg_cancel/README.md
+++ b/tests/integration/defs/stress_test/disagg_cancel/README.md
@@ -1,7 +1,7 @@
 # Disaggregated Cancellation Stress-Test Suite
 
 Marathon-style stress tests that gate regressions of the bug class
-fixed by [PR #13713](https://github.com/NVIDIA/TensorRT-LLM/pull/13713)
+fixed by <https://github.com/NVIDIA/TensorRT-LLM/pull/13713>
 (cleanup / lifetime / quiescence invariants in the disagg KV
 transceiver under heavy mid-flight cancellation).
 
@@ -9,7 +9,7 @@ transceiver under heavy mid-flight cancellation).
 |---|---|
 | **Tracked by** | [TRTLLM-12648](https://jirasw.nvidia.com/browse/TRTLLM-12648), [TRTLLM-12721](https://jirasw.nvidia.com/browse/TRTLLM-12721) |
 | **Bug it gates** | NVBug 6104831 (disaggregated permanent wedge) |
-| **Fix it gates** | [PR #13713](https://github.com/NVIDIA/TensorRT-LLM/pull/13713) |
+| **Fix it gates** | <https://github.com/NVIDIA/TensorRT-LLM/pull/13713> |
 
 ## Status
 
@@ -22,12 +22,12 @@ land incrementally:
 | `metrics_thread` | Implemented — `trtllm_kv_cache_utilization` scraper |
 | `injector_thread` | Implemented — SIGSTOP/SIGCONT/SIGKILL + respawn |
 | `canary_thread` | Implemented — greedy canaries + token-equivalence |
-| `load_thread` | Stub |
+| `load_thread` | Implemented — duration-bounded steady/burst cancellation load |
 
 Component-level coverage: `test_log_scanner.py`, `test_metrics_thread.py`,
-`test_injector.py`, `test_canary.py`. The parametrized marathon pytest
-still runs a lifecycle smoke until `setup()` launches a real cluster
-and the remaining thread (`load`) is wired.
+`test_injector.py`, `test_canary.py`, `test_load_thread.py`. The
+parametrized marathon pytest still runs a lifecycle smoke until
+`setup()` launches a real cluster.
 
 ## File layout
 
@@ -41,6 +41,7 @@ tests/integration/defs/stress_test/disagg_cancel/
 ├── test_metrics_thread.py          (metrics_thread unit tests)
 ├── test_injector.py                (injector unit tests)
 ├── test_canary.py                  (canary_thread unit tests)
+├── test_load_thread.py             (load_thread unit tests)
 └── configs/
     ├── README.md                   (YAML schema + how to add a config)
     ├── marathon_cpp_v1_deepseek.yaml
@@ -61,7 +62,7 @@ Future additions:
 The marathons are **not** registered in pre-merge CI. They are run
 nightly / weekly via
 `tests/integration/test_lists/qa/llm_function_stress.txt` (wiring
-lands together with the load-thread implementation).
+lands with the explicit CI-registration change).
 
 ### Unit tests (no GPU, no cluster)
 
@@ -77,21 +78,26 @@ cd /path/to/TensorRT-LLM
 
 export PYTHONPATH=tests/integration/defs:tests/integration/defs/disaggregated
 
-# Step 4 — canary thread (greedy canaries + token-equivalence)
+# Steps 1-2 — log scanner + metrics (optional sanity)
 python3 -m pytest -c /dev/null -o addopts= \
   --confcutdir=tests/integration/defs/stress_test \
-  tests/integration/defs/stress_test/disagg_cancel/test_canary.py -v
+  tests/integration/defs/stress_test/disagg_cancel/test_log_scanner.py \
+  tests/integration/defs/stress_test/disagg_cancel/test_metrics_thread.py -v
 
 # Step 3 — injector thread (SIGSTOP / SIGCONT / SIGKILL + respawn)
 python3 -m pytest -c /dev/null -o addopts= \
   --confcutdir=tests/integration/defs/stress_test \
   tests/integration/defs/stress_test/disagg_cancel/test_injector.py -v
 
-# Steps 1-2 — log scanner + metrics (optional sanity)
+# Step 4 — canary thread (greedy canaries + token-equivalence)
 python3 -m pytest -c /dev/null -o addopts= \
   --confcutdir=tests/integration/defs/stress_test \
-  tests/integration/defs/stress_test/disagg_cancel/test_log_scanner.py \
-  tests/integration/defs/stress_test/disagg_cancel/test_metrics_thread.py -v
+  tests/integration/defs/stress_test/disagg_cancel/test_canary.py -v
+
+# Step 5 — load thread (steady/burst wrapper around cancel stress load)
+python3 -m pytest -c /dev/null -o addopts= \
+  --confcutdir=tests/integration/defs/stress_test \
+  tests/integration/defs/stress_test/disagg_cancel/test_load_thread.py -v
 
 # Marathon YAML parse/validate (includes stress_config.injections schedule)
 python3 -m pytest -c /dev/null -o addopts= \
@@ -99,7 +105,7 @@ python3 -m pytest -c /dev/null -o addopts= \
   tests/integration/defs/stress_test/disagg_cancel/test_disagg_cancel_stress.py::test_all_marathon_yamls_parse_and_validate -v
 ```
 
-All three together:
+All component tests together:
 
 ```bash
 python3 -m pytest -c /dev/null -o addopts= \
@@ -125,7 +131,7 @@ pytest -sv tests/integration/defs/stress_test/disagg_cancel/test_disagg_cancel_s
 immediately because no workers are registered via
 `bind_tracked_workers()`.
 
-### Local marathon (after `setup()` + load/canary land)
+### Local marathon (after `setup()` lands)
 
 Once `setup()` launches a real 3P3D cluster and registers workers,
 the full 2-hour marathon runs via the same pytest entry point. For
@@ -171,7 +177,7 @@ For now, when the skeleton test fails:
 
 ## Cross-references
 
-- [PR #13713](https://github.com/NVIDIA/TensorRT-LLM/pull/13713) —
+- <https://github.com/NVIDIA/TensorRT-LLM/pull/13713> —
   the bug fix this suite gates regressions against.
 - [TRTLLM-12648](https://jirasw.nvidia.com/browse/TRTLLM-12648),
   [TRTLLM-12721](https://jirasw.nvidia.com/browse/TRTLLM-12721) —

--- a/tests/integration/defs/stress_test/disagg_cancel/configs/marathon_cpp_v1_deepseek.yaml
+++ b/tests/integration/defs/stress_test/disagg_cancel/configs/marathon_cpp_v1_deepseek.yaml
@@ -2,7 +2,7 @@
 #
 # Exercises the C++-backed disagg path (BindKvCacheTransceiver + V1
 # KVCacheManager + NIXL backend) — the configuration NVBug 6104831
-# was filed against and that PR #13713 stabilizes. Schema
+# was filed against and that the in-flight cancellation fix stabilizes. Schema
 # documentation lives in ../README.md.
 
 hostname: localhost

--- a/tests/integration/defs/stress_test/disagg_cancel/harness.py
+++ b/tests/integration/defs/stress_test/disagg_cancel/harness.py
@@ -58,7 +58,7 @@ logger = logging.getLogger(__name__)
 # simply aren't passed to the constructor, so the field defaults
 # apply automatically and are not duplicated here.
 _STRESS_CONFIG_COERCERS: dict[str, Callable[[Any], Any]] = {
-    "duration_min": int,
+    "duration_min": float,
     "kv_cache_manager": str,
     "transceiver": str,
     "base_concurrency": int,
@@ -76,7 +76,7 @@ class StressConfig:
     pass them around without re-parsing.
     """
 
-    duration_min: int = 120
+    duration_min: float = 120.0
     kv_cache_manager: str = "v1"  # v1 | v2  (v2 + CPP is invalid)
     transceiver: str = "cpp"  # cpp | python
     base_concurrency: int = 64
@@ -704,6 +704,111 @@ def _tokens_equivalent(returned: Optional[list[int]], reference: Optional[list[i
 
 
 # ---------------------------------------------------------------------------
+# Load-thread helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_token_range(raw: Any, default: tuple[int, int], label: str) -> tuple[int, int]:
+    """Parse a YAML ``input_length`` mapping into a `(min_tokens, max_tokens)` tuple."""
+    if raw is None:
+        return default
+    if not isinstance(raw, dict):
+        raise ValueError(f"{label} must be a mapping with min_tokens/max_tokens, got {raw!r}")
+    try:
+        min_tokens = int(raw.get("min_tokens", default[0]))
+        max_tokens = int(raw.get("max_tokens", default[1]))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} min_tokens/max_tokens must be integers: {raw!r}") from exc
+    if min_tokens <= 0 or max_tokens < min_tokens:
+        raise ValueError(
+            f"{label} must satisfy 0 < min_tokens <= max_tokens, got {min_tokens}/{max_tokens}"
+        )
+    return min_tokens, max_tokens
+
+
+def _parse_cancel_after_range(raw: Any) -> tuple[float, float]:
+    """Parse optional ``cancel_after_range`` config; default to existing test values."""
+    default = (0.01, 0.1)
+    if raw is None:
+        return default
+    if not isinstance(raw, dict):
+        raise ValueError(f"cancel_after_range must be a mapping, got {raw!r}")
+    try:
+        min_s = float(raw.get("min_s", raw.get("min", default[0])))
+        max_s = float(raw.get("max_s", raw.get("max", default[1])))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"cancel_after_range min/max must be numbers: {raw!r}") from exc
+    if min_s < 0.0 or max_s < min_s:
+        raise ValueError(f"cancel_after_range must satisfy 0 <= min <= max, got {min_s}/{max_s}")
+    return min_s, max_s
+
+
+def _load_iteration_shape(config: StressConfig, elapsed_s: float) -> dict[str, Any]:
+    """Return the load shape that should run at ``elapsed_s``.
+
+    Bursts start after the first full ``bursts.interval_min`` period,
+    then repeat every interval. This keeps the marathon from starting
+    immediately in burst mode and preserves a steady-state baseline at
+    T+0.
+    """
+    steady_prompt_range = _parse_token_range(
+        config.raw.get("input_length"), (4096, 12288), "stress_config.input_length"
+    )
+    if config.base_concurrency <= 0:
+        raise ValueError(
+            f"stress_config.base_concurrency must be positive, got {config.base_concurrency}"
+        )
+    shape: dict[str, Any] = {
+        "mode": "steady",
+        "requests_per_burst": config.base_concurrency,
+        "prompt_len_range": steady_prompt_range,
+    }
+
+    bursts = config.raw.get("bursts")
+    if bursts is None:
+        return shape
+    if not isinstance(bursts, dict):
+        raise ValueError("stress_config.bursts must be a mapping")
+
+    try:
+        interval_s = float(bursts.get("interval_min", 0.0)) * 60.0
+        duration_s = float(bursts.get("duration_s", 0.0))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("stress_config.bursts interval_min/duration_s must be numbers") from exc
+
+    if interval_s <= 0.0:
+        raise ValueError(
+            f"stress_config.bursts.interval_min must be positive, got {bursts.get('interval_min')!r}"
+        )
+    if duration_s <= 0.0:
+        raise ValueError(
+            f"stress_config.bursts.duration_s must be positive, got {bursts.get('duration_s')!r}"
+        )
+    if elapsed_s < interval_s:
+        return shape
+
+    offset_s = elapsed_s % interval_s
+    if offset_s >= duration_s:
+        return shape
+
+    try:
+        requests_per_burst = int(bursts.get("concurrency", config.base_concurrency))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("stress_config.bursts.concurrency must be an integer") from exc
+    if requests_per_burst <= 0:
+        raise ValueError(
+            f"stress_config.bursts.concurrency must be positive, got {requests_per_burst}"
+        )
+    return {
+        "mode": "burst",
+        "requests_per_burst": requests_per_burst,
+        "prompt_len_range": _parse_token_range(
+            bursts.get("input_length"), steady_prompt_range, "stress_config.bursts.input_length"
+        ),
+    }
+
+
+# ---------------------------------------------------------------------------
 # Harness
 # ---------------------------------------------------------------------------
 
@@ -742,6 +847,8 @@ class DisaggCancellationStressHarness:
         injector_poll_interval_s: float = 1.0,
         canary_request_timeout_s: float = 10.0,
         canary_interval_s: Optional[float] = None,
+        load_duration_s: Optional[float] = None,
+        load_iteration_pause_s: float = 0.05,
     ) -> None:
         """Construct a marathon harness.
 
@@ -773,6 +880,14 @@ class DisaggCancellationStressHarness:
                 gap between requests. `None` derives from
                 `canary.rate_per_min` (`60 / rate_per_min`); tests
                 pass a small value.
+            load_duration_s: Optional override (seconds) for the load
+                loop duration. `None` derives from `duration_min`;
+                tests pass a small value.
+            load_iteration_pause_s: Minimum pause between load
+                generator calls. Keeps the wrapper from busy-spinning
+                when the injected load runner returns immediately in
+                unit tests; the production generator already spends
+                most of its time in HTTP requests.
 
         Raises:
             ValueError: If the YAML is malformed or its
@@ -794,6 +909,8 @@ class DisaggCancellationStressHarness:
         self._injector_poll_interval_s: float = injector_poll_interval_s
         self._canary_request_timeout_s: float = canary_request_timeout_s
         self._canary_interval_s: Optional[float] = canary_interval_s
+        self._load_duration_s: Optional[float] = load_duration_s
+        self._load_iteration_pause_s: float = load_iteration_pause_s
 
         # Cluster + worker tracking (populated by setup()).
         self._cluster: Any = None  # tuple returned by setup_disagg_cluster
@@ -818,6 +935,7 @@ class DisaggCancellationStressHarness:
         self._canary_records: list[dict[str, Any]] = []
         self._kv_utilization_samples: list[dict[str, Any]] = []
         self._injection_events: list[dict[str, Any]] = []
+        self._load_records: list[dict[str, Any]] = []
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -872,10 +990,9 @@ class DisaggCancellationStressHarness:
     def start(self) -> None:
         """Spawn the five worker threads. Returns immediately.
 
-        Stub stage: each thread body is a no-op that returns
-        immediately. The load-thread stub signals ``stop_event`` on
-        exit so the lifecycle smoke ``start() -> wait_until_done() ->
-        stop()`` completes cleanly without waiting out the
+        If ``setup()`` has not bound a live server endpoint yet, the
+        load thread warns and signals ``stop_event`` so the lifecycle
+        smoke still completes cleanly without waiting out the
         ``wait_until_done`` timeout.
         """
         self._marathon_start_monotonic = time.monotonic()
@@ -1008,6 +1125,7 @@ class DisaggCancellationStressHarness:
             for the caller to mutate without affecting the harness):
 
             - ``canary_records``: per-canary request outcomes.
+            - ``load_records``: per-load-generator call outcomes.
             - ``kv_utilization_samples``: timestamped KV-cache
               utilization scrapes from the metrics thread.
             - ``injection_events``: SIGSTOP / SIGCONT / SIGKILL
@@ -1018,6 +1136,7 @@ class DisaggCancellationStressHarness:
         """
         return {
             "canary_records": list(self._canary_records),
+            "load_records": list(self._load_records),
             "kv_utilization_samples": list(self._kv_utilization_samples),
             "injection_events": list(self._injection_events),
             "failure_reason": self.failure_reason,
@@ -1030,17 +1149,120 @@ class DisaggCancellationStressHarness:
     def _load_thread_body(self) -> None:
         """Wrap ``run_cancel_stress_test`` in a duration-bounded loop.
 
-        Stub: no-op that immediately signals end-of-marathon via
-        ``stop_event``. The real implementation loops until either
-        ``duration_min`` elapses or ``stop_event`` is set, calling
-        ``run_cancel_stress_test`` repeatedly; at end-of-marathon it
-        sets ``stop_event`` so the other four threads wind down.
-        Setting ``stop_event`` here in the stub preserves that
-        downstream contract and lets ``wait_until_done`` return
-        cleanly from the lifecycle smoke.
+        Loops until ``duration_min`` elapses or a stop/fail-fast
+        event is set. Each loop iteration picks the current steady
+        or burst load shape from ``stress_config``, runs one burst of
+        the existing disagg cancellation load generator, and appends
+        a record to ``_load_records`` for later correlation with
+        canary/metrics/injection observations.
+
+        At normal end-of-marathon, the load thread sets
+        ``stop_event`` so the other four threads wind down.
         """
-        logger.debug("[load_thread] stub — exiting and signalling stop_event")
-        self.stop_event.set()
+        if not self._server_url:
+            logger.warning("[load_thread] no server endpoint bound (setup() not wired); exiting")
+            self.stop_event.set()
+            return
+
+        duration_s = (
+            self._load_duration_s
+            if self._load_duration_s is not None
+            else float(self.config.duration_min) * 60.0
+        )
+        if duration_s <= 0.0:
+            logger.info("[load_thread] non-positive duration %.3fs; exiting", duration_s)
+            self.stop_event.set()
+            return
+
+        try:
+            cancel_after_range = _parse_cancel_after_range(
+                self.config.raw.get("cancel_after_range")
+            )
+        except ValueError as exc:
+            self.mark_failed(f"load_thread config error: {exc}")
+            return
+
+        deadline = time.monotonic() + duration_s
+        logger.info(
+            "[load_thread] running for %.1fs against %s (base_concurrency=%d)",
+            duration_s,
+            self._server_url,
+            self.config.base_concurrency,
+        )
+
+        try:
+            while (
+                time.monotonic() < deadline
+                and not self.stop_event.is_set()
+                and not self.failed_event.is_set()
+            ):
+                iteration_start = time.monotonic()
+                elapsed_s = iteration_start - self._marathon_start_monotonic
+                try:
+                    shape = _load_iteration_shape(self.config, elapsed_s)
+                except ValueError as exc:
+                    self.mark_failed(f"load_thread config error: {exc}")
+                    break
+
+                record: dict[str, Any] = {
+                    "timestamp": time.time(),
+                    "elapsed_s": elapsed_s,
+                    "mode": shape["mode"],
+                    "num_bursts": 1,
+                    "requests_per_burst": shape["requests_per_burst"],
+                    "prompt_len_range": shape["prompt_len_range"],
+                    "cancel_after_range": cancel_after_range,
+                    "success": False,
+                    "error": None,
+                }
+                try:
+                    self._run_cancel_stress_iteration(
+                        server_url=self._server_url,
+                        num_bursts=1,
+                        requests_per_burst=shape["requests_per_burst"],
+                        prompt_len_range=shape["prompt_len_range"],
+                        cancel_after_range=cancel_after_range,
+                    )
+                    record["success"] = True
+                except Exception as exc:
+                    record["error"] = f"{type(exc).__name__}: {exc}"
+                    self.mark_failed(f"load_thread runner failed: {record['error']}")
+                    break
+                finally:
+                    record["duration_s"] = time.monotonic() - iteration_start
+                    self._load_records.append(record)
+
+                pause_s = min(self._load_iteration_pause_s, max(0.0, deadline - time.monotonic()))
+                if pause_s > 0.0:
+                    self.stop_event.wait(timeout=pause_s)
+        finally:
+            if not self.failed_event.is_set():
+                logger.info("[load_thread] completed; signalling stop_event")
+                self.stop_event.set()
+
+    def _run_cancel_stress_iteration(
+        self,
+        *,
+        server_url: str,
+        num_bursts: int,
+        requests_per_burst: int,
+        prompt_len_range: tuple[int, int],
+        cancel_after_range: tuple[float, float],
+    ) -> None:
+        """Run one call to the shared disaggregated cancellation load generator.
+
+        Kept as a method so unit tests can monkeypatch it without
+        importing the heavyweight disaggregated integration module.
+        """
+        from test_disaggregated import run_cancel_stress_test
+
+        run_cancel_stress_test(
+            server_url,
+            num_bursts=num_bursts,
+            requests_per_burst=requests_per_burst,
+            prompt_len_range=prompt_len_range,
+            cancel_after_range=cancel_after_range,
+        )
 
     def _canary_thread_body(self) -> None:
         """Send greedy canaries and append per-request records to `_canary_records`.

--- a/tests/integration/defs/stress_test/disagg_cancel/test_disagg_cancel_stress.py
+++ b/tests/integration/defs/stress_test/disagg_cancel/test_disagg_cancel_stress.py
@@ -61,7 +61,8 @@ def test_disagg_cancellation_marathon(config_filename: str) -> None:
 
     Current scope: only what the already-implemented thread bodies
     can contribute. The marathon entry point exists; the marathon
-    *content* lands incrementally as each thread body is wired up:
+    *content* lands incrementally as setup / pass-criteria wiring is
+    completed:
 
     - lifecycle plumbing (setup -> start -> wait -> stop ->
       collect_results, fail-fast event propagation, dict-shape
@@ -71,7 +72,7 @@ def test_disagg_cancellation_marathon(config_filename: str) -> None:
       (component-level coverage in ``test_log_scanner.py``).
 
     Marathon pass criteria not yet enforced here (will land alongside
-    their owning thread bodies in follow-up changes): canary error
+    their owning result aggregation in follow-up changes): canary error
     rate, recovery time after each injection, KV-cache utilization
     growth bound, injection-schedule completeness, sustained load
     throughput. Until those land, this test passes trivially after
@@ -89,13 +90,12 @@ def test_disagg_cancellation_marathon(config_filename: str) -> None:
     try:
         harness.setup()
         harness.start()
-        # Skeleton stage: stub threads exit immediately; the
-        # load-thread stub signals ``stop_event`` on exit so this
-        # returns cleanly (True) almost instantly. Once the
-        # duration-bounded load thread is wired up, the timeout
-        # becomes ``stress_config.duration_min`` plus a safety
-        # margin, and ``clean`` reports whether the marathon ran to
-        # completion without tripping fail-fast.
+        # setup() is still a stub, so no server endpoint is bound.
+        # The load thread exits and signals ``stop_event`` on that
+        # no-endpoint path, which lets this lifecycle smoke complete
+        # almost instantly. Once setup launches a real cluster, the
+        # timeout becomes ``stress_config.duration_min`` plus a safety
+        # margin.
         clean = harness.wait_until_done(timeout_s=10.0)
         assert clean is True, (
             f"wait_until_done did not return cleanly; failure_reason={harness.failure_reason!r}"
@@ -108,6 +108,7 @@ def test_disagg_cancellation_marathon(config_filename: str) -> None:
     # collector returns the expected shape so future commits can
     # extend in place.
     assert "canary_records" in results
+    assert "load_records" in results
     assert "kv_utilization_samples" in results
     assert "injection_events" in results
     assert results["failure_reason"] is None, (

--- a/tests/integration/defs/stress_test/disagg_cancel/test_load_thread.py
+++ b/tests/integration/defs/stress_test/disagg_cancel/test_load_thread.py
@@ -1,0 +1,276 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for ``DisaggCancellationStressHarness._load_thread_body``.
+
+The load thread is tested with a monkeypatched
+``_run_cancel_stress_iteration`` so these tests do not import the
+heavy disaggregated integration module, start a server, or require
+GPU/model resources.
+"""
+
+from __future__ import annotations
+
+import textwrap
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from .harness import (
+    DisaggCancellationStressHarness,
+    StressConfig,
+    _load_iteration_shape,
+    _parse_cancel_after_range,
+    _parse_token_range,
+)
+
+
+def _write_load_yaml(
+    tmp_path: Path,
+    *,
+    extra_stress_config: str = "",
+) -> Path:
+    """Write a minimal valid marathon YAML for load-thread tests."""
+    yaml_path = tmp_path / "stress.yaml"
+    content = textwrap.dedent(
+        """\
+        hostname: localhost
+        model: dummy
+        backend: pytorch
+        context_servers: {}
+        generation_servers: {}
+        stress_config:
+          duration_min: 1
+          kv_cache_manager: v1
+          transceiver: cpp
+          base_concurrency: 4
+          input_length:
+            distribution: uniform
+            min_tokens: 11
+            max_tokens: 22
+        """
+    )
+    if extra_stress_config:
+        content += textwrap.indent(textwrap.dedent(extra_stress_config).strip(), "  ") + "\n"
+    yaml_path.write_text(content)
+    return yaml_path
+
+
+def _make_harness(
+    tmp_path: Path,
+    *,
+    extra_stress_config: str = "",
+    load_duration_s: float = 0.05,
+) -> DisaggCancellationStressHarness:
+    """Construct a load-thread harness with a short test duration."""
+    h = DisaggCancellationStressHarness(
+        _write_load_yaml(tmp_path, extra_stress_config=extra_stress_config),
+        load_duration_s=load_duration_s,
+        load_iteration_pause_s=0.005,
+    )
+    h.bind_server_endpoint("http://127.0.0.1:8000", "test-model")
+    h._marathon_start_monotonic = time.monotonic()
+    return h
+
+
+def _run_load_thread(h: DisaggCancellationStressHarness, timeout_s: float = 2.0) -> None:
+    """Run the load thread to self-exit and assert it joined."""
+    thread = threading.Thread(target=h._load_thread_body, name="test-load", daemon=True)
+    thread.start()
+    thread.join(timeout=timeout_s)
+    assert not thread.is_alive(), "load thread did not exit within timeout"
+
+
+def test_parse_token_range_defaults_and_validates() -> None:
+    assert _parse_token_range(None, (1, 2), "input") == (1, 2)
+    assert _parse_token_range({"min_tokens": "3", "max_tokens": 5}, (1, 2), "input") == (
+        3,
+        5,
+    )
+    with pytest.raises(ValueError, match="min_tokens <= max_tokens"):
+        _parse_token_range({"min_tokens": 8, "max_tokens": 7}, (1, 2), "input")
+
+
+def test_parse_cancel_after_range_defaults_and_validates() -> None:
+    assert _parse_cancel_after_range(None) == pytest.approx((0.01, 0.1))
+    assert _parse_cancel_after_range({"min_s": 0.2, "max_s": 0.4}) == pytest.approx((0.2, 0.4))
+    with pytest.raises(ValueError, match="0 <= min <= max"):
+        _parse_cancel_after_range({"min_s": 0.5, "max_s": 0.4})
+
+
+def test_load_iteration_shape_switches_from_steady_to_burst(tmp_path: Path) -> None:
+    yaml_path = _write_load_yaml(
+        tmp_path,
+        extra_stress_config=textwrap.dedent(
+            """\
+            bursts:
+              interval_min: 1
+              concurrency: 9
+              duration_s: 10
+              input_length:
+                min_tokens: 33
+                max_tokens: 44
+            """
+        ),
+    )
+    cfg = StressConfig.from_yaml_path(yaml_path)
+
+    steady = _load_iteration_shape(cfg, elapsed_s=30)
+    assert steady["mode"] == "steady"
+    assert steady["requests_per_burst"] == 4
+    assert steady["prompt_len_range"] == (11, 22)
+
+    burst = _load_iteration_shape(cfg, elapsed_s=61)
+    assert burst["mode"] == "burst"
+    assert burst["requests_per_burst"] == 9
+    assert burst["prompt_len_range"] == (33, 44)
+
+
+@pytest.mark.parametrize(
+    ("burst_config", "match"),
+    [
+        (
+            "interval_min: 0\nconcurrency: 9\nduration_s: 10\n",
+            "bursts.interval_min must be positive",
+        ),
+        (
+            "interval_min: 1\nconcurrency: 9\nduration_s: 0\n",
+            "bursts.duration_s must be positive",
+        ),
+    ],
+)
+def test_load_iteration_shape_rejects_invalid_burst_timing(
+    tmp_path: Path, burst_config: str, match: str
+) -> None:
+    yaml_path = _write_load_yaml(
+        tmp_path,
+        extra_stress_config="bursts:\n" + textwrap.indent(burst_config, "  "),
+    )
+    cfg = StressConfig.from_yaml_path(yaml_path)
+
+    with pytest.raises(ValueError, match=match):
+        _load_iteration_shape(cfg, elapsed_s=61)
+
+
+def test_load_thread_without_server_endpoint_exits_and_signals_stop(tmp_path: Path) -> None:
+    h = DisaggCancellationStressHarness(
+        _write_load_yaml(tmp_path),
+        load_duration_s=0.05,
+        load_iteration_pause_s=0.005,
+    )
+
+    _run_load_thread(h)
+
+    assert h.stop_event.is_set()
+    assert h._load_records == []
+
+
+def test_load_thread_runs_steady_iterations_and_records_results(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    h = _make_harness(tmp_path)
+    calls: list[dict[str, Any]] = []
+
+    def fake_runner(**kwargs: Any) -> None:
+        calls.append(kwargs)
+        time.sleep(0.002)
+
+    monkeypatch.setattr(h, "_run_cancel_stress_iteration", fake_runner)
+
+    _run_load_thread(h)
+
+    assert h.stop_event.is_set()
+    assert not h.failed_event.is_set()
+    assert len(calls) >= 1
+    assert len(h._load_records) == len(calls)
+    assert all(record["mode"] == "steady" for record in h._load_records)
+    assert calls[0]["server_url"] == "http://127.0.0.1:8000"
+    assert calls[0]["num_bursts"] == 1
+    assert calls[0]["requests_per_burst"] == 4
+    assert calls[0]["prompt_len_range"] == (11, 22)
+
+
+def test_load_thread_uses_burst_shape_inside_burst_window(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    h = _make_harness(
+        tmp_path,
+        extra_stress_config=textwrap.dedent(
+            """\
+            bursts:
+              interval_min: 0.001
+              concurrency: 9
+              duration_s: 0.04
+              input_length:
+                min_tokens: 33
+                max_tokens: 44
+            """
+        ),
+        load_duration_s=0.12,
+    )
+
+    def fake_runner(**_kwargs: Any) -> None:
+        time.sleep(0.004)
+
+    monkeypatch.setattr(h, "_run_cancel_stress_iteration", fake_runner)
+
+    _run_load_thread(h)
+
+    modes = {record["mode"] for record in h._load_records}
+    assert modes == {"steady", "burst"}
+    burst_records = [record for record in h._load_records if record["mode"] == "burst"]
+    assert burst_records
+    assert all(record["requests_per_burst"] == 9 for record in burst_records)
+    assert all(record["prompt_len_range"] == (33, 44) for record in burst_records)
+
+
+def test_load_thread_observes_stop_event_after_runner_returns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    h = _make_harness(tmp_path, load_duration_s=10.0)
+    calls: list[dict[str, Any]] = []
+
+    def fake_runner(**kwargs: Any) -> None:
+        calls.append(kwargs)
+        h.stop_event.set()
+
+    monkeypatch.setattr(h, "_run_cancel_stress_iteration", fake_runner)
+
+    _run_load_thread(h)
+
+    assert len(calls) == 1
+    assert len(h._load_records) == 1
+    assert h._load_records[0]["success"] is True
+
+
+def test_load_thread_runner_exception_trips_fail_fast(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    h = _make_harness(tmp_path, load_duration_s=10.0)
+
+    def fake_runner(**_kwargs: Any) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(h, "_run_cancel_stress_iteration", fake_runner)
+
+    _run_load_thread(h)
+
+    assert h.failed_event.is_set()
+    assert h.failure_reason == "load_thread runner failed: RuntimeError: boom"
+    assert len(h._load_records) == 1
+    assert h._load_records[0]["success"] is False
+    assert h._load_records[0]["error"] == "RuntimeError: boom"


### PR DESCRIPTION
## Summary

Fifth thread body in the disaggregated cancellation stress-test suite - the marathon-style harness that gates regressions of the disaggregated KV-transfer cancellation / poison failure class. The skeleton + log scanner landed in the first harness change, followed by the metrics thread, injector thread, and canary thread; this change adds the load thread.

**This PR ships:**

* **`load_thread` body** - replaces the no-op stub with a duration-bounded loop. The thread exits on `stop_event` / `failed_event`, runs until `stress_config.duration_min` elapses, and sets `stop_event` at normal end-of-marathon so canary, metrics, injector, and log-scanner threads wind down.
* **Steady / burst load scheduling** - selects the active load shape from `stress_config`. Steady state uses `base_concurrency` and `input_length`; burst windows use `bursts.interval_min`, `bursts.duration_s`, `bursts.concurrency`, and `bursts.input_length`. Bursts begin after the first full interval so the marathon starts with a steady-state baseline.
* **`run_cancel_stress_test` wrapper** - calls the existing disaggregated cancellation load generator one burst at a time via `_run_cancel_stress_iteration(...)`. The import is lazy so unit tests can monkeypatch the method without importing the heavyweight disaggregated integration module.
* **Load result records** - appends one `_load_records` entry per load-generator call with `{timestamp, elapsed_s, mode, num_bursts, requests_per_burst, prompt_len_range, cancel_after_range, success, error, duration_s}` and exposes those records from `collect_results()` as `load_records`.
* **Config parsing helpers** - adds `_parse_token_range`, `_parse_cancel_after_range`, and `_load_iteration_shape` to validate load-shape knobs and fail fast on malformed load config, including malformed burst timing.
* **Lifecycle smoke update** - keeps the current `setup()`-stub path fast: if no server endpoint is bound, `load_thread` logs a warning, sets `stop_event`, and exits, so the marathon pytest remains a lifecycle smoke until real cluster setup lands.

## PR chain plan

| Change | Adds | Marathon assertion it enables |
| --- | --- | --- |
| [skeleton + log scanner](https://github.com/NVIDIA/TensorRT-LLM/pull/14375) | harness lifecycle + `log_scanner_thread` | hard-zero log patterns |
| [metrics thread](https://github.com/NVIDIA/TensorRT-LLM/pull/14807) | `metrics_thread` | KV-cache utilization growth bound |
| [injector thread](https://github.com/NVIDIA/TensorRT-LLM/pull/14920) | `injector_thread` | SIGSTOP / SIGCONT / SIGKILL+respawn; `injection_events` count |
| [canary thread](https://github.com/NVIDIA/TensorRT-LLM/pull/15015) | `canary_thread` | canary correctness plus error-rate / recovery-time inputs |
| **this change** | **`load_thread`** | **sustained steady/burst cancellation load over the configured duration** |
| next | real `setup_disagg_cluster` invocation with `save_log=True` + endpoint binding | marathon entry point becomes a real cluster-backed marathon |
| later | marathon YAML/reference completion + test-list registration | weekly stress CI enablement |

This change still does not enable the marathon in CI. Registration in `tests/integration/test_lists/qa/llm_function_stress.txt` remains deferred.

## Why one-burst wrapper calls

`run_cancel_stress_test` already owns the asyncio request-spam/cancel behavior used by existing disaggregated cancellation tests. Rather than reimplementing the HTTP client, `load_thread` calls it with `num_bursts=1` in a loop and lets the harness decide which load shape is active for each iteration.

This keeps Step 5 small and reviewable:
* the shared load generator remains the only implementation of client-side disconnect-during-prefill traffic;
* the harness owns marathon scheduling, duration, stop/fail-fast coordination, and observability;
* future load-generator improvements, such as honoring `client_cancel_rate` or `output_length`, can land separately without restructuring the harness.

## Tests added

All deterministic, GPU-free, second-scale. Under `tests/integration/defs/stress_test/disagg_cancel/`.

* **`test_load_thread.py`** - 10 unit tests across three layers:
   * **Config helpers (5)**: token range defaults/validation, cancel-after range defaults/validation, steady-to-burst load-shape selection, and invalid burst interval/duration fail-fast.
   * **Thread-body lifecycle (3)**: no-endpoint path signals `stop_event`, steady iterations record successful `load_records`, and externally set `stop_event` stops after the current runner call.
   * **Burst/failure behavior (2)**: burst window uses burst concurrency/prompt range, and runner exceptions trip fail-fast while recording the failed load iteration.
* **`test_disagg_cancel_stress.py`** - lifecycle smoke now asserts the `load_records` result bucket.

Run locally (no GPU, no cluster):
```bash
PYTHONPATH=tests/integration/defs:tests/integration/defs/disaggregated \
python3 -m pytest -c /dev/null -o addopts= \
  -p no:cacheprovider \
  --confcutdir=tests/integration/defs/stress_test \
  tests/integration/defs/stress_test/disagg_cancel/test_load_thread.py \
  tests/integration/defs/stress_test/disagg_cancel/test_disagg_cancel_stress.py -q
```

Full component suite:
```bash
PYTHONPATH=tests/integration/defs:tests/integration/defs/disaggregated \
python3 -m pytest -c /dev/null -o addopts= \
  -p no:cacheprovider \
  --confcutdir=tests/integration/defs/stress_test \
  tests/integration/defs/stress_test/disagg_cancel/ -q
```

## Validation

* Focused load/lifecycle tests: `12 passed`.
* Full colocated component suite: `89 passed`.
* `git diff --check`.
* Pre-commit passed after `ruff-format` reformatted `harness.py`. The local commit skipped only `waive list check` and `validate-test-lists` because the hook runner's Python failed while parsing the repo script annotation `str | None` in `scripts/check_test_list.py`.

Note: the full component suite was run outside the filesystem sandbox because existing canary/metrics tests bind local loopback HTTP servers.

## Out of scope (deferred to later changes in this chain)

* Real `setup_disagg_cluster` invocation and worker/server endpoint binding. `setup()` is still a stub, so the lifecycle smoke does not launch a real cluster yet.
* Extending `run_cancel_stress_test` to honor `client_cancel_rate` and `output_length`; Step 5 intentionally reuses the existing cancellation load generator as-is.
* End-of-marathon gate computation from `_load_records`, `_canary_records`, `_kv_utilization_samples`, and `_injection_events`.
* `configs/stress_canary_prompts.json` plus `tools/generate_canary_references.py`.
* Test-list registration for weekly stress CI.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work)).
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities.
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes.
- Documentation updated as needed.
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for load-thread behavior in stress tests, including validation of cancellation load configurations, iteration shape transitions, and error handling scenarios.
  * Enhanced existing stress-test assertions to verify load-record collection.

* **Documentation**
  * Updated stress-test README with improved coverage details and explicit step-by-step run instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->