### PR TITLE
[TRTLLM-12950][feat] MegaMoE CuteDSL: import latest kernel + tuning rework

### DIFF
--- a/tensorrt_llm/_torch/autotuner.py
+++ b/tensorrt_llm/_torch/autotuner.py
@@ -1436,6 +1436,22 @@ class AutoTuner:
             # profile the kernel with the full repeat to get precise time
             avg_time = pure_profile(stream, self.repeat)
 
+        # Under the MERGE strategy every rank profiles the SAME tactic in
+        # lockstep (no tactic split, tp_barrier before each measurement,
+        # short-profile disabled), so the per-rank timings for this tactic are
+        # directly comparable. For a cross-rank coupled kernel (e.g. AllReduce,
+        # MegaMoE) the effective latency is the SLOWEST rank -- the op is done
+        # only when every rank finishes -- so reduce the per-rank times by MAX
+        # to score the tactic by its true multi-rank cost instead of a single
+        # rank's local view. Reducing here also gives every rank an identical
+        # score, so all ranks select the same best tactic (required when the
+        # kernel needs every rank on the same compiled tactic). The all-gather
+        # uses the same group as _merge_cache_data and is balanced across ranks
+        # because MERGE forces an identical number of launches per rank.
+        if (tuning_config.distributed_tuning_strategy
+                == DistributedTuningStrategy.MERGE and self._is_distributed()):
+            avg_time = max(self._dist.tp_cp_allgather(avg_time))
+
         shapes = self._get_input_sizes(inputs)
         self._debug_logger(
             f"[Autotuner] Profiled runner={runner}, tactic={tactic}, shapes={shapes}: {avg_time:.6f}ms."

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_megamoe_custom_op.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_megamoe_custom_op.py
@@ -385,10 +385,10 @@ def validate_megamoe_tactic(tactic: Tuple) -> None:
     if (not isinstance(group_hint, int)) or isinstance(group_hint, bool) or group_hint <= 0:
         raise ValueError(f"group_hint must be a positive int, got {group_hint!r}.")
     if group_hint < 512:
-        logger.warning(
-            "[MegaMoE] group_hint=%d < 512; group_hint saturates around 512 "
-            "and smaller values are strictly worse.",
-            group_hint,
+        logger.warning_once(
+            f"[MegaMoE] group_hint={group_hint} < 512; group_hint saturates "
+            f"around 512 and smaller values are strictly worse.",
+            key="megamoe_group_hint_lt_512",
         )
 
     if load_balance_mode not in {"static", "atomic_counter"}:
@@ -760,7 +760,7 @@ if IS_MEGAMOE_OP_AVAILABLE:
                 peer_ptr = int(self._handle.buffer_ptrs[r])
                 self.peer_offsets.append(peer_ptr - local_base)
 
-            logger.info(
+            logger.debug(
                 "[MegaMoeSymmMemProvider] group=%s rank=%d/%d total_bytes=%d "
                 "(activation=%d sf=%d topk_weights=%d combine=%d shared=%d)",
                 self.group_name,
@@ -1448,10 +1448,11 @@ if IS_MEGAMOE_OP_AVAILABLE:
             compile_kwargs["max_active_clusters"] = hardware_info.get_max_active_clusters(
                 max(cluster_size, 1)
             )
-            # CuTe DSL compile is the dominant first-launch cost; log
-            # start/end at INFO so the long compile gap is visible through
-            # the standard TRT-LLM logger (honors TLLM_LOG_LEVEL).
-            logger.info(
+            # CuTe DSL compile is the dominant first-launch cost; log start/end
+            # at DEBUG only (the per-tactic compile-time stats must never appear
+            # at INFO on the normal serving path). Enable via TLLM_LOG_LEVEL=DEBUG
+            # when diagnosing the compile gap.
+            logger.debug(
                 f"[MegaMoECuteDsl] cute.compile START tactic="
                 f"(mma_tiler={mma_tiler}, cluster={cluster_shape}, "
                 f"group_hint={group_hint}, load_balance={load_balance_mode!r}, "
@@ -1462,7 +1463,7 @@ if IS_MEGAMOE_OP_AVAILABLE:
             t_compile_start = time.perf_counter()
             compiled = cute.compile(kernel, **compile_kwargs)
             t_compile_ms = (time.perf_counter() - t_compile_start) * 1000
-            logger.info(
+            logger.debug(
                 f"[MegaMoECuteDsl] cute.compile DONE in {t_compile_ms:.0f} ms "
                 f"(cache_keys_now={len(self.__class__.kernel_cache) + 1})"
             )

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_megamoe_custom_op.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_megamoe_custom_op.py
@@ -215,22 +215,25 @@ _GEOMETRIES_REDUCED: Tuple[Tuple[Tuple[int, int, int], Tuple[int, int, int]], ..
 # The 15 legal geometries: M128/1-CTA with
 # cluster_m in {1,2,4}, and M256/2-CTA with cluster_m in {2,4} (use_2cta even
 # divisibility), each crossed with N in {64,128,256}.
+# Defined as ``_GEOMETRIES_REDUCED`` plus the extra geometries so the reduced
+# set stays a guaranteed subset of the full set (no manual drift between them).
 _GEOMETRIES_FULL: Tuple[Tuple[Tuple[int, int, int], Tuple[int, int, int]], ...] = (
-    ((128, 64, 256), (1, 1, 1)),
-    ((128, 128, 256), (1, 1, 1)),
-    ((128, 256, 256), (1, 1, 1)),
-    ((128, 64, 256), (2, 1, 1)),
-    ((128, 128, 256), (2, 1, 1)),
-    ((128, 256, 256), (2, 1, 1)),
-    ((128, 64, 256), (4, 1, 1)),
-    ((128, 128, 256), (4, 1, 1)),
-    ((128, 256, 256), (4, 1, 1)),
-    ((256, 64, 256), (2, 1, 1)),
-    ((256, 128, 256), (2, 1, 1)),
-    ((256, 256, 256), (2, 1, 1)),
-    ((256, 64, 256), (4, 1, 1)),
-    ((256, 128, 256), (4, 1, 1)),
-    ((256, 256, 256), (4, 1, 1)),
+    _GEOMETRIES_REDUCED
+    + (
+        ((128, 64, 256), (1, 1, 1)),
+        ((128, 128, 256), (1, 1, 1)),
+        ((128, 256, 256), (1, 1, 1)),
+        ((128, 64, 256), (2, 1, 1)),
+        ((128, 128, 256), (2, 1, 1)),
+        ((128, 256, 256), (2, 1, 1)),
+        ((128, 64, 256), (4, 1, 1)),
+        ((128, 128, 256), (4, 1, 1)),
+        ((128, 256, 256), (4, 1, 1)),
+        ((256, 64, 256), (2, 1, 1)),
+        ((256, 64, 256), (4, 1, 1)),
+        ((256, 128, 256), (4, 1, 1)),
+        ((256, 256, 256), (4, 1, 1)),
+    )
 )
 
 # token_back modes scanned. BEST=0 drops standalone (never a sole winner).

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_megamoe_custom_op.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_megamoe_custom_op.py
@@ -29,6 +29,7 @@ touching the MoE backend.
 from __future__ import annotations
 
 import dataclasses
+import os
 import time
 from typing import Any, List, Optional, Tuple
 
@@ -37,6 +38,7 @@ import torch
 from tensorrt_llm.logger import logger
 
 from ..._utils import get_sm_version
+from ...math_utils import ceil_div, pad_up
 from ..autotuner import (
     AutoTuner,
     ConstraintSpec,
@@ -50,12 +52,11 @@ from ..cute_dsl_utils import IS_CUTLASS_DSL_AVAILABLE
 from ..utils import get_last_power_of_2_num_tokens_buckets, last_positive_power_of_2
 
 __all__ = [
-    "DEFAULT_MEGAMOE_TACTIC",
     "IS_MEGAMOE_OP_AVAILABLE",
     "MEGAMOE_OP_UNAVAILABLE_REASON",
+    "default_megamoe_tactic",
     "enumerate_megamoe_candidate_tactics",
     "megamoe_activation_sf_bytes_per_row",
-    "resolve_megamoe_group_hint",
     "validate_megamoe_tactic",
 ]
 
@@ -71,48 +72,173 @@ MEGAMOE_OP_UNAVAILABLE_REASON: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
-# Tactic representation
+# Tactic representation (v3: 8-tuple perf knobs)
 # ---------------------------------------------------------------------------
 #
 # A tactic is a tuple of JSON-friendly primitives (lists / ints / bools /
-# strings) so it round-trips through ``json.dumps``/``json.loads`` *and*
-# ``eval(repr(tactic))`` — both are required by ``TunableRunner`` cache
-# serialization. Order matches the kernel constructor kwargs.
+# strings / nested tuples) so it round-trips through ``json.dumps``/
+# ``json.loads`` *and* ``eval(repr(tactic))`` -- both are required by
+# ``TunableRunner`` cache serialization. Order matches the kernel
+# constructor kwargs.
 #
-#   (mma_tiler_mnk,        # list[int] of length 3
-#    cluster_shape_mnk,    # list[int] of length 3
-#    use_2cta_instrs,      # bool
-#    resolved_group_hint,  # int (always resolved before cache lookup)
-#    load_balance_mode,    # str: "static" | "atomic_counter"
-#    use_bf16_redg)        # bool: form A (False) vs form B (True)
+#   (mma_tiler_mnk,       # list[int] of length 3 (M decides use_2cta)
+#    cluster_shape_mnk,   # list[int] of length 3
+#    group_hint,          # int, TUNED (>=512); NOT max_active_clusters
+#    load_balance_mode,   # str: "static" | "atomic_counter"
+#    token_back_mode,     # "epi_warps" | "standalone_warps" | "reuse_dispatch_warps"
+#    use_bulk_fc2_store,  # bool (bulk store valid only with epi_warps)
+#    flag_batch,          # int >= 1 (standalone_warps requires == 1)
+#    epi_flag_batch)      # (int, int) fc1/fc2 done-counter publish batch
+#
+# Derived / out-of-tuple:
+#   use_2cta_instrs      = (mma_tiler_mnk[0] == 256)  -- derived in _build_kernel.
+#   in_kernel_fc2_reduce -- backend functional config (default False), carried
+#                           in the runner ``unique_id``, NOT a perf-tuning knob.
 #
 # Tuple wrapping makes the tactic hashable, which AutoTuner needs for the
-# tactics cache. Lists nested inside the tuple are reconstructed from
-# JSON intact.
+# tactics cache. Lists / nested tuples inside the tuple are reconstructed
+# from JSON intact.
+
+_TACTIC_LEN = 8
+
+# Kernel-side upper bound on the done-counter publish batch. ``flag_batch`` is
+# hard-checked ``[1, 32]`` in ``TokenInPullTokenBackPush.__init__``
+# (token_comm.py) and the ``epi_flag_batch`` entries are silently clamped to
+# ``[1, 32]`` in ``SwapABSwigluFp4Epilogue.__init__`` (epilogue_refactor.py).
+# Reject ``> 32`` here so a hand-supplied / JSON-cached tactic fails fast with a
+# clear message instead of crashing at kernel build (flag_batch) or silently
+# running at 32 (epi_flag_batch). The curated/full enumeration tops out at
+# flag_batch=16 and epi_flag_batch=(2, 4), so legal candidates are unaffected.
+_FLAG_BATCH_MAX = 32
 
 
-DEFAULT_MEGAMOE_TACTIC: Tuple[List[int], List[int], bool, int, str, bool] = (
-    [128, 128, 256],
-    [1, 1, 1],
-    False,
-    1,  # placeholder; the launcher always resolves group_hint first
-    "static",
-    False,
+def _unpack_tactic(tactic: Tuple) -> Tuple:
+    """Return the tactic's 8 fields in canonical order, the single source of
+    truth for the field layout.
+
+    Every consumer (validate / kernel build / cache key / compile / log)
+    unpacks through this helper so the field order is defined once. A 9th
+    tactic field is then a one-line change here plus the consumers that
+    actually use it, instead of editing five copy-pasted positional unpacks
+    that must stay in lockstep.
+
+    Order::
+
+        (
+            mma_tiler_mnk,
+            cluster_shape_mnk,
+            group_hint,
+            load_balance_mode,
+            token_back_mode,
+            use_bulk_fc2_store,
+            flag_batch,
+            epi_flag_batch,
+        )
+
+    This is a plain positional unpack (no validation); callers that need
+    legality go through :func:`validate_megamoe_tactic`.
+    """
+    (
+        mma_tiler,
+        cluster_shape,
+        group_hint,
+        load_balance_mode,
+        token_back_mode,
+        use_bulk_fc2_store,
+        flag_batch,
+        epi_flag_batch,
+    ) = tactic
+    return (
+        mma_tiler,
+        cluster_shape,
+        group_hint,
+        load_balance_mode,
+        token_back_mode,
+        use_bulk_fc2_store,
+        flag_batch,
+        epi_flag_batch,
+    )
+
+
+def default_megamoe_tactic(num_tokens: int) -> Tuple:
+    """Token-aware fallback tactic (autotune disabled / cache miss / tactic=-1).
+
+    Picks one of three token regimes. This is NOT a tactic the autotuner
+    profiles; it is the deterministic fallback when no tuned tactic is
+    available. The autotuner, when enabled, profiles the curated candidate
+    list per token bucket instead.
+    """
+    if num_tokens <= 1024:
+        # decode winner: N128 only helps epi_warps + bulk.
+        return ([256, 128, 256], [2, 1, 1], 512, "static", "epi_warps", True, 1, (1, 1))
+    if num_tokens <= 8192:
+        # transition/mid: robust N256 geometry, flag_batch=4 as mid default.
+        return ([256, 256, 256], [2, 1, 1], 512, "static", "epi_warps", True, 4, (1, 1))
+    # prefill: reuse_dispatch_warps forces non-bulk fc2 store; atomic_counter
+    # only helps the very large tail (>=16384).
+    return (
+        [256, 256, 256],
+        [2, 1, 1],
+        512,
+        "atomic_counter" if num_tokens >= 16384 else "static",
+        "reuse_dispatch_warps",
+        False,
+        8,
+        (2, 4),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Curated tuning space.
+#
+# ``MEGAMOE_CUTEDSL_TUNING_FULL=0`` (default): curated reduced space.
+# ``MEGAMOE_CUTEDSL_TUNING_FULL=1``: full cartesian product (exhaustive search).
+# Both share the same legality filter (``validate_megamoe_tactic`` +
+# token_back/store binding + N128-only-epi rule).
+# ---------------------------------------------------------------------------
+
+# token_back_mode -> the only legal use_bulk_fc2_store (bulk binds to epi_warps;
+# reuse/standalone force non-bulk).
+_TOKEN_BACK_STORE_BINDING: dict = {
+    "epi_warps": True,
+    "reuse_dispatch_warps": False,
+    "standalone_warps": False,
+}
+
+# (mma_tiler_mnk, cluster_shape_mnk) geometries. use_2cta is derived (M==256).
+# BEST=0 reduced set: N256 + N128, cluster_m2 only (drop N64, M128/1-CTA,
+# cluster_m4). BEST=1 full set adds M128/1-CTA + cluster_m4 + N64.
+_GEOMETRIES_REDUCED: Tuple[Tuple[Tuple[int, int, int], Tuple[int, int, int]], ...] = (
+    ((256, 256, 256), (2, 1, 1)),
+    ((256, 128, 256), (2, 1, 1)),
+)
+# The 15 legal geometries: M128/1-CTA with
+# cluster_m in {1,2,4}, and M256/2-CTA with cluster_m in {2,4} (use_2cta even
+# divisibility), each crossed with N in {64,128,256}.
+_GEOMETRIES_FULL: Tuple[Tuple[Tuple[int, int, int], Tuple[int, int, int]], ...] = (
+    ((128, 64, 256), (1, 1, 1)),
+    ((128, 128, 256), (1, 1, 1)),
+    ((128, 256, 256), (1, 1, 1)),
+    ((128, 64, 256), (2, 1, 1)),
+    ((128, 128, 256), (2, 1, 1)),
+    ((128, 256, 256), (2, 1, 1)),
+    ((128, 64, 256), (4, 1, 1)),
+    ((128, 128, 256), (4, 1, 1)),
+    ((128, 256, 256), (4, 1, 1)),
+    ((256, 64, 256), (2, 1, 1)),
+    ((256, 128, 256), (2, 1, 1)),
+    ((256, 256, 256), (2, 1, 1)),
+    ((256, 64, 256), (4, 1, 1)),
+    ((256, 128, 256), (4, 1, 1)),
+    ((256, 256, 256), (4, 1, 1)),
 )
 
-
-# Candidate tactic geometries derived from the upstream functional test
-# matrix ``moe_nvfp4_swapab/run_mega_tests.sh`` (M01..M20). Each entry is
-# ``(mma_tiler_mnk, cluster_shape_mnk, use_2cta_instrs)``. Other tactic
-# fields (load_balance_mode, use_bf16_redg) are intentionally constrained
-# here. Expanding either axis needs the backend buffer contract and tests to
-# move with it.
-_RUN_MEGA_TESTS_CANDIDATE_GEOMETRIES: Tuple[
-    Tuple[Tuple[int, int, int], Tuple[int, int, int], bool], ...
-] = (
-    ((128, 128, 256), (1, 1, 1), False),
-    ((256, 256, 256), (2, 1, 1), True),
-    ((256, 256, 256), (4, 1, 1), True),
+# token_back modes scanned. BEST=0 drops standalone (never a sole winner).
+_TOKEN_BACK_MODES_REDUCED: Tuple[str, ...] = ("epi_warps", "reuse_dispatch_warps")
+_TOKEN_BACK_MODES_FULL: Tuple[str, ...] = (
+    "epi_warps",
+    "reuse_dispatch_warps",
+    "standalone_warps",
 )
 
 # Load-balance modes supported by the integrated fused FC12 path (see
@@ -120,6 +246,30 @@ _RUN_MEGA_TESTS_CANDIDATE_GEOMETRIES: Tuple[
 # ``clc`` is intentionally excluded -- it routes through a separate
 # scheduler class not wired through the fused FC12 kernel here.
 _LOAD_BALANCE_MODE_CANDIDATES: Tuple[str, ...] = ("static", "atomic_counter")
+
+# group_hint scan: ~512 saturates, larger is better, omission -> ~74 (worst).
+# BEST=0 scans {512, 1024}; BEST=1 adds 256 (validated but low-value).
+_GROUP_HINT_REDUCED: Tuple[int, ...] = (512, 1024)
+_GROUP_HINT_FULL: Tuple[int, ...] = (256, 512, 1024)
+
+# flag_batch scan. BEST=0 {1,4,8}; BEST=1 {1,4,8,16}.
+_FLAG_BATCH_REDUCED: Tuple[int, ...] = (1, 4, 8)
+_FLAG_BATCH_FULL: Tuple[int, ...] = (1, 4, 8, 16)
+
+# epi_flag_batch is token-bucket dependent (NOT a free scan axis):
+# decode/transition use (1, 1); prefill (>8192) uses (2, 4). One value per
+# token bucket; see ``_epi_flag_batch_for_tokens``.
+_EPI_FLAG_BATCH_SMALL: Tuple[int, int] = (1, 1)
+_EPI_FLAG_BATCH_LARGE: Tuple[int, int] = (2, 4)
+_EPI_FLAG_BATCH_TOKEN_THRESHOLD = 8192
+
+
+def _epi_flag_batch_for_tokens(num_tokens: int) -> Tuple[int, int]:
+    """Token-bucket epi_flag_batch: ``<=8192 -> (1,1)``, ``>8192 -> (2,4)``."""
+    if num_tokens > _EPI_FLAG_BATCH_TOKEN_THRESHOLD:
+        return _EPI_FLAG_BATCH_LARGE
+    return _EPI_FLAG_BATCH_SMALL
+
 
 # Kernel-construction knobs locked until the backend owns the corresponding
 # runtime buffer / scheduler contracts.
@@ -151,11 +301,10 @@ def megamoe_activation_sf_bytes_per_row(hidden_size: int) -> int:
     if hidden_size <= 0 or hidden_size % 32 != 0:
         raise ValueError(f"hidden_size must be a positive multiple of 32, got {hidden_size}")
     # ceil(hidden / 16) rounded up to multiples of 4 FP8 columns
-    # (= `round_up(ceil(hidden_size / scaling_vector_size), 4)`), matching
+    # (= `pad_up(ceil_div(hidden_size, scaling_vector_size=16), 4)`), matching
     # the kernel's TMA load width and the ``can_implement`` hidden_size
     # alignment rule.
-    sf_cols = (hidden_size + 15) // 16
-    return ((sf_cols + 3) // 4) * 4
+    return pad_up(ceil_div(hidden_size, 16), 4)
 
 
 def validate_megamoe_tactic(tactic: Tuple) -> None:
@@ -170,13 +319,21 @@ def validate_megamoe_tactic(tactic: Tuple) -> None:
         SupportedMmaTileN,
     )
 
-    if (not isinstance(tactic, tuple)) or len(tactic) != 6:
+    if (not isinstance(tactic, tuple)) or len(tactic) != _TACTIC_LEN:
         raise ValueError(
-            f"MegaMoE tactic must be a 6-tuple, got {type(tactic).__name__}={tactic!r}"
+            f"MegaMoE tactic must be an {_TACTIC_LEN}-tuple, got "
+            f"{type(tactic).__name__} len={len(tactic) if isinstance(tactic, tuple) else 'NA'}={tactic!r}"
         )
-    (mma_tiler, cluster_shape, use_2cta, resolved_group_hint, load_balance_mode, use_bf16_redg) = (
-        tactic
-    )
+    (
+        mma_tiler,
+        cluster_shape,
+        group_hint,
+        load_balance_mode,
+        token_back_mode,
+        use_bulk_fc2_store,
+        flag_batch,
+        epi_flag_batch,
+    ) = _unpack_tactic(tactic)
 
     if (not isinstance(mma_tiler, (list, tuple))) or len(mma_tiler) != 3:
         raise ValueError(f"mma_tiler_mnk must be a 3-tuple/list, got {mma_tiler!r}")
@@ -194,6 +351,9 @@ def validate_megamoe_tactic(tactic: Tuple) -> None:
             f"{Nvfp4BlockSize * 4} (= sf_vec_size * 4); see kernel_fc12 "
             f"_validate_mma_*."
         )
+
+    # ``use_2cta_instrs`` is DERIVED from M (not a tactic field): M==256 -> 2cta.
+    use_2cta = mma_tiler[0] == 256
 
     if (not isinstance(cluster_shape, (list, tuple))) or len(cluster_shape) != 3:
         raise ValueError(f"cluster_shape_mnk must be a 3-tuple/list, got {cluster_shape!r}")
@@ -215,24 +375,20 @@ def validate_megamoe_tactic(tactic: Tuple) -> None:
             f"{cluster_shape[0] * cluster_shape[1]}."
         )
 
-    if not isinstance(use_2cta, bool):
-        raise ValueError(f"use_2cta_instrs must be bool, got {use_2cta!r}.")
-    expected_2cta = mma_tiler[0] == 256
-    if use_2cta != expected_2cta:
-        raise ValueError(
-            f"use_2cta_instrs must be {expected_2cta} for mma_tiler_mnk[0]={mma_tiler[0]}, got {use_2cta}."
-        )
-
     if cluster_shape[0] % (2 if use_2cta else 1) != 0:
         raise ValueError(
             f"cluster_shape_mnk[0] ({cluster_shape[0]}) must be divisible by "
-            f"{(2 if use_2cta else 1)} when use_2cta_instrs={use_2cta}."
+            f"{(2 if use_2cta else 1)} when use_2cta_instrs={use_2cta} "
+            f"(derived from mma_tiler_mnk[0]={mma_tiler[0]})."
         )
 
-    if (not isinstance(resolved_group_hint, int)) or resolved_group_hint <= 0:
-        raise ValueError(
-            f"resolved_group_hint must be a positive int (resolved before "
-            f"cache lookup), got {resolved_group_hint!r}."
+    if (not isinstance(group_hint, int)) or isinstance(group_hint, bool) or group_hint <= 0:
+        raise ValueError(f"group_hint must be a positive int, got {group_hint!r}.")
+    if group_hint < 512:
+        logger.warning(
+            "[MegaMoE] group_hint=%d < 512; group_hint saturates around 512 "
+            "and smaller values are strictly worse.",
+            group_hint,
         )
 
     if load_balance_mode not in {"static", "atomic_counter"}:
@@ -240,62 +396,102 @@ def validate_megamoe_tactic(tactic: Tuple) -> None:
             f"load_balance_mode must be 'static' or 'atomic_counter', got {load_balance_mode!r}."
         )
 
-    if not isinstance(use_bf16_redg, bool):
-        raise ValueError(f"use_bf16_redg must be bool, got {use_bf16_redg!r}.")
-    if use_bf16_redg:
+    if token_back_mode not in {"epi_warps", "standalone_warps", "reuse_dispatch_warps"}:
         raise ValueError(
-            "use_bf16_redg=True (form-B in-kernel top-k reduction) is not "
-            "wired in MegaMoECuteDsl yet. The backend allocates form-A "
-            "combine_output with shape (T, top_k, hidden) and performs the "
-            "top-k reduction on the host, so cached or manually supplied "
-            "form-B tactics are rejected."
+            f"token_back_mode must be one of 'epi_warps' / 'standalone_warps' / "
+            f"'reuse_dispatch_warps', got {token_back_mode!r}."
         )
 
+    if not isinstance(use_bulk_fc2_store, bool):
+        raise ValueError(f"use_bulk_fc2_store must be bool, got {use_bulk_fc2_store!r}.")
+    # bulk fc2 store is only valid under epi_warps (the non-epi modes stage fc2
+    # output locally -> forced non-bulk).
+    if use_bulk_fc2_store and token_back_mode != "epi_warps":
+        raise ValueError(
+            f"use_bulk_fc2_store=True requires token_back_mode='epi_warps', got "
+            f"{token_back_mode!r} (non-epi token-back forces non-bulk fc2 store)."
+        )
+    # N128 only pays off under epi_warps + bulk; other token-back modes
+    # with N128 are not recommended.
+    if mma_tiler[1] == 128 and token_back_mode != "epi_warps":
+        raise ValueError(
+            f"mma_tiler_mnk[1]=128 (N128) is only recommended with "
+            f"token_back_mode='epi_warps'; got {token_back_mode!r}."
+        )
 
-def resolve_megamoe_group_hint(cluster_shape_mnk: Tuple[int, int, int]) -> int:
-    """Resolve ``group_hint=None`` to ``HardwareInfo().get_max_active_clusters``.
+    if (
+        (not isinstance(flag_batch, int))
+        or isinstance(flag_batch, bool)
+        or not (1 <= flag_batch <= _FLAG_BATCH_MAX)
+    ):
+        raise ValueError(
+            f"flag_batch must be an int in [1, {_FLAG_BATCH_MAX}] (kernel "
+            f"TokenInPullTokenBackPush hard limit), got {flag_batch!r}."
+        )
+    # standalone token-back warps publish one slot at a time.
+    if token_back_mode == "standalone_warps" and flag_batch != 1:
+        raise ValueError(
+            f"token_back_mode='standalone_warps' requires flag_batch == 1, got {flag_batch}."
+        )
 
-    The kernel uses ``group_hint`` as a construction-time constant
-    (``Sm100MegaMoEKernel.__init__``); caching under ``None`` would
-    produce a wrong cache key. Falls back to 1 on hosts without
-    CUDA / Cutlass DSL so the tactic remains JSON-serializable.
-    """
-    cluster_size = cluster_shape_mnk[0] * cluster_shape_mnk[1] * cluster_shape_mnk[2]
-    if cluster_size <= 0:
-        cluster_size = 1
-    try:
-        from cutlass.utils import HardwareInfo
-
-        return max(1, int(HardwareInfo().get_max_active_clusters(cluster_size)))
-    except Exception:  # pragma: no cover - host without CUDA / Cutlass DSL
-        return 1
-
-
-def enumerate_megamoe_candidate_tactics() -> List[Tuple]:
-    """Return the integrated candidate tactic list, fully resolved.
-
-    Each candidate has its ``resolved_group_hint`` stamped to the value
-    returned by ``HardwareInfo.get_max_active_clusters`` for that
-    cluster shape. Form A is the only supported reduction mode until the
-    backend wires the form-B output buffer and reduction path.
-    """
-    candidates: List[Tuple] = []
-    for mma_tiler, cluster_shape, use_2cta in _RUN_MEGA_TESTS_CANDIDATE_GEOMETRIES:
-        for load_balance_mode in _LOAD_BALANCE_MODE_CANDIDATES:
-            tactic = (
-                list(mma_tiler),
-                list(cluster_shape),
-                use_2cta,
-                resolve_megamoe_group_hint(cluster_shape),
-                load_balance_mode,
-                False,
+    if (not isinstance(epi_flag_batch, (tuple, list))) or len(epi_flag_batch) != 2:
+        raise ValueError(f"epi_flag_batch must be a 2-tuple (fc1, fc2), got {epi_flag_batch!r}.")
+    for v in epi_flag_batch:
+        # The epilogue silently clamps each entry to [1, 32]; reject out-of-range
+        # here so the requested value never diverges from what runs, and so two
+        # tactics differing only above 32 do not produce distinct cache keys for
+        # identical kernel behavior.
+        if (not isinstance(v, int)) or isinstance(v, bool) or not (1 <= v <= _FLAG_BATCH_MAX):
+            raise ValueError(
+                f"epi_flag_batch entries must be ints in [1, {_FLAG_BATCH_MAX}] "
+                f"(epilogue clamp range), got {epi_flag_batch!r}."
             )
-            try:
-                validate_megamoe_tactic(tactic)
-            except ValueError as e:
-                logger.debug(f"[MegaMoE] dropping candidate tactic {tactic!r}: {e}")
-                continue
-            candidates.append(tactic)
+
+
+def enumerate_megamoe_candidate_tactics(num_tokens: int) -> List[Tuple]:
+    """Return the curated candidate tactic list for the current token bucket.
+
+    ``MEGAMOE_CUTEDSL_TUNING_FULL`` selects the search space size (0/unset ->
+    curated reduced set ~36 per bucket; 1 -> full exhaustive cartesian product).
+    Both build the full cartesian product over the selected dimension ranges and
+    then drop illegal combinations through the SAME ``validate_megamoe_tactic``
+    filter (geometry legality, bulk<=>epi binding, standalone=>flag_batch==1,
+    N128-only-epi).
+
+    ``epi_flag_batch`` is token-bucket dependent (one value per bucket, NOT a
+    free scan axis): ``num_tokens <= 8192 -> (1, 1)``, ``> 8192 -> (2, 4)``.
+    """
+    # 0 / unset -> curated reduced space; 1 -> full exhaustive space.
+    full = os.environ.get("MEGAMOE_CUTEDSL_TUNING_FULL", "0") == "1"
+    geometries = _GEOMETRIES_FULL if full else _GEOMETRIES_REDUCED
+    token_back_modes = _TOKEN_BACK_MODES_FULL if full else _TOKEN_BACK_MODES_REDUCED
+    group_hints = _GROUP_HINT_FULL if full else _GROUP_HINT_REDUCED
+    flag_batches = _FLAG_BATCH_FULL if full else _FLAG_BATCH_REDUCED
+    epi_flag_batch = _epi_flag_batch_for_tokens(num_tokens)
+
+    candidates: List[Tuple] = []
+    for mma_tiler, cluster_shape in geometries:
+        for token_back_mode in token_back_modes:
+            use_bulk = _TOKEN_BACK_STORE_BINDING[token_back_mode]
+            for load_balance_mode in _LOAD_BALANCE_MODE_CANDIDATES:
+                for group_hint in group_hints:
+                    for flag_batch in flag_batches:
+                        tactic = (
+                            list(mma_tiler),
+                            list(cluster_shape),
+                            int(group_hint),
+                            load_balance_mode,
+                            token_back_mode,
+                            use_bulk,
+                            int(flag_batch),
+                            tuple(epi_flag_batch),
+                        )
+                        try:
+                            validate_megamoe_tactic(tactic)
+                        except ValueError as e:
+                            logger.debug(f"[MegaMoE] dropping candidate tactic {tactic!r}: {e}")
+                            continue
+                        candidates.append(tactic)
     return candidates
 
 
@@ -416,9 +612,6 @@ if IS_MEGAMOE_OP_AVAILABLE:
     # ``_MEGA_MOE_SYMM_BUFFER_CACHE`` in ``mega_moe_deepgemm.py``).
     _MEGAMOE_SYMM_PROVIDER_CACHE: dict = {}
 
-    def _round_up_to(value: int, alignment: int) -> int:
-        return ((value + alignment - 1) // alignment) * alignment
-
     @dataclasses.dataclass
     class MegaMoeSymmRegions:
         """User-domain symmetric tensors carved out of a single rendezvous'd
@@ -439,7 +632,8 @@ if IS_MEGAMOE_OP_AVAILABLE:
         # kernel sf_addr formula in dispatch_kernel.py.
         activation_sf: torch.Tensor  # (max_T, sf_bytes_per_row) uint8 (FP8 SF)
         topk_weights: torch.Tensor  # (max_T, num_topk) float32
-        combine_output: torch.Tensor  # (max_T, num_topk, hidden) output_dtype
+        # (max_T, combine_k, hidden): combine_k = num_topk (form-A) or 1 (form-B).
+        combine_output: torch.Tensor
         shared_workspace: torch.Tensor  # (shared_ws_bytes,) uint8
         peer_offsets: List[int]  # symmetric peer-pointer deltas
         rank: int
@@ -481,6 +675,7 @@ if IS_MEGAMOE_OP_AVAILABLE:
             num_topk: int,
             output_dtype: torch.dtype,
             shared_workspace_bytes: int,
+            in_kernel_fc2_reduce: bool = False,
         ) -> None:
             if not (dist.is_available() and dist.is_initialized()):
                 raise RuntimeError("MegaMoeSymmMemProvider requires torch.distributed initialized.")
@@ -504,6 +699,13 @@ if IS_MEGAMOE_OP_AVAILABLE:
             self.max_tokens_per_rank = int(max_tokens_per_rank)
             self.num_topk = int(num_topk)
             self.output_dtype = output_dtype
+            # ``in_kernel_fc2_reduce`` (form-B) folds the top-k reduction into
+            # the kernel, so the combine region is (max_T, 1, hidden); form-A
+            # keeps (max_T, num_topk, hidden) and reduces on the host. The
+            # combine_k MUST match the kernel ``combine_output`` shape -- a
+            # mismatch silently corrupts the symmetric combine region.
+            self.in_kernel_fc2_reduce = bool(in_kernel_fc2_reduce)
+            self.combine_k = 1 if self.in_kernel_fc2_reduce else int(num_topk)
 
             # Region byte sizes (worst case across launches; staging
             # writes only the live ``T`` rows). NVFP4 packs 2 elems / byte
@@ -515,17 +717,13 @@ if IS_MEGAMOE_OP_AVAILABLE:
             act_bytes_per_row = hidden_size // 2
             sf_bytes_per_row = megamoe_activation_sf_bytes_per_row(hidden_size)
             topkw_bytes_per_row = num_topk * 4  # float32
-            combine_bytes_per_row = num_topk * hidden_size * output_dtype.itemsize
+            combine_bytes_per_row = self.combine_k * hidden_size * output_dtype.itemsize
 
-            act_region = _round_up_to(max_tokens_per_rank * act_bytes_per_row, self._REGION_ALIGN)
-            sf_region = _round_up_to(max_tokens_per_rank * sf_bytes_per_row, self._REGION_ALIGN)
-            topkw_region = _round_up_to(
-                max_tokens_per_rank * topkw_bytes_per_row, self._REGION_ALIGN
-            )
-            combine_region = _round_up_to(
-                max_tokens_per_rank * combine_bytes_per_row, self._REGION_ALIGN
-            )
-            shared_region = _round_up_to(shared_workspace_bytes, self._REGION_ALIGN)
+            act_region = pad_up(max_tokens_per_rank * act_bytes_per_row, self._REGION_ALIGN)
+            sf_region = pad_up(max_tokens_per_rank * sf_bytes_per_row, self._REGION_ALIGN)
+            topkw_region = pad_up(max_tokens_per_rank * topkw_bytes_per_row, self._REGION_ALIGN)
+            combine_region = pad_up(max_tokens_per_rank * combine_bytes_per_row, self._REGION_ALIGN)
+            shared_region = pad_up(shared_workspace_bytes, self._REGION_ALIGN)
 
             self._region_offsets: dict = {}
             self._region_sizes: dict = {}
@@ -591,6 +789,7 @@ if IS_MEGAMOE_OP_AVAILABLE:
             hidden = self.hidden_size
             max_t = self.max_tokens_per_rank
             top_k = self.num_topk
+            combine_k = self.combine_k
             # ``sf_bytes_per_row`` MUST match the byte width used at
             # allocation time (``__init__`` above) and at the backend's
             # ``quantize_input`` output: kernel reads
@@ -606,7 +805,7 @@ if IS_MEGAMOE_OP_AVAILABLE:
                 ),
                 topk_weights=self._region_view("topk_weights", (max_t, top_k), torch.float32),
                 combine_output=self._region_view(
-                    "combine_output", (max_t, top_k, hidden), self.output_dtype
+                    "combine_output", (max_t, combine_k, hidden), self.output_dtype
                 ),
                 shared_workspace=self._region_view(
                     "shared_workspace", (self._region_sizes["shared_workspace"],), torch.uint8
@@ -626,11 +825,17 @@ if IS_MEGAMOE_OP_AVAILABLE:
         num_topk: int,
         output_dtype: torch.dtype,
         shared_workspace_bytes: int,
+        in_kernel_fc2_reduce: bool = False,
     ) -> MegaMoeSymmMemProvider:
         """Return a cached provider for (group, layout). The cache is
         keyed on the group ``group_name`` plus every layout knob that
         affects allocation size so two MoE layers with the same shape
         share the same symmetric buffer.
+
+        ``in_kernel_fc2_reduce`` (form selector) MUST be in the cache key:
+        form-A and form-B size the combine region differently (num_topk vs 1
+        rows per token), so a shared cache entry would hand back a
+        wrong-sized combine region.
 
         First call from each rank performs the (collective)
         ``torch_symm_mem.rendezvous``; subsequent calls return the
@@ -649,6 +854,7 @@ if IS_MEGAMOE_OP_AVAILABLE:
             int(num_topk),
             str(output_dtype),
             int(shared_workspace_bytes),
+            bool(in_kernel_fc2_reduce),
         )
         cached = _MEGAMOE_SYMM_PROVIDER_CACHE.get(cache_key)
         if cached is not None:
@@ -662,6 +868,7 @@ if IS_MEGAMOE_OP_AVAILABLE:
             num_topk=num_topk,
             output_dtype=output_dtype,
             shared_workspace_bytes=shared_workspace_bytes,
+            in_kernel_fc2_reduce=in_kernel_fc2_reduce,
         )
         _MEGAMOE_SYMM_PROVIDER_CACHE[cache_key] = provider
         return provider
@@ -679,38 +886,46 @@ if IS_MEGAMOE_OP_AVAILABLE:
         tactic: Optional[Tuple] = None,
         apply_topk_in_fc1: bool = True,
         gate_up_clamp: Optional[float] = None,
+        in_kernel_fc2_reduce: bool = False,
     ) -> int:
         """Probe ``Sm100MegaMoEKernel.get_workspace_sizes()`` for the
-        shared workspace byte count. The shared workspace size is
+        shared workspace byte count. The SHARED workspace size is
         invariant across all candidate tactics and across the codegen-time
         graph/clamp modes (its regions depend only on world_size /
         num_experts_per_rank / num_topk / max_tokens_per_rank -- see
         _build_shared_region_specs in megamoe_kernel.py), so we use the
-        default tactic for the probe. ``apply_topk_in_fc1`` / ``gate_up_clamp``
-        are still threaded so the probe kernel ctor signature is satisfied
-        and matches the real build.
+        default 8-tuple tactic for the probe. ``apply_topk_in_fc1`` /
+        ``gate_up_clamp`` / ``in_kernel_fc2_reduce`` are still threaded so the
+        probe kernel ctor signature is satisfied and matches the real build
+        (``in_kernel_fc2_reduce`` does not change the SHARED size, only the
+        LOCAL workspace, but the ctor requires it).
         """
         from ..cute_dsl_kernels.mega_moe_nvfp4 import import_kernel
 
         if tactic is None:
-            cluster = tuple(DEFAULT_MEGAMOE_TACTIC[1])
-            tactic = (
-                list(DEFAULT_MEGAMOE_TACTIC[0]),
-                list(cluster),
-                DEFAULT_MEGAMOE_TACTIC[2],
-                resolve_megamoe_group_hint(cluster),
-                DEFAULT_MEGAMOE_TACTIC[4],
-                DEFAULT_MEGAMOE_TACTIC[5],
-            )
+            # Any valid tactic works: the shared workspace size is invariant
+            # across tactics, so reuse the token-aware fallback for sizing.
+            tactic = default_megamoe_tactic(0)
+        (
+            mma_tiler,
+            cluster_shape,
+            group_hint,
+            load_balance_mode,
+            token_back_mode,
+            use_bulk_fc2_store,
+            flag_batch,
+            epi_flag_batch,
+        ) = _unpack_tactic(tactic)
+        mma_tiler = tuple(mma_tiler)
         kernel_cls = import_kernel()
         probe = kernel_cls(
-            mma_tiler_mnk=tuple(tactic[0]),
-            cluster_shape_mnk=tuple(tactic[1]),
-            use_2cta_instrs=bool(tactic[2]),
-            group_hint=int(tactic[3]),
+            mma_tiler_mnk=mma_tiler,
+            cluster_shape_mnk=tuple(cluster_shape),
+            use_2cta_instrs=bool(mma_tiler[0] == 256),
+            group_hint=int(group_hint),
             token_padding_block=64,
             sf_padding_block=SfPaddingBlock,
-            load_balance_mode=str(tactic[4]),
+            load_balance_mode=str(load_balance_mode),
             static_expert_shape=(
                 num_experts_per_rank,
                 expand_intermediate_size_per_partition,
@@ -722,7 +937,11 @@ if IS_MEGAMOE_OP_AVAILABLE:
             max_tokens_per_rank=int(max_tokens_per_rank),
             hidden=int(hidden_size),
             fc2_output_dtype=cutlass.BFloat16,
-            in_kernel_fc2_reduce=bool(tactic[5]),
+            in_kernel_fc2_reduce=bool(in_kernel_fc2_reduce),
+            token_back_mode=str(token_back_mode),
+            non_ubulk_fc2_store=(not bool(use_bulk_fc2_store)),
+            flag_batch=int(flag_batch),
+            epi_flag_batch=tuple(epi_flag_batch),
             apply_topk_in_fc1=bool(apply_topk_in_fc1),
             gate_up_clamp=(None if gate_up_clamp is None else float(gate_up_clamp)),
             **_LOCKED_KERNEL_KWARGS,
@@ -759,6 +978,13 @@ if IS_MEGAMOE_OP_AVAILABLE:
         # Module-scope compile cache shared by every runner instance.
         kernel_cache: dict = {}
 
+        # Module-scope tuning-config cache keyed on ``unique_id()``. The op
+        # rebuilds a runner per call, so an instance-level cache would never
+        # hit; keeping it at class scope amortizes the config build across
+        # calls (mirrors the ``tuning_config_cache`` of the CuteDSL
+        # grouped-gemm runners in ``cute_dsl_custom_ops.py``).
+        tuning_config_cache: dict = {}
+
         def __init__(
             self,
             *,
@@ -773,8 +999,7 @@ if IS_MEGAMOE_OP_AVAILABLE:
             output_dtype: torch.dtype,
             apply_topk_in_fc1: bool = True,
             gate_up_clamp: Optional[float] = None,
-            token_back_by_dispatch: bool = False,
-            non_ubulk_fc2_store: bool = True,
+            in_kernel_fc2_reduce: bool = False,
         ) -> None:
             super().__init__()
             if (sm_version := get_sm_version()) not in (100, 103):
@@ -803,13 +1028,17 @@ if IS_MEGAMOE_OP_AVAILABLE:
             )
             self.max_tokens_per_rank = int(max_tokens_per_rank)
             self.output_dtype = output_dtype
-            # Codegen-time graph/clamp modes. They change the generated
-            # kernel, so they are part of ``unique_id`` (and therefore the
-            # compile-cache key) -- never per-call runtime kwargs.
+            # Codegen-time graph/clamp/output modes. They change the generated
+            # kernel (and form-B changes the combine_output buffer shape), so
+            # they are part of ``unique_id`` (and therefore the compile-cache +
+            # workspace-cache key) -- never per-call runtime kwargs.
+            #
+            # ``in_kernel_fc2_reduce`` is a backend FUNCTIONAL config (form-A vs
+            # form-B output), NOT a perf-tuning tactic field; it lives here so
+            # form-A and form-B get independent compile / workspace caches.
             self.apply_topk_in_fc1 = bool(apply_topk_in_fc1)
             self.gate_up_clamp = None if gate_up_clamp is None else float(gate_up_clamp)
-            self.token_back_by_dispatch = bool(token_back_by_dispatch)
-            self.non_ubulk_fc2_store = bool(non_ubulk_fc2_store)
+            self.in_kernel_fc2_reduce = bool(in_kernel_fc2_reduce)
 
         def unique_id(self):
             return (
@@ -824,8 +1053,7 @@ if IS_MEGAMOE_OP_AVAILABLE:
                 str(self.output_dtype),
                 self.apply_topk_in_fc1,
                 self.gate_up_clamp,
-                self.token_back_by_dispatch,
-                self.non_ubulk_fc2_store,
+                self.in_kernel_fc2_reduce,
             )
 
         def get_valid_tactics(
@@ -834,38 +1062,31 @@ if IS_MEGAMOE_OP_AVAILABLE:
             profile: OptimizationProfile,
             **kwargs,
         ) -> List[Tuple]:
-            del inputs, profile, kwargs
-            return enumerate_megamoe_candidate_tactics()
+            del profile, kwargs
+            # The activation token axis (inputs[0].shape[0]) drives the
+            # token-bucket-dependent ``epi_flag_batch`` choice; pass it through
+            # so the autotuner profiles ``(2, 4)`` for >8192 buckets and
+            # ``(1, 1)`` otherwise.
+            num_tokens = int(inputs[0].shape[0])
+            return enumerate_megamoe_candidate_tactics(num_tokens)
 
         def _autotuner_inputs_pre_hook(self, inputs: List[torch.Tensor]) -> List[torch.Tensor]:
             """Sanitize ONLY the autotuner-regenerated fake inputs.
 
-            ``AutoTuner._prepare_input_tensors`` rebuilds fresh fake tensors
-            for the dynamic / constraint inputs -- activation (0),
-            activation_sf (1), topk_idx (2), topk_weights (3),
-            combine_output (11) -- and passes every STATIC input through BY
-            REFERENCE (``tensor = inputs[i]`` for non-dynamic dims). The static
-            inputs here are the caller's REAL weight-side tensors: fc1_weight
-            (4), fc1_weight_sf (5), fc2_weight (6), fc2_weight_sf (7),
-            fc1_alpha (8), fc2_alpha (9), fc1_norm_const (10).
+            AutoTuner rebuilds fake tensors for the dynamic/constraint inputs
+            (activation 0, activation_sf 1, topk_idx 2, topk_weights 3,
+            combine_output 11) and passes the static inputs (the caller's real
+            weights/scales at indices 4-10) through by reference. We fix only
+            the regenerated tensors and leave 4-10 untouched: filling them
+            would clobber the real per-expert weight SF / alphas and make every
+            post-tuning forward emit all-zero output.
 
-            Therefore this hook must mirror ``CuteDslFusedMoE.inputs_pre_hook``:
-            only fix up the regenerated tensors and pass the real weights /
-            scales through untouched. The fresh ``topk_idx`` is filled with
-            random ints in ``[-5, 4]`` whose out-of-range values index a
-            per-CTA SMEM histogram + the peer-rank pointer table and trigger
-            illegal memory access, so we rewrite it to a valid round-robin;
-            the fresh ``activation_sf`` / ``topk_weights`` are zeroed to keep
-            the FP8/FP32 epilogue NaN-free (autotuning measures runtime, not
-            numerics).
-
-            We intentionally do NOT touch indices 4-10. An in-place
-            ``zero_()`` / ``fill_()`` on those would permanently clobber the
-            caller's REAL per-expert weight scale factors / alphas (they are
-            not regenerated), zeroing the weight SF and forcing every
-            post-tuning forward to emit an all-zero ``combine_output``. The
-            real weights are already valid (no NaN, non-zero norm_const), so
-            they need no sanitization. This keeps the hook copy-free.
+            - topk_idx: fresh random ints can be out of range and index OOB
+              into the SMEM histogram / peer-pointer table, so rewrite to a
+              valid round-robin.
+            - activation_sf / topk_weights: fill with 1.0 (NOT 0) so the kernel
+              does real, NaN-free work; SF==0 degenerates the GEMMs and gives
+              unrealistic tactic timing.
             """
             inputs = list(inputs)
             total_experts = self.num_experts_per_rank * self.world_size
@@ -885,17 +1106,18 @@ if IS_MEGAMOE_OP_AVAILABLE:
                 ).view(T, K)
                 topk_idx.copy_(valid)
 
-            # activation_sf (1) and topk_weights (3) are autotuner-regenerated
-            # fresh tensors; zero them to keep the FC1/FC2 epilogue paths
-            # NaN-free against random ``uint8`` -> FP8 reinterpretation. The
-            # weight SF (5, 7) and per-expert alphas (8, 9, 10) are the real,
-            # already-valid backend tensors and are deliberately left alone.
+            # inputs[1] is already float8_e4m3fn, where fill_(1.0) writes the
+            # FP8 value 1.0 (byte 0x38); the uint8 fallback writes that raw byte
+            # directly (do NOT fill_(0x38) on the FP8 view -- that is 56.0).
             activation_sf = inputs[1]
             if isinstance(activation_sf, torch.Tensor):
-                activation_sf.zero_()
+                if activation_sf.dtype == torch.float8_e4m3fn:
+                    activation_sf.fill_(1.0)  # FP8 1.0 (exact, byte 0x38)
+                else:
+                    activation_sf.view(torch.uint8).fill_(0x38)  # raw byte = FP8 1.0
             topk_weights = inputs[3]
             if isinstance(topk_weights, torch.Tensor):
-                topk_weights.zero_()
+                topk_weights.fill_(1.0)
 
             return inputs
 
@@ -906,7 +1128,20 @@ if IS_MEGAMOE_OP_AVAILABLE:
             combine_output to the activation token count, so the
             autotuner does not double-enumerate tile sizes for
             independent token axes.
+
+            Cached at class scope keyed on ``unique_id()``: every field below
+            is constant except ``inputs_pre_hook`` and ``tune_max_num_tokens``.
+            ``inputs_pre_hook`` is a bound method that only reads
+            ``num_experts_per_rank`` / ``world_size`` and ``tune_max_num_tokens``
+            is ``max_tokens_per_rank`` -- all three are part of ``unique_id()``,
+            so two runners that map to the same key share a functionally
+            identical config. (Mirrors the ``tuning_config_cache`` pattern of
+            the CuteDSL grouped-gemm runners.)
             """
+            key = self.unique_id()
+            cached = self.__class__.tuning_config_cache.get(key)
+            if cached is not None:
+                return cached
 
             # Constraints reuse the runner's own shape-derivation rules
             # (the activation token count drives every other tensor's
@@ -915,7 +1150,7 @@ if IS_MEGAMOE_OP_AVAILABLE:
             def _num_tokens(shapes: List[torch.Size]) -> int:
                 return shapes[0][0]
 
-            return TuningConfig(
+            config = TuningConfig(
                 dynamic_tensor_specs=(
                     DynamicTensorSpec(
                         0, 0, get_last_power_of_2_num_tokens_buckets, last_positive_power_of_2
@@ -931,6 +1166,14 @@ if IS_MEGAMOE_OP_AVAILABLE:
                 ),
                 inputs_pre_hook=self._autotuner_inputs_pre_hook,
                 use_cold_l2_cache=True,
+                # Pin the num_tokens bucket ladder to the per-rank token
+                # ceiling instead of letting it depend on whatever
+                # num_tokens the autotuner warmup forward happened to feed
+                # (which is clamped by available KV cache and may be a
+                # non-power-of-2 / lower value). Mirrors trtllm-gen's
+                # ``tune_max_num_tokens=self.max_num_tokens`` (the runner-level
+                # name for that ceiling here is ``max_tokens_per_rank``).
+                tune_max_num_tokens=self.max_tokens_per_rank,
                 # CUDA Graph capture cannot reproduce MegaMoE's runtime
                 # peer-pointer table / dispatch-counter view and would
                 # spin inside the captured barrier when the autotuner's
@@ -945,24 +1188,29 @@ if IS_MEGAMOE_OP_AVAILABLE:
                 # ``cute_dsl_custom_ops.py``).
                 distributed_tuning_strategy=DistributedTuningStrategy.PARALLEL,
             )
+            self.__class__.tuning_config_cache[key] = config
+            return config
 
         def _build_kernel(self, tactic: Tuple):
             (
                 mma_tiler,
                 cluster_shape,
-                use_2cta,
-                resolved_group_hint,
+                group_hint,
                 load_balance_mode,
-                use_bf16_redg,
-            ) = tactic
+                token_back_mode,
+                use_bulk_fc2_store,
+                flag_batch,
+                epi_flag_batch,
+            ) = _unpack_tactic(tactic)
             from ..cute_dsl_kernels.mega_moe_nvfp4 import import_kernel
 
             kernel_cls = import_kernel()
             return kernel_cls(
                 mma_tiler_mnk=tuple(mma_tiler),
                 cluster_shape_mnk=tuple(cluster_shape),
-                use_2cta_instrs=bool(use_2cta),
-                group_hint=int(resolved_group_hint),
+                # use_2cta_instrs is DERIVED from M, not a tactic field.
+                use_2cta_instrs=bool(mma_tiler[0] == 256),
+                group_hint=int(group_hint),
                 token_padding_block=64,
                 sf_padding_block=SfPaddingBlock,
                 load_balance_mode=str(load_balance_mode),
@@ -977,33 +1225,70 @@ if IS_MEGAMOE_OP_AVAILABLE:
                 max_tokens_per_rank=self.max_tokens_per_rank,
                 hidden=self.hidden_size,
                 fc2_output_dtype=cutlass.BFloat16,
-                in_kernel_fc2_reduce=bool(use_bf16_redg),
+                # in_kernel_fc2_reduce is a backend functional config (form-A/B),
+                # carried in unique_id, NOT a tactic field.
+                in_kernel_fc2_reduce=self.in_kernel_fc2_reduce,
+                token_back_mode=str(token_back_mode),
+                non_ubulk_fc2_store=(not bool(use_bulk_fc2_store)),
+                flag_batch=int(flag_batch),
+                epi_flag_batch=tuple(epi_flag_batch),
                 apply_topk_in_fc1=self.apply_topk_in_fc1,
                 gate_up_clamp=self.gate_up_clamp,
-                token_back_by_dispatch=self.token_back_by_dispatch,
-                non_ubulk_fc2_store=self.non_ubulk_fc2_store,
                 **_LOCKED_KERNEL_KWARGS,
             )
 
-        def _compile_or_get(self, tactic: Tuple, kernel, runtime_kwargs):
-            # ``unique_id()`` already carries apply_topk_in_fc1 / gate_up_clamp,
-            # so the codegen-time graph/clamp modes are part of the cache key
-            # without listing them again here.
-            cache_key = (
+        def _tactic_cache_key(self, tactic: Tuple) -> Tuple:
+            """Hashable cache key over ``unique_id()`` + the FULL 8-tuple.
+
+            Both the compile cache and the local-workspace cache MUST key on
+            the full tactic: the local workspace size varies with the tactic
+            (token_back_mode != 'epi_warps' adds a large fc2_output_workspace +
+            fc2_done_counter; atomic_counter adds token_back_schedule_counter),
+            so an under-keyed workspace cache would reuse an epi-sized buffer
+            for a reuse/standalone tactic -> OOB / 100% SM hang. ``unique_id()``
+            already carries apply_topk_in_fc1 / gate_up_clamp / in_kernel_fc2_reduce
+            (form-A and form-B never share a cache entry).
+            """
+            (
+                mma_tiler,
+                cluster_shape,
+                group_hint,
+                load_balance_mode,
+                token_back_mode,
+                use_bulk_fc2_store,
+                flag_batch,
+                epi_flag_batch,
+            ) = _unpack_tactic(tactic)
+            return (
                 self.unique_id(),
-                tuple(tactic[0]),
-                tuple(tactic[1]),
-                bool(tactic[2]),
-                int(tactic[3]),
-                str(tactic[4]),
-                bool(tactic[5]),
+                tuple(mma_tiler),
+                tuple(cluster_shape),
+                int(group_hint),
+                str(load_balance_mode),
+                str(token_back_mode),
+                bool(use_bulk_fc2_store),
+                int(flag_batch),
+                tuple(epi_flag_batch),
             )
+
+        def _compile_or_get(self, tactic: Tuple, kernel, runtime_kwargs):
+            (
+                mma_tiler,
+                cluster_shape,
+                group_hint,
+                load_balance_mode,
+                token_back_mode,
+                use_bulk_fc2_store,
+                flag_batch,
+                epi_flag_batch,
+            ) = _unpack_tactic(tactic)
+            cache_key = self._tactic_cache_key(tactic)
             compiled = self.__class__.kernel_cache.get(cache_key)
             if compiled is not None:
                 return compiled
             compile_kwargs = dict(runtime_kwargs)
             hardware_info = cutlass.utils.HardwareInfo()
-            cluster_size = tactic[1][0] * tactic[1][1] * tactic[1][2]
+            cluster_size = cluster_shape[0] * cluster_shape[1] * cluster_shape[2]
             compile_kwargs["max_active_clusters"] = hardware_info.get_max_active_clusters(
                 max(cluster_size, 1)
             )
@@ -1012,9 +1297,11 @@ if IS_MEGAMOE_OP_AVAILABLE:
             # the standard TRT-LLM logger (honors TLLM_LOG_LEVEL).
             logger.info(
                 f"[MegaMoECuteDsl] cute.compile START tactic="
-                f"(mma_tiler={tactic[0]}, cluster={tactic[1]}, "
-                f"use_2cta={tactic[2]}, group_hint={tactic[3]}, "
-                f"load_balance={tactic[4]!r}, use_bf16_redg={tactic[5]})"
+                f"(mma_tiler={mma_tiler}, cluster={cluster_shape}, "
+                f"group_hint={group_hint}, load_balance={load_balance_mode!r}, "
+                f"token_back_mode={token_back_mode!r}, use_bulk={use_bulk_fc2_store}, "
+                f"flag_batch={flag_batch}, epi_flag_batch={epi_flag_batch}, "
+                f"in_kernel_fc2_reduce={self.in_kernel_fc2_reduce})"
             )
             t_compile_start = time.perf_counter()
             compiled = cute.compile(kernel, **compile_kwargs)
@@ -1031,31 +1318,18 @@ if IS_MEGAMOE_OP_AVAILABLE:
             inputs: List[torch.Tensor],
             *,
             tactic: Any = -1,
-            do_preparation: bool = False,
             peer_offsets: Optional[List[int]] = None,
             shared_workspace: Optional[torch.Tensor] = None,
             **kwargs,
         ) -> None:
             del kwargs
-            # ``do_preparation=True`` is the autotuner's pre-tactic
-            # warm-up hook. MegaMoE has no caller-allocated preallocation
-            # to do (workspaces are owned by the caller / runner class
-            # cache); running the kernel here would also leak unsupported-
-            # tactic crashes as async CUDA errors into the next call.
-            # Mirrors AllReduceRunner's early-return pattern.
-            if do_preparation:
-                return None
             t_forward_start = time.perf_counter()
-            # Resolve fallback tactic.
+            # Resolve fallback tactic. ``inputs`` is in hand here, so the
+            # autotune-disabled / tactic=-1 fallback selects the token-aware
+            # ``default_megamoe_tactic(num_tokens)`` directly (3-regime).
             if tactic == -1 or tactic is None:
-                tactic_t = (
-                    list(DEFAULT_MEGAMOE_TACTIC[0]),
-                    list(DEFAULT_MEGAMOE_TACTIC[1]),
-                    DEFAULT_MEGAMOE_TACTIC[2],
-                    resolve_megamoe_group_hint(tuple(DEFAULT_MEGAMOE_TACTIC[1])),
-                    DEFAULT_MEGAMOE_TACTIC[4],
-                    DEFAULT_MEGAMOE_TACTIC[5],
-                )
+                num_tokens = int(inputs[0].shape[0])
+                tactic_t = default_megamoe_tactic(num_tokens)
             elif isinstance(tactic, list):
                 tactic_t = tuple(tactic)
             else:
@@ -1087,18 +1361,23 @@ if IS_MEGAMOE_OP_AVAILABLE:
 
             kernel = self._build_kernel(tactic_t)
 
-            # ``local_workspace`` is per-rank private; cached across calls.
+            # form-B (in_kernel_fc2_reduce) accumulates the top-k reduction into
+            # ``combine_output`` via in-kernel atomic / cp.reduce on top of the
+            # existing cell, so the combine buffer's live rows MUST start at 0.
+            # The caller (MegaMoECuteDsl backend) zeros only ``[:num_tokens]``
+            # before invoking this op -- we do NOT full-``max_T`` zero here
+            # because the op has no live token count (the activation is always
+            # padded to ``max_T``, so ``inputs[0].shape[0]`` is not the live
+            # count) and a full zero is wasted work for small decode batches.
+            # form-A overwrites cells and needs no per-launch zero.
+
+            # ``local_workspace`` is per-rank private; cached across calls. The
+            # cache key is the FULL 8-tuple because the local workspace SIZE
+            # varies with the tactic (token_back_mode / load_balance add large
+            # regions); an under-keyed cache would reuse a wrong-sized buffer.
             local_workspace = _get_or_alloc_local_workspace(
                 kernel,
-                cache_key=(
-                    self.unique_id(),
-                    tuple(tactic_t[0]),
-                    tuple(tactic_t[1]),
-                    bool(tactic_t[2]),
-                    int(tactic_t[3]),
-                    str(tactic_t[4]),
-                    bool(tactic_t[5]),
-                ),
+                cache_key=self._tactic_cache_key(tactic_t),
                 device=activation.device,
             )
             # ``shared_workspace`` is peer-mapped (symmetric heap) for
@@ -1208,10 +1487,11 @@ if IS_MEGAMOE_OP_AVAILABLE:
             t_forward_ms = (time.perf_counter() - t_forward_start) * 1000
             logger.debug(
                 "[MegaMoECuteDsl] forward DONE tactic="
-                "(mma_tiler=%s, cluster=%s, load_balance=%r) "
+                "(mma_tiler=%s, cluster=%s, load_balance=%r, token_back=%r) "
                 "launch+sync=%.0fms total=%.0fms",
                 tactic_t[0],
                 tactic_t[1],
+                tactic_t[3],
                 tactic_t[4],
                 t_launch_ms,
                 t_forward_ms,
@@ -1250,8 +1530,7 @@ if IS_MEGAMOE_OP_AVAILABLE:
         peer_offsets: List[int],
         apply_topk_in_fc1: bool = True,
         gate_up_clamp: Optional[float] = None,
-        token_back_by_dispatch: bool = False,
-        non_ubulk_fc2_store: bool = True,
+        in_kernel_fc2_reduce: bool = False,
     ) -> None:
         """Run the fused MegaMoE CuteDSL NVFP4 kernel.
 
@@ -1265,9 +1544,17 @@ if IS_MEGAMOE_OP_AVAILABLE:
         local CUDA tensor is acceptable for the single-rank degenerate
         path. ``combine_output`` is mutated in place; the op does not
         return it because torch custom_op forbids the return value from
-        aliasing any mutated input. Form A semantics: ``combine_output``
-        keeps its ``(T, num_topk, hidden)`` layout, and the caller is
-        responsible for the host-side ``.sum(dim=1)``.
+        aliasing any mutated input.
+
+        ``in_kernel_fc2_reduce`` selects the output reduction form:
+        ``False`` (default, form-A) keeps ``combine_output`` at
+        ``(T, num_topk, hidden)`` and the caller does the host-side
+        ``.sum(dim=1)``; ``True`` (form-B) uses ``(T, 1, hidden)`` (zeroed
+        per launch) and the kernel folds the top-k reduction in-kernel, so
+        the output is NON-deterministic (in-kernel float accumulation order).
+        ``token_back_mode`` / ``use_bulk_fc2_store`` / ``flag_batch`` /
+        ``epi_flag_batch`` are perf knobs selected by the autotuner tactic,
+        not op arguments.
         """
         sm_version = get_sm_version()
         if sm_version not in (100, 103):
@@ -1288,8 +1575,7 @@ if IS_MEGAMOE_OP_AVAILABLE:
             output_dtype=combine_output.dtype,
             apply_topk_in_fc1=apply_topk_in_fc1,
             gate_up_clamp=gate_up_clamp,
-            token_back_by_dispatch=token_back_by_dispatch,
-            non_ubulk_fc2_store=non_ubulk_fc2_store,
+            in_kernel_fc2_reduce=in_kernel_fc2_reduce,
         )
         inputs = [
             activation,
@@ -1347,7 +1633,6 @@ if IS_MEGAMOE_OP_AVAILABLE:
         peer_offsets: List[int],
         apply_topk_in_fc1: bool = True,
         gate_up_clamp: Optional[float] = None,
-        token_back_by_dispatch: bool = False,
-        non_ubulk_fc2_store: bool = True,
+        in_kernel_fc2_reduce: bool = False,
     ) -> None:
         return None

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_megamoe_custom_op.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_megamoe_custom_op.py
@@ -1296,7 +1296,19 @@ if IS_MEGAMOE_OP_AVAILABLE:
                     ConstraintSpec(11, 0, _num_tokens),  # combine_output
                 ),
                 inputs_pre_hook=self._autotuner_inputs_pre_hook,
-                use_cold_l2_cache=True,
+                # MUST stay False for multi-rank MegaMoE. ``use_cold_l2_cache``
+                # makes the AutoTuner ``clone()`` the profiling inputs into extra
+                # buffers for L2-cold rotation. The cross-rank inputs
+                # (activation / activation_sf / topk_weights / combine_output)
+                # are routed by ``_autotuner_inputs_pre_hook`` to a SYMMETRIC
+                # scratch; the clones are ordinary NON-symmetric tensors, so the
+                # kernel's peer-pointer mapping (base = clone ptr + the scratch's
+                # peer_offsets) resolves outside any symmetric region and a
+                # dispatch/combine peer access lands out of bounds (CUDA illegal
+                # memory access during autotuning, e.g. e4_k4 at the m=128
+                # profiling bucket). Single-batch profiling keeps every launch on
+                # the real symmetric scratch.
+                use_cold_l2_cache=False,
                 # Pin the num_tokens bucket ladder to the per-rank token
                 # ceiling instead of letting it depend on whatever
                 # num_tokens the autotuner warmup forward happened to feed

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_megamoe_custom_op.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_megamoe_custom_op.py
@@ -1130,9 +1130,18 @@ if IS_MEGAMOE_OP_AVAILABLE:
             self.in_kernel_fc2_reduce = bool(in_kernel_fc2_reduce)
 
         def unique_id(self):
+            # local_rank is intentionally excluded from the key. The kernel
+            # requires every EP rank to run the SAME tactic (shared NVLink
+            # dispatch barrier + peer-pointer layout), and the MERGE tuning
+            # strategy merges per-shape timings by cache key across ranks --
+            # so the key MUST be identical on every rank for the all-gather
+            # merge to converge them onto one global-best tactic. Including
+            # local_rank would give each rank a distinct key, leaving every
+            # rank on its own best and breaking the same-tactic requirement.
+            # world_size stays so single-rank (degenerate) and multi-rank
+            # tuning never share entries.
             return (
                 self.world_size,
-                self.local_rank,
                 self.num_topk,
                 self.num_experts_per_rank,
                 self.hidden_size,
@@ -1302,13 +1311,26 @@ if IS_MEGAMOE_OP_AVAILABLE:
                 # L2-cache buffers rotate. Plain repeat-loop profiling
                 # is correct and only marginally slower.
                 use_cuda_graph=False,
-                # FUSED_COMM hard requirement: every EP rank must run
-                # the same compiled tactic per chunk so the NVLink
-                # dispatch barrier and peer pointer mapping line up.
-                # PARALLEL strategy keeps tactic selection lockstep
-                # across ranks (same as every multi-rank CuteDSL op in
-                # ``cute_dsl_custom_ops.py``).
-                distributed_tuning_strategy=DistributedTuningStrategy.PARALLEL,
+                # MegaMoE fuses cross-rank dispatch + FC1 + FC2 + combine into
+                # one kernel: ranks couple at the dispatch count-exchange and
+                # combine NVLink barriers, and FC1 token tiles depend on peers'
+                # pull progress. Faithful per-tactic timing therefore requires
+                # ALL EP ranks to run the SAME tactic in lockstep and time it
+                # together. MERGE does exactly that: it does NOT split the
+                # candidate list across ranks (every rank profiles the full
+                # list, same tactic per step), inserts a tp_barrier before each
+                # measurement, and disables the short-profile heuristic so every
+                # rank issues an identical number of launches (otherwise the
+                # all-rank NVLink barriers would desync/hang). It then all-gathers
+                # the per-shape timings so every rank converges onto one
+                # global-best tactic -- which the kernel requires, since all EP
+                # ranks must run the same compiled tactic for the NVLink dispatch
+                # barrier and peer-pointer mapping to line up. PARALLEL (used by
+                # plain multi-rank CuteDSL GEMMs that have no in-kernel cross-rank
+                # coupling) would split tactics across ranks, contaminating the
+                # comm-coupled timing and risking barrier desync, so it is NOT
+                # used here.
+                distributed_tuning_strategy=DistributedTuningStrategy.MERGE,
             )
             self.__class__.tuning_config_cache[key] = config
             return config

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_megamoe_custom_op.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_megamoe_custom_op.py
@@ -873,6 +873,89 @@ if IS_MEGAMOE_OP_AVAILABLE:
         _MEGAMOE_SYMM_PROVIDER_CACHE[cache_key] = provider
         return provider
 
+    # ---- AutoTuner profiling scratch (symmetric, transient) ---------------
+    # The fused kernel uses a SINGLE ``peer_rank_ptr_mapper`` (one
+    # ``peer_offsets``) for every cross-rank access, so ALL cross-rank tensors
+    # -- activation / activation_sf / topk_weights / combine_output AND the
+    # shared_workspace -- must live in one symmetric allocation at a consistent
+    # per-rank offset. During the real run the backend supplies the staging
+    # symmetric buffer; but the AutoTuner regenerates the data inputs as fresh
+    # NON-symmetric tensors for each profile, which makes the peer mapping point
+    # outside any symmetric region (illegal memory access, multi-rank only).
+    # We therefore profile against a SEPARATE symmetric scratch buffer (a full
+    # MegaMoeSymmMemProvider with its own peer_offsets) so the real staging
+    # buffer is never corrupted. The scratch is shared across MoE layers with
+    # the same layout (one buffer per shape) and released after warmup via
+    # ``release_megamoe_profiling_scratch()``.
+    _MEGAMOE_PROFILING_SCRATCH_CACHE: dict = {}
+    _ACTIVE_MEGAMOE_PROFILING_SCRATCH = None
+
+    def get_megamoe_profiling_scratch(
+        *,
+        process_group,
+        world_size: int,
+        rank: int,
+        hidden_size: int,
+        max_tokens_per_rank: int,
+        num_topk: int,
+        output_dtype: torch.dtype,
+        shared_workspace_bytes: int,
+        in_kernel_fc2_reduce: bool = False,
+    ):
+        """Return a cached, transient symmetric scratch provider used ONLY for
+        AutoTuner profiling. ``None`` for single-rank (no cross-rank exchange).
+        Shares one buffer across layers with the same layout; freed by
+        :func:`release_megamoe_profiling_scratch`.
+        """
+        if int(world_size) <= 1:
+            return None
+        if not hasattr(process_group, "group_name"):
+            raise RuntimeError(
+                "get_megamoe_profiling_scratch requires a ProcessGroup with "
+                ".group_name (mapping.moe_ep_group_pg)."
+            )
+        cache_key = (
+            str(process_group.group_name),
+            int(hidden_size),
+            int(max_tokens_per_rank),
+            int(num_topk),
+            str(output_dtype),
+            int(shared_workspace_bytes),
+            bool(in_kernel_fc2_reduce),
+        )
+        cached = _MEGAMOE_PROFILING_SCRATCH_CACHE.get(cache_key)
+        if cached is not None:
+            return cached
+        provider = MegaMoeSymmMemProvider(
+            process_group=process_group,
+            world_size=world_size,
+            rank=rank,
+            hidden_size=hidden_size,
+            max_tokens_per_rank=max_tokens_per_rank,
+            num_topk=num_topk,
+            output_dtype=output_dtype,
+            shared_workspace_bytes=shared_workspace_bytes,
+            in_kernel_fc2_reduce=in_kernel_fc2_reduce,
+        )
+        _MEGAMOE_PROFILING_SCRATCH_CACHE[cache_key] = provider
+        return provider
+
+    def set_active_megamoe_profiling_scratch(regions) -> None:
+        """Set (``None`` clears) the :class:`MegaMoeSymmRegions` the MegaMoE op
+        uses for AutoTuner profiling on the current call. The backend sets this
+        around the op invocation; the op consumes it inside ``choose_one``.
+        """
+        global _ACTIVE_MEGAMOE_PROFILING_SCRATCH
+        _ACTIVE_MEGAMOE_PROFILING_SCRATCH = regions
+
+    def release_megamoe_profiling_scratch() -> None:
+        """Free all profiling-scratch symmetric buffers. Call after warmup once
+        tuning is done; profiling re-allocates lazily if it runs again.
+        """
+        global _ACTIVE_MEGAMOE_PROFILING_SCRATCH
+        _ACTIVE_MEGAMOE_PROFILING_SCRATCH = None
+        _MEGAMOE_PROFILING_SCRATCH_CACHE.clear()
+
     def query_megamoe_shared_workspace_bytes(
         *,
         world_size: int,
@@ -1038,6 +1121,12 @@ if IS_MEGAMOE_OP_AVAILABLE:
             # form-A and form-B get independent compile / workspace caches.
             self.apply_topk_in_fc1 = bool(apply_topk_in_fc1)
             self.gate_up_clamp = None if gate_up_clamp is None else float(gate_up_clamp)
+            # Per-call AutoTuner profiling scratch (symmetric ``MegaMoeSymmRegions``)
+            # set by the op around ``choose_one`` so the profiling pre-hook routes
+            # the cross-rank inputs through a symmetric scratch buffer instead of
+            # the AutoTuner's fresh non-symmetric tensors. ``None`` outside tuning
+            # and for the single-rank degenerate path.
+            self._profiling_scratch = None
             self.in_kernel_fc2_reduce = bool(in_kernel_fc2_reduce)
 
         def unique_id(self):
@@ -1093,6 +1182,9 @@ if IS_MEGAMOE_OP_AVAILABLE:
             if total_experts <= 0:
                 return inputs
 
+            # topk_idx (inputs[2]) is consumed LOCALLY (not peer-mapped), so it
+            # stays a regenerated tensor; just make the fake ids a valid
+            # round-robin so they never index OOB into the expert tables.
             topk_idx = inputs[2]
             if isinstance(topk_idx, torch.Tensor) and topk_idx.dim() == 2:
                 T, K = topk_idx.shape
@@ -1106,6 +1198,36 @@ if IS_MEGAMOE_OP_AVAILABLE:
                 ).view(T, K)
                 topk_idx.copy_(valid)
 
+            scratch = self._profiling_scratch
+            if scratch is not None:
+                # Multi-rank profiling: route the CROSS-RANK inputs through the
+                # symmetric scratch buffer (sliced to the regenerated token
+                # count) so the kernel's single peer_rank_ptr_mapper resolves to
+                # a valid symmetric region. The AutoTuner's fresh non-symmetric
+                # tensors are discarded for these indices; the staging buffer is
+                # never touched. Fake values mirror the legacy sanitizer
+                # (round-robin topk above, SF/weights == 1.0) so the GEMM does
+                # NaN-free, representative work.
+                m = int(inputs[0].shape[0])
+                act = scratch.activation[:m]
+                act.copy_(inputs[0].view(torch.uint8))
+                inputs[0] = act.view(inputs[0].dtype)
+
+                sf = scratch.activation_sf[:m]
+                sf.fill_(0x38)  # raw byte == FP8 1.0
+                inputs[1] = sf if inputs[1].dtype == torch.uint8 else sf.view(inputs[1].dtype)
+
+                w = scratch.topk_weights[:m]
+                w.fill_(1.0)
+                inputs[3] = w
+
+                comb = scratch.combine_output[:m]
+                comb.zero_()  # form-B accumulates onto live rows; form-A overwrites
+                inputs[11] = comb
+                return inputs
+
+            # Single-rank / scratch-disabled (legacy path; no symmetric
+            # requirement): sanitize the regenerated tensors in place.
             # inputs[1] is already float8_e4m3fn, where fill_(1.0) writes the
             # FP8 value 1.0 (byte 0x38); the uint8 fallback writes that raw byte
             # directly (do NOT fill_(0x38) on the FP8 view -- that is 56.0).
@@ -1592,14 +1714,32 @@ if IS_MEGAMOE_OP_AVAILABLE:
             combine_output,
         ]
         tuner = AutoTuner.get()
-        _, best_tactic = tuner.choose_one(
-            "trtllm::cute_dsl_megamoe_nvfp4_blackwell",
-            [runner],
-            runner.get_tuning_config(),
-            inputs,
-            peer_offsets=peer_offsets,
-            shared_workspace=shared_workspace,
-        )
+        # AutoTuner profiling must use a SYMMETRIC buffer for the cross-rank
+        # inputs. The backend hands off a transient symmetric scratch (its own
+        # peer_offsets + shared_workspace); the profiling pre-hook routes the
+        # cross-rank inputs through it so the real staging buffer is never
+        # corrupted. Single-rank / no-scratch falls back to the staging buffer.
+        prof_scratch = _ACTIVE_MEGAMOE_PROFILING_SCRATCH if world_size > 1 else None
+        if prof_scratch is not None:
+            runner._profiling_scratch = prof_scratch
+            prof_peer_offsets = list(prof_scratch.peer_offsets)
+            prof_shared_workspace = prof_scratch.shared_workspace
+        else:
+            runner._profiling_scratch = None
+            prof_peer_offsets = peer_offsets
+            prof_shared_workspace = shared_workspace
+        try:
+            _, best_tactic = tuner.choose_one(
+                "trtllm::cute_dsl_megamoe_nvfp4_blackwell",
+                [runner],
+                runner.get_tuning_config(),
+                inputs,
+                peer_offsets=prof_peer_offsets,
+                shared_workspace=prof_shared_workspace,
+            )
+        finally:
+            runner._profiling_scratch = None
+        # Real run always uses the caller's staging buffer + peer_offsets.
         runner(
             inputs,
             tactic=best_tactic,

--- a/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/contract.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/contract.py
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 """Codegen-time finite mapping contracts for RMEM tensor handoff."""
 
 from __future__ import annotations
@@ -78,9 +80,8 @@ class Space:
         """Convert a coordinate tuple into a CuTe-style linear index."""
         coord_tuple = tuple(coord)
         if len(coord_tuple) != self.rank:
-            raise ContractError(
-                f"Coordinate rank mismatch for {self.names!r}: {len(coord_tuple)} != {self.rank}"
-            )
+            raise ContractError(f"Coordinate rank mismatch for {self.names!r}: "
+                                f"{len(coord_tuple)} != {self.rank}")
 
         linear = 0
         stride = 1
@@ -162,8 +163,8 @@ class TableMapping:
         """Validate and return the canonical table for the given spaces."""
         if len(self.table) != domain.size:
             raise ContractError(
-                f"TableMapping length must equal domain size {domain.size}, got {len(self.table)}"
-            )
+                f"TableMapping length must equal domain size {domain.size}, "
+                f"got {len(self.table)}")
         for idx, value in enumerate(self.table):
             if value < 0 or value >= codomain.size:
                 raise ContractError(
@@ -395,3 +396,27 @@ class TensorWithContract:
 
     tensor: Any
     contract: Contract
+
+
+def eval_function_mapping(contract: Contract, **domain_coord):
+    """Evaluate a FunctionMapping contract at runtime."""
+    if not isinstance(contract.mapping, FunctionMapping):
+        raise TypeError("runtime contract eval requires a FunctionMapping")
+
+    result = contract.mapping.function(**domain_coord)
+    if isinstance(result, dict):
+        return result
+    if isinstance(result, (tuple, list)):
+        if len(result) != contract.codomain.rank:
+            raise ValueError(
+                "FunctionMapping result rank does not match codomain rank: "
+                f"{len(result)} vs {contract.codomain.rank}")
+        return {
+            name: result[i]
+            for i, name in enumerate(contract.codomain.names)
+        }
+    if contract.codomain.rank == 1:
+        return {contract.codomain.names[0]: result}
+    raise TypeError(
+        "FunctionMapping runtime eval must return dict/tuple/list, or scalar "
+        "for rank-1 codomain")

--- a/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/custom_ext.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/custom_ext.py
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 """Sched extension for fused fc1+fc2 work-tile enrichment and GMEM slicing."""
 
 from typing import List, Optional, Tuple, Union
@@ -39,6 +41,9 @@ class SwapABSwigluFp4Fc12WorkTileInfo(MoEWorkTileInfo):
         cumulative_token_block_count: Int32,
         valid_tokens_in_tile: Int32,
         phase_and_peek: Int32,
+        # Transient scheduler field — carried through MLIR serialization but
+        # NOT written to SMEM.  Default: tile_n_idx (correct for swap-AB).
+        fc1_counter_index: Int32,
     ):
         # Slot 3 reuses base k_tile_cnt storage.
         super().__init__(
@@ -56,6 +61,7 @@ class SwapABSwigluFp4Fc12WorkTileInfo(MoEWorkTileInfo):
         # consumers call them directly so the codebase reads as if the
         # two pieces were separate fields.
         self.phase_and_peek = phase_and_peek
+        self.fc1_counter_index = fc1_counter_index
 
     @property
     def phase(self) -> Int32:
@@ -83,11 +89,12 @@ class SwapABSwigluFp4Fc12WorkTileInfo(MoEWorkTileInfo):
         values.extend(extract_mlir_values(self.cumulative_token_block_count))
         values.extend(extract_mlir_values(self.valid_tokens_in_tile))
         values.extend(extract_mlir_values(self.phase_and_peek))
+        values.extend(extract_mlir_values(self.fc1_counter_index))
         return values
 
     def __new_from_mlir_values__(
             self, values: List[ir.Value]) -> "SwapABSwigluFp4Fc12WorkTileInfo":
-        assert len(values) == 8
+        assert len(values) == 9
         return SwapABSwigluFp4Fc12WorkTileInfo(
             expert_idx=new_from_mlir_values(self.expert_idx, [values[0]]),
             tile_m_idx=new_from_mlir_values(self.tile_m_idx, [values[1]]),
@@ -102,6 +109,8 @@ class SwapABSwigluFp4Fc12WorkTileInfo(MoEWorkTileInfo):
                                                       [values[6]]),
             phase_and_peek=new_from_mlir_values(self.phase_and_peek,
                                                 [values[7]]),
+            fc1_counter_index=new_from_mlir_values(self.fc1_counter_index,
+                                                   [values[8]]),
         )
 
     def to_rmem(self) -> cute.Tensor:
@@ -127,6 +136,7 @@ class SwapABSwigluFp4Fc12WorkTileInfo(MoEWorkTileInfo):
             cumulative_token_block_count=rmem[5],  # type: ignore[arg-type]
             valid_tokens_in_tile=rmem[6],  # type: ignore[arg-type]
             phase_and_peek=rmem[7],  # type: ignore[arg-type]
+            fc1_counter_index=rmem[2],  # type: ignore[arg-type]
         )
 
 
@@ -248,9 +258,9 @@ class SwapABSwigluFp4Fc12SchedExtension(MoESchedExtension):
             # Same slot index for both phases -- fc1 release-add (dispatch
             # pull) and fc2 release-add (fc1 epi) target the per-task-tile
             # counter slot indexed by ``cumulative_token_block_count +
-            # tile_n_idx``.
+            # fc1_counter_index``.
             counter_slot = (base_work.cumulative_token_block_count +
-                            base_work.tile_n_idx)
+                            base_work.fc1_counter_index)
             is_fc1 = base_work.phase == Int32(int(BlockPhase.Linear1))
             is_fc2 = base_work.phase == Int32(int(BlockPhase.Linear2))
 
@@ -301,6 +311,7 @@ class SwapABSwigluFp4Fc12SchedExtension(MoESchedExtension):
             cumulative_token_block_count=base_work.cumulative_token_block_count,
             valid_tokens_in_tile=base_work.valid_tokens_in_tile,
             phase_and_peek=new_phase_and_peek,
+            fc1_counter_index=base_work.fc1_counter_index,
         )
 
     # --------------------------------------------------------------
@@ -408,3 +419,152 @@ class SwapABSwigluFp4Fc12SchedExtension(MoESchedExtension):
     @cute.jit
     def prefetch_for_expert(self, expert_idx: Int32) -> None:
         """No-op: swap-AB makes every TMA desc tile-invariant in both phases."""
+
+
+class GluMxFp8Fc12SchedExtension(SwapABSwigluFp4Fc12SchedExtension):
+    """Sched extension for the fused fc1+fc2 GLU MXFP8 kernel.
+    """
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        fc1_done_counter_ptr: Pointer,
+        fc2_spin_threshold: Union[int, Int32],
+        fc1_ready_counter_ptr: Optional[Pointer] = None,
+    ):
+        super().__init__(
+            sf_vec_size=sf_vec_size,
+            fc1_done_counter_ptr=fc1_done_counter_ptr,
+            fc2_spin_threshold=fc2_spin_threshold,
+            fc1_ready_counter_ptr=fc1_ready_counter_ptr,
+        )
+
+    def __new_from_mlir_values__(
+            self, values: List[ir.Value]) -> "GluMxFp8Fc12SchedExtension":
+        base = super().__new_from_mlir_values__(values)
+        result = GluMxFp8Fc12SchedExtension.__new__(GluMxFp8Fc12SchedExtension)
+        result.workspace = base.workspace
+        result.sf_vec_size = base.sf_vec_size
+        result.fc1_done_counter_ptr = base.fc1_done_counter_ptr
+        result.fc2_spin_threshold = base.fc2_spin_threshold
+        result.fc1_ready_counter_ptr = base.fc1_ready_counter_ptr
+        return result
+
+    @cute.jit
+    def enrich_work_tile_info(
+        self,
+        base_work: SwapABSwigluFp4Fc12WorkTileInfo,
+    ) -> SwapABSwigluFp4Fc12WorkTileInfo:
+        """Delegate to base; defined here so ``ext`` keeps one MLIR struct across warps."""
+        return SwapABSwigluFp4Fc12SchedExtension.enrich_work_tile_info(
+            self, base_work)
+
+    @cute.jit
+    def prefetch_for_expert(self, expert_idx: Int32) -> None:
+        """No-op on subclass for the same reason as ``enrich_work_tile_info``."""
+
+    @cute.jit
+    def get_gmem_tensor(
+        self,
+        tensor_name: str,
+        gmem_tensor_in_moe_view: cute.Tensor,
+        work_tile_info: SwapABSwigluFp4Fc12WorkTileInfo,
+    ) -> Tuple[cute.Tensor, Optional[Pointer]]:
+        """Phase-invariant GMEM slice for the operands."""
+        expert_idx = work_tile_info.expert_idx
+        data_token_offset = work_tile_info.cumulative_data_physical_row
+        sf_token_offset = work_tile_info.cumulative_sf_physical_row
+
+        shape = gmem_tensor_in_moe_view.shape
+        stride = gmem_tensor_in_moe_view.stride
+        c1 = cutlass.Int32(1)
+        sf_vec_size = self.sf_vec_size
+
+        if cutlass.const_expr(tensor_name == "fc1_activation"):
+            real = cute.domain_offset((data_token_offset, 0, 0),
+                                      gmem_tensor_in_moe_view)
+            real = rewrite_tensor_shape(
+                real, (shape[0], shape[1], c1))  # type: ignore[index]
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "fc1_weight"):
+            real = cute.domain_offset((0, 0, expert_idx),
+                                      gmem_tensor_in_moe_view)
+            real = rewrite_tensor_shape(
+                real, (shape[0], shape[1], c1))  # type: ignore[index]
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "fc1_activation_sf"):
+            real = cute.domain_offset((sf_token_offset, 0, 0),
+                                      gmem_tensor_in_moe_view)
+            per_expert_shape = (shape[0], shape[1], c1)  # type: ignore[index]
+            sf_layout = tile_atom_to_shape_SF(per_expert_shape, sf_vec_size)
+            real = cute.make_tensor(
+                real.iterator, cute.make_layout(sf_layout.shape, stride=stride))
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "fc1_weight_sf"):
+            real = cute.domain_offset((0, 0, expert_idx),
+                                      gmem_tensor_in_moe_view)
+            per_expert_shape = (shape[0], shape[1], c1)  # type: ignore[index]
+            sf_layout = tile_atom_to_shape_SF(per_expert_shape, sf_vec_size)
+            real = cute.make_tensor(
+                real.iterator, cute.make_layout(sf_layout.shape, stride=stride))
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "d"):
+            real = cute.domain_offset((data_token_offset, 0, 0),
+                                      gmem_tensor_in_moe_view)
+            real = rewrite_tensor_shape(
+                real, (shape[0], shape[1], c1))  # type: ignore[index]
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "sfd"):
+            real = cute.domain_offset((sf_token_offset, 0, 0),
+                                      gmem_tensor_in_moe_view)
+            per_expert_shape = (shape[0], shape[1], c1)  # type: ignore[index]
+            sf_layout = tile_atom_to_shape_SF(per_expert_shape, sf_vec_size)
+            real = cute.make_tensor(
+                real.iterator, cute.make_layout(sf_layout.shape, stride=stride))
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "topk"):
+            real = cute.domain_offset((data_token_offset, ),
+                                      gmem_tensor_in_moe_view)
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "fc2_activation"):
+            # fc2 A-side = fc1_output (token-indexed, same formula as "b")
+            real = cute.domain_offset((data_token_offset, 0, 0),
+                                      gmem_tensor_in_moe_view)
+            real = rewrite_tensor_shape(real, (shape[0], shape[1], c1))
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "fc2_activation_sf"):
+            # fc2 SFA = fc1_output_sf (token-indexed sf)
+            real = cute.domain_offset((sf_token_offset, 0, 0),
+                                      gmem_tensor_in_moe_view)
+            per_expert_shape = (shape[0], shape[1], c1)
+            sf_layout = tile_atom_to_shape_SF(per_expert_shape, sf_vec_size)
+            real = cute.make_tensor(
+                real.iterator, cute.make_layout(sf_layout.shape, stride=stride))
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "fc2_weight"):
+            # fc2 B-side = fc2_weight (expert-indexed)
+            real = cute.domain_offset((0, 0, expert_idx),
+                                      gmem_tensor_in_moe_view)
+            real = rewrite_tensor_shape(real, (shape[0], shape[1], c1))
+            return (real, None)
+
+        elif cutlass.const_expr(tensor_name == "fc2_weight_sf"):
+            # fc2 SFB = fc2_weight_sf (expert-indexed)
+            real = cute.domain_offset((0, 0, expert_idx),
+                                      gmem_tensor_in_moe_view)
+            per_expert_shape = (shape[0], shape[1], c1)
+            sf_layout = tile_atom_to_shape_SF(per_expert_shape, sf_vec_size)
+            real = cute.make_tensor(
+                real.iterator, cute.make_layout(sf_layout.shape, stride=stride))
+            return (real, None)
+
+        raise ValueError(f"Unknown tensor_name: {tensor_name!r}.")

--- a/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/epilogue_refactor.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/epilogue_refactor.py
@@ -1,10 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 """Autonomous epilogue for the fused fc1+fc2 swap-AB MegaMoE kernel.
 
-Component boundaries use ``TensorWithContract`` to keep per-thread RMEM layout
-semantics explicit at the handoff between transpose, SwiGLU, quantize, and fc2
-store components.
+Per-thread RMEM tensors flow between the transpose / SwiGLU / quantize / fc2
+store steps as bare ``cute.Tensor`` fragments; their thread distribution is a
+fixed physical property of the surrounding atom sequence and is documented in
+local comments.  A ``Contract`` is only kept where it earns its keep: the fc2
+store-out mapping (``Fc2ProcessPipeline.store_out_mapping``) is evaluated at
+runtime to drive which token/hidden cell each issue targets and therefore how
+the per-token metadata is fetched.
 """
 
 import dataclasses
@@ -19,160 +25,23 @@ from cutlass._mlir import ir
 from cutlass._mlir.dialects import llvm
 from cutlass.cute.nvgpu import cpasync, tcgen05
 from cutlass.cute.typing import AddressSpace
-from cutlass.cutlass_dsl import dsl_user_op
+from cutlass.cutlass_dsl import Int64
 
-from .contract import (Contract, FunctionMapping, Space, TensorWithContract,
-                       assert_contract_equivalent)
+from .contract import Contract, FunctionMapping, Space, eval_function_mapping
 from .fc1_fc2_fuse_sched import BlockPhase
+from .flag_batch import GpuReleaseFlagBatchTracker
 from .iket_compat import iket
 from .megamoe_constants import Nvfp4BlockSize
 from .moe_persistent_scheduler import (MoESchedConsumer, MoESchedExtension,
                                        MoEWorkTileInfo)
+from .ptx_helpers import cp_async_bulk_s2g as _cp_async_bulk_s2g
+from .ptx_helpers import \
+    cp_reduce_async_bulk_add_noftz_bf16_s2g as \
+    _cp_reduce_async_bulk_add_noftz_bf16_s2g
+from .ptx_helpers import \
+    red_add_relaxed_sys_v2_bf16x2 as _red_add_relaxed_sys_v2_bf16x2
 from .sym_buffer import SymBufferDeviceBase
-from .token_comm import TokenCommArgs
-
-# =============================================================================
-# Module-local helpers
-# =============================================================================
-
-
-@dsl_user_op
-def _red_add_relaxed_sys_v2_bf16x2(
-    addr,
-    val0_packed_bf16x2,
-    val1_packed_bf16x2,
-    *,
-    loc: Optional[ir.Location] = None,
-    ip: Optional[ir.InsertionPoint] = None,
-) -> None:
-    """Issue ``red.relaxed.sys.global.add.v2.bf16x2 [addr], {v0, v1};``.
-
-    Used by the fc2 REDG path to atomic-add 4 bf16 cells.  Inline asm is
-    used because cuTeDSL has no vector-form ``red.v2.bf16x2`` surface; the
-    operands are packed bf16x2 bit patterns carried in 32-bit registers.
-    """
-    llvm.inline_asm(
-        None,
-        [
-            addr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
-            val0_packed_bf16x2.ir_value(loc=loc, ip=ip),
-            val1_packed_bf16x2.ir_value(loc=loc, ip=ip),
-        ],
-        "red.relaxed.sys.global.add.noftz.v2.bf16x2 [$0], {$1, $2};",
-        "l,r,r",
-        has_side_effects=True,
-        is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
-        loc=loc,
-        ip=ip,
-    )
-
-
-@dsl_user_op
-def _red_add_release_gpu_s32(
-    counter_ptr,
-    value,
-    *,
-    loc: Optional[ir.Location] = None,
-    ip: Optional[ir.InsertionPoint] = None,
-) -> None:
-    """Issue ``red.release.gpu.add.s32`` to a GMEM int32 location.
-
-    Publishes fc1 task-tile completion after the caller has flushed the fc1
-    output stores.  Single-thread helper; caller guards the thread predicate.
-    """
-    llvm.inline_asm(
-        None,
-        [
-            counter_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
-            value.ir_value(loc=loc, ip=ip),
-        ],
-        "red.release.gpu.global.add.s32 [$0], $1;",
-        "l,r",
-        has_side_effects=True,
-        is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
-        loc=loc,
-        ip=ip,
-    )
-
-
-@dsl_user_op
-def _cp_async_bulk_s2g(
-    dst_gmem,
-    src_smem,
-    size_bytes,
-    *,
-    loc: Optional[ir.Location] = None,
-    ip: Optional[ir.InsertionPoint] = None,
-) -> None:
-    """Issue non-tensor descriptor-free ``cp.async.bulk`` SMEM->GMEM.
-
-    cuTeDSL does expose ``cpasync.CopyBulkS2GOp`` / ``cute.copy`` for this
-    instruction family, but that abstraction bakes the transfer size into
-    the copy atom / static tensor layout: CuteNvGPU lowers it as an
-    ``arch.copy.SM90.bulk_copy_s2g`` op whose ``size`` is an ``I32Attr``.
-    The fc2 UBLK epilogue needs a runtime byte count for the hidden-tail
-    row (still 16B-aligned, but not necessarily the full 128-hidden row).
-    Using the cute copy atom would silently encode the wrong semantic
-    contract, so keep the raw PTX here until the dialect grows a dynamic-size
-    descriptor-free bulk-copy op.
-
-    This helper only issues the instruction.  The caller owns
-    ``cp_async_bulk_commit_group`` so copy and reduce bulk paths share the
-    same group boundary.
-    """
-    # with cute.arch.elect_one():
-    llvm.inline_asm(
-        None,
-        [
-            dst_gmem.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
-            src_smem.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
-            size_bytes.ir_value(loc=loc, ip=ip),
-        ],
-        "cp.async.bulk.global.shared::cta.bulk_group [$0], [$1], $2;",
-        "l,r,r",
-        has_side_effects=True,
-        is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
-        loc=loc,
-        ip=ip,
-    )
-
-
-@dsl_user_op
-def _cp_reduce_async_bulk_add_noftz_bf16_s2g(
-    dst_gmem,
-    src_smem,
-    size_bytes,
-    *,
-    loc: Optional[ir.Location] = None,
-    ip: Optional[ir.InsertionPoint] = None,
-) -> None:
-    """Issue non-tensor ``cp.reduce.async.bulk`` for BF16 add.
-
-    cuTeDSL currently exposes descriptor-free ``CopyBulkS2GOp`` but not the
-    matching descriptor-free reduce atom.  Keep the fallback local to this
-    epilogue path so the rest of the bulk pipeline can still share the same
-    tensor/layout front-end.
-    """
-    # with cute.arch.elect_one():
-    llvm.inline_asm(
-        None,
-        [
-            dst_gmem.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
-            src_smem.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
-            size_bytes.ir_value(loc=loc, ip=ip),
-        ],
-        "cp.reduce.async.bulk.global.shared::cta.bulk_group.add.noftz.bf16 [$0], [$1], $2;",
-        "l,r,r",
-        has_side_effects=True,
-        is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
-        loc=loc,
-        ip=ip,
-    )
-
+from .token_comm import TokenCommArgs, TokenSrcMetadata
 
 # =============================================================================
 # Region tag
@@ -192,42 +61,20 @@ class Region:
 
 
 class _TmemTranspose16x32Core:
-    """Contract-naive physical implementation of the 16x32 -> 32x16 TMEM
-    in-place transpose.  Shared by:
+    """Physical implementation of the 16x32 -> 32x16 TMEM in-place transpose.
 
-      - ``TmemTranspose16x32``       : fc1 epi codomain naming
-                                       (``intermediate_output_idx``);
-                                       elements are fp32 (swiglu fold output).
-      - ``TmemTranspose16x32Packed`` : fc2 epi codomain naming
-                                       (``hidden_pair_idx``); elements are
-                                       32-bit packed ``(bf16, bf16)`` pairs.
+    The transpose is a fixed sequence of tcgen05 32-bit element atoms; each
+    32-bit slot is opaque to it (an fp32 swiglu-fold value for fc1, or a packed
+    ``(bf16, bf16)`` pair for fc2 -- the physical (lane_idx, elem_idx)
+    distribution is identical either way).  The (thread, reg) -> (tmem_dp,
+    tmem_col) input / output mapping is documented on the ``TmemTranspose16x32``
+    subclass, which is the public entry point.
 
-    The (lane_idx, elem_idx) physical distribution is identical for both
-    subclasses -- the underlying tcgen05 atoms are 32-bit element atoms,
-    agnostic to whether each 32-bit slot holds an fp32 or a packed bf16x2.
-    Only the codomain semantic names differ, expressed via the subclass's
-    ``InputContract`` / ``OutputContract`` class attributes.
-
-    Per-thread RMEM coordinate convention (used by both subclasses' contracts):
+    Per-thread RMEM coordinate convention:
 
       - ``lane_idx`` -- warp lane id (= thread index within warp), in [0, 32).
       - ``elem_idx`` -- per-thread reg index, in [0, 16).
-
-    Subclasses MUST override these two class attributes:
-      ``InputContract``  -- (lane_idx, elem_idx) -> codomain mapping after
-                            R1.Load (or after ``reg_tensor`` is fed in for
-                            skip-R1.Load mode).
-      ``OutputContract`` -- (lane_idx, elem_idx) -> codomain mapping after
-                            ``r4_perm`` has run all four rounds.
-
-    The Core's ``__init__`` reads ``self.InputContract`` / ``self.OutputContract``
-    via Python's normal MRO attribute lookup; the subclass's overrides take
-    precedence at construction time.
     """
-
-    # Subclasses MUST override these.
-    InputContract: Contract
-    OutputContract: Contract
 
     _PermR1 = (0, 8, 2, 10, 4, 12, 6, 14, 1, 9, 3, 11, 5, 13, 7, 15)
     _PermR3 = (0, 1, 4, 5, 2, 3, 6, 7, 8, 9, 12, 13, 10, 11, 14, 15)
@@ -270,24 +117,19 @@ class _TmemTranspose16x32Core:
         ``warp_lane_offset + acc_stage_col_offset + subtile_col_offset``;
         see ``SwapABSwigluFp4Epilogue._subtile_local_tmem_tensor``).
 
-        Returns a 4-tuple of (16,) fp32 RMEM tensors, each carrying
-        the (lane_idx, elem_idx) -> codomain distribution described by
-        ``TmemTranspose16x32.InputContract`` /
-        ``TmemTranspose16x32Packed.InputContract`` (physically identical
-        for fc1 and fc2, only codomain semantic names differ):
+        Returns a 4-tuple of (16,) fp32 RMEM tensors, each carrying the
+        (lane_idx, elem_idx) input distribution documented on
+        ``TmemTranspose16x32`` (physically identical for fc1 and fc2):
 
           [0] gate_lo / first-half top   -- subtile cols 0..31, lanes 0..15
           [1] up_lo   / first-half bot   -- subtile cols 0..31, lanes 16..31
           [2] raw_top / second-half top  -- subtile cols 32..63, lanes 0..15
           [3] raw_bot / second-half bot  -- subtile cols 32..63, lanes 16..31
 
-        4 atom calls of ``Ld16x64bOp(Repetition.x16) Float32`` -- the
-        same atom currently used by the per-subtile entry LDTM in
-        ``_run_fc1_subtile`` and by ``second_t.r1_load`` /
-        ``Fc2AccLoadAndPack`` per-half LDTMs.  Caller is expected to
-        wrap each output in ``TensorWithContract`` with
-        ``TmemTranspose16x32{,Packed}.InputContract`` before handing
-        them downstream.
+        4 atom calls of ``Ld16x64bOp(Repetition.x16) Float32`` -- the same
+        atom used by the per-subtile entry LDTM.  Each output is in the
+        ``TmemTranspose16x32`` input distribution and can be fed straight
+        into a transpose as ``reg_tensor`` (skip-R1.Load mode).
         """
         atom_ld16x64 = cute.make_copy_atom(
             tcgen05.Ld16x64bOp(tcgen05.Repetition.x16),
@@ -358,8 +200,18 @@ class _TmemTranspose16x32Core:
         self,
         tmem_ptr,
         region: int,
-        reg_tensor: Optional[TensorWithContract] = None,
+        reg_tensor: Optional[cute.Tensor] = None,
     ) -> None:
+        # The whole transpose is built from 32-bit element atoms; _io_dtype
+        # drives _src_regs / output / every LDTM/STTM atom below, so guard the
+        # invariant once here (tautological today, defensive against future
+        # dtype edits).
+        if cutlass.const_expr(self._io_dtype.width != 32):
+            raise TypeError(
+                f"{type(self).__name__} requires a 32-bit _io_dtype (the "
+                f"transpose uses 32-bit element atoms), got {self._io_dtype} "
+                f"(width {self._io_dtype.width}).")
+
         half_lane_off = 16 * self._TmemRowStride
         if region == Region.Top:
             src_ptr = tmem_ptr
@@ -403,21 +255,31 @@ class _TmemTranspose16x32Core:
         )
 
         self._src_regs = cute.make_rmem_tensor((16, ), self._io_dtype)
-        output_tensor = cute.make_rmem_tensor((16, ), self._io_dtype)
-        self.output = TensorWithContract(
-            tensor=output_tensor,
-            contract=self.OutputContract,
-        )
+        # ``output`` is a bare (16,) RMEM fragment; its (lane_idx, elem_idx)
+        # distribution after all four rounds is the transpose output mapping
+        # documented on ``TmemTranspose16x32``.
+        self.output = cute.make_rmem_tensor((16, ), self._io_dtype)
 
+        # skip-R1.Load mode: ``reg_tensor`` must already be in the transpose
+        # input distribution (see ``TmemTranspose16x32`` / produced by
+        # ``load_subtile_raw_acc``); we copy it in lieu of the R1 LDTM.
+        # Weak entry guard (replaces the removed input contract): the transpose
+        # atoms are 32-bit element atoms over exactly 16 regs/lane, so the fed
+        # tensor must be a 32-bit element type (fp32 or packed bf16x2) of size 16.
         self._reg_tensor = reg_tensor
         if reg_tensor is not None:
-            assert_contract_equivalent(
-                reg_tensor.contract,
-                self.InputContract,
-                context=f"{type(self).__name__} skip-R1.Load reg_tensor",
-            )
+            if cutlass.const_expr(reg_tensor.element_type.width != 32):
+                raise TypeError(
+                    f"{type(self).__name__} reg_tensor must be a 32-bit element "
+                    f"type (fp32 or packed bf16x2), got element type "
+                    f"{reg_tensor.element_type} (width {reg_tensor.element_type.width})."
+                )
+            if cutlass.const_expr(cute.size(reg_tensor) != 16):
+                raise ValueError(
+                    f"{type(self).__name__} reg_tensor must hold exactly 16 "
+                    f"elements, got {cute.size(reg_tensor)}.")
             for r in range(16):
-                self._src_regs[r] = reg_tensor.tensor[r]
+                self._src_regs[r] = reg_tensor[r]
 
     # -- R1 ------------------------------------------------------------------
 
@@ -433,12 +295,12 @@ class _TmemTranspose16x32Core:
 
     def r1_perm(self) -> None:
         for r in range(16):
-            self.output.tensor[r] = self._src_regs[self._PermR1[r]]
+            self.output[r] = self._src_regs[self._PermR1[r]]
 
     def r1_store(self) -> None:
         cute.copy(
             self._atom_st16x128,
-            self._rmem_copy_view(self.output.tensor, 16),
+            self._rmem_copy_view(self.output, 16),
             self._tmem_src_full,
         )
 
@@ -476,12 +338,12 @@ class _TmemTranspose16x32Core:
 
     def r3_perm(self) -> None:
         for r in range(16):
-            self.output.tensor[r] = self._src_regs[self._PermR3[r]]
+            self.output[r] = self._src_regs[self._PermR3[r]]
 
     def r3_store(self) -> None:
         cute.copy(
             self._atom_st32x32,
-            self._rmem_copy_view(self.output.tensor, 16),
+            self._rmem_copy_view(self.output, 16),
             self._tmem_dst_full,
         )
 
@@ -503,12 +365,12 @@ class _TmemTranspose16x32Core:
 
     def r4_perm(self) -> None:
         for r in range(16):
-            self.output.tensor[r] = self._src_regs[self._PermR4[r]]
+            self.output[r] = self._src_regs[self._PermR4[r]]
 
     def r4_store(self) -> None:
         cute.copy(
             self._atom_st32x32,
-            self._rmem_copy_view(self.output.tensor, 16),
+            self._rmem_copy_view(self.output, 16),
             self._tmem_dst_full,
         )
 
@@ -528,64 +390,28 @@ class _TmemTranspose16x32Core:
 
 
 class TmemTranspose16x32(_TmemTranspose16x32Core):
-    """fc1 epi 16x32 -> 32x16 TMEM in-place transpose.
+    """Public 16x32 -> 32x16 TMEM in-place transpose.
 
-    Contract summary:
-      - input : ``token_idx = elem_idx * 2 + ((lane_idx // 2) % 2)``
-      - output: ``token_idx = lane_idx``
-    The second codomain axis is ``intermediate_output_idx``.
+    The per-thread RMEM ``(lane_idx, elem_idx) -> (tmem_dp, tmem_col)`` mapping
+    is fixed by the underlying atom sequence and is identical for fc1 (each slot
+    is an fp32 swiglu-fold value, ``tmem_col`` = intermediate-output index) and
+    fc2 (each slot is a packed bf16x2, ``tmem_col`` = hidden-pair index).  Only
+    the ``tmem_col`` semantic name differs between the two uses; the physical
+    distribution below is the single source of truth.
+
+    Input distribution -- what each (lane_idx, elem_idx) reg holds on entry
+    (i.e. straight after the 16-dp x 32-col source LDTM, or as fed in via
+    ``reg_tensor`` / ``load_subtile_raw_acc`` for skip-R1.Load mode):
+
+        tmem_dp  = elem_idx * 2 + (lane_idx // 2) % 2          # in [0, 32)
+        tmem_col = (lane_idx % 2) * 8 + lane_idx // 4          # in [0, 16)
+
+    Output distribution -- after all four rounds, the 32-dp x 16-col result has
+    each lane owning one full dp-row of 16 cols:
+
+        tmem_dp  = lane_idx                                    # in [0, 32)
+        tmem_col = elem_idx                                    # in [0, 16)
     """
-
-    _domain = Space(("lane_idx", "elem_idx"), (32, 16))
-    _codomain = Space(("token_idx", "intermediate_output_idx"), (32, 16))
-
-    InputContract = Contract(
-        domain=_domain,
-        codomain=_codomain,
-        mapping=FunctionMapping(
-            lambda lane_idx, elem_idx: {
-                "token_idx": elem_idx * 2 + ((lane_idx // 2) % 2),
-                "intermediate_output_idx": (lane_idx % 2) * 8 + lane_idx // 4,
-            }),
-    )
-    OutputContract = Contract(
-        domain=_domain,
-        codomain=_codomain,
-        mapping=FunctionMapping(lambda lane_idx, elem_idx: {
-            "token_idx": lane_idx,
-            "intermediate_output_idx": elem_idx,
-        }),
-    )
-
-
-class TmemTranspose16x32Packed(_TmemTranspose16x32Core):
-    """fc2 epi 16x32 -> 32x16 TMEM in-place transpose, 32-bit packed
-    bf16x2 elements.
-
-    Same physical atom sequence as ``TmemTranspose16x32``; codomain is
-    ``(token_idx, hidden_pair_idx)`` and each slot holds one packed bf16x2.
-    """
-
-    _domain = Space(("lane_idx", "elem_idx"), (32, 16))
-    _codomain = Space(("token_idx", "hidden_pair_idx"), (32, 16))
-
-    InputContract = Contract(
-        domain=_domain,
-        codomain=_codomain,
-        mapping=FunctionMapping(
-            lambda lane_idx, elem_idx: {
-                "token_idx": elem_idx * 2 + ((lane_idx // 2) % 2),
-                "hidden_pair_idx": (lane_idx % 2) * 8 + lane_idx // 4,
-            }),
-    )
-    OutputContract = Contract(
-        domain=_domain,
-        codomain=_codomain,
-        mapping=FunctionMapping(lambda lane_idx, elem_idx: {
-            "token_idx": lane_idx,
-            "hidden_pair_idx": elem_idx,
-        }),
-    )
 
 
 # =============================================================================
@@ -604,8 +430,8 @@ class TmemTranspose32x32Inplace:
     def __init__(
         self,
         tmem_ptr,
-        reg_tensor_top: Optional[TensorWithContract] = None,
-        reg_tensor_bot: Optional[TensorWithContract] = None,
+        reg_tensor_top: Optional[cute.Tensor] = None,
+        reg_tensor_bot: Optional[cute.Tensor] = None,
     ) -> None:
         if (reg_tensor_top is None) != (reg_tensor_bot is None):
             raise ValueError(
@@ -709,6 +535,8 @@ class SwapABSwigluFp4Epilogue:
             static_expert_shape: Optional[Tuple[
                 int, int, int]] = None,  # [expert, intermediate, hidden]
             gate_up_clamp: Optional[float] = None,  # Swiglu style only
+            epi_flag_batch: Optional[Tuple[int, int]] = (
+                1, 1),  # (fc1, fc2) done-counter publish batch
     ) -> None:
         if fc1_output_dtype is not cutlass.Float4E2M1FN:
             raise NotImplementedError(
@@ -733,23 +561,27 @@ class SwapABSwigluFp4Epilogue:
         self.sf_vec_size = sf_vec_size
         # Swiglu gate/up clamp limit; None disables clamping.
         self.gate_up_clamp = gate_up_clamp
-        self.cluster_tile_intermediate_downproj = (
-            self._EpilogueFc1IntermediateDownTileSize * cluster_shape_mn[0])
+        # Done-counter publish batch granularity
+        _fc1_eb, _fc2_eb = (1, 1) if epi_flag_batch is None else epi_flag_batch
+        self.fc1_epi_flag_batch = max(1, min(32, int(_fc1_eb)))
+        self.fc2_epi_flag_batch = max(1, min(32, int(_fc2_eb)))
+        self.cluster_tile_intermediate_downproj = self._EpilogueFc1IntermediateDownTileSize * cluster_shape_mn[
+            0]
 
         atom_thr_size = 2 if use_2cta_instrs else 1
         self.cta_tile_m = self._EpilogueFc2HiddenTileSize
         self.cta_tile_n = mma_tiler_mnk[1]
         self.cta_tile_k = mma_tiler_mnk[2]
-        assert mma_tiler_mnk[0] // atom_thr_size == self.cta_tile_m
-        assert self.cta_tile_n % self._EpilogueTokenTileSize == 0
+        assert (mma_tiler_mnk[0] // atom_thr_size == self.cta_tile_m)
+        assert (self.cta_tile_n % self._EpilogueTokenTileSize == 0)
         self.static_expert_shape = static_expert_shape
         self.acc_tmem_cols = self.cta_tile_n
         self.acc_sf_cols = (max(self.cta_tile_n // 128, 1) * self.cta_tile_k +
                             max(self.cta_tile_m // 128, 1) *
                             self.cta_tile_k) // self.sf_vec_size
 
-        if (static_expert_shape is not None and static_expert_shape[2] %
-            (self.cta_tile_m * cluster_shape_mn[0]) == 0):
+        if static_expert_shape is not None and static_expert_shape[2] % (
+                self.cta_tile_m * cluster_shape_mn[0]) == 0:
             self.fc2_hidden_needs_predicate: bool = False
         else:
             self.fc2_hidden_needs_predicate: bool = True
@@ -766,19 +598,17 @@ class SwapABSwigluFp4Epilogue:
         self.num_acc_stage = 2
         self.num_acc_pipeline_stages = 1 if self.overlapping_accum else self.num_acc_stage
         self.overlapped_tmem_cols = self._EpilogueTokenTileSize if self.overlapping_accum else 0
-        assert not self.overlapping_accum or self.overlapped_tmem_cols >= self.acc_sf_cols
+        assert (not self.overlapping_accum
+                or self.overlapped_tmem_cols >= self.acc_sf_cols)
         self.epi_smem_bytes = 8 * 1024
         if self.fc1_output_dtype.width > 4:
             raise NotImplementedError(
                 "Remember to adjust the smem size when switch to mxfp8 support")
-        self.tmem_acc_layout_py_obj = (
-            (self.cta_tile_m, self.cta_tile_n, self.num_acc_stage),
-            (
-                _TmemTranspose16x32Core._TmemRowStride,
-                1,
-                self.cta_tile_n - self.overlapped_tmem_cols,
-            ),
-        )
+        self.tmem_acc_layout_py_obj = ((self.cta_tile_m, self.cta_tile_n,
+                                        self.num_acc_stage),
+                                       (_TmemTranspose16x32Core._TmemRowStride,
+                                        1, self.cta_tile_n -
+                                        self.overlapped_tmem_cols))
 
     def get_epi_storage_type(self) -> Type:
         # This could be extended to take atoms space for the larger sf_vec_size quant.
@@ -841,17 +671,10 @@ class SwapABSwigluFp4Epilogue:
             ),
         )
 
-        fc1_epi = SwapABFc1Epilogue(
-            self,
-            tidx,
-            epi_smem_storage,
-            sched_ext,
-            tma_atom_fc1_output,
-            fc1_output,
-            fc1_output_sf,
-            fc1_done_counter,
-            optional_epi_args,
-        )
+        fc1_epi = SwapABFc1Epilogue(self, tidx, epi_smem_storage, sched_ext,
+                                    tma_atom_fc1_output, fc1_output,
+                                    fc1_output_sf, fc1_done_counter,
+                                    optional_epi_args)
         fc2_epi = SwapABFc2Epilogue(self, tidx, epi_smem_storage, fc2_output,
                                     token_comm_args, optional_epi_args)
 
@@ -862,8 +685,15 @@ class SwapABSwigluFp4Epilogue:
             num_threads=32 * self._EpilogueWarpCnt,
         )
         is_odd_turn = cutlass.Int32(1)
-
         work_tile_info = sched_consumer.consume_work()
+
+        flag_tracker = GpuReleaseFlagBatchTracker(
+            flag_addr=Int64(0),
+            cumulated_flags=cutlass.Int32(0),
+            phase=cutlass.Int32(work_tile_info.phase),
+            tid=tidx % (self._EpilogueWarpCnt * 32),
+        )
+
         while work_tile_info.is_valid_tile:
             if cutlass.const_expr(self.overlapping_accum):
                 tmem_stage_idx = acc_consumer_state.phase
@@ -904,20 +734,38 @@ class SwapABSwigluFp4Epilogue:
             if cur_was_linear1:
                 cute.arch.cp_async_bulk_commit_group()
                 cute.arch.cp_async_bulk_wait_group(0, read=True)
-                cute.arch.fence_acq_rel_gpu()
-            elif cutlass.const_expr(self.token_back_by_dispatch):
-                cute.arch.fence_acq_rel_gpu()
+            # _fence_rel_gpu()
             wait_only_named_barrier.arrive_and_wait()
 
             # Publish completion for the work tile snapshotted above.
             if cur_was_linear1:
-                fc1_epi.signal_fc1_done(prev_work_tile_info)
+                flag_tracker = fc1_epi.signal_fc1_done(prev_work_tile_info,
+                                                       work_tile_info,
+                                                       flag_tracker)
             else:
-                fc2_epi.signal_fc2_done(prev_work_tile_info)
+                flag_tracker = fc2_epi.signal_fc2_done(prev_work_tile_info,
+                                                       work_tile_info,
+                                                       flag_tracker)
+        # Tail flush
+        flag_tracker.fire()
+
+
+class _ImmutableAfterInit:
+    """Froze at the point calling `_freeze()`"""
+
+    def __setattr__(self, name, value):
+        if self.__dict__.get("_frozen_", False):
+            raise AttributeError(
+                f"{type(self).__name__} is immutable after __init__ "
+                f"(cannot set {name!r}).")
+        object.__setattr__(self, name, value)
+
+    def _freeze(self) -> None:
+        object.__setattr__(self, "_frozen_", True)
 
 
 # Device only object
-class SwapABFc1Epilogue:
+class SwapABFc1Epilogue(_ImmutableAfterInit):
 
     def __init__(
         self,
@@ -953,6 +801,7 @@ class SwapABFc1Epilogue:
         self.fc1_output_sf = fc1_output_sf
         self.fc1_done_counter = fc1_done_counter
         self.optional_epi_args = optional_epi_args
+        self._freeze()
 
     def __getattr__(self, name):
         return getattr(object.__getattribute__(self, "base"), name)
@@ -971,8 +820,9 @@ class SwapABFc1Epilogue:
         return self
 
     @cute.jit
-    def signal_fc1_done(self, work_tile_info):
-        # Only in-bound intermediate_downproj tiles signal
+    def signal_fc1_done(self, work_tile_info, next_work_tile_info,
+                        flag_tracker):
+        # Only in-bound intermediate_downproj tiles signal; OOB -> null slot.
         if cutlass.const_expr(self.static_expert_shape is None
                               or self.intermediate_downproj %
                               self.cluster_tile_intermediate_downproj != 0):
@@ -981,23 +831,25 @@ class SwapABFc1Epilogue:
                         < self.fc1_output.shape[1])
         else:
             in_bound = True
+        slot = (work_tile_info.cumulative_token_block_count +
+                work_tile_info.tile_n_idx)
+        flag_addr = Int64(0)
         if in_bound:
-            if self.tidx == 0:
-                slot = work_tile_info.cumulative_token_block_count + work_tile_info.tile_n_idx
-                _red_add_release_gpu_s32(
-                    self.fc1_done_counter.iterator + slot,
-                    cutlass.Int32(1),
-                )
+            flag_addr = (self.fc1_done_counter.iterator + slot).toint()
+        return flag_tracker.accumulate(
+            next_work_tile_info.phase,
+            self.fc1_epi_flag_batch,
+            flag_addr,
+        )
 
     @cute.jit
     def __call__(
-        self,
-        work_tile_info: MoEWorkTileInfo,
-        tmem_acc_tensor: cute.Tensor,  # (cta_tile_m, cta_tile_n)
-        acc_pipeline,
-        acc_consumer_state,
-        is_odd_turn: cutlass.Int32,
-    ):
+            self,
+            work_tile_info: MoEWorkTileInfo,
+            tmem_acc_tensor: cute.Tensor,  # (cta_tile_m, cta_tile_n)
+            acc_pipeline,
+            acc_consumer_state,
+            is_odd_turn: cutlass.Int32):
         # (tokens_this_expert, intermediate_down, 1)
         real_fc1_output, _ = self.sched_ext.get_gmem_tensor(
             "c",
@@ -1024,10 +876,8 @@ class SwapABFc1Epilogue:
             norm_const = None
         # (cta_tile_m, cta_tile_n) -> (epi_tile_m, epi_tile_n, iters)
         tmem_acc_tensor_tiled_by_epi_tile = cute.flat_divide(
-            tmem_acc_tensor,
-            (self._EpilogueFc1IntermediateGateUpTileSize,
-             self._EpilogueTokenTileSize),
-        )[None, None, 0, None]
+            tmem_acc_tensor, (self._EpilogueFc1IntermediateGateUpTileSize,
+                              self._EpilogueTokenTileSize))[None, None, 0, None]
 
         acc_pipeline.consumer_wait(acc_consumer_state)
         iket.range_push("fc1_epi")
@@ -1055,9 +905,9 @@ class SwapABFc1Epilogue:
             # the tmem transpose consumes them.
             preload_subtile_first: Tuple[
                 cute.Tensor, cute.Tensor, cute.Tensor,
-                cute.Tensor] = (_TmemTranspose16x32Core.load_subtile_raw_acc(
+                cute.Tensor] = _TmemTranspose16x32Core.load_subtile_raw_acc(
                     tmem_acc_tensor_tiled_by_epi_tile[None, None,
-                                                      subtile_idx_first]))
+                                                      subtile_idx_first])
 
             # Release acc to next MMA unconditionally.
             cute.arch.fence_view_async_tmem_load()
@@ -1068,9 +918,9 @@ class SwapABFc1Epilogue:
             # quadrant/offset invariants and opaque per-lane layout as above.
             preload_subtile_second: Tuple[
                 cute.Tensor, cute.Tensor, cute.Tensor,
-                cute.Tensor] = (_TmemTranspose16x32Core.load_subtile_raw_acc(
+                cute.Tensor] = _TmemTranspose16x32Core.load_subtile_raw_acc(
                     tmem_acc_tensor_tiled_by_epi_tile[None, None,
-                                                      subtile_idx_second]))
+                                                      subtile_idx_second])
 
             # Both unrolled subtiles borrow tmem_subtile_second as workspace.
             preload_pair = (preload_subtile_first, preload_subtile_second)
@@ -1153,13 +1003,10 @@ class SwapABFc1Epilogue:
             work_tile_info.tile_n_idx * self.cta_tile_n +
             subtile_idx * self._EpilogueTokenTileSize + self.lane_idx,
             work_tile_info.tile_n_idx * self.cta_tile_n +
-            subtile_idx * self._EpilogueTokenTileSize + self.lane_idx + 32,
-        )
+            subtile_idx * self._EpilogueTokenTileSize + self.lane_idx + 32)
         if cutlass.const_expr(topk_score_tensor is not None):
-            topk_scores = (
-                topk_score_tensor[current_two_token_idices[0]],
-                topk_score_tensor[current_two_token_idices[1]],
-            )
+            topk_scores = (topk_score_tensor[current_two_token_idices[0]],
+                           topk_score_tensor[current_two_token_idices[1]])
         else:
             topk_scores = None
 
@@ -1213,52 +1060,44 @@ class SwapABFc1Epilogue:
         token_0_32_pre_quant_pre_trans = self.alpha_swiglu_clamp(
             gate_token_0_32, up_token_0_32, alpha_val)
 
+        # gate_token_32_64 / up_token_32_64 are already in the transpose input
+        # distribution (see TmemTranspose16x32 / load_subtile_raw_acc).
         token_32_64_tmem_trans = TmemTranspose32x32Inplace(
             tmem_subtile_tensor.iterator,
-            reg_tensor_top=TensorWithContract(
-                tensor=gate_token_32_64,
-                contract=TmemTranspose16x32.InputContract,
-            ),
-            reg_tensor_bot=TensorWithContract(
-                tensor=up_token_32_64,
-                contract=TmemTranspose16x32.InputContract,
-            ),
+            reg_tensor_top=gate_token_32_64,
+            reg_tensor_bot=up_token_32_64,
         )
 
-        # (epi_tid, vid) -> (token_idx, intermediate_output_idx), each lane hold (token_1, intermediate_16) in this rmem tensor.
-        gate_token_32_64_trans_pre_act, up_token_32_64_trans_pre_act = (
-            token_32_64_tmem_trans.from_r1_perm_until_last_store())
+        # Transpose output: each lane holds (token_1, intermediate_16); tmem_dp
+        # = lane_idx (token), tmem_col = elem_idx (intermediate output idx).
+        gate_token_32_64_trans_pre_act, up_token_32_64_trans_pre_act = token_32_64_tmem_trans.from_r1_perm_until_last_store(
+        )
 
         token_32_64_pre_quant = self.alpha_swiglu_clamp(
-            gate_token_32_64_trans_pre_act.tensor,
-            up_token_32_64_trans_pre_act.tensor,
+            gate_token_32_64_trans_pre_act,
+            up_token_32_64_trans_pre_act,
             alpha_val,
         )
 
         token_0_32_tmem_trans = TmemTranspose16x32(
             tmem_subtile_tensor.iterator,
             Region.Top,
-            reg_tensor=TensorWithContract(
-                tensor=token_0_32_pre_quant_pre_trans,
-                contract=TmemTranspose16x32.InputContract,
-            ),
+            reg_tensor=token_0_32_pre_quant_pre_trans,
         )
         token_0_32_pre_quant = token_0_32_tmem_trans.from_r1_perm_until_last_store(
-        ).tensor
-
-        # Step 2: Quant
-        self.nvfp4_quant(
-            work_tile_info=work_tile_info,
-            two_token=(token_0_32_pre_quant, token_32_64_pre_quant),
-            topk_scores=topk_scores,
-            norm_const=norm_const,
-            intermediate_output_size=cute.size(fc1_output, 1),
-            fc1_output_sf=fc1_output_sf,
-            subtile_idx=subtile_idx,
         )
 
+        # Step 2: Quant
+        self.nvfp4_quant(work_tile_info=work_tile_info,
+                         two_token=(token_0_32_pre_quant,
+                                    token_32_64_pre_quant),
+                         topk_scores=topk_scores,
+                         norm_const=norm_const,
+                         intermediate_output_size=cute.size(fc1_output, 1),
+                         fc1_output_sf=fc1_output_sf,
+                         subtile_idx=subtile_idx)
+
         # Step 3: TMASTG
-        cute.arch.fence_proxy("async.shared", space="cta")
         # (token_64, intermeidate_64)
         fc1_smem = self.smem_tensor[None, None, subtile_idx]
         # (token, intermediate_down, l=1) -> (cta_token, cta_intermediate_down)
@@ -1270,8 +1109,8 @@ class SwapABFc1Epilogue:
         fc1_gmem_subtile_view = cute.flat_divide(
             fc1_gmem_cta_view,
             (self._EpilogueTokenTileSize,
-             self._EpilogueFc1IntermediateDownTileSize),
-        )[None, None, subtile_idx, 0]
+             self._EpilogueFc1IntermediateDownTileSize))[None, None,
+                                                         subtile_idx, 0]
         tma_smem_src, tma_gmem_dst = cpasync.tma_partition(
             self.fc1_tma_atom,
             0,
@@ -1286,6 +1125,7 @@ class SwapABFc1Epilogue:
             barrier_id=subtile_bar_id,
             num_threads=self._EpilogueWarpCnt * 32,
         )
+        cute.arch.fence_proxy("async.shared", space="cta")
         if self.warp_idx == subtile_idx:
             tma_ready_to_read_smem_named_barrier.arrive_and_wait()
             with cute.arch.elect_one():
@@ -1300,7 +1140,7 @@ class SwapABFc1Epilogue:
         Tensor,  # Raw fc1 acc (pre-dequant); even-size 1D fp32 rmem
         up_rmem: cute.
         Tensor,  # Raw fc1 acc (pre-dequant); even-size 1D fp32 rmem
-        alpha_val: Optional[cutlass.Float32],
+        alpha_val: Optional[cutlass.Float32]
     ) -> cute.Tensor:
         # ── Input contract checks (compile-time): fp32, 1D, even-count, rmem ──
         # Wrapped in const_expr so the DSL evaluates them at trace time and the
@@ -1443,8 +1283,7 @@ class SwapABFc1Epilogue:
         intermediate_output_size: cutlass.Int32,
         fc1_output_sf: cute.
         Tensor,  # MoE domain (token_this_rank, intermediate_down, 1)
-        subtile_idx: cutlass.Int32,
-    ):
+        subtile_idx: cutlass.Int32):
         _Nvfp4RcpLimit = 1.0 / 6.0  # 1 / max abs of Float4E2M1FN (= 6.0)
         _Fp32Max = 3.40282346638528859812e38
         # ``two_token`` are the two post-swiglu, transposed token rmem tensors;
@@ -1562,891 +1401,22 @@ class SwapABFc1Epilogue:
             )
 
 
-"""
-Acc to pre-store process:
-    some kind of ldtm -> f2fp -> some kind of reorder
-
-Pre-store status:
-    (epi_tid, vid) -> rmem x (token, hidden)
-
-Store process:
-    Mapping: (epi_tid, iter_idx) -> (token, topk, hidden).
-    This defines in each sending, which thread(s) send which part to which dst. However, this is impl-irrevalent.
-    Always starts at rmem x (token, hidden)?
-"""
-
-
-def eval_function_mapping(contract: Contract, **domain_coord):
-    """Evaluate a FunctionMapping contract at runtime.
-
-    This is intentionally local to the fc2 epilogue refactor for now.  It only
-    supports FunctionMapping-backed contracts whose Python function can run in
-    CuTe tracing context; table-backed runtime eval can be designed later in
-    contract.py.
-    """
-    if not isinstance(contract.mapping, FunctionMapping):
-        raise TypeError("runtime contract eval requires a FunctionMapping")
-
-    result = contract.mapping.function(**domain_coord)
-    if isinstance(result, dict):
-        return result
-    if isinstance(result, (tuple, list)):
-        if len(result) != contract.codomain.rank:
-            raise ValueError(
-                "FunctionMapping result rank does not match codomain rank: "
-                f"{len(result)} vs {contract.codomain.rank}")
-        return {
-            name: result[i]
-            for i, name in enumerate(contract.codomain.names)
-        }
-    if contract.codomain.rank == 1:
-        return {contract.codomain.names[0]: result}
-    raise TypeError(
-        "FunctionMapping runtime eval must return dict/tuple/list, or scalar for rank-1 codomain"
-    )
-
-
 @dataclasses.dataclass(frozen=True)
-class Fc2OutputRouter:
-    # (token, 3), 3 -> rank_idx, token_idx, top_k
-    # Later this will be changed to (token, 2), where top_k and rank_idx will be fused into 32bit.
-    # If metadata is None then this is a local write.
-    metadata: Optional[cute.Tensor]
-    direct_token_base_this_cta_tile: Optional[cutlass.Int32]
-    base_output: cute.Tensor  # (token, topk, hidden)
-    hidden_base_this_cta_tile: Union[cutlass.Int32, int]
-    peer_rank_ptr_mapper: Optional[SymBufferDeviceBase]
-    valid_tokens_this_cta_tile: cutlass.Int32
-    valid_hidden_this_cta_tile: Union[cutlass.Int32, int]
-    reduce_topk_in_kernel: bool
-    output_mapping: Contract  # (epi_tid, iter_idx) -> (token_cta_tile, hidden_cta_tile).
-    epi_tid: cutlass.Int32
-
-    # After metadata prefetch
-    dst_ptrs: Optional[cute.Tensor] = (
-        None  # i64 x (copy_iters_this_thread_cta_tile), fundamentally the pointers.
-    )
-    valid: Optional[cute.Tensor] = None  # (copy_iters_this_thread_cta_tile)
-
-    def __post_init__(self) -> None:
-        if (self.metadata is None) == (self.direct_token_base_this_cta_tile
-                                       is None):
-            raise ValueError(
-                "Fc2OutputRouter requires exactly one of metadata or "
-                "direct_token_base_this_cta_tile.")
-        if (self.metadata is None) != (self.peer_rank_ptr_mapper is None):
-            raise ValueError(
-                "Fc2OutputRouter requires peer_rank_ptr_mapper iff metadata is set."
-            )
-        if self.reduce_topk_in_kernel and self.metadata is None:
-            raise ValueError(
-                "Fc2OutputRouter reduce_topk_in_kernel requires metadata routing."
-            )
-
-    @cute.jit
-    def prefetch(self) -> "Fc2OutputRouter":
-        iter_axis = self.output_mapping.domain.names.index("iter_idx")
-        copy_iters: cutlass.Constexpr[int] = self.output_mapping.domain.sizes[
-            iter_axis]
-
-        valid = cute.make_rmem_tensor((copy_iters, ), cutlass.Int32)
-        dst_ptrs = cute.make_rmem_tensor((copy_iters, ), cutlass.Int64)
-
-        # Compiler should be able to optimize the same token_copy_group's offset add. (Fundamental cse + strength_reduce)
-        # We should check the SASS to ensure this happens.
-        for iter_idx in cutlass.range_constexpr(copy_iters):
-            coord = eval_function_mapping(
-                self.output_mapping,
-                epi_tid=self.epi_tid,
-                iter_idx=iter_idx,
-            )
-            token_in_tile = cutlass.Int32(coord["token_in_cta_tile"])
-            hidden_in_tile = cutlass.Int32(coord["hidden_in_cta_tile"])
-
-            valid[iter_idx] = cutlass.Int32(0)
-            dst_ptrs[iter_idx] = cutlass.Int64(0)
-
-            token_valid = token_in_tile < self.valid_tokens_this_cta_tile
-            hidden_valid = hidden_in_tile < cutlass.Int32(
-                self.valid_hidden_this_cta_tile)
-            if token_valid and hidden_valid:
-                valid[iter_idx] = cutlass.Int32(1)
-                if cutlass.const_expr(self.metadata is None):
-                    dst_tokens = self.direct_token_base_this_cta_tile + token_in_tile
-                    dst_hidden = hidden_in_tile + self.hidden_base_this_cta_tile
-                    dst_ptrs[iter_idx] = self.base_output[
-                        dst_tokens, None, dst_hidden].iterator.toint()
-
-                else:
-                    dst_rank = cutlass.Int32(self.metadata[token_in_tile, 0])
-                    dst_token = cutlass.Int32(self.metadata[token_in_tile, 1])
-                    dst_hidden = hidden_in_tile + self.hidden_base_this_cta_tile
-                    if cutlass.const_expr(not self.reduce_topk_in_kernel):
-                        dst_topk = cutlass.Int32(self.metadata[token_in_tile,
-                                                               2])
-                    else:
-                        dst_topk = 0
-                    dst_ptrs[
-                        iter_idx] = self.peer_rank_ptr_mapper.ptr_map_to_rank(
-                            cute.domain_offset(
-                                (dst_token, dst_topk, dst_hidden),
-                                self.base_output).iterator,
-                            dst_rank,
-                        ).toint()
-
-        return dataclasses.replace(
-            self,
-            dst_ptrs=dst_ptrs,
-            valid=valid,
-        )
-
-    # Return a tuple of (src, dst) tensors, each represents copy_atom's one call.
-    @cute.jit
-    def resolve(
-        self,
-        copy_src: cute.Tensor,  # (v, rest...)
-        iters_per_subtile: int,
-        subtile_idx: Union[cutlass.Int32, int],
-    ) -> Tuple[Tuple[cute.Tensor, cute.Tensor], ...]:
-        if cutlass.const_expr(self.dst_ptrs is None or self.valid is None):
-            raise ValueError(
-                "Fc2OutputRouter.resolve requires prefetch() first.")
-        # Normalize any strategy-specific source view into the canonical copy
-        # iterator form:
-        #
-        #     ((atom_v, rest_v), rests...)
-        #
-        # The trailing ``rest`` modes enumerate one copy-atom issue inside the
-        # current subtile; their product must equal ``iters_per_subtile``.
-        # Everything before those trailing modes is the copy atom payload
-        # (``atom_v`` elements).  We intentionally flatten first because callers
-        # may hand us nested CuTe layouts whose hierarchy is meaningful to their
-        # local algorithm but irrelevant to the final copy issue schedule.  After
-        # finding the trailing rest modes, two ``group_modes`` calls make rank 0
-        # the payload and rank 1 the full rest/iter space; coalescing with
-        # ``target_profile=(1, 1)`` preserves that two-rank profile while
-        # simplifying each side's internal layout.
-        flat_src = cute.flatten(copy_src)
-        flat_rank: cutlass.Constexpr[int] = cute.rank(flat_src)
-
-        rest_start = flat_rank
-        rest_size = 1
-        for mode in cutlass.range_constexpr(flat_rank - 1, -1, -1):
-            rest_start = mode
-            rest_size *= cute.size(flat_src, mode=[mode])
-            if cutlass.const_expr(rest_size == iters_per_subtile):
-                break
-        if cutlass.const_expr(rest_size != iters_per_subtile):
-            raise ValueError(
-                "Fc2OutputRouter.resolve: trailing rest modes must multiply "
-                f"to iters_per_subtile={iters_per_subtile}, got {rest_size}.")
-        if cutlass.const_expr(rest_start == 0):
-            raise ValueError(
-                "Fc2OutputRouter.resolve requires at least one atom payload mode "
-                "before the trailing rest modes.")
-
-        atom_v: cutlass.Constexpr[int] = cute.size(
-            flat_src) // iters_per_subtile
-        atom_rest = cute.group_modes(flat_src, 0, rest_start)
-        atom_rest = cute.group_modes(atom_rest, 1, cute.rank(atom_rest))
-        atom_rest = cute.coalesce(atom_rest, target_profile=(1, 1))
-
-        single_copy_layout = cute.make_layout(
-            ((atom_v, 1), ),
-            stride=((1, 0), ),
-        )
-        subtile_iter_base = cutlass.Int32(subtile_idx) * cutlass.Int32(
-            iters_per_subtile)
-
-        copy_pairs = ()
-        for local_iter in cutlass.range_constexpr(iters_per_subtile):
-            global_iter = subtile_iter_base + cutlass.Int32(local_iter)
-            src_atom = atom_rest[None, local_iter]
-            copy_src_i = cute.make_tensor(src_atom.iterator, single_copy_layout)
-            dst_ptr = cute.make_ptr(
-                copy_src.element_type,
-                self.dst_ptrs[global_iter],
-                AddressSpace.gmem,
-                assumed_align=32,
-            )
-            copy_dst_i = cute.make_tensor(dst_ptr, single_copy_layout)
-            copy_pairs = copy_pairs + ((copy_src_i, copy_dst_i), )
-
-        return copy_pairs
-
-
-@dataclasses.dataclass(frozen=True)
-class Fc2ProcessPipeline:
+class Fc2ProcessPipeline():
     tmem_acc_load: Callable
     f2fp: Callable
     post_f2fp_reorder: Callable
     store_function: Callable
-    pre_store_contract: Contract
+    # Kept as a finer-grained, elem-level reading aid for the store-out layout
+    # (never evaluated); ``store_out_mapping`` is the per-issue form that the
+    # router actually evaluates at runtime to drive metadata / pointer math.
     fc2_cta_tile_contract: Contract
     store_out_mapping: Contract
     require_tmem_trans: bool
 
 
-# =============================================================================
-# fc2 STG strategy callables (subtile granularity)
-#
-# Faithful port of the original transpose+STG path, re-cut into the four
-# Fc2ProcessPipeline steps. Originals in epilogue.py:
-#   - load        : _TmemTranspose16x32Core.load_subtile_raw_acc
-#   - pack        : Fc2AccLoadAndPack.__init__  (L986-997)
-#   - transpose   : TmemTranspose16x32Packed (+ from_r1_perm_until_last_store)
-#   - unpack      : Fc2UnpackPermuteStg._init_direct  (L1510-1520)
-#   - store       : Fc2UnpackPermuteStg._stg_direct   (L1522-1605)
-#
-# All callables take the unified kwargs + ``**_`` (extras ignored; missing
-# required -> TypeError). ``epi`` is the SwapABFc2Epilogue device object.
-# =============================================================================
-
-# Subtile pre-store contract C (the pivot): each lane holds 64 bf16 values;
-# vid in [0,32) -> token=lane (half 0), vid in [32,64) -> token=lane+32 (half 1);
-# hidden = vid % 32 (this warp's 32-hidden span, natural order).
-_Fc2StgSubtilePreStoreContract = Contract(
-    domain=Space(("lane_idx", "vid"), (32, 64)),
-    codomain=Space(("token_idx", "hidden_idx"), (64, 32)),
-    mapping=FunctionMapping(lambda lane_idx, vid: {
-        "token_idx": lane_idx + 32 * (vid // 32),
-        "hidden_idx": vid % 32,
-    }),
-)
-
-# UBLK pre-store contract: after f2fp (and before R2S), each lane owns one
-# hidden element across the 64 token positions of the subtile.  This is
-# warp-local + subtile-local; the store-out contract below is CTA-level and
-# describes the later bulk issue rows, not this RMEM distribution.
-_Fc2UblkSubtilePreStoreContract = Contract(
-    domain=Space(("lane_idx", "vid"), (32, 64)),
-    codomain=Space(("token_idx", "hidden_idx"), (64, 32)),
-    mapping=FunctionMapping(lambda lane_idx, vid: {
-        "token_idx": vid,
-        "hidden_idx": lane_idx,
-    }),
-)
-
-# REDG pre-store contract: after the extra STTM + LDTM(16x256b.x2)
-# reshuffle, each lane owns bf16 scalar elements arranged so every 4
-# consecutive elem_idx values form one red.v2.bf16x2 issue payload.
-_Fc2RedgSubtilePreStoreContract = Contract(
-    domain=Space(("lane_idx", "elem_idx"), (32, 64)),
-    codomain=Space(("token_idx", "hidden_idx"), (64, 32)),
-    mapping=FunctionMapping(
-        lambda lane_idx, elem_idx: {
-            "token_idx":
-            (((elem_idx // 2) // 16) * 32 + (((elem_idx // 2) // 8) % 2) * 16 +
-             (((elem_idx // 2) // 2) % 2) * 8 + lane_idx // 4),
-            "hidden_idx": ((lane_idx % 4) * 4 + (((elem_idx // 2) // 4) % 2) *
-                           16 + ((elem_idx // 2) % 2) * 2 + (elem_idx % 2)),
-        }),
-)
-
-
-# TODO: Enable for non-BF16 dtypes
-def make_fc2_stg_cta_store_out_contract(fc2_output_dtype: Type[cutlass.Numeric],
-                                        cta_token_tile_size: int,
-                                        cta_hidden_tile_size: int):
-    assert cta_hidden_tile_size == 128
-    assert cta_token_tile_size % 64 == 0
-    assert fc2_output_dtype.width == 16
-    fundamental_mapping = Contract(
-        domain=Space(("epi_tid", "elem_idx"), (128, cta_token_tile_size)),
-        codomain=Space(("token_in_cta_tile", "hidden_in_cta_tile"),
-                       (cta_token_tile_size, cta_hidden_tile_size)),
-        mapping=FunctionMapping(
-            lambda epi_tid, elem_idx: {
-                "token_in_cta_tile": epi_tid % 32 + elem_idx // 32 * 32,
-                "hidden_in_cta_tile": elem_idx % 32 + epi_tid // 32 * 32,
-            }),
-    )
-    store_out_mapping = Contract(
-        domain=Space(("epi_tid", "iter_idx"),
-                     (128, 32 // 16 * cta_token_tile_size // 32)),
-        codomain=Space(("token_in_cta_tile", "hidden_in_cta_tile"),
-                       (cta_token_tile_size, cta_hidden_tile_size)),
-        mapping=FunctionMapping(
-            lambda epi_tid, iter_idx: {
-                "token_in_cta_tile": epi_tid % 32 + iter_idx // 2 * 32,
-                "hidden_in_cta_tile": (iter_idx % 2) * 16 + epi_tid // 32 * 32,
-            }),
-    )
-    return store_out_mapping, fundamental_mapping
-
-
-def make_fc2_redg_cta_store_out_contract(
-        fc2_output_dtype: Type[cutlass.Numeric], cta_token_tile_size: int,
-        cta_hidden_tile_size: int):
-    assert cta_hidden_tile_size == 128
-    assert cta_token_tile_size % 64 == 0
-    assert fc2_output_dtype.width == 16
-    fundamental_mapping = Contract(
-        domain=Space(("epi_tid", "elem_idx"), (128, cta_token_tile_size)),
-        codomain=Space(("token_in_cta_tile", "hidden_in_cta_tile"),
-                       (cta_token_tile_size, cta_hidden_tile_size)),
-        mapping=FunctionMapping(
-            lambda epi_tid, elem_idx: {
-                "token_in_cta_tile":
-                (((elem_idx // 4) // 16) * 64 + (((elem_idx // 4) % 16) // 8) *
-                 32 + (((elem_idx // 4) % 8) // 4) * 16 + ((
-                     (elem_idx // 4) % 4) % 2) * 8 + (epi_tid % 32) // 4),
-                "hidden_in_cta_tile": (
-                    (epi_tid // 32) * 32 + (epi_tid % 4) * 4 + ((
-                        (elem_idx // 4) % 4) // 2) * 16 + elem_idx % 4),
-            }),
-    )
-    # SIMT REDG emits one 8B red.v2.bf16x2 per 4 hidden elements.  Each
-    # 64-token subtile contributes two token rows per lane and 8 hidden
-    # segments per token row.
-    store_out_mapping = Contract(
-        domain=Space(("epi_tid", "iter_idx"),
-                     (128, cta_token_tile_size // 64 * 16)),
-        codomain=Space(("token_in_cta_tile", "hidden_in_cta_tile"),
-                       (cta_token_tile_size, cta_hidden_tile_size)),
-        mapping=FunctionMapping(
-            lambda epi_tid, iter_idx: {
-                "token_in_cta_tile": ((iter_idx // 16) * 64 + (
-                    (iter_idx % 16) // 8) * 32 + ((iter_idx % 8) // 4) * 16 + (
-                        (iter_idx % 4) % 2) * 8 + (epi_tid % 32) // 4),
-                "hidden_in_cta_tile": ((epi_tid // 32) * 32 + (epi_tid % 4) * 4
-                                       + ((iter_idx % 4) // 2) * 16),
-            }),
-    )
-    return store_out_mapping, fundamental_mapping
-
-
-def make_fc2_ublk_store_out_contract(fc2_output_dtype: Type[cutlass.Numeric],
-                                     cta_token_tile_size: int,
-                                     cta_hidden_tile_size: int):
-    assert cta_hidden_tile_size == 128
-    assert cta_token_tile_size % 64 == 0
-    assert fc2_output_dtype.width == 16
-    fundamental_mapping = Contract(
-        domain=Space(("epi_tid", "elem_idx"), (128, cta_token_tile_size)),
-        codomain=Space(("token_in_cta_tile", "hidden_in_cta_tile"),
-                       (cta_token_tile_size, cta_hidden_tile_size)),
-        mapping=FunctionMapping(
-            lambda epi_tid, elem_idx: {
-                "token_in_cta_tile":
-                epi_tid % 8 + epi_tid // 32 * 8 + ((epi_tid % 32) // 8) * 32 +
-                elem_idx // cta_hidden_tile_size * 128,
-                "hidden_in_cta_tile":
-                elem_idx % cta_hidden_tile_size,
-            }),
-    )
-    store_out_mapping = Contract(
-        domain=Space(("epi_tid", "iter_idx"),
-                     (128, (cta_token_tile_size + 127) // 128)),
-        codomain=Space(("token_in_cta_tile", "hidden_in_cta_tile"),
-                       (cta_token_tile_size, cta_hidden_tile_size)),
-        mapping=FunctionMapping(
-            lambda epi_tid, iter_idx: {
-                "token_in_cta_tile":
-                epi_tid % 8 + epi_tid // 32 * 8 +
-                ((epi_tid % 32) // 8) * 32 + iter_idx * 128,
-                "hidden_in_cta_tile":
-                0,
-            }),
-    )
-    return store_out_mapping, fundamental_mapping
-
-
-@cute.jit
-def fc2_f2fp(
-    *tensors,
-    fc2_output_dtype: Type[cutlass.Numeric],
-    alpha_val: Optional[cutlass.Float32] = None,
-    **_,
-) -> cute.Tensor:
-    # cvt every input fp32 rmem -> fc2_output_dtype and concatenate, in order,
-    # into one flat rmem tensor. Each block is stored contiguously (no scalar
-    # element copy) at its running offset.
-    total_size = 0
-    for t in tensors:
-        total_size += cute.size(t)
-    converted_acc = cute.make_rmem_tensor((total_size, ), fc2_output_dtype)
-    elems_processed = 0
-    for t in tensors:
-        current_tensor_size = cute.size(t)
-        dst = cute.make_tensor(
-            converted_acc.iterator + elems_processed,
-            cute.make_layout((current_tensor_size, )),
-        )
-        if cutlass.const_expr(alpha_val is None):
-            dst.store(t.load().to(fc2_output_dtype))
-        else:
-            if cutlass.const_expr(current_tensor_size % 2 != 0):
-                raise ValueError(
-                    "fc2_f2fp expects even elements for each input tensor.")
-            scaled = cute.make_rmem_tensor((current_tensor_size, ),
-                                           cutlass.Float32)
-            for i in cutlass.range_constexpr(0, current_tensor_size, 2):
-                # scaled[i] = t[i] * alpha_val
-                s0, s1 = cute.arch.mul_packed_f32x2((t[i], t[i + 1]),
-                                                    (alpha_val, alpha_val))
-                scaled[i] = s0
-                scaled[i + 1] = s1
-            dst.store(scaled.load().to(fc2_output_dtype))
-        elems_processed += current_tensor_size
-    return converted_acc
-
-
-@cute.jit
-def post_f2fp_reorder_identity(*, casted: cute.Tensor, contract: Contract, **_):
-    return TensorWithContract(tensor=casted, contract=contract)
-
-
-@cute.jit
-def fc2_stg_tmem_acc_load(*, tmem_subtile_tensor: cute.Tensor, **_):
-    return _TmemTranspose16x32Core.load_subtile_raw_acc(tmem_subtile_tensor)
-
-
-@cute.jit
-def fc2_ublk_tmem_acc_load(*, tmem_subtile_tensor: cute.Tensor, epi, **_):
-    # UBLK consumes a warp-local 32-hidden x 64-token slice.  The caller passes
-    # the CTA-level 128-hidden x 64-token subtile view, so select this epi
-    # warp's hidden block before issuing LDTM.x64.
-    tmem_subtile_per_warp = cute.logical_divide(
-        tmem_subtile_tensor,
-        (32, None),
-    )[(None, epi.warp_idx), None]
-    raw_regs = cute.make_rmem_tensor((64, ), cutlass.Float32)
-    atom_ld32x32_x64 = cute.make_copy_atom(
-        tcgen05.Ld32x32bOp(tcgen05.Repetition.x64),
-        cutlass.Float32,
-    )
-    cute.copy(
-        atom_ld32x32_x64,
-        wrap_into_copy_standard_layout(tmem_subtile_per_warp),
-        wrap_into_copy_standard_layout(raw_regs),
-    )
-    return (raw_regs, )
-
-
-@cute.jit
-def fc2_stg_post_f2fp_reorder(
-    *,
-    casted: cute.Tensor,  # (subtile_cnt,)
-    fc2_output_dtype: Type[cutlass.Numeric],
-    tmem_subtile_view: cute.Tensor,  # (epi_tile_m, epi_tile_n)
-    **_,
-):
-    if cutlass.const_expr(cute.size(casted) != 64):
-        raise NotImplementedError(
-            "fc2 stg pass expects 64 fp32 regs in total before store reorder.")
-
-    # casted (flat 64) = [h0_top, h0_bot, h1_top, h1_bot], 16 bf16 each.
-    #
-    # gather: interleave (top[i], bot[i]) -> bf16x2 slot i, both halves at once.
-    #   read casted through (t, hidden, half) -> casted[t*16 + hidden + half*32]
-    #   in (t fastest) order -> [top0,bot0,top1,bot1,...] per half = packed bf16x2.
-    # scatter: de-interleave the transposed natural-hidden regs back to the
-    #   (token, hidden) pre-store order declared by _Fc2StgSubtilePreStoreContract.
-    gather_top_bot_map = ((2, 16, 2), (16, 1, 32))
-    scatter_top_bot_map = ((16, 2, 2), (2, 1, 32))
-    dtype = fc2_output_dtype
-
-    packed = cute.make_rmem_tensor((64, ), dtype)
-    cute.autovec_copy(
-        cute.composition(
-            casted,
-            cute.make_layout((gather_top_bot_map[0], ),
-                             stride=(gather_top_bot_map[1], ))),
-        packed,
-    )
-    # Although this works...
-    # packed.store(
-    #     cute.make_tensor(
-    #         casted.iterator,
-    #         cute.make_layout(gather_top_bot_map[0], stride=gather_top_bot_map[1]),
-    #     ).load()
-    # )
-    packed_i32 = cute.recast_tensor(packed,
-                                    cutlass.Float32)  # (32,): 16 i32 per half
-
-    token_0_32_pre_scatter_back = TmemTranspose16x32Packed(
-        tmem_subtile_view.iterator,
-        Region.Top,
-        reg_tensor=TensorWithContract(
-            tensor=cute.composition(packed_i32, (16, )),
-            contract=TmemTranspose16x32Packed.InputContract,
-        ),
-    ).from_r1_perm_until_last_store()
-    token_32_64_pre_scatter_back = TmemTranspose16x32Packed(
-        tmem_subtile_view.iterator + 32,
-        Region.Top,
-        reg_tensor=TensorWithContract(
-            tensor=cute.composition(cute.domain_offset(16, packed_i32), (16, )),
-            contract=TmemTranspose16x32Packed.InputContract,
-        ),
-    ).from_r1_perm_until_last_store()
-    cute.autovec_copy(token_0_32_pre_scatter_back.tensor,
-                      cute.zipped_divide(packed_i32, (16, ))[None, 0])
-    cute.autovec_copy(token_32_64_pre_scatter_back.tensor,
-                      cute.zipped_divide(packed_i32, (16, ))[None, 1])
-    out = cute.make_rmem_tensor((64, ), dtype)
-    cute.autovec_copy(
-        cute.composition(
-            packed,
-            cute.make_layout((scatter_top_bot_map[0], ),
-                             stride=(scatter_top_bot_map[1], ))),
-        out,
-    )
-    return TensorWithContract(tensor=out,
-                              contract=_Fc2StgSubtilePreStoreContract)
-
-
-# (...) -> ((atom_v, 1))
-@cute.jit
-def wrap_into_copy_standard_layout(tensor: cute.Tensor):
-    tensor = cute.coalesce(cute.flatten(tensor))
-    tensor = cute.append_ones(tensor, cute.rank(tensor) + 1)
-    tensor = cute.group_modes(tensor, 0, cute.rank(tensor) - 1)
-    tensor = cute.group_modes(tensor, 0, cute.rank(tensor))
-    return tensor
-
-
-@cute.jit
-def fc2_redg_post_f2fp_reorder(
-    *,
-    casted: cute.Tensor,
-    fc2_output_dtype: Type[cutlass.Numeric],
-    tmem_subtile_view: cute.Tensor,
-    **_,
-):
-    # (epi_tid, elem_idx) -> (token_64, hidden_128), each thread hold token_2 x hidden_32
-    natural = fc2_stg_post_f2fp_reorder(
-        casted=casted,
-        fc2_output_dtype=fc2_output_dtype,
-        tmem_subtile_view=tmem_subtile_view,
-    ).tensor
-    core_matrix_reorder_sttm_atom = cute.make_copy_atom(
-        tcgen05.St32x32bOp(tcgen05.Repetition.x16),
-        cutlass.Float32,
-    )
-    core_matrix_reorder_ldtm_atom = cute.make_copy_atom(
-        tcgen05.Ld16x256bOp(tcgen05.Repetition.x2),
-        cutlass.Float32,
-    )
-    # ((16, 2), token_32_group)
-    natural_divided_by_token32_16dp = cute.logical_divide(
-        cute.zipped_divide(natural, (32, )), (16, None))
-    out = cute.make_rmem_tensor(natural_divided_by_token32_16dp.shape,
-                                casted.dtype)
-    out_as_i32 = cute.recast_tensor(out, cutlass.Float32)
-    # (32, 64)
-    tmem_subtile_warp_local = cute.flat_divide(
-        tmem_subtile_view, (32, cute.size(tmem_subtile_view, 1)))[None, None, 0,
-                                                                  0]
-    # (16, 16, 16dp_group, token_32_groups). Note, this tmem can provide 2x cols since the original is bf16.
-    tmem_subtile_divided_by_token_group_divided_by_16dp = cute.flat_divide(
-        tmem_subtile_warp_local, (16, 16))
-    for i in cutlass.range_constexpr(
-            cute.size(natural_divided_by_token32_16dp, 1)):
-        current_sttm_src = cute.recast_tensor(
-            natural_divided_by_token32_16dp[None, i], cutlass.Float32)
-        cute.copy(
-            core_matrix_reorder_sttm_atom,
-            wrap_into_copy_standard_layout(current_sttm_src),
-            wrap_into_copy_standard_layout(
-                tmem_subtile_divided_by_token_group_divided_by_16dp[None, None,
-                                                                    None, i]),
-        )
-        cute.copy(
-            core_matrix_reorder_ldtm_atom,
-            wrap_into_copy_standard_layout(
-                tmem_subtile_divided_by_token_group_divided_by_16dp[None, None,
-                                                                    0, i]),
-            wrap_into_copy_standard_layout(out_as_i32[(None, 0), i]),
-        )
-        cute.copy(
-            core_matrix_reorder_ldtm_atom,
-            wrap_into_copy_standard_layout(
-                tmem_subtile_divided_by_token_group_divided_by_16dp[None, None,
-                                                                    1, i]),
-            wrap_into_copy_standard_layout(out_as_i32[(None, 1), i]),
-        )
-
-    return TensorWithContract(tensor=cute.coalesce(out),
-                              contract=_Fc2RedgSubtilePreStoreContract)
-
-
-@cute.jit
-def fc2_stg_store_function(
-    *,
-    epi,
-    subtile: TensorWithContract,
-    subtile_idx: cutlass.Int32,
-    fc2_output_router: Fc2OutputRouter,
-    **_,
-):
-    assert_contract_equivalent(
-        subtile.contract,
-        _Fc2StgSubtilePreStoreContract,
-        context="fc2 STG store input",
-    )
-    copy_atom_256b = cute.make_copy_atom(
-        cute.nvgpu.CopyUniversalOp(),
-        subtile.tensor.element_type,
-        num_bits_per_copy=256,
-    )
-    stg_width_elems: cutlass.Constexpr[
-        int] = 256 // subtile.tensor.element_type.width
-    elem_axis: cutlass.Constexpr[int] = subtile.contract.domain.names.index(
-        "vid")
-    elems_per_thread: cutlass.Constexpr[int] = subtile.contract.domain.sizes[
-        elem_axis]
-    if cutlass.const_expr(elems_per_thread % stg_width_elems != 0):
-        raise ValueError(
-            "fc2 STG store requires pre-store elems per thread to be divisible "
-            f"by STG issue width, got {elems_per_thread} and {stg_width_elems}."
-        )
-    iters_per_subtile: cutlass.Constexpr[
-        int] = elems_per_thread // stg_width_elems
-    copy_src = cute.zipped_divide(subtile.tensor, (stg_width_elems, ))
-    copy_pairs = fc2_output_router.resolve(
-        copy_src,
-        iters_per_subtile,
-        subtile_idx,
-    )
-    subtile_iter_base = cutlass.Int32(subtile_idx) * cutlass.Int32(
-        iters_per_subtile)
-    for local_iter in cutlass.range_constexpr(iters_per_subtile):
-        global_iter = subtile_iter_base + cutlass.Int32(local_iter)
-        if fc2_output_router.valid[global_iter] != cutlass.Int32(0):
-            copy_src_i, copy_dst_i = copy_pairs[local_iter]
-            cute.copy(copy_atom_256b, copy_src_i, copy_dst_i)
-
-
-@cute.jit
-def fc2_ublk_store_function_impl(
-    *,
-    epi,
-    subtile: TensorWithContract,
-    subtile_idx: cutlass.Int32,
-    fc2_output_router: Fc2OutputRouter,
-):
-    assert_contract_equivalent(
-        subtile.contract,
-        epi.process_pipeline.pre_store_contract,
-        context="fc2 UBLK store input",
-    )
-    smem_tensor = epi.smem_tensor
-    if cutlass.const_expr(smem_tensor is None):
-        raise ValueError("fc2 UBLK store requires epi.smem_tensor.")
-
-    smem_read_write_bar = pipeline.NamedBarrier(
-        barrier_id=SwapABSwigluFp4Epilogue._EpilogueSyncWaitBarId,
-        num_threads=SwapABSwigluFp4Epilogue._EpilogueWarpCnt * 32,
-    )
-    warp_idx = epi.warp_idx
-    lane_idx = epi.lane_idx
-    warp_hidden_base = cutlass.Int32(warp_idx * 32)
-
-    vid_axis: cutlass.Constexpr[int] = subtile.contract.domain.names.index(
-        "vid")
-    regs_per_thread: cutlass.Constexpr[int] = subtile.contract.domain.sizes[
-        vid_axis]
-    tokens_per_smem_slice: cutlass.Constexpr[int] = cute.size(smem_tensor,
-                                                              mode=[0])
-    if cutlass.const_expr(regs_per_thread % tokens_per_smem_slice != 0):
-        raise ValueError(
-            "fc2 UBLK store requires pre-store regs per thread to be divisible "
-            f"by scratch token rows, got {regs_per_thread} and {tokens_per_smem_slice}."
-        )
-    loop_cnt: cutlass.Constexpr[int] = regs_per_thread // tokens_per_smem_slice
-
-    for loop_idx in cutlass.range_constexpr(loop_cnt):
-        if cutlass.const_expr(loop_idx > 0):
-            cute.arch.cp_async_bulk_wait_group(0, read=True)
-            cute.arch.sync_warp()
-            smem_read_write_bar.arrive_and_wait()
-
-        # R2S: materialize this loop's token slice into the fixed
-        # (token_rows, hidden_128) scratch tile.  The pre-store contract says
-        # each lane owns one hidden column over all subtile tokens, so loop_idx
-        # simply selects the next contiguous token_rows chunk from RMEM.
-        for token_i in cutlass.range_constexpr(tokens_per_smem_slice):
-            src_reg = token_i + tokens_per_smem_slice * loop_idx
-            smem_tensor[token_i,
-                        warp_hidden_base + lane_idx] = subtile.tensor[src_reg]
-
-        cute.arch.fence_proxy("async.shared", space="cta")
-        cute.arch.sync_warp()
-        smem_read_write_bar.arrive_and_wait()
-
-        iter_idx = subtile_idx // cutlass.Int32(2)
-        store_coord = eval_function_mapping(
-            fc2_output_router.output_mapping,
-            epi_tid=epi.tidx,
-            iter_idx=iter_idx,
-        )
-        token_in_cta_tile = cutlass.Int32(store_coord["token_in_cta_tile"])
-        slice_token_start = subtile_idx * cutlass.Int32(
-            epi._EpilogueTokenTileSize) + cutlass.Int32(
-                loop_idx * tokens_per_smem_slice)
-        slice_token_end = slice_token_start + cutlass.Int32(
-            tokens_per_smem_slice)
-
-        if (fc2_output_router.valid[iter_idx] != cutlass.Int32(0)
-                and token_in_cta_tile >= slice_token_start
-                and token_in_cta_tile < slice_token_end):
-            scratch_row = token_in_cta_tile - slice_token_start
-            copy_elems = cutlass.Int32(128)
-            if cutlass.const_expr(epi.fc2_hidden_needs_predicate):
-                copy_elems = cutlass.Int32(
-                    fc2_output_router.valid_hidden_this_cta_tile)
-            copy_bytes = copy_elems * epi.fc2_output_dtype.width // 8
-
-            src_row = cute.slice_(smem_tensor, (scratch_row, None))
-            dst_ptr = cute.make_ptr(
-                src_row.element_type,
-                fc2_output_router.dst_ptrs[iter_idx],
-                AddressSpace.gmem,
-                assumed_align=16,
-            )
-            if cutlass.const_expr(epi.reduce_topk_in_kernel):
-                _cp_reduce_async_bulk_add_noftz_bf16_s2g(
-                    dst_ptr,
-                    src_row.iterator,
-                    copy_bytes,
-                )
-            else:
-                _cp_async_bulk_s2g(
-                    dst_ptr,
-                    src_row.iterator,
-                    copy_bytes,
-                )
-
-        cute.arch.cp_async_bulk_commit_group()
-
-    # Drain the final bulk op before the fixed scratch tile is reused by the
-    # next subtile / task tile.
-    cute.arch.cp_async_bulk_wait_group(0, read=True)
-    smem_read_write_bar.arrive_and_wait()
-
-
-@cute.jit
-def fc2_redg_store_function(
-    *,
-    epi,
-    subtile: TensorWithContract,
-    subtile_idx: cutlass.Int32,
-    fc2_output_router: Fc2OutputRouter,
-    **_,
-):
-    assert_contract_equivalent(
-        subtile.contract,
-        _Fc2RedgSubtilePreStoreContract,
-        context="fc2 REDG store input",
-    )
-    redg_width_elems: cutlass.Constexpr[int] = 4
-    elem_axis: cutlass.Constexpr[int] = subtile.contract.domain.names.index(
-        "elem_idx")
-    elems_per_thread: cutlass.Constexpr[int] = subtile.contract.domain.sizes[
-        elem_axis]
-    if cutlass.const_expr(elems_per_thread % redg_width_elems != 0):
-        raise ValueError(
-            "fc2 REDG store requires pre-store elems per thread to be divisible "
-            f"by REDG issue width, got {elems_per_thread} and {redg_width_elems}."
-        )
-    iters_per_subtile: cutlass.Constexpr[
-        int] = elems_per_thread // redg_width_elems
-    subtile_iter_base = cutlass.Int32(subtile_idx) * cutlass.Int32(
-        iters_per_subtile)
-    subtile_by_redg_issue = cute.zipped_divide(subtile.tensor,
-                                               (redg_width_elems, ))
-
-    for local_iter in cutlass.range_constexpr(iters_per_subtile):
-        global_iter = subtile_iter_base + cutlass.Int32(local_iter)
-        if fc2_output_router.valid[global_iter] != cutlass.Int32(0):
-            bf16x4 = subtile_by_redg_issue[None, local_iter]
-            packed_bf16x2 = cute.recast_tensor(bf16x4, cutlass.Float32)
-            dst_ptr = cute.make_ptr(
-                fc2_output_router.base_output.element_type,
-                fc2_output_router.dst_ptrs[global_iter],
-                AddressSpace.gmem,
-                assumed_align=8,
-            )
-            _red_add_relaxed_sys_v2_bf16x2(
-                dst_ptr,
-                cutlass.Float32(packed_bf16x2[0]),
-                cutlass.Float32(packed_bf16x2[1]),
-            )
-
-
-def make_fc2_stg_process_pipeline(
-    *,
-    fc2_output_dtype: Type[cutlass.Numeric],
-    cta_token_tile_size: int,
-    cta_hidden_tile_size: int,
-) -> Fc2ProcessPipeline:
-    store_out_mapping, fundamental_mapping = make_fc2_stg_cta_store_out_contract(
-        fc2_output_dtype,
-        cta_token_tile_size,
-        cta_hidden_tile_size,
-    )
-    return Fc2ProcessPipeline(
-        tmem_acc_load=fc2_stg_tmem_acc_load,
-        f2fp=fc2_f2fp,
-        post_f2fp_reorder=fc2_stg_post_f2fp_reorder,
-        store_function=fc2_stg_store_function,
-        pre_store_contract=_Fc2StgSubtilePreStoreContract,
-        fc2_cta_tile_contract=fundamental_mapping,
-        store_out_mapping=store_out_mapping,
-        require_tmem_trans=True,
-    )
-
-
-def make_fc2_redg_process_pipeline(
-    *,
-    fc2_output_dtype: Type[cutlass.Numeric],
-    cta_token_tile_size: int,
-    cta_hidden_tile_size: int,
-) -> Fc2ProcessPipeline:
-    store_out_mapping, fundamental_mapping = make_fc2_redg_cta_store_out_contract(
-        fc2_output_dtype,
-        cta_token_tile_size,
-        cta_hidden_tile_size,
-    )
-    return Fc2ProcessPipeline(
-        tmem_acc_load=fc2_stg_tmem_acc_load,
-        f2fp=fc2_f2fp,
-        post_f2fp_reorder=fc2_redg_post_f2fp_reorder,
-        store_function=fc2_redg_store_function,
-        pre_store_contract=_Fc2RedgSubtilePreStoreContract,
-        fc2_cta_tile_contract=fundamental_mapping,
-        store_out_mapping=store_out_mapping,
-        require_tmem_trans=True,
-    )
-
-
-def make_fc2_ublk_process_pipeline(
-    *,
-    fc2_output_dtype: Type[cutlass.Numeric],
-    cta_token_tile_size: int,
-    cta_hidden_tile_size: int,
-) -> Fc2ProcessPipeline:
-    store_out_mapping, fundamental_mapping = make_fc2_ublk_store_out_contract(
-        fc2_output_dtype,
-        cta_token_tile_size,
-        cta_hidden_tile_size,
-    )
-    return Fc2ProcessPipeline(
-        tmem_acc_load=fc2_ublk_tmem_acc_load,
-        f2fp=fc2_f2fp,
-        post_f2fp_reorder=post_f2fp_reorder_identity,
-        store_function=fc2_ublk_store_function_impl,
-        pre_store_contract=_Fc2UblkSubtilePreStoreContract,
-        fc2_cta_tile_contract=fundamental_mapping,
-        store_out_mapping=store_out_mapping,
-        require_tmem_trans=False,
-    )
-
-
 # Device only object
-class SwapABFc2Epilogue:
+class SwapABFc2Epilogue(_ImmutableAfterInit):
 
     def __init__(
         self,
@@ -2501,6 +1471,7 @@ class SwapABFc2Epilogue:
                     cta_token_tile_size=base.cta_tile_n,
                     cta_hidden_tile_size=base.cta_tile_m,
                 )
+        self._freeze()
 
     def __getattr__(self, name):
         return getattr(object.__getattribute__(self, "base"), name)
@@ -2518,25 +1489,31 @@ class SwapABFc2Epilogue:
         return self
 
     @cute.jit
-    def signal_fc2_done(self, work_tile_info):
+    def signal_fc2_done(self, work_tile_info, next_work_tile_info,
+                        flag_tracker):
+        # fc2 publishes only under token_back_by_dispatch; otherwise null slot.
+        # Either way the accumulate call's phase switch flushes the pending fc1
+        # batch at the Linear1->Linear2 boundary.
         if cutlass.const_expr(self.token_back_by_dispatch):
-            if self.tidx == 0:
-                _red_add_release_gpu_s32(
-                    self.token_comm_args.fc2_done_counter.iterator +
-                    work_tile_info.expert_idx,
-                    cutlass.Int32(1),
-                )
+            flag_addr = (self.token_comm_args.fc2_done_counter.iterator +
+                         work_tile_info.expert_idx).toint()
+        else:
+            flag_addr = Int64(0)
+        no_fire: cutlass.Constexpr = not self.token_back_by_dispatch
+        return flag_tracker.accumulate(next_work_tile_info.phase,
+                                       self.fc2_epi_flag_batch, flag_addr,
+                                       no_fire)
 
     @cute.jit
     def _make_output_router(
         self,
         work_tile_info: MoEWorkTileInfo,
-    ) -> Fc2OutputRouter:
+    ) -> "Fc2OutputRouter":
         task_tile_data_row_start = (
             work_tile_info.cumulative_data_physical_row +
             work_tile_info.tile_n_idx * cutlass.Int32(self.cta_tile_n))
-        hidden_base_this_cta_tile = work_tile_info.tile_m_idx * cutlass.Int32(
-            self.cta_tile_m)
+        hidden_base_this_cta_tile = (work_tile_info.tile_m_idx *
+                                     cutlass.Int32(self.cta_tile_m))
         valid_hidden_this_cta_tile = (cutlass.Int32(self.fc2_output.shape[2]) -
                                       hidden_base_this_cta_tile)
         if valid_hidden_this_cta_tile < 0:
@@ -2602,9 +1579,9 @@ class SwapABFc2Epilogue:
         valid_tokens = work_tile_info.valid_tokens_in_tile
 
         # Overlap path preloads two subtiles before releasing acc TMEM.
-        unroll_tile_cnt = (2 if cutlass.const_expr(
-            self.overlapping_accum and self.process_pipeline.require_tmem_trans)
-                           else 0)
+        unroll_tile_cnt = 2 if cutlass.const_expr(
+            self.overlapping_accum
+            and self.process_pipeline.require_tmem_trans) else 0
         remain_subtile_cnt = self.subtile_cnt - unroll_tile_cnt
 
         if cutlass.const_expr(unroll_tile_cnt > 0):
@@ -2625,9 +1602,9 @@ class SwapABFc2Epilogue:
             # the tmem transpose consumes them.
             preload_subtile_first: Tuple[
                 cute.Tensor, cute.Tensor, cute.Tensor,
-                cute.Tensor] = (_TmemTranspose16x32Core.load_subtile_raw_acc(
+                cute.Tensor] = _TmemTranspose16x32Core.load_subtile_raw_acc(
                     tmem_acc_tensor_tiled_by_epi_tile[None, None,
-                                                      subtile_idx_first]))
+                                                      subtile_idx_first])
 
             # Release acc to next MMA unconditionally.
             cute.arch.fence_view_async_tmem_load()
@@ -2638,9 +1615,9 @@ class SwapABFc2Epilogue:
             # quadrant/offset invariants and opaque per-lane layout as above.
             preload_subtile_second: Tuple[
                 cute.Tensor, cute.Tensor, cute.Tensor,
-                cute.Tensor] = (_TmemTranspose16x32Core.load_subtile_raw_acc(
+                cute.Tensor] = _TmemTranspose16x32Core.load_subtile_raw_acc(
                     tmem_acc_tensor_tiled_by_epi_tile[None, None,
-                                                      subtile_idx_second]))
+                                                      subtile_idx_second])
 
             # Both unrolled subtiles borrow tmem_subtile_second as workspace.
             preload_pair = (preload_subtile_first, preload_subtile_second)
@@ -2701,7 +1678,7 @@ class SwapABFc2Epilogue:
         tmem_subtile_tensor: cute.Tensor,
         preload_acc: Optional[Tuple[cute.Tensor, cute.Tensor, cute.Tensor,
                                     cute.Tensor]],
-        fc2_output_router: Fc2OutputRouter,
+        fc2_output_router: "Fc2OutputRouter",
         alpha_val: Optional[cutlass.Float32],
         release_after_ldtm: Union[cutlass.Boolean, bool],
         acc_pipeline,
@@ -2724,16 +1701,12 @@ class SwapABFc2Epilogue:
             fc2_output_dtype=self.fc2_output_dtype,
             alpha_val=alpha_val,
         )
+        # reorder returns a bare RMEM fragment in the store's expected pre-store
+        # distribution; reorder + store are paired 1:1 inside the pipeline.
         pre_store = process_pipeline.post_f2fp_reorder(
             casted=casted,
-            contract=process_pipeline.pre_store_contract,
             fc2_output_dtype=self.fc2_output_dtype,
             tmem_subtile_view=tmem_subtile_tensor,
-        )
-        assert_contract_equivalent(
-            pre_store.contract,
-            process_pipeline.pre_store_contract,
-            context="fc2 process pipeline pre-store",
         )
         process_pipeline.store_function(
             epi=self,
@@ -2741,3 +1714,727 @@ class SwapABFc2Epilogue:
             subtile_idx=subtile_idx,
             fc2_output_router=fc2_output_router,
         )
+
+
+@dataclasses.dataclass(frozen=True)
+class Fc2OutputRouter:
+    # (token, 3), 3 -> rank_idx, token_idx, top_k
+    # Later this will be changed to (token, 2), where top_k and rank_idx will be fused into 32bit.
+    # If metadata is None then this is a local write.
+    metadata: Optional[cute.Tensor]
+    direct_token_base_this_cta_tile: Optional[cutlass.Int32]
+    base_output: cute.Tensor  # (token, topk, hidden)
+    hidden_base_this_cta_tile: Union[cutlass.Int32, int]
+    peer_rank_ptr_mapper: Optional[SymBufferDeviceBase]
+    valid_tokens_this_cta_tile: cutlass.Int32
+    valid_hidden_this_cta_tile: Union[cutlass.Int32, int]
+    reduce_topk_in_kernel: bool
+    output_mapping: Contract  # (epi_tid, iter_idx) -> (token_cta_tile, hidden_cta_tile).
+    epi_tid: cutlass.Int32
+
+    # After metadata prefetch
+    dst_ptrs: Optional[
+        cute.
+        Tensor] = None  # i64 x (copy_iters_this_thread_cta_tile), fundamentally the pointers.
+    valid: Optional[cute.Tensor] = None  # (copy_iters_this_thread_cta_tile)
+
+    def __post_init__(self) -> None:
+        if (self.metadata is None) == (self.direct_token_base_this_cta_tile
+                                       is None):
+            raise ValueError(
+                "Fc2OutputRouter requires exactly one of metadata or "
+                "direct_token_base_this_cta_tile.")
+        if (self.metadata is None) != (self.peer_rank_ptr_mapper is None):
+            raise ValueError(
+                "Fc2OutputRouter requires peer_rank_ptr_mapper iff metadata is set."
+            )
+        if self.reduce_topk_in_kernel and self.metadata is None:
+            raise ValueError(
+                "Fc2OutputRouter reduce_topk_in_kernel requires metadata routing."
+            )
+
+    @cute.jit
+    def prefetch(self) -> "Fc2OutputRouter":
+        # Only the metadata (comm) path prefetches a pointer array: its
+        # metadata-derived address has long-latency LDGs worth issuing early.
+        # The local (no-comm) path computes its affine address on demand in
+        # get_dst() -- no array, hence no runtime-indexed local-memory spill.
+        if cutlass.const_expr(self.metadata is None):
+            return self
+        iter_axis = self.output_mapping.domain.names.index("iter_idx")
+        copy_iters: cutlass.Constexpr[int] = self.output_mapping.domain.sizes[
+            iter_axis]
+
+        valid = cute.make_rmem_tensor((copy_iters, ), cutlass.Int32)
+        dst_ptrs = cute.make_rmem_tensor((copy_iters, ), cutlass.Int64)
+
+        # Compiler should be able to optimize the same token_copy_group's offset add. (Fundamental cse + strength_reduce)
+        # We should check the SASS to ensure this happens.
+        for iter_idx in cutlass.range_constexpr(copy_iters):
+            coord = eval_function_mapping(
+                self.output_mapping,
+                epi_tid=self.epi_tid,
+                iter_idx=iter_idx,
+            )
+            token_in_tile = cutlass.Int32(coord["token_in_cta_tile"])
+            hidden_in_tile = cutlass.Int32(coord["hidden_in_cta_tile"])
+
+            valid[iter_idx] = cutlass.Int32(0)
+            dst_ptrs[iter_idx] = cutlass.Int64(0)
+
+            token_valid = token_in_tile < self.valid_tokens_this_cta_tile
+            hidden_valid = hidden_in_tile < cutlass.Int32(
+                self.valid_hidden_this_cta_tile)
+            if token_valid and hidden_valid:
+                valid[iter_idx] = cutlass.Int32(1)
+                if cutlass.const_expr(self.metadata is None):
+                    dst_tokens = self.direct_token_base_this_cta_tile + token_in_tile
+                    dst_hidden = hidden_in_tile + self.hidden_base_this_cta_tile
+                    dst_ptrs[iter_idx] = self.base_output[
+                        dst_tokens, None, dst_hidden].iterator.toint()
+
+                else:
+                    md = TokenSrcMetadata.load(self.metadata.iterator.toint() +
+                                               Int64(token_in_tile) *
+                                               Int64(TokenSrcMetadata.nbytes))
+                    dst_rank = md.src_rank
+                    dst_token = md.src_token
+                    dst_hidden = hidden_in_tile + self.hidden_base_this_cta_tile
+                    if cutlass.const_expr(not self.reduce_topk_in_kernel):
+                        dst_topk = md.src_topk
+                    else:
+                        dst_topk = 0
+                    dst_ptrs[
+                        iter_idx] = self.peer_rank_ptr_mapper.ptr_map_to_rank(
+                            cute.domain_offset(
+                                (dst_token, dst_topk, dst_hidden),
+                                self.base_output).iterator, dst_rank).toint()
+
+        return dataclasses.replace(
+            self,
+            dst_ptrs=dst_ptrs,
+            valid=valid,
+        )
+
+    @cute.jit
+    def get_dst(
+        self,
+        iter_idx: Union[int, cutlass.Int32],
+    ) -> Tuple[cute.Pointer, cutlass.Int32]:
+        """Per-issue destination: gmem pointer + validity predicate.
+
+        Replaces resolve().  The router owns ``base_output`` so the caller
+        never re-assembles a pointer from a raw int; it just builds its own
+        copy tensor (STG) or feeds the pointer to inline asm (REDG/UBLK).
+
+        Alignment is unified at 32 B: only STG feeds this pointer to a real
+        ``cute.copy`` (256 b vector store, genuinely 32 B aligned); REDG/UBLK
+        only ``ptrtoint`` it for inline-asm issue, where the hint is inert.
+        """
+        if cutlass.const_expr(self.metadata is None):
+            # no-comm: on-demand affine address (no prefetched array). The
+            # invariant base hoists out of the caller's loop via CSE; a
+            # constexpr iter folds the per-issue offset into the store.
+            coord = eval_function_mapping(
+                self.output_mapping,
+                epi_tid=self.epi_tid,
+                iter_idx=iter_idx,
+            )
+            token_in_tile = cutlass.Int32(coord["token_in_cta_tile"])
+            hidden_in_tile = cutlass.Int32(coord["hidden_in_cta_tile"])
+            pred = cutlass.Int32(0)
+            addr = cutlass.Int64(0)
+            if (token_in_tile < self.valid_tokens_this_cta_tile
+                    and hidden_in_tile < cutlass.Int32(
+                        self.valid_hidden_this_cta_tile)):
+                pred = cutlass.Int32(1)
+                dst_tokens = self.direct_token_base_this_cta_tile + token_in_tile
+                dst_hidden = hidden_in_tile + self.hidden_base_this_cta_tile
+                addr = self.base_output[dst_tokens, None,
+                                        dst_hidden].iterator.toint()
+        else:
+            # comm: read the pointer / validity prefetched by prefetch().
+            addr = self.dst_ptrs[iter_idx]
+            pred = self.valid[iter_idx]
+        ptr = cute.make_ptr(
+            self.base_output.element_type,
+            addr,
+            AddressSpace.gmem,
+            assumed_align=32,
+        )
+        return ptr, pred
+
+
+# =============================================================================
+# fc2 STG strategy callables (subtile granularity)
+#
+# Faithful port of the original transpose+STG path, re-cut into the four
+# Fc2ProcessPipeline steps. Originals in epilogue.py:
+#   - load        : _TmemTranspose16x32Core.load_subtile_raw_acc
+#   - pack        : Fc2AccLoadAndPack.__init__  (L986-997)
+#   - transpose   : TmemTranspose16x32 (+ from_r1_perm_until_last_store), each
+#                   32-bit slot carrying one packed bf16x2 pair
+#   - unpack      : Fc2UnpackPermuteStg._init_direct  (L1510-1520)
+#   - store       : Fc2UnpackPermuteStg._stg_direct   (L1522-1605)
+#
+# All callables take the unified kwargs + ``**_`` (extras ignored; missing
+# required -> TypeError). ``epi`` is the SwapABFc2Epilogue device object.
+# =============================================================================
+
+# Per-subtile pre-store RMEM distributions (each lane holds 64 bf16 values).
+# These are fixed properties of the reorder step that produces them and are
+# paired 1:1 with their store function inside ``make_fc2_*_process_pipeline``;
+# the store derives its per-thread element count from ``cute.size`` directly.
+# Documented here for reference -- ``(lane_idx, vid_or_elem) -> (token, hidden)``:
+#
+#   STG  (fc2_stg_post_f2fp_reorder): the pivot order
+#     token  = lane_idx + 32 * (vid // 32)   # vid<32 -> lane, else lane+32
+#     hidden = vid % 32                       # this warp's 32-hidden span
+#
+#   UBLK (post_f2fp_reorder_identity): warp-local + subtile-local; each lane
+#     owns one hidden element across the 64 token positions of the subtile.
+#     token  = vid
+#     hidden = lane_idx
+#
+#   REDG (fc2_redg_post_f2fp_reorder): after the extra STTM + LDTM(16x256b.x2)
+#     reshuffle, every 4 consecutive elem_idx form one red.v2.bf16x2 payload.
+#     token  = ((elem_idx // 2) // 16) * 32
+#            + (((elem_idx // 2) // 8) % 2) * 16
+#            + (((elem_idx // 2) // 2) % 2) * 8
+#            + lane_idx // 4
+#     hidden = (lane_idx % 4) * 4
+#            + (((elem_idx // 2) // 4) % 2) * 16
+#            + ((elem_idx // 2) % 2) * 2
+#            + (elem_idx % 2)
+
+
+# TODO: Enable for non-BF16 dtypes
+def make_fc2_stg_cta_store_out_contract(fc2_output_dtype: Type[cutlass.Numeric],
+                                        cta_token_tile_size: int,
+                                        cta_hidden_tile_size: int):
+    assert (cta_hidden_tile_size == 128)
+    assert (cta_token_tile_size % 64 == 0)
+    assert (fc2_output_dtype.width == 16)
+    fundamental_mapping = Contract(
+        domain=Space(("epi_tid", "elem_idx"), (128, cta_token_tile_size)),
+        codomain=Space(("token_in_cta_tile", "hidden_in_cta_tile"),
+                       (cta_token_tile_size, cta_hidden_tile_size)),
+        mapping=FunctionMapping(
+            lambda epi_tid, elem_idx: {
+                "token_in_cta_tile": epi_tid % 32 + elem_idx // 32 * 32,
+                "hidden_in_cta_tile": elem_idx % 32 + epi_tid // 32 * 32,
+            }))
+    store_out_mapping = Contract(
+        domain=Space(("epi_tid", "iter_idx"),
+                     (128, 32 // 16 * cta_token_tile_size // 32)),
+        codomain=Space(("token_in_cta_tile", "hidden_in_cta_tile"),
+                       (cta_token_tile_size, cta_hidden_tile_size)),
+        mapping=FunctionMapping(
+            lambda epi_tid, iter_idx: {
+                "token_in_cta_tile": epi_tid % 32 + iter_idx // 2 * 32,
+                "hidden_in_cta_tile": (iter_idx % 2) * 16 + epi_tid // 32 * 32,
+            }))
+    return store_out_mapping, fundamental_mapping
+
+
+def make_fc2_redg_cta_store_out_contract(
+        fc2_output_dtype: Type[cutlass.Numeric], cta_token_tile_size: int,
+        cta_hidden_tile_size: int):
+    assert (cta_hidden_tile_size == 128)
+    assert (cta_token_tile_size % 64 == 0)
+    assert (fc2_output_dtype.width == 16)
+    fundamental_mapping = Contract(
+        domain=Space(("epi_tid", "elem_idx"), (128, cta_token_tile_size)),
+        codomain=Space(("token_in_cta_tile", "hidden_in_cta_tile"),
+                       (cta_token_tile_size, cta_hidden_tile_size)),
+        mapping=FunctionMapping(
+            lambda epi_tid, elem_idx: {
+                "token_in_cta_tile":
+                (((elem_idx // 4) // 16) * 64 + (((elem_idx // 4) % 16) // 8) *
+                 32 + (((elem_idx // 4) % 8) // 4) * 16 + ((
+                     (elem_idx // 4) % 4) % 2) * 8 + (epi_tid % 32) // 4),
+                "hidden_in_cta_tile": (
+                    (epi_tid // 32) * 32 + (epi_tid % 4) * 4 + ((
+                        (elem_idx // 4) % 4) // 2) * 16 + elem_idx % 4),
+            }))
+    # SIMT REDG emits one 8B red.v2.bf16x2 per 4 hidden elements.  Each
+    # 64-token subtile contributes two token rows per lane and 8 hidden
+    # segments per token row.
+    store_out_mapping = Contract(
+        domain=Space(("epi_tid", "iter_idx"),
+                     (128, cta_token_tile_size // 64 * 16)),
+        codomain=Space(("token_in_cta_tile", "hidden_in_cta_tile"),
+                       (cta_token_tile_size, cta_hidden_tile_size)),
+        mapping=FunctionMapping(
+            lambda epi_tid, iter_idx: {
+                "token_in_cta_tile": ((iter_idx // 16) * 64 + (
+                    (iter_idx % 16) // 8) * 32 + ((iter_idx % 8) // 4) * 16 + (
+                        (iter_idx % 4) % 2) * 8 + (epi_tid % 32) // 4),
+                "hidden_in_cta_tile": ((epi_tid // 32) * 32 + (epi_tid % 4) * 4
+                                       + ((iter_idx % 4) // 2) * 16),
+            }))
+    return store_out_mapping, fundamental_mapping
+
+
+def make_fc2_ublk_store_out_contract(fc2_output_dtype: Type[cutlass.Numeric],
+                                     cta_token_tile_size: int,
+                                     cta_hidden_tile_size: int):
+    assert (cta_hidden_tile_size == 128)
+    assert (cta_token_tile_size % 64 == 0)
+    assert (fc2_output_dtype.width == 16)
+    assert (cta_token_tile_size <= 256)
+    max_token_cta_tile = 256
+    fundamental_mapping = Contract(
+        domain=Space(("epi_tid", "elem_idx"), (128, cta_token_tile_size)),
+        codomain=Space(("token_in_cta_tile", "hidden_in_cta_tile"),
+                       (max_token_cta_tile, cta_hidden_tile_size)),
+        mapping=FunctionMapping(
+            lambda epi_tid, elem_idx: {
+                "token_in_cta_tile":
+                elem_idx // cta_hidden_tile_size * 32 + epi_tid % 8 + epi_tid //
+                32 * 8 + ((epi_tid % 32) // 8) * 64,
+                "hidden_in_cta_tile":
+                elem_idx % cta_hidden_tile_size,
+            }))
+    store_out_mapping = Contract(
+        domain=Space(("epi_tid", "iter_idx"), (128, 2)),
+        codomain=Space(("token_in_cta_tile", "hidden_in_cta_tile"),
+                       (max_token_cta_tile, cta_hidden_tile_size)),
+        mapping=FunctionMapping(
+            lambda epi_tid, iter_idx: {
+                "token_in_cta_tile":
+                iter_idx * 32 + epi_tid % 8 + epi_tid // 32 * 8 +
+                ((epi_tid % 32) // 8) * 64,
+                "hidden_in_cta_tile":
+                0,
+            }))
+    return store_out_mapping, fundamental_mapping
+
+
+# (...) -> ((atom_v, 1))
+@cute.jit
+def wrap_into_copy_standard_layout(tensor: cute.Tensor):
+    tensor = cute.coalesce(cute.flatten(tensor))
+    tensor = cute.append_ones(tensor, cute.rank(tensor) + 1)
+    tensor = cute.group_modes(tensor, 0, cute.rank(tensor) - 1)
+    tensor = cute.group_modes(tensor, 0, cute.rank(tensor))
+    return tensor
+
+
+@cute.jit
+def fc2_f2fp(
+    *tensors,
+    fc2_output_dtype: Type[cutlass.Numeric],
+    alpha_val: Optional[cutlass.Float32] = None,
+    **_,
+) -> cute.Tensor:
+    # cvt every input fp32 rmem -> fc2_output_dtype and concatenate, in order,
+    # into one flat rmem tensor. Each block is stored contiguously (no scalar
+    # element copy) at its running offset.
+    total_size = 0
+    for t in tensors:
+        total_size += cute.size(t)
+    converted_acc = cute.make_rmem_tensor((total_size, ), fc2_output_dtype)
+    elems_processed = 0
+    for t in tensors:
+        current_tensor_size = cute.size(t)
+        dst = cute.make_tensor(
+            converted_acc.iterator + elems_processed,
+            cute.make_layout((current_tensor_size, )),
+        )
+        if cutlass.const_expr(alpha_val is None):
+            dst.store(t.load().to(fc2_output_dtype))
+        else:
+            if cutlass.const_expr(current_tensor_size % 2 != 0):
+                raise ValueError(
+                    "fc2_f2fp expects even elements for each input tensor.")
+            scaled = cute.make_rmem_tensor((current_tensor_size, ),
+                                           cutlass.Float32)
+            for i in cutlass.range_constexpr(0, current_tensor_size, 2):
+                # scaled[i] = t[i] * alpha_val
+                s0, s1 = cute.arch.mul_packed_f32x2((t[i], t[i + 1]),
+                                                    (alpha_val, alpha_val))
+                scaled[i] = s0
+                scaled[i + 1] = s1
+            dst.store(scaled.load().to(fc2_output_dtype))
+        elems_processed += current_tensor_size
+    return converted_acc
+
+
+@cute.jit
+def post_f2fp_reorder_identity(*, casted: cute.Tensor, **_):
+    # UBLK: the f2fp output is already in the pre-store distribution (each lane
+    # owns one hidden element across the 64 subtile tokens); no reorder needed.
+    return casted
+
+
+@cute.jit
+def fc2_stg_tmem_acc_load(*, tmem_subtile_tensor: cute.Tensor, **_):
+    return _TmemTranspose16x32Core.load_subtile_raw_acc(tmem_subtile_tensor)
+
+
+@cute.jit
+def fc2_ublk_tmem_acc_load(*, tmem_subtile_tensor: cute.Tensor, epi, **_):
+    # UBLK consumes a warp-local 32-hidden x 64-token slice.  The caller passes
+    # the CTA-level 128-hidden x 64-token subtile view, so select this epi
+    # warp's hidden block before issuing LDTM.x64.
+    tmem_subtile_per_warp = cute.logical_divide(
+        tmem_subtile_tensor,
+        (32, None),
+    )[(None, epi.warp_idx), None]
+    raw_regs = cute.make_rmem_tensor((64, ), cutlass.Float32)
+    atom_ld32x32_x64 = cute.make_copy_atom(
+        tcgen05.Ld32x32bOp(tcgen05.Repetition.x64),
+        cutlass.Float32,
+    )
+    cute.copy(
+        atom_ld32x32_x64,
+        wrap_into_copy_standard_layout(tmem_subtile_per_warp),
+        wrap_into_copy_standard_layout(raw_regs),
+    )
+    return (raw_regs, )
+
+
+@cute.jit
+def fc2_stg_post_f2fp_reorder(
+        *,
+        casted: cute.Tensor,  # (subtile_cnt,)
+        fc2_output_dtype: Type[cutlass.Numeric],
+        tmem_subtile_view: cute.Tensor,  # (epi_tile_m, epi_tile_n)
+        **_):
+
+    if cutlass.const_expr(cute.size(casted) != 64):
+        raise NotImplementedError(
+            "fc2 stg pass expects 64 fp32 regs in total before store reorder.")
+
+    # casted (flat 64) = [h0_top, h0_bot, h1_top, h1_bot], 16 bf16 each.
+    #
+    # gather: interleave (top[i], bot[i]) -> bf16x2 slot i, both halves at once.
+    #   read casted through (t, hidden, half) -> casted[t*16 + hidden + half*32]
+    #   in (t fastest) order -> [top0,bot0,top1,bot1,...] per half = packed bf16x2.
+    # scatter: de-interleave the transposed natural-hidden regs back to the
+    #   STG pre-store order (token = lane + 32*(vid//32), hidden = vid % 32).
+    gather_top_bot_map = ((2, 16, 2), (16, 1, 32))
+    scatter_top_bot_map = ((16, 2, 2), (2, 1, 32))
+    dtype = fc2_output_dtype
+
+    packed = cute.make_rmem_tensor((64, ), dtype)
+    cute.autovec_copy(
+        cute.composition(
+            casted,
+            cute.make_layout((gather_top_bot_map[0], ),
+                             stride=(gather_top_bot_map[1], ))), packed)
+    # Although this works...
+    # packed.store(
+    #     cute.make_tensor(
+    #         casted.iterator,
+    #         cute.make_layout(gather_top_bot_map[0], stride=gather_top_bot_map[1]),
+    #     ).load()
+    # )
+    packed_i32 = cute.recast_tensor(packed,
+                                    cutlass.Float32)  # (32,): 16 i32 per half
+
+    # Reuse the 32-bit transpose: each i32 slot carries one packed bf16x2 pair.
+    token_0_32_pre_scatter_back = TmemTranspose16x32(
+        tmem_subtile_view.iterator,
+        Region.Top,
+        reg_tensor=cute.composition(packed_i32, (16, )),
+    ).from_r1_perm_until_last_store()
+    token_32_64_pre_scatter_back = TmemTranspose16x32(
+        tmem_subtile_view.iterator + 32,
+        Region.Top,
+        reg_tensor=cute.composition(cute.domain_offset(16, packed_i32), (16, )),
+    ).from_r1_perm_until_last_store()
+    cute.autovec_copy(token_0_32_pre_scatter_back,
+                      cute.zipped_divide(packed_i32, (16, ))[None, 0])
+    cute.autovec_copy(token_32_64_pre_scatter_back,
+                      cute.zipped_divide(packed_i32, (16, ))[None, 1])
+    out = cute.make_rmem_tensor((64, ), dtype)
+    cute.autovec_copy(
+        cute.composition(
+            packed,
+            cute.make_layout((scatter_top_bot_map[0], ),
+                             stride=(scatter_top_bot_map[1], ))), out)
+    return out
+
+
+@cute.jit
+def fc2_redg_post_f2fp_reorder(
+    *,
+    casted: cute.Tensor,
+    fc2_output_dtype: Type[cutlass.Numeric],
+    tmem_subtile_view: cute.Tensor,
+    **_,
+):
+    # (epi_tid, elem_idx) -> (token_64, hidden_128), each thread hold token_2 x hidden_32
+    natural = fc2_stg_post_f2fp_reorder(
+        casted=casted,
+        fc2_output_dtype=fc2_output_dtype,
+        tmem_subtile_view=tmem_subtile_view,
+    )
+    core_matrix_reorder_sttm_atom = cute.make_copy_atom(
+        tcgen05.St32x32bOp(tcgen05.Repetition.x16),
+        cutlass.Float32,
+    )
+    core_matrix_reorder_ldtm_atom = cute.make_copy_atom(
+        tcgen05.Ld16x256bOp(tcgen05.Repetition.x2),
+        cutlass.Float32,
+    )
+    # ((16, 2), token_32_group)
+    natural_divided_by_token32_16dp = cute.logical_divide(
+        cute.zipped_divide(natural, (32, )), (16, None))
+    out = cute.make_rmem_tensor(natural_divided_by_token32_16dp.shape,
+                                casted.dtype)
+    out_as_i32 = cute.recast_tensor(out, cutlass.Float32)
+    # (32, 64)
+    tmem_subtile_warp_local = cute.flat_divide(
+        tmem_subtile_view, (32, cute.size(tmem_subtile_view, 1)))[None, None, 0,
+                                                                  0]
+    # (16, 16, 16dp_group, token_32_groups). Note, this tmem can provide 2x cols since the original is bf16.
+    tmem_subtile_divided_by_token_group_divided_by_16dp = cute.flat_divide(
+        tmem_subtile_warp_local, (16, 16))
+    for i in cutlass.range_constexpr(
+            cute.size(natural_divided_by_token32_16dp, 1)):
+        current_sttm_src = cute.recast_tensor(
+            natural_divided_by_token32_16dp[None, i], cutlass.Float32)
+        cute.copy(
+            core_matrix_reorder_sttm_atom,
+            wrap_into_copy_standard_layout(current_sttm_src),
+            wrap_into_copy_standard_layout(
+                tmem_subtile_divided_by_token_group_divided_by_16dp[None, None,
+                                                                    None, i]))
+        cute.copy(
+            core_matrix_reorder_ldtm_atom,
+            wrap_into_copy_standard_layout(
+                tmem_subtile_divided_by_token_group_divided_by_16dp[None, None,
+                                                                    0, i]),
+            wrap_into_copy_standard_layout(out_as_i32[(None, 0), i]))
+        cute.copy(
+            core_matrix_reorder_ldtm_atom,
+            wrap_into_copy_standard_layout(
+                tmem_subtile_divided_by_token_group_divided_by_16dp[None, None,
+                                                                    1, i]),
+            wrap_into_copy_standard_layout(out_as_i32[(None, 1), i]))
+
+    return cute.coalesce(out)
+
+
+@cute.jit
+def fc2_stg_store_function(
+        *,
+        epi,
+        subtile: cute.
+    Tensor,  # pre-store STG distribution (see top of fc2 section)
+        subtile_idx: cutlass.Int32,
+        fc2_output_router: Fc2OutputRouter,
+        **_):
+    copy_atom_256b = cute.make_copy_atom(
+        cute.nvgpu.CopyUniversalOp(),
+        subtile.element_type,
+        num_bits_per_copy=256,
+    )
+    stg_width_elems: cutlass.Constexpr[int] = 256 // subtile.element_type.width
+    elems_per_thread: cutlass.Constexpr[int] = cute.size(subtile)
+    if cutlass.const_expr(elems_per_thread % stg_width_elems != 0):
+        raise ValueError(
+            "fc2 STG store requires pre-store elems per thread to be divisible "
+            f"by STG issue width, got {elems_per_thread} and {stg_width_elems}."
+        )
+    iters_per_subtile: cutlass.Constexpr[
+        int] = elems_per_thread // stg_width_elems
+    copy_src = cute.zipped_divide(subtile, (stg_width_elems, ))
+    single_copy_layout = cute.make_layout(((stg_width_elems, 1), ),
+                                          stride=((1, 0), ))
+    subtile_iter_base = cutlass.Int32(subtile_idx) * cutlass.Int32(
+        iters_per_subtile)
+    for local_iter in cutlass.range_constexpr(iters_per_subtile):
+        global_iter = subtile_iter_base + cutlass.Int32(local_iter)
+        dst_ptr, pred = fc2_output_router.get_dst(global_iter)
+        if pred != cutlass.Int32(0):
+            src_i = cute.make_tensor(copy_src[None, local_iter].iterator,
+                                     single_copy_layout)
+            dst_i = cute.make_tensor(dst_ptr, single_copy_layout)
+            cute.copy(copy_atom_256b, src_i, dst_i)
+
+
+@cute.jit
+def fc2_ublk_store_function_impl(
+    *,
+    epi,
+    subtile: cute.
+    Tensor,  # pre-store UBLK distribution (see top of fc2 section)
+    subtile_idx: cutlass.Int32,
+    fc2_output_router: Fc2OutputRouter,
+):
+    smem_tensor = epi.smem_tensor
+    if cutlass.const_expr(smem_tensor is None):
+        raise ValueError("fc2 UBLK store requires epi.smem_tensor.")
+
+    smem_read_write_bar = pipeline.NamedBarrier(
+        barrier_id=SwapABSwigluFp4Epilogue._EpilogueSyncWaitBarId,
+        num_threads=SwapABSwigluFp4Epilogue._EpilogueWarpCnt * 32,
+    )
+    warp_idx = epi.warp_idx
+    lane_idx = epi.lane_idx
+    warp_hidden_base = cutlass.Int32(warp_idx * 32)
+
+    regs_per_thread: cutlass.Constexpr[int] = cute.size(subtile)
+    tokens_per_smem_slice: cutlass.Constexpr[int] = cute.size(smem_tensor,
+                                                              mode=[0])
+    if cutlass.const_expr(regs_per_thread % tokens_per_smem_slice != 0):
+        raise ValueError(
+            "fc2 UBLK store requires pre-store regs per thread to be divisible "
+            f"by scratch token rows, got {regs_per_thread} and {tokens_per_smem_slice}."
+        )
+    loop_cnt: cutlass.Constexpr[int] = regs_per_thread // tokens_per_smem_slice
+
+    for token32_group_idx in cutlass.range_constexpr(loop_cnt):
+        if cutlass.const_expr(token32_group_idx > 0):
+            cute.arch.cp_async_bulk_wait_group(0, read=True)
+            smem_read_write_bar.arrive_and_wait()
+
+        # R2S transpose: each lane writes its hidden column's 32 token rows for this group.
+        for token_i in cutlass.range_constexpr(tokens_per_smem_slice):
+            src_reg = token_i + tokens_per_smem_slice * token32_group_idx
+            smem_tensor[token_i, warp_hidden_base + lane_idx] = subtile[src_reg]
+
+        cute.arch.fence_proxy("async.shared", space="cta")
+        smem_read_write_bar.arrive_and_wait()
+
+        # ublk_iter_idx is constexpr so get_dst indexes a constexpr slot (no spill).
+        # Gate / scratch_row specialize the store-out mapping: lane_idx//8 picks the
+        # subtile, warp_idx*8 + lane_idx%8 is the token's row within the 32-group.
+        ublk_iter_idx = token32_group_idx
+        dst_ptr, pred = fc2_output_router.get_dst(ublk_iter_idx)
+        if pred != cutlass.Int32(0) and (lane_idx //
+                                         cutlass.Int32(8)) == subtile_idx:
+            scratch_row = warp_idx * cutlass.Int32(
+                8) + lane_idx % cutlass.Int32(8)
+            copy_elems = cutlass.Int32(128)
+            if cutlass.const_expr(epi.fc2_hidden_needs_predicate):
+                copy_elems = cutlass.Int32(
+                    fc2_output_router.valid_hidden_this_cta_tile)
+            copy_bytes = copy_elems * epi.fc2_output_dtype.width // 8
+
+            src_row = cute.slice_(smem_tensor, (scratch_row, None))
+            if cutlass.const_expr(epi.reduce_topk_in_kernel):
+                _cp_reduce_async_bulk_add_noftz_bf16_s2g(
+                    dst_ptr,
+                    src_row.iterator,
+                    copy_bytes,
+                )
+            else:
+                _cp_async_bulk_s2g(
+                    dst_ptr,
+                    src_row.iterator,
+                    copy_bytes,
+                )
+
+        cute.arch.cp_async_bulk_commit_group()
+
+    # Drain the final bulk op before the fixed scratch tile is reused by the
+    # next subtile / task tile.
+    cute.arch.cp_async_bulk_wait_group(0, read=True)
+    smem_read_write_bar.arrive_and_wait()
+
+
+@cute.jit
+def fc2_redg_store_function(
+    *,
+    epi,
+    subtile: cute.
+    Tensor,  # pre-store REDG distribution (see top of fc2 section)
+    subtile_idx: cutlass.Int32,
+    fc2_output_router: Fc2OutputRouter,
+    **_,
+):
+    redg_width_elems: cutlass.Constexpr[int] = 4
+    elems_per_thread: cutlass.Constexpr[int] = cute.size(subtile)
+    if cutlass.const_expr(elems_per_thread % redg_width_elems != 0):
+        raise ValueError(
+            "fc2 REDG store requires pre-store elems per thread to be divisible "
+            f"by REDG issue width, got {elems_per_thread} and {redg_width_elems}."
+        )
+    iters_per_subtile: cutlass.Constexpr[
+        int] = elems_per_thread // redg_width_elems
+    subtile_iter_base = cutlass.Int32(subtile_idx) * cutlass.Int32(
+        iters_per_subtile)
+    subtile_by_redg_issue = cute.zipped_divide(subtile, (redg_width_elems, ))
+
+    for local_iter in cutlass.range_constexpr(iters_per_subtile):
+        global_iter = subtile_iter_base + cutlass.Int32(local_iter)
+        dst_ptr, pred = fc2_output_router.get_dst(global_iter)
+        if pred != cutlass.Int32(0):
+            bf16x4 = subtile_by_redg_issue[None, local_iter]
+            packed_bf16x2 = cute.recast_tensor(bf16x4, cutlass.Float32)
+            _red_add_relaxed_sys_v2_bf16x2(
+                dst_ptr,
+                cutlass.Float32(packed_bf16x2[0]),
+                cutlass.Float32(packed_bf16x2[1]),
+            )
+
+
+def make_fc2_stg_process_pipeline(
+    *,
+    fc2_output_dtype: Type[cutlass.Numeric],
+    cta_token_tile_size: int,
+    cta_hidden_tile_size: int,
+) -> Fc2ProcessPipeline:
+    store_out_mapping, fundamental_mapping = make_fc2_stg_cta_store_out_contract(
+        fc2_output_dtype,
+        cta_token_tile_size,
+        cta_hidden_tile_size,
+    )
+    return Fc2ProcessPipeline(
+        tmem_acc_load=fc2_stg_tmem_acc_load,
+        f2fp=fc2_f2fp,
+        post_f2fp_reorder=fc2_stg_post_f2fp_reorder,
+        store_function=fc2_stg_store_function,
+        fc2_cta_tile_contract=fundamental_mapping,
+        store_out_mapping=store_out_mapping,
+        require_tmem_trans=True,
+    )
+
+
+def make_fc2_redg_process_pipeline(
+    *,
+    fc2_output_dtype: Type[cutlass.Numeric],
+    cta_token_tile_size: int,
+    cta_hidden_tile_size: int,
+) -> Fc2ProcessPipeline:
+    store_out_mapping, fundamental_mapping = make_fc2_redg_cta_store_out_contract(
+        fc2_output_dtype,
+        cta_token_tile_size,
+        cta_hidden_tile_size,
+    )
+    return Fc2ProcessPipeline(
+        tmem_acc_load=fc2_stg_tmem_acc_load,
+        f2fp=fc2_f2fp,
+        post_f2fp_reorder=fc2_redg_post_f2fp_reorder,
+        store_function=fc2_redg_store_function,
+        fc2_cta_tile_contract=fundamental_mapping,
+        store_out_mapping=store_out_mapping,
+        require_tmem_trans=True,
+    )
+
+
+def make_fc2_ublk_process_pipeline(
+    *,
+    fc2_output_dtype: Type[cutlass.Numeric],
+    cta_token_tile_size: int,
+    cta_hidden_tile_size: int,
+) -> Fc2ProcessPipeline:
+    store_out_mapping, fundamental_mapping = make_fc2_ublk_store_out_contract(
+        fc2_output_dtype,
+        cta_token_tile_size,
+        cta_hidden_tile_size,
+    )
+    return Fc2ProcessPipeline(
+        tmem_acc_load=fc2_ublk_tmem_acc_load,
+        f2fp=fc2_f2fp,
+        post_f2fp_reorder=post_f2fp_reorder_identity,
+        store_function=fc2_ublk_store_function_impl,
+        fc2_cta_tile_contract=fundamental_mapping,
+        store_out_mapping=store_out_mapping,
+        require_tmem_trans=False,
+    )

--- a/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/fc1_fc2_fuse_sched.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/fc1_fc2_fuse_sched.py
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 """Fused fc1 + fc2 MegaMoE scheduler."""
 
 from enum import IntEnum
@@ -669,6 +671,7 @@ class MoEFusedFc12PersistentTileScheduler(MoESchedulerBase):
             cumulative_token_block_count=Int32(0),
             valid_tokens_in_tile=Int32(0),
             phase_and_peek=Int32(BlockPhase.None_),
+            fc1_counter_index=Int32(0),
         )
 
         sched_producer_group = pipeline.CooperativeGroup(
@@ -1193,6 +1196,10 @@ class MoEFusedFc12PersistentTileScheduler(MoESchedulerBase):
             tile_m_idx = cta_token_block_idx
             tile_n_idx = cta_intermediate_or_hidden_block_idx
 
+        # fc1_counter_index: intra-expert token-block index.
+        fc1_counter_index = tile_n_idx if const_expr(
+            params.is_swap_ab) else cluster_token_block_idx
+
         # ext.enrich_work_tile_info may OR the peek bit into phase_and_peek.
         return self._ext.WorkTileInfo(
             expert_idx=state.current_expert_idx,
@@ -1203,6 +1210,7 @@ class MoEFusedFc12PersistentTileScheduler(MoESchedulerBase):
             cumulative_token_block_count=state.current_token_block_cumul,
             valid_tokens_in_tile=valid_tokens_in_tile,
             phase_and_peek=state.current_phase,
+            fc1_counter_index=fc1_counter_index,
         )
 
     @dsl_user_op
@@ -1227,6 +1235,7 @@ class MoEFusedFc12PersistentTileScheduler(MoESchedulerBase):
             cumulative_token_block_count=Int32(0),
             valid_tokens_in_tile=Int32(0),
             phase_and_peek=Int32(BlockPhase.None_),
+            fc1_counter_index=Int32(0),
         )
 
         # DSL carry for mutated self and while-condition fields.

--- a/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/flag_batch.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/flag_batch.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Rotating-lane delayed release helpers for done-counter publishing."""
+
+import dataclasses
+from typing import Any
+
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.typing import AddressSpace
+from cutlass.cutlass_dsl import Int64
+
+from .ptx_helpers import red_add_release_gpu_s32, red_add_release_sys_s32_raw
+
+
+@dataclasses.dataclass(frozen=True)
+class FlagBatchTrackerBase:
+    """Loop-carried per-thread state for batched release-counter publishing."""
+
+    flag_addr: Int64  # per-lane counter-slot address (0 == null)
+    cumulated_flags: cutlass.Int32  # current batch fill count (uniform)
+    phase: cutlass.Int32  # current accumulated phase (uniform)
+    tid: cutlass.Int32  # lane/thread id within the rotating group
+
+    @cute.jit
+    def _make(
+        self,
+        flag_addr: Int64,
+        cumulated_flags: cutlass.Int32,
+        phase: cutlass.Int32,
+    ) -> "FlagBatchTrackerBase":
+        return FlagBatchTrackerBase(
+            flag_addr=flag_addr,
+            cumulated_flags=cumulated_flags,
+            phase=phase,
+            tid=self.tid,
+        )
+
+    @cute.jit
+    def fire(self) -> None:
+        """Publish this lane's pending slot. Subclasses define the scope."""
+        raise NotImplementedError
+
+    @cute.jit
+    def accumulate(
+        self,
+        next_phase: Any,
+        flush_threshold: int,
+        flag_addr: Int64,
+        no_fire: bool = False,
+    ) -> "FlagBatchTrackerBase":
+        if cutlass.const_expr(flush_threshold == 1):
+            if cutlass.const_expr(not no_fire):
+                per_lane_addr = Int64(0)
+                if self.tid == 0:
+                    per_lane_addr = flag_addr
+                self._make(
+                    flag_addr=per_lane_addr,
+                    cumulated_flags=cutlass.Int32(1),
+                    phase=self.phase,
+                ).fire()
+            return self._make(
+                flag_addr=Int64(0),
+                cumulated_flags=cutlass.Int32(0),
+                phase=cutlass.Int32(next_phase),
+            )
+
+        cur_addr = self.flag_addr
+        cumulated = self.cumulated_flags
+        if self.tid == cumulated:
+            cur_addr = flag_addr
+        cumulated = cumulated + 1
+
+        if cumulated == flush_threshold or next_phase != self.phase:
+            if not no_fire:
+                self._make(
+                    flag_addr=cur_addr,
+                    cumulated_flags=cumulated,
+                    phase=self.phase,
+                ).fire()
+            cumulated = cutlass.Int32(0)
+            cur_addr = Int64(0)
+
+        return self._make(
+            flag_addr=cur_addr,
+            cumulated_flags=cumulated,
+            phase=cutlass.Int32(next_phase),
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class GpuReleaseFlagBatchTracker(FlagBatchTrackerBase):
+    """Batched done-counter publisher using GPU-scope release reductions."""
+
+    @cute.jit
+    def _make(
+        self,
+        flag_addr: Int64,
+        cumulated_flags: cutlass.Int32,
+        phase: cutlass.Int32,
+    ) -> "GpuReleaseFlagBatchTracker":
+        return GpuReleaseFlagBatchTracker(
+            flag_addr=flag_addr,
+            cumulated_flags=cumulated_flags,
+            phase=phase,
+            tid=self.tid,
+        )
+
+    @cute.jit
+    def fire(self) -> None:
+        if self.flag_addr != Int64(0):
+            ptr = cute.make_ptr(
+                cutlass.Int32,
+                self.flag_addr,
+                AddressSpace.gmem,
+                assumed_align=4,
+            )
+            red_add_release_gpu_s32(ptr, cutlass.Int32(1))
+
+
+@dataclasses.dataclass(frozen=True)
+class SysReleaseFlagBatchTracker(FlagBatchTrackerBase):
+    """Batched done-counter publisher using system-scope release reductions."""
+
+    @cute.jit
+    def _make(
+        self,
+        flag_addr: Int64,
+        cumulated_flags: cutlass.Int32,
+        phase: cutlass.Int32,
+    ) -> "SysReleaseFlagBatchTracker":
+        return SysReleaseFlagBatchTracker(
+            flag_addr=flag_addr,
+            cumulated_flags=cumulated_flags,
+            phase=phase,
+            tid=self.tid,
+        )
+
+    @cute.jit
+    def fire(self) -> None:
+        if self.flag_addr != Int64(0):
+            red_add_release_sys_s32_raw(self.flag_addr, cutlass.Int32(1))

--- a/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/grid_sync.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/grid_sync.py
@@ -119,11 +119,12 @@ def software_grid_sync(counter_ptr,
          "selp.b32 %delta, $2, $3, %is_sm0;\n\t"
          "atom.release.gpu.global.add.u32 %old, [$0], %delta;\n\t"
          "SPIN:\n\t"
-         "ld.acquire.gpu.global.b32 %cur, [$0];\n\t"
+         "ld.relaxed.gpu.global.b32 %cur, [$0];\n\t"
          "xor.b32 %cur, %cur, %old;\n\t"
          "and.b32 %cur, %cur, 0x80000000;\n\t"
          "setp.eq.u32 %waiting, %cur, 0;\n\t"
          "@%waiting bra SPIN;\n\t"
+         "fence.acq_rel.gpu;\n\t"
          "DONE:\n\t"
          "}"),
         "l,r,r,r,r",

--- a/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/kernel_fc12.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/kernel_fc12.py
@@ -794,7 +794,7 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
         activation_sf_gemm = cute.make_tensor(
             activation_sf.iterator,
             blockscaled_utils.tile_atom_to_shape_SF(
-                (tokens_sum_padded, hidden_padded, 1), self.sf_vec_size),
+                (tokens_sum_padded, hidden_padded, c1), self.sf_vec_size),
         )
         intermediate_gateup_padded_mul_hidden_padded = fc1_weight_sf.shape[1]
         intermediate_gateup_padded = (
@@ -926,7 +926,7 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
             self.mma_tiler,
             tiled_mma,
             self.cluster_layout_vmnk.shape,
-            internal_type=cutlass.Uint64,
+            internal_type=cutlass.Uint16,
         )
 
         # TMA load SFB1 (= activation_sf, fc1 activation SFs)
@@ -941,7 +941,7 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
             self.mma_tiler_sfb,
             tiled_mma_sfb,
             self.cluster_layout_sfb_vmnk.shape,
-            internal_type=cutlass.Uint64,
+            internal_type=cutlass.Uint16,
         )
 
         # TMA store for fc1 NVFP4 output (via SMEM-staged bulk store).
@@ -999,7 +999,7 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
             self.mma_tiler,
             tiled_mma,
             self.cluster_layout_vmnk.shape,
-            internal_type=cutlass.Uint64,
+            internal_type=cutlass.Uint16,
         )
         tma_atom_fc1_output_sf_as_fc2_input, tma_tensor_fc1_output_sf_as_fc2_input = cute.nvgpu.make_tiled_tma_atom_B(
             sfb_op,
@@ -1008,7 +1008,7 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
             self.mma_tiler_sfb,
             tiled_mma_sfb,
             self.cluster_layout_sfb_vmnk.shape,
-            internal_type=cutlass.Uint64,
+            internal_type=cutlass.Uint16,
         )
 
         # ── Scheduler params + grid + launch ──

--- a/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/kernel_fc12.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/kernel_fc12.py
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 """Fused fc1+fc2 swap-AB SwiGLU NVFP4 kernel for SM100."""
 
 from typing import Literal, Optional, Tuple, Type
@@ -55,31 +57,32 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
     _SmemMiscBudget = 1024
 
     def __init__(
-        self,
-        # Geometry.
-        mma_tiler_mnk: Tuple[int, int, int],
-        cluster_shape_mnk: Tuple[int, int, int],
-        use_2cta_instrs: bool,
-        # Fused fc1+fc2 scheduler knobs.
-        group_hint: int,
-        token_padding_block: int,
-        sf_padding_block: int,
-        load_balance_mode: Literal["static", "atomic_counter"] = "static",
-        # Optional scheduler/codegen knobs.
-        static_expert_shape: Optional[Tuple[int, int, int]] = None,
-        force_static_sched: bool = True,
-        clc_bundle_size: Optional[int] = None,
-        num_sched_stages: Optional[int] = None,
-        acc_dtype: Type[cutlass.Numeric] = cutlass.Float32,
-        sf_vec_size: int = 16,
-        scenario: Literal["2Dx3D"] = "2Dx3D",
-        *,
-        fc2_output_dtype: Type[cutlass.Numeric],
-        non_ubulk_fc2_store: bool = True,
-        in_kernel_fc2_reduce: bool = False,
-        token_back_by_dispatch: bool = False,
-        apply_topk_in_fc1: bool = True,
-        gate_up_clamp: Optional[float] = None,
+            self,
+            # Geometry.
+            mma_tiler_mnk: Tuple[int, int, int],
+            cluster_shape_mnk: Tuple[int, int, int],
+            use_2cta_instrs: bool,
+            # Fused fc1+fc2 scheduler knobs.
+            group_hint: int,
+            token_padding_block: int,
+            sf_padding_block: int,
+            load_balance_mode: Literal["static", "atomic_counter"] = "static",
+            # Optional scheduler/codegen knobs.
+            static_expert_shape: Optional[Tuple[int, int, int]] = None,
+            force_static_sched: bool = True,
+            clc_bundle_size: Optional[int] = None,
+            num_sched_stages: Optional[int] = None,
+            acc_dtype: Type[cutlass.Numeric] = cutlass.Float32,
+            sf_vec_size: int = 16,
+            scenario: Literal["2Dx3D"] = "2Dx3D",
+            *,
+            fc2_output_dtype: Type[cutlass.Numeric],
+            non_ubulk_fc2_store: bool = True,
+            in_kernel_fc2_reduce: bool = False,
+            token_back_by_dispatch: bool = False,
+            apply_topk_in_fc1: bool = True,
+            gate_up_clamp: Optional[float] = None,
+            epi_flag_batch: Optional[Tuple[int, int]] = (1, 1),
     ) -> None:
         if not force_static_sched:
             raise NotImplementedError(
@@ -123,6 +126,7 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
         self.token_back_by_dispatch = token_back_by_dispatch
         self.apply_topk_in_fc1 = apply_topk_in_fc1
         self.gate_up_clamp = gate_up_clamp
+        self.epi_flag_batch = epi_flag_batch
 
         self._validate_mma_tiler_and_cluster_shape()
         self.mma_tiler = mma_tiler_mnk
@@ -142,6 +146,8 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
         self.sched_warp_id = 7
         # Installed by token-comm subclasses.
         self.dispatch_warp_id: Optional[Tuple[int, int, int, int]] = None
+        self.token_back_warp_id: Optional[Tuple[int, int, int, int]] = None
+        self.token_back_standalone: bool = False
         self.threads_per_cta = 32 * len((
             self.mma_warp_id,
             self.tma_a_warp_id,
@@ -161,7 +167,7 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
         # register allocation because setmaxnreg emission is gated by
         # ``self.enable_token_comm`` inside the device kernel.
         self.epi_reg_cnt = 256
-        self.task_reg_cnt = 96
+        self.task_reg_cnt = 72
 
         self.smem_capacity = utils.get_smem_capacity_in_bytes(self.arch)
         self.num_tmem_alloc_cols = cute.arch.get_max_tmem_alloc_cols(self.arch)
@@ -322,6 +328,7 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
             non_ubulk_fc2_store=self.non_ubulk_fc2_store,
             in_kernel_fc2_reduce=self.in_kernel_fc2_reduce,
             token_back_by_dispatch=self.token_back_by_dispatch,
+            epi_flag_batch=self.epi_flag_batch,
             acc_dtype=self.acc_dtype,
             allow_overlap_acc=True,
             static_expert_shape=self.static_expert_shape,
@@ -597,6 +604,18 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
         tidx,
     ):
         """Subclass dispatch warp body; no-op in the lean kernel."""
+
+    @cute.jit
+    def token_comm_hook_token_back_warp_body(
+        self,
+        token_comm_args,
+        token_comm_storage,
+        *,
+        warp_idx,
+        lane_idx,
+        tidx,
+    ):
+        """Subclass standalone token-back warp body; no-op in the lean kernel."""
 
     @cute.jit
     def token_comm_hook_kernel_tail(
@@ -1834,7 +1853,7 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
                         spin_wait(
                             counter_ptr,
                             lambda v: v >= fc2_spin_threshold,
-                            fail_sleep_cycles=20,
+                            fail_sleep_cycles=500,
                         )
                         iket.range_pop()
 
@@ -2023,8 +2042,10 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
                     ab_consumer.reset()
                     peek_ab_full_status = cutlass.Boolean(1)
                     if k_tile_cnt > 0:
+                        iket.range_push("mma_acquire")
                         peek_ab_full_status = ab_consumer.try_wait()
                         acc_pipeline.producer_acquire(acc_producer_state)
+                        iket.range_pop()
 
                     # Apply TMEM pointer offset hack when mma_tiler_n == 64.
                     tCtSFB_mma = tCtSFB
@@ -2151,13 +2172,31 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
                 cute.arch.warpgroup_reg_dealloc(self.task_reg_cnt)
 
                 lane_idx_for_dispatch = cute.arch.lane_idx()
-                self.token_comm_hook_dispatch_warp_body(
-                    token_comm_args,
-                    token_comm_storage,
-                    warp_idx=warp_idx,
-                    lane_idx=lane_idx_for_dispatch,
-                    tidx=tidx,
-                )
+                if cutlass.const_expr(self.token_back_standalone):
+                    if warp_idx < self.token_back_warp_id[0]:
+                        self.token_comm_hook_dispatch_warp_body(
+                            token_comm_args,
+                            token_comm_storage,
+                            warp_idx=warp_idx,
+                            lane_idx=lane_idx_for_dispatch,
+                            tidx=tidx,
+                        )
+                    else:
+                        self.token_comm_hook_token_back_warp_body(
+                            token_comm_args,
+                            token_comm_storage,
+                            warp_idx=warp_idx,
+                            lane_idx=lane_idx_for_dispatch,
+                            tidx=tidx,
+                        )
+                else:
+                    self.token_comm_hook_dispatch_warp_body(
+                        token_comm_args,
+                        token_comm_storage,
+                        warp_idx=warp_idx,
+                        lane_idx=lane_idx_for_dispatch,
+                        tidx=tidx,
+                    )
 
         # ════════════════════════════════════════════════════════════════════
         # Kernel tail hook (MegaMoE-only path; lean base = no-op)

--- a/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/kernel_fc12.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/kernel_fc12.py
@@ -794,7 +794,7 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
         activation_sf_gemm = cute.make_tensor(
             activation_sf.iterator,
             blockscaled_utils.tile_atom_to_shape_SF(
-                (tokens_sum_padded, hidden_padded, c1), self.sf_vec_size),
+                (tokens_sum_padded, hidden_padded, 1), self.sf_vec_size),
         )
         intermediate_gateup_padded_mul_hidden_padded = fc1_weight_sf.shape[1]
         intermediate_gateup_padded = (
@@ -926,7 +926,7 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
             self.mma_tiler,
             tiled_mma,
             self.cluster_layout_vmnk.shape,
-            internal_type=cutlass.Uint16,
+            internal_type=cutlass.Uint64,
         )
 
         # TMA load SFB1 (= activation_sf, fc1 activation SFs)
@@ -941,7 +941,7 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
             self.mma_tiler_sfb,
             tiled_mma_sfb,
             self.cluster_layout_sfb_vmnk.shape,
-            internal_type=cutlass.Uint16,
+            internal_type=cutlass.Uint64,
         )
 
         # TMA store for fc1 NVFP4 output (via SMEM-staged bulk store).
@@ -999,7 +999,7 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
             self.mma_tiler,
             tiled_mma,
             self.cluster_layout_vmnk.shape,
-            internal_type=cutlass.Uint16,
+            internal_type=cutlass.Uint64,
         )
         tma_atom_fc1_output_sf_as_fc2_input, tma_tensor_fc1_output_sf_as_fc2_input = cute.nvgpu.make_tiled_tma_atom_B(
             sfb_op,
@@ -1008,7 +1008,7 @@ class Sm100SwapABSwigluFp4Fc12Kernel:
             self.mma_tiler_sfb,
             tiled_mma_sfb,
             self.cluster_layout_sfb_vmnk.shape,
-            internal_type=cutlass.Uint16,
+            internal_type=cutlass.Uint64,
         )
 
         # ── Scheduler params + grid + launch ──

--- a/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/megamoe_constants.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/megamoe_constants.py
@@ -1,6 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Shared constants for the fused fc1+fc2 MegaMoE path."""
+"""Shared constants for the fused fc1+fc2 MegaMoE path.
+
+Deliberately cutlass-free (a TRT-LLM-local trim of the upstream
+``common/megamoe_constants.py``): the package ``__init__`` imports these for
+capability probing on non-SM100 / no-cutlass-dsl hosts, so this module must NOT
+``from cutlass...`` import. Only the constants actually consumed by the ported
+kernel package are kept; the cutlass-typed ``Log2E`` / ``Fp32Max`` upstream
+constants are unused here (the kernels inline their own ``cutlass.Float32``).
+"""
 
 Nvfp4BlockSize = 16
 SfPaddingBlock = 128

--- a/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/megamoe_kernel.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/megamoe_kernel.py
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 """MegaMoE fused dispatch + fc1 + fc2 + combine kernel.
 
 The base class owns the local fc1/fc2 GEMM pipeline.  This subclass owns the
@@ -38,7 +40,7 @@ multiple of ``token_padding_block``.
 # quoted explicitly.
 
 import dataclasses
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, List, Literal, Optional, Tuple, Type
 
 import cutlass
 import cutlass.cute as cute
@@ -47,7 +49,7 @@ from cutlass.cutlass_dsl import Int64
 
 from .kernel_fc12 import Sm100SwapABSwigluFp4Fc12Kernel
 from .token_comm import TokenCommArgs as ExtractedTokenCommArgs
-from .token_comm import TokenInPullTokenBackPush
+from .token_comm import TokenInPullTokenBackPush, TokenSrcMetadata
 
 # =============================================================================
 # Module-level constants.
@@ -60,9 +62,9 @@ _DispatchToSchedNamedBarrierId = 9  # 4 dispatch + 1 sched (160 threads)
 # Dispatch warp count.
 _DispatchWarpCount = 4
 
-# Per-pool-slot provenance record consumed by combine STG redirect (S3).
-# Three packed Uint32 fields = 12 bytes: ``{src_rank, src_token, src_topk}``.
-_TokenMetadataBytes = 12
+# Per-pool-slot provenance record consumed by combine STG redirect (S3) and
+# token-back; one i64 = {src_rank, src_token, src_topk} (see TokenSrcMetadata).
+_TokenMetadataBytes = TokenSrcMetadata.nbytes
 
 # NVLink signal slots used by the DeepGEMM-style phase/sign barrier.
 # A separate local counter selects phase/sign; the signal slots are not reset
@@ -175,9 +177,12 @@ class Sm100MegaMoEKernel(Sm100SwapABSwigluFp4Fc12Kernel):
         fc2_output_dtype: Type[cutlass.Numeric],
         non_ubulk_fc2_store: bool = True,
         in_kernel_fc2_reduce: bool = False,
-        token_back_by_dispatch: bool = False,
+        token_back_mode: Literal["epi_warps", "standalone_warps",
+                                 "reuse_dispatch_warps"] = "epi_warps",
         apply_topk_in_fc1: bool = True,
         gate_up_clamp: Optional[float] = None,
+        epi_flag_batch: Optional[Tuple[int, int]] = (1, 1),
+        flag_batch: int = 1,
     ) -> None:
         if static_expert_shape is None:
             raise NotImplementedError(
@@ -190,6 +195,20 @@ class Sm100MegaMoEKernel(Sm100SwapABSwigluFp4Fc12Kernel):
             raise ValueError(
                 f"hidden ({hidden}) must equal "
                 f"static_expert_shape[2] ({static_expert_shape[2]}).")
+
+        # token_back_mode selects where the cross-rank fc2 push-back runs:
+        #   epi_warps            -> epilogue warps STG directly to the peer
+        #   standalone_warps     -> dedicated warp group 12-15, concurrent
+        #                           with dispatch_pull
+        #   reuse_dispatch_warps -> dispatch warps 8-11 push after dispatch_pull
+        # The two non-epi modes both stage fc2 to a local workspace first, i.e.
+        # token_back_by_dispatch=True; epi_warps keeps the epilogue STG redirect.
+        if token_back_mode not in ("epi_warps", "standalone_warps",
+                                   "reuse_dispatch_warps"):
+            raise ValueError(
+                f"token_back_mode must be 'epi_warps', 'standalone_warps', "
+                f"or 'reuse_dispatch_warps'; got {token_back_mode!r}.")
+        token_back_by_dispatch = token_back_mode != "epi_warps"
 
         super().__init__(
             mma_tiler_mnk=mma_tiler_mnk,
@@ -212,16 +231,26 @@ class Sm100MegaMoEKernel(Sm100SwapABSwigluFp4Fc12Kernel):
             token_back_by_dispatch=token_back_by_dispatch,
             apply_topk_in_fc1=apply_topk_in_fc1,
             gate_up_clamp=gate_up_clamp,
+            epi_flag_batch=epi_flag_batch,
         )
 
         self.enable_token_comm = True
         self.dispatch_warp_id = (8, 9, 10, 11)
+        # Standalone token-back: a dedicated 4-warp group (12-15) doing
+        # token_back_by_push concurrently with dispatch_pull, selected by the
+        # user-facing token_back_mode knob ("standalone_warps").
+        self.token_back_mode = token_back_mode
+        self.token_back_standalone = token_back_mode == "standalone_warps"
+        self.token_back_warp_id = (12, 13, 14,
+                                   15) if self.token_back_standalone else None
+        num_token_back_warps = (len(self.token_back_warp_id)
+                                if self.token_back_standalone else 0)
         self.threads_per_cta = 32 * (
             len(self.epilogue_warp_id) + 1  # mma
             + 1  # tma_a
             + 1  # tma_b
             + 1  # sched
-            + len(self.dispatch_warp_id))
+            + len(self.dispatch_warp_id) + num_token_back_warps)
 
         # Independent MegaMoE-specific constants.
         self.world_size = world_size
@@ -275,6 +304,12 @@ class Sm100MegaMoEKernel(Sm100SwapABSwigluFp4Fc12Kernel):
             (self.hidden + cluster_fc2_tile_hidden - 1) //
             cluster_fc2_tile_hidden) * self.cluster_shape_mn[0]
 
+        # Homomorphic to the fc1+fc2 scheduler: atomic_counter token-back only
+        # nets a win with enough tokens, the same condition that selects the
+        # atomic_counter fc1+fc2 scheduler.  Static when token-back is off.
+        self.token_back_schedule_mode = (
+            self.load_balance_mode if self.token_back_by_dispatch else "static")
+
         self.token_comm = TokenInPullTokenBackPush(
             world_size=self.world_size,
             local_rank=self.local_rank,
@@ -287,6 +322,9 @@ class Sm100MegaMoEKernel(Sm100SwapABSwigluFp4Fc12Kernel):
                               if self.token_back_by_dispatch else None),
             fc2_publishes_per_token_cluster_tile=
             fc2_publishes_per_token_cluster_tile,
+            token_back_reduce_topk=(self.token_back_by_dispatch
+                                    and self.in_kernel_fc2_reduce),
+            token_back_standalone=self.token_back_standalone,
             sf_uint32_per_token=self.sf_uint32_per_token,
             token_padding_block=self.token_padding_block,
             sf_padding_block=self.sf_padding_block,
@@ -294,6 +332,8 @@ class Sm100MegaMoEKernel(Sm100SwapABSwigluFp4Fc12Kernel):
             cluster_shape_mn=self.cluster_shape_mn,
             dispatch_warp_start=self.dispatch_warp_id[0],
             num_other_warps=num_other_warps,
+            flag_batch=flag_batch,
+            token_back_schedule_mode=self.token_back_schedule_mode,
         )
 
         # Region layout (same call drives both get_workspace_sizes() and
@@ -322,9 +362,13 @@ class Sm100MegaMoEKernel(Sm100SwapABSwigluFp4Fc12Kernel):
         pull_mbar_bytes = _DispatchWarpCount * 8
         expert_count_bytes = self.num_total_experts * 4
         pull_buffer_bytes = _DispatchWarpCount * self.hidden_bytes
-        return (_round_up(pull_mbar_bytes, 16) +
-                _round_up(expert_count_bytes, 16) +
-                _round_up(pull_buffer_bytes, 128))
+        total = (_round_up(pull_mbar_bytes, 16) +
+                 _round_up(expert_count_bytes, 16) +
+                 _round_up(pull_buffer_bytes, 128))
+        if self.token_back_standalone:
+            total += (_round_up(_DispatchWarpCount * 8, 16) + _round_up(
+                _DispatchWarpCount * self.token_comm.tb_chunk_bytes, 128))
+        return total
 
     def _smem_misc_budget_bytes(self) -> int:
         """Base misc reservation plus dispatch-warp SMEM."""
@@ -504,6 +548,14 @@ class Sm100MegaMoEKernel(Sm100SwapABSwigluFp4Fc12Kernel):
                     (num_experts_per_rank, ),
                     16,
                 ))
+            if self.token_back_schedule_mode == "atomic_counter":
+                specs.append(
+                    _RegionSpec(
+                        "token_back_schedule_counter",
+                        cutlass.Int32,
+                        (1, ),
+                        16,
+                    ))
 
         if self.load_balance_mode == "atomic_counter":
             specs.append(
@@ -881,6 +933,15 @@ class Sm100MegaMoEKernel(Sm100SwapABSwigluFp4Fc12Kernel):
             fc2_done_counter = None
             combine_output_u8 = combine_output
 
+        if cutlass.const_expr(
+                self.token_back_schedule_mode == "atomic_counter"):
+            token_back_schedule_counter = self._view_local(
+                local_workspace,
+                "token_back_schedule_counter",
+            ).iterator
+        else:
+            token_back_schedule_counter = None
+
         token_comm_args = ExtractedTokenCommArgs(
             input_token_buffer=activation,
             input_sf_buffer=activation_sf,
@@ -898,6 +959,7 @@ class Sm100MegaMoEKernel(Sm100SwapABSwigluFp4Fc12Kernel):
             combine_output=combine_output_u8,
             fc2_output_workspace=fc2_output_workspace_u8,
             fc2_done_counter=fc2_done_counter,
+            token_back_schedule_counter=token_back_schedule_counter,
             nvlink_barrier_signal=nvlink_barrier_signal,
             nvlink_barrier_counter=nvlink_barrier_counter,
             grid_sync_counter=grid_sync_counter,
@@ -987,6 +1049,24 @@ class Sm100MegaMoEKernel(Sm100SwapABSwigluFp4Fc12Kernel):
         tidx,
     ):
         self.token_comm.dispatch_warp_body(
+            token_comm_args,
+            token_comm_storage,
+            warp_idx=warp_idx,
+            lane_idx=lane_idx,
+            tidx=tidx,
+        )
+
+    @cute.jit
+    def token_comm_hook_token_back_warp_body(
+        self,
+        token_comm_args,
+        token_comm_storage,
+        *,
+        warp_idx,
+        lane_idx,
+        tidx,
+    ):
+        self.token_comm.token_back_warp_body(
             token_comm_args,
             token_comm_storage,
             warp_idx=warp_idx,

--- a/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/moe_persistent_scheduler.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/moe_persistent_scheduler.py
@@ -1,5 +1,32 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """Shared MoE persistent scheduler utilities."""
 
 from abc import ABC, abstractmethod
@@ -399,8 +426,8 @@ class MoEStaticSchedulerParams(MoESchedulerParamsBase):
         else:
             result.hidden = self.hidden
         assert idx == len(values), (
-            f"Static sched params type-discrim mismatch: idx={idx} len(values)={len(values)}"
-        )
+            f"Static sched params type-discrim mismatch: idx={idx} "
+            f"len(values)={len(values)}")
         return result
 
     def get_scheduler_type(self) -> type:
@@ -543,8 +570,8 @@ class MoEDynamicSchedulerParams(MoESchedulerParamsBase):
         else:
             result.hidden = self.hidden
         assert idx == len(values), (
-            f"Dyn sched params type-discrim mismatch: idx={idx} len(values)={len(values)}"
-        )
+            f"Dyn sched params type-discrim mismatch: idx={idx} "
+            f"len(values)={len(values)}")
         return result
 
     def get_scheduler_type(self) -> type:
@@ -1976,7 +2003,8 @@ class MoEDynamicPersistentTileScheduler(MoESchedulerBase):
         For 2Dx2D, S is always 1, so bundle_idx is always 0; the formula
         degenerates correctly.
         """
-        linear_idx = self._clc_state.clc_l * self.params.work_id_bundle_scale + bundle_idx
+        linear_idx = (self._clc_state.clc_l * self.params.work_id_bundle_scale +
+                      bundle_idx)
         return self._get_work_tile_for_linear_idx(linear_idx, loc=loc, ip=ip)
 
     # =========================================================================

--- a/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/moe_utils.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/moe_utils.py
@@ -1,5 +1,32 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """Shared MoE scheduler utilities and online TMA descriptor helpers."""
 
 from abc import ABC, abstractmethod
@@ -179,8 +206,8 @@ def gmem_ptr_to_generic(
 ) -> Pointer:
     if gmem_ptr.memspace != AddressSpace.gmem:
         raise ValueError(
-            f"gmem_ptr_to_generic requires pointer in gmem address space, got {gmem_ptr.memspace}"
-        )
+            f"gmem_ptr_to_generic requires pointer in gmem address space, "
+            f"got {gmem_ptr.memspace}")
     # Get LLVM pointer and cast to generic address space
     llvm_ptr = gmem_ptr.to_llvm_ptr(loc=loc,
                                     ip=ip)  # type: ignore[attr-defined]
@@ -1145,12 +1172,12 @@ class MoEScaledGroupedGemmTensormapConstructor(OnlineTensormapDescCreator):
 
         a_chunks_to_move = (padded_offset // self.sf_vec_size *
                             cute.size(self.sfa_tensor, mode=[0]) // 128)
-        a_elems_to_move = cute.size(
-            self.sfa_tensor, mode=[0]) * padded_offset // self.sf_vec_size
+        a_elems_to_move = (cute.size(self.sfa_tensor, mode=[0]) *
+                           padded_offset // self.sf_vec_size)
         b_chunks_to_move = (padded_offset // self.sf_vec_size *
                             cute.size(self.sfb_tensor, mode=[0]) // 128)
-        b_elems_to_move = cute.size(
-            self.sfb_tensor, mode=[0]) * padded_offset // self.sf_vec_size
+        b_elems_to_move = (cute.size(self.sfb_tensor, mode=[0]) *
+                           padded_offset // self.sf_vec_size)
 
         per_expert_sfa_shape = (self.sfa_tensor.shape[0], padded_size_i, c1
                                 )  # type: ignore[index]

--- a/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/ptx_helpers.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/ptx_helpers.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Inline-PTX wrappers (TMA 1D load/store, fns.b32, raw-int64 peer ops) for the cuTeDSL dispatch kernel."""
+"""Inline-PTX wrappers (TMA 1D load/store, fns.b32, raw-int64 peer ops) for the cuTeDSL kernels."""
 
+from typing import Optional
+
+from cutlass._mlir import ir
 from cutlass._mlir.dialects import llvm
 from cutlass.cutlass_dsl import Float32, Int32, Int64, T, dsl_user_op
 
@@ -87,6 +90,63 @@ def tma_store_1d(dst_gmem, src_smem, num_bytes, *, loc=None, ip=None):
         "l,r,r,l",
         has_side_effects=True,
         asm_dialect=0,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def cp_async_bulk_s2g(dst_gmem,
+                      src_smem,
+                      size_bytes,
+                      *,
+                      loc=None,
+                      ip=None) -> None:
+    """Issue descriptor-free ``cp.async.bulk`` SMEM->GMEM.
+
+    The caller owns ``cp_async_bulk_commit_group`` so copy and reduce bulk
+    paths can share the same group boundary.
+    """
+    llvm.inline_asm(
+        None,
+        [
+            dst_gmem.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            src_smem.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            size_bytes.ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.bulk.global.shared::cta.bulk_group [$0], [$1], $2;",
+        "l,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def cp_reduce_async_bulk_add_noftz_bf16_s2g(
+    dst_gmem,
+    src_smem,
+    size_bytes,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Issue descriptor-free ``cp.reduce.async.bulk`` for BF16 add."""
+    llvm.inline_asm(
+        None,
+        [
+            dst_gmem.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            src_smem.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            size_bytes.ir_value(loc=loc, ip=ip),
+        ],
+        "cp.reduce.async.bulk.global.shared::cta.bulk_group.add.noftz.bf16 "
+        "[$0], [$1], $2;",
+        "l,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
         loc=loc,
         ip=ip,
     )
@@ -205,6 +265,31 @@ def red_add_release_sys_u64_raw(addr: Int64,
 
 
 @dsl_user_op
+def red_add_relaxed_sys_u64_raw(addr: Int64,
+                                val: Int64,
+                                *,
+                                loc=None,
+                                ip=None) -> None:
+    """``red.relaxed.sys.global.add.u64`` via raw int64 byte address.
+
+    Relaxed (no release fence) sibling of ``red_add_release_sys_u64_raw``.  Use
+    when an enclosing ``bar.sync`` + a later release fence (e.g. the trailing
+    ``nvlink_barrier`` publish) already provides cross-rank ordering, so the
+    per-op release fence would just emit a redundant ``membar.sys`` drain.
+    """
+    llvm.inline_asm(
+        None,
+        [addr.ir_value(), val.ir_value()],
+        "red.relaxed.sys.global.add.u64 [$0], $1;",
+        "l,l",
+        has_side_effects=True,
+        asm_dialect=0,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
 def red_add_release_sys_s32_raw(addr: Int64,
                                 val: Int32,
                                 *,
@@ -222,6 +307,58 @@ def red_add_release_sys_s32_raw(addr: Int64,
         "l,r",
         has_side_effects=True,
         asm_dialect=0,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def red_add_relaxed_sys_v2_bf16x2(
+    addr,
+    val0_packed_bf16x2,
+    val1_packed_bf16x2,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Issue ``red.relaxed.sys.global.add.v2.bf16x2 [addr], {v0, v1};``."""
+    llvm.inline_asm(
+        None,
+        [
+            addr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            val0_packed_bf16x2.ir_value(loc=loc, ip=ip),
+            val1_packed_bf16x2.ir_value(loc=loc, ip=ip),
+        ],
+        "red.relaxed.sys.global.add.noftz.v2.bf16x2 [$0], {$1, $2};",
+        "l,r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def red_add_release_gpu_s32(
+    counter_ptr,
+    value,
+    *,
+    loc: Optional[ir.Location] = None,
+    ip: Optional[ir.InsertionPoint] = None,
+) -> None:
+    """Issue ``red.release.gpu.global.add.s32`` to a GMEM int32 location."""
+    llvm.inline_asm(
+        None,
+        [
+            counter_ptr.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            value.ir_value(loc=loc, ip=ip),
+        ],
+        "red.release.gpu.global.add.s32 [$0], $1;",
+        "l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
         loc=loc,
         ip=ip,
     )
@@ -267,3 +404,27 @@ def read_clock64(*, loc=None, ip=None) -> Int64:
             loc=loc,
             ip=ip,
         ))
+
+
+@dsl_user_op
+def _fence_rel_sys(*,
+                   loc: Optional[ir.Location] = None,
+                   ip: Optional[ir.InsertionPoint] = None) -> None:
+    """
+    Fence operation with acquire-release semantics at system scope.
+
+    See the `PTX documentation <https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-membar>`__.
+    """
+    llvm.fence(llvm.AtomicOrdering.release, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def _fence_rel_gpu(*,
+                   loc: Optional[ir.Location] = None,
+                   ip: Optional[ir.InsertionPoint] = None) -> None:
+    """
+    Fence operation with acquire-release semantics at system scope.
+
+    See the `PTX documentation <https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-membar>`__.
+    """
+    llvm.fence(llvm.AtomicOrdering.release, syncscope="device", loc=loc, ip=ip)

--- a/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/sym_buffer.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/sym_buffer.py
@@ -2,17 +2,22 @@
 # SPDX-License-Identifier: Apache-2.0
 """Symmetric-heap peer pointer mapper.
 
-``SymBufferHost`` is the runtime payload that crosses the Python ->
-generated-host-code boundary.  Inside the generated host wrapper, it packs
-the runtime base address and per-rank offsets into a device-side
-``SymBuffer{N}`` native struct:
+The device-side SymBuffer carries ONLY the per-rank offset table.  Layout is
+chosen at trace time by ``num_max_ranks`` (a constexpr):
 
-    { i64 base, vector<N x i64> offsets, i32 rank_idx }
+* ``<= 16`` ranks: a ``cute_nvgpu.grid_constant`` / ``llvm.byval`` pointer to a
+  ``struct<(array<16 x i64>)>`` (exactly 128B).  ``map`` does a runtime-indexed
+  ``getelementptr`` + ``load`` that lowers to a const-bank ``LDC c[bnk][Ra]``.
+  The 128B byval size matches the host-side ``createKernelArgs`` copy (hardcoded
+  to 128B today), so it is corruption-safe up to EP16.
 
-Device code only sees that struct and calls ``.map`` /
-``.ptr_map_to_rank``.  The vector field is deliberate: LLVM supports
-runtime-indexed ``extractelement`` on vectors, which NVPTX lowers to an
-indexed param-bank load (``LDC.U64``).
+* ``> 16`` ranks: a by-value ``vector<N x i64>`` read with ``extractelement``.
+  Correct but spills the runtime index -- the fallback until the byval-size fix
+  reaches public cutedsl.
+
+``base``/``rank_idx`` are intentionally dropped: ``get_base_ptr`` had no callers
+and ``rank_idx`` is the owning rank's own constexpr (never read on device), so
+freeing those slots lets all 16 byval lanes hold offsets (EP16, not EP14).
 """
 
 from dataclasses import dataclass
@@ -24,16 +29,63 @@ from cutlass._mlir import ir
 from cutlass._mlir.dialects import arith, llvm
 from cutlass.base_dsl.dsl import (extract_mlir_values, get_mlir_types,
                                   new_from_mlir_values)
-from cutlass.base_dsl.native_struct import native_struct
 from cutlass.base_dsl.runtime.jit_arg_adapters import JitArgAdapterRegistry
 from cutlass.base_dsl.typing import get_c_pointers
 from cutlass.cute.typing import AddressSpace
 from cutlass.cutlass_dsl import Int32, Int64, dsl_user_op
 
+try:
+    # GEP encodes a runtime index by storing this sentinel in rawConstantIndices;
+    # it is MLIR's LLVM::GEPOp::kDynamicIndex (== INT32_MIN), frozen by the IR
+    # encoding ABI.  Track the canonical constant rather than re-hardcoding it.
+    from cutlass.base_dsl.typing import MLIR_DYNAMIC_INDEX
+except ImportError:  # older wheels: value is fixed by the GEP encoding ABI
+    MLIR_DYNAMIC_INDEX = -(2**31)
+
+_BYVAL_RANK_LIMIT = 16  # struct<(array<16 x i64>)> == exactly 128B
+
+
+#TODO: Fix this when compiler fixed. This is a shit WAR due to the cuda-to-llvm bug, it just treats any kernel arg to tma_desc as long as it's marked `grid_constant + byval`
+def _byval_struct_ty() -> Any:
+    """128B byval pointee shared by alloca / GEP / the ``llvm.byval`` attr."""
+    return ir.Type.parse(f"!llvm.struct<(array<{_BYVAL_RANK_LIMIT} x i64>)>")
+
 
 @dataclass(frozen=True)
 class SymBufferDeviceBase:
-    """Device-side methods shared by all generated ``SymBuffer{N}`` types."""
+    """Device-side SymBuffer: the per-rank offset table only.
+
+    ``val`` is a ``!llvm.ptr`` to a byval/grid_constant ``struct<(array<16 x i64>)>``
+    when ``num_max_ranks <= 16`` (``map`` -> GEP + load -> ``LDC``), else a by-value
+    ``vector<N x i64>`` (``map`` -> ``extractelement``, spills).
+    """
+
+    val: Any
+    num_max_ranks: cutlass.Constexpr[int]
+
+    def __extract_mlir_values__(self) -> list:
+        return [self.val]
+
+    def __new_from_mlir_values__(self, values: list) -> "SymBufferDeviceBase":
+        return SymBufferDeviceBase(val=values[0],
+                                   num_max_ranks=self.num_max_ranks)
+
+    def __get_mlir_types__(self) -> list:
+        if self.num_max_ranks <= _BYVAL_RANK_LIMIT:
+            return [ir.Type.parse("!llvm.ptr")]
+        return [ir.Type.parse(f"vector<{self.num_max_ranks}xi64>")]
+
+    def __extract_mlir_attributes__(self) -> list:
+        if self.num_max_ranks <= _BYVAL_RANK_LIMIT:
+            return [
+                ir.DictAttr.get({
+                    "cute_nvgpu.grid_constant":
+                    ir.UnitAttr.get(),
+                    "llvm.byval":
+                    ir.TypeAttr.get(_byval_struct_ty()),
+                })
+            ]
+        return [ir.DictAttr.get({})]
 
     @cute.jit
     def map(
@@ -42,12 +94,23 @@ class SymBufferDeviceBase:
             dst_rank_idx: Int32,
             byte_off: Int64 = Int64(0),
     ) -> Int64:
-        off = Int64(llvm.extractelement(self.offsets, dst_rank_idx.ir_value()))
+        if cutlass.const_expr(self.num_max_ranks <= _BYVAL_RANK_LIMIT):
+            # Opaque ptr -> the offsets array sits at byte 0 of the byval struct,
+            # so a flat ``gep i64, ptr, dst_rank`` reaches offsets[dst_rank]
+            # directly; the byval struct type only governs the 128B const-bank copy.
+            i64_ty = ir.Type.parse("i64")
+            off_ptr = llvm.getelementptr(
+                ir.Type.parse("!llvm.ptr"),
+                self.val,
+                [dst_rank_idx.ir_value()],
+                [MLIR_DYNAMIC_INDEX],
+                i64_ty,
+                no_wrap_flags="None",
+            )
+            off = Int64(llvm.load(i64_ty, off_ptr))
+        else:
+            off = Int64(llvm.extractelement(self.val, dst_rank_idx.ir_value()))
         return local_ptr + off + byte_off
-
-    @cute.jit
-    def get_base_ptr(self) -> Int64:
-        return self.base
 
     @cute.jit
     def ptr_map_to_rank(self, ptr, dst_rank_idx: Int32):
@@ -81,45 +144,50 @@ class SymBufferHost:
     def _as_int32(value) -> Int32:
         return value if isinstance(value, Int32) else Int32(int(value))
 
-    @staticmethod
-    def _make_device_type(num_max_ranks: int) -> type:
-        if num_max_ranks <= 0:
-            raise ValueError(
-                f"num_max_ranks must be positive, got {num_max_ranks}")
-
-        vec_ty_str = f"vector<{num_max_ranks}xi64>"
-
-        class _OffsetsT:
-
-            @staticmethod
-            def mlir_type() -> ir.Type:
-                return ir.Type.parse(vec_ty_str)
-
-        @native_struct
-        class _SymBufferDevice(SymBufferDeviceBase):
-            base: Int64
-            offsets: _OffsetsT
-            rank_idx: Int32
-
-        cls = _SymBufferDevice
-        cls.__name__ = f"SymBuffer{num_max_ranks}"
-        cls.__qualname__ = cls.__name__
-        cls.NUM_MAX_RANKS = num_max_ranks
-        return cls
-
     @dsl_user_op
     def make_device_obj(self, *, loc=None, ip=None) -> Any:
+        """Build the offsets-only device obj (see module docstring for layout)."""
         offsets = tuple(self.offsets)
         num_max_ranks = self.num_max_ranks
         if len(offsets) != num_max_ranks:
-            raise ValueError(
-                f"len(offsets)={len(offsets)} must equal "
-                f"num_max_ranks={num_max_ranks}; SymBuffer requires its "
-                f"runtime payload length to match the compiled vector type.")
+            raise ValueError(f"len(offsets)={len(offsets)} must equal "
+                             f"num_max_ranks={num_max_ranks}.")
 
+        if num_max_ranks <= _BYVAL_RANK_LIMIT:
+            ptr_ty = ir.Type.parse("!llvm.ptr")
+            st_ty = _byval_struct_ty()
+            i64_ty = ir.Type.parse("i64")
+            one = arith.constant(
+                value=ir.IntegerAttr.get(i64_ty, 1),
+                result=i64_ty,
+                loc=loc,
+                ip=ip,
+            )
+            buf = llvm.alloca(
+                res=ptr_ty,
+                elem_type=st_ty,
+                array_size=one,
+                alignment=64,
+                loc=loc,
+                ip=ip,
+            )
+            for i, off in enumerate(offsets):
+                slot = llvm.getelementptr(
+                    ptr_ty,
+                    buf,
+                    [],
+                    [i],
+                    i64_ty,
+                    no_wrap_flags="None",
+                    loc=loc,
+                    ip=ip,
+                )
+                llvm.store(self._as_int64(off).ir_value(), slot, loc=loc, ip=ip)
+            return SymBufferDeviceBase(val=buf, num_max_ranks=num_max_ranks)
+
+        i32_ty = ir.Type.parse("i32")
         vec_ty = ir.Type.parse(f"vector<{num_max_ranks}xi64>")
         vec = llvm.mlir_zero(vec_ty, loc=loc, ip=ip)
-        i32_ty = ir.Type.parse("i32")
         for i, off in enumerate(offsets):
             idx = arith.constant(
                 value=ir.IntegerAttr.get(i32_ty, i),
@@ -134,14 +202,7 @@ class SymBufferHost:
                 loc=loc,
                 ip=ip,
             )
-
-        return self._make_device_type(num_max_ranks)(
-            base=self._as_int64(self.base_addr),
-            offsets=vec,
-            rank_idx=self._as_int32(self.rank_idx),
-            loc=loc,
-            ip=ip,
-        )
+        return SymBufferDeviceBase(val=vec, num_max_ranks=num_max_ranks)
 
 
 @JitArgAdapterRegistry.register_jit_arg_adapter(SymBufferHost)

--- a/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/token_comm.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/token_comm.py
@@ -6,11 +6,15 @@ Current implementation: token-in pull with token-back push.  The standalone
 ``dispatch_kernel`` uses the same object methods as the fused MegaMoE kernel.
 """
 
-from typing import Any, Dict, List
+import dataclasses
+import os
+from typing import Any, ClassVar, Dict, List, Literal, Union
 
 import cutlass
 import cutlass.cute as cute
 import cutlass.pipeline as pipeline
+from cutlass.base_dsl.dsl import extract_mlir_attributes
+from cutlass.cute.typing import AddressSpace
 from cutlass.cutlass_dsl import (Float32, Int32, Int64, Uint8, Uint32,
                                  extract_mlir_values, new_from_mlir_values)
 
@@ -27,27 +31,55 @@ except NotImplementedError:  # pragma: no cover
 
 from cutlass._mlir import ir
 
+from .flag_batch import GpuReleaseFlagBatchTracker
 from .grid_sync import software_grid_sync
-from .moe_utils import spin_wait
-from .ptx_helpers import (fns_b32, ldg_b32_raw, ldg_f32_raw,
-                          red_add_release_sys_s32_raw,
-                          red_add_release_sys_u64_raw, stg_b32_raw, stg_b64_raw,
+from .moe_utils import _nanosleep, spin_wait
+from .ptx_helpers import (cp_reduce_async_bulk_add_noftz_bf16_s2g, fns_b32,
+                          ldg_b32_raw, ldg_f32_raw, read_clock64,
+                          red_add_relaxed_sys_u64_raw,
+                          red_add_release_sys_s32_raw, stg_b32_raw, stg_b64_raw,
                           tma_load_1d_raw, tma_store_1d)
 from .sf_swizzle import sf_atom_int32_offset
 
 
-def _store_token_src_metadata_u32x3(
-    token_src_metadata,
-    pool_token_idx,
-    src_rank: Uint32,
-    src_token: Uint32,
-    src_topk: Uint32,
-) -> None:
-    """Store `{src_rank, src_token, src_topk}` as three 32-bit fields."""
-    base_ptr = token_src_metadata.iterator + (pool_token_idx * Int32(12))
-    cute.arch.store(base_ptr, src_rank, scope="gpu")
-    cute.arch.store(base_ptr + Int32(4), src_token, scope="gpu")
-    cute.arch.store(base_ptr + Int32(8), src_topk, scope="gpu")
+@dataclasses.dataclass(frozen=True)
+class TokenSrcMetadata:
+    """Per pool-token routing record: written by token-in, read by token-back
+    and the fc2 combine-redirect epilogue.
+
+    Wire format is one i64: low 32b = ``src_token`` (needs full width); high 32b
+    = ``(src_rank << 16) | src_topk`` (``src_rank < world_size`` and
+    ``src_topk < num_topk`` both fit in 16b).  ``load`` / ``store`` accept either
+    a ``cute.Pointer`` or a raw ``Int64`` byte address.
+    """
+
+    src_rank: Int32
+    src_token: Int32
+    src_topk: Int32
+
+    nbytes: ClassVar[int] = 8
+
+    def _pack(self) -> Int64:
+        hi = (Int64(self.src_rank) << Int64(16)) | Int64(self.src_topk)
+        return (hi << Int64(32)) | (Int64(self.src_token) & Int64(0xFFFFFFFF))
+
+    @staticmethod
+    def _i64_ptr(addr: Union[cute.Pointer, Int64]) -> cute.Pointer:
+        addr_i = addr if isinstance(addr, Int64) else addr.toint()
+        return cute.make_ptr(Int64, addr_i, AddressSpace.gmem, assumed_align=8)
+
+    def store(self, addr: Union[cute.Pointer, Int64]) -> None:
+        cute.arch.store(self._i64_ptr(addr), self._pack(), scope="gpu")
+
+    @classmethod
+    def load(cls, addr: Union[cute.Pointer, Int64]) -> "TokenSrcMetadata":
+        v = Int64(cute.arch.load(cls._i64_ptr(addr), Int64, scope="gpu"))
+        hi = v >> Int64(32)
+        return cls(
+            src_rank=Int32((hi >> Int64(16)) & Int64(0xFFFF)),
+            src_token=Int32(v & Int64(0xFFFFFFFF)),
+            src_topk=Int32(hi & Int64(0xFFFF)),
+        )
 
 
 _MLIR_VALUE_FIELDS = (
@@ -67,6 +99,7 @@ _MLIR_VALUE_FIELDS = (
     "combine_output",
     "fc2_output_workspace",
     "fc2_done_counter",
+    "token_back_schedule_counter",
     "nvlink_barrier_signal",
     "nvlink_barrier_counter",
     "grid_sync_counter",
@@ -123,6 +156,7 @@ class TokenCommArgs:
         sm_count: int,
         fc2_output_workspace: cute.Tensor = None,
         fc2_done_counter: cute.Tensor = None,
+        token_back_schedule_counter: cute.Pointer = None,
     ):
         self.input_token_buffer = input_token_buffer
         self.input_sf_buffer = input_sf_buffer
@@ -140,6 +174,7 @@ class TokenCommArgs:
         self.combine_output = combine_output
         self.fc2_output_workspace = fc2_output_workspace
         self.fc2_done_counter = fc2_done_counter
+        self.token_back_schedule_counter = token_back_schedule_counter
         self.nvlink_barrier_signal = nvlink_barrier_signal
         self.nvlink_barrier_counter = nvlink_barrier_counter
         self.grid_sync_counter = grid_sync_counter
@@ -164,6 +199,17 @@ class TokenCommArgs:
             values.extend(extract_mlir_values(attr))
         return values
 
+    def __extract_mlir_attributes__(self) -> List[Any]:
+        # Mirror __extract_mlir_values__ 1:1 so per-arg attrs stay aligned; the
+        # only non-empty entry is peer_rank_ptr_mapper's byval/grid_constant.
+        attrs: List[Any] = []
+        for name in _MLIR_VALUE_FIELDS:
+            attr = getattr(self, name)
+            if attr is None:
+                continue
+            attrs.extend(extract_mlir_attributes(attr))
+        return attrs
+
     def __new_from_mlir_values__(self,
                                  values: List[ir.Value]) -> "TokenCommArgs":
         idx = 0
@@ -176,9 +222,8 @@ class TokenCommArgs:
             n = len(extract_mlir_values(proto))
             rebuilt[name] = new_from_mlir_values(proto, values[idx:idx + n])
             idx += n
-        assert idx == len(values), (
-            f"TokenCommArgs serialization mismatch: consumed={idx} provided={len(values)}"
-        )
+        assert idx == len(values), (f"TokenCommArgs serialization mismatch: "
+                                    f"consumed={idx} provided={len(values)}")
         const_kwargs = {name: getattr(self, name) for name in _CONST_FIELDS}
         return TokenCommArgs(**rebuilt, **const_kwargs)
 
@@ -192,8 +237,11 @@ class TokenInPullTokenBackPush:
     dispatch_intra_cta_bar_id: int = 10
     kernel_tail_named_barrier_id: int = 8
     dispatch_to_sched_named_barrier_id: int = 9
-    dispatch_to_sched_threads: int = (num_dispatch_warps + 1) * warp_threads
+    # dispatch_to_sched / kernel_tail thread counts are per-instance (see __init__).
     experts_per_dispatch_pass: int = num_dispatch_threads
+    # Developer-only knob (MEGA_TOKEN_BACK_ATOMIC_BATCH); not user-facing.
+    token_back_atomic_batch: int = int(
+        os.environ.get("MEGA_TOKEN_BACK_ATOMIC_BATCH", "1"))
 
     def __init__(
         self,
@@ -214,6 +262,11 @@ class TokenInPullTokenBackPush:
         num_other_warps: int,
         fc2_output_dtype=None,
         fc2_publishes_per_token_cluster_tile: int = 0,
+        token_back_reduce_topk: bool = False,
+        token_back_standalone: bool = False,
+        flag_batch: int = 1,
+        token_back_schedule_mode: Literal["static",
+                                          "atomic_counter"] = "static",
     ) -> None:
         self.world_size = world_size
         self.local_rank = local_rank
@@ -228,6 +281,18 @@ class TokenInPullTokenBackPush:
         self.sf_padding_block = sf_padding_block
         self.cluster_tile_tokens = cluster_tile_tokens
         self.cluster_shape_mn = cluster_shape_mn
+        if flag_batch < 1 or flag_batch > 32:
+            raise ValueError(
+                f"flag_batch must be in [1, 32], got {flag_batch}.")
+        # Release-flag batch size consumed by dispatch_pull as a Python int.
+        # One warp lane carries one delayed release target.
+        self._flag_batch = flag_batch
+
+        if token_back_schedule_mode not in ("static", "atomic_counter"):
+            raise ValueError(
+                "token_back_schedule_mode must be 'static' or "
+                f"'atomic_counter'; got {token_back_schedule_mode!r}.")
+        self.token_back_schedule_mode = token_back_schedule_mode
         self.dispatch_warp_start = dispatch_warp_start
         # Warps that share this CTA with the dispatch group but are not part
         # of it. They participate in kernel-tail / dispatch-with-other
@@ -236,10 +301,39 @@ class TokenInPullTokenBackPush:
         # collapse to dispatch-only).
         self.num_other_warps = num_other_warps
         self.num_other_threads = num_other_warps * self.warp_threads
-        self.num_total_threads = self.num_dispatch_threads + self.num_other_threads
+
+        # Standalone token-back: a dedicated warpgroup (size == dispatch group)
+        # right after the dispatch warps, active only when token-back is enabled.
+        # It joins the dispatch->sched handshake and the kernel-tail rendezvous.
+        self.token_back_standalone = (fc2_output_dtype
+                                      is not None) and token_back_standalone
+        self.num_token_back_warps = self.num_dispatch_warps if self.token_back_standalone else 0
+        self.num_token_back_threads = self.num_token_back_warps * self.warp_threads
+        self.token_back_warp_start = dispatch_warp_start + self.num_dispatch_warps
+        # Standalone token-back per-warp pull buffer; token is moved in
+        # tb_chunk_bytes pieces (last piece carries the remainder), so this is
+        # independent of hidden.
+        self.tb_chunk_bytes = 2048
+
+        self.num_total_threads = (self.num_dispatch_threads +
+                                  self.num_other_threads +
+                                  self.num_token_back_threads)
+        self.dispatch_to_sched_threads = (
+            self.num_dispatch_warps + 1 +
+            self.num_token_back_warps) * self.warp_threads
         self.kernel_tail_threads = self.num_total_threads
 
         self.fc2_output_dtype = fc2_output_dtype
+        if token_back_reduce_topk:
+            if fc2_output_dtype is None:
+                raise ValueError(
+                    "token_back_reduce_topk=True requires fc2_output_dtype "
+                    "to enable token-back.")
+            if fc2_output_dtype is not cutlass.BFloat16:
+                raise NotImplementedError(
+                    "token_back_reduce_topk currently supports BF16 fc2 "
+                    f"output only, got {fc2_output_dtype}.")
+        self.token_back_reduce_topk = token_back_reduce_topk
         if fc2_output_dtype is not None:
             self.fc2_token_bytes = hidden * int(fc2_output_dtype.width) // 8
             if self.fc2_token_bytes % self.hidden_bytes != 0:
@@ -252,7 +346,8 @@ class TokenInPullTokenBackPush:
                 raise ValueError(
                     "fc2_publishes_per_token_cluster_tile must be > 0 when "
                     "fc2_output_dtype is set (token_back_by_push enabled).")
-            self.fc2_publishes_per_token_cluster_tile = fc2_publishes_per_token_cluster_tile
+            self.fc2_publishes_per_token_cluster_tile = (
+                fc2_publishes_per_token_cluster_tile)
         else:
             self.fc2_token_bytes = 0
             self.fc2_num_chunks = 0
@@ -265,6 +360,22 @@ class TokenInPullTokenBackPush:
     def extra_smem_storage_class(self) -> type:
         hidden_bytes = self.hidden_bytes
         num_total_experts = self.num_total_experts
+
+        if self.token_back_standalone:
+
+            @cute.struct
+            class TokenCommStorage:
+                pull_mbar: cute.struct.MemRange[Int64, self.num_dispatch_warps]
+                smem_expert_count: cute.struct.MemRange[Int32,
+                                                        num_total_experts]
+                pull_buffer: cute.struct.Align[cute.struct.MemRange[
+                    Uint8, self.num_dispatch_warps * hidden_bytes], 16]
+                tb_pull_mbar: cute.struct.MemRange[Int64,
+                                                   self.num_token_back_warps]
+                tb_pull_buffer: cute.struct.Align[cute.struct.MemRange[
+                    Uint8, self.num_token_back_warps * self.tb_chunk_bytes], 16]
+
+            return TokenCommStorage
 
         @cute.struct
         class TokenCommStorage:
@@ -288,14 +399,15 @@ class TokenInPullTokenBackPush:
 
     @cute.jit
     def fc1_tma_b_predispatch_spin(self, token_comm_args, work_tile_info):
-        counter_slot = work_tile_info.cumulative_token_block_count + work_tile_info.tile_n_idx
+        counter_slot = (work_tile_info.cumulative_token_block_count +
+                        work_tile_info.tile_n_idx)
         counter_ptr = token_comm_args.fc1_ready_counter.iterator + counter_slot
         if not work_tile_info.peek_ready:
             _iket.range_push("tma_token_fc1_wait")
             spin_wait(
                 counter_ptr,
                 lambda v: v >= work_tile_info.valid_tokens_in_tile,
-                fail_sleep_cycles=20,
+                fail_sleep_cycles=1000,
             )
             _iket.range_pop()
 
@@ -471,7 +583,8 @@ class TokenInPullTokenBackPush:
                         dst_rank,
                         Int64(dst_local_expert * Int32(8)),
                     )
-                    red_add_release_sys_u64_raw(ercs_peer_addr, status_u64)
+                    red_add_relaxed_sys_u64_raw(ercs_peer_addr, status_u64)
+            cute.arch.fence_acq_rel_sys()
         cute.arch.barrier(
             barrier_id=self.dispatch_intra_cta_bar_id,
             number_of_threads=self.num_dispatch_threads,
@@ -530,6 +643,19 @@ class TokenInPullTokenBackPush:
         # SF rows use their own padding; token and SF pool offsets can diverge.
         expert_sf_pool_block_offset = Int32(0)
 
+        # ── Release-flag batching ────────────────────────────────────────
+        # Delay fc1-ready counter publication with the same rotating-lane
+        # tracker used by the epilogue.  Each token's TMA store to the FC1 pool
+        # is drained CTA-locally by ``cp_async_bulk_wait_group(0)`` before its
+        # release target is accumulated; the eventual red.release.gpu add
+        # publishes the corresponding pool data to GPU scope.
+        flag_tracker = GpuReleaseFlagBatchTracker(
+            flag_addr=Int64(0),
+            cumulated_flags=Int32(0),
+            phase=Int32(0),
+            tid=lane_idx,
+        )
+
         stored_rank_count_lane = Int32(0)
 
         NUM_EXPERTS_PER_LANE: cutlass.Constexpr[int] = (
@@ -549,8 +675,8 @@ class TokenInPullTokenBackPush:
             int] = num_sms * self.num_dispatch_warps
         token_idx = sm_idx * Int32(self.num_dispatch_warps) + warp_idx
 
-        _iket_pull_emit = (sm_idx == Int32(0)) and (warp_idx == Int32(0)) and (
-            lane_idx == Int32(0))
+        _iket_pull_emit = ((sm_idx == Int32(0)) and (warp_idx == Int32(0))
+                           and (lane_idx == Int32(0)))
 
         while current_expert_idx < Int32(self.num_experts_per_rank):
             if _iket_pull_emit:
@@ -562,17 +688,20 @@ class TokenInPullTokenBackPush:
                 prev_block_count = (prev_valid_count +
                                     Int32(self.token_padding_block) -
                                     Int32(1)) // Int32(self.token_padding_block)
-                expert_pool_block_offset = expert_pool_block_offset + prev_block_count
+                expert_pool_block_offset = (expert_pool_block_offset +
+                                            prev_block_count)
                 # Mirror cumul for the release-counter granularity (self.cluster_tile_tokens).
                 prev_task_tile_count = (
                     prev_valid_count + Int32(self.cluster_tile_tokens) -
                     Int32(1)) // Int32(self.cluster_tile_tokens)
-                expert_task_tile_offset = expert_task_tile_offset + prev_task_tile_count
+                expert_task_tile_offset = (expert_task_tile_offset +
+                                           prev_task_tile_count)
                 # Mirror cumul for the SF axis granularity (self.sf_padding_block).
                 prev_sf_block_count = (prev_valid_count +
                                        Int32(self.sf_padding_block) -
                                        Int32(1)) // Int32(self.sf_padding_block)
-                expert_sf_pool_block_offset = expert_sf_pool_block_offset + prev_sf_block_count
+                expert_sf_pool_block_offset = (expert_sf_pool_block_offset +
+                                               prev_sf_block_count)
                 current_expert_idx = current_expert_idx + Int32(1)
                 if current_expert_idx < Int32(self.num_experts_per_rank):
                     expert_start_idx = expert_end_idx
@@ -744,13 +873,13 @@ class TokenInPullTokenBackPush:
                     )
 
                 with cute.arch.elect_one():
-                    _store_token_src_metadata_u32x3(
-                        token_src_metadata,
-                        pool_token_idx,
-                        Uint32(current_rank_in_expert_idx),
-                        Uint32(src_token),
-                        Uint32(src_topk),
-                    )
+                    TokenSrcMetadata(
+                        src_rank=current_rank_in_expert_idx,
+                        src_token=src_token,
+                        src_topk=src_topk,
+                    ).store(token_src_metadata.iterator +
+                            Int64(pool_token_idx) *
+                            Int64(TokenSrcMetadata.nbytes))
 
                 with cute.arch.elect_one():
                     cute.arch.cp_async_bulk_commit_group()
@@ -760,15 +889,20 @@ class TokenInPullTokenBackPush:
                     _iket.range_pop()  # Pull.TMA_Store
                     _iket.range_push("Pull.Arrival_Atomic")
 
-                with cute.arch.elect_one():
-                    task_tile_idx = expert_task_tile_offset + (
-                        token_idx_in_expert // Int32(self.cluster_tile_tokens))
-                    cute.arch.atomic_add(
-                        fc1_ready_counter.iterator + task_tile_idx,
-                        Int32(1),
-                        sem="release",
-                        scope="gpu",
-                    )
+                # Accumulate this token's release target into the rotating-lane
+                # batch tracker.  task_tile_idx is warp-uniform (token_idx /
+                # expert offsets are warp-wide), so every lane runs the same
+                # state-machine transition while only one lane records the
+                # current address.
+                task_tile_idx = expert_task_tile_offset + (
+                    token_idx_in_expert // Int32(self.cluster_tile_tokens))
+                task_tile_addr = (fc1_ready_counter.iterator +
+                                  task_tile_idx).toint()
+                flag_tracker = flag_tracker.accumulate(
+                    Int32(0),
+                    self._flag_batch,
+                    task_tile_addr,
+                )
                 cute.arch.sync_warp()
 
                 if _iket_pull_emit:
@@ -778,16 +912,52 @@ class TokenInPullTokenBackPush:
 
                 token_idx = token_idx + Int32(num_global_warps)
 
+        # Tail flush: publish any leftover (< self._flag_batch) accumulated release.
+        flag_tracker.fire()
+        cute.arch.sync_warp()
+
         return phase_bit, stored_num_tokens_per_expert
+
+    @cute.jit
+    def _adaptive_pace(
+        self,
+        avg,
+        current_window,
+        *,
+        lo: cutlass.Constexpr[int],
+        hi: cutlass.Constexpr[int],
+    ):
+        # NVLink pacing: EMA the measured round-trip and nanosleep the deviation
+        # so outstanding NVLink requests stay bounded and don't head-of-line
+        # block this SM's non-NVLink (local) load/store traffic.
+        if current_window > avg:
+            avg = avg + ((current_window - avg + Int32(3)) // Int32(4))
+            sleep_cycle = current_window - avg
+            if sleep_cycle > Int32(hi):
+                sleep_cycle = Int32(hi)
+            if sleep_cycle > Int32(50):
+                _nanosleep(sleep_cycle)
+        else:
+            avg = avg - ((avg - current_window + Int32(3)) // Int32(4))
+            sleep_cycle = avg - current_window
+            if sleep_cycle > Int32(50):
+                _nanosleep(sleep_cycle)
+        if avg > Int32(hi):
+            avg = Int32(hi)
+        if avg < Int32(lo):
+            avg = Int32(lo)
+        return avg
 
     @cute.jit
     def token_back_by_push(
         self,
-        token_comm_storage,
+        pull_buffer_ptr,
+        pull_mbar_ptr,
         fc2_output_workspace,
         fc2_done_counter,
         token_src_metadata,
         combine_output,
+        token_back_schedule_counter,
         peer_rank_ptr_mapper,
         phase_bit,
         stored_num_tokens_per_expert,
@@ -796,24 +966,79 @@ class TokenInPullTokenBackPush:
         lane_idx,
         *,
         num_sms,
+        chunk_bytes: cutlass.Constexpr[int],
     ):
         _iket_emit = (sm_idx == Int32(0)) and (warp_idx == Int32(0))
+        avg_token_back_window = Int32(2500)
 
-        chunk_bytes: cutlass.Constexpr[int] = self.hidden_bytes
-        num_chunks: cutlass.Constexpr[int] = self.fc2_num_chunks
+        # Chunk the fc2 token in ``chunk_bytes`` pieces; the last piece carries
+        # the remainder so any chunk_bytes works for any fc2_token_bytes.
         fc2_token_bytes: cutlass.Constexpr[int] = self.fc2_token_bytes
-
-        pull_buffer_ptr = token_comm_storage.pull_buffer.data_ptr()
-        pull_mbar_ptr = token_comm_storage.pull_mbar.data_ptr()
+        num_chunks: cutlass.Constexpr[int] = (fc2_token_bytes + chunk_bytes -
+                                              1) // chunk_bytes
+        last_chunk_bytes: cutlass.Constexpr[int] = (
+            fc2_token_bytes - (num_chunks - 1) * chunk_bytes)
 
         num_experts_per_lane: cutlass.Constexpr[int] = (
             self.num_experts_per_rank + 31) // 32
-        num_global_warps: cutlass.Constexpr[
-            int] = num_sms * self.num_dispatch_warps
+        num_global_warps: cutlass.Constexpr[int] = (num_sms *
+                                                    self.num_dispatch_warps)
+        schedule_mode = self.token_back_schedule_mode
+        atomic_batch = self.token_back_atomic_batch
 
-        token_idx = sm_idx * Int32(self.num_dispatch_warps) + warp_idx
+        # static: stride by the global warp count.  atomic_counter: consume one
+        # slot of the current batch, refilling via one grid-scoped
+        # atomicAdd(atomic_batch) when exhausted so fast warps keep stealing
+        # work.  cuTeDSL forbids closures over enclosing locals -> pass all in.
+        def update_token_idx(
+            token_idx,
+            batch_remaining,
+            lane_idx,
+            schedule_counter,
+            schedule_mode,
+            atomic_batch,
+            num_global_warps,
+        ):
+            if cutlass.const_expr(schedule_mode == "atomic_counter"):
+                batch_remaining = batch_remaining - Int32(1)
+                if batch_remaining == Int32(0):
+                    base = Int32(0)
+                    if lane_idx == Int32(0):
+                        base = cute.arch.atomic_add(
+                            schedule_counter,
+                            Int32(atomic_batch),
+                            sem="relaxed",
+                            scope="gpu",
+                        )
+                    token_idx = cute.arch.shuffle_sync(base, Int32(0))
+                    batch_remaining = Int32(atomic_batch)
+                else:
+                    token_idx = token_idx + Int32(1)
+            else:
+                token_idx = token_idx + Int32(num_global_warps)
+            return token_idx, batch_remaining
+
+        if cutlass.const_expr(schedule_mode == "atomic_counter"):
+            # Prime the first batch: batch_remaining=1 makes update_token_idx
+            # decrement to 0 and pull the initial atomic batch.
+            token_idx = Int32(0)
+            batch_remaining = Int32(1)
+            token_idx, batch_remaining = update_token_idx(
+                token_idx,
+                batch_remaining,
+                lane_idx,
+                token_back_schedule_counter,
+                schedule_mode,
+                atomic_batch,
+                num_global_warps,
+            )
+        else:
+            token_idx = sm_idx * Int32(self.num_dispatch_warps) + warp_idx
+            batch_remaining = Int32(0)
 
         current_expert_idx = Int32(-1)
+        confirmed_expert_idx = Int32(-1)
+        cur_expert_expected = Int32(0)
         expert_start_idx = Int32(0)
         expert_end_idx = Int32(0)
         expert_pool_block_offset = Int32(0)
@@ -825,7 +1050,8 @@ class TokenInPullTokenBackPush:
                 prev_block_count = (prev_valid_count +
                                     Int32(self.token_padding_block) -
                                     Int32(1)) // Int32(self.token_padding_block)
-                expert_pool_block_offset = expert_pool_block_offset + prev_block_count
+                expert_pool_block_offset = (expert_pool_block_offset +
+                                            prev_block_count)
 
                 current_expert_idx = current_expert_idx + Int32(1)
                 if current_expert_idx < Int32(self.num_experts_per_rank):
@@ -845,83 +1071,124 @@ class TokenInPullTokenBackPush:
                     cluster_tile_cnt = (
                         total_for_expert + Int32(self.cluster_tile_tokens) -
                         Int32(1)) // Int32(self.cluster_tile_tokens)
-                    expected = cluster_tile_cnt * Int32(
+                    # Stash the threshold; the wait is deferred to the expert we
+                    # actually land on, so stepped-over experts are never waited.
+                    cur_expert_expected = cluster_tile_cnt * Int32(
                         self.fc2_publishes_per_token_cluster_tile)
-                    spin_wait(
-                        fc2_done_counter.iterator + current_expert_idx,
-                        lambda v: v >= expected,
-                        fail_sleep_cycles=500,
-                    )
 
             if current_expert_idx < Int32(self.num_experts_per_rank):
+                # Wait once per processed expert (both indices monotonic; fc2
+                # completes in expert order so confirming k implies all < k).
+                if current_expert_idx > confirmed_expert_idx:
+                    spin_wait(
+                        fc2_done_counter.iterator + current_expert_idx,
+                        lambda v: v >= cur_expert_expected,
+                        fail_sleep_cycles=500,
+                    )
+                    confirmed_expert_idx = current_expert_idx
+
+                remain_experts = Int32(
+                    self.num_experts_per_rank) - current_expert_idx
                 token_idx_in_expert = token_idx - expert_start_idx
                 pool_token_idx = (
                     expert_pool_block_offset * Int32(self.token_padding_block) +
                     token_idx_in_expert)
 
-                md_base = token_src_metadata.iterator + (pool_token_idx *
-                                                         Int32(12))
-                src_rank = Int32(
-                    cute.arch.load(md_base + Int32(0), Int32, scope="gpu"))
-                src_token = Int32(
-                    cute.arch.load(md_base + Int32(4), Int32, scope="gpu"))
-                src_topk = Int32(
-                    cute.arch.load(md_base + Int32(8), Int32, scope="gpu"))
+                md = TokenSrcMetadata.load(token_src_metadata.iterator +
+                                           Int64(pool_token_idx) *
+                                           Int64(TokenSrcMetadata.nbytes))
+                src_rank = md.src_rank
+                src_token = md.src_token
+                src_topk = md.src_topk
+                is_remote_token_back = src_rank != Int32(self.local_rank)
 
-                local_token_addr = fc2_output_workspace.iterator.toint(
-                ) + Int64(pool_token_idx) * Int64(fc2_token_bytes)
+                local_token_addr = (
+                    fc2_output_workspace.iterator.toint() +
+                    Int64(pool_token_idx) * Int64(fc2_token_bytes))
                 peer_combine_ptr = peer_rank_ptr_mapper.ptr_map_to_rank(
                     combine_output.iterator,
                     src_rank,
                 )
-                peer_token_ptr = peer_combine_ptr + (
-                    Int64(src_token * Int32(self.num_topk) + src_topk) *
-                    Int64(fc2_token_bytes))
+                if cutlass.const_expr(self.token_back_reduce_topk):
+                    peer_token_offset = Int64(src_token) * Int64(
+                        fc2_token_bytes)
+                else:
+                    peer_token_offset = (
+                        Int64(src_token * Int32(self.num_topk) + src_topk) *
+                        Int64(fc2_token_bytes))
+                peer_token_ptr = peer_combine_ptr + peer_token_offset
 
                 smem_ptr_warp = pull_buffer_ptr + warp_idx * Int32(chunk_bytes)
                 mbar_ptr_warp = pull_mbar_ptr + warp_idx
 
                 if _iket_emit:
                     _iket.range_push("token_back")
+                cute.arch.sync_warp()
 
-                for chunk in cutlass.range_constexpr(0, num_chunks, 1):
+                for chunk in cutlass.range(num_chunks, unroll=1):
+                    t0 = read_clock64()
                     chunk_off = Int64(chunk * chunk_bytes)
-                    # chunk_t0 = read_clock64()
+                    peer_chunk_ptr = peer_token_ptr + chunk_off
+
+                    this_bytes = Int32(chunk_bytes)
+                    if cutlass.const_expr(last_chunk_bytes != chunk_bytes):
+                        if chunk == Int32(num_chunks - 1):
+                            this_bytes = Int32(last_chunk_bytes)
 
                     with cute.arch.elect_one():
                         tma_load_1d_raw(
                             smem_ptr_warp,
                             local_token_addr + chunk_off,
                             mbar_ptr_warp,
-                            Int32(chunk_bytes),
+                            this_bytes,
                         )
                         cute.arch.mbarrier_arrive_and_expect_tx(
                             mbar_ptr_warp,
-                            Int32(chunk_bytes),
+                            this_bytes,
                         )
                         cute.arch.mbarrier_wait(mbar_ptr_warp, phase_bit)
-                    cute.arch.sync_warp()
-
-                    with cute.arch.elect_one():
-                        tma_store_1d(
-                            peer_token_ptr + chunk_off,
-                            smem_ptr_warp,
-                            Int32(chunk_bytes),
-                        )
-                        cute.arch.cp_async_bulk_commit_group()
-                        cute.arch.cp_async_bulk_wait_group(0)
-                    cute.arch.sync_warp()
-
-                    # if read_clock64() - chunk_t0 < Int64(600):
-                    #     _nanosleep(100)
-
+                        if cutlass.const_expr(self.token_back_reduce_topk):
+                            cp_reduce_async_bulk_add_noftz_bf16_s2g(
+                                peer_chunk_ptr,
+                                smem_ptr_warp,
+                                this_bytes,
+                            )
+                        else:
+                            tma_store_1d(
+                                peer_chunk_ptr,
+                                smem_ptr_warp,
+                                this_bytes,
+                            )
                     phase_bit = phase_bit ^ Int32(1)
+                    cute.arch.cp_async_bulk_commit_group()
+                    cute.arch.cp_async_bulk_wait_group(0)
+                    t1 = read_clock64()
+                    current_window = Int32(t1 - t0)
+                    if is_remote_token_back and remain_experts > Int32(4):
+                        avg_token_back_window = self._adaptive_pace(
+                            avg_token_back_window,
+                            current_window,
+                            lo=1000,
+                            hi=5000,
+                        )
+
                 if _iket_emit:
                     _iket.range_pop()
 
-                token_idx = token_idx + Int32(num_global_warps)
+                token_idx, batch_remaining = update_token_idx(
+                    token_idx,
+                    batch_remaining,
+                    lane_idx,
+                    token_back_schedule_counter,
+                    schedule_mode,
+                    atomic_batch,
+                    num_global_warps,
+                )
+        # if lane_idx == 0:
+        #     cute.printf("<{}>", avg_token_back_window)
 
         cute.arch.fence_acq_rel_sys()
+        # _fence_rel_sys()
 
     @cute.jit
     def nvlink_barrier(
@@ -943,13 +1210,11 @@ class TokenInPullTokenBackPush:
         tid_in_group = warp_idx * Int32(self.warp_threads) + lane_idx
 
         if prologue_grid_sync:
-            software_grid_sync(
-                grid_sync_counter,
-                sm_idx,
-                num_sms,
-                tid_in_group,
-                num_threads=self.num_dispatch_threads,
-            )
+            software_grid_sync(grid_sync_counter,
+                               sm_idx,
+                               num_sms,
+                               tid_in_group,
+                               num_threads=self.num_dispatch_threads)
 
         if sm_idx == 0:
             if warp_idx == 0:
@@ -984,26 +1249,24 @@ class TokenInPullTokenBackPush:
                         )
                     local_signal_ptr = nvlink_barrier_signal.iterator + signal_phase
                     if cutlass.const_expr(nvlink_barrier_counter is None):
-                        while (cute.arch.load(local_signal_ptr,
-                                              Int32,
-                                              sem="acquire",
-                                              scope="sys") < target):
+                        while cute.arch.load(local_signal_ptr,
+                                             Int32,
+                                             sem="acquire",
+                                             scope="sys") < target:
                             pass
                     else:
-                        while (cute.arch.load(local_signal_ptr,
-                                              Int32,
-                                              sem="acquire",
-                                              scope="sys") != target):
+                        while cute.arch.load(local_signal_ptr,
+                                             Int32,
+                                             sem="acquire",
+                                             scope="sys") != target:
                             pass
 
         if epilogue_grid_sync:
-            software_grid_sync(
-                grid_sync_counter,
-                sm_idx,
-                num_sms,
-                tid_in_group,
-                num_threads=self.num_dispatch_threads,
-            )
+            software_grid_sync(grid_sync_counter,
+                               sm_idx,
+                               num_sms,
+                               tid_in_group,
+                               num_threads=self.num_dispatch_threads)
 
     @cute.jit
     def dispatch_warp_body(
@@ -1091,16 +1354,19 @@ class TokenInPullTokenBackPush:
         if iket_active:
             _iket.range_pop()
 
-        if cutlass.const_expr(self.enable_token_back):
+        if cutlass.const_expr(self.enable_token_back
+                              and not self.token_back_standalone):
             if iket_active:
                 _iket.range_push("Token_Back_By_Push")
 
             self.token_back_by_push(
-                token_comm_storage,
+                token_comm_storage.pull_buffer.data_ptr(),
+                token_comm_storage.pull_mbar.data_ptr(),
                 token_comm_args.fc2_output_workspace,
                 token_comm_args.fc2_done_counter,
                 token_comm_args.token_src_metadata,
                 token_comm_args.combine_output,
+                token_comm_args.token_back_schedule_counter,
                 token_comm_args.peer_rank_ptr_mapper,
                 phase_bit,
                 stored_num_tokens_per_expert,
@@ -1108,10 +1374,81 @@ class TokenInPullTokenBackPush:
                 local_warp_idx,
                 lane_idx,
                 num_sms=token_comm_args.sm_count,
+                chunk_bytes=self.hidden_bytes,
             )
 
             if iket_active:
                 _iket.range_pop()
+
+    @cute.jit
+    def token_back_warp_body(
+        self,
+        token_comm_args,
+        token_comm_storage,
+        *,
+        warp_idx,
+        lane_idx,
+        tidx,
+    ):
+        bidx, bidy, bidz = cute.arch.block_idx()
+        cta_linear_id = (
+            Int32(bidx) + Int32(self.cluster_shape_mn[1]) * Int32(bidy) +
+            Int32(self.cluster_shape_mn[1] * self.cluster_shape_mn[0]) *
+            Int32(bidz))
+        local_warp_idx = Int32(warp_idx) - Int32(self.token_back_warp_start)
+
+        # Handshake: dispatch_barrier done => expert_recv_count_sum populated.
+        nb_dispatch_to_sched = pipeline.NamedBarrier(
+            barrier_id=self.dispatch_to_sched_named_barrier_id,
+            num_threads=self.dispatch_to_sched_threads,
+        )
+        nb_dispatch_to_sched.arrive_and_wait()
+
+        tb_pull_mbar_ptr = token_comm_storage.tb_pull_mbar.data_ptr()
+        tb_pull_buffer_ptr = token_comm_storage.tb_pull_buffer.data_ptr()
+        if lane_idx == Int32(0):
+            cute.arch.mbarrier_init(tb_pull_mbar_ptr + local_warp_idx, 1)
+        cute.arch.sync_warp()
+
+        NUM_EXPERTS_PER_LANE: cutlass.Constexpr[int] = (
+            self.num_experts_per_rank + 31) // 32
+        stored_num_tokens_per_expert = []
+        for _ in cutlass.range_constexpr(0, NUM_EXPERTS_PER_LANE, 1):
+            stored_num_tokens_per_expert.append(Int32(0))
+        for i in cutlass.range_constexpr(0, NUM_EXPERTS_PER_LANE, 1):
+            e_idx_for_lane = Int32(i * self.warp_threads) + lane_idx
+            if e_idx_for_lane < Int32(self.num_experts_per_rank):
+                sum_packed_init = token_comm_args.expert_recv_count_sum[
+                    e_idx_for_lane]
+                stored_num_tokens_per_expert[i] = Int32(
+                    Int64(sum_packed_init) & Int64(0xFFFFFFFF))
+        cute.arch.sync_warp()
+
+        iket_active = (cta_linear_id == Int32(0)) and (local_warp_idx
+                                                       == Int32(0))
+        if iket_active:
+            _iket.range_push("Token_Back_By_Push_Standalone")
+
+        self.token_back_by_push(
+            tb_pull_buffer_ptr,
+            tb_pull_mbar_ptr,
+            token_comm_args.fc2_output_workspace,
+            token_comm_args.fc2_done_counter,
+            token_comm_args.token_src_metadata,
+            token_comm_args.combine_output,
+            token_comm_args.token_back_schedule_counter,
+            token_comm_args.peer_rank_ptr_mapper,
+            Int32(0),
+            stored_num_tokens_per_expert,
+            cta_linear_id,
+            local_warp_idx,
+            lane_idx,
+            num_sms=token_comm_args.sm_count,
+            chunk_bytes=self.tb_chunk_bytes,
+        )
+
+        if iket_active:
+            _iket.range_pop()
 
     @cute.jit
     def tail_reset_shared_counters(
@@ -1122,12 +1459,13 @@ class TokenInPullTokenBackPush:
         local_warp_idx,
         lane_idx,
     ):
-        thread_linear = (cta_linear_id * Int32(self.num_dispatch_warps) +
-                         local_warp_idx) * Int32(self.warp_threads) + lane_idx
+        thread_linear = (
+            (cta_linear_id * Int32(self.num_dispatch_warps) + local_warp_idx) *
+            Int32(self.warp_threads) + lane_idx)
         stride = Int32(token_comm_args.sm_count * self.num_dispatch_threads)
 
-        recv_total: cutlass.Constexpr[
-            int] = self.world_size * self.num_experts_per_rank
+        recv_total: cutlass.Constexpr[int] = (self.world_size *
+                                              self.num_experts_per_rank)
         i = thread_linear
         while i < Int32(recv_total):
             rank_idx = i // Int32(self.num_experts_per_rank)
@@ -1146,6 +1484,11 @@ class TokenInPullTokenBackPush:
                 token_comm_args.fc2_done_counter[i] = Int32(0)
                 i = i + stride
 
+        if cutlass.const_expr(
+                self.token_back_schedule_mode == "atomic_counter"):
+            if thread_linear == Int32(0):
+                token_comm_args.token_back_schedule_counter.store(Int32(0))
+
     @cute.jit
     def kernel_tail(
         self,
@@ -1161,7 +1504,10 @@ class TokenInPullTokenBackPush:
         )
         nb_kernel_tail.arrive_and_wait()
 
-        if warp_idx >= self.dispatch_warp_start:
+        # Only the dispatch warps run NVLink cleanup; standalone token-back
+        # warps (>= token_back_warp_start) just join the rendezvous above.
+        if (warp_idx >= self.dispatch_warp_start) and (
+                warp_idx < self.dispatch_warp_start + self.num_dispatch_warps):
             bidx, bidy, bidz = cute.arch.block_idx()
             cta_linear_id = (
                 Int32(bidx) + Int32(self.cluster_shape_mn[1]) * Int32(bidy) +

--- a/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/topk_reduce.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/topk_reduce.py
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
 """Standalone CuTeDSL topk reduce kernel.
 
 Form A writes one BF16 fc2 output row per ``(token, topk)`` cell into
@@ -200,8 +202,8 @@ def _pack_f32_to_fp4(fp32: torch.Tensor) -> torch.Tensor:
     """Round FP32 to FP4 E2M1 and pack pairs along the last dimension."""
     if fp32.dim() == 0 or fp32.shape[-1] % 2 != 0:
         raise ValueError(
-            f"FP4 packing requires an even non-empty last dim, got {tuple(fp32.shape)}."
-        )
+            f"FP4 packing requires an even non-empty last dim, got "
+            f"{tuple(fp32.shape)}.")
     device = fp32.device
     boundaries = torch.tensor(
         [
@@ -260,8 +262,8 @@ def unpack_fp4_to_f32(packed: torch.Tensor) -> torch.Tensor:
         raw = packed.view(torch.uint8)
     else:
         raise TypeError(
-            f"packed must be torch.uint8 or torch.float4_e2m1fn_x2, got {packed.dtype}."
-        )
+            "packed must be torch.uint8 or torch.float4_e2m1fn_x2, got "
+            f"{packed.dtype}.")
     lo = (raw & 0x0F).to(torch.int64)
     hi = (raw >> 4).to(torch.int64)
     lut = _Fp4DecodeTable.to(raw.device)
@@ -942,17 +944,15 @@ def _validate_tensors(
     nvfp4_global_scale: Optional[torch.Tensor] = None,
 ) -> Tuple[int, int, int, int]:
     if combine_output.dim() != 3:
-        raise ValueError(
-            f"combine_output must have shape (T, K, H), got {tuple(combine_output.shape)}."
-        )
+        raise ValueError(f"combine_output must have shape (T, K, H), got "
+                         f"{tuple(combine_output.shape)}.")
     if reduced_output.dim() != 2:
-        raise ValueError(
-            f"reduced_output must have shape (T, H), got {tuple(reduced_output.shape)}."
-        )
+        raise ValueError(f"reduced_output must have shape (T, H), got "
+                         f"{tuple(reduced_output.shape)}.")
     if reduced_output.dtype not in (torch.float32, torch.bfloat16):
         raise TypeError(
-            f"reduced_output must be torch.float32 or torch.bfloat16, got {reduced_output.dtype}."
-        )
+            f"reduced_output must be torch.float32 or torch.bfloat16, "
+            f"got {reduced_output.dtype}.")
     if not combine_output.is_cuda or not reduced_output.is_cuda:
         raise ValueError(
             "combine_output and reduced_output must both be CUDA tensors.")
@@ -977,9 +977,8 @@ def _validate_tensors(
     nvfp4_mode = nvfp4_sfc_scale is not None
     H = int(H_storage) * 2 if nvfp4_mode else int(H_storage)
     if reduced_output.shape != (T, H):
-        raise ValueError(
-            f"reduced_output shape must be {(T, H)}, got {tuple(reduced_output.shape)}."
-        )
+        raise ValueError(f"reduced_output shape must be {(T, H)}, got "
+                         f"{tuple(reduced_output.shape)}.")
 
     mxfp8_scale_rank = 0
     if mxfp8_scale is None and not nvfp4_mode:
@@ -994,22 +993,20 @@ def _validate_tensors(
                 "MXFP8 mode requires torch float8_e4m3fn and float8_e8m0fnu.")
         if combine_output.dtype != torch.float8_e4m3fn:
             raise TypeError(
-                f"MXFP8 combine_output must be torch.float8_e4m3fn, got {combine_output.dtype}."
-            )
+                f"MXFP8 combine_output must be torch.float8_e4m3fn, got "
+                f"{combine_output.dtype}.")
         if mxfp8_scale.dtype != torch.float8_e8m0fnu:
-            raise TypeError(
-                f"mxfp8_scale must be torch.float8_e8m0fnu, got {mxfp8_scale.dtype}."
-            )
+            raise TypeError(f"mxfp8_scale must be torch.float8_e8m0fnu, got "
+                            f"{mxfp8_scale.dtype}.")
         if reduced_output.dtype != torch.bfloat16:
-            raise TypeError(
-                f"MXFP8 reduced_output must be torch.bfloat16, got {reduced_output.dtype}."
-            )
+            raise TypeError(f"MXFP8 reduced_output must be torch.bfloat16, got "
+                            f"{reduced_output.dtype}.")
         if not mxfp8_scale.is_cuda:
             raise ValueError("mxfp8_scale must be a CUDA tensor.")
         if mxfp8_scale.device != combine_output.device:
             raise ValueError(
-                f"mxfp8_scale must be on {combine_output.device}, got {mxfp8_scale.device}."
-            )
+                f"mxfp8_scale must be on {combine_output.device}, got "
+                f"{mxfp8_scale.device}.")
         scale_cols = (H + MXFP8_SCALE_BLOCK_SIZE - 1) // MXFP8_SCALE_BLOCK_SIZE
         if mxfp8_scale.dim() == 2:
             expected_scale_shape = (T, scale_cols)
@@ -1021,30 +1018,28 @@ def _validate_tensors(
                 f"(T, K, ceil_div(H, 32)), got {tuple(mxfp8_scale.shape)}.")
         if mxfp8_scale.shape != expected_scale_shape:
             raise ValueError(
-                f"mxfp8_scale shape must be {expected_scale_shape}, got {tuple(mxfp8_scale.shape)}."
-            )
+                f"mxfp8_scale shape must be {expected_scale_shape}, got "
+                f"{tuple(mxfp8_scale.shape)}.")
         mxfp8_scale_rank = mxfp8_scale.dim()
     else:
         if not hasattr(torch, "float8_e4m3fn"):
             raise TypeError("NVFP4 mode requires torch float8_e4m3fn.")
         if combine_output.dtype != torch.uint8:
             raise TypeError(
-                f"NVFP4 combine_output must be packed torch.uint8, got {combine_output.dtype}."
-            )
+                f"NVFP4 combine_output must be packed torch.uint8, got "
+                f"{combine_output.dtype}.")
         if nvfp4_sfc_scale.dtype != torch.float8_e4m3fn:
-            raise TypeError(
-                f"nvfp4_sfc_scale must be torch.float8_e4m3fn, got {nvfp4_sfc_scale.dtype}."
-            )
+            raise TypeError(f"nvfp4_sfc_scale must be torch.float8_e4m3fn, got "
+                            f"{nvfp4_sfc_scale.dtype}.")
         if nvfp4_global_scale.dtype != torch.float32:
-            raise TypeError(
-                f"nvfp4_global_scale must be torch.float32, got {nvfp4_global_scale.dtype}."
-            )
+            raise TypeError(f"nvfp4_global_scale must be torch.float32, got "
+                            f"{nvfp4_global_scale.dtype}.")
         if not nvfp4_sfc_scale.is_cuda or not nvfp4_global_scale.is_cuda:
             raise ValueError("NVFP4 scales must be CUDA tensors.")
         if nvfp4_sfc_scale.device != combine_output.device:
             raise ValueError(
-                f"nvfp4_sfc_scale must be on {combine_output.device}, got {nvfp4_sfc_scale.device}."
-            )
+                f"nvfp4_sfc_scale must be on {combine_output.device}, got "
+                f"{nvfp4_sfc_scale.device}.")
         if nvfp4_global_scale.device != combine_output.device:
             raise ValueError(
                 f"nvfp4_global_scale must be on {combine_output.device}, got "
@@ -1060,16 +1055,15 @@ def _validate_tensors(
             raise ValueError(
                 f"nvfp4_sfc_scale shape must be {expected_sfc_shape}, got "
                 f"{tuple(nvfp4_sfc_scale.shape)}.")
-        if nvfp4_global_scale.dim(
-        ) != 3 or nvfp4_global_scale.shape != expected_global_shape:
+        if (nvfp4_global_scale.dim() != 3
+                or nvfp4_global_scale.shape != expected_global_shape):
             raise ValueError(
                 f"nvfp4_global_scale shape must be {expected_global_shape}, got "
                 f"{tuple(nvfp4_global_scale.shape)}.")
     if topk_score is not None:
         if topk_score.dim() != 2:
-            raise ValueError(
-                f"topk_score must have shape (T, K), got {tuple(topk_score.shape)}."
-            )
+            raise ValueError(f"topk_score must have shape (T, K), got "
+                             f"{tuple(topk_score.shape)}.")
         if topk_score.dtype != torch.float32:
             raise TypeError(
                 f"topk_score must be torch.float32, got {topk_score.dtype}.")
@@ -1077,12 +1071,11 @@ def _validate_tensors(
             raise ValueError("topk_score must be a CUDA tensor.")
         if topk_score.device != combine_output.device:
             raise ValueError(
-                f"topk_score must be on {combine_output.device}, got {topk_score.device}."
-            )
+                f"topk_score must be on {combine_output.device}, got "
+                f"{topk_score.device}.")
         if topk_score.shape != (T, K):
-            raise ValueError(
-                f"topk_score shape must be {(T, K)}, got {tuple(topk_score.shape)}."
-            )
+            raise ValueError(f"topk_score shape must be {(T, K)}, got "
+                             f"{tuple(topk_score.shape)}.")
     return int(T), int(K), int(H), int(mxfp8_scale_rank)
 
 
@@ -1140,8 +1133,8 @@ def compile_topk_reduce(
         topk_score) if topk_score is not None else None
     mxfp8_scale_cute = _to_cute_tensor(
         mxfp8_scale) if mxfp8_scale is not None else None
-    nvfp4_sfc_scale_cute = _to_cute_tensor(
-        nvfp4_sfc_scale) if nvfp4_sfc_scale is not None else None
+    nvfp4_sfc_scale_cute = (_to_cute_tensor(nvfp4_sfc_scale)
+                            if nvfp4_sfc_scale is not None else None)
     nvfp4_global_scale_cute = (_to_cute_tensor(nvfp4_global_scale)
                                if nvfp4_global_scale is not None else None)
     nvfp4_mode = nvfp4_sfc_scale is not None
@@ -1603,9 +1596,9 @@ def benchmark_topk_reduce_vs_torch_sum(
 
 
 def _parse_bench_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description=(
-        "Benchmark CuTeDSL topk_reduce against combine_output_ref.to(torch.float32).sum(dim=1)."
-    ))
+    parser = argparse.ArgumentParser(
+        description=("Benchmark CuTeDSL topk_reduce against "
+                     "combine_output_ref.to(torch.float32).sum(dim=1)."))
     parser.add_argument("--tokens", type=int, default=192)
     parser.add_argument("--topk", type=int, default=8)
     parser.add_argument("--hidden", type=int, default=7168)

--- a/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_cute_dsl.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_cute_dsl.py
@@ -549,6 +549,11 @@ class MegaMoECuteDsl(MoE):
         # cache in ``cute_dsl_megamoe_custom_op.py``. ``None`` for the
         # single-rank degenerate path.
         self._symm_provider = None
+        # Symmetric scratch regions used ONLY for AutoTuner profiling (one
+        # buffer shared across same-shape MoE layers). Allocated alongside
+        # ``_symm_provider`` and released after warmup via
+        # ``release_megamoe_profiling_scratch()``. ``None`` for single-rank.
+        self._profiling_scratch_regions = None
         self._weights_loaded = False
         self._weights_created = False
         self._post_load_done = False
@@ -749,6 +754,7 @@ class MegaMoECuteDsl(MoE):
         would block the rendezvous and is a hard error for multi-rank.
         """
         from ....custom_ops.cute_dsl_megamoe_custom_op import (
+            get_megamoe_profiling_scratch,
             get_megamoe_symm_provider,
             query_megamoe_shared_workspace_bytes,
         )
@@ -771,7 +777,7 @@ class MegaMoECuteDsl(MoE):
             max_tokens_per_rank=int(self.max_num_tokens),
             in_kernel_fc2_reduce=bool(self.in_kernel_fc2_reduce),
         )
-        return get_megamoe_symm_provider(
+        staging = get_megamoe_symm_provider(
             process_group=self._ep_pg,
             world_size=self.ep_size,
             rank=self.ep_rank,
@@ -782,6 +788,21 @@ class MegaMoECuteDsl(MoE):
             shared_workspace_bytes=shared_workspace_bytes,
             in_kernel_fc2_reduce=bool(self.in_kernel_fc2_reduce),
         )
+        # Separate symmetric scratch for AutoTuner profiling (same layout, own
+        # peer_offsets). Shared across same-shape layers; freed after warmup.
+        scratch = get_megamoe_profiling_scratch(
+            process_group=self._ep_pg,
+            world_size=self.ep_size,
+            rank=self.ep_rank,
+            hidden_size=self.hidden_size,
+            max_tokens_per_rank=int(self.max_num_tokens),
+            num_topk=top_k,
+            output_dtype=self.dtype or torch.bfloat16,
+            shared_workspace_bytes=shared_workspace_bytes,
+            in_kernel_fc2_reduce=bool(self.in_kernel_fc2_reduce),
+        )
+        self._profiling_scratch_regions = scratch.get_regions() if scratch is not None else None
+        return staging
 
     def load_weights(self, weights: List[Dict], allow_partial_loading: bool = False) -> None:
         if self.quant_method is None:
@@ -1221,6 +1242,15 @@ class MegaMoECuteDsl(MoE):
         # and needs no per-launch zero.
         if self.in_kernel_fc2_reduce and num_tokens > 0:
             combine_output[:num_tokens].zero_()
+        # Hand the symmetric profiling scratch to the op so AutoTuner profiling
+        # keeps the cross-rank inputs symmetric without touching this staging
+        # buffer. Cleared right after so a later same-process op call for a
+        # different shape never reuses a stale scratch.
+        from ....custom_ops.cute_dsl_megamoe_custom_op import set_active_megamoe_profiling_scratch
+
+        set_active_megamoe_profiling_scratch(
+            self._profiling_scratch_regions if world_size > 1 else None
+        )
         torch.ops.trtllm.cute_dsl_megamoe_nvfp4_blackwell(
             activation=_as_nvfp4(activation),
             activation_sf=_as_fp8_sf(activation_sf),
@@ -1248,6 +1278,7 @@ class MegaMoECuteDsl(MoE):
             gate_up_clamp=self.gate_up_clamp,
             in_kernel_fc2_reduce=bool(self.in_kernel_fc2_reduce),
         )
+        set_active_megamoe_profiling_scratch(None)
         if num_tokens == 0:
             return torch.empty((0, hidden), dtype=output_dtype, device=combine_output.device)
         if self.in_kernel_fc2_reduce:

--- a/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_cute_dsl.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_cute_dsl.py
@@ -68,6 +68,7 @@ non-1 scales compute correctly.
 
 from __future__ import annotations
 
+import weakref
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -549,11 +550,13 @@ class MegaMoECuteDsl(MoE):
         # cache in ``cute_dsl_megamoe_custom_op.py``. ``None`` for the
         # single-rank degenerate path.
         self._symm_provider = None
-        # Symmetric scratch regions used ONLY for AutoTuner profiling (one
-        # buffer shared across same-shape MoE layers). Allocated alongside
-        # ``_symm_provider`` and released after warmup via
-        # ``release_megamoe_profiling_scratch()``. ``None`` for single-rank.
-        self._profiling_scratch_regions = None
+        # WEAK reference to the symmetric scratch provider used ONLY for
+        # AutoTuner profiling (one buffer shared across same-shape MoE layers).
+        # The process-global ``_MEGAMOE_PROFILING_SCRATCH_CACHE`` is the SOLE
+        # strong owner, so once ``release_megamoe_profiling_scratch()`` clears
+        # that cache after warmup the buffer is reclaimed and this weakref goes
+        # dead -- no per-module teardown needed. ``None`` for single-rank.
+        self._profiling_scratch_provider_ref = None
         self._weights_loaded = False
         self._weights_created = False
         self._post_load_done = False
@@ -801,7 +804,10 @@ class MegaMoECuteDsl(MoE):
             shared_workspace_bytes=shared_workspace_bytes,
             in_kernel_fc2_reduce=bool(self.in_kernel_fc2_reduce),
         )
-        self._profiling_scratch_regions = scratch.get_regions() if scratch is not None else None
+        # Hold only a weakref: the global scratch cache owns the buffer, so it
+        # is freed by ``release_megamoe_profiling_scratch()`` after warmup
+        # without this module pinning it for the process lifetime.
+        self._profiling_scratch_provider_ref = weakref.ref(scratch) if scratch is not None else None
         return staging
 
     def load_weights(self, weights: List[Dict], allow_partial_loading: bool = False) -> None:
@@ -1245,11 +1251,21 @@ class MegaMoECuteDsl(MoE):
         # Hand the symmetric profiling scratch to the op so AutoTuner profiling
         # keeps the cross-rank inputs symmetric without touching this staging
         # buffer. Cleared right after so a later same-process op call for a
-        # different shape never reuses a stale scratch.
+        # different shape never reuses a stale scratch. The provider is held via
+        # a weakref: after warmup ``release_megamoe_profiling_scratch()`` drops
+        # the global cache (sole owner), the weakref goes dead, and this resolves
+        # to ``None`` so steady-state forwards use the staging buffer.
         from ....custom_ops.cute_dsl_megamoe_custom_op import set_active_megamoe_profiling_scratch
 
+        scratch_provider = (
+            self._profiling_scratch_provider_ref()
+            if self._profiling_scratch_provider_ref is not None
+            else None
+        )
         set_active_megamoe_profiling_scratch(
-            self._profiling_scratch_regions if world_size > 1 else None
+            scratch_provider.get_regions()
+            if (scratch_provider is not None and world_size > 1)
+            else None
         )
         torch.ops.trtllm.cute_dsl_megamoe_nvfp4_blackwell(
             activation=_as_nvfp4(activation),

--- a/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_cute_dsl.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_cute_dsl.py
@@ -76,6 +76,7 @@ import torch.distributed as dist
 
 from tensorrt_llm._utils import get_sm_version, is_sm_100f
 from tensorrt_llm.logger import logger
+from tensorrt_llm.math_utils import ceil_div
 from tensorrt_llm.models.modeling_utils import QuantAlgo
 
 # ``megamoe_activation_sf_bytes_per_row`` lives at module top of the
@@ -426,6 +427,7 @@ class MegaMoECuteDsl(MoE):
         without_comm: bool = False,
         activation_type: ActivationType = ActivationType.Swiglu,
         swiglu_limit: Optional[torch.Tensor] = None,
+        in_kernel_fc2_reduce: bool = False,
         **kwargs,
     ) -> None:
         # ``aux_stream_dict`` is accepted for ``create_moe_backend`` signature
@@ -491,24 +493,23 @@ class MegaMoECuteDsl(MoE):
         # the transformers route is GPU-validated and promoted to MoeConfig.
         self.apply_topk_in_fc1 = True
 
-        # Cross-rank combine path. ``False`` (default): the FC2 epilogue writes
-        # ``combine_output`` directly (scattered symmetric writes back to the
-        # source rank). ``True``: the kernel stages FC2 output in a local
-        # ``fc2_output_workspace`` and a fused in-kernel NVLink ``token_back_by_push``
-        # bulk-returns it to the source rank's ``combine_output`` -- faster for
-        # multi-rank EP at the cost of the extra (local) fc2_output_workspace +
-        # fc2_done_counter budget (auto-sized by ``get_workspace_sizes``). The
-        # ``combine_output`` shape / host ``.sum(dim=1)`` reduce are unchanged
-        # (those depend on ``in_kernel_fc2_reduce``, not this knob). Internal
-        # backend constant for now; flip to opt into the fused-combine path.
-        self.token_back_by_dispatch = False
-
-        # FC2 output store path (codegen-time). ``True`` (default): non-bulk
-        # TMA store (upstream default). ``False``: bulk store path. Kept as an
-        # internal backend attribute so different shapes/cases can pick the
-        # cheaper store; it changes the generated kernel, so it is part of the
-        # runner ``unique_id`` / compile-cache key (never a per-call runtime kwarg).
-        self.non_ubulk_fc2_store = True
+        # Output reduction form (functional, NOT a perf tactic). ``False``
+        # (default, form-A): ``combine_output`` is ``(T, num_topk, hidden)`` and
+        # the host reduces ``.sum(dim=1)`` -- deterministic. ``True`` (form-B):
+        # ``combine_output`` is ``(T, 1, hidden)`` (zeroed per launch) and the
+        # kernel folds the top-k reduction in-kernel, fusing the standalone
+        # reduce kernel into the mega kernel (saves one launch) at the cost of
+        # NON-deterministic output (in-kernel float accumulation order). It
+        # changes codegen + the combine buffer shape, so it is carried in the
+        # runner ``unique_id`` / compile + workspace caches and in the symm
+        # provider cache key (form-A and form-B never share buffers). The caller
+        # opts into form-B by constructing the backend with
+        # ``in_kernel_fc2_reduce=True``; otherwise the deterministic form-A is
+        # used and serve configs need no change.
+        # NOTE: the cross-rank combine path (token_back_mode) and fc2 store path
+        # (use_bulk_fc2_store) are now autotuner TACTIC fields, not backend
+        # constants -- the op/runner pick them per token bucket.
+        self.in_kernel_fc2_reduce = bool(in_kernel_fc2_reduce)
 
         # SwiGLU clamp: map the model-provided per-layer ``swiglu_limit`` tensor
         # to the kernel's codegen-time scalar ``gate_up_clamp``. The MegaMoE
@@ -768,6 +769,7 @@ class MegaMoECuteDsl(MoE):
             intermediate_size_per_partition=int(self.intermediate_size_per_partition),
             expand_intermediate_size_per_partition=int(self.expand_intermediate_size_per_partition),
             max_tokens_per_rank=int(self.max_num_tokens),
+            in_kernel_fc2_reduce=bool(self.in_kernel_fc2_reduce),
         )
         return get_megamoe_symm_provider(
             process_group=self._ep_pg,
@@ -778,6 +780,7 @@ class MegaMoECuteDsl(MoE):
             num_topk=top_k,
             output_dtype=self.dtype or torch.bfloat16,
             shared_workspace_bytes=shared_workspace_bytes,
+            in_kernel_fc2_reduce=bool(self.in_kernel_fc2_reduce),
         )
 
     def load_weights(self, weights: List[Dict], allow_partial_loading: bool = False) -> None:
@@ -922,10 +925,11 @@ class MegaMoECuteDsl(MoE):
         )
         # ``fp4_quantize(is_sf_swizzled=False)`` returns LINEAR layout
         # ``(rows, ceil(hidden/16))`` with no column pad. The kernel TMA
-        # load needs ``round_up(ceil(hidden/16), 4)`` bytes per row, so
+        # load needs ``pad_up(ceil_div(hidden, 16), 4)`` bytes per row
+        # (== ``megamoe_activation_sf_bytes_per_row``), so
         # 32-aligned-but-not-64-aligned hidden sizes (1568, 1632, 2080)
         # come back 2 bytes short; pad the tail before returning.
-        raw_cols = (hidden + 15) // 16
+        raw_cols = ceil_div(hidden, 16)
         x_sf_raw = x_sf.view(x_bf16.shape[0], raw_cols)
         if sf_cols == raw_cols:
             return x_fp4, x_sf_raw
@@ -1044,8 +1048,11 @@ class MegaMoECuteDsl(MoE):
             staging["activation_sf"] = torch.empty(
                 (max_T, sf_bytes_per_row), dtype=torch.uint8, device=device
             )
+            # form-A: (max_T, top_k, hidden); form-B (in_kernel_fc2_reduce):
+            # (max_T, 1, hidden) -- kernel folds the top-k reduction in-kernel.
+            combine_k = 1 if self.in_kernel_fc2_reduce else top_k
             staging["combine_output"] = torch.empty(
-                (max_T, top_k, hidden),
+                (max_T, combine_k, hidden),
                 dtype=torch.bfloat16,
                 device=device,
             )
@@ -1066,6 +1073,7 @@ class MegaMoECuteDsl(MoE):
                     self.expand_intermediate_size_per_partition
                 ),
                 max_tokens_per_rank=max_T,
+                in_kernel_fc2_reduce=bool(self.in_kernel_fc2_reduce),
             )
             staging["shared_workspace"] = torch.empty(
                 shared_bytes, dtype=torch.uint8, device=device
@@ -1201,6 +1209,18 @@ class MegaMoECuteDsl(MoE):
         through the module-level :func:`_as_nvfp4` / :func:`_as_fp8_sf`
         helpers (the kernel rejects raw uint8 byte tensors).
         """
+        # form-B (in_kernel_fc2_reduce) accumulates the top-k reduction on top
+        # of the existing combine cell, so the live rows MUST start at 0. Only
+        # the first ``num_tokens`` rows are consumed (the host squeeze reads
+        # ``combine_output[:num_tokens]`` below) and the padded tail rows are
+        # never written by any rank (``topk_idx == -1`` skips them), so zeroing
+        # just ``[:num_tokens]`` is sufficient and avoids clearing the whole
+        # ``max_T``-row buffer every launch. The zero is stream-ordered before
+        # the kernel launch (and thus before any peer cross-rank push, which is
+        # gated behind the in-kernel dispatch barrier). form-A overwrites cells
+        # and needs no per-launch zero.
+        if self.in_kernel_fc2_reduce and num_tokens > 0:
+            combine_output[:num_tokens].zero_()
         torch.ops.trtllm.cute_dsl_megamoe_nvfp4_blackwell(
             activation=_as_nvfp4(activation),
             activation_sf=_as_fp8_sf(activation_sf),
@@ -1226,16 +1246,21 @@ class MegaMoECuteDsl(MoE):
             peer_offsets=peer_offsets,
             apply_topk_in_fc1=bool(self.apply_topk_in_fc1),
             gate_up_clamp=self.gate_up_clamp,
-            token_back_by_dispatch=bool(self.token_back_by_dispatch),
-            non_ubulk_fc2_store=bool(self.non_ubulk_fc2_store),
+            in_kernel_fc2_reduce=bool(self.in_kernel_fc2_reduce),
         )
         if num_tokens == 0:
             return torch.empty((0, hidden), dtype=output_dtype, device=combine_output.device)
-        # Deepgemm graph (apply_topk_in_fc1=True): the kernel already folded
-        # the topk score into the per-route BF16 terms, so the host reduce is
-        # a plain sum over the top-k axis. Accumulate in fp32 explicitly to
-        # match the design reference ``bf16(sum_fp32(term))`` and to be robust
-        # against any future change to the bf16 reduction accumulator type.
+        if self.in_kernel_fc2_reduce:
+            # form-B: the kernel already summed the top-k routes in-kernel, so
+            # ``combine_output`` is (T, 1, hidden); just drop the singleton axis
+            # (NO host reduce). Output is non-deterministic (in-kernel float
+            # accumulation order).
+            return combine_output[:num_tokens].squeeze(1).to(output_dtype)
+        # form-A deepgemm graph (apply_topk_in_fc1=True): the kernel folded the
+        # topk score into the per-route BF16 terms, so the host reduce is a
+        # plain sum over the top-k axis. Accumulate in fp32 explicitly to match
+        # the design reference ``bf16(sum_fp32(term))`` and to be robust against
+        # any future change to the bf16 reduction accumulator type.
         out = combine_output[:num_tokens].to(torch.float32).sum(dim=1).to(output_dtype)
         return out
 

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1014,6 +1014,18 @@ class PyTorchModelEngine(ModelEngine):
         )
         AutoTuner.get().print_profiling_cache()
 
+        # Free the MegaMoE CuteDSL AutoTuner profiling scratch (a transient
+        # symmetric buffer only needed during profiling). Clearing the
+        # process-global cache here drops its sole strong owner; MegaMoE modules
+        # hold only a weakref to it, so the symmetric buffer is reclaimed below
+        # without keeping it in the KV-cache memory baseline.
+        from ..custom_ops import cute_dsl_megamoe_custom_op as _megamoe_op
+        release_megamoe_scratch = getattr(_megamoe_op,
+                                          "release_megamoe_profiling_scratch",
+                                          None)
+        if release_megamoe_scratch is not None:
+            release_megamoe_scratch()
+
         # Clear workspace buffers allocated during the autotuner forward pass.
         # The autotuner runs a context-only forward with max_num_tokens, which
         # causes the global Buffers pool to cache large MoE/GEMM workspaces.

--- a/tests/unittest/_torch/modules/moe/moe_test_utils.py
+++ b/tests/unittest/_torch/modules/moe/moe_test_utils.py
@@ -865,12 +865,11 @@ def supports_autotuner_capture(
     Returns:
         True if autotuner capture/replay is supported, False otherwise
     """
-    # DEEPGEMM and both MegaMoE backends do not support autotuner capture
+    # DEEPGEMM and MEGAMOE_DEEPGEMM do not support autotuner capture
     # (fused kernels own dispatch+combine).
     if backend_type in (
         MoeBackendType.DEEPGEMM,
         MoeBackendType.MEGAMOE_DEEPGEMM,
-        MoeBackendType.MEGAMOE_CUTEDSL,
     ):
         return False
 

--- a/tests/unittest/_torch/modules/moe/test_moe_module.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_module.py
@@ -1643,6 +1643,11 @@ def test_configurable_moe_multi_gpu(
     ):
         dtype_routing_logits = torch.float32
 
+    # MegaMoECuteDsl tunes its fused cross-rank kernel via the MERGE strategy,
+    # which only runs under autotune; enable it so the multi-GPU lockstep tuning
+    # path is actually exercised for this backend.
+    enable_autotune = moe_backend == MoeBackendType.MEGAMOE_CUTEDSL.value
+
     world_size = 4
     _test_moe_multi_gpu(
         comm_method_type,
@@ -1653,6 +1658,7 @@ def test_configurable_moe_multi_gpu(
         parallel_mode=parallel_mode,
         model_config=model_config,
         seq_len=seq_len,
+        enable_autotune=enable_autotune,
         routing_method_cls=routing_method_cls,
         dtype_routing_logits=dtype_routing_logits,
         swiglu_alpha=swiglu_alpha,


### PR DESCRIPTION
## What

- Import the latest MegaMoE CuteDSL kernel from the upstream MR (bangyus/cutedsl_megamoe!12): https://gitlab-master.nvidia.com/bangyus/cutedsl_megamoe/-/merge_requests/12
- Update the autotuning candidate space according to perf guidance, and introduce the `MEGAMOE_CUTEDSL_TUNING_FULL` env var to switch between the curated reduced space (default) and the full exhaustive cartesian product.

## Details

- Re-sync `mega_moe_nvfp4` kernel package to the upstream perf tip (TokenSrcMetadata, flag_batch, token_back_mode, byval SymBuffer, relaxed grid_sync, red_add_relaxed); keep local separate-handler + cutlass-free `megamoe_constants` fixes.
- Rework tactic to an 8-tuple (drop derived use_2cta / use_bf16_redg); rewrite `validate_megamoe_tactic`; add token-aware `default_megamoe_tactic` and curated/full candidate enumeration.
- `MEGAMOE_CUTEDSL_TUNING_FULL=0` (default): curated reduced space (~36/bucket). `=1`: full exhaustive search. Both share the same legality filter.
- Plumb the 8-tuple through `_build_kernel` / compile + workspace cache keys; pin `TuningConfig.tune_max_num_tokens` to the per-rank token ceiling.

## Test

- Autotuning + serving validated on GB200 (OCI) during the kernel port.