### PR TITLE
[None][fix] Pass dtype to AllReduce ctor to enable MNNVL all-reduce fo…

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_qwen3_next.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3_next.py
@@ -125,7 +125,8 @@ class Qwen3NextSparseMoeBlock(nn.Module):
         self.mapping = model_config.mapping
 
         self.allreduce = AllReduce(mapping=model_config.mapping,
-                                   strategy=model_config.allreduce_strategy)
+                                   strategy=model_config.allreduce_strategy,
+                                   dtype=config.torch_dtype)
 
         self.aux_stream = aux_stream
 
@@ -346,7 +347,8 @@ class Qwen3NextLinearDecoderLayer(DecoderLayer):
         self.layer_idx = layer_idx
 
         self.allreduce = AllReduce(mapping=model_config.mapping,
-                                   strategy=model_config.allreduce_strategy)
+                                   strategy=model_config.allreduce_strategy,
+                                   dtype=config.torch_dtype)
 
         self.next_layer_layernorm: RMSNorm = None
 
@@ -510,7 +512,8 @@ class Qwen3NextFullAttentionDecoderLayer(DecoderLayer):
         self.layer_idx = layer_idx
 
         self.allreduce = AllReduce(mapping=model_config.mapping,
-                                   strategy=model_config.allreduce_strategy)
+                                   strategy=model_config.allreduce_strategy,
+                                   dtype=config.torch_dtype)
 
         self.next_layer_layernorm: RMSNorm = None
 


### PR DESCRIPTION
…r Qwen3.5

On NVL multi-node systems, AllReduce must be given dtype at construction so it can build the MNNVL all-reduce path (its Lamport workspace is sized by the dtype's element size). If dtype is omitted, mnnvl_allreduce is None, so the op falls back to the generic NCCL all-reduce across nodes — functionally correct but lower performance than the NVLink-fabric MNNVL path.
