### PR TITLE
[None][fix] Fall back to NVLink P2P when NVLS fabric is unprovisioned

### DIFF
--- a/cpp/include/tensorrt_llm/runtime/ipcNvlsMemory.h
+++ b/cpp/include/tensorrt_llm/runtime/ipcNvlsMemory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,12 @@ struct IpcNvlsHandle
 
 void MPI_group_barrier(std::set<int> ranks);
 
+//! \brief Whether NVLS (NVLink SHARP) multicast can actually be used on this
+//! node. Checks the static capability (CUDA driver >= 12010 and
+//! CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED) and then confirms the fabric/IMEX
+//! plane can really bind multicast memory -- the static attribute alone is a
+//! false positive when nvidia-imex is not provisioned. Returns true only when
+//! multicast is both supported and usable. The (heavy) result is cached.
 bool ipcNvlsSupported();
 
 IpcNvlsHandle* ipcNvlsAllocate(size_t size, std::set<int> ranks);

--- a/cpp/tensorrt_llm/common/opUtils.cpp
+++ b/cpp/tensorrt_llm/common/opUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@
 
 #include "tensorrt_llm/common/opUtils.h"
 #include "tensorrt_llm/common/ncclUtils.h"
+#include "tensorrt_llm/runtime/ipcNvlsMemory.h"
 #include "tensorrt_llm/runtime/utils/mpiTags.h"
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
 
@@ -160,6 +161,13 @@ std::shared_ptr<ncclComm_t> getComm(std::set<int> const& group)
 #else
     setenv("NCCL_RUNTIME_CONNECT", "0", 0);
     setenv("NCCL_GRAPH_REGISTER", "0", 0);
+    // NCCL aborts during init if it tries NVLS multicast but the fabric/IMEX
+    // plane can't bind it. Disable NVLS when it isn't actually usable so NCCL
+    // falls back to NVLink P2P. No-overwrite preserves an explicit user setting.
+    if (!tensorrt_llm::runtime::ipcNvlsSupported())
+    {
+        setenv("NCCL_NVLS_ENABLE", "0", 0);
+    }
 #endif // _WIN32
     NCCLCHECK_THROW(ncclCommInitRank(ncclComm.get(), group.size(), id, groupRank));
     commMap[group] = ncclComm;

--- a/cpp/tensorrt_llm/runtime/ipcNvlsMemory.cu
+++ b/cpp/tensorrt_llm/runtime/ipcNvlsMemory.cu
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -144,6 +144,108 @@ public:
 private:
     MPI_Comm mGroupComm;
 };
