### PR TITLE
[#13061][bugfix] Add rotate_activation to DSA fused_cat_fp8 path

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -2336,15 +2336,13 @@ class Indexer(nn.Module):
         """
         if self.use_fp4:
             return torch.ops.trtllm.fused_cat_fp4(qk_pe, qk_nope)
-        from tensorrt_llm.quantization.utils.fp8_utils import (
-            fp8_quantize_1x128_sf_transpose,
-        )
+        from tensorrt_llm.quantization.utils.fp8_utils import \
+            fp8_quantize_1x128_sf_transpose
         combined = torch.cat([qk_pe, qk_nope], dim=-1)
         combined = rotate_activation(combined)
         combined_2d = combined.view(-1, combined.shape[-1])
         return fp8_quantize_1x128_sf_transpose(
-            combined_2d, use_ue8m0=self.scale_fmt == "ue8m0"
-        )
+            combined_2d, use_ue8m0=self.scale_fmt == "ue8m0")
 
     def pre_indexer_proj(
         self, qr: torch.Tensor, hidden_states: torch.Tensor,

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -2336,19 +2336,15 @@ class Indexer(nn.Module):
         """
         if self.use_fp4:
             return torch.ops.trtllm.fused_cat_fp4(qk_pe, qk_nope)
+        from tensorrt_llm.quantization.utils.fp8_utils import (
+            fp8_quantize_1x128_sf_transpose,
+        )
         combined = torch.cat([qk_pe, qk_nope], dim=-1)
         combined = rotate_activation(combined)
-        head_dim = combined.shape[-1]
-        combined_2d = combined.view(-1, head_dim)
-        fp8_out, scale = torch.ops.trtllm.fp8_quantize_1x128(
-            combined_2d, use_ue8m0=self.scale_fmt == "ue8m0")
-        if scale.ndim == 1:
-            padded_m = (combined_2d.shape[0] + 3) // 4 * 4
-            num_blocks = (head_dim + 127) // 128
-            scale = scale[:padded_m * num_blocks].view(
-                num_blocks, padded_m)[:, :combined_2d.shape[0]]
-        scale = scale.contiguous().transpose(0, 1)
-        return fp8_out, scale
+        combined_2d = combined.view(-1, combined.shape[-1])
+        return fp8_quantize_1x128_sf_transpose(
+            combined_2d, use_ue8m0=self.scale_fmt == "ue8m0"
+        )
 
     def pre_indexer_proj(
         self, qr: torch.Tensor, hidden_states: torch.Tensor,

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -2327,15 +2327,12 @@ class Indexer(nn.Module):
         return q_pe, q_nope, k_pe, k_nope
 
     def _prep_q_or_k(self, qk_pe: torch.Tensor, qk_nope: torch.Tensor):
-        """Concatenate, rotate, and FP8 quantize for Q or K.
-
-        The FP8 path is intentionally unfused (cat -> rotate -> quantize) so the
-        Hadamard rotate_activation is applied. The fused_cat_fp8 kernel added in
-        #11899 omits the rotation, which is the regression tracked by #13061.
-        FP4 keeps the fused cat+quantize (rotation TODO).
-        """
+        """Concatenate, rotate, and FP8 quantize for Q or K."""
         if self.use_fp4:
+            # FP4 stays fused; Hadamard rotation not applied here yet (follow-up).
             return torch.ops.trtllm.fused_cat_fp4(qk_pe, qk_nope)
+        # Unfused so the Hadamard rotation runs between cat and quantize;
+        # the fused_cat_fp8 kernel skips it (see #13061).
         q_or_k = maybe_compiled_cat([qk_pe, qk_nope], dim=-1)
         q_or_k = rotate_activation(q_or_k)
         q_or_k = q_or_k.view(-1, self.head_dim)

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -24,7 +24,7 @@ from tensorrt_llm._torch.modules.multi_stream_utils import \
     maybe_execute_in_parallel
 from tensorrt_llm._torch.modules.rotary_embedding import RotaryEmbedding
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
-from tensorrt_llm._torch.utils import maybe_compile
+from tensorrt_llm._torch.utils import maybe_compile, maybe_compiled_cat
 from tensorrt_llm._utils import get_size_in_bytes, get_sm_version, prefer_pinned
 from tensorrt_llm.bindings import DataType
 from tensorrt_llm.bindings.executor import KvCacheConfig
@@ -38,6 +38,7 @@ from tensorrt_llm.llmapi.llm_args import SparseAttentionConfig
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantConfig
+from tensorrt_llm.quantization.utils import fp8_utils
 
 ModelConfig = tensorrt_llm.bindings.ModelConfig
 
@@ -2326,23 +2327,20 @@ class Indexer(nn.Module):
         return q_pe, q_nope, k_pe, k_nope
 
     def _prep_q_or_k(self, qk_pe: torch.Tensor, qk_nope: torch.Tensor):
-        """Concatenate, rotate, and quantize for Q or K.
+        """Concatenate, rotate, and FP8 quantize for Q or K.
 
-        Applies Hadamard rotation (rotate_activation) between concatenation
-        and quantization — required for DSA sparse attention correctness.
-
-        FP8 mode: cat → rotate → FP8 quantize (unfused to allow rotation).
-        FP4 mode: fused cat + FP4 quantize (TODO: add rotation).
+        The FP8 path is intentionally unfused (cat -> rotate -> quantize) so the
+        Hadamard rotate_activation is applied. The fused_cat_fp8 kernel added in
+        #11899 omits the rotation, which is the regression tracked by #13061.
+        FP4 keeps the fused cat+quantize (rotation TODO).
         """
         if self.use_fp4:
             return torch.ops.trtllm.fused_cat_fp4(qk_pe, qk_nope)
-        from tensorrt_llm.quantization.utils.fp8_utils import \
-            fp8_quantize_1x128_sf_transpose
-        combined = torch.cat([qk_pe, qk_nope], dim=-1)
-        combined = rotate_activation(combined)
-        combined_2d = combined.view(-1, combined.shape[-1])
-        return fp8_quantize_1x128_sf_transpose(
-            combined_2d, use_ue8m0=self.scale_fmt == "ue8m0")
+        q_or_k = maybe_compiled_cat([qk_pe, qk_nope], dim=-1)
+        q_or_k = rotate_activation(q_or_k)
+        q_or_k = q_or_k.view(-1, self.head_dim)
+        return fp8_utils.fp8_quantize_1x128_sf_transpose(
+            q_or_k, use_ue8m0=self.scale_fmt == "ue8m0")
 
     def pre_indexer_proj(
         self, qr: torch.Tensor, hidden_states: torch.Tensor,

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -2326,17 +2326,28 @@ class Indexer(nn.Module):
         return q_pe, q_nope, k_pe, k_nope
 
     def _prep_q_or_k(self, qk_pe: torch.Tensor, qk_nope: torch.Tensor):
-        """Concatenate and quantize for Q or K.
+        """Concatenate, rotate, and quantize for Q or K.
 
-        FP8 mode: fused cat + FP8 quantize via CUDA kernel.
-        FP4 mode: fused cat + per-block-32 FP4 E2M1 quantize via CUDA kernel.
-        The returned packed bytes are int8 (two FP4 codes per byte) and the
-        scale is int32 (four UE8M0 exponents packed little-endian).
+        Applies Hadamard rotation (rotate_activation) between concatenation
+        and quantization — required for DSA sparse attention correctness.
+
+        FP8 mode: cat → rotate → FP8 quantize (unfused to allow rotation).
+        FP4 mode: fused cat + FP4 quantize (TODO: add rotation).
         """
         if self.use_fp4:
             return torch.ops.trtllm.fused_cat_fp4(qk_pe, qk_nope)
-        fp8_out, scale = torch.ops.trtllm.fused_cat_fp8(
-            qk_pe, qk_nope, self.scale_fmt == "ue8m0")
+        combined = torch.cat([qk_pe, qk_nope], dim=-1)
+        combined = rotate_activation(combined)
+        head_dim = combined.shape[-1]
+        combined_2d = combined.view(-1, head_dim)
+        fp8_out, scale = torch.ops.trtllm.fp8_quantize_1x128(
+            combined_2d, use_ue8m0=self.scale_fmt == "ue8m0")
+        if scale.ndim == 1:
+            padded_m = (combined_2d.shape[0] + 3) // 4 * 4
+            num_blocks = (head_dim + 127) // 128
+            scale = scale[:padded_m * num_blocks].view(
+                num_blocks, padded_m)[:, :combined_2d.shape[0]]
+        scale = scale.contiguous().transpose(0, 1)
         return fp8_out, scale
 
     def pre_indexer_proj(


### PR DESCRIPTION
## Summary

Fixes #13061 — the DSA sparse attention indexer's `_prep_q_or_k` method calls `fused_cat_fp8` to concatenate `[qk_pe, qk_nope]` and quantize to FP8 in a single fused kernel, but **skips `rotate_activation`** (Hadamard rotation) which DSA requires between concatenation and quantization.

- **Root cause**: `fused_cat_fp8` is a single CUDA kernel that does cat+quant atomically — there's no way to inject the rotation in between.
- **Fix**: Unfuse the FP8 path into `torch.cat → rotate_activation → fp8_quantize_1x128`. The scale transpose logic follows the reference implementation in `test_fused_cat_fp8.py`.
- **Backward-compatible**: `rotate_activation` gracefully returns identity when `fast-hadamard-transform` is not installed (existing warning).
- **FP4 gap**: The FP4 path (`fused_cat_fp4`) has the same issue but needs a standalone FP4 quantize-only kernel to unfuse — noted in the docstring as a follow-up.

## Code flow (before → after)

**Before** (buggy):
```
qk_pe, qk_nope → fused_cat_fp8 (cat + quant) → fp8_out, scale
                   rotate_activation skipped
```

**After** (fixed):
```
qk_pe, qk_nope → torch.cat → rotate_activation → fp8_quantize_1x128 → fp8_out, scale
                               Hadamard rotation applied
```

## Test plan

- [x] `rotate_activation` fallback: returns identity when fast-hadamard-transform is missing — no regression for existing setups

Not run in my environment (no GPU build / no DeepSeek V3.2 weights) — flagged for CI / reviewer validation:

- `test_fused_cat_fp8.py`: the `fused_cat_fp8` CUDA kernel is **unchanged** by this PR (the FP8 path now reaches the quantizer via `fp8_quantize_1x128_sf_transpose` after the Hadamard rotation), so the kernel test is unaffected.
- DSA sparse attention end-to-end with DeepSeek V3.2 (requires model weights + `fast-hadamard-transform`).

Closes #13061
## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized sparse attention backend with improved quantization implementation and enhanced tensor processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

