### PR TITLE
[None][feat] Add HunyuanVideo 1.5 text-to-video support to VisualGen

### DIFF
--- a/docs/source/models/visual-generation.md
+++ b/docs/source/models/visual-generation.md
@@ -39,6 +39,8 @@ TensorRT-LLM **VisualGen** provides a unified inference stack for diffusion mode
 | `Qwen/Qwen-Image-2512` | Text-to-Image |
 | `nvidia/Cosmos3-Nano` | Text-to-Image, Text-to-Video, Image-to-Video |
 | `nvidia/Cosmos3-Super` | Text-to-Image, Text-to-Video, Image-to-Video |
+| `hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v` | Text-to-Video |
+| `hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-720p_t2v` | Text-to-Video |
 
 Models are auto-detected from the checkpoint directory. Diffusers-format models are detected via `model_index.json`; LTX-2 monolithic safetensors checkpoints are detected via embedded metadata. The `AutoPipeline` registry selects the appropriate pipeline class automatically.
 
@@ -54,6 +56,7 @@ Models are auto-detected from the checkpoint directory. Diffusers-format models 
 | **LTX-2** | Yes | Yes | Yes [^4] | Yes | Yes | Yes | No | No | Yes | Yes | Yes | Yes | No | No |
 | **Qwen-Image** [^5] | Yes | Yes | No | No | No | Yes | No | Yes | Yes | Yes | Yes | Yes | No | No |
 | **Cosmos3** | Yes | Yes | No | No | Yes | Yes | Yes | Yes | Yes | Yes | No | No | Yes | No |
+| **HunyuanVideo 1.5** [^6] | Yes | Yes | No | No | No | No | No | No | No | Yes | No | No | No | No |
 
 [^1]: FLUX models use embedded guidance and do not have a separate negative prompt path, so CFG parallelism is not applicable.
 
@@ -64,6 +67,8 @@ Models are auto-detected from the checkpoint directory. Diffusers-format models 
 [^4]: LTX-2 has no built-in TeaCache coefficient table in TRT-LLM; set `teacache.coefficients` explicitly when enabling TeaCache.
 
 [^5]: Qwen-Image ships a native BF16 implementation with per-module numerical parity against `diffusers.QwenImagePipeline` (cosine similarity >= 0.999 on the full 20B transformer) and supports `trtllm-serve` / `/v1/images/generations`. VisualGen supports FP8 blockwise and NVFP4 dynamic quantization from BF16 checkpoints, as well as direct loading of statically quantized FP8 and NVFP4 ModelOpt checkpoints.
+
+[^6]: HunyuanVideo 1.5 currently supports single-GPU text-to-video with BF16 parity vs `diffusers` (cosine >= 0.99 on the full transformer). FP8 blockwise and NVFP4 use VisualGen dynamic quantization from BF16 checkpoints. Image-to-video, sequence/CFG parallelism, parallel VAE, and caching (TeaCache / Cache-DiT) are not yet supported.
 
 ## Quick Start
 

--- a/examples/visual_gen/README.md
+++ b/examples/visual_gen/README.md
@@ -23,6 +23,7 @@ python models/flux1.py
 python models/flux2.py
 python models/cosmos3_ti2v.py --prompt "A robot arm picks fruit in a grocery store"
 python models/qwen_image.py
+python models/hunyuan_t2v.py
 
 # With engine config (quant, parallelism, etc.)
 python models/wan_t2v.py --visual_gen_args configs/wan2.2-t2v-fp4-1gpu.yaml
@@ -32,6 +33,7 @@ python models/flux1.py --visual_gen_args configs/flux1-dev-fp4-1gpu.yaml
 python models/flux2.py --visual_gen_args configs/flux2-dev-fp4-1gpu.yaml
 python models/cosmos3_ti2v.py --visual_gen_args configs/cosmos3-nano-1gpu.yaml --prompt "A robot arm picks fruit in a grocery store"
 python models/qwen_image.py --visual_gen_args configs/qwen-image-fp8-1gpu.yaml
