### PR TITLE
[None][test] Fix Mamba hybrid transceiver helper

### DIFF
--- a/tests/unittest/others/test_kv_cache_transceiver.py
+++ b/tests/unittest/others/test_kv_cache_transceiver.py
@@ -16,7 +16,7 @@ from tensorrt_llm._torch.pyexecutor.kv_cache_transceiver import \
 from tensorrt_llm._torch.pyexecutor.llm_request import (LlmRequest,
                                                         LlmRequestState)
 from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import \
-    MambaHybridCacheManager
+    MixedMambaHybridCacheManager
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
 from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
 from tensorrt_llm.llmapi.llm_args import CacheTransceiverConfig, KvCacheConfig
@@ -432,7 +432,7 @@ def create_hybrid_cache_manager(mapping,
                                 dtype,
                                 mamba_conv_dtype=torch.float16,
                                 mamba_ssm_dtype=torch.float16):
-    """Create a MambaHybridCacheManager for testing hybrid models.
+    """Create a MixedMambaHybridCacheManager for testing hybrid models.
 
     This manager handles both KV cache (attention layers) and Mamba cache (RNN layers).
 
@@ -449,7 +449,7 @@ def create_hybrid_cache_manager(mapping,
     attention_layer_mask = [True, False]
     mamba_layer_mask = [False, True]
 
-    return MambaHybridCacheManager(
+    return MixedMambaHybridCacheManager(
         # Mamba cache parameters
         mamba_d_state=16,
         mamba_d_conv=4,
@@ -460,7 +460,6 @@ def create_hybrid_cache_manager(mapping,
         mamba_layer_mask=mamba_layer_mask,
         mamba_cache_dtype=mamba_conv_dtype,
         mamba_ssm_cache_dtype=mamba_ssm_dtype,
-        is_disagg=True,
         kv_cache_config=KvCacheConfig(
             max_tokens=256,
             enable_block_reuse=False,
@@ -572,7 +571,7 @@ def test_hybrid_cache_transceiver_single_process(backend, hybrid_dtypes,
                                                       max_tokens_in_buffer=512)
     dist = Distributed.get(mapping)
 
-    # Create transceivers - MambaHybridCacheManager serves as both kv_cache_manager and mamba_cache_manager
+    # Create transceivers - the hybrid manager serves as both kv_cache_manager and mamba_cache_manager
     cache_transceiver_ctx = create_kv_cache_transceiver(
         mapping,
         dist,


### PR DESCRIPTION
## Summary
- Update the hybrid KV cache transceiver test helper to instantiate `MixedMambaHybridCacheManager` instead of the marker `MambaHybridCacheManager` base class.
- Refresh the helper docstring/comment to match the concrete test path.

## Root Cause
`MambaHybridCacheManager` was refactored into a marker base class used for `isinstance` checks and type hints. The unit-test helper still attempted to call it with constructor arguments, which raises `TypeError: MambaHybridCacheManager() takes no arguments` before the hybrid transceiver tests can run. The helper constructs a disaggregated mixed KV+Mamba manager directly, so the matching concrete class is `MixedMambaHybridCacheManager`.

## Dependency
This PR is based directly on `main` and does not depend on PR #15181.

## Validation
- `python3 -m py_compile tests/unittest/others/test_kv_cache_transceiver.py`
- Local pre-commit hooks passed during `git commit -s` using Python 3.12.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated KV-cache transceiver test infrastructure to use an improved hybrid cache manager for better test coverage and management of cache operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->