### PR TITLE
[#14679][fix] Fix fused-QKV TP sharding for Phi-3/Phi-4

### DIFF
--- a/examples/auto_deploy/model_registry/models.yaml
+++ b/examples/auto_deploy/model_registry/models.yaml
@@ -67,18 +67,15 @@ models:
 - name: Qwen/Qwen3-8B
   config_id: default_ws_2
   yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml']
-# RuntimeError: a and b must have same reduction dim, but got [s44*s70, 5120] X [2560, 5120]. See https://github.com/NVIDIA/TensorRT-LLM/issues/14679
-# - name: microsoft/phi-4
-#   config_id: default_ws_2
-#   yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml']
-# RuntimeError: a and b must have same reduction dim, but got [s44*s70, 5120] X [2560, 5120]. See https://github.com/NVIDIA/TensorRT-LLM/issues/14679
-# - name: microsoft/Phi-4-reasoning
-#   config_id: default_ws_2
-#   yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml']
-# RuntimeError: a and b must have same reduction dim, but got [s44*s70, 5120] X [2560, 5120]. See https://github.com/NVIDIA/TensorRT-LLM/issues/14679
-# - name: microsoft/Phi-4-reasoning-plus
-#   config_id: default_ws_2
-#   yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml']
+- name: microsoft/phi-4
+  config_id: default_ws_2
+  yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml', 'enable_sharder_ir.yaml']
+- name: microsoft/Phi-4-reasoning
+  config_id: default_ws_2
+  yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml', 'enable_sharder_ir.yaml']
+- name: microsoft/Phi-4-reasoning-plus
+  config_id: default_ws_2
+  yaml_extra: ['dashboard_default.yaml', 'world_size_2.yaml', 'enable_sharder_ir.yaml']
 # IndexError: list index out of range in AutoDeploy sharding path. See https://github.com/NVIDIA/TensorRT-LLM/issues/14681
 # - name: google/gemma-1.1-7b-it
 #   config_id: default_ws_2

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/__init__.py
@@ -54,6 +54,7 @@ _MODEL_MODULES = {
     "modeling_nemotron_h": ["NemotronHForCausalLM"],
     "modeling_olmo3": ["Olmo3ForCausalLM"],
     "modeling_openelm": ["OpenELMForCausalLM"],
+    "modeling_phi3": ["Phi3ForCausalLM"],
     "modeling_qwen3": ["Qwen3ForCausalLM"],
     "modeling_qwen3_5_moe": ["Qwen3_5MoeForCausalLM", "Qwen3_5MoeForConditionalGeneration"],
     "modeling_qwen3_moe": ["Qwen3MoeForCausalLM"],

--- a/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_phi3.py
+++ b/tensorrt_llm/_torch/auto_deploy/models/custom/modeling_phi3.py
@@ -1,0 +1,366 @@
+# Copyright 2018 The HuggingFace Team
+# Licensed under the Apache License, Version 2.0.
+# Original source: https://github.com/huggingface/transformers
+#
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Phi-3 / Phi-4 model (sharding IR).
+
+Source:
+https://huggingface.co/microsoft/phi-4
+
+Phi-3/Phi-4 share the Llama-style decoder (GQA, SwiGLU MLP, RMSNorm, RoPE) but
+use two *fused* projections:
+
+* ``qkv_proj``      -> fused [Q | K | V]  (colwise, ``output_sizes=[q, kv, kv]``)
+* ``gate_up_proj``  -> fused [gate | up]  (colwise, ``output_sizes=[inter, inter]``)
+
+These carry explicit sharding hints (``output_sizes`` for proportional column
+sharding plus ``split_with_sizes(enable_sharding=True)``) so the IR sharder
+splits each fused weight head-aligned per rank, mirroring ``modeling_nemotron_h``'s
+fused ``in_proj``. The legacy structural sharder mishandled this fused layout
+(see https://github.com/NVIDIA/TensorRT-LLM/issues/14679).
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import torch
+from torch import nn
+from transformers.activations import ACT2FN
+from transformers.generation import GenerationMixin
+from transformers.modeling_utils import PreTrainedModel
+from transformers.models.phi3.configuration_phi3 import Phi3Config
+from transformers.utils import ModelOutput
+
+from ..hf import AutoModelForCausalLMFactory
+from ._rope_utils import init_rope_inv_freq
+
+
+class Phi3RMSNorm(nn.Module):
+    def __init__(self, hidden_size: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return torch.ops.auto_deploy.torch_rmsnorm(
+            hidden_states, self.weight, self.variance_epsilon
+        )
+
+
+class Phi3RotaryEmbedding(nn.Module):
+    """RoPE for Phi-3/Phi-4. Supports default and longrope via init_rope_inv_freq."""
+
+    def __init__(self, config: Phi3Config):
+        super().__init__()
+        inv_freq, self.attention_scaling = init_rope_inv_freq(config)
+
+        max_pos = config.max_position_embeddings
+        t = torch.arange(max_pos, dtype=inv_freq.dtype)
+        freqs = torch.outer(t, inv_freq)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        self.register_buffer("_ad_cos_cached", emb.cos() * self.attention_scaling, persistent=False)
+        self.register_buffer("_ad_sin_cached", emb.sin() * self.attention_scaling, persistent=False)
+
+    def forward(
+        self, x: torch.Tensor, position_ids: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        cos = self._ad_cos_cached.to(dtype=x.dtype, device=x.device)
+        sin = self._ad_sin_cached.to(dtype=x.dtype, device=x.device)
+        return cos[position_ids], sin[position_ids]
+
+
+class Phi3MLP(nn.Module):
+    """SwiGLU MLP with fused gate_up_proj.
+
+    Sharding: gate_up_proj -> colwise (output_sizes=[inter, inter]),
+    down_proj -> rowwise + all_reduce.
+    """
+
+    def __init__(self, config: Phi3Config):
+        super().__init__()
+        self.intermediate_size = config.intermediate_size
+        self.gate_up_proj = nn.Linear(config.hidden_size, 2 * config.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(config.intermediate_size, config.hidden_size, bias=False)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        gate_up = torch.ops.auto_deploy.torch_linear_simple(
+            x,
+            self.gate_up_proj.weight,
+            self.gate_up_proj.bias,
+            tp_mode="colwise",
+            output_sizes=[self.intermediate_size, self.intermediate_size],
+            layer_type="mlp",
+        )
+        gate, up = torch.ops.auto_deploy.split_with_sizes(
+            gate_up,
+            [self.intermediate_size, self.intermediate_size],
+            dim=-1,
+            enable_sharding=True,
+            layer_type="mlp",
+        )
+        down = torch.ops.auto_deploy.torch_linear_simple(
+            self.act_fn(gate) * up,
+            self.down_proj.weight,
+            self.down_proj.bias,
+            tp_mode="rowwise",
+            layer_type="mlp",
+        )
+        down = torch.ops.auto_deploy.all_reduce(down, layer_type="mlp")
+        return down
+
+
+class Phi3Attention(nn.Module):
+    """GQA with fused qkv_proj.
+
+    Sharding: qkv_proj -> colwise (output_sizes=[q, kv, kv], tp_min_local_shape=head_dim),
+    view -> tp_scaled_dim=2, o_proj -> rowwise + all_reduce.
+    """
+
+    def __init__(self, config: Phi3Config, layer_idx: Optional[int] = None):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+
+        self.num_heads = config.num_attention_heads
+        self.num_kv_heads = config.num_key_value_heads
+        self.head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scaling = self.head_dim ** (-0.5)
+
+        attention_bias = getattr(config, "attention_bias", False)
+        self.qkv_proj = nn.Linear(
+            config.hidden_size, self.q_size + 2 * self.kv_size, bias=attention_bias
+        )
+        self.o_proj = nn.Linear(self.q_size, config.hidden_size, bias=attention_bias)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        bsz, q_len, _ = hidden_states.size()
+
+        qkv = torch.ops.auto_deploy.torch_linear_simple(
+            hidden_states,
+            self.qkv_proj.weight,
+            self.qkv_proj.bias,
+            tp_mode="colwise",
+            output_sizes=[self.q_size, self.kv_size, self.kv_size],
+            tp_min_local_shape=self.head_dim,
+            layer_type="mha",
+        )
+        q, k, v = torch.ops.auto_deploy.split_with_sizes(
+            qkv,
+            [self.q_size, self.kv_size, self.kv_size],
+            dim=-1,
+            enable_sharding=True,
+            layer_type="mha",
+        )
+        q = torch.ops.auto_deploy.view(
+            q, [bsz, q_len, self.num_heads, self.head_dim], tp_scaled_dim=2, layer_type="mha"
+        )
+        k = torch.ops.auto_deploy.view(
+            k, [bsz, q_len, self.num_kv_heads, self.head_dim], tp_scaled_dim=2, layer_type="mha"
+        )
+        v = torch.ops.auto_deploy.view(
+            v, [bsz, q_len, self.num_kv_heads, self.head_dim], tp_scaled_dim=2, layer_type="mha"
+        )
+
+        cos, sin = position_embeddings
+        q, k = torch.ops.auto_deploy.torch_rope_with_explicit_cos_sin(q, k, cos, sin, 2)
+
+        attn_output = torch.ops.auto_deploy.torch_attention(
+            q,
+            k,
+            v,
+            None,  # attn_mask
+            0.0,  # dropout_p
+            True,  # is_causal
+            self.scaling,  # scale
+            None,  # sinks
+            None,  # sliding_window
+            None,  # logit_cap
+            "bsnd",  # layout
+        )
+
+        attn_output = torch.ops.auto_deploy.view(
+            attn_output, [bsz, q_len, self.q_size], tp_scaled_dim=2, layer_type="mha"
+        )
+        attn_output = torch.ops.auto_deploy.torch_linear_simple(
+            attn_output,
+            self.o_proj.weight,
+            self.o_proj.bias,
+            tp_mode="rowwise",
+            layer_type="mha",
+        )
+        attn_output = torch.ops.auto_deploy.all_reduce(attn_output, layer_type="mha")
+        return attn_output
+
+
+class Phi3DecoderLayer(nn.Module):
+    def __init__(self, config: Phi3Config, layer_idx: int):
+        super().__init__()
+        self.self_attn = Phi3Attention(config, layer_idx=layer_idx)
+        self.mlp = Phi3MLP(config)
+        self.input_layernorm = Phi3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Phi3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = self.self_attn(hidden_states, position_embeddings)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        return hidden_states
+
+
+@dataclass
+class Phi3Output(ModelOutput):
+    last_hidden_state: Optional[torch.FloatTensor] = None
+
+
+@dataclass
+class Phi3CausalLMOutput(ModelOutput):
+    logits: Optional[torch.FloatTensor] = None
+
+
+class Phi3PreTrainedModel(PreTrainedModel):
+    config_class = Phi3Config
+    base_model_prefix = "model"
+    _no_split_modules = ["Phi3DecoderLayer"]
+    supports_gradient_checkpointing = False
+
+    def _init_weights(self, module):
+        std = self.config.initializer_range
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()
+
+
+class Phi3Model(Phi3PreTrainedModel):
+    def __init__(self, config: Phi3Config):
+        super().__init__(config)
+        self.config = config
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList(
+            [Phi3DecoderLayer(config, layer_idx=idx) for idx in range(config.num_hidden_layers)]
+        )
+        self.norm = Phi3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = Phi3RotaryEmbedding(config)
+
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.embed_tokens = value
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        **kwargs,
+    ) -> Phi3Output:
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError("Cannot specify both input_ids and inputs_embeds")
+        elif input_ids is None and inputs_embeds is None:
+            raise ValueError("Must specify either input_ids or inputs_embeds")
+
+        assert position_ids is not None, "position_ids must be provided for AD export"
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        inputs_embeds = inputs_embeds.to(self.norm.weight.dtype)
+        position_embeddings = self.rotary_emb(inputs_embeds, position_ids)
+
+        hidden_states = inputs_embeds
+        for decoder_layer in self.layers:
+            hidden_states = decoder_layer(hidden_states, position_embeddings)
+
+        hidden_states = self.norm(hidden_states)
+        return Phi3Output(last_hidden_state=hidden_states)
+
+
+class Phi3ForCausalLM(Phi3PreTrainedModel, GenerationMixin):
+    def __init__(self, config, **kwargs):
+        super().__init__(config)
+        self.model = Phi3Model(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.model.embed_tokens = value
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def get_decoder(self):
+        return self.model
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        **kwargs,
+    ) -> Phi3CausalLMOutput:
+        assert position_ids is not None, "position_ids must be provided for AD export"
+        outputs = self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            **kwargs,
+        )
+        hidden_states = outputs.last_hidden_state
+        logits = self.lm_head(hidden_states).float()
+        return Phi3CausalLMOutput(logits=logits)
+
+
+AutoModelForCausalLMFactory.register_custom_model_cls("Phi3Config", Phi3ForCausalLM)

--- a/tests/unittest/auto_deploy/singlegpu/models/test_phi3_modeling.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_phi3_modeling.py
@@ -1,0 +1,442 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Phi-3 / Phi-4 custom model implementation.
+
+Phi-3/Phi-4 share the Llama-style decoder but use fused ``qkv_proj`` and
+``gate_up_proj`` projections. These tests compare the custom AD model (which
+carries sharding-IR hints on the fused linears) against the HF reference.
+"""
+
+import pytest
+import torch
+from _model_test_utils import assert_rmse_close
+from torch.export import Dim
+from transformers.models.phi3.configuration_phi3 import Phi3Config
+
+from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
+from tensorrt_llm._torch.auto_deploy.models.custom.modeling_phi3 import (
+    Phi3Attention,
+    Phi3DecoderLayer,
+    Phi3ForCausalLM,
+    Phi3MLP,
+    Phi3RMSNorm,
+    Phi3RotaryEmbedding,
+)
+from tensorrt_llm._torch.auto_deploy.utils._graph import move_to_device
+
+_BATCH_AND_SEQUENCE_TEST_CASES = ((2, 6), (1, 8))
+
+
+def _create_causal_mask(B: int, S: int, device: str, dtype: torch.dtype) -> torch.Tensor:
+    """Create the additive causal mask expected by HF eager attention."""
+    causal_mask = torch.full((S, S), float("-inf"), device=device, dtype=dtype)
+    causal_mask = torch.triu(causal_mask, diagonal=1)
+    return causal_mask.unsqueeze(0).unsqueeze(0).expand(B, 1, S, S)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def set_seed():
+    torch.manual_seed(42)
+
+
+def _create_small_config() -> Phi3Config:
+    """Create a small Phi-3 config for testing (GQA: 4 Q heads, 2 KV heads)."""
+    return Phi3Config(
+        vocab_size=1000,
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=3,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        hidden_act="silu",
+        max_position_embeddings=512,
+        rms_norm_eps=1e-6,
+        rope_theta=10000.0,
+        rope_scaling=None,
+        attention_bias=False,
+        attention_dropout=0.0,
+        tie_word_embeddings=False,
+        pad_token_id=0,
+    )
+
+
+# =========================================================================
+# HF reference class helpers
+# =========================================================================
+
+
+def _get_hf_model_class():
+    try:
+        from transformers.models.phi3.modeling_phi3 import Phi3ForCausalLM as HFPhi3ForCausalLM
+
+        return HFPhi3ForCausalLM
+    except ImportError:
+        return None
+
+
+def _get_hf_attention_class():
+    try:
+        from transformers.models.phi3.modeling_phi3 import Phi3Attention as HFPhi3Attention
+
+        return HFPhi3Attention
+    except ImportError:
+        return None
+
+
+def _get_hf_mlp_class():
+    try:
+        from transformers.models.phi3.modeling_phi3 import Phi3MLP as HFPhi3MLP
+
+        return HFPhi3MLP
+    except ImportError:
+        return None
+
+
+def _get_hf_decoder_layer_class():
+    try:
+        from transformers.models.phi3.modeling_phi3 import Phi3DecoderLayer as HFPhi3DecoderLayer
+
+        return HFPhi3DecoderLayer
+    except ImportError:
+        return None
+
+
+def _get_hf_rotary_class():
+    try:
+        from transformers.models.phi3.modeling_phi3 import Phi3RotaryEmbedding as HFPhi3Rotary
+
+        return HFPhi3Rotary
+    except ImportError:
+        return None
+
+
+# =========================================================================
+# Block equivalence tests (Level 1)
+# =========================================================================
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@torch.no_grad()
+def test_phi3_rmsnorm_equivalence(B, S, dtype):
+    try:
+        from transformers.models.phi3.modeling_phi3 import Phi3RMSNorm as HFPhi3RMSNorm
+    except ImportError:
+        pytest.skip("transformers doesn't have Phi3RMSNorm")
+
+    device = "cuda"
+    config = _create_small_config()
+
+    hf_norm = HFPhi3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+    hf_norm.to(device=device, dtype=dtype)
+    hf_norm.eval()
+
+    custom_norm = Phi3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+    custom_norm.to(device=device, dtype=dtype)
+    custom_norm.load_state_dict(hf_norm.state_dict())
+    custom_norm.eval()
+
+    x = torch.randn(B, S, config.hidden_size, device=device, dtype=dtype)
+
+    torch.testing.assert_close(custom_norm(x), hf_norm(x), rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@torch.no_grad()
+def test_phi3_mlp_equivalence(B, S, dtype):
+    """Fused gate_up_proj MLP must match HF Phi3MLP."""
+    HFMLP = _get_hf_mlp_class()
+    if HFMLP is None:
+        pytest.skip("transformers doesn't have Phi3MLP")
+
+    device = "cuda"
+    config = _create_small_config()
+
+    hf_mlp = HFMLP(config)
+    hf_mlp.to(device=device, dtype=dtype)
+    hf_mlp.eval()
+
+    custom_mlp = Phi3MLP(config)
+    custom_mlp.to(device=device, dtype=dtype)
+    custom_mlp.load_state_dict(hf_mlp.state_dict())
+    custom_mlp.eval()
+
+    x = torch.randn(B, S, config.hidden_size, device=device, dtype=dtype)
+
+    torch.testing.assert_close(custom_mlp(x), hf_mlp(x), rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@torch.no_grad()
+def test_phi3_attention_equivalence(B, S, dtype):
+    """Fused qkv_proj attention must match HF Phi3Attention."""
+    HFAttention = _get_hf_attention_class()
+    HFRotary = _get_hf_rotary_class()
+    if HFAttention is None or HFRotary is None:
+        pytest.skip("transformers doesn't have Phi3Attention or Phi3RotaryEmbedding")
+
+    device = "cuda"
+    config = _create_small_config()
+    config._attn_implementation = "eager"
+
+    hf_attn = HFAttention(config, layer_idx=0)
+    hf_attn.to(device=device, dtype=dtype)
+    hf_attn.eval()
+
+    custom_attn = Phi3Attention(config, layer_idx=0)
+    custom_attn.to(device=device, dtype=dtype)
+    custom_attn.load_state_dict(hf_attn.state_dict())
+    custom_attn.eval()
+
+    x = torch.randn(B, S, config.hidden_size, device=device, dtype=dtype)
+    position_ids = torch.arange(S, device=device).unsqueeze(0).expand(B, -1)
+
+    hf_rotary = HFRotary(config=config, device=device)
+    hf_cos, hf_sin = hf_rotary(x, position_ids)
+
+    custom_rotary = Phi3RotaryEmbedding(config)
+    custom_rotary.to(device=device, dtype=dtype)
+    custom_cos, custom_sin = custom_rotary(x, position_ids)
+
+    causal_mask = _create_causal_mask(B, S, device, dtype)
+
+    hf_out, _ = hf_attn(
+        hidden_states=x,
+        position_embeddings=(hf_cos, hf_sin),
+        attention_mask=causal_mask,
+    )
+    custom_out = custom_attn(
+        hidden_states=x,
+        position_embeddings=(custom_cos, custom_sin),
+    )
+
+    assert_rmse_close(custom_out, hf_out, rmse_ratio_tol=0.10, msg="Attention: ")
+
+
+# =========================================================================
+# Layer equivalence tests (Level 2)
+# =========================================================================
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@torch.no_grad()
+def test_phi3_decoder_layer_equivalence(B, S, dtype):
+    HFDecoderLayer = _get_hf_decoder_layer_class()
+    HFRotary = _get_hf_rotary_class()
+    if HFDecoderLayer is None or HFRotary is None:
+        pytest.skip("transformers doesn't have Phi3DecoderLayer or Phi3RotaryEmbedding")
+
+    device = "cuda"
+    config = _create_small_config()
+    config._attn_implementation = "eager"
+
+    hf_layer = HFDecoderLayer(config, layer_idx=0)
+    hf_layer.to(device=device, dtype=dtype)
+    hf_layer.eval()
+
+    custom_layer = Phi3DecoderLayer(config, layer_idx=0)
+    custom_layer.to(device=device, dtype=dtype)
+    custom_layer.load_state_dict(hf_layer.state_dict())
+    custom_layer.eval()
+
+    x = torch.randn(B, S, config.hidden_size, device=device, dtype=dtype)
+    position_ids = torch.arange(S, device=device).unsqueeze(0).expand(B, -1)
+
+    hf_rotary = HFRotary(config=config, device=device)
+    hf_cos, hf_sin = hf_rotary(x, position_ids)
+
+    custom_rotary = Phi3RotaryEmbedding(config)
+    custom_rotary.to(device=device, dtype=dtype)
+    custom_cos, custom_sin = custom_rotary(x, position_ids)
+
+    causal_mask = _create_causal_mask(B, S, device, dtype)
+
+    hf_out = hf_layer(
+        hidden_states=x,
+        attention_mask=causal_mask,
+        position_ids=position_ids,
+        position_embeddings=(hf_cos, hf_sin),
+    )
+    if isinstance(hf_out, tuple):
+        hf_out = hf_out[0]
+
+    custom_out = custom_layer(
+        hidden_states=x,
+        position_embeddings=(custom_cos, custom_sin),
+    )
+
+    assert_rmse_close(custom_out, hf_out, rmse_ratio_tol=0.05, msg="Decoder layer: ")
+
+
+# =========================================================================
+# Full model equivalence tests (Level 3)
+# =========================================================================
+
+
+@pytest.mark.parametrize("B,S", _BATCH_AND_SEQUENCE_TEST_CASES)
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("device", ["cuda"])
+@torch.no_grad()
+def test_phi3_full_model_equivalence(B, S, dtype, device):
+    HFModel = _get_hf_model_class()
+    if HFModel is None:
+        pytest.skip("transformers doesn't have Phi3ForCausalLM")
+
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    config = _create_small_config()
+    config._attn_implementation = "eager"
+
+    hf_model = HFModel(config)
+    hf_model.to(device=device, dtype=dtype)
+    hf_model.eval()
+
+    custom_model = Phi3ForCausalLM(config)
+    custom_model.to(device=device, dtype=dtype)
+    custom_model.load_state_dict(hf_model.state_dict())
+    custom_model.eval()
+
+    input_ids = torch.randint(0, config.vocab_size, (B, S), device=device)
+    position_ids = torch.arange(S, device=device).unsqueeze(0).expand(B, -1)
+
+    hf_out = hf_model(input_ids=input_ids, position_ids=position_ids)
+    custom_out = custom_model(input_ids=input_ids, position_ids=position_ids)
+
+    assert_rmse_close(
+        custom_out.logits.float(),
+        hf_out.logits.float(),
+        rmse_ratio_tol=0.05,
+        msg="Full model logits: ",
+    )
+
+
+# =========================================================================
+# Export test (Level 4)
+# =========================================================================
+
+
+@torch.no_grad()
+def test_phi3_model_can_be_exported():
+    device = "cuda"
+    dtype = torch.bfloat16
+    config = _create_small_config()
+
+    model = Phi3ForCausalLM(config)
+    model.to(device=device, dtype=dtype)
+    model.eval()
+
+    B, S = 2, 8
+    input_ids = torch.randint(0, config.vocab_size, (B, S), device=device)
+    position_ids = torch.arange(S, device=device).unsqueeze(0).expand(B, -1)
+
+    eager_out = model(input_ids=input_ids, position_ids=position_ids)
+
+    dynamic_shapes = (
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+        {0: Dim.DYNAMIC, 1: Dim.DYNAMIC},
+    )
+
+    gm = torch_export_to_gm(
+        model,
+        args=tuple(),
+        kwargs={"input_ids": input_ids, "position_ids": position_ids},
+        dynamic_shapes=dynamic_shapes,
+    )
+    move_to_device(gm, device)
+
+    with torch.inference_mode():
+        out_gm = gm(input_ids=input_ids, position_ids=position_ids)
+
+    assert "logits" in out_gm
+    logits = out_gm["logits"]
+    assert logits.shape == (B, S, config.vocab_size)
+    assert_rmse_close(
+        logits.float(),
+        eager_out.logits.float(),
+        rmse_ratio_tol=0.05,
+        msg="Export vs eager: ",
+    )
+
+    B2, S2 = 1, 4
+    input_ids2 = torch.randint(0, config.vocab_size, (B2, S2), device=device)
+    position_ids2 = torch.arange(S2, device=device).unsqueeze(0).expand(B2, -1)
+
+    eager_out2 = model(input_ids=input_ids2, position_ids=position_ids2)
+    with torch.inference_mode():
+        out_gm2 = gm(input_ids=input_ids2, position_ids=position_ids2)
+
+    logits2 = out_gm2["logits"]
+    assert logits2.shape == (B2, S2, config.vocab_size)
+    assert_rmse_close(
+        logits2.float(),
+        eager_out2.logits.float(),
+        rmse_ratio_tol=0.05,
+        msg="Export vs eager (dynamic shape): ",
+    )
+
+
+# =========================================================================
+# Structural tests
+# =========================================================================
+
+
+def test_phi3_config_registration():
+    config = _create_small_config()
+    assert config.model_type == "phi3"
+    assert hasattr(config, "hidden_size")
+    assert hasattr(config, "num_attention_heads")
+    assert hasattr(config, "num_key_value_heads")
+
+
+def test_phi3_gqa_structure():
+    config = _create_small_config()
+    model = Phi3ForCausalLM(config)
+
+    attn = model.model.layers[0].self_attn
+    assert attn.num_heads == 4, f"Expected 4 Q heads, got {attn.num_heads}"
+    assert attn.num_kv_heads == 2, f"Expected 2 KV heads, got {attn.num_kv_heads}"
+
+
+def test_phi3_state_dict_keys():
+    """State_dict keys must match the fused Phi-3 checkpoint format."""
+    config = _create_small_config()
+    model = Phi3ForCausalLM(config)
+    state_dict = model.state_dict()
+
+    expected_key_patterns = [
+        "model.embed_tokens.weight",
+        "model.layers.0.self_attn.qkv_proj.weight",
+        "model.layers.0.self_attn.o_proj.weight",
+        "model.layers.0.mlp.gate_up_proj.weight",
+        "model.layers.0.mlp.down_proj.weight",
+        "model.layers.0.input_layernorm.weight",
+        "model.layers.0.post_attention_layernorm.weight",
+        "model.norm.weight",
+        "lm_head.weight",
+    ]
+    for key in expected_key_patterns:
+        assert key in state_dict, (
+            f"Expected key '{key}' in state_dict, got keys: {list(state_dict.keys())[:10]}..."
+        )
+
+    # Projections are fused: no separate q/k/v or gate/up keys.
+    for key in state_dict:
+        for unfused in ("q_proj", "k_proj", "v_proj", "gate_proj", "up_proj"):
+            assert unfused not in key, f"Unexpected unfused key: {key}"

--- a/tests/unittest/auto_deploy/singlegpu/models/test_phi3_modeling.py
+++ b/tests/unittest/auto_deploy/singlegpu/models/test_phi3_modeling.py
@@ -439,4 +439,4 @@ def test_phi3_state_dict_keys():
     # Projections are fused: no separate q/k/v or gate/up keys.
     for key in state_dict:
         for unfused in ("q_proj", "k_proj", "v_proj", "gate_proj", "up_proj"):
-            assert unfused not in key, f"Unexpected unfused key: {key}"
+            assert unfused not in key.split("."), f"Unexpected unfused key: {key}"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled Microsoft Phi-4 model variants (`microsoft/phi-4`, `microsoft/Phi-4-reasoning`, `microsoft/Phi-4-reasoning-plus`) for automatic deployment.

* **Bug Fixes**
  * Fixed tensor parallel sharding computation for fused weight operations to ensure correct dimension calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

close #14679

`_determine_fused_weight_dims` computed the q/k/v split sizes but never returned them, so tensor-parallel column sharding of a fused qkv_proj got None and broke Phi-3/Phi-4 at TP≥2 (reduction-dim mismatch [s44*s70, 3840] X [2560, 5120]).

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

- `test_determine_fused_weight_dims_qkv` -> New regression test. Exports a fused-QKV block and asserts `_determine_fused_weight_dims` returns the [q, k, v] split sizes (not None).
- `test_tp_sharding.py` -> Guards that the broader column/row TP-sharding path still produces correct sharded outputs
- manually tested on local L4 GPU and worked as expected

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
