### PR TITLE
[https://nvbugs/6179661][fix] Fix disagg generation-side KV transfer timeout deadlocks and teardown crashes

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
+++ b/cpp/include/tensorrt_llm/batch_manager/cacheTransceiver.h
@@ -285,7 +285,6 @@ private:
     // request while a C++ status check still dereferences it.
     std::vector<std::pair<std::shared_ptr<LlmRequest>, std::future<void>>> mSenderFutures;
     std::vector<std::pair<std::shared_ptr<LlmRequest>, std::future<void>>> mRequesterFutures;
-    // Dedup sets so observe-only timeout WARN logs fire at most once per stuck request.
     std::unordered_set<LlmRequest::RequestIdType> mTimedOutSenderIds;
     std::unordered_set<LlmRequest::RequestIdType> mTimedOutRequesterIds;
     std::unordered_set<LlmRequest::RequestIdType> mCompletedSenderRequestIds;
@@ -294,6 +293,10 @@ private:
     std::unordered_set<LlmRequest::RequestIdType> mCompletedRequesterRequestIds;
     std::unordered_set<LlmRequest::RequestIdType> mFailedRequesterRequestIds;
     std::unordered_map<LlmRequest::RequestIdType, std::shared_ptr<LlmRequest>> mRequesterRequestsAwaitingConsensus;
+    // checkGenTransferStatus bounded-poll metrics, logged on budget exhaustion.
+    size_t mGenPollWaitedCalls{0};
+    size_t mGenPollWaitedIterationsTotal{0};
+    size_t mGenPollBudgetExhaustedCount{0};
     mpi::MpiComm const* mMpiWorldComm{nullptr};
 
     std::shared_ptr<CacheTransceiverComm> mGroupComm;

--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -53,8 +53,10 @@
 #include "tensorrt_llm/runtime/utils/mpiUtils.h"
 #include "tensorrt_llm/runtime/utils/pgUtils.h"
 #include <algorithm>
+#include <chrono>
 #include <cstddef>
 #include <numeric>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -508,6 +510,11 @@ CacheTransceiver::CacheTransceiver(kv_cache_manager::BaseKVCacheManager* cacheMa
 
 CacheTransceiver::~CacheTransceiver()
 {
+    // Join sender/receiver background threads while mManager (declared later,
+    // destroyed earlier) is still alive; otherwise the sender's response
+    // thread can dereference the destroyed manager and segfault on teardown.
+    mCacheSender.reset();
+    mCacheReceiver.reset();
     if (mWrapperLibHandle)
     {
         std::lock_guard<std::mutex> lock(mDllMutex);
@@ -866,123 +873,74 @@ RequestStatuses CacheTransceiver::checkContextTransferStatus(
 
 void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastRequestNum)
 {
-    bool blockAll = !atLeastRequestNum.has_value();
-    std::vector<LlmRequest::RequestIdType> genTransferReadyRequestIds;
-    for (auto&& [request, future] : mRequesterFutures)
-    {
-        if (future.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready)
-        {
-            genTransferReadyRequestIds.push_back(request->mRequestId);
-        }
-    }
-    std::unordered_map<LlmRequest::RequestIdType, int> frequencyMap;
+    // Bounded poll instead of unbounded future::get(): a stalled transfer must
+    // not wedge this rank while sibling ranks advance to the next collective.
+    // Cross-rank agreement on the committed outcome is handled by
+    // reduceTransferStates below, so the poll itself is purely local -- only
+    // futures that are already ready are completed; the rest are left in flight
+    // for later calls or kv-transfer-timeout handling.
+    static constexpr int kMaxPollIterations = 32;
+    static constexpr auto kPollInterval = std::chrono::milliseconds(2);
 
-    std::vector<LlmRequest::RequestIdType> toBlockRequestIds;
     auto syncComm = mCacheState->getParallelConfig().mEnableAttentionDP ? mGroupDataComm : mGroupComm;
-    if ((syncComm) && syncComm->getSize() > 1)
-    {
-        auto gatherRequestIdVec = gatherRequestIds(syncComm, genTransferReadyRequestIds);
-        for (auto&& requestId : gatherRequestIdVec)
-        {
-            frequencyMap[requestId]++;
-        }
-    }
-    else
-    {
-        for (auto&& requestId : genTransferReadyRequestIds)
-        {
-            frequencyMap[requestId]++;
-        }
-    }
+    int const dbgRank = useMPI() ? mpi::MpiComm::world().getRank() : tensorrt_llm::pg_utils::get_world_pg()->getRank();
 
-    std::vector<std::pair<LlmRequest::RequestIdType, int>> freqVec(frequencyMap.begin(), frequencyMap.end());
-
-    std::sort(freqVec.begin(), freqVec.end(),
-        [](std::pair<LlmRequest::RequestIdType, int> const& left,
-            std::pair<LlmRequest::RequestIdType, int> const& right) { return left.second > right.second; });
-    std::unordered_set<LlmRequest::RequestIdType> toCompleteIdSet;
-    size_t idx = 0;
-    while (atLeastRequestNum.value_or(0) > static_cast<int>(toCompleteIdSet.size()))
+    auto countReadyFutures = [this]()
     {
-        if (idx >= freqVec.size())
+        int ready = 0;
+        for (auto&& [request, future] : mRequesterFutures)
         {
-            break;
-        }
-        toCompleteIdSet.insert(freqVec.at(idx).first);
-        if (useMPI())
-        {
-            TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
-                " checkGenTransferStatus at least from freqVec requestId: %zu ", freqVec.at(idx).first);
-        }
-        else
-        {
-            TLLM_LOG_DEBUG(tensorrt_llm::pg_utils::get_world_pg()->getRank(),
-                " checkGenTransferStatus at least from freqVec requestId: %zu ", freqVec.at(idx).first);
-        }
-        idx++;
-    }
-    idx = 0;
-
-    // insert order
-    while (atLeastRequestNum.value_or(0) > static_cast<int>(toCompleteIdSet.size()))
-    {
-        if (idx >= mRequesterFutures.size())
-        {
-            break;
-        }
-        if (toCompleteIdSet.find(mRequesterFutures.at(idx).first->mRequestId) == toCompleteIdSet.end())
-        {
-            toCompleteIdSet.insert(mRequesterFutures.at(idx).first->mRequestId);
-            if (useMPI())
+            if (future.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready)
             {
-                TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
-                    " checkGenTransferStatus at least from RequesterFuture requestId: %zu atLeastRequestNum:%d",
-                    mRequesterFutures.at(idx).first->mRequestId, atLeastRequestNum.value_or(0));
-            }
-            else
-            {
-                TLLM_LOG_DEBUG(tensorrt_llm::pg_utils::get_world_pg()->getRank(),
-                    " checkGenTransferStatus at least from RequesterFuture requestId: %zu atLeastRequestNum:%d",
-                    mRequesterFutures.at(idx).first->mRequestId, atLeastRequestNum.value_or(0));
+                ++ready;
             }
         }
-        idx++;
-    }
-    for (auto&& [requestId, freq] : freqVec)
+        return ready;
+    };
+
+    // atLeastRequestNum asks the caller to make progress on at least that many
+    // transfers; wait for them with a capped budget instead of blocking. A
+    // missing value keeps the legacy "drain everything" intent (bounded by the
+    // poll budget) so callers polling until checkGenTransferComplete() converge.
+    int const target = std::min(atLeastRequestNum.value_or(static_cast<int>(mRequesterFutures.size())),
+        static_cast<int>(mRequesterFutures.size()));
+    int pollIterations = 0;
+    int readyCount = countReadyFutures();
+    while (readyCount < target && pollIterations < kMaxPollIterations - 1)
     {
-        if (freq == ((syncComm != nullptr) ? syncComm->getSize() : 1))
-        {
-            toCompleteIdSet.insert(requestId);
-        }
-        if (useMPI())
-        {
-            TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(), " checkGenTransferStatus freqVec requestId: %zu,freq:%d  ",
-                requestId, freq);
-        }
-        else
-        {
-            TLLM_LOG_DEBUG(tensorrt_llm::pg_utils::get_world_pg()->getRank(),
-                " checkGenTransferStatus freqVec requestId: %zu,freq:%d  ", requestId, freq);
-        }
+        ++pollIterations;
+        std::this_thread::sleep_for(kPollInterval);
+        readyCount = countReadyFutures();
     }
