### PR TITLE
[None][perf] enable paged context for skip-softmax fp8 kv

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/trtllm.py
+++ b/tensorrt_llm/_torch/attention_backend/trtllm.py
@@ -1765,6 +1765,12 @@ class TrtllmAttention(AttentionBackend[TrtllmAttentionMetadata]):
                 self.sparse_params, 'algorithm', None) == 'mqa_gqa'):
             metadata.use_paged_context_fmha = True
 
+        # FP8 KV-cache skip-softmax needs paged context so preprocessing
+        # quantizes context QKV before FMHA dispatch.
+        if (isinstance(self.sparse_params, SkipSoftmaxParams)
+                and self.has_fp8_kv_cache):
+            metadata.use_paged_context_fmha = True
+
         if self.is_mla_enable:
             # Context MLA uses separate qkv instead of paged_context_fmha
             metadata.use_paged_context_fmha = False


### PR DESCRIPTION

## Summary
- Force paged-context FMHA when skip-softmax attention is used with FP8 KV cache.
- This keeps context QKV on the paged-context preprocessing path so FP8 KV-cache skip-softmax dispatch does not fall back to BF16 packed context.

## Testing
- python3 -m py_compile tensorrt_llm/_torch/attention_backend/trtllm.py
- git diff --check HEAD^ HEAD

## Not run
- pytest/runtime verification in tekit4. Local Python is missing pluggy/torch, and I did not build TensorRT-LLM in this checkout.
- Full-file ruff on trtllm.py reports pre-existing style violations unrelated to this change.
