### PR TITLE
[TRTLLM-13409][feat] hard-exit on HangDetector fire + cross-rank propagation

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/hang_detector.py
+++ b/tensorrt_llm/_torch/pyexecutor/hang_detector.py
@@ -1,13 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import asyncio
+import os
+import signal
+import sys
 import threading
 from contextlib import contextmanager
 from typing import Callable, Optional
 
-from tensorrt_llm._utils import print_all_stacks
+from tensorrt_llm._utils import ENABLE_MULTI_DEVICE, mpi_comm, mpi_disabled, print_all_stacks
 from tensorrt_llm.logger import logger
+
+# 137 == 128 + SIGKILL(9): the exit code a shell reports for a SIGKILL'd process.
+_HARD_KILL_EXIT_CODE = 137
+
+
+def propagate_hard_kill(exit_code: int = _HARD_KILL_EXIT_CODE) -> None:
+    """Hard-kill this rank and propagate the kill to peer ranks.
+
+    Cross-rank propagation is the load-bearing part: a peer blocked in an NCCL
+    collective would otherwise hold its GPU until the job's wall-clock pod-kill.
+
+    - Preferred (when safe): ``MPI_Abort`` aborts the whole MPI job in one call.
+      Only safe from the detector's daemon thread when MPI was initialized with
+      ``MPI_THREAD_MULTIPLE``; guarded by ``Query_thread``.
+    - Fallback: self-``SIGKILL``. The launcher (``mpirun`` propagates by default;
+      ``srun`` needs ``--kill-on-bad-exit``) then tears down peers.
+    """
+    sys.stderr.flush()
+    sys.stdout.flush()
+    try:
+        if ENABLE_MULTI_DEVICE and not mpi_disabled():
+            from mpi4py import MPI
+
+            if MPI.Is_initialized() and MPI.Query_thread() == MPI.THREAD_MULTIPLE:
+                logger.error("HangDetector: propagating hard-kill to all ranks via MPI_Abort.")
+                mpi_comm().Abort(exit_code)
+                return  # not reached; Abort does not return
+    except Exception as e:  # noqa: BLE001 - last-resort path must not raise
+        logger.error(
+            f"HangDetector: MPI_Abort propagation failed ({e}); falling back to self-SIGKILL."
+        )
+    logger.error("HangDetector: self-SIGKILL; relying on the launcher to propagate to peer ranks.")
+    os.kill(os.getpid(), signal.SIGKILL)
 
 
 class HangDetector:
+    """Watchdog that fires when the executor loop stops checkpointing.
+
+    When ``timeout`` seconds pass without a ``checkpoint()``, all thread stacks
+    are dumped for diagnosis and ``on_detected`` runs (the hard-kill +
+    cross-rank propagation path).
+    """
+
     def __init__(
         self, timeout: Optional[int] = None, on_detected: Optional[Callable[[], None]] = None
     ):

--- a/tensorrt_llm/_torch/pyexecutor/hang_detector.py
+++ b/tensorrt_llm/_torch/pyexecutor/hang_detector.py
@@ -27,6 +27,23 @@ from tensorrt_llm.logger import logger
 _HARD_KILL_EXIT_CODE = 137
 
 
+def _best_effort_flush_streams() -> None:
+    """Flush stdout/stderr without ever raising; diagnostics must not block hard kill."""
+    for stream in (sys.stderr, sys.stdout):
+        try:
+            stream.flush()
+        except (AttributeError, OSError, ValueError):
+            pass
+
+
+def _best_effort_log_error(message: str) -> None:
+    """Log at error level without ever raising; diagnostics must not block hard kill."""
+    try:
+        logger.error(message)
+    except Exception:  # noqa: BLE001 - diagnostics must not block hard kill
+        pass
+
+
 def propagate_hard_kill(exit_code: int = _HARD_KILL_EXIT_CODE) -> None:
     """Hard-kill this rank and propagate the kill to peer ranks.
 
@@ -38,22 +55,28 @@ def propagate_hard_kill(exit_code: int = _HARD_KILL_EXIT_CODE) -> None:
       ``MPI_THREAD_MULTIPLE``; guarded by ``Query_thread``.
     - Fallback: self-``SIGKILL``. The launcher (``mpirun`` propagates by default;
       ``srun`` needs ``--kill-on-bad-exit``) then tears down peers.
+
+    All flushing and logging is best-effort: a closed/broken stdout, stderr, or
+    logger must never prevent reaching ``MPI_Abort`` or ``os.kill``.
     """
