### PR TITLE
[TRTLLM-13248][feat] Wave 3: migrate MoE staged hooks

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -1761,15 +1761,18 @@ class Indexer(nn.Module):
             warmup_heuristic_topk_decode(top_k=self.index_topk)
 
         # Fused wk + weights_proj weight for single FP32 cuBLAS GEMM
-        # (populated in post_load_weights; maps to TF32 tensor cores on Ampere+)
+        # (populated in cache_derived_state; maps to TF32 tensor cores on Ampere+)
         self._fused_wk_wp_weight: Optional[torch.Tensor] = None
 
-    def post_load_weights(self):
+    def cache_derived_state(self) -> None:
         """Fuse wk + weights_proj into single FP32 weight for F.linear GEMM under allow_tf32 (TF32 tensor cores on Ampere+)."""
         # wk: [head_dim, hidden_size] + weights_proj: [n_heads, hidden_size]
         # → fused: [head_dim + n_heads, hidden_size]
         self._fused_wk_wp_weight = torch.cat(
             [self.wk.weight.data, self.weights_proj.weight.data], dim=0)
+
+    def post_load_weights(self) -> None:
+        self.cache_derived_state()
 
     @staticmethod
     def prepare_one_prefill_chunk(
@@ -2835,7 +2838,7 @@ class Indexer(nn.Module):
         split in MLA.forward_dsa_proj sees a stable signature.
         """
         assert self._fused_wk_wp_weight is not None, \
-            "post_load_weights() must be called before forward()"
+            "cache_derived_state() must be called before forward()"
         hidden_float = _to_float(hidden_states)
         with _tf32_matmul_enabled():
             # F.linear computes input @ weight.T internally; no explicit .t() needed.

--- a/tensorrt_llm/_torch/models/modeling_llama_min_latency.py
+++ b/tensorrt_llm/_torch/models/modeling_llama_min_latency.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from collections.abc import Callable
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -308,7 +323,7 @@ class Llama4MinLatencyGatedMLP(GatedMLP):
 
     # After loading both gate_up_proj and down_proj, we need to set the scales needed by the special kernels and by
     # the trtllm-gen gemm+swiglu kernel.
-    def post_load_weights(self):
+    def cache_derived_state(self) -> None:
         if self.gate_up_proj.has_fp8_qdq:
             # For the special gemm+swiglu kernel, we need to set the inverse of the output scale, which is the inverse
             # of down_proj's combined input scale.
@@ -316,6 +331,9 @@ class Llama4MinLatencyGatedMLP(GatedMLP):
             # For the trtllm-gen gemm+swiglu kernel, we need to set the global scale, which is gate_up_proj's
             # combined input scale times inv_output_scale.
             self.gate_up_proj.trtllm_gen_global_scale = self.gate_up_proj.combined_scale * self.gate_up_proj.inv_output_scale
+
+    def post_load_weights(self) -> None:
+        self.cache_derived_state()
 
     def forward(
         self,
@@ -566,7 +584,7 @@ class Llama4MinLatencyMoE(Llama4MoE):
             dtype=model_config.pretrained_config.torch_dtype,
             quant_config=None)
 
-    def post_load_weights(self):
+    def cache_derived_state(self) -> None:
         # Set min-latency quant scales for routed experts if we plan to use min-latency MoE kernels.
         # This is because the routed experts' input scale is after the score multiplication, so we must use the
         # pre-score scaling input scale, which happens to be shared expert's input scale.
@@ -581,6 +599,9 @@ class Llama4MinLatencyMoE(Llama4MoE):
                 fc2_dequant=self.experts.fc2_dequant,
                 fc1_input_dequant=pre_score_scaling_input_scale,
             )
+
+    def post_load_weights(self) -> None:
+        self.cache_derived_state()
 
     def compute_routed_output(
             self,

--- a/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 ConfigurableMoE: Composition-based Configurable MoE Module
 
@@ -73,7 +72,6 @@ class ConfigurableMoE(MoE):
     # authoritative check -- if the chosen inner backend doesn't opt in, its
     # ``MoE.__init__`` will still raise.
     _supports_non_divisible_ep: bool = True
-
     """
     Configurable MoE layer using composition pattern with automatic configuration
 
@@ -654,17 +652,33 @@ class ConfigurableMoE(MoE):
         assert hasattr(self.backend, "load_weights"), (
             f"Backend {self.backend.__class__.__name__} must implement load_weights()"
         )
-        return self.backend.load_weights(weights, allow_partial_loading)
+        result = self.backend.load_weights(weights, allow_partial_loading)
+        if weights:
+            self._weights_transformed = False
+        return result
 
-    def post_load_weights(self):
+    def transform_weights(self) -> None:
         """
-        Post load weights processing - delegated to backend
+        Transform weights - delegated to backend
 
         """
-        assert hasattr(self.backend, "post_load_weights"), (
-            f"Backend {self.backend.__class__.__name__} must implement post_load_weights()"
+        if getattr(self, "_weights_transformed", False):
+            return
+        assert hasattr(self.backend, "transform_weights"), (
+            f"Backend {self.backend.__class__.__name__} must implement transform_weights()"
         )
-        return self.backend.post_load_weights()
+        self.backend.transform_weights()
+        self._weights_transformed = True
+
+    def cache_derived_state(self) -> None:
+        """
+        Cache derived state - delegated to backend
+
+        """
+        assert hasattr(self.backend, "cache_derived_state"), (
+            f"Backend {self.backend.__class__.__name__} must implement cache_derived_state()"
+        )
+        self.backend.cache_derived_state()
 
     def process_weights_after_loading(self):
         """

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cute_dsl_b12x.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cute_dsl_b12x.py
@@ -68,7 +68,7 @@ class CuteDslB12xFusedMoE(CuteDslFusedMoE):
     ``_get_quant_method``). The inherited CUTLASS NVFP4 layout is finalised
     by the base class, and the b12x-shaped tensors (un-normalised FP8 SF,
     ``convert_sf_to_mma_layout`` reshape, ``B12xMoEWrapper`` instance) are
-    materialised on top by the quant method's ``post_load_weights``. Both
+    materialised on top by the quant method's ``transform_weights``. Both
     layouts coexist in memory and the dispatcher picks per call based on
     ``x.shape[0]``.
 
@@ -173,7 +173,7 @@ class CuteDslB12xFusedMoE(CuteDslFusedMoE):
         return isinstance(x, torch.Tensor) and x.shape[0] >= self._PREFILL_VIA_CUTLASS_THRESHOLD
 
     # ``post_load_weights`` is inherited from ``CutlassFusedMoE`` and
-    # dispatches to ``self.quant_method.post_load_weights(self)`` — for this
+    # dispatches to ``self.quant_method.transform_weights(self)`` — for this
     # backend ``self.quant_method`` is ``NVFP4CuteDslB12xFusedMoEMethod``
     # (see ``_get_quant_method`` override), which performs the SF un-normalization,
     # ``convert_sf_to_mma_layout`` reshape, ``B12xMoEWrapper`` instantiation,

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import inspect
 import os
 from functools import cached_property
@@ -1621,6 +1636,3 @@ class CutlassFusedMoE(MoE):
             kargs["allow_partial_loading"] = allow_partial_loading
         self.quant_method.load_weights(self, weights, self.weight_loading_mode,
                                        **kargs)
-
-    def post_load_weights(self):
-        self.quant_method.post_load_weights(self)

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_densegemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_densegemm.py
@@ -290,9 +290,6 @@ class DenseGEMMFusedMoE(MoE):
                     f"got {self.quant_config.quant_mode}."
                 )
 
-    def post_load_weights(self):
-        self.quant_method.post_load_weights(self)
-
     def _transform_w2_weight_scale_for_min_latency(self):
         """Transform w2_weight_scale for minimum latency path optimization."""
         # Calculate padded dimensions

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_triton.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_triton.py
@@ -1377,7 +1377,7 @@ class TritonMXFP4FusedMoEMethod(TritonUnquantizedFusedMoEMethod):
 
         return gemm2_output
 
-    def post_load_weights(self, module: torch.nn.Module):
+    def transform_weights(self, module: torch.nn.Module) -> None:
         if 'w3_w1_weight' in module._parameters:
             w31_scale = shuffle_weight_for_activation_kernel(
                 module.fc31_dequant.data)
@@ -1391,7 +1391,7 @@ class TritonMXFP4FusedMoEMethod(TritonUnquantizedFusedMoEMethod):
                 module.fc31_input_dequant = None
                 module.fc2_input_dequant = None
 
-        super().post_load_weights(module)
+        super().transform_weights(module)
 
 
 class TritonFusedMoE(MoE):
@@ -1595,6 +1595,3 @@ class TritonFusedMoE(MoE):
         weights = weights[0]
 
         self.quant_method.load_weights(self, weights, self.weight_loading_mode)
-
-    def post_load_weights(self):
-        self.quant_method.post_load_weights(self)

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py
@@ -552,9 +552,6 @@ class TRTLLMGenFusedMoE(MoE):
         self.quant_method.load_weights(self, weights, self.weight_loading_mode,
                                        **kargs)
 
-    def post_load_weights(self):
-        self.quant_method.post_load_weights(self)
-
     def quantize_input(self, x, post_quant_comm: bool = True):
         """Quantize inputs prior to post-communication (alltoall/allgather) or before MoE computation.
 

--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import inspect
 import os
 from typing import Dict, List, Optional, Tuple, Union
@@ -961,9 +976,6 @@ class WideEPMoE(MoE):
             kargs["allow_partial_loading"] = allow_partial_loading
         self.quant_method.load_weights(self, weights, self.weight_loading_mode,
                                        **kargs)
-
-    def post_load_weights(self):
-        self.quant_method.post_load_weights(self)
 
     def forward_fake(
         self,

--- a/tensorrt_llm/_torch/modules/fused_moe/interface.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/interface.py
@@ -834,8 +834,18 @@ class MoE(nn.Module):
         """
         raise NotImplementedError
 
-    def post_load_weights(self):
-        pass
+    def transform_weights(self) -> None:
+        if getattr(self, "_weights_transformed", False):
+            return
+        self.quant_method.transform_weights(self)
+        self._weights_transformed = True
+
+    def cache_derived_state(self) -> None:
+        self.quant_method.cache_derived_state(self)
+
+    def post_load_weights(self) -> None:
+        self.transform_weights()
+        self.cache_derived_state()
 
     def process_weights_after_loading(self):
         """

--- a/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_cute_dsl.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_cute_dsl.py
@@ -816,7 +816,8 @@ class MegaMoECuteDsl(MoE):
     def post_load_weights(self) -> None:
         if self.quant_method is None:
             self.create_weights()
-        self.quant_method.post_load_weights(self)
+        self.transform_weights()
+        self.cache_derived_state()
 
     def process_weights_after_loading(self) -> None:
         """Run quant-method weight transforms; idempotent across calls.

--- a/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py
@@ -16,8 +16,8 @@
 
 This backend owns capability checks, routing/activation quantization, and the
 fused kernel entry point. ``W4A8MXFP4MXFP8MegaMoEDeepGemmMethod`` owns the
-DG-native weight tensors, checkpoint loading, scale conversion, SymmBuffer
-allocation, and DeepGEMM weight transform.
+DG-native weight tensors, checkpoint loading, scale conversion, and DeepGEMM
+weight transform. The backend owns SymmBuffer allocation and reuse.
 """
 
 from __future__ import annotations
@@ -327,20 +327,15 @@ class MegaMoEDeepGemm(MoE):
         # capture because rendezvous is a host-side IPC operation.
         # ``_resolve_ep_pg`` above relies on the same lockstep window.
         #
-        # The actual allocation is deferred to ``create_weights`` so that
-        # ConfigurableMoE has a chance to overwrite EPLB-derived
-        # attributes (``num_slots``, ``expert_size_per_partition``, ...)
-        # via ``_BACKEND_SYNC_ATTRS`` before we size the buffer. When the
-        # backend is constructed with ``init_load_balancer=False`` (the
-        # ConfigurableMoE path), ``MoE.__init__`` only seeds
-        # ``num_slots = num_experts`` as a placeholder; under EPLB the
-        # real slot count is larger, and sizing the SymmBuffer here would
-        # produce ``sym_buffer.num_experts != num_experts_per_rank *
-        # num_ranks`` at forward time. ``create_weights`` is also
-        # collective across ranks (called by ConfigurableMoE on all ranks
-        # right after the sync, or by the backend itself when used
-        # standalone with ``init_load_balancer=True``), so deferring keeps
-        # the rendezvous lockstep guarantee intact.
+        # The actual allocation is deferred to ``cache_derived_state`` so
+        # ConfigurableMoE can first sync EPLB-derived attributes (``num_slots``,
+        # ``expert_size_per_partition``, ...) via ``_BACKEND_SYNC_ATTRS`` and
+        # MetaInitMode can exit before the collective. ``MoE.__init__`` only
+        # seeds ``num_slots = num_experts`` as a placeholder when the backend
+        # is constructed with ``init_load_balancer=False``; sizing the buffer
+        # here would therefore break EPLB. The loader walks the cache stage in
+        # deterministic module order on all EP ranks, preserving rendezvous
+        # lockstep for ordinary and GMS RO loads.
         # See ``_alloc_symm_buffer`` for the cache contract.
         self._symm_buffer = None
 
@@ -605,29 +600,18 @@ class MegaMoEDeepGemm(MoE):
             self.create_weights()
         self.quant_method.load_weights(self, weights, allow_partial_loading)
 
+    def cache_derived_state(self) -> None:
+        # The rendezvous cannot run from create_weights under MetaInitMode.
+        # This stage runs in deterministic module order after materialization
+        # for both ordinary loads and GMS RO readers.
+        self._alloc_symm_buffer()
+        super().cache_derived_state()
+
     def post_load_weights(self) -> None:
         if self.quant_method is None:
             self.create_weights()
-        # Allocate the DG NVLink SymmBuffer and run its EP rendezvous here
-        # rather than in create_weights, for two reasons:
-        #   1. EPLB sizing: ConfigurableMoE syncs the EPLB-derived attributes
-        #      (num_slots, expert_size_per_partition, ...) onto the backend only
-        #      after __init__. Sizing the buffer earlier would use the
-        #      placeholder num_slots = num_experts and break EPLB at forward
-        #      time (DeepGEMM asserts num_experts == num_experts_per_rank *
-        #      num_ranks in mega.hpp).
-        #   2. MetaInitMode: the rendezvous (symm_mem.rendezvous + EP barrier
-        #      inside get_symm_buffer_for_mega_moe) is a real collective, but
-        #      create_weights runs under MetaInitMode where a c10d.barrier on a
-        #      meta tensor raises MetaInitException — aborting meta-init and
-        #      forcing the slow regular-init fallback that materializes every
-        #      weight on host RAM and OOM-kills small-host nodes (e.g. GB300,
-        #      ~900 GiB/node).
-        # The loader invokes this hook for every module in deterministic order
-        # on all EP ranks (lockstep), after MetaInitMode has exited and before
-        # forward / CUDA-graph capture. Idempotent — a no-op once allocated.
-        self._alloc_symm_buffer()
-        self.quant_method.post_load_weights(self)
+        self.transform_weights()
+        self.cache_derived_state()
 
     # ------------------------------------------------------------------
     # MoE-contract methods
@@ -690,7 +674,7 @@ class MegaMoEDeepGemm(MoE):
         buf = self._symm_buffer
         assert buf is not None, (
             "MegaMoE SymmBuffer not allocated — _alloc_symm_buffer runs in "
-            "post_load_weights; ensure the model loader's post_load_weights "
+            "cache_derived_state; ensure the model loader's cache/post-load "
             "pass ran before forward (and was not skipped by _weights_removed)."
         )
         num_tokens = x.shape[0]

--- a/tensorrt_llm/_torch/modules/fused_moe/quantization.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/quantization.py
@@ -453,6 +453,8 @@ class FusedMoEMethodBase(ABC):
             module.w2_bias.data if module.bias else None, **additional_kargs)
 
         self.load_quant_scales(module, weights)
+        if weights:
+            module._weights_transformed = False
 
         if self.need_load_shared_weights(module):
             local_shared_load_expert_ids = module.layer_load_balancer.get_load_expert_ids(
@@ -519,7 +521,7 @@ class FusedMoEMethodBase(ABC):
             # before the next layer is loaded. This prevents accumulation of all
             # layers' shared weight tensors in host memory simultaneously.
             # Partial-loading callers (e.g. RLHF reload) instead rely on
-            # ``post_load_weights`` to finalize once the loading sequence ends.
+            # ``transform_weights`` to finalize once the loading sequence ends.
             self._finalize_shared_weights(module)
 
     def _prepare_shared_weights_for_finalization(self, module: torch.nn.Module):
@@ -538,14 +540,14 @@ class FusedMoEMethodBase(ABC):
         shared memory, then delete the private CPU tensor copies.
 
         Calling this at the end of each layer's ``load_weights`` (rather than
-        deferring to ``post_load_weights``) prevents all layers' CPU tensors
+        deferring to ``transform_weights``) prevents all layers' CPU tensors
         from accumulating in host memory simultaneously.  With fewer GPUs per
         node each rank is responsible for more experts, so the accumulated
         private tensors can easily exceed available host memory.
 
         This method is idempotent: if the per-layer ``local_shared_*`` tensors
         have already been finalized (and deleted), it is a no-op.  This lets
-        ``post_load_weights`` invoke it as a safety net for callers that pass
+        ``transform_weights`` invoke it as a safety net for callers that pass
         ``allow_partial_loading=True`` (e.g. the RLHF reload path), without
         double-finalizing in the eager path.
         """
@@ -572,18 +574,24 @@ class FusedMoEMethodBase(ABC):
         module.register_all_parameter_slot_and_to_fix_weight_fns(weight_fns)
         module.layer_load_balancer.host_tensor_sharer.finalize_layer_weights()
 
-    def post_load_weights(self, module: torch.nn.Module):
+    def transform_weights(self, module: torch.nn.Module) -> None:
         # Safety net for deferred-finalization callers (e.g. RLHF reload, which
         # passes allow_partial_loading=True and so skips the eager per-layer
         # finalization in load_weights).  Idempotent when finalization already
         # ran eagerly.
         self._finalize_shared_weights(module)
+
+    def cache_derived_state(self, module: torch.nn.Module) -> None:
         if hasattr(module,
                    "layer_load_balancer") and module.layer_load_balancer:
             module.layer_load_balancer.set_initial_weight_assignments(
                 module.initial_global_assignments)
         # Re-setup quant scales after loading weights as the tensors may have been modified.
         self.setup_quant_scales(module)
+
+    def post_load_weights(self, module: torch.nn.Module) -> None:
+        self.transform_weights(module)
+        self.cache_derived_state(module)
 
     def load_quant_scales(self, module: torch.nn.Module, weights: List[Dict]):
         pass
@@ -788,10 +796,10 @@ class BF16TRTLLMGenFusedMoEMethod(UnquantizedFusedMoEMethod):
                                             module.rebuild_tensor_metadata)
         module._trtllm_gen_layout_transform_pending = False
 
-    def post_load_weights(self, module: torch.nn.Module):
+    def transform_weights(self, module: torch.nn.Module) -> None:
         if getattr(module, "_trtllm_gen_layout_transform_pending", False):
             self.process_weights_after_loading(module)
-        super().post_load_weights(module)
+        super().transform_weights(module)
 
 
 def load_expert_fc31_input_scale_fp8_qdq(w1_input_scale, w3_input_scale,
@@ -1019,8 +1027,8 @@ class FP8QDQFusedMoEMethod(FusedMoEMethodBase):
         delattr(module, 'tmp_fc31_input_scale')
         delattr(module, 'tmp_fc2_input_scale')
 
-    def post_load_weights(self, module):
-        super().post_load_weights(module)
+    def transform_weights(self, module: torch.nn.Module) -> None:
+        super().transform_weights(module)
 
         # Padding weights to meet FP8 GEMM alignment requirements.
         def _maybe_padding_weights(tensor: torch.Tensor, row_alignment: int,
@@ -1284,11 +1292,11 @@ class DeepSeekFP8BlockScalesFusedMoEMethodDeepGemm(
                             transformed_shared_w2_scale.cpu())
         super()._prepare_shared_weights_for_finalization(module)
 
-    def post_load_weights(self, module: torch.nn.Module):
-        super().post_load_weights(module)
+    def transform_weights(self, module: torch.nn.Module) -> None:
+        super().transform_weights(module)
 
         if self._needs_e8m0_resmooth():
-            logger.debug("Resmoothing FP8 weights in post_load_weights")
+            logger.debug("Resmoothing FP8 weights in transform_weights")
             resmoothed_w3_w1_weight, transformed_w3_w1_scale = resmooth_and_transform_fp8_scale(
                 module.w3_w1_weight, module.w3_w1_weight_scaling_factor)
             module.w3_w1_weight.data.copy_(resmoothed_w3_w1_weight)
@@ -1304,7 +1312,6 @@ class DeepSeekFP8BlockScalesFusedMoEMethodDeepGemm(
                                                 "w2_weight_scaling_factor",
                                                 transformed_w2_scale,
                                                 module.rebuild_tensor_metadata)
-            self.setup_quant_scales(module)
 
 
 class INT8WoqPerChannelFusedMoEMethod(FusedMoEMethodBase):
@@ -2946,7 +2953,7 @@ class NVFP4MarlinFusedMoEMethod(NVFP4CutlassFusedMoEMethod):
     """NVFP4 MoE quantization method for the Marlin backend.
 
     Inherits weight loading from the CUTLASS method, then transforms the loaded
-    weights to Marlin tiled format in ``post_load_weights``.
+    weights to Marlin tiled format in ``transform_weights``.
 
     The Marlin kernel is W4A16 (BF16 activations, no activation quantization),
     so global_scale must be the raw ``weight_scale_2`` — not the CUTLASS alpha
@@ -2954,7 +2961,7 @@ class NVFP4MarlinFusedMoEMethod(NVFP4CutlassFusedMoEMethod):
     raw ``weight_scale_2`` values.
     """
 
-    # Marlin's ``post_load_weights`` repacks weights into Marlin tiled format
+    # Marlin's ``transform_weights`` repacks weights into Marlin tiled format
     # and rebuilds the module parameters, which is incompatible with dynamic
     # EPLB weight migration.
     eplb_support_status = EplbSupportStatus.NOT_SUPPORTED
@@ -2970,12 +2977,12 @@ class NVFP4MarlinFusedMoEMethod(NVFP4CutlassFusedMoEMethod):
         w2_ws2 = w2_weight_scale_2[...].reshape([])
         dst_w2_alpha.copy_(w2_ws2)
 
-    def post_load_weights(self, module):
+    def transform_weights(self, module: torch.nn.Module) -> None:
         """Transform CUTLASS-format NVFP4 weights to Marlin tiled format."""
         from tensorrt_llm.quantization.utils import marlin_utils
 
         # Standard CUTLASS loading (swizzles scales, computes alpha, etc.)
-        super().post_load_weights(module)
+        super().transform_weights(module)
 
         num_experts = module.expert_size_per_partition
         hidden_size = module.hidden_size
@@ -3243,11 +3250,11 @@ class NVFP4CuteDslB12xFusedMoEMethod(NVFP4CutlassFusedMoEMethod):
     """NVFP4 quant method for the FlashInfer B12x MoE backend (SM120 / SM121).
 
     Inherits the full CUTLASS NVFP4 weight pipeline (cat + pad +
-    block_scale_interleave + setup_quant_scales) so the backend's
+    block_scale_interleave) so the backend's
     hybrid prefill path can continue to consume the standard CUTLASS
     NVFP4 GroupGEMM layout via the inherited ``CutlassFusedMoE.run_moe``.
 
