### PR TITLE
[None][fix] Fix AutoDeploy shim test expecting soft fallback for speculative+flashinfer

### DIFF
--- a/tests/unittest/auto_deploy/singlegpu/shim/test_llm_config.py
+++ b/tests/unittest/auto_deploy/singlegpu/shim/test_llm_config.py
@@ -95,7 +95,7 @@ def test_yaml_compile_backend_disables_default_piecewise(tmp_path):
     assert args.transforms["compile_model"]["piecewise_enabled"] is False
 
 
-def test_speculative_flashinfer_fallback_disables_piecewise():
+def test_speculative_flashinfer_torch_simple_disables_piecewise():
     from tensorrt_llm.llmapi import EagleDecodingConfig
 
     spec_config = EagleDecodingConfig(
@@ -108,6 +108,7 @@ def test_speculative_flashinfer_fallback_disables_piecewise():
         model="test-model",
         attn_backend="flashinfer",
         speculative_config=spec_config,
+        compile_backend="torch-simple",
     )
 
     assert args.compile_backend == "torch-simple"


### PR DESCRIPTION
@coderabbitai summary

## Description

`test_speculative_flashinfer_fallback_disables_piecewise` was failing with a hard `pydantic.ValidationError` because it was written against the old auto-correction behavior (silent fallback to `torch-simple`), but the `reject_cudagraph_for_speculative_flashinfer` validator now explicitly rejects the speculative + FlashInfer + CUDA-graph-backend combination and requires the user to set `compile_backend='torch-simple'` explicitly.

Fix: pass `compile_backend="torch-simple"` in the test and rename it to `test_speculative_flashinfer_torch_simple_disables_piecewise` to accurately describe what it tests. The test still covers a distinct scenario (speculative + flashinfer + torch-simple → `piecewise_enabled` is `False`) not exercised by the existing `test_accepts_flashinfer_torch_simple` or `test_non_piecewise_compile_backend_disables_default_piecewise`.

## Test Coverage

- `tests/unittest/auto_deploy/singlegpu/shim/test_llm_config.py::test_speculative_flashinfer_torch_simple_disables_piecewise` — the renamed/fixed test itself

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.