### PR TITLE
[https://nvbugs/6368480][fix] Cache the SM count once in FmhaDispatcher's constructor and reuse the cached…

### DIFF
--- a/cpp/tensorrt_llm/kernels/fmhaDispatcher.cpp
+++ b/cpp/tensorrt_llm/kernels/fmhaDispatcher.cpp
@@ -53,6 +53,7 @@ FmhaDispatcher::FmhaDispatcher(MHARunnerFixedParams fixedParams)
     // The exception will fall back to fmha v2.
     // Please update fmha_v2/setup.py if you want to add more supported head sizes.
     , mUseTllmGen(tensorrt_llm::common::isSM100Family() && fixedParams.headSize != 72)
+    , mMultiProcessorCount(tensorrt_llm::common::getMultiProcessorCount())
 {
     if (mUseTllmGen)
     {
@@ -128,7 +129,7 @@ bool FmhaDispatcher::isSupported()
         tllmRunnerParams.mHeadDimV = mFixedParams.headSizeV;
         tllmRunnerParams.mNumTokensPerPage = (qkvLayout == QkvLayout::PagedKv) ? mFixedParams.numTokensPerBlock : 0;
         tllmRunnerParams.mNumHeadsQPerKv = mFixedParams.numQHeads / mFixedParams.numKvHeads;
-        tllmRunnerParams.mMultiProcessorCount = tensorrt_llm::common::getMultiProcessorCount();
+        tllmRunnerParams.mMultiProcessorCount = mMultiProcessorCount;
         // Set the chunked attention size and sliding window size to INT_MAX to disable them when checking if
         // the kernel is supported.
         tllmRunnerParams.mChunkedAttentionSize = INT_MAX;
@@ -247,7 +248,7 @@ void FmhaDispatcher::run(MHARunnerParams runnerParams)
         tllmRunnerParams.mScaleQ = mFixedParams.qScaling;
         // Set it to INT_MAX as the kv cache pageOffsets will ensure that there is no out-of-bounds access.
         tllmRunnerParams.mNumPagesInMemPool = INT_MAX;
-        tllmRunnerParams.mMultiProcessorCount = tensorrt_llm::common::getMultiProcessorCount();
+        tllmRunnerParams.mMultiProcessorCount = mMultiProcessorCount;
         tllmRunnerParams.mSfStartTokenIdx = 0;
         // SageAttention scaling factors.
         tllmRunnerParams.sageAttnSfsQPtr = runnerParams.qScalePtr;

--- a/cpp/tensorrt_llm/kernels/fmhaDispatcher.h
+++ b/cpp/tensorrt_llm/kernels/fmhaDispatcher.h
@@ -61,6 +61,9 @@ private:
     UniqPtrWNullCopy<kernels::FusedMHARunnerV2> mFMHARunner;
     // Runner for trtllm-gen fmha kernels (for SM == 100)
     UniqPtrWNullCopy<kernels::TllmGenFmhaRunner> mTllmGenFMHARunner;
+    // Cached SM count to avoid repeated cudaDeviceGetAttribute calls in the per-iter
+    // FMHA dispatch hot path (isSupported / run).
+    int mMultiProcessorCount{0};
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary
- **Root cause**: FmhaDispatcher::isSupported() and FmhaDispatcher::run() are on the per-iter FMHA dispatch hot path, and each invocation called tensorrt_llm::common::getMultiProcessorCount(), which is a cudaDeviceGetAttribute() call into the CUDA driver. The repeated driver round-trips show up as host overhead on llama-3.3-70B FP4 TP4 (llama70b_fp4_tp4_512_32-con512_iter10_512_32) and caused the perf regression observed in PR12643.
- **Fix**: Cache the SM count once in FmhaDispatcher's constructor and reuse the cached value on every isSupported() / run() invocation. New private member mMultiProcessorCount is initialized from getMultiProcessorCount() in the constructor initializer list; both call sites that previously called getMultiProcessorCount() now read mMultiProcessorCount. SM count is fixed per process, so caching is safe.
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6368480


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved dispatch efficiency by caching a GPU capability value instead of recalculating it repeatedly.
  * This should reduce overhead in attention kernel setup and help keep inference runs more efficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->