### PR TITLE
[TRTLLM-12721][perf] Remove ready-ID transfer gathers

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
+++ b/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
@@ -35,6 +35,7 @@
 #include <torch/custom_class.h>
 #include <torch/python.h>
 #include <type_traits>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -287,6 +288,12 @@ private:
     // Dedup sets so observe-only timeout WARN logs fire at most once per stuck request.
     std::unordered_set<LlmRequest::RequestIdType> mTimedOutSenderIds;
     std::unordered_set<LlmRequest::RequestIdType> mTimedOutRequesterIds;
+    std::unordered_set<LlmRequest::RequestIdType> mCompletedSenderRequestIds;
+    std::unordered_set<LlmRequest::RequestIdType> mFailedSenderRequestIds;
+    std::unordered_map<LlmRequest::RequestIdType, std::shared_ptr<LlmRequest>> mSenderRequestsAwaitingConsensus;
+    std::unordered_set<LlmRequest::RequestIdType> mCompletedRequesterRequestIds;
+    std::unordered_set<LlmRequest::RequestIdType> mFailedRequesterRequestIds;
+    std::unordered_map<LlmRequest::RequestIdType, std::shared_ptr<LlmRequest>> mRequesterRequestsAwaitingConsensus;
     mpi::MpiComm const* mMpiWorldComm{nullptr};
 
     std::shared_ptr<CacheTransceiverComm> mGroupComm;

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -55,12 +55,164 @@
 #include <algorithm>
 #include <cstddef>
 #include <numeric>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace tensorrt_llm::batch_manager
 {
 
 std::mutex CacheTransceiver::mDllMutex;
+
+namespace
+{
+
+using RequestIdType = LlmRequest::RequestIdType;
+
+enum class TransferConsensusState : std::uint64_t
+{
+    kCompleted = 1,
+    kFailed = 2,
+};
+
+struct TransferStateCounts
+{
+    int completedCount{0};
+    int failedCount{0};
+};
+
+struct TransferConsensusOutcome
+{
+    std::unordered_set<RequestIdType> completedRequestIds;
+    std::unordered_set<RequestIdType> failedRequestIds;
+};
+
+void appendPackedTransferState(
+    std::vector<std::uint64_t>& packedStates, RequestIdType requestId, TransferConsensusState state)
+{
+    packedStates.push_back(requestId);
+    packedStates.push_back(static_cast<std::uint64_t>(state));
+}
+
+std::vector<std::uint64_t> gatherPackedTransferStates(
+    std::shared_ptr<CacheTransceiverComm> const& comm, std::vector<std::uint64_t> const& packedStates)
+{
+    int localSize = static_cast<int>(packedStates.size());
+    std::vector<int> sizes(comm->getSize());
+    std::vector<std::uint64_t> gatheredStates;
+    if (useMPI())
+    {
+        comm->allgather(&localSize, sizes.data(), 1, mpi::MpiType::kINT32);
+        std::vector<int> displs(comm->getSize());
+        size_t totalSize = 0;
+        for (int i = 0; i < comm->getSize(); i++)
+        {
+            displs[i] = static_cast<int>(totalSize);
+            totalSize += sizes[i];
+        }
+        gatheredStates.resize(totalSize);
+        comm->allgatherv(packedStates.data(), static_cast<int>(packedStates.size()), mpi::MpiType::kUINT64,
+            gatheredStates.data(), sizes, displs, mpi::MpiType::kUINT64);
+    }
+    else
+    {
+        comm->allgather(&localSize, std::ref(sizes), {});
+        size_t totalSize = std::accumulate(sizes.begin(), sizes.end(), 0);
+        gatheredStates.resize(totalSize);
+        comm->allgatherv(std::ref(packedStates), std::ref(gatheredStates), std::cref(sizes), {});
+    }
+    return gatheredStates;
+}
+
+TransferConsensusOutcome reduceTransferStates(std::shared_ptr<CacheTransceiverComm> const& comm,
+    std::unordered_set<RequestIdType> const& completedRequestIds,
+    std::unordered_set<RequestIdType> const& failedRequestIds)
+{
+    std::vector<std::uint64_t> localStates;
+    localStates.reserve((completedRequestIds.size() + failedRequestIds.size()) * 2);
+    for (auto const requestId : completedRequestIds)
+    {
+        if (failedRequestIds.find(requestId) == failedRequestIds.end())
+        {
+            appendPackedTransferState(localStates, requestId, TransferConsensusState::kCompleted);
+        }
+    }
+    for (auto const requestId : failedRequestIds)
+    {
+        appendPackedTransferState(localStates, requestId, TransferConsensusState::kFailed);
+    }
+
+    int const syncSize = (comm != nullptr) ? comm->getSize() : 1;
+    auto const gatheredStates
+        = ((comm != nullptr) && syncSize > 1) ? gatherPackedTransferStates(comm, localStates) : std::move(localStates);
+
+    constexpr size_t kPackedStateFields = 2;
+    TLLM_CHECK_WITH_INFO(gatheredStates.size() % kPackedStateFields == 0,
+        "Packed transfer state consensus payload must contain request/state pairs.");
+
+    std::unordered_map<RequestIdType, TransferStateCounts> stateCounts;
+    for (size_t idx = 0; idx < gatheredStates.size(); idx += kPackedStateFields)
+    {
+        auto const requestId = gatheredStates.at(idx);
+        auto const state = static_cast<TransferConsensusState>(gatheredStates.at(idx + 1));
+        auto& counts = stateCounts[requestId];
+        switch (state)
+        {
+        case TransferConsensusState::kCompleted: counts.completedCount++; break;
+        case TransferConsensusState::kFailed: counts.failedCount++; break;
+        }
+    }
+
+    TransferConsensusOutcome outcome;
+    for (auto const& [requestId, counts] : stateCounts)
+    {
+        auto const terminalCount = counts.completedCount + counts.failedCount;
+        if (terminalCount == syncSize && counts.failedCount > 0)
+        {
+            outcome.failedRequestIds.insert(requestId);
+        }
+        else if (counts.completedCount == syncSize)
+        {
+            outcome.completedRequestIds.insert(requestId);
+        }
+    }
+    return outcome;
+}
+
+TransferConsensusOutcome reduceTransferStates(std::shared_ptr<CacheTransceiverComm> const& firstComm,
+    std::shared_ptr<CacheTransceiverComm> const& secondComm,
+    std::unordered_set<RequestIdType> const& completedRequestIds,
+    std::unordered_set<RequestIdType> const& failedRequestIds)
+{
+    auto const firstOutcome = reduceTransferStates(firstComm, completedRequestIds, failedRequestIds);
+    return reduceTransferStates(secondComm, firstOutcome.completedRequestIds, firstOutcome.failedRequestIds);
+}
+
+void recordLocalTransferOutcome(RequestIdType requestId, std::shared_ptr<LlmRequest> request, bool failed,
+    std::unordered_set<RequestIdType>& completedRequestIds, std::unordered_set<RequestIdType>& failedRequestIds,
+    std::unordered_map<RequestIdType, std::shared_ptr<LlmRequest>>& requestsAwaitingConsensus)
+{
+    requestsAwaitingConsensus[requestId] = std::move(request);
+    if (failed)
+    {
+        completedRequestIds.erase(requestId);
+        failedRequestIds.insert(requestId);
+    }
+    else if (failedRequestIds.find(requestId) == failedRequestIds.end())
+    {
+        completedRequestIds.insert(requestId);
+    }
+}
+
+void eraseLocalTransferOutcome(RequestIdType requestId, std::unordered_set<RequestIdType>& completedRequestIds,
+    std::unordered_set<RequestIdType>& failedRequestIds,
+    std::unordered_map<RequestIdType, std::shared_ptr<LlmRequest>>& requestsAwaitingConsensus)
+{
+    completedRequestIds.erase(requestId);
+    failedRequestIds.erase(requestId);
+    requestsAwaitingConsensus.erase(requestId);
+}
+
+} // namespace
 
 std::unique_ptr<BaseCacheTransceiver> CacheTransceiverFactory::createCacheTransceiver(
     kv_cache_manager::BaseKVCacheManager* cacheManager, runtime::ModelConfig const& modelConfig,
@@ -141,6 +293,13 @@ CacheTransceiver::CacheTransceiver(kv_cache_manager::BaseKVCacheManager* cacheMa
     {
         mGroupTensorParaComm = std::make_shared<CacheTransceiverComm>(
             mGroupComm->split(worldConfig.getPipelineParallelRank(), worldConfig.getRank()));
+    }
+    if (worldConfig.isPipelineParallel())
+    {
+        auto const ppGroupColor = worldConfig.getTensorParallelRank() * worldConfig.getContextParallelism()
+            + worldConfig.getContextParallelRank();
+        mGroupPipeParaComm
+            = std::make_shared<CacheTransceiverComm>(mGroupComm->split(ppGroupColor, worldConfig.getRank()));
     }
     int kvFactor = 2;
     if (cacheManager->getCacheType() == kv_cache_manager::CacheType::kSELFKONLY)
@@ -605,9 +764,9 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
         toCompleteIdSet.insert(request->mRequestId);
     }
 
-    RequestStatuses requestsStatus{};
-
-    // Complete all the requests in toCompleteIdSet
+    // Record local terminal outcomes for requests selected this round. The
+    // request is reported only after all ranks in the sync group agree that the
+    // request reached a terminal state.
     for (auto it = mSenderFutures.begin(); it != mSenderFutures.end();)
     {
         auto& [request, future] = *it;
@@ -626,6 +785,7 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
         }
         if (blockAll || (toCompleteIdSet.find(request->mRequestId) != toCompleteIdSet.end()))
         {
+            auto const requestId = request->mRequestId;
             try
             {
                 // Wait for up to a specified timeout
@@ -633,12 +793,9 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                 if (status == std::future_status::ready || !senderFutureTimeoutMs.has_value())
                 {
                     future.get();
-                    requestsStatus.completedRequestIds.insert(request->mRequestId);
-                    if (markComplete)
-                    {
-                        request->setState(LlmRequestState::kDISAGG_CONTEXT_COMPLETE);
-                    }
-                    mTimedOutSenderIds.erase(request->mRequestId);
+                    bool const failed = request->getState() == LlmRequestState::kDISAGG_TRANS_ERROR;
+                    recordLocalTransferOutcome(requestId, request, failed, mCompletedSenderRequestIds,
+                        mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
                     it = mSenderFutures.erase(it);
                 }
                 else if (status == std::future_status::timeout)
@@ -649,22 +806,20 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                 }
                 else
                 {
-                    TLLM_LOG_ERROR(
-                        "Future returned unexpected status for request %ld. Marking as error", request->mRequestId);
+                    TLLM_LOG_ERROR("Future returned unexpected status for request %ld. Marking as error", requestId);
 
                     request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
-                    requestsStatus.errorRequestIds.insert(request->mRequestId);
-                    mTimedOutSenderIds.erase(request->mRequestId);
+                    recordLocalTransferOutcome(requestId, request, /*failed=*/true, mCompletedSenderRequestIds,
+                        mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
                     it = mSenderFutures.erase(it);
                 }
             }
             catch (std::exception const& e)
             {
-                TLLM_LOG_ERROR(
-                    "Error occurred during context transfer for request %ld: %s", request->mRequestId, e.what());
+                TLLM_LOG_ERROR("Error occurred during context transfer for request %ld: %s", requestId, e.what());
                 request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
-                requestsStatus.errorRequestIds.insert(request->mRequestId);
-                mTimedOutSenderIds.erase(request->mRequestId);
+                recordLocalTransferOutcome(requestId, request, /*failed=*/true, mCompletedSenderRequestIds,
+                    mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
                 it = mSenderFutures.erase(it);
             }
         }
@@ -672,6 +827,39 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
         {
             ++it;
         }
+    }
+
+    RequestStatuses requestsStatus{};
+    auto const consensusOutcome
+        = reduceTransferStates(syncComm, mGroupPipeParaComm, mCompletedSenderRequestIds, mFailedSenderRequestIds);
+    for (auto const requestId : consensusOutcome.failedRequestIds)
+    {
+        auto const requestIt = mSenderRequestsAwaitingConsensus.find(requestId);
+        if (requestIt == mSenderRequestsAwaitingConsensus.end())
+        {
+            continue;
+        }
+        requestIt->second->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+        requestsStatus.errorRequestIds.insert(requestId);
+        mTimedOutSenderIds.erase(requestId);
+        eraseLocalTransferOutcome(
+            requestId, mCompletedSenderRequestIds, mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
+    }
+    for (auto const requestId : consensusOutcome.completedRequestIds)
+    {
+        auto const requestIt = mSenderRequestsAwaitingConsensus.find(requestId);
+        if (requestIt == mSenderRequestsAwaitingConsensus.end())
+        {
+            continue;
+        }
+        requestsStatus.completedRequestIds.insert(requestId);
+        if (markComplete)
+        {
+            requestIt->second->setState(LlmRequestState::kDISAGG_CONTEXT_COMPLETE);
+        }
+        mTimedOutSenderIds.erase(requestId);
+        eraseLocalTransferOutcome(
+            requestId, mCompletedSenderRequestIds, mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
     }
 
     return requestsStatus;
@@ -799,6 +987,7 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
     for (auto it = mRequesterFutures.begin(); it != mRequesterFutures.end();)
     {
         auto& request = it->first;
+        auto const requestId = request->mRequestId;
         if (kvTransferTimeoutMs.has_value())
         {
             auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -812,39 +1001,34 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
                     request->mRequestId, elapsedMs, kvTransferTimeoutMs.value());
             }
         }
-        if (blockAll || toCompleteIdSet.find(request->mRequestId) != toCompleteIdSet.end())
+        if (blockAll || toCompleteIdSet.find(requestId) != toCompleteIdSet.end())
         {
             try
             {
                 it->second.get();
-                request->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_COMPLETE);
-
-                // Gather the kv cache transfer time from all workers and update to leader rank
-                if (!common::getEnvKVCacheTimeOutputPath().empty())
-                {
-                    auto bwSyncComm = mCacheState->getParallelConfig().mEnableAttentionDP ? mGroupDataComm : mGroupComm;
-                    updateKVCacheTransferBW(bwSyncComm, request.get());
-                }
+                bool const failed = request->getState() == LlmRequestState::kDISAGG_TRANS_ERROR;
+                recordLocalTransferOutcome(requestId, request, failed, mCompletedRequesterRequestIds,
+                    mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
             }
             catch (std::exception const& e)
             {
-                TLLM_LOG_ERROR(
-                    "Error occurred during generation transfer for request %ld: %s", request->mRequestId, e.what());
+                TLLM_LOG_ERROR("Error occurred during generation transfer for request %ld: %s", requestId, e.what());
                 request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+                recordLocalTransferOutcome(requestId, request, /*failed=*/true, mCompletedRequesterRequestIds,
+                    mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
             }
             if (useMPI())
             {
                 TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
-                    "**** it->first->mRequestId: %ld, context request ID: %ld ******** get feature ***",
-                    request->mRequestId, request->getContextPhaseParams().value().getReqId());
+                    "**** it->first->mRequestId: %ld, context request ID: %ld ******** get feature ***", requestId,
+                    request->getContextPhaseParams().value().getReqId());
             }
             else
             {
                 TLLM_LOG_DEBUG(tensorrt_llm::pg_utils::get_world_pg()->getRank(),
-                    "**** it->first->mRequestId: %ld, context request ID: %ld ******** get feature ***",
-                    request->mRequestId, request->getContextPhaseParams().value().getReqId());
+                    "**** it->first->mRequestId: %ld, context request ID: %ld ******** get feature ***", requestId,
+                    request->getContextPhaseParams().value().getReqId());
             }
-            mTimedOutRequesterIds.erase(request->mRequestId);
             it = mRequesterFutures.erase(it);
         }
         else
@@ -852,11 +1036,44 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
             ++it;
         }
     }
