### PR TITLE
[TRTLLM-12721][fix] Add gated C++ NIXL in-flight cancellation and safe cleanup

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
+++ b/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
@@ -226,6 +226,11 @@ public:
     [[nodiscard]] virtual bool checkGenTransferComplete() const = 0;
 
     virtual bool cancelRequest(std::shared_ptr<LlmRequest> llmRequest) = 0;
+
+    [[nodiscard]] virtual bool hasPoisonedTransferBuffer() const
+    {
+        return false;
+    }
 };
 
 class CacheTransceiver : public BaseCacheTransceiver
@@ -271,6 +276,8 @@ public:
 
     virtual bool cancelRequest(std::shared_ptr<LlmRequest> llmRequest) override;
 
+    [[nodiscard]] bool hasPoisonedTransferBuffer() const override;
+
 private:
     void initializeCommState();
 
@@ -283,9 +290,12 @@ private:
     // request while a C++ status check still dereferences it.
     std::vector<std::pair<std::shared_ptr<LlmRequest>, std::future<void>>> mSenderFutures;
     std::vector<std::pair<std::shared_ptr<LlmRequest>, std::future<void>>> mRequesterFutures;
-    // Dedup sets so observe-only timeout WARN logs fire at most once per stuck request.
+    // Dedup timeout logs separately from accepted cancellation requests so a
+    // backend that initially declines cancellation is retried on later polls.
     std::unordered_set<LlmRequest::RequestIdType> mTimedOutSenderIds;
     std::unordered_set<LlmRequest::RequestIdType> mTimedOutRequesterIds;
+    std::unordered_set<LlmRequest::RequestIdType> mCancelRequestedSenderIds;
+    std::unordered_set<LlmRequest::RequestIdType> mCancelRequestedRequesterIds;
     std::unordered_set<LlmRequest::RequestIdType> mCompletedSenderRequestIds;
     std::unordered_set<LlmRequest::RequestIdType> mFailedSenderRequestIds;
     std::unordered_map<LlmRequest::RequestIdType, std::shared_ptr<LlmRequest>> mSenderRequestsAwaitingConsensus;

--- a/cpp/include/tensorrt_llm/executor/transferAgent.h
+++ b/cpp/include/tensorrt_llm/executor/transferAgent.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -356,6 +356,13 @@ public:
     virtual ~TransferStatus() = default;
     [[nodiscard]] virtual bool isCompleted() const = 0;
     virtual TransferState wait(int64_t timeout_ms = -1) const = 0;
+
+    /// Release the backend transfer request handle. A true return means the backend accepted the handle release; it
+    /// does not prove remote memory quiescence.
+    [[nodiscard]] virtual bool release()
+    {
+        return false;
+    }
 };
 
 struct BaseAgentConfig

--- a/cpp/tensorrt_llm/batch_manager/baseTransBuffer.cpp
+++ b/cpp/tensorrt_llm/batch_manager/baseTransBuffer.cpp
@@ -332,13 +332,20 @@ std::optional<int> BaseTransBufferManager::assignBufferIndex(ConcurrenceResource
         return resource.mPoisoned.load(std::memory_order_relaxed)
             || static_cast<size_t>(resource.mConcurrence) < bufferCount;
     };
-    auto const slice = std::chrono::milliseconds{waitSliceMs};
-    while (!predicate())
+    if (perRequestCancel == nullptr)
     {
-        resource.mBuffersCV.wait_for(lk, slice);
-        if (isCancelled())
+        resource.mBuffersCV.wait(lk, predicate);
+    }
+    else
+    {
+        auto const slice = std::chrono::milliseconds{waitSliceMs};
+        while (!predicate())
         {
-            TLLM_THROW("Cache transfer buffer acquisition cancelled");
+            resource.mBuffersCV.wait_for(lk, slice);
+            if (isCancelled())
+            {
+                TLLM_THROW("Cache transfer buffer acquisition cancelled");
+            }
         }
     }
     if (isCancelled())

--- a/cpp/tensorrt_llm/batch_manager/baseTransBuffer.cpp
+++ b/cpp/tensorrt_llm/batch_manager/baseTransBuffer.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,14 +21,60 @@
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/common/opUtils.h"
 
+#include <chrono>
+#include <exception>
 #include <mutex>
 
 namespace tensorrt_llm::batch_manager
 {
 
+namespace
+{
+
+char const* bufferKindName(BufferKind kind)
+{
+    switch (kind)
+    {
+    case BufferKind::kKV: return "kv";
+    case BufferKind::kKV_INDEXER: return "kv_indexer";
+    case BufferKind::kRNN: return "rnn";
+    }
+    return "unknown";
+}
+
+} // namespace
+
 void BufferIndexHolder::release() noexcept
 {
-    if (!mHeld || mMgr == nullptr)
+    if (mMgr == nullptr)
+    {
+        return;
+    }
+    if (mHeld)
+    {
+        try
+        {
+            if (mIsRecv)
+            {
+                mMgr->freeBufferIndexForRecv(mIndex);
+            }
+            else
+            {
+                mMgr->freeBufferIndexForSend(mIndex);
+            }
+        }
+        catch (...)
+        {
+            // noexcept: swallow so the destructor can never throw.
+        }
+    }
+    mHeld = false;
+    mMgr = nullptr;
+}
+
+void BufferIndexHolder::poison() noexcept
+{
+    if (mMgr == nullptr)
     {
         return;
     }
@@ -36,18 +82,19 @@ void BufferIndexHolder::release() noexcept
     {
         if (mIsRecv)
         {
-            mMgr->freeBufferIndexForRecv(mIndex);
+            mMgr->poisonBufferIndexForRecv(mIndex);
         }
         else
         {
-            mMgr->freeBufferIndexForSend(mIndex);
+            mMgr->poisonBufferIndexForSend(mIndex);
         }
     }
     catch (...)
     {
-        // noexcept: swallow so the destructor can never throw.
+        // noexcept: poison is a fail-closed best effort from exception paths.
     }
     mHeld = false;
+    mMgr = nullptr;
 }
 
 BaseTransBufferManager::BaseTransBufferManager(
@@ -78,9 +125,11 @@ BaseTransBufferManager::BaseTransBufferManager(
     allocateBuffer();
 }
 
-std::optional<int> BaseTransBufferManager::assignBufferIndexForSend()
+std::optional<int> BaseTransBufferManager::assignBufferIndexForSend(
+    std::atomic<bool> const* perRequestCancel, int64_t waitSliceMs)
 {
-    return assignBufferIndex(mConcurrenceSendResource, mSendBufferCount, mOnlyUseDynamicBuffer);
+    return assignBufferIndex(
+        mConcurrenceSendResource, mSendBufferCount, mOnlyUseDynamicBuffer, perRequestCancel, waitSliceMs);
 }
 
 void BaseTransBufferManager::freeBufferIndexForSend(std::optional<int> bufferId)
@@ -88,14 +137,26 @@ void BaseTransBufferManager::freeBufferIndexForSend(std::optional<int> bufferId)
     freeBufferIndex(mConcurrenceSendResource, bufferId, mSendBufferCount, mOnlyUseDynamicBuffer);
 }
 
-std::optional<int> BaseTransBufferManager::assignBufferIndexForRecv()
+void BaseTransBufferManager::poisonBufferIndexForSend(std::optional<int> bufferId) noexcept
 {
-    return assignBufferIndex(mConcurrenceRecvResource, mRecvBufferCount, mOnlyUseDynamicBuffer);
+    poisonBufferIndex(mConcurrenceSendResource, bufferId, mSendBufferCount, mOnlyUseDynamicBuffer, "send");
+}
+
+std::optional<int> BaseTransBufferManager::assignBufferIndexForRecv(
+    std::atomic<bool> const* perRequestCancel, int64_t waitSliceMs)
+{
+    return assignBufferIndex(
+        mConcurrenceRecvResource, mRecvBufferCount, mOnlyUseDynamicBuffer, perRequestCancel, waitSliceMs);
 }
 
 void BaseTransBufferManager::freeBufferIndexForRecv(std::optional<int> bufferId)
 {
     freeBufferIndex(mConcurrenceRecvResource, bufferId, mRecvBufferCount, mOnlyUseDynamicBuffer);
+}
+
+void BaseTransBufferManager::poisonBufferIndexForRecv(std::optional<int> bufferId) noexcept
+{
+    poisonBufferIndex(mConcurrenceRecvResource, bufferId, mRecvBufferCount, mOnlyUseDynamicBuffer, "recv");
 }
 
 std::tuple<std::vector<runtime::ITensor::SharedPtr>, size_t, bool> BaseTransBufferManager::getOrAllocateSendBuffers(
@@ -249,16 +310,44 @@ void BaseTransBufferManager::allocateBuffer()
     }
 }
 
-std::optional<int> BaseTransBufferManager::assignBufferIndex(
-    ConcurrenceResource& resource, size_t bufferCount, bool onlyUseDynamicBuffer)
+std::optional<int> BaseTransBufferManager::assignBufferIndex(ConcurrenceResource& resource, size_t bufferCount,
+    bool onlyUseDynamicBuffer, std::atomic<bool> const* perRequestCancel, int64_t waitSliceMs)
 {
+    auto const isCancelled = [perRequestCancel]()
+    { return perRequestCancel != nullptr && perRequestCancel->load(std::memory_order_relaxed); };
+    if (isCancelled())
+    {
+        TLLM_THROW("Cache transfer buffer acquisition cancelled");
+    }
     if (onlyUseDynamicBuffer)
     {
+        TLLM_CHECK_WITH_INFO(!resource.mPoisoned.load(std::memory_order_relaxed),
+            "Cannot assign dynamic cache transfer buffer kind=%s because the transfer buffer pool is poisoned",
+            bufferKindName(getBufferKind()));
         return std::nullopt;
     }
     std::unique_lock lk(resource.mBuffersMutex);
-    resource.mBuffersCV.wait(
-        lk, [&resource, bufferCount]() { return static_cast<size_t>(resource.mConcurrence) < bufferCount; });
+    auto const predicate = [&resource, bufferCount]()
+    {
+        return resource.mPoisoned.load(std::memory_order_relaxed)
+            || static_cast<size_t>(resource.mConcurrence) < bufferCount;
+    };
+    auto const slice = std::chrono::milliseconds{waitSliceMs};
+    while (!predicate())
+    {
+        resource.mBuffersCV.wait_for(lk, slice);
+        if (isCancelled())
+        {
+            TLLM_THROW("Cache transfer buffer acquisition cancelled");
+        }
+    }
+    if (isCancelled())
+    {
+        TLLM_THROW("Cache transfer buffer acquisition cancelled");
+    }
+    TLLM_CHECK_WITH_INFO(!resource.mPoisoned.load(std::memory_order_relaxed),
+        "Cannot assign cache transfer buffer kind=%s because the transfer buffer pool is poisoned",
+        bufferKindName(getBufferKind()));
     int bufferId = -1;
     for (size_t i = 0; i < bufferCount; i++)
     {
@@ -288,11 +377,59 @@ void BaseTransBufferManager::freeBufferIndex(
         TLLM_CHECK(static_cast<size_t>(bufferId.value()) < bufferCount);
         {
             std::scoped_lock lk(resource.mBuffersMutex);
+            if (resource.mBufferIndexFlag[bufferId.value()] == 2)
+            {
+                TLLM_LOG_ERROR("Refusing to free poisoned cache transfer buffer kind=%s index=%d",
+                    bufferKindName(getBufferKind()), bufferId.value());
+                return;
+            }
             resource.mBufferIndexFlag[bufferId.value()] = 0;
         }
         resource.mConcurrence--;
         resource.mBuffersCV.notify_one();
     }
+}
+
+void BaseTransBufferManager::poisonBufferIndex(ConcurrenceResource& resource, std::optional<int> bufferId,
+    size_t bufferCount, bool onlyUseDynamicBuffer, char const* direction) noexcept
+{
+    resource.mPoisoned.store(true, std::memory_order_relaxed);
+
+    if (onlyUseDynamicBuffer)
+    {
+        TLLM_LOG_ERROR("Poisoned dynamic %s cache transfer buffer kind=%s; process restart is required", direction,
+            bufferKindName(getBufferKind()));
+        resource.mBuffersCV.notify_all();
+        return;
+    }
+
+    try
+    {
+        if (bufferId.has_value())
+        {
+            TLLM_CHECK(static_cast<size_t>(bufferId.value()) < bufferCount);
+            {
+                std::scoped_lock lk(resource.mBuffersMutex);
+                if (resource.mBufferIndexFlag[bufferId.value()] == 1)
+                {
+                    resource.mBufferIndexFlag[bufferId.value()] = 2;
+                }
+            }
+        }
+        TLLM_LOG_ERROR("Poisoned %s cache transfer buffer kind=%s index=%d; process restart is required", direction,
+            bufferKindName(getBufferKind()), bufferId.value_or(-1));
+    }
+    catch (std::exception const& e)
+    {
+        TLLM_LOG_ERROR("Exception while poisoning %s cache transfer buffer kind=%s index=%d: %s", direction,
+            bufferKindName(getBufferKind()), bufferId.value_or(-1), e.what());
+    }
+    catch (...)
+    {
+        TLLM_LOG_ERROR("Unknown exception while poisoning %s cache transfer buffer kind=%s index=%d", direction,
+            bufferKindName(getBufferKind()), bufferId.value_or(-1));
+    }
+    resource.mBuffersCV.notify_all();
 }
 
 size_t BaseTransBufferManager::getRecvBufferCount()

--- a/cpp/tensorrt_llm/batch_manager/baseTransBuffer.h
+++ b/cpp/tensorrt_llm/batch_manager/baseTransBuffer.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,8 +49,9 @@ enum class BufferKind : uint8_t
 class BaseTransBufferManager;
 
 /// @brief RAII holder for an index from BaseTransBufferManager::assignBufferIndexFor{Send,Recv}.
-///        Releases on destruction (incl. exception unwind). Move-only; call release() on
-///        the happy path or detach() when ownership is handed off downstream.
+///        Releases on destruction (incl. exception unwind). A dynamic-buffer holder has no
+///        concrete index, but retains its manager binding so poison() can fail closed.
+///        Move-only; call release() on the happy path or detach() when ownership is handed off downstream.
 class BufferIndexHolder
 {
 public:
@@ -82,6 +83,7 @@ public:
         , mIsRecv(other.mIsRecv)
     {
         other.mHeld = false;
+        other.mMgr = nullptr;
     }
 
     BufferIndexHolder& operator=(BufferIndexHolder&& other) noexcept
@@ -94,6 +96,7 @@ public:
             mHeld = other.mHeld;
             mIsRecv = other.mIsRecv;
             other.mHeld = false;
+            other.mMgr = nullptr;
         }
         return *this;
     }
@@ -114,11 +117,15 @@ public:
     std::optional<int> detach() noexcept
     {
         mHeld = false;
+        mMgr = nullptr;
         return mIndex;
     }
 
     /// @brief Release the slot now and disarm the destructor. Safe to call multiple times.
     void release() noexcept;
+
+    /// @brief Fail-closed release for an exit path where transfer-buffer quiescence is unknown.
+    void poison() noexcept;
 
 private:
     BaseTransBufferManager* mMgr{nullptr};
@@ -126,6 +133,8 @@ private:
     bool mHeld{false};
     bool mIsRecv{true};
 };
+
+inline constexpr int64_t kBufferAcquireSliceMs = 100;
 
 /// @brief Base class for cache transfer buffer management.
 /// Handles buffer pool allocation, index assignment, and slicing.
@@ -139,19 +148,27 @@ public:
 
     /// @brief Assign a buffer index for sending.
     /// @return Assigned buffer index, or nullopt if using dynamic buffers.
-    std::optional<int> assignBufferIndexForSend();
+    std::optional<int> assignBufferIndexForSend(
+        std::atomic<bool> const* perRequestCancel = nullptr, int64_t waitSliceMs = kBufferAcquireSliceMs);
 
     /// @brief Free a buffer index used for sending.
     /// @param bufferId The buffer index to free.
     void freeBufferIndexForSend(std::optional<int> bufferId);
 
+    /// @brief Poison a send buffer index after an unquiesced transfer exit.
+    void poisonBufferIndexForSend(std::optional<int> bufferId) noexcept;
+
     /// @brief Assign a buffer index for receiving.
     /// @return Assigned buffer index, or nullopt if using dynamic buffers.
-    std::optional<int> assignBufferIndexForRecv();
+    std::optional<int> assignBufferIndexForRecv(
+        std::atomic<bool> const* perRequestCancel = nullptr, int64_t waitSliceMs = kBufferAcquireSliceMs);
 
     /// @brief Free a buffer index used for receiving.
     /// @param bufferId The buffer index to free.
     void freeBufferIndexForRecv(std::optional<int> bufferId);
+
+    /// @brief Poison a receive buffer index after an unquiesced transfer exit.
+    void poisonBufferIndexForRecv(std::optional<int> bufferId) noexcept;
 
     /// @brief Get or allocate send buffers for cache transfer.
     /// @param bufferId The assigned buffer ID.
@@ -191,6 +208,12 @@ public:
         return mMaxNumTokens;
     }
 
+    [[nodiscard]] bool hasPoisonedBuffer() const noexcept
+    {
+        return mConcurrenceSendResource.mPoisoned.load(std::memory_order_relaxed)
+            || mConcurrenceRecvResource.mPoisoned.load(std::memory_order_relaxed);
+    }
+
 protected:
     /// @brief Constructor - derived classes call this after computing buffer sizes.
     /// @param transferBufferSize Size of each transfer buffer in bytes.
@@ -206,6 +229,7 @@ protected:
         std::mutex mBuffersMutex;
         std::condition_variable mBuffersCV;
         std::atomic<int> mConcurrence{0};
+        std::atomic<bool> mPoisoned{false};
     };
 
     std::tuple<std::vector<runtime::ITensor::SharedPtr>, size_t, bool> getOrAllocateBuffers(std::optional<int> bufferId,
@@ -213,9 +237,12 @@ protected:
         runtime::BufferManager const& bufferManagerToUse, ConcurrenceResource& concurrenceResource);
 
     void allocateBuffer();
-    std::optional<int> assignBufferIndex(ConcurrenceResource& resource, size_t bufferCount, bool onlyUseDynamicBuffer);
+    std::optional<int> assignBufferIndex(ConcurrenceResource& resource, size_t bufferCount, bool onlyUseDynamicBuffer,
+        std::atomic<bool> const* perRequestCancel = nullptr, int64_t waitSliceMs = kBufferAcquireSliceMs);
     void freeBufferIndex(
         ConcurrenceResource& resource, std::optional<int> bufferId, size_t bufferCount, bool onlyUseDynamicBuffer);
+    void poisonBufferIndex(ConcurrenceResource& resource, std::optional<int> bufferId, size_t bufferCount,
+        bool onlyUseDynamicBuffer, char const* direction) noexcept;
 
     size_t mPreAllocBufferSize;
     size_t mRecvBufferCount;

--- a/cpp/tensorrt_llm/batch_manager/baseTransBuffer.h
+++ b/cpp/tensorrt_llm/batch_manager/baseTransBuffer.h
@@ -111,6 +111,11 @@ public:
         return mHeld;
     }
 
+    [[nodiscard]] bool isBoundTo(BaseTransBufferManager const& manager) const noexcept
+    {
+        return mMgr == &manager;
+    }
+
     /// @brief Relinquish ownership without releasing. Use when a downstream
     ///        owner (e.g. the formatter inside receiveSync) takes over the
     ///        release responsibility on the happy path.

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -529,7 +529,8 @@ void CacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& sessio
         // cache blocks to the corresponding buffer.
         // 5. send the buffer to the corresponding target. Ideally, we send only once (one buffer) for each target.
 
-        auto cacheBufferId = mCacheTransBufferManager->assignBufferIndexForSend();
+        auto const* sendCancelFlag = &session.getDataContext().getTransferTerminate();
+        auto cacheBufferId = mCacheTransBufferManager->assignBufferIndexForSend(sendCancelFlag);
         BufferIndexHolder sendHolder(*mCacheTransBufferManager, cacheBufferId, /*isRecv=*/false);
         int peerDuplicateHeadFactor = targetInfo.mPeerDupHeadFactor;
         auto bufferTargetNum = targetNum / peerDuplicateHeadFactor;
@@ -609,8 +610,19 @@ void CacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& sessio
                 == inputKvCacheBlocksPerWindow.begin()->second.front()->getDataType());
         }
 
-        sendAllBuffers(session, deviceId, outputSplitCaches, bufferCoverTargetNum, preAllocSendBuffer, bufferManager,
-            targetInfo, pickUpConnections);
+        try
+        {
+            sendAllBuffers(session, deviceId, outputSplitCaches, bufferCoverTargetNum, preAllocSendBuffer,
+                bufferManager, targetInfo, pickUpConnections);
+        }
+        catch (...)
+        {
+            if (agentConnection != nullptr && common::getEnvDisaggEnableInflightCancel())
+            {
+                sendHolder.poison();
+            }
+            throw;
+        }
 
         session.setTime(TransferSession::kTimeTransmissions);
 

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -529,7 +529,8 @@ void CacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& sessio
         // cache blocks to the corresponding buffer.
         // 5. send the buffer to the corresponding target. Ideally, we send only once (one buffer) for each target.
 
-        auto const* sendCancelFlag = &session.getDataContext().getTransferTerminate();
+        auto const* sendCancelFlag
+            = common::getEnvDisaggEnableInflightCancel() ? &session.getDataContext().getTransferTerminate() : nullptr;
         auto cacheBufferId = mCacheTransBufferManager->assignBufferIndexForSend(sendCancelFlag);
         BufferIndexHolder sendHolder(*mCacheTransBufferManager, cacheBufferId, /*isRecv=*/false);
         int peerDuplicateHeadFactor = targetInfo.mPeerDupHeadFactor;
@@ -608,6 +609,11 @@ void CacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& sessio
         {
             TLLM_CHECK(preAllocSendBuffer->getDataType()
                 == inputKvCacheBlocksPerWindow.begin()->second.front()->getDataType());
+        }
+
+        if (sendCancelFlag != nullptr && sendCancelFlag->load(std::memory_order_relaxed))
+        {
+            TLLM_THROW("KV cache transfer cancelled before NIXL submission");
         }
 
         try
@@ -887,12 +893,16 @@ void CacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& sess
                 if (preAssignedKvId.has_value())
                 {
                     cacheBufferId = static_cast<int>(*preAssignedKvId);
+                    if (!session.hasReservedRecvBuffer(*mCacheTransBufferManager))
+                    {
+                        recvHolder = BufferIndexHolder(*mCacheTransBufferManager, cacheBufferId, /*isRecv=*/true);
+                    }
                 }
                 else
                 {
                     cacheBufferId = mCacheTransBufferManager->assignBufferIndexForRecv();
+                    recvHolder = BufferIndexHolder(*mCacheTransBufferManager, cacheBufferId, /*isRecv=*/true);
                 }
-                recvHolder = BufferIndexHolder(*mCacheTransBufferManager, cacheBufferId, /*isRecv=*/true);
                 auto [recvSplitCachestmp, bufferCoverTargetNumtmp, onlyUseDynamicBuffer]
                     = mCacheTransBufferManager->getOrAllocateRecvBuffers(
                         cacheBufferId, static_cast<int>(targetNum), bufferEleSizes, bufferManager);
@@ -1026,6 +1036,7 @@ void CacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& sess
                     recvSplitCaches, outputBuffersPerWindow, destConfig, selfConfig, selfIdx, bufferManager);
 
                 bufferManager.getStream().synchronize();
+                (void) session.releaseReservedRecvBuffer(*mCacheTransBufferManager);
                 recvHolder.release();
             }
             session.setTime(TransferSession::kTimePostprocess);

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -243,6 +243,12 @@ std::unique_ptr<BaseCacheTransceiver> CacheTransceiverFactory::createCacheTransc
         return nullptr;
     }
     auto backendType = cacheTransceiverConfig.value().getBackendType();
+    if (common::getEnvDisaggEnableInflightCancel())
+    {
+        TLLM_CHECK_WITH_INFO(backendType.value() != executor::CacheTransceiverConfig::BackendType::DEFAULT,
+            "TRTLLM_DISAGG_ENABLE_INFLIGHT_CANCEL=1 requires an explicit cache transceiver backend; "
+            "BackendType::DEFAULT is not supported.");
+    }
     if (backendType.value() == executor::CacheTransceiverConfig::BackendType::DEFAULT)
     {
         if (common::getEnvUseUCXKvCache())
@@ -297,6 +303,20 @@ CacheTransceiver::CacheTransceiver(kv_cache_manager::BaseKVCacheManager* cacheMa
     : mCacheTransceiverConfig{cacheTransceiverConfig}
 {
     using tensorrt_llm::batch_manager::kv_cache_manager::CacheFormatter;
+    TLLM_CHECK_WITH_INFO(mCacheTransceiverConfig.has_value(), "CacheTransceiverConfig is not set.");
+    auto const backendType = mCacheTransceiverConfig.value().getBackendType();
+    TLLM_CHECK_WITH_INFO(
+        backendType.has_value() && (backendType.value() != executor::CacheTransceiverConfig::BackendType::DEFAULT),
+        " CacheTransceiverConfig::BackendType is not set.");
+    if (common::getEnvDisaggEnableInflightCancel())
+    {
+        auto const nixlBackend = common::getEnvNixlBackend();
+        TLLM_CHECK_WITH_INFO(
+            backendType.value() == executor::CacheTransceiverConfig::BackendType::NIXL && nixlBackend == "UCX",
+            "TRTLLM_DISAGG_ENABLE_INFLIGHT_CANCEL=1 is experimental and currently supported only with the "
+            "NIXL cache transceiver and the UCX NIXL backend.");
+    }
+
     if (useMPI())
     {
         mGroupComm = std::make_shared<CacheTransceiverComm>(std::addressof(tensorrt_llm::mpi::MpiComm::session()));
@@ -347,12 +367,6 @@ CacheTransceiver::CacheTransceiver(kv_cache_manager::BaseKVCacheManager* cacheMa
         }
     }
     bool isMLA = attentionType == executor::kv_cache::CacheState::AttentionType::kMLA;
-    TLLM_CHECK_WITH_INFO(mCacheTransceiverConfig.has_value(), "CacheTransceiverConfig is not set.");
-    auto backendType = mCacheTransceiverConfig.value().getBackendType();
-    TLLM_CHECK_WITH_INFO(
-        backendType.has_value() && (backendType.value() != executor::CacheTransceiverConfig::BackendType::DEFAULT),
-        " CacheTransceiverConfig::BackendType is not set.");
-
     std::optional<size_t> maxNumTokens = mCacheTransceiverConfig.value().getMaxTokensInBuffer();
 
     mCacheTransBufferManagers.push_back(
@@ -795,12 +809,29 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
             auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
                 LlmRequest::getSteadyClockNow() - request->getKvCacheTransferStart());
             auto elapsedMs = static_cast<long>(elapsed.count());
-            if (elapsedMs > kvTransferTimeoutMs.value() && mTimedOutSenderIds.insert(requestId).second)
+            if (elapsedMs > kvTransferTimeoutMs.value())
             {
-                TLLM_LOG_WARNING(
-                    "Context KV cache transfer for request %ld exceeded configured timeout: "
-                    "elapsed %ld ms > limit %d ms (observe-only).",
-                    requestId, elapsedMs, kvTransferTimeoutMs.value());
+                bool const inflightCancelEnabled = common::getEnvDisaggEnableInflightCancel();
+                if (mTimedOutSenderIds.insert(requestId).second)
+                {
+                    TLLM_LOG_WARNING(
+                        "Context KV cache transfer for request %ld exceeded configured timeout: "
+                        "elapsed %ld ms > limit %d ms (%s).",
+                        requestId, elapsedMs, kvTransferTimeoutMs.value(),
+                        inflightCancelEnabled ? "requesting cancellation" : "observe-only");
+                }
+                if (inflightCancelEnabled
+                    && mCancelRequestedSenderIds.find(requestId) == mCancelRequestedSenderIds.end())
+                {
+                    if (mCacheSender->cancelRequest(*request))
+                    {
+                        mCancelRequestedSenderIds.insert(requestId);
+                    }
+                    else
+                    {
+                        TLLM_LOG_DEBUG("Context cancellation for request %ld was not accepted; will retry", requestId);
+                    }
+                }
             }
         }
         if (blockAll || (toCompleteIdSet.find(requestId) != toCompleteIdSet.end()))
@@ -861,6 +892,7 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
         requestIt->second->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
         requestsStatus.errorRequestIds.insert(requestId);
         mTimedOutSenderIds.erase(requestId);
+        mCancelRequestedSenderIds.erase(requestId);
         eraseLocalTransferOutcome(
             requestId, mCompletedSenderRequestIds, mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
     }
@@ -877,6 +909,7 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
             requestIt->second->setState(LlmRequestState::kDISAGG_CONTEXT_COMPLETE);
         }
         mTimedOutSenderIds.erase(requestId);
+        mCancelRequestedSenderIds.erase(requestId);
         eraseLocalTransferOutcome(
             requestId, mCompletedSenderRequestIds, mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
     }
@@ -991,12 +1024,30 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
             auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
                 LlmRequest::getSteadyClockNow() - request->getKvCacheTransferStart());
             auto elapsedMs = static_cast<long>(elapsed.count());
-            if (elapsedMs > kvTransferTimeoutMs.value() && mTimedOutRequesterIds.insert(requestId).second)
+            if (elapsedMs > kvTransferTimeoutMs.value())
             {
-                TLLM_LOG_WARNING(
-                    "Generation KV cache transfer for request %ld exceeded configured timeout: "
-                    "elapsed %ld ms > limit %d ms (observe-only).",
-                    requestId, elapsedMs, kvTransferTimeoutMs.value());
+                bool const inflightCancelEnabled = common::getEnvDisaggEnableInflightCancel();
+                if (mTimedOutRequesterIds.insert(requestId).second)
+                {
+                    TLLM_LOG_WARNING(
+                        "Generation KV cache transfer for request %ld exceeded configured timeout: "
+                        "elapsed %ld ms > limit %d ms (%s).",
+                        requestId, elapsedMs, kvTransferTimeoutMs.value(),
+                        inflightCancelEnabled ? "requesting cancellation" : "observe-only");
+                }
+                if (inflightCancelEnabled
+                    && mCancelRequestedRequesterIds.find(requestId) == mCancelRequestedRequesterIds.end())
+                {
+                    if (mCacheReceiver->cancelRequest(*request))
+                    {
+                        mCancelRequestedRequesterIds.insert(requestId);
+                    }
+                    else
+                    {
+                        TLLM_LOG_DEBUG(
+                            "Generation cancellation for request %ld was not accepted; will retry", requestId);
+                    }
+                }
             }
         }
         if (blockAll || toCompleteIdSet.find(requestId) != toCompleteIdSet.end())
@@ -1070,6 +1121,7 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
         }
         requestIt->second->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
         mTimedOutRequesterIds.erase(requestId);
+        mCancelRequestedRequesterIds.erase(requestId);
         eraseLocalTransferOutcome(
             requestId, mCompletedRequesterRequestIds, mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
     }
@@ -1088,6 +1140,7 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
             updateKVCacheTransferBW(syncComm, requestIt->second.get());
         }
         mTimedOutRequesterIds.erase(requestId);
+        mCancelRequestedRequesterIds.erase(requestId);
         eraseLocalTransferOutcome(
             requestId, mCompletedRequesterRequestIds, mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
     }
@@ -1096,6 +1149,12 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
 bool CacheTransceiver::checkGenTransferComplete() const
 {
     return mRequesterFutures.empty() && mCompletedRequesterRequestIds.empty() && mFailedRequesterRequestIds.empty();
+}
+
+bool CacheTransceiver::hasPoisonedTransferBuffer() const
+{
+    return std::any_of(mCacheTransBufferManagerPtrs.begin(), mCacheTransBufferManagerPtrs.end(),
+        [](BaseTransBufferManager const* manager) { return manager != nullptr && manager->hasPoisonedBuffer(); });
 }
 
 bool CacheTransceiver::cancelRequest(std::shared_ptr<LlmRequest> llmRequest)

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -56,6 +56,7 @@
 #include <chrono>
 #include <cstddef>
 #include <numeric>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -90,19 +91,56 @@ enum class TransferConsensusState : std::uint64_t
 {
     kCompleted = 1,
     kFailed = 2,
+    kTimedOut = 3,
 };
 
 struct TransferStateCounts
 {
     int completedCount{0};
     int failedCount{0};
+    int timedOutCount{0};
 };
 
 struct TransferConsensusOutcome
 {
     std::unordered_set<RequestIdType> completedRequestIds;
     std::unordered_set<RequestIdType> failedRequestIds;
+    std::unordered_set<RequestIdType> timedOutRequestIds;
 };
