### PR TITLE
[TRTLLM-12807][feat] Add multiple FMHA library support to TRTLLM attention backend

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/fmha/__init__.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/__init__.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .fallback import FallbackFmha
+from .flashinfer_trtllm_gen import FlashInferTrtllmGenFmha
+from .interface import Fmha
+from .phased import FmhaParams, PhasedFmha
+from .registry import DEFAULT_FMHA_LIBS, FMHA_LIBS, FmhaCls, get_enabled_fmha_lib_classes
+
+__all__ = [
+    "DEFAULT_FMHA_LIBS",
+    "FMHA_LIBS",
+    "FallbackFmha",
+    "FlashInferTrtllmGenFmha",
+    "Fmha",
+    "FmhaCls",
+    "FmhaParams",
+    "PhasedFmha",
+    "get_enabled_fmha_lib_classes",
+]

--- a/tensorrt_llm/_torch/attention_backend/fmha/fallback.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/fallback.py
@@ -38,7 +38,7 @@ _THOP_EXCLUDED_FIELDS: frozenset = frozenset(
     {
         "topk_indices",  # DSA-only
         "attention_mask_data",  # custom-mask code path
-        "out_scale_sf",  # promoted into ``out_scale`` in ``TrtllmAttention._run`` for NVFP4 path
+        "out_scale_sf",  # promoted into ``out_scale`` in ``TrtllmAttention.forward`` for NVFP4 path
     }
 )
 

--- a/tensorrt_llm/_torch/attention_backend/fmha/fallback.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/fallback.py
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from tensorrt_llm._torch.attention_backend.interface import AttentionForwardArgs
+from tensorrt_llm._torch.attention_backend.sparse.skip_softmax import (
+    SkipSoftmaxKernelParams,
+    SkipSoftmaxParams,
+)
+from tensorrt_llm.bindings.internal import thop
+
+from .interface import Fmha
+
+if TYPE_CHECKING:
+    from tensorrt_llm._torch.attention_backend.trtllm import TrtllmAttentionMetadata
+
+
+# ``AttentionForwardArgs`` fields that this backend does not consume.
+# Sync test (test_attention_op_sync.py) requires every other field to map to a
+# kwarg name, a @property on the dataclass, or a field that some @property
+# transitively reads; entries here are exempt.
+_THOP_EXCLUDED_FIELDS: frozenset = frozenset(
+    {
+        "topk_indices",  # DSA-only
+        "attention_mask_data",  # custom-mask code path
+        "out_scale_sf",  # promoted into ``out_scale`` in ``TrtllmAttention._run`` for NVFP4 path
+    }
+)
+
+# ``thop.attention`` kwargs hard-wired to a literal at the call site (no
+# rich object owns them). Sync test enforces both the kwarg name and the
+# literal value.
+_THOP_LITERALS: dict = {}
+
+
+class FallbackFmha(Fmha):
+    """Fallback FMHA implementation using the fused TRT-LLM thop attention op."""
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> None:
+        attn = self.attn
+        sparse_params = attn.sparse_params
+        skip_softmax_kernel_params = (
+            sparse_params.scheduler.get_kernel_params(timestep=forward_args.timestep)
+            if isinstance(sparse_params, SkipSoftmaxParams)
+            else SkipSoftmaxKernelParams()
+        )
+
+        # Every kwarg sources from ``attn`` / ``metadata`` / ``forward_args``
+        # (with ``forward_args.sparse_prediction`` for sparse-attn inputs),
+        # ``skip_softmax_kernel_params``, or a literal allowlisted in
+        # ``_THOP_LITERALS``. ``test_attention_op_sync.py`` enforces this
+        # statically.
+        thop.attention(
+            q=q,
+            k=k,
+            v=v,
+            output=forward_args.output,
+            output_sf=forward_args.output_sf,
+            workspace_=metadata.effective_workspace,
+            # --- Per-step batch state (TrtllmAttentionMetadata) ---
+            sequence_length=metadata.kv_lens_cuda_runtime,
+            host_past_key_value_lengths=metadata.kv_lens_runtime,
+            host_total_kv_lens=metadata.host_total_kv_lens,
+            context_lengths=metadata.prompt_lens_cuda_runtime,
+            host_context_lengths=metadata.prompt_lens_cpu_runtime,
+            host_request_types=metadata.host_request_types_runtime,
+            max_context_q_len_override=metadata.max_context_q_len_override,
+            kv_cache_block_offsets=metadata.kv_cache_block_offsets,
+            host_kv_cache_pool_pointers=metadata.host_kv_cache_pool_pointers,
+            host_kv_cache_pool_mapping=metadata.host_kv_cache_pool_mapping,
+            cache_indirection=metadata.cache_indirection,
+            block_ids_per_seq=metadata.block_ids_per_seq,
+            tokens_per_block=metadata.tokens_per_block,
+            max_num_requests=metadata.max_num_requests,
+            beam_width=metadata.effective_beam_width,
+            use_paged_context_fmha=metadata.use_paged_context_fmha,
+            helix_position_offsets=metadata.helix_position_offsets,
+            helix_is_inactive_rank=metadata.helix_is_inactive_rank,
+            is_spec_decoding_enabled=metadata.is_spec_decoding_enabled,
+            use_spec_decoding=metadata.use_spec_decoding,
+            is_spec_dec_tree=metadata.is_spec_dec_tree,
+            spec_decoding_generation_lengths=metadata.spec_decoding_generation_lengths,
+            spec_decoding_position_offsets_for_cpp=metadata.spec_decoding_position_offsets_for_cpp,
+            spec_decoding_packed_mask=metadata.spec_decoding_packed_mask,
+            spec_decoding_bl_tree_mask_offset=metadata.spec_decoding_bl_tree_mask_offset,
+            spec_decoding_bl_tree_mask=metadata.spec_decoding_bl_tree_mask,
+            spec_decoding_target_max_draft_tokens=metadata.max_total_draft_tokens,
+            spec_bl_tree_first_sparse_mask_offset_kv=metadata.spec_bl_tree_first_sparse_mask_offset_kv,
+            num_sparse_topk=metadata.num_sparse_topk,
+            flash_mla_tile_scheduler_metadata=metadata.flash_mla_tile_scheduler_metadata,
+            flash_mla_num_splits=metadata.flash_mla_num_splits,
+            num_contexts=metadata.num_contexts,
+            num_ctx_tokens=metadata.num_ctx_tokens,
+            max_context_length=metadata.max_context_length,
+            max_seq_len=metadata.max_seq_len,
+            trtllm_gen_jit_warmup=metadata.trtllm_gen_jit_warmup,
+            is_cross=metadata.is_cross,
+            # --- Per-call (AttentionForwardArgs) ---
+            out_scale=forward_args.out_scale,
+            kv_scale_orig_quant=forward_args.kv_scale_orig_quant,
+            kv_scale_quant_orig=forward_args.kv_scale_quant_orig,
+            latent_cache=forward_args.latent_cache,
+            q_pe=forward_args.q_pe,
+            attention_sinks=forward_args.attention_sinks,
+            mask_type=forward_args.mask_type,
+            attention_input_type=int(forward_args.attention_input_type),
+            attention_window_size=forward_args.attention_window_size,
+            chunked_prefill_buffer_batch_size=forward_args.chunked_prefill_buffer_batch_size,
+            mrope_rotary_cos_sin=forward_args.mrope_rotary_cos_sin,
+            mrope_position_deltas=forward_args.mrope_position_deltas,
+            softmax_stats_tensor=forward_args.softmax_stats_tensor,
+            cu_q_seqlens=forward_args.cu_q_seqlens,
+            cu_kv_seqlens=forward_args.cu_kv_seqlens,
+            fmha_scheduler_counter=forward_args.fmha_scheduler_counter,
+            mla_bmm1_scale=forward_args.mla_bmm1_scale,
+            mla_bmm2_scale=forward_args.mla_bmm2_scale,
+            quant_q_buffer=forward_args.quant_q_buffer,
+            sage_attn_num_elts_per_blk_q=forward_args.sage_attn_num_elts_per_blk_q,
+            sage_attn_num_elts_per_blk_k=forward_args.sage_attn_num_elts_per_blk_k,
+            sage_attn_num_elts_per_blk_v=forward_args.sage_attn_num_elts_per_blk_v,
+            sage_attn_qk_int8=forward_args.sage_attn_qk_int8,
+            is_fused_qkv=forward_args.is_fused_qkv,
+            update_kv_cache=forward_args.update_kv_cache,
+            cross_kv=forward_args.cross_kv,
+            relative_attention_bias=forward_args.relative_attention_bias,
+            relative_attention_max_distance=forward_args.relative_attention_max_distance,
+            # --- Module config (TrtllmAttention) ---
+            rotary_inv_freq=attn.rotary_inv_freq,
+            rotary_cos_sin=attn.rotary_cos_sin,
+            predicted_tokens_per_seq=attn.predicted_tokens_per_seq,
+            local_layer_idx=attn.local_layer_idx,
+            num_heads=attn.num_heads,
+            num_kv_heads=attn.num_kv_heads,
+            head_size=attn.head_dim,
+            quant_mode=attn.quant_mode,
+            q_scaling=attn.q_scaling,
+            position_embedding_type=attn.position_embedding_type,
+            rope_dim=attn.rope_dim,
+            rope_base=attn.rope_base,
+            rope_scale_type=attn.rope_scale_type,
+            rope_scale=attn.rope_scale,
+            rope_short_m_scale=attn.rope_short_m_scale,
+            rope_long_m_scale=attn.rope_long_m_scale,
+            rope_max_positions=attn.rope_max_positions,
+            rope_original_max_positions=attn.rope_original_max_positions,
+            is_mla_enable=attn.is_mla_enable,
+            q_lora_rank=attn.q_lora_rank,
+            kv_lora_rank=attn.kv_lora_rank,
+            qk_nope_head_dim=attn.qk_nope_head_dim,
+            qk_rope_head_dim=attn.qk_rope_head_dim,
+            v_head_dim=attn.v_head_dim,
+            rope_append=attn.rope_append,
+            attention_chunk_size=attn.attention_chunk_size,
+            skip_softmax_threshold_scale_factor_prefill=skip_softmax_kernel_params.threshold_scale_factor_prefill,
+            skip_softmax_threshold_scale_factor_decode=skip_softmax_kernel_params.threshold_scale_factor_decode,
+            skip_softmax_stat=attn.skip_softmax_stat,
+            # --- Sparse-specific (AttentionForwardArgs.sparse_prediction) ---
+            sparse_kv_indices=forward_args.sparse_prediction.sparse_kv_indices,
+            sparse_kv_offsets=forward_args.sparse_prediction.sparse_kv_offsets,
+            sparse_attn_indices=forward_args.sparse_prediction.sparse_attn_indices,
+            sparse_attn_offsets=forward_args.sparse_prediction.sparse_attn_offsets,
+            sparse_attn_indices_block_size=forward_args.sparse_prediction.sparse_attn_indices_block_size,
+            sparse_mla_topk_lens=forward_args.sparse_prediction.sparse_mla_topk_lens,
+            compressed_kv_cache_pool_ptr=forward_args.sparse_prediction.compressed_kv_cache_pool_ptr,
+        )

