### PR TITLE
[TRTLLM-12373][feat] standalone SwiGLU + NVFP4-quant fusion for GatedMLP

### DIFF
--- a/cpp/tensorrt_llm/kernels/fusedActivationQuant.cu
+++ b/cpp/tensorrt_llm/kernels/fusedActivationQuant.cu
@@ -37,6 +37,14 @@ __device__ __forceinline__ float relu2_f32(float x)
     return r * r;
 }
 
+// SwiGLU gate: silu(a) * b. Multiplication order (sigmoid(a) * a * b) mirrors the
+// Triton silu_and_mul_kernel in tensorrt_llm/_torch/modules/swiglu.py:42.
+__device__ __forceinline__ float silu_mul_f32(float a, float b)
+{
+    float sig = 1.0f / (1.0f + __expf(-a));
+    return sig * a * b;
+}
+
 // Fused relu2 + NVFP4 quantization kernel.
 //
 // To match the unfused path (PyTorch relu2 -> cvt_warp_fp16_to_fp4), relu2 is
@@ -179,6 +187,157 @@ template void invokeFusedRelu2Quantize<half>(
 
 #ifdef ENABLE_BF16
 template void invokeFusedRelu2Quantize<__nv_bfloat16>(
+    __nv_bfloat16 const*, float const*, std::uint8_t*, std::uint8_t*, int, int, int, cudaStream_t);
+#endif
+
+// Fused SwiGLU (silu(gate) * up) + NVFP4 quantization kernel.
+//
+// Input is [m, 2n] with the gate half in columns [0, n) and the up half in
+// columns [n, 2n); output is the NVFP4-quantized [m, n] activation. To match the
+// unfused path (Triton silu_and_mul -> fp4_quantize), the gate is computed in f32
+// then rounded back to native precision (bf16/fp16) before quantization. All
+// absmax / scale-factor / swizzled-SF math is identical to fusedRelu2QuantizeKernel.
+template <typename T>
+__global__ void fusedSiluMulQuantizeKernel(T const* __restrict__ input, float const* __restrict__ sfScale,
+    uint32_t* __restrict__ outputFp4, uint32_t* __restrict__ outputSf, int m, int n)
+{
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+    constexpr int kSfVecSize = 16;
+    constexpr int kNumThreadsPerSf = kSfVecSize / kEltsPerThread;
+    constexpr int kPackedPerThread = kEltsPerThread / 2;
+
+    using PackedType = std::conditional_t<std::is_same_v<T, half>, __half2, __nv_bfloat162>;
+
+    float const SFScaleVal = sfScale[0];
+    int const numColThreads = n / kEltsPerThread;
+    int const numColVecs = n / kSfVecSize;
+    int const numColThreadsPadded = ((n + 4 * kSfVecSize - 1) / (4 * kSfVecSize)) * (4 * kSfVecSize) / kEltsPerThread;
+    int const rowIdx = blockIdx.x;
+
+    if (rowIdx >= m)
+        return;
+
+    // Input row stride is 2n; gate half starts at column 0, up half at column n.
+    int const gateBase = rowIdx * 2 * n;
+    int const upBase = gateBase + n;
+
+    for (int colIdx = threadIdx.x; colIdx < numColThreadsPadded; colIdx += blockDim.x)
+    {
+        bool const isValidCol = colIdx < numColThreads;
+        PackedType packedVals[kPackedPerThread];
+
+        if (isValidCol)
+        {
+            int const colOffset = colIdx * kEltsPerThread;
+#pragma unroll
+            for (int i = 0; i < kPackedPerThread; i++)
+            {
+                int const c0 = colOffset + i * 2;
+                int const c1 = colOffset + i * 2 + 1;
+                float f0 = silu_mul_f32(static_cast<float>(input[gateBase + c0]), static_cast<float>(input[upBase + c0]));
+                float f1 = silu_mul_f32(static_cast<float>(input[gateBase + c1]), static_cast<float>(input[upBase + c1]));
+                if constexpr (std::is_same_v<T, half>)
+                {
+                    packedVals[i] = __floats2half2_rn(f0, f1);
+                }
+                else
+                {
+                    packedVals[i] = __floats2bfloat162_rn(f0, f1);
+                }
+            }
+        }
+        else
+        {
+#pragma unroll
+            for (int i = 0; i < kPackedPerThread; i++)
+            {
+                if constexpr (std::is_same_v<T, half>)
+                {
+                    packedVals[i] = __float2half2_rn(0.0f);
+                }
+                else
+                {
+                    packedVals[i] = __float2bfloat162_rn(0.0f);
+                }
+            }
+        }
+
+        // Absmax in native precision, then reduce across the SF group (2 threads).
+        auto localMax = cuda_abs(packedVals[0]);
+#pragma unroll
+        for (int i = 1; i < kPackedPerThread; i++)
+        {
+            localMax = cuda_max(localMax, cuda_abs(packedVals[i]));
+        }
+        localMax = cuda_max(__shfl_xor_sync(uint32_t(-1), localMax, 1), localMax);
+        float vecMax = float(cuda_max(localMax.x, localMax.y));
+
+        // Scale-factor computation (identical to cvt_warp_fp16_to_fp4).
+        float SFValue = SFScaleVal * (vecMax * reciprocal_approximate_ftz(6.0f));
+        __nv_fp8_e4m3 fp8SF = __nv_fp8_e4m3(SFValue);
+        uint8_t fp8SFVal = fp8SF.__x;
+        SFValue = static_cast<float>(fp8SF);
+
+        float outputScale
+            = vecMax != 0.0f ? reciprocal_approximate_ftz(SFValue * reciprocal_approximate_ftz(SFScaleVal)) : 0.0f;
+
+        if (colIdx % kNumThreadsPerSf == 0)
+        {
+            auto sfOutPtr = cvt_quant_get_sf_out_offset<uint32_t, kNumThreadsPerSf>(std::nullopt, rowIdx, colIdx,
+                std::optional<int>(m), numColVecs, outputSf, QuantizationSFLayout::SWIZZLED);
+            if (sfOutPtr != nullptr)
+            {
+                *sfOutPtr = fp8SFVal;
+            }
+        }
+
+        if (isValidCol)
+        {
+            float2 fp2Vals[kPackedPerThread];
+#pragma unroll
+            for (int i = 0; i < kPackedPerThread; i++)
+            {
+                if constexpr (std::is_same_v<T, half>)
+                {
+                    fp2Vals[i] = __half22float2(packedVals[i]);
+                }
+                else
+                {
+                    fp2Vals[i] = __bfloat1622float2(packedVals[i]);
+                }
+                fp2Vals[i].x *= outputScale;
+                fp2Vals[i].y *= outputScale;
+            }
+
+            outputFp4[rowIdx * numColThreads + colIdx] = fp32_vec_to_e2m1(fp2Vals);
+        }
+    }
+#else
+    if (threadIdx.x == 0 && blockIdx.x == 0)
+    {
+        printf("FP4 quantization requires SM100 (Blackwell) or later!\n");
+    }
+#endif
+}
+
+template <typename T>
+void invokeFusedSiluMulQuantize(T const* input, float const* sfScale, std::uint8_t* outputFp4, std::uint8_t* outputSf,
+    int m, int n, int sfVecSize, cudaStream_t stream)
+{
+    constexpr int kSfVecSize = 16;
+    int const numColThreadsPadded = ((n + 4 * kSfVecSize - 1) / (4 * kSfVecSize)) * (4 * kSfVecSize) / kEltsPerThread;
+    int threadsPerBlock = min(512, numColThreadsPadded);
+    threadsPerBlock = max(32, ((threadsPerBlock + 31) / 32) * 32);
+
+    fusedSiluMulQuantizeKernel<T><<<m, threadsPerBlock, 0, stream>>>(
+        input, sfScale, reinterpret_cast<uint32_t*>(outputFp4), reinterpret_cast<uint32_t*>(outputSf), m, n);
+}
+
+template void invokeFusedSiluMulQuantize<half>(
+    half const*, float const*, std::uint8_t*, std::uint8_t*, int, int, int, cudaStream_t);
+
+#ifdef ENABLE_BF16
+template void invokeFusedSiluMulQuantize<__nv_bfloat16>(
     __nv_bfloat16 const*, float const*, std::uint8_t*, std::uint8_t*, int, int, int, cudaStream_t);
 #endif
 

--- a/cpp/tensorrt_llm/kernels/fusedActivationQuant.h
+++ b/cpp/tensorrt_llm/kernels/fusedActivationQuant.h
@@ -28,6 +28,12 @@ template <typename T>
 void invokeFusedRelu2Quantize(T const* input, float const* sfScale, std::uint8_t* outputFp4, std::uint8_t* outputSf,
     int m, int n, int sfVecSize, cudaStream_t stream);
 
+// Fused SwiGLU (silu(gate) * up) + NVFP4 quantization. Input is [m, 2n] (gate half
+// in [0, n), up half in [n, 2n)); outputs the NVFP4-quantized [m, n] activation.
+template <typename T>
+void invokeFusedSiluMulQuantize(T const* input, float const* sfScale, std::uint8_t* outputFp4, std::uint8_t* outputSf,
+    int m, int n, int sfVecSize, cudaStream_t stream);
+
 } // namespace kernels
 
 TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/thop/fusedActivationQuant.cpp
