### PR TITLE
[None][infra] use default split when CBTS test-db download fails

### DIFF
--- a/jenkins/L0_Test.groovy
+++ b/jenkins/L0_Test.groovy
@@ -1643,37 +1643,27 @@ def runLLMTestlistWithSbatch(pipeline, platform, testList, config=VANILLA_CONFIG
     }
 }
 
-// CBTS Layer 3 split-collapse heuristic: when the affected stage's narrowed
-// test count (from main.py compute_stage_test_counts) is below 20, collapse
-// pytest-split's splits to 1 — only group 1 runs everything; groups 2..N
-// skip and don't allocate a machine. At/above 20, splits stay at the
-// stage's default and pytest-split parallelizes normally.
-//
-// The 20 below is hard-coded inline rather than a top-level constant
-// because Groovy script-level `def` is not visible from method bodies
-// without `@Field`, and we don't otherwise need this value elsewhere.
-//
-// Returns [skip: bool, splits: int, splitId: int]. Callers should
-// `return` early when skip == true and otherwise overwrite splits/splitId
-// with the returned values before continuing their existing dispatch logic.
+// CBTS Layer 2.5: a narrowed stage runs K = min(narrowed count, default splits) shards. Returns [skip, splits, splitId].
 def _cbtsMaybeCollapseSplits(stageName, splitId, splits) {
     def cbts = testFilter[(CBTS_RESULT)]
-    def counts = cbts?.affected_stage_test_counts
-    if (!counts) {
+    // No CBTS or tarball not uploaded (renderTestDB then runs full source) -> keep default splits.
+    if (cbts == null || !cbts.cbts_test_db_artifact_path) {
         return [skip: false, splits: splits, splitId: splitId]
     }
-    def count = counts[stageName]
-    if (count == null || count >= 20) {
+    def counts = cbts.affected_stage_test_counts
+    def count = counts ? counts[stageName] : null
+    if (count == null) {
         return [skip: false, splits: splits, splitId: splitId]
     }
-    if (splitId > 1) {
-        echo "CBTS [${cbts.scope}]: ${stageName} narrowed to ${count} (< 20), skipping group ${splitId}/${splits}"
+    int k = Math.max(1, Math.min(count as int, splits as int))
+    if (k >= splits) {
+        return [skip: false, splits: splits, splitId: splitId]
+    }
+    if (splitId > k) {
+        echo "CBTS [${cbts.scope}]: ${stageName} narrowed to ${count} tests → ${k}/${splits} shards, skipping group ${splitId}"
         return [skip: true, splits: splits, splitId: splitId]
     }
-    if (splits > 1) {
-        echo "CBTS [${cbts.scope}]: ${stageName} narrowed to ${count} (< 20), collapsing splits=${splits} → 1"
-    }
-    return [skip: false, splits: 1, splitId: 1]
+    return [skip: false, splits: k, splitId: splitId]
 }
 
 def runLLMTestlistOnSlurm(pipeline, platform, testList, config=VANILLA_CONFIG, perfMode=false, stageName="Undefined", splitId=1, splits=1, gpuCount=1, nodeCount=1, runWithSbatch=false, skipInstallWheel=false, cpver="cp312", String outerAttemptTag="", boolean useClusterDurations=false)
@@ -2822,7 +2812,7 @@ def renderTestDB(pipeline, testContext, llmSrc, stageName, preDefinedMakoOpts=nu
         if (dirExists != "yes") {
             try {
                 def artifactUrl = "${URM_ARTIFACTORY_BASE}/${cbts.cbts_test_db_artifact_path}"
-                sh "wget -q '${artifactUrl}' -O /tmp/cbts_test_db.tar.gz && tar xzf /tmp/cbts_test_db.tar.gz -C ${llmSrc}"
+                trtllm_utils.llmExecStepWithRetry(pipeline, script: "wget -nv '${artifactUrl}' -O /tmp/cbts_test_db.tar.gz && tar xzf /tmp/cbts_test_db.tar.gz -C ${llmSrc}")
                 echo "CBTS Layer 3: extracted cbts_test_db from artifact"
             } catch (Exception e) {
                 echo "CBTS Layer 3: artifact download failed " +


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved test sharding behavior for smaller filtered test sets, helping reduce unnecessary split groups and avoid wasted scheduling.
  * Added smarter fallback handling so jobs keep the expected shard layout when narrowed test data isn’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
