### PR TITLE
[TRTLLM-13614][feat] Disaggregated KV-cache bounce transfer

### DIFF
--- a/tensorrt_llm/_torch/disaggregation/native/bounce/__init__.py
+++ b/tensorrt_llm/_torch/disaggregation/native/bounce/__init__.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Opt-in (TransferWorkerConfig.bounce) VRAM d2d KV bounce buffering: coalesce a
+transfer's scattered per-block KV into ONE contiguous fabric-VMM WRITE (reliable
+cuda_ipc/MNNVL) through the BounceTransport interface; default per-block path is
+unchanged when no Config is given. config_from_size() is the on/off switch."""
+
+from .buffer import Buffer, SlotAllocator
+from .config import Config, FixedSizing, Sizing, SizingContext, config_from_size
+from .core import BounceTransport, Disposition, ScatterState, TransferContext, TransferState
+from .gather_scatter import Plan
+from .impl import (
+    NoBounceTransport,
+    VmmBounceTransport,
+    build_send_request,
+    create_bounce,
+    decode_result_tail,
+    encode_result_tail,
+    scatter_write_result,
+)
+
+__all__ = [
+    "BounceTransport",
+    "Buffer",
+    "Config",
+    "Disposition",
+    "FixedSizing",
+    "NoBounceTransport",
+    "Plan",
+    "ScatterState",
+    "Sizing",
+    "SizingContext",
+    "SlotAllocator",
+    "TransferContext",
+    "TransferState",
+    "VmmBounceTransport",
+    "build_send_request",
+    "config_from_size",
+    "create_bounce",
+    "decode_result_tail",
+    "encode_result_tail",
+    "scatter_write_result",
+]

--- a/tensorrt_llm/_torch/disaggregation/native/bounce/buffer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/bounce/buffer.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fabric-VMM bounce buffers. A fabric region lets the write ride the fast intra-node fabric, which a
+plain device allocation cannot; it is allocated once at setup and reused."""
+
+import threading
+import time
+from typing import Dict, Optional, Tuple
+
+from tensorrt_llm import logger
+from tensorrt_llm._torch.disaggregation.base.agent import RegMemoryDescs
+from tensorrt_llm.runtime.kv_cache_manager_v2._cuda_virt_mem import PooledPhysMemAllocator, VirtMem
+
+_MIB = 1024 * 1024
+
+
+def _div_up(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+class Buffer:
+    """One contiguous fabric region for coalescing cache data. The physical chunk size must match the
+    cache pool's chunk size, which the C++ splitter relies on."""
+
+    __slots__ = ("_device_id", "_name", "_size", "_vm")
+
+    def __init__(self, capacity_bytes: int, phys_chunk_size: int, name: str = "kv_bounce"):
+        if capacity_bytes <= 0 or phys_chunk_size <= 0:
+            raise ValueError(
+                f"Buffer: capacity_bytes={capacity_bytes}, "
+                f"phys_chunk_size={phys_chunk_size} must both be > 0"
+            )
+        vm_size = _div_up(capacity_bytes, phys_chunk_size) * phys_chunk_size
+        allocator = PooledPhysMemAllocator(phys_chunk_size)
+        # back the whole region up front so its address is writable and stable for life
+        self._vm = VirtMem(vm_size, allocator, init_num_phys_mem=vm_size // phys_chunk_size)
+        self._size = vm_size
+        self._device_id = allocator.device_id
+        self._name = name
+        logger.info(
+            f"[kv-bounce] allocated fabric bounce buffer '{name}': "
+            f"{vm_size / _MIB:.1f} MiB @ 0x{int(self._vm.address):x} "
+            f"(chunk={phys_chunk_size // _MIB}MiB, dev={self._device_id})"
+        )
+
+    @property
+    def base_ptr(self) -> int:
+        return int(self._vm.address)
+
+    @property
+    def size(self) -> int:
+        return self._size
+
+    @property
+    def device_id(self) -> int:
+        return self._device_id
+
+    def reg_descs(self) -> "RegMemoryDescs":
+        # the type is the string "VRAM", not the enum, because the agent upper-cases it
+        return RegMemoryDescs("VRAM", [(self.base_ptr, self._size, self._device_id, self._name)])
+
+    def close(self) -> None:
+        vm = getattr(self, "_vm", None)
+        if vm is not None:
+            vm.destroy()
+            self._vm = None  # type: ignore[assignment]
+
+    def __del__(self):
+        # A destructor must never raise, but a leaked region should be visible, so log the failure.
+        try:
+            self.close()
+        except Exception as e:
+            logger.debug(f"[kv-bounce] buffer '{getattr(self, '_name', '?')}' cleanup failed: {e}")
+
+
+# region starts are rounded to this for copy alignment (negligible waste)
+_ALIGN = 512
+
+
+class SlotAllocator:
+    """First-fit allocator over one fabric buffer. Regions may be freed in any order, and first-fit
+    reuses a hole freed out of order rather than skipping it. Reserve is thread-safe and blocking.
+    The whole buffer is one registration, so a write can stripe across the network links."""
+
+    __slots__ = ("_buf", "_cap", "_cv", "_in_use", "_quarantine", "_next_slot_id")
+
+    def __init__(self, capacity_bytes: int, phys_chunk_size: int, name: str = "kv_bounce"):
+        if capacity_bytes <= 0:
+            raise ValueError(f"SlotAllocator: capacity_bytes={capacity_bytes} must be > 0")
+        self._buf = Buffer(capacity_bytes, phys_chunk_size, name=name)
+        self._cap = self._buf.size  # rounded up to a chunk multiple
+        self._in_use: Dict[int, Tuple[int, int]] = {}  # each live slot maps to its start and size
+        # Quarantined slots not yet reusable: an orphaned writer's write may still be landing
+        # and cannot be aborted, so each is held out of the pool until its deadline passes.
+        self._quarantine: Dict[int, Tuple[int, int, float]] = {}
+        self._next_slot_id = 0
+        self._cv = threading.Condition(threading.Lock())
+
+    @property
+    def capacity(self) -> int:
+        return self._cap
+
+    def _occupied(self):
+        """Ranges that must not be handed out: live and quarantined, treated the same."""
+        for s, n in self._in_use.values():
+            yield s, n
+        for s, n, _dl in self._quarantine.values():
+            yield s, n
+
+    def _find_free_start(self, size: int) -> Optional[int]:
+        """Lowest free gap large enough, or None if none fits. Live and quarantined regions both
+        block reuse, so an out-of-order-freed hole is reused but a quarantined one is not."""
+        cursor = 0
+        for s, n in sorted(self._occupied()):
+            if s - cursor >= size:
+                return cursor
+            cursor = max(cursor, s + n)
+        return cursor if self._cap - cursor >= size else None
+
+    def reserve(self, size: int, timeout: Optional[float] = None) -> Optional[Tuple[int, int]]:
+        """Reserve a contiguous region, or None if it can never fit or nothing frees within the
+        timeout."""
+        size = _div_up(size, _ALIGN) * _ALIGN
+        if size <= 0 or size > self._cap:
+            return None
+        deadline = None if timeout is None else time.monotonic() + timeout
+        with self._cv:
+            while True:
+                start = self._find_free_start(size)
+                if start is not None:
+                    slot_id = self._next_slot_id
+                    self._next_slot_id += 1
+                    self._in_use[slot_id] = (start, size)
+                    return slot_id, self._buf.base_ptr + start
+                if deadline is None:
+                    self._cv.wait()
+                else:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0 or not self._cv.wait(timeout=remaining):
+                        return None
+
+    def release(self, slot_id: int) -> None:
+        with self._cv:
+            self._in_use.pop(slot_id, None)
+            self._cv.notify_all()
+
+    def quarantine(self, slot_id: int, grace_s: float) -> None:
+        """Hold a slot out of the free pool for the grace period instead of releasing it, because its
+        region may still be under an in-doubt write. An infinite grace holds it until close."""
+        with self._cv:
+            entry = self._in_use.pop(slot_id, None)
+            if entry is not None:
+                start, size = entry
+                # a finite time plus infinity is infinity, so an infinite grace never expires
+                deadline = time.monotonic() + grace_s
+                self._quarantine[slot_id] = (start, size, deadline)
+            self._cv.notify_all()
+
+    def reclaim_expired(self) -> int:
+        """Return quarantined slots past their deadline to the free pool and report how many. Runs
+        off a timer, not tied to reserve, so it makes progress even when the arena is full."""
+        now = time.monotonic()
+        with self._cv:
+            expired = [sid for sid, (_s, _n, dl) in self._quarantine.items() if dl <= now]
+            for sid in expired:
+                del self._quarantine[sid]
+            if expired:
+                self._cv.notify_all()
+        return len(expired)
+
+    @property
+    def quarantined_bytes(self) -> int:
+        """Bytes currently held in quarantine, for observability."""
+        return sum(n for _s, n, _dl in self._quarantine.values())
+
+    def reg_descs(self) -> "RegMemoryDescs":
+        return self._buf.reg_descs()
+
+    def close(self) -> None:
+        self._buf.close()

--- a/tensorrt_llm/_torch/disaggregation/native/bounce/config.py
+++ b/tensorrt_llm/_torch/disaggregation/native/bounce/config.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Bounce configuration and pluggable sizing policy. A config enables bounce; leaving it unset keeps
+the per-block path. The size knob doubles as the on and off switch."""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+_MIB = 1024 * 1024
+
+
+def _round_up(a: int, b: int) -> int:
+    return (a + b - 1) // b * b
+
+
+@dataclass(frozen=True)
+class SizingContext:
+    free_bytes: int  # free at setup, after the cache pool claimed its fraction
+    total_bytes: int
+    chunk_bytes: int
+    device_id: int
+
+
+@dataclass(frozen=True)
+class Sizing:
+    """Returns the byte size of one region; there are two, one for sending and one for receiving."""
+
+    def resolve(self, ctx: SizingContext) -> int:
+        raise NotImplementedError
+
+
+# Default size in MiB per region. Raise it to bounce larger single transfers, lower it to save
+# memory. It is clamped to the free-memory budget at setup.
+DEFAULT_CAPACITY_MB = 384
+
+
+@dataclass(frozen=True)
+class FixedSizing(Sizing):
+    """A fixed capacity per region, clamped to free memory at setup."""
+
+    capacity_mb: int = DEFAULT_CAPACITY_MB
+
+    def resolve(self, ctx: SizingContext) -> int:
+        return max(_round_up(self.capacity_mb * _MIB, ctx.chunk_bytes), ctx.chunk_bytes)
+
+
+# bounce takes at most this fraction of the free memory left after the cache pool
+_HEADROOM_FRACTION = 0.5
+
+
+def fit_within_free(
+    capacity_bytes: int,
+    *,
+    free_bytes: int,
+    chunk_bytes: int,
+    max_free_fraction: float = _HEADROOM_FRACTION,
+) -> Optional[int]:
+    """Clamp each region so the two together stay within the allowed fraction of free memory, rounded
+    to a chunk. Returns None if not even one chunk fits."""
+    budget_per_dir = (int(free_bytes * max_free_fraction) // 2 // chunk_bytes) * chunk_bytes
+    if budget_per_dir < chunk_bytes:
+        return None
+    capacity_bytes = min(capacity_bytes, budget_per_dir)
+    capacity_bytes = max(capacity_bytes, chunk_bytes)
+    return capacity_bytes
+
+
+@dataclass
+class Config:
+    sizing: Sizing = field(default_factory=FixedSizing)  # how much memory to reserve (pluggable)
+    chunk_mb: int = 32  # physical chunk size; a large chunk keeps the write to a single descriptor
+    # skip bounce below this many blocks (roughly 12k tokens at 128 per block); heuristic, tunable
+    min_blocks: int = 96
+
+
+def config_from_size(size_mb: int) -> Optional[Config]:
+    """Build a bounce config from a per-region size in MiB, or None to leave bounce off when the size
+    is not positive. The size is both the capacity and the on and off switch."""
+    if size_mb is None or size_mb <= 0:
+        return None
+    return Config(sizing=FixedSizing(capacity_mb=size_mb))

--- a/tensorrt_llm/_torch/disaggregation/native/bounce/core.py
+++ b/tensorrt_llm/_torch/disaggregation/native/bounce/core.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pure core of the KV bounce subsystem: the transport contract and the per-region lifetime state
+machine. No CUDA or NIXL imports, so it is unit-testable on CPU."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Callable, Dict, List, Optional, Tuple
+
+
+class TransferState(Enum):
+    """Lifecycle of one bounced receive region."""
+
+    INIT = "init"  # leased, not yet advertised to any sender
+    ACTIVE = "active"  # writers in flight
+    SCATTERING = "scattering"  # all writers succeeded; scattering back into the cache
+    COMPLETED = "completed"  # scattered cleanly, slot released
+    FAILED = "failed"  # all writers done, at least one failed, slot released
+    QUARANTINED = "quarantined"  # a writer is in doubt, slot held out of reuse
+
+
+class ScatterState(Enum):
+    IDLE = "idle"
+    QUEUED = "queued"
+    DONE = "done"
+    FAILED = "failed"
+
+
+class Disposition(Enum):
+    """What to do with the slot when the transfer finishes."""
+
+    RELEASE = "release"  # drained: return it to the free pool
+    QUARANTINE = "quarantine"  # in doubt: hold it out of the pool for a grace period
+
+
+@dataclass
+class Settlement:
+    """What the transport carries out on finish: the slot, whether to release or quarantine it,
+    whether the transfer succeeded, and the callback to fire."""
+
+    slot_id: int
+    disposition: Disposition
+    success: bool
+    on_done: Optional[Callable[[bool], None]]
+
+
+@dataclass
+class TransferContext:
+    """Lifetime state machine for one bounced receive region. The region is released only after every
+    writer reports (success or failure both mean its write has drained); a writer given up on (a
+    cancelled or timed-out transfer, whose one-sided write cannot be aborted) makes it quarantined
+    instead of reused."""
+
+    rid_slice: Tuple[int, int]
+    slot_id: int
+    base_addr: int
+    per_writer_bytes: int
+    num_writers: int
+    on_done: Optional[Callable[[bool], None]] = None
+
+    # Whether each writer that reported succeeded, keyed by rank; presence means it reported.
+    _writer_ok: Dict[int, bool] = field(default_factory=dict)
+    # per successful writer: where it wrote, plus the fragments to scatter back
+    _scatter_descs: List[tuple] = field(default_factory=list)
+    _orphaned: bool = False
+    scatter_state: ScatterState = ScatterState.IDLE
+    state: TransferState = TransferState.INIT
+    settled: bool = False
+
+    def writer_base(self, writer_index: int) -> int:
+        """Where this fan-in writer writes in the region."""
+        return self.base_addr + writer_index * self.per_writer_bytes
+
+    def _writers_final(self) -> bool:
+        return self.settled or self.state in (
+            TransferState.SCATTERING,
+            TransferState.COMPLETED,
+            TransferState.FAILED,
+            TransferState.QUARANTINED,
+        )
+
+    def _all_writers_reported(self) -> bool:
+        return len(self._writer_ok) >= self.num_writers
+
+    def _all_writers_succeeded(self) -> bool:
+        return self._all_writers_reported() and all(self._writer_ok.values())
+
+    # Mutations: call only while holding the transport's reservation lock.
+    def record_writer_result(
+        self,
+        peer_rank: int,
+        succeeded: bool,
+        *,
+        src_base: Optional[int] = None,
+        dst_ptrs=None,
+        sizes=None,
+    ) -> None:
+        """Record one writer's terminal report. Repeat or late reports are ignored, so duplicate or
+        out-of-order messages are harmless."""
+        # A duplicate or late report can still arrive after the writer set is final, because
+        # scatter runs on another thread while the region stays live. For example a retransmitted
+        # notification, or a stray failure that would flip a good transfer to failed; drop it.
+        if self._writers_final() or peer_rank in self._writer_ok:
+            return
+        self._writer_ok[peer_rank] = succeeded
+        if succeeded and dst_ptrs is not None and int(dst_ptrs.size) > 0:
+            self._scatter_descs.append(
+                (src_base if src_base is not None else self.base_addr, dst_ptrs, sizes)
+            )
+        if self.state is TransferState.INIT:
+            self.state = TransferState.ACTIVE
+
+    def mark_orphaned(self) -> None:
+        """Give up on writers that never reported (cancel, timeout, shutdown): a one-sided write
+        cannot be aborted, so the region is quarantined on settle. No-op once scattering or done."""
+        if self._writers_final():
+            return
+        self._orphaned = True
+
+    def begin_scatter(self) -> None:
+        self.state = TransferState.SCATTERING
+        self.scatter_state = ScatterState.QUEUED
+
+    def sorted_scatter_descs(self) -> List[tuple]:
+        """Success fragments ordered by source, for a deterministic scatter."""
+        return sorted(self._scatter_descs, key=lambda t: t[0])
+
+    def finish_scatter(self, ok: bool) -> None:
+        self.scatter_state = ScatterState.DONE if ok else ScatterState.FAILED
+
+    def ready_to_scatter(self) -> bool:
+        """All writers succeeded, there is data to scatter, and scatter has not started."""
+        return (
+            self.state is TransferState.ACTIVE
+            and not self._orphaned
+            and self._all_writers_succeeded()
+            and bool(self._scatter_descs)
+        )
+
+    def ready_to_settle(self) -> bool:
+        if self.settled:
+            return False
+        if self._orphaned:
+            return True  # in doubt: settle now and quarantine
+        if not self._all_writers_reported():
+            return False  # a writer has not reported yet
+        if self._all_writers_succeeded() and self._scatter_descs:
+            return self.scatter_state in (ScatterState.DONE, ScatterState.FAILED)
+        return True  # nothing to scatter, or a failure among them: either way drained
+
+    def settle(self) -> Optional[Settlement]:
+        """Finalize the transfer once and return the decision, or None if already done. Every
+        termination path calls this; only the first call has any effect."""
+        if self.settled:
+            return None
+        self.settled = True
+        if self._orphaned:
+            self.state = TransferState.QUARANTINED
+            return Settlement(self.slot_id, Disposition.QUARANTINE, False, self.on_done)
+        success = self._all_writers_succeeded() and self.scatter_state is not ScatterState.FAILED
+        self.state = TransferState.COMPLETED if success else TransferState.FAILED
+        return Settlement(self.slot_id, Disposition.RELEASE, success, self.on_done)
+
+
+class BounceTransport(ABC):
+    """Contract both transports implement so they cannot drift; the factory returns one, and the rest
+    of the code depends only on this interface."""
+
+    #: True for a real transport, False for the disabled null object.
+    enabled: bool = False
+
+    @abstractmethod
+    def build_request(self, write_meta):
+        """Gather the request's cache into a send region and build the coalesced write, or None to
+        fall back to the per-fragment path."""
+
+    @abstractmethod
+    def release_send(self, slot_id) -> None:
+        """Release a send region after its write completes."""
+
+    @abstractmethod
+    def reserve(self, recv_req, num_writers: int = 1, *, timeout: Optional[float] = None) -> bool:
+        """Reserve a region and record its address for the senders. False falls back to per-fragment."""
+
+    @abstractmethod
+    def writer_base(self, rid_slice, writer_index: int) -> Optional[int]:
+        """Where the given fan-in writer writes in the region."""
+
+    @abstractmethod
+    def is_bounced(self, rid_slice) -> bool:
+        """Whether this request and slice name a live bounced region."""
+
+    @abstractmethod
+    def release_idle_reservation(self, rid_slice) -> None:
+        """Immediately free a reservation cancelled before any address went out."""
+
+    @abstractmethod
+    def record_result(
+        self, rid_slice, peer_rank, dst_ptrs=None, sizes=None, src_base=None, on_done=None
+    ) -> None:
+        """Handle a writer's success; scatter and finalize once all writers reported."""
+
+    @abstractmethod
+    def record_failure(self, rid_slice, peer_rank) -> None:
+        """Handle a writer's failure; free the region once all writers reported."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Stop the scatter worker, deregister memory, free the arenas."""

--- a/tensorrt_llm/_torch/disaggregation/native/bounce/gather_scatter.py
+++ b/tensorrt_llm/_torch/disaggregation/native/bounce/gather_scatter.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Device-to-device gather and scatter for KV bounce. It coalesces the scattered fragments into one
+contiguous buffer, and the inverse, in a single batched kernel launch, and falls back to a
+per-fragment copy loop when Triton or the GPU is unavailable."""
+
+import threading
+from dataclasses import dataclass
+
+import numpy as np
+
+try:
+    from cuda.bindings import runtime as cudart
+except ImportError:
+    from cuda import cudart
+
+from tensorrt_llm._utils import prefer_pinned
+from tensorrt_llm.runtime.generation import CUASSERT
+
+try:
+    import torch
+    import triton
+    import triton.language as tl
+
+    _HAVE_TRITON = True
+except ImportError:  # keep importable without GPU or Triton at import time
+    _HAVE_TRITON = False
+
+_D2D = cudart.cudaMemcpyKind.cudaMemcpyDeviceToDevice
+
+# copy in 128-bit elements, the widest per-thread transaction, as two 64-bit words
+_ELEM_BYTES = 16
+
+# elements per program; an architecture-agnostic default of about 64 KiB of copy
+_BLOCK = 4096
+# fixed rather than autotuned, to avoid recompiling per shape on the hot path
+_NUM_WARPS = 4
+_CHUNK_BYTES = _BLOCK * _ELEM_BYTES
+
+
+@dataclass
+class Plan:
+    """One transfer's coalescing plan: the source and destination fragment addresses, their sizes,
+    and the total. Both sides walk the fragments in the same order, and the offsets are the running
+    sum of the sizes."""
+
+    src_ptrs: np.ndarray  # source fragment addresses
+    dst_ptrs: np.ndarray  # destination fragment addresses
+    sizes: np.ndarray  # bytes per fragment
+    total_size: int  # total bytes; must not exceed the bounce buffer capacity
+
+    @property
+    def offsets(self) -> np.ndarray:
+        if self.sizes.size == 0:
+            return np.zeros(0, dtype=np.int64)
+        off = np.empty(self.sizes.size, dtype=np.int64)
+        off[0] = 0
+        np.cumsum(self.sizes[:-1], out=off[1:])
+        return off
+
+
+if _HAVE_TRITON:
+
+    @triton.jit
+    def _batched_copy_kernel(
+        dst_ptrs_ptr,  # destination address per fragment
+        src_ptrs_ptr,  # source address per fragment
+        nvec_ptr,  # 128-bit element count per fragment
+        n_frags,  # number of fragments
+        BLOCK: tl.constexpr,  # elements copied per program
+    ):
+        # each program copies one block-sized slice of one fragment
+        frag = tl.program_id(0)
+        chunk = tl.program_id(1)
+        if frag >= n_frags:
+            return
+
+        dst_addr = tl.load(dst_ptrs_ptr + frag)
+        src_addr = tl.load(src_ptrs_ptr + frag)
+        nvec = tl.load(nvec_ptr + frag)
+
+        vec = chunk * BLOCK + tl.arange(0, BLOCK)  # element index within the fragment
+        mask = vec < nvec  # masks off the fragment's tail
+
+        # each row is two 64-bit words the compiler coalesces into one 128-bit access
+        i64 = vec[:, None] * 2 + tl.arange(0, 2)[None, :]
+        m2 = mask[:, None]
+        src_i64 = src_addr.to(tl.uint64).to(tl.pointer_type(tl.int64))
+        dst_i64 = dst_addr.to(tl.uint64).to(tl.pointer_type(tl.int64))
+
+        vals = tl.load(src_i64 + i64, mask=m2)
+        tl.store(dst_i64 + i64, vals, mask=m2)
+
+
+def _uniform_nelem(sizes: np.ndarray):
+    """Return the element counts, the maximum, and whether every fragment is 16-byte aligned, which
+    the 128-bit copy requires."""
+    if sizes.size == 0:
+        return None, 0, False
+    if not np.all((sizes % _ELEM_BYTES) == 0):
+        return None, 0, False
+    nvec = (sizes // _ELEM_BYTES).astype(np.int64)
+    return nvec, int(nvec.max()), True
+
+
+# reusable pinned staging for the metadata copy, one per stream, so the copy is a true async transfer
+_meta_lock = threading.Lock()
+_meta_buffers = {}  # each stream maps to its pinned host buffer, device buffer, and capacity
+
+
+def _get_meta_buffers(stream_handle: int, need: int, dev):
+    """Return the pinned host and device buffers for the stream, large enough for the request,
+    growing them under a lock."""
+    with _meta_lock:
+        ent = _meta_buffers.get(stream_handle)
+        if ent is None or ent[2] < need:
+            new_cap = max(need, (ent[2] * 2 if ent else 0), 4096)
+            pinned = torch.empty(new_cap, dtype=torch.int64, pin_memory=prefer_pinned())
+            devt = torch.empty(new_cap, dtype=torch.int64, device=dev)
+            ent = (pinned, devt, new_cap)
+            _meta_buffers[stream_handle] = ent
+        return ent[0], ent[1]
+
+
+def _launch_batched_copy(
+    dst_addrs: np.ndarray, src_addrs: np.ndarray, sizes: np.ndarray, stream
+) -> bool:
+    """Run the single batched copy on the stream. Returns False when the caller must use the loop
+    fallback."""
+    if not _HAVE_TRITON or not torch.cuda.is_available():
+        return False
+
+    n = int(src_addrs.size)
+    if n == 0:
+        return True  # nothing to copy, trivially done
+
+    nvec, max_nvec, ok = _uniform_nelem(sizes)
+    if not ok or max_nvec == 0:
+        return False
+
+    dev = torch.device("cuda", torch.cuda.current_device())
+    # pack all three address arrays into one pinned buffer and one async copy, so the kernel is
+    # ordered after it
+    stream_handle = int(stream)
+    pinned, devt = _get_meta_buffers(stream_handle, 3 * n, dev)
+    host = pinned.numpy()
+    host[:n] = dst_addrs
+    host[n : 2 * n] = src_addrs
+    host[2 * n : 3 * n] = nvec
+
+    n_chunks = triton.cdiv(max_nvec, _BLOCK)
+    grid = (n, n_chunks)
+
+    # buffer reuse is safe: every caller syncs the stream between calls, so the previous copy and
+    # kernel finish before the refill
+    ext_stream = torch.cuda.ExternalStream(stream_handle)
+    with torch.cuda.stream(ext_stream):
+        devt[: 3 * n].copy_(pinned[: 3 * n], non_blocking=True)
+        _batched_copy_kernel[grid](
+            devt[:n],
+            devt[n : 2 * n],
+            devt[2 * n : 3 * n],
+            n,
+            BLOCK=_BLOCK,
+            num_warps=_NUM_WARPS,
+        )
+    return True
+
+
+def _copy_frags(pairs, sizes: np.ndarray, stream) -> None:
+    """Fallback used when the batched copy is unavailable: one async copy per fragment."""
+    # strict zip: a length mismatch must fail fast rather than silently drop part of the copy
+    for (dst, src), n in zip(pairs, sizes, strict=True):
+        CUASSERT(cudart.cudaMemcpyAsync(int(dst), int(src), int(n), _D2D, stream))
+
+
+def gather_contiguous(
+    dst_base: int,
+    src_ptrs: np.ndarray,
+    sizes: np.ndarray,
+    offsets: np.ndarray,
+    *,
+    stream,
+) -> None:
+    """Gather each source fragment into its place in the contiguous buffer, asynchronously. The
+    caller syncs before issuing the write."""
+    src_addrs = np.asarray(src_ptrs, dtype=np.int64)
+    dst_addrs = np.int64(dst_base) + np.asarray(offsets, dtype=np.int64)
+    sizes = np.asarray(sizes, dtype=np.int64)
+
+    if _launch_batched_copy(dst_addrs, src_addrs, sizes, stream):
+        return
+
+    _copy_frags(
+        ((int(dst_addrs[k]), int(src_addrs[k])) for k in range(src_addrs.size)),
+        sizes,
+        stream,
+    )
+
+
+def scatter_contiguous(
+    src_base: int,
+    dst_ptrs: np.ndarray,
+    sizes: np.ndarray,
+    offsets: np.ndarray,
+    *,
+    stream,
+) -> None:
+    """The inverse of gather: scatter each piece of the contiguous buffer back to its destination
+    fragment, asynchronously. The caller syncs before signaling completion."""
+    dst_addrs = np.asarray(dst_ptrs, dtype=np.int64)
+    src_addrs = np.int64(src_base) + np.asarray(offsets, dtype=np.int64)
+    sizes = np.asarray(sizes, dtype=np.int64)
+
+    if _launch_batched_copy(dst_addrs, src_addrs, sizes, stream):
+        return
+
+    _copy_frags(
+        ((int(dst_addrs[k]), int(src_addrs[k])) for k in range(dst_addrs.size)),
+        sizes,
+        stream,
+    )

--- a/tensorrt_llm/_torch/disaggregation/native/bounce/impl.py
+++ b/tensorrt_llm/_torch/disaggregation/native/bounce/impl.py
@@ -1,0 +1,509 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The two KV bounce transports (the real fabric-VMM one and the disabled null object) implementing
+the contract in core.py. Holds the buffers, the gather and scatter kernels, and the scatter worker,
+and runs the side effects that drive each region's state machine. Never imports transfer.py."""
+
+import queue
+import threading
+from typing import Callable, Dict, List, Optional
+
+import numpy as np
+
+try:
+    from cuda.bindings import runtime as cudart
+except ImportError:
+    from cuda import cudart
+
+from tensorrt_llm import logger
+from tensorrt_llm._torch.disaggregation.base.agent import (
+    MemoryDescs,
+    MemoryType,
+    TransferOp,
+    TransferRequest,
+)
+from tensorrt_llm.runtime.generation import CUASSERT
+
+from .buffer import SlotAllocator
+from .config import SizingContext, fit_within_free
+from .core import BounceTransport, Disposition, Settlement, TransferContext
+from .gather_scatter import Plan, gather_contiguous, scatter_contiguous
+
+RidSlice = tuple  # the request id and slice id a region serves
+_MIB = 1024 * 1024
+_SCATTER_POLL_S = 0.5  # how often the scatter worker wakes to re-check the stop flag and reclaim
+_RESERVE_TIMEOUT_S = 0.2  # max wait for a bounce region before falling back to per-fragment
+_CLOSE_JOIN_S = 2.0  # max wait for the scatter thread to drain on close
+_QUARANTINE_GRACE_S = 60.0  # how long an orphaned region is held out of reuse
+
+
+class VmmBounceTransport(BounceTransport):
+    """The real transport: gather the request's cache into one fabric region, issue a single coalesced
+    multi-rail write, and scatter it back on the receiver."""
+
+    enabled = True
+
+    @classmethod
+    def from_config(
+        cls, agent, cfg, *, device_id: int, block_bytes_per_group: List[int]
+    ) -> Optional["VmmBounceTransport"]:
+        """Build a transport sized from the config and clamped to free memory, or None if not even one
+        chunk fits."""
+        chunk = cfg.chunk_mb * _MIB
+        free_b, total_b = CUASSERT(cudart.cudaMemGetInfo())
+        want_capacity = cfg.sizing.resolve(
+            SizingContext(
+                free_bytes=free_b, total_bytes=total_b, chunk_bytes=chunk, device_id=device_id
+            )
+        )
+        capacity_bytes = fit_within_free(want_capacity, free_bytes=free_b, chunk_bytes=chunk)
+        if capacity_bytes is None:
+            logger.warning(f"[kv-bounce] disabled: only {free_b // _MIB}MiB free")
+            return None
+        if capacity_bytes != want_capacity:
+            logger.warning(
+                f"[kv-bounce] each region clamped to {capacity_bytes // _MIB}MiB "
+                f"(2x total) to fit {free_b // _MIB}MiB free"
+            )
+        return cls(
+            agent,
+            device_id=device_id,
+            capacity_bytes=capacity_bytes,
+            phys_chunk_size=chunk,
+            block_bytes_per_group=block_bytes_per_group,
+            min_blocks=cfg.min_blocks,
+        )
+
+    def __init__(
+        self,
+        agent,
+        *,
+        device_id: int,
+        capacity_bytes: int,
+        phys_chunk_size: int,
+        block_bytes_per_group: List[int],
+        min_blocks: int = 96,
+        quarantine_grace_s: float = _QUARANTINE_GRACE_S,
+        name: str = "kv_bounce",
+    ):
+        self._agent = agent
+        self._device_id = device_id
+        # The byte size of one cache block, listed for each attention layer group.
+        self._block_bytes_per_group = list(block_bytes_per_group)
+        # Below this many blocks, skip bounce: coalescing only pays off for long context (the default
+        # is roughly twelve thousand tokens; a heuristic, and tunable).
+        self._min_blocks = min_blocks
+        # how long an orphaned region is held out of reuse; must outlast the worst in-flight write
+        self._quarantine_grace_s = quarantine_grace_s
+
+        # one registered region each for sending and receiving
+        self._send_alloc = SlotAllocator(capacity_bytes, phys_chunk_size, name=f"{name}_send")
+        self._recv_alloc = SlotAllocator(capacity_bytes, phys_chunk_size, name=f"{name}_recv")
+        self._reg_descs = [self._send_alloc.reg_descs(), self._recv_alloc.reg_descs()]
+        for d in self._reg_descs:
+            self._agent.register_memory(d)
+
+        self._send_stream = self._new_stream()
+        self._send_stream_lock = threading.Lock()
+
+        self._init_recv_state()
+        self._start_scatter_worker(name)
+
+        logger.info(
+            f"[kv-bounce] Transport: send+recv regions of "
+            f"{self._send_alloc.capacity / _MIB:.1f}MiB each"
+        )
+
+    def _init_recv_state(self) -> None:
+        # Live per-transfer state, guarded by a leaf lock: mutate and decide under it, then release
+        # it before any CUDA sync, allocator call, or callback.
+        self._reserved_map: Dict[RidSlice, TransferContext] = {}
+        self._reserved_map_lock = threading.Lock()
+
+    def _start_scatter_worker(self, name: str) -> None:
+        # Scatter runs on its own thread: it ends in a blocking sync, so keeping it off the
+        # completion handler lets that handler keep draining other transfers.
+        self._scatter_q: "queue.Queue" = queue.Queue()
+        self._scatter_stream = self._new_stream()
+        self._stop = threading.Event()
+        self._scatter_thread = threading.Thread(
+            target=self._scatter_loop, name=f"{name}-scatter", daemon=True
+        )
+        self._scatter_thread.start()
+
+    def _new_stream(self):
+        return CUASSERT(cudart.cudaStreamCreate())[0]
+
+    def _launch_gather(self, src_addr: int, write_meta, total: int):
+        """Launch the gather of the scattered fragments into the send region and return an event to
+        wait on."""
+        plan = Plan(write_meta.src_ptrs, write_meta.dst_ptrs, write_meta.sizes, total)
+        with self._send_stream_lock:
+            gather_contiguous(
+                src_addr, plan.src_ptrs, plan.sizes, plan.offsets, stream=self._send_stream
+            )
+            event = CUASSERT(cudart.cudaEventCreate())[0]
+            CUASSERT(cudart.cudaEventRecord(event, self._send_stream))
+        return event
+
+    def _wait_gather(self, event) -> None:
+        if event is not None:
+            CUASSERT(cudart.cudaEventSynchronize(event))
+            CUASSERT(cudart.cudaEventDestroy(event))
+
+    def _make_write(self, src_addr: int, write_meta, total: int):
+        # one coalesced descriptor spanning the whole region
+        sizes = np.array([total], dtype=np.int64)
+        src = MemoryDescs.from_arrays_uniform_device(
+            MemoryType.VRAM, np.array([src_addr], dtype=np.int64), sizes, self._device_id
+        )
+        dst = MemoryDescs.from_arrays_uniform_device(
+            MemoryType.VRAM,
+            np.array([write_meta.bounce_dst_base], dtype=np.int64),
+            sizes,
+            write_meta.dst_device_id,
+        )
+        return TransferRequest(TransferOp.WRITE, src, dst, write_meta.peer_name, None)
+
+    def _reserve_and_gather(self, write_meta, *, timeout):
+        """Reserve a send slot and gather into it, or None on send-region backpressure. Eligibility
+        was already decided by the receiver, so the sender only falls back under backpressure."""
+        total = int(write_meta.sizes.sum())
+        res = self._send_alloc.reserve(total, timeout=timeout)
+        if res is None:
+            logger.debug(
+                f"[kv-bounce] in-place: no send region space for {total // _MIB}MiB within {timeout}s "
+                f"(sender backpressure); falling back"
+            )
+            return None
+        slot_id, src_addr = res
+        return slot_id, src_addr, total, self._launch_gather(src_addr, write_meta, total)
+
+    def build_request(self, write_meta):
+        """Gather into a send slot and build the coalesced write, or None on backpressure. Frees the
+        slot if the gather raises."""
+        gathered = self._reserve_and_gather(write_meta, timeout=_RESERVE_TIMEOUT_S)
+        if gathered is None:  # backpressure: fall back
+            return None
+        slot_id, src_addr, total, event = gathered
+        try:
+            self._wait_gather(event)
+        except Exception:
+            self._send_alloc.release(slot_id)
+            raise
+        return self._make_write(src_addr, write_meta, total), slot_id
+
+    def release_send(self, slot_id) -> None:
+        """Release a send region after its write has completed."""
+        self._send_alloc.release(slot_id)
+
+    @staticmethod
+    def _skip_bounce(reason: str, *, warn_key: Optional[str] = None) -> bool:
+        """Log why a transfer falls back to the per-fragment path and return False, so the guards
+        above stay one line each."""
+        msg = f"[kv-bounce] in-place: {reason}"
+        logger.warning_once(msg, key=warn_key) if warn_key else logger.debug(msg)
+        return False
+
+    def reserve(
+        self, recv_req, num_writers: int = 1, *, timeout: Optional[float] = _RESERVE_TIMEOUT_S
+    ) -> bool:
+        """Reserve a region and create its state, recording the address for the senders. Returns
+        False to fall back to the per-fragment path. A fan-in splits the region evenly, so the total
+        must divide across the writers."""
+        nblocks = sum(int(a.size) for a in recv_req.block_ids_per_layer_groups)
+        if nblocks < self._min_blocks:
+            return self._skip_bounce(f"{nblocks} blocks < min {self._min_blocks} (too small)")
+        total = 0
+        for g, block_ids in enumerate(recv_req.block_ids_per_layer_groups):
+            if g >= len(self._block_bytes_per_group):
+                return self._skip_bounce(f"layer group {g} has no known slot size (e.g. mamba)")
+            total += int(block_ids.size) * self._block_bytes_per_group[g]
+        if total <= 0:
+            return self._skip_bounce(f"computed transfer size {total} <= 0")
+        if num_writers > 1 and total % num_writers != 0:
+            return self._skip_bounce(
+                f"fan-in {total}B across {num_writers} senders is not an even split "
+                f"({total % num_writers}B remainder); head-mismatch explosion NOT mitigated",
+                warn_key="kv-bounce-uneven-fanin",
+            )
+        if total > self._recv_alloc.capacity:  # too big to ever fit, unlike transient backpressure
+            return self._skip_bounce(
+                f"transfer {total // _MIB}MiB exceeds the {self._recv_alloc.capacity // _MIB}MiB bounce "
+                f"region; raise the bounce arena size to re-enable coalescing",
+                warn_key="kv-bounce-oversize",
+            )
+        res = self._recv_alloc.reserve(total, timeout=timeout)
+        if res is None:
+            return self._skip_bounce(
+                f"no recv region space for {total // _MIB}MiB within {timeout}s (backpressure)"
+            )
+        slot_id, addr = res
+        recv_req.bounce_dst_base = addr
+        with self._reserved_map_lock:
+            ctx = TransferContext(
+                rid_slice=(recv_req.unique_rid, recv_req.slice_id),
+                slot_id=slot_id,
+                base_addr=addr,
+                per_writer_bytes=total // num_writers,
+                num_writers=num_writers,
+            )
+            self._reserved_map[ctx.rid_slice] = ctx  # inactive until the first writer reports
+        return True
+
+    def writer_base(self, rid_slice: RidSlice, writer_index: int) -> Optional[int]:
+        """Where the given fan-in writer writes in the region."""
+        with self._reserved_map_lock:
+            ctx = self._reserved_map.get(rid_slice)
+            return None if ctx is None else ctx.writer_base(writer_index)
+
+    def is_bounced(self, rid_slice: RidSlice) -> bool:
+        with self._reserved_map_lock:
+            return rid_slice in self._reserved_map
+
+    def release_idle_reservation(self, rid_slice: RidSlice) -> None:
+        """Immediately release a reservation cancelled before any address went out; no write can be
+        in flight. Idempotent. Drained transfers finalize through the result path instead."""
+        with self._reserved_map_lock:
+            ctx = self._reserved_map.pop(rid_slice, None)
+        if ctx is not None:
+            self._recv_alloc.release(ctx.slot_id)
+
+    def _apply(self, rid_slice: RidSlice, mutate: Callable[[TransferContext], None]) -> None:
+        """Mutate the state under the lock, then do what it asks (scatter or settle) with the lock
+        released, never holding it across a CUDA sync, a queue put, or a callback. No-op if the
+        region is already gone."""
+        scatter: Optional[tuple] = None
+        settlement: Optional[Settlement] = None
+        with self._reserved_map_lock:
+            ctx = self._reserved_map.get(rid_slice)
+            if ctx is None:
+                return
+            mutate(ctx)
+            if ctx.ready_to_scatter():
+                ctx.begin_scatter()
+                scatter = (ctx, ctx.sorted_scatter_descs())
+            elif ctx.ready_to_settle():
+                settlement = ctx.settle()
+                if settlement is not None:
+                    self._reserved_map.pop(rid_slice, None)
+        if scatter is not None:
+            self._enqueue_scatter(*scatter)
+        if settlement is not None:
+            self._commit(settlement)
+
+    def _enqueue_scatter(self, ctx: TransferContext, descs: List[tuple]) -> None:
+        """Hand the per-writer fragments to the worker. Each is scattered from its own source, so a
+        writer that fell back to the in-place path cannot shift where the others are read from."""
+        self._scatter_q.put((ctx, descs))
+
+    def _commit(self, settlement: Settlement) -> None:
+        """Carry out the decision: release or quarantine the slot, then fire the callback once. No
+        lock is held."""
+        if settlement.disposition is Disposition.QUARANTINE:
+            self._recv_alloc.quarantine(settlement.slot_id, self._quarantine_grace_s)
+        else:
+            self._recv_alloc.release(settlement.slot_id)
+        if settlement.on_done is not None:
+            try:
+                settlement.on_done(settlement.success)
+            except Exception as e:  # never let the callback strand the arena
+                logger.error(
+                    f"[kv-bounce] completion callback failed (slot={settlement.slot_id}): {e}"
+                )
+
+    def record_result(
+        self,
+        rid_slice: RidSlice,
+        peer_rank: int,
+        dst_ptrs=None,
+        sizes=None,
+        src_base=None,
+        on_done: Optional[Callable[[bool], None]] = None,
+    ) -> None:
+        """A writer reported success. The completion callback fires only after the scatter lands, so
+        the reader never sees completion before the cache is in place."""
+
+        def mut(ctx: TransferContext) -> None:
+            if on_done is not None:
+                ctx.on_done = on_done
+            ctx.record_writer_result(
+                peer_rank, succeeded=True, src_base=src_base, dst_ptrs=dst_ptrs, sizes=sizes
+            )
+
+        self._apply(rid_slice, mut)
+
+    def record_failure(self, rid_slice: RidSlice, peer_rank: int) -> None:
+        """A writer reported failure (it has drained). The region is freed only once every writer has
+        reported, not here."""
+        self._apply(rid_slice, lambda ctx: ctx.record_writer_result(peer_rank, succeeded=False))
+
+    def _scatter_loop(self):
+        CUASSERT(cudart.cudaSetDevice(self._device_id))
+        while not self._stop.is_set():
+            try:
+                item = self._scatter_q.get(timeout=_SCATTER_POLL_S)
+            except queue.Empty:
+                # idle: reclaim quarantine past its grace period, independent of any reserve call
+                self._recv_alloc.reclaim_expired()
+                continue
+            if item is None:
+                break  # poison pill from close: wake and exit
+            ctx, descs = item
+            ok = True
+            try:
+                # Scatter each writer's fragments from its own source, never one global offset, so a
+                # missing or fallback writer cannot shift where the others are read from.
+                for src_base, dst_ptrs, sizes in descs:
+                    p = Plan(dst_ptrs, dst_ptrs, sizes, int(sizes.sum()))
+                    scatter_contiguous(
+                        src_base, p.dst_ptrs, p.sizes, p.offsets, stream=self._scatter_stream
+                    )
+                CUASSERT(cudart.cudaStreamSynchronize(self._scatter_stream))
+            except Exception as e:
+                # a scatter failure must not kill the worker nor be reported as success
+                ok = False
+                logger.error(f"[kv-bounce] scatter failed (slot={ctx.slot_id}): {e}")
+            # record the outcome and settle; completion fires only after the sync above
+            self._apply(ctx.rid_slice, lambda c, ok=ok: c.finish_scatter(ok))
+
+    def close(self) -> None:
+        self._stop.set()
+        # poison pill: wake the worker now instead of waiting out its poll
+        self._scatter_q.put(None)
+        if self._scatter_thread.is_alive():
+            self._scatter_thread.join(timeout=_CLOSE_JOIN_S)
+        for d in self._reg_descs:
+            try:
+                self._agent.deregister_memory(d)
+            except Exception:
+                pass
+        self._send_alloc.close()
+        self._recv_alloc.close()
+
+
+class NoBounceTransport(BounceTransport):
+    """The disabled transport, used when bounce is off so callers need no None checks. Every method
+    is a no-op or a negative answer."""
+
+    enabled = False
+    _reg_descs = ()
+
+    def build_request(self, write_meta):
+        return None
+
+    def release_send(self, slot_id) -> None:
+        pass
+
+    def reserve(
+        self, recv_req, num_writers: int = 1, *, timeout: Optional[float] = _RESERVE_TIMEOUT_S
+    ) -> bool:
+        return False
+
+    def writer_base(self, rid_slice, writer_index: int):
+        return None
+
+    def is_bounced(self, rid_slice) -> bool:
+        return False
+
+    def release_idle_reservation(self, rid_slice) -> None:
+        pass
+
+    def record_result(
+        self, rid_slice, peer_rank, dst_ptrs=None, sizes=None, src_base=None, on_done=None
+    ):
+        pass
+
+    def record_failure(self, rid_slice, peer_rank) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+def create_bounce(agent, cfg, *, device_id: int, page_table) -> BounceTransport:
+    """Build the real transport from the config, or the disabled one when bounce is off, it cannot
+    fit, or the fabric allocation races."""
+    if cfg is None:
+        return NoBounceTransport()
+    try:
+        transport = VmmBounceTransport.from_config(
+            agent, cfg, device_id=device_id, block_bytes_per_group=block_bytes_per_group(page_table)
+        )
+        return transport if transport is not None else NoBounceTransport()
+    except (
+        Exception
+    ) as e:  # rare race: memory taken between the free-memory query and the allocation
+        logger.warning(f"[kv-bounce] disabled (alloc failed: {e}); using in-place path")
+        return NoBounceTransport()
+
+
+def build_send_request(bounce, write_meta, fallback):
+    """Build a coalesced bounce write when eligible (release the returned slot afterward), otherwise
+    fall back to the per-fragment request."""
+    if write_meta.bounce_dst_base is not None:
+        built = bounce.build_request(write_meta)
+        if built is not None:
+            return built
+    return fallback(), None
+
+
+def scatter_write_result(
+    bounce, rid_slice, peer_rank: int, dst_ptrs, sizes, src_base=None, on_done=None
+) -> None:
+    """Handle a success result: a bounced transfer records the writer and scatters once all arrive; a
+    non-bounced transfer already landed in place, so fire the callback inline."""
+    if bounce.is_bounced(rid_slice):
+        bounce.record_result(rid_slice, peer_rank, dst_ptrs, sizes, src_base, on_done)
+    elif on_done is not None:
+        on_done(True)
+
+
+def encode_result_tail(write_meta) -> list:
+    """The binary tail appended to a bounced result: the destination fragment table and the source
+    this writer wrote to, so the receiver can scatter and order the fan-in writers."""
+    sb = write_meta.bounce_dst_base if write_meta.bounce_dst_base is not None else 0
+    return [
+        write_meta.dst_ptrs.tobytes(),
+        write_meta.sizes.tobytes(),
+        np.array([sb], dtype=np.int64).tobytes(),
+    ]
+
+
+def decode_result_tail(message):
+    """Recover the destination fragments, sizes, and source from the optional trailing frames, or
+    nothing if the tail is absent."""
+    if len(message) >= 5:
+        return (
+            np.frombuffer(message[2], dtype=np.int64),
+            np.frombuffer(message[3], dtype=np.int64),
+            int(np.frombuffer(message[4], dtype=np.int64)[0]),
+        )
+    return None, None, None
+
+
+def block_bytes_per_group(page_table) -> list:
+    """Byte size of one cache block for each leading attention layer group, stopping at the first
+    non-attention group."""
+    from tensorrt_llm._torch.disaggregation.resource.page import AttentionLayerGroup
+    from tensorrt_llm._torch.disaggregation.resource.utils import get_physical_pool
+
+    assert page_table is not None
+    out: list = []
+    for lg_idx, lg in enumerate(page_table.layer_groups):
+        if not isinstance(lg, AttentionLayerGroup):
+            break
+        out.append(int(get_physical_pool(page_table, lg_idx, 0).slot_bytes))
+    return out

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import os
 import queue
+import struct
 import threading
 import time
 import weakref
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
 import msgpack
 import numpy as np
@@ -54,6 +55,9 @@ from tensorrt_llm._utils import nvtx_range
 from tensorrt_llm.disaggregated_params import DisaggregatedParams, DisaggScheduleStyle
 from tensorrt_llm.runtime.generation import CUASSERT
 
+if TYPE_CHECKING:
+    from .bounce import Config
+
 AttentionTypeCpp = tensorrt_llm.bindings.internal.batch_manager.AttentionType
 LlmRequestType = tensorrt_llm.bindings.internal.batch_manager.LlmRequestType
 
@@ -76,6 +80,7 @@ class RecvReqInfo:
     aux_slot: Optional[int] = None
     mamba_state_index: Optional[int] = None
     slice_id: Optional[int] = None
+    bounce_dst_base: Optional[int] = None
 
     def to_bytes(self) -> bytes:
         return msgpack.packb(
@@ -91,6 +96,7 @@ class RecvReqInfo:
                 "aux_slot": self.aux_slot,
                 "mamba_state_index": self.mamba_state_index,
                 "slice_id": self.slice_id,
+                "bounce_dst_base": self.bounce_dst_base,
             }
         )
 
@@ -130,6 +136,7 @@ class WriteMeta:
     slice_id: Optional[int] = None
     is_last_slice: bool = False
     meta_type: WriteMetaType = WriteMetaType.KV
+    bounce_dst_base: Optional[int] = None
 
 
 class MessageType:
@@ -152,6 +159,35 @@ class TaskStatus(Enum):
 class AgentResult(Enum):
     SUCCESS = "SUCCESS"
     FAILED = "FAILED"
+
+
+# KV_AGENT_RESULT prefix in one struct frame (was 5 ascii frames serialized/parsed under the
+# GIL per slice per writer): instance_rank, unique_rid, slice_id, is_last, status. The optional
+# bounce tail follows at message[2:].
+_KV_RESULT_PREFIX = struct.Struct("<qqq?B")
+_AGENT_RESULT_CODE = {AgentResult.SUCCESS: 0, AgentResult.FAILED: 1}
+_AGENT_RESULT_BY_CODE = {0: AgentResult.SUCCESS, 1: AgentResult.FAILED}
+
+
+def _make_kv_result_msg(
+    instance_rank, unique_rid, slice_id, is_last_slice, agent_result, tail=None
+):
+    """Build a KV_AGENT_RESULT message. ALL result sends (success AND failed/cancelled) must go
+    through this single binary frame so the receiver's _KV_RESULT_PREFIX.unpack never hits a stale
+    ascii payload (which would fail to decode and leave the RX task stuck forever)."""
+    msg = [
+        MessageType.KV_AGENT_RESULT,
+        _KV_RESULT_PREFIX.pack(
+            int(instance_rank),
+            int(unique_rid),
+            int(slice_id),
+            bool(is_last_slice),
+            _AGENT_RESULT_CODE[agent_result],
+        ),
+    ]
+    if tail:
+        msg += tail
+    return msg
 
 
 class SendTaskBase:
@@ -229,10 +265,12 @@ class Sender(SenderBase):
         self,
         peer_registrar: PeerRegistrar,
         agent: BaseTransferAgent,
+        bounce=None,
     ):
         self._registrar = peer_registrar
         self._device_id = peer_registrar.self_rank_info.device_id
         self._agent = agent
