### PR TITLE
[TRTLLM-1234][feat] initial profiling of worker wall-clock latency on grid of isl/batch size conditions (api-compatible)

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -743,6 +743,8 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
         self.py_decoding_iter = 0
         self.is_attention_dp_dummy = False
         self.is_cuda_graph_dummy = False
+        self.is_self_benchmark_request = False
+        self.py_self_benchmark_point_id = None
         self.py_kv_transfer_start_time = None
         self.py_kv_transfer_timed_out = False
 
@@ -960,7 +962,8 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
                 setattr(py_request, attr_name, deepcopy(attr_value))
             elif attr_name in [
                     'is_attention_dp_dummy', 'is_cuda_graph_dummy',
-                    'encoder_tokens', 'encoder_output_len'
+                    'encoder_tokens', 'encoder_output_len',
+                    'is_self_benchmark_request'
             ]:
                 setattr(py_request, attr_name, attr_value)
 
@@ -1191,6 +1194,10 @@ def executor_request_to_llm_request(
     llm_request.py_disaggregated_params = getattr(executor_request,
                                                   "py_disaggregated_params",
                                                   None)
+    llm_request.is_self_benchmark_request = getattr(
+        executor_request, "py_is_self_benchmark_request", False)
+    llm_request.py_self_benchmark_point_id = getattr(
+        executor_request, "py_self_benchmark_point_id", None)
     if child_req_ids:
         for child_id in child_req_ids:
             llm_request.create_child_request(child_id)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -3770,15 +3770,19 @@ class PyExecutor:
                             timeout))
 
             if benchmark_active:
+                # During self-benchmarking, defer real user requests
+                # (accumulate them) and forward only control/special items.
+                # Synthetic benchmark PREFILL requests are NOT injected here:
+                # they are built per-rank in _fetch_and_activate_new_requests so
+                # every TP rank deterministically produces the same forward
+                # batch. Injecting them into rank 0's broadcast queue would
+                # double-inject on non-rank-0 ranks (once via broadcast, once
+                # locally) and desync the per-rank state machine.
                 for req_item in queued_requests:
                     if req_item.is_normal_request:
                         self.request_accumulated.append(req_item)
                     else:
                         new_requests.append(req_item)
-                if len(new_requests) == 0:
-                    new_requests.extend(
-                        self.self_benchmark.make_prefill_queue_items(
-                            self.active_requests, waiting_queue))
             else:
                 new_requests.extend(queued_requests)
 
@@ -3972,8 +3976,19 @@ class PyExecutor:
 
         self.active_requests.extend(validated_requests)
         if self.self_benchmark is not None and self.self_benchmark.active:
-            benchmark_requests = self.self_benchmark.make_decode_requests(
+            # Self-benchmark injection runs identically on EVERY TP rank here
+            # (this method is invoked per-rank by the main loops). Both prefill
+            # and decode requests are constructed locally and deterministically
+            # from the grid point index, so each rank advances the same state
+            # machine and produces the same forward batch in lockstep -- no
+            # per-iteration broadcast/collective is needed. Prefill is attempted
+            # first; make_prefill_requests returns [] when the next point is a
+            # decode point (and vice versa), so at most one path injects.
+            benchmark_requests = self.self_benchmark.make_prefill_requests(
                 self.active_requests, self.waiting_queue)
+            benchmark_requests.extend(
+                self.self_benchmark.make_decode_requests(
+                    self.active_requests, self.waiting_queue))
             self.active_requests.extend(benchmark_requests)
             validated_requests.extend(benchmark_requests)
         return validated_requests

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1,6 +1,7 @@
 import dataclasses
 import datetime
 import functools
+import json
 import os
 import threading
 import time
@@ -84,6 +85,7 @@ from .scheduler import (RequestScheduler, ScheduledRequests,
                         SerializableSchedulerOutput, WaitingQueue,
                         create_waiting_queue)
 from .scheduler.adp_router import ADPRouter
+from .self_benchmark import SelfBenchmark
 
 if TYPE_CHECKING:
     from ray.actor import ActorHandle
@@ -623,6 +625,8 @@ class PyExecutor:
         # Waiting queue for requests that have been fetched but not yet scheduled
         self.waiting_queue: WaitingQueue = create_waiting_queue(
             waiting_queue_policy)
+        self.self_benchmark = SelfBenchmark(
+            self) if self.llm_args.self_benchmark_config is not None else None
 
         self.control_request_barrier = threading.Event()
         self.control_action_done = threading.Event()
@@ -1336,7 +1340,8 @@ class PyExecutor:
 
     @staticmethod
     def _is_stats_dummy_request(req) -> bool:
-        return bool(getattr(req, "is_dummy", False))
+        return bool(getattr(req, "is_dummy", False)) and not bool(
+            getattr(req, "is_self_benchmark_request", False))
 
     def _collect_scheduled_batch_stats(
             self, scheduled_batch: ScheduledRequests) -> ScheduledBatchStats:
@@ -1904,6 +1909,19 @@ class PyExecutor:
                                         batch_state.scheduled_requests,
                                         micro_batch_id,
                                         batch_state.scheduled_batch_stats)
+        if self.self_benchmark is not None and self.self_benchmark.active:
+            stats_dict = json.loads(stats.to_json_str())
+            if host_step_time_ms is not None:
+                stats_dict["hostStepTimeMS"] = host_step_time_ms
+            if prev_device_step_time_ms is not None:
+                stats_dict["prevDeviceStepTimeMS"] = prev_device_step_time_ms
+            is_overlap_like = (not self.disable_overlap_scheduler
+                               or self.dist.pp_size > 1)
+            stats_dict["schedulerMode"] = (
+                "overlap" if is_overlap_like else "non_overlap")
+            if self.self_benchmark.observe_iteration(
+                    batch_state.scheduled_requests, stats_dict):
+                return
         if self.enable_attention_dp:
             self._adp_iter_stats.queue(
                 stats,
@@ -3725,18 +3743,24 @@ class PyExecutor:
         else:
             timeout = datetime.timedelta(0)
 
-        # Fetch requests from rank 0
         new_requests = []
-        if self.dist.rank == 0:
-            # Process accumulated requests that were queued during control request handling.
-            if len(self.request_accumulated) != 0:
-                new_requests.extend(self.request_accumulated)
-                self.request_accumulated.clear()
-                # Reset timeout to 0 to avoid hanging when no new requests are available
-                timeout = datetime.timedelta(0)
-            with self.hang_detector.pause():
+        if self.self_benchmark is not None and self.self_benchmark.active:
+            if self.dist.rank == 0:
                 new_requests.extend(
-                    self.executor_request_queue.get_from_request_queue(timeout))
+                    self.self_benchmark.make_prefill_queue_items(
+                        self.active_requests, waiting_queue))
+        else:
+            # Fetch requests from rank 0
+            if self.dist.rank == 0:
+                # Process accumulated requests that were queued during control request handling.
+                if len(self.request_accumulated) != 0:
+                    new_requests.extend(self.request_accumulated)
+                    self.request_accumulated.clear()
+                    # Reset timeout to 0 to avoid hanging when no new requests are available
+                    timeout = datetime.timedelta(0)
+                with self.hang_detector.pause():
+                    new_requests.extend(
+                        self.executor_request_queue.get_from_request_queue(timeout))
 
         # Broadcast requests and handle Python objects
         new_requests, py_request_objects = self.request_broadcaster.broadcast(
@@ -3927,6 +3951,11 @@ class PyExecutor:
         ]
 
         self.active_requests.extend(validated_requests)
+        if self.self_benchmark is not None and self.self_benchmark.active:
+            benchmark_requests = self.self_benchmark.make_decode_requests(
+                self.active_requests, self.waiting_queue)
+            self.active_requests.extend(benchmark_requests)
+            validated_requests.extend(benchmark_requests)
         return validated_requests
 
     def _add_kv_cache_events(self):
@@ -5295,6 +5324,13 @@ class PyExecutor:
             req_id = request.py_request_id
             # no responses for dummy request, and finish it
             if request.is_attention_dp_dummy:
+                requests_to_terminate.append(request)
+                continue
+            if getattr(request, "is_self_benchmark_request", False):
+                self.perf_manager.append_step_metrics(
+                    request,
+                    self.iter_counter,
+                    batch_token_time=batch_token_time)
                 requests_to_terminate.append(request)
                 continue
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -8,7 +8,7 @@ import time
 import traceback
 from contextlib import contextmanager
 from enum import IntEnum
-from queue import Queue
+from queue import Empty, Queue
 from typing import (TYPE_CHECKING, Callable, Dict, Iterable, List, Optional,
                     Tuple, Union)
 
@@ -3744,23 +3744,43 @@ class PyExecutor:
             timeout = datetime.timedelta(0)
 
         new_requests = []
-        if self.self_benchmark is not None and self.self_benchmark.active:
-            if self.dist.rank == 0:
-                new_requests.extend(
-                    self.self_benchmark.make_prefill_queue_items(
-                        self.active_requests, waiting_queue))
-        else:
-            # Fetch requests from rank 0
-            if self.dist.rank == 0:
-                # Process accumulated requests that were queued during control request handling.
-                if len(self.request_accumulated) != 0:
-                    new_requests.extend(self.request_accumulated)
-                    self.request_accumulated.clear()
-                    # Reset timeout to 0 to avoid hanging when no new requests are available
-                    timeout = datetime.timedelta(0)
-                with self.hang_detector.pause():
+        benchmark_active = (self.self_benchmark is not None
+                            and self.self_benchmark.active)
+        # Fetch requests from rank 0
+        if self.dist.rank == 0:
+            queued_requests = []
+            # Process accumulated requests that were queued during control request handling.
+            if len(self.request_accumulated) != 0:
+                queued_requests.extend(self.request_accumulated)
+                self.request_accumulated.clear()
+                # Reset timeout to 0 to avoid hanging when no new requests are available
+                timeout = datetime.timedelta(0)
+            with self.hang_detector.pause():
+                if benchmark_active:
+                    request_queue = (
+                        self.executor_request_queue.get_request_queue())
+                    while True:
+                        try:
+                            queued_requests.append(request_queue.get_nowait())
+                        except Empty:
+                            break
+                else:
+                    queued_requests.extend(
+                        self.executor_request_queue.get_from_request_queue(
+                            timeout))
+
+            if benchmark_active:
+                for req_item in queued_requests:
+                    if req_item.is_normal_request:
+                        self.request_accumulated.append(req_item)
+                    else:
+                        new_requests.append(req_item)
+                if len(new_requests) == 0:
                     new_requests.extend(
-                        self.executor_request_queue.get_from_request_queue(timeout))
+                        self.self_benchmark.make_prefill_queue_items(
+                            self.active_requests, waiting_queue))
+            else:
+                new_requests.extend(queued_requests)
 
         # Broadcast requests and handle Python objects
         new_requests, py_request_objects = self.request_broadcaster.broadcast(

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -929,32 +929,49 @@ def create_py_executor(
             if estimating_kv_cache else ExecutorMemoryType.EXTRA_RESOURCES):
         # run gc.collect() to free memory of the previous py_executor, avoid cudaFree overlap with cuda graph capture
         gc.collect()
-        py_executor = create_py_executor_instance(
-            dist=dist,
-            resources=resources,
-            mapping=mapping,
-            llm_args=llm_args,
-            ctx_chunk_config=ctx_chunk_config,
-            model_engine=model_engine,
-            start_worker=False,
-            sampler=sampler,
-            drafter=drafter,
-            guided_decoder=guided_decoder,
-            lora_config=lora_config,
-            garbage_collection_gen0_threshold=garbage_collection_gen0_threshold,
-            kv_connector_manager=kv_connector_manager
-            if not estimating_kv_cache else None,
-            resource_governor_queue=resource_governor_queue,
-            max_seq_len=max_seq_len,
-            max_batch_size=max_batch_size,
-            max_beam_width=max_beam_width,
-            max_num_tokens=max_num_tokens,
-            peft_cache_config=peft_cache_config,
-            scheduler_config=scheduler_config,
-            cache_transceiver_config=cache_transceiver_config,
-            virtual_memory_pools=vm_pools if not estimating_kv_cache else None,
-            execution_stream=execution_stream,
-        )
+        executor_llm_args = llm_args
+        original_model_engine_llm_args = None
+        if estimating_kv_cache and llm_args.self_benchmark_config is not None:
+            # The temporary KV-estimation executor disables iter stats, so
+            # self-benchmark points cannot observe completion there.
+            logger.debug(
+                "Disabling self_benchmark_config for temporary KV-cache "
+                "estimation executor")
+            executor_llm_args = copy.copy(llm_args)
+            executor_llm_args.self_benchmark_config = None
+            original_model_engine_llm_args = model_engine.llm_args
+            model_engine.llm_args = executor_llm_args
+
+        try:
+            py_executor = create_py_executor_instance(
+                dist=dist,
+                resources=resources,
+                mapping=mapping,
+                llm_args=executor_llm_args,
+                ctx_chunk_config=ctx_chunk_config,
+                model_engine=model_engine,
+                start_worker=False,
+                sampler=sampler,
+                drafter=drafter,
+                guided_decoder=guided_decoder,
+                lora_config=lora_config,
+                garbage_collection_gen0_threshold=garbage_collection_gen0_threshold,
+                kv_connector_manager=kv_connector_manager
+                if not estimating_kv_cache else None,
+                resource_governor_queue=resource_governor_queue,
+                max_seq_len=max_seq_len,
+                max_batch_size=max_batch_size,
+                max_beam_width=max_beam_width,
+                max_num_tokens=max_num_tokens,
+                peft_cache_config=peft_cache_config,
+                scheduler_config=scheduler_config,
+                cache_transceiver_config=cache_transceiver_config,
+                virtual_memory_pools=vm_pools if not estimating_kv_cache else None,
+                execution_stream=execution_stream,
+            )
+        finally:
+            if original_model_engine_llm_args is not None:
+                model_engine.llm_args = original_model_engine_llm_args
 
         # Originally, peft_cache_config might be mutated inside
         # create_py_executor_instance. Restore it here.

--- a/tensorrt_llm/_torch/pyexecutor/request_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/request_utils.py
@@ -528,6 +528,12 @@ class RequestBroadcaster:
             new_requests, "py_disaggregated_params"
         )
         py_lora_path = collect_py_objects_from_requests(new_requests, "py_lora_path")
