### PR TITLE
[https://nvbugs/6221351][fix] Guard FlashInfer CUDA graph replay by KV page count

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/flashinfer.py
+++ b/tensorrt_llm/_torch/attention_backend/flashinfer.py
@@ -612,6 +612,12 @@ class FlashInferAttentionMetadata(AttentionMetadata):
         metadata.__post_init__()
         return metadata
 
+    def cuda_graph_replay_signature(self):
+        num_blocks = getattr(self, "num_blocks", None)
+        if num_blocks is None:
+            return None
+        return tuple(int(num_block) for num_block in num_blocks)
+
     @property
     def page_size(self) -> int:
         """

--- a/tensorrt_llm/_torch/attention_backend/interface.py
+++ b/tensorrt_llm/_torch/attention_backend/interface.py
@@ -314,6 +314,17 @@ class AttentionMetadata:
         """
         self._prepare_mamba_metadata()
 
+    def cuda_graph_replay_signature(self) -> Optional[Tuple[Any, ...]]:
+        """
+        Returns backend-specific metadata that must match the captured CUDA graph
+        before replay.
+
+        CUDA graph keys cover the model-level batch shape. Attention backends
+        can add values that affect their graph-captured kernel launches but are
+        not represented in the model-level key.
+        """
+        return None
+
     def _prepare_mamba_metadata(self):
         if self.mamba_metadata is False:
             return

--- a/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
+++ b/tensorrt_llm/_torch/pyexecutor/cuda_graph_runner.py
@@ -315,6 +315,13 @@ class CUDAGraphRunner:
     def needs_capture(self, key: KeyType):
         return self._capture_allowed and key not in self.graph_outputs
 
+    def is_cuda_graph_replay_compatible(self, key: KeyType,
+                                        attn_metadata: Any) -> bool:
+        stored_signature = self.graph_metadata[key].get(
+            "cuda_graph_replay_signature")
+        current_signature = attn_metadata.cuda_graph_replay_signature()
+        return stored_signature == current_signature
+
     @contextlib.contextmanager
     def allow_capture(self):
         """Context manager that enables CUDA graph capture.
@@ -375,8 +382,12 @@ class CUDAGraphRunner:
         capture_inputs.update(sliced_static_tensors)
 
         self.graph_metadata[key] = {
-            "attn_metadata": initial_inputs["attn_metadata"],
-            "spec_metadata": initial_inputs.get("spec_metadata", None),
+            "attn_metadata":
+            initial_inputs["attn_metadata"],
+            "spec_metadata":
+            initial_inputs.get("spec_metadata", None),
+            "cuda_graph_replay_signature":
+            initial_inputs["attn_metadata"].cuda_graph_replay_signature(),
         }
 
         def _setup_spec_decoding_and_forward(key: KeyType, forward_fn: Callable,

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -4982,6 +4982,14 @@ class PyTorchModelEngine(ModelEngine):
                 new_tensors_device, cache_indirection_buffer,
                 num_accepted_tokens_device, req_id_to_old_request,
                 resource_manager, can_run_graph)
+            graph_needs_capture = (self.cuda_graph_runner.needs_capture(key)
+                                   if can_run_graph else False)
+            graph_metadata_compatible = (
+                not can_run_graph or graph_needs_capture
+                or self.cuda_graph_runner.is_cuda_graph_replay_compatible(
+                    key, attn_metadata))
+            if not graph_metadata_compatible:
+                can_run_graph = False
 
             with with_shared_pool(self.cuda_graph_runner.get_graph_pool()):
                 if not can_run_graph:

--- a/tests/unittest/_torch/attention/test_flashinfer_attention.py
+++ b/tests/unittest/_torch/attention/test_flashinfer_attention.py
@@ -61,6 +61,71 @@ class CUDAGraphTestScenario:
 
 class TestFlashInferAttention(unittest.TestCase):
 
+    def test_cuda_graph_replay_signature_tracks_decode_page_counts(
+            self) -> None:
+        if not torch.cuda.is_available():
+            self.skipTest("CUDA is required")
+
+        batch_size = 3
+        tokens_per_block = 4
+        max_blocks_per_seq = 4
+        max_seq_len = tokens_per_block * max_blocks_per_seq
+        request_ids = list(range(batch_size))
+        mapping = Mapping(world_size=1, tp_size=1, rank=0)
+        kv_cache_manager = KVCacheManager(
+            KvCacheConfig(max_tokens=batch_size * max_seq_len),
+            tensorrt_llm.bindings.internal.batch_manager.CacheType.SELF,
+            num_layers=1,
+            num_kv_heads=2,
+            head_dim=8,
+            tokens_per_block=tokens_per_block,
+            max_seq_len=max_seq_len,
+            max_batch_size=batch_size,
+            mapping=mapping,
+            dtype=tensorrt_llm.bindings.DataType.BF16,
+        )
+        kv_cache_manager.add_dummy_requests(request_ids,
+                                            [max_seq_len] * batch_size)
+
+        try:
+            metadata = TestingFlashInferAttentionMetadata(
+                seq_lens=torch.ones((batch_size, ), dtype=torch.int),
+                num_contexts=0,
+                is_cuda_graph=True,
+                kv_cache_params=KVCacheParams(
+                    use_cache=True,
+                    num_cached_tokens_per_seq=[0, 3, 4],
+                ),
+                max_num_requests=batch_size,
+                max_num_tokens=batch_size,
+                kv_cache_manager=kv_cache_manager,
+                request_ids=request_ids,
+            )
+
+            metadata.prepare()
+
+            self.assertEqual(metadata.num_blocks, [1, 1, 2])
+            self.assertEqual(metadata.cuda_graph_replay_signature(), (1, 1, 2))
+            self.assertEqual(
+                metadata.paged_kv_indptr_decode[:batch_size + 1].cpu().tolist(),
+                [0, 1, 2, 4],
+            )
+
+            metadata.kv_cache_params = KVCacheParams(
+                use_cache=True,
+                num_cached_tokens_per_seq=[12, 0, 7],
+            )
+            metadata.prepare()
+
+            self.assertEqual(metadata.num_blocks, [4, 1, 2])
+            self.assertEqual(metadata.cuda_graph_replay_signature(), (4, 1, 2))
+            self.assertEqual(
+                metadata.paged_kv_indptr_decode[:batch_size + 1].cpu().tolist(),
+                [0, 4, 5, 7],
+            )
+        finally:
+            kv_cache_manager.shutdown()
+
     @parameterized.expand([
         Scenario(num_layers=1,
                  num_heads=32,

--- a/tests/unittest/_torch/executor/test_pytorch_model_engine.py
+++ b/tests/unittest/_torch/executor/test_pytorch_model_engine.py
@@ -11,6 +11,7 @@ import tensorrt_llm
 from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.pyexecutor.connectors.kv_cache_connector import \
     KvCacheConnectorWorker
+from tensorrt_llm._torch.pyexecutor.cuda_graph_runner import CUDAGraphRunner
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
 from tensorrt_llm._torch.pyexecutor.model_engine import PyTorchModelEngine
 from tensorrt_llm.llmapi.llm_args import TorchLlmArgs
@@ -83,6 +84,69 @@ class DummyModelEngine(PyTorchModelEngine):
                          mapping=mapping,
                          model=model,
                          llm_args=llm_args)
+
+
+class DummyReplaySignatureMetadata:
+
+    def __init__(self, signature):
+        self.signature = signature
+
+    def cuda_graph_replay_signature(self):
+        return self.signature
+
+
+def _create_cuda_graph_runner_with_signature(key, signature):
+    runner = object.__new__(CUDAGraphRunner)
+    runner.graphs = {}
+    runner.graph_outputs = {}
+    runner.memory_pool = None
+    runner.padding_dummy_requests = {}
+    runner.graph_metadata = {
+        key: {
+            "cuda_graph_replay_signature": signature,
+        },
+    }
+    return runner
+
+
+def test_cuda_graph_replay_signature_allows_unconstrained_backends():
+    key = (1, 0, False, False, True)
+    runner = _create_cuda_graph_runner_with_signature(key, None)
+
+    assert runner.is_cuda_graph_replay_compatible(
+        key, DummyReplaySignatureMetadata(None))
+
+
+def test_cuda_graph_replay_signature_accepts_matching_metadata():
+    key = (1, 0, False, False, True)
+    runner = _create_cuda_graph_runner_with_signature(key, (272, ))
+
+    assert runner.is_cuda_graph_replay_compatible(
+        key, DummyReplaySignatureMetadata((272, )))
+
+
+def test_cuda_graph_replay_signature_rejects_active_page_count_mismatch():
+    key = (1, 0, False, False, True)
+    runner = _create_cuda_graph_runner_with_signature(key, (272, ))
+
+    assert not runner.is_cuda_graph_replay_compatible(
+        key, DummyReplaySignatureMetadata((1, )))
+
+
+def test_cuda_graph_replay_signature_rejects_missing_current_signature():
+    key = (1, 0, False, False, True)
+    runner = _create_cuda_graph_runner_with_signature(key, (272, ))
+
+    assert not runner.is_cuda_graph_replay_compatible(
+        key, DummyReplaySignatureMetadata(None))
+
+
+def test_cuda_graph_replay_signature_rejects_batch_shape_mismatch():
+    key = (2, 0, False, False, True)
+    runner = _create_cuda_graph_runner_with_signature(key, (16, 16))
+
+    assert not runner.is_cuda_graph_replay_compatible(
+        key, DummyReplaySignatureMetadata((16, )))
 
 
 def _create_request(num_tokens, req_id: int):


### PR DESCRIPTION
 <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced CUDA graph replay with compatibility validation to ensure captured graphs can be safely reused with current attention metadata.
  * Attention backends now compute replay signatures that track memory configuration changes affecting graph execution.

* **Tests**
  * Added tests validating CUDA graph replay compatibility checks across various metadata scenarios.
  * Added tests confirming attention metadata signatures properly track memory configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->                                                                                                                                                                                                                                     
                                                               
  ## Description

  FlashInfer decode CUDA graph replay can hang when the graph was captured with one active paged-KV layout and later replayed with a different one. In the Gemma3 multimodal repro, warmup captured a decode graph with `num_blocks=(272,)`, while a real
  decode step reused that graph with a smaller active page count. The executor then wedged and surfaced as a hang in `FlashInferAttentionMetadata.prepare()` at `num_blocks.tolist()`.

  This PR adds an attention-metadata-owned CUDA graph replay signature. The default metadata signature is `None`; FlashInfer metadata returns its active `num_blocks`. The CUDA graph runner records the signature at capture time, and the PyTorch model
  engine skips replay when the current signature differs from the captured signature.

  This is a correctness guard. Matching signatures still use CUDA graph replay; mismatched FlashInfer page layouts fall back to eager execution instead of replaying an incompatible graph.

  ## Test Coverage

  - Added focused unit coverage for CUDA graph replay-signature compatibility:
    - unconstrained backend metadata
    - matching signature
    - active page-count mismatch
    - missing current signature
    - batch-shape mismatch

  - Added FlashInfer metadata coverage with a real KV cache manager to verify:
    - `num_blocks`
    - `cuda_graph_replay_signature()`
    - `paged_kv_indptr_decode`

  - Verified in `nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc19`:
    - Focused pytest: `6 passed, 22 deselected`
    - Patched Gemma3 12B multimodal repro completed with `text='\n\nWhite.'`
    - Vanilla rc19 reproduced the 300s hang at `flashinfer.py: self.num_blocks = num_blocks.tolist()`

  ## PR Checklist

  Please review the following before submitting your PR:
  - PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
  - PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
  - Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
  - If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
  - Any new dependencies have been scanned for license and vulnerabilities
  - [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
  - Documentation updated as needed
  - Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
  - The reviewers assigned automatically/manually are appropriate for the PR.

  - [ ] Please check this after reviewing the above items as appropriate for this PR.


## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
