### PR TITLE
[TRTLLM-12648][test] enable disagg cancellation stress test

### DIFF
--- a/tests/integration/defs/stress_test/disagg_cancel/README.md
+++ b/tests/integration/defs/stress_test/disagg_cancel/README.md
@@ -26,8 +26,9 @@ land incrementally:
 
 Component-level coverage: `test_log_scanner.py`, `test_metrics_thread.py`,
 `test_injector.py`, `test_canary.py`, `test_load_thread.py`. The
-parametrized marathon pytest still runs a lifecycle smoke until
-`setup()` launches a real cluster.
+parametrized C++/V1 DeepSeek marathon is registered in the QA stress
+test list; it still runs a lifecycle smoke until `setup()` launches a
+real cluster.
 
 ## File layout
 
@@ -59,10 +60,33 @@ Future additions:
 
 ## How to run
 
-The marathons are **not** registered in pre-merge CI. They are run
-nightly / weekly via
-`tests/integration/test_lists/qa/llm_function_stress.txt` (wiring
-lands with the explicit CI-registration change).
+### Automatic QA stress run
+
+The C++/V1 DeepSeek marathon is registered in
+`tests/integration/test_lists/qa/llm_function_stress.txt` for scheduled
+QA stress runs. The registered entry is:
+
+```text
+stress_test/disagg_cancel/test_disagg_cancel_stress.py::test_disagg_cancellation_marathon[marathon_cpp_v1_deepseek.yaml] TIMEOUT (150)
+```
+
+The integration test-list parser interprets `TIMEOUT (150)` in
+minutes. CI should run the list from `tests/integration/defs` with:
+
+```bash
+pytest --test-list=../test_lists/qa/llm_function_stress.txt \
+  --output-dir=<ci-output-dir> \
+  -s -v
+```
+
+The automatic runner must use the normal TRT-LLM integration container
+or virtual environment. Once `setup()` launches the real disaggregated
+cluster, it also needs `LLM_MODELS_ROOT` set so
+`DeepSeek-V3-Lite/bf16` resolves to local model weights. At this stage
+the entry still completes as a lifecycle smoke because `setup()` has
+not launched a real disaggregated cluster yet; once cluster setup
+lands, the same test-list entry runs the configured 120-minute
+marathon.
 
 ### Unit tests (no GPU, no cluster)
 
@@ -120,16 +144,57 @@ the same tests also run under the normal integration pytest path:
 pytest -sv tests/integration/defs/stress_test/disagg_cancel/test_injector.py
 ```
 
-### Lifecycle smoke (injector not exercised on real workers)
+### Direct lifecycle smoke (no GPU, no cluster)
 
 ```bash
-pytest -sv tests/integration/defs/stress_test/disagg_cancel/test_disagg_cancel_stress.py::test_disagg_cancellation_marathon
+PYTHONPATH=tests/integration/defs:tests/integration/defs/disaggregated \
+python3 -m pytest -c /dev/null -o addopts= \
+  -p no:cacheprovider \
+  --confcutdir=tests/integration/defs/stress_test \
+  tests/integration/defs/stress_test/disagg_cancel/test_disagg_cancel_stress.py::test_disagg_cancellation_marathon -sv
 ```
 
 `setup()` is still a stub, so this only checks harness lifecycle
 (`setup` → `start` → `wait` → `stop`). The injector thread exits
 immediately because no workers are registered via
 `bind_tracked_workers()`.
+
+### Manual QA stress-list selection
+
+From a full TRT-LLM integration environment:
+
+```bash
+cd /path/to/TensorRT-LLM/tests/integration/defs
+export LLM_MODELS_ROOT=/path/to/model/root  # required once real setup() lands
+
+pytest stress_test/disagg_cancel/test_disagg_cancel_stress.py \
+  --test-list=../test_lists/qa/llm_function_stress.txt \
+  --output-dir=/tmp/trtllm-disagg-cancel-stress \
+  -s -v
+```
+
+To collect without running:
+
+```bash
+pytest stress_test/disagg_cancel/test_disagg_cancel_stress.py \
+  --test-list=../test_lists/qa/llm_function_stress.txt \
+  --output-dir=/tmp/trtllm-disagg-cancel-stress \
+  -s --co -q
+```
+
+### Manual CI trigger
+
+On a GitHub pull request, ask the CI bot which stress stages are
+available, then trigger the QA stress stage that consumes
+`tests/integration/test_lists/qa/llm_function_stress.txt`:
+
+```text
+/bot help
+/bot run --extra-stage "<QA stress stage that runs llm_function_stress.txt>"
+```
+
+The bot stage name is owned by CI/Jenkins configuration and is not
+declared in this directory.
 
 ### Local marathon (after `setup()` lands)
 

--- a/tests/integration/defs/stress_test/disagg_cancel/README.md
+++ b/tests/integration/defs/stress_test/disagg_cancel/README.md
@@ -1,6 +1,6 @@
 # Disaggregated Cancellation Stress-Test Suite
 
-Marathon-style stress tests that gate regressions of the bug class
+Disaggregated stress tests that gate regressions of the bug class
 fixed by <https://github.com/NVIDIA/TensorRT-LLM/pull/13713>
 (cleanup / lifetime / quiescence invariants in the disagg KV
 transceiver under heavy mid-flight cancellation).
@@ -13,8 +13,22 @@ transceiver under heavy mid-flight cancellation).
 
 ## Status
 
-The harness class structure and lifecycle are in place. Thread bodies
-land incrementally:
+The registered QA stress entry now launches a real C++/V1 DeepSeek
+disaggregated cluster in `log_only` mode. That mode sends normal
+non-cancel completion probes through the front-end and scans saved
+worker/server logs for UAF, broken-promise, and segmentation-fault
+signatures. It is intentionally narrow so it can run regularly before
+in-flight cancellation and poison-buffer hardening are available.
+
+The full cancellation/poison marathon is implemented as an explicit
+mode switch, but it is not the registered default yet.
+
+| Mode | CI status | Threads | Coverage |
+|------|-----------|---------|----------|
+| `log_only` | Registered in `qa/llm_function_stress.txt` | log-only probe + log scanner | startup/data-path crash guard: UAF, broken promise, segfault-class logs |
+| `full_cancel_poison` | Opt-in only | load, canary, injector, log scanner, metrics | cancellation load, failure injection, poison canaries, KV-growth guard |
+
+Thread bodies:
 
 | Thread | Status |
 |--------|--------|
@@ -26,9 +40,8 @@ land incrementally:
 
 Component-level coverage: `test_log_scanner.py`, `test_metrics_thread.py`,
 `test_injector.py`, `test_canary.py`, `test_load_thread.py`. The
-parametrized C++/V1 DeepSeek marathon is registered in the QA stress
-test list; it still runs a lifecycle smoke until `setup()` launches a
-real cluster.
+parametrized C++/V1 DeepSeek run is registered in the QA stress test
+list as a real `log_only` guardrail.
 
 ## File layout
 
@@ -53,10 +66,41 @@ Future additions:
 - `tools/generate_canary_references.py` — one-shot reference generator
   that records greedy-decode token IDs for the canary prompts.
 - `configs/stress_canary_prompts.json` — canary prompts + recorded
-  reference token IDs (consumed by the canary thread).
+  reference token IDs for `full_cancel_poison`.
 - Per-scenario YAMLs covering additional axes: 1P1D, 4P2D,
   V1+Python, UCX, block-reuse-off, overlap-off, aggressive-timeout,
   multi-node (all Python-only test-side configuration).
+
+## Mode Switch
+
+The active mode is controlled by
+`configs/marathon_cpp_v1_deepseek.yaml`:
+
+```yaml
+stress_config:
+  mode: log_only
+  duration_min: 10
+```
+
+Use `log_only` for regular CI until both runtime features are in
+place:
+
+- in-flight request cancellation support for the disaggregated path.
+- poison-buffer hardening that makes poisoned cache transfers
+  expected and recoverable.
+
+To switch to the full cancellation/poison marathon after those
+features are ready:
+
+1. Set `stress_config.mode: full_cancel_poison`.
+2. Set `stress_config.duration_min: 120` for the two-hour marathon.
+3. Keep or tune `base_concurrency`, `bursts`, and `injections`.
+4. Add `configs/stress_canary_prompts.json` with token references and
+   keep `canary.check_token_equivalent: true`.
+5. Add the poison-buffer hard-zero/expected-recovery patterns that
+   match the finalized runtime behavior.
+6. Raise the test-list timeout back to a full-marathon budget, e.g.
+   `TIMEOUT (150)`.
 
 ## How to run
 
@@ -67,10 +111,10 @@ The C++/V1 DeepSeek marathon is registered in
 QA stress runs. The registered entry is:
 
 ```text
