### PR TITLE
[None][perf] Bound Triton MoE JIT specializations via token-dim bucketing and warmup

### DIFF
--- a/tensorrt_llm/_torch/model_config.py
+++ b/tensorrt_llm/_torch/model_config.py
@@ -150,6 +150,9 @@ class ModelConfig(Generic[TConfig]):
     moe_disable_finalize_fusion: bool = False
     # If true, use low precision combine in MoE operations (only for NVFP4 quantization)
     use_low_precision_moe_combine: bool = False
+    # If true, pad the MoE token dimension to geometric buckets in the TRITON
+    # MoE backend to bound the Triton JIT kernel specialization space
+    moe_triton_pad_token_dim: bool = False
 
     # NVFP4 GEMM backend configuration - list of backends to consider for auto-selection
     # Default excludes 'cutedsl' for faster build time. Add 'cutedsl' for extreme perf.

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_triton.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_triton.py
@@ -30,6 +30,8 @@ from triton_kernels.numerics_details.mxfp import downcast_to_mxfp_torch
 from triton_kernels.tensor import FP4, convert_layout, wrap_torch_tensor
 from triton_kernels.tensor_details import layout
 
+from tensorrt_llm.logger import logger
+
 from ...model_config import ModelConfig
 from ..linear import TensorParallelMode, load_weight_shard
 from .interface import MoE
