### PR TITLE
[TRTLLM-13444][test] Add Qwen-Image text-to-image unit tests

### DIFF
--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -116,6 +116,8 @@ l0_a10:
   - unittest/visual_gen/test_output.py
   - unittest/visual_gen/test_media_encoding.py
   - unittest/_torch/visual_gen/test_tensor_payload.py
+  - unittest/_torch/visual_gen/test_qwen_image_infer.py
+  - unittest/_torch/visual_gen/test_qwen_image_pipeline.py
   # llmapi
   - unittest/llmapi/test_llm_utils.py
   - unittest/llmapi/test_gc_utils.py

--- a/tests/unittest/_torch/visual_gen/test_qwen_image_infer.py
+++ b/tests/unittest/_torch/visual_gen/test_qwen_image_infer.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``QwenImagePipeline.infer`` request orchestration.
+
+Covers batch fan-out (``num_images_per_prompt``, multiple prompts),
+negative-prompt broadcasting/validation, and generation-parameter pass-through.
+``forward`` is stubbed to capture the arguments it receives, so these run on
+CPU with no model or weights.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from tensorrt_llm._torch.visual_gen.models.qwen_image import QwenImagePipeline
+
+
+def _pipeline_with_captured_forward():
+    pipe = QwenImagePipeline.__new__(QwenImagePipeline)
+    captured = {}
+    pipe.forward = lambda **kwargs: captured.update(kwargs) or "image"
+    return pipe, captured
+
+
+def _req(
+    prompt,
+    *,
+    num_images_per_prompt=1,
+    negative_prompt=None,
+    height=1328,
+    width=1328,
+    num_inference_steps=2,
+    guidance_scale=4.0,
+    seed=42,
+    max_sequence_length=64,
+):
+    params = SimpleNamespace(
+        num_images_per_prompt=num_images_per_prompt,
+        negative_prompt=negative_prompt,
+        height=height,
+        width=width,
+        num_inference_steps=num_inference_steps,
+        guidance_scale=guidance_scale,
+        seed=seed,
+        max_sequence_length=max_sequence_length,
+    )
+    return SimpleNamespace(prompt=prompt, params=params)
+
+
+@pytest.mark.parametrize(
+    ("prompt", "num_per", "negative", "exp_prompts", "exp_negs"),
+    [
+        ("a cat", 1, None, ["a cat"], None),
+        ("a cat", 3, None, ["a cat", "a cat", "a cat"], None),
+        (["a", "b"], 2, None, ["a", "a", "b", "b"], None),
+        (["a", "b"], 2, "bad", ["a", "a", "b", "b"], ["bad", "bad", "bad", "bad"]),
+        (["a", "b"], 2, ["bad"], ["a", "a", "b", "b"], ["bad", "bad", "bad", "bad"]),
+        (["a", "b"], 2, ["n0", "n1"], ["a", "a", "b", "b"], ["n0", "n0", "n1", "n1"]),
+    ],
+)
+def test_infer_fans_out_prompts_and_negatives(prompt, num_per, negative, exp_prompts, exp_negs):
+    pipe, captured = _pipeline_with_captured_forward()
+    result = pipe.infer(_req(prompt, num_images_per_prompt=num_per, negative_prompt=negative))
+    assert result == "image"
+    assert captured["prompt"] == exp_prompts
+    assert captured["negative_prompt"] == exp_negs
+
+
+def test_infer_forwards_generation_params():
+    pipe, captured = _pipeline_with_captured_forward()
+    pipe.infer(
+        _req(
+            "a cat",
+            height=768,
+            width=1024,
+            num_inference_steps=7,
+            guidance_scale=3.25,
+            seed=123,
+            max_sequence_length=256,
+        )
+    )
+    assert captured["height"] == 768
+    assert captured["width"] == 1024
+    assert captured["num_inference_steps"] == 7
+    assert captured["true_cfg_scale"] == 3.25
+    assert captured["seed"] == 123
+    assert captured["max_sequence_length"] == 256
+
+
+def test_infer_rejects_mismatched_negative_prompt_count():
+    pipe, _ = _pipeline_with_captured_forward()
+    req = _req(["a", "b", "c"], negative_prompt=["n0", "n1"])
+    with pytest.raises(ValueError, match="negative_prompt"):
+        pipe.infer(req)