+        py_is_self_benchmark_request = collect_py_objects_from_requests(
+            new_requests, "py_is_self_benchmark_request"
+        )
+        py_self_benchmark_point_id = collect_py_objects_from_requests(
+            new_requests, "py_self_benchmark_point_id"
+        )
 
         return tuple(
             filter(
@@ -539,6 +545,8 @@ class RequestBroadcaster:
                     py_num_logprobs,
                     py_disaggregated_params,
                     py_lora_path,
+                    py_is_self_benchmark_request,
+                    py_self_benchmark_point_id,
                 ],
             )
         )

--- a/tensorrt_llm/_torch/pyexecutor/self_benchmark.py
+++ b/tensorrt_llm/_torch/pyexecutor/self_benchmark.py
@@ -35,11 +35,13 @@ _BENCHMARK_REQUEST_ID_BASE = 900_000_000
 
 @dataclass
 class BenchmarkPoint:
-    point_type: Literal["warmup", "prefill", "decode"]
+    point_type: Literal["warmup", "prefill_seed", "prefill", "decode"]
     index: int
     isl: int = 0
+    kv_read_tokens: int = 0
     context_length: int = 0
     batch_size: int = 1
+    cache_salt_id: Optional[int] = None
 
 
 @dataclass
@@ -47,6 +49,8 @@ class BenchmarkPointResult:
     point: BenchmarkPoint
     stats: list[dict] = field(default_factory=list)
     skipped_reason: Optional[str] = None
+    observed_kv_read_tokens: Optional[int] = None
+    cache_hit_validated: Optional[bool] = None
 
 
 class SelfBenchmark:
@@ -80,7 +84,7 @@ class SelfBenchmark:
         if point is None:
             self._finish()
             return []
-        if point.point_type not in ("warmup", "prefill"):
+        if point.point_type not in ("warmup", "prefill_seed", "prefill"):
             return []
 
         self._start_point(point)
@@ -157,7 +161,8 @@ class SelfBenchmark:
             return False
 
         self._sanitize_queue_counters(stats)
-        if self._current.point.point_type != "warmup":
+        self._record_cache_hit_validation(requests, stats)
+        if self._should_record_current_point():
             self._current.stats.append(stats)
 
         if self._point_is_complete(stats):
@@ -178,6 +183,8 @@ class SelfBenchmark:
                     "point": asdict(result.point),
                     "iteration_stats": result.stats,
                     "skipped_reason": result.skipped_reason,
+                    "observed_kv_read_tokens": result.observed_kv_read_tokens,
+                    "cache_hit_validated": result.cache_hit_validated,
                 } for result in self._results
             ],
         }
@@ -205,11 +212,23 @@ class SelfBenchmark:
         if self.config.mode in ("prefill", "agg"):
             for isl in self._sample_values(self._max_prefill_isl(),
                                            self.config.prefill_isl_granularity):
-                grid.append(
-                    BenchmarkPoint(point_type="prefill",
-                                   index=next_index,
-                                   isl=isl))
-                next_index += 1
+                for kv_read_tokens in self._kv_read_values_for_isl(isl):
+                    cache_salt_id = self._cache_salt_id(next_index)
+                    if kv_read_tokens > 0:
+                        grid.append(
+                            BenchmarkPoint(point_type="prefill_seed",
+                                           index=next_index,
+                                           isl=kv_read_tokens,
+                                           kv_read_tokens=kv_read_tokens,
+                                           cache_salt_id=cache_salt_id))
+                        next_index += 1
+                    grid.append(
+                        BenchmarkPoint(point_type="prefill",
+                                       index=next_index,
+                                       isl=isl,
+                                       kv_read_tokens=kv_read_tokens,
+                                       cache_salt_id=cache_salt_id))
+                    next_index += 1
 
         if self.config.mode in ("decode", "agg"):
             context_values = self._sample_values(
@@ -230,6 +249,9 @@ class SelfBenchmark:
     def _make_prefill_request(self, point: BenchmarkPoint) -> Request:
         output_config = OutputConfig()
         output_config.return_perf_metrics = True
+        cache_salt_id = point.cache_salt_id
+        if cache_salt_id is None:
+            cache_salt_id = self._cache_salt_id(point.index)
         request = Request(
             input_token_ids=[1] * max(1, point.isl),
             max_tokens=1,
@@ -239,7 +261,7 @@ class SelfBenchmark:
             pad_id=0,
             output_config=output_config,
             return_all_generated_tokens=False,
-            cache_salt_id=self._request_id(point.index, 0))
+            cache_salt_id=cache_salt_id)
         request.py_is_self_benchmark_request = True
         request.py_self_benchmark_point_id = point.index
         return request
@@ -276,7 +298,7 @@ class SelfBenchmark:
     def _finish_current_point(self) -> None:
         if self._current is None:
             return
-        if self._current.point.point_type != "warmup":
+        if self._should_record_current_point():
             self._results.append(self._current)
         self._current = None
 
@@ -286,7 +308,7 @@ class SelfBenchmark:
         logger.warning("Skipping self-benchmark point %s: %s",
                        self._current.point, reason)
         self._current.skipped_reason = reason
-        if self._current.point.point_type != "warmup":
+        if self._should_record_current_point():
             self._results.append(self._current)
         self._current = None
 
@@ -301,11 +323,52 @@ class SelfBenchmark:
     def _point_is_complete(self, stats: dict) -> bool:
         if self._current is None:
             return False
-        if self._current.point.point_type in ("warmup", "prefill"):
+        if self._current.point.point_type in ("warmup", "prefill_seed",
+                                              "prefill"):
             return self._num_context_requests(stats) > 0
         if self._current.point.point_type == "decode":
             return self._num_decode_requests(stats) > 0
         return False
+
+    def _record_cache_hit_validation(self, requests: list["LlmRequest"],
+                                     stats: dict) -> None:
+        if self._current is None:
+            return
+        point = self._current.point
+        if point.point_type != "prefill" or point.kv_read_tokens <= 0:
+            return
+        observed = self._observed_cached_tokens(requests, point)
+        self._current.observed_kv_read_tokens = observed
+        validated = observed is not None and observed >= point.kv_read_tokens
+        self._current.cache_hit_validated = validated
+        stats["selfBenchmark"] = {
+            "expectedKvReadTokens": point.kv_read_tokens,
+            "observedCachedTokens": observed,
+            "cacheHitValidated": validated,
+        }
+        if not validated:
+            self._current.skipped_reason = (
+                "expected cached_tokens >= "
+                f"{point.kv_read_tokens}, observed {observed}")
+            logger.warning("Self-benchmark cache-hit validation failed for "
+                           "point %s: observed cached_tokens=%s",
+                           point, observed)
+
+    @staticmethod
+    def _observed_cached_tokens(requests: list["LlmRequest"],
+                                point: BenchmarkPoint) -> Optional[int]:
+        observed = [
+            int(getattr(req, "cached_tokens"))
+            for req in requests
+            if (getattr(req, "py_self_benchmark_point_id", None) == point.index
+                and hasattr(req, "cached_tokens"))
+        ]
+        return max(observed) if observed else None
+
+    def _should_record_current_point(self) -> bool:
+        return (self._current is not None
+                and self._current.point.point_type
+                not in ("warmup", "prefill_seed"))
 
     @staticmethod
     def _sanitize_queue_counters(stats: dict) -> None:
@@ -337,6 +400,31 @@ class SelfBenchmark:
         }
         return sorted(max(1, min(max_value, int(value))) for value in values)
 
+    def _kv_read_values_for_isl(self, isl: int) -> list[int]:
+        block_size = self._tokens_per_block()
+        if block_size <= 0 or not self._enable_block_reuse():
+            return [0]
+        max_read_tokens = ((max(0, isl - 1)) // block_size) * block_size
+        if max_read_tokens == 0:
+            return [0]
+        return self._sample_block_aligned_values(
+            max_read_tokens, self.config.prefill_kv_read_granularity,
+            block_size)
+
+    @staticmethod
+    def _sample_block_aligned_values(max_value: int, granularity: int,
+                                     block_size: int) -> list[int]:
+        block_values = list(range(0, max_value + 1, block_size))
+        if granularity <= 1:
+            return [0]
+        if len(block_values) <= granularity:
+            return block_values
+        sampled_indices = {
+            round(i * (len(block_values) - 1) / (granularity - 1))
+            for i in range(granularity)
+        }
+        return [block_values[i] for i in sorted(sampled_indices)]
+
     def _max_prefill_isl(self) -> int:
         return self._bounded_length(default=1)
 
@@ -364,6 +452,19 @@ class SelfBenchmark:
                 candidates.append(value)
         return min(candidates) if candidates else 1
 
+    def _tokens_per_block(self) -> int:
+        kv_cache_manager = self._executor.resource_manager.get_resource_manager(
+            ResourceManagerType.KV_CACHE_MANAGER)
+        if kv_cache_manager is None:
+            return 0
+        kv_stats = kv_cache_manager.get_kv_cache_stats()
+        return int(getattr(kv_stats, "tokens_per_block", 0) or 0)
+
+    def _enable_block_reuse(self) -> bool:
+        kv_cache_manager = self._executor.resource_manager.get_resource_manager(
+            ResourceManagerType.KV_CACHE_MANAGER)
+        return bool(getattr(kv_cache_manager, "enable_block_reuse", False))
+
     def _limits(self) -> dict:
         kv_cache_manager = self._executor.resource_manager.get_resource_manager(
             ResourceManagerType.KV_CACHE_MANAGER)
@@ -388,6 +489,10 @@ class SelfBenchmark:
     @staticmethod
     def _request_id(point_index: int, offset: int) -> int:
         return _BENCHMARK_REQUEST_ID_BASE + point_index * 1024 + offset
+
+    @staticmethod
+    def _cache_salt_id(point_index: int) -> int:
+        return _BENCHMARK_REQUEST_ID_BASE + 500_000 + point_index
 
     @staticmethod
     def _is_benchmark_request(request: "LlmRequest") -> bool:

--- a/tensorrt_llm/_torch/pyexecutor/self_benchmark.py
+++ b/tensorrt_llm/_torch/pyexecutor/self_benchmark.py
@@ -15,14 +15,16 @@
 
 import json
 import os
+import tempfile
 import time
+import uuid
 from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Literal, Optional
 
 from tensorrt_llm.bindings.executor import OutputConfig, Request, SamplingConfig
 from tensorrt_llm.logger import logger
 
-from .executor_request_queue import RequestQueueItem
+from .llm_request import executor_request_to_llm_request
 from .resource_manager import ResourceManagerType
 from .scheduler import ScheduledRequests, WaitingQueue
 
@@ -61,23 +63,49 @@ class SelfBenchmark:
         self.config = executor.llm_args.self_benchmark_config
         self._grid = self._build_grid()
         self._grid_index = 0
+        # Per-point request-id stride must exceed the largest decode batch so
+        # point N's request ids never overflow into point N+1's id range.
+        self._id_stride = max(1024, self._max_decode_batch_size() + 1)
         self._current: Optional[BenchmarkPointResult] = None
         self._results: list[BenchmarkPointResult] = []
         self._done = self.config is None
-        self._timed_out = False
         self._started_at = time.monotonic()
+        self._run_id = uuid.uuid4().hex[:12]
+        self._output_path = (None if self.config is None else
+                             self._rank_output_path(self.config.output_path))
+        self._identity = self._build_identity()
         if not self._done:
             logger.info("Self-benchmark enabled: %s", self.config)
             logger.info("Self-benchmark grid: %d point(s)", len(self._grid))
+            # Invalidate any stale results from a previous run up front, so a
+            # crash mid-sweep can never leave a prior run's file looking valid.
+            self._invalidate_output()
 
     @property
     def active(self) -> bool:
         return not self._done
 
-    def make_prefill_queue_items(
-            self,
-            active_requests: list["LlmRequest"],
-            waiting_queue: WaitingQueue) -> list[RequestQueueItem]:
+    def make_prefill_requests(
+            self, active_requests: list["LlmRequest"],
+            waiting_queue: WaitingQueue) -> list["LlmRequest"]:
+        """Build the synthetic prefill request for the next grid point.
+
+        Per-rank lockstep rationale: this runs on EVERY TP rank (alongside
+        decode injection in ``_fetch_and_activate_new_requests``), not via the
+        rank-0 request-queue + broadcast path. For the TP forward collectives to
+        stay aligned, every rank must produce an identical request and advance
+        the state machine identically each iteration. Every input below is a
+        deterministic function of ``point.index`` (which is itself driven by the
+        grid + ``_grid_index``, advanced identically on all ranks), so the
+        constructed ``LlmRequest`` is bit-for-bit identical across ranks:
+          * request id  -> ``_request_id(point.index, 0)`` (pure arithmetic)
+          * prompt tokens -> ``[1] * isl`` (isl is a grid field)
+          * cache_salt  -> ``_cache_salt_id(point.index)`` (pure arithmetic)
+          * max_tokens / sampling / end_id / pad_id -> constants
+        Because the request is constructed locally on each rank, it must NOT be
+        injected into rank 0's broadcast queue as well (that would double-inject
+        on non-rank-0 ranks and diverge the state machine).
+        """
         if not self._can_start_next_point(active_requests, waiting_queue):
             return []
         point = self._peek_next_point()
@@ -89,12 +117,18 @@ class SelfBenchmark:
 
         self._start_point(point)
         request = self._make_prefill_request(point)
-        return [
-            RequestQueueItem(
-                id=self._request_id(point.index, 0),
-                request=request,
-                child_req_ids=None)
-        ]
+        # Construct the LlmRequest locally on this rank instead of going through
+        # the rank-0 fetch + RequestBroadcaster path. exclude_last_generation
+        # logits is a deterministic engine-wide flag (identical across TP ranks).
+        llm_request = executor_request_to_llm_request(
+            req_id=self._request_id(point.index, 0),
+            executor_request=request,
+            child_req_ids=None,
+            exclude_last_generation_logits=self._exclude_last_generation_logits(
+            ))
+        llm_request.is_self_benchmark_request = True
+        llm_request.py_self_benchmark_point_id = point.index
+        return [llm_request]
 
     def make_decode_requests(self, active_requests: list["LlmRequest"],
                              waiting_queue: WaitingQueue) -> list["LlmRequest"]:
@@ -120,17 +154,26 @@ class SelfBenchmark:
             self._request_id(point.index, offset)
             for offset in range(point.batch_size)
         ]
