### PR TITLE
[None][CI] Waive flaky test_vbench_dimension_score_wan (nvbugs/6357628)

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -157,6 +157,7 @@ examples/test_whisper.py::test_llm_whisper_general[large-v3-disable_gemm_plugin-
 examples/visual_gen/test_visual_gen.py::test_flux1_lpips_against_golden SKIP (https://nvbugs/6215688)
 examples/visual_gen/test_visual_gen.py::test_flux2_lpips_against_golden SKIP (https://nvbugs/6215688)
 examples/visual_gen/test_visual_gen.py::test_ltx2_lpips_against_golden SKIP (https://nvbugs/6215688)
+examples/visual_gen/test_visual_gen.py::test_vbench_dimension_score_wan SKIP (https://nvbugs/6357628)
 examples/visual_gen/test_visual_gen.py::test_vbench_dimension_score_wan22_a14b_fp8 SKIP (https://nvbugs/6310230)
 examples/visual_gen/test_visual_gen.py::test_vbench_dimension_score_wan22_a14b_nvfp4 SKIP (https://nvbugs/6310230)
 examples/visual_gen/test_visual_gen.py::test_wan21_t2v_lpips_against_golden SKIP (https://nvbugs/6215688)


### PR DESCRIPTION
## What
Waive the flaky test `examples/visual_gen/test_visual_gen.py::test_vbench_dimension_score_wan` (SKIP), tracked by **nvbugs/6357628**.

## Why
The test is **flaky by design**: it generates a video with a non-deterministic seed (`VisualGenParams.seed` defaults to `None`) and compares *absolute* per-dimension VBench scores against a single fixed-seed HF-reference golden with a uniform 0.05 band. Several dimensions vary far more than 0.05 across seeds — `dynamic_degree` is effectively binary (0/1), and `aesthetic_quality`/`imaging_quality` swing 0.15–0.25.

Reproduced on `upstream/main` HEAD (B200, exact CI config: 4 GPU, `cfg_size=2`, `ulysses_size=1`, full 6-dimension VBench), three identical-config runs → **FAIL / PASS / FAIL**, each failing on a *different* dimension. Single-GPU and 2-GPU both pass at a fixed seed, so this is **not a code regression** (suspect commits #13978 / #14961 / #14687 ruled out).

This mirrors the already-waived sibling tests `test_vbench_dimension_score_wan22_a14b_fp8` / `_nvfp4` (nvbugs/6310230).

## Recommended real fix (for visual_gen owners @NVIDIA/trt-llm-torch-visual-gen-devs)
Pin a fixed generation seed (verified deterministic), re-baseline all 6 goldens from pinned-seed runs, and special-case the binary `dynamic_degree` (exact match, not a 0.05 band). Tracked in nvbugs/6357628.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test skip entry for a known issue in visual generation testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->