### PR TITLE
[https://nvbugs/6315845][fix] Dual-location revert of #14851's protective-code removal: (1) pin…

### DIFF
--- a/cpp/tensorrt_llm/common/attentionOp.cpp
+++ b/cpp/tensorrt_llm/common/attentionOp.cpp
@@ -1133,7 +1133,15 @@ int AttentionOp::mlaGeneration(
         tllmRunnerParams.mMaxSeqLenCacheKv = generation_params.max_attention_window_size;
         // This should be set to numDraftTokens + 1.
         tllmRunnerParams.mMaxSeqLenQ = params.acc_q_len / batch_beam;
-        tllmRunnerParams.mMaxSeqLenKv = generation_params.max_past_kv_length;
+        // Pin mMaxSeqLenKv to the static max cache capacity so trtllm-gen FMHA picks the
+        // same kernel as CUDA-graph warmup and the PR #14851 JIT warmup grid. Using a
+        // dynamic max_past_kv_length here cycles through buckets that the warmup grid
+        // (which uses mMaxSeqLen) never covered, causing 1-15 NVRTC re-compiles of
+        // 7-9 s each on the first MTP-decode iterations and blowing TTFT P99 from
+        // 882 ms to 25 s on DeepSeek-R1-FP8 8K1K. Safe for PagedKv: strides do not
+        // depend on mMaxSeqLenKv, and extra KV CTAs early-exit through seqLensKvPtr
+        // (rationale from PR #13505 / commit c37992c that #14851 inadvertently reverted).
+        tllmRunnerParams.mMaxSeqLenKv = generation_params.max_attention_window_size;
         tllmRunnerParams.mJITWarmup = generation_params.trtllm_gen_jit_warmup;
         tllmRunnerParams.mJITWarmupMaxNumRequests = mMaxNumRequests;
         tllmRunnerParams.mJITWarmupMaxSeqLenQ = mMaxContextLength;

--- a/cpp/tensorrt_llm/kernels/xqaDispatcher.cpp
+++ b/cpp/tensorrt_llm/kernels/xqaDispatcher.cpp
@@ -506,7 +506,15 @@ void XqaDispatcher::runImpl(
         }
         else
         {
-            tllmRunnerParams.mMaxSeqLenKv = params.max_past_kv_length;
+            // Pin mMaxSeqLenKv to a static per-layer value so warmup and runtime pick the
+            // same FMHA kernel and avoid the eager-mode NVRTC JIT misses re-introduced by
+            // PR #14851. For PagedKv, strides do not depend on mMaxSeqLenKv and extra KV
+            // CTAs early-exit via seqLensKvPtr (rationale from the original protection that
+            // #14851 reverted). ContiguousKv must keep its true past-kv length because its
+            // strides do depend on it.
+            tllmRunnerParams.mMaxSeqLenKv = (tllmRunnerParams.mQkvLayout == QkvLayout::PagedKv)
+                ? params.max_attention_window_size
+                : params.max_past_kv_length;
         }
         tllmRunnerParams.mJITWarmup = params.trtllm_gen_jit_warmup;
         tllmRunnerParams.mJITWarmupMaxNumRequests = params.trtllm_gen_jit_warmup_max_num_requests;


### PR DESCRIPTION
## Summary
- **Root cause**: PR #14851 (commit 6dee1673) reverted static `mMaxSeqLenKv` pinning in BOTH `mlaGeneration` (cpp/tensorrt_llm/common/attentionOp.cpp:1133) and `XqaDispatcher::runImpl` (cpp/tensorrt_llm/kernels/xqaDispatcher.cpp:~509), replacing them with per-iteration `max_past_kv_length`. The dynamic value cycles through seqLenKv buckets the warmup grid never covered, triggering 1-15 NVRTC re-compiles of 7-9 s each and blowing TTFT P99 from 882 ms to 25 s while decode (TPOT/ITL) stays within 1%. Prior attempts addressed only `mlaGeneration` (or only the warmup grid).
- **Fix**: Dual-location revert of #14851's protective-code removal: (1) pin `mMaxSeqLenKv = max_attention_window_size` in `mlaGeneration` (safe for PagedKv — strides independent, KV CTAs early-exit via seqLensKvPtr); (2) pin `mMaxSeqLenKv = (mQkvLayout == PagedKv) ? max_attention_window_size : max_past_kv_length` in `XqaDispatcher::runImpl` non-spec-dec-tree branch — QkvLayout-aware so ContiguousKv keeps its true past-kv length. C++-only, two files, 18 insertions / 2 deletions, no Python or warmup-grid changes.
- **Perf metric**: output_token_throughput (higher-is-better)
- **Bad perf**: 609
- **Good perf**: 992.5
- **Perf after fix**: 988.9
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6315845


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attention window size handling during generation to better manage KV cache sequence lengths and kernel selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->