### PR TITLE
[None][feat] Add prefix-aware scheduling config flag to support opt-out

### DIFF
--- a/cpp/include/tensorrt_llm/batch_manager/capacityScheduler.h
+++ b/cpp/include/tensorrt_llm/batch_manager/capacityScheduler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2023-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,7 +97,8 @@ class MaxUtilizationScheduler : public BaseCapacityScheduler
 public:
     MaxUtilizationScheduler(SizeType32 maxNumRequests, bool twoStepsLookAhead,
         LlmRequestState noScheduleUntilState = LlmRequestState::kCONTEXT_INIT,
-        LlmRequestState noScheduleAfterState = LlmRequestState::kGENERATION_COMPLETE);
+        LlmRequestState noScheduleAfterState = LlmRequestState::kGENERATION_COMPLETE,
+        bool enablePrefixAwareScheduling = true);
 
     [[nodiscard]] std::tuple<RequestVector, RequestVector> operator()(
         kv_cache_manager::BaseKVCacheManager& kvCacheManager,
@@ -108,6 +109,8 @@ private:
     SizeType32 mMaxNumRequests;
     /// @brief Boolean that indicates if two step lookahead is enabled
     bool mTwoStepsLookAhead;
+    /// @brief Whether to use KV prefix-reuse estimates in scheduling decisions.
+    bool mEnablePrefixAwareScheduling;
 };
 
 /// @brief Schedule requests using the GUARANTEED_NO_EVICT policy
@@ -120,7 +123,8 @@ class GuaranteedNoEvictScheduler : public BaseCapacityScheduler
 public:
     GuaranteedNoEvictScheduler(SizeType32 maxNumRequests,
         LlmRequestState noScheduleUntilState = LlmRequestState::kCONTEXT_INIT,
-        LlmRequestState noScheduleAfterState = LlmRequestState::kGENERATION_COMPLETE);
+        LlmRequestState noScheduleAfterState = LlmRequestState::kGENERATION_COMPLETE,
+        bool enablePrefixAwareScheduling = true);
 
     [[nodiscard]] std::tuple<RequestVector, RequestVector> operator()(
         kv_cache_manager::BaseKVCacheManager const& kvCacheManager,
@@ -136,6 +140,8 @@ protected:
 
 private:
     SizeType32 mMaxNumRequests;
+    /// @brief Whether to use KV prefix-reuse estimates in scheduling decisions.
+    bool mEnablePrefixAwareScheduling;
 };
 
 /// @brief Schedule requests using the STATIC_BATCH policy
