### PR TITLE
[None][refactor] Refine Skip Softmax follow-ups

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/fmha/fallback.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/fallback.py
@@ -136,6 +136,8 @@ class FallbackFmha(Fmha):
             cross_kv=forward_args.cross_kv,
             relative_attention_bias=forward_args.relative_attention_bias,
             relative_attention_max_distance=forward_args.relative_attention_max_distance,
+            skip_softmax_threshold_scale_factor_prefill=forward_args.skip_softmax_kernel_params.threshold_scale_factor_prefill,
+            skip_softmax_threshold_scale_factor_decode=forward_args.skip_softmax_kernel_params.threshold_scale_factor_decode,
             # --- Module config (TrtllmAttention) ---
             rotary_inv_freq=attn.rotary_inv_freq,
             rotary_cos_sin=attn.rotary_cos_sin,
@@ -163,8 +165,6 @@ class FallbackFmha(Fmha):
             v_head_dim=attn.v_head_dim,
             rope_append=attn.rope_append,
             attention_chunk_size=attn.attention_chunk_size,
-            skip_softmax_threshold_scale_factor_prefill=forward_args.skip_softmax_kernel_params.threshold_scale_factor_prefill,
-            skip_softmax_threshold_scale_factor_decode=forward_args.skip_softmax_kernel_params.threshold_scale_factor_decode,
             skip_softmax_stat=attn.skip_softmax_stat,
             # --- Sparse-specific (AttentionForwardArgs.sparse_prediction) ---
             sparse_kv_indices=forward_args.sparse_prediction.sparse_kv_indices,

--- a/tensorrt_llm/_torch/attention_backend/fmha/fallback.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/fallback.py
@@ -18,10 +18,6 @@ from typing import TYPE_CHECKING, Optional
 import torch
 
 from tensorrt_llm._torch.attention_backend.interface import AttentionForwardArgs
-from tensorrt_llm._torch.attention_backend.sparse.skip_softmax import (
-    SkipSoftmaxKernelParams,
-    SkipSoftmaxParams,
-)
 from tensorrt_llm.bindings.internal import thop
 
 from .interface import Fmha
@@ -60,18 +56,11 @@ class FallbackFmha(Fmha):
         forward_args: AttentionForwardArgs,
     ) -> None:
         attn = self.attn
-        sparse_params = attn.sparse_params
-        skip_softmax_kernel_params = (
-            sparse_params.scheduler.get_kernel_params(timestep=forward_args.timestep)
-            if isinstance(sparse_params, SkipSoftmaxParams)
-            else SkipSoftmaxKernelParams()
-        )
 
         # Every kwarg sources from ``attn`` / ``metadata`` / ``forward_args``
         # (with ``forward_args.sparse_prediction`` for sparse-attn inputs),
-        # ``skip_softmax_kernel_params``, or a literal allowlisted in
-        # ``_THOP_LITERALS``. ``test_attention_op_sync.py`` enforces this
-        # statically.
+        # or a literal allowlisted in ``_THOP_LITERALS``.
+        # ``test_attention_op_sync.py`` enforces this statically.
         thop.attention(
             q=q,
             k=k,
@@ -174,8 +163,8 @@ class FallbackFmha(Fmha):
             v_head_dim=attn.v_head_dim,
             rope_append=attn.rope_append,
             attention_chunk_size=attn.attention_chunk_size,
-            skip_softmax_threshold_scale_factor_prefill=skip_softmax_kernel_params.threshold_scale_factor_prefill,
-            skip_softmax_threshold_scale_factor_decode=skip_softmax_kernel_params.threshold_scale_factor_decode,
+            skip_softmax_threshold_scale_factor_prefill=forward_args.skip_softmax_kernel_params.threshold_scale_factor_prefill,
+            skip_softmax_threshold_scale_factor_decode=forward_args.skip_softmax_kernel_params.threshold_scale_factor_decode,
             skip_softmax_stat=attn.skip_softmax_stat,
             # --- Sparse-specific (AttentionForwardArgs.sparse_prediction) ---
             sparse_kv_indices=forward_args.sparse_prediction.sparse_kv_indices,

--- a/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
+++ b/tensorrt_llm/_torch/attention_backend/fmha/flashinfer_trtllm_gen.py
@@ -608,7 +608,7 @@ class FlashInferTrtllmGenFmha(PhasedFmha):
     ) -> Tuple[bool, str]:
         is_mla_enable = attn.is_mla_enable
         sparse_params = attn.sparse_params
