### PR TITLE
[None][infra] CBTS Layer 3: pass test-db via Artifactory instead of env var

### DIFF
--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -769,27 +769,22 @@ def getCbtsResult(pipeline, testFilter, globalVars)
                           "Reasons: ${result.reasons.join('; ')}")
             return null
         }
-        // Piggyback input JSON on testFilter so each L0_Test stage agent can
-        // re-run main.py and regenerate cbts_test_db/ locally. The payload is
-        // base64-encoded because the raw JSON contains PR diffs and may include
-        // ${...} or {...} sequences that the Jenkins tokenmacro plugin would
-        // try to evaluate when the parent serializes globalVars for the
-        // Parameterized-Remote-Trigger plugin, raising MacroEvaluationException
-        // and blocking test dispatch. Capped at 256 KB (post-encoding, since
-        // that is what travels on the wire); oversize → drop piggyback,
-        // Layer 3 falls back to source.
-        final int CBTS_INPUT_PIGGYBACK_MAX_BYTES = 256000
-        def inputJsonB64 = inputJson.bytes.encodeBase64().toString()
-        def inputJsonB64Size = inputJsonB64.length()
-        if (inputJsonB64Size <= CBTS_INPUT_PIGGYBACK_MAX_BYTES) {
-            result.cbts_input_json_b64 = inputJsonB64
-            pipeline.echo("CBTS Layer 3: cbts_input_json_b64 piggyback enabled " +
-                          "(${inputJsonB64Size} bytes encoded, ${inputJson.length()} bytes raw)")
-        } else {
-            pipeline.echo("CBTS Layer 3: cbts_input_json_b64 is ${inputJsonB64Size} bytes, " +
-                          "exceeds ${CBTS_INPUT_PIGGYBACK_MAX_BYTES}-byte piggyback limit; " +
-                          "downstream stages will fall back to source test-db " +
-                          "(Layer 2 stage filtering still applies)")
+        // Upload the generated cbts_test_db/ to Artifactory so each L0_Test
+        // stage agent can download it directly instead of re-running main.py
+        // with the raw PR diff. This avoids passing large payloads as Jenkins
+        // parameters (env vars), which caused "Argument list too long" failures
+        // when diffs were large. Agents fall back to the source test-db if the
+        // download fails.
+        if (result.test_db_dir_override) {
+            try {
+                sh "tar czf /tmp/cbts_test_db.tar.gz -C ${LLM_ROOT} ${result.test_db_dir_override}"
+                trtllm_utils.uploadArtifacts("/tmp/cbts_test_db.tar.gz", "${UPLOAD_PATH}/cbts/")
+                result.cbts_test_db_artifact_path = "${UPLOAD_PATH}/cbts/cbts_test_db.tar.gz"
+                pipeline.echo("CBTS Layer 3: uploaded cbts_test_db to ${result.cbts_test_db_artifact_path}")
+            } catch (Exception e) {
+                pipeline.echo("CBTS Layer 3: artifact upload failed (${e.message}); " +
+                              "agents will fall back to source test-db")
+            }
         }
         pipeline.echo("CBTS: scope=${result.scope}, " +
                       "stages=${result.affected_stages.size()}")
@@ -1329,20 +1324,6 @@ def getCommonParameters()
     ]
 }
 
