### PR TITLE
Fix/docs stale links

### DIFF
--- a/docs/source/legacy/advanced/disaggregated-service.md
+++ b/docs/source/legacy/advanced/disaggregated-service.md
@@ -10,7 +10,7 @@ Currently TRT-LLM supports `disaggregated-service`, where the context and genera
 
 For more information on disaggregated service in LLM inference, one can refer to papers such as [DistServe](https://arxiv.org/abs/2401.09670), [SplitWise](https://arxiv.org/abs/2311.18677).
 
-An [architectural and performance overview](../../../docs/source/blogs/tech_blog/blog05_Disaggregated_Serving_in_TensorRT-LLM.md), as well as [usage examples](../../../examples/disaggregated/README.md), are provided.
+An [architectural and performance overview](../../blogs/tech_blog/blog05_Disaggregated_Serving_in_TensorRT-LLM.md), as well as [usage examples](../../../../examples/disaggregated/README.md), are provided.
 
 ## Environment Variables
 

--- a/docs/source/torch/kv_cache_manager.md
+++ b/docs/source/torch/kv_cache_manager.md
@@ -51,8 +51,8 @@ There are also interfaces for warming up `PyTorchModelEngine`, especially when u
 ## Customize KV Cache Manager
 
 To customize `KVCacheManager`, implement all the necessary interfaces.
-Then, integrate it into the `PyExecutor`. For the PyTorch backend, the relevant code is in [pytorch_model_registry.py](../../../tensorrt_llm/_torch/pyexecutor/backend_registries/pytorch_model_registry.py).
-In the `create_pytorch_model_based_executor` function, the `KVCacheManager` is instantiated as follows:
+Then, integrate it into the `PyExecutor`. For the PyTorch backend, the relevant code is in [resource_manager.py](../../../tensorrt_llm/_torch/pyexecutor/resource_manager.py).
+The `KVCacheManager` is instantiated as follows:
 
 ```python
     kv_cache_manager = KVCacheManager(


### PR DESCRIPTION
## Description

Two unrelated but similarly-scoped doc link bugs, fixed together.

**1. [`docs/source/legacy/advanced/disaggregated-service.md#L13`](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docs/source/legacy/advanced/disaggregated-service.md#L13) — wrong relative paths**

Both links on line 13 had one extra `../` level, causing them to resolve to non-existent paths:

- `../../../docs/source/blogs/tech_blog/blog05_...` resolved to [`docs/docs/source/blogs/...`](https://github.com/NVIDIA/TensorRT-LLM/tree/main/docs/docs/source/blogs) ❌
- `../../../examples/disaggregated/README.md` resolved to [`docs/examples/disaggregated/README.md`](https://github.com/NVIDIA/TensorRT-LLM/tree/main/docs/examples/disaggregated) ❌

**2. [`docs/source/torch/kv_cache_manager.md#L54`](https://github.com/NVIDIA/TensorRT-LLM/blob/main/docs/source/torch/kv_cache_manager.md#L54) — reference to deleted file**

The "Customize KV Cache Manager" section pointed to `backend_registries/pytorch_model_registry.py` and the function `create_pytorch_model_based_executor`, both of which no longer exist after a refactor. The `KVCacheManager` class now lives in `resource_manager.py`.

## Fix

Corrected the relative paths so they resolve to the actual file locations:

| Link | Before | After |
|------|--------|-------|
| Blog overview | `../../../docs/source/blogs/tech_blog/blog05_...` | `../../blogs/tech_blog/blog05_...` |
| Usage examples | `../../../examples/disaggregated/README.md` | `../../../../examples/disaggregated/README.md` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several guide links to point to the latest documentation and example locations.
  * Refined setup guidance for customizing cache management to reference the current integration path.
  * Kept the rest of the instructions intact for easier navigation and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->