+
+    auto const consensusOutcome
+        = reduceTransferStates(syncComm, mCompletedRequesterRequestIds, mFailedRequesterRequestIds);
+    for (auto const requestId : consensusOutcome.failedRequestIds)
+    {
+        auto const requestIt = mRequesterRequestsAwaitingConsensus.find(requestId);
+        if (requestIt == mRequesterRequestsAwaitingConsensus.end())
+        {
+            continue;
+        }
+        requestIt->second->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
+        mTimedOutRequesterIds.erase(requestId);
+        eraseLocalTransferOutcome(
+            requestId, mCompletedRequesterRequestIds, mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
+    }
+    for (auto const requestId : consensusOutcome.completedRequestIds)
+    {
+        auto const requestIt = mRequesterRequestsAwaitingConsensus.find(requestId);
+        if (requestIt == mRequesterRequestsAwaitingConsensus.end())
+        {
+            continue;
+        }
+        requestIt->second->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_COMPLETE);
+
+        // Gather the kv cache transfer time from all workers and update to leader rank.
+        if (!common::getEnvKVCacheTimeOutputPath().empty())
+        {
+            updateKVCacheTransferBW(syncComm, requestIt->second.get());
+        }
+        mTimedOutRequesterIds.erase(requestId);
+        eraseLocalTransferOutcome(
+            requestId, mCompletedRequesterRequestIds, mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
+    }
 }
 
 bool CacheTransceiver::checkGenTransferComplete() const
 {
-    return mRequesterFutures.empty();
+    return mRequesterFutures.empty() && mCompletedRequesterRequestIds.empty() && mFailedRequesterRequestIds.empty();
 }
 
 bool CacheTransceiver::cancelRequest(std::shared_ptr<LlmRequest> llmRequest)

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -603,36 +603,6 @@ void CacheTransceiver::requestAndReceiveAsync(std::shared_ptr<LlmRequest> llmReq
     requestPtr->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_IN_PROGRESS);
 }
 
