### PR TITLE
[None][feat] AutoDeploy: enable attention-DP request balancer in SuperV3-MTP config

### DIFF
--- a/examples/auto_deploy/model_registry/configs/super_v3_mtp.yaml
+++ b/examples/auto_deploy/model_registry/configs/super_v3_mtp.yaml
@@ -18,6 +18,18 @@ speculative_config:
   decoding_type: MTP
   num_nextn_predict_layers: 6
   mtp_eagle_one_model: true
+# Enable the attention-DP request balancer (PyExecutor._balance_adp_requests).
+# No-op unless attention-DP is active (multi-GPU with enable_attention_dp).
+# When active, it balances per-rank decode load so the busiest rank does not
+# gate every MoE all-to-all collective step (the collective syncs all ranks),
+# which otherwise inflates inter-token latency. Measured +64-111% output-token
+# throughput at concurrency 128/256 on SuperV3-MTP NVFP4 attention-DP serving.
+# Trade-off: defers prefill, raising TTFT at high concurrency; tune the wait
+# iters below if first-token latency is the priority.
+attention_dp_config:
+  enable_balance: true
+  batching_wait_iters: 10
+  timeout_iters: 16
 transforms:
   detect_sharding:
     allreduce_strategy: NCCL


### PR DESCRIPTION
## Summary
Enables the attention-DP request balancer (`PyExecutor._balance_adp_requests`) for the SuperV3-MTP AutoDeploy config by adding a top-level `attention_dp_config` block to the shipped `examples/auto_deploy/model_registry/configs/super_v3_mtp.yaml`:

```yaml
attention_dp_config:
  enable_balance: true
  batching_wait_iters: 10
  timeout_iters: 16
```

## Why
Under attention-DP, each MoE all-to-all is a collective that synchronizes all DP ranks every step. The rank holding the most sequences becomes a straggler that gates the collective, inflating inter-token latency. The balancer redistributes per-rank decode load so no single rank gates the collective.

## Impact
- **+64–111% output-token throughput** at concurrency 128/256 on SuperV3-MTP NVFP4 attention-DP serving (SPEED-Bench).
- Trade-off: defers prefill, raising TTFT at high concurrency. Tune `batching_wait_iters` / `timeout_iters` when first-token latency is the priority.

## Scope / safety
- **Config-only change.** No source-code default changes — the balancer stays opt-in. Configs that do not set `attention_dp_config` are unaffected.
- **No-op unless attention-DP is active** (multi-GPU with `enable_attention_dp`). Single-GPU and `attn_dp_off` paths are unchanged (the balancer requires `tp_size > 1`).
- The `TestNemotronSuperV3::test_accuracy` matrix drives `enable_attention_dp` via a `detect_sharding` kwarg override, so both `attn_dp_off` and `attn_dp_on` variants continue to exercise this config correctly.

## Test Coverage
Covered by existing `accuracy/test_llm_api_autodeploy.py::TestNemotronSuperV3::test_accuracy[*-4-attn_dp_on-trtllm]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added attention-DP request balancer configuration for SuperV3 MTP speculative decoding, enabling optimized decode load balancing across distributed ranks with tunable batching and timeout parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->