### PR TITLE
[TRTLLM-12721][feat] Add disagg transfer state consensus

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
+++ b/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
@@ -35,6 +35,7 @@
 #include <torch/custom_class.h>
 #include <torch/python.h>
 #include <type_traits>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -287,6 +288,12 @@ private:
     // Dedup sets so observe-only timeout WARN logs fire at most once per stuck request.
     std::unordered_set<LlmRequest::RequestIdType> mTimedOutSenderIds;
     std::unordered_set<LlmRequest::RequestIdType> mTimedOutRequesterIds;
+    std::unordered_set<LlmRequest::RequestIdType> mCompletedSenderRequestIds;
+    std::unordered_set<LlmRequest::RequestIdType> mFailedSenderRequestIds;
+    std::unordered_map<LlmRequest::RequestIdType, std::shared_ptr<LlmRequest>> mSenderRequestsAwaitingConsensus;
+    std::unordered_set<LlmRequest::RequestIdType> mCompletedRequesterRequestIds;
+    std::unordered_set<LlmRequest::RequestIdType> mFailedRequesterRequestIds;
+    std::unordered_map<LlmRequest::RequestIdType, std::shared_ptr<LlmRequest>> mRequesterRequestsAwaitingConsensus;
     mpi::MpiComm const* mMpiWorldComm{nullptr};
 
     std::shared_ptr<CacheTransceiverComm> mGroupComm;

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -55,12 +55,164 @@
 #include <algorithm>
 #include <cstddef>
 #include <numeric>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace tensorrt_llm::batch_manager
 {
 
 std::mutex CacheTransceiver::mDllMutex;
+
+namespace
+{
+
+using RequestIdType = LlmRequest::RequestIdType;
+
+enum class TransferConsensusState : std::uint64_t
+{
+    kCompleted = 1,
+    kFailed = 2,
+};
+
+struct TransferStateCounts
+{
+    int completedCount{0};
+    int failedCount{0};
+};
+
+struct TransferConsensusOutcome
+{
+    std::unordered_set<RequestIdType> completedRequestIds;
+    std::unordered_set<RequestIdType> failedRequestIds;
+};
+
+void appendPackedTransferState(
+    std::vector<std::uint64_t>& packedStates, RequestIdType requestId, TransferConsensusState state)
+{
+    packedStates.push_back(requestId);
+    packedStates.push_back(static_cast<std::uint64_t>(state));
+}
+
+std::vector<std::uint64_t> gatherPackedTransferStates(
+    std::shared_ptr<CacheTransceiverComm> const& comm, std::vector<std::uint64_t> const& packedStates)
+{
+    int localSize = static_cast<int>(packedStates.size());
+    std::vector<int> sizes(comm->getSize());
+    std::vector<std::uint64_t> gatheredStates;
+    if (useMPI())
+    {
+        comm->allgather(&localSize, sizes.data(), 1, mpi::MpiType::kINT32);
+        std::vector<int> displs(comm->getSize());
+        size_t totalSize = 0;
+        for (int i = 0; i < comm->getSize(); i++)
+        {
+            displs[i] = static_cast<int>(totalSize);
+            totalSize += sizes[i];
+        }
+        gatheredStates.resize(totalSize);
+        comm->allgatherv(packedStates.data(), static_cast<int>(packedStates.size()), mpi::MpiType::kUINT64,
+            gatheredStates.data(), sizes, displs, mpi::MpiType::kUINT64);
+    }
+    else
+    {
+        comm->allgather(&localSize, std::ref(sizes), {});
+        size_t totalSize = std::accumulate(sizes.begin(), sizes.end(), 0);
+        gatheredStates.resize(totalSize);
+        comm->allgatherv(std::ref(packedStates), std::ref(gatheredStates), std::cref(sizes), {});
+    }
+    return gatheredStates;
+}
+
+TransferConsensusOutcome reduceTransferStates(std::shared_ptr<CacheTransceiverComm> const& comm,
+    std::unordered_set<RequestIdType> const& completedRequestIds,
+    std::unordered_set<RequestIdType> const& failedRequestIds)
+{
+    std::vector<std::uint64_t> localStates;
+    localStates.reserve((completedRequestIds.size() + failedRequestIds.size()) * 2);
+    for (auto const requestId : completedRequestIds)
+    {
+        if (failedRequestIds.find(requestId) == failedRequestIds.end())
+        {
+            appendPackedTransferState(localStates, requestId, TransferConsensusState::kCompleted);
+        }
+    }
+    for (auto const requestId : failedRequestIds)
+    {
+        appendPackedTransferState(localStates, requestId, TransferConsensusState::kFailed);
+    }
+
+    int const syncSize = (comm != nullptr) ? comm->getSize() : 1;
+    auto const gatheredStates
+        = ((comm != nullptr) && syncSize > 1) ? gatherPackedTransferStates(comm, localStates) : std::move(localStates);
+
+    constexpr size_t kPackedStateFields = 2;
+    TLLM_CHECK_WITH_INFO(gatheredStates.size() % kPackedStateFields == 0,
+        "Packed transfer state consensus payload must contain request/state pairs.");
+
+    std::unordered_map<RequestIdType, TransferStateCounts> stateCounts;
+    for (size_t idx = 0; idx < gatheredStates.size(); idx += kPackedStateFields)
+    {
+        auto const requestId = gatheredStates.at(idx);
+        auto const state = static_cast<TransferConsensusState>(gatheredStates.at(idx + 1));
+        auto& counts = stateCounts[requestId];
+        switch (state)
+        {
+        case TransferConsensusState::kCompleted: counts.completedCount++; break;
+        case TransferConsensusState::kFailed: counts.failedCount++; break;
+        }
+    }
+
+    TransferConsensusOutcome outcome;
+    for (auto const& [requestId, counts] : stateCounts)
+    {
+        auto const terminalCount = counts.completedCount + counts.failedCount;
+        if (terminalCount == syncSize && counts.failedCount > 0)
+        {
+            outcome.failedRequestIds.insert(requestId);
+        }
+        else if (counts.completedCount == syncSize)
+        {
+            outcome.completedRequestIds.insert(requestId);
+        }
+    }
+    return outcome;
+}
+
+TransferConsensusOutcome reduceTransferStates(std::shared_ptr<CacheTransceiverComm> const& firstComm,
+    std::shared_ptr<CacheTransceiverComm> const& secondComm,
+    std::unordered_set<RequestIdType> const& completedRequestIds,
+    std::unordered_set<RequestIdType> const& failedRequestIds)
+{
+    auto const firstOutcome = reduceTransferStates(firstComm, completedRequestIds, failedRequestIds);
+    return reduceTransferStates(secondComm, firstOutcome.completedRequestIds, firstOutcome.failedRequestIds);
+}
+
+void recordLocalTransferOutcome(RequestIdType requestId, std::shared_ptr<LlmRequest> request, bool failed,
+    std::unordered_set<RequestIdType>& completedRequestIds, std::unordered_set<RequestIdType>& failedRequestIds,
+    std::unordered_map<RequestIdType, std::shared_ptr<LlmRequest>>& requestsAwaitingConsensus)
+{
+    requestsAwaitingConsensus[requestId] = std::move(request);
+    if (failed)
+    {
+        completedRequestIds.erase(requestId);
+        failedRequestIds.insert(requestId);
+    }
+    else if (failedRequestIds.find(requestId) == failedRequestIds.end())
+    {
+        completedRequestIds.insert(requestId);
+    }
+}
+
+void eraseLocalTransferOutcome(RequestIdType requestId, std::unordered_set<RequestIdType>& completedRequestIds,
+    std::unordered_set<RequestIdType>& failedRequestIds,
+    std::unordered_map<RequestIdType, std::shared_ptr<LlmRequest>>& requestsAwaitingConsensus)
+{
+    completedRequestIds.erase(requestId);
+    failedRequestIds.erase(requestId);
+    requestsAwaitingConsensus.erase(requestId);
+}
+
+} // namespace
 
 std::unique_ptr<BaseCacheTransceiver> CacheTransceiverFactory::createCacheTransceiver(
     kv_cache_manager::BaseKVCacheManager* cacheManager, runtime::ModelConfig const& modelConfig,
@@ -141,6 +293,13 @@ CacheTransceiver::CacheTransceiver(kv_cache_manager::BaseKVCacheManager* cacheMa
     {
         mGroupTensorParaComm = std::make_shared<CacheTransceiverComm>(
             mGroupComm->split(worldConfig.getPipelineParallelRank(), worldConfig.getRank()));
+    }
+    if (worldConfig.isPipelineParallel())
+    {
+        auto const ppGroupColor = worldConfig.getTensorParallelRank() * worldConfig.getContextParallelism()
+            + worldConfig.getContextParallelRank();
+        mGroupPipeParaComm
+            = std::make_shared<CacheTransceiverComm>(mGroupComm->split(ppGroupColor, worldConfig.getRank()));
     }
     int kvFactor = 2;
     if (cacheManager->getCacheType() == kv_cache_manager::CacheType::kSELFKONLY)
@@ -605,9 +764,9 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
         toCompleteIdSet.insert(request->mRequestId);
     }
 
-    RequestStatuses requestsStatus{};
-
-    // Complete all the requests in toCompleteIdSet
+    // Record local terminal outcomes for requests selected this round. The
+    // request is reported only after all ranks in the sync group agree that the
+    // request reached a terminal state.
     for (auto it = mSenderFutures.begin(); it != mSenderFutures.end();)
     {
         auto& [request, future] = *it;
@@ -626,6 +785,7 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
         }
         if (blockAll || (toCompleteIdSet.find(request->mRequestId) != toCompleteIdSet.end()))
         {
+            auto const requestId = request->mRequestId;
             try
             {
                 // Wait for up to a specified timeout
@@ -633,12 +793,9 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                 if (status == std::future_status::ready || !senderFutureTimeoutMs.has_value())
                 {
                     future.get();
-                    requestsStatus.completedRequestIds.insert(request->mRequestId);
-                    if (markComplete)
-                    {
-                        request->setState(LlmRequestState::kDISAGG_CONTEXT_COMPLETE);
-                    }
-                    mTimedOutSenderIds.erase(request->mRequestId);
+                    bool const failed = request->getState() == LlmRequestState::kDISAGG_TRANS_ERROR;
+                    recordLocalTransferOutcome(requestId, request, failed, mCompletedSenderRequestIds,
+                        mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
                     it = mSenderFutures.erase(it);
                 }
                 else if (status == std::future_status::timeout)
@@ -649,22 +806,20 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                 }
                 else
                 {
-                    TLLM_LOG_ERROR(
-                        "Future returned unexpected status for request %ld. Marking as error", request->mRequestId);
+                    TLLM_LOG_ERROR("Future returned unexpected status for request %ld. Marking as error", requestId);
 
                     request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
-                    requestsStatus.errorRequestIds.insert(request->mRequestId);
-                    mTimedOutSenderIds.erase(request->mRequestId);
+                    recordLocalTransferOutcome(requestId, request, /*failed=*/true, mCompletedSenderRequestIds,
+                        mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
                     it = mSenderFutures.erase(it);
                 }
             }
             catch (std::exception const& e)
             {
-                TLLM_LOG_ERROR(
-                    "Error occurred during context transfer for request %ld: %s", request->mRequestId, e.what());
+                TLLM_LOG_ERROR("Error occurred during context transfer for request %ld: %s", requestId, e.what());
                 request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
-                requestsStatus.errorRequestIds.insert(request->mRequestId);
-                mTimedOutSenderIds.erase(request->mRequestId);
+                recordLocalTransferOutcome(requestId, request, /*failed=*/true, mCompletedSenderRequestIds,
+                    mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
                 it = mSenderFutures.erase(it);
             }
         }
@@ -672,6 +827,39 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
         {
             ++it;
         }
+    }
+
+    RequestStatuses requestsStatus{};
+    auto const consensusOutcome
+        = reduceTransferStates(syncComm, mGroupPipeParaComm, mCompletedSenderRequestIds, mFailedSenderRequestIds);
+    for (auto const requestId : consensusOutcome.failedRequestIds)
+    {
+        auto const requestIt = mSenderRequestsAwaitingConsensus.find(requestId);
+        if (requestIt == mSenderRequestsAwaitingConsensus.end())
+        {
+            continue;
+        }
+        requestIt->second->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+        requestsStatus.errorRequestIds.insert(requestId);
+        mTimedOutSenderIds.erase(requestId);
+        eraseLocalTransferOutcome(
+            requestId, mCompletedSenderRequestIds, mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
+    }
+    for (auto const requestId : consensusOutcome.completedRequestIds)
+    {
+        auto const requestIt = mSenderRequestsAwaitingConsensus.find(requestId);
+        if (requestIt == mSenderRequestsAwaitingConsensus.end())
+        {
+            continue;
+        }
+        requestsStatus.completedRequestIds.insert(requestId);
+        if (markComplete)
+        {
+            requestIt->second->setState(LlmRequestState::kDISAGG_CONTEXT_COMPLETE);
+        }
+        mTimedOutSenderIds.erase(requestId);
+        eraseLocalTransferOutcome(
+            requestId, mCompletedSenderRequestIds, mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
     }
 
     return requestsStatus;
@@ -799,6 +987,7 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
     for (auto it = mRequesterFutures.begin(); it != mRequesterFutures.end();)
     {
         auto& request = it->first;
+        auto const requestId = request->mRequestId;
         if (kvTransferTimeoutMs.has_value())
         {
             auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -812,39 +1001,34 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
                     request->mRequestId, elapsedMs, kvTransferTimeoutMs.value());
             }
         }
-        if (blockAll || toCompleteIdSet.find(request->mRequestId) != toCompleteIdSet.end())
+        if (blockAll || toCompleteIdSet.find(requestId) != toCompleteIdSet.end())
         {
             try
             {
                 it->second.get();
-                request->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_COMPLETE);
-
-                // Gather the kv cache transfer time from all workers and update to leader rank
-                if (!common::getEnvKVCacheTimeOutputPath().empty())
-                {
-                    auto bwSyncComm = mCacheState->getParallelConfig().mEnableAttentionDP ? mGroupDataComm : mGroupComm;
-                    updateKVCacheTransferBW(bwSyncComm, request.get());
-                }
+                bool const failed = request->getState() == LlmRequestState::kDISAGG_TRANS_ERROR;
+                recordLocalTransferOutcome(requestId, request, failed, mCompletedRequesterRequestIds,
+                    mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
             }
             catch (std::exception const& e)
             {
-                TLLM_LOG_ERROR(
-                    "Error occurred during generation transfer for request %ld: %s", request->mRequestId, e.what());
+                TLLM_LOG_ERROR("Error occurred during generation transfer for request %ld: %s", requestId, e.what());
                 request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+                recordLocalTransferOutcome(requestId, request, /*failed=*/true, mCompletedRequesterRequestIds,
+                    mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
             }
             if (useMPI())
             {
                 TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
-                    "**** it->first->mRequestId: %ld, context request ID: %ld ******** get feature ***",
-                    request->mRequestId, request->getContextPhaseParams().value().getReqId());
+                    "**** it->first->mRequestId: %ld, context request ID: %ld ******** get feature ***", requestId,
+                    request->getContextPhaseParams().value().getReqId());
             }
             else
             {
                 TLLM_LOG_DEBUG(tensorrt_llm::pg_utils::get_world_pg()->getRank(),
-                    "**** it->first->mRequestId: %ld, context request ID: %ld ******** get feature ***",
-                    request->mRequestId, request->getContextPhaseParams().value().getReqId());
+                    "**** it->first->mRequestId: %ld, context request ID: %ld ******** get feature ***", requestId,
+                    request->getContextPhaseParams().value().getReqId());
             }
-            mTimedOutRequesterIds.erase(request->mRequestId);
             it = mRequesterFutures.erase(it);
         }
         else
@@ -852,11 +1036,44 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
             ++it;
         }
     }
