### PR TITLE
[TRTLLM-5516][feat] Qwen3.5/3.6 MoE engine-path support + naive Gated DeltaNet plugin

### DIFF
--- a/cpp/include/tensorrt_llm/runtime/modelConfig.h
+++ b/cpp/include/tensorrt_llm/runtime/modelConfig.h
@@ -47,6 +47,7 @@ public:
         kMamba = 3,          // https://github.com/state-spaces/mamba
         kRecurrentGemma = 4, // https://github.com/google-deepmind/recurrentgemma
         kEncDec = 5,
+        kQwen3Next = 6,      // Qwen3.5/3.6 hybrid: Gated DeltaNet (linear attention) + full attention
     };
 
     struct RnnConfig
@@ -782,7 +783,8 @@ public:
 
     [[nodiscard]] bool constexpr isRnnBased() const noexcept
     {
-        return mModelVariant == ModelVariant::kMamba || mModelVariant == ModelVariant::kRecurrentGemma;
+        return mModelVariant == ModelVariant::kMamba || mModelVariant == ModelVariant::kRecurrentGemma
+            || mModelVariant == ModelVariant::kQwen3Next;
     }
 
     [[nodiscard]] std::vector<LayerType> const& getLayerTypes() const noexcept

--- a/cpp/tensorrt_llm/plugins/CMakeLists.txt
+++ b/cpp/tensorrt_llm/plugins/CMakeLists.txt
@@ -72,6 +72,7 @@ set(PLUGIN_LISTS
     mixtureOfExperts
     selectiveScanPlugin
     mambaConv1dPlugin
+    gatedDeltaNetPlugin
     lruPlugin
     cumsumLastDimPlugin
     topkLastDimPlugin

--- a/cpp/tensorrt_llm/plugins/api/tllmPlugin.cpp
+++ b/cpp/tensorrt_llm/plugins/api/tllmPlugin.cpp
@@ -23,6 +23,7 @@
 #include "tensorrt_llm/plugins/doraPlugin/doraPlugin.h"
 #include "tensorrt_llm/plugins/fp8RowwiseGemmPlugin/fp8RowwiseGemmPlugin.h"
 #include "tensorrt_llm/plugins/fusedLayernormPlugin/fusedLayernormPlugin.h"
+#include "tensorrt_llm/plugins/gatedDeltaNetPlugin/gatedDeltaNetPlugin.h"
 #include "tensorrt_llm/plugins/gemmPlugin/gemmPlugin.h"
 #include "tensorrt_llm/plugins/gemmSwigluPlugin/gemmSwigluPlugin.h"
 #include "tensorrt_llm/plugins/gptAttentionPlugin/gptAttentionPlugin.h"
@@ -237,6 +238,7 @@ extern "C"
         static tensorrt_llm::plugins::SelectiveScanPluginCreator selectiveScanPluginCreator;
         static tensorrt_llm::plugins::Fp4GemmPluginCreator fp4GemmPluginCreator;
         static tensorrt_llm::plugins::MambaConv1dPluginCreator mambaConv1DPluginCreator;
+        static tensorrt_llm::plugins::GatedDeltaNetPluginCreator gatedDeltaNetPluginCreator;
         static tensorrt_llm::plugins::lruPluginCreator lruPluginCreator;
         static tensorrt_llm::plugins::CumsumLastDimPluginCreator cumsumLastDimPluginCreator;
         static tensorrt_llm::plugins::TopkLastDimPluginCreator topkLastDimPluginCreator;
@@ -276,6 +278,7 @@ extern "C"
                   creatorPtr(lookupPluginCreator),
                   creatorPtr(loraPluginCreator),
                   creatorPtr(selectiveScanPluginCreator),
+                  creatorPtr(gatedDeltaNetPluginCreator),
                   creatorPtr(fp4GemmPluginCreator),
                   creatorPtr(mambaConv1DPluginCreator),
                   creatorPtr(lruPluginCreator),

--- a/cpp/tensorrt_llm/plugins/gatedDeltaNetPlugin/CMakeLists.txt
+++ b/cpp/tensorrt_llm/plugins/gatedDeltaNetPlugin/CMakeLists.txt
@@ -1,0 +1,23 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved. SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# This plugin keeps its CUDA kernel (gatedDeltaNetKernel.cu) in the plugin dir,
+# so we glob both *.cpp and *.cu into PLUGIN_SOURCES (mirrors gemmSwigluPlugin).
+file(GLOB SRCS *.cpp *.cu)
+set(PLUGIN_SOURCES ${PLUGIN_SOURCES} ${SRCS})
+set(PLUGIN_SOURCES
+    ${PLUGIN_SOURCES}
+    PARENT_SCOPE)

--- a/cpp/tensorrt_llm/plugins/gatedDeltaNetPlugin/gatedDeltaNetKernel.cu
+++ b/cpp/tensorrt_llm/plugins/gatedDeltaNetPlugin/gatedDeltaNetKernel.cu
@@ -1,0 +1,264 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * CUDA kernel for the "Gated DeltaNet" (GDN) linear-attention recurrence used by
+ * the Qwen3.5/3.6 engine path. This is a naive, correctness-first port of the
+ * recurrence (one CUDA thread/block walks a sequence token-by-token, fp32
+ * state). Optimization (chunking, tensor cores, vectorized loads,
+ * register-tiling of the state S, etc.) is explicitly OUT OF SCOPE here: the
+ * goal is numerical parity with the PyTorch reference.
+ *
+ * Math per (batch b, v-head h), looping tokens t = 0 .. seqlens[b]-1, starting
+ * from S = S_in[b, h]  (state S is [D_k, D_v]):
+ *
+ *   qn = l2norm(q_t) ; kn = l2norm(k_t)            # over D_k, eps = 1e-6
+ *   qn *= 1 / sqrt(D_k)                            # SCALE on q only
+ *   S  *= exp(g_t)                                 # elementwise decay on [D_k,D_v]
+ *   kvmem[j] = sum_i S[i,j] * kn[i]                # read with (normalized) key
+ *   delta[j] = (v_t[j] - kvmem[j]) * beta_t        # correction
+ *   S[i,j]  += kn[i] * delta[j]                    # rank-1 outer-product update
+ *   y_t[j]   = sum_i S[i,j] * qn[i]                # read with (scaled) query, on UPDATED S
+ *
+ * The order (decay -> read-kv -> delta -> write -> read-y on updated S) is
+ * load-bearing.
+ */
+
+#include "tensorrt_llm/plugins/gatedDeltaNetPlugin/gatedDeltaNetPlugin.h"
+
+#include <cuda_runtime.h>
+
+namespace tensorrt_llm::plugins
+{
+
+namespace
+{
+
+// Upper bound on D_k / D_v for static per-thread local storage. The real model
+// uses D_k = D_v = 128; we size the per-thread S-column to this. The kernel still
+// reads the actual D_k / D_v from the launch params and only touches the valid range.
+constexpr int kMaxDim = 128;
+
+constexpr float kL2NormEps = 1e-6f;
+
+// One CUDA block per (batch, v-head) pair. Within a block we launch D_v threads;
+// thread j owns column j of the recurrent state, i.e. the length-D_k vector
+// S[:, j]. The recurrence is sequential over tokens, so the block loops t inside
+// while distinct (b, h) blocks run in parallel.
+//
+// Shared memory per block holds, for the current token:
+//   - kn[D_k] : L2-normalized key
+//   - qn[D_k] : L2-normalized + scaled query
+// plus a small scratch slot for the block-wide reduction used to compute the
+// L2 norms. The two scalars (exp(g_t), beta_t) are recomputed by every thread --
+// cheap and avoids extra sync points.
+__global__ void gatedDeltaRuleKernel(float const* __restrict__ q, // [B,T,H,Dk]
+    float const* __restrict__ k,                                  // [B,T,H,Dk]
+    float const* __restrict__ v,                                  // [B,T,H,Dv]
+    float const* __restrict__ g,                                  // [B,T,H]
+    float const* __restrict__ beta,                               // [B,T,H]
+    float const* __restrict__ S_in,                               // [B,H,Dk,Dv]
+    int const* __restrict__ seqlens,                              // [B]
+    float* __restrict__ y,                                        // [B,T,H,Dv]
+    float* __restrict__ S_out,                                    // [B,H,Dk,Dv]
+    int B, int T, int H, int Dk, int Dv, bool useQkL2norm)
+{
+    int const bh = blockIdx.x; // flattened (b, h) index in [0, B*H)
+    int const b = bh / H;      // batch index
+    int const h = bh % H;      // v-head index
+    int const j = threadIdx.x; // this thread's state column in [0, Dv)
+
+    if (b >= B || h >= H)
+    {
+        return;
+    }
+
+    // Shared layout: [ kn(Dk) | qn(Dk) | scratch(blockDim.x) ].
+    extern __shared__ float smem[];
+    float* sh_kn = smem;            // [Dk]
+    float* sh_qn = sh_kn + Dk;      // [Dk]
+    float* sh_scratch = sh_qn + Dk; // [blockDim.x] reduction scratch
+
+    bool const active = (j < Dv);
+
+    // Per-thread state column S[:, j] for the column this thread owns, in local
+    // (per-thread) memory. Only the first Dk entries are used.
+    float Scol[kMaxDim];
+
+    // Base offset of this (b, h) state block inside S_in / S_out: element [i, j]
+    // lives at base + i * Dv + j.
+    long const state_base = ((long) bh) * Dk * Dv;
+
+    // Initialize the owned state column from S_in (S[i, j] for all i).
+    if (active)
+    {
+        for (int i = 0; i < Dk; ++i)
+        {
+            Scol[i] = S_in[state_base + (long) i * Dv + j];
+        }
+    }
+
+    int const L = seqlens[b];
+
+    for (int t = 0; t < L; ++t)
+    {
+        // Per-token base offsets into the [B,T,H,*] tensors.
+        long const qk_base = ((((long) b * T + t) * H) + h) * Dk; // q,k row start
+        long const v_base = ((((long) b * T + t) * H) + h) * Dv;  // v / y row start
+        long const gb_base = (((long) b * T + t) * H) + h;        // g,beta scalar
+
+        // ----------------------------------------------------------------
+        // Step 1 (part a): L2-norm denominators for q and k over D_k.
+        // We compute sum(q^2) and sum(k^2) with a simple block reduction so the
+        // (eps-stabilized) rsqrt matches the reference exactly. Thread j handles
+        // index j of the length-D_k vectors during the reduction (D_k == blockDim
+        // here since blockDim == D_v == D_k == 128 for this model, but we guard so
+        // it works whenever blockDim >= Dk by zero-padding the tail).
+        // ----------------------------------------------------------------
+        float const scale = rsqrtf((float) Dk); // SCALE = 1/sqrt(D_k), applied to q only
+
+        // -- sum of squares for q --
+        {
+            float partial = 0.0f;
+            if (j < Dk)
+            {
+                float const qj = q[qk_base + j];
+                partial = qj * qj;
+            }
+            sh_scratch[threadIdx.x] = partial;
+            __syncthreads();
+            // Tree reduction over the whole block.
+            for (int stride = blockDim.x >> 1; stride > 0; stride >>= 1)
+            {
+                if (threadIdx.x < stride)
+                {
+                    sh_scratch[threadIdx.x] += sh_scratch[threadIdx.x + stride];
+                }
+                __syncthreads();
+            }
+            float const q_rnorm = useQkL2norm ? rsqrtf(sh_scratch[0] + kL2NormEps) : 1.0f;
+            // Step 1+2: normalize q (if enabled) then apply SCALE = 1/sqrt(D_k).
+            if (j < Dk)
+            {
+                sh_qn[j] = q[qk_base + j] * q_rnorm * scale;
+            }
+            __syncthreads();
+        }
+        // -- sum of squares for k --
+        {
+            float partial = 0.0f;
+            if (j < Dk)
+            {
+                float const kj = k[qk_base + j];
+                partial = kj * kj;
+            }
+            sh_scratch[threadIdx.x] = partial;
+            __syncthreads();
+            for (int stride = blockDim.x >> 1; stride > 0; stride >>= 1)
+            {
+                if (threadIdx.x < stride)
+                {
+                    sh_scratch[threadIdx.x] += sh_scratch[threadIdx.x + stride];
+                }
+                __syncthreads();
+            }
+            float const k_rnorm = useQkL2norm ? rsqrtf(sh_scratch[0] + kL2NormEps) : 1.0f;
+            if (j < Dk)
+            {
+                sh_kn[j] = k[qk_base + j] * k_rnorm; // k is NOT scaled
+            }
+            __syncthreads();
+        }
+
+        // Per-token scalars (recomputed by every active thread).
+        float const decay = expf(g[gb_base]); // exp(g_t)
+        float const bt = beta[gb_base];       // beta_t
+
+        if (active)
+        {
+            // Step 3: decay the owned state column elementwise.  S[i,j] *= decay.
+            for (int i = 0; i < Dk; ++i)
+            {
+                Scol[i] *= decay;
+            }
+
+            // Step 4: read with normalized key.  kvmem[j] = sum_i S[i,j] * kn[i].
+            float kvmem = 0.0f;
+            for (int i = 0; i < Dk; ++i)
+            {
+                kvmem += Scol[i] * sh_kn[i];
+            }
+
+            // Step 5: delta[j] = (v_t[j] - kvmem[j]) * beta_t.
+            float const delta = (v[v_base + j] - kvmem) * bt;
+
+            // Step 6: rank-1 update.  S[i,j] += kn[i] * delta.
+            for (int i = 0; i < Dk; ++i)
+            {
+                Scol[i] += sh_kn[i] * delta;
+            }
+
+            // Step 7: read with scaled query on the UPDATED state.
+            //         y_t[j] = sum_i S[i,j] * qn[i].
+            float yj = 0.0f;
+            for (int i = 0; i < Dk; ++i)
+            {
+                yj += Scol[i] * sh_qn[i];
+            }
+            y[v_base + j] = yj;
+        }
+
+        // Ensure all threads finished reading sh_kn / sh_qn for this token before
+        // the next iteration overwrites them.
+        __syncthreads();
+    }
+
+    // Write the final state column back to S_out.
+    if (active)
+    {
+        for (int i = 0; i < Dk; ++i)
+        {
+            S_out[state_base + (long) i * Dv + j] = Scol[i];
+        }
+    }
+}
+
+} // anonymous namespace
+
+void invokeGatedDeltaNet(GatedDeltaNetParams const& params, cudaStream_t stream)
+{
+    int const B = params.batch;
+    int const T = params.maxSeqLen;
+    int const H = params.numVHeads;
+    int const Dk = params.headKDim;
+    int const Dv = params.headVDim;
+
+    // One block per (b, h). Threads = D_v columns; we also need >= D_k lanes for
+    // the L2-norm reduction. For this model D_k == D_v == 128 so D_v threads
+    // suffice. The host (plugin enqueue) validates Dk/Dv <= kMaxDim and Dv >= Dk.
+    int const threads = Dv;
+    dim3 const grid((unsigned) (B * H));
+    dim3 const block((unsigned) threads);
+
+    // Shared: kn(Dk) + qn(Dk) + scratch(threads).
+    size_t const smemBytes = (size_t) (2 * Dk + threads) * sizeof(float);
+
+    gatedDeltaRuleKernel<<<grid, block, smemBytes, stream>>>(static_cast<float const*>(params.q),
+        static_cast<float const*>(params.k), static_cast<float const*>(params.v), static_cast<float const*>(params.g),
+        static_cast<float const*>(params.beta), static_cast<float const*>(params.statePtrIn), params.seqLens,
+        static_cast<float*>(params.y), static_cast<float*>(params.statePtrOut), B, T, H, Dk, Dv, params.useQkL2norm);
+}
+
+} // namespace tensorrt_llm::plugins

--- a/cpp/tensorrt_llm/plugins/gatedDeltaNetPlugin/gatedDeltaNetPlugin.cpp
+++ b/cpp/tensorrt_llm/plugins/gatedDeltaNetPlugin/gatedDeltaNetPlugin.cpp
@@ -1,0 +1,394 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gatedDeltaNetPlugin.h"
+#include "tensorrt_llm/common/assert.h"
+
+using namespace nvinfer1;
+using namespace tensorrt_llm::common;
+using tensorrt_llm::plugins::GatedDeltaNetPluginCreator;
+using tensorrt_llm::plugins::GatedDeltaNetPlugin;
+
+static char const* GATED_DELTA_NET_PLUGIN_VERSION{"1"};
+static char const* GATED_DELTA_NET_PLUGIN_NAME{"GatedDeltaNet"};
+PluginFieldCollection GatedDeltaNetPluginCreator::mFC{};
+std::vector<nvinfer1::PluginField> GatedDeltaNetPluginCreator::mPluginAttributes;
+
+GatedDeltaNetPlugin::GatedDeltaNetPlugin(int numVHeads, int headKDim, int headVDim, int chunkSize, bool useQkL2norm,
+    nvinfer1::DataType type, bool removePadding, bool pagedState)
+    : mNumVHeads(numVHeads)
+    , mHeadKDim(headKDim)
+    , mHeadVDim(headVDim)
+    , mChunkSize(chunkSize)
+    , mUseQkL2norm(useQkL2norm)
+    , mType(type)
+    , mRemovePadding(removePadding)
+    , mPagedState(pagedState)
+{
+    // CORRECTNESS-FIRST: the recurrent state is always fp32, and for this first
+    // version we only support the fp32 compute path.
+    TLLM_CHECK_WITH_INFO(mType == DataType::kFLOAT, "GatedDeltaNetPlugin only supports float (fp32) for now.");
+}
+
+// Parameterized constructor
+GatedDeltaNetPlugin::GatedDeltaNetPlugin(void const* data, size_t length)
+{
+    char const *d = reinterpret_cast<char const*>(data), *a = d;
+    read(d, mNumVHeads);
+    read(d, mHeadKDim);
+    read(d, mHeadVDim);
+    read(d, mChunkSize);
+    read(d, mUseQkL2norm);
+    read(d, mType);
+    read(d, mRemovePadding);
+    read(d, mPagedState);
+    TLLM_CHECK(d == a + length);
+    TLLM_CHECK_WITH_INFO(mType == DataType::kFLOAT, "GatedDeltaNetPlugin only supports float (fp32) for now.");
+}
+
+// IPluginV2DynamicExt Methods
+nvinfer1::IPluginV2DynamicExt* GatedDeltaNetPlugin::clone() const noexcept
+{
+    auto* plugin = new GatedDeltaNetPlugin(
+        mNumVHeads, mHeadKDim, mHeadVDim, mChunkSize, mUseQkL2norm, mType, mRemovePadding, mPagedState);
+    plugin->setPluginNamespace(mNamespace.c_str());
+    return plugin;
+}
+
+// Outputs
+//     0. y             [B, T, H_v, D_v] or [num_tokens, H_v, D_v] for remove_input_padding
+//     1. present_state [B, H_v, D_k, D_v] fp32 (omitted iff paged_state)
+nvinfer1::DimsExprs GatedDeltaNetPlugin::getOutputDimensions(
+    int outputIndex, nvinfer1::DimsExprs const* inputs, int nbInputs, nvinfer1::IExprBuilder& exprBuilder) noexcept
+{
+    if (outputIndex == 0)
+    {
+        // y has the same leading layout as v (which carries D_v as the last dim).
+        return inputs[getVIdx()];
+    }
+    // present_state mirrors the input recurrent state [B, H_v, D_k, D_v].
+    return inputs[getStateIdx()];
+}
+
+bool GatedDeltaNetPlugin::supportsFormatCombination(
+    int pos, nvinfer1::PluginTensorDesc const* inOut, int nbInputs, int nbOutputs) noexcept
+{
+    if (pos == getHostRequestTypesIdx() || pos == getLastTokenIdsIdx()
+        || (mRemovePadding && pos == getHostContextLengthIdx()) || (mPagedState && pos == getSlotMappingIdx()))
+    {
+        return inOut[pos].type == nvinfer1::DataType::kINT32;
+    }
+    else if (mPagedState && pos == getStateIdx())
+    {
+        // host pointer to the paged recurrent state
+        return inOut[pos].type == nvinfer1::DataType::kINT64;
+    }
+    else
+    {
+        // q, k, v, g, beta, (dense) state, y, present_state are all fp32 / linear.
+        return (inOut[pos].type == mType) && (inOut[pos].format == TensorFormat::kLINEAR);
+    }
+}
+
+void GatedDeltaNetPlugin::configurePlugin(nvinfer1::DynamicPluginTensorDesc const* in, int nbInputs,
+    nvinfer1::DynamicPluginTensorDesc const* out, int nbOutputs) noexcept
+{
+}
+
+size_t GatedDeltaNetPlugin::getWorkspaceSize(nvinfer1::PluginTensorDesc const* inputs, int nbInputs,
+    nvinfer1::PluginTensorDesc const* outputs, int nbOutputs) const noexcept
+{
+    // The kernel keeps per-thread local state (one S-column per thread); no
+    // device scratch is required.
+    return 0;
+}
+
+template <typename T>
+int GatedDeltaNetPlugin::enqueueImpl(nvinfer1::PluginTensorDesc const* inputDesc,
+    nvinfer1::PluginTensorDesc const* outputDesc, void const* const* inputs, void* const* outputs, void* workspace,
+    cudaStream_t stream)
+{
+    // inputs
+    //     0. q     [B, T, H_v, D_k]
+    //     1. k     [B, T, H_v, D_k]
+    //     2. v     [B, T, H_v, D_v]
+    //     3. g     [B, T, H_v]
+    //     4. beta  [B, T, H_v]
+    //     5. state_or_ptr [B, H_v, D_k, D_v] fp32 (or host [1] int64 ptr if paged_state)
+    //     6. host_request_types [B] int32 (0: context, 1: generation)
+    //     7. last_token_ids     [B] int32
+    //     8. host_context_lengths [B] int32 (iff remove_input_padding)
+    //     9. slot_mapping         [B] int32 (iff paged_state)
+    // outputs
+    //     0. y             [B, T, H_v, D_v]
+    //     1. present_state [B, H_v, D_k, D_v] fp32 (omitted iff paged_state)
+
+    // CORRECTNESS-FIRST: only the dense (non-paged, non-remove-padding) path is
+    // wired up for now. The paged_state / remove_input_padding signatures are
+    // parsed and stored so the plugin is future-proof, but their kernel handling
+    // is not yet implemented.
+    TLLM_CHECK_WITH_INFO(!mPagedState && !mRemovePadding,
+        "GatedDeltaNetPlugin: paged_state and remove_input_padding paths are not yet implemented; only the dense "
+        "[B,T,...] non-paged path is supported.");
+
+    auto const batchSize = inputDesc[getHostRequestTypesIdx()].dims.d[0];
+    // Dense path: T is the padded sequence length carried by q.
+    int const maxSeqLen = inputDesc[getQIdx()].dims.d[1];
+
+    // host_request_types selects context vs generation for the whole batch (we do
+    // not support mixing context and generation in one enqueue, matching
+    // selectiveScanPlugin).
+    RequestType const* reqTypes = static_cast<RequestType const*>(inputs[getHostRequestTypesIdx()]);
+
+    // present_state is a dedicated output buffer in the dense path; the kernel
+    // reads from the input state and writes the updated state here.
+    void* statePtrIn = const_cast<void*>(inputs[getStateIdx()]);
+    void* statePtrOut = outputs[1];
+
+    // Zero-initialize y so that padding tokens beyond each request's valid length
+    // (which the kernel never writes) are well-defined zeros, matching the
+    // reference launcher semantics.
+    {
+        size_t const yElems = static_cast<size_t>(batchSize) * maxSeqLen * mNumVHeads * mHeadVDim;
+        TLLM_CUDA_CHECK(cudaMemsetAsync(outputs[0], 0, yElems * sizeof(T), stream));
+    }
+
+    GatedDeltaNetParams params;
+    memset(&params, 0, sizeof(params));
+    params.batch = static_cast<int>(batchSize);
+    params.maxSeqLen = maxSeqLen;
+    params.numVHeads = mNumVHeads;
+    params.headKDim = mHeadKDim;
+    params.headVDim = mHeadVDim;
+    params.q = inputs[getQIdx()];
+    params.k = inputs[getKIdx()];
+    params.v = inputs[getVIdx()];
+    params.g = inputs[getGIdx()];
+    params.beta = inputs[getBetaIdx()];
+    params.statePtrIn = statePtrIn;
+    // For context, last_token_ids carries the per-request inclusive valid length
+    // (non-removePadding case). For generation each request processes exactly one
+    // token; the kernel reads seqlens[b] directly, so this maps cleanly.
+    params.seqLens = static_cast<int const*>(inputs[getLastTokenIdsIdx()]);
+    // RequestType is an int32-backed enum; the params struct carries the raw
+    // int32 host pointer (the kernel does not branch on it in this dense path).
+    params.hostReqTypes = reinterpret_cast<int const*>(reqTypes);
+    params.y = outputs[0];
+    params.statePtrOut = statePtrOut;
+    params.useQkL2norm = mUseQkL2norm;
+
+    invokeGatedDeltaNet(params, stream);
+
+    sync_check_cuda_error(stream);
+    return 0;
+}
+
+int GatedDeltaNetPlugin::enqueue(nvinfer1::PluginTensorDesc const* inputDesc,
+    nvinfer1::PluginTensorDesc const* outputDesc, void const* const* inputs, void* const* outputs, void* workspace,
+    cudaStream_t stream) noexcept
+{
+    if (isBuilding())
+    {
+        return 0;
+    }
+    if (mType == DataType::kFLOAT)
+    {
+        return enqueueImpl<float>(inputDesc, outputDesc, inputs, outputs, workspace, stream);
+    }
+    return 0;
+}
+
+// IPluginV2Ext Methods
+nvinfer1::DataType GatedDeltaNetPlugin::getOutputDataType(
+    int index, nvinfer1::DataType const* inputTypes, int nbInputs) const noexcept
+{
+    if (index == 0)
+    {
+        return inputTypes[getVIdx()];
+    }
+    return inputTypes[getStateIdx()];
+}
+
+// IPluginV2 Methods
+
+char const* GatedDeltaNetPlugin::getPluginType() const noexcept
+{
+    return GATED_DELTA_NET_PLUGIN_NAME;
+}
+
+char const* GatedDeltaNetPlugin::getPluginVersion() const noexcept
+{
+    return GATED_DELTA_NET_PLUGIN_VERSION;
+}
+
+int GatedDeltaNetPlugin::getNbOutputs() const noexcept
+{
+    return mPagedState ? 1 : 2;
+}
+
+int GatedDeltaNetPlugin::initialize() noexcept
+{
+    return 0;
+}
+
+void GatedDeltaNetPlugin::terminate() noexcept {}
+
+size_t GatedDeltaNetPlugin::getSerializationSize() const noexcept
+{
+    return sizeof(mNumVHeads) + sizeof(mHeadKDim) + sizeof(mHeadVDim) + sizeof(mChunkSize) + sizeof(mUseQkL2norm)
+        + sizeof(mType) + sizeof(mRemovePadding) + sizeof(mPagedState);
+}
+
+void GatedDeltaNetPlugin::serialize(void* buffer) const noexcept
+{
+    char *d = static_cast<char*>(buffer), *a = d;
+    write(d, mNumVHeads);
+    write(d, mHeadKDim);
+    write(d, mHeadVDim);
+    write(d, mChunkSize);
+    write(d, mUseQkL2norm);
+    write(d, mType);
+    write(d, mRemovePadding);
+    write(d, mPagedState);
+    TLLM_CHECK(d == a + getSerializationSize());
+}
+
+void GatedDeltaNetPlugin::destroy() noexcept
+{
+    delete this;
+}
+
+///////////////
+
+GatedDeltaNetPluginCreator::GatedDeltaNetPluginCreator()
+{
+    // Fill PluginFieldCollection with PluginField arguments metadata
+    mPluginAttributes.clear();
+    mPluginAttributes.emplace_back(PluginField("num_v_heads", nullptr, PluginFieldType::kINT32));
+    mPluginAttributes.emplace_back(PluginField("head_k_dim", nullptr, PluginFieldType::kINT32));
+    mPluginAttributes.emplace_back(PluginField("head_v_dim", nullptr, PluginFieldType::kINT32));
+    mPluginAttributes.emplace_back(PluginField("chunk_size", nullptr, PluginFieldType::kINT32));
+    mPluginAttributes.emplace_back(PluginField("use_qk_l2norm", nullptr, PluginFieldType::kINT8));
+    mPluginAttributes.emplace_back(PluginField("type_id", nullptr, PluginFieldType::kINT32));
+    mPluginAttributes.emplace_back(PluginField("remove_input_padding", nullptr, PluginFieldType::kINT8));
+    mPluginAttributes.emplace_back(PluginField("paged_state", nullptr, PluginFieldType::kINT8));
+    mFC.nbFields = mPluginAttributes.size();
+    mFC.fields = mPluginAttributes.data();
+}
+
+char const* GatedDeltaNetPluginCreator::getPluginName() const noexcept
+{
+    return GATED_DELTA_NET_PLUGIN_NAME;
+}
+
+char const* GatedDeltaNetPluginCreator::getPluginVersion() const noexcept
+{
+    return GATED_DELTA_NET_PLUGIN_VERSION;
+}
+
+PluginFieldCollection const* GatedDeltaNetPluginCreator::getFieldNames() noexcept
+{
+    return &mFC;
+}
+
+IPluginV2* GatedDeltaNetPluginCreator::createPlugin(char const* name, PluginFieldCollection const* fc) noexcept
+{
+    PluginField const* fields = fc->fields;
+    int numVHeads{};
+    int headKDim{};
+    int headVDim{};
+    int chunkSize{};
+    bool useQkL2norm{};
+    bool removePadding{};
+    bool pagedState{};
+    nvinfer1::DataType type{};
+    // Read configurations from each field.
+    for (int i = 0; i < fc->nbFields; ++i)
+    {
+        char const* attrName = fields[i].name;
+        if (!strcmp(attrName, "num_v_heads"))
+        {
+            TLLM_CHECK(fields[i].type == PluginFieldType::kINT32);
+            numVHeads = static_cast<int>(*(static_cast<int const*>(fields[i].data)));
+        }
+        else if (!strcmp(attrName, "head_k_dim"))
+        {
+            TLLM_CHECK(fields[i].type == PluginFieldType::kINT32);
+            headKDim = static_cast<int>(*(static_cast<int const*>(fields[i].data)));
+        }
+        else if (!strcmp(attrName, "head_v_dim"))
+        {
+            TLLM_CHECK(fields[i].type == PluginFieldType::kINT32);
+            headVDim = static_cast<int>(*(static_cast<int const*>(fields[i].data)));
+        }
+        else if (!strcmp(attrName, "chunk_size"))
+        {
+            TLLM_CHECK(fields[i].type == PluginFieldType::kINT32);
+            chunkSize = static_cast<int>(*(static_cast<int const*>(fields[i].data)));
+        }
+        else if (!strcmp(attrName, "use_qk_l2norm"))
+        {
+            TLLM_CHECK(fields[i].type == PluginFieldType::kINT8);
+            useQkL2norm = static_cast<bool>(*(static_cast<bool const*>(fields[i].data)));
+        }
+        else if (!strcmp(attrName, "type_id"))
+        {
+            TLLM_CHECK(fields[i].type == PluginFieldType::kINT32);
+            type = static_cast<nvinfer1::DataType>(*(static_cast<nvinfer1::DataType const*>(fields[i].data)));
+        }
+        else if (!strcmp(attrName, "remove_input_padding"))
+        {
+            TLLM_CHECK(fields[i].type == PluginFieldType::kINT8);
+            removePadding = static_cast<bool>(*(static_cast<bool const*>(fields[i].data)));
+        }
+        else if (!strcmp(attrName, "paged_state"))
+        {
+            TLLM_CHECK(fields[i].type == PluginFieldType::kINT8);
+            pagedState = static_cast<bool>(*(static_cast<bool const*>(fields[i].data)));
+        }
+    }
+    try
+    {
+        auto* obj = new GatedDeltaNetPlugin(
+            numVHeads, headKDim, headVDim, chunkSize, useQkL2norm, type, removePadding, pagedState);
+        obj->setPluginNamespace(mNamespace.c_str());
+        return obj;
+    }
+    catch (std::exception const& e)
+    {
+        caughtError(e);
+    }
+    return nullptr;
+}
+
+IPluginV2* GatedDeltaNetPluginCreator::deserializePlugin(
+    char const* name, void const* serialData, size_t serialLength) noexcept
+{
+    // This object will be deleted when the network is destroyed, which will
+    // call GatedDeltaNetPlugin::destroy()
+    try
+    {
+        auto* obj = new GatedDeltaNetPlugin(serialData, serialLength);
+        obj->setPluginNamespace(mNamespace.c_str());
+        return obj;
+    }
+    catch (std::exception const& e)
+    {
+        caughtError(e);
+    }
+    return nullptr;
+}

--- a/cpp/tensorrt_llm/plugins/gatedDeltaNetPlugin/gatedDeltaNetPlugin.h
+++ b/cpp/tensorrt_llm/plugins/gatedDeltaNetPlugin/gatedDeltaNetPlugin.h
@@ -1,0 +1,230 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TRT_GATED_DELTA_NET_PLUGIN_H
+#define TRT_GATED_DELTA_NET_PLUGIN_H
+#include "tensorrt_llm/plugins/common/plugin.h"
+#include <cassert>
+#include <cstdint>
+
+namespace tensorrt_llm::plugins
+{
+// Gated DeltaNet (GDN) linear-attention recurrence plugin.
+//
+// A naive, correctness-first port of the GDN recurrence into the TensorRT
+// plugin framework. The recurrence is, per (batch b, v-head h), sequential over
+// tokens, with the recurrent state S[D_k, D_v] kept in fp32:
+//
+//   qn = l2norm(q_t) ; kn = l2norm(k_t)          # over D_k, eps = 1e-6
+//   qn *= 1 / sqrt(D_k)                           # SCALE on q only
+//   S  *= exp(g_t)                                # elementwise decay
+//   kvmem[j] = sum_i S[i,j] * kn[i]               # read with normalized key
+//   delta[j] = (v_t[j] - kvmem[j]) * beta_t       # correction
+//   S[i,j]  += kn[i] * delta[j]                   # rank-1 outer-product update
+//   y_t[j]   = sum_i S[i,j] * qn[i]               # read with scaled query (updated S)
+//
+// batch_size = num_ctx_requests or num_gen_requests
+//   num_ctx_requests = number of context requests (single sequence per request).
+//   num_gen_requests = number of generation requests (single sequence per request).
+// Cannot support beam search.
+//
+// inputs
+//     0.  q     [B, T, H_v, D_k] or [num_tokens, H_v, D_k] for remove_input_padding
+//     1.  k     same shape as q
+//     2.  v     [B, T, H_v, D_v] or [num_tokens, H_v, D_v] for remove_input_padding
+//     3.  g     [B, T, H_v]      or [num_tokens, H_v]      (log-decay, <= 0)
+//     4.  beta  [B, T, H_v]      or [num_tokens, H_v]      (in (0,1))
+//     5.  state_or_ptr [B, H_v, D_k, D_v] fp32, or host [1] int64 pointer for paged_state
+//     6.  host_request_types [B] int32. 0: context; 1: generation.
+//     7.  last_token_ids     [B] int32
+//     8.  host_context_lengths [B] int32, optional iff remove_input_padding
+//     9.  slot_mapping         [B] int32, optional iff paged_state
+// outputs
+//     0.  y             [B, T, H_v, D_v] or [num_tokens, H_v, D_v] for remove_input_padding
+//     1.  present_state [B, H_v, D_k, D_v] fp32, omitted iff paged_state (updated in place via ptr)
+
+// Parameters passed to the CUDA launcher. Kept POD so it can live in this header
+// shared between the plugin .cpp and the kernel .cu.
+struct GatedDeltaNetParams
+{
+    // sizes
+    int batch;     // B
+    int maxSeqLen; // T (max sequence length of the dense [B,T,...] tensors)
+    int numVHeads; // H_v
+    int headKDim;  // D_k
+    int headVDim;  // D_v
+
+    // device pointers (all fp32 unless noted)
+    void const* q;           // [B,T,H_v,D_k]
+    void const* k;           // [B,T,H_v,D_k]
+    void const* v;           // [B,T,H_v,D_v]
+    void const* g;           // [B,T,H_v]
+    void const* beta;        // [B,T,H_v]
+    void const* statePtrIn;  // [B,H_v,D_k,D_v] input recurrent state
+    int const* seqLens;      // [B] int32, per-request valid token count (gen => 1)
+    int const* hostReqTypes; // host [B] int32, 0: context, 1: generation
+
+    // outputs
+    void* y;           // [B,T,H_v,D_v]
+    void* statePtrOut; // [B,H_v,D_k,D_v] output recurrent state
+
+    bool useQkL2norm;  // whether to L2-normalize q,k inside the kernel
+};
+
+// Launcher implemented in gatedDeltaNetKernel.cu.
+void invokeGatedDeltaNet(GatedDeltaNetParams const& params, cudaStream_t stream);
+
+class GatedDeltaNetPlugin : public BasePlugin
+{
+public:
+    GatedDeltaNetPlugin(int numVHeads, int headKDim, int headVDim, int chunkSize, bool useQkL2norm,
+        nvinfer1::DataType type, bool removePadding, bool pagedState);
+
+    GatedDeltaNetPlugin(void const* data, size_t length);
+
+    ~GatedDeltaNetPlugin() override = default;
+
+    // IPluginV2DynamicExt Methods
+    nvinfer1::IPluginV2DynamicExt* clone() const noexcept override;
+    nvinfer1::DimsExprs getOutputDimensions(int outputIndex, nvinfer1::DimsExprs const* inputs, int nbInputs,
+        nvinfer1::IExprBuilder& exprBuilder) noexcept override;
+    bool supportsFormatCombination(
+        int pos, nvinfer1::PluginTensorDesc const* inOut, int nbInputs, int nbOutputs) noexcept override;
+    void configurePlugin(nvinfer1::DynamicPluginTensorDesc const* in, int nbInputs,
+        nvinfer1::DynamicPluginTensorDesc const* out, int nbOutputs) noexcept override;
+    size_t getWorkspaceSize(nvinfer1::PluginTensorDesc const* inputs, int nbInputs,
+        nvinfer1::PluginTensorDesc const* outputs, int nbOutputs) const noexcept override;
+    int enqueue(nvinfer1::PluginTensorDesc const* inputDesc, nvinfer1::PluginTensorDesc const* outputDesc,
+        void const* const* inputs, void* const* outputs, void* workspace, cudaStream_t stream) noexcept override;
+    template <typename T>
+    int enqueueImpl(nvinfer1::PluginTensorDesc const* inputDesc, nvinfer1::PluginTensorDesc const* outputDesc,
+        void const* const* inputs, void* const* outputs, void* workspace, cudaStream_t stream);
+
+    // IPluginV2Ext Methods
+    nvinfer1::DataType getOutputDataType(
+        int index, nvinfer1::DataType const* inputTypes, int nbInputs) const noexcept override;
+
+    // IPluginV2 Methods
+    char const* getPluginType() const noexcept override;
+    char const* getPluginVersion() const noexcept override;
+    int getNbOutputs() const noexcept override;
+    int initialize() noexcept override;
+    void terminate() noexcept override;
+    size_t getSerializationSize() const noexcept override;
+    void serialize(void* buffer) const noexcept override;
+    void destroy() noexcept override;
+
+    enum class RequestType : int32_t
+    {
+        kCONTEXT = 0,
+        kGENERATION = 1
+    };
+
+private:
+    using IndexType = std::int32_t;
+
+    IndexType getQIdx() const
+    {
+        return 0;
+    };
+
+    IndexType getKIdx() const
+    {
+        return 1;
+    };
+
+    IndexType getVIdx() const
+    {
+        return 2;
+    };
+
+    IndexType getGIdx() const
+    {
+        return 3;
+    };
+
+    IndexType getBetaIdx() const
+    {
+        return 4;
+    };
+
+    IndexType getStateIdx() const
+    {
+        return 5;
+    };
+
+    IndexType getHostRequestTypesIdx() const
+    {
+        return 6;
+    };
+
+    IndexType getLastTokenIdsIdx() const
+    {
+        return 7;
+    };
+
+    IndexType getHostContextLengthIdx() const
+    {
+        if (mRemovePadding)
+            return 8;
+        else
+            return 7;
+    };
+
+    IndexType getSlotMappingIdx() const
+    {
+        if (mPagedState)
+            return getHostContextLengthIdx() + 1;
+        else
+            return getHostContextLengthIdx();
+    };
+
+private:
+    int mNumVHeads;
+    int mHeadKDim;
+    int mHeadVDim;
+    int mChunkSize;
+    bool mUseQkL2norm;
+    nvinfer1::DataType mType;
+    bool mRemovePadding = false;
+    bool mPagedState = false;
+};
+
+class GatedDeltaNetPluginCreator : public BaseCreator
+{
+public:
+    GatedDeltaNetPluginCreator();
+
+    char const* getPluginName() const noexcept override;
+
+    char const* getPluginVersion() const noexcept override;
+
+    nvinfer1::PluginFieldCollection const* getFieldNames() noexcept override;
+
+    nvinfer1::IPluginV2* createPlugin(char const* name, nvinfer1::PluginFieldCollection const* fc) noexcept override;
+
+    nvinfer1::IPluginV2* deserializePlugin(
+        char const* name, void const* serialData, size_t serialLength) noexcept override;
+
+private:
+    static nvinfer1::PluginFieldCollection mFC;
+    static std::vector<nvinfer1::PluginField> mPluginAttributes;
+};
+
+} // namespace tensorrt_llm::plugins
+
+#endif // TRT_GATED_DELTA_NET_PLUGIN_H

--- a/cpp/tensorrt_llm/runtime/gptJsonConfig.cpp
+++ b/cpp/tensorrt_llm/runtime/gptJsonConfig.cpp
@@ -646,6 +646,13 @@ GptJsonConfig parseJson(InputType&& input)
         {
             modelConfig.setModelVariant(ModelConfig::ModelVariant::kRecurrentGemma);
         }
+        else if (architecture == std::string("Qwen3_5MoeForConditionalGeneration")
+            || architecture == std::string("Qwen3NextForCausalLM"))
+        {
+            // Qwen3.5/3.6 hybrid: Gated DeltaNet (linear attention) layers reuse the
+            // paged RNN/conv state path; full-attention layers use the KV cache.
+            modelConfig.setModelVariant(ModelConfig::ModelVariant::kQwen3Next);
+        }
         if (modelConfig.isRnnBased())
         {
             auto const& stateSize = pretrainedConfig.at("state_size").template get<SizeType32>();

--- a/tensorrt_llm/functional.py
+++ b/tensorrt_llm/functional.py
@@ -7178,6 +7178,124 @@ def selective_scan(input: Tensor,
         return output, present_state
 
 
+def gated_delta_rule(q: Tensor,
+                     k: Tensor,
+                     v: Tensor,
+                     g: Tensor,
+                     beta: Tensor,
+                     state_or_ptr: Tensor,
+                     host_request_types: Tensor,
+                     last_token_ids: Tensor,
+                     num_v_heads: int,
+                     head_k_dim: int,
+                     head_v_dim: int,
+                     chunk_size: int = 64,
+                     use_qk_l2norm: bool = True,
+                     dtype: str = 'float32',
+                     host_context_lengths: Optional[Tensor] = None,
+                     slot_mapping: Optional[Tensor] = None):
+    """Gated DeltaNet (Qwen3-Next linear attention) recurrence.
+
+    Binds the ``GatedDeltaNet`` TensorRT plugin. The recurrent state is a
+    per-(request, v-head) matrix ``[head_k_dim, head_v_dim]`` carried across
+    context/generation phases via the paged RNN-state path (like Mamba/RG-LRU).
+    The depthwise causal conv is handled separately by ``mamba_conv1d``; this op
+    consumes the post-conv, head-split ``q/k/v`` and the per-head ``g``/``beta``.
+
+    Parameters:
+        q : Tensor (On GPU)
+            Query. Shape ``[batch, seq_len, num_v_heads, head_k_dim]`` or
+            ``[num_tokens, num_v_heads, head_k_dim]`` for remove_input_padding.
+        k : Tensor (On GPU)
+            Key. Same shape as ``q`` (GQA already expanded to ``num_v_heads``).
+        v : Tensor (On GPU)
+            Value. ``[batch, seq_len, num_v_heads, head_v_dim]`` or packed.
+        g : Tensor (On GPU)
+            Per-head log-decay (``<= 0``). ``[batch, seq_len, num_v_heads]``.
+        beta : Tensor (On GPU)
+            Per-head update gate in ``(0, 1)``. ``[batch, seq_len, num_v_heads]``.
+        state_or_ptr : Tensor (On GPU or CPU)
+            The recurrent state ``[batch, num_v_heads, head_k_dim, head_v_dim]``
+            in float32, or a CPU ``[1]`` int64 pointer for paged state.
+        host_request_types : Tensor (On CPU)
+            ``[batch]`` int32. 0: context; 1: generation.
+        last_token_ids : Tensor (On GPU)
+            The inclusive prefix-sum of the lengths or the lengths of the
+            sequences in the batch.
+        num_v_heads, head_k_dim, head_v_dim : int
+            GDN head configuration.
+        chunk_size : int
+            Prefill chunk size (kernel attribute).
+        use_qk_l2norm : bool
+            Whether to L2-normalize q,k over ``head_k_dim`` inside the kernel.
+        dtype : str
+            Compute dtype (state is always float32).
+        host_context_lengths : Tensor (On CPU) (Optional)
+            Required for remove_input_padding.
+        slot_mapping : Tensor (On GPU) (Optional)
+            Required for paged_state.
+
+    Returns:
+        (output, present_state). ``output`` has the value-head shape of ``v``;
+        ``present_state`` is ``None`` when paged_state (updated in place).
+    """
+    assert host_request_types is not None
+    gdn_plg_creator = trt.get_plugin_registry().get_plugin_creator(
+        'GatedDeltaNet', '1', TRT_LLM_PLUGIN_NAMESPACE)
+    assert gdn_plg_creator is not None
+
+    num_v_heads = trt.PluginField("num_v_heads",
+                                  np.array(num_v_heads, dtype=np.int32),
+                                  trt.PluginFieldType.INT32)
+    head_k_dim = trt.PluginField("head_k_dim",
+                                 np.array(head_k_dim, dtype=np.int32),
+                                 trt.PluginFieldType.INT32)
+    head_v_dim = trt.PluginField("head_v_dim",
+                                 np.array(head_v_dim, dtype=np.int32),
+                                 trt.PluginFieldType.INT32)
+    chunk_size = trt.PluginField("chunk_size",
+                                 np.array(chunk_size, dtype=np.int32),
+                                 trt.PluginFieldType.INT32)
+    use_qk_l2norm = trt.PluginField(
+        "use_qk_l2norm", np.array(np.int8(use_qk_l2norm), dtype=np.int8),
+        trt.PluginFieldType.INT8)
+    pf_type = trt.PluginField(
+        "type_id", np.array([int(str_dtype_to_trt(dtype))], np.int32),
+        trt.PluginFieldType.INT32)
+    remove_input_padding = trt.PluginField(
+        "remove_input_padding",
+        np.array(np.int8(default_net().plugin_config.remove_input_padding),
+                 dtype=np.int8), trt.PluginFieldType.INT8)
+    paged_state = trt.PluginField(
+        "paged_state",
+        np.array(np.int8(default_net().plugin_config.paged_state),
+                 dtype=np.int8), trt.PluginFieldType.INT8)
+
+    pfc = trt.PluginFieldCollection([
+        num_v_heads, head_k_dim, head_v_dim, chunk_size, use_qk_l2norm, pf_type,
+        remove_input_padding, paged_state
+    ])
+    gdn_plug = gdn_plg_creator.create_plugin("gated_delta_rule", pfc)
+
+    plug_inputs = [
+        q, k, v, g, beta, state_or_ptr, host_request_types, last_token_ids
+    ]
+    if default_net().plugin_config.remove_input_padding:
+        plug_inputs += [host_context_lengths]
+    if default_net().plugin_config.paged_state:
+        plug_inputs += [slot_mapping]
+    plug_inputs = [i.trt_tensor for i in plug_inputs]
+
+    layer = default_trtnet().add_plugin_v2(plug_inputs, gdn_plug)
+    _add_plugin_info(layer, gdn_plg_creator, "gated_delta_rule", pfc)
+    output = _create_tensor(layer.get_output(0), layer)
+    if default_net().plugin_config.paged_state:
+        return output, None
+    else:
+        present_state = _create_tensor(layer.get_output(1), layer)
+        return output, present_state
+
+
 def rg_lru(input: Tensor,
            A: Tensor,
            state_or_ptr: Tensor,

--- a/tensorrt_llm/layers/attention.py
+++ b/tensorrt_llm/layers/attention.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -366,6 +366,7 @@ class Attention(Module):
                  layernorm_type=LayerNormType.LayerNorm,
                  layernorm_share=True,
                  inner_layernorm=False,
+                 attn_output_gate=False,
                  eps=1e-05,
                  attention_mask_type=AttentionMaskType.padding,
                  bias=True,
@@ -530,6 +531,25 @@ class Attention(Module):
                                dtype=dtype,
                                tp_group=tp_group,
                                tp_size=tp_size)
+
+        # Optional sigmoid output gate on the attention output (Qwen3-Next /
+        # Qwen3.5-MoE ``attn_output_gate``). In HF this is fused into a doubled
+        # q projection; on the engine path the converter de-interleaves the
+        # gate half into this separate projection. ``gate`` shards over heads
+        # exactly like Q (ColumnLinear, gather_output=False) so the elementwise
+        # ``context * sigmoid(gate)`` stays per-rank-consistent, and the real
+        # ``dense`` (o_proj) below still owns the single TP all-reduce and the
+        # FP8 output-quant wiring (set_fp8_context_fmha keys on ``self.dense``).
+        self.attn_output_gate = attn_output_gate
+        if self.attn_output_gate:
+            self.gate = ColumnLinear(hidden_size,
+                                     tp_size * self.num_attention_heads *
+                                     self.attention_head_size,
+                                     bias=bias,
+                                     dtype=dtype,
+                                     tp_group=tp_group,
+                                     tp_size=tp_size,
+                                     gather_output=False)
 
         # see optimize_model's add_lora for LoRA initialization
         self.qkv_lora = None
@@ -1587,6 +1607,30 @@ class Attention(Module):
 
         if self.inner_layernorm is not None:
             context = self.inner_layernorm(context)
+        if self.attn_output_gate:
+            # Qwen3-Next / Qwen3.5-MoE output gate: context * sigmoid(gate),
+            # applied on the pre-dense context (post-plugin, head-sharded under
+            # TP) so the elementwise multiply lines up with ``self.gate``'s
+            # matching per-rank Q-head shard, then ``self.dense`` (o_proj) does
+            # the single all-reduce. ``attention_input`` is the module input
+            # hidden_states (the gate is a projection of the layer input).
+            gate = ACT2FN['sigmoid'](self.gate(attention_input))
+            # The gpt_attention plugin can emit its context already quantized to
+            # FP8 (so a downstream FP8 ``dense`` consumes it directly). FP8 can't
+            # be an elementwise-PROD operand, and TRT only lets an FP8 tensor be
+            # consumed by a Dequantize/plugin layer -- so dequantize the context
+            # back to the gate dtype using ``dense``'s activation scale, apply the
+            # gate, and let ``dense`` re-quantize its (now model-dtype) input.
+            if context.dtype == trt.fp8 and context.dtype != gate.dtype:
+                deq_scale = getattr(self.dense, 'activation_scaling_factor',
+                                    None)
+                assert deq_scale is not None, (
+                    "FP8 attention context requires the dense activation scale "
+                    "to dequantize before the attn_output_gate multiply.")
+                context = dequantize(context, deq_scale.value, -1, gate.dtype)
+            elif context.dtype != gate.dtype:
+                context = context.cast(gate.dtype)
+            context = context * gate
         context = self.dense(context,
                              lora_runtime_params=dense_lora_params,
                              all_reduce_params=all_reduce_params)

--- a/tensorrt_llm/models/__init__.py
+++ b/tensorrt_llm/models/__init__.py
@@ -58,6 +58,8 @@ from .nemotron_nas.model import DeciLMForCausalLM
 from .opt.model import OPTForCausalLM, OPTModel
 from .phi3.model import Phi3ForCausalLM, Phi3Model
 from .phi.model import PhiForCausalLM, PhiModel
+from .qwen3_next.config import Qwen3NextConfig
+from .qwen3_next.model import Qwen3NextForCausalLM
 from .qwen.model import QWenForCausalLM
 from .recurrentgemma.model import RecurrentGemmaForCausalLM
 from .redrafter.model import ReDrafterForLLaMALM, ReDrafterForQWenLM
@@ -113,6 +115,8 @@ __all__ = [
     'QWenConfig'
     'QWenForCausalLM',
     'QWenModel',
+    'Qwen3NextConfig',
+    'Qwen3NextForCausalLM',
     'EncoderModel',
     'DecoderModel',
     'PretrainedConfig',
@@ -197,6 +201,8 @@ MODEL_MAP = {
     'Qwen2VLModel': QWenForCausalLM,
     'Qwen3ForCausalLM': QWenForCausalLM,
     'Qwen3MoeForCausalLM': QWenForCausalLM,
+    'Qwen3_5MoeForConditionalGeneration': Qwen3NextForCausalLM,
+    'Qwen3NextForCausalLM': Qwen3NextForCausalLM,
     'WhisperEncoder': WhisperEncoder,
     'EncoderModel': EncoderModel,
     'DecoderModel': DecoderModel,

--- a/tensorrt_llm/models/qwen3_next/__init__.py
+++ b/tensorrt_llm/models/qwen3_next/__init__.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Engine-path support for the Qwen3.5/Qwen3.6 hybrid MoE family.
+
+This package targets the *classic TensorRT-engine* flow (convert checkpoint ->
+``trtllm-build`` -> serialized ``.engine``) for checkpoints whose HF
+``architectures[0]`` is ``Qwen3_5MoeForConditionalGeneration`` (``model_type``
+``qwen3_5_moe``), e.g. ``nvidia/Qwen3.6-35B-A3B-NVFP4``.
+
+The architecture is a Qwen3-Next-style hybrid: a 3:1 interleave of Gated
+DeltaNet "linear attention" layers and full-attention layers, with a 256-expert
+MoE (plus shared expert) per layer. This initial engine-path drop covers the
+text-generation path; the MTP head and the Qwen3-VL vision tower are not built
+here.
+"""
+
+from .config import Qwen3NextConfig
+from .model import Qwen3NextForCausalLM
+
+__all__ = [
+    "Qwen3NextConfig",
+    "Qwen3NextForCausalLM",
+]

--- a/tensorrt_llm/models/qwen3_next/config.py
+++ b/tensorrt_llm/models/qwen3_next/config.py
@@ -1,0 +1,392 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import TYPE_CHECKING, List, Optional, Union
+
+from ...layers import MoeConfig
+from ...mapping import Mapping
+from ..convert_utils import infer_dtype
+from ..modeling_utils import PretrainedConfig, QuantConfig
+
+if TYPE_CHECKING:
+    import transformers
+
+
+def _get_rope_theta(text_cfg: dict, default: float = 10000000.0) -> float:
+    """RoPE ``theta`` from a (possibly v5-nested) HF text config dict.
+
+    Transformers v5+ nests ``rope_theta`` under ``rope_parameters``; older
+    releases expose ``rope_theta`` directly. Inlined here so this module does
+    not depend on ``tensorrt_llm._utils.get_hf_rope_theta``, which is absent in
+    older installed wheels.
+    """
+    theta = text_cfg.get("rope_theta")
+    if theta is not None:
+        return float(theta)
+    rope_params = text_cfg.get("rope_parameters")
+    if isinstance(rope_params, dict) and rope_params.get("rope_theta") is not None:
+        return float(rope_params["rope_theta"])
+    return default
+
+
+# Layer-type tokens used by the HF ``qwen3_5_moe`` / Qwen3-Next configs.
+LINEAR_ATTENTION = "linear_attention"
+FULL_ATTENTION = "full_attention"
+
+
+class Qwen3NextConfig(PretrainedConfig):
+    """Engine-path config for the Qwen3.5/Qwen3.6 hybrid MoE family.
+
+    Parses the nested HF ``config.json`` (``text_config`` + ``vision_config`` +
+    ``quantization_config``) into the flat field set the TensorRT-LLM engine
+    builder expects, while preserving the hybrid layer pattern (``layer_types``)
+    and the Gated DeltaNet ("linear attention") parameters needed to build the
+    recurrent layers.
+
+    Only the *text decoder* fields are consumed by the engine model today. The
+    vision-tower and MTP fields are parsed and stored so the converter can carry
+    those weights, but building/running them is not yet supported on the engine
+    path.
+    """
+
+    def __init__(
+        self,
+        *,
+        # --- hybrid layer pattern ---
+        layer_types: Optional[List[str]] = None,
+        full_attention_interval: int = 4,
+        # --- full attention ---
+        attn_bias: bool = False,
+        attn_output_gate: bool = True,
+        rotary_base: float = 10000000.0,
+        rotary_scaling: Optional[dict] = None,
+        partial_rotary_factor: float = 0.25,
+        mrope_section: Optional[List[int]] = None,
+        mrope_interleaved: bool = True,
+        # --- gated deltanet (linear attention) ---
+        linear_conv_kernel_dim: int = 4,
+        linear_key_head_dim: int = 128,
+        linear_num_key_heads: int = 16,
+        linear_num_value_heads: int = 32,
+        linear_value_head_dim: int = 128,
+        mamba_ssm_dtype: str = "float32",
+        # --- moe ---
+        moe: Optional[Union[MoeConfig, dict]] = None,
+        moe_intermediate_size: int = 0,
+        moe_shared_expert_intermediate_size: int = 0,
+        # --- mtp ---
+        mtp_num_hidden_layers: int = 0,
+        mtp_use_dedicated_embeddings: bool = False,
+        # --- multimodal ---
+        vision_config: Optional[dict] = None,
+        image_token_id: Optional[int] = None,
+        video_token_id: Optional[int] = None,
+        vision_start_token_id: Optional[int] = None,
+        vision_end_token_id: Optional[int] = None,
+        **kwargs,
+    ):
+        # Keep the canonical HF vocabulary internally (``linear_attention`` /
+        # ``full_attention``) so the Python build's per-layer dispatch works. But
+        # tolerate the C++-runtime vocabulary too: a round-trip rebuild from a
+        # saved TRT-LLM checkpoint would otherwise feed back the translated
+        # ``recurrent``/``attention`` strings (emitted by ``to_dict`` for the C++
+        # ``buildLayerTypes`` parser) and silently build an all-attention model.
+        _runtime_to_canonical = {
+            "recurrent": LINEAR_ATTENTION,
+            "attention": FULL_ATTENTION,
+        }
+        self.layer_types = [_runtime_to_canonical.get(t, t) for t in (layer_types or [])]
+        self.full_attention_interval = full_attention_interval
+
+        self.attn_bias = attn_bias
+        self.attn_output_gate = attn_output_gate
+        self.rotary_base = rotary_base
+        self.rotary_scaling = rotary_scaling
+        self.partial_rotary_factor = partial_rotary_factor
+        # ``Attention.create_attention_const_params`` reads the rotary fraction
+        # as ``config.rotary_pct`` (the RecurrentGemma/engine convention),
+        # defaulting to 1.0 (FULL RoPE) when absent. The HF checkpoint expresses
+        # it as ``partial_rotary_factor`` (0.25 -> rotary_dim 64), so expose the
+        # alias too — without it the gpt_attention RoPE const params (baked into
+        # the engine) use the wrong rotary dimension and the model emits
+        # gibberish (Q/K rotated over 256 dims instead of 64).
+        self.rotary_pct = partial_rotary_factor
+        self.mrope_section = mrope_section
+        self.mrope_interleaved = mrope_interleaved
+
+        self.linear_conv_kernel_dim = linear_conv_kernel_dim
+        self.linear_key_head_dim = linear_key_head_dim
+        self.linear_num_key_heads = linear_num_key_heads
+        self.linear_num_value_heads = linear_num_value_heads
+        self.linear_value_head_dim = linear_value_head_dim
+        self.mamba_ssm_dtype = mamba_ssm_dtype
+
+        self.moe_intermediate_size = moe_intermediate_size
+        self.moe_shared_expert_intermediate_size = moe_shared_expert_intermediate_size
+        if moe is None:
+            moe = MoeConfig(
+                num_experts=kwargs.pop("moe_num_experts", 0),
+                top_k=kwargs.pop("moe_top_k", 0),
+                normalization_mode=MoeConfig.ExpertScaleNormalizationMode.NONE,
+            )
+        elif isinstance(moe, dict):
+            moe = MoeConfig.from_dict(moe)
+        assert isinstance(moe, MoeConfig)
+        self.moe = moe.validate()
+
+        self.mtp_num_hidden_layers = mtp_num_hidden_layers
+        self.mtp_use_dedicated_embeddings = mtp_use_dedicated_embeddings
+
+        self.vision_config = vision_config
+        self.image_token_id = image_token_id
+        self.video_token_id = video_token_id
+        self.vision_start_token_id = vision_start_token_id
+        self.vision_end_token_id = vision_end_token_id
+
+        super().__init__(**kwargs)
+
+        # Recurrent-state runtime fields consumed by the C++ RnnConfig parse
+        # (gptJsonConfig.cpp, gated by isRnnBased()/ModelVariant::kQwen3Next).
+        # Derived from the Gated DeltaNet linear_* dims; the same names + meaning
+        # Mamba uses (models/mamba/config.py). Set AFTER super().__init__ so they
+        # always win over any same-named value leaked in via **kwargs on a
+        # checkpoint round-trip. They serialize automatically through the base
+        # ``to_dict`` (deepcopy of __dict__) and are inert to the Python build
+        # (only the C++ recurrent-state runtime reads them). For GDN layer-0:
+        # state_size 128 / conv_kernel 4 / rnn_hidden_size 4096 / rnn_head_size
+        # 128 / rnn_conv_dim_size 8192 -> rnn state [L,S,32,128,128], conv state
+        # [L,S,3,8192] (matches the engine's past_rnn_state / past_conv_state).
+        key_dim = self.linear_num_key_heads * self.linear_key_head_dim
+        value_dim = self.linear_num_value_heads * self.linear_value_head_dim
+        self.state_size = self.linear_key_head_dim
+        self.conv_kernel = self.linear_conv_kernel_dim
+        self.rnn_hidden_size = value_dim
+        self.rnn_head_size = self.linear_value_head_dim
+        self.rnn_conv_dim_size = 2 * key_dim + value_dim
+
+    # ------------------------------------------------------------------
+    # Per-layer helpers (hybrid pattern)
+    # ------------------------------------------------------------------
+    def is_linear_attention_layer(self, layer_idx: int) -> bool:
+        """Whether ``layer_idx`` is a Gated DeltaNet (linear attention) layer."""
+        return self.get_layer_type(layer_idx) == LINEAR_ATTENTION
+
+    def get_layer_type(self, layer_idx: int) -> str:
+        if self.layer_types:
+            return self.layer_types[layer_idx % len(self.layer_types)]
+        # Fall back to the interval rule used by the HF config.
+        is_full = (layer_idx + 1) % self.full_attention_interval == 0
+        return FULL_ATTENTION if is_full else LINEAR_ATTENTION
+
+    @property
+    def has_vision(self) -> bool:
+        return self.vision_config is not None
+
+    @property
+    def has_mtp(self) -> bool:
+        return self.mtp_num_hidden_layers > 0
+
+    def to_dict(self):
+        output = super().to_dict()
+        # NOTE: 'layer_types' is intentionally NOT in this list — it is emitted
+        # below, translated to the C++ runtime vocabulary. The 5 recurrent-state
+        # fields (state_size/conv_kernel/rnn_hidden_size/rnn_head_size/
+        # rnn_conv_dim_size) are NOT listed either: they ride the base
+        # ``to_dict``'s deepcopy of ``__dict__`` (the Mamba pattern), and this
+        # explicit loop only overwrites the keys it names, so it never clobbers
+        # them.
+        for f in [
+            "full_attention_interval",
+            "attn_bias",
+            "attn_output_gate",
+            "rotary_base",
+            "rotary_scaling",
+            "partial_rotary_factor",
+            "rotary_pct",
+            "mrope_section",
+            "mrope_interleaved",
+            "linear_conv_kernel_dim",
+            "linear_key_head_dim",
+            "linear_num_key_heads",
+            "linear_num_value_heads",
+            "linear_value_head_dim",
+            "mamba_ssm_dtype",
+            "moe_intermediate_size",
+            "moe_shared_expert_intermediate_size",
+            "mtp_num_hidden_layers",
+            "mtp_use_dedicated_embeddings",
+            "vision_config",
+            "image_token_id",
+            "video_token_id",
+            "vision_start_token_id",
+            "vision_end_token_id",
+        ]:
+            output[f] = getattr(self, f)
+        output["moe"] = self.moe.to_dict()
+        # Translate layer_types to the C++ runtime vocabulary. The C++
+        # ``buildLayerTypes`` (gptJsonConfig.cpp) only recognizes
+        # attention/recurrent/linear/no_op; unknown strings -> WARNING + default
+        # attention. The 30 Gated DeltaNet (linear_attention) layers are the
+        # recurrent/conv-state path -> 'recurrent'; the 10 full_attention layers
+        # use the KV cache -> 'attention'. We translate ONLY here, leaving the
+        # in-memory ``self.layer_types`` canonical so the Python build is intact.
+        _canonical_to_runtime = {
+            LINEAR_ATTENTION: "recurrent",
+            FULL_ATTENTION: "attention",
+        }
+        output["layer_types"] = [_canonical_to_runtime.get(t, t) for t in self.layer_types]
+        return output
+
+    @classmethod
+    def from_hugging_face(
+        cls,
+        hf_config_or_dir: Union[str, "transformers.PretrainedConfig"],
+        dtype: str = "auto",
+        mapping: Optional[Mapping] = None,
+        quant_config: Optional[QuantConfig] = None,
+        **kwargs,
+    ) -> "Qwen3NextConfig":
+        import json
+        import os
+
+        import transformers
+
+        trust_remote_code = kwargs.pop("trust_remote_code", True)
+
+        if isinstance(hf_config_or_dir, transformers.PretrainedConfig):
+            hf_dict = hf_config_or_dir.to_dict()
+        else:
+            # The Qwen3.5/3.6 ``qwen3_5_moe`` arch may be newer than the
+            # installed transformers, in which case ``AutoConfig`` raises.
+            # The engine path only needs the config dict, so read config.json
+            # directly when AutoConfig cannot recognize the model type.
+            cfg_dir = str(hf_config_or_dir)
+            try:
+                hf_config = transformers.AutoConfig.from_pretrained(
+                    cfg_dir, trust_remote_code=trust_remote_code
+                )
+                hf_dict = hf_config.to_dict()
+            except (ValueError, KeyError):
+                cfg_path = (
+                    cfg_dir if cfg_dir.endswith(".json") else os.path.join(cfg_dir, "config.json")
+                )
+                with open(cfg_path) as f:
+                    hf_dict = json.load(f)
+        # Top-level multimodal wrapper -> text_config holds the decoder.
+        text_cfg = hf_dict.get("text_config", hf_dict)
+        vision_cfg = hf_dict.get("vision_config", None)
+        hf_quant_cfg = hf_dict.get("quantization_config")
+
+        arch = hf_dict.get("architectures", ["Qwen3_5MoeForConditionalGeneration"])[0]
+
+        head_dim = text_cfg.get(
+            "head_dim", text_cfg["hidden_size"] // text_cfg["num_attention_heads"]
+        )
+
+        rope_params = text_cfg.get("rope_parameters", {}) or {}
+        rotary_base = _get_rope_theta(text_cfg, 10000000.0)
+        partial_rotary_factor = rope_params.get("partial_rotary_factor") or text_cfg.get(
+            "partial_rotary_factor", 1.0
+        )
+        mrope_section = rope_params.get("mrope_section")
+        mrope_interleaved = rope_params.get("mrope_interleaved", False)
+        rotary_scaling = text_cfg.get("rope_scaling", None)
+
+        dtype = infer_dtype(dtype, text_cfg.get("dtype") or text_cfg.get("torch_dtype"))
+
+        moe_config = MoeConfig(
+            num_experts=text_cfg.get("num_experts", 0),
+            top_k=text_cfg.get("num_experts_per_tok", 0),
+            normalization_mode=MoeConfig.ExpertScaleNormalizationMode.NONE,
+        )
+        moe_config.validate()
+
+        # Mixed-precision (FP8 attention + NVFP4 MoE/lm_head + bf16 MTP/vision)
+        # quant ingestion. An explicitly-supplied ``quant_config``
+        # takes precedence; otherwise parse the checkpoint's modelopt
+        # ``quantization_config`` into a per-layer ``LayerQuantConfig`` so the
+        # engine builds real FP8/NVFP4 weights (not a silent bf16 fallback).
+        quantization = quant_config
+        if (
+            quantization is None
+            and isinstance(hf_quant_cfg, dict)
+            and hf_quant_cfg.get("quant_algo") == "MIXED_PRECISION"
+        ):
+            from .convert import build_layer_quant_config
+
+            num_layers = text_cfg["num_hidden_layers"]
+            layer_types = text_cfg.get("layer_types")
+            full_attn_interval = text_cfg.get("full_attention_interval", 4)
+
+            def _is_linear(layer_idx: int) -> bool:
+                if layer_types:
+                    return layer_types[layer_idx % len(layer_types)] == LINEAR_ATTENTION
+                return (layer_idx + 1) % full_attn_interval != 0
+
+            quantization = build_layer_quant_config(hf_quant_cfg, num_layers, _is_linear)
+
+        return cls(
+            architecture=arch,
+            dtype=dtype,
+            # core dims
+            num_hidden_layers=text_cfg["num_hidden_layers"],
+            num_attention_heads=text_cfg["num_attention_heads"],
+            num_key_value_heads=text_cfg.get("num_key_value_heads"),
+            hidden_size=text_cfg["hidden_size"],
+            intermediate_size=text_cfg.get(
+                "intermediate_size", text_cfg.get("moe_intermediate_size")
+            ),
+            head_size=head_dim,
+            vocab_size=text_cfg["vocab_size"],
+            max_position_embeddings=text_cfg.get("max_position_embeddings"),
+            norm_epsilon=text_cfg.get("rms_norm_eps", 1e-6),
+            hidden_act="swiglu",
+            tie_word_embeddings=text_cfg.get("tie_word_embeddings", False),
+            # hybrid pattern
+            layer_types=text_cfg.get("layer_types"),
+            full_attention_interval=text_cfg.get("full_attention_interval", 4),
+            # full attention
+            attn_bias=text_cfg.get("attention_bias", False),
+            attn_output_gate=text_cfg.get("attn_output_gate", True),
+            position_embedding_type="rope_gpt_neox",
+            rotary_base=rotary_base,
+            rotary_scaling=rotary_scaling,
+            partial_rotary_factor=partial_rotary_factor,
+            mrope_section=mrope_section,
+            mrope_interleaved=mrope_interleaved,
+            qk_layernorm=True,
+            # gated deltanet
+            linear_conv_kernel_dim=text_cfg.get("linear_conv_kernel_dim", 4),
+            linear_key_head_dim=text_cfg.get("linear_key_head_dim", 128),
+            linear_num_key_heads=text_cfg.get("linear_num_key_heads", 16),
+            linear_num_value_heads=text_cfg.get("linear_num_value_heads", 32),
+            linear_value_head_dim=text_cfg.get("linear_value_head_dim", 128),
+            mamba_ssm_dtype=text_cfg.get("mamba_ssm_dtype", "float32"),
+            # moe
+            moe=moe_config,
+            moe_intermediate_size=text_cfg.get("moe_intermediate_size", 0),
+            moe_shared_expert_intermediate_size=text_cfg.get("shared_expert_intermediate_size", 0),
+            # mtp
+            mtp_num_hidden_layers=text_cfg.get("mtp_num_hidden_layers", 0),
+            mtp_use_dedicated_embeddings=text_cfg.get("mtp_use_dedicated_embeddings", False),
+            # multimodal
+            vision_config=vision_cfg,
+            image_token_id=hf_dict.get("image_token_id"),
+            video_token_id=hf_dict.get("video_token_id"),
+            vision_start_token_id=hf_dict.get("vision_start_token_id"),
+            vision_end_token_id=hf_dict.get("vision_end_token_id"),
+            mapping=mapping,
+            quantization=quantization,
+            **kwargs,
+        )

--- a/tensorrt_llm/models/qwen3_next/convert.py
+++ b/tensorrt_llm/models/qwen3_next/convert.py
@@ -1,0 +1,450 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Checkpoint conversion for Qwen3.5/Qwen3.6 hybrid MoE.
+
+Maps the HF safetensors (text decoder) to the TensorRT-LLM engine checkpoint,
+including the per-layer mixed-precision quant scoping (attention projections =
+FP8, MoE/shared-expert/lm_head = W4A16_NVFP4 group_size 16). The pre-quantized
+ModelOpt scale tensors (``weight_scale``, ``weight_scale_2``, ``input_scale``)
+are renamed to the TRT-LLM names consumed by ``preprocess_perlayer_weights`` so
+the engine builds real NVFP4 weights (not a bf16 fallback).
+"""
+
+from typing import TYPE_CHECKING, Callable, Tuple
+
+from ...quantization.mode import QuantAlgo
+from ..modeling_utils import LayerQuantConfig, QuantConfig
+
+if TYPE_CHECKING:
+    import torch
+
+
+def split_attn_output_gate(
+    q_proj_weight: "torch.Tensor", num_heads: int, head_dim: int
+) -> Tuple["torch.Tensor", "torch.Tensor"]:
+    """De-interleave a gate-doubled ``q_proj`` into real-Q and gate rows.
+
+    For a Qwen3-Next / Qwen3.5-MoE full-attention layer, split the doubled
+    ``q_proj`` into its real-Q rows and its ``attn_output_gate`` rows.
+
+    In the HF checkpoint the attention output gate is fused into a single
+    doubled projection ``q_proj.weight`` of shape
+    ``[2 * num_heads * head_dim, hidden]``. The doubling is **per head and
+    interleaved**: viewing the rows as ``[num_heads, 2 * head_dim, hidden]``,
+    the first ``head_dim`` rows of each head are the real query projection and
+    the next ``head_dim`` rows are the gate projection. (This matches HF
+    ``Qwen3_5MoeAttention``: ``q_proj(h).view(..., num_heads, head_dim*2)`` then
+    ``chunk(2, dim=-1)``.)
+
+    A naive split at the tensor midpoint (``[:num_heads*head_dim]`` /
+    ``[num_heads*head_dim:]``) would be WRONG — it would interleave heads. The
+    per-head de-interleave below produces **head-major** real-Q rows (feeding
+    the fused ``attention.qkv`` Q-section) and **head-major** gate rows (feeding
+    ``attention.gate.weight``), the order the engine ``Attention`` and its
+    gpt_attention context expect.
+
+    Matches the per-head ``q_proj(h).view(..., num_heads, head_dim*2).chunk(2,
+    dim=-1)`` split in HF ``Qwen3_5MoeAttention``.
+
+    Args:
+        q_proj_weight: HF ``self_attn.q_proj.weight``,
+            shape ``[2 * num_heads * head_dim, hidden]``.
+        num_heads: number of query heads (e.g. 16).
+        head_dim: per-head dimension (e.g. 256).
+
+    Returns:
+        ``(q_weight, gate_weight)`` each shape ``[num_heads * head_dim, hidden]``,
+        head-major and contiguous.
+
+    Note: this operates on the raw weight rows; for the FP8-quantized
+    checkpoint the per-tensor ``weight_scale``/``input_scale`` apply uniformly
+    to both halves (a single scale on the whole ``q_proj``), so the caller may
+    split before or after dequantization. The fused-QKV FP8 re-scaling across
+    q/k/v is handled by the weight loader, not here.
+    """
+    hidden = q_proj_weight.shape[-1]
+    expected = 2 * num_heads * head_dim
+    assert q_proj_weight.shape[0] == expected, (
+        f"q_proj rows {q_proj_weight.shape[0]} != 2*num_heads*head_dim "
+        f"({expected}); attn_output_gate expects a doubled q projection"
+    )
+    qp = q_proj_weight.view(num_heads, 2 * head_dim, hidden)
+    q_weight = qp[:, :head_dim, :].reshape(num_heads * head_dim, hidden)
+    gate_weight = qp[:, head_dim:, :].reshape(num_heads * head_dim, hidden)
+    return q_weight.contiguous(), gate_weight.contiguous()
+
+
+# HF (modelopt) ``quant_algo`` strings -> TRT-LLM ``QuantAlgo``. The MoE/lm_head
+# pieces are tagged ``W4A16_NVFP4`` in the checkpoint, which is *not* a TRT-LLM
+# ``QuantAlgo`` member; the engine path expresses NVFP4 (4-bit weights, FP8
+# group scales at group_size 16, FP32 global scale) as ``QuantAlgo.NVFP4`` +
+# ``group_size=16`` (verified: ``QuantAlgo`` has NVFP4 but no W4A16_NVFP4).
+_HF_ALGO_TO_TRTLLM = {
+    "FP8": QuantAlgo.FP8,
+    "W4A16_NVFP4": QuantAlgo.NVFP4,
+    "NVFP4": QuantAlgo.NVFP4,
+}
+
+
+def _hf_layer_quant_config(hf_quant_config: dict) -> dict:
+    """Return the HF ``quantized_layers`` map (module name -> spec dict).
+
+    The Qwen3.5/3.6 ``config.json.quantization_config`` carries both a
+    ``config_groups`` block and a flat ``quantized_layers`` dict; the latter is
+    a clean per-module ``{name: {quant_algo, group_size?}}`` map and is the
+    authoritative source used here.
+    """
+    layers = hf_quant_config.get("quantized_layers")
+    if not isinstance(layers, dict) or not layers:
+        raise ValueError(
+            "quantization_config.quantized_layers is missing or empty; expected "
+            "the modelopt per-module quant map for a MIXED_PRECISION checkpoint."
+        )
+    return layers
+
+
+def _to_quant_config(hf_spec: dict, hf_name: str) -> QuantConfig:
+    """Translate one HF ``quantized_layers`` entry into a ``QuantConfig``."""
+    algo = hf_spec.get("quant_algo")
+    if algo not in _HF_ALGO_TO_TRTLLM:
+        raise ValueError(
+            f"Unsupported quant_algo {algo!r} for module {hf_name!r}; expected "
+            f"one of {sorted(_HF_ALGO_TO_TRTLLM)}."
+        )
+    trtllm_algo = _HF_ALGO_TO_TRTLLM[algo]
+    kwargs = {"quant_algo": trtllm_algo}
+    if trtllm_algo == QuantAlgo.NVFP4:
+        # NVFP4 is group-wise; the checkpoint uses group_size 16.
+        kwargs["group_size"] = hf_spec.get("group_size", 16)
+    return QuantConfig(**kwargs)
+
+
+def build_layer_quant_config(
+    hf_quant_config: dict, num_hidden_layers: int, is_linear_attention: Callable[[int], bool]
+) -> "LayerQuantConfig":
+    """Translate the HF ``quantization_config`` into a TRT-LLM ``LayerQuantConfig``.
+
+    The checkpoint is ``MIXED_PRECISION``: the attention
+    projections are FP8, the MoE experts / shared expert / ``lm_head`` are
+    NVFP4 (group_size 16), and MTP + vision stay bf16. The returned
+    ``LayerQuantConfig`` keys are **TRT-LLM module-name globs** (matched by
+    ``fnmatch`` against the names produced by ``named_modules_with_parent`` in
+    :func:`tensorrt_llm.quantization.quantize.quantize`), NOT the HF tensor
+    names — so the per-layer assignment must be expressed in engine namespace:
+
+    =====================================  =========================================
+    HF module (checkpoint)                 TRT-LLM module (engine)
+    =====================================  =========================================
+    ``self_attn.{q,k,v}_proj``             ``self_attn.attention.qkv`` (fused)
+    ``self_attn.q_proj`` (gate half)       ``self_attn.attention.gate``
+    ``self_attn.o_proj``                   ``self_attn.attention.dense``
+    ``linear_attn.{in_proj_qkv,...}``      ``linear_attn.{in_proj_qkv,...}`` (same)
+    ``mlp.experts`` / ``mlp.shared_*``     ``mlp`` (the whole SharedMoE, see below)
+    ``lm_head``                            ``lm_head``
+    =====================================  =========================================
+
+    (The decoder wraps the engine ``Attention`` module under a ``self_attn``
+    attribute, so the full-attention sub-linears live at
+    ``transformer.layers.{i}.self_attn.attention.{qkv,gate,dense}``.)
+
+    The MoE assignment targets only the parent ``...mlp`` module: ``quantize``
+    re-creates the whole ``SharedMoE`` (rebuilding its expert + shared-expert
+    sub-linears as NVFP4 in the constructor, while internally excluding the
+    router and ``shared_expert_gate``), and ``named_modules_with_parent``
+    re-reads children from the parent after replacement, so the rebuilt
+    children must NOT also match a glob (mirrors Mixtral's
+    ``PretrainedConfig.to_layer_quant_config``). The unquantized GDN params
+    (``in_proj_a/b``, ``conv1d``, ``A_log``, ``dt_bias``, ``norm``), routers,
+    and norms get no glob -> ``quantize`` leaves them at the model dtype.
+
+    Args:
+        hf_quant_config: the HF ``config.json.quantization_config`` dict.
+        num_hidden_layers: number of text-decoder layers (40 here).
+        is_linear_attention: ``layer_idx -> bool`` (True for Gated DeltaNet
+            layers, False for full-attention layers).
+
+    Returns:
+        A ``LayerQuantConfig(quant_algo=MIXED_PRECISION, quantized_layers=...)``.
+    """
+    hf_layers = _hf_layer_quant_config(hf_quant_config)
+
+    def hf_spec(name: str) -> dict:
+        if name not in hf_layers:
+            raise ValueError(
+                f"Expected quantized module {name!r} in "
+                f"quantization_config.quantized_layers but it is absent."
+            )
+        return hf_layers[name]
+
+    quantized_layers: dict = {}
+    for i in range(num_hidden_layers):
+        prefix = f"transformer.layers.{i}"
+        hf_prefix = f"model.language_model.layers.{i}"
+        if is_linear_attention(i):
+            # Gated DeltaNet: in_proj_qkv / in_proj_z / out_proj are FP8 (same
+            # name in both namespaces); in_proj_a/b, conv1d, A_log, dt_bias,
+            # norm are unquantized and intentionally omitted.
+            for sub in ("in_proj_qkv", "in_proj_z", "out_proj"):
+                cfg = _to_quant_config(
+                    hf_spec(f"{hf_prefix}.linear_attn.{sub}"), f"{hf_prefix}.linear_attn.{sub}"
+                )
+                quantized_layers[f"{prefix}.linear_attn.{sub}"] = cfg
+        else:
+            # Full attention: q/k/v/o_proj are FP8. q and o map to the fused
+            # ``attention.qkv`` and ``attention.dense``; the gate half of the
+            # doubled q_proj feeds ``attention.gate`` (same FP8 per-tensor
+            # scale as q_proj).
+            q_cfg = _to_quant_config(
+                hf_spec(f"{hf_prefix}.self_attn.q_proj"), f"{hf_prefix}.self_attn.q_proj"
+            )
+            o_cfg = _to_quant_config(
+                hf_spec(f"{hf_prefix}.self_attn.o_proj"), f"{hf_prefix}.self_attn.o_proj"
+            )
+            quantized_layers[f"{prefix}.self_attn.attention.qkv"] = q_cfg
+            quantized_layers[f"{prefix}.self_attn.attention.gate"] = q_cfg
+            quantized_layers[f"{prefix}.self_attn.attention.dense"] = o_cfg
+        # MoE (every layer) -> NVFP4. ``quantize`` re-creates the whole
+        # ``SharedMoE`` from the parent ``...mlp`` glob (which rebuilds the 256
+        # routed experts as an NVFP4 ``MOEWeightWrapper`` and internally excludes
+        # the router + shared_expert_gate). BUT the rebuilt ``SharedMoE``'s
+        # shared-expert ``MLP`` constructs plain ``ColumnLinear``/``RowLinear``
+        # (its ctor does not quantize), so the shared-expert sub-linears need
+        # their OWN globs -- ``named_modules_with_parent`` re-reads children from
+        # the parent after replacement, so the walk reaches the rebuilt
+        # ``shared_expert.fc/proj`` and swaps them to FP4. These names do NOT
+        # collide with the expert wrapper (``mlp.fc``/``mlp.proj``), so the
+        # experts are NOT doubly wrapped.
+        moe_cfg = _to_quant_config(hf_spec(f"{hf_prefix}.mlp.experts"), f"{hf_prefix}.mlp.experts")
+        quantized_layers[f"{prefix}.mlp"] = moe_cfg
+        for sub in ("gate_proj", "up_proj", "down_proj"):
+            # the shared expert's three HF projections share the experts' NVFP4
+            # format in this checkpoint; assert presence + matching algo.
+            _to_quant_config(
+                hf_spec(f"{hf_prefix}.mlp.shared_expert.{sub}"),
+                f"{hf_prefix}.mlp.shared_expert.{sub}",
+            )
+        quantized_layers[f"{prefix}.mlp.shared_expert.fc"] = moe_cfg
+        quantized_layers[f"{prefix}.mlp.shared_expert.proj"] = moe_cfg
+
+    # lm_head -> NVFP4.
+    quantized_layers["lm_head"] = _to_quant_config(hf_spec("lm_head"), "lm_head")
+
+    return LayerQuantConfig(quant_algo=QuantAlgo.MIXED_PRECISION, quantized_layers=quantized_layers)
+
+
+def load_weights_from_hf_model(hf_model_dir: str, model) -> None:
+    """Load the HF checkpoint into ``model`` via the unified ``ModelWeightsLoader``.
+
+    Mirrors the modern qwen MoE path
+    (``tensorrt_llm/models/qwen/model.py``): the unified loader translates each
+    TRT-LLM parameter name to its HF tensor name(s) and dispatches to the
+    module's own ``postprocess``, so the FP8 qkv-scale fusion, NVFP4 block-scale
+    interleave + per-expert ``alpha``, and 256-expert stacking are all handled by
+    the framework. This converter only supplies the Qwen3-Next-specific remaps
+    the framework cannot infer:
+
+      * the gate-doubled ``q_proj`` → fused ``attention.qkv`` Q-section +
+        ``attention.gate`` (de-interleaved split, FP8 per-tensor scale shared);
+      * the MoE ``w1/w3/w2`` → ``gate_proj/up_proj/down_proj`` rename and the
+        router ``mlp.gate`` mapping (mirrors qwen);
+      * the NVFP4 ``shared_expert.fc`` gate+up fusion (the fused FP4 ColumnLinear
+        has no list-concat in its postprocess, so it is concatenated here).
+
+    The GDN ``linear_attn`` params keep their HF names and load through the
+    default path (FP8 for ``in_proj_qkv/in_proj_z/out_proj``; bf16/fp32 for
+    ``in_proj_a/b``, ``conv1d``, ``A_log``, ``dt_bias``, ``norm``).
+
+    Loads with ``skip_tp=True`` on the split projections (single-GPU,
+    ``tp_size==1`` for the text-only token-exact check). MTP + vision are not
+    constructed in the engine model, so the loader never requests their weights.
+
+    Args:
+        hf_model_dir: path to the HF checkpoint directory (safetensors).
+        model: the constructed (and already ``quantize``-d) ``Qwen3NextForCausalLM``.
+    """
+    import torch
+    from tqdm import tqdm
+
+    from ...layers.moe import MOEWeightWrapper
+    from ..model_weights_loader import ModelWeightsLoader
+
+    config = model.config
+    num_heads = config.num_attention_heads
+    head_dim = config.head_size
+
+    # Base key remaps the framework cannot infer from module names alone.
+    #   * transformer -> model.language_model: the checkpoint nests the text
+    #     decoder under ``model.language_model.*`` (multimodal wrapper), while
+    #     ``lm_head`` stays top-level. The base loader maps ``transformer ->
+    #     model``, which misses the ``language_model`` infix.
+    #   * attention -> "": the decoder nests the engine ``Attention`` module under
+    #     a ``self_attn`` attribute, so the TRT-LLM path is
+    #     ``self_attn.attention.{qkv,gate,dense}``. The base loader maps
+    #     ``attention -> self_attn``; collapse our extra ``attention`` section to
+    #     empty so it resolves to the HF ``self_attn.{q,k,v,o}_proj``.
+    #   * fc -> [up_proj, gate_proj]: the fused gate+up ColumnLinear in every MLP
+    #     (incl. the shared expert) is loaded from the two HF projections, in the
+    #     order the engine's gated-activation GEMM expects (up first, then gate),
+    #     matching qwen3_moe.
+    #   * q/k layernorm names.
+    custom_dict = {
+        "transformer": "model.language_model",
+        "attention": "",
+        "fc": ["up_proj", "gate_proj"],
+        "q_layernorm": "q_norm",
+        "k_layernorm": "k_norm",
+    }
+    loader = ModelWeightsLoader(hf_model_dir, custom_dict)
+    loader.update_key_mapping(model)
+
+    def split_q_half(weights):
+        """Replace the q_proj weight (index 0) with its real-Q half.
+
+        For the fused FP8 qkv, ``weight`` translates to the 6-tensor list
+        ``[q_w, q_ws, k_w, k_ws, v_w, v_ws]`` (``FP8Linear`` is_qkv dict). Only
+        the q weight is gate-doubled; de-interleave it to the real-Q rows and
+        leave the per-tensor scales untouched (they apply to both halves).
+        """
+        if weights is None:
+            return weights
+        wlist = weights if isinstance(weights, list) else [weights]
+        if wlist[0] is not None:
+            wlist[0] = split_attn_output_gate(wlist[0].contiguous(), num_heads, head_dim)[0]
+        return wlist if isinstance(weights, list) else wlist[0]
+
+    def take_gate_half(weights):
+        """Take the gate half of the gate-doubled q_proj weight."""
+        if weights is None:
+            return weights
+        return split_attn_output_gate(weights.contiguous(), num_heads, head_dim)[1]
+
+    # Patch per-module key dicts: MoE experts (w1/w3/w2 -> gate/up/down_proj),
+    # router (mlp.gate), and the attention output gate (sources from q_proj).
+    for tllm_key, _ in model.named_parameters():
+        sub_module = model
+        for attr in tllm_key.split(".")[:-1]:
+            sub_module = getattr(sub_module, attr)
+
+        if "router" in tllm_key or isinstance(sub_module, MOEWeightWrapper):
+            d = sub_module.tllm_to_externel_key_dict
+            d["mlp"] = "mlp"
+            if "fc" in d:
+                d["fc"] = [k.replace("w1", "gate_proj").replace("w3", "up_proj") for k in d["fc"]]
+            if "proj" in d:
+                d["proj"] = [k.replace("w2", "down_proj") for k in d["proj"]]
+            sub_module.tllm_to_externel_key_dict = d
+        elif ".attention.gate." in tllm_key:
+            # The output gate has no direct HF tensor: source the weight from the
+            # gate half of the gate-doubled q_proj, and reuse q_proj's per-tensor
+            # FP8 scales (they apply to both halves).
+            sub_module.tllm_to_externel_key_dict = {
+                "gate": "q_proj",
+                "weights_scaling_factor": "weight_scale",
+                "activation_scaling_factor": "input_scale",
+            }
+
+    def fuse_shared_expert_fc(tllm_key, weights):
+        """Fuse the [up, gate] halves of the NVFP4 ``shared_expert.fc``.
+
+        ``fc -> [up_proj, gate_proj]`` makes every key a 2-element list; the
+        fused FP4 ColumnLinear (non-qkv) ``postprocess`` does not concat lists.
+        The per-row tensors (FP4 ``weight``, FP8 ``weights_block_scaling_factor``)
+        concat along the output-feature dim 0. The global/activation scales are
+        per-tensor; verified identical across up/gate in this checkpoint (modelopt
+        used a shared global), so collapse the list to a single scalar — which
+        lets the default FP4 postprocess (interleave / ``.float()`` /
+        ``alpha = w_global * a_global``) produce the correct fused result.
+        """
+        if weights is None or not isinstance(weights, list):
+            return weights
+        if any(w is None for w in weights):
+            raise ValueError(f"Missing an up/gate half while fusing {tllm_key}: {weights}")
+        if (
+            tllm_key.endswith("weight")
+            or tllm_key.endswith("weights_block_scaling_factor")
+            or tllm_key.endswith("weights_block_scaling_factor_interleaved")
+        ):
+            # per-output-row tensors -> concat along dim 0 (up rows then gate rows)
+            return torch.cat(weights, dim=0)
+        if tllm_key.endswith("alpha"):
+            # translated to [up_w2, up_in, gate_w2, gate_in]; up==gate, keep one pair
+            return [weights[0], weights[1]]
+        # per-tensor global/activation scales: up == gate, collapse to one.
+        return weights[0]
+
+    def conv1d_weight_4d(weights):
+        """Reshape the depthwise ``conv1d.weight`` to the engine's 4D layout.
+
+        HF depthwise ``conv1d.weight`` is ``[conv_dim, 1, kernel]``; the engine
+        ``MambaConv1d`` expects ``[conv_dim, 1, kernel, 1]`` (mirrors
+        ``mamba/convert.py``). ``loader.fill`` would otherwise pad the missing
+        dim and silently misshape the conv.
+        """
+        if weights is None:
+            return weights
+        return weights.unsqueeze(3)
+
+    def gemma_norm_offset(weights):
+        """Fold the Gemma-style RMSNorm ``+1`` offset into the loaded weight.
+
+        Qwen3.5/3.6 uses the Gemma-style ``Qwen3_5MoeRMSNorm`` whose forward is
+        ``x_normed * (1 + weight)`` for the decoder layernorms (input_layernorm,
+        post_attention_layernorm), q/k norms, and the final norm. The engine's
+        ``RmsNorm`` computes the standard ``x_normed * weight``, so fold the ``+1``
+        into the loaded weight here. (The GDN gated norm uses the plain-weight
+        ``Qwen3_5MoeRMSNormGated`` and is intentionally NOT offset.)
+        """
+        if weights is None:
+            return weights
+        return weights.float() + 1.0
+
+    # TRT-LLM param-name suffixes whose RMSNorm uses the (1 + weight) convention.
+    GEMMA_NORM_SUFFIXES = (
+        ".input_layernorm.weight",
+        ".post_attention_layernorm.weight",
+        ".attention.q_layernorm.weight",
+        ".attention.k_layernorm.weight",
+    )
+
+    tllm_weights = {}
+    for tllm_key, _ in tqdm(model.named_parameters(), desc="Loading Qwen3-Next weights"):
+        if ".attention.qkv." in tllm_key and tllm_key.endswith("weight"):
+            tllm_weights.update(loader.load(tllm_key, preprocess=split_q_half, skip_tp=True))
+        elif tllm_key.endswith(".attention.gate.weight"):
+            tllm_weights.update(loader.load(tllm_key, preprocess=take_gate_half, skip_tp=True))
+        elif ".mlp.shared_expert.fc." in tllm_key:
+            tllm_weights.update(
+                loader.load(tllm_key, preprocess=lambda w, k=tllm_key: fuse_shared_expert_fc(k, w))
+            )
+        elif tllm_key.endswith(".linear_attn.conv1d.weight"):
+            tllm_weights.update(loader.load(tllm_key, preprocess=conv1d_weight_4d))
+        elif tllm_key.endswith(".linear_attn.conv1d.bias"):
+            # HF Qwen3-Next conv1d uses bias=False, but the engine MambaConv1d
+            # always allocates a bias and uses it in the conv -> supply zeros.
+            param = model
+            for attr in tllm_key.split("."):
+                param = getattr(param, attr)
+            from ..._utils import trt_dtype_to_torch
+
+            tllm_weights[tllm_key] = torch.zeros(
+                tuple(param.shape), dtype=trt_dtype_to_torch(param.dtype)
+            )
+        elif tllm_key.endswith(GEMMA_NORM_SUFFIXES) or tllm_key == "transformer.norm.weight":
+            # Gemma-style (1 + weight) RMSNorm (NOT the GDN gated norm).
+            tllm_weights.update(loader.load(tllm_key, preprocess=gemma_norm_offset))
+        else:
+            tllm_weights.update(loader.load(tllm_key))
+
+    loader.fill(tllm_weights)

--- a/tensorrt_llm/models/qwen3_next/model.py
+++ b/tensorrt_llm/models/qwen3_next/model.py
@@ -1,0 +1,948 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Engine-path model for the Qwen3.5/Qwen3.6 hybrid MoE family.
+
+Registers the architecture, parses the config, and assembles the hybrid decoder
+structure: Gated DeltaNet "linear attention" layers interleaved 3:1 with full
+attention, each followed by a 256-expert MoE + shared expert. It is built on the
+RecurrentGemma hybrid template, which interleaves recurrent and attention blocks
+in a single engine.
+
+The Gated DeltaNet recurrence runs through the ``GatedDeltaNet`` TensorRT plugin
+(``functional.gated_delta_rule``), carrying its per-(request, v-head) state on
+the paged RNN-state path alongside the depthwise conv state, exactly like the
+Mamba / RecurrentGemma recurrent layers. The full-attention layers reuse the
+engine ``Attention`` module with the ``attn_output_gate`` sigmoid output gate.
+
+Not implemented in this initial engine-path drop:
+
+* Interleaved MRoPE (``mrope_section``) for multimodal positions. Text-only
+  positions collapse to standard RoPE, so text generation is unaffected.
+* The MTP (multi-token-prediction) head.
+* The Qwen3-VL vision tower.
+"""
+
+from collections import OrderedDict
+from typing import Optional
+
+import tensorrt as trt
+
+from ..._common import default_net
+from ..._utils import pad_vocab_size, str_dtype_to_trt
+from ...functional import (
+    ACT2FN,
+    LayerNormType,
+    Tensor,
+    arange,
+    concat,
+    exp,
+    expand,
+    gated_delta_rule,
+    gather_last_token_logits,
+    repeat_interleave,
+    shape,
+    sigmoid,
+    softplus,
+    split,
+    unsqueeze,
+    view,
+)
+from ...layers import (
+    Attention,
+    AttentionMaskType,
+    AttentionParams,
+    ColumnLinear,
+    Embedding,
+    KeyValueCacheParams,
+    RmsNorm,
+    SharedMoE,
+)
+from ...layers.ssm import MambaConv1d
+from ...mapping import Mapping
+from ...module import Module, ModuleList
+from ...parameter import Parameter
+from ..generation_mixin import GenerationMixin
+from ..modeling_utils import PretrainedModel, QuantConfig
+from .config import FULL_ATTENTION, LINEAR_ATTENTION, Qwen3NextConfig
+
+
+class Qwen3NextGatedDeltaNet(Module):
+    """Gated DeltaNet ("linear attention") mixer.
+
+    Construction wires the checkpoint parameter layout:
+
+      * ``in_proj_qkv``: hidden -> [Q | K | V] = key_dim*2 + value_dim
+      * ``in_proj_z``  : hidden -> value_dim (output gate)
+      * ``in_proj_a``  : hidden -> num_v_heads (decay logits)
+      * ``in_proj_b``  : hidden -> num_v_heads (beta logits)
+      * ``conv1d``     : depthwise causal conv over [Q|K|V], kernel 4
+      * ``A_log``, ``dt_bias``: per value-head
+      * ``norm``       : gated RMSNorm over head_v_dim
+      * ``out_proj``   : value_dim -> hidden
+
+    The recurrence (chunked prefill + single-step decode against a
+    ``[B, num_v_heads, head_k, head_v]`` recurrent state and a
+    ``[B, conv_dim, kernel-1]`` conv state) runs through the ``GatedDeltaNet``
+    plugin via ``functional.gated_delta_rule``.
+    """
+
+    def __init__(self, config: Qwen3NextConfig, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.config = config
+        self.dtype = config.dtype
+
+        self.num_k_heads = config.linear_num_key_heads
+        self.num_v_heads = config.linear_num_value_heads
+        self.head_k_dim = config.linear_key_head_dim
+        self.head_v_dim = config.linear_value_head_dim
+        self.key_dim = self.head_k_dim * self.num_k_heads
+        self.value_dim = self.head_v_dim * self.num_v_heads
+        self.conv_dim = self.key_dim * 2 + self.value_dim
+        self.conv_kernel = config.linear_conv_kernel_dim
+
+        # Parameter modules mirror the HF split-projection checkpoint layout.
+        self.in_proj_qkv = ColumnLinear(
+            config.hidden_size,
+            self.conv_dim,
+            bias=False,
+            dtype=config.dtype,
+            tp_group=config.mapping.tp_group,
+            tp_size=config.mapping.tp_size,
+            gather_output=False,
+        )
+        self.in_proj_z = ColumnLinear(
+            config.hidden_size,
+            self.value_dim,
+            bias=False,
+            dtype=config.dtype,
+            tp_group=config.mapping.tp_group,
+            tp_size=config.mapping.tp_size,
+            gather_output=False,
+        )
+        self.in_proj_a = ColumnLinear(
+            config.hidden_size,
+            self.num_v_heads,
+            bias=False,
+            dtype=config.dtype,
+            gather_output=False,
+        )
+        self.in_proj_b = ColumnLinear(
+            config.hidden_size,
+            self.num_v_heads,
+            bias=False,
+            dtype=config.dtype,
+            gather_output=False,
+        )
+        self.conv1d = MambaConv1d(
+            self.conv_dim, d_conv=self.conv_kernel, dtype=config.dtype, apply_silu=True
+        )
+        # Per-(value-)head decay/timestep params (kept fp32 for the recurrence).
+        self.A_log = Parameter(shape=(self.num_v_heads,), dtype="float32")
+        self.dt_bias = Parameter(shape=(self.num_v_heads,), dtype="float32")
+        self.norm = RmsNorm(
+            normalized_shape=self.head_v_dim, eps=config.norm_epsilon, dtype=config.dtype
+        )
+        self.out_proj = ColumnLinear(
+            self.value_dim,
+            config.hidden_size,
+            bias=False,
+            dtype=config.dtype,
+            tp_group=config.mapping.tp_group,
+            tp_size=config.mapping.tp_size,
+            gather_output=True,
+        )
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        conv_state: Tensor,
+        rnn_state: Tensor,
+        host_request_types: Tensor,
+        last_token_ids: Tensor,
+        host_context_lengths=None,
+        slot_mapping=None,
+        conv_indices=None,
+    ):
+        """Gated DeltaNet forward.
+
+        Returns (out, present_conv_state, present_rnn_state).
+        """
+        gqa = self.num_v_heads // self.num_k_heads
+
+        # 1. projections
+        mixed_qkv = self.in_proj_qkv(hidden_states)  # [.., conv_dim]
+        z = self.in_proj_z(hidden_states)  # [.., value_dim]
+        a = self.in_proj_a(hidden_states)  # [.., num_v_heads]
+        b = self.in_proj_b(hidden_states)  # [.., num_v_heads]
+
+        # 2. depthwise causal conv over [Q|K|V] (+ SiLU), updates conv_state
+        mixed_qkv, present_conv = self.conv1d(
+            mixed_qkv,
+            conv_state,
+            host_request_types,
+            last_token_ids,
+            host_context_lengths,
+            slot_mapping,
+            conv_indices,
+        )
+
+        # 3. split into q,k,v and shape into heads; GQA-expand q,k to num_v_heads
+        q, k, v = split(mixed_qkv, [self.key_dim, self.key_dim, self.value_dim], dim=-1)
+        remove_padding = default_net().plugin_config.remove_input_padding
+
+        def _heads(x, n_heads, head_dim):
+            # [.., n_heads*head_dim] -> [.., n_heads, head_dim] (packed or padded)
+            if remove_padding:
+                new_shape = concat([shape(x, 0), n_heads, head_dim])
+            else:
+                new_shape = concat([shape(x, 0), shape(x, 1), n_heads, head_dim])
+            return view(x, new_shape)
+
+        q = _heads(q, self.num_k_heads, self.head_k_dim)
+        k = _heads(k, self.num_k_heads, self.head_k_dim)
+        v = _heads(v, self.num_v_heads, self.head_v_dim)
+        if gqa > 1:
+            # repeat_interleave key heads to match value heads
+            head_dim_axis = 1 if remove_padding else 2
+            q = repeat_interleave(q, gqa, dim=head_dim_axis)
+            k = repeat_interleave(k, gqa, dim=head_dim_axis)
+
+        # 4. per-head gates: beta = sigmoid(b); g = -exp(A_log) * softplus(a + dt_bias)
+        #    (softplus with PyTorch defaults beta=1.0, threshold=20.0, matching
+        #    the HF reference F.softplus(a + dt_bias)).
+        beta = sigmoid(b)
+        g = (0.0 - exp(self.A_log.value.cast("float32"))) * softplus(
+            a.cast("float32") + self.dt_bias.value, 1.0, 20.0
+        )
+
+        # 5. gated delta rule recurrence (updates rnn_state). The GatedDeltaNet
+        #    plugin is fp32-only (state is always fp32; correctness-first path),
+        #    so q/k/v/beta must be fp32 too (g is already fp32 above). The fp32
+        #    state matches the recurrence's numerical requirements.
+        q = q.cast("float32")
+        k = k.cast("float32")
+        v = v.cast("float32")
+        beta = beta.cast("float32")
+        y, present_rnn = gated_delta_rule(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            rnn_state,
+            host_request_types,
+            last_token_ids,
+            num_v_heads=self.num_v_heads,
+            head_k_dim=self.head_k_dim,
+            head_v_dim=self.head_v_dim,
+            chunk_size=64,
+            use_qk_l2norm=True,
+            dtype=self.config.mamba_ssm_dtype,
+            host_context_lengths=host_context_lengths,
+            slot_mapping=slot_mapping,
+        )
+
+        # 6. gated RMSNorm over head_v (norm-before-gate, SiLU(z)) then out_proj.
+        #    The plugin emits y in fp32; bring it back to the model dtype for the
+        #    gated norm + out_proj (which run in the model dtype).
+        y = y.cast(self.dtype)
+        y = self.norm(y)
+        z = _heads(z, self.num_v_heads, self.head_v_dim)
+        y = y * ACT2FN["silu"](z)
+        if remove_padding:
+            y = view(y, concat([shape(y, 0), self.value_dim]))
+        else:
+            y = view(y, concat([shape(y, 0), shape(y, 1), self.value_dim]))
+        out = self.out_proj(y)
+        return out, present_conv, present_rnn
+
+
+class Qwen3NextAttention(Module):
+    """Full-attention mixer for the 1-in-4 ``full_attention`` layers.
+
+    Reuses the engine ``Attention`` module for QKV / partial-RoPE / GQA /
+    qk_layernorm, plus its built-in ``attn_output_gate`` hook: a sigmoid gate
+    applied to the attention output before ``o_proj``. In the HF checkpoint this
+    gate is fused into a doubled ``q_proj`` (``[2 * num_heads * head_dim,
+    hidden]``; per head the first ``head_dim`` rows are real Q, the next
+    ``head_dim`` are the gate). The converter de-interleaves those halves:
+    real-Q rows feed the fused ``attention.qkv`` Q-section, gate rows feed
+    ``attention.gate``.
+
+    NOTE: interleaved MRoPE (``mrope_section``) is not wired here. For text-only
+    positions MRoPE collapses to standard RoPE, so this layer matches HF for
+    text; multimodal (image) position parity additionally requires MRoPE.
+    """
+
+    def __init__(self, config: Qwen3NextConfig, layer_idx: int, attn_layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.attn_output_gate = config.attn_output_gate
+
+        # attn_layer_idx is this layer's index into the KV cache (i.e. the count
+        # of full-attention layers at or before it), NOT the global layer index.
+        self.attention = Attention(
+            local_layer_idx=attn_layer_idx,
+            hidden_size=config.hidden_size,
+            attention_head_size=config.head_size,
+            num_attention_heads=config.num_attention_heads,
+            num_kv_heads=config.num_key_value_heads,
+            max_position_embeddings=config.max_position_embeddings,
+            dtype=config.dtype,
+            attention_mask_type=AttentionMaskType.causal,
+            bias=config.attn_bias,
+            position_embedding_type=config.position_embedding_type,
+            rotary_embedding_base=config.rotary_base,
+            rotary_embedding_scaling=config.rotary_scaling,
+            rotary_embedding_percentage=config.partial_rotary_factor,
+            tp_rank=config.mapping.tp_rank,
+            tp_group=config.mapping.tp_group,
+            tp_size=config.mapping.tp_size,
+            quant_mode=config.quant_mode,
+            dense_bias=False,
+            qk_layernorm=True,
+            layernorm_type=LayerNormType.RmsNorm,
+            attn_output_gate=config.attn_output_gate,
+        )
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        attention_mask=None,
+        use_cache=False,
+        kv_cache_params=None,
+        attention_params=None,
+    ):
+        """Full-attention forward.
+
+        Returns ``context`` (or ``(context, present_kv)`` when ``use_cache``).
+        The ``attn_output_gate`` is applied inside the engine ``Attention``
+        module (see its ``forward``), so the FP8 output-quant wiring and the
+        single TP all-reduce on ``o_proj`` remain intact.
+        """
+        return self.attention(
+            hidden_states,
+            attention_mask=attention_mask,
+            use_cache=use_cache,
+            kv_cache_params=kv_cache_params,
+            attention_params=attention_params,
+        )
+
+
+def _build_mlp(config: Qwen3NextConfig):
+    """Per-layer MoE (256 experts) + shared expert, matching the checkpoint."""
+    mlp_kwargs = {
+        "moe_config": config.moe,
+        "mapping": config.mapping,
+        "use_shared_gate": True,
+        "use_side_stream": True,
+    }
+    # The shared-expert intermediate size is carried on the MoeConfig.
+    config.moe.shared_expert_intermediate_size = config.moe_shared_expert_intermediate_size
+    return SharedMoE(
+        hidden_size=config.hidden_size,
+        ffn_hidden_size=config.moe_intermediate_size,
+        hidden_act=config.hidden_act,
+        dtype=config.dtype,
+        bias=False,
+        tp_group=config.mapping.tp_group,
+        tp_size=config.mapping.tp_size,
+        quant_mode=config.quant_mode,
+        **mlp_kwargs,
+    )
+
+
+class Qwen3NextDecoderLayer(Module):
+    """One hybrid decoder layer: (linear|full) mixer + MoE, with residuals."""
+
+    def __init__(self, config: Qwen3NextConfig, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.config = config
+        self.is_linear = config.is_linear_attention_layer(layer_idx)
+
+        self.input_layernorm = RmsNorm(
+            normalized_shape=config.hidden_size, eps=config.norm_epsilon, dtype=config.dtype
+        )
+        if self.is_linear:
+            self.linear_attn = Qwen3NextGatedDeltaNet(config, layer_idx)
+        else:
+            # KV-cache slot = number of full-attention layers at or before this
+            # one, minus one (RecurrentGemma pattern for hybrid models).
+            attn_kv_idx = (
+                sum(1 for i in range(layer_idx + 1) if config.get_layer_type(i) == FULL_ATTENTION)
+                - 1
+            )
+            self.self_attn = Qwen3NextAttention(config, layer_idx, attn_kv_idx)
+        self.post_attention_layernorm = RmsNorm(
+            normalized_shape=config.hidden_size, eps=config.norm_epsilon, dtype=config.dtype
+        )
+        self.mlp = _build_mlp(config)
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        attention_mask=None,
+        use_cache=False,
+        kv_cache_params=None,
+        attention_params=None,
+        conv_state=None,
+        rnn_state=None,
+        host_request_types=None,
+        last_token_ids=None,
+        host_context_lengths=None,
+        slot_mapping=None,
+        conv_indices=None,
+    ):
+        """Returns (hidden, present_kv|None, present_conv|None, present_rnn|None)."""
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+
+        present_kv = present_conv = present_rnn = None
+        if self.is_linear:
+            hidden_states, present_conv, present_rnn = self.linear_attn(
+                hidden_states,
+                conv_state=conv_state,
+                rnn_state=rnn_state,
+                host_request_types=host_request_types,
+                last_token_ids=last_token_ids,
+                host_context_lengths=host_context_lengths,
+                slot_mapping=slot_mapping,
+                conv_indices=conv_indices,
+            )
+        else:
+            attn_out = self.self_attn(
+                hidden_states,
+                attention_mask=attention_mask,
+                use_cache=use_cache,
+                kv_cache_params=kv_cache_params,
+                attention_params=attention_params,
+            )
+            if use_cache:
+                hidden_states, present_kv = attn_out
+            else:
+                hidden_states = attn_out
+
+        hidden_states = residual + hidden_states
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states, present_kv, present_conv, present_rnn
+
+
+class Qwen3NextModel(Module):
+    def __init__(self, config: Qwen3NextConfig):
+        super().__init__()
+        self.config = config
+        self.mapping = config.mapping
+        if self.mapping.is_first_pp_rank():
+            self.vocab_embedding = Embedding(
+                config.vocab_size, config.hidden_size, dtype=config.dtype
+            )
+        layers_range = config.mapping.pp_layers(config.num_hidden_layers)
+        self.layers = ModuleList([Qwen3NextDecoderLayer(config, idx) for idx in layers_range])
+        if self.mapping.is_last_pp_rank():
+            self.norm = RmsNorm(
+                normalized_shape=config.hidden_size, eps=config.norm_epsilon, dtype=config.dtype
+            )
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        use_cache=False,
+        attention_mask=None,
+        kv_cache_params=None,
+        attention_params=None,
+        conv_states=None,
+        rnn_states=None,
+        host_request_types=None,
+        last_token_ids=None,
+        host_context_lengths=None,
+        slot_mapping=None,
+    ):
+        hidden_states = self.vocab_embedding(input_ids)
+
+        # conv_indices (only needed by the OOTB conv path, i.e. no mamba_conv1d
+        # plugin); mirrors RecurrentGemma.
+        conv_indices = None
+        if not default_net().plugin_config.mamba_conv1d_plugin:
+            batch_size = shape(input_ids, 0)
+            dim = self.config.linear_num_value_heads * self.config.linear_value_head_dim
+            d_conv = self.config.linear_conv_kernel_dim
+            indices = expand(
+                unsqueeze(arange(0, d_conv - 1, dtype="int32"), 0), concat([batch_size, d_conv - 1])
+            )
+            offsets = expand(unsqueeze(last_token_ids, 1), concat([batch_size, d_conv - 1]))
+            indices = unsqueeze(indices + offsets, 1)
+            conv_indices = expand(indices, concat([batch_size, dim, d_conv - 1]))
+
+        present_kvs, present_convs, present_rnns = [], [], []
+        for layer, past_kv, past_conv, past_rnn in zip(
+            self.layers, kv_cache_params.past_key_value, conv_states, rnn_states
+        ):
+            hidden_states, present_kv, present_conv, present_rnn = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                use_cache=use_cache,
+                kv_cache_params=KeyValueCacheParams(
+                    past_key_value=[past_kv],
+                    host_past_key_value_lengths=kv_cache_params.host_past_key_value_lengths,
+                    host_max_attention_window_sizes=kv_cache_params.host_max_attention_window_sizes,
+                    host_sink_token_length=kv_cache_params.host_sink_token_length,
+                    kv_cache_block_offsets=kv_cache_params.kv_cache_block_offsets,
+                    host_kv_cache_block_offsets=kv_cache_params.host_kv_cache_block_offsets,
+                    host_kv_cache_pool_pointers=kv_cache_params.host_kv_cache_pool_pointers,
+                    host_kv_cache_pool_mapping=kv_cache_params.host_kv_cache_pool_mapping,
+                    cache_indirection=kv_cache_params.cache_indirection,
+                ),
+                attention_params=attention_params,
+                conv_state=past_conv,
+                rnn_state=past_rnn,
+                host_request_types=host_request_types,
+                last_token_ids=last_token_ids,
+                host_context_lengths=host_context_lengths,
+                slot_mapping=slot_mapping,
+                conv_indices=conv_indices,
+            )
+            present_kvs.append(present_kv)
+            present_convs.append(present_conv)
+            present_rnns.append(present_rnn)
+
+        hidden_states = self.norm(hidden_states)
+        return hidden_states, tuple(present_kvs), tuple(present_convs), tuple(present_rnns)
+
+
+class Qwen3NextForCausalLM(PretrainedModel):
+    """Engine-path ``ForCausalLM`` for Qwen3.5/Qwen3.6 hybrid MoE checkpoints.
+
+    Registers the architecture, constructs the full module tree (hybrid
+    GatedDeltaNet + full-attention decoder, MoE), and wires the recurrent
+    conv/RNN-state inputs alongside the KV cache so the engine builds and runs
+    the text-generation path. The MTP head and vision tower are out of scope
+    here (see module docstring).
+    """
+
+    config_class = Qwen3NextConfig
+
+    def __init__(self, config: Qwen3NextConfig):
+        self.check_config(config)
+        super().__init__(config)
+        dtype = config.dtype
+        self.dtype = str_dtype_to_trt(dtype) if isinstance(dtype, str) else dtype
+        self.quant_mode = config.quant_mode
+        self.mapping = config.mapping
+        self.config = config
+        self.gather_context_logits = False
+
+        # Per-layer temporal types (used by prepare_inputs / the forward loop to
+        # split KV-cache vs recurrent-state layers).
+        self.layer_types = [config.get_layer_type(i) for i in range(config.num_hidden_layers)]
+
+        # Constant attention params shared by the full-attention layers.
+        Attention.create_attention_const_params(self, config)
+        self.position_embedding_type = config.position_embedding_type
+
+        logits_dtype = config.logits_dtype
+        self._logits_dtype = (
+            str_dtype_to_trt(logits_dtype) if isinstance(logits_dtype, str) else logits_dtype
+        )
+
+        self.transformer = Qwen3NextModel(config)
+        vocab_size_padded = pad_vocab_size(config.vocab_size, config.mapping.tp_size)
+        if config.mapping.is_last_pp_rank():
+            self.lm_head = ColumnLinear(
+                config.hidden_size,
+                vocab_size_padded,
+                bias=False,
+                dtype=dtype,
+                tp_group=config.mapping.tp_group,
+                tp_size=config.mapping.tp_size,
+                gather_output=True,
+            )
+        else:
+            self.lm_head = None
+
+    def check_config(self, config):
+        config.set_if_not_exist("linear_num_key_heads", 16)
+        config.set_if_not_exist("linear_num_value_heads", 32)
+        config.set_if_not_exist("linear_key_head_dim", 128)
+        config.set_if_not_exist("linear_value_head_dim", 128)
+        config.set_if_not_exist("linear_conv_kernel_dim", 4)
+        config.set_if_not_exist("mamba_ssm_dtype", "float32")
+
+    @classmethod
+    def from_hugging_face(
+        cls,
+        hf_model_or_dir,
+        dtype: str = "auto",
+        mapping: Optional[Mapping] = None,
+        quant_config: Optional[QuantConfig] = None,
+        **kwargs,
+    ):
+        """Build the TRT-LLM model + load weights from an HF checkpoint dir.
+
+        Parses the config (incl. the modelopt mixed-precision
+        ``quantization_config`` -> per-layer ``LayerQuantConfig``), constructs
+        the module tree (which ``quantize``-s the FP8/NVFP4 layers), then loads
+        and remaps the HF safetensors via the unified ``ModelWeightsLoader``
+        (see ``convert.py``). MTP + vision are not built here and are out of
+        scope for the text-only path.
+        """
+        from .convert import load_weights_from_hf_model
+
+        config = Qwen3NextConfig.from_hugging_face(
+            hf_model_or_dir, dtype=dtype, mapping=mapping, quant_config=quant_config, **kwargs
+        )
+        model = cls(config)
+        load_weights_from_hf_model(hf_model_or_dir, model)
+        return model
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        position_ids=None,
+        use_cache=False,
+        attention_mask=None,
+        kv_cache_params=None,
+        attention_params=None,
+        conv_states=None,
+        rnn_states=None,
+        host_request_types=None,
+        last_token_ids=None,
+        last_token_ids_for_logits=None,
+        host_context_lengths=None,
+        slot_mapping=None,
+    ):
+        attention_params = Attention.fill_attention_params(self, attention_params)
+
+        hidden_states, present_kvs, present_convs, present_rnns = self.transformer(
+            input_ids,
+            use_cache=use_cache,
+            attention_mask=attention_mask,
+            kv_cache_params=kv_cache_params,
+            attention_params=attention_params,
+            conv_states=conv_states,
+            rnn_states=rnn_states,
+            host_request_types=host_request_types,
+            last_token_ids=last_token_ids,
+            host_context_lengths=host_context_lengths,
+            slot_mapping=slot_mapping,
+        )
+
+        hidden_states = gather_last_token_logits(
+            hidden_states,
+            last_token_ids_for_logits,
+            default_net().plugin_config.remove_input_padding,
+        )
+        lm_logits = self.lm_head(hidden_states)
+        lm_logits.mark_output("logits", self._logits_dtype)
+
+        if not default_net().plugin_config.paged_kv_cache:
+            for i, present_kv in enumerate(present_kvs):
+                if present_kv is not None:
+                    present_kv.mark_output(f"present_key_value_{i}", self.dtype)
+        if not default_net().plugin_config.paged_state:
+            for i, present_conv in enumerate(present_convs):
+                if present_conv is not None:
+                    present_conv.mark_output(f"present_conv_state_{i}", self.dtype)
+            for i, present_rnn in enumerate(present_rnns):
+                if present_rnn is not None:
+                    present_rnn.mark_output(f"present_rnn_state_{i}", str_dtype_to_trt("float32"))
+        return (lm_logits, present_kvs, present_convs, present_rnns)
+
+    def prepare_recurrent_inputs(self, max_batch_size, num_profiles, mapping):
+        """Build per-GDN-layer conv + recurrent (matrix) state inputs.
+
+        Non-GDN layers get None placeholders so the per-layer lists align with
+        self.layers.
+        """
+        paged = default_net().plugin_config.paged_state
+        default_range = GenerationMixin.default_range
+        batch_range = [default_range(max_batch_size)] * num_profiles
+
+        cfg = self.config
+        conv_dim = (
+            cfg.linear_key_head_dim * cfg.linear_num_key_heads * 2
+            + cfg.linear_value_head_dim * cfg.linear_num_value_heads
+        ) // mapping.tp_size
+        n_v_heads = cfg.linear_num_value_heads // mapping.tp_size
+        d_conv = cfg.linear_conv_kernel_dim
+
+        conv_state_dim_range = OrderedDict(
+            [
+                ("batch_size", batch_range),
+                ("kernel_size", [d_conv - 1] * num_profiles),
+                ("conv_dim", [conv_dim] * num_profiles),
+            ]
+        )
+        # GDN recurrent state is the per-v-head matrix [head_k, head_v].
+        rnn_state_dim_range = OrderedDict(
+            [
+                ("batch_size", batch_range),
+                ("num_v_heads", [n_v_heads] * num_profiles),
+                ("head_k_dim", [cfg.linear_key_head_dim] * num_profiles),
+                ("head_v_dim", [cfg.linear_value_head_dim] * num_profiles),
+            ]
+        )
+        one_dim_range = OrderedDict([("buffer_count", [1] * num_profiles)])
+
+        conv_states, rnn_states = [], []
+        for i in range(cfg.num_hidden_layers):
+            if self.layer_types[i] != LINEAR_ATTENTION:
+                conv_states.append(None)
+                rnn_states.append(None)
+                continue
+            if paged:
+                conv_state = Tensor(
+                    name=f"conv_state_ptr_{i}",
+                    dtype=str_dtype_to_trt("int64"),
+                    shape=[1],
+                    dim_range=one_dim_range,
+                )
+                rnn_state = Tensor(
+                    name=f"rnn_state_ptr_{i}",
+                    dtype=str_dtype_to_trt("int64"),
+                    shape=[1],
+                    dim_range=one_dim_range,
+                )
+            else:
+                conv_state = Tensor(
+                    name=f"past_conv_state_{i}",
+                    dtype=self.dtype,
+                    shape=[-1, d_conv - 1, conv_dim],
+                    dim_range=conv_state_dim_range,
+                )
+                rnn_state = Tensor(
+                    name=f"past_rnn_state_{i}",
+                    dtype=str_dtype_to_trt("float32"),
+                    shape=[-1, n_v_heads, cfg.linear_key_head_dim, cfg.linear_value_head_dim],
+                    dim_range=rnn_state_dim_range,
+                )
+            conv_states.append(conv_state)
+            rnn_states.append(rnn_state)
+
+        slot_mapping = None
+        if paged:
+            slot_mapping = Tensor(
+                name="slot_mapping",
+                dtype=trt.int32,
+                shape=[-1],
+                dim_range=OrderedDict([("batch_size", batch_range)]),
+            )
+        return {
+            "conv_states": conv_states,
+            "rnn_states": rnn_states,
+            "slot_mapping": slot_mapping,
+        }
+
+    def prepare_inputs(
+        self,
+        max_batch_size,
+        max_input_len,
+        max_seq_len,
+        max_num_tokens,
+        use_cache,
+        max_beam_width: int = 1,
+        opt_num_tokens: int = None,
+        opt_batch_size: int = 0,
+        prompt_embedding_table_size: int = 0,
+        max_draft_len: int = 0,
+        gather_context_logits: bool = False,
+        lora_target_modules=None,
+        speculative_decoding_draft_tokens_external: bool = False,
+    ):
+        """Prepare the hybrid input tensors.
+
+        Standard LM + attention inputs for the full-attention layers, plus
+        conv/recurrent-state inputs for the GDN layers. Mirrors
+        RecurrentGemmaForCausalLM.prepare_inputs.
+        """
+        assert not speculative_decoding_draft_tokens_external, (
+            "Qwen3-Next does not support external draft-token spec decoding."
+        )
+        assert max_beam_width == 1, "Qwen3-Next does not support beam search."
+
+        from ..modeling_utils import get_kv_cache_type_from_legacy
+
+        remove_input_padding = default_net().plugin_config.remove_input_padding
+        use_gpt_attention_plugin = default_net().plugin_config.gpt_attention_plugin
+        use_gemm_plugin = default_net().plugin_config.gemm_plugin
+        paged_kv_cache = default_net().plugin_config.paged_kv_cache
+        tokens_per_block = default_net().plugin_config.tokens_per_block
+        multiple_profiles = default_net().plugin_config.multiple_profiles
+        streamingllm = default_net().plugin_config.streamingllm
+
+        mapping = self.config.mapping
+        kv_cache_type = get_kv_cache_type_from_legacy(use_cache, paged_kv_cache)
+
+        enable_ctx_gen_opt_profiles = GenerationMixin.has_ctx_gen_opt_profiles(
+            use_gpt_attention_plugin=use_gpt_attention_plugin,
+            use_gemm_plugin=use_gemm_plugin,
+            remove_input_padding=remove_input_padding,
+            kv_cache_type=kv_cache_type,
+        )
+        num_profiles, ranges = GenerationMixin.get_profiles_ranges(
+            max_batch_size=max_batch_size,
+            max_beam_width=max_beam_width,
+            max_input_len=max_input_len,
+            max_num_tokens=max_num_tokens,
+            max_draft_len=max_draft_len,
+            opt_batch_size=opt_batch_size,
+            opt_num_tokens=opt_num_tokens,
+            enable_ctx_gen_opt_profiles=enable_ctx_gen_opt_profiles,
+            multiple_profiles=multiple_profiles,
+            kv_cache_type=kv_cache_type,
+        )
+
+        if remove_input_padding:
+            input_ids = Tensor(
+                name="input_ids",
+                dtype=trt.int32,
+                shape=[-1],
+                dim_range=OrderedDict(
+                    [
+                        ("num_tokens", ranges["num_tokens_range"]),
+                    ]
+                ),
+            )
+            position_ids = Tensor(
+                name="position_ids",
+                dtype=trt.int32,
+                shape=[-1],
+                dim_range=OrderedDict(
+                    [
+                        ("position_ids_num_tokens_range", ranges["num_tokens_range"]),
+                    ]
+                ),
+            )
+        else:
+            input_ids = Tensor(
+                name="input_ids",
+                dtype=trt.int32,
+                shape=[-1, -1],
+                dim_range=OrderedDict(
+                    [
+                        ("batch_size_beam_width", ranges["bb_range"]),
+                        ("input_len", ranges["inlen_range"]),
+                    ]
+                ),
+            )
+            position_ids = Tensor(
+                name="position_ids",
+                dtype=trt.int32,
+                shape=[-1, -1],
+                dim_range=OrderedDict(
+                    [
+                        ("batch_size_beam_width", ranges["bb_range"]),
+                        ("position_ids_inlen_range", ranges["position_ids_inlen_range"]),
+                    ]
+                ),
+            )
+
+        # KV cache only for the full-attention layers.
+        attn_layer_idx = [
+            i for i in range(self.config.num_hidden_layers) if self.layer_types[i] == FULL_ATTENTION
+        ]
+        attention_inputs = self.prepare_attention_inputs(
+            max_batch_size=max_batch_size,
+            max_beam_width=max_beam_width,
+            max_input_len=max_input_len,
+            max_seq_len=max_seq_len,
+            num_kv_heads=self.config.num_key_value_heads,
+            head_size=self.config.head_size,
+            num_layers=self.config.num_hidden_layers,
+            kv_dtype=str_dtype_to_trt(self.config.kv_dtype),
+            num_profiles=num_profiles,
+            enable_ctx_gen_opt_profiles=enable_ctx_gen_opt_profiles,
+            remove_input_padding=remove_input_padding,
+            use_gpt_attention_plugin=use_gpt_attention_plugin,
+            kv_cache_type=kv_cache_type,
+            tokens_per_block=tokens_per_block,
+            mapping=mapping,
+            streamingllm=streamingllm,
+            attn_layer_idx=attn_layer_idx,
+        )
+
+        recurrent_inputs = self.prepare_recurrent_inputs(
+            max_batch_size=max_batch_size, num_profiles=num_profiles, mapping=mapping
+        )
+
+        if use_gpt_attention_plugin:
+            host_request_types = attention_inputs["host_request_types"]
+        else:
+            host_request_types = Tensor(
+                name="host_request_types",
+                dtype=trt.int32,
+                shape=[-1],
+                dim_range=OrderedDict([("batch_size_beam_width", ranges["bb_range"])]),
+            )
+
+        last_token_ids = Tensor(
+            name="last_token_ids",
+            dtype=trt.int32,
+            shape=[-1],
+            dim_range=OrderedDict([("batch_size_last_token_ids", ranges["bbd_range"])]),
+        )
+        last_token_ids_for_logits = None
+        if not gather_context_logits:
+            last_token_ids_for_logits = last_token_ids
+
+        if use_gpt_attention_plugin and remove_input_padding:
+            host_context_lengths = attention_inputs["host_context_lengths"]
+        elif remove_input_padding:
+            host_context_lengths = Tensor(
+                name="host_context_lengths",
+                dtype=trt.int32,
+                shape=[-1],
+                dim_range=OrderedDict([("batch_size_beam_width", ranges["bb_range"])]),
+            )
+        else:
+            host_context_lengths = None
+
+        return {
+            "input_ids": input_ids,
+            "position_ids": position_ids,
+            "use_cache": True,
+            "attention_mask": attention_inputs["attention_mask"],
+            "kv_cache_params": KeyValueCacheParams(
+                past_key_value=attention_inputs["past_key_value"],
+                host_past_key_value_lengths=attention_inputs["host_past_key_value_lengths"],
+                host_max_attention_window_sizes=attention_inputs["host_max_attention_window_sizes"],
+                host_sink_token_length=attention_inputs["host_sink_token_length"],
+                kv_cache_block_offsets=attention_inputs["kv_cache_block_offsets"],
+                host_kv_cache_block_offsets=attention_inputs["host_kv_cache_block_offsets"],
+                host_kv_cache_pool_pointers=attention_inputs["host_kv_cache_pool_pointers"],
+                host_kv_cache_pool_mapping=attention_inputs["host_kv_cache_pool_mapping"],
+                cache_indirection=attention_inputs["cache_indirection"],
+            ),
+            "attention_params": AttentionParams(
+                sequence_length=attention_inputs["sequence_length"],
+                context_lengths=attention_inputs["context_lengths"],
+                host_context_lengths=attention_inputs["host_context_lengths"],
+                max_context_length=max_input_len,
+                host_request_types=attention_inputs["host_request_types"],
+                host_runtime_perf_knobs=attention_inputs["host_runtime_perf_knobs"],
+                host_context_progress=attention_inputs["host_context_progress"],
+            ),
+            "conv_states": recurrent_inputs["conv_states"],
+            "rnn_states": recurrent_inputs["rnn_states"],
+            "host_request_types": host_request_types,
+            "last_token_ids": last_token_ids,
+            "last_token_ids_for_logits": last_token_ids_for_logits,
+            "host_context_lengths": host_context_lengths,
+            "slot_mapping": recurrent_inputs["slot_mapping"],
+        }


### PR DESCRIPTION
## Summary

Adds **classic TensorRT engine-path** support for the Qwen3.5 / Qwen3.6 hybrid MoE family (HF architectures `Qwen3_5MoeForConditionalGeneration` / `Qwen3NextForCausalLM`), together with a naive (correctness-first) TensorRT plugin for the Gated DeltaNet (GDN) linear-attention recurrence.

The model is a Qwen3-Next-style hybrid built on the RecurrentGemma hybrid template: a 3:1 interleave of **Gated DeltaNet linear-attention** layers and **full-attention** layers, each followed by a **256-expert MoE + shared expert**. The GDN layers reuse the engine's paged conv/RNN-state path (as for Mamba / RecurrentGemma); the full-attention layers use the KV cache and add an `attn_output_gate`.

> **Note on scope vs. the PyTorch backend:** this targets the *classic TensorRT engine* path (`tensorrt_llm/models/qwen3_next/`, the `convert → trtllm-build → serialized engine` flow). It is independent of the existing PyTorch-backend Qwen3-Next implementation (`tensorrt_llm/_torch/...`) and the FlashInfer GDN kernels — disjoint code paths, no overlap.

## Changes

- **C++ — naive Gated DeltaNet plugin** (`cpp/tensorrt_llm/plugins/gatedDeltaNetPlugin/`): correctness-first kernel that walks each sequence token-by-token with an fp32 recurrent state `[D_k, D_v]` per (request, v-head). Optimization (chunking, tensor cores, vectorized loads, state tiling) is intentionally out of scope; the goal is numerical parity with the PyTorch reference. Only the dense (non-paged, non-remove-padding) path is wired up; the paged_state / remove_input_padding signatures are parsed and reserved for a follow-up. Registered in `tllmPlugin.cpp` + plugin CMake list.
- **C++ — runtime recognition** (`modelConfig.h`, `gptJsonConfig.cpp`): adds a `kQwen3Next` model variant, marks it RNN-based so the recurrent conv/RNN-state path is reused for the GDN layers, maps both architectures, and parses the recurrent-state config fields.
- **Python op binding** (`functional.gated_delta_rule`): binds the plugin; consumes the post-conv, head-split q/k/v and per-head decay `g` / update-gate `beta`, returns recurrence output + present state.
- **`layers/attention.py` — `attn_output_gate`**: optional sigmoid output gate (`context * sigmoid(gate)`) applied before `o_proj`. The gate shards over heads like Q (`gather_output=False`), so `o_proj` still owns the single TP all-reduce. Handles the FP8 attention-context case (dequantize with `dense`'s activation scale before the gate multiply, then re-quantize).
- **Model** (`tensorrt_llm/models/qwen3_next/`): config parser (nested HF text/vision/quant config → flat engine fields + recurrent-state self-description for the C++ runtime), checkpoint converter (mixed-precision FP8 attention + NVFP4 MoE/lm_head ingestion, gate-doubled `q_proj` de-interleave, Gemma-style RMSNorm `+1` fold), and the model (GDN mixer, full attention with output gate, paged conv/RNN-state wiring). Registers both architectures in `models/__init__.py`.

## Scope / not included

This is an initial engine-path drop covering the **text-generation path**. Out of scope here:

- The MTP (multi-token-prediction) head.
- The Qwen3-VL vision tower.
- Interleaved MRoPE for multimodal positions (text-only positions collapse to standard RoPE, so text generation is unaffected).
- The paged_state / remove_input_padding kernel paths in the GDN plugin (signatures reserved).

## Testing

The engine-path numerical validation was done with a standalone correctness harness (GDN recurrence vs. a PyTorch reference, plus token-exact comparisons against the HF/vLLM reference) that lives outside the library source tree, so it is **not** part of this PR. Adding in-tree unit tests for the GDN plugin and the model construction/conversion is a planned follow-up. Reviewers' guidance on the preferred test location/shape is welcome.

## Notes for reviewers

- Per CONTRIBUTING, this is filed against `main`.
- Pre-commit formatting/lint hooks (isort, yapf, clang-format, cmake-format, ruff, ruff-legacy, autoflake, codespell) pass on the changed files.
