### PR TITLE
[None][feat] Handle empty-block ranks with Helix CP

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
+++ b/cpp/include/tensorrt_llm/batch_manager/kvCacheManager.h
@@ -98,6 +98,13 @@ template <typename T>
 std::list<std::vector<T>> chopVectorIntoBlocks(
     std::vector<T> const& vec, SizeType32 usableSize, SizeType32 elementsPerBlock, bool allowPartial)
 {
+    // No usable elements yields no blocks. Guard non-positive usableSize explicitly: callers may pass
+    // usableSize = inputLength - 1, which is -1 for a Helix CP "empty" rank with 0 input tokens. With a
+    // negative usableSize, downstream usage of "vec.begin() + usableSize" is undefined behavior.
+    if (usableSize <= 0)
+    {
+        return {};
+    }
     TLLM_CHECK_WITH_INFO(
         usableSize <= static_cast<SizeType32>(vec.size()), "usableSize=%d > %ld=vec.size()", usableSize, vec.size());
     std::list<std::vector<T>> blockedVectors;

--- a/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
+++ b/cpp/include/tensorrt_llm/batch_manager/llmRequest.h
@@ -2247,7 +2247,10 @@ private:
 
         // Scatter the input tokens to other beam
         mTokens = BeamTokens(mSamplingConfig.beamWidth, inputTokens);
-        mLastTokens = VecTokens(mSamplingConfig.beamWidth, inputTokens.back());
+        // A request may legitimately have no input tokens on this rank (e.g. an "empty" Helix CP rank that owns zero KV
+        // blocks for the sequence). Guard against calling .back() on an empty vector (undefined behavior).
+        mLastTokens = inputTokens.empty() ? VecTokens(mSamplingConfig.beamWidth)
+                                          : VecTokens(mSamplingConfig.beamWidth, inputTokens.back());
 
         // Init mUniqueTokens
         VecUniqueTokens uniqueTokens{inputTokens.size()};

--- a/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheFormatter.cpp
@@ -74,6 +74,13 @@ void sendBuffer(TransferSession& session, int deviceId, size_t localIdx,
     size_t bufferIdx = computeBufferIdx(localIdx, targetInfo);
     size_t size = outputBuffers[bufferIdx]->getSizeInBytes();
 
+    // Skip Helix CP ranks that own no blocks for this sequence (num_total_blocks < cp_size).
+    // The matching gen rank skips its receive, so no 0-byte transfer is posted on either side.
+    if (size == 0)
+    {
+        return;
+    }
+
     if (bufferIdx < bufferCoverTargetNum)
     {
         TLLM_LOG_DEBUG(mpi::MpiComm::world().getRank(), " send connIdx: %ld bufferIdx: %ld size:%ld", connIdx,
@@ -686,6 +693,13 @@ void CacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& sess
         "outputBuffersPerWindow size: %ld,blockNum: %d , kvWindowSizes: %ld", outputBuffersPerWindow.size(), blockNum,
         kvWindowSizes.size());
     TLLM_CHECK(!outputBuffersPerWindow.empty());
+
+    // An "empty" Helix CP rank owns no KV blocks for this sequence (num_total_blocks < cp_size).
+    // There is nothing to receive; the sender (context, CP=1) skips the matching 0-byte transfer.
+    if (blockNum == 0)
+    {
+        return;
+    }
     if (outputBuffersPerWindow.size() > 1)
     {
         // We only support limited case for VSWA.

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -857,26 +857,32 @@ public:
         if (!mCacheTransferLayer.getCacheManager()->getBlockManager().isVariableWindow())
         {
             auto* cacheManager = mCacheTransferLayer.getCacheManager();
-            auto beam = 0;
             auto const srcPpSize = destCacheState.getParallelConfig().mPipelineParallelism;
             auto requestedBlockRange = getBlockRangeForReceiving(cacheManager, llmRequest,
                 destCacheState.getEnableBlockReuse(), destCacheState.getEnablePartialReuse(),
                 /*recvSideHasCP=*/false, srcPpSize);
 
-            auto const& uniqueTokens = llmRequest.getUniqueTokens(beam);
-            auto lastBlockKey
-                = BlockKey(llmRequest.getInputTokensExtraIds().has_value(), llmRequest.getLoraTaskId(), uniqueTokens);
-            auto tokensPerBlock = cacheManager->getBlockManager().getTokensPerBlock();
-            SizeType32 startTokenIdx = static_cast<SizeType32>(uniqueTokens.size() / tokensPerBlock) * tokensPerBlock;
-            SizeType32 endTokenIdx = static_cast<SizeType32>(uniqueTokens.size());
-            auto extraKeys = kv_cache_manager::generateBlockHashExtraKeys(llmRequest, startTokenIdx, endTokenIdx);
-            lastBlockKey.extraKeys = std::move(extraKeys);
-            // Compute indexFromEnd from the number of requested blocks
             int32_t requestedBlockSize = requestedBlockRange.getBlockIdsPerWindow().begin()->second.size();
-            TLLM_CHECK_WITH_INFO(requestedBlockSize > 0, "requestedBlockSize must be > 0");
-            int32_t indexFromEnd = requestedBlockSize - 1;
+            // An empty Helix CP rank owns zero KV blocks for this sequence (fewer blocks than
+            // cp_size). It still sends a RequestInfo so the context's per-request counterpart count
+            // is satisfied, but requests zero blocks: the default RequestInfo (indexFromEnd=0, empty
+            // lastBlockKey) is used and the context transmits nothing to it.
+            if (requestedBlockSize > 0)
+            {
+                auto const beam = 0;
+                auto const& uniqueTokens = llmRequest.getUniqueTokens(beam);
+                auto lastBlockKey = BlockKey(
+                    llmRequest.getInputTokensExtraIds().has_value(), llmRequest.getLoraTaskId(), uniqueTokens);
+                auto tokensPerBlock = cacheManager->getBlockManager().getTokensPerBlock();
+                SizeType32 startTokenIdx
+                    = static_cast<SizeType32>(uniqueTokens.size() / tokensPerBlock) * tokensPerBlock;
+                SizeType32 endTokenIdx = static_cast<SizeType32>(uniqueTokens.size());
+                auto extraKeys = kv_cache_manager::generateBlockHashExtraKeys(llmRequest, startTokenIdx, endTokenIdx);
+                lastBlockKey.extraKeys = std::move(extraKeys);
+                int32_t indexFromEnd = requestedBlockSize - 1;
 
-            requestInfo = RequestInfo(requestId, mSelfState, indexFromEnd, lastBlockKey);
+                requestInfo = RequestInfo(requestId, mSelfState, indexFromEnd, lastBlockKey);
+            }
         }
 
         auto* agentConnectionManager = dynamic_cast<executor::kv_cache::AgentConnectionManager*>(mManager);

--- a/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
+++ b/cpp/tensorrt_llm/batch_manager/mlaCacheFormatter.cpp
@@ -304,6 +304,13 @@ void MLACacheFormatter::format(tensorrt_llm::batch_manager::TransferSession& ses
             auto cpDomainIdx = processIdx / connectionsPerCPDomain;
             auto ppDomainIdx = (processIdx % connectionsPerCPDomain) % pPDomainSize;
             auto cacheIdx = cpDomainIdx * pPDomainSize + ppDomainIdx;
+            // Helix: skip CP ranks that own no blocks for this sequence (num_total_blocks < cp_size).
+            // The matching gen rank skips its receive, so no 0-byte transfer is posted on either side.
+            auto const& splitCache = outputSplitCaches.at(cacheIdx);
+            if (splitCache == nullptr || splitCache->getSizeInBytes() == 0)
+            {
+                return;
+            }
             if (cacheIdx < bufferCoverTargetNum)
             {
                 size_t size = outputSplitCaches.at(cacheIdx)->getSizeInBytes();
@@ -456,6 +463,13 @@ void MLACacheFormatter::unformat(tensorrt_llm::batch_manager::TransferSession& s
                 outputBuffers.push_back(it);
                 blockNum++;
             }
+        }
+
+        // Helix: an "empty" CP rank owns no KV blocks for this sequence (num_total_blocks < cp_size).
+        // There is nothing to receive; the sender (context, CP=1) skips the matching 0-byte transfer.
+        if (blockNum == 0)
+        {
+            continue;
         }
 
         int deviceId = bufferManager.getStream().getDevice();

--- a/cpp/tensorrt_llm/executor/requestImpl.h
+++ b/cpp/tensorrt_llm/executor/requestImpl.h
@@ -510,7 +510,12 @@ public:
 private:
     void validate()
     {
-        TLLM_CHECK(!mInputTokenIds.empty());
+        if (mInputTokenIds.empty())
+        {
+            TLLM_LOG_WARNING(
+                "Request created with empty inputTokenIds; expected only on empty Helix CP ranks when num_total_blocks "
+                "< cp_size.");
+        }
         TLLM_CHECK(mMaxNewTokens > 0);
 
         // Show warning message unless mNumReturnSequences is the default value.

--- a/cpp/tests/unit_tests/multi_gpu/cacheTransceiverTest.cpp
+++ b/cpp/tests/unit_tests/multi_gpu/cacheTransceiverTest.cpp
@@ -1340,24 +1340,8 @@ TEST_P(AsymmetricalCacheTest, TestCase)
         // https://nvbugs/5760737
         GTEST_SKIP() << "Temporarily skipping cache transceiver tests with Mooncake backend for Indexer KCache.";
     }
+
     std::vector<int> lenList = {30, 10, 60, 80};
-    if (genCp > 1)
-    {
-        std::vector<int> updatedLenList;
-        for (auto len : lenList)
-        {
-            if (len > tokensPerBlock * (genCp - 1))
-            {
-                updatedLenList.push_back(len);
-            }
-        }
-        if (updatedLenList.empty())
-        {
-            GTEST_SKIP() << "Skipping test because not even one request has one block per genCP rank. tokensPerBlock="
-                         << tokensPerBlock << ", genCp=" << genCp;
-        }
-        lenList = updatedLenList;
-    }
 
     setUpCommunicator(contextTp, contextPp, contextCp, genTp, genPp, genCp, isMLA, contextDP, generationDP);
 
@@ -1465,26 +1449,8 @@ TEST_P(AsymmetricalCacheTestWithDP, TestCase)
     {
         GTEST_SKIP() << "Temporarily skipping cache transceiver tests with NIXL and MOONCAKE backend for CP.";
     }
-    // Filter request lengths based on CP requirements.
-    // Each request must have at least one block per CP rank to be valid for CP tests.
+
     std::vector<int> lenList = {60, 30, 60, 10};
-    if (genCp > 1)
-    {
-        std::vector<int> updatedLenList;
-        for (auto len : lenList)
-        {
-            if (len > tokensPerBlock * (genCp - 1))
-            {
-                updatedLenList.push_back(len);
-            }
-        }
-        if (updatedLenList.empty())
-        {
-            GTEST_SKIP() << "Skipping test because not even one request has one block per genCP rank. tokensPerBlock="
-                         << tokensPerBlock << ", genCp=" << genCp;
-        }
-        lenList = updatedLenList;
-    }
 
     setUpCommunicator(contextTp, contextPp, contextCp, genTp, genPp, genCp, isMLA, contextDP, generationDP);
 

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -2,7 +2,7 @@ import functools
 import math
 import os
 import weakref
-from typing import List, Optional, Union, cast
+from typing import List, Optional, Tuple, Union, cast
 
 import torch
 from torch import nn
@@ -144,6 +144,77 @@ def attn_custom_op_inplace(
     )
 
 
+def _helix_zero_kv_mask(
+        attn_metadata: AttentionMetadata,
+        num_tokens: int,
+        *,
+        seq_start: int = 0,
+        num_seqs: Optional[int] = None) -> Optional[torch.Tensor]:
+    """Return a per-token bool mask marking tokens with zero local KV on this CP rank.
+
+    These tokens belong to sequences for which this rank owns no KV blocks. Since
+    kv_lens_cuda is per-sequence, it is expanded to per-token using the
+    seq_lens_cuda query lengths, which stays correct when a sequence spans
+    multiple tokens (e.g. speculative decoding). The buffers are static and
+    output_size is passed to repeat_interleave, so the mask is CUDA-graph safe.
+    Returns None when a length buffer is unavailable.
+
+    Args:
+        attn_metadata: Attention metadata holding the length buffers.
+        num_tokens: Number of tokens covered by partial_o; used as the static
+            output_size of the per-token expansion.
+        seq_start: Index of the first sequence covered by partial_o. Defaults to
+            0 for generation-only callers; MLA passes num_contexts to select the
+            generation slice.
+        num_seqs: Number of sequences covered by partial_o. Defaults to all
+            sequences after seq_start.
+    """
+    kv_lens = getattr(attn_metadata, "kv_lens_cuda", None)
+    seq_lens = getattr(attn_metadata, "seq_lens_cuda", None)
+    if kv_lens is None or seq_lens is None:
+        return None
+    if num_seqs is None:
+        num_seqs = attn_metadata.num_seqs - seq_start
+    seq_slice = slice(seq_start, seq_start + num_seqs)
+    per_seq_mask = kv_lens[seq_slice] == 0
+    return torch.repeat_interleave(per_seq_mask,
+                                   seq_lens[seq_slice],
+                                   output_size=num_tokens)
+
+
+def _helix_sanitize_empty_kv(
+    partial_o: torch.Tensor,
+    softmax_stats: torch.Tensor,
+    zero_kv_mask: Optional[torch.Tensor],
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Force zero-local-KV rows to a no-op contribution for the Helix combine.
+
+    A CP rank that owns no KV blocks for a token attends to zero keys, so the
+    attention kernel normalizes by a zero softmax sum and yields NaN. The combine
+    weights each rank by sum * exp(max - global_max), so such rows must contribute
+    softmax_stats of (-inf, 0) and a zeroed partial_o to act as a no-op. The rows
+    are selected by zero_kv_mask, which is robust regardless of what the kernel
+    wrote. Passing None disables sanitization.
+
+    Args:
+        partial_o: Partial attention output, shape [num_tokens, ...].
+        softmax_stats: Per (token, head) (max, sum), shape [num_tokens, num_heads, 2].
+        zero_kv_mask: Bool tensor of shape [num_tokens], True where this rank has
+            zero local KV.
+    """
+    if zero_kv_mask is None:
+        return partial_o, softmax_stats
+    num_tokens = partial_o.shape[0]
+    mask = zero_kv_mask[:num_tokens].view(-1, 1)
+    # masked_fill overwrites masked rows regardless of their current (possibly NaN)
+    # value and is CUDA-graph safe due to static shapes.
+    partial_o = partial_o.masked_fill(mask, 0.0)
+    sm_max = softmax_stats[..., 0].masked_fill(mask, float("-inf"))
+    sm_sum = softmax_stats[..., 1].masked_fill(mask, 0.0)
+    softmax_stats = torch.stack([sm_max, sm_sum], dim=-1)
+    return partial_o, softmax_stats
+
+
 def _helix_post_process(
     partial_o: torch.Tensor,
     softmax_stats: torch.Tensor,
@@ -152,6 +223,7 @@ def _helix_post_process(
     value_dim: int,
     aux_stream: Optional[torch.cuda.Stream] = None,
     ln_events: Optional[list] = None,
+    zero_kv_mask: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Helix CP post-processing: all-to-all exchange and combine partial
     attention outputs across CP ranks.
@@ -160,10 +232,17 @@ def _helix_post_process(
     dimension that differs between the two callers is *value_dim*
     (``head_dim`` for MHA, ``kv_lora_rank`` for MLA).
 
+    zero_kv_mask marks tokens for which this CP rank owns no KV blocks; those rows
+    are forced to a no-op contribution before the exchange (see
+    _helix_sanitize_empty_kv).
+
     When *aux_stream* and *ln_events* are provided the two
     ``.contiguous()`` calls in the FIFO-v1 path are overlapped on
     separate CUDA streams for better performance.
     """
+    partial_o, softmax_stats = _helix_sanitize_empty_kv(partial_o,
+                                                        softmax_stats,
+                                                        zero_kv_mask)
     if mapping.cp_config.get("use_nccl_for_alltoall", True):
         # NCCL-based implementation using alltoall_helix.
         chunks = []
@@ -692,11 +771,17 @@ class Attention(nn.Module):
             is_gen_only=False)
 
     def _helix_post_process(self, partial_o: torch.Tensor,
-                            softmax_stats: torch.Tensor) -> torch.Tensor:
+                            softmax_stats: torch.Tensor,
+                            attn_metadata: AttentionMetadata) -> torch.Tensor:
         """Helix CP post-processing: all-to-all exchange and combine partial
         attention outputs across CP ranks."""
-        return _helix_post_process(partial_o, softmax_stats, self.mapping,
-                                   self.num_heads_tp_cp, self.head_dim)
+        zero_kv_mask = _helix_zero_kv_mask(attn_metadata, partial_o.shape[0])
+        return _helix_post_process(partial_o,
+                                   softmax_stats,
+                                   self.mapping,
+                                   self.num_heads_tp_cp,
+                                   self.head_dim,
+                                   zero_kv_mask=zero_kv_mask)
 
     def _attn_impl(
         self,
@@ -757,7 +842,8 @@ class Attention(nn.Module):
                 ))
             if isinstance(attn_output, tuple):
                 attn_output = attn_output[0]
-            attn_output = self._helix_post_process(attn_output, softmax_stats)
+            attn_output = self._helix_post_process(attn_output, softmax_stats,
+                                                   attn_metadata)
             return attn_output, None
 
         # Don't set out_scale if o_proj has pre_quant_scale — this prevents
@@ -1812,9 +1898,21 @@ class MLA(nn.Module):
             kv_lora_rank = partial_o.shape[-1] // self.num_heads_tp
             assert self.kv_lora_rank == kv_lora_rank
 
-            return _helix_post_process(partial_o, softmax_stats, self.mapping,
-                                       self.num_heads_tp_cp, kv_lora_rank,
-                                       self.aux_stream, self.ln_events)
+            # MLA processes only the generation token slice here, so build the
+            # mask from the generation sequence range [num_contexts, num_seqs).
+            zero_kv_mask = _helix_zero_kv_mask(
+                attn_metadata,
+                partial_o.shape[0],
+                seq_start=attn_metadata.num_contexts,
+                num_seqs=attn_metadata.num_generations)
+            return _helix_post_process(partial_o,
+                                       softmax_stats,
+                                       self.mapping,
+                                       self.num_heads_tp_cp,
+                                       kv_lora_rank,
+                                       self.aux_stream,
+                                       self.ln_events,
+                                       zero_kv_mask=zero_kv_mask)
         else:
             attn_output = attn_backend.forward(
                 q,

--- a/tensorrt_llm/_torch/pyexecutor/request_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/request_utils.py
@@ -252,19 +252,25 @@ def partition_context_for_helix(
     Returns:
         Tuple of (input_ids_this_rank, position_ids_this_rank, input_len, padding_len).
 
+        When num_total_blocks < cp_size, the highest-indexed CP ranks own no blocks
+        for this sequence; those empty ranks return empty token and position lists.
+        input_len still reflects the full prompt length so global position ids stay
+        correct.
+
     Raises:
-        ValueError: If there aren't enough tokens for at least one block per CP rank.
+        ValueError: If the prompt is empty (no blocks to distribute).
     """
     all_input_ids = torch.tensor(input_token_ids, dtype=torch.int64).unsqueeze(0)
     input_len = all_input_ids.shape[-1]
 
     num_total_blocks = (input_len + tokens_per_block - 1) // tokens_per_block
-    if num_total_blocks < cp_size:
-        raise ValueError(
-            f"There aren't enough tokens to get at least one block per CP rank. "
-            f"num_total_blocks {num_total_blocks} < num_cp_ranks {cp_size}. "
-            f"Please use smaller tokens_per_block for KV cache or reduce the number of CP ranks."
-        )
+    if num_total_blocks == 0:
+        raise ValueError("Cannot partition an empty prompt for Helix CP: num_total_blocks == 0.")
+    # NOTE: When num_total_blocks < cp_size, CP ranks in [num_total_blocks, cp_size)
+    # own zero blocks ("empty" ranks). This is supported: such ranks contribute a
+    # no-op (-inf, 0) to the Helix attention combine and receive zero KV blocks
+    # during cache transmission. Rank 0 always owns global block 0, so the combine
+    # denominator is never zero.
 
     # Pad the last (partial) block so every block has exactly tokens_per_block tokens.
     padding_len = 0
@@ -280,10 +286,14 @@ def partition_context_for_helix(
     input_id_blocks = list(all_input_ids.split(tokens_per_block, dim=-1))
     position_id_blocks = list(all_position_ids.split(tokens_per_block, dim=-1))
 
-    input_ids_this_rank = torch.cat(input_id_blocks[cp_rank::cp_size], dim=-1).flatten().tolist()
-    position_ids_this_rank = (
-        torch.cat(position_id_blocks[cp_rank::cp_size], dim=-1).flatten().tolist()
-    )
+    curank_input_blocks = input_id_blocks[cp_rank::cp_size]
+    curank_position_blocks = position_id_blocks[cp_rank::cp_size]
+    # Empty rank: this CP rank owns no blocks for this sequence (num_total_blocks < cp_size).
+    if len(curank_input_blocks) == 0:
+        return [], [], input_len, padding_len
+
+    input_ids_this_rank = torch.cat(curank_input_blocks, dim=-1).flatten().tolist()
+    position_ids_this_rank = torch.cat(curank_position_blocks, dim=-1).flatten().tolist()
 
     # The (single) padded block is the global last block; under round-robin it is owned by rank
     # (num_total_blocks - 1) % cp_size, and is the last local block on that rank. Strip its padding.

--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -2268,19 +2268,22 @@ def test_llama4_long_context_kv_cache_overflow(disaggregated_test_root,
                              cwd=llm_venv.get_working_directory())
 
 
+@pytest.mark.timeout(2400)
 @pytest.mark.skip_less_device(4)
+@pytest.mark.parametrize("prompt_file", ["prompts.json", "long_prompts.json"],
+                         ids=["short_prompt", "long_prompt"])
 @pytest.mark.parametrize("deepseek_v3_model_root", ['DeepSeek-V3-Lite-bf16'],
                          indirect=True)
 def test_disaggregated_deepseek_v3_lite_bf16_tllm_gen_helix(
         disaggregated_test_root, disaggregated_example_root, llm_venv,
-        deepseek_v3_model_root):
+        deepseek_v3_model_root, prompt_file):
     setup_model_symlink(llm_venv, deepseek_v3_model_root,
                         "DeepSeek-V3-Lite/bf16")
 
     run_disaggregated_test(disaggregated_example_root,
                            "deepseek_v3_lite_bf16_tllm_gen_helix",
                            env=llm_venv._new_env,
-                           prompt_file="long_prompts.json",
+                           prompt_file=prompt_file,
                            model_path=deepseek_v3_model_root,
                            cwd=llm_venv.get_working_directory())
 

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -861,6 +861,8 @@ disaggregated/test_disaggregated.py::test_disaggregated_cuda_graph[TinyLlama-1.1
 disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_bf16_cache_aware_balance[DeepSeek-V3-Lite-bf16]
 disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_bf16_conditional[DeepSeek-V3-Lite-bf16]
 disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_bf16_empty_batch[DeepSeek-V3-Lite-bf16]
+disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_bf16_tllm_gen_helix[DeepSeek-V3-Lite-bf16-short_prompt]
+disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_bf16_tllm_gen_helix[DeepSeek-V3-Lite-bf16-long_prompt]
 disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_fp8_attention_dp[DeepSeek-V3-Lite-fp8]
 disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_fp8_attention_dp_gen_only[DeepSeek-V3-Lite-fp8]
 disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_fp8_attention_dp_one[DeepSeek-V3-Lite-fp8]

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -227,6 +227,8 @@ l0_dgx_b200:
   - accuracy/test_disaggregated_serving.py::TestQwen3_8B::test_auto_dtype_with_helix[fifo_v1-cudagraph:with_padding-pp1dp2cp2] TIMEOUT (60)
   - accuracy/test_disaggregated_serving.py::TestDeepSeekV32Exp::test_auto_dtype_with_helix[fifo-cudagraph:with_padding-pp1dp2cp2] TIMEOUT (60)
   - accuracy/test_disaggregated_serving.py::TestDeepSeekV32Exp::test_auto_dtype_with_helix[fifo-cudagraph:with_padding-pp2tp1cp2] TIMEOUT (60)
+  - disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_bf16_tllm_gen_helix[DeepSeek-V3-Lite-bf16-short_prompt] TIMEOUT (60)
+  - disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_bf16_tllm_gen_helix[DeepSeek-V3-Lite-bf16-long_prompt] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekR1::test_nvfp4_multi_gpus_corner_case TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_fp8_blockscale[baseline_fp8kv] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_fp8_blockscale[latency] TIMEOUT (60)

--- a/tests/unittest/_torch/executor/test_request_utils.py
+++ b/tests/unittest/_torch/executor/test_request_utils.py
@@ -154,13 +154,19 @@ def test_merge_helix_requests_without_padding():
             assert llm_request.get_tokens(0) == [5, 6, 7, 8]
 
 
-def test_merge_helix_requests_insufficient_blocks_error():
-    """Test merge_helix_requests raises error when insufficient blocks."""
+def test_merge_helix_requests_empty_ranks():
+    """When num_total_blocks < cp_size, the highest CP ranks own no blocks.
+
+    Such "empty" ranks must produce an empty token list (and seqlen_this_rank_cp
+    == 0), while total_input_len_cp still reflects the full prompt length so the
+    global position ids stay correct. They are no longer rejected.
+    """
     tokens_per_block = 4
 
-    # Create input with only 12 tokens. This creates 3 blocks which is fewer than 4 CP ranks.
+    # 12 tokens -> 3 blocks, which is fewer than 4 CP ranks, so rank 3 is empty.
+    input_tokens = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     executor_request = trtllm.Request(
-        input_token_ids=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+        input_token_ids=input_tokens,
         max_tokens=12,
         streaming=False,
         sampling_config=trtllm.SamplingConfig(),
@@ -171,18 +177,92 @@ def test_merge_helix_requests_insufficient_blocks_error():
         request=executor_request,
     )
 
-    # Loop over ranks 0, 1, 2, 3 and verify that all ranks throw assertion.
+    from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
+
+    # Round-robin block distribution across 4 CP ranks (3 blocks total, 4 tokens/block):
+    #   rank 0 owns block {0} -> tokens [1,2,3,4]
+    #   rank 1 owns block {1} -> tokens [5,6,7,8]
+    #   rank 2 owns block {2} -> tokens [9,10,11,12]
+    #   rank 3 owns no blocks -> [] (empty rank)
+    expected_tokens = {
+        0: [1, 2, 3, 4],
+        1: [5, 6, 7, 8],
+        2: [9, 10, 11, 12],
+        3: [],
+    }
     for rank in range(4):
-        with pytest.raises(
-            ValueError, match="There aren't enough tokens to get at least one block per CP rank"
-        ):
-            merge_helix_requests(
-                [request_item],
-                cp_rank=rank,
-                cp_size=4,
-                tokens_per_block=tokens_per_block,
-                exclude_last_generation_logits=False,
-            )
+        result = merge_helix_requests(
+            [request_item],
+            cp_rank=rank,
+            cp_size=4,
+            tokens_per_block=tokens_per_block,
+            exclude_last_generation_logits=False,
+        )
+
+        assert len(result) == 1
+        llm_request = result[0]
+        assert isinstance(llm_request, LlmRequest)
+        assert llm_request.request_id == 1
+        assert llm_request.get_tokens(0) == expected_tokens[rank]
+        # total_input_len_cp is always the full prompt length.
+        assert llm_request.total_input_len_cp == len(input_tokens)
+        assert llm_request.seqlen_this_rank_cp == len(expected_tokens[rank])
+
+
+def test_merge_helix_requests_empty_ranks_with_padding():
+    """Exercise padding-strip-on-last-owner and empty ranks together.
+
+    With 10 tokens and tokens_per_block=4 there are 3 blocks, the last of which
+    is partially filled (tokens [9, 10]). Distributed round-robin over 4 CP
+    ranks, the last block owner (rank 2) must strip the block padding while the
+    block-less rank (rank 3) must be an empty rank.
+    """
+    tokens_per_block = 4
+
+    # 10 tokens -> 3 blocks (last block half-full), fewer than 4 CP ranks.
+    input_tokens = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    executor_request = trtllm.Request(
+        input_token_ids=input_tokens,
+        max_tokens=12,
+        streaming=False,
+        sampling_config=trtllm.SamplingConfig(),
+        output_config=trtllm.OutputConfig(),
+    )
+    request_item = RequestQueueItem(
+        id=1,
+        request=executor_request,
+    )
+
+    from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
+
+    # Round-robin block distribution across 4 CP ranks (3 blocks, 4 tokens/block):
+    #   rank 0 owns block {0} -> tokens [1,2,3,4]
+    #   rank 1 owns block {1} -> tokens [5,6,7,8]
+    #   rank 2 owns block {2} -> tokens [9,10]  (last block; padding stripped)
+    #   rank 3 owns no blocks -> [] (empty rank)
+    expected_tokens = {
+        0: [1, 2, 3, 4],
+        1: [5, 6, 7, 8],
+        2: [9, 10],
+        3: [],
+    }
+    for rank in range(4):
+        result = merge_helix_requests(
+            [request_item],
+            cp_rank=rank,
+            cp_size=4,
+            tokens_per_block=tokens_per_block,
+            exclude_last_generation_logits=False,
+        )
+
+        assert len(result) == 1
+        llm_request = result[0]
+        assert isinstance(llm_request, LlmRequest)
+        assert llm_request.request_id == 1
+        assert llm_request.get_tokens(0) == expected_tokens[rank]
+        # total_input_len_cp is always the full prompt length.
+        assert llm_request.total_input_len_cp == len(input_tokens)
+        assert llm_request.seqlen_this_rank_cp == len(expected_tokens[rank])
 
 
 @patch("tensorrt_llm._torch.pyexecutor.request_utils.executor_request_to_llm_request")

--- a/tests/unittest/_torch/thop/parallel_hw_agnostic/test_helix_postprocess.py
+++ b/tests/unittest/_torch/thop/parallel_hw_agnostic/test_helix_postprocess.py
@@ -20,6 +20,19 @@ import torch
 from parameterized import parameterized
 
 import tensorrt_llm
+from tensorrt_llm._torch.modules.attention import _helix_sanitize_empty_kv, _helix_zero_kv_mask
+
+
+class _FakeAttnMetadata:
+    """Minimal stand-in exposing only the fields _helix_zero_kv_mask reads."""
+
+    def __init__(self, kv_lens_cuda=None, seq_lens_cuda=None):
+        self.kv_lens_cuda = kv_lens_cuda
+        self.seq_lens_cuda = seq_lens_cuda
+
+    @property
+    def num_seqs(self):
+        return self.seq_lens_cuda.shape[0]
 
 
 def baseline(gathered_o, gathered_stats, kv_lora_rank, scale, native_v1=False, native_v2=False):
@@ -289,6 +302,52 @@ class TestHelixPostProcess(unittest.TestCase):
             native_v2=native_v2,
         )
 
+    def test_helix_postprocess_empty_rank_noop(self):
+        """A CP rank that owns no KV blocks (num_total_blocks < cp_size) must be a
+        no-op in the combine: it contributes (-inf, 0) softmax stats and a zeroed
+        partial output. The result must match combining only the non-empty ranks
+        and stay finite.
+
+        This mirrors the Python post-sanitization in _helix_post_process, which
+        forces zero-local-KV rows to (-inf, 0) and zeros their partial output
+        before this op runs.
+        """
+        device = torch.device("cuda")
+        cp_size, num_tokens, num_heads, kv_lora_rank = 4, 8, 2, 64
+        dtype = torch.float16
+        scale = 1.0
+
+        gathered_o = torch.empty(
+            cp_size, num_tokens, num_heads, kv_lora_rank, dtype=dtype, device=device
+        ).uniform_(-1, 1)
+        gathered_stats = torch.empty(
+            cp_size, num_tokens, num_heads, 2, dtype=torch.float32, device=device
+        )
+        gathered_o_max = torch.max(gathered_o, dim=-1, keepdim=True)[0]
+        gathered_stats[..., 0] = gathered_o_max[..., 0]
+        gathered_stats[..., 1] = torch.sum(torch.exp(gathered_o - gathered_o_max), dim=-1)
+
+        # Mark the highest CP rank as "empty" (rank 0 always owns block 0, so it
+        # is never empty). Empty rank: (-inf, 0) stats and zeroed partial output.
+        empty = cp_size - 1
+        gathered_stats[empty, ..., 0] = float("-inf")
+        gathered_stats[empty, ..., 1] = 0.0
+        gathered_o[empty] = 0.0
+
+        gathered_o_v = gathered_o.view(cp_size, num_tokens, num_heads * kv_lora_rank)
+        output = torch.ops.trtllm.helix_post_process(gathered_o_v, gathered_stats, scale)
+
+        # Reference: combine only the non-empty ranks.
+        expected = baseline(
+            gathered_o_v[:empty].contiguous(),
+            gathered_stats[:empty].contiguous(),
+            kv_lora_rank,
+            scale,
+        )
+
+        assert torch.isfinite(output).all()
+        torch.testing.assert_close(output, expected, atol=1e-3, rtol=1e-2)
+
     def test_helix_postprocess_invalid_inputs(self):
         """Test error handling for invalid inputs (non-native)"""
         device = torch.device("cuda")
@@ -412,6 +471,82 @@ class TestHelixPostProcess(unittest.TestCase):
             gathered_stats = torch.randn(4, 8, 1, 2, dtype=torch.float32, device=device)
             with pytest.raises(RuntimeError):
                 torch.ops.trtllm.helix_post_process(gathered_o, gathered_stats, 1.0)
+
+
+class TestHelixZeroKvMask(unittest.TestCase):
+    """Unit tests for the per-token zero-local-KV mask helper.
+
+    kv_lens_cuda is per-sequence, so the helper must expand it to per-token using
+    seq_lens_cuda. This matters when a sequence spans multiple tokens (e.g.
+    speculative decoding), where num_tokens != num_seqs.
+    """
+
+    def test_single_token_per_seq(self):
+        # Plain decode: one token per sequence, so per-seq == per-token.
+        # Seq 1 owns zero KV blocks on this rank.
+        meta = _FakeAttnMetadata(
+            kv_lens_cuda=torch.tensor([5, 0, 7], dtype=torch.int32),
+            seq_lens_cuda=torch.tensor([1, 1, 1], dtype=torch.int32),
+        )
+        mask = _helix_zero_kv_mask(meta, num_tokens=3)
+        expected = torch.tensor([False, True, False])
+        torch.testing.assert_close(mask, expected)
+
+    def test_multi_token_per_seq_spec_dec(self):
+        # Speculative decoding: each gen sequence spans multiple tokens, so the
+        # per-sequence empty flag must be expanded by seq_lens (num_tokens=9).
+        meta = _FakeAttnMetadata(
+            kv_lens_cuda=torch.tensor([5, 0, 7], dtype=torch.int32),
+            seq_lens_cuda=torch.tensor([3, 3, 3], dtype=torch.int32),
+        )
+        mask = _helix_zero_kv_mask(meta, num_tokens=9)
+        expected = torch.tensor([False, False, False, True, True, True, False, False, False])
+        torch.testing.assert_close(mask, expected)
+
+    def test_generation_slice_with_contexts(self):
+        # MLA passes only the generation slice: seq 0 is context, seqs 1-2 are
+        # generations spanning 2 tokens each (num_tokens=4). Seq 1 is empty.
+        meta = _FakeAttnMetadata(
+            kv_lens_cuda=torch.tensor([10, 0, 4], dtype=torch.int32),
+            seq_lens_cuda=torch.tensor([8, 2, 2], dtype=torch.int32),
+        )
+        mask = _helix_zero_kv_mask(meta, num_tokens=4, seq_start=1, num_seqs=2)
+        expected = torch.tensor([True, True, False, False])
+        torch.testing.assert_close(mask, expected)
+
+    def test_returns_none_without_buffers(self):
+        # Missing either buffer disables masking.
+        assert _helix_zero_kv_mask(_FakeAttnMetadata(), num_tokens=4) is None
+        meta = _FakeAttnMetadata(kv_lens_cuda=torch.tensor([0, 1]))
+        assert _helix_zero_kv_mask(meta, num_tokens=2) is None
+
+    def test_sanitize_forces_noop_and_clears_nan(self):
+        # Empty-rank rows (with NaNs from zero-key softmax) must become a no-op:
+        # zeroed partial output and (-inf, 0) softmax stats.
+        partial_o = torch.tensor([[1.0, 2.0], [float("nan"), float("nan")], [3.0, 4.0]])
+        softmax_stats = torch.tensor(
+            [
+                [[0.5, 1.0]],
+                [[float("nan"), 0.0]],
+                [[0.7, 2.0]],
+            ]
+        )
+        mask = torch.tensor([False, True, False])
+        out_o, out_stats = _helix_sanitize_empty_kv(partial_o, softmax_stats, mask)
+
+        assert torch.isfinite(out_o).all()
+        torch.testing.assert_close(out_o[1], torch.zeros(2))
+        # Non-masked rows are untouched.
+        torch.testing.assert_close(out_o[0], torch.tensor([1.0, 2.0]))
+        assert out_stats[1, 0, 0] == float("-inf")
+        assert out_stats[1, 0, 1] == 0.0
+
+    def test_sanitize_none_mask_is_passthrough(self):
+        partial_o = torch.randn(3, 2)
+        softmax_stats = torch.randn(3, 1, 2)
+        out_o, out_stats = _helix_sanitize_empty_kv(partial_o, softmax_stats, None)
+        assert out_o is partial_o
+        assert out_stats is softmax_stats
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

With Helix context parallelism (CP), a sequence's KV cache is sharded across CP ranks. When a sequence has fewer KV blocks than the CP size, the highest CP rank(s) own zero blocks for that sequence ("empty" ranks). This shows up most easily with short prompts on cp_size > 1.

Empty Helix CP ranks aren't supported on main. This MR adds support for the same.

## Test Coverage

```
$ pytest tests/integration/defs/disaggregated/test_disaggregated.py::test_disaggregated_deepseek_v3_lite_bf16_tllm_gen_helix -s -v
$ pytest tests/unittest/_torch/thop/parallel_hw_agnostic/test_helix_postprocess.py::TestHelixPostProcess::test_helix_postprocess_empty_rank_noop -s -v
$ pytest tests/unittest/_torch/executor/test_request_utils.py::test_merge_helix_requests_empty_ranks -s -v
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved edge case handling for context parallelism scenarios where some ranks own zero KV cache blocks, preventing potential undefined behavior and failed transfers.

* **New Features**
  * Added support for asymmetric KV cache block distribution across context parallel ranks in Helix mode.

* **Tests**
  * Added test coverage for context parallelism with empty ranks and asymmetric block distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->