+python models/hunyuan_t2v.py --visual_gen_args configs/hunyuan-t2v-fp8-1gpu.yaml
 ```
 
 Install deps from the repo root: `pip install -r requirements-dev.txt`.

--- a/examples/visual_gen/configs/hunyuan-t2v-fp8-1gpu.yaml
+++ b/examples/visual_gen/configs/hunyuan-t2v-fp8-1gpu.yaml
@@ -1,0 +1,14 @@
+# 1-GPU HunyuanVideo 1.5 text-to-video with FP8 dynamic quantization.
+# Model: hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v (or 720p_t2v)
+# Shared by offline examples (--visual_gen_args) and trtllm-serve.
+#
+# HunyuanVideo 1.5 constraints: single-GPU text-to-video only. Sequence/CFG
+# parallelism, parallel VAE, and caching are not yet supported.
+quant_config:
+  quant_algo: FP8
+  dynamic: true
+parallel_config:
+  cfg_size: 1
+  ulysses_size: 1
+cuda_graph_config:
+  enable: false

--- a/examples/visual_gen/configs/hunyuan-t2v-fp8-1gpu.yaml
+++ b/examples/visual_gen/configs/hunyuan-t2v-fp8-1gpu.yaml
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # 1-GPU HunyuanVideo 1.5 text-to-video with FP8 dynamic quantization.
 # Model: hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v (or 720p_t2v)
 # Shared by offline examples (--visual_gen_args) and trtllm-serve.

--- a/examples/visual_gen/configs/hunyuan-t2v-fp8-1gpu.yaml
+++ b/examples/visual_gen/configs/hunyuan-t2v-fp8-1gpu.yaml
@@ -14,11 +14,7 @@
 # limitations under the License.
 
 # 1-GPU HunyuanVideo 1.5 text-to-video with FP8 dynamic quantization.
-# Model: hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v (or 720p_t2v)
 # Shared by offline examples (--visual_gen_args) and trtllm-serve.
-#
-# HunyuanVideo 1.5 constraints: single-GPU text-to-video only. Sequence/CFG
-# parallelism, parallel VAE, and caching are not yet supported.
 quant_config:
   quant_algo: FP8
   dynamic: true

--- a/examples/visual_gen/models/hunyuan_t2v.py
+++ b/examples/visual_gen/models/hunyuan_t2v.py
@@ -37,7 +37,7 @@ def _output_paths(output_path: str, num_videos: int) -> str | list[str]:
     return [str(path.with_name(f"{path.stem}_{idx + 1}{path.suffix}")) for idx in range(num_videos)]
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="HunyuanVideo 1.5 Text-to-Video example")
     parser.add_argument(
         "--model",

--- a/examples/visual_gen/models/hunyuan_t2v.py
+++ b/examples/visual_gen/models/hunyuan_t2v.py
@@ -1,3 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """HunyuanVideo 1.5 Text-to-Video generation.
 
 Single-GPU text-to-video. Image-to-video, parallelism, and caching are not yet

--- a/examples/visual_gen/models/hunyuan_t2v.py
+++ b/examples/visual_gen/models/hunyuan_t2v.py
@@ -1,0 +1,82 @@
+"""HunyuanVideo 1.5 Text-to-Video generation.
+
+Single-GPU text-to-video. Image-to-video, parallelism, and caching are not yet
+supported for this model.
+
+Usage:
+    python hunyuan_t2v.py
+    python hunyuan_t2v.py --visual_gen_args ../configs/hunyuan-t2v-fp8-1gpu.yaml
+"""
+
+import argparse
+from pathlib import Path
+
+from tensorrt_llm import VisualGen, VisualGenArgs
+
+
+def _output_paths(output_path: str, num_videos: int) -> str | list[str]:
+    if num_videos == 1:
+        return output_path
+
+    path = Path(output_path)
+    return [str(path.with_name(f"{path.stem}_{idx + 1}{path.suffix}")) for idx in range(num_videos)]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="HunyuanVideo 1.5 Text-to-Video example")
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v",
+        help="Model path or HuggingFace Hub ID",
+    )
+    parser.add_argument(
+        "--visual_gen_args",
+        "--extra_visual_gen_options",
+        dest="visual_gen_args",
+        type=str,
+        default=None,
+        help="Path to YAML config (same as trtllm-serve --visual_gen_args)",
+    )
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        default="A cute cat playing piano",
+        help="Text prompt for video generation",
+    )
+    parser.add_argument(
+        "--num_videos_per_prompt",
+        type=int,
+        default=1,
+        help="Number of videos to generate for the prompt",
+    )
+    parser.add_argument(
+        "--output_path",
+        type=str,
+        default="hunyuan_t2v_output.mp4",
+        help="Path to save the output video. For multiple videos, an index is appended.",
+    )
+    args = parser.parse_args()
+    if args.num_videos_per_prompt < 1:
+        raise ValueError("--num_videos_per_prompt must be >= 1")
+
+    # Engine config from shared YAML (optional); model-specific defaults apply otherwise.
+    extra_args = VisualGenArgs.from_yaml(args.visual_gen_args) if args.visual_gen_args else None
+    visual_gen = VisualGen(model=args.model, args=extra_args)
+
+    # --- Model-specific: T2V request construction ---
+    # Start from per-model defaults (steps, guidance, seed, etc.) and override resolution/frames.
+    params = visual_gen.default_params
+    params.height = 480
+    params.width = 832
+    params.num_frames = 121
+    params.num_images_per_prompt = args.num_videos_per_prompt
+
+    output = visual_gen.generate(inputs=args.prompt, params=params)
+
+    saved = output.save(_output_paths(args.output_path, args.num_videos_per_prompt))
+    print(f"Saved: {saved}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/visual_gen/serve/configs/hunyuan.yml
+++ b/examples/visual_gen/serve/configs/hunyuan.yml
@@ -1,0 +1,5 @@
+# HunyuanVideo 1.5 text-to-video (single GPU).
+# Sequence/CFG parallelism and caching are not yet supported for this model.
+parallel_config:
+  cfg_size: 1
+  ulysses_size: 1

--- a/examples/visual_gen/serve/configs/hunyuan.yml
+++ b/examples/visual_gen/serve/configs/hunyuan.yml
@@ -1,5 +1,4 @@
 # HunyuanVideo 1.5 text-to-video (single GPU).
-# Sequence/CFG parallelism and caching are not yet supported for this model.
 parallel_config:
   cfg_size: 1
   ulysses_size: 1

--- a/tensorrt_llm/_torch/visual_gen/models/__init__.py
+++ b/tensorrt_llm/_torch/visual_gen/models/__init__.py
@@ -35,6 +35,7 @@ from ..pipeline import BasePipeline
 from ..pipeline_registry import AutoPipeline, register_pipeline
 from .cosmos3 import Cosmos3OmniMoTPipeline
 from .flux import Flux2Pipeline, FluxPipeline
+from .hunyuan_video1_5 import HunyuanVideo15Pipeline
 from .ltx2 import LTX2Pipeline  # noqa: F401
 from .qwen_image import QwenImagePipeline
 from .wan import WanImageToVideoPipeline, WanPipeline
@@ -49,4 +50,5 @@ __all__ = [
     "WanImageToVideoPipeline",
     "Cosmos3OmniMoTPipeline",
     "register_pipeline",
+    "HunyuanVideo15Pipeline",
 ]

--- a/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/__init__.py
+++ b/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from .pipeline_hunyuan_video1_5 import HunyuanVideo15Pipeline
+from .transformer_hunyuan_video1_5 import HunyuanVideo15Attention, HunyuanVideo15Transformer3DModel
+
+__all__ = [
+    "HunyuanVideo15Pipeline",
+    "HunyuanVideo15Transformer3DModel",
+    "HunyuanVideo15Attention",
+]

--- a/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/__init__.py
+++ b/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/__init__.py
@@ -1,5 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from .pipeline_hunyuan_video1_5 import HunyuanVideo15Pipeline
 from .transformer_hunyuan_video1_5 import HunyuanVideo15Attention, HunyuanVideo15Transformer3DModel

--- a/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/pipeline_hunyuan_video1_5.py
+++ b/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/pipeline_hunyuan_video1_5.py
@@ -1,5 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """HunyuanVideo 1.5 text-to-video pipeline."""
 
 import inspect

--- a/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/pipeline_hunyuan_video1_5.py
+++ b/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/pipeline_hunyuan_video1_5.py
@@ -684,7 +684,12 @@ class HunyuanVideo15Pipeline(BasePipeline):
         self._num_timesteps = len(timesteps)
 
         def forward_fn(
-            latents, extra_stream_latents, timestep, encoder_hidden_states, extra_tensors
+            latents,
+            extra_stream_latents,
+            step_index,
+            timestep,
+            encoder_hidden_states,
+            extra_tensors,
         ):
             # Concatenate the conditioning latents and binary mask onto the channel
             # dim to build the transformer input (in_channels = latent channels +

--- a/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/pipeline_hunyuan_video1_5.py
+++ b/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/pipeline_hunyuan_video1_5.py
@@ -1,0 +1,749 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""HunyuanVideo 1.5 text-to-video pipeline."""
+
+import inspect
+import os
+import re
+import time
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import numpy as np
+import torch
+from diffusers.guiders import ClassifierFreeGuidance
+from diffusers.models import AutoencoderKLHunyuanVideo15
+from diffusers.pipelines.hunyuan_video1_5.image_processor import HunyuanVideo15ImageProcessor
+from diffusers.schedulers import FlowMatchEulerDiscreteScheduler
+from diffusers.utils.torch_utils import randn_tensor
+from transformers import ByT5Tokenizer, Qwen2_5_VLTextModel, Qwen2Tokenizer, T5EncoderModel
+
+from tensorrt_llm import logger
+from tensorrt_llm._torch.visual_gen.config import DiffusionPipelineConfig
+from tensorrt_llm._torch.visual_gen.output import CudaPhaseTimer, PipelineOutput
+from tensorrt_llm._torch.visual_gen.pipeline import BasePipeline
+from tensorrt_llm._torch.visual_gen.pipeline_registry import PipelineComponent, register_pipeline
+from tensorrt_llm._torch.visual_gen.utils import postprocess_video_tensor
+
+from .transformer_hunyuan_video1_5 import HunyuanVideo15Transformer3DModel
+
+
+# Copied from HF
+def format_text_input(prompt: List[str], system_message: str) -> List[Dict[str, Any]]:
+    """
+    Apply text to template.
+
+    Args:
+        prompt (list[str]): Input text.
+        system_message (str): System message.
+
+    Returns:
+        list[dict[str, Any]]: List of chat conversation.
+    """
+
+    template = [
+        [
+            {"role": "system", "content": system_message},
+            {"role": "user", "content": p if p else " "},
+        ]
+        for p in prompt
+    ]
+
+    return template
+
+
+# Copied from HF
+def extract_glyph_texts(prompt: str) -> List[str]:
+    """
+    Extract glyph texts from prompt using regex pattern.
+
+    Args:
+        prompt: Input prompt string
+
+    Returns:
+        List of extracted glyph texts
+    """
+    pattern = r"\"(.*?)\"|“(.*?)”"
+    matches = re.findall(pattern, prompt)
+    result = [match[0] or match[1] for match in matches]
+    result = list(dict.fromkeys(result)) if len(result) > 1 else result
+
+    if result:
+        formatted_result = ". ".join([f'Text "{text}"' for text in result]) + ". "
+    else:
+        formatted_result = None
+
+    return formatted_result
+
+
+# Copied from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion.retrieve_timesteps
+def retrieve_timesteps(
+    scheduler,
+    num_inference_steps: Optional[int] = None,
+    device: Optional[Union[str, torch.device]] = None,
+    timesteps: Optional[List[int]] = None,
+    **kwargs,
+):
+    """
+    Calls the scheduler's `set_timesteps` method and retrieves timesteps from the scheduler after the call. Handles
+    custom timesteps. Any kwargs will be supplied to `scheduler.set_timesteps`.
+
+    Args:
+        scheduler (`SchedulerMixin`):
+            The scheduler to get timesteps from.
+        num_inference_steps (`int`):
+            The number of diffusion steps used when generating samples with a pre-trained model. If used,
+            `timesteps` must be `None`.
+        device (`str` or `torch.device`, *optional*):
+            The device to which the timesteps should be moved to. If `None`, the timesteps are not moved.
+        timesteps (`List[int]`, *optional*):
+                Custom timesteps used to support arbitrary spacing between timesteps. If `None`, then the default
+                timestep spacing strategy of the scheduler is used. If `timesteps` is passed, `num_inference_steps`
+                must be `None`.
+
+    Returns:
+        `Tuple[torch.Tensor, int]`: A tuple where the first element is the timestep schedule from the scheduler and the
+        second element is the number of inference steps.
+    """
+    if timesteps is not None:
+        accepts_timesteps = "timesteps" in set(
+            inspect.signature(scheduler.set_timesteps).parameters.keys()
+        )
+        if not accepts_timesteps:
+            raise ValueError(
+                f"The current scheduler class {scheduler.__class__}'s `set_timesteps` does not support custom"
+                f" timestep schedules. Please check whether you are using the correct scheduler."
+            )
+        scheduler.set_timesteps(timesteps=timesteps, device=device, **kwargs)
+        timesteps = scheduler.timesteps
+        num_inference_steps = len(timesteps)
+    else:
+        scheduler.set_timesteps(num_inference_steps, device=device, **kwargs)
+        timesteps = scheduler.timesteps
+    return timesteps, num_inference_steps
+
+
+@register_pipeline(
+    "HunyuanVideo15Pipeline",
+    hf_ids=[
+        "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-720p_t2v",
+        "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v",
+        "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v_distilled",
+    ],
+    doc="Tencent HunyuanVideo 1.5 family (text-to-video).",
+)
+class HunyuanVideo15Pipeline(BasePipeline):
+    def __init__(self, pipeline_config: DiffusionPipelineConfig):
+        super().__init__(pipeline_config)
+
+    # Copied from HF
+    @staticmethod
+    def _get_mllm_prompt_embeds(
+        text_encoder: Qwen2_5_VLTextModel,
+        tokenizer: Qwen2Tokenizer,
+        prompt: Union[str, List[str]],
+        device: torch.device,
+        tokenizer_max_length: int = 1000,
+        num_hidden_layers_to_skip: int = 2,
+        # fmt: off
+        system_message: str = "You are a helpful assistant. Describe the video by detailing the following aspects: \
+        1. The main content and theme of the video. \
+        2. The color, shape, size, texture, quantity, text, and spatial relationships of the objects. \
+        3. Actions, events, behaviors temporal relationships, physical movement changes of the objects. \
+        4. background environment, light, style and atmosphere. \
+        5. camera angles, movements, and transitions used in the video.",
+        # fmt: on
+        crop_start: int = 108,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        prompt = [prompt] if isinstance(prompt, str) else prompt
+
+        prompt = format_text_input(prompt, system_message)
+
+        text_inputs = tokenizer.apply_chat_template(
+            prompt,
+            add_generation_prompt=True,
+            tokenize=True,
+            return_dict=True,
+            padding="max_length",
+            max_length=tokenizer_max_length + crop_start,
+            truncation=True,
+            return_tensors="pt",
+        )
+
+        text_input_ids = text_inputs.input_ids.to(device=device)
+        prompt_attention_mask = text_inputs.attention_mask.to(device=device)
+
+        prompt_embeds = text_encoder(
+            input_ids=text_input_ids,
+            attention_mask=prompt_attention_mask,
+            output_hidden_states=True,
+        ).hidden_states[-(num_hidden_layers_to_skip + 1)]
+
+        if crop_start is not None and crop_start > 0:
+            prompt_embeds = prompt_embeds[:, crop_start:]
+            prompt_attention_mask = prompt_attention_mask[:, crop_start:]
+
+        return prompt_embeds, prompt_attention_mask
+
+    # Copied from HF
+    @staticmethod
+    def _get_byt5_prompt_embeds(
+        tokenizer: ByT5Tokenizer,
+        text_encoder: T5EncoderModel,
+        prompt: Union[str, List[str]],
+        device: torch.device,
+        tokenizer_max_length: int = 256,
+    ):
+        prompt = [prompt] if isinstance(prompt, str) else prompt
+
+        glyph_texts = [extract_glyph_texts(p) for p in prompt]
+
+        prompt_embeds_list = []
+        prompt_embeds_mask_list = []
+
+        for glyph_text in glyph_texts:
+            if glyph_text is None:
+                glyph_text_embeds = torch.zeros(
+                    (1, tokenizer_max_length, text_encoder.config.d_model),
+                    device=device,
+                    dtype=text_encoder.dtype,
+                )
+                glyph_text_embeds_mask = torch.zeros(
+                    (1, tokenizer_max_length), device=device, dtype=torch.int64
+                )
+            else:
+                txt_tokens = tokenizer(
+                    glyph_text,
+                    padding="max_length",
+                    max_length=tokenizer_max_length,
+                    truncation=True,
+                    add_special_tokens=True,
+                    return_tensors="pt",
+                ).to(device)
+
+                glyph_text_embeds = text_encoder(
+                    input_ids=txt_tokens.input_ids,
+                    attention_mask=txt_tokens.attention_mask.float(),
+                )[0]
+                glyph_text_embeds = glyph_text_embeds.to(device=device)
+                glyph_text_embeds_mask = txt_tokens.attention_mask.to(device=device)
+
+            prompt_embeds_list.append(glyph_text_embeds)
+            prompt_embeds_mask_list.append(glyph_text_embeds_mask)
+
+        prompt_embeds = torch.cat(prompt_embeds_list, dim=0)
+        prompt_embeds_mask = torch.cat(prompt_embeds_mask_list, dim=0)
+
+        return prompt_embeds, prompt_embeds_mask
+
+    # Copied from HF
+    def _encode_prompt(
+        self,
+        prompt: Optional[Union[str, List[str]]],
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None,
+        batch_size: int = 1,
+        num_videos_per_prompt: int = 1,
+        prompt_embeds: Optional[torch.Tensor] = None,
+        prompt_embeds_mask: Optional[torch.Tensor] = None,
+        prompt_embeds_2: Optional[torch.Tensor] = None,
+        prompt_embeds_mask_2: Optional[torch.Tensor] = None,
+    ):
+        r"""
+
+        Args:
+            prompt (`str` or `list[str]`, *optional*):
+                prompt to be encoded
+            device: (`torch.device`):
+                torch device
+            batch_size (`int`):
+                batch size of prompts, defaults to 1
+            num_images_per_prompt (`int`):
+                number of images that should be generated per prompt
+            prompt_embeds (`torch.Tensor`, *optional*):
+                Pre-generated text embeddings. If not provided, text embeddings will be generated from `prompt` input
+                argument.
+            prompt_embeds_mask (`torch.Tensor`, *optional*):
+                Pre-generated text mask. If not provided, text mask will be generated from `prompt` input argument.
+            prompt_embeds_2 (`torch.Tensor`, *optional*):
+                Pre-generated glyph text embeddings from ByT5. If not provided, will be generated from `prompt` input
+                argument using self.tokenizer_2 and self.text_encoder_2.
+            prompt_embeds_mask_2 (`torch.Tensor`, *optional*):
+                Pre-generated glyph text mask from ByT5. If not provided, will be generated from `prompt` input
+                argument using self.tokenizer_2 and self.text_encoder_2.
+        """
+        dtype = dtype or self.text_encoder.dtype
+
+        if prompt is None:
+            prompt = [""] * batch_size
+        # Broadcast a single prompt string to batch_size so prompt and negative prompt
+        # can have different batch sizes.
+        elif isinstance(prompt, str):
+            prompt = [prompt] * batch_size
+
+        if prompt_embeds is None:
+            prompt_embeds, prompt_embeds_mask = self._get_mllm_prompt_embeds(
+                tokenizer=self.tokenizer,
+                text_encoder=self.text_encoder,
+                prompt=prompt,
+                device=device,
+                tokenizer_max_length=self.tokenizer_max_length,
+                system_message=self.system_message,
+                crop_start=self.prompt_template_encode_start_idx,
+            )
+
+        if prompt_embeds_2 is None:
+            prompt_embeds_2, prompt_embeds_mask_2 = self._get_byt5_prompt_embeds(
+                tokenizer=self.tokenizer_2,
+                text_encoder=self.text_encoder_2,
+                prompt=prompt,
+                device=device,
+                tokenizer_max_length=self.tokenizer_2_max_length,
+            )
+
+        _, seq_len, _ = prompt_embeds.shape
+        prompt_embeds = prompt_embeds.repeat(1, num_videos_per_prompt, 1)
+        prompt_embeds = prompt_embeds.view(batch_size * num_videos_per_prompt, seq_len, -1)
+        prompt_embeds_mask = prompt_embeds_mask.repeat(1, num_videos_per_prompt, 1)
+        prompt_embeds_mask = prompt_embeds_mask.view(batch_size * num_videos_per_prompt, seq_len)
+
+        _, seq_len_2, _ = prompt_embeds_2.shape
+        prompt_embeds_2 = prompt_embeds_2.repeat(1, num_videos_per_prompt, 1)
+        prompt_embeds_2 = prompt_embeds_2.view(batch_size * num_videos_per_prompt, seq_len_2, -1)
+        prompt_embeds_mask_2 = prompt_embeds_mask_2.repeat(1, num_videos_per_prompt, 1)
+        prompt_embeds_mask_2 = prompt_embeds_mask_2.view(
+            batch_size * num_videos_per_prompt, seq_len_2
+        )
+
+        prompt_embeds = prompt_embeds.to(dtype=dtype, device=device)
+        prompt_embeds_mask = prompt_embeds_mask.to(dtype=dtype, device=device)
+        prompt_embeds_2 = prompt_embeds_2.to(dtype=dtype, device=device)
+        prompt_embeds_mask_2 = prompt_embeds_mask_2.to(dtype=dtype, device=device)
+
+        return prompt_embeds, prompt_embeds_mask, prompt_embeds_2, prompt_embeds_mask_2
+
+    # Copied from HF
+    def prepare_cond_latents_and_mask(
+        self, latents, dtype: Optional[torch.dtype], device: Optional[torch.device]
+    ):
+        batch, channels, frames, height, width = latents.shape
+        cond_latents_concat = torch.zeros(
+            batch, channels, frames, height, width, dtype=dtype, device=device
+        )
+        mask_concat = torch.zeros(batch, 1, frames, height, width, dtype=dtype, device=device)
+        return cond_latents_concat, mask_concat
+
+    def _prepare_mask(self, latents, dtype: Optional[torch.dtype], device: Optional[torch.device]):
+        return torch.zeros(*latents.shape, dtype=dtype, device=device)
+
+    def _init_transformer(self) -> None:
+        """Initialize HunyuanVideo1.5 transformer with quantization support."""
+        logger.info("Creating HunyuanVideo1.5  transformer with quantization support...")
+        self.transformer = HunyuanVideo15Transformer3DModel(
+            model_config=self.pipeline_config.model_configs["transformer"]
+        )
+
+    def load_standard_components(
+        self,
+        checkpoint_dir: str,
+        device: torch.device,
+        skip_components: Optional[List] = None,
+        **kwargs,
+    ) -> None:
+        skip_components = skip_components or []
+
+        # Tokenizer (Qwen2Tokenizer)
+        if PipelineComponent.TOKENIZER not in skip_components:
+            logger.info("Loading tokenizer (Qwen2Tokenizer)...")
+            tokenizer_path = os.path.join(checkpoint_dir, PipelineComponent.TOKENIZER)
+            self.tokenizer = Qwen2Tokenizer.from_pretrained(
+                tokenizer_path, torch_dtype=self.pipeline_config.torch_dtype
+            )
+
+        # Tokenizer 2 (ByT5Tokenizer)
+        if PipelineComponent.TOKENIZER_2 not in skip_components:
+            logger.info("Loading tokenizer 2 (ByT5Tokenizer)...")
+            tokenizer_2_path = os.path.join(checkpoint_dir, PipelineComponent.TOKENIZER_2)
+            self.tokenizer_2 = ByT5Tokenizer.from_pretrained(
+                tokenizer_2_path, torch_dtype=self.pipeline_config.torch_dtype
+            )
+
+        # Text Encoder (Qwen2.5-VL-7B-Instruct)
+        if PipelineComponent.TEXT_ENCODER not in skip_components:
+            logger.info("Loading text encoder (Qwen2.5-VL-7B-Instruct)...")
+            text_encoder_path = os.path.join(checkpoint_dir, PipelineComponent.TEXT_ENCODER)
+            self.text_encoder = Qwen2_5_VLTextModel.from_pretrained(
+                text_encoder_path, torch_dtype=self.pipeline_config.torch_dtype
+            ).to(device)
+
+        # Text Encoder 2 (T5EncoderModel)
+        if PipelineComponent.TEXT_ENCODER_2 not in skip_components:
+            logger.info("Loading text encoder 2 (T5EncoderModel)...")
+            text_encoder_2_path = os.path.join(checkpoint_dir, PipelineComponent.TEXT_ENCODER_2)
+            self.text_encoder_2 = T5EncoderModel.from_pretrained(
+                text_encoder_2_path, torch_dtype=self.pipeline_config.torch_dtype
+            ).to(device)
+
+        # VAE (AutoencoderKLHunyuanVideo15)
+        if PipelineComponent.VAE not in skip_components:
+            logger.info("Loading VAE (AutoencoderKLHunyuanVideo15)...")
+            vae_path = os.path.join(checkpoint_dir, PipelineComponent.VAE)
+            self.vae = AutoencoderKLHunyuanVideo15.from_pretrained(
+                vae_path, torch_dtype=self.pipeline_config.torch_dtype
+            ).to(device)
+
+        # Scheduler (FlowMatchEulerDiscreteScheduler)
+        if PipelineComponent.SCHEDULER not in skip_components:
+            logger.info("Loading Scheduler (FlowMatchEulerDiscreteScheduler)...")
+            scheduler_path = os.path.join(checkpoint_dir, PipelineComponent.SCHEDULER)
+            self.scheduler = FlowMatchEulerDiscreteScheduler.from_pretrained(
+                scheduler_path, torch_dtype=self.pipeline_config.torch_dtype
+            )
+
+        if PipelineComponent.GUIDER not in skip_components:
+            logger.info("Loading Guider (ClassifierFreeGuidance)...")
+            guider_path = os.path.join(checkpoint_dir, PipelineComponent.GUIDER)
+            self.guider = ClassifierFreeGuidance.from_pretrained(
+                guider_path, torch_dtype=self.pipeline_config.torch_dtype
+            )
+
+        # HunyuanVideo-1.5 Config
+
+        # Default from HF
+        # fmt: off
+        self.system_message = "You are a helpful assistant. Describe the video by detailing the following aspects: \
+        1. The main content and theme of the video. \
+        2. The color, shape, size, texture, quantity, text, and spatial relationships of the objects. \
+        3. Actions, events, behaviors temporal relationships, physical movement changes of the objects. \
+        4. background environment, light, style and atmosphere. \
+        5. camera angles, movements, and transitions used in the video."
+        # fmt: on
+
+        self.vae_scale_factor_temporal = (
+            self.vae.temporal_compression_ratio if getattr(self, "vae", None) else 4
+        )
+        self.vae_scale_factor_spatial = (
+            self.vae.spatial_compression_ratio if getattr(self, "vae", None) else 16
+        )
+        self.video_processor = HunyuanVideo15ImageProcessor(
+            vae_scale_factor=self.vae_scale_factor_spatial
+        )
+        self.target_size = (
+            self.transformer.config.target_size if getattr(self, "transformer", None) else 640
+        )
+        self.vision_states_dim = (
+            self.transformer.config.image_embed_dim if getattr(self, "transformer", None) else 1152
+        )
+
+        self.num_channels_latents = (
+            self.vae.config.latent_channels if getattr(self, "vae", None) else 32
+        )
+        self.prompt_template_encode_start_idx = 108
+        self.tokenizer_max_length = 1000
+        self.tokenizer_2_max_length = 256
+        self.vision_num_semantic_tokens = 729
+        self.default_aspect_ratio = (16, 9)
+
+    # Copied from HF
+    def _prepare_latents(
+        self,
+        batch_size: int,
+        num_channels_latents: int = 32,
+        height: int = 720,
+        width: int = 1280,
+        num_frames: int = 129,
+        dtype: Optional[torch.dtype] = None,
+        device: Optional[torch.device] = None,
+        generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
+        latents: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if latents is not None:
+            return latents.to(device=device, dtype=dtype)
+
+        shape = (
+            batch_size,
+            num_channels_latents,
+            (num_frames - 1) // self.vae_scale_factor_temporal + 1,
+            int(height) // self.vae_scale_factor_spatial,
+            int(width) // self.vae_scale_factor_spatial,
+        )
+        if isinstance(generator, list) and len(generator) != batch_size:
+            raise ValueError(
+                f"You have passed a list of generators of length {len(generator)}, but requested an effective batch"
+                f" size of {batch_size}. Make sure the batch size matches the length of the generators."
+            )
+
+        latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
+        return latents
+
+    def _decode_latents(self, latents: torch.Tensor) -> torch.Tensor:
+        """Decode latents to a ``(B, T, H, W, C)`` uint8 video tensor."""
+
+        latents = latents.to(self.vae.dtype) / self.vae.config.scaling_factor
+        video = self.vae.decode(latents, return_dict=False)[0]
+        return postprocess_video_tensor(video)
+
+    @property
+    def device(self):
+        if self.transformer is not None:
+            return next(self.transformer.parameters()).device
+        return torch.device("cuda:0")
+
+    @property
+    def dtype(self):
+        return self.pipeline_config.torch_dtype
+
+    @property
+    def default_generation_params(self) -> dict:
+        """Model-specific defaults for None fields in VisualGenParams."""
+        return {
+            "height": 480,
+            "width": 832,
+            "num_inference_steps": 50,
+            "num_frames": 121,
+            "frame_rate": 24.0,
+        }
+
+    @property
+    def default_warmup_resolutions(self) -> List[Tuple[int, int]]:
+        # Only the 480p checkpoint is supported; 720p (1280) is not a multiple of
+        # resolution_multiple_of (32), so it would be skipped during warmup anyway.
+        return [(480, 832)]
+
+    @property
+    def default_warmup_num_frames(self) -> List[int]:
+        return [121]
+
+    @property
+    def resolution_multiple_of(self) -> Tuple[int, int]:
+        patch_size = self.transformer.config.patch_size if self.transformer is not None else 2
+        return (
+            self.vae_scale_factor_spatial * patch_size,
+            self.vae_scale_factor_spatial * patch_size,
+        )
+
+    def _run_warmup(self, height: int, width: int, num_frames: int, steps: int) -> None:
+        with torch.no_grad():
+            self.forward(
+                prompt="warmup",
+                seed=42,
+                height=height,
+                width=width,
+                negative_prompt="",
+                num_frames=num_frames,
+                num_inference_steps=steps,
+            )
+
+    def infer(self, req):
+        """Run inference from a DiffusionRequest (serve / high-level API path)."""
+        if req.params.image is not None:
+            raise ValueError(
+                "HunyuanVideo 1.5 currently supports text-to-video only; "
+                "image conditioning (I2V) is not supported."
+            )
+        return self.forward(
+            prompt=req.prompt,
+            seed=req.params.seed,
+            height=req.params.height,
+            width=req.params.width,
+            negative_prompt=req.params.negative_prompt,
+            num_frames=req.params.num_frames,
+            num_inference_steps=req.params.num_inference_steps,
+            num_videos_per_prompt=req.params.num_images_per_prompt,
+        )
+
+    @torch.inference_mode()
+    def forward(
+        self,
+        prompt: Union[str, List[str]],
+        seed: int,
+        height: int,
+        width: int,
+        negative_prompt: Union[str, List[str]] = None,
+        num_frames: int = 121,
+        num_inference_steps: int = 50,
+        num_videos_per_prompt: int = 1,
+        sigmas: Optional[List[float]] = None,
+        output_type: Optional[str] = "np",
+        prompt_embeds: Optional[torch.Tensor] = None,
+        prompt_embeds_mask: Optional[torch.Tensor] = None,
+        negative_prompt_embeds: Optional[torch.Tensor] = None,
+        negative_prompt_embeds_mask: Optional[torch.Tensor] = None,
+        prompt_embeds_2: Optional[torch.Tensor] = None,
+        prompt_embeds_mask_2: Optional[torch.Tensor] = None,
+        negative_prompt_embeds_2: Optional[torch.Tensor] = None,
+        negative_prompt_embeds_mask_2: Optional[torch.Tensor] = None,
+        latents: Optional[torch.Tensor] = None,
+    ):
+        pipeline_start = time.time()
+        timer = CudaPhaseTimer()
+        timer.mark_pre_start()
+
+        if isinstance(prompt, str):
+            batch_size = 1
+        elif isinstance(prompt, list):
+            batch_size = len(prompt)
+        else:
+            batch_size = prompt_embeds.shape[0]
+
+        if num_videos_per_prompt < 1:
+            raise ValueError(f"num_videos_per_prompt must be >= 1, got {num_videos_per_prompt}")
+
+        # Batch generation is unsupported upstream: the diffusers HunyuanVideo1.5 VAE builds a
+        # causal attention mask without a head dimension, so scaled_dot_product_attention fails
+        # for an effective batch > 1.
+        effective_batch_size = batch_size * num_videos_per_prompt
+        if effective_batch_size > 1:
+            raise ValueError(
+                "HunyuanVideo1.5 currently supports an effective batch size of 1 only "
+                f"(batch_size={batch_size}, num_videos_per_prompt={num_videos_per_prompt})."
+            )
+
+        generator = torch.Generator(device=self.device).manual_seed(seed)
+
+        device = self.device
+
+        # 1. Encode
+        prompt_embeds, prompt_embeds_mask, prompt_embeds_2, prompt_embeds_mask_2 = (
+            self._encode_prompt(
+                prompt=prompt,
+                device=device,
+                dtype=self.dtype,
+                batch_size=batch_size,
+                num_videos_per_prompt=num_videos_per_prompt,
+                prompt_embeds=prompt_embeds,
+                prompt_embeds_mask=prompt_embeds_mask,
+                prompt_embeds_2=prompt_embeds_2,
+                prompt_embeds_mask_2=prompt_embeds_mask_2,
+            )
+        )
+
+        # 2. Guidance
+        do_cfg = self.guider._enabled and self.guider.num_conditions > 1
+        if do_cfg:
+            (
+                negative_prompt_embeds,
+                negative_prompt_embeds_mask,
+                negative_prompt_embeds_2,
+                negative_prompt_embeds_mask_2,
+            ) = self._encode_prompt(
+                prompt=negative_prompt,
+                device=device,
+                dtype=self.dtype,
+                batch_size=batch_size,
+                num_videos_per_prompt=num_videos_per_prompt,
+                prompt_embeds=negative_prompt_embeds,
+                prompt_embeds_mask=negative_prompt_embeds_mask,
+                prompt_embeds_2=negative_prompt_embeds_2,
+                prompt_embeds_mask_2=negative_prompt_embeds_mask_2,
+            )
+
+        # 3. Timesteps
+        sigmas = np.linspace(1.0, 0.0, num_inference_steps + 1)[:-1] if sigmas is None else sigmas
+        timesteps, num_inference_steps = retrieve_timesteps(
+            self.scheduler, num_inference_steps, device, sigmas=sigmas
+        )
+
+        # 4. Latents
+        latents = self._prepare_latents(
+            batch_size * num_videos_per_prompt,
+            self.num_channels_latents,
+            height,
+            width,
+            num_frames,
+            self.dtype,
+            device,
+            generator,
+            latents,
+        )
+
+        cond_latents_concat, mask_concat = self.prepare_cond_latents_and_mask(
+            latents, self.dtype, device
+        )
+        image_embeds = torch.zeros(
+            batch_size,
+            self.vision_num_semantic_tokens,
+            self.vision_states_dim,
+            dtype=self.dtype,
+            device=device,
+        )
+
+        # 5. Run Transformer
+        self._num_timesteps = len(timesteps)
+
+        def forward_fn(
+            latents, extra_stream_latents, timestep, encoder_hidden_states, extra_tensors
+        ):
+            # Concatenate the conditioning latents and binary mask onto the channel
+            # dim to build the transformer input (in_channels = latent channels +
+            # cond latent channels + mask channel). denoise() has already selected
+            # the correct cond/uncond branch for every entry in extra_tensors.
+            latent_model_input = torch.cat(
+                [latents, extra_tensors["cond_latents_concat"], extra_tensors["mask_concat"]],
+                dim=1,
+            )
+
+            noise_pred = self.transformer(
+                hidden_states=latent_model_input,
+                timestep=timestep,
+                encoder_hidden_states=encoder_hidden_states,
+                encoder_attention_mask=extra_tensors["encoder_attention_mask"],
+                encoder_hidden_states_2=extra_tensors["encoder_hidden_states_2"],
+                encoder_attention_mask_2=extra_tensors["encoder_attention_mask_2"],
+                image_embeds=extra_tensors["image_embeds"],
+                return_dict=False,
+            )[0]
+            return noise_pred
+
+        timer.mark_denoise_start()
+        # Route every per-batch conditioning input through ``extra_cfg_tensors``
+        # so it flows via the same (conditional, unconditional) channel that
+        # classifier-free guidance will use. With guidance disabled the negative
+        # entry is unused; tensors that are shared across cond/uncond pass the
+        # same tensor for both so they duplicate correctly once CFG is enabled.
+        latents = self.denoise(
+            latents,
+            self.scheduler,
+            prompt_embeds=prompt_embeds,
+            neg_prompt_embeds=negative_prompt_embeds if do_cfg else None,
+            guidance_scale=self.guider.guidance_scale if do_cfg else 1.0,
+            guidance_rescale=self.guider.guidance_rescale if do_cfg else 0.0,
+            forward_fn=forward_fn,
+            extra_cfg_tensors={
+                "encoder_attention_mask": (prompt_embeds_mask, negative_prompt_embeds_mask),
+                "encoder_hidden_states_2": (prompt_embeds_2, negative_prompt_embeds_2),
+                "encoder_attention_mask_2": (prompt_embeds_mask_2, negative_prompt_embeds_mask_2),
+                "image_embeds": (image_embeds, image_embeds),
+                "cond_latents_concat": (cond_latents_concat, cond_latents_concat),
+                "mask_concat": (mask_concat, mask_concat),
+            },
+        )
+        timer.mark_post_start()
+
+        # 6. Decode
+        logger.info("Decoding image...")
+        decode_start = time.time()
+
+        if output_type != "latent":
+            video = self.decode_latents(latents, self._decode_latents)
+        else:
+            video = latents
+
+        if self.rank == 0:
+            logger.info(f"Image decoded in {time.time() - decode_start:.2f}s")
+            logger.info(f"Total pipeline time: {time.time() - pipeline_start:.2f}s")
+
+        timer.mark_end()
+        return timer.fill(PipelineOutput(video=video, frame_rate=24.0))
+
+    def load_weights(self, weights: dict) -> None:
+        """Load transformer weights."""
+        if self.transformer is not None and hasattr(self.transformer, "load_weights"):
+            logger.info("Loading transformer weights...")
+            transformer_weights = weights.get("transformer", weights)
+            self.transformer.load_weights(transformer_weights)
+            logger.info("Transformer weights loaded successfully.")
+
+        self._target_dtype = self.pipeline_config.torch_dtype
+
+        if self.transformer is not None:
+            self.transformer.eval()

--- a/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/pipeline_hunyuan_video1_5.py
+++ b/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/pipeline_hunyuan_video1_5.py
@@ -702,7 +702,7 @@ class HunyuanVideo15Pipeline(BasePipeline):
 
             noise_pred = self.transformer(
                 hidden_states=latent_model_input,
-                timestep=timestep,
+                timestep=timestep / self.scheduler.config.num_train_timesteps,
                 encoder_hidden_states=encoder_hidden_states,
                 encoder_attention_mask=extra_tensors["encoder_attention_mask"],
                 encoder_hidden_states_2=extra_tensors["encoder_hidden_states_2"],

--- a/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/timestep_embedding.py
+++ b/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/timestep_embedding.py
@@ -1,5 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import torch
 from diffusers.models.embeddings import PixArtAlphaTextProjection, TimestepEmbedding, Timesteps
 

--- a/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/timestep_embedding.py
+++ b/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/timestep_embedding.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import torch
+from diffusers.models.embeddings import PixArtAlphaTextProjection, TimestepEmbedding, Timesteps
+
+
+class CombinedTimestepTextProjEmbeddings(torch.nn.Module):
+    def __init__(self, embedding_dim, pooled_projection_dim):
+        super().__init__()
+
+        self.time_proj = Timesteps(num_channels=256, flip_sin_to_cos=True, downscale_freq_shift=0)
+        self.timestep_embedder = TimestepEmbedding(in_channels=256, time_embed_dim=embedding_dim)
+        self.text_embedder = PixArtAlphaTextProjection(
+            pooled_projection_dim, embedding_dim, act_fn="silu"
+        )
+
+    def forward(self, timestep, pooled_projection):
+        timesteps_proj = self.time_proj(timestep)
+        timesteps_emb = self.timestep_embedder(
+            timesteps_proj.to(dtype=pooled_projection.dtype)
+        )  # (N, D)
+
+        pooled_projections = self.text_embedder(pooled_projection)
+
+        conditioning = timesteps_emb + pooled_projections
+
+        return conditioning
+
+
+class CombinedTimestepGuidanceTextProjEmbeddings(torch.nn.Module):
+    def __init__(self, embedding_dim, pooled_projection_dim):
+        super().__init__()
+
+        self.time_proj = Timesteps(num_channels=256, flip_sin_to_cos=True, downscale_freq_shift=0)
+        self.timestep_embedder = TimestepEmbedding(in_channels=256, time_embed_dim=embedding_dim)
+        self.guidance_embedder = TimestepEmbedding(in_channels=256, time_embed_dim=embedding_dim)
+        self.text_embedder = PixArtAlphaTextProjection(
+            pooled_projection_dim, embedding_dim, act_fn="silu"
+        )
+
+    def forward(self, timestep, guidance, pooled_projection):
+        timesteps_proj = self.time_proj(timestep)
+        timesteps_emb = self.timestep_embedder(
+            timesteps_proj.to(dtype=pooled_projection.dtype)
+        )  # (N, D)
+
+        guidance_proj = self.time_proj(guidance)
+        guidance_emb = self.guidance_embedder(
+            guidance_proj.to(dtype=pooled_projection.dtype)
+        )  # (N, D)
+
+        time_guidance_emb = timesteps_emb + guidance_emb
+
+        pooled_projections = self.text_embedder(pooled_projection)
+        conditioning = time_guidance_emb + pooled_projections
+
+        return conditioning

--- a/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/transformer_hunyuan_video1_5.py
+++ b/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/transformer_hunyuan_video1_5.py
@@ -1,0 +1,1184 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import torch
+import torch.nn.functional as F
+from diffusers.models.modeling_outputs import Transformer2DModelOutput
+
+# Some existing Hunyuan components can be imported from HF, as they are trivial.
+# However, HunyuanVideo15ImageProjection, HunyuanVideo15TokenRefiner, and
+# HunyuanVideo15ByT5TextProjection must be reimplemented to avoid meta tensor errors.
+from diffusers.models.transformers.transformer_hunyuan_video15 import (
+    HunyuanVideo15PatchEmbed,
+    HunyuanVideo15TimeEmbedding,
+)
+from tqdm import tqdm
+
+from tensorrt_llm._torch.modules.embedding import Embedding
+from tensorrt_llm._torch.modules.layer_norm import LayerNorm
+from tensorrt_llm._torch.modules.linear import Linear
+from tensorrt_llm._torch.modules.mlp import MLP
+from tensorrt_llm._torch.modules.rms_norm import RMSNorm
+from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig
+from tensorrt_llm._torch.visual_gen.models.modeling import BaseDiffusionModel
+from tensorrt_llm._torch.visual_gen.modules.attention import Attention, QKVMode
+from tensorrt_llm._torch.visual_gen.quantization.loader import DynamicLinearWeightLoader
+from tensorrt_llm._torch.visual_gen.utils import SequenceSharder
+from tensorrt_llm.models.modeling_utils import QuantConfig
+
+from .timestep_embedding import CombinedTimestepTextProjEmbeddings
+
+_WEIGHT_KEY_REMAPS = [
+    (".net.0.proj.", ".up_proj."),
+    (".net.2.", ".down_proj."),
+]
+
+
+# Torch compiler disable is here based on Qwen Image
+@torch.compiler.disable
+def _gelu_tanh_eager(x: torch.Tensor) -> torch.Tensor:
+    return F.gelu(x, approximate="tanh")
+
+
+# Copied from HF
+def _apply_rotary_emb(x: torch.Tensor, freqs_cis: Tuple[torch.Tensor, torch.Tensor]):
+    cos, sin = freqs_cis  # [S, D]
+    cos = cos[None, :, None, :]  # sequence_dim=1 -> [1, S, 1, D]
+    sin = sin[None, :, None, :]
+    cos, sin = cos.to(x.device), sin.to(x.device)
+
+    x_real, x_imag = x.reshape(*x.shape[:-1], -1, 2).unbind(-1)  # [B, S, H, D//2]
+    x_rotated = torch.stack([-x_imag, x_real], dim=-1).flatten(3)
+    return (x.float() * cos + x_rotated.float() * sin).to(x.dtype)
+
+
+def _get_1d_rotary_pos_embed(
+    dim: int,
+    pos: torch.Tensor,
+    theta: float = 10000.0,
+    freqs_dtype: torch.dtype = torch.float32,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    assert dim % 2 == 0
+    freqs = 1.0 / (
+        theta ** (torch.arange(0, dim, 2, dtype=freqs_dtype, device=pos.device) / dim)
+    )  # [D/2]
+    freqs = torch.outer(pos, freqs)  # [S, D/2]
+    freqs_cos = freqs.cos().repeat_interleave(2, dim=1, output_size=freqs.shape[1] * 2).float()
+    freqs_sin = freqs.sin().repeat_interleave(2, dim=1, output_size=freqs.shape[1] * 2).float()
+    return freqs_cos, freqs_sin
+
+
+class HunyuanVideo15RotaryPosEmbed(torch.nn.Module):
+    def __init__(
+        self, patch_size: int, patch_size_t: int, rope_dim: List[int], theta: float = 256.0
+    ) -> None:
+        super().__init__()
+        self.patch_size = patch_size
+        self.patch_size_t = patch_size_t
+        self.rope_dim = rope_dim
+        self.theta = theta
+
+    def forward(self, hidden_states: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        _, _, num_frames, height, width = hidden_states.shape
+        rope_sizes = [
+            num_frames // self.patch_size_t,
+            height // self.patch_size,
+            width // self.patch_size,
+        ]
+
+        axes_grids = [
+            torch.arange(0, size, device=hidden_states.device, dtype=torch.float32)
+            for size in rope_sizes
+        ]
+        grid = torch.meshgrid(*axes_grids, indexing="ij")  # [T, H, W]
+        grid = torch.stack(grid, dim=0)  # [3, T, H, W]
+
+        freqs = [
+            _get_1d_rotary_pos_embed(self.rope_dim[i], grid[i].reshape(-1), self.theta)
+            for i in range(3)
+        ]
+
+        freqs_cos = torch.cat([f[0] for f in freqs], dim=1)  # [T * H * W, D / 2]
+        freqs_sin = torch.cat([f[1] for f in freqs], dim=1)  # [T * H * W, D / 2]
+        return freqs_cos, freqs_sin
+
+
+class HunyuanVideo15FeedForward(MLP):
+    """TRT-LLM MLP with HunyuanVideo1.5 GELU activation."""
+
+    def __init__(
+        self,
+        dim: int,
+        mult: float = 4.0,
+        activation_fn: str = "gelu-approximate",
+        dtype: Optional[torch.dtype] = None,
+        model_config: Optional[DiffusionModelConfig] = None,
+        layer_idx: Optional[int] = None,
+    ) -> None:
+        if activation_fn == "gelu-approximate":
+            activation = _gelu_tanh_eager
+        elif activation_fn == "linear-silu":
+            activation = F.silu
+        else:
+            raise ValueError(
+                f"Unsupported activation_fn={activation_fn} for HunyuanVideo15FeedForward; "
+                "only 'gelu-approximate' and 'linear-silu' are used."
+            )
+        if dtype is None and model_config is not None:
+            dtype = model_config.torch_dtype
+        super().__init__(
+            hidden_size=dim,
+            intermediate_size=int(dim * mult),
+            bias=True,
+            activation=activation,
+            dtype=dtype,
+            config=model_config,
+            layer_idx=layer_idx,
+            reduce_output=False,
+        )
+
+
+def _aux_linear(
+    in_features: int,
+    out_features: int,
+    bias: bool = True,
+    model_config: Optional[DiffusionModelConfig] = None,
+) -> Linear:
+    """Build a quant-aware Linear for an auxiliary (non-block) projection."""
+    return Linear(
+        in_features,
+        out_features,
+        bias=bias,
+        dtype=model_config.torch_dtype if model_config else None,
+        quant_config=model_config.quant_config if model_config else None,
+        skip_create_weights_in_init=(
+            model_config.skip_create_weights_in_init if model_config else False
+        ),
+        force_dynamic_quantization=(
+            model_config.force_dynamic_quantization if model_config else False
+        ),
+    )
+
+
+def _remap_checkpoint_keys(weights: dict) -> dict:
+    """Remap HuggingFace checkpoint keys to our module attribute names.
+
+    HF diffusers uses nn.ModuleList wrappers that add numeric indices to
+    weight key paths. Our simplified module structure uses plain attributes,
+    so we translate the keys at load time.
+    """
+    remapped = {}
+    for key, value in weights.items():
+        new_key = key
+        for old, new in _WEIGHT_KEY_REMAPS:
+            new_key = new_key.replace(old, new)
+        remapped[new_key] = value
+    return remapped
+
+
+class HunyuanVideo15AdaLayerNormZero(torch.nn.Module):
+    """TRT-LLM replacement for diffusers AdaLayerNormZero."""
+
+    def __init__(
+        self,
+        embedding_dim: int,
+        model_config: Optional[DiffusionModelConfig] = None,
+    ) -> None:
+        super().__init__()
+        self.silu = torch.nn.SiLU()
+        self.linear = _aux_linear(embedding_dim, 6 * embedding_dim, model_config=model_config)
+
+        # Kept elementwise_affine=False LayerNorms as torch equivalent
+        self.norm = torch.nn.LayerNorm(embedding_dim, elementwise_affine=False, eps=1e-6)
+
+    def forward(
+        self, x: torch.Tensor, emb: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        emb = self.linear(self.silu(emb))
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = emb.chunk(6, dim=1)
+        x = self.norm(x) * (1 + scale_msa[:, None]) + shift_msa[:, None]
+        return x, gate_msa, shift_mlp, scale_mlp, gate_mlp
+
+
+class HunyuanVideo15AdaLayerNormContinuous(torch.nn.Module):
+    """TRT-LLM replacement for diffusers AdaLayerNormContinuous."""
+
+    def __init__(
+        self,
+        embedding_dim: int,
+        conditioning_embedding_dim: int,
+        elementwise_affine: bool = False,
+        eps: float = 1e-6,
+        model_config: Optional[DiffusionModelConfig] = None,
+    ) -> None:
+        super().__init__()
+        self.silu = torch.nn.SiLU()
+        self.linear = _aux_linear(
+            conditioning_embedding_dim, embedding_dim * 2, model_config=model_config
+        )
+        self.norm = torch.nn.LayerNorm(
+            embedding_dim, eps=eps, elementwise_affine=elementwise_affine
+        )
+
+    def forward(self, x: torch.Tensor, conditioning_embedding: torch.Tensor) -> torch.Tensor:
+        emb = self.linear(self.silu(conditioning_embedding).to(x.dtype))
+        scale, shift = torch.chunk(emb, 2, dim=1)
+        x = self.norm(x) * (1 + scale)[:, None, :] + shift[:, None, :]
+        return x
+
+
+class HunyuanVideo15ImageProjection(torch.nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        hidden_size: int,
+        model_config: Optional[DiffusionModelConfig] = None,
+    ):
+        super().__init__()
+        # LayerNorm uses eps=1e-5 to match torch implementation
+        self.norm_in = LayerNorm(hidden_size=in_channels, eps=1e-5)
+        self.linear_1 = _aux_linear(in_channels, in_channels, model_config=model_config)
+        self.act_fn = F.gelu
+        self.linear_2 = _aux_linear(in_channels, hidden_size, model_config=model_config)
+        self.norm_out = LayerNorm(hidden_size=hidden_size, eps=1e-5)
+
+    def forward(self, image_embeds: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.norm_in(image_embeds)
+        hidden_states = self.linear_1(hidden_states)
+        hidden_states = self.act_fn(hidden_states)
+        hidden_states = self.linear_2(hidden_states)
+        hidden_states = self.norm_out(hidden_states)
+        return hidden_states
+
+
+class HunyuanVideo15AdaNorm(torch.nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        out_features: Optional[int] = None,
+        model_config: Optional[DiffusionModelConfig] = None,
+    ) -> None:
+        super().__init__()
+
+        out_features = out_features or 2 * in_features
+        self.linear = _aux_linear(in_features, out_features, model_config=model_config)
+        self.nonlinearity = F.silu
+
+    def forward(
+        self, temb: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        temb = self.linear(self.nonlinearity(temb))
+        gate_msa, gate_mlp = temb.chunk(2, dim=1)
+        gate_msa, gate_mlp = gate_msa.unsqueeze(1), gate_mlp.unsqueeze(1)
+        return gate_msa, gate_mlp
+
+
+class HunyuanVideo15RefinerAttention(Attention):
+    """Token-refiner self-attention"""
+
+    def __init__(
+        self,
+        dim: int,
+        num_attention_heads: int,
+        attention_head_dim: int,
+        bias: bool = True,
+        model_config: Optional[DiffusionModelConfig] = None,
+    ) -> None:
+        super().__init__(
+            hidden_size=dim,
+            num_attention_heads=num_attention_heads,
+            head_dim=attention_head_dim,
+            qkv_mode=QKVMode.FUSE_QKV,
+            qk_norm=False,
+            bias=bias,
+            config=model_config or DiffusionModelConfig(),
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        key_padding_mask = attention_mask.bool() if attention_mask is not None else None
+        q, k, v = self.get_qkv(hidden_states)
+        out = self._attn_impl(q, k, v, key_padding_mask=key_padding_mask)
+        return self.to_out[0](out)
+
+
+class HunyuanVideo15IndividualTokenRefinerBlock(torch.nn.Module):
+    def __init__(
+        self,
+        num_attention_heads: int,
+        attention_head_dim: int,
+        mlp_width_ratio: str = 4.0,
+        mlp_drop_rate: float = 0.0,
+        attention_bias: bool = True,
+        model_config: Optional[DiffusionModelConfig] = None,
+    ) -> None:
+        super().__init__()
+
+        hidden_size = num_attention_heads * attention_head_dim
+
+        # has_weights and has_bias are equivalent to torch's elementwise_affine
+        self.norm1 = LayerNorm(hidden_size=hidden_size, has_weights=True, has_bias=True, eps=1e-6)
+        self.attn = HunyuanVideo15RefinerAttention(
+            dim=hidden_size,
+            num_attention_heads=num_attention_heads,
+            attention_head_dim=attention_head_dim,
+            bias=attention_bias,
+            model_config=model_config,
+        )
+
+        self.norm2 = LayerNorm(hidden_size=hidden_size, has_weights=True, has_bias=True, eps=1e-6)
+        self.ff = HunyuanVideo15FeedForward(
+            hidden_size,
+            mult=mlp_width_ratio,
+            activation_fn="linear-silu",
+            model_config=model_config,
+        )
+
+        self.norm_out = HunyuanVideo15AdaNorm(
+            hidden_size, 2 * hidden_size, model_config=model_config
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        temb: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        norm_hidden_states = self.norm1(hidden_states)
+
+        attn_output = self.attn(
+            hidden_states=norm_hidden_states,
+            attention_mask=attention_mask,
+        )
+
+        gate_msa, gate_mlp = self.norm_out(temb)
+        hidden_states = hidden_states + attn_output * gate_msa
+
+        ff_output = self.ff(self.norm2(hidden_states))
+        hidden_states = hidden_states + ff_output * gate_mlp
+
+        return hidden_states
+
+
+class HunyuanVideo15IndividualTokenRefiner(torch.nn.Module):
+    def __init__(
+        self,
+        num_attention_heads: int,
+        attention_head_dim: int,
+        num_layers: int,
+        mlp_width_ratio: float = 4.0,
+        mlp_drop_rate: float = 0.0,
+        attention_bias: bool = True,
+        model_config: Optional[DiffusionModelConfig] = None,
+    ) -> None:
+        super().__init__()
+
+        self.refiner_blocks = torch.nn.ModuleList(
+            [
+                HunyuanVideo15IndividualTokenRefinerBlock(
+                    num_attention_heads=num_attention_heads,
+                    attention_head_dim=attention_head_dim,
+                    mlp_width_ratio=mlp_width_ratio,
+                    mlp_drop_rate=mlp_drop_rate,
+                    attention_bias=attention_bias,
+                    model_config=model_config,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        temb: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+    ) -> None:
+        # The VisualGen attention backend masks padded keys via a [B, S]
+        # key_padding_mask (valid query rows then attend only to valid keys,
+        # matching the diffusers 2D mask for the tokens kept downstream).
+        key_padding_mask = None
+        if attention_mask is not None:
+            key_padding_mask = attention_mask.to(hidden_states.device).bool()
+
+        for block in self.refiner_blocks:
+            hidden_states = block(hidden_states, temb, key_padding_mask)
+
+        return hidden_states
+
+
+class HunyuanVideo15TokenRefiner(torch.nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        num_attention_heads: int,
+        attention_head_dim: int,
+        num_layers: int,
+        mlp_ratio: float = 4.0,
+        mlp_drop_rate: float = 0.0,
+        attention_bias: bool = True,
+        model_config: Optional[DiffusionModelConfig] = None,
+    ) -> None:
+        super().__init__()
+
+        hidden_size = num_attention_heads * attention_head_dim
+
+        self.time_text_embed = CombinedTimestepTextProjEmbeddings(
+            embedding_dim=hidden_size, pooled_projection_dim=in_channels
+        )
+        self.proj_in = _aux_linear(in_channels, hidden_size, bias=True, model_config=model_config)
+        self.token_refiner = HunyuanVideo15IndividualTokenRefiner(
+            num_attention_heads=num_attention_heads,
+            attention_head_dim=attention_head_dim,
+            num_layers=num_layers,
+            mlp_width_ratio=mlp_ratio,
+            mlp_drop_rate=mlp_drop_rate,
+            attention_bias=attention_bias,
+            model_config=model_config,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.LongTensor,
+        attention_mask: Optional[torch.LongTensor] = None,
+    ) -> torch.Tensor:
+        if attention_mask is None:
+            pooled_projections = hidden_states.mean(dim=1)
+        else:
+            original_dtype = hidden_states.dtype
+            mask_float = attention_mask.float().unsqueeze(-1)
+            pooled_projections = (hidden_states * mask_float).sum(dim=1) / mask_float.sum(dim=1)
+            pooled_projections = pooled_projections.to(original_dtype)
+
+        temb = self.time_text_embed(timestep, pooled_projections)
+        hidden_states = self.proj_in(hidden_states)
+        hidden_states = self.token_refiner(hidden_states, temb, attention_mask)
+
+        return hidden_states
+
+
+class HunyuanVideo15ByT5TextProjection(torch.nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        hidden_size: int,
+        out_features: int,
+        model_config: Optional[DiffusionModelConfig] = None,
+    ):
+        super().__init__()
+        # Use eps=1e-5 for torch parity
+        self.norm = LayerNorm(hidden_size=in_features, eps=1e-5)
+        self.linear_1 = _aux_linear(in_features, hidden_size, model_config=model_config)
+        self.linear_2 = _aux_linear(hidden_size, hidden_size, model_config=model_config)
+        self.linear_3 = _aux_linear(hidden_size, out_features, model_config=model_config)
+        self.act_fn = F.gelu
+
+    def forward(self, encoder_hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = self.norm(encoder_hidden_states)
+        hidden_states = self.linear_1(hidden_states)
+        hidden_states = self.act_fn(hidden_states)
+        hidden_states = self.linear_2(hidden_states)
+        hidden_states = self.act_fn(hidden_states)
+        hidden_states = self.linear_3(hidden_states)
+        return hidden_states
+
+
+class HunyuanVideo15Attention(Attention):
+    def __init__(
+        self,
+        dim: int,
+        num_attention_heads: int,
+        attention_head_dim: int,
+        eps: float = 1e-6,
+        dtype: Optional[torch.dtype] = None,
+        config: Optional[DiffusionModelConfig] = None,
+        layer_idx: int = 0,
+    ):
+        config = config or DiffusionModelConfig()
+        super().__init__(
+            num_attention_heads=num_attention_heads,
+            head_dim=attention_head_dim,
+            hidden_size=dim,
+            config=config,
+            qk_norm_mode="per_head",
+            qkv_mode=QKVMode.FUSE_QKV,
+            qk_norm=True,
+        )
+
+        self.heads = num_attention_heads
+        self.head_dim = attention_head_dim
+
+        self.add_q_proj = Linear(
+            dim,
+            dim,
+            bias=True,
+            dtype=dtype,
+            mapping=self.mapping,
+            quant_config=self.quant_config,
+            skip_create_weights_in_init=self.skip_create_weights_in_init,
+            force_dynamic_quantization=self.force_dynamic_quantization,
+        )
+        self.add_k_proj = Linear(
+            dim,
+            dim,
+            bias=True,
+            dtype=dtype,
+            mapping=self.mapping,
+            quant_config=self.quant_config,
+            skip_create_weights_in_init=self.skip_create_weights_in_init,
+            force_dynamic_quantization=self.force_dynamic_quantization,
+        )
+        self.add_v_proj = Linear(
+            dim,
+            dim,
+            bias=True,
+            dtype=dtype,
+            mapping=self.mapping,
+            quant_config=self.quant_config,
+            skip_create_weights_in_init=self.skip_create_weights_in_init,
+            force_dynamic_quantization=self.force_dynamic_quantization,
+        )
+
+        # QK-norms, applied per-head on the head_dim.
+        self.norm_added_q = RMSNorm(
+            hidden_size=attention_head_dim, eps=eps, dtype=dtype, has_weights=True
+        )
+        self.norm_added_k = RMSNorm(
+            hidden_size=attention_head_dim, eps=eps, dtype=dtype, has_weights=True
+        )
+
+        self.to_out = torch.nn.ModuleList(
+            [
+                Linear(
+                    dim,
+                    dim,
+                    bias=True,
+                    dtype=dtype,
+                    mapping=self.mapping,
+                    quant_config=self.quant_config,
+                    skip_create_weights_in_init=self.skip_create_weights_in_init,
+                    force_dynamic_quantization=self.force_dynamic_quantization,
+                ),
+                torch.nn.Dropout(0.0),
+            ]
+        )
+        self.to_add_out = Linear(
+            dim,
+            dim,
+            bias=True,
+            dtype=dtype,
+            mapping=self.mapping,
+            quant_config=self.quant_config,
+            skip_create_weights_in_init=self.skip_create_weights_in_init,
+            force_dynamic_quantization=self.force_dynamic_quantization,
+        )
+
+    @staticmethod
+    def _head_norm(norm: torch.nn.Module, x: torch.Tensor) -> torch.Tensor:
+        # flashinfer RMSNorm only supports 2D/3D inputs; collapse the batch and
+        # sequence dims so a 4D (B, S, H, D) tensor becomes 3D (B*S, H, D) before
+        # the per-head norm over the head dim, then restore the original shape.
+        b, s, h, d = x.shape
+        return norm(x.reshape(b * s, h, d)).reshape(b, s, h, d)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        image_rotary_emb: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        # QKV Proj
+        query, key, value = self.get_qkv(hidden_states)
+        query = query.unflatten(2, (self.heads, -1))
+        key = key.unflatten(2, (self.heads, -1))
+        value = value.unflatten(2, (self.heads, -1))
+
+        # QK Normalization
+        if self.qk_norm:
+            query = self._head_norm(self.norm_q, query)
+            key = self._head_norm(self.norm_k, key)
+
+        # Rotary Embedding Application
+        if image_rotary_emb is not None:
+            query = _apply_rotary_emb(query, image_rotary_emb)
+            key = _apply_rotary_emb(key, image_rotary_emb)
+
+        # Encoder condition QKV projection and normalization
+        if encoder_hidden_states is not None:
+            encoder_query = self.add_q_proj(encoder_hidden_states)
+            encoder_key = self.add_k_proj(encoder_hidden_states)
+            encoder_value = self.add_v_proj(encoder_hidden_states)
+
+            encoder_query = encoder_query.unflatten(2, (self.heads, -1))
+            encoder_key = encoder_key.unflatten(2, (self.heads, -1))
+            encoder_value = encoder_value.unflatten(2, (self.heads, -1))
+
+            encoder_query = self._head_norm(self.norm_added_q, encoder_query)
+            encoder_key = self._head_norm(self.norm_added_k, encoder_key)
+
+            query = torch.cat([query, encoder_query], dim=1)
+            key = torch.cat([key, encoder_key], dim=1)
+            value = torch.cat([value, encoder_value], dim=1)
+
+        batch_size, seq_len, *_ = query.shape
+        key_padding_mask = torch.nn.functional.pad(
+            attention_mask, (seq_len - attention_mask.shape[1], 0), value=True
+        ).bool()
+
+        hidden_states = self._attn_impl(query, key, value, key_padding_mask=key_padding_mask)
+
+        # hidden_states = hidden_states.flatten(2, 3)
+        hidden_states = hidden_states.to(query.dtype)
+
+        if encoder_hidden_states is not None:
+            hidden_states, encoder_hidden_states = (
+                hidden_states[:, : -encoder_hidden_states.shape[1]],
+                hidden_states[:, -encoder_hidden_states.shape[1] :],
+            )
+
+            hidden_states = self.to_out[0](hidden_states)
+            hidden_states = self.to_out[1](hidden_states)
+            encoder_hidden_states = self.to_add_out(encoder_hidden_states)
+
+        return hidden_states, encoder_hidden_states
+
+
+class HunyuanVideo15TransformerBlock(torch.nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_attention_heads: int,
+        attention_head_dim: int,
+        mlp_ratio: float,
+        eps: float = 1e-6,
+        dtype: Optional[torch.dtype] = None,
+        config: Optional[DiffusionModelConfig] = None,
+        layer_idx=0,
+        qk_norm: str = "rms_norm",
+    ) -> None:
+        super().__init__()
+
+        hidden_size = num_attention_heads * attention_head_dim
+
+        self.norm1 = HunyuanVideo15AdaLayerNormZero(hidden_size, model_config=config)
+        self.norm1_context = HunyuanVideo15AdaLayerNormZero(hidden_size, model_config=config)
+
+        self.attn = HunyuanVideo15Attention(
+            dim, num_attention_heads, attention_head_dim, eps, dtype, config, layer_idx
+        )
+
+        self.norm2 = torch.nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
+        self.ff = HunyuanVideo15FeedForward(
+            hidden_size,
+            mult=mlp_ratio,
+            activation_fn="gelu-approximate",
+            dtype=dtype,
+            model_config=config,
+            layer_idx=layer_idx,
+        )
+
+        self.norm2_context = torch.nn.LayerNorm(hidden_size, elementwise_affine=False, eps=1e-6)
+        self.ff_context = HunyuanVideo15FeedForward(
+            hidden_size,
+            mult=mlp_ratio,
+            activation_fn="gelu-approximate",
+            dtype=dtype,
+            model_config=config,
+            layer_idx=layer_idx,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        temb: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        freqs_cis: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        *args,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        # 1. Input normalization
+        norm_hidden_states, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.norm1(
+            hidden_states, emb=temb
+        )
+        norm_encoder_hidden_states, c_gate_msa, c_shift_mlp, c_scale_mlp, c_gate_mlp = (
+            self.norm1_context(encoder_hidden_states, emb=temb)
+        )
+
+        # 2. Joint attention
+        attn_output, context_attn_output = self.attn(
+            hidden_states=norm_hidden_states,
+            encoder_hidden_states=norm_encoder_hidden_states,
+            attention_mask=attention_mask,
+            image_rotary_emb=freqs_cis,
+        )
+
+        # 3. Modulation and residual connection
+        hidden_states = hidden_states + attn_output * gate_msa.unsqueeze(1)
+        encoder_hidden_states = encoder_hidden_states + context_attn_output * c_gate_msa.unsqueeze(
+            1
+        )
+
+        norm_hidden_states = self.norm2(hidden_states)
+        norm_encoder_hidden_states = self.norm2_context(encoder_hidden_states)
+
+        norm_hidden_states = norm_hidden_states * (1 + scale_mlp[:, None]) + shift_mlp[:, None]
+        norm_encoder_hidden_states = (
+            norm_encoder_hidden_states * (1 + c_scale_mlp[:, None]) + c_shift_mlp[:, None]
+        )
+
+        # 4. Feed-forward
+        ff_output = self.ff(norm_hidden_states)
+        context_ff_output = self.ff_context(norm_encoder_hidden_states)
+
+        hidden_states = hidden_states + gate_mlp.unsqueeze(1) * ff_output
+        encoder_hidden_states = encoder_hidden_states + c_gate_mlp.unsqueeze(1) * context_ff_output
+
+        return hidden_states, encoder_hidden_states
+
+
+class HunyuanVideo15Transformer3DModel(BaseDiffusionModel):
+    def __init__(self, model_config: DiffusionModelConfig):
+        super().__init__(model_config)
+
+        vgm = model_config.visual_gen_mapping
+        num_heads = getattr(model_config.pretrained_config, "num_attention_heads", 48)
+        self.sharder = SequenceSharder.from_vgm(vgm, num_attention_heads=num_heads)
+
+        pretrained_config = model_config.pretrained_config
+
+        dtype = model_config.torch_dtype
+        quant_config = model_config.quant_config
+        skip_create_weights = model_config.skip_create_weights_in_init
+        force_dynamic_quant = model_config.force_dynamic_quantization
+
+        # Extract parameters from pretrained config
+        # Defaults are derived from the '720p_t2v` variant`
+        attn_mode = getattr(pretrained_config, "attn_mode", "flash")
+        attn_param = getattr(pretrained_config, "attn_param", None)
+        concat_condition = getattr(pretrained_config, "concat_condition", True)
+        glyph_byT5_v2 = getattr(pretrained_config, "glyph_byT5_v2", True)
+        guidance_embed = getattr(pretrained_config, "guidance_embed", False)
+        heads_num = getattr(pretrained_config, "heads_num", 16)
+        hidden_size = getattr(pretrained_config, "hidden_size", 2048)
+        ideal_resolution = getattr(pretrained_config, "ideal_resolution", "720p")
+        ideal_task = getattr(pretrained_config, "ideal_task", "t2v")
+        in_channels = getattr(pretrained_config, "in_channels", 32)
+        is_reshape_temporal_channels = getattr(
+            pretrained_config, "is_reshape_temporal_channels", False
+        )
+        mlp_act_type = getattr(pretrained_config, "mlp_act_type", "gelu_tanh")
+        mlp_width_ratio = getattr(pretrained_config, "mlp_width_ratio", 4)
+        mm_double_blocks_depth = getattr(pretrained_config, "mm_double_blocks_depth", 54)
+        mm_single_blocks_depth = getattr(pretrained_config, "mm_single_blocks_depth", 0)
+        out_channels = getattr(pretrained_config, "out_channels", 32)
+        # Patch size differs from HF 1 vs (1, 1, 1)
+        patch_size = getattr(pretrained_config, "patch_size", 1)
+        qk_norm = getattr(pretrained_config, "qk_norm", True)
+        qk_norm_type = getattr(pretrained_config, "qk_norm_type", "rms")
+        qkv_bias = getattr(pretrained_config, "qkv_bias", True)
+        rope_dim_list = getattr(pretrained_config, "rope_dim_list", [16, 56, 56])
+        rope_theta = getattr(pretrained_config, "rope_theta", 256)
+        text_pool_type = getattr(pretrained_config, "text_pool_type", None)
+        text_projection = getattr(pretrained_config, "text_projection", "single_refiner")
+        text_states_dim = getattr(pretrained_config, "text_states_dim", 3584)
+        text_states_dim_2 = getattr(pretrained_config, "text_states_dim_2", None)
+        use_attention_mask = getattr(pretrained_config, "use_attention_mask", True)
+        use_cond_type_embedding = getattr(pretrained_config, "use_cond_type_embedding", True)
+        use_meanflow = getattr(pretrained_config, "use_meanflow", False)
+        vision_projection = getattr(pretrained_config, "vision_projection", "linear")
+        vision_states_dim = getattr(pretrained_config, "vision_states_dim", 1152)
+
+        num_attention_heads = getattr(pretrained_config, "num_attention_heads", 16)
+        attention_head_dim = getattr(pretrained_config, "attention_head_dim", 128)
+        image_embed_dim = getattr(pretrained_config, "image_embed_dim", 1152)
+        num_refiner_layers = getattr(pretrained_config, "num_refiner_layers", 2)
+        patch_size_t = getattr(pretrained_config, "patch_size_t", 1)
+        rope_axes_dim = getattr(pretrained_config, "rope_axes_dim", (16, 56, 56))
+        text_embed_dim = getattr(pretrained_config, "text_embed_dim", 3584)
+        text_embed_2_dim = getattr(pretrained_config, "text_embed_2_dim", 1472)
+        num_layers = getattr(pretrained_config, "num_layers", 54)
+        mlp_ratio = getattr(pretrained_config, "mlp_ratio", 4.0)
+        target_size = getattr(pretrained_config, "target_size", 640)
+
+        inner_dim = num_attention_heads * attention_head_dim
+        out_channels = out_channels or in_channels
+
+        self.gradient_checkpointing = False
+
+        # Store config for compatibility
+        self.config = type(
+            "Config",
+            (),
+            {
+                "attn_mode": attn_mode,
+                "attn_param": attn_param,
+                "concat_condition": concat_condition,
+                "glyph_byT5_v2": glyph_byT5_v2,
+                "guidance_embed": guidance_embed,
+                "heads_num": heads_num,
+                "hidden_size": hidden_size,
+                "ideal_resolution": ideal_resolution,
+                "ideal_task": ideal_task,
+                "in_channels": in_channels,
+                "out_channels": out_channels,
+                "patch_size": patch_size,
+                "inner_dim": inner_dim,
+                "is_reshape_temporal_channels": is_reshape_temporal_channels,
+                "mlp_act_type": mlp_act_type,
+                "mlp_width_ratio": mlp_width_ratio,
+                "mm_double_blocks_depth": mm_double_blocks_depth,
+                "mm_single_blocks_depth": mm_single_blocks_depth,
+                "qk_norm": qk_norm,
+                "qk_norm_type": qk_norm_type,
+                "qkv_bias": qkv_bias,
+                "rope_dim_list": rope_dim_list,
+                "rope_theta": rope_theta,
+                "text_pool_type": text_pool_type,
+                "text_projection": text_projection,
+                "text_states_dim": text_states_dim,
+                "text_states_dim_2": text_states_dim_2,
+                "use_attention_mask": use_attention_mask,
+                "use_cond_type_embedding": use_cond_type_embedding,
+                "use_meanflow": use_meanflow,
+                "vision_projection": vision_projection,
+                "vision_states_dim": vision_states_dim,
+                "patch_size_t": patch_size_t,
+                "dtype": dtype,
+                "target_size": target_size,
+                "image_embed_dim": image_embed_dim,
+                "force_dynamic_quantization": force_dynamic_quant,
+                "skip_create_weights": skip_create_weights,
+                "quant_config": quant_config,
+            },
+        )()
+
+        self.x_embedder = HunyuanVideo15PatchEmbed(
+            (patch_size_t, patch_size, patch_size), in_channels, inner_dim
+        )
+
+        self.image_embedder = HunyuanVideo15ImageProjection(
+            image_embed_dim, inner_dim, model_config=model_config
+        )
+        self.context_embedder = HunyuanVideo15TokenRefiner(
+            text_embed_dim,
+            num_attention_heads,
+            attention_head_dim,
+            num_layers=num_refiner_layers,
+            model_config=model_config,
+        )
+        self.context_embedder_2 = HunyuanVideo15ByT5TextProjection(
+            text_embed_2_dim, 2048, inner_dim, model_config=model_config
+        )
+
+        self.time_embed = HunyuanVideo15TimeEmbedding(inner_dim, use_meanflow=use_meanflow)
+        self.cond_type_embed = Embedding(3, inner_dim)
+
+        self.rope = HunyuanVideo15RotaryPosEmbed(
+            patch_size, patch_size_t, rope_axes_dim, rope_theta
+        )
+
+        self.transformer_blocks = torch.nn.ModuleList(
+            [
+                HunyuanVideo15TransformerBlock(
+                    dim=inner_dim,
+                    num_attention_heads=num_attention_heads,
+                    attention_head_dim=attention_head_dim,
+                    mlp_ratio=mlp_ratio,
+                    qk_norm=qk_norm,
+                    layer_idx=layer_idx,
+                    config=model_config,
+                    dtype=dtype,
+                )
+                for layer_idx in range(num_layers)
+            ]
+        )
+
+        self.norm_out = HunyuanVideo15AdaLayerNormContinuous(
+            inner_dim, inner_dim, elementwise_affine=False, eps=1e-6, model_config=model_config
+        )
+        self.proj_out = _aux_linear(
+            inner_dim,
+            patch_size_t * patch_size * patch_size * out_channels,
+            model_config=model_config,
+        )
+
+        self.apply_quant_config_exclude_modules()
+        self.__post_init__()
+
+    def apply_quant_config_exclude_modules(self) -> None:
+        """Opt excluded Linears out of quantization (mirrors the Wan transformer)."""
+        quant_config = self.model_config.quant_config
+        if quant_config is None or quant_config.exclude_modules is None:
+            return
+        no_quant_config = QuantConfig(kv_cache_quant_algo=quant_config.kv_cache_quant_algo)
+        for name, module in self.named_modules():
+            if (
+                isinstance(module, Linear)
+                and getattr(module, "quant_config", None) is not None
+                and quant_config.is_module_excluded_from_quantization(name)
+            ):
+                module.quant_config = no_quant_config
+                module._weights_created = False
+                module.create_weights()
+
+    def __post_init__(self) -> None:
+        for _, module in self.named_modules():
+            if callable(getattr(module, "create_weights", None)):
+                module.create_weights()
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        timestep: torch.LongTensor,
+        encoder_hidden_states: torch.Tensor,
+        encoder_attention_mask: Optional[torch.Tensor] = None,
+        timestep_r: Optional[torch.LongTensor] = None,
+        encoder_hidden_states_2: Optional[torch.Tensor] = None,
+        encoder_attention_mask_2: Optional[torch.Tensor] = None,
+        image_embeds: Optional[torch.Tensor] = None,
+        attention_kwargs: Optional[Dict[str, Any]] = None,
+        return_dict: bool = True,
+    ) -> Union[Tuple[torch.Tensor], Transformer2DModelOutput]:
+        batch_size, num_channels, num_frames, height, width = hidden_states.shape
+        p_t, p_h, p_w = self.config.patch_size_t, self.config.patch_size, self.config.patch_size
+        post_patch_num_frames = num_frames // p_t
+        post_patch_height = height // p_h
+        post_patch_width = width // p_w
+
+        # 1. RoPE
+        image_rotary_emb = self.rope(hidden_states)
+
+        # 2. Conditional embeddings
+        timestep_r = timestep_r.to(self.config.dtype) if timestep_r else None
+        temb = self.time_embed(timestep.to(self.config.dtype), timestep_r=timestep_r)
+
+        hidden_states = self.x_embedder(hidden_states)
+
+        # qwen text embedding
+        encoder_hidden_states = self.context_embedder(
+            encoder_hidden_states, timestep, encoder_attention_mask
+        )
+
+        encoder_hidden_states_cond_emb = self.cond_type_embed(
+            torch.zeros_like(encoder_hidden_states[:, :, 0], dtype=torch.long)
+        )
+        encoder_hidden_states = encoder_hidden_states + encoder_hidden_states_cond_emb
+
+        # byt5 text embedding
+        encoder_hidden_states_2 = self.context_embedder_2(encoder_hidden_states_2)
+
+        encoder_hidden_states_2_cond_emb = self.cond_type_embed(
+            torch.ones_like(encoder_hidden_states_2[:, :, 0], dtype=torch.long)
+        )
+        encoder_hidden_states_2 = encoder_hidden_states_2 + encoder_hidden_states_2_cond_emb
+
+        # image embed
+        encoder_hidden_states_3 = self.image_embedder(image_embeds)
+        is_t2v = torch.all(image_embeds == 0)
+        if is_t2v:
+            encoder_hidden_states_3 = encoder_hidden_states_3 * 0.0
+            encoder_attention_mask_3 = torch.zeros(
+                (batch_size, encoder_hidden_states_3.shape[1]),
+                dtype=encoder_attention_mask.dtype,
+                device=encoder_attention_mask.device,
+            )
+        else:
+            encoder_attention_mask_3 = torch.ones(
+                (batch_size, encoder_hidden_states_3.shape[1]),
+                dtype=encoder_attention_mask.dtype,
+                device=encoder_attention_mask.device,
+            )
+        encoder_hidden_states_3_cond_emb = self.cond_type_embed(
+            2
+            * torch.ones_like(
+                encoder_hidden_states_3[:, :, 0],
+                dtype=torch.long,
+            )
+        )
+        encoder_hidden_states_3 = encoder_hidden_states_3 + encoder_hidden_states_3_cond_emb
+
+        # reorder and combine text tokens: combine valid tokens first, then padding
+        encoder_attention_mask = encoder_attention_mask.bool()
+        encoder_attention_mask_2 = encoder_attention_mask_2.bool()
+        encoder_attention_mask_3 = encoder_attention_mask_3.bool()
+        new_encoder_hidden_states = []
+        new_encoder_attention_mask = []
+
+        for text, text_mask, text_2, text_mask_2, image, image_mask in zip(
+            encoder_hidden_states,
+            encoder_attention_mask,
+            encoder_hidden_states_2,
+            encoder_attention_mask_2,
+            encoder_hidden_states_3,
+            encoder_attention_mask_3,
+        ):
+            # Concatenate: [valid_image, valid_byt5, valid_mllm, invalid_image, invalid_byt5, invalid_mllm]
+            new_encoder_hidden_states.append(
+                torch.cat(
+                    [
+                        image[image_mask],  # valid image
+                        text_2[text_mask_2],  # valid byt5
+                        text[text_mask],  # valid mllm
+                        image[~image_mask],  # invalid image
+                        torch.zeros_like(text_2[~text_mask_2]),  # invalid byt5 (zeroed)
+                        torch.zeros_like(text[~text_mask]),  # invalid mllm (zeroed)
+                    ],
+                    dim=0,
+                )
+            )
+
+            # Apply same reordering to attention masks
+            new_encoder_attention_mask.append(
+                torch.cat(
+                    [
+                        image_mask[image_mask],
+                        text_mask_2[text_mask_2],
+                        text_mask[text_mask],
+                        image_mask[~image_mask],
+                        text_mask_2[~text_mask_2],
+                        text_mask[~text_mask],
+                    ],
+                    dim=0,
+                )
+            )
+
+        encoder_hidden_states = torch.stack(new_encoder_hidden_states)
+        encoder_attention_mask = torch.stack(new_encoder_attention_mask)
+
+        # 4. Transformer blocks
+        if torch.is_grad_enabled() and self.gradient_checkpointing:
+            for block in self.transformer_blocks:
+                hidden_states, encoder_hidden_states = self._gradient_checkpointing_func(
+                    block,
+                    hidden_states,
+                    encoder_hidden_states,
+                    temb,
+                    encoder_attention_mask,
+                    image_rotary_emb,
+                )
+
+        else:
+            for block in self.transformer_blocks:
+                hidden_states, encoder_hidden_states = block(
+                    hidden_states,
+                    encoder_hidden_states,
+                    temb,
+                    encoder_attention_mask,
+                    image_rotary_emb,
+                )
+
+        # 5. Output projection
+        hidden_states = self.norm_out(hidden_states, temb)
+        hidden_states = self.proj_out(hidden_states)
+
+        hidden_states = hidden_states.reshape(
+            batch_size,
+            post_patch_num_frames,
+            post_patch_height,
+            post_patch_width,
+            -1,
+            p_t,
+            p_h,
+            p_w,
+        )
+        hidden_states = hidden_states.permute(0, 4, 1, 5, 2, 6, 3, 7)
+        hidden_states = hidden_states.flatten(6, 7).flatten(4, 5).flatten(2, 3)
+
+        if not return_dict:
+            return (hidden_states,)
+
+        return Transformer2DModelOutput(sample=hidden_states)
+
+    def load_weights(self, weights: dict) -> None:
+        """Load weights into the transformer.
+
+        Args:
+            weights: Dictionary of parameter name -> tensor
+        """
+
+        # Remap HF checkpoint keys to our module attribute names
+        weights = _remap_checkpoint_keys(weights)
+
+        # Map fused QKV layer names to original HF checkpoint names
+        # HF checkpoint has separate to_q, to_k, to_v / add_q_proj, add_k_proj, add_v_proj
+        # We fuse them into qkv_proj / add_qkv_proj for better performance
+        params_map = {
+            "add_qkv_proj": ["add_q_proj", "add_k_proj", "add_v_proj"],
+            "qkv_proj": ["to_q", "to_k", "to_v"],
+        }
+
+        loader = DynamicLinearWeightLoader(self.model_config, params_map=params_map)
+
+        # Track prefixes of wrapper projectors whose sub-Linears are loaded
+        # by the parent's load_weights — the generic Linear loader must skip
+        # them (their FUSED weight modes would look for nonexistent checkpoint
+        # keys via params_map and error).
+        managed_prefixes = set()
+
+        for name, module in tqdm(self.named_modules(), desc="Loading weights"):
+            if any(name.startswith(p) for p in managed_prefixes):
+                continue
+
+            # Create weights for modules with skip_create_weights_in_init=True
+            # This must be done before loading weights (following Wan pattern)
+            if callable(getattr(module, "create_weights", None)):
+                module.create_weights()
+
+            if len(module._parameters) == 0:
+                continue
+
+            if isinstance(module, Embedding):
+                # Embedding subclasses Linear but must never be weight-quantized
+                weight_dicts = loader.get_linear_weights(module, name, weights)
+                if weight_dicts:
+                    module.load_weights(weight_dicts)
+            elif isinstance(module, Linear):
+                weight_dicts = loader.get_linear_weights(module, name, weights)
+
+                if weight_dicts:
+                    loader.load_linear_weights(module, name, weight_dicts)
+            else:
+                module_weights = loader.filter_weights(name, weights)
+                for param_name, param in module._parameters.items():
+                    if param is not None and param_name in module_weights:
+                        param.data.copy_(
+                            module_weights[param_name].to(self.model_config.torch_dtype)
+                        )
+
+    def post_load_weights(self) -> None:
+        """Call post_load_weights on all Linear modules and convert embedders to target dtype."""
+        # Convert time_text_embed components to target dtype
+        target_dtype = self.model_config.torch_dtype
+        if hasattr(self, "time_text_embed"):
+            if hasattr(self.time_text_embed, "timestep_embedder"):
+                self.time_text_embed.timestep_embedder.to(target_dtype)
+            if hasattr(self.time_text_embed, "text_embedder"):
+                self.time_text_embed.text_embedder.to(target_dtype)
+            if hasattr(self.time_text_embed, "guidance_embedder"):
+                self.time_text_embed.guidance_embedder.to(target_dtype)
+
+        # Finalize per-module weights and normalize dtypes to the compute dtype.
+        compute_dtype = self.config.dtype
+        quantized_dtypes = (torch.float8_e4m3fn, torch.float8_e5m2)
+        for _, module in self.named_modules():
+            if isinstance(module, Linear):
+                module.post_load_weights()
+                # Non-quantized Linear weights (e.g. fp32 embedder projections) need the
+                # compute dtype
+                weight = getattr(module, "weight", None)
+                if (
+                    weight is not None
+                    and weight.is_floating_point()
+                    and weight.dtype not in quantized_dtypes
+                ):
+                    module.to(compute_dtype)
+                continue
+            for param in module._parameters.values():
+                if param is not None and param.is_floating_point():
+                    param.data = param.data.to(compute_dtype)

--- a/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/transformer_hunyuan_video1_5.py
+++ b/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/transformer_hunyuan_video1_5.py
@@ -1,5 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch

--- a/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/transformer_hunyuan_video1_5.py
+++ b/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/transformer_hunyuan_video1_5.py
@@ -968,7 +968,7 @@ class HunyuanVideo15Transformer3DModel(BaseDiffusionModel):
         image_rotary_emb = self.rope(hidden_states)
 
         # 2. Conditional embeddings
-        timestep_r = timestep_r.to(self.config.dtype) if timestep_r else None
+        timestep_r = timestep_r.to(self.config.dtype) if timestep_r is not None else None
         temb = self.time_embed(timestep.to(self.config.dtype), timestep_r=timestep_r)
 
         hidden_states = self.x_embedder(hidden_states)

--- a/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/transformer_hunyuan_video1_5.py
+++ b/tensorrt_llm/_torch/visual_gen/models/hunyuan_video1_5/transformer_hunyuan_video1_5.py
@@ -456,7 +456,7 @@ class HunyuanVideo15TokenRefiner(torch.nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        timestep: torch.LongTensor,
+        timestep: torch.Tensor,
         attention_mask: Optional[torch.LongTensor] = None,
     ) -> torch.Tensor:
         if attention_mask is None:
@@ -818,6 +818,7 @@ class HunyuanVideo15Transformer3DModel(BaseDiffusionModel):
         num_layers = getattr(pretrained_config, "num_layers", 54)
         mlp_ratio = getattr(pretrained_config, "mlp_ratio", 4.0)
         target_size = getattr(pretrained_config, "target_size", 640)
+        num_train_timesteps = getattr(pretrained_config, "num_train_timesteps", 1000)
 
         inner_dim = num_attention_heads * attention_head_dim
         out_channels = out_channels or in_channels
@@ -864,6 +865,7 @@ class HunyuanVideo15Transformer3DModel(BaseDiffusionModel):
                 "patch_size_t": patch_size_t,
                 "dtype": dtype,
                 "target_size": target_size,
+                "num_train_timesteps": num_train_timesteps,
                 "image_embed_dim": image_embed_dim,
                 "force_dynamic_quantization": force_dynamic_quant,
                 "skip_create_weights": skip_create_weights,
@@ -948,16 +950,20 @@ class HunyuanVideo15Transformer3DModel(BaseDiffusionModel):
     def forward(
         self,
         hidden_states: torch.Tensor,
-        timestep: torch.LongTensor,
+        timestep: torch.Tensor,
         encoder_hidden_states: torch.Tensor,
         encoder_attention_mask: Optional[torch.Tensor] = None,
-        timestep_r: Optional[torch.LongTensor] = None,
+        timestep_r: Optional[torch.Tensor] = None,
         encoder_hidden_states_2: Optional[torch.Tensor] = None,
         encoder_attention_mask_2: Optional[torch.Tensor] = None,
         image_embeds: Optional[torch.Tensor] = None,
         attention_kwargs: Optional[Dict[str, Any]] = None,
         return_dict: bool = True,
     ) -> Union[Tuple[torch.Tensor], Transformer2DModelOutput]:
+        """
+        Args:
+            timestep: Normalized scheduler timestep tensor in [0, 1].
+        """
         batch_size, num_channels, num_frames, height, width = hidden_states.shape
         p_t, p_h, p_w = self.config.patch_size_t, self.config.patch_size, self.config.patch_size
         post_patch_num_frames = num_frames // p_t
@@ -967,9 +973,15 @@ class HunyuanVideo15Transformer3DModel(BaseDiffusionModel):
         # 1. RoPE
         image_rotary_emb = self.rope(hidden_states)
 
-        # 2. Conditional embeddings
-        timestep_r = timestep_r.to(self.config.dtype) if timestep_r is not None else None
-        temb = self.time_embed(timestep.to(self.config.dtype), timestep_r=timestep_r)
+        # 2. Conditional embeddings. HunyuanVideo1.5 timestep embeddings use the
+        # scheduler's 1000-step scale internally.
+        timestep = timestep.to(self.config.dtype) * self.config.num_train_timesteps
+        timestep_r = (
+            timestep_r.to(self.config.dtype) * self.config.num_train_timesteps
+            if timestep_r is not None
+            else None
+        )
+        temb = self.time_embed(timestep, timestep_r=timestep_r)
 
         hidden_states = self.x_embedder(hidden_states)
 

--- a/tensorrt_llm/_torch/visual_gen/pipeline_registry.py
+++ b/tensorrt_llm/_torch/visual_gen/pipeline_registry.py
@@ -57,6 +57,7 @@ class PipelineComponent(str, Enum):
     IMAGE_ENCODER = "image_encoder"
     IMAGE_PROCESSOR = "image_processor"
     SOUND_TOKENIZER = "sound_tokenizer"
+    GUIDER = "guider"
 
 
 @dataclass
@@ -187,6 +188,9 @@ class AutoPipeline:
 
             if "Cosmos3" in class_name:
                 return "Cosmos3OmniMoTPipeline"
+
+            if "HunyuanVideo15" in class_name:
+                return "HunyuanVideo15Pipeline"
 
         #########################################################
         # 2. Single-safetensors with embedded metadata (LTX-2 specific)

--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -227,6 +227,8 @@ l0_b200:
   - unittest/_torch/visual_gen/test_wan_transformer.py
   - unittest/_torch/visual_gen/test_cosmos3_transformer.py
   - unittest/_torch/visual_gen/test_cosmos3_pipeline.py
+  - unittest/_torch/visual_gen/test_hunyuan_video1_5_transformer.py
+  - unittest/_torch/visual_gen/test_hunyuan_video1_5_pipeline.py
   - examples/visual_gen/test_visual_gen.py::test_wan_t2v_example
   - examples/visual_gen/test_visual_gen.py::test_flux1_example
   - examples/visual_gen/test_visual_gen.py::test_flux2_example

--- a/tests/unittest/_torch/visual_gen/test_hunyuan_video1_5_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_hunyuan_video1_5_pipeline.py
@@ -1,5 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import gc
 import os
 

--- a/tests/unittest/_torch/visual_gen/test_hunyuan_video1_5_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_hunyuan_video1_5_pipeline.py
@@ -1,0 +1,591 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import gc
+import os
+
+from tensorrt_llm._torch.modules.linear import Linear
+
+os.environ["TLLM_DISABLE_MPI"] = "1"
+
+import numpy as np
+import pytest
+import torch
+import torch.nn.functional as F
+from diffusers import DiffusionPipeline
+
+from tensorrt_llm._torch.visual_gen.pipeline_loader import PipelineComponent, PipelineLoader
+from tensorrt_llm.visual_gen.args import AttentionConfig, TorchCompileConfig, VisualGenArgs
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _cleanup_mpi_env():
+    yield
+    os.environ.pop("TLLM_DISABLE_MPI", None)
+
+
+# ============================================================================
+# Test constants
+# ============================================================================
+
+HUNYUAN_VIDEO_1_5_PATH = "hunyuanvideo-community/HunyuanVideo-1.5-Diffusers-480p_t2v"
+
+PROMPT = "A dinosaur walking through the jungle"
+NEGATIVE_PROMPT = ""
+HEIGHT = 256
+WIDTH = 256
+NUM_FRAMES = 10
+NUM_STEPS = 30
+SEED = 42
+COS_SIM_THRESHOLD = 0.99
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _load_trtllm_pipeline(checkpoint_path: str, skip_components=None, **kwargs):
+    """Load TRTLLM HunyuanVideo 1.5 pipeline without torch.compile or warmup."""
+
+    args = VisualGenArgs(
+        model=checkpoint_path, torch_compile_config=TorchCompileConfig(enable=False), **kwargs
+    )
+    return PipelineLoader(args).load(skip_warmup=True, skip_components=skip_components)
+
+
+def _load_hf_pipeline(checkpoint_path: str):
+    """Load HuggingFace diffusers pipeline (auto-detects class from model_index.json)."""
+    hf_pipe = DiffusionPipeline.from_pretrained(
+        checkpoint_path,
+        torch_dtype=torch.bfloat16,
+    )
+    hf_pipe = hf_pipe.to("cuda")
+    hf_pipe.set_progress_bar_config(disable=True)
+    return hf_pipe
+
+
+def _teardown_pipeline(pipe) -> None:
+    """Release a pipeline reference and reclaim GPU memory."""
+    del pipe
+    gc.collect()
+    torch.cuda.empty_cache()
+    torch._dynamo.reset()
+
+
+def _capture_trtllm_video(
+    pipeline,
+    prompt: str,
+    negative_prompt: str,
+    height: int,
+    width: int,
+    num_frames: int,
+    num_inference_steps: int,
+    seed: int,
+):
+    """Run full TRTLLM pipeline including VAE decode; return the raw pipeline output."""
+    with torch.no_grad():
+        return pipeline.forward(
+            prompt=prompt,
+            negative_prompt=negative_prompt,
+            height=height,
+            width=width,
+            num_frames=num_frames,
+            num_inference_steps=num_inference_steps,
+            seed=seed,
+        )
+
+
+def _capture_hf_video(
+    hf_pipe,
+    prompt: str,
+    negative_prompt: str,
+    height: int,
+    width: int,
+    num_frames: int,
+    num_inference_steps: int,
+    seed: int,
+):
+    """Run HF pipeline with output_type='np'; return the raw pipeline output."""
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    return hf_pipe(
+        prompt=prompt,
+        negative_prompt=negative_prompt,
+        height=height,
+        width=width,
+        num_frames=num_frames,
+        num_inference_steps=num_inference_steps,
+        generator=generator,
+        output_type="np",
+    )
+
+
+def _to_video_tensor(frames) -> torch.Tensor:
+    """Convert (B, T, H, W, C) frames to a float (T, H, W, C) tensor in [0, 1]."""
+
+    if isinstance(frames, np.ndarray):
+        frames = torch.from_numpy(frames)
+    frames = frames[0]
+    if frames.dtype == torch.uint8:
+        return frames.float() / 255.0
+    return frames.float()
+
+
+def _cosine_similarity(a: torch.Tensor, b: torch.Tensor) -> float:
+    """Cosine similarity between two tensors (flattened to 1D, cast to float32 on CPU)."""
+    a_flat = a.float().cpu().reshape(-1)
+    b_flat = b.float().cpu().reshape(-1)
+    return F.cosine_similarity(a_flat.unsqueeze(0), b_flat.unsqueeze(0)).clamp(-1.0, 1.0).item()
+
+
+def _assert_pipeline_matches_hf(
+    checkpoint_path: str,
+    height: int,
+    width: int,
+    num_frames: int,
+    model_label: str,
+) -> None:
+    """Run TRTLLM and HF pipelines sequentially, compare decoded video output."""
+    # --- TRTLLM ---
+    try:
+        trtllm_pipe = _load_trtllm_pipeline(checkpoint_path)
+        trtllm_output = _capture_trtllm_video(
+            trtllm_pipe,
+            prompt=PROMPT,
+            negative_prompt=NEGATIVE_PROMPT,
+            height=height,
+            width=width,
+            num_frames=num_frames,
+            num_inference_steps=NUM_STEPS,
+            seed=SEED,
+        )
+        trtllm_video = _to_video_tensor(trtllm_output.video)
+    finally:
+        _teardown_pipeline(trtllm_pipe)
+
+    # --- HF reference ---
+    try:
+        hf_pipe = _load_hf_pipeline(checkpoint_path)
+        hf_output = _capture_hf_video(
+            hf_pipe,
+            prompt=PROMPT,
+            negative_prompt=NEGATIVE_PROMPT,
+            height=height,
+            width=width,
+            num_frames=num_frames,
+            num_inference_steps=NUM_STEPS,
+            seed=SEED,
+        )
+        hf_video = _to_video_tensor(hf_output.frames)
+    finally:
+        _teardown_pipeline(hf_pipe)
+
+    # --- Compare ---
+    assert trtllm_video.numel() == hf_video.numel(), (
+        f"{model_label}: element count mismatch — "
+        f"TRTLLM {trtllm_video.shape} ({trtllm_video.numel()}) vs "
+        f"HF {hf_video.shape} ({hf_video.numel()})"
+    )
+
+    cos_sim = _cosine_similarity(trtllm_video, hf_video)
+    print(f"\n  {model_label} cosine similarity: {cos_sim:.6f}")
+    assert cos_sim >= COS_SIM_THRESHOLD, (
+        f"{model_label}: cosine similarity {cos_sim:.6f} < {COS_SIM_THRESHOLD}. "
+        f"TRTLLM pipeline output diverges from the HuggingFace reference. "
+        f"Video shapes — TRTLLM: {trtllm_video.shape}, HF: {hf_video.shape}."
+    )
+
+
+# ============================================================================
+# Tests
+# ============================================================================
+
+
+@pytest.mark.integration
+class TestHunyuanVideo15PipelineCorrectness:
+    """HunyuanVideo 1.5 T2V correctness vs HuggingFace reference (256x256, 10 frames)."""
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_cosine_similarity(self):
+        _assert_pipeline_matches_hf(
+            checkpoint_path=HUNYUAN_VIDEO_1_5_PATH,
+            height=HEIGHT,
+            width=WIDTH,
+            num_frames=NUM_FRAMES,
+            model_label="HunyuanVideo1.5-T2V",
+        )
+
+
+@pytest.mark.integration
+class TestHunyuanVideo15BatchGeneration:
+    """Batch generation tests for HunyuanVideo 1.5 pipeline
+
+    Tests that passing a list of prompts produces batched output
+    and matches sequential generation with the same seeds.
+    """
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_single_prompt_backward_compat(self):
+        """Single prompt returns (B, T, H, W, C) for backward compatibility."""
+
+        try:
+            pipe = _load_trtllm_pipeline(HUNYUAN_VIDEO_1_5_PATH)
+            result = _capture_trtllm_video(
+                pipe,
+                prompt=PROMPT,
+                negative_prompt=NEGATIVE_PROMPT,
+                height=HEIGHT,
+                width=WIDTH,
+                num_frames=NUM_FRAMES,
+                num_inference_steps=NUM_STEPS,
+                seed=SEED,
+            )
+            assert result.video.ndim == 5, f"Expected 5D (B,T,H,W,C), got {result.video.ndim}D"
+            B, _T, H, W, C = result.video.shape
+            assert B == 1 and H == HEIGHT and W == WIDTH and C == 3
+        finally:
+            _teardown_pipeline(pipe)
+
+
+# =============================================================================
+# Quantization Optimization Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestHunyuanVideo15QuantizationOptimizations:
+    """FP8 + TRTLLM attention on HunyuanVideo1.5."""
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_fp8_trtllm_attention(self):
+        pipe_args = {
+            "quant_config": {"quant_algo": "FP8", "dynamic": True},
+            "attention_config": AttentionConfig(backend="TRTLLM"),
+        }
+
+        try:
+            pipe = _load_trtllm_pipeline(HUNYUAN_VIDEO_1_5_PATH, **pipe_args)
+            result = _capture_trtllm_video(
+                pipe,
+                prompt=PROMPT,
+                negative_prompt=NEGATIVE_PROMPT,
+                height=HEIGHT,
+                width=WIDTH,
+                num_frames=NUM_FRAMES,
+                num_inference_steps=NUM_STEPS,
+                seed=SEED,
+            )
+
+            assert result.video.ndim == 5, f"Expected 5D (B,T,H,W,C), got {result.video.ndim}D"
+            B, _T, H, W, C = result.video.shape
+            assert B == 1 and H == HEIGHT and W == WIDTH and C == 3
+        finally:
+            _teardown_pipeline(pipe)
+
+
+# =============================================================================
+# Quantization / dtype feature tests (transformer only)
+# =============================================================================
+
+_SKIP_AUX = [
+    PipelineComponent.TEXT_ENCODER,
+    PipelineComponent.TEXT_ENCODER_2,
+    PipelineComponent.TOKENIZER,
+    PipelineComponent.TOKENIZER_2,
+    PipelineComponent.VAE,
+    PipelineComponent.SCHEDULER,
+    PipelineComponent.GUIDER,
+]
+
+
+def _assert_fp8_blocks_quantized(pipe) -> None:
+    """Assert at least one transformer-block Linear is FP8 (float8_e4m3fn) with a weight_scale."""
+    for name, module in pipe.transformer.named_modules():
+        if isinstance(module, Linear) and "transformer_blocks." in name:
+            assert module.weight.dtype == torch.float8_e4m3fn, (
+                f"{name}: expected float8_e4m3fn, got {module.weight.dtype}"
+            )
+            assert hasattr(module, "weight_scale"), f"{name}: missing weight_scale"
+            return
+    pytest.fail("No FP8 Linear found in transformer blocks")
+
+
+def _assert_nvfp4_blocks_quantized(pipe) -> None:
+    """Assert at least one transformer-block Linear is NVFP4 (packed FP4) with a two-level scale."""
+    from tensorrt_llm.quantization.utils import fp4_utils
+
+    for name, module in pipe.transformer.named_modules():
+        if isinstance(module, Linear) and "transformer_blocks." in name:
+            assert module.weight.dtype == fp4_utils.float4_e2m1x2, (
+                f"{name}: expected float4_e2m1x2, got {module.weight.dtype}"
+            )
+            assert hasattr(module, "weight_scale"), f"{name}: missing weight_scale"
+            assert hasattr(module, "weight_scale_2"), f"{name}: missing weight_scale_2"
+            return
+    pytest.fail("No NVFP4 Linear found in transformer blocks")
+
+
+def _skip_if_no_fp8_ops() -> None:
+    try:
+        if not hasattr(torch.ops, "tensorrt_llm"):
+            pytest.skip("tensorrt_llm torch ops not available")
+        _ = torch.ops.tensorrt_llm.quantize_e4m3_per_tensor
+        _ = torch.ops.tensorrt_llm.quantize_e4m3_activation
+    except (AttributeError, RuntimeError) as e:
+        pytest.skip(f"FP8 quantization ops not available: {e}")
+
+
+def _skip_if_no_nvfp4_ops() -> None:
+    if torch.cuda.get_device_capability(0) < (10, 0):
+        pytest.skip("NVFP4 requires SM>=10.0 (Blackwell+)")
+    try:
+        _ = torch.ops.trtllm.fp4_quantize
+    except (AttributeError, RuntimeError) as e:
+        pytest.skip(f"fp4_quantize op not available: {e}")
+
+
+def _transformer_inputs(transformer, device: str = "cuda", dtype=torch.bfloat16, seed: int = 42):
+    """Build a minimal valid HunyuanVideo1.5 transformer forward batch."""
+    in_channels = transformer.config.in_channels
+    image_embed_dim = transformer.config.image_embed_dim
+    text_embed_dim = transformer.context_embedder.proj_in.in_features
+    text_embed_2_dim = transformer.context_embedder_2.linear_1.in_features
+
+    g = torch.Generator(device=device).manual_seed(seed)
+    seq_len = 6
+    return {
+        "hidden_states": torch.randn(
+            1, in_channels, 1, 32, 32, device=device, dtype=dtype, generator=g
+        ),
+        "encoder_hidden_states": torch.randn(
+            1, seq_len, text_embed_dim, device=device, dtype=dtype, generator=g
+        ),
+        "encoder_hidden_states_2": torch.randn(
+            1, seq_len, text_embed_2_dim, device=device, dtype=dtype, generator=g
+        ),
+        "image_embeds": torch.randn(
+            1, seq_len, image_embed_dim, device=device, dtype=dtype, generator=g
+        ),
+        "encoder_attention_mask": torch.ones(1, seq_len, device=device, dtype=dtype),
+        "encoder_attention_mask_2": torch.ones(1, seq_len, device=device, dtype=dtype),
+        "timestep": torch.tensor([1], device=device, dtype=dtype),
+    }
+
+
+def _run_transformer(transformer, inputs: dict) -> torch.Tensor:
+    """Run the transformer on cloned inputs; return the float32 sample output."""
+    cloned = {k: (v.clone() if torch.is_tensor(v) else v) for k, v in inputs.items()}
+    with torch.no_grad():
+        out = transformer(**cloned, return_dict=False)[0]
+    return out.float()
+
+
+@pytest.mark.integration
+class TestHunyuanVideo15PipelineFeatures:
+    """Quantization loading, dtype layout, numerical accuracy, and memory for HunyuanVideo1.5."""
+
+    def test_parameter_dtypes(self):
+        """BF16 pipeline: every transformer param is on CUDA; all non-scale params are BF16."""
+        pipe = None
+        try:
+            pipe = _load_trtllm_pipeline(HUNYUAN_VIDEO_1_5_PATH, skip_components=_SKIP_AUX)
+            bf16_count = 0
+            for name, param in pipe.transformer.named_parameters():
+                assert param.device.type == "cuda", f"{name} not on CUDA"
+                if "scale" not in name.lower():
+                    assert param.dtype == torch.bfloat16, (
+                        f"{name}: expected bfloat16, got {param.dtype}"
+                    )
+                    bf16_count += 1
+            assert bf16_count > 0, "No BF16 parameters found"
+        finally:
+            _teardown_pipeline(pipe)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_fp8_weights_loaded(self):
+        """FP8 transformer blocks have float8_e4m3fn weights and weight_scale."""
+        _skip_if_no_fp8_ops()
+        pipe = None
+        try:
+            pipe = _load_trtllm_pipeline(
+                HUNYUAN_VIDEO_1_5_PATH,
+                skip_components=_SKIP_AUX,
+                quant_config={"quant_algo": "FP8", "dynamic": True},
+            )
+            _assert_fp8_blocks_quantized(pipe)
+        finally:
+            _teardown_pipeline(pipe)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_fp8_block_scales_weights_loaded(self):
+        """FP8_BLOCK_SCALES transformer blocks have float8_e4m3fn weights and weight_scale."""
+        _skip_if_no_fp8_ops()
+        pipe = None
+        try:
+            pipe = _load_trtllm_pipeline(
+                HUNYUAN_VIDEO_1_5_PATH,
+                skip_components=_SKIP_AUX,
+                quant_config={"quant_algo": "FP8_BLOCK_SCALES", "dynamic": True},
+            )
+            _assert_fp8_blocks_quantized(pipe)
+        finally:
+            _teardown_pipeline(pipe)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_nvfp4_weights_loaded(self):
+        """NVFP4 transformer blocks have packed FP4 weights with a two-level scale."""
+        _skip_if_no_nvfp4_ops()
+        pipe = None
+        try:
+            pipe = _load_trtllm_pipeline(
+                HUNYUAN_VIDEO_1_5_PATH,
+                skip_components=_SKIP_AUX,
+                quant_config={"quant_algo": "NVFP4", "dynamic": True},
+            )
+            _assert_nvfp4_blocks_quantized(pipe)
+        finally:
+            _teardown_pipeline(pipe)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_fp8_single_layer_accuracy(self):
+        """FP8 qkv_proj output matches the BF16 F.linear reference (cos_sim > 0.99)."""
+        _skip_if_no_fp8_ops()
+        bf16_pipe = None
+        fp8_pipe = None
+        try:
+            bf16_pipe = _load_trtllm_pipeline(HUNYUAN_VIDEO_1_5_PATH, skip_components=_SKIP_AUX)
+            fp8_pipe = _load_trtllm_pipeline(
+                HUNYUAN_VIDEO_1_5_PATH,
+                skip_components=_SKIP_AUX,
+                quant_config={"quant_algo": "FP8", "dynamic": True},
+            )
+            linear_bf16 = bf16_pipe.transformer.transformer_blocks[0].attn.qkv_proj
+            linear_fp8 = fp8_pipe.transformer.transformer_blocks[0].attn.qkv_proj
+
+            weight = linear_bf16.weight.data.clone()
+            bias = linear_bf16.bias.data.clone() if linear_bf16.bias is not None else None
+            x = torch.randn(
+                1024,
+                linear_bf16.in_features,
+                dtype=torch.bfloat16,
+                device="cuda",
+                generator=torch.Generator("cuda").manual_seed(42),
+            )
+
+            with torch.no_grad():
+                ref = F.linear(x, weight, bias)
+                fp8_out = linear_fp8(x)
+
+            cos_sim = F.cosine_similarity(
+                fp8_out.flatten().float(), ref.flatten().float(), dim=0
+            ).item()
+            mse = F.mse_loss(fp8_out.float(), ref.float()).item()
+            print(f"\n  FP8 qkv_proj: cos_sim={cos_sim:.6f}, mse={mse:.6f}")
+            assert cos_sim > 0.99, f"cos_sim too low: {cos_sim:.6f}"
+            assert mse < 1.0, f"MSE too high: {mse:.6f}"
+        finally:
+            if fp8_pipe is not None:
+                _teardown_pipeline(fp8_pipe)
+            if bf16_pipe is not None:
+                _teardown_pipeline(bf16_pipe)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_fp8_memory_savings(self):
+        """FP8 transformer uses less parameter memory than BF16."""
+        _skip_if_no_fp8_ops()
+
+        def _mem_gb(pipe):
+            return (
+                sum(p.numel() * p.element_size() for p in pipe.transformer.parameters()) / 1024**3
+            )
+
+        bf16_pipe = None
+        fp8_pipe = None
+        try:
+            bf16_pipe = _load_trtllm_pipeline(HUNYUAN_VIDEO_1_5_PATH, skip_components=_SKIP_AUX)
+            fp8_pipe = _load_trtllm_pipeline(
+                HUNYUAN_VIDEO_1_5_PATH,
+                skip_components=_SKIP_AUX,
+                quant_config={"quant_algo": "FP8", "dynamic": True},
+            )
+            bf16_gb = _mem_gb(bf16_pipe)
+            fp8_gb = _mem_gb(fp8_pipe)
+            ratio = bf16_gb / fp8_gb
+            print(f"\n  BF16={bf16_gb:.3f} GB, FP8={fp8_gb:.3f} GB, ratio={ratio:.2f}x")
+            assert ratio > 1.9, f"Expected FP8 memory reduction, got {ratio:.2f}x"
+        finally:
+            if fp8_pipe is not None:
+                _teardown_pipeline(fp8_pipe)
+            if bf16_pipe is not None:
+                _teardown_pipeline(bf16_pipe)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    @pytest.mark.parametrize("quant_algo", ["FP8", "FP8_BLOCK_SCALES"])
+    def test_fp8_e2e_accuracy(self, quant_algo):
+        """FP8 / FP8_BLOCK_SCALES full-transformer output close to BF16 (cos_sim > 0.99)."""
+        _skip_if_no_fp8_ops()
+        bf16_pipe = None
+        quant_pipe = None
+        try:
+            bf16_pipe = _load_trtllm_pipeline(HUNYUAN_VIDEO_1_5_PATH, skip_components=_SKIP_AUX)
+            quant_pipe = _load_trtllm_pipeline(
+                HUNYUAN_VIDEO_1_5_PATH,
+                skip_components=_SKIP_AUX,
+                quant_config={"quant_algo": quant_algo, "dynamic": True},
+            )
+            inputs = _transformer_inputs(bf16_pipe.transformer)
+            out_bf16 = _run_transformer(bf16_pipe.transformer, inputs)
+            out_quant = _run_transformer(quant_pipe.transformer, inputs)
+
+            assert not torch.isnan(out_bf16).any(), "BF16 output contains NaN"
+            assert not torch.isinf(out_bf16).any(), "BF16 output contains Inf"
+            assert not torch.isnan(out_quant).any(), f"{quant_algo} output contains NaN"
+            assert not torch.isinf(out_quant).any(), f"{quant_algo} output contains Inf"
+
+            cos_sim = F.cosine_similarity(out_quant.flatten(), out_bf16.flatten(), dim=0).item()
+            mse = F.mse_loss(out_quant, out_bf16).item()
+            print(
+                f"\n  {quant_algo} E2E ({len(bf16_pipe.transformer.transformer_blocks)} layers): "
+                f"cos_sim={cos_sim:.6f}, mse={mse:.6f}"
+            )
+            # Block-scales is a coarser (per-block) scheme than per-tensor FP8, so it
+            min_cos_sim = 0.975 if quant_algo == "FP8_BLOCK_SCALES" else 0.99
+            assert cos_sim > min_cos_sim, f"{quant_algo} cos_sim too low: {cos_sim:.6f}"
+        finally:
+            if quant_pipe is not None:
+                _teardown_pipeline(quant_pipe)
+            if bf16_pipe is not None:
+                _teardown_pipeline(bf16_pipe)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_nvfp4_e2e_accuracy(self):
+        """NVFP4 full-transformer output close to BF16 (cos_sim > 0.95)."""
+        _skip_if_no_nvfp4_ops()
+        bf16_pipe = None
+        nvfp4_pipe = None
+        try:
+            bf16_pipe = _load_trtllm_pipeline(HUNYUAN_VIDEO_1_5_PATH, skip_components=_SKIP_AUX)
+            nvfp4_pipe = _load_trtllm_pipeline(
+                HUNYUAN_VIDEO_1_5_PATH,
+                skip_components=_SKIP_AUX,
+                quant_config={"quant_algo": "NVFP4", "dynamic": True},
+            )
+            inputs = _transformer_inputs(bf16_pipe.transformer)
+            out_bf16 = _run_transformer(bf16_pipe.transformer, inputs)
+            out_nvfp4 = _run_transformer(nvfp4_pipe.transformer, inputs)
+
+            assert not torch.isnan(out_nvfp4).any(), "NVFP4 output contains NaN"
+            assert not torch.isinf(out_nvfp4).any(), "NVFP4 output contains Inf"
+
+            cos_sim = F.cosine_similarity(out_nvfp4.flatten(), out_bf16.flatten(), dim=0).item()
+            mse = F.mse_loss(out_nvfp4, out_bf16).item()
+            print(
+                f"\n  NVFP4 E2E ({len(bf16_pipe.transformer.transformer_blocks)} layers): "
+                f"cos_sim={cos_sim:.6f}, mse={mse:.6f}"
+            )
+            # NOTE: AdaLayerNorm modulation linears hurt accuracy at nvfp4, consider adding omissions later
+            assert cos_sim > 0.90, f"NVFP4 cos_sim too low: {cos_sim:.6f}"
+        finally:
+            if nvfp4_pipe is not None:
+                _teardown_pipeline(nvfp4_pipe)
+            if bf16_pipe is not None:
+                _teardown_pipeline(bf16_pipe)

--- a/tests/unittest/_torch/visual_gen/test_hunyuan_video1_5_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_hunyuan_video1_5_pipeline.py
@@ -159,6 +159,7 @@ def _assert_pipeline_matches_hf(
 ) -> None:
     """Run TRTLLM and HF pipelines sequentially, compare decoded video output."""
     # --- TRTLLM ---
+    trtllm_pipe = None
     try:
         trtllm_pipe = _load_trtllm_pipeline(checkpoint_path)
         trtllm_output = _capture_trtllm_video(
@@ -176,6 +177,7 @@ def _assert_pipeline_matches_hf(
         _teardown_pipeline(trtllm_pipe)
 
     # --- HF reference ---
+    hf_pipe = None
     try:
         hf_pipe = _load_hf_pipeline(checkpoint_path)
         hf_output = _capture_hf_video(
@@ -240,6 +242,7 @@ class TestHunyuanVideo15BatchGeneration:
     def test_single_prompt_backward_compat(self):
         """Single prompt returns (B, T, H, W, C) for backward compatibility."""
 
+        pipe = None
         try:
             pipe = _load_trtllm_pipeline(HUNYUAN_VIDEO_1_5_PATH)
             result = _capture_trtllm_video(
@@ -275,6 +278,7 @@ class TestHunyuanVideo15QuantizationOptimizations:
             "attention_config": AttentionConfig(backend="TRTLLM"),
         }
 
+        pipe = None
         try:
             pipe = _load_trtllm_pipeline(HUNYUAN_VIDEO_1_5_PATH, **pipe_args)
             result = _capture_trtllm_video(

--- a/tests/unittest/_torch/visual_gen/test_hunyuan_video1_5_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_hunyuan_video1_5_pipeline.py
@@ -234,8 +234,9 @@ class TestHunyuanVideo15PipelineCorrectness:
 class TestHunyuanVideo15BatchGeneration:
     """Batch generation tests for HunyuanVideo 1.5 pipeline
 
-    Tests that passing a list of prompts produces batched output
-    and matches sequential generation with the same seeds.
+    Validates that single-prompt generation returns (B, T, H, W, C) output and
+    that an effective batch size > 1 (e.g. a list of prompts) is rejected with a
+    ValueError, matching the current pipeline contract.
     """
 
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -258,6 +259,26 @@ class TestHunyuanVideo15BatchGeneration:
             assert result.video.ndim == 5, f"Expected 5D (B,T,H,W,C), got {result.video.ndim}D"
             B, _T, H, W, C = result.video.shape
             assert B == 1 and H == HEIGHT and W == WIDTH and C == 3
+        finally:
+            _teardown_pipeline(pipe)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_multi_prompt_raises(self):
+        """A list of prompts (effective batch size > 1) raises ValueError."""
+
+        pipe = None
+        try:
+            pipe = _load_trtllm_pipeline(HUNYUAN_VIDEO_1_5_PATH)
+            with torch.no_grad(), pytest.raises(ValueError):
+                pipe.forward(
+                    prompt=[PROMPT, PROMPT],
+                    negative_prompt=NEGATIVE_PROMPT,
+                    height=HEIGHT,
+                    width=WIDTH,
+                    num_frames=NUM_FRAMES,
+                    num_inference_steps=NUM_STEPS,
+                    seed=SEED,
+                )
         finally:
             _teardown_pipeline(pipe)
 
@@ -400,6 +421,7 @@ def _run_transformer(transformer, inputs: dict) -> torch.Tensor:
 class TestHunyuanVideo15PipelineFeatures:
     """Quantization loading, dtype layout, numerical accuracy, and memory for HunyuanVideo1.5."""
 
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     def test_parameter_dtypes(self):
         """BF16 pipeline: every transformer param is on CUDA; all non-scale params are BF16."""
         pipe = None

--- a/tests/unittest/_torch/visual_gen/test_hunyuan_video1_5_transformer.py
+++ b/tests/unittest/_torch/visual_gen/test_hunyuan_video1_5_transformer.py
@@ -1,5 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 from copy import deepcopy
 from types import SimpleNamespace

--- a/tests/unittest/_torch/visual_gen/test_hunyuan_video1_5_transformer.py
+++ b/tests/unittest/_torch/visual_gen/test_hunyuan_video1_5_transformer.py
@@ -1,0 +1,271 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import unittest
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from tensorrt_llm._torch.visual_gen import DiffusionModelConfig
+from tensorrt_llm.llmapi import QuantConfig
+from tensorrt_llm.mapping import Mapping
+from tensorrt_llm.visual_gen import AttentionConfig
+
+CONFIG = {
+    "in_channels": 32,
+    "text_embed_dim": 3584,
+    "text_embed_2_dim": 1472,
+    "hidden_size": 2048,
+    "image_embed_dim": 1152,
+    "torch_dtype": "bfloat16",
+}
+
+
+def _create_model_config(config_dict: dict, backend: str = "VANILLA") -> DiffusionModelConfig:
+    """Create DiffusionModelConfig from config dict."""
+    pretrained_config = SimpleNamespace(**config_dict)
+    return DiffusionModelConfig(
+        pretrained_config=pretrained_config,
+        quant_config=QuantConfig(),
+        mapping=Mapping(),
+        attention=AttentionConfig(backend=backend),
+        skip_create_weights_in_init=False,
+    )
+
+
+def _make_inputs(config, dtype, device):
+    batch_size = 1
+    num_frames = 1
+    height, width = 32, 32
+
+    sequence_length = 6
+    text_embed_dim = config["text_embed_dim"]
+    text_embed_2_dim = config["text_embed_2_dim"]
+    num_channels = config["in_channels"]
+    image_embed_dim = config["image_embed_dim"]
+
+    generator = torch.Generator(device=device).manual_seed(42)
+
+    hidden_states = torch.randn(
+        batch_size,
+        num_channels,
+        num_frames,
+        height,
+        width,
+        device=device,
+        dtype=dtype,
+        generator=generator,
+    )
+
+    encoder_hidden_states = torch.randn(
+        batch_size, sequence_length, text_embed_dim, device=device, dtype=dtype, generator=generator
+    )
+
+    encoder_hidden_states_2 = torch.randn(
+        batch_size,
+        sequence_length,
+        text_embed_2_dim,
+        device=device,
+        dtype=dtype,
+        generator=generator,
+    )
+
+    image_embeds = torch.randn(
+        batch_size,
+        sequence_length,
+        image_embed_dim,
+        device=device,
+        dtype=dtype,
+        generator=generator,
+    )
+
+    encoder_attention_mask = torch.ones(batch_size, sequence_length, device=device, dtype=dtype)
+
+    encoder_attention_mask_2 = torch.ones(batch_size, sequence_length, device=device, dtype=dtype)
+
+    timestep = torch.tensor([1], device=device, dtype=dtype)
+
+    return (
+        hidden_states,
+        encoder_hidden_states,
+        image_embeds,
+        encoder_attention_mask,
+        encoder_hidden_states_2,
+        encoder_attention_mask_2,
+        timestep,
+    )
+
+
+class TestHunyuanVideo15Transformer(unittest.TestCase):
+    DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_hunyuan_video1_5_structure(self):
+        from tensorrt_llm._torch.visual_gen.models.hunyuan_video1_5.transformer_hunyuan_video1_5 import (
+            HunyuanVideo15Transformer3DModel,
+        )
+
+        config = deepcopy(CONFIG)
+        config["num_layers"] = 1
+        model_config = _create_model_config(config)
+        model = HunyuanVideo15Transformer3DModel(model_config)
+
+        # Check components are present in model
+        components = [
+            "x_embedder",
+            "image_embedder",
+            "context_embedder",
+            "context_embedder_2",
+            "time_embed",
+            "cond_type_embed",
+            "rope",
+            "transformer_blocks",
+            "norm_out",
+            "proj_out",
+        ]
+
+        for component in components:
+            self.assertTrue(hasattr(model, component))
+
+        self.assertEqual(len(model.transformer_blocks), 1)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_hunyuan_video1_5_forward_sanity(self):
+        from tensorrt_llm._torch.visual_gen.models.hunyuan_video1_5.transformer_hunyuan_video1_5 import (
+            HunyuanVideo15Transformer3DModel,
+        )
+
+        config = deepcopy(CONFIG)
+        config["num_layers"] = 1
+        model_config = _create_model_config(config)
+        dtype = torch.bfloat16
+
+        model = HunyuanVideo15Transformer3DModel(model_config).to(self.DEVICE, dtype=dtype).eval()
+
+        (
+            hidden_states,
+            encoder_hidden_states,
+            image_embeds,
+            encoder_attention_mask,
+            encoder_hidden_states_2,
+            encoder_attention_mask_2,
+            timestep,
+        ) = _make_inputs(config, dtype, self.DEVICE)
+
+        with torch.no_grad():
+            output = model(
+                hidden_states=hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
+                timestep=timestep,
+                encoder_attention_mask=encoder_attention_mask,
+                encoder_hidden_states_2=encoder_hidden_states_2,
+                image_embeds=image_embeds,
+                encoder_attention_mask_2=encoder_attention_mask_2,
+            )
+
+        # Model returns {"sample": tensor}
+        if isinstance(output, dict):
+            output = output["sample"]
+
+        # Note: With random weights, NaN can occur. For unit tests, we only check shape.
+        # Full numerical correctness is tested in TestFluxHuggingFaceComparison.
+        self.assertEqual(output.shape, hidden_states.shape)
+
+
+class TestHunyuanVideo15HuggingFaceComparison(unittest.TestCase):
+    DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_hunyuan_video1_5_allclose_to_hf(self):
+        try:
+            from diffusers import (
+                HunyuanVideo15Transformer3DModel as HFHunyuanVideo15Transformer3DModel,
+            )
+        except ImportError:
+            self.skipTest("diffusers not installed")
+
+        from tensorrt_llm._torch.visual_gen.models.hunyuan_video1_5.transformer_hunyuan_video1_5 import (
+            HunyuanVideo15Transformer3DModel,
+        )
+
+        torch.manual_seed(42)
+
+        # Create TRT-LLM Model
+        config = deepcopy(CONFIG)
+        config["num_layers"] = 1
+        model_config = _create_model_config(config)
+        dtype = torch.bfloat16
+        trtllm_model = (
+            HunyuanVideo15Transformer3DModel(model_config).to(self.DEVICE, dtype=dtype).eval()
+        )
+
+        hf_model = (
+            HFHunyuanVideo15Transformer3DModel(
+                in_channels=config["in_channels"], num_layers=config["num_layers"]
+            )
+            .to(self.DEVICE, dtype=dtype)
+            .eval()
+        )
+
+        # Copy weights from HF to TRT-LLM
+        hf_state_dict = hf_model.state_dict()
+        trtllm_model.load_weights(hf_state_dict)
+
+        # Create inputs
+        (
+            hidden_states,
+            encoder_hidden_states,
+            image_embeds,
+            encoder_attention_mask,
+            encoder_hidden_states_2,
+            encoder_attention_mask_2,
+            timestep,
+        ) = _make_inputs(config, dtype, self.DEVICE)
+
+        with torch.no_grad():
+            hf_output = hf_model(
+                hidden_states=hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
+                timestep=timestep,
+                encoder_attention_mask=encoder_attention_mask,
+                encoder_hidden_states_2=encoder_hidden_states_2,
+                image_embeds=image_embeds,
+                encoder_attention_mask_2=encoder_attention_mask_2,
+                return_dict=False,
+            )[0]
+
+            trtllm_output = trtllm_model(
+                hidden_states=hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
+                timestep=timestep,
+                encoder_attention_mask=encoder_attention_mask,
+                encoder_hidden_states_2=encoder_hidden_states_2,
+                image_embeds=image_embeds,
+                encoder_attention_mask_2=encoder_attention_mask_2,
+            )
+
+        # Model returns {"sample": tensor}
+        if isinstance(trtllm_output, dict):
+            trtllm_output = trtllm_output["sample"]
+
+        # Compare outputs
+        hf_output = hf_output.float()
+        trtllm_output = trtllm_output.float()
+
+        cos_sim = F.cosine_similarity(
+            hf_output.flatten().unsqueeze(0), trtllm_output.flatten().unsqueeze(0)
+        ).item()
+
+        max_diff = (hf_output - trtllm_output).abs().max().item()
+
+        print("\n[HunyuanVideo1.5 HF Comparison]")
+        print(f"  Cosine similarity: {cos_sim:.6f}")
+        print(f"  Max diff: {max_diff:.6f}")
+
+        self.assertGreater(cos_sim, 0.99, f"Cosine similarity too low: {cos_sim}")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unittest/_torch/visual_gen/test_hunyuan_video1_5_transformer.py
+++ b/tests/unittest/_torch/visual_gen/test_hunyuan_video1_5_transformer.py
@@ -35,6 +35,8 @@ CONFIG = {
     "torch_dtype": "bfloat16",
 }
 
+NUM_TRAIN_TIMESTEPS = 1000
+
 
 def _create_model_config(config_dict: dict, backend: str = "VANILLA") -> DiffusionModelConfig:
     """Create DiffusionModelConfig from config dict."""
@@ -98,7 +100,8 @@ def _make_inputs(config, dtype, device):
 
     encoder_attention_mask_2 = torch.ones(batch_size, sequence_length, device=device, dtype=dtype)
 
-    timestep = torch.tensor([1], device=device, dtype=dtype)
+    # Normalized timestep in [0, 1]; 0.5 is exact in bf16 so it round-trips cleanly.
+    timestep = torch.tensor([0.5], device=device, dtype=dtype)
 
     return (
         hidden_states,
@@ -238,10 +241,11 @@ class TestHunyuanVideo15HuggingFaceComparison(unittest.TestCase):
         ) = _make_inputs(config, dtype, self.DEVICE)
 
         with torch.no_grad():
+            # HF consumes the raw timestep; TRT-LLM consumes the normalized one.
             hf_output = hf_model(
                 hidden_states=hidden_states,
                 encoder_hidden_states=encoder_hidden_states,
-                timestep=timestep,
+                timestep=timestep * NUM_TRAIN_TIMESTEPS,
                 encoder_attention_mask=encoder_attention_mask,
                 encoder_hidden_states_2=encoder_hidden_states_2,
                 image_embeds=image_embeds,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HunyuanVideo 1.5 text-to-video support in VisualGen.
  * Added single-GPU FP8 dynamic quantization configuration.
  * Added pipeline, transformer, attention, timestep embedding, and checkpoint-loading support.
  * Registered `HunyuanVideo15Pipeline` as a public model export.
  * Added offline generation and serving examples.
  * Added support limitations for batch generation, image conditioning, caching, and parallelism.

## Documentation

* Updated the supported-model table and feature matrix.
* Added HunyuanVideo 1.5 usage and configuration instructions.

## Dev Engineer Review

* The implementation adds the HunyuanVideo 1.5 pipeline and transformer components.
* Configuration files define single-GPU execution with `cfg_size: 1` and `ulysses_size: 1`.
* The pipeline rejects unsupported multi-prompt and image-conditioned requests.
* Review the return annotation of `HunyuanVideo15AdaNorm.forward`; it does not match the two tensors returned by the implementation.
* Planned cache support, parallelism, and Sage attention support are not included.

## QA Engineer Review

* Added transformer tests for model structure, output shape, Hugging Face parity, dtype handling, and quantization.
* Added pipeline tests for video generation, batch validation, attention configuration, FP8/NVFP4 loading, accuracy, and memory usage.
* Added integration tests for LPIPS golden-video validation and end-to-end example execution.
* Added the transformer and pipeline unit tests, the Hunyuan T2V example test, and the LPIPS accuracy test to `tests/integration/test_lists/test-db/l0_b200.yml`.
* The test-list entries cover the added test modules and integration tests.
* Verdict: sufficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Added support for HunyuanVideo1.5 T2V pipeline along with unit tests and example to VisualGen. Wanted to get this merged then follow up with cache, parallelism, and maybe sage attention support

## Test Coverage

Added test_hunyuan_video1_5_transformer.py and test_hunyuan_video1_5_pipeline.py


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [X] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
