### PR TITLE
[None][feat] Support DSA cross-layer indexer top-k sharing (e.g. GLM-5.2)

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -96,6 +96,10 @@ class DSAParams(SparseParams):
     indexer_rope_interleave: bool = False
     enable_heuristic_topk: bool = False
     indexer_k_dtype: Literal["fp8", "fp4"] = "fp8"
+    # Cross-layer indexer sharing: whether this layer runs its own indexer
+    # ("full") or reuses the previous full layer's top-k ("shared"). Always
+    # True for a dense per-layer indexer (e.g. DeepSeek-V3.2).
+    is_full_indexer_layer: bool = True
 
     @property
     def indices_block_size(self) -> int:
@@ -555,6 +559,9 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
     indexer_quant_block_size: int = 128
     # Enable indexer skip for short sequences
     enable_indexer_skip: bool = False
+    # Cross-layer indexer sharing: previous full layer's top-k, reused by
+    # "shared" layers (None for a dense per-layer indexer).
+    shared_topk_indices: Optional[torch.Tensor] = None
     # Whether skip the indexer for context requests
     skip_indexer_for_ctx_reqs: bool = False
     # Whether skip the indexer for generation requests
@@ -655,6 +662,9 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
     def prepare(self):
         super().prepare()
         self._invalidate_pool_view_cache()
+        # Cross-layer indexer sharing is per-step state; clear it so a "shared"
+        # layer can never reuse a previous step's top-k before a full layer runs.
+        self.shared_topk_indices = None
 
         # Get kv lengths
         assert self.kv_cache_params.use_cache is True, "DSA requires use_cache to be True"
@@ -718,6 +728,9 @@ class DSAtrtllmAttentionMetadata(TrtllmAttentionMetadata):
         # pool_view cache here so it is recomputed on the next
         # transform_local_topk_and_prepare_pool_view() call.
         self._invalidate_pool_view_cache()
+        # Per-step state for cross-layer indexer sharing; clear at the step
+        # boundary so a "shared" layer never reuses a stale top-k.
+        self.shared_topk_indices = None
 
         if self.kv_cache_manager is not None and self.num_tokens > 0:
             seq_lens = self.seq_lens_cuda[:self.num_seqs]
@@ -2934,14 +2947,24 @@ class DSATrtllmAttention(TrtllmAttention):
             attention_chunk_size=attention_chunk_size,
             **kwargs)
 
