### PR TITLE
[None][perf] reduce rank-0 GIL contention in disaggregated generation

### DIFF
--- a/tensorrt_llm/_torch/distributed/communicator.py
+++ b/tensorrt_llm/_torch/distributed/communicator.py
@@ -308,18 +308,12 @@ def safe_broadcast(comm, obj, root=0, chunk_size: int = 4 * 1024 * 1024):
         offset += cur
 
     # ---- Reconstruction and deserialization ----
-    # Validate the received byte count and unpickle.
     if rank == root:
-        # Root already has `serialized`
-        if len(serialized) != total_size:
-            raise RuntimeError(
-                f"Data size mismatch at root: expected {total_size}, got {len(serialized)}"
-            )
-        try:
-            return pickle.loads(serialized)  # nosec B301
-        except Exception as e:
-            raise RuntimeError(f"Deserialization failed: {str(e)}") from e
+        # Root already holds `obj`; rebuilding it from its own serialized bytes
+        # would be a needless deep copy.
+        return obj
     else:
+        # Validate the received byte count and unpickle.
         if len(dst_buf) != total_size:
             raise RuntimeError(
                 f"Data size mismatch at rank {rank}: expected {total_size}, got {len(dst_buf)}"

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -310,17 +310,17 @@ class DefaultADPRouter(ADPRouter):
 
         heapq.heapify(all_ranks_new_requests_heap)
 
-        new_requests = sorted(
-            new_requests,
-            key=lambda x: len(getattr(x.request, "input_token_ids", [])) if x.request else 0,
-            reverse=True,
-        )
+        # input_token_ids is a C++ getter that copies the whole token list on every
+        # access, so read it once per request instead of in both the sort key and
+        # the loop below.
+        counted = [
+            (len(req.input_token_ids) if (req := item.request) is not None else 0, item)
+            for item in new_requests
+        ]
+        counted.sort(key=lambda item: item[0], reverse=True)
 
-        for req_item in new_requests:
+        for token_count, req_item in counted:
             val = heapq.heappop(all_ranks_new_requests_heap)
-            token_count = (
-                len(getattr(req_item.request, "input_token_ids", [])) if req_item.request else 0
-            )
             val = val._replace(
                 num_tokens=val.num_tokens + token_count,
                 num_requests=val.num_requests + 1,


### PR DESCRIPTION
## What

Reduce per-iteration GIL contention on the disaggregated **generation** rank-0
process. At high concurrency rank 0 runs the executor loop, the request ingress,
and the attention-DP request broadcast on a single GIL, so host work on rank 0
paces the iteration. Two redundant, hot GIL costs on the executor-loop thread are
removed:

1. **`safe_broadcast` (`_torch/distributed/communicator.py`)** — the root rank
   rebuilt its return value by `pickle.loads`-ing its *own* just-serialized bytes,
   a full deep copy of the broadcast payload (which carries the new requests'
   token ids) on every iteration. Return the original object instead. Also drops a
   now-dead size check that compared a length against itself.

2. **`DefaultADPRouter._balance_requests_across_ranks`
   (`_torch/pyexecutor/scheduler/adp_router.py`)** — `input_token_ids` is a C++
   getter that copies the whole token list on every access, and it was read twice
   per request per iteration (the descending-token sort key and the heap loop).
   Read it once per request.

Both run on the rank-0 executor-loop thread on every iteration at scale.

## Impact

Measured on DeepSeek-V4-Pro 7P1D disaggregated (7×CTX-DEP4 + 1×GEN-DEP8, GB300),
concurrency 2880, py-spy on the rank-0 generation worker:

- GEN `host_step_time` p50: 123.5 ms → ~105 ms (**−15%**)
- GEN `device_step_time` p50: 123 ms → ~99 ms (**−19%**) — under the overlap
  scheduler the device step was being dragged up to the host step, i.e. the
  generation step was host-bound; relieving the host work surfaces the true
  device time
- per-request output speed (SSE) p25: **+~6%**

No functional change.

## Test

- Router change is order-equivalent to the original (same descending-token sort).
- `safe_broadcast` root return is value-identical: non-root ranks still
  reconstruct the same object from the broadcast bytes; the root already holds it.
