### PR TITLE
[https://nvbugs/6301807][fix] Fix FP8 rowwise linear reference precision

### DIFF
--- a/tests/unittest/_torch/thop/parallel/test_fp8_rowwise_linear.py
+++ b/tests/unittest/_torch/thop/parallel/test_fp8_rowwise_linear.py
@@ -42,7 +42,7 @@ def test_fp8_rowwise_linear(dtype):
     with torch.inference_mode():
         x_dq = x_fp8.to(x_scale.dtype) * x_scale.view(-1, 1)
         w_dq = w_fp8.to(w_scale.dtype).t() * w_scale.view(1, -1)
-        ref_output = x_dq.to(dtype) @ w_dq.to(dtype)
+        ref_output = (x_dq.float() @ w_dq.float()).to(dtype)
 
     # compare
     torch.cuda.synchronize()


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test accuracy for FP8 rowwise linear operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

  The previous reference cast dequantized FP8 inputs to the target dtype before matmul, which introduced extra BF16/FP16 input rounding that does not match the CUTLASS FP8 rowwise GEMM path. The kernel accumulates
  FP8 values and applies row/channel scales in FP32 before casting to the output dtype.

  This updates the reference to perform the matmul in FP32 first, then cast to the target dtype.
<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

unittest/_torch/thop/parallel/test_fp8_rowwise_linear.py::test_fp8_rowwise_linear
<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
