### PR TITLE
[None][perf] offload chat template rendering into async

### DIFF
--- a/tensorrt_llm/inputs/utils.py
+++ b/tensorrt_llm/inputs/utils.py
@@ -707,6 +707,37 @@ def apply_chat_template(
     return result
 
 
+async def async_apply_chat_template(
+    *,
+    model_type: str,
+    tokenizer: Union[TransformersTokenizer, TokenizerBase],
+    processor: ProcessorMixin,
+    conversation: list[ConversationMessage],
+    add_generation_prompt: bool,
+    mm_placeholder_counts: list[dict[str, int]],
+    tools: Optional[list[dict[str, Any]]] = None,
+    documents: Optional[list[dict[str, str]]] = None,
+    chat_template: Optional[str] = None,
+    chat_template_kwargs: Optional[dict[str, Any]] = None,
+    enable_tokenize: bool = False,
+) -> (str | List[str]):
+    """Apply chat template without blocking the event loop."""
+    return await asyncio.to_thread(
+        apply_chat_template,
+        model_type=model_type,
+        tokenizer=tokenizer,
+        processor=processor,
+        conversation=conversation,
+        add_generation_prompt=add_generation_prompt,
+        mm_placeholder_counts=mm_placeholder_counts,
+        tools=tools,
+        documents=documents,
+        chat_template=chat_template,
+        chat_template_kwargs=chat_template_kwargs,
+        enable_tokenize=enable_tokenize,
+    )
+
+
 def default_multimodal_input_loader(
     *,
     tokenizer: Optional[Union[TransformersTokenizer, TokenizerBase]],

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -39,7 +39,8 @@ from tensorrt_llm.inputs.data import TokensPrompt
 from tensorrt_llm.inputs.media_io import BaseMediaIO
 from tensorrt_llm.inputs.multimodal import MultimodalServerConfig
 from tensorrt_llm.inputs.registry import BaseMultimodalInputProcessor
-from tensorrt_llm.inputs.utils import ConversationMessage, apply_chat_template
+from tensorrt_llm.inputs.utils import (ConversationMessage,
+                                       async_apply_chat_template)
 from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
 from tensorrt_llm.llmapi import MultimodalEncoder, SchedulingParams, tracing
 from tensorrt_llm.llmapi.disagg_utils import (DisaggClusterConfig,
@@ -1329,7 +1330,7 @@ class OpenAIServer(_VideoRoutesMixin):
             if request.prompt_token_ids is not None:
                 prompt = request.prompt_token_ids
             else:
-                prompt: str = apply_chat_template(
+                prompt_task = async_apply_chat_template(
                     model_type=resolve_top_level_model_type(self.model_config),
                     tokenizer=self.tokenizer,
                     processor=self.processor,
@@ -1341,9 +1342,12 @@ class OpenAIServer(_VideoRoutesMixin):
                     chat_template=request.chat_template or self.chat_template,
                     chat_template_kwargs=request.chat_template_kwargs or {},
                 )
+                prompt, (mm_data, mm_embeddings) = await asyncio.gather(
+                    prompt_task, mm_coroutines)
             prompt = prompt_inputs(prompt)
 
-            mm_data, mm_embeddings = await mm_coroutines
+            if request.prompt_token_ids is not None:
+                mm_data, mm_embeddings = await mm_coroutines
             if mm_data:
                 prompt["multi_modal_data"] = mm_data
             if mm_embeddings:
@@ -1505,7 +1509,7 @@ class OpenAIServer(_VideoRoutesMixin):
             if request.prompt_token_ids is not None:
                 prompt = request.prompt_token_ids
             else:
-                prompt: str = apply_chat_template(
+                prompt_task = async_apply_chat_template(
                     model_type=resolve_top_level_model_type(self.model_config),
                     tokenizer=self.tokenizer,
                     processor=self.processor,
@@ -1517,9 +1521,12 @@ class OpenAIServer(_VideoRoutesMixin):
                     chat_template=request.chat_template,
                     chat_template_kwargs=request.chat_template_kwargs or {},
                 )
+                prompt, (mm_data, mm_embeddings) = await asyncio.gather(
+                    prompt_task, mm_coroutines)
             prompt = prompt_inputs(prompt)
 
-            mm_data, mm_embeddings = await mm_coroutines
+            if request.prompt_token_ids is not None:
+                mm_data, mm_embeddings = await mm_coroutines
             if mm_embeddings:
                 raise ValueError("Cannot use multimodal embeddings as input")
             if mm_data is not None:

--- a/tensorrt_llm/serve/resource_governor.py
+++ b/tensorrt_llm/serve/resource_governor.py
@@ -19,6 +19,7 @@ PyExecutor via a dedicated resource governor queue, bypassing the
 LLM/Proxy/Worker chain.
 """
 
+import asyncio
 import traceback
 from http import HTTPStatus
 from typing import Callable, List, Optional
@@ -27,7 +28,7 @@ from fastapi import FastAPI
 from starlette.responses import JSONResponse, Response
 
 from tensorrt_llm.executor.request import TruncateKVCacheRequest
-from tensorrt_llm.inputs.utils import ConversationMessage, apply_chat_template
+from tensorrt_llm.inputs.utils import ConversationMessage, async_apply_chat_template
 from tensorrt_llm.logger import logger
 from tensorrt_llm.serve.chat_utils import parse_chat_messages_coroutines
 from tensorrt_llm.serve.openai_protocol import (
@@ -91,7 +92,7 @@ class ResourceGovernor:
         queue.put(request)
         return None
 
-    def _convert_messages(
+    async def _convert_messages(
         self,
         messages,
         tool_dicts,
@@ -102,20 +103,24 @@ class ResourceGovernor:
     ) -> List[int]:
         """Convert chat messages to token IDs via chat template + tokenization."""
         conversation: List[ConversationMessage] = []
-        conversation, _, __ = parse_chat_messages_coroutines(messages, self.model_config, None)
-        return apply_chat_template(
+        conversation, mm_coroutines, mm_placeholder_counts = parse_chat_messages_coroutines(
+            messages, self.model_config, None
+        )
+        token_task = async_apply_chat_template(
             model_type=self.model_config.model_type,
             tokenizer=self.tokenizer,
             processor=self.processor,
             conversation=conversation,
             add_generation_prompt=add_generation_prompt,
-            mm_placeholder_counts=[],
+            mm_placeholder_counts=mm_placeholder_counts,
             tools=tool_dicts,
             documents=documents,
             chat_template=chat_template,
             chat_template_kwargs=chat_template_kwargs or {},
             enable_tokenize=True,
         )
+        token_ids, _ = await asyncio.gather(token_task, mm_coroutines)
+        return token_ids
 
     async def _truncate_kv_cache(self, request: KVCacheTruncateRequest) -> Response:
         try:
@@ -126,7 +131,7 @@ class ResourceGovernor:
             chat_template_kwargs = request.chat_template_kwargs or {}
 
             messages_to_retain = (
-                self._convert_messages(
+                await self._convert_messages(
                     request.messages_to_retain,
                     tool_dicts,
                     request.add_generation_prompt,
@@ -139,7 +144,7 @@ class ResourceGovernor:
             )
 
             messages = (
-                self._convert_messages(
+                await self._convert_messages(
                     request.messages,
                     tool_dicts,
                     request.add_generation_prompt,

--- a/tensorrt_llm/serve/resource_governor.py
+++ b/tensorrt_llm/serve/resource_governor.py
@@ -30,7 +30,10 @@ from starlette.responses import JSONResponse, Response
 from tensorrt_llm.executor.request import TruncateKVCacheRequest
 from tensorrt_llm.inputs.utils import ConversationMessage, async_apply_chat_template
 from tensorrt_llm.logger import logger
-from tensorrt_llm.serve.chat_utils import parse_chat_messages_coroutines
+from tensorrt_llm.serve.chat_utils import (
+    parse_chat_messages_coroutines,
+    resolve_top_level_model_type,
+)
 from tensorrt_llm.serve.openai_protocol import (
     KVCacheTruncateRequest,
     ensure_request_chat_template_allowed,
@@ -107,7 +110,7 @@ class ResourceGovernor:
             messages, self.model_config, None
         )
         token_task = async_apply_chat_template(
-            model_type=self.model_config.model_type,
+            model_type=resolve_top_level_model_type(self.model_config),
             tokenizer=self.tokenizer,
             processor=self.processor,
             conversation=conversation,

--- a/tensorrt_llm/serve/responses_utils.py
+++ b/tensorrt_llm/serve/responses_utils.py
@@ -836,7 +836,9 @@ async def _create_input_tokens(
         mm_placeholder_counts=mm_placeholder_counts,
         enable_tokenize=True,
     )
-    token_ids, mm_data = await asyncio.gather(token_task, mm_coroutines)
+    token_ids, (mm_data,
+                _mm_embeddings) = await asyncio.gather(token_task,
+                                                       mm_coroutines)
 
     return token_ids, mm_data
 

--- a/tensorrt_llm/serve/responses_utils.py
+++ b/tensorrt_llm/serve/responses_utils.py
@@ -42,7 +42,7 @@ from transformers import AutoProcessor, PretrainedConfig
 
 from tensorrt_llm.bindings import steady_clock_now
 from tensorrt_llm.executor import GenerationResult
-from tensorrt_llm.inputs.utils import apply_chat_template
+from tensorrt_llm.inputs.utils import async_apply_chat_template
 from tensorrt_llm.llmapi import SamplingParams
 from tensorrt_llm.llmapi.llm import RequestOutput
 from tensorrt_llm.llmapi.reasoning_parser import (BaseReasoningParser,
@@ -822,13 +822,11 @@ async def _create_input_tokens(
 
     conversation, mm_coroutines, mm_placeholder_counts = parse_chat_messages_coroutines(
         messages, model_config)
-    mm_data = await mm_coroutines
-
     tools_dict = [
         tool.model_dump()
         for tool in _get_chat_completion_function_tools(request.tools)
     ]
-    token_ids = apply_chat_template(
+    token_task = async_apply_chat_template(
         model_type=resolve_top_level_model_type(model_config),
         tokenizer=tokenizer,
         processor=processor,
@@ -838,6 +836,7 @@ async def _create_input_tokens(
         mm_placeholder_counts=mm_placeholder_counts,
         enable_tokenize=True,
     )
+    token_ids, mm_data = await asyncio.gather(token_task, mm_coroutines)
 
     return token_ids, mm_data
 

--- a/tests/unittest/inputs/test_chat_template_dispatch.py
+++ b/tests/unittest/inputs/test_chat_template_dispatch.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Tests for content-format-driven chat template dispatch and placeholder handling."""
 
+import threading
+
 import pytest
 
 from tensorrt_llm.inputs.content_format import ContentFormat
@@ -15,6 +17,7 @@ from tensorrt_llm.inputs.utils import (
     _build_openai_content,
     _resolve_content_format,
     add_multimodal_placeholders,
+    async_apply_chat_template,
     interleave_mm_placeholders,
 )
 
@@ -324,3 +327,33 @@ class TestAddMultimodalPlaceholdersDedup:
         )
         assert result == text
         assert result.count("<image>") == 3
+
+
+class TestAsyncApplyChatTemplate:
+    @pytest.mark.asyncio
+    async def test_runs_in_worker_thread(self):
+        event_loop_thread_id = threading.current_thread().ident
+
+        class TrackingTokenizer:
+            def __init__(self):
+                self.worker_thread_id = None
+
+            def apply_chat_template(self, **_):
+                self.worker_thread_id = threading.current_thread().ident
+                return "rendered"
+
+        tokenizer = TrackingTokenizer()
+
+        result = await async_apply_chat_template(
+            model_type="test_string_model",
+            tokenizer=tokenizer,
+            processor=None,
+            conversation=[ConversationMessage(role="user", content="hello", media=[])],
+            add_generation_prompt=True,
+            mm_placeholder_counts=[{}],
+            chat_template="{{ messages }}",
+        )
+
+        assert result == "rendered"
+        assert tokenizer.worker_thread_id is not None
+        assert tokenizer.worker_thread_id != event_loop_thread_id

--- a/tests/unittest/inputs/test_chat_template_dispatch.py
+++ b/tests/unittest/inputs/test_chat_template_dispatch.py
@@ -357,3 +357,101 @@ class TestAsyncApplyChatTemplate:
         assert result == "rendered"
         assert tokenizer.worker_thread_id is not None
         assert tokenizer.worker_thread_id != event_loop_thread_id
+
+
+class TestServingChatTemplateGather:
+    """Cover the asyncio.gather integration in the serving chat-template paths."""
+
+    @pytest.mark.asyncio
+    async def test_resource_governor_convert_messages(self, monkeypatch):
+        from unittest.mock import Mock
+
+        import tensorrt_llm.serve.resource_governor as rg
+
+        governor = object.__new__(rg.ResourceGovernor)
+        governor.model_config = Mock()
+        governor.tokenizer = Mock()
+        governor.processor = None
+
+        async def fake_mm_coroutine():
+            # parse_chat_messages_coroutines' coroutine yields
+            # (mm_data, mm_embeddings).
+            return ({"image": ["data"]}, None)
+
+        monkeypatch.setattr(
+            rg,
+            "parse_chat_messages_coroutines",
+            lambda messages, model_config, _: ([], fake_mm_coroutine(), [{}]),
+        )
+        # Must resolve the top-level model type, matching the serving call
+        # sites (not the raw model_config.model_type).
+        monkeypatch.setattr(rg, "resolve_top_level_model_type", lambda cfg: "resolved-model-type")
+
+        captured = {}
+
+        async def fake_async_apply(**kwargs):
+            captured.update(kwargs)
+            return [1, 2, 3]
+
+        monkeypatch.setattr(rg, "async_apply_chat_template", fake_async_apply)
+
+        token_ids = await governor._convert_messages(
+            messages=[{"role": "user", "content": "hi"}],
+            tool_dicts=None,
+            add_generation_prompt=True,
+            documents=None,
+            chat_template=None,
+            chat_template_kwargs=None,
+        )
+
+        # Returns only token_ids, not the (mm_data, mm_embeddings) tuple.
+        assert token_ids == [1, 2, 3]
+        # Uses the top-level resolver and forwards the real placeholder counts.
+        assert captured["model_type"] == "resolved-model-type"
+        assert captured["mm_placeholder_counts"] == [{}]
+
+    @pytest.mark.asyncio
+    async def test_responses_create_input_tokens_unpacks_mm_tuple(self, monkeypatch):
+        """_create_input_tokens must return mm_data, not the whole gather tuple."""
+        from unittest.mock import Mock
+
+        import tensorrt_llm.serve.responses_utils as ru
+
+        async def fake_create_input_messages(request, prev_msgs):
+            return [{"role": "user", "content": "hi"}]
+
+        async def fake_mm_coroutine():
+            return ({"image": ["data"]}, {"image": ["embed"]})
+
+        monkeypatch.setattr(ru, "_create_input_messages", fake_create_input_messages)
+        monkeypatch.setattr(
+            ru,
+            "parse_chat_messages_coroutines",
+            lambda messages, model_config: ([], fake_mm_coroutine(), [{}]),
+        )
+        monkeypatch.setattr(ru, "resolve_top_level_model_type", lambda cfg: "resolved-model-type")
+        monkeypatch.setattr(ru, "_get_chat_completion_function_tools", lambda tools: [])
+
+        async def fake_async_apply(**kwargs):
+            return [1, 2, 3]
+
+        monkeypatch.setattr(ru, "async_apply_chat_template", fake_async_apply)
+
+        request = Mock()
+        request.tools = None
+        request.store = False
+
+        token_ids, mm_data = await ru._create_input_tokens(
+            request=request,
+            prev_response=None,
+            prev_msgs=None,
+            conversation_store=None,
+            enable_store=False,
+            tokenizer=Mock(),
+            model_config=Mock(),
+            processor=None,
+        )
+
+        assert token_ids == [1, 2, 3]
+        # mm_data is the data dict, not the (mm_data, mm_embeddings) tuple.
+        assert mm_data == {"image": ["data"]}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Chat template processing is now asynchronous and non-blocking throughout the inference server, enabling concurrent execution with multimodal preprocessing and other operations. This improves request throughput and server responsiveness, with particular benefits for workflows involving multimodal content.

* **Tests**
  * Added tests to validate async chat template processing works correctly in concurrent execution scenarios without blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->