### PR TITLE
[TRTLLM-13613][test] Trim duplicated and dead multimodal accuracy tests from pre-merge CI

### DIFF
--- a/tests/integration/defs/accuracy/test_llm_api_pytorch_multimodal.py
+++ b/tests/integration/defs/accuracy/test_llm_api_pytorch_multimodal.py
@@ -247,10 +247,9 @@ class TestNemotron_Nano_12B_V2_VL(LlmapiAccuracyTestHarness):
     @pytest.mark.parametrize(
         "enable_chunked_prefill,max_num_tokens",
         [
-            (False, MAX_NUM_TOKENS),
             (True, 1024),
         ],
-        ids=["full_budget", "forced_chunked_prefill"],
+        ids=["forced_chunked_prefill"],
     )
     def test_auto_dtype(self, enable_chunked_prefill, max_num_tokens):
         with LLM(
@@ -494,10 +493,9 @@ class TestQwen3VL(LlmapiAccuracyTestHarness):
     @pytest.mark.parametrize(
         "enable_chunked_prefill,max_num_tokens",
         [
-            (False, MAX_NUM_TOKENS),
             (True, 1024),
         ],
-        ids=["full_budget", "forced_chunked_prefill"],
+        ids=["forced_chunked_prefill"],
     )
     def test_auto_dtype(self, enable_chunked_prefill, max_num_tokens):
         with LLM(
@@ -543,8 +541,8 @@ class TestKimiK25(LlmapiAccuracyTestHarness):
     @pytest.mark.skip_less_device_memory(183000)
     @pytest.mark.parametrize(
         "ep_size,attention_dp",
-        [(1, False), (1, True), (8, False), (8, True)],
-        ids=["tp8", "tp8_attn_dp", "ep8", "dep8"],
+        [(8, True)],
+        ids=["dep8"],
     )
     def test_nvfp4(self, ep_size, attention_dp):
         """NVFP4 accuracy on MMMU benchmark (8x B200)."""
@@ -575,7 +573,6 @@ class TestKimiK25(LlmapiAccuracyTestHarness):
 class TestMistralSmall24B(LlmapiAccuracyTestHarness):
     MODEL_NAME = "mistralai/Mistral-Small-3.1-24B-Instruct-2503"
     MODEL_PATH = f"{llm_models_root()}/Mistral-Small-3.1-24B-Instruct-2503"
-    MAX_NUM_TOKENS = 16384
 
     # NOTE: MMMU adds <|endoftext|> to the stop token.
     sampling_params = SamplingParams(
@@ -588,10 +585,9 @@ class TestMistralSmall24B(LlmapiAccuracyTestHarness):
     @pytest.mark.parametrize(
         "max_num_tokens",
         [
-            MAX_NUM_TOKENS,
             1024,
         ],
-        ids=["full_budget", "forced_chunked_prefill"],
+        ids=["forced_chunked_prefill"],
     )
     def test_auto_dtype(self, max_num_tokens):
         kv_cache_config = KvCacheConfig(free_gpu_memory_fraction=0.75)
@@ -742,7 +738,7 @@ class TestNanoV3Omni(LlmapiAccuracyTestHarness):
                 ),
                 128,
                 QuantAlgo.MIXED_PRECISION,
-                (MMMU_TASK_SPEC, VOXPOPULI_TASK_SPEC, VIDEOMME_TASK_SPEC),
+                (MMMU_TASK_SPEC, VOXPOPULI_TASK_SPEC),
                 None,
                 marks=(skip_pre_blackwell,),
                 id="nvfp4",

--- a/tests/integration/test_lists/test-db/l0_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_b200.yml
@@ -57,7 +57,6 @@ l0_b200:
   - accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B::test_w4a16_mxfp4[latency-TRTLLM]
   - accuracy/test_llm_api_pytorch.py::TestQwen3_30B_A3B_Instruct_2507::test_skip_softmax_attention[target_sparsity_0.9-fp8kv=True]
   - accuracy/test_llm_api_pytorch.py::TestQwen3_5_35B_A3B::test_fp8[enable_block_reuse=True]
-  - accuracy/test_llm_api_pytorch_multimodal.py::TestNanoV3Omni::test_auto_dtype[nvfp4]
   - accuracy/test_llm_api_pytorch_multimodal.py::TestNanoV3Omni::test_auto_dtype[fp8_mmmu_encoder_cuda_graph]
   - accuracy/test_epd_disagg_multimodal.py::TestVideoMMEEPD::test_disaggregated_videomme[qwen3vl_2b_instruct]
   - accuracy/test_epd_disagg_multimodal.py::TestVideoMMEEPD::test_disaggregated_videomme[nemotron_nano_v3_omni_nvfp4]
@@ -353,6 +352,7 @@ l0_b200:
   - accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_w4_1gpu[v1_kv_cache-True-True-trtllm-auto]
   - accuracy/test_llm_api_pytorch.py::TestGPTOSS::test_w4_1gpu[v2_kv_cache-True-True-trtllm-auto]
   - accuracy/test_llm_api_pytorch_multimodal.py::TestNanoV3Omni::test_auto_dtype[bf16]
+  - accuracy/test_llm_api_pytorch_multimodal.py::TestNanoV3Omni::test_auto_dtype[nvfp4]
   # ------------- VisualGen single-GPU tests ---------------
   - examples/visual_gen/test_visual_gen.py::test_visual_gen_quickstart
   - examples/visual_gen/test_visual_gen.py::test_visual_gen_api_walkthrough

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -155,7 +155,6 @@ l0_dgx_b200:
   - accuracy/test_llm_api_pytorch.py::TestDeepSeekV32::test_dsa_host_cache_offload[host_cache_offload_mtp3_no_adp] TIMEOUT (60)
   - accuracy/test_disaggregated_serving.py::TestDeepSeekV32Exp::test_auto_dtype[False] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[tp8] TIMEOUT (60)
-  - accuracy/test_llm_api_pytorch_multimodal.py::TestKimiK25::test_nvfp4[dep8] TIMEOUT (120)
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_8gpus_mtp TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_8gpus_mtp_custom_op TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_8gpus[attention_dp_on-trtllm] TIMEOUT (60)
@@ -210,6 +209,7 @@ l0_dgx_b200:
   - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[tp8_attn_dp] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[ep8] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestKimiK25::test_nvfp4[dep8] TIMEOUT (60)
+  - accuracy/test_llm_api_pytorch_multimodal.py::TestKimiK25::test_nvfp4[dep8] TIMEOUT (120)
   - accuracy/test_llm_api_pytorch.py::TestMistralLarge3_675B::test_fp8[latency_moe_deepgemm] TIMEOUT (60)
   - accuracy/test_llm_api_pytorch.py::TestNemotronV3Super::test_nvfp4_parallelism[TP8_PP1] TIMEOUT (60)
   - test_e2e.py::test_deepseek_r1_mtp_bench TIMEOUT(60) # Cover https://nvbugs/5670108

--- a/tests/integration/test_lists/test-db/l0_l40s.yml
+++ b/tests/integration/test_lists/test-db/l0_l40s.yml
@@ -27,9 +27,6 @@ l0_l40s:
   - unittest/_torch/modeling/test_modeling_step3p7vl.py
   - test_e2e.py::test_ptp_scaffolding[DeepSeek-R1-Distill-Qwen-7B-DeepSeek-R1/DeepSeek-R1-Distill-Qwen-7B]
   - unittest/llmapi/apps/_test_openai_chat_multimodal.py::test_single_chat_session_image_embeds -m needs_l40s
-  # MMMU sanity check
-  - accuracy/test_llm_api_pytorch_multimodal.py::TestQwen2_5_VL_7B::test_auto_dtype
-  - accuracy/test_llm_api_pytorch_multimodal.py::TestVILA1_5_3B::test_auto_dtype
   # AutoDeploy: Nemotron-Nano-V3 on Ada uses flashinfer; trtllm has no
   # (E4M3 input, BF16 output, paged_kv, head_dim=128, sm_89) FMHA cubin.
   - accuracy/test_llm_api_autodeploy.py::TestNemotronNanoV3::test_accuracy[fp8-1-attn_dp_off-flashinfer]
@@ -85,8 +82,6 @@ l0_l40s:
   tests:
   - examples/test_gpt.py::test_llm_gpt2_next_prompt_tuning[use_cpp_session-tp1] # 10 mins
   - examples/test_gpt.py::test_llm_gpt2_next_prompt_tuning[use_py_session-tp1]
-  - examples/test_multimodal.py::test_llm_multimodal_general[video-neva-pp:1-tp:1-bfloat16-bs:1-cpp_e2e:False-nb:1]
-  - examples/test_multimodal.py::test_llm_multimodal_general[kosmos-2-pp:1-tp:1-float16-bs:1-cpp_e2e:True-nb:1]
   - examples/test_nemotron.py::test_llm_nemotron_3_8b_1gpu[bfloat16-fp8] # 18mins
   - examples/test_whisper.py::test_llm_whisper_general[large-v3-disable_gemm_plugin-disable_attention_plugin-disable_weight_only-float16-nb:1-use_python_runtime] # 8 mins
   - unittest/trt/attention/test_bert_attention.py # 12 mins


### PR DESCRIPTION
# Multimodal Accuracy Tests — Change Summary

Trim duplicated / dead / over-budget multimodal accuracy tests from **pre-merge** CI.
Runtimes = OpenSearch L0 CI, 45-day avg. **No input modality (image/video/audio)
coverage is lost** — every change keeps a cheaper or equivalent guard (logit-match
unittest, EPD test, post-merge, or QA).

Reflects committed state as of `b4420a5908`.

| ID | Test (Class::variant) | Change | Stage before → after | Runtime/PR | Why |
|----|------------------------|--------|----------------------|-----------:|-----|
| A1 | `TestNanoV3Omni::test_auto_dtype` VideoMME | drop VideoMME from **nvfp4** only; **keep on fp8** | fp8 unchanged (MMMU+VoxPopuli+VideoMME, pre-merge H100); nvfp4 task spec → MMMU+VoxPopuli | folded into A3 | Reviewer (@2ez4bz): keep VideoMME on one agg flavor — it's the only video coverage on the standard (non-EPD) path. fp8 chosen (more stable in CI than nvfp4); nvfp4 VideoMME still covered by EPD. |
| A2 | `test_llm_api_pytorch_multimodal.py::TestKimiK25::test_nvfp4[dep8]` | demote | pre-merge → post-merge, 8× B200 (`l0_dgx_b200.yml`) | ~1934 s | most expensive mm test (~32 min) every PR; low per-PR value. Coverage retained post-merge + QA (`llm_function_core.txt:819` — confirmed re @xinhe-nv: already QA-listed, no new QA entry needed). |
| A3 | `TestNanoV3Omni::test_auto_dtype[nvfp4]` | demote | pre-merge → post-merge, 1× B200 (`l0_b200.yml`) | ~379 s | per-PR nvfp4 image/audio regression value is low; `[fp8_mmmu_encoder_cuda_graph]` keeps a pre-merge B200 image guard, `[bf16]` is already post-merge, and fp8 stays pre-merge (H100). Coverage retained post-merge + QA. |
| B1 | `TestNemotron_Nano_12B_V2_VL::test_auto_dtype[full_budget]` | delete param | listed nowhere → removed | 0 s | dead variant; `forced_chunked_prefill` sibling covers the model |
| B2 | `TestQwen3VL::test_auto_dtype[full_budget]` | delete param | listed nowhere → removed | 0 s | dead variant; sibling covers the model |
| B3 | `TestMistralSmall24B::test_auto_dtype[full_budget]` | delete param (+ unused `MAX_NUM_TOKENS`) | listed nowhere → removed | 0 s | dead variant; sibling covers the model |
| B4 | `TestKimiK25::test_nvfp4[tp8] / [tp8_attn_dp] / [ep8]` | delete params (mm file) | listed nowhere → removed | 0 s | dead in mm file; text-path namesake in `test_llm_api_pytorch.py` runs these. QA only ever referenced mm `[dep8]` (`llm_function_core.txt:819`), so no dangling QA entries. |
| C1 | `TestQwen2_5_VL_7B::test_auto_dtype` | remove from pre-merge | pre-merge (L40S) → QA only | 689 s | "MMMU sanity" overlaps cheaper logit-match unittest (109 s) on same stage; QA retains MMMU |
| C2 | `TestVILA1_5_3B::test_auto_dtype` | remove from pre-merge | pre-merge (L40S) → QA only | 291 s | same; logit-match `modeling_vila` (38 s) stays pre-merge; QA retains MMMU |
| C3 | `examples/test_multimodal.py::...[video-neva]` + `[kosmos-2]` | remove from pre-merge | pre-merge (L40S) → removed | 0 s | legacy **TRT** workflow; 0 runs in 120 days; PyTorch serving e2e tests retained |

**Files touched**
- `tests/integration/defs/accuracy/test_llm_api_pytorch_multimodal.py` — A1, B1–B4
- `tests/integration/test_lists/test-db/l0_b200.yml` — A3
- `tests/integration/test_lists/test-db/l0_dgx_b200.yml` — A2
- `tests/integration/test_lists/test-db/l0_l40s.yml` — C1–C3

**Per-PR pre-merge time recovered:** ~980 s (L40S) + ~1934 s (8× DGX_B200, A2) + ~379 s
(1× DGX_B200, A3). VideoMME stays on fp8/H100, so there is no DGX_H100 recovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated multimodal and accuracy test coverage to focus on the currently supported evaluation scenarios.
  * Simplified several benchmark runs to use a single, standard configuration, reducing redundant test variants.
  * Adjusted test scheduling so multimodal checks run in the appropriate pipeline stage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