+
+template <typename CancelFn>
+bool requestCancellationNoThrow(RequestIdType requestId, char const* transferKind, CancelFn&& cancelFn) noexcept
+{
+    try
+    {
+        return cancelFn();
+    }
+    catch (std::exception const& error)
+    {
+        TLLM_LOG_ERROR(
+            "%s cancellation for request %ld failed and will be retried: %s", transferKind, requestId, error.what());
+    }
+    catch (...)
+    {
+        TLLM_LOG_ERROR("%s cancellation for request %ld failed with an unknown error and will be retried", transferKind,
+            requestId);
+    }
+    return false;
+}
+
+long getTransferElapsedMs(std::shared_ptr<LlmRequest> const& request, LlmRequest::TimePoint end)
+{
+    auto const elapsed
+        = std::chrono::duration_cast<std::chrono::milliseconds>(end - request->getKvCacheTransferStart());
+    return static_cast<long>(elapsed.count());
+}
+
+std::vector<RequestIdType> sortedRequestIds(std::unordered_set<RequestIdType> const& requestIds)
+{
+    std::vector<RequestIdType> result(requestIds.begin(), requestIds.end());
+    std::sort(result.begin(), result.end());
+    return result;
+}
 
 void appendPackedTransferState(
     std::vector<std::uint64_t>& packedStates, RequestIdType requestId, TransferConsensusState state)
