### PR TITLE
[TRTLLM-12721][fix] Bound disagg transfer polling and admission

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/disaggTransferAdmissionController.h
+++ b/cpp/include/tensorrt_llm/batch_manager/disaggTransferAdmissionController.h
@@ -41,6 +41,11 @@ public:
         std::size_t admittedTransferBlocks{};
         std::size_t deferredRequestCount{};
         bool limitedByBudget{};
+
+        [[nodiscard]] bool isBlockedByActiveTransfers() const
+        {
+            return limitedByBudget && admittedRequests.empty() && activeTransferBlocks > 0;
+        }
     };
 
     explicit DisaggTransferAdmissionController(std::optional<std::size_t> maxTokensInBuffer, SizeType32 tokensPerBlock,

--- a/cpp/include/tensorrt_llm/batch_manager/disaggTransferAdmissionController.h
+++ b/cpp/include/tensorrt_llm/batch_manager/disaggTransferAdmissionController.h
@@ -1,0 +1,160 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/batch_manager/common.h"
+#include "tensorrt_llm/batch_manager/llmRequest.h"
+
+#include <cstddef>
+#include <optional>
+
+namespace tensorrt_llm::batch_manager
+{
+
+class DisaggTransferAdmissionController
+{
+public:
+    enum class Policy
+    {
+        kFcfsEstimatedBlockBudget
+    };
+
+    struct Result
+    {
+        RequestVector admittedRequests;
+        std::size_t activeTransferBlocks{};
+        std::size_t admittedTransferBlocks{};
+        std::size_t deferredRequestCount{};
+        bool limitedByBudget{};
+    };
+
+    explicit DisaggTransferAdmissionController(std::optional<std::size_t> maxTokensInBuffer, SizeType32 tokensPerBlock,
+        Policy policy = Policy::kFcfsEstimatedBlockBudget)
+        : mMaxTransferBlocks(toBlockBudget(maxTokensInBuffer, tokensPerBlock))
+        , mTokensPerBlock(tokensPerBlock)
+        , mPolicy(policy)
+    {
+    }
+
+    [[nodiscard]] bool enabled() const
+    {
+        return mMaxTransferBlocks.has_value();
+    }
+
+    [[nodiscard]] std::optional<std::size_t> getMaxTransferBlocks() const
+    {
+        return mMaxTransferBlocks;
+    }
+
+    [[nodiscard]] Result select(RequestList const& activeRequests, RequestVector const& candidates) const
+    {
+        if (!enabled())
+        {
+            return Result{
+                candidates, estimateActiveTransferBlocks(activeRequests), estimateRequestsBlocks(candidates), 0, false};
+        }
+
+        switch (mPolicy)
+        {
+        case Policy::kFcfsEstimatedBlockBudget: return selectFcfsEstimatedBlockBudget(activeRequests, candidates);
+        }
+
+        return Result{};
+    }
+
+private:
+    [[nodiscard]] static std::optional<std::size_t> toBlockBudget(
+        std::optional<std::size_t> maxTokensInBuffer, SizeType32 tokensPerBlock)
+    {
+        if (!maxTokensInBuffer.has_value() || maxTokensInBuffer.value() == 0 || tokensPerBlock <= 0)
+        {
+            return std::nullopt;
+        }
+        auto const blockSize = static_cast<std::size_t>(tokensPerBlock);
+        return (maxTokensInBuffer.value() + blockSize - 1) / blockSize;
+    }
+
+    [[nodiscard]] std::size_t estimateRequestBlocks(LlmRequest const& request) const
+    {
+        if (mTokensPerBlock <= 0)
+        {
+            return 0;
+        }
+        auto const promptLen = static_cast<std::size_t>(request.getPromptLen());
+        auto const blockSize = static_cast<std::size_t>(mTokensPerBlock);
+        return (promptLen + blockSize - 1) / blockSize;
+    }
+
+    [[nodiscard]] std::size_t estimateRequestsBlocks(RequestVector const& requests) const
+    {
+        std::size_t blocks{};
+        for (auto const& request : requests)
+        {
+            blocks += estimateRequestBlocks(*request);
+        }
+        return blocks;
+    }
+
+    [[nodiscard]] std::size_t estimateActiveTransferBlocks(RequestList const& activeRequests) const
+    {
+        std::size_t blocks{};
+        for (auto const& request : activeRequests)
+        {
+            if (request->isDisaggGenerationTransmissionInProgress())
+            {
+                blocks += estimateRequestBlocks(*request);
+            }
+        }
+        return blocks;
+    }
+
+    [[nodiscard]] Result selectFcfsEstimatedBlockBudget(
+        RequestList const& activeRequests, RequestVector const& candidates) const
+    {
+        Result result;
+        result.activeTransferBlocks = estimateActiveTransferBlocks(activeRequests);
+
+        auto const maxTransferBlocks = mMaxTransferBlocks.value();
+        auto usedBlocks = result.activeTransferBlocks;
+        for (auto const& request : candidates)
+        {
+            auto const requestBlocks = estimateRequestBlocks(*request);
+            bool const fitsBudget = usedBlocks + requestBlocks <= maxTransferBlocks;
+            bool const admitOversizedHead = result.admittedRequests.empty() && result.activeTransferBlocks == 0
+                && requestBlocks > maxTransferBlocks;
+            if (!fitsBudget && !admitOversizedHead)
+            {
+                result.limitedByBudget = true;
+                break;
+            }
+
+            result.admittedRequests.push_back(request);
+            usedBlocks += requestBlocks;
+            result.admittedTransferBlocks += requestBlocks;
+        }
+
+        result.deferredRequestCount = candidates.size() - result.admittedRequests.size();
+        return result;
+    }
+
+    std::optional<std::size_t> mMaxTransferBlocks;
+    SizeType32 mTokensPerBlock;
+    Policy mPolicy;
+};
+
+} // namespace tensorrt_llm::batch_manager

--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -1501,20 +1501,25 @@ public:
         NIXL = 3,
         MOONCAKE = 4
     };
+    static constexpr int kDefaultKvTransferPollIntervalMs = 5000;
+
     explicit CacheTransceiverConfig(std::optional<BackendType> backendType = std::nullopt,
         std::optional<size_t> maxNumTokens = std::nullopt, std::optional<int> kvTransferTimeoutMs = std::nullopt,
-        std::optional<int> kvTransferSenderFutureTimeoutMs = std::nullopt);
+        std::optional<int> kvTransferSenderFutureTimeoutMs = std::nullopt,
+        std::optional<int> kvTransferPollIntervalMs = kDefaultKvTransferPollIntervalMs);
 
     bool operator==(CacheTransceiverConfig const& other) const;
     void setBackendType(std::optional<BackendType> backendType);
     void setMaxTokensInBuffer(std::optional<size_t> maxTokensInBuffer);
     void setKvTransferTimeoutMs(std::optional<int> kvTransferTimeoutMs);
     void setKvTransferSenderFutureTimeoutMs(std::optional<int> kvTransferSenderFutureTimeoutMs);
+    void setKvTransferPollIntervalMs(std::optional<int> kvTransferPollIntervalMs);
 
     [[nodiscard]] std::optional<size_t> getMaxTokensInBuffer() const;
     [[nodiscard]] std::optional<BackendType> getBackendType() const;
     [[nodiscard]] std::optional<int> getKvTransferTimeoutMs() const;
     [[nodiscard]] std::optional<int> getKvTransferSenderFutureTimeoutMs() const;
+    [[nodiscard]] std::optional<int> getKvTransferPollIntervalMs() const;
 
 private:
     std::optional<BackendType> mBackendType;
@@ -1526,6 +1531,9 @@ private:
     // @brief Timeout in milliseconds to wait for the sender future to be ready when scheduled batch size is 0. This
     // allows the request to be eventually cancelled by the user or because of kv_transfer_timeout_ms
     std::optional<int> mKvTransferSenderFutureTimeoutMs;
+    // @brief Bounded wait interval in milliseconds for polling KV transfer progress when active transfers block
+    // disaggregated admission.
+    std::optional<int> mKvTransferPollIntervalMs;
 };
 
 /// @brief Configuration class for the model executor

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -893,12 +893,37 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
 void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastRequestNum)
 {
     bool const blockAll = !atLeastRequestNum.has_value();
-    std::vector<LlmRequest::RequestIdType> genTransferReadyRequestIds;
-    for (auto&& [request, future] : mRequesterFutures)
+    bool const needsProgress = atLeastRequestNum.value_or(0) > 0;
+    std::optional<int> genTransferPollIntervalMs = std::nullopt;
+    if (mCacheTransceiverConfig.has_value())
     {
-        if (future.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready)
+        genTransferPollIntervalMs = mCacheTransceiverConfig->getKvTransferPollIntervalMs();
+    }
+    auto const futureWaitInterval = getTransferFutureWaitInterval(genTransferPollIntervalMs, needsProgress);
+
+    std::vector<LlmRequest::RequestIdType> genTransferReadyRequestIds;
+    auto collectReadyRequestIds = [&]()
+    {
+        genTransferReadyRequestIds.clear();
+        for (auto&& [request, future] : mRequesterFutures)
         {
-            genTransferReadyRequestIds.push_back(request->mRequestId);
+            if (future.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready)
+            {
+                genTransferReadyRequestIds.push_back(request->mRequestId);
+            }
+        }
+    };
+    collectReadyRequestIds();
+    if (needsProgress)
+    {
+        auto const deadline = std::chrono::steady_clock::now() + futureWaitInterval;
+        while (static_cast<int>(genTransferReadyRequestIds.size()) < atLeastRequestNum.value()
+            && std::chrono::steady_clock::now() < deadline)
+        {
+            auto const remaining
+                = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - std::chrono::steady_clock::now());
+            std::this_thread::sleep_for(std::min(std::chrono::milliseconds(kTransferFuturePollIntervalMs), remaining));
+            collectReadyRequestIds();
         }
     }
     std::unordered_map<LlmRequest::RequestIdType, int> frequencyMap;
@@ -927,53 +952,6 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
         [](std::pair<LlmRequest::RequestIdType, int> const& left,
             std::pair<LlmRequest::RequestIdType, int> const& right) { return left.second > right.second; });
     std::unordered_set<LlmRequest::RequestIdType> toCompleteIdSet;
-    size_t idx = 0;
-    while (atLeastRequestNum.value_or(0) > static_cast<int>(toCompleteIdSet.size()))
-    {
-        if (idx >= freqVec.size())
-        {
-            break;
-        }
-        toCompleteIdSet.insert(freqVec.at(idx).first);
-        if (useMPI())
-        {
-            TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
-                " checkGenTransferStatus at least from freqVec requestId: %zu ", freqVec.at(idx).first);
-        }
-        else
-        {
-            TLLM_LOG_DEBUG(tensorrt_llm::pg_utils::get_world_pg()->getRank(),
-                " checkGenTransferStatus at least from freqVec requestId: %zu ", freqVec.at(idx).first);
-        }
-        idx++;
-    }
-    idx = 0;
-
-    // insert order
-    while (atLeastRequestNum.value_or(0) > static_cast<int>(toCompleteIdSet.size()))
-    {
-        if (idx >= mRequesterFutures.size())
-        {
-            break;
-        }
-        if (toCompleteIdSet.find(mRequesterFutures.at(idx).first->mRequestId) == toCompleteIdSet.end())
-        {
-            toCompleteIdSet.insert(mRequesterFutures.at(idx).first->mRequestId);
-            if (useMPI())
-            {
-                TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
-                    " checkGenTransferStatus at least from RequesterFuture requestId: %zu atLeastRequestNum:%d",
-                    mRequesterFutures.at(idx).first->mRequestId, atLeastRequestNum.value_or(0));
-            }
-            else
-            {
-                TLLM_LOG_DEBUG(tensorrt_llm::pg_utils::get_world_pg()->getRank(),
-                    " checkGenTransferStatus at least from RequesterFuture requestId: %zu atLeastRequestNum:%d",
-                    mRequesterFutures.at(idx).first->mRequestId, atLeastRequestNum.value_or(0));
-            }
-        }
-        idx++;
-    }
     for (auto&& [requestId, freq] : freqVec)
     {
         if (freq == ((syncComm != nullptr) ? syncComm->getSize() : 1))
@@ -1003,13 +981,6 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
             " checkGenTransferStatus toCompleteIdSet size: %zu, atLeastRequestNum: %d ", toCompleteIdSet.size(),
             atLeastRequestNum.value_or(0));
     }
-    std::optional<int> requesterFutureTimeoutMs = std::nullopt;
-    if (mCacheTransceiverConfig.has_value())
-    {
-        requesterFutureTimeoutMs = mCacheTransceiverConfig->getKvTransferSenderFutureTimeoutMs();
-    }
-    bool const needsProgress = atLeastRequestNum.value_or(0) > 0;
-    auto const futureWaitInterval = getTransferFutureWaitInterval(requesterFutureTimeoutMs, needsProgress);
 
     // Observe-only: gen-side mirror of the context-side timeout WARN.
     std::optional<int> kvTransferTimeoutMs = std::nullopt;

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -617,6 +617,7 @@ void CacheTransceiver::requestAndReceiveAsync(std::shared_ptr<LlmRequest> llmReq
         return;
     }
 
+    llmRequest->setKvCacheTransferStart(LlmRequest::getSteadyClockNow());
     auto future = mCacheReceiver->receiveAsync(llmRequest);
     auto* requestPtr = llmRequest.get();
     mRequesterFutures.emplace_back(std::move(llmRequest), std::move(future));

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -71,16 +71,19 @@ using RequestIdType = LlmRequest::RequestIdType;
 
 constexpr int kTransferFuturePollIntervalMs = 10;
 
-// Finite status checks are scheduler polls, not terminal deadlines. Keep each
-// slice short so the caller can yield back to scheduling and transfer progress.
-std::chrono::milliseconds getTransferFuturePollInterval(std::optional<int> const& configuredTimeoutMs)
+// Finite status checks are scheduler polls, not terminal deadlines. Pure polls
+// use short slices; calls that ask for at least one completion keep bounded
+// backpressure by waiting up to the configured future timeout.
+std::chrono::milliseconds getTransferFutureWaitInterval(
+    std::optional<int> const& configuredTimeoutMs, bool const needsProgress)
 {
     auto waitMs = kTransferFuturePollIntervalMs;
     if (configuredTimeoutMs.has_value())
     {
-        waitMs = std::max(1, std::min(configuredTimeoutMs.value(), kTransferFuturePollIntervalMs));
+        waitMs = needsProgress ? configuredTimeoutMs.value()
+                               : std::min(configuredTimeoutMs.value(), kTransferFuturePollIntervalMs);
     }
-    return std::chrono::milliseconds(waitMs);
+    return std::chrono::milliseconds(std::max(1, waitMs));
 }
 
 enum class TransferConsensusState : std::uint64_t
@@ -727,7 +730,8 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
     {
         senderFutureTimeoutMs = mCacheTransceiverConfig->getKvTransferSenderFutureTimeoutMs();
     }
-    auto const futurePollInterval = getTransferFuturePollInterval(senderFutureTimeoutMs);
+    bool const needsProgress = atLeastRequestNum.value_or(0) > 0;
+    auto const futureWaitInterval = getTransferFutureWaitInterval(senderFutureTimeoutMs, needsProgress);
     // Observe-only: WARN per-request when the wall-clock transfer time exceeds
     // kvTransferTimeoutMs. No cancellation, eviction, or state transition.
     std::optional<int> kvTransferTimeoutMs = std::nullopt;
