### PR TITLE
[None][fix] avoid type checking failures due to pip dependency resolution

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -47,3 +47,5 @@ nvidia-cuda-cupti>=13.0,<13.2
 cxxfilt
 hf-transfer==0.1.9
 line_profiler
+# workaround to prevent picking up 20260602.2.5 which pulls in NumPy 2.5.0
+numpy-typing-compat!=20260602.2.5


### PR DESCRIPTION
## Description

The recent release of NumPy (2.5.0), made numpy-typing-compat 20260602.2.5 installable, which depends on numpy 2.5.0. As described in the [documentation of numpy-typing-compat](https://pypi.org/project/numpy-typing-compat/), this results in the installation of numpy 2.5.0, even though `numpy <2.4.0` is required elsewhere. NumPy 2.5.0, in turn, brakes static type checking.

## Test Coverage

n/a

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted development dependency constraints for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->