@@ -143,10 +181,11 @@ std::vector<std::uint64_t> gatherPackedTransferStates(
 
 TransferConsensusOutcome reduceTransferStates(std::shared_ptr<CacheTransceiverComm> const& comm,
     std::unordered_set<RequestIdType> const& completedRequestIds,
-    std::unordered_set<RequestIdType> const& failedRequestIds)
+    std::unordered_set<RequestIdType> const& failedRequestIds,
+    std::unordered_set<RequestIdType> const& timedOutRequestIds)
 {
     std::vector<std::uint64_t> localStates;
-    localStates.reserve((completedRequestIds.size() + failedRequestIds.size()) * 2);
+    localStates.reserve((completedRequestIds.size() + failedRequestIds.size() + timedOutRequestIds.size()) * 2);
     for (auto const requestId : completedRequestIds)
     {
         if (failedRequestIds.find(requestId) == failedRequestIds.end())
@@ -157,6 +196,10 @@ TransferConsensusOutcome reduceTransferStates(std::shared_ptr<CacheTransceiverCo
     for (auto const requestId : failedRequestIds)
     {
         appendPackedTransferState(localStates, requestId, TransferConsensusState::kFailed);
+    }
+    for (auto const requestId : timedOutRequestIds)
+    {
+        appendPackedTransferState(localStates, requestId, TransferConsensusState::kTimedOut);
     }
 
     int const syncSize = (comm != nullptr) ? comm->getSize() : 1;
@@ -177,6 +220,7 @@ TransferConsensusOutcome reduceTransferStates(std::shared_ptr<CacheTransceiverCo
         {
         case TransferConsensusState::kCompleted: counts.completedCount++; break;
         case TransferConsensusState::kFailed: counts.failedCount++; break;
+        case TransferConsensusState::kTimedOut: counts.timedOutCount++; break;
         }
     }
 
@@ -184,7 +228,11 @@ TransferConsensusOutcome reduceTransferStates(std::shared_ptr<CacheTransceiverCo
     for (auto const& [requestId, counts] : stateCounts)
     {
         auto const terminalCount = counts.completedCount + counts.failedCount;
-        if (terminalCount == syncSize && counts.failedCount > 0)
+        if (counts.timedOutCount > 0)
+        {
+            outcome.timedOutRequestIds.insert(requestId);
+        }
+        if (terminalCount == syncSize && (counts.failedCount > 0 || counts.timedOutCount > 0))
         {
             outcome.failedRequestIds.insert(requestId);
         }
@@ -199,10 +247,13 @@ TransferConsensusOutcome reduceTransferStates(std::shared_ptr<CacheTransceiverCo
 TransferConsensusOutcome reduceTransferStates(std::shared_ptr<CacheTransceiverComm> const& firstComm,
     std::shared_ptr<CacheTransceiverComm> const& secondComm,
     std::unordered_set<RequestIdType> const& completedRequestIds,
-    std::unordered_set<RequestIdType> const& failedRequestIds)
+    std::unordered_set<RequestIdType> const& failedRequestIds,
+    std::unordered_set<RequestIdType> const& timedOutRequestIds)
 {
-    auto const firstOutcome = reduceTransferStates(firstComm, completedRequestIds, failedRequestIds);
-    return reduceTransferStates(secondComm, firstOutcome.completedRequestIds, firstOutcome.failedRequestIds);
+    auto const firstOutcome
+        = reduceTransferStates(firstComm, completedRequestIds, failedRequestIds, timedOutRequestIds);
+    return reduceTransferStates(
+        secondComm, firstOutcome.completedRequestIds, firstOutcome.failedRequestIds, firstOutcome.timedOutRequestIds);
 }
 
 void recordLocalTransferOutcome(RequestIdType requestId, std::shared_ptr<LlmRequest> request, bool failed,
@@ -242,13 +293,10 @@ std::unique_ptr<BaseCacheTransceiver> CacheTransceiverFactory::createCacheTransc
         TLLM_LOG_INFO("CacheTransceiver is disabled.");
         return nullptr;
     }
+    TLLM_CHECK_WITH_INFO(!common::getEnvDisaggEnableInflightCancel(),
+        "TRTLLM_DISAGG_ENABLE_INFLIGHT_CANCEL=1 is supported only by the PyExecutor C++ NIXL transceiver path; "
+        "the legacy C++ executor does not provide the required deferred cleanup and poison escalation.");
     auto backendType = cacheTransceiverConfig.value().getBackendType();
-    if (common::getEnvDisaggEnableInflightCancel())
-    {
-        TLLM_CHECK_WITH_INFO(backendType.value() != executor::CacheTransceiverConfig::BackendType::DEFAULT,
-            "TRTLLM_DISAGG_ENABLE_INFLIGHT_CANCEL=1 requires an explicit cache transceiver backend; "
-            "BackendType::DEFAULT is not supported.");
-    }
     if (backendType.value() == executor::CacheTransceiverConfig::BackendType::DEFAULT)
     {
         if (common::getEnvUseUCXKvCache())
@@ -315,6 +363,16 @@ CacheTransceiver::CacheTransceiver(kv_cache_manager::BaseKVCacheManager* cacheMa
             backendType.value() == executor::CacheTransceiverConfig::BackendType::NIXL && nixlBackend == "UCX",
             "TRTLLM_DISAGG_ENABLE_INFLIGHT_CANCEL=1 is experimental and currently supported only with the "
             "NIXL cache transceiver and the UCX NIXL backend.");
+        TLLM_CHECK_WITH_INFO(mCacheTransceiverConfig->getKvTransferTimeoutMs().has_value(),
+            "TRTLLM_DISAGG_ENABLE_INFLIGHT_CANCEL=1 requires kv_transfer_timeout_ms to enforce a finite deadline.");
+        TLLM_CHECK_WITH_INFO(!common::getEnvDisableKVCacheTransferOverlap(),
+            "TRTLLM_DISAGG_ENABLE_INFLIGHT_CANCEL=1 requires asynchronous KV cache transfer; "
+            "TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP=1 is not supported.");
+        TLLM_CHECK_WITH_INFO(!common::getEnvDisaggLayerwise(),
+            "TRTLLM_DISAGG_ENABLE_INFLIGHT_CANCEL=1 does not support layer-wise KV cache transfer.");
+        TLLM_CHECK_WITH_INFO(!common::getEnvTryZCopyForKVCacheTransfer(),
+            "TRTLLM_DISAGG_ENABLE_INFLIGHT_CANCEL=1 does not support zero-copy KV cache transfer because request "
+            "blocks cannot be quarantined after an unquiesced cancellation.");
     }
 
     if (useMPI())
@@ -606,6 +664,14 @@ void CacheTransceiver::requestAndReceiveSync(std::shared_ptr<LlmRequest> llmRequ
             contextRequestId, err.what());
         return;
     }
+    catch (...)
+    {
+        llmRequest->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+        llmRequest->setKvCacheTransferEnd(LlmRequest::getSteadyClockNow());
+        TLLM_LOG_ERROR("Synchronous KV cache receive request %zu, context request %zu failed with an unknown error",
+            requestId, contextRequestId);
+        return;
+    }
     if (llmRequest->getState() == LlmRequestState::kDISAGG_TRANS_ERROR)
     {
         TLLM_LOG_ERROR("Synchronous KV cache receive request %zu, context request %zu completed with an error state.",
@@ -733,6 +799,9 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
     std::optional<int> const& atLeastRequestNum, bool markComplete)
 {
     bool const blockAll = !atLeastRequestNum.has_value();
+    bool const inflightCancelEnabled = common::getEnvDisaggEnableInflightCancel();
+    TLLM_CHECK_WITH_INFO(!inflightCancelEnabled || !blockAll,
+        "In-flight cancellation requires a finite context-transfer status poll; pass 0 for a nonblocking poll.");
     std::optional<int> senderFutureTimeoutMs = std::nullopt;
     if (mCacheTransceiverConfig.has_value())
     {
@@ -740,8 +809,9 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
     }
     bool const needsProgress = atLeastRequestNum.value_or(0) > 0;
     auto const futureWaitInterval = getTransferFutureWaitInterval(senderFutureTimeoutMs, needsProgress);
-    // Observe-only: WARN per-request when the wall-clock transfer time exceeds
-    // kvTransferTimeoutMs. No cancellation, eviction, or state transition.
+    // Without the opt-in flag, deadline checks remain observe-only. With the
+    // flag, timeout IDs participate in the same topology consensus as terminal
+    // outcomes and request cancellation is requested on every nonterminal rank.
     std::optional<int> kvTransferTimeoutMs = std::nullopt;
     if (mCacheTransceiverConfig.has_value())
     {
@@ -804,14 +874,12 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
     {
         auto& [request, future] = *it;
         auto const requestId = request->mRequestId;
-        if (kvTransferTimeoutMs.has_value())
+        if (kvTransferTimeoutMs.has_value()
+            && future.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready)
         {
-            auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-                LlmRequest::getSteadyClockNow() - request->getKvCacheTransferStart());
-            auto elapsedMs = static_cast<long>(elapsed.count());
+            auto const elapsedMs = getTransferElapsedMs(request, LlmRequest::getSteadyClockNow());
             if (elapsedMs > kvTransferTimeoutMs.value())
             {
-                bool const inflightCancelEnabled = common::getEnvDisaggEnableInflightCancel();
                 if (mTimedOutSenderIds.insert(requestId).second)
                 {
                     TLLM_LOG_WARNING(
@@ -819,18 +887,6 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                         "elapsed %ld ms > limit %d ms (%s).",
                         requestId, elapsedMs, kvTransferTimeoutMs.value(),
                         inflightCancelEnabled ? "requesting cancellation" : "observe-only");
-                }
-                if (inflightCancelEnabled
-                    && mCancelRequestedSenderIds.find(requestId) == mCancelRequestedSenderIds.end())
-                {
-                    if (mCacheSender->cancelRequest(*request))
-                    {
-                        mCancelRequestedSenderIds.insert(requestId);
-                    }
-                    else
-                    {
-                        TLLM_LOG_DEBUG("Context cancellation for request %ld was not accepted; will retry", requestId);
-                    }
                 }
             }
         }
@@ -842,8 +898,19 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                 if (status == std::future_status::ready)
                 {
                     future.get();
-                    bool const failed = request->getState() == LlmRequestState::kDISAGG_TRANS_ERROR;
-                    recordLocalTransferOutcome(requestId, request, failed, mCompletedSenderRequestIds,
+                    if (kvTransferTimeoutMs.has_value())
+                    {
+                        auto const elapsedMs = getTransferElapsedMs(request, request->getKvCacheTransferEnd());
+                        if (elapsedMs > kvTransferTimeoutMs.value() && mTimedOutSenderIds.insert(requestId).second)
+                        {
+                            TLLM_LOG_WARNING(
+                                "Context KV cache transfer for request %ld completed after its deadline: "
+                                "elapsed %ld ms > limit %d ms (%s).",
+                                requestId, elapsedMs, kvTransferTimeoutMs.value(),
+                                inflightCancelEnabled ? "failing request" : "observe-only");
+                        }
+                    }
+                    recordLocalTransferOutcome(requestId, request, /*failed=*/false, mCompletedSenderRequestIds,
                         mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
                     it = mSenderFutures.erase(it);
                 }
@@ -872,6 +939,13 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                     mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
                 it = mSenderFutures.erase(it);
             }
+            catch (...)
+            {
+                TLLM_LOG_ERROR("Unknown error occurred during context transfer for request %ld", requestId);
+                recordLocalTransferOutcome(requestId, request, /*failed=*/true, mCompletedSenderRequestIds,
+                    mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
+                it = mSenderFutures.erase(it);
+            }
         }
         else
         {
@@ -880,9 +954,33 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
     }
 
     RequestStatuses requestsStatus{};
-    auto const consensusOutcome
-        = reduceTransferStates(syncComm, mGroupPipeParaComm, mCompletedSenderRequestIds, mFailedSenderRequestIds);
-    for (auto const requestId : consensusOutcome.failedRequestIds)
+    auto const consensusOutcome = reduceTransferStates(syncComm, mGroupPipeParaComm, mCompletedSenderRequestIds,
+        mFailedSenderRequestIds, inflightCancelEnabled ? mTimedOutSenderIds : std::unordered_set<RequestIdType>{});
+    if (inflightCancelEnabled)
+    {
+        for (auto const requestId : consensusOutcome.timedOutRequestIds)
+        {
+            auto const futureIt = std::find_if(mSenderFutures.begin(), mSenderFutures.end(),
+                [requestId](auto const& entry) { return entry.first->mRequestId == requestId; });
+            if (futureIt == mSenderFutures.end()
+                || futureIt->second.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready
+                || mCancelRequestedSenderIds.find(requestId) != mCancelRequestedSenderIds.end())
+            {
+                continue;
+            }
+            mTimedOutSenderIds.insert(requestId);
+            if (requestCancellationNoThrow(
+                    requestId, "Context", [&]() { return mCacheSender->cancelRequest(*futureIt->first); }))
+            {
+                mCancelRequestedSenderIds.insert(requestId);
+            }
+            else
+            {
+                TLLM_LOG_DEBUG("Context cancellation for request %ld was not accepted; will retry", requestId);
+            }
+        }
+    }
+    for (auto const requestId : sortedRequestIds(consensusOutcome.failedRequestIds))
     {
         auto const requestIt = mSenderRequestsAwaitingConsensus.find(requestId);
         if (requestIt == mSenderRequestsAwaitingConsensus.end())
@@ -896,7 +994,7 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
         eraseLocalTransferOutcome(
             requestId, mCompletedSenderRequestIds, mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
     }
-    for (auto const requestId : consensusOutcome.completedRequestIds)
+    for (auto const requestId : sortedRequestIds(consensusOutcome.completedRequestIds))
     {
         auto const requestIt = mSenderRequestsAwaitingConsensus.find(requestId);
         if (requestIt == mSenderRequestsAwaitingConsensus.end())
@@ -920,6 +1018,9 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
 void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastRequestNum)
 {
     bool const blockAll = !atLeastRequestNum.has_value();
+    bool const inflightCancelEnabled = common::getEnvDisaggEnableInflightCancel();
+    TLLM_CHECK_WITH_INFO(!inflightCancelEnabled || !blockAll,
+        "In-flight cancellation requires a finite generation-transfer status poll; pass 0 for a nonblocking poll.");
     bool const needsProgress = atLeastRequestNum.value_or(0) > 0;
     std::optional<int> genTransferPollIntervalMs = std::nullopt;
     if (mCacheTransceiverConfig.has_value())
@@ -1009,7 +1110,7 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
             atLeastRequestNum.value_or(0));
     }
 
-    // Observe-only: gen-side mirror of the context-side timeout WARN.
+    // Gen-side mirror of the context deadline/consensus path.
     std::optional<int> kvTransferTimeoutMs = std::nullopt;
     if (mCacheTransceiverConfig.has_value())
     {
@@ -1019,14 +1120,12 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
     {
         auto& request = it->first;
         auto const requestId = request->mRequestId;
-        if (kvTransferTimeoutMs.has_value())
+        if (kvTransferTimeoutMs.has_value()
+            && it->second.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready)
         {
-            auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-                LlmRequest::getSteadyClockNow() - request->getKvCacheTransferStart());
-            auto elapsedMs = static_cast<long>(elapsed.count());
+            auto const elapsedMs = getTransferElapsedMs(request, LlmRequest::getSteadyClockNow());
             if (elapsedMs > kvTransferTimeoutMs.value())
             {
-                bool const inflightCancelEnabled = common::getEnvDisaggEnableInflightCancel();
                 if (mTimedOutRequesterIds.insert(requestId).second)
                 {
                     TLLM_LOG_WARNING(
@@ -1034,19 +1133,6 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
                         "elapsed %ld ms > limit %d ms (%s).",
                         requestId, elapsedMs, kvTransferTimeoutMs.value(),
                         inflightCancelEnabled ? "requesting cancellation" : "observe-only");
-                }
-                if (inflightCancelEnabled
-                    && mCancelRequestedRequesterIds.find(requestId) == mCancelRequestedRequesterIds.end())
-                {
-                    if (mCacheReceiver->cancelRequest(*request))
-                    {
-                        mCancelRequestedRequesterIds.insert(requestId);
-                    }
-                    else
-                    {
-                        TLLM_LOG_DEBUG(
-                            "Generation cancellation for request %ld was not accepted; will retry", requestId);
-                    }
                 }
             }
         }
@@ -1058,14 +1144,19 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
                 if (status == std::future_status::ready)
                 {
                     it->second.get();
-                    bool const failed = request->getState() == LlmRequestState::kDISAGG_TRANS_ERROR;
-                    if (failed)
+                    if (kvTransferTimeoutMs.has_value())
                     {
-                        // The receiver uses the error state as a local transfer-failed signal.
-                        // Keep that signal local until the consensus outcome commits it globally.
-                        request->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_IN_PROGRESS);
+                        auto const elapsedMs = getTransferElapsedMs(request, request->getKvCacheTransferEnd());
+                        if (elapsedMs > kvTransferTimeoutMs.value() && mTimedOutRequesterIds.insert(requestId).second)
+                        {
+                            TLLM_LOG_WARNING(
+                                "Generation KV cache transfer for request %ld completed after its deadline: "
+                                "elapsed %ld ms > limit %d ms (%s).",
+                                requestId, elapsedMs, kvTransferTimeoutMs.value(),
+                                inflightCancelEnabled ? "failing request" : "observe-only");
+                        }
                     }
-                    recordLocalTransferOutcome(requestId, request, failed, mCompletedRequesterRequestIds,
+                    recordLocalTransferOutcome(requestId, request, /*failed=*/false, mCompletedRequesterRequestIds,
                         mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
                 }
                 else if (status == std::future_status::timeout)
@@ -1090,6 +1181,12 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
                 recordLocalTransferOutcome(requestId, request, /*failed=*/true, mCompletedRequesterRequestIds,
                     mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
             }
+            catch (...)
+            {
+                TLLM_LOG_ERROR("Unknown error occurred during generation transfer for request %ld", requestId);
+                recordLocalTransferOutcome(requestId, request, /*failed=*/true, mCompletedRequesterRequestIds,
+                    mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
+            }
             if (useMPI())
             {
                 TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
@@ -1111,8 +1208,33 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
     }
 
     auto const consensusOutcome
-        = reduceTransferStates(syncComm, mCompletedRequesterRequestIds, mFailedRequesterRequestIds);
-    for (auto const requestId : consensusOutcome.failedRequestIds)
+        = reduceTransferStates(syncComm, mCompletedRequesterRequestIds, mFailedRequesterRequestIds,
+            inflightCancelEnabled ? mTimedOutRequesterIds : std::unordered_set<RequestIdType>{});
+    if (inflightCancelEnabled)
+    {
+        for (auto const requestId : consensusOutcome.timedOutRequestIds)
+        {
+            auto const futureIt = std::find_if(mRequesterFutures.begin(), mRequesterFutures.end(),
+                [requestId](auto const& entry) { return entry.first->mRequestId == requestId; });
+            if (futureIt == mRequesterFutures.end()
+                || futureIt->second.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready
+                || mCancelRequestedRequesterIds.find(requestId) != mCancelRequestedRequesterIds.end())
+            {
+                continue;
+            }
+            mTimedOutRequesterIds.insert(requestId);
+            if (requestCancellationNoThrow(
+                    requestId, "Generation", [&]() { return mCacheReceiver->cancelRequest(*futureIt->first); }))
+            {
+                mCancelRequestedRequesterIds.insert(requestId);
+            }
+            else
+            {
+                TLLM_LOG_DEBUG("Generation cancellation for request %ld was not accepted; will retry", requestId);
+            }
+        }
+    }
+    for (auto const requestId : sortedRequestIds(consensusOutcome.failedRequestIds))
     {
         auto const requestIt = mRequesterRequestsAwaitingConsensus.find(requestId);
         if (requestIt == mRequesterRequestsAwaitingConsensus.end())
@@ -1125,7 +1247,7 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
         eraseLocalTransferOutcome(
             requestId, mCompletedRequesterRequestIds, mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
     }
-    for (auto const requestId : consensusOutcome.completedRequestIds)
+    for (auto const requestId : sortedRequestIds(consensusOutcome.completedRequestIds))
     {
         auto const requestIt = mRequesterRequestsAwaitingConsensus.find(requestId);
         if (requestIt == mRequesterRequestsAwaitingConsensus.end())
@@ -1159,6 +1281,11 @@ bool CacheTransceiver::hasPoisonedTransferBuffer() const
 
 bool CacheTransceiver::cancelRequest(std::shared_ptr<LlmRequest> llmRequest)
 {
+    if (llmRequest == nullptr)
+    {
+        TLLM_LOG_WARNING("Cannot cancel a null KV cache transfer request");
+        return false;
+    }
     if (llmRequest->isContextOnlyRequest())
     {
         return mCacheSender->cancelRequest(*llmRequest);

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -303,6 +303,7 @@ public:
         std::promise<void> promise;
         auto future = promise.get_future();
         llmRequest->setKvCacheTransferStart(LlmRequest::getSteadyClockNow());
+        (void) getOrCreateInFlightCancelFlag(llmRequest->mRequestId);
         {
             std::scoped_lock lock(mSenderMutex);
             TLLM_CHECK_WITH_INFO(
@@ -314,6 +315,19 @@ public:
         }
         mSenderCv.notify_all();
         return future;
+    }
+
+    std::shared_ptr<std::atomic<bool>> getOrCreateInFlightCancelFlag(RequestIdType requestId)
+    {
+        std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
+        auto it = mInFlightCancelFlags.find(requestId);
+        if (it != mInFlightCancelFlags.end())
+        {
+            return it->second;
+        }
+        auto flag = std::make_shared<std::atomic<bool>>(false);
+        mInFlightCancelFlags.emplace(requestId, flag);
+        return flag;
     }
 
     [[nodiscard]] executor::kv_cache::CommState const& getCommState() const
@@ -336,24 +350,30 @@ public:
 
     void release(LlmRequest::RequestIdType requestId)
     {
-        std::unique_lock<std::mutex> lk(mMtxForMap);
-        auto it = mRequestToSession.find(requestId);
-        TLLM_CHECK(it != mRequestToSession.end());
-        if (!common::getEnvKVCacheTimeOutputPath().empty())
         {
-            if (!mMeasuresFile.is_open())
+            std::unique_lock<std::mutex> lk(mMtxForMap);
+            auto it = mRequestToSession.find(requestId);
+            TLLM_CHECK(it != mRequestToSession.end());
+            if (!common::getEnvKVCacheTimeOutputPath().empty())
             {
-                auto outputPath = getTransferOutputPath("send");
-                mMeasuresFile.open(outputPath);
-                TLLM_CHECK_WITH_INFO(
-                    mMeasuresFile.is_open(), "Failed to open transfer output file: %s", outputPath.string().c_str());
+                if (!mMeasuresFile.is_open())
+                {
+                    auto outputPath = getTransferOutputPath("send");
+                    mMeasuresFile.open(outputPath);
+                    TLLM_CHECK_WITH_INFO(mMeasuresFile.is_open(), "Failed to open transfer output file: %s",
+                        outputPath.string().c_str());
+                }
+                it->second.exportMeasure(mMeasuresFile, true);
             }
-            it->second.exportMeasure(mMeasuresFile, true);
+            mRequestToSession.erase(it);
         }
-        mRequestToSession.erase(it);
+        {
+            std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
+            mInFlightCancelFlags.erase(requestId);
+        }
     }
 
-    void discardSession(LlmRequest::RequestIdType requestId) noexcept
+    void discardTransferState(LlmRequest::RequestIdType requestId) noexcept
     {
         try
         {
@@ -362,7 +382,24 @@ public:
         }
         catch (std::exception const& e)
         {
-            TLLM_LOG_ERROR("Failed to discard KV cache transfer session for request %zu: %s", requestId, e.what());
+            TLLM_LOG_WARNING("Failed to discard sender session for request %ld: %s", requestId, e.what());
+        }
+        catch (...)
+        {
+            TLLM_LOG_WARNING("Failed to discard sender session for request %ld: unknown exception", requestId);
+        }
+        try
+        {
+            std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
+            mInFlightCancelFlags.erase(requestId);
+        }
+        catch (std::exception const& e)
+        {
+            TLLM_LOG_WARNING("Failed to discard in-flight cancel flag for request %ld: %s", requestId, e.what());
+        }
+        catch (...)
+        {
+            TLLM_LOG_WARNING("Failed to discard in-flight cancel flag for request %ld: unknown exception", requestId);
         }
     }
 
@@ -406,13 +443,14 @@ public:
 
         TLLM_CHECK_WITH_INFO(peerIdx < static_cast<int>(allCounterparts.size()),
             "Peer rank %d not found in expected counterparts", peerSelfIdx);
+        auto cancelFlag = getOrCreateInFlightCancelFlag(requestId);
         {
             std::unique_lock<std::mutex> lk(mMtxForMap);
             auto it = mRequestToSession.find(requestId);
             if (it == mRequestToSession.end())
             {
                 auto session = TransferSession(std::vector<Connection const*>(allCounterparts.size(), nullptr),
-                    DataContext{tagFromRequestId(requestId), mTerminate}, allCounterparts, mSelfState,
+                    DataContext{tagFromRequestId(requestId), *cancelFlag}, allCounterparts, mSelfState,
                     info.getTransState(), mBufferManager, info.getIndexFromEnd(), info.getLastBlockKey(), nullptr,
                     !common::getEnvKVCacheTimeOutputPath().empty());
                 session.setTime(TransferSession::kTimeRequestInfo);
@@ -442,16 +480,28 @@ public:
     bool cancelRequest(LlmRequest const& llmRequest)
     {
         bool isCancelled = false;
-        std::scoped_lock lock(mSenderMutex);
-        auto it = mReadyResponses.find(llmRequest.mRequestId);
-        // If the request is not the current request and already in the ready queue, we can cancel it.
-        if (it != mReadyResponses.end()
-            && (!mCurrentRequest.has_value() || mCurrentRequest.value() != llmRequest.mRequestId))
         {
-            mCancelledRequests.insert(llmRequest.mRequestId);
-            isCancelled = true;
+            std::scoped_lock lock(mSenderMutex);
+            auto it = mReadyResponses.find(llmRequest.mRequestId);
+            // If the request is not the current request and already in the ready queue, we can cancel it.
+            if (it != mReadyResponses.end()
+                && (!mCurrentRequest.has_value() || mCurrentRequest.value() != llmRequest.mRequestId))
+            {
+                mCancelledRequests.insert(llmRequest.mRequestId);
+                isCancelled = true;
+            }
         }
-        else
+        if (!isCancelled && common::getEnvDisaggEnableInflightCancel())
+        {
+            std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
+            auto flagIt = mInFlightCancelFlags.find(llmRequest.mRequestId);
+            if (flagIt != mInFlightCancelFlags.end())
+            {
+                flagIt->second->store(true, std::memory_order_relaxed);
+                isCancelled = true;
+            }
+        }
+        if (!isCancelled)
         {
             TLLM_LOG_WARNING("Cannot cancel request %zu", llmRequest.mRequestId);
         }
@@ -549,16 +599,16 @@ private:
         }
         catch (tensorrt_llm::common::RequestSpecificException const& e)
         {
-            discardSession(id);
             TLLM_LOG_ERROR("Exception in sendAndRemoveResponse: %s ", e.what());
+            discardTransferState(id);
             auto new_exception = TLLM_REQUEST_EXCEPTION(id, e.getErrorCode(), "%s", e.what());
             failResponse(resp, std::make_exception_ptr(new_exception));
         }
         catch (std::exception const& e)
         {
             auto const exception = std::current_exception();
-            discardSession(id);
             TLLM_LOG_ERROR("Exception in sendAndRemoveResponse: %s request id: %ld", e.what(), id);
+            discardTransferState(id);
             failResponse(resp, exception);
         }
     }
@@ -574,6 +624,7 @@ private:
         catch (std::exception const& err)
         {
             TLLM_LOG_ERROR("Failed to queue asynchronous KV cache send for request %zu: %s", id, err.what());
+            discardTransferState(id);
             failResponse(resp, std::current_exception());
         }
     }
@@ -630,7 +681,7 @@ private:
         }
         else
         {
-            discardSession(reqId);
+            discardTransferState(reqId);
             failResponse(response,
                 std::make_exception_ptr(TLLM_REQUEST_EXCEPTION(reqId, common::RequestErrorCode::kNETWORK_ERROR,
                     "KV cache transfer for request %zu was cancelled", reqId)));
@@ -706,6 +757,15 @@ private:
             std::scoped_lock lock(mSenderMutex);
             mTerminate = true;
         }
+        {
+            std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
+            for (auto& [id, flag] : mInFlightCancelFlags)
+            {
+                flag->store(true, std::memory_order_relaxed);
+            }
+        }
+        // Wake the sender loop and make in-flight agent transfers observe termination through
+        // their per-request cancellation flags.
         mSenderCv.notify_all();
         if (mResponseFuture.valid())
         {
@@ -788,6 +848,8 @@ private:
     std::mutex mMtxForMap;
     runtime::BufferManager mBufferManager;
     std::ofstream mMeasuresFile;
+    std::mutex mInFlightCancelMutex;
+    std::unordered_map<LlmRequest::RequestIdType, std::shared_ptr<std::atomic<bool>>> mInFlightCancelFlags;
 };
 
 class CacheReceiver::Impl
@@ -835,9 +897,14 @@ public:
                 mRequestFutures.emplace_back(std::move(requestFuture));
             }
             auto& asyncResource = mInstanceToAsyncResource.at(processInfo);
+            auto cancelFlag = std::make_shared<std::atomic<bool>>(false);
+            {
+                std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
+                mInFlightCancelFlags[llmRequest->mRequestId] = cancelFlag;
+            }
             {
                 std::unique_lock<std::mutex> lck(asyncResource->mMtxForQueue);
-                asyncResource->mRequestsQueue.emplace_back(llmRequest, std::move(promise));
+                asyncResource->mRequestsQueue.emplace_back(llmRequest, std::move(promise), cancelFlag);
             }
             asyncResource->mCVforQueue.notify_all();
             return future;
@@ -865,7 +932,8 @@ public:
         }
     }
 
-    TransferSession sendRequestInfo(LlmRequest const& llmRequest)
+    TransferSession sendRequestInfo(LlmRequest const& llmRequest, std::atomic<bool> const* perRequestCancel = nullptr,
+        std::vector<std::optional<size_t>> cacheBufferIds = {})
     {
         uint64_t requestId = llmRequest.getContextPhaseParams().value().getReqId();
         auto const& contextState = llmRequest.getDataTransceiverState();
@@ -907,12 +975,22 @@ public:
         }
 
         auto* agentConnectionManager = dynamic_cast<executor::kv_cache::AgentConnectionManager*>(mManager);
-        std::vector<std::optional<size_t>> cacheBufferIds;
         if (agentConnectionManager)
         {
-            for (auto& cacheTransBufferManager : agentConnectionManager->getCacheTransBufferManagers())
+            if (cacheBufferIds.empty())
             {
-                cacheBufferIds.push_back(cacheTransBufferManager->assignBufferIndexForRecv());
+                for (auto& cacheTransBufferManager : agentConnectionManager->getCacheTransBufferManagers())
+                {
+                    auto rawIdx = cacheTransBufferManager->assignBufferIndexForRecv(perRequestCancel);
+                    if (rawIdx.has_value())
+                    {
+                        cacheBufferIds.push_back(static_cast<size_t>(rawIdx.value()));
+                    }
+                    else
+                    {
+                        cacheBufferIds.push_back(std::nullopt);
+                    }
+                }
             }
             TLLM_CHECK(!cacheBufferIds.empty());
         }
@@ -993,7 +1071,7 @@ public:
                 TLLM_CHECK(agentConnection != nullptr);
 
                 const_cast<executor::kv_cache::AgentConnection*>(agentConnection)
-                    ->sendRequestAndBufferInfo(requestInfo, idsForRank, validConnectionIdx);
+                    ->sendRequestAndBufferInfo(requestInfo, idsForRank, validConnectionIdx, perRequestCancel);
             }
             else
             {
@@ -1001,6 +1079,13 @@ public:
             }
         }
         auto const& resource = getReceiveCacheResource(llmRequest);
+        if (perRequestCancel != nullptr)
+        {
+            return TransferSession(std::move(allConnections),
+                DataContext{tagFromRequestId(requestId), *perRequestCancel}, std::move(allCounterparts), mSelfState,
+                contextState, resource->mBufferManager, requestInfo.getIndexFromEnd(), requestInfo.getLastBlockKey(),
+                &llmRequest, !common::getEnvKVCacheTimeOutputPath().empty());
+        }
         return TransferSession(std::move(allConnections), DataContext{tagFromRequestId(requestId), mTerminate},
             std::move(allCounterparts), mSelfState, contextState, resource->mBufferManager,
             requestInfo.getIndexFromEnd(), requestInfo.getLastBlockKey(), &llmRequest,
@@ -1048,6 +1133,7 @@ public:
 
         bool isCancelled = false;
         auto& asyncResource = mInstanceToAsyncResource.at(processInfo);
+        std::optional<LlmRequest::RequestIdType> queuedCancelledReqId;
         {
             std::unique_lock<std::mutex> lck(asyncResource->mMtxForQueue);
             auto it = std::find_if(asyncResource->mRequestsQueue.begin(), asyncResource->mRequestsQueue.end(),
@@ -1074,43 +1160,92 @@ public:
                 }
                 asyncResource->mRequestsQueue.erase(it);
                 isCancelled = true;
+                queuedCancelledReqId = llmRequest.mRequestId;
             }
-            else
+        }
+        if (queuedCancelledReqId.has_value())
+        {
+            std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
+            mInFlightCancelFlags.erase(*queuedCancelledReqId);
+        }
+        if (!isCancelled && common::getEnvDisaggEnableInflightCancel())
+        {
+            std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
+            auto flagIt = mInFlightCancelFlags.find(llmRequest.mRequestId);
+            if (flagIt != mInFlightCancelFlags.end())
             {
-                TLLM_LOG_WARNING("Cannot cancel request %zu", llmRequest.mRequestId);
+                flagIt->second->store(true, std::memory_order_relaxed);
+                isCancelled = true;
             }
+        }
+        if (!isCancelled)
+        {
+            TLLM_LOG_WARNING("Cannot cancel request %zu", llmRequest.mRequestId);
         }
         return isCancelled;
     }
 
-    bool receiveReadySignal(TransferSession& session)
+    enum class ReadySignalResult
+    {
+        kReady,
+        kNotReady,
+        kCancelled,
+    };
+
+    ReadySignalResult receiveReadySignalDetailed(TransferSession& session, std::atomic<bool> const& perRequestCancel)
     {
         bool isReadyFinal = true;
         bool isReady = false;
         auto const& connections = session.getConnections();
         for (size_t i = 0; i < connections.size(); i++)
         {
+            if (perRequestCancel.load(std::memory_order_relaxed))
+            {
+                return ReadySignalResult::kCancelled;
+            }
             auto* agentConnectionManager = dynamic_cast<executor::kv_cache::AgentConnectionManager*>(mManager);
             if (agentConnectionManager)
             {
                 auto* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connections.at(i));
                 TLLM_CHECK(agentConnection);
-                isReady = agentConnection->recvReadySignal(session.getDataContext());
+                auto ready = agentConnection->recvReadySignalWithStatus(
+                    executor::kv_cache::DataContext{TransceiverTag::kREADY_SIGNAL_TAG, perRequestCancel});
+                if (!ready.has_value())
+                {
+                    return ReadySignalResult::kCancelled;
+                }
+                isReady = ready.value();
             }
             else
             {
                 connections.at(i)->recv(
                     executor::kv_cache::DataContext{TransceiverTag::kREADY_SIGNAL_TAG}, &isReady, sizeof(isReady));
+                if (perRequestCancel.load(std::memory_order_relaxed))
+                {
+                    return ReadySignalResult::kCancelled;
+                }
             }
             isReadyFinal &= isReady;
         }
 
-        return isReadyFinal;
+        return isReadyFinal ? ReadySignalResult::kReady : ReadySignalResult::kNotReady;
+    }
+
+    bool receiveReadySignal(TransferSession& session)
+    {
+        return receiveReadySignalDetailed(session, mTerminate) == ReadySignalResult::kReady;
     }
 
     ~Impl()
     {
         mTerminate.store(true);
+        {
+            std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
+            for (auto& [id, flag] : mInFlightCancelFlags)
+            {
+                flag->store(true, std::memory_order_relaxed);
+            }
+        }
         for (auto&& [processInfo, asyncResource] : mInstanceToAsyncResource)
         {
             asyncResource->mTerminate = true;
@@ -1123,19 +1258,57 @@ public:
     }
 
 private:
-    void requestSync(LlmRequest& llmRequest)
+    void requestSync(LlmRequest& llmRequest, std::atomic<bool> const& perRequestCancel)
     {
         auto const requestId = llmRequest.mRequestId;
         auto const contextRequestId = llmRequest.getContextPhaseParams().value().getReqId();
         char const* phase = "request-info";
         TLLM_LOG_DEBUG("KV cache receive request %zu, context request %zu started.", requestId, contextRequestId);
         llmRequest.setKvCacheTransferStart(LlmRequest::getSteadyClockNow());
+        if (perRequestCancel.load(std::memory_order_relaxed) || mTerminate.load(std::memory_order_relaxed))
+        {
+            llmRequest.setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+            llmRequest.setKvCacheTransferEnd(LlmRequest::getSteadyClockNow());
+            return;
+        }
+        TLLM_CUDA_CHECK(cudaSetDevice(mDeviceId));
+
+        std::vector<BufferIndexHolder> recvHolders;
+        std::vector<std::optional<size_t>> cacheBufferIds;
+        auto* agentConnectionManager = dynamic_cast<executor::kv_cache::AgentConnectionManager*>(mManager);
+        if (agentConnectionManager)
+        {
+            auto const& managers = agentConnectionManager->getCacheTransBufferManagers();
+            recvHolders.reserve(managers.size());
+            cacheBufferIds.reserve(managers.size());
+            for (auto* cacheTransBufferManager : managers)
+            {
+                auto rawIdx = cacheTransBufferManager->assignBufferIndexForRecv(&perRequestCancel);
+                recvHolders.emplace_back(*cacheTransBufferManager, rawIdx, /*isRecv=*/true);
+                if (rawIdx.has_value())
+                {
+                    cacheBufferIds.push_back(static_cast<size_t>(rawIdx.value()));
+                }
+                else
+                {
+                    cacheBufferIds.push_back(std::nullopt);
+                }
+            }
+        }
+
+        auto poisonRecvHolders = [&recvHolders]()
+        {
+            for (auto& holder : recvHolders)
+            {
+                holder.poison();
+            }
+        };
+
         try
         {
-            TLLM_CUDA_CHECK(cudaSetDevice(mDeviceId));
             TLLM_LOG_DEBUG("KV cache receive request %zu, context request %zu phase=%s begin.", requestId,
                 contextRequestId, phase);
-            auto session = sendRequestInfo(llmRequest);
+            auto session = sendRequestInfo(llmRequest, &perRequestCancel, std::move(cacheBufferIds));
             session.setTime(TransferSession::kTimeRequestInfo);
             TLLM_LOG_DEBUG(
                 "KV cache receive request %zu, context request %zu phase=%s end.", requestId, contextRequestId, phase);
@@ -1143,12 +1316,21 @@ private:
             phase = "ready-signal";
             TLLM_LOG_DEBUG("KV cache receive request %zu, context request %zu phase=%s begin.", requestId,
                 contextRequestId, phase);
-            bool const isReady = receiveReadySignal(session);
-            TLLM_LOG_DEBUG("KV cache receive request %zu, context request %zu phase=%s end: ready=%d.", requestId,
-                contextRequestId, phase, static_cast<int>(isReady));
-            if (!isReady)
+            auto readyResult = receiveReadySignalDetailed(session, perRequestCancel);
+            TLLM_LOG_DEBUG("KV cache receive request %zu, context request %zu phase=%s end: result=%d.", requestId,
+                contextRequestId, phase, static_cast<int>(readyResult));
+            if (readyResult == ReadySignalResult::kCancelled)
             {
-                // Reuse the error state for the cancelled request.
+                if (common::getEnvDisaggEnableInflightCancel())
+                {
+                    poisonRecvHolders();
+                }
+                llmRequest.setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+                llmRequest.setKvCacheTransferEnd(LlmRequest::getSteadyClockNow());
+                return;
+            }
+            if (readyResult == ReadySignalResult::kNotReady)
+            {
                 llmRequest.setState(LlmRequestState::kDISAGG_TRANS_ERROR);
                 llmRequest.setKvCacheTransferEnd(LlmRequest::getSteadyClockNow());
                 return;
@@ -1161,9 +1343,20 @@ private:
             TLLM_LOG_DEBUG(
                 "KV cache receive request %zu, context request %zu phase=%s end.", requestId, contextRequestId, phase);
             llmRequest.setKvCacheTransferEnd(LlmRequest::getSteadyClockNow());
+
+            for (auto& holder : recvHolders)
+            {
+                (void) holder.detach();
+            }
         }
         catch (std::exception const& err)
         {
+            if (common::getEnvDisaggEnableInflightCancel())
+            {
+                poisonRecvHolders();
+            }
+            llmRequest.setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+            llmRequest.setKvCacheTransferEnd(LlmRequest::getSteadyClockNow());
             TLLM_LOG_ERROR("KV cache receive request %zu, context request %zu failed in phase=%s: %s", requestId,
                 contextRequestId, phase, err.what());
             throw;
@@ -1172,22 +1365,31 @@ private:
         TLLM_LOG_DEBUG("KV cache receive request %zu, context request %zu completed.", requestId, contextRequestId);
     }
 
+    void requestSync(LlmRequest& llmRequest)
+    {
+        requestSync(llmRequest, mTerminate);
+    }
+
     struct RequestAndPromise
     {
         // shared_ptr so this struct co-owns the request until the promise resolves;
         // protects worker-side dereferences and the promise itself from premature destruction.
         std::shared_ptr<LlmRequest> mRequest;
         std::unique_ptr<std::promise<void>> mPromise;
+        std::shared_ptr<std::atomic<bool>> mCancelFlag;
 
         RequestAndPromise()
             : mRequest(nullptr)
             , mPromise(nullptr)
+            , mCancelFlag(nullptr)
         {
         }
 
-        RequestAndPromise(std::shared_ptr<LlmRequest> request, std::unique_ptr<std::promise<void>>&& promise)
+        RequestAndPromise(std::shared_ptr<LlmRequest> request, std::unique_ptr<std::promise<void>>&& promise,
+            std::shared_ptr<std::atomic<bool>> cancelFlag)
             : mRequest(std::move(request))
             , mPromise(std::move(promise))
+            , mCancelFlag(std::move(cancelFlag))
         {
         }
 
@@ -1196,6 +1398,7 @@ private:
         RequestAndPromise(RequestAndPromise&& other) noexcept
             : mRequest(std::move(other.mRequest))
             , mPromise(std::move(other.mPromise))
+            , mCancelFlag(std::move(other.mCancelFlag))
         {
         }
 
@@ -1211,6 +1414,7 @@ private:
 
                 mRequest = std::move(other.mRequest);
                 mPromise = std::move(other.mPromise);
+                mCancelFlag = std::move(other.mCancelFlag);
             }
             return *this;
         }
@@ -1254,7 +1458,9 @@ private:
                 try
                 {
                     TLLM_CHECK_WITH_INFO(requestAndPromise.mRequest != nullptr, "requestAndPromise.mRequest is null");
-                    requestSync(*requestAndPromise.mRequest);
+                    TLLM_CHECK_WITH_INFO(
+                        requestAndPromise.mCancelFlag != nullptr, "requestAndPromise.mCancelFlag is null");
+                    requestSync(*requestAndPromise.mRequest, *requestAndPromise.mCancelFlag);
                     requestAndPromise.mPromise->set_value();
                 }
                 catch (tensorrt_llm::common::RequestSpecificException const& err)
@@ -1272,6 +1478,19 @@ private:
                         requestAndPromise.mRequest->mRequestId,
                         requestAndPromise.mRequest->getContextPhaseParams().value().getReqId(), err.what());
                     requestAndPromise.mPromise->set_exception(std::current_exception());
+                }
+                catch (...)
+                {
+                    TLLM_LOG_ERROR("Unknown exception in CacheReceiver request() loop");
+                    if (requestAndPromise.mPromise)
+                    {
+                        requestAndPromise.mPromise->set_exception(std::current_exception());
+                    }
+                }
+                if (requestAndPromise.mRequest != nullptr)
+                {
+                    std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
+                    mInFlightCancelFlags.erase(requestAndPromise.mRequest->mRequestId);
                 }
             }
         }
@@ -1300,6 +1519,8 @@ private:
     std::ofstream mMeasuresFile;
     std::mutex mMeasuresFileMutex;
     std::atomic<bool> mTerminate{false};
+    std::mutex mInFlightCancelMutex;
+    std::unordered_map<LlmRequest::RequestIdType, std::shared_ptr<std::atomic<bool>>> mInFlightCancelFlags;
 };
 
 void CacheSender::ImplDeleter::operator()(Impl* ptr)

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -29,6 +29,7 @@
 #include "tensorrt_llm/executor/cache_transmission/cacheSplitConcat.h"
 #include "tensorrt_llm/runtime/common.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
+#include <algorithm>
 #include <chrono>
 #include <future>
 #include <map>
@@ -123,6 +124,49 @@ void TransferSession::appendMeasure(LlmRequest::TimePoint start, LlmRequest::Tim
     {
         mTimes->measures.emplace_back(Measure{start, end, size});
     }
+}
+
+void TransferSession::setReservedRecvBuffers(std::vector<BufferIndexHolder> holders)
+{
+    TLLM_CHECK(mReservedRecvBuffers.empty());
+    mReservedRecvBuffers = std::move(holders);
+}
+
+bool TransferSession::hasReservedRecvBuffer(BaseTransBufferManager const& manager) const noexcept
+{
+    return std::any_of(mReservedRecvBuffers.begin(), mReservedRecvBuffers.end(),
+        [&manager](BufferIndexHolder const& holder) { return holder.isBoundTo(manager); });
+}
+
+bool TransferSession::releaseReservedRecvBuffer(BaseTransBufferManager const& manager) noexcept
+{
+    auto const holderIt = std::find_if(mReservedRecvBuffers.begin(), mReservedRecvBuffers.end(),
+        [&manager](BufferIndexHolder const& holder) { return holder.isBoundTo(manager); });
+    if (holderIt == mReservedRecvBuffers.end())
+    {
+        return false;
+    }
+    holderIt->release();
+    mReservedRecvBuffers.erase(holderIt);
+    return true;
+}
+
+void TransferSession::releaseReservedRecvBuffers() noexcept
+{
+    for (auto& holder : mReservedRecvBuffers)
+    {
+        holder.release();
+    }
+    mReservedRecvBuffers.clear();
+}
+
+void TransferSession::poisonReservedRecvBuffers() noexcept
+{
+    for (auto& holder : mReservedRecvBuffers)
+    {
+        holder.poison();
+    }
+    mReservedRecvBuffers.clear();
 }
 
 void TransferSession::exportMeasure(std::ofstream& outFile, bool isContext) const
@@ -303,7 +347,10 @@ public:
         std::promise<void> promise;
         auto future = promise.get_future();
         llmRequest->setKvCacheTransferStart(LlmRequest::getSteadyClockNow());
-        (void) getOrCreateInFlightCancelFlag(llmRequest->mRequestId);
+        if (common::getEnvDisaggEnableInflightCancel())
+        {
+            (void) getOrCreateInFlightCancelFlag(llmRequest->mRequestId);
+        }
         {
             std::scoped_lock lock(mSenderMutex);
             TLLM_CHECK_WITH_INFO(
@@ -367,6 +414,7 @@ public:
             }
             mRequestToSession.erase(it);
         }
+        if (common::getEnvDisaggEnableInflightCancel())
         {
             std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
             mInFlightCancelFlags.erase(requestId);
@@ -387,6 +435,10 @@ public:
         catch (...)
         {
             TLLM_LOG_WARNING("Failed to discard sender session for request %ld: unknown exception", requestId);
+        }
+        if (!common::getEnvDisaggEnableInflightCancel())
+        {
+            return;
         }
         try
         {
@@ -443,16 +495,25 @@ public:
 
         TLLM_CHECK_WITH_INFO(peerIdx < static_cast<int>(allCounterparts.size()),
             "Peer rank %d not found in expected counterparts", peerSelfIdx);
-        auto cancelFlag = getOrCreateInFlightCancelFlag(requestId);
+        std::shared_ptr<std::atomic<bool>> cancelFlag;
+        if (common::getEnvDisaggEnableInflightCancel())
+        {
+            cancelFlag = getOrCreateInFlightCancelFlag(requestId);
+        }
         {
             std::unique_lock<std::mutex> lk(mMtxForMap);
             auto it = mRequestToSession.find(requestId);
             if (it == mRequestToSession.end())
             {
-                auto session = TransferSession(std::vector<Connection const*>(allCounterparts.size(), nullptr),
-                    DataContext{tagFromRequestId(requestId), *cancelFlag}, allCounterparts, mSelfState,
-                    info.getTransState(), mBufferManager, info.getIndexFromEnd(), info.getLastBlockKey(), nullptr,
-                    !common::getEnvKVCacheTimeOutputPath().empty());
+                auto session = cancelFlag != nullptr
+                    ? TransferSession(std::vector<Connection const*>(allCounterparts.size(), nullptr),
+                        DataContext{tagFromRequestId(requestId), *cancelFlag}, allCounterparts, mSelfState,
+                        info.getTransState(), mBufferManager, info.getIndexFromEnd(), info.getLastBlockKey(), nullptr,
+                        !common::getEnvKVCacheTimeOutputPath().empty())
+                    : TransferSession(std::vector<Connection const*>(allCounterparts.size(), nullptr),
+                        DataContext{tagFromRequestId(requestId), mTerminate}, allCounterparts, mSelfState,
+                        info.getTransState(), mBufferManager, info.getIndexFromEnd(), info.getLastBlockKey(), nullptr,
+                        !common::getEnvKVCacheTimeOutputPath().empty());
                 session.setTime(TransferSession::kTimeRequestInfo);
                 it = mRequestToSession.emplace(requestId, std::move(session)).first;
             }
@@ -479,19 +540,36 @@ public:
 
     bool cancelRequest(LlmRequest const& llmRequest)
     {
+        bool const inflightCancelEnabled = common::getEnvDisaggEnableInflightCancel();
         bool isCancelled = false;
+        bool isCurrentRequest = false;
         {
             std::scoped_lock lock(mSenderMutex);
             auto it = mReadyResponses.find(llmRequest.mRequestId);
-            // If the request is not the current request and already in the ready queue, we can cancel it.
-            if (it != mReadyResponses.end()
-                && (!mCurrentRequest.has_value() || mCurrentRequest.value() != llmRequest.mRequestId))
+            if (it != mReadyResponses.end())
             {
-                mCancelledRequests.insert(llmRequest.mRequestId);
-                isCancelled = true;
+                isCurrentRequest = mCurrentRequest.has_value() && mCurrentRequest.value() == llmRequest.mRequestId;
+                // The legacy path cannot interrupt a ready/active transfer, so
+                // preserve its false return until the opt-in is enabled.
+                if (!isCurrentRequest || inflightCancelEnabled)
+                {
+                    mCancelledRequests.insert(llmRequest.mRequestId);
+                    isCancelled = true;
+                    if (inflightCancelEnabled && !isCurrentRequest)
+                    {
+                        // Keep only the request ID as a tombstone so a late peer
+                        // receives ready=false without retaining the request.
+                        failResponse(it->second,
+                            std::make_exception_ptr(
+                                TLLM_REQUEST_EXCEPTION(llmRequest.mRequestId, common::RequestErrorCode::kNETWORK_ERROR,
+                                    "Context KV cache request cancelled before a peer was ready for request %zu",
+                                    llmRequest.mRequestId)));
+                        mReadyResponses.erase(it);
+                    }
+                }
             }
         }
-        if (!isCancelled && common::getEnvDisaggEnableInflightCancel())
+        if (inflightCancelEnabled && (!isCancelled || isCurrentRequest))
         {
             std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
             auto flagIt = mInFlightCancelFlags.find(llmRequest.mRequestId);
@@ -504,6 +582,10 @@ public:
         if (!isCancelled)
         {
             TLLM_LOG_WARNING("Cannot cancel request %zu", llmRequest.mRequestId);
+        }
+        else
+        {
+            mSenderCv.notify_all();
         }
         return isCancelled;
     }
@@ -611,6 +693,13 @@ private:
             discardTransferState(id);
             failResponse(resp, exception);
         }
+        catch (...)
+        {
+            auto const exception = std::current_exception();
+            TLLM_LOG_ERROR("Unknown exception in sendAndRemoveResponse for request id: %ld", id);
+            discardTransferState(id);
+            failResponse(resp, exception);
+        }
     }
 
     void asyncSendAndRemoveResponse(RequestIdType id, Response resp) noexcept
@@ -627,26 +716,55 @@ private:
             discardTransferState(id);
             failResponse(resp, std::current_exception());
         }
+        catch (...)
+        {
+            TLLM_LOG_ERROR("Unknown error while queueing asynchronous KV cache send for request %zu", id);
+            discardTransferState(id);
+            failResponse(resp, std::current_exception());
+        }
     }
 
     void sendResponse(RequestIdType reqId)
     {
         bool isReady = true;
+        bool allCounterpartsReady = false;
+        std::optional<Response> cancelledResponse;
         {
             std::scoped_lock lock(mSenderMutex);
             TLLM_CHECK(mCurrentRequest.has_value() && mCurrentRequest.value() == reqId);
-            TLLM_CHECK(mReadyResponses.find(reqId) != mReadyResponses.end());
+            auto responseIt = mReadyResponses.find(reqId);
+            bool const isCancelled = mCancelledRequests.find(reqId) != mCancelledRequests.end();
+            TLLM_CHECK(responseIt != mReadyResponses.end() || isCancelled);
             auto countIt = mRemainSendCount.find(reqId);
             TLLM_CHECK(countIt != mRemainSendCount.end());
             auto const count = --countIt->second;
             TLLM_CHECK(count >= 0);
+            if (isCancelled && responseIt != mReadyResponses.end())
+            {
+                cancelledResponse.emplace(std::move(responseIt->second));
+                mReadyResponses.erase(responseIt);
+            }
             if (count > 0)
             {
                 mCurrentRequest = std::nullopt;
-                return;
             }
-            mRemainSendCount.erase(countIt);
-            isReady = mCancelledRequests.find(reqId) == mCancelledRequests.end();
+            else
+            {
+                mRemainSendCount.erase(countIt);
+                isReady = !isCancelled;
+                allCounterpartsReady = true;
+            }
+        }
+
+        if (cancelledResponse.has_value())
+        {
+            failResponse(*cancelledResponse,
+                std::make_exception_ptr(TLLM_REQUEST_EXCEPTION(reqId, common::RequestErrorCode::kNETWORK_ERROR,
+                    "KV cache transfer for request %zu was cancelled", reqId)));
+        }
+        if (!allCounterpartsReady)
+        {
+            return;
         }
 
         // Keep mCurrentRequest set while notifying the peer so cancellation cannot change the decision after it has
@@ -657,9 +775,12 @@ private:
         {
             std::scoped_lock lock(mSenderMutex);
             auto it = mReadyResponses.find(reqId);
-            TLLM_CHECK(it != mReadyResponses.end());
-            response = std::move(it->second);
-            mReadyResponses.erase(it);
+            if (isReady)
+            {
+                TLLM_CHECK(it != mReadyResponses.end());
+                response = std::move(it->second);
+                mReadyResponses.erase(it);
+            }
             mCancelledRequests.erase(reqId);
             mCurrentRequest = std::nullopt;
         }
@@ -682,9 +803,6 @@ private:
         else
         {
             discardTransferState(reqId);
-            failResponse(response,
-                std::make_exception_ptr(TLLM_REQUEST_EXCEPTION(reqId, common::RequestErrorCode::kNETWORK_ERROR,
-                    "KV cache transfer for request %zu was cancelled", reqId)));
         }
     }
 
@@ -699,7 +817,8 @@ private:
             {
                 {
                     std::unique_lock lock(mSenderMutex);
-                    mSenderCv.wait(lock, [this]() { return mTerminate || !mReadyResponses.empty(); });
+                    mSenderCv.wait(lock,
+                        [this]() { return mTerminate || !mReadyResponses.empty() || !mCancelledRequests.empty(); });
                     if (mTerminate)
                     {
                         break;
@@ -722,7 +841,11 @@ private:
                     std::unique_lock lock(mSenderMutex);
                     mCurrentRequest = reqId;
                     mSenderCv.wait(lock,
-                        [this, reqId]() { return mTerminate || mReadyResponses.find(reqId) != mReadyResponses.end(); });
+                        [this, reqId]()
+                        {
+                            return mTerminate || mReadyResponses.find(reqId) != mReadyResponses.end()
+                                || mCancelledRequests.find(reqId) != mCancelledRequests.end();
+                        });
                     if (mTerminate)
                     {
                         mCurrentRequest = std::nullopt;
@@ -735,6 +858,11 @@ private:
         catch (std::exception const& err)
         {
             TLLM_LOG_ERROR("Exception in CacheSender response: %s", err.what());
+            responseException = std::current_exception();
+        }
+        catch (...)
+        {
+            TLLM_LOG_ERROR("Unknown exception in CacheSender response");
             responseException = std::current_exception();
         }
 
@@ -757,6 +885,7 @@ private:
             std::scoped_lock lock(mSenderMutex);
             mTerminate = true;
         }
+        if (common::getEnvDisaggEnableInflightCancel())
         {
             std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
             for (auto& [id, flag] : mInFlightCancelFlags)
@@ -897,8 +1026,10 @@ public:
                 mRequestFutures.emplace_back(std::move(requestFuture));
             }
             auto& asyncResource = mInstanceToAsyncResource.at(processInfo);
-            auto cancelFlag = std::make_shared<std::atomic<bool>>(false);
+            std::shared_ptr<std::atomic<bool>> cancelFlag;
+            if (common::getEnvDisaggEnableInflightCancel())
             {
+                cancelFlag = std::make_shared<std::atomic<bool>>(false);
                 std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
                 mInFlightCancelFlags[llmRequest->mRequestId] = cancelFlag;
             }
@@ -917,23 +1048,34 @@ public:
 
     void receiveSync(TransferSession& session)
     {
-        mCacheTransferLayer.unformat(session);
-        if (!common::getEnvKVCacheTimeOutputPath().empty())
+        try
         {
-            std::unique_lock<std::mutex> lock(mMeasuresFileMutex);
-            if (!mMeasuresFile.is_open())
+            mCacheTransferLayer.unformat(session);
+            if (!common::getEnvKVCacheTimeOutputPath().empty())
             {
-                auto outputPath = getTransferOutputPath("recv");
-                mMeasuresFile.open(outputPath);
-                TLLM_CHECK_WITH_INFO(
-                    mMeasuresFile.is_open(), "Failed to open transfer output file: %s", outputPath.string().c_str());
+                std::unique_lock<std::mutex> lock(mMeasuresFileMutex);
+                if (!mMeasuresFile.is_open())
+                {
+                    auto outputPath = getTransferOutputPath("recv");
+                    mMeasuresFile.open(outputPath);
+                    TLLM_CHECK_WITH_INFO(mMeasuresFile.is_open(), "Failed to open transfer output file: %s",
+                        outputPath.string().c_str());
+                }
+                session.exportMeasure(mMeasuresFile, false);
             }
-            session.exportMeasure(mMeasuresFile, false);
+            session.releaseReservedRecvBuffers();
+        }
+        catch (...)
+        {
+            if (common::getEnvDisaggEnableInflightCancel())
+            {
+                session.poisonReservedRecvBuffers();
+            }
+            throw;
         }
     }
 
-    TransferSession sendRequestInfo(LlmRequest const& llmRequest, std::atomic<bool> const* perRequestCancel = nullptr,
-        std::vector<std::optional<size_t>> cacheBufferIds = {})
+    TransferSession sendRequestInfo(LlmRequest const& llmRequest, std::atomic<bool> const* perRequestCancel = nullptr)
     {
         uint64_t requestId = llmRequest.getContextPhaseParams().value().getReqId();
         auto const& contextState = llmRequest.getDataTransceiverState();
@@ -975,21 +1117,25 @@ public:
         }
 
         auto* agentConnectionManager = dynamic_cast<executor::kv_cache::AgentConnectionManager*>(mManager);
+        std::vector<BufferIndexHolder> recvHolders;
+        std::vector<std::optional<size_t>> cacheBufferIds;
         if (agentConnectionManager)
         {
-            if (cacheBufferIds.empty())
+            auto const* bufferCancel = common::getEnvDisaggEnableInflightCancel() ? perRequestCancel : nullptr;
+            auto const& managers = agentConnectionManager->getCacheTransBufferManagers();
+            recvHolders.reserve(managers.size());
+            cacheBufferIds.reserve(managers.size());
+            for (auto& cacheTransBufferManager : managers)
             {
-                for (auto& cacheTransBufferManager : agentConnectionManager->getCacheTransBufferManagers())
+                auto rawIdx = cacheTransBufferManager->assignBufferIndexForRecv(bufferCancel);
+                recvHolders.emplace_back(*cacheTransBufferManager, rawIdx, /*isRecv=*/true);
+                if (rawIdx.has_value())
                 {
-                    auto rawIdx = cacheTransBufferManager->assignBufferIndexForRecv(perRequestCancel);
-                    if (rawIdx.has_value())
-                    {
-                        cacheBufferIds.push_back(static_cast<size_t>(rawIdx.value()));
-                    }
-                    else
-                    {
-                        cacheBufferIds.push_back(std::nullopt);
-                    }
+                    cacheBufferIds.push_back(static_cast<size_t>(rawIdx.value()));
+                }
+                else
+                {
+                    cacheBufferIds.push_back(std::nullopt);
                 }
             }
             TLLM_CHECK(!cacheBufferIds.empty());
@@ -1019,77 +1165,102 @@ public:
             allConnections.emplace_back(connection);
         }
 
-        for (size_t ci = 0; ci < allCounterparts.size(); ci++)
+        if (common::getEnvDisaggEnableInflightCancel() && perRequestCancel != nullptr
+            && perRequestCancel->load(std::memory_order_relaxed))
         {
-            auto rank = allCounterparts[ci];
-            auto const* connection = connections.at(rank);
+            TLLM_THROW("KV cache receive request cancelled before publishing receive buffers");
+        }
 
-            bool isKvCounterpart
-                = std::find(kvCounterParts.begin(), kvCounterParts.end(), rank) != kvCounterParts.end();
-            bool isRnnCounterpart
-                = hasRnn && std::find(rnnCounterParts.begin(), rnnCounterParts.end(), rank) != rnnCounterParts.end();
-
-            if (agentConnectionManager)
+        try
+        {
+            for (size_t ci = 0; ci < allCounterparts.size(); ci++)
             {
-                auto idsForRank = cacheBufferIds;
-                auto const& managers = agentConnectionManager->getCacheTransBufferManagers();
-                for (size_t i = 0; i < idsForRank.size(); i++)
+                auto rank = allCounterparts[ci];
+                auto const* connection = connections.at(rank);
+
+                bool isKvCounterpart
+                    = std::find(kvCounterParts.begin(), kvCounterParts.end(), rank) != kvCounterParts.end();
+                bool isRnnCounterpart = hasRnn
+                    && std::find(rnnCounterParts.begin(), rnnCounterParts.end(), rank) != rnnCounterParts.end();
+
+                if (agentConnectionManager)
                 {
-                    auto kind = managers[i]->getBufferKind();
-                    bool include = (kind != BufferKind::kRNN) ? isKvCounterpart : isRnnCounterpart;
-                    if (!include)
+                    auto idsForRank = cacheBufferIds;
+                    auto const& managers = agentConnectionManager->getCacheTransBufferManagers();
+                    for (size_t i = 0; i < idsForRank.size(); i++)
                     {
-                        idsForRank[i] = std::nullopt;
+                        auto kind = managers[i]->getBufferKind();
+                        bool include = (kind != BufferKind::kRNN) ? isKvCounterpart : isRnnCounterpart;
+                        if (!include)
+                        {
+                            idsForRank[i] = std::nullopt;
+                        }
                     }
-                }
 
-                int validConnectionIdx = 0;
-                if (isKvCounterpart)
+                    int validConnectionIdx = 0;
+                    if (isKvCounterpart)
+                    {
+                        auto kvCpIdx
+                            = std::find(kvCounterParts.begin(), kvCounterParts.end(), rank) - kvCounterParts.begin();
+                        auto [pickUpIdx, localRankIdx] = mCacheTransferLayer.getKvFormatter()->pickRecvConnections(
+                            allCounterparts.size(), mSelfState.getCacheState().value(),
+                            mSelfState.getCommState().value().getSelfIdx(), destCacheState, allCounterparts);
+                        validConnectionIdx
+                            = std::find(localRankIdx.begin(), localRankIdx.end(), kvCpIdx) - localRankIdx.begin();
+                    }
+                    else if (isRnnCounterpart)
+                    {
+                        auto rnnTargetInfo = executor::kv_cache::targetIRanksForRnn(destCacheState,
+                            mCacheTransferLayer.getCacheState(), mSelfState.getCommState().value().getSelfIdx());
+                        auto rnnCpIdx
+                            = std::find(rnnCounterParts.begin(), rnnCounterParts.end(), rank) - rnnCounterParts.begin();
+                        auto [pickUpIdx, localRankIdx]
+                            = cache_formatter_utils::pickRecvConnections(rnnCounterParts.size(),
+                                mCacheTransferLayer.getCacheState(), mSelfState.getCommState().value().getSelfIdx(),
+                                destCacheState, rnnCounterParts, rnnTargetInfo);
+                        validConnectionIdx
+                            = std::find(localRankIdx.begin(), localRankIdx.end(), rnnCpIdx) - localRankIdx.begin();
+                    }
+
+                    auto* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connection);
+                    TLLM_CHECK(agentConnection != nullptr);
+
+                    const_cast<executor::kv_cache::AgentConnection*>(agentConnection)
+                        ->sendRequestAndBufferInfo(requestInfo, idsForRank, validConnectionIdx, perRequestCancel);
+                }
+                else
                 {
-                    auto kvCpIdx
-                        = std::find(kvCounterParts.begin(), kvCounterParts.end(), rank) - kvCounterParts.begin();
-                    auto [pickUpIdx, localRankIdx] = mCacheTransferLayer.getKvFormatter()->pickRecvConnections(
-                        allCounterparts.size(), mSelfState.getCacheState().value(),
-                        mSelfState.getCommState().value().getSelfIdx(), destCacheState, allCounterparts);
-                    validConnectionIdx
-                        = std::find(localRankIdx.begin(), localRankIdx.end(), kvCpIdx) - localRankIdx.begin();
+                    sendRequestInfo(connection, requestInfo);
                 }
-                else if (isRnnCounterpart)
-                {
-                    auto rnnTargetInfo = executor::kv_cache::targetIRanksForRnn(destCacheState,
-                        mCacheTransferLayer.getCacheState(), mSelfState.getCommState().value().getSelfIdx());
-                    auto rnnCpIdx
-                        = std::find(rnnCounterParts.begin(), rnnCounterParts.end(), rank) - rnnCounterParts.begin();
-                    auto [pickUpIdx, localRankIdx] = cache_formatter_utils::pickRecvConnections(rnnCounterParts.size(),
-                        mCacheTransferLayer.getCacheState(), mSelfState.getCommState().value().getSelfIdx(),
-                        destCacheState, rnnCounterParts, rnnTargetInfo);
-                    validConnectionIdx
-                        = std::find(localRankIdx.begin(), localRankIdx.end(), rnnCpIdx) - localRankIdx.begin();
-                }
-
-                auto* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connection);
-                TLLM_CHECK(agentConnection != nullptr);
-
-                const_cast<executor::kv_cache::AgentConnection*>(agentConnection)
-                    ->sendRequestAndBufferInfo(requestInfo, idsForRank, validConnectionIdx, perRequestCancel);
             }
-            else
+
+            auto const& resource = getReceiveCacheResource(llmRequest);
+            TransferSession session = perRequestCancel != nullptr
+                ? TransferSession(std::move(allConnections),
+                    DataContext{tagFromRequestId(requestId), *perRequestCancel}, std::move(allCounterparts), mSelfState,
+                    contextState, resource->mBufferManager, requestInfo.getIndexFromEnd(),
+                    requestInfo.getLastBlockKey(), &llmRequest, !common::getEnvKVCacheTimeOutputPath().empty())
+                : TransferSession(std::move(allConnections), DataContext{tagFromRequestId(requestId), mTerminate},
+                    std::move(allCounterparts), mSelfState, contextState, resource->mBufferManager,
+                    requestInfo.getIndexFromEnd(), requestInfo.getLastBlockKey(), &llmRequest,
+                    !common::getEnvKVCacheTimeOutputPath().empty());
+            if (!recvHolders.empty())
             {
-                sendRequestInfo(connection, requestInfo);
+                session.setReservedRecvBuffers(std::move(recvHolders));
             }
+            return session;
         }
-        auto const& resource = getReceiveCacheResource(llmRequest);
-        if (perRequestCancel != nullptr)
+        catch (...)
         {
-            return TransferSession(std::move(allConnections),
-                DataContext{tagFromRequestId(requestId), *perRequestCancel}, std::move(allCounterparts), mSelfState,
-                contextState, resource->mBufferManager, requestInfo.getIndexFromEnd(), requestInfo.getLastBlockKey(),
-                &llmRequest, !common::getEnvKVCacheTimeOutputPath().empty());
+            if (common::getEnvDisaggEnableInflightCancel())
+            {
+                for (auto& holder : recvHolders)
+                {
+                    holder.poison();
+                }
+            }
+            throw;
         }
-        return TransferSession(std::move(allConnections), DataContext{tagFromRequestId(requestId), mTerminate},
-            std::move(allCounterparts), mSelfState, contextState, resource->mBufferManager,
-            requestInfo.getIndexFromEnd(), requestInfo.getLastBlockKey(), &llmRequest,
-            !common::getEnvKVCacheTimeOutputPath().empty());
     }
 
     std::unique_ptr<ReceiveCacheResource> const& getReceiveCacheResource(LlmRequest const& llmRequest)
@@ -1128,11 +1299,26 @@ public:
         std::string processInfo = kDefaultProcessInfo;
         if (common::getEnvRequestKVCacheConcurrent())
         {
-            processInfo = llmRequest.getDataTransceiverState().getCommState()->toString();
+            auto const& commState = llmRequest.getDataTransceiverState().getCommState();
+            if (!commState.has_value())
+            {
+                TLLM_LOG_WARNING("Cannot cancel request %zu: the request has no data-transceiver communication state",
+                    llmRequest.mRequestId);
+                return false;
+            }
+            processInfo = commState->toString();
+        }
+
+        auto const resourceIt = mInstanceToAsyncResource.find(processInfo);
+        if (resourceIt == mInstanceToAsyncResource.end())
+        {
+            TLLM_LOG_WARNING("Cannot cancel request %zu: receive worker %s is not registered", llmRequest.mRequestId,
+                processInfo.c_str());
+            return false;
         }
 
         bool isCancelled = false;
-        auto& asyncResource = mInstanceToAsyncResource.at(processInfo);
+        auto& asyncResource = resourceIt->second;
         std::optional<LlmRequest::RequestIdType> queuedCancelledReqId;
         {
             std::unique_lock<std::mutex> lck(asyncResource->mMtxForQueue);
@@ -1163,7 +1349,7 @@ public:
                 queuedCancelledReqId = llmRequest.mRequestId;
             }
         }
-        if (queuedCancelledReqId.has_value())
+        if (common::getEnvDisaggEnableInflightCancel() && queuedCancelledReqId.has_value())
         {
             std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
             mInFlightCancelFlags.erase(*queuedCancelledReqId);
@@ -1189,13 +1375,15 @@ public:
     {
         kReady,
         kNotReady,
+        kMixed,
         kCancelled,
     };
 
     ReadySignalResult receiveReadySignalDetailed(TransferSession& session, std::atomic<bool> const& perRequestCancel)
     {
-        bool isReadyFinal = true;
         bool isReady = false;
+        bool anyReady = false;
+        bool anyNotReady = false;
         auto const& connections = session.getConnections();
         for (size_t i = 0; i < connections.size(); i++)
         {
@@ -1209,7 +1397,7 @@ public:
                 auto* agentConnection = dynamic_cast<executor::kv_cache::AgentConnection const*>(connections.at(i));
                 TLLM_CHECK(agentConnection);
                 auto ready = agentConnection->recvReadySignalWithStatus(
-                    executor::kv_cache::DataContext{TransceiverTag::kREADY_SIGNAL_TAG, perRequestCancel});
+                    executor::kv_cache::DataContext{session.getDataContext().getTag(), perRequestCancel});
                 if (!ready.has_value())
                 {
                     return ReadySignalResult::kCancelled;
@@ -1225,20 +1413,42 @@ public:
                     return ReadySignalResult::kCancelled;
                 }
             }
-            isReadyFinal &= isReady;
+            anyReady |= isReady;
+            anyNotReady |= !isReady;
         }
 
-        return isReadyFinal ? ReadySignalResult::kReady : ReadySignalResult::kNotReady;
+        if (anyReady && anyNotReady)
+        {
+            return ReadySignalResult::kMixed;
+        }
+        return anyReady ? ReadySignalResult::kReady : ReadySignalResult::kNotReady;
     }
 
     bool receiveReadySignal(TransferSession& session)
     {
-        return receiveReadySignalDetailed(session, mTerminate) == ReadySignalResult::kReady;
+        auto const result = receiveReadySignalDetailed(session, mTerminate);
+        if (result == ReadySignalResult::kNotReady)
+        {
+            session.releaseReservedRecvBuffers();
+        }
+        else if (result == ReadySignalResult::kMixed)
+        {
+            if (common::getEnvDisaggEnableInflightCancel())
+            {
+                session.poisonReservedRecvBuffers();
+            }
+            else
+            {
+                session.releaseReservedRecvBuffers();
+            }
+        }
+        return result == ReadySignalResult::kReady;
     }
 
     ~Impl()
     {
         mTerminate.store(true);
+        if (common::getEnvDisaggEnableInflightCancel())
         {
             std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
             for (auto& [id, flag] : mInFlightCancelFlags)
@@ -1264,101 +1474,90 @@ private:
         auto const contextRequestId = llmRequest.getContextPhaseParams().value().getReqId();
         char const* phase = "request-info";
         TLLM_LOG_DEBUG("KV cache receive request %zu, context request %zu started.", requestId, contextRequestId);
-        llmRequest.setKvCacheTransferStart(LlmRequest::getSteadyClockNow());
-        if (perRequestCancel.load(std::memory_order_relaxed) || mTerminate.load(std::memory_order_relaxed))
+        if (llmRequest.getKvCacheTransferStart() == LlmRequest::TimePoint{})
         {
-            llmRequest.setState(LlmRequestState::kDISAGG_TRANS_ERROR);
-            llmRequest.setKvCacheTransferEnd(LlmRequest::getSteadyClockNow());
-            return;
-        }
-        TLLM_CUDA_CHECK(cudaSetDevice(mDeviceId));
-
-        std::vector<BufferIndexHolder> recvHolders;
-        std::vector<std::optional<size_t>> cacheBufferIds;
-        auto* agentConnectionManager = dynamic_cast<executor::kv_cache::AgentConnectionManager*>(mManager);
-        if (agentConnectionManager)
-        {
-            auto const& managers = agentConnectionManager->getCacheTransBufferManagers();
-            recvHolders.reserve(managers.size());
-            cacheBufferIds.reserve(managers.size());
-            for (auto* cacheTransBufferManager : managers)
-            {
-                auto rawIdx = cacheTransBufferManager->assignBufferIndexForRecv(&perRequestCancel);
-                recvHolders.emplace_back(*cacheTransBufferManager, rawIdx, /*isRecv=*/true);
-                if (rawIdx.has_value())
-                {
-                    cacheBufferIds.push_back(static_cast<size_t>(rawIdx.value()));
-                }
-                else
-                {
-                    cacheBufferIds.push_back(std::nullopt);
-                }
-            }
+            llmRequest.setKvCacheTransferStart(LlmRequest::getSteadyClockNow());
         }
 
-        auto poisonRecvHolders = [&recvHolders]()
-        {
-            for (auto& holder : recvHolders)
-            {
-                holder.poison();
-            }
-        };
-
+        std::optional<TransferSession> session;
         try
         {
+            if (perRequestCancel.load(std::memory_order_relaxed) || mTerminate.load(std::memory_order_relaxed))
+            {
+                TLLM_THROW("KV cache receive request %zu cancelled before request-info", requestId);
+            }
+            TLLM_CUDA_CHECK(cudaSetDevice(mDeviceId));
             TLLM_LOG_DEBUG("KV cache receive request %zu, context request %zu phase=%s begin.", requestId,
                 contextRequestId, phase);
-            auto session = sendRequestInfo(llmRequest, &perRequestCancel, std::move(cacheBufferIds));
-            session.setTime(TransferSession::kTimeRequestInfo);
+            auto const* cancelFlag = common::getEnvDisaggEnableInflightCancel() ? &perRequestCancel : nullptr;
+            session.emplace(sendRequestInfo(llmRequest, cancelFlag));
+            session->setTime(TransferSession::kTimeRequestInfo);
             TLLM_LOG_DEBUG(
                 "KV cache receive request %zu, context request %zu phase=%s end.", requestId, contextRequestId, phase);
 
             phase = "ready-signal";
             TLLM_LOG_DEBUG("KV cache receive request %zu, context request %zu phase=%s begin.", requestId,
                 contextRequestId, phase);
-            auto readyResult = receiveReadySignalDetailed(session, perRequestCancel);
+            auto readyResult = receiveReadySignalDetailed(*session, perRequestCancel);
             TLLM_LOG_DEBUG("KV cache receive request %zu, context request %zu phase=%s end: result=%d.", requestId,
                 contextRequestId, phase, static_cast<int>(readyResult));
             if (readyResult == ReadySignalResult::kCancelled)
             {
                 if (common::getEnvDisaggEnableInflightCancel())
                 {
-                    poisonRecvHolders();
+                    session->poisonReservedRecvBuffers();
                 }
-                llmRequest.setState(LlmRequestState::kDISAGG_TRANS_ERROR);
-                llmRequest.setKvCacheTransferEnd(LlmRequest::getSteadyClockNow());
-                return;
+                TLLM_THROW("KV cache receive request %zu cancelled while waiting for the ready signal", requestId);
             }
             if (readyResult == ReadySignalResult::kNotReady)
             {
-                llmRequest.setState(LlmRequestState::kDISAGG_TRANS_ERROR);
-                llmRequest.setKvCacheTransferEnd(LlmRequest::getSteadyClockNow());
-                return;
+                session->releaseReservedRecvBuffers();
+                TLLM_THROW("KV cache receive request %zu was rejected by the context peer", requestId);
+            }
+            if (readyResult == ReadySignalResult::kMixed)
+            {
+                if (common::getEnvDisaggEnableInflightCancel())
+                {
+                    session->poisonReservedRecvBuffers();
+                }
+                else
+                {
+                    session->releaseReservedRecvBuffers();
+                }
+                TLLM_THROW("KV cache receive request %zu received inconsistent ready signals from its context peers",
+                    requestId);
             }
 
             phase = "transfer-completion-notification";
             TLLM_LOG_DEBUG("KV cache receive request %zu, context request %zu phase=%s begin.", requestId,
                 contextRequestId, phase);
-            receiveSync(session);
+            receiveSync(*session);
             TLLM_LOG_DEBUG(
                 "KV cache receive request %zu, context request %zu phase=%s end.", requestId, contextRequestId, phase);
             llmRequest.setKvCacheTransferEnd(LlmRequest::getSteadyClockNow());
-
-            for (auto& holder : recvHolders)
-            {
-                (void) holder.detach();
-            }
         }
         catch (std::exception const& err)
         {
-            if (common::getEnvDisaggEnableInflightCancel())
+            if (common::getEnvDisaggEnableInflightCancel() && session.has_value())
             {
-                poisonRecvHolders();
+                session->poisonReservedRecvBuffers();
             }
-            llmRequest.setState(LlmRequestState::kDISAGG_TRANS_ERROR);
             llmRequest.setKvCacheTransferEnd(LlmRequest::getSteadyClockNow());
             TLLM_LOG_ERROR("KV cache receive request %zu, context request %zu failed in phase=%s: %s", requestId,
                 contextRequestId, phase, err.what());
+            throw;
+        }
+        catch (...)
+        {
+            if (common::getEnvDisaggEnableInflightCancel() && session.has_value())
+            {
+                session->poisonReservedRecvBuffers();
+            }
+            llmRequest.setKvCacheTransferEnd(LlmRequest::getSteadyClockNow());
+            TLLM_LOG_ERROR(
+                "KV cache receive request %zu, context request %zu failed in phase=%s with an unknown "
+                "exception",
+                requestId, contextRequestId, phase);
             throw;
         }
 
@@ -1458,9 +1657,9 @@ private:
                 try
                 {
                     TLLM_CHECK_WITH_INFO(requestAndPromise.mRequest != nullptr, "requestAndPromise.mRequest is null");
-                    TLLM_CHECK_WITH_INFO(
-                        requestAndPromise.mCancelFlag != nullptr, "requestAndPromise.mCancelFlag is null");
-                    requestSync(*requestAndPromise.mRequest, *requestAndPromise.mCancelFlag);
+                    auto const& cancelFlag
+                        = requestAndPromise.mCancelFlag != nullptr ? *requestAndPromise.mCancelFlag : mTerminate;
+                    requestSync(*requestAndPromise.mRequest, cancelFlag);
                     requestAndPromise.mPromise->set_value();
                 }
                 catch (tensorrt_llm::common::RequestSpecificException const& err)
@@ -1487,7 +1686,7 @@ private:
                         requestAndPromise.mPromise->set_exception(std::current_exception());
                     }
                 }