@@ -752,6 +754,48 @@ def swizzle_weight_and_scale(w: torch.Tensor, w_scale: torch.Tensor):
 
 def get_padded_size(size: int, padding: int) -> int:
     return ((size + padding - 1) // padding) * padding
+
+
+# ---------------------------------------------------------------------------
+# Token-dim bucketing to bound the Triton kernel specialization space
+# ---------------------------------------------------------------------------
+# The Triton grouped GEMM (matmul_ogs) JIT-compiles a new kernel specialization
+# the first time it sees a novel token count m: kernel meta-parameters such as
+# block_m are derived from m (see triton_kernels/matmul_ogs_details/
+# opt_flags.py), and Triton additionally specializes the m-derived integer
+# kernel arguments (m * top_k, grid_m, ...) on divisibility by 16. Under
+# serving traffic with randomized prompt lengths, novel m values keep arriving
+# and each first-seen specialization stalls the host (and therefore the GPU)
+# for the duration of a JIT compile (~0.2-2s).
+#
+# Padding the token dimension up to a geometric bucket
+# (MoeConfig.triton_pad_token_dim) keeps the set of m values observable by the
+# Triton kernels finite, so all specializations can be exhaustively
+# pre-compiled at warmup (see _run_triton_moe_prewarm in
+# pyexecutor/model_engine.py).
+
+# m is rounded up to a multiple of 2**(floor(log2(m)) - 3), i.e. 8 buckets per
+# power-of-two octave, which bounds the padding overhead by 12.5%.
+_PAD_M_LOG2_BUCKETS_PER_OCTAVE = 3
+
+
+def round_up_to_triton_moe_m_bucket(num_tokens: int) -> int:
+    """Rounds num_tokens up to the next Triton MoE token-dim bucket."""
+    if num_tokens <= (1 << _PAD_M_LOG2_BUCKETS_PER_OCTAVE):
+        return num_tokens
+    granularity = 1 << (num_tokens.bit_length() - 1 -
+                        _PAD_M_LOG2_BUCKETS_PER_OCTAVE)
+    return (num_tokens + granularity - 1) // granularity * granularity
+
+
+def iter_triton_moe_m_buckets(max_num_tokens: int) -> List[int]:
+    """Returns all Triton MoE token-dim buckets in [1, max_num_tokens], ascending."""
+    buckets = []
+    bucket = 1
+    while bucket <= max_num_tokens:
+        buckets.append(bucket)
+        bucket = round_up_to_triton_moe_m_bucket(bucket + 1)
+    return buckets
 
 
 # Pad both n and k dimensions, then shard along shard_axis
@@ -1523,6 +1567,22 @@ class TritonFusedMoE(MoE):
         self.swiglu_beta = _maybe_squeeze_act_param(swiglu_beta)
         self.swiglu_limit = _maybe_squeeze_act_param(swiglu_limit)
 
+        # Token-dim bucketing is restricted to W4A16 MXFP4, where padded rows
+        # provably cannot change the outputs of real tokens (BF16/FP16
+        # activations, no dynamic activation scales). Quantization modes with
+        # dynamic per-tensor activation scales (FP8 QDQ, W4A8 MXFP4 FP8) are
+        # excluded because padded rows contribute swiglu(bias) values to the
+        # second GEMM's dynamic amax.
+        self.pad_token_dim = (
+            model_config.moe_triton_pad_token_dim
+            and self.quant_config is not None
+            and self.quant_config.layer_quant_mode.has_w4a16_mxfp4())
+        if model_config.moe_triton_pad_token_dim and not self.pad_token_dim:
+            logger.warning_once(
+                "moe_config.triton_pad_token_dim is only supported with W4A16 "
+                "MXFP4 quantization; disabling token-dim padding.",
+                key="triton_pad_token_dim_unsupported_quant")
+
         self._weights_created = False
         if not model_config.skip_create_weights_in_init:
             self.create_weights()
@@ -1566,7 +1626,26 @@ class TritonFusedMoE(MoE):
         assert use_dp_padding is None or not use_dp_padding, \
             "TritonFusedMoE does not support use_dp_padding=True"
 
+        num_tokens = x.shape[0]
+        padded_num_tokens = round_up_to_triton_moe_m_bucket(
+            num_tokens) if self.pad_token_dim else num_tokens
+        if padded_num_tokens != num_tokens:
+            # Pad the token dimension to a bucket so the set of Triton kernel
+            # specializations stays finite (see the comment above
+            # round_up_to_triton_moe_m_bucket). The padded rows hold zero
+            # activations and zero router logits: they are routed like any
+            # other token, but the grouped GEMMs compute every output row
+            # independently from its own input row, so they only append rows
+            # to the expert groups and never mix into the outputs of real
+            # tokens, which are sliced back out below.
+            pad_rows = padded_num_tokens - num_tokens
+            x = torch.nn.functional.pad(x, (0, 0, 0, pad_rows))
+            router_logits = torch.nn.functional.pad(router_logits,
+                                                    (0, 0, 0, pad_rows))
+
         hidden_states = self.quant_method.apply(self, x, router_logits)
+        if padded_num_tokens != num_tokens:
+            hidden_states = hidden_states[:num_tokens]
 
         final_hidden_states = self.reducescatter_or_allreduce(
             hidden_states,

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -5,6 +5,7 @@ import gc
 import inspect
 import math
 import os
+import time
 import weakref
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
@@ -962,6 +963,11 @@ class PyTorchModelEngine(ModelEngine):
         # is decode-only and runs into issues with autotuner warmup.
         if not self.mapping.has_cp_helix():
             self._run_autotuner_warmup(resource_manager)
+        if can_run_general_warmup:
+            # Pre-compile the Triton MoE kernel specializations across the
+            # context token-dim buckets (active iff
+            # moe_config.triton_pad_token_dim enabled token-dim bucketing).
+            self._run_triton_moe_prewarm(resource_manager)
         with self.cuda_graph_runner.allow_capture():
             self._run_cuda_graph_warmup(resource_manager)
         if can_run_general_warmup:
@@ -1140,6 +1146,69 @@ class PyTorchModelEngine(ModelEngine):
             f"[Autotuner] Cache size after warmup is {len(AutoTuner.get().profiling_cache)}"
         )
         AutoTuner.get().print_profiling_cache()
+
+    def _run_triton_moe_prewarm(self, resource_manager: ResourceManager):
+        """Pre-compiles Triton MoE (matmul_ogs) kernel specializations across
+        the context token-dim buckets.
+
+        The Triton MoE backend JIT-compiles a new grouped-GEMM specialization
+        the first time it sees a novel total token count m (see the comment
+        above round_up_to_triton_moe_m_bucket in fused_moe_triton.py). In
+        serving, every first-seen specialization stalls the GPU for the
+        duration of the JIT compile (~0.2-2s). With token-dim bucketing
+        active, the set of m values the kernels can observe is finite, so this
+        warmup sweeps exactly those buckets and the compiles happen at startup
+        instead of in the serving path.
+
+        No-op unless the model contains Triton MoE modules with token-dim
+        bucketing enabled (moe_config.triton_pad_token_dim).
+        """
+        from ..modules.fused_moe.fused_moe_triton import TritonFusedMoE
+        if not any(
+                isinstance(module, TritonFusedMoE) and module.pad_token_dim
+                for module in self.model.modules()):
+            return
+        token_counts = self._get_triton_moe_prewarm_token_counts(
+            resource_manager)
+        if not token_counts:
+            return
+        logger.info(
+            f"Running Triton MoE prewarm with {len(token_counts)} context "
+            f"token counts in [{token_counts[0]}, {token_counts[-1]}]")
+        start_time = time.time()
+        self._general_warmup(resource_manager,
+                             [(num_tokens, 0) for num_tokens in token_counts])
+        logger.info(
+            f"Triton MoE prewarm took {time.time() - start_time:.1f} seconds")
+
+    def _get_triton_moe_prewarm_token_counts(
+            self, resource_manager: ResourceManager) -> List[int]:
+        """Returns the ascending grid of context token counts to sweep in
+        :meth:`_run_triton_moe_prewarm`."""
+        from ..modules.fused_moe.fused_moe_triton import \
+            iter_triton_moe_m_buckets
+        kv_cache_manager = resource_manager.get_resource_manager(
+            self.kv_cache_manager_key)
+        token_num_upper_bound = min(self.max_num_tokens,
+                                    self.batch_size * (self.max_seq_len - 1))
+        curr_max_num_tokens = kv_cache_manager.get_num_available_tokens(
+            token_num_upper_bound=token_num_upper_bound,
+            max_num_draft_tokens=self.original_max_draft_len)
+        max_tokens = min(self.max_num_tokens, curr_max_num_tokens)
+        # 1- and 2-token shapes are already covered by the general warmup.
+        min_tokens = 3
+        if max_tokens < min_tokens:
+            return []
+        # With token-dim bucketing active, the Triton MoE only ever sees
+        # bucket-sized token counts, so warming exactly the buckets is
+        # exhaustive. max_tokens itself is included because it pads internally
+        # to the same (possibly > max_tokens) bucket that any serving token
+        # count in the last partial bucket maps to.
+        token_counts = set(bucket
+                           for bucket in iter_triton_moe_m_buckets(max_tokens)
+                           if bucket >= min_tokens)
+        token_counts.add(max_tokens)
+        return sorted(token_counts)
 
     def _compute_dynamic_draft_len_mapping(self) -> Optional[Dict[int, int]]:
         """Compute graph_bs → draft_len mapping for dynamic draft length feature.

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -924,6 +924,8 @@ class ModelLoader:
             disable_finalize_fusion,
             use_low_precision_moe_combine=self.llm_args.moe_config.
             use_low_precision_moe_combine,
+            moe_triton_pad_token_dim=self.llm_args.moe_config.
+            triton_pad_token_dim,
             nvfp4_gemm_allowed_backends=self.llm_args.nvfp4_gemm_config.
             allowed_backends,
             use_cute_dsl_blockscaling_mm=self.llm_args.

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -784,6 +784,12 @@ class MoeConfig(StrictBaseModel):
         "Use low precision combine in MoE operations (only for NVFP4 quantization). When enabled, uses lower precision for combining expert outputs to improve performance."
     )
 
+    triton_pad_token_dim: bool = Field(
+        default=False,
+        description=
+        "Pad the MoE token dimension to a finite set of geometric buckets (at most 12.5% padding) before the Triton grouped GEMMs, and pre-compile those buckets during engine warmup. This bounds the number of Triton JIT kernel specializations, eliminating first-seen-shape compile stalls under serving traffic with varied prompt lengths. Only effective for the TRITON MoE backend with W4A16 MXFP4 quantization (where padded outputs are bit-identical); ignored otherwise."
+    )
+
 
 Nvfp4Backend = Literal['cutlass', 'cublaslt', 'cutedsl', 'cuda_core']
 

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -27,6 +27,7 @@ l0_h100:
   - unittest/_torch/modules/test_fused_activation_quant.py
   - unittest/_torch/modules/test_awq_quantization.py
   - unittest/_torch/modules/test_triton_linear.py
+  - unittest/_torch/modules/fused_moe/test_triton_moe_padding.py
   - unittest/_torch/modules/test_group_rmn_norm.py
   - unittest/_torch/modules/test_rotary_embedding.py
   - unittest/_torch/modules/mamba

--- a/tests/unittest/_torch/modules/fused_moe/test_triton_moe_padding.py
+++ b/tests/unittest/_torch/modules/fused_moe/test_triton_moe_padding.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for Triton MoE token-dim bucketing (``MoeConfig.triton_pad_token_dim``).
+
+Run as a pytest:
+    pytest tests/unittest/_torch/modules/fused_moe/test_triton_moe_padding.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from utils.util import skip_no_hopper
+
+from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.modules.fused_moe.fused_moe_triton import (
+    TritonFusedMoE,
+    iter_triton_moe_m_buckets,
+    round_up_to_triton_moe_m_bucket,
+)
+from tensorrt_llm._torch.modules.fused_moe.routing import RenormalizeMoeRoutingMethod
+from tensorrt_llm._utils import mpi_rank
+from tensorrt_llm.mapping import Mapping
+from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
+
+MAX_TOKENS = 65536
+
+
+def test_bucket_round_up_properties():
+    buckets = set(iter_triton_moe_m_buckets(MAX_TOKENS))
+    prev_bucket = 0
+    for num_tokens in range(1, MAX_TOKENS + 1):
+        bucket = round_up_to_triton_moe_m_bucket(num_tokens)
+        # Rounds up, by at most 12.5%.
+        assert num_tokens <= bucket <= num_tokens + max(num_tokens // 8, 1)
+        # Buckets are fixed points (padding a padded size is a no-op).
+        assert round_up_to_triton_moe_m_bucket(bucket) == bucket
+        # Monotonic in num_tokens.
+        assert bucket >= prev_bucket
+        prev_bucket = bucket
+        # iter_triton_moe_m_buckets enumerates exactly the reachable buckets.
+        assert bucket in buckets
+
+
+def test_bucket_iter_is_sorted_and_compact():
+    buckets = iter_triton_moe_m_buckets(MAX_TOKENS)
+    assert buckets == sorted(set(buckets))
+    assert buckets[0] == 1
+    assert buckets[-1] >= MAX_TOKENS // 8 * 8
+    # 8 buckets per power-of-two octave => O(8 * log2(n)) buckets in total.
+    assert len(buckets) <= 8 * (MAX_TOKENS.bit_length() + 1)
+
+
+@skip_no_hopper
+@pytest.mark.parametrize("num_tokens", [5, 17, 100, 1000])
+@pytest.mark.parametrize("bias", [True, False])
+def test_triton_moe_padding_bit_identical(num_tokens, bias):
+    """Padded and unpadded forwards must produce bit-identical outputs on the
+    W4A16 MXFP4 path."""
+    assert round_up_to_triton_moe_m_bucket(num_tokens) != num_tokens or num_tokens == 5, (
+        "test sizes should exercise actual padding"
+    )
+
+    mapping = Mapping()
+    mapping.rank = mpi_rank()
+
+    with torch.device(f"cuda:{mapping.rank}"):
+        dtype = torch.bfloat16
+        HIDDEN_SIZE = 2880
+        INTERMEDIATE_SIZE = 720
+        NUM_EXPERTS = 32
+        TOP_K = 4
+        routing_method = RenormalizeMoeRoutingMethod(top_k=TOP_K)
+        torch.manual_seed(0)
+        torch.cuda.manual_seed(0)
+        x = torch.randn((num_tokens, HIDDEN_SIZE), dtype=dtype).cuda()
+        router_logits = torch.randn((num_tokens, NUM_EXPERTS), dtype=dtype).cuda()
+
+        weights = {}
+        for expert_id in range(NUM_EXPERTS):
+            weights[f"{expert_id}.w1.weight"] = torch.randn(
+                (INTERMEDIATE_SIZE, HIDDEN_SIZE), dtype=dtype
+            ).cuda()
+            weights[f"{expert_id}.w2.weight"] = torch.randn(
+                (HIDDEN_SIZE, INTERMEDIATE_SIZE), dtype=dtype
+            ).cuda()
+            weights[f"{expert_id}.w3.weight"] = torch.randn(
+                (INTERMEDIATE_SIZE, HIDDEN_SIZE), dtype=dtype
+            ).cuda()
+            if bias:
+                weights[f"{expert_id}.w1.bias"] = torch.randn(
+                    (INTERMEDIATE_SIZE,), dtype=dtype
+                ).cuda()
+                weights[f"{expert_id}.w2.bias"] = torch.randn((HIDDEN_SIZE,), dtype=dtype).cuda()
+                weights[f"{expert_id}.w3.bias"] = torch.randn(
+                    (INTERMEDIATE_SIZE,), dtype=dtype
+                ).cuda()
+
+        quant_config = QuantConfig(quant_algo=QuantAlgo.W4A16_MXFP4)
+        fused_moe = TritonFusedMoE(
+            num_experts=NUM_EXPERTS,
+            routing_method=routing_method,
+            hidden_size=HIDDEN_SIZE,
+            intermediate_size=INTERMEDIATE_SIZE,
+            dtype=dtype,
+            reduce_results=True,
+            bias=bias,
+            model_config=ModelConfig(
+                quant_config=quant_config, moe_triton_pad_token_dim=True, mapping=mapping
+            ),
+        )
+        fused_moe.load_weights([weights])
+        fused_moe.cuda()
+        assert fused_moe.pad_token_dim
+
+        with torch.inference_mode():
+            output_padded = fused_moe.forward(x, router_logits)
+            # The flag is captured at init and only consumed in forward_impl,
+            # so flipping it on the module exercises the unpadded path with
+            # identical weights.
+            fused_moe.pad_token_dim = False
+            output_unpadded = fused_moe.forward(x, router_logits)
+        torch.cuda.synchronize()
+
+        assert output_padded.shape == output_unpadded.shape == x.shape
+        assert torch.equal(output_padded, output_unpadded)
+
+
+@skip_no_hopper
+def test_triton_moe_padding_requires_w4a16_mxfp4():
+    """The padding flag must be ignored (with a warning) on quantization paths
+    where bit-identity is not guaranteed."""
+    mapping = Mapping()
+    mapping.rank = mpi_rank()
+    with torch.device(f"cuda:{mapping.rank}"):
+        fused_moe = TritonFusedMoE(
+            num_experts=8,
+            routing_method=RenormalizeMoeRoutingMethod(top_k=2),
+            hidden_size=2880,
+            intermediate_size=720,
+            dtype=torch.bfloat16,
+            reduce_results=True,
+            model_config=ModelConfig(
+                quant_config=QuantConfig(quant_algo=QuantAlgo.FP8),
+                moe_triton_pad_token_dim=True,
+                mapping=mapping,
+                skip_create_weights_in_init=True,
+            ),
+        )
+        assert not fused_moe.pad_token_dim


### PR DESCRIPTION
## Description

The TRITON MoE backend (OpenAI `matmul_ogs` grouped GEMMs, the recommended backend
for gpt-oss MXFP4 on Hopper) JIT-compiles a new kernel specialization the first
time it sees a novel total token count `m`: kernel meta-parameters such as
`block_m` are derived from `m` (`triton_kernels/matmul_ogs_details/opt_flags.py`),
and Triton additionally specializes the `m`-derived integer kernel arguments on
divisibility by 16. Under serving traffic with varied prompt lengths, novel `m`
values keep arriving for the whole lifetime of the server, and each first-seen
specialization stalls the GPU for the duration of a JIT compile (~0.2–2 s).

Measured on gpt-oss-120b (W4A16 MXFP4) on H200 under a randomized-length serving
workload (uniform input lengths in [0.8·ISL, ISL], streaming, concurrency 4–64),
these stalls account for **12.6%** of wall time at ISL/OSL 1k/1k conc 64,
**22%** at 8k/1k conc 64, and **~34%** at TP2 8k/1k conc 16 (the per-layer
allreduce propagates either rank's stall to both ranks).

This PR adds `moe_config.triton_pad_token_dim` (default off): the MoE token
dimension is padded to geometric buckets (8 per power-of-two octave, ≤12.5%
padding, ~6% average) before the grouped GEMMs and sliced back before the
allreduce, which makes the set of observable `m` values — and therefore the JIT
specialization space — provably finite (97 buckets for max_num_tokens=20000).
Engine warmup then pre-compiles exactly those buckets before the server starts
taking traffic (`_run_triton_moe_prewarm`), following the same pattern as the
trtllm-gen FMHA JIT warmup (#14851).

The flag is restricted to W4A16 MXFP4, where padded rows provably cannot change
the outputs of real tokens (row-independent grouped GEMMs, BF16/FP16 activations,
no dynamic activation scales); on other quantization modes it logs a warning and
stays off (dynamic per-tensor activation scales would let padded rows shift the
second GEMM's amax).

Measured impact (InferenceX harness recipe, gpt-oss-120b, H200, 1.3.0rc14+patch,
GSM8K unchanged at 0.956 vs 0.957 baseline):

| cell | baseline tok/s/GPU @ tok/s/user | with this PR | Δ |
|---|---|---|---|
| 1k1k TP1 conc64 | 2653 @ 47.2 | 3048 @ 48.8 | +14.9% / +3.4% |
| 8k1k TP1 conc64 | 1392 @ 24.8 | 1781 @ 28.3 | +27.9% / +14.1% |
| 8k1k TP2EP1 conc16 | 480 @ 69.8 | 723 @ 94.4 | +50.7% / +35.2% |

Full 20-cell sweep: +8% to +65% throughput (avg ≈ +25% attributable to this
change alone), with simultaneous interactivity (median TPOT) improvements.
A cold→warm `TRITON_CACHE_DIR` A/B on the unmodified code reproduces the same
gains, confirming the mechanism; warmup-grid-only (without padding) recovers
almost nothing because Triton's `%16` integer specializations are not coverable
by a finite grid of raw (unpadded) token counts.

Note on scope: `TritonFusedMoE` is on the legacy MoE path, but the TRITON
backend exists only there, and this is a perf fix scoped to that backend —
pattern-identical to `disable_finalize_fusion` (CUTLASS-specific knob consumed
inside the legacy backend file).

## Test Coverage

- `tests/unittest/_torch/modules/fused_moe/test_triton_moe_padding.py`
  - `test_bucket_round_up_properties` / `test_bucket_iter_is_sorted_and_compact`
    (CPU): exhaustive bucket-math properties over [1, 65536] — rounds up by
    ≤12.5%, fixed-point, monotonic, enumeration matches closure.
  - `test_triton_moe_padding_bit_identical` (`@skip_no_hopper`):
    `torch.equal` between padded and unpadded forwards on the W4A16 MXFP4 path,
    parametrized over token counts and bias.
  - `test_triton_moe_padding_requires_w4a16_mxfp4` (`@skip_no_hopper`):
    the flag is ignored on non-W4A16 quant modes.
- Registered in `l0_h100.yml` (SM90 lane).

## PR Checklist

- [x] Config surface follows CODING_GUIDELINES Pydantic rules (StrictBaseModel
      field with description; nested MoeConfig field — no api_stability
      reference changes required, matching precedent #7898).
- [x] No behavior change with the flag unset (default).
- [x] pre-commit run on all changed files.
- [x] GPU-validated end to end (import smoke, unit tests, serving A/B) on 2xH200.
