### PR TITLE
[None][fix] Fix disagg gen-consensus deadlock under pipeline parallelism

### DIFF
--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -314,11 +314,13 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         return ready_ids
 
     def _gen_consensus(self, local_ids: list) -> list:
-        sync_size = (
-            self._mapping.pp_size if self._mapping.enable_attention_dp else self._mapping.world_size
-        )
+        # adp-off: use the TP-then-PP two-stage consensus (same ordered TP/PP
+        # communicators as ctx; tp x pp == world) instead of a lone WORLD
+        # allgather that deadlocks against the PP subgroup collectives.
+        if not self._mapping.enable_attention_dp:
+            return self._ctx_consensus(local_ids)
         all_ranks = self._gen_allgather(local_ids) if self._gen_need_sync else [local_ids]
-        return _find_consensus_request_ids(all_ranks, sync_size)
+        return _find_consensus_request_ids(all_ranks, self._mapping.pp_size)
 
     @staticmethod
     def _allgather_or_passthrough(
@@ -366,6 +368,23 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         return new_cancelled, new_failed, new_completed
 
     def _gen_consensus_outcome(self, to_process, cancelled, failed, completed):
+        # adp-off: TP-then-PP two-stage on the ordered subgroup communicators
+        # (not a WORLD allgather) to avoid the cross-communicator PP deadlock;
+        # tp x pp == world, so the outcome is identical.
+        if not self._mapping.enable_attention_dp:
+            c, f, d = self._consensus_outcome(
+                to_process,
+                cancelled,
+                failed,
+                completed,
+                self._dist.tp_allgather,
+                self._ctx_need_tp_sync,
+            )
+            if self._ctx_need_pp_sync:
+                c, f, d = self._consensus_outcome(
+                    to_process, c, f, d, self._dist.pp_allgather, True
+                )
+            return c, f, d
         return self._consensus_outcome(
             to_process, cancelled, failed, completed, self._gen_allgather, self._gen_need_sync
         )

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -1937,9 +1937,14 @@ class PyExecutor:
                                    and is_dp_broadcast):
             scheduled_batch, fitting_disagg_gen_init_requests, num_fitting_reqs = self._schedule(
             )
+            disagg_gen_transfer_in_progress = (
+                self.kv_cache_transceiver is not None
+                and (any(req.is_disagg_generation_transmission_in_progress
+                         for req in self.active_requests)
+                     or bool(fitting_disagg_gen_init_requests)))
             serializable_schedule = SerializableSchedulerOutput.from_scheduler_result(
                 scheduled_batch, fitting_disagg_gen_init_requests,
-                num_fitting_reqs)
+                num_fitting_reqs, disagg_gen_transfer_in_progress)
 
         # Broadcast within first tp+cp group before send/recv chain to other tp+cp groups
         if self.dist.is_first_pp_rank:
@@ -1971,6 +1976,11 @@ class PyExecutor:
         if scheduled_batch is None:
             scheduled_batch, fitting_disagg_gen_init_requests, num_fitting_reqs = serializable_schedule.to_scheduler_result(
                 self.active_requests)
+        # Adopt the scheduling rank's disagg-gen-transfer flag on every PP rank
+        # (rode this broadcast, no extra collective) so the next iteration's
+        # gen transfer-status allgather is entered/skipped by all ranks together.
+        self._pp_disagg_gen_transfer_in_progress = (
+            serializable_schedule.disagg_gen_transfer_in_progress)
         return scheduled_batch, fitting_disagg_gen_init_requests, num_fitting_reqs
 
     def _pp_retry_until_can_schedule(self, scheduled_batch):
@@ -4294,6 +4304,13 @@ class PyExecutor:
         need_check_one = bool(non_gen_first_reqs) and all(
             req.is_disagg_generation_transmission_in_progress
             for req in non_gen_first_reqs)
+
+        # PP: gate the transceiver's group allgather on the scheduling rank's
+        # propagated flag (set only on the PP loop) so all ranks enter/skip
+        # together; a divergent per-rank need_check deadlocks that allgather.
+        pp_flag = getattr(self, "_pp_disagg_gen_transfer_in_progress", None)
+        if pp_flag is not None:
+            need_check = pp_flag
 
         if need_check:
             at_least_num = 1 if need_check_one else 0

