### PR TITLE
Fix NVFP4 pre-MLP fusion capability check

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -1313,8 +1313,6 @@ class DeepseekV3DecoderLayer(DecoderLayer):
                 config.intermediate_size, block_size)
 
             has_mlp_tp = self.mlp_tp_size > 1
-            self.fusion_config.PRE_MLP_FUSION = self.enable_fusion and has_mlp_tp and self.is_nvfp4
-            self.fusion_config.POST_MLP_FUSION = self.enable_fusion and has_mlp_tp
 
             self.mlp = GatedMLP(
                 hidden_size=config.hidden_size,
@@ -1327,6 +1325,10 @@ class DeepseekV3DecoderLayer(DecoderLayer):
                 use_cute_dsl_blockscaling_mm=model_config.
                 use_cute_dsl_blockscaling_mm,
             )
+            self.fusion_config.PRE_MLP_FUSION = (
+                self.enable_fusion and has_mlp_tp
+                and self.mlp.can_use_nvfp4_pre_quant_fusion())
+            self.fusion_config.POST_MLP_FUSION = self.enable_fusion and has_mlp_tp
 
         self.input_layernorm = RMSNorm(hidden_size=config.hidden_size,
                                        eps=config.rms_norm_eps,

--- a/tensorrt_llm/_torch/models/modeling_exaone_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_exaone_moe.py
@@ -236,9 +236,6 @@ class ExaoneMoeDecoderLayer(DecoderLayer):
             self.mlp_tp_size = self._compute_mlp_tp_size(config.intermediate_size, block_size)
             has_mlp_tp = self.mlp_tp_size > 1
 
-            self.fusion_config.PRE_MLP_FUSION = self.enable_fusion and has_mlp_tp and self.is_nvfp4
-            self.fusion_config.POST_MLP_FUSION = self.enable_fusion and has_mlp_tp
-
             self.mlp = GatedMLP(
                 hidden_size=config.hidden_size,
                 intermediate_size=config.intermediate_size,
@@ -251,6 +248,10 @@ class ExaoneMoeDecoderLayer(DecoderLayer):
                 layer_idx=layer_idx,
                 reduce_output=has_mlp_tp,
             )
+            self.fusion_config.PRE_MLP_FUSION = (
+                self.enable_fusion and has_mlp_tp
+                and self.mlp.can_use_nvfp4_pre_quant_fusion())
+            self.fusion_config.POST_MLP_FUSION = self.enable_fusion and has_mlp_tp
 
         self.disable_attn_allreduce = (
             self.fusion_config.PRE_MOE_FUSION

--- a/tensorrt_llm/_torch/models/modeling_glm.py
+++ b/tensorrt_llm/_torch/models/modeling_glm.py
@@ -554,8 +554,6 @@ class Glm4DecoderLayer(DecoderLayer):
             self.mlp_tp_size = self._compute_mlp_tp_size(config.intermediate_size, block_size)
 
             has_mlp_tp = self.mlp_tp_size > 1
-            self.fusion_config.PRE_MLP_FUSION = self.enable_fusion and has_mlp_tp and self.is_nvfp4
-            self.fusion_config.POST_MLP_FUSION = self.enable_fusion and has_mlp_tp
 
             self.mlp = GatedMLP(
                 hidden_size=config.hidden_size,
@@ -566,6 +564,10 @@ class Glm4DecoderLayer(DecoderLayer):
                 overridden_tp_size=self.mlp_tp_size,
                 reduce_output=True,
             )
+            self.fusion_config.PRE_MLP_FUSION = (
+                self.enable_fusion and has_mlp_tp
+                and self.mlp.can_use_nvfp4_pre_quant_fusion())
+            self.fusion_config.POST_MLP_FUSION = self.enable_fusion and has_mlp_tp
 
         self.input_layernorm = RMSNorm(
             hidden_size=config.hidden_size, eps=config.rms_norm_eps, dtype=config.torch_dtype

--- a/tensorrt_llm/_torch/modules/gated_mlp.py
+++ b/tensorrt_llm/_torch/modules/gated_mlp.py
@@ -186,6 +186,14 @@ class GatedMLP(nn.Module):
             return False
         return True
 
+    def can_use_nvfp4_pre_quant_fusion(self):
+        """Return whether gate_up_proj can consume externally quantized FP4 input."""
+        return (self.gate_up_proj.has_nvfp4
+                and hasattr(self.gate_up_proj, "input_scale")
+                and self.gate_up_proj.input_scale is not None
+                and not self.gate_up_proj.force_dynamic_quantization
+                and self.gate_up_proj.pre_quant_scale is None)
+
     def _fused_gate_up_swiglu(self, x, fp4_out=False):
         """Fused FC1 GEMM + SwiGLU using CuteDSL dense kernel.
 


### PR DESCRIPTION
## Summary

Fix NVFP4 pre-MLP fusion enablement for dense GatedMLP layers by checking the actual `gate_up_proj` capabilities before enabling the quantizing fused all-reduce path.

## Root Cause

GLM/DeepSeek/Exaone dense MLP layers enabled `PRE_MLP_FUSION` from the layer-level NVFP4 quantization flag. That path later unconditionally reads `self.mlp.gate_up_proj.input_scale`.

For recipes where the dense `gate_up_proj` is still an unquantized `Linear`, the layer-level flag can be true while `gate_up_proj` has no `input_scale`, causing warmup to fail with:

```text
AttributeError: 'Linear' object has no attribute 'input_scale'
```

## Changes

- Add `GatedMLP.can_use_nvfp4_pre_quant_fusion()` to centralize the capability check.
- Enable dense pre-MLP NVFP4 quant fusion only when `gate_up_proj`:
  - is NVFP4,
  - has a non-null static `input_scale`,
  - is not forced to dynamic quantization,
  - has no `pre_quant_scale` that requires local input preparation.
- Apply the check to DeepSeekV3, GLM, and Exaone-MoE dense MLP layer setup.

## Validation

- `python3 -m py_compile tensorrt_llm/_torch/modules/gated_mlp.py tensorrt_llm/_torch/models/modeling_deepseekv3.py tensorrt_llm/_torch/models/modeling_glm.py tensorrt_llm/_torch/models/modeling_exaone_moe.py`
- `git diff --check`

`ruff` and runtime GLM5.1-NVFP4 validation were not run in this local environment because the checkout does not have the project Python dependencies installed.
