### PR TITLE
[None][fix] Fix cross KV sparse attention config kwarg

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -1301,7 +1301,7 @@ class KvCacheCreator:
             max_seq_len=max_seq_len,
             max_batch_size=self._max_batch_size,
             spec_config=None,
-            sparse_attn_config=None,
+            sparse_attention_config=None,
             max_num_tokens=self._max_num_tokens,
             max_beam_width=1,
             kv_connector_manager=None,


### PR DESCRIPTION
@coderabbitai summary

## Description

Fix `_create_cross_kv_cache_manager` to pass `sparse_attention_config=None` to `_create_kv_cache_manager`. The old `sparse_attn_config` keyword does not match `_create_kv_cache_manager`'s signature and can raise `TypeError` when creating the cross KV cache manager.

## Test Coverage

- `python3 -m compileall -q tensorrt_llm/_torch/pyexecutor/_util.py`
- `git diff --check`
- AST check that `_create_kv_cache_manager` calls do not use `sparse_attn_config`
- `pre-commit run --files tensorrt_llm/_torch/pyexecutor/_util.py`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.