### PR TITLE
[None][test] Add e2e example tests for flux1/2, ltx2, wan_i2v, and cosmos3

### DIFF
--- a/tests/integration/defs/examples/test_visual_gen.py
+++ b/tests/integration/defs/examples/test_visual_gen.py
@@ -35,6 +35,7 @@ from defs.trt_test_alternative import check_call
 WAN_T2V_MODEL_SUBPATH = "Wan2.1-T2V-1.3B-Diffusers"
 WAN22_A14B_FP8_MODEL_SUBPATH = "Wan2.2-T2V-A14B-Diffusers-FP8"
 WAN22_A14B_NVFP4_MODEL_SUBPATH = "Wan2.2-T2V-A14B-Diffusers-NVFP4"
+WAN22_I2V_A14B_NVFP4_MODEL_SUBPATH = "Wan2.2-I2V-A14B-Diffusers-NVFP4"
 VISUAL_GEN_OUTPUT_VIDEO = "trtllm_output.mp4"
 DIFFUSERS_REFERENCE_VIDEO = "diffusers_reference.mp4"
 WAN_T2V_PROMPT = "A cute cat playing piano"
@@ -1292,6 +1293,198 @@ def test_wan_t2v_example(_visual_gen_deps, llm_root, llm_venv):
             model_path,
             "--visual_gen_args",
             config_path,
