### PR TITLE
[TRTLLM-13334][fix] Add EP assertion to DenseGEMMFusedMoE

### DIFF
--- a/tensorrt_llm/_torch/modules/fused_moe/fused_moe_densegemm.py
+++ b/tensorrt_llm/_torch/modules/fused_moe/fused_moe_densegemm.py
@@ -192,6 +192,14 @@ class DenseGEMMFusedMoE(MoE):
             f"when weight_per_expert is not MMA tile-K aligned."
         )
 
+        # DenseGEMM only supports TP; EP requires alltoall communication not implemented here.
+        ep_size = model_config.mapping.moe_ep_size
+        assert ep_size == 1, (
+            f"DenseGEMMFusedMoE does not support Expert Parallelism "
+            f"(got ep_size={ep_size}). Use a different MoE backend (e.g. CutlassFusedMoE) "
+            f"when EP is enabled."
+        )
+
         # Call MoE base class directly (not CutlassFusedMoE).
         # Note: `without_comm` and `apply_router_weight_on_input` are accepted
         # for API compatibility with create_moe_backend() but are not passed to


### PR DESCRIPTION
## Summary
- `DenseGEMMFusedMoE` uses CuTe DSL dense GEMM kernels and only supports Tensor Parallelism (TP). It has no alltoall/allgather communication path for Expert Parallelism (EP).
- Without this guard, configuring `ep_size > 1` silently produces wrong results: the base class `MoE.__init__` sets EP attributes (`ep_size`, `expert_size_per_partition`, `slot_start/end`) but the kernels never dispatch/combine tokens across EP ranks.
- This PR adds a pre-`super().__init__()` assertion that raises immediately with a clear error message pointing users to an EP-capable backend (e.g. `CutlassFusedMoE`).

## Test plan
- Confirm assertion fires: instantiate `DenseGEMMFusedMoE` with a `ModelConfig` whose `mapping.moe_ep_size > 1` and verify `AssertionError` with the expected message.
- Run existing MoE unit tests: `pytest tests/unittest/ -k "moe" -x`
- Confirm no regression on TP-only path (ep_size=1 passes normally).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent incompatible expert parallelism configurations. Users attempting to use expert parallelism with this backend will now receive a clear error message with guidance to use an alternative implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->