### PR TITLE
[TRTLLM-13333][feat] Add prefetch_reuse_blocks and configurable prefetch count

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -51,7 +51,7 @@ from tensorrt_llm.runtime.kv_cache_manager_v2 import KVCacheManagerConfig as KVC
 from tensorrt_llm.runtime.kv_cache_manager_v2._block_radix_tree import (
     gen_multimodal_cache_key_tokens,
 )
-from tensorrt_llm.runtime.kv_cache_manager_v2._common import BAD_PAGE_INDEX, GPU_LEVEL
+from tensorrt_llm.runtime.kv_cache_manager_v2._common import BAD_PAGE_INDEX, CACHE_LEVEL1, GPU_LEVEL
 from tensorrt_llm.runtime.kv_cache_manager_v2._config import DataRole
 from tensorrt_llm.runtime.kv_cache_manager_v2._utils import exact_div, typed_range
 from tensorrt_llm.sampling_params import SamplingParams
@@ -695,6 +695,7 @@ class KVCacheManagerV2(BaseResourceManager):
 
         self.enable_block_reuse = kv_cache_config.enable_block_reuse
         self.enable_partial_reuse = kv_cache_config.enable_partial_reuse
+        self.disk_prefetch_num_reqs = kv_cache_config.disk_prefetch_num_reqs
 
         # With pipeline parallelism, multiple microbatches can be in-flight
         # simultaneously, so we need slots for all concurrent sequences.
@@ -1828,6 +1829,40 @@ class KVCacheManagerV2(BaseResourceManager):
                 ]
                 kv_cache.set_base_page_index_buf(i, pool_idx, memoryview(buffer.numpy()))
         return kv_cache
+
+    def prefetch_for_context_tokens(self, requests: list) -> bool:
+        """Prefetch radix-tree blocks from disk→host for upcoming context requests.
+
+        Returns True if all prefetches succeeded, False if any failed.
+        """
+        if not self.enable_block_reuse:
+            return False
+        # Prefetch via a transient KV cache that holds the reuse-matched blocks,
+        # prefetches disk->host, then closes. Holding blocks costs no GPU space
+        # (never resumed) and close() needs no stream sync. The transient cache
+        # is NOT registered in kv_cache_map / IndexMapper.
+        success = True
+        for req in requests:
+            all_tokens = req.get_tokens(DEFAULT_BEAM_INDEX)
+            tokens = self._augment_tokens_for_block_reuse(all_tokens, req, end=len(all_tokens) - 1)
+            # Match the ReuseScope salt derivation used in _create_kv_cache so
+            # the transient cache hits the same radix-tree blocks.
+            cache_salt = req.cache_salt
+            salt_int = (
+                int.from_bytes(hashlib.sha256(cache_salt.encode("utf-8")).digest()[:8], "little")
+                if cache_salt is not None
+                else None
+            )
+            kv_cache = self.impl.create_kv_cache(
+                ReuseScope(lora_id=req.lora_task_id, salt=salt_int), tokens
+            )
+            # Prefetch to the first tier below GPU (host if present, otherwise
+            # disk). prefetch() is a best-effort hint either way.
+            if not kv_cache.prefetch(CACHE_LEVEL1):
+                logger.warning("prefetch failed for request %s", req.py_request_id)
+                success = False
+            kv_cache.close()
+        return success
 
     def reset_reuse_state(self):
         self.impl.clear_reusable_blocks()

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -441,6 +441,7 @@ class PyExecutor:
         # unnecessary).  Several revert/skip paths gate on this flag.
         self._is_kv_manager_v2 = isinstance(self.kv_cache_manager,
                                             KVCacheManagerV2)
+        self._prefetched_request_ids: set[int] = set()
         self.enable_kv_cache_events = self.kv_cache_manager is not None and self.kv_cache_manager.event_buffer_max_size > 0
         self.enable_kv_cache_reuse = self.kv_cache_manager is not None and self.kv_cache_manager.enable_block_reuse
         self.enable_partial_reuse_for_disagg = (
@@ -2549,6 +2550,30 @@ class PyExecutor:
         for req in dropped_context_requests:
             self.kv_cache_manager.revert_allocate_context(req)
 
+    @nvtx_range("_prefetch_for_context_requests")
+    def _prefetch_for_context_requests(self) -> None:
+        """Pre-stage disk blocks to host for upcoming context requests with block reuse."""
+        if not isinstance(getattr(self, "kv_cache_manager", None),
+                          KVCacheManagerV2):
+            return
+        if not self.kv_cache_manager.enable_block_reuse:
+            return
+        if self.kv_cache_manager.disk_prefetch_num_reqs <= 0:
+            return
+        max_prefetch = self.kv_cache_manager.disk_prefetch_num_reqs
+        candidates = []
+        for req in self.active_requests:
+            if len(candidates) >= max_prefetch:
+                break
+            if (req.is_first_context_chunk and req.py_request_id
+                    not in self.kv_cache_manager.kv_cache_map
+                    and req.py_request_id not in self._prefetched_request_ids):
+                candidates.append(req)
+                self._prefetched_request_ids.add(req.py_request_id)
+
+        if candidates:
+            self.kv_cache_manager.prefetch_for_context_tokens(candidates)
+
     def _prepare_and_schedule_batch(self):
         new_requests = self._fetch_and_activate_new_requests()
         if self.should_stop_processing:
@@ -2566,6 +2591,8 @@ class PyExecutor:
                 self._get_new_active_requests_queue_latency())
 
         self._pad_attention_dp_dummy_request()
