### PR TITLE
[None][fix] visual_gen/wan: pass precision-cast compile option

### DIFF
--- a/examples/visual_gen/configs/wan2.2-i2v-fp4-1gpu.yaml
+++ b/examples/visual_gen/configs/wan2.2-i2v-fp4-1gpu.yaml
@@ -23,5 +23,8 @@ attention_config:
 parallel_config:
   cfg_size: 1
   ulysses_size: 1
+torch_compile_config:
+  options:
+    emulate_precision_casts: true
 cuda_graph_config:
   enable: false

--- a/examples/visual_gen/configs/wan2.2-t2v-fp4-1gpu.yaml
+++ b/examples/visual_gen/configs/wan2.2-t2v-fp4-1gpu.yaml
@@ -23,5 +23,8 @@ attention_config:
 parallel_config:
   cfg_size: 1
   ulysses_size: 1
+torch_compile_config:
+  options:
+    emulate_precision_casts: true
 cuda_graph_config:
   enable: false

--- a/examples/visual_gen/configs/wan2.2-t2v-fp4-4gpu.yaml
+++ b/examples/visual_gen/configs/wan2.2-t2v-fp4-4gpu.yaml
@@ -25,5 +25,8 @@ parallel_config:
   ulysses_size: 2
   async_ulysses: true
   parallel_vae_size: 4
+torch_compile_config:
+  options:
+    emulate_precision_casts: true
 cuda_graph_config:
   enable: false

--- a/examples/visual_gen/configs/wan2.2-t2v-fp8-8gpu.yaml
+++ b/examples/visual_gen/configs/wan2.2-t2v-fp8-8gpu.yaml
@@ -24,5 +24,8 @@ parallel_config:
   cfg_size: 2
   ulysses_size: 4
   parallel_vae_size: 8
+torch_compile_config:
+  options:
+    emulate_precision_casts: true
 cuda_graph_config:
   enable: false

--- a/examples/visual_gen/serve/configs/wan21.yml
+++ b/examples/visual_gen/serve/configs/wan21.yml
@@ -4,3 +4,6 @@ cache_config:
 parallel_config:
   cfg_size: 1
   ulysses_size: 1
+torch_compile_config:
+  options:
+    emulate_precision_casts: true

--- a/examples/visual_gen/serve/configs/wan22.yml
+++ b/examples/visual_gen/serve/configs/wan22.yml
@@ -3,3 +3,6 @@ cache_config:
 parallel_config:
   cfg_size: 1
   ulysses_size: 1
+torch_compile_config:
+  options:
+    emulate_precision_casts: true

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Union
 import diffusers
 import PIL.Image
 import torch
+import torch._inductor.config as inductor_config
 from diffusers import AutoencoderKLWan, FlowMatchEulerDiscreteScheduler
 from diffusers.utils.torch_utils import randn_tensor
 from diffusers.video_processor import VideoProcessor
@@ -122,6 +123,12 @@ class WanPipeline(BasePipeline):
             )
 
         super().__init__(pipeline_config)
+
+    def _torch_compile_options(self) -> dict:
+        options = super()._torch_compile_options()
+        if hasattr(inductor_config, "emulate_precision_casts"):
+            options.setdefault("emulate_precision_casts", True)
+        return options
 
     def _compute_wan_timestep_embedding(self, module, timestep=None, **kwargs):
         """Compute timestep embedding for WAN transformer.

--- a/tensorrt_llm/_torch/visual_gen/pipeline.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline.py
@@ -522,6 +522,10 @@ class BasePipeline(nn.Module):
             f"world_size={dist.get_world_size(vgm.vae_group)}"
         )
 
+    def _torch_compile_options(self) -> Dict[str, Any]:
+        """Return torch.compile options for this pipeline."""
+        return dict(self.pipeline_config.torch_compile.options)
+
     def torch_compile(self) -> None:
         """Apply torch.compile to pipeline components based on TorchCompileConfig.
 
@@ -536,6 +540,17 @@ class BasePipeline(nn.Module):
         # Using default as max-autotune mode takes more initialization time and
         # does not improve performance a lot.
         compile_mode = "default"
+        compile_options = self._torch_compile_options()
+        compile_kwargs = {
+            "dynamic": None,
+            "fullgraph": tc_config.enable_fullgraph,
+        }
+        if compile_options:
+            compile_kwargs["options"] = compile_options
+            compile_detail = f"options={compile_options}"
+        else:
+            compile_kwargs["mode"] = compile_mode
+            compile_detail = f"mode={compile_mode}"
 
         # Compiling transformer blocks provides max performance value.
         targets = self.transformer_components