@@ -144,7 +150,8 @@ class StaticBatchScheduler : public GuaranteedNoEvictScheduler
 public:
     StaticBatchScheduler(SizeType32 maxNumRequests,
         LlmRequestState noScheduleUntilState = LlmRequestState::kCONTEXT_INIT,
-        LlmRequestState noScheduleAfterState = LlmRequestState::kGENERATION_COMPLETE);
+        LlmRequestState noScheduleAfterState = LlmRequestState::kGENERATION_COMPLETE,
+        bool enablePrefixAwareScheduling = true);
 
     [[nodiscard]] std::tuple<RequestVector, RequestVector> operator()(
         kv_cache_manager::BaseKVCacheManager const& kvCacheManager,
@@ -160,7 +167,8 @@ public:
     explicit CapacityScheduler(SizeType32 maxNumRequests, executor::CapacitySchedulerPolicy capacitySchedulerPolicy,
         bool hasKvCacheManager, bool twoStepsLookAhead = false,
         LlmRequestState noScheduleUntilState = LlmRequestState::kCONTEXT_INIT,
-        LlmRequestState noScheduleAfterState = LlmRequestState::kGENERATION_COMPLETE);
+        LlmRequestState noScheduleAfterState = LlmRequestState::kGENERATION_COMPLETE,
+        bool enablePrefixAwareScheduling = true);
 
     /**
      * @brief Schedules requests following the selected policy.

--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -989,6 +989,8 @@ public:
 
     [[nodiscard]] std::vector<std::pair<SizeType32, SizeType32>> getBatchSizeTable() const;
 
+    bool operator==(DynamicBatchConfig const& other) const;
+
     /// @brief The default value of batch size table
     static std::vector<std::pair<SizeType32, SizeType32>> const kDefaultBatchSizeTable;
 

--- a/cpp/include/tensorrt_llm/executor/executor.h
+++ b/cpp/include/tensorrt_llm/executor/executor.h
@@ -1019,7 +1019,7 @@ public:
     explicit SchedulerConfig(
         CapacitySchedulerPolicy capacitySchedulerPolicy = CapacitySchedulerPolicy::kGUARANTEED_NO_EVICT,
         std::optional<ContextChunkingPolicy> contextChunkingPolicy = std::nullopt,
-        std::optional<DynamicBatchConfig> dynamicBatchConfig = std::nullopt);
+        std::optional<DynamicBatchConfig> dynamicBatchConfig = std::nullopt, bool enablePrefixAwareScheduling = true);
 
     bool operator==(SchedulerConfig const& other) const;
 
@@ -1028,6 +1028,8 @@ public:
     [[nodiscard]] std::optional<ContextChunkingPolicy> getContextChunkingPolicy() const;
 
     [[nodiscard]] std::optional<DynamicBatchConfig> getDynamicBatchConfig() const;
+
+    [[nodiscard]] bool getEnablePrefixAwareScheduling() const;
 
 private:
     friend class Serialization;
@@ -1040,6 +1042,9 @@ private:
 
     /// @brief The config for tuning batch size dynamically. See DynamicBatchSizeConfig.
     std::optional<DynamicBatchConfig> mDynamicBatchConfig;
+
+    /// @brief Whether schedulers use KV prefix-reuse estimates for admission and token-budget decisions.
+    bool mEnablePrefixAwareScheduling;
 };
 
 /// @brief Configuration class for the KV cache

--- a/cpp/tensorrt_llm/batch_manager/capacityScheduler.cpp
+++ b/cpp/tensorrt_llm/batch_manager/capacityScheduler.cpp
@@ -351,7 +351,8 @@ std::tuple<RequestVector, RequestVector> GuaranteedNoEvictScheduler::impl(
                         crossSummary = crossKvCacheManager->analyzePrefixReuse(uniqueTokens, *req);
                     }
                 }
-                else if (isEncoderInit && crossKvCacheManager && crossKvCacheManager->isEnableBlockReuse()
+                else if (mEnablePrefixAwareScheduling && isEncoderInit && crossKvCacheManager
+                    && crossKvCacheManager->isEnableBlockReuse()
                     && !crossKvCacheManager->getBlockManager().isVariableWindow())
                 {
                     // Encoder admission only needs the cross summary for reuse ordering.

--- a/cpp/tensorrt_llm/batch_manager/capacityScheduler.cpp
+++ b/cpp/tensorrt_llm/batch_manager/capacityScheduler.cpp
@@ -151,23 +151,26 @@ MaxRequestsScheduler::MaxRequestsScheduler(
 }
 
 MaxUtilizationScheduler::MaxUtilizationScheduler(SizeType32 maxNumRequests, bool twoStepsLookAhead,
-    LlmRequestState noScheduleUntilState, LlmRequestState noScheduleAfterState)
+    LlmRequestState noScheduleUntilState, LlmRequestState noScheduleAfterState, bool enablePrefixAwareScheduling)
     : BaseCapacityScheduler(noScheduleUntilState, noScheduleAfterState)
     , mMaxNumRequests(maxNumRequests)
     , mTwoStepsLookAhead{twoStepsLookAhead}
+    , mEnablePrefixAwareScheduling{enablePrefixAwareScheduling}
 {
 }
 
-GuaranteedNoEvictScheduler::GuaranteedNoEvictScheduler(
-    SizeType32 maxNumRequests, LlmRequestState noScheduleUntilState, LlmRequestState noScheduleAfterState)
+GuaranteedNoEvictScheduler::GuaranteedNoEvictScheduler(SizeType32 maxNumRequests, LlmRequestState noScheduleUntilState,
+    LlmRequestState noScheduleAfterState, bool enablePrefixAwareScheduling)
     : BaseCapacityScheduler(noScheduleUntilState, noScheduleAfterState)
     , mMaxNumRequests(maxNumRequests)
+    , mEnablePrefixAwareScheduling{enablePrefixAwareScheduling}
 {
 }
 
-StaticBatchScheduler::StaticBatchScheduler(
-    SizeType32 maxNumRequests, LlmRequestState noScheduleUntilState, LlmRequestState noScheduleAfterState)
-    : GuaranteedNoEvictScheduler(maxNumRequests, noScheduleUntilState, noScheduleAfterState)
+StaticBatchScheduler::StaticBatchScheduler(SizeType32 maxNumRequests, LlmRequestState noScheduleUntilState,
+    LlmRequestState noScheduleAfterState, bool enablePrefixAwareScheduling)
+    : GuaranteedNoEvictScheduler(
+        maxNumRequests, noScheduleUntilState, noScheduleAfterState, enablePrefixAwareScheduling)
 {
 }
 
@@ -226,7 +229,7 @@ std::tuple<RequestVector, RequestVector> GuaranteedNoEvictScheduler::impl(
         = peftCacheManager ? peftCacheManager->getMaxDevicePages() : std::numeric_limits<SizeType32>::max();
 
     // The optimization of delaying requests won't work for variable window attention
-    bool skippingIsRelevant = (!kvCacheManager.getBlockManager().isVariableWindow())
+    bool skippingIsRelevant = mEnablePrefixAwareScheduling && (!kvCacheManager.getBlockManager().isVariableWindow())
         && (!crossKvCacheManager || !crossKvCacheManager->getBlockManager().isVariableWindow());
 
     // Keep track of blocks contributed by requests in context phase
@@ -327,12 +330,21 @@ std::tuple<RequestVector, RequestVector> GuaranteedNoEvictScheduler::impl(
                 {
                     // analyzePrefixReuse asserts on variable-window managers; skip the walk there
                     // and let downstream callers fall back to their fresh tree-walk path.
-                    if (kvCacheManager.isEnableBlockReuse() && !kvCacheManager.getBlockManager().isVariableWindow())
+                    if (!mEnablePrefixAwareScheduling)
+                    {
+                        summary = kv_cache_manager::PrefixReuseSummary{};
+                        if (crossKvCacheManager)
+                        {
+                            crossSummary = kv_cache_manager::PrefixReuseSummary{};
+                        }
+                    }
+                    else if (kvCacheManager.isEnableBlockReuse()
+                        && !kvCacheManager.getBlockManager().isVariableWindow())
                     {
                         auto uniqueTokens = req->getUniqueTokens(0);
                         summary = kvCacheManager.analyzePrefixReuse(uniqueTokens, *req);
                     }
-                    if (crossKvCacheManager && crossKvCacheManager->isEnableBlockReuse()
+                    if (mEnablePrefixAwareScheduling && crossKvCacheManager && crossKvCacheManager->isEnableBlockReuse()
                         && !crossKvCacheManager->getBlockManager().isVariableWindow())
                     {
                         auto uniqueTokens = *(req->getEncoderUniqueTokens().value());
@@ -442,7 +454,7 @@ std::tuple<RequestVector, RequestVector> MaxUtilizationScheduler::operator()(
     }
 
     // The optimization of delaying requests won't work for variable window attention
-    bool skippingIsRelevant = !kvCacheManager.getBlockManager().isVariableWindow();
+    bool skippingIsRelevant = mEnablePrefixAwareScheduling && !kvCacheManager.getBlockManager().isVariableWindow();
 
     // Keep track of number of requests and block needed for the scheduled requests
     auto scheduledBlocksManager
@@ -459,8 +471,13 @@ std::tuple<RequestVector, RequestVector> MaxUtilizationScheduler::operator()(
     std::unordered_set<uint64_t> seenTaskIds;
 
     // Keep track of blocks contributed by requests in context phase
-    auto [newlyContributedContextBlocks, newlyContributedCrossContextBlocks]
-        = prefillWithChunkedContextsAlreadyExecuting(activeRequests, kvCacheManager);
+    std::unordered_set<BlockKey, BlockKeyHasher> newlyContributedContextBlocks;
+    std::unordered_set<BlockKey, BlockKeyHasher> newlyContributedCrossContextBlocks;
+    if (skippingIsRelevant)
+    {
+        std::tie(newlyContributedContextBlocks, newlyContributedCrossContextBlocks)
+            = prefillWithChunkedContextsAlreadyExecuting(activeRequests, kvCacheManager);
+    }
 
     // Find last active in case we need to evict.  Encoder-init requests are
     // intentionally excluded here: they hold no started self- or cross-pool
@@ -511,7 +528,11 @@ std::tuple<RequestVector, RequestVector> MaxUtilizationScheduler::operator()(
         std::optional<kv_cache_manager::PrefixReuseSummary> summary;
         // analyzePrefixReuse asserts on variable-window managers; skip the walk there
         // and let downstream callers fall back to their fresh tree-walk path.
-        if (isFirstChunkContext && kvCacheManager.isEnableBlockReuse()
+        if (isFirstChunkContext && !mEnablePrefixAwareScheduling)
+        {
+            summary = kv_cache_manager::PrefixReuseSummary{};
+        }
+        else if (isFirstChunkContext && kvCacheManager.isEnableBlockReuse()
             && !kvCacheManager.getBlockManager().isVariableWindow())
         {
             auto uniqueTokens = req->getUniqueTokens(0);
@@ -644,7 +665,7 @@ bool trySchedulingRequestMaxUtilization(std::shared_ptr<LlmRequest> const& req, 
 
 CapacityScheduler::CapacityScheduler(SizeType32 maxNumRequests,
     executor::CapacitySchedulerPolicy capacitySchedulerPolicy, bool hasKvCacheManager, bool twoStepsLookAhead,
-    LlmRequestState noScheduleUntilState, LlmRequestState noScheduleAfterState)
+    LlmRequestState noScheduleUntilState, LlmRequestState noScheduleAfterState, bool enablePrefixAwareScheduling)
 {
     if (!hasKvCacheManager)
     {
@@ -652,16 +673,18 @@ CapacityScheduler::CapacityScheduler(SizeType32 maxNumRequests,
     }
     else if (capacitySchedulerPolicy == executor::CapacitySchedulerPolicy::kMAX_UTILIZATION)
     {
-        mScheduler
-            = MaxUtilizationScheduler{maxNumRequests, twoStepsLookAhead, noScheduleUntilState, noScheduleAfterState};
+        mScheduler = MaxUtilizationScheduler{
+            maxNumRequests, twoStepsLookAhead, noScheduleUntilState, noScheduleAfterState, enablePrefixAwareScheduling};
     }
     else if (capacitySchedulerPolicy == executor::CapacitySchedulerPolicy::kGUARANTEED_NO_EVICT)
     {
-        mScheduler = GuaranteedNoEvictScheduler{maxNumRequests, noScheduleUntilState, noScheduleAfterState};
+        mScheduler = GuaranteedNoEvictScheduler{
+            maxNumRequests, noScheduleUntilState, noScheduleAfterState, enablePrefixAwareScheduling};
     }
     else if (capacitySchedulerPolicy == executor::CapacitySchedulerPolicy::kSTATIC_BATCH)
     {
-        mScheduler = StaticBatchScheduler{maxNumRequests, noScheduleUntilState, noScheduleAfterState};
+        mScheduler = StaticBatchScheduler{
+            maxNumRequests, noScheduleUntilState, noScheduleAfterState, enablePrefixAwareScheduling};
     }
     else
     {

--- a/cpp/tensorrt_llm/batch_manager/capacityScheduler.cpp
+++ b/cpp/tensorrt_llm/batch_manager/capacityScheduler.cpp
@@ -326,38 +326,39 @@ std::tuple<RequestVector, RequestVector> GuaranteedNoEvictScheduler::impl(
                 bool const isEncoderInit = req->isEncoderInitState();
                 std::optional<kv_cache_manager::PrefixReuseSummary> summary;
                 std::optional<kv_cache_manager::PrefixReuseSummary> crossSummary;
-                if (isFirstChunkContext)
+                if (mEnablePrefixAwareScheduling)
                 {
-                    // analyzePrefixReuse asserts on variable-window managers; skip the walk there
-                    // and let downstream callers fall back to their fresh tree-walk path.
-                    if (!mEnablePrefixAwareScheduling)
+                    if (isFirstChunkContext)
                     {
-                        summary = kv_cache_manager::PrefixReuseSummary{};
-                        if (crossKvCacheManager)
+                        // analyzePrefixReuse asserts on variable-window managers; skip the walk there
+                        // and let downstream callers fall back to their fresh tree-walk path.
+                        if (kvCacheManager.isEnableBlockReuse() && !kvCacheManager.getBlockManager().isVariableWindow())
                         {
-                            crossSummary = kv_cache_manager::PrefixReuseSummary{};
+                            auto uniqueTokens = req->getUniqueTokens(0);
+                            summary = kvCacheManager.analyzePrefixReuse(uniqueTokens, *req);
+                        }
+                        if (crossKvCacheManager && crossKvCacheManager->isEnableBlockReuse()
+                            && !crossKvCacheManager->getBlockManager().isVariableWindow())
+                        {
+                            auto uniqueTokens = *(req->getEncoderUniqueTokens().value());
+                            crossSummary = crossKvCacheManager->analyzePrefixReuse(uniqueTokens, *req);
                         }
                     }
-                    else if (kvCacheManager.isEnableBlockReuse()
-                        && !kvCacheManager.getBlockManager().isVariableWindow())
-                    {
-                        auto uniqueTokens = req->getUniqueTokens(0);
-                        summary = kvCacheManager.analyzePrefixReuse(uniqueTokens, *req);
-                    }
-                    if (mEnablePrefixAwareScheduling && crossKvCacheManager && crossKvCacheManager->isEnableBlockReuse()
+                    else if (isEncoderInit && crossKvCacheManager && crossKvCacheManager->isEnableBlockReuse()
                         && !crossKvCacheManager->getBlockManager().isVariableWindow())
                     {
+                        // Encoder admission only needs the cross summary for reuse ordering.
                         auto uniqueTokens = *(req->getEncoderUniqueTokens().value());
                         crossSummary = crossKvCacheManager->analyzePrefixReuse(uniqueTokens, *req);
                     }
                 }
-                else if (mEnablePrefixAwareScheduling && isEncoderInit && crossKvCacheManager
-                    && crossKvCacheManager->isEnableBlockReuse()
-                    && !crossKvCacheManager->getBlockManager().isVariableWindow())
+                else if (isFirstChunkContext)
                 {
-                    // Encoder admission only needs the cross summary for reuse ordering.
-                    auto uniqueTokens = *(req->getEncoderUniqueTokens().value());
-                    crossSummary = crossKvCacheManager->analyzePrefixReuse(uniqueTokens, *req);
+                    summary = kv_cache_manager::PrefixReuseSummary{};
+                    if (crossKvCacheManager)
+                    {
+                        crossSummary = kv_cache_manager::PrefixReuseSummary{};
+                    }
                 }
                 // Beneficial-to-skip check using the cached summary
                 if (!StaticBatchScheduling && skippingIsRelevant && (isFirstChunkContext || isEncoderInit)

--- a/cpp/tensorrt_llm/batch_manager/trtEncoderModel.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtEncoderModel.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -76,8 +76,11 @@ TrtEncoderModel::TrtEncoderModel(runtime::ModelConfig const& modelConfig, WorldC
     // handling of maximizing utilization or pause/evict
     // TODO: finer control on encoder requests scheduling
     mCapacityScheduler = std::make_unique<tensorrt_llm::batch_manager::CapacityScheduler>(
-        getMaxBatchSize() * mNumMicroBatches, executorConfig.getSchedulerConfig().getCapacitySchedulerPolicy(), false,
-        false, LlmRequestState::kENCODER_INIT, LlmRequestState::kCONTEXT_INIT);
+        getMaxBatchSize() * mNumMicroBatches, executorConfig.getSchedulerConfig().getCapacitySchedulerPolicy(),
+        /*hasKvCacheManager=*/false, /*twoStepsLookAhead=*/false,
+        /*noScheduleUntilState=*/LlmRequestState::kENCODER_INIT,
+        /*noScheduleAfterState=*/LlmRequestState::kCONTEXT_INIT,
+        /*enablePrefixAwareScheduling=*/executorConfig.getSchedulerConfig().getEnablePrefixAwareScheduling());
 
     mMicroBatchScheduler = std::make_unique<tensorrt_llm::batch_manager::MicroBatchScheduler>(
         std::nullopt, mModelConfig.getMaxInputLen(), LlmRequestState::kENCODER_INIT, LlmRequestState::kCONTEXT_INIT);

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -445,7 +445,10 @@ TrtGptModelInflightBatching::TrtGptModelInflightBatching(std::shared_ptr<nvinfer
 
     mCapacityScheduler = std::make_unique<CapacityScheduler>(getMaxNumSequences(),
         executorConfig.getSchedulerConfig().getCapacitySchedulerPolicy(), mKvCacheManager != nullptr,
-        mWorldConfig.isPipelineParallel());
+        /*twoStepsLookAhead=*/mWorldConfig.isPipelineParallel(),
+        /*noScheduleUntilState=*/LlmRequestState::kCONTEXT_INIT,
+        /*noScheduleAfterState=*/LlmRequestState::kGENERATION_COMPLETE,
+        /*enablePrefixAwareScheduling=*/executorConfig.getSchedulerConfig().getEnablePrefixAwareScheduling());
 
     mMicroBatchScheduler = std::make_unique<MicroBatchScheduler>(ctxChunkConfig, maxContextLength);
 