--- a/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
@@ -14,11 +14,12 @@
 # limitations under the License.
 
 """
-TrtLLM-Gen Attention Backend
+FlashInfer TRTLLM-Gen FMHA
 
 This module implements attention computation using flashinfer's trtllm-gen kernels.
-It provides a drop-in replacement for thop.attention() with support for trtllm-gen
-kernel only (Blackwell architecture: SM100/SM103). Enabled via TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION=1.
+It provides a TRT-LLM attention FMHA library for trtllm-gen kernels
+(Blackwell architecture: SM100/SM103). Enable or disable it through
+``TLLM_FMHA_LIBS``.
 
 Architecture:
     - QKV preprocessing & RoPE: C++ kernels via tensorrt_llm.bindings.internal.thop,
@@ -27,20 +28,17 @@ Architecture:
       the paged KV cache fields carried by FmhaParams.
 
 Entry points:
-    FlashInferTrtllmGenAttention.is_supported()  - Check if trtllm-gen can handle the given config.
-    FlashInferTrtllmGenAttention.forward()       - Main attention method.
+    FlashInferTrtllmGenFmha.is_available() - Check if this FMHA library can be instantiated.
+    FlashInferTrtllmGenFmha.is_supported() - Check if trtllm-gen can handle the given request.
+    FlashInferTrtllmGenFmha.forward()      - Main attention method.
 
 Example:
-    backend = FlashInferTrtllmGenAttention(attention_layer=...)
-    supported, reason = backend.is_supported(q, k, v, attn=..., meta=..., fwd=...)
-    if supported:
-        backend.forward(q, k, v, attn=..., meta=..., fwd=...)
-    else:
-        Fallback to thop.attention()
+    fmha = FlashInferTrtllmGenFmha(attn=...)
+    if fmha.is_supported(q, k, v, metadata, forward_args):
+        fmha.forward(q, k, v, metadata, forward_args)
 """
 
 import math
-from dataclasses import dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
@@ -56,7 +54,10 @@ from tensorrt_llm._utils import get_sm_version, is_sm_100f, torch_dtype_to_bindi
 from tensorrt_llm.bindings import DataType
 from tensorrt_llm.bindings.internal import thop
 from tensorrt_llm.functional import AttentionMaskType
+from tensorrt_llm.logger import logger
 from tensorrt_llm.quantization.mode import QuantMode