+        self._bounce = bounce
         self._peer_requests: dict = {}
         self._peer_requests_timestamps: dict[int, float] = {}  # unique_rid -> insert time
         self._peer_requests_lock = threading.Lock()
@@ -498,55 +536,69 @@ class Sender(SenderBase):
                 RuntimeError(f"session {write_meta.unique_rid} {status.value}, transfer aborted")
             )
             self._get_or_connect_dealer(write_meta.peer_endpoint).send(
-                [
-                    MessageType.KV_AGENT_RESULT,
-                    str(self._instance_rank).encode("ascii"),
-                    str(write_meta.unique_rid).encode("ascii"),
-                    str(write_meta.slice_id).encode("ascii"),
-                    b"True",  # is_last_slice — ensures receiver resolves its task future
-                    AgentResult.FAILED.value.encode("ascii"),
-                ]
+                _make_kv_result_msg(
+                    self._instance_rank,
+                    write_meta.unique_rid,
+                    write_meta.slice_id,
+                    True,  # is_last_slice — ensures receiver resolves its task future
+                    AgentResult.FAILED,
+                )
             )
             return
 
+        from .bounce import build_send_request, encode_result_tail
+
         agent_result = AgentResult.SUCCESS
+        send_slot_id = None
         if write_meta.src_ptrs.size > 0:
