### PR TITLE
[https://nvbugs/6129870][fix] Support ModelOpt/vLLM EAGLE3 draft arch names for DeepSeek-V3/Kimi-K2

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_speculative.py
+++ b/tensorrt_llm/_torch/models/modeling_speculative.py
@@ -466,6 +466,11 @@ class Eagle3DraftModel(DecoderModel):
 # We use Llama3 as the base architecture for EAGLE3 draft layers
 @register_auto_model("EAGLE3LlamaForCausalLM")
 @register_auto_model("Eagle3DeepSeekV3ForCausalLM")
+# Aliases matching the architecture names emitted by ModelOpt and accepted by
+# vLLM / SGLang for DeepSeek-V3 / Kimi-K2 EAGLE3 draft checkpoints, so the same
+# exported checkpoint deploys across frameworks without editing config.json.
+@register_auto_model("Eagle3DeepseekV2ForCausalLM")
+@register_auto_model("Eagle3DeepseekV3ForCausalLM")
 class Eagle3ForCausalLM(DecoderModelForCausalLM[Eagle3DraftModel,
                                                 PretrainedConfig]):
 


### PR DESCRIPTION
@coderabbitai summary

## Description

Deploying ModelOpt-exported DeepSeek-V3 / Kimi-K2 EAGLE3 draft checkpoints
(e.g. `nvidia/Kimi-K2-Thinking-Eagle3`) on the PyTorch backend fails at init:

```
ValueError: Unknown architecture for AutoModelForCausalLM: Eagle3DeepseekV2ForCausalLM
```

These checkpoints declare `architectures: ["Eagle3DeepseekV2ForCausalLM"]`, the
name shared by ModelOpt's exporter, vLLM, and SGLang. TRT-LLM only registers
`Eagle3DeepSeekV3ForCausalLM` (different casing + version), so its
case-sensitive lookup misses:

| Framework | Registered EAGLE3 DeepSeek/Kimi arch name | Accepts `Eagle3DeepseekV2ForCausalLM`? |
|---|---|---|
| vLLM   | `Eagle3DeepseekV2ForCausalLM`, `Eagle3DeepseekV3ForCausalLM` | ✅ |
| SGLang | `Eagle3DeepseekV2ForCausalLM` | ✅ |
| TRT-LLM (before) | `Eagle3DeepSeekV3ForCausalLM` | ❌ |

**Fix:** register `Eagle3DeepseekV2ForCausalLM` and `Eagle3DeepseekV3ForCausalLM`
as aliases of the existing `Eagle3ForCausalLM` class. It already auto-selects MLA
for DeepSeek-V3-style configs via `kv_lora_rank`, so the aliased checkpoints route
to the correct draft path. The change is purely additive (existing registrations
untouched), so the same exported checkpoint now deploys across TRT-LLM, vLLM, and
SGLang without editing `config.json`.

## Test Coverage

Registry-only change (added `@register_auto_model` decorators) mapping the new
names onto the already-tested `Eagle3ForCausalLM` code path.

**Verified end-to-end** with this patch applied on top of the `1.3.0rc17`
release container:

- **Env:** 1× GB200 NVL72 node (4 GPUs), container
  `nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc17`, PyTorch backend.
- **Models:** base `nvidia/Kimi-K2.5-NVFP4` + EAGLE3 draft
  `Kimi-K2.5-Eagle3` whose `config.json` declares
  `architectures: ["Eagle3DeepseekV2ForCausalLM"]` (the exact failing name).
- **Config:** `tensor_parallel_size=4`, `enable_attention_dp=True`,
  `Eagle3DecodingConfig(max_draft_len=3, eagle3_one_model=True)`,
  launched via `trtllm-llmapi-launch`.

Registry now resolves the aliased names, the architecture error is gone, and the
model loads and generates:

```
=== eagle registrations AFTER patch ===
455:@register_auto_model("EAGLE3LlamaForCausalLM")
456:@register_auto_model("Eagle3DeepSeekV3ForCausalLM")
457:@register_auto_model("Eagle3DeepseekV2ForCausalLM")
458:@register_auto_model("Eagle3DeepseekV3ForCausalLM")
REGCHECK V2: True
REGCHECK V3: True
...
Model init total -- 381.27s
LLM_INIT_OK
OUT: 'Hello, world!' -> " I'm back from my holiday hiatus, and I hope you all had a wonderful holiday season..."
OUT: 'The capital of France is' -> " Paris. Paris is located in the north-central part of the country along the Seine River..."
DEPLOY_OK
Rank0 Task exit code: 0
```

Before the fix, the same setup fails at executor init with
`Unknown architecture for AutoModelForCausalLM: Eagle3DeepseekV2ForCausalLM`.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
