### PR TITLE
[None][feat] DSA: adaptive indexer prefill chunk size for long sequences

### DIFF
--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -3358,7 +3358,7 @@ def launchTestJobs(pipeline, testFilter)
     fullSet += SBSATestConfigs.keySet()
 
     SBSASlurmTestConfigs = [
-        "GB200-4_GPUs-PyTorch-DS-1": ["auto:gb200-x4", "l0_gb200_multi_gpus_ds", 1, 1, 4],
+        "GB200-4_GPUs-PyTorch-DS-1": ["auto:gb200-x4-split", "l0_gb200_multi_gpus_ds", 1, 1, 4],
     ]
     fullSet += SBSASlurmTestConfigs.keySet()
 

--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -347,6 +347,29 @@ def split_prefill_chunks(
     return chunk_groups
 
 
+# Shrink the indexer prefill chunk size for very long requests to bound the
+# fp8(_fp4)_mqa_logits activation memory (~ chunk_size * K_compressed), keyed on
+# the largest compressed KV length in the batch. Entries are
+# (k_compressed_lower_bound_exclusive, chunk_size); >512K -> 8K, [256K, 512K]
+# -> 16K, otherwise unchanged.
+_INDEXER_CHUNK_SIZE_HEURISTIC = (
+    (512 * 1024, 8 * 1024),
+    (256 * 1024 - 1, 16 * 1024),
+)
+
+
+def select_indexer_chunk_size(configured_chunk_size: int,
+                              max_k_compressed: int) -> int:
+    """Pick the indexer prefill chunk size from the batch's largest K_compressed.
+
+    Only reduces ``configured_chunk_size`` (never increases it).
+    """
+    for threshold, chunk_size in _INDEXER_CHUNK_SIZE_HEURISTIC:
+        if max_k_compressed > threshold:
+            return min(configured_chunk_size, chunk_size)
+    return configured_chunk_size
+
+
 def _select_indexer_compress_ratio(compress_ratios: List[int]) -> int:
     if 4 in compress_ratios:
         return 4
@@ -1778,9 +1801,15 @@ class Indexer(nn.Module):
         else:
             # Use indexer's own chunking logic to prevent L^2 complexity of indexer MQA logits computation for long sequences.
             # This is only used when MLA chunked prefill is not enabled.
+            # Adapt chunk size to the batch's largest K_compressed (see
+            # select_indexer_chunk_size).
+            max_k_compressed = int(indexer_params.kv_lens[:num_contexts].max().
+                                   item()) if num_contexts > 0 else 0
+            effective_chunk_size = select_indexer_chunk_size(
+                metadata.indexer_max_chunk_size, max_k_compressed)
             chunk_groups = split_prefill_chunks(
                 seq_lens[:num_contexts],
-                metadata.indexer_max_chunk_size,
+                effective_chunk_size,
                 start_idx=0,
             )
 

--- a/tensorrt_llm/_torch/custom_ops/cute_dsl_megamoe_custom_op.py
+++ b/tensorrt_llm/_torch/custom_ops/cute_dsl_megamoe_custom_op.py
@@ -409,14 +409,14 @@ def validate_megamoe_tactic(tactic: Tuple) -> None:
         raise ValueError(f"use_bulk_fc2_store must be bool, got {use_bulk_fc2_store!r}.")
     # bulk fc2 store is only valid under epi_warps (the non-epi modes stage fc2
     # output locally -> forced non-bulk).
-    if use_bulk_fc2_store and token_back_mode != "epi_warps":
+    if use_bulk_fc2_store and token_back_mode != "epi_warps":  # nosec B105
         raise ValueError(
             f"use_bulk_fc2_store=True requires token_back_mode='epi_warps', got "
             f"{token_back_mode!r} (non-epi token-back forces non-bulk fc2 store)."
         )
     # N128 only pays off under epi_warps + bulk; other token-back modes
     # with N128 are not recommended.
-    if mma_tiler[1] == 128 and token_back_mode != "epi_warps":
+    if mma_tiler[1] == 128 and token_back_mode != "epi_warps":  # nosec B105
         raise ValueError(
             f"mma_tiler_mnk[1]=128 (N128) is only recommended with "
             f"token_back_mode='epi_warps'; got {token_back_mode!r}."
@@ -432,7 +432,7 @@ def validate_megamoe_tactic(tactic: Tuple) -> None:
             f"TokenInPullTokenBackPush hard limit), got {flag_batch!r}."
         )
     # standalone token-back warps publish one slot at a time.
-    if token_back_mode == "standalone_warps" and flag_batch != 1:
+    if token_back_mode == "standalone_warps" and flag_batch != 1:  # nosec B105
         raise ValueError(
             f"token_back_mode='standalone_warps' requires flag_batch == 1, got {flag_batch}."
         )

--- a/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/megamoe_kernel.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/megamoe_kernel.py
@@ -208,7 +208,7 @@ class Sm100MegaMoEKernel(Sm100SwapABSwigluFp4Fc12Kernel):
             raise ValueError(
                 f"token_back_mode must be 'epi_warps', 'standalone_warps', "
                 f"or 'reuse_dispatch_warps'; got {token_back_mode!r}.")
-        token_back_by_dispatch = token_back_mode != "epi_warps"
+        token_back_by_dispatch = token_back_mode != "epi_warps"  # nosec B105
 
         super().__init__(
             mma_tiler_mnk=mma_tiler_mnk,
@@ -240,7 +240,7 @@ class Sm100MegaMoEKernel(Sm100SwapABSwigluFp4Fc12Kernel):
         # token_back_by_push concurrently with dispatch_pull, selected by the
         # user-facing token_back_mode knob ("standalone_warps").
         self.token_back_mode = token_back_mode
-        self.token_back_standalone = token_back_mode == "standalone_warps"
+        self.token_back_standalone = token_back_mode == "standalone_warps"  # nosec B105
         self.token_back_warp_id = (12, 13, 14,
                                    15) if self.token_back_standalone else None
         num_token_back_warps = (len(self.token_back_warp_id)
@@ -548,7 +548,7 @@ class Sm100MegaMoEKernel(Sm100SwapABSwigluFp4Fc12Kernel):
                     (num_experts_per_rank, ),
                     16,
                 ))
-            if self.token_back_schedule_mode == "atomic_counter":
+            if self.token_back_schedule_mode == "atomic_counter":  # nosec B105
                 specs.append(
                     _RegionSpec(
                         "token_back_schedule_counter",
@@ -933,8 +933,8 @@ class Sm100MegaMoEKernel(Sm100SwapABSwigluFp4Fc12Kernel):
             fc2_done_counter = None
             combine_output_u8 = combine_output
 
-        if cutlass.const_expr(
-                self.token_back_schedule_mode == "atomic_counter"):
+        if cutlass.const_expr(self.token_back_schedule_mode ==
+                              "atomic_counter"):  # nosec B105
             token_back_schedule_counter = self._view_local(
                 local_workspace,
                 "token_back_schedule_counter",

--- a/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/token_comm.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/mega_moe_nvfp4/token_comm.py
@@ -1484,8 +1484,8 @@ class TokenInPullTokenBackPush:
                 token_comm_args.fc2_done_counter[i] = Int32(0)
                 i = i + stride
 
-        if cutlass.const_expr(
-                self.token_back_schedule_mode == "atomic_counter"):
+        if cutlass.const_expr(self.token_back_schedule_mode ==
+                              "atomic_counter"):  # nosec B105
             if thread_linear == Int32(0):
                 token_comm_args.token_back_schedule_counter.store(Int32(0))
 


### PR DESCRIPTION
## Background / Motivation

The DSA indexer's `fp8_fp4_mqa_logits` / `fp8_mqa_logits` activation memory
scales with `indexer_max_chunk_size * K_compressed` (the compressed KV length
of the current request). For very long sequences this can OOM — e.g. a
~500K-token request with the default 32K chunk size needs ~16GB of activation
memory.

The current workaround is to uniformly lower `indexer_max_chunk_size` (e.g. to
8K). That avoids the OOM but costs prefill throughput for the common case,
where the vast majority of requests are far below these lengths — a blunt
one-size-fits-all setting for what is really a long-tail problem.

## Summary

Select the indexer prefill chunk size **per-batch** based on the largest
compressed KV length (`K_compressed`) among the context requests, instead of
always using the statically-configured value:

| max K_compressed in batch | effective chunk size |
|---------------------------|----------------------|
| `> 512K`                  | 8K                   |
| `[256K, 512K]`            | 16K                  |
| `< 256K`                  | configured (default 32K, unchanged) |

Implementation:
- New helper `select_indexer_chunk_size(configured_chunk_size, max_k_compressed)`
  in `dsa.py`. It **only ever reduces** the configured chunk size (never
  increases it), so any explicitly-configured value still acts as an upper
  bound.
- Wired into `Indexer.prepare_for_chunked_prefill`, on the indexer's own
  chunking path only. The MLA chunked-prefill path is untouched (it already
  bounds the chunk to the MLA chunk).
- `max K_compressed` is read from `indexer_params.kv_lens` (already host-side
  during prefill prepare).

## Impact

- **Long requests (>256K):** smaller chunk → lower indexer activation memory,
  avoids the OOM without manual tuning.
- **Common case (<256K):** behavior unchanged — keeps the larger,
  higher-throughput chunk size.
- Safe to vary per-batch because the prefill path does not use CUDA graphs.
- No API/config changes; existing `indexer_max_chunk_size` continues to act as
  the upper bound.

## Notes

- Draft for early review / discussion. Thresholds (256K / 512K) and chunk
  sizes (8K / 16K / 32K) are centralized in `_INDEXER_CHUNK_SIZE_HEURISTIC` for
  easy tuning.
- TODO before un-drafting: add a unit test for `select_indexer_chunk_size`
  boundaries and validate end-to-end memory/perf on a long-sequence workload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