-        self.indexer = Indexer(quant_config,
-                               pos_embd_params,
-                               mla_params,
-                               skip_create_weights_in_init,
-                               sparse_params,
-                               dtype=dtype,
-                               layer_idx=layer_idx,
-                               aux_stream=aux_stream)
+        # Cross-layer indexer sharing: only "full" layers own an indexer;
+        # "shared" layers reuse the previous full layer's top-k (see
+        # MLA.forward_dsa_*). Resolved per-layer in to_sparse_params; defaults to
+        # full (dense per-layer indexer). indexer=None also makes the weight
+        # loader skip the (absent) shared-layer indexer weights.
+        self.is_full_indexer_layer = getattr(sparse_params,
+                                             'is_full_indexer_layer', True)
+        if self.is_full_indexer_layer:
+            self.indexer = Indexer(quant_config,
+                                   pos_embd_params,
+                                   mla_params,
+                                   skip_create_weights_in_init,
+                                   sparse_params,
+                                   dtype=dtype,
+                                   layer_idx=layer_idx,
+                                   aux_stream=aux_stream)
+        else:
+            self.indexer = None
 
     def sparse_attn_predict(
         self,

--- a/tensorrt_llm/_torch/modules/attention.py
+++ b/tensorrt_llm/_torch/modules/attention.py
@@ -1111,6 +1111,10 @@ def _mla_dsa_proj_fake(
     k_pe = hidden_states.new_empty([num_tokens, mla_layer.qk_rope_head_dim])
     latent_cache = hidden_states.new_empty(
         [num_tokens, mla_layer.kv_lora_rank + mla_layer.qk_rope_head_dim])
+    if indexer is None:
+        # DSA "shared" layer: no indexer, mirror forward_dsa_proj's early
+        # return of only the 4 base tensors (no indexer intermediates).
+        return [q, compressed_kv, k_pe, latent_cache]
     # Indexer intermediates: q_fp8, k_fp8, k_scale, weights, q_scale.
     # Under FP4 q_fp8's trailing dim is head_dim // 2 (two E2M1 codes per
     # byte) and q_scale carries one int32 per (token, head) packing four
@@ -2113,6 +2117,11 @@ class MLA(nn.Module):
         if use_short_mha_for_ctx and attn_metadata.num_generations == 0:
             return [q, compressed_kv, k_pe, latent_cache]
 
+        # DSA "shared" layer: no indexer; reuses the previous full layer's
+        # top-k (in forward_dsa_attn), so skip the projection.
+        if self.mqa.indexer is None:
+            return [q, compressed_kv, k_pe, latent_cache]
+
         # pre_indexer_proj is the CUDA-graph-safe portion: pure token-wise
         # compute (cublas_mm, rope, FP4/FP8 quantize, weight scaling) with no
         # access to batch-specific metadata or the k cache. Returns q_scale
@@ -2166,6 +2175,14 @@ class MLA(nn.Module):
 
         if use_short_mha_for_ctx and num_generations == 0:
             topk_indices = None
+        elif self.mqa.indexer is None:
+            # DSA "shared" layer: reuse the previous full layer's top-k. These
+            # are local token positions, so they are layer-agnostic; each layer
+            # applies its own paged-KV transform downstream.
+            topk_indices = getattr(attn_metadata, 'shared_topk_indices', None)
+            assert topk_indices is not None, (
+                "DSA shared layer has no top-k from a preceding full indexer "
+                "layer; check the index_topk_pattern/freq schedule.")
         else:
             q_fp8, k_fp8, k_scale, weights, q_scale = indexer_intermediates
             # Slice indexer intermediates to actual num_tokens (they were
@@ -2184,6 +2201,9 @@ class MLA(nn.Module):
                 weights,
                 q_scale=q_scale,
             )
+            # Stash for subsequent DSA "shared" layers (full -> shared reuse);
+            # unused by a dense per-layer indexer.
+            attn_metadata.shared_topk_indices = topk_indices
 
         assert output is not None, "output must be provided"
 

--- a/tensorrt_llm/_torch/pyexecutor/config_utils.py
+++ b/tensorrt_llm/_torch/pyexecutor/config_utils.py
@@ -532,6 +532,17 @@ def load_pretrained_config(model_name_or_path: str,
         model_config.text_config = transformers.Qwen3NextConfig.from_dict(
             _Qwen35ConfigCompat.normalize(config_dict,
                                           require_text_config=True))
+    elif model_type == "glm_moe_dsa":
+        # GLM-MoE-DSA configs tag every layer with
+        # layer_types=['deepseek_sparse_attention', ...] for HF bookkeeping.
+        # TRT-LLM never reads it (get_layer_types is Gemma3-only; DSA layer
+        # routing is driven by index_topk_freq / index_skip_topk_offset), and
+        # transformers' validate_layer_type rejects the unknown entry. Drop the
+        # unused field and build from the dict via the registered config class,
+        # mirroring the exaone4 handling below.
+        config_dict.pop("layer_types", None)
+        model_config = _CONFIG_REGISTRY[model_type].from_dict(
+            config_dict, **kwargs)
     elif model_type in _CONFIG_REGISTRY:
         config_class = _CONFIG_REGISTRY[model_type]
         model_config = config_class.from_pretrained(model_name_or_path,

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -818,6 +818,37 @@ class DeepSeekSparseAttentionConfig(SeqLenAwareSparseAttentionConfig):
         self.seq_len_threshold = self.index_topk
         return self.skip_indexer_for_short_seqs
 
+    @staticmethod
+    def _is_full_indexer_layer(pretrained_config, layer_idx) -> bool:
+        """Whether a DSA layer runs its own indexer ("full") or reuses the
+        previous full layer's top-k ("shared") -- cross-layer indexer sharing.
+
+        Resolved from the HF config: index_topk_pattern, else
+        index_topk_freq/index_skip_topk_offset. The MTP/nextn layer
+        (>= num_hidden_layers) is always full. Defaults to full (a dense
+        per-layer indexer, e.g. DeepSeek-V3.2).
+        """
+        if pretrained_config is None or layer_idx is None:
+            return True
+        n = getattr(pretrained_config, "num_hidden_layers", None)
+        if n is not None and layer_idx >= n:
+            return True  # MTP/nextn layer
+        pattern = getattr(pretrained_config, "index_topk_pattern", None)
+        if pattern is not None:
+            is_full = not (layer_idx < len(pattern)
+                           and str(pattern[layer_idx]).upper() == "S")
+        else:
+            freq = max(getattr(pretrained_config, "index_topk_freq", 1) or 1, 1)
+            offset = getattr(pretrained_config, "index_skip_topk_offset", 2)
+            is_full = (max(layer_idx - offset + 1, 0) % freq) == 0
+        if layer_idx == 0 and not is_full:
+            logger.warning(
+                "DSA layer 0 resolved to 'shared' but has no prior full layer's "
+                "top-k to reuse; forcing it to 'full'. Check index_topk_pattern."
+            )
+            is_full = True
+        return is_full
+
     def to_sparse_params(self, **kwargs):
         from tensorrt_llm._torch.attention_backend.sparse.dsa import DSAParams
 
@@ -843,6 +874,8 @@ class DeepSeekSparseAttentionConfig(SeqLenAwareSparseAttentionConfig):
             indexer_rope_interleave=self.indexer_rope_interleave,
             enable_heuristic_topk=self.enable_heuristic_topk,
             indexer_k_dtype=self.indexer_k_dtype,
+            is_full_indexer_layer=self._is_full_indexer_layer(
+                pretrained_config, kwargs.get("layer_idx")),
         )
 
     def to_sparse_metadata_params(self, **kwargs):

--- a/tensorrt_llm/llmapi/llm_utils.py
+++ b/tensorrt_llm/llmapi/llm_utils.py
@@ -701,15 +701,19 @@ class ModelLoader:
             trust_remote_code: bool = True,
             **kwargs) -> Optional[transformers.PretrainedConfig]:
         try:
-            # Route via AutoConfig so model_types registered through
-            # transformers.models.auto.configuration_auto.CONFIG_MAPPING
-            # (e.g. deepseek_v32 / kimi_k2 via tensorrt_llm/_torch/configs/)
-            # are dispatched to their TRT-LLM-local config class. Calling
-            # PretrainedConfig.from_pretrained directly bypasses CONFIG_MAPPING
-            # and on transformers 5.5.x returns a bare PretrainedConfig that
-            # lacks attributes like max_position_embeddings.
-            return transformers.AutoConfig.from_pretrained(
-                model_dir, trust_remote_code=trust_remote_code, **kwargs)
+            # Route via load_pretrained_config so model_types registered in
+            # TRT-LLM's _CONFIG_REGISTRY (e.g. deepseek_v32 / kimi_k2 /
+            # glm_moe_dsa) are dispatched to their TRT-LLM-local config class
+            # and get the same compat handling as the engine's own config load
+            # (e.g. dropping GLM-MoE-DSA's unsupported layer_types); it falls
+            # back to AutoConfig for everything else. Calling AutoConfig /
+            # PretrainedConfig.from_pretrained directly here would instead hit
+            # transformers' validate_layer_type and return None.
+            from tensorrt_llm._torch.pyexecutor.config_utils import \
+                load_pretrained_config
+            return load_pretrained_config(model_dir,
+                                          trust_remote_code=trust_remote_code,
+                                          **kwargs)
         except Exception as e:
             logger.warning(
                 f"Failed to load hf model config from {model_dir}, encountered error: {e}"

--- a/tensorrt_llm/models/modeling_utils.py
+++ b/tensorrt_llm/models/modeling_utils.py
@@ -257,6 +257,13 @@ class QuantConfig(StrictBaseModel):
         module (without a glob suffix) implicitly excludes all of its
         children.
 
+        A trailing ``.*`` subtree wildcard also matches the parent node
+        itself, so an entry like ``model.layers.1.*`` excludes both
+        ``model.layers.1`` and everything under it. This keeps a subtree
+        exclusion consistent regardless of whether the producer wrote it as
+        ``model.layers.1`` / ``model.layers.1*`` / ``model.layers.1.*``
+        (modelopt mixes these forms within a single checkpoint).
+
         Args:
             name (str): The name of the module.
 
@@ -272,6 +279,9 @@ class QuantConfig(StrictBaseModel):
                     if re.fullmatch(exclude_module[3:], candidate):
                         return True
                 elif fnmatch.fnmatchcase(candidate, exclude_module):
+                    return True
+                elif exclude_module.endswith(".*") and fnmatch.fnmatchcase(
+                        candidate, exclude_module[:-2]):
                     return True
             if '.' not in candidate:
                 return False

--- a/tensorrt_llm/tokenizer/tokenizer.py
+++ b/tensorrt_llm/tokenizer/tokenizer.py
@@ -272,13 +272,19 @@ class TransformersTokenizer(TokenizerBase):
         try:
             tokenizer = AutoTokenizer.from_pretrained(pretrained_model_dir,
                                                       **kwargs)
-        except AttributeError as e:
-            # transformers 5.x: bare PreTrainedConfig fallback (for model_types
-            # not in CONFIG_MAPPING_NAMES, e.g. deepseek_v32) hits
-            # modeling_rope_utils → self.max_position_embeddings → AttributeError
-            # because PreTrainedConfig is now a dataclass with declared fields.
-            # See deepseek-ai/DeepSeek-V3#1207.
-            if "max_position_embeddings" not in str(e):
+        except Exception as e:
+            # Two transformers 5.x regressions for model_types not registered
+            # in CONFIG_MAPPING_NAMES. PreTrainedTokenizerFast reads
+            # tokenizer.json directly and skips AutoConfig, so it sidesteps
+            # both:
+            #  - deepseek_v32: bare PreTrainedConfig fallback hits
+            #    modeling_rope_utils → self.max_position_embeddings →
+            #    AttributeError (PreTrainedConfig is now a dataclass with
+            #    declared fields). See deepseek-ai/DeepSeek-V3#1207.
+            #  - glm_moe_dsa: layer_types=['deepseek_sparse_attention', ...] is
+            #    rejected by validate_layer_type (not in ALLOWED_LAYER_TYPES).
+            msg = str(e)
+            if "max_position_embeddings" not in msg and "layer_types" not in msg:
                 raise
             tokenizer = _fallback_to_fast_tokenizer(pretrained_model_dir, e,
                                                     **kwargs)

--- a/tests/integration/defs/accuracy/references/gsm8k.yaml
+++ b/tests/integration/defs/accuracy/references/gsm8k.yaml
@@ -458,6 +458,10 @@ zai-org/GLM-5-FP8:
   - quant_algo: FP8_BLOCK_SCALES
     spec_dec_algo: MTP
     accuracy: 78.0
+zai-org/GLM-5.2-FP8:
+  - quant_algo: FP8_BLOCK_SCALES
+    spec_dec_algo: MTP
+    accuracy: 90
 # Step-3.7-Flash text decoder (MoE) GSM8K, full 1319-sample split, TP4/EP4 with
 # TRTLLM attention + MoE backends. FP8 measured on the FP8 block-scale
 # checkpoint; NVFP4 measured on the modelopt NVFP4 export (FP8 KV cache). MTP

--- a/tests/integration/defs/accuracy/references/gsm8k.yaml
+++ b/tests/integration/defs/accuracy/references/gsm8k.yaml
@@ -458,8 +458,9 @@ zai-org/GLM-5-FP8:
   - quant_algo: FP8_BLOCK_SCALES
     spec_dec_algo: MTP
     accuracy: 78.0
-zai-org/GLM-5.2-FP8:
-  - quant_algo: FP8_BLOCK_SCALES
+zai-org/GLM-5.2:
+  - quant_algo: NVFP4
+    kv_cache_quant_algo: FP8
     spec_dec_algo: MTP
     accuracy: 90
 # Step-3.7-Flash text decoder (MoE) GSM8K, full 1319-sample split, TP4/EP4 with

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -7372,3 +7372,35 @@ class TestStep3_7(LlmapiAccuracyTestHarness):
             assert llm.args.quant_config.quant_algo == QuantAlgo.NVFP4
             task = GSM8K(self.MODEL_NAME)
             task.evaluate(llm)
+
+
+class TestGLM52FP8(LlmapiAccuracyTestHarness):
+    MODEL_NAME = "zai-org/GLM-5.2-FP8"
+    MODEL_PATH = f"{llm_models_root()}/GLM-5.2-FP8"
+
+    @parametrize_with_ids("tp_size,ep_size", [(8, 8)])
+    @pytest.mark.skip_less_device(8)
+    def test_8gpus(self, tp_size, ep_size):
+        # GLM-5.2 reuses the DeepSeek-V3.2 path (MLA + DSA) with cross-layer
+        # indexer sharing: only "full" layers run the indexer, "shared" layers
+        # reuse the previous full layer's top-k.
+        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.7)
+
+        pytorch_config = dict(
+            disable_overlap_scheduler=False,
+            cuda_graph_config=CudaGraphConfig(max_batch_size=128,
+                                              enable_padding=True),
+            moe_config=MoeConfig(backend="DEEPGEMM"),
+            speculative_config=MTPDecodingConfig(max_draft_len=1),
+            enable_chunked_prefill=True,
+        )
+
+        with LLM(self.MODEL_PATH,
+                 tensor_parallel_size=tp_size,
+                 pipeline_parallel_size=1,
+                 moe_expert_parallel_size=ep_size,
+                 kv_cache_config=kv_cache_config,
+                 max_seq_len=8192,
+                 **pytorch_config) as llm:
+            task = GSM8K(self.MODEL_NAME)
+            task.evaluate(llm)

--- a/tests/integration/defs/accuracy/test_llm_api_pytorch.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch.py
@@ -7289,6 +7289,42 @@ class TestGLM5FP8(LlmapiAccuracyTestHarness):
             task.evaluate(llm)
 
 
+class TestGLM52(LlmapiAccuracyTestHarness):
+
+    @skip_pre_blackwell
+    @pytest.mark.skip_less_device(8)
+    @parametrize_with_ids("tp_size,ep_size", [(8, 8)])
+    def test_nvfp4(self, tp_size, ep_size):
+        # GLM-5.2 reuses the DeepSeek-V3.2 path (MLA + DSA) with cross-layer
+        # indexer sharing. NVFP4 weights run on the CuteDSL MoE backend with
+        # MTP speculative decoding. The checkpoint keeps the leading dense
+        # layers and per-MoE-layer shared_experts / self_attn in higher
+        # precision.
+        model_name = "zai-org/GLM-5.2"
+        model_path = f"{llm_models_root()}/GLM-5.2-NVFP4"
+        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.7)
+
+        pytorch_config = dict(
+            disable_overlap_scheduler=False,
+            cuda_graph_config=CudaGraphConfig(max_batch_size=128,
+                                              enable_padding=True),
+            moe_config=MoeConfig(backend="CUTEDSL"),
+            speculative_config=MTPDecodingConfig(max_draft_len=1),
+            enable_chunked_prefill=True,
+        )
+
+        with LLM(model_path,
+                 tensor_parallel_size=tp_size,
+                 pipeline_parallel_size=1,
+                 moe_expert_parallel_size=ep_size,
+                 kv_cache_config=kv_cache_config,
+                 max_seq_len=8192,
+                 **pytorch_config) as llm:
+            assert llm.args.quant_config.quant_algo == QuantAlgo.NVFP4
+            task = GSM8K(model_name)
+            task.evaluate(llm)
+
+
 @skip_pre_blackwell
 class TestStep3_7(LlmapiAccuracyTestHarness):
     # Step-3.7-Flash is a MoE model registered under the multimodal