-        has_skip_softmax = getattr(sparse_params, "algorithm", None) == "skip_softmax"
+        has_skip_softmax = sparse_params is not None and sparse_params.algorithm == "skip_softmax"
         has_sparse_attention = sparse_params is not None and not has_skip_softmax
         if (
             fwd.sage_attn_num_elts_per_blk_q > 0

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -27,7 +27,7 @@ from ..pyexecutor.mamba_cache_manager import BaseMambaCacheManager
 from ..pyexecutor.resource_manager import KVCacheManager
 from ..pyexecutor.trace_log_utils import log_tensor_size
 from ..utils import get_model_extra_attrs
-from .sparse.params import SparseMetadataParams
+from .sparse.params import SkipSoftmaxKernelParams, SparseMetadataParams
 
 try:
     # Transformers v5
@@ -957,6 +957,8 @@ class AttentionForwardArgs:
 
     sparse_prediction: SparsePrediction = field(
         default_factory=SparsePrediction)
+    skip_softmax_kernel_params: SkipSoftmaxKernelParams = field(
+        default_factory=SkipSoftmaxKernelParams)
 
     @property
     def mask_type(self) -> int:

--- a/tensorrt_llm/_torch/attention_backend/sparse/params.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/params.py
@@ -18,8 +18,12 @@ User-facing SparseAttentionConfig live in LLM / VisualGen args and
 ModelConfig. They lower through ``to_sparse_params()`` for per-backend runtime
 state and ``to_sparse_metadata_params()`` for metadata allocation/update state.
 
-Concrete parameter classes live with their backend implementations.
+Concrete sparse algorithm params live with their backend implementations;
+shared kernel-facing carriers live here when they are part of the generic
+attention-forward contract.
 """
+
+from dataclasses import dataclass
 
 
 class SparseParams:
@@ -42,3 +46,15 @@ class SparseMetadataParams:
     metadata owns batch/runtime buffers rather than per-layer
     ``AttentionBackend`` behavior.
     """
+
+
+@dataclass
+class SkipSoftmaxKernelParams:
+    """Skip-softmax thresholds passed to attention backend kernels."""
+
+    # The kernel divides this by the context length to get the skip threshold;
+    # zero turns skip-softmax off.
+    threshold_scale_factor_prefill: float = 0.0
+    # Only autoregressive (LLM) decoding has a decode phase; diffusion and
+    # visual generation leave this at zero.
+    threshold_scale_factor_decode: float = 0.0

--- a/tensorrt_llm/_torch/attention_backend/sparse/skip_softmax.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/skip_softmax.py
@@ -17,11 +17,8 @@
 The kernel consumes a scalar ``threshold_scale_factor`` (combined with
 the sequence length at runtime) to decide which KV blocks to skip.
 This module owns the calibration side that produces that scalar from a
-semantic ``target_sparsity`` via a formula shipped with the checkpoint
-(the formula model and checkpoint-parsing helpers), plus the
-kernel-facing :class:`SkipSoftmaxKernelParams` carrier that the shared
-``TrtllmAttention`` reads. All of it is shared by the LLM and VisualGen
-pipelines.
+semantic ``target_sparsity`` via a formula shipped with the checkpoint.
+The helpers are shared by the LLM and VisualGen pipelines.
 """
 
 from dataclasses import dataclass, field
@@ -34,7 +31,7 @@ from pydantic import Field as PydanticField
 
 from tensorrt_llm.llmapi.utils import StrictBaseModel
 
-from .params import SparseParams
+from .params import SkipSoftmaxKernelParams, SparseParams
 
 _RESERVED_FORMULA_KEYS = frozenset({"formula", "target_sparsity"})
 _SKIP_SOFTMAX_ALGORITHMS = frozenset({"skip_softmax", "softmax_skip"})
@@ -270,21 +267,6 @@ def skip_softmax_formula_from_ckpt_sparse_attention_config(
         # Scalar VisualGen configs may also keep coefficients next to formula.
         return SkipSoftmaxFormula.parse_from_dict(threshold_config)
     return None
-
-
-@dataclass
-class SkipSoftmaxKernelParams:
-    """Skip-softmax thresholds passed to attention backend kernels.
-
-    Produced by ``SkipSoftmaxScheduler.get_kernel_params()``.
-    """
-
-    # The kernel divides this by the context length to get the skip threshold;
-    # zero turns skip-softmax off.
-    threshold_scale_factor_prefill: float = 0.0
-    # Only autoregressive (LLM) decoding has a decode phase; diffusion and
-    # visual generation leave this at zero.
-    threshold_scale_factor_decode: float = 0.0
 
 
 class SkipSoftmaxScheduler:

--- a/tensorrt_llm/_torch/attention_backend/sparse/utils.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/utils.py
@@ -1,10 +1,13 @@
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Type, Union
 
 if TYPE_CHECKING:
+    from tensorrt_llm._torch.attention_backend.interface import AttentionBackend
     from tensorrt_llm.llmapi.llm_args import \
         SparseAttentionConfig as LlmSparseAttentionConfig
     from tensorrt_llm.visual_gen.args import \
         SparseAttentionConfig as VisualGenSparseAttentionConfig
+
+    from .params import SparseParams
 
     SparseAttentionConfig = Union[LlmSparseAttentionConfig,
                                   VisualGenSparseAttentionConfig]
@@ -16,7 +19,7 @@ if TYPE_CHECKING:
 
 
 def get_sparse_attn_kv_cache_manager(
-        sparse_attention_config: "SparseAttentionConfig"):
+        sparse_attention_config: "SparseAttentionConfig") -> type:
     from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
 
     from .deepseek_v4 import DeepseekV4CacheManager
@@ -40,36 +43,36 @@ def get_sparse_attn_kv_cache_manager(
 
 
 def get_vanilla_sparse_attn_attention_backend(
-        sparse_attention_config: "SparseAttentionConfig"):
+        sparse_params: "SparseParams") -> Type["AttentionBackend"]:
     from .minimax_m3 import get_minimax_m3_attention_backend_cls
     from .rocket import RocketVanillaAttention
-    if sparse_attention_config.algorithm == "rocket":
+    if sparse_params.algorithm == "rocket":
         return RocketVanillaAttention
-    elif sparse_attention_config.algorithm == "minimax_m3":
+    elif sparse_params.algorithm == "minimax_m3":
         return get_minimax_m3_attention_backend_cls()
     else:
         raise ValueError(
-            f"Unsupported sparse attention algorithm in vanilla attention backend: {sparse_attention_config.algorithm}"
+            f"Unsupported sparse attention algorithm in vanilla attention backend: {sparse_params.algorithm}"
         )
 
 
 def get_trtllm_sparse_attn_attention_backend(
-        sparse_attention_config: "SparseAttentionConfig"):
+        sparse_params: "SparseParams") -> Type["AttentionBackend"]:
     from tensorrt_llm._torch.attention_backend.trtllm import TrtllmAttention
 
     from .deepseek_v4 import DeepseekV4TrtllmAttention
     from .dsa import DSATrtllmAttention
     from .minimax_m3 import get_minimax_m3_attention_backend_cls
     from .rocket import RocketTrtllmAttention
-    if sparse_attention_config.algorithm == "rocket":
+    if sparse_params.algorithm == "rocket":
         return RocketTrtllmAttention
-    elif sparse_attention_config.algorithm == "dsa":
+    elif sparse_params.algorithm == "dsa":
         return DSATrtllmAttention
-    elif sparse_attention_config.algorithm == "deepseek_v4":
+    elif sparse_params.algorithm == "deepseek_v4":
         return DeepseekV4TrtllmAttention
-    elif sparse_attention_config.algorithm == "skip_softmax":
+    elif sparse_params.algorithm == "skip_softmax":
         return TrtllmAttention
-    elif sparse_attention_config.algorithm == "minimax_m3":
+    elif sparse_params.algorithm == "minimax_m3":
         # The MiniMax-M3 sparse algorithm runs in Python through the
         # model-layer override; this backend exists so the standard
         # `create_attention(...)` dispatch in `Attention.__init__`
@@ -78,15 +81,15 @@ def get_trtllm_sparse_attn_attention_backend(
         return get_minimax_m3_attention_backend_cls()
     else:
         raise ValueError(
-            f"Unsupported sparse attention algorithm in trtllm attention backend: {sparse_attention_config.algorithm}"
+            f"Unsupported sparse attention algorithm in trtllm attention backend: {sparse_params.algorithm}"
         )
 
 
 def get_flashinfer_sparse_attn_attention_backend(
-        sparse_attention_config: "SparseAttentionConfig"):
+        sparse_params: "SparseParams") -> Type["AttentionBackend"]:
     from .minimax_m3 import get_minimax_m3_attention_backend_cls
-    if sparse_attention_config.algorithm == "minimax_m3":
+    if sparse_params.algorithm == "minimax_m3":
         return get_minimax_m3_attention_backend_cls()
     raise ValueError(
-        f"Unsupported sparse attention algorithm in flashinfer attention backend: {sparse_attention_config.algorithm}"
+        f"Unsupported sparse attention algorithm in flashinfer attention backend: {sparse_params.algorithm}"
     )

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1726,6 +1726,12 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         if forward_args.kv_scale_quant_orig is None:
             forward_args.kv_scale_quant_orig = self.kv_scale_quant_orig
 
+        sparse_params = self.sparse_params
+        if isinstance(sparse_params, SkipSoftmaxParams):
+            forward_args.skip_softmax_kernel_params = (
+                sparse_params.scheduler.get_kernel_params(
+                    timestep=forward_args.timestep))
+
         # max_context_q_len_override is only set when encoder CUDA graphs are enabled.
         if metadata.max_context_q_len_override is not None:
             assert metadata.is_cuda_graph

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1487,6 +1487,11 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         # Cross-attention uses the THOP path; the trtllm-gen backend API does
         # not carry encoder K/V tensors yet.
 
+        # Paged context enables the QKV preprocessing required for FP8 context
+        # FMHA when the KV cache uses FP8 storage.
+        if self.has_fp8_kv_cache:
+            metadata.use_paged_context_fmha = True
+
         # SM90 forces `use_paged_context_fmha` on for correctness
         # (https://nvbugs/5624818).
         if get_sm_version() == 90:

--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1487,8 +1487,9 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
         # Cross-attention uses the THOP path; the trtllm-gen backend API does
         # not carry encoder K/V tensors yet.
 
-        # Paged context enables the QKV preprocessing required for FP8 context
-        # FMHA when the KV cache uses FP8 storage.
+        # cpp/tensorrt_llm/thop/attentionOp.cpp enables mFP8ContextFMHA for an
+        # FP8 KV cache only when use_paged_context_fmha is true. Force paged
+        # context so QKV preprocessing and context FMHA use the FP8 path.
         if self.has_fp8_kv_cache:
             metadata.use_paged_context_fmha = True
 

--- a/tensorrt_llm/_torch/attention_backend/utils.py
+++ b/tensorrt_llm/_torch/attention_backend/utils.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Sequence, Type, Union
+from typing import Optional, Sequence, Type
 
 import torch
 
@@ -14,36 +14,24 @@ from .sparse.params import SparseParams
 from .trtllm import TrtllmAttention
 from .vanilla import VanillaAttention
 
-if TYPE_CHECKING:
-    from tensorrt_llm.llmapi.llm_args import \
-        SparseAttentionConfig as LlmSparseAttentionConfig
-    from tensorrt_llm.visual_gen.args import \
-        SparseAttentionConfig as VisualGenSparseAttentionConfig
-
-    SparseAttentionConfig = Union[LlmSparseAttentionConfig,
-                                  VisualGenSparseAttentionConfig]
-
 
 def get_attention_backend(
     backend_name: str,
-    sparse_attention_config: Optional["SparseAttentionConfig"] = None,
+    sparse_params: Optional[SparseParams] = None,
 ) -> Type[AttentionBackend]:
     backend_name = backend_name.upper()
     if backend_name == "VANILLA":
-        if sparse_attention_config is not None:
-            return get_vanilla_sparse_attn_attention_backend(
-                sparse_attention_config)
+        if sparse_params is not None:
+            return get_vanilla_sparse_attn_attention_backend(sparse_params)
         return VanillaAttention
     elif backend_name == "TRTLLM":
-        if sparse_attention_config is not None:
-            return get_trtllm_sparse_attn_attention_backend(
-                sparse_attention_config)
+        if sparse_params is not None:
+            return get_trtllm_sparse_attn_attention_backend(sparse_params)
         return TrtllmAttention
     elif backend_name == "FLASHINFER" and IS_FLASHINFER_AVAILABLE:
         from .flashinfer import FlashInferAttention
-        if sparse_attention_config is not None:
-            return get_flashinfer_sparse_attn_attention_backend(
-                sparse_attention_config)
+        if sparse_params is not None:
+            return get_flashinfer_sparse_attn_attention_backend(sparse_params)
         return FlashInferAttention
     elif backend_name == "FLASHINFER_STAR_ATTENTION" and IS_FLASHINFER_AVAILABLE:
         from .star_flashinfer import StarAttention
@@ -73,7 +61,6 @@ def create_attention(
     predicted_tokens_per_seq: Optional[int] = 1,
     skip_create_weights_in_init: bool = False,
     attention_chunk_size: Optional[int] = None,
-    attn_cls: Optional[Type[AttentionBackend]] = None,
     sparse_params: Optional[SparseParams] = None,
     dtype: Optional[torch.dtype] = None,
     aux_stream: Optional[torch.cuda.Stream] = None,
@@ -81,11 +68,7 @@ def create_attention(
     if attention_chunk_size is not None and backend_name.upper() != "TRTLLM":
         raise ValueError(
             f"Backend {backend_name} does not support chunked attention.")
-    if sparse_params is not None and attn_cls is None:
-        raise ValueError("attn_cls is required when sparse_params is set.")
-
-    if attn_cls is None:
-        attn_cls = get_attention_backend(backend_name)
+    attn_cls = get_attention_backend(backend_name, sparse_params=sparse_params)
 
     if is_mla_enable:
         assert attn_cls.support_mla(
@@ -114,9 +97,8 @@ def create_attention(
         attention_chunk_size=attention_chunk_size,
         dtype=dtype,
         aux_stream=aux_stream,
+        sparse_params=sparse_params,
     )
-    if sparse_params is not None:
-        kwargs["sparse_params"] = sparse_params
 
     return attn_cls(
         layer_idx,

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -26,19 +26,6 @@ from .multi_stream_utils import maybe_execute_in_parallel
 from .rotary_embedding import MRotaryEmbedding, RotaryEmbedding
 
 
-def _lower_sparse_attention_params(sparse_attn_cfg,
-                                   pretrained_config=None,
-                                   layer_idx: Optional[int] = None):
-    if getattr(sparse_attn_cfg, "algorithm", None) == "deepseek_v4":
-        from tensorrt_llm._torch.attention_backend.sparse.deepseek_v4 import \
-            make_deepseek_v4_sparse_params
-
-        return make_deepseek_v4_sparse_params(
-            sparse_attn_cfg, pretrained_config=pretrained_config)
-    return sparse_attn_cfg.to_sparse_params(pretrained_config=pretrained_config,
-                                            layer_idx=layer_idx)
-
-
 def extract_extra_attrs(layer_idx: str, attn_type: str):
     assert attn_type in ["mla", "attn"], "Invalid attention type"
     extra_attrs = get_model_extra_attrs()
@@ -609,8 +596,7 @@ class Attention(nn.Module):
         self.attn_backend = config.attn_backend
 
         sparse_attn_cfg = config.sparse_attention_config
-        sparse_params = (_lower_sparse_attention_params(
-            sparse_attn_cfg,
+        sparse_params = (sparse_attn_cfg.to_sparse_params(
             pretrained_config=config.pretrained_config,
             layer_idx=self.layer_idx) if sparse_attn_cfg is not None else None)
 

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -614,8 +614,8 @@ class Attention(nn.Module):
             pretrained_config=config.pretrained_config,
             layer_idx=self.layer_idx) if sparse_attn_cfg is not None else None)
 
-        attn_cls = get_attention_backend(
-            self.attn_backend, sparse_attention_config=sparse_attn_cfg)
+        attn_cls = get_attention_backend(self.attn_backend,
+                                         sparse_params=sparse_params)
 
         self.is_marlin_enabled: bool = is_nvfp4_marlin_enabled()
 
@@ -686,7 +686,6 @@ class Attention(nn.Module):
             skip_create_weights_in_init=config.skip_create_weights_in_init,
             q_scaling=self.q_scaling,
             attention_chunk_size=self.attention_chunk_size,
-            attn_cls=attn_cls,
             sparse_params=sparse_params,
         )
 

--- a/tensorrt_llm/_torch/modules/mla.py
+++ b/tensorrt_llm/_torch/modules/mla.py
@@ -53,7 +53,6 @@ from .attention import (
     _helix_cp_output_projection,
     _helix_post_process,
     _helix_zero_kv_mask,
-    _lower_sparse_attention_params,
     extract_extra_attrs,
 )
 from .linear import Linear, TensorParallelMode
@@ -353,8 +352,7 @@ class MLA(nn.Module):
         config = config or ModelConfig()
         sparse_attn_cfg = config.sparse_attention_config
         sparse_params = (
-            _lower_sparse_attention_params(
-                sparse_attn_cfg,
+            sparse_attn_cfg.to_sparse_params(
                 pretrained_config=config.pretrained_config,
                 layer_idx=self.layer_idx,
             )

--- a/tensorrt_llm/_torch/modules/mla.py
+++ b/tensorrt_llm/_torch/modules/mla.py
@@ -44,7 +44,7 @@ from ..attention_backend.sparse.dsa import (
     DSAtrtllmAttentionMetadata,
     transform_local_topk_and_prepare_pool_view,
 )
-from ..attention_backend.utils import create_attention, get_attention_backend
+from ..attention_backend.utils import create_attention
 from ..distributed import AllReduceParams
 from ..model_config import ModelConfig
 from ..utils import is_torch_compiling, maybe_compiled_cat, maybe_compiled_copy_
@@ -591,8 +591,8 @@ class MLA(nn.Module):
         self.has_dsv4_indexer = (
             self.is_deepseek_v4
             and layer_idx is not None
-            and config.sparse_attention_config is not None
-            and config.sparse_attention_config.compress_ratios[layer_idx] == 4
+            and sparse_params is not None
+            and sparse_params.compress_ratios[layer_idx] == 4
         )
         self.indexer_stream = None
         self.indexer_aux_stream = None
@@ -605,9 +605,6 @@ class MLA(nn.Module):
             self.indexer_aux_stream if self.indexer_aux_stream is not None else aux_stream
         )
 
-        mqa_cls = get_attention_backend(
-            config.attn_backend, sparse_attention_config=config.sparse_attention_config
-        )
         self.mqa = create_attention(
             config.attn_backend,
             self.layer_idx,
@@ -626,7 +623,6 @@ class MLA(nn.Module):
             hidden_size=self.hidden_size,
             predicted_tokens_per_seq=self.predicted_tokens_per_seq,
             skip_create_weights_in_init=config.skip_create_weights_in_init,
-            attn_cls=mqa_cls,
             sparse_params=sparse_params,
             dtype=dtype,
             aux_stream=mqa_aux_stream,
@@ -681,10 +677,7 @@ class MLA(nn.Module):
             self.is_dsa and self.short_seq_mha_threshold > 0 and not self.apply_rotary_emb
         )
         if (not self.is_dsa or _short_seq_mha) and not self.is_deepseek_v4:
-            mha_sparse_config = None if _short_seq_mha else config.sparse_attention_config
-            mha_cls = get_attention_backend(
-                config.attn_backend, sparse_attention_config=mha_sparse_config
-            )
+            mha_sparse_params = None if _short_seq_mha else sparse_params
             self.mha = create_attention(
                 config.attn_backend,
                 self.layer_idx,
@@ -702,8 +695,7 @@ class MLA(nn.Module):
                 v_head_dim=self.v_head_dim,
                 predicted_tokens_per_seq=self.predicted_tokens_per_seq,
                 skip_create_weights_in_init=config.skip_create_weights_in_init,
-                attn_cls=mha_cls,
-                sparse_params=(None if _short_seq_mha else sparse_params),
+                sparse_params=mha_sparse_params,
             )
         else:
             self.mha = None

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -103,16 +103,26 @@ def get_kv_cache_manager_cls(
       * ``TRTLLM_USE_PY_MAMBA=1``  — Mixed manager with PythonMambaCacheManager.
     """
     config = model_config.pretrained_config
-    sparse_attention_config = model_config.sparse_attention_config
-    if sparse_attention_config is not None:
-        return get_sparse_attn_kv_cache_manager(sparse_attention_config)
-    elif is_hybrid_linear(config):
+    sparse_attn_config = model_config.sparse_attention_config
+    sparse_attn_algorithm = getattr(sparse_attn_config, "algorithm", None)
+    if is_hybrid_linear(config):
         # Degenerate case: model is flagged as hybrid but the config has zero
-        # mamba layers. Fall through to the standard non-hybrid manager.
+        # mamba layers. Fall through to the standard non-hybrid routes.
         if model_config.get_num_mamba_layers() == 0:
             logger.info("Hybrid linear model has 0 mamba layers; using "
-                        "KVCacheManager without mamba caching")
+                        "KV cache manager without mamba caching")
+            if sparse_attn_config is not None:
+                return get_sparse_attn_kv_cache_manager(sparse_attn_config)
             return _non_hybrid_kv_cache_manager_cls(config, kv_cache_config)
