### PR TITLE
[None][chore] Simplify MoE lora

### DIFF
--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/include/moe_kernels.h
@@ -21,7 +21,7 @@
 #include "tensorrt_llm/common/cudaUtils.h"
 #include "tensorrt_llm/common/quantization.h"
 #include "tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm.h"
-#include "tensorrt_llm/kernels/cutlass_kernels/include/moe_lora_device_path.h"
+#include "tensorrt_llm/kernels/cutlass_kernels/include/moe_lora_grouped_gemm.h"
 #include <cstdint>
 #ifdef ENABLE_FP4
 #include <cuda_fp4.h>
@@ -69,13 +69,14 @@ struct LoraParams
 
     cudaEvent_t* memcpy_event_ptr;
 
-    // Device-side capture-safe LoRA path scratch. When device_path.enabled is
+    // Capture-safe grouped-GEMM LoRA core scratch. When grouped_gemm.enabled is
     // true, the kernel uses launchMoeLoraPointerExpand, launchMoeLoraProblemBuilder,
-    // and cudaGraph(SplitK)GroupedGemm instead of the legacy host-pointer
-    // LoraImpl::run path. The pointers refer to persistent allocations owned by
-    // the calling FusedMoeRunner, so their addresses are stable across
-    // CUDA-graph captures and replays.
-    ::tensorrt_llm::kernels::cutlass_kernels::MoeLoraDevicePath device_path;
+    // and cudaGraph(SplitK)GroupedGemm instead of the host-pointer LoraImpl::run
+    // path. The pointers refer to persistent allocations owned by the calling
+    // FusedMoeRunner, so their addresses are stable across CUDA-graph captures
+    // and replays. Default-constructed (enabled == false) for the legacy
+    // TensorRT MoE plugin, which uses its own cuBLAS LoraImpl path.
+    ::tensorrt_llm::kernels::cutlass_kernels::MoeLoraGroupedGemm grouped_gemm;
 
     LoraParams() = default;
 

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/include/moe_lora_grouped_gemm.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/include/moe_lora_grouped_gemm.h
@@ -29,10 +29,10 @@ namespace kernels::cutlass_kernels
 {
 
 // Forward declaration; the typedef below references it by name.
-struct MoeLoraDevicePathModule;
+struct MoeLoraGroupedGemmModule;
 
 // Function-pointer dispatch for the libtorch-dependent GEMM stage of the MoE
-// LoRA device path. The implementation lives in th_common (moeOp.cpp) because
+// LoRA grouped-GEMM core. The implementation lives in th_common (moeOp.cpp) because
 // the underlying cudaGraph(SplitK)GroupedGemm wrappers allocate workspace via
 // at::Tensor, which is not linkable from libmoe_gemm_src.a (that archive ends
 // up inside the TensorRT plugin shared object, which deliberately does not
@@ -54,7 +54,7 @@ struct MoeLoraDevicePathModule;
 //   data_type:           scalar dtype expected by the GEMM wrappers
 //                        (fp16/bf16/fp32).
 //   stream:              CUDA stream to launch onto.
-using MoeLoraDeviceRunFn = void (*)(MoeLoraDevicePathModule const& mod, int64_t num_permuted_tokens,
+using MoeLoraGroupedGemmRunFn = void (*)(MoeLoraGroupedGemmModule const& mod, int64_t num_permuted_tokens,
     int64_t in_hidden_size, int64_t max_lora_rank, int64_t dtype_bytes, int64_t splitk_slices, void const* input_base,
     void* output_base, nvinfer1::DataType data_type, cudaStream_t stream);
 
@@ -80,8 +80,8 @@ using MoeLoraDeviceRunFn = void (*)(MoeLoraDevicePathModule const& mod, int64_t 
 //
 // out_hidden_size is the trailing dimension of the module's output buffer; it
 // is inter_size for fc1/gated and hidden_size for fc2. The output base address
-// itself is passed directly to runMoeLoraDeviceModule at the call site.
-struct MoeLoraDevicePathModule
+// itself is passed directly to runMoeLoraGroupedGemmModule at the call site.
+struct MoeLoraGroupedGemmModule
 {
     // Per-source-token (rank, A_ptr, B_ptr) device mirrors, staged via a
     // pinned-host to device async H2D in FusedMoeRunner::buildMoeLoraParams.
@@ -128,14 +128,15 @@ struct MoeLoraDevicePathModule
 
     // Trailing dimension of the module's output buffer (inter_size for
     // fc1/gated, hidden_size for fc2). The output base address is supplied
-    // directly to runMoeLoraDeviceModule at the call site.
+    // directly to runMoeLoraGroupedGemmModule at the call site.
     int64_t out_hidden_size = 0;
 };
 
-// Top-level device-path bundle attached to LoraParams when the device LoRA
-// path is active. enabled == false means the FusedMoeRunner runs the legacy
-// host path.
-struct MoeLoraDevicePath
+// Top-level grouped-GEMM bundle attached to LoraParams when the MoE op runs the
+// capture-safe grouped-GEMM LoRA core. enabled == false is the default and means
+// this consumer does not use the core (the legacy TensorRT MoE plugin leaves it
+// false and runs its own cuBLAS LoRA path).
+struct MoeLoraGroupedGemm
 {
     bool enabled = false;
 
@@ -149,13 +150,13 @@ struct MoeLoraDevicePath
     bool has_gated = false;
 
     // libtorch-bound GEMM dispatch entry point, populated by moeOp.cpp when the
-    // device path is enabled. nullptr means the device path is unavailable from
+    // grouped-GEMM core is enabled. nullptr means the core is unavailable from
     // this consumer (for example, the TensorRT plugin).
-    MoeLoraDeviceRunFn run = nullptr;
+    MoeLoraGroupedGemmRunFn run = nullptr;
 
-    MoeLoraDevicePathModule fc1;
-    MoeLoraDevicePathModule fc2;
-    MoeLoraDevicePathModule gated;
+    MoeLoraGroupedGemmModule fc1;
+    MoeLoraGroupedGemmModule fc2;
+    MoeLoraGroupedGemmModule gated;
 };
 
 } // namespace kernels::cutlass_kernels

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_kernels.cu
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_kernels.cu
@@ -60,11 +60,11 @@
 
 #include "tensorrt_llm/kernels/cutlass_kernels/include/moe_lora_pointer_expand.h"
 #include "tensorrt_llm/kernels/cutlass_kernels/include/moe_util_kernels.h"
-// NOTE: the device-path GEMM dispatch (cudaGraph(SplitK)GroupedGemm,
+// NOTE: the grouped-GEMM dispatch (cudaGraph(SplitK)GroupedGemm,
 // launchMoeLoraProblemBuilder) is not called here. Those wrappers pull in
 // libtorch via at::Tensor, and this file is archived into libmoe_gemm_src.a,
 // which the TensorRT plugin also links and must keep libtorch-free. The
-// dispatch is reached through the LoraParams::device_path.run function pointer,
+// dispatch is reached through the LoraParams::grouped_gemm.run function pointer,
 // populated in moeOp.cpp.
 
 #ifndef CUDART_VERSION
@@ -3680,18 +3680,19 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, BackBoneType, Enab
     sync_check_cuda_error(stream);
 }
 
-// Thin wrapper around the LoraParams::device_path.run function pointer (the
+// Thin wrapper around the LoraParams::grouped_gemm.run function pointer (the
 // libtorch-bound GEMM dispatch defined in moeOp.cpp). Validates the module was
 // populated and that a dispatch is available before calling through.
-inline void runMoeLoraDeviceModule(::tensorrt_llm::kernels::cutlass_kernels::MoeLoraDevicePathModule const& mod,
+inline void runMoeLoraGroupedGemmModule(::tensorrt_llm::kernels::cutlass_kernels::MoeLoraGroupedGemmModule const& mod,
     int64_t num_permuted_tokens, int64_t in_hidden_size, int64_t max_lora_rank, int64_t dtype_bytes,
     int64_t splitk_slices, void const* input_base, void* output_base,
-    ::tensorrt_llm::kernels::cutlass_kernels::MoeLoraDeviceRunFn run, nvinfer1::DataType data_type, cudaStream_t stream)
+    ::tensorrt_llm::kernels::cutlass_kernels::MoeLoraGroupedGemmRunFn run, nvinfer1::DataType data_type,
+    cudaStream_t stream)
 {
     TLLM_CHECK_WITH_INFO(mod.permuted_ranks_dev != nullptr,
-        "Device-path LoRA module is missing permuted ranks buffer (forgot to populate device_path?).");
+        "Grouped-GEMM LoRA module is missing permuted ranks buffer (forgot to populate grouped_gemm?).");
     TLLM_CHECK_WITH_INFO(run != nullptr,
-        "Device-path LoRA GEMM dispatch is unavailable: device_path.run was not populated (this consumer of "
+        "Grouped-GEMM LoRA GEMM dispatch is unavailable: grouped_gemm.run was not populated (this consumer of "
         "libmoe_gemm_src.a does not link libtorch).");
     run(mod, num_permuted_tokens, in_hidden_size, max_lora_rank, dtype_bytes, splitk_slices, input_base, output_base,
         data_type, stream);
@@ -3719,7 +3720,7 @@ constexpr nvinfer1::DataType moeLoraNvInferType()
     }
     else
     {
-        static_assert(sizeof(ScaleBiasType) == 0, "MoE LoRA device path supports fp16/bf16/fp32 only.");
+        static_assert(sizeof(ScaleBiasType) == 0, "MoE LoRA grouped-GEMM path supports fp16/bf16/fp32 only.");
     }
 }
 
@@ -3741,45 +3742,67 @@ bool CutlassMoeFCRunner<T, WeightType, OutputType, InputType, BackBoneType, Enab
 
     bool all_token_without_lora = true;
 
-    // Device-path early return. When enabled, launchMoeLoraPointerExpand
+    // Grouped-GEMM early return. When enabled, launchMoeLoraPointerExpand
     // produces every consumer's input on-device, so the host pointer fan-out
     // and its gating cudaEventSynchronize are skipped. Returning false is safe:
     // zero per-token ranks collapse the grouped-GEMM problems to no-ops.
-    if (lora_params.device_path.enabled)
+    if (lora_params.grouped_gemm.enabled)
     {
-        auto const& dp = lora_params.device_path;
-        // Translate per-module device-path metadata into the MoeLoraExpandModule
+        auto const& grouped_gemm = lora_params.grouped_gemm;
+        // Validate the metadata host-side before the pointer-expand kernel
+        // computes per-expert byte offsets from it and dereferences them, so a
+        // stale dimension or unpopulated module fails with a clear message
+        // instead of a device illegal access.
+        TLLM_CHECK_WITH_INFO(grouped_gemm.dtype_bytes > 0,
+            "Grouped-GEMM LoRA dtype_bytes must be positive (grouped_gemm not fully populated?).");
+        auto validateLoraModule = [](::tensorrt_llm::kernels::cutlass_kernels::MoeLoraGroupedGemmModule const& mod,
+                                      char const* name, int64_t expectedDimA, int64_t expectedDimB)
+        {
+            TLLM_CHECK_WITH_INFO(mod.ranks_src_dev != nullptr && mod.ptrs_src_dev != nullptr
+                    && mod.permuted_ranks_dev != nullptr && mod.permuted_ptrs_dev != nullptr,
+                "Grouped-GEMM LoRA %s module is missing pointer-expand buffers.", name);
+            TLLM_CHECK_WITH_INFO(mod.dim_a == expectedDimA && mod.dim_b == expectedDimB,
+                "Grouped-GEMM LoRA %s module dimensions do not match the MoE runner dimensions.", name);
+        };
+        validateLoraModule(grouped_gemm.fc1, "fc1", hidden_size, inter_size);
+        validateLoraModule(grouped_gemm.fc2, "fc2", inter_size, hidden_size);
+        if (is_gated_activation)
+        {
+            validateLoraModule(grouped_gemm.gated, "gated", hidden_size, inter_size);
+        }
+
+        // Translate per-module grouped-GEMM metadata into the MoeLoraExpandModule
         // API that the pointer-expand kernel expects.
         ::tensorrt_llm::kernels::cutlass_kernels::MoeLoraExpandModule fc1_mod{};
-        fc1_mod.ranks_src = dp.fc1.ranks_src_dev;
-        fc1_mod.ptrs_src = dp.fc1.ptrs_src_dev;
-        fc1_mod.dim_a = dp.fc1.dim_a;
-        fc1_mod.dim_b = dp.fc1.dim_b;
-        fc1_mod.ranks_out = dp.fc1.permuted_ranks_dev;
-        fc1_mod.ptrs_out = dp.fc1.permuted_ptrs_dev;
+        fc1_mod.ranks_src = grouped_gemm.fc1.ranks_src_dev;
+        fc1_mod.ptrs_src = grouped_gemm.fc1.ptrs_src_dev;
+        fc1_mod.dim_a = grouped_gemm.fc1.dim_a;
+        fc1_mod.dim_b = grouped_gemm.fc1.dim_b;
+        fc1_mod.ranks_out = grouped_gemm.fc1.permuted_ranks_dev;
+        fc1_mod.ptrs_out = grouped_gemm.fc1.permuted_ptrs_dev;
 
         ::tensorrt_llm::kernels::cutlass_kernels::MoeLoraExpandModule fc2_mod{};
-        fc2_mod.ranks_src = dp.fc2.ranks_src_dev;
-        fc2_mod.ptrs_src = dp.fc2.ptrs_src_dev;
-        fc2_mod.dim_a = dp.fc2.dim_a;
-        fc2_mod.dim_b = dp.fc2.dim_b;
-        fc2_mod.ranks_out = dp.fc2.permuted_ranks_dev;
-        fc2_mod.ptrs_out = dp.fc2.permuted_ptrs_dev;
+        fc2_mod.ranks_src = grouped_gemm.fc2.ranks_src_dev;
+        fc2_mod.ptrs_src = grouped_gemm.fc2.ptrs_src_dev;
+        fc2_mod.dim_a = grouped_gemm.fc2.dim_a;
+        fc2_mod.dim_b = grouped_gemm.fc2.dim_b;
+        fc2_mod.ranks_out = grouped_gemm.fc2.permuted_ranks_dev;
+        fc2_mod.ptrs_out = grouped_gemm.fc2.permuted_ptrs_dev;
 
         ::tensorrt_llm::kernels::cutlass_kernels::MoeLoraExpandModule gated_mod{};
         if (is_gated_activation)
         {
-            gated_mod.ranks_src = dp.gated.ranks_src_dev;
-            gated_mod.ptrs_src = dp.gated.ptrs_src_dev;
-            gated_mod.dim_a = dp.gated.dim_a;
-            gated_mod.dim_b = dp.gated.dim_b;
-            gated_mod.ranks_out = dp.gated.permuted_ranks_dev;
-            gated_mod.ptrs_out = dp.gated.permuted_ptrs_dev;
+            gated_mod.ranks_src = grouped_gemm.gated.ranks_src_dev;
+            gated_mod.ptrs_src = grouped_gemm.gated.ptrs_src_dev;
+            gated_mod.dim_a = grouped_gemm.gated.dim_a;
+            gated_mod.dim_b = grouped_gemm.gated.dim_b;
+            gated_mod.ranks_out = grouped_gemm.gated.permuted_ranks_dev;
+            gated_mod.ptrs_out = grouped_gemm.gated.permuted_ptrs_dev;
         }
 
         ::tensorrt_llm::kernels::cutlass_kernels::launchMoeLoraPointerExpand(permuted_row_to_unpermuted_row_,
-            expert_first_token_offset_, num_experts_per_node, start_expert, num_rows, expanded_num_rows, dp.dtype_bytes,
-            fc1_mod, fc2_mod, is_gated_activation ? &gated_mod : nullptr, stream);
+            expert_first_token_offset_, num_experts_per_node, start_expert, num_rows, expanded_num_rows,
+            grouped_gemm.dtype_bytes, fc1_mod, fc2_mod, is_gated_activation ? &gated_mod : nullptr, stream);
         sync_check_cuda_error(stream);
         return /*all_token_without_lora=*/false;
     }
@@ -3896,15 +3919,15 @@ auto CutlassMoeFCRunner<T, WeightType, OutputType, InputType, BackBoneType, Enab
         input = reinterpret_cast<ScaleBiasType*>(permuted_data_);
     }
 
