### PR TITLE
[None][feat] DSv4 prep: attention op plumbing

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -733,6 +733,10 @@ class AttentionSparseArgs:
     sparse_attn_indices: Optional[torch.Tensor] = None
     sparse_attn_offsets: Optional[torch.Tensor] = None
     sparse_attn_indices_block_size: int = 0
+    # DeepSeek-V4 sparse-MLA only: per-token compressed top-k lengths and the
+    # base pointer of the compressed KV cache pool (compress_ratio > 1).
+    sparse_mla_topk_lens: Optional[torch.Tensor] = None
+    compressed_kv_cache_pool_ptr: Optional[int] = None
 
 
 @dataclass(kw_only=True, slots=True)

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1641,8 +1641,6 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                 max_seq_len=metadata.max_seq_len,
                 trtllm_gen_jit_warmup=metadata.trtllm_gen_jit_warmup,
                 is_cross=metadata.is_cross,
-                spec_decoding_target_max_draft_tokens=metadata.
-                max_total_draft_tokens,
 
                 # --- Per-call (AttentionForwardArgs) ---
                 out_scale=forward_args.out_scale,
@@ -1722,6 +1720,8 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                 sparse_mla_topk_lens=forward_args.sparse.sparse_mla_topk_lens,
                 compressed_kv_cache_pool_ptr=forward_args.sparse.
                 compressed_kv_cache_pool_ptr,
+                spec_decoding_target_max_draft_tokens=getattr(
+                    metadata, 'max_total_draft_tokens', None),
 
                 # --- Literals intentionally in _THOP_LITERALS ---
             )

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1641,6 +1641,8 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                 max_seq_len=metadata.max_seq_len,
                 trtllm_gen_jit_warmup=metadata.trtllm_gen_jit_warmup,
                 is_cross=metadata.is_cross,
+                spec_decoding_target_max_draft_tokens=metadata.
+                max_total_draft_tokens,
 
                 # --- Per-call (AttentionForwardArgs) ---
                 out_scale=forward_args.out_scale,
@@ -1720,8 +1722,6 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                 sparse_mla_topk_lens=forward_args.sparse.sparse_mla_topk_lens,
                 compressed_kv_cache_pool_ptr=forward_args.sparse.
                 compressed_kv_cache_pool_ptr,
-                spec_decoding_target_max_draft_tokens=getattr(
-                    metadata, 'max_total_draft_tokens', None),
 
                 # --- Literals intentionally in _THOP_LITERALS ---
             )

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1629,6 +1629,8 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                 spec_decoding_bl_tree_mask_offset=metadata.
                 spec_decoding_bl_tree_mask_offset,
                 spec_decoding_bl_tree_mask=metadata.spec_decoding_bl_tree_mask,
+                spec_decoding_target_max_draft_tokens=metadata.
+                max_total_draft_tokens,
                 spec_bl_tree_first_sparse_mask_offset_kv=metadata.
                 spec_bl_tree_first_sparse_mask_offset_kv,
                 num_sparse_topk=metadata.num_sparse_topk,
@@ -1641,8 +1643,6 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                 max_seq_len=metadata.max_seq_len,
                 trtllm_gen_jit_warmup=metadata.trtllm_gen_jit_warmup,
                 is_cross=metadata.is_cross,
-                spec_decoding_target_max_draft_tokens=metadata.
-                max_total_draft_tokens,
 
                 # --- Per-call (AttentionForwardArgs) ---
                 out_scale=forward_args.out_scale,

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1641,6 +1641,8 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                 max_seq_len=metadata.max_seq_len,
                 trtllm_gen_jit_warmup=metadata.trtllm_gen_jit_warmup,
                 is_cross=metadata.is_cross,
+                spec_decoding_target_max_draft_tokens=metadata.
+                max_total_draft_tokens,
 
                 # --- Per-call (AttentionForwardArgs) ---
                 out_scale=forward_args.out_scale,
