### PR TITLE
[TRTLLM-13486][perf] LTX-2: pad short audio seqlen >128 to keep audio cross-attn on cuDNN SM100

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
@@ -1557,7 +1557,7 @@ class LTX2Pipeline(BasePipeline):
             hop_length=getattr(self, "audio_hop_length", 160),
         )
 
-        self.transformer.configure_audio_ulysses(audio_shape.frames)
+        self.transformer.configure_audio_padding(audio_shape.frames)
 
         # ---- 4. Generate initial noise / image conditioning ---------------
         latents = torch.randn(

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
@@ -1040,7 +1040,7 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
             sample_rate=getattr(self, "audio_sampling_rate", 16000),
             hop_length=getattr(self, "audio_hop_length", 160),
         )
-        self.transformer.configure_audio_ulysses(audio_shape.frames)
+        self.transformer.configure_audio_padding(audio_shape.frames)
 
         # --- Video: patchify, positions ---
         v_latents = self.video_patchifier.patchify(video_latents)

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
@@ -879,7 +879,7 @@ class BasicAVTransformerBlock(nn.Module):
                 # (Q=video huge, K/V=audio small — AG of the small audio is
                 # far cheaper than full-video a2a collectives).
                 # key_padding_mask zeros attention on the audio pad slots that
-                # configure_audio_ulysses appended to make T_a divisible by U.
+                # configure_audio_padding appended to make T_a divisible by U.
                 k_a2v, v_a2v = self.audio_to_video_attn.project_kv(
                     ax_scaled, pe=audio.cross_positional_embeddings
                 )
@@ -1137,7 +1137,7 @@ class LTXModel(BaseDiffusionModel):
             raise ValueError("LTX2 does not currently support TP.")
 
         self._audio_is_sharded = False
-        self._audio_pad = 0  # set by configure_audio_ulysses
+        self._audio_pad = 0  # set by configure_audio_padding
         self._cache_dit_video_args: Optional[TransformerArgs] = None
         self._cache_dit_audio_args: Optional[TransformerArgs] = None
         # Per-block text cross-attn KV lists, looked up by inner.idx in the
@@ -1466,7 +1466,7 @@ class LTXModel(BaseDiffusionModel):
         for the fused kernel or keeps 4D for the eager apply_rotary_emb path.
         LTX-2 SPLIT rope produces 4D PE; INTERLEAVED is not used in prod.
 
-        ``_audio_is_sharded`` (set in ``configure_audio_ulysses``) already
+        ``_audio_is_sharded`` (set in ``configure_audio_padding``) already
         encodes whether audio_seq_len is divisible by ulysses_size, so we
         gate sharding on that flag alone — no second divisibility check.
         """
@@ -1568,27 +1568,34 @@ class LTXModel(BaseDiffusionModel):
             timesteps = audio.timesteps
         return replace(audio, latent=latent, positions=positions, timesteps=timesteps)
 
-    def configure_audio_ulysses(self, audio_seq_len: int) -> None:
-        """Configure audio sharding + padding for Ulysses.
+    def configure_audio_padding(self, audio_seq_len: int) -> None:
+        """Pad audio + configure Ulysses sharding once, before the denoise loop.
 
-        Call once before the denoising loop when the audio token count is
-        known. The decision is cached — ``forward()`` uses it without
-        re-checking.
-
-        When sequence parallelism is active, audio is always padded to
-        ``(U - T_a % U) % U`` slots so ``T_a`` becomes divisible by ``U``
-        and a ``[B, T_a_padded]`` validity mask is attached so attention
-        zeros out pad positions. ``forward`` strips the pad tail on exit.
+        Pads audio to a length divisible by Ulysses size U. For the VANILLA
+        backend only, also bumps short audio (T_a <= 128) past 128 so its cuDNN
+        SDPA stays on the SM100 flash kernel instead of the ~3x slower SM80
+        fallback. Cached for forward(), which applies the pad + validity mask.
         """