-stress_test/disagg_cancel/test_disagg_cancel_stress.py::test_disagg_cancellation_marathon[marathon_cpp_v1_deepseek.yaml] TIMEOUT (150)
+stress_test/disagg_cancel/test_disagg_cancel_stress.py::test_disagg_cancellation_marathon[marathon_cpp_v1_deepseek.yaml] TIMEOUT (45)
 ```
 
-The integration test-list parser interprets `TIMEOUT (150)` in
+The integration test-list parser interprets `TIMEOUT (45)` in
 minutes. CI should run the list from `tests/integration/defs` with:
 
 ```bash
@@ -80,13 +124,11 @@ pytest --test-list=../test_lists/qa/llm_function_stress.txt \
 ```
 
 The automatic runner must use the normal TRT-LLM integration container
-or virtual environment. Once `setup()` launches the real disaggregated
-cluster, it also needs `LLM_MODELS_ROOT` set so
-`DeepSeek-V3-Lite/bf16` resolves to local model weights. At this stage
-the entry still completes as a lifecycle smoke because `setup()` has
-not launched a real disaggregated cluster yet; once cluster setup
-lands, the same test-list entry runs the configured 120-minute
-marathon.
+or virtual environment with GPU access, `trtllm-serve` on `PATH`, and
+`LLM_MODELS_ROOT` set so `DeepSeek-V3-Lite/bf16` resolves to local
+model weights. The current registered run is `log_only`: setup can
+take up to 20 minutes, then the harness probes for 10 minutes and
+tails worker/server logs.
 
 ### Unit tests (no GPU, no cluster)
 
@@ -129,12 +171,13 @@ python3 -m pytest -c /dev/null -o addopts= \
   tests/integration/defs/stress_test/disagg_cancel/test_disagg_cancel_stress.py::test_all_marathon_yamls_parse_and_validate -v
 ```
 
-All component tests together:
+All component tests together, excluding the real cluster entry:
 
 ```bash
 python3 -m pytest -c /dev/null -o addopts= \
   --confcutdir=tests/integration/defs/stress_test \
-  tests/integration/defs/stress_test/disagg_cancel/ -q
+  tests/integration/defs/stress_test/disagg_cancel/ \
+  -k "not test_disagg_cancellation_marathon" -q
 ```
 
 In a full TRT-LLM dev container/venv (with `transformers` installed),
@@ -144,28 +187,13 @@ the same tests also run under the normal integration pytest path:
 pytest -sv tests/integration/defs/stress_test/disagg_cancel/test_injector.py
 ```
 
-### Direct lifecycle smoke (no GPU, no cluster)
-
-```bash
-PYTHONPATH=tests/integration/defs:tests/integration/defs/disaggregated \
-python3 -m pytest -c /dev/null -o addopts= \
-  -p no:cacheprovider \
-  --confcutdir=tests/integration/defs/stress_test \
-  tests/integration/defs/stress_test/disagg_cancel/test_disagg_cancel_stress.py::test_disagg_cancellation_marathon -sv
-```
-
-`setup()` is still a stub, so this only checks harness lifecycle
-(`setup` → `start` → `wait` → `stop`). The injector thread exits
-immediately because no workers are registered via
-`bind_tracked_workers()`.
-
-### Manual QA stress-list selection
+### Manual regular guardrail run
 
 From a full TRT-LLM integration environment:
 
 ```bash
 cd /path/to/TensorRT-LLM/tests/integration/defs
-export LLM_MODELS_ROOT=/path/to/model/root  # required once real setup() lands
+export LLM_MODELS_ROOT=/path/to/model/root
 
 pytest stress_test/disagg_cancel/test_disagg_cancel_stress.py \
   --test-list=../test_lists/qa/llm_function_stress.txt \
@@ -196,16 +224,26 @@ available, then trigger the QA stress stage that consumes
 The bot stage name is owned by CI/Jenkins configuration and is not
 declared in this directory.
 
-### Local marathon (after `setup()` lands)
+### Manual full cancellation/poison run
 
-Once `setup()` launches a real 3P3D cluster and registers workers,
-the full 2-hour marathon runs via the same pytest entry point. For
-development, set `duration_min: 10` and trim `injections:` in the
-YAML.
+After the runtime support is in place, switch the YAML to
+`mode: full_cancel_poison`, set the intended duration and canary
+references, then run the same pytest entry point. For development,
+use a shorter `duration_min` and trim `injections:` locally before
+restoring the checked-in values.
 
 ## Pass criteria
 
-A marathon run is "clean" iff all of the following hold:
+`log_only` is clean iff all of the following hold:
+
+- The 3P3D disaggregated cluster starts and reaches readiness.
+- At least one normal completion probe succeeds through the
+  disaggregated front-end.
+- No hard-zero log patterns for UAF, broken promise, or
+  segmentation-fault-class failures appear in any saved worker or
+  disagg-server log.
+
+`full_cancel_poison` is clean iff all of the following hold:
 
 - No hard-zero log patterns (e.g. `Cannot cancel request`, `Broken
   promise`, `unquiesced`, double-free / UAF traces) appear in any
@@ -222,23 +260,22 @@ A marathon run is "clean" iff all of the following hold:
 - KV-cache utilization growth ≤ 10 percentage points end-to-end
   (leak guard).
 
-Concrete thresholds for each metric are declared in the marathon
-YAML's `pass_criteria:` block.
+Concrete thresholds for each metric are declared in the marathon YAML.
 
 ## How to debug a failure
 
-(Stub — the full debug guide lands together with the thread
-implementations.)
-
-For now, when the skeleton test fails:
+When the regular guardrail fails:
 
 1. Confirm the YAML parses:
    ```bash
    python -c "from harness import StressConfig; StressConfig.from_yaml_path('configs/marathon_cpp_v1_deepseek.yaml')"
    ```
 2. Check the `failure_reason` field in `collect_results()` output.
-3. Look at the pytest stdout for harness `logger` lines (each thread
-   logs its identity on entry / exit).
+3. Inspect the log tails printed by `disagg_test_utils.terminate()`
+   during teardown; saved worker logs and `disagg_server.log` are
+   tailed before cleanup.
+4. If setup times out, confirm `LLM_MODELS_ROOT`, GPU count, and
+   `trtllm-serve` availability in the integration environment.
 
 ## Cross-references
 

--- a/tests/integration/defs/stress_test/disagg_cancel/README.md
+++ b/tests/integration/defs/stress_test/disagg_cancel/README.md
@@ -104,11 +104,18 @@ features are ready:
 
 ## How to run
 
-### Automatic QA stress run
+### Scheduled QA stress run
 
 The C++/V1 DeepSeek marathon is registered in
