### PR TITLE
[None][bugfix] Fix Mamba preloaded HF model loading

### DIFF
--- a/tensorrt_llm/models/mamba/model.py
+++ b/tensorrt_llm/models/mamba/model.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -456,7 +456,9 @@ class MambaForCausalLM(PretrainedModel):
                                                quant_config=quant_config,
                                                **kwargs)
 
-        if not os.path.exists(hf_model_dir):
+        if use_preloading:
+            weights = convert_hf_mamba(hf_model, dtype)
+        elif not os.path.exists(hf_model_dir):
             hf_model = AutoModelForCausalLM.from_pretrained(
                 hf_model_dir, dtype="auto", trust_remote_code=True)
 


### PR DESCRIPTION
### What changed

`MambaForCausalLM.from_hugging_face()` now handles an already-loaded Hugging Face `PreTrainedModel` before checking filesystem paths.

### Why

The preloaded-model path set `hf_model` and `hf_config_or_dir`, but `hf_model_dir` was only initialized for string inputs. The shared path check could therefore raise `UnboundLocalError` before conversion.

### Validation

- `python3 -m py_compile tensorrt_llm/models/mamba/model.py`
- `git diff --check -- tensorrt_llm/models/mamba/model.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized Mamba model weight loading process for preloaded Hugging Face models. The weight conversion logic has been refined to directly and efficiently process preloaded model instances, improving compatibility and performance. Complete backward compatibility is maintained for all existing remote model loading scenarios.

* **Chores**
  * Updated copyright year information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->