@@ -7370,37 +7406,5 @@ class TestStep3_7(LlmapiAccuracyTestHarness):
                  trust_remote_code=True,
                  **pytorch_config) as llm:
             assert llm.args.quant_config.quant_algo == QuantAlgo.NVFP4
-            task = GSM8K(self.MODEL_NAME)
-            task.evaluate(llm)
-
-
-class TestGLM52FP8(LlmapiAccuracyTestHarness):
-    MODEL_NAME = "zai-org/GLM-5.2-FP8"
-    MODEL_PATH = f"{llm_models_root()}/GLM-5.2-FP8"
-
-    @parametrize_with_ids("tp_size,ep_size", [(8, 8)])
-    @pytest.mark.skip_less_device(8)
-    def test_8gpus(self, tp_size, ep_size):
-        # GLM-5.2 reuses the DeepSeek-V3.2 path (MLA + DSA) with cross-layer
-        # indexer sharing: only "full" layers run the indexer, "shared" layers
-        # reuse the previous full layer's top-k.
-        kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.7)
-
-        pytorch_config = dict(
-            disable_overlap_scheduler=False,
-            cuda_graph_config=CudaGraphConfig(max_batch_size=128,
-                                              enable_padding=True),
-            moe_config=MoeConfig(backend="DEEPGEMM"),
-            speculative_config=MTPDecodingConfig(max_draft_len=1),
-            enable_chunked_prefill=True,
-        )
-
-        with LLM(self.MODEL_PATH,
-                 tensor_parallel_size=tp_size,
-                 pipeline_parallel_size=1,
-                 moe_expert_parallel_size=ep_size,
-                 kv_cache_config=kv_cache_config,
-                 max_seq_len=8192,
-                 **pytorch_config) as llm:
             task = GSM8K(self.MODEL_NAME)
             task.evaluate(llm)

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -475,6 +475,7 @@ accuracy/test_llm_api_pytorch.py::TestGemma3_1BInstruct::test_fp8_vswa_reuse
 accuracy/test_llm_api_pytorch.py::TestGemma3_27BInstruct::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestGemma3_27BInstruct::test_fp8_prequantized
 accuracy/test_llm_api_pytorch.py::TestGLM5FP8::test_8gpus[tp_size=8-ep_size=8]