-`tests/integration/test_lists/qa/llm_function_stress.txt` for scheduled
-QA stress runs. The registered entry is:
+`tests/integration/test_lists/qa/llm_function_stress.txt`, which makes
+it eligible for the QA/Jenkins job that consumes that stress list. This
+PR does not create or modify the scheduler for that job; the exact
+cadence and wall-clock start time are owned by QA CI configuration
+outside this directory. The in-repo QA README describes QA lists as
+regular daily/release and weekly/release/on-demand coverage, but does
+not define a file-specific cadence for `llm_function_stress.txt`.
+
+The registered entry is:
 
 ```text
 stress_test/disagg_cancel/test_disagg_cancel_stress.py::test_disagg_cancellation_marathon[marathon_cpp_v1_deepseek.yaml] TIMEOUT (45)
@@ -123,7 +130,7 @@ pytest --test-list=../test_lists/qa/llm_function_stress.txt \
   -s -v
 ```
 
-The automatic runner must use the normal TRT-LLM integration container
+The scheduled runner must use the normal TRT-LLM integration container
 or virtual environment with GPU access, `trtllm-serve` on `PATH`, and
 `LLM_MODELS_ROOT` set so `DeepSeek-V3-Lite/bf16` resolves to local
 model weights. The current registered run is `log_only`: setup can

--- a/tests/integration/defs/stress_test/disagg_cancel/configs/README.md
+++ b/tests/integration/defs/stress_test/disagg_cancel/configs/README.md
@@ -25,6 +25,25 @@ The new `stress_config:` top-level block is consumed by
 `StressConfig` itself (dataclass field docstrings) and the
 example values in `marathon_cpp_v1_deepseek.yaml`.
 
+## Harness modes
+
+`stress_config.mode` is the switch between the regular guardrail and
+the full cancellation/poison marathon:
+
+- `log_only`: registered CI mode. The harness launches the real
+  disaggregated cluster, sends normal non-cancel probes, and scans
+  worker/server logs for UAF, broken-promise, and segmentation-fault
+  signatures. This mode is safe before in-flight cancellation and
+  poison-buffer hardening are available.
+- `full_cancel_poison`: opt-in mode for the completed runtime. The
+  harness enables the cancellation load, SIGSTOP/SIGKILL injections,
+  token-equivalent canaries, metrics scraping, and KV-growth checks.
+
+When switching from `log_only` to `full_cancel_poison`, update
+`duration_min`, canary references, poison-buffer log expectations, and
+the test-list timeout together. The top-level README has the exact
+checklist.
+
 ## Backend-knob axis: KV-cache manager × transceiver runtime
 
 Two knobs select which (KV cache manager × transceiver runtime)
@@ -51,7 +70,8 @@ Python changes** required beyond extending the parametrize list. To
 add a new config:
 
 1. Copy `marathon_cpp_v1_deepseek.yaml` as a template.
-2. Adjust `model`, `kv_cache_manager`, `transceiver`, and any
+2. Choose `stress_config.mode`, then adjust `model`,
+   `kv_cache_manager`, `transceiver`, and any
    load-shape knobs (`base_concurrency`, `client_cancel_rate`,
    `output_length`, `injections:`, `pass_criteria:`).
 3. Add the new filename to `_MARATHON_CONFIGS` in

--- a/tests/integration/defs/stress_test/disagg_cancel/configs/marathon_cpp_v1_deepseek.yaml
+++ b/tests/integration/defs/stress_test/disagg_cancel/configs/marathon_cpp_v1_deepseek.yaml
@@ -52,12 +52,28 @@ generation_servers:
 # Schema documented in ../README.md.
 # ============================================================================
 stress_config:
-  duration_min: 120                  # 2 h marathon
+  # MODE SWITCH (intentionally loud):
+  # - log_only: current registered CI mode. Launches the real disagg cluster,
+  #   sends normal non-cancel probes, and scans saved worker/server logs for
+  #   UAF, broken-promise, and segmentation-fault signatures. This mode does
+  #   NOT require in-flight cancellation or poison-buffer support.
+  # - full_cancel_poison: future opt-in mode after in-flight cancellation and
+  #   poison-buffer hardening are available. It enables the cancellation load,
+  #   fault injections, token-equivalent canaries, and KV-growth checks below.
+  mode: log_only
+  duration_min: 10                   # regular guardrail run; use 120 for full_cancel_poison
 
   # Backend-knob axis selectors. Must match
   # context_servers / generation_servers above.
   kv_cache_manager: v1               # V1 (C++) KV cache manager
   transceiver: cpp                   # C++-backed transceiver (BindKvCacheTransceiver)
+
+  log_only_probe:
+    interval_s: 30
+    prompt: "Write one sentence about reliable distributed inference."
+    max_tokens: 32
+    seed: 42
+    request_timeout_s: 30
 
   base_concurrency: 64
   client_cancel_rate: 0.10
@@ -120,10 +136,13 @@ stress_config:
   log_scan:
     hard_zero_patterns:
       - "Broken promise"
-      - "NO RECOVERY"
       - "Segfault"
+      - "Segmentation fault"
       - "SIGSEGV"
       - "0xffffffffffffffff"
-      - "Poisoned .* cache transfer buffer"
+      - "use-after-free"
+      - "heap-use-after-free"
+      - "AddressSanitizer:.*use-after-free"
+      - "double[- ]free"
 
   kv_cache_growth_max: 0.10   # final utilization ≤ baseline + 10 percentage points

--- a/tests/integration/defs/stress_test/disagg_cancel/configs/marathon_python_v2_qwen.yaml
+++ b/tests/integration/defs/stress_test/disagg_cancel/configs/marathon_python_v2_qwen.yaml
@@ -54,6 +54,11 @@ generation_servers:
     kv_transfer_timeout_ms: 60000
 
 stress_config:
+  # Placeholder template for the future full marathon. This YAML is
+  # intentionally not parametrized until the runtime supports the
+  # cancellation + poison-buffer contract and canary references are
+  # recorded for Qwen2.5-7B-Instruct.
+  mode: full_cancel_poison
   duration_min: 120
 
   kv_cache_manager: v2

--- a/tests/integration/defs/stress_test/disagg_cancel/harness.py
+++ b/tests/integration/defs/stress_test/disagg_cancel/harness.py
@@ -33,8 +33,10 @@ import logging
 import os
 import random
 import re
+import shutil
 import signal
 import subprocess
+import tempfile
 import threading
 import time
 import urllib.error
@@ -47,6 +49,10 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
+_STRESS_MODE_LOG_ONLY = "log_only"
+_STRESS_MODE_FULL_CANCEL_POISON = "full_cancel_poison"
+_STRESS_MODES = (_STRESS_MODE_LOG_ONLY, _STRESS_MODE_FULL_CANCEL_POISON)
+
 
 # ---------------------------------------------------------------------------
 # Config dataclasses
@@ -58,6 +64,7 @@ logger = logging.getLogger(__name__)
 # simply aren't passed to the constructor, so the field defaults
 # apply automatically and are not duplicated here.
 _STRESS_CONFIG_COERCERS: dict[str, Callable[[Any], Any]] = {
+    "mode": str,
     "duration_min": float,
     "kv_cache_manager": str,
     "transceiver": str,
@@ -76,6 +83,7 @@ class StressConfig:
     pass them around without re-parsing.
     """
 
+    mode: str = _STRESS_MODE_LOG_ONLY
     duration_min: float = 120.0
     kv_cache_manager: str = "v1"  # v1 | v2  (v2 + CPP is invalid)
     transceiver: str = "cpp"  # cpp | python
@@ -137,6 +145,8 @@ class StressConfig:
                 supplied (the C++ transceiver only supports the V1
                 KV cache manager).
         """
+        if self.mode not in _STRESS_MODES:
+            raise ValueError(f"mode must be one of {_STRESS_MODES}, got {self.mode!r}")
         if self.kv_cache_manager == "v2" and self.transceiver == "cpp":
             # The C++ transceiver (BindKvCacheTransceiver) only supports
             # the V1 KV cache manager. V2 must be paired with the Python
@@ -151,6 +161,16 @@ class StressConfig:
             )
         if self.transceiver not in ("cpp", "python"):
             raise ValueError(f"transceiver must be 'cpp' or 'python', got {self.transceiver!r}")
