### PR TITLE
[None][chore] Allow fp8 per-tensor base weights for MoE LoRA

### DIFF
--- a/cpp/tensorrt_llm/thop/moeOp.cpp
+++ b/cpp/tensorrt_llm/thop/moeOp.cpp
@@ -606,15 +606,20 @@ public:
             TORCH_CHECK(!(lora_per_request && lora_slot_indexed),
                 "MoE LoRA: the per-request (fc1_lora_ranks, ...) and slot-indexed (fc1_slot_lora_ranks, ..., "
                 "token_to_slot) input schemas are mutually exclusive. Provide exactly one, not both.");
-            // Conservative rejections (min-latency, alltoall, quant, graph capture).
+            // Conservative rejections (min-latency, alltoall, unsupported quant, graph capture).
             TORCH_CHECK(!min_latency_mode, "MoE LoRA is not supported in min-latency mode.");
             TORCH_CHECK(!enable_alltoall,
                 "MoE LoRA is not supported with alltoall: the per-token adapter pointer arrays do not survive "
                 "cross-rank token reshuffling.");
-            TORCH_CHECK(mActivationDtype == c10::ScalarType::Half || mActivationDtype == c10::ScalarType::BFloat16,
-                "MoE LoRA only supports fp16 and bf16 activation dtypes.");
-            TORCH_CHECK(mWeightDtype == c10::ScalarType::Half || mWeightDtype == c10::ScalarType::BFloat16,
-                "MoE LoRA only supports unquantized fp16/bf16 expert weights.");
+            bool const is_per_tensor_fp8 = isFp8Quant();
+            TORCH_CHECK(mActivationDtype == c10::ScalarType::Half || mActivationDtype == c10::ScalarType::BFloat16
+                    || is_per_tensor_fp8,
+                "MoE LoRA only supports fp16, bf16, or per-tensor FP8 (qdq) base weights. FP8 block-scale, NVFP4, "
+                "MXFP8, and integer quant are not supported.");
+            TORCH_CHECK(
+                mWeightDtype == c10::ScalarType::Half || mWeightDtype == c10::ScalarType::BFloat16 || is_per_tensor_fp8,
+                "MoE LoRA supports unquantized fp16/bf16 or per-tensor FP8 (qdq) base expert weights only "
+                "(LoRA adapters are always fp16/bf16).");
             // CUDA-graph capture is only safe on the device LoRA path. The
             // legacy host path performs a host-side cudaEventSynchronize and
             // per-token pointer expansion in setupLoraWorkspace, plus host-side
@@ -1274,7 +1279,7 @@ private:
     }
 
     // Map a torch dtype to the TRT-LLM nvinfer1::DataType expected by LoraImpl.
-    static nvinfer1::DataType loraTypeFromActDtype(c10::ScalarType dtype)
+    nvinfer1::DataType loraTypeFromActDtype(c10::ScalarType dtype) const
     {
         switch (dtype)
         {
@@ -1282,6 +1287,12 @@ private:
         case c10::ScalarType::Float: return nvinfer1::DataType::kFLOAT;
 #ifdef ENABLE_BF16
         case c10::ScalarType::BFloat16: return nvinfer1::DataType::kBF16;
+#endif
+#ifdef ENABLE_FP8
+        case c10::ScalarType::Float8_e4m3fn:
+            TORCH_CHECK(mOutputDtype != c10::ScalarType::Float8_e4m3fn,
+                "MoE LoRA with FP8 base activations requires an fp16/bf16 output (LoRA compute) dtype.");
+            return loraTypeFromActDtype(mOutputDtype);
 #endif
         default: C10_THROW_ERROR_FORMATTED(Error, "MoE LoRA only supports fp16/bf16/fp32 activation dtype.");
         }

--- a/tensorrt_llm/_torch/models/modeling_mixtral.py
+++ b/tensorrt_llm/_torch/models/modeling_mixtral.py
@@ -61,6 +61,7 @@ class MixtralMoE(nn.Module):
         self,
         hidden_states: torch.Tensor,
         attn_metadata: AttentionMetadata,
+        lora_params: Optional[dict] = None,
     ) -> torch.Tensor:
         all_rank_num_tokens = attn_metadata.all_rank_num_tokens
         router_logits = self.gate(hidden_states)
@@ -68,7 +69,8 @@ class MixtralMoE(nn.Module):
             hidden_states,
             router_logits,
             all_rank_num_tokens=all_rank_num_tokens,
-            use_dp_padding=False)
+            use_dp_padding=False,
+            lora_params=lora_params)
         return final_hidden_states
 
 
@@ -141,6 +143,7 @@ class MixtralDecoderLayer(DecoderLayer):
         hidden_states: torch.Tensor,
         attn_metadata: AttentionMetadata,
         residual: Optional[torch.Tensor],
+        lora_params: Optional[dict] = None,
         **kwargs,
     ) -> torch.Tensor:
         if residual is None:
@@ -155,13 +158,16 @@ class MixtralDecoderLayer(DecoderLayer):
             position_ids=position_ids,
             hidden_states=hidden_states,
             attn_metadata=attn_metadata,
+            lora_params=lora_params,
             **kwargs,
         )
 
         # Fully Connected
         hidden_states, residual = self.post_attention_layernorm(
             hidden_states, residual)
-        hidden_states = self.block_sparse_moe(hidden_states, attn_metadata)
+        hidden_states = self.block_sparse_moe(hidden_states,
+                                              attn_metadata,
+                                              lora_params=lora_params)
         return hidden_states, residual
 
 
@@ -195,6 +201,7 @@ class MixtralModel(DecoderModel):
         input_ids: Optional[torch.IntTensor] = None,
         position_ids: Optional[torch.IntTensor] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
+        lora_params: Optional[dict] = None,
         **kwargs,
     ) -> torch.Tensor:
         if (input_ids is None) ^ (inputs_embeds is not None):
@@ -212,7 +219,8 @@ class MixtralModel(DecoderModel):
             hidden_states, residual = decoder_layer(position_ids=position_ids,
                                                     hidden_states=hidden_states,
                                                     attn_metadata=attn_metadata,
-                                                    residual=residual)
+                                                    residual=residual,
+                                                    lora_params=lora_params)
 
         hidden_states, _ = self.norm(hidden_states, residual)
         return hidden_states

--- a/tensorrt_llm/_torch/peft/lora/validation.py
+++ b/tensorrt_llm/_torch/peft/lora/validation.py
@@ -2,20 +2,40 @@
 # SPDX-License-Identifier: Apache-2.0
 """Validation helpers for routed-expert (MoE) LoRA.
 
-MoE LoRA is supported only on the Cutlass backend with unquantized fp16/bf16
-base weights. This module provides a single helper, `check_moe_lora_supported`,
-that callers (typically the MoE factory in `create_moe.py`) can invoke at
-construction time so that unsupported combinations fail loudly instead of
-silently dropping the LoRA contribution at runtime.
+MoE LoRA is supported only on the Cutlass backend with unquantized fp16/bf16 or
+per-tensor FP8 (qdq) base weights. This module provides a single helper,
+`check_moe_lora_supported`, that callers (typically the MoE factory in
+`create_moe.py`) can invoke at construction time so that unsupported
+combinations fail loudly instead of silently dropping the LoRA contribution at
+runtime.
 
-Runtime-only rejections (min-latency mode, alltoall, FP4 base, CUDA-graph
-without slot pointers) are enforced in the C++ thop / runtime call paths and
-are NOT re-checked here.
+Runtime-only rejections (min-latency mode, alltoall, CUDA-graph without slot
+pointers) are enforced in the C++ thop / runtime call paths and are NOT
+re-checked here.
 """
 
 from typing import Iterable, Optional, Set
 
 from tensorrt_llm.lora_helper import LoraConfig