+            "--output_path",
+            output_path,
+        ],
+    )
+    assert os.path.isfile(output_path), f"Example did not produce output at {output_path}"
+
+
+def test_flux1_example(_visual_gen_deps, llm_root, llm_venv):
+    """Run examples/visual_gen/models/flux1.py with NVFP4 config end-to-end.
+
+    Validates that the FLUX.1-dev example script and ``configs/flux1-dev-fp4-1gpu.yaml``
+    work together as documented. Uses the local FLUX.1-dev checkpoint and the shared
+    NVFP4 dynamic-quant config.
+    """
+    model_path = _lpips_model_path("FLUX.1-dev")
+    _skip_if_missing(model_path, "FLUX.1-dev checkpoint", is_dir=True)
+
+    out_dir = os.path.join(llm_venv.get_working_directory(), "visual_gen_output", "flux1_example")
+    os.makedirs(out_dir, exist_ok=True)
+    output_path = os.path.join(out_dir, "flux1_output.png")
+
+    script_path = os.path.join(llm_root, "examples", "visual_gen", "models", "flux1.py")
+    config_path = os.path.join(
+        llm_root, "examples", "visual_gen", "configs", "flux1-dev-fp4-1gpu.yaml"
+    )
+    assert os.path.isfile(script_path), f"Example script not found: {script_path}"
+    assert os.path.isfile(config_path), f"Config not found: {config_path}"
+
+    venv_check_call(
+        llm_venv,
+        [
+            script_path,
+            "--model",
+            model_path,
+            "--visual_gen_args",
+            config_path,
+            "--output_path",
+            output_path,
+        ],
+    )
+    assert os.path.isfile(output_path), f"Example did not produce output at {output_path}"
+
+
+def test_flux2_example(_visual_gen_deps, llm_root, llm_venv):
+    """Run examples/visual_gen/models/flux2.py with NVFP4 config end-to-end.
+
+    Validates that the FLUX.2-dev example script and ``configs/flux2-dev-fp4-1gpu.yaml``
+    work together as documented. Uses the local FLUX.2-dev checkpoint and the shared
+    NVFP4 dynamic-quant config.
+    """
+    model_path = _lpips_model_path("FLUX.2-dev")
+    _skip_if_missing(model_path, "FLUX.2-dev checkpoint", is_dir=True)
+
+    out_dir = os.path.join(llm_venv.get_working_directory(), "visual_gen_output", "flux2_example")
+    os.makedirs(out_dir, exist_ok=True)
+    output_path = os.path.join(out_dir, "flux2_output.png")
+
+    script_path = os.path.join(llm_root, "examples", "visual_gen", "models", "flux2.py")
+    config_path = os.path.join(
+        llm_root, "examples", "visual_gen", "configs", "flux2-dev-fp4-1gpu.yaml"
+    )
+    assert os.path.isfile(script_path), f"Example script not found: {script_path}"
+    assert os.path.isfile(config_path), f"Config not found: {config_path}"
+
+    venv_check_call(
+        llm_venv,
+        [
+            script_path,
+            "--model",
+            model_path,
+            "--visual_gen_args",
+            config_path,
+            "--output_path",
+            output_path,
+        ],
+    )
+    assert os.path.isfile(output_path), f"Example did not produce output at {output_path}"
+
+
+def test_ltx2_example(_visual_gen_deps, llm_root, llm_venv):
+    """Run examples/visual_gen/models/ltx2.py with NVFP4 config end-to-end.
+
+    Validates that the LTX-2 example script and ``configs/ltx2-t2v-fp4-1gpu.yaml``
+    work together as documented. The Gemma3 text encoder is passed separately via
+    ``--text_encoder_path`` because the shared YAML intentionally omits it to keep
+    the config model-path-agnostic.
+    """
+    model_path = _lpips_model_path("LTX-2")
+    _skip_if_missing(model_path, "LTX-2 model directory", is_dir=True)
+    text_encoder_path = _ltx2_lpips_text_encoder_path()
+    _skip_if_missing(text_encoder_path, "LTX-2 text encoder (gemma-3-12b-it)", is_dir=True)
+
+    out_dir = os.path.join(llm_venv.get_working_directory(), "visual_gen_output", "ltx2_example")
+    os.makedirs(out_dir, exist_ok=True)
+    output_path = os.path.join(out_dir, "ltx2_output.mp4")
+
+    script_path = os.path.join(llm_root, "examples", "visual_gen", "models", "ltx2.py")
+    config_path = os.path.join(
+        llm_root, "examples", "visual_gen", "configs", "ltx2-t2v-fp4-1gpu.yaml"
+    )
+    assert os.path.isfile(script_path), f"Example script not found: {script_path}"
+    assert os.path.isfile(config_path), f"Config not found: {config_path}"
+
+    venv_check_call(
+        llm_venv,
+        [
+            script_path,
+            "--model",
+            model_path,
+            "--visual_gen_args",
+            config_path,
+            "--text_encoder_path",
+            text_encoder_path,
+            "--output_path",
+            output_path,
+        ],
+    )
+    assert os.path.isfile(output_path), f"Example did not produce output at {output_path}"
+
+
+def test_wan_i2v_example(_visual_gen_deps, llm_root, llm_venv):
+    """Run examples/visual_gen/models/wan_i2v.py with NVFP4 config end-to-end.
+
+    Validates that the Wan I2V example script and ``configs/wan2.2-i2v-fp4-1gpu.yaml``
+    work together as documented. Uses the pre-quantized Wan 2.2 I2V A14B NVFP4
+    checkpoint and the default input image (cat_piano.png) bundled with the examples.
+    """
+    scratch_space = conftest.llm_models_root()
+    model_path = os.path.join(scratch_space, WAN22_I2V_A14B_NVFP4_MODEL_SUBPATH)
+    if not os.path.isdir(model_path):
+        pytest.skip(
+            f"Model not found: {model_path} "
+            f"(set LLM_MODELS_ROOT or place {WAN22_I2V_A14B_NVFP4_MODEL_SUBPATH} under models root)"
+        )
+
+    out_dir = os.path.join(llm_venv.get_working_directory(), "visual_gen_output", "wan_i2v_example")
+    os.makedirs(out_dir, exist_ok=True)
+    output_path = os.path.join(out_dir, "wan_i2v_output.mp4")
+
+    script_path = os.path.join(llm_root, "examples", "visual_gen", "models", "wan_i2v.py")
+    config_path = os.path.join(
+        llm_root, "examples", "visual_gen", "configs", "wan2.2-i2v-fp4-1gpu.yaml"
+    )
+    assert os.path.isfile(script_path), f"Example script not found: {script_path}"
+    assert os.path.isfile(config_path), f"Config not found: {config_path}"
+
+    venv_check_call(
+        llm_venv,
+        [
+            script_path,
+            "--model",
+            model_path,
+            "--visual_gen_args",
+            config_path,
+            "--output_path",
+            output_path,
+        ],
+    )
+    assert os.path.isfile(output_path), f"Example did not produce output at {output_path}"
+
+
+def test_cosmos3_example(_visual_gen_deps, llm_root, llm_venv):
+    """Run examples/visual_gen/models/cosmos3_ti2v.py with FP8 config end-to-end.
+
+    Validates that the Cosmos3-Nano example script and ``configs/cosmos3-nano-1gpu.yaml``
+    work together as documented. Uses the local Cosmos3-Nano checkpoint and
+    the shared FP8 dynamic-quant config.
+    """
+    model_path = _lpips_model_path("Cosmos3-Nano")
+    _skip_if_missing(model_path, "Cosmos3-Nano checkpoint", is_dir=True)
+
+    out_dir = os.path.join(llm_venv.get_working_directory(), "visual_gen_output", "cosmos3_example")
+    os.makedirs(out_dir, exist_ok=True)
+    output_path = os.path.join(out_dir, "cosmos3_output.mp4")
+
+    script_path = os.path.join(llm_root, "examples", "visual_gen", "models", "cosmos3_ti2v.py")
+    config_path = os.path.join(
+        llm_root, "examples", "visual_gen", "configs", "cosmos3-nano-1gpu.yaml"
+    )
+    assert os.path.isfile(script_path), f"Example script not found: {script_path}"
+    assert os.path.isfile(config_path), f"Config not found: {config_path}"
+
+    venv_check_call(
+        llm_venv,
+        [
+            script_path,
+            "--model",
+            model_path,
+            "--visual_gen_args",
+            config_path,
+            "--prompt",
+            "A serene mountain landscape with snow-capped peaks and a flowing river",
             "--output_path",
             output_path,
         ],

--- a/tests/integration/defs/examples/test_visual_gen.py
+++ b/tests/integration/defs/examples/test_visual_gen.py
@@ -1380,8 +1380,8 @@ def test_ltx2_example(_visual_gen_deps, llm_root, llm_venv):
     ``--text_encoder_path`` because the shared YAML intentionally omits it to keep
     the config model-path-agnostic.
     """
-    model_path = _lpips_model_path("LTX-2")
-    _skip_if_missing(model_path, "LTX-2 model directory", is_dir=True)
+    model_path = _lpips_model_path("LTX-2", "ltx-2-19b-dev.safetensors")
+    _skip_if_missing(model_path, "LTX-2 checkpoint")
     text_encoder_path = _ltx2_lpips_text_encoder_path()
     _skip_if_missing(text_encoder_path, "LTX-2 text encoder (gemma-3-12b-it)", is_dir=True)
 
@@ -1488,5 +1488,6 @@ def test_cosmos3_example(_visual_gen_deps, llm_root, llm_venv):
             "--output_path",
             output_path,
         ],
+        env={"TRTLLM_DISABLE_COSMOS3_GUARDRAILS": "1"},
     )
     assert os.path.isfile(output_path), f"Example did not produce output at {output_path}"

--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -213,6 +213,11 @@ l0_b200:
   - unittest/_torch/visual_gen/test_cosmos3_transformer.py
   - unittest/_torch/visual_gen/test_cosmos3_pipeline.py
   - examples/test_visual_gen.py::test_wan_t2v_example
+  - examples/test_visual_gen.py::test_flux1_example
+  - examples/test_visual_gen.py::test_flux2_example
+  - examples/test_visual_gen.py::test_ltx2_example
+  - examples/test_visual_gen.py::test_wan_i2v_example
+  - examples/test_visual_gen.py::test_cosmos3_example
   # - examples/test_visual_gen.py
   # ------------- Host perf module regression tests (6 representative scenarios) ---------------
   - perf/host_perf/test_module_scheduler.py::test_scheduler_production[production_gen_only_bs8]


### PR DESCRIPTION
## Summary

Five example scripts were recently added under `examples/visual_gen/models/`
(`flux1.py`, `flux2.py`, `ltx2.py`, `wan_i2v.py`, `cosmos3_ti2v.py`) but none
had integration test coverage.  This PR adds one smoke test per script and wires
them into CI.

**Tests added** (`tests/integration/defs/examples/test_visual_gen.py`):
- `test_flux1_example` — runs `flux1.py` + `configs/flux1-dev-fp4-1gpu.yaml`
- `test_flux2_example` — runs `flux2.py` + `configs/flux2-dev-fp4-1gpu.yaml`
- `test_ltx2_example` — runs `ltx2.py` + `configs/ltx2-t2v-fp4-1gpu.yaml` (passes `--text_encoder_path` separately since the shared YAML omits it intentionally)
- `test_wan_i2v_example` — runs `wan_i2v.py` + `configs/wan2.2-i2v-fp4-1gpu.yaml` (uses NVFP4 pre-quantized checkpoint, default `cat_piano.png` input image)
- `test_cosmos3_example` — runs `cosmos3_ti2v.py` + `configs/cosmos3-nano-1gpu.yaml`

Each test:
1. Skips gracefully if the model checkpoint is absent under `LLM_MODELS_ROOT`
2. Passes the shared YAML config from `examples/visual_gen/configs/`
3. Asserts the expected output file (`.png` or `.mp4`) is produced

**CI registration** (`tests/integration/test_lists/test-db/l0_b200.yml`):
All five tests registered in the B200 post-merge stage alongside the existing `test_wan_t2v_example`.

## Test plan
- [x] Pre-merge CI (B200 post-merge stage) runs all 5 new tests
- [x] Tests with missing checkpoints skip cleanly rather than fail
- [x] `Validate test list entries exist in source files (AST)` pre-commit hook passes (already verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end integration tests for visual generation examples, covering Flux1, Flux2, LTX-2, Wan 2.2 I2V, and Cosmos3.
  * New tests validate example scripts, configurations, and output generation for each model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->