-            request = Sender._make_agent_request(write_meta, device_id=self._device_id)
+            request, send_slot_id = build_send_request(
+                self._bounce,
+                write_meta,
+                lambda: Sender._make_agent_request(write_meta, device_id=self._device_id),
+            )
             if timer:
                 timer.record_transfer_start(write_meta.peer_rank)
-            status = self._agent.submit_transfer_requests(request)
-            if not status.wait():
-                agent_result = AgentResult.FAILED
-                last_status = getattr(status, "last_status_str", lambda: "<no detail>")()
-                agent_name = getattr(self._agent, "name", "<?>")
-                detail = (
-                    f"KV transfer agent failed: "
-                    f"unique_rid={write_meta.unique_rid} "
-                    f"slice={write_meta.slice_id} "
-                    f"peer_rank={write_meta.peer_rank} "
-                    f"peer_endpoint={write_meta.peer_endpoint} "
-                    f"op={getattr(request, 'op', '?')} "
-                    f"remote={getattr(request, 'remote_name', '?')} "
-                    f"src_size={int(write_meta.src_ptrs.size)} "
-                    f"dst_size={int(write_meta.dst_ptrs.size)} "
-                    f"nixl_status={last_status} agent={agent_name}"
-                )
-                logger.error(detail)
-                task.fail(RuntimeError(detail))
+            try:
+                status = self._agent.submit_transfer_requests(request)
+                if not status.wait():
+                    agent_result = AgentResult.FAILED
+                    last_status = getattr(status, "last_status_str", lambda: "<no detail>")()
+                    agent_name = getattr(self._agent, "name", "<?>")
+                    detail = (
+                        f"KV transfer agent failed: "
+                        f"unique_rid={write_meta.unique_rid} "
+                        f"slice={write_meta.slice_id} "
+                        f"peer_rank={write_meta.peer_rank} "
+                        f"peer_endpoint={write_meta.peer_endpoint} "
+                        f"op={getattr(request, 'op', '?')} "
+                        f"remote={getattr(request, 'remote_name', '?')} "
+                        f"src_size={int(write_meta.src_ptrs.size)} "
+                        f"dst_size={int(write_meta.dst_ptrs.size)} "
+                        f"nixl_status={last_status} agent={agent_name}"
+                    )
+                    logger.error(detail)
+                    task.fail(RuntimeError(detail))
+            finally:
+                if send_slot_id is not None:
+                    self._bounce.release_send(send_slot_id)
         if timer:
             timer.record_transfer_end(write_meta.peer_rank)
 
         ## TODO: just last slice need to send task state?
