### PR TITLE
[https://nvbugs/6330273][fix] Reserve KV cache slots for concurrent decode in V2

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -1848,6 +1848,19 @@ class KVCacheManagerV2(BaseResourceManager):
                 )
             )
 
+        constraints.append(
+            self._build_concurrent_decode_constraint(
+                max_batch_size=self.max_batch_size,
+                tokens_per_block=tokens_per_block,
+            )
+        )
+        if typical_step is None:
+            # Preserve StorageManager's historical fallback ratio while using
+            # the concurrent decode constraint only as a min-slot floor.
+            typical_step = BatchDesc(
+                [KVCacheDesc(capacity=2049, history_length=2048)]
+            )
+
         return KVCacheManagerConfigPy(
             tokens_per_block=tokens_per_block,
             cache_tiers=cache_tiers,
@@ -1889,6 +1902,19 @@ class KVCacheManagerV2(BaseResourceManager):
         new roles do not require C++ changes.
         """
         return None
+
+    @staticmethod
+    def _build_concurrent_decode_constraint(
+        *, max_batch_size: int, tokens_per_block: int
+    ) -> BatchDesc:
+        assert max_batch_size > 0
+        assert tokens_per_block > 0
+        return BatchDesc(
+            [
+                KVCacheDesc(capacity=tokens_per_block, history_length=tokens_per_block - 1)
+                for _ in range(max_batch_size)
+            ]
+        )
 
     def get_disagg_role_mapper_kinds(self) -> dict[DataRole, MapperKind]:
         """Map native cache roles to disaggregation mapper kinds.

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_manager_v2.py
@@ -1851,15 +1851,14 @@ class KVCacheManagerV2(BaseResourceManager):
         constraints.append(
             self._build_concurrent_decode_constraint(
                 max_batch_size=self.max_batch_size,
+                max_tokens=kv_cache_config.max_tokens,
                 tokens_per_block=tokens_per_block,
             )
         )
         if typical_step is None:
             # Preserve StorageManager's historical fallback ratio while using
             # the concurrent decode constraint only as a min-slot floor.
-            typical_step = BatchDesc(
-                [KVCacheDesc(capacity=2049, history_length=2048)]
-            )
+            typical_step = BatchDesc([KVCacheDesc(capacity=2049, history_length=2048)])
 
         return KVCacheManagerConfigPy(
             tokens_per_block=tokens_per_block,
@@ -1905,10 +1904,12 @@ class KVCacheManagerV2(BaseResourceManager):
 
     @staticmethod
     def _build_concurrent_decode_constraint(
-        *, max_batch_size: int, tokens_per_block: int
+        *, max_batch_size: int, max_tokens: Optional[int], tokens_per_block: int
     ) -> BatchDesc:
         assert max_batch_size > 0
         assert tokens_per_block > 0
+        if max_tokens is not None:
+            max_batch_size = max(1, min(max_batch_size, max_tokens // tokens_per_block))
         return BatchDesc(
             [
                 KVCacheDesc(capacity=tokens_per_block, history_length=tokens_per_block - 1)

--- a/tests/unittest/_torch/executor/test_per_layer_head_dim.py
+++ b/tests/unittest/_torch/executor/test_per_layer_head_dim.py
@@ -26,6 +26,7 @@ from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import (
 )
 from tensorrt_llm.llmapi.llm_args import KvCacheConfig as KvCacheConfigV2
 from tensorrt_llm.mapping import Mapping
+from tensorrt_llm.runtime.kv_cache_manager_v2 import GpuCacheTierConfig
 
 DataType = tensorrt_llm.bindings.DataType
 CacheType = tensorrt_llm.bindings.internal.batch_manager.CacheType
@@ -111,6 +112,40 @@ class TestPerLayerHeadDimBasic(unittest.TestCase):
             self.assertEqual(requested_indices, [all_indices[0][:1]])
         finally:
             mgr.shutdown()
+
+    def test_build_cache_config_reserves_concurrent_decode_slots(self):
+        mgr = KVCacheManagerV2.__new__(KVCacheManagerV2)
+        mgr.kv_cache_type = CacheType.SELF
+        mgr.dtype = DataType.HALF
+        mgr.kv_factor = 2
+        mgr.max_batch_size = 4
+        mgr.max_attention_window_vec = [4, None]
+        mgr.num_local_layers = 2
+        mgr.pp_layers = [0, 1]
+        mgr.num_kv_heads_per_layer = [1, 1]
+        mgr.head_dim_per_layer = [8, 8]
+        mgr.enable_swa_scratch_reuse = False
+        mgr.enable_stats = False
+
+        config = mgr._build_base_config(
+            KvCacheConfigV2(max_tokens=128, enable_block_reuse=False),
+            tokens_per_block=8,
+            cache_tiers=[GpuCacheTierConfig(quota=1 << 20)],
+        )
+
+        self.assertEqual(len(config.constraints), 1)
+        decode_constraint = config.constraints[0]
+        self.assertEqual(len(decode_constraint.kv_caches), mgr.max_batch_size)
+        for kv_cache in decode_constraint.kv_caches:
+            self.assertEqual(kv_cache.capacity, 8)
+            self.assertEqual(kv_cache.history_length, 7)
+
+        # Keep the previous StorageManager fallback ratio basis so adding the
+        # constraint only floors min slots and does not change ratio selection.
+        self.assertIsNotNone(config.typical_step)
+        self.assertEqual(len(config.typical_step.kv_caches), 1)
+        self.assertEqual(config.typical_step.kv_caches[0].capacity, 2049)
+        self.assertEqual(config.typical_step.kv_caches[0].history_length, 2048)
 
     def test_per_layer_head_dim_wrong_length(self):
         """Test that mismatched list length raises assertion."""

--- a/tests/unittest/_torch/executor/test_per_layer_head_dim.py
+++ b/tests/unittest/_torch/executor/test_per_layer_head_dim.py
@@ -66,6 +66,22 @@ def _create_kv_cache_manager_v2(
     )
 
 
+def _create_cache_config_only_manager() -> KVCacheManagerV2:
+    mgr = KVCacheManagerV2.__new__(KVCacheManagerV2)
+    mgr.kv_cache_type = CacheType.SELF
+    mgr.dtype = DataType.HALF
+    mgr.kv_factor = 2
+    mgr.max_batch_size = 4
+    mgr.max_attention_window_vec = [4, None]
+    mgr.num_local_layers = 2
+    mgr.pp_layers = [0, 1]
+    mgr.num_kv_heads_per_layer = [1, 1]
+    mgr.head_dim_per_layer = [8, 8]
+    mgr.enable_swa_scratch_reuse = False
+    mgr.enable_stats = False
+    return mgr
+
+
 class TestPerLayerHeadDimBasic(unittest.TestCase):
     """Tests that don't allocate GPU memory or use uniform buffer sizes."""
 
@@ -113,19 +129,8 @@ class TestPerLayerHeadDimBasic(unittest.TestCase):
         finally:
             mgr.shutdown()
 
-    def test_build_cache_config_reserves_concurrent_decode_slots(self):
-        mgr = KVCacheManagerV2.__new__(KVCacheManagerV2)
-        mgr.kv_cache_type = CacheType.SELF
-        mgr.dtype = DataType.HALF
-        mgr.kv_factor = 2
-        mgr.max_batch_size = 4
-        mgr.max_attention_window_vec = [4, None]
-        mgr.num_local_layers = 2
-        mgr.pp_layers = [0, 1]
-        mgr.num_kv_heads_per_layer = [1, 1]
-        mgr.head_dim_per_layer = [8, 8]
-        mgr.enable_swa_scratch_reuse = False
-        mgr.enable_stats = False
+    def test_build_base_config_reserves_concurrent_decode_slots(self):
+        mgr = _create_cache_config_only_manager()
 
         config = mgr._build_base_config(
             KvCacheConfigV2(max_tokens=128, enable_block_reuse=False),
@@ -146,6 +151,17 @@ class TestPerLayerHeadDimBasic(unittest.TestCase):
         self.assertEqual(len(config.typical_step.kv_caches), 1)
         self.assertEqual(config.typical_step.kv_caches[0].capacity, 2049)
         self.assertEqual(config.typical_step.kv_caches[0].history_length, 2048)
+
+    def test_build_base_config_bounds_concurrent_decode_slots_by_max_tokens(self):
+        mgr = _create_cache_config_only_manager()
+
+        config = mgr._build_base_config(
+            KvCacheConfigV2(max_tokens=16, enable_block_reuse=False),
+            tokens_per_block=8,
+            cache_tiers=[GpuCacheTierConfig(quota=1 << 20)],
+        )
+
+        self.assertEqual(len(config.constraints[0].kv_caches), 2)
 
     def test_per_layer_head_dim_wrong_length(self):
         """Test that mismatched list length raises assertion."""


### PR DESCRIPTION
### Description

Fixes #15401.

KVCacheManagerV2 can under-reserve windowed pool slots when capacity planning only sees long-history requests. For a sliding window smaller than one block, the stale range can leave a pool with only one slot and deadlock scheduling once multiple requests decode concurrently.

This adds a concurrent-decode feasibility constraint with one block per request. The request count is capped by kv_cache_config.max_tokens when an explicit token budget is configured, while unconstrained sizing reserves up to max_batch_size slots. BatchDesc uses the global ledger block size so context-parallel Helix configurations account for a super-block correctly.

When no workload-derived typical step or explicit pool ratio exists, the config keeps StorageManager’s historical 2049/2048 fallback ratio. The new constraint therefore changes only the minimum slot floor, not the default pool ratio.

### Tests

Refreshed on 2026-09-11 at `471c1a063`, rebased onto `74f97c038`. The test conflict retains upstream initialization additions and this PR's ledger-size override. Ruff 0.9.4 check/format, all applicable pre-commit hooks (Python 3.12), compilation, isolated sizing checks and `git diff --check` pass. These static/isolated checks are not a full TensorRT runtime test.

- Updated KV cache manager V2 unit coverage for the default fallback, explicit pool ratio, avg_seq_len constraints, max_tokens bounding (including a budget smaller than one ledger block), and Helix ledger block sizing
- pre-commit run --files tensorrt_llm/_torch/pyexecutor/kv_cache/kv_cache_manager_v2.py tests/unittest/_torch/executor/kv_cache/test_kv_cache_manager_v2.py
- python3 -m py_compile tensorrt_llm/_torch/pyexecutor/kv_cache/kv_cache_manager_v2.py tests/unittest/_torch/executor/kv_cache/test_kv_cache_manager_v2.py
- git diff --check

Targeted pytest collection requires the project’s Python 3.12 TensorRT/PyTorch test environment, which is not available in this local macOS checkout; provisioned NVIDIA CI is still required before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Dev Engineer Review

- `KVCacheManagerV2` adds a concurrent-decode constraint for each allowed request.
- The constraint uses the global ledger block size and respects explicit `max_tokens` budgets.
- Unconstrained sizing retains `max_batch_size` behavior.
- Existing fallback pool-ratio behavior remains unchanged.
- Full runtime verification remains pending because required dependencies were unavailable.
- No public API or configuration files changed.

## QA Engineer Review

- Modified `tests/unittest/_torch/executor/kv_cache/test_kv_cache_manager_v2.py`.
- Coverage includes concurrent-decode sizing, pool ratios, sequence-length constraints, token-budget limits, fallback behavior, and Helix ledger sizing.
- The test file is not listed in the integration CI or manual-QA test lists.
- Local checks passed, but the targeted pytest run was unavailable because TensorRT, PyTorch, and MPI dependencies were missing.
- **Coverage verdict: needs follow-up.**

## Per-File QA Perspective

- `tensorrt_llm/_torch/pyexecutor/kv_cache/kv_cache_manager_v2.py`: Verify concurrent-decode sizing for windowed pools, explicit `max_tokens`, unconstrained `max_batch_size`, Helix ledger sizing, and fallback behavior.
- `tests/unittest/_torch/executor/kv_cache/test_kv_cache_manager_v2.py`: Covers the new sizing paths and regression cases. It is not listed in `tests/integration/test_lists/test-db/` or `tests/integration/test_lists/qa/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