-        requests = kv_cache_manager.add_dummy_requests(
-            request_ids=request_ids,
-            token_nums=[token_num] * point.batch_size,
-            is_gen=True,
-            max_num_draft_tokens=self._executor.max_total_draft_tokens,
-            kv_reserve_draft_tokens=getattr(self._executor.model_engine,
-                                            "max_draft_loop_tokens",
-                                            self._executor.max_total_draft_tokens),
-            use_mrope=getattr(self._executor.model_engine, "use_mrope", False),
-            max_beam_width=self._executor.max_beam_width,
-            draft_kv_cache_manager=draft_kv_cache_manager)
+        try:
+            requests = kv_cache_manager.add_dummy_requests(
+                request_ids=request_ids,
+                token_nums=[token_num] * point.batch_size,
+                is_gen=True,
+                max_num_draft_tokens=self._executor.max_total_draft_tokens,
+                kv_reserve_draft_tokens=getattr(
+                    self._executor.model_engine, "max_draft_loop_tokens",
+                    self._executor.max_total_draft_tokens),
+                use_mrope=getattr(self._executor.model_engine, "use_mrope",
+                                  False),
+                max_beam_width=self._executor.max_beam_width,
+                draft_kv_cache_manager=draft_kv_cache_manager)
+        except Exception as exc:
+            # add_dummy_requests only prechecks for >=1 free block, so a large
+            # batch can still fail mid-allocation when pages run out. Skip the
+            # point instead of crashing the engine.
+            self._skip_current_point(
+                f"synthetic decode KV allocation failed: {exc}")
+            return []
         if requests is None:
             self._skip_current_point("insufficient KV cache for synthetic decode")
             return []
@@ -171,13 +214,18 @@ class SelfBenchmark:
         return True
 
     def write_output(self) -> None:
-        if self.config is None:
+        if self.config is None or self._output_path is None:
             return
-        output_path = self._rank_output_path(self.config.output_path)
         output = {
+            "schema_version": 1,
+            "status": "complete",
+            "valid": True,
+            "run_id": self._run_id,
+            "completed_at_unix": time.time(),
+            "identity": self._identity,
+            "output_path": self._output_path,
             "config": self.config.model_dump(),
             "limits": self._limits(),
-            "timed_out": self._timed_out,
             "results": [
                 {
                     "point": asdict(result.point),
@@ -188,13 +236,79 @@ class SelfBenchmark:
                 } for result in self._results
             ],
         }