+
+    auto const consensusOutcome
+        = reduceTransferStates(syncComm, mCompletedRequesterRequestIds, mFailedRequesterRequestIds);
+    for (auto const requestId : consensusOutcome.failedRequestIds)
+    {
+        auto const requestIt = mRequesterRequestsAwaitingConsensus.find(requestId);
+        if (requestIt == mRequesterRequestsAwaitingConsensus.end())
+        {
+            continue;
+        }
+        requestIt->second->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+        mTimedOutRequesterIds.erase(requestId);
+        eraseLocalTransferOutcome(
+            requestId, mCompletedRequesterRequestIds, mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
+    }
+    for (auto const requestId : consensusOutcome.completedRequestIds)
+    {
+        auto const requestIt = mRequesterRequestsAwaitingConsensus.find(requestId);
+        if (requestIt == mRequesterRequestsAwaitingConsensus.end())
+        {
+            continue;
+        }
+        requestIt->second->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_COMPLETE);
+
+        // Gather the kv cache transfer time from all workers and update to leader rank.
+        if (!common::getEnvKVCacheTimeOutputPath().empty())
+        {
+            updateKVCacheTransferBW(syncComm, requestIt->second.get());
+        }
+        mTimedOutRequesterIds.erase(requestId);
+        eraseLocalTransferOutcome(
+            requestId, mCompletedRequesterRequestIds, mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
+    }
 }
 
 bool CacheTransceiver::checkGenTransferComplete() const
 {
-    return mRequesterFutures.empty();
+    return mRequesterFutures.empty() && mCompletedRequesterRequestIds.empty() && mFailedRequesterRequestIds.empty();
 }
 
 bool CacheTransceiver::cancelRequest(std::shared_ptr<LlmRequest> llmRequest)

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -806,9 +806,9 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                 }
                 else
                 {
-                    TLLM_LOG_ERROR("Future returned unexpected status for request %ld. Marking as error", requestId);
+                    TLLM_LOG_ERROR(
+                        "Future returned unexpected status for request %ld. Recording as failed.", requestId);
 
-                    request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
                     recordLocalTransferOutcome(requestId, request, /*failed=*/true, mCompletedSenderRequestIds,
                         mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
                     it = mSenderFutures.erase(it);
@@ -817,7 +817,6 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
             catch (std::exception const& e)
             {
                 TLLM_LOG_ERROR("Error occurred during context transfer for request %ld: %s", requestId, e.what());
-                request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
                 recordLocalTransferOutcome(requestId, request, /*failed=*/true, mCompletedSenderRequestIds,
                     mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
                 it = mSenderFutures.erase(it);
@@ -1007,13 +1006,18 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
             {
                 it->second.get();
                 bool const failed = request->getState() == LlmRequestState::kDISAGG_TRANS_ERROR;
+                if (failed)
+                {
+                    // The receiver uses the error state as a local transfer-failed signal.
+                    // Keep that signal local until the consensus outcome commits it globally.
+                    request->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_IN_PROGRESS);
+                }
                 recordLocalTransferOutcome(requestId, request, failed, mCompletedRequesterRequestIds,
                     mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
             }
             catch (std::exception const& e)
             {
                 TLLM_LOG_ERROR("Error occurred during generation transfer for request %ld: %s", requestId, e.what());
-                request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
                 recordLocalTransferOutcome(requestId, request, /*failed=*/true, mCompletedRequesterRequestIds,
                     mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
             }


### PR DESCRIPTION
## Description

Adds a V1 `CacheTransceiver` request-state consensus step for disaggregated KV transfer terminal transitions.

The implementation records local completed/failed transfer outcomes, packs `{request_id, state}` entries, gathers them through the existing communication backend, and applies a deterministic consensus result before mutating request state. Context-side consensus uses the existing TP/CP sync group and then the PP group; generation-side consensus uses the existing generation sync group.

This keeps PR#1 scoped to the consensus foundation for safe in-flight cancellation. It does not yet add deadline enforcement, deferred cleanup/quarantine, richer cancellation states, or hard mid-transfer abort semantics; those remain for the follow-up cancellation/lifetime PR.

## Dependency graph

Arrows point from prerequisite to dependent. PR numbers in graph nodes are clickable.

```mermaid
graph TD
    PR15139["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15139'>#15139</a>: transfer state consensus (this PR, merged)"]
    PR15181["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15181'>#15181</a>: bounded C++ transfer status polling (inflight)"]
    PR15356["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15356'>#15356</a>: bounded V2 context transfer polling (inflight)"]
    PR15238["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15238'>#15238</a>: in-flight cancellation + buffer poison (draft)"]
    WORK_BLOCKALL["blockAll / wait-all cancellation (planned)"]
    WORK_BUFFER["multi-slot buffers + unpoison recovery (planned)"]

    PR15139 -->|satisfied| PR15238
    PR15181 -->|blocking| PR15356
    PR15181 -->|blocking| PR15238
    PR15356 -->|blocking| PR15238
    PR15238 -.->|planned| WORK_BLOCKALL
    PR15238 -.->|planned| WORK_BUFFER

    classDef merged fill:#dcfce7,stroke:#16a34a,color:#14532d;
    classDef inflight fill:#dbeafe,stroke:#2563eb,color:#1e3a8a;
    classDef draft fill:#ffedd5,stroke:#f97316,color:#7c2d12;
    classDef current fill:#ede9fe,stroke:#7c3aed,color:#3b0764,stroke-width:3px;
    classDef downstream fill:#f3f4f6,stroke:#6b7280,color:#374151,stroke-dasharray:5 5;
    linkStyle 0 stroke:#16a34a,stroke-width:2px;
    linkStyle 1,2,3 stroke:#ea580c,stroke-width:3px;
    linkStyle 4,5 stroke:#6b7280,stroke-width:2px,stroke-dasharray:5 5;

    class PR15139 current;
    class PR15181,PR15356 inflight;
    class PR15238 draft;
    class WORK_BLOCKALL,WORK_BUFFER downstream;
```

## Notes

- Failed terminal state wins over completed once all participating ranks report a terminal state.
- Generation transfer no longer overwrites a receiver-side `kDISAGG_TRANS_ERROR` with `kDISAGG_GENERATION_TRANS_COMPLETE`.
- The existing ready-request-ID collectives are intentionally left in place for this first slice.

## Follow-ups

- Audit the existing ready-request-ID gather path after this consensus foundation lands:
  - `checkContextTransferStatus`: `gatherRequestIds(syncComm, contextCompleteRequestIds)`
  - `checkGenTransferStatus`: `gatherRequestIds(syncComm, genTransferReadyRequestIds)`
- If the new `{request_id, completed/failed}` transfer-state consensus fully covers the same cross-rank agreement semantics, remove or fold those ready-ID gathers into the consensus path.
- Keep this as a separate cleanup/performance PR so this PR stays focused on correctness of terminal-state consensus.

## Testing

- `pre-commit run clang-format --files cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp`
- `pre-commit run codespell --files cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp`
- `git diff --check upstream/main..HEAD`

Attempted full file-scoped pre-commit as well, but local hooks fail in `scripts/check_test_list.py` with `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'` under the local hook environment; unrelated C++ hooks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cross-rank consensus mechanism for KV cache transfer outcomes in distributed configurations

* **Refactor**
  * Improved cache transceiver with optimized pipeline-parallel communication setup and deferred state transitions for increased reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