-std::vector<LlmRequest::RequestIdType> gatherRequestIds(
-    std::shared_ptr<CacheTransceiverComm> const& mComm, std::vector<LlmRequest::RequestIdType> const& requestIds)
-{
-    int localSize = static_cast<int>(requestIds.size());
-    std::vector<int> sizes(mComm->getSize());
-    std::vector<LlmRequest::RequestIdType> retData;
-    if (useMPI())
-    {
-        mComm->allgather(&localSize, sizes.data(), 1, mpi::MpiType::kINT32);
-        std::vector<int> displs(mComm->getSize());
-        size_t totalSize = 0;
-        for (int i = 0; i < mComm->getSize(); i++)
-        {
-            displs[i] = totalSize;
-            totalSize += sizes[i];
-        }
-        retData.resize(totalSize);
-        mComm->allgatherv(requestIds.data(), static_cast<int>(requestIds.size()), mpi::MpiType::kUINT64, retData.data(),
-            sizes, displs, mpi::MpiType::kUINT64);
-    }
-    else
-    {
-        mComm->allgather(&localSize, std::ref(sizes), {});
-        size_t totalSize = std::accumulate(sizes.begin(), sizes.end(), 0);
-        retData.resize(totalSize);
-        mComm->allgatherv(std::ref(requestIds), std::ref(retData), std::cref(sizes), {});
-    }
-    return retData;
-}
-
 void updateKVCacheTransferBW(std::shared_ptr<CacheTransceiverComm> const& mComm, LlmRequest* request)
 {
     namespace su = executor::serialize_utils;
@@ -716,42 +686,12 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
     }
 
     auto syncComm = mCacheState->getParallelConfig().mEnableAttentionDP ? mGroupTPInDPComm : mGroupTensorParaComm;