-        tmp_path = f"{output_path}.tmp"
-        os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
-        with open(tmp_path, "w") as f:
-            json.dump(output, f, indent=2)
-        os.replace(tmp_path, output_path)
+        self._atomic_write_json(self._output_path, output)
         logger.info("Self-benchmark results written to %s (%d point(s))",
-                    output_path, len(self._results))
+                    self._output_path, len(self._results))
+
+    def _invalidate_output(self) -> None:
+        """Replace any prior-run output with an invalid 'running' sentinel.
+
+        Readiness consumers must not treat the mere existence of the output
+        file as a completed result: a crash mid-sweep would otherwise leave a
+        previous run's file looking valid. Writing the sentinel at init (and
+        flipping it to status=complete only in write_output) makes existence
+        insufficient and the run_id/identity authoritative.
+        """
+        if self._output_path is None:
+            return
+        output = {
+            "schema_version": 1,
+            "status": "running",
+            "valid": False,
+            "run_id": self._run_id,
+            "started_at_unix": time.time(),
+            "identity": self._identity,
+            "output_path": self._output_path,
+            "message": "Self-benchmark is running; previous results are invalid.",
+        }
+        try:
+            os.unlink(self._output_path)
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.warning("Failed to remove stale self-benchmark output %s: %s",
+                           self._output_path, exc)
+        self._atomic_write_json(self._output_path, output)
+
+    def _atomic_write_json(self, output_path: str, output: dict) -> None:
+        output_dir = os.path.dirname(output_path) or "."
+        os.makedirs(output_dir, exist_ok=True)
+        basename = os.path.basename(output_path)
+        # Process-unique temp file so co-located writers never clobber a shared
+        # ".tmp"; os.replace then publishes atomically.
+        fd, tmp_path = tempfile.mkstemp(prefix=f".{basename}.{os.getpid()}.",
+                                        suffix=".tmp",
+                                        dir=output_dir,
+                                        text=True)
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(output, f, indent=2)
+                f.write("\n")
+            os.replace(tmp_path, output_path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+    def _build_identity(self) -> dict:
+        executor = self._executor
+        llm_args = getattr(executor, "llm_args", None)
+        dist = getattr(executor, "dist", None)
+        parallel = getattr(llm_args, "parallel_config", None)
+        model = getattr(llm_args, "model", None)
+        if model is not None and not isinstance(model, (str, int, float, bool)):
+            model = str(model)
+        return {
+            "model": model,
+            "benchmark_mode": getattr(self.config, "mode", None),
+            "rank": getattr(dist, "rank", 0),
+            "world_size": getattr(parallel, "world_size", None),
+            "tp_size": getattr(parallel, "tp_size", None),
+            "pp_size": getattr(parallel, "pp_size", None),
+            "pid": os.getpid(),
+        }
 
     def _build_grid(self) -> list[BenchmarkPoint]:
         if self.config is None:
@@ -256,7 +370,12 @@ class SelfBenchmark:
             input_token_ids=[1] * max(1, point.isl),
             max_tokens=1,
             streaming=False,
-            sampling_config=SamplingConfig(),
+            # Match the engine's beam width so the synthetic prefill batch is
+            # shaped like real requests (the decode path already passes
+            # max_beam_width to add_dummy_requests). Using the default beam=1
+            # under a beam>1 engine would mis-shape the forward batch.
+            sampling_config=SamplingConfig(
+                beam_width=self._executor.max_beam_width),
             end_id=-1,
             pad_id=0,
             output_config=output_config,
@@ -265,6 +384,13 @@ class SelfBenchmark:
         request.py_is_self_benchmark_request = True
         request.py_self_benchmark_point_id = point.index
         return request
+
+    def _exclude_last_generation_logits(self) -> bool:
+        # Engine-wide flag derived from disable_overlap_scheduler and pp_size;
+        # identical across TP ranks, so it does not perturb per-rank lockstep.
+        return bool(
+            getattr(self._executor, "should_exclude_last_generation_logits",
+                    False))
 
     def _mark_benchmark_request(self, request: "LlmRequest",
                                 point: BenchmarkPoint) -> None:
@@ -279,14 +405,6 @@ class SelfBenchmark:
             logger.info(
                 "Self-benchmark stopping early because shutdown was requested."
             )
-            self._finish()
-            return False
-        if self.config is not None and (
-                time.monotonic() - self._started_at) >= self.config.timeout_s:
-            self._timed_out = True
-            logger.warning(
-                "Self-benchmark timed out after %ds; writing partial results.",
-                self.config.timeout_s)
             self._finish()
             return False
         return not active_requests and len(waiting_queue) == 0
@@ -489,9 +607,9 @@ class SelfBenchmark:
         stem, ext = os.path.splitext(base_path)
         return f"{stem}_rank{rank}{ext}"
 
-    @staticmethod
-    def _request_id(point_index: int, offset: int) -> int:
-        return _BENCHMARK_REQUEST_ID_BASE + point_index * 1024 + offset
+    def _request_id(self, point_index: int, offset: int) -> int:
+        return (_BENCHMARK_REQUEST_ID_BASE + point_index * self._id_stride +
+                offset)
 
     @staticmethod
     def _cache_salt_id(point_index: int) -> int:

--- a/tensorrt_llm/_torch/pyexecutor/self_benchmark.py
+++ b/tensorrt_llm/_torch/pyexecutor/self_benchmark.py
@@ -1,0 +1,394 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from typing import TYPE_CHECKING, Literal, Optional
+
+from tensorrt_llm.bindings.executor import OutputConfig, Request, SamplingConfig
+from tensorrt_llm.logger import logger
+
+from .executor_request_queue import RequestQueueItem
+from .resource_manager import ResourceManagerType
+from .scheduler import ScheduledRequests, WaitingQueue
+
+if TYPE_CHECKING:
+    from .llm_request import LlmRequest
+    from .py_executor import PyExecutor
+
+_BENCHMARK_REQUEST_ID_BASE = 900_000_000
+
+
+@dataclass
+class BenchmarkPoint:
+    point_type: Literal["warmup", "prefill", "decode"]
+    index: int
+    isl: int = 0
+    context_length: int = 0
+    batch_size: int = 1
+
+
+@dataclass
+class BenchmarkPointResult:
+    point: BenchmarkPoint
+    stats: list[dict] = field(default_factory=list)
+    skipped_reason: Optional[str] = None
+
+
+class SelfBenchmark:
+    """Runs synthetic startup benchmark points inside the PyExecutor loop."""
+
+    def __init__(self, executor: "PyExecutor") -> None:
+        self._executor = executor
+        self.config = executor.llm_args.self_benchmark_config
+        self._grid = self._build_grid()
+        self._grid_index = 0
+        self._current: Optional[BenchmarkPointResult] = None
+        self._results: list[BenchmarkPointResult] = []
+        self._done = self.config is None
+        self._timed_out = False
+        self._started_at = time.monotonic()
+        if not self._done:
+            logger.info("Self-benchmark enabled: %s", self.config)
+            logger.info("Self-benchmark grid: %d point(s)", len(self._grid))
+
+    @property
+    def active(self) -> bool:
+        return not self._done
+
+    def make_prefill_queue_items(
+            self,
+            active_requests: list["LlmRequest"],
+            waiting_queue: WaitingQueue) -> list[RequestQueueItem]:
+        if not self._can_start_next_point(active_requests, waiting_queue):
+            return []
+        point = self._peek_next_point()
+        if point is None:
+            self._finish()
+            return []
+        if point.point_type not in ("warmup", "prefill"):
+            return []
+
+        self._start_point(point)
+        request = self._make_prefill_request(point)
+        return [
+            RequestQueueItem(
+                id=self._request_id(point.index, 0),
+                request=request,
+                child_req_ids=None)
+        ]
+
+    def make_decode_requests(self, active_requests: list["LlmRequest"],
+                             waiting_queue: WaitingQueue) -> list["LlmRequest"]:
+        if not self._can_start_next_point(active_requests, waiting_queue):
+            return []
+        point = self._peek_next_point()
+        if point is None:
+            self._finish()
+            return []
+        if point.point_type != "decode":
+            return []
+
+        self._start_point(point)
+        kv_cache_manager = self._executor.resource_manager.get_resource_manager(
+            ResourceManagerType.KV_CACHE_MANAGER)
+        if kv_cache_manager is None:
+            self._skip_current_point("KV cache manager is not available")
+            return []
+        draft_kv_cache_manager = self._executor.resource_manager.get_resource_manager(
+            ResourceManagerType.DRAFT_KV_CACHE_MANAGER)
+        token_num = max(1, point.context_length + 1)
+        request_ids = [
+            self._request_id(point.index, offset)
+            for offset in range(point.batch_size)
+        ]
+        requests = kv_cache_manager.add_dummy_requests(
+            request_ids=request_ids,
+            token_nums=[token_num] * point.batch_size,
+            is_gen=True,
+            max_num_draft_tokens=self._executor.max_total_draft_tokens,
+            kv_reserve_draft_tokens=getattr(self._executor.model_engine,
+                                            "max_draft_loop_tokens",
+                                            self._executor.max_total_draft_tokens),
+            use_mrope=getattr(self._executor.model_engine, "use_mrope", False),
+            max_beam_width=self._executor.max_beam_width,
+            draft_kv_cache_manager=draft_kv_cache_manager)
+        if requests is None:
+            self._skip_current_point("insufficient KV cache for synthetic decode")
+            return []
+        for request in requests:
+            self._mark_benchmark_request(request, point)
+        return requests
+
+    def observe_iteration(self, scheduled_batch: ScheduledRequests,
+                          stats: dict) -> bool:
+        """Record benchmark stats for benchmark-only batches.
+
+        Returns:
+            True when the iteration belonged to self-benchmarking and should
+            not be appended to the normal public iteration-stats buffer.
+        """
+        if self._current is None:
+            return False
+
+        requests = scheduled_batch.all_requests()
+        if not requests:
+            return False
+        if not all(self._is_benchmark_request(req)
+                   or bool(getattr(req, "is_dummy", False))
+                   for req in requests):
+            logger.warning(
+                "Self-benchmark saw a mixed batch; ignoring it for benchmark output."
+            )
+            return False
+
+        self._sanitize_queue_counters(stats)
+        if self._current.point.point_type != "warmup":
+            self._current.stats.append(stats)
+
+        if self._point_is_complete(stats):
+            self._finish_current_point()
+
+        return True
+
+    def write_output(self) -> None:
+        if self.config is None:
+            return
+        output_path = self._rank_output_path(self.config.output_path)
+        output = {
+            "config": self.config.model_dump(),
+            "limits": self._limits(),
+            "timed_out": self._timed_out,
+            "results": [
+                {
+                    "point": asdict(result.point),
+                    "iteration_stats": result.stats,
+                    "skipped_reason": result.skipped_reason,
+                } for result in self._results
+            ],
+        }
+        tmp_path = f"{output_path}.tmp"
+        os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+        with open(tmp_path, "w") as f:
+            json.dump(output, f, indent=2)
+        os.replace(tmp_path, output_path)
+        logger.info("Self-benchmark results written to %s (%d point(s))",
+                    output_path, len(self._results))
+
+    def _build_grid(self) -> list[BenchmarkPoint]:
+        if self.config is None:
+            return []
+        grid: list[BenchmarkPoint] = []
+        next_index = 0
+        warmup_isl = min(8, self._max_prefill_isl())
+        for _ in range(self.config.warmup_iterations):
+            grid.append(
+                BenchmarkPoint(point_type="warmup",
+                               index=next_index,
+                               isl=warmup_isl))
+            next_index += 1
+
+        if self.config.mode in ("prefill", "agg"):
+            for isl in self._sample_values(self._max_prefill_isl(),
+                                           self.config.prefill_isl_granularity):
+                grid.append(
+                    BenchmarkPoint(point_type="prefill",
+                                   index=next_index,
+                                   isl=isl))
+                next_index += 1
+
+        if self.config.mode in ("decode", "agg"):
+            context_values = self._sample_values(
+                self._max_decode_context_length(),
+                self.config.decode_context_granularity)
+            batch_values = self._sample_values(self._max_decode_batch_size(),
+                                               self.config.decode_batch_granularity)
+            for context_length in context_values:
+                for batch_size in batch_values:
+                    grid.append(
+                        BenchmarkPoint(point_type="decode",
+                                       index=next_index,
+                                       context_length=context_length,
+                                       batch_size=batch_size))
+                    next_index += 1
+        return grid
+
+    def _make_prefill_request(self, point: BenchmarkPoint) -> Request:
+        output_config = OutputConfig()
+        output_config.return_perf_metrics = True
+        request = Request(
+            input_token_ids=[1] * max(1, point.isl),
+            max_tokens=1,
+            streaming=False,
+            sampling_config=SamplingConfig(),
+            end_id=-1,
+            pad_id=0,
+            output_config=output_config,
+            return_all_generated_tokens=False,
+            cache_salt_id=self._request_id(point.index, 0))
+        request.py_is_self_benchmark_request = True
+        request.py_self_benchmark_point_id = point.index
+        return request
+
+    def _mark_benchmark_request(self, request: "LlmRequest",
+                                point: BenchmarkPoint) -> None:
+        request.is_self_benchmark_request = True
+        request.py_self_benchmark_point_id = point.index
+
+    def _can_start_next_point(self, active_requests: list["LlmRequest"],
+                              waiting_queue: WaitingQueue) -> bool:
+        if self._done or self._current is not None:
+            return False
+        if self.config is not None and (
+                time.monotonic() - self._started_at) >= self.config.timeout_s:
+            self._timed_out = True
+            logger.warning(
+                "Self-benchmark timed out after %ds; writing partial results.",
+                self.config.timeout_s)
+            self._finish()
+            return False
+        return not active_requests and len(waiting_queue) == 0
+
+    def _peek_next_point(self) -> Optional[BenchmarkPoint]:
+        if self._grid_index >= len(self._grid):
+            return None
+        return self._grid[self._grid_index]
+
+    def _start_point(self, point: BenchmarkPoint) -> None:
+        self._grid_index += 1
+        self._current = BenchmarkPointResult(point=point)
+        logger.debug("Starting self-benchmark point: %s", point)
+
+    def _finish_current_point(self) -> None:
+        if self._current is None:
+            return
+        if self._current.point.point_type != "warmup":
+            self._results.append(self._current)
+        self._current = None
+
+    def _skip_current_point(self, reason: str) -> None:
+        if self._current is None:
+            return
+        logger.warning("Skipping self-benchmark point %s: %s",
+                       self._current.point, reason)
+        self._current.skipped_reason = reason
+        if self._current.point.point_type != "warmup":
+            self._results.append(self._current)
+        self._current = None
+
+    def _finish(self) -> None:
+        if self._current is not None:
+            self._finish_current_point()
+        self._done = True
+        self.write_output()
+        logger.info("Self-benchmark completed in %.3fs",
+                    time.monotonic() - self._started_at)
+
+    def _point_is_complete(self, stats: dict) -> bool:
+        if self._current is None:
+            return False
+        if self._current.point.point_type in ("warmup", "prefill"):
+            return self._num_context_requests(stats) > 0
+        if self._current.point.point_type == "decode":
+            return self._num_decode_requests(stats) > 0
+        return False
+
+    @staticmethod
+    def _sanitize_queue_counters(stats: dict) -> None:
+        stats["numQueuedRequests"] = 0
+        inflight_stats = stats.get("inflightBatchingStats", {})
+        inflight_stats["numQueuedContextRequests"] = 0
+        inflight_stats["numQueuedCtxTokens"] = 0
+        inflight_stats["numQueuedGenRequests"] = 0
+        inflight_stats["numQueuedGenKvTokens"] = 0
+
+    @staticmethod
+    def _num_context_requests(stats: dict) -> int:
+        return int(stats.get("inflightBatchingStats", {}).get(
+            "numContextRequests", 0))
+
+    @staticmethod
+    def _num_decode_requests(stats: dict) -> int:
+        return int(stats.get("inflightBatchingStats", {}).get(
+            "numGenRequests", 0))
+
+    @staticmethod
+    def _sample_values(max_value: int, granularity: int) -> list[int]:
+        max_value = max(1, int(max_value))
+        if granularity <= 1:
+            return [max_value]
+        values = {
+            round(1 + i * (max_value - 1) / (granularity - 1))
+            for i in range(granularity)
+        }
+        return sorted(max(1, min(max_value, int(value))) for value in values)
+
+    def _max_prefill_isl(self) -> int:
+        return self._bounded_length(default=1)
+
+    def _max_decode_context_length(self) -> int:
+        return max(1, self._bounded_length(default=2) - 1)
+
+    def _bounded_length(self, default: int) -> int:
+        candidates = []
+        for value in (
+                getattr(self._executor, "max_input_len", None),
+                getattr(self._executor, "max_seq_len", None),
+                getattr(self._executor, "max_num_tokens", None),
+        ):
+            if isinstance(value, int) and 0 < value < 2**30:
+                candidates.append(value)
+        return min(candidates) if candidates else default
+
+    def _max_decode_batch_size(self) -> int:
+        candidates = []
+        for value in (
+                getattr(self._executor, "max_num_active_requests", None),
+                getattr(self._executor, "max_batch_size", None),
+        ):
+            if isinstance(value, int) and value > 0:
+                candidates.append(value)
+        return min(candidates) if candidates else 1
+
+    def _limits(self) -> dict:
+        kv_cache_manager = self._executor.resource_manager.get_resource_manager(
+            ResourceManagerType.KV_CACHE_MANAGER)
+        kv_stats = kv_cache_manager.get_kv_cache_stats(
+        ) if kv_cache_manager is not None else None
+        return {
+            "max_num_scheduled_tokens": self._executor.max_num_tokens,
+            "max_num_running_reqs": self._executor.max_num_active_requests,
+            "max_model_len": self._executor.max_seq_len,
+            "max_input_len": self._executor.max_input_len,
+            "tokens_per_block": getattr(kv_stats, "tokens_per_block", None),
+            "num_gpu_blocks": getattr(kv_stats, "max_num_blocks", None),
+        }
+
+    def _rank_output_path(self, base_path: str) -> str:
+        rank = getattr(self._executor.dist, "rank", 0)
+        if rank == 0:
+            return base_path
+        stem, ext = os.path.splitext(base_path)
+        return f"{stem}_rank{rank}{ext}"
+
+    @staticmethod
+    def _request_id(point_index: int, offset: int) -> int:
+        return _BENCHMARK_REQUEST_ID_BASE + point_index * 1024 + offset
+
+    @staticmethod
+    def _is_benchmark_request(request: "LlmRequest") -> bool:
+        return bool(getattr(request, "is_self_benchmark_request", False))

--- a/tensorrt_llm/_torch/pyexecutor/self_benchmark.py
+++ b/tensorrt_llm/_torch/pyexecutor/self_benchmark.py
@@ -261,7 +261,7 @@ class SelfBenchmark:
             pad_id=0,
             output_config=output_config,
             return_all_generated_tokens=False,
-            cache_salt_id=cache_salt_id)
+            cache_salt=str(cache_salt_id))
         request.py_is_self_benchmark_request = True
         request.py_self_benchmark_point_id = point.index
         return request
@@ -274,6 +274,12 @@ class SelfBenchmark:
     def _can_start_next_point(self, active_requests: list["LlmRequest"],
                               waiting_queue: WaitingQueue) -> bool:
         if self._done or self._current is not None:
+            return False
+        if getattr(self._executor, "is_shutdown", False):
+            logger.info(
+                "Self-benchmark stopping early because shutdown was requested."
+            )
+            self._finish()
             return False
         if self.config is not None and (
                 time.monotonic() - self._started_at) >= self.config.timeout_s:
@@ -347,9 +353,6 @@ class SelfBenchmark:
             "cacheHitValidated": validated,
         }
         if not validated:
-            self._current.skipped_reason = (
-                "expected cached_tokens >= "
-                f"{point.kv_read_tokens}, observed {observed}")
             logger.warning("Self-benchmark cache-hit validation failed for "
                            "point %s: observed cached_tokens=%s",
                            point, observed)

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -35,7 +35,8 @@ from tensorrt_llm.llmapi.disagg_utils import (DisaggClusterConfig,
                                               extract_disagg_cluster_config,
                                               parse_disagg_config_file,
                                               parse_metadata_server_config_file)
-from tensorrt_llm.llmapi.llm_args import TorchLlmArgs, TrtLlmArgs
+from tensorrt_llm.llmapi.llm_args import (SelfBenchmarkConfig, TorchLlmArgs,
+                                          TrtLlmArgs)
 from tensorrt_llm.llmapi.llm_utils import update_llm_args_with_extra_dict
 from tensorrt_llm.llmapi.mpi_session import find_free_ipc_addr
 from tensorrt_llm.llmapi.reasoning_parser import (ReasoningParserFactory,
@@ -56,6 +57,18 @@ _child_p_global: Optional[subprocess.Popen] = None
 
 # Bound gRPC messages while leaving room for multimodal image payloads.
 _GRPC_MAX_MESSAGE_LENGTH_BYTES = 32 * 1024 * 1024
+_SELF_BENCHMARK_PREFILL_GRANULARITY = SelfBenchmarkConfig.model_fields[
+    "prefill_isl_granularity"].default
+_SELF_BENCHMARK_DECODE_LENGTH_GRANULARITY = SelfBenchmarkConfig.model_fields[
+    "decode_context_granularity"].default
+_SELF_BENCHMARK_DECODE_BATCH_GRANULARITY = SelfBenchmarkConfig.model_fields[
+    "decode_batch_granularity"].default
+_SELF_BENCHMARK_WARMUP_ITERATIONS = SelfBenchmarkConfig.model_fields[
+    "warmup_iterations"].default
+_SELF_BENCHMARK_OUTPUT_PATH = SelfBenchmarkConfig.model_fields[
+    "output_path"].default
+_SELF_BENCHMARK_TIMEOUT = SelfBenchmarkConfig.model_fields[
+    "timeout_s"].default
 
 
 def _apply_fastapi_middlewares(app, middlewares: Sequence[str]) -> None:
@@ -209,6 +222,16 @@ def get_llm_args(
         telemetry: bool = True,
         agent_percentage: float = 0.0,
         agent_types: Optional[str] = None,
+        self_benchmark_mode: Optional[str] = None,
+        self_benchmark_prefill_granularity: int = (
+            _SELF_BENCHMARK_PREFILL_GRANULARITY),
+        self_benchmark_decode_length_granularity: int = (
+            _SELF_BENCHMARK_DECODE_LENGTH_GRANULARITY),
+        self_benchmark_decode_batch_granularity: int = (
+            _SELF_BENCHMARK_DECODE_BATCH_GRANULARITY),
+        self_benchmark_warmup_iterations: int = _SELF_BENCHMARK_WARMUP_ITERATIONS,
+        self_benchmark_output_path: str = _SELF_BENCHMARK_OUTPUT_PATH,
+        self_benchmark_timeout: int = _SELF_BENCHMARK_TIMEOUT,
         explicit_cli_keys: Optional[Set[str]] = None,
         **llm_args_extra_dict: Any):
 
@@ -302,6 +325,16 @@ def get_llm_args(
         agent_percentage,
         "agent_types":
         agent_types,
+        "self_benchmark_config":
+        SelfBenchmarkConfig(
+            mode=self_benchmark_mode,
+            prefill_isl_granularity=self_benchmark_prefill_granularity,
+            decode_context_granularity=self_benchmark_decode_length_granularity,
+            decode_batch_granularity=self_benchmark_decode_batch_granularity,
+            warmup_iterations=self_benchmark_warmup_iterations,
+            output_path=self_benchmark_output_path,
+            timeout_s=self_benchmark_timeout,
+        ) if self_benchmark_mode is not None else None,
     }
 
     llm_args = {
@@ -858,6 +891,54 @@ class ChoiceWithAlias(click.Choice):
                   "Applied by Efficient Video Sampling (EVS). "
                   "None disables EVS, values in [0, 1) enable pruning.",
                   "prototype"))
