### PR TITLE
[TRTLLM-12352][feat] integrate ModelExpress checkpoint loading

### DIFF
--- a/docker/Dockerfile.multi
+++ b/docker/Dockerfile.multi
@@ -128,7 +128,9 @@ FROM ${DEVEL_IMAGE} AS release
 
 WORKDIR /app/tensorrt_llm
 RUN --mount=type=cache,target=/root/.cache/pip --mount=type=bind,from=wheel,source=/src/tensorrt_llm/build,target=/tmp/wheel \
-    pip install /tmp/wheel/tensorrt_llm*.whl
+    TRTLLM_WHEEL=$(find /tmp/wheel -maxdepth 1 -name 'tensorrt_llm*.whl' -print -quit) && \
+    test -n "${TRTLLM_WHEEL}" && \
+    pip install "${TRTLLM_WHEEL}[mx]"
 
 RUN --mount=type=bind,source=README.md,target=/mnt/ctx/README.md \
     --mount=type=bind,source=docs,target=/mnt/ctx/docs \

--- a/docs/source/features/checkpoint-loading.md
+++ b/docs/source/features/checkpoint-loading.md
@@ -83,12 +83,14 @@ Currently, HF checkpoint loader is the primary built-in format, supporting:
 - **Configuration parser** - Parsing HF stored configuration information to TRTLLM `ModelConfig` object
 - **Weights Mapping** - Converting HF weights into TRTLLM compatible representation
 
-### ModelExpress (MX) Format
+### ModelExpress (MX) Loading Path
 
 The PyTorch backend can use ModelExpress (MX) for peer-to-peer weight transfer
 from a running TensorRT-LLM source instance before falling back to Hugging Face
-checkpoint loading. For installation, MX service deployment, and configuration
-details, see [ModelExpress (MX) Checkpoint Loading](./model-express.md).
+checkpoint loading. Selecting MX does not require an MX-specific on-disk
+checkpoint or conversion of the Hugging Face checkpoint. For installation, MX
+service deployment, and configuration details, see
+[ModelExpress (MX) Checkpoint Loading](./model-express.md).
 
 ## Using Checkpoint Loaders
 

--- a/docs/source/features/checkpoint-loading.md
+++ b/docs/source/features/checkpoint-loading.md
@@ -83,6 +83,13 @@ Currently, HF checkpoint loader is the primary built-in format, supporting:
 - **Configuration parser** - Parsing HF stored configuration information to TRTLLM `ModelConfig` object
 - **Weights Mapping** - Converting HF weights into TRTLLM compatible representation
 
+### ModelExpress (MX) Format
+
+The PyTorch backend can use ModelExpress (MX) for peer-to-peer weight transfer
+from a running TensorRT-LLM source instance before falling back to Hugging Face
+checkpoint loading. For installation, MX service deployment, and configuration
+details, see [ModelExpress (MX) Checkpoint Loading](./model-express.md).
+
 ## Using Checkpoint Loaders
 
 ### Basic Usage

--- a/docs/source/features/model-express.md
+++ b/docs/source/features/model-express.md
@@ -54,7 +54,14 @@ Support for another model family requires a focused qualification change:
 
 ## Installation
 
-MX support is optional. Install the MX Python client through the `mx` extra:
+The official TensorRT-LLM release container includes the MX Python client. No
+additional Python package installation is required in that container. MX
+remains opt-in at runtime: TensorRT-LLM uses the client only when the MX
+checkpoint-loading path and a server URL are configured. Installing the client
+does not expand the model support scope described above.
+
+For pip installations outside the official release container, install the MX
+Python client through the optional `mx` extra:
 
 ```bash
 pip install "tensorrt_llm[mx]"

--- a/docs/source/features/model-express.md
+++ b/docs/source/features/model-express.md
@@ -5,23 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 
 # ModelExpress (MX) Checkpoint Loading
 
-TensorRT-LLM can use ModelExpress (MX) as a checkpoint-loading path for
+The MX checkpoint-loading integration is intended to reduce repeated disk
+reads when multiple TensorRT LLM workers load the same model. A worker that
+loads from disk can publish its weights as an MX source, and later workers can
+receive those weights directly through MX.
+
+TensorRT LLM can use ModelExpress (MX) as a checkpoint-loading path for
 PyTorch backend deployments. `checkpoint_format="MX"` selects this loading
 path; it does not identify an MX-specific on-disk checkpoint format, and no
-checkpoint conversion is required. TensorRT-LLM attempts to fetch compatible
-weights from another running TensorRT-LLM instance through the MX server. If
+checkpoint conversion is required. TensorRT LLM attempts to fetch compatible
+weights from another running TensorRT LLM instance through the MX server. If
 no compatible source is available, or if MX transfer fails, loading falls back
 to the provided Hugging Face checkpoint.
-
-This integration is intended to reduce repeated disk reads when multiple
-TensorRT-LLM workers load the same model. A worker that loads from disk can
-publish its weights as an MX source, and later workers can receive those
-weights directly through MX.
 
 ## Current Support Scope
 
 The post-transform MX receive path currently supports only
-`LlamaForCausalLM` with transform protocol version 1. TensorRT-LLM publishes
+`LlamaForCausalLM` with transform protocol version 1. TensorRT LLM publishes
 post-transform weights together with source-identity and layout metadata. A
 receiver whose model family is not allow-listed does not consume those bytes;
 it falls back to the standard Hugging Face checkpoint path.
@@ -54,9 +54,9 @@ Support for another model family requires a focused qualification change:
 
 ## Installation
 
-The official TensorRT-LLM release container includes the MX Python client. No
+The official TensorRT LLM release container includes the MX Python client. No
 additional Python package installation is required in that container. MX
-remains opt-in at runtime: TensorRT-LLM uses the client only when the MX
+remains opt-in at runtime: TensorRT LLM uses the client only when the MX
 checkpoint-loading path and a server URL are configured. Installing the client
 does not expand the model support scope described above.
 
@@ -73,8 +73,8 @@ API qualified by this integration. Deploy a compatible MX server version.
 ## Deploy the MX Service
 
 Deploy the MX server and its Redis metadata backend independently of
-TensorRT-LLM. One MX service can be shared by multiple TensorRT-LLM launches,
-provided every instance can reach the MX endpoint. TensorRT-LLM does not start,
+TensorRT LLM. One MX service can be shared by multiple TensorRT LLM launches,
+provided every instance can reach the MX endpoint. TensorRT LLM does not start,
 stop, or otherwise manage either service.
 
 The following commands illustrate a standalone Docker deployment. Production
@@ -96,7 +96,7 @@ docker run -d --name modelexpress-server \
   nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.4.1
 ```
 
-## Configure TensorRT-LLM
+## Configure TensorRT LLM
 
 Select the MX checkpoint-loading path and provide the MX server URL in a
 `trtllm-serve` config. The model argument remains a standard Hugging Face model
@@ -115,7 +115,7 @@ trtllm-serve /path/to/model --config config.yaml
 The `MODEL_EXPRESS_URL` environment variable can also provide the server URL
 when `mx_config.server_url` is not set.
 
-Multiple TensorRT-LLM launches can use the same configuration. A worker that
+Multiple TensorRT LLM launches can use the same configuration. A worker that
 does not find a compatible source loads from Hugging Face storage and publishes
 its weights through MX. Later compatible workers can receive those weights by
 P2P transfer.
@@ -129,17 +129,17 @@ path.
 | Field | Default | Description |
 |-------|---------|-------------|
 | `mx_config.server_url` | `null` | URL of the separately managed MX server. |
-| `mx_config.server_query_timeout_s` | `null` | Timeout for MX source discovery. When unset, TensorRT-LLM uses a short fallback cap when no source exists and otherwise lets MX wait for long donor loads. |
+| `mx_config.server_query_timeout_s` | `null` | Timeout for MX source discovery. When unset, TensorRT LLM uses a short fallback cap when no source exists and otherwise lets MX wait for long donor loads. |
 
 ## Notes and Limitations
 
 - Post-transform MX reception is currently limited to the Llama model family.
   Other model families safely fall back to Hugging Face loading until they are
   explicitly qualified and added to the staged-receiver allow-list.
-- The MX server and Redis lifecycle is external to TensorRT-LLM. Every
-  TensorRT-LLM instance must be able to reach the configured MX server URL.
+- The MX server and Redis lifecycle is external to TensorRT LLM. Every
+  TensorRT LLM instance must be able to reach the configured MX server URL.
 - The MX server coordinates source discovery but does not store model weights.
-  A source TensorRT-LLM process must remain running and network-reachable until
+  A source TensorRT LLM process must remain running and network-reachable until
   receiver transfers finish.
 - The first worker may still load weights from disk if no compatible MX source
   is already registered.

--- a/docs/source/features/model-express.md
+++ b/docs/source/features/model-express.md
@@ -64,11 +64,16 @@ For pip installations outside the official release container, install the MX
 Python client through the optional `mx` extra:
 
 ```bash
-pip install "tensorrt_llm[mx]"
+pip install "tensorrt-llm[mx]"
 ```
 
 The extra pins the ModelExpress client to version `0.4.1`, matching the client
 API qualified by this integration. Deploy a compatible MX server version.
+The extra can be added to an existing TensorRT LLM installation. If the MX
+loading path is configured but the client cannot be imported, TensorRT LLM
+fails with an actionable installation message instead of silently loading from
+the Hugging Face checkpoint. Source discovery and transfer failures continue to
+use the Hugging Face fallback described above.
 
 ## Deploy the MX Service
 