+++ b/cpp/tensorrt_llm/thop/fusedActivationQuant.cpp
@@ -79,6 +79,59 @@ std::tuple<at::Tensor, at::Tensor> fused_relu2_quantize(
     return std::make_tuple(output_fp4, output_sf);
 }
 
+// Fused SwiGLU (silu(gate) * up) + NVFP4 quantization.
+// Input is [M, 2N] with the gate half in columns [0, N) and the up half in
+// [N, 2N). Output is the NVFP4-quantized [M, N] activation plus its swizzled SF.
+std::tuple<at::Tensor, at::Tensor> silu_and_mul_nvfp4_quantize(
+    at::Tensor const& input, at::Tensor const& sf_scale, int64_t sf_vec_size)
+{
+    CHECK_TH_CUDA(input);
+    CHECK_CONTIGUOUS(input);
+    CHECK_INPUT(sf_scale, torch::kFloat32);
+
+    auto const& inputShape = input.sizes();
+    TORCH_CHECK(inputShape.size() == 2, "input should be 2D tensor [M, 2N].");
+
+    int64_t const m = inputShape[0];
+    int64_t const twoN = inputShape[1];
+
+    TORCH_CHECK(sf_vec_size == 16, "sf_vec_size must be 16 for NVFP4.");
+    TORCH_CHECK(twoN % 2 == 0, "input last dim must be even (gate||up).");
+    int64_t const n = twoN / 2;
+    TORCH_CHECK(n % sf_vec_size == 0, "Output width N must be divisible by sf_vec_size.");
+
+    auto stream = at::cuda::getCurrentCUDAStream(input.get_device());
+
+    at::Tensor output_fp4 = at::detail::empty_cuda({m, n / 2}, torch::kUInt8, input.device(), std::nullopt);
+    int64_t const sfSize = tensorrt_llm::computeSwizzledLayoutSFSize(m, n / sf_vec_size);
+    at::Tensor output_sf = at::detail::empty_cuda({sfSize}, SF_DTYPE, input.device(), std::nullopt);
+
+    float const* sfScalePtr = sf_scale.data_ptr<float>();
+
+    if (input.scalar_type() == at::ScalarType::Half)
+    {
+        kernels::invokeFusedSiluMulQuantize<half>(reinterpret_cast<half const*>(input.data_ptr()), sfScalePtr,
+            output_fp4.data_ptr<uint8_t>(), output_sf.data_ptr<uint8_t>(), static_cast<int>(m), static_cast<int>(n),
+            static_cast<int>(sf_vec_size), stream);
+    }
+    else if (input.scalar_type() == at::ScalarType::BFloat16)
+    {
+#ifdef ENABLE_BF16
+        kernels::invokeFusedSiluMulQuantize<__nv_bfloat16>(reinterpret_cast<__nv_bfloat16 const*>(input.data_ptr()),
+            sfScalePtr, output_fp4.data_ptr<uint8_t>(), output_sf.data_ptr<uint8_t>(), static_cast<int>(m),
+            static_cast<int>(n), static_cast<int>(sf_vec_size), stream);
+#else
+        C10_THROW_ERROR(NotImplementedError, "BFloat16 not enabled.");
+#endif
+    }
+    else
+    {
+        C10_THROW_ERROR(NotImplementedError, "silu_and_mul_nvfp4_quantize only supports fp16/bf16.");
+    }
+
+    return std::make_tuple(output_fp4, output_sf);
+}
+
 } // namespace torch_ext
 
 TRTLLM_NAMESPACE_END