+@click.option(
+    "--self_benchmark_mode",
+    type=click.Choice(["prefill", "decode", "agg"]),
+    default=None,
+    help=help_info_with_stability_tag(
+        "Run scheduler-local self-benchmarking on startup and write JSON "
+        "results to --self_benchmark_output_path.", "prototype"))
+@click.option(
+    "--self_benchmark_prefill_granularity",
+    type=int,
+    default=_SELF_BENCHMARK_PREFILL_GRANULARITY,
+    help=help_info_with_stability_tag(
+        "Number of input sequence length sample points for startup "
+        "self-benchmark prefill sweep.", "prototype"))
+@click.option(
+    "--self_benchmark_decode_length_granularity",
+    type=int,
+    default=_SELF_BENCHMARK_DECODE_LENGTH_GRANULARITY,
+    help=help_info_with_stability_tag(
+        "Number of context length sample points for startup self-benchmark "
+        "decode sweep.", "prototype"))
+@click.option(
+    "--self_benchmark_decode_batch_granularity",
+    type=int,
+    default=_SELF_BENCHMARK_DECODE_BATCH_GRANULARITY,
+    help=help_info_with_stability_tag(
+        "Number of batch size sample points for each startup self-benchmark "
+        "decode context length.", "prototype"))
+@click.option(
+    "--self_benchmark_warmup_iterations",
+    type=int,
+    default=_SELF_BENCHMARK_WARMUP_ITERATIONS,
+    help=help_info_with_stability_tag(
+        "Number of synthetic warmup iterations before startup "
+        "self-benchmark collection.", "prototype"))
+@click.option(
+    "--self_benchmark_output_path",
+    type=str,
+    default=_SELF_BENCHMARK_OUTPUT_PATH,
+    help=help_info_with_stability_tag(
+        "Path to write startup self-benchmark results JSON.", "prototype"))
+@click.option(
+    "--self_benchmark_timeout",
+    type=int,
+    default=_SELF_BENCHMARK_TIMEOUT,
+    help=help_info_with_stability_tag(
+        "Maximum seconds external launchers should wait for startup "
+        "self-benchmark output.", "prototype"))
 @click.option("--chat_template",
               type=str,
               default=None,
@@ -927,6 +1008,13 @@ def serve(
         enable_attention_dp: bool, disagg_cluster_uri: Optional[str],
         media_io_kwargs: Optional[str], agent_percentage: float,
         agent_types: Optional[str], video_pruning_rate: Optional[float],
+        self_benchmark_mode: Optional[str],
+        self_benchmark_prefill_granularity: int,
+        self_benchmark_decode_length_granularity: int,
+        self_benchmark_decode_batch_granularity: int,
+        self_benchmark_warmup_iterations: int,
+        self_benchmark_output_path: str,
+        self_benchmark_timeout: int,
         telemetry: bool, custom_module_dirs: list[Path],
         chat_template: Optional[str], middleware: tuple[str, ...], grpc: bool,
         served_model_name: Optional[str], visual_gen_args: Optional[str]):
@@ -989,6 +1077,20 @@ def serve(
 
     explicit_cli_keys = collect_explicit_cli_keys(
         exclude=("extra_llm_api_options", "config"))
+    self_benchmark_cli_keys = {
+        "self_benchmark_prefill_granularity",
+        "self_benchmark_decode_length_granularity",
+        "self_benchmark_decode_batch_granularity",
+        "self_benchmark_warmup_iterations",
+        "self_benchmark_output_path",
+        "self_benchmark_timeout",
+    }
+    if (self_benchmark_mode is None
+            and explicit_cli_keys.intersection(self_benchmark_cli_keys)):
+        raise click.BadParameter(
+            "--self_benchmark_mode must be set when any other "
+            "--self_benchmark_* option is provided.",
+            param_hint="--self_benchmark_mode")
 
     def _serve_llm():
         nonlocal server_role
@@ -1022,6 +1124,13 @@ def serve(
             telemetry=telemetry,
             agent_percentage=agent_percentage,
             agent_types=agent_types,
+            self_benchmark_mode=self_benchmark_mode,
+            self_benchmark_prefill_granularity=self_benchmark_prefill_granularity,
+            self_benchmark_decode_length_granularity=self_benchmark_decode_length_granularity,
+            self_benchmark_decode_batch_granularity=self_benchmark_decode_batch_granularity,
+            self_benchmark_warmup_iterations=self_benchmark_warmup_iterations,
+            self_benchmark_output_path=self_benchmark_output_path,
+            self_benchmark_timeout=self_benchmark_timeout,
             explicit_cli_keys=explicit_cli_keys)
 
         llm_args_extra_dict = {}

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -59,6 +59,8 @@ _child_p_global: Optional[subprocess.Popen] = None
 _GRPC_MAX_MESSAGE_LENGTH_BYTES = 32 * 1024 * 1024
 _SELF_BENCHMARK_PREFILL_GRANULARITY = SelfBenchmarkConfig.model_fields[
     "prefill_isl_granularity"].default
+_SELF_BENCHMARK_PREFILL_KV_READ_GRANULARITY = SelfBenchmarkConfig.model_fields[
+    "prefill_kv_read_granularity"].default
 _SELF_BENCHMARK_DECODE_LENGTH_GRANULARITY = SelfBenchmarkConfig.model_fields[
     "decode_context_granularity"].default
 _SELF_BENCHMARK_DECODE_BATCH_GRANULARITY = SelfBenchmarkConfig.model_fields[
@@ -225,6 +227,8 @@ def get_llm_args(
         self_benchmark_mode: Optional[str] = None,
         self_benchmark_prefill_granularity: int = (
             _SELF_BENCHMARK_PREFILL_GRANULARITY),
+        self_benchmark_prefill_kv_read_granularity: int = (
+            _SELF_BENCHMARK_PREFILL_KV_READ_GRANULARITY),
         self_benchmark_decode_length_granularity: int = (
             _SELF_BENCHMARK_DECODE_LENGTH_GRANULARITY),
         self_benchmark_decode_batch_granularity: int = (
@@ -329,6 +333,8 @@ def get_llm_args(
         SelfBenchmarkConfig(
             mode=self_benchmark_mode,
             prefill_isl_granularity=self_benchmark_prefill_granularity,
+            prefill_kv_read_granularity=(
+                self_benchmark_prefill_kv_read_granularity),
             decode_context_granularity=self_benchmark_decode_length_granularity,
             decode_batch_granularity=self_benchmark_decode_batch_granularity,
             warmup_iterations=self_benchmark_warmup_iterations,
@@ -906,6 +912,13 @@ class ChoiceWithAlias(click.Choice):
         "Number of input sequence length sample points for startup "
         "self-benchmark prefill sweep.", "prototype"))
 @click.option(
+    "--self_benchmark_prefill_kv_read_granularity",
+    type=int,
+    default=_SELF_BENCHMARK_PREFILL_KV_READ_GRANULARITY,
+    help=help_info_with_stability_tag(
+        "Number of block-aligned KV-read sample points per input sequence "
+        "length for startup self-benchmark prefill sweep.", "prototype"))
+@click.option(
     "--self_benchmark_decode_length_granularity",
     type=int,
     default=_SELF_BENCHMARK_DECODE_LENGTH_GRANULARITY,
@@ -1010,6 +1023,7 @@ def serve(
         agent_types: Optional[str], video_pruning_rate: Optional[float],
         self_benchmark_mode: Optional[str],
         self_benchmark_prefill_granularity: int,
+        self_benchmark_prefill_kv_read_granularity: int,
         self_benchmark_decode_length_granularity: int,
         self_benchmark_decode_batch_granularity: int,
         self_benchmark_warmup_iterations: int,
@@ -1079,6 +1093,7 @@ def serve(
         exclude=("extra_llm_api_options", "config"))
     self_benchmark_cli_keys = {
         "self_benchmark_prefill_granularity",
+        "self_benchmark_prefill_kv_read_granularity",
         "self_benchmark_decode_length_granularity",
         "self_benchmark_decode_batch_granularity",
         "self_benchmark_warmup_iterations",
@@ -1126,6 +1141,8 @@ def serve(
             agent_types=agent_types,
             self_benchmark_mode=self_benchmark_mode,
             self_benchmark_prefill_granularity=self_benchmark_prefill_granularity,
+            self_benchmark_prefill_kv_read_granularity=(
+                self_benchmark_prefill_kv_read_granularity),
             self_benchmark_decode_length_granularity=self_benchmark_decode_length_granularity,
             self_benchmark_decode_batch_granularity=self_benchmark_decode_batch_granularity,
             self_benchmark_warmup_iterations=self_benchmark_warmup_iterations,

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -69,8 +69,6 @@ _SELF_BENCHMARK_WARMUP_ITERATIONS = SelfBenchmarkConfig.model_fields[
     "warmup_iterations"].default
 _SELF_BENCHMARK_OUTPUT_PATH = SelfBenchmarkConfig.model_fields[
     "output_path"].default
-_SELF_BENCHMARK_TIMEOUT = SelfBenchmarkConfig.model_fields[
-    "timeout_s"].default
 
 
 def _apply_fastapi_middlewares(app, middlewares: Sequence[str]) -> None:
@@ -235,7 +233,6 @@ def get_llm_args(
             _SELF_BENCHMARK_DECODE_BATCH_GRANULARITY),
         self_benchmark_warmup_iterations: int = _SELF_BENCHMARK_WARMUP_ITERATIONS,
         self_benchmark_output_path: str = _SELF_BENCHMARK_OUTPUT_PATH,
-        self_benchmark_timeout: int = _SELF_BENCHMARK_TIMEOUT,
         explicit_cli_keys: Optional[Set[str]] = None,
         **llm_args_extra_dict: Any):
 
@@ -339,7 +336,6 @@ def get_llm_args(
             decode_batch_granularity=self_benchmark_decode_batch_granularity,
             warmup_iterations=self_benchmark_warmup_iterations,
             output_path=self_benchmark_output_path,
-            timeout_s=self_benchmark_timeout,
         ) if self_benchmark_mode is not None else None,
     }
 
@@ -945,13 +941,6 @@ class ChoiceWithAlias(click.Choice):
     default=_SELF_BENCHMARK_OUTPUT_PATH,
     help=help_info_with_stability_tag(
         "Path to write startup self-benchmark results JSON.", "prototype"))
-@click.option(
-    "--self_benchmark_timeout",
-    type=int,
-    default=_SELF_BENCHMARK_TIMEOUT,
-    help=help_info_with_stability_tag(
-        "Maximum seconds external launchers should wait for startup "
-        "self-benchmark output.", "prototype"))
 @click.option("--chat_template",
               type=str,
               default=None,
@@ -1028,7 +1017,6 @@ def serve(
         self_benchmark_decode_batch_granularity: int,
         self_benchmark_warmup_iterations: int,
         self_benchmark_output_path: str,
-        self_benchmark_timeout: int,
         telemetry: bool, custom_module_dirs: list[Path],
         chat_template: Optional[str], middleware: tuple[str, ...], grpc: bool,
         served_model_name: Optional[str], visual_gen_args: Optional[str]):
@@ -1098,7 +1086,6 @@ def serve(
         "self_benchmark_decode_batch_granularity",
         "self_benchmark_warmup_iterations",
         "self_benchmark_output_path",
-        "self_benchmark_timeout",
     }
     if (self_benchmark_mode is None
             and explicit_cli_keys.intersection(self_benchmark_cli_keys)):
@@ -1147,7 +1134,6 @@ def serve(
             self_benchmark_decode_batch_granularity=self_benchmark_decode_batch_granularity,
             self_benchmark_warmup_iterations=self_benchmark_warmup_iterations,
             self_benchmark_output_path=self_benchmark_output_path,
-            self_benchmark_timeout=self_benchmark_timeout,
             explicit_cli_keys=explicit_cli_keys)
 
         llm_args_extra_dict = {}

--- a/tensorrt_llm/llmapi/__init__.py
+++ b/tensorrt_llm/llmapi/__init__.py
@@ -21,6 +21,7 @@ from .llm_args import (AttentionDpConfig, AutoDecodingConfig, BatchingType,
                        ReorderRequestPolicyConfig, RocketSparseAttentionConfig,
                        SADecodingConfig, SAEnhancerConfig,
                        SaveHiddenStatesDecodingConfig, SchedulerConfig,
+                       SelfBenchmarkConfig,
                        SkipSoftmaxAttentionConfig, TorchCompileConfig,
                        TorchLlmArgs, TrtLlmArgs, UserProvidedDecodingConfig)
 from .llm_utils import (BuildConfig, KvCacheRetentionConfig, QuantAlgo,
@@ -87,6 +88,7 @@ __all__ = [
     'SchedulingParams',
     'SkipSoftmaxAttentionConfig',
     'PrometheusMetricsConfig',
+    'SelfBenchmarkConfig',
     'ThinkingBudgetLogitsProcessor',
     'add_thinking_budget_logits_processor',
 ]

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2357,6 +2357,13 @@ class SelfBenchmarkConfig(StrictBaseModel):
         "Number of input sequence length sample points in the prefill sweep.",
         status="prototype")
 
+    prefill_kv_read_granularity: PositiveInt = Field(
+        default=4,
+        description=
+        "Number of block-aligned KV-read sample points per input sequence "
+        "length in the prefill sweep.",
+        status="prototype")
+
     decode_context_granularity: PositiveInt = Field(
         default=6,
         description=

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -4942,6 +4942,11 @@ class TorchLlmArgs(BaseLlmArgs):
                 "self_benchmark_config is not supported with attention data "
                 "parallelism yet. Disable enable_attention_dp to use startup "
                 "self-benchmarking.")
+        if self.parallel_config.world_size != 1:
+            raise ValueError(
+                "self_benchmark_config is only supported with world_size=1 "
+                "until benchmark request injection is synchronized across "
+                "distributed ranks.")
         self.enable_iter_perf_stats = True
         return self
 

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2340,6 +2340,55 @@ class PrometheusMetricsConfig(StrictBaseModel):
         return v
 
 
+class SelfBenchmarkConfig(StrictBaseModel):
+    """Configuration for startup self-benchmarking."""
+
+    mode: Literal["prefill", "decode", "agg"] = Field(
+        default="agg",
+        description=
+        "Self-benchmark mode. 'prefill' sweeps input sequence lengths, "
+        "'decode' sweeps decode context lengths and batch sizes, and 'agg' "
+        "runs both sweeps.",
+        status="prototype")
+
+    prefill_isl_granularity: PositiveInt = Field(
+        default=16,
+        description=
+        "Number of input sequence length sample points in the prefill sweep.",
+        status="prototype")
+
+    decode_context_granularity: PositiveInt = Field(
+        default=6,
+        description=
+        "Number of context length sample points in the decode sweep.",
+        status="prototype")
+
+    decode_batch_granularity: PositiveInt = Field(
+        default=6,
+        description=
+        "Number of batch size sample points for each decode context length.",
+        status="prototype")
+
+    warmup_iterations: NonNegativeInt = Field(
+        default=5,
+        description=
+        "Number of synthetic warmup iterations to run before collecting "
+        "self-benchmark results.",
+        status="prototype")
+
+    output_path: str = Field(
+        default="/tmp/trtllm_self_benchmark.json",
+        description="Path to write self-benchmark results JSON.",
+        status="prototype")
+
+    timeout_s: PositiveInt = Field(
+        default=300,
+        description=
+        "Maximum number of seconds external callers should wait for "
+        "self-benchmark output.",
+        status="prototype")
+
+
 class RayPlacementConfig(StrictBaseModel):
     """Configuration for Ray GPU workers placement.
     Currently, this config is only used with AsyncLLM for RL scenarios.
@@ -4430,6 +4479,15 @@ class TorchLlmArgs(BaseLlmArgs):
         "scheduler is disabled.",
         status="prototype")
 
+    self_benchmark_config: Optional[SelfBenchmarkConfig] = Field(
+        default=None,
+        description=
+        "Configuration for startup self-benchmarking. When set, the PyTorch "
+        "executor runs synthetic prefill and/or decode benchmark points before "
+        "serving normal requests and writes the collected iteration metrics to "
+        "the configured JSON output path.",
+        status="prototype")
+
     enable_iter_perf_stats: bool = Field(
         default=False,
         description="Enable iteration performance statistics.",
@@ -4861,6 +4919,23 @@ class TorchLlmArgs(BaseLlmArgs):
                 "aggregated workloads; disabling it because "
                 "cache_transceiver_config is configured.")
             self.enable_early_first_token_response = False
+        return self
+
+    @model_validator(mode="after")
+    def validate_self_benchmark_config(self) -> 'TorchLlmArgs':
+        if self.self_benchmark_config is None:
+            return self
+        if self.encode_only or self.mm_encoder_only:
+            raise ValueError(
+                "self_benchmark_config is only supported for decoder generation "
+                "workloads. Disable encode_only/mm_encoder_only to use "
+                "startup self-benchmarking.")
+        if self.enable_attention_dp:
+            raise ValueError(
+                "self_benchmark_config is not supported with attention data "
+                "parallelism yet. Disable enable_attention_dp to use startup "
+                "self-benchmarking.")
+        self.enable_iter_perf_stats = True
         return self
 
     @model_validator(mode="after")

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2388,13 +2388,6 @@ class SelfBenchmarkConfig(StrictBaseModel):
         description="Path to write self-benchmark results JSON.",
         status="prototype")
 
-    timeout_s: PositiveInt = Field(
-        default=300,
-        description=
-        "Maximum number of seconds external callers should wait for "
-        "self-benchmark output.",
-        status="prototype")
-
 
 class RayPlacementConfig(StrictBaseModel):
     """Configuration for Ray GPU workers placement.
@@ -4942,11 +4935,41 @@ class TorchLlmArgs(BaseLlmArgs):
                 "self_benchmark_config is not supported with attention data "
                 "parallelism yet. Disable enable_attention_dp to use startup "
                 "self-benchmarking.")
-        if self.parallel_config.world_size != 1:
+        # Self-benchmark injection is per-rank deterministic and relies on every
+        # rank building an identical forward batch each iteration. Pure tensor
+        # parallelism preserves that invariant (active_requests / waiting_queue
+        # are mirrored across TP ranks and per-rank KV budgets are equal), so
+        # tensor_parallel_size > 1 is allowed. Pipeline/context/expert/data
+        # parallelism break the per-rank lockstep (uneven pipeline stages,
+        # partitioned context, asymmetric expert/DP routing) and are rejected
+        # until those paths are validated.
+        parallel = self.parallel_config
+        if parallel.pp_size > 1:
             raise ValueError(
-                "self_benchmark_config is only supported with world_size=1 "
-                "until benchmark request injection is synchronized across "
-                "distributed ranks.")
+                "self_benchmark_config is not supported with pipeline "
+                "parallelism yet (pipeline_parallel_size > 1). Only pure tensor "
+                "parallelism is supported.")
+        if parallel.cp_size > 1:
+            raise ValueError(
+                "self_benchmark_config is not supported with context "
+                "parallelism yet (cp_size > 1). Only pure tensor parallelism is "
+                "supported.")
+        if parallel.enable_attention_dp:
+            raise ValueError(
+                "self_benchmark_config is not supported with data/attention "
+                "parallelism yet. Only pure tensor parallelism is supported.")
+        if parallel.moe_ep_size > 1 or parallel.moe_cluster_size > 1:
+            raise ValueError(
+                "self_benchmark_config is not supported with expert "
+                "parallelism yet (moe_ep_size/moe_cluster_size > 1). Only pure "
+                "tensor parallelism is supported.")
+        # Any remaining world_size > 1 must be pure TP (tp_size == world_size).
+        if parallel.world_size != parallel.tp_size:
+            raise ValueError(
+                "self_benchmark_config only supports pure tensor parallelism; "
+                f"got world_size={parallel.world_size} with "
+                f"tp_size={parallel.tp_size}. Disable other forms of "
+                "parallelism to use startup self-benchmarking.")
         self.enable_iter_perf_stats = True
         return self
 

--- a/tests/unittest/api_stability/references/llm.yaml
+++ b/tests/unittest/api_stability/references/llm.yaml
@@ -183,6 +183,10 @@ methods:
         annotation: Optional[tensorrt_llm.llmapi.llm_args.PrometheusMetricsConfig]
         default: null
         status: prototype
+      self_benchmark_config:
+        annotation: Optional[tensorrt_llm.llmapi.llm_args.SelfBenchmarkConfig]
+        default: null
+        status: prototype
       enable_energy_metrics:
         annotation: bool
         default: False

--- a/tests/unittest/pyexecutor/test_self_benchmark.py
+++ b/tests/unittest/pyexecutor/test_self_benchmark.py
@@ -1,0 +1,240 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import types
+
+import pytest
+
+from tensorrt_llm._torch.pyexecutor.resource_manager import ResourceManagerType
+from tensorrt_llm._torch.pyexecutor.self_benchmark import (
+    BenchmarkPoint,
+    BenchmarkPointResult,
+    SelfBenchmark,
+)
+from tensorrt_llm.llmapi.llm_args import SelfBenchmarkConfig, TorchLlmArgs
+
+
+class _FakeRequest:
+
+    def __init__(self):
+        self.is_dummy_request = True
+        self.is_attention_dp_dummy = False
+        self.is_cuda_graph_dummy = False
+        self.is_self_benchmark_request = False
+        self.py_self_benchmark_point_id = None
+
+    @property
+    def is_dummy(self):
+        return (self.is_dummy_request or self.is_attention_dp_dummy
+                or self.is_cuda_graph_dummy)
+
+
+class _FakeKvStats:
+    tokens_per_block = 32
+    max_num_blocks = 128
+
+
+class _FakeKvCacheManager:
+
+    def __init__(self):
+        self.add_dummy_calls = []
+
+    def add_dummy_requests(self, **kwargs):
+        self.add_dummy_calls.append(kwargs)
+        return [_FakeRequest() for _ in kwargs["request_ids"]]
+
+    def get_kv_cache_stats(self):
+        return _FakeKvStats()
+
+
+class _FakeResourceManager:
+
+    def __init__(self, kv_cache_manager):
+        self._kv_cache_manager = kv_cache_manager
+
+    def get_resource_manager(self, resource_manager_type):
+        if resource_manager_type == ResourceManagerType.KV_CACHE_MANAGER:
+            return self._kv_cache_manager
+        return None
+
+
+class _FakeScheduledBatch:
+
+    def __init__(self, requests):
+        self._requests = requests
+
+    def all_requests(self):
+        return self._requests
+
+
+def _make_executor(config: SelfBenchmarkConfig) -> types.SimpleNamespace:
+    kv_cache_manager = _FakeKvCacheManager()
+    return types.SimpleNamespace(
+        llm_args=types.SimpleNamespace(self_benchmark_config=config),
+        max_input_len=16,
+        max_seq_len=9,
+        max_num_tokens=8,
+        max_num_active_requests=4,
+        max_batch_size=4,
+        max_total_draft_tokens=0,
+        max_beam_width=1,
+        model_engine=types.SimpleNamespace(max_draft_loop_tokens=0,
+                                           use_mrope=False),
+        resource_manager=_FakeResourceManager(kv_cache_manager),
+        dist=types.SimpleNamespace(rank=0),
+    )
+
+
+def test_torch_llm_args_self_benchmark_enables_iter_stats():
+    args = TorchLlmArgs(model="dummy",
+                        self_benchmark_config=SelfBenchmarkConfig())
+
+    assert args.enable_iter_perf_stats is True
+
+
+def test_torch_llm_args_self_benchmark_rejects_encode_only():
+    with pytest.raises(ValueError, match="decoder generation workloads"):
+        TorchLlmArgs(model="dummy",
+                     encode_only=True,
+                     self_benchmark_config=SelfBenchmarkConfig())
+
+
+def test_torch_llm_args_self_benchmark_rejects_attention_dp():
+    with pytest.raises(ValueError, match="attention data parallelism"):
+        TorchLlmArgs(model="dummy",
+                     enable_attention_dp=True,
+                     self_benchmark_config=SelfBenchmarkConfig())
+
+
+def test_grid_generation_uses_executor_limits():
+    config = SelfBenchmarkConfig(
+        mode="agg",
+        prefill_isl_granularity=2,
+        decode_context_granularity=2,
+        decode_batch_granularity=2,
+        warmup_iterations=1,
+    )
+
+    benchmark = SelfBenchmark(_make_executor(config))
+
+    assert [point.point_type for point in benchmark._grid] == [
+        "warmup",
+        "prefill",
+        "prefill",
+        "decode",
+        "decode",
+        "decode",
+        "decode",
+    ]
+    assert [point.isl for point in benchmark._grid
+            if point.point_type == "prefill"] == [1, 8]
+    assert {(point.context_length, point.batch_size)
+            for point in benchmark._grid if point.point_type == "decode"} == {
+                (1, 1),
+                (1, 4),
+                (7, 1),
+                (7, 4),
+            }
+
+
+def test_prefill_queue_item_marks_executor_request():
+    config = SelfBenchmarkConfig(mode="prefill",
+                                 prefill_isl_granularity=1,
+                                 warmup_iterations=0)
+    benchmark = SelfBenchmark(_make_executor(config))
+
+    items = benchmark.make_prefill_queue_items([], [])
+
+    assert len(items) == 1
+    assert items[0].id == 900_000_000
+    assert items[0].request.py_is_self_benchmark_request is True
+    assert items[0].request.py_self_benchmark_point_id == 0
+
+
+def test_decode_injection_uses_dummy_kv_path():
+    config = SelfBenchmarkConfig(mode="decode",
+                                 decode_context_granularity=1,
+                                 decode_batch_granularity=1,
+                                 warmup_iterations=0)
+    executor = _make_executor(config)
+    benchmark = SelfBenchmark(executor)
+
+    requests = benchmark.make_decode_requests([], [])
+
+    assert len(requests) == 4
+    assert all(request.is_self_benchmark_request for request in requests)
+    add_dummy_call = executor.resource_manager._kv_cache_manager.add_dummy_calls[
+        0]
+    assert add_dummy_call["request_ids"] == [
+        900_000_000,
+        900_000_001,
+        900_000_002,
+        900_000_003,
+    ]
+    assert add_dummy_call["token_nums"] == [8, 8, 8, 8]
+    assert add_dummy_call["is_gen"] is True
+
+
+def test_observe_iteration_sanitizes_queue_counters_and_records_result():
+    config = SelfBenchmarkConfig(mode="prefill", warmup_iterations=0)
+    benchmark = SelfBenchmark(_make_executor(config))
+    point = BenchmarkPoint(point_type="prefill", index=0, isl=4)
+    benchmark._current = BenchmarkPointResult(point=point)
+    request = types.SimpleNamespace(is_self_benchmark_request=True,
+                                    is_dummy=False)
+    stats = {
+        "numQueuedRequests": 3,
+        "inflightBatchingStats": {
+            "numContextRequests": 1,
+            "numQueuedContextRequests": 3,
+            "numQueuedCtxTokens": 128,
+            "numQueuedGenRequests": 2,
+            "numQueuedGenKvTokens": 256,
+        },
+    }
+
+    consumed = benchmark.observe_iteration(_FakeScheduledBatch([request]),
+                                           stats)
+
+    assert consumed is True
+    assert benchmark._current is None
+    assert len(benchmark._results) == 1
+    recorded_stats = benchmark._results[0].stats[0]
+    assert recorded_stats["numQueuedRequests"] == 0
+    assert recorded_stats["inflightBatchingStats"][
+        "numQueuedContextRequests"] == 0
+    assert recorded_stats["inflightBatchingStats"]["numQueuedCtxTokens"] == 0
+    assert recorded_stats["inflightBatchingStats"]["numQueuedGenRequests"] == 0
+    assert recorded_stats["inflightBatchingStats"]["numQueuedGenKvTokens"] == 0
+
+
+def test_write_output(tmp_path):
+    output_path = tmp_path / "benchmark.json"
+    config = SelfBenchmarkConfig(mode="prefill",
+                                 output_path=str(output_path),
+                                 warmup_iterations=0)
+    benchmark = SelfBenchmark(_make_executor(config))
+    benchmark._results.append(
+        BenchmarkPointResult(
+            point=BenchmarkPoint(point_type="prefill", index=0, isl=8),
+            stats=[{
+                "inflightBatchingStats": {
+                    "numContextRequests": 1
+                }
+            }],
+        ))
+
+    benchmark.write_output()
+
+    with open(output_path) as f:
+        data = json.load(f)
+    assert data["config"]["mode"] == "prefill"
+    assert data["timed_out"] is False
+    assert data["limits"]["max_num_scheduled_tokens"] == 8
+    assert data["limits"]["tokens_per_block"] == 32
+    assert data["results"][0]["point"]["isl"] == 8
+    assert data["results"][0]["iteration_stats"][0][
+        "inflightBatchingStats"]["numContextRequests"] == 1

--- a/tests/unittest/pyexecutor/test_self_benchmark.py
+++ b/tests/unittest/pyexecutor/test_self_benchmark.py
@@ -8,6 +8,7 @@ import types
 
 import pytest
 
+import tensorrt_llm._torch.pyexecutor.self_benchmark as self_benchmark_module
 from tensorrt_llm._torch.pyexecutor.resource_manager import ResourceManagerType
 from tensorrt_llm._torch.pyexecutor.self_benchmark import (
     BenchmarkPoint,
@@ -15,6 +16,34 @@ from tensorrt_llm._torch.pyexecutor.self_benchmark import (
     SelfBenchmark,
 )
 from tensorrt_llm.llmapi.llm_args import SelfBenchmarkConfig, TorchLlmArgs
+
+
+class _FakeLlmRequest:
+    """Stand-in for the LlmRequest produced by executor_request_to_llm_request.
+
+    The real conversion needs torch/bindings (unavailable on CPU-only CI), so
+    tests monkeypatch executor_request_to_llm_request with _fake_to_llm_request
+    below. The fake just carries the deterministic per-rank inputs we assert on.
+    """
+
+    def __init__(self, req_id, executor_request):
+        self.py_request_id = req_id
+        self.executor_request = executor_request
+        self.input_token_ids = list(executor_request.input_token_ids)
+        self.cache_salt = executor_request.cache_salt
+        self.is_self_benchmark_request = False
+        self.py_self_benchmark_point_id = None
+
+
+def _fake_to_llm_request(req_id, executor_request, child_req_ids,
+                         exclude_last_generation_logits, **kwargs):
+    return _FakeLlmRequest(req_id, executor_request)
+
+
+@pytest.fixture(autouse=True)
+def _patch_executor_request_to_llm_request(monkeypatch):
+    monkeypatch.setattr(self_benchmark_module, "executor_request_to_llm_request",
+                        _fake_to_llm_request)
 
 
 class _FakeRequest:
@@ -117,10 +146,27 @@ def test_torch_llm_args_self_benchmark_rejects_attention_dp():
                      self_benchmark_config=SelfBenchmarkConfig())
 
 
-def test_torch_llm_args_self_benchmark_rejects_multi_rank():
-    with pytest.raises(ValueError, match="world_size=1"):
+def test_torch_llm_args_self_benchmark_accepts_pure_tp():
+    # Per-rank deterministic replication makes pure tensor parallelism safe:
+    # every TP rank builds the same forward batch in lockstep.
+    args = TorchLlmArgs(model="dummy",
+                        tensor_parallel_size=2,
+                        self_benchmark_config=SelfBenchmarkConfig())
+    assert args.parallel_config.tp_size == 2
+    assert args.enable_iter_perf_stats is True
+
+
+def test_torch_llm_args_self_benchmark_rejects_pipeline_parallel():
+    with pytest.raises(ValueError, match="pipeline parallelism"):
         TorchLlmArgs(model="dummy",
-                     tensor_parallel_size=2,
+                     pipeline_parallel_size=2,
+                     self_benchmark_config=SelfBenchmarkConfig())
+
+
+def test_torch_llm_args_self_benchmark_rejects_context_parallel():
+    with pytest.raises(ValueError, match="context parallelism"):
+        TorchLlmArgs(model="dummy",
+                     context_parallel_size=2,
                      self_benchmark_config=SelfBenchmarkConfig())
 
 
@@ -196,18 +242,44 @@ def test_prefill_grid_omits_kv_read_axis_when_block_reuse_disabled():
             ]
 
 
-def test_prefill_queue_item_marks_executor_request():
+def test_prefill_request_built_per_rank_marks_llm_request():
     config = SelfBenchmarkConfig(mode="prefill",
                                  prefill_isl_granularity=1,
                                  warmup_iterations=0)
     benchmark = SelfBenchmark(_make_executor(config))
 
-    items = benchmark.make_prefill_queue_items([], [])
+    requests = benchmark.make_prefill_requests([], [])
 
-    assert len(items) == 1
-    assert items[0].id == 900_000_000
-    assert items[0].request.py_is_self_benchmark_request is True
-    assert items[0].request.py_self_benchmark_point_id == 0
+    # Built locally per-rank (no RequestQueueItem / broadcast). Deterministic
+    # request id and benchmark marking are set on the LlmRequest itself.
+    assert len(requests) == 1
+    assert requests[0].py_request_id == 900_000_000
+    assert requests[0].is_self_benchmark_request is True
+    assert requests[0].py_self_benchmark_point_id == 0
+
+
+def test_prefill_request_is_rank_independent():
+    """Per-rank lockstep: non-rank-0 builds the same prefill request as rank 0.
+
+    This guards the core TP invariant -- prefill injection must not depend on
+    being rank 0. Every input is a deterministic function of the grid point, so
+    a rank-1 executor produces a bit-identical request id / tokens / cache_salt.
+    """
+    config = SelfBenchmarkConfig(mode="prefill",
+                                 prefill_isl_granularity=1,
+                                 warmup_iterations=0)
+    rank0 = SelfBenchmark(_make_executor(config))
+    executor_rank1 = _make_executor(config)
+    executor_rank1.dist = types.SimpleNamespace(rank=1)
+    rank1 = SelfBenchmark(executor_rank1)
+
+    req0 = rank0.make_prefill_requests([], [])[0]
+    req1 = rank1.make_prefill_requests([], [])[0]
+
+    assert req0.py_request_id == req1.py_request_id
+    assert req0.input_token_ids == req1.input_token_ids
+    assert req0.cache_salt == req1.cache_salt
+    assert req0.py_self_benchmark_point_id == req1.py_self_benchmark_point_id
 
 
 def test_shutdown_finishes_benchmark_without_starting_next_point(tmp_path):
@@ -219,7 +291,7 @@ def test_shutdown_finishes_benchmark_without_starting_next_point(tmp_path):
     executor.is_shutdown = True
     benchmark = SelfBenchmark(executor)
 
-    assert benchmark.make_prefill_queue_items([], []) == []
+    assert benchmark.make_prefill_requests([], []) == []
     assert benchmark.active is False
     assert output_path.exists()
 
@@ -240,14 +312,14 @@ def test_prefill_seed_and_measure_requests_share_cache_salt():
                        cache_salt_id=123),
     ]
 
-    seed_items = benchmark.make_prefill_queue_items([], [])
+    seed_items = benchmark.make_prefill_requests([], [])
     benchmark._finish_current_point()
-    measure_items = benchmark.make_prefill_queue_items([], [])
+    measure_items = benchmark.make_prefill_requests([], [])
 
-    assert seed_items[0].request.input_token_ids == [1, 1, 1, 1]
-    assert seed_items[0].request.cache_salt == "123"
-    assert measure_items[0].request.input_token_ids == [1] * 8
-    assert measure_items[0].request.cache_salt == "123"
+    assert seed_items[0].input_token_ids == [1, 1, 1, 1]
+    assert seed_items[0].cache_salt == "123"
+    assert measure_items[0].input_token_ids == [1] * 8
+    assert measure_items[0].cache_salt == "123"
 
 
 def test_decode_injection_uses_dummy_kv_path():
@@ -397,7 +469,8 @@ def test_write_output(tmp_path):
     with open(output_path) as f:
         data = json.load(f)
     assert data["config"]["mode"] == "prefill"
-    assert data["timed_out"] is False
+    assert data["status"] == "complete"
+    assert data["valid"] is True
     assert data["limits"]["max_num_scheduled_tokens"] == 8
     assert data["limits"]["tokens_per_block"] == 32
     assert data["results"][0]["point"]["isl"] == 8

--- a/tests/unittest/pyexecutor/test_self_benchmark.py
+++ b/tests/unittest/pyexecutor/test_self_benchmark.py
@@ -33,21 +33,25 @@ class _FakeRequest:
 
 
 class _FakeKvStats:
-    tokens_per_block = 32
-    max_num_blocks = 128
+
+    def __init__(self, tokens_per_block=32):
+        self.tokens_per_block = tokens_per_block
+        self.max_num_blocks = 128
 
 
 class _FakeKvCacheManager:
 
-    def __init__(self):
+    def __init__(self, tokens_per_block=32, enable_block_reuse=True):
         self.add_dummy_calls = []
+        self._tokens_per_block = tokens_per_block
+        self.enable_block_reuse = enable_block_reuse
 
     def add_dummy_requests(self, **kwargs):
         self.add_dummy_calls.append(kwargs)
         return [_FakeRequest() for _ in kwargs["request_ids"]]
 
     def get_kv_cache_stats(self):
-        return _FakeKvStats()
+        return _FakeKvStats(tokens_per_block=self._tokens_per_block)
 
 
 class _FakeResourceManager:
@@ -70,8 +74,12 @@ class _FakeScheduledBatch:
         return self._requests
 
 
-def _make_executor(config: SelfBenchmarkConfig) -> types.SimpleNamespace:
-    kv_cache_manager = _FakeKvCacheManager()
+def _make_executor(config: SelfBenchmarkConfig,
+                   tokens_per_block=32,
+                   enable_block_reuse=True) -> types.SimpleNamespace:
+    kv_cache_manager = _FakeKvCacheManager(
+        tokens_per_block=tokens_per_block,
+        enable_block_reuse=enable_block_reuse)
     return types.SimpleNamespace(
         llm_args=types.SimpleNamespace(self_benchmark_config=config),
         max_input_len=16,
@@ -131,6 +139,8 @@ def test_grid_generation_uses_executor_limits():
     ]
     assert [point.isl for point in benchmark._grid
             if point.point_type == "prefill"] == [1, 8]
+    assert [point.kv_read_tokens for point in benchmark._grid
+            if point.point_type == "prefill"] == [0, 0]
     assert {(point.context_length, point.batch_size)
             for point in benchmark._grid if point.point_type == "decode"} == {
                 (1, 1),
@@ -138,6 +148,45 @@ def test_grid_generation_uses_executor_limits():
                 (7, 1),
                 (7, 4),
             }
+
+
+def test_prefill_grid_includes_block_aligned_kv_read_axis():
+    config = SelfBenchmarkConfig(
+        mode="prefill",
+        prefill_isl_granularity=2,
+        prefill_kv_read_granularity=4,
+        warmup_iterations=0,
+    )
+
+    benchmark = SelfBenchmark(_make_executor(config, tokens_per_block=4))
+
+    assert [(point.point_type, point.isl, point.kv_read_tokens)
+            for point in benchmark._grid] == [
+                ("prefill", 1, 0),
+                ("prefill", 8, 0),
+                ("prefill_seed", 4, 4),
+                ("prefill", 8, 4),
+            ]
+    assert benchmark._grid[2].cache_salt_id == benchmark._grid[
+        3].cache_salt_id
+
+
+def test_prefill_grid_omits_kv_read_axis_when_block_reuse_disabled():
+    config = SelfBenchmarkConfig(
+        mode="prefill",
+        prefill_isl_granularity=2,
+        prefill_kv_read_granularity=4,
+        warmup_iterations=0,
+    )
+
+    benchmark = SelfBenchmark(
+        _make_executor(config, tokens_per_block=4, enable_block_reuse=False))
+
+    assert [(point.point_type, point.isl, point.kv_read_tokens)
+            for point in benchmark._grid] == [
+                ("prefill", 1, 0),
+                ("prefill", 8, 0),
+            ]
 
 
 def test_prefill_queue_item_marks_executor_request():
@@ -152,6 +201,32 @@ def test_prefill_queue_item_marks_executor_request():
     assert items[0].id == 900_000_000
     assert items[0].request.py_is_self_benchmark_request is True
     assert items[0].request.py_self_benchmark_point_id == 0
+
+
+def test_prefill_seed_and_measure_requests_share_cache_salt():
+    config = SelfBenchmarkConfig(mode="prefill", warmup_iterations=0)
+    benchmark = SelfBenchmark(_make_executor(config))
+    benchmark._grid = [
+        BenchmarkPoint(point_type="prefill_seed",
+                       index=0,
+                       isl=4,
+                       kv_read_tokens=4,
+                       cache_salt_id=123),
+        BenchmarkPoint(point_type="prefill",
+                       index=1,
+                       isl=8,
+                       kv_read_tokens=4,
+                       cache_salt_id=123),
+    ]
+
+    seed_items = benchmark.make_prefill_queue_items([], [])
+    benchmark._finish_current_point()
+    measure_items = benchmark.make_prefill_queue_items([], [])
+
+    assert seed_items[0].request.input_token_ids == [1, 1, 1, 1]
+    assert seed_items[0].request.cache_salt_id == 123
+    assert measure_items[0].request.input_token_ids == [1] * 8
+    assert measure_items[0].request.cache_salt_id == 123
 
 
 def test_decode_injection_uses_dummy_kv_path():
@@ -211,6 +286,39 @@ def test_observe_iteration_sanitizes_queue_counters_and_records_result():
     assert recorded_stats["inflightBatchingStats"]["numQueuedGenKvTokens"] == 0
 
 
+def test_observe_iteration_records_cache_hit_validation():
+    config = SelfBenchmarkConfig(mode="prefill", warmup_iterations=0)
+    benchmark = SelfBenchmark(_make_executor(config))
+    point = BenchmarkPoint(point_type="prefill",
+                           index=0,
+                           isl=8,
+                           kv_read_tokens=4)
+    benchmark._current = BenchmarkPointResult(point=point)
+    request = types.SimpleNamespace(is_self_benchmark_request=True,
+                                    py_self_benchmark_point_id=0,
+                                    cached_tokens=4,
+                                    is_dummy=False)
+    stats = {
+        "numQueuedRequests": 0,
+        "inflightBatchingStats": {
+            "numContextRequests": 1,
+        },
+    }
+
+    consumed = benchmark.observe_iteration(_FakeScheduledBatch([request]),
+                                           stats)
+
+    assert consumed is True
+    result = benchmark._results[0]
+    assert result.observed_kv_read_tokens == 4
+    assert result.cache_hit_validated is True
+    assert result.stats[0]["selfBenchmark"] == {
+        "expectedKvReadTokens": 4,
+        "observedCachedTokens": 4,
+        "cacheHitValidated": True,
+    }
+
+
 def test_write_output(tmp_path):
     output_path = tmp_path / "benchmark.json"
     config = SelfBenchmarkConfig(mode="prefill",
@@ -225,6 +333,8 @@ def test_write_output(tmp_path):
                     "numContextRequests": 1
                 }
             }],