-                if (requestAndPromise.mRequest != nullptr)
+                if (common::getEnvDisaggEnableInflightCancel() && requestAndPromise.mRequest != nullptr)
                 {
                     std::lock_guard<std::mutex> lg(mInFlightCancelMutex);
                     mInFlightCancelFlags.erase(requestAndPromise.mRequest->mRequestId);

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.h
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 
+#include "tensorrt_llm/batch_manager/baseTransBuffer.h"
 #include "tensorrt_llm/batch_manager/cacheTransceiver.h"
 #include "tensorrt_llm/batch_manager/cacheTransferLayer.h"
 #include "tensorrt_llm/batch_manager/llmRequest.h"
@@ -128,6 +129,20 @@ public:
 
     void appendMeasure(LlmRequest::TimePoint start, LlmRequest::TimePoint end, size_t size);
 
+    /// @brief Transfer ownership of pre-assigned receive buffers to this session.
+    void setReservedRecvBuffers(std::vector<BufferIndexHolder> holders);
+
+    [[nodiscard]] bool hasReservedRecvBuffer(BaseTransBufferManager const& manager) const noexcept;
+
+    /// @brief Release one formatter's pre-assigned buffer after its receive and postprocessing complete.
+    bool releaseReservedRecvBuffer(BaseTransBufferManager const& manager) noexcept;
+
+    /// @brief Release all pre-assigned receive buffers after the full receive pipeline completes.
+    void releaseReservedRecvBuffers() noexcept;
+
+    /// @brief Fail closed when receive-buffer quiescence cannot be established.
+    void poisonReservedRecvBuffers() noexcept;
+
     // TODO: 1. use global id instead of context request id; 2. export to llm metrics instead of file
     void exportMeasure(std::ofstream& outFile, bool isContext) const;
 
@@ -160,6 +175,7 @@ private:
     runtime::BufferManager const* mBufferManager;
     LlmRequest const* mRequest;
     std::unique_ptr<KVCacheTimes> mTimes;
+    std::vector<BufferIndexHolder> mReservedRecvBuffers;
     int32_t mIndexFromEnd{0};
     BlockKey mLastBlockKey{};
 };

--- a/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -253,7 +253,8 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
             return bufferSizeForTarget;
         };
         auto bufferEleSizes = getBufferSizeForTarget();
-        auto cacheBufferId = mCacheTransBufferManagers[transferIndexerKCache]->assignBufferIndexForSend();
+        auto const* sendCancelFlag = &session.getDataContext().getTransferTerminate();
+        auto cacheBufferId = mCacheTransBufferManagers[transferIndexerKCache]->assignBufferIndexForSend(sendCancelFlag);
         BufferIndexHolder sendHolder(
             *mCacheTransBufferManagers[transferIndexerKCache], cacheBufferId, /*isRecv=*/false);
         auto result = mCacheTransBufferManagers[transferIndexerKCache]->getOrAllocateSendBuffers(
@@ -346,48 +347,59 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
             session.appendMeasure(startTime, endTime, outputSplitCaches.at(cacheIdx)->getSizeInBytes());
         };
 
-        if (pickUpConnections.size() > 1)
+        try
         {
-            if (!common::getEnvEnableReceiveKVCacheParallel())
+            if (pickUpConnections.size() > 1)
             {
-                TLLM_LOG_DEBUG("Disable parallel receiving of the KV cache.");
-                for (size_t i = 0; i < pickUpConnections.size(); i++)
+                if (!common::getEnvEnableReceiveKVCacheParallel())
                 {
-                    sendBufferFun(deviceId, pickUpConnections[i]);
+                    TLLM_LOG_DEBUG("Disable parallel receiving of the KV cache.");
+                    for (size_t i = 0; i < pickUpConnections.size(); i++)
+                    {
+                        sendBufferFun(deviceId, pickUpConnections[i]);
+                    }
+                }
+                else
+                {
+                    // concurrency num
+                    auto concurrencyNum
+                        = std::min(std::max(static_cast<size_t>(1), bufferCoverTargetNum), pPDomainSize * cPDomainSize);
+
+                    auto remainSendNum = pickUpConnections.size();
+
+                    while (remainSendNum > 0)
+                    {
+                        auto sendConcurrencyNum = std::min(remainSendNum, concurrencyNum);
+                        std::vector<std::future<void>> futures;
+                        futures.reserve(sendConcurrencyNum);
+                        for (size_t i = 0; i < sendConcurrencyNum; i++)
+                        {
+                            size_t idx = i + (pickUpConnections.size() - remainSendNum);
+                            size_t connIdx = pickUpConnections[idx];
+                            TLLM_CHECK(idx < pickUpConnections.size());
+                            TLLM_CHECK(connIdx < session.getConnections().size());
+                            futures.push_back(std::async(std::launch::async, sendBufferFun, deviceId, connIdx));
+                        }
+                        for (auto& future : futures)
+                        {
+                            future.get();
+                        }
+                        remainSendNum -= sendConcurrencyNum;
+                    }
                 }
             }
             else
             {
-                // concurrency num
-                auto concurrencyNum
-                    = std::min(std::max(static_cast<size_t>(1), bufferCoverTargetNum), pPDomainSize * cPDomainSize);
-
-                auto remainSendNum = pickUpConnections.size();
-
-                while (remainSendNum > 0)
-                {
-                    auto sendConcurrencyNum = std::min(remainSendNum, concurrencyNum);
-                    std::vector<std::future<void>> futures;
-                    futures.reserve(sendConcurrencyNum);
-                    for (size_t i = 0; i < sendConcurrencyNum; i++)
-                    {
-                        size_t idx = i + (pickUpConnections.size() - remainSendNum);
-                        size_t connIdx = pickUpConnections[idx];
-                        TLLM_CHECK(idx < pickUpConnections.size());
-                        TLLM_CHECK(connIdx < session.getConnections().size());
-                        futures.push_back(std::async(std::launch::async, sendBufferFun, deviceId, connIdx));
-                    }
-                    for (auto& future : futures)
-                    {
-                        future.get();
-                    }
-                    remainSendNum -= sendConcurrencyNum;
-                }
+                sendBufferFun(deviceId, pickUpConnections[0]);
             }
         }
-        else
+        catch (...)
         {
-            sendBufferFun(deviceId, pickUpConnections[0]);
+            if (agentConnection != nullptr && common::getEnvDisaggEnableInflightCancel())
+            {
+                sendHolder.poison();
+            }
+            throw;
         }
         sendHolder.release();
     }

--- a/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
@@ -253,7 +253,8 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
             return bufferSizeForTarget;
         };
         auto bufferEleSizes = getBufferSizeForTarget();
-        auto const* sendCancelFlag = &session.getDataContext().getTransferTerminate();
+        auto const* sendCancelFlag
+            = common::getEnvDisaggEnableInflightCancel() ? &session.getDataContext().getTransferTerminate() : nullptr;
         auto cacheBufferId = mCacheTransBufferManagers[transferIndexerKCache]->assignBufferIndexForSend(sendCancelFlag);
         BufferIndexHolder sendHolder(
             *mCacheTransBufferManagers[transferIndexerKCache], cacheBufferId, /*isRecv=*/false);
@@ -346,6 +347,11 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
             auto endTime = LlmRequest::getSteadyClockNow();
             session.appendMeasure(startTime, endTime, outputSplitCaches.at(cacheIdx)->getSizeInBytes());
         };
+
+        if (sendCancelFlag != nullptr && sendCancelFlag->load(std::memory_order_relaxed))
+        {
+            TLLM_THROW("MLA cache transfer cancelled before NIXL submission");
+        }
 
         try
         {
@@ -519,13 +525,18 @@ void MLACacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& s
             if (preAssignedId.has_value())
             {
                 cacheBufferId = static_cast<int>(*preAssignedId);
+                if (!session.hasReservedRecvBuffer(*mCacheTransBufferManagers[transferIndexerKCache]))
+                {
+                    recvHolder = BufferIndexHolder(
+                        *mCacheTransBufferManagers[transferIndexerKCache], cacheBufferId, /*isRecv=*/true);
+                }
             }
             else
             {
                 cacheBufferId = mCacheTransBufferManagers[transferIndexerKCache]->assignBufferIndexForRecv();
+                recvHolder = BufferIndexHolder(
+                    *mCacheTransBufferManagers[transferIndexerKCache], cacheBufferId, /*isRecv=*/true);
             }
-            recvHolder
-                = BufferIndexHolder(*mCacheTransBufferManagers[transferIndexerKCache], cacheBufferId, /*isRecv=*/true);
 
             auto targetNum = pickUpConnections.size();
 
@@ -673,6 +684,7 @@ void MLACacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& s
             bufferManager.getStream().synchronize();
         }
 
+        (void) session.releaseReservedRecvBuffer(*mCacheTransBufferManagers[transferIndexerKCache]);
         recvHolder.release();
     }
     session.setTime(TransferSession::kTimePostprocess);

--- a/cpp/tensorrt_llm/batch_manager/rnnCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/rnnCacheFormatter.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,7 @@
 #include "tensorrt_llm/batch_manager/kvCacheUtils.h"
 #include "tensorrt_llm/common/assert.h"
 #include "tensorrt_llm/common/dataType.h"
+#include "tensorrt_llm/common/envUtils.h"
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/common/nvtxUtils.h"
 #include "tensorrt_llm/executor/cache_transmission/agent_utils/connection.h"
@@ -169,11 +170,24 @@ void RnnCacheFormatter::format(TransferSession& session)
                 bufferSizesPerTarget[t] = ssmBufBytes + convBufBytes;
             }
 
-            auto cacheBufferId = mRnnCacheTransBufferManager->assignBufferIndexForSend();
+            auto const* sendCancelFlag = &session.getDataContext().getTransferTerminate();
+            auto cacheBufferId = mRnnCacheTransBufferManager->assignBufferIndexForSend(sendCancelFlag);
+            BufferIndexHolder sendHolder(*mRnnCacheTransBufferManager, cacheBufferId, /*isRecv=*/false);
             auto allocationResult = mRnnCacheTransBufferManager->getOrAllocateSendBuffers(
                 cacheBufferId, static_cast<int>(bufferTargetNum), bufferSizesPerTarget, bufferManager);
             auto& outputBuffers = std::get<0>(allocationResult);
             auto& bufferCoverTargetNum = std::get<1>(allocationResult);
+            auto& onlyUseDynamicBuffer = std::get<2>(allocationResult);
+            TLLM_CHECK(cacheBufferId.has_value() || onlyUseDynamicBuffer);
+            auto const* agentConnection = rnnSendConns.empty()
+                ? nullptr
+                : dynamic_cast<executor::kv_cache::AgentConnection const*>(connections[rnnSendConns[0]]);
+            if (agentConnection != nullptr)
+            {
+                TLLM_CHECK_WITH_INFO(bufferCoverTargetNum == bufferTargetNum,
+                    "Agent needs all unified-pool RNN send buffers pre-allocated");
+                TLLM_CHECK(onlyUseDynamicBuffer == false);
+            }
 
             // Split each outputBuffer into SSM and conv portions.
             std::vector<runtime::ITensor::SharedPtr> ssmOutputBuffers(numTargets);
@@ -203,11 +217,22 @@ void RnnCacheFormatter::format(TransferSession& session)
             int deviceId;
             TLLM_CUDA_CHECK(cudaGetDevice(&deviceId));
             auto preAllocSendBuffer = mRnnCacheTransBufferManager->getSendBuffer(cacheBufferId);
-            sendAllBuffers(session, deviceId, outputBuffers, bufferCoverTargetNum, preAllocSendBuffer, bufferManager,
-                targetInfo, rnnSendConns);
+            try
+            {
+                sendAllBuffers(session, deviceId, outputBuffers, bufferCoverTargetNum, preAllocSendBuffer,
+                    bufferManager, targetInfo, rnnSendConns);
+            }
+            catch (...)
+            {
+                if (agentConnection != nullptr && common::getEnvDisaggEnableInflightCancel())
+                {
+                    sendHolder.poison();
+                }
+                throw;
+            }
 
             session.setTime(TransferSession::kTimeTransmissions);
-            mRnnCacheTransBufferManager->freeBufferIndexForSend(cacheBufferId);
+            sendHolder.release();
         }
     }
 

--- a/cpp/tensorrt_llm/batch_manager/rnnCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/rnnCacheFormatter.cpp
@@ -170,7 +170,9 @@ void RnnCacheFormatter::format(TransferSession& session)
                 bufferSizesPerTarget[t] = ssmBufBytes + convBufBytes;
             }
 