-// Strip cbts_input_json_b64 before passing testFilter as a Jenkins parameter.
-// The b64 payload can be up to 256 KB; combined with other env vars it can
-// exceed ARG_MAX and cause "git: error=7, Argument list too long" on agents.
-// Layer 2 stage filtering survives; Layer 3 test-db regeneration falls back
-// to the source test-db on agents that don't receive the piggyback.
-def _testFilterForDownstream(testFilter) {
-    def cbts = testFilter[(CBTS_RESULT)]
-    if (cbts == null || !cbts.containsKey('cbts_input_json_b64')) {
-        return testFilter
-    }
-    def cbtsStripped = cbts.findAll { k, v -> k != 'cbts_input_json_b64' }
-    return testFilter + [(CBTS_RESULT): cbtsStripped]
-}
-
 def launchJob(pipeline, jobName, reuseBuild, enableFailFast, globalVars, platform="x86_64", additionalParameters = [:]) {
     def parameters = getCommonParameters()
     // Build a local copy to avoid racey growth from shared parallel mutations.
@@ -1441,7 +1422,7 @@ def launchStages(pipeline, reuseBuild, testFilter, enableFailFast, globalVars)
                         return
                     }
                     try {
-                        String testFilterJson = writeJSON returnText: true, json: _testFilterForDownstream(testFilter)
+                        String testFilterJson = writeJSON returnText: true, json: testFilter
                         def additionalParameters = [
                             'testFilter': testFilterJson,
                             'dockerImage': globalVars["LLM_DOCKER_IMAGE"],
@@ -1497,7 +1478,7 @@ def launchStages(pipeline, reuseBuild, testFilter, enableFailFast, globalVars)
                         return
                     }
                     try {
-                        def testFilterJson = writeJSON returnText: true, json: _testFilterForDownstream(testFilter)
+                        def testFilterJson = writeJSON returnText: true, json: testFilter
                         def additionalParameters = [
                             'testFilter': testFilterJson,
                             'dockerImage': globalVars["LLM_DOCKER_IMAGE"],
@@ -1553,7 +1534,7 @@ def launchStages(pipeline, reuseBuild, testFilter, enableFailFast, globalVars)
                         return
                     }
                     try {
-                        String testFilterJson = writeJSON returnText: true, json: _testFilterForDownstream(testFilter)
+                        String testFilterJson = writeJSON returnText: true, json: testFilter
                         def additionalParameters = [
                             'testFilter': testFilterJson,
                             "dockerImage": globalVars["LLM_SBSA_DOCKER_IMAGE"],
@@ -1608,7 +1589,7 @@ def launchStages(pipeline, reuseBuild, testFilter, enableFailFast, globalVars)
                         return
                     }
                     try {
-                        def testFilterJson = writeJSON returnText: true, json: _testFilterForDownstream(testFilter)
+                        def testFilterJson = writeJSON returnText: true, json: testFilter
                         def additionalParameters = [
                             'testFilter': testFilterJson,
                             "dockerImage": globalVars["LLM_SBSA_DOCKER_IMAGE"],

--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -1329,6 +1329,20 @@ def getCommonParameters()
     ]
 }
 
+// Strip cbts_input_json_b64 before passing testFilter as a Jenkins parameter.
+// The b64 payload can be up to 256 KB; combined with other env vars it can
+// exceed ARG_MAX and cause "git: error=7, Argument list too long" on agents.
+// Layer 2 stage filtering survives; Layer 3 test-db regeneration falls back
+// to the source test-db on agents that don't receive the piggyback.
+def _testFilterForDownstream(testFilter) {
+    def cbts = testFilter[(CBTS_RESULT)]
+    if (cbts == null || !cbts.containsKey('cbts_input_json_b64')) {
+        return testFilter
+    }
+    def cbtsStripped = cbts.findAll { k, v -> k != 'cbts_input_json_b64' }
+    return testFilter + [(CBTS_RESULT): cbtsStripped]
+}
+
 def launchJob(pipeline, jobName, reuseBuild, enableFailFast, globalVars, platform="x86_64", additionalParameters = [:]) {
     def parameters = getCommonParameters()
     // Build a local copy to avoid racey growth from shared parallel mutations.
@@ -1427,7 +1441,7 @@ def launchStages(pipeline, reuseBuild, testFilter, enableFailFast, globalVars)
                         return
                     }
                     try {
-                        String testFilterJson = writeJSON returnText: true, json: testFilter
+                        String testFilterJson = writeJSON returnText: true, json: _testFilterForDownstream(testFilter)
                         def additionalParameters = [
                             'testFilter': testFilterJson,
                             'dockerImage': globalVars["LLM_DOCKER_IMAGE"],
@@ -1483,7 +1497,7 @@ def launchStages(pipeline, reuseBuild, testFilter, enableFailFast, globalVars)
                         return
                     }
                     try {
-                        def testFilterJson = writeJSON returnText: true, json: testFilter
+                        def testFilterJson = writeJSON returnText: true, json: _testFilterForDownstream(testFilter)
                         def additionalParameters = [
                             'testFilter': testFilterJson,
                             'dockerImage': globalVars["LLM_DOCKER_IMAGE"],
@@ -1539,7 +1553,7 @@ def launchStages(pipeline, reuseBuild, testFilter, enableFailFast, globalVars)
                         return
                     }
                     try {
-                        String testFilterJson = writeJSON returnText: true, json: testFilter
+                        String testFilterJson = writeJSON returnText: true, json: _testFilterForDownstream(testFilter)
                         def additionalParameters = [
                             'testFilter': testFilterJson,
                             "dockerImage": globalVars["LLM_SBSA_DOCKER_IMAGE"],
@@ -1594,7 +1608,7 @@ def launchStages(pipeline, reuseBuild, testFilter, enableFailFast, globalVars)
                         return
                     }
                     try {
-                        def testFilterJson = writeJSON returnText: true, json: testFilter
+                        def testFilterJson = writeJSON returnText: true, json: _testFilterForDownstream(testFilter)
                         def additionalParameters = [
                             'testFilter': testFilterJson,
                             "dockerImage": globalVars["LLM_SBSA_DOCKER_IMAGE"],

--- a/jenkins/L0_MergeRequest.groovy
+++ b/jenkins/L0_MergeRequest.groovy
@@ -781,6 +781,8 @@ def getCbtsResult(pipeline, testFilter, globalVars)
                 trtllm_utils.uploadArtifacts("/tmp/cbts_test_db.tar.gz", "${UPLOAD_PATH}/cbts/")
                 result.cbts_test_db_artifact_path = "${UPLOAD_PATH}/cbts/cbts_test_db.tar.gz"
                 pipeline.echo("CBTS Layer 3: uploaded cbts_test_db to ${result.cbts_test_db_artifact_path}")
+            } catch (InterruptedException e) {
+                throw e
             } catch (Exception e) {
                 pipeline.echo("CBTS Layer 3: artifact upload failed (${e.message}); " +
                               "agents will fall back to source test-db")

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -29,6 +29,7 @@ LLM_ROOT = "llm"
 
 ARTIFACT_PATH = env.artifactPath ? env.artifactPath : "sw-tensorrt-generic/llm-artifacts/${JOB_NAME}/${BUILD_NUMBER}"
 UPLOAD_PATH = env.uploadPath ? env.uploadPath : "sw-tensorrt-generic/llm-artifacts/${JOB_NAME}/${BUILD_NUMBER}"
+URM_ARTIFACTORY_BASE = "https://urm.nvidia.com/artifactory"
 
 X86_64_TRIPLE = "x86_64-linux-gnu"
 AARCH64_TRIPLE = "aarch64-linux-gnu"
@@ -2475,7 +2476,7 @@ def renderTestDB(pipeline, testContext, llmSrc, stageName, preDefinedMakoOpts=nu
         def dirExists = sh(returnStdout: true, script: "test -d ${overrideDir} && echo yes || echo no").trim()
         if (dirExists != "yes") {
             try {
-                def artifactUrl = "https://urm.nvidia.com/artifactory/${cbts.cbts_test_db_artifact_path}"
+                def artifactUrl = "${URM_ARTIFACTORY_BASE}/${cbts.cbts_test_db_artifact_path}"
                 sh "wget -q '${artifactUrl}' -O /tmp/cbts_test_db.tar.gz && tar xzf /tmp/cbts_test_db.tar.gz -C ${llmSrc}"
                 echo "CBTS Layer 3: extracted cbts_test_db from artifact"
             } catch (Exception e) {

--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -2462,28 +2462,24 @@ def renderTestDB(pipeline, testContext, llmSrc, stageName, preDefinedMakoOpts=nu
     }
 
     sh "pip3 install --extra-index-url https://urm.nvidia.com/artifactory/api/pypi/sw-tensorrt-pypi/simple --ignore-installed trt-test-db==1.8.5+bc6df7"
-    // CBTS Layer 3: regenerate cbts_test_db/ on this stage agent from the
-    // piggybacked input JSON if not already present. The piggyback payload is
-    // base64-encoded on the orchestrator (see getCbtsResult in
-    // L0_MergeRequest.groovy) to keep tokenmacro from interpreting ${...} or
-    // {...} fragments inside the PR diff when globalVars is serialized. If
-    // decoding or regeneration throws (truncated/malformed payload), we
-    // swallow the error: the override directory will be absent below, the
-    // overrideYaml check will fail, and renderTestDB falls back to the
-    // source test-db.
+    // CBTS Layer 3: download the pre-built cbts_test_db/ tarball that the
+    // orchestrator uploaded to Artifactory (see getCbtsResult in
+    // L0_MergeRequest.groovy). This avoids re-running main.py locally and
+    // avoids passing large PR-diff payloads as Jenkins parameters (env vars).
+    // If the download or extraction fails we swallow the error: the override
+    // directory will be absent below, the overrideYaml check will fail, and
+    // renderTestDB falls back to the source test-db.
     def cbts = testFilter[(CBTS_RESULT)]
-    if (cbts != null && cbts.test_db_dir_override && cbts.cbts_input_json_b64) {
+    if (cbts != null && cbts.test_db_dir_override && cbts.cbts_test_db_artifact_path) {
         def overrideDir = "${llmSrc}/${cbts.test_db_dir_override}"
         def dirExists = sh(returnStdout: true, script: "test -d ${overrideDir} && echo yes || echo no").trim()
         if (dirExists != "yes") {
             try {
-                def cbtsInputJson = new String(cbts.cbts_input_json_b64.decodeBase64())
-                def cbtsInputLocal = Utils.createTempLocation(pipeline, "./cbts_input.json")
-                pipeline.writeFile(file: cbtsInputLocal, text: cbtsInputJson)
-                sh "apt-get update -qq && apt-get install -y -qq python3-yaml || true"
-                sh "cd ${llmSrc} && python3 jenkins/scripts/cbts/main.py ${cbtsInputLocal} > /dev/null 2>&1 || true"
+                def artifactUrl = "https://urm.nvidia.com/artifactory/${cbts.cbts_test_db_artifact_path}"
+                sh "wget -q '${artifactUrl}' -O /tmp/cbts_test_db.tar.gz && tar xzf /tmp/cbts_test_db.tar.gz -C ${llmSrc}"
+                echo "CBTS Layer 3: extracted cbts_test_db from artifact"
             } catch (Exception e) {
-                echo "CBTS Layer 3: failed to materialize piggyback payload " +
+                echo "CBTS Layer 3: artifact download failed " +
                      "(${e.class.simpleName}: ${e.message}); falling back to source test-db"
             }
         }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
    
Previously cbts_input_json_b64 piggybacked the raw PR diff (base64-encoded,
up to 256 KB) onto the testFilter Jenkins parameter so each L0_Test agent
could re-run main.py locally to regenerate cbts_test_db/. When diffs were
large this pushed the process environment over Linux ARG_MAX (~2 MB), causing
git to fail with "error=7, Argument list too long" before agents could even
check out the pipeline script.

Fix: the orchestrator now tars the already-generated cbts_test_db/ and
uploads it to Artifactory (${UPLOAD_PATH}/cbts/cbts_test_db.tar.gz) after
main.py runs. Each agent downloads and extracts the tarball directly instead
of re-running main.py. The testFilter parameter no longer carries any large
payload, eliminating the ARG_MAX failure. Layer 3 per-test filtering is fully
preserved; agents fall back to the source test-db if the download fails.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