-        self._get_or_connect_thread_dealer(write_meta.peer_endpoint).send(
-            [
-                MessageType.KV_AGENT_RESULT,
-                str(self._instance_rank).encode("ascii"),
-                str(write_meta.unique_rid).encode("ascii"),
-                str(write_meta.slice_id).encode("ascii"),
-                str(write_meta.is_last_slice).encode("ascii"),
-                agent_result.value.encode("ascii"),
-            ]
+        tail = (
+            encode_result_tail(write_meta)
+            if send_slot_id is not None and agent_result == AgentResult.SUCCESS
+            else None
         )
+        result_msg = _make_kv_result_msg(
+            self._instance_rank,
+            write_meta.unique_rid,
+            write_meta.slice_id,
+            write_meta.is_last_slice,
+            agent_result,
+            tail=tail,
+        )
+        self._get_or_connect_thread_dealer(write_meta.peer_endpoint).send(result_msg)
 
         if timer:
             timer.record_task_end(write_meta.peer_rank)
@@ -825,6 +877,7 @@ class Sender(SenderBase):
             unique_rid=task._unique_rid,
             slice_id=task.slice_id,
             is_last_slice=task._slice.is_last_slice,
+            bounce_dst_base=req_info.bounce_dst_base,
         )
 
     def _build_aux_write_meta(self, task: AuxSendTask, req_info: RecvReqInfo) -> WriteMeta:
@@ -983,14 +1036,13 @@ class Sender(SenderBase):
             peer_ri = self._registrar.get_peer_rank_info(info.instance_name, info.instance_rank)
             slice_id = info.slice_id if info.slice_id is not None else 0
             self._get_or_connect_dealer(peer_ri.self_endpoint).send(
-                [
-                    MessageType.KV_AGENT_RESULT,
-                    str(self._instance_rank).encode("ascii"),
-                    str(info.unique_rid).encode("ascii"),
-                    str(slice_id).encode("ascii"),
-                    b"True",  # is_last_slice
-                    AgentResult.FAILED.value.encode("ascii"),
-                ]
+                _make_kv_result_msg(
+                    self._instance_rank,
+                    info.unique_rid,
+                    slice_id,
+                    True,  # is_last_slice
+                    AgentResult.FAILED,
+                )
             )
         except Exception as e:
             logger.warning(
@@ -1368,9 +1420,11 @@ class Receiver(ReceiverBase):
         self,
         peer_registrar: PeerRegistrar,
         agent: BaseTransferAgent,
+        bounce=None,
     ):
         self._registrar = peer_registrar
         self._agent = agent
+        self._bounce = bounce
         self._dealers = {}
         self._sender_ep_instance_map = {}
 
@@ -1443,6 +1497,28 @@ class Receiver(ReceiverBase):
             slice_id=task.slice_id,
         )
 
