### PR TITLE
[None][fix] Fix beam search log_probs non-determinism with batch_size > 1

### DIFF
--- a/cpp/tensorrt_llm/kernels/decodingKernels.cu
+++ b/cpp/tensorrt_llm/kernels/decodingKernels.cu
@@ -728,7 +728,7 @@ namespace tensorrt_llm::runtime::kernels
 {
 // Must be similar to [cpp/tensorrt_llm/thop/gatherTreeOp.cpp] gatherTree
 void gatherTree(DecodingOutput const& decodingOutput, DecodingInput const& decodingInput,
-    SamplingConfig const& samplingConfig, runtime::CudaStream const& cudaStream)
+    SamplingConfig const& samplingConfig, runtime::CudaStream const& cudaStream, runtime::SizeType32 batchSlot)
 {
     TLLM_LOG_TRACE("%s start", __PRETTY_FUNCTION__);
 
@@ -781,7 +781,11 @@ void gatherTree(DecodingOutput const& decodingOutput, DecodingInput const& decod
     lengthPenaltyPtr = manager.copyFrom(lengthPenaltyVec, ITensor::makeShape({batchSize}), runtime::MemoryType::kGPU);
 
     tensorrt_llm::kernels::BeamHypotheses bh;
-    bh.nMaxBatchSize = batchSize;
+    // logProbsTiled has shape [MSL, maxNumSequences, BM] and is passed unsliced.
+    // Use its actual dim-1 as nMaxBatchSize (stride), and offset the pointer to
+    // the correct batch slot so insertUnfinishedPathKernel indexes correctly.
+    auto const logProbsTiledMaxBatchSize = static_cast<SizeType32>(decodingOutput.logProbsTiled->getShape().d[1]);
+    bh.nMaxBatchSize = logProbsTiledMaxBatchSize;
     bh.nBatchSize = batchSize;
     bh.nBeamWidth = beamWidth;
     bh.nMaxSeqLen = maxSeqLength;
@@ -789,7 +793,7 @@ void gatherTree(DecodingOutput const& decodingOutput, DecodingInput const& decod
     bh.inputLengths = bufferCast<SizeType32>(*decodingInput.lengths);
     bh.outputIds = bufferCast<TokenIdType>(finalOutputIds);
     bh.logProbs = bufferCastOrNull<float>(decodingOutput.logProbs);
-    bh.logProbsTiled = bufferCast<float>(*decodingOutput.logProbsTiled);
+    bh.logProbsTiled = bufferCast<float>(*decodingOutput.logProbsTiled) + batchSlot * beamWidth;
     bh.sequenceLengths = bufferCast<SizeType32>(*decodingOutput.lengths);
     bh.cumLogProbs = bufferCast<float>(*decodingOutput.cumLogProbs);
     bh.outputIdsCBA = bufferCast<TokenIdType>(*decodingOutput.beamHypotheses.outputIdsCBA);

--- a/cpp/tensorrt_llm/kernels/decodingKernels.cu
+++ b/cpp/tensorrt_llm/kernels/decodingKernels.cu
@@ -789,6 +789,15 @@ void gatherTree(DecodingOutput const& decodingOutput, DecodingInput const& decod
     //   = base[step * maxBS * BM + batchSlot * BM + beamIdx]
     //   = logProbsTiled[step][batchSlot][beamIdx]  ✓
     auto const logProbsTiledMaxBatchSize = static_cast<SizeType32>(decodingOutput.logProbsTiled->getShape().d[1]);
+    auto const logProbsTiledBeamWidth = static_cast<SizeType32>(decodingOutput.logProbsTiled->getShape().d[2]);
+    TLLM_CHECK_WITH_INFO(batchSlot < logProbsTiledMaxBatchSize,
+        "batchSlot (%d) must be < logProbsTiled maxBatchSize (%d); "
+        "logProbsTiled would be accessed out of bounds.",
+        batchSlot, logProbsTiledMaxBatchSize);
+    TLLM_CHECK_WITH_INFO(beamWidth == logProbsTiledBeamWidth,
+        "beamWidth (%d) must equal logProbsTiled BM dimension (%d); "
+        "pointer offset batchSlot*beamWidth would be misaligned.",
+        beamWidth, logProbsTiledBeamWidth);
     bh.nMaxBatchSize = logProbsTiledMaxBatchSize;
     bh.nBatchSize = batchSize;
     bh.nBeamWidth = beamWidth;

--- a/cpp/tensorrt_llm/kernels/decodingKernels.cu
+++ b/cpp/tensorrt_llm/kernels/decodingKernels.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -782,8 +782,12 @@ void gatherTree(DecodingOutput const& decodingOutput, DecodingInput const& decod
 
     tensorrt_llm::kernels::BeamHypotheses bh;
     // logProbsTiled has shape [MSL, maxNumSequences, BM] and is passed unsliced.
-    // Use its actual dim-1 as nMaxBatchSize (stride), and offset the pointer to
-    // the correct batch slot so insertUnfinishedPathKernel indexes correctly.
+    // nMaxBatchSize must equal the allocation stride (dim-1), not the per-slot batchSize=1.
+    // The pointer is pre-offset by batchSlot*BM so that insertUnfinishedPathKernel,
+    // which uses bid=0 / nBatchSize=1, computes:
+    //   (base + batchSlot*BM)[step * maxBS * BM + 0*BM + beamIdx]
+    //   = base[step * maxBS * BM + batchSlot * BM + beamIdx]
+    //   = logProbsTiled[step][batchSlot][beamIdx]  ✓
     auto const logProbsTiledMaxBatchSize = static_cast<SizeType32>(decodingOutput.logProbsTiled->getShape().d[1]);
     bh.nMaxBatchSize = logProbsTiledMaxBatchSize;
     bh.nBatchSize = batchSize;

--- a/cpp/tensorrt_llm/kernels/decodingKernels.h
+++ b/cpp/tensorrt_llm/kernels/decodingKernels.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tensorrt_llm/kernels/decodingKernels.h
+++ b/cpp/tensorrt_llm/kernels/decodingKernels.h
@@ -133,5 +133,5 @@ namespace tensorrt_llm::runtime::kernels
 //! \param cudaStream the CUDA stream on which to perform the operation.
 
 void gatherTree(DecodingOutput const& decodingOutput, DecodingInput const& decodingInput,
-    SamplingConfig const& samplingConfig, runtime::CudaStream const& cudaStream);
+    SamplingConfig const& samplingConfig, runtime::CudaStream const& cudaStream, runtime::SizeType32 batchSlot = 0);
 } // namespace tensorrt_llm::runtime::kernels

--- a/cpp/tensorrt_llm/layers/beamSearchLayer.cu
+++ b/cpp/tensorrt_llm/layers/beamSearchLayer.cu
@@ -335,7 +335,9 @@ void BeamSearchLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> const
     BeamHypotheses bh;
     // bh's members not used in this function: outputIds, logProbs, outputIdsUnfinish, parentIdsUnfinish
     bh.bVBWS = this->mVBWS;
-    bh.nMaxBatchSize = static_cast<std::int32_t>(op->outputIdsPtr->getDimension<0>());
+    bh.nMaxBatchSize = op->outputLogProbsTiled.has_value()
+        ? static_cast<std::int32_t>(op->outputLogProbsTiled.value()->getShape().d[1])
+        : static_cast<std::int32_t>(op->outputIdsPtr->getDimension<0>());
     bh.nBatchSize = ip->localBatchSize;
     bh.nBeamWidth = op->outputIds->getDimension<1>();
     bh.nMaxSeqLen = op->outputIds->getDimension<2>();

--- a/cpp/tensorrt_llm/layers/beamSearchLayer.cu
+++ b/cpp/tensorrt_llm/layers/beamSearchLayer.cu
@@ -335,9 +335,9 @@ void BeamSearchLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> const
     BeamHypotheses bh;
     // bh's members not used in this function: outputIds, logProbs, outputIdsUnfinish, parentIdsUnfinish
     bh.bVBWS = this->mVBWS;
-    bh.nMaxBatchSize = op->outputLogProbsTiled.has_value()
-        ? static_cast<std::int32_t>(op->outputLogProbsTiled.value()->getShape().d[1])
-        : static_cast<std::int32_t>(op->outputIdsPtr->getDimension<0>());
+    // outputIds is never sliced to active batch size; its dim-0 is always maxBatchSize.
+    // outputIdsPtr is sliced to activeBatchSize in DynamicDecodeLayer and must not be used as a stride.
+    bh.nMaxBatchSize = static_cast<std::int32_t>(op->outputIds->getDimension<0>());
     bh.nBatchSize = ip->localBatchSize;
     bh.nBeamWidth = op->outputIds->getDimension<1>();
     bh.nMaxSeqLen = op->outputIds->getDimension<2>();

--- a/cpp/tensorrt_llm/layers/beamSearchLayer.cu
+++ b/cpp/tensorrt_llm/layers/beamSearchLayer.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2019-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -335,8 +335,9 @@ void BeamSearchLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> const
     BeamHypotheses bh;
     // bh's members not used in this function: outputIds, logProbs, outputIdsUnfinish, parentIdsUnfinish
     bh.bVBWS = this->mVBWS;
-    // outputIds is never sliced to active batch size; its dim-0 is always maxBatchSize.
-    // outputIdsPtr is sliced to activeBatchSize in DynamicDecodeLayer and must not be used as a stride.
+    // outputIds retains its full maxBatchSize allocation; outputIdsPtr is sliced to the active
+    // batch size in DynamicDecodeLayer::prepareIdsPtrs (ITensor::slice(mOutputIdsPtrDevice, 0, batchSize))
+    // and must not be used as a stride for the [MSL, maxBatchSize, BM]-shaped logProbsTiled buffer.
     bh.nMaxBatchSize = static_cast<std::int32_t>(op->outputIds->getDimension<0>());
     bh.nBatchSize = ip->localBatchSize;
     bh.nBeamWidth = op->outputIds->getDimension<1>();
@@ -399,7 +400,7 @@ void BeamSearchLayer<T>::forwardAsync(std::shared_ptr<BaseDecodingOutputs> const
     T const* bias = static_cast<T const*>(nullptr);
     TLLM_CHECK_WITH_INFO(getWorkspaceSize() >= 2 * bh.nBatchSize * bh.nBeamWidth * bh.nBeamWidth * 2,
         "Workspace size (%lu) is not enough for topk softmax required (%lu).", (uint64_t) getWorkspaceSize(),
-        (uint64_t) (2 * bh.nMaxBatchSize * bh.nBeamWidth * bh.nBeamWidth * 2));
+        (uint64_t) (2 * bh.nBatchSize * bh.nBeamWidth * bh.nBeamWidth * 2));
 
     if (this->mV2 || this->mVBWS)
     {

--- a/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
+++ b/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
+++ b/cpp/tensorrt_llm/runtime/gptDecoderBatched.cpp
@@ -247,7 +247,7 @@ CudaEvent GptDecoderBatched::finalize(decoder::DecoderState const& decoderState,
 
     auto [dInput, dOutput] = prepareGatherTree(decoderState, batchSlot, streaming, *mRuntimeStream);
 
-    kernels::gatherTree(dOutput, dInput, samplingConfig, *mRuntimeStream);
+    kernels::gatherTree(dOutput, dInput, samplingConfig, *mRuntimeStream, batchSlot);
 
     CudaEvent event{};
     mRuntimeStream->record(event);

--- a/tests/integration/defs/examples/test_whisper.py
+++ b/tests/integration/defs/examples/test_whisper.py
@@ -219,7 +219,7 @@ def test_whisper_beam_search_generation_logits(llm_venv, engine_dir,
 @pytest.mark.parametrize("batch_size", [4],
                          ids=lambda batch_size: f'bs:{batch_size}')
 @pytest.mark.parametrize("whisper_model_root", ['large-v3'], indirect=True)
-def test_whisper_log_probs_determinism(llm_venv, engine_dir,
+def test_whisper_log_probs_determinism(llm_venv, engine_dir, llm_root,
                                        whisper_example_root, whisper_model_root,
                                        num_beams, batch_size,
                                        llm_datasets_root):
@@ -286,9 +286,13 @@ def test_whisper_log_probs_determinism(llm_venv, engine_dir,
         "--num_runs=5",
     ]
     env = {
+        # llm_root is listed first so the worktree's tensorrt_llm takes priority
+        # over any system-installed version when the validation subprocess runs.
         "PYTHONPATH":
         os.pathsep.join(
-            filter(None, [whisper_example_root,
-                          os.environ.get("PYTHONPATH")])),
+            filter(
+                None,
+                [llm_root, whisper_example_root,
+                 os.environ.get("PYTHONPATH")])),
     }
     venv_check_call(llm_venv, run_cmd, env=env)

--- a/tests/integration/defs/examples/test_whisper.py
+++ b/tests/integration/defs/examples/test_whisper.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -205,6 +205,87 @@ def test_whisper_beam_search_generation_logits(llm_venv, engine_dir,
     env = {
         "HF_DATASETS_OFFLINE":
         "0",
+        "PYTHONPATH":
+        os.pathsep.join(
+            filter(None, [whisper_example_root,
+                          os.environ.get("PYTHONPATH")])),
+    }
+    venv_check_call(llm_venv, run_cmd, env=env)
+
+
+@skip_post_blackwell
+@pytest.mark.parametrize("num_beams", [4],
+                         ids=lambda num_beams: f'nb:{num_beams}')
+@pytest.mark.parametrize("batch_size", [4],
+                         ids=lambda batch_size: f'bs:{batch_size}')
+@pytest.mark.parametrize("whisper_model_root", ['large-v3'], indirect=True)
+def test_whisper_log_probs_determinism(llm_venv, engine_dir,
+                                       whisper_example_root, whisper_model_root,
+                                       num_beams, batch_size,
+                                       llm_datasets_root):
+    """Regression test for nMaxBatchSize stride bug in beam search log_probs.
+
+    Sends a batch of requests with different audio samples so each item produces
+    a different number of output tokens.  When the batch drains unevenly the
+    active batch dimension shrinks; the bug caused beamStage3 to use that
+    shrinking value as the logProbsTiled stride, producing non-deterministic
+    log_probs across runs.
+
+    Runs inference num_runs times and asserts log_probs are bit-identical.
+    """
+    tllm_model_name, model_ckpt_dir = whisper_model_root
+
+    whisper_engine_dir = (f"{engine_dir}/{tllm_model_name}"
+                          f"/float16_bs{batch_size}_nb{num_beams}_logprobs_det")
+
+    converted_weight_dir = convert_weights(llm_venv=llm_venv,
+                                           example_root=whisper_example_root,
+                                           cmodel_dir=whisper_engine_dir,
+                                           model=tllm_model_name,
+                                           model_path=model_ckpt_dir,
+                                           use_weight_only=False,
+                                           weight_only_precision=None)
+
+    print("Build engines for log_probs determinism test...")
+    for component in ["encoder", "decoder"]:
+        build_cmd = [
+            "trtllm-build",
+            f"--checkpoint_dir={converted_weight_dir}/{component}",
+            f"--output_dir={whisper_engine_dir}/{component}",
+            "--paged_kv_cache=enable",
+            "--remove_input_padding=enable",
+            "--moe_plugin=disable",
+            f"--max_batch_size={batch_size}",
+            "--gemm_plugin=float16",
+            "--bert_attention_plugin=float16",
+            "--gpt_attention_plugin=float16",
+        ]
+        if component == "encoder":
+            build_cmd.append("--max_input_len=3000")
+            build_cmd.append("--max_seq_len=3000")
+        if component == "decoder":
+            build_cmd.append("--max_input_len=14")
+            build_cmd.append("--max_seq_len=114")
+            build_cmd.append("--max_encoder_input_len=3000")
+            build_cmd.append(f"--max_beam_width={num_beams}")
+
+        check_call(build_cmd, env=llm_venv._new_env)
+
+    print("Run log_probs determinism validation...")
+    validation_script = os.path.join(
+        os.path.dirname(__file__), "validate_whisper_log_probs_determinism.py")
+    librispeech_dir = os.path.join(llm_datasets_root,
+                                   "hf-internal-testing/librispeech_asr_dummy")
+    run_cmd = [
+        validation_script,
+        f"--engine_dir={whisper_engine_dir}",
+        f"--assets_dir={model_ckpt_dir}",
+        f"--dataset_dir={librispeech_dir}",
+        f"--num_beams={num_beams}",
+        f"--batch_size={batch_size}",
+        "--num_runs=5",
+    ]
+    env = {
         "PYTHONPATH":
         os.pathsep.join(
             filter(None, [whisper_example_root,

--- a/tests/integration/defs/examples/validate_whisper_log_probs_determinism.py
+++ b/tests/integration/defs/examples/validate_whisper_log_probs_determinism.py
@@ -1,0 +1,184 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Validate that log_probs are deterministic across runs with beam search and batch_size > 1.
+
+Reproduces the nMaxBatchSize stride bug: when batch items finish at different
+times the active batch dimension shrinks, causing beamStage3 to read logProbsTiled
+with the wrong stride and produce different log_probs values across runs.
+
+Different LibriSpeech samples produce different decoder output lengths, creating
+an uneven batch where some items finish before others — the exact scenario that
+triggers the bug.
+"""
+
+import argparse
+import json
+import sys
+from collections import OrderedDict
+from pathlib import Path
+
+import numpy as np
+import torch
+
+import tensorrt_llm
+from tensorrt_llm._utils import str_dtype_to_torch
+from tensorrt_llm.runtime import ModelRunnerCpp
+
+
+def read_config(component, engine_dir):
+    config_path = engine_dir / component / "config.json"
+    with open(config_path, "r") as f:
+        config = json.load(f)
+    model_config = OrderedDict()
+    model_config.update(config["pretrained_config"])
+    model_config.update(config["build_config"])
+    return model_config
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--engine_dir", type=str, required=True)
+    parser.add_argument("--assets_dir", type=str, required=True)
+    parser.add_argument(
+        "--dataset_dir",
+        type=str,
+        required=True,
+        help="Local path to hf-internal-testing/librispeech_asr_dummy dataset",
+    )
+    parser.add_argument("--num_beams", type=int, default=4)
+    parser.add_argument("--batch_size", type=int, default=4)
+    parser.add_argument("--max_new_tokens", type=int, default=96)
+    parser.add_argument("--num_runs", type=int, default=5)
+    args = parser.parse_args()
+    if args.num_runs < 2:
+        parser.error("--num_runs must be >= 2 to compare log_probs across runs")
+    return args
+
+
+def main():
+    args = parse_arguments()
+    tensorrt_llm.logger.set_level("warning")
+
+    engine_dir = Path(args.engine_dir)
+    encoder_config = read_config("encoder", engine_dir)
+    decoder_config = read_config("decoder", engine_dir)
+
+    n_mels = encoder_config["n_mels"]
+    is_multilingual = decoder_config["vocab_size"] >= 51865
+
+    from tokenizer import get_tokenizer
+    from whisper_utils import log_mel_spectrogram
+
+    tokenizer_name = "multilingual" if is_multilingual else "gpt2"
+    tokenizer = get_tokenizer(
+        name=tokenizer_name,
+        num_languages=encoder_config["num_languages"],
+        tokenizer_dir=args.assets_dir,
+    )
+    eot_id = tokenizer.encode("<|endoftext|>", allowed_special=tokenizer.special_tokens_set)[0]
+
+    runner = ModelRunnerCpp.from_dir(
+        engine_dir=engine_dir,
+        is_enc_dec=True,
+        max_batch_size=args.batch_size,
+        max_input_len=3000,
+        max_output_len=args.max_new_tokens,
+        max_beam_width=args.num_beams,
+        kv_cache_free_gpu_memory_fraction=0.9,
+        cross_kv_cache_fraction=0.5,
+        gather_generation_logits=True,
+    )
+
+    # Use different LibriSpeech samples so each batch item produces a different
+    # number of output tokens — this creates the uneven-finish condition that
+    # triggers the nMaxBatchSize stride bug.
+    from datasets import load_dataset
+
+    dataset = load_dataset(args.dataset_dir, "clean", split="validation", trust_remote_code=True)
+
+    mel_list = []
+    for i in range(args.batch_size):
+        speech = dataset[i]["audio"]["array"].astype(np.float32)
+        waveform = torch.from_numpy(speech)
+        m = log_mel_spectrogram(waveform, n_mels, device="cuda", mel_filters_dir=args.assets_dir)
+        m = m.type(str_dtype_to_torch("float16"))
+        if m.shape[1] % 2:
+            m = torch.nn.functional.pad(m, (0, 1))
+        mel_list.append(m)
+
+    max_mel_len = max(m.shape[1] for m in mel_list)
+    mel_batched = torch.zeros(
+        args.batch_size,
+        mel_list[0].shape[0],
+        max_mel_len,
+        dtype=mel_list[0].dtype,
+        device=mel_list[0].device,
+    )
+    for i, m in enumerate(mel_list):
+        mel_batched[i, :, : m.shape[1]] = m
+
+    mel_input_lengths = torch.full(
+        (args.batch_size,), max_mel_len, dtype=torch.int32, device="cuda"
+    )
+
+    prompt_text = "<|startoftranscript|><|en|><|transcribe|><|notimestamps|>"
+    prompt_ids = tokenizer.encode(prompt_text, allowed_special=tokenizer.special_tokens_set)
+    decoder_input_ids = torch.tensor(prompt_ids).unsqueeze(0).repeat(args.batch_size, 1)
+
+    all_log_probs = []
+    for run_idx in range(args.num_runs):
+        with torch.no_grad():
+            outputs = runner.generate(
+                batch_input_ids=decoder_input_ids,
+                encoder_input_features=mel_batched.transpose(1, 2),
+                encoder_output_lengths=mel_input_lengths // 2,
+                max_new_tokens=args.max_new_tokens,
+                end_id=eot_id,
+                pad_id=eot_id,
+                num_beams=args.num_beams,
+                num_return_sequences=1,
+                output_sequence_lengths=True,
+                output_generation_logits=True,
+                output_log_probs=True,
+                return_dict=True,
+            )
+        torch.cuda.synchronize()
+        all_log_probs.append(outputs["log_probs"][:, 0, :].cpu())
+
+    for i in range(1, args.num_runs):
+        if all_log_probs[i].shape != all_log_probs[0].shape:
+            print(
+                f"FAIL: log_probs shape mismatch between run 1 {all_log_probs[0].shape} "
+                f"and run {i + 1} {all_log_probs[i].shape}"
+            )
+            sys.exit(1)
+
+    max_diff = max(
+        (all_log_probs[0] - all_log_probs[i]).abs().max().item() for i in range(1, args.num_runs)
+    )
+
+    if max_diff < 1e-6:
+        print(
+            f"PASS: log_probs are deterministic across {args.num_runs} runs "
+            f"(max diff: {max_diff:.2e})"
+        )
+        sys.exit(0)
+    else:
+        print(f"FAIL: log_probs are non-deterministic (max diff: {max_diff:.6f})")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/defs/examples/validate_whisper_log_probs_determinism.py
+++ b/tests/integration/defs/examples/validate_whisper_log_probs_determinism.py
@@ -76,7 +76,7 @@ def main():
     decoder_config = read_config("decoder", engine_dir)
 
     n_mels = encoder_config["n_mels"]
-    is_multilingual = decoder_config["vocab_size"] >= 51865
+    is_multilingual = decoder_config["vocab_size"] >= 51865  # multilingual vocab size threshold
 
     from tokenizer import get_tokenizer
     from whisper_utils import log_mel_spectrogram
@@ -138,6 +138,9 @@ def main():
     decoder_input_ids = torch.tensor(prompt_ids).unsqueeze(0).repeat(args.batch_size, 1)
 
     all_log_probs = []
+    ref_output_ids = None
+    ref_gen_logits = None
+    input_len = decoder_input_ids.shape[1]
     for run_idx in range(args.num_runs):
         with torch.no_grad():
             outputs = runner.generate(
@@ -156,6 +159,9 @@ def main():
             )
         torch.cuda.synchronize()
         all_log_probs.append(outputs["log_probs"][:, 0, :].cpu())
+        if run_idx == 0:
+            ref_output_ids = outputs["output_ids"].cpu()
+            ref_gen_logits = outputs["generation_logits"].cpu()
 
     for i in range(1, args.num_runs):
         if all_log_probs[i].shape != all_log_probs[0].shape:
@@ -169,15 +175,43 @@ def main():
         (all_log_probs[0] - all_log_probs[i]).abs().max().item() for i in range(1, args.num_runs)
     )
 
-    if max_diff < 1e-6:
-        print(
-            f"PASS: log_probs are deterministic across {args.num_runs} runs "
-            f"(max diff: {max_diff:.2e})"
-        )
-        sys.exit(0)
-    else:
+    if max_diff >= 1e-6:
         print(f"FAIL: log_probs are non-deterministic (max diff: {max_diff:.6f})")
         sys.exit(1)
+
+    # Correctness check: verify log_probs[b][t] matches log_softmax(generation_logits[b][t])[token]
+    # for every batch slot b (including b > 0, exercising the gatherTree batchSlot offset fix).
+    # Uses a loose tolerance because log_probs come from float32 beam search bookkeeping while
+    # generation_logits are the raw fp16->fp32 decoder outputs.
+    LOG_PROB_ATOL = 0.5
+    all_aligned = True
+    for b in range(args.batch_size):
+        gen_tokens = ref_output_ids[b, 0, input_len:]
+        eot_pos = (gen_tokens == eot_id).nonzero(as_tuple=True)[0]
+        gen_len = eot_pos[0].item() if len(eot_pos) > 0 else gen_tokens.shape[0]
+        if gen_len == 0:
+            continue
+        logits = ref_gen_logits[b, 0, :gen_len, :]
+        log_probs_from_logits = torch.nn.functional.log_softmax(logits.float(), dim=-1)
+        expected = log_probs_from_logits.gather(1, gen_tokens[:gen_len].unsqueeze(1)).squeeze(1)
+        actual = all_log_probs[0][b, :gen_len]
+        max_lp_diff = (actual - expected).abs().max().item()
+        if max_lp_diff > LOG_PROB_ATOL:
+            print(
+                f"FAIL: log_probs[batch={b}] deviate from generation_logits "
+                f"(max diff: {max_lp_diff:.4f} > {LOG_PROB_ATOL}); "
+                "likely caused by wrong logProbsTiled batchSlot offset in gatherTree."
+            )
+            all_aligned = False
+
+    if not all_aligned:
+        sys.exit(1)
+
+    print(
+        f"PASS: log_probs are deterministic across {args.num_runs} runs "
+        f"(max diff: {max_diff:.2e}) and aligned with generation_logits for all batch slots."
+    )
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_lists/test-db/l0_a100.yml
+++ b/tests/integration/test_lists/test-db/l0_a100.yml
@@ -79,6 +79,8 @@ l0_a100:
   - unittest/llmapi/test_llm_models.py -m "part0"
   - examples/test_whisper.py::test_llm_whisper_general[large-v3-disable_gemm_plugin-enable_attention_plugin-disable_weight_only-float16-nb:1-use_cpp_runtime]
   - examples/test_whisper.py::test_llm_whisper_general[large-v3-disable_gemm_plugin-enable_attention_plugin-disable_weight_only-float16-nb:1-use_python_runtime]
+  - examples/test_whisper.py::test_whisper_beam_search_generation_logits[large-v3-nb:4]
+  - examples/test_whisper.py::test_whisper_log_probs_determinism[large-v3-bs:4-nb:4]
 - condition:
     ranges:
       system_gpu_count:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected batch-slot handling in beam-search decoding so batched inference computes log-probabilities consistently across items and runs.
  * Ensured deterministic beam-search outputs for variable-length/unevenly finishing items.

* **Tests**
  * Added integration test and validator to assert log-prob determinism for Whisper beam-search across repeated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

`bh.nMaxBatchSize` in `BeamSearchLayer::forwardAsync` was derived from `outputIdsPtr->getDimension<0>()`, which reflects the *active* batch size. `outputIdsPtr` is sliced to `activeBatchSize` in `DynamicDecodeLayer::setupOutputIds` (`ITensor::slice(mOutputIdsPtrDevice, 0, batchSize)`), so as requests finish at different times and the batch drains unevenly, this dimension shrinks. BeamStage3 then reads `logProbsTiled` with the wrong stride, producing non-deterministic log_prob values across runs.

**Fix 1** (`beamSearchLayer.cu`): Use `outputIds->getDimension<0>()` unconditionally — `outputIds` is never sliced to active batch size (it is used as a base pointer with per-slot offsets up to `maxBatchSize-1`), so its dim-0 is always `maxBatchSize`. This supersedes a prior partial fix that only applied when `output_log_probs=True`.

**Fix 2** (`decodingKernels.cu` / `gptDecoderBatched.cpp`): `gatherTree`'s `insertUnfinishedPathKernel` was using `nMaxBatchSize=1` (from the per-slot `batchSize`) and reading `logProbsTiled` from the wrong base pointer (missing `batchSlot * beamWidth` offset). Fixed to use the actual tensor allocation dimension and correct pointer offset.

Both fixes are TRT backend only and affect all models using beam search with `batch_size > 1` and `output_log_probs=True` (or `gather_generation_logits=True`).

## Test Coverage

New integration test `test_whisper_log_probs_determinism` in `tests/integration/defs/examples/test_whisper.py`:
- Runs Whisper large-v3 with `batch_size=4`, `num_beams=4` across 5 inference runs
- Uses 4 different LibriSpeech samples so each batch item produces a different number of output tokens (uneven batch drain)
- Asserts `log_probs` are bit-identical across all runs
- Uses pre-cached local dataset (`llm_datasets_root`) — no HuggingFace download at test time

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.