### PR TITLE
[None][test] Remove dis-agg DSv4 accuracy tests from DGX B200/B300 CI

### DIFF
--- a/tests/integration/test_lists/test-db/l0_dgx_b200_ds.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200_ds.yml
@@ -16,13 +16,10 @@ l0_dgx_b200_ds:
       orchestrator: mpi
   tests:
   - unittest/_torch/modeling/test_modeling_deepseekv4.py
-  - accuracy/test_disaggregated_serving.py::TestDeepSeekV4Flash::test_auto_dtype
-  - accuracy/test_disaggregated_serving.py::TestDeepSeekV4Flash::test_gen_first
   # V4-Flash NVFP4 aggregate smoke (TP=4, no EPLB): integration-test mode
   # (1 MMLU sample, no GSM8K reference required). Validates the basic
   # forward path without disagg or EPLB complexity.
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV4Flash::test_auto_dtype TIMEOUT (60)
-  - accuracy/test_disaggregated_serving.py::TestDeepSeekV4FlashBase::test_auto_dtype TIMEOUT (120)
   # ------------- Disaggregated transfer component tests (multi-process) ---------------
   - unittest/disaggregated/test_kv_transfer_mp.py
   # Split test_py_cache_transceiver_mp.py by workflow (4 × 12 = 48 combos).

--- a/tests/integration/test_lists/test-db/l0_dgx_b300_ds.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b300_ds.yml
@@ -16,8 +16,6 @@ l0_dgx_b300_ds:
       backend: pytorch
       orchestrator: mpi
   tests:
-  - accuracy/test_disaggregated_serving.py::TestDeepSeekV4Flash::test_auto_dtype
-  - accuracy/test_disaggregated_serving.py::TestDeepSeekV4Flash::test_gen_first
   - accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_kv_cache_v2_nixl_python
   - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_kv_cache_v2_nixl_python
   - accuracy/test_disaggregated_serving.py::TestGemma3_1BInstruct::test_kv_cache_v2_nixl_python
@@ -37,12 +35,6 @@ l0_dgx_b300_ds:
   # B300's larger per-GPU memory (~288 GB) lets V4 EPLB and FP8 aggregate
   # smoke fit at TP=4. (Same tests at TP=8 would also fit on 8x B200, but a
   # dedicated 8-GPU B200 stage is not currently provisioned.)
-  # V4-Flash-Base FP8 aggregate smoke (TP=4, no EPLB): 1 MMLU sample.
-  # TRTLLMGen FP8 backend selected here: it is the user-facing default on
-  # Blackwell (model_config.py::resolve_moe_backend) and ~7% faster per step
-  # than WIDEEP in our measurements. WIDEEP variant of the same test is
-  # currently held out of CI (see test_auto_dtype[moe_backend=WIDEEP]).
-  - accuracy/test_disaggregated_serving.py::TestDeepSeekV4FlashBase::test_auto_dtype TIMEOUT (120)
   # V4-Flash NVFP4 aggregate smoke (TP=4, no EPLB): 1 MMLU sample.
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV4Flash::test_auto_dtype TIMEOUT (60)
   # V4-Flash-Base FP8 chunked-prefill smoke with FP8 KV cache. Keep

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -2,8 +2,6 @@ accuracy/test_cli_flow.py::TestGptNext::test_auto_dtype SKIP (https://nvbugs/616
 accuracy/test_disaggregated_serving.py::TestDeepSeekV32Exp::test_auto_dtype[False] SKIP (https://nvbugs/6120535)
 accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_gen_first[adp-mtp2] SKIP
 accuracy/test_disaggregated_serving.py::TestDeepSeekV3Lite::test_gen_first[noadp-mtp0] SKIP
-accuracy/test_disaggregated_serving.py::TestDeepSeekV4Flash::test_auto_dtype SKIP (https://nvbugs/6309785)
-accuracy/test_disaggregated_serving.py::TestDeepSeekV4FlashBase::test_auto_dtype SKIP (https://nvbugs/6200572)
 accuracy/test_disaggregated_serving.py::TestGemma3_1BInstruct::test_auto_dtype[False] SKIP (https://nvbugs/6117811)
 accuracy/test_disaggregated_serving.py::TestGemma3_1BInstruct::test_auto_dtype[True] SKIP (https://nvbugs/6117811)
 accuracy/test_disaggregated_serving.py::TestGemma3_1BInstruct::test_kv_cache_v2_nixl_python SKIP (https://nvbugs/6117811)


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

This pull request updates the test lists for DeepSeek V4 Flash and V4 Flash Base models, primarily by removing or unskipping several tests related to `test_auto_dtype` and `test_gen_first`. These changes affect multiple integration test configurations and the waives (skipped tests) list.

**Test List Updates:**

* Removed the following tests from the `l0_dgx_b200_ds.yml` and `l0_dgx_b300_ds.yml` integration test lists:
  - `accuracy/test_disaggregated_serving.py::TestDeepSeekV4Flash::test_auto_dtype`
  - `accuracy/test_disaggregated_serving.py::TestDeepSeekV4Flash::test_gen_first`
  - `accuracy/test_disaggregated_serving.py::TestDeepSeekV4FlashBase::test_auto_dtype` [[1]](diffhunk://#diff-ce859388f99e0694344d55b2e3731bbc12180b16cec061154a38372ac7c56902L19-L25) [[2]](diffhunk://#diff-cc3fbe12bf95e82db01a20286c8b822ffa60edecb6164e3aa1594f9b457512b4L19-L20) [[3]](diffhunk://#diff-cc3fbe12bf95e82db01a20286c8b822ffa60edecb6164e3aa1594f9b457512b4L40-L45)

**Waives List Updates:**

* Removed the following tests from the waives (skipped tests) list, meaning they are no longer explicitly skipped:
  - `accuracy/test_disaggregated_serving.py::TestDeepSeekV4Flash::test_auto_dtype`
  - `accuracy/test_disaggregated_serving.py::TestDeepSeekV4FlashBase::test_auto_dtype`

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
