### PR TITLE
[#15516][fix] Guard PRE_MLP NVFP4 fusion when dense MLP is unquantized

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_deepseekv3.py
+++ b/tensorrt_llm/_torch/models/modeling_deepseekv3.py
@@ -74,6 +74,8 @@ from ..utils import (AuxStreamType, EventType, Fp4QuantizedTensor,
                      create_lm_head_tp_mapping)
 from .modeling_speculative import SpecDecOneEngineForCausalLM
 from .modeling_utils import (DecoderModel, EagerFusionConfig, filter_weights,
+                             gate_up_proj_supports_pre_mlp_nvfp4_fusion,
+                             reconcile_pre_mlp_nvfp4_fusion,
                              register_auto_model)
 
 
@@ -1541,7 +1543,9 @@ class DeepseekV3DecoderLayer(DecoderLayer):
         spec_metadata: Optional[SpecMetadata] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
 
-        if self.fusion_config.PRE_MLP_FUSION:
+        if (self.fusion_config.PRE_MLP_FUSION
+                and gate_up_proj_supports_pre_mlp_nvfp4_fusion(
+                    self.mlp.gate_up_proj)):
             act_fp4, act_sf, residual = self.allreduce(
                 hidden_states,
                 all_reduce_params=AllReduceParams(
@@ -1929,3 +1933,5 @@ class DeepseekV3ForCausalLM(SpecDecOneEngineForCausalLM[DeepseekV3Model,
             else:
                 layer.next_layer_layernorm = self.model.layers[
                     idx + 1].input_layernorm
+            if isinstance(layer.mlp, GatedMLP):
+                reconcile_pre_mlp_nvfp4_fusion(layer.fusion_config, layer.mlp)

--- a/tensorrt_llm/_torch/models/modeling_exaone_moe.py
+++ b/tensorrt_llm/_torch/models/modeling_exaone_moe.py
@@ -54,7 +54,10 @@ from ..utils import AuxStreamType, EventType, Fp4QuantizedTensor
 from .checkpoints.hf.exaone_moe_weight_mapper import ExaoneMoeWeightMapper
 from .modeling_deepseekv3 import DeepseekV3MTPHead
 from .modeling_speculative import SpecDecOneEngineForCausalLM
-from .modeling_utils import DecoderModel, EagerFusionConfig, register_auto_model
+from .modeling_utils import (DecoderModel, EagerFusionConfig,
+                             gate_up_proj_supports_pre_mlp_nvfp4_fusion,
+                             reconcile_pre_mlp_nvfp4_fusion,
+                             register_auto_model)
 
 
 def check_is_moe(config: ExaoneMoeConfig, layer_idx: int, is_mtp_layer: bool = False) -> bool:
@@ -432,7 +435,9 @@ class ExaoneMoeDecoderLayer(DecoderLayer):
         hidden_states: torch.Tensor,
         residual: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        if self.fusion_config.PRE_MLP_FUSION:
+        if (self.fusion_config.PRE_MLP_FUSION
+                and gate_up_proj_supports_pre_mlp_nvfp4_fusion(
+                    self.mlp.gate_up_proj)):
             act_fp4, act_sf, residual = self.allreduce(
                 hidden_states,
                 all_reduce_params=AllReduceParams(
@@ -732,3 +737,5 @@ class ExaoneMoeForCausalLM(SpecDecOneEngineForCausalLM[ExaoneMoeModel, ExaoneMoe
                 layer.next_layer_layernorm = self.model.norm
             else:
                 layer.next_layer_layernorm = self.model.layers[idx + 1].input_layernorm
+            if isinstance(layer.mlp, GatedMLP):
+                reconcile_pre_mlp_nvfp4_fusion(layer.fusion_config, layer.mlp)

--- a/tensorrt_llm/_torch/models/modeling_glm.py
+++ b/tensorrt_llm/_torch/models/modeling_glm.py
@@ -44,6 +44,8 @@ from .modeling_utils import (
     EagerFusionConfig,
     duplicate_kv_weight,
     filter_weights,
+    gate_up_proj_supports_pre_mlp_nvfp4_fusion,
+    reconcile_pre_mlp_nvfp4_fusion,
     register_auto_model,
 )
 
@@ -773,7 +775,9 @@ class Glm4DecoderLayer(DecoderLayer):
         residual: torch.Tensor,
         spec_metadata: Optional[SpecMetadata] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        if self.fusion_config.PRE_MLP_FUSION:
+        if (self.fusion_config.PRE_MLP_FUSION
+                and gate_up_proj_supports_pre_mlp_nvfp4_fusion(
+                    self.mlp.gate_up_proj)):
             act_fp4, act_sf, residual = self.allreduce(
                 hidden_states,
                 all_reduce_params=AllReduceParams(
@@ -1080,3 +1084,5 @@ class Glm4MoeForCausalLM(SpecDecOneEngineForCausalLM[Glm4Model, PretrainedConfig
                 layer.next_layer_layernorm = self.model.norm
             else:
                 layer.next_layer_layernorm = self.model.layers[idx + 1].input_layernorm
+            if isinstance(layer.mlp, GatedMLP):
+                reconcile_pre_mlp_nvfp4_fusion(layer.fusion_config, layer.mlp)

--- a/tensorrt_llm/_torch/models/modeling_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_utils.py
@@ -46,6 +46,23 @@ class EagerFusionConfig:
     POST_MOE_FUSION: bool = False
 
 
+def gate_up_proj_supports_pre_mlp_nvfp4_fusion(gate_up_proj) -> bool:
+    """Return True when PRE_MLP NVFP4 fusion can read gate_up_proj.input_scale."""
+    return getattr(gate_up_proj, "has_nvfp4",
+                   False) and hasattr(gate_up_proj, "input_scale")
+
+
+def reconcile_pre_mlp_nvfp4_fusion(fusion_config: EagerFusionConfig,
+                                   mlp) -> None:
+    """Disable PRE_MLP_FUSION when dense MLP gate_up_proj is not NVFP4."""
+    if not fusion_config.PRE_MLP_FUSION:
+        return
+    gate_up_proj = getattr(mlp, "gate_up_proj", None)
+    if gate_up_proj is None or not gate_up_proj_supports_pre_mlp_nvfp4_fusion(
+            gate_up_proj):
+        fusion_config.PRE_MLP_FUSION = False
+
+
 class MetaInitException(RuntimeError):
     pass
 

--- a/tests/unittest/_torch/modeling/test_pre_mlp_nvfp4_fusion.py
+++ b/tests/unittest/_torch/modeling/test_pre_mlp_nvfp4_fusion.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for PRE_MLP NVFP4 fusion helpers."""
+
+from types import SimpleNamespace
+
+from tensorrt_llm._torch.models.modeling_utils import (
+    EagerFusionConfig,
+    gate_up_proj_supports_pre_mlp_nvfp4_fusion,
+    reconcile_pre_mlp_nvfp4_fusion,
+)
+
+
+def test_gate_up_proj_supports_pre_mlp_nvfp4_fusion():
+    assert gate_up_proj_supports_pre_mlp_nvfp4_fusion(
+        SimpleNamespace(has_nvfp4=True, input_scale=1.0))
+    assert not gate_up_proj_supports_pre_mlp_nvfp4_fusion(
+        SimpleNamespace(has_nvfp4=False))
+    assert not gate_up_proj_supports_pre_mlp_nvfp4_fusion(SimpleNamespace())
+
+
+def test_reconcile_pre_mlp_nvfp4_fusion():
+    fusion_config = EagerFusionConfig(PRE_MLP_FUSION=True)
+    mlp = SimpleNamespace(
+        gate_up_proj=SimpleNamespace(has_nvfp4=False),
+    )
+    reconcile_pre_mlp_nvfp4_fusion(fusion_config, mlp)
+    assert fusion_config.PRE_MLP_FUSION is False
+
+    fusion_config = EagerFusionConfig(PRE_MLP_FUSION=True)
+    mlp = SimpleNamespace(
+        gate_up_proj=SimpleNamespace(has_nvfp4=True, input_scale=1.0),
+    )
+    reconcile_pre_mlp_nvfp4_fusion(fusion_config, mlp)
+    assert fusion_config.PRE_MLP_FUSION is True


### PR DESCRIPTION
@coderabbitai summary

## Description

Fixes #15516.

Serving `nvidia/GLM-5.1-NVFP4` fails during PyExecutor warmup with:

```
AttributeError: 'Linear' object has no attribute 'input_scale'
```

**Root cause:** `PRE_MLP_FUSION` is enabled per dense decoder layer when global quant config is NVFP4 and MLP TP > 1, but the checkpoint excludes submodule weights (e.g. `model.layers.0*`, `model.layers.1.*`, `model.layers.2.*`) from quantization. Layer-level `_get_decoder_layer_quant_config()` only checks whether the whole layer `model.layers.{idx}` is excluded, so `is_nvfp4` stays `True` and `PRE_MLP_FUSION` is set. Later, `apply_quant_config_exclude_modules()` correctly de-quantizes `gate_up_proj`, leaving a plain `Linear` without `input_scale`. `forward_mlp()` still takes the NVFP4 fusion path and crashes.

**Fix:**
- Add shared helpers in `modeling_utils.py` to detect when `gate_up_proj` supports PRE_MLP NVFP4 fusion.
- Guard the fusion path in `forward_mlp()` for DeepSeek V3, GLM, and ExaOne MoE models.
- Reconcile `PRE_MLP_FUSION` in `post_load_weights()` after exclude-module handling and weight load.

This is a defensive reconcile against the final module quantization state, rather than re-parsing `hf_quant_config.json`, so it stays consistent with `apply_quant_config_exclude_modules()` for any exclude pattern/source.

## Test Coverage

- Added unit tests: `tests/unittest/_torch/modeling/test_pre_mlp_nvfp4_fusion.py`
  - `gate_up_proj_supports_pre_mlp_nvfp4_fusion()`
  - `reconcile_pre_mlp_nvfp4_fusion()`
- Manual verification (reporter environment, not yet run on this branch):
  - `trtllm-serve /models` with `nvidia/GLM-5.1-NVFP4`, 2x B300, `release:1.3.0rc17`, `--tp_size 2`, ConfigMap config with `moe_config.backend: TRTLLM` and MTP enabled
  - Confirm warmup succeeds without `gate_up_proj.input_scale` AttributeError

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