--- a/tests/unittest/_torch/visual_gen/test_qwen_image_pipeline.py
+++ b/tests/unittest/_torch/visual_gen/test_qwen_image_pipeline.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ``QwenImagePipeline.forward`` denoise-loop orchestration.
+
+Heavy model components are replaced by lightweight test doubles so the tests
+exercise pipeline wiring without loading a checkpoint or running a real
+transformer/VAE. Covers both the
+true-CFG path (dual cond/uncond forward plus the norm-preserving CFG
+combination) and the non-CFG path, on CPU.
+"""
+
+import torch
+
+from tensorrt_llm._torch.visual_gen.models.qwen_image import QwenImagePipeline
+
+
+class _RecordingTransformer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.in_channels = 4
+        self._device_anchor = torch.nn.Parameter(torch.zeros(()))
+        self.calls = []
+
+    def forward(
+        self,
+        *,
+        hidden_states,
+        timestep,
+        encoder_hidden_states_mask,
+        encoder_hidden_states,
+        img_shapes,
+        return_dict,
+    ):
+        self.calls.append(
+            {
+                "hidden_states_shape": tuple(hidden_states.shape),
+                "timestep": timestep.clone(),
+                "encoder_hidden_states": encoder_hidden_states.clone(),
+                "encoder_hidden_states_mask": encoder_hidden_states_mask.clone(),
+                "img_shapes": img_shapes,
+                "return_dict": return_dict,
+            }
+        )
+        values = [-0.5, 0.25, 1.5, -1.0] if encoder_hidden_states[0, 0, 0] < 0 else [1, 2, 3, 4]
+        pattern = torch.tensor(values, dtype=hidden_states.dtype, device=hidden_states.device)
+        return (pattern.view(1, 1, -1).expand_as(hidden_states).clone(),)
+
+
+class _RecordingScheduler:
+    def __init__(self):
+        self.config = {}
+        self.set_timesteps_call = None
+        self.begin_index = None
+        self.step_calls = []
+        self.timesteps = torch.empty(0)
+
+    def set_timesteps(self, *, sigmas, device, mu):
+        self.set_timesteps_call = {"sigmas": sigmas, "device": device, "mu": mu}
+        self.timesteps = torch.arange(len(sigmas), 0, -1, device=device, dtype=torch.float32)
+
+    def set_begin_index(self, index):
+        self.begin_index = index
+
+    def step(self, noise_pred, timestep, latents, *, return_dict):
+        self.step_calls.append(
+            {
+                "noise_pred_shape": tuple(noise_pred.shape),
+                "noise_pred": noise_pred.clone(),
+                "timestep": timestep.clone(),
+                "latents_shape": tuple(latents.shape),
+                "return_dict": return_dict,
+            }
+        )
+        return (latents - noise_pred * 0.1,)
+
+
+def _pipeline_with_test_doubles():
+    pipe = QwenImagePipeline.__new__(QwenImagePipeline)
+    torch.nn.Module.__init__(pipe)
+    pipe.vae_scale_factor = 8
+    pipe.transformer = _RecordingTransformer()
+    pipe.scheduler = _RecordingScheduler()
+    captured = {"encoded_prompts": []}
+
+    def _encode_prompt(prompt, device, max_sequence_length):
+        captured["encoded_prompts"].append((list(prompt), device, max_sequence_length))
+        sign = -1.0 if prompt and prompt[0] == "bad" else 1.0
+        embeds = torch.full((len(prompt), 2, 3), sign, device=device)
+        mask = torch.ones((len(prompt), 2), dtype=torch.bool, device=device)
+        return embeds, mask
+
+    def _prepare_latents(
+        batch_size,
+        num_channels_latents,
+        height,
+        width,
+        dtype,
+        device,
+        generator,
+    ):
+        captured["prepared_latents"] = {
+            "batch_size": batch_size,
+            "num_channels_latents": num_channels_latents,
+            "height": height,
+            "width": width,
+            "dtype": dtype,
+            "device": device,
+            "generator_device": generator.device,
+        }
+        return torch.ones((batch_size, 6, num_channels_latents * 4), dtype=dtype, device=device)
+
+    def _decode_latents(latents, height, width):
+        captured["decoded"] = {
+            "latents_shape": tuple(latents.shape),
+            "height": height,
+            "width": width,
+        }
+        return torch.full((latents.shape[0], height, width, 3), 7, dtype=torch.uint8)
+
+    pipe._encode_prompt = _encode_prompt
+    pipe._prepare_latents = _prepare_latents
+    pipe._decode_latents = _decode_latents
+    return pipe, captured
+
+
+def _expanded_noise(values, *, batch_size, seq_len, dtype=torch.float32):
+    pattern = torch.tensor(values, dtype=dtype)
+    return pattern.view(1, 1, -1).expand(batch_size, seq_len, -1)
+
+
+def test_forward_runs_without_true_cfg():
+    pipe, captured = _pipeline_with_test_doubles()
+
+    output = pipe.forward(
+        prompt=["a cat"],
+        negative_prompt=None,
+        height=32,
+        width=48,
+        num_inference_steps=3,
+        true_cfg_scale=4.0,
+        seed=123,
+        max_sequence_length=16,
+        sigmas=[1.0, 0.5, 0.25],
+    )
+
+    assert output.image.shape == (1, 32, 48, 3)
+    assert output.image.dtype == torch.uint8
+    assert captured["encoded_prompts"] == [(["a cat"], torch.device("cpu"), 16)]
+    assert captured["prepared_latents"]["batch_size"] == 1
+    assert captured["decoded"] == {"latents_shape": (1, 6, 4), "height": 32, "width": 48}
+    assert len(pipe.transformer.calls) == 3
+    assert pipe.transformer.calls[0]["img_shapes"] == [[(1, 2, 3)]]
+    assert pipe.transformer.calls[0]["hidden_states_shape"] == (1, 6, 4)
+    assert torch.all(pipe.transformer.calls[0]["encoder_hidden_states"] > 0)
+    assert len(pipe.scheduler.step_calls) == 3
+    assert torch.allclose(
+        pipe.scheduler.step_calls[0]["noise_pred"],
+        _expanded_noise([1, 2, 3, 4], batch_size=1, seq_len=6),
+    )
+
+
+def test_forward_runs_true_cfg_pipeline():
+    pipe, captured = _pipeline_with_test_doubles()
+
+    output = pipe.forward(
+        prompt=["a cat", "a dog"],
+        negative_prompt="bad",
+        height=32,
+        width=48,
+        num_inference_steps=2,
+        true_cfg_scale=3.0,
+        seed=123,
+        max_sequence_length=16,
+        sigmas=[1.0, 0.5],
+    )
+
+    assert output.image.shape == (2, 32, 48, 3)
+    assert output.image.dtype == torch.uint8
+    assert captured["encoded_prompts"] == [
+        (["a cat", "a dog"], torch.device("cpu"), 16),
+        (["bad", "bad"], torch.device("cpu"), 16),
+    ]
+    assert captured["prepared_latents"] == {
+        "batch_size": 2,
+        "num_channels_latents": 1,
+        "height": 32,
+        "width": 48,
+        "dtype": torch.float32,
+        "device": torch.device("cpu"),
+        "generator_device": torch.device("cpu"),
+    }
+    assert captured["decoded"] == {"latents_shape": (2, 6, 4), "height": 32, "width": 48}
+    assert len(pipe.transformer.calls) == 4
+    assert pipe.transformer.calls[0]["img_shapes"] == [[(1, 2, 3)]] * 2
+    assert pipe.transformer.calls[0]["hidden_states_shape"] == (2, 6, 4)
+    assert torch.all(pipe.transformer.calls[0]["encoder_hidden_states"] > 0)
+    assert torch.all(pipe.transformer.calls[1]["encoder_hidden_states"] < 0)
+    assert pipe.transformer.calls[0]["return_dict"] is False
+    assert pipe.scheduler.set_timesteps_call["sigmas"] == [1.0, 0.5]
+    assert pipe.scheduler.set_timesteps_call["device"] == torch.device("cpu")
+    assert pipe.scheduler.begin_index == 0
+    assert len(pipe.scheduler.step_calls) == 2
+    assert pipe.scheduler.step_calls[0]["noise_pred_shape"] == (2, 6, 4)
+    cond_noise = _expanded_noise([1, 2, 3, 4], batch_size=2, seq_len=6)
+    neg_noise = _expanded_noise([-0.5, 0.25, 1.5, -1.0], batch_size=2, seq_len=6)
+    combined_noise = neg_noise + 3.0 * (cond_noise - neg_noise)
+    expected_cfg_noise = combined_noise * (
+        torch.norm(cond_noise, dim=-1, keepdim=True)
+        / torch.norm(combined_noise, dim=-1, keepdim=True)
+    )
+    assert torch.allclose(pipe.scheduler.step_calls[0]["noise_pred"], expected_cfg_noise)
+    assert pipe.scheduler.step_calls[0]["return_dict"] is False


### PR DESCRIPTION
Add CPU-only unit tests for the VisualGen Qwen-Image pipeline:
- infer request orchestration: batch fan-out (num_images_per_prompt, multiple prompts), negative-prompt broadcasting and length validation, generation-parameter pass-through.
- forward denoise-loop: true-CFG and non-CFG paths with stubbed transformer/scheduler/VAE components.

Register both in l0_a10.yml so they run in pre-merge CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for image generation pipeline request handling, including prompt fan-out, negative prompt matching, and parameter forwarding.
  * Added end-to-end pipeline tests for both standard and CFG-based inference paths using lightweight test doubles.
  * Expanded the integration test list to include the new visual generation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
