### PR TITLE
[#15189][doc] Fix broken links in example READMEs

### DIFF
--- a/examples/ngram/README.md
+++ b/examples/ngram/README.md
@@ -47,7 +47,7 @@ return None                                         # No any candidate exists
 + `--use_paged_context_fmha=enable` must be specified since we need KVcache reuse in this approach.
 + `--speculative_decoding_mode=draft_tokens_external` must be specified.
 + `--max_draft_len` must be specified as the length maximum of the draft tokens.
-+ `--ngram_config` is corresponding configuration of NGram, we can see its usage in [util.py](../util.py).
++ `--ngram_config` is corresponding configuration of NGram, we can see its usage in [utils.py](../utils.py).
   + As an example, `[10,2,[0]]` means `max_draft_len=10`, `max_matching_ngram_size=2`, and device of target model is `GPU0`.
 + `--kv_cache_enable_block_reuse` must be specified for this approach.
 + Only CPP session is supported, so `--use_py_session` must not be specified.

--- a/examples/sample_weight_stripping/README.md
+++ b/examples/sample_weight_stripping/README.md
@@ -68,7 +68,7 @@ wget https://huggingface.co/EleutherAI/gpt-j-6b/resolve/main/merges.txt
 ```
 
 2. Convert the Hugging Face checkpoint into TensorRT LLM format.
-Run below command lines in [`examples/models/contrib/gpt`](../gptj) directory.
+Run below command lines in [`examples/models/contrib/gptj`](../models/contrib/gptj) directory.
 ```bash
 # Build a float16 checkpoint using HF weights.
 python convert_checkpoint.py --model_dir ./gpt-j-6b \


### PR DESCRIPTION
## Description

Fix two broken relative links in example READMEs.

- `examples/sample_weight_stripping/README.md:71` now links to `../models/contrib/gptj`
- `examples/ngram/README.md:50` now links to `../utils.py`

This change only updates README links. It does not touch code paths or runtime behavior.

## Test Coverage

N/A. Documentation-only link fix.

Manual verification:
- resolved `examples/sample_weight_stripping/README.md` + `../models/contrib/gptj` to an existing in-tree directory
- resolved `examples/ngram/README.md` + `../utils.py` to an existing in-tree file

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Corrected utility file references in V1 workflow documentation.
  * Updated directory paths in GPT-J workflow instructions to point to the correct example directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->