### PR TITLE
[#12715][fix] Disable NCCL window buffers on GB10

### DIFF
--- a/cpp/tensorrt_llm/common/ncclUtils.cpp
+++ b/cpp/tensorrt_llm/common/ncclUtils.cpp
@@ -90,6 +90,121 @@ struct NcclMemGuard
 namespace tensorrt_llm::common::nccl_util
 {
 
+namespace
+{
+
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
+constexpr int kNcclWindowMinRuntimeVersion = NCCL_VERSION(2, 28, 0);
+constexpr int kNcclGb10WindowFixedVersion = NCCL_VERSION(2, 30, 4);
+constexpr int kGb10RealSmVersion = 121;
+
+bool isGb10Platform(int realSmVersion, bool isIntegrated)
+{
+    return realSmVersion == kGb10RealSmVersion && isIntegrated;
+}
+#endif
+
+bool queryNcclWindowSupported()
+{
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
+    int version = 0;
+    if (ncclGetVersion(&version) != ncclSuccess)
+    {
+        TLLM_LOG_WARNING("[NCCLUtil] Failed to query NCCL runtime version; falling back to regular tensors.");
+        return false;
+    }
+
+    if (version < kNcclWindowMinRuntimeVersion)
+    {
+        TLLM_LOG_WARNING(
+            "[NCCLUtil] NCCL runtime version %d.%d.%d does not support window buffers; falling back to regular "
+            "tensors.",
+            version / 10000, (version % 10000) / 100, version % 100);
+        return false;
+    }
+
+    if (version >= kNcclGb10WindowFixedVersion)
+    {
+        return true;
+    }
+
+    int device = -1;
+    cudaError_t const deviceErr = cudaGetDevice(&device);
+    if (deviceErr != cudaSuccess)
+    {
+        TLLM_LOG_WARNING(
+            "[NCCLUtil] Failed to query the current CUDA device while checking NCCL window support: %s; "
+            "falling back to regular tensors.",
+            cudaGetErrorString(deviceErr));
+        return false;
+    }
+
+    int isIntegrated = 0;
+    cudaError_t const integratedErr = cudaDeviceGetAttribute(&isIntegrated, cudaDevAttrIntegrated, device);
+    if (integratedErr != cudaSuccess)
+    {
+        TLLM_LOG_WARNING(
+            "[NCCLUtil] Failed to query CUDA integrated-device attribute for device %d while checking NCCL window "
+            "support: %s; falling back to regular tensors.",
+            device, cudaGetErrorString(integratedErr));
+        return false;
+    }
+
+    int realSmVersion = -1;
+    try
+    {
+        realSmVersion = tensorrt_llm::common::getSMVersion(/*queryRealSmArch=*/true);
+    }
+    catch (std::exception const& e)
+    {
+        TLLM_LOG_WARNING(
+            "[NCCLUtil] Failed to query real CUDA SM version while checking NCCL window support: %s; falling back "
+            "to regular tensors.",
+            e.what());
+        return false;
+    }
+
+    bool const supported = !isGb10Platform(realSmVersion, isIntegrated != 0);
+    if (!supported)
+    {
+        TLLM_LOG_WARNING(
+            "[NCCLUtil] Disabling NCCL window buffers on integrated SM %d with NCCL runtime version %d.%d.%d; "
+            "GB10 requires NCCL 2.30.4 or newer for symmetric window registration.",
+            realSmVersion, version / 10000, (version % 10000) / 100, version % 100);
+    }
+    return supported;
+#else
+    return false;
+#endif
+}
+
+} // namespace
+
+bool isNcclWindowSupportedForPlatform(int realSmVersion, bool isIntegrated, int ncclRuntimeVersion)
+{
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
+    if (ncclRuntimeVersion < kNcclWindowMinRuntimeVersion)
+    {
+        return false;
+    }
+
+    return !(ncclRuntimeVersion < kNcclGb10WindowFixedVersion && isGb10Platform(realSmVersion, isIntegrated));
+#else
+    (void) realSmVersion;
+    (void) isIntegrated;
+    (void) ncclRuntimeVersion;
+    return false;
+#endif
+}
+
+bool isNcclWindowSupported()
+{
+    static std::once_flag supportCheckFlag;
+    static bool windowBuffersSupported = false;
+    std::call_once(supportCheckFlag, []() { windowBuffersSupported = queryNcclWindowSupported(); });
+    return windowBuffersSupported;
+}
+
 //==============================================================================
 // NcclCommResourceManager Implementation
 //==============================================================================
@@ -287,26 +402,7 @@ NCCLWindowAllocator& NCCLWindowAllocator::getInstance()
 
 NCCLWindowBuffer NCCLWindowAllocator::requestBuffer(ncclComm_t comm, size_t size)
 {
-    // One-time runtime version check: the runtime NCCL library must also support window buffers.
-    static std::once_flag versionCheckFlag;
-    static bool runtimeVersionOk = false;
-    std::call_once(versionCheckFlag,
-        []()
-        {
-            int version = 0;
-            if (ncclGetVersion(&version) == ncclSuccess && version >= NCCL_VERSION(2, 28, 0))
-            {
-                runtimeVersionOk = true;
-            }
-            else
-            {
-                TLLM_LOG_WARNING(
-                    "[NCCLUtil] NCCL runtime version %d.%d.%d does not support window buffers; "
-                    "falling back to regular tensors.",
-                    version / 10000, (version % 10000) / 100, version % 100);
-            }
-        });
-    if (!runtimeVersionOk)
+    if (!isNcclWindowSupported())
     {
         return NCCLWindowBuffer();
     }

--- a/cpp/tensorrt_llm/common/ncclUtils.h
+++ b/cpp/tensorrt_llm/common/ncclUtils.h
@@ -164,21 +164,14 @@ private:
 // NCCL Version Check
 //==============================================================================
 
+// Returns true if NCCL window buffers (ncclMemAlloc / ncclCommWindowRegister)
+// are supported for the given real SM version, integrated-device flag, and runtime NCCL version.
+// Exposed for focused unit testing of platform/version gates.
+bool isNcclWindowSupportedForPlatform(int realSmVersion, bool isIntegrated, int ncclRuntimeVersion);
+
 // Returns true if the compile-time and runtime NCCL versions support window buffers
-// (ncclMemAlloc / ncclCommWindowRegister).
-inline bool isNcclWindowSupported()
-{
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
-    int version = 0;
-    if (ncclGetVersion(&version) != ncclSuccess)
-    {
-        return false;
-    }
-    return version >= NCCL_VERSION(2, 28, 0);
-#else
-    return false;
-#endif
-}
+// and the current CUDA device is not in a known-unsupported platform/version set.
+bool isNcclWindowSupported();
 
 //==============================================================================
 // NCCL Window Buffer Allocation

--- a/cpp/tests/unit_tests/multi_gpu/ncclUtilsTest.cpp
+++ b/cpp/tests/unit_tests/multi_gpu/ncclUtilsTest.cpp
@@ -38,6 +38,22 @@ namespace nccl_util = tensorrt_llm::common::nccl_util;
 
 using tensorrt_llm::getComm;
 
+TEST(NCCLWindowSupportTest, RuntimeVersionAndGB10Gate)
+{
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)
+    EXPECT_FALSE(nccl_util::isNcclWindowSupportedForPlatform(121, true, NCCL_VERSION(2, 27, 9)));
+    EXPECT_FALSE(nccl_util::isNcclWindowSupportedForPlatform(121, true, NCCL_VERSION(2, 29, 2)));
+    EXPECT_FALSE(nccl_util::isNcclWindowSupportedForPlatform(121, true, NCCL_VERSION(2, 30, 3)));
+
+    EXPECT_TRUE(nccl_util::isNcclWindowSupportedForPlatform(121, true, NCCL_VERSION(2, 30, 4)));
+    EXPECT_TRUE(nccl_util::isNcclWindowSupportedForPlatform(121, false, NCCL_VERSION(2, 29, 2)));
+    EXPECT_TRUE(nccl_util::isNcclWindowSupportedForPlatform(120, true, NCCL_VERSION(2, 29, 2)));
+    EXPECT_TRUE(nccl_util::isNcclWindowSupportedForPlatform(100, false, NCCL_VERSION(2, 29, 2)));
+#else
+    GTEST_SKIP() << "NCCL window buffers are not compiled in";
+#endif
+}
+
 // Helper function to create a split communicator for testing
 // This allows us to test cleanup behavior explicitly by controlling the lifetime
 std::shared_ptr<ncclComm_t> createSplitComm(ncclComm_t parentComm, int color, int key)

--- a/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/torch_custom_ops.py
@@ -13,11 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ctypes
 import enum
 import os
 import threading
-from ctypes.util import find_library
 from dataclasses import replace
 from functools import lru_cache
 from typing import ClassVar, List, Mapping, Optional, Tuple, Union
@@ -57,56 +55,6 @@ if IS_CUTLASS_DSL_AVAILABLE:
 
 # BufferKind is bound from C++; see cpp/tensorrt_llm/thop/outputTensor.h (torch_ext::BufferKind).
 from tensorrt_llm.bindings.internal.thop import BufferKind
-
-_NCCL_GB10_SYMMETRIC_FIXED_VERSION = 23004  # NCCL 2.30.4
-_NCCL_MNNVL_ENABLE = "NCCL_MNNVL_ENABLE"
-
-
-@lru_cache(maxsize=None)
-def _is_gb10() -> bool:
-    """Return True on GB10 (DGX Spark)."""
-    return "GB10" in torch.cuda.get_device_name()
-
-
-@lru_cache(maxsize=None)
-def _get_nccl_runtime_version_code() -> Optional[int]:
-    lib_names = ["libnccl.so.2", "libnccl.so"]
-    nccl_lib = find_library("nccl")
-    if nccl_lib is not None and nccl_lib not in lib_names:
-        lib_names.append(nccl_lib)
-
-    for lib_name in lib_names:
-        try:
-            nccl = ctypes.CDLL(lib_name)
-            nccl.ncclGetVersion.argtypes = [ctypes.POINTER(ctypes.c_int)]
-            nccl.ncclGetVersion.restype = ctypes.c_int
-        except (AttributeError, OSError):
-            continue
-
-        version = ctypes.c_int()
-        if nccl.ncclGetVersion(ctypes.byref(version)) == 0:
-            return version.value
-
-    return None
-
-
-@lru_cache(maxsize=None)
-def _needs_gb10_nccl_symmetric_workaround() -> bool:
-    if not _is_gb10():
-        return False
-
-    runtime_version = _get_nccl_runtime_version_code()
-    return (runtime_version is None
-            or runtime_version < _NCCL_GB10_SYMMETRIC_FIXED_VERSION)
-
-
-@lru_cache(maxsize=None)
-def _init_gb10_nccl_symmetric_workaround() -> bool:
-    if not _needs_gb10_nccl_symmetric_workaround():
-        return False
-
-    os.environ.setdefault(_NCCL_MNNVL_ENABLE, "0")
-    return True
 
 
 # Used to WAR an issue in torch.bmm that it would break the graph when the out is not contiguous.
@@ -2065,14 +2013,10 @@ class AllReduceRunner(TunableRunner):
         profile: OptimizationProfile,
         **kwargs,
     ) -> List[int]:
-        # NCCL_SYMMETRIC is unsupported on GB10 (DGX Spark) before NCCL 2.30.4.
-        if _needs_gb10_nccl_symmetric_workaround():
-            valid_strategies = [AllReduceStrategy.NCCL.value]
-        else:
-            valid_strategies = [
-                AllReduceStrategy.NCCL_SYMMETRIC.value,
-                AllReduceStrategy.NCCL.value,
-            ]
+        valid_strategies = [
+            AllReduceStrategy.NCCL_SYMMETRIC.value,
+            AllReduceStrategy.NCCL.value,
+        ]
         # Fallback in allreduceOp is set to NCCL_SYMMETRIC as default
         # So we need to check if the workspace size is too large to avoid hanging.
         workspace_size = inputs[0].numel() * inputs[0].element_size()
@@ -2099,7 +2043,6 @@ class AllReduceRunner(TunableRunner):
         **kwargs,
     ) -> torch.Tensor:
         input, residual, norm_weight, scale, bias, workspace = inputs