+
+        if (sparse_attn_config is not None
+                and sparse_attn_algorithm != "skip_softmax"):
+            raise ValueError(
+                f"Sparse attention algorithm {sparse_attn_algorithm!r} is not "
+                "supported with hybrid Mamba / linear-attention models.")
+
+        # Skip Softmax only changes attention kernels. Hybrid models still
+        # need a Mamba-capable cache manager for recurrent state.
         if use_py_mamba_cache_manager():
             if kv_cache_config.enable_block_reuse:
                 raise ValueError(
@@ -153,6 +163,8 @@ def get_kv_cache_manager_cls(
                     f"Expected 'CPP' or 'MIXED'. Using default {default_cls.__name__}."
                 )
         return default_cls
+    elif sparse_attn_config is not None:
+        return get_sparse_attn_kv_cache_manager(sparse_attn_config)
     else:
         return _non_hybrid_kv_cache_manager_cls(config, kv_cache_config)
 

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -532,9 +532,11 @@ class PyTorchModelEngine(ModelEngine):
                                                          dtype=torch.int,
                                                          device='cuda')
 
-        self.attn_backend = get_attention_backend(
-            self.llm_args.attn_backend,
-            sparse_attention_config=self.sparse_attention_config)
+        sparse_params = (self.sparse_attention_config.to_sparse_params(
+            pretrained_config=self.model.model_config.pretrained_config)
+                         if self.sparse_attention_config is not None else None)
+        self.attn_backend = get_attention_backend(self.llm_args.attn_backend,
+                                                  sparse_params=sparse_params)
 
         self.get_runtime_tokens_per_gen_step = spec_config.get_runtime_tokens_per_gen_step if spec_config is not None else lambda runtime_draft_len: 1
 