-    // Device-path branch, running entirely on the stream. setupLoraWorkspace
+    // Grouped-GEMM branch, running entirely on the stream. setupLoraWorkspace
     // has already populated the per-permuted-row ranks and pointers for fc1 and
     // gated via launchMoeLoraPointerExpand.
-    if (lora_params.device_path.enabled)
+    if (lora_params.grouped_gemm.enabled)
     {
-        auto const& dp = lora_params.device_path;
+        auto const& grouped_gemm = lora_params.grouped_gemm;
         nvinfer1::DataType const data_type = moeLoraNvInferType<ScaleBiasType>();
 
-        // The device-path GEMM skips rank-0 rows, but the bias/reorder paths
+        // The grouped-GEMM GEMM skips rank-0 rows, but the bias/reorder paths
         // read lora_fc1_result_ for every valid row. Zero the buffer first so
         // skipped rows are a deterministic no-op. It is contiguous and holds
         // both the gated and fc1 halves when gated, so one memset covers both.
@@ -3912,15 +3935,17 @@ auto CutlassMoeFCRunner<T, WeightType, OutputType, InputType, BackBoneType, Enab
             * (is_gated_activation ? 2u : 1u) * sizeof(ScaleBiasType);
         TLLM_CUDA_CHECK(cudaMemsetAsync(lora_fc1_result_, 0, fc1_result_bytes, stream));
 
-        runMoeLoraDeviceModule(dp.fc1, expanded_num_rows, /*in_hidden_size=*/hidden_size, dp.max_lora_rank,
-            dp.dtype_bytes, dp.splitk_slices, /*input_base=*/static_cast<void const*>(input),
-            /*output_base=*/static_cast<void*>(lora_fc1_result), dp.run, data_type, stream);
+        runMoeLoraGroupedGemmModule(grouped_gemm.fc1, expanded_num_rows, /*in_hidden_size=*/hidden_size,
+            grouped_gemm.max_lora_rank, grouped_gemm.dtype_bytes, grouped_gemm.splitk_slices,
+            /*input_base=*/static_cast<void const*>(input),
+            /*output_base=*/static_cast<void*>(lora_fc1_result), grouped_gemm.run, data_type, stream);
 
         if (is_gated_activation)
         {
-            runMoeLoraDeviceModule(dp.gated, expanded_num_rows, /*in_hidden_size=*/hidden_size, dp.max_lora_rank,
-                dp.dtype_bytes, dp.splitk_slices, /*input_base=*/static_cast<void const*>(input),
-                /*output_base=*/static_cast<void*>(lora_gated_out), dp.run, data_type, stream);
+            runMoeLoraGroupedGemmModule(grouped_gemm.gated, expanded_num_rows, /*in_hidden_size=*/hidden_size,
+                grouped_gemm.max_lora_rank, grouped_gemm.dtype_bytes, grouped_gemm.splitk_slices,
+                /*input_base=*/static_cast<void const*>(input),
+                /*output_base=*/static_cast<void*>(lora_gated_out), grouped_gemm.run, data_type, stream);
         }
     }
     else
@@ -3988,13 +4013,13 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, BackBoneType, Enab
         input = reinterpret_cast<ScaleBiasType*>(fc1_result_);
     }
 
-    // Device-path branch, mirroring loraFC1's branch. It consumes the
+    // Grouped-GEMM branch, mirroring loraFC1's branch. It consumes the
     // per-permuted-row ranks and pointers that setupLoraWorkspace produced via
     // launchMoeLoraPointerExpand. num_tokens here is expanded_num_rows from
     // runMoe (top_k * num_rows).
-    if (lora_params.device_path.enabled)
+    if (lora_params.grouped_gemm.enabled)
     {
-        auto const& dp = lora_params.device_path;
+        auto const& grouped_gemm = lora_params.grouped_gemm;
         nvinfer1::DataType const data_type = moeLoraNvInferType<ScaleBiasType>();
 
         // As in loraFC1, zero the output so rank-0 rows the GEMM skips do not
@@ -4003,9 +4028,10 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, BackBoneType, Enab
             = static_cast<size_t>(num_tokens) * static_cast<size_t>(hidden_size) * sizeof(ScaleBiasType);
         TLLM_CUDA_CHECK(cudaMemsetAsync(lora_fc2_result_, 0, fc2_result_bytes, stream));
 
-        runMoeLoraDeviceModule(dp.fc2, num_tokens, /*in_hidden_size=*/inter_size, dp.max_lora_rank, dp.dtype_bytes,
-            dp.splitk_slices, /*input_base=*/static_cast<void const*>(input),
-            /*output_base=*/static_cast<void*>(lora_fc2_result_), dp.run, data_type, stream);
+        runMoeLoraGroupedGemmModule(grouped_gemm.fc2, num_tokens, /*in_hidden_size=*/inter_size,
+            grouped_gemm.max_lora_rank, grouped_gemm.dtype_bytes, grouped_gemm.splitk_slices,
+            /*input_base=*/static_cast<void const*>(input),
+            /*output_base=*/static_cast<void*>(lora_fc2_result_), grouped_gemm.run, data_type, stream);
         sync_check_cuda_error(stream);
         return;
     }
@@ -4254,11 +4280,11 @@ void CutlassMoeFCRunner<T, WeightType, OutputType, InputType, BackBoneType, Enab
 
         bool is_gated_activation = isGatedActivation(fc1_activation_type);
 
-        // The device path builds every consumer's input on-device via
+        // The grouped-GEMM path builds every consumer's input on-device via
         // launchMoeLoraPointerExpand, so skip the host staging D2H copies and the
         // gating event. Keeping them would add a host dependency that breaks
         // CUDA-graph capture.
-        if (use_lora && !lora_params.device_path.enabled)
+        if (use_lora && !lora_params.grouped_gemm.enabled)
         {
             std::vector<int>& host_permuted_rows = host_lora_workspace_.host_permuted_rows;
             std::vector<int64_t>& host_expert_first_token_offset = host_lora_workspace_.host_expert_first_token_offset;

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_lora_pointer_expand.cu
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/moe_gemm/moe_lora_pointer_expand.cu
@@ -60,7 +60,7 @@ __device__ inline void expandOneModule(
     mod.ranks_out[i] = rank;
 }
 
-// Reset one module's output slot to a rank-0 no-op. The device-path scratch is
+// Reset one module's output slot to a rank-0 no-op. The grouped-GEMM scratch is
 // persistent and reused, so ghost rows must be explicitly zeroed; otherwise
 // stale ranks or pointers survive into the next grouped GEMM.
 __device__ inline void zeroOneModule(MoeLoraExpandModule const& mod, int64_t i)

--- a/cpp/tensorrt_llm/thop/moeOp.cpp
+++ b/cpp/tensorrt_llm/thop/moeOp.cpp
@@ -22,21 +22,18 @@
 #endif
 // Always include the public header for moe_gemm_kernels.h
 #include "tensorrt_llm/kernels/cutlass_kernels/include/moe_gemm_kernels.h"
-#include "tensorrt_llm/kernels/cutlass_kernels/include/moe_lora_device_path.h"
+#include "tensorrt_llm/kernels/cutlass_kernels/include/moe_lora_grouped_gemm.h"
 #include "tensorrt_llm/kernels/cutlass_kernels/include/moe_lora_problem_builder.h"
 #include "tensorrt_llm/kernels/cutlass_kernels/include/moe_lora_slot_expand.h"
 
 #include "cutlass/gemm_coord.h"
 
 #include "tensorrt_llm/common/config.h"
-#include "tensorrt_llm/common/cublasMMWrapper.h"
 #include "tensorrt_llm/common/dataType.h"
-#include "tensorrt_llm/common/opUtils.h"
 #include "tensorrt_llm/common/workspace.h"
 #include "tensorrt_llm/kernels/cuda_graph_grouped_gemm.h"
 #include "tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm.h"
 #include "tensorrt_llm/kernels/cutlass_kernels/include/cutlass_kernel_selector.h"
-#include "tensorrt_llm/kernels/lora/lora.h"
 #include "tensorrt_llm/runtime/torchUtils.h"
 #include "tensorrt_llm/thop/thUtils.h"
 
@@ -76,27 +73,27 @@ enum class MoeLoraRequestType : int32_t
 };
 
 // ---------------------------------------------------------------------------
-// libtorch-bound implementation of MoeLoraDeviceRunFn.
+// libtorch-bound implementation of MoeLoraGroupedGemmRunFn.
 //
-// This is the per-module GEMM dispatch the device LoRA path uses. It builds the
-// per-token problem descriptors on device via the libtorch-free
+// This is the per-module GEMM dispatch the grouped-GEMM LoRA core uses. It builds
+// the per-token problem descriptors on device via the libtorch-free
 // launchMoeLoraProblemBuilder, then dispatches cudaGraph(SplitK)GroupedGemm.
 // The latter allocates workspace via at::Tensor, so this function must live in
 // th_common, which links libtorch. moe_kernels.cu reaches it indirectly through
-// the function pointer stored in LoraParams::device_path.run; that indirection
+// the function pointer stored in LoraParams::grouped_gemm.run; that indirection
 // keeps libmoe_gemm_src.a (also linked into the TensorRT plugin shared object)
 // free of a transitive dependency on libtorch.
 // ---------------------------------------------------------------------------
-inline void moeLoraDeviceRunImpl(::tensorrt_llm::kernels::cutlass_kernels::MoeLoraDevicePathModule const& mod,
+inline void moeLoraGroupedGemmRunImpl(::tensorrt_llm::kernels::cutlass_kernels::MoeLoraGroupedGemmModule const& mod,
     int64_t num_permuted_tokens, int64_t in_hidden_size, int64_t max_lora_rank, int64_t dtype_bytes,
     int64_t splitk_slices, void const* input_base, void* output_base, nvinfer1::DataType data_type, cudaStream_t stream)
 {
     TLLM_CHECK_WITH_INFO(mod.permuted_ranks_dev != nullptr,
-        "Device-path LoRA module is missing permuted ranks buffer (forgot to populate device_path?).");
+        "Grouped-GEMM LoRA module is missing permuted ranks buffer (forgot to populate grouped_gemm?).");
 
     // Repack the device-resident scratch into the bundle the problem-builder
     // consumes. The typed casts recover the concrete pointer types that
-    // MoeLoraDevicePathModule stores as void* for header decoupling.
+    // MoeLoraGroupedGemmModule stores as void* for header decoupling.
     ::tensorrt_llm::kernels::cutlass_kernels::MoeLoraGemmGroupArrays arrays{};
     arrays.problem_sizes_in = static_cast<cutlass::gemm::GemmCoord*>(mod.problem_sizes_in_dev);
     arrays.problem_sizes_out = static_cast<cutlass::gemm::GemmCoord*>(mod.problem_sizes_out_dev);
@@ -338,17 +335,6 @@ public:
         mGemm1Profiles = mKernelRunner->getTactics(MoeGemmId::GEMM_1);
         mGemm2Profiles = mKernelRunner->getTactics(MoeGemmId::GEMM_2);
         cuInit(0);
-
-        // Device-LoRA-path opt-in for the per-request (eager) schema. Any
-        // non-empty value other than "0"/"OFF"/"off" enables it, matching
-        // LORA_USE_UNIFIED_GEMM. The slot-indexed (CUDA-graph) schema always
-        // uses the device path regardless, since the host path is not
-        // capturable (it does a host-side cudaEventSynchronize).
-        if (char const* envv = std::getenv("TLLM_MOE_LORA_USE_DEVICE_PATH"))
-        {
-            std::string val(envv);
-            mUseDeviceLoraPath = !val.empty() && val != "0" && val != "OFF" && val != "off";
-        }
     }
 
     ~FusedMoeRunner()
@@ -358,12 +344,6 @@ public:
             auto const cu_free_status = cudaFree(mProfileWorkspace);
             TORCH_CHECK(
                 cu_free_status == cudaSuccess, "Can't free profile workspace during FusedMoeRunner destruction.");
-        }
-        if (mLoraMemcpyEvent != nullptr)
-        {
-            // Destruction is best-effort; do not throw from the destructor.
-            (void) cudaEventDestroy(mLoraMemcpyEvent);
-            mLoraMemcpyEvent = nullptr;
         }
     }
 
@@ -377,9 +357,6 @@ public:
         std::lock_guard<std::mutex> lock(mMutex);
         mStreamWorkspaces.clear();
         freeProfileWorkspace();
-        // LoraImpl objects retain non-trivial cuBLAS state; drop the cache so the
-        // next LoRA call re-builds them. The shared cuBLAS wrapper is kept.
-        mLoraImplCache.clear();
     }
 
     torch::Tensor runMoe(torch::Tensor const& input, torch::Tensor const& token_selected_experts,
@@ -620,46 +597,28 @@ public:
                 mWeightDtype == c10::ScalarType::Half || mWeightDtype == c10::ScalarType::BFloat16 || is_per_tensor_fp8,
                 "MoE LoRA supports unquantized fp16/bf16 or per-tensor FP8 (qdq) base expert weights only "
                 "(LoRA adapters are always fp16/bf16).");
-            // CUDA-graph capture is only safe on the device LoRA path. The
-            // legacy host path performs a host-side cudaEventSynchronize and
-            // per-token pointer expansion in setupLoraWorkspace, plus host-side
-            // run-length encoding in LoraImpl::run, none of which is capturable.
-            // The device path (launchMoeLoraPointerExpand and
-            // runMoeLoraDeviceModule in moe_kernels.cu) runs entirely on the
-            // stream. The slot-indexed schema implies the device path (see the
-            // constructor's activation-story comment), so capture is allowed
-            // whenever the device path will be taken: env-var opt-in OR
-            // slot-indexed inputs.
-            bool const use_device_path = mUseDeviceLoraPath || lora_slot_indexed;
-            TORCH_CHECK(use_device_path || !tensorrt_llm::common::isCapturing(stream),
-                "MoE LoRA + CUDA graph capture requires the device LoRA path. The per-request schema runs "
-                "the legacy host path by default, which performs a host-side cudaEventSynchronize after a "
-                "D2H pointer-expansion copy and is not capturable. Use the slot-indexed schema (which always "
-                "takes the device path), set TLLM_MOE_LORA_USE_DEVICE_PATH=1, run LoRA eagerly, or disable "
-                "MoE LoRA when capturing.");
+            // The grouped-GEMM core runs entirely on the stream, so CUDA-graph
+            // capture is supported, but only with the slot-indexed schema. The
+            // per-request schema expands adapters on the host into pinned
+            // buffers, which a captured graph would freeze at capture time.
+            TORCH_CHECK(!(lora_per_request && tensorrt_llm::common::isCapturing(stream)),
+                "MoE LoRA: the per-request input schema is not CUDA-graph capturable (its host-side adapter "
+                "expansion is frozen at capture time). Use the slot-indexed schema (fc1_slot_lora_ranks, ..., "
+                "token_to_slot) for CUDA-graph decode, or run the per-request schema eagerly.");
         }
-        // Build LoraParams up-front so we can compute the required cuBLAS workspace before allocation.
+        // Build LoraParams up-front. The grouped-GEMM core uses persistent
+        // device scratch wired into LoraParams::grouped_gemm; there is no
+        // separate cuBLAS workspace to size.
         auto lora_params_opt = buildMoeLoraParams(fc1_lora_ranks, fc1_lora_weight_ptrs, fc2_lora_ranks,
             fc2_lora_weight_ptrs, gated_lora_ranks, gated_lora_weight_ptrs, host_request_types, host_context_lengths,
             fc1_slot_lora_ranks, fc1_slot_lora_weight_ptrs, fc2_slot_lora_ranks, fc2_slot_lora_weight_ptrs,
             gated_slot_lora_ranks, gated_slot_lora_weight_ptrs, token_to_slot,
             /*num_tokens=*/num_rows, hidden_size, inter_size, mActivationDtype, lora_max_low_rank, is_gated_act, stream,
             static_cast<int>(experts_per_token));
