### PR TITLE
[https://nvbugs/6248837][fix] Densify trtllm-gen fmha warmup grid to catch missing kernels

### DIFF
--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/fmha/fmhaKernels.h
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/fmha/fmhaKernels.h
@@ -301,12 +301,29 @@ public:
     }
 
 private:
+    // Warmup up grid selection should be able to cover most possible kernel cases.
+    // Given a model, autotuner decision is relative to number of numCtas/numCtasPerSeqKv,
+    // which translate to batch size, seqLenQ and seqLenKv. Autotuner is sensitive to
+    // numCtas/numCtasPerSeqKv in the range of 1-24, but became much insensitive later.
+
+    // Selection of batch size: numCtas = numCtasPerSeqKv * batchsize
+    // So we need batch size = 1-24 to cover sensitive area when numCtasPerSeqKv = 1
+    // And then gradually increase gap between batch sizes.
     inline static std::vector<int> const kDefaultWarmupBatchSizeCandidates
-        = {1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 16, 20, 24, 28, 32, 40, 48, 56, 64, 80, 96, 128, 256, 512, 1024};
-    inline static std::vector<int> const kDefaultWarmupPrefillBatchSizeCandidates
-        = {1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64, 128, 256};
-    inline static std::vector<int> const kDefaultWarmupSeqLenQkvCandidates
-        = {1, 128, 512, 1024, 2048, 4096, 8192, 16384, 32768};
+        = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 26, 28, 30, 32, 36,
+            40, 48, 56, 64, 80, 96, 128, 256, 384, 512, 768, 1024, 1280, 1536, 2048};
+    // Selection of seqLenKv: numCtasPerSeqKv = seqLenKv / (tileSizePerKv)
+    // TileSizePerKv is typically 128, 256 and 512 and numCtasPerSeqKv is capped at SM number.
+    // For numCtasPerSeqKv we like to cover full range of 1-23, and sparsely cover 25-256
+    // Final formula: set({1, ..., 24, 26, 28, 32, 40, 48, 64, 80, 96, 128, 192, 256} * {128, 256, 512})
+    inline static std::vector<int> const kDefaultWarmupSeqLenKvCandidates = {1, 128, 256, 384, 512, 640, 768, 896, 1024,
+        1152, 1280, 1408, 1536, 1664, 1792, 1920, 2048, 2176, 2304, 2432, 2560, 2688, 2816, 2944, 3072, 3328, 3584,
+        3840, 4096, 4352, 4608, 4864, 5120, 5376, 5632, 5888, 6144, 6656, 7168, 7680, 8192, 8704, 9216, 9728, 10240,
+        10752, 11264, 11776, 12288, 13312, 14336, 16384, 20480, 24576, 32768, 40960, 49152, 65536, 98304, 131072};
+    // Selection of seqLenQ: typically our prefill kernels would not use JIT and seqLenQ is fixed during decode.
+    // However seqLenQ can change when we use generation kernel to do prefill. SeqLenQ is sensitive in the range 1-16.
+    // But for prefill we typically face much longer sequence. So we only use a very single datapoint.
+    inline static std::vector<int> const kDefaultWarmupSeqLenQCandidates = {128};
 
     static std::vector<int> makeWarmupCandidateSizes(std::vector<int> const& defaultCandidateSizes, int maxSize)
     {
@@ -392,14 +409,13 @@ private:
         TLLM_CHECK_WITH_INFO(maxBatchSize > 0 && maxSeqLenKv > 0 && (!useGenKernelForPrefill || maxSeqLenQ > 0),
             "TRTLLM-Gen Fmha Warmup Param is invalid.");
 
-        auto const& batchSizeDefaults
-            = useGenKernelForPrefill ? kDefaultWarmupPrefillBatchSizeCandidates : kDefaultWarmupBatchSizeCandidates;
-        std::vector<int> batchSizeCandidates = makeWarmupCandidateSizes(batchSizeDefaults, maxBatchSize);
+        std::vector<int> batchSizeCandidates
+            = makeWarmupCandidateSizes(kDefaultWarmupBatchSizeCandidates, maxBatchSize);
         // Use specified Q for generation, and use our Q grid for prefill
         std::vector<int> seqLenQCandidates = useGenKernelForPrefill
-            ? makeWarmupCandidateSizes(kDefaultWarmupSeqLenQkvCandidates, maxSeqLenQ)
+            ? makeWarmupCandidateSizes(kDefaultWarmupSeqLenQCandidates, maxSeqLenQ)
             : std::vector<int>{runnerParams.mMaxSeqLenQ};
-        std::vector<int> seqLenKvCandidates = makeWarmupCandidateSizes(kDefaultWarmupSeqLenQkvCandidates, maxSeqLenKv);
+        std::vector<int> seqLenKvCandidates = makeWarmupCandidateSizes(kDefaultWarmupSeqLenKvCandidates, maxSeqLenKv);
 
         auto warmupParams = runnerParams;
 


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

### Background and Analysis

After previous warmup modification PR at #14851 , most JIT in the middle of execution issue is resolved. However we met a problem on some particular DSR1 case, where a kernel is not covered in the warmup grid and cause performance issue afterwards. In this special case the kernel would be selected only if seqlen between a very narrow area (8193-9316).

This PR densified the grid based on learning from autotuner, and should protect this case and other possible narrow cases without introducing much overhead.

### Why the soultion in this PR should work (even for future cases)

Given other parameters, the autotuner would select kernel based on `batchSize`, `seqLenQ`, `seqLenKv`. For decode case, `seqLenQ` is given. As attention is done in tiles, these parameters only affect autotuner by affecting number of total tile and tile per sequence. 

When tile number is in the range of 1 - 24, the autotuner logic would be rather delicate so that we require dense cover of this area. Outside this area the autotuner logic will be much less delicate and we can just cover some of them. 

Each tile can be of size 128, 256 and 512. The tile number per sequence is capped at `multiprocessorCount` and the total tile number also mostly work by comparing with `multiprocessorCount` multiplied by a factor.

So for `seqLenKv` we use such range: `[*dense_tile_num_range, *sprase_tile_num_range] multiplied by [128, 256, 512]`. `dense_tile_num_range = [1,2, ..., 24]` covers full 1-24 tile num range, and `sparese_tile_num_range = [26, 28, 32, 40, 48, 64, 96, 128, 192, 256]` would loosely cover from 24 - 256 (upper cap of multiprocessor count)

For batchsize we want total number of tiles cover 1 - 24 and loosely cover other cases. Remember we have full 1-24 tile for `seqLenKv` range, we would like to cover most cases for each `seqLenKv` (effectively tile number per sequence). For `tileNumPerSeq = 1`, we want `batchsize = 1, ..., 24`; for `tileNumPerSeq = 2`, we want `batchsize = 1, ..., 12`, etc. So the final coverage would be similar to tile range of  `seqLenKv`, but I added more batchsizes just to be sure about real cases.

### Overhead

As the warmup happens on C++ fmhaRunner level, the overhead would be much easier to handle. `Overhead = Tuning Overhead + Kernel Compilation Overhead`. For a given model config, as the warmup should catch every posssible kernel in the run, this can be seen as a constant. Before and after this PR this should not change much (it will increase as we did catch a previously missing kernel), likely an increase of 8s. And the `Tuning Overhead = mesh point * tuning time * model layer number * number of execution`, tuning time is typically less than 20us, interpreting to less than 6s for most models. In actual test environment the tuning overhead is measured less than 1s. I believe this is due to the fact we are overestimating the tuning time and mesh point.

### Follow up tasks

1. Change to tune only on a new layer, so we can remove model layer number factor from tuning overhead and allow for even more warmup.
2. Reduce kernel compilation overhead.

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated generation kernel warmup configuration to enhance compilation efficiency and provide optimized performance across various batch and sequence length scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->