-    if (useMPI())
+
+    if (pollIterations > 0)
     {
-        TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
-            " checkGenTransferStatus toCompleteIdSet size: %zu, atLeastRequestNum: %d ", toCompleteIdSet.size(),
-            atLeastRequestNum.value_or(0));
+        ++mGenPollWaitedCalls;
+        mGenPollWaitedIterationsTotal += pollIterations;
     }
-    else
+    if (readyCount < target)
     {
-        TLLM_LOG_DEBUG(tensorrt_llm::pg_utils::get_world_pg()->getRank(),
-            " checkGenTransferStatus toCompleteIdSet size: %zu, atLeastRequestNum: %d ", toCompleteIdSet.size(),
-            atLeastRequestNum.value_or(0));
+        ++mGenPollBudgetExhaustedCount;
+        TLLM_LOG_WARNING(
+            "checkGenTransferStatus: poll budget exhausted (%d iterations of %ld ms): %d/%d transfers ready, "
+            "%zu in flight; leaving the rest for later checks or kv-transfer-timeout handling "
+            "(budget exhausted %zu times, waited in %zu calls, %zu poll iterations in total).",
+            kMaxPollIterations, static_cast<long>(kPollInterval.count()), readyCount, target, mRequesterFutures.size(),
+            mGenPollBudgetExhaustedCount, mGenPollWaitedCalls, mGenPollWaitedIterationsTotal);
     }
