### PR TITLE
[None][fix] bound weight-load CPU parallelism by node topology

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -12,7 +12,7 @@ from torch.utils._python_dispatch import TorchDispatchMode
 from torch.utils._pytree import tree_any_only
 from tqdm import tqdm
 
-from tensorrt_llm._utils import local_mpi_rank
+from tensorrt_llm._utils import local_mpi_rank, local_mpi_size
 from tensorrt_llm.lora_manager import HfLoraLoader
 from tensorrt_llm.models.convert_utils import split_matrix_tp
 
@@ -914,6 +914,10 @@ def filter_weights(prefix, weights: Dict):
     return result
 
 
+# Per-rank weight-load pool size; small to cap simultaneous (multi-GB) transforms.
+_DEFAULT_LOAD_WORKERS = 4
+
+
 def run_concurrently(func,
                      args_list,
                      reduce_func=None,
@@ -925,29 +929,62 @@ def run_concurrently(func,
     args_list: a list of tuples of arguments for the function.
     reduce_func: an optional function to reduce the results.
     pbar: an optional tqdm progress bar.
+    num_workers: thread-pool size; when None, derived from this rank's core share.
+
+    Weight-load tasks run OpenMP-parallel ATen ops (e.g. .contiguous() on fused
+    MoE tensors); with several ranks per node, an unbounded pool x all-core
+    intra-op threads oversubscribes the CPU and can stall loading / exhaust host
+    RAM. Bound both to this rank's share (cores // local_ranks).
     """
     from concurrent import futures
-    with futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
-        # Submit all tasks
-        future_to_result = {
-            executor.submit(func, *arg): arg
-            for arg in args_list
-        }
 
-        # Process completed tasks as they finish
-        for result in futures.as_completed(future_to_result):
-            arg = future_to_result[result]
-            try:
-                part_weights = result.result()
-                if reduce_func:
-                    reduce_func(part_weights)
-                if pbar:
-                    pbar.update(1)
-            except Exception as e:
-                logger.error(
-                    f"Error executing {func.__name__} with args {arg}: {str(e)}"
-                )
-                raise
+    # This rank's fair share of cores (honors cgroup/affinity).
+    try:
+        available_cpus = len(os.sched_getaffinity(0))
+    except (AttributeError, OSError):
+        available_cpus = os.cpu_count() or 1
+    local_ranks = max(1, local_mpi_size())
+    per_rank_cores = max(1, available_cpus // local_ranks)
+
+    if num_workers is None:
+        num_workers = min(_DEFAULT_LOAD_WORKERS, per_rank_cores)
+    if num_workers < 1:
+        raise ValueError(
+            f"num_workers must be a positive integer, got {num_workers}")
+
+    # Split that budget across workers; honor user OMP_NUM_THREADS, restore after.
+    restore_num_threads = None
+    if "OMP_NUM_THREADS" not in os.environ:
+        intra_op_threads = max(1, per_rank_cores // num_workers)
+        if intra_op_threads != torch.get_num_threads():
+            restore_num_threads = torch.get_num_threads()
+            torch.set_num_threads(intra_op_threads)
+
+    try:
+        with futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
+            # Submit all tasks
+            future_to_result = {
+                executor.submit(func, *arg): arg
+                for arg in args_list
+            }
+
+            # Process completed tasks as they finish
+            for result in futures.as_completed(future_to_result):
+                arg = future_to_result[result]
+                try:
+                    part_weights = result.result()
+                    if reduce_func:
+                        reduce_func(part_weights)
+                    if pbar:
+                        pbar.update(1)
+                except Exception as e:
+                    logger.error(
+                        f"Error executing {func.__name__} with args {arg}: {e!s}"
+                    )
+                    raise
+    finally:
+        if restore_num_threads is not None:
+            torch.set_num_threads(restore_num_threads)
 
 
 def _load_weights_impl(model: Union[nn.Module, DecoderModelForCausalLM],

--- a/tests/unittest/_torch/test_run_concurrently.py
+++ b/tests/unittest/_torch/test_run_concurrently.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for run_concurrently's CPU-thread / pool bounding.
+
+run_concurrently must not oversubscribe the host CPU when multiple ranks are
+co-located on one node: it bounds both the worker-pool size and the per-op
+intra-op thread count to this rank's fair share of cores, and restores the
+process-wide thread count afterwards.
+"""
+
+import os
+from unittest import mock
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.models import modeling_utils
+
+
+def _available_cpus():
+    try:
+        return len(os.sched_getaffinity(0))
+    except (AttributeError, OSError):
+        return os.cpu_count() or 1
+
+
+@pytest.fixture(autouse=True)
+def _restore_thread_state():
+    original = torch.get_num_threads()
+    yield
+    torch.set_num_threads(original)
+
+
+def test_bounds_intra_op_threads_to_per_rank_share(monkeypatch):
+    """With N co-located ranks, intra-op threads during tasks must not exceed
+    this rank's core share (cores // N)."""
+    monkeypatch.delenv("OMP_NUM_THREADS", raising=False)
+    before = torch.get_num_threads()
+    observed = []
+
+    def task(x):
+        observed.append(torch.get_num_threads())
+        return x
+
+    with mock.patch.object(modeling_utils, "local_mpi_size", return_value=8):
+        modeling_utils.run_concurrently(task, [(i,) for i in range(16)])
+
+    per_rank = max(1, _available_cpus() // 8)
+    assert observed, "task was never executed"
+    assert max(observed) <= per_rank
+    # Thread count is restored after the call.
+    assert torch.get_num_threads() == before
+
+
+def test_respects_user_omp_num_threads(monkeypatch):
+    """An explicit user OMP_NUM_THREADS must not be overridden."""
+    monkeypatch.setenv("OMP_NUM_THREADS", "5")
+    torch.set_num_threads(5)
+    observed = []
+
+    with mock.patch.object(modeling_utils, "local_mpi_size", return_value=8):
+        modeling_utils.run_concurrently(
+            lambda x: observed.append(torch.get_num_threads()), [(i,) for i in range(4)]
+        )
+
+    assert observed and all(t == 5 for t in observed)
+    assert torch.get_num_threads() == 5
+
+
+def test_results_are_reduced_and_complete():
+    """Functional check: every task runs and reduce_func sees every result."""
+    seen = []
+    with mock.patch.object(modeling_utils, "local_mpi_size", return_value=1):
+        modeling_utils.run_concurrently(
+            lambda x: x * 2, [(i,) for i in range(32)], reduce_func=lambda r: seen.append(r)
+        )
+    assert sorted(seen) == [i * 2 for i in range(32)]
+
+
+def test_restores_thread_count_when_task_raises(monkeypatch):
+    """The process-wide thread count is restored even if a task raises."""
+    monkeypatch.delenv("OMP_NUM_THREADS", raising=False)
+    before = torch.get_num_threads()
+
+    def boom(x):
+        raise RuntimeError("boom")
+
+    with mock.patch.object(modeling_utils, "local_mpi_size", return_value=8):
+        with pytest.raises(RuntimeError, match="boom"):
+            modeling_utils.run_concurrently(boom, [(1,)])
+
+    assert torch.get_num_threads() == before
+
+
+def test_rejects_non_positive_num_workers():
+    """An explicit non-positive num_workers is rejected with a clear error."""
+    with mock.patch.object(modeling_utils, "local_mpi_size", return_value=1):
+        with pytest.raises(ValueError, match="num_workers"):
+            modeling_utils.run_concurrently(lambda x: x, [(1,)], num_workers=0)


### PR DESCRIPTION
## Motivation
Loading large models on a high-core node with several ranks co-located (e.g. TP8 on a 192-core host) can stall during weight loading and drive host RAM toward OOM.
Reported in #15296 for Qwen3.5-397B-A17B (bf16) on 8×H200.

## Root cause (corrected vs the #15296 hypothesis)
The original report attributed it to non-mmap `load_file` / missing `mark_consumed`. Investigation (py-spy on the wedged ranks + `top` + a gc storage-census) shows otherwise:
- Weights **do** reach GPU fine (meta-init; ~108 GB/rank); the source dict is mmap-backed (~0.9 GB anon). No checkpoint copies accumulate on host.
- The real cause is **CPU thread oversubscription** in `run_concurrently`: an unbounded thread pool (CPython default `min(32, cpu+4)`) × full-core OpenMP intra-op threads per `.contiguous()` × `local_ranks` ≈ tens of thousands of
  threads on a 192-core node. It deterministically wedges at the first heavy MoE layer; the ~1.8 TB host-RAM growth is a *symptom* of the stall (in-flight scratch buffers piling up), not retained weights.

## Change
Bound both the worker-pool size and the per-op intra-op thread count in `run_concurrently` to this rank's fair share of cores (`cores // local_ranks`), so `local_ranks × pool × intra_op ≈ cores` and concurrent scratch allocations stay small. Honors an explicit user `OMP_NUM_THREADS`; restores the process-wide thread count afterwards.

## Tests
- New unit tests (`tests/unittest/_torch/test_run_concurrently.py`): per-rank thread bound, `OMP_NUM_THREADS` passthrough, functional completeness.
- End-to-end: Qwen3.5-397B-A17B bf16 on 8×H200 now loads (no env vars), serves (`/health` 200), generates, and prefix-caches (`cached_tokens` 0→768 on repeat).
  Pre-fix it wedged at module 887/1749.

## Known follow-up
When a launcher already pins per-rank CPU affinity to a subset, `cores // local_ranks` under-allocates (it divides an already-per-rank set again). Not a correctness issue (just fewer threads); a refinement could use the affinity set directly when it's already constrained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved weight loading concurrency to better manage CPU resources in multi-GPU setups, preventing thread oversubscription and optimizing performance.

* **Tests**
  * Added comprehensive test coverage for weight loading concurrency, including thread management and resource allocation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->