+accuracy/test_llm_api_pytorch.py::TestGLM52FP8::test_8gpus[tp_size=8-ep_size=8]
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_dummy_load_format
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_eagle3_2gpus[cutlass-one_model-overlap_scheduler]
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_eagle3_2gpus[cutlass-two_model-overlap_scheduler]

--- a/tests/integration/test_lists/qa/llm_function_core.txt
+++ b/tests/integration/test_lists/qa/llm_function_core.txt
@@ -475,7 +475,7 @@ accuracy/test_llm_api_pytorch.py::TestGemma3_1BInstruct::test_fp8_vswa_reuse
 accuracy/test_llm_api_pytorch.py::TestGemma3_27BInstruct::test_auto_dtype
 accuracy/test_llm_api_pytorch.py::TestGemma3_27BInstruct::test_fp8_prequantized
 accuracy/test_llm_api_pytorch.py::TestGLM5FP8::test_8gpus[tp_size=8-ep_size=8]
-accuracy/test_llm_api_pytorch.py::TestGLM52FP8::test_8gpus[tp_size=8-ep_size=8]
+accuracy/test_llm_api_pytorch.py::TestGLM52::test_nvfp4[tp_size=8-ep_size=8]
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_dummy_load_format
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_eagle3_2gpus[cutlass-one_model-overlap_scheduler]
 accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_eagle3_2gpus[cutlass-two_model-overlap_scheduler]

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -162,6 +162,7 @@ l0_dgx_b200:
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_dsa_host_cache_offload[host_cache_offload] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_dsa_host_cache_offload[host_cache_offload_mtp1] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_dsa_host_cache_offload[host_cache_offload_mtp3_no_adp] TIMEOUT (60)
+  - accuracy/test_llm_api_pytorch.py::TestGLM52FP8::test_8gpus[tp_size=8-ep_size=8] TIMEOUT (60)
   - accuracy/test_disaggregated_serving.py::TestDeepSeekV32Exp::test_auto_dtype[False] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[tp8] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_8gpus_mtp TIMEOUT (60)

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -162,7 +162,7 @@ l0_dgx_b200:
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_dsa_host_cache_offload[host_cache_offload] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_dsa_host_cache_offload[host_cache_offload_mtp1] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_dsa_host_cache_offload[host_cache_offload_mtp3_no_adp] TIMEOUT (60)
-  - accuracy/test_llm_api_pytorch.py::TestGLM52FP8::test_8gpus[tp_size=8-ep_size=8] TIMEOUT (60)
+  - accuracy/test_llm_api_pytorch.py::TestGLM52::test_nvfp4[tp_size=8-ep_size=8] TIMEOUT (60)
   - accuracy/test_disaggregated_serving.py::TestDeepSeekV32Exp::test_auto_dtype[False] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[tp8] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_8gpus_mtp TIMEOUT (60)