+    TLLM_LOG_DEBUG(dbgRank, " checkGenTransferStatus readyCount: %d, atLeastRequestNum: %d, pollIterations: %d ",
+        readyCount, atLeastRequestNum.value_or(0), pollIterations);
+
     // Observe-only: gen-side mirror of the context-side timeout WARN.
     std::optional<int> kvTransferTimeoutMs = std::nullopt;
     if (mCacheTransceiverConfig.has_value())
     {
         kvTransferTimeoutMs = mCacheTransceiverConfig->getKvTransferTimeoutMs();
     }
+    // Complete only the futures that are already ready (get() returns
+    // immediately); record the local outcome so reduceTransferStates can commit
+    // it once every rank agrees. A not-yet-ready future is never blocked on and
+    // is revisited on the next call.
     for (auto it = mRequesterFutures.begin(); it != mRequesterFutures.end();)
     {
         auto& request = it->first;
@@ -992,53 +950,41 @@ void CacheTransceiver::checkGenTransferStatus(std::optional<int> const& atLeastR
             auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
                 LlmRequest::getSteadyClockNow() - request->getKvCacheTransferStart());
             auto elapsedMs = static_cast<long>(elapsed.count());
-            if (elapsedMs > kvTransferTimeoutMs.value() && mTimedOutRequesterIds.insert(request->mRequestId).second)
+            if (elapsedMs > kvTransferTimeoutMs.value() && mTimedOutRequesterIds.insert(requestId).second)
             {
                 TLLM_LOG_WARNING(
                     "Generation KV cache transfer for request %ld exceeded configured timeout: "
                     "elapsed %ld ms > limit %d ms (observe-only).",
-                    request->mRequestId, elapsedMs, kvTransferTimeoutMs.value());
+                    requestId, elapsedMs, kvTransferTimeoutMs.value());
             }
         }
