### PR TITLE
[None][perf] Serialize GenerationRequest token-id lists as int32 bytes

### DIFF
--- a/tensorrt_llm/executor/request.py
+++ b/tensorrt_llm/executor/request.py
@@ -146,6 +146,45 @@ class GenerationRequest:
         self.id = id
         return self
 
+    # --- int32-byte serialization of token-id lists (kills per-token pickle PyLong) ---
+    _I32 = "\x00i32be"
+
+    @staticmethod
+    def _enc_tokens(v):
+        # flat list[int] -> (_I32, int32 bytes); leave anything else (None,
+        # list[list[int]], ndarray) untouched.
+        if type(v) is list and (len(v) == 0 or type(v[0]) is int):
+            import numpy as _np
+            return (GenerationRequest._I32,
+                    _np.asarray(v, dtype=_np.int32).tobytes())
+        return v
+
+    @staticmethod
+    def _dec_tokens(v):
+        if type(v) is tuple and len(v) == 2 and v[0] == GenerationRequest._I32:
+            import numpy as _np
+            return _np.frombuffer(v[1], dtype=_np.int32).tolist()
+        return v
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        if "prompt_token_ids" in state:
+            state["prompt_token_ids"] = GenerationRequest._enc_tokens(
+                state["prompt_token_ids"])
+        if state.get("query_token_ids") is not None:
+            state["query_token_ids"] = GenerationRequest._enc_tokens(
+                state["query_token_ids"])
+        return state
+
+    def __setstate__(self, state):
+        if "prompt_token_ids" in state:
+            state["prompt_token_ids"] = GenerationRequest._dec_tokens(
+                state["prompt_token_ids"])
+        if state.get("query_token_ids") is not None:
+            state["query_token_ids"] = GenerationRequest._dec_tokens(
+                state["query_token_ids"])
+        self.__dict__.update(state)
+
 
 class TruncateKVCacheRequest:
 


### PR DESCRIPTION
## What

`GenerationRequest.prompt_token_ids` / `query_token_ids` are stored as Python `list[int]`. When the request is pickled on the RPC submit path (proxy → worker), each token emits a separate PyLong/BININT pickle frame. For long-context requests (tens of thousands of prompt tokens) this per-token framing dominates host-side serialization cost.

This adds `__getstate__` / `__setstate__` to `GenerationRequest` that encode the flat token-id lists as a raw int32 byte buffer (single numpy C pass) and decode them back to `list[int]` on the receiving side. Non-list values (`None`, `list[list[int]]`, ndarray) pass through untouched, so all downstream consumers are unchanged. The encoding is symmetric and only consumed within one build (proxy ↔ worker), so there is no cross-version wire-format concern.

This is the Python analog of the C++ `tllm.Request` `__getstate__`/`__setstate__` change; it targets the object actually pickled on the submit path.

## Effect

On DSv4 CTX-only (c256, ~41K-token ISL), the host-side `_fetch_new_requests` NVTX window drops ~22% in profiles where the IPC thread is the contention source. The effect is host/GIL-side; end-to-end throughput at GPU-bound concurrencies is unchanged within noise. Complementary to the C++ `tllm.Request` serialization change (which covers the worker-side DP broadcast path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)