### PR DESCRIPTION
## What

Add **cross-layer indexer sharing** to DeepSeek-style sparse attention (DSA): `"full"` layers run the lightning indexer; `"shared"` layers reuse the previous full layer's top-k. The old DSA path assumed an indexer on every layer, so it fails to load GLM-5.2 (`GlmMoeDsaForCausalLM`), whose checkpoint has no indexer weights on shared layers. This PR also enables the GLM-5.2 **NVFP4** checkpoint. Dense per-layer DSA (e.g. DeepSeek-V3.2) is unchanged.

## Design choices

- **HF-config-driven, no new engine arg** (matches vLLM/SGLang IndexCache). Per-layer placement is resolved in `DeepSeekSparseAttentionConfig.to_sparse_params`: `index_topk_pattern` > `index_topk_freq`/`index_skip_topk_offset`; MTP layer always full; defaults to full (dense indexer). Like upstream, the checkpoint's `indexer_types` array is not read — for GLM-5.2 the freq/offset fields reproduce it exactly (21 full / 57 shared).
  - Also https://github.com/THUDM/IndexCache/blob/main/indexcache.patch#L102 for reference
- **Build the indexer only on `"full"` layers** (`None` on `"shared"`); this also makes the weight loader skip the absent shared-layer indexer weights.
- **Shared layers reuse the stashed top-k** in the MLA forward (top-k are local token positions → layer-agnostic; each layer applies its own paged-KV transform).
- **NVFP4 mixed precision**: a trailing `.*` exclude wildcard now also matches the parent module, so modelopt's mixed `model.layers.0*` / `model.layers.1.*` forms both exclude the leading dense layers — otherwise they were built NVFP4 over unquantized weights and crashed on a missing `input_scale`.
- **`layer_types=['deepseek_sparse_attention', ...]` compat**: the field is unused by TRT-LLM but rejected by the pinned transformers' `validate_layer_type`. It is dropped in `load_pretrained_config`, with a fast-tokenizer fallback and `load_hf_model_config` routed through the same loader — no mutation of transformers globals.

