### PR TITLE
[TRTLLM-13378][feat] Drop legacy --extra_visual_gen_options CLI alias

### DIFF
--- a/docs/source/commands/trtllm-serve/trtllm-serve.rst
+++ b/docs/source/commands/trtllm-serve/trtllm-serve.rst
@@ -224,13 +224,13 @@ Visual Generation Serving
 
    # Video generation (Wan)
    trtllm-serve Wan-AI/Wan2.2-T2V-A14B-Diffusers \
-       --extra_visual_gen_options config.yml
+       --visual_gen_args config.yml
 
    # Image generation (FLUX)
    trtllm-serve black-forest-labs/FLUX.2-dev \
-       --extra_visual_gen_options config.yml
+       --visual_gen_args config.yml
 
-The ``--extra_visual_gen_options`` flag accepts a YAML file that configures quantization, parallelism, and TeaCache. Available visual generation endpoints include ``/v1/images/generations``, ``/v1/videos``, ``/v1/videos/generations``, and video management APIs.
+The ``--visual_gen_args`` flag accepts a YAML file that configures quantization, parallelism, and TeaCache. Available visual generation endpoints include ``/v1/images/generations``, ``/v1/videos``, ``/v1/videos/generations``, and video management APIs.
 
 For full details, see the :doc:`../../models/visual-generation.md` feature documentation. Example client scripts are available in the `examples/visual_gen/serve/ <https://github.com/NVIDIA/TensorRT-LLM/tree/main/examples/visual_gen/serve>`_ directory.
 

--- a/examples/visual_gen/configs/ltx2-4gpu.yaml
+++ b/examples/visual_gen/configs/ltx2-4gpu.yaml
@@ -15,7 +15,7 @@
 
 # 4-GPU LTX-2 AudioVideo parallel config (precision-agnostic — picks up
 # whatever checkpoint is passed via --model_path). Shared by offline
-# examples (--extra_visual_gen_options) and trtllm-serve.
+# examples (--visual_gen_args) and trtllm-serve.
 attention_config:
   backend: VANILLA
 parallel_config:

--- a/examples/visual_gen/configs/wan2.2-t2v-fp4-1gpu.yaml
+++ b/examples/visual_gen/configs/wan2.2-t2v-fp4-1gpu.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # 1-GPU Wan 2.2 T2V with NVFP4 dynamic quantization.
-# Shared by offline examples (--extra_visual_gen_options) and trtllm-serve.
+# Shared by offline examples (--visual_gen_args) and trtllm-serve.
 quant_config:
   quant_algo: NVFP4
   dynamic: true

--- a/examples/visual_gen/configs/wan2.2-t2v-fp4-4gpu.yaml
+++ b/examples/visual_gen/configs/wan2.2-t2v-fp4-4gpu.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # 4-GPU Wan 2.2 T2V with NVFP4 dynamic quantization.
-# Shared by offline examples (--extra_visual_gen_options) and trtllm-serve.
+# Shared by offline examples (--visual_gen_args) and trtllm-serve.
 quant_config:
   quant_algo: NVFP4
   dynamic: true

--- a/examples/visual_gen/configs/wan2.2-t2v-fp8-8gpu.yaml
+++ b/examples/visual_gen/configs/wan2.2-t2v-fp8-8gpu.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # 8-GPU Wan 2.2 T2V with FP8 blockwise dynamic quantization.
-# Shared by offline examples (--extra_visual_gen_options) and trtllm-serve.
+# Shared by offline examples (--visual_gen_args) and trtllm-serve.
 quant_config:
   quant_algo: FP8_BLOCK_SCALES
   dynamic: true