--- a/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler.py
+++ b/tensorrt_llm/_torch/pyexecutor/scheduler/scheduler.py
@@ -236,6 +236,10 @@ class SerializableSchedulerOutput:
         int
     ]  # request ids of fitting disaggregated generation initialization requests
     num_fitting_requests: int  # number of fitting requests
+    # Scheduling rank's "any disagg-gen KV transfer in progress" flag; rides
+    # this existing schedule broadcast (no extra collective) so all PP ranks
+    # enter/skip the gen transfer-status allgather together (else it deadlocks).
+    disagg_gen_transfer_in_progress: bool = False
 
     @classmethod
     def from_scheduler_result(
@@ -243,6 +247,7 @@ class SerializableSchedulerOutput:
         scheduled_requests: ScheduledRequests,
         fitting_disagg_gen_init_requests: RequestList,
         num_fitting_requests: int,
+        disagg_gen_transfer_in_progress: bool = False,
     ) -> "SerializableSchedulerOutput":
         return cls(
             encoder_requests=[req.request_id for req in scheduled_requests.encoder_requests],
@@ -258,6 +263,7 @@ class SerializableSchedulerOutput:
                 req.request_id for req in fitting_disagg_gen_init_requests
             ],
             num_fitting_requests=num_fitting_requests,
+            disagg_gen_transfer_in_progress=disagg_gen_transfer_in_progress,
         )
 
     def to_scheduler_result(


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

This pull request introduces important changes to the pipeline and parallelism (PP/TP) consensus and scheduling logic for disaggregated generation in the distributed execution engine. The main focus is on improving synchronization and preventing deadlocks in collective operations by ensuring all pipeline parallel (PP) ranks make consistent decisions about entering or skipping group collectives, particularly during disaggregated generation KV cache transfers.

The most important changes are:

**Consensus and Synchronization Improvements:**

* Modified `_gen_consensus` and `_gen_consensus_outcome` in `transceiver.py` to use a two-stage tensor-parallel (TP) then pipeline-parallel (PP) consensus instead of a single world allgather when attention data parallelism is disabled, preventing deadlocks caused by cross-communicator collectives. [[1]](diffhunk://#diff-3cab8f284e64d42a9c7004535a761cabcdc7323d787ddbecdbd467b7e4f935b9L301-R307) [[2]](diffhunk://#diff-3cab8f284e64d42a9c7004535a761cabcdc7323d787ddbecdbd467b7e4f935b9R355-R366)

**KV Cache Transfer Coordination:**

* Added a `disagg_gen_transfer_in_progress` flag to `SerializableSchedulerOutput` in `scheduler.py` to propagate the scheduling rank's transfer status to all PP ranks via the existing schedule broadcast, ensuring all ranks enter or skip the transfer-status allgather together. [[1]](diffhunk://#diff-1591fdd055b4f8da201884e00214d3312afe97e5dd07c7fea7e3309b67e876d0R239-R250) [[2]](diffhunk://#diff-1591fdd055b4f8da201884e00214d3312afe97e5dd07c7fea7e3309b67e876d0R266)
* Updated `_pp_schedule_and_propagate` in `py_executor.py` to set and propagate the `disagg_gen_transfer_in_progress` flag, and to adopt this flag on every PP rank for consistent collective participation. [[1]](diffhunk://#diff-f0b4c3c02708916fd189f863c48b982a55f34ae94996089b23aa0a6f0571fe19R1960-R1966) [[2]](diffhunk://#diff-f0b4c3c02708916fd189f863c48b982a55f34ae94996089b23aa0a6f0571fe19R1998-R2002)
* Modified `_check_disagg_gen_transfer_status` in `py_executor.py` to gate the group allgather on the propagated flag, avoiding divergent per-rank decisions that could lead to deadlock.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coordination during distributed generation so all pipeline stages stay in sync when KV transfer is active.
  * Reduced unnecessary synchronization overhead when attention data parallelism is disabled.
  * Made generation consensus handling more consistent across different distributed execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->