### PR TITLE
[None][feat] Qwen-Image: NVFP4 SVDQuant (NVFP4 residual + rank-r BF16 LoRA)

### DIFF
--- a/docs/source/models/visual-generation.md
+++ b/docs/source/models/visual-generation.md
@@ -55,7 +55,7 @@ Models are auto-detected from the checkpoint directory. Diffusers-format models 
 
 [^1]: FLUX models use embedded guidance and do not have a separate negative prompt path, so CFG parallelism is not applicable.
 
-[^2]: Qwen-Image ships a native BF16 implementation with per-module numerical parity vs `diffusers.QwenImagePipeline` (cosine >= 0.999 on the full 20B transformer) and `trtllm-serve` / `/v1/images/generations` support. FP8 blockwise and NVFP4 work both as VisualGen dynamic quantization from a BF16 checkpoint (no pre-quantized checkpoint required) and by loading a pre-quantized ModelOpt checkpoint (static scales, with the checkpoint's `quantization_config` `ignore` list keeping the embedders, output projection, and first/last transformer blocks in high precision). 
+[^2]: Qwen-Image ships a native BF16 implementation with per-module numerical parity vs `diffusers.QwenImagePipeline` (cosine >= 0.999 on the full 20B transformer) and `trtllm-serve` / `/v1/images/generations` support. FP8 blockwise and NVFP4 work both as VisualGen dynamic quantization from a BF16 checkpoint (no pre-quantized checkpoint required) and by loading a pre-quantized ModelOpt checkpoint (static scales, with the checkpoint's `quantization_config` `ignore` list keeping the embedders, output projection, and first/last transformer blocks in high precision). ModelOpt **NVFP4 SVDQuant** checkpoints (`quant_algo` `NVFP4_SVD`: an NVFP4 residual plus a per-input-channel `pre_quant_scale` and a rank-r BF16 LoRA correction) are also supported. 
 
 ## Quick Start
 

--- a/docs/source/models/visual-generation.md
+++ b/docs/source/models/visual-generation.md
@@ -55,7 +55,7 @@ Models are auto-detected from the checkpoint directory. Diffusers-format models 
 
 [^1]: FLUX models use embedded guidance and do not have a separate negative prompt path, so CFG parallelism is not applicable.
 
-[^2]: Qwen-Image ships a native BF16 implementation with per-module numerical parity vs `diffusers.QwenImagePipeline` (cosine >= 0.999 on the full 20B transformer) and `trtllm-serve` / `/v1/images/generations` support. FP8 blockwise and NVFP4 use VisualGen dynamic quantization from BF16 checkpoints; no pre-quantized checkpoint is required. 
+[^2]: Qwen-Image ships a native BF16 implementation with per-module numerical parity vs `diffusers.QwenImagePipeline` (cosine >= 0.999 on the full 20B transformer) and `trtllm-serve` / `/v1/images/generations` support. FP8 blockwise and NVFP4 work both as VisualGen dynamic quantization from a BF16 checkpoint (no pre-quantized checkpoint required) and by loading a pre-quantized ModelOpt checkpoint (static scales, with the checkpoint's `quantization_config` `ignore` list keeping the embedders, output projection, and first/last transformer blocks in high precision). 
 
 ## Quick Start
 

--- a/examples/visual_gen/README.md
+++ b/examples/visual_gen/README.md
@@ -21,6 +21,7 @@ python models/wan_t2v.py
 python models/ltx2.py
 python models/flux1.py
 python models/flux2.py
+python models/qwen_image.py
 
 # With engine config (quant, parallelism, etc.)
 python models/wan_t2v.py --visual_gen_args configs/wan2.2-t2v-fp4-1gpu.yaml
@@ -28,6 +29,10 @@ python models/wan_i2v.py --visual_gen_args configs/wan2.2-i2v-fp4-1gpu.yaml --im
 python models/ltx2.py --visual_gen_args configs/ltx2-t2v-fp8-1-gpu.yaml
 python models/flux1.py --visual_gen_args configs/flux1-dev-fp4-1gpu.yaml
 python models/flux2.py --visual_gen_args configs/flux2-dev-fp4-1gpu.yaml
+
+# Qwen-Image NVFP4: point --model at a ModelOpt-quantized checkpoint; the NVFP4
+# config is read from the checkpoint. (Use a BF16 checkpoint for the baseline.)
+python models/qwen_image.py --model <qwen-image-nvfp4> --visual_gen_args configs/qwen-image-fp4-1gpu.yaml
 ```
 
 Install deps from the repo root: `pip install -r requirements-dev.txt`.

--- a/examples/visual_gen/configs/qwen-image-bf16-1gpu.yaml
+++ b/examples/visual_gen/configs/qwen-image-bf16-1gpu.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 1-GPU Qwen-Image BF16 reference (no quantization). Use with the BF16 base
+# model (Qwen/Qwen-Image) as a quality/latency baseline for the NVFP4 config.
+attention_config:
+  backend: VANILLA
+parallel_config:
+  cfg_size: 1
+  ulysses_size: 1
+cuda_graph_config:
+  enable: false

--- a/examples/visual_gen/configs/qwen-image-fp4-1gpu.yaml
+++ b/examples/visual_gen/configs/qwen-image-fp4-1gpu.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 1-GPU Qwen-Image with NVFP4. Shared by offline examples (--visual_gen_args)
+# and trtllm-serve.
+#
+# Point --model at a ModelOpt-quantized Qwen-Image NVFP4 checkpoint. The NVFP4
+# settings (algo, group size, and the per-block "ignore" list that keeps the
+# first/last transformer blocks and the embedders/projection in high precision)
+# are read from the checkpoint's transformer/config.json, so no quant_config is
+# needed here.
+#
+# To instead dynamically quantize the BF16 base model (Qwen/Qwen-Image) to
+# NVFP4 at load time, add:
+#   quant_config:
+#     quant_algo: NVFP4
+#     dynamic: true
+attention_config:
+  backend: VANILLA
+parallel_config:
+  cfg_size: 1
+  ulysses_size: 1
+cuda_graph_config:
+  enable: false

--- a/examples/visual_gen/configs/qwen-image-svdquant-1gpu.yaml
+++ b/examples/visual_gen/configs/qwen-image-svdquant-1gpu.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# 1-GPU Qwen-Image with NVFP4 SVDQuant (NVFP4 residual + rank-r BF16 LoRA).
+#
+# Point --model at a ModelOpt-quantized Qwen-Image SVDQuant checkpoint
+# (quant_algo NVFP4_SVD). The quantization (NVFP4 residual, per-input-channel
+# pre_quant_scale smoothing, and the low-rank LoRA factors) is read from the
+# checkpoint's transformer/config.json + weights, so no quant_config is needed
+# here. The same per-block "ignore" list as plain NVFP4 keeps the embedders,
+# output projection, and first/last transformer blocks in high precision.
+attention_config:
+  backend: VANILLA
+parallel_config:
+  cfg_size: 1
+  ulysses_size: 1
+cuda_graph_config:
+  enable: false

--- a/examples/visual_gen/models/qwen_image.py
+++ b/examples/visual_gen/models/qwen_image.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Qwen-Image text-to-image generation.
+
+Usage:
+    # BF16 reference (HF Hub id or local diffusers checkpoint)
+    python qwen_image.py --model Qwen/Qwen-Image
+
+    # NVFP4 (ModelOpt pre-quantized checkpoint; quantization is read from the
+    # checkpoint's transformer/config.json)
+    python qwen_image.py --model <qwen-image-nvfp4> \
+        --visual_gen_args ../configs/qwen-image-fp4-1gpu.yaml
+"""
+
+import argparse
+from pathlib import Path
+
+from tensorrt_llm import VisualGen, VisualGenArgs
+
+
+def _output_paths(output_path: str, num_images: int) -> str | list[str]:
+    if num_images == 1:
+        return output_path
+
+    path = Path(output_path)
+    return [str(path.with_name(f"{path.stem}_{idx + 1}{path.suffix}")) for idx in range(num_images)]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Qwen-Image Text-to-Image example")
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="Qwen/Qwen-Image",
+        help="Model path or HuggingFace Hub ID (BF16 base or a ModelOpt-quantized checkpoint)",
+    )
+    parser.add_argument(
+        "--visual_gen_args",
+        dest="visual_gen_args",
+        type=str,
+        default=None,
+        help="Path to YAML config (same as trtllm-serve --visual_gen_args)",
+    )
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        default=(
+            "A coffee shop entrance features a chalkboard sign reading "
+            '"Qwen Coffee, $2 per cup," with a neon light beside it displaying '
+            "a steaming coffee cup, photorealistic, highly detailed"),
+        help="Text prompt for image generation",
+    )
+    parser.add_argument(
+        "--num_images_per_prompt",
+        type=int,
+        default=1,
+        help="Number of images to generate for the prompt",
+    )
+    parser.add_argument(
+        "--output_path",
+        type=str,
+        default="qwen_image_output.png",
+        help="Path to save the output image. For multiple images, an index is appended.",
+    )
+    args = parser.parse_args()
+    if args.num_images_per_prompt < 1:
+        raise ValueError("--num_images_per_prompt must be >= 1")
+
+    # Engine config from shared YAML (optional); model-specific defaults apply otherwise.
+    extra_args = VisualGenArgs.from_yaml(args.visual_gen_args) if args.visual_gen_args else None
+    visual_gen = VisualGen(model=args.model, args=extra_args)
+
+    # --- Model-specific: T2I request construction ---
+    # Start from per-model defaults (resolution, steps, guidance, seed, etc.) and set image count.
+    params = visual_gen.default_params
+    params.num_images_per_prompt = args.num_images_per_prompt
+
+    output = visual_gen.generate(inputs=args.prompt, params=params)
+
+    saved = output.save(_output_paths(args.output_path, args.num_images_per_prompt))
+    print(f"Saved: {saved}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tensorrt_llm/_torch/visual_gen/config.py
+++ b/tensorrt_llm/_torch/visual_gen/config.py
@@ -273,6 +273,10 @@ class DiffusionPipelineConfig(_VisualGenConfigBase):
                 "FP8": QuantAlgo.FP8,
                 "FP8_BLOCK_SCALES": QuantAlgo.FP8_BLOCK_SCALES,
                 "NVFP4": QuantAlgo.NVFP4,
+                # SVDQuant: the NVFP4 residual loads on the standard NVFP4 path;
+                # the rank-r BF16 LoRA correction + pre_quant_scale are handled
+                # by the model's NVFP4SVDLinearMethod (detected from the ckpt).
+                "NVFP4_SVD": QuantAlgo.NVFP4,
                 "W4A16_AWQ": QuantAlgo.W4A16_AWQ,
                 "W4A8_AWQ": QuantAlgo.W4A8_AWQ,
                 "W8A8_SQ_PER_CHANNEL": QuantAlgo.W8A8_SQ_PER_CHANNEL,

--- a/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
+++ b/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
@@ -25,7 +25,7 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-from tensorrt_llm._torch.modules.linear import Linear
+from tensorrt_llm._torch.modules.linear import Linear, NVFP4LinearMethod
 from tensorrt_llm._torch.modules.mlp import MLP
 from tensorrt_llm._torch.modules.rms_norm import RMSNorm
 from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig
@@ -50,6 +50,71 @@ _QUANT_DERIVED_PARAM_SUFFIXES = (
     ".kv_scales",
     ".inv_kv_scales",
 )
+
+# SVDQuant (NVFP4_SVD) checkpoints carry, per quantized Linear, three tensors on
+# top of the NVFP4 residual: a per-input-channel smoothing scale and the two
+# low-rank LoRA factors. They are consumed by NVFP4SVDLinearMethod, not by the
+# module's named parameters, so they are excluded from the strict key check.
+_SVDQUANT_PROVIDED_SUFFIXES = (
+    ".pre_quant_scale",
+    ".svdquant_lora_a",
+    ".svdquant_lora_b",
+)
+
+
+class NVFP4SVDLinearMethod(NVFP4LinearMethod):
+    """SVDQuant: NVFP4 residual GEMM + rank-r BF16 LoRA correction.
+
+    ModelOpt SVDQuant factorizes ``W ≈ R + L1·L2`` with per-input-channel
+    activation smoothing ``s`` (``pre_quant_scale``). With ``X̂ = X · s``, the
+    smoothed-space residual ``R`` (NVFP4) and low-rank term give::
+
+        Y = nvfp4_gemm(quant(X̂), R) · scales + (X̂ @ L2ᵀ) @ L1ᵀ  [+ bias]
+
+    where ``svdquant_lora_a`` = L2 ``[r, in]`` and ``svdquant_lora_b`` = L1
+    ``[out, r]``. The NVFP4 residual reuses the base method; this subclass adds
+    the smoothing + LoRA correction. Functional path (BF16 matmuls for the
+    LoRA); the fused FlashInfer SVDQuant kernel is a separate perf optimization.
+    """
+
+    def create_weights(self, module, in_features, out_features, bias, dtype):
+        super().create_weights(module, in_features, out_features, bias, dtype)
+        # Materialized lazily in load_weights_vanilla (rank comes from the ckpt).
+        module.svdquant_lora_a = None
+        module.svdquant_lora_b = None
+
+    def load_weights_vanilla(self, module, weights, allow_partial_loading: bool = False) -> None:
+        super().load_weights_vanilla(module, weights, allow_partial_loading)
+        w = weights[0]
+        device = module.weight.device
+        # pre_quant_scale ([in_features]) may already be loaded by the base NVFP4
+        # method on newer releases; load it here too for robustness.
+        if getattr(module, "pre_quant_scale", None) is None and "pre_quant_scale" in w:
+            module.pre_quant_scale = nn.Parameter(
+                w["pre_quant_scale"].to(device), requires_grad=False)
+        if "svdquant_lora_a" in w:
+            module.svdquant_lora_a = nn.Parameter(
+                w["svdquant_lora_a"].to(device), requires_grad=False)
+            module.svdquant_lora_b = nn.Parameter(
+                w["svdquant_lora_b"].to(device), requires_grad=False)
+
+    def apply(self, module, input, bias):
+        pqs = getattr(module, "pre_quant_scale", None)
+        x_hat = input * pqs if pqs is not None else input
+        # Residual NVFP4 GEMM on the already-smoothed activation; clear
+        # pre_quant_scale so the base method does not smooth a second time.
+        saved = getattr(module, "pre_quant_scale", None)
+        module.pre_quant_scale = None
+        try:
+            out = super().apply(module, x_hat, bias)
+        finally:
+            module.pre_quant_scale = saved
+        a = getattr(module, "svdquant_lora_a", None)
+        b = getattr(module, "svdquant_lora_b", None)
+        if a is not None and b is not None:
+            lora = torch.matmul(torch.matmul(x_hat, a.t()), b.t())
+            out = out + lora.to(out.dtype)
+        return out
 
 
 def _remap_checkpoint_keys(weights: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
@@ -931,13 +996,28 @@ class QwenImageTransformer2DModel(BaseDiffusionModel):
         # statically pre-quantized ModelOpt checkpoint passes the key check.
         missing = sorted(k for k in (expected - provided)
                          if not k.endswith(_QUANT_DERIVED_PARAM_SUFFIXES))
-        unexpected = sorted(provided - expected)
+        # SVDQuant LoRA factors + pre_quant_scale are loaded by the quant method
+        # (not module params at this point), so they are not "unexpected".
+        unexpected = sorted(k for k in (provided - expected)
+                            if not k.endswith(_SVDQUANT_PROVIDED_SUFFIXES))
         # Dynamic quantization creates scale parameters while loading Linear
         # modules, so those keys are expected to be absent from BF16 checkpoints.
         if missing and not self.model_config.dynamic_weight_quant:
             raise RuntimeError(f"Missing keys when loading transformer: {missing[:5]}...")
         if unexpected:
             raise RuntimeError(f"Unexpected keys when loading transformer: {unexpected[:5]}...")
+
+        # SVDQuant: the residual loaded above is plain NVFP4; swap in the method
+        # that also loads + applies the rank-r BF16 LoRA correction. Detected by
+        # the presence of LoRA factors in the checkpoint (config maps
+        # NVFP4_SVD -> NVFP4 so the residual uses the NVFP4 path).
+        if any(k.endswith(".svdquant_lora_a") for k in provided):
+            for _, module in self.named_modules():
+                if (isinstance(module, Linear) and module.quant_config is not None
+                        and module.quant_config.quant_algo is not None):
+                    module.quant_method = NVFP4SVDLinearMethod()
+                    module.svdquant_lora_a = None
+                    module.svdquant_lora_b = None
 
         loader = DynamicLinearWeightLoader(self.model_config)
         for name, module in self.named_modules():

--- a/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
+++ b/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
@@ -38,6 +38,19 @@ _WEIGHT_KEY_REMAPS = [
     (".net.2.", ".down_proj."),
 ]
 
+# Helper buffers that FP8/NVFP4 ``Linear.create_weights()`` registers but that
+# are derived from the stored scales at load time (``alpha`` and
+# ``inv_input_scale``) or default to ones (the NVFP4 KV-cache scales). They are
+# never serialized in a ModelOpt checkpoint, so they must be excluded from the
+# strict key check when loading a statically pre-quantized checkpoint
+# (``dynamic_weight_quant=False``).
+_QUANT_DERIVED_PARAM_SUFFIXES = (
+    ".alpha",
+    ".inv_input_scale",
+    ".kv_scales",
+    ".inv_kv_scales",
+)
+
 
 def _remap_checkpoint_keys(weights: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
     remapped = {}
@@ -873,6 +886,27 @@ class QwenImageTransformer2DModel(BaseDiffusionModel):
                     buffer.data = buffer.data.to(target_dtype)
         return self
 
+    def _clear_quant_config_on_excluded_layers(self) -> None:
+        """Build the checkpoint's excluded layers as unquantized.
+
+        ModelOpt keeps some layers in high precision (the ``ignore`` list in
+        the checkpoint's ``quantization_config`` -- e.g. img_in / txt_in /
+        proj_out / norm_out / time_text_embed and the first/last transformer
+        blocks), storing plain BF16 weights with no scales for them.
+        ``get_quant_method()`` selects the Linear method purely from
+        ``module.quant_config``, so clear it on the excluded Linear modules to
+        fall back to the unquantized method. Must run before any
+        ``create_weights()`` call, since parent modules (e.g. ``MLP``) may
+        materialize their child Linears eagerly.
+        """
+        quant_config = self.model_config.quant_config
+        if quant_config is None or quant_config.quant_algo is None:
+            return
+        for name, module in self.named_modules():
+            if (isinstance(module, Linear)
+                    and quant_config.is_module_excluded_from_quantization(name)):
+                module.quant_config = None
+
     def load_weights(self, weights: Dict[str, torch.Tensor]) -> None:
         """Load HF ``transformer/*.safetensors`` state_dict.
 
@@ -882,6 +916,9 @@ class QwenImageTransformer2DModel(BaseDiffusionModel):
         weights = _remap_checkpoint_keys(weights)
 
         device = self._weight_loading_device()
+        # Build excluded layers (the checkpoint's quantization ``ignore`` list)
+        # as unquantized, before any create_weights() call.
+        self._clear_quant_config_on_excluded_layers()
         for _, module in self.named_modules():
             if callable(getattr(module, "create_weights", None)):
                 module.create_weights()
@@ -889,7 +926,11 @@ class QwenImageTransformer2DModel(BaseDiffusionModel):
 
         expected = {name for name, _ in self.named_parameters()}
         provided = set(weights)
-        missing = sorted(expected - provided)
+        # FP8/NVFP4 Linear.create_weights() registers helper buffers that are
+        # derived at load time and never stored in a checkpoint; drop them so a
+        # statically pre-quantized ModelOpt checkpoint passes the key check.
+        missing = sorted(k for k in (expected - provided)
+                         if not k.endswith(_QUANT_DERIVED_PARAM_SUFFIXES))
         unexpected = sorted(provided - expected)
         # Dynamic quantization creates scale parameters while loading Linear
         # modules, so those keys are expected to be absent from BF16 checkpoints.

--- a/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
+++ b/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
@@ -26,6 +26,7 @@ import torch.nn.functional as F
 from torch import nn
 
 from tensorrt_llm._torch.modules.linear import Linear, NVFP4LinearMethod
+from tensorrt_llm.logger import logger
 from tensorrt_llm._torch.modules.mlp import MLP
 from tensorrt_llm._torch.modules.rms_norm import RMSNorm
 from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig
@@ -98,7 +99,19 @@ class NVFP4SVDLinearMethod(NVFP4LinearMethod):
             module.svdquant_lora_b = nn.Parameter(
                 w["svdquant_lora_b"].to(device), requires_grad=False)
 
+    # Minimum padded token count for the fused kernel; below this the per-call launch
+    # overhead dominates, so the eager path is used instead.
+    _FUSED_MIN_M = 128
+
     def apply(self, module, input, bias):
+        # Fast path: FlashInfer's fused SVDQuant kernel computes the NVFP4 residual and the
+        # LoRA up-projection in a single GEMM. It returns None (falling through to the eager
+        # path below) whenever the kernel is unavailable or the shape is unsupported, so this
+        # method is correct with or without the fused kernel present.
+        fused = self._svd_try_fused(module, input, bias)
+        if fused is not None:
+            return fused
+
         pqs = getattr(module, "pre_quant_scale", None)
         x_hat = input * pqs if pqs is not None else input
         # Residual NVFP4 GEMM on the already-smoothed activation; clear
@@ -115,6 +128,108 @@ class NVFP4SVDLinearMethod(NVFP4LinearMethod):
             lora = torch.matmul(torch.matmul(x_hat, a.t()), b.t())
             out = out + lora.to(out.dtype)
         return out
+
+    def _svd_try_fused(
+        self, module, input: torch.Tensor, bias: Optional[torch.Tensor]
+    ) -> Optional[torch.Tensor]:
+        """Run the linear via FlashInfer's fused SVDQuant kernel; return None to fall back.
+
+        Computes ``Y = dequant(nvfp4(X̂) @ nvfp4(R)ᵀ)·α + (X̂ @ L2ᵀ) @ L1ᵀ`` in one GEMM.
+        The activation is quantized with the same TRT-LLM NVFP4 quantizer the residual path
+        uses and injected into the kernel, so the fused result matches eager closely.
+        """
+        if getattr(module, "svdquant_lora_a", None) is None:
+            return None
+        try:
+            from flashinfer.gemm import mm_fp4_svdquant, prepare_svdquant_state
+        except ImportError:
+            return None  # fused SVDQuant kernel unavailable -> eager fallback
+        try:
+            orig_shape = input.shape if input.dim() > 2 else None
+            x2d = input.reshape(-1, input.shape[-1]) if orig_shape is not None else input
+            m = int(x2d.shape[0])
+            if m < self._FUSED_MIN_M:
+                return None
+            in_features = int(module.weight.shape[1]) * 2
+            if x2d.shape[1] != in_features:
+                x2d = F.pad(x2d, (0, in_features - x2d.shape[1]))
+            # Pad M to a multiple of 128: misaligned M is data-dependently inaccurate for both
+            # the block-scaled GEMM and the activation scale-factor injection. The pad rows are
+            # computed then sliced off.
+            m_pad = ((m + 127) // 128) * 128
+            xp = F.pad(x2d, (0, 0, 0, m_pad - m)) if m_pad != m else x2d
+            state = self._svd_fused_state(module, m_pad, prepare_svdquant_state)
+            if state is None:
+                return None
+            pqs = getattr(module, "pre_quant_scale", None)
+            if pqs is not None:
+                p = pqs.reshape(-1)
+                if p.numel() != in_features:
+                    p = F.pad(p, (0, in_features - p.numel()), value=1.0)
+                x_hat = xp * p
+            else:
+                x_hat = xp
+            ext_xq, ext_sf = torch.ops.trtllm.fp4_quantize(
+                x_hat, module.input_scale, 16, False
+            )
+            y = mm_fp4_svdquant(xp, state, ext_xq=ext_xq, ext_sf=ext_sf)
+            y = y[:m, : module.out_features]
+            if orig_shape is not None:
+                y = y.reshape(*orig_shape[:-1], module.out_features)
+            return (y + bias) if bias is not None else y
+        except Exception as e:
+            # Any unsupported shape / runtime issue -> eager fallback (correctness preserved).
+            logger.debug(f"SVDQuant fused path unavailable, using eager: {e!r}")
+            return None
+
+    def _svd_fused_state(self, module, m_pad: int, prepare_svdquant_state):
+        """Build (and cache per padded-M) the fused-kernel state from the module's NVFP4 SVD
+        tensors: residual weight, the NVFP4-MMA-swizzled weight scale factors, LoRA L1/L2,
+        the global scales, and pre_quant_scale."""
+        cache = getattr(module, "_svd_fused_state_cache", None)
+        if cache is None:
+            cache = {}
+            module._svd_fused_state_cache = cache
+        if m_pad in cache:
+            return cache[m_pad]
+        from tensorrt_llm._torch.utils import swizzle_sf, unswizzle_sf
+
+        def _pad_up(x: int, mult: int) -> int:
+            return ((x + mult - 1) // mult) * mult
+
+        rq = module.weight.detach().view(torch.uint8).contiguous()
+        out_features, in_half = int(rq.shape[0]), int(rq.shape[1])
+        in_features = in_half * 2
+        sf_k = in_features // 16
+        ws = module.weight_scale.detach().view(torch.uint8)
+        sf_w = unswizzle_sf(
+            ws, _pad_up(out_features, 128), _pad_up(sf_k, 4) * 16, 16
+        )[:out_features, :sf_k].contiguous()
+        # The fused kernel consumes the weight SF in the NVFP4-MMA swizzle (read as a raw ptr).
+        sf_w = swizzle_sf(sf_w.contiguous().view(torch.uint8), out_features, in_features, 16)
+
+        l2 = module.svdquant_lora_a.detach().to(torch.bfloat16)  # [r, in]
+        l1 = module.svdquant_lora_b.detach().to(torch.bfloat16)  # [out, r]
+        r = int(l2.shape[0])
+        if l2.shape[1] != in_features:
+            l2 = F.pad(l2, (0, in_features - l2.shape[1]))
+        if l1.shape[0] != out_features:
+            l1 = F.pad(l1, (0, 0, 0, out_features - l1.shape[0]))
+
+        gscale_x = float((1.0 / module.input_scale.detach().float()).item())
+        gscale_w = float(module.weight_scale_2.detach().float().item())
+        pqs = getattr(module, "pre_quant_scale", None)
+        if pqs is not None:
+            pqs = pqs.detach().reshape(-1)
+            if pqs.numel() != in_features:
+                pqs = F.pad(pqs, (0, in_features - pqs.numel()), value=1.0)
+
+        state = prepare_svdquant_state(
+            m_pad, rq, sf_w, l1, l2, gscale_x, gscale_w, r,
+            pre_quant_scale=pqs, external_quant=True,
+        )
+        cache[m_pad] = state
+        return state
 
 
 def _remap_checkpoint_keys(weights: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:

--- a/tests/unittest/_torch/visual_gen/test_qwen_image_registry.py
+++ b/tests/unittest/_torch/visual_gen/test_qwen_image_registry.py
@@ -65,6 +65,49 @@ def test_transformer_load_weights_detects_mismatch():
         model.load_weights({})
 
 
+def test_static_quant_excludes_high_precision_layers():
+    """Layers in the checkpoint's ``ignore`` list build as unquantized.
+
+    A statically pre-quantized ModelOpt NVFP4 checkpoint stores the excluded
+    layers (embedders, output projection, first/last transformer blocks) in
+    BF16 with no scales, so they must fall back to the unquantized Linear
+    method while the rest stay NVFP4.
+    """
+    from tensorrt_llm.models.modeling_utils import QuantConfig
+    from tensorrt_llm.quantization.mode import QuantAlgo
+
+    quant_config = QuantConfig(
+        quant_algo=QuantAlgo.NVFP4,
+        group_size=16,
+        exclude_modules=[
+            "img_in",
+            "txt_in",
+            "proj_out",
+            "norm_out*",
+            "transformer_blocks.0*",
+            "transformer_blocks.1.*",
+        ],
+    )
+    model_config = DiffusionModelConfig(
+        quant_config=quant_config,
+        skip_create_weights_in_init=True,
+    )
+    model = QwenImageTransformer2DModel(model_config=model_config, num_layers=4)
+    model._clear_quant_config_on_excluded_layers()
+
+    # Excluded -> quant_config cleared (unquantized Linear method).
+    assert model.img_in.quant_config is None
+    assert model.txt_in.quant_config is None
+    assert model.proj_out.quant_config is None
+    assert model.norm_out.linear.quant_config is None
+    assert model.transformer_blocks[0].attn.to_q.quant_config is None
+    assert model.transformer_blocks[1].img_mlp.up_proj.quant_config is None
+    # Quantized blocks keep NVFP4.
+    keep = model.transformer_blocks[2].attn.to_q.quant_config
+    assert keep is not None and keep.quant_algo == QuantAlgo.NVFP4
+    assert model.transformer_blocks[3].img_mlp.down_proj.quant_config is not None
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 @pytest.mark.parametrize("with_text_mask", [False, True])
 def test_transformer_forward_sanity(with_text_mask):


### PR DESCRIPTION
### What does this PR do?

Type of change: New feature

Adds **NVFP4 SVDQuant** support for **Qwen-Image** in VisualGen: running from a
ModelOpt SVDQuant checkpoint (`quant_algo: NVFP4_SVD`), where each quantized
linear is `W ≈ R + L1·L2` — an **NVFP4 residual** `R` plus a per-input-channel
`pre_quant_scale` smoothing and a **rank-r BF16 LoRA** correction
(`svdquant_lora_a` = L2 `[r,in]`, `svdquant_lora_b` = L1 `[out,r]`).

> **Stacked on #15470** (NVFP4 static-checkpoint loading). The first commit is
> that PR; review commit `54507bf` for the SVDQuant-only diff, and merge #15470
> first. The SVDQuant residual reuses the NVFP4 static-load path, the exclude
> handling, and the relaxed key check from #15470.

**Changes (the SVDQuant commit):**
- `NVFP4SVDLinearMethod` (`transformer_qwen_image.py`): `Y = nvfp4_gemm(quant(X̂), R)
  + (X̂ @ L2ᵀ) @ L1ᵀ + bias`, `X̂ = X·pre_quant_scale`. Subclasses the NVFP4 method
  for the residual; loads `pre_quant_scale` + the two LoRA factors per Linear.
- `load_weights` detects SVDQuant from `svdquant_lora_a` keys, swaps the method
  onto the quantized Linears, and relaxes the key check for the 3 extra tensors.
- `config.py`: `NVFP4_SVD → NVFP4` in `algo_map` so the residual loads on the
  standard static-NVFP4 path. Excluded layers (embedders/proj_out/first+last
  blocks) stay BF16, same as NVFP4.
- New `examples/visual_gen/configs/qwen-image-svdquant-1gpu.yaml`; documented in
  `visual-generation.md`.

This is the **functional** path (BF16 matmuls for the LoRA). A fused FlashInfer
SVDQuant kernel for the residual+LoRA is a follow-up perf optimization.

### Usage
```bash
python examples/visual_gen/models/qwen_image.py --model <qwen-image-svdquant> \
    --visual_gen_args examples/visual_gen/configs/qwen-image-svdquant-1gpu.yaml
```

### Output samples (1328×1328, 50 steps, seed 42, same prompt)

SVDQuant quality is on par with NVFP4 and BF16:

| BF16 | NVFP4 | NVFP4 SVDQuant (this PR) |
|---|---|---|
| <img width="260" src="https://raw.githubusercontent.com/jingyu-ml/TensorRT-LLM/qwen-image-bench-assets/docs/.assets/qwen-image-bench/bf16_1328x1328_50steps.png"> | <img width="260" src="https://raw.githubusercontent.com/jingyu-ml/TensorRT-LLM/qwen-image-bench-assets/docs/.assets/qwen-image-bench/nvfp4_1328x1328_50steps.png"> | <img width="260" src="https://raw.githubusercontent.com/jingyu-ml/TensorRT-LLM/qwen-image-bench-assets/docs/.assets/qwen-image-bench/svdquant_1328x1328_50steps.png"> |

### Testing
On 1× GB200 (sm_100), TRT-LLM release container: the SVDQuant checkpoint loads
(729/729 transformer weights, no key/shape errors) and renders a coherent
1328² image visually on par with BF16/NVFP4 at the same prompt/seed. (The
residual-only output would be visibly degraded without the LoRA, so the clean
result confirms the LoRA term is applied.)

### Before your PR is "Ready for review"
- Backward compatible: ✅ (additive; NVFP4/BF16/dynamic paths unchanged)
- New tests: ⚠️ covered by end-to-end image validation; unit coverage TODO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added NVFP4 SVDQuant support for Qwen-Image with LoRA correction
  * Added Qwen-Image text-to-image generation CLI example
  * Added 1-GPU configuration files for BF16, NVFP4, and SVDQuant setups

* **Documentation**
  * Enhanced Qwen-Image documentation with quantization and loading details
  * Added usage examples for Qwen-Image model configurations

* **Tests**
  * Added quantization exclusion behavior test

<!-- end of auto-generated comment: release notes by coderabbit.ai -->