@@ -86,9 +139,11 @@ TRTLLM_NAMESPACE_END
 TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
     m.def("fused_relu2_quantize(Tensor input, Tensor sf_scale, int sf_vec_size=16) -> (Tensor, Tensor)");
+    m.def("silu_and_mul_nvfp4_quantize(Tensor input, Tensor sf_scale, int sf_vec_size=16) -> (Tensor, Tensor)");
 }
 
 TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
 {
     m.impl("fused_relu2_quantize", &tensorrt_llm::torch_ext::fused_relu2_quantize);
+    m.impl("silu_and_mul_nvfp4_quantize", &tensorrt_llm::torch_ext::silu_and_mul_nvfp4_quantize);
 }

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -1147,6 +1147,23 @@ def _register_fake():
         output_sf = input.new_empty((scale_shape, ), dtype=torch.uint8)
         return output_fp4, output_sf
 
+    @torch.library.register_fake("trtllm::silu_and_mul_nvfp4_quantize")
+    def _(
+        input: torch.Tensor,
+        sf_scale: torch.Tensor,
+        sf_vec_size: int = 16,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # input: 2D tensor [M, 2N] (gate||up, bf16 or fp16)
+        # output_fp4: [M, N/2] (packed FP4 values, 2 per byte)
+        # output_sf: swizzled scale factors for the [M, N] post-SwiGLU activation
+        m, two_n = input.shape
+        n = two_n // 2
+        output_shape, scale_shape = fp4_utils.get_fp4_shape(
+            (m, n), sf_vec_size, is_swizzled_layout=True)
+        output_fp4 = input.new_empty(output_shape, dtype=torch.uint8)
+        output_sf = input.new_empty((scale_shape, ), dtype=torch.uint8)
+        return output_fp4, output_sf
+
     @torch.library.register_fake("trtllm::convert_req_index_to_global")
     def _(req_id: torch.Tensor, block_table: torch.Tensor,
           token_indices: torch.Tensor, block_size: int, num_topk_tokens: int,

--- a/tensorrt_llm/_torch/modules/gated_mlp.py
+++ b/tensorrt_llm/_torch/modules/gated_mlp.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import Callable
 from typing import Optional, Union
 
@@ -5,6 +6,7 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
+from tensorrt_llm._utils import get_sm_version
 from tensorrt_llm.logger import logger
 from tensorrt_llm.mapping import Mapping
 
@@ -129,6 +131,39 @@ class GatedMLP(nn.Module):
             [LoraModuleType.MLP_GATE_UP],
             [2 * self.intermediate_size // mapping.tp_size])
 
+        # Lazily resolved on first forward (down_proj weights must be created
+        # before has_nvfp4 / input_scale can be inspected). None = not yet
+        # checked.
+        self._can_fuse_swiglu_nvfp4_quant: Optional[bool] = None
+
+    def _swiglu_nvfp4_quant_eligible(self, *, has_lora: bool) -> bool:
+        """Whether to fuse the post-SwiGLU NVFP4 input-quant of down_proj into
+        the activation kernel.
+
+        Eligible iff down_proj is statically-quantized NVFP4 (calibrated
+        input_scale, not forced dynamic, no AWQ pre_quant_scale) on SM100+ --
+        the same static-NVFP4 condition NVFP4LinearMethod._input_prepare uses, so
+        the fused path's quant semantics match the unfused path. LoRA is excluded
+        (its activation must stay bf16/fp16 for the LoRA grouped GEMM); resolved
+        lazily since weights must exist first.
+        """
+        if self._can_fuse_swiglu_nvfp4_quant is None:
+            down = self.down_proj
+            # Opt-out gate for A/B benchmarking: fusion is on by default; set
+            # TRTLLM_DISABLE_SWIGLU_NVFP4_FUSION=1 to fall back to the unfused
+            # swiglu -> fp4_quantize path on the same wheel.
+            disabled = os.environ.get("TRTLLM_DISABLE_SWIGLU_NVFP4_FUSION",
+                                      "0") == "1"
+            self._can_fuse_swiglu_nvfp4_quant = (
+                not disabled
+                and hasattr(torch.ops.trtllm, 'silu_and_mul_nvfp4_quantize')
+                and getattr(down, 'has_nvfp4', False)
+                and getattr(down, 'input_scale', None) is not None
+                and not getattr(down, 'force_dynamic_quantization', False)
+                and getattr(down, 'pre_quant_scale', None) is None
+                and get_sm_version() >= 100)
+        return self._can_fuse_swiglu_nvfp4_quant and not has_lora
+
     def _apply_activation(self, x, *, has_lora: bool = False):
         if self.activation == F.silu:
             if self.down_proj.has_fp8_qdq or self.down_proj.has_w4a8_nvfp4_fp8:
@@ -144,6 +179,14 @@ class GatedMLP(nn.Module):
                     return swiglu(x,
                                   quant_scale=self.down_proj.input_scale,
                                   quant_type=torch.float8_e4m3fn)
+            if self._swiglu_nvfp4_quant_eligible(has_lora=has_lora):
+                x = x if x.is_contiguous() else x.contiguous()
+                act_fp4, act_sf = torch.ops.trtllm.silu_and_mul_nvfp4_quantize(
+                    x, self.down_proj.input_scale,
+                    self.down_proj.scaling_vector_size)
+                return Fp4QuantizedTensor(fp4_tensor=act_fp4,
+                                          scaling_factor=act_sf,
+                                          is_sf_swizzled=True)
             else:
                 return swiglu(x)
         elif callable(self.activation):

--- a/tests/unittest/_torch/modules/test_silu_and_mul_nvfp4_quantize.py
+++ b/tests/unittest/_torch/modules/test_silu_and_mul_nvfp4_quantize.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the fused SwiGLU + NVFP4-quantize kernel.
+
+``silu_and_mul_nvfp4_quantize`` folds the standalone NVFP4 input-quantize
+(FP16/BF16 -> NVFP4) into the SwiGLU activation that produces it, at the
+GatedMLP ``gate_up_proj -> swiglu -> down_proj`` site (dense MLP + shared
+experts on DeepSeek-V3.2 / Kimi-K2.5). It targets small problem sizes where the
+constrained GEMM+SwiGLU+quant fusion cannot run.
+
+Input is ``[M, 2N]`` (gate half in ``[0, N)``, up half in ``[N, 2N)``); output
+is the NVFP4-quantized ``[M, N]`` activation plus its swizzled scale factors.
+
+Accuracy is checked against the unfused reference the fusion replaces: the
+Triton ``silu_and_mul`` (sigmoid(a) * a * b) followed by
+``torch.ops.trtllm.fp4_quantize``. The fused kernel computes the gate in
+registers while already reading the tensor to quantize it, so a handful of
+values right at quantization boundaries can fall on the other side of a step due
+to FMA-vs-separate rounding; we require a >= 99% match on the packed FP4 bytes,
+mirroring ``test_fused_rmsnorm_fp4_quantize.py``.
+"""
+
+import pytest
+import torch
+
+from tests.unittest.utils.util import getSMVersion
+
+
+def silu_and_mul_nvfp4_quantize_available():
+    return hasattr(torch.ops, "trtllm") and hasattr(
+        torch.ops.trtllm, "silu_and_mul_nvfp4_quantize")
+
+
+def fp4_quantize_available():
+    return hasattr(torch.ops, "trtllm") and hasattr(torch.ops.trtllm,
+                                                    "fp4_quantize")
+
+
+skip_unless_swiglu = pytest.mark.skipif(
+    getSMVersion() < 100 or not silu_and_mul_nvfp4_quantize_available()
+    or not fp4_quantize_available(),
+    reason="Requires SM100+ (Blackwell) and trtllm "
+    "silu_and_mul_nvfp4_quantize + fp4_quantize ops",
+)
+
+
+def silu_and_mul_ref(x: torch.Tensor) -> torch.Tensor:
+    """Reference SwiGLU matching the Triton silu_and_mul_kernel
+    (tensorrt_llm/_torch/modules/swiglu.py:42): sigmoid(a) * a * b, computed in
+    fp32 then cast back to the input dtype."""
+    d = x.shape[-1] // 2
+    a = x[:, :d].to(torch.float32)
+    b = x[:, d:].to(torch.float32)
+    out = torch.sigmoid(a) * a * b
+    return out.to(x.dtype)
+
+
+def fp4_quantize_ref(act: torch.Tensor, sf_scale: torch.Tensor):
+    """Unfused baseline: the standalone NVFP4 quantize the fusion replaces."""
+    return torch.ops.trtllm.fp4_quantize(
+        act.contiguous(),
+        sf_scale,
+        16,
+        False,  # use_ue8m0
+        True,  # is_sf_swizzled_layout
+    )
+
+
+def make_sf_scale(act: torch.Tensor) -> torch.Tensor:
+    """Per-tensor SF scale (amax / (6 * 448)), the same scalar fed to both the
+    fused op and fp4_quantize -- both forward it to cvt_warp_fp16_to_fp4."""
+    return (act.abs().amax().float() / (6.0 * 448.0)).to(act.device).view(1)
+
+
+def assert_fp4_match(fp4_fused: torch.Tensor, fp4_ref: torch.Tensor, ctx: str):
+    assert fp4_fused.shape == fp4_ref.shape, (
+        f"shape mismatch {tuple(fp4_fused.shape)} vs {tuple(fp4_ref.shape)} "
+        f"({ctx})")
+    match_rate = (fp4_fused == fp4_ref).float().mean().item()
+    assert match_rate >= 0.99, (
+        f"FP4 packed match rate {match_rate:.4f} < 0.99 ({ctx})")
+
+
+@skip_unless_swiglu
+@pytest.mark.parametrize("m", [1, 4, 17, 64, 256])
+@pytest.mark.parametrize("n", [16, 128, 512, 2048])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_silu_and_mul_nvfp4_quantize_vs_separate(m, n, dtype):
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+
+    # Input is [M, 2N]: gate half then up half.
+    x = torch.randn(m, 2 * n, dtype=dtype, device=device)
+
+    act_ref = silu_and_mul_ref(x)
+    sf_scale = make_sf_scale(act_ref)
+    fp4_ref, _ = fp4_quantize_ref(act_ref, sf_scale)
+
+    quant_out, scale_out = torch.ops.trtllm.silu_and_mul_nvfp4_quantize(
+        x, sf_scale, 16)
+
+    assert quant_out.shape == (m, n // 2), "output must be packed [M, N/2]"
+    assert_fp4_match(quant_out, fp4_ref, f"swiglu m={m} n={n} {dtype}")
+
+
+@skip_unless_swiglu
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_silu_and_mul_nvfp4_quantize_does_not_mutate_input(dtype):
+    """The kernel only reads the input; it must not write back into it."""
+    torch.manual_seed(3)
+    device = torch.device("cuda")
+    m, n = 32, 512
+
+    x = torch.randn(m, 2 * n, dtype=dtype, device=device)
+    x_before = x.clone()
+    sf_scale = make_sf_scale(silu_and_mul_ref(x))
+
+    torch.ops.trtllm.silu_and_mul_nvfp4_quantize(x, sf_scale, 16)
+    torch.testing.assert_close(x, x_before, rtol=0, atol=0)


### PR DESCRIPTION
Fuse the dense GatedMLP activation+quant pair (silu_and_mul -> fp4_quantize of down_proj's NVFP4 input) into a single kernel, for small problem sizes where the GEMM-epilogue SwiGLU fusion does not apply (M/N tiling limits).

Adds silu_and_mul_nvfp4_quantize (kernel + thop), modeled on the existing fused_relu2_quantize: reads the [M, 2N] gate||up activation, computes silu(gate)*up, and NVFP4-quantizes the [M, N] result with down_proj's calibrated input_scale as the global scale, emitting packed FP4 + swizzled scale factors in one pass.

GatedMLP._apply_activation fuses when down_proj is statically-quantized NVFP4 (the same static-NVFP4 condition NVFP4LinearMethod._input_prepare uses, so quant semantics match the unfused path), emitting an Fp4QuantizedTensor that down_proj consumes directly. Auto-enabled on SM100+; TRTLLM_DISABLE_SWIGLU_NVFP4_FUSION=1 opts out for A/B comparison.

Unit tests validate the op bit-exact (>=99% packed-FP4 match) against the unfused silu_and_mul -> fp4_quantize reference across M in {1,4,17,64,256}, N in {16,128,512,2048}, fp16 and bf16, plus a no-mutate check. SM100-gated.

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
