### PR TITLE
[#15613][fix] Gemma4 multimodal: fix vision TP and xgrammar startup crashes

### DIFF
--- a/tensorrt_llm/_torch/models/modeling_gemma4_vision.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4_vision.py
@@ -949,8 +949,12 @@ class Gemma4VisionModel(nn.Module):
 
         hf_hd = first_attn.hf_head_dim
         padded_hd = first_attn.head_dim
-        nh = first_attn.num_heads
-        nkv = first_attn.num_key_value_heads
+        # first_attn.num_heads / num_key_value_heads are already divided by
+        # tp_size, but these weights are still unsharded here, so read the full
+        # head counts from the vision config (no-op at tp1).
+        vc = first_attn.vision_config
+        nh = vc.num_attention_heads
+        nkv = getattr(vc, "num_key_value_heads", nh)
         pad_w = padded_hd - hf_hd
 
         # HF keys at this point have already had ``.linear.`` stripped if the

--- a/tensorrt_llm/_torch/models/modeling_gemma4mm.py
+++ b/tensorrt_llm/_torch/models/modeling_gemma4mm.py
@@ -769,6 +769,10 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
         return self.llm.infer_max_seq_len()
 
     @property
+    def vocab_size_padded(self) -> int:
+        return self.llm.vocab_size_padded
+
+    @property
     def multimodal_data_device_paths(self) -> List[str]:
         """Dotted paths in ``multimodal_data`` that the engine should ship to
         GPU. Anything not listed stays CPU-resident — notably


### PR DESCRIPTION
## Description

Fixes #15613.

Two independent startup crashes when serving Gemma4 multimodal (`Gemma4ForConditionalGeneration`) on the PyTorch backend. Both trigger on a stock build under specific configs and are isolated to Gemma4 — one small fix each.

**Fix 1 — vision tower crashes at `tp_size > 1`.** `Gemma4VisionModel._pad_attention_head_dim` zero-pads the vision q/k/v weights to round `head_dim` up to an FMHA-supported size (72 → 80). It runs on the **full, unsharded** checkpoint (the TP split happens later), but sized the reshape from `first_attn.num_heads` — which `Attention.__init__` has already divided by `tp_size`. At `tp_size=2` it expects half the rows the weight actually has and asserts at load time:

```
AssertionError: Unexpected qkv shape (1152, 1152) ... (expected first dim = 8*72)
```

The fix reads the unsharded counts from `vision_config` (`num_attention_heads` / `num_key_value_heads`), correct at any `tp_size`. No-op at `tp_size=1`.

**Fix 2 — xgrammar guided decoding crashes at startup.** `py_executor_creator` reads `model.vocab_size_padded` to build the xgrammar token bitmask. Text-only models inherit this from `DecoderModelForCausalLM`, but the multimodal wrapper holds the language model as `self.llm` and doesn't, so `guided_decoding_backend=xgrammar` crashes:

```
'Gemma4ForConditionalGeneration' object has no attribute 'vocab_size_padded'
```

The fix delegates the property to `self.llm`, matching `modeling_gemma3vl` and the other multimodal wrappers.

## Test Coverage

Verified by serving Gemma-4-31B multimodal on B200 with `--tp_size 2` and `guided_decoding_backend=xgrammar`: both crashes are gone, startup completes, and structured-output (`json_object` / `json_schema`) requests succeed. Both changes are confined to Gemma4 model files and are no-ops for the previously-working paths (`tp_size=1`; non-xgrammar decoding).

## PR Checklist

- [x] PR description clearly explains what and why.
- [x] PR follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of my knowledge.
- [x] No API changes (no `api-compatible` / `api-breaking` label needed).
- [x] No new dependencies.
- [x] No CODEOWNERS / documentation / architecture-diagram changes required.
