### PR TITLE
[TRTLLM-12807][test] Guard thop attention kwarg aliases

### DIFF
--- a/tests/unittest/_torch/attention_backend/test_attention_op_sync.py
+++ b/tests/unittest/_torch/attention_backend/test_attention_op_sync.py
@@ -58,6 +58,20 @@ _SOURCE_CLASSES = {
     "forward_args": AttentionForwardArgs,
 }
 
+_THOP_KWARG_SOURCE_ALIASES: dict[str, tuple[str, tuple[str, ...]]] = {
+    "context_lengths": ("metadata", ("prompt_lens_cuda_runtime",)),
+    "head_size": ("self", ("head_dim",)),
+    "host_context_lengths": ("metadata", ("prompt_lens_cpu_runtime",)),
+    "host_past_key_value_lengths": ("metadata", ("kv_lens_runtime",)),
+    "host_request_types": ("metadata", ("host_request_types_runtime",)),
+    "sequence_length": ("metadata", ("kv_lens_cuda_runtime",)),
+    "spec_decoding_target_max_draft_tokens": (
+        "metadata",
+        ("max_total_draft_tokens",),
+    ),
+    "workspace_": ("metadata", ("effective_workspace",)),
+}
+
 # The C++ attention() declaration is the single source of truth for kwarg
 # names, ordering, and types.
 _HEADER = pathlib.Path(__file__).resolve().parents[4] / ("cpp/tensorrt_llm/thop/attentionOp.h")
@@ -214,13 +228,39 @@ def _attribute_path(node: ast.AST) -> tuple[str, tuple[str, ...]] | None:
     return current.id, tuple(reversed(attrs))
 
 
+def _getattr_path(node: ast.AST) -> tuple[str, tuple[str, ...]] | None:
+    """If ``node`` is ``getattr(Name.attr..., "leaf", <default>)``, return
+    ``(root_name_id, (attr1, ..., leaf))``. Otherwise return ``None``.
+    """
+    if (
+        not isinstance(node, ast.Call)
+        or not isinstance(node.func, ast.Name)
+        or node.func.id != "getattr"
+        or len(node.args) not in (2, 3)
+        or not isinstance(node.args[1], ast.Constant)
+        or not isinstance(node.args[1].value, str)
+    ):
+        return None
+    root_path: tuple[str, tuple[str, ...]]
+    if isinstance(node.args[0], ast.Name):
+        root_path = (node.args[0].id, ())
+    else:
+        path = _attribute_path(node.args[0])
+        if path is None:
+            return None
+        root_path = path
+    root, attrs = root_path
+    return root, (*attrs, node.args[1].value)
+
+
 def _classify_kwargs() -> tuple[
     dict[str, tuple[str, tuple[str, ...]]], dict[str, object], set[str]
 ]:
     """Split the call site's kwargs into three buckets:
 
-    - ``attr_kwargs``: ``kwarg=source.attr[...]`` (or
-      ``kwarg=int(source.attr)``) → ``{kwarg: (root, path)}``.
+    - ``attr_kwargs``: ``kwarg=source.attr[...]``,
+      ``kwarg=int(source.attr)``, or ``kwarg=getattr(source, "attr", ...)``
+      → ``{kwarg: (root, path)}``.
     - ``literal_kwargs``: ``kwarg=<constant>`` → ``{kwarg: value}``.
     - ``other_kwargs``: kwargs whose value is anything else (e.g. a bare
       Name like ``q``).
@@ -246,6 +286,10 @@ def _classify_kwargs() -> tuple[
             continue
         if isinstance(v, ast.Constant):
             literal_kwargs[kw.arg] = v.value
+            continue
+        path = _getattr_path(v)
+        if path is not None:
+            attr_kwargs[kw.arg] = path
             continue
         path = _attribute_path(v)
         if path is not None:
@@ -406,6 +450,20 @@ def test_each_source_attr_kwarg_resolves_uniquely():
                     f" → {cpp_cat}) bound to `{chain}` "
                     f"({leaf_py_type!r} → {py_cat})."
                 )
+
+
+def test_attr_kwarg_names_match_source_leaf_attrs_except_allowlisted_aliases():
+    """Most ``thop.attention`` kwargs should bind to a source attribute with
+    the same name. Existing aliases must stay explicit so new semantic
+    mismatches cannot slip in under a broad type-compatible mapping.
+    """
+    attr_kwargs, _, _ = _classify_kwargs()
+    aliases = {kwarg: source for kwarg, source in attr_kwargs.items() if kwarg != source[1][-1]}
+    assert aliases == _THOP_KWARG_SOURCE_ALIASES, (
+        "Unexpected thop kwarg/source attribute aliases.\n"
+        f"new or changed aliases: {aliases.items() - _THOP_KWARG_SOURCE_ALIASES.items()}\n"
+        f"stale allowlist entries: {_THOP_KWARG_SOURCE_ALIASES.items() - aliases.items()}"
+    )
 
 
 def test_literal_kwargs_match_allowlist():


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation for attention operation parameter naming conventions, including support for attribute source aliases and improved expression parsing to ensure consistent kwarg naming across configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Adds a static sync-test guard for the `thop.attention(...)` call site so kwargs sourced from `self` / `metadata` / `forward_args` must match the source leaf attribute name by default.

Existing intentional aliases are listed explicitly in the test allowlist, including:

```text
context_lengths = metadata.prompt_lens_cuda_runtime
head_size = self.head_dim
host_context_lengths = metadata.prompt_lens_cpu_runtime
host_past_key_value_lengths = metadata.kv_lens_runtime
host_request_types = metadata.host_request_types_runtime
sequence_length = metadata.kv_lens_cuda_runtime
spec_decoding_target_max_draft_tokens = metadata.max_total_draft_tokens
workspace_ = metadata.effective_workspace
```

The test helper also recognizes `getattr(source, "attr", ...)` as a source attribute path so the current `spec_decoding_target_max_draft_tokens` mapping is checked instead of classified as an arbitrary expression.

## Test Coverage

- `pytest -q tests/unittest/_torch/attention_backend/test_attention_op_sync.py`
- `pre-commit run --files tests/unittest/_torch/attention_backend/test_attention_op_sync.py`
- `pre-commit run --from-ref origin/main --to-ref HEAD`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
