### PR TITLE
[feat] Enable MLA chunked prefill and KV cache reuse on SM121

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -673,10 +673,10 @@ def create_py_executor(
 
         sm_version = get_sm_version()
         if kv_cache_config.enable_block_reuse and sm_version not in [
-                90, 100, 103, 120
+                90, 100, 103, 120, 121
         ]:
             logger.warning(
-                f"KV cache reuse for MLA can only be enabled on SM90/SM100/SM103/SM120, "
+                f"KV cache reuse for MLA can only be enabled on SM90/SM100/SM103/SM120/SM121, "
                 f"disable enable_block_reuse for SM{sm_version}")
             kv_cache_config.enable_block_reuse = False
             _set_model_engines_cache_reuse([model_engine, draft_model_engine],
@@ -693,9 +693,9 @@ def create_py_executor(
             kv_cache_config.enable_block_reuse = False
             _set_model_engines_cache_reuse([model_engine, draft_model_engine],
                                            False)
-        if enable_chunked_context and sm_version not in [90, 100, 103, 120]:
+        if enable_chunked_context and sm_version not in [90, 100, 103, 120, 121]:
             logger.warning(
-                "Chunked Prefill for MLA can only be enabled on SM90/SM100/SM103/SM120, "
+                "Chunked Prefill for MLA can only be enabled on SM90/SM100/SM103/SM120/SM121, "
                 f"disable enable_chunked_context for SM{sm_version}")
             enable_chunked_context = False
             model_engine.attn_runtime_features.chunked_prefill = False


### PR DESCRIPTION
I updated the SM version check logic in `py_executor_creator.py` to allow MLA chunked prefill and KV cache block reuse on SM121 (Blackwell) architectures. Specifically, I added SM121 (`121`) to the validation lists for both `enable_block_reuse` and `enable_chunked_context` checks, preventing the executor from automatically disabling these features on Blackwell GPUs.

This resolves issue #15344, where these optimization features were being disabled on SM121 devices because the Python-side validator was missing SM121 in its allowlist. The underlying C++ kernels already support SM121, so this change enables full compatibility for MLA optimizations on this hardware.