### PR TITLE
[TRTLLM-13247][feat] Wave 2: stage Linear and Attention transforms

### DIFF
--- a/tensorrt_llm/_torch/memory/gpu_memory_backend.py
+++ b/tensorrt_llm/_torch/memory/gpu_memory_backend.py
@@ -42,9 +42,10 @@ Operating modes:
   whose `post_load_weights()` is pure alias wiring; models that additionally
   rely on plain Python attributes set inside `post_load_weights()` (rather
   than registered `nn.Buffer` / `nn.Parameter` assignments) need to migrate
-  those side effects to `cache_derived_state()` or another path that runs on
-  RO readers. The GMS RO reader runs `setup_aliases()` before
-  `materialize_module()` and `cache_derived_state()` afterward; it does not
+  those side effects to `cache_derived_state()` or another hook that runs on
+  RO readers. One-shot tensor layout changes belong in `transform_weights()`
+  on the writer; the GMS RO reader runs `setup_aliases()` before
+  `materialize_module()`, then `cache_derived_state()` afterward. It does not
   run `transform_weights()`.
 """
 

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -3027,5 +3027,8 @@ class MLA(nn.Module):
                 self.v_b_proj, self.v_b_proj_scale, recipe=(1, 128, 128))
         self._weights_transformed = True
 
+    def cache_derived_state(self) -> None:
+        self._weights_transformed = True
+
     def post_load_weights(self) -> None:
         self.transform_weights()

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1241,6 +1241,7 @@ class MLA(nn.Module):
         self.layer_idx = layer_idx
         self.layer_idx_str = str(layer_idx)
         self.dtype = dtype
+        self._weights_transformed = False
 
         self.hidden_size = hidden_size
         self.num_heads = num_attention_heads
@@ -1629,6 +1630,7 @@ class MLA(nn.Module):
         else:
             self.k_b_proj_trans_scale = None
             self.v_b_proj_scale = None
+        self._weights_transformed = False
 
     def apply_rope(
         self,
@@ -3008,7 +3010,9 @@ class MLA(nn.Module):
 
         return weight_param, scale_param
 
-    def post_load_weights(self):
+    def transform_weights(self) -> None:
+        if self._weights_transformed:
+            return
         has_fp8_block_scales = (
             self.kv_b_proj.quant_config
             and self.kv_b_proj.quant_config.quant_mode.has_fp8_block_scales())
@@ -3021,3 +3025,7 @@ class MLA(nn.Module):
 
             self.v_b_proj, self.v_b_proj_scale = self.resmooth_parameters(
                 self.v_b_proj, self.v_b_proj_scale, recipe=(1, 128, 128))
+        self._weights_transformed = True
+
+    def post_load_weights(self) -> None:
+        self.transform_weights()

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -2799,7 +2799,7 @@ class W4A8MXFP4MXFP8LinearMethod(W4A8MXFP4FP8LinearMethod):
 class MarlinNVFP4LinearMethod(NVFP4LinearMethod):
     """NVFP4 Linear method backed by the Marlin W4A16 kernel (Hopper only)."""
 
-    def post_load_weights(self, module: Linear):
+    def transform_weights(self, module: Linear) -> None:
         from tensorrt_llm.quantization.utils import marlin_utils
 
         weight = module.weight.data
@@ -2881,7 +2881,7 @@ class MarlinNVFP4LinearMethod(NVFP4LinearMethod):
         assert is_nvfp4_marlin_enabled()
         size_k = module.in_features
         size_n = module.out_features
-        # Set by post_load_weights; equal to size_k/size_n when 64-aligned.
+        # Set by transform_weights; equal to size_k/size_n when 64-aligned.
         size_k_pad = getattr(module, "_marlin_size_k", size_k)
         size_n_pad = getattr(module, "_marlin_size_n", size_n)
 

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -382,7 +382,7 @@ class LinearMethodBase(ABC):
             self.process_weights_after_loading(module)
 
     def transform_weights(self, module: Linear) -> None:
-        pass
+        ...
 
     def post_load_weights(self, module: Linear) -> None:
         self.transform_weights(module)
@@ -3267,6 +3267,9 @@ class Linear(nn.Module):
         if self._weights_transformed:
             return
         self.quant_method.transform_weights(self)
+        self._weights_transformed = True
+
+    def cache_derived_state(self) -> None:
         self._weights_transformed = True
 
     def post_load_weights(self) -> None:

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -381,8 +381,11 @@ class LinearMethodBase(ABC):
         if not allow_partial_loading:
             self.process_weights_after_loading(module)
 
-    def post_load_weights(self, module: Linear):
+    def transform_weights(self, module: Linear) -> None:
         pass
+
+    def post_load_weights(self, module: Linear) -> None:
+        self.transform_weights(module)
 
     def load_weight_scales(self, weights: List[Dict], *args, **kwargs):
         """