--- a/cpp/tensorrt_llm/executor/dynamicBatchConfig.cpp
+++ b/cpp/tensorrt_llm/executor/dynamicBatchConfig.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,6 +47,14 @@ SizeType32 DynamicBatchConfig::getDynamicBatchMovingAverageWindow() const
 std::vector<std::pair<SizeType32, SizeType32>> DynamicBatchConfig::getBatchSizeTable() const
 {
     return mBatchSizeTable;
+}
+
+bool DynamicBatchConfig::operator==(DynamicBatchConfig const& other) const
+{
+    return mEnableBatchSizeTuning == other.mEnableBatchSizeTuning
+        && mEnableMaxNumTokensTuning == other.mEnableMaxNumTokensTuning
+        && mDynamicBatchMovingAverageWindow == other.mDynamicBatchMovingAverageWindow
+        && mBatchSizeTable == other.mBatchSizeTable;
 }
 
 std::vector<std::pair<SizeType32, SizeType32>> const DynamicBatchConfig::kDefaultBatchSizeTable{

--- a/cpp/tensorrt_llm/executor/schedulerConfig.cpp
+++ b/cpp/tensorrt_llm/executor/schedulerConfig.cpp
@@ -20,6 +20,29 @@
 namespace tensorrt_llm::executor
 {
 
+namespace
+{
+
+bool dynamicBatchConfigsEqual(
+    std::optional<DynamicBatchConfig> const& lhs, std::optional<DynamicBatchConfig> const& rhs)
+{
+    if (lhs.has_value() != rhs.has_value())
+    {
+        return false;
+    }
+    if (!lhs.has_value())
+    {
+        return true;
+    }
+
+    return lhs->getEnableBatchSizeTuning() == rhs->getEnableBatchSizeTuning()
+        && lhs->getEnableMaxNumTokensTuning() == rhs->getEnableMaxNumTokensTuning()
+        && lhs->getDynamicBatchMovingAverageWindow() == rhs->getDynamicBatchMovingAverageWindow()
+        && lhs->getBatchSizeTable() == rhs->getBatchSizeTable();
+}
+
+} // namespace
+
 SchedulerConfig::SchedulerConfig(CapacitySchedulerPolicy capacitySchedulerPolicy,
     std::optional<ContextChunkingPolicy> contextChunkingPolicy, std::optional<DynamicBatchConfig> dynamicBatchConfig,
     bool enablePrefixAwareScheduling)
@@ -34,6 +57,7 @@ bool SchedulerConfig::operator==(SchedulerConfig const& other) const
 {
     return mCapacitySchedulerPolicy == other.mCapacitySchedulerPolicy
         && mContextChunkingPolicy == other.mContextChunkingPolicy
+        && dynamicBatchConfigsEqual(mDynamicBatchConfig, other.mDynamicBatchConfig)
         && mEnablePrefixAwareScheduling == other.mEnablePrefixAwareScheduling;
 }
 

--- a/cpp/tensorrt_llm/executor/schedulerConfig.cpp
+++ b/cpp/tensorrt_llm/executor/schedulerConfig.cpp
@@ -20,29 +20,6 @@
 namespace tensorrt_llm::executor
 {
 
-namespace
-{
-
-bool dynamicBatchConfigsEqual(
-    std::optional<DynamicBatchConfig> const& lhs, std::optional<DynamicBatchConfig> const& rhs)
-{
-    if (lhs.has_value() != rhs.has_value())
-    {
-        return false;
-    }
-    if (!lhs.has_value())
-    {
-        return true;
-    }
-
-    return lhs->getEnableBatchSizeTuning() == rhs->getEnableBatchSizeTuning()
-        && lhs->getEnableMaxNumTokensTuning() == rhs->getEnableMaxNumTokensTuning()
-        && lhs->getDynamicBatchMovingAverageWindow() == rhs->getDynamicBatchMovingAverageWindow()
-        && lhs->getBatchSizeTable() == rhs->getBatchSizeTable();
-}
-
-} // namespace
-
 SchedulerConfig::SchedulerConfig(CapacitySchedulerPolicy capacitySchedulerPolicy,
     std::optional<ContextChunkingPolicy> contextChunkingPolicy, std::optional<DynamicBatchConfig> dynamicBatchConfig,
     bool enablePrefixAwareScheduling)
@@ -56,8 +33,7 @@ SchedulerConfig::SchedulerConfig(CapacitySchedulerPolicy capacitySchedulerPolicy
 bool SchedulerConfig::operator==(SchedulerConfig const& other) const
 {
     return mCapacitySchedulerPolicy == other.mCapacitySchedulerPolicy
-        && mContextChunkingPolicy == other.mContextChunkingPolicy
-        && dynamicBatchConfigsEqual(mDynamicBatchConfig, other.mDynamicBatchConfig)
+        && mContextChunkingPolicy == other.mContextChunkingPolicy && mDynamicBatchConfig == other.mDynamicBatchConfig
         && mEnablePrefixAwareScheduling == other.mEnablePrefixAwareScheduling;
 }
 

--- a/cpp/tensorrt_llm/executor/schedulerConfig.cpp
+++ b/cpp/tensorrt_llm/executor/schedulerConfig.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,17 +21,20 @@ namespace tensorrt_llm::executor
 {
 
 SchedulerConfig::SchedulerConfig(CapacitySchedulerPolicy capacitySchedulerPolicy,
-    std::optional<ContextChunkingPolicy> contextChunkingPolicy, std::optional<DynamicBatchConfig> dynamicBatchConfig)
+    std::optional<ContextChunkingPolicy> contextChunkingPolicy, std::optional<DynamicBatchConfig> dynamicBatchConfig,
+    bool enablePrefixAwareScheduling)
     : mCapacitySchedulerPolicy(capacitySchedulerPolicy)
     , mContextChunkingPolicy(std::move(contextChunkingPolicy))
     , mDynamicBatchConfig(std::move(dynamicBatchConfig))
+    , mEnablePrefixAwareScheduling(enablePrefixAwareScheduling)
 {
 }
 
 bool SchedulerConfig::operator==(SchedulerConfig const& other) const
 {
     return mCapacitySchedulerPolicy == other.mCapacitySchedulerPolicy
-        && mContextChunkingPolicy == other.mContextChunkingPolicy;
+        && mContextChunkingPolicy == other.mContextChunkingPolicy
+        && mEnablePrefixAwareScheduling == other.mEnablePrefixAwareScheduling;
 }
 
 [[nodiscard]] CapacitySchedulerPolicy SchedulerConfig::getCapacitySchedulerPolicy() const
@@ -47,6 +50,11 @@ bool SchedulerConfig::operator==(SchedulerConfig const& other) const
 [[nodiscard]] std::optional<DynamicBatchConfig> SchedulerConfig::getDynamicBatchConfig() const
 {
     return mDynamicBatchConfig;
+}
+
+[[nodiscard]] bool SchedulerConfig::getEnablePrefixAwareScheduling() const
+{
+    return mEnablePrefixAwareScheduling;
 }
 
 } // namespace tensorrt_llm::executor

--- a/cpp/tensorrt_llm/executor/serialization.cpp
+++ b/cpp/tensorrt_llm/executor/serialization.cpp
@@ -1427,7 +1427,9 @@ SchedulerConfig Serialization::deserializeSchedulerConfig(std::istream& is)
     auto capacitySchedulerPolicy = su::deserialize<CapacitySchedulerPolicy>(is);
     auto contextChunkingPolicy = su::deserialize<std::optional<ContextChunkingPolicy>>(is);
     auto dynamicBatchConfig = su::deserialize<std::optional<DynamicBatchConfig>>(is);
-    return SchedulerConfig{capacitySchedulerPolicy, contextChunkingPolicy, dynamicBatchConfig};
+    auto enablePrefixAwareScheduling = su::deserialize<bool>(is);
+    return SchedulerConfig{
+        capacitySchedulerPolicy, contextChunkingPolicy, dynamicBatchConfig, enablePrefixAwareScheduling};
 }
 
 void Serialization::serialize(SchedulerConfig const& schedulerConfig, std::ostream& os)
@@ -1435,6 +1437,7 @@ void Serialization::serialize(SchedulerConfig const& schedulerConfig, std::ostre
     su::serialize(schedulerConfig.getCapacitySchedulerPolicy(), os);
     su::serialize(schedulerConfig.getContextChunkingPolicy(), os);
     su::serialize(schedulerConfig.getDynamicBatchConfig(), os);
+    su::serialize(schedulerConfig.getEnablePrefixAwareScheduling(), os);
 }
 
 size_t Serialization::serializedSize(SchedulerConfig const& schedulerConfig)
@@ -1443,6 +1446,7 @@ size_t Serialization::serializedSize(SchedulerConfig const& schedulerConfig)
     totalSize += su::serializedSize(schedulerConfig.getCapacitySchedulerPolicy());
     totalSize += su::serializedSize(schedulerConfig.getContextChunkingPolicy());
     totalSize += su::serializedSize(schedulerConfig.getDynamicBatchConfig());
+    totalSize += su::serializedSize(schedulerConfig.getEnablePrefixAwareScheduling());
     return totalSize;
 }
 

--- a/cpp/tensorrt_llm/nanobind/batch_manager/algorithms.cpp
+++ b/cpp/tensorrt_llm/nanobind/batch_manager/algorithms.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -85,10 +85,12 @@ void tensorrt_llm::nanobind::batch_manager::algorithms::initBindings(nb::module_
         .def("__setstate__", agentTreeConfigSetstate);
 
     nb::class_<CapacityScheduler>(m, CapacityScheduler::name)
-        .def(nb::init<SizeType32, executor::CapacitySchedulerPolicy, bool, bool, LlmRequestState, LlmRequestState>(),
+        .def(nb::init<SizeType32, executor::CapacitySchedulerPolicy, bool, bool, LlmRequestState, LlmRequestState,
+                 bool>(),
             nb::arg("max_num_requests"), nb::arg("capacity_scheduler_policy"), nb::arg("has_kv_cache_manager"),
             nb::arg("two_step_lookahead") = false, nb::arg("no_schedule_until_state") = LlmRequestState::kCONTEXT_INIT,
-            nb::arg("no_schedule_after_state") = LlmRequestState::kGENERATION_COMPLETE)
+            nb::arg("no_schedule_after_state") = LlmRequestState::kGENERATION_COMPLETE,
+            nb::arg("enable_prefix_aware_scheduling") = true)
         .def("__call__", &CapacityScheduler::operator(), nb::arg("active_requests"),
             nb::arg("kv_cache_manager") = nullptr, nb::arg("peft_cache_manager") = nullptr,
             nb::arg("cross_kv_cache_manager") = nullptr)

--- a/cpp/tensorrt_llm/nanobind/executor/executorConfig.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/executorConfig.cpp
@@ -76,14 +76,13 @@ void initConfigBindings(nb::module_& m)
 
     auto schedulerConfigSetstate = [](tle::SchedulerConfig& self, nb::tuple const& state)
     {
-        if (state.size() != 3 && state.size() != 4)
+        if (state.size() != 4)
         {
             throw std::runtime_error("Invalid state!");
         }
-        bool const enablePrefixAwareScheduling = state.size() == 4 ? nb::cast<bool>(state[3]) : true;
         new (&self) tle::SchedulerConfig(nb::cast<tle::CapacitySchedulerPolicy>(state[0]),
             nb::cast<std::optional<tle::ContextChunkingPolicy>>(state[1]),
-            nb::cast<std::optional<tle::DynamicBatchConfig>>(state[2]), enablePrefixAwareScheduling);
+            nb::cast<std::optional<tle::DynamicBatchConfig>>(state[2]), nb::cast<bool>(state[3]));
     };
     auto schedulerConfigGetstate = [](tle::SchedulerConfig const& self)
     {

--- a/cpp/tensorrt_llm/nanobind/executor/executorConfig.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/executorConfig.cpp
@@ -76,27 +76,30 @@ void initConfigBindings(nb::module_& m)
 
     auto schedulerConfigSetstate = [](tle::SchedulerConfig& self, nb::tuple const& state)
     {
-        if (state.size() != 3)
+        if (state.size() != 3 && state.size() != 4)
         {
             throw std::runtime_error("Invalid state!");
         }
+        bool const enablePrefixAwareScheduling = state.size() == 4 ? nb::cast<bool>(state[3]) : true;
         new (&self) tle::SchedulerConfig(nb::cast<tle::CapacitySchedulerPolicy>(state[0]),
             nb::cast<std::optional<tle::ContextChunkingPolicy>>(state[1]),
-            nb::cast<std::optional<tle::DynamicBatchConfig>>(state[2]));
+            nb::cast<std::optional<tle::DynamicBatchConfig>>(state[2]), enablePrefixAwareScheduling);
     };
     auto schedulerConfigGetstate = [](tle::SchedulerConfig const& self)
     {
-        return nb::make_tuple(
-            self.getCapacitySchedulerPolicy(), self.getContextChunkingPolicy(), self.getDynamicBatchConfig());
+        return nb::make_tuple(self.getCapacitySchedulerPolicy(), self.getContextChunkingPolicy(),
+            self.getDynamicBatchConfig(), self.getEnablePrefixAwareScheduling());
     };
     nb::class_<tle::SchedulerConfig>(m, "SchedulerConfig")
         .def(nb::init<tle::CapacitySchedulerPolicy, std::optional<tle::ContextChunkingPolicy>,
-                 std::optional<tle::DynamicBatchConfig>>(),
+                 std::optional<tle::DynamicBatchConfig>, bool>(),
             nb::arg("capacity_scheduler_policy") = tle::CapacitySchedulerPolicy::kGUARANTEED_NO_EVICT,
-            nb::arg("context_chunking_policy") = nb::none(), nb::arg("dynamic_batch_config") = nb::none())
+            nb::arg("context_chunking_policy") = nb::none(), nb::arg("dynamic_batch_config") = nb::none(),
+            nb::arg("enable_prefix_aware_scheduling") = true)
         .def_prop_ro("capacity_scheduler_policy", &tle::SchedulerConfig::getCapacitySchedulerPolicy)
         .def_prop_ro("context_chunking_policy", &tle::SchedulerConfig::getContextChunkingPolicy)
         .def_prop_ro("dynamic_batch_config", &tle::SchedulerConfig::getDynamicBatchConfig)
