### PR TITLE
[None][infra] pin pytest and click workaround

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,7 +9,7 @@ parameterized
 pre-commit
 pybind11
 pybind11-stubgen
-pytest
+pytest<9.1
 pytest-asyncio
 pytest-cov
 pytest-csv

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ optimum
 datasets==3.1.0
 evaluate
 mpmath>=1.3.0
-click
+click>=8.3.1,<8.4
 click_option_group
 aenum
 pyzmq


### PR DESCRIPTION
## Summary

- Pin `pytest<9.1` in `requirements-dev.txt` as a quick workaround for the recent pytest compatibility failures.
- Constrain `click>=8.3.1,<8.4` in `requirements.txt` so installs satisfy `spin 0.17` while still meeting the repo's `click>=8.3.0` tooling requirement.

## Root Cause

Recent dependency resolution can select versions that expose CI failures:

- Newer pytest behavior trips existing collection-time parametrization issues.
- `click 8.4.1` conflicts with `spin 0.17`, which requires `click>=8,<8.4,!=8.3.0`.

This PR is a minimal dependency workaround while the source-level pytest fixes are handled separately.

## Validation

- `git diff --check -- requirements.txt requirements-dev.txt`
- Verified the chosen specifiers allow `click 8.3.1` and `pytest 9.0.x`, while excluding `click 8.4.1` and `pytest 9.1.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `pytest` development dependency with version constraints
  * Pinned `click` dependency to a specific version range

<!-- end of auto-generated comment: release notes by coderabbit.ai -->