+
+// Returns CU_MEM_HANDLE_TYPE_FABRIC when fabric-handle memory can actually be
+// allocated and exported on the current device (i.e. the fabric/IMEX plane is
+// provisioned), else CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR. Used both to pick
+// the NVLS allocation handle type and by ipcNvlsSupported() to gauge usability.
+static CUmemAllocationHandleType getMemHandleType()
+{
+    int device_id;
+    TLLM_CUDA_CHECK(cudaGetDevice(&device_id));
+
+    // Check if fabric handle support is available.
+    int fabric_supported = 0;
+    CUCHECK(cuDeviceGetAttribute(&fabric_supported, CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED, device_id));
+    if (!fabric_supported)
+    {
+        TLLM_LOG_TRACE("checking fabric support... CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED not supported.");
+        return CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+    }
+
+    auto nvml = tensorrt_llm::common::NVMLWrapper::getInstance();
+    tensorrt_llm::common::NvmlManager nvmlManager;
+
+    nvmlDevice_t nvml_device;
+    NVMLCHECK(nvml->nvmlDeviceGetHandleByIndex(device_id, &nvml_device));
+
+    nvmlGpuFabricState_t fabric_state;
+    nvmlReturn_t fabric_status;
+    if (nvml->hasGpuFabricInfoV())
+    {
+        nvmlGpuFabricInfoV_t fabric_info_v;
+        memset(&fabric_info_v, 0, sizeof(fabric_info_v));
+        fabric_info_v.version = nvmlGpuFabricInfo_v2;
+        NVMLCHECK(nvml->nvmlDeviceGetGpuFabricInfoV(nvml_device, &fabric_info_v));
+        fabric_state = fabric_info_v.state;
+        fabric_status = fabric_info_v.status;
+    }
+    else if (nvml->hasGpuFabricInfo())
+    {
+        nvmlGpuFabricInfo_t fabric_info;
+        NVMLCHECK(nvml->nvmlDeviceGetGpuFabricInfo(nvml_device, &fabric_info));
+        fabric_state = fabric_info.state;
+        fabric_status = fabric_info.status;
+    }
+    else
+    {
+        TLLM_LOG_TRACE("checking fabric support... NVML fabric info APIs not available.");
+        return CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+    }
+
+    // Check if the fabric is fully initialized.
+    if (fabric_state != NVML_GPU_FABRIC_STATE_COMPLETED || fabric_status != NVML_SUCCESS)
+    {
+        TLLM_LOG_TRACE("checking fabric support... fabric state is NOT COMPLETE: state=%u status=%u.", fabric_state,
+            fabric_status);
+        return CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+    }
+
+    // Check that fabric handles can be created.
+    CUmemAllocationProp prop;
+    memset(&prop, 0, sizeof(CUmemAllocationProp));
+    prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+    prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    prop.location.id = device_id;
+    prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+
+    size_t alloc_size = 1024; // anything > 0
+    size_t min_gran = 0;
+    CUCHECK(cuMemGetAllocationGranularity(&min_gran, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM));
+    alloc_size = ROUND_UP(alloc_size, min_gran);
+
+    CUmemGenericAllocationHandle handle;
+    CUresult err = cuMemCreate(&handle, alloc_size, &prop, 0);
+    if (err == CUDA_ERROR_NOT_PERMITTED || err == CUDA_ERROR_NOT_SUPPORTED)
+    {
+        TLLM_LOG_TRACE("checking fabric support... cuMemCreate failed with not %s.",
+            err == CUDA_ERROR_NOT_PERMITTED ? "permitted" : "supported");
+        return CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+    }
+    else
+    {
+        CUCHECK(err);
+    }
+
+    // Check if fabric handles can be exported & imported by IMEX (Internode Memory Exchange).
+    CUmemFabricHandle fh;
+    CUmemGenericAllocationHandle imported_handle;
+    err = cuMemExportToShareableHandle(&fh, handle, CU_MEM_HANDLE_TYPE_FABRIC, 0);
+    if (err != CUDA_SUCCESS
+        || (err = cuMemImportFromShareableHandle(&imported_handle, &fh, CU_MEM_HANDLE_TYPE_FABRIC)) != CUDA_SUCCESS)
+    {
+        TLLM_LOG_TRACE("checking fabric support... cuMemExport/cuMemImport failed.");
+        CUCHECK(cuMemRelease(handle));
+        return CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+    }
+
+    TLLM_LOG_TRACE("fabric status: device=%d, state=%u status=%u", device_id, fabric_state, fabric_status);
+
+    CUCHECK(cuMemRelease(imported_handle));
+    CUCHECK(cuMemRelease(handle));
+    // If we get here, fabric handles are supported.
+    return CU_MEM_HANDLE_TYPE_FABRIC;
+}
 
 class NVLSCudaAllocator
 {
@@ -313,104 +415,6 @@ public:
             CUCHECK(cuMemAddressFree(nvls_handle->ipc_uc_vas[i], nvls_handle->size));
         }
     }