+        .def_prop_ro("enable_prefix_aware_scheduling", &tle::SchedulerConfig::getEnablePrefixAwareScheduling)
         .def("__getstate__", schedulerConfigGetstate)
         .def("__setstate__", schedulerConfigSetstate);
 

--- a/cpp/tests/unit_tests/batch_manager/capacitySchedulerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/capacitySchedulerTest.cpp
@@ -1822,6 +1822,50 @@ TEST_F(CapacitySchedulerTest, DelayDuplicateRequest)
     }
 }
 
+TEST_F(CapacitySchedulerTest, PrefixAwareSchedulingDisabledDoesNotDelayDuplicateRequest)
+{
+    SizeType32 kvCacheMaxNumTokens = 200;
+    SizeType32 kvCacheTokensPerBlock = 10;
+    SizeType32 kvCacheMaxNumTokensPerSeq = 50;
+    SizeType32 maxNumRequests = 3;
+    bool enableReuse = true;
+    bool enablePrefixAwareScheduling = false;
+
+    auto capacitySchedulerPolicies = std::vector<CapacitySchedulerPolicy>{
+        CapacitySchedulerPolicy::kMAX_UTILIZATION, CapacitySchedulerPolicy::kGUARANTEED_NO_EVICT};
+    for (auto capacitySchedulerPolicy : capacitySchedulerPolicies)
+    {
+        auto kvCacheManager = getKvCacheManager(maxNumRequests, kvCacheTokensPerBlock, kvCacheMaxNumTokens,
+            kvCacheMaxNumTokensPerSeq, /*sinkTokenLength=*/0, /*enableReuse=*/enableReuse);
+        auto peftCacheManager = getPeftCacheManager();
+        auto capacityScheduler = CapacityScheduler(maxNumRequests, capacitySchedulerPolicy, kvCacheManager != nullptr,
+            /*twoStepsLookAhead=*/false, /*noScheduleUntilState=*/LlmRequestState::kCONTEXT_INIT,
+            /*noScheduleAfterState=*/LlmRequestState::kGENERATION_COMPLETE,
+            /*enablePrefixAwareScheduling=*/enablePrefixAwareScheduling);
+
+        int32_t maxNewTokens = 2;
+        int32_t promptLen = 2 * kvCacheTokensPerBlock + 1;
+
+        auto inputTokens = std::make_shared<std::vector<int32_t>>(promptLen, 1);
+        std::iota(inputTokens->begin(), inputTokens->end(), 0);
+
+        RequestList activeRequests;
+        activeRequests.push_back(createRequest(inputTokens, maxNewTokens, 0, 1234));
+        activeRequests.push_back(createRequest(inputTokens, maxNewTokens, 1, 1234));
+        activeRequests.push_back(createRequest(inputTokens, maxNewTokens, 2, 1234));
+
+        auto [scheduled, disaggInit, paused] = capacityScheduler(activeRequests, *kvCacheManager, peftCacheManager);
+
+        EXPECT_EQ(scheduled.size(), 3u);
+        EXPECT_TRUE(disaggInit.empty());
+        EXPECT_TRUE(paused.empty());
+        for (auto const& req : activeRequests)
+        {
+            EXPECT_EQ(req->getEstimatedReusableTokens(), 0);
+        }
+    }
+}
+
 TEST_F(CapacitySchedulerTest, DelayDuplicateRequestChunked)
 {
     SizeType32 kvCacheMaxNumTokens = 200;

--- a/cpp/tests/unit_tests/batch_manager/microBatchSchedulerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/microBatchSchedulerTest.cpp
@@ -1366,6 +1366,77 @@ TEST_F(CombinedSchedulerTest, CapacitySchedulerSetsReusableTokensForMicroBatch)
     kvCacheManager->removeSequence(req0->mRequestId, req0);
 }
 