-        if (blockAll || toCompleteIdSet.find(requestId) != toCompleteIdSet.end())
-        {
-            try
-            {
-                it->second.get();
-                bool const failed = request->getState() == LlmRequestState::kDISAGG_TRANS_ERROR;
-                if (failed)
-                {
-                    // The receiver uses the error state as a local transfer-failed signal.
-                    // Keep that signal local until the consensus outcome commits it globally.
-                    request->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_IN_PROGRESS);
-                }
-                recordLocalTransferOutcome(requestId, request, failed, mCompletedRequesterRequestIds,
-                    mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
-            }
-            catch (std::exception const& e)
-            {
-                TLLM_LOG_ERROR("Error occurred during generation transfer for request %ld: %s", requestId, e.what());
-                recordLocalTransferOutcome(requestId, request, /*failed=*/true, mCompletedRequesterRequestIds,
-                    mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
-            }
-            if (useMPI())
-            {
-                TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(),
-                    "**** it->first->mRequestId: %ld, context request ID: %ld ******** get feature ***", requestId,
-                    request->getContextPhaseParams().value().getReqId());
-            }
-            else
-            {
-                TLLM_LOG_DEBUG(tensorrt_llm::pg_utils::get_world_pg()->getRank(),
-                    "**** it->first->mRequestId: %ld, context request ID: %ld ******** get feature ***", requestId,
-                    request->getContextPhaseParams().value().getReqId());
-            }
-            it = mRequesterFutures.erase(it);
-        }
-        else
+        if (it->second.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready)
         {
             ++it;
+            continue;
         }
+        try
+        {
+            it->second.get();
+            bool const failed = request->getState() == LlmRequestState::kDISAGG_TRANS_ERROR;
+            if (failed)
+            {
+                // The receiver uses the error state as a local transfer-failed signal.
+                // Keep that signal local until the consensus outcome commits it globally.
+                request->setState(LlmRequestState::kDISAGG_GENERATION_TRANS_IN_PROGRESS);
+            }
+            recordLocalTransferOutcome(requestId, request, failed, mCompletedRequesterRequestIds,
+                mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
+        }
+        catch (std::exception const& e)
+        {
+            TLLM_LOG_ERROR("Error occurred during generation transfer for request %ld: %s", requestId, e.what());
+            recordLocalTransferOutcome(requestId, request, /*failed=*/true, mCompletedRequesterRequestIds,
+                mFailedRequesterRequestIds, mRequesterRequestsAwaitingConsensus);
+        }
+        TLLM_LOG_DEBUG(dbgRank, "**** it->first->mRequestId: %ld, context request ID: %ld ******** get feature ***",
+            requestId, request->getContextPhaseParams().value().getReqId());
+        it = mRequesterFutures.erase(it);
     }
 
     auto const consensusOutcome

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -361,7 +361,9 @@ public:
         auto const* connection = isAgent
             ? agentConnectionManager->recvConnectionAndRequestInfo(info, mTerminate)
             : mManager->recvConnect(DataContext{TransceiverTag::kID_TAG, mTerminate}, &id, sizeof(id));
-        if (connection == nullptr && !mManager->isRunning())
+        // A null connection only happens on shutdown paths (terminate flag or
+        // manager stopping); bail out before touching the empty RequestInfo.
+        if (connection == nullptr)
         {
             TLLM_LOG_WARNING(" recvRequestInfo connection is nullptr, maybe the server is terminating");
             return info;
@@ -673,6 +675,12 @@ private:
                             break;
                         }
                         it = getCurrentResponse();
+                    }
+                    // Terminating while waiting leaves it == end(); bail out
+                    // instead of dereferencing it inside sendResponse.
+                    if (mTerminate || it == mReadyResponses.end())
+                    {
+                        break;
                     }
                     sendResponse(it);
                 }

--- a/jenkins/scripts/perf/local/submit.py
+++ b/jenkins/scripts/perf/local/submit.py
@@ -820,7 +820,7 @@ def main():
         if is_b200:
             ucx_tls_cmd = "export UCX_TLS=^ib &&"
         else:
