### PR TITLE
[None][doc] Clarify dtype='auto' resolution for LLM and KvCacheConfig

### DIFF
--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3374,11 +3374,11 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
     dtype: str = Field(
         default="auto",
         description=
-                "The data type for the KV cache. 'auto' (default) leaves the checkpoint's "
-                "own KV-cache quantization metadata untouched (quant_config.kv_cache_quant_algo "
-                "is inherited as-is); 'fp8' or 'nvfp4' override it explicitly. Resolved at "
-                "LLM-construction time, including when set via trtllm-serve "
-                "--extra_llm_api_options.",
+        "The data type for the KV cache. 'auto' (default) leaves the checkpoint's "
+        "own KV-cache quantization metadata untouched (quant_config.kv_cache_quant_algo "
+        "is inherited as-is); 'fp8' or 'nvfp4' override it explicitly. Resolved at "
+        "LLM-construction time, including when set via trtllm-serve "
+        "--extra_llm_api_options.",
         telemetry=TelemetryField.categorical("auto", "float16", "bfloat16",
                                              "float32", "fp8", "nvfp4"))
 
@@ -3817,15 +3817,16 @@ class BaseLlmArgs(StrictBaseModel):
     tensor_parallel_size: int = Field(default=1,
                                       description="The tensor parallel size.")
 
-    dtype: str = Field(default="auto",
-                       description="The data type to use for the model. When 'auto' "
-                                    "(default), it is read from the HF config.json ('dtype', or the "
-                                    "deprecated 'torch_dtype'); for composite/VLM configs it falls "
-                                    "back to the nested text_config.dtype. Defaults to bfloat16 if "
-                                    "none is found, and is overridden to float16 on GPUs with compute "
-                                    "capability < 8.0 (pre-Ampere).",
-                       telemetry=TelemetryField.categorical(
-                           "auto", "float16", "bfloat16", "float32"))
+    dtype: str = Field(
+        default="auto",
+        description="The data type to use for the model. When 'auto' "
+        "(default), it is read from the HF config.json ('dtype', or the "
+        "deprecated 'torch_dtype'); for composite/VLM configs it falls "
+        "back to the nested text_config.dtype. Defaults to bfloat16 if "
+        "none is found, and is overridden to float16 on GPUs with compute "
+        "capability < 8.0 (pre-Ampere).",
+        telemetry=TelemetryField.categorical("auto", "float16", "bfloat16",
+                                             "float32"))
 
     revision: Optional[str] = Field(
         default=None, description="The revision to use for the model.")

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3374,7 +3374,11 @@ class KvCacheConfig(StrictBaseModel, PybindMirror):
     dtype: str = Field(
         default="auto",
         description=
-        "The data type to use for the KV cache. Use 'auto' to follow checkpoint metadata, otherwise force the specified dtype.",
+                "The data type for the KV cache. 'auto' (default) leaves the checkpoint's "
+                "own KV-cache quantization metadata untouched (quant_config.kv_cache_quant_algo "
+                "is inherited as-is); 'fp8' or 'nvfp4' override it explicitly. Resolved at "
+                "LLM-construction time, including when set via trtllm-serve "
+                "--extra_llm_api_options.",
         telemetry=TelemetryField.categorical("auto", "float16", "bfloat16",
                                              "float32", "fp8", "nvfp4"))
 
@@ -3814,7 +3818,12 @@ class BaseLlmArgs(StrictBaseModel):
                                       description="The tensor parallel size.")
 
     dtype: str = Field(default="auto",
-                       description="The data type to use for the model.",
+                       description="The data type to use for the model. When 'auto' "
+                                    "(default), it is read from the HF config.json ('dtype', or the "
+                                    "deprecated 'torch_dtype'); for composite/VLM configs it falls "
+                                    "back to the nested text_config.dtype. Defaults to bfloat16 if "
+                                    "none is found, and is overridden to float16 on GPUs with compute "
+                                    "capability < 8.0 (pre-Ampere).",
                        telemetry=TelemetryField.categorical(
                            "auto", "float16", "bfloat16", "float32"))
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified automatic data type resolution for KV-cache and model configurations, including explicit override behavior and GPU compute capability impacts on selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Documents the `dtype="auto"` resolution behavior for two fields in `tensorrt_llm/llmapi/llm_args.py`, which previously gave no detail on what `"auto"` resolves to.

**`BaseLlmArgs.dtype`** — `"auto"` reads `dtype` (or deprecated `torch_dtype`) from the HF `config.json`, falls back to nested `text_config.dtype` for composite/VLM configs, defaults to `bfloat16` when none is found, and is overridden to `float16` on pre-Ampere GPUs (compute capability < 8.0).

**`KvCacheConfig.dtype`** — `"auto"` leaves the checkpoint's own KV-cache quant metadata (`quant_config.kv_cache_quant_algo`) untouched; `"fp8"`/`"nvfp4"` override it explicitly, resolved at LLM-construction time including via `trtllm-serve --extra_llm_api_options`.

Docstring-only change; no functional or behavioral changes.

## Test Coverage

N/A — documentation-only change to `Field(description=...)` strings.

Closes #15512