### PR TITLE
[docs] Fix broken LlmArgs link in AutoDeploy README

### DIFF
--- a/examples/auto_deploy/README.md
+++ b/examples/auto_deploy/README.md
@@ -176,7 +176,7 @@ For expert users, `build_and_run_ad.py` provides advanced configuration capabili
 
 #### CLI Arguments with Dot Notation
 
-The script supports flexible CLI argument parsing using dot notation to modify nested configurations dynamically. You can target any field in both the [`ExperimentConfig`](./build_and_run_ad.py) and nested [`AutoDeployConfig`](../../tensorrt_llm/_torch/auto_deploy/llm_args.py)/[`LlmArgs`](../../tensorrt_llm/_torch/auto_deploy/llm_args.) objects:
+The script supports flexible CLI argument parsing using dot notation to modify nested configurations dynamically. You can target any field in both the [`ExperimentConfig`](./build_and_run_ad.py) and nested [`AutoDeployConfig`](../../tensorrt_llm/_torch/auto_deploy/llm_args.py)/[`LlmArgs`](../../tensorrt_llm/_torch/auto_deploy/llm_args.py) objects:
 
 ```bash
 # Configure model parameters


### PR DESCRIPTION
I corrected a broken markdown link in the AutoDeploy README (`examples/auto_deploy/README.md`) under the CLI Arguments section. The link path pointing to `LlmArgs` was missing the `.py` file extension at the end of the filename.

This resolves issue #15191. Fixing this typo restores the correct file link to `llm_args.py` so that users reading the documentation can navigate directly to the configuration file definition.