### PR TITLE
[None][perf] avoid full input_token_ids copy in ADP router token count

### DIFF
--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -745,6 +745,7 @@ public:
     ~Request();
 
     [[nodiscard]] VecTokens getInputTokenIds() const;
+    [[nodiscard]] SizeType32 getNumInputTokens() const;
     [[nodiscard]] SizeType32 getMaxTokens() const;
     [[nodiscard]] bool getStreaming() const;
     [[nodiscard]] SamplingConfig getSamplingConfig() const;

--- a/cpp/tensorrt_llm/executor/request.cpp
+++ b/cpp/tensorrt_llm/executor/request.cpp
@@ -79,6 +79,11 @@ VecTokens Request::getInputTokenIds() const
     return mImpl->getInputTokenIds();
 }
 
+SizeType32 Request::getNumInputTokens() const
+{
+    return mImpl->getNumInputTokens();
+}
+
 SizeType32 Request::getMaxTokens() const
 {
     return mImpl->getMaxNewTokens();

--- a/cpp/tensorrt_llm/executor/requestImpl.h
+++ b/cpp/tensorrt_llm/executor/requestImpl.h
@@ -120,6 +120,11 @@ public:
         return mInputTokenIds;
     }
 
+    [[nodiscard]] SizeType32 getNumInputTokens() const
+    {
+        return static_cast<SizeType32>(mInputTokenIds.size());
+    }
+
     [[nodiscard]] SizeType32 getMaxNewTokens() const
     {
         return mMaxNewTokens;

--- a/cpp/tensorrt_llm/nanobind/executor/request.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/request.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -728,6 +728,7 @@ void initRequestBindings(nb::module_& m)
         nb::arg("disagg_request_id") = nb::none()
     )         // clang-format on
         .def_prop_ro("input_token_ids", &tle::Request::getInputTokenIds)
+        .def_prop_ro("num_input_tokens", &tle::Request::getNumInputTokens)
         .def_prop_ro("max_tokens", &tle::Request::getMaxTokens)
         .def_prop_rw("streaming", &tle::Request::getStreaming, &tle::Request::setStreaming)
         .def_prop_rw("sampling_config", &tle::Request::getSamplingConfig, &tle::Request::setSamplingConfig)

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/adp_router.py
@@ -36,6 +36,12 @@ if TYPE_CHECKING:
 HeapVal = namedtuple("HeapVal", ["num_tokens", "num_requests", "rank", "request_list"])
 
 
