### PR TITLE
[https://nvbugs/6150288][fix] Use persistent per-stream workspace in cublas_mm for CUDA-graph safety

### DIFF
--- a/cpp/tensorrt_llm/thop/cublasScaledMM.cpp
+++ b/cpp/tensorrt_llm/thop/cublasScaledMM.cpp
@@ -26,6 +26,7 @@
 #include "userbuffersTensor.h"
 #include <cublasLt.h>
 #include <torch/extension.h>
+#include <unordered_map>
 
 using torch::Tensor;
 
@@ -189,10 +190,27 @@ void cublas_gemm_caller(torch::Tensor& out, torch::Tensor const& a, torch::Tenso
     cudaDataType_t scaleType = CUDA_R_32F;
     cublasWrapper->setGemmConfig(aType, bType, outType, /*computeType=*/scaleType);
 
-    auto const workspace_options = torch::TensorOptions().dtype(torch::kUInt8).device(a.device());
-    auto workspace = torch::empty(CUBLAS_WORKSPACE_SIZE, workspace_options);
-
     auto stream = at::cuda::getCurrentCUDAStream(a.get_device());
+
+    // Persistent per-stream cublasLt workspace. The cublasLt kernel records a
+    // fixed pointer to this workspace; if we destruct the workspace storage at
+    // function return (the previous behavior), the CUDA caching allocator may
+    // hand the same block out to a later allocation while a captured CUDA
+    // graph still references the workspace pointer -> use-after-free that
+    // surfaces as free-block-tree corruption on the next allocator operation
+    // (e.g. FusedMoeRunner::getWorkspaceInfo's first torch::empty destructor).
+    //
+    // Keyed by (device, stream) so that concurrent GEMMs on different streams
+    // don't race on the same scratch bytes. Mirrors PyTorch's per-stream
+    // cublasLt workspace cache in at::cuda.
+    thread_local std::unordered_map<cudaStream_t, at::Tensor> workspace_cache;
+    auto stream_ptr = stream.stream();
+    auto& workspace = workspace_cache[stream_ptr];
+    if (!workspace.defined() || workspace.device() != a.device())
+    {
+        auto const workspace_options = torch::TensorOptions().dtype(torch::kUInt8).device(a.device());
+        workspace = torch::empty(CUBLAS_WORKSPACE_SIZE, workspace_options);
+    }
 
     auto* a_ptr = static_cast<void*>(a.data_ptr());
     auto* b_ptr = static_cast<void*>(b.data_ptr());

--- a/cpp/tensorrt_llm/thop/cublasScaledMM.cpp
+++ b/cpp/tensorrt_llm/thop/cublasScaledMM.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (out) 1993-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -159,6 +159,33 @@ bool find_special_algo_deprecated(cublasLtMatmulAlgo_t& algo, std::shared_ptr<Cu
     return true;
 }
 
+// Helper function: Get or create a workspace tensor for the given (device, stream).
+// Workspace is reused across multiple GEMM calls so the pointer captured by the
+// cublasLt kernel remains valid for CUDA-graph capture/replay. Keyed by
+// (device, stream) so concurrent GEMMs on different streams of the same device
+// don't race on the same scratch bytes.
+inline at::Tensor const& getWorkspaceTensor(c10::Device device, cudaStream_t stream)
+{
+    struct KeyHash
+    {
+        std::size_t operator()(std::pair<int, cudaStream_t> const& key) const noexcept
+        {
+            return std::hash<int>()(key.first) ^ (std::hash<cudaStream_t>()(key.second) << 1);
+        }
+    };
+
+    thread_local std::unordered_map<std::pair<int, cudaStream_t>, at::Tensor, KeyHash> workspace_tensors;
+    auto key = std::make_pair(device.index(), stream);
+
+    if (workspace_tensors.find(key) == workspace_tensors.end())
+    {
+        workspace_tensors[key]
+            = torch::empty(CUBLAS_WORKSPACE_SIZE, torch::TensorOptions().dtype(torch::kUInt8).device(device));
+    }
+
+    return workspace_tensors[key];
+}
+
 void cublas_gemm_caller(torch::Tensor& out, torch::Tensor const& a, torch::Tensor const& b,
     std::optional<at::Tensor> const& scale_a, std::optional<at::Tensor> const& scale_b,
     std::optional<at::Tensor> const& bias, bool fast_acc = false)
@@ -191,26 +218,7 @@ void cublas_gemm_caller(torch::Tensor& out, torch::Tensor const& a, torch::Tenso
     cublasWrapper->setGemmConfig(aType, bType, outType, /*computeType=*/scaleType);
 
     auto stream = at::cuda::getCurrentCUDAStream(a.get_device());
-
-    // Persistent per-stream cublasLt workspace. The cublasLt kernel records a
-    // fixed pointer to this workspace; if we destruct the workspace storage at
-    // function return (the previous behavior), the CUDA caching allocator may
-    // hand the same block out to a later allocation while a captured CUDA
-    // graph still references the workspace pointer -> use-after-free that
-    // surfaces as free-block-tree corruption on the next allocator operation
-    // (e.g. FusedMoeRunner::getWorkspaceInfo's first torch::empty destructor).
-    //
-    // Keyed by (device, stream) so that concurrent GEMMs on different streams
-    // don't race on the same scratch bytes. Mirrors PyTorch's per-stream
-    // cublasLt workspace cache in at::cuda.
-    thread_local std::unordered_map<cudaStream_t, at::Tensor> workspace_cache;
-    auto stream_ptr = stream.stream();
-    auto& workspace = workspace_cache[stream_ptr];
-    if (!workspace.defined() || workspace.device() != a.device())
-    {
-        auto const workspace_options = torch::TensorOptions().dtype(torch::kUInt8).device(a.device());
-        workspace = torch::empty(CUBLAS_WORKSPACE_SIZE, workspace_options);
-    }
+    auto const& workspace = getWorkspaceTensor(a.device(), stream.stream());
 
     auto* a_ptr = static_cast<void*>(a.data_ptr());
     auto* b_ptr = static_cast<void*>(b.data_ptr());

--- a/cpp/tensorrt_llm/thop/cublasScaledMM.cpp
+++ b/cpp/tensorrt_llm/thop/cublasScaledMM.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (out) 1993-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory management for CUDA workspace allocation to prevent stale pointer references when using CUDA graphs with allocator caching, improving system stability and runtime performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

`torch.ops.trtllm.cublas_mm` (which Nemotron-H reroutes Linear `apply()` to on SM121 since #13160) calls `cublas_gemm_caller`, which allocated a fresh `torch::empty(CUBLAS_WORKSPACE_SIZE /* 32 MiB */)` workspace on every invocation and let it destruct at function-return. Inside a CUDA-graph capture region the captured cublasLt kernel records a fixed pointer into the workspace storage; freeing the storage back to the CUDA caching allocator while the captured graph still references the pointer is a use-after-free. It surfaces later as free-block-tree corruption on the next allocator operation, manifesting as the `FusedMoeRunner::getWorkspaceInfo` segfault reported on the second generation-only CUDA-graph warmup with mamba-hybrid NVFP4 MoE.

Repro: Nemotron-3-Nano-Omni-30B-A3B-Reasoning-NVFP4 on DGX-Spark with the YAML in the bug. Exposure is Spark-specific because #13160 only enables `use_custom_cublas_mm` when `sm_version() == 121`, but the underlying graph-unsafety is not.

## Fix

Replace the per-call allocation with a per-stream workspace cache, mirroring PyTorch's own per-stream cublasLt workspace cache in `at::cuda`. Keyed by stream so concurrent GEMMs on different streams don't race on the same scratch bytes.

## Validation

Rebuilt rc14 wheel at the first-bad commit `43e3070de4` + the QA repro YAML (CUDA graphs ON, `enable_padding: true`):
- ✅ Crash cleared — `Application startup complete` reached, no `Bus error / Failing at address: 0x1` on aarch64.
- ✅ Three deterministic prompts (temperature=0, greedy decode) produce correct outputs matching the `cuda_graph_config: null` baseline:
  - `"What is the capital of France?"` → `Paris`
  - `"Write the integers from 1 to 10..."` → `1, 2, 3, 4, 5, 6, 7, 8, 9, 10`
  - `"Translate 'Hello, world' to French."` → `Bonjour, monde`
- ✅ Peak GPU memory drops 91.65 GiB (stock rc14, crashed) → 67.58 GiB (patched) — the stock build was effectively leaking ~24 GiB through cached 32 MiB workspace blocks the caching allocator was holding but couldn't reclaim. KV cache budget for this config goes up from 23.06 GiB to 42.33 GiB.

NVBUG: https://nvbugs/6150288

## Test plan

- [x] Crash repro on DGX-Spark cleared with this fix
- [x] Numerical correctness verified vs `cuda_graph_config: null` baseline
- [x] CI / `/bot run`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