@@ -552,27 +567,15 @@ class BasePipeline(nn.Module):
                     blocks = getattr(model, block_name)
                     logger.info(
                         f"torch.compile: {name}.{block_name} "
-                        f"({len(blocks)} blocks, mode={compile_mode})"
+                        f"({len(blocks)} blocks, {compile_detail})"
                     )
                     compiled_blocks = []
                     for block in blocks:
-                        compiled_blocks.append(
-                            torch.compile(
-                                block,
-                                mode=compile_mode,
-                                dynamic=None,
-                                fullgraph=tc_config.enable_fullgraph,
-                            )
-                        )
+                        compiled_blocks.append(torch.compile(block, **compile_kwargs))
                     setattr(model, block_name, nn.ModuleList(compiled_blocks))
             else:
-                logger.info(f"torch.compile: {name} (whole module, mode={compile_mode})")
-                compiled = torch.compile(
-                    model,
-                    mode=compile_mode,
-                    dynamic=None,
-                    fullgraph=tc_config.enable_fullgraph,
-                )
+                logger.info(f"torch.compile: {name} (whole module, {compile_detail})")
+                compiled = torch.compile(model, **compile_kwargs)
                 setattr(self, name, compiled)
 
     @staticmethod

--- a/tensorrt_llm/visual_gen/args.py
+++ b/tensorrt_llm/visual_gen/args.py
@@ -406,6 +406,11 @@ class TorchCompileConfig(StrictBaseModel):
     enable: bool = Field(True, status="prototype")
     enable_fullgraph: bool = Field(False, status="prototype")
     enable_autotune: bool = Field(True, status="prototype")
+    options: Dict[str, Any] = Field(
+        default_factory=dict,
+        status="prototype",
+        description="Additional options forwarded to torch.compile(options=...).",
+    )
 
 
 class CudaGraphConfig(StrictBaseModel):

--- a/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
+++ b/tests/unittest/_torch/visual_gen/test_visual_gen_args.py
@@ -234,6 +234,90 @@ class TestVisualGenArgsFromDict:
         assert "dynamic_weight_quant" not in dumped
         assert "force_dynamic_quantization" not in dumped
 
