### PR TITLE
[https://nvbugs/6245862][fix] Fix MoE EP divisibility check for EPLB configurations

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/interface.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/interface.py
@@ -337,19 +337,15 @@ class MoE(nn.Module):
         self.ep_size = model_config.mapping.moe_ep_size
         self.ep_rank = model_config.mapping.moe_ep_rank
 
-        # Non-divisible EP gate. Backends opt in via the class attribute
-        # ``_supports_non_divisible_ep``. Default is to reject so that any backend
-        # whose dispatch/combine paths still assume uniform partitioning fails fast
-        # with a clear error instead of silently using a wrong local-expert range.
-        if (self.num_experts % self.ep_size != 0
-                and not type(self)._supports_non_divisible_ep):
-            raise ValueError(
-                f"{type(self).__name__} does not support non-divisible EP: "
-                f"num_experts ({self.num_experts}) must be divisible by "
-                f"ep_size ({self.ep_size}). Override "
-                f"`_supports_non_divisible_ep = True` on the subclass after "
-                f"verifying the kernel/comm path handles ceil/floor partitioning."
-            )
+        # Non-divisible EP divisibility is gated inside _init_load_balancer()
+        # because the correct quantity to check depends on whether EPLB is
+        # active (num_slots vs num_experts), and num_slots is only known
+        # after the load balancer config is consulted.
+        #
+        # When init_load_balancer=False (the wrapper path, e.g. ConfigurableMoE
+        # creating an inner backend), the wrapper is responsible for the
+        # divisibility contract and we skip the check entirely — the wrapper's
+        # own _init_load_balancer will gate it.
 
         self.moe_backend = model_config.moe_backend
         self.use_dp = model_config.mapping.enable_attention_dp
@@ -551,6 +547,17 @@ class MoE(nn.Module):
             assert self._supports_load_balancer()
             assert self.use_dp and self.parallel_size > 1, "Load Balancer should be only used with ADP and EP > 1"
             assert moe_load_balancer_config is not None
+            # EPLB provides uniform slot partition: every rank holds exactly
+            # num_slots // ep_size slots, regardless of (num_experts % ep_size).
+            # All backend kernels see uniform local-slot counts, so the
+            # non-divisible-EP opt-in is irrelevant here. We only need
+            # num_slots to divide ep_size for the slot partition to be uniform.
+            if moe_load_balancer_config.num_slots % self.ep_size != 0:
+                raise ValueError(
+                    f"{type(self).__name__}: with EPLB enabled, num_slots "
+                    f"({moe_load_balancer_config.num_slots}) must be divisible "
+                    f"by ep_size ({self.ep_size}) so each rank holds the same "
+                    f"number of slots.")
             top_k = self.routing_method.experts_per_token
             self.expert_size_per_partition = moe_load_balancer_config.num_local_slots
 
@@ -598,6 +605,20 @@ class MoE(nn.Module):
             assert len(
                 self.initial_local_expert_ids) == self.expert_size_per_partition
         else:
+            # No EPLB: each rank gets a ceil/floor slice of num_experts.
+            # Only backends that have validated their dispatch/combine paths
+            # for the ceil/floor partition may opt in; others fail fast with
+            # an actionable error pointing at EPLB as the simpler escape.
+            if (self.num_experts % self.ep_size != 0
+                    and not type(self)._supports_non_divisible_ep):
+                raise ValueError(
+                    f"{type(self).__name__} does not support non-divisible EP: "
+                    f"num_experts ({self.num_experts}) must be divisible by "
+                    f"ep_size ({self.ep_size}). Enable EPLB with num_slots "
+                    f"divisible by ep_size, or override "
+                    f"`_supports_non_divisible_ep = True` on the subclass "
+                    f"after verifying the kernel/comm path handles ceil/floor "
+                    f"partitioning.")
             # Fallback: ceil/floor distribution across ranks.
             # Ranks 0..remainder-1 each hold (base+1) experts; remaining ranks hold base.
             _size, _start, _end = _compute_ep_partition(self.num_experts,


### PR DESCRIPTION
This pull request refactors how expert parallel (EP) divisibility checks are performed in the Mixture of Experts (MoE) module. The main change is to move divisibility validation logic from the constructor to the `_init_load_balancer` method, allowing more accurate and context-aware checks depending on whether the Expert Parallel Load Balancer (EPLB) is enabled. This ensures that errors are raised only when necessary and with clearer, more actionable messages.

**Load balancer divisibility checks and error handling:**

* The divisibility check for EP is moved from the `__init__` method to `_init_load_balancer`, so the correct quantity (either `num_experts` or `num_slots`) is validated depending on whether EPLB is active. This prevents premature or incorrect validation and clarifies responsibility between wrapper and backend classes.
* When EPLB is enabled, the code now checks that `num_slots` is divisible by `ep_size` and raises a clear error if this is not the case, ensuring uniform slot partitioning across ranks.
* When EPLB is not enabled, the code checks that `num_experts` is divisible by `ep_size` unless the backend explicitly opts in to support non-divisible partitions. If not, a detailed error message is raised, guiding users to enable EPLB or override the backend opt-in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation and error messages for expert-parallel (EP) configurations in load balancing.
  * Enhanced flexibility in divisibility enforcement with clearer guidance on resolution options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->