-    On top of that base layout, ``post_load_weights`` materialises the
+    On top of that base layout, ``transform_weights`` materialises the
     b12x-specific weight tensors: SF un-normalization (multiply per-block
     FP8 scales by ``weight_scale_2 = fc_alpha * fc_input_scale``),
     ``convert_sf_to_mma_layout`` reshape, per-expert ``w*_alpha = 1 /
@@ -3266,11 +3273,12 @@ class NVFP4CuteDslB12xFusedMoEMethod(NVFP4CutlassFusedMoEMethod):
         ActivationType.Swiglu: "silu",
     }
 
-    def post_load_weights(self, module: torch.nn.Module):
-        # Base class handles shared-weight finalize, load-balancer init,
-        # and setup_quant_scales. Leaves the standard CUTLASS NVFP4
-        # weight + SF layout in place for the inherited prefill path.
-        super().post_load_weights(module)
+    def transform_weights(self, module: torch.nn.Module) -> None:
+        # Base class handles shared-weight finalization. The cache stage
+        # handles load-balancer assignments and setup_quant_scales.
+        # Leaves the standard CUTLASS NVFP4 weight + SF layout in place
+        # for the inherited prefill path.
+        super().transform_weights(module)
 
         try:
             from flashinfer import B12xMoEWrapper