## Accuracy (GSM8K)

| Model / setting | Score |
|---|---|
| `zai-org/GLM-5.2-FP8`, full 1319 (chat template, CUDA graph) | 95.7% |
| `zai-org/GLM-5.2-FP8`, harness regime (256-tok, no chat template) | 94.16% |
| `zai-org/GLM-5.2-FP8` + MTP (`max_draft_len=1`) | lossless |
| `nvidia/GLM-5.2-NVFP4`, CuteDSL MoE + MTP (200 samples) | 97.0% |

Reference set to 90 for run-to-run margin.

## Perf (disaggregated serving, FP8, GB300×4, ctx1+gen1 TP4, 8k/1k — functional)

| Concurrency | Throughput | Median TTFT | Median TPOT |
|---|---|---|---|
| 32 | 7,126 tok/s | 5.56 s | 31 ms |
| 256 | 13,093 tok/s | 68.6 s | 40 ms |

## Test

`TestGLM52::test_nvfp4` (TP8/EP8, NVFP4, CuteDSL MoE, MTP `max_draft_len=1`) — pre-merge L0 on **B200×8** (`l0_dgx_b200.yml`, alongside DeepSeek-V3.2) + QA (`qa/llm_function_core.txt`); `gsm8k.yaml` reference `90`.