+            observed_kv_read_tokens=0,
+            cache_hit_validated=True,
         ))
 
     benchmark.write_output()
@@ -236,5 +346,7 @@ def test_write_output(tmp_path):
     assert data["limits"]["max_num_scheduled_tokens"] == 8
     assert data["limits"]["tokens_per_block"] == 32
     assert data["results"][0]["point"]["isl"] == 8
+    assert data["results"][0]["observed_kv_read_tokens"] == 0
+    assert data["results"][0]["cache_hit_validated"] is True
     assert data["results"][0]["iteration_stats"][0][
         "inflightBatchingStats"]["numContextRequests"] == 1

--- a/tests/unittest/pyexecutor/test_self_benchmark.py
+++ b/tests/unittest/pyexecutor/test_self_benchmark.py
@@ -117,6 +117,13 @@ def test_torch_llm_args_self_benchmark_rejects_attention_dp():
                      self_benchmark_config=SelfBenchmarkConfig())
 
 
+def test_torch_llm_args_self_benchmark_rejects_multi_rank():
+    with pytest.raises(ValueError, match="world_size=1"):
+        TorchLlmArgs(model="dummy",
+                     tensor_parallel_size=2,
+                     self_benchmark_config=SelfBenchmarkConfig())
+
+
 def test_grid_generation_uses_executor_limits():
     config = SelfBenchmarkConfig(
         mode="agg",
@@ -203,6 +210,20 @@ def test_prefill_queue_item_marks_executor_request():
     assert items[0].request.py_self_benchmark_point_id == 0
 
 
+def test_shutdown_finishes_benchmark_without_starting_next_point(tmp_path):
+    output_path = tmp_path / "benchmark.json"
+    config = SelfBenchmarkConfig(mode="prefill",
+                                 output_path=str(output_path),
+                                 warmup_iterations=0)
+    executor = _make_executor(config)
+    executor.is_shutdown = True
+    benchmark = SelfBenchmark(executor)
+
+    assert benchmark.make_prefill_queue_items([], []) == []
+    assert benchmark.active is False
+    assert output_path.exists()
+
+
 def test_prefill_seed_and_measure_requests_share_cache_salt():
     config = SelfBenchmarkConfig(mode="prefill", warmup_iterations=0)
     benchmark = SelfBenchmark(_make_executor(config))
@@ -224,9 +245,9 @@ def test_prefill_seed_and_measure_requests_share_cache_salt():
     measure_items = benchmark.make_prefill_queue_items([], [])
 
     assert seed_items[0].request.input_token_ids == [1, 1, 1, 1]
-    assert seed_items[0].request.cache_salt_id == 123
+    assert seed_items[0].request.cache_salt == "123"
     assert measure_items[0].request.input_token_ids == [1] * 8
-    assert measure_items[0].request.cache_salt_id == 123
+    assert measure_items[0].request.cache_salt == "123"
 
 
 def test_decode_injection_uses_dummy_kv_path():
@@ -316,6 +337,40 @@ def test_observe_iteration_records_cache_hit_validation():
         "expectedKvReadTokens": 4,
         "observedCachedTokens": 4,
         "cacheHitValidated": True,
+    }
+
+
+def test_observe_iteration_records_cache_hit_mismatch_without_skip():
+    config = SelfBenchmarkConfig(mode="prefill", warmup_iterations=0)
+    benchmark = SelfBenchmark(_make_executor(config))
+    point = BenchmarkPoint(point_type="prefill",
+                           index=0,
+                           isl=8,
+                           kv_read_tokens=4)
+    benchmark._current = BenchmarkPointResult(point=point)
+    request = types.SimpleNamespace(is_self_benchmark_request=True,
+                                    py_self_benchmark_point_id=0,
+                                    cached_tokens=0,
+                                    is_dummy=False)
+    stats = {
+        "numQueuedRequests": 0,
+        "inflightBatchingStats": {
+            "numContextRequests": 1,
+        },
+    }
+
+    consumed = benchmark.observe_iteration(_FakeScheduledBatch([request]),
+                                           stats)
+
+    assert consumed is True
+    result = benchmark._results[0]
+    assert result.skipped_reason is None
+    assert result.observed_kv_read_tokens == 0
+    assert result.cache_hit_validated is False
+    assert result.stats[0]["selfBenchmark"] == {
+        "expectedKvReadTokens": 4,
+        "observedCachedTokens": 0,
+        "cacheHitValidated": False,
     }
 
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a self-benchmark mode for serving, with configurable warmup, prefill, decode, and output settings.
  * Requests can now carry self-benchmark metadata so benchmark traffic is tracked consistently across the system.
  * Benchmark results are written out as a structured report after completion.