@@ -1242,8 +1245,8 @@ class FP8BlockScalesLinearMethod(UnquantizedLinearMethod):
                 copy_weight_shard(module.weight_scale, scale, shard_offset,
                                   shard_size)
 
-    def post_load_weights(self, module: Linear):
-        super().post_load_weights(module)
+    def transform_weights(self, module: Linear) -> None:
+        super().transform_weights(module)
         if (is_sm_100f() and not (module.use_cute_dsl_blockscaling_mm
                                  or module.disable_deep_gemm)) or \
            get_sm_version() == 120:
@@ -1822,9 +1825,9 @@ class NVFP4LinearMethod(LinearMethodBase):
             torch.ops.trtllm.block_scale_interleave(ws_swapped),
             requires_grad=False)
 
-    def post_load_weights(self, module: Linear):
+    def transform_weights(self, module: Linear) -> None:
         """Pad weight and weight_scale tensors to meet torch trtllm NVFP4 GEMM alignment requirements."""
-        super().post_load_weights(module)
+        super().transform_weights(module)
         row_alignment, col_alignment = 32, 16
         row_pad_size = (row_alignment - module.weight.size(0)) % row_alignment
         col_pad_size = (col_alignment - module.weight.size(1)) % col_alignment
@@ -1874,10 +1877,10 @@ class W4A16NVFP4LinearMethod(NVFP4LinearMethod):
     its fused path is SM>=100-gated upstream.
     """
 
-    def post_load_weights(self, module: Linear):
+    def transform_weights(self, module: Linear) -> None:
         # Skip parent's 32x16 weight padding (apply() accepts [N, K/2] as-is)
         # and un-swizzle per-block scale once at load.
-        LinearMethodBase.post_load_weights(self, module)
+        LinearMethodBase.transform_weights(self, module)
         pad_rows = fp4_utils.pad_up(module.out_features, 128)
         pad_cols = fp4_utils.pad_up(
             module.in_features // module.scaling_vector_size, 4)
@@ -3035,6 +3038,7 @@ class Linear(nn.Module):
                                     dtype=self.dtype) if reduce_output else None
 
         self._weights_created = False
+        self._weights_transformed = False
         self.reduce_output = reduce_output
         self.use_custom_cublas_mm = use_custom_cublas_mm
         self.use_cute_dsl_bf16_gemm = use_cute_dsl_bf16_gemm
@@ -3087,6 +3091,7 @@ class Linear(nn.Module):
                                          self.dtype)
 
         self._weights_created = True
+        self._weights_transformed = False
 
     @property
     def has_any_quant(self):
@@ -3248,6 +3253,7 @@ class Linear(nn.Module):
             assert allow_partial_loading is False, (
                 f"{type(self.quant_method).__name__} does not support "
                 "allow_partial_loading")
+        self._weights_transformed = False
         self.quant_method.load_weights(
             self,
             weights,
@@ -3257,8 +3263,14 @@ class Linear(nn.Module):
     def process_weights_after_loading(self):
         self.quant_method.process_weights_after_loading(self)
 
-    def post_load_weights(self):
-        self.quant_method.post_load_weights(self)
+    def transform_weights(self) -> None:
+        if self._weights_transformed:
+            return
+        self.quant_method.transform_weights(self)
+        self._weights_transformed = True
+
+    def post_load_weights(self) -> None:
+        self.transform_weights()
 
     def pre_reload_weights(self):
         assert hasattr(

--- a/tests/unittest/_torch/pyexecutor/test_model_loader_gms.py
+++ b/tests/unittest/_torch/pyexecutor/test_model_loader_gms.py
@@ -195,6 +195,8 @@ def test_gms_load_branch(monkeypatch, is_rw, expected_events):
         # ``model=model`` is passed for symmetry with the LoadFormat.AUTO
         # path (see model_loader.py); HF ignores it, MX uses it for direct
         # P2P writes when MX+GMS composition eventually lands.
+        # ``source_identity`` is included so format-specific loaders can
+        # publish the same compatibility fingerprint the RO path validates.
         checkpoint_loader.load_weights.assert_called_once_with(
             "/ckpt",
             mapping=loader.mapping,

--- a/tests/unittest/_torch/pyexecutor/test_model_loader_mx.py
+++ b/tests/unittest/_torch/pyexecutor/test_model_loader_mx.py
@@ -9,6 +9,9 @@ from unittest.mock import MagicMock
 import torch
 from torch import nn
 
+from tensorrt_llm._torch.modules import attention as attention_mod
+from tensorrt_llm._torch.modules.attention import MLA
+from tensorrt_llm._torch.modules.linear import Linear
 from tensorrt_llm._torch.pyexecutor import model_loader as model_loader_mod
 from tensorrt_llm._torch.pyexecutor.model_loader import ModelLoader
 from tensorrt_llm.llmapi.llm_args import LoadFormat
@@ -282,3 +285,56 @@ def test_reset_weights_transformed_only_resets_existing_flags():
     assert model.child._weights_transformed is False
     assert model.transformed_child._weights_transformed is False
     assert not hasattr(model.removed_child, "_weights_transformed")
+
+
+def test_linear_transform_weights_is_idempotent():
+    linear = Linear(
+        1,
+        1,
+        bias=False,
+        reduce_output=False,
+        skip_create_weights_in_init=True,
+    )
+    linear.quant_method = MagicMock()
+
+    linear.transform_weights()
+    linear.post_load_weights()
+
+    linear.quant_method.transform_weights.assert_called_once_with(linear)
+    assert linear._weights_transformed is True
+
+    linear._weights_transformed = False
+    linear.post_load_weights()
+    assert linear.quant_method.transform_weights.call_count == 2
+
+
+def test_mla_transform_weights_is_idempotent(monkeypatch):
+    monkeypatch.setattr(attention_mod, "get_sm_version", lambda: 120)
+    quant_mode = SimpleNamespace(has_fp8_block_scales=lambda: True)
+    mla = MLA.__new__(MLA)
+    mla._weights_transformed = False
+    mla.kv_b_proj = SimpleNamespace(quant_config=SimpleNamespace(quant_mode=quant_mode))
+    mla.k_b_proj_trans = "k_weight"
+    mla.k_b_proj_trans_scale = "k_scale"
+    mla.v_b_proj = "v_weight"
+    mla.v_b_proj_scale = "v_scale"
+    calls = []
+
+    def fake_resmooth(weight, scale, recipe):
+        calls.append((weight, scale, recipe))
+        return f"{weight}_transformed", f"{scale}_transformed"
+
+    mla.resmooth_parameters = fake_resmooth
+
+    MLA.transform_weights(mla)
+    MLA.post_load_weights(mla)
+
+    assert calls == [
+        ("k_weight", "k_scale", (1, 128, 128)),
+        ("v_weight", "v_scale", (1, 128, 128)),
+    ]
+    assert mla.k_b_proj_trans == "k_weight_transformed"
+    assert mla.k_b_proj_trans_scale == "k_scale_transformed"
+    assert mla.v_b_proj == "v_weight_transformed"
+    assert mla.v_b_proj_scale == "v_scale_transformed"
+    assert mla._weights_transformed is True

--- a/tests/unittest/_torch/pyexecutor/test_model_loader_mx.py
+++ b/tests/unittest/_torch/pyexecutor/test_model_loader_mx.py
@@ -307,6 +307,10 @@ def test_linear_transform_weights_is_idempotent():
     linear.post_load_weights()
     assert linear.quant_method.transform_weights.call_count == 2
 
+    linear._weights_transformed = False
+    linear.cache_derived_state()
+    assert linear._weights_transformed is True
+
 
 def test_mla_transform_weights_is_idempotent(monkeypatch):
     monkeypatch.setattr(attention_mod, "get_sm_version", lambda: 120)
@@ -337,4 +341,8 @@ def test_mla_transform_weights_is_idempotent(monkeypatch):
     assert mla.k_b_proj_trans_scale == "k_scale_transformed"
     assert mla.v_b_proj == "v_weight_transformed"
     assert mla.v_b_proj_scale == "v_scale_transformed"
+    assert mla._weights_transformed is True
+
+    mla._weights_transformed = False
+    MLA.cache_derived_state(mla)
     assert mla._weights_transformed is True


### PR DESCRIPTION
## Summary

Wave 2 of the staged post-load hooks rollout, stacked on #15014.

This migrates the remaining Linear and MLA tensor-layout post-load work into `transform_weights()` with `_weights_transformed` guards, while keeping `post_load_weights()` as the backward-compatible shim for existing full post-load walks.

## What Changed

- Added `Linear.transform_weights()` and a quant-method-level `transform_weights()` hook, with `post_load_weights()` delegating through the staged hook.
- Moved FP8 block-scale resmoothing, NVFP4 padding, and W4A16 NVFP4 scale unswizzling from Linear `post_load_weights()` implementations into `transform_weights()`.
- Added `_weights_transformed` state for Linear and MLA, reset when fresh Linear weights or auxiliary MLA weight tensors are created/loaded.
- Moved MLA SM120 FP8 resmoothing into `MLA.transform_weights()` and kept `MLA.post_load_weights()` as a shim.
- Clarified the GMS RO documentation: RO readers run `setup_aliases()`, `materialize_module()`, then `cache_derived_state()`; writer-only tensor layout changes belong in `transform_weights()`.
- Updated/added pyexecutor unit coverage for transform idempotency and the GMS RW `source_identity` call shape.

## Dependency / prerequisite stack

This PR is Wave 2 in the staged post-load hooks rollout. The foundation PRs #14770 and #14878 are already merged. The wave PRs should merge in sequence; after each upstream wave lands, rebase the next wave onto `main` so review and CI focus on that wave's delta.

Arrows point from prerequisite to dependent. PR numbers in graph nodes are clickable.

```mermaid
graph TD
    PR14770["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/14770'>#14770</a>: staged-hook contract (merged)"]
    PR14878["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/14878'>#14878</a>: GMS SourceIdentity gate (merged)"]
    PR15014["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15014'>#15014</a>: Wave 1 aliases + GMS RO load (open)"]
    PR15288["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15288'>#15288</a>: Wave 2 Linear/Attention transforms (this PR, draft)"]
    PR15386["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15386'>#15386</a>: Wave 3 MoE/Mamba staged hooks (draft)"]
    PR15387["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15387'>#15387</a>: Wave 4 MX receiver cutover (draft)"]
    PR15432["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15432'>#15432</a>: Wave 5 MX publisher + Llama receiver (draft)"]
    VERIFY["post-migration verification / demo (planned)"]

    PR14770 -->|satisfied| PR15014
    PR14878 -->|satisfied| PR15014
    PR15014 -->|blocking| PR15288
    PR15288 -->|blocking| PR15386
    PR15386 -->|blocking| PR15387
    PR15387 -->|blocking| PR15432
    PR15432 -.->|planned| VERIFY

    classDef merged fill:#dcfce7,stroke:#16a34a,color:#14532d;
    classDef inflight fill:#dbeafe,stroke:#2563eb,color:#1e3a8a;
    classDef draft fill:#ffedd5,stroke:#f97316,color:#7c2d12;
    classDef current fill:#ede9fe,stroke:#7c3aed,color:#3b0764,stroke-width:3px;
    classDef downstream fill:#f3f4f6,stroke:#6b7280,color:#374151,stroke-dasharray:5 5;
    linkStyle 0,1 stroke:#16a34a,stroke-width:2px;
    linkStyle 2,3,4,5 stroke:#ea580c,stroke-width:3px;
    linkStyle 6 stroke:#6b7280,stroke-width:2px,stroke-dasharray:5 5;

    class PR14770,PR14878 merged;
    class PR15014 inflight;
    class PR15386,PR15387,PR15432 draft;
    class PR15288 current;
    class VERIFY downstream;
```

Immediate merge dependency for this PR: #15014 must land first; after it lands, rebase this branch onto `main` so the PR diff collapses to the Wave 2 delta.


## Test Plan

- `PYTHONPYCACHEPREFIX=/tmp/trtllm-wave2-pycache python3 -m py_compile tensorrt_llm/_torch/modules/linear.py tensorrt_llm/_torch/modules/attention.py tensorrt_llm/_torch/memory/gpu_memory_backend.py tests/unittest/_torch/pyexecutor/test_model_loader_mx.py tests/unittest/_torch/pyexecutor/test_model_loader_gms.py`
- `git diff --check`
- `PATH=/Users/chienchunh/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin:$PATH pre-commit run --files tensorrt_llm/_torch/memory/gpu_memory_backend.py tensorrt_llm/_torch/modules/attention.py tensorrt_llm/_torch/modules/linear.py tests/unittest/_torch/pyexecutor/test_model_loader_gms.py tests/unittest/_torch/pyexecutor/test_model_loader_mx.py`
- Focused pytest command attempted but blocked in this macOS shell because `transformers` is not installed: `PYTHONPATH=. PYTHONPYCACHEPREFIX=/tmp/trtllm-wave2-pycache pytest tests/unittest/_torch/pyexecutor/test_model_loader_mx.py tests/unittest/_torch/pyexecutor/test_model_loader_gms.py`

## Next Steps

- Wave 3: migrate MoE and Mamba post-load transforms/cache state.
- After #15014 lands, rebase this branch onto `main` so the PR diff collapses to the Wave 2 commit only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed weight initialization sequencing in read-only weight sharing models to ensure structural aliases are properly configured before tensor materialization.

* **Refactor**
  * Restructured weight loading and transformation pipeline with enhanced state tracking and idempotency checks to prevent redundant transformations.
  * Updated and consolidated weight initialization hooks across multiple model implementations for improved lifecycle management and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->