+TEST_F(CombinedSchedulerTest, PrefixAwareSchedulingDisabledKeepsReusableTokensZero)
+{
+    constexpr SizeType32 tokensPerBlock = 10;
+    constexpr SizeType32 kvCacheMaxNumTokens = 100;
+    constexpr SizeType32 kvCacheMaxNumTokensPerSeq = 50;
+    constexpr SizeType32 maxNumRequests = 4;
+
+    auto kvCacheManager = createKvCacheManager(
+        maxNumRequests, tokensPerBlock, kvCacheMaxNumTokens, kvCacheMaxNumTokensPerSeq, /*enableReuse=*/true);
+
+    auto capacityScheduler = CapacityScheduler(maxNumRequests, CapacitySchedulerPolicy::kMAX_UTILIZATION,
+        /*hasKvCacheManager=*/true, /*twoStepsLookAhead=*/false,
+        /*noScheduleUntilState=*/LlmRequestState::kCONTEXT_INIT,
+        /*noScheduleAfterState=*/LlmRequestState::kGENERATION_COMPLETE, /*enablePrefixAwareScheduling=*/false);
+
+    auto microBatchScheduler = MicroBatchScheduler();
+
+    constexpr int32_t promptLen = 30;
+    constexpr int32_t maxNewTokens = 5;
+    auto inputTokens = std::make_shared<std::vector<int32_t>>(promptLen);
+    std::iota(inputTokens->begin(), inputTokens->end(), 0);
+
+    auto req0 = createRequestWithTokens(inputTokens, maxNewTokens, 0);
+    auto req1 = createRequestWithTokens(inputTokens, maxNewTokens, 1);
+
+    RequestList activeList;
+    activeList.push_back(req0);
+    activeList.push_back(req1);
+
+    auto [scheduled0, disaggInit0, paused0]
+        = capacityScheduler(activeList, *kvCacheManager, /*peftCacheManager=*/std::nullopt);
+    ASSERT_GE(scheduled0.size(), 1u);
+    EXPECT_TRUE(disaggInit0.empty());
+    EXPECT_TRUE(paused0.empty());
+    EXPECT_EQ(req1->getEstimatedReusableTokens(), 0);
+
+    kvCacheManager->addSequenceBatch({{{req0->mRequestId, promptLen, /*beamWidth=*/1}}}, {std::ref(*req0)});
+    req0->moveToNextContextChunk();
+    tensorrt_llm::testing::KvCacheManagerTestUtil::simulatePrefillCompletion(*req0);
+    kvCacheManager->storeContextBlocks(*req0);
+    req0->addNewTokens({0});
+    req0->setState(LlmRequestState::kGENERATION_IN_PROGRESS);
+    kvCacheManager->addToken(req0->mRequestId);
+
+    auto [scheduled1, disaggInit1, paused1]
+        = capacityScheduler(activeList, *kvCacheManager, /*peftCacheManager=*/std::nullopt);
+
+    EXPECT_TRUE(disaggInit1.empty());
+    EXPECT_TRUE(paused1.empty());
+    EXPECT_EQ(req1->getEstimatedReusableTokens(), 0);
+
+    RequestVector microBatchActive;
+    for (auto& req : scheduled1)
+    {
+        microBatchActive.push_back(req);
+    }
+
+    constexpr SizeType32 maxNumTokensBudget = 15;
+    constexpr SizeType32 maxBatchSize = 4;
+    ReqIdsSet inflightReqIds;
+    auto [ctx, gen] = microBatchScheduler(microBatchActive, inflightReqIds, maxBatchSize, maxNumTokensBudget);
+
+    auto const req1InCtx = std::any_of(ctx.begin(), ctx.end(), [](auto const& req) { return req->mRequestId == 1; });
+    EXPECT_FALSE(req1InCtx) << "Without scheduler-side reusable-token credit, req1 exceeds the tight token budget";
+
+    auto const req0InGen = std::any_of(gen.begin(), gen.end(), [](auto const& req) { return req->mRequestId == 0; });
+    EXPECT_TRUE(req0InGen);
+
+    kvCacheManager->removeSequence(req0->mRequestId, req0);
+}
+
 TEST_F(CombinedSchedulerTest, CapacitySchedulerReusableTokensWithChunkedMicroBatch)
 {
     // Same pipeline but with chunked prefill.

--- a/cpp/tests/unit_tests/batch_manager/microBatchSchedulerTest.cpp
+++ b/cpp/tests/unit_tests/batch_manager/microBatchSchedulerTest.cpp
@@ -1416,6 +1416,9 @@ TEST_F(CombinedSchedulerTest, PrefixAwareSchedulingDisabledKeepsReusableTokensZe
     EXPECT_TRUE(disaggInit1.empty());
     EXPECT_TRUE(paused1.empty());
     EXPECT_EQ(req1->getEstimatedReusableTokens(), 0);
+    auto const req1Scheduled
+        = std::any_of(scheduled1.begin(), scheduled1.end(), [](auto const& req) { return req->mRequestId == 1; });
+    ASSERT_TRUE(req1Scheduled) << "Capacity scheduler must admit req1 before micro batch budget filtering";
 
     RequestVector microBatchActive;
     for (auto& req : scheduled1)

--- a/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
+++ b/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
@@ -505,13 +505,26 @@ TEST(SerializeUtilsTest, SchedulerConfig)
     texec::SchedulerConfig defaultSchedulerConfig;
     EXPECT_TRUE(defaultSchedulerConfig.getEnablePrefixAwareScheduling());
 
+    texec::DynamicBatchConfig dynamicBatchConfig{/*enableBatchSizeTuning=*/true,
+        /*enableMaxNumTokensTuning=*/true, /*dynamicBatchMovingAverageWindow=*/64};
     texec::SchedulerConfig schedulerConfig(texec::CapacitySchedulerPolicy::kMAX_UTILIZATION,
-        texec::ContextChunkingPolicy::kFIRST_COME_FIRST_SERVED, std::nullopt, false);
+        texec::ContextChunkingPolicy::kFIRST_COME_FIRST_SERVED, dynamicBatchConfig, false);
     auto schedulerConfig2 = serializeDeserialize(schedulerConfig);
     EXPECT_EQ(schedulerConfig.getCapacitySchedulerPolicy(), schedulerConfig2.getCapacitySchedulerPolicy());
     EXPECT_EQ(schedulerConfig.getContextChunkingPolicy(), schedulerConfig2.getContextChunkingPolicy());
-    EXPECT_FALSE(schedulerConfig2.getDynamicBatchConfig().has_value());
+    EXPECT_EQ(schedulerConfig, schedulerConfig2);
+    ASSERT_TRUE(schedulerConfig2.getDynamicBatchConfig().has_value());
+    EXPECT_TRUE(schedulerConfig2.getDynamicBatchConfig()->getEnableBatchSizeTuning());
+    EXPECT_TRUE(schedulerConfig2.getDynamicBatchConfig()->getEnableMaxNumTokensTuning());
+    EXPECT_EQ(schedulerConfig2.getDynamicBatchConfig()->getDynamicBatchMovingAverageWindow(), 64);
     EXPECT_FALSE(schedulerConfig2.getEnablePrefixAwareScheduling());
+
+    texec::SchedulerConfig differentDynamicBatchConfig(texec::CapacitySchedulerPolicy::kMAX_UTILIZATION,
+        texec::ContextChunkingPolicy::kFIRST_COME_FIRST_SERVED,
+        texec::DynamicBatchConfig{/*enableBatchSizeTuning=*/false, /*enableMaxNumTokensTuning=*/true,
+            /*dynamicBatchMovingAverageWindow=*/64},
+        false);
+    EXPECT_FALSE(schedulerConfig == differentDynamicBatchConfig);
 }
 
 TEST(SerializeUtilsTest, ParallelConfig)

--- a/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
+++ b/cpp/tests/unit_tests/executor/serializeUtilsTest.cpp
@@ -502,11 +502,16 @@ TEST(SerializeUtilsTest, KvCacheConfig)
 
 TEST(SerializeUtilsTest, SchedulerConfig)
 {
-    texec::SchedulerConfig schedulerConfig(
-        texec::CapacitySchedulerPolicy::kMAX_UTILIZATION, texec::ContextChunkingPolicy::kFIRST_COME_FIRST_SERVED);
+    texec::SchedulerConfig defaultSchedulerConfig;
+    EXPECT_TRUE(defaultSchedulerConfig.getEnablePrefixAwareScheduling());
+
+    texec::SchedulerConfig schedulerConfig(texec::CapacitySchedulerPolicy::kMAX_UTILIZATION,
+        texec::ContextChunkingPolicy::kFIRST_COME_FIRST_SERVED, std::nullopt, false);
     auto schedulerConfig2 = serializeDeserialize(schedulerConfig);
     EXPECT_EQ(schedulerConfig.getCapacitySchedulerPolicy(), schedulerConfig2.getCapacitySchedulerPolicy());
     EXPECT_EQ(schedulerConfig.getContextChunkingPolicy(), schedulerConfig2.getContextChunkingPolicy());
+    EXPECT_FALSE(schedulerConfig2.getDynamicBatchConfig().has_value());
+    EXPECT_FALSE(schedulerConfig2.getEnablePrefixAwareScheduling());
 }
 
 TEST(SerializeUtilsTest, ParallelConfig)

--- a/docs/source/developer-guide/telemetry.md
+++ b/docs/source/developer-guide/telemetry.md
@@ -181,6 +181,7 @@ unset or when the safety sanitizer rejects the runtime value.
 | `scheduler_config.dynamic_batch_config.dynamic_batch_moving_average_window` | `<class 'int'>` | `value` |  |  |
 | `scheduler_config.dynamic_batch_config.enable_batch_size_tuning` | `<class 'bool'>` | `value` |  |  |
 | `scheduler_config.dynamic_batch_config.enable_max_num_tokens_tuning` | `<class 'bool'>` | `value` |  |  |
+| `scheduler_config.enable_prefix_aware_scheduling` | `<class 'bool'>` | `value` |  |  |
 | `scheduler_config.use_python_scheduler` | `<class 'bool'>` | `value` |  |  |
 | `scheduler_config.waiting_queue_policy` | `<enum 'WaitingQueuePolicy'>` | `categorical` |  | `fcfs`, `priority` |
 | `skip_tokenizer_init` | `<class 'bool'>` | `value` |  |  |
@@ -460,6 +461,7 @@ unset or when the safety sanitizer rejects the runtime value.
 | `scheduler_config.dynamic_batch_config.dynamic_batch_moving_average_window` | `<class 'int'>` | `value` |  |  |
 | `scheduler_config.dynamic_batch_config.enable_batch_size_tuning` | `<class 'bool'>` | `value` |  |  |
 | `scheduler_config.dynamic_batch_config.enable_max_num_tokens_tuning` | `<class 'bool'>` | `value` |  |  |
+| `scheduler_config.enable_prefix_aware_scheduling` | `<class 'bool'>` | `value` |  |  |
 | `scheduler_config.use_python_scheduler` | `<class 'bool'>` | `value` |  |  |
 | `scheduler_config.waiting_queue_policy` | `<enum 'WaitingQueuePolicy'>` | `categorical` |  | `fcfs`, `priority` |
 | `skip_tokenizer_init` | `<class 'bool'>` | `value` |  |  |

--- a/docs/source/features/kvcache.md
+++ b/docs/source/features/kvcache.md
@@ -58,6 +58,22 @@ Property ```free_gpu_memory_fraction``` is a ratio > 0 and < 1 that specifies ho
 
 Block reuse across requests is enabled by default, but can be disabled by setting ```enable_block_reuse``` to False.
 