* **Bug Fixes**
  * Improved handling so benchmark requests are separated from normal traffic and measured correctly.
  * Added validation to prevent unsupported runtime configurations when self-benchmarking is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Adds startup self-benchmarking for the PyTorch executor path. The benchmark runs synthetic prefill and/or decode points inside the scheduler loop, writes the collected iteration FWP metrics to a JSON file.
The goal of this PR is to let the engine profile itself on startup, so that consumers of this - namely Dynamo planner can use this to initialize the perf prediction regression model and make smarter online scaling decisions.  See this equivalent vLLM PR for more details [here](https://github.com/ai-dynamo/dynamo/pull/7779) 

Self Benchmarking is gated by the `SelfBenchmarkConfig`, `trtllm-serve` self-benchmark flags.

## Motivation

In pursuit of intelligent LLM inference autoscaling that can maximize goodput for some SLAs such as max `TTFT`, `TPOT` - Autoscalers like Dynamo Planner aim to make predictions about how a LLM inference server would perform under different deployment configurations and traffic conditions.  

By emitting `ForwardPassMetrics` one can observe the actual wall clock latency for the model worker forward at every iteration of the scheduler.  

The goal of Self-benchmarking is to collect `ForwardPassMetrics` on server start - this will allow downstream consumers like Dynamo Planner to bootstrap performance prediction models with real data and ultimately make more accurate predictions and therefore better scaling decisions.

What makes this feature valuable when implemented in the inference engines themselves, is that we can gather more data a given benchmarking time budget, by skipping actual prefill during decode benchmarking.  We can still measure how decode performs for a given ISL *by using synthetic kv cache block placement*.  Based on our tests, this still gives us an accurate estimate of what decode would look like if prefill had actually run (falling within 3% of FPMs observed with real prefill).

**Callout**: While this is can be considered an 'invasive' change as we mutate some scheduler state, this is gated by the self-benchmarking flags which default to off.

## More on how it works

The benchmark sweeps a configurable grid of operating points:

- Prefill: input sequence lengths / ISLs.
- Decode: context lengths and batch sizes.

## Testing

### TRT-LLM Self-Benchmark PR Results

Common setup:
- Runtime image: `public.ecr.aws/m4g4v5k2/sachalm-test/d-test:trt-selfbenchmarking`
- Model: `Qwen/Qwen3-0.6B`
- Offline HF cache: `HF_HOME=/model-store`, model loaded from `/model-store/hub`
- Attention backend: `FLASHINFER`
- CUDA graphs: enabled via the qwen3 TRT-LLM config
- Benchmark grid: `prefill=2`, `kv-read=2`, `decode-length=2`, `decode-batch=2`, `warmup=0`

| Experiment | Topology | Result | Artifact |
|---|---:|---|---|
| `01-agg-tp1` | Aggregated, TP1 | Complete, valid, 6 points: 2 prefill + 4 decode | `experiments/self-benchmarking/trtllm/results/01-agg-tp1-trtllm_self_benchmark.json` |
| `02-agg-tp2` | Aggregated, TP2 | Complete, valid, 6 points: 2 prefill + 4 decode | `experiments/self-benchmarking/trtllm/results/02-agg-tp2-trtllm_self_benchmark.json` |
| `07-disagg-tp4` | Disaggregated, TP4 prefill + TP4 decode | Complete, valid. Decode emitted 4 decode points; prefill emitted 2 prefill points | `experiments/self-benchmarking/trtllm/results/07-disagg-tp4-decode-trtllm_self_benchmark.json`, `experiments/self-benchmarking/trtllm/results/07-disagg-tp4-prefill-trtllm_self_benchmark.json` |



## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.