### PR TITLE
[None][perf] DSv4 prep: attention fusion custom ops

### DIFF
--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_quant_packed.cu
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_quant_packed.cu
@@ -194,6 +194,11 @@ __global__ void fp8_quantize_1x128_packed_kernel_impl(__nv_fp8_e4m3* __restrict_
 void launch_fp8_quantize_1x128_packed_bf16_e4m3(__nv_fp8_e4m3* fp8_output, int32_t* packed_scale_output,
     __nv_bfloat16 const* input, int m, int k, int scale_leading_dim_uint32, cudaStream_t stream)
 {
+    if (m <= 0 || k <= 0)
+    {
+        return;
+    }
+
     constexpr int kWarpsPerBlock = 4;
     int const num_packed_sf_k = (((k + 127) / 128) + 3) / 4;
     int const m_blocks = (m + kWarpsPerBlock - 1) / kWarpsPerBlock;

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_quant_packed.cu
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_quant_packed.cu
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Fused 1x128 FP8 quantize + UE8M0 scale packing.
+//
+// Replaces the (scale_1x128_kernel + pack_fp32_into_ue8m0) two-kernel sequence
+// used by SM100 deep_gemm fp8 block-scale GEMMs. Adapted from the SM120 MoE
+// in-kernel packing pattern (`scale_1x128_kernel_sm120` in
+// sm120_blockwise_gemm/sm120_fp8_moe_gemm_1d1d.cuh), specialised for the
+// non-MoE case (single contiguous batch, no token offsets).
+
+#include "fp8_blockscale_quant_packed.h"
+
+#include "tensorrt_llm/common/config.h"
+#include "tensorrt_llm/common/envUtils.h"
+
+#include <cstdint>
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime_api.h>
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels::fp8_blockscale_gemm
+{
+
+namespace
+{
+
+__device__ __forceinline__ float reciprocal_approximate_ftz_local(float a)
+{
+    float b;
+    asm volatile("rcp.approx.ftz.f32 %0, %1;\n" : "=f"(b) : "f"(a));
+    return b;
+}
+
+// Each warp consumes one row × 4 quantization blocks (4 × 128 = 512 K elems).
+// 32 lanes split into 4 lane-groups of 8: each group covers 1 quant block
+// (8 lanes × 16 BF16 elems = 128 elems). After per-block amax, lanes
+// 0/8/16/24 each hold one UE8M0 scale byte; lane 0 packs them into a uint32
+// and stores in the deep_gemm-expected MN-major layout.
+template <int WarpsPerBlock>
+__global__ void fp8_quantize_1x128_packed_kernel_impl(__nv_fp8_e4m3* __restrict__ fp8_output,
+    int32_t* __restrict__ packed_scale_output, __nv_bfloat16 const* __restrict__ input, int const m, int const k,
+    int const scale_leading_dim_uint32)
+{
+    int const packed_sf_k_idx = static_cast<int>(blockIdx.x);
+    int const warp_id = static_cast<int>(threadIdx.x) >> 5;
+    int const lane_id = static_cast<int>(threadIdx.x) & 31;
+    int const m_idx = static_cast<int>(blockIdx.y) * WarpsPerBlock + warp_id;
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+    cudaGridDependencySynchronize();
+#endif
+
+    if (m_idx >= m)
+    {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+        cudaTriggerProgrammaticLaunchCompletion();
+#endif
+        return;
+    }
+
+    int const k_base = packed_sf_k_idx * 512 + lane_id * 16;
+
+    // ---- 1. Load 16 BF16 elements per lane. ----
+    auto const* in_ptr = reinterpret_cast<double4 const*>(input + static_cast<int64_t>(m_idx) * k + k_base);
+    constexpr int kLoadNumElems = sizeof(double4) / sizeof(__nv_bfloat16); // 16
+
+    union LoadTrick
+    {
+        double4 pack;
+        __nv_bfloat16 v[kLoadNumElems];
+    };
+
+    LoadTrick load_trick;
+    bool const k_in_range = (k_base < k);
+    load_trick.pack = k_in_range ? in_ptr[0] : double4{};
+
+    if (k_in_range && k_base + kLoadNumElems > k)
+    {
+        int const valid = k - k_base;
+#pragma unroll
+        for (int i = 0; i < kLoadNumElems; ++i)
+        {
+            if (i >= valid)
+            {
+                load_trick.v[i] = __nv_bfloat16(0.0f);
+            }
+        }
+    }
+
+    // ---- 2. Per-block amax (lanes 0..7 / 8..15 / 16..23 / 24..31 = 4 quant blocks). ----
+    __nv_bfloat16 max_elem = __nv_bfloat16(0.0f);
+#pragma unroll
+    for (int i = 0; i < kLoadNumElems; ++i)
+    {
+        max_elem = __hmax(max_elem, __habs(load_trick.v[i]));
+    }
+    float amax = static_cast<float>(max_elem);
+    amax = fmaxf(amax, __shfl_xor_sync(0xFFFFFFFFu, amax, 4, 8));
+    amax = fmaxf(amax, __shfl_xor_sync(0xFFFFFFFFu, amax, 2, 8));
+    amax = fmaxf(amax, __shfl_xor_sync(0xFFFFFFFFu, amax, 1, 8));
+    amax = fmaxf(amax, 1e-10f);
+
+    // ---- 3. UE8M0 dequant scale. ----
+    float const dequant_scale_raw = amax * reciprocal_approximate_ftz_local(448.0f);
+    __nv_fp8_e8m0 ue8m0_scale;
+    ue8m0_scale.__x = __nv_cvt_float_to_e8m0(dequant_scale_raw, __NV_SATFINITE, cudaRoundPosInf);
+
+    // Recover quant_scale = 1 / 2^(exp - 127) for fp8 conversion.
+    constexpr uint32_t FP32_EXPONENT_BIAS = 127u;
+    float const quant_scale = (ue8m0_scale.__x == 0)
+        ? 1.0f
+        : exp2f(static_cast<float>(FP32_EXPONENT_BIAS) - static_cast<float>(ue8m0_scale.__x));
+
+    // ---- 4. Quantize and store FP8 output. ----
+    constexpr int kStoreNumElems = sizeof(float4) / sizeof(__nv_fp8_e4m3); // 16
+
+    union StoreTrick
+    {
+        float4 pack;
+        __nv_fp8_e4m3 v[kStoreNumElems];
+    };
+
+    StoreTrick store_trick;
+    store_trick.pack = float4{};
+#pragma unroll
+    for (int i = 0; i < kStoreNumElems; ++i)
+    {
+        store_trick.v[i] = __nv_fp8_e4m3(static_cast<float>(load_trick.v[i]) * quant_scale);
+    }
+    auto* out_ptr = reinterpret_cast<float4*>(fp8_output + static_cast<int64_t>(m_idx) * k + k_base);
+    if (k_in_range)
+    {
+        if (k_base + kStoreNumElems > k)
+        {
+            int const valid = k - k_base;
+#pragma unroll
+            for (int i = 0; i < kStoreNumElems; ++i)
+            {
+                if (i >= valid)
+                {
+                    store_trick.v[i] = __nv_fp8_e4m3(0.0f);
+                }
+            }
+        }
+        out_ptr[0] = store_trick.pack;
+    }
+
+    // ---- 5. Pack 4 UE8M0 scales (lanes 0/8/16/24) and store. ----
+    uint32_t const s0 = __shfl_sync(0xFFFFFFFFu, static_cast<uint32_t>(ue8m0_scale.__x), 0);
+    uint32_t const s1 = __shfl_sync(0xFFFFFFFFu, static_cast<uint32_t>(ue8m0_scale.__x), 8);
+    uint32_t const s2 = __shfl_sync(0xFFFFFFFFu, static_cast<uint32_t>(ue8m0_scale.__x), 16);
+    uint32_t const s3 = __shfl_sync(0xFFFFFFFFu, static_cast<uint32_t>(ue8m0_scale.__x), 24);
+    if (lane_id == 0)
+    {
+        // Mask off scale bytes whose sf_k is past the actual K.
+        int const num_sf_k = (k + 127) / 128;
+        int const sf_k_base = packed_sf_k_idx * 4;
+        uint32_t packed = 0u;
+        if (sf_k_base + 0 < num_sf_k)
+            packed |= s0;
+        if (sf_k_base + 1 < num_sf_k)
+            packed |= (s1 << 8);
+        if (sf_k_base + 2 < num_sf_k)
+            packed |= (s2 << 16);
+        if (sf_k_base + 3 < num_sf_k)
+            packed |= (s3 << 24);
+        // Layout: packed_scale[packed_sf_k_idx, m_idx]
+        packed_scale_output[static_cast<int64_t>(packed_sf_k_idx) * scale_leading_dim_uint32 + m_idx] = packed;
+    }
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+    cudaTriggerProgrammaticLaunchCompletion();
+#endif
+}
+
+} // namespace
+
+void launch_fp8_quantize_1x128_packed_bf16_e4m3(__nv_fp8_e4m3* fp8_output, int32_t* packed_scale_output,
+    __nv_bfloat16 const* input, int m, int k, int scale_leading_dim_uint32, cudaStream_t stream)
+{
+    constexpr int kWarpsPerBlock = 4;
+    int const num_packed_sf_k = (((k + 127) / 128) + 3) / 4;
+    int const m_blocks = (m + kWarpsPerBlock - 1) / kWarpsPerBlock;
+    dim3 const grid(num_packed_sf_k, m_blocks, 1);
+    dim3 const block(kWarpsPerBlock * 32, 1, 1);
+
+    tensorrt_llm::common::launchWithPdlWhenEnabled("fp8_quantize_1x128_packed_kernel_impl",
+        fp8_quantize_1x128_packed_kernel_impl<kWarpsPerBlock>, grid, block, 0, stream, fp8_output, packed_scale_output,
+        input, m, k, scale_leading_dim_uint32);
+}
+
+} // namespace kernels::fp8_blockscale_gemm
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_quant_packed.h
+++ b/cpp/tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_quant_packed.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Host-callable launcher for the fused FP8 1x128 quantize + UE8M0-pack kernel.
+// Kernel implementation lives in fp8_blockscale_quant_packed.cu and is built
+// by nvcc; this header is safe to include from .cpp files compiled by g++.
+
+#pragma once
+
+#include "tensorrt_llm/common/config.h"
+
+#include <cstdint>
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime_api.h>
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels::fp8_blockscale_gemm
+{
+
+// Launches the fused 1x128 FP8 quant + UE8M0 pack kernel.
+//
+// Inputs:
+//   input  : BF16 [m, k] row-major contiguous
+// Outputs:
+//   fp8_output           : E4M3 [m, k] row-major contiguous
+//   packed_scale_output  : uint32 [packed_sf_k, scale_leading_dim_uint32]
+//                          where packed_sf_k = ceil(ceil(k/128)/4)
+//
+// `scale_leading_dim_uint32` is the (uint32) stride between consecutive
+// packed_sf_k rows of the scale tensor; caller is responsible for choosing
+// it (typically aligned to 4 uint32 = 16 bytes for TMA alignment).
+void launch_fp8_quantize_1x128_packed_bf16_e4m3(__nv_fp8_e4m3* fp8_output, int32_t* packed_scale_output,
+    __nv_bfloat16 const* input, int m, int k, int scale_leading_dim_uint32, cudaStream_t stream);
+
+} // namespace kernels::fp8_blockscale_gemm
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/kernels/deepseekV4QNormKernel.cu
+++ b/cpp/tensorrt_llm/kernels/deepseekV4QNormKernel.cu
@@ -16,7 +16,8 @@
 
 #include "tensorrt_llm/kernels/deepseekV4QNormKernel.h"
 
-#include <cassert>
+#include "tensorrt_llm/common/assert.h"
+
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
@@ -124,7 +125,7 @@ template <typename T>
 void dispatchDeepseekV4QNorm(
     void const* input, void* output, int totalRows, int headDim, float eps, cudaStream_t stream)
 {
-    assert(headDim == 512);
+    TLLM_CHECK_WITH_INFO(headDim == 512, "deepseek_v4_q_norm only supports head_dim=512, got %d", headDim);
 
     dim3 const block(kThreadsPerBlock);
     dim3 const grid((totalRows + kWarpsPerBlock - 1) / kWarpsPerBlock);

--- a/cpp/tensorrt_llm/kernels/deepseekV4QNormKernel.cu
+++ b/cpp/tensorrt_llm/kernels/deepseekV4QNormKernel.cu
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/kernels/deepseekV4QNormKernel.h"
+
+#include <cassert>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels
+{
+namespace
+{
+
+constexpr int kWarpSize = 32;
+constexpr int kWarpsPerBlock = 4;
+constexpr int kThreadsPerBlock = kWarpSize * kWarpsPerBlock;
+
+template <typename T>
+struct Vec2Traits;
+
+template <>
+struct Vec2Traits<half>
+{
+    using Type = half2;
+
+    __device__ static float2 toFloat2(Type value)
+    {
+        return __half22float2(value);
+    }
+
+    __device__ static Type fromFloat2(float2 value)
+    {
+        return __floats2half2_rn(value.x, value.y);
+    }
+};
+
+template <>
+struct Vec2Traits<__nv_bfloat16>
+{
+    using Type = __nv_bfloat162;
+
+    __device__ static float2 toFloat2(Type value)
+    {
+        return __bfloat1622float2(value);
+    }
+
+    __device__ static Type fromFloat2(float2 value)
+    {
+        return __floats2bfloat162_rn(value.x, value.y);
+    }
+};
+
+__device__ __forceinline__ float warpReduceSum(float value)
+{
+    for (int mask = kWarpSize / 2; mask > 0; mask >>= 1)
+    {
+        value += __shfl_xor_sync(0xFFFFFFFF, value, mask);
+    }
+    return value;
+}
+
+template <typename T, int kHeadDim>
+__global__ void deepseekV4QNormKernel(T const* input, T* output, int totalRows, float eps)
+{
+    static_assert(kHeadDim % (2 * kWarpSize) == 0);
+    constexpr int kPairsPerRow = kHeadDim / 2;
+    constexpr int kPairsPerLane = kPairsPerRow / kWarpSize;
+
+    using Vec2 = typename Vec2Traits<T>::Type;
+
+    int const warpId = threadIdx.x / kWarpSize;
+    int const laneId = threadIdx.x % kWarpSize;
+    int const row = blockIdx.x * kWarpsPerBlock + warpId;
+
+    if (row >= totalRows)
+    {
+        return;
+    }
+
+    auto const* inputPair = reinterpret_cast<Vec2 const*>(input + static_cast<int64_t>(row) * kHeadDim);
+    auto* outputPair = reinterpret_cast<Vec2*>(output + static_cast<int64_t>(row) * kHeadDim);
+
+    float2 values[kPairsPerLane];
+    float sumSquares = 0.0F;
+
+#pragma unroll
+    for (int i = 0; i < kPairsPerLane; ++i)
+    {
+        int const pairIdx = i * kWarpSize + laneId;
+        values[i] = Vec2Traits<T>::toFloat2(inputPair[pairIdx]);
+        sumSquares += values[i].x * values[i].x + values[i].y * values[i].y;
+    }
+
+    sumSquares = warpReduceSum(sumSquares);
+    float const scale = rsqrtf(sumSquares / static_cast<float>(kHeadDim) + eps);
+
+#pragma unroll
+    for (int i = 0; i < kPairsPerLane; ++i)
+    {
+        int const pairIdx = i * kWarpSize + laneId;
+        float2 value{values[i].x * scale, values[i].y * scale};
+        outputPair[pairIdx] = Vec2Traits<T>::fromFloat2(value);
+    }
+}
+
+template <typename T>
+void dispatchDeepseekV4QNorm(
+    void const* input, void* output, int totalRows, int headDim, float eps, cudaStream_t stream)
+{
+    assert(headDim == 512);
+
+    dim3 const block(kThreadsPerBlock);
+    dim3 const grid((totalRows + kWarpsPerBlock - 1) / kWarpsPerBlock);
+    deepseekV4QNormKernel<T, 512>
+        <<<grid, block, 0, stream>>>(static_cast<T const*>(input), static_cast<T*>(output), totalRows, eps);
+}
+
+} // namespace
+
+void invokeDeepseekV4QNorm(
+    void const* input, void* output, int totalRows, int headDim, bool isBfloat16, float eps, cudaStream_t stream)
+{
+    if (totalRows == 0)
+    {
+        return;
+    }
+
+    if (isBfloat16)
+    {
+        dispatchDeepseekV4QNorm<__nv_bfloat16>(input, output, totalRows, headDim, eps, stream);
+    }
+    else
+    {
+        dispatchDeepseekV4QNorm<half>(input, output, totalRows, headDim, eps, stream);
+    }
+}
+
+} // namespace kernels
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/kernels/deepseekV4QNormKernel.h
+++ b/cpp/tensorrt_llm/kernels/deepseekV4QNormKernel.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "tensorrt_llm/common/config.h"
+
+#include <cuda_runtime.h>
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace kernels
+{
+
+void invokeDeepseekV4QNorm(
+    void const* input, void* output, int totalRows, int headDim, bool isBfloat16, float eps, cudaStream_t stream);
+
+} // namespace kernels
+
+TRTLLM_NAMESPACE_END

--- a/cpp/tensorrt_llm/thop/CMakeLists.txt
+++ b/cpp/tensorrt_llm/thop/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library(
   fp8RowwiseGemm.cpp
   fp8Quantize.cpp
   dsv3FusedAGemmOp.cpp
+  deepseekV4QNormOp.cpp
   fusedQKNormRopeOp.cpp
   fusedDiTQKNormRopeOp.cpp
   fusedDiTSplitQKNormRopeOp.cpp
@@ -99,6 +100,7 @@ add_library(
   IndexerKCacheGatherOp.cpp
   IndexerKCacheScatterOp.cpp
   IndexerTopKOp.cpp
+  mlaRopeInplaceOp.cpp
   ncclCommunicatorOp.cpp
   allocateOutput.cpp
   parallelDecodeKVCacheUpdateOp.cpp

--- a/cpp/tensorrt_llm/thop/deepseekV4QNormOp.cpp
+++ b/cpp/tensorrt_llm/thop/deepseekV4QNormOp.cpp
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/kernels/deepseekV4QNormKernel.h"
+
+#include <ATen/cuda/CUDAContext.h>
+#include <limits>
+#include <torch/extension.h>
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace torch_ext
+{
+
+torch::Tensor deepseekV4QNorm(torch::Tensor q, int64_t numHeads, int64_t headDim, double eps)
+{
+    TORCH_CHECK(q.is_cuda(), "deepseek_v4_q_norm expects a CUDA tensor");
+    TORCH_CHECK(q.is_contiguous(), "deepseek_v4_q_norm expects a contiguous tensor");
+    TORCH_CHECK(q.scalar_type() == torch::kFloat16 || q.scalar_type() == torch::kBFloat16,
+        "deepseek_v4_q_norm expects fp16/bf16 input, got ", q.scalar_type());
+    TORCH_CHECK(headDim == 512, "deepseek_v4_q_norm only supports head_dim=512, got ", headDim);
+
+    TORCH_CHECK(q.dim() == 2, "deepseek_v4_q_norm expects 2D q [num_tokens, num_heads * head_dim], got ", q.dim(), "D");
+    TORCH_CHECK(q.size(1) == numHeads * headDim, "q.shape[1] must equal num_heads * head_dim");
+
+    auto output = torch::empty_like(q);
+    int64_t const totalRows64 = q.size(0) * numHeads;
+    TORCH_CHECK(totalRows64 <= std::numeric_limits<int>::max(), "deepseek_v4_q_norm total rows exceed int range");
+    int const totalRows = static_cast<int>(totalRows64);
+    auto stream = at::cuda::getCurrentCUDAStream(q.get_device());
+
+    if (q.scalar_type() == torch::kFloat16)
+    {
+        tensorrt_llm::kernels::invokeDeepseekV4QNorm(q.data_ptr(), output.data_ptr(), totalRows,
+            static_cast<int>(headDim), false, static_cast<float>(eps), stream);
+    }
+    else
+    {
+        tensorrt_llm::kernels::invokeDeepseekV4QNorm(q.data_ptr(), output.data_ptr(), totalRows,
+            static_cast<int>(headDim), true, static_cast<float>(eps), stream);
+    }
+    return output;
+}
+
+} // namespace torch_ext
+
+TRTLLM_NAMESPACE_END
+
+TORCH_LIBRARY_FRAGMENT(trtllm, m)
+{
+    m.def("deepseek_v4_q_norm(Tensor q, int num_heads, int head_dim, float eps) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
+{
+    m.impl("deepseek_v4_q_norm", &tensorrt_llm::torch_ext::deepseekV4QNorm);
+}

--- a/cpp/tensorrt_llm/thop/fp8Quantize.cpp
+++ b/cpp/tensorrt_llm/thop/fp8Quantize.cpp
@@ -16,6 +16,7 @@
 
 #include "tensorrt_llm/common/cudaUtils.h"
 #include "tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_gemm.h"
+#include "tensorrt_llm/kernels/cutlass_kernels/fp8_blockscale_gemm/fp8_blockscale_quant_packed.h"
 #include "tensorrt_llm/thop/thUtils.h"
 
 #include <ATen/cuda/EmptyTensor.h>
@@ -141,6 +142,73 @@ std::tuple<at::Tensor, at::Tensor> fp8_batched_quantize_1x128_permute102(at::Ten
 
     return {valueE4M3.slice(0, 0, b * m * n).view({b, m, n}), scaleFP8SF};
 }
+
+// Fused 1x128 FP8 quantize + UE8M0 packing (SM100 only).
+//
+// Drop-in replacement for the (fp8_quantize_1x128 → get_mn_major_tma_aligned_packed_ue8m0_tensor)
+// two-kernel sequence used by deep_gemm fp8 block-scale GEMMs.  Returns the
+// packed UE8M0 scale tensor (int32, MN-major, TMA-aligned) directly so
+// deep_gemm's transform_sf_into_required_layout falls through the
+// `(INT, 1, gran_k)` branch and skips its own pack call.
+std::tuple<at::Tensor, at::Tensor> fp8_quantize_1x128_packed_ue8m0(at::Tensor const& self)
+{
+    CHECK_TH_CUDA(self);
+    CHECK_CONTIGUOUS(self);
+
+    TORCH_CHECK(self.scalar_type() == at::ScalarType::BFloat16, "Input matrix dtype must be BF16.");
+    TORCH_CHECK(self.dim() == 2, "input must be a matrix");
+    TORCH_CHECK(tensorrt_llm::common::isSM100Family(),
+        "fp8_quantize_1x128_packed_ue8m0 currently only supports SM100 (Blackwell).");
+
+    auto const m = self.sizes()[0];
+    auto const n = self.sizes()[1];
+
+    TORCH_CHECK(m <= std::numeric_limits<int32_t>::max(), "M must be within int32");
+    TORCH_CHECK(n <= std::numeric_limits<int32_t>::max(), "N must be within int32");
+    TORCH_CHECK(n % 16 == 0, "self.sizes()[1] must be a multiple of 16, but got ", n);
+
+    // FP8 output is row-major [m, n] with the same alignment used by the legacy path.
+    // The legacy path pads M to a multiple of 4; replicate that to avoid layout surprises.
+    auto const m_padded = (m + 4 - 1) / 4 * 4;
+
+    at::Tensor valueE4M3 = at::detail::empty_cuda(
+        {m_padded, n}, at::ScalarType::Float8_e4m3fn, self.device(), /* stride */ std::nullopt);
+
+    // Packed scale physical layout: [num_packed_sf_k, m_aligned] uint32, MN-contiguous in memory.
+    // deep_gemm's get_mn_major_tma_aligned_packed_ue8m0_tensor returns a strided VIEW with
+    // PyTorch shape `[mn, packed_sf_k]` and strides `(1, tma_aligned_mn)`. We build the same
+    // strided view so deep_gemm's transform_sf_into_required_layout falls into the
+    // `(INT, 1, gran_k)` branch and skips its own pack call.
+    auto const num_n_blocks = (n + 127) / 128;
+    auto const num_packed_sf_k = (num_n_blocks + 3) / 4;
+    constexpr int kTmaAlignedUint32Elems = 4; // 16 bytes / sizeof(uint32_t)
+    auto const m_aligned = (m_padded + kTmaAlignedUint32Elems - 1) / kTmaAlignedUint32Elems * kTmaAlignedUint32Elems;
+
+    // Allocate physical buffer [num_packed_sf_k, m_aligned] (K-major in memory).
+    at::Tensor packedBuf = at::detail::empty_cuda(
+        {num_packed_sf_k, m_aligned}, at::ScalarType::Int, self.device(), /* stride */ std::nullopt);
+    // Zero-fill so the [m, m_aligned) tail and out-of-range scale slots are deterministic.
+    packedBuf.zero_();
+
+    auto stream = at::cuda::getCurrentCUDAStream(self.get_device());
+
+    tensorrt_llm::kernels::fp8_blockscale_gemm::launch_fp8_quantize_1x128_packed_bf16_e4m3(
+        reinterpret_cast<__nv_fp8_e4m3*>(valueE4M3.data_ptr()), reinterpret_cast<int32_t*>(packedBuf.data_ptr()),
+        reinterpret_cast<__nv_bfloat16 const*>(self.data_ptr()), static_cast<int>(m), static_cast<int>(n),
+        static_cast<int>(m_aligned), stream);
+
+    // Wrap the [num_packed_sf_k, m_aligned] memory as a [m, num_packed_sf_k] strided tensor
+    // matching deep_gemm's get_mn_major_tma_aligned_packed_ue8m0_tensor return contract:
+    //   shape  = (m, num_packed_sf_k)
+    //   stride = (1, m_aligned)
+    at::Tensor packedScale = at::from_blob(
+        packedBuf.data_ptr(),
+        /* sizes   */ {m, num_packed_sf_k},
+        /* strides */ {1, m_aligned},
+        /* deleter */ [keep = packedBuf](void*) mutable {}, packedBuf.options());
+
+    return {valueE4M3.slice(0, 0, m), packedScale};
+}
 } // namespace torch_ext
 
 TRTLLM_NAMESPACE_END
@@ -149,10 +217,12 @@ TORCH_LIBRARY_FRAGMENT(trtllm, m)
 {
     m.def("fp8_quantize_1x128(Tensor input, bool use_ue8m0=False) -> (Tensor, Tensor)");
     m.def("fp8_batched_quantize_1x128_permute102(Tensor input) -> (Tensor, Tensor)");
+    m.def("fp8_quantize_1x128_packed_ue8m0(Tensor input) -> (Tensor, Tensor)");
 }
 
 TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
 {
     m.impl("fp8_quantize_1x128", &tensorrt_llm::torch_ext::fp8_quantize_1x128);
     m.impl("fp8_batched_quantize_1x128_permute102", &tensorrt_llm::torch_ext::fp8_batched_quantize_1x128_permute102);
+    m.impl("fp8_quantize_1x128_packed_ue8m0", &tensorrt_llm::torch_ext::fp8_quantize_1x128_packed_ue8m0);
 }

--- a/cpp/tensorrt_llm/thop/fp8Quantize.cpp
+++ b/cpp/tensorrt_llm/thop/fp8Quantize.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2023, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2020-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tensorrt_llm/thop/mlaRopeInplaceOp.cpp
+++ b/cpp/tensorrt_llm/thop/mlaRopeInplaceOp.cpp
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 1993-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "tensorrt_llm/kernels/mlaKernels.h"
+#include "tensorrt_llm/thop/thUtils.h"
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <torch/extension.h>
+
+namespace tk = tensorrt_llm::kernels;
+
+TRTLLM_NAMESPACE_BEGIN
+
+namespace torch_ext
+{
+
+// Apply RoPE in-place to only the last rope_dim elements of each head.
+// data: [num_tokens, num_heads, nope_dim + rope_dim]
+// position_ids: [num_tokens]
+// cos_sin_cache: [max_positions, 2, rope_dim/2] float
+// is_neox: true = neox style (first/second half), false = interleaved style (even/odd)
+void mla_rope_inplace(torch::Tensor data, torch::Tensor position_ids, torch::Tensor cos_sin_cache, int64_t num_heads,
+    int64_t nope_dim, int64_t rope_dim, bool inverse, bool is_neox)
+{
+    auto stream = at::cuda::getCurrentCUDAStream(data.get_device());
+    int const num_tokens = data.size(0);
+    auto const dtype = data.scalar_type();
+
+    TORCH_CHECK(data.dim() == 3, "data must be 3D [num_tokens, num_heads, head_dim]");
+    TORCH_CHECK(data.size(1) == num_heads, "data.size(1) must equal num_heads");
+    TORCH_CHECK(data.size(2) == nope_dim + rope_dim, "data.size(2) must equal nope_dim + rope_dim");
+    TORCH_CHECK(data.is_contiguous(), "data must be contiguous");
+    TORCH_CHECK(position_ids.dim() == 1 && position_ids.size(0) == num_tokens, "position_ids shape mismatch");
+    TORCH_CHECK(position_ids.scalar_type() == torch::kInt32, "position_ids must be int32");
+    TORCH_CHECK(cos_sin_cache.scalar_type() == torch::kFloat32, "cos_sin_cache must be float32");
+
+    if (dtype == torch::kBFloat16)
+    {
+        tk::invokeMLARoPEInplace(static_cast<__nv_bfloat16*>(data.data_ptr()), position_ids.data_ptr<int32_t>(),
+            cos_sin_cache.data_ptr<float>(), num_tokens, static_cast<int>(num_heads), static_cast<int>(nope_dim),
+            static_cast<int>(rope_dim), inverse, is_neox, stream);
+    }
+    else if (dtype == torch::kFloat16)
+    {
+        tk::invokeMLARoPEInplace(static_cast<half*>(data.data_ptr()), position_ids.data_ptr<int32_t>(),
+            cos_sin_cache.data_ptr<float>(), num_tokens, static_cast<int>(num_heads), static_cast<int>(nope_dim),
+            static_cast<int>(rope_dim), inverse, is_neox, stream);
+    }
+    else
+    {
+        TORCH_CHECK(false, "mla_rope_inplace: unsupported dtype, expected bf16 or fp16");
+    }
+}
+
+} // namespace torch_ext
+
+TRTLLM_NAMESPACE_END
+
+TORCH_LIBRARY_FRAGMENT(trtllm, m)
+{
+    m.def(
+        "mla_rope_inplace("
+        "Tensor(a!) data"
+        ", Tensor position_ids"
+        ", Tensor cos_sin_cache"
+        ", int num_heads"
+        ", int nope_dim"
+        ", int rope_dim"
+        ", bool inverse"
+        ", bool is_neox"
+        ") -> ()");
+}
+
+TORCH_LIBRARY_IMPL(trtllm, CUDA, m)
+{
+    m.impl("mla_rope_inplace", &tensorrt_llm::torch_ext::mla_rope_inplace);
+}

--- a/cpp/tensorrt_llm/thop/mlaRopeInplaceOp.cpp
+++ b/cpp/tensorrt_llm/thop/mlaRopeInplaceOp.cpp
@@ -37,17 +37,27 @@ namespace torch_ext
 void mla_rope_inplace(torch::Tensor data, torch::Tensor position_ids, torch::Tensor cos_sin_cache, int64_t num_heads,
     int64_t nope_dim, int64_t rope_dim, bool inverse, bool is_neox)
 {
-    auto stream = at::cuda::getCurrentCUDAStream(data.get_device());
-    int const num_tokens = data.size(0);
-    auto const dtype = data.scalar_type();
-
+    TORCH_CHECK(data.is_cuda(), "data must be a CUDA tensor");
+    TORCH_CHECK(position_ids.is_cuda(), "position_ids must be a CUDA tensor");
+    TORCH_CHECK(cos_sin_cache.is_cuda(), "cos_sin_cache must be a CUDA tensor");
+    TORCH_CHECK(position_ids.device() == data.device(), "position_ids must be on the same device as data");
+    TORCH_CHECK(cos_sin_cache.device() == data.device(), "cos_sin_cache must be on the same device as data");
     TORCH_CHECK(data.dim() == 3, "data must be 3D [num_tokens, num_heads, head_dim]");
+    int const num_tokens = data.size(0);
     TORCH_CHECK(data.size(1) == num_heads, "data.size(1) must equal num_heads");
     TORCH_CHECK(data.size(2) == nope_dim + rope_dim, "data.size(2) must equal nope_dim + rope_dim");
     TORCH_CHECK(data.is_contiguous(), "data must be contiguous");
     TORCH_CHECK(position_ids.dim() == 1 && position_ids.size(0) == num_tokens, "position_ids shape mismatch");
+    TORCH_CHECK(position_ids.is_contiguous(), "position_ids must be contiguous");
     TORCH_CHECK(position_ids.scalar_type() == torch::kInt32, "position_ids must be int32");
+    TORCH_CHECK(rope_dim % 2 == 0, "rope_dim must be even");
     TORCH_CHECK(cos_sin_cache.scalar_type() == torch::kFloat32, "cos_sin_cache must be float32");
+    TORCH_CHECK(cos_sin_cache.dim() == 3 && cos_sin_cache.size(1) == 2 && cos_sin_cache.size(2) * 2 == rope_dim,
+        "cos_sin_cache must have shape [max_positions, 2, rope_dim / 2]");
+    TORCH_CHECK(cos_sin_cache.is_contiguous(), "cos_sin_cache must be contiguous");
+
+    auto stream = at::cuda::getCurrentCUDAStream(data.get_device());
+    auto const dtype = data.scalar_type();
 
     if (dtype == torch::kBFloat16)
     {

--- a/tensorrt_llm/_torch/custom_ops/__init__.py
+++ b/tensorrt_llm/_torch/custom_ops/__init__.py
@@ -1,3 +1,6 @@
+# Imported first to register the op before the chain via ..modules.attention re-enters this package.
+from . import triton_fused_inv_rope_fp8_quant  # noqa: F401  # isort: skip
+
 import torch
 
 from ..cuda_tile_utils import IS_CUDA_TILE_AVAILABLE

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -136,6 +136,10 @@ def _register_fake():
           trigger_completion_at_end):
         return [torch.empty_like(q), torch.empty_like(k)]
 
+    @torch.library.register_fake("trtllm::deepseek_v4_q_norm")
+    def _(q: torch.Tensor, num_heads: int, head_dim: int, eps: float):
+        return torch.empty_like(q)
+
     @torch.library.register_fake("trtllm::allgather")
     def allgather(input, sizes, group):
         if sizes is None:
@@ -663,6 +667,17 @@ def _register_fake():
         packed = pe.new_empty((M, head_dim // 2), dtype=torch.int8)
         scale = pe.new_empty((M, 1), dtype=torch.int32)
         return packed, scale
+
+    @torch.library.register_fake("trtllm::fp8_quantize_1x128_packed_ue8m0")
+    def _(input: torch.Tensor):
+        # Returns (fp8_e4m3 [m, k], packed_ue8m0_int32 [m, packed_sf_k])
+        # matching deep_gemm.get_mn_major_tma_aligned_packed_ue8m0_tensor's return shape.
+        m, k = input.shape[0], input.shape[1]
+        num_n_blocks = (k + 127) // 128
+        num_packed_sf_k = (num_n_blocks + 3) // 4
+        return torch.empty_like(input,
+                                dtype=torch.float8_e4m3fn), input.new_empty(
+                                    (m, num_packed_sf_k), dtype=torch.int32)
 
     @torch.library.register_fake("trtllm::causal_conv1d_fwd")
     def _(

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1707,7 +1707,7 @@ def _fp8_quantize_1x128_ue8m0(input: torch.Tensor, tactic: int):
         a_sf = deep_gemm.get_mn_major_tma_aligned_packed_ue8m0_tensor(
             a_sf.transpose(0, 1))
         return a, a_sf
-    if _USE_FUSED_FP8_QUANT_PACK and get_sm_version() in (100, 103):
+    if _USE_FUSED_FP8_QUANT_PACK and get_sm_version() >= 100:
         a, a_sf = torch.ops.trtllm.fp8_quantize_1x128_packed_ue8m0(input)
         return a, a_sf
     a, a_sf = torch.ops.trtllm.fp8_quantize_1x128(input, use_ue8m0=True)

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1707,7 +1707,7 @@ def _fp8_quantize_1x128_ue8m0(input: torch.Tensor, tactic: int):
         a_sf = deep_gemm.get_mn_major_tma_aligned_packed_ue8m0_tensor(
             a_sf.transpose(0, 1))
         return a, a_sf
-    if _USE_FUSED_FP8_QUANT_PACK and get_sm_version() >= 100:
+    if _USE_FUSED_FP8_QUANT_PACK and get_sm_version() in (100, 103):
         a, a_sf = torch.ops.trtllm.fp8_quantize_1x128_packed_ue8m0(input)
         return a, a_sf
     a, a_sf = torch.ops.trtllm.fp8_quantize_1x128(input, use_ue8m0=True)

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -1687,14 +1687,30 @@ def _(
 
 # deep_gemm_gen_tuning_buckets is imported from ..utils
 
+_USE_FUSED_FP8_QUANT_PACK = os.environ.get("TRTLLM_FUSED_FP8_QUANT_PACK",
+                                           "1") == "1"
+
 
 def _fp8_quantize_1x128_ue8m0(input: torch.Tensor, tactic: int):
-    """Dispatch FP8 1x128 quantization to CUDA or Triton kernel."""
+    """Dispatch FP8 1x128 quantization to CUDA or Triton kernel.
+
+    When the CUDA path is selected on SM100 and ``TRTLLM_FUSED_FP8_QUANT_PACK=1``
+    is set, the fused ``fp8_quantize_1x128_packed_ue8m0`` op is used and the
+    follow-on ``get_mn_major_tma_aligned_packed_ue8m0_tensor`` call is skipped:
+    the new op writes packed-UE8M0 (int32) scales directly in the layout
+    deep_gemm expects, so deep_gemm's internal layout transform falls into the
+    pre-packed branch and skips its own pack kernel as well.
+    """
     TACTIC_TRITON = 1
     if tactic == TACTIC_TRITON:
         a, a_sf = fp8_quantize.triton_fp8_quantize_1x128(input, use_ue8m0=True)
-    else:
-        a, a_sf = torch.ops.trtllm.fp8_quantize_1x128(input, use_ue8m0=True)
+        a_sf = deep_gemm.get_mn_major_tma_aligned_packed_ue8m0_tensor(
+            a_sf.transpose(0, 1))
+        return a, a_sf
+    if _USE_FUSED_FP8_QUANT_PACK and get_sm_version() >= 100:
+        a, a_sf = torch.ops.trtllm.fp8_quantize_1x128_packed_ue8m0(input)
+        return a, a_sf
+    a, a_sf = torch.ops.trtllm.fp8_quantize_1x128(input, use_ue8m0=True)
     a_sf = deep_gemm.get_mn_major_tma_aligned_packed_ue8m0_tensor(
         a_sf.transpose(0, 1))
     return a, a_sf

--- a/tensorrt_llm/_torch/custom_ops/triton_fused_inv_rope_fp8_quant.py
+++ b/tensorrt_llm/_torch/custom_ops/triton_fused_inv_rope_fp8_quant.py
@@ -1,0 +1,312 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-License-Identifier: Apache-2.0
+#
+# Adapted from vLLM:
+#   https://github.com/vllm-project/vllm/blob/ecd0b60aad2f4e28dd00ababfc1402690d88cbed/vllm/v1/attention/ops/deepseek_v4_ops/fused_inv_rope_fp8_quant.py
+#
+# Modifications relative to upstream vLLM (Apache-2.0, licensed identically to
+# TensorRT-LLM):
+#  * Added a NEOX RoPE branch (`IS_NEOX` constexpr). Upstream is interleaved
+#    (GPT-J style) only; DeepSeek-V4 in TensorRT-LLM uses NEOX layout for the
+#    inverse RoPE applied before `o_a_proj` (see
+#    `cpp/tensorrt_llm/kernels/mlaKernels.cu:1190-1276`).
+#  * Output FP8 buffer is returned without the trailing `transpose(0, 1)` so
+#    the result is directly consumable by `cute_dsl_fp8_bmm_blackwell` whose
+#    input layout is `[batch=n_groups, m=num_tokens, k=d]`. Likewise the scale
+#    buffer is returned as a contiguous `[n_groups, num_scale_blocks, pad_up(num_tokens, 4)]`
+#    FP32 tensor (matching the output of `fp8_batched_quantize_1x128_permute102`)
+#    rather than the strided `[T, G, num_scale_blocks]` view used by vLLM.
+#  * Drops the `tma_aligned_scales`/SM90 split — TensorRT-LLM's consumer is
+#    SM100 with FP32 a-side scales, so the upstream UE8M0-INT32 pack path is
+#    not needed here.
+#  * Rebound the cos/sin cache to TensorRT-LLM's NEOX layout
+#    `[max_pos, 2, half_rope]` (cos block then sin block per position) by
+#    advertising the contract as a flat `[max_pos, rope_dim]` view; the
+#    indexing math is identical for both kernels.
+#  * Replaces vLLM's `direct_register_custom_op` with `torch.library.custom_op`,
+#    matching the rest of `tensorrt_llm/_torch/custom_ops/`.
+#
+# Engaged from `tensorrt_llm/_torch/modules/attention.py:_deepseek_v4_o_proj`
+# when `use_cute_dsl_blockscaling_bmm` is enabled in `extra_llm_api_options` on
+# SM100; falls back to the legacy `mla_rope_inplace + permute102_quant` pair
+# otherwise.
+"""
+Fused inverse-RoPE + 1x128 block-scaled FP8 quantize, for DeepSeek-V4 ``o_a_proj``.
+
+Replaces the (``mla_rope_inplace`` -> ``fp8_batched_quantize_1x128_permute102``)
+two-kernel pair in ``_deepseek_v4_o_proj``. The output is consumed verbatim by
+``cute_dsl_fp8_bmm_blackwell``.
+"""
+
+from __future__ import annotations
+
+import torch
+import triton  # type: ignore[import]
+import triton.language as tl  # type: ignore[import]
+
+
+@triton.jit
+def _fused_inv_rope_fp8_quant_per_head(
+    o_ptr,
+    positions_ptr,
+    cos_sin_cache_ptr,
+    fp8_ptr,
+    scale_ptr,
+    num_tokens,
+    heads_per_group: tl.constexpr,
+    o_stride_token,
+    o_stride_head,
+    cache_stride_pos,
+    fp8_stride_group,
+    fp8_stride_token,
+    scale_stride_group,
+    scale_stride_k,
+    fp8_max: tl.constexpr,
+    eps: tl.constexpr,
+    QUANT_GROUP_SIZE: tl.constexpr,
+    CHUNKS_PER_HEAD: tl.constexpr,
+    ROPE_START: tl.constexpr,
+    HALF_ROPE: tl.constexpr,
+    IS_NEOX: tl.constexpr,
+):
+    # int64: stride multiply overflows int32 past num_tokens=32768 (IMA).
+    pid_token = tl.program_id(0).to(tl.int64)
+    pid_gh = tl.program_id(1).to(tl.int64)
+
+    g = pid_gh // heads_per_group
+    head_in_group = pid_gh % heads_per_group
+    global_head = pid_gh
+    qb_start = head_in_group * CHUNKS_PER_HEAD
+
+    # Padding rows (M aligned up to 4): zero out the scale and skip quant.
+    if pid_token >= num_tokens:
+        block_offsets = tl.arange(0, CHUNKS_PER_HEAD)
+        qb_indices = qb_start + block_offsets
+        scale_addrs = scale_ptr + g * scale_stride_group + pid_token + qb_indices * scale_stride_k
+        tl.store(scale_addrs, tl.zeros((CHUNKS_PER_HEAD,), dtype=tl.float32))
+        return
+
+    input_base = o_ptr + pid_token * o_stride_token + global_head * o_stride_head
+
+    HEAD_DIM: tl.constexpr = CHUNKS_PER_HEAD * QUANT_GROUP_SIZE
+    offsets = tl.arange(0, HEAD_DIM)
+    x = tl.load(input_base + offsets).to(tl.float32)
+
+    rope_abs_start: tl.constexpr = (CHUNKS_PER_HEAD - 1) * QUANT_GROUP_SIZE + ROPE_START
+    pos = tl.load(positions_ptr + pid_token)
+    cache_base = cos_sin_cache_ptr + pos * cache_stride_pos
+    is_rope = offsets >= rope_abs_start
+    rope_local = offsets - rope_abs_start
+
+    if IS_NEOX:
+        # NEOX layout: rope half = [x1[0..H), x2[0..H)] where H = HALF_ROPE.
+        # For inverse RoPE (coef = (cos, -sin)):
+        #   new_x1[i] = cos[i] * x1[i] + sin[i] * x2[i]
+        #   new_x2[i] = cos[i] * x2[i] - sin[i] * x1[i]
+        # In a single per-element formulation:
+        #   partner_offset = (i < H) ? i + H : i - H
+        #   sign = (i < H) ? +1 : -1
+        #   new = cos * x[i] + sign * sin * x[partner]
+        is_first_half = rope_local < HALF_ROPE
+        partner_local = tl.where(is_first_half, rope_local + HALF_ROPE, rope_local - HALF_ROPE)
+        partner_abs = rope_abs_start + partner_local
+        x_partner = tl.load(input_base + partner_abs, mask=is_rope, other=0.0).to(tl.float32)
+        cs_idx = tl.where(is_first_half, rope_local, rope_local - HALF_ROPE)
+        cos_v = tl.load(cache_base + cs_idx, mask=is_rope, other=1.0)
+        sin_v = tl.load(cache_base + HALF_ROPE + cs_idx, mask=is_rope, other=0.0)
+        sign = tl.where(is_first_half, 1.0, -1.0)
+        rotated = x * cos_v + sign * sin_v * x_partner
+    else:
+        # GPT-J / interleaved layout: pairs (x[2i], x[2i+1]).
+        x_partner = tl.load(input_base + (offsets ^ 1), mask=is_rope, other=0.0).to(tl.float32)
+        cs_idx = tl.maximum(rope_local >> 1, 0)
+        cos_v = tl.load(cache_base + cs_idx, mask=is_rope, other=1.0)
+        sin_v = tl.load(cache_base + HALF_ROPE + cs_idx, mask=is_rope, other=0.0)
+        x_add = x * cos_v + x_partner * sin_v
+        x_sub = x * cos_v - x_partner * sin_v
+        is_even = (rope_local & 1) == 0
+        rotated = tl.where(is_even, x_add, x_sub)
+
+    x = tl.where(is_rope, rotated, x)
+
+    x_2d = tl.reshape(tl.abs(x), (CHUNKS_PER_HEAD, QUANT_GROUP_SIZE))
+    block_absmax = tl.maximum(tl.max(x_2d, axis=1), eps)
+    # Match `fp8_batched_quantize_1x128_permute102`'s raw FP32 scale layout
+    # (no UE8M0 round-up): scales = absmax / fp8_max so that quant value =
+    # x / scale = x * fp8_max / absmax. This keeps `cute_dsl_fp8_bmm_blackwell`
+    # bit-for-bit on parity with the legacy permute102 quant in the same gate.
+    scales = block_absmax * (1.0 / fp8_max)
+
+    scales_exp = tl.reshape(
+        tl.broadcast_to(
+            tl.reshape(scales, (CHUNKS_PER_HEAD, 1)),
+            (CHUNKS_PER_HEAD, QUANT_GROUP_SIZE),
+        ),
+        (HEAD_DIM,),
+    )
+    x_quant = tl.clamp(x / scales_exp, -fp8_max, fp8_max).to(tl.float8e4nv)
+
+    fp8_base = (
+        fp8_ptr + g * fp8_stride_group + pid_token * fp8_stride_token + qb_start * QUANT_GROUP_SIZE
+    )
+    tl.store(fp8_base + offsets, x_quant)
+
+    block_offsets = tl.arange(0, CHUNKS_PER_HEAD)
+    qb_indices = qb_start + block_offsets
+    scale_addrs = scale_ptr + g * scale_stride_group + pid_token + qb_indices * scale_stride_k
+    tl.store(scale_addrs, scales)
+
+
+def _tma_aligned_size(x: int, tma_align_size_in_elems: int = 4) -> int:
+    return (x + tma_align_size_in_elems - 1) // tma_align_size_in_elems * tma_align_size_in_elems
+
+
+def _fused_inv_rope_fp8_quant_impl(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    n_groups: int,
+    heads_per_group: int,
+    nope_dim: int,
+    rope_dim: int,
+    quant_group_size: int,
+    is_neox: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    num_tokens, num_heads, head_dim = o.shape
+    assert num_heads == n_groups * heads_per_group, (
+        f"num_heads={num_heads} != n_groups({n_groups}) * heads_per_group({heads_per_group})"
+    )
+    assert head_dim == nope_dim + rope_dim, (
+        f"head_dim={head_dim} != nope_dim({nope_dim}) + rope_dim({rope_dim})"
+    )
+    assert head_dim % quant_group_size == 0
+    expected_nope_mod = quant_group_size - rope_dim
+    assert nope_dim % quant_group_size == expected_nope_mod, (
+        f"Layout requires nope_dim%{quant_group_size}=="
+        f"{quant_group_size}-rope_dim={expected_nope_mod}, "
+        f"got {nope_dim % quant_group_size}"
+    )
+    assert rope_dim % 2 == 0
+    assert cos_sin_cache.dtype == torch.float32, (
+        f"cos_sin_cache must be fp32, got {cos_sin_cache.dtype}"
+    )
+
+    d = heads_per_group * head_dim
+    num_scale_blocks = d // quant_group_size
+    chunks_per_head = head_dim // quant_group_size
+
+    fp8_dtype = torch.float8_e4m3fn
+    fp8_max = torch.finfo(fp8_dtype).max
+
+    tma_aligned_T = _tma_aligned_size(num_tokens, 4)
+
+    # FP8 output buffer: fully contiguous [n_groups, num_tokens, d] — must
+    # match `fp8_batched_quantize_1x128_permute102`'s contiguous output exactly,
+    # because `cute_dsl_fp8_bmm_blackwell` consumes the FP8 buffer via
+    # `make_ptr(.data_ptr())` and assumes contiguous `(G, T, K)` strides
+    # `(T*K, K, 1)`. Padding the M dim (tma_aligned_T) leaves stride[0] =
+    # tma_aligned_T*K, which silently shifts every batch's data when
+    # num_tokens % 4 != 0 — manifested as a catastrophic gsm8k regression
+    # (96.25 -> 37.38) on Pro TEP8 c128 in the first attempt.
+    fp8_buf = torch.empty(
+        (n_groups, num_tokens, d),
+        dtype=fp8_dtype,
+        device=o.device,
+    )
+
+    # Scale buffer: contiguous [n_groups, num_scale_blocks, tma_aligned_T] FP32.
+    scale_buf = torch.empty(
+        (n_groups, num_scale_blocks, tma_aligned_T),
+        dtype=torch.float32,
+        device=o.device,
+    )
+    # The kernel addresses scales via `scale_ptr + g * scale_stride_group +
+    # token_idx + qb_indices * scale_stride_k`, i.e. layout
+    # `[n_groups, num_scale_blocks, tma_aligned_T]` with the inner stride 1
+    # along tokens.  scale_stride_group = num_scale_blocks * tma_aligned_T,
+    # scale_stride_k = tma_aligned_T.
+
+    # Pass cos_sin_cache as a flat [max_pos, rope_dim] view. TensorRT-LLM
+    # stores it as [max_pos, 2, rope_dim/2] (cos block then sin block per
+    # position) which is bit-identical layout — just a different shape.
+    cos_sin_view = cos_sin_cache.view(cos_sin_cache.shape[0], -1)
+    assert cos_sin_view.shape[-1] == rope_dim, (
+        f"cos_sin_cache last dim {cos_sin_view.shape[-1]} != rope_dim {rope_dim}"
+    )
+
+    # positions can be int32 or int64; the kernel does an opaque tl.load.
+    if positions.dtype != torch.int32 and positions.dtype != torch.int64:
+        positions = positions.to(torch.int64)
+
+    grid = (tma_aligned_T, n_groups * heads_per_group)
+    _fused_inv_rope_fp8_quant_per_head[grid](
+        o,
+        positions,
+        cos_sin_view,
+        fp8_buf,
+        scale_buf,
+        num_tokens,
+        heads_per_group=heads_per_group,
+        o_stride_token=o.stride(0),
+        o_stride_head=o.stride(1),
+        cache_stride_pos=cos_sin_view.stride(0),
+        fp8_stride_group=fp8_buf.stride(0),
+        fp8_stride_token=fp8_buf.stride(1),
+        scale_stride_group=scale_buf.stride(0),
+        scale_stride_k=scale_buf.stride(1),
+        fp8_max=fp8_max,
+        eps=1e-10,
+        QUANT_GROUP_SIZE=quant_group_size,
+        CHUNKS_PER_HEAD=chunks_per_head,
+        ROPE_START=nope_dim % quant_group_size,
+        HALF_ROPE=rope_dim // 2,
+        IS_NEOX=is_neox,
+        num_warps=1,
+        num_stages=1,
+    )
+    return fp8_buf, scale_buf
+
+
+def _fused_inv_rope_fp8_quant_fake(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    n_groups: int,
+    heads_per_group: int,
+    nope_dim: int,
+    rope_dim: int,
+    quant_group_size: int,
+    is_neox: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    num_tokens, num_heads, head_dim = o.shape
+    d = heads_per_group * head_dim
+    num_scale_blocks = d // quant_group_size
+    tma_aligned_T = _tma_aligned_size(num_tokens, 4)
+    fp8_buf = torch.empty(
+        (n_groups, num_tokens, d),
+        dtype=torch.float8_e4m3fn,
+        device=o.device,
+    )
+    scale_buf = torch.empty(
+        (n_groups, num_scale_blocks, tma_aligned_T),
+        dtype=torch.float32,
+        device=o.device,
+    )
+    return fp8_buf, scale_buf
+
+
+# Register as a torch custom op so dynamo / cudagraph see an opaque boundary.
+torch.library.define(
+    "trtllm::fused_inv_rope_fp8_quant_vllm_port",
+    "(Tensor o, Tensor positions, Tensor cos_sin_cache, "
+    "int n_groups, int heads_per_group, int nope_dim, int rope_dim, "
+    "int quant_group_size, bool is_neox) -> (Tensor, Tensor)",
+)
+torch.library.impl(
+    "trtllm::fused_inv_rope_fp8_quant_vllm_port",
+    "CUDA",
+)(_fused_inv_rope_fp8_quant_impl)
+torch.library.register_fake(
+    "trtllm::fused_inv_rope_fp8_quant_vllm_port",
+)(_fused_inv_rope_fp8_quant_fake)

--- a/tensorrt_llm/_torch/custom_ops/triton_fused_inv_rope_fp8_quant.py
+++ b/tensorrt_llm/_torch/custom_ops/triton_fused_inv_rope_fp8_quant.py
@@ -162,7 +162,8 @@ def _tma_aligned_size(x: int, tma_align_size_in_elems: int = 4) -> int:
     return (x + tma_align_size_in_elems - 1) // tma_align_size_in_elems * tma_align_size_in_elems
 
 
-def _fused_inv_rope_fp8_quant_impl(
+@torch.library.custom_op("trtllm::fused_inv_rope_fp8_quant_vllm_port", mutates_args=())
+def fused_inv_rope_fp8_quant_vllm_port(
     o: torch.Tensor,
     positions: torch.Tensor,
     cos_sin_cache: torch.Tensor,
@@ -173,24 +174,59 @@ def _fused_inv_rope_fp8_quant_impl(
     quant_group_size: int,
     is_neox: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
+    if not o.is_cuda:
+        raise ValueError("o must be a CUDA tensor")
+    if not positions.is_cuda:
+        raise ValueError("positions must be a CUDA tensor")
+    if not cos_sin_cache.is_cuda:
+        raise ValueError("cos_sin_cache must be a CUDA tensor")
+    if positions.device != o.device:
+        raise ValueError("positions must be on the same device as o")
+    if cos_sin_cache.device != o.device:
+        raise ValueError("cos_sin_cache must be on the same device as o")
+    if o.dim() != 3:
+        raise ValueError(f"o must be 3D [num_tokens, num_heads, head_dim], got {o.dim()}D")
+    if o.stride(-1) != 1:
+        raise ValueError("o last dimension must be contiguous")
+
     num_tokens, num_heads, head_dim = o.shape
-    assert num_heads == n_groups * heads_per_group, (
-        f"num_heads={num_heads} != n_groups({n_groups}) * heads_per_group({heads_per_group})"
-    )
-    assert head_dim == nope_dim + rope_dim, (
-        f"head_dim={head_dim} != nope_dim({nope_dim}) + rope_dim({rope_dim})"
-    )
-    assert head_dim % quant_group_size == 0
+    if num_heads != n_groups * heads_per_group:
+        raise ValueError(
+            f"num_heads={num_heads} != n_groups({n_groups}) * heads_per_group({heads_per_group})"
+        )
+    if head_dim != nope_dim + rope_dim:
+        raise ValueError(f"head_dim={head_dim} != nope_dim({nope_dim}) + rope_dim({rope_dim})")
+    if quant_group_size <= 0:
+        raise ValueError(f"quant_group_size must be positive, got {quant_group_size}")
+    if head_dim % quant_group_size != 0:
+        raise ValueError(
+            f"head_dim={head_dim} must be divisible by quant_group_size={quant_group_size}"
+        )
+    if rope_dim <= 0 or rope_dim > quant_group_size or rope_dim % 2 != 0:
+        raise ValueError(
+            f"rope_dim must be positive, even, and <= quant_group_size, got {rope_dim}"
+        )
     expected_nope_mod = quant_group_size - rope_dim
-    assert nope_dim % quant_group_size == expected_nope_mod, (
-        f"Layout requires nope_dim%{quant_group_size}=="
-        f"{quant_group_size}-rope_dim={expected_nope_mod}, "
-        f"got {nope_dim % quant_group_size}"
-    )
-    assert rope_dim % 2 == 0
-    assert cos_sin_cache.dtype == torch.float32, (
-        f"cos_sin_cache must be fp32, got {cos_sin_cache.dtype}"
-    )
+    if nope_dim % quant_group_size != expected_nope_mod:
+        raise ValueError(
+            f"Layout requires nope_dim%{quant_group_size}=="
+            f"{quant_group_size}-rope_dim={expected_nope_mod}, "
+            f"got {nope_dim % quant_group_size}"
+        )
+    if positions.numel() != num_tokens:
+        raise ValueError(
+            f"positions.numel()={positions.numel()} must equal num_tokens={num_tokens}"
+        )
+    if cos_sin_cache.dtype != torch.float32:
+        raise TypeError(f"cos_sin_cache must be fp32, got {cos_sin_cache.dtype}")
+    if (
+        cos_sin_cache.dim() != 3
+        or cos_sin_cache.size(1) != 2
+        or cos_sin_cache.size(2) * 2 != rope_dim
+    ):
+        raise ValueError("cos_sin_cache must have shape [max_positions, 2, rope_dim / 2]")
+    if not cos_sin_cache.is_contiguous():
+        raise ValueError("cos_sin_cache must be contiguous")
 
     d = heads_per_group * head_dim
     num_scale_blocks = d // quant_group_size
@@ -231,9 +267,6 @@ def _fused_inv_rope_fp8_quant_impl(
     # stores it as [max_pos, 2, rope_dim/2] (cos block then sin block per
     # position) which is bit-identical layout — just a different shape.
     cos_sin_view = cos_sin_cache.view(cos_sin_cache.shape[0], -1)
-    assert cos_sin_view.shape[-1] == rope_dim, (
-        f"cos_sin_cache last dim {cos_sin_view.shape[-1]} != rope_dim {rope_dim}"
-    )
 
     # positions can be int32 or int64; the kernel does an opaque tl.load.
     if positions.dtype != torch.int32 and positions.dtype != torch.int64:
@@ -268,6 +301,7 @@ def _fused_inv_rope_fp8_quant_impl(
     return fp8_buf, scale_buf
 
 
+@torch.library.register_fake("trtllm::fused_inv_rope_fp8_quant_vllm_port")
 def _fused_inv_rope_fp8_quant_fake(
     o: torch.Tensor,
     positions: torch.Tensor,
@@ -279,7 +313,7 @@ def _fused_inv_rope_fp8_quant_fake(
     quant_group_size: int,
     is_neox: bool,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    num_tokens, num_heads, head_dim = o.shape
+    num_tokens, _num_heads, head_dim = o.shape
     d = heads_per_group * head_dim
     num_scale_blocks = d // quant_group_size
     tma_aligned_T = _tma_aligned_size(num_tokens, 4)
@@ -294,19 +328,3 @@ def _fused_inv_rope_fp8_quant_fake(
         device=o.device,
     )
     return fp8_buf, scale_buf
-
-
-# Register as a torch custom op so dynamo / cudagraph see an opaque boundary.
-torch.library.define(
-    "trtllm::fused_inv_rope_fp8_quant_vllm_port",
-    "(Tensor o, Tensor positions, Tensor cos_sin_cache, "
-    "int n_groups, int heads_per_group, int nope_dim, int rope_dim, "
-    "int quant_group_size, bool is_neox) -> (Tensor, Tensor)",
-)
-torch.library.impl(
-    "trtllm::fused_inv_rope_fp8_quant_vllm_port",
-    "CUDA",
-)(_fused_inv_rope_fp8_quant_impl)
-torch.library.register_fake(
-    "trtllm::fused_inv_rope_fp8_quant_vllm_port",
-)(_fused_inv_rope_fp8_quant_fake)

--- a/tests/unittest/_torch/custom_ops/test_deepseek_v4_q_norm.py
+++ b/tests/unittest/_torch/custom_ops/test_deepseek_v4_q_norm.py
@@ -1,0 +1,62 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import pytest
+import torch
+
+import tensorrt_llm._torch.custom_ops  # noqa: F401
+
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="Requires CUDA")
+
+
+def _reference_q_norm(q: torch.Tensor, head_dim: int, eps: float) -> torch.Tensor:
+    q_view = q.view(-1, head_dim).float()
+    inv_rms = torch.rsqrt(q_view.pow(2).mean(dim=-1, keepdim=True) + eps)
+    return (q_view * inv_rms).to(q.dtype).view_as(q)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 7, 129])
+@pytest.mark.parametrize("num_heads", [1, 16])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        torch.float16,
+        pytest.param(
+            torch.bfloat16,
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_bf16_supported(), reason="Requires BF16 support"
+            ),
+        ),
+    ],
+)
+def test_deepseek_v4_q_norm_matches_reference(num_tokens, num_heads, dtype):
+    torch.manual_seed(0)
+    device = "cuda"
+    head_dim = 512
+    eps = 1e-6
+    q = torch.randn(num_tokens, num_heads * head_dim, dtype=dtype, device=device).contiguous()
+
+    out = torch.ops.trtllm.deepseek_v4_q_norm(q, num_heads, head_dim, eps)
+    ref = _reference_q_norm(q, head_dim, eps)
+
+    atol = 3.2e-2 if dtype == torch.bfloat16 else 5e-3
+    rtol = 8e-3 if dtype == torch.bfloat16 else 5e-3
+    torch.testing.assert_close(out, ref, atol=atol, rtol=rtol)
+
+
+def test_deepseek_v4_q_norm_torch_compile_fullgraph():
+    torch.manual_seed(0)
+    num_heads = 16
+    head_dim = 512
+    eps = 1e-6
+    q = torch.randn(8, num_heads * head_dim, dtype=torch.float16, device="cuda").contiguous()
+
+    def q_norm(q):
+        return torch.ops.trtllm.deepseek_v4_q_norm(q, num_heads, head_dim, eps)
+
+    out = torch.compile(q_norm, backend="eager", fullgraph=True)(q)
+    ref = _reference_q_norm(q, head_dim, eps)
+
+    torch.testing.assert_close(out, ref, atol=5e-3, rtol=5e-3)

--- a/tests/unittest/_torch/custom_ops/test_deepseek_v4_q_norm.py
+++ b/tests/unittest/_torch/custom_ops/test_deepseek_v4_q_norm.py
@@ -60,3 +60,34 @@ def test_deepseek_v4_q_norm_torch_compile_fullgraph():
     ref = _reference_q_norm(q, head_dim, eps)
 
     torch.testing.assert_close(out, ref, atol=5e-3, rtol=5e-3)
+
+
+def test_deepseek_v4_q_norm_rejects_invalid_inputs():
+    num_heads = 2
+    head_dim = 512
+    eps = 1e-6
+    q = torch.randn(3, num_heads * head_dim, dtype=torch.float16, device="cuda").contiguous()
+
+    with pytest.raises(RuntimeError, match="CUDA|CPU|backend"):
+        torch.ops.trtllm.deepseek_v4_q_norm(q.cpu(), num_heads, head_dim, eps)
+
+    q_noncontiguous = torch.randn(num_heads * head_dim, 3, dtype=torch.float16, device="cuda").t()
+    with pytest.raises(RuntimeError, match="contiguous"):
+        torch.ops.trtllm.deepseek_v4_q_norm(q_noncontiguous, num_heads, head_dim, eps)
+
+    with pytest.raises(RuntimeError, match="fp16/bf16"):
+        torch.ops.trtllm.deepseek_v4_q_norm(q.float(), num_heads, head_dim, eps)
+
+    with pytest.raises(RuntimeError, match="2D"):
+        torch.ops.trtllm.deepseek_v4_q_norm(
+            q.view(1, 3, num_heads * head_dim), num_heads, head_dim, eps
+        )
+
+    q_bad_shape = torch.randn(
+        3, num_heads * head_dim + 1, dtype=torch.float16, device="cuda"
+    ).contiguous()
+    with pytest.raises(RuntimeError, match="num_heads \\* head_dim"):
+        torch.ops.trtllm.deepseek_v4_q_norm(q_bad_shape, num_heads, head_dim, eps)
+
+    with pytest.raises(RuntimeError, match="head_dim=512"):
+        torch.ops.trtllm.deepseek_v4_q_norm(q, num_heads, 256, eps)

--- a/tests/unittest/_torch/custom_ops/test_fused_inv_rope_fp8_quant.py
+++ b/tests/unittest/_torch/custom_ops/test_fused_inv_rope_fp8_quant.py
@@ -55,8 +55,9 @@ def _fused_path(
     return fp8_fused, scale_fused
 
 
+@pytest.mark.parametrize("is_neox", [True, False])
 @pytest.mark.parametrize("num_tokens", [3, 64, 257, 512])
-def test_fused_inv_rope_fp8_quant_neox(num_tokens):
+def test_fused_inv_rope_fp8_quant_matches_reference(num_tokens, is_neox):
     torch.manual_seed(0)
     device = "cuda"
     n_groups = 4
@@ -77,7 +78,14 @@ def test_fused_inv_rope_fp8_quant_neox(num_tokens):
     position_ids = torch.randint(0, max_pos, (num_tokens,), dtype=torch.int32, device=device)
 
     fp8_ref, scale_ref = _ref_path(
-        o_bf16, position_ids, rotary_cos_sin, num_heads, n_groups, nope_dim, rope_dim, is_neox=True
+        o_bf16,
+        position_ids,
+        rotary_cos_sin,
+        num_heads,
+        n_groups,
+        nope_dim,
+        rope_dim,
+        is_neox=is_neox,
     )
     fp8_fused, scale_fused = _fused_path(
         o_bf16,
@@ -87,7 +95,7 @@ def test_fused_inv_rope_fp8_quant_neox(num_tokens):
         heads_per_group,
         nope_dim,
         rope_dim,
-        is_neox=True,
+        is_neox=is_neox,
     )
 
     assert fp8_ref.shape == fp8_fused.shape, (fp8_ref.shape, fp8_fused.shape)

--- a/tests/unittest/_torch/custom_ops/test_fused_inv_rope_fp8_quant.py
+++ b/tests/unittest/_torch/custom_ops/test_fused_inv_rope_fp8_quant.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Numerical-equivalence test for the vLLM-ported fused inverse-RoPE +
+FP8 1x128 quantize op.
+
+Compares (mla_rope_inplace -> fp8_batched_quantize_1x128_permute102) against
+the new fused op `trtllm::fused_inv_rope_fp8_quant_vllm_port`.
+
+Run inside a CUDA Blackwell (SM100f) container (the TRT-LLM build sqsh).
+"""
+
+import pytest
+import torch
+
+import tensorrt_llm._torch.custom_ops  # noqa: F401  (registers the fused op)
+from tensorrt_llm._utils import is_sm_100f
+
+pytestmark = pytest.mark.skipif(
+    not (torch.cuda.is_available() and is_sm_100f()),
+    reason="Requires SM100 family GPU",
+)
+
+
+def _ref_path(
+    o_bf16, position_ids, rotary_cos_sin, num_heads_tp, n_groups, nope_dim, rope_dim, is_neox
+):
+    """Reference: in-place mla_rope_inplace -> fp8_batched_quantize_1x128_permute102."""
+    o = o_bf16.clone().contiguous()
+    torch.ops.trtllm.mla_rope_inplace(
+        o, position_ids.view(-1), rotary_cos_sin, num_heads_tp, nope_dim, rope_dim, True, is_neox
+    )
+    # Reshape to [N, n_groups, heads_per_group * head_dim] to match the BMM site.
+    num_tokens = o.shape[0]
+    grouped = o.view(num_tokens, n_groups, -1)
+    fp8_ref, scale_ref = torch.ops.trtllm.fp8_batched_quantize_1x128_permute102(grouped)
+    return fp8_ref, scale_ref
+
+
+def _fused_path(
+    o_bf16, position_ids, rotary_cos_sin, n_groups, heads_per_group, nope_dim, rope_dim, is_neox
+):
+    o = o_bf16.contiguous()
+    fp8_fused, scale_fused = torch.ops.trtllm.fused_inv_rope_fp8_quant_vllm_port(
+        o,
+        position_ids.view(-1),
+        rotary_cos_sin,
+        n_groups,
+        heads_per_group,
+        nope_dim,
+        rope_dim,
+        128,
+        is_neox,
+    )
+    return fp8_fused, scale_fused
+
+
+@pytest.mark.parametrize("num_tokens", [3, 64, 257, 512])
+def test_fused_inv_rope_fp8_quant_neox(num_tokens):
+    torch.manual_seed(0)
+    device = "cuda"
+    n_groups = 4
+    heads_per_group = 8  # smaller for the test
+    num_heads = n_groups * heads_per_group
+    nope_dim, rope_dim = 448, 64
+    head_dim = nope_dim + rope_dim  # 512
+    max_pos = 2048
+
+    o_bf16 = torch.randn(num_tokens, num_heads, head_dim, dtype=torch.bfloat16, device=device)
+    # Simulate the TRT-LLM rotary_cos_sin layout: (max_pos, 2, rope_dim/2) fp32.
+    half = rope_dim // 2
+    cos = torch.randn(max_pos, half, dtype=torch.float32, device=device).cos()
+    sin = torch.randn(max_pos, half, dtype=torch.float32, device=device).sin()
+    rotary_cos_sin = torch.stack([cos, sin], dim=1).contiguous()
+    assert rotary_cos_sin.shape == (max_pos, 2, half)
+
+    position_ids = torch.randint(0, max_pos, (num_tokens,), dtype=torch.int32, device=device)
+
+    fp8_ref, scale_ref = _ref_path(
+        o_bf16, position_ids, rotary_cos_sin, num_heads, n_groups, nope_dim, rope_dim, is_neox=True
+    )
+    fp8_fused, scale_fused = _fused_path(
+        o_bf16,
+        position_ids,
+        rotary_cos_sin,
+        n_groups,
+        heads_per_group,
+        nope_dim,
+        rope_dim,
+        is_neox=True,
+    )
+
+    assert fp8_ref.shape == fp8_fused.shape, (fp8_ref.shape, fp8_fused.shape)
+    assert scale_ref.shape == scale_fused.shape, (scale_ref.shape, scale_fused.shape)
+
+    # Compare in dequantized BF16 space (FP8 truncation + FMA reordering can
+    # differ by 1 ULP).
+    def dequant(fp8, scale):
+        # fp8: [G, T, D]; scale: [G, D/128, pad_up(T,4)]
+        G, T, D = fp8.shape
+        f = fp8.to(torch.float32)
+        # Expand scale to [G, T, D]
+        s = scale.permute(0, 2, 1).contiguous()  # [G, pad_up_T, D/128]
+        s = s[:, :T, :]
+        s = s.unsqueeze(-1).expand(G, T, D // 128, 128).reshape(G, T, D)
+        return f * s
+
+    deq_ref = dequant(fp8_ref, scale_ref)
+    deq_fused = dequant(fp8_fused, scale_fused)
+    abs_diff = (deq_ref - deq_fused).abs()
+    rel = abs_diff.mean() / (deq_ref.abs().mean() + 1e-9)
+    # FP8 e4m3 has ~3 mantissa bits; 1-ULP tolerance scales with the value.
+    # Allow a generous 1% relative bound.
+    assert rel.item() < 1e-2, f"relative mismatch {rel.item()}"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FP8 quantization with UE8M0 scale packing for block-scale GEMM operations
  * Added DeepSeek V4 Q normalization operation
  * Added MLA RoPE inplace operation
  * Added fused inverse RoPE + FP8 quantization for DeepSeek-V4 models

* **Tests**
  * Added validation tests for DeepSeek V4 Q normalization
  * Added tests for fused inverse RoPE + FP8 quantization operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

This PR is PR-5 from the DeepSeek-V4 split of umbrella PR #14751.

It lands the standalone attention fusion/custom-op optimization primitives without bringing in the full DSv4 sparse MLA backend, cache manager, MoE routing, or DSv4 model/tokenizer files.

Changes included:
- Add DSv4 q-norm CUDA/thop op.
- Add MLA RoPE in-place thop op used by the focused fused quant reference path.
- Add fused inverse-RoPE + FP8 1x128 quantization torch custom op.
- Add packed FP8 1x128 quantization path for SM100.
- Add focused numerical tests for the new custom ops.

Reviewer note: this is intended as a standalone attention optimization PR. Later DSv4 sparse MLA work can consume these ops, but this PR does not functionally depend on the sparse MLA backend PR.

Rebase/conflict note: before push, this branch was rebased from `github/main` `e171875352df96eeb543557fe1c12fe320d37c7e` to `f49d09f1e0c0df1fa61f0fb89ed416b8e1056326`. No conflicts occurred.

## Test Coverage

- Built and installed from source after rebasing to latest main:
  `python3 ./scripts/build_wheel.py --trt_root /usr/local/tensorrt --benchmarks --use_ccache --cuda_architectures "90-real;100-real" --configure_cmake`
- Installed generated wheel:
  `./.venv-3.12/bin/pip install --force-reinstall --no-deps build/tensorrt_llm-1.3.0rc19-cp312-cp312-linux_x86_64.whl`
- Smoke checked that the current worktree source is imported and `deepseek_v4_q_norm`, `fp8_quantize_1x128_packed_ue8m0`, and `mla_rope_inplace` are registered.
- Checked GPU state with `nvidia-smi` before tests; used idle `CUDA_VISIBLE_DEVICES=0` after rebase.
- `CUDA_VISIBLE_DEVICES=0 timeout 1800 ./.venv-3.12/bin/python -m pytest -q --tb=short -ra tests/unittest/_torch/custom_ops/test_deepseek_v4_q_norm.py`
  - 13 passed
- `CUDA_VISIBLE_DEVICES=0 timeout 1800 ./.venv-3.12/bin/python -m pytest -q --tb=short -ra tests/unittest/_torch/custom_ops/test_fused_inv_rope_fp8_quant.py`
  - 4 passed
- `./.venv-3.12/bin/pre-commit run --files <PR5 files>`
  - Passed
- PR-5 scope-leakage check: no sparse MLA dispatch/backend, cache manager, MoE, compressor/mHC, IndexerTopK/TopK, or DSv4 model/tokenizer files.
- `git diff --check HEAD~1..HEAD`
  - Passed

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