@@ -1718,10 +1720,10 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                 sparse_attn_indices_block_size=forward_args.sparse.
                 sparse_attn_indices_block_size,
                 sparse_mla_topk_lens=forward_args.sparse.sparse_mla_topk_lens,
-                compressed_kv_cache_pool_ptr=(
-                    forward_args.sparse.compressed_kv_cache_pool_ptr),
-                spec_decoding_target_max_draft_tokens=metadata.
-                max_total_draft_tokens,
+                compressed_kv_cache_pool_ptr=forward_args.sparse.
+                compressed_kv_cache_pool_ptr,
+
+                # --- Literals intentionally in _THOP_LITERALS ---
             )
 
         if self.print_skip_softmax_stat:

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -22,9 +22,9 @@ from ..utils import (compute_swizzled_sf_shape, get_global_attrs,
                      get_model_extra_attrs)
 from .interface import (AttentionBackend, AttentionForwardArgs,
                         AttentionInputType, AttentionMask, AttentionMetadata,
-                        AttentionSparseArgs, KVCacheParams, MLAParams,
-                        PositionalEmbeddingParams, PredefinedAttentionMask,
-                        RopeParams, merge_attention_forward_args)
+                        KVCacheParams, MLAParams, PositionalEmbeddingParams,
+                        PredefinedAttentionMask, RopeParams,
+                        merge_attention_forward_args)
 
 # Enable TRTLLM-Gen attention backend by default. Set
 # TRTLLM_ENABLE_TRTLLM_GEN_ATTENTION=0 to force the thop.attention path.
@@ -44,10 +44,7 @@ _THOP_EXCLUDED_FIELDS: frozenset = frozenset({
 # ``thop.attention`` kwargs hard-wired to a literal at the call site (no
 # rich object owns them). Sync test enforces both the kwarg name and the
 # literal value.
-_THOP_LITERALS: dict = {
-    "sparse_mla_topk_lens": None,
-    "compressed_kv_cache_pool_ptr": None,
-}
+_THOP_LITERALS: dict = {}
 
 
 @functools.cache
@@ -114,6 +111,7 @@ class TrtllmAttentionMetadata(AttentionMetadata):
     is_spec_dec_dynamic_tree: bool = False
 
     # parameters required for spec-dec mode
+    max_total_draft_tokens: Optional[int] = None
     spec_decoding_position_offsets: Optional[torch.Tensor] = None
     # C++ attention op requires a 2-D position_offsets tensor and reads
     # sizes()[1] as the generation length / packed-mask row stride.
@@ -1719,14 +1717,11 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                 sparse_attn_offsets=forward_args.sparse.sparse_attn_offsets,
                 sparse_attn_indices_block_size=forward_args.sparse.
                 sparse_attn_indices_block_size,
-
-                # --- Literals intentionally None (see _THOP_LITERALS) ---
-                # ``sparse_mla_topk_lens`` and ``compressed_kv_cache_pool_ptr``
-                # stay as literal ``None`` until DeepSeek V4 sparse-MLA lands.
-                sparse_mla_topk_lens=None,
-                compressed_kv_cache_pool_ptr=None,
-                spec_decoding_target_max_draft_tokens=getattr(
-                    metadata, 'max_total_draft_tokens', None),
+                sparse_mla_topk_lens=forward_args.sparse.sparse_mla_topk_lens,
+                compressed_kv_cache_pool_ptr=(
+                    forward_args.sparse.compressed_kv_cache_pool_ptr),
+                spec_decoding_target_max_draft_tokens=metadata.
+                max_total_draft_tokens,
             )
 
         if self.print_skip_softmax_stat:
@@ -1811,14 +1806,13 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                                                     forward_args)
             at_idx, at_off = self.sparse_attn_predict(q, k, metadata,
                                                       forward_args)
