### PR TITLE
[None][chore] Enable KV cache manager v2 by default

### DIFF
--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3285,9 +3285,11 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
         "The number of tokens between cache steps in the Mamba prefix cache.")
 
     use_kv_cache_manager_v2: bool = Field(
-        default=False,
+        default=True,
         status="prototype",
-        description="Whether to use the KV cache manager v2 (experimental).")
+        description=
+        "Whether to use the KV cache manager v2. Unsupported feature combinations fall back to the original KV cache manager."
+    )
 
     kv_cache_event_hash_algo: Literal[
         "auto", "v1_block_key", "v2_sha256", "v2_sha256_64"] = Field(

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -337,6 +337,7 @@ class TestModelDefaults:
 
 def test_KvCacheConfig_declaration():
     assert KvCacheConfig().kv_cache_event_hash_algo == "auto"
+    assert KvCacheConfig().use_kv_cache_manager_v2 is True
 
     config = KvCacheConfig(enable_block_reuse=True,
                            max_tokens=1024,


### PR DESCRIPTION
## Description

Enable `KvCacheConfig.use_kv_cache_manager_v2` by default in LLM args. The field description now notes that unsupported feature combinations fall back to the original KV cache manager.

## Test Coverage

- Pre-commit hooks run by `git commit -s`
- Added unit coverage for the new default in `tests/unittest/llmapi/test_llm_args.py`
- CI PerfSanity stage will be triggered on this draft PR

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.