### PR TITLE
[None][fix] Honor Qwen Image quant ignore list

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
+++ b/tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py
@@ -32,6 +32,7 @@ from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig
 from tensorrt_llm._torch.visual_gen.models.modeling import BaseDiffusionModel
 from tensorrt_llm._torch.visual_gen.modules.attention import Attention, QKVMode
 from tensorrt_llm._torch.visual_gen.quantization.loader import DynamicLinearWeightLoader
+from tensorrt_llm.models.modeling_utils import QuantConfig
 
 _WEIGHT_KEY_REMAPS = [
     (".net.0.proj.", ".up_proj."),
@@ -825,6 +826,8 @@ class QwenImageTransformer2DModel(BaseDiffusionModel):
             **linear_kwargs,
         )
 
+        self.apply_quant_config_exclude_modules()
+
     @property
     def device(self) -> torch.device:
         return self.proj_out.weight.device
@@ -872,6 +875,26 @@ class QwenImageTransformer2DModel(BaseDiffusionModel):
                 if buffer.is_floating_point():
                     buffer.data = buffer.data.to(target_dtype)
         return self
+
+    def apply_quant_config_exclude_modules(self) -> None:
+        quant_config = self.model_config.quant_config
+        if quant_config is None or quant_config.exclude_modules is None:
+            return
+
+        kv_cache_quant_algo = quant_config.kv_cache_quant_algo if quant_config else None
+        no_quant_config = QuantConfig(kv_cache_quant_algo=kv_cache_quant_algo)
+
+        for name, module in self.named_modules():
+            if isinstance(module, Linear):
+                is_excluded = quant_config.is_module_excluded_from_quantization(name)
+                if is_excluded and getattr(module, "quant_config", None) is not None:
+                    module.quant_config = no_quant_config
+                    if getattr(module, "_weights_created", False):
+                        # Rebuild weights so quant_method and parameter layout match the no-quant config.
+                        module._weights_created = False
+                        module._parameters.clear()
+                        module._buffers.clear()
+                        module.create_weights()
 
     def load_weights(self, weights: Dict[str, torch.Tensor]) -> None:
         """Load HF ``transformer/*.safetensors`` state_dict.

--- a/tests/unittest/_torch/visual_gen/test_qwen_image_registry.py
+++ b/tests/unittest/_torch/visual_gen/test_qwen_image_registry.py
@@ -13,6 +13,8 @@ import json
 import pytest
 import torch
 
+from tensorrt_llm._torch.modules.linear import NVFP4LinearMethod, UnquantizedLinearMethod
+
 # Importing the models package side-effects the ``@register_pipeline``
 # decorator on ``QwenImagePipeline`` being applied, which is what we are
 # testing here.
@@ -23,6 +25,8 @@ from tensorrt_llm._torch.visual_gen.models.qwen_image import (
     QwenImageTransformer2DModel,
 )
 from tensorrt_llm._torch.visual_gen.pipeline_registry import PIPELINE_REGISTRY, AutoPipeline
+from tensorrt_llm.models.modeling_utils import QuantConfig
+from tensorrt_llm.quantization.mode import QuantAlgo
 from tensorrt_llm.visual_gen.args import AttentionConfig
 
 
@@ -63,6 +67,41 @@ def test_transformer_load_weights_detects_mismatch():
     model = QwenImageTransformer2DModel(model_config=None, num_layers=2)
     with pytest.raises(RuntimeError, match=r"Missing keys|Unexpected keys"):
         model.load_weights({})
+
+
+def test_transformer_applies_quant_config_ignore_list() -> None:
+    """Qwen-Image should honor selective dynamic quantization exclusions."""
+    model_config = DiffusionModelConfig(
+        quant_config=QuantConfig(
+            quant_algo=QuantAlgo.NVFP4,
+            exclude_modules=[
+                "transformer_blocks.0*",
+                "img_in",
+                "proj_out",
+            ],
+        ),
+        dynamic_weight_quant=True,
+        force_dynamic_quantization=True,
+    )
+    model = QwenImageTransformer2DModel(model_config=model_config, num_layers=2)
+
+    assert model.img_in.quant_config.quant_algo is None
+    assert model.proj_out.quant_config.quant_algo is None
+    assert model.transformer_blocks[0].attn.add_q_proj.quant_config.quant_algo is None
+    assert model.transformer_blocks[0].img_mlp.up_proj.quant_config.quant_algo is None
+    assert isinstance(model.img_in.quant_method, UnquantizedLinearMethod)
+    assert isinstance(model.proj_out.quant_method, UnquantizedLinearMethod)
+    assert isinstance(
+        model.transformer_blocks[0].attn.add_q_proj.quant_method, UnquantizedLinearMethod
+    )
+    assert isinstance(
+        model.transformer_blocks[0].img_mlp.up_proj.quant_method, UnquantizedLinearMethod
+    )
+
+    assert model.txt_in.quant_config.quant_algo == QuantAlgo.NVFP4
+    assert model.transformer_blocks[1].attn.add_q_proj.quant_config.quant_algo == QuantAlgo.NVFP4
+    assert isinstance(model.txt_in.quant_method, NVFP4LinearMethod)
+    assert isinstance(model.transformer_blocks[1].attn.add_q_proj.quant_method, NVFP4LinearMethod)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")


### PR DESCRIPTION
## Description

Fix Qwen-Image dynamic quantization so `quant_config.ignore` is applied to the module graph, matching the behavior used by other VisualGen transformers such as WAN and FLUX.

The Qwen-Image dynamic weight loader already skipped load-time quantization for ignored module names, but the `Linear` modules were still constructed with the global quant config. That meant excluded modules could still retain NVFP4/FP8 module state and activation behavior, making selective quantization appear ineffective.

This change adds an exclusion pass in `QwenImageTransformer2DModel` that replaces ignored `Linear.quant_config` values with a no-op weight quant config, while preserving any KV cache quant setting. It also adds a unit test that verifies ignored Qwen modules are left unquantized while non-ignored modules keep NVFP4.

## Testing

- `python -m py_compile tensorrt_llm/_torch/visual_gen/models/qwen_image/transformer_qwen_image.py tests/unittest/_torch/visual_gen/test_qwen_image_registry.py`
- `git diff --check`

Could not run targeted pytest locally because `tests/unittest/conftest.py` imports `mpi4py`, which is not installed in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Qwen Image models now respect quantization exclusion settings, allowing selected layers to stay unquantized while the rest of the model still uses the configured quantization behavior.
  * Improved initialization so excluded components are handled automatically at model load time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->