-        if not self._sharder.is_active:
-            self._audio_is_sharded = False
-            self._audio_pad = 0
+        sp = self._sharder.is_active
+        U = self._sharder.size if sp else 1
+        # Divisible by U (no-op when U == 1).
+        padded_len = audio_seq_len + (U - audio_seq_len % U) % U
+        # cuDNN-only (VANILLA backend) bump above the SM100 min query seqlen
+        # (> 128), keeping the U-divisibility. Other backends don't hit the
+        # cuDNN SM80 fallback, so don't pad them past 128.
+        attn_cfg = (
+            getattr(self.model_config, "attention", None) if self.model_config is not None else None
+        )
+        is_vanilla = getattr(attn_cfg, "backend", "VANILLA") == "VANILLA"
+        if is_vanilla and padded_len <= 128:
+            padded_len = (128 // U + 1) * U  # smallest U-multiple strictly > 128
+        self._audio_pad = padded_len - audio_seq_len
+        self._audio_is_sharded = sp
+
+        # Per-block Ulysses toggle only matters under SP; without it the blocks
+        # keep their default (unsharded) state and just consume the padded audio.
+        if not sp:
             return
-
-        U = self._sharder.size
-        self._audio_pad = (U - audio_seq_len % U) % U
-        self._audio_is_sharded = True
-
         for block in self.transformer_blocks:
             target = block.inner if isinstance(block, LTX2CacheDiTPattern0BlockWrapper) else block
             target._audio_is_sharded = self._audio_is_sharded
@@ -1606,7 +1613,7 @@ class LTXModel(BaseDiffusionModel):
         rank (e.g. Stage 2 of the two-stage pipeline where non-primary
         workers have already exited).  Call with ``True`` to restore
         multi-rank operation; audio sharding will be reconfigured by
-        the next :meth:`configure_audio_ulysses` call.
+        the next :meth:`configure_audio_padding` call.
         """
         if self._sharder.size <= 1:
             return
@@ -1746,7 +1753,7 @@ class LTXModel(BaseDiffusionModel):
             raise ValueError("Audio is not enabled for this model")
 
         # Audio padding for Ulysses: when self._audio_pad > 0 (set once by
-        # configure_audio_ulysses to make T_a divisible by ulysses_size), pad
+        # configure_audio_padding to make T_a divisible by ulysses_size), pad
         # audio on entry to make it shardable. Build a [B, T_a_padded] bool mask
         # (True=valid, False=pad) that travels through TransformerArgs to
         # audio_attn1 + a2v. Strip the padded tail on output below.
@@ -1795,7 +1802,7 @@ class LTXModel(BaseDiffusionModel):
 
         # Shard sequences for parallelism (Ulysses head-sharding, ring CP, or Attention2D).
         # Video is always sharded.  Audio sharding is decided once by
-        # configure_audio_ulysses() and cached in self._audio_is_sharded.
+        # configure_audio_padding() and cached in self._audio_is_sharded.
         if self._sharder.is_active:
             if video_args is not None:
                 video_args = self._shard_transformer_args(video_args)

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_async_ulysses.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_async_ulysses.py
@@ -289,7 +289,7 @@ def _build_av_model(
 ):
     """Build LTXModel (AudioVideo) with deterministic weights via shared seed.
 
-    ``configure_audio_ulysses(audio_seq_len)`` gates audio_attn1's Ulysses
+    ``configure_audio_padding(audio_seq_len)`` gates audio_attn1's Ulysses
     activity by divisibility: not divisible → ``set_ulysses_active(False)``
     swaps the audio backend to plain (no ``forward_async``), forcing async
     self-attn to fall through the ``hasattr`` guard in ``LTX2Attention.forward``.
@@ -308,7 +308,7 @@ def _build_av_model(
         .eval()
     )
     _init_all_weights(model)
-    model.configure_audio_ulysses(audio_seq_len)
+    model.configure_audio_padding(audio_seq_len)
     return model
 
 

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_ulysses.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_ulysses.py
@@ -260,7 +260,7 @@ def _logic_ltx2_av_ulysses_vs_single_gpu(rank, world_size, backend, audio_seq_le
         .eval()
     )
     _init_all_weights(ref_model)
-    ref_model.configure_audio_ulysses(audio_seq_len)
+    ref_model.configure_audio_padding(audio_seq_len)
     ref_state = ref_model.state_dict()
 
     # ── Ulysses model: same weights ─────────────────────────────────────────
@@ -272,7 +272,7 @@ def _logic_ltx2_av_ulysses_vs_single_gpu(rank, world_size, backend, audio_seq_le
         .eval()
     )
     u_model.load_state_dict(ref_state)
-    u_model.configure_audio_ulysses(audio_seq_len)
+    u_model.configure_audio_padding(audio_seq_len)
 
     # ── Inputs (identical across ranks) ─────────────────────────────────────
     video, audio, v_ctx, a_ctx, v_pos, a_pos = _build_inputs(


### PR DESCRIPTION
@coderabbitai summary

## Description

LTX-2's audio sequence is 126 tokens. With the VANILLA attention backend (SDPA lowered to cuDNN by inductor), cuDNN's SM100 flash-fprop kernel requires query seqlen > 128 — at <= 128 it falls back to the legacy SM80 WMMA kernel. The audio self-attn and the v2a cross-attn use the full audio seqlen as their SDPA query, so they are all stuck on the SM80 fallback. This PR broadens `configure_audio_ulysses` -> `configure_audio_padding`: for the VANILLA backend, a short audio sequence (`T_a <= 128`) is padded up to the smallest length that is both `> 128` and divisible by the Ulysses size `U`. It reuses the existing audio pad / validity-mask / strip-on-exit path unchanged, leaves Ulysses-divisibility behavior for longer audio untouched, is parallelism-independent (helps single-GPU and cfg-only too), and is gated to VANILLA only (TRTLLM/FA4/CUTEDSL do not use cuDNN SDPA, so they are not padded past 128).

## Test Coverage

Measured on B200 (cuDNN 9.15, bf16). The cuDNN SM100-vs-SM80 cutoff for head_dim=64 is a strict `seqlen > 128` (verified by a fine sweep: 128 -> SM80, 129 -> SM100).

### Kernel microbench (single attention, µs, mean over 50 iters)

Real LTX-2 shapes, per Ulysses rank (uly N -> 32/N heads/rank; video full seq 15360, audio 126, text 1024). `cuDNN unpad` = native audio seqlen; `cuDNN pad>128` = this PR (audio padded to the smallest U-multiple > 128). Video-only attentions carry no audio and are never padded.

**Ulysses=1 (32 heads/rank, audio 126->129):**
| attn | q×k | cuDNN unpad | cuDNN pad>128 |
|:--|:--|:--|:--|
| video_self | 15360×15360 | sm100 2780 | — |
| video_text | 15360×1024 | sm100 229 | — |
| audio_self | 126×126 | sm80 4.9 | sm100 7.6 |
| a2v (Q=vid) | 15360×126 | sm80 76 | sm100 62 |
| **v2a (Q=aud)** | 126×15360 | **sm80 425** | **sm100 149** |
| audio_text | 126×1024 | sm80 18 | sm100 14 |

**Ulysses=2 (16 heads/rank, audio 126->130):**
| attn | q×k | cuDNN unpad | cuDNN pad>128 |
|:--|:--|:--|:--|
| video_self | 15360×15360 | sm100 1409 | — |
| video_text | 7680×1024 | sm100 123 | — |
| audio_self | 126×126 | sm80 4.8 | sm100 7.6 |
| a2v (Q=vid) | 7680×126 | sm80 38 | sm100 34 |
| **v2a (Q=aud)** | 126×15360 | **sm80 424** | **sm100 148** |
| audio_text | 63×1024 | sm80 18 | sm80 18 |

**Ulysses=4 (8 heads/rank, audio 128->132):**
| attn | q×k | cuDNN unpad | cuDNN pad>128 |
|:--|:--|:--|:--|
| video_self | 15360×15360 | sm100 715 | — |
| video_text | 3840×1024 | sm100 66 | — |
| audio_self | 128×128 | sm80 4.8 | sm100 7.6 |
| a2v (Q=vid) | 3840×128 | sm80 21 | sm100 21 |
| **v2a (Q=aud)** | 128×15360 | **sm80 423** | **sm100 148** |
| audio_text | 32×1024 | sm80 18 | sm80 18 |

**v2a (Q=audio, K=video=15360) is the dominant win: SM80 ~424 -> SM100 ~148 µs (~2.9×) at every rank.** Secondary effects: a2v (audio is its KV) also flips to SM100 when audio is padded (small win at uly1/2, ~neutral at uly4); audio_self is a tiny net regression (SM100 ~7.6 vs SM80 ~4.9 µs on its ~128² shape); audio_text only flips at uly1 (its sharded query drops back below 128 at uly2/4). All secondary effects are a few µs and dwarfed by the v2a saving.

### End-to-end LTX-2

Single-stage, 768×1280, 121 frames, 40 steps, guidance 4.0, NVFP4, B200, min-of-4 timed runs. Controlled A/B toggling this PR's >128 audio pad on a fixed build (NVLS disabled as an unrelated node-NCCL workaround; the kernel switch is NVLS-independent):

| GPUs | parallel | audio pad | VANILLA no-pad | VANILLA pad>128 | speedup |
|----:|:--|:--|:--|:--|:--|
| 1 | cfg1·uly1 | 126→129 | 31.76 s | 31.76 s | ~0% |
| 2 | cfg2·uly1 | 126→129 | 17.98 s | 17.68 s | −1.7% |
| 4 | cfg2·uly2 | 126→130 | 12.49 s | 12.24 s | −2.0% |
| 8 | cfg2·uly4 | 128→132 | 8.88 s | 8.47 s | −4.6% |

The benefit grows with Ulysses — the fixed v2a saving is a larger fraction of the shrinking transformer wall — peaking at −4.6% at 8 GPU, consistent with the ~4.9% measured directly on this branch (audio 128→132: 9.29 s → 8.83 s). At 1 GPU it is neutral: the audio attn is a negligible slice of e2e there and the few padded tokens offset the small kernel gain.

Runtime-verified under Ulysses SP (4-GPU): audio pads 126 -> 130, the audio-query SDPA shapes flip onto the SM100 point, generation completes correctly. A single-GPU (non-SP) cosine-equivalence check vs unpadded is still pending.

## PR Checklist

- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md).
- Test cases are provided for new code paths.
- Any new dependencies have been scanned for license and vulnerabilities.
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes.
- Documentation updated as needed.
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if significant design change.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