@@ -5655,8 +5663,8 @@ class MXFP4WeightTRTLLMGenFusedMoEMethod(MXFP4WeightFusedMoEMethod):
     def setup_quant_scales(self, module: torch.nn.Module):
         module.quant_scales = tuple()
 
-    def post_load_weights(self, module: torch.nn.Module):
-        super().post_load_weights(module)
+    def cache_derived_state(self, module: torch.nn.Module) -> None:
+        super().cache_derived_state(module)
         # Create a proxy weight of unpadded size; dtype does not matter
         w1_weight = torch.empty([module.intermediate_size, module.hidden_size])
         # Calculate alignment
@@ -6247,7 +6255,7 @@ class W4A8MXFP4MXFP8MegaMoEDeepGemmMethod(FusedMoEMethodBase):
         # ``initial_local_expert_ids`` which already populate the device
         # weight tensors above). We allocate matching CPU tensors with the
         # same per-expert shape/dtype as the device weights and load the
-        # same MXFP4 byte layout into them. ``post_load_weights`` will later
+        # same MXFP4 byte layout into them. ``transform_weights`` will later
         # transform these into DG-required form and register them with the
         # host_tensor_sharer so peer ranks can read them during migration.
         # The CPU staging is required because EPLB's host_tensor_sharer
@@ -6285,7 +6293,25 @@ class W4A8MXFP4MXFP8MegaMoEDeepGemmMethod(FusedMoEMethodBase):
                 module.local_shared_w2_scale_tensors,
             )
 