-            forward_args.sparse = AttentionSparseArgs(
-                sparse_kv_indices=kv_idx,
-                sparse_kv_offsets=kv_off,
-                sparse_attn_indices=at_idx,
-                sparse_attn_offsets=at_off,
-                sparse_attn_indices_block_size=self.sparse_attention_config.
-                get_indices_block_size(),
-            )
+            sparse_args = forward_args.sparse
+            sparse_args.sparse_kv_indices = kv_idx
+            sparse_args.sparse_kv_offsets = kv_off
+            sparse_args.sparse_attn_indices = at_idx
+            sparse_args.sparse_attn_offsets = at_off
+            sparse_args.sparse_attn_indices_block_size = (
+                self.sparse_attention_config.get_indices_block_size())
 
         # Compute FlashMLA tile-scheduler metadata once per forward pass.
         # The flag is reset in prepare_flash_mla() and update_for_spec_dec() to trigger


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for DeepSeek-V4 sparse-MLA (Multi-Head Latent Attention) algorithm with optimized attention handling for sparse patterns.
  * Enhanced speculative decoding integration with improved metadata tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

This PR adds the remaining Python-side attention-op plumbing needed for the DSv4 split:

- exposes optional sparse-MLA handoff fields on `AttentionSparseArgs`
- forwards `sparse_mla_topk_lens` and `compressed_kv_cache_pool_ptr` into `thop.attention`
- populates those fields for sparse configs with `algorithm == "deepseek_v4"` using duck-typed metadata/config fields, without importing `DeepSeekV4SparseAttentionConfig` or any DSv4 model/backend/cache-manager modules
- explicitly declares `TrtllmAttentionMetadata.max_total_draft_tokens` so the attention-op sync test can validate the thop call site without a dynamic `getattr`

This is intentionally limited to shared TRTLLM attention backend/interface plumbing. The DSv4 sparse backend and cache-manager implementation are left for the later split PR that consumes these fields.

## Test Coverage

- Build/install:
  - `python3 ./scripts/build_wheel.py --trt_root /usr/local/tensorrt --benchmarks --use_ccache --cuda_architectures "90-real;100-real" --configure_cmake`
  - `.venv-3.12/bin/python -m pip install --force-reinstall --no-deps build/tensorrt_llm-1.3.0rc18-cp312-cp312-linux_x86_64.whl`
- Import/scope:
  - import smoke confirmed `tensorrt_llm`, `tensorrt_llm._torch.attention_backend.trtllm`, and `tensorrt_llm.bindings.internal.thop` load from this worktree / installed wheel
  - negative import assertion confirmed no `modeling_deepseekv4`, DSv4 sparse backend, or DSv4 sparse cache-manager module is loaded by importing `trtllm.py`
  - scope grep confirmed only `tensorrt_llm/_torch/attention_backend/interface.py` and `tensorrt_llm/_torch/attention_backend/trtllm.py` are changed, with no compressor/mHC, IndexerTopK/TopK, MoE, DSv4 model/tokenizer, fusion/custom-op, or sparse-backend implementation files
- Tests:
  - `CUDA_VISIBLE_DEVICES=0 timeout 1800 .venv-3.12/bin/python -m pytest -q --tb=short -ra tests/unittest/_torch/attention/sparse/test_cpp_custom_ops.py`
    - 43 passed, 2 warnings in 2.33s
  - `CUDA_VISIBLE_DEVICES=0 timeout 600 .venv-3.12/bin/python -m pytest -q --tb=short -ra tests/unittest/_torch/attention_backend/test_attention_op_sync.py`
    - 7 passed, 2 warnings in 1.25s

Also attempted `tests/unittest/_torch/attention/test_attention_mla.py` on idle GPU 0. It failed in existing TRTLLM-Gen FMHA NVRTC preprocessing at step 1 with `could not open source file "cuda.h" (no directories in search list)`. Retrying the failing case with `CPATH=/usr/local/cuda-13.1/targets/x86_64-linux/include` produced the same NVRTC include-path error, so this is recorded as an environment/runtime include issue rather than a PR-4 plumbing assertion failure.

Build note: attribution generation warned `ninja -t inputs returned no results for wheel targets`, but the wheel build exited 0.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
