### PR TITLE
[#15191][doc] Fix broken AutoDeploy README link

### DIFF
--- a/examples/auto_deploy/README.md
+++ b/examples/auto_deploy/README.md
@@ -176,7 +176,7 @@ For expert users, `build_and_run_ad.py` provides advanced configuration capabili
 
 #### CLI Arguments with Dot Notation
 
-The script supports flexible CLI argument parsing using dot notation to modify nested configurations dynamically. You can target any field in both the [`ExperimentConfig`](./build_and_run_ad.py) and nested [`AutoDeployConfig`](../../tensorrt_llm/_torch/auto_deploy/llm_args.py)/[`LlmArgs`](../../tensorrt_llm/_torch/auto_deploy/llm_args.) objects:
+The script supports flexible CLI argument parsing using dot notation to modify nested configurations dynamically. You can target any field in both the [`ExperimentConfig`](./build_and_run_ad.py) and nested [`AutoDeployConfig`](../../tensorrt_llm/_torch/auto_deploy/llm_args.py)/[`LlmArgs`](../../tensorrt_llm/_torch/auto_deploy/llm_args.py) objects:
 
 ```bash
 # Configure model parameters


### PR DESCRIPTION
## Description

This fixes a broken relative link in `examples/auto_deploy/README.md:179`.

The advanced configuration section linked `LlmArgs` to `../../tensorrt_llm/_torch/auto_deploy/llm_args.`, but the in-tree file is `../../tensorrt_llm/_torch/auto_deploy/llm_args.py`.

This patch updates the link target to the existing file. It only changes documentation navigation.

## Test Coverage

N/A. Documentation-only link fix.

Manual verification:
- confirmed `examples/auto_deploy/README.md:179` points `LlmArgs` to `llm_args.py`
- confirmed `tensorrt_llm/_torch/auto_deploy/llm_args.py` exists in-tree
- confirmed `tensorrt_llm/_torch/auto_deploy/llm_args.` does not exist

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified CLI arguments with dot-notation documentation to better explain how it targets fields across configuration structures.
  * Corrected reference text in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->