-            auto const* sendCancelFlag = &session.getDataContext().getTransferTerminate();
+            auto const* sendCancelFlag = common::getEnvDisaggEnableInflightCancel()
+                ? &session.getDataContext().getTransferTerminate()
+                : nullptr;
             auto cacheBufferId = mRnnCacheTransBufferManager->assignBufferIndexForSend(sendCancelFlag);
             BufferIndexHolder sendHolder(*mRnnCacheTransBufferManager, cacheBufferId, /*isRecv=*/false);
             auto allocationResult = mRnnCacheTransBufferManager->getOrAllocateSendBuffers(
@@ -217,6 +219,10 @@ void RnnCacheFormatter::format(TransferSession& session)
             int deviceId;
             TLLM_CUDA_CHECK(cudaGetDevice(&deviceId));
             auto preAllocSendBuffer = mRnnCacheTransBufferManager->getSendBuffer(cacheBufferId);
+            if (sendCancelFlag != nullptr && sendCancelFlag->load(std::memory_order_relaxed))
+            {
+                TLLM_THROW("Unified-pool RNN cache transfer cancelled before NIXL submission");
+            }
             try
             {
                 sendAllBuffers(session, deviceId, outputBuffers, bufferCoverTargetNum, preAllocSendBuffer,
@@ -372,15 +378,21 @@ void RnnCacheFormatter::unformat(TransferSession& session)
 
             // Use pre-assigned buffer ID from NIXL connection if available.
             std::optional<int> cacheBufferId = std::nullopt;
+            BufferIndexHolder recvHolder;
             auto preAssignedRnnId
                 = connections[rnnRecvConns[0]]->getPreAssignedBufferId(static_cast<uint8_t>(BufferKind::kRNN));
             if (preAssignedRnnId.has_value())
             {
                 cacheBufferId = static_cast<int>(*preAssignedRnnId);
+                if (!session.hasReservedRecvBuffer(*mRnnCacheTransBufferManager))
+                {
+                    recvHolder = BufferIndexHolder(*mRnnCacheTransBufferManager, cacheBufferId, /*isRecv=*/true);
+                }
             }
             else
             {
                 cacheBufferId = mRnnCacheTransBufferManager->assignBufferIndexForRecv();
+                recvHolder = BufferIndexHolder(*mRnnCacheTransBufferManager, cacheBufferId, /*isRecv=*/true);
             }
 
             auto allocationResult = mRnnCacheTransBufferManager->getOrAllocateRecvBuffers(
@@ -427,9 +439,11 @@ void RnnCacheFormatter::unformat(TransferSession& session)
 
             bufferManager.getStream().synchronize();
 
-            mRnnCacheTransBufferManager->freeBufferIndexForRecv(cacheBufferId);
+            recvHolder.release();
         }
     }
+
+    (void) session.releaseReservedRecvBuffer(*mRnnCacheTransBufferManager);
 
     TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(), "End receiving unified pool RNN state for request ID: %ld.",
         llmRequest.mRequestId);

--- a/cpp/tensorrt_llm/common/envUtils.cpp
+++ b/cpp/tensorrt_llm/common/envUtils.cpp
@@ -401,6 +401,12 @@ bool getEnvTryZCopyForKVCacheTransfer()
     return zcopyForSysmmetricKVCache;
 }
 
+bool getEnvDisaggEnableInflightCancel()
+{
+    static bool const enabled = getBoolEnv("TRTLLM_DISAGG_ENABLE_INFLIGHT_CANCEL");
+    return enabled;
+}
+
 bool getEnvForceDeterministic()
 {
     static bool const forceDeterministic = getBoolEnv("FORCE_DETERMINISTIC");

--- a/cpp/tensorrt_llm/common/envUtils.h
+++ b/cpp/tensorrt_llm/common/envUtils.h
@@ -115,6 +115,9 @@ std::string const& getEnvKVCacheTimeOutputPath();
 
 bool getEnvTryZCopyForKVCacheTransfer();
 
+// Opt-in for disaggregated KV transfer in-flight cancellation and fail-closed transfer-buffer quarantine.
+bool getEnvDisaggEnableInflightCancel();
+
 // Force deterministic behavior for all kernels.
 bool getEnvForceDeterministic();
 

--- a/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.cpp
@@ -189,25 +189,35 @@ void AgentConnection::send(DataContext const& ctx, void const* data, size_t size
     NotificationInfo notificationInfo{syncInfo};
     std::stringstream ss;
     NotificationInfo::serialize(notificationInfo, ss);
-    static constexpr int64_t kCancelPollTimeoutMs = 100;
-    TransferState transferState = TransferState::kIN_PROGRESS;
-    while (transferState == TransferState::kIN_PROGRESS)
+    bool const inflightCancelEnabled = common::getEnvDisaggEnableInflightCancel();
+    TransferState transferState;
+    if (!inflightCancelEnabled)
     {
-        transferState = status->wait(kCancelPollTimeoutMs);
-        if (transferState == TransferState::kIN_PROGRESS && ctx.getTransferTerminate().load(std::memory_order_relaxed))
+        transferState = status->wait();
+    }
+    else
+    {
+        static constexpr int64_t kCancelPollTimeoutMs = 100;
+        transferState = TransferState::kIN_PROGRESS;
+        while (transferState == TransferState::kIN_PROGRESS)
         {
-            bool const released = status->release();
-            TLLM_LOG_WARNING(
-                "AgentConnection::send cancelled while transfer was in progress (ctx tag=%d, remote=%s, "
-                "releaseAccepted=%d)",
-                ctx.getTag(), mRemoteAgentName.c_str(), released);
-            TLLM_CHECK_WITH_INFO(
-                released, "AgentConnection::send cancel could not release the backend transfer handle");
-            TLLM_THROW("AgentConnection::send cancelled mid-transfer");
+            transferState = status->wait(kCancelPollTimeoutMs);
+            if (transferState == TransferState::kIN_PROGRESS
+                && ctx.getTransferTerminate().load(std::memory_order_relaxed))
+            {
+                bool const released = status->release();
+                TLLM_LOG_WARNING(
+                    "AgentConnection::send cancelled while transfer was in progress (ctx tag=%d, remote=%s, "
+                    "releaseAccepted=%d)",
+                    ctx.getTag(), mRemoteAgentName.c_str(), released);
+                TLLM_CHECK_WITH_INFO(
+                    released, "AgentConnection::send cancel could not release the backend transfer handle");
+                TLLM_THROW("AgentConnection::send cancelled mid-transfer");
+            }
         }
     }
     TLLM_CHECK_WITH_INFO(transferState == TransferState::kSUCCESS, "AgentConnection::send failed");
-    if (ctx.getTransferTerminate().load(std::memory_order_relaxed))
+    if (inflightCancelEnabled && ctx.getTransferTerminate().load(std::memory_order_relaxed))
     {
         bool const released = status->release();
         TLLM_LOG_WARNING(
@@ -290,7 +300,8 @@ void AgentConnection::sendRequestAndBufferInfo(batch_manager::RequestInfo& reque
     std::stringstream ss;
     NotificationInfo notificationInfo{requestAndBufferInfo};
     NotificationInfo::serialize(notificationInfo, ss);
-    if (perRequestCancel != nullptr && perRequestCancel->load(std::memory_order_relaxed))
+    if (common::getEnvDisaggEnableInflightCancel() && perRequestCancel != nullptr
+        && perRequestCancel->load(std::memory_order_relaxed))
     {
         TLLM_THROW("sendRequestAndBufferInfo cancelled before notify");
     }

--- a/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.cpp
@@ -189,8 +189,35 @@ void AgentConnection::send(DataContext const& ctx, void const* data, size_t size
     NotificationInfo notificationInfo{syncInfo};
     std::stringstream ss;
     NotificationInfo::serialize(notificationInfo, ss);
-    TransferState transferState = status->wait();
+    static constexpr int64_t kCancelPollTimeoutMs = 100;
+    TransferState transferState = TransferState::kIN_PROGRESS;
+    while (transferState == TransferState::kIN_PROGRESS)
+    {
+        transferState = status->wait(kCancelPollTimeoutMs);
+        if (transferState == TransferState::kIN_PROGRESS && ctx.getTransferTerminate().load(std::memory_order_relaxed))
+        {
+            bool const released = status->release();
+            TLLM_LOG_WARNING(
+                "AgentConnection::send cancelled while transfer was in progress (ctx tag=%d, remote=%s, "
+                "releaseAccepted=%d)",
+                ctx.getTag(), mRemoteAgentName.c_str(), released);
+            TLLM_CHECK_WITH_INFO(
+                released, "AgentConnection::send cancel could not release the backend transfer handle");
+            TLLM_THROW("AgentConnection::send cancelled mid-transfer");
+        }
+    }
     TLLM_CHECK_WITH_INFO(transferState == TransferState::kSUCCESS, "AgentConnection::send failed");
+    if (ctx.getTransferTerminate().load(std::memory_order_relaxed))
+    {
+        bool const released = status->release();
+        TLLM_LOG_WARNING(
+            "AgentConnection::send cancelled after transfer completed but before notify (ctx tag=%d, remote=%s, "
+            "releaseAccepted=%d)",
+            ctx.getTag(), mRemoteAgentName.c_str(), released);
+        TLLM_CHECK_WITH_INFO(
+            released, "AgentConnection::send pre-notify cancel could not release the backend transfer handle");
+        TLLM_THROW("AgentConnection::send cancelled pre-notify");
+    }
     // TODO: there is a bug in request_with_notify https://github.com/ai-dynamo/nixl/pull/252
     mAgentConnectionManager->getAgent()->notifySyncMessage(mRemoteAgentName, ss.str());
 }
@@ -199,11 +226,19 @@ void AgentConnection::recv(DataContext const& ctx, void* data, size_t size) cons
 {
 
     NotificationSyncInfo syncInfo{mAgentName, ctx};
-    mAgentConnectionManager->waitForSyncInfo(mRemoteAgentName, syncInfo, ctx.getTransferTerminate());
+    bool const received
+        = mAgentConnectionManager->waitForSyncInfo(mRemoteAgentName, syncInfo, ctx.getTransferTerminate());
+    if (common::getEnvDisaggEnableInflightCancel())
+    {
+        TLLM_CHECK_WITH_INFO(received,
+            "AgentConnection::recv ended before receiving sync notification (ctx tag=%d, remote=%s)", ctx.getTag(),
+            mRemoteAgentName.c_str());
+    }
 }
 
 void AgentConnection::sendRequestAndBufferInfo(batch_manager::RequestInfo& requestInfo,
-    std::vector<std::optional<size_t>> const& cacheBufferIds, int connectionIdx)
+    std::vector<std::optional<size_t>> const& cacheBufferIds, int connectionIdx,
+    std::atomic<bool> const* perRequestCancel)
 {
     TLLM_CHECK(!common::getEnvTryZCopyForKVCacheTransfer());
 
@@ -255,6 +290,10 @@ void AgentConnection::sendRequestAndBufferInfo(batch_manager::RequestInfo& reque
     std::stringstream ss;
     NotificationInfo notificationInfo{requestAndBufferInfo};
     NotificationInfo::serialize(notificationInfo, ss);
+    if (perRequestCancel != nullptr && perRequestCancel->load(std::memory_order_relaxed))
+    {
+        TLLM_THROW("sendRequestAndBufferInfo cancelled before notify");
+    }
     mAgentConnectionManager->getAgent()->notifySyncMessage(mRemoteAgentName, ss.str());
 }
 
@@ -292,8 +331,16 @@ void AgentConnection::sendReadySignal(DataContext const& ctx, bool isReady) cons
 
 bool AgentConnection::recvReadySignal(DataContext const& ctx) const
 {
+    return recvReadySignalWithStatus(ctx).value_or(false);
+}
+
+std::optional<bool> AgentConnection::recvReadySignalWithStatus(DataContext const& ctx) const
+{
     ReadySignalInfo readySignalInfo{mAgentName, ctx, false};
-    mAgentConnectionManager->waitForReadySignal(mRemoteAgentName, readySignalInfo, ctx.getTransferTerminate());
+    if (!mAgentConnectionManager->waitForReadySignal(mRemoteAgentName, readySignalInfo, ctx.getTransferTerminate()))
+    {
+        return std::nullopt;
+    }
     return readySignalInfo.mIsReady;
 }
 
@@ -692,7 +739,7 @@ int AgentConnectionManager::getDeviceId() const
 }
 
 template <typename NotificationType>
-void AgentConnectionManager::waitForNotification(
+bool AgentConnectionManager::waitForNotification(
     std::string const& remoteAgentName, NotificationType& expectedInfo, std::atomic<bool> const& terminateFlag)
 {
     while (!terminateFlag.load())
@@ -700,7 +747,7 @@ void AgentConnectionManager::waitForNotification(
 
         if (!mIsRunning)
         {
-            return;
+            return false;
         }
         updateUnhandledNotifications();
         std::scoped_lock lock(mNotificationMutex);
@@ -733,7 +780,7 @@ void AgentConnectionManager::waitForNotification(
                             {
                                 it = mUnhandledNotifications.erase(it);
                             }
-                            return;
+                            return true;
                         }
                     }
                 }
@@ -753,7 +800,7 @@ void AgentConnectionManager::waitForNotification(
                             {
                                 it = mUnhandledNotifications.erase(it);
                             }
-                            return;
+                            return true;
                         }
                     }
                 }
@@ -773,24 +820,25 @@ void AgentConnectionManager::waitForNotification(
             }
         }
     }
+    return false;
 }
 
 // Explicit template instantiations
