### PR TITLE
[None][perf] Improve Qwen3-VL Preprocessing Perf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ cuda-python>=13
 diffusers>=0.37.1
 ftfy
 lark
+lazy_loader~=0.5
 mpi4py
 numpy>=2.0.0,<2.4 # numba 0.63.1 requires numpy<2.4
 onnx>=1.21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,3 +91,4 @@ smg-grpc-proto>=0.4.2
 cache-dit>=1.3.5
 librosa
 msgpack
+uvloop>=0.19.0

--- a/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_utils.py
@@ -19,7 +19,8 @@
 import functools
 import math
 import os
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
+from typing import (Any, Callable, Dict, List, Optional, Tuple, TypedDict,
+                    Union, cast)
 
 import torch
 import torch.nn.functional as F
@@ -61,6 +62,34 @@ _PROCESSOR_OUTPUT_KEYS = frozenset({
     "second_per_grid_ts",
     "mm_token_type_ids",
 })
+
+
+def _get_cached_merged_typed_dict(schema, cache):
+    """Return a stable copy of ProcessorMixin's ephemeral merged TypedDict.
+
+    `ProcessorMixin._merge_kwargs` creates a fresh
+    `TypedDict("merged_typed_dict", ...)` for image/video kwargs on every
+    processor call. `huggingface_hub` caches strict dataclass validators by
+    schema-object identity, so a fresh type defeats that cache. Reuse an
+    equivalent TypedDict class keyed by (totality, annotation items) so the
+    upstream validator hits cache and skips the recursive type validation.
+    """
+    if getattr(schema, "__name__", None) != "merged_typed_dict":
+        return schema
+    try:
+        cache_key = (getattr(schema, "__total__",
+                             True), tuple(schema.__annotations__.items()))
+        cached_schema = cache.get(cache_key)
+    except TypeError:
+        return schema
+    if cached_schema is None:
+        cached_schema = TypedDict(
+            "merged_typed_dict",
+            dict(schema.__annotations__),
+            total=getattr(schema, "__total__", True),
+        )
+        cache[cache_key] = cached_schema
+    return cached_schema
 
 
 @functools.lru_cache(maxsize=None)
@@ -107,6 +136,7 @@ def _install_processor_output_validation_filter():
             "No transformers module exposes validate_typed_dict; "
             "cannot patch processor output validation.")
     base_orig = binders[0].validate_typed_dict
+    merged_schema_cache: dict = {}
 
     def _filtered_validate(schema, data):
         if isinstance(data, dict):
@@ -114,6 +144,7 @@ def _install_processor_output_validation_filter():
                 k: v
                 for k, v in data.items() if k not in _PROCESSOR_OUTPUT_KEYS
             }
+        schema = _get_cached_merged_typed_dict(schema, merged_schema_cache)
         return base_orig(schema, data)
 
     for b in binders:

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -104,7 +104,8 @@ def _install_merge_kwargs_cache(processor) -> None:
     def _cached_merge_kwargs(*args, **kwargs):
         try:
             key = repr(sorted(kwargs.items()))
