### PR TITLE
[TRTLLM-13582][feat] Reduce context-phase host overhead in input prep

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -1,3 +1,4 @@
+import array
 import bisect
 import contextlib
 import functools
@@ -238,6 +239,20 @@ def _configure_deep_gemm_pdl() -> None:
 
     deep_gemm.set_pdl(os.environ.get("TRTLLM_ENABLE_PDL", "1") == "1")
     _DEEP_GEMM_PDL_CONFIGURED = True
+
+
+def _copy_int_list_to_device(values: List[int], dst: torch.Tensor) -> None:
+    """Copy an int list into ``dst[:len(values)]`` (preallocated int32 CUDA buffer).
+
+    Stages via ``array.array('i', ...)`` + ``torch.frombuffer`` instead of
+    ``torch.tensor(<list>)``, which is ~3x faster for long sequences.
+    """
+    if not values:
+        # torch.frombuffer rejects an empty buffer; nothing to copy.
+        return
+    dst[:len(values)].copy_(torch.frombuffer(array.array('i', values),
+                                             dtype=torch.int),
+                            non_blocking=True)
 
 
 class PyTorchModelEngine(ModelEngine):
@@ -3240,6 +3255,16 @@ class PyTorchModelEngine(ModelEngine):
         request_ids = []  # per request
         gather_ids = []
         position_ids = []  # per sequence
+        # Pure-context batches (no generation request, no MRoPE, no position
+        # offset) have contiguous range() positions, so we build position_ids
+        # directly on-device with torch.arange and skip the Python list build
+        # entirely. With a generation request the gen/extend/draft loops below
+        # need the running len(position_ids), so fall back to the list.
+        arange_positions = (not self.use_mrope
+                            and self._get_position_id_offset() == 0 and len(
+                                scheduled_requests.generation_requests) == 0)
+        ctx_position_segments = [
+        ]  # (begin_compute, length) per context request
         num_cached_tokens_per_seq = []  # per sequence
         draft_tokens = []
         draft_lens = []
@@ -3313,8 +3338,12 @@ class PyTorchModelEngine(ModelEngine):
             begin_compute = request.context_current_position
             end_compute = begin_compute + request.context_chunk_size
             prompt_tokens = all_prompt_tokens[begin_compute:end_compute]
-            position_ids.extend(
-                range(begin_compute, begin_compute + len(prompt_tokens)))
+            if arange_positions:
+                ctx_position_segments.append(
+                    (begin_compute, len(prompt_tokens)))
+            else:
+                position_ids.extend(
+                    range(begin_compute, begin_compute + len(prompt_tokens)))
 
             # Start offset of this request's (current-chunk) tokens within the
             # flattened input_ids. Recorded on multimodal_params below so models
@@ -3777,16 +3806,14 @@ class PyTorchModelEngine(ModelEngine):
 
         num_tokens = len(input_ids)
         num_draft_tokens = len(draft_tokens)
-        total_num_tokens = len(position_ids)
+        total_num_tokens = (sum(n for _, n in ctx_position_segments)
+                            if arange_positions else len(position_ids))
         assert total_num_tokens <= self.max_num_tokens, (
             f"total_num_tokens ({total_num_tokens}) should be less than or equal to max_num_tokens ({self.max_num_tokens})"
         )
         # if exist requests that do not have previous batch, copy input_ids and draft_tokens
         if num_tokens > 0:
-            input_ids = torch.tensor(input_ids,
-                                     dtype=torch.int,
-                                     pin_memory=prefer_pinned())
-            self.input_ids_cuda[:num_tokens].copy_(input_ids, non_blocking=True)
+            _copy_int_list_to_device(input_ids, self.input_ids_cuda)
 
             # Update input_ids_cuda with new tokens from new_tensors_device (draft model only)
             if self.is_draft_model and num_accepted_tokens_device is not None:
@@ -4032,12 +4059,22 @@ class PyTorchModelEngine(ModelEngine):
                     segment[:, :, :end_idx - start_idx], non_blocking=True)
             final_position_ids = self.mrope_position_ids_cuda[:, :, :
                                                               total_num_tokens]
