### PR TITLE
[None][bugfix] Guard e_score_correction_bias load for DeepSeek-V2-Lite

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -856,7 +856,7 @@ class DeepseekV3Gate(nn.Module):
             bias_dtype = torch.bfloat16
         else:
             bias_dtype = torch.float32
-        self.e_score_correction_bias = nn.Parameter(torch.empty(
+        self.e_score_correction_bias = nn.Parameter(torch.zeros(
             (num_experts), dtype=bias_dtype),
                                                     requires_grad=False)
 

--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -898,11 +898,16 @@ class DeepseekV3Gate(nn.Module):
         w = weights[0].get("weight")
         bias = weights[0].get("e_score_correction_bias")
         if not allow_partial_loading:
-            assert w is not None and bias is not None, (
-                "DeepseekV3Gate expects 'weight' and 'e_score_correction_bias' "
-                "when partial loading is disabled")
+            assert w is not None, (
+                "DeepseekV3Gate expects 'weight' when partial loading is "
+                "disabled")
         if w is not None:
             self.weight.copy_(w[:])
+        # e_score_correction_bias is specific to V3's sigmoid routing with
+        # auxiliary-loss-free load balancing; DeepSeek-V2-Lite checkpoints
+        # (scoring_func=softmax) legitimately omit it, so it stays optional
+        # even when partial loading is disabled (the parameter is
+        # zero-initialized).
         if bias is not None:
             self.e_score_correction_bias.copy_(bias[:].to(
                 self.e_score_correction_bias.dtype))


### PR DESCRIPTION
## Summary

- `DeepseekV3Gate.load_weights` accesses `e_score_correction_bias` unconditionally, but lite DeepSeek checkpoints (`scoring_func=softmax`, `q_lora_rank=None`, e.g. DeepSeek-V2-Lite) do not have this tensor — it is V3-specific (sigmoid routing with auxiliary-loss-free load balancing).
- The PyTorch `DeepseekV3` model class already supports these lite checkpoints (the `is_lite = q_lora_rank is None` branches throughout `modeling_deepseekv3.py`), so a lite checkpoint served under a registered V3-family architecture reaches this gate and hits a `KeyError` on load (e.g. an NVFP4-quantized DeepSeek-V2-Lite).
- Fix: guard the `.copy_()` with a key-existence check, and zero-initialize the parameter (`torch.empty` → `torch.zeros`) so the missing-key path is a safe no-op — `e_score_correction_bias` is **added** to the routing scores (`scores + e_score_correction_bias` in `noaux_tc`), so zero means "no correction". The same optional-bias guard is used by sibling gates (`modeling_laguna.py`, `modeling_minimaxm2.py`).

## Reproduction

```python
# A lite (q_lora_rank=None, softmax-routed) checkpoint served via the DeepseekV3
# PyTorch class — e.g. an NVFP4-quantized DeepSeek-V2-Lite:
#   KeyError: 'e_score_correction_bias' in DeepseekV3Gate.load_weights
```

## Test plan

- [x] Verified on RTX PRO 6000 (SM120) with DeepSeek-V2-Lite NVFP4 (modelopt 0.37, `kv_b_proj` kept BF16) — warmup + generate produce coherent output after the fix
- [ ] Existing unit tests pass (`pytest tests/unittest/`)

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where loading DeepSeekV3 models could fail due to missing checkpoint weights, improving model loading robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