-
-private:
-    static CUmemAllocationHandleType getMemHandleType()
-    {
-        int device_id;
-        TLLM_CUDA_CHECK(cudaGetDevice(&device_id));
-
-        // Check if fabric handle support is available.
-        int fabric_supported = 0;
-        CUCHECK(cuDeviceGetAttribute(&fabric_supported, CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED, device_id));
-        if (!fabric_supported)
-        {
-            TLLM_LOG_TRACE(
-                "checking fabric support... CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED not supported.");
-            return CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
-        }
-
-        auto nvml = tensorrt_llm::common::NVMLWrapper::getInstance();
-        tensorrt_llm::common::NvmlManager nvmlManager;
-
-        nvmlDevice_t nvml_device;
-        NVMLCHECK(nvml->nvmlDeviceGetHandleByIndex(device_id, &nvml_device));
-
-        nvmlGpuFabricState_t fabric_state;
-        nvmlReturn_t fabric_status;
-        if (nvml->hasGpuFabricInfoV())
-        {
-            nvmlGpuFabricInfoV_t fabric_info_v;
-            memset(&fabric_info_v, 0, sizeof(fabric_info_v));
-            fabric_info_v.version = nvmlGpuFabricInfo_v2;
-            NVMLCHECK(nvml->nvmlDeviceGetGpuFabricInfoV(nvml_device, &fabric_info_v));
-            fabric_state = fabric_info_v.state;
-            fabric_status = fabric_info_v.status;
-        }
-        else if (nvml->hasGpuFabricInfo())
-        {
-            nvmlGpuFabricInfo_t fabric_info;
-            NVMLCHECK(nvml->nvmlDeviceGetGpuFabricInfo(nvml_device, &fabric_info));
-            fabric_state = fabric_info.state;
-            fabric_status = fabric_info.status;
-        }
-        else
-        {
-            TLLM_LOG_TRACE("checking fabric support... NVML fabric info APIs not available.");
-            return CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
-        }
-
-        // Check if the fabric is fully initialized.
-        if (fabric_state != NVML_GPU_FABRIC_STATE_COMPLETED || fabric_status != NVML_SUCCESS)
-        {
-            TLLM_LOG_TRACE("checking fabric support... fabric state is NOT COMPLETE: state=%u status=%u.", fabric_state,
-                fabric_status);
-            return CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
-        }
-
-        // Check that fabric handles can be created.
-        CUmemAllocationProp prop;
-        memset(&prop, 0, sizeof(CUmemAllocationProp));
-        prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
-        prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
-        prop.location.id = device_id;
-        prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
-
-        size_t alloc_size = 1024; // anything > 0
-        size_t min_gran = 0;
-        CUCHECK(cuMemGetAllocationGranularity(&min_gran, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM));
-        alloc_size = ROUND_UP(alloc_size, min_gran);
-
-        CUmemGenericAllocationHandle handle;
-        CUresult err = cuMemCreate(&handle, alloc_size, &prop, 0);
-        if (err == CUDA_ERROR_NOT_PERMITTED || err == CUDA_ERROR_NOT_SUPPORTED)
-        {
-            TLLM_LOG_TRACE("checking fabric support... cuMemCreate failed with not %s.",
-                err == CUDA_ERROR_NOT_PERMITTED ? "permitted" : "supported");
-            return CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
-        }
-        else
-        {
-            CUCHECK(err);
-        }
-
-        // Check if fabric handles can be exported & imported by IMEX (Internode Memory Exchange)
-        CUmemFabricHandle fh;
-        err = cuMemExportToShareableHandle(&fh, handle, CU_MEM_HANDLE_TYPE_FABRIC, 0);
-        if (err != CUDA_SUCCESS
-            || (err = cuMemImportFromShareableHandle(&handle, &fh, CU_MEM_HANDLE_TYPE_FABRIC)) != CUDA_SUCCESS)
-        {
-            TLLM_LOG_TRACE("checking fabric support... cuMemExport/cuMemImport failed.");
-            CUCHECK(cuMemRelease(handle));
-            return CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
-        }
-
-        TLLM_LOG_TRACE("fabric status: state=%u status=%u", device_id, fabric_state, fabric_status);
-
-        CUCHECK(cuMemRelease(handle));
-        // If we get here, fabric handles are supported.
-        return CU_MEM_HANDLE_TYPE_FABRIC;
-    }
 };
 #endif
 