+from tensorrt_llm.quantization.mode import QuantMode
+
+# Base-weight quantization bits that MoE LoRA does not support. Only per-tensor
+# FP8 (qdq) composes with MoE LoRA; any of the bits below makes the combination
+# unsupported.
+_UNSUPPORTED_QUANT = (
+    QuantMode.INT4_WEIGHTS
+    | QuantMode.INT8_WEIGHTS
+    | QuantMode.ACTIVATIONS
+    | QuantMode.FP8_ROWWISE
+    | QuantMode.FP8_1x128_128x128
+    | QuantMode.W4A8_QSERVE
+    | QuantMode.NVFP4
+    | QuantMode.W4A8_NVFP4_FP8
+    | QuantMode.W4A8_MXFP4_FP8
+    | QuantMode.W4A16_MXFP4
+    | QuantMode.W4A8_MXFP4_MXFP8
+    | QuantMode.MXFP8
+)
 
 # TRTLLM module names that map to routed-expert MoE projections.
 MOE_LORA_MODULE_NAMES: Set[str] = {"moe_h_to_4h", "moe_4h_to_h", "moe_gate"}
@@ -33,6 +53,30 @@ def has_moe_lora_targets(lora_config: Optional[LoraConfig]) -> bool:
         MOE_LORA_MODULE_NAMES
         & _normalize_targets(getattr(lora_config, "lora_target_modules", []) or [])
     )
