### PR TITLE
[None][perf] disagg: CTX-side incremental conversation tokenization

### DIFF
--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -23,7 +23,7 @@ import socket
 import time
 import traceback
 import uuid
-from collections import deque
+from collections import OrderedDict, deque
 from contextlib import asynccontextmanager
 from datetime import datetime
 from http import HTTPStatus
@@ -360,6 +360,15 @@ class OpenAIServer(_VideoRoutesMixin):
 
     def _init_llm(self, chat_template: Optional[str] = None):
         self.tokenizer = self.generator.tokenizer
+        # CTX-side incremental tokenizer (opt-in via TLLM_CTX_INCR_TOKENIZE=1).
+        # Re-encodes only the suffix that extends the previous turn's prompt,
+        # avoiding a full re-tokenize of the (often tens-of-thousands-token)
+        # prompt on every turn. See _encode_with_prefix_cache.
+        self._tok_prefix_cache = (
+            OrderedDict()
+            if os.environ.get("TLLM_CTX_INCR_TOKENIZE") == "1" else None)
+        if self._tok_prefix_cache is not None:
+            logger.info("CTX incremental tokenization enabled")
         hf_tokenizer_path = self.generator._hf_model_dir
         if not hf_tokenizer_path:
             hf_tokenizer_path = getattr(
@@ -1090,6 +1099,37 @@ class OpenAIServer(_VideoRoutesMixin):
             logger.info("Iteration stats collector loop cancelled")
             raise
 
+    def _encode_with_prefix_cache(self, rendered: str, key: int) -> list[int]:
+        """Tokenize ``rendered`` reusing the prefix cached from the previous turn.
+
+        Only the suffix that extends the cached render is re-encoded; the rest of
+        the token ids are reused, avoiding a full re-tokenize of the (often very
+        long) conversation prompt on every turn. A prompt that does not extend
+        the cached one falls back to a full encode.
+
+        Mirrors ``KvCacheAwareRouter._encode_with_prefix_cache`` on the context
+        path: with conversation-sticky routing the router skips its own tokenize,
+        so the context worker would otherwise re-encode the whole prompt every
+        turn. The cache key is the hash of the first messages, which carries the
+        per-session cache-bust id so concurrent sessions do not clobber each
+        other; the delta encode is exact because chat renders end on a special
+        token (an atomic boundary that BPE never merges across).
+        """
+        hf = getattr(self.tokenizer, "tokenizer", self.tokenizer)
+        cache = self._tok_prefix_cache
+        entry = cache.get(key)
+        if (entry is not None and len(rendered) > len(entry[0])
+                and rendered.startswith(entry[0])):
+            ids = entry[1] + hf.encode(rendered[len(entry[0]):],
+                                       add_special_tokens=False)
+        else:
+            ids = hf.encode(rendered, add_special_tokens=False)
+        cache[key] = (rendered, ids)
+        cache.move_to_end(key)
+        while len(cache) > 1024:
+            cache.popitem(last=False)
+        return ids
+
     async def openai_chat(self, request: ChatCompletionRequest,
                           raw_request: Request) -> Response:
 
@@ -1194,6 +1234,19 @@ class OpenAIServer(_VideoRoutesMixin):
                     chat_template=request.chat_template or self.chat_template,
                     chat_template_kwargs=request.chat_template_kwargs or {},
                 )
+                # Incremental tokenization (opt-in): turn the rendered text into
+                # token ids via the prefix cache so _preprocess skips a full
+                # re-encode of the whole prompt. Only reachable on the context
+                # path (the generation path takes prompt_token_ids). Keyed by the
+                # first messages, which carry the per-session cache-bust id.
+                if self._tok_prefix_cache is not None and isinstance(prompt, str):
+                    key = hash("".join(
+                        str(m.get("content", "") if isinstance(m, dict) else
+                            getattr(m, "content", ""))
+                        for m in request.messages[:2]))
+                    prompt = await asyncio.to_thread(
+                        self._encode_with_prefix_cache, prompt, key)
+                    request.prompt_token_ids = prompt
             prompt = prompt_inputs(prompt)
 
             mm_data, mm_embeddings = await mm_coroutines


### PR DESCRIPTION
@coderabbitai summary

## Description

In disaggregated serving with **conversation-sticky routing**, the router
(`ConversationRouter`, PR #14957) routes by the session table and **skips its
own tokenize / block-hash compute**, so it does not set `prompt_token_ids`. The
**context server** therefore re-renders and re-tokenizes the *full* conversation
prompt — tens of thousands of tokens for long multi-turn / agentic
conversations — on **every** turn. Host-overhead profiling of a DeepSeek-V4-Pro
6×CTX+1×GEN deployment at high concurrency showed the CTX serving process
saturated at 100–135% CPU, almost entirely in the HF fast-tokenizer, on the TTFT
critical path.

This PR caches, per session, the previous turn's rendered prompt and its token
ids on the context path, and re-encodes only the suffix that extends it — the
same approach as the merged `KvCacheAwareRouter._encode_with_prefix_cache`
(PR #15040), applied where the work actually lands in a conversation-sticky
disagg deployment.

- **Opt-in / zero default impact** — enabled only when `TLLM_CTX_INCR_TOKENIZE=1`;
  otherwise the cache is never constructed and the path is inert.
- **Context path only** — runs in `openai_chat` after `apply_chat_template`; the
  generation path takes `prompt_token_ids` and never reaches it.
- **Session-correct key** — keyed by the hash of the first messages, which carry
  the per-session cache-bust id, so concurrent sessions that share a routing
  `conversation_id` do not clobber each other (verified on real traffic: two
  concurrent sessions of one conversation → disjoint keys, no clobber).
- **Exact, fallback-safe** — the delta encode is bit-exact because chat renders
  end on a special token (an atomic added-token boundary that BPE never merges
  across; confirmed `<think>`/`</think>`/`<｜Assistant｜>` are dedicated token
  ids). Any prompt that does not extend the cached one falls back to a full
  encode; the cache is a bounded LRU (1024 entries).

Measured on the 6p1d DeepSeek-V4-Pro deployment with the feature on: CTX serving
CPU ~135% → ~27%, steady-state prefix reuse ~96–97%, and at the SLO operating
point a TTFT p50/p95 reduction of roughly 15–25% with throughput +6–11% (the CTX
tokenize was the binding host stage there). The win is concentrated where the
CTX stage is the bottleneck; it is neutral once GEN becomes the limiter at higher
concurrency.

## Test Coverage

- Gated behind `TLLM_CTX_INCR_TOKENIZE` (default off) — no change to existing
  default code paths; current `serve` / `openai_server` tests are unaffected.
- Correctness rests on the special-token boundary property above (the same
  property the merged PR #15040 relies on for the router). The incremental result
  was validated bit-identical to a full `encode` on real DeepSeek-V4-Pro
  disaggregated traffic (no divergence observed over tens of thousands of CTX
  tokenize calls).
- Follow-up (can add to this PR on request): a unit test mirroring #15040's —
  assert the incremental ids equal a full `tokenizer.encode` over a sequence of
  growing renders, plus a non-extending case that exercises the full-encode
  fallback.

## PR Checklist

- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