+
+from .phased import FmhaParams, PhasedFmha
 
 if TYPE_CHECKING:
     from tensorrt_llm._torch.attention_backend.trtllm import (
@@ -350,36 +351,7 @@ def _get_workspace_size(
     return max(context_size, generation_size)
 
 
-@dataclass(slots=True)
-class FmhaParams:
-    attn: "TrtllmAttention"
-    meta: "TrtllmAttentionMetadata"
-    fwd: AttentionForwardArgs
-    workspace: torch.Tensor
-    attention_input: Optional[torch.Tensor] = None
-    qkv_input: Optional[torch.Tensor] = None
-    context_buf: Optional[torch.Tensor] = None
-    sequence_lengths: Optional[torch.Tensor] = None
-    context_lengths: Optional[torch.Tensor] = None
-    input_seq_length: int = 0
-    max_past_kv_length: int = 0
-    max_attention_window_size: int = 0
-    cyclic_attention_window_size: int = 0
-    num_tokens: int = 0
-    seq_offset: int = 0
-    tokens_per_block: int = 64
-    fp8_context_fmha: bool = False
-    kv_factor: int = 0
-    total_num_blocks: int = 0
-    # Context-only fields
-    batch_size: int = 0
-    # Generation-only fields
-    num_requests: int = 0
-    spec_decoding_generation_lengths: Optional[torch.Tensor] = None
-    spec_decoding_position_offsets: Optional[torch.Tensor] = None
-
-
-class FlashInferTrtllmGenAttention:
+class FlashInferTrtllmGenFmha(PhasedFmha):
     """
     An attention backend using pure trtllm-gen kernels from flashinfer.
     """
@@ -387,6 +359,7 @@ class FlashInferTrtllmGenAttention:
     # Default KV layout for flashinfer
     # HND = [max_num_pages, kv_factor, num_kv_heads, page_size, head_dim]
     DEFAULT_KV_LAYOUT = "HND"
+    REQUIRES_PAGED_KV = True
     # Keep shared paged indices disabled to match the current TensorRT-LLM
     # block-table layout used by the fused preprocessing path.
     USE_SHARED_PAGED_KV_IDX = False
@@ -436,21 +409,62 @@ class FlashInferTrtllmGenAttention:
         (576, 512, 32),
     }
 
-    def __init__(
-        self,
-        attention_layer: "TrtllmAttention",
-    ):
+    def __init__(self, attn: "TrtllmAttention"):
+        super().__init__(attn)
         self._layout = self.DEFAULT_KV_LAYOUT
         # Read once so the hot path is not sensitive to later environment changes.
         self._enable_pdl = get_env_enable_pdl()
-        missing_ops = self._missing_fused_nanobind_ops()
-        if missing_ops:
-            raise RuntimeError(
-                f"trtllm-gen requires fused nanobind ops, missing: {', '.join(missing_ops)}."
-            )
 
         # Lazily set on the first forward() call from the query device.
         self._multi_processor_count: Optional[int] = None
+
+    @classmethod
+    def is_available(cls, attn: "TrtllmAttention") -> bool:
+        if not IS_FLASHINFER_AVAILABLE:
+            logger.debug("FlashInfer TRTLLM-Gen FMHA is unavailable: flashinfer is not installed.")
+            return False
+
+        missing_ops = cls._missing_fused_nanobind_ops()
+        if missing_ops:
+            logger.debug(
+                "FlashInfer TRTLLM-Gen FMHA is unavailable: missing fused "
+                f"nanobind ops: {', '.join(missing_ops)}."
+            )
+            return False
+
+        sm = get_sm_version()
+        if not is_sm_100f(sm):
+            logger.debug(
+                f"FlashInfer TRTLLM-Gen FMHA is unavailable: requires SM100 or SM103, got SM{sm}."
+            )
+            return False
+
+        has_skip_softmax = (
+            attn.skip_softmax_threshold_scale_factor_prefill is not None
+            or attn.skip_softmax_threshold_scale_factor_decode is not None
+        )
+        if has_skip_softmax:
+            logger.debug(
+                "FlashInfer TRTLLM-Gen FMHA is unavailable: skip-softmax attention is enabled."
+            )
+            return False
+
+        if attn.num_heads <= 0 or attn.num_kv_heads <= 0:
+            logger.debug(
+                "FlashInfer TRTLLM-Gen FMHA is unavailable: "
+                f"num_heads={attn.num_heads}, num_kv_heads={attn.num_kv_heads}."
+            )
+            return False
+
+        if attn.num_heads % attn.num_kv_heads != 0:
+            logger.debug(
+                "FlashInfer TRTLLM-Gen FMHA is unavailable: "
+                f"num_heads ({attn.num_heads}) must be divisible by "
+                f"num_kv_heads ({attn.num_kv_heads})."
+            )
+            return False
+
+        return True
 
     @property
     def layout(self) -> str:
@@ -483,45 +497,13 @@ class FlashInferTrtllmGenAttention:
         return kv_scale_orig_quant, kv_scale_quant_orig
 
     @staticmethod
-    def _get_kv_cache_dtype_and_total_blocks(
+    def _get_kv_cache_dtype(
         meta: "TrtllmAttentionMetadata",
-        is_mla_enable: bool,
-    ) -> Tuple[Optional[DataType], int]:
-        kv_cache_dtype = None
-        total_num_blocks = 0
+    ) -> Optional[DataType]:
         kv_cache_manager = meta.kv_cache_manager
         if kv_cache_manager is not None:
-            kv_cache_dtype = kv_cache_manager.dtype
-            kv_factor = 1 if is_mla_enable else 2
-            blocks_in_primary_pool = getattr(kv_cache_manager, "blocks_in_primary_pool", None)
-            if blocks_in_primary_pool is None:
-                blocks_per_window = getattr(kv_cache_manager, "blocks_per_window", None)
-                if blocks_per_window:
-                    blocks_in_primary_pool = max(
-                        int(primary) for primary, _ in blocks_per_window.values()
-                    )
-            if blocks_in_primary_pool is not None:
-                total_num_blocks = (
-                    int(blocks_in_primary_pool) * kv_cache_manager.num_local_layers * kv_factor
-                )
-        return kv_cache_dtype, total_num_blocks
-
-    @staticmethod
-    def _get_kv_factor(attn: "TrtllmAttention") -> int:
-        return 1 if attn.is_mla_enable else 2
-
-    @staticmethod
-    def _get_generation_out_head_size(attn: "TrtllmAttention") -> int:
-        kv_lora_rank = attn.kv_lora_rank or 0
-        if attn.is_mla_enable and kv_lora_rank:
-            return kv_lora_rank
-        return attn.head_dim
-
-    @staticmethod
-    def _get_context_out_head_size(attn: "TrtllmAttention") -> int:
-        if attn.is_mla_enable and attn.v_head_dim:
-            return attn.v_head_dim
-        return attn.head_dim
+            return kv_cache_manager.dtype
+        return None
 
     @staticmethod
     def _get_bmm1_scale(attn: "TrtllmAttention") -> float:
@@ -588,6 +570,26 @@ class FlashInferTrtllmGenAttention:
         q: torch.Tensor,
         k: Optional[torch.Tensor],
         v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> bool:
+        supported, reason = self._is_supported_with_reason(
+            q,
+            k,
+            v,
+            self.attn,
+            metadata,
+            forward_args,
+        )
+        if not supported:
+            logger.debug(f"FlashInfer TRTLLM-Gen FMHA does not support request: {reason}")
+        return supported
+
+    def _is_supported_with_reason(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
         attn: "TrtllmAttention",
         meta: "TrtllmAttentionMetadata",
         fwd: AttentionForwardArgs,
@@ -625,8 +627,6 @@ class FlashInferTrtllmGenAttention:
         if is_mla_enable and fwd.attention_input_type != AttentionInputType.generation_only:
             return False, "trtllm-gen MLA supports generation-only attention."
 
-        if not IS_FLASHINFER_AVAILABLE:
-            return False, "flashinfer package is not installed."
         if meta.kv_cache_block_offsets is None:
             return False, "trtllm-gen requires paged KV cache."
         output = fwd.output
@@ -643,16 +643,12 @@ class FlashInferTrtllmGenAttention:
         q_dtype = q.dtype
         o_dtype = output.dtype
 
-        sm = get_sm_version()
-        if not is_sm_100f(sm):
-            return False, (f"trtllm-gen requires SM100 or SM103 (Blackwell). Current: SM{sm}.")
-
         if q_dtype not in self.SUPPORTED_INPUT_DTYPES:
             return False, (
                 f"Input dtype {q_dtype} not supported. Supported: FP16, BF16, FP8 (E4M3)."
             )
 
-        kv_cache_dtype, _ = self._get_kv_cache_dtype_and_total_blocks(meta, is_mla_enable)
+        kv_cache_dtype = self._get_kv_cache_dtype(meta)
         if kv_cache_dtype is None:
             kv_cache_dtype = torch_dtype_to_binding(q_dtype)
 
@@ -672,15 +668,6 @@ class FlashInferTrtllmGenAttention:
             )
         if o_dtype not in self.SUPPORTED_OUT_DTYPES:
             return False, f"Output dtype {o_dtype} not supported. Supported: FP16, BF16, FP8."
-
-        assert attn.num_heads > 0, "num_heads must be positive."
-        assert attn.num_kv_heads > 0, "num_kv_heads must be positive."
-        if attn.num_heads % attn.num_kv_heads != 0:
-            return (
-                False,
-                f"num_heads ({attn.num_heads}) must be divisible by "
-                f"num_kv_heads ({attn.num_kv_heads}).",
-            )
 
         has_alibi = attn.position_embedding_type in (4, 5)
         check_context_phase = has_context_phase and not is_mla_enable
@@ -772,184 +759,70 @@ class FlashInferTrtllmGenAttention:
             device_index = torch.cuda.current_device()
         return self._get_multi_processor_count_for_device(device_index)
 
-    def forward(
+    def get_fp8_context_fmha(
         self,
         q: torch.Tensor,
-        k: Optional[torch.Tensor],
-        v: Optional[torch.Tensor],
-        attn: "TrtllmAttention",
-        meta: "TrtllmAttentionMetadata",
-        fwd: AttentionForwardArgs,
-    ) -> None:
-        output = fwd.output
-        if output is None:
-            raise RuntimeError("trtllm-gen attention requires output.")
-        if meta.kv_cache_block_offsets is None:
-            raise RuntimeError("trtllm-gen attention requires paged KV cache.")
-
-        workspace = meta.effective_workspace
-        if workspace is None:
-            workspace = torch.empty((0,), device=q.device, dtype=torch.int8)
-
-        # Lazily cache the SM count from the first query tensor's device.
-        if self._multi_processor_count is None:
-            self._multi_processor_count = self._get_multi_processor_count(q.device)
-
-        num_heads = attn.num_heads
-        num_kv_heads = attn.num_kv_heads
-        head_size = attn.head_dim
-        quant_mode = attn.quant_mode
-        is_mla_enable = attn.is_mla_enable
-        tokens_per_block = meta.tokens_per_block
-        max_num_requests = meta.max_num_requests
-        max_context_length = meta.max_context_length
-        attention_window_size = fwd.attention_window_size
-        beam_width = meta.beam_width
-
-        num_tokens = q.size(0)
-        attn_input_type = fwd.attention_input_type
-        is_gen_only = attn_input_type == AttentionInputType.generation_only
-        is_fp8_out = output.dtype == torch.float8_e4m3fn
-        is_fp4_out = output.dtype == torch.uint8
-        kv_cache_quant_mode = QuantMode(quant_mode)
-        fp8_context_fmha = (
-            is_fp8_out
-            or is_fp4_out
+        output: torch.Tensor,
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+        is_gen_only: bool,
+    ) -> bool:
+        del q, metadata, forward_args
+        kv_cache_quant_mode = QuantMode(self.attn.quant_mode)
+        return (
+            output.dtype == torch.float8_e4m3fn
+            or output.dtype == torch.uint8
             or kv_cache_quant_mode.has_fp4_kv_cache()
             or (kv_cache_quant_mode.has_fp8_kv_cache() and not is_gen_only)
         )
 
-        num_contexts = meta.num_contexts
-        num_ctx_tokens = meta.num_ctx_tokens
-        num_generations = meta.num_generations
-        num_gen_tokens = num_tokens if is_gen_only else num_tokens - num_ctx_tokens
-        if num_gen_tokens < 0:
-            raise RuntimeError(
-                f"Invalid trtllm-gen attention token counts: num_tokens={num_tokens}, "
-                f"num_ctx_tokens={num_ctx_tokens}, attention_input_type={attn_input_type}."
-            )
+    def prepare_workspace(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+        workspace: torch.Tensor,
+    ) -> None:
+        del k, v
+        attn = self.attn
+        # Lazily cache the SM count from the first query tensor's device.
+        if self._multi_processor_count is None:
+            self._multi_processor_count = self._get_multi_processor_count(q.device)
 
-        workspace_max_tokens = max(num_tokens, max_context_length)
-        workspace_max_gen_tokens = max(num_gen_tokens, max_num_requests)
+        num_tokens = q.size(0)
+        attention_input_type = forward_args.attention_input_type
+        is_gen_only = attention_input_type == AttentionInputType.generation_only
+        num_gen_tokens = num_tokens if is_gen_only else num_tokens - metadata.num_ctx_tokens
+        output = forward_args.output
+        if output is None:
+            raise RuntimeError(f"{type(self).__name__} requires output.")
+        fp8_context_fmha = self.get_fp8_context_fmha(q, output, metadata, forward_args, is_gen_only)
+
+        workspace_max_tokens = max(num_tokens, metadata.max_context_length)
+        workspace_max_gen_tokens = max(num_gen_tokens, metadata.max_num_requests)
         required_workspace_size = _get_workspace_size(
             dtype=q.dtype,
             num_tokens=workspace_max_tokens,
             num_gen_tokens=workspace_max_gen_tokens,
-            num_heads=num_heads,
-            num_kv_heads=num_kv_heads,
-            head_size=head_size,
-            max_num_requests=max_num_requests,
+            num_heads=attn.num_heads,
+            num_kv_heads=attn.num_kv_heads,
+            head_size=attn.head_dim,
+            max_num_requests=metadata.max_num_requests,
             rotary_embedding_dim=attn.rope_dim,
             fp8_context_fmha=fp8_context_fmha,
         )
 
         current_workspace_size = workspace.numel() * workspace.element_size()
         if current_workspace_size < required_workspace_size:
-            if meta.is_cuda_graph and torch.cuda.is_current_stream_capturing():
+            if metadata.is_cuda_graph and torch.cuda.is_current_stream_capturing():
                 raise RuntimeError(
                     "Attention CUDA graph workspace is smaller than the "
                     "required size for trtllm-gen."
                 )
             required_workspace_numel = math.ceil(required_workspace_size / workspace.element_size())
             workspace.resize_((required_workspace_numel,))
-
-        out_head_size = (
-            self._get_generation_out_head_size(attn)
-            if is_gen_only
-            else self._get_context_out_head_size(attn)
-        )
-        out_tensor = output.view(num_tokens, num_heads, out_head_size)
-
-        cache_indirection = meta.cache_indirection
-        max_attn_window_size = (
-            attention_window_size
-            if beam_width == 1
-            else (
-                cache_indirection.size(2)
-                if cache_indirection is not None
-                else attention_window_size
-            )
-        )
-        cyclic_attn_window_size = attention_window_size
-        tokens_per_block = tokens_per_block if tokens_per_block is not None else 64
-        _, total_num_blocks = self._get_kv_cache_dtype_and_total_blocks(meta, is_mla_enable)
-
-        params = FmhaParams(
-            attn=attn,
-            meta=meta,
-            fwd=fwd,
-            workspace=workspace,
-            max_attention_window_size=max_attn_window_size,
-            cyclic_attention_window_size=cyclic_attn_window_size,
-            tokens_per_block=tokens_per_block,
-            fp8_context_fmha=fp8_context_fmha,
-            kv_factor=self._get_kv_factor(attn),
-            total_num_blocks=total_num_blocks,
-        )
-
-        sequence_length = meta.kv_lens_cuda_runtime
-        host_past_key_value_lengths = meta.kv_lens_runtime
-
-        if num_contexts > 0 and attn_input_type != AttentionInputType.generation_only:
-            seq_offset = 0
-            token_offset = 0
-            num_seqs = num_contexts
-
-            context_lengths = meta.prompt_lens_cuda_runtime
-            host_context_lengths = meta.prompt_lens_cpu_runtime
-            max_context_q_len = int(host_context_lengths[seq_offset : seq_offset + num_seqs].max())
-            max_past_kv_len = int(
-                host_past_key_value_lengths[seq_offset : seq_offset + num_seqs].max()
-            )
-
-            params.attention_input = q[token_offset : token_offset + num_ctx_tokens]
-            params.qkv_input = params.attention_input
-            params.context_buf = out_tensor[token_offset : token_offset + num_ctx_tokens]
-            params.sequence_lengths = sequence_length[seq_offset:]
-            params.context_lengths = context_lengths[seq_offset:]
-            params.max_past_kv_length = max_past_kv_len
-            params.num_tokens = num_ctx_tokens
-            params.seq_offset = seq_offset
-            params.input_seq_length = max_context_q_len
-            params.batch_size = num_seqs
-            self.run_context(params)
-
-        if num_generations > 0 and attn_input_type != AttentionInputType.context_only:
-            seq_offset = num_contexts
-            token_offset = 0 if is_gen_only else num_ctx_tokens
-            num_seqs = num_generations
-
-            max_past_kv_len = int(
-                host_past_key_value_lengths[seq_offset : seq_offset + num_seqs].max()
-            )
-            input_seq_length = num_gen_tokens // num_seqs if num_seqs > 0 else 1
-
-            predicted_tokens_per_seq = attn.predicted_tokens_per_seq
-            spec_gen_lengths = None
-            spec_pos_offsets = None
-            if meta.is_spec_decoding_enabled and predicted_tokens_per_seq > 1:
-                spec_gen_lengths = meta.spec_decoding_generation_lengths
-                position_offsets_for_cpp = meta.spec_decoding_position_offsets_for_cpp
-                if position_offsets_for_cpp is not None and position_offsets_for_cpp.dim() == 1:
-                    position_offsets_for_cpp = position_offsets_for_cpp.view(max_num_requests, -1)
-                spec_pos_offsets = position_offsets_for_cpp
-
-            params.attention_input = q[token_offset : token_offset + num_gen_tokens]
-            params.qkv_input = params.attention_input
-            params.context_buf = out_tensor[token_offset : token_offset + num_gen_tokens]
-            params.sequence_lengths = sequence_length[seq_offset:]
-            params.max_past_kv_length = max_past_kv_len
-            params.num_tokens = num_gen_tokens
-            params.seq_offset = seq_offset
-            params.input_seq_length = input_seq_length
-            params.num_requests = num_seqs // beam_width
-            params.spec_decoding_generation_lengths = spec_gen_lengths
-            params.spec_decoding_position_offsets = spec_pos_offsets
-            if is_mla_enable:
-                self.run_mla_generation(params)
-            else:
-                self.run_generation(params)
-        return
 
     @staticmethod
     def _compute_window_left(

--- a/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
@@ -359,7 +359,6 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
     # Default KV layout for flashinfer
     # HND = [max_num_pages, kv_factor, num_kv_heads, page_size, head_dim]
     DEFAULT_KV_LAYOUT = "HND"
-    REQUIRES_PAGED_KV = True
     # Keep shared paged indices disabled to match the current TensorRT-LLM
     # block-table layout used by the fused preprocessing path.
     USE_SHARED_PAGED_KV_IDX = False
@@ -767,7 +766,6 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
         forward_args: AttentionForwardArgs,
         is_gen_only: bool,
     ) -> bool:
-        del q, metadata, forward_args
         kv_cache_quant_mode = QuantMode(self.attn.quant_mode)
         return (
             output.dtype == torch.float8_e4m3fn
@@ -785,7 +783,6 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
         forward_args: AttentionForwardArgs,
         workspace: torch.Tensor,
     ) -> None:
-        del k, v
         attn = self.attn
         # Lazily cache the SM count from the first query tensor's device.
         if self._multi_processor_count is None:

--- a/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
@@ -50,6 +50,7 @@ if IS_FLASHINFER_AVAILABLE:
     import flashinfer
 
 from tensorrt_llm._torch.attention_backend.interface import AttentionForwardArgs, AttentionInputType
+from tensorrt_llm._torch.attention_backend.sparse.skip_softmax import SkipSoftmaxParams
 from tensorrt_llm._utils import get_sm_version, is_sm_100f, torch_dtype_to_binding
 from tensorrt_llm.bindings import DataType
 from tensorrt_llm.bindings.internal import thop
@@ -438,10 +439,7 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
             )
             return False
 
-        has_skip_softmax = (
-            attn.skip_softmax_threshold_scale_factor_prefill is not None
-            or attn.skip_softmax_threshold_scale_factor_decode is not None
-        )
+        has_skip_softmax = isinstance(attn.sparse_params, SkipSoftmaxParams)
         if has_skip_softmax:
             logger.debug(
                 "FlashInfer TRTLLM-Gen FMHA is unavailable: skip-softmax attention is enabled."

--- a/tensorrt_llm/_torch/attention_backend/fmha/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/interface.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from tensorrt_llm._torch.attention_backend.interface import AttentionForwardArgs
+
+if TYPE_CHECKING:
+    from tensorrt_llm._torch.attention_backend.trtllm import (
+        TrtllmAttention,
+        TrtllmAttentionMetadata,
+    )
+
+
+class Fmha(ABC):
+    """Common runtime contract for TRT-LLM attention FMHA libraries."""
+
+    def __init__(self, attn: "TrtllmAttention"):
+        self.attn = attn
+
+    @classmethod
+    def is_available(cls, attn: "TrtllmAttention") -> bool:
+        return True
+
+    def is_supported(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> bool:
+        return True
+
+    @abstractmethod
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> None:
+        raise NotImplementedError

--- a/tensorrt_llm/_torch/attention_backend/fmha/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/interface.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import weakref
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Optional
 
@@ -31,7 +32,14 @@ class Fmha(ABC):
     """Common runtime contract for TRT-LLM attention FMHA libraries."""
 
     def __init__(self, attn: "TrtllmAttention"):
-        self.attn = attn
+        self._attn_ref: weakref.ReferenceType["TrtllmAttention"] = weakref.ref(attn)
+
+    @property
+    def attn(self) -> "TrtllmAttention":
+        attn = self._attn_ref()
+        if attn is None:
+            raise RuntimeError("The owning TrtllmAttention instance has been garbage collected.")
+        return attn
 
     @classmethod
     def is_available(cls, attn: "TrtllmAttention") -> bool:

--- a/tensorrt_llm/_torch/attention_backend/fmha/phased.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/phased.py
@@ -59,9 +59,9 @@ class FmhaParams:
 
 
 class PhasedFmha(Fmha):
-    """FMHA base that dispatches mixed requests by phase and attention family."""
+    """FMHA helper for paged-KV libraries that split work by request phase."""
 
-    REQUIRES_PAGED_KV = False
+    REQUIRES_PAGED_KV = True
 
     def __init__(self, attn: "TrtllmAttention"):
         super().__init__(attn)

--- a/tensorrt_llm/_torch/attention_backend/fmha/phased.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/phased.py
@@ -1,0 +1,269 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional, cast
+
+import torch
+
+from tensorrt_llm._torch.attention_backend.interface import AttentionForwardArgs, AttentionInputType
+
+from .interface import Fmha
+
+if TYPE_CHECKING:
+    from tensorrt_llm._torch.attention_backend.trtllm import (
+        TrtllmAttention,
+        TrtllmAttentionMetadata,
+    )
+
+
+@dataclass(slots=True)
+class FmhaParams:
+    attn: "TrtllmAttention"
+    meta: "TrtllmAttentionMetadata"
+    fwd: AttentionForwardArgs
+    workspace: torch.Tensor
+    attention_input: Optional[torch.Tensor] = None
+    qkv_input: Optional[torch.Tensor] = None
+    context_buf: Optional[torch.Tensor] = None
+    sequence_lengths: Optional[torch.Tensor] = None
+    context_lengths: Optional[torch.Tensor] = None
+    input_seq_length: int = 0
+    max_past_kv_length: int = 0
+    max_attention_window_size: int = 0
+    cyclic_attention_window_size: int = 0
+    num_tokens: int = 0
+    seq_offset: int = 0
+    tokens_per_block: int = 64
+    fp8_context_fmha: bool = False
+    kv_factor: int = 0
+    total_num_blocks: int = 0
+    # Context-only fields
+    batch_size: int = 0
+    # Generation-only fields
+    num_requests: int = 0
+    spec_decoding_generation_lengths: Optional[torch.Tensor] = None
+    spec_decoding_position_offsets: Optional[torch.Tensor] = None
+
+
+class PhasedFmha(Fmha):
+    """FMHA base that dispatches mixed requests by phase and attention family."""
+
+    REQUIRES_PAGED_KV = False
+
+    def __init__(self, attn: "TrtllmAttention"):
+        super().__init__(attn)
+        self.kv_factor = 1 if attn.is_mla_enable else 2
+        kv_lora_rank = attn.kv_lora_rank or 0
+        self.generation_out_head_size = (
+            kv_lora_rank if attn.is_mla_enable and kv_lora_rank else attn.head_dim
+        )
+        self.context_out_head_size = (
+            attn.v_head_dim if attn.is_mla_enable and attn.v_head_dim else attn.head_dim
+        )
+
+    def _get_total_num_blocks(
+        self,
+        meta: "TrtllmAttentionMetadata",
+    ) -> int:
+        kv_cache_manager = meta.kv_cache_manager
+        if kv_cache_manager is None:
+            return 0
+
+        blocks_in_primary_pool = getattr(kv_cache_manager, "blocks_in_primary_pool", None)
+        if blocks_in_primary_pool is None:
+            blocks_per_window = getattr(kv_cache_manager, "blocks_per_window", None)
+            if blocks_per_window:
+                blocks_in_primary_pool = max(
+                    int(primary) for primary, _ in blocks_per_window.values()
+                )
+        if blocks_in_primary_pool is None:
+            return 0
+        return int(blocks_in_primary_pool) * kv_cache_manager.num_local_layers * self.kv_factor
+
+    def get_fp8_context_fmha(
+        self,
+        q: torch.Tensor,
+        output: torch.Tensor,
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+        is_gen_only: bool,
+    ) -> bool:
+        return False
+
+    def prepare_workspace(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+        workspace: torch.Tensor,
+    ) -> None:
+        pass
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: Optional[torch.Tensor],
+        v: Optional[torch.Tensor],
+        metadata: "TrtllmAttentionMetadata",
+        forward_args: AttentionForwardArgs,
+    ) -> None:
+        attn = self.attn
+        output = forward_args.output
+        if output is None:
+            raise RuntimeError(f"{type(self).__name__} requires output.")
+        if self.REQUIRES_PAGED_KV and metadata.kv_cache_block_offsets is None:
+            raise RuntimeError(f"{type(self).__name__} requires paged KV cache.")
+
+        workspace = cast(torch.Tensor, metadata.effective_workspace)
+
+        num_tokens = q.size(0)
+        attention_input_type = forward_args.attention_input_type
+        is_gen_only = attention_input_type == AttentionInputType.generation_only
+
+        num_contexts = metadata.num_contexts
+        num_ctx_tokens = metadata.num_ctx_tokens
+        num_generations = metadata.num_generations
+        num_gen_tokens = num_tokens if is_gen_only else num_tokens - num_ctx_tokens
+        if num_gen_tokens < 0:
+            raise RuntimeError(
+                f"Invalid FMHA token counts: num_tokens={num_tokens}, "
+                f"num_ctx_tokens={num_ctx_tokens}, attention_input_type={attention_input_type}."
+            )
+
+        fp8_context_fmha = self.get_fp8_context_fmha(q, output, metadata, forward_args, is_gen_only)
+        self.prepare_workspace(
+            q,
+            k,
+            v,
+            metadata,
+            forward_args,
+            workspace,
+        )
+
+        out_head_size = self.generation_out_head_size if is_gen_only else self.context_out_head_size
+        out_tensor = output.view(num_tokens, attn.num_heads, out_head_size)
+
+        attention_window_size = forward_args.attention_window_size
+        cache_indirection = metadata.cache_indirection
+        max_attention_window_size = (
+            attention_window_size
+            if metadata.beam_width == 1
+            else (
+                cache_indirection.size(2)
+                if cache_indirection is not None
+                else attention_window_size
+            )
+        )
+        tokens_per_block = (
+            metadata.tokens_per_block if metadata.tokens_per_block is not None else 64
+        )
+
+        params = FmhaParams(
+            attn=attn,
+            meta=metadata,
+            fwd=forward_args,
+            workspace=workspace,
+            max_attention_window_size=max_attention_window_size,
+            cyclic_attention_window_size=attention_window_size,
+            tokens_per_block=tokens_per_block,
+            fp8_context_fmha=fp8_context_fmha,
+            kv_factor=self.kv_factor,
+            total_num_blocks=self._get_total_num_blocks(metadata),
+        )
+
+        sequence_length = metadata.kv_lens_cuda_runtime
+        host_past_key_value_lengths = metadata.kv_lens_runtime
+
+        if num_contexts > 0 and attention_input_type != AttentionInputType.generation_only:
+            seq_offset = 0
+            token_offset = 0
+            num_seqs = num_contexts
+
+            context_lengths = metadata.prompt_lens_cuda_runtime
+            host_context_lengths = metadata.prompt_lens_cpu_runtime
+            max_context_q_len = int(host_context_lengths[seq_offset : seq_offset + num_seqs].max())
+            max_past_kv_len = int(
+                host_past_key_value_lengths[seq_offset : seq_offset + num_seqs].max()
+            )
+
+            params.attention_input = q[token_offset : token_offset + num_ctx_tokens]
+            params.qkv_input = params.attention_input
+            params.context_buf = out_tensor[token_offset : token_offset + num_ctx_tokens]
+            params.sequence_lengths = sequence_length[seq_offset:]
+            params.context_lengths = context_lengths[seq_offset:]
+            params.max_past_kv_length = max_past_kv_len
+            params.num_tokens = num_ctx_tokens
+            params.seq_offset = seq_offset
+            params.input_seq_length = max_context_q_len
+            params.batch_size = num_seqs
+            if attn.is_mla_enable:
+                self.run_mla_context(params)
+            else:
+                self.run_context(params)
+
+        if num_generations > 0 and attention_input_type != AttentionInputType.context_only:
+            seq_offset = num_contexts
+            token_offset = 0 if is_gen_only else num_ctx_tokens
+            num_seqs = num_generations
+
+            max_past_kv_len = int(
+                host_past_key_value_lengths[seq_offset : seq_offset + num_seqs].max()
+            )
+            input_seq_length = num_gen_tokens // num_seqs if num_seqs > 0 else 1
+
+            predicted_tokens_per_seq = attn.predicted_tokens_per_seq
+            spec_gen_lengths = None
+            spec_pos_offsets = None
+            if metadata.is_spec_decoding_enabled and predicted_tokens_per_seq > 1:
+                spec_gen_lengths = metadata.spec_decoding_generation_lengths
+                position_offsets_for_cpp = metadata.spec_decoding_position_offsets_for_cpp
+                if position_offsets_for_cpp is not None and position_offsets_for_cpp.dim() == 1:
+                    position_offsets_for_cpp = position_offsets_for_cpp.view(
+                        metadata.max_num_requests, -1
+                    )
+                spec_pos_offsets = position_offsets_for_cpp
+
+            params.attention_input = q[token_offset : token_offset + num_gen_tokens]
+            params.qkv_input = params.attention_input
+            params.context_buf = out_tensor[token_offset : token_offset + num_gen_tokens]
+            params.sequence_lengths = sequence_length[seq_offset:]
+            params.max_past_kv_length = max_past_kv_len
+            params.num_tokens = num_gen_tokens
+            params.seq_offset = seq_offset
+            params.input_seq_length = input_seq_length
+            params.num_requests = num_seqs // metadata.beam_width
+            params.spec_decoding_generation_lengths = spec_gen_lengths
+            params.spec_decoding_position_offsets = spec_pos_offsets
+            if attn.is_mla_enable:
+                self.run_mla_generation(params)
+            else:
+                self.run_generation(params)
+
+    def run_context(self, params: FmhaParams) -> None:
+        raise NotImplementedError(f"{type(self).__name__} does not support context attention.")
+
+    def run_generation(self, params: FmhaParams) -> None:
+        raise NotImplementedError(f"{type(self).__name__} does not support generation attention.")
+
+    def run_mla_context(self, params: FmhaParams) -> None:
+        raise NotImplementedError(f"{type(self).__name__} does not support MLA context attention.")
+
+    def run_mla_generation(self, params: FmhaParams) -> None:
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support MLA generation attention."
+        )

--- a/tensorrt_llm/_torch/attention_backend/fmha/registry.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/registry.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing import TypeAlias
+
+from .fallback import FallbackFmha
+from .flashinfer_trtllm_gen import FlashInferTrtllmGenFmha
+from .interface import Fmha
+
+FmhaCls: TypeAlias = type[Fmha]
+
+FMHA_LIBS: dict[str, FmhaCls] = {
+    "flashinfer_trtllm_gen": FlashInferTrtllmGenFmha,
+    "fallback": FallbackFmha,
+}
+DEFAULT_FMHA_LIBS: tuple[str, ...] = tuple(FMHA_LIBS)
+
+
+def _parse_fmha_libs_env() -> tuple[str, ...]:
+    value = os.environ.get("TLLM_FMHA_LIBS")
+    if value is None or not value.strip():
+        return DEFAULT_FMHA_LIBS
+
+    tokens = [token.strip() for token in value.split(",") if token.strip()]
+    if not tokens:
+        return DEFAULT_FMHA_LIBS
+
+    has_delta_token = any(token[0] in "+-" for token in tokens)
+    if has_delta_token and not all(token[0] in "+-" for token in tokens):
+        raise ValueError(
+            "TLLM_FMHA_LIBS must use either an exact comma-separated list "
+            "or only +/- delta entries."
+        )
+
+    if has_delta_token:
+        names = list(DEFAULT_FMHA_LIBS)
+        for token in tokens:
+            sign = token[0]
+            name = token[1:].strip()
+            if not name:
+                raise ValueError(f"Invalid empty FMHA library entry in {value!r}.")
+            if name not in FMHA_LIBS:
+                raise ValueError(f"Unknown FMHA library {name!r} in TLLM_FMHA_LIBS.")
+            if sign == "+" and name not in names:
+                names.append(name)
+            elif sign == "-" and name in names:
+                names.remove(name)
+    else:
+        names = []
+        for name in tokens:
+            if name not in FMHA_LIBS:
+                raise ValueError(f"Unknown FMHA library {name!r} in TLLM_FMHA_LIBS.")
+            if name not in names:
+                names.append(name)
+
+    return tuple(names)
+
+
+def get_enabled_fmha_lib_classes() -> list[FmhaCls]:
+    return [FMHA_LIBS[name] for name in _parse_fmha_libs_env()]
+
+
+__all__ = [
+    "DEFAULT_FMHA_LIBS",
+    "FMHA_LIBS",
+    "FmhaCls",
+    "get_enabled_fmha_lib_classes",
+]

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1415,13 +1415,11 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
     def rope_original_max_positions(self) -> int:
         return self.rope_params.original_max_positions
 
-
     def create_fmha_libs(self) -> None:
         self.fmha_libs = []
         for fmha_cls in get_enabled_fmha_lib_classes():
             if fmha_cls.is_available(self):
                 self.fmha_libs.append(fmha_cls(self))
-
 
     def forward(
         self,

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import functools
 import math
 import os
@@ -105,7 +120,6 @@ class TrtllmAttentionMetadata(AttentionMetadata):
     spec_decoding_bl_tree_mask_offset: Optional[torch.Tensor] = None
     spec_decoding_bl_tree_mask: Optional[torch.Tensor] = None
     spec_bl_tree_first_sparse_mask_offset_kv: Optional[torch.Tensor] = None
-    max_total_draft_tokens: Optional[int] = None
 
     # TRTLLM-Gen FMHA JIT warmup controls.
     trtllm_gen_jit_warmup: bool = False

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -11,7 +11,8 @@ if TYPE_CHECKING:
     from ..speculative.interface import SpecMetadata
     from ..speculative.spec_tree_manager import SpecTreeManager
 
-from tensorrt_llm._torch.attention_backend import trtllm_gen
+from tensorrt_llm._torch.attention_backend.fmha import (
+    Fmha, get_enabled_fmha_lib_classes)
 from tensorrt_llm._utils import get_sm_version, maybe_pin_memory, prefer_pinned
 from tensorrt_llm.bindings.internal import thop
 from tensorrt_llm.functional import AttentionMaskType
@@ -25,27 +26,7 @@ from .interface import (AttentionBackend, AttentionForwardArgs,
                         PredefinedAttentionMask, RopeParams, SparsePrediction,
                         merge_attention_forward_args)
 from .sparse.params import SparseParams
-from .sparse.skip_softmax import SkipSoftmaxKernelParams, SkipSoftmaxParams
-
-# Enable TRTLLM-Gen attention backend by default. Set
-# TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION=0 to force the thop.attention path.
-_TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION = (os.environ.get(
-    "TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION", "1") == "1")
-
-# ``AttentionForwardArgs`` fields that this backend does not consume.
-# Sync test (test_attention_op_sync.py) requires every other field to map to a
-# kwarg name, a @property on the dataclass, or a field that some @property
-# transitively reads; entries here are exempt.
-_THOP_EXCLUDED_FIELDS: frozenset = frozenset({
-    "topk_indices",  # DSA-only
-    "attention_mask_data",  # custom-mask code path
-    "out_scale_sf",  # promoted into ``out_scale`` in ``_run`` for NVFP4 path
-})
-
-# ``thop.attention`` kwargs hard-wired to a literal at the call site (no
-# rich object owns them). Sync test enforces both the kwarg name and the
-# literal value.
-_THOP_LITERALS: dict = {}
+from .sparse.skip_softmax import SkipSoftmaxParams
 
 
 @functools.cache
@@ -124,6 +105,7 @@ class TrtllmAttentionMetadata(AttentionMetadata):
     spec_decoding_bl_tree_mask_offset: Optional[torch.Tensor] = None
     spec_decoding_bl_tree_mask: Optional[torch.Tensor] = None
     spec_bl_tree_first_sparse_mask_offset_kv: Optional[torch.Tensor] = None
+    max_total_draft_tokens: Optional[int] = None
 
     # TRTLLM-Gen FMHA JIT warmup controls.
     trtllm_gen_jit_warmup: bool = False
@@ -1213,6 +1195,7 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         self.kv_scale_orig_quant = 1.0 / self.kv_cache_scaling_factor
 
         self.local_layer_idx: Optional[int] = None
+        self.fmha_libs: List[Fmha] = []
         if not skip_create_weights_in_init:
             self.update_quant_config(self.quant_config)
 
@@ -1235,6 +1218,7 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
             self.has_nvfp4 = self.quant_config.layer_quant_mode.has_nvfp4()
             self.has_w4a8_nvfp4_fp8 = self.quant_config.layer_quant_mode.has_w4a8_nvfp4_fp8(
             )
+        self.create_fmha_libs()
 
     def get_local_layer_idx(self, metadata: TrtllmAttentionMetadata) -> int:
         if self.local_layer_idx is not None:
@@ -1417,320 +1401,13 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
     def rope_original_max_positions(self) -> int:
         return self.rope_params.original_max_positions
 
-    def _get_trtllm_gen_backend(
-            self) -> trtllm_gen.FlashInferTrtllmGenAttention:
-        backend = getattr(self, "_trtllm_gen_backend", None)
-        if backend is None:
-            backend = trtllm_gen.FlashInferTrtllmGenAttention(
-                attention_layer=self, )
-            self._trtllm_gen_backend = backend
-        return backend
 
-    def _run(
-        self,
-        q: torch.Tensor,
-        k: Optional[torch.Tensor],
-        v: Optional[torch.Tensor],
-        metadata: TrtllmAttentionMetadata,
-        forward_args: AttentionForwardArgs,
-    ) -> None:
-        if metadata.is_cross:
-            if k is not None and v is not None:
-                k_flat = k.contiguous().view(k.shape[0], -1)
-                v_flat = v.contiguous().view(v.shape[0], -1)
-                forward_args.cross_kv = torch.cat([k_flat, v_flat],
-                                                  dim=1).contiguous()
+    def create_fmha_libs(self) -> None:
+        self.fmha_libs = []
+        for fmha_cls in get_enabled_fmha_lib_classes():
+            if fmha_cls.is_available(self):
+                self.fmha_libs.append(fmha_cls(self))
 
-            q_hidden_size = self.num_heads * self.head_dim
-            kv_hidden_size = self.num_kv_heads * self.head_dim
-            qkv_hidden_size = q_hidden_size + 2 * kv_hidden_size
-            if q.shape[1] == q_hidden_size:
-                fused_q = q.new_zeros((q.shape[0], qkv_hidden_size))
-                fused_q[:, :q_hidden_size].copy_(q)
-                q = fused_q
-            else:
-                assert q.shape[1] == qkv_hidden_size
-            k = None
-            v = None
-            forward_args.is_fused_qkv = True
-
-        attention_input_type = forward_args.attention_input_type
-        if not self.is_mla_enable:
-            if forward_args.is_fused_qkv:
-                qkv_hidden_size = (self.num_heads +
-                                   2 * self.num_kv_heads) * self.head_dim
-                assert q.shape[1] == qkv_hidden_size
-            else:
-                q_hidden_size = self.num_heads * self.head_dim
-                assert q.shape[1] == q_hidden_size
-                if forward_args.update_kv_cache:
-                    kv_hidden_size = self.num_kv_heads * self.head_dim
-                    assert k.shape[1] == kv_hidden_size
-                    assert v.shape[1] == kv_hidden_size
-            num_tokens = q.shape[0]
-            if k is not None and not metadata.is_cross:
-                assert k.shape[0] == num_tokens
-                assert v.shape[0] == num_tokens
-        else:
-            is_sparse_attn = forward_args.sparse_prediction.sparse_attn_indices is not None and forward_args.sparse_prediction.sparse_attn_indices.numel(
-            ) > 0
-            if attention_input_type == AttentionInputType.context_only and is_sparse_attn:
-                assert forward_args.is_fused_qkv
-                qkv_hidden_size = self.num_heads * (self.kv_lora_rank +
-                                                    self.qk_rope_head_dim)
-            elif attention_input_type == AttentionInputType.context_only:
-                assert not forward_args.is_fused_qkv
-                qkv_hidden_size = self.num_heads * (self.qk_nope_head_dim +
-                                                    self.qk_rope_head_dim)
-            elif attention_input_type == AttentionInputType.generation_only:
-                assert forward_args.is_fused_qkv
-                qkv_hidden_size = self.num_heads * (self.kv_lora_rank +
-                                                    self.qk_rope_head_dim)
-            else:
-                raise ValueError(
-                    "In MLA, TrtllmAttention can only support context_only or generation_only, not mixed."
-                )
-            assert q.shape[
-                1] == qkv_hidden_size, f"q.shape[1] must be equal to qkv_hidden_size, got {q.shape[1]=}, {qkv_hidden_size=}"
-
-        batch_size = metadata.kv_lens_cuda_runtime.shape[0]
-        assert metadata.kv_lens_runtime.shape[0] == batch_size
-        assert metadata.prompt_lens_cuda_runtime.shape[0] == batch_size
-        assert metadata.prompt_lens_cpu_runtime.shape[0] == batch_size
-        assert metadata.host_request_types_runtime.shape[0] == batch_size
-
-        self._ensure_rope_table_size(metadata.max_seq_len)
-
-        # Prime ``self.local_layer_idx`` so the ``thop.attention`` kwarg
-        # below reads a populated int rather than the ``None`` placeholder.
-        # The call is a fast cache hit after the first forward.
-        self.local_layer_idx = self.get_local_layer_idx(metadata)
-        if metadata.spec_decoding_bl_tree_mask is not None and self.local_layer_idx == 0:
-            metadata.spec_decoding_bl_tree_mask.zero_()
-
-        if self.print_skip_softmax_stat:
-            self.skip_softmax_stat.zero_()
-
-        # Propagate the KV cache manager's SWA window to the FMHA kernel when
-        # the model does not specify one, so paged-context attention does not
-        # read stale page-table entries (BAD_PAGE_INDEX).
-        if forward_args.attention_window_size is None and metadata.kv_cache_manager is not None:
-            window_vec = getattr(metadata.kv_cache_manager,
-                                 'max_attention_window_vec', None)
-            if window_vec:
-                window = window_vec[self.local_layer_idx % len(window_vec)]
-                if window is not None:
-                    forward_args.attention_window_size = window
-        if forward_args.attention_window_size is None:
-            forward_args.attention_window_size = metadata.max_seq_len
-
-        # Promote ``out_scale_sf`` -> ``out_scale`` for the NVFP4-output path
-        # (kernel reads a single ``out_scale`` and interprets it as the SF
-        # quant scale when ``output_sf`` is allocated). ``output_sf`` is
-        # populated by ``create_output`` in ``forward`` above, so the
-        # decision is correct only here, not at the modules/attention.py
-        # call site where ``output_sf`` is always ``None``.
-        if forward_args.output_sf is not None and forward_args.out_scale_sf is not None:
-            forward_args.out_scale = forward_args.out_scale_sf
-
-        # Default ``forward_args.kv_scale_*`` to the layer-level mirrors when
-        # the caller didn't populate them. ``modules/attention.py`` only sets
-        # these for fp4 KV cache; fp8-KV models leave them ``None``. Several
-        # XQA kernels (mha.cu, mha_sm90.cu) deref ``kvCacheScale[0]`` when
-        # ``isKVCacheQuantized`` is true and don't check for nullptr, so
-        # passing ``None`` crashes with illegal memory access.
-        if forward_args.kv_scale_orig_quant is None:
-            forward_args.kv_scale_orig_quant = self.kv_scale_orig_quant
-        if forward_args.kv_scale_quant_orig is None:
-            forward_args.kv_scale_quant_orig = self.kv_scale_quant_orig
-
-        # max_context_q_len_override is only set when encoder CUDA graphs are enabled.
-        if metadata.max_context_q_len_override is not None:
-            assert metadata.is_cuda_graph
-            assert metadata.num_generations == 0
-            assert metadata.kv_cache_manager is None
-            assert metadata.num_contexts == metadata.num_seqs
-
-        use_trtllm_gen = False
-        if _TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION:
-            trtllm_gen_backend = self._get_trtllm_gen_backend()
-            use_trtllm_gen = trtllm_gen_backend.is_supported(
-                q,
-                k,
-                v,
-                attn=self,
-                meta=metadata,
-                fwd=forward_args,
-            )[0]
-
-        if use_trtllm_gen:
-            trtllm_gen_backend.forward(
-                q,
-                k,
-                v,
-                attn=self,
-                meta=metadata,
-                fwd=forward_args,
-            )
-        else:
-            sparse_params = self.sparse_params
-            skip_softmax_kernel_params = (
-                sparse_params.scheduler.get_kernel_params(
-                    timestep=forward_args.timestep) if isinstance(
-                        sparse_params,
-                        SkipSoftmaxParams) else SkipSoftmaxKernelParams())
-
-            # Every kwarg sources from ``self`` / ``metadata`` /
-            # ``forward_args`` (with ``forward_args.sparse_prediction`` for
-            # sparse-attn inputs), ``skip_softmax_kernel_params``, or a literal
-            # allowlisted in ``_THOP_LITERALS``. ``test_attention_op_sync.py``
-            # enforces this statically.
-            thop.attention(
-                q=q,
-                k=k,
-                v=v,
-                output=forward_args.output,
-                output_sf=forward_args.output_sf,
-                workspace_=metadata.effective_workspace,
-
-                # --- Per-step batch state (TrtllmAttentionMetadata) ---
-                sequence_length=metadata.kv_lens_cuda_runtime,
-                host_past_key_value_lengths=metadata.kv_lens_runtime,
-                host_total_kv_lens=metadata.host_total_kv_lens,
-                context_lengths=metadata.prompt_lens_cuda_runtime,
-                host_context_lengths=metadata.prompt_lens_cpu_runtime,
-                host_request_types=metadata.host_request_types_runtime,
-                max_context_q_len_override=metadata.max_context_q_len_override,
-                kv_cache_block_offsets=metadata.kv_cache_block_offsets,
-                host_kv_cache_pool_pointers=metadata.
-                host_kv_cache_pool_pointers,
-                host_kv_cache_pool_mapping=metadata.host_kv_cache_pool_mapping,
-                cache_indirection=metadata.cache_indirection,
-                block_ids_per_seq=metadata.block_ids_per_seq,
-                tokens_per_block=metadata.tokens_per_block,
-                max_num_requests=metadata.max_num_requests,
-                beam_width=metadata.effective_beam_width,
-                use_paged_context_fmha=metadata.use_paged_context_fmha,
-                helix_position_offsets=metadata.helix_position_offsets,
-                helix_is_inactive_rank=metadata.helix_is_inactive_rank,
-                is_spec_decoding_enabled=metadata.is_spec_decoding_enabled,
-                use_spec_decoding=metadata.use_spec_decoding,
-                is_spec_dec_tree=metadata.is_spec_dec_tree,
-                spec_decoding_generation_lengths=metadata.
-                spec_decoding_generation_lengths,
-                spec_decoding_position_offsets_for_cpp=metadata.
-                spec_decoding_position_offsets_for_cpp,
-                spec_decoding_packed_mask=metadata.spec_decoding_packed_mask,
-                spec_decoding_bl_tree_mask_offset=metadata.
-                spec_decoding_bl_tree_mask_offset,
-                spec_decoding_bl_tree_mask=metadata.spec_decoding_bl_tree_mask,
-                spec_decoding_target_max_draft_tokens=metadata.
-                max_total_draft_tokens,
-                spec_bl_tree_first_sparse_mask_offset_kv=metadata.
-                spec_bl_tree_first_sparse_mask_offset_kv,
-                num_sparse_topk=metadata.num_sparse_topk,
-                flash_mla_tile_scheduler_metadata=metadata.
-                flash_mla_tile_scheduler_metadata,
-                flash_mla_num_splits=metadata.flash_mla_num_splits,
-                num_contexts=metadata.num_contexts,
-                num_ctx_tokens=metadata.num_ctx_tokens,
-                max_context_length=metadata.max_context_length,
-                max_seq_len=metadata.max_seq_len,
-                trtllm_gen_jit_warmup=metadata.trtllm_gen_jit_warmup,
-                is_cross=metadata.is_cross,
-
-                # --- Per-call (AttentionForwardArgs) ---
-                out_scale=forward_args.out_scale,
-                kv_scale_orig_quant=forward_args.kv_scale_orig_quant,
-                kv_scale_quant_orig=forward_args.kv_scale_quant_orig,
-                latent_cache=forward_args.latent_cache,
-                q_pe=forward_args.q_pe,
-                attention_sinks=forward_args.attention_sinks,
-                mask_type=forward_args.mask_type,
-                attention_input_type=int(forward_args.attention_input_type),
-                attention_window_size=forward_args.attention_window_size,
-                chunked_prefill_buffer_batch_size=forward_args.
-                chunked_prefill_buffer_batch_size,
-                mrope_rotary_cos_sin=forward_args.mrope_rotary_cos_sin,
-                mrope_position_deltas=forward_args.mrope_position_deltas,
-                softmax_stats_tensor=forward_args.softmax_stats_tensor,
-                cu_q_seqlens=forward_args.cu_q_seqlens,
-                cu_kv_seqlens=forward_args.cu_kv_seqlens,
-                fmha_scheduler_counter=forward_args.fmha_scheduler_counter,
-                mla_bmm1_scale=forward_args.mla_bmm1_scale,
-                mla_bmm2_scale=forward_args.mla_bmm2_scale,
-                quant_q_buffer=forward_args.quant_q_buffer,
-                sage_attn_num_elts_per_blk_q=forward_args.
-                sage_attn_num_elts_per_blk_q,
-                sage_attn_num_elts_per_blk_k=forward_args.
-                sage_attn_num_elts_per_blk_k,
-                sage_attn_num_elts_per_blk_v=forward_args.
-                sage_attn_num_elts_per_blk_v,
-                sage_attn_qk_int8=forward_args.sage_attn_qk_int8,
-                is_fused_qkv=forward_args.is_fused_qkv,
-                update_kv_cache=forward_args.update_kv_cache,
-                cross_kv=forward_args.cross_kv,
-                relative_attention_bias=forward_args.relative_attention_bias,
-                relative_attention_max_distance=forward_args.
-                relative_attention_max_distance,
-                position_embedding_type=self.position_embedding_type,
-                # --- Module config (TrtllmAttention) ---
-                rotary_inv_freq=self.rotary_inv_freq,
-                rotary_cos_sin=self.rotary_cos_sin,
-                predicted_tokens_per_seq=self.predicted_tokens_per_seq,
-                local_layer_idx=self.local_layer_idx,
-                num_heads=self.num_heads,
-                num_kv_heads=self.num_kv_heads,
-                head_size=self.head_dim,
-                quant_mode=self.quant_mode,
-                q_scaling=self.q_scaling,
-                rope_dim=self.rope_dim,
-                rope_base=self.rope_base,
-                rope_scale_type=self.rope_scale_type,
-                rope_scale=self.rope_scale,
-                rope_short_m_scale=self.rope_short_m_scale,
-                rope_long_m_scale=self.rope_long_m_scale,
-                rope_max_positions=self.rope_max_positions,
-                rope_original_max_positions=self.rope_original_max_positions,
-                is_mla_enable=self.is_mla_enable,
-                q_lora_rank=self.q_lora_rank,
-                kv_lora_rank=self.kv_lora_rank,
-                qk_nope_head_dim=self.qk_nope_head_dim,
-                qk_rope_head_dim=self.qk_rope_head_dim,
-                v_head_dim=self.v_head_dim,
-                rope_append=self.rope_append,
-                attention_chunk_size=self.attention_chunk_size,
-                skip_softmax_threshold_scale_factor_prefill=
-                skip_softmax_kernel_params.threshold_scale_factor_prefill,
-                skip_softmax_threshold_scale_factor_decode=
-                skip_softmax_kernel_params.threshold_scale_factor_decode,
-                skip_softmax_stat=self.skip_softmax_stat,
-
-                # --- Sparse-specific (AttentionForwardArgs.sparse_prediction) ---
-                sparse_kv_indices=forward_args.sparse_prediction.
-                sparse_kv_indices,
-                sparse_kv_offsets=forward_args.sparse_prediction.
-                sparse_kv_offsets,
-                sparse_attn_indices=forward_args.sparse_prediction.
-                sparse_attn_indices,
-                sparse_attn_offsets=forward_args.sparse_prediction.
-                sparse_attn_offsets,
-                sparse_attn_indices_block_size=forward_args.sparse_prediction.
-                sparse_attn_indices_block_size,
-                sparse_mla_topk_lens=forward_args.sparse_prediction.
-                sparse_mla_topk_lens,
-                compressed_kv_cache_pool_ptr=forward_args.sparse_prediction.
-                compressed_kv_cache_pool_ptr,
-
-                # --- Literals intentionally in _THOP_LITERALS ---
-            )
-
-        if self.print_skip_softmax_stat:
-            total_blocks, skipped_blocks = self.skip_softmax_stat
-            if total_blocks != 0:
-                print(
-                    f"SKIP_SOFTMAX_STAT: layer{self.layer_idx}: {skipped_blocks} / {total_blocks}"
-                    f" = {skipped_blocks / total_blocks * 100: .2f}%")
 
     def forward(
         self,
@@ -1832,7 +1509,140 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                 and metadata._seq_lens_cuda is not None):
             metadata.update_blackwell_first_sparse_mask_offset()
 
-        self._run(q, k, v, metadata, forward_args)
+        if metadata.is_cross:
+            if k is not None and v is not None:
+                k_flat = k.contiguous().view(k.shape[0], -1)
+                v_flat = v.contiguous().view(v.shape[0], -1)
+                forward_args.cross_kv = torch.cat([k_flat, v_flat],
+                                                  dim=1).contiguous()
+
+            q_hidden_size = self.num_heads * self.head_dim
+            kv_hidden_size = self.num_kv_heads * self.head_dim
+            qkv_hidden_size = q_hidden_size + 2 * kv_hidden_size
+            if q.shape[1] == q_hidden_size:
+                fused_q = q.new_zeros((q.shape[0], qkv_hidden_size))
+                fused_q[:, :q_hidden_size].copy_(q)
+                q = fused_q
+            else:
+                assert q.shape[1] == qkv_hidden_size
+            k = None
+            v = None
+            forward_args.is_fused_qkv = True
+
+        attention_input_type = forward_args.attention_input_type
+        if not self.is_mla_enable:
+            if forward_args.is_fused_qkv:
+                qkv_hidden_size = (self.num_heads +
+                                   2 * self.num_kv_heads) * self.head_dim
+                assert q.shape[1] == qkv_hidden_size
+            else:
+                q_hidden_size = self.num_heads * self.head_dim
+                assert q.shape[1] == q_hidden_size
+                if forward_args.update_kv_cache:
+                    kv_hidden_size = self.num_kv_heads * self.head_dim
+                    assert k.shape[1] == kv_hidden_size
+                    assert v.shape[1] == kv_hidden_size
+            num_tokens = q.shape[0]
+            if k is not None and not metadata.is_cross:
+                assert k.shape[0] == num_tokens
+                assert v.shape[0] == num_tokens
+        else:
+            is_sparse_attn = forward_args.sparse_prediction.sparse_attn_indices is not None and forward_args.sparse_prediction.sparse_attn_indices.numel(
+            ) > 0
+            if attention_input_type == AttentionInputType.context_only and is_sparse_attn:
+                assert forward_args.is_fused_qkv
+                qkv_hidden_size = self.num_heads * (self.kv_lora_rank +
+                                                    self.qk_rope_head_dim)
+            elif attention_input_type == AttentionInputType.context_only:
+                assert not forward_args.is_fused_qkv
+                qkv_hidden_size = self.num_heads * (self.qk_nope_head_dim +
+                                                    self.qk_rope_head_dim)
+            elif attention_input_type == AttentionInputType.generation_only:
+                assert forward_args.is_fused_qkv
+                qkv_hidden_size = self.num_heads * (self.kv_lora_rank +
+                                                    self.qk_rope_head_dim)
+            else:
+                raise ValueError(
+                    "In MLA, TrtllmAttention can only support context_only or generation_only, not mixed."
+                )
+            assert q.shape[
+                1] == qkv_hidden_size, f"q.shape[1] must be equal to qkv_hidden_size, got {q.shape[1]=}, {qkv_hidden_size=}"
+
+        batch_size = metadata.kv_lens_cuda_runtime.shape[0]
+        assert metadata.kv_lens_runtime.shape[0] == batch_size
+        assert metadata.prompt_lens_cuda_runtime.shape[0] == batch_size
+        assert metadata.prompt_lens_cpu_runtime.shape[0] == batch_size
+        assert metadata.host_request_types_runtime.shape[0] == batch_size
+
+        self._ensure_rope_table_size(metadata.max_seq_len)
+
+        # Prime ``self.local_layer_idx`` so FMHA implementations read a
+        # populated int rather than the ``None`` placeholder.
+        # The call is a fast cache hit after the first forward.
+        self.local_layer_idx = self.get_local_layer_idx(metadata)
+        if metadata.spec_decoding_bl_tree_mask is not None and self.local_layer_idx == 0:
+            metadata.spec_decoding_bl_tree_mask.zero_()
+
+        if self.print_skip_softmax_stat:
+            self.skip_softmax_stat.zero_()
+
+        # Propagate the KV cache manager's SWA window to the FMHA kernel when
+        # the model does not specify one, so paged-context attention does not
+        # read stale page-table entries (BAD_PAGE_INDEX).
+        if forward_args.attention_window_size is None and metadata.kv_cache_manager is not None:
+            window_vec = getattr(metadata.kv_cache_manager,
+                                 'max_attention_window_vec', None)
+            if window_vec:
+                window = window_vec[self.local_layer_idx % len(window_vec)]
+                if window is not None:
+                    forward_args.attention_window_size = window
+        if forward_args.attention_window_size is None:
+            forward_args.attention_window_size = metadata.max_seq_len
+
+        # Promote ``out_scale_sf`` -> ``out_scale`` for the NVFP4-output path
+        # (kernel reads a single ``out_scale`` and interprets it as the SF
+        # quant scale when ``output_sf`` is allocated). ``output_sf`` is
+        # populated by ``create_output`` in ``forward`` above, so the
+        # decision is correct only here, not at the modules/attention.py
+        # call site where ``output_sf`` is always ``None``.
+        if forward_args.output_sf is not None and forward_args.out_scale_sf is not None:
+            forward_args.out_scale = forward_args.out_scale_sf
+
+        # Default ``forward_args.kv_scale_*`` to the layer-level mirrors when
+        # the caller didn't populate them. ``modules/attention.py`` only sets
+        # these for fp4 KV cache; fp8-KV models leave them ``None``. Several
+        # XQA kernels (mha.cu, mha_sm90.cu) deref ``kvCacheScale[0]`` when
+        # ``isKVCacheQuantized`` is true and don't check for nullptr, so
+        # passing ``None`` crashes with illegal memory access.
+        if forward_args.kv_scale_orig_quant is None:
+            forward_args.kv_scale_orig_quant = self.kv_scale_orig_quant
+        if forward_args.kv_scale_quant_orig is None:
+            forward_args.kv_scale_quant_orig = self.kv_scale_quant_orig
+
+        # max_context_q_len_override is only set when encoder CUDA graphs are enabled.
+        if metadata.max_context_q_len_override is not None:
+            assert metadata.is_cuda_graph
+            assert metadata.num_generations == 0
+            assert metadata.kv_cache_manager is None
+            assert metadata.num_contexts == metadata.num_seqs
+
+        if not self.fmha_libs:
+            self.create_fmha_libs()
+
+        for fmha in self.fmha_libs:
+            if fmha.is_supported(q, k, v, metadata, forward_args):
+                fmha.forward(q, k, v, metadata, forward_args)
+                break
+        else:
+            raise RuntimeError(
+                "No TRT-LLM attention FMHA library supports this request.")
+
+        if self.print_skip_softmax_stat:
+            total_blocks, skipped_blocks = self.skip_softmax_stat
+            if total_blocks != 0:
+                print(
+                    f"SKIP_SOFTMAX_STAT: layer{self.layer_idx}: {skipped_blocks} / {total_blocks}"
+                    f" = {skipped_blocks / total_blocks * 100: .2f}%")
 
         if forward_args.output_sf is None:
             return forward_args.output

--- a/tensorrt_llm/_torch/modules/ATTENTION_DEVELOPER_GUIDE.md
+++ b/tensorrt_llm/_torch/modules/ATTENTION_DEVELOPER_GUIDE.md
@@ -243,13 +243,32 @@ The main differences across backends:
 | `VANILLA` | Python-side | Python-side slicing |
 | `FLASHINFER` | Python-side (explicit append) | Page-table metadata |
 
-#### 3.2.2 `TRTLLM` internal `trtllm_gen` path
+#### 3.2.2 `TRTLLM` internal FMHA libraries
 
-`trtllm_gen.py` integrates trtllm-gen kernels from FlashInfer into the
-`TRTLLM` backend. It is not a separate backend. It is an internal fast path
-disabled by default (`TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION`). It bridges the
-TRTLLM block-offset format into the page-table shape expected by those kernels.
-If it does not apply, `TrtllmAttention` stays on its regular runtime path.
+`TrtllmAttention` dispatches attention through an ordered list of internal FMHA
+libraries. `FlashInferTrtllmGenFmha` integrates trtllm-gen kernels from
+FlashInfer into the `TRTLLM` backend, and `FallbackFmha` calls the regular
+`thop.attention` runtime path. These are not separate attention backends.
+
+`TLLM_FMHA_LIBS` controls the ordered list. Unset means
+`flashinfer_trtllm_gen,fallback`; use `TLLM_FMHA_LIBS=fallback` or
+`TLLM_FMHA_LIBS=-flashinfer_trtllm_gen` to force the fallback path. Each FMHA
+library exposes `is_available()` for module/static environment checks and
+`is_supported()` for per-forward request checks.
+
+The FMHA package is split by role:
+
+- `fmha/interface.py` defines the `Fmha` runtime contract.
+- `fmha/phased.py` defines `PhasedFmha`, which handles mixed context/generation
+  requests and dispatches them to phase-specific hooks.
+- `fmha/flashinfer_trtllm_gen.py` implements the FlashInfer trtllm-gen FMHA
+  library.
+- `fmha/fallback.py` implements the regular `thop.attention` fallback library.
+- `fmha/registry.py` owns `TLLM_FMHA_LIBS` parsing and library ordering.
+
+Use `PhasedFmha` for libraries that need separate context/generation or MHA/MLA
+entry points. Use `Fmha` directly for libraries that already own the full
+request shape.
 
 #### 3.2.3 MLA cached-context semantics
 
@@ -338,7 +357,7 @@ Working rules:
 | `tensorrt_llm/_torch/attention_backend/interface.py` | Backend contract, base metadata, capability hooks |
 | `tensorrt_llm/_torch/attention_backend/utils.py` | Backend and sparse-backend selection |
 | `tensorrt_llm/_torch/attention_backend/trtllm.py` | TRTLLM backend and metadata |
-| `tensorrt_llm/_torch/attention_backend/trtllm_gen.py` | Internal dense fast path |
+| `tensorrt_llm/_torch/attention_backend/fmha/` | Internal TRTLLM FMHA libraries |
 | `tensorrt_llm/_torch/attention_backend/vanilla.py` | Torch fallback backend and metadata |
 | `tensorrt_llm/_torch/attention_backend/flashinfer.py` | FlashInfer backend and metadata |
 | `tensorrt_llm/_torch/attention_backend/sparse/` | DSA, Rocket sparse backends, metadata, cache managers |

--- a/tests/unittest/_torch/attention_backend/test_attention_op_sync.py
+++ b/tests/unittest/_torch/attention_backend/test_attention_op_sync.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Static sync test for the inline ``thop.attention(...)`` call in
-``TrtllmAttention._run``.
+"""Static sync test for the fallback ``thop.attention(...)`` call in
+``FallbackFmha.forward``.
 
 That call is the single explicit-kwarg call site for the C++ ``thop.attention``
 binding. This test parses both the call site (Python AST) and the C++
@@ -20,7 +20,7 @@ function declaration in ``attentionOp.h`` (text/regex), and enforces:
 
 1. Every C++ parameter name appears at the call site (and nothing extra).
 2. Every call-site kwarg sourced as ``root.attr[.attr...]`` resolves on
-   exactly one of ``self`` / ``metadata`` / ``forward_args``, and its
+   exactly one of ``attn`` / ``metadata`` / ``forward_args``, and its
    declared C++ type matches the source attribute's Python type at a
    coarse-category level (tensor / int / bool / float / list-of-X).
 3. Every dataclass field reachable from ``AttentionForwardArgs`` (including
@@ -42,27 +42,28 @@ import textwrap
 import typing
 from dataclasses import fields
 
-from tensorrt_llm._torch.attention_backend.interface import AttentionForwardArgs
-from tensorrt_llm._torch.attention_backend.sparse.skip_softmax import SkipSoftmaxKernelParams
-from tensorrt_llm._torch.attention_backend.trtllm import (
+from tensorrt_llm._torch.attention_backend.fmha.fallback import (
     _THOP_EXCLUDED_FIELDS,
     _THOP_LITERALS,
-    TrtllmAttention,
-    TrtllmAttentionMetadata,
+    FallbackFmha,
 )
+from tensorrt_llm._torch.attention_backend.interface import AttentionForwardArgs
+from tensorrt_llm._torch.attention_backend.sparse.skip_softmax import SkipSoftmaxKernelParams
+from tensorrt_llm._torch.attention_backend.trtllm import TrtllmAttention, TrtllmAttentionMetadata
 
 # Roots used as the LHS of attribute chains at the call site. Match the
-# parameter names inside ``TrtllmAttention._run``.
+# names inside ``FallbackFmha.forward``.
 _SOURCE_CLASSES = {
-    "self": TrtllmAttention,
+    "attn": TrtllmAttention,
     "metadata": TrtllmAttentionMetadata,
     "forward_args": AttentionForwardArgs,
     "skip_softmax_kernel_params": SkipSoftmaxKernelParams,
 }
 
 _THOP_KWARG_SOURCE_ALIASES: dict[str, tuple[str, tuple[str, ...]]] = {
+    "beam_width": ("metadata", ("effective_beam_width",)),
     "context_lengths": ("metadata", ("prompt_lens_cuda_runtime",)),
-    "head_size": ("self", ("head_dim",)),
+    "head_size": ("attn", ("head_dim",)),
     "host_context_lengths": ("metadata", ("prompt_lens_cpu_runtime",)),
     "host_past_key_value_lengths": ("metadata", ("kv_lens_runtime",)),
     "host_request_types": ("metadata", ("host_request_types_runtime",)),
@@ -199,8 +200,9 @@ def _binding_types() -> dict[str, str]:
 
 
 def _parse_thop_attention_call() -> ast.Call:
-    """Locate the single ``thop.attention(...)`` call inside ``_run``."""
-    src = textwrap.dedent(inspect.getsource(TrtllmAttention._run))
+    """Locate the single ``thop.attention(...)`` call inside
+    ``FallbackFmha.forward``."""
+    src = textwrap.dedent(inspect.getsource(FallbackFmha.forward))
     tree = ast.parse(src)
     for node in ast.walk(tree):
         if (
@@ -211,7 +213,7 @@ def _parse_thop_attention_call() -> ast.Call:
             and node.func.value.id == "thop"
         ):
             return node
-    raise AssertionError("Could not find thop.attention(...) call in TrtllmAttention._run")
+    raise AssertionError("Could not find thop.attention(...) call in FallbackFmha.forward")
 
 
 def _attribute_path(node: ast.AST) -> tuple[str, tuple[str, ...]] | None:
@@ -504,8 +506,9 @@ def _self_attrs_in_property(prop: property) -> set[str]:
 
 
 def _collect_chains(root: str) -> set[tuple[str, ...]]:
-    """All attribute paths in ``_run`` that start with ``Name(root).``."""
-    src = textwrap.dedent(inspect.getsource(TrtllmAttention._run))
+    """All attribute paths in ``FallbackFmha.forward`` that start with
+    ``Name(root).``."""
+    src = textwrap.dedent(inspect.getsource(FallbackFmha.forward))
     chains: set[tuple[str, ...]] = set()
     for node in ast.walk(ast.parse(src)):
         if not isinstance(node, ast.Attribute):
@@ -568,7 +571,7 @@ def test_every_forward_args_field_is_consumed():
 
 def test_no_unexpected_other_kwargs():
     """The only call-site kwargs that aren't ``source.attr`` chains or
-    allowlisted literals are the ``_run`` positional parameters."""
+    allowlisted literals are the ``FallbackFmha.forward`` parameters."""
     _, _, other_kwargs = _classify_kwargs()
     expected = {"q", "k", "v"}
     unexpected = other_kwargs - expected


### PR DESCRIPTION
## Description

JIRA: https://jirasw.nvidia.com/browse/TRTLLM-12807

Refactor the TRTLLM PyTorch attention FMHA implementation into explicit FMHA library classes under `tensorrt_llm/_torch/attention_backend/fmha/`.

This change:
- Adds the `Fmha` interface and `PhasedFmha` helper for context/generation and MHA/MLA dispatch.
- Moves the FlashInfer TRTLLM-Gen path into `FlashInferTrtllmGenFmha`.
- Moves the `thop.attention` path into `FallbackFmha`.
- Adds FMHA library registry support for `TLLM_FMHA_LIBS`.
- Removes the old `attention_backend/trtllm_gen.py` compatibility wrapper.
- Updates the attention developer guide for the new FMHA package layout.

## Test Coverage

- `python3 -m pytest -q tests/unittest/_torch/attention_backend/test_attention_op_sync.py`
- B200: `tests/integration/defs/accuracy/test_llm_api_pytorch.py::TestQwen3_8B::test_bf16[latency]`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