-    std::vector<LlmRequest::RequestIdType> contextCompleteRequestIds;
+    std::unordered_set<LlmRequest::RequestIdType> toCompleteIdSet;
     for (auto&& [request, future] : mSenderFutures)
     {
         if (future.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready)
         {
-            contextCompleteRequestIds.push_back(request->mRequestId);
-        }
-    }
-
-    std::unordered_map<LlmRequest::RequestIdType, int> frequencyMap;
-    if ((syncComm) && syncComm->getSize() > 1)
-    {
-        auto gatherRequestIdVec = gatherRequestIds(syncComm, contextCompleteRequestIds);
-        for (auto&& requestId : gatherRequestIdVec)
-        {
-            frequencyMap[requestId]++;
-        }
-    }
-    else
-    {
-        for (auto&& requestId : contextCompleteRequestIds)
-        {
-            frequencyMap[requestId]++;
-        }
-    }
-    std::vector<std::pair<LlmRequest::RequestIdType, int>> freqVec(frequencyMap.begin(), frequencyMap.end());
-
-    std::sort(freqVec.begin(), freqVec.end(),
-        [](std::pair<LlmRequest::RequestIdType, int> const& left,
-            std::pair<LlmRequest::RequestIdType, int> const& right) { return left.second > right.second; });
-    std::unordered_set<LlmRequest::RequestIdType> toCompleteIdSet;
-    for (auto&& [requestId, freq] : freqVec)
-    {
-        if (freq == ((syncComm) ? syncComm->getSize() : 1))
-        {
-            toCompleteIdSet.insert(requestId);
+            toCompleteIdSet.insert(request->mRequestId);
         }
     }
 