+`scheduler_config.enable_prefix_aware_scheduling` controls only scheduler-side use of prefix-reuse estimates. When it is
+`True` (the default), schedulers can use estimated reusable KV tokens to defer duplicate first-chunk context requests and
+to reduce token-budget accounting for requests that are expected to reuse cached prefix blocks. When it is `False`,
+these scheduler estimates are disabled and reusable-token estimates remain zero, but actual KV block reuse is still
+controlled by `kv_cache_config.enable_block_reuse`.
+
+For example, this keeps runtime KV block reuse enabled while disabling prefix-aware scheduler admission and token-budget
+credit:
+
+```yaml
+kv_cache_config:
+  enable_block_reuse: true
+scheduler_config:
+  enable_prefix_aware_scheduling: false
+```
+
 ### KV Cache Salting for Secure Reuse
 
 KV cache salting provides a security mechanism to control which requests can reuse cached KV states. When a `cache_salt` parameter is provided with a request, the KV cache system will only allow reuse of cached blocks given the same cache salt value. This prevents potential security issues such as prompt theft attacks, where malicious users might try to infer information from cached states of other users' requests.

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -2131,6 +2131,9 @@ def create_py_executor_instance(
         scheduler_policy = (scheduler_config.capacity_scheduler_policy
                             if scheduler_config is not None else
                             CapacitySchedulerPolicy.MAX_UTILIZATION)
+        enable_prefix_aware_scheduling = (
+            scheduler_config.enable_prefix_aware_scheduling
+            if scheduler_config is not None else True)
         scheduler = KVCacheV2Scheduler(
             max_batch_size=max_batch_size,
             max_num_tokens=max_num_tokens,
@@ -2143,9 +2146,11 @@ def create_py_executor_instance(
             draft_kv_cache_manager=draft_kv_cache_manager,
             cross_kv_cache_manager=cross_kv_cache_manager,
             no_schedule_until_state=no_schedule_until_state,
+            enable_prefix_aware_scheduling=enable_prefix_aware_scheduling,
         )
     elif (scheduler_config is not None
           and scheduler_config.use_python_scheduler):
+        enable_prefix_aware_scheduling = scheduler_config.enable_prefix_aware_scheduling
         scheduler = SimpleUnifiedScheduler(
             max_batch_size=max_batch_size,
             max_num_tokens=max_num_tokens,
@@ -2159,8 +2164,13 @@ def create_py_executor_instance(
             if cross_kv_cache_manager is not None else None,
             two_step_lookahead=mapping.has_pp(),
             scheduler_capacity=scheduler_capacity,
-            no_schedule_until_state=no_schedule_until_state)
+            no_schedule_until_state=no_schedule_until_state,
+            enable_prefix_aware_scheduling=enable_prefix_aware_scheduling,
+        )
     else:
+        enable_prefix_aware_scheduling = (
+            scheduler_config.enable_prefix_aware_scheduling
+            if scheduler_config is not None else True)
         capacity_scheduler = BindCapacityScheduler(
             scheduler_capacity,
             kv_cache_manager.impl if kv_cache_manager is not None else None,
@@ -2169,7 +2179,9 @@ def create_py_executor_instance(
             cross_kv_cache_manager=cross_kv_cache_manager.impl
             if cross_kv_cache_manager is not None else None,
             two_step_lookahead=mapping.has_pp(),
-            no_schedule_until_state=no_schedule_until_state)
+            no_schedule_until_state=no_schedule_until_state,
+            enable_prefix_aware_scheduling=enable_prefix_aware_scheduling,
+        )
 
         mb_scheduler = BindMicroBatchScheduler(max_batch_size, max_num_tokens,
                                                ctx_chunk_config)

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler.py
@@ -21,6 +21,10 @@ PrefixSummaryCache: TypeAlias = dict[int, PrefixReuseSummary]
 T = TypeVar("T")
 
 
+def _zero_prefix_reuse_summary() -> PrefixReuseSummary:
+    return tb_internal.batch_manager.PrefixReuseSummary()
+
+
 def _call_with_optional_summary(
     fn: Callable[..., T],
     *args: Any,
@@ -306,14 +310,15 @@ class BindCapacityScheduler(CapacityScheduler):
     def __init__(
         self,
         max_num_requests: int,
-        kv_cache_manager,
+        kv_cache_manager: object | None,
         peft_cache_manager: tb_internal.batch_manager.PeftCacheManager | None,
         scheduler_policy: CapacitySchedulerPolicy = CapacitySchedulerPolicy.GUARANTEED_NO_EVICT,
         *,
-        cross_kv_cache_manager=None,
+        cross_kv_cache_manager: object | None = None,
         two_step_lookahead: bool = False,
         no_schedule_until_state: LlmRequestState = LlmRequestState.CONTEXT_INIT,
-    ):
+        enable_prefix_aware_scheduling: bool = True,
+    ) -> None:
         """C++-bound capacity scheduler wrapper.
 
         ``cross_kv_cache_manager`` enables encoder-decoder dual-pool
@@ -336,6 +341,7 @@ class BindCapacityScheduler(CapacityScheduler):
             two_step_lookahead=two_step_lookahead,
             no_schedule_until_state=no_schedule_until_state,
             no_schedule_after_state=LlmRequestState.GENERATION_COMPLETE,
+            enable_prefix_aware_scheduling=enable_prefix_aware_scheduling,
         )
 
     def schedule_request(
@@ -1112,8 +1118,12 @@ class GuaranteedNoEvictPolicy(SchedulerPolicyBase):
                     # MaxUtilizationPolicy.schedule and the C++
                     # single-walk-per-request convention.
                     req_id = req.py_request_id
-                    cached_summary = summary_by_req.get(req_id)
-                    cached_cross_summary = cross_summary_by_req.get(req_id)
+                    cached_summary = summary_by_req.get(
+                        req_id
+                    ) or scheduler._disabled_prefix_summary(req)
+                    cached_cross_summary = cross_summary_by_req.get(
+                        req_id
+                    ) or scheduler._disabled_prefix_summary(req)
 
                     if req.is_encoder_init_state:
                         # Encoder admission only admits encoder compute.
@@ -1261,7 +1271,8 @@ class MaxUtilizationPolicy(SchedulerPolicyBase):
                 scheduled_cross_blocks_manager,
                 num_scheduled_peft_pages,
                 seen_task_ids,
-                cached_summary=summary_by_req.get(req.py_request_id),
+                cached_summary=summary_by_req.get(req.py_request_id)
+                or scheduler._disabled_prefix_summary(req),
             )
 
             if was_scheduled:
@@ -1495,14 +1506,15 @@ class PyCapacityScheduler:
     def __init__(
         self,
         max_num_requests: int,
-        kv_cache_manager=None,
-        peft_cache_manager=None,
+        kv_cache_manager: object | None = None,
+        peft_cache_manager: object | None = None,
         scheduler_policy: CapacitySchedulerPolicy = CapacitySchedulerPolicy.GUARANTEED_NO_EVICT,
-        cross_kv_cache_manager=None,
+        cross_kv_cache_manager: object | None = None,
         two_step_lookahead: bool = False,
         no_schedule_until_state: LlmRequestState = LlmRequestState.CONTEXT_INIT,
         no_schedule_after_state: LlmRequestState = LlmRequestState.GENERATION_COMPLETE,
-    ):
+        enable_prefix_aware_scheduling: bool = True,
+    ) -> None:
         """
         Initialize the capacity scheduler.
 
@@ -1515,6 +1527,7 @@ class PyCapacityScheduler:
             two_step_lookahead: Enable two-step lookahead for MAX_UTILIZATION
             no_schedule_until_state: Don't schedule until this state is reached
             no_schedule_after_state: Don't schedule after this state is reached
+            enable_prefix_aware_scheduling: Use KV prefix-reuse estimates for scheduler decisions
         """
         self.max_num_requests = max_num_requests
         self.kv_cache_manager = kv_cache_manager
@@ -1524,6 +1537,7 @@ class PyCapacityScheduler:
         self.two_step_lookahead = two_step_lookahead
         self.no_schedule_until_state = no_schedule_until_state
         self.no_schedule_after_state = no_schedule_after_state
+        self.enable_prefix_aware_scheduling = enable_prefix_aware_scheduling
         # Cache state values to avoid repeated .value access (optimization)
         self._no_schedule_until_state_value = no_schedule_until_state.value
         self._no_schedule_after_state_value = no_schedule_after_state.value
@@ -1569,6 +1583,8 @@ class PyCapacityScheduler:
         """
         if self.kv_cache_manager is None:
             return False
+        if not self.enable_prefix_aware_scheduling:
+            return False
         if self.kv_cache_manager.is_variable_window:
             return False
         if (
@@ -1588,7 +1604,7 @@ class PyCapacityScheduler:
         newly_contributed_context_blocks: Set = set()
         newly_contributed_cross_context_blocks: Set = set()
 
-        if self.kv_cache_manager is None:
+        if self.kv_cache_manager is None or not self.enable_prefix_aware_scheduling:
             return newly_contributed_context_blocks, newly_contributed_cross_context_blocks
 
         enable_block_reuse = self.kv_cache_manager.enable_block_reuse
@@ -1640,6 +1656,8 @@ class PyCapacityScheduler:
 
         C++ reference: capacityScheduler.cpp (beneficialToSkip / oneManagerBeneficialToSkip)
         """
+        if not self.enable_prefix_aware_scheduling:
+            return False
         if not (req.is_context_init_state and req.is_first_context_chunk):
             return False
 
@@ -1689,6 +1707,13 @@ class PyCapacityScheduler:
             newly_contributed_cross_context_blocks.add(cross_new_block)
 
         return False
+
+    def _disabled_prefix_summary(self, req: LlmRequest) -> Optional[PrefixReuseSummary]:
+        if self.enable_prefix_aware_scheduling:
+            return None
+        if req.is_context_init_state and req.is_first_context_chunk:
+            return _zero_prefix_reuse_summary()
+        return None
 
     def _get_max_peft_pages(self) -> int:
         """Get maximum PEFT cache pages."""
@@ -1768,15 +1793,16 @@ class SimpleUnifiedScheduler(RequestScheduler):
         self,
         max_batch_size: int,
         max_num_tokens: int,
-        kv_cache_manager,
-        peft_cache_manager,
+        kv_cache_manager: object | None,
+        peft_cache_manager: object | None,
         scheduler_policy: CapacitySchedulerPolicy,
         ctx_chunk_config: Optional[tuple[StrEnum, int]] = None,
-        cross_kv_cache_manager=None,
+        cross_kv_cache_manager: object | None = None,
         two_step_lookahead: bool = False,
         scheduler_capacity: Optional[int] = None,
         no_schedule_until_state: LlmRequestState = LlmRequestState.CONTEXT_INIT,
-    ):
+        enable_prefix_aware_scheduling: bool = True,
+    ) -> None:
         # Use scheduler_capacity if provided, otherwise fall back to max_batch_size
         # scheduler_capacity may differ from max_batch_size (e.g., adjusted for attention_dp + disagg)
         capacity = scheduler_capacity if scheduler_capacity is not None else max_batch_size
@@ -1791,6 +1817,7 @@ class SimpleUnifiedScheduler(RequestScheduler):
             cross_kv_cache_manager=cross_kv_cache_manager,
             two_step_lookahead=two_step_lookahead,
             no_schedule_until_state=no_schedule_until_state,
+            enable_prefix_aware_scheduling=enable_prefix_aware_scheduling,
         )
 
         # 2. Initialize Python MicroBatch Scheduler

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler_v2.py
@@ -141,16 +141,17 @@ class KVCacheV2Scheduler(RequestScheduler):
         self,
         max_batch_size: int,
         max_num_tokens: Optional[int],
-        kv_cache_manager,  # KVCacheManagerV2
+        kv_cache_manager: object,  # KVCacheManagerV2
         scheduler_policy: CapacitySchedulerPolicy,
         ctx_chunk_config: Optional[tuple] = None,
-        peft_cache_manager=None,
+        peft_cache_manager: object | None = None,
         scheduler_capacity: Optional[int] = None,
         no_schedule_until_state: LlmRequestState = LlmRequestState.CONTEXT_INIT,
         no_schedule_after_state: LlmRequestState = LlmRequestState.GENERATION_TO_COMPLETE,
-        draft_kv_cache_manager=None,  # KVCacheManagerV2 for MTP draft layers
-        cross_kv_cache_manager=None,  # KVCacheManagerV2 for enc-dec cross-attn
-    ):
+        draft_kv_cache_manager: object | None = None,  # KVCacheManagerV2 for MTP draft layers
+        cross_kv_cache_manager: object | None = None,  # KVCacheManagerV2 for enc-dec cross-attn
+        enable_prefix_aware_scheduling: bool = True,
+    ) -> None:
         self.max_num_tokens = max_num_tokens
         self.max_num_requests = (
             scheduler_capacity if scheduler_capacity is not None else max_batch_size
@@ -163,6 +164,7 @@ class KVCacheV2Scheduler(RequestScheduler):
         self.kv_cache_manager = kv_cache_manager
         self.draft_kv_cache_manager = draft_kv_cache_manager
         self.cross_kv_cache_manager = cross_kv_cache_manager
+        self.enable_prefix_aware_scheduling = enable_prefix_aware_scheduling
         if scheduler_policy != CapacitySchedulerPolicy.MAX_UTILIZATION:
             logger.warning(
                 "KVCacheV2Scheduler only supports MAX_UTILIZATION for now, "
@@ -186,7 +188,8 @@ class KVCacheV2Scheduler(RequestScheduler):
         logger.info(
             f"KVCacheV2Scheduler: tokens_per_block={self.tokens_per_block}, "
             f"max_num_tokens={max_num_tokens}, max_batch_size={max_batch_size}, "
-            f"draft_mgr={draft_mgr_name}, cross_mgr={cross_mgr_name}"
+            f"draft_mgr={draft_mgr_name}, cross_mgr={cross_mgr_name}, "
+            f"enable_prefix_aware_scheduling={enable_prefix_aware_scheduling}"
         )
         if ctx_chunk_config is not None:
             self.chunking_enabled = True
@@ -501,6 +504,19 @@ class KVCacheV2Scheduler(RequestScheduler):
 
         Returns ``(action, tokens, chunking_flag)``.
         """
+        pre_prepare_context_tokens = req.context_remaining_length
+        draft_len = get_draft_token_length(req)
+        if not self.enable_prefix_aware_scheduling:
+            req_tokens = pre_prepare_context_tokens + draft_len
+            if not budget.can_fit_tokens(req_tokens):
+                return ScheduleAction.STOP, 0, False
+            assert (
+                self.max_context_length is None
+                or pre_prepare_context_tokens <= self.max_context_length
+            ), (
+                f"Context tokens ({pre_prepare_context_tokens}) exceeds limit ({self.max_context_length})"
+            )
+
         # Prepare first so block reuse updates context_remaining_length
         # before budget check.
         if not self.kv_cache_manager.prepare_context(req):
@@ -508,19 +524,19 @@ class KVCacheV2Scheduler(RequestScheduler):
             return ScheduleAction.STOP, 0, False
 
         context_tokens = req.context_remaining_length
-        draft_len = get_draft_token_length(req)
-        req_tokens = context_tokens + draft_len
+        if self.enable_prefix_aware_scheduling:
+            req_tokens = context_tokens + draft_len
 
-        if not budget.can_fit_tokens(req_tokens):
-            return ScheduleAction.STOP, 0, False
+            if not budget.can_fit_tokens(req_tokens):
+                return ScheduleAction.STOP, 0, False
 
-        assert self.max_context_length is None or context_tokens <= self.max_context_length, (
-            f"Context tokens ({context_tokens}) exceeds limit ({self.max_context_length})"
-        )
+            assert self.max_context_length is None or context_tokens <= self.max_context_length, (
+                f"Context tokens ({context_tokens}) exceeds limit ({self.max_context_length})"
+            )
 
         # V2 resizes KV cache directly in the scheduler (no separate
         # prepareResources for main cache), so include draft tokens.
-        if not self.kv_cache_manager.resize_context(req, req_tokens):
+        if not self.kv_cache_manager.resize_context(req, context_tokens + draft_len):
             return ScheduleAction.SKIP, 0, False
 
         cross_action = self._try_schedule_cross_context(req)
@@ -542,6 +558,7 @@ class KVCacheV2Scheduler(RequestScheduler):
         (needing only ~1 token) to still be scheduled.
         """
         remaining_budget = budget.remaining_tokens
+        pre_prepare_context_remaining = req.context_remaining_length
 
         # Min budget check — need at least one chunk unit
         if remaining_budget is not None and remaining_budget < self.chunk_unit_size:
@@ -555,17 +572,22 @@ class KVCacheV2Scheduler(RequestScheduler):
         # Calculate chunk size from remaining budget
         #    (context_remaining_length is now correct after block reuse)
         context_remaining = req.context_remaining_length
+        budget_context_remaining = (
+            context_remaining
+            if self.enable_prefix_aware_scheduling
+            else pre_prepare_context_remaining
+        )
         chunk_size = (
-            min(remaining_budget, context_remaining)
+            min(remaining_budget, budget_context_remaining)
             if remaining_budget is not None
-            else context_remaining
+            else budget_context_remaining
         )
 
         if self.max_context_length is not None:
             chunk_size = min(chunk_size, self.max_context_length)
 
         # Round down to chunk_unit_size boundary (unless last chunk).
-        if chunk_size < context_remaining:
+        if chunk_size < budget_context_remaining:
             chunk_size = (chunk_size // self.chunk_unit_size) * self.chunk_unit_size
 
         if chunk_size <= 0:
@@ -585,18 +607,21 @@ class KVCacheV2Scheduler(RequestScheduler):
         if chunk_size <= 0:
             return ScheduleAction.SKIP, 0, False
 
-        req.context_chunk_size = chunk_size
+        budget_chunk_size = chunk_size
+        req.context_chunk_size = min(chunk_size, context_remaining)
 
         # Draft tokens only matter for last chunk (budget + resize)
-        chunk_tokens = chunk_size
+        chunk_tokens = budget_chunk_size
+        resize_tokens = req.context_chunk_size
         if req.is_last_context_chunk:
             draft_len = get_draft_token_length(req)
             if draft_len > 0:
                 chunk_tokens += draft_len
+                resize_tokens += draft_len
 
         # V2 resizes KV cache directly in the scheduler, so include
         # draft tokens for last chunk.
-        if not self.kv_cache_manager.resize_context(req, chunk_tokens):
+        if not self.kv_cache_manager.resize_context(req, resize_tokens):
             return ScheduleAction.SKIP, 0, False
 
         cross_action = self._try_schedule_cross_context(req)

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -2951,14 +2951,22 @@ class SchedulerConfig(StrictBaseModel, PybindMirror):
         default=False,
         description="Use pure-Python scheduler instead of C++ scheduler.")
 
-    def _to_pybind(self):
+    enable_prefix_aware_scheduling: bool = Field(
+        default=True,
+        description=("Use KV prefix-reuse estimates for scheduler admission, "
+                     "duplicate-request deferral, and token-budget decisions. "
+                     "This is orthogonal to "
+                     "kv_cache_config.enable_block_reuse."))
+
+    def _to_pybind(self) -> _SchedulerConfig:
         return _SchedulerConfig(
             capacity_scheduler_policy=self.capacity_scheduler_policy._to_pybind(
             ),
             context_chunking_policy=self.context_chunking_policy._to_pybind()
             if self.context_chunking_policy else None,
             dynamic_batch_config=self.dynamic_batch_config._to_pybind()
-            if self.dynamic_batch_config else None)
+            if self.dynamic_batch_config else None,
+            enable_prefix_aware_scheduling=self.enable_prefix_aware_scheduling)
 
 
 @PybindMirror.mirror_pybind_fields(_PeftCacheConfig)

--- a/tensorrt_llm/usage/llm_args_golden_manifest.json
+++ b/tensorrt_llm/usage/llm_args_golden_manifest.json
@@ -1189,6 +1189,13 @@
       "annotation": "<class 'bool'>",
       "converter": "",
       "kind": "value",
+      "path": "scheduler_config.enable_prefix_aware_scheduling"
+    },
+    {
+      "allowed_values": [],
+      "annotation": "<class 'bool'>",
+      "converter": "",
+      "kind": "value",
       "path": "scheduler_config.use_python_scheduler"
     },
     {
@@ -3397,6 +3404,13 @@
       "converter": "",
       "kind": "value",
       "path": "scheduler_config.dynamic_batch_config.enable_max_num_tokens_tuning"
+    },
+    {
+      "allowed_values": [],
+      "annotation": "<class 'bool'>",
+      "converter": "",
+      "kind": "value",
+      "path": "scheduler_config.enable_prefix_aware_scheduling"
     },
     {
       "allowed_values": [],

--- a/tensorrt_llm/usage/schemas/README.md
+++ b/tensorrt_llm/usage/schemas/README.md
@@ -185,6 +185,7 @@ exhaustive field table at docs build time under **Developer Guide > Telemetry**.
 | `kv_cache_config.enable_block_reuse` | Whether KV cache block reuse/prefix caching is enabled. |
 | `cuda_graph_config.batch_sizes` | CUDA graph batch sizes when configured. |
 | `scheduler_config.capacity_scheduler_policy` | Scheduler capacity policy. |
+| `scheduler_config.enable_prefix_aware_scheduling` | Whether scheduler admission and token budgeting use KV prefix-reuse estimates. |
 | `torch_compile_config.enable_inductor` | Whether Torch Inductor compilation is enabled. |
 | `moe_config.backend` | MoE backend selection (`AUTO`, `CUTLASS`, `TRTLLM`, ...), an annotation-derived categorical. |
 | `speculative_config.decoding_type` | Speculative decoding mode discriminator (e.g. `User_Provided`); other arms expose their own numeric/boolean knobs under `speculative_config.*`. |

--- a/tests/unittest/_torch/executor/test_kv_cache_v2_scheduler.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_v2_scheduler.py
@@ -175,16 +175,17 @@ def make_peft_cache_manager(max_device_pages, pages_per_task=1):
 
 
 def make_scheduler(
-    kv_cache_manager,
-    max_batch_size=100,
-    max_num_tokens=1024,
-    ctx_chunk_config=None,
-    peft_cache_manager=None,
-    scheduler_capacity=None,
-    no_schedule_until_state=None,
-    no_schedule_after_state=None,
-    cross_kv_cache_manager=None,
-):
+    kv_cache_manager: Mock,
+    max_batch_size: int = 100,
+    max_num_tokens: int | None = 1024,
+    ctx_chunk_config: tuple | None = None,
+    peft_cache_manager: Mock | None = None,
+    scheduler_capacity: int | None = None,
+    no_schedule_until_state: LlmRequestState | None = None,
+    no_schedule_after_state: LlmRequestState | None = None,
+    cross_kv_cache_manager: Mock | None = None,
+    enable_prefix_aware_scheduling: bool = True,
+) -> object:
     """Create KVCacheV2Scheduler, patching isinstance check for mock mgr."""
     from tensorrt_llm._torch.pyexecutor.scheduler.scheduler_v2 import KVCacheV2Scheduler
 
@@ -207,6 +208,7 @@ def make_scheduler(
             ctx_chunk_config=ctx_chunk_config,
             peft_cache_manager=peft_cache_manager,
             scheduler_capacity=scheduler_capacity,
+            enable_prefix_aware_scheduling=enable_prefix_aware_scheduling,
             **kwargs,
         )
 
@@ -1983,6 +1985,44 @@ class TestPrepareBeforeBudget:
         req = make_ctx_request(0, context_remaining_length=1000)
         out = sched.schedule_request([req], set())
         assert ids(out.context_requests) == [0]
+
+    def test_prefix_aware_scheduling_disabled_charges_pre_reuse_tokens(self) -> None:
+        """Actual KV resize uses post-reuse length, but scheduler budget uses the pre-reuse length."""
+        resize_calls: list[int] = []
+
+        def prepare_with_reuse(req: Mock) -> bool:
+            req.context_remaining_length = 500
+            return True
+
+        def track_resize(req: Mock, num_tokens: int) -> bool:
+            resize_calls.append(num_tokens)
+            return True
+
+        mgr = make_kv_cache_manager(
+            prepare_context_fn=prepare_with_reuse,
+            resize_context_fn=track_resize,
+        )
+        sched = make_scheduler(
+            mgr,
+            max_num_tokens=1000,
+            enable_prefix_aware_scheduling=False,
+        )
+        req = make_ctx_request(0, context_remaining_length=1000)
+        out = sched.schedule_request([req], set())
+        assert ids(out.context_requests) == [0]
+        assert resize_calls == [500]
+
+        mgr = make_kv_cache_manager(prepare_context_fn=prepare_with_reuse)
+        sched = make_scheduler(
+            mgr,
+            max_num_tokens=1000,
+            enable_prefix_aware_scheduling=False,
+        )
+        gen = make_gen_request(1)
+        ctx = make_ctx_request(2, context_remaining_length=1000)
+        out = sched.schedule_request([gen, ctx], set())
+        assert ids(out.generation_requests) == [1]
+        assert ids(out.context_requests) == []
 
 
 # ===========================================================================

--- a/tests/unittest/_torch/executor/test_py_scheduler.py
+++ b/tests/unittest/_torch/executor/test_py_scheduler.py
@@ -2849,6 +2849,35 @@ class TestPyCapacitySchedulerKVCacheReuse:
         assert fitting[0].request_id == 0
         assert len(paused) == 0
 
+    def test_prefix_aware_scheduling_disabled_does_not_delay_duplicates(self) -> None:
+        kv = MockKVCacheManager(num_free_blocks=100, blocks_per_request=3, enable_block_reuse=True)
+
+        def fail_analyze_prefix_reuse(
+            unique_tokens: object, req: LlmRequest
+        ) -> MockPrefixReuseSummary:
+            raise AssertionError("prefix reuse should not be probed when scheduling is disabled")
+
+        kv.analyze_prefix_reuse = fail_analyze_prefix_reuse
+        scheduler = PyCapacityScheduler(
+            max_num_requests=3,
+            kv_cache_manager=kv,
+            scheduler_policy=CapacitySchedulerPolicy.GUARANTEED_NO_EVICT,
+            enable_prefix_aware_scheduling=False,
+        )
+        tokens = list(range(21))
+        r0 = _make_request(0, prompt_len=21, input_tokens=tokens)
+        r1 = _make_request(1, prompt_len=21, input_tokens=tokens)
+        r2 = _make_request(2, prompt_len=21, input_tokens=tokens)
+        fitting, disagg, paused = scheduler.schedule_request([r0, r1, r2])
+
+        assert [req.request_id for req in fitting] == [0, 1, 2]
+        assert len(disagg) == 0
+        assert len(paused) == 0
+        assert kv.enable_block_reuse is True
+        assert r0.estimated_reusable_tokens == 0
+        assert r1.estimated_reusable_tokens == 0
+        assert r2.estimated_reusable_tokens == 0
+
     def test_delay_duplicate_request_chunked(self):
         """C++ ref: DelayDuplicateRequestChunked"""
         kv = MockKVCacheManager(num_free_blocks=100, blocks_per_request=5, enable_block_reuse=True)

--- a/tests/unittest/bindings/test_executor_bindings.py
+++ b/tests/unittest/bindings/test_executor_bindings.py
@@ -1372,7 +1372,7 @@ def test_dynamic_batch_config_pickle():
     assert config_copy.dynamic_batch_moving_average_window == 128
 
 
-def test_scheduler_config() -> None:
+def test_scheduler_config():
     capacity_scheduler_policy = trtllm.CapacitySchedulerPolicy.GUARANTEED_NO_EVICT
     config = trtllm.SchedulerConfig()
     assert config.capacity_scheduler_policy == capacity_scheduler_policy

--- a/tests/unittest/bindings/test_executor_bindings.py
+++ b/tests/unittest/bindings/test_executor_bindings.py
@@ -1372,11 +1372,12 @@ def test_dynamic_batch_config_pickle():
     assert config_copy.dynamic_batch_moving_average_window == 128
 
 
-def test_scheduler_config():
+def test_scheduler_config() -> None:
     capacity_scheduler_policy = trtllm.CapacitySchedulerPolicy.GUARANTEED_NO_EVICT
     config = trtllm.SchedulerConfig()
     assert config.capacity_scheduler_policy == capacity_scheduler_policy
     assert config.context_chunking_policy is None
+    assert config.enable_prefix_aware_scheduling is True
 
     capacity_scheduler_policy = trtllm.CapacitySchedulerPolicy.MAX_UTILIZATION
     config = trtllm.SchedulerConfig(capacity_scheduler_policy)
@@ -1402,12 +1403,13 @@ def test_scheduler_config():
     dynamic_batch_config = trtllm.DynamicBatchConfig(True, True, 128)
     config = trtllm.SchedulerConfig(capacity_scheduler_policy,
                                     context_chunking_policy,
-                                    dynamic_batch_config)
+                                    dynamic_batch_config, False)
     assert config.capacity_scheduler_policy == capacity_scheduler_policy
     assert config.context_chunking_policy == context_chunking_policy
     assert config.dynamic_batch_config.enable_batch_size_tuning == True
     assert config.dynamic_batch_config.enable_max_num_tokens_tuning == True
     assert config.dynamic_batch_config.dynamic_batch_moving_average_window == 128
+    assert config.enable_prefix_aware_scheduling is False
 
 
 def test_kv_cache_config():
@@ -2490,12 +2492,14 @@ def test_request_stats_per_iteration():
     assert stats_json["requestStats"][0]["id"] == 1
 
 
-def test_scheduler_config_pickle():
+def test_scheduler_config_pickle() -> None:
     policy = trtllm.CapacitySchedulerPolicy.MAX_UTILIZATION
-    config = trtllm.SchedulerConfig(policy)
+    config = trtllm.SchedulerConfig(policy,
+                                    enable_prefix_aware_scheduling=False)
     config_str = pickle.dumps(config)
     config_copy = pickle.loads(config_str)
     assert config.capacity_scheduler_policy == config_copy.capacity_scheduler_policy
+    assert config_copy.enable_prefix_aware_scheduling is False
 
 
 def test_kv_cache_config_pickle():
@@ -2627,7 +2631,7 @@ def test_cache_transceiver_config_pickle():
     assert config_copy.kv_transfer_poll_interval_ms == config.kv_transfer_poll_interval_ms
 
 
-def test_executor_config_pickle():
+def test_executor_config_pickle() -> None:
     beam_width = 2
     config = trtllm.ExecutorConfig(beam_width)
 
@@ -2639,7 +2643,8 @@ def test_executor_config_pickle():
         "max_num_tokens":
         128,
         "scheduler_config":
-        trtllm.SchedulerConfig(trtllm.CapacitySchedulerPolicy.MAX_UTILIZATION),
+        trtllm.SchedulerConfig(trtllm.CapacitySchedulerPolicy.MAX_UTILIZATION,
+                               enable_prefix_aware_scheduling=False),
         "kv_cache_config":
         trtllm.KvCacheConfig(enable_block_reuse=True,
                              free_gpu_memory_fraction=0.5),
@@ -2697,6 +2702,7 @@ def test_executor_config_pickle():
     assert config.max_batch_size == config_copy.max_batch_size
     assert config.max_num_tokens == config_copy.max_num_tokens
     assert config.scheduler_config.capacity_scheduler_policy == config_copy.scheduler_config.capacity_scheduler_policy
+    assert config_copy.scheduler_config.enable_prefix_aware_scheduling is False
     assert config.kv_cache_config.enable_block_reuse == config_copy.kv_cache_config.enable_block_reuse
     assert config.enable_chunked_context == config_copy.enable_chunked_context
     assert config.normalize_log_probs == config_copy.normalize_log_probs

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -570,20 +570,27 @@ def test_DynamicBatchConfig_declaration():
     assert pybind_config.dynamic_batch_moving_average_window == 10
 
 
-def test_SchedulerConfig_declaration():
+def test_SchedulerConfig_declaration() -> None:
+    default_config = SchedulerConfig()
+    default_pybind_config = PybindMirror.maybe_to_pybind(default_config)
+    assert default_config.enable_prefix_aware_scheduling is True
+    assert default_pybind_config.enable_prefix_aware_scheduling is True
+
     config = SchedulerConfig(
         capacity_scheduler_policy=CapacitySchedulerPolicy.MAX_UTILIZATION,
         context_chunking_policy=ContextChunkingPolicy.EQUAL_PROGRESS,
         dynamic_batch_config=DynamicBatchConfig(
             enable_batch_size_tuning=True,
             enable_max_num_tokens_tuning=True,
-            dynamic_batch_moving_average_window=10))
+            dynamic_batch_moving_average_window=10),
+        enable_prefix_aware_scheduling=False)
 
     pybind_config = PybindMirror.maybe_to_pybind(config)
     assert pybind_config.capacity_scheduler_policy == tle.CapacitySchedulerPolicy.MAX_UTILIZATION
     assert pybind_config.context_chunking_policy == tle.ContextChunkingPolicy.EQUAL_PROGRESS
     assert PybindMirror.pybind_equals(pybind_config.dynamic_batch_config,
                                       config.dynamic_batch_config._to_pybind())
+    assert pybind_config.enable_prefix_aware_scheduling is False
 
 
 def test_PeftCacheConfig_declaration():


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `enable_prefix_aware_scheduling` configuration option to the scheduler, allowing fine-grained control over prefix-aware scheduling behavior for KV cache optimization (enabled by default).

* **Documentation**
  * Updated guides with information on the new scheduler configuration option and its interaction with KV cache block reuse settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

C++ focused gtests:
CapacitySchedulerTest.PrefixAwareSchedulingDisabledDoesNotDelayDuplicateRequest
CombinedSchedulerTest.PrefixAwareSchedulingDisabledKeepsReusableTokensZero
SerializeUtilsTest.SchedulerConfig

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
