### PR TITLE
[TRTLLM-13249][feat] Wave 4: add MX staged receiver cutover

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/base_checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/base_checkpoint_loader.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABC, abstractmethod
 from typing import Any
 
@@ -67,6 +70,17 @@ class BaseCheckpointLoader(ABC):
 
     def is_weights_preloaded(self) -> bool:
         """Whether the last load wrote weights directly into the model."""
+        return False
+
+    def is_post_transform_weights_preloaded(self) -> bool:
+        """Whether the last direct preload delivered post-transform weights.
+
+        This is narrower than :meth:`is_weights_preloaded`: a loader may write
+        bytes directly into the model while those bytes are still the raw
+        checkpoint layout. Only return ``True`` when the source identity was
+        verified and the incoming bytes can safely skip module
+        ``transform_weights()`` hooks.
+        """
         return False
 
     def post_load_apply(self,

--- a/tensorrt_llm/_torch/models/checkpoints/base_checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/base_checkpoint_loader.py
@@ -76,10 +76,9 @@ class BaseCheckpointLoader(ABC):
         """Whether the last direct preload delivered post-transform weights.
 
         This is narrower than :meth:`is_weights_preloaded`: a loader may write
-        bytes directly into the model while those bytes are still the raw
-        checkpoint layout. Only return ``True`` when the source identity was
-        verified and the incoming bytes can safely skip module
-        ``transform_weights()`` hooks.
+        bytes directly into the model while those bytes still use the raw
+        checkpoint layout. Return True only when the source identity was
+        verified and the incoming bytes can safely skip module transform hooks.
         """
         return False
 

--- a/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
@@ -223,6 +223,7 @@ class MXCheckpointLoader(HfCheckpointLoader):
         model = kwargs.pop("model", None)
         # Popped here so it never leaks into the disk-fallback signature.
         self._local_source_identity = kwargs.pop("source_identity", None)
+        allow_post_transform_weights = kwargs.pop("allow_post_transform_weights", True)
         self._p2p_succeeded = False
         self._post_transform_weights_preloaded = False
         self._source_identity_compatible_for_last_load = False
@@ -270,6 +271,15 @@ class MXCheckpointLoader(HfCheckpointLoader):
         self._post_transform_weights_preloaded = self._source_metadata_is_post_transform(
             checkpoint_dir, MxClient, _build_trtllm_identity
         )
+        if self._post_transform_weights_preloaded and not allow_post_transform_weights:
+            self._post_transform_weights_preloaded = False
+            self._source_identity_compatible_for_last_load = False
+            return self._fallback_to_disk(
+                checkpoint_dir,
+                mapping,
+                reason="post-transform MX source is not allowed for this load",
+                **kwargs,
+            )
 
         timeout_override = self._resolve_query_timeout_override(
             checkpoint_dir,

--- a/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
@@ -129,6 +129,8 @@ class MXCheckpointLoader(HfCheckpointLoader):
         self._model_name = str(model_name) if model_name is not None else None
         self._query_timeout_s = query_timeout_s
         self._p2p_succeeded = False
+        self._post_transform_weights_preloaded = False
+        self._source_identity_compatible_for_last_load = False
         # Receiver's local SourceIdentity, supplied per load_weights() call by
         # ModelLoader; the authority for the pre-transfer compatibility gate.
         self._local_source_identity: Optional[SourceIdentity] = None
@@ -184,6 +186,21 @@ class MXCheckpointLoader(HfCheckpointLoader):
         """
         return self._p2p_succeeded
 
+    def is_post_transform_weights_preloaded(self) -> bool:
+        """Whether the last successful MX preload delivered transformed bytes.
+
+        Wave 4 wires the receiver-side staged hook path, but the MX publisher
+        still emits raw pre-transform bytes. Keep this false until Wave 5 wires
+        explicit MX metadata for post-transform publication. The source
+        identity bit is included here so callers have one conservative signal:
+        no identity match, no transform skip.
+        """
+        return (
+            self._p2p_succeeded
+            and self._post_transform_weights_preloaded
+            and self._source_identity_compatible_for_last_load
+        )
+
     def load_weights(self, checkpoint_dir: str, mapping: Mapping, **kwargs) -> dict[str, Any]:
         """Load weights, preferring MX P2P transfer when available.
 
@@ -207,6 +224,8 @@ class MXCheckpointLoader(HfCheckpointLoader):
         # Popped here so it never leaks into the disk-fallback signature.
         self._local_source_identity = kwargs.pop("source_identity", None)
         self._p2p_succeeded = False
+        self._post_transform_weights_preloaded = False
+        self._source_identity_compatible_for_last_load = False
 
         if self._mx_server_url is None or model is None:
             return self._fallback_to_disk(
@@ -237,13 +256,20 @@ class MXCheckpointLoader(HfCheckpointLoader):
 
         # Pre-transfer compatibility gate: on mismatch, skip the transfer
         # before any RDMA work starts and fall back to disk.
-        if not self._source_identity_compatible(checkpoint_dir, MxClient, _build_trtllm_identity):
+        self._source_identity_compatible_for_last_load = self._source_identity_compatible(
+            checkpoint_dir, MxClient, _build_trtllm_identity
+        )
+        if not self._source_identity_compatible_for_last_load:
             return self._fallback_to_disk(
                 checkpoint_dir,
                 mapping,
                 reason="source SourceIdentity incompatible with receiver",
                 **kwargs,
             )
+
+        self._post_transform_weights_preloaded = self._source_metadata_is_post_transform(
+            checkpoint_dir, MxClient, _build_trtllm_identity
+        )
 
         timeout_override = self._resolve_query_timeout_override(
             checkpoint_dir,
@@ -271,6 +297,24 @@ class MXCheckpointLoader(HfCheckpointLoader):
             fallback_bytes = sum(
                 tensor.numel() * tensor.element_size() for tensor in fallback_weights.values()
             )
+            if self._post_transform_weights_preloaded:
+                self._post_transform_weights_preloaded = False
+                self._source_identity_compatible_for_last_load = False
+                logger.warning(
+                    "MX P2P returned %d fallback weights (%.2f MiB, size mismatch) "
+                    "from a post-transform source at %s. Falling back to a full "
+                    "disk load to avoid mixing transformed P2P tensors with raw "
+                    "fallback tensors before the full post-load transform path.",
+                    len(fallback_weights),
+                    fallback_bytes / (1 << 20),
+                    self._mx_server_url,
+                )
+                return self._fallback_to_disk(
+                    checkpoint_dir,
+                    mapping,
+                    reason="post-transform source returned partial fallback weights",
+                    **kwargs,
+                )
             # Mixed-success case: MX delivered matched tensors into model
             # params via P2P and returned only size-mismatched tensors for
             # the standard disk path to apply. Keep the P2P transfer and
@@ -285,6 +329,7 @@ class MXCheckpointLoader(HfCheckpointLoader):
                 self._mx_server_url,
             )
             self._p2p_succeeded = True
+            self._post_transform_weights_preloaded = False
             return fallback_weights
 
         self._p2p_succeeded = True
@@ -385,6 +430,18 @@ class MXCheckpointLoader(HfCheckpointLoader):
         # metadata channel (get_metadata / WorkerMetadata) once upstream
         # exposes a field for it. This is the single seam the gate depends on.
         return None
+
+    def _source_metadata_is_post_transform(
+        self, _checkpoint_dir: str, _mx_client_type: Type[Any], _build_identity: Callable[..., Any]
+    ) -> bool:
+        """Whether the selected MX source publishes post-transform bytes.
+
+        Wave 4 keeps production behavior dormant: Modelexpress metadata does
+        not yet expose raw-vs-transformed layout state, and the TRT-LLM MX
+        publisher still publishes before module transforms. Wave 5 should wire
+        this seam to explicit source metadata when flipping the publisher.
+        """
+        return False
 
     def _resolve_publish_name(self, checkpoint_dir: Optional[str]) -> str:
         return _resolve_mx_model_name(self._model_name, checkpoint_dir)

--- a/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
@@ -19,7 +19,7 @@ Thin adapter on top of the upstream `modelexpress` Python client
 (`ai-dynamo/modelexpress`). All NIXL/RDMA mechanics (agent setup,
 tensor registration, source-target name matching, dtype-cast handling,
 PVC fallback, etc.) live in the upstream `MxLiveWeightLoader` and
-`publish_model_params` helpers — we only call them at the right
+`publish_model_params` helpers. This class only calls them at the right
 points in TRT-LLM's loading lifecycle.
 
 When no MX server is reachable (or the upstream library is not
@@ -96,9 +96,8 @@ class MXCheckpointLoader(HfCheckpointLoader):
 
     All transport-level mechanics (NIXL, dtype casts, source matching,
     fallback) are delegated to `modelexpress.trtllm_live_transfer`
-    so that this class stays a thin adapter — when the MX wire
-    protocol or transport evolves, only the upstream library needs
-    to track it.
+    so that this class stays a thin adapter. When the MX wire protocol or
+    transport evolves, only the upstream library needs to track it.
     """
 
     def __init__(
@@ -189,11 +188,10 @@ class MXCheckpointLoader(HfCheckpointLoader):
     def is_post_transform_weights_preloaded(self) -> bool:
         """Whether the last successful MX preload delivered transformed bytes.
 
-        Wave 4 wires the receiver-side staged hook path, but the MX publisher
-        still emits raw pre-transform bytes. Keep this false until Wave 5 wires
-        explicit MX metadata for post-transform publication. The source
-        identity bit is included here so callers have one conservative signal:
-        no identity match, no transform skip.
+        MX does not yet expose whether the selected source publishes raw
+        checkpoint bytes or transformed runtime bytes. Keep this signal false
+        until the published layout is explicit. Source identity must also match
+        before callers skip transforms.
         """
         return (
             self._p2p_succeeded
@@ -446,10 +444,9 @@ class MXCheckpointLoader(HfCheckpointLoader):
     ) -> bool:
         """Whether the selected MX source publishes post-transform bytes.
 
-        Wave 4 keeps production behavior dormant: Modelexpress metadata does
-        not yet expose raw-vs-transformed layout state, and the TRT-LLM MX
-        publisher still publishes before module transforms. Wave 5 should wire
-        this seam to explicit source metadata when flipping the publisher.
+        ModelExpress metadata does not yet expose whether a source publishes
+        raw checkpoint bytes or transformed runtime bytes. Wire this to
+        explicit source metadata before enabling transformed publication.
         """
         return False
 

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -485,6 +485,9 @@ class ModelLoader:
                 f"Use {rank_model_storage / (1024**3):.2f} GB for model weights."
             )
             weights_preloaded = False
+            loads_draft_weights = (
+                self.spec_config is not None
+                and self.spec_config.spec_dec_mode.need_load_draft_weights())
             # Set when either GMS RW or GMS RO branch has already run the
             # post_load_* hooks itself, so the shared post-load block below
             # must skip them. RW handles them inside `mem_pool_scope` so the
@@ -504,6 +507,13 @@ class ModelLoader:
                     # Generic loaders ignore it; MXCheckpointLoader pops it.
                     "source_identity": self._source_identity,
                 }
+                if checkpoint_loader.checkpoint_format == "MX":
+                    # If a separate draft model still needs a raw disk load,
+                    # do not accept post-transform bytes for only the target
+                    # model. Wave 5 can relax this after the target/draft
+                    # subgraphs have an explicit mixed-layout policy.
+                    load_weights_kwargs["allow_post_transform_weights"] = (
+                        not loads_draft_weights)
 
                 if hasattr(model, 'llm_checkpoint_dir'):
                     weights = checkpoint_loader.load_weights(
@@ -523,8 +533,7 @@ class ModelLoader:
                     self._call_load_weights(model.load_weights, weights,
                                             self.weight_mapper)
 
-                if self.spec_config is not None and self.spec_config.spec_dec_mode.need_load_draft_weights(
-                ):
+                if loads_draft_weights:
                     weights = checkpoint_loader.load_weights(
                         self.spec_config.speculative_model,
                         mapping=self.mapping)
@@ -651,8 +660,7 @@ class ModelLoader:
                                     "commit an unpopulated model to the GMS "
                                     "pool.")
 
-                            if self.spec_config is not None and self.spec_config.spec_dec_mode.need_load_draft_weights(
-                            ):
+                            if loads_draft_weights:
                                 draft_weights = checkpoint_loader.load_weights(
                                     self.spec_config.speculative_model,
                                     mapping=self.mapping)
@@ -769,8 +777,7 @@ class ModelLoader:
                 self.weight_mapper = checkpoint_loader.get_initialized_weight_mapper(
                     model, config)
                 initialize_dummy_weights(model)
-                if self.spec_config is not None and self.spec_config.spec_dec_mode.need_load_draft_weights(
-                ):
+                if loads_draft_weights:
                     model.draft_model.load_weights_from_target_model(model)
 
             elif load_format == LoadFormat.VISION_ONLY:
@@ -789,7 +796,8 @@ class ModelLoader:
                 mx_staged_receiver_path = self._should_run_mx_staged_receiver_path(
                     checkpoint_loader,
                     model,
-                    weights_preloaded=weights_preloaded)
+                    weights_preloaded=weights_preloaded,
+                    loads_draft_weights=loads_draft_weights)
                 if mx_staged_receiver_path:
                     self._setup_aliases(model)
                     self._mark_weights_transformed(model)
@@ -854,8 +862,12 @@ class ModelLoader:
 
     @classmethod
     def _should_run_mx_staged_receiver_path(
-            cls, checkpoint_loader: BaseCheckpointLoader,
-            model: DecoderModelForCausalLM, *, weights_preloaded: bool) -> bool:
+            cls,
+            checkpoint_loader: BaseCheckpointLoader,
+            model: DecoderModelForCausalLM,
+            *,
+            weights_preloaded: bool,
+            loads_draft_weights: bool = False) -> bool:
         """Whether an MX receiver can skip one-shot weight transforms.
 
         The Wave 4 path is intentionally dormant for production: the allow-list
@@ -871,6 +883,14 @@ class ModelLoader:
         if method is None or not checkpoint_loader.is_post_transform_weights_preloaded(
         ):
             return False
+
+        if loads_draft_weights:
+            raise RuntimeError(
+                "MX receiver accepted post-transform weights while a separate "
+                "draft-model load is required. This is unsafe because the "
+                "target and draft subgraphs may need different post-load "
+                "transform handling. Disable post-transform MX for this load "
+                "or add an explicit mixed target/draft policy.")
 
         allowlist_key = (
             type(model),

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -510,8 +510,8 @@ class ModelLoader:
                 if checkpoint_loader.checkpoint_format == "MX":
                     # If a separate draft model still needs a raw disk load,
                     # do not accept post-transform bytes for only the target
-                    # model. Wave 5 can relax this after the target/draft
-                    # subgraphs have an explicit mixed-layout policy.
+                    # model. Enable this only after target and draft subgraphs
+                    # have an explicit mixed-layout policy.
                     load_weights_kwargs["allow_post_transform_weights"] = (
                         not loads_draft_weights)
 
@@ -870,10 +870,9 @@ class ModelLoader:
             loads_draft_weights: bool = False) -> bool:
         """Whether an MX receiver can skip one-shot weight transforms.
 
-        The Wave 4 path is intentionally dormant for production: the allow-list
-        is empty, and MX still reports raw pre-transform bytes. Tests can opt in
-        a synthetic model by patching the allow-list and checkpoint-loader
-        signal, proving the staged receiver branch without enabling real models.
+        Production keeps this dormant until model validation and source
+        metadata are explicit. Tests opt in a synthetic model by patching both
+        signals.
         """
         if checkpoint_loader.checkpoint_format != "MX" or not weights_preloaded:
             return False
@@ -905,10 +904,10 @@ class ModelLoader:
             )
             return True
 
-        # WAVE 5 NOTE: once MX can publish real post-transform bytes, this
-        # fallthrough must not run the full post_load_weights() path on those
-        # bytes for a non-allow-listed model. Wave 5 should either fail/fallback
-        # before accepting the transfer or allow-list the model after validation.
+        # TODO(MX-POST-TRANSFORM): When MX can publish transformed bytes,
+        # reject non-allow-listed transfers before P2P or validate the model
+        # and add it to the allow-list. Do not run the full post-load path on
+        # transformed bytes.
         logger.info(
             "MX receiver got post-transform weights for %s, but the model is "
             "not allow-listed for staged post-load transform protocol v%d. "
@@ -922,7 +921,7 @@ class ModelLoader:
     def _mark_weights_transformed(model: DecoderModelForCausalLM) -> None:
         """Mark modules with transform guards as already transformed.
 
-        Post-transform sharing paths skip ``transform_weights()`` because the
+        Post-transform sharing paths skip transform_weights() because the
         incoming bytes already use the final runtime layout. Preserve that
         lifecycle state on modules that participate in the transform guard
         protocol so a later orchestrator/refactor does not treat them as raw

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import copy
 import inspect
 import os
@@ -263,6 +266,8 @@ class ModelLoader:
     Handles the loading, configuration, and weight initialization of a PyTorch model.
     This class isolates model loading logic from the main execution engine.
     """
+    _MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION = 1
+    _MX_STAGED_RECEIVER_ALLOWLIST = frozenset()
 
     def __init__(self,
                  llm_args: TorchLlmArgs,
@@ -781,12 +786,20 @@ class ModelLoader:
             if not gms_post_load_handled:
                 checkpoint_loader.post_load_apply(
                     model, weights_preloaded=weights_preloaded)
+                mx_staged_receiver_path = self._should_run_mx_staged_receiver_path(
+                    checkpoint_loader,
+                    model,
+                    weights_preloaded=weights_preloaded)
+                if mx_staged_receiver_path:
+                    self._setup_aliases(model)
+                    self._mark_weights_transformed(model)
+                    self._walk_cache_state(model)
                 checkpoint_loader.post_load_publish(
                     model,
                     checkpoint_dir=checkpoint_dir,
                     weights_preloaded=weights_preloaded)
-
-                self._walk_full_post_load(model)
+                if not mx_staged_receiver_path:
+                    self._walk_full_post_load(model)
 
             # TODO(GMS-MOE-LB): when the (MoE, GMS) combination is enabled,
             # `register_weight_slots_after_to_cuda` and `finalize_model`
@@ -838,6 +851,67 @@ class ModelLoader:
             gms_backend.get_source_identity(),
             IdentityCheckPolicy.STRICT,
         )
+
+    @classmethod
+    def _should_run_mx_staged_receiver_path(
+            cls, checkpoint_loader: BaseCheckpointLoader,
+            model: DecoderModelForCausalLM, *, weights_preloaded: bool) -> bool:
+        """Whether an MX receiver can skip one-shot weight transforms.
+
+        The Wave 4 path is intentionally dormant for production: the allow-list
+        is empty, and MX still reports raw pre-transform bytes. Tests can opt in
+        a synthetic model by patching the allow-list and checkpoint-loader
+        signal, proving the staged receiver branch without enabling real models.
+        """
+        if checkpoint_loader.checkpoint_format != "MX" or not weights_preloaded:
+            return False
+
+        method = getattr(type(checkpoint_loader),
+                         'is_post_transform_weights_preloaded', None)
+        if method is None or not checkpoint_loader.is_post_transform_weights_preloaded(
+        ):
+            return False
+
+        allowlist_key = (
+            type(model),
+            cls._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION,
+        )
+        if allowlist_key in cls._MX_STAGED_RECEIVER_ALLOWLIST:
+            logger.info(
+                "MX receiver using staged post-load path for %s "
+                "(transform protocol v%d).",
+                type(model).__name__,
+                cls._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION,
+            )
+            return True
+
+        # WAVE 5 NOTE: once MX can publish real post-transform bytes, this
+        # fallthrough must not run the full post_load_weights() path on those
+        # bytes for a non-allow-listed model. Wave 5 should either fail/fallback
+        # before accepting the transfer or allow-list the model after validation.
+        logger.info(
+            "MX receiver got post-transform weights for %s, but the model is "
+            "not allow-listed for staged post-load transform protocol v%d. "
+            "Running the full post-load path.",
+            type(model).__name__,
+            cls._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION,
+        )
+        return False
+
+    @staticmethod
+    def _mark_weights_transformed(model: DecoderModelForCausalLM) -> None:
+        """Mark modules with transform guards as already transformed.
+
+        Post-transform sharing paths skip ``transform_weights()`` because the
+        incoming bytes already use the final runtime layout. Preserve that
+        lifecycle state on modules that participate in the transform guard
+        protocol so a later orchestrator/refactor does not treat them as raw
+        checkpoint bytes.
+        """
+        for module in model.modules():
+            if hasattr(module, '_weights_transformed') and not getattr(
+                    module, '_weights_removed', False):
+                module._weights_transformed = True
 
     @staticmethod
     def _setup_aliases(model: DecoderModelForCausalLM) -> None:

--- a/tests/unittest/_torch/executor/test_model_loader_mx.py
+++ b/tests/unittest/_torch/executor/test_model_loader_mx.py
@@ -28,6 +28,10 @@ _SOURCE_IDENTITY = model_loader_mod.SourceIdentity(
 
 
 class _LinearStub(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self._weights_transformed = False
+
     def post_load_weights(self):
         pass
 
@@ -41,6 +45,7 @@ class _DraftModel(nn.Module):
 class _TinyModel(nn.Module):
     def __init__(self, events):
         super().__init__()
+        self._weights_transformed = False
         self.linear = _LinearStub()
         self.draft_model = _DraftModel()
         self.draft_config = SimpleNamespace(
@@ -60,6 +65,12 @@ class _TinyModel(nn.Module):
 
     def load_draft_weights(self, weights, mapper):
         self._events.append("load_draft_weights")
+
+    def setup_aliases(self):
+        self._events.append("setup_aliases")
+
+    def cache_derived_state(self):
+        self._events.append("cache_derived_state")
 
     def post_load_weights(self):
         self._events.append("post_load_weights")
@@ -182,6 +193,56 @@ def test_mx_partial_fallback_merges_returned_weights(monkeypatch):
     )
 
 
+class _PostTransformMxLoader:
+    checkpoint_format = "MX"
+
+    def __init__(self, *, post_transform: bool) -> None:
+        self._post_transform = post_transform
+        self.load_weights = MagicMock(return_value={})
+        self.is_weights_preloaded = MagicMock(return_value=True)
+        self.get_initialized_weight_mapper = MagicMock(return_value=MagicMock())
+        self.post_load_apply = MagicMock()
+        self.post_load_publish = MagicMock()
+
+    def is_post_transform_weights_preloaded(self) -> bool:
+        return self._post_transform
+
+
+def test_mx_post_transform_receiver_uses_staged_path_when_allowlisted(monkeypatch):
+    events = []
+    loader = _make_loader(monkeypatch, events=events)
+    monkeypatch.setattr(
+        ModelLoader,
+        "_MX_STAGED_RECEIVER_ALLOWLIST",
+        frozenset({(_TinyModel, ModelLoader._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION)}),
+    )
+    checkpoint_loader = _PostTransformMxLoader(post_transform=True)
+
+    model, _ = loader.load("/ckpt", checkpoint_loader)
+
+    loader._call_load_weights.assert_not_called()
+    checkpoint_loader.post_load_publish.assert_called_once_with(
+        model, checkpoint_dir="/ckpt", weights_preloaded=True
+    )
+    # Post-transform receivers skip transform_weights(), but the accepted
+    # tensors are already in final layout. Keep the transform guard in sync so
+    # future reload/refactor paths do not accidentally treat them as raw bytes.
+    assert model._weights_transformed is True
+    assert model.linear._weights_transformed is True
+    assert model.draft_model.linear._weights_transformed is True
+    assert events == ["setup_aliases", "cache_derived_state"]
+
+
+def test_mx_post_transform_receiver_falls_back_when_allowlist_empty(monkeypatch):
+    events = []
+    loader = _make_loader(monkeypatch, events=events)
+    checkpoint_loader = _PostTransformMxLoader(post_transform=True)
+
+    loader.load("/ckpt", checkpoint_loader)
+
+    assert events == ["post_load_weights"]
+
+
 def test_mx_fallback_runs_standard_weight_mapping(monkeypatch):
     events = []
     loader = _make_loader(monkeypatch, events=events)
@@ -284,6 +345,20 @@ def test_reset_weights_transformed_only_resets_existing_flags():
     assert model._weights_transformed is False
     assert model.child._weights_transformed is False
     assert model.transformed_child._weights_transformed is False
+    assert not hasattr(model.removed_child, "_weights_transformed")
+
+
+def test_mark_weights_transformed_only_sets_existing_flags():
+    events = []
+    model = _HookModel(events)
+    model._weights_transformed = False
+    model.child._weights_transformed = False
+
+    ModelLoader._mark_weights_transformed(model)
+
+    assert model._weights_transformed is True
+    assert model.child._weights_transformed is True
+    assert model.transformed_child._weights_transformed is True
     assert not hasattr(model.removed_child, "_weights_transformed")
 
 

--- a/tests/unittest/_torch/executor/test_model_loader_mx.py
+++ b/tests/unittest/_torch/executor/test_model_loader_mx.py
@@ -198,14 +198,29 @@ class _PostTransformMxLoader:
 
     def __init__(self, *, post_transform: bool) -> None:
         self._post_transform = post_transform
-        self.load_weights = MagicMock(return_value={})
-        self.is_weights_preloaded = MagicMock(return_value=True)
+        self._weights_preloaded = True
+        self.load_weights = MagicMock(side_effect=self._load_weights)
+        self.is_weights_preloaded = MagicMock(side_effect=lambda: self._weights_preloaded)
         self.get_initialized_weight_mapper = MagicMock(return_value=MagicMock())
         self.post_load_apply = MagicMock()
         self.post_load_publish = MagicMock()
 
+    def _load_weights(self, *_args, **kwargs):
+        if self._post_transform and kwargs.get("allow_post_transform_weights") is False:
+            self._post_transform = False
+            self._weights_preloaded = False
+            return {"disk.weight": MagicMock()}
+        return {}
+
     def is_post_transform_weights_preloaded(self) -> bool:
         return self._post_transform
+
+
+def _spec_config_needing_draft_weights():
+    return SimpleNamespace(
+        spec_dec_mode=SimpleNamespace(need_load_draft_weights=lambda: True),
+        speculative_model="/draft",
+    )
 
 
 def test_mx_post_transform_receiver_uses_staged_path_when_allowlisted(monkeypatch):
@@ -221,6 +236,7 @@ def test_mx_post_transform_receiver_uses_staged_path_when_allowlisted(monkeypatc
     model, _ = loader.load("/ckpt", checkpoint_loader)
 
     loader._call_load_weights.assert_not_called()
+    assert checkpoint_loader.load_weights.call_args.kwargs["allow_post_transform_weights"] is True
     checkpoint_loader.post_load_publish.assert_called_once_with(
         model, checkpoint_dir="/ckpt", weights_preloaded=True
     )
@@ -231,6 +247,33 @@ def test_mx_post_transform_receiver_uses_staged_path_when_allowlisted(monkeypatc
     assert model.linear._weights_transformed is True
     assert model.draft_model.linear._weights_transformed is True
     assert events == ["setup_aliases", "cache_derived_state"]
+
+
+def test_mx_post_transform_receiver_with_draft_weights_forces_disk_fallback(monkeypatch):
+    events = []
+    loader = _make_loader(
+        monkeypatch,
+        events=events,
+        spec_config=_spec_config_needing_draft_weights(),
+    )
+    monkeypatch.setattr(
+        ModelLoader,
+        "_MX_STAGED_RECEIVER_ALLOWLIST",
+        frozenset({(_TinyModel, ModelLoader._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION)}),
+    )
+    checkpoint_loader = _PostTransformMxLoader(post_transform=True)
+
+    model, _ = loader.load("/ckpt", checkpoint_loader)
+
+    primary_kwargs = checkpoint_loader.load_weights.call_args_list[0].kwargs
+    assert primary_kwargs["allow_post_transform_weights"] is False
+    assert loader._call_load_weights.call_count == 2
+    checkpoint_loader.post_load_publish.assert_called_once_with(
+        model, checkpoint_dir="/ckpt", weights_preloaded=False
+    )
+    assert model._weights_transformed is False
+    assert model.linear._weights_transformed is False
+    assert events == ["load_weights", "load_draft_weights", "post_load_weights"]
 
 
 def test_mx_post_transform_receiver_falls_back_when_allowlist_empty(monkeypatch):

--- a/tests/unittest/_torch/executor/test_model_loader_mx.py
+++ b/tests/unittest/_torch/executor/test_model_loader_mx.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Unit tests for MX-specific branches in ``ModelLoader``."""
+"""Unit tests for MX-specific ModelLoader branches."""
 
 from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace

--- a/tests/unittest/_torch/executor/test_model_loader_mx.py
+++ b/tests/unittest/_torch/executor/test_model_loader_mx.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 import torch
 from torch import nn
 
+from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.modules import mla as mla_mod
 from tensorrt_llm._torch.modules.linear import Linear
 from tensorrt_llm._torch.modules.mla import MLA
@@ -36,9 +37,22 @@ class _LinearStub(nn.Module):
         pass
 
 
+def _make_draft_model_config():
+    pretrained_config = SimpleNamespace(
+        architectures=["DraftArch"],
+        num_attention_heads=1,
+        num_key_value_heads=1,
+        tie_word_embeddings=False,
+        torch_dtype=torch.float16,
+    )
+    return ModelConfig(pretrained_config=pretrained_config)
+
+
 class _DraftModel(nn.Module):
-    def __init__(self):
+    def __init__(self, model_config):
         super().__init__()
+        self.model_config = model_config
+        self.config = model_config.pretrained_config
         self.linear = _LinearStub()
 
 
@@ -47,10 +61,8 @@ class _TinyModel(nn.Module):
         super().__init__()
         self._weights_transformed = False
         self.linear = _LinearStub()
-        self.draft_model = _DraftModel()
-        self.draft_config = SimpleNamespace(
-            pretrained_config=SimpleNamespace(architectures=["DraftArch"])
-        )
+        self.draft_config = _make_draft_model_config()
+        self.draft_model = _DraftModel(self.draft_config)
         self._events = events
 
     def _apply(self, fn):

--- a/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
+++ b/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
@@ -283,6 +283,36 @@ class TestLoadWeightsMxPath:
         assert loader.is_post_transform_weights_preloaded() is False
         mock_super_load.assert_called_once()
 
+    def test_post_transform_source_can_be_disallowed_before_p2p(self):
+        # Some receiver shapes, such as target+draft speculative decoding, are
+        # not ready to mix post-transform target bytes with separately loaded
+        # raw draft bytes. Let ModelLoader force a disk fallback before MX
+        # starts RDMA, rather than accepting bytes it cannot safely stage.
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        loader._source_identity_compatible = MagicMock(return_value=True)
+        loader._source_metadata_is_post_transform = MagicMock(return_value=True)
+        disk_weights = {"disk.weight": MagicMock()}
+        fake_mx = _build_fake_modelexpress(load_weights_return={})
+
+        with (
+            _install_fake_modelexpress(fake_mx),
+            patch.object(
+                HfCheckpointLoader, "load_weights", return_value=disk_weights
+            ) as mock_super_load,
+        ):
+            result = loader.load_weights(
+                "/nonexistent",
+                mapping=MagicMock(),
+                model=MagicMock(),
+                allow_post_transform_weights=False,
+            )
+
+        assert result is disk_weights
+        assert loader.is_weights_preloaded() is False
+        assert loader.is_post_transform_weights_preloaded() is False
+        fake_mx.trtllm_live_transfer.MxLiveWeightLoader.assert_not_called()
+        mock_super_load.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # publish_as_source — env-var dance and graceful no-op

--- a/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
+++ b/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
@@ -46,11 +46,13 @@ class TestConstruction:
         loader = MXCheckpointLoader()
         assert loader.mx_server_url is None
         assert loader.is_weights_preloaded() is False
+        assert loader.is_post_transform_weights_preloaded() is False
 
     def test_mx_server_url_stored(self):
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
         assert loader.mx_server_url == "http://mx:8001"
         assert loader.is_weights_preloaded() is False
+        assert loader.is_post_transform_weights_preloaded() is False
 
     def test_query_timeout_stored(self):
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001", query_timeout_s=900)
@@ -77,6 +79,17 @@ class TestConstruction:
     def test_is_weights_preloaded_initial(self):
         loader = MXCheckpointLoader()
         assert loader.is_weights_preloaded() is False
+        assert loader.is_post_transform_weights_preloaded() is False
+
+    def test_post_transform_signal_requires_p2p_and_identity_match(self):
+        loader = MXCheckpointLoader()
+        loader._p2p_succeeded = True
+        loader._post_transform_weights_preloaded = True
+        loader._source_identity_compatible_for_last_load = False
+        assert loader.is_post_transform_weights_preloaded() is False
+
+        loader._source_identity_compatible_for_last_load = True
+        assert loader.is_post_transform_weights_preloaded() is True
 
 
 # ---------------------------------------------------------------------------
@@ -147,9 +160,11 @@ class TestLoadWeightsFallback:
 
     @staticmethod
     def _upstream_raises(stack):
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        loader._source_identity_compatible = MagicMock(return_value=True)
         fake_mx = _build_fake_modelexpress(load_weights_side_effect=RuntimeError("boom"))
         stack.enter_context(_install_fake_modelexpress(fake_mx))
-        return (MXCheckpointLoader(mx_server_url="http://mx:8001"), {"model": MagicMock()})
+        return (loader, {"model": MagicMock()})
 
     @pytest.mark.parametrize(
         "trigger_id, setup",
@@ -199,6 +214,7 @@ class TestLoadWeightsMxPath:
         # ``is_weights_preloaded()`` signal as "skip the standard
         # weight-mapping pipeline".
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        loader._source_identity_compatible = MagicMock(return_value=True)
         fake_mx = _build_fake_modelexpress(load_weights_return={})
         mapping = MagicMock(name="mapping")
         model = MagicMock(name="model")
@@ -208,6 +224,7 @@ class TestLoadWeightsMxPath:
 
         assert result == {}
         assert loader.is_weights_preloaded() is True
+        assert loader.is_post_transform_weights_preloaded() is False
 
         # Verify the integration contract with the upstream library:
         # 1. Constructed MxLiveWeightLoader with our mx_server_url.
@@ -225,6 +242,7 @@ class TestLoadWeightsMxPath:
         # tensors), keep the P2P transfer and let ModelLoader merge these
         # tensors through the standard disk pipeline.
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        loader._source_identity_compatible = MagicMock(return_value=True)
         fallback = {"some.weight": MagicMock()}
         fake_mx = _build_fake_modelexpress(load_weights_return=fallback)
 
@@ -235,8 +253,35 @@ class TestLoadWeightsMxPath:
             result = loader.load_weights("/nonexistent", mapping=MagicMock(), model=MagicMock())
 
         assert loader.is_weights_preloaded() is True
+        assert loader.is_post_transform_weights_preloaded() is False
         assert result is fallback
         mock_super_load.assert_not_called()
+
+    def test_post_transform_mixed_success_falls_back_to_full_disk_load(self):
+        # Wave 5 will let MX advertise post-transform sources. If such a
+        # source only partially succeeds, merging raw fallback tensors would
+        # force ModelLoader onto the full post-load path and double-transform
+        # the P2P subset. Lock the safer behavior now: abandon the partial
+        # post-transform transfer and return a full disk load instead.
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        loader._source_identity_compatible = MagicMock(return_value=True)
+        loader._source_metadata_is_post_transform = MagicMock(return_value=True)
+        fallback = {"some.weight": MagicMock(numel=lambda: 1, element_size=lambda: 4)}
+        disk_weights = {"disk.weight": MagicMock()}
+        fake_mx = _build_fake_modelexpress(load_weights_return=fallback)
+
+        with (
+            _install_fake_modelexpress(fake_mx),
+            patch.object(
+                HfCheckpointLoader, "load_weights", return_value=disk_weights
+            ) as mock_super_load,
+        ):
+            result = loader.load_weights("/nonexistent", mapping=MagicMock(), model=MagicMock())
+
+        assert result is disk_weights
+        assert loader.is_weights_preloaded() is False
+        assert loader.is_post_transform_weights_preloaded() is False
+        mock_super_load.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -432,6 +477,7 @@ class TestMxSourceQueryTimeoutDefault:
             return {}
 
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        loader._source_identity_compatible = MagicMock(return_value=True)
         fake_mx = _build_fake_modelexpress(load_weights_side_effect=_assert_timeout)
         with _install_fake_modelexpress(fake_mx):
             loader.load_weights("/nonexistent", mapping=MagicMock(), model=MagicMock())
@@ -444,6 +490,7 @@ class TestMxSourceQueryTimeoutDefault:
             return {}
 
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        loader._source_identity_compatible = MagicMock(return_value=True)
         fake_mx = _build_fake_modelexpress(
             load_weights_side_effect=_assert_no_timeout,
             source_instances=[MagicMock()],
@@ -463,6 +510,7 @@ class TestMxSourceQueryTimeoutDefault:
             return {}
 
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        loader._source_identity_compatible = MagicMock(return_value=True)
         fake_mx = _build_fake_modelexpress(load_weights_side_effect=_assert_env_timeout)
         with _install_fake_modelexpress(fake_mx):
             loader.load_weights("/nonexistent", mapping=MagicMock(), model=MagicMock())
@@ -475,6 +523,7 @@ class TestMxSourceQueryTimeoutDefault:
             return {}
 
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001", query_timeout_s=900)
+        loader._source_identity_compatible = MagicMock(return_value=True)
         fake_mx = _build_fake_modelexpress(load_weights_side_effect=_assert_config_timeout)
         with _install_fake_modelexpress(fake_mx):
             loader.load_weights("/nonexistent", mapping=MagicMock(), model=MagicMock())

--- a/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
+++ b/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
@@ -6,12 +6,11 @@
 # You may obtain a copy of the License at
 #
 # http://www.apache.org/licenses/LICENSE-2.0
-"""Unit tests for ``MXCheckpointLoader`` (``checkpoint_format='MX'``).
+"""Unit tests for MXCheckpointLoader with checkpoint_format='MX'.
 
-These tests intentionally do NOT exercise the upstream ``modelexpress``
-library. Tests for the import-failure fallback path mock
-``modelexpress.*`` symbols out of ``sys.modules`` so the assertion is
-about *our* fallback behavior, not about the upstream API.
+These tests intentionally do not exercise the upstream modelexpress library.
+The import-failure path blocks modelexpress symbols from sys.modules so the
+assertion is about our fallback behavior, not the upstream API.
 """
 
 import os
@@ -70,9 +69,8 @@ class TestConstruction:
         assert loader.checkpoint_format == "MX"
 
     def test_checkpoint_format_backing_attr(self):
-        # Several call sites read ``self._checkpoint_format`` directly
-        # (instead of going through the property). The constructor must
-        # align the backing attribute with the property override.
+        # Some call sites read self._checkpoint_format directly. Keep the
+        # backing attribute aligned with the property override.
         loader = MXCheckpointLoader()
         assert loader._checkpoint_format == "MX"
 
@@ -99,12 +97,8 @@ class TestConstruction:
 
 class TestRegistry:
     def test_registered_under_mx(self):
-        # ``ModelLoader.load`` resolves a checkpoint loader from
-        # ``checkpoint_format`` via ``BaseCheckpointLoader.get``. PR #13045
-        # registers ``MX`` via ``@register_checkpoint_loader("MX")``.
-        # The real call site (in _construct_checkpoint_loader) passes
-        # weight_loader=, weight_mapper=, config_loader=, plus optional
-        # mx_server_url= — so test with the same call shape.
+        # BaseCheckpointLoader.get resolves MX through the loader registry.
+        # Use the same constructor shape as _construct_checkpoint_loader.
         loader = BaseCheckpointLoader.get(
             checkpoint_format="MX",
             weight_loader=None,
@@ -130,7 +124,7 @@ class TestMxMapperFallback:
 
 
 # ---------------------------------------------------------------------------
-# load_weights — disk-fallback paths (no upstream library involved)
+# load_weights: disk-fallback paths with no upstream library involved.
 # ---------------------------------------------------------------------------
 
 
@@ -138,15 +132,13 @@ class TestLoadWeightsFallback:
     """Disk-fallback paths that should not touch the upstream MX library.
 
     All four fallback triggers share the same observable contract:
-    ``is_weights_preloaded()`` stays False, the parent ``HfCheckpointLoader.
-    load_weights`` is invoked exactly once, and its return value is
-    propagated unchanged. We parameterize the trigger to keep that
-    contract in one place.
+    is_weights_preloaded() stays False, HfCheckpointLoader.load_weights is
+    invoked exactly once, and its return value is propagated unchanged.
     """
 
     # Trigger setup builders.
     @staticmethod
-    def _no_url(stack):  # noqa: ARG004 — stack unused for this trigger
+    def _no_url(stack):  # noqa: ARG004 - stack unused for this trigger.
         return MXCheckpointLoader(), {"model": MagicMock()}
 
     @staticmethod
@@ -202,7 +194,7 @@ class TestLoadWeightsFallback:
 
 
 # ---------------------------------------------------------------------------
-# load_weights — MX-success and mixed-success paths (mocked upstream)
+# load_weights: MX-success and mixed-success paths with mocked upstream.
 # ---------------------------------------------------------------------------
 
 
@@ -210,9 +202,8 @@ class TestLoadWeightsFallback:
 class TestLoadWeightsMxPath:
     def test_p2p_full_success_returns_empty_dict(self):
         # Empty fallback dict means MX delivered all weights into model
-        # params; ``ModelLoader`` interprets the empty dict + the
-        # ``is_weights_preloaded()`` signal as "skip the standard
-        # weight-mapping pipeline".
+        # params. ModelLoader uses the empty dict plus is_weights_preloaded()
+        # to skip the standard weight-mapping pipeline.
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
         loader._source_identity_compatible = MagicMock(return_value=True)
         fake_mx = _build_fake_modelexpress(load_weights_return={})
@@ -258,11 +249,9 @@ class TestLoadWeightsMxPath:
         mock_super_load.assert_not_called()
 
     def test_post_transform_mixed_success_falls_back_to_full_disk_load(self):
-        # Wave 5 will let MX advertise post-transform sources. If such a
-        # source only partially succeeds, merging raw fallback tensors would
-        # force ModelLoader onto the full post-load path and double-transform
-        # the P2P subset. Lock the safer behavior now: abandon the partial
-        # post-transform transfer and return a full disk load instead.
+        # Post-transform sources are safe only when all tensors arrive via P2P.
+        # If MX returns raw fallback tensors, avoid mixing layouts by falling
+        # back to a full disk load.
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
         loader._source_identity_compatible = MagicMock(return_value=True)
         loader._source_metadata_is_post_transform = MagicMock(return_value=True)
@@ -488,11 +477,10 @@ def _install_fake_modelexpress(fake_pkg):
 
 
 class TestMxSourceQueryTimeoutDefault:
-    """``load_weights`` caps upstream's source-query timeout on P2P attempts.
+    """load_weights caps upstream's source-query timeout on P2P attempts.
 
     The first replica on a cold cluster should not block for the upstream
-    default of 1 hour. ``setdefault`` semantics — never overrides an
-    explicit user value.
+    default of 1 hour. Existing user values are preserved.
     """
 
     @pytest.fixture(autouse=True)
@@ -625,7 +613,7 @@ class TestNormalizeModelIdentity:
 
     def test_hf_snapshot_unmangling(self):
         # HF cache layout: ".../models--<org>--<name>/snapshots/<sha>/"
-        # → "<org>/<name>" (not the commit sha).
+        # to "<org>/<name>" instead of the commit sha.
         snapshot = (
             "/cache/huggingface/hub/models--Qwen--Qwen2.5-72B-Instruct/snapshots/abc123def456789"
         )
@@ -638,8 +626,7 @@ class TestNormalizeModelIdentity:
 
 
 class TestResolveMxModelName:
-    """``_resolve_mx_model_name`` is the priority-ordered lookup used by
-    ``publish_as_source``. Verifying the ordering."""
+    """_resolve_mx_model_name uses publish_as_source's lookup order."""
 
     @pytest.fixture(autouse=True)
     def _isolated_env(self, monkeypatch):
@@ -672,9 +659,9 @@ class TestResolveMxModelName:
 
 
 class TestPublishAsSourceModelName:
-    """``publish_as_source`` must set ``MODEL_NAME`` from the resolved
-    identity so upstream's ``publish_model_params`` reads it via env,
-    and must restore the prior env value afterwards.
+    """publish_as_source sets MODEL_NAME for upstream publish_model_params.
+
+    The prior environment value must be restored afterwards.
     """
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

Wave 4 of the staged post-load hooks rollout, stacked on #15386.

This adds the dormant MX receiver-side cutover infrastructure for consuming post-transform weights once Wave 5 teaches MX publishers to advertise that layout. Production behavior remains unchanged today: the MX post-transform signal defaults false and the per-model allow-list ships empty.

## What Changed

- Added a checkpoint-loader signal for direct preloads that are already post-transform, keeping the base default false.
- Added MX receiver gating for post-transform preloads: MX format, successful preload, compatible SourceIdentity, and `(model_class, transform_protocol_version)` allow-list entry are all required before skipping `transform_weights()`.
- Added the staged receiver path in `ModelLoader`: `setup_aliases()` -> mark participating modules as `_weights_transformed=True` -> `cache_derived_state()`, while preserving the existing full `post_load_weights()` path for all non-allow-listed cases.
- Kept MX production behavior dormant with `_source_metadata_is_post_transform()` returning false until Wave 5 wires explicit MX metadata.
- Added a Wave 5 code reminder that non-allow-listed post-transform bytes must not fall through into the full post-load path once real post-transform publishing is enabled.
- Added focused unit coverage for the synthetic allow-list path, fallback path, transformed-flag marking, and post-transform partial-transfer fallback to a full disk load.

## Dependency / prerequisite stack

This PR is Wave 4 in the staged post-load hooks rollout. The foundation PRs #14770 and #14878 and upstream wave PRs #15014 and #15288 are already merged. The remaining wave PRs should merge in sequence; after each upstream wave lands, rebase the next wave onto `main` so review and CI focus on that wave's delta.

Arrows point from prerequisite to dependent. PR numbers in graph nodes are clickable.

```mermaid
graph TD
    PR14770["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/14770'>#14770</a>: staged-hook contract (merged)"]
    PR14878["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/14878'>#14878</a>: GMS SourceIdentity gate (merged)"]
    PR15014["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15014'>#15014</a>: Wave 1 aliases + GMS RO load (merged)"]
    PR15288["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15288'>#15288</a>: Wave 2 Linear/Attention transforms (merged)"]
    PR15386["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15386'>#15386</a>: Wave 3 MoE/Mamba staged hooks (open)"]
    PR15387["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15387'>#15387</a>: Wave 4 MX receiver cutover (this PR, open)"]
    PR15432["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15432'>#15432</a>: Wave 5 MX post-transform Llama receiver (open)"]
    VERIFY["post-migration verification / demo (planned)"]

    PR14770 -->|satisfied| PR15014
    PR14878 -->|satisfied| PR15014
    PR15014 -->|satisfied| PR15288
    PR15288 -->|satisfied| PR15386
    PR15386 -->|blocking| PR15387
    PR15387 -->|blocking| PR15432
    PR15432 -.->|planned| VERIFY

    classDef merged fill:#dcfce7,stroke:#16a34a,color:#14532d;
    classDef inflight fill:#dbeafe,stroke:#2563eb,color:#1e3a8a;
    classDef current fill:#ede9fe,stroke:#7c3aed,color:#3b0764,stroke-width:3px;
    classDef downstream fill:#f3f4f6,stroke:#6b7280,color:#374151,stroke-dasharray:5 5;
    linkStyle 0,1,2,3 stroke:#16a34a,stroke-width:2px;
    linkStyle 4,5 stroke:#ea580c,stroke-width:3px;
    linkStyle 6 stroke:#6b7280,stroke-width:2px,stroke-dasharray:5 5;

    class PR14770,PR14878,PR15014,PR15288 merged;
    class PR15386,PR15432 inflight;
    class PR15387 current;
    class VERIFY downstream;
```

Immediate merge dependency for this PR: #15386 must land first; after it lands, rebase this branch onto `main` so the PR diff collapses to the Wave 4 delta.


## Test Plan

- `git diff --check`
- `python -m py_compile tensorrt_llm/_torch/models/checkpoints/base_checkpoint_loader.py tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py tensorrt_llm/_torch/pyexecutor/model_loader.py tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py tests/unittest/_torch/pyexecutor/test_model_loader_mx.py`
- `python -m pytest tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py tests/unittest/_torch/pyexecutor/test_model_loader_mx.py -q` attempted, but blocked in this local shell because `transformers` is not installed.
- Pre-commit on commit: isort, yapf, ruff, ruff-format, codespell, DCO, and other applicable hooks passed. `waive list check` and `validate-test-lists` were skipped because the hook runtime fails in `scripts/check_test_list.py` on `str | None` before inspecting this diff.

## Next Steps

- Wave 5 should wire explicit MX post-transform metadata and ensure non-allow-listed post-transform sources fail or fall back before full post-load transforms can run on transformed bytes.
- After #15386 lands or rebases, rebase this branch so the PR diff collapses to the Wave 4 commit only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced staged weight loading with support for recognizing and utilizing pre-transformed weights from external sources (e.g., peer-to-peer transfers).

* **Improvements**
  * Weight transformation processing is now more robust, with idempotent transformations ensuring consistent behavior across multiple invocations.
  * Enhanced efficiency when pre-transformed weights are available, reducing redundant processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