@@ -867,63 +807,18 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
 void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastRequestNum)
 {
     bool blockAll = !atLeastRequestNum.has_value();
-    std::vector<LlmRequest::RequestIdType> genTransferReadyRequestIds;
+    auto syncComm = mCacheState->getParallelConfig().mEnableAttentionDP ? mGroupDataComm : mGroupComm;
+    std::unordered_set<LlmRequest::RequestIdType> toCompleteIdSet;
     for (auto&& [request, future] : mRequesterFutures)
     {
         if (future.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready)
         {
-            genTransferReadyRequestIds.push_back(request->mRequestId);
+            toCompleteIdSet.insert(request->mRequestId);
         }
     }
-    std::unordered_map<LlmRequest::RequestIdType, int> frequencyMap;
-
-    std::vector<LlmRequest::RequestIdType> toBlockRequestIds;
-    auto syncComm = mCacheState->getParallelConfig().mEnableAttentionDP ? mGroupDataComm : mGroupComm;
-    if ((syncComm) && syncComm->getSize() > 1)
-    {
-        auto gatherRequestIdVec = gatherRequestIds(syncComm, genTransferReadyRequestIds);
-        for (auto&& requestId : gatherRequestIdVec)
-        {
-            frequencyMap[requestId]++;
-        }
-    }
-    else
-    {
-        for (auto&& requestId : genTransferReadyRequestIds)
-        {
-            frequencyMap[requestId]++;
-        }
-    }
-
-    std::vector<std::pair<LlmRequest::RequestIdType, int>> freqVec(frequencyMap.begin(), frequencyMap.end());
-
-    std::sort(freqVec.begin(), freqVec.end(),
-        [](std::pair<LlmRequest::RequestIdType, int> const& left,
-            std::pair<LlmRequest::RequestIdType, int> const& right) { return left.second > right.second; });
-    std::unordered_set<LlmRequest::RequestIdType> toCompleteIdSet;
-    size_t idx = 0;
-    while (atLeastRequestNum.value_or(0) > static_cast<int>(toCompleteIdSet.size()))
-    {
-        if (idx >= freqVec.size())
-        {
-            break;
-        }
-        toCompleteIdSet.insert(freqVec.at(idx).first);
-        if (useMPI())
-        {
-            TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
-                " checkGenTransferStatus at least from freqVec requestId: %zu ", freqVec.at(idx).first);
-        }
-        else
-        {
-            TLLM_LOG_DEBUG(tensorrt_llm::pg_utils::get_world_pg()->getRank(),
-                " checkGenTransferStatus at least from freqVec requestId: %zu ", freqVec.at(idx).first);
-        }
-        idx++;
-    }
-    idx = 0;
 
     // insert order
