### PR TITLE
[#14146][bugfix] Fix CuteDSL MoE ghost-token and global-index bugs

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -142,9 +142,13 @@ class GroupedGemmInputsHelper:
             ]
 
         for j, num_tokens_j in enumerate(num_tokens_per_expert):
+            if num_tokens_j <= 0:
+                continue
             selection_order_j = selection_orders[j].tolist()
+            global_j = j + self.local_expert_offset
             prioritized = torch.nonzero(num_selected_experts <= (
-                self.top_k - (self.num_experts - j))).squeeze(-1).tolist()
+                self.top_k -
+                (self.num_experts - global_j))).squeeze(-1).tolist()
             if len(prioritized) > 0:
                 selection_order_j = prioritized + [
                     i for i in selection_order_j if i not in prioritized
@@ -153,7 +157,7 @@ class GroupedGemmInputsHelper:
                 if num_selected_experts[i] < self.top_k:
                     token_selected_experts[
                         i,
-                        num_selected_experts[i]] = j + self.local_expert_offset
+                        num_selected_experts[i]] = global_j
                     num_selected_experts[i] += 1
                     num_tokens_j -= 1
                     if num_tokens_j <= 0:

--- a/tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py
+++ b/tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py
@@ -53,6 +53,45 @@ def test_grouped_gemm_inputs_helper(top_k: int, ep_size: int, tile_size: int):
     )
 
 
+def test_ghost_token_zero_allocation():
+    """Experts with num_tokens_per_expert == 0 must not receive any tokens."""
+    num_experts = 256
+    top_k = 8
+    ep_size = 16
+    num_local_experts = num_experts // ep_size
+
+    helper = GroupedGemmInputsHelper(num_experts, top_k, num_local_experts, 0, 128)
+    num_tokens_per_expert = helper.generate_num_tokens_per_expert(
+        1, approx_max_load=True)
+    result = helper.generate_token_selected_experts(1, num_tokens_per_expert)
+
+    assigned_experts = result[result >= 0].tolist()
+    for j, count in enumerate(num_tokens_per_expert):
+        if count == 0:
+            assert j not in assigned_experts, (
+                f"Expert {j} has 0 allocated tokens but was assigned to a token")
+
+
+def test_prioritization_uses_global_index():
+    """Bug 2: prioritization must use global expert index, not local."""
+    num_experts = 256
+    top_k = 8
+    ep_size = 16
+    num_local_experts = num_experts // ep_size
+    local_expert_offset = num_local_experts
+
+    helper = GroupedGemmInputsHelper(
+        num_experts, top_k, num_local_experts, local_expert_offset, 128)
+    num_tokens_per_expert = helper.generate_num_tokens_per_expert(
+        1, approx_max_load=True)
+    result = helper.generate_token_selected_experts(1, num_tokens_per_expert)
+
+    for val in result[result >= 0].tolist():
+        assert local_expert_offset <= val < local_expert_offset + num_local_experts, (
+            f"Expert {val} outside local range [{local_expert_offset}, "
+            f"{local_expert_offset + num_local_experts})")
+
+
 @pytest.mark.parametrize("tile_size", [128, 256])
 @pytest.mark.parametrize("ep_size", [1, 8, 32])
 @pytest.mark.parametrize("top_k", [1, 2, 8])

--- a/tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py
+++ b/tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py
@@ -86,10 +86,16 @@ def test_prioritization_uses_global_index():
         1, approx_max_load=True)
     result = helper.generate_token_selected_experts(1, num_tokens_per_expert)
 
-    for val in result[result >= 0].tolist():
-        assert local_expert_offset <= val < local_expert_offset + num_local_experts, (
-            f"Expert {val} outside local range [{local_expert_offset}, "
-            f"{local_expert_offset + num_local_experts})")
+    assigned = set(result[result >= 0].tolist())
+    expected = {
+        local_expert_offset + j
+        for j, count in enumerate(num_tokens_per_expert)
+        if int(count) > 0
+    }
+    assert assigned.issubset(expected), (
+        f"Assigned experts {sorted(assigned)} are not a subset of expected "
+        f"global experts {sorted(expected)}"
+    )
 
 
 @pytest.mark.parametrize("tile_size", [128, 256])

--- a/tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py
+++ b/tests/unittest/_torch/thop/parallel/test_cute_dsl_moe.py
@@ -61,40 +61,55 @@ def test_ghost_token_zero_allocation():
     num_local_experts = num_experts // ep_size
 
     helper = GroupedGemmInputsHelper(num_experts, top_k, num_local_experts, 0, 128)