-        gb10_nccl_workaround = _needs_gb10_nccl_symmetric_workaround()
         if do_preparation:
             valid_tactics = self.get_valid_tactics(inputs,
                                                    OptimizationProfile(),
@@ -2116,15 +2059,10 @@ class AllReduceRunner(TunableRunner):
             return input
         if tactic == -1:
             # tactic == -1 means the autotuner cache missed for this shape.
-            # On GB10 (DGX Spark), NCCL_SYMMETRIC is unsupported before NCCL
-            # 2.30.4, so fall back to plain NCCL. On other platforms fall back
-            # to NCCL_SYMMETRIC; asymmetric ncclMemAlloc failures are handled
+            # Fall back to NCCL_SYMMETRIC; asymmetric ncclMemAlloc failures are handled
             # by a cross-rank barrier in NCCLWindowAllocator which falls back
             # to plain NCCL.
-            if gb10_nccl_workaround:
-                tactic = AllReduceStrategy.NCCL.value
-            else:
-                tactic = AllReduceStrategy.NCCL_SYMMETRIC.value
+            tactic = AllReduceStrategy.NCCL_SYMMETRIC.value
 
         return torch.ops.trtllm.allreduce(
             input,

--- a/tensorrt_llm/_torch/distributed/ops.py
+++ b/tensorrt_llm/_torch/distributed/ops.py
@@ -714,10 +714,6 @@ class AllReduce(nn.Module):
         # read it here and stash the values as class-level attributes that
         # AllReduceRunner.forward can use during the autotuner warm-up phase.
         extra_attrs = get_model_extra_attrs()
-        from tensorrt_llm._torch.custom_ops.torch_custom_ops import \
-            _init_gb10_nccl_symmetric_workaround
-        _init_gb10_nccl_symmetric_workaround()
-
         if extra_attrs:
             from tensorrt_llm._torch.custom_ops.torch_custom_ops import \
                 AllReduceRunner


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced NCCL window buffer support detection with more robust runtime version and device attribute validation.
  * Simplified multi-GPU all-reduce communication strategy selection by removing platform-specific compatibility workarounds.

* **Tests**
  * Added unit tests to validate NCCL window buffer support detection across varying platform and runtime configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Description

  PR https://github.com/NVIDIA/TensorRT-LLM/pull/12902 avoided the NCCL symmetric allreduce path, but the same unsupported NCCL window registration could still be reached through other callers, including the fused GEMM output path:

  `FP4GemmRunner::runGemm -> createNCCLWindowTensor -> ncclCommGroupRegisterSymmetric`

  This change makes the workaround more holistic by guarding the native NCCL window allocator itself. On GB10/integrated SM 121 platforms with NCCL runtime versions older than 2.30.4, TRT-LLM now skips NCCL window buffer registration and falls back to regular tensors. The platform/version check is cached process-wide, so the normal path remains cheap after the first query,
  and newer NCCL versions avoid the platform probe entirely.

  The Python-side GB10 workaround is removed so the behavior is centralized in the C++ NCCL window path used by all callers.

  ## Test Coverage

  - Added unit coverage for the GB10/NCCL runtime-version gate in `cpp/tests/unit_tests/multi_gpu/ncclUtilsTest.cpp`.
  - Verified `git diff --check`.
  - Verified Python syntax with `python3 -m py_compile` for the edited Python files.
  - Reproduced the crash on unpatched rc18 with dual-node serving:
    - Qwen3-0.6B failed in `ncclCommGroupRegisterSymmetric`.
    - TinyLlama failed in the same NCCL symmetric/window path.
  - Verified patched rc18 dual-node serving:
    - Qwen3-0.6B completed successfully with the native guard firing.
    - TinyLlama completed successfully with the native guard firing.

- [x] Please check this after reviewing the above items as appropriate for this PR.