+    size_t idx = 0;
     while (atLeastRequestNum.value_or(0) > static_cast<int>(toCompleteIdSet.size()))
     {
         if (idx >= mRequesterFutures.size())
@@ -947,23 +842,6 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
             }
         }
         idx++;
-    }
-    for (auto&& [requestId, freq] : freqVec)
-    {
-        if (freq == ((syncComm != nullptr) ? syncComm->getSize() : 1))
-        {
-            toCompleteIdSet.insert(requestId);
-        }
-        if (useMPI())
-        {
-            TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(), " checkGenTransferStatus freqVec requestId: %zu,freq:%d  ",
-                requestId, freq);
-        }
-        else
-        {
-            TLLM_LOG_DEBUG(tensorrt_llm::pg_utils::get_world_pg()->getRank(),
-                " checkGenTransferStatus freqVec requestId: %zu,freq:%d  ", requestId, freq);
-        }
     }
     if (useMPI())
     {

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -806,9 +806,9 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                 }
                 else
                 {
-                    TLLM_LOG_ERROR("Future returned unexpected status for request %ld. Marking as error", requestId);
+                    TLLM_LOG_ERROR(
+                        "Future returned unexpected status for request %ld. Recording as failed.", requestId);
 
-                    request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
                     recordLocalTransferOutcome(requestId, request, /*failed=*/true, mCompletedSenderRequestIds,
                         mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
                     it = mSenderFutures.erase(it);
@@ -817,7 +817,6 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
             catch (std::exception const& e)
             {
                 TLLM_LOG_ERROR("Error occurred during context transfer for request %ld: %s", requestId, e.what());
-                request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
                 recordLocalTransferOutcome(requestId, request, /*failed=*/true, mCompletedSenderRequestIds,
                     mFailedSenderRequestIds, mSenderRequestsAwaitingConsensus);
                 it = mSenderFutures.erase(it);
@@ -1007,13 +1006,18 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
             {
                 it->second.get();
                 bool const failed = request->getState() == LlmRequestState::kDISAGG_TRANS_ERROR;
+                if (failed)
+                {
+                    // The receiver uses the error state as a local transfer-failed signal.
+                    // Keep that signal local until the consensus outcome commits it globally.
+                    request->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_IN_PROGRESS);
+                }
                 recordLocalTransferOutcome(requestId, request, failed, mCompletedRequesterRequestIds,
                     mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
             }
             catch (std::exception const& e)
             {
                 TLLM_LOG_ERROR("Error occurred during generation transfer for request %ld: %s", requestId, e.what());
-                request->setState(LlmRequestState::kDISAGG_TRANS_ERROR);
                 recordLocalTransferOutcome(requestId, request, /*failed=*/true, mCompletedRequesterRequestIds,
                     mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
             }


### PR DESCRIPTION
## Dependency

Depends on #15139. This draft PR is stacked on top of the transfer-state consensus foundation from #15139 and should not be reviewed or merged independently.

## Description

Removes the existing ready-request-ID gather path from `CacheTransceiver` and lets the new transfer-state consensus path from #15139 provide the cross-rank terminal-state agreement.

Specifically, this removes:

- `gatherRequestIds(...)`
- `checkContextTransferStatus`: `gatherRequestIds(syncComm, contextCompleteRequestIds)`
- `checkGenTransferStatus`: `gatherRequestIds(syncComm, genTransferReadyRequestIds)`

After this change, each side seeds `toCompleteIdSet` from locally ready futures and keeps the existing insertion-order fallback for `atLeastRequestNum`. Final state commit remains gated by the `{request_id, completed/failed}` consensus path introduced in #15139.

## Why Draft

This is intentionally an experiment/cleanup PR to let CI validate whether the older ready-ID collectives are truly redundant. The main risk is preserving `atLeastRequestNum`, ordering, and blocking semantics across TP/PP/CP/attention-DP cases.

## Testing

- `pre-commit run clang-format --files cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp`
- `pre-commit run codespell --files cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp`
- `git diff --check`

Full commit-time pre-commit was attempted, but local hooks fail in `scripts/check_test_list.py` with `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'` under the local hook environment; unrelated C++ hooks passed.