+
+        self._prefetch_for_context_requests()
 
         if self.drafter is not None:
             # Honor permanent disable flag based on rolling acceptance first
@@ -4816,6 +4843,7 @@ class PyExecutor:
 
     def _do_terminate_request(self, request: LlmRequest):
         self.resource_manager.free_resources(request)
+        self._prefetched_request_ids.discard(request.py_request_id)
 
         if self.gather_all_responses or self.dist.rank == 0:
             self.result_wait_queues.pop(request.py_request_id, None)

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2907,6 +2907,14 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
         "your own risk. Only used when using KV cache manager v2 "
         "(experimental).")
 
+    disk_prefetch_num_reqs: int = Field(
+        default=4,
+        ge=0,
+        description=
+        "Number of queued context requests to prefetch disk-tier KV cache blocks to host for. "
+        "Set to 0 to disable prefetch. Only effective with KV cache manager v2 and block reuse enabled."
+    )
+
     def _to_pybind(self):
         config = _KvCacheConfig(
             enable_block_reuse=self.enable_block_reuse,

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2908,7 +2908,7 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
         "(experimental).")
 
     disk_prefetch_num_reqs: int = Field(
-        default=4,
+        default=0,
         ge=0,
         description=
         "Number of queued context requests to prefetch disk-tier KV cache blocks to host for. "

--- a/tensorrt_llm/runtime/kv_cache_manager_v2/_common.py
+++ b/tensorrt_llm/runtime/kv_cache_manager_v2/_common.py
@@ -47,6 +47,9 @@ CacheLevel = NewType("CacheLevel", int)
 
 
 GPU_LEVEL: Final[CacheLevel] = CacheLevel(0)
+# First cache level below GPU. Its semantic tier depends on the configured
+# cache_tiers: host when a host tier exists, otherwise disk.
+CACHE_LEVEL1: Final[CacheLevel] = CacheLevel(1)
 
 # Normal token id that falls in the tokenizer vocabulary.
 TokenId = NewType("TokenId", int)

--- a/tests/unittest/disaggregated/test_cache_transceiver_single_process.py
+++ b/tests/unittest/disaggregated/test_cache_transceiver_single_process.py
@@ -105,6 +105,7 @@ class KvCacheConfigV2:
     enable_partial_reuse: bool = False
     copy_on_partial_reuse: bool = False
     dtype: str = "auto"
+    disk_prefetch_num_reqs: int = 4
     max_util_for_resume: float = 0.95
 
 

--- a/tests/unittest/disaggregated/test_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_kv_transfer.py
@@ -64,6 +64,7 @@ class KvCacheConfigV2:
     enable_partial_reuse: bool = False
     copy_on_partial_reuse: bool = False
     dtype: str = "auto"
+    disk_prefetch_num_reqs: int = 4
     # V2 specific field
     max_util_for_resume: float = 0.95
 


### PR DESCRIPTION
- Add KVCacheManager.prefetch_reuse_blocks() to probe radix tree and pre-stage disk-tier pages to host before scheduling
- Make prefetch count configurable via kv_cache_config.disk_prefetch_num_reqs
- Add unit test for prefetch_reuse_blocks disk-to-host migration
<html>
<body>
<!--StartFragment--><h3>Performance Summary</h3>
<div class="table-wrap">
Setup: nvidia/Kimi-K2.5-NVFP4, DEP4 (TP4+attention_dp+EP4), 1 CTX + 1 GEN node, host128g + disk256g, ISL=260K/OSL=8K, batch=16, 30min profiling phase, subagents-256k dataset.

Metric | N=0 | N=2 | N=4 | N=8
-- | -- | -- | -- | --
Request Throughput (req/s) | 0.36 | 0.42 | 0.49 | 0.52
Output Token Throughput (tok/s) | 372.3 | 396.8 | 486.2 | 446.4
Input Token Throughput (tok/s) | 31,484 | 35,866 | 40,677 | 45,159
Mean TTFT (ms) | 118,437 | 114,918 | 82,804 | 84,579
Completed Requests (30min) | 661 | 773 | 921 | 996
Error Rate (%) | 0 | 0 | 2.28 | 2.71


</div><!--EndFragment-->
</body>
</html>
<html>
<body>
<!--StartFragment--><h3>KV Cache Metrics (RANK 0, cumulative across all 30s intervals)</h3>
<div class="table-wrap">

Metric | N=0 | N=2 | N=4 | N=8
-- | -- | -- | -- | --
Total Offload Blocks | 689,564 | 700,607 | 806,932 | 971,136
Total Onboard Blocks | 304,929 | 347,863 | 445,153 | 612,533
Total Disk Onboard Blocks | 39,603 | 38,240 | 72,377 | 108,324
Recovery Rate (onboard/offload) | 44.2% | 49.7% | 55.2% | 63.1%
Dropped Blocks | 0 | 0 | 0 | 0


</div><!--EndFragment-->
</body>
</html>
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added disk KV cache block prefetching to improve performance when block reuse is enabled.
  * Introduced a new configuration parameter to control how many queued context requests are prefetched for disk-tier KV cache blocks (defaults to 4).

* **Tests**
  * Added comprehensive tests for KV cache block prefetch functionality across cache tier transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
