### PR TITLE
[None][fix] LTX-2: re-enable Ulysses for v2a cross-attention

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/attention_backend/parallel.py
+++ b/tensorrt_llm/_torch/visual_gen/attention_backend/parallel.py
@@ -812,6 +812,7 @@ def wrap_parallel_attention(
     *,
     visual_gen_mapping: Optional["VisualGenMapping"] = None,
     enable_sequence_parallel: bool = True,
+    use_ulysses: bool = True,
     async_ulysses: bool = False,
 ) -> AttentionBackend:
     """Wrap a compute backend with the configured parallelism strategy.
@@ -822,6 +823,12 @@ def wrap_parallel_attention(
 
     When ``enable_sequence_parallel`` is False, no wrappers are applied (callers
     use this for cross-attention paths that cannot use Ulysses/Ring/Attention2D).
+
+    ``use_ulysses`` gates the Ulysses head-sharding wrap independently of
+    ``ulysses_size``: pass False to skip it even when ``ulysses_size > 1`` (e.g. a
+    SEPARATE_QKV cross-attn that falls back to all-gather and built its inner
+    backend with the full, un-sharded head count). This keeps the wrap consistent
+    with the caller's inner head-count decision.
     """
     if not enable_sequence_parallel or visual_gen_mapping is None:
         return attn
@@ -840,7 +847,7 @@ def wrap_parallel_attention(
     elif ring_size > 1:
         attn = RingAttention(attn, process_group=vgm.ring_group)
 
-    if ulysses_size > 1:
+    if ulysses_size > 1 and use_ulysses:
         attn = UlyssesAttention(
             attn,
             process_group=vgm.ulysses_group,

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
@@ -170,11 +170,14 @@ class LTX2Attention(Attention):
             # (sharded inner backend + UlyssesAttention) for both self-attn and
             # cross-attn paths.
 
-        # For audio self-attention that may need a runtime Ulysses toggle
-        # (sequence length not always divisible by ulysses_size), create a
-        # plain backend as fallback.  The base class already set self.attn
-        # to UlyssesAttention(inner_backend=sharded_backend).
-        if use_ulysses and not self._is_cross_attn and ulysses_size > 1:
+        # Build a Ulysses/plain dual-attn pair so set_ulysses_active() can toggle
+        # at runtime. Needed for self-attn (audio seq not always divisible by
+        # ulysses_size) and for v2a cross-attn under pure Ulysses (cp_size == 1),
+        # where it lets the block forward use Ulysses a2a instead of all-gathering
+        # the full video K/V. Combined ring/attn2d + Ulysses (cp_size > 1) keeps
+        # cross-attn on the all-gather fallback. The base class already set
+        # self.attn to UlyssesAttention(inner_backend=sharded_backend).
+        if use_ulysses and (cp_size == 1 or not self._is_cross_attn) and ulysses_size > 1:
             self._ulysses_attn = self.attn
             self._plain_attn = create_attention(
                 backend=self.attn_backend,
@@ -684,6 +687,7 @@ class BasicAVTransformerBlock(nn.Module):
             layer_idx=idx,
             module_name=f"transformer_blocks.{idx}.video_to_audio_attn",
             enable_sequence_parallel=True,
+            use_ulysses=True,
         )
         self.scale_shift_table_a2v_ca_audio = nn.Parameter(torch.empty(5, a_cfg.dim))
         self.scale_shift_table_a2v_ca_video = nn.Parameter(torch.empty(5, v_cfg.dim))

--- a/tensorrt_llm/_torch/visual_gen/modules/attention.py
+++ b/tensorrt_llm/_torch/visual_gen/modules/attention.py
@@ -4,6 +4,7 @@ from typing import Optional, Tuple
 import torch
 import torch.nn as nn
 
+from tensorrt_llm.logger import logger
 from tensorrt_llm.visual_gen.sparse_attention import SkipSoftmaxAttentionConfig
 
 from ...modules.linear import Linear, TensorParallelMode, WeightMode, WeightsLoadingConfig
@@ -188,6 +189,16 @@ class Attention(nn.Module):
             and enable_sequence_parallel
             and (self.qkv_mode != QKVMode.SEPARATE_QKV or async_ulysses or cp_size == 1)
         )
+        if ulysses_size > 1 and enable_sequence_parallel and not use_ulysses:
+            # Ulysses was requested (ulysses_size > 1, SP on) but disabled: this is a
+            # SEPARATE_QKV cross-attention that is neither async nor pure-Ulysses
+            # (cp_size > 1), so it falls back to the all-gather K/V path.
+            logger.debug(
+                f"Attention(layer={layer_idx}): Ulysses disabled despite ulysses_size="
+                f"{ulysses_size} — qkv_mode={self.qkv_mode.value}, "
+                f"async_ulysses={async_ulysses}, cp_size={cp_size} "
+                f"(SEPARATE_QKV cross-attn needs async_ulysses or cp_size==1)."
+            )
 
         # Compute head counts for the backend
         # Ulysses shards heads across workers; inner backend sees sharded count
@@ -235,6 +246,7 @@ class Attention(nn.Module):
             self.attn,
             visual_gen_mapping=vgm,
             enable_sequence_parallel=enable_sequence_parallel,
+            use_ulysses=use_ulysses,
             async_ulysses=use_ulysses and async_ulysses,
         )
 

--- a/tensorrt_llm/_torch/visual_gen/modules/attention.py
+++ b/tensorrt_llm/_torch/visual_gen/modules/attention.py
@@ -182,10 +182,11 @@ class Attention(nn.Module):
         # The async-ulysses path uses SEPARATE_QKV for stream-pipelined
         # V/Q/K projections AND still needs the head-sharding wrap — opt in
         # via async_ulysses=True.
+        cp_size = vgm.cp_size if vgm else 1
         use_ulysses = (
             ulysses_size > 1
             and enable_sequence_parallel
-            and (self.qkv_mode != QKVMode.SEPARATE_QKV or async_ulysses)
+            and (self.qkv_mode != QKVMode.SEPARATE_QKV or async_ulysses or cp_size == 1)
         )
 
         # Compute head counts for the backend


### PR DESCRIPTION
## Description

#14044 added Ulysses sequence-parallelism for the **v2a** (video→audio) cross-attention; #13978 (async-Ulysses refactor) silently disabled it — cross-attn was excluded from the Ulysses path at both the base-class `use_ulysses` gate and the LTX-2 dual-attn gate, and `use_ulysses=True` was dropped from the v2a construction. As a result v2a fell back to all-gathering the full video K/V every block, so its per-rank communication grows with `ulysses_size` instead of scaling.

This restores the v2a Ulysses path under **pure Ulysses (`cp_size == 1`)**, while preserving #13978's async-Ulysses (self-attn only) and keeping the combined ring/attn2d + Ulysses (`cp_size > 1`) all-gather fallback unchanged:
- `modules/attention.py`: head-shard the `SEPARATE_QKV` cross-attn inner backend when `cp_size == 1`.
- `transformer_ltx2.py`: build the dual-attn pair for cross-attn under pure Ulysses, and pass `use_ulysses=True` to `video_to_audio_attn`.

Output is numerically unchanged; this is a communication/perf fix (v2a uses the Ulysses 4-collective a2a instead of the full-video all-gather).

## Test Coverage

Existing multi-GPU parity tests (`multi_gpu/test_ltx2_ulysses.py`, `multi_gpu/test_ltx2_async_ulysses.py`) cover correctness/parity for the v2a + async paths.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced attention mechanism configuration in visual generation models for improved performance.
  * Optimized cross-attention setup for audio-visual task processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->