### PR TITLE
[https://nvbugs/6223556][fix] Propagate gen-first ctx usage via aux buffer to postproc

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -578,6 +578,12 @@ class LlmResult:
         self._py_result = py_result
         self.is_final = is_final
         self.cached_tokens = 0
+        # Context-worker usage propagated to the generation worker via the
+        # KV-transfer aux buffer in gen-first disaggregated scheduling. Carried
+        # on the response so the postprocessor can adopt the context-side
+        # prompt/cached token accounting (the gen worker treats the whole
+        # transferred prompt as cached and would otherwise over-report).
+        self.ctx_usage = None
         # Time breakdown metrics for performance analysis
         # Contains: step_metrics (list), ctx_gpu_forward_time (float), ctx_gpu_sample_time (float)
         self.time_breakdown_metrics = time_breakdown_metrics

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -578,11 +578,8 @@ class LlmResult:
         self._py_result = py_result
         self.is_final = is_final
         self.cached_tokens = 0
-        # Context-worker usage propagated to the generation worker via the
-        # KV-transfer aux buffer in gen-first disaggregated scheduling. Carried
-        # on the response so the postprocessor can adopt the context-side
-        # prompt/cached token accounting (the gen worker treats the whole
-        # transferred prompt as cached and would otherwise over-report).
+        # Context-worker usage for gen-first disagg, delivered via the
+        # KV-transfer aux buffer (see _maybe_attach_ctx_usage).
         self.ctx_usage = None
         # Time breakdown metrics for performance analysis
         # Contains: step_metrics (list), ctx_gpu_forward_time (float), ctx_gpu_sample_time (float)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -789,6 +789,7 @@ class PyExecutor:
             response = request.create_response(False, self.dist.rank)
             if response:
                 response.result.cached_tokens = request.cached_tokens
+                self._maybe_attach_ctx_usage(request, response)
                 # Buffer the response instead of enqueueing immediately.
                 # With ADP, _enqueue_responses does a tp_gather collective.
                 # Calling it here would deadlock because only the owning DP
@@ -4321,6 +4322,22 @@ class PyExecutor:
         cum_log_probs[seq_slot, :beam_width].copy_(values)
         return True
 
+    @staticmethod
+    def _maybe_attach_ctx_usage(request: LlmRequest, response):
+        """Carry context-worker usage onto the generation response.
+
+        In gen-first disaggregated scheduling the context and generation
+        requests run concurrently, so the context worker's usage cannot be
+        injected into the request as in the context-first path. Instead it is
+        delivered to the generation worker through the KV-transfer aux buffer
+        (see RxSession.unpack_aux) and stored on
+        ``py_disaggregated_params.ctx_usage``. Surface it on the response so the
+        postprocessor can adopt the context-side prompt/cached token accounting.
+        """
+        disagg_params = getattr(request, 'py_disaggregated_params', None)
+        if disagg_params is not None and disagg_params.ctx_usage is not None:
+            response.result.ctx_usage = disagg_params.ctx_usage
+
     def _maybe_prepend_logprobs_and_logits(self, req, beam_width):
         """Prepend logprobs and generation logits for first_gen_tokens
         if transferred from prefill."""
@@ -4980,6 +4997,7 @@ class PyExecutor:
             if response is None:
                 continue
             response.result.cached_tokens = request.cached_tokens
+            self._maybe_attach_ctx_usage(request, response)
             if logits_snapshot is not None:
                 response.result.generation_logits = logits_snapshot
             new_responses.append((request.py_request_id, response))
@@ -5067,6 +5085,7 @@ class PyExecutor:
                 if response:
                     request_done = request.is_finished
                     response.result.cached_tokens = request.cached_tokens
+                    self._maybe_attach_ctx_usage(request, response)
                     response.result.per_pos_drafted = request.py_per_pos_drafted
                     response.result.per_pos_accepted = request.py_per_pos_accepted
                     new_responses.append((req_id, response))

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -4324,16 +4324,9 @@ class PyExecutor:
 
     @staticmethod
     def _maybe_attach_ctx_usage(request: LlmRequest, response):
-        """Carry context-worker usage onto the generation response.
-
-        In gen-first disaggregated scheduling the context and generation
-        requests run concurrently, so the context worker's usage cannot be
-        injected into the request as in the context-first path. Instead it is
-        delivered to the generation worker through the KV-transfer aux buffer
-        (see RxSession.unpack_aux) and stored on
-        ``py_disaggregated_params.ctx_usage``. Surface it on the response so the
-        postprocessor can adopt the context-side prompt/cached token accounting.
-        """
+        """Surface gen-first ctx usage (delivered via the KV-transfer aux
+        buffer in RxSession.unpack_aux) onto the response so the postprocessor
+        adopts the context-side prompt/cached token accounting."""
         disagg_params = getattr(request, 'py_disaggregated_params', None)
         if disagg_params is not None and disagg_params.ctx_usage is not None:
             response.result.ctx_usage = disagg_params.ctx_usage

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -4327,7 +4327,7 @@ class PyExecutor:
         """Surface gen-first ctx usage (delivered via the KV-transfer aux
         buffer in RxSession.unpack_aux) onto the response so the postprocessor
         adopts the context-side prompt/cached token accounting."""
-        disagg_params = getattr(request, 'py_disaggregated_params', None)
+        disagg_params = request.py_disaggregated_params
         if disagg_params is not None and disagg_params.ctx_usage is not None:
             response.result.ctx_usage = disagg_params.ctx_usage
 

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -500,7 +500,7 @@ class GenerationResultBase:
             self.avg_decoded_tokens_per_iter = response_result.avg_decoded_tokens_per_iter
             # Expose gen-first ctx usage so the postprocessor
             # (_ctx_usage_from_outputs) can adopt the context-side accounting.
-            ctx_usage = getattr(response_result, 'ctx_usage', None)
+            ctx_usage = response_result.ctx_usage
             if ctx_usage is not None:
                 self._disaggregated_params = dataclasses.replace(
                     self._disaggregated_params or DisaggregatedParams(),

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -498,6 +498,16 @@ class GenerationResultBase:
             self.per_pos_accepted = getattr(response_result, 'per_pos_accepted',
                                             None)
             self.avg_decoded_tokens_per_iter = response_result.avg_decoded_tokens_per_iter
+            # Gen-first disaggregated: the context worker's usage is delivered to
+            # the generation worker via the KV-transfer aux buffer and surfaced
+            # here so the postprocessor (_ctx_usage_from_outputs) can adopt the
+            # context-side prompt/cached token accounting.
+            ctx_usage = getattr(response_result, 'ctx_usage', None)
+            if ctx_usage is not None:
+                self._disaggregated_params = dataclasses.replace(
+                    self._disaggregated_params or DisaggregatedParams(),
+                    ctx_usage=ctx_usage,
+                )
             if context_phase_params is not None:
                 existing_disagg_params = self.disaggregated_params
                 # Use `replace` to preserve things like `mrope_position_ids_handle` and

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -498,10 +498,8 @@ class GenerationResultBase:
             self.per_pos_accepted = getattr(response_result, 'per_pos_accepted',
                                             None)
             self.avg_decoded_tokens_per_iter = response_result.avg_decoded_tokens_per_iter
-            # Gen-first disaggregated: the context worker's usage is delivered to
-            # the generation worker via the KV-transfer aux buffer and surfaced
-            # here so the postprocessor (_ctx_usage_from_outputs) can adopt the
-            # context-side prompt/cached token accounting.
+            # Expose gen-first ctx usage so the postprocessor
+            # (_ctx_usage_from_outputs) can adopt the context-side accounting.
             ctx_usage = getattr(response_result, 'ctx_usage', None)
             if ctx_usage is not None:
                 self._disaggregated_params = dataclasses.replace(

--- a/tensorrt_llm/executor/result.py
+++ b/tensorrt_llm/executor/result.py
@@ -500,7 +500,10 @@ class GenerationResultBase:
             self.avg_decoded_tokens_per_iter = response_result.avg_decoded_tokens_per_iter
             # Expose gen-first ctx usage so the postprocessor
             # (_ctx_usage_from_outputs) can adopt the context-side accounting.
-            ctx_usage = response_result.ctx_usage
+            # ctx_usage only exists on the Python LlmResult wrapper; the raw C++
+            # bindings.executor.Result (non-disagg / benchmark path) does not
+            # have it, so fall back to None as with cached_tokens above.
+            ctx_usage = getattr(response_result, 'ctx_usage', None)
             if ctx_usage is not None:
                 self._disaggregated_params = dataclasses.replace(
                     self._disaggregated_params or DisaggregatedParams(),

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_overlap_gen_first.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_overlap_gen_first.yaml
@@ -12,9 +12,9 @@ context_servers:
   tensor_parallel_size: 1
   pipeline_parallel_size: 1
   kv_cache_config:
-    enable_block_reuse: False
+    enable_block_reuse: True
     free_gpu_memory_fraction: 0.2
-    enable_partial_reuse: False
+    enable_partial_reuse: True
 
   cache_transceiver_config:
     backend: DEFAULT
@@ -29,9 +29,9 @@ generation_servers:
   max_num_tokens: 4096
   max_seq_len: 4096
   kv_cache_config:
-    enable_block_reuse: False
+    enable_block_reuse: True
     free_gpu_memory_fraction: 0.2
-    enable_partial_reuse: False
+    enable_partial_reuse: True
   cache_transceiver_config:
     backend: DEFAULT
     transceiver_runtime: PYTHON

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_overlap_gen_first_pp4.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_overlap_gen_first_pp4.yaml
@@ -12,9 +12,9 @@ context_servers:
   tensor_parallel_size: 1
   pipeline_parallel_size: 4
   kv_cache_config:
-    enable_block_reuse: False
+    enable_block_reuse: True
     free_gpu_memory_fraction: 0.2
-    enable_partial_reuse: False
+    enable_partial_reuse: True
 
   cache_transceiver_config:
     backend: DEFAULT
@@ -29,9 +29,9 @@ generation_servers:
   max_num_tokens: 4096
   max_seq_len: 4096
   kv_cache_config:
-    enable_block_reuse: False
+    enable_block_reuse: True
     free_gpu_memory_fraction: 0.2
-    enable_partial_reuse: False
+    enable_partial_reuse: True
   cache_transceiver_config:
     backend: DEFAULT
     transceiver_runtime: PYTHON

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -128,8 +128,6 @@ disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_fp8_tp1
 disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_fp8_tp1_two_mtp[DeepSeek-V3-Lite-fp8] SKIP (https://nvbugs/6162322)
 disaggregated/test_disaggregated.py::test_disaggregated_genbs1[TinyLlama-1.1B-Chat-v1.0] SKIP (https://nvbugs/6162322)
 disaggregated/test_disaggregated.py::test_disaggregated_gpt_oss_120b_harmony[gpt_oss/gpt-oss-120b] SKIP (https://nvbugs/6245317)
-disaggregated/test_disaggregated.py::test_disaggregated_overlap_gen_first[ctx_pp1-TinyLlama-1.1B-Chat-v1.0] SKIP (https://nvbugs/6223556)
-disaggregated/test_disaggregated.py::test_disaggregated_overlap_gen_first[ctx_pp4-TinyLlama-1.1B-Chat-v1.0] SKIP (https://nvbugs/6223556)
 disaggregated/test_disaggregated_single_gpu.py::test_disaggregated_llama_context_capacity[False-False-DeepSeek-V3-Lite-fp8/fp8] SKIP (https://nvbugs/6266302)
 disaggregated/test_workers.py::test_workers_conversation_router[TinyLlama-1.1B-Chat-v1.0] SKIP (https://nvbugs/6162322)
 disaggregated/test_workers.py::test_workers_kv_cache_aware_router_deepseek_v3_lite_bf16[DeepSeek-V3-Lite-bf16] SKIP (https://nvbugs/6162322)


### PR DESCRIPTION
## Summary

**Root cause:** In gen-first disaggregated scheduling the context and generation requests run concurrently, so the context worker's usage accounting cannot be injected into the request as it is in the context-first path. It is instead delivered to the generation worker through the KV-transfer aux buffer (`RxSession.unpack_aux`), which sets `py_disaggregated_params.ctx_usage`. However, that value was never surfaced onto the response, so the postprocessor fell back to the generation worker's local accounting — which treats the entire transferred prompt as cached and over-reports `cached_tokens` (the full prompt length 17 instead of the reused `prompt_tokens-1 = 16`). This caused `test_disaggregated_overlap_gen_first` to fail its cache-reuse usage check.

**Fix:** Complete the existing aux-buffer transmission pipeline (introduced in #14177) instead of rewriting usage at the orchestrator:
- Carry `ctx_usage` on `LlmResult`.
- Set it on the response alongside `cached_tokens` in `py_executor` (all three response-creation sites: generation, fast-transfer, and streaming emit).
- Surface it onto the output's `disaggregated_params` in `result.py` so the existing postprocessor path (`_ctx_usage_from_outputs` -> `rewrite_usage_info_from_ctx`) adopts the context-side accounting.

This keeps the disaggregated orchestrator a thin proxy (consistent with #14177) and fixes **both** streaming and non-streaming gen-first usage, since the postprocessor already handles both uniformly.

The `overlap_gen_first` test configs are updated to enable block/partial reuse so the cache-reuse usage check is meaningful, and the corresponding waives are removed.

## Test plan
- [x] `test_disaggregated_overlap_gen_first[ctx_pp1-TinyLlama-1.1B-Chat-v1.0]` passes (B200). Before fix: every request reported `cached_tokens == prompt_tokens` (17/17). After fix: first (cold) request reports the context-side count (e.g. `cached_tokens: 3`), second (reuse) request reports `prompt_tokens - 1` (16 for completions, 30 for chat).
- [x] `ctx_pp4` variant — verified by CI (locally blocked by GPU availability; logic is identical and independent of context-side pipeline parallelism).

## Links
- Bug: https://nvbugs/6223556

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed disaggregated scheduling test cases for TinyLlama-1.1B-Chat model that were previously waived.

* **Improvements**
  * Enhanced context-side usage tracking and accounting in disaggregated execution scheduling modes.
  * Enabled KV-cache block reuse optimization in test configurations for better memory efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->