### PR TITLE
[None][perf] serve: parse request bodies with orjson when available

### DIFF
--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -110,6 +110,46 @@ from .harmony_adapter import (HarmonyAdapter, get_harmony_adapter,
 # yapf: enable
 TIMEOUT_KEEP_ALIVE = 5  # seconds.
 
+# Parse incoming request bodies with orjson instead of the stdlib json when it
+# is available. FastAPI/Starlette call Request.json() (stdlib json.loads) before
+# pydantic validation; at high concurrency that decode dominates the single
+# OpenAI-server process's event-loop/GIL time, and orjson is ~5-10x faster.
+# Fully fallback-safe: if orjson is not installed behavior is unchanged, and any
+# input orjson rejects is re-parsed with the stdlib parser per request.
+try:
+    import orjson as _orjson
+    from fastapi.routing import APIRoute as _APIRoute
+
+    class _ORJSONRequest(Request):
+        """Request that decodes its JSON body with orjson (stdlib fallback)."""
+
+        async def json(self) -> Any:
+            if not hasattr(self, "_json"):
+                body = await self.body()
+                try:
+                    self._json = _orjson.loads(body)
+                except ValueError:
+                    # orjson is stricter than the stdlib (e.g. rejects
+                    # NaN/Infinity); fall back so behavior is identical.
+                    self._json = json.loads(body)
+            return self._json
+
+    class _ORJSONRoute(_APIRoute):
+        """APIRoute whose request bodies are parsed via orjson."""
+
+        def get_route_handler(self):
+            original = super().get_route_handler()
+
+            async def handler(request: Request):
+                return await original(
+                    _ORJSONRequest(request.scope, request.receive))
+
+            return handler
+
+    _HAS_ORJSON = True
+except Exception:  # pragma: no cover - orjson is an optional speedup
+    _HAS_ORJSON = False
+
 
 def _build_tool_strict_guided_decoding_params(tools, tool_parser_name):
     """Build GuidedDecodingParams with structural tags for tools with strict=True.
@@ -320,6 +360,9 @@ class OpenAIServer(_VideoRoutesMixin):
             self.generator.shutdown()
 
         self.app = FastAPI(lifespan=lifespan)
+        if _HAS_ORJSON:
+            # Routes registered below inherit the orjson-based request class.
+            self.app.router.route_class = _ORJSONRoute
 
         @self.app.exception_handler(RequestValidationError)
         async def validation_exception_handler(_, exc):


### PR DESCRIPTION
## Summary

FastAPI/Starlette decode each incoming request body with the stdlib `json`
(`Request.json`) before pydantic validation. At high concurrency the OpenAI-server
process runs a single event loop / GIL, and that JSON decode dominates its host time —
py-spy attributed **~32% of the serving-process GIL** to `json.raw_decode` on a
DeepSeek-V4-Pro disaggregated **generation** worker at concurrency 2048. `orjson` parses
the same JSON ~5–10× faster.

## Change

Override the FastAPI route class so request bodies decode via `orjson` when it is
importable. The change lives in the shared `OpenAIServer`, so it applies to **context and
generation workers and the aggregated server**.

Fully fallback-safe:
- if `orjson` is not installed → behavior unchanged (stdlib `json`);
- any input `orjson` rejects (e.g. `NaN`/`Infinity`, which the stdlib accepts) → re-parsed
  per request with the stdlib parser, so results are identical.

`orjson` is treated as an **optional speedup** and is *not* added as a hard dependency in
this PR (used-if-available). Adding it to `requirements` to guarantee the speedup in
production is a follow-up.

## Test

- `py_compile` clean.
- Unit-level `exec` of the new block (stubbed `orjson`/`fastapi`) verifies: the orjson
  parse path, `_json` caching, the `NaN`→stdlib fallback, and `_ORJSONRoute` request
  wrapping.
- Fallback-safe by construction: `orjson` unimportable → `route_class` unchanged →
  byte-identical to baseline.

## Performance caveat (honest)

In same-window A/B on DSv4-Pro 6p1d c2048 (metrics-off), orjson's marginal gain was **within
run-to-run noise** once the redundant chat-message history was already stripped from the
generation request (`orjson + body-strip` ≈ `body-strip alone` on TTFT p95, within ~3% on
req/s). At that operating point the larger, robust lever was **body-strip** (separate
change). orjson's incremental upside here is mainly **CTX-side** — the body-strip change is
generation-only, whereas this orjson change also covers the **context** workers, where the
parse cost was previously unrelieved — plus value as a transparent, reusable speedup.
Recommend measuring CTX-side impact before relying on it.
