### PR TITLE
[None][perf] Gate DeepSeek TRTLLMGen finalize fusion by backend capability

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -44,6 +44,7 @@ from tensorrt_llm._torch.models.checkpoints.base_weight_loader import \
 from tensorrt_llm._utils import get_sm_version, is_sm_100f
 from tensorrt_llm.bindings.internal.thop import BufferKind
 from tensorrt_llm.functional import PositionEmbeddingType
+from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantConfig
 from tensorrt_llm.quantization.mode import QuantAlgo
@@ -1445,6 +1446,48 @@ class DeepseekV3DecoderLayer(DecoderLayer):
                 spec_metadata=spec_metadata,
             )
 
+    def _use_trtllm_gen_finalize_fusion(self,
+                                        hidden_states: torch.Tensor) -> bool:
+        """Gate TRTLLMGen MoE output-finalize fusion for DeepSeek/Kimi MoE."""
+        reasons = []
+        moe_backend = self.model_config.moe_backend.upper()
+
+        if self.mapping.is_multi_node():
+            reasons.append("multi-node mapping")
+        if not self.fusion_config.POST_MOE_FUSION:
+            reasons.append("post-MoE fusion disabled")
+        if self.moe_allreduce is None:
+            reasons.append("MoE allreduce unavailable")
+        elif hidden_states.shape[0] > self.moe_allreduce.max_token:
+            reasons.append(
+                f"token count {hidden_states.shape[0]} exceeds "
+                f"MoE allreduce limit {self.moe_allreduce.max_token}")
+        if moe_backend != "TRTLLM":
+            reasons.append(f"moe_backend={self.model_config.moe_backend}")
+
+        experts = getattr(self.mlp, "experts", None)
+        supports_finalize_fusion = getattr(experts,
+                                           "supports_finalize_fusion", False)
+        if callable(supports_finalize_fusion):
+            supports_finalize_fusion = supports_finalize_fusion()
+        if not bool(supports_finalize_fusion):
+            reasons.append("MoE backend cannot return unfinalized output")
+        if not self.is_p2p_supported:
+            reasons.append("peer access unavailable")
+
+        if not reasons:
+            return True
+
+        if moe_backend == "TRTLLM":
+            log_once = (logger.info_once if self.model_config.enable_min_latency
+                        else logger.debug_once)
+            log_once(
+                "DeepSeek/Kimi TRTLLMGen MoE finalize fusion disabled "
+                f"on layer {self.layer_idx}: {', '.join(reasons)}.",
+                key="deepseek_trtllm_gen_finalize_fusion_disabled",
+            )
+        return False
+
     def forward_MoE(
         self,
         hidden_states: torch.Tensor,
@@ -1481,12 +1524,9 @@ class DeepseekV3DecoderLayer(DecoderLayer):
             hidden_states, residual = self.post_attention_layernorm(
                 hidden_states, residual)
 
-        # Note: this fusion pattern is only supported for single-node TRTLLM-nvfp4 backend now
-        do_finalize = self.mapping.is_multi_node() or (
-            not (self.fusion_config.POST_MOE_FUSION
-                 and hidden_states.shape[0] <= self.moe_allreduce.max_token
-                 and self.model_config.moe_backend == "TRTLLM"
-                 and self.mlp.experts.has_nvfp4 and self.is_p2p_supported))
+        use_trtllm_gen_finalize_fusion = self._use_trtllm_gen_finalize_fusion(
+            hidden_states)
+        do_finalize = not use_trtllm_gen_finalize_fusion
 
         hidden_states = _run_MoE(hidden_states,
                                  hidden_states_fp4=None,

--- a/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
@@ -718,6 +718,12 @@ class ConfigurableMoE(MoE):
         """Delegate has_nvfp4 to backend"""
         return getattr(self.backend, "has_nvfp4", False)
 
+    @property
+    def supports_finalize_fusion(self):
+        """Delegate post-MoE finalize-fusion capability to backend."""
+        supports = getattr(self.backend, "supports_finalize_fusion", False)
+        return supports() if callable(supports) else bool(supports)
+
     def forward_fake(
         self,
         x: Union[torch.Tensor, Fp4QuantizedTensor],

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
@@ -436,6 +436,19 @@ class TRTLLMGenFusedMoE(MoE):
             return True
         return self.use_dp and self.parallel_size > 1
 
+    @property
+    def supports_finalize_fusion(self) -> bool:
+        """Return whether ``run_moe(..., do_finalize=False)`` is supported.
+
+        DeepSeek/Kimi can fuse the post-MoE finalize with the following TP
+        allreduce only when the backend returns the unfinalized FC2 payload plus
+        routing metadata. FP8 block-scale and W4A8_MXFP4_FP8 paths finalize
+        inside their kernels today, so keep them on the normal path.
+        """
+        return (self.has_nvfp4 or self.has_w4a16_mxfp4
+                or self.has_w4a8_nvfp4_fp8
+                or self.has_w4a8_mxfp4_mxfp8)
+
     @cached_property
     def enable_alltoall(self):
         """ enable_alltoall (bool): whether to enable alltoall instead of allgather/reducescatter


### PR DESCRIPTION
## Summary
- Adds a TRTLLMGen MoE capability flag for returning unfinalized MoE outputs.
- Uses that capability in the DeepSeek/Kimi decoder gate instead of hard-coding `has_nvfp4`.
- Logs one-shot reasons when TRTLLMGen post-MoE finalize fusion is disabled.

## Why
`TRTLLMGenFusedMoE.run_moe(..., do_finalize=False)` is implemented for multiple quantization layouts beyond NVFP4, including W4A16 MXFP4, W4A8 NVFP4/FP8, and W4A8 MXFP4/MXFP8. The DeepSeek/Kimi decoder gate only checked `has_nvfp4`, which silently kept those supported TRTLLMGen paths on the slower finalized-output path.

The unsupported layouts, such as FP8 block scales and W4A8 MXFP4/FP8, remain excluded because they finalize inside the backend today.

## Validation
- `python3 -m py_compile tensorrt_llm/_torch/models/modeling_deepseekv3.py tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py`
- `git diff --check HEAD~1..HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized Mixture of Experts (MoE) fusion handling for DeepSeekV3 model to improve inference efficiency with enhanced backend capability detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->