### PR TITLE
[None][perf] Draft: pin serve preprocessing threadpool to local NUMA node

### DIFF
--- a/tensorrt_llm/llmapi/utils.py
+++ b/tensorrt_llm/llmapi/utils.py
@@ -622,6 +622,49 @@ def get_numa_aware_cpu_affinity(device_id):
     return cpu_affinity
 
 
+def _parse_cpulist(cpulist: str) -> List[int]:
+    cpus: List[int] = []
+    for part in cpulist.split(','):
+        part = part.strip()
+        if '-' in part:
+            lo, hi = part.split('-', 1)
+            cpus.extend(range(int(lo), int(hi) + 1))
+        elif part:
+            cpus.append(int(part))
+    return cpus
+
+
+def get_current_numa_cpus() -> List[int]:
+    '''Return the CPU IDs on the same NUMA node as the calling thread.
+
+    Reads the current CPU from the OS scheduler and maps it to its NUMA node
+    via sysfs.  Falls back to all CPUs on non-NUMA systems or on any error.
+    '''
+    cpu_count = psutil.cpu_count()
+    all_cpus = list(range(cpu_count))
+
+    if not os.path.isdir("/sys/devices/system/node/node1"):
+        return all_cpus
+
+    try:
+        current_cpu = psutil.Process().cpu_num()
+        for entry in sorted(os.scandir("/sys/devices/system/node"),
+                            key=lambda e: e.name):
+            if not entry.name.startswith("node"):
+                continue
+            cpulist_path = os.path.join(entry.path, "cpulist")
+            if not os.path.exists(cpulist_path):
+                continue
+            with open(cpulist_path) as f:
+                cpus = _parse_cpulist(f.read().strip())
+            if current_cpu in cpus:
+                return cpus
+    except Exception:
+        pass
+
+    return all_cpus
+
+
 def generate_api_docs_as_docstring(model: Type[BaseModel],
                                    include_annotations=False,
                                    indent="") -> str:

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import asyncio
 import base64
+import concurrent.futures
 import json
 import os
 import re
@@ -42,6 +43,7 @@ from tensorrt_llm.llmapi.disagg_utils import (DisaggClusterConfig,
 from tensorrt_llm.llmapi.llm import RequestOutput
 from tensorrt_llm.llmapi.thinking_budget import \
     add_thinking_budget_logits_processor
+from tensorrt_llm.llmapi.utils import get_current_numa_cpus
 from tensorrt_llm.logger import logger
 from tensorrt_llm.media.encoding import image_to_bytes
 from tensorrt_llm.metrics.collector import MetricsCollector
@@ -243,8 +245,29 @@ class OpenAIServer(_VideoRoutesMixin):
         else:
             self._init_llm(chat_template)
 
+        _preprocessing_numa_cpus = get_current_numa_cpus()
+        _preprocessing_num_workers = min(32, (os.cpu_count() or 1) + 4)
+
         @asynccontextmanager
         async def lifespan(app: FastAPI):
+
+            def _pin_preprocessing_thread():
+                if hasattr(os, 'sched_setaffinity'):
+                    try:
+                        os.sched_setaffinity(0, _preprocessing_numa_cpus)
+                    except OSError:
+                        pass
+
+            preprocessing_executor = concurrent.futures.ThreadPoolExecutor(
+                max_workers=_preprocessing_num_workers,
+                initializer=_pin_preprocessing_thread,
+            )
+            asyncio.get_running_loop().set_default_executor(
+                preprocessing_executor)
+            logger.info(
+                f"Preprocessing threadpool ({_preprocessing_num_workers} workers) "
+                f"pinned to CPUs {_preprocessing_numa_cpus}")
+
             if self.metadata_server is not None:
                 metadata = {
                     "model": self.model,
@@ -316,6 +339,7 @@ class OpenAIServer(_VideoRoutesMixin):
             if self.resource_governor is not None:
                 self.resource_governor.close()
             self.generator.shutdown()
+            preprocessing_executor.shutdown(wait=False)
 
         self.app = FastAPI(lifespan=lifespan)
 


### PR DESCRIPTION
Add get_current_numa_cpus() to llmapi/utils.py which samples the calling thread's current CPU and maps it to its NUMA node via sysfs, falling back to all CPUs on non-NUMA systems.

In OpenAIServer, install a ThreadPoolExecutor as the asyncio default executor (same worker count as the stdlib default) whose initializer calls os.sched_setaffinity(0, ...) to pin each preprocessing thread to the local NUMA node. This prevents inter-core migration that thrashes L1/L2 caches and keeps CPython heap allocations co-located during tokenization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented NUMA-aware CPU selection utilities to detect and utilize CPUs local to the current NUMA node.
  * Server preprocessing threads are now CPU-affinity pinned to local NUMA CPUs, with automatic fallback for non-NUMA systems.
  * Added server startup and shutdown logging for preprocessing thread configuration and CPU mask assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
