### PR TITLE
[#15344][fix] Add SM121 MLA cache reuse support

### DIFF
--- a/docs/source/models/supported-models.md
+++ b/docs/source/models/supported-models.md
@@ -80,7 +80,7 @@ Note: Support for other models may vary. Features marked "N/A" are not applicabl
 | `Step3p7ForConditionalGeneration`| Yes               | Yes        | Yes                        | Untested              | Untested        | Yes | No               | No                | No     | Yes           | Untested         | Untested       | Yes                      | Untested              | Untested        |
 | `MiniMaxM3SparseForConditionalGeneration` [^12] | Yes               | Yes        | Yes                        | Untested              | Untested        | No  | No               | No                | No     | Yes           | Untested         | No             | N/A                      | Untested              | Untested        |
 
-[^1]: Chunked Prefill for MLA can only be enabled on SM90/SM100/SM103/SM120/SM121.
+[^1]: Chunked Prefill for MLA can only be enabled on SM90/SM100/SM103/SM120.
 [^2]: KV cache reuse for MLA can only be enabled on SM90/SM100/SM103/SM120/SM121 and in BF16/FP8 KV cache dtype.
 [^3]: Qwen3-Next-80B-A3B exhibits relatively low accuracy on the SciCode-AA-v2 benchmark.
 [^5]: Supported via the [AutoDeploy](../features/auto_deploy/auto-deploy.md) backend. See [AD Configs](../../../examples/auto_deploy/model_registry/configs).

--- a/docs/source/models/supported-models.md
+++ b/docs/source/models/supported-models.md
@@ -80,8 +80,8 @@ Note: Support for other models may vary. Features marked "N/A" are not applicabl
 | `Step3p7ForConditionalGeneration`| Yes               | Yes        | Yes                        | Untested              | Untested        | Yes | No               | No                | No     | Yes           | Untested         | Untested       | Yes                      | Untested              | Untested        |
 | `MiniMaxM3SparseForConditionalGeneration` [^12] | Yes               | Yes        | Yes                        | Untested              | Untested        | No  | No               | No                | No     | Yes           | Untested         | No             | N/A                      | Untested              | Untested        |
 
-[^1]: Chunked Prefill for MLA can only be enabled on SM100/SM103.
-[^2]: KV cache reuse for MLA can only be enabled on SM90/SM100/SM103 and in BF16/FP8 KV cache dtype.
+[^1]: Chunked Prefill for MLA can only be enabled on SM90/SM100/SM103/SM120/SM121.
+[^2]: KV cache reuse for MLA can only be enabled on SM90/SM100/SM103/SM120/SM121 and in BF16/FP8 KV cache dtype.
 [^3]: Qwen3-Next-80B-A3B exhibits relatively low accuracy on the SciCode-AA-v2 benchmark.
 [^5]: Supported via the [AutoDeploy](../features/auto_deploy/auto-deploy.md) backend. See [AD Configs](../../../examples/auto_deploy/model_registry/configs).
 [^6]: Also supports text-only inference via the [AutoDeploy](../features/auto_deploy/auto-deploy.md) backend.

--- a/examples/models/core/deepseek_v3/README.md
+++ b/examples/models/core/deepseek_v3/README.md
@@ -866,7 +866,7 @@ The converted checkpoint could be used as `<YOUR_MODEL_DIR>` and consumed by oth
 KV cache reuse is supported for MLA on SM90, SM100, SM103, SM120 and SM121. It is enabled by default. Due to extra operations like memcpy and GEMMs, GPU memory consumption may be higher and the E2E performance may have regression in some cases. Users could pass `KvCacheConfig(enable_block_reuse=False)` to LLM API to disable it.
 
 ### Chunked Prefill
-Chunked Prefill is supported for MLA on SM90, SM100, SM103, SM120 and SM121. You should add `--enable_chunked_prefill` to enable it. The GPU memory consumption is highly correlated with `max_num_tokens` and `max_batch_size`. If encountering out-of-memory errors, you may make these values smaller. (`max_num_tokens` must be divisible by kv cache's `tokens_per_block`)
+Chunked Prefill is supported for MLA on SM90, SM100, SM103 and SM120. You should add `--enable_chunked_prefill` to enable it. The GPU memory consumption is highly correlated with `max_num_tokens` and `max_batch_size`. If encountering out-of-memory errors, you may make these values smaller. (`max_num_tokens` must be divisible by kv cache's `tokens_per_block`)
 
 More specifically, we can imitate what we did in the [Quick Start](#quick-start):
 

--- a/examples/models/core/deepseek_v3/README.md
+++ b/examples/models/core/deepseek_v3/README.md
@@ -863,10 +863,10 @@ echo "All processes completed!"
 The converted checkpoint could be used as `<YOUR_MODEL_DIR>` and consumed by other commands.
 
 ### KV Cache Reuse
-KV cache reuse is supported for MLA on SM90, SM100 and SM120. It is enabled by default. Due to extra operations like memcpy and GEMMs, GPU memory consumption may be higher and the E2E performance may have regression in some cases. Users could pass `KvCacheConfig(enable_block_reuse=False)` to LLM API to disable it.
+KV cache reuse is supported for MLA on SM90, SM100, SM103, SM120 and SM121. It is enabled by default. Due to extra operations like memcpy and GEMMs, GPU memory consumption may be higher and the E2E performance may have regression in some cases. Users could pass `KvCacheConfig(enable_block_reuse=False)` to LLM API to disable it.
 
 ### Chunked Prefill
-Chunked Prefill is supported for MLA only on SM90 and SM100 currently. You should add `--enable_chunked_prefill` to enable it. The GPU memory consumption is highly correlated with `max_num_tokens` and `max_batch_size`. If encountering out-of-memory errors, you may make these values smaller. (`max_num_tokens` must be divisible by kv cache's `tokens_per_block`)
+Chunked Prefill is supported for MLA on SM90, SM100, SM103, SM120 and SM121. You should add `--enable_chunked_prefill` to enable it. The GPU memory consumption is highly correlated with `max_num_tokens` and `max_batch_size`. If encountering out-of-memory errors, you may make these values smaller. (`max_num_tokens` must be divisible by kv cache's `tokens_per_block`)
 
 More specifically, we can imitate what we did in the [Quick Start](#quick-start):
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -48,6 +48,10 @@ from .model_engine import PyTorchModelEngine
 from .model_loader import ModelLoader, _construct_checkpoint_loader
 from .py_executor import PyExecutor
 
+_MLA_SUPPORTED_SM_VERSIONS = (90, 100, 103, 120, 121)
+_MLA_SUPPORTED_SM_VERSIONS_STR = "/".join(
+    f"SM{sm_version}" for sm_version in _MLA_SUPPORTED_SM_VERSIONS)
+
 
 class _ExecutorMemoryMonitor:
     """Currently this focuses on tracking memory usage and related errors."""
@@ -704,11 +708,10 @@ def create_py_executor(
             )
 
         sm_version = get_sm_version()
-        if kv_cache_config.enable_block_reuse and sm_version not in [
-                90, 100, 103, 120, 121
-        ]:
+        if (kv_cache_config.enable_block_reuse
+                and sm_version not in _MLA_SUPPORTED_SM_VERSIONS):
             logger.warning(
-                f"KV cache reuse for MLA can only be enabled on SM90/SM100/SM103/SM120/SM121, "
+                f"KV cache reuse for MLA can only be enabled on {_MLA_SUPPORTED_SM_VERSIONS_STR}, "
                 f"disable enable_block_reuse for SM{sm_version}")
             kv_cache_config.enable_block_reuse = False
             _set_model_engines_cache_reuse([model_engine, draft_model_engine],
@@ -725,11 +728,10 @@ def create_py_executor(
             kv_cache_config.enable_block_reuse = False
             _set_model_engines_cache_reuse([model_engine, draft_model_engine],
                                            False)
-        if enable_chunked_context and sm_version not in [
-                90, 100, 103, 120, 121
-        ]:
+        if (enable_chunked_context
+                and sm_version not in _MLA_SUPPORTED_SM_VERSIONS):
             logger.warning(
-                "Chunked Prefill for MLA can only be enabled on SM90/SM100/SM103/SM120/SM121, "
+                f"Chunked Prefill for MLA can only be enabled on {_MLA_SUPPORTED_SM_VERSIONS_STR}, "
                 f"disable enable_chunked_context for SM{sm_version}")
             enable_chunked_context = False
             model_engine.attn_runtime_features.chunked_prefill = False

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -725,7 +725,9 @@ def create_py_executor(
             kv_cache_config.enable_block_reuse = False
             _set_model_engines_cache_reuse([model_engine, draft_model_engine],
                                            False)
-        if enable_chunked_context and sm_version not in [90, 100, 103, 120, 121]:
+        if enable_chunked_context and sm_version not in [
+                90, 100, 103, 120, 121
+        ]:
             logger.warning(
                 "Chunked Prefill for MLA can only be enabled on SM90/SM100/SM103/SM120/SM121, "
                 f"disable enable_chunked_context for SM{sm_version}")

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -48,9 +48,14 @@ from .model_engine import PyTorchModelEngine
 from .model_loader import ModelLoader, _construct_checkpoint_loader
 from .py_executor import PyExecutor
 
-_MLA_SUPPORTED_SM_VERSIONS = (90, 100, 103, 120, 121)
-_MLA_SUPPORTED_SM_VERSIONS_STR = "/".join(
-    f"SM{sm_version}" for sm_version in _MLA_SUPPORTED_SM_VERSIONS)
+_MLA_KV_CACHE_REUSE_SUPPORTED_SM_VERSIONS = (90, 100, 103, 120, 121)
+_MLA_CHUNKED_PREFILL_SUPPORTED_SM_VERSIONS = (90, 100, 103, 120)
+_MLA_KV_CACHE_REUSE_SUPPORTED_SM_VERSIONS_STR = "/".join(
+    f"SM{sm_version}"
+    for sm_version in _MLA_KV_CACHE_REUSE_SUPPORTED_SM_VERSIONS)
+_MLA_CHUNKED_PREFILL_SUPPORTED_SM_VERSIONS_STR = "/".join(
+    f"SM{sm_version}"
+    for sm_version in _MLA_CHUNKED_PREFILL_SUPPORTED_SM_VERSIONS)
 
 
 class _ExecutorMemoryMonitor:
@@ -708,11 +713,11 @@ def create_py_executor(
             )
 
         sm_version = get_sm_version()
-        if (kv_cache_config.enable_block_reuse
-                and sm_version not in _MLA_SUPPORTED_SM_VERSIONS):
-            logger.warning(
-                f"KV cache reuse for MLA can only be enabled on {_MLA_SUPPORTED_SM_VERSIONS_STR}, "
-                f"disable enable_block_reuse for SM{sm_version}")
+        if (kv_cache_config.enable_block_reuse and sm_version
+                not in _MLA_KV_CACHE_REUSE_SUPPORTED_SM_VERSIONS):
+            logger.warning("KV cache reuse for MLA can only be enabled on "
+                           f"{_MLA_KV_CACHE_REUSE_SUPPORTED_SM_VERSIONS_STR}, "
+                           f"disable enable_block_reuse for SM{sm_version}")
             kv_cache_config.enable_block_reuse = False
             _set_model_engines_cache_reuse([model_engine, draft_model_engine],
                                            False)
@@ -728,11 +733,11 @@ def create_py_executor(
             kv_cache_config.enable_block_reuse = False
             _set_model_engines_cache_reuse([model_engine, draft_model_engine],
                                            False)
-        if (enable_chunked_context
-                and sm_version not in _MLA_SUPPORTED_SM_VERSIONS):
-            logger.warning(
-                f"Chunked Prefill for MLA can only be enabled on {_MLA_SUPPORTED_SM_VERSIONS_STR}, "
-                f"disable enable_chunked_context for SM{sm_version}")
+        if (enable_chunked_context and sm_version
+                not in _MLA_CHUNKED_PREFILL_SUPPORTED_SM_VERSIONS):
+            logger.warning("Chunked Prefill for MLA can only be enabled on "
+                           f"{_MLA_CHUNKED_PREFILL_SUPPORTED_SM_VERSIONS_STR}, "
+                           f"disable enable_chunked_context for SM{sm_version}")
             enable_chunked_context = False
             model_engine.attn_runtime_features.chunked_prefill = False
             if draft_model_engine is not None:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -705,10 +705,10 @@ def create_py_executor(
 
         sm_version = get_sm_version()
         if kv_cache_config.enable_block_reuse and sm_version not in [
-                90, 100, 103, 120
+                90, 100, 103, 120, 121
         ]:
             logger.warning(
-                f"KV cache reuse for MLA can only be enabled on SM90/SM100/SM103/SM120, "
+                f"KV cache reuse for MLA can only be enabled on SM90/SM100/SM103/SM120/SM121, "
                 f"disable enable_block_reuse for SM{sm_version}")
             kv_cache_config.enable_block_reuse = False
             _set_model_engines_cache_reuse([model_engine, draft_model_engine],
@@ -725,9 +725,9 @@ def create_py_executor(
             kv_cache_config.enable_block_reuse = False
             _set_model_engines_cache_reuse([model_engine, draft_model_engine],
                                            False)
-        if enable_chunked_context and sm_version not in [90, 100, 103, 120]:
+        if enable_chunked_context and sm_version not in [90, 100, 103, 120, 121]:
             logger.warning(
-                "Chunked Prefill for MLA can only be enabled on SM90/SM100/SM103/SM120, "
+                "Chunked Prefill for MLA can only be enabled on SM90/SM100/SM103/SM120/SM121, "
                 f"disable enable_chunked_context for SM{sm_version}")
             enable_chunked_context = False
             model_engine.attn_runtime_features.chunked_prefill = False

--- a/tests/unittest/_torch/executor/test_py_executor_creator_mla_cache_reuse_sync.py
+++ b/tests/unittest/_torch/executor/test_py_executor_creator_mla_cache_reuse_sync.py
@@ -15,9 +15,14 @@
 
 from types import SimpleNamespace
 
+import pytest
+
 from tensorrt_llm._torch.pyexecutor import py_executor_creator
 from tensorrt_llm._torch.pyexecutor.resource_manager import ResourceManagerType
 from tensorrt_llm.quantization import QuantAlgo
+
+
+_MLA_SUPPORTED_SM_VERSIONS = [90, 100, 103, 120, 121]
 
 
 class _DummyCalibrator:
@@ -323,40 +328,20 @@ def test_mla_unsupported_kv_quant_fallback_syncs_cache_reuse(monkeypatch):
     assert runtime_cache_reuse is False
 
 
-def test_mla_supported_configuration_preserves_cache_reuse(monkeypatch):
-    """Verify MLA supported configuration preserves cache reuse in both config and runtime.
+@pytest.mark.parametrize("sm_version", _MLA_SUPPORTED_SM_VERSIONS)
+def test_mla_supported_configuration_preserves_cache_reuse(
+    monkeypatch, sm_version
+):
+    """Verify every supported MLA SM preserves cache reuse in both config and runtime.
 
-    When both SM version (90) and KV quantization (NO_QUANT) are supported for MLA,
-    no fallback occurs and:
-    - kv_cache_config.enable_block_reuse remains True
-    - model_engine.attn_runtime_features.cache_reuse remains True
-
-    This positive test ensures the default path does not regress.
-    """
-    kv_cache_reuse, runtime_cache_reuse, _ = _run_create_py_executor(
-        monkeypatch,
-        sm_version=90,
-        kv_cache_quant_algo=QuantAlgo.NO_QUANT,
-    )
-
-    assert kv_cache_reuse is True
-    assert runtime_cache_reuse is True
-
-
-def test_mla_sm121_supported_configuration_preserves_cache_reuse(monkeypatch):
-    """Verify MLA support on SM121 preserves cache reuse in both config and runtime.
-
-    When SM121 is treated as a supported MLA architecture and KV quantization is
+    When the SM version is in the MLA allowlist and KV quantization is
     NO_QUANT, no unsupported-SM fallback should occur and:
     - kv_cache_config.enable_block_reuse remains True
     - model_engine.attn_runtime_features.cache_reuse remains True
-
-    This regression test protects the SM121 allowlist expansion added for MLA
-    cache reuse support.
     """
     kv_cache_reuse, runtime_cache_reuse, _ = _run_create_py_executor(
         monkeypatch,
-        sm_version=121,
+        sm_version=sm_version,
         kv_cache_quant_algo=QuantAlgo.NO_QUANT,
     )
 
@@ -364,15 +349,14 @@ def test_mla_sm121_supported_configuration_preserves_cache_reuse(monkeypatch):
     assert runtime_cache_reuse is True
 
 
-def test_mla_sm121_supported_configuration_preserves_chunked_prefill(monkeypatch):
-    """Verify MLA support on SM121 preserves chunked prefill when it is requested.
-
-    When SM121 is treated as a supported MLA architecture and chunked prefill is
-    enabled, the unsupported-SM fallback should not disable the runtime feature.
-    """
+@pytest.mark.parametrize("sm_version", _MLA_SUPPORTED_SM_VERSIONS)
+def test_mla_supported_configuration_preserves_chunked_prefill(
+    monkeypatch, sm_version
+):
+    """Verify every supported MLA SM preserves chunked prefill when requested."""
     _, _, runtime_chunked_prefill = _run_create_py_executor(
         monkeypatch,
-        sm_version=121,
+        sm_version=sm_version,
         kv_cache_quant_algo=QuantAlgo.NO_QUANT,
         enable_chunked_prefill=True,
     )

--- a/tests/unittest/_torch/executor/test_py_executor_creator_mla_cache_reuse_sync.py
+++ b/tests/unittest/_torch/executor/test_py_executor_creator_mla_cache_reuse_sync.py
@@ -184,8 +184,12 @@ def _make_llm_args():
     )
 
 
-def _run_create_py_executor(monkeypatch, *, sm_version, kv_cache_quant_algo):
-    """Execute create_py_executor with mocked dependencies and return cache reuse flags.
+def _run_create_py_executor(monkeypatch,
+                            *,
+                            sm_version,
+                            kv_cache_quant_algo,
+                            enable_chunked_prefill=False):
+    """Execute create_py_executor with mocked dependencies and return MLA runtime flags.
 
     Mocks all external dependencies (model engine, resource managers, etc.) to isolate
     executor creation logic and verify that KV cache reuse configuration is synchronized
@@ -195,11 +199,14 @@ def _run_create_py_executor(monkeypatch, *, sm_version, kv_cache_quant_algo):
         monkeypatch: pytest fixture for mocking.
         sm_version: CUDA SM version to simulate (e.g., 89, 90).
         kv_cache_quant_algo: Quantization algorithm to use (e.g., NO_QUANT, INT8).
+        enable_chunked_prefill: Whether to request MLA chunked prefill support.
 
     Returns:
-        Tuple of (kv_cache_reuse_flag, runtime_cache_reuse_flag) from created executor.
+        Tuple of (kv_cache_reuse_flag, runtime_cache_reuse_flag,
+        runtime_chunked_prefill_flag) from created executor.
     """
     llm_args = _make_llm_args()
+    llm_args.enable_chunked_prefill = enable_chunked_prefill
     fake_mapping = SimpleNamespace(
         rank=0,
         tp_size=1,
@@ -275,6 +282,7 @@ def _run_create_py_executor(monkeypatch, *, sm_version, kv_cache_quant_algo):
     return (
         kv_cache_manager.enable_block_reuse,
         py_executor.model_engine.attn_runtime_features.cache_reuse,
+        py_executor.model_engine.attn_runtime_features.chunked_prefill,
     )
 
 
@@ -287,7 +295,7 @@ def test_mla_unsupported_sm_fallback_syncs_cache_reuse(monkeypatch):
 
     This test ensures invariant synchronization is maintained across the fallback.
     """
-    kv_cache_reuse, runtime_cache_reuse = _run_create_py_executor(
+    kv_cache_reuse, runtime_cache_reuse, _ = _run_create_py_executor(
         monkeypatch,
         sm_version=89,
         kv_cache_quant_algo=QuantAlgo.NO_QUANT,
@@ -307,7 +315,7 @@ def test_mla_unsupported_kv_quant_fallback_syncs_cache_reuse(monkeypatch):
 
     This test ensures invariant synchronization is maintained across the fallback.
     """
-    kv_cache_reuse, runtime_cache_reuse = _run_create_py_executor(
+    kv_cache_reuse, runtime_cache_reuse, _ = _run_create_py_executor(
         monkeypatch,
         sm_version=90,
         kv_cache_quant_algo=QuantAlgo.INT8,
@@ -327,7 +335,7 @@ def test_mla_supported_configuration_preserves_cache_reuse(monkeypatch):
 
     This positive test ensures the default path does not regress.
     """
-    kv_cache_reuse, runtime_cache_reuse = _run_create_py_executor(
+    kv_cache_reuse, runtime_cache_reuse, _ = _run_create_py_executor(
         monkeypatch,
         sm_version=90,
         kv_cache_quant_algo=QuantAlgo.NO_QUANT,
@@ -348,7 +356,7 @@ def test_mla_sm121_supported_configuration_preserves_cache_reuse(monkeypatch):
     This regression test protects the SM121 allowlist expansion added for MLA
     cache reuse support.
     """
-    kv_cache_reuse, runtime_cache_reuse = _run_create_py_executor(
+    kv_cache_reuse, runtime_cache_reuse, _ = _run_create_py_executor(
         monkeypatch,
         sm_version=121,
         kv_cache_quant_algo=QuantAlgo.NO_QUANT,
@@ -356,3 +364,19 @@ def test_mla_sm121_supported_configuration_preserves_cache_reuse(monkeypatch):
 
     assert kv_cache_reuse is True
     assert runtime_cache_reuse is True
+
+
+def test_mla_sm121_supported_configuration_preserves_chunked_prefill(monkeypatch):
+    """Verify MLA support on SM121 preserves chunked prefill when it is requested.
+
+    When SM121 is treated as a supported MLA architecture and chunked prefill is
+    enabled, the unsupported-SM fallback should not disable the runtime feature.
+    """
+    _, _, runtime_chunked_prefill = _run_create_py_executor(
+        monkeypatch,
+        sm_version=121,
+        kv_cache_quant_algo=QuantAlgo.NO_QUANT,
+        enable_chunked_prefill=True,
+    )
+
+    assert runtime_chunked_prefill is True

--- a/tests/unittest/_torch/executor/test_py_executor_creator_mla_cache_reuse_sync.py
+++ b/tests/unittest/_torch/executor/test_py_executor_creator_mla_cache_reuse_sync.py
@@ -18,10 +18,11 @@ from types import SimpleNamespace
 import pytest
 
 from tensorrt_llm._torch.pyexecutor import py_executor_creator
+from tensorrt_llm._torch.pyexecutor.py_executor_creator import (
+    _MLA_SUPPORTED_SM_VERSIONS,
+)
 from tensorrt_llm._torch.pyexecutor.resource_manager import ResourceManagerType
 from tensorrt_llm.quantization import QuantAlgo
-
-_MLA_SUPPORTED_SM_VERSIONS = [90, 100, 103, 120, 121]
 
 
 class _DummyCalibrator:

--- a/tests/unittest/_torch/executor/test_py_executor_creator_mla_cache_reuse_sync.py
+++ b/tests/unittest/_torch/executor/test_py_executor_creator_mla_cache_reuse_sync.py
@@ -335,3 +335,24 @@ def test_mla_supported_configuration_preserves_cache_reuse(monkeypatch):
 
     assert kv_cache_reuse is True
     assert runtime_cache_reuse is True
+
+
+def test_mla_sm121_supported_configuration_preserves_cache_reuse(monkeypatch):
+    """Verify MLA support on SM121 preserves cache reuse in both config and runtime.
+
+    When SM121 is treated as a supported MLA architecture and KV quantization is
+    NO_QUANT, no unsupported-SM fallback should occur and:
+    - kv_cache_config.enable_block_reuse remains True
+    - model_engine.attn_runtime_features.cache_reuse remains True
+
+    This regression test protects the SM121 allowlist expansion added for MLA
+    cache reuse support.
+    """
+    kv_cache_reuse, runtime_cache_reuse = _run_create_py_executor(
+        monkeypatch,
+        sm_version=121,
+        kv_cache_quant_algo=QuantAlgo.NO_QUANT,
+    )
+
+    assert kv_cache_reuse is True
+    assert runtime_cache_reuse is True

--- a/tests/unittest/_torch/executor/test_py_executor_creator_mla_cache_reuse_sync.py
+++ b/tests/unittest/_torch/executor/test_py_executor_creator_mla_cache_reuse_sync.py
@@ -21,7 +21,6 @@ from tensorrt_llm._torch.pyexecutor import py_executor_creator
 from tensorrt_llm._torch.pyexecutor.resource_manager import ResourceManagerType
 from tensorrt_llm.quantization import QuantAlgo
 
-
 _MLA_SUPPORTED_SM_VERSIONS = [90, 100, 103, 120, 121]
 
 
@@ -329,9 +328,7 @@ def test_mla_unsupported_kv_quant_fallback_syncs_cache_reuse(monkeypatch):
 
 
 @pytest.mark.parametrize("sm_version", _MLA_SUPPORTED_SM_VERSIONS)
-def test_mla_supported_configuration_preserves_cache_reuse(
-    monkeypatch, sm_version
-):
+def test_mla_supported_configuration_preserves_cache_reuse(monkeypatch, sm_version):
     """Verify every supported MLA SM preserves cache reuse in both config and runtime.
 
     When the SM version is in the MLA allowlist and KV quantization is
@@ -350,9 +347,7 @@ def test_mla_supported_configuration_preserves_cache_reuse(
 
 
 @pytest.mark.parametrize("sm_version", _MLA_SUPPORTED_SM_VERSIONS)
-def test_mla_supported_configuration_preserves_chunked_prefill(
-    monkeypatch, sm_version
-):
+def test_mla_supported_configuration_preserves_chunked_prefill(monkeypatch, sm_version):
     """Verify every supported MLA SM preserves chunked prefill when requested."""
     _, _, runtime_chunked_prefill = _run_create_py_executor(
         monkeypatch,

--- a/tests/unittest/_torch/executor/test_py_executor_creator_mla_cache_reuse_sync.py
+++ b/tests/unittest/_torch/executor/test_py_executor_creator_mla_cache_reuse_sync.py
@@ -18,9 +18,7 @@ from types import SimpleNamespace
 import pytest
 
 from tensorrt_llm._torch.pyexecutor import py_executor_creator
-from tensorrt_llm._torch.pyexecutor.py_executor_creator import (
-    _MLA_SUPPORTED_SM_VERSIONS,
-)
+from tensorrt_llm._torch.pyexecutor.py_executor_creator import _MLA_SUPPORTED_SM_VERSIONS
 from tensorrt_llm._torch.pyexecutor.resource_manager import ResourceManagerType
 from tensorrt_llm.quantization import QuantAlgo
 

--- a/tests/unittest/_torch/executor/test_py_executor_creator_mla_cache_reuse_sync.py
+++ b/tests/unittest/_torch/executor/test_py_executor_creator_mla_cache_reuse_sync.py
@@ -184,11 +184,9 @@ def _make_llm_args():
     )
 
 
-def _run_create_py_executor(monkeypatch,
-                            *,
-                            sm_version,
-                            kv_cache_quant_algo,
-                            enable_chunked_prefill=False):
+def _run_create_py_executor(
+    monkeypatch, *, sm_version, kv_cache_quant_algo, enable_chunked_prefill=False
+):
     """Execute create_py_executor with mocked dependencies and return MLA runtime flags.
 
     Mocks all external dependencies (model engine, resource managers, etc.) to isolate

--- a/tests/unittest/_torch/executor/test_py_executor_creator_mla_cache_reuse_sync.py
+++ b/tests/unittest/_torch/executor/test_py_executor_creator_mla_cache_reuse_sync.py
@@ -18,7 +18,10 @@ from types import SimpleNamespace
 import pytest
 
 from tensorrt_llm._torch.pyexecutor import py_executor_creator
-from tensorrt_llm._torch.pyexecutor.py_executor_creator import _MLA_SUPPORTED_SM_VERSIONS
+from tensorrt_llm._torch.pyexecutor.py_executor_creator import (
+    _MLA_CHUNKED_PREFILL_SUPPORTED_SM_VERSIONS,
+    _MLA_KV_CACHE_REUSE_SUPPORTED_SM_VERSIONS,
+)
 from tensorrt_llm._torch.pyexecutor.resource_manager import ResourceManagerType
 from tensorrt_llm.quantization import QuantAlgo
 
@@ -326,7 +329,7 @@ def test_mla_unsupported_kv_quant_fallback_syncs_cache_reuse(monkeypatch):
     assert runtime_cache_reuse is False
 
 
-@pytest.mark.parametrize("sm_version", _MLA_SUPPORTED_SM_VERSIONS)
+@pytest.mark.parametrize("sm_version", _MLA_KV_CACHE_REUSE_SUPPORTED_SM_VERSIONS)
 def test_mla_supported_configuration_preserves_cache_reuse(monkeypatch, sm_version):
     """Verify every supported MLA SM preserves cache reuse in both config and runtime.
 
@@ -345,7 +348,7 @@ def test_mla_supported_configuration_preserves_cache_reuse(monkeypatch, sm_versi
     assert runtime_cache_reuse is True
 
 
-@pytest.mark.parametrize("sm_version", _MLA_SUPPORTED_SM_VERSIONS)
+@pytest.mark.parametrize("sm_version", _MLA_CHUNKED_PREFILL_SUPPORTED_SM_VERSIONS)
 def test_mla_supported_configuration_preserves_chunked_prefill(monkeypatch, sm_version):
     """Verify every supported MLA SM preserves chunked prefill when requested."""
     _, _, runtime_chunked_prefill = _run_create_py_executor(
@@ -356,3 +359,19 @@ def test_mla_supported_configuration_preserves_chunked_prefill(monkeypatch, sm_v
     )
 
     assert runtime_chunked_prefill is True
+
+
+def test_mla_sm121_fallback_preserves_cache_reuse_and_disables_chunked_prefill(
+    monkeypatch,
+):
+    """Verify SM121 keeps cache reuse while disabling unsupported chunked prefill."""
+    kv_cache_reuse, runtime_cache_reuse, runtime_chunked_prefill = _run_create_py_executor(
+        monkeypatch,
+        sm_version=121,
+        kv_cache_quant_algo=QuantAlgo.NO_QUANT,
+        enable_chunked_prefill=True,
+    )
+
+    assert kv_cache_reuse is True
+    assert runtime_cache_reuse is True
+    assert runtime_chunked_prefill is False


### PR DESCRIPTION
## Description

SM121 supports MLA KV cache reuse, but MLA chunked prefill remains unsupported. The prior shared allowlist enabled both features on SM121.

This update separates the support checks:
- KV cache reuse: SM90/SM100/SM103/SM120/SM121
- Chunked prefill: SM90/SM100/SM103/SM120

On SM121, a chunked-prefill request now follows the existing fallback and disables only chunked prefill. KV cache reuse remains enabled. The supported-model and DeepSeek V3 documentation now use the same split.

## Test Coverage

- `git diff --check upstream/main...HEAD`
- `python3 -m py_compile tensorrt_llm/_torch/pyexecutor/py_executor_creator.py tests/unittest/_torch/executor/test_py_executor_creator_mla_cache_reuse_sync.py`
- Added a regression that checks SM121 preserves cache reuse while disabling chunked prefill.
- Tried the focused pytest module. Test collection stops before execution because the available environment does not include PyTorch.

## PR Checklist

- [x] Please check this after reviewing the above items as appropriate for this PR.