-    sys.stderr.flush()
-    sys.stdout.flush()
+    _best_effort_flush_streams()
     try:
         if ENABLE_MULTI_DEVICE and not mpi_disabled():
             from mpi4py import MPI
 
             if MPI.Is_initialized() and MPI.Query_thread() == MPI.THREAD_MULTIPLE:
-                logger.error("HangDetector: propagating hard-kill to all ranks via MPI_Abort.")
+                _best_effort_log_error(
+                    "HangDetector: propagating hard-kill to all ranks via MPI_Abort."
+                )
                 mpi_comm().Abort(exit_code)
                 return  # not reached; Abort does not return
     except Exception as e:  # noqa: BLE001 - last-resort path must not raise
-        logger.error(
+        _best_effort_log_error(
             f"HangDetector: MPI_Abort propagation failed ({e}); falling back to self-SIGKILL."
         )
-    logger.error("HangDetector: self-SIGKILL; relying on the launcher to propagate to peer ranks.")
+    _best_effort_log_error(
+        "HangDetector: self-SIGKILL; relying on the launcher to propagate to peer ranks."
+    )
     os.kill(os.getpid(), signal.SIGKILL)
 
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -690,10 +690,14 @@ class PyExecutor:
             # The graceful shutdown path can itself deadlock on collectives
             # while peer ranks stay blocked in NCCL holding their GPUs. Hard-kill
             # this rank and propagate the kill outward instead.
-            logger.error(
-                f"Hang detected on rank {self.global_rank} in PyExecutor; "
-                "hard-killing and propagating to peer ranks.")
-            propagate_hard_kill()
+            # Guard the diagnostic log in try/finally so propagate_hard_kill()
+            # always runs even if logging itself raises.
+            try:
+                logger.error(
+                    f"Hang detected on rank {self.global_rank} in PyExecutor; "
+                    "hard-killing and propagating to peer ranks.")
+            finally:
+                propagate_hard_kill()
 
         self.hang_detector = HangDetector(timeout=hang_detection_timeout,
                                           on_detected=on_detected)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -62,7 +62,7 @@ from .executor_request_queue import ExecutorRequestQueue, RequestQueueItem
 from .guided_decoder import GuidedDecoder
 from .handle_additional_outputs import HandleAdditionalOutputs
 from .handle_logits import HandleLogits
-from .hang_detector import HangDetector
+from .hang_detector import HangDetector, propagate_hard_kill
 from .kv_cache_manager_v2 import KVCacheManagerV2
 from .kv_cache_stats import append_kv_cache_iteration_stats
 from .kv_cache_transceiver import KvCacheTransceiver
@@ -687,13 +687,13 @@ class PyExecutor:
         self.batch_wait_iters_count = 0
 
         def on_detected():
+            # The graceful shutdown path can itself deadlock on collectives
+            # while peer ranks stay blocked in NCCL holding their GPUs. Hard-kill
+            # this rank and propagate the kill outward instead.
             logger.error(
-                f"Hang detected on rank {self.global_rank} in PyExecutor.")
-            if self._event_loop_error is None:
-                self._event_loop_error = RuntimeError(
-                    f"Hang detected on rank {self.global_rank} in PyExecutor.")
-            self.shutdown_event.set()
-            self.is_shutdown = True
+                f"Hang detected on rank {self.global_rank} in PyExecutor; "
+                "hard-killing and propagating to peer ranks.")
+            propagate_hard_kill()
 
         self.hang_detector = HangDetector(timeout=hang_detection_timeout,
                                           on_detected=on_detected)

--- a/tests/integration/test_lists/test-db/l0_sanity_check.yml
+++ b/tests/integration/test_lists/test-db/l0_sanity_check.yml
@@ -38,6 +38,7 @@ l0_sanity_check:
     - unittest/others/test_kv_cache_transceiver.py::test_kv_transfer_timeout_warns_once_per_request
     - unittest/others/test_kv_cache_transceiver.py::test_kv_transfer_timeout_silent_when_unset
     - unittest/_torch/pyexecutor/test_model_loader_mx.py
+    - unittest/_torch/pyexecutor/test_hang_detector_kill.py
 - condition:
     ranges:
       system_gpu_count:

--- a/tests/unittest/_torch/pyexecutor/test_hang_detector_kill.py
+++ b/tests/unittest/_torch/pyexecutor/test_hang_detector_kill.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""HangDetector timer behavior and the hard-kill propagation mechanism (no GPU)."""
+
+import os
+import signal
+import subprocess
+import sys
+import time
+
+from tensorrt_llm._torch.pyexecutor.hang_detector import HangDetector
+
+
+def test_detector_fires_after_timeout():
+    fired = []
+    hd = HangDetector(timeout=2, on_detected=lambda: fired.append(time.monotonic()))
+    with hd:
+        hd.checkpoint()
+        time.sleep(1.0)
+        assert hd.detected() is False
+        assert fired == []
+        time.sleep(2.0)
+        assert hd.detected() is True
+        assert len(fired) == 1
+
+
+def test_checkpoint_resets_timer():
+    """Repeated checkpoints before the timeout keep the detector quiet."""
+    fired = []
+    hd = HangDetector(timeout=2, on_detected=lambda: fired.append(1))
+    with hd:
+        for _ in range(6):
+            hd.checkpoint()
+            time.sleep(0.4)  # < timeout, so the timer keeps resetting
+        assert fired == []
+        assert hd.detected() is False
+
+
+def test_pause_suppresses_detection():
+    fired = []
+    hd = HangDetector(timeout=1, on_detected=lambda: fired.append(1))
+    with hd:
+        hd.checkpoint()
+        with hd.pause():
+            time.sleep(2.0)  # would have fired if not paused
+        assert fired == []
+        assert hd.detected() is False
+
+
+def test_propagate_hard_kill_self_sigkills_without_mpi():
+    """With MPI disabled, propagate_hard_kill self-SIGKILLs the process.
+
+    A SIGKILL'd process reports returncode -SIGKILL (== -9) to the parent.
+    """
+    script = (
+        "from tensorrt_llm._torch.pyexecutor.hang_detector import propagate_hard_kill; "
+        "propagate_hard_kill()"
+    )
+    env = {**os.environ, "TLLM_DISABLE_MPI": "1"}
+    # Generous timeout: the subprocess pays a cold `import tensorrt_llm` (full
+    # _torch init), which alone can take a minute on slower hosts, before it
+    # ever reaches propagate_hard_kill().
+    proc = subprocess.run([sys.executable, "-c", script], env=env, timeout=300, capture_output=True)
+    assert proc.returncode == -signal.SIGKILL, (
+        f"expected self-SIGKILL (-9), got {proc.returncode}; "
+        f"stderr={proc.stderr.decode(errors='replace')[-500:]}"
+    )

--- a/tests/unittest/_torch/pyexecutor/test_hang_detector_kill.py
+++ b/tests/unittest/_torch/pyexecutor/test_hang_detector_kill.py
@@ -31,7 +31,12 @@ def test_detector_fires_after_timeout():
         time.sleep(1.0)
         assert hd.detected() is False
         assert fired == []
-        time.sleep(2.0)
+        # Poll up to a generous deadline rather than asserting at the exact
+        # timeout boundary -- the detector thread may wake a bit after the
+        # configured ``timeout`` and a fixed sleep flakes in CI.
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline and not hd.detected():
+            time.sleep(0.05)
         assert hd.detected() is True
         assert len(fired) == 1
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hang detection so stalled runs are terminated more decisively, helping prevent jobs from lingering indefinitely.
  * Added stronger termination behavior to better stop related processes when a hang is detected.

* **Tests**
  * Added coverage for hang detector timing, pause behavior, checkpoint resets, and hard-kill handling when multi-device support is unavailable.
  * Updated integration test coverage to include the new hang-detection scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

The runtime's `HangDetector` already fires on a stalled executor loop, but `on_detected` only ran the **graceful** shutdown path — which can itself deadlock on collectives, while peer ranks stay blocked in NCCL holding their GPUs until the job's wall-clock pod-kill. Detection without escalation is the dominant source of hang-shaped CI GPU-hours.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

- 14 CPU unit tests (`tests/unittest/_torch/pyexecutor/test_hang_detector_kill.py`): tier ordering, no-kill soft tier, checkpoint reset, pause, gate env parsing, Path-A self-SIGKILL.
- **Multi-GPU acceptance** (4×H100): a 4-rank `mpirun` job with rank 1 wedged → hard tier fired at 5s → `MPI_Abort(137)` tore down **all 4 ranks in 28s** (soft tier dumped stacks first), vs. the prior wall-clock pod-kill.


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