--- a/docs/source/features/model-express.md
+++ b/docs/source/features/model-express.md
@@ -1,0 +1,138 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# ModelExpress (MX) Checkpoint Loading
+
+TensorRT-LLM can use ModelExpress (MX) as a checkpoint-loading path for
+PyTorch backend deployments. When `checkpoint_format="MX"` is selected,
+TensorRT-LLM attempts to fetch compatible weights from another running
+TensorRT-LLM instance through the MX server. If no compatible source is
+available, or if MX transfer fails, loading falls back to the standard
+Hugging Face checkpoint path.
+
+This integration is intended to reduce repeated disk reads when multiple
+TensorRT-LLM workers load the same model. A worker that loads from disk can
+publish its weights as an MX source, and later workers can receive those
+weights directly through MX.
+
+## Current Support Scope
+
+The post-transform MX receive path currently supports only
+`LlamaForCausalLM` with transform protocol version 1. TensorRT-LLM publishes
+post-transform weights together with source-identity and layout metadata. A
+receiver whose model family is not allow-listed does not consume those bytes;
+it falls back to the standard Hugging Face checkpoint path.
+
+Loads that require a separately loaded draft model also fall back to the
+standard checkpoint path. Target-plus-draft post-transform transfer remains
+disabled until layout state is tracked and qualified independently for each
+submodel.
+
+### Adding a Model Family
+
+Support for another model family requires a focused qualification change:
+
+1. Audit every post-load hook in the family and its nested modules. Move
+   structural wiring to `setup_aliases()`, one-time tensor-layout changes to
+   `transform_weights()`, and process-local derived state to
+   `cache_derived_state()`.
+2. Verify that every one-time transform is guarded by `_weights_transformed`
+   and that the staged receiver can skip `transform_weights()` without
+   changing aliases, derived state, tensor layout, or outputs.
+3. Add the model class and transform protocol version to the MX staged-receiver
+   allow-list only after full-load and staged-load equivalence tests pass.
+4. Cover compatible transfer, source-identity mismatch, unsupported layout or
+   protocol, and non-allow-listed fallback. Keep target-plus-draft loading
+   disabled unless that combination has its own mixed-layout tests.
+5. Run a real ModelExpress donor/receiver test with the model configurations
+   being claimed, including the supported quantization and TP/PP/EP layouts.
+   Compare deterministic output token IDs with the standard Hugging Face load
+   path before documenting the family as supported.
+
+## Installation
+
+MX support is optional. Install the MX Python client through the `mx` extra:
+
+```bash
+pip install "tensorrt_llm[mx]"
+```
+
+The extra pins the ModelExpress client to version `0.4.1`, matching the client
+API qualified by this integration. Deploy a compatible MX server version.
+
+## Deploy the MX Service
+
+Deploy the MX server and its Redis metadata backend independently of
+TensorRT-LLM. One MX service can be shared by multiple TensorRT-LLM launches,
+provided every instance can reach the MX endpoint. TensorRT-LLM does not start,
+stop, or otherwise manage either service.
+
+The following commands illustrate a standalone Docker deployment. Production
+deployments should manage service lifecycle, persistence, networking, and
+security according to their environment.
+
+```bash
+docker network create modelexpress
+docker run -d --name modelexpress-redis \
+  --network modelexpress \
+  redis:8-alpine
+docker run -d --name modelexpress-server \
+  --network modelexpress \
+  -p 8001:8001 \
+  -e MODEL_EXPRESS_SERVER_PORT=8001 \
+  -e MODEL_EXPRESS_LOG_LEVEL=info \
+  -e MX_METADATA_BACKEND=redis \
+  -e REDIS_URL=redis://modelexpress-redis:6379 \
+  nvcr.io/nvidia/ai-dynamo/modelexpress-server:0.4.1
+```
+
+## Configure TensorRT-LLM
+
+Set the checkpoint format to `MX` and provide the MX server URL in a
+`trtllm-serve` config:
+
+```yaml
+checkpoint_format: MX
+mx_config:
+  server_url: http://mx-server.example.com:8001
+```
+
+```bash
+trtllm-serve /path/to/model --config config.yaml
+```
+
+The `MODEL_EXPRESS_URL` environment variable can also provide the server URL
+when `mx_config.server_url` is not set.
+
+Multiple TensorRT-LLM launches can use the same configuration. A worker that
+does not find a compatible source loads from Hugging Face storage and publishes
+its weights through MX. Later compatible workers can receive those weights by
+P2P transfer.
+
+If neither `mx_config.server_url` nor `MODEL_EXPRESS_URL` is set, MX transfer is
+not attempted and checkpoint loading falls back to the standard Hugging Face
+path.
+
+## Configuration
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `mx_config.server_url` | `null` | URL of the separately managed MX server. |
+| `mx_config.server_query_timeout_s` | `null` | Timeout for MX source discovery. When unset, TensorRT-LLM uses a short fallback cap when no source exists and otherwise lets MX wait for long donor loads. |
+
+## Notes and Limitations
+
+- Post-transform MX reception is currently limited to the Llama model family.
+  Other model families safely fall back to Hugging Face loading until they are
+  explicitly qualified and added to the staged-receiver allow-list.
+- The MX server and Redis lifecycle is external to TensorRT-LLM. Every
+  TensorRT-LLM instance must be able to reach the configured MX server URL.
+- The MX server coordinates source discovery but does not store model weights.
+  A source TensorRT-LLM process must remain running and network-reachable until
+  receiver transfers finish.
+- The first worker may still load weights from disk if no compatible MX source
+  is already registered.
+- This page describes the MX checkpoint-loading path only. GPU Memory Service
+  (GMS) integration is configured separately.

--- a/docs/source/features/model-express.md
+++ b/docs/source/features/model-express.md
@@ -6,11 +6,12 @@ SPDX-License-Identifier: Apache-2.0
 # ModelExpress (MX) Checkpoint Loading
 
 TensorRT-LLM can use ModelExpress (MX) as a checkpoint-loading path for
-PyTorch backend deployments. When `checkpoint_format="MX"` is selected,
-TensorRT-LLM attempts to fetch compatible weights from another running
-TensorRT-LLM instance through the MX server. If no compatible source is
-available, or if MX transfer fails, loading falls back to the standard
-Hugging Face checkpoint path.
+PyTorch backend deployments. `checkpoint_format="MX"` selects this loading
+path; it does not identify an MX-specific on-disk checkpoint format, and no
+checkpoint conversion is required. TensorRT-LLM attempts to fetch compatible
+weights from another running TensorRT-LLM instance through the MX server. If
+no compatible source is available, or if MX transfer fails, loading falls back
+to the provided Hugging Face checkpoint.
 
 This integration is intended to reduce repeated disk reads when multiple
 TensorRT-LLM workers load the same model. A worker that loads from disk can
@@ -90,8 +91,9 @@ docker run -d --name modelexpress-server \
 
 ## Configure TensorRT-LLM
 