-            ucx_tls_cmd = "unset UCX_TLS &&"
+            ucx_tls_cmd = "unset UCX_TLS UCX_NET_DEVICES &&"
         script_prefix_lines.extend(
             [
                 f'export CTX_WORKER_ENV_VARS="{ctx_worker_env_vars}"',

--- a/tensorrt_llm/_torch/pyexecutor/llm_request.py
+++ b/tensorrt_llm/_torch/pyexecutor/llm_request.py
@@ -703,6 +703,7 @@ class LlmRequest(tensorrt_llm.bindings.internal.batch_manager.LlmRequest):
         self.is_cuda_graph_dummy = False
         self.py_kv_transfer_start_time = None
         self.py_kv_transfer_timed_out = False
+        self.py_kv_transfer_cancelled = False
 
         # Performance timing info (step metrics, GPU events, context GPU timing)
         # Lazily created only when return_perf_metrics is enabled to avoid

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -4044,7 +4044,97 @@ class PyExecutor:
             at_least_num = 1 if need_check_one else 0
             self._check_disagg_gen_cache_transfer_status(at_least_num)
 
+        self._cancel_timed_out_gen_transfers()
+
         return
+
+    @nvtx_range("_cancel_timed_out_gen_transfers")
+    def _cancel_timed_out_gen_transfers(self) -> None:
+        """Cancel generation-side transfers that exceeded the transfer timeout.
+
+        Runs on every rank each iteration. The cancel decision and the
+        resulting request-state change must land on the same iteration on
+        every rank, otherwise per-rank KV-block release / scheduling diverges
+        and the next collective deadlocks. Timeout flags are refreshed here so
+        the path also works in loops (e.g. PP) that do not call
+        _check_kv_transfer_timeout for generation requests.
+        """
+        timeout_ms = self.kv_cache_transceiver.kv_transfer_timeout_ms
+        if timeout_ms is None:
+            return
+        in_progress = {
+            req.py_request_id: req
+            for req in self.active_requests
+            if req.is_disagg_generation_transmission_in_progress
+        }
+        # Refresh generation-side timeout flags (mirrors the generation branch
+        # of _check_kv_transfer_timeout) so cancellation does not depend on the
+        # caller having flagged them first.
+        current_time = time.time()
+        for req in in_progress.values():
+            if req.py_kv_transfer_start_time is None:
+                continue
+            elapsed_ms = (current_time - req.py_kv_transfer_start_time) * 1000
+            if elapsed_ms > timeout_ms and not req.py_kv_transfer_timed_out:
+                logger.warning(
+                    f"Terminating generation request {req.py_request_id} due to KV cache transfer timeout"
+                )
+                req.py_kv_transfer_timed_out = True
+        user_canceled = set(self.canceled_req_ids)
+        local_timed_out = sorted(
+            rid for rid, req in in_progress.items()
+            if req.py_kv_transfer_timed_out and rid not in user_canceled)
+
+        if self.dist.tp_size > 1:
+            any_timed_out = self.dist.tp_allreduce(int(bool(local_timed_out)),
+                                                   op=ReduceOp.MAX)
+        else:
+            any_timed_out = int(bool(local_timed_out))
+        if not any_timed_out:
+            return
+
+        if self.dist.tp_size > 1:
+            gathered = self.dist.tp_allgather(local_timed_out)
+            global_timed_out = sorted(set().union(*gathered))
+        else:
+            global_timed_out = local_timed_out
+
+        local_ok = []
+        for rid in global_timed_out:
+            req = in_progress.get(rid)
+            if req is None:
+                # Not tracked on this rank
+                local_ok.append(True)
+                continue
+            if not req.py_kv_transfer_cancelled and \
+                    self.kv_cache_transceiver.cancel_request(req):
+                req.py_kv_transfer_cancelled = True
+            local_ok.append(req.py_kv_transfer_cancelled)
+
+        if self.dist.tp_size > 1:
+            all_ok = self.dist.tp_allgather(local_ok)
+            global_ok = [
+                all(ok[i] for ok in all_ok)
+                for i in range(len(global_timed_out))
+            ]
+        else:
+            global_ok = local_ok
+
+        for rid, ok in zip(global_timed_out, global_ok, strict=True):
+            req = in_progress.get(rid)
+            if not ok or req is None:
+                # Cancellation incomplete somewhere (e.g. transfer mid-flight,
+                # which the transceiver cannot abort yet); retry next iteration.
+                continue
+            logger.warning(
+                f"Cancelled generation request {rid} after KV cache transfer timeout"
+            )
+            req.py_kv_transfer_start_time = None
+            req.state = LlmRequestState.DISAGG_TRANS_ERROR
+        self._handle_errors(
+            "Error in kv cache transfer for generation requests",
+            requests=self._get_disagg_reqs_in_error_state(),
+            charge_budget=False)
 
     @nvtx_range("_check_kv_transfer_timeout")
     def _check_kv_transfer_timeout(self):
@@ -5005,16 +5095,6 @@ class PyExecutor:
             # no responses for dummy request, and finish it
             if request.is_attention_dp_dummy:
                 requests_to_terminate.append(request)
-                continue
-
-            # Check if generation request needs cleanup due to KV cache transfer timeout
-            if request.py_kv_transfer_timed_out:
-                is_cancelled = self.kv_cache_transceiver.cancel_request(request)
-                if is_cancelled:
-                    self._handle_errors(
-                        error_msg=f"Request {request.py_request_id} timed out",
-                        requests=[request],
-                        charge_budget=False)
                 continue
 
             if request.is_generation_only_request() and not request.is_finished:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown and teardown reliability for distributed cache management operations.
  * Enhanced timeout detection and error handling for generation transfers in distributed settings.
  * Added safeguards against invalid iterator access during transfer response processing.

* **Chores**
  * Updated environment configuration for distributed communication setup.
  * Refactored transfer status polling with improved multi-rank synchronization and budget management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

In disaggregated serving, when a generation-side KV cache transfer does not complete in time (e.g. under heavy transport load), the PyTorch executor/cache-transceiver path could deadlock or crash the engine. This PR fixes the following issues:

1. **Unbounded blocking in `checkGenTransferStatus` (C++).** To satisfy `atLeastRequestNum`, the generation-side status check force-selected not-yet-ready requests and then blocked in `future::get()` with no bound. A transfer that never completes wedged that rank inside `get()` while sibling ranks advanced to the next collective, deadlocking the whole sync group. It is now a bounded poll: only futures ready on every rank of the sync group are completed, the wait for `atLeastRequestNum` is capped, and incomplete transfers are left in flight for later checks. All loop-exit decisions are derived from rank-identical data so every rank runs the same number of collectives.

2. **Generation-side transfer timeouts were not acted upon consistently (Python).** The timeout flag was set but its only consumer was unreachable behind the blocking call above, and it was rank-local. `_cancel_timed_out_gen_transfers` now runs every iteration on every rank and reaches a TP-wide consensus before changing request state: an OR-gate allreduce to skip when nothing timed out, an allgather union of the timed-out ids (so wall-clock skew between ranks does not diverge the set), and a second allgather on the per-rank cancel result so a request is only failed once every rank tracking it has cancelled its share.

3. **Collective gated on rank-local error state (Python).** `_check_cache_transfer_errors` only entered `_handle_errors` (`→ _enqueue_responses → tp_gather`) when the local rank had errored requests. Under attention DP a cancel succeeds on a subset of ranks, so some ranks entered the gather while others skipped it, deadlocking the TP group. The generation-side path now flushes errors on every rank unconditionally.

4. **Use-after-free on teardown (C++).** `~CacheTransceiver` relied on member destruction order, but `ConnectionManager` is declared after — and thus destroyed before — `CacheSender`/`CacheReceiver`, whose background threads still dereferenced it, causing a segfault during shutdown. The destructor now resets the sender and receiver first, while the manager is still alive.

5. **Two shutdown-path crashes in `CacheSender::response()` (C++).** (a) `recvRequestInfo` returning a null connection was only handled when the manager had already stopped; otherwise an empty `RequestInfo` flowed into processing and threw `bad_optional_access`. (b) Terminating while waiting in the inner loop left the iterator at `end()`, which was then dereferenced in `sendResponse`. Both now bail out cleanly when terminating.

A bounded-poll metric (waited calls / total poll iterations / budget-exhaustion count) is logged on budget exhaustion to keep the throughput impact of the non-blocking rewrite observable.

## Test Coverage

Validated with the disaggregated perf-sanity case `perf/test_perf_sanity.py::test_e2e[disagg_upload-e2e-gb200_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL]` on GB200 (gen TP16 / attention-DP, ctx TP4, NIXL)

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