--- a/examples/visual_gen/models/cosmos3_ti2v.py
+++ b/examples/visual_gen/models/cosmos3_ti2v.py
@@ -85,7 +85,6 @@ def main():
     )
     parser.add_argument(
         "--visual_gen_args",
-        "--extra_visual_gen_options",
         dest="visual_gen_args",
         type=str,
         default=None,

--- a/examples/visual_gen/models/flux1.py
+++ b/examples/visual_gen/models/flux1.py
@@ -44,7 +44,6 @@ def main():
     )
     parser.add_argument(
         "--visual_gen_args",
-        "--extra_visual_gen_options",
         dest="visual_gen_args",
         type=str,
         default=None,

--- a/examples/visual_gen/models/flux2.py
+++ b/examples/visual_gen/models/flux2.py
@@ -44,7 +44,6 @@ def main():
     )
     parser.add_argument(
         "--visual_gen_args",
-        "--extra_visual_gen_options",
         dest="visual_gen_args",
         type=str,
         default=None,

--- a/examples/visual_gen/models/ltx2.py
+++ b/examples/visual_gen/models/ltx2.py
@@ -35,7 +35,6 @@ def main():
     )
     parser.add_argument(
         "--visual_gen_args",
-        "--extra_visual_gen_options",
         dest="visual_gen_args",
         type=str,
         default=None,

--- a/examples/visual_gen/models/wan_i2v.py
+++ b/examples/visual_gen/models/wan_i2v.py
@@ -38,7 +38,6 @@ def main():
     )
     parser.add_argument(
         "--visual_gen_args",
-        "--extra_visual_gen_options",
         dest="visual_gen_args",
         type=str,
         default=None,

--- a/examples/visual_gen/models/wan_t2v.py
+++ b/examples/visual_gen/models/wan_t2v.py
@@ -35,7 +35,6 @@ def main():
     )
     parser.add_argument(
         "--visual_gen_args",
-        "--extra_visual_gen_options",
         dest="visual_gen_args",
         type=str,
         default=None,

--- a/examples/visual_gen/serve/README.md
+++ b/examples/visual_gen/serve/README.md
@@ -29,21 +29,21 @@ Before running these examples, ensure you have:
 
 2. **Server Running**: The TensorRT-LLM visual generation server must be running
    ```bash
-   trtllm-serve <path to your model> --extra_visual_gen_options <path to config yaml>
+   trtllm-serve <path to your model> --visual_gen_args <path to config yaml>
    ```
 
    e.g.
 
    ```bash
-   trtllm-serve $LLM_MODEL_DIR/Wan2.1-T2V-1.3B-Diffusers --extra_visual_gen_options ./configs/wan21.yml
-   trtllm-serve $LLM_MODEL_DIR/Wan2.2-T2V-A14B-Diffusers --extra_visual_gen_options ./configs/wan22.yml
-   trtllm-serve $LLM_MODEL_DIR/FLUX.1-dev --extra_visual_gen_options ./configs/flux1.yml
-   trtllm-serve $LLM_MODEL_DIR/FLUX.2-dev --extra_visual_gen_options ./configs/flux2.yml
-   trtllm-serve $LLM_MODEL_DIR/LTX-2/ --extra_visual_gen_options ./configs/ltx2.yml
-   trtllm-serve $LLM_MODEL_DIR/Qwen-Image --extra_visual_gen_options ./configs/qwen_image.yml
+   trtllm-serve $LLM_MODEL_DIR/Wan2.1-T2V-1.3B-Diffusers --visual_gen_args ./configs/wan21.yml
+   trtllm-serve $LLM_MODEL_DIR/Wan2.2-T2V-A14B-Diffusers --visual_gen_args ./configs/wan22.yml
+   trtllm-serve $LLM_MODEL_DIR/FLUX.1-dev --visual_gen_args ./configs/flux1.yml
+   trtllm-serve $LLM_MODEL_DIR/FLUX.2-dev --visual_gen_args ./configs/flux2.yml
+   trtllm-serve $LLM_MODEL_DIR/LTX-2/ --visual_gen_args ./configs/ltx2.yml
+   trtllm-serve $LLM_MODEL_DIR/Qwen-Image --visual_gen_args ./configs/qwen_image.yml
 
    # Run server on background:
-   trtllm-serve $LLM_MODEL_DIR/Wan2.1-T2V-1.3B-Diffusers --extra_visual_gen_options ./configs/wan21.yml > /tmp/serve.log 2>&1 &
+   trtllm-serve $LLM_MODEL_DIR/Wan2.1-T2V-1.3B-Diffusers --visual_gen_args ./configs/wan21.yml > /tmp/serve.log 2>&1 &
 
    ## Check if the server is setup
    tail -f /tmp/serve.log

--- a/examples/visual_gen/serve/benchmark_visual_gen.sh
+++ b/examples/visual_gen/serve/benchmark_visual_gen.sh
@@ -110,7 +110,7 @@ echo ""
 # Step 1: Start server
 SERVER_CMD="trtllm-serve ${MODEL} --host ${HOST} --port ${PORT}"
 if [ -n "$SERVER_CONFIG" ]; then
-    SERVER_CMD="${SERVER_CMD} --extra_visual_gen_options ${SERVER_CONFIG}"
+    SERVER_CMD="${SERVER_CMD} --visual_gen_args ${SERVER_CONFIG}"
 fi
 
 echo "Step 1: Starting server..."

--- a/examples/visual_gen/serve/benchmark_visual_gen_mgmn_distributed.sh
+++ b/examples/visual_gen/serve/benchmark_visual_gen_mgmn_distributed.sh
@@ -158,7 +158,7 @@ echo ""
 
 export SERVER_CMD="trtllm-serve ${MODEL} --host 0.0.0.0 --port ${SERVER_PORT}"
 if [ -n "$SERVER_CONFIG" ]; then
-    SERVER_CMD="${SERVER_CMD} --extra_visual_gen_options ${SERVER_CONFIG}"
+    SERVER_CMD="${SERVER_CMD} --visual_gen_args ${SERVER_CONFIG}"
 fi
 
 echo "Step 1: Starting distributed server..."

--- a/scripts/visualgen_eval/visual_gen_lpips_score_eval.py
+++ b/scripts/visualgen_eval/visual_gen_lpips_score_eval.py
@@ -17,7 +17,7 @@
 r"""Evaluate VisualGen image/video quality with LPIPS against a JSON dataset.
 
 The YAML config follows the same VisualGenArgs format used by trtllm-serve
---extra_visual_gen_options and examples/visual_gen/configs.
+--visual_gen_args and examples/visual_gen/configs.
 
 Example:
   python scripts/visualgen_eval/visual_gen_lpips_score_eval.py \\
@@ -128,7 +128,7 @@ def parse_args() -> argparse.Namespace:
         type=pathlib.Path,
         help=(
             "VisualGenArgs YAML config. This should match trtllm-serve "
-            "--extra_visual_gen_options / examples/visual_gen/configs format. "
+            "--visual_gen_args / examples/visual_gen/configs format. "
             "Required only when generation is needed."
         ),
     )

--- a/tensorrt_llm/bench/benchmark/visual_gen.py
+++ b/tensorrt_llm/bench/benchmark/visual_gen.py
@@ -57,8 +57,6 @@ def _parse_size(size_str: str) -> tuple[Optional[int], Optional[int]]:
 @click.command(name="visual-gen", context_settings={"show_default": True})
 @click.option(
     "--visual_gen_args",
-    "--extra_visual_gen_options",
-    "visual_gen_args",
     type=str,
     default=None,
     help="Path to a YAML file with VisualGen engine args "

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -890,8 +890,6 @@ class ChoiceWithAlias(click.Choice):
         "when you want to expose a custom name to clients.", "prototype"))
 @click.option(
     "--visual_gen_args",
-    "--extra_visual_gen_options",
-    "visual_gen_args",
     type=str,
     default=None,
     help=help_info_with_stability_tag(

--- a/tensorrt_llm/serve/scripts/benchmark_visual_gen.py
+++ b/tensorrt_llm/serve/scripts/benchmark_visual_gen.py
@@ -614,7 +614,6 @@ if __name__ == "__main__":
 
     parser.add_argument(
         "--visual-gen-args",
-        "--extra-visual-gen-options",
         dest="visual_gen_args",
         type=str,
         default=None,


### PR DESCRIPTION
## Description

The standard `--visual_gen_args` flag has stabilized and all in-tree examples, docs, and benchmark scripts use it. This drops the legacy `--extra_visual_gen_options` click/argparse alias (kept until now as an alias of `--visual_gen_args` in `trtllm-serve`, `trtllm-bench visual-gen`, the standalone visual-gen benchmark script, and the offline example scripts) and updates the remaining doc, README, YAML-comment, and shell-script references to point at the standard flag.

- CLI definitions: `tensorrt_llm/commands/serve.py`, `tensorrt_llm/bench/benchmark/visual_gen.py`, `tensorrt_llm/serve/scripts/benchmark_visual_gen.py`
- Docs: `docs/source/commands/trtllm-serve/trtllm-serve.rst`
- Examples: `examples/visual_gen/serve/README.md`, both `benchmark_visual_gen*.sh`, comment headers in `examples/visual_gen/configs/*.yaml`, and the argparse aliases in `examples/visual_gen/models/*.py`
- Eval: `scripts/visualgen_eval/visual_gen_lpips_score_eval.py`

After this change, `git grep extra_visual_gen_options` returns nothing.

## Test Coverage

Built TRT-LLM from source on a GB200 dev container and confirmed:
- `trtllm-serve serve --help` lists only `--visual_gen_args`.
- `trtllm-bench visual-gen --help` lists only `--visual_gen_args`.
- `--extra_visual_gen_options` is absent from both.

Tracking: [TRTLLM-13378](https://jirasw.nvidia.com/browse/TRTLLM-13378) (under epic [TRTLLM-10897](https://jirasw.nvidia.com/browse/TRTLLM-10897) — VisualGen API Polish (M2)).

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated visual generation serving documentation, example scripts, and benchmark tools. The configuration flag for visual generation has been renamed to `--visual_gen_args` across all examples and serving commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->