+        self._clear_transformed_weight_cache(module)
+        module._weights_transformed = False
         module._weights_loaded = True
+
+    @staticmethod
+    def _clear_transformed_weight_cache(module: torch.nn.Module) -> None:
+        """Drop DG-derived tensors so fresh raw weights rebuild the native layout."""
+        for attr in (
+                "_t_l1",
+                "_t_l2",
+                "_t_l1_weight",
+                "_t_l1_scale",
+                "_t_l1_scale_slot",
+                "_t_l2_weight",
+                "_t_l2_scale",
+                "_t_l2_scale_slot",
+        ):
+            if hasattr(module, attr):
+                setattr(module, attr, None)
 
     def _transform_weights_for_mega_moe(
         self,
@@ -6338,21 +6364,19 @@ class W4A8MXFP4MXFP8MegaMoEDeepGemmMethod(FusedMoEMethodBase):
         return dg.transform_weights_for_mega_moe((l1_weight, l1_sf),
                                                  (l2_weight, l2_sf))
 
-    def post_load_weights(self, module: torch.nn.Module) -> None:
+    def transform_weights(self, module: torch.nn.Module) -> None:
         """Transform loaded MXFP4 weights into DG-native form.
 
         Pipeline (each step is independent and idempotent on its own guard):
           1. ``_transform_main_weights`` - DG-form L1/L2 + EPLB-friendly slot views
           2. ``_setup_shared_weights_for_eplb`` - host-side shared copies for dynamic EPLB
-          3. ``_attach_initial_weight_assignments`` - tell load_balancer the initial layout
 
         The NVLink SymmBuffer (forward-time activation workspace, not
-        weight storage) is allocated by ``MegaMoEDeepGemm.__init__`` itself
-        because that is the build-time lockstep window where the
-        ``symm_mem.rendezvous`` collective is safe; see
+        weight storage) is allocated by ``MegaMoEDeepGemm.cache_derived_state``
+        so the rendezvous runs after MetaInitMode and for GMS RO readers; see
         ``MegaMoEDeepGemm._alloc_symm_buffer``.
         """
-        assert module._weights_loaded, "post_load_weights before load_weights"
+        assert module._weights_loaded, "transform_weights before load_weights"
         if module.num_slots % module.ep_size != 0:
             raise ValueError(
                 f"MegaMoEDeepGemm requires num_slots ({module.num_slots}) "
@@ -6360,7 +6384,6 @@ class W4A8MXFP4MXFP8MegaMoEDeepGemmMethod(FusedMoEMethodBase):
                 f"replication factor or ep_size.")
         self._transform_main_weights(module)
         self._setup_shared_weights_for_eplb(module)
-        self._attach_initial_weight_assignments(module)
 
     def _transform_main_weights(self, module: torch.nn.Module) -> None:
         """Build DG-form ``_t_l1`` / ``_t_l2`` and EPLB-friendly slot views.
@@ -6503,11 +6526,3 @@ class W4A8MXFP4MXFP8MegaMoEDeepGemmMethod(FusedMoEMethodBase):
         ):
             delattr(module, attr)
         module.layer_load_balancer.host_tensor_sharer.finalize_layer_weights()
-
-    @staticmethod
-    def _attach_initial_weight_assignments(module: torch.nn.Module) -> None:
-        """Hand the initial expert->slot assignments to the load balancer."""
-        if hasattr(module,
-                   "layer_load_balancer") and module.layer_load_balancer:
-            module.layer_load_balancer.set_initial_weight_assignments(
-                module.initial_global_assignments)

--- a/tensorrt_llm/_torch/modules/linear.py
+++ b/tensorrt_llm/_torch/modules/linear.py
@@ -382,15 +382,16 @@ class LinearMethodBase(ABC):
             self.process_weights_after_loading(module)
 
     def transform_weights(self, module: Linear) -> None:
-        ...
+        return None
 
     def post_load_weights(self, module: Linear) -> None:
         self.transform_weights(module)
 
-    def load_weight_scales(self, weights: List[Dict], *args, **kwargs):
+    def load_weight_scales(self, weights: List[Dict], *args, **kwargs) -> None:
         """
         Load quantized weight scales from the checkpoint.
         """
+        return None
 
     @abstractmethod
     def load_weights_vanilla(self,
@@ -424,7 +425,7 @@ class LinearMethodBase(ABC):
         """
         raise NotImplementedError
 
-    def process_weights_after_loading(self, module: Linear):
+    def process_weights_after_loading(self, module: Linear) -> None:
         """
         Process quantization weights and scales after loading weights.
         """
@@ -438,23 +439,27 @@ class LinearMethodBase(ABC):
         else:
             raise ValueError(f'unsupported weight mode: {weight_mode}')
 
-    def process_weights_after_loading_vanilla(self, module: Linear):
+    def process_weights_after_loading_vanilla(self, module: Linear) -> None:
         """
         Process quantization weights and scales after loading weights for vanilla linear layer.
         """
+        return None
 
-    def process_weights_after_loading_fused_qkv_linear(self, module: Linear):
+    def process_weights_after_loading_fused_qkv_linear(self,
+                                                       module: Linear) -> None:
         """
         Process quantization weights and scales after loading weights for fused QKV linear layer.
         """
+        return None
 
     def process_weights_after_loading_fused_gate_up_linear(
-            self, module: Linear):
+            self, module: Linear) -> None:
         """
         Process quantization weights and scales after loading weights for fused gate up linear layer.
         """
