### PR TITLE
[None][perf] disagg: optionally drop message history from generation request

### DIFF
--- a/tensorrt_llm/llmapi/disagg_utils.py
+++ b/tensorrt_llm/llmapi/disagg_utils.py
@@ -86,6 +86,10 @@ class DisaggServerConfig():
     # If this causes collisions, users can set node_id manually within range [0, 1023] in config
     schedule_style: Literal['context_first',
                             'generation_first'] = 'context_first'
+    # Drop conversation history from generation_only requests to shrink the gen
+    # worker's request body / JSON-parse GIL cost at high concurrency. Enable
+    # ONLY for text-only, non-harmony deployments (see _get_gen_request).
+    gen_strip_message_history: bool = False
 
 
 @dataclass
@@ -135,6 +139,7 @@ def extract_disagg_cfg(hostname: str = 'localhost',
                        schedule_style: Literal[
                            'context_first',
                            'generation_first'] = 'context_first',
+                       gen_strip_message_history: bool = False,
                        **kwargs: Any) -> DisaggServerConfig:
     context_servers = context_servers or {}
     generation_servers = generation_servers or {}
@@ -182,6 +187,7 @@ def extract_disagg_cfg(hostname: str = 'localhost',
         config.node_id = node_id
     if schedule_style:
         config.schedule_style = schedule_style
+    config.gen_strip_message_history = gen_strip_message_history
     return config
 
 

--- a/tensorrt_llm/serve/openai_disagg_service.py
+++ b/tensorrt_llm/serve/openai_disagg_service.py
@@ -76,6 +76,8 @@ class OpenAIDisaggregatedService(OpenAIService):
         self._perf_metrics_collector = perf_metrics_collector
         self._cluster_storage = disagg_cluster_storage
         self._health_check_interval_secs = health_check_interval_secs
+        # Opt-in body-shrink for generation_only requests; see _get_gen_request.
+        self._strip_gen_message_history = config.gen_strip_message_history
 
         self._ctx_client = None
         self._gen_client = None
@@ -350,6 +352,17 @@ class OpenAIDisaggregatedService(OpenAIService):
                 request.prompt = ctx_response.prompt_token_ids
             elif isinstance(request, ChatCompletionRequest):
                 request.prompt_token_ids = ctx_response.prompt_token_ids
+                # Opt-in: drop conversation history so the gen worker doesn't
+                # re-parse the full conversation JSON (dominates its GIL at high
+                # concurrency). It uses prompt_token_ids and only reads the last
+                # message; tools are preserved. Config-gated because it's unsafe
+                # for harmony/multimodal workers (model type is fixed per deploy).
+                if (
+                    self._strip_gen_message_history
+                    and request.messages
+                    and len(request.messages) > 1
+                ):
+                    request.messages = request.messages[-1:]
         else:
             # no ctx response, it's either a generation-only request or a generation-first disagg request
             request.disaggregated_params = DisaggregatedParams(


### PR DESCRIPTION
> Same change as #15366, re-targeted to the `feat/deepseek_v4_bench` integration branch.

## Summary

In disaggregated serving the orchestrator forwards each `generation_only` request to the
generation worker carrying **both** the full chat `messages` history **and** the
`prompt_token_ids` produced by the context server. The generation worker uses
`prompt_token_ids` directly (it skips `apply_chat_template`) and only reads the last message
for postprocessing, so the full conversation in `messages` is redundant on the gen side.

At high concurrency the gen worker's single OpenAI-server process is GIL/event-loop bound on
JSON-parsing + pydantic-validating that large request body; the `messages` history is ~40% of
it. Trimming `messages` to the last turn — when the gen ingress is the binding constraint —
measurably raises throughput and lowers TTFT.

## Change

- New disagg config **`gen_strip_message_history`** (default **off**) on `DisaggServerConfig`,
  wired through `extract_disagg_cfg` as an explicit parameter (not `**kwargs`, so it is not
  inadvertently inherited into the per-server configs).
- When enabled, `OpenAIDisaggregatedService._get_gen_request` trims `messages` → `messages[-1:]`
  for `generation_only` `ChatCompletionRequest`s (only when `prompt_token_ids` is set). Tools
  are preserved (still used for tool-parser / guided decoding).

Enable via the disagg YAML top level (same level as `hostname` / `schedule_style`):

```yaml
gen_strip_message_history: true
```

## Why config-gated (not unconditional)

A code audit found two GEN-side hazards an unconditional strip would hit on other model families:

1. **harmony / gpt_oss** — `chat_harmony` ignores `prompt_token_ids` and always re-tokenizes
   `request.messages` (`openai_to_harmony_tokens`); stripping → only the last turn is rendered →
   token/KV mismatch → corrupt output.
2. **multimodal** — `parse_chat_messages_coroutines` extracts `mm_data` from `messages`; stripping
   drops history image/audio parts.

Both are per-model properties and a disagg cluster serves a single model, so a default-off config
flag (an operator assertion "text-only + non-harmony deployment") covers them with zero blast
radius. The standard `openai_chat` path is unaffected: it consumes `prompt_token_ids`, skips
`apply_chat_template`, and only reads `messages[-1]` (`get_role()` / `last_message_content`).

## Performance (DeepSeek-V4-Pro, 6p1d DEP4×6 + DEP8 GEN, MTP3, GB300, c2048, metrics-off)

| metric | baseline | `gen_strip_message_history` |
|---|--:|--:|
| TTFT p50 | 4.89 s | 4.00 s (−18%) |
| TTFT p95 | 8.61 s | 8.06 s (−6%) |
| req/s | 104.5 | 107.0 (+2.4%) |

The gain appears at the un-throttled operating point where the gen-serving JSON-parse GIL is the
binding ingress constraint; it is absorbed when the system is decode-bound (closed-loop workload).

## Test

- `extract_disagg_cfg` parses the new top-level key onto `DisaggServerConfig.gen_strip_message_history`
  and does **not** leak it into the per-server configs; default (unset) = `False`.
- No behavior change when the flag is off (the default), so existing deployments are unaffected.

