### PR TITLE
[TRTLLM-13370][perf] LTX2 + WAN: Fuse MLP up-GEMM + bias + GELU(tanh) + NVFP4-quant into CuteDSL epilogue

### DIFF
--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -324,10 +324,10 @@ if IS_CUTLASS_DSL_AVAILABLE:
         Sm100BlockScaledContiguousGroupedGemmSwigluFusionKernel
     from ..cute_dsl_kernels.blackwell.blockwise_gemm.blockwise_gemm import \
         Sm100BlockwiseGemmKernel
+    from ..cute_dsl_kernels.blackwell.dense_blockscaled_gemm_act_fusion import \
+        Sm100BlockScaledPersistentDenseGemmActFusionKernel
     from ..cute_dsl_kernels.blackwell.dense_blockscaled_gemm_persistent import \
         Sm100BlockScaledPersistentDenseGemmKernel
-    from ..cute_dsl_kernels.blackwell.dense_blockscaled_gemm_swiglu_fusion import \
-        Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel
     from ..cute_dsl_kernels.blackwell.dense_gemm_persistent import \
         PersistentDenseGemmKernel
     from ..cute_dsl_kernels.blackwell.moe_as_dense_gemm.fc1 import \
@@ -852,7 +852,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         single kernel for shared experts. The weight tensor has N columns
         (gate + up interleaved), and the output has N/2 columns after SwiGLU.
         """
-        kernel_class = Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel
+        kernel_class = Sm100BlockScaledPersistentDenseGemmActFusionKernel
         kernel_cache = dict()
         tuning_config = TuningConfig(
             dynamic_tensor_specs=(DynamicTensorSpec(
@@ -863,7 +863,10 @@ if IS_CUTLASS_DSL_AVAILABLE:
             distributed_tuning_strategy=DistributedTuningStrategy.PARALLEL,
         )
 
-        def __init__(self, output_dtype: torch.dtype, use_tvm_ffi: bool = True):
+        def __init__(self,
+                     output_dtype: torch.dtype,
+                     use_tvm_ffi: bool = True,
+                     activation_type: ActivationType = ActivationType.Swiglu):
             super().__init__()
 
             if output_dtype != torch.bfloat16:
@@ -872,9 +875,11 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 )
             self.output_dtype = output_dtype
             self.use_tvm_ffi = use_tvm_ffi
+            self.activation_type = activation_type
+            self.is_gated = is_gated_activation(activation_type)
 
         def unique_id(self):
-            return (self.output_dtype, self.use_tvm_ffi)
+            return (self.output_dtype, self.use_tvm_ffi, self.activation_type)
 
         def get_valid_tactics(
             self,
@@ -911,8 +916,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     f"(K%32={real_k%32}, expected 0). Skipping all tactics.")
                 return []
 
-            # SwiGLU output has N/2 columns — check alignment for C
-            n_out = n // 2
+            # Gated (SwiGLU) halves output N; non-gated (e.g. GELU) keeps full N.
+            n_out = n // 2 if self.is_gated else n
             if n_out % 8 != 0:
                 logger.debug(
                     f"CuteDSL SwiGLU: N_out={n_out} (N/2) does not meet 16-byte alignment "
@@ -1027,11 +1032,24 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     False,
                 ]
 
-            a_tensor, b_tensor, a_sf_tensor, b_sf_tensor, alpha_tensor = inputs
+            # Optional trailing per-N bias (non-gated GELU only). Default off.
+            bias_tensor = inputs[5] if len(inputs) > 5 else None
+            (a_tensor, b_tensor, a_sf_tensor, b_sf_tensor,
+             alpha_tensor) = inputs[:5]
             m, k, n = a_tensor.shape[0], a_tensor.shape[1], b_tensor.shape[0]
-            n_out = n // 2  # SwiGLU halves the N dimension
+            # Gated (SwiGLU) halves output N; non-gated (e.g. GELU) keeps full N.
+            n_out = n // 2 if self.is_gated else n
 
-            # Allocate output tensor with halved N dimension
+            # Bias is a per-N vector [n_out]; broadcast over M happens in the
+            # kernel via a stride-0 layout. Require contiguous N for that.
+            if bias_tensor is not None:
+                if bias_tensor.numel() != n_out:
+                    raise ValueError(
+                        f"CuteDSL GELU: bias must have {n_out} elements "
+                        f"(n_out), got {bias_tensor.numel()}")
+                bias_tensor = bias_tensor.contiguous()
+
+            # Allocate output tensor with the activation-adjusted N dimension
             c_tensor = torch.empty(*(m, n_out),
                                    dtype=self.output_dtype,
                                    device="cuda")
@@ -1062,6 +1080,18 @@ if IS_CUTLASS_DSL_AVAILABLE:
             a_sf_tensor = a_sf_tensor.reshape(sf_m * sf_k)
             b_sf_tensor = b_sf_tensor.reshape(sf_n * sf_k)
 
+            # Resolve optional bias dtype (bf16/fp32 accepted; consumed in fp32).
+            has_bias = bias_tensor is not None
+            if has_bias:
+                if bias_tensor.dtype == torch.bfloat16:
+                    bias_cute_dtype = cutlass.BFloat16
+                elif bias_tensor.dtype == torch.float32:
+                    bias_cute_dtype = cutlass.Float32
+                else:
+                    raise ValueError(
+                        f"CuteDSL GELU: bias must be bf16 or fp32, "
+                        f"got {bias_tensor.dtype}")
+
             if not self.use_tvm_ffi:
                 a_ptr = self.make_cute_dsl_global_pointer(
                     a_tensor, cutlass.Float4E2M1FN, 32)
@@ -1073,6 +1103,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     b_sf_tensor, cutlass.Float8E4M3FN, 16)
                 c_ptr = self.make_cute_dsl_global_pointer(
                     c_tensor, cutlass.BFloat16, 16)
+                bias_ptr = self.make_cute_dsl_global_pointer(
+                    bias_tensor, bias_cute_dtype, 4) if has_bias else None
                 alpha_cute_tensor = cute.runtime.from_dlpack(alpha_tensor)
 
                 torch_stream = torch.cuda.current_stream()
@@ -1084,8 +1116,12 @@ if IS_CUTLASS_DSL_AVAILABLE:
             kernel_sf_m = sf_m
             kernel_sf_n = sf_n
 
+            # Cache key includes bias presence + dtype so the bias-free and
+            # bias paths compile to distinct kernels (different host signature).
+            bias_key = bias_tensor.dtype if has_bias else None
             cache_key = (sf_vec_size, mma_tiler_mn, cluster_shape_mn,
-                         use_prefetch, self.use_tvm_ffi)
+                         use_prefetch, self.use_tvm_ffi, self.activation_type,
+                         bias_key)
             if cache_key not in self.__class__.kernel_cache:
                 if self.use_tvm_ffi:
                     a_ptr = self.make_cute_dsl_global_pointer(
@@ -1098,6 +1134,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
                         b_sf_tensor, cutlass.Float8E4M3FN, 16)
                     c_ptr = self.make_cute_dsl_global_pointer(
                         c_tensor, cutlass.BFloat16, 16)
+                    bias_ptr = self.make_cute_dsl_global_pointer(
+                        bias_tensor, bias_cute_dtype, 4) if has_bias else None
                     alpha_cute_tensor = cute.runtime.from_dlpack(alpha_tensor)
                     stream = cute.runtime.make_fake_stream(
                         use_tvm_ffi_env_stream=True)
@@ -1108,12 +1146,15 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     cluster_shape_mn,
                     True,  # vectorized_f32
                     use_prefetch,
+                    activation_type=self.activation_type,
                 )
                 hardware_info = cutlass.utils.HardwareInfo()
                 max_active_clusters = hardware_info.get_max_active_clusters(
                     cluster_shape_mn[0] * cluster_shape_mn[1])
 
-                compiled_gemm = cute.compile(
+                # bias_ptr is the trailing keyword of wrapper; omit it entirely
+                # when absent so the bias-free signature is unchanged.
+                compile_args = [
                     gemm.wrapper,
                     kernel_m,
                     kernel_n,
@@ -1131,9 +1172,14 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     max_active_clusters,
                     stream,
                     False,  # swap_ab=False for SwiGLU
+                ]
+                compile_kwargs = dict(
                     options=f"--opt-level 2 --enable-tvm-ffi"
-                    if self.use_tvm_ffi else "--opt-level 2",
-                )
+                    if self.use_tvm_ffi else "--opt-level 2", )
+                if has_bias:
+                    compile_kwargs["bias_ptr"] = bias_ptr
+
+                compiled_gemm = cute.compile(*compile_args, **compile_kwargs)
 
                 self.__class__.kernel_cache[cache_key] = compiled_gemm
             else:
@@ -1141,7 +1187,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             # Launch kernel
             if self.use_tvm_ffi:
-                compiled_gemm(
+                # bias data_ptr (when present) is the trailing dynamic arg,
+                # mirroring the bias_ptr appended at compile time.
+                tvm_args = [
                     kernel_m,
                     kernel_n,
                     real_k,
@@ -1154,9 +1202,15 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     b_sf_tensor.data_ptr(),
                     c_tensor.data_ptr(),
                     alpha_tensor,
-                )
+                ]
+                if has_bias:
+                    tvm_args.append(bias_tensor.data_ptr())
+                compiled_gemm(*tvm_args)
             else:
-                compiled_gemm(
+                # bias_ptr is the trailing runtime arg of the compiled wrapper
+                # (swap_ab/epilogue_op are constexprs baked in at compile time);
+                # omit it entirely when absent.
+                call_args = [
                     kernel_m,
                     kernel_n,
                     real_k,
@@ -1170,7 +1224,10 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     c_ptr,
                     alpha_cute_tensor,
                     stream,
-                )
+                ]
+                if has_bias:
+                    call_args.append(bias_ptr)
+                compiled_gemm(*call_args)
 
             return c_tensor
 
@@ -1244,6 +1301,100 @@ if IS_CUTLASS_DSL_AVAILABLE:
         ret = mat_a.new_empty(shape, dtype=torch.bfloat16)
         return ret
 
+    class CuteDSLNVFP4GeluBlackwellRunner(CuteDSLNVFP4SwigluBlackwellRunner):
+        """Non-gated GELU(tanh) variant of the dense bf16-out runner.
+
+        Reuses the swiglu runner's forward/get_valid_tactics; only the fused
+        activation (GELU, non-gated -> output keeps full N) and the kernel
+        compile cache differ.
+        """
+        kernel_cache = dict()
+
+        def __init__(self, output_dtype: torch.dtype, use_tvm_ffi: bool = True):
+            super().__init__(output_dtype,
+                             use_tvm_ffi,
+                             activation_type=ActivationType.Gelu)
+
+        def unique_id(self):
+            return (self.output_dtype, self.use_tvm_ffi, 'gelu')
+
+    # a/b: fp4, scale: fp8, output: bf16, fused non-gated GELU(tanh)
+    @torch.library.custom_op("trtllm::cute_dsl_nvfp4_dense_gemm_gelu_blackwell",
+                             mutates_args=(),
+                             device_types="cuda")
+    def cute_dsl_nvfp4_dense_gemm_gelu_blackwell(
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        input_scale: torch.Tensor,
+        weight_scale: torch.Tensor,
+        alpha: torch.Tensor,
+        output_dtype: torch.dtype,
+        bias: Optional[torch.Tensor] = None,
+        use_tvm_ffi: bool = True,
+    ) -> torch.Tensor:
+        """CuteDSL NVFP4 dense GEMM + non-gated GELU(tanh) with bf16 output for Blackwell.
+
+        Non-gated counterpart of cute_dsl_nvfp4_dense_gemm_swiglu_blackwell:
+        the output keeps the full N dimension (no gate/up halving), and the
+        epilogue applies GELU(tanh) before writing bf16. Optionally adds a
+        per-N bias (``gelu_tanh(alpha * acc + bias)``).
+
+        Args:
+            input: Activation tensor [m, k] in FP4 format (packed in uint8)
+            weight: Weight tensor [n, k] in FP4 format (packed in uint8).
+                    n = intermediate_size.
+            input_scale: Activation scale factors
+            weight_scale: Weight scale factors
+            alpha: GEMM scaling factor
+            output_dtype: Output data type (must be bfloat16)
+            bias: Optional per-N bias vector [n] (bf16/fp32, NOT quantized),
+                broadcast over M and added before GELU. None (default) -> no bias.
+            use_tvm_ffi: Whether to use TVM-FFI for reduced host launch overhead.
+
+        Returns:
+            Output tensor [m, n] in bfloat16 after non-gated GELU(tanh).
+        """
+        if (sm_version := get_sm_version()) not in (100, 103):
+            raise ValueError(
+                f"CuteDSL NVFP4 GELU backend requires SM 100 (B200) or SM 103 (B300), "
+                f"but got SM {sm_version}.")
+
+        tuner = AutoTuner.get()
+
+        runner = CuteDSLNVFP4GeluBlackwellRunner(output_dtype, use_tvm_ffi)
+        inputs = [input, weight, input_scale, weight_scale, alpha]
+        if bias is not None:
+            inputs.append(bias)
+        _, best_tactic = tuner.choose_one(
+            "trtllm::cute_dsl_nvfp4_dense_gemm_gelu_blackwell",
+            [runner],
+            runner.__class__.tuning_config,
+            inputs,
+        )
+
+        output = runner(inputs, tactic=best_tactic)
+        return output
+
+    @torch.library.register_fake(
+        "trtllm::cute_dsl_nvfp4_dense_gemm_gelu_blackwell")
+    def _(
+        mat_a: torch.Tensor,
+        mat_b: torch.Tensor,
+        input_scale: torch.Tensor,
+        weight_scale: torch.Tensor,
+        alpha: torch.Tensor,
+        output_dtype: torch.dtype,
+        bias: Optional[torch.Tensor] = None,
+        use_tvm_ffi: bool = True,
+    ):
+        # [m, k]
+        shape = list(mat_a.shape)
+        # [n, k] -> non-gated GELU keeps the full N dimension
+        shape[-1] = mat_b.shape[-2]
+        # output is fixed as bf16
+        ret = mat_a.new_empty(shape, dtype=torch.bfloat16)
+        return ret
+
     class CuteDSLNVFP4SwigluFP4OutBlackwellRunner(TunableRunner):
         """Runner for dense GEMM + SwiGLU fusion with FP4 output on Blackwell.
 
