### PR TITLE
[TRTLLM-13250][feat] Wave 5: Enable MX post-transform Llama receiver

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """MX (ModelExpress) checkpoint loader.
 
 Thin adapter on top of the upstream `modelexpress` Python client
@@ -28,10 +27,13 @@ HuggingFace checkpoint loading (disk -> CPU -> GPU) by way of its
 `HfCheckpointLoader` base class.
 """
 
+import inspect
+import json
 import os
 import threading
 import traceback
 from contextlib import contextmanager
+from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Optional, Type, Union
 
@@ -60,6 +62,17 @@ from tensorrt_llm.mapping import Mapping
 # Tracked as MX-4 in §15 (non-blocking source-query API upstream).
 _MX_SOURCE_QUERY_TIMEOUT_DEFAULT_S = "30"
 _MX_PUBLISH_ENV_LOCK = threading.Lock()
+_MX_SOURCE_IDENTITY_METADATA_KEY = "trtllm_source_identity"
+_MX_WEIGHT_LAYOUT_METADATA_KEY = "trtllm_weight_layout"
+_MX_TRANSFORM_PROTOCOL_VERSION_METADATA_KEY = "trtllm_transform_protocol_version"
+_MX_WEIGHT_LAYOUT_POST_TRANSFORM = "post_transform"
+_MX_STAGED_TRANSFORM_PROTOCOL_VERSION = 1
+
+
+class _MxWeightLayoutStatus(Enum):
+    PRE_TRANSFORM = "pre_transform"
+    POST_TRANSFORM_SUPPORTED = "post_transform_supported"
+    UNSUPPORTED = "unsupported"
 
 
 @contextmanager
@@ -86,9 +99,8 @@ class MXCheckpointLoader(HfCheckpointLoader):
     When an MX server is reachable AND the upstream `modelexpress`
     library is installed, weights are transferred directly from a
     source instance via NIXL/RDMA, bypassing disk I/O. The source
-    publishes its weights *before* `post_load_weights()` runs so
-    targets receive raw loaded state and can run their own
-    post-load transforms.
+    publishes its weights after `post_load_weights()` runs, together with
+    metadata that lets compatible targets skip one-shot post-load transforms.
 
     When the MX server or library is unavailable, this loader
     transparently falls back to standard HuggingFace checkpoint
@@ -188,10 +200,8 @@ class MXCheckpointLoader(HfCheckpointLoader):
     def is_post_transform_weights_preloaded(self) -> bool:
         """Whether the last successful MX preload delivered transformed bytes.
 
-        MX does not yet expose whether the selected source publishes raw
-        checkpoint bytes or transformed runtime bytes. Keep this signal false
-        until the published layout is explicit. Source identity must also match
-        before callers skip transforms.
+        The source identity bit is included here so callers have one
+        conservative signal: no identity match, no transform skip.
         """
         return (
             self._p2p_succeeded
@@ -221,7 +231,7 @@ class MXCheckpointLoader(HfCheckpointLoader):
         model = kwargs.pop("model", None)
         # Popped here so it never leaks into the disk-fallback signature.
         self._local_source_identity = kwargs.pop("source_identity", None)
-        allow_post_transform_weights = kwargs.pop("allow_post_transform_weights", True)
+        allow_post_transform_weights = kwargs.pop("allow_post_transform_weights", False)
         self._p2p_succeeded = False
         self._post_transform_weights_preloaded = False
         self._source_identity_compatible_for_last_load = False
@@ -253,10 +263,13 @@ class MXCheckpointLoader(HfCheckpointLoader):
             )
             return self._fallback_to_disk(checkpoint_dir, mapping, **kwargs)
 
+        source_metadata = self._fetch_source_metadata(
+            checkpoint_dir, MxClient, _build_trtllm_identity
+        )
         # Pre-transfer compatibility gate: on mismatch, skip the transfer
         # before any RDMA work starts and fall back to disk.