-        size_t lora_workspace_size = 0;
-        // The device path uses persistent device scratch and never touches the
-        // legacy cuBLAS lora_workspace, so skip computing/allocating it there to
-        // avoid duplicating LoRA scratch per stream (and the resulting OOM risk
-        // at large top_k/rank).
-        if (lora_params_opt.has_value() && !lora_params_opt->device_path.enabled)
-        {
-            auto const lora_dtype = loraTypeFromActDtype(mActivationDtype);
-            lora_workspace_size = computeLoraWorkspaceSize(lora_params_opt->fc1_lora_impl,
-                lora_params_opt->fc2_lora_impl, num_rows, experts_per_token, lora_params_opt->num_reqs, lora_dtype);
-        }
 
         WorkspaceInfo const& workspace_info = getWorkspaceInfo(num_rows, hidden_size, inter_size, num_experts_total,
             static_cast<int>(experts_per_token), base_activation_type, parallelism_config, min_latency_mode, stream,
-            lora_active, lora_workspace_size);
+            lora_active);
 
         auto quant_params
             = getQuantParams(num_experts_on_rank, hidden_size, inter_size, quant_scales, base_activation_type);
@@ -686,13 +645,9 @@ public:
 
         kernels::MoeMinLatencyParams min_latency_params{};
 
-        // LoraParams is either the populated one we just built or a default-constructed empty one (use_lora=false).
+        // Use the populated LoraParams when LoRA is active, otherwise a default-constructed empty one.
         ::tensorrt_llm::kernels::LoraParams lora_params
             = lora_params_opt.value_or(::tensorrt_llm::kernels::LoraParams{});
-        if (lora_active && !lora_params.device_path.enabled)
-        {
-            lora_params.workspace = workspace_info.lora_workspace;
-        }
 #ifdef USING_OSS_CUTLASS_MOE_GEMM
         mKernelRunner->runMoe(input.const_data_ptr(),
             input_sf.has_value() ? input_sf.value().const_data_ptr() : nullptr, swizzled_input_sf,
@@ -1012,10 +967,6 @@ private:
     {
         torch::Tensor workspace{};
         void* src_to_dest_map{};
-        // Cublas grouped-gemm scratch consumed by LoraImpl::run inside the MoE
-        // kernel's loraFC1/loraFC2 paths. Pointer aliases into `workspace`.
-        // nullptr when LoRA is inactive.
-        void* lora_workspace{};
     };
 
     std::mutex mMutex;
@@ -1042,18 +993,6 @@ private:
     std::vector<Profile> mGemm2Profiles;
 
     // ===== Routed-expert LoRA state =====
-    // Lazily constructed on first LoRA call.
-    std::shared_ptr<tensorrt_llm::common::CublasMMWrapper> mLoraCublasWrapper;
-    // Cache of LoraImpl instances keyed by (hidden_size, inter_size, lora_dtype, max_rank).
-    // value.first  = fc1/gated impl (in=hidden, out=inter)
-    // value.second = fc2 impl       (in=inter,  out=hidden)
-    using LoraImplKey = std::tuple<int64_t, int64_t, c10::ScalarType, int>;
-    using LoraImplPtr = ::tensorrt_llm::kernels::LoraParams::LoraImplPtr;
-    std::map<LoraImplKey, std::pair<LoraImplPtr, LoraImplPtr>> mLoraImplCache;
-    // Sync event used by setupLoraWorkspace (kernel waits on this before reading
-    // host-side permuted_rows arrays). Created lazily.
-    cudaEvent_t mLoraMemcpyEvent = nullptr;
-
     // Pinned-host and persistent-device buffers for the capture-safe MoE LoRA
     // path. The pinned-host tensors hold the per-token expanded LoRA tables
     // (ranks and weight-pointer pairs) so the in-op async H2D into the device
@@ -1108,12 +1047,12 @@ private:
     int64_t mLoraSlotTableCapacity = 0;
 
     // Persistent device-resident scratch backing the capture-safe MoE LoRA
-    // path. One LoraDevicePathBuffers per module (fc1, fc2, gated). All
+    // path. One LoraGroupedGemmBuffers per module (fc1, fc2, gated). All
     // at::Tensor members are allocated by ensureLoraDeviceScratch and reused
     // across calls so the addresses baked into a captured graph remain valid
     // for replay. Pointers from these tensors are packed into
-    // LoraParams::device_path by buildMoeLoraParams when the device path is taken.
-    struct LoraDevicePathBuffers
+    // LoraParams::grouped_gemm by buildMoeLoraParams when the grouped-GEMM core is used.
+    struct LoraGroupedGemmBuffers
     {
         // Per-permuted-row (rank, A_ptr + offset, B_ptr + offset).
         at::Tensor permuted_ranks; // int32  [P_max]
@@ -1145,9 +1084,9 @@ private:
         at::Tensor host_max_problem_out; // int8 pinned [sizeof(GemmCoord)]
     };
 
-    LoraDevicePathBuffers mFc1DeviceBuf;
-    LoraDevicePathBuffers mFc2DeviceBuf;
-    LoraDevicePathBuffers mGatedDeviceBuf;
+    LoraGroupedGemmBuffers mFc1DeviceBuf;
+    LoraGroupedGemmBuffers mFc2DeviceBuf;
+    LoraGroupedGemmBuffers mGatedDeviceBuf;
 
     // Tracks the shape parameters baked into the current scratch
     // allocation. (Re)allocation is required if any of these grows or if
@@ -1158,16 +1097,10 @@ private:
     int64_t mLoraDeviceScratchSplitKSlices = 0;
     bool mLoraDeviceScratchHasGated = false;
 
-    // Set from the TLLM_MOE_LORA_USE_DEVICE_PATH environment variable at
-    // construction time. Selects the capture-safe device LoRA path.
-    bool mUseDeviceLoraPath = false;
-
-    // Split-K slice count for the device-path low-rank in-GEMM. Mirrors the
-    // value LoraImpl uses internally so the device-path split-K workspace is
-    // sized identically. Shared between buildMoeLoraParams (lazy sizing) and
-    // reserveLoraHostBuffers (warmup pre-sizing) so both reserve the same
-    // amount of scratch.
-    static constexpr int64_t kDevicePathSplitKSlices = 16;
+    // Split-K slice count for the grouped-GEMM low-rank in-GEMM. Shared between
+    // buildMoeLoraParams (lazy sizing) and reserveLoraHostBuffers (warmup
+    // pre-sizing) so both reserve the same amount of scratch.
+    static constexpr int64_t kGroupedGemmSplitKSlices = 16;
 
     void freeProfileWorkspace()
     {
@@ -1209,7 +1142,7 @@ private:
     WorkspaceInfo const& getWorkspaceInfo(int64_t const num_rows, int64_t const hidden_size, int64_t const inter_size,
         int num_experts, int experts_per_token, ActivationType activation_type,
         kernels::MOEParallelismConfig const& parallelismConfig, bool min_latency_mode, cudaStream_t stream,
-        bool use_lora = false, size_t lora_workspace_size = 0)
+        bool use_lora = false)
     {
         size_t moe_workspace_size = mKernelRunner->getWorkspaceSize(num_rows, hidden_size, inter_size, num_experts,
             experts_per_token, activation_type, parallelismConfig, use_lora, mUseDeepSeekFP8BlockScaling,
@@ -1218,10 +1151,6 @@ private:
         auto& workspace_info = mStreamWorkspaces[stream];
 
         std::vector<size_t> workspaces{moe_workspace_size, src_to_dest_map_size};
-        if (use_lora && lora_workspace_size > 0)
-        {
-            workspaces.push_back(lora_workspace_size);
-        }
 
         int64_t const total_workspace_size = common::calculateTotalWorkspaceSize(workspaces.data(), workspaces.size());
 
@@ -1246,39 +1175,15 @@ private:
         }
         workspace_info.src_to_dest_map
             = common::nextWorkspacePtr(static_cast<int8_t*>(workspace_info.workspace.data_ptr()), moe_workspace_size);
-        if (use_lora && lora_workspace_size > 0)
-        {
-            workspace_info.lora_workspace
-                = common::nextWorkspacePtr(static_cast<int8_t*>(workspace_info.src_to_dest_map), src_to_dest_map_size);
-        }
-        else
-        {
-            workspace_info.lora_workspace = nullptr;
-        }
 
         return workspace_info;
     }
 
     // ===== LoRA helpers =====
 
-    // Lazy-construct the shared cuBLAS wrapper and the memcpy sync event used
-    // by the kernel's setupLoraWorkspace. Idempotent.
-    void ensureLoraInfra()
-    {
-        if (mLoraCublasWrapper == nullptr)
-        {
-            auto cublasHandle = ::tensorrt_llm::getCublasHandle();
-            auto cublasLtHandle = ::tensorrt_llm::getCublasLtHandle();
-            mLoraCublasWrapper = std::make_shared<::tensorrt_llm::common::CublasMMWrapper>(
-                cublasHandle, cublasLtHandle, /*allocator=*/nullptr, /*workspace=*/nullptr);
-        }
-        if (mLoraMemcpyEvent == nullptr)
-        {
-            TLLM_CUDA_CHECK(cudaEventCreateWithFlags(&mLoraMemcpyEvent, cudaEventDisableTiming));
-        }
-    }
-
-    // Map a torch dtype to the TRT-LLM nvinfer1::DataType expected by LoraImpl.
+    // Map a torch dtype to the TRT-LLM nvinfer1::DataType used to size the
+    // grouped-GEMM low-rank scratch. Kept as a const member (not static) so the
+    // FP8 case can read mOutputDtype to pick the fp16/bf16 LoRA compute dtype.
     nvinfer1::DataType loraTypeFromActDtype(c10::ScalarType dtype) const
     {
         switch (dtype)
@@ -1296,39 +1201,6 @@ private:
 #endif
         default: C10_THROW_ERROR_FORMATTED(Error, "MoE LoRA only supports fp16/bf16/fp32 activation dtype.");
         }
-    }
-
-    // Get or create the (fc1, fc2) LoraImpl pair for these shapes/dtype.
-    // fc1 impl runs (hidden -> inter) and is also used for the optional gated side.
-    // fc2 impl runs (inter -> hidden).
-    std::pair<LoraImplPtr, LoraImplPtr> getOrCreateLoraImpls(
-        int64_t hidden_size, int64_t inter_size, c10::ScalarType act_dtype, int max_low_rank)
-    {
-        LoraImplKey key{hidden_size, inter_size, act_dtype, max_low_rank};
-        auto it = mLoraImplCache.find(key);
-        if (it != mLoraImplCache.end())
-        {
-            return it->second;
-        }
-
-        ensureLoraInfra();
-        auto const lora_dtype = loraTypeFromActDtype(act_dtype);
-
-        auto fc1_impl = std::make_shared<::tensorrt_llm::kernels::LoraImpl>(
-            /*in_hidden_size=*/static_cast<int>(hidden_size),
-            /*out_hidden_sizes=*/std::vector<int>{static_cast<int>(inter_size)},
-            /*transA=*/false, /*transB=*/true, /*num_lora_modules=*/1, lora_dtype, max_low_rank, mLoraCublasWrapper);
-        auto fc2_impl = std::make_shared<::tensorrt_llm::kernels::LoraImpl>(
-            /*in_hidden_size=*/static_cast<int>(inter_size),
-            /*out_hidden_sizes=*/std::vector<int>{static_cast<int>(hidden_size)},
-            /*transA=*/false, /*transB=*/true, /*num_lora_modules=*/1, lora_dtype, max_low_rank, mLoraCublasWrapper);
-
-        // No profiler integration yet; cuBLAS auto-selects per call.
-        fc1_impl->setBestTactic(std::nullopt);
-        fc2_impl->setBestTactic(std::nullopt);
-
-        auto inserted = mLoraImplCache.emplace(key, std::make_pair(fc1_impl, fc2_impl));
-        return inserted.first->second;
     }
 
     // Expand per-request LoRA ranks and weight-pointer pairs into per-token arrays.
@@ -1445,9 +1317,8 @@ public:
         TORCH_CHECK(experts_per_token > 0, "experts_per_token must be positive; got ", experts_per_token);
         TORCH_CHECK(max_lora_size > 0, "max_lora_size must be positive; got ", max_lora_size);
 
-        // Host pinned + device-mirror expansion buffers (and the device
-        // token_to_slot mirror). Needed by both the legacy host path and the
-        // device path.
+        // Pinned-host and device-mirror expansion buffers, plus the device
+        // token_to_slot mirror.
         if (max_num_tokens > mLoraHostBufCapacity)
         {
             // Reserve is meant to run during warmup (before any capture). If a
@@ -1467,15 +1338,14 @@ public:
             mLoraSlotTableCapacity = max_lora_size;
         }
 
-        // Device grouped-GEMM scratch. CUDA-graph (slot-indexed) MoE LoRA always
-        // takes the device path, so pre-size it unconditionally rather than
-        // gating on the env-var opt-in. Otherwise the first capture would
-        // trigger a lazy allocation that the in-capture realloc guard rejects.
+        // Grouped-GEMM device scratch. Pre-size it unconditionally; otherwise
+        // the first capture would trigger a lazy allocation that the in-capture
+        // realloc guard rejects.
         TORCH_CHECK(max_lora_rank > 0, "max_lora_rank must be positive to reserve MoE-LoRA device scratch; got ",
             max_lora_rank);
         int64_t const dtype_bytes = static_cast<int64_t>(common::getDTypeSize(loraTypeFromActDtype(mActivationDtype)));
         int64_t const capacity = max_num_tokens * experts_per_token;
-        ensureLoraDeviceScratch(capacity, max_lora_rank, dtype_bytes, kDevicePathSplitKSlices, has_gated);
+        ensureLoraDeviceScratch(capacity, max_lora_rank, dtype_bytes, kGroupedGemmSplitKSlices, has_gated);
     }
 
 private:
@@ -1564,7 +1434,7 @@ private:
         mLoraSlotGatedPtrsDevice = at::empty({max_lora_size * 3}, dev_long_opts);
     }
 
-    // Allocate the per-module device-path scratch for the capture-safe LoRA
+    // Allocate the per-module grouped-GEMM scratch for the capture-safe LoRA
     // path. The buffers are sized in permuted tokens (P = num_tokens * top_k)
     // and the per-token LoRA rank upper bound max_lora_rank; both feed the
     // pointer-expand, problem-builder, and cuda_graph_*_grouped_gemm kernels.
@@ -1580,10 +1450,10 @@ private:
     void ensureLoraDeviceScratch(int64_t capacity, int64_t max_lora_rank, int64_t dtype_bytes, int64_t splitk_slices,
         bool has_gated, cudaStream_t stream = nullptr)
     {
-        TORCH_CHECK(capacity > 0, "device-path capacity must be positive; got ", capacity);
-        TORCH_CHECK(max_lora_rank > 0, "device-path max_lora_rank must be positive; got ", max_lora_rank);
-        TORCH_CHECK(dtype_bytes > 0, "device-path dtype_bytes must be positive; got ", dtype_bytes);
-        TORCH_CHECK(splitk_slices > 0, "device-path splitk_slices must be positive; got ", splitk_slices);
+        TORCH_CHECK(capacity > 0, "grouped-GEMM capacity must be positive; got ", capacity);
+        TORCH_CHECK(max_lora_rank > 0, "grouped-GEMM max_lora_rank must be positive; got ", max_lora_rank);
+        TORCH_CHECK(dtype_bytes > 0, "grouped-GEMM dtype_bytes must be positive; got ", dtype_bytes);
+        TORCH_CHECK(splitk_slices > 0, "grouped-GEMM splitk_slices must be positive; got ", splitk_slices);
 
         bool const need_resize = capacity > mLoraDeviceScratchCapacity || max_lora_rank > mLoraDeviceScratchMaxLoraRank
             || dtype_bytes != mLoraDeviceScratchDtypeBytes || splitk_slices != mLoraDeviceScratchSplitKSlices
@@ -1611,7 +1481,7 @@ private:
         // Callers should pass bf16/fp16 (2 bytes). Other sizes still work at the
         // byte level, but this assertion catches accidental misuse.
         TORCH_CHECK(dtype_bytes == 1 || dtype_bytes == 2 || dtype_bytes == 4,
-            "device-path lowrank workspace dtype_bytes must be 1/2/4; got ", dtype_bytes);
+            "grouped-GEMM lowrank workspace dtype_bytes must be 1/2/4; got ", dtype_bytes);
 
         auto const dev_int8_opts = at::TensorOptions().dtype(at::kByte).device(at::kCUDA);
         auto const dev_int32_opts = at::TensorOptions().dtype(at::kInt).device(at::kCUDA);