@@ -809,7 +813,7 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
         {
             try
             {
-                auto const status = blockAll ? std::future_status::ready : future.wait_for(futurePollInterval);
+                auto const status = blockAll ? std::future_status::ready : future.wait_for(futureWaitInterval);
                 if (status == std::future_status::ready)
                 {
                     future.get();
@@ -823,7 +827,7 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                     TLLM_LOG_DEBUG(
                         "Context KV cache transfer for request %ld is not ready after %ld ms wait slice; keeping it "
                         "in progress.",
-                        requestId, static_cast<long>(futurePollInterval.count()));
+                        requestId, static_cast<long>(futureWaitInterval.count()));
                     ++it;
                 }
                 else
@@ -1004,7 +1008,8 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
     {
         requesterFutureTimeoutMs = mCacheTransceiverConfig->getKvTransferSenderFutureTimeoutMs();
     }
-    auto const futurePollInterval = getTransferFuturePollInterval(requesterFutureTimeoutMs);
+    bool const needsProgress = atLeastRequestNum.value_or(0) > 0;
+    auto const futureWaitInterval = getTransferFutureWaitInterval(requesterFutureTimeoutMs, needsProgress);
 
     // Observe-only: gen-side mirror of the context-side timeout WARN.
     std::optional<int> kvTransferTimeoutMs = std::nullopt;
@@ -1033,7 +1038,7 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
         {
             try
             {
-                auto const status = blockAll ? std::future_status::ready : it->second.wait_for(futurePollInterval);
+                auto const status = blockAll ? std::future_status::ready : it->second.wait_for(futureWaitInterval);
                 if (status == std::future_status::ready)
                 {
                     it->second.get();
@@ -1052,7 +1057,7 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
                     TLLM_LOG_DEBUG(
                         "Generation KV cache transfer for request %ld is not ready after %ld ms wait slice; keeping "
                         "it in progress.",
-                        requestId, static_cast<long>(futurePollInterval.count()));
+                        requestId, static_cast<long>(futureWaitInterval.count()));
                     ++it;
                     continue;
                 }

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -53,6 +53,7 @@
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
 #include "tensorrt_llm/runtime/utils/pgUtils.h"
 #include <algorithm>
+#include <chrono>
 #include <cstddef>
 #include <numeric>
 #include <unordered_map>
@@ -67,6 +68,20 @@ namespace
 {
 
 using RequestIdType = LlmRequest::RequestIdType;
+
+constexpr int kTransferFuturePollIntervalMs = 10;
+
+// Finite status checks are scheduler polls, not terminal deadlines. Keep each
+// slice short so the caller can yield back to scheduling and transfer progress.
+std::chrono::milliseconds getTransferFuturePollInterval(std::optional<int> const& configuredTimeoutMs)
+{
+    auto waitMs = kTransferFuturePollIntervalMs;
+    if (configuredTimeoutMs.has_value())
+    {
+        waitMs = std::max(1, std::min(configuredTimeoutMs.value(), kTransferFuturePollIntervalMs));
+    }
+    return std::chrono::milliseconds(waitMs);
+}
 
 enum class TransferConsensusState : std::uint64_t
 {
@@ -705,13 +720,13 @@ void updateKVCacheTransferBW(std::shared_ptr<CacheTransceiverComm> const& mComm,
 RequestStatuses CacheTransceiver::checkContextTransferStatus(
     std::optional<int> const& atLeastRequestNum, bool markComplete)
 {
-    bool blockAll = !atLeastRequestNum.has_value();
+    bool const blockAll = !atLeastRequestNum.has_value();
     std::optional<int> senderFutureTimeoutMs = std::nullopt;
-    // If blockAll is true, we want to block and not use a timeout
-    if (!blockAll && mCacheTransceiverConfig.has_value())
+    if (mCacheTransceiverConfig.has_value())
     {
         senderFutureTimeoutMs = mCacheTransceiverConfig->getKvTransferSenderFutureTimeoutMs();
     }
+    auto const futurePollInterval = getTransferFuturePollInterval(senderFutureTimeoutMs);
     // Observe-only: WARN per-request when the wall-clock transfer time exceeds
     // kvTransferTimeoutMs. No cancellation, eviction, or state transition.
     std::optional<int> kvTransferTimeoutMs = std::nullopt;
@@ -775,27 +790,26 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
     for (auto it = mSenderFutures.begin(); it != mSenderFutures.end();)
     {
         auto& [request, future] = *it;
+        auto const requestId = request->mRequestId;
         if (kvTransferTimeoutMs.has_value())
         {
             auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
                 LlmRequest::getSteadyClockNow() - request->getKvCacheTransferStart());
             auto elapsedMs = static_cast<long>(elapsed.count());
-            if (elapsedMs > kvTransferTimeoutMs.value() && mTimedOutSenderIds.insert(request->mRequestId).second)
+            if (elapsedMs > kvTransferTimeoutMs.value() && mTimedOutSenderIds.insert(requestId).second)
             {
                 TLLM_LOG_WARNING(
                     "Context KV cache transfer for request %ld exceeded configured timeout: "
                     "elapsed %ld ms > limit %d ms (observe-only).",
-                    request->mRequestId, elapsedMs, kvTransferTimeoutMs.value());
+                    requestId, elapsedMs, kvTransferTimeoutMs.value());
             }
         }
-        if (blockAll || (toCompleteIdSet.find(request->mRequestId) != toCompleteIdSet.end()))
+        if (blockAll || (toCompleteIdSet.find(requestId) != toCompleteIdSet.end()))
         {
-            auto const requestId = request->mRequestId;
             try
             {
-                // Wait for up to a specified timeout
-                auto status = future.wait_for(std::chrono::milliseconds(senderFutureTimeoutMs.value_or(0)));
-                if (status == std::future_status::ready || !senderFutureTimeoutMs.has_value())
+                auto const status = blockAll ? std::future_status::ready : future.wait_for(futurePollInterval);
+                if (status == std::future_status::ready)
                 {
                     future.get();
                     bool const failed = request->getState() == LlmRequestState::kDISAGG_TRANS_ERROR;
@@ -805,8 +819,10 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
                 }
                 else if (status == std::future_status::timeout)
                 {
-                    TLLM_LOG_WARNING("Timed out waiting for context KV cache transfer after %d milliseconds.",
-                        senderFutureTimeoutMs.value());
+                    TLLM_LOG_DEBUG(
+                        "Context KV cache transfer for request %ld is not ready after %ld ms wait slice; keeping it "
+                        "in progress.",
+                        requestId, static_cast<long>(futurePollInterval.count()));
                     ++it;
                 }
                 else
@@ -871,7 +887,7 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
 
 void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastRequestNum)
 {
-    bool blockAll = !atLeastRequestNum.has_value();
+    bool const blockAll = !atLeastRequestNum.has_value();
     std::vector<LlmRequest::RequestIdType> genTransferReadyRequestIds;
     for (auto&& [request, future] : mRequesterFutures)
     {
@@ -982,6 +998,13 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
             " checkGenTransferStatus toCompleteIdSet size: %zu, atLeastRequestNum: %d ", toCompleteIdSet.size(),
             atLeastRequestNum.value_or(0));
     }
+    std::optional<int> requesterFutureTimeoutMs = std::nullopt;
+    if (mCacheTransceiverConfig.has_value())
+    {
+        requesterFutureTimeoutMs = mCacheTransceiverConfig->getKvTransferSenderFutureTimeoutMs();
+    }
+    auto const futurePollInterval = getTransferFuturePollInterval(requesterFutureTimeoutMs);
+
     // Observe-only: gen-side mirror of the context-side timeout WARN.
     std::optional<int> kvTransferTimeoutMs = std::nullopt;
     if (mCacheTransceiverConfig.has_value())
@@ -997,28 +1020,47 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
             auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
                 LlmRequest::getSteadyClockNow() - request->getKvCacheTransferStart());
             auto elapsedMs = static_cast<long>(elapsed.count());
-            if (elapsedMs > kvTransferTimeoutMs.value() && mTimedOutRequesterIds.insert(request->mRequestId).second)
+            if (elapsedMs > kvTransferTimeoutMs.value() && mTimedOutRequesterIds.insert(requestId).second)
             {
                 TLLM_LOG_WARNING(
                     "Generation KV cache transfer for request %ld exceeded configured timeout: "
                     "elapsed %ld ms > limit %d ms (observe-only).",
-                    request->mRequestId, elapsedMs, kvTransferTimeoutMs.value());
+                    requestId, elapsedMs, kvTransferTimeoutMs.value());
             }
         }
         if (blockAll || toCompleteIdSet.find(requestId) != toCompleteIdSet.end())
         {
             try
             {
-                it->second.get();
-                bool const failed = request->getState() == LlmRequestState::kDISAGG_TRANS_ERROR;
-                if (failed)
+                auto const status = blockAll ? std::future_status::ready : it->second.wait_for(futurePollInterval);
+                if (status == std::future_status::ready)
                 {
-                    // The receiver uses the error state as a local transfer-failed signal.
-                    // Keep that signal local until the consensus outcome commits it globally.
-                    request->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_IN_PROGRESS);
+                    it->second.get();
+                    bool const failed = request->getState() == LlmRequestState::kDISAGG_TRANS_ERROR;
+                    if (failed)
+                    {
+                        // The receiver uses the error state as a local transfer-failed signal.
+                        // Keep that signal local until the consensus outcome commits it globally.
+                        request->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_IN_PROGRESS);
+                    }
+                    recordLocalTransferOutcome(requestId, request, failed, mCompletedRequesterRequestIds,
+                        mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
                 }
-                recordLocalTransferOutcome(requestId, request, failed, mCompletedRequesterRequestIds,
-                    mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
+                else if (status == std::future_status::timeout)
+                {
+                    TLLM_LOG_DEBUG(
+                        "Generation KV cache transfer for request %ld is not ready after %ld ms wait slice; keeping "
+                        "it in progress.",
+                        requestId, static_cast<long>(futurePollInterval.count()));
+                    ++it;
+                    continue;
+                }
+                else
+                {
+                    TLLM_LOG_ERROR("Future returned unexpected status for request %ld. Marking as error.", requestId);
+                    recordLocalTransferOutcome(requestId, request, /*failed=*/true, mCompletedRequesterRequestIds,
+                        mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
+                }
             }
             catch (std::exception const& e)
             {

--- a/cpp/tensorrt_llm/batch_manager/capacityScheduler.cpp
+++ b/cpp/tensorrt_llm/batch_manager/capacityScheduler.cpp
@@ -128,6 +128,19 @@ void checkRequiredCrossKvCacheManager(
         static_cast<bool>(crossKvCacheManager), "Encoder-decoder scheduling requires a cross_kv_cache_manager.");
 }
 
+void claimPeftPagesForRequest(std::shared_ptr<LlmRequest> const& req,
+    OptionalRef<BasePeftCacheManager const> peftCacheManager, SizeType32& claimedPeftPages,
+    std::unordered_set<uint64_t>& uniqTaskIds)
+{
+    bool const reqHasLora = req->getLoraTaskId().has_value();
+    bool const isNewTask = reqHasLora && !uniqTaskIds.count(req->getLoraTaskId().value());
+    if (isNewTask)
+    {
+        claimedPeftPages += peftCacheManager ? peftCacheManager->determineNumPages(req) : 0;
+        uniqTaskIds.insert(req->getLoraTaskId().value());
+    }
+}
+
 } // namespace
 
 MaxRequestsScheduler::MaxRequestsScheduler(
@@ -237,6 +250,7 @@ std::tuple<RequestVector, RequestVector> GuaranteedNoEvictScheduler::impl(
         : std::nullopt;
     SizeType32 claimedPeftPages{0};
     std::unordered_set<uint64_t> uniqTaskIds{};
+    std::size_t numAdmittedRequests{0};
     RequestVector pendingRequests;
     RequestVector pendingDisGenInitRequests;
     pendingRequests.reserve(activeRequests.size());
@@ -246,20 +260,24 @@ std::tuple<RequestVector, RequestVector> GuaranteedNoEvictScheduler::impl(
         // if request cannot be scheduled yet or request should no longer be scheduled, skip
         if (
             // Allow disagg_generation_init requests to be scheduled, so that we'll allocate their KV cache
-            !req->isDisaggGenerationInitState()
+            !req->isDisaggGenerationInitState() && !req->isDisaggGenerationTransmissionInProgress()
             && (!req->hasReachedState(getNoScheduleUntilState()) || req->hasReachedState(getNoScheduleAfterState())))
         {
             continue;
         }
 
-        if (scheduledRequests.size() >= static_cast<std::size_t>(mMaxNumRequests))
+        if (numAdmittedRequests >= static_cast<std::size_t>(mMaxNumRequests))
         {
             break;
         }
 
-        if (req->isGenerationInProgressState())
+        if (req->isDisaggGenerationTransmissionInProgress() || req->isGenerationInProgressState())
         {
-            scheduledRequests.emplace_back(req);
+            ++numAdmittedRequests;
+            if (req->isGenerationInProgressState())
+            {
+                scheduledRequests.emplace_back(req);
+            }
             reservedBlocks.enoughAvailableBlocks(*req);
             reservedBlocks.commitBlocks();
             if (reservedCrossBlocks)
@@ -267,13 +285,7 @@ std::tuple<RequestVector, RequestVector> GuaranteedNoEvictScheduler::impl(
                 reservedCrossBlocks->enoughAvailableBlocks(*req);
                 reservedCrossBlocks->commitBlocks();
             }
-            bool const reqHasLora = req->getLoraTaskId().has_value();
-            bool const isNewTask = reqHasLora && !uniqTaskIds.count(req->getLoraTaskId().value());
-            if (isNewTask)
-            {
-                claimedPeftPages += peftCacheManager ? peftCacheManager->determineNumPages(req) : 0;
-                uniqTaskIds.insert(req->getLoraTaskId().value());
-            }
+            claimPeftPagesForRequest(req, peftCacheManager, claimedPeftPages, uniqTaskIds);
         }
         else if (req->isDisaggGenerationInitState())
         {
@@ -287,7 +299,7 @@ std::tuple<RequestVector, RequestVector> GuaranteedNoEvictScheduler::impl(
 
     // If StaticBatchScheduling == true check if we can add pending requests only when no requests are active.
     // Otherwise, add just check that we can add pending requests.
-    if (!StaticBatchScheduling || scheduledRequests.size() == 0)
+    if (!StaticBatchScheduling || numAdmittedRequests == 0)
     {
         auto availablePeftPages = maxPeftCachePages - claimedPeftPages;
 
@@ -342,7 +354,7 @@ std::tuple<RequestVector, RequestVector> GuaranteedNoEvictScheduler::impl(
                     continue;
                 }
 
-                if (scheduledRequests.size() >= static_cast<std::size_t>(mMaxNumRequests))
+                if (numAdmittedRequests >= static_cast<std::size_t>(mMaxNumRequests))
                 {
                     break;
                 }
@@ -356,6 +368,7 @@ std::tuple<RequestVector, RequestVector> GuaranteedNoEvictScheduler::impl(
                     if (neededPeftPages <= availablePeftPages)
                     {
                         scheduledRequests.emplace_back(req);
+                        ++numAdmittedRequests;
                         availablePeftPages -= neededPeftPages;
                         if (isNewTask)
                         {
@@ -380,6 +393,7 @@ std::tuple<RequestVector, RequestVector> GuaranteedNoEvictScheduler::impl(
                     if (enoughBlocks && enoughCrossBlocks && neededPeftPages <= availablePeftPages)
                     {
                         scheduledRequests.emplace_back(req);
+                        ++numAdmittedRequests;
                         // Decrement using the cached values computed by enoughAvailableBlocks.
                         reservedBlocks.commitBlocks();
                         if (reservedCrossBlocks)
@@ -407,7 +421,8 @@ std::tuple<RequestVector, RequestVector> GuaranteedNoEvictScheduler::impl(
 // TODO(nhaber): remove forward declare and just keep the function here, right before the merge. I put it below just so
 // the remote diff is easier to look at/rebase conflicts
 bool trySchedulingRequestMaxUtilization(std::shared_ptr<LlmRequest> const& req, SizeType32 maxNumRequests,
-    RequestVector& scheduledRequests, kv_cache_manager::MaxUtilizationScheduledBlocksManager& blocksManager,
+    std::size_t& numAdmittedRequests, RequestVector& scheduledRequests,
+    kv_cache_manager::MaxUtilizationScheduledBlocksManager& blocksManager,
     std::optional<kv_cache_manager::MaxUtilizationScheduledBlocksManager>& crossBlocksManager,
     OptionalRef<BasePeftCacheManager const> peftCacheManager, SizeType32& numScheduledPeftPages,
     std::unordered_set<uint64_t>& seenTaskIds,
@@ -458,6 +473,7 @@ std::tuple<RequestVector, RequestVector> MaxUtilizationScheduler::operator()(
 
     RequestVector scheduledRequests;
     RequestVector pausedRequests;
+    std::size_t numAdmittedRequests{0};
     auto reqItEnd = std::end(activeRequests);
     for (auto reqIt = std::begin(activeRequests); reqIt != reqItEnd;)
     {
@@ -467,10 +483,22 @@ std::tuple<RequestVector, RequestVector> MaxUtilizationScheduler::operator()(
         // if request cannot be scheduled yet or request should no longer be scheduled, skip
         if (
             // Allow disagg_generation_init requests to be scheduled, so that we'll allocate their KV cache
-            !req->isDisaggGenerationInitState()
+            !req->isDisaggGenerationInitState() && !req->isDisaggGenerationTransmissionInProgress()
             && (!req->hasReachedState(getNoScheduleUntilState()) || req->hasReachedState(getNoScheduleAfterState())))
         {
             TLLM_LOG_DEBUG("MaxUtilizationScheduler: request ID %lu cannot / should not be scheduled", req->mRequestId);
+            reqIt++;
+            continue;
+        }
+
+        if (req->isDisaggGenerationTransmissionInProgress())
+        {
+            if (numAdmittedRequests >= static_cast<std::size_t>(mMaxNumRequests))
+            {
+                break;
+            }
+            claimPeftPagesForRequest(req, peftCacheManager, numScheduledPeftPages, seenTaskIds);
+            ++numAdmittedRequests;
             reqIt++;
             continue;
         }
@@ -499,9 +527,9 @@ std::tuple<RequestVector, RequestVector> MaxUtilizationScheduler::operator()(
             continue;
         }
 
-        bool const wasScheduled
-            = trySchedulingRequestMaxUtilization(req, mMaxNumRequests, scheduledRequests, scheduledBlocksManager,
-                scheduledCrossBlocksManager, peftCacheManager, numScheduledPeftPages, seenTaskIds, summary);
+        bool const wasScheduled = trySchedulingRequestMaxUtilization(req, mMaxNumRequests, numAdmittedRequests,
+            scheduledRequests, scheduledBlocksManager, scheduledCrossBlocksManager, peftCacheManager,
+            numScheduledPeftPages, seenTaskIds, summary);
         if (wasScheduled)
         {
             TLLM_LOG_DEBUG("MaxUtilizationScheduler: request ID %lu -> start", req->mRequestId);
@@ -540,12 +568,13 @@ std::tuple<RequestVector, RequestVector> MaxUtilizationScheduler::operator()(
 }
 
 bool trySchedulingRequestMaxUtilization(std::shared_ptr<LlmRequest> const& req, SizeType32 maxNumRequests,
-    RequestVector& scheduledRequests, kv_cache_manager::MaxUtilizationScheduledBlocksManager& blocksManager,
+    std::size_t& numAdmittedRequests, RequestVector& scheduledRequests,
+    kv_cache_manager::MaxUtilizationScheduledBlocksManager& blocksManager,
     std::optional<kv_cache_manager::MaxUtilizationScheduledBlocksManager>& crossBlocksManager,
     OptionalRef<BasePeftCacheManager const> peftCacheManager, SizeType32& numScheduledPeftPages,
     std::unordered_set<uint64_t>& seenTaskIds, std::optional<kv_cache_manager::PrefixReuseSummary> const& cachedSummary)
 {
-    if (scheduledRequests.size() < static_cast<std::size_t>(maxNumRequests))
+    if (numAdmittedRequests < static_cast<std::size_t>(maxNumRequests))
     {
         bool reqHasLora = req->getLoraTaskId().has_value();
         bool isNewTask = reqHasLora && !seenTaskIds.count(req->getLoraTaskId().value());
@@ -566,6 +595,7 @@ bool trySchedulingRequestMaxUtilization(std::shared_ptr<LlmRequest> const& req, 
             {
                 numScheduledPeftPages += numRequiredPeftPages;
                 scheduledRequests.emplace_back(req);
+                ++numAdmittedRequests;
                 if (isNewTask)
                 {
                     seenTaskIds.insert(req->getLoraTaskId().value());
@@ -601,6 +631,7 @@ bool trySchedulingRequestMaxUtilization(std::shared_ptr<LlmRequest> const& req, 
             numScheduledPeftPages += numRequiredPeftPages;
             TLLM_LOG_DEBUG("MaxUtilizationScheduler: scheduled peft pages: %i", numRequiredPeftPages);
             scheduledRequests.emplace_back(req);
+            ++numAdmittedRequests;
             if (isNewTask)
             {
                 seenTaskIds.insert(req->getLoraTaskId().value());

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -1103,7 +1103,7 @@ private:
         TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
             "Start calling requestSync for request ID: %zu, context request ID: %zu.", llmRequest.mRequestId,
             llmRequest.getContextPhaseParams().value().getReqId());
-        llmRequest.setKvCacheTransferStart(std::chrono::steady_clock::now());
+        llmRequest.setKvCacheTransferStart(LlmRequest::getSteadyClockNow());
         TLLM_CUDA_CHECK(cudaSetDevice(mDeviceId));
         auto session = sendRequestInfo(llmRequest);
         session.setTime(TransferSession::kTimeRequestInfo);
@@ -1112,11 +1112,11 @@ private:
         {
             // Reuse the error state for the cancelled request.
             llmRequest.setState(LlmRequestState::kDISAGG_TRANS_ERROR);
-            llmRequest.setKvCacheTransferEnd(std::chrono::steady_clock::now());
+            llmRequest.setKvCacheTransferEnd(LlmRequest::getSteadyClockNow());
             return;
         }
         receiveSync(session);
-        llmRequest.setKvCacheTransferEnd(std::chrono::steady_clock::now());
+        llmRequest.setKvCacheTransferEnd(LlmRequest::getSteadyClockNow());
 
         TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
             "End calling requestSync for request ID: %zu, context request ID: %zu.", llmRequest.mRequestId,

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -1054,7 +1054,7 @@ void TrtGptModelInflightBatching::forwardAsync(RequestList const& activeRequests
             {
                 if (waitForDisaggGenTransferProgress)
                 {
-                    TLLM_LOG_DEBUG("Waiting for one generation KV cache transfer to free disagg admission budget");
+                    TLLM_LOG_DEBUG("Waiting for generation KV cache transfer progress to free disagg admission budget");
                     mCacheTransceiver->checkGenTransferStatus(1);
                 }
                 else
@@ -1658,10 +1658,10 @@ void TrtGptModelInflightBatching::prepareDisaggGenInitRequests(
         auto const blockTransfer = std::all_of(activeRequests.begin(), activeRequests.end(),
             [](auto const& req) { return req->isDisaggGenerationTransmissionInProgress(); });
         TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
-            "newGenReqs.size():%ld requests, activeRequests.size():%ld checkGenTransferStatus :%d original "
+            "newGenReqs.size():%ld requests, activeRequests.size():%ld allTransferInProgress:%d original "
             "gen_only_requests_num:%ld",
             newGenReqs.size(), activeRequests.size(), blockTransfer, genInitReqNum);
-        mCacheTransceiver->checkGenTransferStatus(blockTransfer ? 1 : 0);
+        mCacheTransceiver->checkGenTransferStatus(0);
         auto timeEnd = std::chrono::steady_clock::now();
         auto duration = std::chrono::duration<float, std::milli>(timeEnd - timeStart).count();
         TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
@@ -1690,21 +1690,14 @@ void TrtGptModelInflightBatching::checkDisaggGenTransferStatus(RequestList const
 
     if (needCheck)
     {
-        auto const needCheckOne = std::all_of(activeRequests.begin(), activeRequests.end(),
-            [](auto const& req) { return req->isDisaggGenerationTransmissionInProgress(); });
-
-        int atLeastNum = needCheckOne ? 1 : 0;
-        TLLM_LOG_DEBUG(
-            mpi::MpiComm::world().getRank(), "noPreppared requests, checkGenTransferStatus atLeastNum:%d", atLeastNum);
-
-        mCacheTransceiver->checkGenTransferStatus(atLeastNum);
+        mCacheTransceiver->checkGenTransferStatus(0);
 
         auto timeEnd = std::chrono::steady_clock::now();
         auto duration = std::chrono::duration<float, std::milli>(timeEnd - timeStart).count();
         TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
             "no Prepare checkDisaggGenTransferStatus time:%f ms, "
-            "needCheckOne:%d,needCheck:%ld,activeRequests.size():%ld",
-            duration, needCheckOne, needCheck, activeRequests.size());
+            "needCheck:%d,activeRequests.size():%ld",
+            duration, needCheck, activeRequests.size());
     }
 }
 

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -25,6 +25,7 @@
 #include "tensorrt_llm/batch_manager/contextProgress.h"
 #include "tensorrt_llm/batch_manager/createNewDecoderRequests.h"
 #include "tensorrt_llm/batch_manager/decoderBuffers.h"
+#include "tensorrt_llm/batch_manager/disaggTransferAdmissionController.h"
 #include "tensorrt_llm/batch_manager/guidedDecoder.h"
 #include "tensorrt_llm/batch_manager/handleContextLogits.h"
 #include "tensorrt_llm/batch_manager/handleGenerationLogits.h"
@@ -333,6 +334,8 @@ TrtGptModelInflightBatching::TrtGptModelInflightBatching(std::shared_ptr<nvinfer
         mCacheTransceiver
             = CacheTransceiverFactory::createCacheTransceiver(mKvCacheManager.get(), mModelConfig, mWorldConfig,
                 executor::kv_cache::CacheState::AttentionType::kDEFAULT, executorConfig.getCacheTransceiverConfig());
+        mDisaggTransferAdmissionController = std::make_unique<DisaggTransferAdmissionController>(
+            cacheTransceiverConfig.getMaxTokensInBuffer(), mModelConfig.getTokensPerBlock());
     }
 
     if (mModelConfig.getSpeculativeDecodingMode().needsKVCacheRewind())
@@ -1020,6 +1023,22 @@ void TrtGptModelInflightBatching::forwardAsync(RequestList const& activeRequests
         // Remove from fitting requests the requests that cannot be scheduled due to disagg KV cache transfer
         if (mModelConfig.isTransformerBased() && getKVCacheManager() && mCacheTransceiver)
         {
+            if (mDisaggTransferAdmissionController && mDisaggTransferAdmissionController->enabled()
+                && !fittingDisaggGenInitRequests.empty())
+            {
+                auto admissionResult
+                    = mDisaggTransferAdmissionController->select(activeRequests, fittingDisaggGenInitRequests);
+                if (admissionResult.deferredRequestCount > 0)
+                {
+                    TLLM_LOG_DEBUG(
+                        "Disagg transfer admission deferred %zu requests; active transfer blocks=%zu, admitted "
+                        "transfer blocks=%zu, budget=%zu",
+                        admissionResult.deferredRequestCount, admissionResult.activeTransferBlocks,
+                        admissionResult.admittedTransferBlocks,
+                        mDisaggTransferAdmissionController->getMaxTransferBlocks().value_or(0));
+                }
+                fittingDisaggGenInitRequests = std::move(admissionResult.admittedRequests);
+            }
             prepareDisaggGenInitRequests(activeRequests, fittingDisaggGenInitRequests);
         }
         if (fittingRequests.empty() && fittingDisaggGenInitRequests.empty())

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -1021,6 +1021,7 @@ void TrtGptModelInflightBatching::forwardAsync(RequestList const& activeRequests
         auto [fittingRequests, fittingDisaggGenInitRequests, requestsToPause]
             = (*mCapacityScheduler)(activeRequests, mKvCacheManager, mPeftCacheManager, mCrossKvCacheManager);
         // Remove from fitting requests the requests that cannot be scheduled due to disagg KV cache transfer
+        bool waitForDisaggGenTransferProgress = false;
         if (mModelConfig.isTransformerBased() && getKVCacheManager() && mCacheTransceiver)
         {
             if (mDisaggTransferAdmissionController && mDisaggTransferAdmissionController->enabled()
@@ -1028,6 +1029,7 @@ void TrtGptModelInflightBatching::forwardAsync(RequestList const& activeRequests
             {
                 auto admissionResult
                     = mDisaggTransferAdmissionController->select(activeRequests, fittingDisaggGenInitRequests);
+                waitForDisaggGenTransferProgress = admissionResult.isBlockedByActiveTransfers();
                 if (admissionResult.deferredRequestCount > 0)
                 {
                     TLLM_LOG_DEBUG(
@@ -1050,8 +1052,16 @@ void TrtGptModelInflightBatching::forwardAsync(RequestList const& activeRequests
                 mIterCounter);
             if (mCacheTransceiver)
             {
-                mCacheTransceiver->checkContextTransferStatus(1, true);
-                // will free kvCache in next iteration.
+                if (waitForDisaggGenTransferProgress)
+                {
+                    TLLM_LOG_DEBUG("Waiting for one generation KV cache transfer to free disagg admission budget");
+                    mCacheTransceiver->checkGenTransferStatus(1);
+                }
+                else
+                {
+                    mCacheTransceiver->checkContextTransferStatus(1, true);
+                    // will free kvCache in next iteration.
+                }
             }
         }
         std::tie(currRequests.contextRequests, currRequests.generationRequests)

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
@@ -88,6 +88,7 @@ class TrtGptModelTest;
 
 // Algorithms
 class CapacityScheduler;
+class DisaggTransferAdmissionController;
 class MicroBatchScheduler;
 class PauseRequests;
 class AssignReqSeqSlots;
@@ -600,6 +601,7 @@ private:
 
     /******************** Cache transceiver ********************/
     std::unique_ptr<BaseCacheTransceiver> mCacheTransceiver;
+    std::unique_ptr<DisaggTransferAdmissionController> mDisaggTransferAdmissionController;
 
     /******************** Spec dec ***********************/
     std::unique_ptr<std::thread> mDraftModelSendLogitsThread;

--- a/cpp/tensorrt_llm/executor/cacheTransceiverConfig.cpp
+++ b/cpp/tensorrt_llm/executor/cacheTransceiverConfig.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,18 +23,21 @@ namespace tensorrt_llm::executor
 
 CacheTransceiverConfig::CacheTransceiverConfig(std::optional<BackendType> backendType,
     std::optional<size_t> maxNumTokens, std::optional<int> kvTransferTimeoutMs,
-    std::optional<int> kvTransferSenderFutureTimeoutMs)
+    std::optional<int> kvTransferSenderFutureTimeoutMs, std::optional<int> kvTransferPollIntervalMs)
     : mBackendType(backendType)
     , mMaxTokensInBuffer(maxNumTokens)
     , mKvTransferTimeoutMs(kvTransferTimeoutMs)
     , mKvTransferSenderFutureTimeoutMs(kvTransferSenderFutureTimeoutMs)
+    , mKvTransferPollIntervalMs(kvTransferPollIntervalMs)
 {
 }
 
 bool CacheTransceiverConfig::operator==(CacheTransceiverConfig const& other) const
 {
     return mMaxTokensInBuffer == other.mMaxTokensInBuffer && mBackendType == other.mBackendType
-        && mKvTransferTimeoutMs == other.mKvTransferTimeoutMs;
+        && mKvTransferTimeoutMs == other.mKvTransferTimeoutMs
+        && mKvTransferSenderFutureTimeoutMs == other.mKvTransferSenderFutureTimeoutMs
+        && mKvTransferPollIntervalMs == other.mKvTransferPollIntervalMs;
 }
 
 void CacheTransceiverConfig::setBackendType(std::optional<BackendType> backendType)
@@ -65,6 +68,15 @@ void CacheTransceiverConfig::setKvTransferSenderFutureTimeoutMs(std::optional<in
     mKvTransferSenderFutureTimeoutMs = kvTransferSenderFutureTimeoutMs;
 }
 
+void CacheTransceiverConfig::setKvTransferPollIntervalMs(std::optional<int> kvTransferPollIntervalMs)
+{
+    if (kvTransferPollIntervalMs.has_value() && kvTransferPollIntervalMs.value() <= 0)
+    {
+        TLLM_THROW("kvTransferPollIntervalMs must be positive");
+    }
+    mKvTransferPollIntervalMs = kvTransferPollIntervalMs;
+}
+
 std::optional<CacheTransceiverConfig::BackendType> CacheTransceiverConfig::getBackendType() const
 {
     return mBackendType;
@@ -83,5 +95,10 @@ std::optional<int> CacheTransceiverConfig::getKvTransferTimeoutMs() const
 std::optional<int> CacheTransceiverConfig::getKvTransferSenderFutureTimeoutMs() const
 {
     return mKvTransferSenderFutureTimeoutMs;
+}
+
+std::optional<int> CacheTransceiverConfig::getKvTransferPollIntervalMs() const
+{
+    return mKvTransferPollIntervalMs;
 }
 } // namespace tensorrt_llm::executor

--- a/cpp/tensorrt_llm/executor/serialization.cpp
+++ b/cpp/tensorrt_llm/executor/serialization.cpp
@@ -1453,7 +1453,9 @@ CacheTransceiverConfig Serialization::deserializeCacheTransceiverConfig(std::ist
     auto maxTokensInBuffer = su::deserialize<std::optional<size_t>>(is);
     auto kvTransferTimeoutMs = su::deserialize<std::optional<int>>(is);
     auto kvTransferSenderFutureTimeoutMs = su::deserialize<std::optional<int>>(is);
-    return CacheTransceiverConfig{backendType, maxTokensInBuffer, kvTransferTimeoutMs, kvTransferSenderFutureTimeoutMs};
+    auto kvTransferPollIntervalMs = su::deserialize<std::optional<int>>(is);
+    return CacheTransceiverConfig{
+        backendType, maxTokensInBuffer, kvTransferTimeoutMs, kvTransferSenderFutureTimeoutMs, kvTransferPollIntervalMs};
 }
 
 void Serialization::serialize(CacheTransceiverConfig const& cacheTransceiverConfig, std::ostream& os)
@@ -1462,6 +1464,7 @@ void Serialization::serialize(CacheTransceiverConfig const& cacheTransceiverConf
     su::serialize(cacheTransceiverConfig.getMaxTokensInBuffer(), os);
     su::serialize(cacheTransceiverConfig.getKvTransferTimeoutMs(), os);
     su::serialize(cacheTransceiverConfig.getKvTransferSenderFutureTimeoutMs(), os);
+    su::serialize(cacheTransceiverConfig.getKvTransferPollIntervalMs(), os);
 }
 
 size_t Serialization::serializedSize(CacheTransceiverConfig const& cacheTransceiverConfig)
@@ -1471,6 +1474,7 @@ size_t Serialization::serializedSize(CacheTransceiverConfig const& cacheTranscei
     totalSize += su::serializedSize(cacheTransceiverConfig.getMaxTokensInBuffer());
     totalSize += su::serializedSize(cacheTransceiverConfig.getKvTransferTimeoutMs());
     totalSize += su::serializedSize(cacheTransceiverConfig.getKvTransferSenderFutureTimeoutMs());
+    totalSize += su::serializedSize(cacheTransceiverConfig.getKvTransferPollIntervalMs());
     return totalSize;
 }
 

--- a/cpp/tensorrt_llm/nanobind/executor/executorConfig.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/executorConfig.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -431,15 +431,24 @@ void initConfigBindings(nb::module_& m)
         .def("__setstate__", guidedDecodingConfigSetstate);
 
     auto cacheTransceiverConfigGetstate = [](tle::CacheTransceiverConfig const& self)
-    { return nb::make_tuple(self.getBackendType(), self.getMaxTokensInBuffer(), self.getKvTransferTimeoutMs()); };
+    {
+        return nb::make_tuple(self.getBackendType(), self.getMaxTokensInBuffer(), self.getKvTransferTimeoutMs(),
+            self.getKvTransferSenderFutureTimeoutMs(), self.getKvTransferPollIntervalMs());
+    };
     auto cacheTransceiverConfigSetstate = [](tle::CacheTransceiverConfig& self, nb::tuple const& state)
     {
-        if (state.size() != 3)
+        if (state.size() < 3 || state.size() > 5)
         {
             throw std::runtime_error("Invalid CacheTransceiverConfig state!");
         }
-        new (&self) tle::CacheTransceiverConfig(nb::cast<tle::CacheTransceiverConfig::BackendType>(state[0]),
-            nb::cast<std::optional<size_t>>(state[1]), nb::cast<std::optional<int>>(state[2]));
+        auto kvTransferSenderFutureTimeoutMs
+            = state.size() >= 4 ? nb::cast<std::optional<int>>(state[3]) : std::optional<int>{std::nullopt};
+        auto kvTransferPollIntervalMs = state.size() >= 5
+            ? nb::cast<std::optional<int>>(state[4])
+            : std::optional<int>{tle::CacheTransceiverConfig::kDefaultKvTransferPollIntervalMs};
+        auto backendType = nb::cast<std::optional<tle::CacheTransceiverConfig::BackendType>>(state[0]);
+        new (&self) tle::CacheTransceiverConfig(backendType, nb::cast<std::optional<size_t>>(state[1]),
+            nb::cast<std::optional<int>>(state[2]), kvTransferSenderFutureTimeoutMs, kvTransferPollIntervalMs);
     };
 
     nb::enum_<tle::CacheTransceiverConfig::BackendType>(m, "CacheTransceiverBackendType")
@@ -466,10 +475,11 @@ void initConfigBindings(nb::module_& m)
 
     nb::class_<tle::CacheTransceiverConfig>(m, "CacheTransceiverConfig")
         .def(nb::init<std::optional<tle::CacheTransceiverConfig::BackendType>, std::optional<size_t>,
-                 std::optional<int>, std::optional<int>>(),
+                 std::optional<int>, std::optional<int>, std::optional<int>>(),
             nb::arg("backend") = std::nullopt, nb::arg("max_tokens_in_buffer") = std::nullopt,
             nb::arg("kv_transfer_timeout_ms") = std::nullopt,
-            nb::arg("kv_transfer_sender_future_timeout_ms") = std::nullopt)
+            nb::arg("kv_transfer_sender_future_timeout_ms") = std::nullopt,
+            nb::arg("kv_transfer_poll_interval_ms") = tle::CacheTransceiverConfig::kDefaultKvTransferPollIntervalMs)
         .def_prop_rw(
             "backend", &tle::CacheTransceiverConfig::getBackendType, &tle::CacheTransceiverConfig::setBackendType)
         .def_prop_rw("max_tokens_in_buffer", &tle::CacheTransceiverConfig::getMaxTokensInBuffer,
@@ -479,6 +489,8 @@ void initConfigBindings(nb::module_& m)
         .def_prop_rw("kv_transfer_sender_future_timeout_ms",
             &tle::CacheTransceiverConfig::getKvTransferSenderFutureTimeoutMs,
             &tle::CacheTransceiverConfig::setKvTransferSenderFutureTimeoutMs)
+        .def_prop_rw("kv_transfer_poll_interval_ms", &tle::CacheTransceiverConfig::getKvTransferPollIntervalMs,
+            &tle::CacheTransceiverConfig::setKvTransferPollIntervalMs)
         .def("__getstate__", cacheTransceiverConfigGetstate)
         .def("__setstate__", cacheTransceiverConfigSetstate);
 

--- a/cpp/tests/unit_tests/batch_manager/capacitySchedulerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/capacitySchedulerTest.cpp
@@ -866,6 +866,7 @@ TEST_F(CapacitySchedulerTest, DisaggTransferAdmissionDisabledPreservesCandidates
     EXPECT_EQ(result.admittedRequests.at(1)->mRequestId, req1->mRequestId);
     EXPECT_EQ(result.deferredRequestCount, 0u);
     EXPECT_FALSE(result.limitedByBudget);
+    EXPECT_FALSE(result.isBlockedByActiveTransfers());
 }
 
 TEST_F(CapacitySchedulerTest, DisaggTransferAdmissionUsesFcfsEstimatedBlockBudget)
@@ -888,6 +889,25 @@ TEST_F(CapacitySchedulerTest, DisaggTransferAdmissionUsesFcfsEstimatedBlockBudge
     EXPECT_EQ(result.admittedTransferBlocks, 1u);
     EXPECT_EQ(result.deferredRequestCount, 2u);
     EXPECT_TRUE(result.limitedByBudget);
+    EXPECT_FALSE(result.isBlockedByActiveTransfers());
+}
+
+TEST_F(CapacitySchedulerTest, DisaggTransferAdmissionReportsActiveTransferBudgetBlock)
+{
+    auto activeTransferReq = createRequest(20, 40, 0, std::nullopt, tensorrt_llm::executor::Request::kDefaultPriority,
+        LlmRequestState::kDISAGG_GENERATION_TRANS_IN_PROGRESS);
+    auto pendingReq = createRequest(10, 40, 1, std::nullopt, tensorrt_llm::executor::Request::kDefaultPriority,
+        LlmRequestState::kDISAGG_GENERATION_INIT);
+
+    DisaggTransferAdmissionController controller(/*maxTokensInBuffer=*/20, /*tokensPerBlock=*/10);
+    auto result = controller.select(RequestList{activeTransferReq}, RequestVector{pendingReq});
+
+    EXPECT_TRUE(result.admittedRequests.empty());
+    EXPECT_EQ(result.activeTransferBlocks, 2u);
+    EXPECT_EQ(result.admittedTransferBlocks, 0u);
+    EXPECT_EQ(result.deferredRequestCount, 1u);
+    EXPECT_TRUE(result.limitedByBudget);
+    EXPECT_TRUE(result.isBlockedByActiveTransfers());
 }
 
 TEST_F(CapacitySchedulerTest, DisaggTransferAdmissionAdmitsOversizedHeadWhenIdle)
@@ -906,6 +926,7 @@ TEST_F(CapacitySchedulerTest, DisaggTransferAdmissionAdmitsOversizedHeadWhenIdle
     EXPECT_EQ(result.admittedTransferBlocks, 3u);
     EXPECT_EQ(result.deferredRequestCount, 1u);
     EXPECT_TRUE(result.limitedByBudget);
+    EXPECT_FALSE(result.isBlockedByActiveTransfers());
 }
 
 TEST_F(CapacitySchedulerTest, RequestsSortedByPriorities)

--- a/cpp/tests/unit_tests/batch_manager/capacitySchedulerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/capacitySchedulerTest.cpp
@@ -20,6 +20,7 @@
 
 #include "tensorrt_llm/batch_manager/capacityScheduler.h"
 #include "tensorrt_llm/batch_manager/common.h"
+#include "tensorrt_llm/batch_manager/disaggTransferAdmissionController.h"
 #include "tensorrt_llm/batch_manager/kvCacheManager.h"
 #include "tensorrt_llm/batch_manager/llmRequest.h"
 #include "tensorrt_llm/batch_manager/peftCacheManager.h"
@@ -847,6 +848,64 @@ TEST_F(CapacitySchedulerTest, DisaggGenTransferInProgressCountsAgainstAdmission)
             << "policy=" << static_cast<int>(capacitySchedulerPolicy);
         EXPECT_TRUE(pausedRequests.empty()) << "policy=" << static_cast<int>(capacitySchedulerPolicy);
     }
+}
+
+TEST_F(CapacitySchedulerTest, DisaggTransferAdmissionDisabledPreservesCandidates)
+{
+    auto req0 = createRequest(10, 40, 0, std::nullopt, tensorrt_llm::executor::Request::kDefaultPriority,
+        LlmRequestState::kDISAGG_GENERATION_INIT);
+    auto req1 = createRequest(20, 40, 1, std::nullopt, tensorrt_llm::executor::Request::kDefaultPriority,
+        LlmRequestState::kDISAGG_GENERATION_INIT);
+
+    DisaggTransferAdmissionController controller(std::nullopt, 10);
+    auto result = controller.select(RequestList{}, RequestVector{req0, req1});
+
+    EXPECT_FALSE(controller.enabled());
+    ASSERT_EQ(result.admittedRequests.size(), 2u);
+    EXPECT_EQ(result.admittedRequests.at(0)->mRequestId, req0->mRequestId);
+    EXPECT_EQ(result.admittedRequests.at(1)->mRequestId, req1->mRequestId);
+    EXPECT_EQ(result.deferredRequestCount, 0u);
+    EXPECT_FALSE(result.limitedByBudget);
+}
+
+TEST_F(CapacitySchedulerTest, DisaggTransferAdmissionUsesFcfsEstimatedBlockBudget)
+{
+    auto activeTransferReq = createRequest(10, 40, 0, std::nullopt, tensorrt_llm::executor::Request::kDefaultPriority,
+        LlmRequestState::kDISAGG_GENERATION_TRANS_IN_PROGRESS);
+    auto req1 = createRequest(10, 40, 1, std::nullopt, tensorrt_llm::executor::Request::kDefaultPriority,
+        LlmRequestState::kDISAGG_GENERATION_INIT);
+    auto req2 = createRequest(20, 40, 2, std::nullopt, tensorrt_llm::executor::Request::kDefaultPriority,
+        LlmRequestState::kDISAGG_GENERATION_INIT);
+    auto req3 = createRequest(10, 40, 3, std::nullopt, tensorrt_llm::executor::Request::kDefaultPriority,
+        LlmRequestState::kDISAGG_GENERATION_INIT);
+
+    DisaggTransferAdmissionController controller(/*maxTokensInBuffer=*/30, /*tokensPerBlock=*/10);
+    auto result = controller.select(RequestList{activeTransferReq}, RequestVector{req1, req2, req3});
+
+    ASSERT_EQ(result.admittedRequests.size(), 1u);
+    EXPECT_EQ(result.admittedRequests.front()->mRequestId, req1->mRequestId);
+    EXPECT_EQ(result.activeTransferBlocks, 1u);
+    EXPECT_EQ(result.admittedTransferBlocks, 1u);
+    EXPECT_EQ(result.deferredRequestCount, 2u);
+    EXPECT_TRUE(result.limitedByBudget);
+}
+
+TEST_F(CapacitySchedulerTest, DisaggTransferAdmissionAdmitsOversizedHeadWhenIdle)
+{
+    auto oversizedReq = createRequest(30, 40, 0, std::nullopt, tensorrt_llm::executor::Request::kDefaultPriority,
+        LlmRequestState::kDISAGG_GENERATION_INIT);
+    auto laterReq = createRequest(10, 40, 1, std::nullopt, tensorrt_llm::executor::Request::kDefaultPriority,
+        LlmRequestState::kDISAGG_GENERATION_INIT);
+
+    DisaggTransferAdmissionController controller(/*maxTokensInBuffer=*/10, /*tokensPerBlock=*/10);
+    auto result = controller.select(RequestList{}, RequestVector{oversizedReq, laterReq});
+
+    ASSERT_EQ(result.admittedRequests.size(), 1u);
+    EXPECT_EQ(result.admittedRequests.front()->mRequestId, oversizedReq->mRequestId);
+    EXPECT_EQ(result.activeTransferBlocks, 0u);
+    EXPECT_EQ(result.admittedTransferBlocks, 3u);
+    EXPECT_EQ(result.deferredRequestCount, 1u);
+    EXPECT_TRUE(result.limitedByBudget);
 }
 
 TEST_F(CapacitySchedulerTest, RequestsSortedByPriorities)

--- a/cpp/tests/unit_tests/batch_manager/capacitySchedulerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/capacitySchedulerTest.cpp
@@ -805,6 +805,50 @@ TEST_F(CapacitySchedulerTest, DisaggGenInitMaxUtilization)
     EXPECT_EQ(numIterations, expectedNumIters);
 }
 
+TEST_F(CapacitySchedulerTest, DisaggGenTransferInProgressCountsAgainstAdmission)
+{
+    SizeType32 kvCacheMaxNumTokens = 200;
+    SizeType32 kvCacheTokensPerBlock = 10;
+    SizeType32 kvCacheMaxNumTokensPerSeq = 90;
+
+    auto capacitySchedulerPolicies = std::vector<CapacitySchedulerPolicy>{
+        CapacitySchedulerPolicy::kGUARANTEED_NO_EVICT, CapacitySchedulerPolicy::kMAX_UTILIZATION};
+    for (auto capacitySchedulerPolicy : capacitySchedulerPolicies)
+    {
+        auto kvCacheManager
+            = getKvCacheManager(2, kvCacheTokensPerBlock, kvCacheMaxNumTokens, kvCacheMaxNumTokensPerSeq);
+        auto peftCacheManager = getPeftCacheManager();
+
+        int32_t maxNewTokens = 40;
+        int32_t promptLen = 10;
+        auto transferReq = createRequest(promptLen, maxNewTokens, 0, std::nullopt,
+            tensorrt_llm::executor::Request::kDefaultPriority, LlmRequestState::kDISAGG_GENERATION_TRANS_IN_PROGRESS);
+        auto pendingReq = createRequest(promptLen, maxNewTokens, 1, std::nullopt,
+            tensorrt_llm::executor::Request::kDefaultPriority, LlmRequestState::kDISAGG_GENERATION_INIT);
+        kvCacheManager->addSequenceBatch(
+            {{{transferReq->mRequestId, transferReq->mPromptLen, transferReq->mSamplingConfig.beamWidth}}},
+            {std::ref(*transferReq)});
+
+        RequestList saturatedActiveRequests{transferReq, pendingReq};
+        auto saturatedScheduler = CapacityScheduler(1, capacitySchedulerPolicy, kvCacheManager != nullptr);
+        auto [saturatedRequests, saturatedDisaggGenInitRequests, saturatedPausedRequests]
+            = saturatedScheduler(saturatedActiveRequests, kvCacheManager, peftCacheManager);
+        EXPECT_TRUE(saturatedRequests.empty()) << "policy=" << static_cast<int>(capacitySchedulerPolicy);
+        EXPECT_TRUE(saturatedDisaggGenInitRequests.empty()) << "policy=" << static_cast<int>(capacitySchedulerPolicy);
+        EXPECT_TRUE(saturatedPausedRequests.empty()) << "policy=" << static_cast<int>(capacitySchedulerPolicy);
+
+        RequestList activeRequestsWithCapacity{transferReq, pendingReq};
+        auto schedulerWithCapacity = CapacityScheduler(2, capacitySchedulerPolicy, kvCacheManager != nullptr);
+        auto [fittingRequests, fittingDisaggGenInitRequests, pausedRequests]
+            = schedulerWithCapacity(activeRequestsWithCapacity, kvCacheManager, peftCacheManager);
+        EXPECT_TRUE(fittingRequests.empty()) << "policy=" << static_cast<int>(capacitySchedulerPolicy);
+        ASSERT_EQ(fittingDisaggGenInitRequests.size(), 1u) << "policy=" << static_cast<int>(capacitySchedulerPolicy);
+        EXPECT_EQ(fittingDisaggGenInitRequests.front()->mRequestId, pendingReq->mRequestId)
+            << "policy=" << static_cast<int>(capacitySchedulerPolicy);
+        EXPECT_TRUE(pausedRequests.empty()) << "policy=" << static_cast<int>(capacitySchedulerPolicy);
+    }
+}
+
 TEST_F(CapacitySchedulerTest, RequestsSortedByPriorities)
 {
     RequestList activeRequests;

--- a/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
+++ b/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
@@ -1068,6 +1068,8 @@ TEST(SerializeUtilsTest, CacheTransceiverConfig)
     EXPECT_EQ(cacheTransceiverConfig.getKvTransferTimeoutMs(), cacheTransceiverConfig2.getKvTransferTimeoutMs());
     EXPECT_EQ(cacheTransceiverConfig.getKvTransferSenderFutureTimeoutMs(),
         cacheTransceiverConfig2.getKvTransferSenderFutureTimeoutMs());
+    EXPECT_EQ(
+        cacheTransceiverConfig.getKvTransferPollIntervalMs(), cacheTransceiverConfig2.getKvTransferPollIntervalMs());
 }
 
 TEST(SerializeUtilsTest, BlockKeyBasic)

--- a/tensorrt_llm/_torch/disaggregation/base/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/base/transfer.py
@@ -142,7 +142,7 @@ class _SessionBase(ABC):
     def is_completed(self) -> bool: ...
 
     @abstractmethod
-    def wait_complete(self) -> Optional[WaitResult]: ...
+    def wait_complete(self, blocking: bool = False) -> Optional[WaitResult]: ...
 
     @property
     @abstractmethod
@@ -159,6 +159,9 @@ class TxSessionBase(_SessionBase):
 
     @abstractmethod
     def send(self, slice: KVSlice) -> None: ...
+
+    @abstractmethod
+    def wait_complete(self, blocking: bool = True) -> Optional[WaitResult]: ...
 
 
 class RxSessionBase(_SessionBase):

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -1195,7 +1195,11 @@ class TxSession(TxSessionBase):
 
     def has_failed(self) -> bool:
         """Non-blocking check: has the transfer failed or been cancelled?"""
-        return self.status in (SessionStatus.ERROR, SessionStatus.CANCELLED)
+        if self.status in (SessionStatus.ERROR, SessionStatus.CANCELLED):
+            return True
+        if any(task.status == TaskStatus.ERROR for task in self.kv_tasks):
+            return True
+        return self.aux_task is not None and self.aux_task.status == TaskStatus.ERROR
 
     def cancel(self) -> None:
         """Cancel the session and notify the remote receiver.
@@ -1225,11 +1229,33 @@ class TxSession(TxSessionBase):
         """
         return any(t.status == TaskStatus.TRANSFERRING for t in self.kv_tasks)
 
-    def wait_complete(self) -> Optional[WaitResult]:
-        """Block until KV (and optionally aux) transfer finishes.
+    def wait_complete(self, blocking: bool = True) -> Optional[WaitResult]:
+        """Poll or block until KV (and optionally aux) transfer finishes.
 
-        Returns WaitResult.COMPLETED, WaitResult.FAILED, or WaitResult.TIMEOUT.
+        With blocking=True (default): waits up to _timeout_s for each task.
+        With blocking=False: polls non-blockingly; returns None if any KV task
+        or aux is not yet done.
         """
+        if self.status in (SessionStatus.ERROR, SessionStatus.CANCELLED):
+            return WaitResult.FAILED
+        if not self.kv_tasks:
+            return None
+        if not blocking:
+            for task in self.kv_tasks:
+                if task.status == TaskStatus.TRANSFERRED:
+                    continue
+                if task.status == TaskStatus.ERROR:
+                    return WaitResult.FAILED
+                return None
+            if self._need_aux:
+                if self.aux_task is None:
+                    return None
+                if self.aux_task.status == TaskStatus.ERROR:
+                    return WaitResult.FAILED
+                if self.aux_task.status != TaskStatus.TRANSFERRED:
+                    return None
+            return WaitResult.COMPLETED
+
         for task in self.kv_tasks:
             if not task.wait(timeout=self._timeout_s):
                 return WaitResult.TIMEOUT

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -1241,11 +1241,13 @@ class TxSession(TxSessionBase):
         if not self.kv_tasks:
             return None
         if not blocking:
+            has_pending = False
             for task in self.kv_tasks:
-                if task.status == TaskStatus.TRANSFERRED:
-                    continue
                 if task.status == TaskStatus.ERROR:
                     return WaitResult.FAILED
+                if task.status != TaskStatus.TRANSFERRED:
+                    has_pending = True
+            if has_pending:
                 return None
             if self._need_aux:
                 if self.aux_task is None:

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -533,11 +533,13 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         completed, timed_out, failed, cancelled = [], [], [], []
         for rid in to_process:
             session = self._send_sessions[rid]
-            result = session.wait_complete()
+            result = session.wait_complete(blocking=block_all)
             if session.status == SessionStatus.CANCELLED:
                 cancelled.append(rid)
             elif result == WaitResult.COMPLETED:
                 completed.append(rid)
+            elif result is None:
+                continue
             elif result == WaitResult.TIMEOUT:
                 logger.warning(
                     f"TxSession rid={session.disagg_request_id} timed out after {self._sender_future_timeout_ms}ms"

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -1,3 +1,4 @@
+import time
 import uuid
 from collections import defaultdict
 from itertools import chain
@@ -63,6 +64,7 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         self._kv_cache_manager = kv_cache_manager
         self._mapping = mapping
         self.kv_transfer_timeout_ms = cache_transceiver_config.kv_transfer_timeout_ms
+        self.kv_transfer_poll_interval_ms = cache_transceiver_config.kv_transfer_poll_interval_ms
         self._sender_future_timeout_ms = (
             cache_transceiver_config.kv_transfer_sender_future_timeout_ms
         )
@@ -578,12 +580,15 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             return [], [], []
         block_all = at_least_request_num is None
         wait_num = at_least_request_num if not block_all else 0
+        need_progress = wait_num > 0
+        if need_progress:
+            self._poll_gen_sessions_for_poll_interval(wait_num)
 
         local_completed, local_failed = self._collect_done(self._recv_sessions, self._recv_reqs)
         to_process = self._build_to_process(
             self._recv_sessions,
             self._gen_consensus(local_completed + local_failed),
-            wait_num,
+            0 if need_progress else wait_num,
             block_all,
         )
 
@@ -633,6 +638,20 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         self._close_failed_sessions(self._recv_sessions, self._recv_reqs, failed)
 
         return completed, failed, cancelled_reqs
+
+    def _poll_gen_sessions_for_poll_interval(self, wait_num: int) -> None:
+        poll_interval_s = (self.kv_transfer_poll_interval_ms or 0) / 1000.0
+        deadline = time.monotonic() + poll_interval_s
+        while True:
+            completed, failed = self._collect_done(self._recv_sessions, self._recv_reqs)
+            if len(completed) + len(failed) >= wait_num:
+                return
+            remaining_s = deadline - time.monotonic()
+            if remaining_s <= 0:
+                return
+            for session in self._recv_sessions.values():
+                session.wait_complete(blocking=False)
+            time.sleep(min(0.001, remaining_s))
 
     def check_gen_transfer_complete(self):
         return len(self._recv_sessions) == 0

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -519,7 +519,9 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
     def check_context_transfer_status(
         self, at_least_request_num: Optional[int], mark_complete: bool = False
     ):
-        if not self._ever_had_send_session and not self._ctx_need_pp_sync:
+        if not self._ever_had_send_session and not (
+            self._ctx_need_tp_sync or self._ctx_need_pp_sync
+        ):
             return [], []
         block_all = at_least_request_num is None
         wait_num = at_least_request_num if not block_all else 0
@@ -576,7 +578,7 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         return completed, failed
 
     def check_gen_transfer_status(self, at_least_request_num: Optional[int]):
-        if not self._ever_had_recv_session and not self._ctx_need_pp_sync:
+        if not self._ever_had_recv_session and not self._gen_need_sync:
             return [], [], []
         block_all = at_least_request_num is None
         wait_num = at_least_request_num if not block_all else 0

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
@@ -179,6 +179,7 @@ class BindKvCacheTransceiver(KvCacheTransceiver):
 
         self.kv_transfer_timeout_ms = cache_transceiver_config.kv_transfer_timeout_ms
         self.kv_transfer_sender_future_timeout_ms = cache_transceiver_config.kv_transfer_sender_future_timeout_ms
+        self.kv_transfer_poll_interval_ms = cache_transceiver_config.kv_transfer_poll_interval_ms
 
         # Get RNN state manager and layer distribution if mamba_cache_manager is provided.
         rnn_state_manager = None

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -2709,26 +2709,46 @@ class PyExecutor:
             self.kv_cache_manager.commit_scheduled_kv_cache_stats(
                 scheduled_batch)
 
+    def _get_disagg_transfer_admission_controller(
+            self) -> DisaggTransferAdmissionController:
+        controller = getattr(self, "_disagg_transfer_admission_controller",
+                             None)
+        if controller is not None:
+            return controller
+
+        cache_transceiver_config = getattr(getattr(self, "llm_args", None),
+                                           "cache_transceiver_config", None)
+        kv_cache_manager = getattr(self, "kv_cache_manager", None)
+        return DisaggTransferAdmissionController(
+            getattr(cache_transceiver_config, "max_tokens_in_buffer", None),
+            getattr(kv_cache_manager, "tokens_per_block", None),
+        )
+
+    def _uses_kv_manager_v2(self) -> bool:
+        explicit_flag = getattr(self, "_is_kv_manager_v2", None)
+        if explicit_flag is not None:
+            return bool(explicit_flag)
+        return isinstance(getattr(self, "kv_cache_manager", None),
+                          KVCacheManagerV2)
+
     def _apply_disagg_transfer_admission(
         self, fitting_disagg_gen_init_requests: List[LlmRequest]
     ) -> Tuple[List[LlmRequest], bool]:
-        if not (self.kv_cache_transceiver
-                and self._disagg_transfer_admission_controller.enabled()
-                and fitting_disagg_gen_init_requests):
+        controller = self._get_disagg_transfer_admission_controller()
+        if not (getattr(self, "kv_cache_transceiver", None)
+                and controller.enabled() and fitting_disagg_gen_init_requests):
             return fitting_disagg_gen_init_requests, False
 
-        admission_result = self._disagg_transfer_admission_controller.select(
-            self.active_requests, fitting_disagg_gen_init_requests)
+        admission_result = controller.select(self.active_requests,
+                                             fitting_disagg_gen_init_requests)
         if admission_result.deferred_request_count > 0:
-            logger.debug(
-                "Disagg transfer admission deferred "
-                f"{admission_result.deferred_request_count} requests; "
-                f"active transfer blocks="
-                f"{admission_result.active_transfer_blocks}, "
-                f"admitted transfer blocks="
-                f"{admission_result.admitted_transfer_blocks}, "
-                f"budget={self._disagg_transfer_admission_controller.max_transfer_blocks}"
-            )
+            logger.debug("Disagg transfer admission deferred "
+                         f"{admission_result.deferred_request_count} requests; "
+                         f"active transfer blocks="
+                         f"{admission_result.active_transfer_blocks}, "
+                         f"admitted transfer blocks="
+                         f"{admission_result.admitted_transfer_blocks}, "
+                         f"budget={controller.max_transfer_blocks}")
 
         self._revert_deferred_disagg_gen_init_alloc(
             fitting_disagg_gen_init_requests,
@@ -2740,7 +2760,7 @@ class PyExecutor:
     def _revert_deferred_disagg_gen_init_alloc(
             self, candidates: List[LlmRequest],
             admitted_requests: List[LlmRequest]) -> None:
-        if not (self._is_kv_manager_v2 and candidates):
+        if not (self._uses_kv_manager_v2() and candidates):
             return
 
         admitted_request_ids = {

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -154,6 +154,95 @@ def _strip_py_multimodal_data_post_prefill(request: LlmRequest) -> None:
 
 
 @dataclasses.dataclass
+class DisaggTransferAdmissionResult:
+    admitted_requests: List[LlmRequest]
+    active_transfer_blocks: int = 0
+    admitted_transfer_blocks: int = 0
+    deferred_request_count: int = 0
+    limited_by_budget: bool = False
+
+    def is_blocked_by_active_transfers(self) -> bool:
+        return (self.limited_by_budget and not self.admitted_requests
+                and self.active_transfer_blocks > 0)
+
+
+class DisaggTransferAdmissionController:
+    """FCFS admission gate for disaggregated generation KV transfers."""
+
+    def __init__(self, max_tokens_in_buffer: Optional[int],
+                 tokens_per_block: Optional[int]) -> None:
+        self.max_transfer_blocks = self._to_block_budget(
+            max_tokens_in_buffer, tokens_per_block)
+        self.tokens_per_block = tokens_per_block or 0
+
+    def enabled(self) -> bool:
+        return self.max_transfer_blocks is not None
+
+    @staticmethod
+    def _to_block_budget(max_tokens_in_buffer: Optional[int],
+                         tokens_per_block: Optional[int]) -> Optional[int]:
+        if (max_tokens_in_buffer is None or max_tokens_in_buffer == 0
+                or tokens_per_block is None or tokens_per_block <= 0):
+            return None
+        return (max_tokens_in_buffer + tokens_per_block - 1) // tokens_per_block
+
+    def _estimate_request_blocks(self, request: LlmRequest) -> int:
+        if self.tokens_per_block <= 0:
+            return 0
+        prompt_len = getattr(request, "py_prompt_len",
+                             getattr(request, "prompt_len", 0))
+        prompt_len = max(int(prompt_len), 0)
+        return (prompt_len + self.tokens_per_block - 1) // self.tokens_per_block
+
+    def _estimate_requests_blocks(self, requests: Iterable[LlmRequest]) -> int:
+        return sum(
+            self._estimate_request_blocks(request) for request in requests)
+
+    def _estimate_active_transfer_blocks(
+            self, active_requests: Iterable[LlmRequest]) -> int:
+        return sum(
+            self._estimate_request_blocks(request)
+            for request in active_requests
+            if request.is_disagg_generation_transmission_in_progress)
+
+    def select(self, active_requests: Iterable[LlmRequest],
+               candidates: List[LlmRequest]) -> DisaggTransferAdmissionResult:
+        if not self.enabled():
+            return DisaggTransferAdmissionResult(
+                admitted_requests=list(candidates),
+                active_transfer_blocks=self._estimate_active_transfer_blocks(
+                    active_requests),
+                admitted_transfer_blocks=self._estimate_requests_blocks(
+                    candidates),
+            )
+
+        result = DisaggTransferAdmissionResult(admitted_requests=[])
+        result.active_transfer_blocks = self._estimate_active_transfer_blocks(
+            active_requests)
+
+        used_blocks = result.active_transfer_blocks
+        max_transfer_blocks = self.max_transfer_blocks
+        assert max_transfer_blocks is not None
+        for request in candidates:
+            request_blocks = self._estimate_request_blocks(request)
+            fits_budget = used_blocks + request_blocks <= max_transfer_blocks
+            admit_oversized_head = (not result.admitted_requests
+                                    and result.active_transfer_blocks == 0
+                                    and request_blocks > max_transfer_blocks)
+            if not fits_budget and not admit_oversized_head:
+                result.limited_by_budget = True
+                break
+
+            result.admitted_requests.append(request)
+            used_blocks += request_blocks
+            result.admitted_transfer_blocks += request_blocks
+
+        result.deferred_request_count = len(candidates) - len(
+            result.admitted_requests)
+        return result
+
+
+@dataclasses.dataclass
 class ScheduledBatchStats:
     # None means the counter was not captured and _update_iter_stats should
     # fall back to the existing scheduled_batch/request accessors.
@@ -664,6 +753,14 @@ class PyExecutor:
         self.gather_all_responses = False
 
         self.kv_cache_transceiver = kv_cache_transceiver
+        cache_transceiver_config = getattr(self.llm_args,
+                                           "cache_transceiver_config", None)
+        max_tokens_in_buffer = getattr(cache_transceiver_config,
+                                       "max_tokens_in_buffer", None)
+        tokens_per_block = getattr(self.kv_cache_manager, "tokens_per_block",
+                                   None)
+        self._disagg_transfer_admission_controller = DisaggTransferAdmissionController(
+            max_tokens_in_buffer, tokens_per_block)
         self.is_benchmark_disagg = (self.benchmark_req_queues_size > 0
                                     and self.kv_cache_transceiver is not None)
         # True while the benchmark disagg fill phase is in progress (waiting
@@ -1932,14 +2029,19 @@ class PyExecutor:
         # For DP cases, the first PP rank schedules the requests.
         scheduled_batch = None
         serializable_schedule = None
+        wait_for_disagg_gen_transfer_progress = False
         is_dp_broadcast = self.dist.tp_size > 1 and self.enable_attention_dp
         if self.dist.rank == 0 or (self.dist.is_first_pp_rank
                                    and is_dp_broadcast):
             scheduled_batch, fitting_disagg_gen_init_requests, num_fitting_reqs = self._schedule(
             )
+            if self.kv_cache_transceiver:
+                fitting_disagg_gen_init_requests, wait_for_disagg_gen_transfer_progress = (
+                    self._apply_disagg_transfer_admission(
+                        fitting_disagg_gen_init_requests))
             serializable_schedule = SerializableSchedulerOutput.from_scheduler_result(
                 scheduled_batch, fitting_disagg_gen_init_requests,
-                num_fitting_reqs)
+                num_fitting_reqs, wait_for_disagg_gen_transfer_progress)
 
         # Broadcast within first tp+cp group before send/recv chain to other tp+cp groups
         if self.dist.is_first_pp_rank:
@@ -1971,7 +2073,10 @@ class PyExecutor:
         if scheduled_batch is None:
             scheduled_batch, fitting_disagg_gen_init_requests, num_fitting_reqs = serializable_schedule.to_scheduler_result(
                 self.active_requests)
-        return scheduled_batch, fitting_disagg_gen_init_requests, num_fitting_reqs
+            wait_for_disagg_gen_transfer_progress = (
+                serializable_schedule.wait_for_disagg_gen_transfer_progress)
+        return (scheduled_batch, fitting_disagg_gen_init_requests,
+                num_fitting_reqs, wait_for_disagg_gen_transfer_progress)
 
     def _pp_retry_until_can_schedule(self, scheduled_batch):
         """
@@ -2051,14 +2156,22 @@ class PyExecutor:
                 self._pad_attention_dp_dummy_request()
 
                 # Stage 0: first PP rank schedules requests and propagates the result to all other PP ranks.
-                scheduled_batch, fitting_disagg_gen_init_requests, num_fitting_reqs = self._pp_schedule_and_propagate(
-                    microbatch_id)
+                (scheduled_batch, fitting_disagg_gen_init_requests,
+                 num_fitting_reqs, wait_for_disagg_gen_transfer_progress
+                 ) = self._pp_schedule_and_propagate(microbatch_id)
                 if self.dist.rank != 0:
                     # Retry until current rank can run first PP's schedule result.
                     self._pp_retry_until_can_schedule(scheduled_batch)
                     # Run scheduler locally because scheduler may change llm requests' state.
-                    self.scheduler.schedule_request(self.active_requests,
-                                                    self.inflight_req_ids)
+                    local_scheduler_output = self.scheduler.schedule_request(
+                        self.active_requests, self.inflight_req_ids)
+                    if self.kv_cache_transceiver:
+                        local_disagg_candidates = getattr(
+                            local_scheduler_output,
+                            "fitting_disagg_gen_init_requests", [])
+                        self._revert_deferred_disagg_gen_init_alloc(
+                            local_disagg_candidates,
+                            fitting_disagg_gen_init_requests)
 
                 # For requests that are fitting disagg gen init, also prepare resources for KV cache manager
                 if self.kv_cache_transceiver:
@@ -2080,21 +2193,9 @@ class PyExecutor:
                     # with attention_dp), so a TP-scoped OR vote is sufficient.
                     # Using WORLD allreduce here serialized the disagg prefill
                     # host loop on every iter (nvbug/6280060).
-                    local_need_check = (num_fitting_reqs == 0 and
-                                        not fitting_disagg_gen_init_requests)
-                    if self.dist.tp_size > 1:
-                        any_need_check = self.dist.tp_allreduce(
-                            int(local_need_check), op=ReduceOp.MAX)
-                    else:
-                        any_need_check = int(local_need_check)
-                    if any_need_check > 0:
-                        if local_need_check and not all_gen_first:
-                            logger.warning(
-                                "num_fitting_reqs=0 and fitting_disagg_gen_init_requests is empty, may not have enough kvCache"
-                            )
-                            self._check_disagg_ctx_cache_transfer_status(1)
-                        else:
-                            self._check_disagg_ctx_cache_transfer_status(0)
+                    self._check_disagg_transfer_progress_when_idle(
+                        num_fitting_reqs, fitting_disagg_gen_init_requests,
+                        wait_for_disagg_gen_transfer_progress, all_gen_first)
 
                 self.num_scheduled_requests = scheduled_batch.batch_size
 
@@ -2605,6 +2706,99 @@ class PyExecutor:
             self.kv_cache_manager.commit_scheduled_kv_cache_stats(
                 scheduled_batch)
 
+    def _apply_disagg_transfer_admission(
+        self, fitting_disagg_gen_init_requests: List[LlmRequest]
+    ) -> Tuple[List[LlmRequest], bool]:
+        if not (self.kv_cache_transceiver
+                and self._disagg_transfer_admission_controller.enabled()
+                and fitting_disagg_gen_init_requests):
+            return fitting_disagg_gen_init_requests, False
+
+        admission_result = self._disagg_transfer_admission_controller.select(
+            self.active_requests, fitting_disagg_gen_init_requests)
+        if admission_result.deferred_request_count > 0:
+            logger.debug(
+                "Disagg transfer admission deferred "
+                f"{admission_result.deferred_request_count} requests; "
+                f"active transfer blocks="
+                f"{admission_result.active_transfer_blocks}, "
+                f"admitted transfer blocks="
+                f"{admission_result.admitted_transfer_blocks}, "
+                f"budget={self._disagg_transfer_admission_controller.max_transfer_blocks}"
+            )
+
+        self._revert_deferred_disagg_gen_init_alloc(
+            fitting_disagg_gen_init_requests,
+            admission_result.admitted_requests)
+
+        return (admission_result.admitted_requests,
+                admission_result.is_blocked_by_active_transfers())
+
+    def _revert_deferred_disagg_gen_init_alloc(
+            self, candidates: List[LlmRequest],
+            admitted_requests: List[LlmRequest]) -> None:
+        if not (self._is_kv_manager_v2 and candidates):
+            return
+
+        admitted_request_ids = {
+            request.py_request_id
+            for request in admitted_requests
+        }
+        deferred_requests = [
+            request for request in candidates
+            if request.py_request_id not in admitted_request_ids
+        ]
+        if deferred_requests:
+            self._revert_ctx_alloc(deferred_requests)
+
+    def _check_disagg_transfer_progress_when_idle(
+            self, num_fitting_reqs: int,
+            fitting_disagg_gen_init_requests: List[LlmRequest],
+            wait_for_disagg_gen_transfer_progress: bool,
+            all_gen_first: bool) -> None:
+        local_need_check = (num_fitting_reqs == 0
+                            and not fitting_disagg_gen_init_requests)
+        local_need_gen_check = (local_need_check
+                                and wait_for_disagg_gen_transfer_progress)
+
+        if self.dist.tp_size > 1:
+            any_need_gen_check = self.dist.tp_allreduce(
+                int(local_need_gen_check), op=ReduceOp.MAX)
+        else:
+            any_need_gen_check = int(local_need_gen_check)
+
+        if any_need_gen_check > 0:
+            if local_need_gen_check:
+                logger.debug(
+                    "Waiting for generation KV cache transfer progress to free "
+                    "disagg admission budget")
+                self._check_disagg_gen_cache_transfer_status(1)
+            else:
+                self._check_disagg_gen_cache_transfer_status(1)
+            return
+
+        if self.dist.tp_size > 1:
+            any_need_check = self.dist.tp_allreduce(int(local_need_check),
+                                                    op=ReduceOp.MAX)
+        else:
+            any_need_check = int(local_need_check)
+        if any_need_check > 0:
+            if local_need_check and not all_gen_first:
+                logger.warning(
+                    "num_fitting_reqs=0 and fitting_disagg_gen_init_requests is empty, may not have enough kvCache"
+                )
+                # Local conditions warrant a blocking wait for at least one
+                # in-flight transfer to complete so KV blocks can be freed.
+                self._check_disagg_ctx_cache_transfer_status(1)
+            else:
+                # Either (a) a peer rank needed the call but we didn't, or
+                # (b) all active requests are gen-first so we don't
+                # actively block. In both cases the non-blocking variant
+                # still runs the internal allgather (keeping all ranks in
+                # sync) and reaps any already-completed transfers without
+                # blocking on un-finished ones.
+                self._check_disagg_ctx_cache_transfer_status(0)
+
     def _prepare_and_schedule_batch(self):
         new_requests = self._fetch_and_activate_new_requests()
         if self.should_stop_processing:
@@ -2675,6 +2869,10 @@ class PyExecutor:
                 request.py_disable_speculative_decoding = True
 
         if self.kv_cache_transceiver:
+            wait_for_disagg_gen_transfer_progress = False
+            fitting_disagg_gen_init_requests, wait_for_disagg_gen_transfer_progress = (
+                self._apply_disagg_transfer_admission(
+                    fitting_disagg_gen_init_requests))
             # For requests that are fitting disagg gen init, also prepare resources for KV cache manager
             self._prepare_disagg_gen_init(fitting_disagg_gen_init_requests)
 
@@ -2695,29 +2893,9 @@ class PyExecutor:
             # holding any individual rank. Use TP-scoped allreduce (matches
             # the C++ syncComm scope) instead of WORLD to avoid serializing
             # the disagg prefill host loop on every iter (nvbug/6280060).
-            local_need_check = (num_fitting_reqs == 0
-                                and not fitting_disagg_gen_init_requests)
-            if self.dist.tp_size > 1:
-                any_need_check = self.dist.tp_allreduce(int(local_need_check),
-                                                        op=ReduceOp.MAX)
-            else:
-                any_need_check = int(local_need_check)
-            if any_need_check > 0:
-                if local_need_check and not all_gen_first:
-                    logger.warning(
-                        "num_fitting_reqs=0 and fitting_disagg_gen_init_requests is empty, may not have enough kvCache"
-                    )
-                    # Local conditions warrant a blocking wait for at least one
-                    # in-flight transfer to complete so KV blocks can be freed.
-                    self._check_disagg_ctx_cache_transfer_status(1)
-                else:
-                    # Either (a) a peer rank needed the call but we didn't, or
-                    # (b) all active requests are gen-first so we don't
-                    # actively block. In both cases the non-blocking variant
-                    # still runs the internal allgather (keeping all ranks in
-                    # sync) and reaps any already-completed transfers without
-                    # blocking on un-finished ones.
-                    self._check_disagg_ctx_cache_transfer_status(0)
+            self._check_disagg_transfer_progress_when_idle(
+                num_fitting_reqs, fitting_disagg_gen_init_requests,
+                wait_for_disagg_gen_transfer_progress, all_gen_first)
 
             # In gen-only benchmark mode, all requests must fit in KV cache
             # simultaneously. If some requests are stuck in INIT state and the
@@ -4286,18 +4464,9 @@ class PyExecutor:
             req.is_disagg_generation_transmission_in_progress
             for req in self.active_requests
         ])
-        non_gen_first_reqs = [
-            req for req in self.active_requests
-            if req.py_disaggregated_params and req.py_disaggregated_params.
-            schedule_style != DisaggScheduleStyle.GENERATION_FIRST
-        ]
-        need_check_one = bool(non_gen_first_reqs) and all(
-            req.is_disagg_generation_transmission_in_progress
-            for req in non_gen_first_reqs)
 
         if need_check:
-            at_least_num = 1 if need_check_one else 0
-            self._check_disagg_gen_cache_transfer_status(at_least_num)
+            self._check_disagg_gen_cache_transfer_status(0)
 
         return
 
@@ -4667,15 +4836,7 @@ class PyExecutor:
                 if req.state == LlmRequestState.DISAGG_GENERATION_TRANS_IN_PROGRESS:
                     req.py_kv_transfer_start_time = time.time()
 
-        non_gen_first_active = [
-            req for req in self.active_requests
-            if req.py_disaggregated_params and req.py_disaggregated_params.
-            schedule_style != DisaggScheduleStyle.GENERATION_FIRST
-        ]
-        block_transfer = bool(non_gen_first_active) and all(
-            req.is_disagg_generation_transmission_in_progress
-            for req in non_gen_first_active)
-        self._check_disagg_gen_cache_transfer_status(1 if block_transfer else 0)
+        self._check_disagg_gen_cache_transfer_status(0)
 
         return
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -186,12 +186,25 @@ class DisaggTransferAdmissionController:
             return None
         return (max_tokens_in_buffer + tokens_per_block - 1) // tokens_per_block
 
+    @staticmethod
+    def _to_nonnegative_int(value) -> Optional[int]:
+        try:
+            return max(int(value), 0)
+        except (TypeError, ValueError):
+            return None
+
+    def _get_request_transfer_token_count(self, request: LlmRequest) -> int:
+        for attr_name in ("total_input_len_cp", "py_prompt_len", "prompt_len"):
+            token_count = self._to_nonnegative_int(
+                getattr(request, attr_name, None))
+            if token_count is not None:
+                return token_count
+        return 0
+
     def _estimate_request_blocks(self, request: LlmRequest) -> int:
         if self.tokens_per_block <= 0:
             return 0
-        prompt_len = getattr(request, "py_prompt_len",
-                             getattr(request, "prompt_len", 0))
-        prompt_len = max(int(prompt_len), 0)
+        prompt_len = self._get_request_transfer_token_count(request)
         return (prompt_len + self.tokens_per_block - 1) // self.tokens_per_block
 
     def _estimate_requests_blocks(self, requests: Iterable[LlmRequest]) -> int:
@@ -2183,16 +2196,6 @@ class PyExecutor:
                         and req.py_disaggregated_params.schedule_style ==
                         DisaggScheduleStyle.GENERATION_FIRST
                         for req in self.active_requests)
-                    # [disagg-ctx-deadlock-fix] Mirror of the OR-gated entry in
-                    # _executor_loop: ensure every TP rank either calls
-                    # _check_disagg_ctx_cache_transfer_status together or skips
-                    # it together, so the internal allgather in
-                    # CacheTransceiver::checkContextTransferStatus always has
-                    # full quorum. The C++ syncComm inside that helper is at
-                    # most TP-wide (mGroupTensorParaComm; mGroupTPInDPComm
-                    # with attention_dp), so a TP-scoped OR vote is sufficient.
-                    # Using WORLD allreduce here serialized the disagg prefill
-                    # host loop on every iter (nvbug/6280060).
                     self._check_disagg_transfer_progress_when_idle(
                         num_fitting_reqs, fitting_disagg_gen_init_requests,
                         wait_for_disagg_gen_transfer_progress, all_gen_first)
@@ -2751,6 +2754,26 @@ class PyExecutor:
         if deferred_requests:
             self._revert_ctx_alloc(deferred_requests)
 
+    @staticmethod
+    def _dist_size(dist, name: str) -> int:
+        try:
+            return int(getattr(dist, name))
+        except (AttributeError, TypeError, ValueError):
+            return 1
+
+    def _sync_disagg_gen_status_entry(self, local_need_check: bool) -> int:
+        if self._dist_size(self.dist, "world_size") > 1:
+            return self.dist.allreduce(int(local_need_check), op=ReduceOp.MAX)
+        return int(local_need_check)
+
+    def _sync_disagg_ctx_status_entry(self, local_need_check: bool) -> int:
+        if self._dist_size(self.dist, "cp_size") > 1:
+            return int(any(self.dist.tp_cp_allgather(int(local_need_check))))
+        if self._dist_size(self.dist, "tp_size") > 1:
+            return self.dist.tp_allreduce(int(local_need_check),
+                                          op=ReduceOp.MAX)
+        return int(local_need_check)
+
     def _check_disagg_transfer_progress_when_idle(
             self, num_fitting_reqs: int,
             fitting_disagg_gen_init_requests: List[LlmRequest],
@@ -2761,27 +2784,17 @@ class PyExecutor:
         local_need_gen_check = (local_need_check
                                 and wait_for_disagg_gen_transfer_progress)
 
-        if self.dist.tp_size > 1:
-            any_need_gen_check = self.dist.tp_allreduce(
-                int(local_need_gen_check), op=ReduceOp.MAX)
-        else:
-            any_need_gen_check = int(local_need_gen_check)
-
+        any_need_gen_check = self._sync_disagg_gen_status_entry(
+            local_need_gen_check)
         if any_need_gen_check > 0:
             if local_need_gen_check:
                 logger.debug(
                     "Waiting for generation KV cache transfer progress to free "
                     "disagg admission budget")
-                self._check_disagg_gen_cache_transfer_status(1)
-            else:
-                self._check_disagg_gen_cache_transfer_status(1)
+            self._check_disagg_gen_cache_transfer_status(1)
             return
 
-        if self.dist.tp_size > 1:
-            any_need_check = self.dist.tp_allreduce(int(local_need_check),
-                                                    op=ReduceOp.MAX)
-        else:
-            any_need_check = int(local_need_check)
+        any_need_check = self._sync_disagg_ctx_status_entry(local_need_check)
         if any_need_check > 0:
             if local_need_check and not all_gen_first:
                 logger.warning(
@@ -2880,19 +2893,6 @@ class PyExecutor:
                 req.py_disaggregated_params and req.py_disaggregated_params.
                 schedule_style == DisaggScheduleStyle.GENERATION_FIRST
                 for req in self.active_requests)
-            # [disagg-ctx-deadlock-fix] _check_disagg_ctx_cache_transfer_status
-            # internally invokes a TP-scoped allgather inside
-            # CacheTransceiver::checkContextTransferStatus. Gating the call on
-            # rank-local `num_fitting_reqs` (which can drift between ranks by
-            # one block due to per-rank UCX/CUDA-event-sync timing variance)
-            # lets some ranks enter the allgather while others skip ahead to
-            # model_forward / kv_connector → cross-rank collective-mismatch
-            # deadlock. OR the decision across TP ranks: if ANY rank wants the
-            # call, ALL ranks call it. Ranks that don't locally need it use the
-            # non-blocking variant so the collective stays in sync without
-            # holding any individual rank. Use TP-scoped allreduce (matches
-            # the C++ syncComm scope) instead of WORLD to avoid serializing
-            # the disagg prefill host loop on every iter (nvbug/6280060).
             self._check_disagg_transfer_progress_when_idle(
                 num_fitting_reqs, fitting_disagg_gen_init_requests,
                 wait_for_disagg_gen_transfer_progress, all_gen_first)
@@ -4459,16 +4459,10 @@ class PyExecutor:
 
     @nvtx_range("_check_disagg_gen_transfer_status")
     def _check_disagg_gen_transfer_status(self):
-
-        need_check = any([
-            req.is_disagg_generation_transmission_in_progress
-            for req in self.active_requests
-        ])
-
-        if need_check:
-            self._check_disagg_gen_cache_transfer_status(0)
-
-        return
+        # Gen-transfer status performs cross-rank consensus internally.
+        # Enter it symmetrically; ranks with no ready local future contribute
+        # an empty ready set.
+        self._check_disagg_gen_cache_transfer_status(0)
 
     @nvtx_range("_check_kv_transfer_timeout")
     def _check_kv_transfer_timeout(self):

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler.py
@@ -236,6 +236,7 @@ class SerializableSchedulerOutput:
         int
     ]  # request ids of fitting disaggregated generation initialization requests
     num_fitting_requests: int  # number of fitting requests
+    wait_for_disagg_gen_transfer_progress: bool = False
 
     @classmethod
     def from_scheduler_result(
@@ -243,6 +244,7 @@ class SerializableSchedulerOutput:
         scheduled_requests: ScheduledRequests,
         fitting_disagg_gen_init_requests: RequestList,
         num_fitting_requests: int,
+        wait_for_disagg_gen_transfer_progress: bool = False,
     ) -> "SerializableSchedulerOutput":
         return cls(
             encoder_requests=[req.request_id for req in scheduled_requests.encoder_requests],
@@ -258,6 +260,7 @@ class SerializableSchedulerOutput:
                 req.request_id for req in fitting_disagg_gen_init_requests
             ],
             num_fitting_requests=num_fitting_requests,
+            wait_for_disagg_gen_transfer_progress=wait_for_disagg_gen_transfer_progress,
         )
 
     def to_scheduler_result(

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3430,13 +3430,20 @@ class CacheTransceiverConfig(StrictBaseModel, PybindMirror):
         "Timeout in milliseconds to wait for the sender future to be ready when scheduled batch size is 0. This allows the request to be eventually cancelled by the user or because of kv_transfer_timeout_ms"
     )
 
+    kv_transfer_poll_interval_ms: Optional[PositiveInt] = Field(
+        default=5000,
+        description=
+        "Bounded wait interval in milliseconds for polling KV transfer "
+        "progress when active transfers block disaggregated admission.")
+
     def _to_pybind(self):
         return _CacheTransceiverConfig(
             backend=_CacheTransceiverBackendType.from_string(self.backend),
             max_tokens_in_buffer=self.max_tokens_in_buffer,
             kv_transfer_timeout_ms=self.kv_transfer_timeout_ms,
             kv_transfer_sender_future_timeout_ms=self.
-            kv_transfer_sender_future_timeout_ms)
+            kv_transfer_sender_future_timeout_ms,
+            kv_transfer_poll_interval_ms=self.kv_transfer_poll_interval_ms)
 
 
 @dataclass

--- a/tests/integration/defs/accuracy/test_disaggregated_serving.py
+++ b/tests/integration/defs/accuracy/test_disaggregated_serving.py
@@ -1948,6 +1948,15 @@ class TestQwen3_8B(LlmapiAccuracyTestHarness):
             "enable_partial_reuse": False,
             "tokens_per_block": 32,
         }
+        cache_transceiver_config = {
+            "backend": "UCX",
+            "max_tokens_in_buffer": 8192,
+        }
+        if (comms_medium == "fifo_v2" and cuda_graph_config is not None
+                and cuda_graph_config.get("enable_padding", False)
+                and not enable_attention_dp and gen_pp == 1
+                and (gen_tp, gen_cp) in ((1, 4), (2, 2))):
+            cache_transceiver_config["kv_transfer_timeout_ms"] = 300000
         ctx_server_config = {
             "pipeline_parallel_size": 1,
             "tensor_parallel_size": 4,
@@ -1956,10 +1965,7 @@ class TestQwen3_8B(LlmapiAccuracyTestHarness):
             "kv_cache_config": kv_cache_config,
             "enable_chunked_prefill": False,
             "cuda_graph_config": None,
-            "cache_transceiver_config": {
-                "backend": "UCX",
-                "max_tokens_in_buffer": 8192,
-            },
+            "cache_transceiver_config": cache_transceiver_config.copy(),
         }
         gen_server_config = {
             "tensor_parallel_size": gen_tp,
@@ -1976,10 +1982,7 @@ class TestQwen3_8B(LlmapiAccuracyTestHarness):
             "kv_cache_config": kv_cache_config,
             "enable_chunked_prefill": False,
             "cuda_graph_config": cuda_graph_config,
-            "cache_transceiver_config": {
-                "backend": "UCX",
-                "max_tokens_in_buffer": 8192,
-            },
+            "cache_transceiver_config": cache_transceiver_config.copy(),
             "enable_attention_dp": enable_attention_dp,
         }
         disaggregated_server_config = {

--- a/tests/integration/defs/accuracy/test_disaggregated_serving.py
+++ b/tests/integration/defs/accuracy/test_disaggregated_serving.py
@@ -1952,11 +1952,6 @@ class TestQwen3_8B(LlmapiAccuracyTestHarness):
             "backend": "UCX",
             "max_tokens_in_buffer": 8192,
         }
-        if (comms_medium == "fifo_v2" and cuda_graph_config is not None
-                and cuda_graph_config.get("enable_padding", False)
-                and not enable_attention_dp and gen_pp == 1
-                and (gen_tp, gen_cp) in ((1, 4), (2, 2))):
-            cache_transceiver_config["kv_transfer_timeout_ms"] = 300000
         ctx_server_config = {
             "pipeline_parallel_size": 1,
             "tensor_parallel_size": 4,

--- a/tests/unittest/_torch/executor/test_py_executor.py
+++ b/tests/unittest/_torch/executor/test_py_executor.py
@@ -22,8 +22,12 @@ from tensorrt_llm._torch.pyexecutor.executor_request_queue import (
     RequestQueueItem,
 )
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequestState
-from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
-from tensorrt_llm._torch.pyexecutor.scheduler import FCFSWaitingQueue
+from tensorrt_llm._torch.pyexecutor.py_executor import DisaggTransferAdmissionController, PyExecutor
+from tensorrt_llm._torch.pyexecutor.scheduler import (
+    FCFSWaitingQueue,
+    ScheduledRequests,
+    SerializableSchedulerOutput,
+)
 
 
 class MockPyExecutor:
@@ -280,6 +284,212 @@ def _make_gen_request(num_draft_tokens=0):
     req = Mock()
     req.num_draft_tokens = num_draft_tokens
     return req
+
+
+def _make_disagg_transfer_request(request_id, prompt_len, in_progress=False):
+    """Helper to create a mock disaggregated generation transfer request."""
+    req = Mock()
+    req.request_id = request_id
+    req.py_request_id = request_id
+    req.py_prompt_len = prompt_len
+    req.is_disagg_generation_transmission_in_progress = in_progress
+    return req
+
+
+class TestDisaggTransferAdmissionController:
+    def test_disabled_preserves_candidates(self):
+        controller = DisaggTransferAdmissionController(
+            max_tokens_in_buffer=None, tokens_per_block=32
+        )
+        candidate = _make_disagg_transfer_request(1, 64)
+
+        result = controller.select(active_requests=[], candidates=[candidate])
+
+        assert result.admitted_requests == [candidate]
+        assert result.deferred_request_count == 0
+        assert not result.is_blocked_by_active_transfers()
+
+    def test_fcfs_budget_counts_active_transfers(self):
+        controller = DisaggTransferAdmissionController(max_tokens_in_buffer=64, tokens_per_block=32)
+        active = _make_disagg_transfer_request(1, 32, in_progress=True)
+        admitted = _make_disagg_transfer_request(2, 32)
+        deferred = _make_disagg_transfer_request(3, 32)
+
+        result = controller.select(active_requests=[active], candidates=[admitted, deferred])
+
+        assert result.admitted_requests == [admitted]
+        assert result.active_transfer_blocks == 1
+        assert result.admitted_transfer_blocks == 1
+        assert result.deferred_request_count == 1
+        assert result.limited_by_budget
+        assert not result.is_blocked_by_active_transfers()
+
+    def test_reports_active_transfer_budget_block(self):
+        controller = DisaggTransferAdmissionController(max_tokens_in_buffer=32, tokens_per_block=32)
+        active = _make_disagg_transfer_request(1, 32, in_progress=True)
+        candidate = _make_disagg_transfer_request(2, 32)
+
+        result = controller.select(active_requests=[active], candidates=[candidate])
+
+        assert result.admitted_requests == []
+        assert result.active_transfer_blocks == 1
+        assert result.deferred_request_count == 1
+        assert result.is_blocked_by_active_transfers()
+
+    def test_admits_oversized_head_when_idle(self):
+        controller = DisaggTransferAdmissionController(max_tokens_in_buffer=32, tokens_per_block=32)
+        oversized = _make_disagg_transfer_request(1, 96)
+        deferred = _make_disagg_transfer_request(2, 32)
+
+        result = controller.select(active_requests=[], candidates=[oversized, deferred])
+
+        assert result.admitted_requests == [oversized]
+        assert result.admitted_transfer_blocks == 3
+        assert result.deferred_request_count == 1
+        assert result.limited_by_budget
+        assert not result.is_blocked_by_active_transfers()
+
+    def test_apply_reverts_deferred_v2_allocations(self):
+        executor = object.__new__(PyExecutor)
+        executor.kv_cache_transceiver = Mock()
+        executor._is_kv_manager_v2 = True
+        executor._revert_ctx_alloc = Mock()
+        executor.active_requests = [_make_disagg_transfer_request(1, 32, in_progress=True)]
+        executor._disagg_transfer_admission_controller = DisaggTransferAdmissionController(
+            max_tokens_in_buffer=32, tokens_per_block=32
+        )
+        candidate = _make_disagg_transfer_request(2, 32)
+
+        admitted, wait_for_progress = PyExecutor._apply_disagg_transfer_admission(
+            executor, [candidate]
+        )
+
+        assert admitted == []
+        assert wait_for_progress
+        executor._revert_ctx_alloc.assert_called_once_with([candidate])
+
+
+class TestDisaggTransferIdleProgress:
+    def test_gen_transfer_status_polls_active_transfers(self):
+        executor = object.__new__(PyExecutor)
+        executor.active_requests = [_make_disagg_transfer_request(1, 32, in_progress=True)]
+        executor._check_disagg_gen_cache_transfer_status = Mock()
+
+        PyExecutor._check_disagg_gen_transfer_status(executor)
+
+        executor._check_disagg_gen_cache_transfer_status.assert_called_once_with(0)
+
+    def test_polls_generation_transfer_when_admission_blocked(self):
+        executor = object.__new__(PyExecutor)
+        executor.dist = Mock(tp_size=1)
+        executor._check_disagg_gen_cache_transfer_status = Mock()
+        executor._check_disagg_ctx_cache_transfer_status = Mock()
+
+        PyExecutor._check_disagg_transfer_progress_when_idle(
+            executor,
+            num_fitting_reqs=0,
+            fitting_disagg_gen_init_requests=[],
+            wait_for_disagg_gen_transfer_progress=True,
+            all_gen_first=False,
+        )
+
+        executor._check_disagg_gen_cache_transfer_status.assert_called_once_with(1)
+        executor._check_disagg_ctx_cache_transfer_status.assert_not_called()
+
+    def test_peer_rank_enters_bounded_progress_poll(self):
+        executor = object.__new__(PyExecutor)
+        executor.dist = Mock(tp_size=2)
+        executor.dist.tp_allreduce.return_value = 1
+        executor._check_disagg_gen_cache_transfer_status = Mock()
+        executor._check_disagg_ctx_cache_transfer_status = Mock()
+
+        PyExecutor._check_disagg_transfer_progress_when_idle(
+            executor,
+            num_fitting_reqs=1,
+            fitting_disagg_gen_init_requests=[],
+            wait_for_disagg_gen_transfer_progress=True,
+            all_gen_first=False,
+        )
+
+        executor._check_disagg_gen_cache_transfer_status.assert_called_once_with(1)
+        executor._check_disagg_ctx_cache_transfer_status.assert_not_called()
+
+    def test_falls_back_to_context_transfer_when_not_generation_blocked(self):
+        executor = object.__new__(PyExecutor)
+        executor.dist = Mock(tp_size=1)
+        executor._check_disagg_gen_cache_transfer_status = Mock()
+        executor._check_disagg_ctx_cache_transfer_status = Mock()
+
+        PyExecutor._check_disagg_transfer_progress_when_idle(
+            executor,
+            num_fitting_reqs=0,
+            fitting_disagg_gen_init_requests=[],
+            wait_for_disagg_gen_transfer_progress=False,
+            all_gen_first=False,
+        )
+
+        executor._check_disagg_ctx_cache_transfer_status.assert_called_once_with(1)
+        executor._check_disagg_gen_cache_transfer_status.assert_not_called()
+
+
+class TestDisaggTransferAdmissionPP:
+    def test_pp_schedule_applies_gate_before_serializing(self):
+        executor = object.__new__(PyExecutor)
+        executor.dist = Mock(
+            rank=0, is_first_pp_rank=True, is_last_pp_rank=True, tp_size=1, cp_size=1
+        )
+        executor.enable_attention_dp = False
+        executor.kv_cache_transceiver = Mock()
+        executor.active_requests = [_make_disagg_transfer_request(1, 32, in_progress=True)]
+        executor._disagg_transfer_admission_controller = DisaggTransferAdmissionController(
+            max_tokens_in_buffer=32, tokens_per_block=32
+        )
+        scheduled_batch = ScheduledRequests()
+        candidate = _make_disagg_transfer_request(2, 32)
+        executor._schedule = Mock(return_value=(scheduled_batch, [candidate], 0))
+
+        scheduled, fitting, num_fitting, wait_for_progress = PyExecutor._pp_schedule_and_propagate(
+            executor, microbatch_id=0
+        )
+
+        assert scheduled is scheduled_batch
+        assert fitting == []
+        assert num_fitting == 0
+        assert wait_for_progress
+
+    def test_pp_schedule_restores_propagated_gate_decision(self):
+        executor = object.__new__(PyExecutor)
+        executor.dist = Mock(
+            rank=1,
+            is_first_pp_rank=False,
+            is_last_pp_rank=True,
+            prev_pp_rank=0,
+            tp_size=1,
+            cp_size=1,
+        )
+        executor.enable_attention_dp = False
+        executor.active_requests = [
+            _make_disagg_transfer_request(1, 32, in_progress=True),
+            _make_disagg_transfer_request(2, 32),
+        ]
+        serializable_schedule = SerializableSchedulerOutput(
+            encoder_requests=[],
+            context_requests_chunking=[],
+            context_requests_last_chunk=[],
+            generation_requests=[],
+            paused_requests=[],
+            fitting_disagg_gen_init_requests=[2],
+            num_fitting_requests=0,
+            wait_for_disagg_gen_transfer_progress=True,
+        )
+        executor.dist.recv_object = Mock(return_value=serializable_schedule)
+
+        _, fitting, _, wait_for_progress = PyExecutor._pp_schedule_and_propagate(
+            executor, microbatch_id=0
+        )
+
+        assert [req.py_request_id for req in fitting] == [2]
+        assert wait_for_progress
 
 
 class TestComputeScheduledTokens:

--- a/tests/unittest/_torch/executor/test_py_executor.py
+++ b/tests/unittest/_torch/executor/test_py_executor.py
@@ -383,6 +383,37 @@ class TestDisaggTransferAdmissionController:
         assert wait_for_progress
         executor._revert_ctx_alloc.assert_called_once_with([candidate])
 
+    def test_apply_missing_controller_preserves_candidates(self):
+        executor = object.__new__(PyExecutor)
+        executor.kv_cache_transceiver = Mock()
+        executor.active_requests = []
+        candidate = _make_disagg_transfer_request(1, 32)
+
+        admitted, wait_for_progress = PyExecutor._apply_disagg_transfer_admission(
+            executor, [candidate]
+        )
+
+        assert admitted == [candidate]
+        assert not wait_for_progress
+
+    def test_apply_missing_v2_flag_defaults_to_non_v2(self):
+        executor = object.__new__(PyExecutor)
+        executor.kv_cache_transceiver = Mock()
+        executor._revert_ctx_alloc = Mock()
+        executor.active_requests = [_make_disagg_transfer_request(1, 32, in_progress=True)]
+        executor._disagg_transfer_admission_controller = DisaggTransferAdmissionController(
+            max_tokens_in_buffer=32, tokens_per_block=32
+        )
+        candidate = _make_disagg_transfer_request(2, 32)
+
+        admitted, wait_for_progress = PyExecutor._apply_disagg_transfer_admission(
+            executor, [candidate]
+        )
+
+        assert admitted == []
+        assert wait_for_progress
+        executor._revert_ctx_alloc.assert_not_called()
+
 
 class TestDisaggTransferIdleProgress:
     def test_gen_transfer_status_polls_active_transfers(self):

--- a/tests/unittest/_torch/executor/test_py_executor.py
+++ b/tests/unittest/_torch/executor/test_py_executor.py
@@ -17,6 +17,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from tensorrt_llm._torch.distributed.communicator import ReduceOp
 from tensorrt_llm._torch.pyexecutor.executor_request_queue import (
     SHUTDOWN_REQUEST_ID,
     RequestQueueItem,
@@ -286,12 +287,15 @@ def _make_gen_request(num_draft_tokens=0):
     return req
 
 
-def _make_disagg_transfer_request(request_id, prompt_len, in_progress=False):
+def _make_disagg_transfer_request(
+    request_id, prompt_len, in_progress=False, total_input_len_cp=None
+):
     """Helper to create a mock disaggregated generation transfer request."""
     req = Mock()
     req.request_id = request_id
     req.py_request_id = request_id
     req.py_prompt_len = prompt_len
+    req.total_input_len_cp = prompt_len if total_input_len_cp is None else total_input_len_cp
     req.is_disagg_generation_transmission_in_progress = in_progress
     return req
 
@@ -349,6 +353,17 @@ class TestDisaggTransferAdmissionController:
         assert result.limited_by_budget
         assert not result.is_blocked_by_active_transfers()
 
+    def test_uses_global_cp_prompt_length_for_transfer_cost(self):
+        controller = DisaggTransferAdmissionController(
+            max_tokens_in_buffer=128, tokens_per_block=32
+        )
+        request = _make_disagg_transfer_request(1, 32, total_input_len_cp=96)
+
+        result = controller.select(active_requests=[], candidates=[request])
+
+        assert result.admitted_requests == [request]
+        assert result.admitted_transfer_blocks == 3
+
     def test_apply_reverts_deferred_v2_allocations(self):
         executor = object.__new__(PyExecutor)
         executor.kv_cache_transceiver = Mock()
@@ -379,6 +394,15 @@ class TestDisaggTransferIdleProgress:
 
         executor._check_disagg_gen_cache_transfer_status.assert_called_once_with(0)
 
+    def test_gen_transfer_status_enters_without_local_active_transfers(self):
+        executor = object.__new__(PyExecutor)
+        executor.active_requests = []
+        executor._check_disagg_gen_cache_transfer_status = Mock()
+
+        PyExecutor._check_disagg_gen_transfer_status(executor)
+
+        executor._check_disagg_gen_cache_transfer_status.assert_called_once_with(0)
+
     def test_polls_generation_transfer_when_admission_blocked(self):
         executor = object.__new__(PyExecutor)
         executor.dist = Mock(tp_size=1)
@@ -398,8 +422,8 @@ class TestDisaggTransferIdleProgress:
 
     def test_peer_rank_enters_bounded_progress_poll(self):
         executor = object.__new__(PyExecutor)
-        executor.dist = Mock(tp_size=2)
-        executor.dist.tp_allreduce.return_value = 1
+        executor.dist = Mock(tp_size=1, cp_size=4, world_size=4)
+        executor.dist.allreduce.return_value = 1
         executor._check_disagg_gen_cache_transfer_status = Mock()
         executor._check_disagg_ctx_cache_transfer_status = Mock()
 
@@ -413,6 +437,7 @@ class TestDisaggTransferIdleProgress:
 
         executor._check_disagg_gen_cache_transfer_status.assert_called_once_with(1)
         executor._check_disagg_ctx_cache_transfer_status.assert_not_called()
+        executor.dist.allreduce.assert_called_once_with(0, op=ReduceOp.MAX)
 
     def test_falls_back_to_context_transfer_when_not_generation_blocked(self):
         executor = object.__new__(PyExecutor)
@@ -430,6 +455,26 @@ class TestDisaggTransferIdleProgress:
 
         executor._check_disagg_ctx_cache_transfer_status.assert_called_once_with(1)
         executor._check_disagg_gen_cache_transfer_status.assert_not_called()
+
+    def test_peer_cp_rank_enters_context_progress_poll(self):
+        executor = object.__new__(PyExecutor)
+        executor.dist = Mock(tp_size=1, cp_size=4, world_size=4)
+        executor.dist.allreduce.return_value = 0
+        executor.dist.tp_cp_allgather.return_value = [0, 1, 0, 0]
+        executor._check_disagg_gen_cache_transfer_status = Mock()
+        executor._check_disagg_ctx_cache_transfer_status = Mock()
+
+        PyExecutor._check_disagg_transfer_progress_when_idle(
+            executor,
+            num_fitting_reqs=1,
+            fitting_disagg_gen_init_requests=[],
+            wait_for_disagg_gen_transfer_progress=False,
+            all_gen_first=False,
+        )
+
+        executor._check_disagg_ctx_cache_transfer_status.assert_called_once_with(0)
+        executor._check_disagg_gen_cache_transfer_status.assert_not_called()
+        executor.dist.tp_cp_allgather.assert_called_once_with(0)
 
 
 class TestDisaggTransferAdmissionPP:

--- a/tests/unittest/_torch/executor/test_scheduler_serializable_output.py
+++ b/tests/unittest/_torch/executor/test_scheduler_serializable_output.py
@@ -33,7 +33,10 @@ def test_serializable_scheduler_output_round_trip():
 
     # Create serializable scheduler output from scheduler result
     serializable_output = SerializableSchedulerOutput.from_scheduler_result(
-        scheduled_requests, fitting_disagg_gen_init_requests, num_fitting_requests
+        scheduled_requests,
+        fitting_disagg_gen_init_requests,
+        num_fitting_requests,
+        wait_for_disagg_gen_transfer_progress=True,
     )
 
     # Serialize and deserialize the serializable scheduler output
@@ -48,6 +51,7 @@ def test_serializable_scheduler_output_round_trip():
 
     # Verify the restored scheduler result is correct
     assert restored_num_fitting == num_fitting_requests
+    assert restored_output.wait_for_disagg_gen_transfer_progress
     assert _request_ids(restored_schedule.encoder_requests) == _request_ids(
         scheduled_requests.encoder_requests
     )

--- a/tests/unittest/bindings/test_executor_bindings.py
+++ b/tests/unittest/bindings/test_executor_bindings.py
@@ -2619,10 +2619,12 @@ def test_guided_decoding_config_pickle():
 def test_cache_transceiver_config_pickle():
     config = trtllm.CacheTransceiverConfig(
         backend=trtllm.CacheTransceiverBackendType.UCX,
-        max_tokens_in_buffer=1024)
+        max_tokens_in_buffer=1024,
+        kv_transfer_poll_interval_ms=5000)
     config_copy = pickle.loads(pickle.dumps(config))
     assert config_copy.backend == config.backend
     assert config_copy.max_tokens_in_buffer == config.max_tokens_in_buffer
+    assert config_copy.kv_transfer_poll_interval_ms == config.kv_transfer_poll_interval_ms
 
 
 def test_executor_config_pickle():

--- a/tests/unittest/disaggregated/test_transceiver_bounded_polling.py
+++ b/tests/unittest/disaggregated/test_transceiver_bounded_polling.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Optional
+from unittest.mock import Mock
 
 from tensorrt_llm._torch.disaggregation.base.transfer import SessionStatus, WaitResult
 from tensorrt_llm._torch.disaggregation.native.transfer import TaskStatus, TxSession
@@ -182,6 +183,46 @@ def test_context_transfer_status_zero_budget_processes_task_level_failure() -> N
     assert req.state == LlmRequestState.DISAGG_TRANS_ERROR
     assert 13 not in transceiver._send_sessions
     assert 13 not in transceiver._send_reqs
+
+
+def test_context_transfer_status_enters_consensus_when_tp_sync_required() -> None:
+    transceiver = object.__new__(KvCacheTransceiverV2)
+    transceiver._ever_had_send_session = False
+    transceiver._ctx_need_tp_sync = True
+    transceiver._ctx_need_pp_sync = False
+    transceiver._send_sessions = {}
+    transceiver._send_reqs = {}
+    transceiver._transfer_worker = _FakeTransferWorker()
+    transceiver._ctx_consensus = Mock(return_value=[])
+    transceiver._build_to_process = Mock(return_value=[])
+    transceiver._ctx_consensus_outcome = Mock(return_value=([], [], [], []))
+    transceiver._close_failed_sessions = Mock()
+
+    completed, failed = transceiver.check_context_transfer_status(at_least_request_num=0)
+
+    assert completed == []
+    assert failed == []
+    transceiver._ctx_consensus.assert_called_once_with([])
+    assert transceiver._transfer_worker.sweep_count == 1
+
+
+def test_gen_transfer_status_enters_consensus_when_sync_required() -> None:
+    transceiver = object.__new__(KvCacheTransceiverV2)
+    transceiver._ever_had_recv_session = False
+    transceiver._gen_need_sync = True
+    transceiver._recv_sessions = {}
+    transceiver._recv_reqs = {}
+    transceiver._gen_consensus = Mock(return_value=[])
+    transceiver._build_to_process = Mock(return_value=[])
+    transceiver._gen_consensus_outcome = Mock(return_value=([], [], []))
+    transceiver._close_failed_sessions = Mock()
+
+    completed, failed, cancelled = transceiver.check_gen_transfer_status(at_least_request_num=0)
+
+    assert completed == []
+    assert failed == []
+    assert cancelled == []
+    transceiver._gen_consensus.assert_called_once_with([])
 
 
 def test_tx_session_wait_complete_defaults_to_blocking() -> None:

--- a/tests/unittest/disaggregated/test_transceiver_bounded_polling.py
+++ b/tests/unittest/disaggregated/test_transceiver_bounded_polling.py
@@ -200,6 +200,16 @@ def test_tx_session_wait_complete_nonblocking_returns_none_without_waiting() -> 
     assert task.wait_calls == []
 
 
+def test_tx_session_wait_complete_nonblocking_reports_later_task_error() -> None:
+    pending_task = _FakeTask(TaskStatus.TRANSFERRING)
+    failed_task = _FakeTask(TaskStatus.ERROR)
+    session = _make_tx_session([pending_task, failed_task])
+
+    assert session.wait_complete(blocking=False) == WaitResult.FAILED
+    assert pending_task.wait_calls == []
+    assert failed_task.wait_calls == []
+
+
 def test_tx_session_has_failed_reports_task_error() -> None:
     task = _FakeTask(TaskStatus.ERROR)
     session = _make_tx_session([task])

--- a/tests/unittest/disaggregated/test_transceiver_bounded_polling.py
+++ b/tests/unittest/disaggregated/test_transceiver_bounded_polling.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Bounded polling tests for KvCacheTransceiverV2 Tx sessions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from tensorrt_llm._torch.disaggregation.base.transfer import SessionStatus, WaitResult
+from tensorrt_llm._torch.disaggregation.native.transfer import TaskStatus, TxSession
+from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+from tensorrt_llm.bindings import LlmRequestState
+
+
+@dataclass
+class _FakeRequest:
+    state: Optional[LlmRequestState] = None
+
+
+class _FakeTransferWorker:
+    def __init__(self) -> None:
+        self.sweep_count = 0
+
+    def sweep_stale_req_infos(self) -> None:
+        self.sweep_count += 1
+
+
+class _FakeSession:
+    def __init__(
+        self,
+        rid: int,
+        wait_result: Optional[WaitResult],
+        *,
+        status: SessionStatus = SessionStatus.READY,
+        is_completed: bool = False,
+        has_failed: bool = False,
+    ) -> None:
+        self._rid = rid
+        self._wait_result = wait_result
+        self._status = status
+        self._is_completed = is_completed
+        self._has_failed = has_failed
+        self.blocking_calls: list[bool] = []
+        self.closed = False
+
+    @property
+    def disagg_request_id(self) -> int:
+        return self._rid
+
+    @property
+    def status(self) -> SessionStatus:
+        return self._status
+
+    def wait_complete(self, blocking: bool = True) -> Optional[WaitResult]:
+        self.blocking_calls.append(blocking)
+        return self._wait_result
+
+    def is_completed(self) -> bool:
+        return self._is_completed
+
+    def has_failed(self) -> bool:
+        return self._has_failed
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeTask:
+    def __init__(self, status: TaskStatus, wait_result: bool = True) -> None:
+        self.status = status
+        self._wait_result = wait_result
+        self.wait_calls: list[Optional[float]] = []
+
+    def wait(self, timeout: Optional[float] = None) -> bool:
+        self.wait_calls.append(timeout)
+        return self._wait_result
+
+
+def _make_transceiver(
+    sessions: dict[int, _FakeSession],
+    reqs: Optional[dict[int, _FakeRequest]] = None,
+) -> KvCacheTransceiverV2:
+    transceiver = object.__new__(KvCacheTransceiverV2)
+    transceiver._send_sessions = sessions
+    transceiver._send_reqs = reqs or {rid: _FakeRequest() for rid in sessions}
+    transceiver._sender_future_timeout_ms = 123
+    transceiver._transfer_worker = _FakeTransferWorker()
+    transceiver._ctx_consensus = lambda local_ids: list(local_ids)
+    transceiver._ctx_consensus_outcome = (
+        lambda _to_process, cancelled, failed, completed, timed_out: (
+            cancelled,
+            failed,
+            completed,
+            timed_out,
+        )
+    )
+    return transceiver
+
+
+def _make_tx_session(
+    kv_tasks: list[_FakeTask],
+    *,
+    need_aux: bool = False,
+    aux_task: Optional[_FakeTask] = None,
+) -> TxSession:
+    session = object.__new__(TxSession)
+    session._timeout_s = 0.25
+    session._need_aux = need_aux
+    session._terminal_status = None
+    session.receiver_ready = True
+    session.kv_tasks = kv_tasks
+    session.aux_task = aux_task
+    session._closed = False
+    session._aux_buffer = None
+    session.aux_slot = None
+    session._sender = None
+    return session
+
+
+def test_context_transfer_status_bounded_poll_keeps_not_ready_session_queued() -> None:
+    session = _FakeSession(rid=11, wait_result=None)
+    transceiver = _make_transceiver({11: session})
+
+    completed, failed = transceiver.check_context_transfer_status(at_least_request_num=1)
+
+    assert completed == []
+    assert failed == []
+    assert session.blocking_calls == [False]
+    assert not session.closed
+    assert 11 in transceiver._send_sessions
+    assert 11 in transceiver._send_reqs
+    assert transceiver._transfer_worker.sweep_count == 1
+
+
+def test_context_transfer_status_block_all_uses_blocking_wait() -> None:
+    session = _FakeSession(rid=12, wait_result=WaitResult.COMPLETED)
+    req = _FakeRequest()
+    transceiver = _make_transceiver({12: session}, {12: req})
+
+    completed, failed = transceiver.check_context_transfer_status(
+        at_least_request_num=None,
+        mark_complete=True,
+    )
+
+    assert completed == [12]
+    assert failed == []
+    assert session.blocking_calls == [True]
+    assert session.closed
+    assert req.state == LlmRequestState.DISAGG_CONTEXT_COMPLETE
+    assert 12 not in transceiver._send_sessions
+    assert 12 not in transceiver._send_reqs
+
+
+def test_context_transfer_status_zero_budget_processes_task_level_failure() -> None:
+    session = _FakeSession(
+        rid=13,
+        wait_result=WaitResult.FAILED,
+        has_failed=True,
+    )
+    req = _FakeRequest()
+    transceiver = _make_transceiver({13: session}, {13: req})
+
+    completed, failed = transceiver.check_context_transfer_status(at_least_request_num=0)
+
+    assert completed == []
+    assert failed == [13]
+    assert session.blocking_calls == [False]
+    assert session.closed
+    assert req.state == LlmRequestState.DISAGG_TRANS_ERROR
+    assert 13 not in transceiver._send_sessions
+    assert 13 not in transceiver._send_reqs
+
+
+def test_tx_session_wait_complete_defaults_to_blocking() -> None:
+    task = _FakeTask(TaskStatus.INIT, wait_result=False)
+    session = _make_tx_session([task])
+
+    assert session.wait_complete() == WaitResult.TIMEOUT
+    assert task.wait_calls == [0.25]
+
+
+def test_tx_session_wait_complete_nonblocking_returns_none_without_waiting() -> None:
+    task = _FakeTask(TaskStatus.TRANSFERRING)
+    session = _make_tx_session([task])
+
+    assert session.wait_complete(blocking=False) is None
+    assert task.wait_calls == []
+
+
+def test_tx_session_has_failed_reports_task_error() -> None:
+    task = _FakeTask(TaskStatus.ERROR)
+    session = _make_tx_session([task])
+
+    assert session.has_failed()

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -1741,6 +1741,7 @@ class TestStrictBaseModelArbitraryArgs:
                                         max_tokens_in_buffer=1024)
         assert config.backend == "UCX"
         assert config.max_tokens_in_buffer == 1024
+        assert config.kv_transfer_poll_interval_ms == 5000
 
         # Arbitrary arguments should be rejected
         with pytest.raises(

--- a/tests/unittest/others/test_kv_cache_transceiver.py
+++ b/tests/unittest/others/test_kv_cache_transceiver.py
@@ -518,7 +518,10 @@ def test_context_transfer_bounded_poll_keeps_request_in_progress(capfd):
     kv_cache_manager_gen = create_kv_cache_manager(mapping, DataType.HALF)
 
     cache_transceiver_config = CacheTransceiverConfig(
-        backend="DEFAULT", max_tokens_in_buffer=512, kv_transfer_timeout_ms=100)
+        backend="DEFAULT",
+        max_tokens_in_buffer=512,
+        kv_transfer_timeout_ms=100,
+        kv_transfer_sender_future_timeout_ms=10)
     transceiver_ctx = create_kv_cache_transceiver(mapping, dist,
                                                   kv_cache_manager_ctx,
                                                   AttentionTypeCpp.DEFAULT,

--- a/tests/unittest/others/test_kv_cache_transceiver.py
+++ b/tests/unittest/others/test_kv_cache_transceiver.py
@@ -26,6 +26,10 @@ from tensorrt_llm.sampling_params import SamplingParams
 AttentionTypeCpp = tensorrt_llm.bindings.internal.batch_manager.AttentionType
 LlmRequestType = tensorrt_llm.bindings.internal.batch_manager.LlmRequestType
 DataType = tensorrt_llm.bindings.DataType
+DEFAULT_KV_TRANSFER_TIMEOUT_S = (
+    CacheTransceiverConfig.model_fields["kv_transfer_timeout_ms"].default /
+    1000.0)
+KV_TRANSFER_COMPLETION_MARGIN_S = 10.0
 
 
 def create_kv_cache_manager(mapping, dtype):
@@ -52,6 +56,32 @@ def fill_kv_cache_buffer(kv_cache_manager):
                                    dtype=torch.float32,
                                    device=buffer.device)
         buffer.copy_(random_values)
+
+
+def wait_for_transfer_completion(poll_fn,
+                                 is_done_fn,
+                                 timeout_s=DEFAULT_KV_TRANSFER_TIMEOUT_S +
+                                 KV_TRANSFER_COMPLETION_MARGIN_S):
+    """Poll until KV cache transfer completes or timeout expires.
+
+    Args:
+        poll_fn: Callable invoked each loop to drive transfer progress.
+        is_done_fn: Callable returning True when transfer is complete.
+        timeout_s: Seconds to wait before asserting failure.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        poll_fn()
+        if is_done_fn():
+            return
+        time.sleep(0.01)
+    poll_fn()
+    assert is_done_fn(), "Timed out waiting for KV cache transfer completion"
+
+
+def shutdown_transceivers(*transceivers):
+    for transceiver in transceivers:
+        transceiver.shutdown()
 
 
 @pytest.fixture(scope="function")
@@ -101,66 +131,86 @@ def test_kv_cache_transceiver_single_process(ctx_gen_kv_cache_dtype,
         mapping, dist, kv_cache_manager_gen, attention_type,
         cache_transceiver_config)
 
-    fill_kv_cache_buffer(kv_cache_manager_ctx)
+    try:
+        fill_kv_cache_buffer(kv_cache_manager_ctx)
 
-    # init ctx request
-    sampling_params = SamplingParams()
-    ctx_request = LlmRequest(
-        request_id=0,
-        max_new_tokens=1,
-        input_tokens=list(range(256)),
-        sampling_config=tensorrt_llm.bindings.SamplingConfig(
-            sampling_params._get_sampling_config()),
-        is_streaming=False,
-        llm_request_type=LlmRequestType.LLMREQUEST_TYPE_CONTEXT_ONLY)
+        # init ctx request
+        sampling_params = SamplingParams()
+        ctx_request = LlmRequest(
+            request_id=0,
+            max_new_tokens=1,
+            input_tokens=list(range(256)),
+            sampling_config=tensorrt_llm.bindings.SamplingConfig(
+                sampling_params._get_sampling_config()),
+            is_streaming=False,
+            llm_request_type=LlmRequestType.LLMREQUEST_TYPE_CONTEXT_ONLY)
 
-    if transceiver_runtime == "PYTHON":
-        disaggregated_params = tensorrt_llm.DisaggregatedParams(
-            request_type="context_only",
-            disagg_request_id=uuid.uuid4().int & 0x7FFFFFFFFFFFFFFF)
-        ctx_request.py_disaggregated_params = disaggregated_params
+        if transceiver_runtime == "PYTHON":
+            disaggregated_params = tensorrt_llm.DisaggregatedParams(
+                request_type="context_only",
+                disagg_request_id=uuid.uuid4().int & 0x7FFFFFFFFFFFFFFF)
+            ctx_request.py_disaggregated_params = disaggregated_params
 
-    kv_cache_manager_ctx.impl.add_sequence_batch(
-        [(ctx_request.py_request_id, ctx_request.prompt_len, 1)], [ctx_request])
-    # send ctx request
-    kv_cache_transceiver_ctx.respond_and_send_async(ctx_request)
+        kv_cache_manager_ctx.impl.add_sequence_batch(
+            [(ctx_request.py_request_id, ctx_request.prompt_len, 1)],
+            [ctx_request])
+        # send ctx request
+        kv_cache_transceiver_ctx.respond_and_send_async(ctx_request)
 
-    # init gen request
-    gen_request = LlmRequest(
-        request_id=0,
-        max_new_tokens=1,
-        input_tokens=list(range(256)),
-        sampling_config=tensorrt_llm.bindings.SamplingConfig(
-            sampling_params._get_sampling_config()),
-        is_streaming=False,
-        llm_request_type=LlmRequestType.LLMREQUEST_TYPE_GENERATION_ONLY,
-        context_phase_params=ctx_request.context_phase_params)
+        # init gen request
+        gen_request = LlmRequest(
+            request_id=0,
+            max_new_tokens=1,
+            input_tokens=list(range(256)),
+            sampling_config=tensorrt_llm.bindings.SamplingConfig(
+                sampling_params._get_sampling_config()),
+            is_streaming=False,
+            llm_request_type=LlmRequestType.LLMREQUEST_TYPE_GENERATION_ONLY,
+            context_phase_params=ctx_request.context_phase_params)
 
-    if transceiver_runtime == "PYTHON":
-        disaggregated_params = tensorrt_llm.DisaggregatedParams(
-            request_type="generation_only",
-            disagg_request_id=ctx_request.py_disaggregated_params.
-            disagg_request_id,
-            ctx_request_id=ctx_request.request_id,
-            ctx_dp_rank=ctx_request.context_phase_params.ctx_dp_rank,
-            ctx_info_endpoint=ctx_request.context_phase_params.
-            disagg_info_endpoint,
-            first_gen_tokens=ctx_request.context_phase_params.first_gen_tokens,
-            draft_tokens=ctx_request.context_phase_params.draft_tokens)
+        if transceiver_runtime == "PYTHON":
+            disaggregated_params = tensorrt_llm.DisaggregatedParams(
+                request_type="generation_only",
+                disagg_request_id=ctx_request.py_disaggregated_params.
+                disagg_request_id,
+                ctx_request_id=ctx_request.request_id,
+                ctx_dp_rank=ctx_request.context_phase_params.ctx_dp_rank,
+                ctx_info_endpoint=ctx_request.context_phase_params.
+                disagg_info_endpoint,
+                first_gen_tokens=ctx_request.context_phase_params.
+                first_gen_tokens,
+                draft_tokens=ctx_request.context_phase_params.draft_tokens)
 
-        gen_request.py_disaggregated_params = disaggregated_params
+            gen_request.py_disaggregated_params = disaggregated_params
 
-    kv_cache_manager_gen.impl.add_sequence_batch(
-        [(gen_request.py_request_id, gen_request.prompt_len, 1)], [gen_request])
-    # send gen request
-    kv_cache_transceiver_gen.request_and_receive_async(gen_request)
+        kv_cache_manager_gen.impl.add_sequence_batch(
+            [(gen_request.py_request_id, gen_request.prompt_len, 1)],
+            [gen_request])
+        # send gen request
+        kv_cache_transceiver_gen.request_and_receive_async(gen_request)
 
-    kv_cache_transceiver_ctx.check_context_transfer_status(1)
-    kv_cache_transceiver_gen.check_gen_transfer_status(1)
+        completed_ctx_ids = set()
 
-    assert torch.equal(
-        kv_cache_manager_gen.get_buffers(0),
-        kv_cache_manager_ctx.get_buffers(0)), "different kv-cache values"
+        def poll_transfers():
+            completed, failed = (
+                kv_cache_transceiver_ctx.check_context_transfer_status(1))
+            assert failed == []
+            completed_ctx_ids.update(completed)
+            kv_cache_transceiver_gen.check_gen_transfer_status(1)
+
+        def transfers_done():
+            return (ctx_request.py_request_id in completed_ctx_ids
+                    and gen_request.state
+                    == LlmRequestState.DISAGG_GENERATION_TRANS_COMPLETE)
+
+        wait_for_transfer_completion(poll_transfers, transfers_done)
+
+        assert torch.equal(
+            kv_cache_manager_gen.get_buffers(0),
+            kv_cache_manager_ctx.get_buffers(0)), "different kv-cache values"
+    finally:
+        shutdown_transceivers(kv_cache_transceiver_gen,
+                              kv_cache_transceiver_ctx)
 
 
 @pytest.mark.timeout(120)
@@ -322,9 +372,29 @@ def test_async_transfer_keeps_llm_request_alive():
         "request_and_receive_async must hold a strong shared_ptr while "
         "the requester future is in flight")
 
+    # Re-acquire temporary strong refs for cleanup after proving the in-flight
+    # futures owned the requests. Once a future is erased, the weakref may
+    # legitimately clear.
+    ctx_request = ctx_ref()
+    gen_request = gen_ref()
+    assert ctx_request is not None
+    assert gen_request is not None
+
     # Drive the transfer to completion so the harness tears down cleanly.
-    transceiver_ctx.check_context_transfer_status(1)
-    transceiver_gen.check_gen_transfer_status(1)
+    completed_ctx_ids = set()
+
+    def poll_transfers():
+        completed, failed = transceiver_ctx.check_context_transfer_status(1)
+        assert failed == []
+        completed_ctx_ids.update(completed)
+        transceiver_gen.check_gen_transfer_status(1)
+
+    def transfers_done():
+        return (ctx_request.py_request_id in completed_ctx_ids
+                and gen_request.state
+                == LlmRequestState.DISAGG_GENERATION_TRANS_COMPLETE)
+
+    wait_for_transfer_completion(poll_transfers, transfers_done)
 
 
 def _build_ctx_request_for_timeout_test(request_id: int) -> LlmRequest:
@@ -426,6 +496,76 @@ def test_kv_transfer_timeout_silent_when_unset(capfd):
         f"unset; stdout:\n{out.out}")
 
     transceiver_ctx.cancel_request(ctx_request)
+
+
+@pytest.mark.timeout(120)
+def test_context_transfer_bounded_poll_keeps_request_in_progress():
+    """A bounded transfer poll must not make a non-ready request terminal."""
+    mapping = Mapping(world_size=1, rank=0)
+    dist = Distributed.get(mapping)
+    kv_cache_manager_ctx = create_kv_cache_manager(mapping, DataType.HALF)
+    kv_cache_manager_gen = create_kv_cache_manager(mapping, DataType.HALF)
+
+    cache_transceiver_config = CacheTransceiverConfig(backend="DEFAULT",
+                                                      max_tokens_in_buffer=512)
+    transceiver_ctx = create_kv_cache_transceiver(mapping, dist,
+                                                  kv_cache_manager_ctx,
+                                                  AttentionTypeCpp.DEFAULT,
+                                                  cache_transceiver_config)
+    transceiver_gen = create_kv_cache_transceiver(mapping, dist,
+                                                  kv_cache_manager_gen,
+                                                  AttentionTypeCpp.DEFAULT,
+                                                  cache_transceiver_config)
+
+    fill_kv_cache_buffer(kv_cache_manager_ctx)
+
+    ctx_request = _build_ctx_request_for_timeout_test(request_id=100)
+    kv_cache_manager_ctx.impl.add_sequence_batch(
+        [(ctx_request.py_request_id, ctx_request.prompt_len, 1)], [ctx_request])
+
+    transceiver_ctx.respond_and_send_async(ctx_request)
+
+    start = time.monotonic()
+    completed_request_ids, error_request_ids = (
+        transceiver_ctx.check_context_transfer_status(1))
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 1.0, (
+        f"Bounded poll should yield back to the executor quickly; "
+        f"elapsed={elapsed:.3f}s")
+    assert completed_request_ids == []
+    assert error_request_ids == []
+    assert ctx_request.state == LlmRequestState.DISAGG_CONTEXT_TRANS_IN_PROGRESS
+
+    sampling_params = SamplingParams()
+    gen_request = LlmRequest(
+        request_id=100,
+        max_new_tokens=1,
+        input_tokens=list(range(256)),
+        sampling_config=tensorrt_llm.bindings.SamplingConfig(
+            sampling_params._get_sampling_config()),
+        is_streaming=False,
+        llm_request_type=LlmRequestType.LLMREQUEST_TYPE_GENERATION_ONLY,
+        context_phase_params=ctx_request.context_phase_params)
+
+    kv_cache_manager_gen.impl.add_sequence_batch(
+        [(gen_request.py_request_id, gen_request.prompt_len, 1)], [gen_request])
+    transceiver_gen.request_and_receive_async(gen_request)
+
+    completed_ctx_ids = set()
+
+    def poll_transfers():
+        completed, failed = transceiver_ctx.check_context_transfer_status(1)
+        assert failed == []
+        completed_ctx_ids.update(completed)
+        transceiver_gen.check_gen_transfer_status(1)
+
+    def transfers_done():
+        return (ctx_request.py_request_id in completed_ctx_ids
+                and gen_request.state
+                == LlmRequestState.DISAGG_GENERATION_TRANS_COMPLETE)
+
+    wait_for_transfer_completion(poll_transfers, transfers_done)
 
 
 def create_hybrid_cache_manager(mapping,
@@ -628,8 +768,21 @@ def test_hybrid_cache_transceiver_single_process(backend, hybrid_dtypes,
 
     cache_transceiver_gen.request_and_receive_async(gen_request)
 
-    cache_transceiver_ctx.check_context_transfer_status(1)
-    cache_transceiver_gen.check_gen_transfer_status(1)
+    completed_ctx_ids = set()
+
+    def poll_transfers():
+        completed, failed = cache_transceiver_ctx.check_context_transfer_status(
+            1)
+        assert failed == []
+        completed_ctx_ids.update(completed)
+        cache_transceiver_gen.check_gen_transfer_status(1)
+
+    def transfers_done():
+        return (ctx_request.py_request_id in completed_ctx_ids
+                and gen_request.state
+                == LlmRequestState.DISAGG_GENERATION_TRANS_COMPLETE)
+
+    wait_for_transfer_completion(poll_transfers, transfers_done)
 
     assert torch.equal(
         hybrid_cache_manager_gen.get_buffers(0),

--- a/tests/unittest/others/test_kv_cache_transceiver.py
+++ b/tests/unittest/others/test_kv_cache_transceiver.py
@@ -510,15 +510,15 @@ def test_kv_transfer_timeout_silent_when_unset(capfd):
 
 
 @pytest.mark.timeout(120)
-def test_context_transfer_bounded_poll_keeps_request_in_progress():
+def test_context_transfer_bounded_poll_keeps_request_in_progress(capfd):
     """A bounded transfer poll must not make a non-ready request terminal."""
     mapping = Mapping(world_size=1, rank=0)
     dist = Distributed.get(mapping)
     kv_cache_manager_ctx = create_kv_cache_manager(mapping, DataType.HALF)
     kv_cache_manager_gen = create_kv_cache_manager(mapping, DataType.HALF)
 
-    cache_transceiver_config = CacheTransceiverConfig(backend="DEFAULT",
-                                                      max_tokens_in_buffer=512)
+    cache_transceiver_config = CacheTransceiverConfig(
+        backend="DEFAULT", max_tokens_in_buffer=512, kv_transfer_timeout_ms=100)
     transceiver_ctx = create_kv_cache_transceiver(mapping, dist,
                                                   kv_cache_manager_ctx,
                                                   AttentionTypeCpp.DEFAULT,
@@ -561,7 +561,15 @@ def test_context_transfer_bounded_poll_keeps_request_in_progress():
 
     kv_cache_manager_gen.impl.add_sequence_batch(
         [(gen_request.py_request_id, gen_request.prompt_len, 1)], [gen_request])
+
+    capfd.readouterr()
     transceiver_gen.request_and_receive_async(gen_request)
+    transceiver_gen.check_gen_transfer_status(0)
+    out = capfd.readouterr()
+    marker = "Generation KV cache transfer for request 100 exceeded configured timeout"
+    assert marker not in out.out, (
+        f"Generation transfer timeout WARN fired before the request had "
+        f"actually timed out; stdout:\n{out.out}")
 
     completed_ctx_ids = set()
 

--- a/tests/unittest/others/test_kv_cache_transceiver.py
+++ b/tests/unittest/others/test_kv_cache_transceiver.py
@@ -84,6 +84,15 @@ def shutdown_transceivers(*transceivers):
         transceiver.shutdown()
 
 
+def get_context_completed_request_id(request, transceiver_runtime):
+    if transceiver_runtime == "PYTHON":
+        assert request.py_disaggregated_params is not None
+        disagg_request_id = request.py_disaggregated_params.disagg_request_id
+        assert disagg_request_id is not None
+        return disagg_request_id
+    return request.py_request_id
+
+
 @pytest.fixture(scope="function")
 def ctx_gen_kv_cache_dtype(request):
     if request.param == "ctx_fp8_gen_fp8":
@@ -198,9 +207,11 @@ def test_kv_cache_transceiver_single_process(ctx_gen_kv_cache_dtype,
             completed_ctx_ids.update(completed)
             kv_cache_transceiver_gen.check_gen_transfer_status(1)
 
+        expected_ctx_id = get_context_completed_request_id(
+            ctx_request, transceiver_runtime)
+
         def transfers_done():
-            return (ctx_request.py_request_id in completed_ctx_ids
-                    and gen_request.state
+            return (expected_ctx_id in completed_ctx_ids and gen_request.state
                     == LlmRequestState.DISAGG_GENERATION_TRANS_COMPLETE)
 
         wait_for_transfer_completion(poll_transfers, transfers_done)


### PR DESCRIPTION
## Summary

Bound disaggregated KV transfer status polling across the C++ and V2/Python transceiver paths, and add explicit disagg transfer-admission throttling.

This PR is intended to be the merge vehicle for the bounded C++ polling stack plus the V2/Python-transceiver and admission-control follow-up. The goal is to keep finite scheduler polls bounded/nonblocking while restoring explicit transfer-admission backpressure so bursty request traffic does not place too many requests into transfer-in-progress with timeout clocks already running.

## Dependency graph

Arrows point from prerequisite to dependent. PR numbers in graph nodes are clickable.

```mermaid
graph TD
    PR15139["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15139'>#15139</a>: transfer state consensus (merged)"]
    PR15356["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15356'>#15356</a>: bounded transfer polling + admission control (this PR, inflight)"]
    PR15238["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15238'>#15238</a>: in-flight cancellation + buffer poison (draft)"]
    WORK_BLOCKALL["blockAll / wait-all cancellation (planned)"]
    WORK_BUFFER["multi-slot buffers + unpoison recovery (planned)"]

    PR15139 -->|satisfied| PR15356
    PR15356 -->|blocking| PR15238
    PR15238 -.->|planned| WORK_BLOCKALL
    PR15238 -.->|planned| WORK_BUFFER

    classDef merged fill:#dcfce7,stroke:#16a34a,color:#14532d;
    classDef draft fill:#ffedd5,stroke:#f97316,color:#7c2d12;
    classDef current fill:#ede9fe,stroke:#7c3aed,color:#3b0764,stroke-width:3px;
    classDef downstream fill:#f3f4f6,stroke:#6b7280,color:#374151,stroke-dasharray:5 5;
    linkStyle 0 stroke:#16a34a,stroke-width:2px;
    linkStyle 1 stroke:#ea580c,stroke-width:3px;
    linkStyle 2,3 stroke:#6b7280,stroke-width:2px,stroke-dasharray:5 5;

    class PR15139 merged;
    class PR15356 current;
    class PR15238 draft;
    class WORK_BLOCKALL,WORK_BUFFER downstream;
```

## Behavior

- Bound finite disagg context/generation transfer status polling so scheduler polls do not become unbounded completion barriers.
- Preserve drain-all behavior for nullopt/None status checks.
- Add an explicit `blocking` argument to V2 `TxSession.wait_complete()`.
- Preserve the raw TxSession API default as blocking, so existing direct transfer tests and callers keep their previous completion-barrier behavior.
- Make `KvCacheTransceiverV2.check_context_transfer_status(at_least_request_num=...)` use nonblocking TxSession polling for bounded scheduler polls.
- Treat `None` from the nonblocking TxSession poll as "not ready yet"; the request remains queued and is polled again later.
- Keep transfer-status polling rank-consistent for the PyExecutor paths, including CP/PP cases where local state can otherwise diverge.

## Transfer admission throttle

This PR adds explicit disaggregated-generation transfer admission control so bounded / nonblocking polling does not admit an unbounded burst of requests into transfer-in-progress with timeout clocks already running.

CapacityScheduler still chooses the candidate disagg-init set. The admission gate then admits only the longest FCFS prefix that fits an estimated transfer-block budget. Active `DISAGG_GENERATION_TRANS_IN_PROGRESS` requests count against that budget. If the first queued request is larger than the budget and no transfer is active, the gate admits that single request to avoid permanent head-of-line blocking.

The initial policy is modular (`DisaggTransferAdmissionController::Policy::kFcfsEstimatedBlockBudget`) so future policies can be added without reshaping the executor loop. The budget is derived from `cache_transceiver_config.max_tokens_in_buffer`, rounded to KV blocks by `tokens_per_block`; when no positive budget is configured, the path falls back to the previous behavior.

## Perf comparison

Compared with the latest main and recent main median for the Qwen / DeepSeek HELIX tests that previously exposed the burst-admission issue:

| Test | This PR | Latest main | Delta vs latest main | Recent main median | Delta vs median |
|---|---:|---:|---:|---:|---:|
| Qwen `pp1tp1cp4` | 190.9s | 194.8s | 3.8s faster | 189.2s | 1.7s slower |
| Qwen `pp1tp2cp2` | 184.3s | 188.9s | 4.6s faster | 187.9s | 3.6s faster |
| DeepSeek `pp1tp1cp4` | 537.0s | 584.0s | 46.9s faster | 569.0s | 31.9s faster |
| DeepSeek `pp1tp2cp2` | 534.3s | 509.3s | 25.0s slower | 546.6s | 12.2s faster |

Conclusion: admission control did not regress the perf for the test.

## Test coverage

- C++ unit coverage for bounded transceiver polling, transfer timing, active-transfer scheduler accounting, and admission-control block-budget behavior.
- Python unit coverage for V2 bounded polling, nonblocking task-error polling, PyExecutor admission gating, global/CP-consistent transfer-cost estimation, and rank-consistent transfer-status entry.
- Config/binding/serialization coverage for the new transfer polling/admission fields.
- Integration coverage for the targeted Qwen and DeepSeek HELIX disaggregated-serving cases that previously failed under burst admission.

Focused local pytest was blocked in this environment by missing `transformers` during repo import.