-template void AgentConnectionManager::waitForNotification<NotificationSyncInfo>(
+template bool AgentConnectionManager::waitForNotification<NotificationSyncInfo>(
     std::string const& remoteAgentName, NotificationSyncInfo& expectedInfo, std::atomic<bool> const& terminateFlag);
-template void AgentConnectionManager::waitForNotification<ReadySignalInfo>(
+template bool AgentConnectionManager::waitForNotification<ReadySignalInfo>(
     std::string const& remoteAgentName, ReadySignalInfo& expectedInfo, std::atomic<bool> const& terminateFlag);
 
-void AgentConnectionManager::waitForSyncInfo(
+bool AgentConnectionManager::waitForSyncInfo(
     std::string const& remoteAgentName, NotificationSyncInfo& syncInfo, std::atomic<bool> const& terminateFlag)
 {
-    waitForNotification(remoteAgentName, syncInfo, terminateFlag);
+    return waitForNotification(remoteAgentName, syncInfo, terminateFlag);
 }
 
-void AgentConnectionManager::waitForReadySignal(
+bool AgentConnectionManager::waitForReadySignal(
     std::string const& remoteAgentName, ReadySignalInfo& readySignalInfo, std::atomic<bool> const& terminateFlag)
 {
-    waitForNotification(remoteAgentName, readySignalInfo, terminateFlag);
+    return waitForNotification(remoteAgentName, readySignalInfo, terminateFlag);
 }
 
 std::string const& AgentConnectionManager::getAgentName() const

--- a/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/agent_utils/connection.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -260,13 +260,15 @@ public:
     void send(DataContext const& ctx, void const* data, size_t size) const override;
     void recv(DataContext const& ctx, void* data, size_t size) const override;
     void sendRequestAndBufferInfo(batch_manager::RequestInfo& requestInfo,
-        std::vector<std::optional<size_t>> const& cacheBufferIds, int validConnectionIdx);
-    void setSenderState(std::vector<MemoryDesc> cacheReceiverBufferDescs, int valideSegmentIdx,
+        std::vector<std::optional<size_t>> const& cacheBufferIds, int validConnectionIdx,
+        std::atomic<bool> const* perRequestCancel = nullptr);
+    void setSenderState(std::vector<MemoryDesc> cacheReceiverBufferDescs, int validSegmentIdx,
         std::vector<std::pair<size_t, size_t>> offsetRatios, std::vector<uint8_t> bufferKinds);
     void setHasLoadRemoteAgent(bool hasLoadRemoteAgent);
     [[nodiscard]] bool hasLoadRemoteAgent() const;
     void sendReadySignal(DataContext const& ctx, bool isReady) const;
     bool recvReadySignal(DataContext const& ctx) const;
+    std::optional<bool> recvReadySignalWithStatus(DataContext const& ctx) const;
 
     void activateBuffer(uint8_t kind) const override;
     [[nodiscard]] std::optional<size_t> getPreAssignedBufferId(uint8_t kind) const override;
@@ -320,11 +322,11 @@ public:
     [[nodiscard]] std::string const& getAgentName() const;
 
     template <typename NotificationType>
-    void waitForNotification(
+    bool waitForNotification(
         std::string const& remoteAgentName, NotificationType& expectedInfo, std::atomic<bool> const& terminateFlag);
-    void waitForSyncInfo(
+    bool waitForSyncInfo(
         std::string const& remoteAgentName, NotificationSyncInfo& syncInfo, std::atomic<bool> const& terminateFlag);
-    void waitForReadySignal(
+    bool waitForReadySignal(
         std::string const& remoteAgentName, ReadySignalInfo& readySignalInfo, std::atomic<bool> const& terminateFlag);
     [[nodiscard]] bool isRunning() const override;
 

--- a/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -328,19 +328,13 @@ NixlTransferStatus::NixlTransferStatus(std::weak_ptr<nixlAgent> agent, nixlXferR
 
 NixlTransferStatus::~NixlTransferStatus() noexcept
 {
-    if (mHandle == nullptr)
-    {
-        return;
-    }
-    // Skip release if the owning agent was reset; the underlying nixlXferReqH is already gone.
-    auto agent = mWeakAgent.lock();
-    if (!agent)
-    {
-        return;
-    }
     try
     {
-        agent->releaseXferReq(mHandle);
+        if (!release())
+        {
+            TLLM_LOG_WARNING(
+                "NIXL transfer handle release failed during destruction; backend handle may remain active");
+        }
     }
     catch (std::exception const& e)
     {
@@ -516,15 +510,24 @@ TransferState NixlTransferStatus::wait(int64_t timeout_ms) const
 
     while (true)
     {
-        auto agent = mWeakAgent.lock();
-        if (!agent)
+        nixl_status_t status;
         {
-            // Owning agent was reset; report failure so callers don't deref a null status.
-            mLastStatus.store(static_cast<int>(NIXL_ERR_INVALID_PARAM), std::memory_order_relaxed);
-            return TransferState::kFAILURE;
+            std::lock_guard<std::mutex> lock(mHandleMutex);
+            if (mHandle == nullptr)
+            {
+                mLastStatus.store(static_cast<int>(NIXL_ERR_INVALID_PARAM), std::memory_order_relaxed);
+                return TransferState::kFAILURE;
+            }
+            auto agent = mWeakAgent.lock();
+            if (!agent)
+            {
+                // Owning agent was reset; report failure so callers don't deref a null status.
+                mLastStatus.store(static_cast<int>(NIXL_ERR_INVALID_PARAM), std::memory_order_relaxed);
+                return TransferState::kFAILURE;
+            }
+            status = agent->getXferStatus(mHandle);
+            mLastStatus.store(static_cast<int>(status), std::memory_order_relaxed);
         }
-        auto status = agent->getXferStatus(mHandle);
-        mLastStatus.store(static_cast<int>(status), std::memory_order_relaxed);
         if (status == NIXL_SUCCESS)
         {
             return TransferState::kSUCCESS;
@@ -566,6 +569,12 @@ std::string NixlTransferStatus::getLastStatusStr() const
 
 [[nodiscard]] bool NixlTransferStatus::isCompleted() const
 {
+    std::lock_guard<std::mutex> lock(mHandleMutex);
+    if (mHandle == nullptr)
+    {
+        mLastStatus.store(static_cast<int>(NIXL_ERR_INVALID_PARAM), std::memory_order_relaxed);
+        return false;
+    }
     auto agent = mWeakAgent.lock();
     if (!agent)
     {
@@ -575,6 +584,34 @@ std::string NixlTransferStatus::getLastStatusStr() const
     auto status = agent->getXferStatus(mHandle);
     mLastStatus.store(static_cast<int>(status), std::memory_order_relaxed);
     return status == NIXL_SUCCESS;
+}
+
+[[nodiscard]] bool NixlTransferStatus::release()
+{
+    std::lock_guard<std::mutex> lock(mHandleMutex);
+    if (mHandle == nullptr)
+    {
+        return true;
+    }
+
+    auto agent = mWeakAgent.lock();
+    if (!agent)
+    {
+        mHandle = nullptr;
+        mLastStatus.store(static_cast<int>(NIXL_ERR_INVALID_PARAM), std::memory_order_relaxed);
+        return true;
+    }
+
+    auto status = agent->releaseXferReq(mHandle);
+    mLastStatus.store(static_cast<int>(status), std::memory_order_relaxed);
+    if (status == NIXL_SUCCESS)
+    {
+        mHandle = nullptr;
+        return true;
+    }
+
+    TLLM_LOG_WARNING("NIXL releaseXferReq failed with status: %s", nixlEnumStrings::statusStr(status).c_str());
+    return false;
 }
 
 NixlTransferAgent::NixlTransferAgent(BaseAgentConfig const& config)

--- a/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.cpp
+++ b/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.cpp
@@ -321,6 +321,7 @@ void NixlHelper::posixFileToGpuFallback(MemoryDescs const& memoryDescs, FileDesc
 NixlTransferStatus::NixlTransferStatus(std::weak_ptr<nixlAgent> agent, nixlXferReqH* handle)
     : mWeakAgent{std::move(agent)}
     , mHandle{handle}
+    , mSynchronizeHandleAccess{common::getEnvDisaggEnableInflightCancel()}
 {
     TLLM_CHECK(!mWeakAgent.expired());
     TLLM_CHECK(mHandle);
@@ -510,24 +511,7 @@ TransferState NixlTransferStatus::wait(int64_t timeout_ms) const
 
     while (true)
     {
-        nixl_status_t status;
-        {
-            std::lock_guard<std::mutex> lock(mHandleMutex);
-            if (mHandle == nullptr)
-            {
-                mLastStatus.store(static_cast<int>(NIXL_ERR_INVALID_PARAM), std::memory_order_relaxed);
-                return TransferState::kFAILURE;
-            }
-            auto agent = mWeakAgent.lock();
-            if (!agent)
-            {
-                // Owning agent was reset; report failure so callers don't deref a null status.
-                mLastStatus.store(static_cast<int>(NIXL_ERR_INVALID_PARAM), std::memory_order_relaxed);
-                return TransferState::kFAILURE;
-            }
-            status = agent->getXferStatus(mHandle);
-            mLastStatus.store(static_cast<int>(status), std::memory_order_relaxed);
-        }
+        auto const status = queryStatus();
         if (status == NIXL_SUCCESS)
         {
             return TransferState::kSUCCESS;
@@ -569,21 +553,36 @@ std::string NixlTransferStatus::getLastStatusStr() const
 
 [[nodiscard]] bool NixlTransferStatus::isCompleted() const
 {
-    std::lock_guard<std::mutex> lock(mHandleMutex);
-    if (mHandle == nullptr)
+    return queryStatus() == NIXL_SUCCESS;
+}
+
+nixl_status_t NixlTransferStatus::queryStatus() const
+{
+    auto const query = [this]()
     {
-        mLastStatus.store(static_cast<int>(NIXL_ERR_INVALID_PARAM), std::memory_order_relaxed);
-        return false;
-    }
-    auto agent = mWeakAgent.lock();
-    if (!agent)
+        if (mHandle == nullptr)
+        {
+            mLastStatus.store(static_cast<int>(NIXL_ERR_INVALID_PARAM), std::memory_order_relaxed);
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        auto agent = mWeakAgent.lock();
+        if (!agent)
+        {
+            // Owning agent was reset; report failure so callers don't deref a null status.
+            mLastStatus.store(static_cast<int>(NIXL_ERR_INVALID_PARAM), std::memory_order_relaxed);
+            return NIXL_ERR_INVALID_PARAM;
+        }
+        auto const status = agent->getXferStatus(mHandle);
+        mLastStatus.store(static_cast<int>(status), std::memory_order_relaxed);
+        return status;
+    };
+
+    if (mSynchronizeHandleAccess)
     {
-        mLastStatus.store(static_cast<int>(NIXL_ERR_INVALID_PARAM), std::memory_order_relaxed);
-        return false;
+        std::lock_guard<std::mutex> lock(mHandleMutex);
+        return query();
     }
-    auto status = agent->getXferStatus(mHandle);
-    mLastStatus.store(static_cast<int>(status), std::memory_order_relaxed);
-    return status == NIXL_SUCCESS;
+    return query();
 }
 
 [[nodiscard]] bool NixlTransferStatus::release()

--- a/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.h
@@ -21,6 +21,7 @@
 #include "tensorrt_llm/executor/transferAgent.h"
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <shared_mutex>
 #include <thread>
 
@@ -73,11 +74,14 @@ public:
     [[nodiscard]] int getLastStatus() const noexcept;
     [[nodiscard]] std::string getLastStatusStr() const;
 
+    [[nodiscard]] bool release() override;
+
 private:
     // weak_ptr so the status outliving the owning agent is safe (lock() returns null after reset).
     std::weak_ptr<nixlAgent> mWeakAgent;
     nixlXferReqH* mHandle{};
     mutable std::atomic<int> mLastStatus{0};
+    mutable std::mutex mHandleMutex;
 };
 
 class NixlTransferAgent final : public BaseTransferAgent

--- a/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.h
+++ b/cpp/tensorrt_llm/executor/cache_transmission/nixl_utils/transferAgent.h
@@ -77,10 +77,13 @@ public:
     [[nodiscard]] bool release() override;
 
 private:
+    [[nodiscard]] nixl_status_t queryStatus() const;
+
     // weak_ptr so the status outliving the owning agent is safe (lock() returns null after reset).
     std::weak_ptr<nixlAgent> mWeakAgent;
     nixlXferReqH* mHandle{};
     mutable std::atomic<int> mLastStatus{0};
+    bool const mSynchronizeHandleAccess;
     mutable std::mutex mHandleMutex;
 };
 

--- a/cpp/tensorrt_llm/nanobind/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/cacheTransceiver.cpp
@@ -111,7 +111,8 @@ void tb::CacheTransceiverBindings::initBindings(nb::module_& m)
         .def("check_gen_transfer_status", &BaseCacheTransceiver::checkGenTransferStatus,
             nb::call_guard<nb::gil_scoped_release>())
         .def("check_gen_transfer_complete", &BaseCacheTransceiver::checkGenTransferComplete)
-        .def("cancel_request", &BaseCacheTransceiver::cancelRequest);
+        .def("cancel_request", &BaseCacheTransceiver::cancelRequest)
+        .def("has_poisoned_transfer_buffer", &BaseCacheTransceiver::hasPoisonedTransferBuffer);
 
     nb::enum_<executor::kv_cache::CacheState::AttentionType>(m, "AttentionType")
         .value("DEFAULT", executor::kv_cache::CacheState::AttentionType::kDEFAULT)

--- a/cpp/tests/unit_tests/batch_manager/bufferIndexHolderTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/bufferIndexHolderTest.cpp
@@ -48,6 +48,16 @@ public:
     {
         return mConcurrenceRecvResource.mConcurrence.load();
     }
+
+    void configureIndexPoolsForTest(size_t count)
+    {
+        ASSERT_EQ(mConcurrenceSendResource.mConcurrence.load(), 0);
+        ASSERT_EQ(mConcurrenceRecvResource.mConcurrence.load(), 0);
+        mSendBufferCount = count;
+        mRecvBufferCount = count;
+        mConcurrenceSendResource.mBufferIndexFlag.assign(count, 0);
+        mConcurrenceRecvResource.mBufferIndexFlag.assign(count, 0);
+    }
 };
 
 } // namespace
@@ -69,12 +79,6 @@ class BufferIndexHolderLifecycleTest : public ::testing::TestWithParam<HolderCas
 protected:
     void SetUp() override
     {
-        setenv("TRTLLM_USE_UCX_KVCACHE", "1", 1);
-        // Move-assignment coverage requires two simultaneously held indices from either pool.
-        setenv("TRTLLM_REQUEST_KV_CACHE_CONCURRENT", "1", 1);
-        setenv("TRTLLM_KVCACHE_RECV_BUFFER_COUNT", "2", 1);
-        setenv("TRTLLM_KVCACHE_SEND_MAX_CONCURRENCY_NUM", "2", 1);
-
         int constexpr numLayers = 2;
         int constexpr numHeads = 2;
         int constexpr sizePerHead = 8;
@@ -95,6 +99,9 @@ protected:
             /*enableBlockReuse=*/true, CacheType::kSELF, std::nullopt, nullptr, true);
         mKv->allocatePools(false);
         mTrans = std::make_unique<ObservableTransBufferManager>(mKv.get(), std::optional<size_t>{kvMaxNumTokens});
+        // envUtils caches process-wide settings, so set up the index-only test
+        // pools directly instead of relying on test-order-sensitive setenv calls.
+        mTrans->configureIndexPoolsForTest(2);
     }
 
     void TearDown() override
@@ -174,6 +181,29 @@ TEST_P(BufferIndexHolderLifecycleTest, NulloptIndexCanPoisonManager)
     EXPECT_FALSE(holder.held());
     EXPECT_TRUE(mgr().hasPoisonedBuffer());
     EXPECT_EQ(inUse(), before);
+}
+
+// Poisoning a concrete slot fails the entire direction closed: the slot stays
+// reserved and no later request can acquire another buffer from that pool.
+TEST_P(BufferIndexHolderLifecycleTest, ValidIndexPoisonPreventsReuse)
+{
+    int const before = inUse();
+    auto idx = acquire();
+    ASSERT_TRUE(idx.has_value());
+    BufferIndexHolder holder{mgr(), idx, isRecv()};
+    EXPECT_EQ(inUse(), before + 1);
+
+    holder.poison();
+
+    EXPECT_FALSE(holder.held());
+    EXPECT_TRUE(mgr().hasPoisonedBuffer());
+    EXPECT_EQ(inUse(), before + 1);
+    EXPECT_THROW((void) acquire(), std::exception);
+
+    // poison() disarms the holder; neither an explicit release nor its
+    // destructor may return the quarantined slot to the pool.
+    holder.release();
+    EXPECT_EQ(inUse(), before + 1);
 }
 
 // RAII: a held slot is released when the holder goes out of scope.

--- a/cpp/tests/unit_tests/batch_manager/bufferIndexHolderTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/bufferIndexHolderTest.cpp
@@ -161,6 +161,21 @@ TEST_P(BufferIndexHolderLifecycleTest, NulloptIndexReleasesNothing)
     EXPECT_EQ(inUse(), before);
 }
 
+// A nullopt holder owns no concrete slot but retains the manager binding needed
+// to poison a dynamic buffer after an unquiesced transfer exit.
+TEST_P(BufferIndexHolderLifecycleTest, NulloptIndexCanPoisonManager)
+{
+    int const before = inUse();
+    BufferIndexHolder holder{mgr(), std::nullopt, isRecv()};
+    EXPECT_FALSE(holder.held());
+
+    holder.poison();
+
+    EXPECT_FALSE(holder.held());
+    EXPECT_TRUE(mgr().hasPoisonedBuffer());
+    EXPECT_EQ(inUse(), before);
+}
+
 // RAII: a held slot is released when the holder goes out of scope.
 TEST_P(BufferIndexHolderLifecycleTest, ValidIndexReleasedOnDestruction)
 {

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
@@ -21,6 +21,9 @@ BackendTypeCpp = tensorrt_llm.bindings.executor.CacheTransceiverBackendType
 
 _DISAGG_INFLIGHT_CANCEL_ENABLED_ENV = "TRTLLM_DISAGG_ENABLE_INFLIGHT_CANCEL"
 _NIXL_KVCACHE_BACKEND_ENV = "TRTLLM_NIXL_KVCACHE_BACKEND"
+_DISABLE_KV_CACHE_TRANSFER_OVERLAP_ENV = "TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP"
+_DISAGG_LAYERWISE_ENV = "TRTLLM_DISAGG_LAYERWISE"
+_TRY_ZCOPY_FOR_KV_CACHE_TRANSFER_ENV = "TRTLLM_TRY_ZCOPY_FOR_KVCACHE_TRANSFER"
 _SUPPORTED_INFLIGHT_CANCEL_NIXL_BACKEND = "UCX"
 _CACHE_TRANSCEIVER_BACKEND_ENV_VARS = (
     ("TRTLLM_USE_NIXL_KVCACHE", "NIXL"),
@@ -51,7 +54,11 @@ def _is_disagg_inflight_cancel_config_supported(
     nixl_backend = getenv(_NIXL_KVCACHE_BACKEND_ENV,
                           _SUPPORTED_INFLIGHT_CANCEL_NIXL_BACKEND)
     return (runtime == "CPP" and cache_transceiver_config.backend == "NIXL"
-            and nixl_backend == _SUPPORTED_INFLIGHT_CANCEL_NIXL_BACKEND)
+            and nixl_backend == _SUPPORTED_INFLIGHT_CANCEL_NIXL_BACKEND
+            and cache_transceiver_config.kv_transfer_timeout_ms is not None
+            and getenv(_DISABLE_KV_CACHE_TRANSFER_OVERLAP_ENV) != "1"
+            and getenv(_DISAGG_LAYERWISE_ENV) != "1"
+            and getenv(_TRY_ZCOPY_FOR_KV_CACHE_TRANSFER_ENV) != "1")
 
 
 def _validate_disagg_inflight_cancel_config(
@@ -63,7 +70,8 @@ def _validate_disagg_inflight_cancel_config(
         env_name for env_name, _ in _CACHE_TRANSCEIVER_BACKEND_ENV_VARS
         if getenv(env_name) == "1"
     ]
-    if len(enabled_backend_env_vars) > 1:
+    if (cache_transceiver_config.backend == "DEFAULT"
+            and len(enabled_backend_env_vars) > 1):
         raise ValueError(
             f"{_DISAGG_INFLIGHT_CANCEL_ENABLED_ENV}=1 requires an "
             "unambiguous cache transceiver backend, but multiple legacy "
@@ -75,13 +83,21 @@ def _validate_disagg_inflight_cancel_config(
     runtime = cache_transceiver_config.transceiver_runtime or "CPP"
     nixl_backend = getenv(_NIXL_KVCACHE_BACKEND_ENV,
                           _SUPPORTED_INFLIGHT_CANCEL_NIXL_BACKEND)
+    disable_overlap = getenv(_DISABLE_KV_CACHE_TRANSFER_OVERLAP_ENV)
+    layerwise = getenv(_DISAGG_LAYERWISE_ENV)
+    try_zcopy = getenv(_TRY_ZCOPY_FOR_KV_CACHE_TRANSFER_ENV)
     raise ValueError(
         f"{_DISAGG_INFLIGHT_CANCEL_ENABLED_ENV}=1 is experimental and "
         "currently supported only with transceiver_runtime='CPP', "
-        "backend='NIXL', and the UCX NIXL backend; got "
+        "backend='NIXL', the UCX NIXL backend, a finite "
+        "kv_transfer_timeout_ms, asynchronous non-layer-wise transfer, and "
+        "zero-copy disabled; got "
         f"transceiver_runtime={runtime!r}, "
         f"backend={cache_transceiver_config.backend!r}, "
-        f"resolved_nixl_backend={nixl_backend!r}.")
+        f"resolved_nixl_backend={nixl_backend!r}, "
+        f"kv_transfer_timeout_ms={cache_transceiver_config.kv_transfer_timeout_ms!r}, "
+        f"disable_transfer_overlap={disable_overlap!r}, "
+        f"layerwise={layerwise!r}, try_zcopy={try_zcopy!r}.")
 
 
 def mapping_to_world_config(mapping: Mapping) -> WorldConfig:

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
@@ -19,6 +19,70 @@ AttentionTypeCpp = tensorrt_llm.bindings.internal.batch_manager.AttentionType
 CacheTransBufferManagerCpp = tensorrt_llm.bindings.internal.batch_manager.CacheTransBufferManager
 BackendTypeCpp = tensorrt_llm.bindings.executor.CacheTransceiverBackendType
 
+_DISAGG_INFLIGHT_CANCEL_ENABLED_ENV = "TRTLLM_DISAGG_ENABLE_INFLIGHT_CANCEL"
+_NIXL_KVCACHE_BACKEND_ENV = "TRTLLM_NIXL_KVCACHE_BACKEND"
+_SUPPORTED_INFLIGHT_CANCEL_NIXL_BACKEND = "UCX"
+_CACHE_TRANSCEIVER_BACKEND_ENV_VARS = (
+    ("TRTLLM_USE_NIXL_KVCACHE", "NIXL"),
+    ("TRTLLM_USE_UCX_KVCACHE", "UCX"),
+    ("TRTLLM_USE_MOONCAKE_KVCACHE", "MOONCAKE"),
+    ("TRTLLM_USE_MPI_KVCACHE", "MPI"),
+)
+_disagg_inflight_cancel_enabled_cache: Optional[bool] = None
+
+
+def is_disagg_inflight_cancel_enabled() -> bool:
+    """Return whether disaggregated in-flight KV transfer cancellation is enabled."""
+    global _disagg_inflight_cancel_enabled_cache
+    if _disagg_inflight_cancel_enabled_cache is None:
+        _disagg_inflight_cancel_enabled_cache = (getenv(
+            _DISAGG_INFLIGHT_CANCEL_ENABLED_ENV, "0") == "1")
+        if _disagg_inflight_cancel_enabled_cache:
+            logger.warning(
+                f"{_DISAGG_INFLIGHT_CANCEL_ENABLED_ENV}=1: disagg KV "
+                "transfer in-flight cancellation was requested. It is active "
+                "only for cache transceivers that advertise support.")
+    return _disagg_inflight_cancel_enabled_cache
+
+
+def _is_disagg_inflight_cancel_config_supported(
+        cache_transceiver_config: CacheTransceiverConfig) -> bool:
+    runtime = cache_transceiver_config.transceiver_runtime or "CPP"
+    nixl_backend = getenv(_NIXL_KVCACHE_BACKEND_ENV,
+                          _SUPPORTED_INFLIGHT_CANCEL_NIXL_BACKEND)
+    return (runtime == "CPP" and cache_transceiver_config.backend == "NIXL"
+            and nixl_backend == _SUPPORTED_INFLIGHT_CANCEL_NIXL_BACKEND)
+
+
+def _validate_disagg_inflight_cancel_config(
+        cache_transceiver_config: CacheTransceiverConfig) -> None:
+    if not is_disagg_inflight_cancel_enabled():
+        return
+
+    enabled_backend_env_vars = [
+        env_name for env_name, _ in _CACHE_TRANSCEIVER_BACKEND_ENV_VARS
+        if getenv(env_name) == "1"
+    ]
+    if len(enabled_backend_env_vars) > 1:
+        raise ValueError(
+            f"{_DISAGG_INFLIGHT_CANCEL_ENABLED_ENV}=1 requires an "
+            "unambiguous cache transceiver backend, but multiple legacy "
+            f"backend selectors are enabled: {enabled_backend_env_vars}.")
+
+    if _is_disagg_inflight_cancel_config_supported(cache_transceiver_config):
+        return
+
+    runtime = cache_transceiver_config.transceiver_runtime or "CPP"
+    nixl_backend = getenv(_NIXL_KVCACHE_BACKEND_ENV,
+                          _SUPPORTED_INFLIGHT_CANCEL_NIXL_BACKEND)
+    raise ValueError(
+        f"{_DISAGG_INFLIGHT_CANCEL_ENABLED_ENV}=1 is experimental and "
+        "currently supported only with transceiver_runtime='CPP', "
+        "backend='NIXL', and the UCX NIXL backend; got "
+        f"transceiver_runtime={runtime!r}, "
+        f"backend={cache_transceiver_config.backend!r}, "
+        f"resolved_nixl_backend={nixl_backend!r}.")
+
 
 def mapping_to_world_config(mapping: Mapping) -> WorldConfig:
 
@@ -42,18 +106,14 @@ def create_kv_cache_transceiver(
         logger.info("cache_transceiver is disabled")
         return None
 
+    _validate_disagg_inflight_cancel_config(cache_transceiver_config)
+
     if cache_transceiver_config.backend == "DEFAULT":
         # When cache_transceiver_config.backend is not set, fallback to env_vars settings
         # NIXL is the default backend for non hybrid models
         cache_transceiver_config.backend = "NIXL"
         # Ordered by priority
-        env_vars = [
-            ("TRTLLM_USE_NIXL_KVCACHE", "NIXL"),
-            ("TRTLLM_USE_UCX_KVCACHE", "UCX"),
-            ("TRTLLM_USE_MOONCAKE_KVCACHE", "MOONCAKE"),
-            ("TRTLLM_USE_MPI_KVCACHE", "MPI"),
-        ]
-        for env_var, be_type in env_vars:
+        for env_var, be_type in _CACHE_TRANSCEIVER_BACKEND_ENV_VARS:
             if getenv(env_var) == "1":
                 logger.warning(
                     f"{env_var}=1 is set, but it's recommended to set cache_transceiver_config.backend in yaml config"
@@ -123,6 +183,12 @@ class KvCacheTransceiver(ABC):
     def cancel_request(self, req: LlmRequest):
         raise NotImplementedError
 
+    def supports_inflight_request_cancellation(self) -> bool:
+        return False
+
+    def has_poisoned_transfer_buffer(self) -> bool:
+        return False
+
     @abstractmethod
     def prepare_context_requests(self, requests: List[LlmRequest]):
         """
@@ -157,6 +223,7 @@ class BindKvCacheTransceiver(KvCacheTransceiver):
                  attention_type: AttentionTypeCpp,
                  cache_transceiver_config: CacheTransceiverConfig,
                  mamba_cache_manager: Optional[BaseMambaCacheManager] = None):
+        _validate_disagg_inflight_cancel_config(cache_transceiver_config)
         world_config = mapping_to_world_config(mapping)
         # Filter out mamba/recurrent state layers (kv_heads == 0) so that
         # CacheState::ModelConfig::mNbKvHeadsPerLayer only contains attention
@@ -180,6 +247,9 @@ class BindKvCacheTransceiver(KvCacheTransceiver):
         self.kv_transfer_timeout_ms = cache_transceiver_config.kv_transfer_timeout_ms
         self.kv_transfer_sender_future_timeout_ms = cache_transceiver_config.kv_transfer_sender_future_timeout_ms
         self.kv_transfer_poll_interval_ms = cache_transceiver_config.kv_transfer_poll_interval_ms
+        self._supports_inflight_request_cancellation = (
+            _is_disagg_inflight_cancel_config_supported(
+                cache_transceiver_config))
 
         # Get RNN layer distribution if mamba_cache_manager is provided.
         rnn_layer_num_per_pp_rank = []
@@ -225,6 +295,14 @@ class BindKvCacheTransceiver(KvCacheTransceiver):
 
     def cancel_request(self, req: LlmRequest):
         return self.impl.cancel_request(req)
+
+    def supports_inflight_request_cancellation(self) -> bool:
+        return self._supports_inflight_request_cancellation
+
+    def has_poisoned_transfer_buffer(self) -> bool:
+        if not is_disagg_inflight_cancel_enabled():
+            return False
+        return self.impl.has_poisoned_transfer_buffer()
 
     def prepare_context_requests(self, requests: List[LlmRequest]):
         # not implemented, an empty placeholder to allow being invoked unconditionally

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1075,7 +1075,14 @@ class PyExecutor:
             self.kv_connector_manager.wait_for_initialization()
 
     def _end_transfer_and_maybe_terminate(self, request: LlmRequest):
+        transfer_failed = request.state == LlmRequestState.DISAGG_TRANS_ERROR
         if self.kv_cache_transceiver and request in self.active_requests:
+            if transfer_failed:
+                # End only the transfer that just became terminal. Keep the
+                # request active so the synchronized error path can emit an
+                # error response after every async transfer releases ownership.
+                self.async_transfer_manager.end_transfer(request)
+                return
             # Fast-transfer: KV transfer completed in the same iteration
             # before _handle_responses could run. Create the response now
             # while state is still TRANS_IN_PROGRESS (required by C++
@@ -1098,6 +1105,8 @@ class PyExecutor:
                 self._terminate_request(request)
             return
         if self.async_transfer_manager.end_transfer(request):
+            if transfer_failed:
+                return
             # Skip if the PP=1 early path already terminated this request;
             # under PP>1 that path is off, so terminate here on transfer-complete.
             if not self.force_terminate_ctx_for_partial_reuse:
@@ -3745,40 +3754,78 @@ class PyExecutor:
         return can_forward, False
 
     def _handle_disagg_cache_errors_synced(self):
-        """ADP-safe disagg cache error handler.
+        """Rank-safe disagg cache error and poison handler.
 
-        Called from the top of every executor iteration. TP ranks vote on
-        failed request IDs and fail matching local replicas together;
+        Called from the top of every executor iteration. Buffer poison is
+        reduced over the full executor world because one poisoned PP/DP rank
+        requires the whole distributed executor to stop. ADP TP ranks then
+        vote on failed request IDs and fail matching local replicas together;
         otherwise the downstream ``tp_gather`` in ``_enqueue_responses``
         deadlocks or leaves peer replicas running.
         """
-        if not (self.kv_cache_transceiver and self.enable_attention_dp
-                and self.dist.world_size != 1):
+        if not self.kv_cache_transceiver:
             return
 
-        def request_vote_id(request: LlmRequest) -> int:
-            return (request.parent_request_id
-                    if request.is_child else request.py_request_id)
+        if self._is_disagg_inflight_cancel_active():
+            local_poisoned = self.kv_cache_transceiver.has_poisoned_transfer_buffer(
+            )
+            if self.dist.world_size != 1:
+                any_poisoned = bool(
+                    self.dist.allreduce(int(local_poisoned), op=ReduceOp.MAX))
+            else:
+                any_poisoned = local_poisoned
+            if any_poisoned:
+                error_msg = (
+                    "Disagg KV cache transfer buffer is poisoned; process "
+                    "restart is required")
+                self._fatal_error = RuntimeError(f"Fatal error: {error_msg}")
+                self.is_shutdown = True
+                self._handle_errors(error_msg,
+                                    requests=None,
+                                    charge_budget=False)
+                return
 
-        local_error_requests = self._get_disagg_reqs_in_error_state()
-        local_error_ids = [
-            request_vote_id(request) for request in local_error_requests
+        if not (self.enable_attention_dp and self.dist.world_size != 1):
+            return
+
+        local_error_requests = [
+            request for request in self.active_requests
+            if request.state == LlmRequestState.DISAGG_TRANS_ERROR
         ]
-        all_error_ids = self.dist.tp_allgather(local_error_ids)
+        local_vote = {
+            "error_ids": [
+                self._request_vote_id(request)
+                for request in local_error_requests
+            ],
+            "blocked_ids": [
+                self._request_vote_id(request)
+                for request in local_error_requests
+                if self._is_disagg_error_cleanup_blocked(request)
+            ],
+        }
+        all_votes = self.dist.tp_allgather(local_vote)
         voted_error_ids = {
             request_id
-            for rank_error_ids in all_error_ids
-            for request_id in rank_error_ids
+            for rank_vote in all_votes
+            for request_id in rank_vote["error_ids"]
         }
-        if not voted_error_ids:
+        blocked_error_ids = {
+            request_id
+            for rank_vote in all_votes
+            for request_id in rank_vote["blocked_ids"]
+        }
+        ready_error_ids = voted_error_ids - blocked_error_ids
+        if not ready_error_ids:
             return
         local_voted_error_requests = [
             request for request in self.active_requests
-            if request_vote_id(request) in voted_error_ids
+            if self._request_vote_id(request) in ready_error_ids
         ]
-        logger.warning(f"Disagg KV cache transfer error: rank={self.dist.rank} "
-                       f"local_err_count={len(local_error_requests)}, "
-                       f"voted_err_count={len(voted_error_ids)}")
+        logger.warning(
+            f"Disagg KV cache transfer error: rank={self.dist.rank} "
+            f"local_err_count={len(local_error_requests)}, "
+            f"voted_err_count={len(voted_error_ids)}, "
+            f"blocked_err_count={len(voted_error_ids & blocked_error_ids)}")
         self._handle_errors(
             "Disagg KV cache transfer error",
             requests=local_voted_error_requests,
@@ -5273,6 +5320,15 @@ class PyExecutor:
             self._disagg_inflight_cancel_unsupported_logged = True
         return False
 
+    def _request_kv_transfer_cancellation(self, request: LlmRequest) -> bool:
+        """Best-effort cancellation that leaves ownership intact on errors."""
+        try:
+            return self.kv_cache_transceiver.cancel_request(request)
+        except Exception as error:
+            logger.error(f"KV transfer cancellation failed for request "
+                         f"{request.py_request_id}; will retry: {error}")
+            return False
+
     @nvtx_range("_cancel_timed_out_gen_transfers")
     def _cancel_timed_out_gen_transfers(self) -> None:
         """Request cancellation for timed-out generation transfers.
@@ -5292,7 +5348,7 @@ class PyExecutor:
             for req in self.active_requests
             if req.is_disagg_generation_transmission_in_progress
         }
-        current_time = time.time()
+        current_time = time.monotonic()
         for request in requests_in_transfer.values():
             if request.py_kv_transfer_start_time is None:
                 continue
@@ -5340,7 +5396,7 @@ class PyExecutor:
             if request_id in self._disagg_timed_out_gen_cancelled_ids:
                 continue
 
-            is_cancelled = self.kv_cache_transceiver.cancel_request(request)
+            is_cancelled = self._request_kv_transfer_cancellation(request)
             if is_cancelled:
                 self._disagg_timed_out_gen_cancelled_ids.add(request_id)
                 logger.warning(
@@ -5355,10 +5411,7 @@ class PyExecutor:
             req for req in self._get_disagg_reqs_in_error_state()
             if req.is_generation_only_request()
         ]
-        poisoned_transfer_buffer = (
-            self.kv_cache_transceiver is not None
-            and self.kv_cache_transceiver.has_poisoned_transfer_buffer())
-        local_needs_flush = bool(error_requests) or poisoned_transfer_buffer
+        local_needs_flush = bool(error_requests)
 
         if self.dist.tp_size > 1:
             any_needs_flush = self.dist.tp_allreduce(int(local_needs_flush),
@@ -5368,22 +5421,10 @@ class PyExecutor:
         if not any_needs_flush:
             return
 
-        if self.dist.tp_size > 1:
-            any_poisoned_transfer_buffer = self.dist.tp_allreduce(
-                int(poisoned_transfer_buffer), op=ReduceOp.MAX)
-        else:
-            any_poisoned_transfer_buffer = int(poisoned_transfer_buffer)
-
         error_msg = "Error in kv cache transfer for generation requests"
-        if any_poisoned_transfer_buffer:
-            error_msg += "; poisoned transfer buffer requires process restart"
-            self._fatal_error = RuntimeError(f"Fatal error: {error_msg}")
-            self.is_shutdown = True
-
-        self._handle_errors(
-            error_msg,
-            requests=None if any_poisoned_transfer_buffer else error_requests,
-            charge_budget=False)
+        self._handle_errors(error_msg,
+                            requests=error_requests,
+                            charge_budget=False)
 
     @nvtx_range("_check_kv_transfer_timeout")
     def _check_kv_transfer_timeout(self):
@@ -5394,7 +5435,7 @@ class PyExecutor:
             return
 
         def flag_if_kv_transfer_timed_out(req: LlmRequest, type: str) -> None:
-            current_time = time.time()
+            current_time = time.monotonic()
             if req.py_kv_transfer_start_time is None:
                 return
             elapsed_time = (current_time - req.py_kv_transfer_start_time) * 1000
@@ -5761,7 +5802,7 @@ class PyExecutor:
         if self.kv_cache_transceiver.kv_transfer_timeout_ms is not None:
             for req in new_gen_reqs:
                 if req.state == LlmRequestState.DISAGG_GENERATION_TRANS_IN_PROGRESS:
-                    req.py_kv_transfer_start_time = time.time()
+                    req.py_kv_transfer_start_time = time.monotonic()
 
         self._check_disagg_gen_cache_transfer_status(0)
 
@@ -5799,7 +5840,7 @@ class PyExecutor:
                     self.kv_cache_transceiver.respond_and_send_async(req)
 
                     if self.kv_cache_transceiver.kv_transfer_timeout_ms is not None:
-                        req.py_kv_transfer_start_time = time.time()
+                        req.py_kv_transfer_start_time = time.monotonic()
 
         if self.kv_connector_manager:
             if not self.disable_overlap_scheduler:
@@ -5814,10 +5855,28 @@ class PyExecutor:
         if self.kv_cache_transceiver:
             self._check_disagg_ctx_cache_transfer_status(0)
 
+    @staticmethod
+    def _request_vote_id(request: LlmRequest) -> int:
+        return (request.parent_request_id
+                if request.is_child else request.py_request_id)
+
+    def _is_disagg_error_cleanup_blocked(self, request: LlmRequest) -> bool:
+        request_id = self._request_vote_id(request)
+        if request_id in getattr(self, "canceled_req_ids", ()):
+            return True
+
+        async_transfer_manager = getattr(self, "async_transfer_manager", None)
+        if (getattr(request, "is_context_only_request", False) is True
+                and async_transfer_manager is not None and request.py_request_id
+                in async_transfer_manager.requests_in_transfer()):
+            return True
+        return False
+
     def _get_disagg_reqs_in_error_state(self):
         return [
             req for req in self.active_requests
             if req.state == LlmRequestState.DISAGG_TRANS_ERROR
+            and not self._is_disagg_error_cleanup_blocked(req)
         ]
 
     def _check_cache_transfer_errors(self, error_msg_prefix: str):
@@ -5830,19 +5889,10 @@ class PyExecutor:
             return
         error_requests = self._get_disagg_reqs_in_error_state()
         if error_requests:
-            poisoned_transfer_buffer = (
-                self.kv_cache_transceiver is not None
-                and self.kv_cache_transceiver.has_poisoned_transfer_buffer())
             error_msg = f"Error in kv cache transfer for {error_msg_prefix}"
-            if poisoned_transfer_buffer:
-                error_msg += (
-                    "; poisoned transfer buffer requires process restart")
-                self._fatal_error = RuntimeError(f"Fatal error: {error_msg}")
-                self.is_shutdown = True
-            self._handle_errors(
-                error_msg,
-                requests=None if poisoned_transfer_buffer else error_requests,
-                charge_budget=False)
+            self._handle_errors(error_msg,
+                                requests=error_requests,
+                                charge_budget=False)
 
     @nvtx_range("_check_disagg_ctx_cache_transfer_status")
     def _check_disagg_ctx_cache_transfer_status(self, atLeastNum: int = 0):
@@ -5876,7 +5926,7 @@ class PyExecutor:
                     or request_id in self._disagg_timed_out_ctx_cancelled_ids):
                 continue
 
-            is_cancelled = self.kv_cache_transceiver.cancel_request(request)
+            is_cancelled = self._request_kv_transfer_cancellation(request)
             if not is_cancelled:
                 continue
 
@@ -6162,10 +6212,11 @@ class PyExecutor:
         is enqueued.  Otherwise only the requests in *requests* are failed.
 
         When ``charge_budget`` is False, the error is treated as a
-        per-request failure: only the specified requests are failed, the
-        error budget is not consumed, and shutdown is never triggered.
-        Use this for request-scoped errors (validation, KV-transfer
-        timeout, guided-decoder) that should not affect server health.
+        per-request failure unless the executor was already marked fatal by
+        the caller. The error budget is not consumed. Use this for
+        request-scoped errors (validation, KV-transfer timeout,
+        guided-decoder) that should not affect server health, and for the
+        cleanup phase of an already-classified fatal error.
 
         .. note::
             The ``charge_budget=False`` path reuses the full
@@ -6189,15 +6240,17 @@ class PyExecutor:
         error_responses: Dict[int, LlmResponse] = {}
         error_msg = error_msg or "error"
 
-        is_fatal = (self._error_budget.consume(error_msg)
-                    if charge_budget else False)
-        if is_fatal and self._error_budget.budget < 1e-9:
+        budget_fatal = (self._error_budget.consume(error_msg)
+                        if charge_budget else False)
+        is_fatal = self._fatal_error is not None or budget_fatal
+        if budget_fatal and self._error_budget.budget < 1e-9:
             logger.error(f"Error budget exhausted "
                          f"(budget={self._error_budget.budget:.3f}), "
                          "treating as fatal")
 
         if is_fatal:
-            self._fatal_error = RuntimeError(f"Fatal error: {error_msg}")
+            if self._fatal_error is None:
+                self._fatal_error = RuntimeError(f"Fatal error: {error_msg}")
             self.is_shutdown = True
             logger.error(
                 f"Fatal error detected, initiating shutdown: {error_msg}")
@@ -6240,10 +6293,14 @@ class PyExecutor:
                                      client_id=getattr(item.request,
                                                        'client_id', None))))
 
-            if waiting_responses:
+            adp_collective_required = (self.enable_attention_dp
+                                       and self.dist.world_size != 1)
+            if waiting_responses or adp_collective_required:
                 self._enqueue_responses(waiting_responses)
-                logger.info(f"Drained {len(waiting_responses)} queued requests "
-                            "on fatal error")
+                if waiting_responses:
+                    logger.info(
+                        f"Drained {len(waiting_responses)} queued requests "
+                        "on fatal error")
 
         failed_requests = (list(self.active_requests)
                            if requests is None else requests)
@@ -6304,14 +6361,22 @@ class PyExecutor:
         if self.kv_cache_transceiver is None:
             return True
 
+        async_transfer_manager = getattr(self, "async_transfer_manager", None)
+        if (getattr(request, "is_context_only_request", False) is True
+                and async_transfer_manager is not None and request.py_request_id
+                in async_transfer_manager.requests_in_transfer()):
+            if self._is_disagg_inflight_cancel_active():
+                self._request_kv_transfer_cancellation(request)
+            return False
+
         if not self._is_request_in_transmission(request):
             return True
 
         if self._is_disagg_inflight_cancel_active():
-            self.kv_cache_transceiver.cancel_request(request)
+            self._request_kv_transfer_cancellation(request)
             return False
 
-        return self.kv_cache_transceiver.cancel_request(request)
+        return self._request_kv_transfer_cancellation(request)
 
     @nvtx_range("_handle_canceled_requests")
     def _handle_canceled_requests(self):
@@ -6334,6 +6399,7 @@ class PyExecutor:
             if is_cancelled:
                 # Mark requests as finished, then, we reuse all existing code
                 # to clean up the KV cache resources.
+                request.py_kv_transfer_timed_out = False
                 request.finish_by_reason(FinishReason.CANCELLED)
                 request.decoding_iter = request.py_decoding_iter
             else:
@@ -6483,20 +6549,28 @@ class PyExecutor:
 
             # Check if a generation request needs cleanup due to KV cache transfer timeout.
             if request.py_kv_transfer_timed_out:
-                defer_timeout_cleanup = (
-                    self._is_disagg_inflight_cancel_active() and
-                    (request.is_disagg_generation_transmission_in_progress
-                     or request.state == LlmRequestState.DISAGG_TRANS_ERROR))
-                if not defer_timeout_cleanup:
-                    is_cancelled = self.kv_cache_transceiver.cancel_request(
-                        request)
-                    if is_cancelled:
-                        # _handle_errors enters response collectives under ADP.
-                        # Defer it until the rank-uniform vote below.
+                if self._is_disagg_inflight_cancel_active():
+                    if (request.is_disagg_generation_transmission_in_progress
+                            or request.state
+                            == LlmRequestState.DISAGG_TRANS_ERROR):
+                        new_active_requests.append(request)
+                    else:
+                        # The transfer completed after the deadline but before
+                        # cancellation won the race. Fail the request without
+                        # touching the now-quiesced transfer buffer.
                         timed_out_requests.append(request)
                     continue
 
-                new_active_requests.append(request)
+                is_cancelled = self._request_kv_transfer_cancellation(request)
+                if is_cancelled:
+                    # _handle_errors enters response collectives under ADP.
+                    # Defer it until the rank-uniform vote below.
+                    timed_out_requests.append(request)
+                else:
+                    # Legacy transceivers cannot cancel every in-flight
+                    # transfer. Keep polling instead of dropping ownership of
+                    # the request and its KV resources.
+                    new_active_requests.append(request)
                 continue
 
             if request.is_generation_only_request() and not request.is_finished:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -66,7 +66,8 @@ from .handle_logits import HandleLogits
 from .hang_detector import HangDetector, propagate_hard_kill
 from .kv_cache_manager_v2 import KVCacheManagerV2
 from .kv_cache_stats import append_kv_cache_iteration_stats
-from .kv_cache_transceiver import KvCacheTransceiver
+from .kv_cache_transceiver import (KvCacheTransceiver,
+                                   is_disagg_inflight_cancel_enabled)
 from .llm_request import (ATTENTION_DP_DUMMY_REQUEST_ID,
                           MAX_SPEC_DECODE_POSITIONS, ExecutorRequest,
                           LlmRequest, LlmRequestState, LlmResponse,
@@ -820,6 +821,9 @@ class PyExecutor:
         self.is_shutdown = False
         self._fatal_error: Optional[BaseException] = None
         self._error_budget = ErrorBudget()
+        self._disagg_timed_out_ctx_cancelled_ids: set[int] = set()
+        self._disagg_timed_out_gen_cancelled_ids: set[int] = set()
+        self._disagg_inflight_cancel_unsupported_logged = False
         self.max_batch_size = max_batch_size
         self.adp_ctx_waiting_iters_count = 0
         self.adp_ctx_batching_wait_iters_count = 0
@@ -5238,6 +5242,149 @@ class PyExecutor:
         # an empty ready set.
         self._check_disagg_gen_cache_transfer_status(0)
 
+        if self._is_disagg_inflight_cancel_active():
+            self._cancel_timed_out_gen_transfers()
+            self._check_gen_cache_transfer_errors_consensus()
+
+        return
+
+    def _is_disagg_inflight_cancel_active(self) -> bool:
+        if not is_disagg_inflight_cancel_enabled():
+            return False
+
+        transceiver = getattr(self, "kv_cache_transceiver", None)
+        if transceiver is None:
+            return False
+
+        supports = getattr(transceiver,
+                           "supports_inflight_request_cancellation", None)
+        if callable(supports) and supports() is True:
+            return True
+
+        if not getattr(self, "_disagg_inflight_cancel_unsupported_logged",
+                       False):
+            logger.warning(
+                "TRTLLM_DISAGG_ENABLE_INFLIGHT_CANCEL=1 was requested, but "
+                f"{type(transceiver).__name__} does not advertise in-flight "
+                "request cancellation support. Cancellation and transfer-buffer "
+                "quarantine are currently scoped to the C++ NIXL transceiver "
+                "with the UCX plugin; using the existing timeout and "
+                "cancellation behavior for this transceiver.")
+            self._disagg_inflight_cancel_unsupported_logged = True
+        return False
+
+    @nvtx_range("_cancel_timed_out_gen_transfers")
+    def _cancel_timed_out_gen_transfers(self) -> None:
+        """Request cancellation for timed-out generation transfers.
+
+        This path is deliberately rank-synchronized. Under attention-DP, each
+        TP rank can own a different request subset, but later error responses
+        still pass through a TP collective. The timeout/cancel decision must
+        therefore be based on the TP-wide request-id union rather than a
+        rank-local timeout observation.
+        """
+        timeout_ms = self.kv_cache_transceiver.kv_transfer_timeout_ms
+        if timeout_ms is None:
+            return
+
+        requests_in_transfer = {
+            req.py_request_id: req
+            for req in self.active_requests
+            if req.is_disagg_generation_transmission_in_progress
+        }
+        current_time = time.time()
+        for request in requests_in_transfer.values():
+            if request.py_kv_transfer_start_time is None:
+                continue
+            elapsed_time = ((current_time - request.py_kv_transfer_start_time) *
+                            1000)
+            if (elapsed_time > timeout_ms
+                    and not request.py_kv_transfer_timed_out):
+                logger.warning(
+                    f"Requesting cancellation for generation request "
+                    f"{request.py_request_id} due to KV cache transfer timeout")
+                request.py_kv_transfer_timed_out = True
+
+        user_canceled_ids = set(self.canceled_req_ids)
+        local_timed_out_ids = sorted(
+            request_id for request_id, request in requests_in_transfer.items()
+            if request.py_kv_transfer_timed_out
+            and request_id not in user_canceled_ids
+            and request_id not in self._disagg_timed_out_gen_cancelled_ids)
+
+        if self.dist.tp_size > 1:
+            any_timed_out = self.dist.tp_allreduce(int(
+                bool(local_timed_out_ids)),
+                                                   op=ReduceOp.MAX)
+        else:
+            any_timed_out = int(bool(local_timed_out_ids))
+        if not any_timed_out:
+            return
+
+        if self.dist.tp_size > 1:
+            gathered_timed_out_ids = self.dist.tp_allgather(local_timed_out_ids)
+            timed_out_ids = sorted(set().union(*gathered_timed_out_ids))
+        else:
+            timed_out_ids = local_timed_out_ids
+
+        for request_id in timed_out_ids:
+            request = requests_in_transfer.get(request_id)
+            if request is None:
+                continue
+
+            # A peer rank may have crossed the timeout first.  Mirror the
+            # TP-wide decision locally so a failed cancel attempt keeps
+            # retrying even if this rank's wall clock had not yet expired.
+            request.py_kv_transfer_timed_out = True
+
+            if request_id in self._disagg_timed_out_gen_cancelled_ids:
+                continue
+
+            is_cancelled = self.kv_cache_transceiver.cancel_request(request)
+            if is_cancelled:
+                self._disagg_timed_out_gen_cancelled_ids.add(request_id)
+                logger.warning(
+                    f"Cancelled timed-out generation KV transfer for request "
+                    f"{request.py_request_id}; waiting for C++ transfer "
+                    "status to report final cleanup")
+
+    @nvtx_range("_check_gen_cache_transfer_errors_consensus")
+    def _check_gen_cache_transfer_errors_consensus(self) -> None:
+        """Flush generation transfer errors through a TP-uniform path."""
+        error_requests = [
+            req for req in self._get_disagg_reqs_in_error_state()
+            if req.is_generation_only_request()
+        ]
+        poisoned_transfer_buffer = (
+            self.kv_cache_transceiver is not None
+            and self.kv_cache_transceiver.has_poisoned_transfer_buffer())
+        local_needs_flush = bool(error_requests) or poisoned_transfer_buffer
+
+        if self.dist.tp_size > 1:
+            any_needs_flush = self.dist.tp_allreduce(int(local_needs_flush),
+                                                     op=ReduceOp.MAX)
+        else:
+            any_needs_flush = int(local_needs_flush)
+        if not any_needs_flush:
+            return
+
+        if self.dist.tp_size > 1:
+            any_poisoned_transfer_buffer = self.dist.tp_allreduce(
+                int(poisoned_transfer_buffer), op=ReduceOp.MAX)
+        else:
+            any_poisoned_transfer_buffer = int(poisoned_transfer_buffer)
+
+        error_msg = "Error in kv cache transfer for generation requests"
+        if any_poisoned_transfer_buffer:
+            error_msg += "; poisoned transfer buffer requires process restart"
+            self._fatal_error = RuntimeError(f"Fatal error: {error_msg}")
+            self.is_shutdown = True
+
+        self._handle_errors(
+            error_msg,
+            requests=None if any_poisoned_transfer_buffer else error_requests,
+            charge_budget=False)
+
     @nvtx_range("_check_kv_transfer_timeout")
     def _check_kv_transfer_timeout(self):
         if not self.kv_cache_transceiver:
@@ -5252,8 +5399,11 @@ class PyExecutor:
                 return
             elapsed_time = (current_time - req.py_kv_transfer_start_time) * 1000
             if elapsed_time > timeout_ms and not req.py_kv_transfer_timed_out:
+                verb = ("Requesting cancellation for"
+                        if self._is_disagg_inflight_cancel_active() else
+                        "Observed timeout on")
                 logger.warning(
-                    f"Terminating {type} request {req.py_request_id} due to KV "
+                    f"{verb} {type} request {req.py_request_id} due to KV "
                     f"cache transfer timeout: elapsed {elapsed_time:.0f}ms > "
                     f"kv_transfer_timeout_ms={timeout_ms}ms")
                 req.py_kv_transfer_timed_out = True
@@ -5680,9 +5830,18 @@ class PyExecutor:
             return
         error_requests = self._get_disagg_reqs_in_error_state()
         if error_requests:
+            poisoned_transfer_buffer = (
+                self.kv_cache_transceiver is not None
+                and self.kv_cache_transceiver.has_poisoned_transfer_buffer())
+            error_msg = f"Error in kv cache transfer for {error_msg_prefix}"
+            if poisoned_transfer_buffer:
+                error_msg += (
+                    "; poisoned transfer buffer requires process restart")
+                self._fatal_error = RuntimeError(f"Fatal error: {error_msg}")
+                self.is_shutdown = True
             self._handle_errors(
-                f"Error in kv cache transfer for {error_msg_prefix}",
-                requests=error_requests,
+                error_msg,
+                requests=None if poisoned_transfer_buffer else error_requests,
                 charge_budget=False)
 
     @nvtx_range("_check_disagg_ctx_cache_transfer_status")
@@ -5712,15 +5871,27 @@ class PyExecutor:
 
         for request_id in list(requests_in_transfer.keys()):
             request = requests_in_transfer[request_id]
-            if request.py_kv_transfer_timed_out and request_id not in completed_req_ids:
-                is_cancelled = self.kv_cache_transceiver.cancel_request(request)
-                # If cancel is successful, mark as complete so it can be cleaned up
-                # Otherwise, try at next iteration
-                if is_cancelled:
-                    request.py_kv_transfer_start_time = None
-                    request.state = LlmRequestState.DISAGG_CONTEXT_COMPLETE
+            if (not request.py_kv_transfer_timed_out
+                    or request_id in completed_req_ids
+                    or request_id in self._disagg_timed_out_ctx_cancelled_ids):
+                continue
 
-                    self._end_transfer_and_maybe_terminate(request)
+            is_cancelled = self.kv_cache_transceiver.cancel_request(request)
+            if not is_cancelled:
+                continue
+
+            if self._is_disagg_inflight_cancel_active():
+                self._disagg_timed_out_ctx_cancelled_ids.add(request_id)
+                logger.warning(f"Cancelled timed-out context KV transfer for "
+                               f"request {request.py_request_id}; waiting for "
+                               "C++ transfer status to report final cleanup")
+            else:
+                # Preserve the legacy timeout behavior when in-flight
+                # cancellation is disabled: a queued transfer that can be
+                # cancelled is immediately released from the async manager.
+                request.py_kv_transfer_start_time = None
+                request.state = LlmRequestState.DISAGG_CONTEXT_COMPLETE
+                self._end_transfer_and_maybe_terminate(request)
 
         self._check_cache_transfer_errors("context requests")
 
@@ -5734,7 +5905,8 @@ class PyExecutor:
                 req_id = req.py_request_id if not req.is_child else req.parent_request_id
                 if req_id not in user_canceled_set:
                     req.state = LlmRequestState.DISAGG_TRANS_ERROR
-        self._check_cache_transfer_errors("generation requests")
+        if not self._is_disagg_inflight_cancel_active():
+            self._check_cache_transfer_errors("generation requests")
 
     def _maybe_prefetch_next_iter_mm_encoders(
             self, scheduled_batch: ScheduledRequests) -> None:
@@ -6110,6 +6282,8 @@ class PyExecutor:
     def _do_terminate_request(self, request: LlmRequest):
         self.resource_manager.free_resources(request)
         self._prefetched_request_ids.discard(request.py_request_id)
+        self._disagg_timed_out_ctx_cancelled_ids.discard(request.py_request_id)
+        self._disagg_timed_out_gen_cancelled_ids.discard(request.py_request_id)
 
         if self.gather_all_responses or self.dist.rank == 0:
             self.result_wait_queues.pop(request.py_request_id, None)
@@ -6132,6 +6306,10 @@ class PyExecutor:
 
         if not self._is_request_in_transmission(request):
             return True
+
+        if self._is_disagg_inflight_cancel_active():
+            self.kv_cache_transceiver.cancel_request(request)
+            return False
 
         return self.kv_cache_transceiver.cancel_request(request)
 
@@ -6303,11 +6481,22 @@ class PyExecutor:
                 requests_to_terminate.append(request)
                 continue
 
-            # Check if generation request needs cleanup due to KV cache transfer timeout
+            # Check if a generation request needs cleanup due to KV cache transfer timeout.
             if request.py_kv_transfer_timed_out:
-                is_cancelled = self.kv_cache_transceiver.cancel_request(request)
-                if is_cancelled:
-                    timed_out_requests.append(request)
+                defer_timeout_cleanup = (
+                    self._is_disagg_inflight_cancel_active() and
+                    (request.is_disagg_generation_transmission_in_progress
+                     or request.state == LlmRequestState.DISAGG_TRANS_ERROR))
+                if not defer_timeout_cleanup:
+                    is_cancelled = self.kv_cache_transceiver.cancel_request(
+                        request)
+                    if is_cancelled:
+                        # _handle_errors enters response collectives under ADP.
+                        # Defer it until the rank-uniform vote below.
+                        timed_out_requests.append(request)
+                    continue
+
+                new_active_requests.append(request)
                 continue
 
             if request.is_generation_only_request() and not request.is_finished:

--- a/tests/integration/defs/accuracy/test_disaggregated_serving.py
+++ b/tests/integration/defs/accuracy/test_disaggregated_serving.py
@@ -54,6 +54,8 @@ DEFAULT_TEST_TIMEOUT = 3600
 DEFAULT_SERVER_WAITING_TIMEOUT = 2100
 # Timeout for the accuracy evaluation
 DEFAULT_ACC_EVALUATION_TIMEOUT = 1500
+# Preserve the legacy effectively-unbounded per-request timeout, in seconds.
+DEFAULT_REQUEST_TIMEOUT_S = 1_800_000
 DEEPSEEKV4_TEST_MAX_BATCH_SIZE = 128
 
 
@@ -153,6 +155,8 @@ def launch_disaggregated_llm(
     enable_perf=False,
     extra_env: Optional[Dict[str, str]] = None,
     gen_extra_env: Optional[Dict[str, str]] = None,
+    request_timeout_s: float = DEFAULT_REQUEST_TIMEOUT_S,
+    request_max_retries: Optional[int] = None,
 ):
     temp_dir = tempfile.TemporaryDirectory()
     disaggregated_serving_config_path = os.path.join(
@@ -406,9 +410,14 @@ def launch_disaggregated_llm(
                 f"Server is not ready after {server_waiting_timeout} seconds. Please check the logs for more details."
             )
 
-        client = openai.OpenAI(api_key="1234567890",
-                               base_url=f"http://localhost:{serve_port}/v1",
-                               timeout=1800000)
+        client_kwargs: Dict[str, Any] = {
+            "api_key": "1234567890",
+            "base_url": f"http://localhost:{serve_port}/v1",
+            "timeout": request_timeout_s,
+        }
+        if request_max_retries is not None:
+            client_kwargs["max_retries"] = request_max_retries
+        client = openai.OpenAI(**client_kwargs)
 
         def send_request(prompt: str, sampling_params: SamplingParams,
                          streaming: bool):
@@ -1078,17 +1087,18 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
     @pytest.mark.skip_less_device_memory(60000)
     @skip_no_hopper
     def test_gen_only_sync(self):
-        """Test gen-only synchronous KV transfer path with NIXL Python transceiver.
+        """Test gen-only synchronous KV transfer path with NIXL C++ transceiver.
 
         Sets TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP=1 so the gen worker calls
-        request_and_receive_sync instead of the async path. Accuracy must be
-        identical to the standard async path.
+        the blocking request_and_receive_sync path. A bounded client timeout
+        makes a stuck transfer fail this test instead of waiting for its outer
+        one-hour timeout.
         """
         ctx_server_config = {
             "disable_overlap_scheduler": True,
             "cache_transceiver_config": {
                 "backend": "NIXL",
-                "transceiver_runtime": "PYTHON",
+                "transceiver_runtime": "CPP",
                 "max_tokens_in_buffer": 4096,
             },
         }
@@ -1096,7 +1106,7 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
             "disable_overlap_scheduler": True,
             "cache_transceiver_config": {
                 "backend": "NIXL",
-                "transceiver_runtime": "PYTHON",
+                "transceiver_runtime": "CPP",
                 "max_tokens_in_buffer": 4096,
             },
         }
@@ -1117,6 +1127,8 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
                 self.MODEL_PATH,
                 # Apply to both servers: gen worker uses sync receive path.
                 extra_env={"TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP": "1"},
+                request_timeout_s=120,
+                request_max_retries=0,
         ) as llm:
             run_accuracy_test(llm, self.MODEL_NAME, ["GSM8K"])
 

--- a/tests/integration/defs/accuracy/test_disaggregated_serving.py
+++ b/tests/integration/defs/accuracy/test_disaggregated_serving.py
@@ -1086,19 +1086,21 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
     @pytest.mark.skip_less_device(2)
     @pytest.mark.skip_less_device_memory(60000)
     @skip_no_hopper
-    def test_gen_only_sync(self):
-        """Test gen-only synchronous KV transfer path with NIXL C++ transceiver.
+    @pytest.mark.parametrize("transceiver_runtime", ["PYTHON", "CPP"],
+                             ids=["python", "cpp"])
+    def test_gen_only_sync(self, transceiver_runtime):
+        """Test gen-only synchronous KV transfer with each NIXL runtime.
 
         Sets TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP=1 so the gen worker calls
-        the blocking request_and_receive_sync path. A bounded client timeout
-        makes a stuck transfer fail this test instead of waiting for its outer
-        one-hour timeout.
+        the blocking request_and_receive_sync path. The C++ variant uses a
+        bounded client timeout so a stuck transfer fails this test instead of
+        waiting for its outer one-hour timeout.
         """
         ctx_server_config = {
             "disable_overlap_scheduler": True,
             "cache_transceiver_config": {
                 "backend": "NIXL",
-                "transceiver_runtime": "CPP",
+                "transceiver_runtime": transceiver_runtime,
                 "max_tokens_in_buffer": 4096,
             },
         }
@@ -1106,7 +1108,7 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
             "disable_overlap_scheduler": True,
             "cache_transceiver_config": {
                 "backend": "NIXL",
-                "transceiver_runtime": "CPP",
+                "transceiver_runtime": transceiver_runtime,
                 "max_tokens_in_buffer": 4096,
             },
         }
@@ -1127,8 +1129,10 @@ class TestDeepSeekV3Lite(LlmapiAccuracyTestHarness):
                 self.MODEL_PATH,
                 # Apply to both servers: gen worker uses sync receive path.
                 extra_env={"TRTLLM_DISABLE_KV_CACHE_TRANSFER_OVERLAP": "1"},
-                request_timeout_s=120,
-                request_max_retries=0,
+                request_timeout_s=(120 if transceiver_runtime == "CPP" else
+                                   DEFAULT_REQUEST_TIMEOUT_S),
+                request_max_retries=(0
+                                     if transceiver_runtime == "CPP" else None),
         ) as llm:
             run_accuracy_test(llm, self.MODEL_NAME, ["GSM8K"])
 

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -19,7 +19,7 @@ accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_auto_dtype_with
 accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_auto_dtype_with_helix[nccl-cudagraph:with_padding-pp1tp1cp4]
 accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_auto_dtype_with_helix[nccl-cudagraph:with_padding-pp1tp2cp2]
 accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_auto_dtype_with_helix[nccl-cudagraph:with_padding-pp2tp1cp2]
-accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_gen_only_sync
+accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_gen_only_sync[python]
 accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_guided_decoding[llguidance-mtp_nextn=0]
 accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_guided_decoding[llguidance-mtp_nextn=2]
 accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_guided_decoding[xgrammar-mtp_nextn=0]

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -17,7 +17,7 @@ l0_dgx_b200:
   tests:
   - unittest/_torch/misc/test_autotuner.py::test_autotuner_distributed_strategy
   - accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_bf16[tp2-TRTLLM]
-  - accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_gen_only_sync
+  - accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_gen_only_sync[cpp]
   # ------------- Encoder-decoder TP tests ---------------
   - llmapi/test_llm_api_pytorch_t5.py::test_t5_pytorch_generate_encoder_decoder_end_to_end[bf16-kv-v1-cuda-graph-off-greedy-tp2-t5-small]
   - llmapi/test_llm_api_pytorch_t5.py::test_t5_pytorch_generate_encoder_decoder_end_to_end[bf16-kv-v1-cuda-graph-on-greedy-tp2-t5-small]

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -17,6 +17,7 @@ l0_dgx_b200:
   tests:
   - unittest/_torch/misc/test_autotuner.py::test_autotuner_distributed_strategy
   - accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_bf16[tp2-TRTLLM]
+  - accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_gen_only_sync
   # ------------- Encoder-decoder TP tests ---------------
   - llmapi/test_llm_api_pytorch_t5.py::test_t5_pytorch_generate_encoder_decoder_end_to_end[bf16-kv-v1-cuda-graph-off-greedy-tp2-t5-small]
   - llmapi/test_llm_api_pytorch_t5.py::test_t5_pytorch_generate_encoder_decoder_end_to_end[bf16-kv-v1-cuda-graph-on-greedy-tp2-t5-small]

--- a/tests/integration/test_lists/test-db/l0_dgx_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_h100.yml
@@ -35,7 +35,7 @@ l0_dgx_h100:
   - accuracy/test_disaggregated_serving.py::TestQwen3_8B::test_chunked_prefill
   - accuracy/test_disaggregated_serving.py::TestQwen3_8B::test_nixl_backend
   - accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_nixl_backend
-  - accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_gen_only_sync
+  - accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_gen_only_sync[python]
   - accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_kv_cache_v2_nixl_python
   - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_ngram
   - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_kv_cache_v2_nixl_python

--- a/tests/unittest/_torch/executor/test_disagg_inflight_cancel_gate.py
+++ b/tests/unittest/_torch/executor/test_disagg_inflight_cancel_gate.py
@@ -1,0 +1,381 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import Mock, call
+
+import pytest
+
+from tensorrt_llm._torch.pyexecutor import kv_cache_transceiver as transceiver_module
+from tensorrt_llm._torch.pyexecutor import py_executor as executor_module
+from tensorrt_llm._torch.pyexecutor.kv_cache_transceiver import BindKvCacheTransceiver
+from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequestState
+from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
+from tensorrt_llm.llmapi.llm_args import CacheTransceiverConfig
+
+
+@pytest.fixture(autouse=True)
+def _reset_inflight_cancel_env_cache(monkeypatch):
+    monkeypatch.delenv(transceiver_module._DISAGG_INFLIGHT_CANCEL_ENABLED_ENV, raising=False)
+    monkeypatch.delenv(transceiver_module._NIXL_KVCACHE_BACKEND_ENV, raising=False)
+    for env_name, _ in transceiver_module._CACHE_TRANSCEIVER_BACKEND_ENV_VARS:
+        monkeypatch.delenv(env_name, raising=False)
+    monkeypatch.setattr(transceiver_module, "_disagg_inflight_cancel_enabled_cache", None)
+
+
+def _make_timeout_request(request_id=7, in_progress=False):
+    return SimpleNamespace(
+        is_attention_dp_dummy=False,
+        py_kv_transfer_timed_out=True,
+        py_request_id=request_id,
+        is_disagg_generation_transmission_in_progress=in_progress,
+        state=object(),
+    )
+
+
+def _make_response_handler_stub(active_requests, tp_allgather_result):
+    executor = object.__new__(PyExecutor)
+    executor.active_requests = list(active_requests)
+    executor.perf_manager = Mock()
+    executor.kv_cache_transceiver = Mock()
+    executor.kv_cache_transceiver.cancel_request.return_value = True
+    executor.kv_cache_transceiver.supports_inflight_request_cancellation.return_value = True
+    executor._disagg_inflight_cancel_unsupported_logged = False
+    executor._pending_timed_out_requests = []
+    executor.enable_attention_dp = True
+    executor.dist = SimpleNamespace(
+        rank=0,
+        world_size=2,
+        tp_allgather=Mock(return_value=tp_allgather_result),
+    )
+    executor._enqueue_responses = Mock()
+    executor._terminate_request = Mock()
+    executor._handle_errors = Mock()
+    executor._timeout_cleanup_order = Mock()
+    executor._timeout_cleanup_order.attach_mock(executor.dist.tp_allgather, "vote")
+    executor._timeout_cleanup_order.attach_mock(executor._handle_errors, "handle")
+    return executor
+
+
+def test_flag_unset_short_circuits_before_capability_query(monkeypatch):
+    executor = object.__new__(PyExecutor)
+    executor.kv_cache_transceiver = Mock()
+    executor._disagg_inflight_cancel_unsupported_logged = False
+    monkeypatch.setattr(executor_module, "is_disagg_inflight_cancel_enabled", lambda: False)
+
+    assert not PyExecutor._is_disagg_inflight_cancel_active(executor)
+    executor.kv_cache_transceiver.supports_inflight_request_cancellation.assert_not_called()
+
+
+def test_unsupported_transceiver_warns_once(monkeypatch):
+    executor = object.__new__(PyExecutor)
+    executor.kv_cache_transceiver = Mock()
+    executor.kv_cache_transceiver.supports_inflight_request_cancellation.return_value = False
+    executor._disagg_inflight_cancel_unsupported_logged = False
+    monkeypatch.setattr(executor_module, "is_disagg_inflight_cancel_enabled", lambda: True)
+    warning = Mock()
+    monkeypatch.setattr(executor_module.logger, "warning", warning)
+
+    assert not PyExecutor._is_disagg_inflight_cancel_active(executor)
+    assert not PyExecutor._is_disagg_inflight_cancel_active(executor)
+
+    assert executor._disagg_inflight_cancel_unsupported_logged
+    warning.assert_called_once()
+
+
+def test_flag_unset_generation_timeout_uses_rank_uniform_cleanup():
+    request = _make_timeout_request()
+    executor = _make_response_handler_stub([request], [True, False])
+
+    PyExecutor._handle_responses(executor)
+    PyExecutor._handle_kv_transfer_timeouts_synced(executor)
+
+    executor.kv_cache_transceiver.cancel_request.assert_called_once_with(request)
+    assert executor.active_requests == []
+    executor.dist.tp_allgather.assert_called_once_with(True)
+    executor._handle_errors.assert_called_once_with(
+        error_msg="Request timed out (KV transfer)",
+        requests=[request],
+        charge_budget=False,
+    )
+    assert executor._timeout_cleanup_order.mock_calls == [
+        call.vote(True),
+        call.handle(
+            error_msg="Request timed out (KV transfer)",
+            requests=[request],
+            charge_budget=False,
+        ),
+    ]
+
+
+def test_flag_unset_generation_timeout_peer_enters_cleanup():
+    executor = _make_response_handler_stub([], [False, True])
+
+    PyExecutor._handle_responses(executor)
+    PyExecutor._handle_kv_transfer_timeouts_synced(executor)
+
+    executor.kv_cache_transceiver.cancel_request.assert_not_called()
+    executor.dist.tp_allgather.assert_called_once_with(False)
+    executor._handle_errors.assert_called_once_with(
+        error_msg="Request timed out (KV transfer)",
+        requests=[],
+        charge_budget=False,
+    )
+    assert executor._timeout_cleanup_order.mock_calls == [
+        call.vote(False),
+        call.handle(
+            error_msg="Request timed out (KV transfer)",
+            requests=[],
+            charge_budget=False,
+        ),
+    ]
+
+
+def test_flag_unset_context_timeout_preserves_legacy_cleanup():
+    request = _make_timeout_request()
+    request.py_kv_transfer_start_time = 1.0
+    request.state = LlmRequestState.DISAGG_CONTEXT_TRANS_IN_PROGRESS
+    executor = object.__new__(PyExecutor)
+    executor.kv_cache_transceiver = Mock()
+    executor.kv_cache_transceiver.check_context_transfer_status.return_value = ([], [])
+    executor.kv_cache_transceiver.cancel_request.return_value = True
+    executor.async_transfer_manager = Mock()
+    executor.async_transfer_manager.requests_in_transfer.return_value = {
+        request.py_request_id: request
+    }
+    executor._disagg_timed_out_ctx_cancelled_ids = set()
+    executor.kv_cache_transceiver.supports_inflight_request_cancellation.return_value = True
+    executor._disagg_inflight_cancel_unsupported_logged = False
+    executor._end_transfer_and_maybe_terminate = Mock()
+    executor._check_cache_transfer_errors = Mock()
+
+    PyExecutor._check_disagg_ctx_cache_transfer_status(executor, 0)
+
+    executor.kv_cache_transceiver.cancel_request.assert_called_once_with(request)
+    assert request.py_kv_transfer_start_time is None
+    assert request.state == LlmRequestState.DISAGG_CONTEXT_COMPLETE
+    executor._end_transfer_and_maybe_terminate.assert_called_once_with(request)
+    assert request.py_request_id not in executor._disagg_timed_out_ctx_cancelled_ids
+
+
+def test_flag_unset_generation_driver_skips_cancel_pipeline():
+    executor = object.__new__(PyExecutor)
+    executor.kv_cache_transceiver = Mock()
+    executor.kv_cache_transceiver.supports_inflight_request_cancellation.return_value = True
+    executor._disagg_inflight_cancel_unsupported_logged = False
+    executor._check_disagg_gen_cache_transfer_status = Mock()
+    executor._cancel_timed_out_gen_transfers = Mock()
+    executor._check_gen_cache_transfer_errors_consensus = Mock()
+
+    PyExecutor._check_disagg_gen_transfer_status(executor)
+
+    executor._check_disagg_gen_cache_transfer_status.assert_called_once_with(0)
+    executor._cancel_timed_out_gen_transfers.assert_not_called()
+    executor._check_gen_cache_transfer_errors_consensus.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "backend,runtime,nixl_backend",
+    [
+        ("UCX", None, "UCX"),
+        ("MPI", None, "UCX"),
+        ("MOONCAKE", None, "UCX"),
+        ("NIXL", "PYTHON", "UCX"),
+        ("NIXL", "CPP", "LIBFABRIC"),
+    ],
+)
+def test_feature_opt_in_rejects_unqualified_config(monkeypatch, backend, runtime, nixl_backend):
+    monkeypatch.setenv(transceiver_module._DISAGG_INFLIGHT_CANCEL_ENABLED_ENV, "1")
+    monkeypatch.setenv(transceiver_module._NIXL_KVCACHE_BACKEND_ENV, nixl_backend)
+    config = CacheTransceiverConfig(backend=backend, transceiver_runtime=runtime)
+
+    with pytest.raises(ValueError, match="currently supported only"):
+        transceiver_module.create_kv_cache_transceiver(Mock(), Mock(), Mock(), Mock(), config)
+
+
+@pytest.mark.parametrize("nixl_backend", [None, "UCX"])
+def test_feature_opt_in_accepts_cpp_nixl_ucx(monkeypatch, nixl_backend):
+    monkeypatch.setenv(transceiver_module._DISAGG_INFLIGHT_CANCEL_ENABLED_ENV, "1")
+    if nixl_backend is not None:
+        monkeypatch.setenv(transceiver_module._NIXL_KVCACHE_BACKEND_ENV, nixl_backend)
+    config = CacheTransceiverConfig(backend="NIXL", transceiver_runtime="CPP")
+    expected = object()
+    constructor = Mock(return_value=expected)
+    monkeypatch.setattr(transceiver_module, "BindKvCacheTransceiver", constructor)
+
+    result = transceiver_module.create_kv_cache_transceiver(Mock(), Mock(), Mock(), Mock(), config)
+
+    assert result is expected
+    assert config.backend == "NIXL"
+    constructor.assert_called_once()
+
+
+def test_feature_opt_in_rejects_default_backend(monkeypatch):
+    monkeypatch.setenv(transceiver_module._DISAGG_INFLIGHT_CANCEL_ENABLED_ENV, "1")
+    monkeypatch.setenv(transceiver_module._NIXL_KVCACHE_BACKEND_ENV, "UCX")
+    config = CacheTransceiverConfig(backend="DEFAULT")
+
+    with pytest.raises(ValueError, match="backend='DEFAULT'"):
+        transceiver_module.create_kv_cache_transceiver(Mock(), Mock(), Mock(), Mock(), config)
+
+
+def test_feature_opt_in_rejects_ambiguous_legacy_backend_env(monkeypatch):
+    monkeypatch.setenv(transceiver_module._DISAGG_INFLIGHT_CANCEL_ENABLED_ENV, "1")
+    monkeypatch.setenv("TRTLLM_USE_NIXL_KVCACHE", "1")
+    monkeypatch.setenv("TRTLLM_USE_UCX_KVCACHE", "1")
+    config = CacheTransceiverConfig(backend="DEFAULT")
+
+    with pytest.raises(ValueError, match="multiple legacy backend selectors"):
+        transceiver_module.create_kv_cache_transceiver(Mock(), Mock(), Mock(), Mock(), config)
+
+
+def test_direct_cpp_wrapper_rejects_python_runtime_opt_in(monkeypatch):
+    monkeypatch.setenv(transceiver_module._DISAGG_INFLIGHT_CANCEL_ENABLED_ENV, "1")
+    config = CacheTransceiverConfig(backend="NIXL", transceiver_runtime="PYTHON")
+
+    with pytest.raises(ValueError, match="currently supported only"):
+        BindKvCacheTransceiver(Mock(), Mock(), Mock(), Mock(), config)
+
+
+def test_flag_unset_preserves_existing_backend_selection(monkeypatch):
+    config = CacheTransceiverConfig(backend="UCX")
+    expected = object()
+    constructor = Mock(return_value=expected)
+    monkeypatch.setattr(transceiver_module, "BindKvCacheTransceiver", constructor)
+
+    result = transceiver_module.create_kv_cache_transceiver(Mock(), Mock(), Mock(), Mock(), config)
+
+    assert result is expected
+    assert config.backend == "UCX"
+    constructor.assert_called_once()
+
+
+def test_flag_unset_preserves_python_transceiver(monkeypatch):
+    config = CacheTransceiverConfig(backend="NIXL", transceiver_runtime="PYTHON")
+    expected = object()
+    constructor = Mock(return_value=expected)
+    fake_module = SimpleNamespace(KvCacheTransceiverV2=constructor)
+    monkeypatch.setitem(sys.modules, "tensorrt_llm._torch.disaggregation.transceiver", fake_module)
+
+    result = transceiver_module.create_kv_cache_transceiver(Mock(), Mock(), Mock(), Mock(), config)
+
+    assert result is expected
+    constructor.assert_called_once()
+
+
+def test_flag_unset_preserves_libfabric_selection(monkeypatch):
+    monkeypatch.setenv(transceiver_module._NIXL_KVCACHE_BACKEND_ENV, "LIBFABRIC")
+    config = CacheTransceiverConfig(backend="NIXL")
+    expected = object()
+    constructor = Mock(return_value=expected)
+    monkeypatch.setattr(transceiver_module, "BindKvCacheTransceiver", constructor)
+
+    result = transceiver_module.create_kv_cache_transceiver(Mock(), Mock(), Mock(), Mock(), config)
+
+    assert result is expected
+    constructor.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "selector,expected_backend",
+    [
+        ("TRTLLM_USE_NIXL_KVCACHE", "NIXL"),
+        ("TRTLLM_USE_UCX_KVCACHE", "UCX"),
+        ("TRTLLM_USE_MOONCAKE_KVCACHE", "MOONCAKE"),
+        ("TRTLLM_USE_MPI_KVCACHE", "MPI"),
+    ],
+)
+def test_flag_unset_preserves_legacy_backend_env(monkeypatch, selector, expected_backend):
+    monkeypatch.setenv(selector, "1")
+    config = CacheTransceiverConfig(backend="DEFAULT")
+    constructor = Mock(return_value=object())
+    monkeypatch.setattr(transceiver_module, "BindKvCacheTransceiver", constructor)
+
+    transceiver_module.create_kv_cache_transceiver(Mock(), Mock(), Mock(), Mock(), config)
+
+    assert config.backend == expected_backend
+    constructor.assert_called_once()
+
+
+def test_flag_unset_preserves_legacy_backend_env_precedence(monkeypatch):
+    for selector in (
+        "TRTLLM_USE_MPI_KVCACHE",
+        "TRTLLM_USE_MOONCAKE_KVCACHE",
+        "TRTLLM_USE_UCX_KVCACHE",
+        "TRTLLM_USE_NIXL_KVCACHE",
+    ):
+        monkeypatch.setenv(selector, "1")
+    config = CacheTransceiverConfig(backend="DEFAULT")
+    monkeypatch.setattr(transceiver_module, "BindKvCacheTransceiver", Mock())
+
+    transceiver_module.create_kv_cache_transceiver(Mock(), Mock(), Mock(), Mock(), config)
+
+    assert config.backend == "NIXL"
+
+
+@pytest.mark.parametrize(
+    "backend,runtime,nixl_backend,expected",
+    [
+        ("NIXL", "CPP", None, True),
+        ("NIXL", None, "UCX", True),
+        ("NIXL", "CPP", "UCX", True),
+        ("NIXL", "PYTHON", "UCX", False),
+        ("NIXL", "CPP", "LIBFABRIC", False),
+        ("UCX", "CPP", "UCX", False),
+    ],
+)
+def test_cpp_capability_is_config_scoped(monkeypatch, backend, runtime, nixl_backend, expected):
+    if nixl_backend is not None:
+        monkeypatch.setenv(transceiver_module._NIXL_KVCACHE_BACKEND_ENV, nixl_backend)
+    config = CacheTransceiverConfig(backend=backend, transceiver_runtime=runtime)
+
+    assert transceiver_module._is_disagg_inflight_cancel_config_supported(config) is expected
+
+    monkeypatch.setattr(transceiver_module, "mapping_to_world_config", lambda mapping: object())
+    constructor = Mock(return_value=Mock())
+    monkeypatch.setattr(transceiver_module, "CacheTransceiverCpp", constructor)
+    monkeypatch.setattr(CacheTransceiverConfig, "_to_pybind", lambda config: object())
+    dist = Mock()
+    dist.pp_allgather.return_value = [1]
+    kv_cache_manager = SimpleNamespace(
+        total_num_kv_heads_per_layer=[1],
+        head_dim=64,
+        tokens_per_block=32,
+        dtype=object(),
+        num_kv_heads_per_layer=[1],
+        impl=object(),
+    )
+
+    transceiver = BindKvCacheTransceiver(Mock(), dist, kv_cache_manager, Mock(), config)
+
+    assert transceiver.supports_inflight_request_cancellation() is expected
+    constructor.assert_called_once()
+
+
+def test_python_transceiver_capability_defaults_to_unsupported():
+    from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    transceiver = object.__new__(KvCacheTransceiverV2)
+
+    assert not transceiver.supports_inflight_request_cancellation()
+    assert not transceiver.has_poisoned_transfer_buffer()
+
+
+def test_flag_unset_skips_cpp_poison_query():
+    transceiver = SimpleNamespace(impl=Mock())
+
+    assert not BindKvCacheTransceiver.has_poisoned_transfer_buffer(transceiver)
+    transceiver.impl.has_poisoned_transfer_buffer.assert_not_called()

--- a/tests/unittest/_torch/executor/test_disagg_inflight_cancel_gate.py
+++ b/tests/unittest/_torch/executor/test_disagg_inflight_cancel_gate.py
@@ -31,6 +31,9 @@ from tensorrt_llm.llmapi.llm_args import CacheTransceiverConfig
 def _reset_inflight_cancel_env_cache(monkeypatch):
     monkeypatch.delenv(transceiver_module._DISAGG_INFLIGHT_CANCEL_ENABLED_ENV, raising=False)
     monkeypatch.delenv(transceiver_module._NIXL_KVCACHE_BACKEND_ENV, raising=False)
+    monkeypatch.delenv(transceiver_module._DISABLE_KV_CACHE_TRANSFER_OVERLAP_ENV, raising=False)
+    monkeypatch.delenv(transceiver_module._DISAGG_LAYERWISE_ENV, raising=False)
+    monkeypatch.delenv(transceiver_module._TRY_ZCOPY_FOR_KV_CACHE_TRANSFER_ENV, raising=False)
     for env_name, _ in transceiver_module._CACHE_TRANSCEIVER_BACKEND_ENV_VARS:
         monkeypatch.delenv(env_name, raising=False)
     monkeypatch.setattr(transceiver_module, "_disagg_inflight_cancel_enabled_cache", None)
@@ -144,6 +147,44 @@ def test_flag_unset_generation_timeout_peer_enters_cleanup():
     ]
 
 
+def test_flag_unset_generation_timeout_keeps_uncancellable_request_active():
+    request = _make_timeout_request(in_progress=True)
+    executor = _make_response_handler_stub([request], [False, False])
+    executor.kv_cache_transceiver.cancel_request.return_value = False
+
+    PyExecutor._handle_responses(executor)
+
+    assert executor.active_requests == [request]
+    assert executor._pending_timed_out_requests == []
+    executor.kv_cache_transceiver.cancel_request.assert_called_once_with(request)
+
+
+def test_enabled_generation_timeout_waits_for_inflight_terminal_state(monkeypatch):
+    request = _make_timeout_request(in_progress=True)
+    request.state = LlmRequestState.DISAGG_GENERATION_TRANS_IN_PROGRESS
+    executor = _make_response_handler_stub([request], [False, False])
+    monkeypatch.setattr(executor_module, "is_disagg_inflight_cancel_enabled", lambda: True)
+
+    PyExecutor._handle_responses(executor)
+
+    assert executor.active_requests == [request]
+    assert executor._pending_timed_out_requests == []
+    executor.kv_cache_transceiver.cancel_request.assert_not_called()
+
+
+def test_enabled_generation_timeout_fails_transfer_that_completed_late(monkeypatch):
+    request = _make_timeout_request(in_progress=False)
+    request.state = LlmRequestState.DISAGG_GENERATION_TRANS_COMPLETE
+    executor = _make_response_handler_stub([request], [True, False])
+    monkeypatch.setattr(executor_module, "is_disagg_inflight_cancel_enabled", lambda: True)
+
+    PyExecutor._handle_responses(executor)
+
+    assert executor.active_requests == []
+    assert executor._pending_timed_out_requests == [request]
+    executor.kv_cache_transceiver.cancel_request.assert_not_called()
+
+
 def test_flag_unset_context_timeout_preserves_legacy_cleanup():
     request = _make_timeout_request()
     request.py_kv_transfer_start_time = 1.0
@@ -171,6 +212,111 @@ def test_flag_unset_context_timeout_preserves_legacy_cleanup():
     assert request.py_request_id not in executor._disagg_timed_out_ctx_cancelled_ids
 
 
+def test_enabled_context_timeout_defers_cleanup_until_cpp_terminal_state(monkeypatch):
+    request = _make_timeout_request()
+    request.py_kv_transfer_start_time = 1.0
+    request.state = LlmRequestState.DISAGG_CONTEXT_TRANS_IN_PROGRESS
+    executor = object.__new__(PyExecutor)
+    executor.kv_cache_transceiver = Mock()
+    executor.kv_cache_transceiver.check_context_transfer_status.return_value = ([], [])
+    executor.kv_cache_transceiver.cancel_request.return_value = True
+    executor.kv_cache_transceiver.supports_inflight_request_cancellation.return_value = True
+    executor.async_transfer_manager = Mock()
+    executor.async_transfer_manager.requests_in_transfer.return_value = {
+        request.py_request_id: request
+    }
+    executor._disagg_timed_out_ctx_cancelled_ids = set()
+    executor._disagg_inflight_cancel_unsupported_logged = False
+    executor._end_transfer_and_maybe_terminate = Mock()
+    executor._check_cache_transfer_errors = Mock()
+    monkeypatch.setattr(executor_module, "is_disagg_inflight_cancel_enabled", lambda: True)
+
+    PyExecutor._check_disagg_ctx_cache_transfer_status(executor, 0)
+
+    executor.kv_cache_transceiver.cancel_request.assert_called_once_with(request)
+    assert request.state == LlmRequestState.DISAGG_CONTEXT_TRANS_IN_PROGRESS
+    assert request.py_request_id in executor._disagg_timed_out_ctx_cancelled_ids
+    executor._end_transfer_and_maybe_terminate.assert_not_called()
+
+
+def test_context_transfer_error_keeps_request_active_until_all_owners_release():
+    request = SimpleNamespace(
+        state=LlmRequestState.DISAGG_TRANS_ERROR,
+        py_request_id=7,
+    )
+    executor = object.__new__(PyExecutor)
+    executor.kv_cache_transceiver = Mock()
+    executor.active_requests = [request]
+    executor.async_transfer_manager = Mock()
+    executor.async_transfer_manager.end_transfer.return_value = True
+    executor._terminate_request = Mock()
+
+    PyExecutor._end_transfer_and_maybe_terminate(executor, request)
+
+    executor.async_transfer_manager.end_transfer.assert_called_once_with(request)
+    assert executor.active_requests == [request]
+    executor._terminate_request.assert_not_called()
+
+
+def test_context_transfer_error_cleanup_waits_for_async_owners():
+    request = SimpleNamespace(
+        state=LlmRequestState.DISAGG_TRANS_ERROR,
+        py_request_id=7,
+        is_child=False,
+        is_context_only_request=True,
+    )
+    executor = object.__new__(PyExecutor)
+    executor.active_requests = [request]
+    executor.canceled_req_ids = []
+    executor.async_transfer_manager = Mock()
+    executor.async_transfer_manager.requests_in_transfer.return_value = {
+        request.py_request_id: request
+    }
+
+    assert PyExecutor._get_disagg_reqs_in_error_state(executor) == []
+
+    executor.async_transfer_manager.requests_in_transfer.return_value = {}
+    assert PyExecutor._get_disagg_reqs_in_error_state(executor) == [request]
+
+
+def test_user_cancel_waits_for_context_transfer_owners(monkeypatch):
+    request = SimpleNamespace(
+        state=LlmRequestState.DISAGG_TRANS_ERROR,
+        py_request_id=7,
+        is_child=False,
+        is_context_only_request=True,
+        py_kv_transfer_timed_out=True,
+        py_decoding_iter=3,
+        finish_by_reason=Mock(),
+    )
+    executor = object.__new__(PyExecutor)
+    executor.active_requests = [request]
+    executor.canceled_req_ids = [request.py_request_id]
+    executor.waiting_queue = Mock()
+    executor.kv_cache_transceiver = Mock()
+    executor.kv_cache_transceiver.cancel_request.return_value = True
+    executor.kv_cache_transceiver.supports_inflight_request_cancellation.return_value = True
+    executor._disagg_inflight_cancel_unsupported_logged = False
+    executor.async_transfer_manager = Mock()
+    executor.async_transfer_manager.requests_in_transfer.return_value = {
+        request.py_request_id: request
+    }
+    monkeypatch.setattr(executor_module, "is_disagg_inflight_cancel_enabled", lambda: True)
+
+    PyExecutor._handle_canceled_requests(executor)
+
+    assert executor.canceled_req_ids == [request.py_request_id]
+    request.finish_by_reason.assert_not_called()
+    executor.kv_cache_transceiver.cancel_request.assert_called_once_with(request)
+
+    executor.async_transfer_manager.requests_in_transfer.return_value = {}
+    PyExecutor._handle_canceled_requests(executor)
+
+    assert executor.canceled_req_ids == []
+    assert request.py_kv_transfer_timed_out is False
+    request.finish_by_reason.assert_called_once()
+
+
 def test_flag_unset_generation_driver_skips_cancel_pipeline():
     executor = object.__new__(PyExecutor)
     executor.kv_cache_transceiver = Mock()
@@ -185,6 +331,61 @@ def test_flag_unset_generation_driver_skips_cancel_pipeline():
     executor._check_disagg_gen_cache_transfer_status.assert_called_once_with(0)
     executor._cancel_timed_out_gen_transfers.assert_not_called()
     executor._check_gen_cache_transfer_errors_consensus.assert_not_called()
+
+
+def test_peer_buffer_poison_triggers_world_consistent_fatal_cleanup(monkeypatch):
+    executor = object.__new__(PyExecutor)
+    executor.kv_cache_transceiver = Mock()
+    executor.kv_cache_transceiver.supports_inflight_request_cancellation.return_value = True
+    executor.kv_cache_transceiver.has_poisoned_transfer_buffer.return_value = False
+    executor._disagg_inflight_cancel_unsupported_logged = False
+    executor.enable_attention_dp = False
+    executor.dist = SimpleNamespace(
+        world_size=2,
+        allreduce=Mock(return_value=1),
+    )
+    executor._fatal_error = None
+    executor.is_shutdown = False
+    executor._handle_errors = Mock()
+    monkeypatch.setattr(executor_module, "is_disagg_inflight_cancel_enabled", lambda: True)
+
+    PyExecutor._handle_disagg_cache_errors_synced(executor)
+
+    executor.dist.allreduce.assert_called_once_with(0, op=executor_module.ReduceOp.MAX)
+    assert isinstance(executor._fatal_error, RuntimeError)
+    assert executor.is_shutdown
+    executor._handle_errors.assert_called_once_with(
+        "Disagg KV cache transfer buffer is poisoned; process restart is required",
+        requests=None,
+        charge_budget=False,
+    )
+
+
+def test_preclassified_fatal_error_keeps_adp_response_collectives_aligned():
+    executor = object.__new__(PyExecutor)
+    executor._fatal_error = RuntimeError("already fatal")
+    executor._error_budget = Mock()
+    executor.is_shutdown = False
+    executor.waiting_queue = []
+    raw_queue = Mock()
+    raw_queue.empty.return_value = True
+    executor.executor_request_queue = Mock()
+    executor.executor_request_queue.get_request_queue.return_value = raw_queue
+    executor.active_requests = []
+    executor.gather_all_responses = False
+    executor.enable_attention_dp = True
+    executor.dist = SimpleNamespace(rank=1, world_size=2)
+    executor._enqueue_responses = Mock()
+    executor._terminate_request = Mock()
+
+    PyExecutor._handle_errors(
+        executor, "poisoned transfer buffer", requests=None, charge_budget=False
+    )
+
+    executor._error_budget.consume.assert_not_called()
+    assert executor.is_shutdown
+    assert executor._enqueue_responses.call_args_list == [call([]), call([])]
+    executor.executor_request_queue.enqueue_shutdown_request.assert_called_once_with()
 
 
 @pytest.mark.parametrize(
@@ -223,6 +424,33 @@ def test_feature_opt_in_accepts_cpp_nixl_ucx(monkeypatch, nixl_backend):
     constructor.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    "unsupported_env",
+    [
+        transceiver_module._DISABLE_KV_CACHE_TRANSFER_OVERLAP_ENV,
+        transceiver_module._DISAGG_LAYERWISE_ENV,
+        transceiver_module._TRY_ZCOPY_FOR_KV_CACHE_TRANSFER_ENV,
+    ],
+)
+def test_feature_opt_in_rejects_unsupported_transfer_mode(monkeypatch, unsupported_env):
+    monkeypatch.setenv(transceiver_module._DISAGG_INFLIGHT_CANCEL_ENABLED_ENV, "1")
+    monkeypatch.setenv(unsupported_env, "1")
+    config = CacheTransceiverConfig(backend="NIXL", transceiver_runtime="CPP")
+
+    with pytest.raises(ValueError, match="currently supported only"):
+        transceiver_module.create_kv_cache_transceiver(Mock(), Mock(), Mock(), Mock(), config)
+
+
+def test_feature_opt_in_requires_finite_transfer_timeout(monkeypatch):
+    monkeypatch.setenv(transceiver_module._DISAGG_INFLIGHT_CANCEL_ENABLED_ENV, "1")
+    config = CacheTransceiverConfig(
+        backend="NIXL", transceiver_runtime="CPP", kv_transfer_timeout_ms=None
+    )
+
+    with pytest.raises(ValueError, match="finite kv_transfer_timeout_ms"):
+        transceiver_module.create_kv_cache_transceiver(Mock(), Mock(), Mock(), Mock(), config)
+
+
 def test_feature_opt_in_rejects_default_backend(monkeypatch):
     monkeypatch.setenv(transceiver_module._DISAGG_INFLIGHT_CANCEL_ENABLED_ENV, "1")
     monkeypatch.setenv(transceiver_module._NIXL_KVCACHE_BACKEND_ENV, "UCX")
@@ -240,6 +468,21 @@ def test_feature_opt_in_rejects_ambiguous_legacy_backend_env(monkeypatch):
 
     with pytest.raises(ValueError, match="multiple legacy backend selectors"):
         transceiver_module.create_kv_cache_transceiver(Mock(), Mock(), Mock(), Mock(), config)
+
+
+def test_feature_opt_in_explicit_backend_ignores_legacy_selectors(monkeypatch):
+    monkeypatch.setenv(transceiver_module._DISAGG_INFLIGHT_CANCEL_ENABLED_ENV, "1")
+    monkeypatch.setenv("TRTLLM_USE_NIXL_KVCACHE", "1")
+    monkeypatch.setenv("TRTLLM_USE_UCX_KVCACHE", "1")
+    config = CacheTransceiverConfig(backend="NIXL", transceiver_runtime="CPP")
+    expected = object()
+    constructor = Mock(return_value=expected)
+    monkeypatch.setattr(transceiver_module, "BindKvCacheTransceiver", constructor)
+
+    result = transceiver_module.create_kv_cache_transceiver(Mock(), Mock(), Mock(), Mock(), config)
+
+    assert result is expected
+    constructor.assert_called_once()
 
 
 def test_direct_cpp_wrapper_rejects_python_runtime_opt_in(monkeypatch):

--- a/tests/unittest/_torch/executor/test_py_executor.py
+++ b/tests/unittest/_torch/executor/test_py_executor.py
@@ -755,7 +755,13 @@ class TestDisaggTransferIdleProgress:
         executor.kv_cache_transceiver = Mock()
         executor.enable_attention_dp = True
         executor.dist = Mock(world_size=4, rank=0)
-        executor.dist.tp_allgather.return_value = [[1], [], [], []]
+        local_vote = {"error_ids": [1], "blocked_ids": []}
+        executor.dist.tp_allgather.return_value = [
+            local_vote,
+            {"error_ids": [], "blocked_ids": []},
+            {"error_ids": [], "blocked_ids": []},
+            {"error_ids": [], "blocked_ids": []},
+        ]
         executor._handle_errors = Mock()
         executor._check_cache_transfer_errors = Mock()
         executor._sync_disagg_transfer_made_progress = False
@@ -795,7 +801,7 @@ class TestDisaggTransferIdleProgress:
 
         PyExecutor._handle_disagg_cache_errors_synced(executor)
 
-        executor.dist.tp_allgather.assert_called_once_with([1])
+        executor.dist.tp_allgather.assert_called_once_with(local_vote)
         executor._handle_errors.assert_called_once_with(
             "Disagg KV cache transfer error",
             requests=[error_request],
@@ -1401,6 +1407,13 @@ def _err_req(request_id=1):
     return _make_adp_request(LlmRequestState.DISAGG_TRANS_ERROR, request_id=request_id)
 
 
+def _disagg_error_vote(error_ids=(), blocked_ids=()):
+    return {
+        "error_ids": list(error_ids),
+        "blocked_ids": list(blocked_ids),
+    }
+
+
 _DEFAULT_KV_CACHE_TRANSCEIVER = object()
 
 
@@ -1419,6 +1432,7 @@ def _make_disagg_err_stub(
         kv_cache_transceiver.supports_inflight_request_cancellation.return_value = False
         kv_cache_transceiver.has_poisoned_transfer_buffer.return_value = False
     stub.kv_cache_transceiver = kv_cache_transceiver
+    stub._disagg_inflight_cancel_unsupported_logged = False
     stub.active_requests = active_requests if active_requests is not None else []
     stub.dist = Mock()
     stub.dist.world_size = world_size
@@ -1435,8 +1449,11 @@ def _make_disagg_err_stub(
         )
 
     stub._handle_errors = _rec_handle_errors
+    stub._request_vote_id = PyExecutor._request_vote_id
     for helper in (
         "_handle_disagg_cache_errors_synced",
+        "_is_disagg_inflight_cancel_active",
+        "_is_disagg_error_cleanup_blocked",
         "_get_disagg_reqs_in_error_state",
         "_check_cache_transfer_errors",
     ):
@@ -1469,7 +1486,8 @@ class TestDisaggCacheErrorsSynced:
         matching = _make_adp_request(_STATE_GENERATION_IN_PROGRESS, request_id=7)
         unrelated = _make_adp_request(_STATE_GENERATION_IN_PROGRESS, request_id=8)
         stub = _make_disagg_err_stub(
-            active_requests=[matching, unrelated], tp_allgather_result=[[], [7]]
+            active_requests=[matching, unrelated],
+            tp_allgather_result=[_disagg_error_vote(), _disagg_error_vote([7])],
         )
         stub._handle_disagg_cache_errors_synced()
         assert len(stub.handle_errors_calls) == 1
@@ -1477,13 +1495,19 @@ class TestDisaggCacheErrorsSynced:
         assert stub.handle_errors_calls[0]["charge_budget"] is False
 
     def test_no_handle_when_no_rank_has_error(self):
-        stub = _make_disagg_err_stub(active_requests=[], tp_allgather_result=[[], []])
+        stub = _make_disagg_err_stub(
+            active_requests=[],
+            tp_allgather_result=[_disagg_error_vote(), _disagg_error_vote()],
+        )
         stub._handle_disagg_cache_errors_synced()
         assert stub.handle_errors_calls == []
 
     def test_peer_error_without_local_replica_still_enters_handler(self):
         unrelated = _make_adp_request(_STATE_GENERATION_IN_PROGRESS, request_id=8)
-        stub = _make_disagg_err_stub(active_requests=[unrelated], tp_allgather_result=[[], [7]])
+        stub = _make_disagg_err_stub(
+            active_requests=[unrelated],
+            tp_allgather_result=[_disagg_error_vote(), _disagg_error_vote([7])],
+        )
 
         stub._handle_disagg_cache_errors_synced()
 
@@ -1492,7 +1516,9 @@ class TestDisaggCacheErrorsSynced:
     def test_local_error_req_forwarded_request_scoped(self):
         err = _err_req()
         ok = _make_adp_request(_STATE_GENERATION_IN_PROGRESS, request_id=2)
-        stub = _make_disagg_err_stub(active_requests=[ok, err], tp_allgather_result=[[1]])
+        stub = _make_disagg_err_stub(
+            active_requests=[ok, err], tp_allgather_result=[_disagg_error_vote([1])]
+        )
         stub._handle_disagg_cache_errors_synced()
         assert len(stub.handle_errors_calls) == 1
         assert stub.handle_errors_calls[0]["requests"] == [err]
@@ -1505,11 +1531,34 @@ class TestDisaggCacheErrorsSynced:
             is_child=True,
             parent_request_id=9,
         )
-        stub = _make_disagg_err_stub(active_requests=[child], tp_allgather_result=[[], [9]])
+        stub = _make_disagg_err_stub(
+            active_requests=[child],
+            tp_allgather_result=[_disagg_error_vote(), _disagg_error_vote([9])],
+        )
 
         stub._handle_disagg_cache_errors_synced()
 
         assert stub.handle_errors_calls[0]["requests"] == [child]
+
+    def test_peer_vote_does_not_clean_up_locally_deferred_request(self):
+        request = _err_req(request_id=7)
+        request.is_context_only_request = True
+        stub = _make_disagg_err_stub(
+            active_requests=[request],
+            tp_allgather_result=[
+                _disagg_error_vote(blocked_ids=[7]),
+                _disagg_error_vote([7]),
+            ],
+        )
+        stub.canceled_req_ids = []
+        stub.async_transfer_manager = Mock()
+        stub.async_transfer_manager.requests_in_transfer.return_value = {
+            request.py_request_id: request
+        }
+
+        stub._handle_disagg_cache_errors_synced()
+
+        assert stub.handle_errors_calls == []
 
 
 class TestCheckCacheTransferErrorsAdpNoop:

--- a/tests/unittest/_torch/executor/test_py_executor.py
+++ b/tests/unittest/_torch/executor/test_py_executor.py
@@ -1401,16 +1401,23 @@ def _err_req(request_id=1):
     return _make_adp_request(LlmRequestState.DISAGG_TRANS_ERROR, request_id=request_id)
 
 
+_DEFAULT_KV_CACHE_TRANSCEIVER = object()
+
+
 def _make_disagg_err_stub(
     *,
     enable_attention_dp=True,
-    kv_cache_transceiver=object(),
+    kv_cache_transceiver=_DEFAULT_KV_CACHE_TRANSCEIVER,
     world_size=2,
     active_requests=None,
     tp_allgather_result=None,
 ):
     stub = types.SimpleNamespace()
     stub.enable_attention_dp = enable_attention_dp
+    if kv_cache_transceiver is _DEFAULT_KV_CACHE_TRANSCEIVER:
+        kv_cache_transceiver = Mock()
+        kv_cache_transceiver.supports_inflight_request_cancellation.return_value = False
+        kv_cache_transceiver.has_poisoned_transfer_buffer.return_value = False
     stub.kv_cache_transceiver = kv_cache_transceiver
     stub.active_requests = active_requests if active_requests is not None else []
     stub.dist = Mock()

--- a/tests/unittest/others/test_kv_cache_transceiver.py
+++ b/tests/unittest/others/test_kv_cache_transceiver.py
@@ -237,6 +237,7 @@ def _run_cpp_nixl_sync_transfer_stress():
     dist = Distributed.get(mapping)
     manager_kwargs = {
         "max_tokens": request_count * prompt_len * 2,
+        # This test validates transfer only, so no decode capacity is needed.
         "max_seq_len": prompt_len,
         "max_batch_size": request_count,
     }
@@ -279,7 +280,7 @@ def _run_cpp_nixl_sync_transfer_stress():
 
         def poll_context_transfers():
             completed, failed = transceiver_ctx.check_context_transfer_status(1)
-            assert failed == []
+            assert failed == [], f"context transfers failed: {failed}"
             completed_ctx_ids.update(completed)
 
         for request_index, ctx_request in enumerate(ctx_requests):

--- a/tests/unittest/others/test_kv_cache_transceiver.py
+++ b/tests/unittest/others/test_kv_cache_transceiver.py
@@ -411,6 +411,7 @@ def test_cancel_request_in_transmission(attention_type):
 
     # Block the main thread due to the async operation
     time.sleep(2)
+    kv_cache_transceiver_gen.check_gen_transfer_status(0)
     assert gen_request.state == LlmRequestState.DISAGG_TRANS_ERROR
 
 
@@ -1025,4 +1026,5 @@ def test_hybrid_cache_transceiver_cancel_request(backend):
 
     # Block the main thread due to the async operation
     time.sleep(2)
+    cache_transceiver_gen.check_gen_transfer_status(0)
     assert gen_request.state == LlmRequestState.DISAGG_TRANS_ERROR


### PR DESCRIPTION
## Summary

This PR adds experimental, default-off deadline enforcement and in-flight KV-transfer cancellation for the PyExecutor C++ NIXL cache transceiver using the NIXL UCX plugin.

The change is self-contained at the request and transfer-resource boundary. When cancellation is enabled, a timed-out or user-cancelled request is not cleaned up merely because cancellation was requested. C++ transfer bookkeeping retains the request lifetime, and `TransferSession` retains any reserved staging-buffer slots until the distributed transfer outcome is terminal. Slots are released only when reuse is known to be safe; otherwise the transfer-buffer pool is poisoned fail-closed and the executor requires a process restart.

Set `TRTLLM_DISAGG_ENABLE_INFLIGHT_CANCEL=1` to opt in. The flag remains disabled by default.

## Activation and compatibility

Opt-in is accepted only with:

- the PyExecutor C++ cache transceiver (`transceiver_runtime='CPP'` or the C++ default);
- `backend='NIXL'` with the NIXL UCX plugin;
- a configured `kv_transfer_timeout_ms`;
- asynchronous, non-layer-wise KV transfer; and
- zero-copy KV transfer disabled.

Python/V2, direct UCX, MPI, Mooncake, NIXL Libfabric, the legacy C++ executor, and ambiguous legacy backend selection reject opt-in before an unsupported cancellation path can run. With the flag unset, existing timeout handling, backend selection, and transceiver behavior remain unchanged.

All participating ranks and both disaggregated services must use the same feature setting and compatible transport configuration. This PR does not negotiate cancellation capability between CTX and GEN.

## Cancellation and cleanup flow

1. The executor observes that a context or generation KV transfer exceeded its configured deadline, or receives a user cancellation.
2. Local completed, failed, and timed-out observations enter the existing distributed transfer-state reduction. Timeout or failure wins across participating ranks.
3. Every nonterminal rank requests cancellation for the agreed request set. NIXL status polling stays bounded so the executor can continue scheduling and transfer progress between polls.
4. C++ transfer bookkeeping retains the request lifetime, while `TransferSession` retains the receive-buffer reservations used by KV, MLA, and RNN formatters as cancellation races with terminal status.
5. The request remains in `AsyncTransferManager` or the active generation set until C++ reports a terminal distributed outcome. Attention-DP error handling votes on request IDs before entering response collectives.
6. On a safely terminal transfer, the NIXL transfer handle is released and staging slots return to their pools. A late success after the deadline still fails the request, but cleanup occurs only after the transfer is quiesced.
7. If quiescence or buffer reuse cannot be established, the affected slot or pool is poisoned. Poison is reduced across the executor world and treated as fatal rather than permitting possible buffer reuse.

The opt-in path rejects `blockAll` / `nullopt` wait-all status calls. Supporting wait-all semantics together with finite cancellation deadlines remains follow-up work.

## Scope boundaries

| Area | Ownership |
| --- | --- |
| Deadline and cancellation decision | Finite deadline detection, distributed timeout/failure reduction, and cancellation of queued or active C++ NIXL transfers are included here. |
| Request and buffer lifetime | Deferred request cleanup, transfer-session staging-slot ownership, NIXL handle release, and fail-closed buffer poisoning are included here because they are required for safe opt-in. |
| Immediate PyExecutor integration | Rank-aligned error handling, retained transfer owners, user-cancellation retry, and fatal poison escalation are included here. |
| Full IPC/worker lifecycle | Process-level fatal propagation, proxy shutdown, and disposable-worker restart behavior remain in #15795. |
| Cross-service protocol | CTX/GEN capability and effective-mode negotiation remain in #15798. Peer cancellation, terminal evidence, and bounded metadata retirement remain in #15799. |
| Other transports | Python/V2, direct UCX, MPI, Mooncake, and NIXL Libfabric require backend-specific cancellation and quiescence contracts. |
| Default-on rollout | Remains in #15738 after the required protocol and lifecycle gates are complete. |

Because this PR now owns the minimum native session and buffer-safety envelope, #15794 should be rebased and narrowed to its remaining C++ protocol, capability, and teardown hardening instead of duplicating this implementation. #15795 continues to own the broader PyExecutor IPC and worker-lifecycle layer.

## Dependency graph

Arrows point from prerequisite to dependent. The bounded-polling work originally proposed in #15181 was subsumed by merged #15356; #15356 and #15737 are inherited from `main`.

```mermaid
flowchart LR
    MAIN["main<br/>prerequisites merged"]
    PR15238["#15238 current<br/>gated cancellation + safe cleanup"]
    PR15794["#15794 draft<br/>remaining C++ protocol hardening"]
    PR15795["#15795 draft<br/>IPC and worker lifecycle"]
    PR15798["#15798 follow-up<br/>CTX/GEN mode negotiation"]
    PR15799["#15799 follow-up<br/>peer terminal protocol"]
    PR15738["#15738 draft<br/>qualified default-on policy"]

    MAIN --> PR15238
    PR15238 --> PR15794
    PR15794 --> PR15795
    PR15794 --> PR15798
    PR15798 --> PR15799
    PR15795 --> PR15738
    PR15798 --> PR15738
    PR15799 -.->|or approved bounded fail/restart policy| PR15738

    classDef merged fill:#d8f3dc,stroke:#2d6a4f,color:#1b4332
    classDef current fill:#cfe8ff,stroke:#0969da,color:#0a3069,stroke-width:3px
    classDef draft fill:#fff3bf,stroke:#e67700,color:#7c2d12
    classDef followup fill:#eeeeee,stroke:#6e7781,color:#24292f,stroke-dasharray: 5 4

    class MAIN merged
    class PR15238 current
    class PR15794,PR15795,PR15738 draft
    class PR15798,PR15799 followup
```

## Validation

- Rebased onto upstream `main` at `1225445ceb`; merged prerequisites are inherited from `main`.
- Full PR-diff formatting, lint, YAML, test-list, merge-marker, and static pre-commit checks passed locally.
- `git diff --check` and Python syntax compilation passed.
- Added focused coverage for default-off compatibility, opt-in qualification, distributed timeout/error handling, deferred cleanup, user cancellation, buffer ownership and poisoning, and NIXL transfer-handle release.
- Added C++/Python NIXL integration coverage to the applicable CI test lists.
- Focused pytest execution is unavailable in the local Darwin checkout because the Python environment lacks `transformers` and the changed C++ bindings are not built. Exact-head CI remains required for compiled and distributed runtime validation.
