### PR TITLE
[None][fix] Fix test-to-stage mapping for extended stages

### DIFF
--- a/scripts/test_to_stage_mapping.py
+++ b/scripts/test_to_stage_mapping.py
@@ -1,4 +1,6 @@
-"""Lookup Jenkins stage names for integration tests and vice versa.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+r"""Lookup Jenkins stage names for integration tests and vice versa.
 
 This helper parses ``jenkins/L0_Test.groovy`` and the YAML files under
 ``tests/integration/test_lists/test-db`` to provide a bidirectional mapping
@@ -46,8 +48,10 @@ def _load_tests_file(path: str) -> List[str]:
     return tests
 
 
-# Regex to parse Jenkins stage configurations from Groovy files
-# Matches patterns like: "Stage-Name": ["platform", "yaml_file", split_id, split_count, gpu_count]
+# Regex to parse Jenkins stage configurations from Groovy files.
+# Matches patterns like:
+#   "Stage-Name": ["platform", "yaml_file", split_id, split_count, gpu_count]
+#   "Stage-Name": ["platform", "yaml_file", split_id, split_count, gpu_count, node_count, true]
 #
 # Pattern breakdown:
 #   "(?P<stage>[^"]+)"     - Captures stage name in quotes (group 'stage')
@@ -55,11 +59,14 @@ def _load_tests_file(path: str) -> List[str]:
 #   \[                    - Matches opening bracket
 #   "[^"]+"              - Matches platform string in quotes (ignored)
 #   ,\s*                 - Matches comma with optional whitespace
-#   "(?P<yml>[^"]+)"     - Captures yaml filename in quotes (group 'yml')
-#   (?:,\s*\d+)*         - Matches zero or more comma-separated numbers (split_id, split_count, gpu_count)
+#   "(?P<yml>[^"]+)"     - Captures YAML filename in quotes (group 'yml')
+#   (?:,\s*(\d+|true|false))* - Matches trailing positional numbers/booleans
 #   \s*\]                - Matches closing bracket with optional whitespace
-_STAGE_RE = re.compile(
-    r'"(?P<stage>[^"]+)"\s*:\s*\["[^"]+",\s*"(?P<yml>[^"]+)"(?:,\s*\d+)*\s*\]')
+_STAGE_RE = re.compile(r'"(?P<stage>[^"]+)"\s*:\s*\['
+                       r'\s*"[^"]+"\s*,'
+                       r'\s*"(?P<yml>[^"]+)"'
+                       r"(?:,\s*(?:\d+|true|false))*"
+                       r"\s*\]")
 
 
 def _extract_terms(entry):

--- a/tests/unittest/tools/test_test_to_stage_mapping.py
+++ b/tests/unittest/tools/test_test_to_stage_mapping.py
@@ -1,7 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import random
 import subprocess
 import sys
+import textwrap
 from collections import defaultdict
 
 import pytest
@@ -11,7 +15,7 @@ REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..'))
 SCRIPTS_DIR = os.path.join(REPO_ROOT, 'scripts')
 sys.path.insert(0, SCRIPTS_DIR)
 
-from test_to_stage_mapping import StageQuery
+from test_to_stage_mapping import StageQuery  # noqa: E402
 
 GROOVY = os.path.join(REPO_ROOT, 'jenkins', 'L0_Test.groovy')
 DB_DIR = os.path.join(REPO_ROOT, 'tests', 'integration', 'test_lists',
@@ -79,13 +83,46 @@ def test_data_availability(stage_query):
     print(f"Max samples configured: {MAX_SAMPLES}")
 
 
+def test_parses_stage_entries_with_trailing_boolean_args(tmp_path):
+    """B200 flex stages append trailing Groovy args after GPU count."""
+    groovy = tmp_path / 'L0_Test.groovy'
+    db_dir = tmp_path / 'test-db'
+    db_dir.mkdir()
+
+    groovy.write_text(
+        textwrap.dedent('''
+        x86SlurmTestConfigs = [
+            "DGX_B200-4_GPUs-AutoDeploy-1": ["auto:dgx-b200-flex", "l0_dgx_b200", 1, 1, 4, 1, true],
+            "DGX_B200-8_GPUs-AutoDeploy-Post-Merge-1": ["auto:dgx-b200-flex", "l0_dgx_b200", 1, 1, 8, 1, true],
+            // "Template-Stage": ["platform", "yaml_file", splitId, split_count, gpu_count]
+        ]
+        '''))
+    (db_dir / 'l0_dgx_b200.yml').write_text(
+        textwrap.dedent('''
+        l0_dgx_b200:
+        - condition:
+            terms:
+              stage: pre_merge
+              backend: autodeploy
+          tests:
+          - accuracy/test_pre.py::test_pre
+        '''))
+
+    query = StageQuery(str(groovy), str(db_dir))
+
+    assert (query.stage_to_yaml['DGX_B200-4_GPUs-AutoDeploy-1'] ==
+            'l0_dgx_b200.yml')
+    assert (query.stage_to_yaml['DGX_B200-8_GPUs-AutoDeploy-Post-Merge-1'] ==
+            'l0_dgx_b200.yml')
+    assert 'Template-Stage' not in query.stage_to_yaml
+
+
 @pytest.mark.skip(reason="https://nvbugs/5547275")
 @pytest.mark.parametrize("direction",
                          ["test_to_stage", "stage_to_test", "roundtrip"])
 def test_bidirectional_mapping_consistency(stage_query, sample_test_cases,
                                            sample_stages, direction):
     """Test mapping consistency in both directions with roundtrip validation."""
-
     if direction == "test_to_stage":
         if not sample_test_cases:
             pytest.skip("No test cases available")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced stage entry parsing to support more flexible Jenkins configuration formats with optional trailing arguments.

* **Tests**
  * Added test coverage for parsing stage entries with trailing boolean arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

test_to_stage_mapping.py did not correctly understand stages with extra arguments like:

```
  "DGX_B200-4_GPUs-AutoDeploy-1": [
      "auto:dgx-b200-flex", "l0_dgx_b200", 1, 1, 4, 1, true
  ]
```

Now it should.

## Test Coverage

Added unit tests for this case.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.