@@ -1251,7 +1402,7 @@ if IS_CUTLASS_DSL_AVAILABLE:
         output with scale factors (SFC quantization), eliminating the bf16→fp4
         requantization between FC1 and FC2.
         """
-        kernel_class = Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel
+        kernel_class = Sm100BlockScaledPersistentDenseGemmActFusionKernel
         kernel_cache = dict()
         tuning_config = TuningConfig(
             dynamic_tensor_specs=(DynamicTensorSpec(

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_custom_ops.py
@@ -1262,9 +1262,13 @@ if IS_CUTLASS_DSL_AVAILABLE:
             distributed_tuning_strategy=DistributedTuningStrategy.PARALLEL,
         )
 
-        def __init__(self, use_tvm_ffi: bool = True):
+        def __init__(self,
+                     use_tvm_ffi: bool = True,
+                     activation_type: ActivationType = ActivationType.Swiglu):
             super().__init__()
             self.use_tvm_ffi = use_tvm_ffi
+            self.activation_type = activation_type
+            self.is_gated = is_gated_activation(activation_type)
 
         def unique_id(self):
             return (self.use_tvm_ffi, 'fp4out')
@@ -1284,8 +1288,10 @@ if IS_CUTLASS_DSL_AVAILABLE:
             profile: OptimizationProfile,
             **kwargs,
         ) -> List[Tuple]:
-            # Same tactic search as BF16 runner but with FP4 C dtype
-            a, b, a_sf, b_sf, alpha, global_sf = inputs
+            # Same tactic search as BF16 runner but with FP4 C dtype.
+            # inputs may carry an optional trailing bias (non-gated GELU); only
+            # the first 6 are needed for shape inference / tactic validity.
+            a, b, a_sf, b_sf, alpha, global_sf = inputs[:6]
             m, k, n = a.shape[0], a.shape[1] * 2, b.shape[0]
 
             # The fp4out kernel's SFC epilogue does not properly predicate
@@ -1335,6 +1341,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             Args:
                 inputs: [act_fp4, weight_fp4, act_sf, weight_sf, alpha, global_sf]
+                    or, for the non-gated GELU path with bias, an extra trailing
+                    [bias] (per-N vector, bf16/fp32, NOT quantized). Bias is only
+                    consumed by the non-gated path; swiglu callers pass 6 inputs.
                 tactic: (mma_tiler_mn, cluster_shape_mn, use_prefetch)
 
             Returns:
@@ -1351,9 +1360,22 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     False,
                 ]
 
-            a_tensor, b_tensor, a_sf_tensor, b_sf_tensor, alpha_tensor, global_sf_tensor = inputs
+            # Optional trailing per-N bias (non-gated GELU only). Default off.
+            bias_tensor = inputs[6] if len(inputs) > 6 else None
+            (a_tensor, b_tensor, a_sf_tensor, b_sf_tensor, alpha_tensor,
+             global_sf_tensor) = inputs[:6]
             m, k, n = a_tensor.shape[0], a_tensor.shape[1], b_tensor.shape[0]
-            n_out = n // 2  # SwiGLU halves the N dimension
+            # Gated (SwiGLU) halves output N; non-gated (e.g. GELU) keeps full N.
+            n_out = n // 2 if self.is_gated else n
+
+            # Bias is a per-N vector [n_out]; broadcast over M happens in the
+            # kernel via a stride-0 layout. Require contiguous N for that.
+            if bias_tensor is not None:
+                if bias_tensor.numel() != n_out:
+                    raise ValueError(
+                        f"CuteDSL GELU FP4Out: bias must have {n_out} elements "
+                        f"(n_out), got {bias_tensor.numel()}")
+                bias_tensor = bias_tensor.contiguous()
 
             # Pad m to CTA tile height to prevent OOB writes from
             # the kernel's epilogue on partial tiles.
@@ -1410,8 +1432,23 @@ if IS_CUTLASS_DSL_AVAILABLE:
             kernel_m = m
             kernel_n = n
 
+            # Resolve optional bias dtype (bf16/fp32 accepted; consumed in fp32).
+            has_bias = bias_tensor is not None
+            if has_bias:
+                if bias_tensor.dtype == torch.bfloat16:
+                    bias_cute_dtype = cutlass.BFloat16
+                elif bias_tensor.dtype == torch.float32:
+                    bias_cute_dtype = cutlass.Float32
+                else:
+                    raise ValueError(
+                        f"CuteDSL GELU FP4Out: bias must be bf16 or fp32, "
+                        f"got {bias_tensor.dtype}")
+
+            # Cache key includes bias presence + dtype so the bias-free and
+            # bias paths compile to distinct kernels (different host signature).
+            bias_key = bias_tensor.dtype if has_bias else None
             cache_key = (sf_vec_size, mma_tiler_mn, cluster_shape_mn,
-                         use_prefetch, self.use_tvm_ffi, 'fp4out')
+                         use_prefetch, self.use_tvm_ffi, 'fp4out', bias_key)
             if cache_key not in self.__class__.kernel_cache:
                 # Create pointers for compilation
                 a_ptr = self.make_cute_dsl_global_pointer(
@@ -1426,6 +1463,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     c_tensor, cutlass.Float4E2M1FN, 32)
                 sfc_ptr = self.make_cute_dsl_global_pointer(
                     c_sf_tensor, cutlass.Float8E4M3FN, 16)
+                bias_ptr = self.make_cute_dsl_global_pointer(
+                    bias_tensor, bias_cute_dtype, 4) if has_bias else None
                 alpha_cute_tensor = cute.runtime.from_dlpack(alpha_tensor)
                 norm_const_cute_tensor = cute.runtime.from_dlpack(
                     global_sf_tensor)
@@ -1443,12 +1482,15 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     cluster_shape_mn,
                     True,  # vectorized_f32
                     use_prefetch,
+                    activation_type=self.activation_type,
                 )
                 hardware_info = cutlass.utils.HardwareInfo()
                 max_active_clusters = hardware_info.get_max_active_clusters(
                     cluster_shape_mn[0] * cluster_shape_mn[1])
 
-                compiled_gemm = cute.compile(
+                # bias_ptr is the trailing positional of wrapper_fp4out; omit it
+                # entirely when absent so the bias-free signature is unchanged.
+                compile_args = [
                     gemm.wrapper_fp4out,
                     kernel_m,
                     kernel_n,
@@ -1469,6 +1511,12 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     norm_const_cute_tensor,
                     max_active_clusters,
                     stream,
+                ]
+                if has_bias:
+                    compile_args.append(bias_ptr)
+
+                compiled_gemm = cute.compile(
+                    *compile_args,
                     options=f"--opt-level 2 --enable-tvm-ffi"
                     if self.use_tvm_ffi else "--opt-level 2",
                 )
@@ -1479,7 +1527,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
             # Launch kernel
             if self.use_tvm_ffi:
-                compiled_gemm(
+                # bias data_ptr (when present) is the trailing dynamic arg,
+                # mirroring the bias_ptr appended at compile time.
+                tvm_args = [
                     kernel_m,
                     kernel_n,
                     real_k,
@@ -1496,7 +1546,10 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     c_sf_tensor.data_ptr(),
                     alpha_tensor,
                     global_sf_tensor,
-                )
+                ]
+                if has_bias:
+                    tvm_args.append(bias_tensor.data_ptr())
+                compiled_gemm(*tvm_args)
             else:
                 a_ptr = self.make_cute_dsl_global_pointer(
                     a_tensor, cutlass.Float4E2M1FN, 32)
@@ -1510,6 +1563,8 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     c_tensor, cutlass.Float4E2M1FN, 32)
                 sfc_ptr = self.make_cute_dsl_global_pointer(
                     c_sf_tensor, cutlass.Float8E4M3FN, 16)
+                bias_ptr = self.make_cute_dsl_global_pointer(
+                    bias_tensor, bias_cute_dtype, 4) if has_bias else None
                 alpha_cute_tensor = cute.runtime.from_dlpack(alpha_tensor)
                 norm_const_cute_tensor = cute.runtime.from_dlpack(
                     global_sf_tensor)
@@ -1517,7 +1572,9 @@ if IS_CUTLASS_DSL_AVAILABLE:
                 torch_stream = torch.cuda.current_stream()
                 stream = cuda.CUstream(torch_stream.cuda_stream)
 
-                compiled_gemm(
+                # bias_ptr is the trailing positional of wrapper_fp4out (after
+                # stream); omit it entirely when absent.
+                call_args = [
                     kernel_m,
                     kernel_n,
                     real_k,
@@ -1535,7 +1592,10 @@ if IS_CUTLASS_DSL_AVAILABLE:
                     alpha_cute_tensor,
                     norm_const_cute_tensor,
                     stream,
-                )
+                ]
+                if has_bias:
+                    call_args.append(bias_ptr)
+                compiled_gemm(*call_args)
 
             # Trim padded C output back to original m rows
             c_tensor = c_tensor[:m]
@@ -1628,6 +1688,109 @@ if IS_CUTLASS_DSL_AVAILABLE:
         m = mat_a.shape[0]
         sf_size = pad_up(m, 128) * pad_up(n_out // sf_vec_size, 4)
         output_sf = input_scale.new_empty([sf_size])
+        return fp4_output, output_sf
+
+    class CuteDSLNVFP4GeluFP4OutBlackwellRunner(
+            CuteDSLNVFP4SwigluFP4OutBlackwellRunner):
+        """Non-gated GELU(tanh) variant of the dense FP4-out runner.
+
+        Reuses the swiglu runner's forward/get_valid_tactics; only the fused
+        activation (GELU, non-gated -> output keeps full N) and the kernel
+        compile cache differ.
+        """
+        kernel_cache = dict()
+
+        def __init__(self, use_tvm_ffi: bool = True):
+            super().__init__(use_tvm_ffi, activation_type=ActivationType.Gelu)
+
+        def unique_id(self):
+            return (self.use_tvm_ffi, 'gelu_fp4out')
+
+    # a/b: fp4, scale: fp8, output: fp4 + sfc, fused non-gated GELU(tanh)
+    @torch.library.custom_op(
+        "trtllm::cute_dsl_nvfp4_dense_gemm_gelu_fp4out_blackwell",
+        mutates_args=(),
+        device_types="cuda")
+    def cute_dsl_nvfp4_dense_gemm_gelu_fp4out_blackwell(
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        input_scale: torch.Tensor,
+        weight_scale: torch.Tensor,
+        alpha: torch.Tensor,
+        global_sf: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+        use_tvm_ffi: bool = True,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """CuteDSL NVFP4 dense GEMM + non-gated GELU(tanh) with FP4 output for Blackwell.
+
+        Non-gated counterpart of cute_dsl_nvfp4_dense_gemm_swiglu_fp4out_blackwell:
+        the output keeps the full N dimension (no gate/up halving), and the
+        epilogue applies GELU(tanh) before FP4 quantization. Optionally adds a
+        per-N bias (``gelu_tanh(alpha * acc + bias)``).
+
+        Args:
+            input: Activation tensor [m, k] in FP4 format (packed)
+            weight: Weight tensor [n, k] in FP4 format (packed). n = intermediate_size.
+            input_scale: Activation scale factors
+            weight_scale: Weight scale factors
+            alpha: GEMM scaling factor
+            global_sf: Output scale (norm_const for SFC quantization)
+            bias: Optional per-N bias vector [n] (bf16/fp32, NOT quantized),
+                broadcast over M and added before GELU. None (default) -> no bias.
+            use_tvm_ffi: Whether to use TVM-FFI.
+
+        Returns:
+            Tuple of (fp4_output, output_sf):
+                fp4_output: [m, n//2] in FP4 packed format
+                output_sf: Scale factors for the output (1D)
+        """
+        if (sm_version := get_sm_version()) not in (100, 103):
+            raise ValueError(
+                f"CuteDSL NVFP4 GELU FP4Out requires SM 100 or SM 103, "
+                f"but got SM {sm_version}.")
+
+        tuner = AutoTuner.get()
+
+        runner = CuteDSLNVFP4GeluFP4OutBlackwellRunner(use_tvm_ffi)
+        inputs = [input, weight, input_scale, weight_scale, alpha, global_sf]
+        if bias is not None:
+            inputs.append(bias)
+        _, best_tactic = tuner.choose_one(
+            "trtllm::cute_dsl_nvfp4_dense_gemm_gelu_fp4out_blackwell",
+            [runner],
+            runner.__class__.tuning_config,
+            inputs,
+        )
+
+        return runner(inputs, tactic=best_tactic)
+
+    @torch.library.register_fake(
+        "trtllm::cute_dsl_nvfp4_dense_gemm_gelu_fp4out_blackwell")
+    def _(
+        mat_a: torch.Tensor,
+        mat_b: torch.Tensor,
+        input_scale: torch.Tensor,
+        weight_scale: torch.Tensor,
+        alpha: torch.Tensor,
+        global_sf: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+        use_tvm_ffi: bool = True,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # bias does not change output shape.
+        m = mat_a.shape[0]
+        n = mat_b.shape[-2]
+        n_out = n  # non-gated: output keeps full N
+        sf_vec_size = 16
+        # FP4 output packed: [m, n_out // 2]
+        fp4_output = torch.empty(m,
+                                 n_out // 2,
+                                 dtype=mat_a.dtype,
+                                 device=mat_a.device)
+        # Scale factors: 1D
+        sf_size = pad_up(m, 128) * pad_up(n_out // sf_vec_size, 4)
+        output_sf = torch.empty(sf_size,
+                                dtype=input_scale.dtype,
+                                device=input_scale.device)
         return fp4_output, output_sf
 
     class Sm100BlockScaledContiguousGroupedGemmRunner(TunableRunner):

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/dense_blockscaled_gemm_act_fusion.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/dense_blockscaled_gemm_act_fusion.py
@@ -68,7 +68,7 @@ from .utils import (
 )
 
 
-class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
+class Sm100BlockScaledPersistentDenseGemmActFusionKernel:
     """Implements batched matrix multiplication with SwiGLU fusion in the epilogue
     (C = SwiGLU(alpha * A x SFA x B x SFB)) for Blackwell GPUs with persistent tile scheduling
     and warp specialization.
@@ -99,7 +99,7 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
             * Cluster shape M/N must be <= 4 for scale factor multicasts due to limited scale factor size.
 
     Example:
-        >>> gemm = Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel(
+        >>> gemm = Sm100BlockScaledPersistentDenseGemmActFusionKernel(
         ...     sf_vec_size=16,
         ...     mma_tiler_mn=(256, 128),
         ...     cluster_shape_mn=(2, 1),
@@ -183,6 +183,18 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
         self.vectorized_f32 = vectorized_f32
         self.activation_type = activation_type
         self.is_gated = is_gated_activation(activation_type)
+        # Precompute per-activation flags as plain Python bools so the epilogue
+        # dispatch can use cutlass.const_expr(...) on them (like is_gated). An
+        # inline enum comparison inside @cute.jit is not folded as a constant.
+        self._act_is_swiglu = activation_type == ActivationType.Swiglu
+        self._act_is_gelu = activation_type == ActivationType.Gelu
+        # Host-side guard (raise is not allowed inside the @cute.kernel epilogue):
+        # only SwiGLU and GELU(tanh) are wired in the fused epilogue.
+        if not (self._act_is_swiglu or self._act_is_gelu):
+            raise NotImplementedError(
+                f"Fused epilogue activation {activation_type} not implemented "
+                f"(only Swiglu and Gelu are wired)."
+            )
 
     def _setup_attributes(self):
         """Set up configurations that are dependent on GEMM inputs
@@ -1539,11 +1551,16 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
 
                     acc_vec_up = tTR_rAcc_up.load()
                     tCompute = cute.make_rmem_tensor(acc_vec_up.shape, self.acc_dtype)
-                    if cutlass.const_expr(self.is_gated):
+                    # Dispatch the fused activation on activation_type (the source
+                    # of truth). is_gated only governs the structural subtile load
+                    # above (2 subtiles up+gate vs 1) and must NOT pick the
+                    # activation: otherwise a non-gated ReLU/SiLU would wrongly get
+                    # GELU and a gated GEGLU would wrongly get SwiGLU.
+                    if cutlass.const_expr(self._act_is_swiglu):
                         # SwiGLU: output = (alpha * up) * silu(alpha * gate)
                         acc_vec_gate = tTR_rAcc_gate.load()
                         self._apply_swiglu_epilogue(acc_vec_up, acc_vec_gate, alpha_val, tCompute)
-                    else:
+                    elif cutlass.const_expr(self._act_is_gelu):
                         # GELU (tanh approx): output = gelu_tanh(alpha * up + bias)
                         bias_vec = None
                         if cutlass.const_expr(gBias_mnl is not None):

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/dense_blockscaled_gemm_swiglu_fusion.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/dense_blockscaled_gemm_swiglu_fusion.py
@@ -55,10 +55,12 @@ import cutlass.utils.blockscaled_layout as blockscaled_utils
 from cutlass._mlir.dialects import math
 from cutlass.cute.nvgpu import cpasync, tcgen05
 
+from ...utils import ActivationType, is_gated_activation
 from .custom_pipeline import PipelineTmaUmma, PipelineUmmaAsync
 from .utils import (
     TRTLLM_ENABLE_PDL,
     fmin,
+    gelu_tanh_f32,
     griddepcontrol_launch_dependents,
     griddepcontrol_wait,
     is_power_of_2,
@@ -122,8 +124,12 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
         cluster_shape_mn: Tuple[int, int],
         vectorized_f32: bool,
         use_prefetch: bool = False,
+        activation_type: ActivationType = ActivationType.Swiglu,
     ):
-        """Initializes the configuration for a Blackwell dense GEMM kernel with SwiGLU fusion.
+        """Initializes the configuration for a Blackwell dense GEMM kernel with fused activation.
+
+        Supports a gated SwiGLU epilogue (``ActivationType.Swiglu``, default; output N/2) and a
+        non-gated GELU-tanh epilogue (``ActivationType.Gelu``; output N).
 
         This configuration includes several key aspects:
 
@@ -175,6 +181,8 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
         self.num_tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
 
         self.vectorized_f32 = vectorized_f32
+        self.activation_type = activation_type
+        self.is_gated = is_gated_activation(activation_type)
 
     def _setup_attributes(self):
         """Set up configurations that are dependent on GEMM inputs
@@ -248,10 +256,10 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
             self.mma_tiler_sfb[2],
         )
 
-        # SwiGLU: mma_tiler_c has N//2 since output is halved after fusion
+        # Gated (SwiGLU) halves output N (interleaved up/gate); non-gated keeps full N.
         self.mma_tiler_c = (
             self.mma_inst_shape_mnk[0],
-            self.mma_inst_shape_mnk[1] // 2,
+            self.mma_inst_shape_mnk[1] // 2 if self.is_gated else self.mma_inst_shape_mnk[1],
             self.mma_inst_shape_mnk[2] * mma_inst_tile_k,
         )
         self.cta_tile_shape_mnk_c = (
@@ -284,8 +292,8 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
             self.cta_tile_shape_mnk_c[0] // self.epi_tile[0],
             self.cta_tile_shape_mnk_c[1] // self.epi_tile[1],
         )
-        # SwiGLU consumes 2 subtiles (up + gate) per output subtile
-        self.epi_tile_n_required = 2 * cute.size(self.epi_tile[1])
+        # Gated (SwiGLU) consumes 2 subtiles (up + gate) per output subtile; non-gated consumes 1.
+        self.epi_tile_n_required = (2 if self.is_gated else 1) * cute.size(self.epi_tile[1])
 
         # Setup A/B/C stage count in shared memory and ACC stage count in tensor memory
         self.num_acc_stage, self.num_ab_stage, self.num_c_stage = self._compute_stages(
@@ -368,6 +376,7 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
         epilogue_op: cutlass.Constexpr = lambda x: x,
         sfc_tensor: Optional[cute.Tensor] = None,
         norm_const_tensor: Optional[cute.Tensor] = None,
+        bias_tensor: Optional[cute.Tensor] = None,
     ):
         """Execute the GEMM operation with SwiGLU fusion in steps:
         - Setup static attributes before smem/grid/tma computation
@@ -388,6 +397,10 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
             epilogue_op (cutlass.Constexpr): Optional elementwise lambda function to apply to the output tensor
             sfc_tensor (Optional[cute.Tensor]): Scale factor tensor for C (for FP4 quantization)
             norm_const_tensor (Optional[cute.Tensor]): Norm constant tensor (for FP4 quantization)
+            bias_tensor (Optional[cute.Tensor]): Optional per-N bias tensor with layout
+                (m, n_out, l) and M-stride 0 (broadcast over rows). Added as
+                ``alpha * acc + bias`` before the activation. Only consumed by the
+                non-gated GELU path; None (default) leaves all paths unchanged.
 
         Raises:
             TypeError: If input data types are incompatible with the MMA instruction.
@@ -595,6 +608,7 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
             tma_tensor_c,
             sfc_tensor,
             norm_const_tensor,
+            bias_tensor,
             self.cluster_layout_vmnk,
             self.cluster_layout_sfb_vmnk,
             self.a_smem_layout_staged,
@@ -635,6 +649,7 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
         mC_mnl: cute.Tensor,
         mSFC_mnl: Optional[cute.Tensor],
         norm_const_tensor: Optional[cute.Tensor],
+        mBias_mnl: Optional[cute.Tensor],
         cluster_layout_vmnk: cute.Layout,
         cluster_layout_sfb_vmnk: cute.Layout,
         a_smem_layout_staged: cute.ComposedLayout,
@@ -792,6 +807,13 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
         gC_mnl = cute.local_tile(
             mC_mnl, cute.slice_(self.mma_tiler_c, (None, None, 0)), (None, None, None)
         )
+        # (bM, bN, RestM, RestN, RestL) - bias tiled IDENTICALLY to C (M-stride 0
+        # broadcast); only present on the non-gated path with a supplied bias.
+        gBias_mnl = None
+        if cutlass.const_expr(mBias_mnl is not None):
+            gBias_mnl = cute.local_tile(
+                mBias_mnl, cute.slice_(self.mma_tiler_c, (None, None, 0)), (None, None, None)
+            )
         k_block_cnt = cutlass.Int32(cute.size(gA_mkl, mode=[3]))
 
         #
@@ -809,6 +831,11 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
         tCgSFB = thr_mma_sfb.partition_B(gSFB_nkl)
         # (MMA, MMA_M, MMA_N, RestM, RestN, RestL)
         tCgC = thr_mma.partition_C(gC_mnl)
+        # Bias partitioned the SAME way as C so the epilogue partition yields a
+        # fragment matching tTR_rAcc_up; only when a bias was supplied.
+        tCgBias = None
+        if cutlass.const_expr(gBias_mnl is not None):
+            tCgBias = thr_mma.partition_C(gBias_mnl)
 
         #
         # Partition global/shared tensor for TMA load A/B
@@ -1325,9 +1352,18 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
                 tTR_tAcc_base,
                 tTR_rAcc_up,
                 tTR_rAcc_gate,
+                tTR_gBias_base,
             ) = self.epilog_tmem_copy_and_partition(
-                epi_tidx, tCtAcc_base, tCgC, epi_tile, use_2cta_instrs
+                epi_tidx, tCtAcc_base, tCgC, epi_tile, use_2cta_instrs, tCgBias
             )
+
+            # Register fragment that receives the per-N bias slice for the current
+            # subtile (same shape as tTR_rAcc_up); only allocated when bias present.
+            # Use the bias source dtype (bf16/fp32) so the gmem->reg autovec_copy
+            # has matching element bit widths; converted to fp32 at add time.
+            tTR_rBias = None
+            if cutlass.const_expr(gBias_mnl is not None):
+                tTR_rBias = cute.make_rmem_tensor(tTR_rAcc_up.shape, gBias_mnl.element_type)
 
             tTR_rC = cute.make_rmem_tensor(tTR_rAcc_up.shape, self.c_dtype)
             tiled_copy_r2s, tRS_rC, tRS_sC = self.epilog_smem_copy_and_partition(
@@ -1398,6 +1434,20 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
                     )
                 ]
 
+                # Per-tile bias slice (same RestM/RestN/RestL coord as C):
+                # (T2R, T2R_M, T2R_N, EPI_M, EPI_N).
+                if cutlass.const_expr(gBias_mnl is not None):
+                    tTR_gBias = tTR_gBias_base[
+                        (
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                            *mma_tile_coord_mnl,
+                        )
+                    ]
+
                 if cutlass.const_expr(self.overlapping_accum):
                     acc_stage_index = acc_consumer_state.phase
                     reverse_subtile = (
@@ -1430,6 +1480,10 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
 
                 tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
                 bSG_gC = cute.group_modes(bSG_gC, 1, cute.rank(bSG_gC))
+                # Group (EPI_M, EPI_N) so real_subtile_idx selects a subtile, just
+                # like tTR_tAcc -> (T2R, T2R_M, T2R_N, EPI).
+                if cutlass.const_expr(gBias_mnl is not None):
+                    tTR_gBias = cute.group_modes(tTR_gBias, 3, cute.rank(tTR_gBias))
 
                 #
                 # Process accumulator subtiles with SwiGLU fusion and store to global memory
@@ -1438,30 +1492,45 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
                 #
                 subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
 
-                for subtile_idx in cutlass.range(0, subtile_cnt, 2):
-                    real_subtile_idx = subtile_idx // 2
+                for subtile_idx in cutlass.range(0, subtile_cnt, 2 if self.is_gated else 1):
+                    if cutlass.const_expr(self.is_gated):
+                        real_subtile_idx = subtile_idx // 2
+                    else:
+                        real_subtile_idx = subtile_idx
                     if cutlass.const_expr(self.overlapping_accum):
                         if reverse_subtile:
                             real_subtile_idx = (
                                 self.cta_tile_shape_mnk[1] // self.epi_tile_n_required
                                 - 1
-                                - subtile_idx // 2
+                                - real_subtile_idx
                             )
                     #
                     # Load accumulator from tensor memory buffer to register
-                    # Load TWO subtiles: up (even) and gate (odd)
                     #
-                    tTR_tAcc_mn_up = tTR_tAcc[(None, None, None, real_subtile_idx * 2)]
-                    tTR_tAcc_mn_gate = tTR_tAcc[(None, None, None, real_subtile_idx * 2 + 1)]
-
-                    cute.copy(tiled_copy_t2r, tTR_tAcc_mn_up, tTR_rAcc_up)
-                    cute.copy(tiled_copy_t2r, tTR_tAcc_mn_gate, tTR_rAcc_gate)
+                    if cutlass.const_expr(self.is_gated):
+                        # Gated: load TWO subtiles: up (even) and gate (odd)
+                        tTR_tAcc_mn_up = tTR_tAcc[(None, None, None, real_subtile_idx * 2)]
+                        tTR_tAcc_mn_gate = tTR_tAcc[(None, None, None, real_subtile_idx * 2 + 1)]
+                        cute.copy(tiled_copy_t2r, tTR_tAcc_mn_up, tTR_rAcc_up)
+                        cute.copy(tiled_copy_t2r, tTR_tAcc_mn_gate, tTR_rAcc_gate)
+                    else:
+                        # Non-gated: load a single subtile
+                        tTR_tAcc_mn = tTR_tAcc[(None, None, None, real_subtile_idx)]
+                        cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc_up)
+                        # Load the per-N bias slice for this subtile (gmem -> reg).
+                        # tTR_gBias[..., real_subtile_idx] has the same layout as
+                        # tTR_rAcc_up; M-broadcast comes from the stride-0 source.
+                        if cutlass.const_expr(gBias_mnl is not None):
+                            cute.autovec_copy(
+                                tTR_gBias[(None, None, None, real_subtile_idx)],
+                                tTR_rBias,
+                            )
 
                     #
                     # Async arrive accumulator buffer empty earlier when overlapping_accum is enabled
                     #
                     if cutlass.const_expr(self.overlapping_accum):
-                        if subtile_idx // 2 == self.iter_acc_early_release_in_epilogue:
+                        if real_subtile_idx == self.iter_acc_early_release_in_epilogue:
                             # Fence for TMEM load
                             cute.arch.fence_view_async_tmem_load()
                             with cute.arch.elect_one():
@@ -1469,66 +1538,19 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
                             acc_consumer_state.advance()
 
                     acc_vec_up = tTR_rAcc_up.load()
-                    acc_vec_gate = tTR_rAcc_gate.load()
-
-                    #
-                    # SwiGLU activation: output = up * silu(gate)
-                    # where silu(x) = x * sigmoid(x)
-                    # up and gate are extracted from interleaved accumulator subtiles
-                    #
-                    tCompute = cute.make_rmem_tensor(acc_vec_gate.shape, self.acc_dtype)
-                    if cutlass.const_expr(self.vectorized_f32):
-                        # SwiGLU Packed Version: uses f32x2 packed operations for better performance
-                        # Computes: output = (alpha * up) * silu(alpha * gate)
-                        # where silu(x) = x * sigmoid(x) = x / (1 + exp(-x))
-                        LOG2_E = cutlass.Float32(1.4426950408889634)
-                        for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc_up), 2):
-                            acc_vec_up_alpha = cute.arch.mul_packed_f32x2(
-                                (acc_vec_up[i], acc_vec_up[i + 1]),
-                                (cutlass.Float32(alpha_val), cutlass.Float32(alpha_val)),
-                            )
-                            acc_vec_gate_alpha = cute.arch.mul_packed_f32x2(
-                                (acc_vec_gate[i], acc_vec_gate[i + 1]),
-                                (cutlass.Float32(alpha_val), cutlass.Float32(alpha_val)),
-                            )
-                            tCompute_log2e = cute.arch.mul_packed_f32x2(
-                                (acc_vec_gate_alpha[0], acc_vec_gate_alpha[1]), (-LOG2_E, -LOG2_E)
-                            )
-                            (
-                                tCompute[i],
-                                tCompute[i + 1],
-                            ) = cute.arch.add_packed_f32x2(
-                                (
-                                    cute.math.exp2(tCompute_log2e[0], fastmath=True),
-                                    cute.math.exp2(tCompute_log2e[1], fastmath=True),
-                                ),
-                                (1.0, 1.0),
-                            )
-                            tCompute[i] = cute.arch.rcp_approx(tCompute[i])
-                            tCompute[i + 1] = cute.arch.rcp_approx(tCompute[i + 1])
-                            (
-                                tCompute[i],
-                                tCompute[i + 1],
-                            ) = cute.arch.mul_packed_f32x2(
-                                (tCompute[i], tCompute[i + 1]),
-                                (acc_vec_gate_alpha[0], acc_vec_gate_alpha[1]),
-                            )
-                            (
-                                tCompute[i],
-                                tCompute[i + 1],
-                            ) = cute.arch.mul_packed_f32x2(
-                                (tCompute[i], tCompute[i + 1]),
-                                (acc_vec_up_alpha[0], acc_vec_up_alpha[1]),
-                            )
+                    tCompute = cute.make_rmem_tensor(acc_vec_up.shape, self.acc_dtype)
+                    if cutlass.const_expr(self.is_gated):
+                        # SwiGLU: output = (alpha * up) * silu(alpha * gate)
+                        acc_vec_gate = tTR_rAcc_gate.load()
+                        self._apply_swiglu_epilogue(acc_vec_up, acc_vec_gate, alpha_val, tCompute)
                     else:
-                        # SwiGLU Unpacked Version: scalar operations
-                        # Computes: output = (alpha * up) * silu(alpha * gate)
-                        for i in cutlass.range_constexpr(cute.size(tTR_rAcc_up)):
-                            acc_vec_up_alpha = acc_vec_up[i] * cutlass.Float32(alpha_val)
-                            acc_vec_gate_alpha = acc_vec_gate[i] * cutlass.Float32(alpha_val)
-                            tCompute[i] = acc_vec_up_alpha * silu_f32(
-                                acc_vec_gate_alpha, fastmath=True
-                            )
+                        # GELU (tanh approx): output = gelu_tanh(alpha * up + bias)
+                        bias_vec = None
+                        if cutlass.const_expr(gBias_mnl is not None):
+                            bias_vec = tTR_rBias.load()
+                        self._apply_gelu_epilogue(
+                            acc_vec_up, alpha_val, tCompute, bias_vec=bias_vec
+                        )
 
                     if cutlass.const_expr(self.generate_sfc):
                         #
@@ -1770,6 +1792,133 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
 
         return tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t
 
+    @cute.jit
+    def _apply_swiglu_epilogue(
+        self,
+        acc_vec_up: cute.Tensor,
+        acc_vec_gate: cute.Tensor,
+        alpha_val,
+        tCompute: cute.Tensor,
+    ):
+        """SwiGLU: ``tCompute[i] = (alpha * up[i]) * silu(alpha * gate[i])``.
+
+        ``up`` and ``gate`` come from the two interleaved accumulator subtiles
+        loaded by the caller.
+        """
+        if cutlass.const_expr(self.vectorized_f32):
+            # Packed f32x2: silu via 1 / (1 + exp2(-log2_e * x))
+            LOG2_E = cutlass.Float32(1.4426950408889634)
+            for i in cutlass.range_constexpr(0, cute.size(acc_vec_up.shape), 2):
+                acc_vec_up_alpha = cute.arch.mul_packed_f32x2(
+                    (acc_vec_up[i], acc_vec_up[i + 1]),
+                    (cutlass.Float32(alpha_val), cutlass.Float32(alpha_val)),
+                )
+                acc_vec_gate_alpha = cute.arch.mul_packed_f32x2(
+                    (acc_vec_gate[i], acc_vec_gate[i + 1]),
+                    (cutlass.Float32(alpha_val), cutlass.Float32(alpha_val)),
+                )
+                tCompute_log2e = cute.arch.mul_packed_f32x2(
+                    (acc_vec_gate_alpha[0], acc_vec_gate_alpha[1]),
+                    (-LOG2_E, -LOG2_E),
+                )
+                (
+                    tCompute[i],
+                    tCompute[i + 1],
+                ) = cute.arch.add_packed_f32x2(
+                    (
+                        cute.math.exp2(tCompute_log2e[0], fastmath=True),
+                        cute.math.exp2(tCompute_log2e[1], fastmath=True),
+                    ),
+                    (1.0, 1.0),
+                )
+                tCompute[i] = cute.arch.rcp_approx(tCompute[i])
+                tCompute[i + 1] = cute.arch.rcp_approx(tCompute[i + 1])
+                (
+                    tCompute[i],
+                    tCompute[i + 1],
+                ) = cute.arch.mul_packed_f32x2(
+                    (tCompute[i], tCompute[i + 1]),
+                    (acc_vec_gate_alpha[0], acc_vec_gate_alpha[1]),
+                )
+                (
+                    tCompute[i],
+                    tCompute[i + 1],
+                ) = cute.arch.mul_packed_f32x2(
+                    (tCompute[i], tCompute[i + 1]),
+                    (acc_vec_up_alpha[0], acc_vec_up_alpha[1]),
+                )
+        else:
+            for i in cutlass.range_constexpr(cute.size(acc_vec_up.shape)):
+                acc_vec_up_alpha = acc_vec_up[i] * cutlass.Float32(alpha_val)
+                acc_vec_gate_alpha = acc_vec_gate[i] * cutlass.Float32(alpha_val)
+                tCompute[i] = acc_vec_up_alpha * silu_f32(acc_vec_gate_alpha, fastmath=True)
+
+    @cute.jit
+    def _apply_gelu_epilogue(
+        self,
+        acc_vec_up: cute.Tensor,
+        alpha_val,
+        tCompute: cute.Tensor,
+        bias_vec: Optional[cute.Tensor] = None,
+    ):
+        """GELU (tanh approx): ``tCompute[i] = gelu_tanh(alpha * up[i] + bias[i])``.
+
+        gelu_tanh(x) = 0.5*x*(1 + tanh(c*(x + 0.044715 x^3)))
+                     = x * sigmoid(2c*(x + 0.044715 x^3)),  c = sqrt(2/pi)
+        Non-gated: only the single ``up`` accumulator subtile is used.
+
+        When ``bias_vec`` is provided it is a per-N register fragment (already
+        broadcast over M by the caller, in the bias source dtype bf16/fp32)
+        added to ``alpha * up`` BEFORE the GELU; each element is converted to
+        fp32 here. ``bias_vec`` is None by default -> behavior is byte-identical
+        to the bias-free path.
+        """
+        LOG2_E = cutlass.Float32(1.4426950408889634)
+        C2 = cutlass.Float32(1.5957691216057308)  # 2 * sqrt(2/pi)
+        K = cutlass.Float32(0.044715)
+        if cutlass.const_expr(self.vectorized_f32):
+            for i in cutlass.range_constexpr(0, cute.size(acc_vec_up.shape), 2):
+                # x = alpha * acc
+                x = cute.arch.mul_packed_f32x2(
+                    (acc_vec_up[i], acc_vec_up[i + 1]),
+                    (cutlass.Float32(alpha_val), cutlass.Float32(alpha_val)),
+                )
+                # x = alpha * acc + bias  (per-N, broadcast over M)
+                if cutlass.const_expr(bias_vec is not None):
+                    x = cute.arch.add_packed_f32x2(
+                        (x[0], x[1]),
+                        (cutlass.Float32(bias_vec[i]), cutlass.Float32(bias_vec[i + 1])),
+                    )
+                # inner = C2 * (x + K * x^3)
+                x2 = cute.arch.mul_packed_f32x2((x[0], x[1]), (x[0], x[1]))
+                x3 = cute.arch.mul_packed_f32x2((x2[0], x2[1]), (x[0], x[1]))
+                kx3 = cute.arch.mul_packed_f32x2((x3[0], x3[1]), (K, K))
+                inner = cute.arch.add_packed_f32x2((x[0], x[1]), (kx3[0], kx3[1]))
+                w = cute.arch.mul_packed_f32x2((inner[0], inner[1]), (C2, C2))
+                # sigmoid(w) = 1 / (1 + exp2(-w * log2_e))
+                neg = cute.arch.mul_packed_f32x2((w[0], w[1]), (-LOG2_E, -LOG2_E))
+                denom = cute.arch.add_packed_f32x2(
+                    (
+                        cute.math.exp2(neg[0], fastmath=True),
+                        cute.math.exp2(neg[1], fastmath=True),
+                    ),
+                    (1.0, 1.0),
+                )
+                s0 = cute.arch.rcp_approx(denom[0])
+                s1 = cute.arch.rcp_approx(denom[1])
+                # out = x * sigmoid(w)
+                (
+                    tCompute[i],
+                    tCompute[i + 1],
+                ) = cute.arch.mul_packed_f32x2((s0, s1), (x[0], x[1]))
+        else:
+            for i in cutlass.range_constexpr(cute.size(acc_vec_up.shape)):
+                x = acc_vec_up[i] * cutlass.Float32(alpha_val)
+                # x = alpha * acc + bias  (per-N, broadcast over M)
+                if cutlass.const_expr(bias_vec is not None):
+                    x = x + cutlass.Float32(bias_vec[i])
+                tCompute[i] = gelu_tanh_f32(x, fastmath=True)
+
     def epilog_tmem_copy_and_partition(
         self,
         tidx: cutlass.Int32,
@@ -1777,7 +1926,8 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
         gC_mnl: cute.Tensor,
         epi_tile: cute.Tile,
         use_2cta_instrs: Union[cutlass.Boolean, bool],
-    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor, cute.Tensor]:
+        tCgBias: Optional[cute.Tensor] = None,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor, cute.Tensor, Optional[cute.Tensor]]:
         """
         Make tiledCopy for tensor memory load, then use it to partition tensor memory
         (source) and register array (destination).
@@ -1791,13 +1941,21 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
             gC_mnl (cute.Tensor): The global tensor C
             epi_tile (cute.Tile): The epilogue tiler
             use_2cta_instrs (bool): Whether use_2cta_instrs is enabled
+            tCgBias (Optional[cute.Tensor]): Optional bias partitioned with
+                ``thr_mma.partition_C`` exactly like ``tCgC`` (broadcast over M
+                via stride 0). When provided it is further partitioned with the
+                SAME tiled copy as C so the resulting fragment matches
+                ``tTR_rAcc_up`` element-for-element.
 
         Returns:
-            A tuple containing (tiled_copy_t2r, tTR_tAcc, tTR_rAcc_up, tTR_rAcc_gate) where:
+            A tuple containing (tiled_copy_t2r, tTR_tAcc, tTR_rAcc_up, tTR_rAcc_gate,
+            tTR_gBias) where:
                 - tiled_copy_t2r: The tiled copy operation for tmem to register copy(t2r)
                 - tTR_tAcc: The partitioned accumulator tensor
                 - tTR_rAcc_up: The register tensor for acc up subtile
                 - tTR_rAcc_gate: The register tensor for acc gate subtile
+                - tTR_gBias: The partitioned global bias tensor (same layout as the
+                  partitioned C), or None when no bias was supplied.
         """
         # Make tiledCopy for tensor memory load
         copy_atom_t2r = sm100_utils.get_tmem_load_op(
@@ -1832,7 +1990,18 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
         tTR_rAcc_gate = cute.make_rmem_tensor(
             tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype
         )
-        return tiled_copy_t2r, tTR_tAcc, tTR_rAcc_up, tTR_rAcc_gate
+
+        # Partition the per-N bias EXACTLY like C (broadcast over M via stride 0).
+        # Same flat_divide + partition_D path -> tTR_gBias has the same layout as
+        # tTR_gC, so a bias fragment matches tTR_rAcc_up position-for-position.
+        tTR_gBias = None
+        if cutlass.const_expr(tCgBias is not None):
+            gBias_mnl_epi = cute.flat_divide(
+                tCgBias[((None, None), 0, 0, None, None, None)], epi_tile
+            )
+            tTR_gBias = thr_copy_t2r.partition_D(gBias_mnl_epi)
+
+        return tiled_copy_t2r, tTR_tAcc, tTR_rAcc_up, tTR_rAcc_gate, tTR_gBias
 
     def epilog_smem_copy_and_partition(
         self,
@@ -2323,6 +2492,7 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
         current_stream: cuda.CUstream,
         swap_ab: cutlass.Constexpr = False,
         epilogue_op: cutlass.Constexpr = lambda x: x,
+        bias_ptr: Optional[cute.Pointer] = None,
     ):
         """Executes the wrapped GEMM kernel with dynamically shaped tensors.
 
@@ -2345,6 +2515,10 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
             current_stream (cuda.CUstream): CUDA stream for the operation.
             epilogue_op (cutlass.Constexpr, optional): Elementwise lambda
                 function for the epilogue. Defaults to identity.
+            bias_ptr (Optional[cute.Pointer]): Optional pointer to a per-N bias
+                vector [n_out]; broadcast over M (stride 0) and added before the
+                activation. Only consumed by the non-gated GELU path. None ->
+                no bias.
         """
 
         # m, k, l
@@ -2360,8 +2534,8 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
                 order=(1, 0, 2),
             ),
         )
-        # m, n//2, l (SwiGLU halves the N dimension)
-        n_out = n // 2
+        # Gated (SwiGLU) halves output N; non-gated keeps full N.
+        n_out = n // 2 if self.is_gated else n
         if cutlass.const_expr(swap_ab):
             c_tensor = cute.make_tensor(
                 c_ptr,
@@ -2394,6 +2568,13 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
                 order=(2, 1, 4, 0, 3, 5),
             ),
         )
+        # Optional per-N bias broadcast over M (and L): stride 0 on M/L, 1 on N.
+        bias_tensor = None
+        if cutlass.const_expr(bias_ptr is not None):
+            bias_tensor = cute.make_tensor(
+                bias_ptr,
+                layout=cute.make_layout((m, n_out, l), stride=(0, 1, 0)),
+            )
 
         self(
             a_tensor,
@@ -2405,6 +2586,7 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
             max_active_clusters,
             current_stream,
             epilogue_op,
+            bias_tensor=bias_tensor,
         )
 
     @cute.jit
@@ -2429,6 +2611,7 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
         norm_const_tensor: cute.Tensor,
         max_active_clusters: cutlass.Constexpr,
         current_stream: cuda.CUstream,
+        bias_ptr: Optional[cute.Pointer] = None,
     ):
         """Wrapper for FP4 output mode with SFC quantization.
 
@@ -2440,6 +2623,9 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
             c_ptr: Pointer to FP4 output tensor [m, n_out] (packed).
             sfc_ptr: Pointer to output scale factor tensor.
             norm_const_tensor: Normalization constant for SFC quantization.
+            bias_ptr: Optional pointer to a per-N bias vector [n_out]. When
+                provided, a broadcast (m, n_out, l) tensor with M-stride 0 is
+                built and added before the activation. None -> no bias.
         """
         # m, k, l
         a_tensor = cute.make_tensor(
@@ -2454,8 +2640,8 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
                 order=(1, 0, 2),
             ),
         )
-        # m, n//2, l (SwiGLU halves the N dimension) — FP4 output
-        n_out = n // 2
+        # Gated (SwiGLU) halves output N; non-gated keeps full N. — FP4 output
+        n_out = n // 2 if self.is_gated else n
         c_tensor = cute.make_tensor(
             c_ptr,
             layout=cute.make_ordered_layout(
@@ -2486,6 +2672,13 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
                 order=(2, 1, 4, 0, 3, 5),
             ),
         )
+        # Optional per-N bias broadcast over M (and L): stride 0 on M/L, 1 on N.
+        bias_tensor = None
+        if cutlass.const_expr(bias_ptr is not None):
+            bias_tensor = cute.make_tensor(
+                bias_ptr,
+                layout=cute.make_layout((m, n_out, l), stride=(0, 1, 0)),
+            )
 
         self(
             a_tensor,
@@ -2498,6 +2691,7 @@ class Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel:
             current_stream,
             sfc_tensor=sfc_tensor,
             norm_const_tensor=norm_const_tensor,
+            bias_tensor=bias_tensor,
         )
 
 

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/utils.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/utils.py
@@ -232,6 +232,22 @@ def silu_f32(a: Union[float, cutlass.Float32],
     return a * sigmoid_f32(a, fastmath=fastmath)
 
 
+def gelu_tanh_f32(a: Union[float, cutlass.Float32],
+                  fastmath: bool = False) -> Union[float, cutlass.Float32]:
+    """
+    Compute the tanh approximation of GELU (matches F.gelu(approximate="tanh")).
+
+    gelu(a) = 0.5 * a * (1 + tanh(c * (a + 0.044715 * a^3))),  c = sqrt(2/pi)
+            = a * sigmoid(2c * (a + 0.044715 * a^3))
+
+    using the identity tanh(z) = 2 * sigmoid(2z) - 1, so the activation reuses
+    the same exp2-based sigmoid as silu_f32.
+    """
+    c2 = 1.5957691216057308  # 2 * sqrt(2/pi)
+    inner = c2 * (a + 0.044715 * a * a * a)
+    return a * sigmoid_f32(inner, fastmath=fastmath)
+
+
 # TODO(zhichenj): try to move these to NVVM wrapper or helper functions
 @dsl_user_op
 def vectorized_atomic_add_bf16x8(rOut_epi_packed,

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -1386,13 +1386,24 @@ class NVFP4LinearMethod(LinearMethodBase):
     def apply(self, module: Linear, input: torch.Tensor,
               bias: Optional[torch.Tensor]):
         # Handle multi-dimensional inputs (e.g., 3D: batch, seq, hidden).
-        # GEMM requires 2D. Only plain tensors support for now, skip for
-        # tuple and Fp4QuantizedTensor.
+        # NVFP4 GEMM requires a 2D mat1; flatten here and unflatten the output below.
         original_shape = None
         if not isinstance(input,
                           (tuple, Fp4QuantizedTensor)) and input.dim() > 2:
             original_shape = input.shape
             input = input.reshape(-1, input.shape[-1])
+        elif isinstance(input,
+                        Fp4QuantizedTensor) and input.fp4_tensor.dim() > 2:
+            # Pre-quantized 3D input (e.g. from a fused activation+quant epilogue):
+            # flatten the packed fp4 tensor; output is unflattened below via
+            # original_shape (mirrors the plain-tensor path).
+            original_shape = input.fp4_tensor.shape
+            input = Fp4QuantizedTensor(
+                fp4_tensor=input.fp4_tensor.reshape(-1,
+                                                    input.fp4_tensor.shape[-1]),
+                scaling_factor=input.scaling_factor,
+                is_sf_swizzled=input.is_sf_swizzled,
+            )
 
         act_fp4, act_sf, alpha = self._input_prepare(module, input)
 

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -1394,9 +1394,6 @@ class NVFP4LinearMethod(LinearMethodBase):
             input = input.reshape(-1, input.shape[-1])
         elif isinstance(input,
                         Fp4QuantizedTensor) and input.fp4_tensor.dim() > 2:
-            # Pre-quantized 3D input (e.g. from a fused activation+quant epilogue):
-            # flatten the packed fp4 tensor; output is unflattened below via
-            # original_shape (mirrors the plain-tensor path).
             original_shape = input.fp4_tensor.shape
             input = Fp4QuantizedTensor(
                 fp4_tensor=input.fp4_tensor.reshape(-1,

--- a/tensorrt_llm/_torch/modules/mlp.py
+++ b/tensorrt_llm/_torch/modules/mlp.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Optional
+from typing import Optional, Tuple, Union
 
 import torch
 from torch import nn
@@ -92,6 +92,8 @@ class MLP(nn.Module):
         )
 
         self._use_fused_relu2_quant = False
+        self._use_fused_gelu = False
+        self._use_fused_gelu_fp4out = False
 
     def create_weights(self):
         self.up_proj.create_weights()
@@ -111,26 +113,36 @@ class MLP(nn.Module):
         self._use_fused_relu2_quant = (has_nvfp4 and has_kernel and has_scale
                                        and is_relu2 and is_sm100_or_later)
 
+        # Eligibility for the fused up-GEMM + bias + GELU(tanh) CuteDSL epilogue,
+        # computed once here (mirrors _use_fused_relu2_quant). bf16-out is the
+        # base path; fp4-out additionally needs an NVFP4 down_proj with a static
+        # input_scale (the SFC norm_const), mirroring GatedMLP.
+        self._use_fused_gelu, self._use_fused_gelu_fp4out = (
+            self._gelu_fusion_eligibility())
+
     # Minimum M for the fp4out CuTe DSL GELU kernel; below this its SFC epilogue
-    # can write out-of-bounds (CTA tile height > output rows), so fall back to eager.
+    # can write out-of-bounds (CTA tile height > output rows), so fall back to
+    # the (still fused) bf16-out path.
     _FP4OUT_MIN_M = 128
 
     def forward(
         self,
-        x: torch.Tensor,
+        x: Union[torch.Tensor, Fp4QuantizedTensor],
         lora_params: Optional[dict] = None,
     ) -> torch.Tensor:
         if lora_params is not None:
             return self.forward_lora(x, lora_params=lora_params)
 
-        # Fuse up_proj GEMM + bias + GELU(tanh) + NVFP4-quant into the GEMM
-        # epilogue (mirrors GatedMLP's SwiGLU fp4out path) when eligible.
-        if self._can_fuse_gelu_fp4out():
-            m = x.reshape(-1, x.shape[-1]).shape[0]
-            if m >= MLP._FP4OUT_MIN_M:
-                # Helper returns a rank-preserving Fp4QuantizedTensor; the NVFP4
-                # down_proj flattens/unflattens 3D inputs (see linear.py).
-                return self.down_proj(self._apply_fused_gelu_fp4out(x))
+        # Fuse up_proj GEMM + bias + GELU(tanh) (+ NVFP4-quant) into the GEMM
+        # epilogue (mirrors GatedMLP's SwiGLU paths) when eligible.
+        if self._use_fused_gelu_fp4out:
+            # fp4-out when M is large enough; otherwise the (still fused) bf16-out
+            # path, after which down_proj re-quantizes.
+            m = self._token_count(x)
+            return self.down_proj(
+                self._fused_gelu(x, fp4_out=m >= MLP._FP4OUT_MIN_M))
+        elif self._use_fused_gelu:
+            return self.down_proj(self._fused_gelu(x))
 
         x_up = self.up_proj(x)
 
@@ -143,42 +155,78 @@ class MLP(nn.Module):
 
         return x_down
 
-    def _can_fuse_gelu_fp4out(self) -> bool:
-        """Eligible for the fused up-GEMM + bias + GELU(tanh) + NVFP4 epilogue op.
+    def _gelu_fusion_eligibility(self) -> Tuple[bool, bool]:
+        """Return (bf16_out_ok, fp4_out_ok) for the fused GELU(tanh) epilogue.
 
-        Mirrors GatedMLP._can_fuse_gate_up_swiglu_fp4out: needs NVFP4 up/down
-        projections, a static down_proj input_scale (the SFC norm_const), the
-        GELU(tanh) activation, the Blackwell CuteDSL op, and SM 100/103.
+        Mirrors GatedMLP._can_fuse_gate_up_swiglu / _can_fuse_gate_up_swiglu_fp4out
+        for the non-gated GELU(tanh) activation (bias supported). Requires the
+        Blackwell CuteDSL op(s), SM 100/103, and an NVFP4 up_proj. fp4-out builds
+        on bf16-out and additionally needs an NVFP4 down_proj with a static
+        input_scale and no forced dynamic quantization.
         """
-        return (self.activation is gelu_tanh and hasattr(
+        if (self.activation is not gelu_tanh
+                or get_sm_version() not in (100, 103)
+                or not getattr(self.up_proj, "has_nvfp4", False)):
+            return False, False
+        bf16_ok = hasattr(torch.ops.trtllm,
+                          "cute_dsl_nvfp4_dense_gemm_gelu_blackwell")
+        fp4_ok = (bf16_ok and hasattr(
             torch.ops.trtllm, "cute_dsl_nvfp4_dense_gemm_gelu_fp4out_blackwell")
-                and get_sm_version() in (100, 103)
-                and getattr(self.up_proj, "has_nvfp4", False)
-                and getattr(self.down_proj, "has_nvfp4", False)
-                and not self.down_proj.force_dynamic_quantization
-                and self.down_proj.input_scale is not None)
+                  and getattr(self.down_proj, "has_nvfp4", False)
+                  and not self.down_proj.force_dynamic_quantization
+                  and self.down_proj.input_scale is not None)
+        return bf16_ok, fp4_ok
 
-    def _apply_fused_gelu_fp4out(self, x: torch.Tensor) -> Fp4QuantizedTensor:
-        """Fused up-GEMM + bias + GELU(tanh) + NVFP4 quant -> down_proj input.
+    @staticmethod
+    def _token_count(x: Union[torch.Tensor, tuple, Fp4QuantizedTensor]) -> int:
+        if isinstance(x, (tuple, Fp4QuantizedTensor)):
+            return x[0].shape[0] if isinstance(x, tuple) else x.shape[0]
+        return x.reshape(-1,
+                         x.shape[-1]).shape[0] if x.dim() > 2 else x.shape[0]
 
-        Preserves input rank: a [B, S, H] input returns a [B, S, H'/2]-packed
-        Fp4QuantizedTensor so the NVFP4 down_proj unflattens its output correctly.
+    def _fused_gelu(
+        self,
+        x: Union[torch.Tensor, tuple, Fp4QuantizedTensor],
+        fp4_out: bool = False,
+    ) -> Union[torch.Tensor, Fp4QuantizedTensor]:
+        """Fused up-GEMM + bias + GELU(tanh) using the Blackwell CuteDSL kernel.
+
+        Mirrors GatedMLP._fused_gate_up_swiglu for the non-gated GELU(tanh)
+        activation. Accepts a plain tensor, a tuple, or a pre-quantized
+        Fp4QuantizedTensor, and preserves input rank.
+
+        Returns a bf16 tensor, or (when fp4_out) a rank-preserving
+        Fp4QuantizedTensor that the NVFP4 down_proj consumes directly.
         """
         module = self.up_proj
+
         original_shape = None
-        if x.dim() > 2:
+        if not isinstance(x, (tuple, Fp4QuantizedTensor)) and x.dim() > 2:
             original_shape = x.shape
             x = x.reshape(-1, x.shape[-1])
 
         act_fp4, act_sf, alpha = module.quant_method._input_prepare(module, x)
-        fp4_output, out_sf = torch.ops.trtllm.cute_dsl_nvfp4_dense_gemm_gelu_fp4out_blackwell(
-            act_fp4, module.weight, act_sf, module.weight_scale, alpha,
-            self.down_proj.input_scale, module.bias)
 
+        if fp4_out:
+            # down_proj's input_scale serves as norm_const for SFC quantization.
+            fp4_output, out_sf = torch.ops.trtllm.cute_dsl_nvfp4_dense_gemm_gelu_fp4out_blackwell(
+                act_fp4, module.weight, act_sf, module.weight_scale, alpha,
+                self.down_proj.input_scale, module.bias)
+            if original_shape is not None:
+                fp4_output = fp4_output.reshape(*original_shape[:-1],
+                                                fp4_output.shape[-1])
+            return Fp4QuantizedTensor(fp4_output, out_sf)
+
+        # bf16-out path (down_proj re-quantizes its input itself).
+        output = torch.ops.trtllm.cute_dsl_nvfp4_dense_gemm_gelu_blackwell(
+            act_fp4, module.weight, act_sf, module.weight_scale, alpha,
+            module.dtype, module.bias)
+        # Non-gated: trim any padding beyond the logical out_features.
+        if output.shape[-1] > module.out_features:
+            output = output[..., :module.out_features].contiguous()
         if original_shape is not None:
-            fp4_output = fp4_output.reshape(*original_shape[:-1],
-                                            fp4_output.shape[-1])
-        return Fp4QuantizedTensor(fp4_output, out_sf)
+            output = output.reshape(*original_shape[:-1], output.shape[-1])
+        return output
 
     def _fused_relu2_quant(self, x: torch.Tensor) -> Fp4QuantizedTensor:
         x_flat = x.view(-1, x.shape[-1])

--- a/tensorrt_llm/_torch/modules/mlp.py
+++ b/tensorrt_llm/_torch/modules/mlp.py
@@ -113,10 +113,8 @@ class MLP(nn.Module):
         self._use_fused_relu2_quant = (has_nvfp4 and has_kernel and has_scale
                                        and is_relu2 and is_sm100_or_later)
 
-        # Eligibility for the fused up-GEMM + bias + GELU(tanh) CuteDSL epilogue,
-        # computed once here (mirrors _use_fused_relu2_quant). bf16-out is the
-        # base path; fp4-out additionally needs an NVFP4 down_proj with a static
-        # input_scale (the SFC norm_const), mirroring GatedMLP.
+        # Static eligibility for the fused GELU(tanh) CuteDSL epilogue (mirrors
+        # GatedMLP); the runtime quant_method check is deferred to first forward.
         self._use_fused_gelu, self._use_fused_gelu_fp4out = (
             self._gelu_fusion_eligibility())
 
@@ -134,12 +132,18 @@ class MLP(nn.Module):
             return self.forward_lora(x, lora_params=lora_params)
 
         # Fuse up_proj GEMM + bias + GELU(tanh) (+ NVFP4-quant) into the GEMM
-        # epilogue (mirrors GatedMLP's SwiGLU paths) when eligible.
-        if self._use_fused_gelu_fp4out:
-            m = self._token_count(x)
-            return self.down_proj(
-                self._fused_gelu(x, fp4_out=m >= MLP._FP4OUT_MIN_M))
-        elif self._use_fused_gelu:
+        # epilogue (mirrors GatedMLP). Static eligibility can go stale: quant_method
+        # may be downgraded to unquantized after create_weights (e.g. LTX-2
+        # quant-exclusion), so re-check the NVFP4 _input_prepare at runtime (a
+        # torch.compile trace-time guard, not a per-step cost); else fall back to eager.
+        if self._use_fused_gelu and hasattr(
+                getattr(self.up_proj, "quant_method", None), "_input_prepare"):
+            if self._use_fused_gelu_fp4out and hasattr(
+                    getattr(self.down_proj, "quant_method", None),
+                    "_input_prepare"):
+                m = self._token_count(x)
+                return self.down_proj(
+                    self._fused_gelu(x, fp4_out=m >= MLP._FP4OUT_MIN_M))
             return self.down_proj(self._fused_gelu(x))
 
         x_up = self.up_proj(x)
@@ -154,13 +158,12 @@ class MLP(nn.Module):
         return x_down
 
     def _gelu_fusion_eligibility(self) -> Tuple[bool, bool]:
-        """Return (bf16_out_ok, fp4_out_ok) for the fused GELU(tanh) epilogue.
-
-        Mirrors GatedMLP._can_fuse_gate_up_swiglu / _can_fuse_gate_up_swiglu_fp4out
-        for the non-gated GELU(tanh) activation (bias supported). Requires the
-        Blackwell CuteDSL op(s), SM 100/103, and an NVFP4 up_proj. fp4-out builds
-        on bf16-out and additionally needs an NVFP4 down_proj with a static
-        input_scale and no forced dynamic quantization.
+        """Return (bf16_out_ok, fp4_out_ok) static eligibility for the fused
+        GELU(tanh) epilogue (mirrors GatedMLP's SwiGLU paths). Requires the
+        Blackwell CuteDSL op(s), SM 100/103, and an NVFP4 up_proj; fp4-out builds
+        on bf16-out and also needs an NVFP4 down_proj with a static input_scale
+        and no forced dynamic quantization. The runtime quant_method check is
+        applied in forward (quant_method can be downgraded after this).
         """
         if (self.activation is not gelu_tanh
                 or get_sm_version() not in (100, 103)

--- a/tensorrt_llm/_torch/modules/mlp.py
+++ b/tensorrt_llm/_torch/modules/mlp.py
@@ -136,8 +136,6 @@ class MLP(nn.Module):
         # Fuse up_proj GEMM + bias + GELU(tanh) (+ NVFP4-quant) into the GEMM
         # epilogue (mirrors GatedMLP's SwiGLU paths) when eligible.
         if self._use_fused_gelu_fp4out:
-            # fp4-out when M is large enough; otherwise the (still fused) bf16-out
-            # path, after which down_proj re-quantizes.
             m = self._token_count(x)
             return self.down_proj(
                 self._fused_gelu(x, fp4_out=m >= MLP._FP4OUT_MIN_M))

--- a/tensorrt_llm/_torch/modules/mlp.py
+++ b/tensorrt_llm/_torch/modules/mlp.py
@@ -9,7 +9,7 @@ from tensorrt_llm.mapping import Mapping
 
 from ..model_config import ModelConfig
 from ..peft.lora.layer import LoraLayer, LoraModuleType
-from ..utils import Fp4QuantizedTensor, relu2
+from ..utils import Fp4QuantizedTensor, gelu_tanh, relu2
 from .linear import Linear, TensorParallelMode, WeightMode, WeightsLoadingConfig
 
 
@@ -111,6 +111,10 @@ class MLP(nn.Module):
         self._use_fused_relu2_quant = (has_nvfp4 and has_kernel and has_scale
                                        and is_relu2 and is_sm100_or_later)
 
+    # Minimum M for the fp4out CuTe DSL GELU kernel; below this its SFC epilogue
+    # can write out-of-bounds (CTA tile height > output rows), so fall back to eager.
+    _FP4OUT_MIN_M = 128
+
     def forward(
         self,
         x: torch.Tensor,
@@ -118,6 +122,15 @@ class MLP(nn.Module):
     ) -> torch.Tensor:
         if lora_params is not None:
             return self.forward_lora(x, lora_params=lora_params)
+
+        # Fuse up_proj GEMM + bias + GELU(tanh) + NVFP4-quant into the GEMM
+        # epilogue (mirrors GatedMLP's SwiGLU fp4out path) when eligible.
+        if self._can_fuse_gelu_fp4out():
+            m = x.reshape(-1, x.shape[-1]).shape[0]
+            if m >= MLP._FP4OUT_MIN_M:
+                # Helper returns a rank-preserving Fp4QuantizedTensor; the NVFP4
+                # down_proj flattens/unflattens 3D inputs (see linear.py).
+                return self.down_proj(self._apply_fused_gelu_fp4out(x))
 
         x_up = self.up_proj(x)
 
@@ -129,6 +142,43 @@ class MLP(nn.Module):
         x_down = self.down_proj(x_act)
 
         return x_down
+
+    def _can_fuse_gelu_fp4out(self) -> bool:
+        """Eligible for the fused up-GEMM + bias + GELU(tanh) + NVFP4 epilogue op.
+
+        Mirrors GatedMLP._can_fuse_gate_up_swiglu_fp4out: needs NVFP4 up/down
+        projections, a static down_proj input_scale (the SFC norm_const), the
+        GELU(tanh) activation, the Blackwell CuteDSL op, and SM 100/103.
+        """
+        return (self.activation is gelu_tanh and hasattr(
+            torch.ops.trtllm, "cute_dsl_nvfp4_dense_gemm_gelu_fp4out_blackwell")
+                and get_sm_version() in (100, 103)
+                and getattr(self.up_proj, "has_nvfp4", False)
+                and getattr(self.down_proj, "has_nvfp4", False)
+                and not self.down_proj.force_dynamic_quantization
+                and self.down_proj.input_scale is not None)
+
+    def _apply_fused_gelu_fp4out(self, x: torch.Tensor) -> Fp4QuantizedTensor:
+        """Fused up-GEMM + bias + GELU(tanh) + NVFP4 quant -> down_proj input.
+
+        Preserves input rank: a [B, S, H] input returns a [B, S, H'/2]-packed
+        Fp4QuantizedTensor so the NVFP4 down_proj unflattens its output correctly.
+        """
+        module = self.up_proj
+        original_shape = None
+        if x.dim() > 2:
+            original_shape = x.shape
+            x = x.reshape(-1, x.shape[-1])
+
+        act_fp4, act_sf, alpha = module.quant_method._input_prepare(module, x)
+        fp4_output, out_sf = torch.ops.trtllm.cute_dsl_nvfp4_dense_gemm_gelu_fp4out_blackwell(
+            act_fp4, module.weight, act_sf, module.weight_scale, alpha,
+            self.down_proj.input_scale, module.bias)
+
+        if original_shape is not None:
+            fp4_output = fp4_output.reshape(*original_shape[:-1],
+                                            fp4_output.shape[-1])
+        return Fp4QuantizedTensor(fp4_output, out_sf)
 
     def _fused_relu2_quant(self, x: torch.Tensor) -> Fp4QuantizedTensor:
         x_flat = x.view(-1, x.shape[-1])

--- a/tensorrt_llm/_torch/utils.py
+++ b/tensorrt_llm/_torch/utils.py
@@ -462,6 +462,10 @@ def relu2(x: torch.Tensor) -> torch.Tensor:
     return torch.square(F.relu(x))
 
 
+def gelu_tanh(x: torch.Tensor) -> torch.Tensor:
+    return F.gelu(x, approximate="tanh")
+
+
 def tensor_to_str(x: torch.Tensor, num_elements: int = 10) -> str:
     # Pass num_elements=-1 will print the whole tensor
     if num_elements < 0:

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
@@ -29,7 +29,7 @@ from tqdm import tqdm
 
 from tensorrt_llm._torch.modules.linear import Linear, WeightMode
 from tensorrt_llm._torch.modules.mlp import MLP
-from tensorrt_llm._torch.utils import Fp4QuantizedTensor
+from tensorrt_llm._torch.utils import Fp4QuantizedTensor, gelu_tanh
 from tensorrt_llm._torch.visual_gen.attention_backend.utils import create_attention
 from tensorrt_llm._torch.visual_gen.models.modeling import BaseDiffusionModel
 from tensorrt_llm._torch.visual_gen.modules.attention import Attention, QKVMode
@@ -576,7 +576,7 @@ class BasicAVTransformerBlock(nn.Module):
             hidden_size=cfg.dim,
             intermediate_size=cfg.dim * 4,
             bias=True,
-            activation=lambda x: F.gelu(x, approximate="tanh"),
+            activation=gelu_tanh,  # named (not a lambda) so MLP can detect+fuse GELU+NVFP4
             dtype=dtype,
             config=model_config,
             layer_idx=idx,

--- a/tensorrt_llm/_torch/visual_gen/models/wan/transformer_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/transformer_wan.py
@@ -11,6 +11,7 @@ from tensorrt_llm._torch.models.hf_parameter_utils import get_parameter_device
 from tensorrt_llm._torch.modules.layer_norm import LayerNorm
 from tensorrt_llm._torch.modules.linear import Linear, TensorParallelMode
 from tensorrt_llm._torch.modules.mlp import MLP
+from tensorrt_llm._torch.utils import gelu_tanh
 from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig
 from tensorrt_llm._torch.visual_gen.models.modeling import BaseDiffusionModel
 from tensorrt_llm._torch.visual_gen.modules.attention import Attention, QKVMode
@@ -349,7 +350,7 @@ class WanBlock(nn.Module):
             hidden_size=hidden_size,
             intermediate_size=ffn_dim,
             bias=True,
-            activation=lambda x: F.gelu(x, approximate="tanh"),
+            activation=gelu_tanh,  # named (not a lambda) so MLP can detect+fuse GELU+NVFP4
             dtype=dtype,
             config=model_config,
             layer_idx=_layer_idx,

--- a/tests/scripts/cute_dsl_kernels/run_dense_blockscaled_gemm_act_fusion.py
+++ b/tests/scripts/cute_dsl_kernels/run_dense_blockscaled_gemm_act_fusion.py
@@ -41,11 +41,16 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"""Functionality and performance test for Sm100 Persistent Dense BlockScaled GEMM with SwiGLU fusion.
+"""Functionality and performance test for Sm100 Persistent Dense BlockScaled GEMM activation fusion.
 
-Functional testing:
+The kernel supports two activations selected via ``--activation``:
+  * ``swiglu`` (default): gated SiLU; output C has N/2 columns.
+  * ``gelu``: non-gated tanh-approx GELU; output C keeps the full N columns,
+    with an optional per-N bias added before the activation (``--bias``).
 
-python run_dense_blockscaled_gemm_swiglu_fusion.py \
+Functional testing (SwiGLU):
+
+python run_dense_blockscaled_gemm_act_fusion.py \
         --mnkl 512,256,256,1 \
         --ab_dtype Float4E2M1FN --c_dtype BFloat16 \
         --sf_dtype Float8E4M3FN --sf_vec_size 16 \
@@ -53,7 +58,23 @@ python run_dense_blockscaled_gemm_swiglu_fusion.py \
 
 Functional testing with FP4 output + SFC:
 
-python run_dense_blockscaled_gemm_swiglu_fusion.py \
+python run_dense_blockscaled_gemm_act_fusion.py \
+        --mnkl 512,256,256,1 \
+        --ab_dtype Float4E2M1FN --c_dtype Float4E2M1FN \
+        --sf_dtype Float8E4M3FN --sf_vec_size 16 \
+        --mma_tiler_mn 128,128 --cluster_shape_mn 1,1
+
+Functional testing (non-gated GELU, bf16 output):
+
+python run_dense_blockscaled_gemm_act_fusion.py --activation gelu \
+        --mnkl 512,256,256,1 \
+        --ab_dtype Float4E2M1FN --c_dtype BFloat16 \
+        --sf_dtype Float8E4M3FN --sf_vec_size 16 \
+        --mma_tiler_mn 128,128 --cluster_shape_mn 1,1
+
+Functional testing (non-gated GELU + bias, FP4 output + SFC):
+
+python run_dense_blockscaled_gemm_act_fusion.py --activation gelu --bias \
         --mnkl 512,256,256,1 \
         --ab_dtype Float4E2M1FN --c_dtype Float4E2M1FN \
         --sf_dtype Float8E4M3FN --sf_vec_size 16 \
@@ -61,7 +82,7 @@ python run_dense_blockscaled_gemm_swiglu_fusion.py \
 
 Perf testing:
 
-python run_dense_blockscaled_gemm_swiglu_fusion.py \
+python run_dense_blockscaled_gemm_act_fusion.py \
         --mnkl 4096,7168,2048,1 \
         --ab_dtype Float4E2M1FN --c_dtype BFloat16 \
         --sf_dtype Float8E4M3FN --sf_vec_size 16 \
@@ -69,10 +90,12 @@ python run_dense_blockscaled_gemm_swiglu_fusion.py \
         --vectorized_f32 \
         --skip_ref_check --use_cold_l2 --use_cupti --warmup_iterations 10 --iterations 50
 
-Note: N is the full B matrix width. The output C has N/2 columns after SwiGLU fusion.
+Note: N is the full B matrix width. For SwiGLU the output C has N/2 columns; for
+non-gated GELU the output C keeps the full N columns.
 """
 
 import argparse
+import math
 import sys
 from pathlib import Path
 from typing import Tuple, Type
@@ -83,16 +106,18 @@ import cutlass.torch as cutlass_torch
 import torch
 from cutlass.cute.runtime import from_dlpack
 
+from tensorrt_llm._torch.utils import ActivationType
+
 try:
     from tensorrt_llm._torch.cute_dsl_kernels.blackwell import (
-        dense_blockscaled_gemm_swiglu_fusion as kernel_module,
+        dense_blockscaled_gemm_act_fusion as kernel_module,
     )
 except (ModuleNotFoundError, ImportError):
     sys.path.insert(0, str(Path(__file__).parents[3] / "tensorrt_llm/_torch/cute_dsl_kernels"))
-    from blackwell import dense_blockscaled_gemm_swiglu_fusion as kernel_module
+    from blackwell import dense_blockscaled_gemm_act_fusion as kernel_module
 
-Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel = (
-    kernel_module.Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel
+Sm100BlockScaledPersistentDenseGemmActFusionKernel = (
+    kernel_module.Sm100BlockScaledPersistentDenseGemmActFusionKernel
 )
 cvt_sf_MKL_to_M32x4xrm_K4xrk_L = kernel_module.cvt_sf_MKL_to_M32x4xrm_K4xrk_L
 
@@ -121,16 +146,20 @@ def run(
     skip_ref_check: bool = False,
     use_cold_l2: bool = False,
     use_cupti: bool = False,
+    activation: str = "swiglu",
+    use_bias: bool = False,
     **kwargs,
 ):
-    """Runs and benchmarks the persistent batched dense block-scaled GEMM with SwiGLU fusion.
+    """Runs and benchmarks the persistent batched dense block-scaled GEMM with activation fusion.
 
     This function prepares input tensors, launches the kernel, optionally
     validates the results against a reference implementation, and measures
     performance.
 
-    N is the full B matrix width. The output C tensor has N/2 columns
-    after the SwiGLU fusion (interleaved up/gate pairs are combined).
+    N is the full B matrix width. For the gated SwiGLU activation the output C
+    tensor has N/2 columns (interleaved up/gate pairs are combined). For the
+    non-gated GELU activation the output C tensor keeps the full N columns,
+    with an optional per-N bias added before the activation.
 
     Args:
         mnkl (Tuple[int, int, int, int]): The dimensions (M, N, K, L) of the
@@ -159,6 +188,11 @@ def run(
             ensure a cold L2 cache. Defaults to False.
         use_cupti (bool, optional): If True, uses CUPTI to measure execution time.
             Defaults to False.
+        activation (str, optional): Fused activation, "swiglu" (gated, output
+            N/2) or "gelu" (non-gated tanh-approx GELU, output N). Defaults to
+            "swiglu".
+        use_bias (bool, optional): If True (only meaningful for "gelu"), adds a
+            random per-N bias before the activation. Defaults to False.
         **kwargs: Additional keyword arguments.
 
     Returns:
@@ -168,7 +202,9 @@ def run(
         RuntimeError: If no CUDA-capable GPU is available.
         TypeError: If the configuration is not supported by the kernel.
     """
-    print("Running Sm100 Persistent Dense BlockScaled GEMM SwiGLU Fusion test with:")
+    print("Running Sm100 Persistent Dense BlockScaled GEMM Activation Fusion test with:")
+    print(f"Activation: {activation}")
+    print(f"Use bias: {use_bias}")
     print(f"mnkl: {mnkl}")
     print(f"AB dtype: {ab_dtype}, SF dtype: {sf_dtype}, SF Vec size: {sf_vec_size}")
     print(f"C dtype: {c_dtype}")
@@ -185,15 +221,19 @@ def run(
 
     # Unpack parameters
     m, n, k, batch = mnkl
-    n_after_swiglu = n // 2
+    # Gated SwiGLU halves the output width; non-gated GELU keeps the full N.
+    n_out = (n // 2) if activation == "swiglu" else n
+    # Alias kept so the SwiGLU reference path below stays byte-identical.
+    n_after_swiglu = n_out
 
-    assert n % 2 == 0, f"N must be even for SwiGLU fusion, got {n}"
+    if activation == "swiglu":
+        assert n % 2 == 0, f"N must be even for SwiGLU fusion, got {n}"
 
     # If c_dtype is Float4E2M1FN, SFC will be generated
     generate_sfc = c_dtype == cutlass.Float4E2M1FN
 
     # Skip unsupported testcase
-    if not Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel.can_implement(
+    if not Sm100BlockScaledPersistentDenseGemmActFusionKernel.can_implement(
         ab_dtype,
         sf_dtype,
         sf_vec_size,
@@ -387,13 +427,26 @@ def run(
     alpha_torch = torch.tensor([alpha_value], dtype=torch.float32).cuda()
     alpha = from_dlpack(alpha_torch)
 
+    # Create optional per-N bias for the non-gated GELU path. The kernel's
+    # __call__ takes a (m, n_out, l) cute.Tensor with M-stride 0 (broadcast over
+    # rows). We build it from a torch [n_out] vector expanded to (m, n_out, l)
+    # with stride (0, 1, 0) -- the same broadcast layout wrapper() constructs.
+    bias_n_torch = None
+    bias_tensor = None
+    use_gelu_bias = activation == "gelu" and use_bias
+    if use_gelu_bias:
+        bias_n_torch = (torch.randn(n_out, dtype=torch.float32) * 0.1).cuda()
+        bias_bcast = bias_n_torch.view(1, n_out, 1).expand(m, n_out, batch)
+        bias_tensor = from_dlpack(bias_bcast, assumed_align=16)
+
     # Configure gemm kernel
-    gemm = Sm100BlockScaledPersistentDenseGemmSwigluFusionKernel(
+    gemm = Sm100BlockScaledPersistentDenseGemmActFusionKernel(
         sf_vec_size,
         mma_tiler_mn,
         cluster_shape_mn,
         vectorized_f32,
         use_prefetch,
+        activation_type=(ActivationType.Gelu if activation == "gelu" else ActivationType.Swiglu),
     )
 
     # Compute max active clusters on current device
@@ -405,7 +458,10 @@ def run(
     # Initialize Stream
     current_stream = cutlass_torch.default_stream()
 
-    # Compile gemm kernel
+    # Compile gemm kernel. bias_tensor is the trailing optional __call__ arg;
+    # it is only supplied for the non-gated GELU + bias path, so the SwiGLU
+    # (and bias-free GELU) compile signatures stay unchanged.
+    compile_bias_kwargs = {"bias_tensor": bias_tensor} if use_gelu_bias else {}
     if generate_sfc:
         compiled_gemm = cute.compile(
             gemm,
@@ -420,6 +476,7 @@ def run(
             lambda x: x,  # epilogue_op (default)
             sfc_tensor,
             norm_const_tensor,
+            **compile_bias_kwargs,
             options="--opt-level 2",
         )
     else:
@@ -433,12 +490,15 @@ def run(
             alpha,
             max_active_clusters,
             current_stream,
+            **compile_bias_kwargs,
             options="--opt-level 2",
         )
 
     # Compute reference result
     if not skip_ref_check:
-        # Execute kernel once for reference checking
+        # Execute kernel once for reference checking. bias_tensor is the trailing
+        # optional arg, supplied only for the non-gated GELU + bias path.
+        run_bias_kwargs = {"bias_tensor": bias_tensor} if use_gelu_bias else {}
         if generate_sfc:
             compiled_gemm(
                 a_tensor,
@@ -450,6 +510,7 @@ def run(
                 current_stream,
                 sfc_tensor,
                 norm_const_tensor,
+                **run_bias_kwargs,
             )
         else:
             compiled_gemm(
@@ -460,6 +521,7 @@ def run(
                 c_tensor,
                 alpha,
                 current_stream,
+                **run_bias_kwargs,
             )
 
         torch.cuda.synchronize()
@@ -471,21 +533,37 @@ def run(
         ref = torch.einsum("mkl,nkl->mnl", res_a, res_b)
         # alpha = 1.0, so no scaling needed for ref
 
-        # Apply SwiGLU: split N into interleaved up/gate blocks of 64 columns
-        # (matching epi_tile N=64), compute output = up * silu(gate)
-        group = 64
-        assert n % group == 0, f"N ({n}) must be divisible by {group} for SwiGLU block grouping"
-        num_blocks = n // group
-        assert num_blocks % 2 == 0, "Number of blocks must be even (pairs of up/gate)"
+        # Apply the fused activation, producing ref_after_swiglu with n_out
+        # columns (the variable name is shared by both activations so the
+        # downstream comparison code is identical).
+        if activation == "swiglu":
+            # Apply SwiGLU: split N into interleaved up/gate blocks of 64 columns
+            # (matching epi_tile N=64), compute output = up * silu(gate)
+            group = 64
+            assert n % group == 0, f"N ({n}) must be divisible by {group} for SwiGLU block grouping"
+            num_blocks = n // group
+            assert num_blocks % 2 == 0, "Number of blocks must be even (pairs of up/gate)"
 
-        cols = torch.arange(n, device=ref.device, dtype=torch.long)
-        block_cols = cols.view(num_blocks, group)
-        # Even blocks (0, 2, 4, ...) are 'up', odd blocks (1, 3, 5, ...) are 'gate'
-        up_idx = block_cols[0::2].reshape(-1)
-        gate_idx = block_cols[1::2].reshape(-1)
-        ref_up = ref.index_select(1, up_idx)
-        ref_gate = ref.index_select(1, gate_idx)
-        ref_after_swiglu = ref_up * (ref_gate * torch.sigmoid(ref_gate))
+            cols = torch.arange(n, device=ref.device, dtype=torch.long)
+            block_cols = cols.view(num_blocks, group)
+            # Even blocks (0, 2, 4, ...) are 'up', odd blocks (1, 3, 5, ...) are 'gate'
+            up_idx = block_cols[0::2].reshape(-1)
+            gate_idx = block_cols[1::2].reshape(-1)
+            ref_up = ref.index_select(1, up_idx)
+            ref_gate = ref.index_select(1, gate_idx)
+            ref_after_swiglu = ref_up * (ref_gate * torch.sigmoid(ref_gate))
+        else:
+            # Non-gated tanh-approx GELU on full N: x = alpha * acc + bias
+            # (bias per-N, broadcast over M), then gelu_tanh(x).
+            x = alpha_value * ref
+            if use_gelu_bias:
+                # bias_n_torch is [n_out] (built on CUDA for the kernel); the
+                # reference GEMM `ref` is on CPU, so align the device before add.
+                # Broadcast over M (dim 0) and L (dim 2).
+                x = x + bias_n_torch.view(1, n_out, 1).to(x.device)
+            ref_after_swiglu = (
+                0.5 * x * (1.0 + torch.tanh(math.sqrt(2.0 / math.pi) * (x + 0.044715 * x**3)))
+            )
 
         # Convert kernel output C back to f32 for comparison
         res = c_ref.cuda()
@@ -620,6 +698,10 @@ def run(
         _, sfa_tensor, _ = create_scale_factor_tensor(batch, m, k, sf_vec_size, sf_dtype)
         _, sfb_tensor, _ = create_scale_factor_tensor(batch, n, k, sf_vec_size, sf_dtype)
 
+        # bias_tensor (read-only broadcast view) is the trailing runtime arg;
+        # appended only for the non-gated GELU + bias path so the bias-free
+        # JitArguments signatures stay unchanged.
+        extra_bias = (bias_tensor,) if use_gelu_bias else ()
         if generate_sfc:
             _, sfc_tensor, _ = create_scale_factor_tensor(
                 batch, m, n_after_swiglu, sf_vec_size, sf_dtype
@@ -636,6 +718,7 @@ def run(
                 current_stream,
                 sfc_tensor,
                 norm_const_tensor,
+                *extra_bias,
             )
         else:
             return cute.testing.JitArguments(
@@ -646,6 +729,7 @@ def run(
                 c_tensor,
                 alpha,
                 current_stream,
+                *extra_bias,
             )
 
     workspace_count = 1
@@ -710,6 +794,21 @@ if __name__ == "__main__":
         type=parse_comma_separated_ints,
         default=(1, 1),
         help="Cluster shape (comma-separated)",
+    )
+    parser.add_argument(
+        "--activation",
+        choices=["swiglu", "gelu"],
+        type=str,
+        default="swiglu",
+        help="Fused activation: 'swiglu' (gated, output N/2) or 'gelu' "
+        "(non-gated tanh-approx GELU, output N).",
+    )
+    parser.add_argument(
+        "--bias",
+        action="store_true",
+        default=False,
+        help="Add a random per-N bias before the activation (only meaningful "
+        "for --activation gelu).",
     )
     parser.add_argument("--ab_dtype", type=cutlass.dtype, default=cutlass.Float4E2M1FN)
     parser.add_argument("--sf_dtype", type=cutlass.dtype, default=cutlass.Float8E4M3FN)
@@ -788,6 +887,8 @@ if __name__ == "__main__":
         args.skip_ref_check,
         args.use_cold_l2,
         args.use_cupti,
+        activation=args.activation,
+        use_bias=args.bias,
     )
     if args.print_duration:
         print(f"Execution time: {exec_time:.2f} us")

--- a/tests/unittest/_torch/thop/parallel/test_dense_gemm_act_fusion.py
+++ b/tests/unittest/_torch/thop/parallel/test_dense_gemm_act_fusion.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the dense NVFP4 GEMM + activation epilogue-fusion kernels.
+
+Covers the dense (non-MoE) CuteDSL act-fusion ops, which share one kernel
+(``dense_blockscaled_gemm_act_fusion.py``) dispatched on the activation type:
+
+  GELU(tanh)  (MLP, non-gated, optional per-N bias):
+    - ``cute_dsl_nvfp4_dense_gemm_gelu_blackwell``         (bf16 out)
+    - ``cute_dsl_nvfp4_dense_gemm_gelu_fp4out_blackwell``  (fp4 out + SFC)
+  SwiGLU      (GatedMLP, gated, bias-free):
+    - ``cute_dsl_nvfp4_dense_gemm_swiglu_blackwell``        (bf16 out)
+    - ``cute_dsl_nvfp4_dense_gemm_swiglu_fp4out_blackwell`` (fp4 out + SFC)
+
+The GELU kernel computes ``gelu_tanh(alpha * (A @ B.T) + bias)``; SwiGLU computes
+``up * silu(gate)`` over ``alpha * (A @ B.T)`` (gate/up interleaved at group 64).
+The fp4-out variants additionally quantize to NVFP4 with scale-factor generation.
+The reference uses ``nvfp4_gemm`` (fp4-precision GEMM matching the kernel operands)
+followed by the activation. fp4-out cases use M >= 128 (the kernel's _FP4OUT_MIN_M
+floor); the small-M (m=64) bf16-out cases exercise the path the MLP/GatedMLP
+fall back to below that floor.
+"""
+
+import pytest
+import torch
+import torch.nn.functional as F
+from utils.util import skip_pre_blackwell
+
+from tensorrt_llm._torch.modules.fused_moe.quantization import interleave_linear_and_gate
+from tensorrt_llm._torch.utils import swizzle_sf, unswizzle_sf
+from tensorrt_llm.math_utils import pad_up
+
+FP4_E2M1_MAX = 6.0
+FP8_E4M3_MAX = 448.0
+SF_VEC = 16
+
+
+def _quantize_nvfp4(x_bf16: torch.Tensor):
+    """Quantize [., K] bf16 -> (fp4 packed, swizzled SF, global_sf scalar)."""
+    global_sf = x_bf16.abs().max().float() / (FP8_E4M3_MAX * FP4_E2M1_MAX)
+    fp4, sf = torch.ops.trtllm.fp4_quantize(x_bf16, 1.0 / global_sf, SF_VEC, False, True)
+    return fp4, sf, global_sf
+
+
+def _gemm_ref(a, b, a_sf, b_sf, alpha):
+    """alpha * (A @ B.T) in fp4 precision (bf16 out), full N."""
+    return torch.ops.trtllm.nvfp4_gemm(
+        a.view(torch.uint8), b.view(torch.uint8), a_sf, b_sf, alpha, torch.bfloat16
+    ).float()
+
+
+def _nibble_match(c, ref_fp4):
+    """Fraction of fp4 nibbles within +/-1 (two nibbles per uint8 byte)."""
+    c_u8 = c.view(torch.uint8).flatten().int()
+    r_u8 = ref_fp4.view(torch.uint8).flatten().int()
+    lo = ((c_u8 & 0xF) - (r_u8 & 0xF)).abs()
+    hi = ((c_u8 >> 4) - (r_u8 >> 4)).abs()
+    return ((lo <= 1).sum().item() + (hi <= 1).sum().item()) / (c_u8.numel() * 2)
+
+
+def _sf_match(c_sf, ref_sf, m, n):
+    """Fraction of scale factors within +/-1 on the valid (first m) rows."""
+    c_un = unswizzle_sf(c_sf.view(-1), pad_up(m, 128), n)[:m, :].view(torch.uint8)
+    r_un = unswizzle_sf(ref_sf.view(-1), pad_up(m, 128), n)[:m, :].view(torch.uint8)
+    return ((c_un.int() - r_un.int()).abs() <= 1).sum().item() / c_un.numel()
+
+
+# ---------------------------------------------------------------------------
+# GELU (non-gated, optional bias)
+# ---------------------------------------------------------------------------
+@skip_pre_blackwell
+@pytest.mark.parametrize("use_bias", [False, True])
+@pytest.mark.parametrize("m, k, n", [(64, 256, 512), (128, 256, 512), (256, 512, 2048)])
+def test_dense_gemm_gelu_bf16out(m: int, k: int, n: int, use_bias: bool):
+    """bf16-out fused up-GEMM + bias + GELU(tanh). m=64 < _FP4OUT_MIN_M (fallback)."""
+    torch.manual_seed(0)
+    a_bf16 = torch.randint(-5, 5, (m, k), dtype=torch.int32, device="cuda").to(torch.bfloat16)
+    b_bf16 = torch.randint(-5, 5, (n, k), dtype=torch.int32, device="cuda").to(torch.bfloat16)
+    a, a_sf, a_gsf = _quantize_nvfp4(a_bf16)
+    b, b_sf, b_gsf = _quantize_nvfp4(b_bf16)
+    alpha = (a_gsf * b_gsf).view(1)
+    bias = (torch.randn(n, dtype=torch.bfloat16, device="cuda") * 0.1) if use_bias else None
+
+    gemm = _gemm_ref(a, b, a_sf, b_sf, alpha)
+    ref = F.gelu(gemm + (bias.float() if bias is not None else 0.0), approximate="tanh")
+
+    c = torch.ops.trtllm.cute_dsl_nvfp4_dense_gemm_gelu_blackwell(
+        a, b, a_sf, b_sf, alpha, torch.bfloat16, bias
+    )[..., :n]
+
+    assert c.shape == (m, n) and c.dtype == torch.bfloat16
+    ratio = torch.isclose(c.float(), ref, rtol=0.1, atol=0.05).float().mean().item()
+    assert ratio > 0.90, f"bf16-out GELU match {ratio * 100:.2f}% < 90%"
+
+
+@skip_pre_blackwell
+@pytest.mark.parametrize("use_bias", [False, True])
+@pytest.mark.parametrize("m, k, n", [(128, 256, 512), (256, 512, 2048)])
+def test_dense_gemm_gelu_fp4out(m: int, k: int, n: int, use_bias: bool):
+    """fp4-out fused up-GEMM + bias + GELU(tanh) + NVFP4 quant (m >= _FP4OUT_MIN_M)."""
+    torch.manual_seed(0)
+    a_bf16 = torch.randint(-5, 5, (m, k), dtype=torch.int32, device="cuda").to(torch.bfloat16)
+    b_bf16 = torch.randint(-5, 5, (n, k), dtype=torch.int32, device="cuda").to(torch.bfloat16)
+    a, a_sf, a_gsf = _quantize_nvfp4(a_bf16)
+    b, b_sf, b_gsf = _quantize_nvfp4(b_bf16)
+    alpha = (a_gsf * b_gsf).view(1)
+    bias = (torch.randn(n, dtype=torch.bfloat16, device="cuda") * 0.1) if use_bias else None
+
+    gemm = _gemm_ref(a, b, a_sf, b_sf, alpha)
+    ref = F.gelu(gemm + (bias.float() if bias is not None else 0.0), approximate="tanh").to(
+        torch.bfloat16
+    )
+    norm_const = (1.0 / (ref.abs().max().float() / (FP8_E4M3_MAX * FP4_E2M1_MAX))).view(1)
+    ref_fp4, ref_sf = torch.ops.trtllm.fp4_quantize(ref, norm_const, SF_VEC, False, True)
+
+    c, c_sf = torch.ops.trtllm.cute_dsl_nvfp4_dense_gemm_gelu_fp4out_blackwell(
+        a, b, a_sf, b_sf, alpha, norm_const, bias
+    )
+
+    assert c.shape == (m, n // 2)
+    assert _nibble_match(c, ref_fp4) > 0.95, "fp4-out GELU nibble match < 95%"
+    assert _sf_match(c_sf, ref_sf, m, n) > 0.95, "fp4-out GELU SF match < 95%"
+
+
+# ---------------------------------------------------------------------------
+# SwiGLU (gated, bias-free). Weight is [2*inter, k] (linear||gate); the kernel
+# takes it gate/up-interleaved at group 64 (as GatedMLP stores it), the
+# reference uses the non-interleaved layout and chunks it.
+# ---------------------------------------------------------------------------
+def _swiglu_weight(inter: int, k: int):
+    """Build [2*inter, k] NVFP4 weight; return (non-interleaved, interleaved) forms."""
+    w = torch.randint(-5, 5, (2 * inter, k), dtype=torch.int32, device="cuda").to(torch.bfloat16)
+    b, b_sf, b_gsf = _quantize_nvfp4(w)
+    n2 = 2 * inter
+    b_il = interleave_linear_and_gate(b.view(torch.uint8), group_size=64, dim=0).view(b.dtype)
+    b_sf_un = unswizzle_sf(b_sf, n2, k)
+    b_sf_il = swizzle_sf(interleave_linear_and_gate(b_sf_un, group_size=64, dim=0), n2, k)
+    return b, b_sf, b_il, b_sf_il, b_gsf
+
+
+def _swiglu_ref(a, b, a_sf, b_sf, alpha):
+    """up * silu(gate) over alpha*(A@B.T); [linear, gate] = chunk(gemm, 2)."""
+    gemm = _gemm_ref(a, b, a_sf, b_sf, alpha)
+    up, gate = gemm.chunk(2, dim=-1)
+    return up * F.silu(gate)
+
+
+@skip_pre_blackwell
+@pytest.mark.parametrize("m, k, inter", [(64, 256, 512), (128, 256, 512), (256, 512, 1024)])
+def test_dense_gemm_swiglu_bf16out(m: int, k: int, inter: int):
+    """bf16-out fused gate-up GEMM + SwiGLU. m=64 < _FP4OUT_MIN_M (fallback)."""
+    torch.manual_seed(0)
+    a_bf16 = torch.randint(-5, 5, (m, k), dtype=torch.int32, device="cuda").to(torch.bfloat16)
+    a, a_sf, a_gsf = _quantize_nvfp4(a_bf16)
+    b, b_sf, b_il, b_sf_il, b_gsf = _swiglu_weight(inter, k)
+    alpha = (a_gsf * b_gsf).view(1)
+
+    ref = _swiglu_ref(a, b, a_sf, b_sf, alpha)
+
+    c = torch.ops.trtllm.cute_dsl_nvfp4_dense_gemm_swiglu_blackwell(
+        a, b_il, a_sf, b_sf_il, alpha, torch.bfloat16
+    )[..., :inter]
+
+    assert c.shape == (m, inter) and c.dtype == torch.bfloat16
+    ratio = torch.isclose(c.float(), ref, rtol=0.1, atol=0.05).float().mean().item()
+    assert ratio > 0.90, f"bf16-out SwiGLU match {ratio * 100:.2f}% < 90%"
+
+
+@skip_pre_blackwell
+@pytest.mark.parametrize("m, k, inter", [(128, 256, 512), (256, 512, 1024)])
+def test_dense_gemm_swiglu_fp4out(m: int, k: int, inter: int):
+    """fp4-out fused gate-up GEMM + SwiGLU + NVFP4 quant (m >= _FP4OUT_MIN_M)."""
+    torch.manual_seed(0)
+    a_bf16 = torch.randint(-5, 5, (m, k), dtype=torch.int32, device="cuda").to(torch.bfloat16)
+    a, a_sf, a_gsf = _quantize_nvfp4(a_bf16)
+    b, b_sf, b_il, b_sf_il, b_gsf = _swiglu_weight(inter, k)
+    alpha = (a_gsf * b_gsf).view(1)
+
+    ref = _swiglu_ref(a, b, a_sf, b_sf, alpha).to(torch.bfloat16)
+    norm_const = (1.0 / (ref.abs().max().float() / (FP8_E4M3_MAX * FP4_E2M1_MAX))).view(1)
+    ref_fp4, ref_sf = torch.ops.trtllm.fp4_quantize(ref, norm_const, SF_VEC, False, True)
+
+    c, c_sf = torch.ops.trtllm.cute_dsl_nvfp4_dense_gemm_swiglu_fp4out_blackwell(
+        a, b_il, a_sf, b_sf_il, alpha, norm_const
+    )
+
+    assert c.shape == (m, inter // 2)
+    assert _nibble_match(c, ref_fp4) > 0.95, "fp4-out SwiGLU nibble match < 95%"
+    assert _sf_match(c_sf, ref_sf, m, inter) > 0.95, "fp4-out SwiGLU SF match < 95%"
+
+
+# ---------------------------------------------------------------------------
+# fp4-out fallback / switching condition (module-level dispatch in MLP.forward).
+# fp4-out is selected only when m >= _FP4OUT_MIN_M; below it the (still-fused)
+# bf16-out path is used (the kernel's SFC epilogue is unsafe on a partial tile).
+# This is HW-independent (no kernel is launched), so it is not Blackwell-gated.
+# ---------------------------------------------------------------------------
+def test_mlp_fp4out_min_m_switch():
+    """MLP.forward picks fp4-out only at m >= _FP4OUT_MIN_M, else bf16-out fallback."""
+    from tensorrt_llm._torch.modules.mlp import MLP
+    from tensorrt_llm._torch.utils import gelu_tanh
+
+    mlp = MLP(hidden_size=64, intermediate_size=128, bias=True, activation=gelu_tanh)
+    mlp._use_fused_gelu_fp4out = True  # force the fp4-out-eligible branch
+    seen = {}
+
+    def _spy(x, fp4_out=False):
+        seen["fp4_out"] = fp4_out
+        return torch.zeros(MLP._token_count(x), mlp.intermediate_size)
+
+    mlp._fused_gelu = _spy
+    mlp.down_proj = torch.nn.Identity()  # skip the real down GEMM
+
+    assert MLP._FP4OUT_MIN_M == 128
+    for m, expected in [(64, False), (127, False), (128, True), (256, True)]:
+        mlp.forward(torch.randn(m, 64))
+        assert seen["fp4_out"] == expected, (
+            f"m={m}: expected fp4_out={expected}, got {seen['fp4_out']}"
+        )

--- a/tests/unittest/_torch/thop/parallel/test_dense_gemm_act_fusion.py
+++ b/tests/unittest/_torch/thop/parallel/test_dense_gemm_act_fusion.py
@@ -197,11 +197,23 @@ def test_dense_gemm_swiglu_fp4out(m: int, k: int, inter: int):
 # ---------------------------------------------------------------------------
 def test_mlp_fp4out_min_m_switch():
     """MLP.forward picks fp4-out only at m >= _FP4OUT_MIN_M, else bf16-out fallback."""
+    import types
+
     from tensorrt_llm._torch.modules.mlp import MLP
     from tensorrt_llm._torch.utils import gelu_tanh
 
     mlp = MLP(hidden_size=64, intermediate_size=128, bias=True, activation=gelu_tanh)
-    mlp._use_fused_gelu_fp4out = True  # force the fp4-out-eligible branch
+    # forward() reaches the fp4-out vs bf16-out switch only when the static
+    # eligibility flags AND a runtime NVFP4 quant_method (exposing _input_prepare)
+    # are present on up/down. Force all of that here; _fused_gelu is stubbed, so no
+    # kernel runs and the test stays HW-independent (hence no skip_pre_blackwell).
+    fake_qm = types.SimpleNamespace(_input_prepare=lambda *a, **k: None)
+    mlp._use_fused_gelu = True
+    mlp._use_fused_gelu_fp4out = True
+    mlp.up_proj.quant_method = fake_qm
+    down = torch.nn.Identity()  # skip the real down GEMM
+    down.quant_method = fake_qm
+    mlp.down_proj = down
     seen = {}
 
     def _spy(x, fp4_out=False):
@@ -209,7 +221,6 @@ def test_mlp_fp4out_min_m_switch():
         return torch.zeros(MLP._token_count(x), mlp.intermediate_size)
 
     mlp._fused_gelu = _spy
-    mlp.down_proj = torch.nn.Identity()  # skip the real down GEMM
 
     assert MLP._FP4OUT_MIN_M == 128
     for m, expected in [(64, False), (127, False), (128, True), (256, True)]:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GELU activation support for fused GEMM operations on Blackwell GPUs.
  * Introduced optional bias parameters for GELU fusion paths.
  * Extended MLP module with fused GELU execution for improved performance.
  * Added support for pre-quantized tensor inputs in linear operations.

* **Tests**
  * Updated test suite to validate both SwiGLU and GELU activation variants with optional bias configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

LTX-2's FFN runs `up_proj GEMM → bias → GELU(tanh) → down_proj` in NVFP4. Today the bias + GELU(tanh) + NVFP4 re-quantization between `up_proj` and `down_proj` run as a standalone `triton_..._gelu_..._fp4_quantize` kernel after the up-GEMM. This PR folds the bias add, GELU(tanh), and NVFP4 output quantization into the **epilogue** of the Blackwell (SM100) CuTe DSL block-scaled dense up-GEMM, eliminating that standalone kernel. The dispatch mirrors `GatedMLP`'s SwiGLU fp4-out fusion and lives in the shared `MLP` module, so any plain-`MLP` + GELU(tanh) + NVFP4 model can opt in by using the named `gelu_tanh` activation — this PR wires in both **LTX-2** and **Wan 2.2**.

## Changes

- `cute_dsl_kernels/blackwell/dense_blockscaled_gemm_act_fusion.py` (renamed from `..._swiglu_fusion.py`): generalize the dense fusion kernel to gated|non-gated via `activation_type`; add a GELU(tanh) epilogue with optional per-N bias. The activation is dispatched on `activation_type`; the structural `is_gated` only governs subtile-load / output width.
- `custom_ops/cute_dsl_custom_ops.py`: new ops `cute_dsl_nvfp4_dense_gemm_gelu_fp4out_blackwell` (fp4 out + SFC) and `cute_dsl_nvfp4_dense_gemm_gelu_blackwell` (bf16 out), both with optional bias.
- `modules/mlp.py`: init-time eligibility flags (`_use_fused_gelu` / `_use_fused_gelu_fp4out`, computed once in `create_weights()` like `_use_fused_relu2_quant`) and a 3-tier forward (fp4-out / bf16-out fused / eager) mirroring `GatedMLP`.
- `modules/linear.py`: NVFP4 `apply()` handles a 3D `Fp4QuantizedTensor` input (flatten/unflatten) so the fused fp4-out activation feeds `down_proj` directly (aligned with #14773).
- `_torch/utils.py` + `visual_gen/models/ltx2/transformer_ltx2.py` + `visual_gen/models/wan/transformer_wan.py`: pass the shared named `gelu_tanh` (instead of a `lambda`) so the `MLP` can identity-detect and fuse — wires the fusion into both LTX-2 and Wan 2.2.

Note: the fp4-out path requires a static `down_proj.input_scale` (the SFC norm-const, known before the GEMM); dynamic NVFP4 cannot quantize in a single-pass epilogue and falls back to the bf16-out fused tier.

## Test Coverage

Kernel numerical test — `tests/scripts/cute_dsl_kernels/run_dense_blockscaled_gemm_act_fusion.py` extended with `--activation gelu` / `--bias`: GELU × {bf16, fp4-out+SFC} × {bias, no-bias} plus SwiGLU × {bf16, fp4-out} regressions all pass the reference check on B200.

GPU-pure kernel A/B (CUDA-graph capture+replay) of the FFN-up (up-GEMM + GELU + fp4-quant), d=2048 / inter=8192, NVFP4, B200:

| M (tokens) | torch.compile | fused (this PR) | speedup |
|---|---|---|---|
| 4096  | 85.67 µs  | 37.32 µs  | 2.30× |
| 15360 | 329.47 µs | 149.26 µs | 2.21× |
| 30720 | 650.37 µs | 303.81 µs | 2.14× |

LTX-2 NVFP4 single-stage e2e (768×1280, 121 frames, B200), fuse off vs on via the same build, valid (finite) video both sides:

| | off | on | Δ |
|---|---|---|---|
| 40-step e2e | 18.99 s | 18.05 s | −0.93 s (−4.9%) |

nsys step-4 transformer GPU-busy drops 374.2 ms → 351.1 ms (−23.1 ms/step, −6.2%): the standalone `triton_..._gelu_..._fp4_quantize` kernel is eliminated and replaced by the fused CuteDSL kernel. −23.1 ms/step × 40 ≈ −0.93 s cross-validates the e2e delta.

Wan 2.2 T2V-A14B static-NVFP4 e2e (720×1280, 81 frames, 10 steps, torch.compile on / cuda_graph off, B200), fuse off vs on, valid (finite) video both sides (fixed −1 GEMM tactic on both sides so the off-vs-on delta is attributable to the fusion alone):

| | off | on | Δ |
|---|---|---|---|
| 10-step e2e | 99.92 s | 98.71 s | −1.20 s (−1.20%) |

nsys step-4 GPU-busy drops 9553 ms → 9432 ms (−122 ms/step, −1.27%, consistent with the e2e delta): the standalone up_proj GEMM + `triton_..._gelu_..._fp4_quantize` + separate quant are eliminated and replaced by the single fused CuteDSL op (FFN-up −136 ms/step). The relative % is smaller than LTX-2 because the Wan step at this resolution is ~75% attention (cuDNN SDPA), which bounds the e2e fraction the FFN can move.

## Output Quality (LPIPS)

LTX-2 output-quality check (LPIPS, fusion off vs on) — single-stage 768×1280, 121 frames, 40 steps, guidance 4.0, static NVFP4, torch.compile + cuda_graph off, eager (pre-PR) vs fused: **mean LPIPS 0.108** (per-frame 0.095–0.140). Per-op the fused kernel is near-exact (bf16-out cos ≈ 1.0; fp4-out 100% within ±1, ~99.4% bit-exact), so the 0.108 is chaotic diffusion-trajectory divergence over 40 CFG steps — the montage confirms identical scene / composition / quality, not a regression.

![LTX-2 LPIPS off vs on (mean 0.108)](https://raw.githubusercontent.com/luyiyun1021/TensorRT-LLM/lpips-assets/lpips121_ltx2_off_vs_on.png)

## PR Checklist

- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md).
- Test cases are provided for new code paths.
- Any new dependencies have been scanned for license and vulnerabilities.
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes.
- Documentation updated as needed.
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if significant design change.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