@@ -2072,7 +2074,7 @@ class PyTorchModelEngine(ModelEngine):
             # Cache the no-cache metadata.
             if self.encoder_attn_metadata is not None:
                 return self.encoder_attn_metadata
-            metadata_kwargs = dict(
+            self.encoder_attn_metadata = metadata_cls(
                 max_num_requests=self.batch_size,
                 max_num_tokens=self.max_num_tokens,
                 max_num_sequences=self.batch_size * self.max_beam_width,
@@ -2085,7 +2087,6 @@ class PyTorchModelEngine(ModelEngine):
                 cache_indirection=cache_indirection,
                 num_heads_per_kv=num_heads_per_kv,
                 sparse_metadata_params=sparse_metadata_params)
-            self.encoder_attn_metadata = metadata_cls(**metadata_kwargs)
             self.encoder_attn_metadata.block_ids_per_seq = None
             self.encoder_attn_metadata.kv_block_ids_per_seq = None
             return self.encoder_attn_metadata
@@ -2096,7 +2097,7 @@ class PyTorchModelEngine(ModelEngine):
             assert self.attn_metadata.kv_cache_manager is kv_cache_manager
             return self.attn_metadata
 
-        metadata_kwargs = dict(
+        self.attn_metadata = metadata_cls(
             max_num_requests=self.batch_size,
             max_num_tokens=self.max_num_tokens,
             max_num_sequences=self.batch_size * self.max_beam_width,
@@ -2110,7 +2111,6 @@ class PyTorchModelEngine(ModelEngine):
             num_heads_per_kv=num_heads_per_kv,
             sparse_metadata_params=sparse_metadata_params,
         )
-        self.attn_metadata = metadata_cls(**metadata_kwargs)
 
         return self.attn_metadata
 

--- a/tensorrt_llm/_torch/visual_gen/models/cosmos3/pipeline_cosmos3.py
+++ b/tensorrt_llm/_torch/visual_gen/models/cosmos3/pipeline_cosmos3.py
@@ -818,8 +818,8 @@ class Cosmos3OmniMoTPipeline(BasePipeline):
 
             result = self.transformer(
                 hidden_states=latent_input,
-                timestep=timestep,
-                attention_timestep=timestep / self.scheduler.config.num_train_timesteps,
+                timestep=timestep / self.scheduler.config.num_train_timesteps,
+                raw_timestep=timestep,
                 text_ids=extra_tensors["text_ids"],
                 text_mask=extra_tensors["text_mask"],
                 video_shape=video_shape,

--- a/tensorrt_llm/_torch/visual_gen/models/cosmos3/transformer_cosmos3.py
+++ b/tensorrt_llm/_torch/visual_gen/models/cosmos3/transformer_cosmos3.py
@@ -972,7 +972,7 @@ class Cosmos3VFMTransformer(BaseDiffusionModel):
         self,
         hidden_states: torch.Tensor,
         timestep: Optional[torch.Tensor] = None,
-        attention_timestep: Optional[torch.Tensor] = None,
+        raw_timestep: Optional[torch.Tensor] = None,
         text_ids: Optional[torch.Tensor] = None,
         text_mask: Optional[torch.Tensor] = None,
         video_shape: Optional[Tuple[int, int, int]] = None,
@@ -986,9 +986,9 @@ class Cosmos3VFMTransformer(BaseDiffusionModel):
 
         Args:
             hidden_states: [B, C, T, H, W] noisy latents
-            timestep: Raw scheduler diffusion timestep, shape [B]
-            attention_timestep: Normalized diffusion timestep in [0, 1], shape [B],
-                for attention backends that use timestep-dependent behavior.
+            timestep: Normalized diffusion timestep in [0, 1], shape [B].
+            raw_timestep: Raw scheduler diffusion timestep, shape [B], used by
+                the Cosmos3 time embedding path.
             text_ids: [B, S_text] tokenized text input
             text_mask: [B, S_text] attention mask for text (1=real, 0=pad)
             video_shape: (T, H, W) in latent space
@@ -1009,6 +1009,10 @@ class Cosmos3VFMTransformer(BaseDiffusionModel):
             provided; otherwise None.  action is always None for now.
         """
         del kwargs  # Kept for diffusers API compatibility.
+        if timestep is None:
+            raise ValueError("Cosmos3VFMTransformer.forward requires normalized timestep.")
+        if raw_timestep is None:
+            raise ValueError("Cosmos3VFMTransformer.forward requires raw_timestep.")
         T, H, W = video_shape
         Hp, Wp, _, _ = self._pad_to_patch_size(H, W)
         max_real_len = text_mask.sum(dim=1).max().item()
@@ -1017,7 +1021,7 @@ class Cosmos3VFMTransformer(BaseDiffusionModel):
         hidden_gen = self.vae2llm(self.patchify(hidden_states, T, H, W))
 
         with torch.autocast("cuda", enabled=True, dtype=torch.float32):
-            time_embed = self.time_embedder((timestep * self.timestep_scale))
+            time_embed = self.time_embedder((raw_timestep * self.timestep_scale))
         time_embed = time_embed.to(hidden_states.dtype)
 
         if noisy_frame_mask is not None:
@@ -1048,7 +1052,7 @@ class Cosmos3VFMTransformer(BaseDiffusionModel):
                 text_ids,
                 text_mask,
                 freqs_und,
-                timestep=attention_timestep,
+                timestep=timestep,
             )
             self.cached_freqs_gen = freqs_gen
 
@@ -1114,7 +1118,7 @@ class Cosmos3VFMTransformer(BaseDiffusionModel):
                     k_und,
                     v_und,
                     freqs_gen,
-                    timestep=attention_timestep,
+                    timestep=timestep,
                     real_text_lens=real_text_lens,
                 )
             else:
@@ -1123,7 +1127,7 @@ class Cosmos3VFMTransformer(BaseDiffusionModel):
                     k_und,
                     v_und,
                     freqs_gen,
-                    timestep=attention_timestep,
+                    timestep=timestep,
                 )
 
         hidden_gen = self.sharder.gather(hidden_gen, dim=1, unpad_to=S_gen)

--- a/tensorrt_llm/_torch/visual_gen/models/wan/transformer_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/transformer_wan.py
@@ -670,7 +670,6 @@ class WanTransformer3DModel(BaseDiffusionModel):
         Args:
             timestep: Normalized scheduler timestep tensor in [0, 1].
         """
-        del kwargs  # Kept for diffusers API compatibility.
         original_shape = hidden_states.shape
         B, C, T, H, W = original_shape
         pt, ph, pw = self.config.patch_size

--- a/tensorrt_llm/tools/layer_wise_benchmarks/runner.py
+++ b/tensorrt_llm/tools/layer_wise_benchmarks/runner.py
@@ -605,18 +605,22 @@ class Runner:
     ):
         world_size = mpi_world_size()
         pretrained_config = self.model_config.pretrained_config
+        sparse_attention_config = self.model_config.sparse_attention_config
+        sparse_params = (
+            sparse_attention_config.to_sparse_params(pretrained_config=pretrained_config)
+            if sparse_attention_config is not None
+            else None
+        )
         AttentionCls = get_attention_backend(
-            self.model_config.attn_backend,
-            sparse_attention_config=self.model_config.sparse_attention_config,
+            self.model_config.attn_backend, sparse_params=sparse_params
         )
         metadata_cls = AttentionCls.Metadata
-        sparse_attention_config = self.model_config.sparse_attention_config
         sparse_metadata_params = (
             sparse_attention_config.to_sparse_metadata_params(pretrained_config=pretrained_config)
             if sparse_attention_config is not None
             else None
         )
-        metadata_kwargs = dict(
+        attn_metadata = metadata_cls(
             seq_lens=torch.tensor([seq_len_q] * batch_size, dtype=torch.int),
             request_ids=list(range(request_id_begin, request_id_begin + batch_size)),
             max_num_requests=kv_cache_manager.max_batch_size,
@@ -641,7 +645,6 @@ class Runner:
             mapping=self.model_config.mapping,
             sparse_metadata_params=sparse_metadata_params,
         )
-        attn_metadata = metadata_cls(**metadata_kwargs)
         attn_metadata.all_rank_num_tokens = [batch_size * seq_len_q] * world_size
         attn_metadata.prepare()
         hidden_size = pretrained_config.hidden_size

--- a/tests/unittest/_torch/attention/sparse/dsa/test_short_seq_mha.py
+++ b/tests/unittest/_torch/attention/sparse/dsa/test_short_seq_mha.py
@@ -268,6 +268,11 @@ def _build_mla(rope_config, device, threshold):
     return mla, mapping, sparse_config, model_config
 
 
+def _attention_cls_for_sparse_config(sparse_config, model_config):
+    sparse_params = sparse_config.to_sparse_params(pretrained_config=model_config.pretrained_config)
+    return get_attention_backend("TRTLLM", sparse_params=sparse_params)
+
+
 def _init_mla_weights(mla):
     """Initialize MLA weights deterministically in the loaded layout.
 
@@ -417,7 +422,7 @@ def test_forward_context_short_mha(name: str, seq_lens: List[int], threshold_off
     _init_mla_weights(mla)
 
     kv_mgr = _build_kv_cache_manager(mapping, sparse_config, model_config, seq_lens, device)
-    attn_cls = get_attention_backend("TRTLLM", sparse_attention_config=sparse_config)
+    attn_cls = _attention_cls_for_sparse_config(sparse_config, model_config)
     q, compressed_kv, k_pe, latent_cache, position_ids = _make_inputs(seq_lens, device)
     metadata = _make_metadata(attn_cls, seq_lens, kv_mgr, mapping, sparse_config)
 
@@ -457,7 +462,7 @@ def test_standard_path_when_exceeds_threshold():
     _init_mla_weights(mla)
 
     kv_mgr = _build_kv_cache_manager(mapping, sparse_config, model_config, seq_lens, device)
-    attn_cls = get_attention_backend("TRTLLM", sparse_attention_config=sparse_config)
+    attn_cls = _attention_cls_for_sparse_config(sparse_config, model_config)
     q, compressed_kv, k_pe, latent_cache, position_ids = _make_inputs(seq_lens, device)
 
     total_tokens = sum(seq_lens)
@@ -511,7 +516,7 @@ def test_agrees_with_absorption_path():
     q, compressed_kv, k_pe, latent_cache, position_ids = _make_inputs(seq_lens, device)
     hidden_states = torch.randn(total_tokens, HIDDEN_SIZE, dtype=torch.bfloat16, device=device)
     qr = torch.randn(total_tokens, Q_LORA_RANK, dtype=torch.bfloat16, device=device)
-    attn_cls = get_attention_backend("TRTLLM", sparse_attention_config=sparse_config)
+    attn_cls = _attention_cls_for_sparse_config(sparse_config, model_config)
 
     def _run(mla_module):
         kv_mgr = _build_kv_cache_manager(mapping, sparse_config, model_config, seq_lens, device)
@@ -559,7 +564,7 @@ def test_chunked_correctness(name: str, chunk_specs: List[Tuple[int, int]], chun
 
     mla, mapping, sparse_config, model_config = _build_mla(rope_config, device, threshold)
     _init_mla_weights(mla)
-    attn_cls = get_attention_backend("TRTLLM", sparse_attention_config=sparse_config)
+    attn_cls = _attention_cls_for_sparse_config(sparse_config, model_config)
 
     q, compressed_kv, k_pe, latent_cache, position_ids = _make_inputs(total_per_seq, device)
 
@@ -640,7 +645,7 @@ def test_chunked_context_rejects_when_kv_exceeds_threshold():
 
     mla, mapping, sparse_config, model_config = _build_mla(rope_config, device, threshold)
     _init_mla_weights(mla)
-    attn_cls = get_attention_backend("TRTLLM", sparse_attention_config=sparse_config)
+    attn_cls = _attention_cls_for_sparse_config(sparse_config, model_config)
 
     q, compressed_kv, k_pe, latent_cache, position_ids = _make_inputs(total_per_seq, device)
 

--- a/tests/unittest/_torch/attention/sparse/test_sparse_mla_forward.py
+++ b/tests/unittest/_torch/attention/sparse/test_sparse_mla_forward.py
@@ -2001,8 +2001,9 @@ def test_forward_sparse_mla_unified(batch_name, kv_cache_dtype: str,
         **kv_cache_manager_kwargs,
     )
 
-    AttentionCls = get_attention_backend("TRTLLM",
-                                         sparse_attention_config=sparse_config)
+    sparse_params = sparse_config.to_sparse_params(
+        pretrained_config=model_config.pretrained_config)
+    AttentionCls = get_attention_backend("TRTLLM", sparse_params=sparse_params)
 
     # Allocate and pre-populate KV cache in batch order [context...][generation...]
 

--- a/tests/unittest/_torch/attention/test_attention_op_sync.py
+++ b/tests/unittest/_torch/attention/test_attention_op_sync.py
@@ -50,7 +50,6 @@ from tensorrt_llm._torch.attention_backend.fmha.fallback import (
     FallbackFmha,
 )
 from tensorrt_llm._torch.attention_backend.interface import AttentionForwardArgs
-from tensorrt_llm._torch.attention_backend.sparse.skip_softmax import SkipSoftmaxKernelParams
 from tensorrt_llm._torch.attention_backend.trtllm import TrtllmAttention, TrtllmAttentionMetadata
 
 # Roots used as the LHS of attribute chains at the call site. Match the
@@ -59,11 +58,9 @@ _SOURCE_CLASSES = {
     "attn": TrtllmAttention,
     "metadata": TrtllmAttentionMetadata,
     "forward_args": AttentionForwardArgs,
-    "skip_softmax_kernel_params": SkipSoftmaxKernelParams,
 }
 
 _THOP_KWARG_SOURCE_ALIASES: dict[str, tuple[str, tuple[str, ...]]] = {
-    "beam_width": ("metadata", ("effective_beam_width",)),
     "context_lengths": ("metadata", ("prompt_lens_cuda_runtime",)),
     "head_size": ("attn", ("head_dim",)),
     "host_context_lengths": ("metadata", ("prompt_lens_cpu_runtime",)),
@@ -73,6 +70,20 @@ _THOP_KWARG_SOURCE_ALIASES: dict[str, tuple[str, tuple[str, ...]]] = {
     "spec_decoding_target_max_draft_tokens": (
         "metadata",
         ("max_total_draft_tokens",),
+    ),
+    "skip_softmax_threshold_scale_factor_decode": (
+        "forward_args",
+        (
+            "skip_softmax_kernel_params",
+            "threshold_scale_factor_decode",
+        ),
+    ),
+    "skip_softmax_threshold_scale_factor_prefill": (
+        "forward_args",
+        (
+            "skip_softmax_kernel_params",
+            "threshold_scale_factor_prefill",
+        ),
     ),
     "workspace_": ("metadata", ("effective_workspace",)),
 }

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_cosmos3_transformer_parallel.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_cosmos3_transformer_parallel.py
@@ -415,7 +415,8 @@ def _forward_with_audio(
     with torch.inference_mode():
         out = model(
             hidden_states=hs,
-            timestep=ts,
+            timestep=ts / _NUM_TRAIN_TIMESTEPS,
+            raw_timestep=ts,
             text_ids=text_ids,
             text_mask=text_mask,
             video_shape=video_shape,

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_cosmos3_transformer_parallel.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_cosmos3_transformer_parallel.py
@@ -108,6 +108,7 @@ _LATENT_W = 4
 _TEXT_LEN = 8
 _MAX_TEXT_LEN = 16
 _TIMESTEP = 500.0
+_NUM_TRAIN_TIMESTEPS = 1000.0
 _FPS = 24.0
 
 # Audio (sound) modality: audio tokens are appended to the gen sequence, so the
@@ -387,7 +388,8 @@ def _forward(model: Cosmos3VFMTransformer, device: torch.device, text_seed: int)
     with torch.inference_mode():
         return model(
             hidden_states=hs,
-            timestep=ts,
+            timestep=ts / _NUM_TRAIN_TIMESTEPS,
+            raw_timestep=ts,
             text_ids=text_ids,
             text_mask=text_mask,
             video_shape=video_shape,

--- a/tests/unittest/_torch/visual_gen/test_attention_trtllm_sage.py
+++ b/tests/unittest/_torch/visual_gen/test_attention_trtllm_sage.py
@@ -88,7 +88,7 @@ def _test_attention_trtllm_sage(
         sparse_attention_config.to_sparse_params() if sparse_attention_config is not None else None
     )
     attention_cls = attention_backend_utils.get_attention_backend(
-        "TRTLLM", sparse_attention_config=sparse_attention_config
+        "TRTLLM", sparse_params=sparse_params
     )
     attention = attention_cls(
         layer_idx=0,

--- a/tests/unittest/_torch/visual_gen/test_cosmos3_transformer.py
+++ b/tests/unittest/_torch/visual_gen/test_cosmos3_transformer.py
@@ -73,6 +73,7 @@ COSMOS3_NANO_PATH = _checkpoint("DIFFUSION_MODEL_PATH_COSMOS3", "Cosmos3-Nano")
 
 DEVICE = "cuda"
 DTYPE = torch.bfloat16
+_NUM_TRAIN_TIMESTEPS = 1000.0
 
 COSMOS3_FP8_QUANT_CONFIG = {
     "quant_algo": "FP8",
@@ -216,7 +217,8 @@ class TestCosmos3Unit:
         with torch.inference_mode():
             out = model(
                 hidden_states=hs,
-                timestep=ts,
+                timestep=ts / _NUM_TRAIN_TIMESTEPS,
+                raw_timestep=ts,
                 text_ids=text_ids,
                 text_mask=text_mask,
                 video_shape=video_shape,
@@ -233,14 +235,16 @@ class TestCosmos3Unit:
         with torch.inference_mode():
             out1 = model(
                 hidden_states=hs,
-                timestep=ts,
+                timestep=ts / _NUM_TRAIN_TIMESTEPS,
+                raw_timestep=ts,
                 text_ids=text_ids,
                 text_mask=text_mask,
                 video_shape=video_shape,
             )
             out2 = model(
                 hidden_states=hs,
-                timestep=ts,
+                timestep=ts / _NUM_TRAIN_TIMESTEPS,
+                raw_timestep=ts,
                 text_ids=text_ids,
                 text_mask=text_mask,
                 video_shape=video_shape,
@@ -261,7 +265,8 @@ class TestCosmos3Unit:
         with torch.inference_mode():
             out = model(
                 hidden_states=hs,
-                timestep=ts,
+                timestep=ts / _NUM_TRAIN_TIMESTEPS,
+                raw_timestep=ts,
                 text_ids=text_ids,
                 text_mask=text_mask,
                 video_shape=video_shape,
@@ -419,7 +424,8 @@ class TestCosmos3TransformerCheckpoint:
         with torch.inference_mode():
             out = transformer(
                 hidden_states=hs,
-                timestep=ts,
+                timestep=ts / _NUM_TRAIN_TIMESTEPS,
+                raw_timestep=ts,
                 text_ids=text_ids,
                 text_mask=text_mask,
                 video_shape=video_shape,
@@ -448,7 +454,8 @@ class TestCosmos3TransformerCheckpoint:
             with torch.inference_mode():
                 out = transformer(
                     hidden_states=hs,
-                    timestep=ts,
+                    timestep=ts / _NUM_TRAIN_TIMESTEPS,
+                    raw_timestep=ts,
                     text_ids=text_ids,
                     text_mask=text_mask,
                     video_shape=video_shape,

--- a/tests/unittest/_torch/visual_gen/test_cosmos3_transformer.py
+++ b/tests/unittest/_torch/visual_gen/test_cosmos3_transformer.py
@@ -340,7 +340,8 @@ class TestCosmos3Audio:
         with torch.inference_mode():
             out = model(
                 hidden_states=hs,
-                timestep=ts,
+                timestep=ts / _NUM_TRAIN_TIMESTEPS,
+                raw_timestep=ts,
                 text_ids=text_ids,
                 text_mask=text_mask,
                 video_shape=video_shape,
@@ -363,7 +364,8 @@ class TestCosmos3Audio:
         with torch.inference_mode():
             out = model(
                 hidden_states=hs,
-                timestep=ts,
+                timestep=ts / _NUM_TRAIN_TIMESTEPS,
+                raw_timestep=ts,
                 text_ids=text_ids,
                 text_mask=text_mask,
                 video_shape=video_shape,
@@ -383,7 +385,8 @@ class TestCosmos3Audio:
         with torch.inference_mode():
             out = model(
                 hidden_states=hs,
-                timestep=ts,
+                timestep=ts / _NUM_TRAIN_TIMESTEPS,
+                raw_timestep=ts,
                 text_ids=text_ids,
                 text_mask=text_mask,
                 video_shape=video_shape,

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -2907,6 +2907,17 @@ class TestDeepSeekV4SparseAttentionConfig:
         with pytest.raises(ValidationError, match="requires SM>=100"):
             DeepSeekV4SparseAttentionConfig(indexer_k_dtype="fp4")
 
+    def test_lowers_to_deepseek_v4_sparse_params(self):
+        config = DeepSeekV4SparseAttentionConfig(compress_ratios=[0, 4, 128])
+
+        sparse_params = config.to_sparse_params()
+        sparse_metadata_params = config.to_sparse_metadata_params()
+
+        assert sparse_params.algorithm == "deepseek_v4"
+        assert sparse_params.compress_ratios == [1, 4, 128]
+        assert sparse_metadata_params.compress_ratios == [1, 4, 128]
+        assert sparse_metadata_params.window_size == 128
+
     @pytest.mark.parametrize("compress_ratios", [[], [-1, 4, 128]])
     def test_invalid_compress_ratios_raise(self, compress_ratios):
         with pytest.raises(ValidationError, match="compress_ratios"):


### PR DESCRIPTION
## Summary

1. Refine sparse attention backend selection to use lowered `SparseParams` instead of user-facing sparse config objects.
2. Move Skip Softmax Attention kernel parameters into `AttentionForwardArgs`, with the lightweight kernel-param carrier kept in the shared sparse params module.
3. Simplify attention metadata construction in PyExecutor and the layer-wise benchmark runner.
4. Keep hybrid Mamba / linear-attention models on the hybrid KV cache-manager route when Skip Softmax is enabled, while preserving sparse KV cache-manager routing for non-hybrid models.
5. Split Cosmos3 raw scheduler timestep from normalized transformer-forward timestep so Cosmos follows the VisualGen attention scheduling contract without changing its time embedding input.
6. Remove the unused WAN `kwargs` deletion.
7. Update the VisualGen SAGE attention test to call `get_attention_backend()` with lowered `sparse_params`, matching the refactored backend-selection API.
8. Use paged-context FMHA for standard attention whenever the KV cache uses FP8, so context QKV follows the supported FP8 preprocessing and kernel path.

## Details

1. Sparse backend selection now happens from lowered params. `get_attention_backend()` takes `sparse_params`, and `create_attention()` derives the backend class internally instead of accepting a preselected `attn_cls`. This keeps user/API config parsing outside backend dispatch while still allowing sparse algorithms to select their backend class.
   - https://github.com/bobboli/TensorRT-LLM/blob/bli/skip-softmax-followups-placeholder/tensorrt_llm/_torch/attention_backend/utils.py
   - https://github.com/bobboli/TensorRT-LLM/blob/bli/skip-softmax-followups-placeholder/tensorrt_llm/_torch/attention_backend/sparse/utils.py
   - https://github.com/bobboli/TensorRT-LLM/blob/bli/skip-softmax-followups-placeholder/tensorrt_llm/_torch/modules/attention.py
   - https://github.com/bobboli/TensorRT-LLM/blob/bli/skip-softmax-followups-placeholder/tensorrt_llm/_torch/modules/mla.py

2. Skip Softmax kernel params are now carried through `AttentionForwardArgs`. `TrtllmAttention` resolves scheduler output into `forward_args.skip_softmax_kernel_params`, and the thop call reads from `forward_args` like the other per-forward inputs. The static thop sync test no longer needs a separate `skip_softmax_kernel_params` source class.
   - https://github.com/bobboli/TensorRT-LLM/blob/bli/skip-softmax-followups-placeholder/tensorrt_llm/_torch/attention_backend/interface.py
   - https://github.com/bobboli/TensorRT-LLM/blob/bli/skip-softmax-followups-placeholder/tensorrt_llm/_torch/attention_backend/sparse/params.py
   - https://github.com/bobboli/TensorRT-LLM/blob/bli/skip-softmax-followups-placeholder/tensorrt_llm/_torch/attention_backend/trtllm.py
   - https://github.com/bobboli/TensorRT-LLM/blob/bli/skip-softmax-followups-placeholder/tests/unittest/_torch/attention_backend/test_attention_op_sync.py

3. Metadata construction now calls the metadata class directly instead of packing `metadata_kwargs` and immediately unpacking it. The same cleanup is applied to the layer-wise benchmark runner.
   - https://github.com/bobboli/TensorRT-LLM/blob/bli/skip-softmax-followups-placeholder/tensorrt_llm/_torch/pyexecutor/model_engine.py
   - https://github.com/bobboli/TensorRT-LLM/blob/bli/skip-softmax-followups-placeholder/tensorrt_llm/tools/layer_wise_benchmarks/runner.py

4. Hybrid Mamba / linear-attention models now keep the Mamba-capable KV cache manager when the sparse attention algorithm is Skip Softmax. Skip Softmax changes attention kernel execution but does not replace the recurrent-state cache manager required by hybrid models. Other sparse attention algorithms still fail early for this combination, and non-hybrid sparse models continue to use their sparse KV cache-manager route.
   - https://github.com/bobboli/TensorRT-LLM/blob/bli/skip-softmax-followups-placeholder/tensorrt_llm/_torch/pyexecutor/_util.py

5. Cosmos3 now passes normalized `timestep` to the transformer/attention path and `raw_timestep` to the Cosmos time embedding path. This keeps scheduler-level/raw-time semantics available to Cosmos while preserving the VisualGen convention that the transformer-forward `timestep` consumed by attention scheduling is normalized. The audio transformer paths added by #14827 and their single- and multi-GPU tests follow the same contract.
   - https://github.com/bobboli/TensorRT-LLM/blob/bli/skip-softmax-followups-placeholder/tensorrt_llm/_torch/visual_gen/models/cosmos3/pipeline_cosmos3.py
   - https://github.com/bobboli/TensorRT-LLM/blob/bli/skip-softmax-followups-placeholder/tensorrt_llm/_torch/visual_gen/models/cosmos3/transformer_cosmos3.py
   - https://github.com/bobboli/TensorRT-LLM/blob/bli/skip-softmax-followups-placeholder/tests/unittest/_torch/visual_gen/test_cosmos3_transformer.py
   - https://github.com/bobboli/TensorRT-LLM/blob/bli/skip-softmax-followups-placeholder/tests/unittest/_torch/visual_gen/multi_gpu/test_cosmos3_transformer_parallel.py

6. WAN no longer explicitly deletes unused `kwargs`; the forward signature still accepts them for compatibility.
   - https://github.com/bobboli/TensorRT-LLM/blob/bli/skip-softmax-followups-placeholder/tensorrt_llm/_torch/visual_gen/models/wan/transformer_wan.py

7. The VisualGen SAGE attention test now passes lowered `sparse_params` into `get_attention_backend()`, matching the sparse backend-selection API introduced by this PR.
   - https://github.com/bobboli/TensorRT-LLM/blob/bli/skip-softmax-followups-placeholder/tests/unittest/_torch/visual_gen/test_attention_trtllm_sage.py

8. Standard TRTLLM attention now enables paged-context FMHA whenever its KV cache uses FP8. The existing C++ attention op uses this mode to select FP8 context FMHA and quantize context QKV before kernel dispatch. The rule applies independently of sparse-attention configuration; MLA keeps its separate context path.
   - https://github.com/bobboli/TensorRT-LLM/blob/bli/skip-softmax-followups-placeholder/tensorrt_llm/_torch/attention_backend/trtllm.py
