### PR TITLE
[None][fix] DSv4 MLA overlap: record_stream cross-stream tensors

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/deepseek_v4/deepseek_v4.py
@@ -1174,6 +1174,14 @@ class DeepseekV4Indexer(Indexer):
                 self.k_cache_update_event.record()
         else:
             weights, k_fp8, k_scale = pre_aux
+            # pre_aux tensors were allocated on aux_stream; record on the
+            # consuming stream so the caching allocator can't recycle them mid-use.
+            cur_stream = torch.cuda.current_stream()
+            weights.record_stream(cur_stream)
+            if k_fp8 is not None:
+                k_fp8.record_stream(cur_stream)
+            if k_scale is not None:
+                k_scale.record_stream(cur_stream)
             q = self._qk_projection_and_rope(qr, position_ids)
 
         q_fp8, q_scale = self._quantize_q(q)

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -2426,6 +2426,14 @@ class MLA(nn.Module):
 
                 self.dsv4_compressor_event.wait()
                 self.dsv4_indexer_event.wait()
+
+                # q/topk_indices were produced on other streams; record on the
+                # consuming stream so the caching allocator can't recycle them mid-use.
+                cur_stream = torch.cuda.current_stream()
+                if q is not None:
+                    q.record_stream(cur_stream)
+                if topk_indices is not None:
+                    topk_indices.record_stream(cur_stream)
             else:
                 q, _ = maybe_execute_in_parallel(
                     _q_branch,


### PR DESCRIPTION
The multi-stream attention prologue (TRTLLM_MLA_EXTRA_OVERLAP) hands tensors across CUDA streams without record_stream():

  - precompute_aux allocates weights/k_fp8/k_scale on aux_stream, consumed on the indexer stream;
  - q_b_proj output q (compressor_stream) and topk_indices (indexer_stream) are consumed on the caller stream.

The cuda.Event waits order execution but not the caching allocator, so under large-batch (>1024) workspace pressure a handed-off block can be recycled for a new allocation while the consumer stream is still reading it -> use-after-free -> CUDA_ERROR_ILLEGAL_ADDRESS. It reproduces deterministically on B300 during the generation CUDA-graph warmup at decode batch 1088 (e.g. tp8/ep8 dp-attn conc-2048), surfacing asynchronously in q_b_proj / q_norm. Both CUDA_LAUNCH_BLOCKING=1 and TRTLLM_MLA_EXTRA_OVERLAP=0 mask it, confirming a stream-ordering / allocator race rather than an OOB.

Add record_stream(current_stream) on the handed-off tensors so the allocator cannot recycle them mid-use. Keeps the overlap (no perf change); verified the warmup + serve now complete cleanly with overlap enabled.

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
