### PR TITLE
[None][feat] support per-layer mixed-precision MoE serving (GLM, Qwen3-MoE)

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_glm.py
+++ b/tensorrt_llm/_torch/models/modeling_glm.py
@@ -370,9 +370,20 @@ class Glm4MoE(nn.Module):
     def _get_experts_quant_config(model_config, layer_idx: int) -> QuantConfig:
         if getattr(model_config, "quant_config_dict", None) is None:
             return model_config.quant_config
-        return model_config.quant_config_dict.get(
-            f"model.layers.{layer_idx}.mlp.experts", model_config.quant_config
-        )
+        qcd = model_config.quant_config_dict
+        base = f"model.layers.{layer_idx}.mlp.experts"
+        if base in qcd:
+            return qcd[base]
+        # ModelOpt exports MIXED_PRECISION checkpoints with per-expert keys (e.g.
+        # "...mlp.experts.0.gate_proj") rather than a single "...mlp.experts" key. The fused MoE
+        # uses one format for the whole experts block, so derive it from a representative routed
+        # expert linear (all experts in a layer share a format under a serveable recipe).
+        prefix = base + "."
+        for name, cfg in qcd.items():
+            if name.startswith(prefix) and name.endswith(
+                (".gate_proj", ".up_proj", ".down_proj")):
+                return cfg
+        return model_config.quant_config
 
     def compute_routed_output(
         self, hidden_states, hidden_states_fp4, all_rank_num_tokens, do_finalize
@@ -515,11 +526,14 @@ class Glm4DecoderLayer(DecoderLayer):
         self.enable_fusion = os.environ.get("TRTLLM_GLM_EAGER_FUSION_DISABLED", "0") == "0"
         self.enable_fusion &= not self.enable_attention_dp
 
-        # FIXME: incompatible with mixed quantization mode
+        # Per-layer quant config. Under MIXED_PRECISION the layer-level algo is ambiguous, so resolve
+        # the routed experts' format per layer (_get_experts_quant_config) and feed THAT to the MoE.
+        # Eager fusion (gated by is_nvfp4) is conservatively disabled under MIXED_PRECISION.
         quant_config = self._get_decoder_layer_quant_config(model_config, layer_idx)
-        self.is_nvfp4 = quant_config.layer_quant_mode.has_nvfp4()
-        assert quant_config.quant_algo is not QuantAlgo.MIXED_PRECISION, (
-            "MIXED_PRECISION is ambiguous"
+        experts_quant_config = Glm4MoE._get_experts_quant_config(model_config, layer_idx)
+        self.is_nvfp4 = (
+            quant_config.quant_algo is not QuantAlgo.MIXED_PRECISION
+            and quant_config.layer_quant_mode.has_nvfp4()
         )
 
         has_tp = mapping.has_tp()
@@ -543,7 +557,7 @@ class Glm4DecoderLayer(DecoderLayer):
                 * self.num_shared_experts,
                 dtype=config.torch_dtype,
                 model_config=model_config,
-                override_quant_config=quant_config,
+                override_quant_config=experts_quant_config,
                 aux_stream_dict=aux_stream_dict,
                 layer_idx=layer_idx,
             )

--- a/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_moe.py
@@ -82,6 +82,24 @@ class Qwen3Gate(nn.Module):
                 f"Unsupported routing method: {self.routing_method_type}")
 
 
+def _get_experts_quant_config(model_config, layer_idx):
+    """Per-layer routed-experts quant config for MIXED_PRECISION checkpoints. ModelOpt exports
+    per-expert keys (".../experts.0.gate_proj"); the fused MoE uses one format for the whole experts
+    block, so derive it from a representative routed expert. Falls back to the global config."""
+    qcd = getattr(model_config, "quant_config_dict", None)
+    if qcd is None:
+        return model_config.quant_config
+    base = f"model.layers.{layer_idx}.mlp.experts"
+    if base in qcd:
+        return qcd[base]
+    prefix = base + "."
+    for name, cfg in qcd.items():
+        if name.startswith(prefix) and name.endswith(
+            (".gate_proj", ".up_proj", ".down_proj")):
+            return cfg
+    return model_config.quant_config
+
+
 class Qwen3MoE(nn.Module):
 
     def __init__(
@@ -124,6 +142,7 @@ class Qwen3MoE(nn.Module):
             dtype=config.torch_dtype,
             reduce_results=False,
             model_config=model_config,
+            override_quant_config=_get_experts_quant_config(model_config, layer_idx),
             layer_idx=layer_idx,
             weight_loading_mode=self.weight_loading_mode,
         )