+    def test_torch_compile_options_dict_passthrough(self):
+        args = VisualGenArgs(
+            **{
+                "model": "/tmp/model",
+                "torch_compile_config": {
+                    "options": {
+                        "emulate_precision_casts": True,
+                    },
+                },
+            }
+        )
+
+        assert args.torch_compile_config.options == {"emulate_precision_casts": True}
+        assert args.model_dump()["torch_compile_config"]["options"] == {
+            "emulate_precision_casts": True
+        }
+
+    def test_torch_compile_options_forwarded_to_torch_compile(self, monkeypatch):
+        import torch.nn as nn
+
+        from tensorrt_llm._torch.visual_gen.config import (
+            DiffusionModelConfig,
+            DiffusionPipelineConfig,
+        )
+        from tensorrt_llm._torch.visual_gen.pipeline import BasePipeline
+
+        class DummyTransformer(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.blocks = nn.ModuleList([nn.Linear(1, 1), nn.Linear(1, 1)])
+
+        class DummyPipeline(BasePipeline):
+            def _init_transformer(self):
+                self.transformer = DummyTransformer()
+
+            def _setup_cuda_graphs(self):
+                pass
+
+        compile_calls = []
+
+        def fake_compile(module, **kwargs):
+            compile_calls.append((module, kwargs))
+            return module
+
+        monkeypatch.setattr("torch.compile", fake_compile)
+
+        config = DiffusionPipelineConfig(
+            model_configs={"transformer": DiffusionModelConfig(pretrained_config={})},
+            torch_compile=TorchCompileConfig(
+                enable_fullgraph=True,
+                options={"emulate_precision_casts": True},
+            ),
+        )
+        pipeline = DummyPipeline(config)
+        pipeline.torch_compile()
+
+        assert len(compile_calls) == 2
+        for _, kwargs in compile_calls:
+            assert "mode" not in kwargs
+            assert kwargs["dynamic"] is None
+            assert kwargs["fullgraph"] is True
+            assert kwargs["options"] == {"emulate_precision_casts": True}
+
+    def test_wan_torch_compile_default_options_preserve_user_override(self):
+        import torch._inductor.config as inductor_config
+
+        from tensorrt_llm._torch.visual_gen.config import DiffusionPipelineConfig
+        from tensorrt_llm._torch.visual_gen.models.wan.pipeline_wan import WanPipeline
+
+        pipeline = object.__new__(WanPipeline)
+        pipeline.pipeline_config = DiffusionPipelineConfig()
+        default_options = pipeline._torch_compile_options()
+
+        if hasattr(inductor_config, "emulate_precision_casts"):
+            assert default_options["emulate_precision_casts"] is True
+        else:
+            assert "emulate_precision_casts" not in default_options
+
+        pipeline.pipeline_config = DiffusionPipelineConfig(
+            torch_compile=TorchCompileConfig(options={"emulate_precision_casts": False})
+        )
+        override_options = pipeline._torch_compile_options()
+        assert override_options["emulate_precision_casts"] is False
+
 
 class TestVisualGenArgsFromYaml:
     """from_yaml round-trips through a YAML file."""
@@ -258,6 +342,19 @@ class TestVisualGenArgsFromYaml:
         yaml_path.write_text("model: /tmp/model\nlinear:\n  type: default\n")
         with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
             VisualGenArgs.from_yaml(yaml_path)
+
+    def test_from_yaml_torch_compile_options(self, tmp_path):
+        yaml_path = tmp_path / "config.yml"
+        yaml_path.write_text(
+            "model: /tmp/model\n"
+            "torch_compile_config:\n"
+            "  options:\n"
+            "    emulate_precision_casts: true\n"
+        )
+
+        args = VisualGenArgs.from_yaml(yaml_path)
+
+        assert args.torch_compile_config.options == {"emulate_precision_casts": True}
 
 
 class TestParallelConfigValidation:


### PR DESCRIPTION
## Description

The WAN transformer block performs several explicit dtype casts, especially around BF16 modulation and normalization intermediates. When `torch.compile` is enabled, Inductor may drop the eager-mode rounding of those casts while fusing, so compiled WAN output can drift numerically from eager. PyTorch supports `emulate_precision_casts` through `torch.compile(options=...)` to make Inductor emulate those eager casts.

This PR adds a VisualGen `TorchCompileConfig.options` dictionary and forwards it to `torch.compile(options=...)`. WAN uses that hook to enable `emulate_precision_casts` by default when the installed PyTorch exposes the option, while explicit user-provided options still take precedence. The shared WAN YAML configs now show the option explicitly:

```yaml
torch_compile_config:
  options:
    emulate_precision_casts: true
```

One implementation detail: PyTorch rejects passing `mode` and `options` together, so the compile path passes `mode="default"` only when no `options` are supplied.

## Why (measured impact)

WAN 2.2 T2V A14B, B200, 50 steps, 720p/81f. **LPIPS measured against the eager (no-`torch.compile`) output of the same precision**; lower = closer to eager. `off` = compiled without `emulate_precision_casts`; `on` = compiled with `options={"emulate_precision_casts": True}`. No sparse attention involved.

| precision | LPIPS vs eager: off -> on | Δ fidelity | gen time: off -> on | Δ perf |
|---|---|---|---|---|
| **BF16** | 0.2185 -> **0.1524** | **-30.3%** | 528.2s -> 528.4s | +0.1s (noise) |
| **FP8 (block)** | 0.3965 -> **0.3840** | -3.2% | 492.0s -> 490.1s | -1.9s (noise) |
| **NVFP4** | 0.5096 -> 0.5134 | +0.8% | 468.3s -> 467.1s | -1.2s (noise) |

- **BF16 (the default precision) gets a large fidelity gain**: compiled output is about 30% closer to eager because fused BF16 cast-heavy block math dominates the numerics there.
- The effect tapers as quantization error grows: small for FP8, neutral for NVFP4 within run-to-run noise.
- **Perf is unchanged** across all three precisions. Every delta is within noise on roughly 470-530s runs.

## Notes for reviewers

- The option is now part of the VisualGen config surface instead of a process-global `torch._inductor.config` mutation.
- WAN keeps the previous default behavior through its pipeline-specific compile-options hook, but users can override it with `torch_compile_config.options.emulate_precision_casts: false`.
- YAML users can pass arbitrary `torch.compile(options=...)` entries through `torch_compile_config.options`.
- This changes WAN compiled numerics. Any golden/accuracy test that exercises a compiled WAN path may need refreshing to the more eager-faithful compiled output.

## Test Coverage

- `pre-commit run --files` on all modified files.
- `pytest -q tests/unittest/_torch/visual_gen/test_visual_gen_args.py` passed before rebasing onto latest `main` (`52 passed`).
- Manual A/B above: eager reference vs compiled without the option vs compiled with the option across BF16 / FP8 / NVFP4, 4 prompts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced Wan model compilation handling for improved precision casting behavior during PyTorch compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