-        except Exception:
+        except TypeError:
+            # Unsortable / un-repr-able kwargs — fall back to uncached call.
             return orig(*args, **kwargs)
         hit = cache.get(key)
         if hit is not None:

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -82,42 +82,6 @@ from .modeling_utils import (ModelConfig, QuantConfig, _load_weights_impl,
 PAD_INDEX = -100  # NOTE: refer to https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py#L269
 
 
-def _install_merge_kwargs_cache(processor) -> None:
-    """Memoize `processor._merge_kwargs` by input kwargs signature.
-
-    `ProcessorMixin._merge_kwargs` is pure but runs on every processor
-    call. When all requests pass the same kwargs (the common deployment
-    case), caching by signature reduces it to an O(1) lookup after the
-    first call.
-
-    Values are deep-copied on get and put because callers mutate the
-    returned dict.
-    """
-    import copy
-
-    if getattr(processor, "_merge_kwargs_cached_installed", False):
-        return
-
-    cache: dict = {}
-    orig = processor._merge_kwargs
-
-    def _cached_merge_kwargs(*args, **kwargs):
-        try:
-            key = repr(sorted(kwargs.items()))
-        except TypeError:
-            # Unsortable / un-repr-able kwargs — fall back to uncached call.
-            return orig(*args, **kwargs)
-        hit = cache.get(key)
-        if hit is not None:
-            return copy.deepcopy(hit)
-        result = orig(*args, **kwargs)
-        cache[key] = copy.deepcopy(result)
-        return result
-
-    processor._merge_kwargs = _cached_merge_kwargs
-    processor._merge_kwargs_cached_installed = True
-
-
 def _prepare_qwen_vl_vision_attn_metadata(
         seq_lens: List[int],
         attn_metadata: AttentionMetadata) -> AttentionMetadata:
@@ -238,7 +202,6 @@ class Qwen2VLInputProcessorBase(BaseMultimodalInputProcessor,
             model_path,
             use_fast=self.use_fast,
             trust_remote_code=trust_remote_code)
-        _install_merge_kwargs_cache(self._processor)
 
         # temporal patch size for video frames
         self.temporal_patch_size = getattr(self.config.vision_config,

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -82,6 +82,41 @@ from .modeling_utils import (ModelConfig, QuantConfig, _load_weights_impl,
 PAD_INDEX = -100  # NOTE: refer to https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py#L269
 
 
+def _install_merge_kwargs_cache(processor) -> None:
+    """Memoize ``processor._merge_kwargs`` by input kwargs signature.
+
+    ``ProcessorMixin._merge_kwargs`` is pure but runs on every processor
+    call. When all requests pass the same kwargs (the common deployment
+    case), caching by signature reduces it to an O(1) lookup after the
+    first call.
+
+    Values are deep-copied on get and put because callers mutate the
+    returned dict.
+    """
+    import copy
+
+    if getattr(processor, "_merge_kwargs_cached_installed", False):
+        return
+
+    cache: dict = {}
+    orig = processor._merge_kwargs
+
+    def _cached_merge_kwargs(*args, **kwargs):
+        try:
+            key = repr(sorted(kwargs.items()))
+        except Exception:
+            return orig(*args, **kwargs)
+        hit = cache.get(key)
+        if hit is not None:
+            return copy.deepcopy(hit)
+        result = orig(*args, **kwargs)
+        cache[key] = copy.deepcopy(result)
+        return result
+
+    processor._merge_kwargs = _cached_merge_kwargs
+    processor._merge_kwargs_cached_installed = True
+
+
 def _prepare_qwen_vl_vision_attn_metadata(
         seq_lens: List[int],
         attn_metadata: AttentionMetadata) -> AttentionMetadata:
@@ -202,6 +237,7 @@ class Qwen2VLInputProcessorBase(BaseMultimodalInputProcessor,
             model_path,
             use_fast=self.use_fast,
             trust_remote_code=trust_remote_code)
+        _install_merge_kwargs_cache(self._processor)
 
         # temporal patch size for video frames
         self.temporal_patch_size = getattr(self.config.vision_config,

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -83,9 +83,9 @@ PAD_INDEX = -100  # NOTE: refer to https://github.com/huggingface/transformers/b
 
 
 def _install_merge_kwargs_cache(processor) -> None:
-    """Memoize ``processor._merge_kwargs`` by input kwargs signature.
+    """Memoize `processor._merge_kwargs` by input kwargs signature.
 
-    ``ProcessorMixin._merge_kwargs`` is pure but runs on every processor
+    `ProcessorMixin._merge_kwargs` is pure but runs on every processor
     call. When all requests pass the same kwargs (the common deployment
     case), caching by signature reduces it to an O(1) lookup after the
     first call.

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -312,7 +312,11 @@ class Qwen2VLInputProcessorBase(BaseMultimodalInputProcessor,
         if isinstance(first_frame, torch.Tensor):
             frame_h = int(first_frame.shape[-2])
             frame_w = int(first_frame.shape[-1])
-        else:
+        elif isinstance(first_frame, np.ndarray):
+            # hwc_uint8 frames from VideoMediaIO: shape (H, W, C).
+            frame_h = int(first_frame.shape[0])
+            frame_w = int(first_frame.shape[1])
+        else:  # PIL.Image
             frame_h, frame_w = first_frame.height, first_frame.width
         encoder_tokens = self._num_vision_tokens(width=frame_w,
                                                  height=frame_h,

--- a/tensorrt_llm/_torch/models/modeling_qwen2vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen2vl.py
@@ -312,11 +312,7 @@ class Qwen2VLInputProcessorBase(BaseMultimodalInputProcessor,
         if isinstance(first_frame, torch.Tensor):
             frame_h = int(first_frame.shape[-2])
             frame_w = int(first_frame.shape[-1])
-        elif isinstance(first_frame, np.ndarray):
-            # hwc_uint8 frames from VideoMediaIO: shape (H, W, C).
-            frame_h = int(first_frame.shape[0])
-            frame_w = int(first_frame.shape[1])
-        else:  # PIL.Image
+        else:
             frame_h, frame_w = first_frame.height, first_frame.width
         encoder_tokens = self._num_vision_tokens(width=frame_w,
                                                  height=frame_h,

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -334,6 +334,8 @@ class Qwen3VLInputProcessorBase(Qwen2VLInputProcessorBase):
             for vd in video_datas:
                 m = dict(vd.metadata or {})
                 m["total_num_frames"] = len(vd.frames)
+                # Internal stash; not a field on HF's VideoMetadata dataclass.
+                m.pop("io_loaded_all_frames", None)
                 video_metadata.append(m)
 
         return self.processor(

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -204,9 +204,11 @@ def _decide_do_sample_frames(
             duration = (vd.metadata or {}).get("duration") or 0
             n_target = math.floor(duration * user_fps)
         else:
-            # If IO loaded every source frame, defer to HF's class-default
-            # sampling; otherwise leave the IO-decoded frames alone.
-            if (vd.metadata or {}).get("io_loaded_all_frames", False):
+            # If IO loaded every source frame (decoded count equals the source
+            # frame count), defer to HF's class-default sampling; otherwise
+            # leave the IO-decoded frames alone.
+            total = (vd.metadata or {}).get("total_num_frames")
+            if total is not None and n_decoded == total:
                 return True
             n_target = n_decoded
         if n_target != n_decoded:
@@ -334,8 +336,6 @@ class Qwen3VLInputProcessorBase(Qwen2VLInputProcessorBase):
             for vd in video_datas:
                 m = dict(vd.metadata or {})
                 m["total_num_frames"] = len(vd.frames)
-                # Internal stash; not a field on HF's VideoMetadata dataclass.
-                m.pop("io_loaded_all_frames", None)
                 video_metadata.append(m)
 
         return self.processor(

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -266,9 +266,13 @@ class Qwen3VLInputProcessorBase(Qwen2VLInputProcessorBase):
         # frames or take a slower path due to the metadata/frame-count
         # mismatch). Caller-supplied kwargs other than fps/num_frames are
         # preserved.
+        # do_sample_frames is intentionally non-overridable: the IO loader has
+        # already sampled to the target frame count, so letting a caller flip
+        # it back to True would re-enter the HF sample_frames branch on
+        # already-sampled input and break the contract this patch establishes.
         proc_kwargs = {"do_sample_frames": False}
         for _k, _v in dict(mm_processor_kwargs).items():
-            if _k not in ("num_frames", "fps"):
+            if _k not in ("num_frames", "fps", "do_sample_frames"):
                 proc_kwargs[_k] = _v
 
         return self.processor(

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -173,14 +173,12 @@ def _decide_do_sample_frames(
 
       1. If `mm_processor_kwargs.do_sample_frames` is explicitly set
          (True or False), honor it.
-      2. Otherwise, for each video compute the target frame count from the
+      2. If the caller supplies no frame target (`num_frames` / `fps`),
+         match HF's class default, which samples frames (returns True).
+      3. Otherwise, for each video compute the target frame count from the
          kwargs (`num_frames` directly, or `floor(duration * fps)` if
          `fps` is given) and compare to `len(vd.frames)`. If any video
          needs a different count, the batch is sampled (returns True).
-      3. When the caller is silent (no `num_frames` / `fps`) and the IO
-         loader decoded every source frame for a video, sample with HF's
-         class defaults so the request still gets a reasonable frame count
-         when the server is configured to load everything at IO.
 
     Per-video targets that match the IO-decoded count don't need HF
     sampling; the all-or-nothing reduction over the batch means a single
@@ -190,27 +188,30 @@ def _decide_do_sample_frames(
     if "do_sample_frames" in mm_processor_kwargs:
         return bool(mm_processor_kwargs["do_sample_frames"])
 
-    user_num_frames = mm_processor_kwargs.get("num_frames")
-    user_fps = mm_processor_kwargs.get("fps")
-
     if not video_datas:
         return False
 
+    user_num_frames = mm_processor_kwargs.get("num_frames")
+    user_fps = mm_processor_kwargs.get("fps")
+    has_num_frames = user_num_frames is not None and user_num_frames != -1
+    has_fps = user_fps is not None and user_fps != -1
+
+    # No explicit frame target from the caller: defer to HF's class-default
+    # sampling (the stock processor sets `do_sample_frames=True` when neither
+    # `num_frames` nor `fps` is given). Returning False here would hand the
+    # IO-decoded frames straight to HF unchanged and diverge from stock HF
+    # whenever the IO loader decoded a different number of frames than HF's
+    # default sampler would select.
+    if not has_num_frames and not has_fps:
+        return True
+
     for vd in video_datas:
         n_decoded = len(vd.frames)
-        if user_num_frames is not None and user_num_frames != -1:
+        if has_num_frames:
             n_target = user_num_frames
-        elif user_fps is not None and user_fps != -1:
+        else:  # has_fps
             duration = (vd.metadata or {}).get("duration") or 0
             n_target = math.floor(duration * user_fps)
-        else:
-            # If IO loaded every source frame (decoded count equals the source
-            # frame count), defer to HF's class-default sampling; otherwise
-            # leave the IO-decoded frames alone.
-            total = (vd.metadata or {}).get("total_num_frames")
-            if total is not None and n_decoded == total:
-                return True
-            n_target = n_decoded
         if n_target != n_decoded:
             return True
     return False

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -260,12 +260,16 @@ class Qwen3VLInputProcessorBase(Qwen2VLInputProcessorBase):
             [vd.metadata for vd in video_datas] if video_datas and mm_processor_kwargs else None
         )
 
-        # num_frames and fps are mutually exclusive in the HF processor's sample_frames.
-        # If the caller set num_frames without fps, null fps explicitly so the class-level
-        # default fps=2 does not interfere.
-        proc_kwargs = dict(mm_processor_kwargs)
-        if "num_frames" in proc_kwargs and "fps" not in proc_kwargs:
-            proc_kwargs["fps"] = None
+        # Frames are already sampled by the IO loader (_load_video_by_cv2).
+        # Pass do_sample_frames=False so the HF processor skips its own
+        # frame-sampling branch (which would otherwise re-sample identical
+        # frames or take a slower path due to the metadata/frame-count
+        # mismatch). Caller-supplied kwargs other than fps/num_frames are
+        # preserved.
+        proc_kwargs = {"do_sample_frames": False}
+        for _k, _v in dict(mm_processor_kwargs).items():
+            if _k not in ("num_frames", "fps"):
+                proc_kwargs[_k] = _v
 
         return self.processor(
             text=[text],

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 import copy
+import math
 import re
 from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -161,6 +162,58 @@ def _expand_prompt_token_ids_for_mm_handoff(
     )
 
 
+def _decide_do_sample_frames(
+    video_datas: Optional[List[Any]],
+    mm_processor_kwargs: Dict[str, Any],
+) -> bool:
+    """Pick a single `do_sample_frames` flag for the HF processor call.
+
+    HF's video processor takes a scalar `do_sample_frames` that applies to
+    every video in the request. Decide it as follows:
+
+      1. If `mm_processor_kwargs.do_sample_frames` is explicitly set
+         (True or False), honor it.
+      2. Otherwise, for each video compute the target frame count from the
+         kwargs (`num_frames` directly, or `floor(duration * fps)` if
+         `fps` is given) and compare to `len(vd.frames)`. If any video
+         needs a different count, the batch is sampled (returns True).
+      3. When the caller is silent (no `num_frames` / `fps`) and the IO
+         loader decoded every source frame for a video, sample with HF's
+         class defaults so the request still gets a reasonable frame count
+         when the server is configured to load everything at IO.
+
+    Per-video targets that match the IO-decoded count don't need HF
+    sampling; the all-or-nothing reduction over the batch means a single
+    video needing resampling pulls the rest along through a no-op
+    identity `np.linspace`.
+    """
+    if "do_sample_frames" in mm_processor_kwargs:
+        return bool(mm_processor_kwargs["do_sample_frames"])
+
+    user_num_frames = mm_processor_kwargs.get("num_frames")
+    user_fps = mm_processor_kwargs.get("fps")
+
+    if not video_datas:
+        return False
+
+    for vd in video_datas:
+        n_decoded = len(vd.frames)
+        if user_num_frames is not None and user_num_frames != -1:
+            n_target = user_num_frames
+        elif user_fps is not None and user_fps != -1:
+            duration = (vd.metadata or {}).get("duration") or 0
+            n_target = math.floor(duration * user_fps)
+        else:
+            # If IO loaded every source frame, defer to HF's class-default
+            # sampling; otherwise leave the IO-decoded frames alone.
+            if (vd.metadata or {}).get("io_loaded_all_frames", False):
+                return True
+            n_target = n_decoded
+        if n_target != n_decoded:
+            return True
+    return False
+
+
 class Qwen3VLInputProcessorBase(Qwen2VLInputProcessorBase):
     """Qwen3-VL input processor.
 
@@ -253,27 +306,35 @@ class Qwen3VLInputProcessorBase(Qwen2VLInputProcessorBase):
         if videos and isinstance(videos[0][0], torch.Tensor):
             do_rescale = False
 
-        # Forward video metadata only when the caller opts into per-request kwargs;
-        # the default path pre-samples frames in the IO loader, so unconditional
-        # metadata triggers IndexError in HF's _decode_and_sample_videos.
-        video_metadata = (
-            [vd.metadata for vd in video_datas] if video_datas and mm_processor_kwargs else None
-        )
+        do_sample_frames = _decide_do_sample_frames(video_datas, mm_processor_kwargs)
 
-        # Frames are already sampled by the IO loader (_load_video_by_cv2).
-        # Pass do_sample_frames=False so the HF processor skips its own
-        # frame-sampling branch (which would otherwise re-sample identical
-        # frames or take a slower path due to the metadata/frame-count
-        # mismatch). Caller-supplied kwargs other than fps/num_frames are
-        # preserved.
-        # do_sample_frames is intentionally non-overridable: the IO loader has
-        # already sampled to the target frame count, so letting a caller flip
-        # it back to True would re-enter the HF sample_frames branch on
-        # already-sampled input and break the contract this patch establishes.
-        proc_kwargs = {"do_sample_frames": False}
-        for _k, _v in dict(mm_processor_kwargs).items():
-            if _k not in ("num_frames", "fps", "do_sample_frames"):
-                proc_kwargs[_k] = _v
+        # Pass `do_sample_frames` plus, when sampling is needed, the
+        # caller's `num_frames` / `fps` target. Everything else the caller
+        # supplied (resize, normalize knobs, etc.) flows through unchanged.
+        proc_kwargs: Dict[str, Any] = {"do_sample_frames": do_sample_frames}
+        for k, v in mm_processor_kwargs.items():
+            if k in ("num_frames", "fps", "do_sample_frames"):
+                continue
+            proc_kwargs[k] = v
+        if do_sample_frames:
+            if "num_frames" in mm_processor_kwargs:
+                proc_kwargs["num_frames"] = mm_processor_kwargs["num_frames"]
+            if "fps" in mm_processor_kwargs:
+                proc_kwargs["fps"] = mm_processor_kwargs["fps"]
+
+        # Forward per-video metadata with `total_num_frames` rewritten to the
+        # actual decoded frame count. HF's `sample_frames` computes indices
+        # via `np.linspace(0, total_num_frames - 1, num_frames)` and indexes
+        # the frame tensor with them; the rewrite keeps those indices in
+        # range and the no-sampling path consistent for downstream qwen3vl
+        # code that consults the metadata.
+        video_metadata: Optional[List[Dict[str, Any]]] = None
+        if video_datas:
+            video_metadata = []
+            for vd in video_datas:
+                m = dict(vd.metadata or {})
+                m["total_num_frames"] = len(vd.frames)
+                video_metadata.append(m)
 
         return self.processor(
             text=[text],

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -323,6 +323,13 @@ class Qwen3VLInputProcessorBase(Qwen2VLInputProcessorBase):
                 proc_kwargs["num_frames"] = mm_processor_kwargs["num_frames"]
             if "fps" in mm_processor_kwargs:
                 proc_kwargs["fps"] = mm_processor_kwargs["fps"]
+            elif "num_frames" in mm_processor_kwargs:
+                # HF's `sample_frames` honors `num_frames` only when `fps` is
+                # not also set; the class-default `fps=2` would otherwise cap
+                # the returned count below the caller's requested
+                # `num_frames` for short clips. Null `fps` so `num_frames` is
+                # respected verbatim.
+                proc_kwargs["fps"] = None
 
         # Forward per-video metadata with `total_num_frames` rewritten to the
         # actual decoded frame count. HF's `sample_frames` computes indices

--- a/tensorrt_llm/_torch/models/modeling_qwen3vl.py
+++ b/tensorrt_llm/_torch/models/modeling_qwen3vl.py
@@ -397,6 +397,11 @@ class Qwen3VLInputProcessorBase(Qwen2VLInputProcessorBase):
             )
         return self.get_num_tokens_per_video(video=video, video_grid_thw=vgt)
 
+    def get_preferred_media_io_kwargs(self) -> Dict[str, Dict[str, Any]]:
+        # uint8 HWC frames let the HF processor rescale/permute once, skipping
+        # the per-frame CHW-float conversion in the IO loader.
+        return {"video": {"format": "np"}}
+
     def build_disagg_prefill_multimodal_inputs(
         self, inputs: TextPrompt, mm_handles: List[Dict[str, Any]]
     ) -> DisaggPrefillMultimodalInputs:

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -54,12 +54,6 @@ from tensorrt_llm.usage import config as _telemetry_config
 from tensorrt_llm.visual_gen import VisualGen
 from tensorrt_llm.visual_gen.args import VisualGenArgs
 
-# Install uvloop as the default asyncio event loop policy before anything
-# in this process creates a loop. libuv-backed event loops have significantly
-# lower per-await overhead than the cpython default; this affects every
-# coroutine in the server.
-uvloop.install()
-
 # Global variable to store the Popen object of the child process
 _child_p_global: Optional[subprocess.Popen] = None
 
@@ -357,7 +351,9 @@ def launch_server(
         disagg_cluster_config: Optional[DisaggClusterConfig] = None,
         multimodal_server_config: Optional[MultimodalServerConfig] = None,
         served_model_name: Optional[str] = None,
-        allow_request_chat_template: bool = False):
+        allow_request_chat_template: bool = False,
+        input_processor_workers: int = 8,
+        media_load_workers: int = 8):
 
     backend = llm_args["backend"]
     model = served_model_name or llm_args["model"]
@@ -401,14 +397,16 @@ def launch_server(
             disagg_cluster_config=disagg_cluster_config,
             multimodal_server_config=multimodal_server_config,
             chat_template=chat_template,
-            allow_request_chat_template=allow_request_chat_template)
+            allow_request_chat_template=allow_request_chat_template,
+            input_processor_workers=input_processor_workers,
+            media_load_workers=media_load_workers)
         _apply_fastapi_middlewares(server.app, middleware)
 
         # Optionally disable GC (default: not disabled)
         if os.getenv("TRTLLM_SERVER_DISABLE_GC", "0") == "1":
             gc.disable()
 
-        asyncio.run(server(host, port, sockets=[s]))
+        uvloop.run(server(host, port, sockets=[s]))
 
 
 def launch_grpc_server(host: str,
@@ -534,7 +532,7 @@ def launch_grpc_server(host: str,
 
             logger.info("Shutdown complete")
 
-    asyncio.run(serve_grpc_async())
+    uvloop.run(serve_grpc_async())
 
 
 def launch_mm_encoder_server(
@@ -555,7 +553,7 @@ def launch_mm_encoder_server(
         metadata_server_cfg=metadata_server_cfg,
         tool_parser=None,
         allow_request_chat_template=allow_request_chat_template)
-    asyncio.run(server(host, port))
+    uvloop.run(server(host, port))
 
 
 def launch_visual_gen_server(
@@ -608,7 +606,7 @@ def launch_visual_gen_server(
                               metadata_server_cfg=metadata_server_cfg,
                               tool_parser=None)
         _apply_fastapi_middlewares(server.app, middleware)
-        asyncio.run(server(host, port, sockets=[s]))
+        uvloop.run(server(host, port, sockets=[s]))
 
 
 class ChoiceWithAlias(click.Choice):
@@ -775,6 +773,22 @@ class ChoiceWithAlias(click.Choice):
                   default=0,
                   help="Number of workers to postprocess raw responses "
                   "to comply with OpenAI protocol.",
+                  status="prototype")
+@stability_option("--input-processor-workers",
+                  "input_processor_workers",
+                  type=click.IntRange(min=1),
+                  default=8,
+                  help="Size of the dedicated thread pool that runs the HF "
+                  "input processor (multimodal preprocess) on the chat "
+                  "and completion endpoints.",
+                  status="prototype")
+@stability_option("--media-load-workers",
+                  "media_load_workers",
+                  type=click.IntRange(min=1),
+                  default=8,
+                  help="Size of the dedicated thread pool that decodes media "
+                  "payloads (image / video / audio) for multimodal "
+                  "requests.",
                   status="prototype")
 @stability_option("--trust_remote_code",
                   is_flag=True,
@@ -952,7 +966,8 @@ def serve(
         moe_expert_parallel_size: Optional[int],
         moe_cluster_parallel_size: Optional[int], gpus_per_node: Optional[int],
         free_gpu_memory_fraction: float, kv_cache_dtype: str,
-        num_postprocess_workers: int, trust_remote_code: bool,
+        num_postprocess_workers: int, input_processor_workers: int,
+        media_load_workers: int, trust_remote_code: bool,
         revision: Optional[str], extra_llm_api_options: Optional[str],
         reasoning_parser: Optional[str], tool_parser: Optional[str],
         metadata_server_config_file: Optional[str], server_role: Optional[str],
@@ -1153,7 +1168,9 @@ def serve(
                 disagg_cluster_config,
                 multimodal_server_config,
                 served_model_name=served_model_name,
-                allow_request_chat_template=allow_request_chat_template)
+                allow_request_chat_template=allow_request_chat_template,
+                input_processor_workers=input_processor_workers,
+                media_load_workers=media_load_workers)
 
     def _serve_visual_gen():
         parsed_visual_gen_args = (VisualGenArgs.from_yaml(visual_gen_args)
@@ -1428,7 +1445,7 @@ def disaggregated(
         if os.getenv("TRTLLM_DISAGG_SERVER_DISABLE_GC", "1") == "1":
             gc.disable()
 
-        asyncio.run(server(disagg_cfg.hostname, disagg_cfg.port, sockets=[s]))
+        uvloop.run(server(disagg_cfg.hostname, disagg_cfg.port, sockets=[s]))
 
 
 def set_cuda_device():

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -3,13 +3,14 @@ import asyncio
 # Install uvloop as the default asyncio event loop policy before any module
 # retrieves a running loop. libuv-backed event loops have significantly lower
 # per-await overhead than the cpython default; this affects every coroutine
-# in the server. Falls back to the default loop when uvloop is not installed.
+# in the server. uvloop is a declared dependency, so the import is expected
+# to succeed; the try-block here is only present so ruff doesn't flag the
+# subsequent module-level imports as E402 (post-statement imports).
 try:
-    import uvloop as _uvloop  # type: ignore[import-not-found]
-
-    _uvloop.install()
+    import uvloop
+    uvloop.install()
 except ImportError:
-    pass
+    raise
 
 import gc
 import importlib

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -1,4 +1,16 @@
 import asyncio
+
+# Install uvloop as the default asyncio event loop policy before any module
+# retrieves a running loop. libuv-backed event loops have significantly lower
+# per-await overhead than the cpython default; this affects every coroutine
+# in the server. Falls back to the default loop when uvloop is not installed.
+try:
+    import uvloop as _uvloop  # type: ignore[import-not-found]
+
+    _uvloop.install()
+except ImportError:
+    pass
+
 import gc
 import importlib
 import inspect

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -1,17 +1,4 @@
 import asyncio
-
-# Install uvloop as the default asyncio event loop policy before any module
-# retrieves a running loop. libuv-backed event loops have significantly lower
-# per-await overhead than the cpython default; this affects every coroutine
-# in the server. uvloop is a declared dependency, so the import is expected
-# to succeed; the try-block here is only present so ruff doesn't flag the
-# subsequent module-level imports as E402 (post-statement imports).
-try:
-    import uvloop
-    uvloop.install()
-except ImportError:
-    raise
-
 import gc
 import importlib
 import inspect
@@ -28,6 +15,7 @@ from typing import Any, Dict, Mapping, Optional, Sequence, Set
 
 import click
 import torch
+import uvloop
 import yaml
 from strenum import StrEnum
 from torch.cuda import device_count
@@ -65,6 +53,12 @@ from tensorrt_llm.tools.importlib_utils import import_custom_module_from_dir
 from tensorrt_llm.usage import config as _telemetry_config
 from tensorrt_llm.visual_gen import VisualGen
 from tensorrt_llm.visual_gen.args import VisualGenArgs
+
+# Install uvloop as the default asyncio event loop policy before anything
+# in this process creates a loop. libuv-backed event loops have significantly
+# lower per-await overhead than the cpython default; this affects every
+# coroutine in the server.
+uvloop.install()
 
 # Global variable to store the Popen object of the child process
 _child_p_global: Optional[subprocess.Popen] = None

--- a/tensorrt_llm/inputs/media_io.py
+++ b/tensorrt_llm/inputs/media_io.py
@@ -4,12 +4,14 @@
 
 import asyncio
 import base64
+import functools
 import ipaddress
 import math
 import os
 import socket
 import tempfile
 from abc import ABC, abstractmethod
+from concurrent.futures import ThreadPoolExecutor
 from io import BytesIO
 from pathlib import Path
 from types import MappingProxyType
@@ -25,6 +27,25 @@ from PIL import Image
 
 from tensorrt_llm.inputs.multimodal_data import AudioData, VideoData
 from tensorrt_llm.logger import logger
+
+# Dedicated executor for blocking media-load work (bytes / base64 / file
+# decode). The cpython default asyncio.to_thread executor is shared across
+# the whole server, so decodes would otherwise contend for thread slots with
+# unrelated to_thread() callers (URL validation, etc.). A dedicated pool
+# isolates this work and lets the size be tuned independently.
+_MEDIA_LOAD_WORKERS = int(os.environ.get("TRTLLM_MEDIA_LOAD_WORKERS", "8"))
+_MEDIA_LOAD_EXECUTOR = ThreadPoolExecutor(
+    max_workers=_MEDIA_LOAD_WORKERS,
+    thread_name_prefix="trtllm_media_load",
+)
+
+
+async def _media_load_run(fn, *args, **kwargs):
+    """Run a blocking media-load callable on the dedicated executor."""
+    if kwargs:
+        fn = functools.partial(fn, **kwargs)
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(_MEDIA_LOAD_EXECUTOR, fn, *args)
 
 
 def rgba_to_rgb(
@@ -482,7 +503,7 @@ class BaseMediaIO(ABC, Generic[_MediaT]):
         if parsed.scheme in ("http", "https"):
             session = await _get_aiohttp_session()
             data = await _safe_aiohttp_get(url, session=session)
-            return await asyncio.to_thread(self.load_bytes, data)
+            return await _media_load_run(self.load_bytes, data)
         elif parsed.scheme == "data":
             data_spec, b64_data = parsed.path.split(",", 1)
             parts = data_spec.split(";", 1)
@@ -490,9 +511,9 @@ class BaseMediaIO(ABC, Generic[_MediaT]):
             encoding = parts[1] if len(parts) > 1 else ""
             if encoding != "base64":
                 raise NotImplementedError("Only base64 data URLs are supported for now.")
-            return await asyncio.to_thread(self.load_base64, media_type, b64_data)
+            return await _media_load_run(self.load_base64, media_type, b64_data)
         elif parsed.scheme in ("", "file"):
-            return await asyncio.to_thread(self.load_file, url)
+            return await _media_load_run(self.load_file, url)
         else:
             raise ValueError(f"Unsupported URL scheme: {parsed.scheme!r}")
 

--- a/tensorrt_llm/inputs/media_io.py
+++ b/tensorrt_llm/inputs/media_io.py
@@ -32,6 +32,7 @@ from typing import (
 from urllib.parse import unquote, urljoin, urlparse
 
 import aiohttp
+import lazy_loader as lazy
 import numpy as np
 import requests
 import soundfile
@@ -41,6 +42,11 @@ from PIL import Image
 
 from tensorrt_llm.inputs.multimodal_data import AudioData, VideoData
 from tensorrt_llm.logger import logger
+
+# Lazy import: OpenCV is large and only needed when the cv2-backed video
+# decode path is exercised. The proxy triggers the actual `import cv2` on
+# first attribute access (e.g. `cv2.VideoCapture`).
+cv2 = lazy.load("cv2")
 
 
 def rgba_to_rgb(
@@ -345,16 +351,13 @@ def _select_cv2_stream_buffered_backend() -> Optional[int]:
     open. Built-in backends (the FFMPEG path in the PyPI wheels) are always
     safe to use.
     """
-    # Keep this import local to avoid importing cv2 if not needed.
-    import cv2
-
     # The stream-buffered API was introduced in OpenCV 4.13.0. Older builds
     # don't have `cv2.videoio_registry.getStreamBufferedBackends`, so signal
     # "no usable backend" and let the caller fall back to the tempfile path.
     if Version(cv2.__version__) < Version("4.13.0"):
         return None
 
-    from cv2 import videoio_registry as vr
+    vr = cv2.videoio_registry
 
     # `getStreamBufferedBackends()` enumerates every backend in this OpenCV
     # build that *claims* to support stream-buffered reads. We filter that
@@ -416,9 +419,6 @@ def _load_video_by_cv2(
                       HF processor (its `do_rescale=True` path).
       `"pil"`       - list[PIL.Image], one per sampled frame.
     """
-    # Keep this import local to avoid importing cv2 if not needed
-    import cv2
-
     assert format in ("pt", "hwc_uint8", "pil"), "format must be one of 'pt', 'hwc_uint8', 'pil'"
 
     # Open the source. Two cases:

--- a/tensorrt_llm/inputs/media_io.py
+++ b/tensorrt_llm/inputs/media_io.py
@@ -11,11 +11,24 @@ import os
 import socket
 import tempfile
 from abc import ABC, abstractmethod
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Executor
 from io import BytesIO
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, Dict, Generic, List, Literal, Mapping, Optional, Tuple, Type, TypeVar, Union
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    Generic,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 from urllib.parse import unquote, urljoin, urlparse
 
 import aiohttp
@@ -23,46 +36,11 @@ import numpy as np
 import requests
 import soundfile
 import torch
+from packaging.version import Version
 from PIL import Image
 
 from tensorrt_llm.inputs.multimodal_data import AudioData, VideoData
 from tensorrt_llm.logger import logger
-
-
-def _read_positive_int_env(name: str, default: int) -> int:
-    """Parse a positive-int env var, falling back to ``default`` on bad values."""
-    raw = os.environ.get(name)
-    if raw is None or raw == "":
-        return default
-    try:
-        value = int(raw)
-    except ValueError:
-        logger.warning("%s=%r is not an integer; using default %d", name, raw, default)
-        return default
-    if value < 1:
-        logger.warning("%s=%d must be >= 1; using default %d", name, value, default)
-        return default
-    return value
-
-
-# Dedicated executor for blocking media-load work (bytes / base64 / file
-# decode). The cpython default asyncio.to_thread executor is shared across
-# the whole server, so decodes would otherwise contend for thread slots with
-# unrelated to_thread() callers (URL validation, etc.). A dedicated pool
-# isolates this work and lets the size be tuned independently.
-_MEDIA_LOAD_WORKERS = _read_positive_int_env("TRTLLM_MEDIA_LOAD_WORKERS", 8)
-_MEDIA_LOAD_EXECUTOR = ThreadPoolExecutor(
-    max_workers=_MEDIA_LOAD_WORKERS,
-    thread_name_prefix="trtllm_media_load",
-)
-
-
-async def _media_load_run(fn, *args, **kwargs):
-    """Run a blocking media-load callable on the dedicated executor."""
-    if kwargs:
-        fn = functools.partial(fn, **kwargs)
-    loop = asyncio.get_event_loop()
-    return await loop.run_in_executor(_MEDIA_LOAD_EXECUTOR, fn, *args)
 
 
 def rgba_to_rgb(
@@ -94,9 +72,13 @@ def convert_image_mode(image: Image.Image, to_mode: str) -> Image.Image:
 # Canonical set of supported media modalities for Pydantic field validation.
 MediaModality = Literal["image", "video", "audio"]
 
-# Output representations supported by `ImageMediaIO` and `VideoMediaIO`:
-# `"pt"` → `torch.Tensor`, `"pil"` → `PIL.Image.Image` (per frame for video).
+# Output representations supported by `ImageMediaIO`:
+# `"pt"` -> `torch.Tensor`, `"pil"` -> `PIL.Image.Image`.
 _SUPPORTED_IMAGE_FORMATS = ("pt", "pil")
+
+# Output representations supported by `VideoMediaIO`. See
+# `_load_video_by_cv2` for the per-format contract.
+_SUPPORTED_VIDEO_FORMATS = ("pt", "hwc_uint8", "pil")
 
 # Module-level aiohttp session shared across all media fetch calls.
 # Created lazily on first use inside the async event loop, then reused so that
@@ -351,49 +333,59 @@ def extract_audio_from_video(
 
 
 def _select_cv2_stream_buffered_backend() -> Optional[int]:
-    """Return a VideoCapture backend that can read from a Python ``BytesIO``.
+    """Return a VideoCapture backend that can read from a Python `BytesIO`.
 
-    Returns ``None`` if no such backend is available in this OpenCV build.
+    Returns `None` if no such backend is available in this OpenCV build —
+    the caller falls back to the tempfile path. The `videoio_registry`
+    stream-buffered API was introduced in OpenCV 4.13.0, so older builds
+    are gated out by a version check.
+
     Plugin-provided backends must implement the stream-buffered API at
     version 1.2+; older plugins exist that load fine but crash on stream
     open. Built-in backends (the FFMPEG path in the PyPI wheels) are always
     safe to use.
     """
+    # Keep this import local to avoid importing cv2 if not needed.
     import cv2
 
-    try:
-        from cv2 import videoio_registry as vr
-    except ImportError:
+    # The stream-buffered API was introduced in OpenCV 4.13.0. Older builds
+    # don't have `cv2.videoio_registry.getStreamBufferedBackends`, so signal
+    # "no usable backend" and let the caller fall back to the tempfile path.
+    if Version(cv2.__version__) < Version("4.13.0"):
         return None
-    try:
-        for backend in vr.getStreamBufferedBackends():
-            if not vr.hasBackend(backend):
+
+    from cv2 import videoio_registry as vr
+
+    # `getStreamBufferedBackends()` enumerates every backend in this OpenCV
+    # build that *claims* to support stream-buffered reads. We filter that
+    # list down to one that's safe to use:
+    #   1. `hasBackend(backend)` — the backend's shared library is actually
+    #      loadable in this process (a backend can be enumerated by the
+    #      registry but missing at link time on a stripped build).
+    #   2. For plugin (non-built-in) backends, check the plugin's announced
+    #      stream-buffered API/ABI version. Plugins reporting ABI<1 or
+    #      (ABI==1, API<2) load fine but segfault on stream open in the
+    #      wild — skip them. Built-in backends (FFMPEG in the PyPI wheels)
+    #      have no plugin-version concept and are always safe.
+    # The first surviving backend is returned. Order is OpenCV's preference.
+    for backend in vr.getStreamBufferedBackends():
+        if not vr.hasBackend(backend):
+            continue
+        if not vr.isBackendBuiltIn(backend):
+            _, abi, api = vr.getStreamBufferedBackendPluginVersion(backend)
+            if abi < 1 or (abi == 1 and api < 2):
                 continue
-            if not vr.isBackendBuiltIn(backend):
-                _, abi, api = vr.getStreamBufferedBackendPluginVersion(backend)
-                if abi < 1 or (abi == 1 and api < 2):
-                    continue
-            return backend
-    except (AttributeError, cv2.error):
-        # Older cv2 without the stream-buffered registry API, or a backend
-        # query failure — caller falls back to the tempfile path.
-        pass
+        return backend
     return None
 
 
-def _write_video_tempfile(data: bytes) -> str:
-    """Persist mp4 bytes to a named tempfile and return its path.
-
-    Used as a fallback when no cv2 stream-buffered backend is available.
-    The caller owns the returned path and must ``os.unlink`` it when done.
-    """
-    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
-    try:
-        tmp.write(data)
-        tmp.flush()
-    finally:
-        tmp.close()
-    return tmp.name
+# TRT-LLM is Linux-only, so /dev/shm (tmpfs, RAM-backed) is normally available
+# and avoids the disk round-trip the system tempdir would incur. Resolved once
+# at import time. Falls back to `None` (system default tempdir, typically
+# /tmp) if /dev/shm is missing or not writable in this environment.
+_VIDEO_TEMPFILE_DIR: Optional[str] = (
+    "/dev/shm" if os.path.isdir("/dev/shm") and os.access("/dev/shm", os.W_OK) else None
+)
 
 
 def _load_video_by_cv2(
@@ -403,50 +395,59 @@ def _load_video_by_cv2(
     format: str = "pt",
     device: str = "cpu",
     extract_audio: bool = False,
+    cv2_backend: Optional[int] = None,
 ) -> VideoData:
     """Decode a video and return sampled frames as a list.
 
-    ``video`` is a file path / URL (``str``) or raw mp4 bytes. When bytes
-    are passed, cv2.VideoCapture is opened over a ``BytesIO`` via the
-    stream-buffered backend, avoiding a tempfile write. A tempfile fallback
-    is used when no stream-buffered backend is available.
+    `video` is either a file path / URL (`str`) or raw mp4 bytes. When
+    bytes are passed the caller must also pass `cv2_backend` (a
+    stream-buffered backend id from `_select_cv2_stream_buffered_backend`);
+    cv2.VideoCapture is then opened over a `BytesIO` via that backend, no
+    tempfile required. Callers that have no stream-buffered backend
+    available should spill to a tempfile themselves and pass a path.
+
+    `format` controls the per-frame return type:
+      `"pt"`        - list[torch.Tensor], dtype=float32, shape=(C, H, W),
+                      range [0, 1]. Frames are rescaled and permuted to
+                      CHW inside this function.
+      `"hwc_uint8"` - list[np.ndarray], dtype=uint8, shape=(H, W, 3).
+                      Frames are returned unchanged from the cv2 decode;
+                      rescale and permute are deferred to the downstream
+                      HF processor (its `do_rescale=True` path).
+      `"pil"`       - list[PIL.Image], one per sampled frame.
     """
     # Keep this import local to avoid importing cv2 if not needed
     import cv2
 
-    assert format in ["pt", "pil"], "format must be either Pytorch or PIL"
+    assert format in ("pt", "hwc_uint8", "pil"), "format must be one of 'pt', 'hwc_uint8', 'pil'"
 
-    # Open the source. Three cases:
-    #   (a) ``video`` is a file path / URL str -> hand it straight to cv2.
-    #   (b) ``video`` is mp4 bytes AND cv2 has a stream-buffered backend ->
-    #       feed cv2 from an in-memory BytesIO. The buffer is held alive in
-    #       ``_video_buf`` because cv2 keeps a non-owning view into it.
-    #   (c) ``video`` is mp4 bytes but no stream-buffered backend -> spill
-    #       to a tempfile and open it. The path is unlinked at end of fn.
-    _video_buf: Optional[BytesIO] = None
-    _tmp_path: Optional[str] = None
+    # Open the source. Two cases:
+    #   (a) `video` is a file path / URL str -> hand it straight to cv2.
+    #   (b) `video` is mp4 bytes -> feed cv2 from an in-memory BytesIO via
+    #       the caller-supplied stream-buffered backend. The buffer is held
+    #       alive in `video_buf` because cv2 keeps a non-owning view into it.
+    video_buf: Optional[BytesIO] = None
     if isinstance(video, (bytes, bytearray, memoryview)):
-        data = bytes(video)
-        api = _select_cv2_stream_buffered_backend()
-        if api is not None:
-            _video_buf = BytesIO(data)
-            vidcap = cv2.VideoCapture(_video_buf, api, [])
-        else:
-            _tmp_path = _write_video_tempfile(data)
-            video = _tmp_path
-            vidcap = cv2.VideoCapture(video)
+        if cv2_backend is None:
+            raise ValueError(
+                "cv2_backend must be provided when `video` is bytes; "
+                "callers without a stream-buffered backend should spill "
+                "the bytes to a tempfile and pass the path instead."
+            )
+        video_buf = BytesIO(bytes(video))
+        vidcap = cv2.VideoCapture(video_buf, cv2_backend, [])
     else:
         vidcap = cv2.VideoCapture(video)
 
     try:
         if not vidcap.isOpened():
-            _src_repr = (
+            src_repr = (
                 f"<{len(video)} bytes>"
                 if isinstance(video, (bytes, bytearray, memoryview))
                 else f"'{video}'"
             )
             raise ValueError(
-                f"Video {_src_repr} could not be opened. Make sure opencv is installed with video support."
+                f"Video {src_repr} could not be opened. Make sure opencv is installed with video support."
             )
 
         frame_count = int(vidcap.get(cv2.CAP_PROP_FRAME_COUNT))
@@ -496,7 +497,11 @@ def _load_video_by_cv2(
             if device != "cpu":
                 tensor_nchw = tensor_nchw.to(device)
             loaded_frames = list(torch.unbind(tensor_nchw, dim=0))
-        else:
+        elif format == "hwc_uint8":
+            # Return uint8 HWC frames as-is; the downstream HF processor
+            # handles rescale and permute via its `do_rescale=True` path.
+            loaded_frames = [raw_frames[i] for i in valid_indices]
+        else:  # "pil"
             loaded_frames = [Image.fromarray(raw_frames[i]) for i in valid_indices]
 
         metadata = {
@@ -504,6 +509,7 @@ def _load_video_by_cv2(
             "fps": original_fps,
             "duration": duration,
             "frames_indices": valid_indices,
+            "io_loaded_all_frames": len(valid_indices) == frame_count,
         }
     finally:
         # Release the OpenCV handle before any downstream re-open (e.g. PyAV
@@ -513,29 +519,21 @@ def _load_video_by_cv2(
     audio = None
     if extract_audio:
         # extract_audio_from_video accepts Union[str, BytesIO]. When the
-        # in-memory cv2 path was taken, ``video`` is still the original
+        # in-memory cv2 path was taken, `video` is still the original
         # bytes parameter — wrap in a fresh BytesIO (the one consumed by
         # cv2 is at end-of-stream). When the tempfile fallback was used,
-        # ``video`` is the file path string and is passed through as-is.
-        _audio_source = (
+        # `video` is the file path string and is passed through as-is.
+        audio_source = (
             BytesIO(bytes(video)) if isinstance(video, (bytes, bytearray, memoryview)) else video
         )
         try:
-            audio_samples, audio_sample_rate = extract_audio_from_video(_audio_source)
+            audio_samples, audio_sample_rate = extract_audio_from_video(audio_source)
             audio = AudioData(samples=audio_samples, sample_rate=audio_sample_rate)
         except ValueError as e:
             if "No audio stream found" in str(e):
                 logger.warning("Video has no audio track, skipping audio extraction.")
             else:
                 raise
-
-    # Clean up the fallback tempfile (if any). Done after audio extraction
-    # since that path may still read from the file.
-    if _tmp_path is not None:
-        try:
-            os.unlink(_tmp_path)
-        except OSError:
-            pass
 
     return VideoData(frames=loaded_frames, metadata=metadata, audio=audio)
 
@@ -559,6 +557,21 @@ class BaseMediaIO(ABC, Generic[_MediaT]):
     and async coordination live here on the base class and are shared by all
     modalities.
     """
+
+    # Executor used by `async_load` to run blocking decode work off the
+    # event loop. `None` selects the asyncio loop's default executor.
+    # Servers can publish a dedicated pool via `configure_executor` so
+    # media decoding does not contend with unrelated `to_thread` callers.
+    _executor: ClassVar[Optional[Executor]] = None
+
+    @classmethod
+    def configure_executor(cls, executor: Executor) -> None:
+        """Publish a shared executor for blocking decode work.
+
+        Affects every existing and future subclass instance. Calling more
+        than once replaces the previously configured executor.
+        """
+        BaseMediaIO._executor = executor
 
     @classmethod
     def create(
@@ -608,13 +621,15 @@ class BaseMediaIO(ABC, Generic[_MediaT]):
         """Fetch and decode media from a URL.
 
         Dispatches on scheme: http/https (remote fetch), data: (inline
-        base64), or file:// / bare path (local file).
+        base64), or file:// / bare path (local file). Blocking decode work
+        runs on the executor published via `configure_executor`, falling
+        back to the asyncio loop's default executor when none is set.
         """
         parsed = urlparse(url)
         if parsed.scheme in ("http", "https"):
             session = await _get_aiohttp_session()
             data = await _safe_aiohttp_get(url, session=session)
-            return await _media_load_run(self.load_bytes, data)
+            return await self._run_in_executor(self.load_bytes, data)
         elif parsed.scheme == "data":
             data_spec, b64_data = parsed.path.split(",", 1)
             parts = data_spec.split(";", 1)
@@ -622,11 +637,19 @@ class BaseMediaIO(ABC, Generic[_MediaT]):
             encoding = parts[1] if len(parts) > 1 else ""
             if encoding != "base64":
                 raise NotImplementedError("Only base64 data URLs are supported for now.")
-            return await _media_load_run(self.load_base64, media_type, b64_data)
+            return await self._run_in_executor(self.load_base64, media_type, b64_data)
         elif parsed.scheme in ("", "file"):
-            return await _media_load_run(self.load_file, url)
+            return await self._run_in_executor(self.load_file, url)
         else:
             raise ValueError(f"Unsupported URL scheme: {parsed.scheme!r}")
+
+    @classmethod
+    async def _run_in_executor(cls, fn, *args, **kwargs):
+        """Run a blocking decode callable on the configured executor."""
+        if kwargs:
+            fn = functools.partial(fn, **kwargs)
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(BaseMediaIO._executor, fn, *args)
 
 
 class ImageMediaIO(BaseMediaIO[Union[Image.Image, torch.Tensor]]):
@@ -690,12 +713,15 @@ class VideoMediaIO(BaseMediaIO[VideoData]):
         self,
         num_frames: int = 10,
         fps: int = 30,
-        format: str = "pt",
+        format: str = "hwc_uint8",
         device: str = "cpu",
         extract_audio: bool = False,
     ) -> None:
-        if format not in _SUPPORTED_IMAGE_FORMATS:
-            raise ValueError(f"format must be one of {_SUPPORTED_IMAGE_FORMATS}, got {format!r}")
+        # Default format is `"hwc_uint8"`: frames are returned as uint8 HWC
+        # and the downstream HF processor handles rescale + permute. Pass
+        # `format="pt"` to get pre-rescaled float32 CHW tensors instead.
+        if format not in _SUPPORTED_VIDEO_FORMATS:
+            raise ValueError(f"format must be one of {_SUPPORTED_VIDEO_FORMATS}, got {format!r}")
         self._num_frames = num_frames
         self._fps = fps
         self._format = format
@@ -722,17 +748,33 @@ class VideoMediaIO(BaseMediaIO[VideoData]):
         return merged
 
     def load_bytes(self, data: bytes) -> VideoData:
-        # Pass mp4 bytes directly; the in-memory fast path in
-        # _load_video_by_cv2 opens cv2.VideoCapture via BytesIO and avoids
-        # a tempfile write.
-        return _load_video_by_cv2(
-            data,
-            self._num_frames,
-            self._fps,
-            self._format,
-            self._device,
-            extract_audio=self._extract_audio,
-        )
+        # In-memory fast path when cv2 has a stream-buffered backend; spill
+        # to a tempfile otherwise so cv2 can open it by path. The tempfile
+        # is unlinked on context exit; the inode survives until cv2 closes
+        # its own fd (Linux semantics), so the decode inside the `with`
+        # block reads safely.
+        cv2_backend = _select_cv2_stream_buffered_backend()
+        if cv2_backend is not None:
+            return _load_video_by_cv2(
+                data,
+                self._num_frames,
+                self._fps,
+                self._format,
+                self._device,
+                extract_audio=self._extract_audio,
+                cv2_backend=cv2_backend,
+            )
+        with tempfile.NamedTemporaryFile(suffix=".mp4", dir=_VIDEO_TEMPFILE_DIR) as tmp:
+            tmp.write(data)
+            tmp.flush()
+            return _load_video_by_cv2(
+                tmp.name,
+                self._num_frames,
+                self._fps,
+                self._format,
+                self._device,
+                extract_audio=self._extract_audio,
+            )
 
     def load_base64(self, media_type: str, data: str) -> VideoData:
         return self.load_bytes(base64.b64decode(data))

--- a/tensorrt_llm/inputs/media_io.py
+++ b/tensorrt_llm/inputs/media_io.py
@@ -334,24 +334,69 @@ def extract_audio_from_video(
 
 
 def _load_video_by_cv2(
-    video: str,
+    video,
     num_frames: int = 10,
     fps: int = 30,
     format: str = "pt",
     device: str = "cpu",
     extract_audio: bool = False,
 ) -> VideoData:
+    """Decode a video and return sampled frames as a list.
+
+    ``video`` is a file path / URL (``str``) or raw mp4 bytes. When bytes
+    are passed, cv2.VideoCapture is opened over a ``BytesIO`` via the
+    stream-buffered backend, avoiding a tempfile write. A tempfile fallback
+    is used when no stream-buffered backend is available.
+    """
     # Keep this import local to avoid importing cv2 if not needed
     import cv2
 
     assert format in ["pt", "pil"], "format must be either Pytorch or PIL"
 
-    vidcap = cv2.VideoCapture(video)
+    # In-memory fast path. The BytesIO must be kept alive for the duration
+    # of decoding — cv2 holds a non-owning view into the buffer.
+    _video_buf = None
+    if isinstance(video, (bytes, bytearray, memoryview)):
+        from cv2 import videoio_registry as _vr
+
+        _api_pref = None
+        try:
+            for _backend in _vr.getStreamBufferedBackends():
+                if not _vr.hasBackend(_backend):
+                    continue
+                if not _vr.isBackendBuiltIn(_backend):
+                    _, _abi, _api = _vr.getStreamBufferedBackendPluginVersion(_backend)
+                    if _abi < 1 or (_abi == 1 and _api < 2):
+                        continue
+                _api_pref = _backend
+                break
+        except Exception:
+            _api_pref = None
+        if _api_pref is not None:
+            _video_buf = BytesIO(bytes(video))
+            vidcap = cv2.VideoCapture(_video_buf, _api_pref, [])
+        else:
+            # No stream-buffered backend; fall back to a tempfile.
+            _tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
+            try:
+                _tmp.write(bytes(video))
+                _tmp.flush()
+            finally:
+                _tmp.close()
+            video = _tmp.name
+            vidcap = cv2.VideoCapture(video)
+    else:
+        vidcap = cv2.VideoCapture(video)
 
     try:
         if not vidcap.isOpened():
+            _src_repr = (
+                f"<{len(video)} bytes>"
+                if isinstance(video, (bytes, bytearray, memoryview))
+                else f"'{video}'"
+            )
             raise ValueError(
-                f"Video '{video}' could not be opened. Make sure opencv is installed with video support."
+                f"Video {_src_repr} could not be opened. Make sure opencv is installed with video support."
             )
 
         frame_count = int(vidcap.get(cv2.CAP_PROP_FRAME_COUNT))
@@ -392,15 +437,11 @@ def _load_video_by_cv2(
 
         valid_indices = [i for i in indices if i in raw_frames]
         if format == "pt":
-            # Bypass PIL: direct numpy HWC uint8 -> torch CHW float32
-            loaded_frames = [
-                torch.from_numpy(raw_frames[i])
-                .permute(2, 0, 1)
-                .float()
-                .div_(255.0)
-                .to(device=device)
-                for i in valid_indices
-            ]
+            # Return uint8 HWC numpy frames. The downstream HF processor's
+            # do_rescale=True path rescales and permutes the stacked
+            # (N, H, W, 3) array as one vectorized op, so per-frame Python
+            # torch conversion here is redundant work.
+            loaded_frames = [raw_frames[i] for i in valid_indices]
         else:
             loaded_frames = [Image.fromarray(raw_frames[i]) for i in valid_indices]
 
@@ -417,8 +458,15 @@ def _load_video_by_cv2(
 
     audio = None
     if extract_audio:
+        # extract_audio_from_video accepts Union[str, BytesIO]. If the
+        # in-memory cv2 path was taken, ``video`` is still the original
+        # bytes parameter — wrap in a fresh BytesIO (the one consumed by
+        # cv2 is at end-of-stream).
+        _audio_source = (
+            BytesIO(bytes(video)) if isinstance(video, (bytes, bytearray, memoryview)) else video
+        )
         try:
-            audio_samples, audio_sample_rate = extract_audio_from_video(video)
+            audio_samples, audio_sample_rate = extract_audio_from_video(_audio_source)
             audio = AudioData(samples=audio_samples, sample_rate=audio_sample_rate)
         except ValueError as e:
             if "No audio stream found" in str(e):
@@ -611,17 +659,17 @@ class VideoMediaIO(BaseMediaIO[VideoData]):
         return merged
 
     def load_bytes(self, data: bytes) -> VideoData:
-        with tempfile.NamedTemporaryFile(delete=True, suffix=".mp4") as f:
-            f.write(data)
-            f.flush()
-            return _load_video_by_cv2(
-                f.name,
-                self._num_frames,
-                self._fps,
-                self._format,
-                self._device,
-                extract_audio=self._extract_audio,
-            )
+        # Pass mp4 bytes directly; the in-memory fast path in
+        # _load_video_by_cv2 opens cv2.VideoCapture via BytesIO and avoids
+        # a tempfile write.
+        return _load_video_by_cv2(
+            data,
+            self._num_frames,
+            self._fps,
+            self._format,
+            self._device,
+            extract_audio=self._extract_audio,
+        )
 
     def load_base64(self, media_type: str, data: str) -> VideoData:
         return self.load_bytes(base64.b64decode(data))

--- a/tensorrt_llm/inputs/media_io.py
+++ b/tensorrt_llm/inputs/media_io.py
@@ -28,12 +28,29 @@ from PIL import Image
 from tensorrt_llm.inputs.multimodal_data import AudioData, VideoData
 from tensorrt_llm.logger import logger
 
+
+def _read_positive_int_env(name: str, default: int) -> int:
+    """Parse a positive-int env var, falling back to ``default`` on bad values."""
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("%s=%r is not an integer; using default %d", name, raw, default)
+        return default
+    if value < 1:
+        logger.warning("%s=%d must be >= 1; using default %d", name, value, default)
+        return default
+    return value
+
+
 # Dedicated executor for blocking media-load work (bytes / base64 / file
 # decode). The cpython default asyncio.to_thread executor is shared across
 # the whole server, so decodes would otherwise contend for thread slots with
 # unrelated to_thread() callers (URL validation, etc.). A dedicated pool
 # isolates this work and lets the size be tuned independently.
-_MEDIA_LOAD_WORKERS = int(os.environ.get("TRTLLM_MEDIA_LOAD_WORKERS", "8"))
+_MEDIA_LOAD_WORKERS = _read_positive_int_env("TRTLLM_MEDIA_LOAD_WORKERS", 8)
 _MEDIA_LOAD_EXECUTOR = ThreadPoolExecutor(
     max_workers=_MEDIA_LOAD_WORKERS,
     thread_name_prefix="trtllm_media_load",
@@ -333,8 +350,54 @@ def extract_audio_from_video(
     return audio, target_sr
 
 
+def _select_cv2_stream_buffered_backend() -> Optional[int]:
+    """Return a VideoCapture backend that can read from a Python ``BytesIO``.
+
+    Returns ``None`` if no such backend is available in this OpenCV build.
+    Plugin-provided backends must implement the stream-buffered API at
+    version 1.2+; older plugins exist that load fine but crash on stream
+    open. Built-in backends (the FFMPEG path in the PyPI wheels) are always
+    safe to use.
+    """
+    import cv2
+
+    try:
+        from cv2 import videoio_registry as vr
+    except ImportError:
+        return None
+    try:
+        for backend in vr.getStreamBufferedBackends():
+            if not vr.hasBackend(backend):
+                continue
+            if not vr.isBackendBuiltIn(backend):
+                _, abi, api = vr.getStreamBufferedBackendPluginVersion(backend)
+                if abi < 1 or (abi == 1 and api < 2):
+                    continue
+            return backend
+    except (AttributeError, cv2.error):
+        # Older cv2 without the stream-buffered registry API, or a backend
+        # query failure — caller falls back to the tempfile path.
+        pass
+    return None
+
+
+def _write_video_tempfile(data: bytes) -> str:
+    """Persist mp4 bytes to a named tempfile and return its path.
+
+    Used as a fallback when no cv2 stream-buffered backend is available.
+    The caller owns the returned path and must ``os.unlink`` it when done.
+    """
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
+    try:
+        tmp.write(data)
+        tmp.flush()
+    finally:
+        tmp.close()
+    return tmp.name
+
+
 def _load_video_by_cv2(
-    video,
+    video: Union[str, bytes],
     num_frames: int = 10,
     fps: int = 30,
     format: str = "pt",
@@ -353,37 +416,24 @@ def _load_video_by_cv2(
 
     assert format in ["pt", "pil"], "format must be either Pytorch or PIL"
 
-    # In-memory fast path. The BytesIO must be kept alive for the duration
-    # of decoding — cv2 holds a non-owning view into the buffer.
-    _video_buf = None
+    # Open the source. Three cases:
+    #   (a) ``video`` is a file path / URL str -> hand it straight to cv2.
+    #   (b) ``video`` is mp4 bytes AND cv2 has a stream-buffered backend ->
+    #       feed cv2 from an in-memory BytesIO. The buffer is held alive in
+    #       ``_video_buf`` because cv2 keeps a non-owning view into it.
+    #   (c) ``video`` is mp4 bytes but no stream-buffered backend -> spill
+    #       to a tempfile and open it. The path is unlinked at end of fn.
+    _video_buf: Optional[BytesIO] = None
+    _tmp_path: Optional[str] = None
     if isinstance(video, (bytes, bytearray, memoryview)):
-        from cv2 import videoio_registry as _vr
-
-        _api_pref = None
-        try:
-            for _backend in _vr.getStreamBufferedBackends():
-                if not _vr.hasBackend(_backend):
-                    continue
-                if not _vr.isBackendBuiltIn(_backend):
-                    _, _abi, _api = _vr.getStreamBufferedBackendPluginVersion(_backend)
-                    if _abi < 1 or (_abi == 1 and _api < 2):
-                        continue
-                _api_pref = _backend
-                break
-        except Exception:
-            _api_pref = None
-        if _api_pref is not None:
-            _video_buf = BytesIO(bytes(video))
-            vidcap = cv2.VideoCapture(_video_buf, _api_pref, [])
+        data = bytes(video)
+        api = _select_cv2_stream_buffered_backend()
+        if api is not None:
+            _video_buf = BytesIO(data)
+            vidcap = cv2.VideoCapture(_video_buf, api, [])
         else:
-            # No stream-buffered backend; fall back to a tempfile.
-            _tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4")
-            try:
-                _tmp.write(bytes(video))
-                _tmp.flush()
-            finally:
-                _tmp.close()
-            video = _tmp.name
+            _tmp_path = _write_video_tempfile(data)
+            video = _tmp_path
             vidcap = cv2.VideoCapture(video)
     else:
         vidcap = cv2.VideoCapture(video)
@@ -437,11 +487,15 @@ def _load_video_by_cv2(
 
         valid_indices = [i for i in indices if i in raw_frames]
         if format == "pt":
-            # Return uint8 HWC numpy frames. The downstream HF processor's
-            # do_rescale=True path rescales and permutes the stacked
-            # (N, H, W, 3) array as one vectorized op, so per-frame Python
-            # torch conversion here is redundant work.
-            loaded_frames = [raw_frames[i] for i in valid_indices]
+            # uint8 -> float32 + /255 rescale done once on the stacked buffer
+            # so the dtype conversion is a single memory pass and there's one
+            # Python torch call instead of one per frame.
+            stacked_uint8 = np.stack([raw_frames[i] for i in valid_indices])
+            stacked_f32 = stacked_uint8.astype(np.float32) * (1.0 / 255.0)
+            tensor_nchw = torch.from_numpy(stacked_f32).permute(0, 3, 1, 2).contiguous()
+            if device != "cpu":
+                tensor_nchw = tensor_nchw.to(device)
+            loaded_frames = list(torch.unbind(tensor_nchw, dim=0))
         else:
             loaded_frames = [Image.fromarray(raw_frames[i]) for i in valid_indices]
 
@@ -458,10 +512,11 @@ def _load_video_by_cv2(
 
     audio = None
     if extract_audio:
-        # extract_audio_from_video accepts Union[str, BytesIO]. If the
+        # extract_audio_from_video accepts Union[str, BytesIO]. When the
         # in-memory cv2 path was taken, ``video`` is still the original
         # bytes parameter — wrap in a fresh BytesIO (the one consumed by
-        # cv2 is at end-of-stream).
+        # cv2 is at end-of-stream). When the tempfile fallback was used,
+        # ``video`` is the file path string and is passed through as-is.
         _audio_source = (
             BytesIO(bytes(video)) if isinstance(video, (bytes, bytearray, memoryview)) else video
         )
@@ -473,6 +528,14 @@ def _load_video_by_cv2(
                 logger.warning("Video has no audio track, skipping audio extraction.")
             else:
                 raise
+
+    # Clean up the fallback tempfile (if any). Done after audio extraction
+    # since that path may still read from the file.
+    if _tmp_path is not None:
+        try:
+            os.unlink(_tmp_path)
+        except OSError:
+            pass
 
     return VideoData(frames=loaded_frames, metadata=metadata, audio=audio)
 

--- a/tensorrt_llm/inputs/media_io.py
+++ b/tensorrt_llm/inputs/media_io.py
@@ -498,8 +498,8 @@ def _load_video_by_cv2(
                 tensor_nchw = tensor_nchw.to(device)
             loaded_frames = list(torch.unbind(tensor_nchw, dim=0))
         elif format == "hwc_uint8":
-            # Return uint8 HWC frames as-is; the downstream HF processor
-            # handles rescale and permute via its `do_rescale=True` path.
+            # Return uint8 HWC frames as-is; let the downstream HF processor
+            # handle this internally.
             loaded_frames = [raw_frames[i] for i in valid_indices]
         else:  # "pil"
             loaded_frames = [Image.fromarray(raw_frames[i]) for i in valid_indices]
@@ -509,7 +509,6 @@ def _load_video_by_cv2(
             "fps": original_fps,
             "duration": duration,
             "frames_indices": valid_indices,
-            "io_loaded_all_frames": len(valid_indices) == frame_count,
         }
     finally:
         # Release the OpenCV handle before any downstream re-open (e.g. PyAV
@@ -560,12 +559,12 @@ class BaseMediaIO(ABC, Generic[_MediaT]):
 
     # Executor used by `async_load` to run blocking decode work off the
     # event loop. `None` selects the asyncio loop's default executor.
-    # Servers can publish a dedicated pool via `configure_executor` so
+    # Servers can publish a dedicated pool via `set_executor` so
     # media decoding does not contend with unrelated `to_thread` callers.
     _executor: ClassVar[Optional[Executor]] = None
 
     @classmethod
-    def configure_executor(cls, executor: Executor) -> None:
+    def set_executor(cls, executor: Executor) -> None:
         """Publish a shared executor for blocking decode work.
 
         Affects every existing and future subclass instance. Calling more
@@ -622,7 +621,7 @@ class BaseMediaIO(ABC, Generic[_MediaT]):
 
         Dispatches on scheme: http/https (remote fetch), data: (inline
         base64), or file:// / bare path (local file). Blocking decode work
-        runs on the executor published via `configure_executor`, falling
+        runs on the executor published via `set_executor`, falling
         back to the asyncio loop's default executor when none is set.
         """
         parsed = urlparse(url)
@@ -643,8 +642,8 @@ class BaseMediaIO(ABC, Generic[_MediaT]):
         else:
             raise ValueError(f"Unsupported URL scheme: {parsed.scheme!r}")
 
-    @classmethod
-    async def _run_in_executor(cls, fn, *args, **kwargs):
+    @staticmethod
+    async def _run_in_executor(fn, *args, **kwargs):
         """Run a blocking decode callable on the configured executor."""
         if kwargs:
             fn = functools.partial(fn, **kwargs)

--- a/tensorrt_llm/inputs/media_io.py
+++ b/tensorrt_llm/inputs/media_io.py
@@ -382,12 +382,14 @@ def _select_cv2_stream_buffered_backend() -> Optional[int]:
     return None
 
 
-# TRT-LLM is Linux-only, so /dev/shm (tmpfs, RAM-backed) is normally available
-# and avoids the disk round-trip the system tempdir would incur. Resolved once
-# at import time. Falls back to `None` (system default tempdir, typically
-# /tmp) if /dev/shm is missing or not writable in this environment.
-_VIDEO_TEMPFILE_DIR: Optional[str] = (
-    "/dev/shm" if os.path.isdir("/dev/shm") and os.access("/dev/shm", os.W_OK) else None
+# Prefer /dev/shm (tmpfs, RAM-backed) over the system tempdir to avoid a disk
+# round-trip; falls back to `None` (system default) when unavailable. Only
+# consumed as the `dir=` argument to `tempfile.NamedTemporaryFile`, so the
+# B108 predictable-path concern does not apply.
+_VIDEO_TEMPFILE_DIR: Optional[str] = (  # nosec B108
+    "/dev/shm"  # nosec B108
+    if os.path.isdir("/dev/shm") and os.access("/dev/shm", os.W_OK)  # nosec B108
+    else None
 )
 
 

--- a/tensorrt_llm/inputs/media_io.py
+++ b/tensorrt_llm/inputs/media_io.py
@@ -84,7 +84,7 @@ _SUPPORTED_IMAGE_FORMATS = ("pt", "pil")
 
 # Output representations supported by `VideoMediaIO`. See
 # `_load_video_by_cv2` for the per-format contract.
-_SUPPORTED_VIDEO_FORMATS = ("pt", "hwc_uint8", "pil")
+_SUPPORTED_VIDEO_FORMATS = ("pt", "np", "pil")
 
 # Module-level aiohttp session shared across all media fetch calls.
 # Created lazily on first use inside the async event loop, then reused so that
@@ -412,16 +412,13 @@ def _load_video_by_cv2(
     available should spill to a tempfile themselves and pass a path.
 
     `format` controls the per-frame return type:
-      `"pt"`        - list[torch.Tensor], dtype=float32, shape=(C, H, W),
-                      range [0, 1]. Frames are rescaled and permuted to
-                      CHW inside this function.
-      `"hwc_uint8"` - list[np.ndarray], dtype=uint8, shape=(H, W, 3).
-                      Frames are returned unchanged from the cv2 decode;
-                      rescale and permute are deferred to the downstream
-                      HF processor (its `do_rescale=True` path).
-      `"pil"`       - list[PIL.Image], one per sampled frame.
+      `"pt"`    - list[torch.Tensor], dtype=float32, shape=(C, H, W), range
+                  [0, 1]; rescaled and permuted to CHW here.
+      `"np"` - list[np.ndarray], dtype=uint8, shape=(H, W, 3); returned as
+                  decoded, leaving rescale/permute to the HF processor.
+      `"pil"`   - list[PIL.Image], one per sampled frame.
     """
-    assert format in ("pt", "hwc_uint8", "pil"), "format must be one of 'pt', 'hwc_uint8', 'pil'"
+    assert format in ("pt", "np", "pil"), "format must be one of 'pt', 'np', 'pil'"
 
     # Open the source. Two cases:
     #   (a) `video` is a file path / URL str -> hand it straight to cv2.
@@ -499,9 +496,8 @@ def _load_video_by_cv2(
             if device != "cpu":
                 tensor_nchw = tensor_nchw.to(device)
             loaded_frames = list(torch.unbind(tensor_nchw, dim=0))
-        elif format == "hwc_uint8":
-            # Return uint8 HWC frames as-is; let the downstream HF processor
-            # handle this internally.
+        elif format == "np":
+            # uint8 HWC frames as-is; the HF processor rescales/permutes.
             loaded_frames = [raw_frames[i] for i in valid_indices]
         else:  # "pil"
             loaded_frames = [Image.fromarray(raw_frames[i]) for i in valid_indices]
@@ -714,13 +710,13 @@ class VideoMediaIO(BaseMediaIO[VideoData]):
         self,
         num_frames: int = 10,
         fps: int = 30,
-        format: str = "hwc_uint8",
+        format: str = "pt",
         device: str = "cpu",
         extract_audio: bool = False,
     ) -> None:
-        # Default format is `"hwc_uint8"`: frames are returned as uint8 HWC
-        # and the downstream HF processor handles rescale + permute. Pass
-        # `format="pt"` to get pre-rescaled float32 CHW tensors instead.
+        # `"pt"` is the safe default every video model handles; models tuned
+        # for the uint8-HWC path opt into `"np"` via
+        # InputProcessor.get_preferred_media_io_kwargs().
         if format not in _SUPPORTED_VIDEO_FORMATS:
             raise ValueError(f"format must be one of {_SUPPORTED_VIDEO_FORMATS}, got {format!r}")
         self._num_frames = num_frames

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -614,6 +614,15 @@ class BaseMultimodalDummyInputsBuilder(ABC):
         """
         return {}
 
+    def get_preferred_media_io_kwargs(self) -> Dict[str, Dict[str, Any]]:
+        """Per-modality media-IO decode defaults for this model.
+
+        Applied under the server's ``--media_io_kwargs`` and any per-request
+        override, so a model can opt into a decode format it was tuned for
+        (e.g. ``{"video": {"format": "np"}}``) without operator config.
+        """
+        return {}
+
     def get_dummy_mm_data_for_tokens(
         self,
         *,

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -36,6 +36,7 @@ from tensorrt_llm.executor import CppExecutorError
 from tensorrt_llm.executor.postproc_worker import PostprocParams
 from tensorrt_llm.inputs import prompt_inputs
 from tensorrt_llm.inputs.data import TokensPrompt
+from tensorrt_llm.inputs.media_io import BaseMediaIO
 from tensorrt_llm.inputs.multimodal import MultimodalServerConfig
 from tensorrt_llm.inputs.utils import ConversationMessage, apply_chat_template
 from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
@@ -93,40 +94,6 @@ from .harmony_adapter import (HarmonyAdapter, get_harmony_adapter,
 
 # yapf: enable
 TIMEOUT_KEEP_ALIVE = 5  # seconds.
-
-
-def _read_positive_int_env(name: str, default: int) -> int:
-    """Parse a positive-int env var, falling back to ``default`` on bad values.
-
-    Avoids crashing server startup on invalid values like ``foo``, ``0``, or
-    ``-1`` — logs a warning and uses ``default`` instead.
-    """
-    raw = os.environ.get(name)
-    if raw is None or raw == "":
-        return default
-    try:
-        value = int(raw)
-    except ValueError:
-        logger.warning("%s=%r is not an integer; using default %d", name, raw,
-                       default)
-        return default
-    if value < 1:
-        logger.warning("%s=%d must be >= 1; using default %d", name, value,
-                       default)
-        return default
-    return value
-
-
-# Dedicated executor for HF input-processor / preprocess work on the chat
-# and completion endpoints. Same rationale as the media-load executor in
-# inputs/media_io.py: isolate this CPU-bound work from unrelated
-# to_thread() callers on the default asyncio pool and allow independent
-# tuning.
-_INPUT_PROC_WORKERS = _read_positive_int_env("TRTLLM_INPUT_PROC_WORKERS", 8)
-_INPUT_PROC_EXECUTOR = ThreadPoolExecutor(
-    max_workers=_INPUT_PROC_WORKERS,
-    thread_name_prefix="trtllm_inputproc",
-)
 
 
 def _build_tool_strict_guided_decoding_params(tools, tool_parser_name):
@@ -225,7 +192,9 @@ class OpenAIServer(_VideoRoutesMixin):
             disagg_cluster_config: Optional[DisaggClusterConfig] = None,
             multimodal_server_config: Optional[MultimodalServerConfig] = None,
             chat_template: Optional[str] = None,
-            allow_request_chat_template: bool = False):
+            allow_request_chat_template: bool = False,
+            input_processor_workers: int = 8,
+            media_load_workers: int = 8):
         self.generator = generator
         self._is_visual_gen = isinstance(generator, VisualGen)
         self.tool_parser = tool_parser
@@ -238,6 +207,20 @@ class OpenAIServer(_VideoRoutesMixin):
         self.binding_addr = None
         self.host = None
         self.port = None
+
+        # Dedicated thread pools for the chat / completion path. Keeping
+        # multimodal preprocessing and decode work off the asyncio default
+        # executor avoids contention with unrelated `to_thread` callers and
+        # lets the two stages be sized independently.
+        self._input_proc_executor = ThreadPoolExecutor(
+            max_workers=input_processor_workers,
+            thread_name_prefix="trtllm_inputproc",
+        )
+        self._media_load_executor = ThreadPoolExecutor(
+            max_workers=media_load_workers,
+            thread_name_prefix="trtllm_media_load",
+        )
+        BaseMediaIO.configure_executor(self._media_load_executor)
 
         model_dir = Path(model)
         if model_dir.exists() and model_dir.is_dir():
@@ -1356,7 +1339,7 @@ class OpenAIServer(_VideoRoutesMixin):
             if preprocess_fn is not None:
                 loop = asyncio.get_event_loop()
                 generate_inputs = await loop.run_in_executor(
-                    _INPUT_PROC_EXECUTOR,
+                    self._input_proc_executor,
                     functools.partial(preprocess_fn, prompt, sampling_params,
                                       disaggregated_params))
 
@@ -1659,7 +1642,7 @@ class OpenAIServer(_VideoRoutesMixin):
                 if prompt.get("prompt") is not None:
                     loop = asyncio.get_event_loop()
                     prompt_token_ids, extra_processed_inputs = await loop.run_in_executor(
-                        _INPUT_PROC_EXECUTOR,
+                        self._input_proc_executor,
                         functools.partial(self.generator.input_processor,
                                           prompt, sampling_params))
                     tokens_prompt = TokensPrompt(

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -220,7 +220,7 @@ class OpenAIServer(_VideoRoutesMixin):
             max_workers=media_load_workers,
             thread_name_prefix="trtllm_media_load",
         )
-        BaseMediaIO.configure_executor(self._media_load_executor)
+        BaseMediaIO.set_executor(self._media_load_executor)
 
         model_dir = Path(model)
         if model_dir.exists() and model_dir.is_dir():

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -94,12 +94,35 @@ from .harmony_adapter import (HarmonyAdapter, get_harmony_adapter,
 # yapf: enable
 TIMEOUT_KEEP_ALIVE = 5  # seconds.
 
+
+def _read_positive_int_env(name: str, default: int) -> int:
+    """Parse a positive-int env var, falling back to ``default`` on bad values.
+
+    Avoids crashing server startup on invalid values like ``foo``, ``0``, or
+    ``-1`` — logs a warning and uses ``default`` instead.
+    """
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("%s=%r is not an integer; using default %d", name, raw,
+                       default)
+        return default
+    if value < 1:
+        logger.warning("%s=%d must be >= 1; using default %d", name, value,
+                       default)
+        return default
+    return value
+
+
 # Dedicated executor for HF input-processor / preprocess work on the chat
 # and completion endpoints. Same rationale as the media-load executor in
 # inputs/media_io.py: isolate this CPU-bound work from unrelated
 # to_thread() callers on the default asyncio pool and allow independent
 # tuning.
-_INPUT_PROC_WORKERS = int(os.environ.get("TRTLLM_INPUT_PROC_WORKERS", "8"))
+_INPUT_PROC_WORKERS = _read_positive_int_env("TRTLLM_INPUT_PROC_WORKERS", 8)
 _INPUT_PROC_EXECUTOR = ThreadPoolExecutor(
     max_workers=_INPUT_PROC_WORKERS,
     thread_name_prefix="trtllm_inputproc",

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import asyncio
 import base64
+import functools
 import json
 import os
 import re
@@ -10,6 +11,7 @@ import time
 import traceback
 import uuid
 from collections import deque
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from datetime import datetime
 from http import HTTPStatus
@@ -91,6 +93,17 @@ from .harmony_adapter import (HarmonyAdapter, get_harmony_adapter,
 
 # yapf: enable
 TIMEOUT_KEEP_ALIVE = 5  # seconds.
+
+# Dedicated executor for HF input-processor / preprocess work on the chat
+# and completion endpoints. Same rationale as the media-load executor in
+# inputs/media_io.py: isolate this CPU-bound work from unrelated
+# to_thread() callers on the default asyncio pool and allow independent
+# tuning.
+_INPUT_PROC_WORKERS = int(os.environ.get("TRTLLM_INPUT_PROC_WORKERS", "8"))
+_INPUT_PROC_EXECUTOR = ThreadPoolExecutor(
+    max_workers=_INPUT_PROC_WORKERS,
+    thread_name_prefix="trtllm_inputproc",
+)
 
 
 def _build_tool_strict_guided_decoding_params(tools, tool_parser_name):
@@ -1318,9 +1331,11 @@ class OpenAIServer(_VideoRoutesMixin):
             generate_inputs = prompt
             preprocess_fn = getattr(self.generator, "preprocess", None)
             if preprocess_fn is not None:
-                generate_inputs = await asyncio.to_thread(
-                    preprocess_fn, prompt, sampling_params,
-                    disaggregated_params)
+                loop = asyncio.get_event_loop()
+                generate_inputs = await loop.run_in_executor(
+                    _INPUT_PROC_EXECUTOR,
+                    functools.partial(preprocess_fn, prompt, sampling_params,
+                                      disaggregated_params))
 
             promise = self.generator.generate_async(
                 inputs=generate_inputs,
@@ -1619,8 +1634,11 @@ class OpenAIServer(_VideoRoutesMixin):
 
                 prompt = prompt_inputs(prompt)
                 if prompt.get("prompt") is not None:
-                    prompt_token_ids, extra_processed_inputs = await asyncio.to_thread(
-                        self.generator.input_processor, prompt, sampling_params)
+                    loop = asyncio.get_event_loop()
+                    prompt_token_ids, extra_processed_inputs = await loop.run_in_executor(
+                        _INPUT_PROC_EXECUTOR,
+                        functools.partial(self.generator.input_processor,
+                                          prompt, sampling_params))
                     tokens_prompt = TokensPrompt(
                         prompt_token_ids=prompt_token_ids,
                         query_token_ids=extra_processed_inputs.get(

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -38,6 +38,7 @@ from tensorrt_llm.inputs import prompt_inputs
 from tensorrt_llm.inputs.data import TokensPrompt
 from tensorrt_llm.inputs.media_io import BaseMediaIO
 from tensorrt_llm.inputs.multimodal import MultimodalServerConfig
+from tensorrt_llm.inputs.registry import BaseMultimodalInputProcessor
 from tensorrt_llm.inputs.utils import ConversationMessage, apply_chat_template
 from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
 from tensorrt_llm.llmapi import MultimodalEncoder, SchedulingParams, tracing
@@ -201,6 +202,19 @@ class OpenAIServer(_VideoRoutesMixin):
         self.metadata_server = create_metadata_server(metadata_server_cfg)
         self.disagg_cluster_config = disagg_cluster_config
         self.multimodal_server_config = multimodal_server_config
+        # Seed media-IO decode defaults from the model's input processor, then
+        # let the server's --media_io_kwargs win (per-request kwargs still
+        # override at request time).
+        ip = getattr(self.generator, "input_processor", None)
+        if isinstance(ip, BaseMultimodalInputProcessor):
+            model_pref = ip.get_preferred_media_io_kwargs() or {}
+            if model_pref:
+                cfg = self.multimodal_server_config or MultimodalServerConfig()
+                merged = {m: dict(kw) for m, kw in model_pref.items()}
+                for modality, kw in (cfg.media_io_kwargs or {}).items():
+                    merged.setdefault(modality, {}).update(kw)
+                cfg.media_io_kwargs = merged
+                self.multimodal_server_config = cfg
         self.allow_request_chat_template = allow_request_chat_template
         self.server_role = server_role
         # Will be set in __call__

--- a/tests/unittest/_torch/modeling/test_modeling_multimodal_utils.py
+++ b/tests/unittest/_torch/modeling/test_modeling_multimodal_utils.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+from typing import Optional, TypedDict
+
+from tensorrt_llm._torch.models.modeling_multimodal_utils import _get_cached_merged_typed_dict
+
+
+def test_merged_typed_dict_reuses_cached_schema():
+    """Two `merged_typed_dict` schemas with the same shape collapse to one cached
+    class. This is what makes huggingface_hub's per-schema validator cache hit
+    on subsequent ProcessorMixin._merge_kwargs calls."""
+    cache: dict = {}
+    first = TypedDict("merged_typed_dict", {"do_rescale": Optional[bool]}, total=False)
+    second = TypedDict("merged_typed_dict", {"do_rescale": Optional[bool]}, total=False)
+
+    cached_first = _get_cached_merged_typed_dict(first, cache)
+    cached_second = _get_cached_merged_typed_dict(second, cache)
+
+    assert cached_first is cached_second  # identity stable across equivalent shapes
+
+
+def test_non_merged_typed_dict_schemas_pass_through():
+    """Schemas whose `__name__` is not the ephemeral `merged_typed_dict` are
+    returned unchanged — only HF's per-call class is the one we want to collapse."""
+    other = TypedDict("other_typed_dict", {"do_rescale": Optional[bool]}, total=False)
+    assert _get_cached_merged_typed_dict(other, {}) is other

--- a/tests/unittest/_torch/modeling/test_modeling_qwen3vl_preprocess.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen3vl_preprocess.py
@@ -89,12 +89,11 @@ class TestDecideDoSampleFrames:
         vd = _fake_video({"total_num_frames": 240}, n_frames=240)
         assert _decide_do_sample_frames([vd], {}) is True
 
-    def test_silent_caller_io_subsampled_no_sampling(self):
-        # No num_frames/fps from caller, IO already subsampled
-        # (decoded count < total_num_frames): leave the IO-decoded frames
-        # alone.
+    def test_silent_caller_io_subsampled_triggers_sampling(self):
+        # No num_frames/fps from caller: defer to HF's class-default sampling
+        # even when IO already subsampled (decoded count < total_num_frames).
         vd = _fake_video({"total_num_frames": 240}, n_frames=8)
-        assert _decide_do_sample_frames([vd], {}) is False
+        assert _decide_do_sample_frames([vd], {}) is True
 
     def test_batch_reduction_is_any_video_needs_sampling(self):
         # One video matches, one needs resampling → batch is sampled.

--- a/tests/unittest/_torch/modeling/test_modeling_qwen3vl_preprocess.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen3vl_preprocess.py
@@ -83,15 +83,17 @@ class TestDecideDoSampleFrames:
         assert _decide_do_sample_frames([vd_diff], {"fps": 4.0}) is True
 
     def test_silent_caller_io_loaded_all_triggers_fallback_sampling(self):
-        # No num_frames/fps from caller, IO loaded every source frame:
-        # defer to HF's class-default sampling.
-        vd = _fake_video({"io_loaded_all_frames": True}, n_frames=240)
+        # No num_frames/fps from caller, IO loaded every source frame
+        # (decoded count == total_num_frames): defer to HF's class-default
+        # sampling.
+        vd = _fake_video({"total_num_frames": 240}, n_frames=240)
         assert _decide_do_sample_frames([vd], {}) is True
 
     def test_silent_caller_io_subsampled_no_sampling(self):
-        # No num_frames/fps from caller, IO already subsampled:
-        # leave the IO-decoded frames alone.
-        vd = _fake_video({"io_loaded_all_frames": False}, n_frames=8)
+        # No num_frames/fps from caller, IO already subsampled
+        # (decoded count < total_num_frames): leave the IO-decoded frames
+        # alone.
+        vd = _fake_video({"total_num_frames": 240}, n_frames=8)
         assert _decide_do_sample_frames([vd], {}) is False
 
     def test_batch_reduction_is_any_video_needs_sampling(self):
@@ -113,14 +115,6 @@ class TestPreprocessMetadataForwarding:
         m = processor.call_args.kwargs["video_metadata"][0]
         assert m["total_num_frames"] == 8
         assert m["fps"] == 24.0  # other fields unchanged
-
-    def test_io_loaded_all_frames_internal_stash_stripped(self):
-        # `io_loaded_all_frames` is consumed by `_decide_do_sample_frames` and
-        # must not leak into HF's VideoMetadata dataclass (which rejects it).
-        vd = _fake_video({"io_loaded_all_frames": True, "duration": 1.0}, n_frames=8)
-        processor = _call_preprocess({"video": [vd]}, {"num_frames": 8})
-        m = processor.call_args.kwargs["video_metadata"][0]
-        assert "io_loaded_all_frames" not in m
 
     def test_metadata_is_none_when_no_videos(self):
         processor = _call_preprocess({}, {"fps": 2.0})

--- a/tests/unittest/_torch/modeling/test_modeling_qwen3vl_preprocess.py
+++ b/tests/unittest/_torch/modeling/test_modeling_qwen3vl_preprocess.py
@@ -12,32 +12,31 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests for Qwen3VLInputProcessorBase._preprocess kwargs handling.
+"""Unit tests for Qwen3-VL preprocess control flow.
 
-Covers the per-request ``mm_processor_kwargs`` plumbing added to Qwen3-VL:
-  * Video metadata from the IO loader is forwarded to the HF processor so
-    sample_frames sees the real source fps (rather than HF's 24 fps default).
-  * ``num_frames`` and ``fps`` are mutually exclusive in HF's sample_frames; if
-    the caller sets ``num_frames`` without ``fps``, ``_preprocess`` must
-    explicitly null ``fps`` so the processor's class-level ``fps=2`` default
-    does not interfere.
-  * The caller-supplied ``mm_processor_kwargs`` dict must not be mutated.
+Covers two pieces of logic that decide what reaches HF's video processor:
 
-The tests bind ``_preprocess`` to a stand-in object so they avoid the heavy
-``__init__`` (which would download an HF processor) and only exercise the new
-control-flow.
+  1. ``_decide_do_sample_frames`` — the decision tree that picks the single
+     ``do_sample_frames`` flag for the whole batch.
+  2. ``_preprocess`` — metadata rewriting and kwargs threading around the
+     processor call.
+
+The tests bind ``_preprocess`` to a stand-in object so they exercise the
+control flow without constructing a real HF processor.
 """
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from tensorrt_llm._torch.models.modeling_qwen3vl import Qwen3VLInputProcessorBase
+from tensorrt_llm._torch.models.modeling_qwen3vl import (
+    Qwen3VLInputProcessorBase,
+    _decide_do_sample_frames,
+)
 
 
-def _fake_video(metadata):
-    """Minimal stand-in for VideoData: just needs ``.frames`` and ``.metadata``."""
-    # A single non-Tensor frame so the do_rescale branch stays in its default.
-    return SimpleNamespace(frames=[object()], metadata=metadata)
+def _fake_video(metadata, *, n_frames=8):
+    """Stand-in for VideoData: only `.frames` (count) and `.metadata` are read."""
+    return SimpleNamespace(frames=[object()] * n_frames, metadata=metadata)
 
 
 def _call_preprocess(mm_data, mm_processor_kwargs):
@@ -52,98 +51,110 @@ def _call_preprocess(mm_data, mm_processor_kwargs):
     return fake_processor
 
 
-class TestVideoMetadataForwarding:
-    """``video_metadata`` is forwarded only when the caller passes
-    ``mm_processor_kwargs``."""
+class TestDecideDoSampleFrames:
+    """Decision tree for whether HF should run ``sample_frames``."""
 
-    def test_metadata_forwarded_when_opted_in(self):
-        """Opted-in path: list built per-video, in order."""
-        md0 = {"total_num_frames": 64, "fps": 25.0, "duration": 2.5}
-        md1 = {"total_num_frames": 32, "fps": 30.0, "duration": 1.0}
-        mm_data = {"video": [_fake_video(md0), _fake_video(md1)]}
+    def test_explicit_true_wins_even_when_counts_match(self):
+        # Even with a matching target, caller's explicit True is honored.
+        vd = _fake_video({"duration": 4.0}, n_frames=8)
+        assert _decide_do_sample_frames([vd], {"do_sample_frames": True}) is True
 
-        processor = _call_preprocess(mm_data, {"fps": 2.0})
+    def test_explicit_false_wins_even_when_counts_differ(self):
+        # Even when num_frames would force sampling, caller's False is honored.
+        vd = _fake_video({"duration": 4.0}, n_frames=8)
+        assert (
+            _decide_do_sample_frames([vd], {"do_sample_frames": False, "num_frames": 16}) is False
+        )
 
-        kwargs = processor.call_args.kwargs
-        assert kwargs["video_metadata"] == [md0, md1]
-        assert len(kwargs["videos"]) == 2
+    def test_num_frames_matches_decoded_no_sampling(self):
+        vd = _fake_video({}, n_frames=8)
+        assert _decide_do_sample_frames([vd], {"num_frames": 8}) is False
 
-    def test_metadata_not_forwarded_with_empty_kwargs(self):
-        """Empty kwargs: videos present but metadata is not forwarded."""
-        mm_data = {"video": [_fake_video({"fps": 30.0})]}
+    def test_num_frames_differs_triggers_sampling(self):
+        vd = _fake_video({}, n_frames=8)
+        assert _decide_do_sample_frames([vd], {"num_frames": 4}) is True
 
-        processor = _call_preprocess(mm_data, {})
+    def test_fps_target_computed_from_duration(self):
+        # Target = floor(duration * fps) = floor(4.0 * 2.0) = 8 → no resample.
+        vd_match = _fake_video({"duration": 4.0}, n_frames=8)
+        assert _decide_do_sample_frames([vd_match], {"fps": 2.0}) is False
+        # Target = floor(4.0 * 4.0) = 16 ≠ 8 → resample.
+        vd_diff = _fake_video({"duration": 4.0}, n_frames=8)
+        assert _decide_do_sample_frames([vd_diff], {"fps": 4.0}) is True
 
-        assert processor.call_args.kwargs["video_metadata"] is None
+    def test_silent_caller_io_loaded_all_triggers_fallback_sampling(self):
+        # No num_frames/fps from caller, IO loaded every source frame:
+        # defer to HF's class-default sampling.
+        vd = _fake_video({"io_loaded_all_frames": True}, n_frames=240)
+        assert _decide_do_sample_frames([vd], {}) is True
+
+    def test_silent_caller_io_subsampled_no_sampling(self):
+        # No num_frames/fps from caller, IO already subsampled:
+        # leave the IO-decoded frames alone.
+        vd = _fake_video({"io_loaded_all_frames": False}, n_frames=8)
+        assert _decide_do_sample_frames([vd], {}) is False
+
+    def test_batch_reduction_is_any_video_needs_sampling(self):
+        # One video matches, one needs resampling → batch is sampled.
+        match = _fake_video({}, n_frames=8)
+        differ = _fake_video({}, n_frames=16)
+        assert _decide_do_sample_frames([match, differ], {"num_frames": 8}) is True
+
+
+class TestPreprocessMetadataForwarding:
+    """`_preprocess` forwards per-video metadata with controlled rewrites."""
+
+    def test_total_num_frames_rewritten_to_decoded_count(self):
+        # Source clip had 240 frames; IO subsampled to 8.
+        # `total_num_frames` must be rewritten so HF's sample_frames indices
+        # stay in range of the 8-frame tensor we hand it.
+        vd = _fake_video({"total_num_frames": 240, "fps": 24.0, "duration": 10.0}, n_frames=8)
+        processor = _call_preprocess({"video": [vd]}, {"num_frames": 8})
+        m = processor.call_args.kwargs["video_metadata"][0]
+        assert m["total_num_frames"] == 8
+        assert m["fps"] == 24.0  # other fields unchanged
+
+    def test_io_loaded_all_frames_internal_stash_stripped(self):
+        # `io_loaded_all_frames` is consumed by `_decide_do_sample_frames` and
+        # must not leak into HF's VideoMetadata dataclass (which rejects it).
+        vd = _fake_video({"io_loaded_all_frames": True, "duration": 1.0}, n_frames=8)
+        processor = _call_preprocess({"video": [vd]}, {"num_frames": 8})
+        m = processor.call_args.kwargs["video_metadata"][0]
+        assert "io_loaded_all_frames" not in m
 
     def test_metadata_is_none_when_no_videos(self):
-        """No videos: metadata is None regardless of kwargs."""
         processor = _call_preprocess({}, {"fps": 2.0})
+        assert processor.call_args.kwargs["video_metadata"] is None
+
+
+class TestPreprocessKwargsForwarding:
+    """`do_sample_frames` is always passed; sampling kwargs are conditional."""
+
+    def test_sampling_kwargs_forwarded_when_sampling(self):
+        # num_frames mismatches frames count → sampling fires → num_frames forwarded.
+        vd = _fake_video({}, n_frames=8)
+        processor = _call_preprocess({"video": [vd]}, {"num_frames": 4})
         kwargs = processor.call_args.kwargs
-        assert kwargs["video_metadata"] is None
-        assert kwargs["videos"] is None
+        assert kwargs["do_sample_frames"] is True
+        assert kwargs["num_frames"] == 4
 
-
-class TestNumFramesFpsMutualExclusivity:
-    """Truth table over ("num_frames" present, "fps" present).
-
-    HF's Qwen3VLProcessor.sample_frames treats num_frames and fps as mutually
-    exclusive; the class-level default ``fps=2`` would otherwise win over the
-    caller's ``num_frames``. The fix injects ``fps=None`` only in the
-    (True, False) corner.
-    """
-
-    def test_num_frames_without_fps_injects_null_fps(self):
-        """(True, False): the corner the fix exists for."""
-        mm_data = {"video": [_fake_video({"fps": 30.0})]}
-
-        processor = _call_preprocess(mm_data, {"num_frames": 8})
-
+    def test_sampling_kwargs_dropped_when_not_sampling(self):
+        # num_frames matches frames count → no sampling → num_frames NOT forwarded
+        # (HF's class-default ``fps=2`` cannot collide because do_sample_frames=False).
+        vd = _fake_video({}, n_frames=8)
+        processor = _call_preprocess({"video": [vd]}, {"num_frames": 8})
         kwargs = processor.call_args.kwargs
-        assert kwargs["num_frames"] == 8
-        assert "fps" in kwargs
-        assert kwargs["fps"] is None
-
-    def test_explicit_fps_is_preserved(self):
-        """(True, True): the fix must not trample a user-supplied fps."""
-        mm_data = {"video": [_fake_video({"fps": 30.0})]}
-
-        processor = _call_preprocess(mm_data, {"num_frames": 8, "fps": 4.0})
-
-        kwargs = processor.call_args.kwargs
-        assert kwargs["num_frames"] == 8
-        assert kwargs["fps"] == 4.0
-
-    def test_fps_only_passes_through_unchanged(self):
-        """(False, True): the condition must not fire for fps alone."""
-        processor = _call_preprocess({}, {"fps": 4.0})
-
-        kwargs = processor.call_args.kwargs
-        assert kwargs["fps"] == 4.0
-        assert "num_frames" not in kwargs
-
-    def test_no_kwargs_means_no_num_frames_no_fps(self):
-        """(False, False): the empty-kwargs case adds no spurious keys."""
-        processor = _call_preprocess({}, {})
-
-        kwargs = processor.call_args.kwargs
+        assert kwargs["do_sample_frames"] is False
         assert "num_frames" not in kwargs
         assert "fps" not in kwargs
 
-
-class TestInputDictNotMutated:
-    """The caller's mm_processor_kwargs dict is copied, not mutated."""
-
-    def test_num_frames_only_dict_not_mutated(self):
-        original = {"num_frames": 8}
+    def test_caller_dict_not_mutated(self):
+        original = {"num_frames": 8, "max_pixels": 1234}
         snapshot = dict(original)
         _call_preprocess({}, original)
         assert original == snapshot
 
-
-class TestUnrelatedKwargsForwarded:
-    """Keys unrelated to the num_frames/fps fix pass through verbatim."""
-
-    def test_unrelated_kwargs_reach_processor(self):
-        processor = _call_preprocess({}, {"num_frames": 8, "max_pixels": 1234})
+    def test_unrelated_kwargs_pass_through(self):
+        # Resize/normalize knobs flow through unchanged.
+        processor = _call_preprocess({}, {"max_pixels": 1234})
         assert processor.call_args.kwargs["max_pixels"] == 1234

--- a/tests/unittest/api_stability/references/trtllm_serve_cli.yaml
+++ b/tests/unittest/api_stability/references/trtllm_serve_cli.yaml
@@ -303,6 +303,24 @@ commands:
         is_flag: false
         flags:
         - "--num_postprocess_workers"
+      input_processor_workers:
+        type: int
+        default: 8
+        status: prototype
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--input-processor-workers"
+      media_load_workers:
+        type: int
+        default: 8
+        status: prototype
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--media-load-workers"
       otlp_traces_endpoint:
         type: str
         default: null


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved media loading and video handling for faster, more reliable processing of local files, URLs, and in-memory content.
  * Added support for more efficient server-side preprocessing with dedicated worker threads.

* **Bug Fixes**
  * Reduced the chance of media decoding delays by moving blocking work off the main async path.
  * Improved handling of video frame sampling so preprocessed inputs are treated more consistently.
  * Made video input handling from bytes more robust, including audio extraction from in-memory content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

A few improvements to the preprocessing speed of Qwen3-VL (and other models should benefit too)
* `[uvloop](https://uvloop.readthedocs.io/)` asyncio event loop backend - already default in vllm and is 2-4 faster which benefits us when event loop is under a huge queue of pending events - this is just a simple drop-in replacement that makes the largest diff
* separate input processor pool - again already done in vllm, and benefits by having a dedicated pool for the heavy HF processor rather than using the default shared asyncio thread pool - for both completion and chat endpoints
* dedicated media IO load pool - same as above, but for media IO loading - which is very slow for videos
* Skip tempfile write for cv2.VideoCapture and pass the BytesIO directly - skips the file IO which is slower especially when under concurrent load
* Don't return a list of pytorch tensors from `_load_video_by_cv2` via python list comprehension (calls `torch.from_numpy` for every request) - instead return the uint8 numpy frames and let the HF processor's do_rescale=True path do the rescale + permute as a single vectorized op on the stacked (N, H, W, 3) array 
* Skip the HF processor frame subsampling by passing `do_sample_frames=False` via mm_processing_kwargs so we don't duplicate the work (Media IO already does this work upstream)
* memoize the call to `merge_kwargs` in preprocessing_qwen3vl. This function is a pure function (i.e same args produce same output), and is called for every input processor invocation - and was taking 76ms under load. Simply memoize the output for the args passed 

## Overall perf improvements:

**benchmark**: 30s 374×374 `libx264` mp4 video (`moving_shapes` synth) + 50 text tokens → ISL ≈ 2.3k–13.1k depending on fps, OSL ∈ {1, 100}, fps ∈ {1, 2, 4, 8}, concurrency ∈ {1, 8, 16, 32, 64, 128, 256}

### Cosmos3-Super-Reasoner

| GPU | Precision | median Δ tok/s/GPU |
|---|---|---:|
| B200 | BF16  | **+7.4%** |
| B200 | FP8   | **+22.9%** |
| B200 | NVFP4 | **+34.4%** |
| H200 | BF16  | **+12.6%** |
| H200 | FP8   | **+25.3%** |
| **All** | **all** | **+19.4%** |

### Cosmos3-Nano-Reasoner

| GPU | Precision | median Δ tok/s/GPU |
|---|---|---:|
| B200 | BF16  | **+43.2%** |
| B200 | FP8   | **+74.4%** |
| B200 | NVFP4 | **+76.4%** |
| H200 | BF16  | **+37.9%** |
| H200 | FP8   | **+52.7%** |
| **All** | **all** | **+49.8%** |

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
