### PR TITLE
[None][feat] VisualGen: TransformerEngine FP8 attention backend + NVENC/libx264 encode fallback

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/attention_backend/te.py
+++ b/tensorrt_llm/_torch/visual_gen/attention_backend/te.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Diffusion TransformerEngine FP8 Attention Backend
+
+FP8 self/cross-attention for visual generation (diffusion) models via
+TransformerEngine's ``DotProductAttention`` under ``fp8_autocast`` with a
+``DelayedScaling(fp8_dpa=True, fp8_mha=True)`` recipe. Ported from the vfly
+``te-fp8`` reference (3rdparty/vfly/vfly/ops/attention.py).
+
+Declares NHD layout ([B, S, H, D]) which maps directly to TE's
+``qkv_format="bshd"`` — avoids the bhsd->bshd transpose. The op is
+``torch.compiler.disable``-d because TE FP8 modules graph-break under
+torch.compile (matches vfly).
+"""
+
+import math
+from typing import Optional
+
+import torch
+
+from ...attention_backend.interface import PredefinedAttentionMask
+from .interface import AttentionBackend, AttentionTensorLayout
+
+try:
+    from transformer_engine.common.recipe import DelayedScaling
+    from transformer_engine.pytorch import DotProductAttention, fp8_autocast
+except ImportError:  # TE absent (e.g. client-only env); fail at construction, not import.
+    DotProductAttention = None
+    DelayedScaling = None
+    fp8_autocast = None
+
+
+class TEAttention(AttentionBackend):
+    """FP8 attention via TransformerEngine ``DotProductAttention``.
+
+    No KV cache (diffusion: full recompute each step). FP8 is always enabled —
+    this backend exists specifically to get FP8 attention; for BF16 use VANILLA.
+    """
+
+    def __init__(
+        self,
+        layer_idx: int = 0,
+        num_heads: int = 8,
+        head_dim: int = 64,
+        num_kv_heads: Optional[int] = None,
+        dtype: Optional[torch.dtype] = None,
+        **kwargs,
+    ):
+        if DotProductAttention is None:
+            raise ImportError(
+                "TransformerEngine is required for the TE attention backend "
+                "(transformer_engine.pytorch.DotProductAttention not importable)."
+            )
+        self.layer_idx = layer_idx
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.num_kv_heads = num_kv_heads or num_heads
+        self.dtype = dtype
+        self.scale = 1.0 / math.sqrt(head_dim)
+        # NHD == [B, S, H, D] == TE qkv_format="bshd" (no transpose needed).
+        self._preferred_layout = AttentionTensorLayout.NHD
+        self.recipe = DelayedScaling(fp8_dpa=True, fp8_mha=True)
+        # DotProductAttention is stateful (amax history); rebuild only when the
+        # (heads, dim, gqa, mask) traits change — mirrors vfly's lazy init.
+        self._attn_op = None
+        self._traits = None
+
+    def _lazy_init(self, num_gqa_groups: Optional[int], attn_mask_type: str) -> None:
+        traits = (self.num_heads, self.head_dim, num_gqa_groups, attn_mask_type)
+        if traits != self._traits:
+            self._attn_op = DotProductAttention(
+                self.num_heads,
+                self.head_dim,
+                num_gqa_groups=num_gqa_groups,
+                attn_mask_type=attn_mask_type,
+                softmax_scale=self.scale,
+                qkv_format="bshd",
+            )
+            self._traits = traits
+
+    @torch.compiler.disable
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        *,
+        attention_mask: PredefinedAttentionMask = PredefinedAttentionMask.FULL,
+        key_padding_mask: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """FP8 attention. q/k/v are NHD ([B, S, H, D]); returns [B, S, H, D]."""
+        assert q.dim() == 4 and q.shape[-1] == self.head_dim, (
+            f"Invalid q shape: expected [B, S, H, D={self.head_dim}], got {q.shape}"
+        )
+        if key_padding_mask is not None:
+            # The Wan T2V forward (full self-attn + fixed-length cross-attn) does
+            # not pass a padding mask; defer this rather than risk wrong masking.
+            raise NotImplementedError("TE attention backend does not yet support key_padding_mask.")
+
+        is_causal = attention_mask == PredefinedAttentionMask.CAUSAL
+        enable_gqa = self.num_heads != self.num_kv_heads
+        num_gqa_groups = k.shape[-2] if enable_gqa else None
+        attn_mask_type = "causal" if is_causal else "no_mask"
+
+        self._lazy_init(num_gqa_groups, attn_mask_type)
+
+        with fp8_autocast(enabled=True, fp8_recipe=self.recipe):
+            out = self._attn_op(q, k, v, attention_mask=None)
+        # TE returns [B, S, H*D]; restore [B, S, H, D] (NHD).
+        return out.unflatten(-1, (self.num_heads, self.head_dim))
+
+    @property
+    def preferred_layout(self) -> AttentionTensorLayout:
+        return self._preferred_layout
+
+    @classmethod
+    def support_fused_qkv(cls) -> bool:
+        return False

--- a/tensorrt_llm/_torch/visual_gen/attention_backend/utils.py
+++ b/tensorrt_llm/_torch/visual_gen/attention_backend/utils.py
@@ -68,6 +68,11 @@ def get_visual_gen_attention_backend(
         return FlashAttn4Attention
     elif backend_name == "CUTEDSL":
         return CuTeDSLAttention
+    elif backend_name == "TE":
+        # Lazy import: TransformerEngine is only needed for the FP8 attn path.
+        from .te import TEAttention
+
+        return TEAttention
     else:
         # Default to VANILLA for maximum compatibility
         return VanillaAttention

--- a/tensorrt_llm/media/encoding.py
+++ b/tensorrt_llm/media/encoding.py
@@ -141,20 +141,13 @@ class _FfmpegCliEncoder(_VideoEncoder):
                 audio_output_args = ["-c:a", "aac", "-shortest"]
 
             ffmpeg_path = _get_ffmpeg_path()
-            cmd = [
-                ffmpeg_path,
-                "-y",
-                "-f",
-                "rawvideo",
-                "-pix_fmt",
-                "rgb24",
-                "-s",
-                f"{width}x{height}",
-                "-r",
-                str(frame_rate),
-                "-i",
-                "-",
-                *audio_input_args,
+            # Prototype: TRTLLM_VIDEO_NVENC=1 attempts the NVENC H.264 hardware
+            # encoder (-cq + named presets p1..p7), then falls back to CPU libx264
+            # if NVENC can't open a session. NB: datacenter GPUs (A100/H100, and
+            # GB200/GB300 Blackwell) have NO usable NVENC engine -> the attempt
+            # fails with "unsupported device" and we fall back. Kept for GPUs that
+            # do have NVENC; on GB300 this is effectively libx264.
+            libx264_args = [
                 "-c:v",
                 "libx264",
                 "-pix_fmt",
@@ -163,23 +156,55 @@ class _FfmpegCliEncoder(_VideoEncoder):
                 "medium",
                 "-crf",
                 "23",
-                *audio_output_args,
-                output_path,
             ]
+            nvenc_args = ["-c:v", "h264_nvenc", "-pix_fmt", "yuv420p", "-preset", "p4", "-cq", "23"]
+            want_nvenc = os.environ.get("TRTLLM_VIDEO_NVENC", "0") == "1"
+            raw_frames = video_np.tobytes()
 
-            try:
-                process = subprocess.Popen(
-                    cmd,
-                    stdin=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                )
-                raw_frames = video_np.tobytes()
-                _, stderr = process.communicate(input=raw_frames)
-                if process.returncode != 0:
-                    raise RuntimeError(f"ffmpeg encoding failed: {stderr.decode()}")
-            except FileNotFoundError:
-                raise RuntimeError("ffmpeg not found. Install ffmpeg for video encoding.")
+            def _run_ffmpeg(codec_args: list) -> Tuple[int, bytes]:
+                cmd = [
+                    ffmpeg_path,
+                    "-y",
+                    "-f",
+                    "rawvideo",
+                    "-pix_fmt",
+                    "rgb24",
+                    "-s",
+                    f"{width}x{height}",
+                    "-r",
+                    str(frame_rate),
+                    "-i",
+                    "-",
+                    *audio_input_args,
+                    *codec_args,
+                    *audio_output_args,
+                    output_path,
+                ]
+                try:
+                    proc = subprocess.Popen(
+                        cmd,
+                        stdin=subprocess.PIPE,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                    )
+                    _, err = proc.communicate(input=raw_frames)
+                    return proc.returncode, err
+                except FileNotFoundError:
+                    raise RuntimeError("ffmpeg not found. Install ffmpeg for video encoding.")
+
+            if want_nvenc:
+                rc, stderr = _run_ffmpeg(nvenc_args)
+                if rc != 0:
+                    logger.warning(
+                        "h264_nvenc encode failed (rc=%s); falling back to libx264. ffmpeg: %s",
+                        rc,
+                        stderr.decode(errors="replace")[-300:],
+                    )
+                    rc, stderr = _run_ffmpeg(libx264_args)
+            else:
+                rc, stderr = _run_ffmpeg(libx264_args)
+            if rc != 0:
+                raise RuntimeError(f"ffmpeg encoding failed: {stderr.decode(errors='replace')}")
 
         logger.info(f"Saved video{' with audio' if audio is not None else ''} to {output_path}")
         return output_path
@@ -385,6 +410,8 @@ def resolve_video_format(output_format) -> Tuple[str, str]:
         )
     elif output_format == "avi":
         return "avi", ".avi"
+    elif output_format == "raw":
+        return "raw", ".rgb.bin"
     elif output_format == "auto":
         if _check_ffmpeg_available():
             return "mp4", ".mp4"
@@ -581,6 +608,22 @@ def save_video(
 
     if format in ("mp4", "avi"):
         return _save_encoded_video(video, audio, output_path, frame_rate, audio_sample_rate)
+    if format == "raw":
+        # No encoding: dump uint8 RGB bytes directly (T*H*W*3 layout).
+        # Audio is dropped — raw mode only carries video pixel data.
+        tensor = video
+        if hasattr(tensor, "detach"):
+            tensor = tensor.detach()
+        if hasattr(tensor, "cpu"):
+            tensor = tensor.cpu()
+        if getattr(tensor, "dtype", None) is not None and tensor.dtype != torch.uint8:
+            if tensor.dtype.is_floating_point:
+                tensor = (tensor.clamp(0, 1) * 255.0).to(torch.uint8)
+            else:
+                tensor = tensor.to(torch.uint8)
+        with open(output_path, "wb") as f:
+            f.write(tensor.contiguous().numpy().tobytes())
+        return output_path
     logger.warning(f"Unsupported video format: {format}, defaulting to mp4")
     output_path = output_path.rsplit(".", 1)[0] + ".mp4"
     return _save_encoded_video(video, audio, output_path, frame_rate, audio_sample_rate)

--- a/tensorrt_llm/visual_gen/args.py
+++ b/tensorrt_llm/visual_gen/args.py
@@ -94,10 +94,10 @@ SparseAttentionConfig = Annotated[
 class AttentionConfig(StrictBaseModel):
     """Configuration for Attention layers."""
 
-    backend: Literal["VANILLA", "TRTLLM", "FA4", "CUTEDSL"] = Field(
+    backend: Literal["VANILLA", "TRTLLM", "FA4", "CUTEDSL", "TE"] = Field(
         "VANILLA",
         status="prototype",
-        description="Attention backend: VANILLA (PyTorch SDPA), TRTLLM, FA4, CUTEDSL",
+        description="Attention backend: VANILLA (PyTorch SDPA), TRTLLM, FA4, CUTEDSL, TE (TransformerEngine FP8)",
     )
     quant_attention_config: Optional[QuantAttentionConfig] = Field(
         None,


### PR DESCRIPTION
## Summary

Two independent videogen improvements, both off by default and non-breaking.

### 1. TransformerEngine FP8 attention backend (`attention_backend: TE`)

Adds `tensorrt_llm/_torch/visual_gen/attention_backend/te.py`: a new
attention backend that routes through `transformer_engine.pytorch.DotProductAttention`
under `fp8_autocast(DelayedScaling(fp8_dpa=True, fp8_mha=True))`.

On Blackwell (GB200/GB300), this dispatches to cuDNN Flash Attention FP8,
which uses SM100a hardware-specific tiling and memory access patterns.
Measured on GB300 with Wan2.2-T2V-A14B (MLPerf offline):

| Backend | QPS (DP4) | vs MLPerf v6.0 |
|---------|-----------|----------------|
| Sage/TRTLLM kernel | 0.0254 | -30.6% |
| **TE FP8 (cuDNN Flash Attn)** | **0.0368** | **+0.5% (parity)** |

Per-step latency: 7.6 s (Sage) -> 5.4 s (TE). VBench accuracy unaffected
(Mean(6) = 0.6975, MLPerf threshold >= 0.691).

**Implementation notes:**
- `@torch.compiler.disable` required: TE's `fp8_autocast` context manager
  causes graph breaks under `torch.compile`
- Input is NHD layout (WanPipeline convention); backend reshapes to `bshd`
  as expected by TE's `DotProductAttention`
- Lazy import in `utils.py` — TransformerEngine is only pulled in when
  `backend: TE` is selected; no hard dependency otherwise
- Registered as `"TE"` in `AttentionConfig.backend` Literal

### 2. NVENC H.264 with libx264 fallback (`TRTLLM_VIDEO_NVENC=1`)

Refactors `_FfmpegCliEncoder._encode_video()` to extract a `_run_ffmpeg()`
helper, then adds an opt-in (`TRTLLM_VIDEO_NVENC=1`) that attempts
`h264_nvenc` first and falls back to `libx264` on failure (e.g.
`OpenEncodeSessionEx: unsupported device` on datacenter GPUs with no
hardware encoder).

Also adds a `"raw"` output format that dumps uncompressed uint8 RGB bytes
to disk, bypassing ffmpeg entirely (useful for offline benchmark pipelines
that decode separately).

Default behavior (libx264, no env var needed) is unchanged.

## Files changed

| File | Change |
|------|--------|
| `tensorrt_llm/_torch/visual_gen/attention_backend/te.py` | New — TEAttention backend |
| `tensorrt_llm/_torch/visual_gen/attention_backend/utils.py` | Register "TE" dispatch |
| `tensorrt_llm/visual_gen/args.py` | Add "TE" to AttentionConfig.backend Literal |
| `tensorrt_llm/media/encoding.py` | NVENC + libx264 fallback + raw format |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced TransformerEngine FP8 attention backend for enhanced performance
  * Added NVENC H.264 video encoding support with automatic CPU fallback
  * Introduced raw RGB video format output option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->