### PR TITLE
[None][feat] DSA: adaptive indexer prefill chunk size for long sequences

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -347,6 +347,29 @@ def split_prefill_chunks(
     return chunk_groups
 
 
+# Shrink the indexer prefill chunk size for very long requests to bound the
+# fp8(_fp4)_mqa_logits activation memory (~ chunk_size * K_compressed), keyed on
+# the largest compressed KV length in the batch. Entries are
+# (k_compressed_lower_bound_exclusive, chunk_size); >512K -> 8K, [256K, 512K]
+# -> 16K, otherwise unchanged.
+_INDEXER_CHUNK_SIZE_HEURISTIC = (
+    (512 * 1024, 8 * 1024),
+    (256 * 1024 - 1, 16 * 1024),
+)
+
+
+def select_indexer_chunk_size(configured_chunk_size: int,
+                              max_k_compressed: int) -> int:
+    """Pick the indexer prefill chunk size from the batch's largest K_compressed.
+
+    Only reduces ``configured_chunk_size`` (never increases it).
+    """
+    for threshold, chunk_size in _INDEXER_CHUNK_SIZE_HEURISTIC:
+        if max_k_compressed > threshold:
+            return min(configured_chunk_size, chunk_size)
+    return configured_chunk_size
+
+
 def _select_indexer_compress_ratio(compress_ratios: List[int]) -> int:
     if 4 in compress_ratios:
         return 4
@@ -1778,9 +1801,15 @@ class Indexer(nn.Module):
         else:
             # Use indexer's own chunking logic to prevent L^2 complexity of indexer MQA logits computation for long sequences.
             # This is only used when MLA chunked prefill is not enabled.
+            # Adapt chunk size to the batch's largest K_compressed (see
+            # select_indexer_chunk_size).
+            max_k_compressed = int(indexer_params.kv_lens[:num_contexts].max().
+                                   item()) if num_contexts > 0 else 0
+            effective_chunk_size = select_indexer_chunk_size(
+                metadata.indexer_max_chunk_size, max_k_compressed)
             chunk_groups = split_prefill_chunks(
                 seq_lens[:num_contexts],
-                metadata.indexer_max_chunk_size,
+                effective_chunk_size,
                 start_idx=0,
             )
 


### PR DESCRIPTION
## Background / Motivation

The DSA indexer's `fp8_fp4_mqa_logits` / `fp8_mqa_logits` activation memory
scales with `indexer_max_chunk_size * K_compressed` (the compressed KV length
of the current request). For very long sequences this can OOM — e.g. a
~500K-token request with the default 32K chunk size needs ~16GB of activation
memory.

The current workaround is to uniformly lower `indexer_max_chunk_size` (e.g. to
8K). That avoids the OOM but costs prefill throughput for the common case,
where the vast majority of requests are far below these lengths — a blunt
one-size-fits-all setting for what is really a long-tail problem.

## Summary

Select the indexer prefill chunk size **per-batch** based on the largest
compressed KV length (`K_compressed`) among the context requests, instead of
always using the statically-configured value:

| max K_compressed in batch | effective chunk size |
|---------------------------|----------------------|
| `> 512K`                  | 8K                   |
| `[256K, 512K]`            | 16K                  |
| `< 256K`                  | configured (default 32K, unchanged) |

Implementation:
- New helper `select_indexer_chunk_size(configured_chunk_size, max_k_compressed)`
  in `dsa.py`. It **only ever reduces** the configured chunk size (never
  increases it), so any explicitly-configured value still acts as an upper
  bound.
- Wired into `Indexer.prepare_for_chunked_prefill`, on the indexer's own
  chunking path only. The MLA chunked-prefill path is untouched (it already
  bounds the chunk to the MLA chunk).
- `max K_compressed` is read from `indexer_params.kv_lens` (already host-side
  during prefill prepare).

## Impact

- **Long requests (>256K):** smaller chunk → lower indexer activation memory,
  avoids the OOM without manual tuning.
- **Common case (<256K):** behavior unchanged — keeps the larger,
  higher-throughput chunk size.
- Safe to vary per-batch because the prefill path does not use CUDA graphs.
- No API/config changes; existing `indexer_max_chunk_size` continues to act as
  the upper bound.

## Notes

- Draft for early review / discussion. Thresholds (256K / 512K) and chunk
  sizes (8K / 16K / 32K) are centralized in `_INDEXER_CHUNK_SIZE_HEURISTIC` for
  easy tuning.
- TODO before un-drafting: add a unit test for `select_indexer_chunk_size`
  boundaries and validate end-to-end memory/perf on a long-sequence workload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)