+
+    @property
+    def is_log_only(self) -> bool:
+        """True when the harness should run the regular CI guardrail mode."""
+        return self.mode == _STRESS_MODE_LOG_ONLY
+
+    @property
+    def is_full_cancel_poison(self) -> bool:
+        """True when the harness should run the full cancellation/poison marathon."""
+        return self.mode == _STRESS_MODE_FULL_CANCEL_POISON
 
 
 _INJECTION_TARGET_RE = re.compile(r"^(ctx|gen)_worker_(\d+)$")
@@ -778,7 +798,8 @@ def _load_iteration_shape(config: StressConfig, elapsed_s: float) -> dict[str, A
 
     if interval_s <= 0.0:
         raise ValueError(
-            f"stress_config.bursts.interval_min must be positive, got {bursts.get('interval_min')!r}"
+            "stress_config.bursts.interval_min must be positive, got "
+            f"{bursts.get('interval_min')!r}"
         )
     if duration_s <= 0.0:
         raise ValueError(
@@ -916,6 +937,7 @@ class DisaggCancellationStressHarness:
         self._cluster: Any = None  # tuple returned by setup_disagg_cluster
         self._worker_specs: list[WorkerLaunchSpec] = []
         self._tracked_workers: list[_TrackedWorker] = []
+        self._server_log_path: Optional[str] = None
         self._marathon_start_monotonic: float = 0.0
 
         # Disagg-server front-end the canary targets; populated by
@@ -926,6 +948,7 @@ class DisaggCancellationStressHarness:
 
         # Thread handles (populated by start()).
         self._load_thread: Optional[threading.Thread] = None
+        self._log_only_thread: Optional[threading.Thread] = None
         self._canary_thread: Optional[threading.Thread] = None
         self._injector_thread: Optional[threading.Thread] = None
         self._log_scanner_thread: Optional[threading.Thread] = None
@@ -944,13 +967,256 @@ class DisaggCancellationStressHarness:
     def setup(self) -> None:
         """Launch the disagg cluster from the YAML and record launch specs.
 
-        Stub: real implementation delegates to ``setup_disagg_cluster``
-        in ``tests/integration/defs/disaggregated/test_disaggregated.py``
+        Delegates the process launch to ``setup_disagg_cluster`` in
+        ``tests/integration/defs/disaggregated/test_disaggregated.py``
         and shadow-tracks per-worker ``WorkerLaunchSpec`` so the
         injector thread can later relaunch a SIGKILLed worker without
-        modifying shared infrastructure.
+        modifying shared infrastructure. The harness-only
+        ``stress_config`` block is stripped from the temporary YAML
+        passed to the shared launcher so worker config validation only
+        sees normal ``trtllm-serve`` settings.
         """
-        logger.info("[harness] setup() — stub: cluster not actually launched")
+        from test_disaggregated import (
+            build_worker_config,
+            get_default_disagg_cluster_config,
+            get_ucx_tls,
+            setup_disagg_cluster,
+        )
+
+        cluster_config = self._load_sanitized_cluster_config()
+        raw_model_name = str(cluster_config.get("model") or "")
+        if not raw_model_name:
+            raise ValueError(f"YAML at {self.yaml_path} is missing top-level model")
+        model_name = self._resolve_model_name(raw_model_name)
+
+        server_start_timeout_s = int(self.config.raw.get("server_start_timeout_s", 1200))
+        run_env = os.environ.copy()
+        run_env["UCX_TLS"] = get_ucx_tls()
+
+        setup_yaml_path = self._write_sanitized_cluster_yaml(cluster_config)
+        try:
+            self._cluster = setup_disagg_cluster(
+                setup_yaml_path,
+                model_name=model_name,
+                env=run_env,
+                server_start_timeout=server_start_timeout_s,
+                save_log=True,
+            )
+        finally:
+            try:
+                os.unlink(setup_yaml_path)
+            except OSError:
+                logger.debug("[harness] could not unlink %s; ignoring", setup_yaml_path)
+
+        config, ctx_workers, gen_workers, disagg_server, server_port, work_dir = self._cluster
+        server_host = config.get("hostname", "localhost")
+        server_url = f"http://{server_host}:{server_port}"
+
+        disagg_cluster = get_default_disagg_cluster_config()
+        disagg_cluster["cluster_uri"] = server_url
+        ctx_servers = config.get("context_servers", {})
+        gen_servers = config.get("generation_servers", {})
+        disagg_cluster["minimal_instances"] = {
+            "context_servers": ctx_servers.get("num_instances", 1),
+            "generation_servers": gen_servers.get("num_instances", 1),
+        }
+        ctx_worker_config = build_worker_config(config, ctx_servers, disagg_cluster)
+        gen_worker_config = build_worker_config(config, gen_servers, disagg_cluster)
+        ctx_specs, gen_specs = self._build_worker_launch_specs(
+            ctx_workers=ctx_workers,
+            gen_workers=gen_workers,
+            ctx_worker_config=ctx_worker_config,
+            gen_worker_config=gen_worker_config,
+            ctx_servers=ctx_servers,
+            gen_servers=gen_servers,
+            model_name=model_name,
+            work_dir=work_dir,
+            env=run_env,
+            host=server_host,
+        )
+        self._refresh_worker_ports_from_cluster_info(server_url, ctx_specs, gen_specs)
+        self.bind_tracked_workers(ctx_workers, gen_workers, ctx_specs, gen_specs)
+        self.bind_server_endpoint(server_url, model_name)
+        self._server_log_path = getattr(disagg_server, "log_path", None)
+        logger.info(
+            "[harness] setup() launched %d ctx worker(s), %d gen worker(s), server=%s",
+            len(ctx_workers),
+            len(gen_workers),
+            server_url,
+        )
+
+    def _load_sanitized_cluster_config(self) -> dict[str, Any]:
+        """Load YAML and remove harness-only fields before cluster launch."""
+        with self.yaml_path.open("r", encoding="utf-8") as f:
+            doc = yaml.safe_load(f)
+        if not isinstance(doc, dict):
+            raise ValueError(f"YAML at {self.yaml_path} must be a mapping")
+        cluster_config = dict(doc)
+        cluster_config.pop("stress_config", None)
+        return cluster_config
+
+    def _write_sanitized_cluster_yaml(self, cluster_config: dict[str, Any]) -> str:
+        """Write the launcher-facing YAML to a temporary file."""
+        fd, path = tempfile.mkstemp(prefix="disagg_cancel_cluster_", suffix=".yaml")
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            yaml.safe_dump(cluster_config, f)
+        return path
+
+    def _resolve_model_name(self, model_name: str) -> str:
+        """Resolve relative model names against ``LLM_MODELS_ROOT`` when set."""
+        path = Path(model_name).expanduser()
+        if path.is_absolute() or path.exists():
+            return str(path)
+        models_root = os.environ.get("LLM_MODELS_ROOT")
+        if models_root:
+            return str(Path(models_root).expanduser() / model_name)
+        return model_name
+
+    def _build_worker_launch_specs(
+        self,
+        *,
+        ctx_workers: list[Any],
+        gen_workers: list[Any],
+        ctx_worker_config: dict[str, Any],
+        gen_worker_config: dict[str, Any],
+        ctx_servers: dict[str, Any],
+        gen_servers: dict[str, Any],
+        model_name: str,
+        work_dir: str,
+        env: dict[str, str],
+        host: str,
+    ) -> tuple[list[WorkerLaunchSpec], list[WorkerLaunchSpec]]:
+        """Reconstruct worker launch metadata for log scanning and respawn."""
+        import torch
+
+        num_gpus = torch.cuda.device_count()
+        if num_gpus <= 0:
+            raise RuntimeError("setup_disagg_cluster returned, but torch reports no CUDA devices")
+
+        gpus_per_ctx = (
+            int(ctx_servers.get("tensor_parallel_size", 1))
+            * int(ctx_servers.get("pipeline_parallel_size", 1))
+            * int(ctx_servers.get("context_parallel_size", 1))
+        )
+        gpus_per_gen = (
+            int(gen_servers.get("tensor_parallel_size", 1))
+            * int(gen_servers.get("pipeline_parallel_size", 1))
+            * int(gen_servers.get("context_parallel_size", 1))
+        )
+
+        ctx_specs: list[WorkerLaunchSpec] = []
+        gen_specs: list[WorkerLaunchSpec] = []
+        next_device = 0
+        for index, wrapper in enumerate(ctx_workers):
+            device = self._format_device_ids(next_device, gpus_per_ctx, num_gpus)
+            next_device += gpus_per_ctx
+            ctx_specs.append(
+                self._make_worker_launch_spec(
+                    role="ctx",
+                    index=index,
+                    wrapper=wrapper,
+                    worker_config=ctx_worker_config,
+                    model_name=model_name,
+                    work_dir=work_dir,
+                    device=device,
+                    env=env,
+                    host=host,
+                )
+            )
+        for index, wrapper in enumerate(gen_workers):
+            device = self._format_device_ids(next_device, gpus_per_gen, num_gpus)
+            next_device += gpus_per_gen
+            gen_specs.append(
+                self._make_worker_launch_spec(
+                    role="gen",
+                    index=index,
+                    wrapper=wrapper,
+                    worker_config=gen_worker_config,
+                    model_name=model_name,
+                    work_dir=work_dir,
+                    device=device,
+                    env=env,
+                    host=host,
+                )
+            )
+        return ctx_specs, gen_specs
+
+    def _format_device_ids(self, first_device: int, count: int, num_gpus: int) -> str:
+        """Return the CUDA_VISIBLE_DEVICES string used by setup_disagg_cluster."""
+        return ",".join(
+            str(d) for d in dict.fromkeys((first_device + j) % num_gpus for j in range(count))
+        )
+
+    def _make_worker_launch_spec(
+        self,
+        *,
+        role: str,
+        index: int,
+        wrapper: Any,
+        worker_config: dict[str, Any],
+        model_name: str,
+        work_dir: str,
+        device: str,
+        env: dict[str, str],
+        host: str,
+    ) -> WorkerLaunchSpec:
+        """Create one shadow launch spec from the shared ProcessWrapper."""
+        return WorkerLaunchSpec(
+            role=role,
+            index=index,
+            model_name=model_name,
+            worker_config=worker_config,
+            work_dir=work_dir,
+            port=int(getattr(wrapper, "port", 0) or 0),
+            device=device,
+            env=env.copy(),
+            log_path=getattr(wrapper, "log_path", None),
+            host=host,
+        )
+
+    def _refresh_worker_ports_from_cluster_info(
+        self,
+        server_url: str,
+        ctx_specs: list[WorkerLaunchSpec],
+        gen_specs: list[WorkerLaunchSpec],
+    ) -> None:
+        """Populate worker host/port from disagg ``/cluster_info`` when available."""
+        try:
+            with urllib.request.urlopen(f"{server_url}/cluster_info", timeout=5.0) as response:
+                info = json.loads(response.read().decode("utf-8", errors="replace"))
+        except (json.JSONDecodeError, TimeoutError, OSError, urllib.error.URLError) as exc:
+            logger.warning("[harness] could not read cluster_info for worker ports: %s", exc)
+            return
+
+        current_workers = info.get("current_workers") or {}
+        for specs, key in (
+            (ctx_specs, "context_servers"),
+            (gen_specs, "generation_servers"),
+        ):
+            workers = current_workers.get(key) or []
+            if len(workers) != len(specs):
+                logger.warning(
+                    "[harness] cluster_info %s count mismatch: %d worker(s), %d spec(s)",
+                    key,
+                    len(workers),
+                    len(specs),
+                )
+            for spec, worker_info in zip(specs, workers):
+                if not isinstance(worker_info, dict):
+                    continue
+                host = worker_info.get("host")
+                port = worker_info.get("port")
+                if isinstance(host, str) and host:
+                    spec.host = host
+                try:
+                    spec.port = int(port)
+                except (TypeError, ValueError):
+                    logger.warning(
+                        "[harness] cluster_info %s worker %d has invalid port %r",
+                        key,
+                        spec.index,
+                        port,
+                    )
 
     def bind_tracked_workers(
         self,
@@ -988,30 +1254,47 @@ class DisaggCancellationStressHarness:
         self._model_name = model_name
 
     def start(self) -> None:
-        """Spawn the five worker threads. Returns immediately.
+        """Spawn the mode-specific worker threads. Returns immediately.
 
-        If ``setup()`` has not bound a live server endpoint yet, the
-        load thread warns and signals ``stop_event`` so the lifecycle
-        smoke still completes cleanly without waiting out the
-        ``wait_until_done`` timeout.
+        ``log_only`` mode runs the regular CI guardrail: a normal
+        non-cancel probe loop plus log-pattern fail-fast. It
+        intentionally avoids the cancellation load, fault injector,
+        poison canary, and KV-growth gates until those runtime fixes
+        are present.
+
+        ``full_cancel_poison`` mode runs all five full-stress threads.
         """
         self._marathon_start_monotonic = time.monotonic()
-        logger.info("[harness] start() — spawning worker threads")
-        self._load_thread = threading.Thread(
-            target=self._load_thread_body, name="stress-load", daemon=True
-        )
-        self._canary_thread = threading.Thread(
-            target=self._canary_thread_body, name="stress-canary", daemon=True
-        )
-        self._injector_thread = threading.Thread(
-            target=self._injector_thread_body, name="stress-injector", daemon=True
-        )
-        self._log_scanner_thread = threading.Thread(
-            target=self._log_scanner_thread_body, name="stress-log-scanner", daemon=True
-        )
-        self._metrics_thread = threading.Thread(
-            target=self._metrics_thread_body, name="stress-metrics", daemon=True
-        )
+        logger.info("[harness] start() — mode=%s", self.config.mode)
+        if self.config.is_log_only:
+            self._log_only_thread = threading.Thread(
+                target=self._log_only_thread_body,
+                name="stress-log-only-probe",
+                daemon=True,
+            )
+            self._log_scanner_thread = threading.Thread(
+                target=self._log_scanner_thread_body,
+                name="stress-log-scanner",
+                daemon=True,
+            )
+        elif self.config.is_full_cancel_poison:
+            self._load_thread = threading.Thread(
+                target=self._load_thread_body, name="stress-load", daemon=True
+            )
+            self._canary_thread = threading.Thread(
+                target=self._canary_thread_body, name="stress-canary", daemon=True
+            )
+            self._injector_thread = threading.Thread(
+                target=self._injector_thread_body, name="stress-injector", daemon=True
+            )
+            self._log_scanner_thread = threading.Thread(
+                target=self._log_scanner_thread_body,
+                name="stress-log-scanner",
+                daemon=True,
+            )
+            self._metrics_thread = threading.Thread(
+                target=self._metrics_thread_body, name="stress-metrics", daemon=True
+            )
         for t in self._all_threads():
             t.start()
 
@@ -1143,8 +1426,125 @@ class DisaggCancellationStressHarness:
         }
 
     # ------------------------------------------------------------------
-    # Thread bodies (stubs — implemented incrementally)
+    # Thread bodies
     # ------------------------------------------------------------------
+
+    def _configured_duration_s(self) -> float:
+        """Return the active run duration, honoring unit-test overrides."""
+        if self._load_duration_s is not None:
+            return self._load_duration_s
+        return float(self.config.duration_min) * 60.0
+
+    def _log_only_thread_body(self) -> None:
+        """Run regular CI protection without cancellation or poison gates.
+
+        This mode still launches the real disaggregated cluster and
+        sends normal completion probes through the front-end. It fails
+        the test on probe errors and runs concurrently with
+        ``log_scanner_thread`` so UAF, broken-promise, and segfault
+        signatures in worker/server logs remain hard-zero failures.
+        """
+        if not self._server_url:
+            self.mark_failed("log_only mode requires setup() to bind a server endpoint")
+            self.stop_event.set()
+            return
+
+        duration_s = self._configured_duration_s()
+        if duration_s <= 0.0:
+            logger.info("[log_only] non-positive duration %.3fs; exiting", duration_s)
+            self.stop_event.set()
+            return
+
+        probe_cfg = self.config.raw.get("log_only_probe") or {}
+        try:
+            interval_s = float(probe_cfg.get("interval_s", 30.0))
+            max_tokens = int(probe_cfg.get("max_tokens", 32))
+            seed = int(probe_cfg.get("seed", 42))
+            timeout_s = float(probe_cfg.get("request_timeout_s", self._canary_request_timeout_s))
+            prompt = str(
+                probe_cfg.get(
+                    "prompt",
+                    "Write one sentence about reliable distributed inference.",
+                )
+            )
+        except (TypeError, ValueError) as exc:
+            self.mark_failed(f"log_only_probe config error: {exc}")
+            self.stop_event.set()
+            return
+        if interval_s <= 0.0:
+            self.mark_failed(f"log_only_probe.interval_s must be positive, got {interval_s}")
+            self.stop_event.set()
+            return
+
+        deadline = time.monotonic() + duration_s
+        logger.info(
+            "[log_only] probing %s every %.1fs for %.1fs",
+            self._server_url,
+            interval_s,
+            duration_s,
+        )
+
+        while (
+            time.monotonic() < deadline
+            and not self.stop_event.is_set()
+            and not self.failed_event.is_set()
+        ):
+            send_start = time.monotonic()
+            token_ids, _, err = self._send_log_only_probe(
+                prompt=prompt,
+                max_tokens=max_tokens,
+                seed=seed,
+                timeout_s=timeout_s,
+            )
+            success = err is None
+            self._canary_records.append(
+                {
+                    "timestamp": time.time(),
+                    "elapsed_s": time.monotonic() - self._marathon_start_monotonic,
+                    "mode": _STRESS_MODE_LOG_ONLY,
+                    "prompt_index": 0,
+                    "success": success,
+                    "token_equivalent": None,
+                    "latency_s": time.monotonic() - send_start,
+                    "error": err,
+                    "token_count": len(token_ids or []),
+                }
+            )
+            if not success:
+                self.mark_failed(f"log_only probe failed: {err}")
+                break
+
+            remaining = min(interval_s, max(0.0, deadline - time.monotonic()))
+            if remaining > 0.0:
+                self.stop_event.wait(timeout=remaining)
+
+        if not self.failed_event.is_set() and not any(
+            record.get("success") for record in self._canary_records
+        ):
+            self.mark_failed("log_only mode completed without a successful probe")
+        if not self.failed_event.is_set():
+            logger.info("[log_only] completed; signalling stop_event")
+            self.stop_event.set()
+
+    def _send_log_only_probe(
+        self,
+        *,
+        prompt: str,
+        max_tokens: int,
+        seed: int,
+        timeout_s: float,
+    ) -> tuple[Optional[list[int]], Optional[str], Optional[str]]:
+        """Send one normal completion request for ``log_only`` mode."""
+        if self._server_url is None:
+            return None, None, "missing_server_url"
+        return _send_canary_request(
+            self._server_url,
+            self._model_name or "log-only-probe",
+            prompt,
+            max_tokens,
+            seed,
+            timeout_s,
+        )
 
     def _load_thread_body(self) -> None:
         """Wrap ``run_cancel_stress_test`` in a duration-bounded loop.
@@ -1164,11 +1564,7 @@ class DisaggCancellationStressHarness:
             self.stop_event.set()
             return
 
-        duration_s = (
-            self._load_duration_s
-            if self._load_duration_s is not None
-            else float(self.config.duration_min) * 60.0
-        )
+        duration_s = self._configured_duration_s()
         if duration_s <= 0.0:
             logger.info("[load_thread] non-positive duration %.3fs; exiting", duration_s)
             self.stop_event.set()
@@ -1570,6 +1966,19 @@ class DisaggCancellationStressHarness:
             return
 
         sources: list[_LogSource] = []
+        if self._server_log_path is not None:
+            server_spec = WorkerLaunchSpec(
+                role="server",
+                index=0,
+                model_name=self._model_name or "disagg-server",
+                worker_config={},
+                work_dir="",
+                port=0,
+                device="",
+                env={},
+                log_path=self._server_log_path,
+            )
+            sources.append(_LogSource(spec=server_spec, path=Path(self._server_log_path)))
         for spec in self._worker_specs:
             if spec.log_path is None:
                 logger.warning(
@@ -1589,7 +1998,7 @@ class DisaggCancellationStressHarness:
             return
 
         logger.info(
-            "[log_scanner] tailing %d worker log(s) against %d hard_zero pattern(s)",
+            "[log_scanner] tailing %d log source(s) against %d hard_zero pattern(s)",
             len(sources),
             len(patterns),
         )
@@ -1682,6 +2091,7 @@ class DisaggCancellationStressHarness:
             t
             for t in (
                 self._load_thread,
+                self._log_only_thread,
                 self._canary_thread,
                 self._injector_thread,
                 self._log_scanner_thread,
@@ -1691,10 +2101,17 @@ class DisaggCancellationStressHarness:
         ]
 
     def _teardown_cluster(self) -> None:
-        """Best-effort cluster shutdown via ``terminate()``.
-
-        Stub: no-op since ``setup()`` doesn't actually launch yet.
-        """
+        """Best-effort cluster shutdown via ``terminate()``."""
         if self._cluster is None:
             return
-        logger.info("[harness] _teardown_cluster — stub")
+        from disagg_test_utils import terminate
+
+        config, ctx_workers, gen_workers, disagg_server, _server_port, work_dir = self._cluster
+        del config
+        logger.info("[harness] tearing down disagg cluster work_dir=%s", work_dir)
+        try:
+            terminate(*ctx_workers, *gen_workers, disagg_server)
+        finally:
+            shutil.rmtree(work_dir, ignore_errors=True)
+            self._cluster = None
+            self._server_log_path = None

--- a/tests/integration/defs/stress_test/disagg_cancel/test_disagg_cancel_stress.py
+++ b/tests/integration/defs/stress_test/disagg_cancel/test_disagg_cancel_stress.py
@@ -25,7 +25,11 @@ each one is added to ``_MARATHON_CONFIGS`` below.
 
 from __future__ import annotations
 
+import textwrap
+import threading
+import time
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -57,29 +61,7 @@ def test_all_marathon_yamls_parse_and_validate() -> None:
 
 @pytest.mark.parametrize("config_filename", _MARATHON_CONFIGS)
 def test_disagg_cancellation_marathon(config_filename: str) -> None:
-    """Drive a long-running disagg cancellation marathon and assert pass criteria.
-
-    Current scope: only what the already-implemented thread bodies
-    can contribute. The marathon entry point exists; the marathon
-    *content* lands incrementally as setup / pass-criteria wiring is
-    completed:
-
-    - lifecycle plumbing (setup -> start -> wait -> stop ->
-      collect_results, fail-fast event propagation, dict-shape
-      contract).
-    - log-pattern fail-fast — a hard-zero pattern in any worker log
-      trips ``failure_reason`` via the log_scanner thread
-      (component-level coverage in ``test_log_scanner.py``).
-
-    Marathon pass criteria not yet enforced here (will land alongside
-    their owning result aggregation in follow-up changes): canary error
-    rate, recovery time after each injection, KV-cache utilization
-    growth bound, injection-schedule completeness, sustained load
-    throughput. Until those land, this test passes trivially after
-    the lifecycle smoke completes; the value at this stage is that
-    the entry point and result-dict contract are pinned down so the
-    follow-up commits can extend in place rather than restructure.
-    """
+    """Drive the configured disagg stress mode and assert current pass criteria."""
     config_path = _CONFIG_DIR / config_filename
     assert config_path.exists(), (
         f"Marathon config not found: {config_path}. "
@@ -90,13 +72,8 @@ def test_disagg_cancellation_marathon(config_filename: str) -> None:
     try:
         harness.setup()
         harness.start()
-        # setup() is still a stub, so no server endpoint is bound.
-        # The load thread exits and signals ``stop_event`` on that
-        # no-endpoint path, which lets this lifecycle smoke complete
-        # almost instantly. Once setup launches a real cluster, the
-        # timeout becomes ``stress_config.duration_min`` plus a safety
-        # margin.
-        clean = harness.wait_until_done(timeout_s=10.0)
+        timeout_s = float(harness.config.duration_min) * 60.0 + 300.0
+        clean = harness.wait_until_done(timeout_s=timeout_s)
         assert clean is True, (
             f"wait_until_done did not return cleanly; failure_reason={harness.failure_reason!r}"
         )
@@ -112,5 +89,109 @@ def test_disagg_cancellation_marathon(config_filename: str) -> None:
     assert "kv_utilization_samples" in results
     assert "injection_events" in results
     assert results["failure_reason"] is None, (
-        f"Harness tripped fail-fast in skeleton run: {results['failure_reason']!r}"
+        f"Harness tripped fail-fast: {results['failure_reason']!r}"
     )
+    if harness.config.is_log_only:
+        assert any(
+            record.get("mode") == "log_only" and record.get("success")
+            for record in results["canary_records"]
+        ), "log_only mode completed without a successful server probe"
+
+
+def _write_mode_yaml(tmp_path: Path, stress_config: str) -> Path:
+    """Write a minimal marathon YAML for mode-level harness tests."""
+    yaml_path = tmp_path / "mode.yaml"
+    content = textwrap.dedent(
+        """\
+        hostname: localhost
+        model: dummy
+        backend: pytorch
+        context_servers: {}
+        generation_servers: {}
+        stress_config:
+        """
+    )
+    content += textwrap.indent(textwrap.dedent(stress_config).strip(), "  ") + "\n"
+    yaml_path.write_text(content)
+    return yaml_path
+
+
+@pytest.mark.parametrize("mode", ["log_only", "full_cancel_poison"])
+def test_stress_config_accepts_supported_modes(tmp_path: Path, mode: str) -> None:
+    """Both supported mode strings should parse and expose helper predicates."""
+    cfg = StressConfig.from_yaml_path(
+        _write_mode_yaml(
+            tmp_path,
+            f"""\
+            mode: {mode}
+            duration_min: 1
+            kv_cache_manager: v1
+            transceiver: cpp
+            """,
+        )
+    )
+
+    assert cfg.mode == mode
+    assert cfg.is_log_only is (mode == "log_only")
+    assert cfg.is_full_cancel_poison is (mode == "full_cancel_poison")
+
+
+def test_stress_config_rejects_unknown_mode(tmp_path: Path) -> None:
+    """Typos in mode must fail during YAML validation."""
+    with pytest.raises(ValueError, match="mode must be one of"):
+        StressConfig.from_yaml_path(
+            _write_mode_yaml(
+                tmp_path,
+                """\
+                mode: accidental
+                duration_min: 1
+                kv_cache_manager: v1
+                transceiver: cpp
+                """,
+            )
+        )
+
+
+def test_log_only_thread_sends_probe_and_stops(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The regular-protection mode should require at least one clean probe."""
+    h = DisaggCancellationStressHarness(
+        _write_mode_yaml(
+            tmp_path,
+            """\
+            mode: log_only
+            duration_min: 1
+            kv_cache_manager: v1
+            transceiver: cpp
+            log_only_probe:
+              interval_s: 0.01
+              max_tokens: 8
+              request_timeout_s: 1
+            log_scan:
+              hard_zero_patterns:
+                - "Broken promise"
+            """,
+        ),
+        load_duration_s=0.03,
+    )
+    h.bind_server_endpoint("http://127.0.0.1:8000", "test-model")
+    h._marathon_start_monotonic = time.monotonic()
+
+    calls: list[dict[str, Any]] = []
+
+    def fake_probe(**kwargs: Any) -> tuple[list[int], None, None]:
+        calls.append(kwargs)
+        return [1, 2], None, None
+
+    monkeypatch.setattr(h, "_send_log_only_probe", fake_probe)
+
+    thread = threading.Thread(target=h._log_only_thread_body, name="test-log-only", daemon=True)
+    thread.start()
+    thread.join(timeout=2.0)
+
+    assert not thread.is_alive()
+    assert h.stop_event.is_set()
+    assert not h.failed_event.is_set()
+    assert calls
+    assert any(record["success"] for record in h._canary_records)

--- a/tests/integration/test_lists/qa/llm_function_stress.txt
+++ b/tests/integration/test_lists/qa/llm_function_stress.txt
@@ -5,7 +5,7 @@ disaggregated/test_disaggregated.py::test_disaggregated_stress_test[input8k-outp
 disaggregated/test_disaggregated.py::test_disaggregated_stress_test[input8k-output1k-conc512-gpt_oss_120b_eagle_trtllm_stress]
 disaggregated/test_disaggregated.py::test_disaggregated_stress_test[input8k-output1k-conc512-gpt_oss_120b_triton_stress]
 disaggregated/test_disaggregated.py::test_disaggregated_stress_test[input8k-output1k-conc512-qwen3_5_4b_fp8_stress]
-stress_test/disagg_cancel/test_disagg_cancel_stress.py::test_disagg_cancellation_marathon[marathon_cpp_v1_deepseek.yaml] TIMEOUT (150)
+stress_test/disagg_cancel/test_disagg_cancel_stress.py::test_disagg_cancellation_marathon[marathon_cpp_v1_deepseek.yaml] TIMEOUT (45)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1LongBenchV2::test_fp8_8gpus
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1LongBenchV2::test_nvfp4_4gpus
 accuracy/test_llm_api_pytorch.py::TestKimiK2::test_nvfp4_longseq_trtllm_moe_stress

--- a/tests/integration/test_lists/qa/llm_function_stress.txt
+++ b/tests/integration/test_lists/qa/llm_function_stress.txt
@@ -5,6 +5,7 @@ disaggregated/test_disaggregated.py::test_disaggregated_stress_test[input8k-outp
 disaggregated/test_disaggregated.py::test_disaggregated_stress_test[input8k-output1k-conc512-gpt_oss_120b_eagle_trtllm_stress]
 disaggregated/test_disaggregated.py::test_disaggregated_stress_test[input8k-output1k-conc512-gpt_oss_120b_triton_stress]
 disaggregated/test_disaggregated.py::test_disaggregated_stress_test[input8k-output1k-conc512-qwen3_5_4b_fp8_stress]
+stress_test/disagg_cancel/test_disagg_cancel_stress.py::test_disagg_cancellation_marathon[marathon_cpp_v1_deepseek.yaml] TIMEOUT (150)
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1LongBenchV2::test_fp8_8gpus
 accuracy/test_llm_api_pytorch.py::TestDeepSeekR1LongBenchV2::test_nvfp4_4gpus
 accuracy/test_llm_api_pytorch.py::TestKimiK2::test_nvfp4_longseq_trtllm_moe_stress


### PR DESCRIPTION
## Summary

Enables the disaggregated cancellation stress-test entry as a real regular guardrail while keeping the full cancellation/poison marathon behind an explicit YAML mode switch.

**This change ships:**

* **Real cluster setup**: `DisaggCancellationStressHarness.setup()` now calls the shared `setup_disagg_cluster(..., save_log=True)`, strips the harness-only `stress_config` block before passing YAML to `trtllm-serve`, binds the disagg server endpoint, tracks worker/server logs, and tears the cluster down.
* **Default regular-protection mode**: `stress_config.mode: log_only` launches the real 3P3D C++/V1 DeepSeek disagg cluster, sends normal non-cancel completion probes, and fails on UAF, broken-promise, and segmentation-fault-class log signatures.
* **Opt-in full-stress mode**: `stress_config.mode: full_cancel_poison` remains the explicit switch for cancellation load, fault injection, token-equivalent canaries, metrics, and KV-growth checks once in-flight cancellation plus poison-buffer hardening are available.
* **QA stress-list registration**: the C++/V1 DeepSeek entry stays registered in `tests/integration/test_lists/qa/llm_function_stress.txt`, now with `TIMEOUT (45)` for the 10-minute regular guardrail plus setup margin. This makes the test eligible for the QA/Jenkins job that consumes that list; it does not create or modify that job schedule.
* **Run instructions**: the README and config README now describe scheduled-run setup, manual runs, bot trigger flow, and the exact mode-switch checklist.

The registered entry is:

```text
stress_test/disagg_cancel/test_disagg_cancel_stress.py::test_disagg_cancellation_marathon[marathon_cpp_v1_deepseek.yaml] TIMEOUT (45)
```

## Implementation chain

| Change | Adds | Assertion it enables |
| --- | --- | --- |
| [skeleton + log scanner](https://github.com/NVIDIA/TensorRT-LLM/pull/14375) | harness lifecycle + `log_scanner_thread` | hard-zero log patterns |
| [metrics thread](https://github.com/NVIDIA/TensorRT-LLM/pull/14807) | `metrics_thread` | KV-cache utilization growth bound |
| [injector thread](https://github.com/NVIDIA/TensorRT-LLM/pull/14920) | `injector_thread` | SIGSTOP / SIGCONT / SIGKILL+respawn; `injection_events` count |
| [canary thread](https://github.com/NVIDIA/TensorRT-LLM/pull/15015) | `canary_thread` | canary correctness plus error-rate / recovery-time inputs |
| [load thread](https://github.com/NVIDIA/TensorRT-LLM/pull/15124) | `load_thread` | sustained steady/burst cancellation load over the configured duration |
| **this change** | real setup, `log_only` regular guardrail, full-mode switch, QA registration, README | scheduled/manual protection against UAF, broken promises, and segfault-class failures today |

There are no remaining test-logic or test-enablement steps in this chain. Future runtime support can flip the YAML from `log_only` to `full_cancel_poison` and add canary references/poison expectations without another harness-architecture step.

## Mode switch

Current regular CI mode:

```yaml
stress_config:
  mode: log_only
  duration_min: 10
```

`log_only` is intentionally the checked-in default. It does not require in-flight cancellation or poison-buffer support. It provides regular protection by:

* launching the real disaggregated cluster,
* sending normal non-cancel completion probes through `/v1/completions`,
* scanning saved context-worker, generation-worker, and disagg-server logs.

To switch to the full cancellation/poison marathon after runtime support is ready:

1. Set `stress_config.mode: full_cancel_poison`.
2. Set `stress_config.duration_min: 120`.
3. Keep or tune `base_concurrency`, `bursts`, and `injections`.
4. Add `configs/stress_canary_prompts.json` with recorded token references.
5. Update poison-buffer log expectations to match the finalized runtime behavior.
6. Raise the test-list timeout back to a full-marathon budget, for example `TIMEOUT (150)`.

## Scheduled run config and setup

The QA stress-list registration is controlled by:

```text
tests/integration/test_lists/qa/llm_function_stress.txt
```

Once merged, this test runs automatically only when the existing QA/Jenkins schedule or release validation job consumes `llm_function_stress.txt`. The exact cadence and wall-clock start time are owned by QA CI configuration outside this PR. The in-repo QA README describes QA coverage as daily/release and weekly/release/on-demand, but does not define a file-specific cadence for this stress list.

CI should run that list from `tests/integration/defs` with the normal TRT-LLM integration container or virtual environment:

```bash
pytest --test-list=../test_lists/qa/llm_function_stress.txt \
  --output-dir=<ci-output-dir> \
  -s -v
```

Required setup:

* GPU integration environment with `trtllm-serve` on `PATH`.
* `LLM_MODELS_ROOT` set so `DeepSeek-V3-Lite/bf16` resolves to local model weights.
* Enough GPUs for the configured 3 context + 3 generation worker shape.

## Manual run and trigger

Manual regular guardrail run:

```bash
cd /path/to/TensorRT-LLM/tests/integration/defs
export LLM_MODELS_ROOT=/path/to/model/root

pytest stress_test/disagg_cancel/test_disagg_cancel_stress.py \
  --test-list=../test_lists/qa/llm_function_stress.txt \
  --output-dir=/tmp/trtllm-disagg-cancel-stress \
  -s -v
```

Collection-only check from a full integration environment:

```bash
pytest stress_test/disagg_cancel/test_disagg_cancel_stress.py \
  --test-list=../test_lists/qa/llm_function_stress.txt \
  --output-dir=/tmp/trtllm-disagg-cancel-stress \
  -s --co -q
```

Manual CI trigger:

```text
/bot help
/bot run --extra-stage "<QA stress stage that runs llm_function_stress.txt>"
```

The exact QA stress stage name is owned by CI/Jenkins configuration and is not declared in this directory.

## Validation

Syntax:

```bash
PYTHONPYCACHEPREFIX=$PWD/.pycache python -m py_compile \
  tests/integration/defs/stress_test/disagg_cancel/harness.py \
  tests/integration/defs/stress_test/disagg_cancel/test_disagg_cancel_stress.py
```

Result: passed.

No-GPU component suite:

```bash
PYTHONPATH=tests/integration/defs:tests/integration/defs/disaggregated \
python -m pytest -c /dev/null -o addopts= \
  --confcutdir=tests/integration/defs/stress_test \
  tests/integration/defs/stress_test/disagg_cancel/ \
  -k "not test_disagg_cancellation_marathon" -q
```

Result: `92 passed, 1 deselected`.

Static test-list validation:

```bash
python scripts/check_test_list.py --validate
```

Result: `OK: 2563 unique test entries validated.`

Also ran `git diff --check`.

Pre-commit on touched files passes formatting/lint hooks. The local `waive list check` and `validate-test-lists` hooks fail only because their hook interpreter cannot parse `str | None` in `scripts/check_test_list.py`; the same validator command above passes under the project Python.

The full `pytest --test-list=... --co` command was not runnable in this local Python environment because the integration `conftest.py` imports `torch._inductor`, which is not present locally.

## Out of scope

* Flipping the checked-in mode to `full_cancel_poison` before runtime support is ready.
* Adding canary reference JSON generation/fixtures.
* Registering additional marathon YAMLs.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded disaggregated cancellation stress suite documentation with detailed explanations of test modes, run procedures, and debugging guidance.

* **New Features**
  * Introduced explicit test modes (`log_only` and `full_cancel_poison`) for the stress test harness, including configuration support and mode-specific execution logic.

* **Tests**
  * Added test coverage for mode validation and log-only thread execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->