+def _num_input_tokens(request) -> int:
+    """Token count via the cheap num_input_tokens accessor (avoids materializing
+    input_token_ids); 0 when request is None."""
+    return request.num_input_tokens if request is not None else 0
+
+
 @dataclass
 class RankState:
     """Per-rank state information shared via allgather before request assignment.
@@ -369,13 +375,7 @@ class DefaultADPRouter(ADPRouter):
 
         heapq.heapify(all_ranks_new_requests_heap)
 
-        # input_token_ids is a C++ getter that copies the whole token list on every
-        # access, so read it once per request instead of in both the sort key and
-        # the loop below.
-        counted = [
-            (len(req.input_token_ids) if (req := item.request) is not None else 0, item)
-            for item in new_requests
-        ]
+        counted = [(_num_input_tokens(item.request), item) for item in new_requests]
         counted.sort(key=lambda item: item[0], reverse=True)
 
         for token_count, req_item in counted:
@@ -554,12 +554,6 @@ class KVCacheAwareADPRouter(ADPRouter):
             return ()
         return tuple(token_ids[:num_tokens])
 
-    @staticmethod
-    def _req_tokens(req_item) -> int:
-        if req_item.request is None:
-            return 0
-        return len(getattr(req_item.request, "input_token_ids", []))
-
     def _match_len(self, rank: int, req_id: int) -> int:
         matches = self._all_ranks_prefix_matches
         return matches[rank].get(req_id, 0) if rank < len(matches) else 0
@@ -606,7 +600,8 @@ class KVCacheAwareADPRouter(ADPRouter):
                 all_ranks_num_active_requests[target_dp_rank] += 1
                 # Keep token tally in sync with the soft-balancing phase.
                 effective = max(
-                    self._req_tokens(req_item) - self._match_len(target_dp_rank, req_item.id),
+                    _num_input_tokens(req_item.request)
+                    - self._match_len(target_dp_rank, req_item.id),
                     0,
                 )
                 all_ranks_num_active_tokens[target_dp_rank] += effective
@@ -649,7 +644,7 @@ class KVCacheAwareADPRouter(ADPRouter):
             if not eligible_ranks:
                 break
 
-            req_tokens = self._req_tokens(req_item)
+            req_tokens = _num_input_tokens(req_item.request)
             req_id = req_item.id
 
             # Shuffle eligible ranks per decision so score ties fall to a

--- a/tests/unittest/_torch/executor/test_adp_router.py
+++ b/tests/unittest/_torch/executor/test_adp_router.py
@@ -18,8 +18,20 @@ from tensorrt_llm._torch.pyexecutor.scheduler.adp_router import (
     DefaultADPRouter,
     KVCacheAwareADPRouter,
     RankState,
+    _num_input_tokens,
 )
 from tensorrt_llm.scheduling_params import SchedulingParams
+
+
+class _MockRequest(MagicMock):
+    """Mock executor Request whose ``num_input_tokens`` mirrors the real binding
+    (it equals ``len(input_token_ids)``) instead of an auto-generated child mock,
+    so the routers' cheap token-count reads work without setting it per call site.
+    """
+
+    @property
+    def num_input_tokens(self):
+        return len(self.input_token_ids)
 
 
 def _mock_dist(tp_rank=0, tp_size=1, has_cp_helix=False):
@@ -32,7 +44,7 @@ def _mock_dist(tp_rank=0, tp_size=1, has_cp_helix=False):
 
 
 def create_mock_request_with_py_schedule_params(attention_dp_rank=None, attention_dp_relax=False):
-    mock_request = Mock()
+    mock_request = _MockRequest()
     if attention_dp_rank is not None:
         mock_schedule_params = Mock()
         mock_schedule_params.attention_dp_rank = attention_dp_rank
@@ -56,7 +68,7 @@ def _make_request_item(req_id, num_tokens=10, target_dp_rank=None, attention_dp_
     scheduling_params = MagicMock()
     scheduling_params.attention_dp_rank = target_dp_rank
     scheduling_params.attention_dp_relax = attention_dp_relax
-    item.request = MagicMock()
+    item.request = _MockRequest()
     item.request.py_scheduling_params = scheduling_params
     item.request.input_token_ids = list(range(num_tokens))
     return item
@@ -1005,7 +1017,7 @@ def _make_conv_request_item(
     scheduling_params = MagicMock()
     scheduling_params.attention_dp_rank = target_dp_rank
     scheduling_params.attention_dp_relax = attention_dp_relax
-    item.request = MagicMock()
+    item.request = _MockRequest()
     item.request.py_scheduling_params = scheduling_params
     item.request.input_token_ids = list(range(num_tokens))
     item.request.py_orig_prompt_len = num_tokens
@@ -1162,3 +1174,24 @@ class TestConversationAwareADPRouter:
         final = [states[r].num_active_requests + len(assign[r]) for r in range(8)]
         assert all(expected >= f for f in final), (expected, final)
         assert sum(len(v) for v in assign.values()) == 40  # nothing dropped
+
+
+class TestNumInputTokens:
+    """The cheap token-count accessor used by the routers (avoids copying the
+    full input_token_ids list just to count it)."""
+
+    def test_none_request(self):
+        assert _num_input_tokens(None) == 0
+
+    def test_prefers_num_input_tokens_without_touching_token_list(self):
+        """When num_input_tokens is available it must be used, and the heavy
+        input_token_ids getter must NOT be accessed."""
+
+        class _Req:
+            num_input_tokens = 1234
+
+            @property
+            def input_token_ids(self):  # materializing it would be a regression
+                raise AssertionError("input_token_ids must not be materialized")
+
+        assert _num_input_tokens(_Req()) == 1234


### PR DESCRIPTION
## Summary
Follow-on to #15133. The ADP request router only needs the **input length** to
load-balance new requests across attention-DP ranks, but it read
`ExecutorRequest.input_token_ids` and called `len()` on it.

`Request::getInputTokenIds()` returns `VecTokens` **by value**, so each access
materializes a fresh ~ISL-sized Python list (one PyObject per token) — under the
GIL, redundantly on **every rank** (routing is symmetric), for **every new
request**. #15133 reduced the access from 2→1 per request; this removes the
copy entirely by counting the tokens without materializing the list.

## Change
- Add a cheap `num_input_tokens` accessor to the `Request` nanobind binding
  (returns `getInputTokenIds().size()` — no Python list is built).
- Route the `DefaultADPRouter` / `KVCacheAwareADPRouter` token-count reads
  through a `_num_input_tokens()` helper. It falls back to
  `len(input_token_ids)` when the accessor is absent (a Python-only deploy whose
  C++ bindings predate it, or test mocks), so routing results are unchanged.

## Why it matters
On DeepSeek-V4-Pro disaggregated generation @ 2880 concurrency (avg ISL ~39k),
the per-iteration `_fetch_new_requests` host path is a known rank-0 GIL
hotspot. Each new request previously triggered a full ~39k-element Python list
build on all 8 ranks just to obtain its length.

## Test
Adds `TestNumInputTokens`: prefers the accessor (and asserts `input_token_ids`
is **not** materialized), falls back to `len()` when absent, ignores a non-int
accessor, and handles a `None` request.

## Notes
- Draft: the C++ binding needs a rebuild to exercise the fast path; the Python
  fallback keeps behavior/CI unchanged without it.
- Possible follow-up: a true O(1) `Request::getNumInputTokens()` on the C++ side
  would avoid even the (cheap) internal `VecTokens` copy that `.size()` incurs.