+    @staticmethod
+    def _fanin_bounce_safe(overlap, peer_ri) -> bool:
+        """Whether multi-writer bounce's equal total//num_writers split is valid for this overlap.
+        The split assumes every writer contributes the same size, which holds when:
+          * duplicate_head_factor == 1 -- else some ranks don't send KV (should_send_kv) yet still
+            count in expected_transfers, so the live writers overflow their slots;
+          * the PP layer split is even -- a single PP stage (overlap_pp_size <= 1) is trivially fine;
+            for PP fan-in, every overlapping stage must hold the same number of layers
+            (peer_ri.layer_num_per_pp all-equal) or per-writer sizes differ. If that full per-stage
+            list isn't available (shorter than the fan-in degree), be conservative and fall back.
+        Otherwise fall back to the per-fragment path (correct, just not coalesced).
+        NOTE: equal layer COUNT == equal BYTES only when per-layer KV is uniform; for mixed layer
+        groups (e.g. differing slot_bytes) reserve()'s `total % num_writers` divisibility guard is the
+        backstop, and a fully size-aware split (per-writer offsets) would be the general fix."""
+        if overlap.duplicate_head_factor != 1:
+            return False
+        if overlap.overlap_pp_size > 1:
+            lpp = getattr(peer_ri, "layer_num_per_pp", None)
+            if not lpp or len(lpp) < overlap.overlap_pp_size or len(set(lpp)) != 1:
+                return False
+        return True
+
     def dispatch_task(self, task: KVRecvTask):
         params = task._params
         logger.debug(
@@ -1480,6 +1556,14 @@ class Receiver(ReceiverBase):
             task.expected_transfers = len(peer_overlap.ranks)
         else:
             task.expected_transfers = len(dp0_overlap.ranks)
+        # TP fan-in splits ONE region equally, so allow it only for a uniform writer set:
+        # _fanin_bounce_safe() (TP-by-head / even-PP), and never under ADP broadcast (sender_dp_rank
+        # None), where the real writer count exceeds expected_transfers and would overflow the slot.
+        topo_overlap = peer_overlap if sender_dp_rank is not None else dp0_overlap
+        allow_bounce = task.expected_transfers == 1 or (
+            sender_dp_rank is not None and self._fanin_bounce_safe(topo_overlap, peer_infos)
+        )
+        bounced = allow_bounce and self._bounce.reserve(receiver_req, task.expected_transfers)
         session = self._get_session(task._unique_rid)
         if session is None:
             raise RuntimeError(
@@ -1491,10 +1575,17 @@ class Receiver(ReceiverBase):
         session._sender_endpoints.update(
             peer_infos.sender_endpoints[rank] for rank in peer_overlap.ranks
         )
-        for rank in peer_overlap.ranks:
+        # Fan-in: each sender gets its own sub-region base (writers must not overwrite); else serialize once.
+        fanin_bounce = bounced and task.expected_transfers > 1
+        key = (receiver_req.unique_rid, receiver_req.slice_id)
+        receiver_req_bytes = None if fanin_bounce else receiver_req.to_bytes()
+        for i, rank in enumerate(peer_overlap.ranks):
             if task._perf_timer is not None:
                 task._perf_timer.record_task_start(rank)
-            self._request_sender_data(peer_infos.sender_endpoints[rank], receiver_req)
+            if fanin_bounce:
+                receiver_req.bounce_dst_base = self._bounce.writer_base(key, i)
+                receiver_req_bytes = receiver_req.to_bytes()
+            self._request_sender_data(peer_infos.sender_endpoints[rank], receiver_req_bytes)
         return
 
     @staticmethod
@@ -1591,17 +1682,17 @@ class Receiver(ReceiverBase):
             session.cancel()
 
     def _process_kv_agent_result(self, _send_id: bytes, message: list[bytes]):
-        msg_type, peer_rank, unique_rid, slice_id_str, is_last_slice_str, status = decode_message(
-            message
-        )
-        peer_rank = int(peer_rank)
-        unique_rid = int(unique_rid)
-        sender_slice_id = int(slice_id_str)
-        if msg_type.encode("ascii") != MessageType.KV_AGENT_RESULT:
+        if message[0] != MessageType.KV_AGENT_RESULT:
             logger.error(
-                f"_process_kv_agent_result: unexpected msg_type={msg_type!r}, expected KV_AGENT_RESULT"
+                f"_process_kv_agent_result: unexpected msg_type={message[0]!r}, expected KV_AGENT_RESULT"
             )
             return
+        peer_rank, unique_rid, sender_slice_id, is_last_slice, status_code = (
+            _KV_RESULT_PREFIX.unpack(message[1])
+        )
+        from .bounce import decode_result_tail
+
+        dst_ptrs, sizes, src_base = decode_result_tail(message)
         session = self._get_session(unique_rid)
         if session is None:
             logger.warning(
@@ -1609,7 +1700,13 @@ class Receiver(ReceiverBase):
             )
             return
         session.process_kv_agent_result(
-            peer_rank, sender_slice_id, is_last_slice_str == "True", AgentResult(status)
+            peer_rank,
+            sender_slice_id,
+            is_last_slice,
+            _AGENT_RESULT_BY_CODE[status_code],
+            dst_ptrs=dst_ptrs,
+            sizes=sizes,
+            src_base=src_base,
         )
 
     def _process_aux_agent_result(self, _send_id: bytes, message: list[bytes]):
@@ -1624,12 +1721,11 @@ class Receiver(ReceiverBase):
             return
         session.process_aux_agent_result(peer_rank, AgentResult(status))
 
-    def _request_sender_data(self, endpoint: str, receiver_info: RecvReqInfo):
-        logger.debug(
-            f"Sending data request to endpoint '{endpoint}' with request info: {receiver_info}"
-        )
+    def _request_sender_data(self, endpoint: str, receiver_info_bytes: bytes):
+        # receiver_info serialized once and reused for every peer rank (block-table msgpack isn't free at fan-out).
+        logger.debug("Sending data request to endpoint '%s'", endpoint)
         messenger = self._get_or_connect_dealer(endpoint)
-        messenger.send([MessageType.REQUEST_DATA, receiver_info.to_bytes()])
+        messenger.send([MessageType.REQUEST_DATA, receiver_info_bytes])
 
     def __del__(self):
         try:
@@ -1721,7 +1817,14 @@ class RxSession(RxSessionBase):
         self._receiver.dispatch_task(task)
 
     def process_kv_agent_result(
-        self, peer_rank: int, sender_slice_id: int, is_last_slice: bool, status: AgentResult
+        self,
+        peer_rank: int,
+        sender_slice_id: int,
+        is_last_slice: bool,
+        status: AgentResult,
+        dst_ptrs=None,
+        sizes=None,
+        src_base=None,
     ):
         with self.lock:
             assert sender_slice_id < len(self._kv_tasks), (
@@ -1731,19 +1834,67 @@ class RxSession(RxSessionBase):
             )
             task = self._kv_tasks[sender_slice_id]
             if status == AgentResult.SUCCESS:
+                from .bounce import scatter_write_result
+
+                on_done = None
                 if is_last_slice:
                     task.last_slice_count += 1
                     if task.last_slice_count == task.expected_transfers:
-                        task.complete()
-
-                        logger.debug(
-                            f"KV transfer complete for request {self.request_id} "
-                            f"slice={sender_slice_id}"
-                        )
-                        if task._perf_timer is not None:
-                            task._perf_timer.record_task_end(peer_rank)
+                        # Completing message: defer task.complete()+perf until the scatter has actually
+                        # landed. scatter_write_result fires this inline for the non-bounced path, or on
+                        # the scatter worker (after cudaStreamSynchronize) for the bounced path, so the
+                        # gen consumer never observes completion before the KV is scattered into place.
+                        request_id = self.request_id
                         ri = self._receiver._registrar.self_rank_info
-                        task.print_perf_info(peer_rank, ri.instance_name, ri.instance_rank)
+                        instance_name, instance_rank = ri.instance_name, ri.instance_rank
+
+                        def on_done(
+                            success,
+                            task=task,
+                            peer_rank=peer_rank,
+                            sender_slice_id=sender_slice_id,
+                            request_id=request_id,
+                            instance_name=instance_name,
+                            instance_rank=instance_rank,
+                        ):
+                            # Runs on the scatter worker thread for the bounced path. Touches only this
+                            # task's own status/_event/_perf_timer (no RxSession.lock, no shared session
+                            # state), so it is lock-free. complete() sets status before _event, keeping
+                            # wait_complete's status-first poll correct.
+                            if not success:
+                                task.fail(
+                                    RuntimeError(
+                                        f"KV bounce scatter failed for request {request_id} "
+                                        f"slice={sender_slice_id}"
+                                    )
+                                )
+                                return
+                            if task.status == TaskStatus.ERROR:
+                                return  # a concurrent FAILED writer already failed it; don't un-fail
+                            try:
+                                if task._perf_timer is not None:
+                                    task._perf_timer.record_task_end(peer_rank)
+                                task.print_perf_info(peer_rank, instance_name, instance_rank)
+                            except Exception as e:  # perf is best-effort; never block completion
+                                logger.warning(
+                                    f"KV transfer perf logging failed for request {request_id} "
+                                    f"slice={sender_slice_id}: {e}"
+                                )
+                            task.complete()
+                            logger.debug(
+                                f"KV transfer complete for request {request_id} "
+                                f"slice={sender_slice_id}"
+                            )
+
+                scatter_write_result(
+                    self._receiver._bounce,
+                    (self.disagg_request_id, task.slice_id),
+                    peer_rank,
+                    dst_ptrs,
+                    sizes,
+                    src_base,
+                    on_done,
+                )
             elif status == AgentResult.FAILED:
                 detail = (
                     f"KV transfer failed for request {self.request_id} slice={sender_slice_id} "
@@ -1751,6 +1902,11 @@ class RxSession(RxSessionBase):
                     f"(reported by remote agent; see sender-side log for nixl_status)"
                 )
                 logger.error(detail)
+                # Drain-before-release: record this writer FAILED; the owner frees the shared region
+                # only once every fan-in writer is terminal (freeing now could race a sibling's RMA).
+                self._receiver._bounce.record_failure(
+                    (self.disagg_request_id, task.slice_id), peer_rank
+                )
                 task.fail(RuntimeError(detail))
                 if self._terminal_status is None:  # Don't overwrite CANCELLED with ERROR
                     self._terminal_status = SessionStatus.ERROR
@@ -1840,6 +1996,11 @@ class RxSession(RxSessionBase):
             exc = RuntimeError(f"RxSession {self.disagg_request_id} cancelled")
             for task in self._kv_tasks:
                 if task.status == TaskStatus.INIT:
+                    # INIT = reserved but no write in flight, so freeing its bounce reservation here
+                    # is safe (TRANSFERRING tasks keep running and self-release on SUCCESS/FAILED).
+                    self._receiver._bounce.release_idle_reservation(
+                        (self.disagg_request_id, task.slice_id)
+                    )
                     task.fail(exc)
         # Send outside the lock to avoid holding it during I/O.
         self._receiver.send_cancel_to_senders(self.disagg_request_id, self._sender_endpoints)
@@ -2001,6 +2162,7 @@ class TransferWorkerConfig:
     max_draft_len: Optional[int] = None
     tx_timeout_s: Optional[float] = None
     rx_timeout_s: Optional[float] = None
+    bounce: Optional["Config"] = None
 
 
 class TransferWorker:
@@ -2073,8 +2235,19 @@ class TransferWorker:
             self._register_kv_cache()
             if self._aux_buffer is not None:
                 self._register_aux_buffer()
-            self._sender = Sender(self._peer_registrar, self._agent)
-            self._receiver = Receiver(self._peer_registrar, self._agent)
+            from .bounce import create_bounce
+
+            self._bounce = create_bounce(
+                self._agent,
+                self._config.bounce,
+                device_id=self._config.device_id,
+                page_table=self._rank_info.page_table,
+            )
+            # The bounce object owns its own NIXL descriptors (deregistered by Transport.close in
+            # shutdown), so they are NOT added to _registered_mem — single-source to avoid a
+            # double deregister.
+            self._sender = Sender(self._peer_registrar, self._agent, bounce=self._bounce)
+            self._receiver = Receiver(self._peer_registrar, self._agent, bounce=self._bounce)
             self._rank_info.transfer_engine_info = bytes(self._agent.get_local_agent_desc())
             self._rank_info.self_endpoint = self._receiver.endpoint
         except Exception:
@@ -2138,6 +2311,16 @@ class TransferWorker:
         receiver = getattr(self, "_receiver", None)
         if receiver is not None:
             receiver.shutdown()
+        # Close the bounce transport (stops its scatter thread, deregisters its own descriptors and
+        # frees the VMM buffers) once the receiver listener is stopped so no new scatter is enqueued.
+        # No-op for the non-bounced path (NoBounceTransport.close); without this the daemon thread + fabric
+        # buffers leak until process exit.
+        bounce = getattr(self, "_bounce", None)
+        if bounce is not None:
+            try:
+                bounce.close()
+            except Exception as e:
+                logger.warning(f"TransferWorker.shutdown: bounce close failed: {e}")
         # Deregister NIXL memory before agent.shutdown so pinned GPU memory is released
         # (e.g. when the KV cache manager is recreated after profiling).
         agent = getattr(self, "_agent", None)

--- a/tensorrt_llm/_torch/disaggregation/nixl/_agent_cpp.py
+++ b/tensorrt_llm/_torch/disaggregation/nixl/_agent_cpp.py
@@ -73,6 +73,22 @@ class BindingsNixlTransferAgent(BaseTransferAgent):
         for key, value in backend_params.items():
             backend_params[key] = str(value)
         backend_params["num_threads"] = str(num_threads)
+        # C++ reads "num_workers" (not "num_threads") for progress threads, default 1.
+        # Env-gated so the default is unchanged (more threads can hurt the coalesced bounce WRITE).
+        # Validate at the boundary: only a positive int reaches the backend.
+        nixl_num_workers = os.environ.get("TRTLLM_NIXL_NUM_WORKERS")
+        if nixl_num_workers is not None:
+            try:
+                workers = int(nixl_num_workers)
+            except ValueError:
+                workers = 0
+            if workers > 0:
+                backend_params["num_workers"] = str(workers)
+            else:
+                logger.warning(
+                    f"Ignoring invalid TRTLLM_NIXL_NUM_WORKERS={nixl_num_workers!r} "
+                    "(expected a positive integer)"
+                )
 
         config = BaseAgentConfig(
             name,

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -17,12 +17,16 @@ from tensorrt_llm._torch.disaggregation.base.transfer import (
     WaitResult,
     get_unique_rid,
 )
+from tensorrt_llm._torch.disaggregation.native.bounce import (
+    config_from_size as bounce_config_from_size,
+)
 from tensorrt_llm._torch.disaggregation.native.transfer import TransferWorker, TransferWorkerConfig
 from tensorrt_llm._torch.disaggregation.resource.cache_reuse import (
     CacheReuseAdapter,
     create_cache_reuse_adapter,
 )
 from tensorrt_llm._torch.disaggregation.resource.page import MambaLayerGroup
+from tensorrt_llm._torch.disaggregation.resource.utils import get_physical_pool
 from tensorrt_llm._torch.distributed.communicator import Distributed
 from tensorrt_llm._torch.pyexecutor.kv_cache_transceiver import KvCacheTransceiver
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
@@ -85,6 +89,8 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
                 max_concurrent_sessions=max(1, int(kv_cache_manager.max_batch_size)) * 20000,
                 tx_timeout_s=self._sender_future_timeout_ms / 1000.0,
                 rx_timeout_s=self.kv_transfer_timeout_ms / 1000.0,
+                # On/off switch via config (size 0 => None => per-block path).
+                bounce=bounce_config_from_size(cache_transceiver_config.kv_cache_bounce_size_mb),
             )
         )
         self._dp_rank = mapping.tp_rank if mapping.enable_attention_dp else 0
@@ -98,6 +104,9 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         self._recv_reqs = {}
         self._wait_reqs = {}
         self._page_table = self._transfer_worker.page_table
+        # _slice_num_bytes() is this rank's KV shard, so scale by tp_size to get the request total (kv_cache_size),
+        # except under attention DP where the local count already is the total.
+        self._kv_size_rank_factor = 1 if mapping.enable_attention_dp else max(1, mapping.tp_size)
 
         # Sticky role markers; flip True once any session opens, used to short-circuit
         # per-iter tp_allgather when this transceiver never sends/receives.
@@ -238,6 +247,27 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             mamba_state_index=mamba_state_index,
             token_range=token_range,
         )
