### PR TITLE
[None][refactor] visual_gen Attention: drop redundant enable_ulysses kwarg (rebase artifact from #13978)

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
@@ -150,7 +150,6 @@ class LTX2Attention(Attention):
             config=config,
             layer_idx=layer_idx,
             enable_sequence_parallel=enable_sp,
-            enable_ulysses=use_ulysses,
             async_ulysses=self._use_async_ulysses,
         )
 

--- a/tensorrt_llm/_torch/visual_gen/modules/attention.py
+++ b/tensorrt_llm/_torch/visual_gen/modules/attention.py
@@ -54,7 +54,6 @@ class Attention(nn.Module):
         config: Optional[DiffusionModelConfig] = None,
         layer_idx: Optional[int] = None,
         enable_sequence_parallel: bool = True,
-        enable_ulysses: bool = True,
         async_ulysses: bool = False,
     ):
         super().__init__()
@@ -184,7 +183,6 @@ class Attention(nn.Module):
         use_ulysses = (
             ulysses_size > 1
             and enable_sequence_parallel
-            and enable_ulysses
             and (self.qkv_mode != QKVMode.SEPARATE_QKV or async_ulysses)
         )
 


### PR DESCRIPTION
@coderabbitai summary

## Description

The `enable_ulysses` kwarg on `Attention.__init__` is a rebase artifact from #13978. Before that PR merged, #13944 (Attention2D) had already consolidated the kwarg surface to a single `enable_sequence_parallel` master switch — the rebase resolution re-introduced the older `enable_ulysses` as a redundant gate.

Only `LTX2Attention` forwarded `enable_ulysses=use_ulysses`, and it always co-varied with `enable_sequence_parallel` (self-attn: both `True`; cross-attn: both `False`). No model uses the SP-on-but-Ulysses-off escape hatch.

- Drop `enable_ulysses` kwarg from base `Attention.__init__`.
- Simplify the `use_ulysses` local-var gate (remove `and enable_ulysses`).
- Drop the `enable_ulysses=use_ulysses` forwarding from `LTX2Attention.__init__`.

`LTX2Attention`'s own `use_ulysses` kwarg is preserved — it still drives `async_ulysses` gating and the audio dual-attention setup, both LTX-local logic.

## Test Coverage

`tests/unittest/_torch/visual_gen/test_ltx2_attention.py` (6/6) + `test_ltx2_transformer.py` (14/14) — covered by existing tests.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.