@@ -1624,7 +1494,7 @@ private:
         // tracks any cutlass struct-layout change.
         int64_t const gemm_coord_bytes = static_cast<int64_t>(sizeof(cutlass::gemm::GemmCoord));
 
-        auto alloc_one = [&](LoraDevicePathBuffers& mod)
+        auto alloc_one = [&](LoraGroupedGemmBuffers& mod)
         {
             mod.permuted_ranks = at::empty({new_capacity}, dev_int32_opts);
             mod.permuted_ptrs = at::empty({new_capacity * 2}, dev_int64_opts);
@@ -1670,9 +1540,9 @@ private:
     // resulting pointers stay valid as long as the runner outlives the
     // LoraParams use. dim_a/dim_b, ranks_src_dev, and out_hidden_size are filled
     // in by buildMoeLoraParams; the output base is passed directly to
-    // runMoeLoraDeviceModule at the call site.
-    void populateLoraDevicePathModule(
-        LoraDevicePathBuffers& mod, ::tensorrt_llm::kernels::cutlass_kernels::MoeLoraDevicePathModule& out) const
+    // runMoeLoraGroupedGemmModule at the call site.
+    void populateLoraGroupedGemmModule(
+        LoraGroupedGemmBuffers& mod, ::tensorrt_llm::kernels::cutlass_kernels::MoeLoraGroupedGemmModule& out) const
     {
         out.permuted_ranks_dev = mod.permuted_ranks.data_ptr<int32_t>();
         out.permuted_ptrs_dev = mod.permuted_ptrs.data_ptr<int64_t>();
@@ -1699,11 +1569,10 @@ private:
         out.out_hidden_size = 0;
     }
 
-    // Build a populated LoraParams from the optional CPU tensors. Caller is
-    // responsible for setting `lora_params.workspace` (the cuBLAS scratch).
-    // Returns std::nullopt when LoRA is inactive (no fc1 ranks tensor).
-    // Mutates the mLoraExpand* pinned tensors and queues an async H2D into
-    // the device mirrors on stream.
+    // Build a populated LoraParams from the optional CPU tensors and wire the
+    // grouped-GEMM core scratch (lora_params.grouped_gemm). Returns std::nullopt
+    // when LoRA is inactive (no fc1 ranks tensor). Mutates the mLoraExpand*
+    // pinned tensors and queues an async H2D into the device mirrors on stream.
     std::optional<::tensorrt_llm::kernels::LoraParams> buildMoeLoraParams(
         torch::optional<torch::Tensor> const& fc1_lora_ranks,
         torch::optional<torch::Tensor> const& fc1_lora_weight_ptrs,
@@ -1769,8 +1638,8 @@ private:
 
             // Every per-request rank must fit within lora_max_low_rank, which sizes
             // both the lowrank workspace and the max-problem hints. A larger rank
-            // would make the device path build GEMM problems wider than the
-            // allocated scratch and write out of bounds, so reject it up front.
+            // would make the grouped-GEMM core build GEMM problems wider than
+            // the allocated scratch and write out of bounds, so reject it up front.
             auto validate_rank_tensor = [&](char const* name, torch::Tensor const& ranks_tensor)
             {
                 CHECK_CPU_INPUT(ranks_tensor, at::ScalarType::Int)
@@ -1957,21 +1826,19 @@ private:
             ck::launchMoeLoraSlotExpand(mLoraTokenToSlotDevice.data_ptr<int32_t>(), num_tokens, num_slots, fc1_slot_mod,
                 fc2_slot_mod, has_gated ? &gated_slot_mod : nullptr, stream);
 
-            // The slot path fills the device mirrors directly via the kernel and
-            // always takes the device path, so the host per-token expand buffers
-            // are unused. Mark their live size 0 so the generic per-request H2D
+            // The slot path fills the device mirrors directly via the kernel, so
+            // the per-request host expand buffers are unused. Mark their live
+            // size 0 so the generic per-request H2D
             // below is skipped and does not clobber the kernel output.
             mLoraExpandFC1Size = 0;
             mLoraExpandFC2Size = 0;
             mLoraExpandGatedSize = 0;
         }
 
-        // Queue an async H2D into the persistent device mirrors. The copy
-        // source is pinned, so the async copy is truly async and capturable, and
-        // the destination is a persistent device buffer with a stable address
-        // across captures. The device path consumes these mirrors via
-        // launchMoeLoraPointerExpand; the legacy host path ignores them and
-        // reads the pinned host pointers through LoraParams below.
+        // Queue an async H2D into the persistent device mirrors that
+        // launchMoeLoraPointerExpand consumes. The copy source is pinned, so the
+        // copy is truly async and capturable, and the destination is a
+        // persistent device buffer with an address stable across captures.
         auto issue_h2d = [&](at::Tensor const& src, at::Tensor& dst, int64_t numel)
         {
             if (numel == 0)
@@ -1988,57 +1855,52 @@ private:
         issue_h2d(mLoraExpandGatedRanksPinned, mLoraExpandGatedRanksDevice, mLoraExpandGatedSize);
         issue_h2d(mLoraExpandGatedWeightPtrsPinned, mLoraExpandGatedWeightPtrsDevice, mLoraExpandGatedSize * 2);
 
-        auto impls = getOrCreateLoraImpls(hidden_size, inter_size, act_dtype, static_cast<int>(lora_max_low_rank));
-
-        // The host-side LoRA path (LoraImpl::run) reads the per-token ranks and
-        // pointers through these raw host pointers, which point at the pinned
-        // host tensors populated above.
+        // The grouped-GEMM core reads its inputs from the device mirrors set up
+        // below, so the cuBLAS LoraImpl pointers and host-sync event on
+        // LoraParams (used by the TensorRT MoE plugin) are left null here.
         ::tensorrt_llm::kernels::LoraParams lora_params{
             static_cast<int>(num_seqs),
             mLoraExpandFC1RanksPinned.data_ptr<int32_t>(),
             reinterpret_cast<void const**>(mLoraExpandFC1WeightPtrsPinned.data_ptr<int64_t>()),
             mLoraExpandFC2RanksPinned.data_ptr<int32_t>(),
             reinterpret_cast<void const**>(mLoraExpandFC2WeightPtrsPinned.data_ptr<int64_t>()),
-            impls.first,
-            impls.second,
-            /*workspace=*/nullptr, // caller fills in
-            &mLoraMemcpyEvent,
+            /*fc1_lora_impl=*/nullptr,
+            /*fc2_lora_impl=*/nullptr,
+            /*workspace=*/nullptr,
+            /*memcpy_event_ptr=*/nullptr,
             has_gated ? mLoraExpandGatedRanksPinned.data_ptr<int32_t>() : nullptr,
             has_gated ? reinterpret_cast<void const**>(mLoraExpandGatedWeightPtrsPinned.data_ptr<int64_t>()) : nullptr,
         };
 
-        // Device-LoRA-path scratch. Allocate the per-module device-resident
-        // buffers and pack their pointers into lora_params.device_path. The
-        // device path is taken when the env-var opts in (per-request eager
-        // testing) OR when the slot-indexed schema is used (CUDA-graph decode),
-        // since slot-indexed inputs always require the capture-safe device path.
-        bool const use_device_path = mUseDeviceLoraPath || has_slot_indexed;
-        if (use_device_path)
+        // Allocate the per-module device-resident scratch and pack its pointers
+        // into lora_params.grouped_gemm. Both eager (per-request) and CUDA-graph
+        // (slot-indexed) inputs feed this capture-safe core. The TensorRT MoE
+        // plugin leaves grouped_gemm.enabled false and uses its own cuBLAS path.
         {
             int64_t const dtype_bytes = static_cast<int64_t>(common::getDTypeSize(loraTypeFromActDtype(act_dtype)));
             int64_t const capacity = num_tokens * static_cast<int64_t>(experts_per_token);
             // Pass stream so a mid-capture resize (which would invalidate
             // previously captured graphs) is rejected with a clear error
             // rather than silently corrupting replay.
-            ensureLoraDeviceScratch(capacity, lora_max_low_rank, dtype_bytes, kDevicePathSplitKSlices,
+            ensureLoraDeviceScratch(capacity, lora_max_low_rank, dtype_bytes, kGroupedGemmSplitKSlices,
                 /*has_gated=*/has_gated, stream);
 
-            auto& dp = lora_params.device_path;
-            dp.enabled = true;
-            dp.in_hidden_size = hidden_size;
-            dp.max_lora_rank = lora_max_low_rank;
-            dp.dtype_bytes = dtype_bytes;
-            dp.splitk_slices = kDevicePathSplitKSlices;
-            dp.has_gated = has_gated;
+            auto& grouped_gemm = lora_params.grouped_gemm;
+            grouped_gemm.enabled = true;
+            grouped_gemm.in_hidden_size = hidden_size;
+            grouped_gemm.max_lora_rank = lora_max_low_rank;
+            grouped_gemm.dtype_bytes = dtype_bytes;
+            grouped_gemm.splitk_slices = kGroupedGemmSplitKSlices;
+            grouped_gemm.has_gated = has_gated;
             // Populate the libtorch-bound GEMM dispatch entry point so
-            // runMoeLoraDeviceModule in moe_kernels.cu can call through
+            // runMoeLoraGroupedGemmModule in moe_kernels.cu can call through
             // it without dragging libtorch into libmoe_gemm_src.a.
-            dp.run = &moeLoraDeviceRunImpl;
-            populateLoraDevicePathModule(mFc1DeviceBuf, dp.fc1);
-            populateLoraDevicePathModule(mFc2DeviceBuf, dp.fc2);
+            grouped_gemm.run = &moeLoraGroupedGemmRunImpl;
+            populateLoraGroupedGemmModule(mFc1DeviceBuf, grouped_gemm.fc1);
+            populateLoraGroupedGemmModule(mFc2DeviceBuf, grouped_gemm.fc2);
             if (has_gated)
             {
-                populateLoraDevicePathModule(mGatedDeviceBuf, dp.gated);
+                populateLoraGroupedGemmModule(mGatedDeviceBuf, grouped_gemm.gated);
             }
 
             // Per-module dim_a/dim_b describe the LoRA adapter shape the
@@ -2046,30 +1908,30 @@ private:
             // describes the LoRA delta sink the problem-builder kernel writes
             // into. The runner passes the output base (lora_fc1_result_ /
             // lora_fc2_result_ / lora_gated_out) directly to
-            // runMoeLoraDeviceModule at the loraFC1/loraFC2 call sites so the
+            // runMoeLoraGroupedGemmModule at the loraFC1/loraFC2 call sites so the
             // GEMMs land where the downstream bias/reorder kernels expect.
             //
             // For fc1 (and gated): adapter A is [hidden, rank], B is [rank, inter].
             // For fc2:             adapter A is [inter,  rank], B is [rank, hidden].
-            dp.fc1.dim_a = hidden_size;
-            dp.fc1.dim_b = inter_size;
-            dp.fc1.ranks_src_dev = mLoraExpandFC1RanksDevice.data_ptr<int32_t>();
-            dp.fc1.ptrs_src_dev = mLoraExpandFC1WeightPtrsDevice.data_ptr<int64_t>();
-            dp.fc1.out_hidden_size = inter_size;
+            grouped_gemm.fc1.dim_a = hidden_size;
+            grouped_gemm.fc1.dim_b = inter_size;
+            grouped_gemm.fc1.ranks_src_dev = mLoraExpandFC1RanksDevice.data_ptr<int32_t>();
+            grouped_gemm.fc1.ptrs_src_dev = mLoraExpandFC1WeightPtrsDevice.data_ptr<int64_t>();
+            grouped_gemm.fc1.out_hidden_size = inter_size;
 
-            dp.fc2.dim_a = inter_size;
-            dp.fc2.dim_b = hidden_size;
-            dp.fc2.ranks_src_dev = mLoraExpandFC2RanksDevice.data_ptr<int32_t>();
-            dp.fc2.ptrs_src_dev = mLoraExpandFC2WeightPtrsDevice.data_ptr<int64_t>();
-            dp.fc2.out_hidden_size = hidden_size;
+            grouped_gemm.fc2.dim_a = inter_size;
+            grouped_gemm.fc2.dim_b = hidden_size;
+            grouped_gemm.fc2.ranks_src_dev = mLoraExpandFC2RanksDevice.data_ptr<int32_t>();
+            grouped_gemm.fc2.ptrs_src_dev = mLoraExpandFC2WeightPtrsDevice.data_ptr<int64_t>();
+            grouped_gemm.fc2.out_hidden_size = hidden_size;
 
             if (has_gated)
             {
-                dp.gated.dim_a = hidden_size;
-                dp.gated.dim_b = inter_size;
-                dp.gated.ranks_src_dev = mLoraExpandGatedRanksDevice.data_ptr<int32_t>();
-                dp.gated.ptrs_src_dev = mLoraExpandGatedWeightPtrsDevice.data_ptr<int64_t>();
-                dp.gated.out_hidden_size = inter_size;
+                grouped_gemm.gated.dim_a = hidden_size;
+                grouped_gemm.gated.dim_b = inter_size;
+                grouped_gemm.gated.ranks_src_dev = mLoraExpandGatedRanksDevice.data_ptr<int32_t>();
+                grouped_gemm.gated.ptrs_src_dev = mLoraExpandGatedWeightPtrsDevice.data_ptr<int64_t>();
+                grouped_gemm.gated.out_hidden_size = inter_size;
             }
 
             // Pinned-host max-problem-size hints used by cuda_graph_*_grouped_gemm
@@ -2082,29 +1944,18 @@ private:
                 *coord = cutlass::gemm::GemmCoord(m, n, k);
             };
             // In-GEMM: M=1, N=max_lora_rank, K=in_dim. Out-GEMM: M=1, N=out_dim, K=max_lora_rank.
-            fill_max_problem(dp.fc1.host_max_problem_in_pinned, 1, lora_max_low_rank, hidden_size);
-            fill_max_problem(dp.fc1.host_max_problem_out_pinned, 1, inter_size, lora_max_low_rank);
-            fill_max_problem(dp.fc2.host_max_problem_in_pinned, 1, lora_max_low_rank, inter_size);
-            fill_max_problem(dp.fc2.host_max_problem_out_pinned, 1, hidden_size, lora_max_low_rank);
+            fill_max_problem(grouped_gemm.fc1.host_max_problem_in_pinned, 1, lora_max_low_rank, hidden_size);
+            fill_max_problem(grouped_gemm.fc1.host_max_problem_out_pinned, 1, inter_size, lora_max_low_rank);
+            fill_max_problem(grouped_gemm.fc2.host_max_problem_in_pinned, 1, lora_max_low_rank, inter_size);
+            fill_max_problem(grouped_gemm.fc2.host_max_problem_out_pinned, 1, hidden_size, lora_max_low_rank);
             if (has_gated)
             {
-                fill_max_problem(dp.gated.host_max_problem_in_pinned, 1, lora_max_low_rank, hidden_size);
-                fill_max_problem(dp.gated.host_max_problem_out_pinned, 1, inter_size, lora_max_low_rank);
+                fill_max_problem(grouped_gemm.gated.host_max_problem_in_pinned, 1, lora_max_low_rank, hidden_size);
+                fill_max_problem(grouped_gemm.gated.host_max_problem_out_pinned, 1, inter_size, lora_max_low_rank);
             }
         }
 
         return lora_params;
-    }
-
-    // Compute cuBLAS LoraImpl scratch size for the current call. Returns 0 when LoRA inactive.
-    size_t computeLoraWorkspaceSize(LoraImplPtr const& fc1_impl, LoraImplPtr const& fc2_impl, int64_t num_tokens,
-        int64_t experts_per_token, int64_t num_seqs, nvinfer1::DataType lora_dtype) const
-    {
-        int64_t const num_lora_tokens = num_tokens * experts_per_token;
-        // num_reqs upper-bounded by num_lora_tokens; mirrors plugin convention.
-        int64_t const num_reqs = std::min<int64_t>(num_seqs * experts_per_token, num_lora_tokens);
-        return std::max(fc1_impl->getWorkspaceSize(num_lora_tokens, num_reqs, lora_dtype),
-            fc2_impl->getWorkspaceSize(num_lora_tokens, num_reqs, lora_dtype));
     }
 
     kernels::QuantParams getQuantParams(int64_t const num_experts_on_rank, int64_t const hidden_size,

--- a/cpp/tests/unit_tests/kernels/moeLoraProblemBuilderTest.cu
+++ b/cpp/tests/unit_tests/kernels/moeLoraProblemBuilderTest.cu
@@ -70,6 +70,10 @@ RefOutputs cpuReference(std::vector<int32_t> const& ranks, std::vector<int64_t> 
     for (int64_t i = 0; i < P; ++i)
     {
         int32_t const rank = ranks[i];
+        // Rank-0 rows carry no active adapter (null A/B pointers), so the
+        // out-GEMM N is forced to 0 to let the grouped GEMM skip them instead of
+        // launching tiles that dereference the null B pointer. Mirrors the
+        // kernel in moe_lora_problem_builder.cu.
         int const out_n = (rank > 0) ? static_cast<int>(out_hidden_size) : 0;
         r.problem_sizes_in[i] = cutlass::gemm::GemmCoord(1, rank, static_cast<int>(in_hidden_size));
         r.problem_sizes_out[i] = cutlass::gemm::GemmCoord(1, out_n, rank);

--- a/docs/source/features/lora.md
+++ b/docs/source/features/lora.md
@@ -149,7 +149,7 @@ LoRA can be applied to the routed-expert projections of a Mixture-of-Experts (Mo
 | Adapter modules | `moe_h_to_4h` (gate side of SwiGLU), `moe_gate` (up side), `moe_4h_to_h` (down). `moe_h_to_4h` and `moe_4h_to_h` must both be present; `moe_gate` is optional (gated activations only). |
 | Adapter layout | Per-expert (stacked `[num_experts, ...]`). |
 | Multi-LoRA in flight | Yes. Reuses the existing slot manager. |
-| Execution paths | Eager, plus CUDA-graph capture/replay via the slot-indexed device path (see below). |
+| Execution modes | Eager and CUDA-graph capture/replay (see below). Both feed the same grouped-GEMM LoRA core. |
 | min-latency mode | Not supported with MoE LoRA. |
 | Alltoall (WideEP) | Not supported with MoE LoRA. |
 | DoRA on MoE modules | Not supported (and rejected at load time). |
@@ -201,13 +201,18 @@ fc1_adapter = make_per_expert_lora(
 # fc1_adapter["B"].shape == (8, 5632, 16)  -- independent per expert
 ```
 
-#### CUDA-graph decode
+#### Execution modes
 
-CUDA-graph capture/replay of a LoRA-active routed-expert MoE layer is supported via the slot-indexed device path. In CUDA-graph decode, `CudaGraphLoraManager` drives a fully on-device slot→token expansion (no host-side `cudaEventSynchronize`), so the per-token `(rank, A, B)` tables are produced on the stream and reassigning a slot's adapter is reflected on replay without re-capture. The legacy per-request host path is not capturable: it performs a host-side `cudaEventSynchronize` after a device-to-host pointer-expansion copy, so when an MoE LoRA is active on that path the fused MoE op detects the capturing stream and raises a clear error.
+Routed-expert MoE LoRA always runs through a single capture-safe grouped-GEMM core (on-stream pointer expansion, problem building, and grouped GEMMs). Two input schemas feed that core, and both produce identical results:
+
+- **Eager** uses the per-request input schema: the op expands the per-request adapter tables into per-token `(rank, A, B)` arrays before launching the core. This mode handles both context (prefill) and decode batches.
+- **CUDA-graph decode** uses the slot-indexed input schema: `CudaGraphLoraManager` maintains stable per-slot adapter tables and a `token_to_slot` map, and the slot→token expansion runs entirely on the stream. Because the tables live at stable addresses and are refreshed in place, reassigning a slot's adapter is reflected on replay without re-capture. CUDA-graph decode is generation-only.
+
+The per-request schema is not itself CUDA-graph capturable (its host-side adapter expansion would be frozen at capture time), so under capture the op uses the slot-indexed schema; supplying per-request inputs while capturing raises a clear error.
 
 #### What is rejected, and where
 
-If you supply MoE LoRA on a non-Cutlass backend or with quantization, `create_moe` raises at construction with a message pointing at the offending setting. At runtime, the fused MoE op also rejects min-latency mode + LoRA, alltoall + LoRA, and CUDA-graph capture on the non-capturable per-request host path (use the slot-indexed device path for capture).
+If you supply MoE LoRA on a non-Cutlass backend or with quantization, `create_moe` raises at construction with a message pointing at the offending setting. At runtime, the fused MoE op also rejects min-latency mode + LoRA, alltoall + LoRA, and per-request (eager-schema) inputs under CUDA-graph capture (use the slot-indexed schema for capture).
 
 ### Cache Management
 

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -353,33 +353,31 @@ def fused_moe(
             "Provide either (fc1_lora_ranks, ...) or (fc1_slot_lora_ranks, ..., token_to_slot), not both."
         )
     run_moe = moe_runner.fused_moe_runner.run_moe_min_latency if min_latency_mode else moe_runner.fused_moe_runner.run_moe
+    # Both run_moe overloads share this positional prefix. The TorchBind schemas
+    # do not honor C++ default arguments, so every positional must be supplied.
+    run_moe_args = [
+        input, token_selected_experts, token_final_scales, fc1_expert_weights,
+        fc1_expert_biases, fc2_expert_weights, fc2_expert_biases, quant_scales,
+        input_sf, swizzled_input_sf, swiglu_alpha, swiglu_beta, swiglu_limit,
+        tp_size, tp_rank, ep_size, ep_rank, cluster_size,
+        cluster_rank, enable_alltoall, min_latency_mode,
+        [gemm_tactic_1, gemm_tactic_2
+         ], activation_type, unpadded_hidden_size, tuner_num_tokens, out_tensor
+    ]
+    if not min_latency_mode:
+        # run_moe takes use_dynamic_fc2_scale plus the eager (per-request) and
+        # CUDA-graph (slot-indexed) LoRA tensor families; run_moe_min_latency
+        # stops at out_tensor.
+        run_moe_args += [
+            use_dynamic_fc2_scale, fc1_lora_ranks, fc1_lora_weight_ptrs,
+            fc2_lora_ranks, fc2_lora_weight_ptrs, gated_lora_ranks,
+            gated_lora_weight_ptrs, host_request_types, host_context_lengths,
+            lora_max_low_rank, fc1_slot_lora_ranks, fc1_slot_lora_weight_ptrs,
+            fc2_slot_lora_ranks, fc2_slot_lora_weight_ptrs,
+            gated_slot_lora_ranks, gated_slot_lora_weight_ptrs, token_to_slot
+        ]
     try:
-        if min_latency_mode:
-            output = run_moe(input, token_selected_experts, token_final_scales,
-                             fc1_expert_weights, fc1_expert_biases,
-                             fc2_expert_weights, fc2_expert_biases,
-                             quant_scales, input_sf, swizzled_input_sf,
-                             swiglu_alpha, swiglu_beta, swiglu_limit, tp_size,
-                             tp_rank, ep_size, ep_rank, cluster_size,
-                             cluster_rank, enable_alltoall, min_latency_mode,
-                             [gemm_tactic_1, gemm_tactic_2], activation_type,
-                             unpadded_hidden_size, tuner_num_tokens, out_tensor)
-        else:
-            output = run_moe(
-                input, token_selected_experts, token_final_scales,
-                fc1_expert_weights, fc1_expert_biases, fc2_expert_weights,
-                fc2_expert_biases, quant_scales, input_sf, swizzled_input_sf,
-                swiglu_alpha, swiglu_beta, swiglu_limit, tp_size, tp_rank,
-                ep_size, ep_rank, cluster_size, cluster_rank, enable_alltoall,
-                min_latency_mode, [gemm_tactic_1, gemm_tactic_2],
-                activation_type, unpadded_hidden_size, tuner_num_tokens,
-                out_tensor, use_dynamic_fc2_scale, fc1_lora_ranks,
-                fc1_lora_weight_ptrs, fc2_lora_ranks, fc2_lora_weight_ptrs,
-                gated_lora_ranks, gated_lora_weight_ptrs, host_request_types,
-                host_context_lengths, lora_max_low_rank, fc1_slot_lora_ranks,
-                fc1_slot_lora_weight_ptrs, fc2_slot_lora_ranks,
-                fc2_slot_lora_weight_ptrs, gated_slot_lora_ranks,
-                gated_slot_lora_weight_ptrs, token_to_slot)
+        output = run_moe(*run_moe_args)
     except RuntimeError as e:
         error_msg = str(e)
         if "DeepGEMM only supports Hopper" in error_msg:

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
@@ -15,7 +15,10 @@ from tensorrt_llm.tools.layer_wise_benchmarks import get_calibrator
 from ...distributed import allgather
 from ...expert_statistic import ExpertStatistic
 from ...model_config import ModelConfig
-from ...peft.lora.layer import LoraModuleType, MoeLoraLayer
+from ...peft.lora.layer import (MOE_LORA_MODULE_NAMES,
+                                MOE_LORA_MODULE_TO_KERNEL_SLOT, LoraModuleType,
+                                MoeLoraLayer)
+from ...peft.lora.validation import has_moe_lora_targets
 from ...utils import (ActivationType, AuxStreamType, EventType,
                       Fp4QuantizedTensor)
 from .interface import AlltoallMethodType, MoE
@@ -31,6 +34,20 @@ from .quantization import (
     WInt4AFP8FusedMoEMethod)
 # isort: on
 from .routing import BaseMoeRoutingMethod
+
+
+def raise_moe_lora_multichunk_unsupported(num_chunks: int) -> None:
+    """Reject multi-chunk execution for routed-expert MoE LoRA.
+
+    Routed-expert MoE LoRA passes per-request/slot adapter metadata that is not
+    re-sliced per token-chunk, so multi-chunk execution would mismatch the
+    kernel's per-token expansion. Shared by CutlassFusedMoE.forward_impl and the
+    MoEScheduler so the message stays in one place.
+    """
+    raise NotImplementedError(
+        f"Routed-expert MoE LoRA does not support multi-chunk execution "
+        f"(num_chunks={num_chunks}). Reduce the per-forward token count or "
+        f"increase `moe_max_num_tokens` so the MoE runs in a single chunk.")
 
 
 class CutlassFusedMoE(MoE):
@@ -382,18 +399,12 @@ class CutlassFusedMoE(MoE):
 
     # ---- Routed-expert LoRA helpers ----
 
-    _MOE_LORA_MODULE_NAMES = ("moe_h_to_4h", "moe_4h_to_h", "moe_gate")
-
     def _has_moe_lora_targets(self, model_config: ModelConfig) -> bool:
         """Return True iff this MoE layer is in the routed-expert LoRA
         target-module set. The LoRA application itself is fused into
         `torch.ops.trtllm.fused_moe`; no submodule is registered.
         """
-        lora_config = getattr(model_config, "lora_config", None)
-        if lora_config is None:
-            return False
-        targets = set(getattr(lora_config, "lora_target_modules", []) or [])
-        return any(name in targets for name in self._MOE_LORA_MODULE_NAMES)
+        return has_moe_lora_targets(getattr(model_config, "lora_config", None))
 
     def _maybe_make_lora_marker(
             self, model_config: ModelConfig) -> Optional[MoeLoraLayer]:
@@ -408,10 +419,16 @@ class CutlassFusedMoE(MoE):
         lora_config = getattr(model_config, "lora_config", None)
         if lora_config is None:
             return None
-        targets = set(getattr(lora_config, "lora_target_modules", []) or [])
+        # Normalize to lowercase to match has_moe_lora_targets (which lowercases
+        # before comparing), so a mixed-case config marks the layer and builds
+        # the discovery marker consistently.
+        targets = {
+            name.lower()
+            for name in (getattr(lora_config, "lora_target_modules", []) or [])
+        }
         active_modules: List[LoraModuleType] = []
         active_out_sizes: List[int] = []
-        for name in self._MOE_LORA_MODULE_NAMES:
+        for name in MOE_LORA_MODULE_NAMES:
             if name not in targets:
                 continue
             module_type = LoraModuleType.from_string(name)
@@ -455,6 +472,22 @@ class CutlassFusedMoE(MoE):
         if getattr(self, "w3_w1_weight", None) is None:
             return
 
+        # The reservation must cover the engine's worst case, otherwise the first
+        # capture hits a lazy allocation that the C++ in-capture guard rejects.
+        assert max_lora_rank > 0, (
+            "reserve_moe_lora_cuda_graph_workspace requires max_lora_rank > 0 "
+            f"(got {max_lora_rank}); set lora_config.max_lora_rank.")
+        assert max_lora_size > 0, (
+            "reserve_moe_lora_cuda_graph_workspace requires max_lora_size > 0 "
+            f"(got {max_lora_size}).")
+        # MoE LoRA only runs on the unquantized fp16/bf16 path, so the MoERunner
+        # instance key below (all-False quant flags, x/weight/out == self.dtype)
+        # must match the key the runtime fused_moe op uses on the same layer;
+        # otherwise the reservation lands on a different cached C++ runner.
+        assert self.dtype in (torch.float16, torch.bfloat16), (
+            "MoE LoRA requires fp16/bf16 activations to reserve a deterministic "
+            f"FusedMoeRunner key; got {self.dtype}.")
+
         from ...custom_ops.torch_custom_ops import MoERunner
 
         # Build the MoERunner with the same instance key the functional
@@ -497,12 +530,60 @@ class CutlassFusedMoE(MoE):
         """
         if not lora_params or self.layer_idx is None:
             return False
+        # CUDA-graph slot-indexed mode carries MoE LoRA in cuda_graph_params
+        # rather than a per-layer eager dict (mirrors _extract_moe_lora_tensors),
+        # so consult the graph layer map to keep the stray-param and multi-chunk
+        # guards effective during capture/replay.
+        if lora_params.get("use_cuda_graph_mode", False):
+            cuda_graph_params = lora_params.get("cuda_graph_params")
+            if cuda_graph_params is None:
+                return False
+            layer_module2key = getattr(cuda_graph_params, "layer_module2key",
+                                       {})
+            return any(
+                (self.layer_idx,
+                 int(LoraModuleType.from_string(name))) in layer_module2key
+                for name in MOE_LORA_MODULE_NAMES)
         layer_params = lora_params.get(self.layer_idx, {})
         if not layer_params:
             return False
         return any(
             int(LoraModuleType.from_string(name)) in layer_params
-            for name in self._MOE_LORA_MODULE_NAMES)
+            for name in MOE_LORA_MODULE_NAMES)
+
+    @staticmethod
+    def _empty_kernel_slot_dict() -> Dict[str, Optional[torch.Tensor]]:
+        return {"fc1": None, "fc2": None, "gated": None}
+
+    def _gather_moe_lora_slots(self, source):
+        """Gather per-kernel-slot (ranks, weight_ptrs) tensors.
+
+        `source(module_type)` returns the (ranks, weight_ptrs) pair for an MoE
+        LoRA module, or None if absent. Returns (ranks_by_slot, ptrs_by_slot)
+        dicts keyed by the kernel slot ("fc1"/"gated"/"fc2"); see
+        MOE_LORA_MODULE_TO_KERNEL_SLOT for the module->slot convention. Shared by
+        the eager (per-request) and CUDA-graph (slot-indexed) extraction paths.
+        """
+        ranks = self._empty_kernel_slot_dict()
+        ptrs = self._empty_kernel_slot_dict()
+        for module_type, slot in MOE_LORA_MODULE_TO_KERNEL_SLOT.items():
+            got = source(module_type)
+            if got is None:
+                continue
+            ranks[slot], ptrs[slot] = got
+        return ranks, ptrs
+
+    @staticmethod
+    def _require_fc1_fc2(ranks: Dict[str, Optional[torch.Tensor]]) -> None:
+        """The kernel always dereferences the fc1 and fc2 rank/pointer arrays
+        (see setupLoraWorkspace in moe_kernels.cu), so moe_h_to_4h (fc1/gate) and
+        moe_4h_to_h (fc2/down) must both be present when MoE LoRA is active. The
+        gated slot (moe_gate) is only read for gated activations.
+        """
+        if ranks["fc1"] is None or ranks["fc2"] is None:
+            raise ValueError(
+                "MoE LoRA requires both `moe_h_to_4h` (gate/SiLU) and "
+                "`moe_4h_to_h` (down) in lora_target_modules.")
 
     def _extract_moe_lora_tensors(
             self, lora_params: Optional[Dict]) -> Optional[Dict[str, object]]:
@@ -529,82 +610,41 @@ class CutlassFusedMoE(MoE):
         if not layer_params:
             return None
 
-        # Map each MoE LoRA module to the kernel's fc1 / gated / fc2 slot.
-        # The kernel applies fc1_lora to the gate (SiLU) half of the packed FC1
-        # output and gated_lora to the up (linear) half (see loraFC1 and
-        # doActivationKernel in moe_kernels.cu). With the canonical convention
-        # (moe_h_to_4h is w1 gate/SiLU, moe_gate is w3 up/linear, moe_4h_to_h is
-        # w2 down), this gives moe_h_to_4h to fc1, moe_gate to gated, and
-        # moe_4h_to_h to fc2.
-        slot_to_kernel = {
-            int(LoraModuleType.MOE_H_TO_4H): "fc1",
-            int(LoraModuleType.MOE_GATE): "gated",
-            int(LoraModuleType.MOE_4H_TO_H): "fc2",
-        }
-        kernel_ranks: Dict[str, Optional[torch.Tensor]] = {
-            "fc1": None,
-            "fc2": None,
-            "gated": None,
-        }
-        kernel_ptrs: Dict[str, Optional[torch.Tensor]] = {
-            "fc1": None,
-            "fc2": None,
-            "gated": None,
-        }
+        # Gather (ranks, weight_ptrs) per kernel slot. weight_pointers is built
+        # flat ([num_seqs * 3], row-major (A, B, DoRA) per seq) in
+        # PyTorchModelEngine._build_lora_params; the op expects [num_seqs, 3].
         active_max_rank = 0
-        for module_id_int, slot in slot_to_kernel.items():
-            entry = layer_params.get(module_id_int)
+
+        def _source(module_type: LoraModuleType):
+            nonlocal active_max_rank
+            entry = layer_params.get(int(module_type))
             if entry is None:
-                continue
-            kernel_ranks[slot] = entry["adapter_size"]
-            # weight_pointers is built flat ([num_seqs * 3], row-major (A, B,
-            # DoRA) per seq) in PyTorchModelEngine._build_lora_params; the MoE op
-            # expects a [num_seqs, 3] table, so restore that shape.
-            kernel_ptrs[slot] = entry["weight_pointers"].reshape(-1, 3)
-            try:
-                active_max_rank = max(active_max_rank,
-                                      int(entry["adapter_size"].max().item()))
-            except (RuntimeError, ValueError):
-                # Empty tensor; treat as no contribution.
-                pass
+                return None
+            rank_t = entry["adapter_size"]
+            if rank_t.numel() > 0:
+                active_max_rank = max(active_max_rank, int(rank_t.max().item()))
+            return rank_t, entry["weight_pointers"].reshape(-1, 3)
 
-        if all(v is None for v in kernel_ranks.values()):
+        ranks, ptrs = self._gather_moe_lora_slots(_source)
+        if all(v is None for v in ranks.values()):
             return None
-
-        # The kernel always dereferences the fc1 and fc2 rank/pointer arrays
-        # (see setupLoraWorkspace in moe_kernels.cu), so moe_h_to_4h (fc1) and
-        # moe_4h_to_h (fc2) must both be present when MoE LoRA is active. The
-        # gated slot (moe_gate) is only read for gated activations and is
-        # checked in the C++ thop layer.
-        if kernel_ranks["fc1"] is None or kernel_ranks["fc2"] is None:
-            raise ValueError(
-                "MoE LoRA requires both `moe_h_to_4h` (gate/SiLU) and "
-                "`moe_4h_to_h` (down) in lora_target_modules; got modules: "
-                f"{[name for name in self._MOE_LORA_MODULE_NAMES if int(LoraModuleType.from_string(name)) in layer_params]}"
-            )
+        self._require_fc1_fc2(ranks)
 
         num_seqs = lora_params["num_seqs"]
+
+        def _slice(t):
+            return t[:num_seqs].contiguous() if t is not None else None
+
         return {
-            "fc1_lora_ranks":
-            kernel_ranks["fc1"][:num_seqs].contiguous(),
-            "fc1_lora_weight_ptrs":
-            kernel_ptrs["fc1"][:num_seqs].contiguous(),
-            "fc2_lora_ranks":
-            kernel_ranks["fc2"][:num_seqs].contiguous(),
-            "fc2_lora_weight_ptrs":
-            kernel_ptrs["fc2"][:num_seqs].contiguous(),
-            "gated_lora_ranks":
-            (kernel_ranks["gated"][:num_seqs].contiguous()
-             if kernel_ranks["gated"] is not None else None),
-            "gated_lora_weight_ptrs":
-            (kernel_ptrs["gated"][:num_seqs].contiguous()
-             if kernel_ptrs["gated"] is not None else None),
-            "host_request_types":
-            lora_params["host_request_types"][:num_seqs].contiguous(),
-            "host_context_lengths":
-            lora_params["prompt_lens_cpu"][:num_seqs].contiguous(),
-            "lora_max_low_rank":
-            active_max_rank,
+            "fc1_lora_ranks": _slice(ranks["fc1"]),
+            "fc1_lora_weight_ptrs": _slice(ptrs["fc1"]),
+            "fc2_lora_ranks": _slice(ranks["fc2"]),
+            "fc2_lora_weight_ptrs": _slice(ptrs["fc2"]),
+            "gated_lora_ranks": _slice(ranks["gated"]),
+            "gated_lora_weight_ptrs": _slice(ptrs["gated"]),
+            "host_request_types": _slice(lora_params["host_request_types"]),
+            "host_context_lengths": _slice(lora_params["prompt_lens_cpu"]),
+            "lora_max_low_rank": active_max_rank,
         }
 
     def _extract_moe_lora_tensors_cuda_graph(
@@ -628,28 +668,11 @@ class CutlassFusedMoE(MoE):
         if cuda_graph_params is None:
             return None
 
-        slot_to_kernel = {
-            int(LoraModuleType.MOE_H_TO_4H): "fc1",
-            int(LoraModuleType.MOE_GATE): "gated",
-            int(LoraModuleType.MOE_4H_TO_H): "fc2",
-        }
-        slot_ranks: Dict[str, Optional[torch.Tensor]] = {
-            "fc1": None,
-            "fc2": None,
-            "gated": None,
-        }
-        slot_ptrs: Dict[str, Optional[torch.Tensor]] = {
-            "fc1": None,
-            "fc2": None,
-            "gated": None,
-        }
-        for module_id_int, slot in slot_to_kernel.items():
-            inputs = cuda_graph_params.get_moe_slot_inputs(
-                self.layer_idx, module_id_int)
-            if inputs is None:
-                continue
-            slot_ranks[slot], slot_ptrs[slot] = inputs
+        def _source(module_type: LoraModuleType):
+            return cuda_graph_params.get_moe_slot_inputs(
+                self.layer_idx, int(module_type))
 
+        slot_ranks, slot_ptrs = self._gather_moe_lora_slots(_source)
         if slot_ranks["fc1"] is None or slot_ranks["fc2"] is None:
             return None
 
@@ -1453,15 +1476,7 @@ class CutlassFusedMoE(MoE):
                       1) // self.moe_max_num_tokens
 
         if num_chunks > 1 and self._moe_lora_active(lora_params):
-            # Routed-expert MoE LoRA passes per-request adapter metadata that is
-            # not re-sliced per token-chunk, so multi-chunk execution would
-            # mismatch the kernel's per-token expansion. Reject with a clear
-            # message instead of failing inside the C++ op.
-            raise NotImplementedError(
-                f"Routed-expert MoE LoRA does not support multi-chunk execution "
-                f"(num_chunks={num_chunks}). Reduce the per-forward token count "
-                f"or increase `moe_max_num_tokens` so the MoE runs in a single "
-                f"chunk.")
+            raise_moe_lora_multichunk_unsupported(num_chunks)
 
         if num_chunks == 1:
             is_first_call = self.repeat_idx == 0

--- a/tensorrt_llm/_torch/modules/fused_moe/moe_scheduler.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/moe_scheduler.py
@@ -54,7 +54,7 @@ from tensorrt_llm.tools.layer_wise_benchmarks import get_calibrator
 from .communication import DeepEP, DeepEPLowLatency, NVLinkOneSided, NVLinkTwoSided
 from .communication.nvlink_two_sided_flashinfer import NVLinkTwoSidedFlashinfer
 from .fused_moe_cute_dsl import CuteDslFusedMoE
-from .fused_moe_cutlass import CutlassFusedMoE
+from .fused_moe_cutlass import CutlassFusedMoE, raise_moe_lora_multichunk_unsupported
 from .fused_moe_deepgemm import DeepGemmFusedMoE
 from .fused_moe_densegemm import DenseGEMMFusedMoE
 from .fused_moe_marlin import MarlinFusedMoE
@@ -153,21 +153,12 @@ class ExternalCommMoEScheduler(MoEScheduler):
         # ========== Step 2: Determine communication method ==========
         num_chunks = moe.calculate_num_chunks(all_rank_num_tokens_padded)
 
-        # Routed-expert MoE LoRA carries per-request adapter metadata that is
-        # not re-sliced per token-chunk, so multi-chunk execution would mismatch
-        # the kernel's per-token expansion. Reject here with a clear message
-        # instead of failing inside the C++ op.
         if (
             num_chunks > 1
             and moe.backend.__class__ == CutlassFusedMoE
             and moe.backend._moe_lora_active(lora_params)
         ):
-            raise NotImplementedError(
-                f"Routed-expert MoE LoRA does not support multi-chunk execution "
-                f"(num_chunks={num_chunks}). Reduce the per-forward token count "
-                f"or increase `moe_max_num_tokens` so the MoE runs in a single "
-                f"chunk."
-            )
+            raise_moe_lora_multichunk_unsupported(num_chunks)
 
         # May fall back AllToAll -> AllGather; this is the only sanctioned
         # mutation of ``moe.comm`` from a scheduler.

--- a/tensorrt_llm/_torch/modules/fused_moe/ops/moe_op_cutlass.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/ops/moe_op_cutlass.py
@@ -204,53 +204,25 @@ class CutlassMoEOp(MoEOp):
         if not isinstance(quant_scales, list):
             quant_scales = list(quant_scales)
 
-        # The C++ run_moe and run_moe_min_latency bindings are TorchBind methods
-        # whose schemas do not honor C++ default arguments, so every positional
-        # argument must be supplied. run_moe has trailing routed-expert LoRA
-        # args; MoE LoRA is fused inside torch.ops.trtllm.fused_moe and never
-        # flows through this op path, so pass None or 0 for them.
-        # run_moe_min_latency takes no use_dynamic_fc2_scale or LoRA args, so its
-        # call stops at out_tensor.
-        if min_latency_mode:
-            output = run_moe(x, token_selected_slots, token_final_scales,
-                             w3_w1_weight.view(weight_dtype), w3_w1_bias,
-                             w2_weight.view(weight_dtype), w2_bias,
-                             quant_scales, input_sf, swizzled_input_sf,
-                             swiglu_alpha, swiglu_beta, swiglu_limit, tp_size,
-                             tp_rank, ep_size, ep_rank, cluster_size,
-                             cluster_rank, use_all_to_all, min_latency_mode,
-                             self.gemm_tactics, activation_type,
-                             unpadded_hidden_size, tuner_num_tokens, None)
-        else:
-            output = run_moe(
-                x,
-                token_selected_slots,
-                token_final_scales,
-                w3_w1_weight.view(weight_dtype),
-                w3_w1_bias,
-                w2_weight.view(weight_dtype),
-                w2_bias,
-                quant_scales,
-                input_sf,
-                swizzled_input_sf,
-                swiglu_alpha,
-                swiglu_beta,
-                swiglu_limit,
-                tp_size,
-                tp_rank,
-                ep_size,
-                ep_rank,
-                cluster_size,
-                cluster_rank,
-                use_all_to_all,
-                min_latency_mode,
-                self.gemm_tactics,
-                activation_type,
-                unpadded_hidden_size,
-                tuner_num_tokens,
-                None,
+        # The C++ run_moe / run_moe_min_latency TorchBind methods share this
+        # positional prefix. The TorchBind schemas do not honor C++ default
+        # arguments, so every positional argument must be supplied. This
+        # profiling/tuning path never applies MoE LoRA (LoRA is fused into
+        # torch.ops.trtllm.fused_moe), so all eager (per-request) and
+        # slot-indexed LoRA args are passed as None/0.
+        run_moe_args = [
+            x, token_selected_slots, token_final_scales,
+            w3_w1_weight.view(weight_dtype), w3_w1_bias,
+            w2_weight.view(weight_dtype), w2_bias, quant_scales, input_sf,
+            swizzled_input_sf, swiglu_alpha, swiglu_beta, swiglu_limit, tp_size,
+            tp_rank, ep_size, ep_rank, cluster_size, cluster_rank,
+            use_all_to_all, min_latency_mode, self.gemm_tactics,
+            activation_type, unpadded_hidden_size, tuner_num_tokens, None
+        ]
+        if not min_latency_mode:
+            run_moe_args += [
                 use_dynamic_fc2_scale,
-                # Routed-expert LoRA args, unused on this op path.
+                # Eager (per-request) LoRA args.
                 None,
                 None,
                 None,
@@ -259,7 +231,17 @@ class CutlassMoEOp(MoEOp):
                 None,
                 None,
                 None,
-                0)
+                0,
+                # Slot-indexed (CUDA-graph) LoRA args.
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None
+            ]
+        output = run_moe(*run_moe_args)
 
         # Return output based on latency mode
         return output if min_latency_mode else [output]

--- a/tensorrt_llm/_torch/peft/lora/cuda_graph_lora_manager.py
+++ b/tensorrt_llm/_torch/peft/lora/cuda_graph_lora_manager.py
@@ -81,7 +81,7 @@ class CudaGraphLoraManager:
         )
 
         # Pre-size routed-expert MoE-LoRA scratch on every MoE layer so the
-        # capture-safe device path never (re)allocates during graph capture.
+        # capture-safe grouped-GEMM core never (re)allocates during graph capture.
         # See CutlassFusedMoE.reserve_moe_lora_cuda_graph_workspace.
         self._reserve_moe_lora_workspaces(model)
 

--- a/tensorrt_llm/_torch/peft/lora/cuda_graph_lora_params.py
+++ b/tensorrt_llm/_torch/peft/lora/cuda_graph_lora_params.py
@@ -120,6 +120,13 @@ class CudaGraphLoraParams:
             self.slot_ranks, device="cpu", pin_memory=prefer_pinned()
         )
 
+        # Per-(layer_idx, module_id) packed [max_lora_size, 3] (A, B, dora) host
+        # pointer tables for the routed-expert MoE LoRA path, populated lazily by
+        # get_moe_slot_inputs and refreshed in place by _refresh_moe_slot_ptr_cache.
+        # Initialized here (not lazily) so the refresh path cannot silently no-op
+        # out of order.
+        self._moe_slot_ptrs_cache: Dict[Tuple[int, int], torch.Tensor] = {}
+
         for key, info in self.layer_info.items():
             assert (
                 info.module_num > 0
@@ -324,7 +331,7 @@ class CudaGraphLoraParams:
         pinned buffers are updated in place to keep their addresses stable (the
         captured H2D copy reads them by address at replay).
         """
-        cache = getattr(self, "_moe_slot_ptrs_cache", None)
+        cache = self._moe_slot_ptrs_cache
         if not cache:
             return
         for (layer_idx, module_id), packed in cache.items():
@@ -456,10 +463,7 @@ class CudaGraphLoraParams:
         # the existing storage isn't laid out as (A, B, dora) per slot. To
         # keep this graph-capture safe, cache the packed buffer per (layer_idx,
         # module_id) so its address is stable across calls.
-        cache = getattr(self, "_moe_slot_ptrs_cache", None)
-        if cache is None:
-            cache = {}
-            self._moe_slot_ptrs_cache = cache
+        cache = self._moe_slot_ptrs_cache
         cache_key = (layer_idx, module_id)
         packed = cache.get(cache_key)
         if packed is None:

--- a/tensorrt_llm/_torch/peft/lora/layer.py
+++ b/tensorrt_llm/_torch/peft/lora/layer.py
@@ -138,6 +138,25 @@ class LoraModuleType(IntEnum):
         return self in {self.MAMBA_IN_PROJ, self.MAMBA_OUT_PROJ}
 
 
+# Canonical routed-expert MoE LoRA module set and module->kernel-slot mapping,
+# shared by the MoE factory/validator (create_moe.py, validation.py), the
+# adapter-layout helpers (moe_layout.py), and the CUTLASS MoE backend
+# (fused_moe_cutlass.py). Keep this the single source of truth.
+#
+# Slot convention (see loraFC1 / doActivationKernel in moe_kernels.cu): the
+# kernel applies the "fc1" LoRA to the gate (SiLU) half of the packed FC1
+# output and the "gated" LoRA to the up (linear) half. With the canonical
+# convention (moe_h_to_4h = w1 gate/SiLU, moe_gate = w3 up/linear,
+# moe_4h_to_h = w2 down), this maps moe_h_to_4h->fc1, moe_gate->gated,
+# moe_4h_to_h->fc2.
+MOE_LORA_MODULE_NAMES = ("moe_h_to_4h", "moe_4h_to_h", "moe_gate")
+MOE_LORA_MODULE_TO_KERNEL_SLOT = {
+    LoraModuleType.MOE_H_TO_4H: "fc1",
+    LoraModuleType.MOE_GATE: "gated",
+    LoraModuleType.MOE_4H_TO_H: "fc2",
+}
+
+
 class LoraLayer(torch.nn.Module):
 
     def __init__(self, lora_module_types: List[LoraModuleType],

--- a/tensorrt_llm/_torch/peft/lora/moe_layout.py
+++ b/tensorrt_llm/_torch/peft/lora/moe_layout.py
@@ -12,8 +12,10 @@ from typing import Dict, List, Optional
 
 import torch
 
-# Routed-expert MoE LoRA modules.
-MOE_LORA_MODULES: List[str] = ["moe_h_to_4h", "moe_4h_to_h", "moe_gate"]
+# Routed-expert MoE LoRA modules (canonical names live in layer.py).
+from .layer import MOE_LORA_MODULE_NAMES
+
+MOE_LORA_MODULES: List[str] = list(MOE_LORA_MODULE_NAMES)
 
 
 def make_per_expert_lora(

--- a/tensorrt_llm/_torch/peft/lora/validation.py
+++ b/tensorrt_llm/_torch/peft/lora/validation.py
@@ -19,6 +19,9 @@ from typing import Iterable, Optional, Set
 from tensorrt_llm.lora_helper import LoraConfig
 from tensorrt_llm.quantization.mode import QuantMode
 
+# Canonical routed-expert MoE LoRA module names (single source of truth).
+from .layer import MOE_LORA_MODULE_NAMES
+
 # Base-weight quantization bits that MoE LoRA does not support. Only per-tensor
 # FP8 (qdq) composes with MoE LoRA; any of the bits below makes the combination
 # unsupported.
@@ -37,8 +40,7 @@ _UNSUPPORTED_QUANT = (
     | QuantMode.MXFP8
 )
 
-# TRTLLM module names that map to routed-expert MoE projections.
-MOE_LORA_MODULE_NAMES: Set[str] = {"moe_h_to_4h", "moe_4h_to_h", "moe_gate"}
+_MOE_LORA_MODULE_NAME_SET: Set[str] = set(MOE_LORA_MODULE_NAMES)
 
 
 def _normalize_targets(lora_target_modules: Iterable[str]) -> Set[str]:
@@ -50,7 +52,7 @@ def has_moe_lora_targets(lora_config: Optional[LoraConfig]) -> bool:
     if lora_config is None:
         return False
     return bool(
-        MOE_LORA_MODULE_NAMES
+        _MOE_LORA_MODULE_NAME_SET
         & _normalize_targets(getattr(lora_config, "lora_target_modules", []) or [])
     )
 

--- a/tests/integration/defs/llmapi/test_llm_api_pytorch_moe_lora.py
+++ b/tests/integration/defs/llmapi/test_llm_api_pytorch_moe_lora.py
@@ -171,13 +171,15 @@ def _run_quantized_routed_expert_multi_lora(
     target_modules: list,
     trtllm_modules_to_hf_modules: dict,
     expected_quant_algo,
+    cuda_graph_config,
 ) -> None:
     """Serve a quantized MoE checkpoint with routed-expert LoRA and assert it applies.
 
     The batch mixes a no-LoRA (rank-0) request with every adapter, asserting the
     no-LoRA row produces output and each adapter changes the output versus the
-    base model. Used for the per-tensor FP8 (qdq) base. Caller must force the
-    device LoRA path.
+    base model. Used for the per-tensor FP8 (qdq) base. With a CUDA graph the
+    decode takes the slot-indexed input schema; without one it takes the
+    per-request schema. Both feed the same grouped-GEMM LoRA core.
     """
     lora_config = LoraConfig(
         lora_dir=lora_paths,
@@ -192,6 +194,7 @@ def _run_quantized_routed_expert_multi_lora(
         lora_config=lora_config,
         moe_config=MoeConfig(backend="CUTLASS"),
         kv_cache_config=_KV_CACHE_CONFIG,
+        cuda_graph_config=cuda_graph_config,
     )
     try:
         assert llm.args.quant_config.quant_algo == expected_quant_algo, (
@@ -223,40 +226,37 @@ def _run_quantized_routed_expert_multi_lora(
 @pytest.mark.parametrize(
     "moe_lora_mode",
     [
-        "host_path",
-        "device_path_eager",
-        "device_path_cudagraph",
+        "eager",
+        "cudagraph",
     ],
 )
-def test_qwen_moe_routed_expert_multi_lora_varying_ranks(moe_lora_mode: str, monkeypatch) -> None:
+def test_qwen_moe_routed_expert_multi_lora_varying_ranks(moe_lora_mode: str) -> None:
     """Routed-expert MoE LoRA on Qwen1.5-MoE with the PyTorch CUTLASS backend.
 
     Five dummy adapters of varying rank target the routed experts (moe_h_to_4h,
-    moe_gate, moe_4h_to_h). The same workload runs through each of the three
-    routed-expert LoRA execution paths, selected by moe_lora_mode:
+    moe_gate, moe_4h_to_h). The same workload runs through both routed-expert
+    LoRA input schemas, which share the grouped-GEMM LoRA core, selected by
+    moe_lora_mode:
 
-    - host_path: eager, legacy host path (per-request D2H pointer expand).
-    - device_path_eager: eager, capture-safe device path forced on via
-      TLLM_MOE_LORA_USE_DEVICE_PATH (per-request schema, no CUDA graph).
-    - device_path_cudagraph: CUDA graph decode, which always takes the
-      slot-indexed device path; all adapters share one captured graph,
-      exercising the slot-indexed device path and per-slot rank handling.
+    - eager: the per-request input schema (host adapter expansion) feeds the
+      grouped-GEMM core; no CUDA graph.
+    - cudagraph: CUDA-graph decode, which takes the slot-indexed input schema;
+      all adapters share one captured graph, exercising per-slot rank handling.
 
-    Current transformers stores the routed experts as fused 3D parameters, so
-    PEFT cannot produce per-expert adapter weights; the adapters are fabricated
-    directly in the per-expert key layout the TRT-LLM loader expects. An
-    explicit module mapping is supplied because the default map only knows
-    w1/w2/w3 for routed experts. lora_B is non-zero so each adapter perturbs the
-    routed-expert output, letting the test assert the LoRA is actually applied.
+    Both modes feed the identical grouped-GEMM core, but end-to-end decoded
+    tokens are not expected to be bit-identical between eager and CUDA-graph
+    runs (CUDA-graph decode pads the batch and may select different GEMM tactics
+    for the non-LoRA parts of the model). Current transformers stores the routed
+    experts as fused 3D parameters, so PEFT cannot produce per-expert adapter
+    weights; the adapters are fabricated directly in the per-expert key layout
+    the TRT-LLM loader expects. An explicit module mapping is supplied because
+    the default map only knows w1/w2/w3 for routed experts. lora_B is non-zero
+    so each adapter perturbs the routed-expert output, letting the test assert
+    the LoRA is actually applied.
     """
-    # Select the execution path. The eager device path is forced via env var
-    # (read once at FusedMoeRunner construction); the CUDA-graph path always
-    # takes the slot-indexed device path, so it needs no env opt-in.
-    cuda_graph_config = None
-    if moe_lora_mode == "device_path_eager":
-        monkeypatch.setenv("TLLM_MOE_LORA_USE_DEVICE_PATH", "1")
-    elif moe_lora_mode == "device_path_cudagraph":
-        cuda_graph_config = CudaGraphConfig(max_batch_size=10)
+    # eager drives the per-request input schema; cudagraph drives the
+    # slot-indexed schema. Both feed the same grouped-GEMM LoRA core.
+    cuda_graph_config = CudaGraphConfig(max_batch_size=10) if moe_lora_mode == "cudagraph" else None
 
     model_dir = f"{llm_models_root()}/Qwen1.5-MoE-A2.7B-Chat"
 
@@ -357,18 +357,32 @@ def test_qwen_moe_routed_expert_multi_lora_varying_ranks(moe_lora_mode: str, mon
 
 @skip_pre_ada
 @pytest.mark.skip_less_device_memory(80000)
-def test_mixtral_moe_routed_expert_fp8_multi_lora_varying_ranks(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    "moe_lora_mode",
+    [
+        "eager",
+        "cudagraph",
+    ],
+)
+def test_mixtral_moe_routed_expert_fp8_multi_lora_varying_ranks(moe_lora_mode: str) -> None:
     """Routed-expert MoE LoRA on a per-tensor FP8 (qdq) Mixtral-8x7B checkpoint.
 
     Exercises the FP8 base-weight + routed-expert LoRA path end to end: the
     CUTLASS MoE kernel dequantizes the FP8 activations to the bf16 LoRA compute
     type before the LoRA GEMM, so the FP8 base and the bf16 adapters compose.
-    Forces the capture-safe device LoRA path (TLLM_MOE_LORA_USE_DEVICE_PATH=1),
-    which performs the FP8 dequant.
+    Like the Qwen test, it runs both routed-expert LoRA input schemas (which
+    share the grouped-GEMM LoRA core) so the FP8 dequant is validated under
+    each, selected by moe_lora_mode:
+
+    - eager: the per-request input schema (host adapter expansion); no CUDA
+      graph.
+    - cudagraph: CUDA-graph decode, which takes the slot-indexed input schema;
+      all adapters share one captured graph, exercising per-slot rank handling.
     """
-    # Force the eager device LoRA path, which runs the FP8 dequant before the
-    # grouped-GEMM LoRA core (loraFC1/loraFC2 in moe_kernels.cu).
-    monkeypatch.setenv("TLLM_MOE_LORA_USE_DEVICE_PATH", "1")
+    # eager drives the per-request input schema; cudagraph drives the
+    # slot-indexed schema. Both run the FP8 dequant before the grouped-GEMM
+    # LoRA core (loraFC1/loraFC2 in moe_kernels.cu).
+    cuda_graph_config = CudaGraphConfig(max_batch_size=10) if moe_lora_mode == "cudagraph" else None
 
     model_dir = f"{llm_models_root()}/Mixtral-8x7B-Instruct-v0.1-fp8"
 
@@ -416,4 +430,5 @@ def test_mixtral_moe_routed_expert_fp8_multi_lora_varying_ranks(monkeypatch) -> 
             target_modules=target_modules,
             trtllm_modules_to_hf_modules=trtllm_modules_to_hf_modules,
             expected_quant_algo=QuantAlgo.FP8,
+            cuda_graph_config=cuda_graph_config,
         )

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -972,10 +972,10 @@ llmapi/test_llm_api_qa.py::TestLlmDefaultBackend::test_llm_args_type_default
 llmapi/test_llm_api_qa.py::TestLlmDefaultBackend::test_llm_args_logging
 
 # Routed-expert (MoE) LoRA
-llmapi/test_llm_api_pytorch_moe_lora.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks[host_path] TIMEOUT (90)
-llmapi/test_llm_api_pytorch_moe_lora.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks[device_path_eager] TIMEOUT (90)
-llmapi/test_llm_api_pytorch_moe_lora.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks[device_path_cudagraph] TIMEOUT (90)
-llmapi/test_llm_api_pytorch_moe_lora.py::test_mixtral_moe_routed_expert_fp8_multi_lora_varying_ranks TIMEOUT (90)
+llmapi/test_llm_api_pytorch_moe_lora.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks[eager] TIMEOUT (90)
+llmapi/test_llm_api_pytorch_moe_lora.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks[cudagraph] TIMEOUT (90)
+llmapi/test_llm_api_pytorch_moe_lora.py::test_mixtral_moe_routed_expert_fp8_multi_lora_varying_ranks[eager] TIMEOUT (90)
+llmapi/test_llm_api_pytorch_moe_lora.py::test_mixtral_moe_routed_expert_fp8_multi_lora_varying_ranks[cudagraph] TIMEOUT (90)
 
 # CuteDSL NVFP4 tests
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_cute_dsl_nvfp4[fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -256,9 +256,8 @@ l0_h100:
     - unittest/llmapi/test_llm_pytorch.py -m "part1"
     - unittest/llmapi/test_llm_pytorch.py -m "part2"
     - unittest/llmapi/test_llm_pytorch.py -m "part3"
-    - llmapi/test_llm_api_pytorch_moe_lora.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks[host_path] TIMEOUT (90)
-    - llmapi/test_llm_api_pytorch_moe_lora.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks[device_path_eager] TIMEOUT (90)
-    - llmapi/test_llm_api_pytorch_moe_lora.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks[device_path_cudagraph] TIMEOUT (90)
+    - llmapi/test_llm_api_pytorch_moe_lora.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks[eager] TIMEOUT (90)
+    - llmapi/test_llm_api_pytorch_moe_lora.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks[cudagraph] TIMEOUT (90)
     - unittest/llmapi/test_async_llm.py -m "not (gpu2 or gpu4)"
     - examples/test_ray.py::test_llm_inference_async_ray
 - condition:
@@ -333,7 +332,8 @@ l0_h100:
       orchestrator: mpi
   tests:
   # ------------- PyTorch tests ---------------
-  - llmapi/test_llm_api_pytorch_moe_lora.py::test_mixtral_moe_routed_expert_fp8_multi_lora_varying_ranks TIMEOUT (90)
+  - llmapi/test_llm_api_pytorch_moe_lora.py::test_mixtral_moe_routed_expert_fp8_multi_lora_varying_ranks[eager] TIMEOUT (90)
+  - llmapi/test_llm_api_pytorch_moe_lora.py::test_mixtral_moe_routed_expert_fp8_multi_lora_varying_ranks[cudagraph] TIMEOUT (90)
   - accuracy/test_llm_api_pytorch.py::TestQwen3_8B::test_eagle3[eagle3_one_model=True-enable_chunked_prefill=True-enable_max_concurrency=False-enable_draft_len_schedule=False]
   - accuracy/test_llm_api_pytorch.py::TestQwen3_8B::test_eagle3[eagle3_one_model=True-enable_chunked_prefill=False-enable_max_concurrency=False-enable_draft_len_schedule=True]
   - accuracy/test_llm_api_pytorch.py::TestQwen3_8B::test_eagle3[eagle3_one_model=True-enable_chunked_prefill=False-enable_max_concurrency=True-enable_draft_len_schedule=False]

--- a/tests/unittest/_torch/lora/test_moe_lora_cuda_graph_params.py
+++ b/tests/unittest/_torch/lora/test_moe_lora_cuda_graph_params.py
@@ -3,7 +3,7 @@
 """Integration tests for the routed-expert MoE LoRA *CUDA-graph slot-table*
 Python wiring.
 
-The op-level tests (`test_moe_lora_op.py`, `test_moe_lora_device_path.py`)
+The op-level tests (`test_moe_lora_op.py`, `test_moe_lora_grouped_gemm.py`)
 exercise `torch.ops.trtllm.fused_moe` with hand-built slot kwargs, bypassing the
 plumbing that actually produces those kwargs at decode time. These tests cover
 that glue end-to-end on the Python side, without model weights or the built C++
@@ -39,8 +39,12 @@ _INTER = 256
 
 class _ExtractStub:
     """Minimal stand-in for a CutlassFusedMoE so the unbound extraction method
-    can run without constructing a full MoE layer. The method only reads
-    `self.layer_idx`."""
+    can run without constructing a full MoE layer. The method reads
+    `self.layer_idx` and the shared slot-gathering helpers, which we borrow from
+    CutlassFusedMoE."""
+
+    _gather_moe_lora_slots = CutlassFusedMoE._gather_moe_lora_slots
+    _empty_kernel_slot_dict = staticmethod(CutlassFusedMoE._empty_kernel_slot_dict)
 
     def __init__(self, layer_idx):
         self.layer_idx = layer_idx

--- a/tests/unittest/_torch/lora/test_moe_lora_extract.py
+++ b/tests/unittest/_torch/lora/test_moe_lora_extract.py
@@ -28,12 +28,14 @@ LoraModuleType = lora_layer.LoraModuleType
 class _ExtractStub:
     """Minimal stand-in for a CutlassFusedMoE instance.
 
-    _extract_moe_lora_tensors only reads self.layer_idx and the class attribute
-    self._MOE_LORA_MODULE_NAMES, so we can drive it via the unbound method
+    _extract_moe_lora_tensors reads self.layer_idx and the small slot-gathering
+    helpers, which we borrow from CutlassFusedMoE so the unbound method can run
     without constructing real weights or a GPU layer.
     """
 
-    _MOE_LORA_MODULE_NAMES = CutlassFusedMoE._MOE_LORA_MODULE_NAMES
+    _gather_moe_lora_slots = CutlassFusedMoE._gather_moe_lora_slots
+    _require_fc1_fc2 = staticmethod(CutlassFusedMoE._require_fc1_fc2)
+    _empty_kernel_slot_dict = staticmethod(CutlassFusedMoE._empty_kernel_slot_dict)
 
     def __init__(self, layer_idx=0):
         self.layer_idx = layer_idx

--- a/tests/unittest/_torch/lora/test_moe_lora_grouped_gemm.py
+++ b/tests/unittest/_torch/lora/test_moe_lora_grouped_gemm.py
@@ -1,18 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for the capture-safe *device path* of routed-expert MoE LoRA in
-`torch.ops.trtllm.fused_moe`.
+"""Tests for the capture-safe grouped-GEMM LoRA core of routed-expert MoE LoRA
+in `torch.ops.trtllm.fused_moe`.
 
-The device path (selected by the slot-indexed input schema, or by
-`TLLM_MOE_LORA_USE_DEVICE_PATH=1` for the per-request schema) performs the
-per-token pointer expansion, problem building, and grouped GEMMs entirely on
-the CUDA stream, so it is safe to record into a CUDA graph. These tests cover
-the surface the eager-only tests in `test_moe_lora_op.py` cannot reach:
+The MoE op always runs the grouped-GEMM core: per-token pointer expansion,
+problem building, and grouped GEMMs run entirely on the CUDA stream, so it is
+safe to record into a CUDA graph. Two input schemas feed the core: the eager
+per-request schema and the CUDA-graph slot-indexed schema. These tests cover the
+surface the eager-only tests in `test_moe_lora_op.py` cannot reach:
 
-  1. Device-path eager correctness vs. the legacy host path and an fp32
-     PyTorch reference (exercises the new on-device kernels).
-  2. CUDA-graph capture + replay of the device path (slot-indexed schema),
-     verified against the eager result.
+  1. Eager per-request correctness vs. an fp32 PyTorch reference (exercises the
+     on-device pointer-expand / problem-builder / grouped-GEMM kernels).
+  2. CUDA-graph capture + replay of the slot-indexed schema, verified against
+     the eager result.
   3. Multi-adapter routing within a single capture (token_to_slot mixing two
      adapter slots).
   4. Slot reassignment under replay: the slot -> per-token expansion runs
@@ -41,8 +41,8 @@ def _isolate_moe_runner_cache():
     """Give every test a fresh cached FusedMoeRunner and release captured graphs
     / device scratch afterward.
 
-    The MoE LoRA device path keeps persistent per-runner scratch (slot tables,
-    pointer arrays, low-rank workspace) on the module-level MoERunner cache, and
+    The MoE LoRA grouped-GEMM core keeps persistent per-runner scratch (slot
+    tables, pointer arrays, low-rank workspace) on the module-level MoERunner cache, and
     these tests leak the CUDA graphs they capture. Without isolation, a test that
     grows the cached runner's slot tables (e.g. max_lora_size 1 -> 2) while an
     earlier test's captured graph still references the old device scratch
@@ -193,13 +193,11 @@ def _reference_multi_slot(x, w3_w1, w2, topk_ids, topk_scores, adapter_sets, tok
 
 
 @requires_cuda_and_op
-def test_device_path_eager_matches_host_and_reference(monkeypatch):
-    """Per-request schema on the device path (env-var opt-in) must match both
-    the legacy host path and the fp32 PyTorch reference. Exercises the on-device
-    pointer-expand / problem-builder / grouped-GEMM kernels in eager mode.
+def test_eager_per_request_matches_reference():
+    """The eager (per-request) input schema feeds the grouped-GEMM LoRA core and
+    must match the fp32 PyTorch reference. Exercises the on-device pointer-expand
+    / problem-builder / grouped-GEMM kernels in eager mode.
     """
-    from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
-
     device = torch.device("cuda")
     dtype = torch.bfloat16
     num_tokens, hidden_size, inter_size = 16, 128, 256
@@ -213,29 +211,11 @@ def test_device_path_eager_matches_host_and_reference(monkeypatch):
     )
     lora_kwargs = _per_request_kwargs(num_tokens, adapters, rank)
 
-    # Host path (device path env explicitly disabled), fresh runner.
-    monkeypatch.setenv("TLLM_MOE_LORA_USE_DEVICE_PATH", "0")
-    MoERunner.runner_dict.clear()
-    try:
-        out_host = _call_fused_moe(x, w3_w1, w2, topk_ids, topk_scores, dtype, dict(lora_kwargs))
-    finally:
-        MoERunner.runner_dict.clear()
-
-    # Device path (env opt-in), fresh runner.
-    monkeypatch.setenv("TLLM_MOE_LORA_USE_DEVICE_PATH", "1")
-    MoERunner.runner_dict.clear()
-    try:
-        out_device = _call_fused_moe(x, w3_w1, w2, topk_ids, topk_scores, dtype, dict(lora_kwargs))
-    finally:
-        MoERunner.runner_dict.clear()
-
+    out = _call_fused_moe(x, w3_w1, w2, topk_ids, topk_scores, dtype, dict(lora_kwargs))
     out_ref = _reference(x, w3_w1, w2, topk_ids, topk_scores, adapters)
 
-    assert torch.isfinite(out_device).all()
-    torch.testing.assert_close(out_device, out_ref, rtol=_RTOL, atol=_ATOL)
-    # Host vs device path are different reduction orders but should agree
-    # within the same bf16 tolerance.
-    torch.testing.assert_close(out_device, out_host, rtol=_RTOL, atol=_ATOL)
+    assert torch.isfinite(out).all()
+    torch.testing.assert_close(out, out_ref, rtol=_RTOL, atol=_ATOL)
 
 
 def _warmup_and_capture(call_fn, warmup_iters=3):
@@ -252,9 +232,9 @@ def _warmup_and_capture(call_fn, warmup_iters=3):
 
 
 @requires_cuda_and_op
-def test_device_path_cuda_graph_replay_matches_eager():
-    """Slot-indexed schema auto-selects the device path; capturing the op into a
-    CUDA graph and replaying must reproduce the eager device-path output.
+def test_cuda_graph_replay_matches_eager():
+    """Capturing the slot-indexed op into a CUDA graph and replaying must
+    reproduce the eager output.
     """
     device = torch.device("cuda")
     dtype = torch.bfloat16
@@ -282,16 +262,16 @@ def test_device_path_cuda_graph_replay_matches_eager():
 
     out_ref = _reference(x, w3_w1, w2, topk_ids, topk_scores, adapters)
     assert torch.isfinite(out_replay).all()
-    # Replay reproduces the captured device-path computation bit-for-bit.
+    # Replay reproduces the captured computation bit-for-bit.
     torch.testing.assert_close(out_replay, out_eager, rtol=0, atol=0)
     torch.testing.assert_close(out_replay, out_ref, rtol=_RTOL, atol=_ATOL)
 
 
 @requires_cuda_and_op
-def test_device_path_cuda_graph_multi_adapter():
+def test_cuda_graph_multi_adapter():
     """Two adapter slots routed per-token via token_to_slot, captured + replayed.
-    Validates the device path threads each token's slot through the on-device
-    pointer expansion correctly.
+    Validates the slot-indexed path threads each token's slot through the
+    on-device pointer expansion correctly.
     """
     device = torch.device("cuda")
     dtype = torch.bfloat16
@@ -327,7 +307,7 @@ def test_device_path_cuda_graph_multi_adapter():
 
 
 @requires_cuda_and_op
-def test_device_path_reserve_prevents_growth_across_captures():
+def test_reserve_prevents_growth_across_captures():
     """Production-mirroring positive test: pre-reserve worst-case LoRA scratch on
     the cached runner, then capture two graphs on the SAME runner at growing slot
     counts (1 then 2). Because reserve pre-sized to the worst case
@@ -440,7 +420,7 @@ def _set_slot_ptrs_inplace(slot_kwargs, adapters, slot_index=0):
 
 
 @requires_cuda_and_op
-def test_device_path_slot_reassignment_reflected_on_replay():
+def test_slot_reassignment_reflected_on_replay():
     """In-place slot reassignment must be reflected on replay WITHOUT recapture.
 
     The slot -> per-token expansion runs on-device (launchMoeLoraSlotExpand)
@@ -477,15 +457,14 @@ def test_device_path_slot_reassignment_reflected_on_replay():
     # Sanity: the two adapters produce meaningfully different outputs.
     assert (out_ref_a.float() - out_ref_b.float()).abs().mean().item() > 1e-2
 
-    # Correctness of the device-path numerics is covered by
-    # test_device_path_cuda_graph_replay_matches_eager and
-    # test_device_path_eager_matches_host_and_reference. This test targets the
+    # Correctness of the grouped-GEMM numerics is covered by
+    # test_cuda_graph_replay_matches_eager and
+    # test_eager_per_request_matches_reference. This test targets the
     # *reassignment* invariant, and uses a precision-robust discriminative check
     # rather than a tight element-wise match: these randomly-drawn adapters push
     # the SwiGLU + FC2 intermediates large enough that a few percent of output
-    # lanes fall into bf16 catastrophic cancellation (the device path is
-    # bit-identical to the host path there; both diverge from the fp32 reference
-    # only on those lanes), so an element-wise reference match is not meaningful.
+    # lanes fall into bf16 catastrophic cancellation and diverge from the fp32
+    # reference on those lanes, so an element-wise reference match is not meaningful.
     # Instead assert that the replayed output tracks whichever adapter is
     # currently assigned (closer in mean to its own reference than to the other)
     # and flips when the slot is reassigned in place, all without recapture.

--- a/tests/unittest/_torch/lora/test_moe_lora_op.py
+++ b/tests/unittest/_torch/lora/test_moe_lora_op.py
@@ -208,15 +208,13 @@ def test_moe_per_expert_lora_changes_output():
 
 
 @requires_cuda_and_op
-def test_moe_lora_slot_indexed_matches_per_request(monkeypatch):
+def test_moe_lora_slot_indexed_matches_per_request():
     """The slot-indexed (CUDA-graph) input schema must produce bit-identical
-    output to the per-request schema for the same adapter, since both expand to
-    the same per-token (rank, A_ptr, B_ptr) arrays inside the op.
+    output to the per-request (eager) schema for the same adapter, since both
+    expand to the same per-token (rank, A_ptr, B_ptr) arrays inside the op.
 
-    The slot-indexed schema always takes the capture-safe device path, so for an
-    apples-to-apples bit-exact comparison we force the per-request schema onto
-    the device path too (TLLM_MOE_LORA_USE_DEVICE_PATH=1). Both then share the
-    pointer-expand + grouped-GEMM kernels, so identical per-token tables yield
+    Both schemas feed the identical grouped-GEMM LoRA core (pointer-expand +
+    problem-builder + grouped GEMM), so identical per-token tables yield
     bit-identical output.
     """
     from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
@@ -255,8 +253,7 @@ def test_moe_lora_slot_indexed_matches_per_request(monkeypatch):
         rank=rank,
     )
 
-    # Force both schemas onto the device path, via a fresh runner.
-    monkeypatch.setenv("TLLM_MOE_LORA_USE_DEVICE_PATH", "1")
+    # Both schemas feed the same grouped-GEMM core; use a fresh runner.
     MoERunner.runner_dict.clear()
     try:
         out_per_request = _call_fused_moe(
@@ -1317,20 +1314,16 @@ def _build_fp8_moe_inputs(x_bf16, w3_w1_bf16, w2_bf16):
 
 @requires_cuda_and_op
 @pytest.mark.parametrize("schema", ["per_request", "slot_indexed"])
-def test_moe_fp8_lora_changes_output(schema, monkeypatch):
+def test_moe_fp8_lora_changes_output(schema):
     """FP8 (qdq) base weights + routed-expert LoRA must run and apply the LoRA.
 
     Validates the FP8 enablement end to end through `torch.ops.trtllm.fused_moe`
-    for both LoRA input schemas (per-request host path and slot-indexed device
-    path): the op accepts FP8 weights/activations together with LoRA tensors,
-    produces finite output, and the output differs from the FP8 no-LoRA
-    baseline (the LoRA delta is actually applied on the FP8 base).
+    for both LoRA input schemas (per-request and slot-indexed), which share the
+    grouped-GEMM LoRA core: the op accepts FP8 weights/activations together with
+    LoRA tensors, produces finite output, and the output differs from the FP8
+    no-LoRA baseline (the LoRA delta is actually applied on the FP8 base).
     """
     from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
-
-    # Force the per-request schema onto the capture-safe device path too, so
-    # both schemas exercise the same FP8 dequant + grouped-GEMM LoRA kernels.
-    monkeypatch.setenv("TLLM_MOE_LORA_USE_DEVICE_PATH", "1")
 
     MoERunner.runner_dict.clear()
     try:


### PR DESCRIPTION
## Description

This MR collapses the routed-expert MoE LoRA code from three execution variants down to a single grouped-GEMM core fed by two input front-ends (eager per-request and CUDA-graph slot-indexed) - with no change to runtime behavior.

Currently, there are 3 execution methods for routed-expert MoE LoRA:
- host_path - eager, legacy cuBLAS/LoraImpl path (per-request D2H pointer expand)
- device_path_eager - eager, capture-safe grouped-GEMM path (per-request input), formerly forced on via `TLLM_MOE_LORA_USE_DEVICE_PATH`.
- device_path_cudagraph - CUDA-graph decode, slot-indexed grouped-GEMM path.

This MR removed the first one. Goal is to minimize codepaths for maintainability and share as much code as possible for eager and cudagraph paths.
<img width="549" height="631" alt="image" src="https://github.com/user-attachments/assets/ce260429-c875-4282-9fa0-e98e20a58bcf" />

This is just a refactor guarded by existing tests.

## Test Coverage

```
$ pytest tests/unittest/_torch/lora/test_moe_lora_op.py -s -v
$ pytest tests/unittest/_torch/lora/test_moe_lora_grouped_gemm.py -s -v
$ pytest tests/unittest/_torch/lora/test_moe_lora_extract.py -s -v
$ pytest tests/unittest/_torch/lora/test_moe_lora_cuda_graph_params.py -s -v
$ pytest tests/unittest/llmapi/test_llm_pytorch.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks -s -v
$ ./cpp/tests/unit_tests/kernels/moeLoraProblemBuilderTest --gtest_filter='MoeLoraProblemBuilderTest.*'
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