+        return None
 
-    def pre_reload_weights(self, module: Linear):
+    def pre_reload_weights(self, module: Linear) -> None:
         """
         Pre-reload weights for the linear layer.
         """

--- a/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
+++ b/tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py
@@ -250,8 +250,8 @@ class Mamba2Mixer(nn.Module):
         self.aux_steram = torch.cuda.Stream()
         self.events = [torch.cuda.Event(), torch.cuda.Event()]
 
-    def post_load_weights(self):
-        """Post-process after loading weights."""
+    def cache_derived_state(self) -> None:
+        """Recompute state derived from loaded weights."""
         if (self.norm.is_nvfp4 and fused_gated_rmsnorm_quant_shape_ok(
                 self.norm.hidden_size, self.norm.group_size)
                 and self.norm.nvfp4_scale is None):
@@ -273,6 +273,9 @@ class Mamba2Mixer(nn.Module):
             self._A_expanded.copy_(a_exp)
             self._dt_bias_expanded.copy_(dt_exp)
             self._D_expanded.copy_(d_exp)
+
+    def post_load_weights(self) -> None:
+        self.cache_derived_state()
 
     def _try_attach_nvfp4_scale(self):
         """Attach input_scale from out_proj to norm for fused RMSNorm+Quant."""

--- a/tests/unittest/_torch/attention/sparse/dsa/test_dsa_indexer.py
+++ b/tests/unittest/_torch/attention/sparse/dsa/test_dsa_indexer.py
@@ -1,3 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 Test suite for DeepGEMM indexer kernels and some related utilities.
 