--- a/tests/unittest/_torch/modeling/test_mixed_precision_moe_quant_config.py
+++ b/tests/unittest/_torch/modeling/test_mixed_precision_moe_quant_config.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for per-layer routed-experts quant-config resolution used to serve MIXED_PRECISION
+MoE checkpoints (GLM-4.x, Qwen3-MoE). The fused MoE uses one format for a layer's whole experts
+block; ModelOpt exports per-expert keys, so the helper must derive the block format from a
+representative routed expert and otherwise fall back to the global config."""
+from types import SimpleNamespace
+
+import pytest
+
+from tensorrt_llm._torch.models.modeling_glm import Glm4MoE
+from tensorrt_llm._torch.models.modeling_qwen3_moe import \
+    _get_experts_quant_config as qwen3_get_experts_quant_config
+from tensorrt_llm.models.modeling_utils import QuantAlgo, QuantConfig
+
+GLOBAL = QuantConfig(quant_algo=QuantAlgo.MIXED_PRECISION)
+NVFP4 = QuantConfig(quant_algo=QuantAlgo.NVFP4)
+FP8 = QuantConfig(quant_algo=QuantAlgo.FP8)
+
+# both implementations share identical logic
+GETTERS = [Glm4MoE._get_experts_quant_config, qwen3_get_experts_quant_config]
+
+
+def _model_config(quant_config_dict):
+    return SimpleNamespace(quant_config=GLOBAL, quant_config_dict=quant_config_dict)
+
+
+@pytest.mark.parametrize("get_cfg", GETTERS)
+def test_no_per_layer_dict_returns_global(get_cfg):
+    # Uniform checkpoints have no per-layer table -> fall back to the global config.
+    assert get_cfg(_model_config(None), 3) is GLOBAL
+
+
+@pytest.mark.parametrize("get_cfg", GETTERS)
+def test_bare_experts_key(get_cfg):
+    cfg = {"model.layers.3.mlp.experts": NVFP4}
+    assert get_cfg(_model_config(cfg), 3) is NVFP4
+
+
+@pytest.mark.parametrize("get_cfg", GETTERS)
+def test_per_expert_keys_fallback(get_cfg):
+    # ModelOpt exports per-expert keys, not a bare "...mlp.experts" key; derive from a member.
+    cfg = {
+        "model.layers.3.mlp.experts.0.gate_proj": FP8,
+        "model.layers.3.mlp.experts.0.up_proj": FP8,
+        "model.layers.3.mlp.experts.0.down_proj": FP8,
+        "model.layers.3.self_attn.q_proj": NVFP4,  # must be ignored (not an expert)
+    }
+    assert get_cfg(_model_config(cfg), 3) is FP8
+
+
+@pytest.mark.parametrize("get_cfg", GETTERS)
+def test_other_layer_keys_return_global(get_cfg):
+    # Only a *different* layer's experts are present -> no match for layer 3 -> global.
+    cfg = {"model.layers.5.mlp.experts.0.gate_proj": NVFP4}
+    assert get_cfg(_model_config(cfg), 3) is GLOBAL


### PR DESCRIPTION
## What
Enable serving **per-layer mixed-precision MoE** checkpoints (e.g. NVFP4 + FP8 across layers) for GLM-4.x and Qwen3-MoE.

## Why
Today a `MIXED_PRECISION` MoE checkpoint fails to serve:
- **GLM** asserts `MIXED_PRECISION is ambiguous` in `Glm4DecoderLayer`.
- The fused MoE otherwise receives the **global** quant config, so under `MIXED_PRECISION` it allocates the experts as **bf16** and crashes in `load_expert_w3_w1_weight` with a shape mismatch.

## How
- Pass the **per-layer routed-experts** quant config to the MoE. `ConfigurableMoE` already propagates `override_quant_config` to the backend before `create_weights`, so the buffers are then allocated in the correct per-layer format.
- `_get_experts_quant_config` derives the block format from the **per-expert keys ModelOpt exports** (`...mlp.experts.0.gate_proj`) when a fused `...mlp.experts` key is absent.
- Drop the `MIXED_PRECISION` assert in GLM; disable eager fusion under `MIXED_PRECISION`.
- Same one-line wiring for `Qwen3MoE`.

Constraint unchanged: a layer's experts block uses a **single** format (fused-kernel requirement); formats may differ **across** layers.

## Test
- Added `tests/unittest/_torch/modeling/test_mixed_precision_moe_quant_config.py` (pure-Python: per-expert-key fallback / bare-key / global-fallback, for both GLM and Qwen3-MoE).
- Validated end-to-end on the equivalent code in a 1.3.0rc8 build: tiny synthetic GLM-4-MoE loads/runs (log-prob cosine 0.9999 vs the fake-quant reference; uniform-NVFP4 output bit-identical to baseline), and a real **Qwen3-30B-A3B** mixed NVFP4+FP8 checkpoint serves on a single GPU with coherent output at ~232 tok/s decode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced quantization configuration handling for mixture-of-experts models in mixed-precision checkpoints across GLM-4 and Qwen3 architectures.

* **Tests**
  * Added unit tests for expert quantization configuration resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->