### PR TITLE
[https://nvbugs/6179661][fix] Harden disagg cache transceiver teardown

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/cacheTransceiver.cpp
@@ -508,6 +508,11 @@ CacheTransceiver::CacheTransceiver(kv_cache_manager::BaseKVCacheManager* cacheMa
 
 CacheTransceiver::~CacheTransceiver()
 {
+    // Stop sender/receiver workers while the connection manager and transfer
+    // plugin are still alive. The workers can access both during termination.
+    mCacheSender.reset();
+    mCacheReceiver.reset();
+
     if (mWrapperLibHandle)
     {
         std::lock_guard<std::mutex> lock(mDllMutex);

--- a/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
+++ b/cpp/tensorrt_llm/batch_manager/dataTransceiver.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,6 +33,7 @@
 #include <future>
 #include <map>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 
 namespace tensorrt_llm::batch_manager
@@ -351,7 +352,7 @@ public:
         mRequestToSession.erase(it);
     }
 
-    [[nodiscard]] RequestInfo recvRequestInfo()
+    [[nodiscard]] std::optional<RequestInfo> recvRequestInfo()
     {
         auto* agentConnectionManager = dynamic_cast<executor::kv_cache::AgentConnectionManager*>(mManager);
         bool isAgent = agentConnectionManager != nullptr;
@@ -361,10 +362,10 @@ public:
         auto const* connection = isAgent
             ? agentConnectionManager->recvConnectionAndRequestInfo(info, mTerminate)
             : mManager->recvConnect(DataContext{TransceiverTag::kID_TAG, mTerminate}, &id, sizeof(id));
-        if (connection == nullptr && !mManager->isRunning())
+        if (connection == nullptr)
         {
-            TLLM_LOG_WARNING(" recvRequestInfo connection is nullptr, maybe the server is terminating");
-            return info;
+            TLLM_LOG_WARNING("recvRequestInfo connection is nullptr, maybe the server is terminating");
+            return std::nullopt;
         }
 
         if (!isAgent)
@@ -639,12 +640,12 @@ private:
                 }
                 if (!mReadyResponses.empty())
                 {
-                    auto const& requestInfo = recvRequestInfo();
-                    if (mTerminate || !mManager->isRunning())
+                    auto requestInfo = recvRequestInfo();
+                    if (!requestInfo.has_value() || mTerminate || !mManager->isRunning())
                     {
                         return;
                     }
-                    auto reqId = requestInfo.getRequestId();
+                    auto reqId = requestInfo->getRequestId();
 
                     {
                         std::scoped_lock lk(mSenderMutex);
@@ -673,6 +674,10 @@ private:
                             break;
                         }
                         it = getCurrentResponse();
+                    }
+                    if (mTerminate || it == mReadyResponses.end())
+                    {
+                        break;
                     }
                     sendResponse(it);
                 }
@@ -1288,7 +1293,9 @@ void CacheSender::sendSync(LlmRequest const& llmRequest)
 
 RequestInfo CacheSender::recvRequestInfo()
 {
-    return mImpl->recvRequestInfo();
+    auto requestInfo = mImpl->recvRequestInfo();
+    TLLM_CHECK(requestInfo.has_value());
+    return *requestInfo;
 }
 
 bool CacheSender::cancelRequest(LlmRequest const& llmRequest)


### PR DESCRIPTION
## Background

PR #15363 by @nv-xtf / Tingfeng Xian identified and prototyped fixes for several disaggregated serving failure modes while debugging generation-side KV transfer timeout deadlocks. This PR extracts only the shutdown/teardown lifetime-hardening pieces from that work into a standalone PR so they can be reviewed independently from bounded polling, timeout cancellation, and request-cancellation semantics.

## Summary

This change hardens cache transceiver teardown by:

- destroying `CacheSender` and `CacheReceiver` while the connection manager and transfer plugin are still alive,
- treating a null request-info connection as an explicit shutdown/nullopt path instead of returning a default `RequestInfo`,
- avoiding `sendResponse()` after the response thread wakes for termination without a valid response iterator.

The change is intentionally ungated because this is shutdown/lifetime correctness, not a new cancellation feature.

## Dependency graph

Arrows point from prerequisite to dependent. PR numbers in graph nodes are clickable.

This PR is based directly on `main`; it does not depend on #15181 or #15356. It is shown with a dashed edge into #15238 because it is preferred hardening before the gated cancellation PR, not because it is part of the bounded-polling stack.

```mermaid
graph TD
    PR15139["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15139'>#15139</a>: transfer state consensus (merged)"]
    PR15422["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15422'>#15422</a>: teardown hardening (this PR, open for review)"]
    PR15181["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15181'>#15181</a>: bounded C++ transfer status polling (inflight)"]
    PR15356["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15356'>#15356</a>: bounded V2 context transfer polling (inflight)"]
    PR15238["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15238'>#15238</a>: in-flight cancellation + buffer poison (draft)"]
    WORK_BLOCKALL["blockAll / wait-all cancellation (planned)"]
    WORK_BUFFER["multi-slot buffers + unpoison recovery (planned)"]

    PR15139 -->|satisfied| PR15238
    PR15181 -->|blocking| PR15356
    PR15181 -->|blocking| PR15238
    PR15356 -->|blocking| PR15238
    PR15422 -.->|preferred hardening| PR15238
    PR15238 -.->|planned| WORK_BLOCKALL
    PR15238 -.->|planned| WORK_BUFFER

    classDef merged fill:#dcfce7,stroke:#16a34a,color:#14532d;
    classDef inflight fill:#dbeafe,stroke:#2563eb,color:#1e3a8a;
    classDef draft fill:#ffedd5,stroke:#f97316,color:#7c2d12;
    classDef current fill:#ede9fe,stroke:#7c3aed,color:#3b0764,stroke-width:3px;
    classDef downstream fill:#f3f4f6,stroke:#6b7280,color:#374151,stroke-dasharray:5 5;
    linkStyle 0 stroke:#16a34a,stroke-width:2px;
    linkStyle 1,2,3 stroke:#ea580c,stroke-width:3px;
    linkStyle 4 stroke:#64748b,stroke-width:2px,stroke-dasharray:3 3;
    linkStyle 5,6 stroke:#6b7280,stroke-width:2px,stroke-dasharray:5 5;

    class PR15139 merged;
    class PR15181,PR15356 inflight;
    class PR15422 current;
    class PR15238 draft;
    class WORK_BLOCKALL,WORK_BUFFER downstream;
```

## Scope and relationship to related PRs

- Related to #15363 for the teardown failure modes and motivation.
- Independent of #15356; this PR does not change V2 bounded polling behavior.
- Independent of #15238; cancellation semantics, transport release, deferred cleanup, and rank-consistent cancellation remain in the gated cancellation PR.
- Preferred to merge before #15238 if possible, so #15238 can rebase on main and inherit the teardown hardening.

## Validation

- `git diff --check`
- `git commit -s` pre-commit hooks passed, including `clang-format`, `codespell`, duplicate waive checks, and test-list validation. The first hook attempt used system Python 3.9 and failed on Python 3.10 union syntax in `scripts/check_test_list.py`; rerunning with bundled Python 3.12 on `PATH` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache management stability by ensuring proper cleanup of worker threads during shutdown, preventing potential resource issues and system instability.
  * Enhanced data reception reliability by implementing graceful error handling for connection failures and edge cases, reducing runtime errors and improving overall system robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
