### PR TITLE
[None][fix] fix tinygemm barrier bug

### DIFF
--- a/cpp/tensorrt_llm/kernels/tinygemm2/tinygemm2_kernel.cuh
+++ b/cpp/tensorrt_llm/kernels/tinygemm2/tinygemm2_kernel.cuh
@@ -358,8 +358,8 @@ __global__ __launch_bounds__(384, 1) void tinygemm_kernel(__nv_bfloat16* output,
 
             while (!weight_ready || !act_ready)
             {
-                weight_ready = bar_try_wait(bar_ptr_wt, phase);
-                act_ready = bar_try_wait(bar_ptr_act, phase);
+                weight_ready = bar_try_wait(__cvta_generic_to_shared(&bar_wt_ready[stage]), phase);
+                act_ready = bar_try_wait(__cvta_generic_to_shared(&bar_act_ready[stage]), phase);
             }
 
             if (PROFILE && blockIdx.y == 0 && threadIdx.x == 0 && ki == 0)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization logic in tensor compute kernels to enhance correctness and stability of mathematical operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description
### How is this bug?
- When Tinygemm and UVA copies are executed simultaneously, gemm results in errors.
- Running Tinygemm exclusively does not cause this problem.
- The bug will not be triggered if UVA or other similar workloads are not present.

### Root cause
- The consumer(compute warp) spin wait uses an obsolete barrier pointer.
- Poll the CURRENT stage's ready barriers. `bar_ptr_wt / bar_ptr_act` are computed ONCE before the loop for the initial stage and never updated, while the `stage` advances by 4 every `ki`.
- When the prefetch below is missed (producer behind, e.g., under heavy concurrent SM->sysmem traffic), this spin-wait polls the wrong, initial-stage barrier. That barrier already completed at `ki==0`, so try_wait returns ready immediately and the consumer proceeds to ldmatrix a stage the TMA has not filled yet -> corrupted output (or a pipeline hang).
- Polling the live stage makes the wait check the barrier that actually gates this iteration's data. 

### Why don't bugs appear when running it exclusively?
- It is only triggered when the producer lags behind, and prefetching fails. When run exclusively, the producer is always ahead, so it is never apparent. 
-  Pinned-host writeback creates the trigger condition by preempting the memory subsystem and slowing down the TMA producer.

Also update the integration in flashinfer: https://github.com/flashinfer-ai/flashinfer/pull/3630

Thanks to @LorrinWWW for reporting this bug and for providing a very detailed script to reproduce it.


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