@@ -50,6 +64,22 @@ def has_deep_gemm():
         return deep_gemm is not None
     except Exception:
         return False
+
+
+def test_indexer_post_load_weights_caches_fused_weight():
+    indexer = Indexer.__new__(Indexer)
+    torch.nn.Module.__init__(indexer)
+    indexer.wk = torch.nn.Linear(3, 2, bias=False)
+    indexer.weights_proj = torch.nn.Linear(3, 4, bias=False)
+    indexer.wk.weight.data.fill_(1.0)
+    indexer.weights_proj.weight.data.fill_(2.0)
+
+    indexer.post_load_weights()
+
+    assert indexer._fused_wk_wp_weight.shape == (6, 3)
+    assert torch.equal(indexer._fused_wk_wp_weight[:2], indexer.wk.weight.data)
+    assert torch.equal(indexer._fused_wk_wp_weight[2:], indexer.weights_proj.weight.data)
+    assert not hasattr(indexer, "_weights_transformed")
 
 
 def _ceil_to_ue8m0(x: torch.Tensor):

--- a/tests/unittest/_torch/modules/mamba/test_mamba2_mixer.py
+++ b/tests/unittest/_torch/modules/mamba/test_mamba2_mixer.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+mamba2_mixer_mod = pytest.importorskip("tensorrt_llm._torch.modules.mamba.mamba2_mixer")
+Mamba2Mixer = mamba2_mixer_mod.Mamba2Mixer
+
+
+def test_mamba2_mixer_post_load_weights_caches_derived_state():
+    mixer = Mamba2Mixer.__new__(Mamba2Mixer)
+    nn.Module.__init__(mixer)
+    mixer.norm = SimpleNamespace(is_nvfp4=False)
+    mixer.A = torch.tensor([1.0, 2.0])
+    mixer.dt_bias = torch.tensor([3.0, 4.0])
+    mixer.D = torch.tensor([5.0, 6.0])
+    mixer.head_dim = 2
+    mixer.d_state = 3
+
+    mixer.post_load_weights()
+
+    assert mixer._A_expanded.shape == (2, 2, 3)
+    assert mixer._dt_bias_expanded.shape == (2, 2)
+    assert mixer._D_expanded.shape == (2, 2)
+    assert not hasattr(mixer, "_weights_transformed")

--- a/tests/unittest/_torch/modules/moe/test_moe_backend.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_backend.py
@@ -29,7 +29,9 @@ Design Goals:
 import itertools
 import logging
 import os
+from types import SimpleNamespace
 from typing import List, Optional
+from unittest.mock import MagicMock
 
 import pytest
 import torch
@@ -57,15 +59,19 @@ from tensorrt_llm._torch.modules.fused_moe import (
 )
 from tensorrt_llm._torch.modules.fused_moe.create_moe import create_moe_backend
 from tensorrt_llm._torch.modules.fused_moe.interface import MoE, MoEWeightLoadingMode
-from tensorrt_llm._torch.modules.fused_moe.mega_moe import MegaMoEDeepGemm
-from tensorrt_llm._torch.modules.fused_moe.quantization import W4A8MXFP4MXFP8MegaMoEDeepGemmMethod
+from tensorrt_llm._torch.modules.fused_moe.mega_moe import MegaMoECuteDsl, MegaMoEDeepGemm
+from tensorrt_llm._torch.modules.fused_moe.quantization import (
+    FusedMoEMethodBase,
+    NVFP4MarlinFusedMoEMethod,
+    UnquantizedFusedMoEMethod,
+    W4A8MXFP4MXFP8MegaMoEDeepGemmMethod,
+)
 from tensorrt_llm._torch.utils import ActivationType, is_gated_activation
 from tensorrt_llm._utils import mpi_rank
 from tensorrt_llm.mapping import Mapping
 from tensorrt_llm.models.modeling_utils import QuantAlgo
 
 logger = logging.getLogger(__name__)
