### PR TITLE
[None][fix] Fix stale sparse attention kwargs

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -1301,7 +1301,7 @@ class KvCacheCreator:
             max_seq_len=max_seq_len,
             max_batch_size=self._max_batch_size,
             spec_config=None,
-            sparse_attn_config=None,
+            sparse_attention_config=None,
             max_num_tokens=self._max_num_tokens,
             max_beam_width=1,
             kv_connector_manager=None,

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -5234,6 +5234,10 @@ class PyTorchModelEngine(ModelEngine):
         # Build a fresh, no-cache attention metadata for the encoder
         # pass.  We do not reuse ``self.attn_metadata`` because that
         # object is bound to the decoder's KV-cache manager.
+        sparse_metadata_params = (
+            self.sparse_attention_config.to_sparse_metadata_params(
+                pretrained_config=self.model.model_config.pretrained_config)
+            if self.sparse_attention_config is not None else None)
         encoder_attn_metadata = self.attn_backend.Metadata(
             max_num_requests=self.batch_size,
             max_num_tokens=self.max_num_tokens,
@@ -5244,7 +5248,7 @@ class PyTorchModelEngine(ModelEngine):
             enable_flash_mla=self.model.model_config.enable_flash_mla,
             enable_context_mla_with_cached_kv=False,
             cache_indirection=None,
-            sparse_attention_config=self.sparse_attention_config,
+            sparse_metadata_params=sparse_metadata_params,
             num_heads_per_kv=1,
         )
         assert isinstance(


### PR DESCRIPTION
## Summary

1. Fix the stale sparse-attention kwarg in the encoder-decoder cross KV-cache manager path.
2. Fix the encoder attention metadata path to pass lowered `sparse_metadata_params` instead of the user-facing sparse config.

## Details

PR #14687 renamed and split sparse-attention plumbing so `AttentionMetadata` consumes `SparseMetadataParams`, while KV-cache manager construction uses `sparse_attention_config`.

Two stale call sites remained on main:

1. `KvCacheCreator._create_cross_kv_cache_manager()` still passed `sparse_attn_config=None` to `_create_kv_cache_manager()`, whose parameter is now `sparse_attention_config`.
2. `PyTorchModelEngine._prepare_tp_inputs_encoder()` still passed `sparse_attention_config=self.sparse_attention_config` into `self.attn_backend.Metadata(...)`, but `TrtllmAttentionMetadata` now expects `sparse_metadata_params`.

This fixes both reported pre-merge CI failures:

- `_create_kv_cache_manager() got an unexpected keyword argument 'sparse_attn_config'`
- `TrtllmAttentionMetadata.__init__() got an unexpected keyword argument 'sparse_attention_config'`

## Test Plan

1. `git diff --check`
2. `python3 -m py_compile tensorrt_llm/_torch/pyexecutor/_util.py tensorrt_llm/_torch/pyexecutor/model_engine.py`
3. `pre-commit run --files tensorrt_llm/_torch/pyexecutor/_util.py tensorrt_llm/_torch/pyexecutor/model_engine.py`
4. Not run locally: `pytest tests/unittest/_torch/executor/test_dual_pool_kv_cache.py -q`, because the local Python environment does not have `pytest` installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated sparse attention configuration handling in encoder-decoder models for improved internal consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->