@@ -449,34 +453,73 @@ void MPI_group_barrier(std::set<int> group)
 bool ipcNvlsSupported()
 {
 #if ENABLE_MULTI_DEVICE
-    CUdevice current_dev;
-    int cuda_dev = -1;
-    int cuda_driver_version = -1;
-    int dev_count = 0;
-
-    TLLM_CUDA_CHECK(cudaDriverGetVersion(&cuda_driver_version));
-    if (cuda_driver_version < 12010)
+    // The result is static for the process and the fabric probe below is
+    // relatively heavy (it allocates and exports fabric-handle memory), so
+    // compute it once and cache it.
+    static bool const supported = []() -> bool
     {
-        TLLM_LOG_DEBUG("CUDA Driver version < 12010");
-        return false;
-    }
-
-    TLLM_CUDA_CHECK(cudaGetDeviceCount(&dev_count));
-    for (int i = 0; i < dev_count; ++i)
-    {
-        TLLM_CUDA_CHECK(cudaGetDevice(&cuda_dev));
-        CUCHECK(cuDeviceGet(&current_dev, cuda_dev));
-
-        int multicast_supported = 0;
-        CUCHECK(cuDeviceGetAttribute(&multicast_supported, CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED, current_dev));
-        if (!multicast_supported)
+        // Cheap static capability check first (driver version + the multicast
+        // attribute on every device); short-circuits the fabric probe.
+        int cuda_driver_version = -1;
+        TLLM_CUDA_CHECK(cudaDriverGetVersion(&cuda_driver_version));
+        if (cuda_driver_version < 12010)
         {
-            TLLM_LOG_DEBUG("CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED not supported on GPU%d.", cuda_dev);
+            TLLM_LOG_DEBUG("CUDA Driver version < 12010");
             return false;
         }
-    }
-
-    return true;
+        int dev_count = 0;
+        TLLM_CUDA_CHECK(cudaGetDeviceCount(&dev_count));
+        for (int i = 0; i < dev_count; ++i)
+        {
+            int cuda_dev = -1;
+            CUdevice current_dev;
+            TLLM_CUDA_CHECK(cudaGetDevice(&cuda_dev));
+            CUCHECK(cuDeviceGet(&current_dev, cuda_dev));
+            int multicast_supported = 0;
+            CUCHECK(cuDeviceGetAttribute(&multicast_supported, CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED, current_dev));
+            if (!multicast_supported)
+            {
+                TLLM_LOG_DEBUG("CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED not supported on GPU%d.", cuda_dev);
+                return false;
+            }
+        }
+#if !ENABLE_NVSHMEM
+        // The multicast attribute is a false positive when the fabric/IMEX plane
+        // is not provisioned (e.g. nvidia-imex not running): NVLS multicast
+        // cannot actually be bound there. getMemHandleType() does the real test
+        // -- it resolves to FABRIC only if fabric-handle memory can be allocated
+        // and exported. On any probe error, assume usable so an unrelated
+        // failure never disables a healthy NVLS setup.
+        try
+        {
+            if (getMemHandleType() != CU_MEM_HANDLE_TYPE_FABRIC)
+            {
+                TLLM_LOG_WARNING(
+                    "\n"
+                    "**************************************************************************\n"
+                    "* NVLS (NVLink SHARP) DISABLED -- falling back to NVLink P2P              *\n"
+                    "**************************************************************************\n"
+                    "* The GPU advertises multicast support, but the NVLink fabric/IMEX plane *\n"
+                    "* is NOT provisioned on this node, so NVLS multicast memory cannot be    *\n"
+                    "* bound. Collectives will still work over NVLink P2P, but NVLS-           *\n"
+                    "* accelerated paths (NCCL NVLS, fused GEMM-allreduce / MNNVL) are off    *\n"
+                    "* and performance may be reduced.                                        *\n"
+                    "*                                                                        *\n"
+                    "* To enable NVLS: start nvidia-imex and expose                           *\n"
+                    "* /dev/nvidia-caps-imex-channels to the container. Set                   *\n"
+                    "* NCCL_NVLS_ENABLE=1 explicitly to override this fallback.               *\n"
+                    "**************************************************************************");
+                return false;
+            }
+        }
+        catch (std::exception const& e)
+        {
+            TLLM_LOG_DEBUG("NVLS fabric probe could not run, assuming usable: %s", e.what());
+        }
+#endif // !ENABLE_NVSHMEM
+        return true;
+    }();
+    return supported;
 #else
     return false;
 #endif


### PR DESCRIPTION
# Why?
    On nodes where the NVLink fabric/IMEX plane is not provisioned (e.g.
    nvidia-imex not running, or its cap devices not exposed to the
    container), NCCL still detects a multicast-capable topology and tries to
    bind NVLS (NVLink SHARP) multicast memory during ncclCommInitRank. That
    bind fails with a sticky CUDA error and aborts communicator creation,
    later surfacing as a generic "unhandled cuda error" at the first
    collective (e.g. the MoE all-gather during warmup).

    Make ipcNvlsSupported() report actual usability instead of just static
    capability: after the existing driver/MULTICAST_SUPPORTED checks, verify
    the fabric/IMEX plane can really bind multicast memory (reusing the
    runtime's getMemHandleType() fabric test). The static attribute alone is
    a false positive on unprovisioned nodes. The combined result is cached
    (the fabric probe is heavy) and short-circuited (the probe runs only
    when the cheap checks already pass).

    In getComm(), disable NVLS via setenv("NCCL_NVLS_ENABLE", "0", 0) before
    ncclCommInitRank when ipcNvlsSupported() is false, beside the existing
    NCCL setenv calls. The no-overwrite flag preserves an explicit user
    NCCL_NVLS_ENABLE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * Refined GPU NVLS capability detection to provide more granular support checks for different NVLS features
  
* **Improvements**
  * Enhanced multi-device communication initialization with improved capability detection to avoid incompatible configurations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