-
 
 _MEGAMOE_BACKEND_TYPES = {
     MoeBackendType.MEGAMOE_DEEPGEMM,
@@ -183,6 +189,238 @@ def create_test_backend(
         weight_loading_mode=weight_loading_mode,
         activation_type=activation_type,
     )
+
+
+def test_moe_post_load_weights_uses_idempotent_transform_hook():
+    class HookTestMoE(MoE):
+        def create_weights(self):
+            raise NotImplementedError
+
+        def load_weights(self, weights, allow_partial_loading=False):
+            raise NotImplementedError
+
+        def quantize_input(self, x, **kwargs):
+            return x, None
+
+        def run_moe(self, **kwargs):
+            raise NotImplementedError
+
+    moe = HookTestMoE.__new__(HookTestMoE)
+    torch.nn.Module.__init__(moe)
+    quant_method = SimpleNamespace(
+        transform_weights=MagicMock(),
+        cache_derived_state=MagicMock(),
+    )
+    moe.quant_method = quant_method
+
+    moe.post_load_weights()
+    moe.transform_weights()
+
+    quant_method.transform_weights.assert_called_once_with(moe)
+    quant_method.cache_derived_state.assert_called_once_with(moe)
+    assert moe._weights_transformed is True
+
+    moe.cache_derived_state()
+    assert quant_method.cache_derived_state.call_count == 2
+
+    moe._weights_transformed = False
+    moe.transform_weights()
+    assert quant_method.transform_weights.call_count == 2
+
+
+def test_fused_moe_load_weights_invalidates_transform_guard():
+    class GuardResetMethod(UnquantizedFusedMoEMethod):
+        def load_expert_weights_to_dst(
+            self,
+            module,
+            weights,
+            weight_loading_mode,
+            load_expert_ids,
+            dst_w3_w1_weight,
+            dst_w2_weight,
+            dst_w3_w1_bias,
+            dst_w2_bias,
+            allow_partial_loading=False,
+        ):
+            module.loaded_allow_partial = allow_partial_loading
+
+        def load_quant_scales(self, module, weights):
+            module.loaded_scales = bool(weights)
+
+        def setup_quant_scales(self, module):
+            module.quant_scales = ()
+
+    method = GuardResetMethod()
+    module = SimpleNamespace(
+        initial_local_expert_ids=[0],
+        w3_w1_weight=torch.empty(1, 2, 2),
+        w2_weight=torch.empty(1, 2, 2),
+        bias=False,
+        _weights_transformed=True,
+    )
+
+    method.load_weights(
+        module,
+        {"0.w1.weight": torch.ones(1)},
+        MoEWeightLoadingMode.VANILLA,
+        allow_partial_loading=True,
+    )
+
+    assert module.loaded_allow_partial is True
+    assert module.loaded_scales is True
+    assert module._weights_transformed is False
+
+
+def test_configurable_moe_post_load_weights_uses_backend_staged_hooks():
+    from tensorrt_llm._torch.modules.fused_moe.configurable_moe import ConfigurableMoE
+
+    class HookTestConfigurableMoE(ConfigurableMoE):
+        def quantize_input(self, x, **kwargs):
+            return x, None
+
+        def run_moe(self, **kwargs):
+            raise NotImplementedError
+
+    configurable_moe = HookTestConfigurableMoE.__new__(HookTestConfigurableMoE)
+    torch.nn.Module.__init__(configurable_moe)
+    backend = torch.nn.Module()
+    backend.transform_weights = MagicMock()
+    backend.cache_derived_state = MagicMock()
+    configurable_moe.backend = backend
+
+    configurable_moe.post_load_weights()
+    configurable_moe.transform_weights()
+
+    backend.transform_weights.assert_called_once_with()
+    backend.cache_derived_state.assert_called_once_with()
+    assert configurable_moe._weights_transformed is True
+
+    configurable_moe.cache_derived_state()
+    assert backend.cache_derived_state.call_count == 2
+
+
+def test_configurable_moe_load_weights_invalidates_wrapper_transform_guard():
+    from tensorrt_llm._torch.modules.fused_moe.configurable_moe import ConfigurableMoE
+
+    configurable_moe = ConfigurableMoE.__new__(ConfigurableMoE)
+    torch.nn.Module.__init__(configurable_moe)
+    backend = torch.nn.Module()
+    backend.load_weights = MagicMock(return_value="loaded")
+    configurable_moe.backend = backend
+    configurable_moe._weights_transformed = True
+
+    weights = [{"0.w1.weight": torch.ones(1)}]
+    result = configurable_moe.load_weights(weights, allow_partial_loading=True)
+
+    assert result == "loaded"
+    backend.load_weights.assert_called_once_with(weights, True)
+    assert configurable_moe._weights_transformed is False
+
+
+def test_marlin_moe_repack_is_transform_stage():
+    assert "transform_weights" in NVFP4MarlinFusedMoEMethod.__dict__
+    assert "post_load_weights" not in NVFP4MarlinFusedMoEMethod.__dict__
+    assert NVFP4MarlinFusedMoEMethod.post_load_weights is FusedMoEMethodBase.post_load_weights
+
+
+def test_megamoe_cutedsl_post_load_weights_uses_staged_hooks():
+    moe = MegaMoECuteDsl.__new__(MegaMoECuteDsl)
+    torch.nn.Module.__init__(moe)
+    quant_method = SimpleNamespace(
+        transform_weights=MagicMock(),
+        cache_derived_state=MagicMock(),
+    )
+    moe.quant_method = quant_method
+
+    moe.post_load_weights()
+    moe.transform_weights()
+
+    quant_method.transform_weights.assert_called_once_with(moe)
+    quant_method.cache_derived_state.assert_called_once_with(moe)
+    assert moe._weights_transformed is True
+
+
+def test_megamoe_load_weights_invalidates_cached_deepgemm_views():
+    method = W4A8MXFP4MXFP8MegaMoEDeepGemmMethod()
+    hidden_size = 128
+    intermediate_size = 128
+    module = SimpleNamespace(
+        weight_loading_mode=MoEWeightLoadingMode.VANILLA,
+        initial_local_expert_ids=[0],
+        w3_w1_weight=torch.empty(1, intermediate_size * 2, hidden_size // 2, dtype=torch.uint8),
+        w3_w1_weight_scale=torch.empty(
+            1, intermediate_size * 2, hidden_size // 32, dtype=torch.uint8
+        ),
+        w2_weight=torch.empty(1, hidden_size, intermediate_size // 2, dtype=torch.uint8),
+        w2_weight_scale=torch.empty(1, hidden_size, intermediate_size // 32, dtype=torch.uint8),
+        _t_l1=(torch.empty(1), torch.empty(1)),
+        _t_l2=(torch.empty(1), torch.empty(1)),
+        _t_l1_weight=torch.empty(1),
+        _t_l1_scale=torch.empty(1),
+        _t_l1_scale_slot=torch.empty(1),
+        _t_l2_weight=torch.empty(1),
+        _t_l2_scale=torch.empty(1),
+        _t_l2_scale_slot=torch.empty(1),
+    )
+    weights = {
+        "0.w1.weight": torch.full((intermediate_size, hidden_size // 2), 1, dtype=torch.uint8),
+        "0.w3.weight": torch.full((intermediate_size, hidden_size // 2), 2, dtype=torch.uint8),
+        "0.w2.weight": torch.full((hidden_size, intermediate_size // 2), 3, dtype=torch.uint8),
+        "0.w1.weight_scale": torch.full(
+            (intermediate_size, hidden_size // 32), 4, dtype=torch.uint8
+        ),
+        "0.w3.weight_scale": torch.full(
+            (intermediate_size, hidden_size // 32), 5, dtype=torch.uint8
+        ),
+        "0.w2.weight_scale": torch.full(
+            (hidden_size, intermediate_size // 32), 6, dtype=torch.uint8
+        ),
+    }
+
+    method.load_weights(module, [weights])
+
+    assert module.w3_w1_weight[0, 0, 0].item() == 1
+    assert module.w3_w1_weight[0, intermediate_size, 0].item() == 2
+    assert module._weights_loaded is True
+    for attr in (
+        "_t_l1",
+        "_t_l2",
+        "_t_l1_weight",
+        "_t_l1_scale",
+        "_t_l1_scale_slot",
+        "_t_l2_weight",
+        "_t_l2_scale",
+        "_t_l2_scale_slot",
+    ):
+        assert getattr(module, attr) is None
+
+
+def test_megamoe_cache_derived_state_sets_initial_assignments_once():
+    method = W4A8MXFP4MXFP8MegaMoEDeepGemmMethod()
+    method.setup_quant_scales = MagicMock()
+    load_balancer = MagicMock()
+    module = SimpleNamespace(
+        layer_load_balancer=load_balancer,
+        initial_global_assignments=[0],
+    )
+
+    method.cache_derived_state(module)
+
+    load_balancer.set_initial_weight_assignments.assert_called_once_with([0])
+    method.setup_quant_scales.assert_called_once_with(module)
+
+
+def test_megamoe_deepgemm_cache_derived_state_allocates_symm_buffer():
+    moe = MegaMoEDeepGemm.__new__(MegaMoEDeepGemm)
+    torch.nn.Module.__init__(moe)
+    quant_method = SimpleNamespace(cache_derived_state=MagicMock())
+    moe.quant_method = quant_method
+    moe._alloc_symm_buffer = MagicMock()
+
+    moe.cache_derived_state()
+
+    moe._alloc_symm_buffer.assert_called_once_with()
+    quant_method.cache_derived_state.assert_called_once_with(moe)
 
 
 def test_megamoe_init_rejects_uneven_num_slots_with_value_error():


### PR DESCRIPTION
## Summary

Wave 3 of the staged post-load hooks rollout, built on merged Wave 2 / #15288 and rebased onto `main`.

This migrates the remaining MoE, Mamba, min-latency, and sparse attention post-load work into the staged hook protocol. Tensor-layout and irreversible MoE weight work now lives in `transform_weights()` behind `_weights_transformed`, while repeatable Python-side state refresh lives in `cache_derived_state()`. Existing full-load paths continue to use `post_load_weights()` as the backward-compatible shim.

## What Changed

- Added staged MoE hooks in `MoE` and `ConfigurableMoE`, with `transform_weights()` guarded by `_weights_transformed` and `cache_derived_state()` delegated to the quant method/backend.
- Split fused-MoE quant-method work so shared-weight finalization and backend-specific transforms run in `transform_weights()`, while quant scales and load-balancer assignment refresh run in `cache_derived_state()`.
- Routed CUTLASS, Triton, TRTLLM-Gen, DenseGEMM, WideEP, and MegaMoE backend post-load shims through the staged module hooks.
- Moved Mamba2, Llama min-latency, and DSA derived-state recomputation into `cache_derived_state()` while keeping `post_load_weights()` compatibility shims.
- Added MoE hook idempotency coverage plus focused DSA and Mamba derived-state tests.

## Dependency / prerequisite stack

This PR is Wave 3 in the staged post-load hooks rollout. The foundation PRs and Waves 1-2 (#14770, #14878, #15014, and #15288) are merged. The remaining wave PRs should merge in sequence; after each upstream wave lands, rebase the next wave onto `main` so review and CI focus on that wave's delta.

Arrows point from prerequisite to dependent. PR numbers in graph nodes are clickable.

```mermaid
graph TD
    PR14770["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/14770'>#14770</a>: staged-hook contract (merged)"]
    PR14878["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/14878'>#14878</a>: GMS SourceIdentity gate (merged)"]
    PR15014["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15014'>#15014</a>: Wave 1 aliases + GMS RO load (merged)"]
    PR15288["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15288'>#15288</a>: Wave 2 Linear/Attention transforms (merged)"]
    PR15386["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15386'>#15386</a>: Wave 3 MoE/Mamba staged hooks (this PR, ready for review)"]
    PR15387["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15387'>#15387</a>: Wave 4 MX receiver cutover (open, ready for review)"]
    PR15432["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15432'>#15432</a>: Wave 5 MX publisher + Llama receiver (open, ready for review)"]
    VERIFY["post-migration verification / demo (planned)"]

    PR14770 -->|satisfied| PR15014
    PR14878 -->|satisfied| PR15014
    PR15014 -->|satisfied| PR15288
    PR15288 -->|satisfied| PR15386
    PR15386 -->|blocking| PR15387
    PR15387 -->|blocking| PR15432
    PR15432 -.->|planned| VERIFY

    classDef merged fill:#dcfce7,stroke:#16a34a,color:#14532d;
    classDef inflight fill:#dbeafe,stroke:#2563eb,color:#1e3a8a;
    classDef current fill:#ede9fe,stroke:#7c3aed,color:#3b0764,stroke-width:3px;
    classDef downstream fill:#f3f4f6,stroke:#6b7280,color:#374151,stroke-dasharray:5 5;
    linkStyle 0,1,2,3 stroke:#16a34a,stroke-width:2px;
    linkStyle 4,5 stroke:#ea580c,stroke-width:3px;
    linkStyle 6 stroke:#6b7280,stroke-width:2px,stroke-dasharray:5 5;

    class PR14770,PR14878,PR15014,PR15288 merged;
    class PR15387,PR15432 inflight;
    class PR15386 current;
    class VERIFY downstream;
```

Immediate merge dependency satisfied: #15288 merged on 2026-06-26, and this branch is rebased onto `main` so the PR diff is the Wave 3 delta.


## Test Plan

- `git diff --check origin/codex/staged-hooks-wave2-transform-weights..HEAD`
- `python -m py_compile tensorrt_llm/_torch/attention_backend/sparse/dsa.py tensorrt_llm/_torch/models/modeling_llama_min_latency.py tensorrt_llm/_torch/modules/fused_moe/configurable_moe.py tensorrt_llm/_torch/modules/fused_moe/fused_moe_cute_dsl_b12x.py tensorrt_llm/_torch/modules/fused_moe/fused_moe_cutlass.py tensorrt_llm/_torch/modules/fused_moe/fused_moe_densegemm.py tensorrt_llm/_torch/modules/fused_moe/fused_moe_triton.py tensorrt_llm/_torch/modules/fused_moe/fused_moe_trtllm_gen.py tensorrt_llm/_torch/modules/fused_moe/fused_moe_wide_ep.py tensorrt_llm/_torch/modules/fused_moe/interface.py tensorrt_llm/_torch/modules/fused_moe/mega_moe/mega_moe_deepgemm.py tensorrt_llm/_torch/modules/fused_moe/quantization.py tensorrt_llm/_torch/modules/mamba/mamba2_mixer.py tests/unittest/_torch/attention/sparse/test_dsa_indexer.py tests/unittest/_torch/modules/moe/test_moe_backend.py tests/unittest/_torch/modules/mamba/test_mamba2_mixer.py`
- Pre-commit on commit: isort, yapf, ruff, ruff-format, codespell, DCO, and other applicable hooks passed. `waive list check` and `validate-test-lists` were skipped because the hook runtime fails in `scripts/check_test_list.py` on `str | None` before inspecting this diff.
- Focused pytest attempted but blocked in this macOS shell because `transformers` is not installed and the local `torch` package lacks `nn` / `distributed`.

## Next Steps

- Complete Wave 3 review and CI, then merge #15386.
- After #15386 lands, rebase #15387 onto `main`; after #15387 lands, repeat for #15432.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal weight loading and model initialization lifecycle management across model backends for improved code organization and maintainability.

* **Tests**
  * Added unit tests validating weight transformation and state caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