+
+    def _slice_num_bytes(self, slice: KVSlice) -> int:
+        """Local-rank KV bytes covered by a slice (sum of num_valid_blocks * pool.slot_bytes), enough to populate
+        kv_cache_size and unblock the perf-metric timestamps that gate on it."""
+        pt = self._page_table
+        if pt is None:
+            return 0
+        total = 0
+        for lg_id, block_ids in enumerate(slice.block_ids_per_layer_groups):
+            if block_ids is None or block_ids.size == 0:
+                continue
+            lg = pt.layer_groups[lg_id]
+            if isinstance(lg, MambaLayerGroup):
+                continue
+            n = int((block_ids >= 0).sum())
+            if n == 0:
+                continue
+            for pv in lg.pool_views:
+                pool = get_physical_pool(pt, lg_id, pv.pool_idx)
+                total += n * pool.slot_bytes
+        return total
 
     @staticmethod
     def _split_packed_beam_block_ids(
@@ -482,10 +512,13 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             session = self._transfer_worker.create_rx_session(req)
             self._recv_sessions[rid] = session
             self._recv_reqs[rid] = req
-            session.receive(self._create_kv_slice(req))
+            kv_slice = self._create_kv_slice(req)
+            session.receive(kv_slice)
             result = session.wait_complete(blocking=True)
 
             if result == WaitResult.COMPLETED:
+                # KV-transfer timing setters deferred to #15871 (clock-source consistency); size only.
+                req.set_kv_cache_size(self._slice_num_bytes(kv_slice) * self._kv_size_rank_factor)
                 if self._need_aux_transfer(req):
                     self._apply_aux(session, req)
                 self._assert_disagg_history_declared(req)
@@ -513,7 +546,9 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         req.state = LlmRequestState.DISAGG_GENERATION_TRANS_IN_PROGRESS
         session = self._transfer_worker.create_rx_session(req)
         self._recv_sessions[rid] = session
-        session.receive(self._create_kv_slice(req))
+        kv_slice = self._create_kv_slice(req)
+        req.py_kv_cache_xfer_bytes = self._slice_num_bytes(kv_slice) * self._kv_size_rank_factor
+        session.receive(kv_slice)
         self._recv_reqs[rid] = req
 
     def check_context_transfer_status(
@@ -625,6 +660,8 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         for rid in completed:
             session = self._recv_sessions[rid]
             req = self._recv_reqs[rid]
+            # transfer_end already stamped at completion detection above.
+            req.set_kv_cache_size(getattr(req, "py_kv_cache_xfer_bytes", 0))
             if self._need_aux_transfer(req):
                 self._apply_aux(session, req)
             self._assert_disagg_history_declared(req)

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3673,6 +3673,13 @@ class CacheTransceiverConfig(StrictBaseModel, PybindMirror):
         "Bounded wait interval in milliseconds for polling KV transfer "
         "progress when active transfers block disaggregated admission.")
 
+    kv_cache_bounce_size_mb: int = Field(
+        default=0,
+        ge=0,
+        description=
+        "Per-region size in MiB of the native-disagg KV-cache bounce buffer (one for send, one for recv). Bounce coalesces a request's scattered per-block KV into one contiguous fabric-VMM buffer and issues a single multi-rail NIXL write. The size doubles as the on/off switch: 0 (default) keeps the per-block path, >0 enables bounce at that capacity. Only used by the Python (v2) transceiver."
+    )
+
     def _to_pybind(self):
         return _CacheTransceiverConfig(
             backend=_CacheTransceiverBackendType.from_string(self.backend),

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_overlap_transceiver_runtime_python_bounce.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_overlap_transceiver_runtime_python_bounce.yaml
@@ -1,0 +1,40 @@
+model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
+hostname: localhost
+port: 8000
+backend: "pytorch"
+cuda_graph_config: null
+free_gpu_memory_fraction: 0.2
+context_servers:
+  num_instances: 1
+  max_batch_size: 1
+  max_num_tokens: 3000
+  max_seq_len: 4096
+  tensor_parallel_size: 1
+  pipeline_parallel_size: 1
+  kv_cache_config:
+    free_gpu_memory_fraction: 0.2
+    enable_partial_reuse: False
+  disable_overlap_scheduler: True
+  cache_transceiver_config:
+    backend: NIXL
+    transceiver_runtime: PYTHON
+    kv_cache_bounce_size_mb: 64
+  urls:
+      - "localhost:8001"
+generation_servers:
+  num_instances: 1
+  tensor_parallel_size: 1
+  pipeline_parallel_size: 1
+  max_batch_size: 256
+  max_num_tokens: 4096
+  max_seq_len: 4096
+  kv_cache_config:
+    free_gpu_memory_fraction: 0.2
+    enable_partial_reuse: False
+  disable_overlap_scheduler: False
+  cache_transceiver_config:
+    backend: NIXL
+    transceiver_runtime: PYTHON
+    kv_cache_bounce_size_mb: 64
+  urls:
+      - "localhost:8002"

--- a/tests/integration/defs/disaggregated/test_disaggregated.py
+++ b/tests/integration/defs/disaggregated/test_disaggregated.py
@@ -225,6 +225,8 @@ def get_test_config(test_desc, example_dir, test_root):
         f"{test_configs_root}/disagg_config_overlap_gen_first_pp4.yaml",
         "overlap_transceiver_runtime_python":
         f"{test_configs_root}/disagg_config_overlap_transceiver_runtime_python.yaml",
+        "overlap_transceiver_runtime_python_bounce":
+        f"{test_configs_root}/disagg_config_overlap_transceiver_runtime_python_bounce.yaml",
         "tool_calls":
         f"{test_configs_root}/disagg_config_overlap.yaml",
         "perf_metrics":
@@ -1151,6 +1153,29 @@ def test_disaggregated_overlap_transceiver_runtime_python_fabric_memory(
     env["TRTLLM_KVCACHE_POOL_USE_FABRIC_MEMORY"] = "1"
     run_disaggregated_test(disaggregated_example_root,
                            "overlap_transceiver_runtime_python",
+                           env=env,
+                           model_path=llama_model_root,
+                           cwd=llm_venv.get_working_directory())
+
+
+# Exercises the disaggregated KV-cache transfer path with the Python cache transceiver AND the
+# KV-cache bounce optimization (cache_transceiver_config.kv_cache_bounce_size_mb > 0): scattered
+# per-block WRITEs are gathered into one coalesced fabric-VMM buffer before a single NIXL WRITE.
+# Restricted to GB200/GB300 since the bounce arena is fabric (MNNVL) VMM memory.
+@pytest.mark.skip_device_not_contain(["GB200", "GB300"])
+@pytest.mark.parametrize("llama_model_root", ['TinyLlama-1.1B-Chat-v1.0'],
+                         indirect=True)
+def test_disaggregated_overlap_transceiver_runtime_python_bounce(
+        disaggregated_test_root, llm_venv, disaggregated_example_root,
+        llama_model_root):
+    setup_model_symlink(llm_venv, llama_model_root,
+                        "TinyLlama/TinyLlama-1.1B-Chat-v1.0")
+
+    env = llm_venv._new_env.copy()
+    env["UCX_TLS"] = get_ucx_tls()
+    env["TRTLLM_KVCACHE_POOL_USE_FABRIC_MEMORY"] = "1"
+    run_disaggregated_test(disaggregated_example_root,
+                           "overlap_transceiver_runtime_python_bounce",
                            env=env,
                            model_path=llama_model_root,
                            cwd=llm_venv.get_working_directory())

--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -67,6 +67,7 @@ l0_a10:
   - unittest/disaggregated/test_cluster_storage.py
   - unittest/disaggregated/test_extractor.py
   - unittest/disaggregated/test_peer.py
+  - unittest/disaggregated/test_bounce.py
   - unittest/disaggregated/region/test_block.py
   - unittest/disaggregated/test_mamba_transfer.py
   - unittest/tools

--- a/tests/integration/test_lists/test-db/l0_gb200_multi_gpus.yml
+++ b/tests/integration/test_lists/test-db/l0_gb200_multi_gpus.yml
@@ -66,6 +66,7 @@ l0_gb200_multi_gpus:
   - unittest/_torch/modules/moe/test_moe_comm.py::TestMoEComm::test_moe_comm
   - unittest/_torch/modules/moe/test_moe_comm.py::TestMoEComm::test_moe_comm_postquant
   - disaggregated/test_disaggregated.py::test_disaggregated_overlap_transceiver_runtime_python_fabric_memory[TinyLlama-1.1B-Chat-v1.0]
+  - disaggregated/test_disaggregated.py::test_disaggregated_overlap_transceiver_runtime_python_bounce[TinyLlama-1.1B-Chat-v1.0]
 
 - condition:
     ranges:

--- a/tests/integration/test_lists/test-db/l0_h100.yml
+++ b/tests/integration/test_lists/test-db/l0_h100.yml
@@ -72,6 +72,7 @@ l0_h100:
   - unittest/disaggregated/test_messenger.py
   - unittest/disaggregated/test_extractor.py
   - unittest/disaggregated/test_peer.py
+  - unittest/disaggregated/test_bounce.py
   - unittest/disaggregated/region/test_block.py
   - unittest/disaggregated/region/test_aux.py
   - unittest/disaggregated/region/test_page.py

--- a/tests/unittest/disaggregated/test_bounce.py
+++ b/tests/unittest/disaggregated/test_bounce.py
@@ -1,0 +1,663 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU-only unit tests for the native-disagg KV ``bounce`` module.
+
+Covers sizing/OOM-guard math, the KV_AGENT_RESULT wire format, the NoBounceTransport
+no-op fallback, and the TP fan-in reserve/record/settle logic (GPU allocators/streams mocked).
+"""
+
+import queue
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from tensorrt_llm._torch.disaggregation.native.bounce import config as bcfg
+
+# core (the BounceTransport contract + the TransferContext state machine) is PURE (no CUDA / NIXL
+# imports), so it is always importable on CPU.
+from tensorrt_llm._torch.disaggregation.native.bounce import core as bcore
+
+# transport/transfer pull CUDA-binding + torch deps at import; skip gracefully when those are
+# absent (CPU-only env). Catch only ImportError so a genuine bug in the module still fails CI
+# instead of being silently turned into a skip.
+try:
+    from tensorrt_llm._torch.disaggregation.native.bounce import buffer as bbuf
+    from tensorrt_llm._torch.disaggregation.native.bounce import impl as btr
+
+    _HAVE_TRANSPORT = True
+except ImportError:  # pragma: no cover - CPU-only env without CUDA bindings
+    _HAVE_TRANSPORT = False
+
+_MIB = 1024 * 1024
+
+
+# --------------------------------------------------------------------------- #
+# config.py — sizing + OOM guard (pure math, always runnable)
+# --------------------------------------------------------------------------- #
+class TestSizing:
+    @pytest.mark.parametrize(
+        "a,b,want", [(0, 8, 0), (1, 8, 8), (8, 8, 8), (9, 8, 16), (33, 32, 64)]
+    )
+    def test_round_up(self, a, b, want):
+        assert bcfg._round_up(a, b) == want
+
+    def test_fixed_sizing_rounds_up_to_chunk(self):
+        chunk = 32 * _MIB
+        ctx = bcfg.SizingContext(
+            free_bytes=80 * _MIB, total_bytes=200 * _MIB, chunk_bytes=chunk, device_id=0
+        )
+        # 50 MiB requested -> rounded up to a 64 MiB (2-chunk) multiple.
+        assert bcfg.FixedSizing(capacity_mb=50).resolve(ctx) == 64 * _MIB
+
+    def test_fixed_sizing_floor_is_one_chunk(self):
+        chunk = 32 * _MIB
+        ctx = bcfg.SizingContext(
+            free_bytes=80 * _MIB, total_bytes=200 * _MIB, chunk_bytes=chunk, device_id=0
+        )
+        # below one chunk still gets a whole chunk.
+        assert bcfg.FixedSizing(capacity_mb=1).resolve(ctx) == chunk
+
+    def test_fit_within_free_clamps_to_half_split_two_regions(self):
+        chunk = 32 * _MIB
+        # max_free_fraction=0.5 of 1024 MiB = 512 MiB, /2 regions = 256 MiB.
+        got = bcfg.fit_within_free(want := 4096 * _MIB, free_bytes=1024 * _MIB, chunk_bytes=chunk)
+        assert got == 256 * _MIB
+        assert got < want
+
+    def test_fit_within_free_keeps_request_when_it_fits(self):
+        chunk = 32 * _MIB
+        got = bcfg.fit_within_free(128 * _MIB, free_bytes=4096 * _MIB, chunk_bytes=chunk)
+        assert got == 128 * _MIB
+
+    def test_fit_within_free_none_when_too_small(self):
+        chunk = 32 * _MIB
+        # only 32 MiB free -> half/2 = 8 MiB < one chunk -> cannot fit.
+        assert bcfg.fit_within_free(64 * _MIB, free_bytes=32 * _MIB, chunk_bytes=chunk) is None
+
+    def test_config_defaults(self):
+        cfg = bcfg.Config()
+        assert isinstance(cfg.sizing, bcfg.FixedSizing)
+        assert cfg.chunk_mb == 32 and cfg.min_blocks == 96
+
+
+# --------------------------------------------------------------------------- #
+# config.py — config on/off switch (size knob doubles as the enable flag)
+# --------------------------------------------------------------------------- #
+class TestConfigFromSize:
+    @pytest.mark.parametrize("size_mb", [0, -1, None])
+    def test_non_positive_is_off(self, size_mb):
+        assert bcfg.config_from_size(size_mb) is None
+
+    def test_positive_enables_with_capacity(self):
+        cfg = bcfg.config_from_size(2048)
+        assert isinstance(cfg, bcfg.Config)
+        assert cfg.sizing.capacity_mb == 2048
+
+
+# --------------------------------------------------------------------------- #
+# wire format — KV_AGENT_RESULT struct prefix + bounce result tail
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(not _HAVE_TRANSPORT, reason="bounce.transport import needs CUDA bindings")
+class TestResultTail:
+    def _wm(self, dst, sizes, base):
+        return SimpleNamespace(
+            dst_ptrs=np.array(dst, dtype=np.int64),
+            sizes=np.array(sizes, dtype=np.int64),
+            bounce_dst_base=base,
+        )
+
+    def test_roundtrip_with_tail(self):
+        wm = self._wm([100, 200, 300], [16, 16, 16], 0xABCD)
+        # message = [msg_type, packed_prefix, *tail]; tail lives at [2:].
+        msg = [b"KV_AGENT_RESULT", b"prefix"] + btr.encode_result_tail(wm)
+        assert len(msg) == 5
+        dst, sizes, src_base = btr.decode_result_tail(msg)
+        assert np.array_equal(dst, wm.dst_ptrs)
+        assert np.array_equal(sizes, wm.sizes)
+        assert src_base == 0xABCD
+
+    def test_no_tail_returns_none(self):
+        # non-bounced result: only [msg_type, prefix] -> no tail.
+        assert btr.decode_result_tail([b"KV_AGENT_RESULT", b"prefix"]) == (None, None, None)
+
+    def test_encode_tail_handles_unset_base(self):
+        wm = self._wm([1, 2], [8, 8], None)
+        tail = btr.encode_result_tail(wm)
+        assert int(np.frombuffer(tail[2], dtype=np.int64)[0]) == 0
+
+
+def test_kv_result_prefix_roundtrip():
+    """The KV_AGENT_RESULT binary prefix (transfer.py) must round-trip exactly."""
+    tfr = pytest.importorskip("tensorrt_llm._torch.disaggregation.native.transfer")
+    for rank, rid, sl, last, status in [
+        (7, 6925227277844486, 42, True, tfr.AgentResult.SUCCESS),
+        (0, 1, 0, False, tfr.AgentResult.FAILED),
+        (31, 2**62, 9999, True, tfr.AgentResult.SUCCESS),
+    ]:
+        packed = tfr._KV_RESULT_PREFIX.pack(rank, rid, sl, last, tfr._AGENT_RESULT_CODE[status])
+        r, i, s, last_out, c = tfr._KV_RESULT_PREFIX.unpack(packed)
+        assert (r, i, s, last_out) == (rank, rid, sl, last)
+        assert tfr._AGENT_RESULT_BY_CODE[c] is status
+
+
+@pytest.mark.parametrize("result_name", ["SUCCESS", "FAILED"])
+def test_make_kv_result_msg_uses_binary_frame(result_name):
+    """Every KV result (success and failure) uses the binary frame so the receiver can decode it."""
+    tfr = pytest.importorskip("tensorrt_llm._torch.disaggregation.native.transfer")
+    result = getattr(tfr.AgentResult, result_name)
+    msg = tfr._make_kv_result_msg(3, 12345, 7, True, result)
+    assert msg[0] == tfr.MessageType.KV_AGENT_RESULT
+    assert len(msg) == 2  # prefix only; no bounce tail when none is passed
+    r, rid, sl, last, code = tfr._KV_RESULT_PREFIX.unpack(msg[1])
+    assert (r, rid, sl, last) == (3, 12345, 7, True)
+    assert tfr._AGENT_RESULT_BY_CODE[code] is result
+
+
+# --------------------------------------------------------------------------- #
+# fan-in safety gate — equal total//num_writers split only for uniform TP-by-head
+# --------------------------------------------------------------------------- #
+def test_fanin_bounce_safe_gate():
+    """Restrict multi-writer equal-split bounce to uniform TP-by-head.
+
+    PP (overlap_pp_size>1 -> unequal per-writer sizes) and duplicate_head_factor>1
+    (MLA / duplicate TP heads -> some ranks don't send KV yet count in
+    expected_transfers) must fall back to the per-fragment path.
+    """
+    tfr = pytest.importorskip("tensorrt_llm._torch.disaggregation.native.transfer")
+    safe = tfr.Receiver._fanin_bounce_safe
+
+    def ov(dup, pp):
+        return SimpleNamespace(duplicate_head_factor=dup, overlap_pp_size=pp)
+
+    def ri(lpp):
+        return SimpleNamespace(layer_num_per_pp=lpp)
+
+    # single PP stage (overlap_pp_size <= 1): only duplicate_head_factor matters
+    assert safe(ov(1, 1), ri([24])) is True
+    assert safe(ov(1, 0), ri([24])) is True
+    assert safe(ov(2, 1), ri([24])) is False  # duplicate heads / MLA -> some don't send
+    # EVEN PP fan-in (equal layers per overlapping stage) -> allowed
+    assert safe(ov(1, 4), ri([20, 20, 20, 20])) is True
+    # UNEVEN PP fan-in -> per-writer sizes differ -> fall back
+    assert safe(ov(1, 4), ri([20, 20, 20, 19])) is False
+    # incomplete per-stage info (single element for a multi-stage fan-in) -> conservative fall back
+    assert safe(ov(1, 4), ri([20])) is False
+    # duplicate heads blocks even an otherwise-even PP split
+    assert safe(ov(2, 4), ri([20, 20, 20, 20])) is False
+
+
+# --------------------------------------------------------------------------- #
+# NoBounceTransport — disabled no-op fallback
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(not _HAVE_TRANSPORT, reason="bounce.transport import needs CUDA bindings")
+class TestNoBounce:
+    def test_noop_behaviour(self):
+        nb = btr.NoBounceTransport()
+        assert nb.enabled is False
+        assert nb.reserve(SimpleNamespace()) is False
+        assert nb.build_request(SimpleNamespace()) is None
+        assert nb.writer_base(("r", 0), 1) is None
+        assert nb.is_bounced(("r", 0)) is False
+        nb.record_result(("r", 0), 1)  # no-op, must not raise
+        nb.record_failure(("r", 0), 1)  # no-op, must not raise
+        nb.release_idle_reservation(("r", 0))  # no-op, must not raise
+        nb.release_send(0)
+        nb.close()
+
+    def test_create_bounce_none_cfg(self):
+        assert isinstance(
+            btr.create_bounce(object(), None, device_id=0, page_table=None), btr.NoBounceTransport
+        )
+
+    def test_implements_bounce_transport_abc(self):
+        # Both implementations must satisfy the explicit contract; instantiating NoBounceTransport
+        # proves no abstractmethod is missing (guards the two impls against drifting apart).
+        assert issubclass(btr.NoBounceTransport, bcore.BounceTransport)
+        assert issubclass(btr.VmmBounceTransport, bcore.BounceTransport)
+        assert isinstance(btr.NoBounceTransport(), bcore.BounceTransport)
+
+
+# --------------------------------------------------------------------------- #
+# Transport TP fan-in logic — reserve gate / writer_base / accumulate ordering
+# (GPU allocators, streams and the scatter worker are mocked out)
+# --------------------------------------------------------------------------- #
+class _FakeAlloc:
+    """Stand-in for SlotAllocator: hands out a fixed base, records reservations."""
+
+    def __init__(self, capacity_bytes, phys_chunk_size, name="kv_bounce"):
+        self._cap = capacity_bytes
+        self.base = 0x100000
+        self.next_id = 0
+        self.released = []
+        self.quarantined = []
+
+    @property
+    def capacity(self):
+        return self._cap
+
+    def reserve(self, size, timeout=None):
+        if size > self._cap:
+            return None
+        sid = self.next_id
+        self.next_id += 1
+        return sid, self.base
+
+    def release(self, slot_id):
+        self.released.append(slot_id)
+
+    def quarantine(self, slot_id, grace_s):
+        self.quarantined.append(slot_id)
+
+    def reclaim_expired(self):
+        return 0
+
+    def reg_descs(self):
+        return []
+
+
+def _make_transport(monkeypatch, block_bytes_per_group, capacity=1 << 30, min_blocks=1):
+    monkeypatch.setattr(btr, "SlotAllocator", _FakeAlloc)
+    monkeypatch.setattr(btr.VmmBounceTransport, "_new_stream", lambda self: 0)
+    monkeypatch.setattr(
+        btr.VmmBounceTransport,
+        "_start_scatter_worker",
+        lambda self, name: setattr(self, "_scatter_q", queue.Queue()),
+    )
+    agent = SimpleNamespace(register_memory=lambda d: None)
+    return btr.VmmBounceTransport(
+        agent,
+        device_id=0,
+        capacity_bytes=capacity,
+        phys_chunk_size=32 * _MIB,
+        block_bytes_per_group=block_bytes_per_group,
+        min_blocks=min_blocks,
+    )
+
+
+def _recv_req(block_counts, rid=1, slice_id=0):
+    return SimpleNamespace(
+        block_ids_per_layer_groups=[SimpleNamespace(size=n) for n in block_counts],
+        unique_rid=rid,
+        slice_id=slice_id,
+        bounce_dst_base=None,
+    )
+
+
+@pytest.mark.skipif(not _HAVE_TRANSPORT, reason="bounce.transport import needs CUDA bindings")
+class TestFanInReserve:
+    def test_reserve_stamps_base_and_per_writer(self, monkeypatch):
+        t = _make_transport(monkeypatch, block_bytes_per_group=[100])
+        req = _recv_req([2])  # total = 2 * 100 = 200
+        assert t.reserve(req, num_writers=2) is True
+        assert req.bounce_dst_base == 0x100000
+        # writer i lands at base + i * (total // num_writers); per_writer = 100.
+        assert t.writer_base((req.unique_rid, req.slice_id), 0) == 0x100000
+        assert t.writer_base((req.unique_rid, req.slice_id), 1) == 0x100000 + 100
+
+    def test_reserve_uneven_fanin_falls_back(self, monkeypatch):
+        t = _make_transport(monkeypatch, block_bytes_per_group=[3])
+        req = _recv_req([1])  # total = 3, not divisible by 2
+        assert t.reserve(req, num_writers=2) is False
+        assert req.bounce_dst_base is None
+
+    def test_reserve_single_writer_ok(self, monkeypatch):
+        t = _make_transport(monkeypatch, block_bytes_per_group=[3])
+        req = _recv_req([1])  # total = 3, num_writers=1 -> no even-split requirement
+        assert t.reserve(req, num_writers=1) is True
+
+    def test_reserve_too_small_falls_back(self, monkeypatch):
+        t = _make_transport(monkeypatch, block_bytes_per_group=[100], min_blocks=96)
+        assert t.reserve(_recv_req([4]), num_writers=1) is False  # 4 < 96 blocks
+
+    def test_reserve_unknown_slot_size_falls_back(self, monkeypatch):
+        t = _make_transport(monkeypatch, block_bytes_per_group=[100])  # only 1 group known
+        assert t.reserve(_recv_req([2, 2]), num_writers=1) is False  # 2nd group unknown
+
+    def test_reserve_oversize_falls_back(self, monkeypatch):
+        t = _make_transport(monkeypatch, block_bytes_per_group=[1000], capacity=500)
+        assert t.reserve(_recv_req([2]), num_writers=1) is False  # total 2000 > cap 500
+
+    def test_fanin_scatters_ordered_by_src_base(self, monkeypatch):
+        t = _make_transport(monkeypatch, block_bytes_per_group=[100])
+        req = _recv_req([2])
+        assert t.reserve(req, num_writers=2) is True
+        rid_slice = (req.unique_rid, req.slice_id)
+        # writer for the HIGHER src_base reports first; scatter must reorder by src_base.
+        t.record_result(
+            rid_slice,
+            7,
+            np.array([20], dtype=np.int64),
+            np.array([8], dtype=np.int64),
+            src_base=200,
+        )
+        assert t._scatter_q.empty()  # only 1 of 2 writers terminal -> no scatter
+        assert not t._recv_alloc.released  # region NOT freed while a writer is still pending
+        t.record_result(
+            rid_slice,
+            3,
+            np.array([10], dtype=np.int64),
+            np.array([8], dtype=np.int64),
+            src_base=100,
+        )
+        ctx, descs = t._scatter_q.get_nowait()
+        # each tail carries its OWN src_base; sorted (100 before 200) so the scatter is deterministic.
+        assert [t[0] for t in descs] == [100, 200]  # per-writer src_base preserved
+        assert [list(t[1]) for t in descs] == [[10], [20]]  # dst_ptrs
+        assert [list(t[2]) for t in descs] == [[8], [8]]  # sizes
+
+    def test_fanin_fallback_writer_leaves_survivor_at_its_own_base(self, monkeypatch):
+        # Regression: if one fan-in writer falls back to in-place (SUCCESS, empty tail) while a
+        # sibling bounces, the survivor must be scattered from ITS OWN src_base, not packed to 0.
+        t = _make_transport(monkeypatch, block_bytes_per_group=[100])
+        req = _recv_req([2])
+        assert t.reserve(req, num_writers=2) is True
+        rid_slice = (req.unique_rid, req.slice_id)
+        t.record_result(
+            rid_slice, 7, None, None
+        )  # writer 0 fell back to in-place: SUCCESS, no tail
+        assert t._scatter_q.empty()  # only 1 of 2 writers terminal
+        t.record_result(
+            rid_slice,
+            3,
+            np.array([10], dtype=np.int64),
+            np.array([8], dtype=np.int64),
+            src_base=100,
+        )  # writer 1 bounced to base+100
+        ctx, descs = t._scatter_q.get_nowait()
+        assert [t[0] for t in descs] == [100]  # only the survivor, read from base+100 (NOT 0)
+        assert [list(t[1]) for t in descs] == [[10]]
+
+    def test_fanin_failed_then_success_releases_only_after_both(self, monkeypatch):
+        # A FAILED writer must not free the shared region until every writer is terminal.
+        t = _make_transport(monkeypatch, block_bytes_per_group=[100])
+        req = _recv_req([2])
+        assert t.reserve(req, num_writers=2) is True
+        rid_slice = (req.unique_rid, req.slice_id)
+        t.record_failure(rid_slice, 7)  # first writer fails
+        assert not t._recv_alloc.released  # region held while a sibling may still be in flight
+        assert t.is_bounced(rid_slice) is True
+        t.record_result(
+            rid_slice, 3, np.array([10], dtype=np.int64), np.array([8], dtype=np.int64), src_base=0
+        )
+        # all terminal, >=1 FAILED -> no scatter, release (both drained), region freed.
+        assert t._scatter_q.empty()
+        assert t._recv_alloc.released
+        assert not t._recv_alloc.quarantined  # FAILED has drained -> release, NOT quarantine
+        assert t.is_bounced(rid_slice) is False
+
+    def test_on_done_fires_after_scatter_lands(self, monkeypatch):
+        # The completion cb rides the context and fires only when the worker records the scatter as
+        # done -> the gen never observes completion before the KV is scattered into place.
+        t = _make_transport(monkeypatch, block_bytes_per_group=[100])
+        req = _recv_req([2])
+        assert t.reserve(req, num_writers=1) is True
+        rid_slice = (req.unique_rid, req.slice_id)
+        calls = []
+        t.record_result(
+            rid_slice,
+            3,
+            np.array([10], dtype=np.int64),
+            np.array([8], dtype=np.int64),
+            src_base=0,
+            on_done=lambda ok: calls.append(ok),
+        )
+        ctx, descs = t._scatter_q.get_nowait()
+        assert calls == []  # deferred, not fired inline
+        t._apply(
+            ctx.rid_slice, lambda c: c.finish_scatter(True)
+        )  # worker records scatter done -> settle
+        assert calls == [True]
+        assert t._recv_alloc.released
+
+    def test_empty_acc_fires_on_done_inline_and_releases(self, monkeypatch):
+        # Bounced SUCCESS that carried no scatter tail: nothing to copy, but the task must still
+        # complete -> on_done(True) inline + slot released, nothing queued.
+        t = _make_transport(monkeypatch, block_bytes_per_group=[100])
+        req = _recv_req([2])
+        assert t.reserve(req, num_writers=1) is True
+        rid_slice = (req.unique_rid, req.slice_id)
+        calls = []
+        t.record_result(rid_slice, 3, None, None, on_done=lambda ok: calls.append(ok))
+        assert calls == [True]
+        assert t._scatter_q.empty()
+        assert t._recv_alloc.released  # slot freed
+
+    def test_missing_key_is_dropped(self, monkeypatch):
+        # A late/duplicate result for an already-settled (popped) rid_slice is dropped: the context's own
+        # settle already fired completion, so re-firing here would double-report.
+        t = _make_transport(monkeypatch, block_bytes_per_group=[100])
+        calls = []
+        t.record_result(
+            ("missing", 0),
+            3,
+            np.array([10], dtype=np.int64),
+            np.array([8], dtype=np.int64),
+            src_base=0,
+            on_done=lambda ok: calls.append(ok),
+        )
+        assert calls == []  # no-op, no callback
+
+    def test_duplicate_writer_is_ignored(self, monkeypatch):
+        # A duplicate SUCCESS from the same peer_rank must not double-count toward all-terminal.
+        t = _make_transport(monkeypatch, block_bytes_per_group=[100])
+        req = _recv_req([2])
+        assert t.reserve(req, num_writers=2) is True
+        rid_slice = (req.unique_rid, req.slice_id)
+        arr = (np.array([10], dtype=np.int64), np.array([8], dtype=np.int64))
+        t.record_result(rid_slice, 7, *arr, src_base=0)
+        t.record_result(rid_slice, 7, *arr, src_base=0)  # duplicate of the SAME writer
+        assert t._scatter_q.empty()  # still only 1 distinct writer -> not all terminal
+        assert not t._recv_alloc.released
+
+    def test_scatter_write_result_non_bounce_fires_on_done(self):
+        # Non-bounced path completes inline (the in-place WRITE already landed the KV).
+        calls = []
+        btr.scatter_write_result(
+            btr.NoBounceTransport(), ("r", 0), 1, None, None, on_done=lambda ok: calls.append(ok)
+        )
+        assert calls == [True]
+
+    def test_release_idle_reservation_frees_slot_and_is_idempotent(self, monkeypatch):
+        # INIT-cancel immediate release (nothing published) must free the recv slot; idempotent.
+        t = _make_transport(monkeypatch, block_bytes_per_group=[100])
+        req = _recv_req([2])
+        assert t.reserve(req, num_writers=1) is True
+        rid_slice = (req.unique_rid, req.slice_id)
+        assert t.is_bounced(rid_slice) is True
+        t.release_idle_reservation(rid_slice)
+        assert t.is_bounced(rid_slice) is False
+        assert t._recv_alloc.released  # slot freed
+        t.release_idle_reservation(rid_slice)  # already gone -> no-op, must not raise
+
+
+# --------------------------------------------------------------------------- #
+# SlotAllocator — first-fit reuses out-of-order freed holes (real Buffer mocked)
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(not _HAVE_TRANSPORT, reason="bounce.transport import needs CUDA bindings")
+class TestSlotAllocator:
+    def _alloc(self, monkeypatch, cap):
+        # SlotAllocator.__init__ resolves Buffer from the buffer module's globals, so patch it there.
+        monkeypatch.setattr(
+            bbuf,
+            "Buffer",
+            lambda *a, **k: SimpleNamespace(
+                size=cap, base_ptr=0x1000, reg_descs=lambda: [], close=lambda: None
+            ),
+        )
+        return btr.SlotAllocator(cap, 512)
+
+    def test_reuses_out_of_order_freed_hole(self, monkeypatch):
+        a = self._alloc(monkeypatch, cap=1024)  # two 512-byte slots
+        _sa, _ = a.reserve(512)  # [0, 512) stays live
+        sb, _ = a.reserve(512)  # [512, 1024)
+        a.release(sb)  # free the TAIL hole out of order
+        # A bump cursor sitting at 1024 would wrap to 0, hit the live [0,512) and block; first-fit
+        # must reuse [512, 1024) immediately.
+        res = a.reserve(512, timeout=0.5)
+        assert res is not None
+        _, addr = res
+        assert addr == 0x1000 + 512
+
+    def test_blocks_until_release_when_full(self, monkeypatch):
+        a = self._alloc(monkeypatch, cap=512)  # single slot
+        a.reserve(512)
+        assert a.reserve(512, timeout=0.05) is None  # full -> times out
+
+
+# --------------------------------------------------------------------------- #
+# core.TransferContext — the pure drain-before-release state machine.
+# No CUDA / NIXL / allocator, so these run on any CPU (no skipif).
+# --------------------------------------------------------------------------- #
+class TestLifecycle:
+    def _ctx(self, num_writers, per_writer_bytes=100, base_addr=0x1000):
+        return bcore.TransferContext(
+            rid_slice=(1, 0),
+            slot_id=0,
+            base_addr=base_addr,
+            per_writer_bytes=per_writer_bytes,
+            num_writers=num_writers,
+        )
+
+    def _dst(self, v=10):
+        return dict(dst_ptrs=np.array([v], dtype=np.int64), sizes=np.array([8], dtype=np.int64))
+
+    def test_writer_base_layout(self):
+        c = self._ctx(3, per_writer_bytes=0x64, base_addr=0x1000)
+        assert [c.writer_base(i) for i in range(3)] == [0x1000, 0x1064, 0x10C8]
+
+    def test_single_writer_success_scatters_then_releases(self):
+        c = self._ctx(1)
+        assert not c.ready_to_scatter() and not c.ready_to_settle()
+        c.record_writer_result(3, succeeded=True, src_base=0, **self._dst())
+        assert c.ready_to_scatter()
+        c.begin_scatter()
+        assert not c.ready_to_settle()  # scatter not landed yet
+        c.finish_scatter(True)
+        assert c.ready_to_settle()
+        ret = c.settle()
+        assert ret.disposition is bcore.Disposition.RELEASE and ret.success is True
+        assert c.state is bcore.TransferState.COMPLETED
+        assert c.settle() is None  # idempotent one-shot
+
+    def test_fanin_holds_until_all_terminal(self):
+        c = self._ctx(2)
+        c.record_writer_result(7, succeeded=True, src_base=0, **self._dst())
+        assert not c.ready_to_scatter()  # 1/2 writers
+        assert not c.ready_to_settle()  # drain-before-release
+        c.record_writer_result(3, succeeded=True, src_base=100, **self._dst())
+        assert c.ready_to_scatter()  # all success -> scatter
+
+    def test_fanin_failed_then_success_releases(self):
+        c = self._ctx(2)
+        c.record_writer_result(7, succeeded=False)
+        assert not c.ready_to_settle()  # a sibling is still pending -> hold
+        c.record_writer_result(3, succeeded=True, src_base=0, **self._dst())
+        assert not c.ready_to_scatter()  # >=1 FAILED -> skip scatter
+        assert c.ready_to_settle()
+        ret = c.settle()
+        assert ret.disposition is bcore.Disposition.RELEASE  # all drained -> free, not quarantine
+        assert ret.success is False
+        assert c.state is bcore.TransferState.FAILED
+
+    def test_orphan_quarantines(self):
+        c = self._ctx(2)
+        c.record_writer_result(7, succeeded=True, src_base=0, **self._dst())
+        c.mark_orphaned()  # the other writer is in-doubt
+        assert c.ready_to_settle()
+        ret = c.settle()
+        assert ret.disposition is bcore.Disposition.QUARANTINE and ret.success is False
+        assert c.state is bcore.TransferState.QUARANTINED
+
+    def test_empty_tail_success_releases_without_scatter(self):
+        c = self._ctx(1)
+        c.record_writer_result(3, succeeded=True)  # no dst tail
+        assert not c.ready_to_scatter()
+        assert c.ready_to_settle()
+        assert c.settle().disposition is bcore.Disposition.RELEASE
+
+    def test_writers_locked_after_scatter_drops_late_writer(self):
+        c = self._ctx(1)
+        c.record_writer_result(3, succeeded=True, src_base=0, **self._dst())
+        c.begin_scatter()  # SCATTERING -> frozen
+        c.record_writer_result(9, succeeded=False)  # a late / reordered report
+        assert 9 not in c._writer_ok  # dropped, cannot re-arm the state
+
+    def test_duplicate_writer_dedup(self):
+        c = self._ctx(2)
+        c.record_writer_result(7, succeeded=True, src_base=0, **self._dst())
+        c.record_writer_result(7, succeeded=False)  # same rank again -> ignored
+        assert c._writer_ok[7] is True
+        assert not c.ready_to_settle()  # still only 1 distinct writer of 2
+
+    def test_scatter_failure_releases_as_failed(self):
+        c = self._ctx(1)
+        c.record_writer_result(3, succeeded=True, src_base=0, **self._dst())
+        c.begin_scatter()
+        c.finish_scatter(False)  # scatter kernel failed
+        ret = c.settle()
+        assert ret.disposition is bcore.Disposition.RELEASE and ret.success is False
+
+    def test_orphan_after_scatter_is_ignored(self):
+        # once SCATTERING, all writers already reported SUCCESS -> nothing is in doubt, so a late
+        # orphan (e.g. a racing cancel) must NOT downgrade a clean transfer to quarantine.
+        c = self._ctx(1)
+        c.record_writer_result(3, succeeded=True, src_base=0, **self._dst())
+        c.begin_scatter()
+        c.mark_orphaned()  # no-op after SCATTERING
+        c.finish_scatter(True)
+        assert c.settle().disposition is bcore.Disposition.RELEASE
+
+
+# --------------------------------------------------------------------------- #
+# SlotAllocator quarantine — orphaned regions are held out of reuse for a grace
+# period, then reclaimed off a timer (never handed out while a stray write could land)
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(not _HAVE_TRANSPORT, reason="bounce.buffer import needs CUDA bindings")
+class TestQuarantine:
+    def _alloc(self, monkeypatch, cap):
+        monkeypatch.setattr(
+            bbuf,
+            "Buffer",
+            lambda *a, **k: SimpleNamespace(
+                size=cap, base_ptr=0x1000, reg_descs=lambda: [], close=lambda: None
+            ),
+        )
+        return btr.SlotAllocator(cap, 512)
+
+    def test_quarantined_region_is_not_reused(self, monkeypatch):
+        a = self._alloc(monkeypatch, cap=1024)  # two 512-byte slots
+        a.reserve(512)  # [0, 512) stays live
+        sb, _ = a.reserve(512)  # [512, 1024)
+        a.quarantine(sb, grace_s=float("inf"))  # hold the tail out of reuse
+        assert a.quarantined_bytes == 512
+        # live [0,512) + quarantined [512,1024) => arena full => next reserve can't fit.
+        assert a.reserve(512, timeout=0.05) is None
+
+    def test_reclaim_returns_expired_to_free(self, monkeypatch):
+        a = self._alloc(monkeypatch, cap=512)  # single slot
+        s, _ = a.reserve(512)
+        a.quarantine(s, grace_s=0.0)  # deadline already in the past
+        assert a.reserve(512, timeout=0.05) is None  # still held until reclaimed
+        assert a.reclaim_expired() == 1
+        assert a.quarantined_bytes == 0
+        assert a.reserve(512, timeout=0.5) is not None  # now reusable
+
+    def test_inf_grace_never_reclaims(self, monkeypatch):
+        a = self._alloc(monkeypatch, cap=512)
+        s, _ = a.reserve(512)
+        a.quarantine(s, grace_s=float("inf"))  # close-only reclaim
+        assert a.reclaim_expired() == 0
+        assert a.quarantined_bytes == 512

--- a/tests/unittest/disaggregated/test_transceiver_bounded_polling.py
+++ b/tests/unittest/disaggregated/test_transceiver_bounded_polling.py
@@ -98,6 +98,10 @@ def _make_transceiver(
     transceiver._send_sessions = sessions
     transceiver._send_reqs = reqs or {rid: _FakeRequest() for rid in sessions}
     transceiver._sender_future_timeout_ms = 123
+    # Attributes read by check_context_transfer_status before it processes sessions.
+    transceiver._ever_had_send_session = True
+    transceiver._ctx_need_tp_sync = False
+    transceiver._ctx_need_pp_sync = False
     transceiver._transfer_worker = _FakeTransferWorker()
     transceiver._ctx_consensus = lambda local_ids: list(local_ids)
     transceiver._ctx_consensus_outcome = (
@@ -223,6 +227,63 @@ def test_gen_transfer_status_enters_consensus_when_sync_required() -> None:
     assert failed == []
     assert cancelled == []
     transceiver._gen_consensus.assert_called_once_with([])
+
+
+def test_consensus_outcome_uses_single_batched_allgather() -> None:
+    # The cancelled/failed/completed id lists are exchanged with ONE allgather
+    # (packed as a list-of-lists) instead of three; verify a single call and that
+    # union (cancelled/failed) + intersection (completed) semantics are preserved.
+    transceiver = object.__new__(KvCacheTransceiverV2)
+    calls: list = []
+
+    def fake_allgather(payload):
+        calls.append(payload)
+        # rank0 = this rank's [cancelled, failed, completed]; rank1 = a peer rank.
+        return [payload, [[], [99], [7, 8]]]
+
+    to_process = [1, 2, 7, 8, 99]
+    new_cancelled, new_failed, new_completed = transceiver._consensus_outcome(
+        to_process, [1], [2], [7], fake_allgather, True
+    )
+
+    assert len(calls) == 1  # batched: a single allgather, not three
+    assert calls[0] == [[1], [2], [7]]
+    assert new_cancelled == [1]  # union of cancelled across ranks
+    assert new_failed == [2, 99]  # union of failed across ranks
+    assert new_completed == [7]  # intersection only (8 is completed on the peer only)
+
+
+def test_ctx_consensus_fastpath_skips_when_idle(monkeypatch) -> None:
+    # With the fast-path enabled, an all-zero terminal count (one fixed-size
+    # allreduce) makes every rank skip the variable-length consensus; a non-zero
+    # count falls through to the normal consensus path.
+    monkeypatch.setattr(
+        "tensorrt_llm._torch.disaggregation.transceiver._CTX_CONSENSUS_FASTPATH", True
+    )
+    transceiver = object.__new__(KvCacheTransceiverV2)
+    transceiver._ever_had_send_session = True
+    transceiver._ctx_need_tp_sync = True
+    transceiver._ctx_need_pp_sync = False
+    transceiver._send_sessions = {}
+    transceiver._send_reqs = {}
+    transceiver._dist = Mock()
+    transceiver._dist.allreduce = Mock(return_value=0)
+    transceiver._ctx_consensus = Mock(return_value=[])
+    transceiver._build_to_process = Mock(return_value=[])
+    transceiver._ctx_consensus_outcome = Mock(return_value=([], [], [], []))
+    transceiver._transfer_worker = _FakeTransferWorker()
+    transceiver._close_failed_sessions = Mock()
+
+    completed, failed = transceiver.check_context_transfer_status(at_least_request_num=0)
+
+    assert completed == [] and failed == []
+    transceiver._dist.allreduce.assert_called_once()
+    transceiver._ctx_consensus.assert_not_called()  # idle fast-path skipped the consensus
+
+    # Non-zero global terminal count => fast-path does not skip; consensus runs.
+    transceiver._dist.allreduce = Mock(return_value=2)
+    transceiver.check_context_transfer_status(at_least_request_num=0)
+    transceiver._ctx_consensus.assert_called_once()
 
 
 def test_tx_session_wait_complete_defaults_to_blocking() -> None:

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -1858,6 +1858,15 @@ class TestStrictBaseModelArbitraryArgs:
         assert config.max_tokens_in_buffer == 1024
         assert config.kv_transfer_poll_interval_ms == 5000
 
+        # The bounce on/off switch defaults to off (0), accepts a positive size, and rejects
+        # negatives at the Pydantic boundary (ge=0). It is a Python-only field consumed directly by
+        # the v2 transceiver, so it is intentionally not part of _to_pybind().
+        assert config.kv_cache_bounce_size_mb == 0
+        assert CacheTransceiverConfig(
+            kv_cache_bounce_size_mb=384).kv_cache_bounce_size_mb == 384
+        with pytest.raises(pydantic_core._pydantic_core.ValidationError):
+            CacheTransceiverConfig(kv_cache_bounce_size_mb=-1)
+
         # Arbitrary arguments should be rejected
         with pytest.raises(
                 pydantic_core._pydantic_core.ValidationError) as exc_info:


### PR DESCRIPTION
<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

This pull request introduces a new "KV bounce buffering" subsystem for VRAM disaggregation in the `tensorrt_llm` codebase. The main goal is to optimize device-to-device (d2d) KV cache transfers by coalescing scattered per-block transfers into contiguous, high-throughput writes using a "bounce buffer" allocated in fabric-accessible memory. The changes are structured to be modular, pluggable, and testable, and include configuration, core logic, buffer management, and interface exposure. Additionally, minor improvements are made to C++ bindings for performance metric recording.

**KV Bounce Buffering Subsystem**

* Introduced a new modular subsystem for VRAM d2d KV bounce buffering, allowing opt-in use via configuration. This subsystem coalesces scattered per-block KV transfers into a single contiguous fabric-VMM write, improving transfer reliability and throughput. The default per-block path remains unchanged unless explicitly enabled. (`tensorrt_llm/_torch/disaggregation/native/bounce/__init__.py`)

**Subsystem Core and Buffer Management**

* Added the core logic for the bounce subsystem, including the transport contract, per-region lifetime state machine, and detailed transfer state tracking. This is implemented in a testable, CUDA/NIXL-free module. (`tensorrt_llm/_torch/disaggregation/native/bounce/core.py`)
* Implemented buffer and slot management for fabric-VMM bounce buffers, including thread-safe allocation, quarantine logic for in-doubt regions, and observability features. (`tensorrt_llm/_torch/disaggregation/native/bounce/buffer.py`)

**Configuration and Sizing Policy**

* Added a flexible configuration and sizing policy system, allowing the bounce buffer to be enabled, sized, and tuned based on available memory and chunk size. Provides both fixed and pluggable sizing strategies and ensures the buffer fits within a specified fraction of free memory. (`tensorrt_llm/_torch/disaggregation/native/bounce/config.py`)

**C++ Bindings Enhancement**

* Enhanced the C++ Python bindings to allow the Python-side transceiver to record per-request KV-transfer timing and size metrics, matching the C++ implementation. Overloaded setter methods now allow either explicit or automatic timestamping. (`cpp/tensorrt_llm/nanobind/batch_manager/bindings.cpp`)

| Workload / config | Metric | Non-bounce | Bounce | Gain |
|---|---|---|---|---|
| **Data-plane (raw KV WRITE)** | | | | |
| gpt-oss real (aa-agentperf), 2P2D TP2+TP2, conc 8 | KV-transfer BW | 141.6 GB/s | 557.4 GB/s | **3.94×** |
| gpt-oss real, conc 8 | per-WRITE latency | 4.04 ms | 1.02 ms | **−75% (3.98×)** |
| gpt-oss real, conc 64 (n=27k transfers) | KV-transfer BW | 129.6 GB/s | 497.2 GB/s | **3.84×** |
| Kimi-K2.5 MLA real, conc 64 (n=16.5k) | KV-transfer BW / latency | 204 GB/s / 4.95 ms | 287 GB/s / 3.46 ms | **1.40× / −30%** |
| **End-to-end serving** | | | | |
| Kimi-K2.5 MLA real, conc 8 | TTFT p50 | 6.02 s | 5.39 s | **−10.6%** |
| Kimi-K2.5 MLA real, conc 8 | output throughput | 195 tok/s | 212 tok/s | **+8.6%** |
| Kimi-K2.5 MLA real, conc 8 | e2e latency p50 | 7.81 s | 7.70 s | −1.4% |
| gpt-oss real, conc 64 (6,531 req, 0 err) | e2e latency p50 | 7.575 s | 7.559 s | parity (−0.2%) |

*Steady-state p50, warmup dropped; same bytes/config, only `kv_cache_bounce_size_mb` differs. Raw data-plane KV-WRITE metrics (e2e is at parity — bounce gives ~3.9× transfer bandwidth at zero e2e cost).*

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