-Set the checkpoint format to `MX` and provide the MX server URL in a
-`trtllm-serve` config:
+Select the MX checkpoint-loading path and provide the MX server URL in a
+`trtllm-serve` config. The model argument remains a standard Hugging Face model
+ID or checkpoint path:
 
 ```yaml
 checkpoint_format: MX

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -80,6 +80,7 @@ Welcome to TensorRT LLM's Documentation!
    features/guided-decoding.md
    features/speculative-decoding.md
    features/checkpoint-loading.md
+   features/model-express.md
    features/auto_deploy/auto-deploy.md
    features/auto_deploy/transforms.rst
    features/ray-orchestrator.md

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ required_deps, extra_URLs = parse_requirements(
 devel_deps, _ = parse_requirements(
     Path("requirements-dev-windows.txt"
          if on_windows else "requirements-dev.txt"))
+mx_deps = ["modelexpress==0.4.1"]
 constraints_file = Path("constraints.txt")
 if constraints_file.exists():
     constraints, _ = parse_requirements(constraints_file)
@@ -446,10 +447,7 @@ setup(
     scripts=['tensorrt_llm/llmapi/trtllm-llmapi-launch'],
     extras_require={
         "devel": devel_deps,
-        # MX remains prototype-only and is intentionally not declared as an
-        # optional package extra until its external dependency completes OSS
-        # allowlist onboarding. Keep install instructions in docs/PR text
-        # rather than packaging metadata.
+        "mx": mx_deps,
     },
     zip_safe=True,
     install_requires=required_deps,

--- a/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
@@ -35,7 +35,7 @@ import traceback
 from contextlib import contextmanager
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Iterator, Optional, Type, Union
+from typing import Any, Callable, Iterator, MutableMapping, Optional, Protocol, Type, Union
 
 from tensorrt_llm._torch.models.checkpoints.base_config_loader import BaseConfigLoader
 from tensorrt_llm._torch.models.checkpoints.base_weight_loader import BaseWeightLoader
@@ -76,6 +76,12 @@ class _MxWeightLayoutStatus(Enum):
     UNSUPPORTED = "unsupported"
 
 
+class _MxSourceIdentity(Protocol):
+    """Subset of ModelExpress's protobuf SourceIdentity used by this adapter."""
+
+    extra_parameters: MutableMapping[str, str]
+
+
 @contextmanager
 def _temporary_env(key: str, value: Optional[str]) -> Iterator[None]:
     """Temporarily set one environment variable when a value is provided."""
@@ -103,8 +109,8 @@ def _serialize_source_identity(identity: SourceIdentity) -> str:
 
 
 def _attach_trtllm_metadata_to_mx_identity(
-    mx_identity: Any, source_identity: Optional[SourceIdentity]
-) -> Any:
+    mx_identity: _MxSourceIdentity, source_identity: Optional[SourceIdentity]
+) -> _MxSourceIdentity:
     """Attach TRT-LLM compatibility metadata to an MX SourceIdentity."""
     if source_identity is None:
         return mx_identity
@@ -138,7 +144,7 @@ def _patched_trtllm_identity_builder(
         yield
         return
 
-    def _wrapped_build_identity(*args: Any, **kwargs: Any) -> Any:
+    def _wrapped_build_identity(*args: Any, **kwargs: Any) -> _MxSourceIdentity:
         return _attach_trtllm_metadata_to_mx_identity(
             original(*args, **kwargs),
             source_identity,
@@ -390,10 +396,12 @@ class MXCheckpointLoader(HfCheckpointLoader):
         source_registered = source_metadata is not None
         if not source_registered and self._local_source_identity is not None:
             # ModelExpress 0.4.1 hashes every SourceIdentity field, including
-            # extra_parameters. The upstream loader polls with this same
-            # patched identity, so any source it later discovers necessarily
-            # carries the expected TRT-LLM identity and layout metadata. Keep
-            # the polling path alive so query_timeout_s remains meaningful.
+            # extra_parameters. Proceed to MxLiveWeightLoader.load_weights()
+            # even though this immediate probe found no source: that method
+            # retries list_sources every five seconds until a source appears or
+            # query_timeout_s expires. It uses this same patched identity, so
+            # any source discovered later necessarily carries the expected
+            # TRT-LLM identity and layout metadata.
             source_metadata = _build_mx_source_metadata(self._local_source_identity)
         # Pre-transfer compatibility gate: on mismatch, skip the transfer
         # before any RDMA work starts and fall back to disk.
@@ -625,11 +633,11 @@ class MXCheckpointLoader(HfCheckpointLoader):
     def _build_mx_identity(
         self,
         checkpoint_dir: str,
-        build_identity: Callable[..., Any],
+        build_identity: Callable[..., _MxSourceIdentity],
         source_identity: Optional[SourceIdentity],
         *,
         model_name: Optional[str] = None,
-    ) -> Any:
+    ) -> _MxSourceIdentity:
         """Build the MX identity used for discovery and attach TRT-LLM identity."""
         resolved_name = model_name or self._resolve_publish_name(checkpoint_dir)
         return _attach_trtllm_metadata_to_mx_identity(

--- a/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
@@ -198,9 +198,10 @@ class MXCheckpointLoader(HfCheckpointLoader):
     publishes its weights after `post_load_weights()` runs, together with
     metadata that lets compatible targets skip one-shot post-load transforms.
 
-    When the MX server or library is unavailable, this loader
-    transparently falls back to standard HuggingFace checkpoint
-    loading via the parent `HfCheckpointLoader`.
+    When the MX server is unavailable, this loader transparently falls back
+    to standard HuggingFace checkpoint loading via the parent
+    `HfCheckpointLoader`. A missing MX client is treated as a configuration
+    error and reported with an actionable installation command.
 
     All transport-level mechanics (NIXL, dtype casts, source matching,
     fallback) are delegated to `modelexpress.trtllm_live_transfer`
@@ -352,13 +353,14 @@ class MXCheckpointLoader(HfCheckpointLoader):
             from modelexpress import (
                 trtllm_live_transfer as mx_transfer,  # type: ignore[import-not-found]
             )
-        except ImportError:
-            logger.warning(
-                "modelexpress library not installed; cannot use MX P2P "
-                "weight transfer. Install TensorRT-LLM with the 'mx' extra. "
-                "Falling back to disk loading."
-            )
-            return self._fallback_to_disk(checkpoint_dir, mapping, **kwargs)
+        except ImportError as exc:
+            raise ImportError(
+                "ModelExpress checkpoint loading was explicitly requested, "
+                "but the ModelExpress client could not be imported. Install "
+                'the MX dependencies with `pip install "tensorrt-llm[mx]"`, '
+                "or select a different "
+                "`checkpoint_format` to continue without MX."
+            ) from exc
 
         try:
             with _MX_TRANSFER_STATE_LOCK:

--- a/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
@@ -101,8 +101,15 @@ def _temporary_env(key: str, value: Optional[str]) -> Iterator[None]:
 
 def _serialize_source_identity(identity: SourceIdentity) -> str:
     """Serialize TRT-LLM's layout identity for MX's identity map."""
+    payload = identity.to_dict()
+    # `model_name` is a cleartext discovery descriptor and is deliberately
+    # excluded from SourceIdentity compatibility checks. The outer MX identity
+    # already carries the normalized model name; embedding a local checkpoint
+    # path here would make otherwise-compatible no-shards receivers hash to a
+    # different MX source.
+    payload.pop("model_name", None)
     return json.dumps(
-        identity.to_dict(),
+        payload,
         sort_keys=True,
         separators=(",", ":"),
     )

--- a/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/mx/checkpoint_loader.py
@@ -35,9 +35,7 @@ import traceback
 from contextlib import contextmanager
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Optional, Type, Union
-
-import grpc
+from typing import Any, Callable, Iterator, Optional, Type, Union
 
 from tensorrt_llm._torch.models.checkpoints.base_config_loader import BaseConfigLoader
 from tensorrt_llm._torch.models.checkpoints.base_weight_loader import BaseWeightLoader
@@ -58,10 +56,13 @@ from tensorrt_llm.mapping import Mapping
 # for a source. On a cold cluster (no donor up yet), this means the very
 # first replica blocks for an hour before falling back to disk. We cap
 # the default at 30 s so first-replica startup degrades gracefully; users
-# can still override via the env var or a future per-loader knob.
+# can still override via the env var or the per-loader `query_timeout_s` setting.
 # Tracked as MX-4 in §15 (non-blocking source-query API upstream).
 _MX_SOURCE_QUERY_TIMEOUT_DEFAULT_S = "30"
-_MX_PUBLISH_ENV_LOCK = threading.Lock()
+# ModelExpress 0.4.1 reads transfer configuration from process-wide
+# environment variables and exposes a module-level identity builder. Keep all
+# temporary mutation of that shared state in one critical section.
+_MX_TRANSFER_STATE_LOCK = threading.Lock()
 _MX_SOURCE_IDENTITY_METADATA_KEY = "trtllm_source_identity"
 _MX_WEIGHT_LAYOUT_METADATA_KEY = "trtllm_weight_layout"
 _MX_TRANSFORM_PROTOCOL_VERSION_METADATA_KEY = "trtllm_transform_protocol_version"
@@ -76,8 +77,8 @@ class _MxWeightLayoutStatus(Enum):
 
 
 @contextmanager
-def _temporary_env(key: str, value: Optional[str]):
-    """Temporarily set or clear one environment variable."""
+def _temporary_env(key: str, value: Optional[str]) -> Iterator[None]:
+    """Temporarily set one environment variable when a value is provided."""
     if value is None:
         yield
         return
@@ -90,6 +91,88 @@ def _temporary_env(key: str, value: Optional[str]):
             os.environ.pop(key, None)
         else:
             os.environ[key] = prior
+
+
+def _serialize_source_identity(identity: SourceIdentity) -> str:
+    """Serialize TRT-LLM's layout identity for MX's identity map."""
+    return json.dumps(
+        identity.to_dict(),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _attach_trtllm_metadata_to_mx_identity(
+    mx_identity: Any, source_identity: Optional[SourceIdentity]
+) -> Any:
+    """Attach TRT-LLM compatibility metadata to an MX SourceIdentity."""
+    if source_identity is None:
+        return mx_identity
+
+    extra_parameters = getattr(mx_identity, "extra_parameters", None)
+    if extra_parameters is None:
+        raise RuntimeError(
+            "MX SourceIdentity has no extra_parameters field; cannot attach "
+            "TRT-LLM SourceIdentity for compatibility filtering."
+        )
+
+    try:
+        for key, value in _build_mx_source_metadata(source_identity).items():
+            extra_parameters[key] = value
+    except (AttributeError, TypeError, ValueError) as e:
+        raise RuntimeError(
+            "Failed to attach TRT-LLM compatibility metadata to MX "
+            "SourceIdentity; MX P2P compatibility filtering will reject "
+            "this source."
+        ) from e
+    return mx_identity
+
+
+@contextmanager
+def _patched_trtllm_identity_builder(
+    mx_transfer: Any, source_identity: Optional[SourceIdentity]
+) -> Iterator[None]:
+    """Temporarily wrap upstream TRT-LLM identity construction."""
+    original = getattr(mx_transfer, "_build_trtllm_identity", None)
+    if source_identity is None or not callable(original):
+        yield
+        return
+
+    def _wrapped_build_identity(*args: Any, **kwargs: Any) -> Any:
+        return _attach_trtllm_metadata_to_mx_identity(
+            original(*args, **kwargs),
+            source_identity,
+        )
+
+    mx_transfer._build_trtllm_identity = _wrapped_build_identity
+    try:
+        yield
+    finally:
+        mx_transfer._build_trtllm_identity = original
+
+
+def _close_mx_client(client: Any) -> None:
+    """Close a best-effort MX discovery client without masking its result."""
+    if client is None:
+        return
+    close = getattr(client, "close", None)
+    if not callable(close):
+        return
+    try:
+        close()
+    except Exception:
+        logger.warning(
+            f"Failed to close MX discovery client; continuing with the "
+            f"completed probe result.\n{traceback.format_exc()}"
+        )
+
+
+def _synchronize_cuda_for_mx_publish() -> None:
+    """Finish pending CUDA writes before exposing source buffers through MX."""
+    import torch
+
+    if torch.cuda.is_initialized():
+        torch.cuda.synchronize()
 
 
 @register_checkpoint_loader("MX")
@@ -135,7 +218,7 @@ class MXCheckpointLoader(HfCheckpointLoader):
         # `model_name` is the human-readable identity to publish/look up
         # under on the MX server. Typically the user-supplied
         # `llm_args.model` (a Hub ID like `"Qwen/Qwen2.5-72B-Instruct"`
-        # or a local path). `publish_as_source()` resolves it via
+        # or a local path). Transfer and publish paths resolve it via
         # :func:`_resolve_mx_model_name` (with HF-snapshot path fallback).
         self._model_name = str(model_name) if model_name is not None else None
         self._query_timeout_s = query_timeout_s
@@ -160,9 +243,9 @@ class MXCheckpointLoader(HfCheckpointLoader):
         """Explicit model identity passed to the constructor (if any).
 
         Note this is the *as-configured* value (e.g. `llm_args.model`),
-        not the final resolved identity that ends up in the published
+        not the final resolved identity passed to ModelExpress as
         `MODEL_NAME`. The full resolution (with env var and basename
-        fallbacks) happens inside :meth:`publish_as_source`.
+        fallbacks) happens inside the transfer and publish paths.
         """
         return self._model_name
 
@@ -253,23 +336,65 @@ class MXCheckpointLoader(HfCheckpointLoader):
             )
 
         try:
-            from modelexpress.trtllm_live_transfer import (  # type: ignore[import-not-found]
-                MxClient,
-                MxLiveWeightLoader,
-                _build_trtllm_identity,
+            from modelexpress import (
+                trtllm_live_transfer as mx_transfer,  # type: ignore[import-not-found]
             )
         except ImportError:
             logger.warning(
                 "modelexpress library not installed; cannot use MX P2P "
-                "weight transfer. Install from "
-                "https://github.com/ai-dynamo/modelexpress (Python client at "
-                "modelexpress_client/python). Falling back to disk loading."
+                "weight transfer. Install TensorRT-LLM with the 'mx' extra. "
+                "Falling back to disk loading."
             )
             return self._fallback_to_disk(checkpoint_dir, mapping, **kwargs)
 
-        source_metadata = self._fetch_source_metadata(
-            checkpoint_dir, MxClient, _build_trtllm_identity
-        )
+        try:
+            with _MX_TRANSFER_STATE_LOCK:
+                MxClient = mx_transfer.MxClient
+                MxLiveWeightLoader = mx_transfer.MxLiveWeightLoader
+                build_trtllm_identity = mx_transfer._build_trtllm_identity
+                # Resolve once so discovery and the released ModelExpress
+                # loader query the same source identity. The lock prevents a
+                # concurrent MX publish from temporarily changing MODEL_NAME or
+                # the identity builder while this state is captured.
+                resolved_name = self._resolve_publish_name(checkpoint_dir)
+        except AttributeError:
+            logger.warning(
+                "modelexpress TRT-LLM live-transfer symbols are missing; "
+                "cannot use MX P2P weight transfer. Falling back to disk "
+                "loading."
+            )
+            return self._fallback_to_disk(checkpoint_dir, mapping, **kwargs)
+
+        try:
+            source_metadata = self._fetch_source_metadata(
+                checkpoint_dir,
+                MxClient,
+                build_trtllm_identity,
+                model_name=resolved_name,
+            )
+        except Exception:
+            # Deliberately broad: source discovery is part of the optional MX
+            # fast path, so an upstream client failure must preserve disk
+            # loading as the correctness path.
+            logger.warning(
+                "MX source metadata fetch failed; falling back to disk "
+                f"loading.\n{traceback.format_exc()}"
+            )
+            return self._fallback_to_disk(
+                checkpoint_dir,
+                mapping,
+                reason="MX source metadata probe failed",
+                **kwargs,
+            )
+
+        source_registered = source_metadata is not None
+        if not source_registered and self._local_source_identity is not None:
+            # ModelExpress 0.4.1 hashes every SourceIdentity field, including
+            # extra_parameters. The upstream loader polls with this same
+            # patched identity, so any source it later discovers necessarily
+            # carries the expected TRT-LLM identity and layout metadata. Keep
+            # the polling path alive so query_timeout_s remains meaningful.
+            source_metadata = _build_mx_source_metadata(self._local_source_identity)
         # Pre-transfer compatibility gate: on mismatch, skip the transfer
         # before any RDMA work starts and fall back to disk.
         self._source_identity_compatible_for_last_load = self._source_metadata_identity_compatible(
@@ -327,27 +452,30 @@ class MXCheckpointLoader(HfCheckpointLoader):
             prepare_post_transform_receiver(model)
 
         timeout_override = self._resolve_query_timeout_override(
-            checkpoint_dir,
-            MxClient,
-            _build_trtllm_identity,
+            source_registered=source_registered,
+            model_name=resolved_name,
         )
-        with _temporary_env("MX_SOURCE_QUERY_TIMEOUT", timeout_override):
-            try:
+        try:
+            with (
+                _MX_TRANSFER_STATE_LOCK,
+                _temporary_env("MX_SOURCE_QUERY_TIMEOUT", timeout_override),
+                _temporary_env("MODEL_NAME", resolved_name),
+                _patched_trtllm_identity_builder(mx_transfer, self._local_source_identity),
+            ):
                 mx_loader = MxLiveWeightLoader(mx_server=self._mx_server_url)
                 fallback_weights = mx_loader.load_weights(
                     checkpoint_dir,
                     mapping=mapping,
                     model=model,
                 )
-            except Exception:
-                # Deliberately broad: MX is an opportunistic fast path and HF
-                # disk loading remains the correctness path. Preserve the full
-                # traceback so unexpected upstream failures are diagnosable.
-                logger.warning(
-                    "MX P2P transfer failed; falling back to disk loading.\n"
-                    f"{traceback.format_exc()}"
-                )
-                return self._fallback_to_disk(checkpoint_dir, mapping, **kwargs)
+        except Exception:
+            # Deliberately broad: MX is an opportunistic fast path and HF
+            # disk loading remains the correctness path. Preserve the full
+            # traceback so unexpected upstream failures are diagnosable.
+            logger.warning(
+                f"MX P2P transfer failed; falling back to disk loading.\n{traceback.format_exc()}"
+            )
+            return self._fallback_to_disk(checkpoint_dir, mapping, **kwargs)
 
         if fallback_weights:
             fallback_bytes = sum(
@@ -396,7 +524,10 @@ class MXCheckpointLoader(HfCheckpointLoader):
         return {}
 
     def _resolve_query_timeout_override(
-        self, checkpoint_dir: str, MxClient: Type[Any], build_identity: Callable[..., Any]
+        self,
+        *,
+        source_registered: bool,
+        model_name: str,
     ) -> Optional[str]:
         """Return temporary `MX_SOURCE_QUERY_TIMEOUT` override, if any."""
         if self._query_timeout_s is not None:
@@ -405,63 +536,17 @@ class MXCheckpointLoader(HfCheckpointLoader):
         if os.environ.get("MX_SOURCE_QUERY_TIMEOUT"):
             return None
 
-        if self._has_any_source_instance(checkpoint_dir, MxClient, build_identity):
+        if source_registered:
             return None
 
         logger.warning(
             "No MX source is currently registered for "
-            f"{self._resolve_publish_name(checkpoint_dir)}; "
+            f"{model_name}; "
             f"using MX_SOURCE_QUERY_TIMEOUT={_MX_SOURCE_QUERY_TIMEOUT_DEFAULT_S} "
             "for fast disk fallback. Set mx_config.server_query_timeout_s or "
             "MX_SOURCE_QUERY_TIMEOUT for long-running donor-load deployments."
         )
         return _MX_SOURCE_QUERY_TIMEOUT_DEFAULT_S
-
-    def _has_any_source_instance(
-        self, checkpoint_dir: str, MxClient: Type[Any], build_identity: Callable[..., Any]
-    ) -> bool:
-        """Best-effort fast probe for registered MX source instances."""
-        client = None
-        try:
-            identity = build_identity(model_name=self._resolve_publish_name(checkpoint_dir))
-            client = MxClient(server_url=self._mx_server_url)
-            list_resp = client.list_sources(identity=identity)
-            return bool(getattr(list_resp, "instances", []))
-        except (AttributeError, RuntimeError, TimeoutError, grpc.RpcError):
-            # If the probe cannot complete, prefer fast fallback over the
-            # upstream 1-hour default. The actual MxLiveWeightLoader call below
-            # remains the source of truth and may still succeed.
-            logger.warning(
-                f"MX source probe failed; using fast fallback timeout.\n{traceback.format_exc()}"
-            )
-            return False
-        finally:
-            if client is not None and hasattr(client, "close"):
-                client.close()
-
-    def _source_identity_compatible(
-        self, checkpoint_dir: str, MxClient: Type[Any], build_identity: Callable[..., Any]
-    ) -> bool:
-        """Whether the MX source's identity is compatible with this receiver.
-
-        Compares the receiver's local :class:`SourceIdentity` against the
-        publisher's via `check_weight_sharing_compatibility` with the `WARN_FALLBACK`
-        policy.
-
-        Args:
-            checkpoint_dir: The checkpoint directory identifying the source.
-            MxClient: The MX discovery client type (forwarded to the fetch
-                seam).
-            build_identity: Builder used to derive the publisher identity
-                (forwarded to the fetch seam).
-
-        Returns:
-            `True` to proceed with P2P only when both identities are present
-            and compatible. `False` when either identity is missing or the
-            identities mismatch, so the caller falls back to disk loading.
-        """
-        source_identity = self._fetch_source_identity(checkpoint_dir, MxClient, build_identity)
-        return self._source_identity_compatible_with_source(source_identity)
 
     def _source_metadata_identity_compatible(self, metadata: Optional[dict[str, Any]]) -> bool:
         source_identity = _source_identity_from_metadata(metadata)
@@ -478,30 +563,23 @@ class MXCheckpointLoader(HfCheckpointLoader):
         )
         return decision.should_share
 
-    def _fetch_source_identity(
-        self, checkpoint_dir: str, MxClient: Type[Any], build_identity: Callable[..., Any]
-    ) -> Optional[SourceIdentity]:
-        """Fetch the publisher's serialized :class:`SourceIdentity`.
-
-        Args:
-            checkpoint_dir: The checkpoint directory identifying the source.
-            MxClient: The MX discovery client type.
-            build_identity: Builder used to derive the publisher identity.
-
-        Returns:
-            The publisher's identity, or `None` when it cannot be fetched
-            yet (the compatibility gate then rejects P2P and falls back).
-        """
-        metadata = self._fetch_source_metadata(checkpoint_dir, MxClient, build_identity)
-        return _source_identity_from_metadata(metadata)
-
     def _fetch_source_metadata(
-        self, checkpoint_dir: str, MxClient: Type[Any], build_identity: Callable[..., Any]
+        self,
+        checkpoint_dir: str,
+        MxClient: Type[Any],
+        build_identity: Callable[..., Any],
+        *,
+        model_name: Optional[str] = None,
     ) -> Optional[dict[str, Any]]:
         """Fetch TRT-LLM metadata for the selected MX source, if available."""
         client = None
         try:
-            identity = build_identity(model_name=self._resolve_publish_name(checkpoint_dir))
+            identity = self._build_mx_identity(
+                checkpoint_dir,
+                build_identity,
+                self._local_source_identity,
+                model_name=model_name,
+            )
             client = MxClient(server_url=self._mx_server_url)
             for method_name in ("get_source_metadata", "get_metadata", "get_worker_metadata"):
                 method = getattr(client, method_name, None)
@@ -510,7 +588,13 @@ class MXCheckpointLoader(HfCheckpointLoader):
                 try:
                     metadata = method(identity=identity)
                 except TypeError:
-                    metadata = method(identity)
+                    try:
+                        metadata = method(identity)
+                    except TypeError:
+                        # modelexpress 0.4.1 get_metadata() takes
+                        # mx_source_id/worker_id rather than an identity. Fall
+                        # through to the exact-identity list_sources query.
+                        continue
                 metadata_dict = _metadata_to_dict(metadata)
                 if _metadata_has_trtllm_key(metadata_dict):
                     return metadata_dict
@@ -522,16 +606,36 @@ class MXCheckpointLoader(HfCheckpointLoader):
                 metadata_dict = _source_instance_metadata(instance)
                 if metadata_dict:
                     metadata_candidates.append(metadata_dict)
-            return self._select_source_metadata(metadata_candidates)
-        except (AttributeError, RuntimeError, TimeoutError, TypeError, ValueError, grpc.RpcError):
-            logger.warning(
-                f"MX source metadata fetch failed; falling back to disk loading.\n"
-                f"{traceback.format_exc()}"
-            )
+            selected_metadata = self._select_source_metadata(metadata_candidates)
+            if selected_metadata is not None:
+                return selected_metadata
+
+            # modelexpress 0.4.1 SourceInstanceRef intentionally omits the
+            # queried SourceIdentity. A non-empty response still proves an
+            # exact match because list_sources hashes every identity field,
+            # including extra_parameters. Reconstruct the metadata that was
+            # embedded in the exact query so the compatibility/layout checks
+            # remain fail-closed without a second metadata channel.
+            if instances and self._local_source_identity is not None:
+                return _build_mx_source_metadata(self._local_source_identity)
             return None
         finally:
-            if client is not None and hasattr(client, "close"):
-                client.close()
+            _close_mx_client(client)
+
+    def _build_mx_identity(
+        self,
+        checkpoint_dir: str,
+        build_identity: Callable[..., Any],
+        source_identity: Optional[SourceIdentity],
+        *,
+        model_name: Optional[str] = None,
+    ) -> Any:
+        """Build the MX identity used for discovery and attach TRT-LLM identity."""
+        resolved_name = model_name or self._resolve_publish_name(checkpoint_dir)
+        return _attach_trtllm_metadata_to_mx_identity(
+            build_identity(model_name=resolved_name),
+            source_identity,
+        )
 
     def _select_source_metadata(
         self, metadata_candidates: list[dict[str, Any]]
@@ -602,70 +706,71 @@ class MXCheckpointLoader(HfCheckpointLoader):
             return
 
         try:
-            from modelexpress.trtllm_live_transfer import (
-                publish_model_params,  # type: ignore[import-not-found]
+            from modelexpress import (
+                trtllm_live_transfer as mx_transfer,  # type: ignore[import-not-found]
             )
         except ImportError:
             logger.debug("modelexpress library not installed; skipping MX publish.")
+            return
+        try:
+            publish_model_params = mx_transfer.publish_model_params
+        except AttributeError:
+            logger.debug("modelexpress publish_model_params is missing; skipping MX publish.")
             return
 
         # THREADSAFETY: upstream publish_model_params reads MODEL_EXPRESS_URL and
         # MODEL_NAME from the environment. Set both from our resolved
         # configuration so per-instance values (URL passed via
         # llm_args.mx_config.server_url, identity from llm_args.model) are
-        # respected, then restore prior state. This is safe for the current
-        # sequential TRT-LLM worker path, but co-resident ranks in one Python
-        # interpreter would race on process-wide env. Tracked as MX-2 in §15
-        # (the env-var dance goes away when upstream exports a public identity
-        # builder / publish API).
-        resolved_name = self._resolve_publish_name(checkpoint_dir)
+        # respected, then restore prior state. MX transfer and publish calls in
+        # this interpreter are serialized while upstream requires process-wide
+        # state. Tracked as MX-2 in §15 (the env-var dance goes away when
+        # upstream exports a public identity builder / publish API).
         metadata = _build_mx_source_metadata(source_identity)
-        metadata_kwargs = _publish_metadata_kwargs(publish_model_params, metadata)
-        if metadata_kwargs is None:
+        metadata_kwargs = _publish_metadata_kwargs(publish_model_params, metadata) or {}
+        identity_builder = getattr(mx_transfer, "_build_trtllm_identity", None)
+        if not metadata_kwargs and not callable(identity_builder):
             logger.warning(
                 "Skipping MX post-transform publish because "
-                "publish_model_params does not accept metadata; receivers "
-                "cannot safely verify transformed weights."
+                "publish_model_params does not accept metadata and MX does "
+                "not expose its TRT-LLM identity builder; receivers cannot "
+                "safely verify transformed weights."
             )
             return
 
-        env_overrides = {
-            "MODEL_EXPRESS_URL": self._mx_server_url,
-            "MODEL_NAME": resolved_name,
-        }
         if threading.active_count() > 1:
             logger.warning_once(
                 "MX publish uses process-wide MODEL_EXPRESS_URL/MODEL_NAME "
-                "environment variables; concurrent publish calls in one Python "
-                "process are serialized, but unrelated env readers can still "
-                "observe transient values. Tracked by MX-2.",
+                "environment variables; concurrent MX transfer and publish calls "
+                "in one Python process are serialized, but unrelated env readers "
+                "can still observe transient values. Tracked by MX-2.",
                 key="mx_publish_env_threaded_warning",
             )
-        with _MX_PUBLISH_ENV_LOCK:
-            prior = {key: os.environ.get(key) for key in env_overrides}
-            for key, value in env_overrides.items():
-                os.environ[key] = value
-
-            try:
-                publish_model_params(model, **metadata_kwargs)
+        try:
+            with _MX_TRANSFER_STATE_LOCK:
+                resolved_name = self._resolve_publish_name(checkpoint_dir)
+                # Post-load transforms may enqueue asynchronous writes. Make
+                # the source buffers globally ready before MX publishes their
+                # addresses and allows a receiver to issue RDMA reads.
+                _synchronize_cuda_for_mx_publish()
+                with (
+                    _temporary_env("MODEL_EXPRESS_URL", self._mx_server_url),
+                    _temporary_env("MODEL_NAME", resolved_name),
+                    _patched_trtllm_identity_builder(mx_transfer, source_identity),
+                ):
+                    publish_model_params(model, **metadata_kwargs)
                 logger.info(
                     "Published post-transform weights to MX server at %s as model=%r",
                     self._mx_server_url,
                     resolved_name,
                 )
-            except Exception:
-                # Deliberately broad: publish is best-effort. A publish failure
-                # should not fail the local worker that already loaded weights.
-                logger.warning(
-                    f"Failed to publish weights to MX server at {self._mx_server_url}.\n"
-                    f"{traceback.format_exc()}"
-                )
-            finally:
-                for key, prior_value in prior.items():
-                    if prior_value is None:
-                        os.environ.pop(key, None)
-                    else:
-                        os.environ[key] = prior_value
+        except Exception:
+            # Deliberately broad: publish is best-effort. A publish failure
+            # should not fail the local worker that already loaded weights.
+            logger.warning(
+                f"Failed to publish weights to MX server at {self._mx_server_url}.\n"
+                f"{traceback.format_exc()}"
+            )
 
     def post_load_publish(
         self,
@@ -761,9 +866,7 @@ def _build_mx_source_metadata(source_identity: Optional[SourceIdentity]) -> dict
         _MX_TRANSFORM_PROTOCOL_VERSION_METADATA_KEY: str(_MX_STAGED_TRANSFORM_PROTOCOL_VERSION),
     }
     if source_identity is not None:
-        metadata[_MX_SOURCE_IDENTITY_METADATA_KEY] = json.dumps(
-            source_identity.to_dict(), sort_keys=True
-        )
+        metadata[_MX_SOURCE_IDENTITY_METADATA_KEY] = _serialize_source_identity(source_identity)
     return metadata
 
 

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -4832,7 +4832,9 @@ class TorchLlmArgs(BaseLlmArgs):
     checkpoint_format: Optional[str] = Field(
         default=None,
         description=
-        "The format of the provided checkpoint. You may use a custom checkpoint format by subclassing "
+        "The registered checkpoint loader format to use. `MX` selects ModelExpress as an opportunistic P2P "
+        "loading path and falls back to loading the provided Hugging Face checkpoint; it does not require "
+        "converting that checkpoint to an MX-specific format. You may use a custom checkpoint format by subclassing "
         "`BaseCheckpointLoader` and registering it with `register_checkpoint_loader`.\n"
         "If neither checkpoint_format nor checkpoint_loader are provided, checkpoint_format will be set to HF "
         "and the default HfCheckpointLoader will be used.\n"

--- a/tests/unittest/_torch/executor/test_model_loader_mx.py
+++ b/tests/unittest/_torch/executor/test_model_loader_mx.py
@@ -17,6 +17,7 @@ from utils.post_transform_qualification import (
 
 from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models import modeling_llama as modeling_llama_mod
+from tensorrt_llm._torch.models.checkpoints.mx.checkpoint_loader import MXCheckpointLoader
 from tensorrt_llm._torch.modules import mla as mla_mod
 from tensorrt_llm._torch.modules.linear import Linear
 from tensorrt_llm._torch.modules.mla import MLA
@@ -204,6 +205,26 @@ def _make_loader(monkeypatch, *, events, spec_config=None):
         lambda: SimpleNamespace(synchronize=lambda: None),
     )
     return loader
+
+
+def test_construct_checkpoint_loader_passes_mx_config():
+    mx_config = SimpleNamespace(
+        server_url="http://mx:8001",
+        server_query_timeout_s=17,
+    )
+
+    checkpoint_loader = model_loader_mod._construct_checkpoint_loader(
+        "pytorch",
+        None,
+        "MX",
+        mx_config=mx_config,
+        mx_model_name="Qwen/Qwen2.5-7B-Instruct",
+    )
+
+    assert isinstance(checkpoint_loader, MXCheckpointLoader)
+    assert checkpoint_loader.mx_server_url == "http://mx:8001"
+    assert checkpoint_loader.query_timeout_s == 17
+    assert checkpoint_loader.model_name == "Qwen/Qwen2.5-7B-Instruct"
 
 
 def test_mx_success_initializes_mapper_skips_weight_mapping_and_reload_works(monkeypatch):
@@ -417,6 +438,12 @@ def test_mx_post_transform_receiver_falls_back_for_unqualified_model(monkeypatch
     assert load_fn == model.load_weights
     assert weights == {"disk.weight": checkpoint_loader._disk_weight}
     assert mapper is loader.weight_mapper
+    checkpoint_loader.post_load_publish.assert_called_once_with(
+        model,
+        checkpoint_dir="/ckpt",
+        weights_preloaded=False,
+        source_identity=loader._source_identity,
+    )
     assert events == ["load_weights", "post_load_weights"]
     checkpoint_loader.post_load_publish.assert_not_called()
 

--- a/tests/unittest/_torch/executor/test_model_loader_mx.py
+++ b/tests/unittest/_torch/executor/test_model_loader_mx.py
@@ -438,12 +438,6 @@ def test_mx_post_transform_receiver_falls_back_for_unqualified_model(monkeypatch
     assert load_fn == model.load_weights
     assert weights == {"disk.weight": checkpoint_loader._disk_weight}
     assert mapper is loader.weight_mapper
-    checkpoint_loader.post_load_publish.assert_called_once_with(
-        model,
-        checkpoint_dir="/ckpt",
-        weights_preloaded=False,
-        source_identity=loader._source_identity,
-    )
     assert events == ["load_weights", "post_load_weights"]
     checkpoint_loader.post_load_publish.assert_not_called()
 

--- a/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
+++ b/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
@@ -10,7 +10,7 @@
 
 These tests intentionally do not exercise the upstream modelexpress library.
 The import-failure path blocks modelexpress symbols from sys.modules so the
-assertion is about our fallback behavior, not the upstream API.
+assertion is about our dependency handling, not the upstream API.
 """
 
 import json
@@ -190,11 +190,6 @@ class TestLoadWeightsFallback:
         return MXCheckpointLoader(mx_server_url="http://mx:8001"), {}
 
     @staticmethod
-    def _modelexpress_unavailable(stack):
-        stack.enter_context(_block_modelexpress())
-        return (MXCheckpointLoader(mx_server_url="http://mx:8001"), {"model": MagicMock()})
-
-    @staticmethod
     def _upstream_raises(stack):
         identity = _identity()
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
@@ -221,14 +216,12 @@ class TestLoadWeightsFallback:
         [
             ("no_mx_server_url", _no_url),
             ("no_model_kwarg", _no_model),
-            ("modelexpress_not_installed", _modelexpress_unavailable),
             ("source_probe_raises", _source_probe_raises),
             ("upstream_raises", _upstream_raises),
         ],
         ids=[
             "no-mx-server-url",
             "no-model-kwarg",
-            "modelexpress-not-installed",
             "source-probe-raises",
             "upstream-raises",
         ],
@@ -251,6 +244,25 @@ class TestLoadWeightsFallback:
             f"trigger={trigger_id}: is_weights_preloaded() must stay False on any fallback path"
         )
         mock_super_load.assert_called_once()
+
+    def test_missing_modelexpress_client_fails_with_install_hint(self):
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        with (
+            _block_modelexpress(),
+            patch.object(HfCheckpointLoader, "load_weights") as mock_super_load,
+            pytest.raises(ImportError) as exc_info,
+        ):
+            loader.load_weights(
+                "/nonexistent",
+                mapping=MagicMock(),
+                model=MagicMock(),
+            )
+
+        message = str(exc_info.value)
+        assert 'pip install "tensorrt-llm[mx]"' in message
+        assert "select a different `checkpoint_format`" in message
+        assert loader.is_weights_preloaded() is False
+        mock_super_load.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
+++ b/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
@@ -40,6 +40,7 @@ from tensorrt_llm._torch.models.checkpoints.mx.checkpoint_loader import (
     _build_mx_source_metadata,
     _normalize_model_identity,
     _resolve_mx_model_name,
+    _serialize_source_identity,
 )
 from tensorrt_llm._torch.weight_sharing import SourceIdentity
 
@@ -653,9 +654,9 @@ class TestPublishAsSource:
 
         assert calls == [model]
         metadata = captured["identity"].extra_parameters
-        assert metadata[_MX_SOURCE_IDENTITY_METADATA_KEY] == json.dumps(
-            source_identity.to_dict(), sort_keys=True, separators=(",", ":")
-        )
+        serialized_identity = json.loads(metadata[_MX_SOURCE_IDENTITY_METADATA_KEY])
+        assert "model_name" not in serialized_identity
+        assert SourceIdentity.from_dict(serialized_identity).matches(source_identity).matched
         assert metadata[_MX_WEIGHT_LAYOUT_METADATA_KEY] == _MX_WEIGHT_LAYOUT_POST_TRANSFORM
         assert metadata[_MX_TRANSFORM_PROTOCOL_VERSION_METADATA_KEY] == str(
             _MX_STAGED_TRANSFORM_PROTOCOL_VERSION
@@ -727,7 +728,9 @@ class TestPublishAsSource:
             )
 
         serialized = captured["identity"].extra_parameters["trtllm_source_identity"]
-        assert SourceIdentity.from_dict(json.loads(serialized)) == source_identity
+        published_identity = SourceIdentity.from_dict(json.loads(serialized))
+        assert published_identity.model_name is None
+        assert published_identity.matches(source_identity).matched
         assert (
             captured["identity"].extra_parameters[_MX_WEIGHT_LAYOUT_METADATA_KEY]
             == _MX_WEIGHT_LAYOUT_POST_TRANSFORM
@@ -735,6 +738,20 @@ class TestPublishAsSource:
         assert captured["identity"].extra_parameters[
             _MX_TRANSFORM_PROTOCOL_VERSION_METADATA_KEY
         ] == str(_MX_STAGED_TRANSFORM_PROTOCOL_VERSION)
+
+    def test_serialized_identity_ignores_local_checkpoint_path(self):
+        donor_identity = _identity()
+        receiver_identity = SourceIdentity(
+            **{
+                **donor_identity.to_dict(),
+                "model_name": "/tmp/no-shards/TinyLlama",
+            }
+        )
+
+        assert donor_identity.model_name != receiver_identity.model_name
+        assert _serialize_source_identity(donor_identity) == _serialize_source_identity(
+            receiver_identity
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
+++ b/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
@@ -890,7 +890,10 @@ class TestMxSourceQueryTimeoutDefault:
                 model=MagicMock(),
                 source_identity=identity,
                 allow_post_transform_weights=True,
+                prepare_post_transform_receiver=lambda _model: None,
             )
+        mx_loader = fake_mx.trtllm_live_transfer.MxLiveWeightLoader.return_value
+        mx_loader.load_weights.assert_called_once()
         assert "MX_SOURCE_QUERY_TIMEOUT" not in os.environ
 
     def test_no_registered_source_honors_configured_timeout(self):
@@ -909,7 +912,10 @@ class TestMxSourceQueryTimeoutDefault:
                 model=MagicMock(),
                 source_identity=identity,
                 allow_post_transform_weights=True,
+                prepare_post_transform_receiver=lambda _model: None,
             )
+        mx_loader = fake_mx.trtllm_live_transfer.MxLiveWeightLoader.return_value
+        mx_loader.load_weights.assert_called_once()
         assert "MX_SOURCE_QUERY_TIMEOUT" not in os.environ
 
     def test_existing_source_keeps_upstream_default_when_unset(self):

--- a/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
+++ b/tests/unittest/_torch/models/checkpoints/mx/test_mx_checkpoint_loader.py
@@ -13,6 +13,7 @@ The import-failure path blocks modelexpress symbols from sys.modules so the
 assertion is about our fallback behavior, not the upstream API.
 """
 
+import json
 import os
 import sys
 from contextlib import ExitStack
@@ -28,6 +29,7 @@ from tensorrt_llm._torch.models.checkpoints.hf.qwen3_next_weight_mapper import (
     Qwen3NextHfWeightMapper,
 )
 from tensorrt_llm._torch.models.checkpoints.hf.weight_mapper import HfWeightMapper
+from tensorrt_llm._torch.models.checkpoints.mx import checkpoint_loader as mx_checkpoint_loader
 from tensorrt_llm._torch.models.checkpoints.mx.checkpoint_loader import (
     _MX_SOURCE_IDENTITY_METADATA_KEY,
     _MX_STAGED_TRANSFORM_PROTOCOL_VERSION,
@@ -44,24 +46,36 @@ from tensorrt_llm._torch.weight_sharing import SourceIdentity
 _MISSING = object()
 
 
-def _identity(rank: int = 0) -> SourceIdentity:
+def _identity(rank: int = 0, suffix: str = "same") -> SourceIdentity:
     return SourceIdentity(
         format_version=1,
-        model_fingerprint="model",
-        quant_fingerprint="quant",
-        backend_fingerprint="backend",
-        parallel_fingerprint="parallel",
+        model_fingerprint=f"model-{suffix}",
+        quant_fingerprint=f"quant-{suffix}",
+        backend_fingerprint=f"backend-{suffix}",
+        parallel_fingerprint=f"parallel-{suffix}",
         rank=rank,
-        shard_fingerprint=f"shard-{rank}",
+        shard_fingerprint=f"shard-{rank}-{suffix}",
         model_name="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
     )
 
 
-def _source_instance(identity: SourceIdentity, *, post_transform: bool = True):
-    metadata = _build_mx_source_metadata(identity)
-    if not post_transform:
-        metadata[_MX_WEIGHT_LAYOUT_METADATA_KEY] = "pre_transform"
-    return SimpleNamespace(metadata=metadata)
+def _source_identity(rank=0, suffix="same"):
+    return _identity(rank=rank, suffix=suffix)
+
+
+def _source_instance(
+    identity: SourceIdentity | None = None, *, post_transform: bool = True, rank=0
+):
+    if identity is not None:
+        metadata = _build_mx_source_metadata(identity)
+        if not post_transform:
+            metadata[_MX_WEIGHT_LAYOUT_METADATA_KEY] = "pre_transform"
+        return SimpleNamespace(metadata=metadata, worker_rank=identity.rank)
+    return SimpleNamespace(
+        mx_source_id=f"source-{rank}",
+        worker_id=f"worker-{rank}",
+        worker_rank=rank,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -160,7 +174,7 @@ class TestMxMapperFallback:
 class TestLoadWeightsFallback:
     """Disk-fallback paths that should not touch the upstream MX library.
 
-    All four fallback triggers share the same observable contract:
+    All fallback triggers share the same observable contract:
     is_weights_preloaded() stays False, HfCheckpointLoader.load_weights is
     invoked exactly once, and its return value is propagated unchanged.
     """
@@ -190,18 +204,31 @@ class TestLoadWeightsFallback:
         stack.enter_context(_install_fake_modelexpress(fake_mx))
         return (loader, {"model": MagicMock(), "source_identity": identity})
 
+    @staticmethod
+    def _source_probe_raises(stack):
+        identity = _identity()
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        fake_mx = _build_fake_modelexpress()
+        fake_mx.trtllm_live_transfer.MxClient.return_value.list_sources.side_effect = RuntimeError(
+            "server unavailable"
+        )
+        stack.enter_context(_install_fake_modelexpress(fake_mx))
+        return (loader, {"model": MagicMock(), "source_identity": identity})
+
     @pytest.mark.parametrize(
         "trigger_id, setup",
         [
             ("no_mx_server_url", _no_url),
             ("no_model_kwarg", _no_model),
             ("modelexpress_not_installed", _modelexpress_unavailable),
+            ("source_probe_raises", _source_probe_raises),
             ("upstream_raises", _upstream_raises),
         ],
         ids=[
             "no-mx-server-url",
             "no-model-kwarg",
             "modelexpress-not-installed",
+            "source-probe-raises",
             "upstream-raises",
         ],
     )
@@ -580,6 +607,24 @@ class TestPublishAsSource:
         )
         assert _MX_SOURCE_IDENTITY_METADATA_KEY in metadata
 
+    def test_publish_synchronizes_cuda_before_exposing_source(self, monkeypatch):
+        events = []
+        monkeypatch.setattr(
+            mx_checkpoint_loader,
+            "_synchronize_cuda_for_mx_publish",
+            lambda: events.append("synchronize"),
+        )
+
+        def _publish(*_args, **_kwargs):
+            events.append("publish")
+
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        fake_mx = _build_fake_modelexpress(publish_side_effect=_publish)
+        with _install_fake_modelexpress(fake_mx):
+            loader.publish_as_source(MagicMock(), source_identity=_identity())
+
+        assert events == ["synchronize", "publish"]
+
     def test_source_identity_required_for_post_transform_publish(self):
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
         fake_mx = _build_fake_modelexpress()
@@ -589,18 +634,32 @@ class TestPublishAsSource:
 
         fake_mx.trtllm_live_transfer.publish_model_params.assert_not_called()
 
-    def test_publish_skipped_when_metadata_unsupported(self):
+    def test_publish_without_metadata_kwarg_uses_identity_metadata(self):
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
         calls = []
+        captured = {}
 
         def _publish_without_metadata(model):
             calls.append(model)
+            captured["identity"] = fake_mx.trtllm_live_transfer._build_trtllm_identity(
+                model_name="local-model"
+            )
 
         fake_mx = _build_fake_modelexpress(publish_model_params=_publish_without_metadata)
+        source_identity = _identity()
         with _install_fake_modelexpress(fake_mx):
-            loader.publish_as_source(MagicMock(), source_identity=_identity())
+            model = MagicMock()
+            loader.publish_as_source(model, source_identity=source_identity)
 
-        assert calls == []
+        assert calls == [model]
+        metadata = captured["identity"].extra_parameters
+        assert metadata[_MX_SOURCE_IDENTITY_METADATA_KEY] == json.dumps(
+            source_identity.to_dict(), sort_keys=True, separators=(",", ":")
+        )
+        assert metadata[_MX_WEIGHT_LAYOUT_METADATA_KEY] == _MX_WEIGHT_LAYOUT_POST_TRANSFORM
+        assert metadata[_MX_TRANSFORM_PROTOCOL_VERSION_METADATA_KEY] == str(
+            _MX_STAGED_TRANSFORM_PROTOCOL_VERSION
+        )
 
     def test_env_var_set_during_publish_then_restored(self):
         loader = MXCheckpointLoader(mx_server_url="http://mx-instance:9999")
@@ -647,6 +706,35 @@ class TestPublishAsSource:
 
         with _install_fake_modelexpress(fake_mx):
             loader.publish_as_source(MagicMock(), source_identity=_identity())  # must not raise
+
+    def test_publish_attaches_trtllm_source_identity_to_mx_identity(self):
+        source_identity = _source_identity()
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
+        loader._local_source_identity = source_identity
+        captured = {}
+
+        def _publish_side_effect(model, **_kwargs):
+            identity = fake_mx.trtllm_live_transfer._build_trtllm_identity(model_name="local-model")
+            captured["identity"] = identity
+
+        fake_mx = _build_fake_modelexpress(publish_side_effect=_publish_side_effect)
+
+        with _install_fake_modelexpress(fake_mx):
+            loader.publish_as_source(
+                MagicMock(),
+                checkpoint_dir="/scratch/local-model",
+                source_identity=source_identity,
+            )
+
+        serialized = captured["identity"].extra_parameters["trtllm_source_identity"]
+        assert SourceIdentity.from_dict(json.loads(serialized)) == source_identity
+        assert (
+            captured["identity"].extra_parameters[_MX_WEIGHT_LAYOUT_METADATA_KEY]
+            == _MX_WEIGHT_LAYOUT_POST_TRANSFORM
+        )
+        assert captured["identity"].extra_parameters[
+            _MX_TRANSFORM_PROTOCOL_VERSION_METADATA_KEY
+        ] == str(_MX_STAGED_TRANSFORM_PROTOCOL_VERSION)
 
 
 # ---------------------------------------------------------------------------
@@ -711,7 +799,9 @@ def _build_fake_modelexpress(
     if source_metadata is not None:
         client_instance.get_source_metadata.return_value = source_metadata
     fake_trtllm_live.MxClient = MagicMock(return_value=client_instance)
-    fake_trtllm_live._build_trtllm_identity = MagicMock(return_value=MagicMock())
+    fake_trtllm_live._build_trtllm_identity = MagicMock(
+        return_value=SimpleNamespace(extra_parameters={})
+    )
 
     # publish_model_params(model)
     if publish_model_params is not None:
@@ -767,8 +857,6 @@ class TestMxSourceQueryTimeoutDefault:
 
     def test_no_registered_source_gets_short_default_during_load(self):
         identity = _identity()
-        source_metadata = _build_mx_source_metadata(identity)
-        source_metadata[_MX_WEIGHT_LAYOUT_METADATA_KEY] = "pre_transform"
 
         def _assert_timeout(*args, **kwargs):
             assert os.environ.get("MX_SOURCE_QUERY_TIMEOUT") == "30"
@@ -777,7 +865,6 @@ class TestMxSourceQueryTimeoutDefault:
         loader = MXCheckpointLoader(mx_server_url="http://mx:8001")
         fake_mx = _build_fake_modelexpress(
             load_weights_side_effect=_assert_timeout,
-            source_metadata=source_metadata,
         )
         with _install_fake_modelexpress(fake_mx):
             loader.load_weights(
@@ -785,6 +872,26 @@ class TestMxSourceQueryTimeoutDefault:
                 mapping=MagicMock(),
                 model=MagicMock(),
                 source_identity=identity,
+                allow_post_transform_weights=True,
+            )
+        assert "MX_SOURCE_QUERY_TIMEOUT" not in os.environ
+
+    def test_no_registered_source_honors_configured_timeout(self):
+        identity = _identity()
+
+        def _assert_timeout(*args, **kwargs):
+            assert os.environ.get("MX_SOURCE_QUERY_TIMEOUT") == "900"
+            return {}
+
+        loader = MXCheckpointLoader(mx_server_url="http://mx:8001", query_timeout_s=900)
+        fake_mx = _build_fake_modelexpress(load_weights_side_effect=_assert_timeout)
+        with _install_fake_modelexpress(fake_mx):
+            loader.load_weights(
+                "/nonexistent",
+                mapping=MagicMock(),
+                model=MagicMock(),
+                source_identity=identity,
+                allow_post_transform_weights=True,
             )
         assert "MX_SOURCE_QUERY_TIMEOUT" not in os.environ
 
@@ -963,6 +1070,39 @@ class TestResolveMxModelName:
         # If the explicit arg looks like a path (e.g. llm_args.model
         # was a Path), it gets normalized too.
         assert _resolve_mx_model_name("/scratch/explicit-path", "/cache/ignored") == "explicit-path"
+
+
+class TestLoadWeightsModelName:
+    def test_uses_resolved_model_name_during_load_and_restores_env(self, monkeypatch):
+        monkeypatch.setenv("MODEL_NAME", "prior-model")
+        identity = _identity()
+        snapshot = "/cache/hub/models--Other--Model/snapshots/abc123"
+
+        def _assert_model_name(*args, **kwargs):
+            assert os.environ.get("MODEL_NAME") == "Qwen/Qwen2.5-72B-Instruct"
+            return {}
+
+        loader = MXCheckpointLoader(
+            mx_server_url="http://mx:8001",
+            model_name="Qwen/Qwen2.5-72B-Instruct",
+        )
+        fake_mx = _build_fake_modelexpress(
+            load_weights_side_effect=_assert_model_name,
+            source_instances=[_source_instance(identity, post_transform=False)],
+        )
+
+        with _install_fake_modelexpress(fake_mx):
+            loader.load_weights(
+                snapshot,
+                mapping=MagicMock(),
+                model=MagicMock(),
+                source_identity=identity,
+            )
+
+        assert os.environ.get("MODEL_NAME") == "prior-model"
+        fake_mx.trtllm_live_transfer._build_trtllm_identity.assert_called_with(
+            model_name="Qwen/Qwen2.5-72B-Instruct"
+        )
 
 
 class TestPublishAsSourceModelName:

--- a/tests/unittest/_torch/weight_sharing/test_mx_source_identity_gate.py
+++ b/tests/unittest/_torch/weight_sharing/test_mx_source_identity_gate.py
@@ -14,12 +14,9 @@
 # limitations under the License.
 """Exercise the real MX checkpoint loader pre-transfer SourceIdentity gate.
 
-These tests drive `MXCheckpointLoader._source_identity_compatible` directly —
-the single decision point the MX `load_weights` path consults before starting
-a P2P transfer. Upstream `modelexpress` is never imported: the discovery
-client / identity builder are passed as stubs, and the publisher-identity fetch
-seam is patched, so the gate logic runs against real `SourceIdentity` objects
-without any model, GPU, or RDMA.
+Upstream `modelexpress` is never imported. The tests run the compatibility
+decision against real `SourceIdentity` objects and use a small discovery
+client stub for the pinned ModelExpress 0.4.1 API shape.
 """
 
 from types import SimpleNamespace
@@ -33,50 +30,44 @@ from tensorrt_llm._torch.models.checkpoints.mx.checkpoint_loader import (
 )
 
 
-def _new_loader(local_identity, source_identity, fetched=True):
-    """Construct a loader bypassing heavy base __init__, wire the seams."""
+def _new_loader(local_identity):
+    """Construct a loader while bypassing the heavy base initializer."""
     loader = MXCheckpointLoader.__new__(MXCheckpointLoader)
     loader._local_source_identity = local_identity
-    # Patch the single fetch seam to return the publisher identity (or None).
-    loader._fetch_source_identity = lambda *a, **k: source_identity if fetched else None
     return loader
-
-
-# MxClient / build_identity are only forwarded to the (patched) fetch seam.
-_STUB_CLIENT = object()
-_STUB_BUILD = object()
 
 
 def test_gate_proceeds_on_matching_identity():
     local = _identity(attn_backend="TRTLLM")
     source = _identity(attn_backend="TRTLLM")
-    loader = _new_loader(local, source)
-    assert loader._source_identity_compatible("ckpt", _STUB_CLIENT, _STUB_BUILD) is True
+    loader = _new_loader(local)
+    assert loader._source_metadata_identity_compatible(_build_mx_source_metadata(source)) is True
 
 
 def test_gate_falls_back_on_mismatch():
     local = _identity(attn_backend="TRTLLM")
     source = _identity(attn_backend="FLASHINFER")
-    loader = _new_loader(local, source)
-    assert loader._source_identity_compatible("ckpt", _STUB_CLIENT, _STUB_BUILD) is False
+    loader = _new_loader(local)
+    assert loader._source_metadata_identity_compatible(_build_mx_source_metadata(source)) is False
 
 
 def test_gate_falls_back_when_no_local_identity():
     # MX must not consume shared weights unless the receiver identity exists.
-    loader = _new_loader(None, _identity())
-    assert loader._source_identity_compatible("ckpt", _STUB_CLIENT, _STUB_BUILD) is False
+    loader = _new_loader(None)
+    assert (
+        loader._source_metadata_identity_compatible(_build_mx_source_metadata(_identity())) is False
+    )
 
 
 def test_gate_falls_back_when_source_identity_unavailable():
-    # Publisher identity not yet fetchable (upstream metadata channel pending);
-    # reject P2P and fall back to disk rather than sharing unverified weights.
+    loader = _new_loader(_identity())
+    assert loader._source_metadata_identity_compatible(None) is False
+
+
+def test_fetch_source_metadata_supports_modelexpress_0_4_1_client_shape_and_close_failure():
     local = _identity()
-    loader = _new_loader(local, None, fetched=False)
-    assert loader._source_identity_compatible("ckpt", _STUB_CLIENT, _STUB_BUILD) is False
-
-
-def test_fetch_source_identity_returns_none_when_metadata_unavailable():
     loader = MXCheckpointLoader.__new__(MXCheckpointLoader)
+    loader._local_source_identity = local
     loader._mx_server_url = "http://mx:8001"
     loader._model_name = None
 
@@ -84,27 +75,24 @@ def test_fetch_source_identity_returns_none_when_metadata_unavailable():
         def __init__(self, *, server_url):
             self.server_url = server_url
 
-        def list_sources(self, *, identity):
-            return SimpleNamespace(instances=[])
-
-    assert loader._fetch_source_identity("ckpt", _Client, lambda **_kw: object()) is None
-
-
-def test_fetch_source_identity_from_source_metadata():
-    source = _identity()
-    loader = MXCheckpointLoader.__new__(MXCheckpointLoader)
-    loader._mx_server_url = "http://mx:8001"
-    loader._model_name = None
-
-    class _Client:
-        def __init__(self, *, server_url):
-            self.server_url = server_url
+        def get_metadata(self, mx_source_id, worker_id):
+            raise AssertionError("ID-based metadata lookup should not be used for identity queries")
 
         def list_sources(self, *, identity):
-            instance = SimpleNamespace(metadata=_build_mx_source_metadata(source))
-            return SimpleNamespace(instances=[instance])
+            return SimpleNamespace(
+                instances=[SimpleNamespace(mx_source_id="source", worker_id="worker")]
+            )
 
-    assert loader._fetch_source_identity("ckpt", _Client, lambda **_kw: object()) == source
+        def close(self):
+            raise RuntimeError("close failed")
+
+    metadata = loader._fetch_source_metadata(
+        "ckpt",
+        _Client,
+        lambda **_kw: SimpleNamespace(extra_parameters={}),
+    )
+
+    assert metadata == _build_mx_source_metadata(local)
 
 
 def test_load_weights_pops_source_identity_kwarg():


### PR DESCRIPTION
## Summary

Integrate optional ModelExpress (MX) checkpoint loading for the TensorRT-LLM PyTorch backend.

MX is treated as a separately deployed shared service. Operators start and manage the MX server and its Redis metadata backend, then configure each TensorRT-LLM launch with the MX server URL. TensorRT-LLM does not start or own MX/Redis processes or containers.

## Deployment Model

| Configuration | Behavior |
|---|---|
| `mx_config.server_url` is set | Use that MX server for source discovery, P2P receive, and publish. |
| `MODEL_EXPRESS_URL` is set and no explicit URL is configured | Resolve it into `mx_config.server_url` and use that server. |
| No MX URL is configured | Skip MX transfer and use Hugging Face checkpoint loading. |
| MX discovery or transfer fails | Fall back to Hugging Face checkpoint loading. |
| `checkpoint_format` is not `MX` | Existing checkpoint behavior is unchanged. |

One MX server can be shared by multiple TensorRT-LLM launches that can reach the endpoint. A worker that does not find a compatible source loads from storage and publishes its weights; later compatible workers can receive them through MX.

## Changes

- Add the optional `mx` package extra with `modelexpress==0.4.1`:
  ```bash
  pip install "tensorrt_llm[mx]"
  ```
- Pass `mx_config.server_url`, `MODEL_EXPRESS_URL`, query timeout, and model identity through the MX checkpoint loader.
- Support the released ModelExpress 0.4.1 client source-query shape and keep polling for a compatible donor when none is registered yet.
- Attach TRT-LLM `SourceIdentity`, weight-layout, and transform-protocol metadata so incompatible publishers are rejected before transfer.
- Serialize temporary process-wide MX environment and identity-builder state across load and publish calls.
- Synchronize pending CUDA writes before exposing post-transform source buffers through MX.
- Preserve Hugging Face fallback when source discovery, transfer, or optional client cleanup fails.
- Preserve mixed-transfer fallback behavior for pre-transform sources and reject unsafe partial post-transform transfers.
- Document independent MX/Redis deployment, shared-server configuration, and source-process lifetime requirements.
- Add focused unit coverage for URL propagation, source discovery, identity compatibility, timeout behavior, transfer, publish ordering, and fallback.

## Current Scope

- Post-transform MX reception is qualified for `LlamaForCausalLM` with transform protocol version 1.
- Other model families fall back to Hugging Face loading until their staged loading hooks and runtime layouts are qualified.
- Loads requiring a separately loaded draft model also fall back.
- Artifact identity is not yet bound to immutable checkpoint contents or a resolved revision; that remains follow-up work before general content-safe deployment.

## Validation

Completed on reviewed head `3388328514`:

- All scoped pre-commit hooks passed, including formatting, lint, codespell, test-list validation, private-key checks, and DCO.
- Python syntax compilation passed for the modified MX implementation and tests.
- `git diff --check` passed.
- Focused pytest could not run in the local macOS environment because the TensorRT-LLM runtime dependencies (`torch` and `transformers`) are not installed.
- No `/bot run` CI rerun was requested for the reviewed head.

## Related Work

- Staged model hook migration landed in [#15432](https://github.com/NVIDIA/TensorRT-LLM/pull/15432).