-        self._source_identity_compatible_for_last_load = self._source_identity_compatible(
-            checkpoint_dir, MxClient, _build_trtllm_identity
+        self._source_identity_compatible_for_last_load = self._source_metadata_identity_compatible(
+            source_metadata
         )
         if not self._source_identity_compatible_for_last_load:
             return self._fallback_to_disk(
@@ -266,8 +279,18 @@ class MXCheckpointLoader(HfCheckpointLoader):
                 **kwargs,
             )
 
-        self._post_transform_weights_preloaded = self._source_metadata_is_post_transform(
-            checkpoint_dir, MxClient, _build_trtllm_identity
+        layout_status = _metadata_weight_layout_status(source_metadata)
+        if layout_status is _MxWeightLayoutStatus.UNSUPPORTED:
+            self._source_identity_compatible_for_last_load = False
+            return self._fallback_to_disk(
+                checkpoint_dir,
+                mapping,
+                reason=_metadata_unsupported_layout_reason(source_metadata),
+                **kwargs,
+            )
+
+        self._post_transform_weights_preloaded = (
+            layout_status is _MxWeightLayoutStatus.POST_TRANSFORM_SUPPORTED
         )
         if self._post_transform_weights_preloaded and not allow_post_transform_weights:
             self._post_transform_weights_preloaded = False
@@ -275,7 +298,10 @@ class MXCheckpointLoader(HfCheckpointLoader):
             return self._fallback_to_disk(
                 checkpoint_dir,
                 mapping,
-                reason="post-transform MX source is not allowed for this load",
+                reason=(
+                    "source publishes post-transform weights but this model is "
+                    "not allow-listed for staged MX receiver loading"
+                ),
                 **kwargs,
             )
 
@@ -297,7 +323,8 @@ class MXCheckpointLoader(HfCheckpointLoader):
                 # disk loading remains the correctness path. Preserve the full
                 # traceback so unexpected upstream failures are diagnosable.
                 logger.warning(
-                    f"MX P2P transfer failed; falling back to disk loading.\n{traceback.format_exc()}"
+                    "MX P2P transfer failed; falling back to disk loading.\n"
+                    f"{traceback.format_exc()}"
                 )
                 return self._fallback_to_disk(checkpoint_dir, mapping, **kwargs)
 
@@ -361,7 +388,8 @@ class MXCheckpointLoader(HfCheckpointLoader):
             return None
 
         logger.warning(
-            f"No MX source is currently registered for {self._resolve_publish_name(checkpoint_dir)}; "
+            "No MX source is currently registered for "
+            f"{self._resolve_publish_name(checkpoint_dir)}; "
             f"using MX_SOURCE_QUERY_TIMEOUT={_MX_SOURCE_QUERY_TIMEOUT_DEFAULT_S} "
             "for fast disk fallback. Set mx_config.server_query_timeout_s or "
             "MX_SOURCE_QUERY_TIMEOUT for long-running donor-load deployments."
@@ -411,8 +439,17 @@ class MXCheckpointLoader(HfCheckpointLoader):
             and compatible. `False` when either identity is missing or the
             identities mismatch, so the caller falls back to disk loading.
         """
-        local_identity = self._local_source_identity
         source_identity = self._fetch_source_identity(checkpoint_dir, MxClient, build_identity)
+        return self._source_identity_compatible_with_source(source_identity)
+
+    def _source_metadata_identity_compatible(self, metadata: Optional[dict[str, Any]]) -> bool:
+        source_identity = _source_identity_from_metadata(metadata)
+        return self._source_identity_compatible_with_source(source_identity)
+
+    def _source_identity_compatible_with_source(
+        self, source_identity: Optional[SourceIdentity]
+    ) -> bool:
+        local_identity = self._local_source_identity
         decision = check_weight_sharing_compatibility(
             local_identity,
             source_identity,
@@ -434,21 +471,64 @@ class MXCheckpointLoader(HfCheckpointLoader):
             The publisher's identity, or `None` when it cannot be fetched
             yet (the compatibility gate then rejects P2P and falls back).
         """
-        # TODO(SOURCE-IDENTITY/MX-2): read the publisher's identity from the MX
-        # metadata channel (get_metadata / WorkerMetadata) once upstream
-        # exposes a field for it. This is the single seam the gate depends on.
-        return None
+        metadata = self._fetch_source_metadata(checkpoint_dir, MxClient, build_identity)
+        return _source_identity_from_metadata(metadata)
 
-    def _source_metadata_is_post_transform(
-        self, _checkpoint_dir: str, _mx_client_type: Type[Any], _build_identity: Callable[..., Any]
-    ) -> bool:
-        """Whether the selected MX source publishes post-transform bytes.
+    def _fetch_source_metadata(
+        self, checkpoint_dir: str, MxClient: Type[Any], build_identity: Callable[..., Any]
+    ) -> Optional[dict[str, Any]]:
+        """Fetch TRT-LLM metadata for the selected MX source, if available."""
+        client = None
+        try:
+            identity = build_identity(model_name=self._resolve_publish_name(checkpoint_dir))
+            client = MxClient(server_url=self._mx_server_url)
+            for method_name in ("get_source_metadata", "get_metadata", "get_worker_metadata"):
+                method = getattr(client, method_name, None)
+                if not callable(method):
+                    continue
+                try:
+                    metadata = method(identity=identity)
+                except TypeError:
+                    metadata = method(identity)
+                metadata_dict = _metadata_to_dict(metadata)
+                if _metadata_has_trtllm_key(metadata_dict):
+                    return metadata_dict
 
-        ModelExpress metadata does not yet expose whether a source publishes
-        raw checkpoint bytes or transformed runtime bytes. Wire this to
-        explicit source metadata before enabling transformed publication.
-        """
-        return False
+            list_resp = client.list_sources(identity=identity)
+            instances = _source_instances_from_list_response(list_resp)
+            metadata_candidates = []
+            for instance in instances:
+                metadata_dict = _source_instance_metadata(instance)
+                if metadata_dict:
+                    metadata_candidates.append(metadata_dict)
+            return self._select_source_metadata(metadata_candidates)
+        except (AttributeError, RuntimeError, TimeoutError, TypeError, ValueError, grpc.RpcError):
+            logger.warning(
+                f"MX source metadata fetch failed; falling back to disk loading.\n"
+                f"{traceback.format_exc()}"
+            )
+            return None
+        finally:
+            if client is not None and hasattr(client, "close"):
+                client.close()
+
+    def _select_source_metadata(
+        self, metadata_candidates: list[dict[str, Any]]
+    ) -> Optional[dict[str, Any]]:
+        """Select metadata that matches the receiver identity when possible."""
+        if not metadata_candidates:
+            return None
+        for metadata in metadata_candidates:
+            if self._source_metadata_matches_local_identity(metadata):
+                return metadata
+        return metadata_candidates[0]
+
+    def _source_metadata_matches_local_identity(self, metadata: dict[str, Any]) -> bool:
+        local_identity = getattr(self, "_local_source_identity", None)
+        source_identity = _source_identity_from_metadata(metadata)
+        if local_identity is None or source_identity is None:
+            return False
+        return local_identity.matches(source_identity).matched
 
     def _resolve_publish_name(self, checkpoint_dir: Optional[str]) -> str:
         return _resolve_mx_model_name(self._model_name, checkpoint_dir)
@@ -467,12 +547,14 @@ class MXCheckpointLoader(HfCheckpointLoader):
         self,
         model,
         checkpoint_dir: Optional[str] = None,
+        *,
+        source_identity: Optional[SourceIdentity] = None,
     ) -> None:
         """Publish this instance's weights so other ranks can pull via P2P.
 
-        Called by the integration in `model_loader.py` *before*
-        `post_load_weights()` so targets receive raw loaded state and
-        can apply their own post-load transforms.
+        Called by the integration in `model_loader.py` after
+        `post_load_weights()` so targets receive the post-transform runtime
+        layout and, when allow-listed, can skip their own one-shot transforms.
 
         Delegates to the upstream
         `modelexpress.trtllm_live_transfer.publish_model_params`
@@ -485,9 +567,17 @@ class MXCheckpointLoader(HfCheckpointLoader):
                 fallback for resolving the `MODEL_NAME` identity when
                 neither `model_name` was passed to the constructor nor
                 `MODEL_NAME` is set in the environment.
+            source_identity: Source identity built before weight load from
+                the same lifecycle point on producer and receiver.
         """
 
         if self._mx_server_url is None:
+            return
+        if source_identity is None:
+            logger.warning(
+                "Skipping MX post-transform publish because SourceIdentity is "
+                "unavailable; receivers cannot safely verify transformed weights."
+            )
             return
 
         try:
@@ -508,6 +598,15 @@ class MXCheckpointLoader(HfCheckpointLoader):
         # (the env-var dance goes away when upstream exports a public identity
         # builder / publish API).
         resolved_name = self._resolve_publish_name(checkpoint_dir)
+        metadata = _build_mx_source_metadata(source_identity)
+        metadata_kwargs = _publish_metadata_kwargs(publish_model_params, metadata)
+        if metadata_kwargs is None:
+            logger.warning(
+                "Skipping MX post-transform publish because "
+                "publish_model_params does not accept metadata; receivers "
+                "cannot safely verify transformed weights."
+            )
+            return
 
         env_overrides = {
             "MODEL_EXPRESS_URL": self._mx_server_url,
@@ -527,9 +626,9 @@ class MXCheckpointLoader(HfCheckpointLoader):
                 os.environ[key] = value
 
             try:
-                publish_model_params(model)
+                publish_model_params(model, **metadata_kwargs)
                 logger.info(
-                    "Published weights to MX server at %s as model=%r",
+                    "Published post-transform weights to MX server at %s as model=%r",
                     self._mx_server_url,
                     resolved_name,
                 )
@@ -548,7 +647,12 @@ class MXCheckpointLoader(HfCheckpointLoader):
                         os.environ[key] = prior_value
 
     def post_load_publish(
-        self, model, *, checkpoint_dir: str, weights_preloaded: bool = False
+        self,
+        model,
+        *,
+        checkpoint_dir: str,
+        weights_preloaded: bool = False,
+        source_identity: Optional[SourceIdentity] = None,
     ) -> None:
         """Publish locally loaded weights as an MX source when appropriate.
 
@@ -560,13 +664,17 @@ class MXCheckpointLoader(HfCheckpointLoader):
             weights_preloaded: Whether this worker already received weights
                 through MX P2P. When true, this worker is an MX receiver and
                 should not republish the same weights as a source.
+            source_identity: Producer identity serialized into MX metadata so
+                receivers can verify layout compatibility before transfer.
 
         Returns:
             None.
         """
         if weights_preloaded:
             return
-        self.publish_as_source(model, checkpoint_dir=checkpoint_dir)
+        self.publish_as_source(
+            model, checkpoint_dir=checkpoint_dir, source_identity=source_identity
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -624,3 +732,163 @@ def _normalize_model_identity(s: str) -> str:
             if ancestor.name.startswith("models--"):
                 return ancestor.name[len("models--") :].replace("--", "/")
     return name or "unknown"
+
+
+def _build_mx_source_metadata(source_identity: Optional[SourceIdentity]) -> dict[str, str]:
+    metadata = {
+        _MX_WEIGHT_LAYOUT_METADATA_KEY: _MX_WEIGHT_LAYOUT_POST_TRANSFORM,
+        _MX_TRANSFORM_PROTOCOL_VERSION_METADATA_KEY: str(_MX_STAGED_TRANSFORM_PROTOCOL_VERSION),
+    }
+    if source_identity is not None:
+        metadata[_MX_SOURCE_IDENTITY_METADATA_KEY] = json.dumps(
+            source_identity.to_dict(), sort_keys=True
+        )
+    return metadata
+
+
+def _publish_metadata_kwargs(
+    publish_model_params: Callable[..., Any],
+    metadata: dict[str, str],
+) -> Optional[dict[str, dict[str, str]]]:
+    try:
+        signature = inspect.signature(publish_model_params)
+    except (TypeError, ValueError):
+        return None
+
+    parameters = signature.parameters
+    if "metadata" in parameters:
+        return {"metadata": metadata}
+    if "worker_metadata" in parameters:
+        return {"worker_metadata": metadata}
+    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values()):
+        return {"metadata": metadata}
+    return None
+
+
+def _metadata_to_dict(metadata: Any) -> dict[str, Any]:
+    if metadata is None or isinstance(metadata, (str, bytes)):
+        return {}
+    if isinstance(metadata, dict):
+        return dict(metadata)
+
+    items = getattr(metadata, "items", None)
+    if callable(items):
+        try:
+            return dict(items())
+        except (TypeError, ValueError):
+            pass
+
+    if type(metadata).__module__.startswith("unittest.mock"):
+        return {}
+
+    attrs = getattr(metadata, "__dict__", None)
+    if isinstance(attrs, dict):
+        return dict(attrs)
+    return {}
+
+
+def _metadata_get(metadata: Optional[dict[str, Any]], key: str) -> Any:
+    if not metadata:
+        return None
+    return metadata.get(key)
+
+
+def _metadata_has_trtllm_key(metadata: dict[str, Any]) -> bool:
+    return any(
+        key in metadata
+        for key in (
+            _MX_SOURCE_IDENTITY_METADATA_KEY,
+            _MX_WEIGHT_LAYOUT_METADATA_KEY,
+            _MX_TRANSFORM_PROTOCOL_VERSION_METADATA_KEY,
+        )
+    )
+
+
+def _source_identity_from_metadata(metadata: Optional[dict[str, Any]]) -> Optional[SourceIdentity]:
+    value = _metadata_get(metadata, _MX_SOURCE_IDENTITY_METADATA_KEY)
+    if value is None:
+        return None
+
+    try:
+        if isinstance(value, SourceIdentity):
+            return value
+        if isinstance(value, bytes):
+            value = value.decode("utf-8")
+        if isinstance(value, str):
+            value = json.loads(value)
+        to_dict = getattr(value, "to_dict", None)
+        if callable(to_dict):
+            value = to_dict()
+        if not isinstance(value, dict):
+            raise TypeError(f"expected dict-compatible SourceIdentity, got {type(value)!r}")
+        return SourceIdentity.from_dict(value)
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError):
+        logger.warning(
+            "MX source metadata contains an invalid SourceIdentity; falling back to disk loading."
+        )
+        return None
+
+
+def _metadata_is_post_transform(metadata: Optional[dict[str, Any]]) -> bool:
+    return (
+        _metadata_weight_layout_status(metadata) is _MxWeightLayoutStatus.POST_TRANSFORM_SUPPORTED
+    )
+
+
+def _metadata_weight_layout_status(metadata: Optional[dict[str, Any]]) -> _MxWeightLayoutStatus:
+    layout = _metadata_get(metadata, _MX_WEIGHT_LAYOUT_METADATA_KEY)
+    if layout is None:
+        return _MxWeightLayoutStatus.PRE_TRANSFORM
+
+    normalized_layout = str(layout).lower()
+    if normalized_layout == "pre_transform":
+        return _MxWeightLayoutStatus.PRE_TRANSFORM
+    if normalized_layout != _MX_WEIGHT_LAYOUT_POST_TRANSFORM:
+        return _MxWeightLayoutStatus.UNSUPPORTED
+
+    version = _metadata_get(metadata, _MX_TRANSFORM_PROTOCOL_VERSION_METADATA_KEY)
+    try:
+        protocol_version = int(version)
+    except (TypeError, ValueError):
+        return _MxWeightLayoutStatus.UNSUPPORTED
+    if protocol_version != _MX_STAGED_TRANSFORM_PROTOCOL_VERSION:
+        return _MxWeightLayoutStatus.UNSUPPORTED
+    return _MxWeightLayoutStatus.POST_TRANSFORM_SUPPORTED
+
+
+def _metadata_unsupported_layout_reason(metadata: Optional[dict[str, Any]]) -> str:
+    layout = _metadata_get(metadata, _MX_WEIGHT_LAYOUT_METADATA_KEY)
+    if str(layout).lower() == _MX_WEIGHT_LAYOUT_POST_TRANSFORM:
+        version = _metadata_get(metadata, _MX_TRANSFORM_PROTOCOL_VERSION_METADATA_KEY)
+        return (
+            "source publishes post-transform weights with unsupported "
+            f"transform protocol {version!r}"
+        )
+    return f"source publishes unsupported MX weight layout {layout!r}"
+
+
+def _source_instances_from_list_response(list_resp: Any) -> list[Any]:
+    if isinstance(list_resp, dict):
+        instances = list_resp.get("instances", [])
+    else:
+        instances = getattr(list_resp, "instances", [])
+    return list(instances or [])
+
+
+def _source_instance_metadata(instance: Any) -> dict[str, Any]:
+    for candidate in (
+        instance,
+        _metadata_attr(instance, "metadata"),
+        _metadata_attr(instance, "worker_metadata"),
+        _metadata_attr(instance, "source_metadata"),
+    ):
+        metadata = _metadata_to_dict(candidate)
+        if _metadata_has_trtllm_key(metadata):
+            return metadata
+    return {}
+
+
+def _metadata_attr(instance: Any, name: str) -> Any:
+    if isinstance(instance, dict):
+        return instance.get(name)
+    return getattr(instance, name, None)

--- a/tensorrt_llm/_torch/pyexecutor/model_loader.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_loader.py
@@ -15,7 +15,8 @@ from tensorrt_llm._torch.models.checkpoints.base_checkpoint_loader import (
 from tensorrt_llm._torch.weight_sharing import (
     IdentityCheckPolicy, SourceIdentity, check_weight_sharing_compatibility)
 from tensorrt_llm._utils import str_dtype_to_torch
-from tensorrt_llm.llmapi.llm_args import (ExecutorMemoryType,
+from tensorrt_llm.llmapi.llm_args import (DecodingBaseConfig,
+                                          ExecutorMemoryType,
                                           ModelExpressConfig,
                                           SparseAttentionConfig, TorchLlmArgs)
 from tensorrt_llm.llmapi.llm_utils import apply_model_defaults_to_llm_args
@@ -27,7 +28,7 @@ from tensorrt_llm.quantization.utils.fp4_utils import float4_e2m1x2
 
 from ...llmapi.llm_args import LoadFormat
 from ..model_config import ModelConfig
-from ..models import AutoModelForCausalLM
+from ..models import AutoModelForCausalLM, LlamaForCausalLM
 from ..models.checkpoints.base_checkpoint_loader import BaseCheckpointLoader
 from ..models.modeling_utils import (DecoderModelForCausalLM, MetaInitMode,
                                      timing)
@@ -267,12 +268,14 @@ class ModelLoader:
     This class isolates model loading logic from the main execution engine.
     """
     _MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION = 1
-    _MX_STAGED_RECEIVER_ALLOWLIST = frozenset()
+    _MX_STAGED_RECEIVER_ALLOWLIST = frozenset({
+        (LlamaForCausalLM, _MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION)
+    })
 
     def __init__(self,
                  llm_args: TorchLlmArgs,
                  mapping: Mapping,
-                 spec_config: Optional["DecodingBaseConfig"],
+                 spec_config: Optional[DecodingBaseConfig],
                  sparse_attention_config: Optional["SparseAttentionConfig"],
                  max_num_tokens: int,
                  max_seq_len: Optional[int],
@@ -412,7 +415,7 @@ class ModelLoader:
                         or checkpoint_dir),
                 )
 
-            memo = dict()
+            memo: dict[torch.Tensor, torch.Tensor] = {}
 
             if (self.model_weights_memory_tag is not None
                     and load_format != LoadFormat.GMS):
@@ -478,7 +481,7 @@ class ModelLoader:
             # No-op if worked as expected
             if load_format != LoadFormat.GMS:
                 model.to("cuda")
-            del memo
+            memo.clear()
 
             rank_model_storage = get_rank_model_storage(model)
             logger.info(
@@ -513,7 +516,8 @@ class ModelLoader:
                     # model. Enable this only after target and draft subgraphs
                     # have an explicit mixed-layout policy.
                     load_weights_kwargs["allow_post_transform_weights"] = (
-                        not loads_draft_weights)
+                        self._is_mx_staged_receiver_allowlisted(model)
+                        and not loads_draft_weights)
 
                 if hasattr(model, 'llm_checkpoint_dir'):
                     weights = checkpoint_loader.load_weights(
@@ -533,7 +537,8 @@ class ModelLoader:
                     self._call_load_weights(model.load_weights, weights,
                                             self.weight_mapper)
 
-                if loads_draft_weights:
+                if self.spec_config is not None and self.spec_config.spec_dec_mode.need_load_draft_weights(
+                ):
                     weights = checkpoint_loader.load_weights(
                         self.spec_config.speculative_model,
                         mapping=self.mapping)
@@ -625,11 +630,18 @@ class ModelLoader:
                             # parameter buffers. Keeping the call shape
                             # consistent here avoids forgetting it when MX+GMS
                             # composition lands later.
+                            load_weights_kwargs = {
+                                "mapping": self.mapping,
+                                "model": model,
+                                "source_identity": self._source_identity,
+                            }
+                            if checkpoint_loader.checkpoint_format == "MX":
+                                load_weights_kwargs[
+                                    "allow_post_transform_weights"] = (
+                                        self._is_mx_staged_receiver_allowlisted(
+                                            model) and not loads_draft_weights)
                             weights = checkpoint_loader.load_weights(
-                                weight_source,
-                                mapping=self.mapping,
-                                model=model,
-                                source_identity=self._source_identity)
+                                weight_source, **load_weights_kwargs)
 
                             # `weights` may be:
                             #   - non-empty dict: standard mapping pipeline runs
@@ -660,7 +672,8 @@ class ModelLoader:
                                     "commit an unpopulated model to the GMS "
                                     "pool.")
 
-                            if loads_draft_weights:
+                            if self.spec_config is not None and self.spec_config.spec_dec_mode.need_load_draft_weights(
+                            ):
                                 draft_weights = checkpoint_loader.load_weights(
                                     self.spec_config.speculative_model,
                                     mapping=self.mapping)
@@ -685,17 +698,18 @@ class ModelLoader:
                             # narrow-scope and commit-ordering concerns.
                             checkpoint_loader.post_load_apply(
                                 model, weights_preloaded=weights_preloaded)
-                            checkpoint_loader.post_load_publish(
-                                model,
-                                checkpoint_dir=checkpoint_dir,
-                                weights_preloaded=weights_preloaded)
 
-                            for module in model.modules():
-                                if hasattr(
-                                        module,
-                                        'post_load_weights') and not getattr(
-                                            module, '_weights_removed', False):
-                                    module.post_load_weights()
+                            mx_staged_receiver_path = self._should_run_mx_staged_receiver_path(
+                                checkpoint_loader,
+                                model,
+                                weights_preloaded=weights_preloaded,
+                                loads_draft_weights=loads_draft_weights)
+                            if mx_staged_receiver_path:
+                                self._setup_aliases(model)
+                                self._mark_weights_transformed(model)
+                                self._walk_cache_state(model)
+                            else:
+                                self._walk_full_post_load(model)
 
                             # Defensive last-mile sweep: catches strays from
                             # C++ ops that bypassed the active torch
@@ -709,6 +723,12 @@ class ModelLoader:
                             # GMS-backed replacements above) before commit so the
                             # cached size doesn't show as live in memory accounting.
                             torch.cuda.empty_cache()
+
+                            self._post_load_publish(
+                                checkpoint_loader,
+                                model,
+                                checkpoint_dir=checkpoint_dir,
+                                weights_preloaded=weights_preloaded)
 
                         # Pool closed. Commit the post-post_load layout.
                         gms_backend.finalize_write(model)
@@ -756,10 +776,10 @@ class ModelLoader:
                         gms_backend.materialize_module(model)
                         self._walk_cache_state(model)
 
-                        checkpoint_loader.post_load_publish(
-                            model,
-                            checkpoint_dir=checkpoint_dir,
-                            weights_preloaded=True)
+                        self._post_load_publish(checkpoint_loader,
+                                                model,
+                                                checkpoint_dir=checkpoint_dir,
+                                                weights_preloaded=True)
                         gms_post_load_handled = True
                         logger.info("LoadFormat.GMS (RO): materialized weights")
                     else:
@@ -777,7 +797,8 @@ class ModelLoader:
                 self.weight_mapper = checkpoint_loader.get_initialized_weight_mapper(
                     model, config)
                 initialize_dummy_weights(model)
-                if loads_draft_weights:
+                if self.spec_config is not None and self.spec_config.spec_dec_mode.need_load_draft_weights(
+                ):
                     model.draft_model.load_weights_from_target_model(model)
 
             elif load_format == LoadFormat.VISION_ONLY:
@@ -802,12 +823,12 @@ class ModelLoader:
                     self._setup_aliases(model)
                     self._mark_weights_transformed(model)
                     self._walk_cache_state(model)
-                checkpoint_loader.post_load_publish(
-                    model,
-                    checkpoint_dir=checkpoint_dir,
-                    weights_preloaded=weights_preloaded)
-                if not mx_staged_receiver_path:
+                else:
                     self._walk_full_post_load(model)
+                self._post_load_publish(checkpoint_loader,
+                                        model,
+                                        checkpoint_dir=checkpoint_dir,
+                                        weights_preloaded=weights_preloaded)
 
             # TODO(GMS-MOE-LB): when the (MoE, GMS) combination is enabled,
             # `register_weight_slots_after_to_cuda` and `finalize_model`
@@ -870,9 +891,11 @@ class ModelLoader:
             loads_draft_weights: bool = False) -> bool:
         """Whether an MX receiver can skip one-shot weight transforms.
 
-        Production keeps this dormant until model validation and source
-        metadata are explicit. Tests opt in a synthetic model by patching both
-        signals.
+        MXCheckpointLoader only accepts post-transform P2P bytes when this same
+        allow-list check passes before transfer. It also refuses
+        target-plus-draft mixed layouts until there is an explicit policy for
+        that combination, so this post-load branch should never see an unsafe
+        post-transform receiver in normal use.
         """
         if checkpoint_loader.checkpoint_format != "MX" or not weights_preloaded:
             return False
@@ -891,11 +914,7 @@ class ModelLoader:
                 "transform handling. Disable post-transform MX for this load "
                 "or add an explicit mixed target/draft policy.")
 
-        allowlist_key = (
-            type(model),
-            cls._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION,
-        )
-        if allowlist_key in cls._MX_STAGED_RECEIVER_ALLOWLIST:
+        if cls._is_mx_staged_receiver_allowlisted(model):
             logger.info(
                 "MX receiver using staged post-load path for %s "
                 "(transform protocol v%d).",
@@ -904,18 +923,34 @@ class ModelLoader:
             )
             return True
 
-        # TODO(MX-POST-TRANSFORM): When MX can publish transformed bytes,
-        # reject non-allow-listed transfers before P2P or validate the model
-        # and add it to the allow-list. Do not run the full post-load path on
-        # transformed bytes.
-        logger.info(
-            "MX receiver got post-transform weights for %s, but the model is "
-            "not allow-listed for staged post-load transform protocol v%d. "
-            "Running the full post-load path.",
-            type(model).__name__,
-            cls._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION,
-        )
+        raise RuntimeError(
+            f"MX receiver got post-transform weights for {type(model).__name__}, "
+            "but the model is not allow-listed for staged post-load transform "
+            f"protocol v{cls._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION}. "
+            "Refusing to run the full post-load path on already-transformed "
+            "weights.")
+
+    @classmethod
+    def _is_mx_staged_receiver_allowlisted(
+            cls, model: DecoderModelForCausalLM) -> bool:
+        for model_type, protocol_version in cls._MX_STAGED_RECEIVER_ALLOWLIST:
+            if (protocol_version
+                    == cls._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION
+                    and isinstance(model, model_type)):
+                return True
         return False
+
+    def _post_load_publish(self, checkpoint_loader: BaseCheckpointLoader,
+                           model: DecoderModelForCausalLM, *,
+                           checkpoint_dir: str,
+                           weights_preloaded: bool) -> None:
+        kwargs = {
+            "checkpoint_dir": checkpoint_dir,
+            "weights_preloaded": weights_preloaded,
+        }
+        if checkpoint_loader.checkpoint_format == "MX":
+            kwargs["source_identity"] = self._source_identity
+        checkpoint_loader.post_load_publish(model, **kwargs)
 
     @staticmethod
     def _mark_weights_transformed(model: DecoderModelForCausalLM) -> None:

--- a/tests/unittest/_torch/executor/test_model_loader_gms.py
+++ b/tests/unittest/_torch/executor/test_model_loader_gms.py
@@ -29,6 +29,7 @@ _SOURCE_IDENTITY = model_loader_mod.SourceIdentity(
 class _TinyModel(nn.Module):
     def __init__(self, events, *, include_draft=False):
         super().__init__()
+        self._weights_transformed = False
         self._events = events
         if include_draft:
             self.draft_model = nn.Module()
@@ -129,6 +130,19 @@ def _build_gms_backend(*, is_rw, events):
 
 def _install_gms_backend(monkeypatch, backend):
     monkeypatch.setattr(memory_mod, "GMSBackend", MagicMock(return_value=backend))
+
+
+class _PostTransformMxLoader:
+    checkpoint_format = "MX"
+
+    def __init__(self) -> None:
+        self.load_weights = MagicMock(return_value={})
+        self.is_weights_preloaded = MagicMock(return_value=True)
+        self.post_load_apply = MagicMock()
+        self.post_load_publish = MagicMock()
+
+    def is_post_transform_weights_preloaded(self) -> bool:
+        return True
 
 
 def _spec_config_needing_draft_weights():
@@ -293,9 +307,9 @@ def test_gms_rw_post_load_runs_inside_pool_before_finalize(monkeypatch):
         "to",
         "load_weights",
         "post_load_apply",
-        "post_load_publish",
         "post_load_weights",
         "move_untracked_params",
+        "post_load_publish",
         "pool_exit",
         "finalize_write",
     ]
@@ -344,6 +358,58 @@ def test_gms_rw_loader_preload_skips_mapping_pipeline(monkeypatch):
 
     loader._call_load_weights.assert_not_called()
     backend.move_untracked_params.assert_called_once_with(model)
+    backend.finalize_write.assert_called_once_with(model)
+
+
+def test_gms_rw_mx_post_transform_preload_uses_staged_path(monkeypatch):
+    """GMS writers that receive post-transform MX bytes must not transform again."""
+    events = []
+    loader = _make_loader(monkeypatch, events=events)
+    monkeypatch.setattr(
+        ModelLoader,
+        "_MX_STAGED_RECEIVER_ALLOWLIST",
+        frozenset({(_TinyModel, ModelLoader._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION)}),
+    )
+    backend = _build_gms_backend(is_rw=True, events=events)
+    backend.move_untracked_params.side_effect = lambda _model: events.append(
+        "move_untracked_params"
+    )
+    backend.finalize_write.side_effect = lambda _model: events.append("finalize_write")
+    _install_gms_backend(monkeypatch, backend)
+
+    checkpoint_loader = _PostTransformMxLoader()
+    checkpoint_loader.post_load_apply.side_effect = lambda *_a, **_kw: events.append(
+        "post_load_apply"
+    )
+    checkpoint_loader.post_load_publish.side_effect = lambda *_a, **_kw: events.append(
+        "post_load_publish"
+    )
+
+    model, _ = loader.load("/ckpt", checkpoint_loader)
+
+    assert events == [
+        "pool_enter",
+        "_apply",
+        "to",
+        "post_load_apply",
+        "setup_aliases",
+        "cache_derived_state",
+        "move_untracked_params",
+        "post_load_publish",
+        "pool_exit",
+        "finalize_write",
+    ]
+    assert "post_load_weights" not in events
+    assert model._weights_transformed is True
+    _args, kwargs = checkpoint_loader.load_weights.call_args
+    assert kwargs["allow_post_transform_weights"] is True
+    loader._call_load_weights.assert_not_called()
+    checkpoint_loader.post_load_publish.assert_called_once_with(
+        model,
+        checkpoint_dir="/ckpt",
+        weights_preloaded=True,
+        source_identity=loader._source_identity,
+    )
     backend.finalize_write.assert_called_once_with(model)
 
 

--- a/tests/unittest/_torch/executor/test_model_loader_mx.py
+++ b/tests/unittest/_torch/executor/test_model_loader_mx.py
@@ -8,8 +8,10 @@ from unittest.mock import MagicMock
 
 import torch
 from torch import nn
+from transformers import LlamaConfig
 
 from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.models import modeling_llama as modeling_llama_mod
 from tensorrt_llm._torch.modules import mla as mla_mod
 from tensorrt_llm._torch.modules.linear import Linear
 from tensorrt_llm._torch.modules.mla import MLA
@@ -93,6 +95,54 @@ def _moe_context(config, mapping):
     yield None
 
 
+def _tiny_llama_model(monkeypatch):
+    monkeypatch.setattr(modeling_llama_mod, "get_sm_version", lambda: 90)
+    llama_config = LlamaConfig(
+        architectures=["LlamaForCausalLM"],
+        attention_bias=False,
+        hidden_act="silu",
+        hidden_size=16,
+        intermediate_size=32,
+        max_position_embeddings=16,
+        mlp_bias=False,
+        num_attention_heads=2,
+        num_hidden_layers=2,
+        num_key_value_heads=2,
+        rms_norm_eps=1e-5,
+        tie_word_embeddings=False,
+        torch_dtype=torch.float32,
+        vocab_size=32,
+    )
+    return model_loader_mod.LlamaForCausalLM(
+        ModelConfig(
+            pretrained_config=llama_config,
+            max_num_tokens=16,
+            max_seq_len=16,
+        )
+    )
+
+
+def _llama_alias_state(model):
+    layers = model.model.layers
+    return {
+        "skip_norm": model.model.skip_norm,
+        "layer0_next_norm": layers[0].next_layer_layernorm is layers[1].input_layernorm,
+        "layer0_next_attn": layers[0].next_attn is layers[1].self_attn,
+        "layer1_skip_input_norm": layers[1].skip_input_layernorm,
+        "layer1_next_norm": layers[1].next_layer_layernorm is model.model.norm,
+        "layer1_next_attn": layers[1].next_attn is None,
+    }
+
+
+def _transform_guard_state(model):
+    return {
+        name: module._weights_transformed
+        for name, module in model.named_modules()
+        if hasattr(module, "_weights_transformed")
+        and not getattr(module, "_weights_removed", False)
+    }
+
+
 def _make_loader(monkeypatch, *, events, spec_config=None):
     llm_args = SimpleNamespace(load_format=LoadFormat.AUTO)
     loader = ModelLoader(
@@ -149,11 +199,15 @@ def test_mx_success_initializes_mapper_skips_weight_mapping_and_reload_works(mon
     assert kwargs["mapping"] is loader.mapping
     assert kwargs["model"] is model
     assert kwargs["source_identity"] is loader._source_identity
+    assert kwargs["allow_post_transform_weights"] is False
     assert loader._call_load_weights.call_count == 0
     checkpoint_loader.get_initialized_weight_mapper.assert_called_once()
     assert loader.weight_mapper is checkpoint_loader.get_initialized_weight_mapper.return_value
     checkpoint_loader.post_load_publish.assert_called_once_with(
-        model, checkpoint_dir="/ckpt", weights_preloaded=True
+        model,
+        checkpoint_dir="/ckpt",
+        weights_preloaded=True,
+        source_identity=loader._source_identity,
     )
 
     # reload() uses self.weight_mapper unconditionally; MX success must
@@ -201,7 +255,10 @@ def test_mx_partial_fallback_merges_returned_weights(monkeypatch):
     assert weights is fallback_weights
     assert mapper is loader.weight_mapper
     checkpoint_loader.post_load_publish.assert_called_once_with(
-        model, checkpoint_dir="/ckpt", weights_preloaded=True
+        model,
+        checkpoint_dir="/ckpt",
+        weights_preloaded=True,
+        source_identity=loader._source_identity,
     )
 
 
@@ -211,6 +268,7 @@ class _PostTransformMxLoader:
     def __init__(self, *, post_transform: bool) -> None:
         self._post_transform = post_transform
         self._weights_preloaded = True
+        self._disk_weight = MagicMock()
         self.load_weights = MagicMock(side_effect=self._load_weights)
         self.is_weights_preloaded = MagicMock(side_effect=lambda: self._weights_preloaded)
         self.get_initialized_weight_mapper = MagicMock(return_value=MagicMock())
@@ -221,18 +279,11 @@ class _PostTransformMxLoader:
         if self._post_transform and kwargs.get("allow_post_transform_weights") is False:
             self._post_transform = False
             self._weights_preloaded = False
-            return {"disk.weight": MagicMock()}
+            return {"disk.weight": self._disk_weight}
         return {}
 
     def is_post_transform_weights_preloaded(self) -> bool:
         return self._post_transform
-
-
-def _spec_config_needing_draft_weights():
-    return SimpleNamespace(
-        spec_dec_mode=SimpleNamespace(need_load_draft_weights=lambda: True),
-        speculative_model="/draft",
-    )
 
 
 def test_mx_post_transform_receiver_uses_staged_path_when_allowlisted(monkeypatch):
@@ -248,9 +299,13 @@ def test_mx_post_transform_receiver_uses_staged_path_when_allowlisted(monkeypatc
     model, _ = loader.load("/ckpt", checkpoint_loader)
 
     loader._call_load_weights.assert_not_called()
-    assert checkpoint_loader.load_weights.call_args.kwargs["allow_post_transform_weights"] is True
+    _args, kwargs = checkpoint_loader.load_weights.call_args
+    assert kwargs["allow_post_transform_weights"] is True
     checkpoint_loader.post_load_publish.assert_called_once_with(
-        model, checkpoint_dir="/ckpt", weights_preloaded=True
+        model,
+        checkpoint_dir="/ckpt",
+        weights_preloaded=True,
+        source_identity=loader._source_identity,
     )
     # Post-transform receivers skip transform_weights(), but the accepted
     # tensors are already in final layout. Keep the transform guard in sync so
@@ -261,41 +316,57 @@ def test_mx_post_transform_receiver_uses_staged_path_when_allowlisted(monkeypatc
     assert events == ["setup_aliases", "cache_derived_state"]
 
 
-def test_mx_post_transform_receiver_with_draft_weights_forces_disk_fallback(monkeypatch):
-    events = []
-    loader = _make_loader(
-        monkeypatch,
-        events=events,
-        spec_config=_spec_config_needing_draft_weights(),
-    )
-    monkeypatch.setattr(
-        ModelLoader,
-        "_MX_STAGED_RECEIVER_ALLOWLIST",
-        frozenset({(_TinyModel, ModelLoader._MX_STAGED_RECEIVER_TRANSFORM_PROTOCOL_VERSION)}),
-    )
+def test_default_mx_staged_receiver_allowlist_matches_real_tiny_llama(monkeypatch):
+    full_model = _tiny_llama_model(monkeypatch)
+    staged_model = _tiny_llama_model(monkeypatch)
     checkpoint_loader = _PostTransformMxLoader(post_transform=True)
 
-    model, _ = loader.load("/ckpt", checkpoint_loader)
-
-    primary_kwargs = checkpoint_loader.load_weights.call_args_list[0].kwargs
-    assert primary_kwargs["allow_post_transform_weights"] is False
-    assert loader._call_load_weights.call_count == 2
-    checkpoint_loader.post_load_publish.assert_called_once_with(
-        model, checkpoint_dir="/ckpt", weights_preloaded=False
+    ModelLoader._walk_full_post_load(full_model)
+    assert (
+        ModelLoader._should_run_mx_staged_receiver_path(
+            checkpoint_loader,
+            staged_model,
+            weights_preloaded=True,
+        )
+        is True
     )
-    assert model._weights_transformed is False
-    assert model.linear._weights_transformed is False
-    assert events == ["load_weights", "load_draft_weights", "post_load_weights"]
+
+    transform_weights_calls = []
+    for module in staged_model.modules():
+        transform_weights = getattr(module, "transform_weights", None)
+        if transform_weights is None:
+            continue
+
+        def _record_transform_weights(*_args, module=module, **_kwargs):
+            transform_weights_calls.append(type(module).__name__)
+
+        module.transform_weights = _record_transform_weights
+
+    ModelLoader._setup_aliases(staged_model)
+    ModelLoader._mark_weights_transformed(staged_model)
+    ModelLoader._walk_cache_state(staged_model)
+
+    assert transform_weights_calls == []
+    assert _llama_alias_state(staged_model) == _llama_alias_state(full_model)
+    assert _transform_guard_state(staged_model) == _transform_guard_state(full_model)
 
 
-def test_mx_post_transform_receiver_falls_back_when_allowlist_empty(monkeypatch):
+def test_mx_post_transform_receiver_falls_back_for_non_allowlisted_model(monkeypatch):
     events = []
     loader = _make_loader(monkeypatch, events=events)
     checkpoint_loader = _PostTransformMxLoader(post_transform=True)
 
-    loader.load("/ckpt", checkpoint_loader)
+    model, _ = loader.load("/ckpt", checkpoint_loader)
 
-    assert events == ["post_load_weights"]
+    _args, kwargs = checkpoint_loader.load_weights.call_args
+    assert kwargs["allow_post_transform_weights"] is False
+    assert checkpoint_loader.is_weights_preloaded() is False
+    assert loader._call_load_weights.call_count == 1
+    load_fn, weights, mapper = loader._call_load_weights.call_args.args
+    assert load_fn == model.load_weights
+    assert weights == {"disk.weight": checkpoint_loader._disk_weight}
+    assert mapper is loader.weight_mapper
+    assert events == ["load_weights", "post_load_weights"]
 
 
 def test_mx_fallback_runs_standard_weight_mapping(monkeypatch):
@@ -313,7 +384,10 @@ def test_mx_fallback_runs_standard_weight_mapping(monkeypatch):
     assert events[0] == "load_weights"
     assert "post_load_weights" in events
     checkpoint_loader.post_load_publish.assert_called_once_with(
-        model, checkpoint_dir="/ckpt", weights_preloaded=False
+        model,
+        checkpoint_dir="/ckpt",
+        weights_preloaded=False,
+        source_identity=loader._source_identity,
     )
 
 

--- a/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
+++ b/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
@@ -16,6 +16,7 @@ assertion is about our fallback behavior, not the upstream API.
 import os
 import sys
 from contextlib import ExitStack
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -28,21 +29,40 @@ from tensorrt_llm._torch.models.checkpoints.hf.qwen3_next_weight_mapper import (
 )
 from tensorrt_llm._torch.models.checkpoints.hf.weight_mapper import HfWeightMapper
 from tensorrt_llm._torch.models.checkpoints.mx.checkpoint_loader import (
+    _MX_SOURCE_IDENTITY_METADATA_KEY,
+    _MX_STAGED_TRANSFORM_PROTOCOL_VERSION,
+    _MX_TRANSFORM_PROTOCOL_VERSION_METADATA_KEY,
+    _MX_WEIGHT_LAYOUT_METADATA_KEY,
+    _MX_WEIGHT_LAYOUT_POST_TRANSFORM,
     MXCheckpointLoader,
+    _build_mx_source_metadata,
     _normalize_model_identity,
     _resolve_mx_model_name,
 )
 from tensorrt_llm._torch.weight_sharing import SourceIdentity
 
-_SOURCE_IDENTITY = SourceIdentity(
-    format_version=1,
-    model_fingerprint="model",
-    quant_fingerprint="quant",
-    backend_fingerprint="backend",
-    parallel_fingerprint="parallel",
-    rank=0,
-    shard_fingerprint="shard",
-)
+_MISSING = object()
+
+
+def _identity(rank: int = 0) -> SourceIdentity:
+    return SourceIdentity(
+        format_version=1,
+        model_fingerprint="model",
+        quant_fingerprint="quant",
+        backend_fingerprint="backend",
+        parallel_fingerprint="parallel",
+        rank=rank,
+        shard_fingerprint=f"shard-{rank}",
+        model_name="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+    )
+
+
+def _source_instance(identity: SourceIdentity, *, post_transform: bool = True):
+    metadata = _build_mx_source_metadata(identity)
+    if not post_transform:
+        metadata[_MX_WEIGHT_LAYOUT_METADATA_KEY] = "pre_transform"
+    return SimpleNamespace(metadata=metadata)
+
 
 # ---------------------------------------------------------------------------
 # Construction & static properties
@@ -161,11 +181,14 @@ class TestLoadWeightsFallback:
 
     @staticmethod
     def _upstream_raises(stack):
+        identity = _identity()
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
-        loader._source_identity_compatible = MagicMock(return_value=True)
-        fake_mx = _build_fake_modelexpress(load_weights_side_effect=RuntimeError("boom"))
+        fake_mx = _build_fake_modelexpress(
+            load_weights_side_effect=RuntimeError("boom"),
+            source_instances=[_source_instance(identity, post_transform=False)],
+        )
         stack.enter_context(_install_fake_modelexpress(fake_mx))
-        return (loader, {"model": MagicMock()})
+        return (loader, {"model": MagicMock(), "source_identity": identity})
 
     @pytest.mark.parametrize(
         "trigger_id, setup",
@@ -212,15 +235,21 @@ class TestLoadWeightsMxPath:
         # Empty fallback dict means MX delivered all weights into model
         # params. ModelLoader uses the empty dict plus is_weights_preloaded()
         # to skip the standard weight-mapping pipeline.
+        identity = _identity()
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
-        fake_mx = _build_fake_modelexpress(load_weights_return={})
+        fake_mx = _build_fake_modelexpress(
+            load_weights_return={},
+            source_instances=[_source_instance(identity, post_transform=False)],
+        )
         mapping = MagicMock(name="mapping")
         model = MagicMock(name="model")
-        source_identity_kwargs = _allow_mx_source_identity(loader)
 
         with _install_fake_modelexpress(fake_mx):
             result = loader.load_weights(
-                "/nonexistent", mapping=mapping, model=model, **source_identity_kwargs
+                "/nonexistent",
+                mapping=mapping,
+                model=model,
+                source_identity=identity,
             )
 
         assert result == {}
@@ -242,20 +271,26 @@ class TestLoadWeightsMxPath:
         # When MX returns a non-empty fallback dict (size-mismatched
         # tensors), keep the P2P transfer and let ModelLoader merge these
         # tensors through the standard disk pipeline.
+        identity = _identity()
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
         fallback_weight = MagicMock()
         fallback_weight.numel.return_value = 2
         fallback_weight.element_size.return_value = 4
         fallback = {"some.weight": fallback_weight}
-        fake_mx = _build_fake_modelexpress(load_weights_return=fallback)
-        source_identity_kwargs = _allow_mx_source_identity(loader)
+        fake_mx = _build_fake_modelexpress(
+            load_weights_return=fallback,
+            source_instances=[_source_instance(identity, post_transform=False)],
+        )
 
         with (
             _install_fake_modelexpress(fake_mx),
             patch.object(HfCheckpointLoader, "load_weights") as mock_super_load,
         ):
             result = loader.load_weights(
-                "/nonexistent", mapping=MagicMock(), model=MagicMock(), **source_identity_kwargs
+                "/nonexistent",
+                mapping=MagicMock(),
+                model=MagicMock(),
+                source_identity=identity,
             )
 
         assert loader.is_weights_preloaded() is True
@@ -263,40 +298,35 @@ class TestLoadWeightsMxPath:
         assert result is fallback
         mock_super_load.assert_not_called()
 
-    def test_post_transform_mixed_success_falls_back_to_full_disk_load(self):
-        # Post-transform sources are safe only when all tensors arrive via P2P.
-        # If MX returns raw fallback tensors, avoid mixing layouts by falling
-        # back to a full disk load.
+    def test_post_transform_full_success_sets_skip_signal_when_allowlisted(self):
+        identity = _identity()
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
-        loader._source_identity_compatible = MagicMock(return_value=True)
-        loader._source_metadata_is_post_transform = MagicMock(return_value=True)
-        fallback = {"some.weight": MagicMock(numel=lambda: 1, element_size=lambda: 4)}
-        disk_weights = {"disk.weight": MagicMock()}
-        fake_mx = _build_fake_modelexpress(load_weights_return=fallback)
+        fake_mx = _build_fake_modelexpress(
+            load_weights_return={},
+            source_instances=[_source_instance(identity)],
+        )
 
-        with (
-            _install_fake_modelexpress(fake_mx),
-            patch.object(
-                HfCheckpointLoader, "load_weights", return_value=disk_weights
-            ) as mock_super_load,
-        ):
-            result = loader.load_weights("/nonexistent", mapping=MagicMock(), model=MagicMock())
+        with _install_fake_modelexpress(fake_mx):
+            result = loader.load_weights(
+                "/nonexistent",
+                mapping=MagicMock(),
+                model=MagicMock(),
+                source_identity=identity,
+                allow_post_transform_weights=True,
+            )
 
-        assert result is disk_weights
-        assert loader.is_weights_preloaded() is False
-        assert loader.is_post_transform_weights_preloaded() is False
-        mock_super_load.assert_called_once()
+        assert result == {}
+        assert loader.is_weights_preloaded() is True
+        assert loader.is_post_transform_weights_preloaded() is True
 
-    def test_post_transform_source_can_be_disallowed_before_p2p(self):
-        # Some receiver shapes, such as target+draft speculative decoding, are
-        # not ready to mix post-transform target bytes with separately loaded
-        # raw draft bytes. Let ModelLoader force a disk fallback before MX
-        # starts RDMA, rather than accepting bytes it cannot safely stage.
+    def test_post_transform_source_falls_back_before_p2p_when_not_allowlisted(self):
+        identity = _identity()
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
-        loader._source_identity_compatible = MagicMock(return_value=True)
-        loader._source_metadata_is_post_transform = MagicMock(return_value=True)
         disk_weights = {"disk.weight": MagicMock()}
-        fake_mx = _build_fake_modelexpress(load_weights_return={})
+        fake_mx = _build_fake_modelexpress(
+            load_weights_return={},
+            source_instances=[_source_instance(identity)],
+        )
 
         with (
             _install_fake_modelexpress(fake_mx),
@@ -308,6 +338,144 @@ class TestLoadWeightsMxPath:
                 "/nonexistent",
                 mapping=MagicMock(),
                 model=MagicMock(),
+                source_identity=identity,
+                allow_post_transform_weights=False,
+            )
+
+        assert result is disk_weights
+        assert loader.is_weights_preloaded() is False
+        assert loader.is_post_transform_weights_preloaded() is False
+        mx_loader = fake_mx.trtllm_live_transfer.MxLiveWeightLoader.return_value
+        mx_loader.load_weights.assert_not_called()
+        mock_super_load.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "protocol_value",
+        ["2", "not-an-int", _MISSING],
+        ids=["newer-protocol", "invalid-protocol", "missing-protocol"],
+    )
+    def test_post_transform_source_with_unsupported_protocol_falls_back_before_p2p(
+        self, protocol_value
+    ):
+        identity = _identity()
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        disk_weights = {"disk.weight": MagicMock()}
+        source_instance = _source_instance(identity)
+        if protocol_value is _MISSING:
+            source_instance.metadata.pop(_MX_TRANSFORM_PROTOCOL_VERSION_METADATA_KEY)
+        else:
+            source_instance.metadata[_MX_TRANSFORM_PROTOCOL_VERSION_METADATA_KEY] = protocol_value
+        fake_mx = _build_fake_modelexpress(
+            load_weights_return={},
+            source_instances=[source_instance],
+        )
+
+        with (
+            _install_fake_modelexpress(fake_mx),
+            patch.object(
+                HfCheckpointLoader, "load_weights", return_value=disk_weights
+            ) as mock_super_load,
+        ):
+            result = loader.load_weights(
+                "/nonexistent",
+                mapping=MagicMock(),
+                model=MagicMock(),
+                source_identity=identity,
+                allow_post_transform_weights=True,
+            )
+
+        assert result is disk_weights
+        assert loader.is_weights_preloaded() is False
+        assert loader.is_post_transform_weights_preloaded() is False
+        mx_loader = fake_mx.trtllm_live_transfer.MxLiveWeightLoader.return_value
+        mx_loader.load_weights.assert_not_called()
+        mock_super_load.assert_called_once()
+
+    def test_selects_matching_source_metadata_from_multiple_instances(self):
+        rank0_identity = _identity(rank=0)
+        rank1_identity = _identity(rank=1)
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        fake_mx = _build_fake_modelexpress(
+            load_weights_return={},
+            source_instances=[
+                _source_instance(rank0_identity),
+                _source_instance(rank1_identity),
+            ],
+        )
+
+        with (
+            _install_fake_modelexpress(fake_mx),
+            patch.object(HfCheckpointLoader, "load_weights") as mock_super_load,
+        ):
+            result = loader.load_weights(
+                "/nonexistent",
+                mapping=MagicMock(),
+                model=MagicMock(),
+                source_identity=rank1_identity,
+                allow_post_transform_weights=True,
+            )
+
+        assert result == {}
+        assert loader.is_weights_preloaded() is True
+        assert loader.is_post_transform_weights_preloaded() is True
+        mock_super_load.assert_not_called()
+
+    def test_post_transform_mixed_success_falls_back_to_full_disk_load(self):
+        # Post-transform sources are safe only when all tensors arrive via P2P.
+        # If MX returns raw fallback tensors, avoid mixing layouts by falling
+        # back to a full disk load.
+        identity = _identity()
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        fallback = {"some.weight": MagicMock(numel=lambda: 1, element_size=lambda: 4)}
+        disk_weights = {"disk.weight": MagicMock()}
+        fake_mx = _build_fake_modelexpress(
+            load_weights_return=fallback,
+            source_instances=[_source_instance(identity)],
+        )
+
+        with (
+            _install_fake_modelexpress(fake_mx),
+            patch.object(
+                HfCheckpointLoader, "load_weights", return_value=disk_weights
+            ) as mock_super_load,
+        ):
+            result = loader.load_weights(
+                "/nonexistent",
+                mapping=MagicMock(),
+                model=MagicMock(),
+                source_identity=identity,
+                allow_post_transform_weights=True,
+            )
+
+        assert result is disk_weights
+        assert loader.is_weights_preloaded() is False
+        assert loader.is_post_transform_weights_preloaded() is False
+        mock_super_load.assert_called_once()
+
+    def test_post_transform_source_can_be_disallowed_before_p2p(self):
+        # Some receiver shapes, such as target+draft speculative decoding, are
+        # not ready to mix post-transform target bytes with separately loaded
+        # raw draft bytes. Let ModelLoader force a disk fallback before MX
+        # starts RDMA, rather than accepting bytes it cannot safely stage.
+        identity = _identity()
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        disk_weights = {"disk.weight": MagicMock()}
+        fake_mx = _build_fake_modelexpress(
+            load_weights_return={},
+            source_instances=[_source_instance(identity)],
+        )
+
+        with (
+            _install_fake_modelexpress(fake_mx),
+            patch.object(
+                HfCheckpointLoader, "load_weights", return_value=disk_weights
+            ) as mock_super_load,
+        ):
+            result = loader.load_weights(
+                "/nonexistent",
+                mapping=MagicMock(),
+                model=MagicMock(),
+                source_identity=identity,
                 allow_post_transform_weights=False,
             )
 
@@ -334,23 +502,54 @@ class TestPublishAsSource:
     def test_modelexpress_unavailable_is_noop(self):
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
         with _block_modelexpress():
-            loader.publish_as_source(MagicMock())  # must not raise
+            loader.publish_as_source(MagicMock(), source_identity=_identity())  # must not raise
 
     def test_publish_called_with_model(self):
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        identity = _identity()
         fake_mx = _build_fake_modelexpress()
         model = MagicMock(name="model")
 
         with _install_fake_modelexpress(fake_mx):
-            loader.publish_as_source(model)
+            loader.publish_as_source(model, source_identity=identity)
 
-        fake_mx.trtllm_live_transfer.publish_model_params.assert_called_once_with(model)
+        fake_mx.trtllm_live_transfer.publish_model_params.assert_called_once()
+        args, kwargs = fake_mx.trtllm_live_transfer.publish_model_params.call_args
+        assert args == (model,)
+        metadata = kwargs["metadata"]
+        assert metadata[_MX_WEIGHT_LAYOUT_METADATA_KEY] == _MX_WEIGHT_LAYOUT_POST_TRANSFORM
+        assert metadata[_MX_TRANSFORM_PROTOCOL_VERSION_METADATA_KEY] == str(
+            _MX_STAGED_TRANSFORM_PROTOCOL_VERSION
+        )
+        assert _MX_SOURCE_IDENTITY_METADATA_KEY in metadata
+
+    def test_source_identity_required_for_post_transform_publish(self):
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        fake_mx = _build_fake_modelexpress()
+
+        with _install_fake_modelexpress(fake_mx):
+            loader.publish_as_source(MagicMock())
+
+        fake_mx.trtllm_live_transfer.publish_model_params.assert_not_called()
+
+    def test_publish_skipped_when_metadata_unsupported(self):
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        calls = []
+
+        def _publish_without_metadata(model):
+            calls.append(model)
+
+        fake_mx = _build_fake_modelexpress(publish_model_params=_publish_without_metadata)
+        with _install_fake_modelexpress(fake_mx):
+            loader.publish_as_source(MagicMock(), source_identity=_identity())
+
+        assert calls == []
 
     def test_env_var_set_during_publish_then_restored(self):
         loader = MXCheckpointLoader(mx_server_url="http://mx-instance:9999")
         captured_env = {}
 
-        def _capture(model):
+        def _capture(model, **_kwargs):
             captured_env["MODEL_EXPRESS_URL"] = os.environ.get("MODEL_EXPRESS_URL")
 
         fake_mx = _build_fake_modelexpress(publish_side_effect=_capture)
@@ -358,7 +557,7 @@ class TestPublishAsSource:
         prior = os.environ.pop("MODEL_EXPRESS_URL", None)
         try:
             with _install_fake_modelexpress(fake_mx):
-                loader.publish_as_source(MagicMock())
+                loader.publish_as_source(MagicMock(), source_identity=_identity())
         finally:
             if prior is not None:
                 os.environ["MODEL_EXPRESS_URL"] = prior
@@ -375,7 +574,7 @@ class TestPublishAsSource:
         os.environ["MODEL_EXPRESS_URL"] = "http://prior-value:1234"
         try:
             with _install_fake_modelexpress(fake_mx):
-                loader.publish_as_source(MagicMock())
+                loader.publish_as_source(MagicMock(), source_identity=_identity())
             assert os.environ["MODEL_EXPRESS_URL"] == "http://prior-value:1234"
         finally:
             if prior is None:
@@ -390,7 +589,7 @@ class TestPublishAsSource:
         fake_mx = _build_fake_modelexpress(publish_side_effect=RuntimeError("upstream went away"))
 
         with _install_fake_modelexpress(fake_mx):
-            loader.publish_as_source(MagicMock())  # must not raise
+            loader.publish_as_source(MagicMock(), source_identity=_identity())  # must not raise
 
 
 # ---------------------------------------------------------------------------
@@ -432,7 +631,9 @@ def _build_fake_modelexpress(
     load_weights_return=None,
     load_weights_side_effect=None,
     publish_side_effect=None,
+    publish_model_params=None,
     source_instances=None,
+    source_metadata=None,
 ):
     """Build a fake modelexpress module tree mimicking the symbols we use."""
     fake_pkg = MagicMock(name="modelexpress")
@@ -450,11 +651,15 @@ def _build_fake_modelexpress(
     fake_trtllm_live.MxLiveWeightLoader = MagicMock(return_value=weight_loader_instance)
     client_instance = MagicMock(name="MxClient instance")
     client_instance.list_sources.return_value = MagicMock(instances=source_instances or [])
+    if source_metadata is not None:
+        client_instance.get_source_metadata.return_value = source_metadata
     fake_trtllm_live.MxClient = MagicMock(return_value=client_instance)
     fake_trtllm_live._build_trtllm_identity = MagicMock(return_value=MagicMock())
 
     # publish_model_params(model)
-    if publish_side_effect is not None:
+    if publish_model_params is not None:
+        fake_trtllm_live.publish_model_params = publish_model_params
+    elif publish_side_effect is not None:
         fake_trtllm_live.publish_model_params = MagicMock(side_effect=publish_side_effect)
     else:
         fake_trtllm_live.publish_model_params = MagicMock()
@@ -486,12 +691,6 @@ def _install_fake_modelexpress(fake_pkg):
     return _Installer()
 
 
-def _allow_mx_source_identity(loader):
-    """Let MX P2P path tests bypass the metadata fetch seam with a matching identity."""
-    loader._fetch_source_identity = MagicMock(return_value=_SOURCE_IDENTITY)
-    return {"source_identity": _SOURCE_IDENTITY}
-
-
 # ---------------------------------------------------------------------------
 # Item 2: defensive MX_SOURCE_QUERY_TIMEOUT default
 # ---------------------------------------------------------------------------
@@ -510,20 +709,31 @@ class TestMxSourceQueryTimeoutDefault:
         yield
 
     def test_no_registered_source_gets_short_default_during_load(self):
+        identity = _identity()
+        source_metadata = _build_mx_source_metadata(identity)
+        source_metadata[_MX_WEIGHT_LAYOUT_METADATA_KEY] = "pre_transform"
+
         def _assert_timeout(*args, **kwargs):
             assert os.environ.get("MX_SOURCE_QUERY_TIMEOUT") == "30"
             return {}
 
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
-        fake_mx = _build_fake_modelexpress(load_weights_side_effect=_assert_timeout)
-        source_identity_kwargs = _allow_mx_source_identity(loader)
+        fake_mx = _build_fake_modelexpress(
+            load_weights_side_effect=_assert_timeout,
+            source_metadata=source_metadata,
+        )
         with _install_fake_modelexpress(fake_mx):
             loader.load_weights(
-                "/nonexistent", mapping=MagicMock(), model=MagicMock(), **source_identity_kwargs
+                "/nonexistent",
+                mapping=MagicMock(),
+                model=MagicMock(),
+                source_identity=identity,
             )
         assert "MX_SOURCE_QUERY_TIMEOUT" not in os.environ
 
     def test_existing_source_keeps_upstream_default_when_unset(self):
+        identity = _identity()
+
         def _assert_no_timeout(*args, **kwargs):
             assert "MX_SOURCE_QUERY_TIMEOUT" not in os.environ
             return {}
@@ -531,16 +741,19 @@ class TestMxSourceQueryTimeoutDefault:
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
         fake_mx = _build_fake_modelexpress(
             load_weights_side_effect=_assert_no_timeout,
-            source_instances=[MagicMock()],
+            source_instances=[_source_instance(identity, post_transform=False)],
         )
-        source_identity_kwargs = _allow_mx_source_identity(loader)
         with _install_fake_modelexpress(fake_mx):
             loader.load_weights(
-                "/nonexistent", mapping=MagicMock(), model=MagicMock(), **source_identity_kwargs
+                "/nonexistent",
+                mapping=MagicMock(),
+                model=MagicMock(),
+                source_identity=identity,
             )
         assert "MX_SOURCE_QUERY_TIMEOUT" not in os.environ
 
     def test_env_value_preserved(self, monkeypatch):
+        identity = _identity()
         # If the user/orchestrator already set a value, our defensive
         # default must not stomp it.
         monkeypatch.setenv("MX_SOURCE_QUERY_TIMEOUT", "120")
@@ -550,25 +763,37 @@ class TestMxSourceQueryTimeoutDefault:
             return {}
 
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
-        fake_mx = _build_fake_modelexpress(load_weights_side_effect=_assert_env_timeout)
-        source_identity_kwargs = _allow_mx_source_identity(loader)
+        fake_mx = _build_fake_modelexpress(
+            load_weights_side_effect=_assert_env_timeout,
+            source_instances=[_source_instance(identity, post_transform=False)],
+        )
         with _install_fake_modelexpress(fake_mx):
             loader.load_weights(
-                "/nonexistent", mapping=MagicMock(), model=MagicMock(), **source_identity_kwargs
+                "/nonexistent",
+                mapping=MagicMock(),
+                model=MagicMock(),
+                source_identity=identity,
             )
         assert os.environ.get("MX_SOURCE_QUERY_TIMEOUT") == "120"
 
     def test_configured_timeout_applies_during_load_and_restores_env(self):
+        identity = _identity()
+
         def _assert_config_timeout(*args, **kwargs):
             assert os.environ.get("MX_SOURCE_QUERY_TIMEOUT") == "900"
             return {}
 
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001", query_timeout_s=900)
-        fake_mx = _build_fake_modelexpress(load_weights_side_effect=_assert_config_timeout)
-        source_identity_kwargs = _allow_mx_source_identity(loader)
+        fake_mx = _build_fake_modelexpress(
+            load_weights_side_effect=_assert_config_timeout,
+            source_instances=[_source_instance(identity, post_transform=False)],
+        )
         with _install_fake_modelexpress(fake_mx):
             loader.load_weights(
-                "/nonexistent", mapping=MagicMock(), model=MagicMock(), **source_identity_kwargs
+                "/nonexistent",
+                mapping=MagicMock(),
+                model=MagicMock(),
+                source_identity=identity,
             )
         assert "MX_SOURCE_QUERY_TIMEOUT" not in os.environ
 
@@ -703,13 +928,13 @@ class TestPublishAsSourceModelName:
         )
         captured = {}
 
-        def _capture(model):
+        def _capture(model, **_kwargs):
             captured["MODEL_NAME"] = os.environ.get("MODEL_NAME")
             captured["MODEL_EXPRESS_URL"] = os.environ.get("MODEL_EXPRESS_URL")
 
         fake_mx = _build_fake_modelexpress(publish_side_effect=_capture)
         with _install_fake_modelexpress(fake_mx):
-            loader.publish_as_source(MagicMock())
+            loader.publish_as_source(MagicMock(), source_identity=_identity())
 
         assert captured["MODEL_NAME"] == "Qwen/Qwen2.5-72B-Instruct"
         assert captured["MODEL_EXPRESS_URL"] == "http://mx:8001"
@@ -722,12 +947,16 @@ class TestPublishAsSourceModelName:
         # No constructor model_name, no MODEL_NAME env → use basename.
         captured = {}
 
-        def _capture(model):
+        def _capture(model, **_kwargs):
             captured["MODEL_NAME"] = os.environ.get("MODEL_NAME")
 
         fake_mx = _build_fake_modelexpress(publish_side_effect=_capture)
         with _install_fake_modelexpress(fake_mx):
-            loader.publish_as_source(MagicMock(), checkpoint_dir="/scratch/local-model")
+            loader.publish_as_source(
+                MagicMock(),
+                checkpoint_dir="/scratch/local-model",
+                source_identity=_identity(),
+            )
 
         assert captured["MODEL_NAME"] == "local-model"
 
@@ -738,12 +967,16 @@ class TestPublishAsSourceModelName:
         )
         captured = {}
 
-        def _capture(model):
+        def _capture(model, **_kwargs):
             captured["MODEL_NAME"] = os.environ.get("MODEL_NAME")
 
         fake_mx = _build_fake_modelexpress(publish_side_effect=_capture)
         with _install_fake_modelexpress(fake_mx):
-            loader.publish_as_source(MagicMock(), checkpoint_dir=snapshot)
+            loader.publish_as_source(
+                MagicMock(),
+                checkpoint_dir=snapshot,
+                source_identity=_identity(),
+            )
 
         # Critical: NOT the commit hash, the human-readable Hub-ID form.
         assert captured["MODEL_NAME"] == "Qwen/Qwen2.5-72B-Instruct"
@@ -758,12 +991,12 @@ class TestPublishAsSourceModelName:
         )
         captured = {}
 
-        def _capture(model):
+        def _capture(model, **_kwargs):
             captured["MODEL_NAME"] = os.environ.get("MODEL_NAME")
 
         fake_mx = _build_fake_modelexpress(publish_side_effect=_capture)
         with _install_fake_modelexpress(fake_mx):
-            loader.publish_as_source(MagicMock())
+            loader.publish_as_source(MagicMock(), source_identity=_identity())
 
         assert captured["MODEL_NAME"] == "explicit"
         # Restored to the prior env value, not unset.
@@ -774,12 +1007,12 @@ class TestPublishAsSourceModelName:
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
         captured = {}
 
-        def _capture(model):
+        def _capture(model, **_kwargs):
             captured["MODEL_NAME"] = os.environ.get("MODEL_NAME")
 
         fake_mx = _build_fake_modelexpress(publish_side_effect=_capture)
         with _install_fake_modelexpress(fake_mx):
-            loader.publish_as_source(MagicMock())
+            loader.publish_as_source(MagicMock(), source_identity=_identity())
 
         assert captured["MODEL_NAME"] == "from-env-only"
         assert os.environ.get("MODEL_NAME") == "from-env-only"
@@ -789,11 +1022,11 @@ class TestPublishAsSourceModelName:
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
         captured = {}
 
-        def _capture(model):
+        def _capture(model, **_kwargs):
             captured["MODEL_NAME"] = os.environ.get("MODEL_NAME")
 
         fake_mx = _build_fake_modelexpress(publish_side_effect=_capture)
         with _install_fake_modelexpress(fake_mx):
-            loader.publish_as_source(MagicMock())
+            loader.publish_as_source(MagicMock(), source_identity=_identity())
 
         assert captured["MODEL_NAME"] == "unknown"

--- a/tests/unittest/_torch/modules/moe/test_moe_backend.py
+++ b/tests/unittest/_torch/modules/moe/test_moe_backend.py
@@ -191,6 +191,12 @@ def create_test_backend(
     )
 
 
+# ============================================================================
+# Staged post-load hook lifecycle tests
+# ============================================================================
+# These tests cover staged hook contracts rather than the common backend matrix
+# below. Keep them grouped so they can move to a dedicated file if the MoE test
+# layout is split later.
 def test_moe_post_load_weights_uses_idempotent_transform_hook():
     class HookTestMoE(MoE):
         def create_weights(self):

--- a/tests/unittest/_torch/weight_sharing/test_mx_source_identity_gate.py
+++ b/tests/unittest/_torch/weight_sharing/test_mx_source_identity_gate.py
@@ -22,10 +22,15 @@ seam is patched, so the gate logic runs against real `SourceIdentity` objects
 without any model, GPU, or RDMA.
 """
 
+from types import SimpleNamespace
+
 from _source_identity_fakes import FakeMapping
 from _source_identity_fakes import make_identity as _identity
 
-from tensorrt_llm._torch.models.checkpoints.mx.checkpoint_loader import MXCheckpointLoader
+from tensorrt_llm._torch.models.checkpoints.mx.checkpoint_loader import (
+    MXCheckpointLoader,
+    _build_mx_source_metadata,
+)
 
 
 def _new_loader(local_identity, source_identity, fetched=True):
@@ -70,11 +75,36 @@ def test_gate_falls_back_when_source_identity_unavailable():
     assert loader._source_identity_compatible("ckpt", _STUB_CLIENT, _STUB_BUILD) is False
 
 
-def test_fetch_source_identity_returns_none_until_upstream_wired():
-    # The seam currently returns None by contract; this pins that behavior so
-    # the day it is wired to real MX metadata, the change is deliberate.
+def test_fetch_source_identity_returns_none_when_metadata_unavailable():
     loader = MXCheckpointLoader.__new__(MXCheckpointLoader)
-    assert loader._fetch_source_identity("ckpt", _STUB_CLIENT, _STUB_BUILD) is None
+    loader._mx_server_url = "http://mx:8001"
+    loader._model_name = None
+
+    class _Client:
+        def __init__(self, *, server_url):
+            self.server_url = server_url
+
+        def list_sources(self, *, identity):
+            return SimpleNamespace(instances=[])
+
+    assert loader._fetch_source_identity("ckpt", _Client, lambda **_kw: object()) is None
+
+
+def test_fetch_source_identity_from_source_metadata():
+    source = _identity()
+    loader = MXCheckpointLoader.__new__(MXCheckpointLoader)
+    loader._mx_server_url = "http://mx:8001"
+    loader._model_name = None
+
+    class _Client:
+        def __init__(self, *, server_url):
+            self.server_url = server_url
+
+        def list_sources(self, *, identity):
+            instance = SimpleNamespace(metadata=_build_mx_source_metadata(source))
+            return SimpleNamespace(instances=[instance])
+
+    assert loader._fetch_source_identity("ckpt", _Client, lambda **_kw: object()) == source
 
 
 def test_load_weights_pops_source_identity_kwarg():


### PR DESCRIPTION
## Summary

Stacked on Wave 4 / #15387.

This implements Wave 5 of the staged post-load hook rollout for MX:

- publish MX sources after post-load transforms with SourceIdentity and transform-layout metadata
- let compatible, allow-listed Llama receivers consume post-transform MX bytes and run only `setup_aliases()` + `cache_derived_state()`
- fail closed before P2P when SourceIdentity is missing/mismatched, transform protocol metadata is unsupported, or the model is not allow-listed
- add unit coverage for metadata fallback cases, publish metadata, GMS/MX post-load publish ordering, and a tiny real-Llama staged receiver equivalence check

## Dependency / prerequisite stack

This PR is Wave 5 in the staged post-load hooks rollout. The foundation PRs #14770 and #14878 are already merged. The wave PRs should merge in sequence; after each upstream wave lands, rebase the next wave onto `main` so review and CI focus on that wave's delta.

Arrows point from prerequisite to dependent. PR numbers in graph nodes are clickable.

```mermaid
graph TD
    PR14770["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/14770'>#14770</a>: staged-hook contract (merged)"]
    PR14878["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/14878'>#14878</a>: GMS SourceIdentity gate (merged)"]
    PR15014["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15014'>#15014</a>: Wave 1 aliases + GMS RO load (merged)"]
    PR15288["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15288'>#15288</a>: Wave 2 Linear/Attention transforms (merged)"]
    PR15386["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15386'>#15386</a>: Wave 3 MoE/Mamba staged hooks (open)"]
    PR15387["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15387'>#15387</a>: Wave 4 MX receiver cutover (open)"]
    PR15432["<a href='https://github.com/NVIDIA/TensorRT-LLM/pull/15432'>#15432</a>: Wave 5 MX publisher + Llama receiver (this PR, open)"]
    VERIFY["post-migration verification / demo (planned)"]

    PR14770 -->|satisfied| PR15014
    PR14878 -->|satisfied| PR15014
    PR15014 -->|blocking| PR15288
    PR15288 -->|blocking| PR15386
    PR15386 -->|blocking| PR15387
    PR15387 -->|blocking| PR15432
    PR15432 -.->|planned| VERIFY

    classDef merged fill:#dcfce7,stroke:#16a34a,color:#14532d;
    classDef open fill:#dbeafe,stroke:#2563eb,color:#1e3a8a;
    classDef current fill:#ede9fe,stroke:#7c3aed,color:#3b0764,stroke-width:3px;
    classDef downstream fill:#f3f4f6,stroke:#6b7280,color:#374151,stroke-dasharray:5 5;
    linkStyle 0,1 stroke:#16a34a,stroke-width:2px;
    linkStyle 2,3,4,5 stroke:#ea580c,stroke-width:3px;
    linkStyle 6 stroke:#6b7280,stroke-width:2px,stroke-dasharray:5 5;

    class PR14770,PR14878,PR15014,PR15288 merged;
    class PR15386,PR15387 open;
    class PR15432 current;
    class VERIFY downstream;
```

Immediate merge dependency for this PR: #15387 must land first; after Wave 5 lands, run the post-migration verification/demo for the completed staged-hook rollout.

## Validation

- `git diff --check`
- `python -m py_compile tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py tensorrt_llm/_torch/pyexecutor/model_loader.py tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py tests/unittest/_torch/pyexecutor/test_model_loader_gms.py tests/unittest/_torch/pyexecutor/test_model_loader_mx.py tests/unittest/_torch/weight_sharing/test_mx_source_identity_gate.py`
- pre-commit on commit, with `waive list check` and `validate-test-lists` skipped locally because `scripts/check_test_list.py` fails under this hook interpreter with `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'`

Focused pytest collection is blocked in this local environment by missing `transformers` before tests are collected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for staged post-transform weight transfers with source identity verification in ModelExpress transfers.
  * Introduced source identity gating to validate weight compatibility across distributed systems.

* **Improvements**
  * Refactored weight transformation pipeline to separate weight transformation and state caching phases for improved clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->