+
+
+def _is_supported_quant(quant_mode) -> bool:
+    """Return True iff the only base-weight quantization is per-tensor FP8 (qdq).
+
+    The CUTLASS MoE LoRA kernel runs the LoRA GEMM on the bf16/fp16 activations,
+    dequantizing the per-tensor FP8 (qdq) activations to the backbone type before
+    the LoRA GEMM. FP8 block-scale, NVFP4, and the integer / MXFP4 / W4A8 formats
+    in `_UNSUPPORTED_QUANT` have no such path and stay rejected.
+    """
+    if quant_mode is None:
+        return False
+    # quant_mode may be a QuantMode, or a QuantModeWrapper that holds a per-layer
+    # list of QuantModes and forwards has_* queries. Normalize to the underlying
+    # QuantMode(s) so the bitwise check works in either case.
+    objs = getattr(quant_mode, "objs", None)
+    modes = objs if objs is not None else [quant_mode]
+    has_supported = False
+    for mode in modes:
+        if mode.has_fp8_qdq():
+            has_supported = True
+        if bool(mode & _UNSUPPORTED_QUANT):
+            return False
+    return has_supported
 
 
 def check_moe_lora_supported(
@@ -55,7 +99,8 @@ def check_moe_lora_supported(
 
     Constraints:
         - MoE backend MUST be CUTLASS.
-        - Base weight quantization MUST be off (no FP8 / FP4 / INT8 / INT4 / W4A8 ...).
+        - Base weight quantization MUST be off (fp16/bf16) or per-tensor FP8
+          (qdq). FP8 block-scale / FP4 / INT8 / INT4 / W4A8 ... are rejected.
 
     Other constraints (alltoall, min-latency, FP4, CUDA-graph) are enforced at
     runtime; we do not pre-check them here because they depend on per-call
@@ -83,10 +128,10 @@ def check_moe_lora_supported(
             except TypeError:
                 # Older signatures may not accept the kwarg; fall back.
                 is_quantized = bool(quant_mode.has_any_quant())
-        if is_quantized:
+        if is_quantized and not _is_supported_quant(quant_mode):
             raise ValueError(
                 f"{prefix}Routed-expert MoE LoRA only supports unquantized "
-                f"fp16/bf16 base weights; got quant_mode={quant_mode}. "
-                "FP8/FP4/INT4/INT8 base weights combined with MoE LoRA are not "
-                "supported."
+                f"fp16/bf16 or per-tensor FP8 (qdq) base weights; got "
+                f"quant_mode={quant_mode}. FP8 block-scale / FP4 / INT4 / INT8 / "
+                "W4A8 base weights combined with MoE LoRA are not supported."
             )

--- a/tests/integration/defs/llmapi/test_llm_api_pytorch_moe_lora.py
+++ b/tests/integration/defs/llmapi/test_llm_api_pytorch_moe_lora.py
@@ -1,0 +1,419 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Routed-expert (MoE) LoRA integration tests on the PyTorch CUTLASS backend.
+
+Covers unquantized bf16 (Qwen1.5-MoE) and per-tensor FP8 qdq (Mixtral-8x7B) base
+weights, with several adapters of varying rank applied in one batch. The adapters
+are fabricated on disk in the per-expert key layout the TRT-LLM loader expects,
+so the tests do not depend on a real PEFT export.
+
+These tests require their model checkpoints under LLM_MODELS_ROOT and fail (not
+skip) when a checkpoint is missing, so a misconfigured model root surfaces as a
+deterministic failure rather than a silent pass.
+"""
+
+import json
+import os
+import tempfile
+
+import pytest
+import torch
+
+from tensorrt_llm import LLM
+from tensorrt_llm.executor.request import LoRARequest
+from tensorrt_llm.llmapi import CudaGraphConfig, KvCacheConfig, SamplingParams
+from tensorrt_llm.llmapi.llm_args import MoeConfig
+from tensorrt_llm.lora_helper import LoraConfig
+from tensorrt_llm.quantization import QuantAlgo
+
+from ..conftest import llm_models_root, skip_pre_ada
+
+# These tests spin up the PyTorch engine (and, in CUDA-graph mode, torch.compile
+# / inductor subprocesses) whose helper threads outlive the test, so the
+# thread-leak check is disabled as for the other LLM-API integration tests.
+pytestmark = [pytest.mark.threadleak(enabled=False)]
+
+_KV_CACHE_CONFIG = KvCacheConfig(free_gpu_memory_fraction=0.4)
+
+# Adapters of varying rank; max_lora_rank must cover the largest.
+_RANKS = [8, 16, 32, 16, 64]
+
+
+def _write_routed_expert_lora_adapter(
+    save_dir: str,
+    *,
+    moe_layers: list[int],
+    num_experts: int,
+    hidden_size: int,
+    moe_intermediate_size: int,
+    rank: int,
+    lora_alpha: float,
+    seed: int,
+) -> None:
+    """Fabricate a per-expert routed-expert HF LoRA adapter on disk.
+
+    Models like Qwen2-MoE and DeepSeek store routed experts under
+    mlp.experts.{e} with gate_proj/up_proj/down_proj projections. This writes
+    per-expert lora_A/lora_B for those projections, keyed as
+    .../mlp.experts.{e}.{proj}.lora_{A,B}.weight. lora_B is non-zero so each
+    adapter perturbs the routed-expert output.
+    """
+    generator = torch.Generator().manual_seed(seed)
+
+    def randn(rows, cols, std=0.02):
+        weight = torch.randn(rows, cols, generator=generator, dtype=torch.float32)
+        return (weight * std).to(torch.bfloat16)
+
+    # (projection name, in_features, out_features) for a single expert.
+    projections = (
+        ("gate_proj", hidden_size, moe_intermediate_size),
+        ("up_proj", hidden_size, moe_intermediate_size),
+        ("down_proj", moe_intermediate_size, hidden_size),
+    )
+
+    state_dict = {}
+    for layer_idx in moe_layers:
+        prefix = f"base_model.model.model.layers.{layer_idx}.mlp.experts"
+        for expert_idx in range(num_experts):
+            for proj, in_features, out_features in projections:
+                key = f"{prefix}.{expert_idx}.{proj}"
+                state_dict[f"{key}.lora_A.weight"] = randn(rank, in_features)
+                state_dict[f"{key}.lora_B.weight"] = randn(out_features, rank)
+
+    os.makedirs(save_dir, exist_ok=True)
+    torch.save(state_dict, os.path.join(save_dir, "adapter_model.bin"))
+    adapter_config = {
+        "peft_type": "LORA",
+        "r": int(rank),
+        "lora_alpha": float(lora_alpha),
+        "target_modules": ["gate_proj", "up_proj", "down_proj"],
+        "bias": "none",
+        "task_type": "CAUSAL_LM",
+        "use_rslora": False,
+    }
+    with open(os.path.join(save_dir, "adapter_config.json"), "w") as f:
+        json.dump(adapter_config, f)
+
+
+def _write_mixtral_expert_lora_adapter(
+    save_dir: str,
+    *,
+    moe_layers: list[int],
+    num_experts: int,
+    hidden_size: int,
+    intermediate_size: int,
+    rank: int,
+    lora_alpha: float,
+    seed: int,
+) -> None:
+    """Fabricate a per-expert routed-expert HF LoRA adapter for Mixtral on disk.
+
+    Mixtral stores each routed expert as three Linears: w1 (gate, silu side),
+    w3 (up, linear side) and w2 (down), under block_sparse_moe.experts.{e}.
+    This writes per-expert lora_A/lora_B for those projections, keyed as
+    .../block_sparse_moe.experts.{e}.{w1,w2,w3}.lora_{A,B}.weight. lora_B is
+    non-zero so each adapter perturbs the routed-expert output.
+    """
+    generator = torch.Generator().manual_seed(seed)
+
+    def randn(rows, cols, std=0.02):
+        weight = torch.randn(rows, cols, generator=generator, dtype=torch.float32)
+        return (weight * std).to(torch.bfloat16)
+
+    # (projection name, in_features, out_features) for a single expert.
+    projections = (
+        ("w1", hidden_size, intermediate_size),
+        ("w3", hidden_size, intermediate_size),
+        ("w2", intermediate_size, hidden_size),
+    )
+
+    state_dict = {}
+    for layer_idx in moe_layers:
+        prefix = f"base_model.model.model.layers.{layer_idx}.block_sparse_moe.experts"
+        for expert_idx in range(num_experts):
+            for proj, in_features, out_features in projections:
+                key = f"{prefix}.{expert_idx}.{proj}"
+                state_dict[f"{key}.lora_A.weight"] = randn(rank, in_features)
+                state_dict[f"{key}.lora_B.weight"] = randn(out_features, rank)
+
+    os.makedirs(save_dir, exist_ok=True)
+    torch.save(state_dict, os.path.join(save_dir, "adapter_model.bin"))
+    adapter_config = {
+        "peft_type": "LORA",
+        "r": int(rank),
+        "lora_alpha": float(lora_alpha),
+        "target_modules": ["w1", "w2", "w3"],
+        "bias": "none",
+        "task_type": "CAUSAL_LM",
+        "use_rslora": False,
+    }
+    with open(os.path.join(save_dir, "adapter_config.json"), "w") as f:
+        json.dump(adapter_config, f)
+
+
+def _run_quantized_routed_expert_multi_lora(
+    model_dir: str,
+    lora_paths: list,
+    *,
+    max_rank: int,
+    target_modules: list,
+    trtllm_modules_to_hf_modules: dict,
+    expected_quant_algo,
+) -> None:
+    """Serve a quantized MoE checkpoint with routed-expert LoRA and assert it applies.
+
+    The batch mixes a no-LoRA (rank-0) request with every adapter, asserting the
+    no-LoRA row produces output and each adapter changes the output versus the
+    base model. Used for the per-tensor FP8 (qdq) base. Caller must force the
+    device LoRA path.
+    """
+    lora_config = LoraConfig(
+        lora_dir=lora_paths,
+        lora_target_modules=target_modules,
+        trtllm_modules_to_hf_modules=trtllm_modules_to_hf_modules,
+        max_lora_rank=max_rank,
+        max_loras=len(lora_paths),
+        max_cpu_loras=len(lora_paths),
+    )
+    llm = LLM(
+        model=model_dir,
+        lora_config=lora_config,
+        moe_config=MoeConfig(backend="CUTLASS"),
+        kv_cache_config=_KV_CACHE_CONFIG,
+    )
+    try:
+        assert llm.args.quant_config.quant_algo == expected_quant_algo, (
+            f"Expected quant_algo={expected_quant_algo}; got {llm.args.quant_config.quant_algo}."
+        )
+        sampling_params = SamplingParams(max_tokens=20, temperature=0.0)
+        prompt = "What is your name?"
+
+        base_tokens = list(
+            llm.generate([prompt], sampling_params, lora_request=None)[0].outputs[0].token_ids
+        )
+
+        lora_requests = [LoRARequest(f"moe-lora-{i}", i, path) for i, path in enumerate(lora_paths)]
+        requests = [None] + lora_requests
+        outputs = llm.generate([prompt] * len(requests), sampling_params, lora_request=requests)
+        out_tokens = [list(o.outputs[0].token_ids) for o in outputs]
+
+        assert out_tokens[0], "No-LoRA row in the mixed batch produced no tokens."
+        for i in range(len(lora_requests)):
+            assert out_tokens[i + 1] != base_tokens, (
+                f"Quantized routed-expert MoE LoRA adapter {i} produced output "
+                "identical to the base model; it was not applied."
+            )
+    finally:
+        llm.shutdown()
+
+
+@pytest.mark.skip_less_device_memory(80000)
+@pytest.mark.parametrize(
+    "moe_lora_mode",
+    [
+        "host_path",
+        "device_path_eager",
+        "device_path_cudagraph",
+    ],
+)
+def test_qwen_moe_routed_expert_multi_lora_varying_ranks(moe_lora_mode: str, monkeypatch) -> None:
+    """Routed-expert MoE LoRA on Qwen1.5-MoE with the PyTorch CUTLASS backend.
+
+    Five dummy adapters of varying rank target the routed experts (moe_h_to_4h,
+    moe_gate, moe_4h_to_h). The same workload runs through each of the three
+    routed-expert LoRA execution paths, selected by moe_lora_mode:
+
+    - host_path: eager, legacy host path (per-request D2H pointer expand).
+    - device_path_eager: eager, capture-safe device path forced on via
+      TLLM_MOE_LORA_USE_DEVICE_PATH (per-request schema, no CUDA graph).
+    - device_path_cudagraph: CUDA graph decode, which always takes the
+      slot-indexed device path; all adapters share one captured graph,
+      exercising the slot-indexed device path and per-slot rank handling.
+
+    Current transformers stores the routed experts as fused 3D parameters, so
+    PEFT cannot produce per-expert adapter weights; the adapters are fabricated
+    directly in the per-expert key layout the TRT-LLM loader expects. An
+    explicit module mapping is supplied because the default map only knows
+    w1/w2/w3 for routed experts. lora_B is non-zero so each adapter perturbs the
+    routed-expert output, letting the test assert the LoRA is actually applied.
+    """
+    # Select the execution path. The eager device path is forced via env var
+    # (read once at FusedMoeRunner construction); the CUDA-graph path always
+    # takes the slot-indexed device path, so it needs no env opt-in.
+    cuda_graph_config = None
+    if moe_lora_mode == "device_path_eager":
+        monkeypatch.setenv("TLLM_MOE_LORA_USE_DEVICE_PATH", "1")
+    elif moe_lora_mode == "device_path_cudagraph":
+        cuda_graph_config = CudaGraphConfig(max_batch_size=10)
+
+    model_dir = f"{llm_models_root()}/Qwen1.5-MoE-A2.7B-Chat"
+
+    ranks = _RANKS
+    max_rank = max(ranks)
+
+    # HF expert-projection names -> routed-expert TRT-LLM module ids. The
+    # default map only carries w1/w2/w3, so the gate/up/down names need an
+    # explicit entry. (gate_proj->w1->moe_h_to_4h, up_proj->w3->moe_gate,
+    # down_proj->w2->moe_4h_to_h.)
+    target_modules = ["moe_h_to_4h", "moe_gate", "moe_4h_to_h"]
+    trtllm_modules_to_hf_modules = {
+        "moe_h_to_4h": "gate_proj",
+        "moe_gate": "up_proj",
+        "moe_4h_to_h": "down_proj",
+    }
+
+    # Derive expert dims and the set of MoE layers from the model config so the
+    # fabricated adapter matches the served model.
+    with open(f"{model_dir}/config.json") as f:
+        cfg = json.load(f)
+    num_experts = cfg["num_experts"]
+    hidden_size = cfg["hidden_size"]
+    moe_intermediate_size = cfg["moe_intermediate_size"]
+    num_hidden_layers = cfg["num_hidden_layers"]
+    decoder_sparse_step = cfg.get("decoder_sparse_step", 1)
+    mlp_only_layers = cfg.get("mlp_only_layers") or []
+    moe_layers = [
+        layer_idx
+        for layer_idx in range(num_hidden_layers)
+        if layer_idx not in mlp_only_layers
+        and num_experts > 0
+        and (layer_idx + 1) % decoder_sparse_step == 0
+    ]
+
+    with tempfile.TemporaryDirectory() as lora_dir:
+        lora_paths = []
+        for i, r in enumerate(ranks):
+            lora_path = f"{lora_dir}/lora_{i}"
+            _write_routed_expert_lora_adapter(
+                lora_path,
+                moe_layers=moe_layers,
+                num_experts=num_experts,
+                hidden_size=hidden_size,
+                moe_intermediate_size=moe_intermediate_size,
+                rank=r,
+                lora_alpha=2 * r,
+                seed=1000 + i,
+            )
+            lora_paths.append(lora_path)
+
+        lora_config = LoraConfig(
+            lora_dir=lora_paths,
+            lora_target_modules=target_modules,
+            trtllm_modules_to_hf_modules=trtllm_modules_to_hf_modules,
+            max_lora_rank=max_rank,
+            max_loras=len(ranks),
+            max_cpu_loras=len(ranks),
+        )
+        llm = LLM(
+            model=model_dir,
+            lora_config=lora_config,
+            moe_config=MoeConfig(backend="CUTLASS"),
+            kv_cache_config=_KV_CACHE_CONFIG,
+            cuda_graph_config=cuda_graph_config,
+        )
+        try:
+            sampling_params = SamplingParams(max_tokens=20, temperature=0.0)
+            prompt = "What is your name?"
+
+            base_tokens = list(
+                llm.generate([prompt], sampling_params, lora_request=None)[0].outputs[0].token_ids
+            )
+
+            lora_requests = [
+                LoRARequest(f"moe-lora-{i}", i, path) for i, path in enumerate(lora_paths)
+            ]
+
+            # One batch mixes a no-LoRA (rank-0) request with every adapter so
+            # the rank-0 skip path and all adapters run through a single
+            # (captured, when enabled) decode graph.
+            requests = [None] + lora_requests
+            outputs = llm.generate([prompt] * len(requests), sampling_params, lora_request=requests)
+            out_tokens = [list(o.outputs[0].token_ids) for o in outputs]
+
+            # The no-LoRA row (index 0) must run (rank-0 skip path) and produce
+            # output.
+            assert out_tokens[0], "No-LoRA row in the mixed batch produced no tokens."
+            # Every adapter must change the output vs base.
+            for i in range(len(lora_requests)):
+                assert out_tokens[i + 1] != base_tokens, (
+                    f"Routed-expert MoE LoRA adapter {i} produced output "
+                    "identical to the base model; it was not applied."
+                )
+        finally:
+            llm.shutdown()
+
+
+@skip_pre_ada
+@pytest.mark.skip_less_device_memory(80000)
+def test_mixtral_moe_routed_expert_fp8_multi_lora_varying_ranks(monkeypatch) -> None:
+    """Routed-expert MoE LoRA on a per-tensor FP8 (qdq) Mixtral-8x7B checkpoint.
+
+    Exercises the FP8 base-weight + routed-expert LoRA path end to end: the
+    CUTLASS MoE kernel dequantizes the FP8 activations to the bf16 LoRA compute
+    type before the LoRA GEMM, so the FP8 base and the bf16 adapters compose.
+    Forces the capture-safe device LoRA path (TLLM_MOE_LORA_USE_DEVICE_PATH=1),
+    which performs the FP8 dequant.
+    """
+    # Force the eager device LoRA path, which runs the FP8 dequant before the
+    # grouped-GEMM LoRA core (loraFC1/loraFC2 in moe_kernels.cu).
+    monkeypatch.setenv("TLLM_MOE_LORA_USE_DEVICE_PATH", "1")
+
+    model_dir = f"{llm_models_root()}/Mixtral-8x7B-Instruct-v0.1-fp8"
+
+    ranks = _RANKS
+    max_rank = max(ranks)
+
+    # Mixtral routed experts are w1 (gate/silu), w3 (up) and w2 (down); map them
+    # to the TRT-LLM routed-expert module ids.
+    target_modules = ["moe_h_to_4h", "moe_gate", "moe_4h_to_h"]
+    trtllm_modules_to_hf_modules = {
+        "moe_h_to_4h": "w1",
+        "moe_gate": "w3",
+        "moe_4h_to_h": "w2",
+    }
+
+    with open(f"{model_dir}/config.json") as f:
+        cfg = json.load(f)
+    num_experts = cfg["num_local_experts"]
+    hidden_size = cfg["hidden_size"]
+    intermediate_size = cfg["intermediate_size"]
+    num_hidden_layers = cfg["num_hidden_layers"]
+    # Every Mixtral decoder layer is a routed-expert MoE layer.
+    moe_layers = list(range(num_hidden_layers))
+
+    with tempfile.TemporaryDirectory() as lora_dir:
+        lora_paths = []
+        for i, r in enumerate(ranks):
+            lora_path = f"{lora_dir}/lora_{i}"
+            _write_mixtral_expert_lora_adapter(
+                lora_path,
+                moe_layers=moe_layers,
+                num_experts=num_experts,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                rank=r,
+                lora_alpha=2 * r,
+                seed=2000 + i,
+            )
+            lora_paths.append(lora_path)
+
+        _run_quantized_routed_expert_multi_lora(
+            model_dir,
+            lora_paths,
+            max_rank=max_rank,
+            target_modules=target_modules,
+            trtllm_modules_to_hf_modules=trtllm_modules_to_hf_modules,
+            expected_quant_algo=QuantAlgo.FP8,
+        )

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -987,6 +987,12 @@ llmapi/test_llm_api_qa.py::TestLlmDefaultBackend::test_llm_args_type_tensorrt
 llmapi/test_llm_api_qa.py::TestLlmDefaultBackend::test_llm_args_type_default
 llmapi/test_llm_api_qa.py::TestLlmDefaultBackend::test_llm_args_logging
 
+# Routed-expert (MoE) LoRA
+llmapi/test_llm_api_pytorch_moe_lora.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks[host_path] TIMEOUT (90)
+llmapi/test_llm_api_pytorch_moe_lora.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks[device_path_eager] TIMEOUT (90)
+llmapi/test_llm_api_pytorch_moe_lora.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks[device_path_cudagraph] TIMEOUT (90)
+llmapi/test_llm_api_pytorch_moe_lora.py::test_mixtral_moe_routed_expert_fp8_multi_lora_varying_ranks TIMEOUT (90)
+
 # CuteDSL NVFP4 tests
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_cute_dsl_nvfp4[fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=False]
 accuracy/test_llm_api_pytorch.py::TestDeepSeekV3Lite::test_cute_dsl_nvfp4[fp8kv=False-attention_dp=False-cuda_graph=False-overlap_scheduler=False-torch_compile=True]

--- a/tests/integration/test_lists/test-db/l0_a100.yml
+++ b/tests/integration/test_lists/test-db/l0_a100.yml
@@ -17,7 +17,6 @@ l0_a100:
     - unittest/llmapi/test_llm_pytorch.py -m "part1"
     - unittest/llmapi/test_llm_pytorch.py -m "part2"
     - unittest/llmapi/test_llm_pytorch.py -m "part3"
-    - unittest/llmapi/test_llm_pytorch.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks TIMEOUT (90)
     - unittest/llmapi/test_llm_encode.py
     - unittest/llmapi/test_llm_encode_multi_item.py
     - unittest/llmapi/test_mpi_session.py ISOLATION

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -256,7 +256,9 @@ l0_h100:
     - unittest/llmapi/test_llm_pytorch.py -m "part1"
     - unittest/llmapi/test_llm_pytorch.py -m "part2"
     - unittest/llmapi/test_llm_pytorch.py -m "part3"
-    - unittest/llmapi/test_llm_pytorch.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks TIMEOUT (90)
+    - llmapi/test_llm_api_pytorch_moe_lora.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks[host_path] TIMEOUT (90)
+    - llmapi/test_llm_api_pytorch_moe_lora.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks[device_path_eager] TIMEOUT (90)
+    - llmapi/test_llm_api_pytorch_moe_lora.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks[device_path_cudagraph] TIMEOUT (90)
     - unittest/llmapi/test_async_llm.py -m "not (gpu2 or gpu4)"
     - examples/test_ray.py::test_llm_inference_async_ray
 - condition:
@@ -331,6 +333,7 @@ l0_h100:
       orchestrator: mpi
   tests:
   # ------------- PyTorch tests ---------------
+  - llmapi/test_llm_api_pytorch_moe_lora.py::test_mixtral_moe_routed_expert_fp8_multi_lora_varying_ranks TIMEOUT (90)
   - accuracy/test_llm_api_pytorch.py::TestQwen3_8B::test_eagle3[eagle3_one_model=True-enable_chunked_prefill=True-enable_max_concurrency=False-enable_draft_len_schedule=False]
   - accuracy/test_llm_api_pytorch.py::TestQwen3_8B::test_eagle3[eagle3_one_model=True-enable_chunked_prefill=False-enable_max_concurrency=False-enable_draft_len_schedule=True]
   - accuracy/test_llm_api_pytorch.py::TestQwen3_8B::test_eagle3[eagle3_one_model=True-enable_chunked_prefill=False-enable_max_concurrency=True-enable_draft_len_schedule=False]

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -481,7 +481,6 @@ unittest/llmapi/test_llm_multi_gpu.py -m "gpu4 and part0" SKIP (https://nvbugs/5
 unittest/llmapi/test_llm_multi_gpu_pytorch.py::test_phi3_lora_fused_modules_output_on_tp2_identical_to_tp1 SKIP (https://nvbugs/6109745)
 unittest/llmapi/test_llm_pytorch.py::test_gqa_nemo_lora[None] SKIP (https://nvbugs/6162504)
 unittest/llmapi/test_llm_pytorch.py::test_gqa_nemo_lora[cuda_graph_config0] SKIP (https://nvbugs/6162504)
-unittest/llmapi/test_llm_pytorch.py::test_qwen_moe_routed_expert_multi_lora_varying_ranks SKIP (https://nvbugs/6335726)
 unittest/llmapi/test_memory_profiling.py::test_profile_kvcache SKIP (https://nvbugs/5580781)
 unittest/tools/test_layer_wise_benchmarks.py::test_deepseek_r1_ctx_dep[1] SKIP (https://nvbugs/6162541)
 unittest/tools/test_layer_wise_benchmarks.py::test_nemotron_gen_dep[1] SKIP (https://nvbugs/6162541)

--- a/tests/unittest/_torch/lora/test_moe_lora_op.py
+++ b/tests/unittest/_torch/lora/test_moe_lora_op.py
@@ -131,7 +131,9 @@ def _build_lora_slot_buffers(
     )
 
 
-def _call_fused_moe(x, w3_w1, w2, topk_ids, topk_scores, output_dtype, lora_kwargs=None):
+def _call_fused_moe(
+    x, w3_w1, w2, topk_ids, topk_scores, output_dtype, lora_kwargs=None, quant_scales=None
+):
     common = dict(
         input=x,
         token_selected_experts=topk_ids,
@@ -141,7 +143,7 @@ def _call_fused_moe(x, w3_w1, w2, topk_ids, topk_scores, output_dtype, lora_kwar
         fc2_expert_weights=w2,
         fc2_expert_biases=None,
         output_dtype=output_dtype,
-        quant_scales=[],
+        quant_scales=quant_scales if quant_scales is not None else [],
     )
     if lora_kwargs is not None:
         common.update(lora_kwargs)
@@ -1236,5 +1238,266 @@ def test_moe_all_three_lora_with_gated_aliased_to_fc1_eager_matches_pytorch_refe
             f"rel_err={rel_err:.3e}"
         )
         torch.testing.assert_close(out_op, out_ref, rtol=5e-2, atol=1.0)
+    finally:
+        MoERunner.runner_dict.clear()
+
+
+# -- Per-tensor FP8 (qdq) base weights + routed-expert LoRA -----------------
+#
+# The CUTLASS MoE LoRA kernel dequantizes per-tensor FP8 activations to the
+# bf16/fp16 LoRA compute type before the LoRA GEMM, so FP8-qdq base weights are
+# supported alongside MoE LoRA. These tests quantize the base MoE inputs to FP8
+# and feed the four quant_scales the op expects, in the order consumed by
+# moeOp.cpp::getQuantParams:
+#
+#     [fc1_dequant (per-expert), fc2_quant (scalar),
+#      fc2_dequant (per-expert), fc1_input_dequant (scalar)]
+
+_FP8_E4M3_MAX = 448.0
+
+
+def _quant_per_tensor_fp8(t):
+    """Per-tensor symmetric FP8 (e4m3) quantization.
+
+    Returns (t_fp8, dequant) with t ~= t_fp8.float() * dequant. dequant is the
+    scalar dequant scale (amax / 448).
+    """
+    amax = t.detach().abs().max().float().clamp(min=1e-6)
+    dequant = amax / _FP8_E4M3_MAX
+    t_fp8 = (t.float() / dequant).clamp(-_FP8_E4M3_MAX, _FP8_E4M3_MAX).to(torch.float8_e4m3fn)
+    return t_fp8, dequant
+
+
+def _quant_per_expert_fp8(w):
+    """Per-expert per-tensor FP8 quantization of a `[E, ...]` weight tensor.
+
+    Returns (w_fp8 `[E, ...]` e4m3, scale `[E]` float32) with
+    `w[e] ~= w_fp8[e].float() * scale[e]`.
+    """
+    num_experts = w.shape[0]
+    scales = torch.empty(num_experts, dtype=torch.float32, device=w.device)
+    w_fp8 = torch.empty_like(w, dtype=torch.float8_e4m3fn)
+    for e in range(num_experts):
+        q, s = _quant_per_tensor_fp8(w[e])
+        w_fp8[e] = q
+        scales[e] = s
+    return w_fp8, scales
+
+
+def _build_fp8_moe_inputs(x_bf16, w3_w1_bf16, w2_bf16):
+    """Quantize base bf16 MoE inputs to per-tensor FP8 (qdq).
+
+    Returns `(x_fp8, w3_w1_fp8, w2_fp8, quant_scales, x_deq, w3_w1_deq,
+    w2_deq)`. The `*_deq` tensors are the FP8 values dequantized back to bf16;
+    feeding them to the reference removes the base-weight quantization error so
+    the comparison isolates kernel correctness (modulo the fc1->fc2 intermediate
+    requant the op performs internally).
+
+    `fc2_quant` is fixed to 1.0 (i.e. the fc1 output is requantized to FP8 with a
+    unit scale): at the shapes/magnitudes used here the SwiGLU intermediate stays
+    well within the FP8 e4m3 range, so this avoids depending on a calibrated
+    activation scale while keeping the math consistent (fc2_dequant == w2_scale).
+    """
+    x_fp8, input_dequant = _quant_per_tensor_fp8(x_bf16)
+    x_deq = (x_fp8.float() * input_dequant).to(x_bf16.dtype)
+
+    w3_w1_fp8, w31_scale = _quant_per_expert_fp8(w3_w1_bf16)
+    w2_fp8, w2_scale = _quant_per_expert_fp8(w2_bf16)
+    w3_w1_deq = (w3_w1_fp8.float() * w31_scale.view(-1, 1, 1)).to(w3_w1_bf16.dtype)
+    w2_deq = (w2_fp8.float() * w2_scale.view(-1, 1, 1)).to(w2_bf16.dtype)
+
+    device = x_bf16.device
+    fc1_dequant = (w31_scale * input_dequant).to(torch.float32)
+    fc2_quant = torch.tensor(1.0, dtype=torch.float32, device=device)
+    fc2_dequant = w2_scale.to(torch.float32)
+    fc1_input_dequant = input_dequant.to(torch.float32).reshape(())
+    quant_scales = [fc1_dequant, fc2_quant, fc2_dequant, fc1_input_dequant]
+    return x_fp8, w3_w1_fp8, w2_fp8, quant_scales, x_deq, w3_w1_deq, w2_deq
+
+
+@requires_cuda_and_op
+@pytest.mark.parametrize("schema", ["per_request", "slot_indexed"])
+def test_moe_fp8_lora_changes_output(schema, monkeypatch):
+    """FP8 (qdq) base weights + routed-expert LoRA must run and apply the LoRA.
+
+    Validates the FP8 enablement end to end through `torch.ops.trtllm.fused_moe`
+    for both LoRA input schemas (per-request host path and slot-indexed device
+    path): the op accepts FP8 weights/activations together with LoRA tensors,
+    produces finite output, and the output differs from the FP8 no-LoRA
+    baseline (the LoRA delta is actually applied on the FP8 base).
+    """
+    from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
+
+    # Force the per-request schema onto the capture-safe device path too, so
+    # both schemas exercise the same FP8 dequant + grouped-GEMM LoRA kernels.
+    monkeypatch.setenv("TLLM_MOE_LORA_USE_DEVICE_PATH", "1")
+
+    MoERunner.runner_dict.clear()
+    try:
+        device = torch.device("cuda")
+        dtype = torch.bfloat16
+        num_tokens, hidden_size, inter_size = 16, 128, 256
+        num_experts, top_k = 4, 2
+        rank = 8
+
+        x, w3_w1, w2, topk_ids, topk_scores = _build_base_inputs(
+            num_tokens, hidden_size, inter_size, num_experts, top_k, dtype, device
+        )
+        x_fp8, w3_w1_fp8, w2_fp8, quant_scales, *_ = _build_fp8_moe_inputs(x, w3_w1, w2)
+
+        out_baseline = _call_fused_moe(
+            x_fp8,
+            w3_w1_fp8,
+            w2_fp8,
+            topk_ids,
+            topk_scores,
+            output_dtype=dtype,
+            quant_scales=quant_scales,
+        )[0]
+
+        fc1_adapter = _make_per_expert_lora_scaled(
+            num_experts, rank, hidden_size, inter_size, dtype=dtype, device=device, seed=410
+        )
+        fc2_adapter = _make_per_expert_lora_scaled(
+            num_experts, rank, inter_size, hidden_size, dtype=dtype, device=device, seed=411
+        )
+
+        if schema == "per_request":
+            lora_kwargs = _build_lora_request_buffers(
+                num_tokens,
+                fc1_adapter["A"],
+                fc1_adapter["B"],
+                fc2_adapter["A"],
+                fc2_adapter["B"],
+                rank=rank,
+            )
+        else:
+            lora_kwargs = _build_lora_slot_buffers(
+                num_tokens,
+                fc1_adapter["A"],
+                fc1_adapter["B"],
+                fc2_adapter["A"],
+                fc2_adapter["B"],
+                rank=rank,
+            )
+
+        out_lora = _call_fused_moe(
+            x_fp8,
+            w3_w1_fp8,
+            w2_fp8,
+            topk_ids,
+            topk_scores,
+            output_dtype=dtype,
+            lora_kwargs=lora_kwargs,
+            quant_scales=quant_scales,
+        )[0]
+
+        assert out_lora.shape == out_baseline.shape
+        assert torch.isfinite(out_lora).all(), f"FP8 fused_moe + LoRA ({schema}) produced NaN / Inf"
+        diff = (out_lora.float() - out_baseline.float()).abs().mean().item()
+        assert diff > 1e-3, (
+            f"FP8 MoE LoRA ({schema}) had no observable effect (mean abs diff={diff})"
+        )
+    finally:
+        MoERunner.runner_dict.clear()
+
+
+def _run_fp8_eager_vs_dequant_reference_check():
+    """Body of `test_moe_fp8_lora_eager_matches_dequant_reference`.
+
+    Compares the FP8 fused MoE + LoRA op against an fp32 PyTorch reference built
+    from the *dequantized* FP8 base weights/activations and the same LoRA
+    adapters. Using the dequantized values removes the base-weight quantization
+    error so any mismatch reflects the kernel pipeline. Tolerances are loose
+    because the op additionally requantizes the fc1->fc2 intermediate to FP8,
+    which the reference does not model.
+    """
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    num_tokens, hidden_size, inter_size = 16, 128, 256
+    num_experts, top_k = 4, 2
+    rank = 8
+
+    x, w3_w1, w2, topk_ids, topk_scores = _build_base_inputs(
+        num_tokens, hidden_size, inter_size, num_experts, top_k, dtype, device
+    )
+    (x_fp8, w3_w1_fp8, w2_fp8, quant_scales, x_deq, w3_w1_deq, w2_deq) = _build_fp8_moe_inputs(
+        x, w3_w1, w2
+    )
+
+    fc1_adapter = _make_per_expert_lora_scaled(
+        num_experts, rank, hidden_size, inter_size, dtype=dtype, device=device, seed=420
+    )
+    gated_adapter = _make_per_expert_lora_scaled(
+        num_experts, rank, hidden_size, inter_size, dtype=dtype, device=device, seed=421
+    )
+    fc2_adapter = _make_per_expert_lora_scaled(
+        num_experts, rank, inter_size, hidden_size, dtype=dtype, device=device, seed=422
+    )
+
+    lora_kwargs = _build_lora_request_buffers(
+        num_tokens,
+        fc1_adapter["A"],
+        fc1_adapter["B"],
+        fc2_adapter["A"],
+        fc2_adapter["B"],
+        rank=rank,
+        gated_a=gated_adapter["A"],
+        gated_b=gated_adapter["B"],
+    )
+
+    out_op = _call_fused_moe(
+        x_fp8,
+        w3_w1_fp8,
+        w2_fp8,
+        topk_ids,
+        topk_scores,
+        output_dtype=dtype,
+        lora_kwargs=lora_kwargs,
+        quant_scales=quant_scales,
+    )[0]
+
+    out_ref = reference_swiglu_moe_lora(
+        x_deq,
+        w3_w1_deq,
+        w2_deq,
+        topk_ids,
+        topk_scores,
+        fc1_a=fc1_adapter["A"],
+        fc1_b=fc1_adapter["B"],
+        gated_a=gated_adapter["A"],
+        gated_b=gated_adapter["B"],
+        fc2_a=fc2_adapter["A"],
+        fc2_b=fc2_adapter["B"],
+    )
+
+    assert torch.isfinite(out_op).all(), "FP8 fused_moe + LoRA produced NaN / Inf"
+    assert torch.isfinite(out_ref).all(), "Dequant reference produced NaN / Inf"
+
+    op_max_mag = out_op.float().abs().max().item()
+    ref_max_mag = out_ref.float().abs().max().item()
+    abs_diff = (out_op.float() - out_ref.float()).abs()
+    max_abs = abs_diff.max().item()
+    rel_err = max_abs / max(op_max_mag, 1e-12)
+
+    print(
+        f"[fp8_eager_vs_ref] op_max_mag={op_max_mag:.3e} "
+        f"ref_max_mag={ref_max_mag:.3e} max_abs_diff={max_abs:.3e} "
+        f"rel_err={rel_err:.3e}"
+    )
+    # Loose tolerance: FP8 base plus the fc1->fc2 intermediate requant.
+    torch.testing.assert_close(out_op, out_ref, rtol=2e-1, atol=2.0)
+
+
+@requires_cuda_and_op
+def test_moe_fp8_lora_eager_matches_dequant_reference():
+    """FP8 (qdq) base + all-three-module routed-expert LoRA parity vs an fp32
+    reference built from the dequantized FP8 base weights.
+    """
+    from tensorrt_llm._torch.custom_ops.torch_custom_ops import MoERunner
+
+    MoERunner.runner_dict.clear()
+    try:
+        _run_fp8_eager_vs_dequant_reference_check()
     finally:
         MoERunner.runner_dict.clear()

--- a/tests/unittest/_torch/lora/test_moe_lora_validator.py
+++ b/tests/unittest/_torch/lora/test_moe_lora_validator.py
@@ -9,6 +9,7 @@ from tensorrt_llm._torch.peft.lora.validation import (
     check_moe_lora_supported,
     has_moe_lora_targets,
 )
+from tensorrt_llm.quantization.mode import QuantMode
 
 
 class _FakeLoraConfig:
@@ -18,17 +19,17 @@ class _FakeLoraConfig:
         self.lora_target_modules = lora_target_modules
 
 
-class _FakeQuantMode:
-    def __init__(self, any_quant: bool):
-        self._any = any_quant
-
-    def has_any_quant(self, exclude_kv_cache: bool = False):
-        return self._any
-
-
 class _FakeQuantConfig:
-    def __init__(self, any_quant: bool):
-        self.quant_mode = _FakeQuantMode(any_quant)
+    """Minimal stand-in for `QuantConfig` carrying a real `QuantMode`."""
+
+    def __init__(self, quant_mode: QuantMode):
+        self.quant_mode = quant_mode
+
+
+_NO_QUANT = QuantMode(0)
+_FP8_QDQ = QuantMode.from_description(use_fp8_qdq=True)
+_FP8_BLOCK_SCALE = QuantMode.from_description(use_fp8_block_scales=True)
+_NVFP4 = QuantMode.from_description(use_nvfp4=True)
 
 
 def test_has_moe_lora_targets_none():
@@ -55,7 +56,7 @@ def test_check_no_lora_is_noop():
     check_moe_lora_supported(
         moe_backend_name="WIDEEP",
         lora_config=None,
-        quant_config=_FakeQuantConfig(True),
+        quant_config=_FakeQuantConfig(_FP8_BLOCK_SCALE),
     )
 
 
@@ -65,7 +66,7 @@ def test_check_no_moe_lora_is_noop():
     check_moe_lora_supported(
         moe_backend_name="TRTLLM",
         lora_config=cfg,
-        quant_config=_FakeQuantConfig(True),
+        quant_config=_FakeQuantConfig(_FP8_BLOCK_SCALE),
     )
 
 
@@ -85,8 +86,30 @@ def test_check_moe_lora_cutlass_unquantized_quant_mode_ok():
     check_moe_lora_supported(
         moe_backend_name="cutlass",  # case-insensitive
         lora_config=cfg,
-        quant_config=_FakeQuantConfig(False),
+        quant_config=_FakeQuantConfig(_NO_QUANT),
     )
+
+
+def test_check_moe_lora_cutlass_fp8_qdq_ok():
+    # Per-tensor FP8 (qdq) base weights are supported on Cutlass.
+    cfg = _FakeLoraConfig(["moe_h_to_4h", "moe_4h_to_h", "moe_gate"])
+    check_moe_lora_supported(
+        moe_backend_name="CUTLASS",
+        lora_config=cfg,
+        quant_config=_FakeQuantConfig(_FP8_QDQ),
+    )
+
+
+def test_check_moe_lora_rejects_fp8_block_scale():
+    # Only per-tensor FP8 (qdq) is supported; FP8 block-scale has no LoRA path
+    # and must be rejected.
+    cfg = _FakeLoraConfig(["moe_h_to_4h", "moe_4h_to_h", "moe_gate"])
+    with pytest.raises(ValueError, match="FP8 block-scale"):
+        check_moe_lora_supported(
+            moe_backend_name="CUTLASS",
+            lora_config=cfg,
+            quant_config=_FakeQuantConfig(_FP8_BLOCK_SCALE),
+        )
 
 
 @pytest.mark.parametrize(
@@ -112,13 +135,15 @@ def test_check_moe_lora_rejects_non_cutlass_backend(backend):
         )
 
 
-def test_check_moe_lora_rejects_quantized_base():
+def test_check_moe_lora_rejects_nvfp4_base():
+    # FP4 (and other non per-tensor-FP8 quant) has no LoRA path and must be
+    # rejected.
     cfg = _FakeLoraConfig(["moe_gate", "moe_4h_to_h"])
-    with pytest.raises(ValueError, match="unquantized fp16/bf16 base weights"):
+    with pytest.raises(ValueError, match="per-tensor FP8"):
         check_moe_lora_supported(
             moe_backend_name="CUTLASS",
             lora_config=cfg,
-            quant_config=_FakeQuantConfig(True),
+            quant_config=_FakeQuantConfig(_NVFP4),
         )
 
 

--- a/tests/unittest/llmapi/test_llm_pytorch.py
+++ b/tests/unittest/llmapi/test_llm_pytorch.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-import os
 import pathlib
 import random
 import time
@@ -13,8 +12,7 @@ from tensorrt_llm import LLM
 from tensorrt_llm.disaggregated_params import DisaggregatedParams
 from tensorrt_llm.executor import GenerationExecutorWorker, RequestError
 from tensorrt_llm.executor.rpc_proxy import GenerationExecutorRpcProxy
-from tensorrt_llm.llmapi import (CacheTransceiverConfig, CudaGraphConfig,
-                                 KvCacheConfig)
+from tensorrt_llm.llmapi import CacheTransceiverConfig, KvCacheConfig
 from tensorrt_llm.llmapi.llm_args import (NGramDecodingConfig, PeftCacheConfig,
                                           SchedulerConfig, WaitingQueuePolicy)
 from tensorrt_llm.llmapi.tokenizer import TransformersTokenizer
@@ -42,7 +40,6 @@ from utils.util import (force_ampere, similar, similarity_score,
                         skip_gpu_memory_less_than_138gb, skip_ray)
 from utils.llm_data import llm_models_root
 from tensorrt_llm.lora_helper import LoraConfig
-from tensorrt_llm.llmapi.llm_args import MoeConfig
 from tensorrt_llm.executor.request import LoRARequest
 import tempfile
 
@@ -955,8 +952,7 @@ def test_nemo_lora_unsupported_modules_validation(tmp_path):
 @pytest.mark.part1
 @test_lora_with_and_without_cuda_graph
 def test_gqa_nemo_lora(tmp_path, cuda_graph_config):
-    """
-    Test NeMo-format LoRA checkpoint loading and GQA support in TinyLlama.
+    """Test NeMo-format LoRA checkpoint loading and GQA support in TinyLlama.
 
     This test verifies two properties:
     1. That a NeMo-format LoRA checkpoint with GQA (grouped query attention) can be loaded and applied to a TinyLlama model,
@@ -1097,199 +1093,11 @@ def test_qwen_moe_shared_expert_lora():
         llm.shutdown()
 
 
-def _write_routed_expert_lora_adapter(save_dir: str, *, moe_layers: list[int],
-                                      num_experts: int, hidden_size: int,
-                                      moe_intermediate_size: int, rank: int,
-                                      lora_alpha: float, seed: int) -> None:
-    """Fabricate a per-expert routed-expert HF LoRA adapter on disk.
-
-    Current transformers stores Qwen2-MoE routed experts as fused 3D parameters
-    (experts.gate_up_proj, experts.down_proj) rather than per-expert Linears, so
-    PEFT cannot emit the per-expert adapter keys the TRT-LLM loader expects.
-    This writes those keys directly: for every MoE layer and expert it creates
-    random lora_A/lora_B for gate_proj (moe_h_to_4h), up_proj (moe_gate) and
-    down_proj (moe_4h_to_h), keyed as .../mlp.experts.{e}.{proj}.lora_{A,B}.weight.
-    lora_B is non-zero so each adapter perturbs the routed-expert output.
-    """
-    generator = torch.Generator().manual_seed(seed)
-
-    def randn(rows, cols, std=0.02):
-        weight = torch.randn(rows,
-                             cols,
-                             generator=generator,
-                             dtype=torch.float32)
-        return (weight * std).to(torch.bfloat16)
-
-    # (projection name, in_features, out_features) for a single expert.
-    projections = (
-        ("gate_proj", hidden_size, moe_intermediate_size),
-        ("up_proj", hidden_size, moe_intermediate_size),
-        ("down_proj", moe_intermediate_size, hidden_size),
-    )
-
-    state_dict = {}
-    for layer_idx in moe_layers:
-        prefix = f"base_model.model.model.layers.{layer_idx}.mlp.experts"
-        for expert_idx in range(num_experts):
-            for proj, in_features, out_features in projections:
-                key = f"{prefix}.{expert_idx}.{proj}"
-                state_dict[f"{key}.lora_A.weight"] = randn(rank, in_features)
-                state_dict[f"{key}.lora_B.weight"] = randn(out_features, rank)
-
-    os.makedirs(save_dir, exist_ok=True)
-    torch.save(state_dict, os.path.join(save_dir, "adapter_model.bin"))
-    adapter_config = {
-        "peft_type": "LORA",
-        "r": int(rank),
-        "lora_alpha": float(lora_alpha),
-        "target_modules": ["gate_proj", "up_proj", "down_proj"],
-        "bias": "none",
-        "task_type": "CAUSAL_LM",
-        "use_rslora": False,
-    }
-    with open(os.path.join(save_dir, "adapter_config.json"), "w") as f:
-        json.dump(adapter_config, f)
-
-
-@skip_gpu_memory_less_than_80gb
-@pytest.mark.parametrize("moe_lora_mode", [
-    "host_path",
-    "device_path_eager",
-    "device_path_cudagraph",
-])
-def test_qwen_moe_routed_expert_multi_lora_varying_ranks(
-        moe_lora_mode: str, monkeypatch) -> None:
-    """Routed-expert MoE LoRA on Qwen1.5-MoE with the PyTorch CUTLASS backend.
-
-    Five dummy adapters of varying rank target the routed experts (moe_h_to_4h,
-    moe_gate, moe_4h_to_h). The same workload runs through each of the three
-    routed-expert LoRA execution paths, selected by moe_lora_mode:
-
-    - host_path: eager, legacy host path (per-request D2H pointer expand).
-    - device_path_eager: eager, capture-safe device path forced on via
-      TLLM_MOE_LORA_USE_DEVICE_PATH (per-request schema, no CUDA graph).
-    - device_path_cudagraph: CUDA graph decode, which always takes the
-      slot-indexed device path; all adapters share one captured graph,
-      exercising the slot-indexed device path and per-slot rank handling.
-
-    Current transformers stores the routed experts as fused 3D parameters, so
-    PEFT cannot produce per-expert adapter weights; the adapters are fabricated
-    directly in the per-expert key layout the TRT-LLM loader expects. An
-    explicit module mapping is supplied because the default map only knows
-    w1/w2/w3 for routed experts. lora_B is non-zero so each adapter perturbs the
-    routed-expert output, letting the test assert the LoRA is actually applied.
-    """
-    # Select the execution path. The eager device path is forced via env var
-    # (read once at FusedMoeRunner construction); the CUDA-graph path always
-    # takes the slot-indexed device path, so it needs no env opt-in.
-    cuda_graph_config = None
-    if moe_lora_mode == "device_path_eager":
-        monkeypatch.setenv("TLLM_MOE_LORA_USE_DEVICE_PATH", "1")
-    elif moe_lora_mode == "device_path_cudagraph":
-        cuda_graph_config = CudaGraphConfig(max_batch_size=10)
-
-    model_dir = f"{llm_models_root()}/Qwen1.5-MoE-A2.7B-Chat"
-
-    # Five adapters with varying ranks; max_lora_rank must cover the largest.
-    ranks = [8, 16, 32, 16, 64]
-    max_rank = max(ranks)
-
-    # HF expert-projection names -> routed-expert TRT-LLM module ids. The
-    # default map only carries w1/w2/w3, so the gate/up/down names need an
-    # explicit entry. (gate_proj->w1->moe_h_to_4h, up_proj->w3->moe_gate,
-    # down_proj->w2->moe_4h_to_h.)
-    target_modules = ["moe_h_to_4h", "moe_gate", "moe_4h_to_h"]
-    trtllm_modules_to_hf_modules = {
-        "moe_h_to_4h": "gate_proj",
-        "moe_gate": "up_proj",
-        "moe_4h_to_h": "down_proj",
-    }
-
-    # Derive expert dims and the set of MoE layers from the model config so the
-    # fabricated adapter matches the served model.
-    with open(f"{model_dir}/config.json") as f:
-        cfg = json.load(f)
-    num_experts = cfg["num_experts"]
-    hidden_size = cfg["hidden_size"]
-    moe_intermediate_size = cfg["moe_intermediate_size"]
-    num_hidden_layers = cfg["num_hidden_layers"]
-    decoder_sparse_step = cfg.get("decoder_sparse_step", 1)
-    mlp_only_layers = cfg.get("mlp_only_layers") or []
-    moe_layers = [
-        layer_idx for layer_idx in range(num_hidden_layers)
-        if layer_idx not in mlp_only_layers and num_experts > 0 and
-        (layer_idx + 1) % decoder_sparse_step == 0
-    ]
-
-    with tempfile.TemporaryDirectory() as lora_dir:
-        lora_paths = []
-        for i, r in enumerate(ranks):
-            lora_path = f"{lora_dir}/lora_{i}"
-            _write_routed_expert_lora_adapter(
-                lora_path,
-                moe_layers=moe_layers,
-                num_experts=num_experts,
-                hidden_size=hidden_size,
-                moe_intermediate_size=moe_intermediate_size,
-                rank=r,
-                lora_alpha=2 * r,
-                seed=1000 + i,
-            )
-            lora_paths.append(lora_path)
-
-        lora_config = LoraConfig(
-            lora_dir=lora_paths,
-            lora_target_modules=target_modules,
-            trtllm_modules_to_hf_modules=trtllm_modules_to_hf_modules,
-            max_lora_rank=max_rank,
-            max_loras=len(ranks),
-            max_cpu_loras=len(ranks),
-        )
-        llm = LLM(model=model_dir,
-                  lora_config=lora_config,
-                  moe_config=MoeConfig(backend="CUTLASS"),
-                  kv_cache_config=global_kvcache_config,
-                  cuda_graph_config=cuda_graph_config)
-        try:
-            sampling_params = SamplingParams(max_tokens=20, temperature=0.0)
-            prompt = "What is your name?"
-
-            base_tokens = list(
-                llm.generate([prompt], sampling_params,
-                             lora_request=None)[0].outputs[0].token_ids)
-
-            lora_requests = [
-                LoRARequest(f"moe-lora-{i}", i, path)
-                for i, path in enumerate(lora_paths)
-            ]
-
-            # One batch mixes a no-LoRA (rank-0) request with every adapter so
-            # the rank-0 skip path and all adapters run through a single
-            # (captured, when enabled) decode graph.
-            requests = [None] + lora_requests
-            outputs = llm.generate([prompt] * len(requests),
-                                   sampling_params,
-                                   lora_request=requests)
-            out_tokens = [list(o.outputs[0].token_ids) for o in outputs]
-
-            # The no-LoRA row (index 0) must run (rank-0 skip path) and produce
-            # output.
-            assert out_tokens[0], (
-                "No-LoRA row in the mixed batch produced no tokens.")
-            # Every adapter -- not just one -- must change the output vs base.
-            for i in range(len(lora_requests)):
-                assert out_tokens[i + 1] != base_tokens, (
-                    f"Routed-expert MoE LoRA adapter {i} produced output "
-                    "identical to the base model; it was not applied.")
-        finally:
-            llm.shutdown()
-
-
 class TestLlmError:
 
     @pytest.mark.part3
     def test_max_num_token_check(self):
-        """ LLM should raise error when got prompt length exceed the valid range. """
+        """LLM should raise error when got prompt length exceed the valid range."""
         llm = LLM(llama_model_path,
                   kv_cache_config=global_kvcache_config,
                   max_num_tokens=100)
@@ -1587,7 +1395,7 @@ class TestLlmError:
 
     @pytest.mark.part3
     def test_max_num_token_check(self):
-        """ LLM should raise error when got prompt length exceed the valid range. """
+        """LLM should raise error when got prompt length exceed the valid range."""
         llm = LLM(llama_model_path,
                   kv_cache_config=global_kvcache_config,
                   max_num_tokens=100)
@@ -1641,7 +1449,6 @@ async def test_llm_rpc_streaming():
 @skip_ray
 def test_llm_rpc_get_stats():
     """Test that get_stats works with RPC orchestrator."""
-
     with LLM(model=llama_model_path,
              kv_cache_config=global_kvcache_config,
              enable_iter_perf_stats=True,


### PR DESCRIPTION
## Description

This MR does the following in context of supporting MoE lora:
1) Validates fp8 qdq support for MoE base weights and relaxes corresponding constraints.
2) Move tests that were previously under unit_tests to integration tests as they involved loading full model weights.

## Test Coverage

```
$ pytest -v tests/integration/defs/llmapi/test_llm_api_pytorch_moe_lora.py
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded MoE LoRA support to cover more quantized model setups, including per-tensor FP8.
  * Enabled LoRA support in Mixtral model execution paths.
  * Added broader validation and end-to-end coverage for routed-expert LoRA with varying adapter ranks.

* **Bug Fixes**
  * Tightened checks to reject unsupported quantization formats for MoE LoRA, improving error handling and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->