+        elif arange_positions:
+            # Build contiguous context positions directly on-device (skips the
+            # Python list build + host->device copy).
+            offset = 0
+            for begin, length in ctx_position_segments:
+                torch.arange(begin,
+                             begin + length,
+                             dtype=torch.int,
+                             device=self.position_ids_cuda.device,
+                             out=self.position_ids_cuda[offset:offset + length])
+                offset += length
+            final_position_ids = self.position_ids_cuda[:
+                                                        total_num_tokens].unsqueeze(
+                                                            0)
         else:
-            position_ids = torch.tensor(position_ids,
-                                        dtype=torch.int,
-                                        pin_memory=prefer_pinned())
-            self.position_ids_cuda[:total_num_tokens].copy_(position_ids,
-                                                            non_blocking=True)
+            _copy_int_list_to_device(position_ids, self.position_ids_cuda)
             final_position_ids = self.position_ids_cuda[:
                                                         total_num_tokens].unsqueeze(
                                                             0)


### PR DESCRIPTION
##  Improvement measurement 

### Breakdown in the code path
GPU-idle ms per host stage, rank-1 worker, Super-120B 50k CTX bs=1.
**"Baseline (main)"** already includes #15625's route fix; **"Optimized (PR)"** adds C1+C2.
Sub-stages are the NVTX ranges actually present in the trace; `route+gather+bcast` is
`_fetch_new_requests − merge_requests` (route_requests / gather_all_rank_states have no
dedicated NVTX marker in this build — the original report added those via separate
`fetchinstr` instrumented runs).

```
                              BASELINE(main)   OPTIMIZED(PR)     notes
_fetch_new_requests              1.28 ms          1.22 ms     ~flat — already route-optimized in main
  ├─ merge_requests              0.82 ms          0.82 ms     LlmRequest construction (C++ token copy) — untouched
  └─ route+gather+bcast          ~0.46ms          ~0.40ms     #15625 uses num_input_tokens accessor → route≈0
                                                              (this is the old C3 target; now in main, not the PR)
_prepare_inputs                  6.49 ms          2.06 ms     C1+C2: list-build + H2D convert + position_ids arange
  └─ attn/mamba metadata         ~0.3 ms          ~0.3 ms     already cheap (Mamba2Metadata.prepare)
prepare_resources                1.56 ms          1.50 ms     mamba/KV-cache resource prep — untouched
_handle_responses                0.33 ms          0.30 ms     (≈+KV xfer in TRUE disagg)
────────────────────────────────────────────────────────────
TOTAL host bubble               ~9.66 ms         ~5.09 ms     (−47%)
forward burst                   ~800 ms (Super) / ~785 ms (real Ultra)   [B300 — far faster than GB200]
bubble % of iteration           ~1.2% (Super) / ~0.7% (real Ultra)
```

> vs the original report: baseline `_fetch_new_requests` is now **1.28 ms, not 12.2 ms** —
> main's #15625 replaced `len(input_token_ids)` with the cheap `num_input_tokens` accessor
> (route ≈0, better than C3's 3.7 ms "1× floor"). Route no longer appears as a PR delta;
> the PR's entire contribution is `_prepare_inputs`.

### Before/after measurement

| Scenario | host bubble before→after | dominant stage | throughput |
|---|--:|---|--:|
| Super-120B, 50k CTX, bs=1 | 9.66 → 5.09 ms (**−47 %**) | `_prepare_inputs` 6.49→2.06 (**−68 %**) | +0.5 % (noise) |
| **Real Ultra-550B, 50k CTX, bs=1** | 9.55 → 5.24 ms (**−45 %**) | `_prepare_inputs` 6.59→2.26 (**−66 %**); `_fetch` ~flat | +0.1 % (noise) |
| Super-120B, 8k CTX, bs=1 | 3.44 → 2.83 ms (**−18 %**) | `_prepare_inputs` 1.71→0.97 (**−43 %**) | +0.3 % (noise) |
| Super-120B, 1k CTX, bs=1 | ~marginal (not re-measured) | tiny host work | noise |
| Super-120B, 1k, bs=16 | not re-measured | — | — |




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved request scheduling by using precomputed input lengths for more consistent token-based balancing.
* **Performance**
  * Reduced overhead when preparing input and position data, which may improve request processing speed.
  * Cached request length calculations to avoid repeated work during execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