-    num_tokens_per_expert = helper.generate_num_tokens_per_expert(
-        1, approx_max_load=True)
+    num_tokens_per_expert = helper.generate_num_tokens_per_expert(1, approx_max_load=True)
     result = helper.generate_token_selected_experts(1, num_tokens_per_expert)
 
     assigned_experts = result[result >= 0].tolist()
     for j, count in enumerate(num_tokens_per_expert):
         if count == 0:
             assert j not in assigned_experts, (
-                f"Expert {j} has 0 allocated tokens but was assigned to a token")
+                f"Expert {j} has 0 allocated tokens but was assigned to a token"
+            )
 
 
-def test_prioritization_uses_global_index():
-    """Bug 2: prioritization must use global expert index, not local."""
-    num_experts = 256
-    top_k = 8
-    ep_size = 16
-    num_local_experts = num_experts // ep_size
-    local_expert_offset = num_local_experts
+def test_prioritization_rescues_at_risk_tokens():
+    """Bug 2: the at-risk-token prioritization must use the GLOBAL expert index.
+
+    With the local index ``j``, the threshold ``top_k - (num_experts - j)`` stays
+    negative on any rank where ``num_local_experts < num_experts``, so
+    ``prioritized`` is always empty and the prioritization is dead code. On this
+    last rank (offset == num_experts - num_local_experts) the global-index fix
+    lets prioritization rescue at-risk tokens, so more of them reach ``top_k``:
+    here 3 tokens fill to top_k instead of 2. Reverting ``global_j`` back to ``j``
+    regresses fully-filled from 3 to 2, so this asserts the global-index behavior
+    rather than only the (offset-invariant) expert-id range.
+    """
+    num_experts = 4
+    top_k = 2
+    num_local_experts = 2
+    local_expert_offset = num_experts - num_local_experts  # last rank of ep=2
+    num_tokens = 4
 
     helper = GroupedGemmInputsHelper(
-        num_experts, top_k, num_local_experts, local_expert_offset, 128)
-    num_tokens_per_expert = helper.generate_num_tokens_per_expert(
-        1, approx_max_load=True)
-    result = helper.generate_token_selected_experts(1, num_tokens_per_expert)
+        num_experts, top_k, num_local_experts, local_expert_offset, 128
+    )
+    num_tokens_per_expert = helper.generate_num_tokens_per_expert(num_tokens, approx_max_load=True)
+    result = helper.generate_token_selected_experts(num_tokens, num_tokens_per_expert)
 
-    assigned = set(result[result >= 0].tolist())
-    expected = {
-        local_expert_offset + j
-        for j, count in enumerate(num_tokens_per_expert)
-        if int(count) > 0
-    }
-    assert assigned.issubset(expected), (
-        f"Assigned experts {sorted(assigned)} are not a subset of expected "
-        f"global experts {sorted(expected)}"
+    # Assigned experts must stay within this rank's global expert range.
+    assigned = result[result >= 0].tolist()
+    assert all(local_expert_offset <= e < num_experts for e in assigned), (
+        f"Assigned experts {sorted(set(assigned))} fall outside this rank's "
+        f"global range [{local_expert_offset}, {num_experts})"
+    )
+
+    # Global-index prioritization fills more tokens to top_k than the local-index
+    # bug, which leaves prioritization dead and strands an at-risk token.
+    num_selected = (result >= 0).sum(dim=-1)
+    fully_filled = int((num_selected == top_k).sum())
+    assert fully_filled == 3, (
+        f"expected 3 tokens filled to top_k via global-index prioritization, "
+        f"got {fully_filled} (local-index regression yields 2)"
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #14146 — two bugs in `generate_token_selected_experts` (`cute_dsl_custom_ops.py`), the helper that synthesizes `token_selected_experts` **for autotuner profiling** (`inputs_pre_hook`). They affect how representative the profiling distribution is — **not** inference routing or accuracy — but the generated profile should still match the per-expert allocation:

- **Ghost-token assignment**: when `num_tokens_per_expert[j] == 0`, the inner loop still assigns 1 token to that expert before breaking. With DeepSeek-V3 EP=16, top_k=8, 1 token: 7 ghost experts get assigned instead of 0. Fix: `if num_tokens_j <= 0: continue`.
- **Prioritization uses local index**: the priority threshold `top_k - (num_experts - j)` uses the loop variable `j` (local) instead of `j + self.local_expert_offset` (global). Whenever `num_local_experts < num_experts` (EP > 1) the threshold is always negative, so the at-risk-token prioritization is dead code on every rank; the global index restores it near the tail of the global expert range. Fix: compute `global_j` and use it consistently.

## Reproduction

```python
# DeepSeek-V3, ep_size=16, top_k=8, num_tokens=1:
#   num_tokens_per_expert = [1, 0, 0, ..., 0]  (1 nonzero, 15 zeros)
#   Buggy: assigns experts [0,1,2,3,4,5,6,7] — 7 ghost experts
#   Fixed: assigns experts [0] — correct
```

## Test plan

- [x] `test_ghost_token_zero_allocation` — experts with 0 allocation receive no tokens (reproduces the `[1,1,0,…]` → assigned `[0,1]` case above)
- [x] `test_prioritization_rescues_at_risk_tokens` — deterministic last-rank config (num_experts=4, top_k=2, 2 local experts, offset=2, 4 tokens): global-index prioritization fills **3** tokens to top_k vs **2** under the local-index bug, so reverting `global_j → j` fails the test (the previous assertion only checked the expert-id range, which is offset-invariant and missed bug 2)
- [ ] Existing `test_grouped_gemm_inputs_helper` and `test_moe_sort` pass

Closes #14146

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed expert index mapping in mixture-of-experts token selection to use global indices instead of local indices, ensuring correct expert assignment.
  * Added conditional handling for model weight loading to properly support checkpoints with optional bias parameters.

* **Tests**
  * Added test coverage for zero-token expert handling and global index prioritization validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
