### PR TITLE
[None][feat] add CI-enforced stability gate for trtllm-serve CLI options

### DIFF
--- a/tensorrt_llm/commands/_serve_stability.py
+++ b/tensorrt_llm/commands/_serve_stability.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Stability-tag plumbing for the `trtllm-serve` CLI.
+
+This module gives every Click option on `trtllm-serve` an explicit, machine-readable
+stability status (`stable | beta | prototype | deprecated`). The status is:
+
+  1. rendered in `--help` (via `help_info_with_stability_tag`), and
+  2. attached to the option as metadata so a CI test can diff the live CLI surface
+     against a checked-in reference YAML (`tests/unittest/api_stability/references/
+     trtllm_serve_cli.yaml`).
+
+Use `stability_option(...)` as a *required* drop-in replacement for `@click.option`
+when adding new options to any `trtllm-serve` subcommand. Plain `@click.option` is
+deliberately not banned in this PR, but the stability checker will fail if a CLI
+option is missing from the reference YAML — which forces the contributor to make
+an explicit status choice.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Callable, Literal
+
+import click
+
+StabilityTag = Literal["stable", "beta", "prototype", "deprecated"]
+
+ALLOWED_TAGS: tuple[StabilityTag, ...] = ("stable", "beta", "prototype", "deprecated")
+
+# Attribute name we stamp on every Click option for the stability checker to read.
+# Using a private attribute keeps it invisible to Click's own machinery.
+_STABILITY_ATTR = "_trtllm_stability"
+
+
+def help_info_with_stability_tag(help_str: str, tag: StabilityTag) -> str:
+    """Append stability info to the help string.
+
+    Kept here (rather than in `serve.py`) so any tooling that needs to read the
+    raw tag can import it from a single place.
+    """
+    if tag not in ALLOWED_TAGS:
+        raise ValueError(f"Invalid stability tag {tag!r}; must be one of {ALLOWED_TAGS}.")
+    return f":tag:`{tag}` {help_str}"
+
+
+def stability_option(*param_decls: str, status: StabilityTag, help: str, **kwargs: Any) -> Callable:
+    """A `@click.option` wrapper that **requires** an explicit stability status.
+
+    Differences from bare `@click.option`:
+      * `status=` is a mandatory keyword argument.
+      * `help=` is also required (so the rendered help carries the stability tag).
+      * The chosen status is stamped onto the resulting `click.Option` instance
+        as `option._trtllm_stability`, so the stability checker can read it back.
+
+    Example::
+
+        @stability_option("--max_batch_size",
+                           type=int,
+                           default=None,
+                           status="beta",
+                           help="Maximum number of requests per batch.")
+        def serve(..., max_batch_size: int | None, ...): ...
+    """
+    if status not in ALLOWED_TAGS:
+        raise ValueError(f"Invalid stability tag {status!r}; must be one of {ALLOWED_TAGS}.")
+
+    tagged_help = help_info_with_stability_tag(help, status)
+    click_decorator = click.option(*param_decls, help=tagged_help, **kwargs)
+
+    def decorator(f: Callable) -> Callable:
+        wrapped = click_decorator(f)
+        # Click stores the new param at the end of __click_params__; stamp it.
+        params = getattr(wrapped, "__click_params__", None)
+        if params:
+            setattr(params[-1], _STABILITY_ATTR, status)
+        return wrapped
+
+    return decorator
+
+
+# Anchored to the start of the help string. `help_info_with_stability_tag(...)`
+# always prepends the tag, so a documented `:tag:`...`` PREFIX is the only
+# valid legacy form. Using `search()` here would accidentally bless an
+# unwrapped `@click.option` whose help text happens to mention the markup
+# anywhere in its body.
+_HELP_TAG_RE = re.compile(r"^:tag:`(stable|beta|prototype|deprecated)`(?:\s|$)")
+
+
+def get_option_stability(option: click.Option) -> StabilityTag | None:
+    """Return the stability tag attached to a Click option, or None if absent.
+
+    Two sources, in order of preference:
+
+    1. The `_trtllm_stability` attribute, stamped by `stability_option(...)`.
+    2. A `:tag:`<status>`` PREFIX on the rendered help string, produced by
+       the legacy `help_info_with_stability_tag` helper. This lets us cover
+       options that were tagged before `stability_option` existed, without
+       forcing a single-PR refactor of every option site. The marker must
+       appear at position 0; an embedded ``:tag:`stable``` inside an
+       otherwise untagged help string is not accepted.
+
+    Returns None for options created via bare `@click.option` (no tag, no
+    legacy helper). The stability checker treats `None` as a violation.
+    """
+    explicit = getattr(option, _STABILITY_ATTR, None)
+    if explicit is not None:
+        return explicit
+    help_text = option.help or ""
+    match = _HELP_TAG_RE.match(help_text)
+    if match:
+        return match.group(1)  # type: ignore[return-value]
+    return None
+
+
+def collect_command_options(command: click.Command) -> dict[str, dict[str, Any]]:
+    """Introspect a Click command and return a mapping of option-name -> spec.
+
+    The returned spec is the on-disk YAML representation used by the stability
+    checker. Each entry contains: ``status``, ``type``, ``default``,
+    ``required``, ``multiple``, ``is_flag``, and ``flags``.
+
+    ``flags`` is the full sorted list of CLI surface strings users actually
+    type (e.g. ``["--tensor_parallel_size", "--tp_size"]`` or
+    ``["--no-telemetry", "--telemetry"]``). The stability gate diffs this
+    list so that renaming or removing an *alias* — even when the canonical
+    ``param.name`` is preserved — fails the build. Without it, dropping
+    ``--tp_size`` or ``--revision`` would silently slip through.
+
+    Positional arguments (``click.Argument``) are skipped — they're part of
+    the invocation contract and don't carry a stability tag in the same way.
+    """
+    out: dict[str, dict[str, Any]] = {}
+    for param in command.params:
+        if not isinstance(param, click.Option):
+            continue
+        name = param.name
+        # `param.opts` is every CLI surface form Click accepts (primary +
+        # aliases, both ``--long`` and ``-s`` styles). `param.secondary_opts`
+        # is the ``--no-foo`` half of a ``--foo/--no-foo`` flag pair. Sort
+        # for diff stability.
+        flags = sorted((param.opts or []) + (param.secondary_opts or []))
+        out[name] = {
+            "status": get_option_stability(param),
+            "type": _format_type(param.type),
+            "default": _format_default(param.default),
+            "required": bool(param.required),
+            "multiple": bool(param.multiple),
+            "is_flag": bool(param.is_flag),
+            "flags": flags,
+        }
+    return out
+
+
+def _format_type(t: Any) -> str:
+    """Render a Click ParamType to a short, stable string for the YAML."""
+    if isinstance(t, click.types.IntParamType):
+        return "int"
+    if isinstance(t, click.types.FloatParamType):
+        return "float"
+    if isinstance(t, click.types.BoolParamType):
+        return "bool"
+    if isinstance(t, click.types.StringParamType):
+        return "str"
+    if isinstance(t, click.Choice):
+        return f"Choice({sorted(t.choices)!r})"
+    if isinstance(t, click.Path):
+        return "Path"
+    # Fall back to the type's name attribute.
+    return getattr(t, "name", t.__class__.__name__)
+
+
+def _format_default(value: Any) -> Any:
+    """Render a Click default to a YAML-serializable form.
+
+    Special-case Click's ``UNSET`` sentinel (the marker for "no default
+    given") so it surfaces as plain ``None`` in the YAML rather than an enum
+    object that ``yaml.safe_dump`` cannot represent. This matters for options
+    like ``multiple=True`` with no explicit ``default=``, where Click stores
+    ``UNSET`` and only materializes ``()`` at parse time.
+    """
+    # Click >= 8.2 stores "no default" as a Sentinel enum. Treat it as None.
+    _unset = getattr(click.core, "UNSET", None)
+    if _unset is not None and value is _unset:
+        return None
+    if callable(value):
+        # ``default_factory``-style callables: record their fully-qualified name
+        # rather than the live object, so the YAML stays stable across runs.
+        mod = getattr(value, "__module__", "")
+        qual = getattr(value, "__qualname__", repr(value))
+        return f"<callable:{mod}.{qual}>" if mod else f"<callable:{qual}>"
+    if isinstance(value, (tuple, list)):
+        return list(value)
+    return value

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -11,7 +11,7 @@ import subprocess  # nosec B404
 import sys
 import uuid
 from pathlib import Path
-from typing import Any, Dict, Literal, Mapping, Optional, Sequence, Set
+from typing import Any, Dict, Mapping, Optional, Sequence, Set
 
 import click
 import torch
@@ -23,6 +23,7 @@ from tensorrt_llm import LLM as PyTorchLLM
 from tensorrt_llm import MultimodalEncoder
 from tensorrt_llm._tensorrt_engine import LLM
 from tensorrt_llm._utils import mpi_rank
+from tensorrt_llm.commands._serve_stability import stability_option
 from tensorrt_llm.commands.utils import (collect_explicit_cli_keys,
                                          get_is_diffusion_only_model)
 from tensorrt_llm.executor.utils import LlmLauncherEnvs
@@ -80,13 +81,6 @@ def _apply_fastapi_middlewares(app, middlewares: Sequence[str]) -> None:
         else:
             raise ValueError(f"Invalid middleware {middleware}. "
                              "Must be a class or an async function.")
-
-
-def help_info_with_stability_tag(
-        help_str: str, tag: Literal["stable", "beta", "prototype",
-                                    "deprecated"]) -> str:
-    """Append stability info to help string."""
-    return f":tag:`{tag}` {help_str}"
 
 
 def _signal_handler_cleanup_child(signum, frame):
@@ -633,327 +627,315 @@ class ChoiceWithAlias(click.Choice):
 
 @click.command("serve")
 @click.argument("model", type=str)
-@click.option(
+@stability_option(
     "--tokenizer",
     type=str,
     default=None,
-    help=help_info_with_stability_tag(
-        "Path or name of the tokenizer. When using the PyTorch backend, "
-        "this replaces the default HuggingFace tokenizer.", "beta"))
-@click.option(
+    help="Path or name of the tokenizer. When using the PyTorch backend, "
+    "this replaces the default HuggingFace tokenizer.",
+    status="beta")
+@stability_option(
     "--custom_tokenizer",
     type=str,
     default=None,
-    help=help_info_with_stability_tag(
-        "Custom tokenizer type: alias (e.g., 'deepseek_v32') or Python import path "
-        "(e.g., 'tensorrt_llm.tokenizer.deepseek_v32.DeepseekV32Tokenizer').",
-        "prototype"))
-@click.option(
+    help=
+    "Custom tokenizer type: alias (e.g., 'deepseek_v32') or Python import path "
+    "(e.g., 'tensorrt_llm.tokenizer.deepseek_v32.DeepseekV32Tokenizer').",
+    status="prototype")
+@stability_option(
     "--post_processor_hook",
     type=str,
     default=None,
-    help=help_info_with_stability_tag(
-        "Python import path of a user post-processing hook applied after "
-        "detokenization and before the per-endpoint response formatter (e.g. "
-        "'my_pkg.guardrail.MyPostProcessorHook'). The class must be importable "
-        "and picklable, take no constructor arguments, and be callable as "
-        "'__call__(chunk) -> verdict' (see tensorrt_llm.executor.postprocessor_hook). "
-        "It runs once per output, per streaming chunk, and may rewrite, "
-        "suppress, or terminate the output; it owns its own per-request state.",
-        "prototype"))
-@click.option("--host",
-              type=str,
-              default="localhost",
-              help=help_info_with_stability_tag("Hostname of the server.",
-                                                "beta"))
-@click.option("--port",
-              type=int,
-              default=8000,
-              help=help_info_with_stability_tag("Port of the server.", "beta"))
-@click.option(
+    help="Python import path of a user post-processing hook applied after "
+    "detokenization and before the per-endpoint response formatter (e.g. "
+    "'my_pkg.guardrail.MyPostProcessorHook'). The class must be importable "
+    "and picklable, take no constructor arguments, and be callable as "
+    "'__call__(chunk) -> verdict' (see tensorrt_llm.executor.postprocessor_hook). "
+    "It runs once per output, per streaming chunk, and may rewrite, "
+    "suppress, or terminate the output; it owns its own per-request state.",
+    status="prototype")
+@stability_option("--host",
+                  type=str,
+                  default="localhost",
+                  help="Hostname of the server.",
+                  status="beta")
+@stability_option("--port",
+                  type=int,
+                  default=8000,
+                  help="Port of the server.",
+                  status="beta")
+@stability_option(
     "--backend",
     type=ChoiceWithAlias(["pytorch", "tensorrt", "_autodeploy"],
                          {"trt": "tensorrt"}),
     default="pytorch",
-    help=help_info_with_stability_tag(
-        "The backend to use to serve the model. Default is pytorch backend.",
-        "beta"))
-@click.option(
-    "--custom_module_dirs",
-    type=click.Path(exists=True,
-                    readable=True,
-                    path_type=Path,
-                    resolve_path=True),
-    default=None,
-    multiple=True,
-    help=help_info_with_stability_tag(
-        "Paths to custom module directories to import.", "prototype"),
-)
-@click.option('--log_level',
-              type=click.Choice(severity_map.keys()),
-              default='info',
-              help=help_info_with_stability_tag("The logging level.", "beta"))
-@click.option("--max_beam_width",
-              type=int,
-              default=BuildConfig.model_fields["max_beam_width"].default,
-              help=help_info_with_stability_tag(
-                  "Maximum number of beams for beam search decoding.", "beta"))
-@click.option("--max_batch_size",
-              type=int,
-              default=BuildConfig.model_fields["max_batch_size"].default,
-              help=help_info_with_stability_tag(
-                  "Maximum number of requests that the engine can schedule.",
-                  "beta"))
-@click.option(
+    help="The backend to use to serve the model. Default is pytorch backend.",
+    status="beta")
+@stability_option("--custom_module_dirs",
+                  type=click.Path(exists=True,
+                                  readable=True,
+                                  path_type=Path,
+                                  resolve_path=True),
+                  default=None,
+                  multiple=True,
+                  help="Paths to custom module directories to import.",
+                  status="prototype")
+@stability_option('--log_level',
+                  type=click.Choice(severity_map.keys()),
+                  default='info',
+                  help="The logging level.",
+                  status="beta")
+@stability_option("--max_beam_width",
+                  type=int,
+                  default=BuildConfig.model_fields["max_beam_width"].default,
+                  help="Maximum number of beams for beam search decoding.",
+                  status="beta")
+@stability_option(
+    "--max_batch_size",
+    type=int,
+    default=BuildConfig.model_fields["max_batch_size"].default,
+    help="Maximum number of requests that the engine can schedule.",
+    status="beta")
+@stability_option(
     "--max_num_tokens",
     type=int,
     default=BuildConfig.model_fields["max_num_tokens"].default,
-    help=help_info_with_stability_tag(
-        "Maximum number of batched input tokens after padding is removed in each batch.",
-        "beta"))
-@click.option(
+    help=
+    "Maximum number of batched input tokens after padding is removed in each batch.",
+    status="beta")
+@stability_option(
     "--max_seq_len",
     type=int,
     default=BuildConfig.model_fields["max_seq_len"].default,
-    help=help_info_with_stability_tag(
-        "Maximum total length of one request, including prompt and outputs. "
-        "If unspecified, the value is deduced from the model config.", "beta"))
-@click.option("--tensor_parallel_size",
-              "--tp_size",
-              type=int,
-              default=1,
-              help=help_info_with_stability_tag('Tensor parallelism size.',
-                                                'beta'))
-@click.option("--pipeline_parallel_size",
-              "--pp_size",
-              type=int,
-              default=1,
-              help=help_info_with_stability_tag('Pipeline parallelism size.',
-                                                'beta'))
-@click.option("--context_parallel_size",
-              "--cp_size",
-              type=int,
-              default=1,
-              help=help_info_with_stability_tag('Context parallelism size.',
-                                                'beta'))
-@click.option("--moe_expert_parallel_size",
-              "--ep_size",
-              type=int,
-              default=None,
-              help=help_info_with_stability_tag("expert parallelism size",
-                                                "beta"))
-@click.option(
+    help="Maximum total length of one request, including prompt and outputs. "
+    "If unspecified, the value is deduced from the model config.",
+    status="beta")
+@stability_option("--tensor_parallel_size",
+                  "--tp_size",
+                  type=int,
+                  default=1,
+                  help='Tensor parallelism size.',
+                  status='beta')
+@stability_option("--pipeline_parallel_size",
+                  "--pp_size",
+                  type=int,
+                  default=1,
+                  help='Pipeline parallelism size.',
+                  status='beta')
+@stability_option("--context_parallel_size",
+                  "--cp_size",
+                  type=int,
+                  default=1,
+                  help='Context parallelism size.',
+                  status='beta')
+@stability_option("--moe_expert_parallel_size",
+                  "--ep_size",
+                  type=int,
+                  default=None,
+                  help="expert parallelism size",
+                  status="beta")
+@stability_option(
     "--moe_cluster_parallel_size",
     "--cluster_size",
     type=int,
     default=None,
-    help=help_info_with_stability_tag(
-        "[Deprecated] Expert cluster parallelism size. "
-        "This option is no longer supported and will be removed in a future release.",
-        "deprecated"))
-@click.option(
+    help="[Deprecated] Expert cluster parallelism size. "
+    "This option is no longer supported and will be removed in a future release.",
+    status="deprecated")
+@stability_option(
     "--gpus_per_node",
     type=int,
     default=None,
-    help=help_info_with_stability_tag(
-        "Number of GPUs per node. Default to None, and it will be detected automatically.",
-        "beta"))
-@click.option("--free_gpu_memory_fraction",
-              "--kv_cache_free_gpu_memory_fraction",
-              type=float,
-              default=0.9,
-              help=help_info_with_stability_tag(
-                  "Free GPU memory fraction reserved for KV Cache, "
-                  "after allocating model weights and buffers.", "beta"))
-@click.option(
+    help=
+    "Number of GPUs per node. Default to None, and it will be detected automatically.",
+    status="beta")
+@stability_option("--free_gpu_memory_fraction",
+                  "--kv_cache_free_gpu_memory_fraction",
+                  type=float,
+                  default=0.9,
+                  help="Free GPU memory fraction reserved for KV Cache, "
+                  "after allocating model weights and buffers.",
+                  status="beta")
+@stability_option(
     "--kv_cache_dtype",
     type=click.Choice(("auto", "fp8", "nvfp4")),
     default="auto",
-    help=help_info_with_stability_tag(
-        "KV cache quantization dtype for PyTorch backend. "
-        "'auto' uses checkpoint/model metadata; explicit values force override.",
-        "prototype"))
-@click.option("--num_postprocess_workers",
-              type=int,
-              default=0,
-              help=help_info_with_stability_tag(
-                  "Number of workers to postprocess raw responses "
-                  "to comply with OpenAI protocol.", "prototype"))
-@click.option("--trust_remote_code",
-              is_flag=True,
-              default=False,
-              help=help_info_with_stability_tag("Flag for HF transformers.",
-                                                "beta"))
-@click.option("--hf_revision",
-              "--revision",
-              "revision",
-              type=str,
-              default=None,
-              help=help_info_with_stability_tag(
-                  "The revision to use for the HuggingFace model "
+    help="KV cache quantization dtype for PyTorch backend. "
+    "'auto' uses checkpoint/model metadata; explicit values force override.",
+    status="prototype")
+@stability_option("--num_postprocess_workers",
+                  type=int,
+                  default=0,
+                  help="Number of workers to postprocess raw responses "
+                  "to comply with OpenAI protocol.",
+                  status="prototype")
+@stability_option("--trust_remote_code",
+                  is_flag=True,
+                  default=False,
+                  help="Flag for HF transformers.",
+                  status="beta")
+@stability_option("--hf_revision",
+                  "--revision",
+                  "revision",
+                  type=str,
+                  default=None,
+                  help="The revision to use for the HuggingFace model "
                   "(branch name, tag name, or commit id). "
-                  "Prefer --hf_revision over --revision.", "beta"))
-@click.option(
+                  "Prefer --hf_revision over --revision.",
+                  status="beta")
+@stability_option(
     "--config",
     "--extra_llm_api_options",
     "extra_llm_api_options",
     type=str,
     default=None,
-    help=help_info_with_stability_tag(
-        "Path to a YAML configuration file. Explicit CLI flags take precedence "
-        "over values in this file. Can be specified as either --config or "
-        "--extra_llm_api_options.", "prototype"))
-@click.option(
-    "--reasoning_parser",
-    type=click.Choice(["auto"] + list(ReasoningParserFactory.keys())),
-    default=None,
-    help=help_info_with_stability_tag(
-        "Specify the parser for reasoning models. "
-        "Use 'auto' to automatically select based on the model.", "prototype"),
-)
-@click.option(
-    "--tool_parser",
-    type=click.Choice(["auto"] + list(ToolParserFactory.parsers.keys())),
-    default=None,
-    help=help_info_with_stability_tag(
-        "Specify the parser for tool models. "
-        "Use 'auto' to automatically select based on the model.", "prototype"),
-)
-@click.option("--metadata_server_config_file",
-              type=str,
-              default=None,
-              help=help_info_with_stability_tag(
-                  "Path to metadata server config file", "prototype"))
-@click.option(
+    help="Path to a YAML configuration file. Explicit CLI flags take precedence "
+    "over values in this file. Can be specified as either --config or "
+    "--extra_llm_api_options.",
+    status="prototype")
+@stability_option("--reasoning_parser",
+                  type=click.Choice(["auto"] +
+                                    list(ReasoningParserFactory.keys())),
+                  default=None,
+                  help="Specify the parser for reasoning models. "
+                  "Use 'auto' to automatically select based on the model.",
+                  status="prototype")
+@stability_option("--tool_parser",
+                  type=click.Choice(["auto"] +
+                                    list(ToolParserFactory.parsers.keys())),
+                  default=None,
+                  help="Specify the parser for tool models. "
+                  "Use 'auto' to automatically select based on the model.",
+                  status="prototype")
+@stability_option("--metadata_server_config_file",
+                  type=str,
+                  default=None,
+                  help="Path to metadata server config file",
+                  status="prototype")
+@stability_option(
     "--server_role",
     type=str,
     default=None,
-    help=help_info_with_stability_tag(
-        "Server role for disaggregated serving. "
-        "CONTEXT=prefill (prompt processing), GENERATION=decode (token generation), "
-        "MM_ENCODER=multimodal encoder, VISUAL_GEN=visual generation. "
-        "Required when using service registry.", "prototype"))
-@click.option(
+    help="Server role for disaggregated serving. "
+    "CONTEXT=prefill (prompt processing), GENERATION=decode (token generation), "
+    "MM_ENCODER=multimodal encoder, VISUAL_GEN=visual generation. "
+    "Required when using service registry.",
+    status="prototype")
+@stability_option(
     "--fail_fast_on_attention_window_too_large",
     is_flag=True,
     default=True,
-    help=help_info_with_stability_tag(
-        "[Deprecated] Exit with runtime error when attention window is too large "
-        "to fit even a single sequence in the KV cache. Now defaults to True. "
-        "This flag only affects the TRT backend and will be removed in a future release.",
-        "deprecated"))
-@click.option("--otlp_traces_endpoint",
-              type=str,
-              default=None,
-              help=help_info_with_stability_tag(
-                  "Target URL to which OpenTelemetry traces will be sent.",
-                  "prototype"))
-@click.option("--telemetry/--no-telemetry",
-              default=True,
-              help="Enable or disable anonymous usage telemetry collection.")
-@click.option("--disagg_cluster_uri",
-              type=str,
-              default=None,
-              help=help_info_with_stability_tag(
-                  "URI of the disaggregated cluster.", "prototype"))
-@click.option("--enable_chunked_prefill",
-              is_flag=True,
-              default=False,
-              help=help_info_with_stability_tag("Enable chunked prefill",
-                                                "prototype"))
-@click.option("--enable_attention_dp",
-              is_flag=True,
-              default=False,
-              help=help_info_with_stability_tag(
-                  "Enable attention data parallel.", "beta"))
-@click.option("--media_io_kwargs",
-              type=str,
-              default=None,
-              help=help_info_with_stability_tag(
-                  "Keyword arguments for media I/O as a JSON string. "
+    help=
+    "[Deprecated] Exit with runtime error when attention window is too large "
+    "to fit even a single sequence in the KV cache. Now defaults to True. "
+    "This flag only affects the TRT backend and will be removed in a future release.",
+    status="deprecated")
+@stability_option("--otlp_traces_endpoint",
+                  type=str,
+                  default=None,
+                  help="Target URL to which OpenTelemetry traces will be sent.",
+                  status="prototype")
+@stability_option(
+    "--telemetry/--no-telemetry",
+    default=True,
+    help="Enable or disable anonymous usage telemetry collection.",
+    status="beta")
+@stability_option("--disagg_cluster_uri",
+                  type=str,
+                  default=None,
+                  help="URI of the disaggregated cluster.",
+                  status="prototype")
+@stability_option("--enable_chunked_prefill",
+                  is_flag=True,
+                  default=False,
+                  help="Enable chunked prefill",
+                  status="prototype")
+@stability_option("--enable_attention_dp",
+                  is_flag=True,
+                  default=False,
+                  help="Enable attention data parallel.",
+                  status="beta")
+@stability_option("--media_io_kwargs",
+                  type=str,
+                  default=None,
+                  help="Keyword arguments for media I/O as a JSON string. "
                   "Keys are modality names (\"video\", \"image\", \"audio\") "
                   "whose values are dicts of keyword arguments forwarded to "
                   "the corresponding loader. "
                   "Example: '{\"video\": {\"extract_audio\": true, "
                   "\"num_frames\": 16}}' to enable audio extraction from "
-                  "video files.", "prototype"))
-@click.option("--video_pruning_rate",
-              type=float,
-              default=None,
-              help=help_info_with_stability_tag(
-                  "Pruning rate for video frames in multimodal models. "
+                  "video files.",
+                  status="prototype")
+@stability_option("--video_pruning_rate",
+                  type=float,
+                  default=None,
+                  help="Pruning rate for video frames in multimodal models. "
                   "Applied by Efficient Video Sampling (EVS). "
                   "None disables EVS, values in [0, 1) enable pruning.",
-                  "prototype"))
-@click.option("--chat_template",
-              type=str,
-              default=None,
-              help=help_info_with_stability_tag(
-                  "Specify a custom chat template. "
+                  status="prototype")
+@stability_option("--chat_template",
+                  type=str,
+                  default=None,
+                  help="Specify a custom chat template. "
                   "Can be a file path or one-liner template string",
-                  "prototype"))
-@click.option("--allow_request_chat_template",
-              is_flag=True,
-              default=False,
-              help=help_info_with_stability_tag(
-                  "Allow clients to supply per-request chat_template values. "
-                  "Only enable this for trusted clients.", "prototype"))
-@click.option(
+                  status="prototype")
+@stability_option(
+    "--allow_request_chat_template",
+    is_flag=True,
+    default=False,
+    help="Allow clients to supply per-request chat_template values. "
+    "Only enable this for trusted clients.",
+    status="prototype")
+@stability_option(
     "--middleware",
     multiple=True,
     type=str,
-    help=help_info_with_stability_tag(
-        "FastAPI middleware import path to add to the server app. "
-        "Can be specified multiple times. Each value must point to either "
-        "a middleware class or an async HTTP middleware function.",
-        "prototype"))
-@click.option(
+    help="FastAPI middleware import path to add to the server app. "
+    "Can be specified multiple times. Each value must point to either "
+    "a middleware class or an async HTTP middleware function.",
+    status="prototype")
+@stability_option(
     "--grpc",
     is_flag=True,
     default=False,
     help="Run gRPC server instead of OpenAI HTTP server. "
-    "gRPC server accepts pre-tokenized requests and returns raw token IDs.")
-@click.option(
+    "gRPC server accepts pre-tokenized requests and returns raw token IDs.",
+    status="prototype")
+@stability_option(
     "--served_model_name",
     type=str,
     default=None,
-    help=help_info_with_stability_tag(
-        "The model name used in the API. If not specified, the model path is "
-        "used as the model name. This is useful when the model path is long or "
-        "when you want to expose a custom name to clients.", "prototype"))
-@click.option(
+    help="The model name used in the API. If not specified, the model path is "
+    "used as the model name. This is useful when the model path is long or "
+    "when you want to expose a custom name to clients.",
+    status="prototype")
+@stability_option(
     "--enable_visual_gen",
     is_flag=True,
     default=False,
-    help=help_info_with_stability_tag(
-        "Enable VisualGen runtime for model checkpoints that support both LLM "
-        "and Visual Generation. Not required if --visual_gen_args specified "
-        "or the model supports Visual Generation only.",
-        "prototype",
-    ),
-)
-@click.option(
-    "--visual_gen_args",
-    type=str,
-    default=None,
-    help=help_info_with_stability_tag(
-        "Path to a YAML file with VisualGen engine args.",
-        "prototype",
-    ),
-)
-@click.option(
+    help="Enable VisualGen runtime for model checkpoints that support both LLM "
+    "and Visual Generation. Not required if --visual_gen_args specified "
+    "or the model supports Visual Generation only.",
+    status="prototype")
+@stability_option("--visual_gen_args",
+                  type=str,
+                  default=None,
+                  help="Path to a YAML file with VisualGen engine args.",
+                  status="prototype")
+@stability_option(
     "--agent_percentage",
     type=float,
     default=0.0,
-    help=
-    "The percentage of agent requests to schedule. Defaults to 0.0. Should be between 0.0 and 1.0."
-)
-@click.option(
+    help="The percentage of agent requests to schedule. Defaults to 0.0. "
+    "Should be between 0.0 and 1.0.",
+    status="prototype")
+@stability_option(
     "--agent_types",
     type=str,
     default=None,
     help=
-    "Types of agents to schedule. Now Only Support Open Deep Research agent.")
+    "Types of agents to schedule. Now Only Support Open Deep Research agent.",
+    status="prototype")
 def serve(
         model: str, tokenizer: Optional[str], custom_tokenizer: Optional[str],
         post_processor_hook: Optional[str], host: str, port: int,
@@ -1186,73 +1168,92 @@ def serve(
 
 @click.command("mm_embedding_serve")
 @click.argument("model", type=str)
-@click.option("--host",
-              type=str,
-              default="localhost",
-              help="Hostname of the server.")
-@click.option("--port", type=int, default=8000, help="Port of the server.")
-@click.option('--log_level',
-              type=click.Choice(severity_map.keys()),
-              default='info',
-              help="The logging level.")
-@click.option("--max_batch_size",
-              type=int,
-              default=BuildConfig.model_fields["max_batch_size"].default,
-              help="Maximum number of requests that the engine can schedule.")
-@click.option(
+@stability_option("--host",
+                  type=str,
+                  default="localhost",
+                  help="Hostname of the server.",
+                  status="beta")
+@stability_option("--port",
+                  type=int,
+                  default=8000,
+                  help="Port of the server.",
+                  status="beta")
+@stability_option('--log_level',
+                  type=click.Choice(severity_map.keys()),
+                  default='info',
+                  help="The logging level.",
+                  status="beta")
+@stability_option(
+    "--max_batch_size",
+    type=int,
+    default=BuildConfig.model_fields["max_batch_size"].default,
+    help="Maximum number of requests that the engine can schedule.",
+    status="beta")
+@stability_option(
     "--max_num_tokens",
     type=int,
     default=16384,  # set higher default max_num_tokens for multimodal encoder
     help=
-    "Maximum number of batched input tokens after padding is removed in each batch."
-)
-@click.option("--gpus_per_node",
-              type=int,
-              default=None,
-              help="Number of GPUs per node. Default to None, and it will be "
-              "detected automatically.")
-@click.option("--trust_remote_code",
-              is_flag=True,
-              default=False,
-              help="Flag for HF transformers.")
-@click.option(
+    "Maximum number of batched input tokens after padding is removed in each batch.",
+    status="beta")
+@stability_option(
+    "--gpus_per_node",
+    type=int,
+    default=None,
+    help="Number of GPUs per node. Default to None, and it will be "
+    "detected automatically.",
+    status="beta")
+@stability_option("--trust_remote_code",
+                  is_flag=True,
+                  default=False,
+                  help="Flag for HF transformers.",
+                  status="beta")
+@stability_option(
     "--config",
     "--extra_encoder_options",
     "extra_encoder_options",
     type=str,
     default=None,
     help="Path to a YAML configuration file. Explicit CLI flags take precedence "
-    "over values in this file. Prefer --config over --extra_encoder_options.")
-@click.option("--hf_revision",
-              "--revision",
-              "revision",
-              type=str,
-              default=None,
-              help="The revision to use for the HuggingFace model "
-              "(branch name, tag name, or commit id).")
-@click.option("--free_gpu_memory_fraction",
-              type=float,
-              default=0.9,
-              help="Free GPU memory fraction reserved for KV Cache, "
-              "after allocating model weights and buffers.")
-@click.option("--tensor_parallel_size",
-              "--tp_size",
-              type=int,
-              default=1,
-              help="Tensor parallelism size.")
-@click.option("--metadata_server_config_file",
-              type=str,
-              default=None,
-              help="Path to metadata server config file")
-@click.option("--allow_request_chat_template",
-              is_flag=True,
-              default=False,
-              help=help_info_with_stability_tag(
-                  "Allow clients to supply per-request chat_template values. "
-                  "Only enable this for trusted clients.", "prototype"))
-@click.option("--telemetry/--no-telemetry",
-              default=True,
-              help="Enable or disable anonymous usage telemetry collection.")
+    "over values in this file. Prefer --config over --extra_encoder_options.",
+    status="prototype")
+@stability_option("--hf_revision",
+                  "--revision",
+                  "revision",
+                  type=str,
+                  default=None,
+                  help="The revision to use for the HuggingFace model "
+                  "(branch name, tag name, or commit id).",
+                  status="beta")
+@stability_option("--free_gpu_memory_fraction",
+                  type=float,
+                  default=0.9,
+                  help="Free GPU memory fraction reserved for KV Cache, "
+                  "after allocating model weights and buffers.",
+                  status="beta")
+@stability_option("--tensor_parallel_size",
+                  "--tp_size",
+                  type=int,
+                  default=1,
+                  help="Tensor parallelism size.",
+                  status="beta")
+@stability_option("--metadata_server_config_file",
+                  type=str,
+                  default=None,
+                  help="Path to metadata server config file",
+                  status="prototype")
+@stability_option(
+    "--allow_request_chat_template",
+    is_flag=True,
+    default=False,
+    help="Allow clients to supply per-request chat_template values. "
+    "Only enable this for trusted clients.",
+    status="prototype")
+@stability_option(
+    "--telemetry/--no-telemetry",
+    default=True,
+    help="Enable or disable anonymous usage telemetry collection.",
+    status="beta")
 def serve_encoder(model: str, host: str, port: int, log_level: str,
                   max_batch_size: int, max_num_tokens: int,
                   gpus_per_node: Optional[int], trust_remote_code: bool,
@@ -1313,46 +1314,53 @@ def serve_encoder(model: str, host: str, port: int, log_level: str,
 
 
 @click.command("disaggregated")
-@click.option("-c",
-              "--config",
-              "--config_file",
-              "config_file",
-              type=str,
-              default=None,
-              help="Path to the disaggregated serving configuration YAML file.")
-@click.option("-m",
-              "--metadata_server_config_file",
-              type=str,
-              default=None,
-              help="Path to metadata server config file")
-@click.option("-t",
-              "--server_start_timeout",
-              type=int,
-              default=180,
-              help="Server start timeout")
-@click.option("-r",
-              "--request_timeout",
-              type=int,
-              default=180,
-              help="Request timeout")
-@click.option("-l",
-              '--log_level',
-              type=click.Choice(severity_map.keys()),
-              default='info',
-              help="The logging level.")
-@click.option("-s",
-              "--schedule_style",
-              type=click.Choice(["context_first", "generation_first"],
-                                case_sensitive=False),
-              default=None,
-              help="The schedule style for the disaggregated server.")
-@click.option(
+@stability_option(
+    "-c",
+    "--config",
+    "--config_file",
+    "config_file",
+    type=str,
+    default=None,
+    help="Path to the disaggregated serving configuration YAML file.",
+    status="beta")
+@stability_option("-m",
+                  "--metadata_server_config_file",
+                  type=str,
+                  default=None,
+                  help="Path to metadata server config file",
+                  status="prototype")
+@stability_option("-t",
+                  "--server_start_timeout",
+                  type=int,
+                  default=180,
+                  help="Server start timeout",
+                  status="beta")
+@stability_option("-r",
+                  "--request_timeout",
+                  type=int,
+                  default=180,
+                  help="Request timeout",
+                  status="beta")
+@stability_option("-l",
+                  '--log_level',
+                  type=click.Choice(severity_map.keys()),
+                  default='info',
+                  help="The logging level.",
+                  status="beta")
+@stability_option("-s",
+                  "--schedule_style",
+                  type=click.Choice(["context_first", "generation_first"],
+                                    case_sensitive=False),
+                  default=None,
+                  help="The schedule style for the disaggregated server.",
+                  status="beta")
+@stability_option(
     "--metrics-log-interval",
     type=int,
     default=0,
     help="[Deprecated] The interval of logging metrics in seconds. "
-    "This option is not connected to any functionality and will be removed in a future release."
-)
+    "This option is not connected to any functionality and will be removed in a future release.",
+    status="deprecated")
 def disaggregated(
     config_file: Optional[str],
     metadata_server_config_file: Optional[str],
@@ -1431,17 +1439,20 @@ def set_cuda_device():
 
 
 @click.command("disaggregated_mpi_worker")
-@click.option("-c",
-              "--config",
-              "--config_file",
-              "config_file",
-              type=str,
-              default=None,
-              help="Path to the disaggregated serving configuration YAML file.")
-@click.option('--log_level',
-              type=click.Choice(severity_map.keys()),
-              default='info',
-              help="The logging level.")
+@stability_option(
+    "-c",
+    "--config",
+    "--config_file",
+    "config_file",
+    type=str,
+    default=None,
+    help="Path to the disaggregated serving configuration YAML file.",
+    status="beta")
+@stability_option('--log_level',
+                  type=click.Choice(severity_map.keys()),
+                  default='info',
+                  help="The logging level.",
+                  status="beta")
 def disaggregated_mpi_worker(config_file: Optional[str], log_level: str):
     """Launching disaggregated MPI worker"""
 

--- a/tests/unittest/api_stability/references/trtllm_serve_cli.yaml
+++ b/tests/unittest/api_stability/references/trtllm_serve_cli.yaml
@@ -14,6 +14,13 @@
 # is strict: adding a new option without a corresponding entry here is a build
 # failure, and so is removing, renaming, or retyping a listed option.
 #
+# Each option records the full user-visible CLI contract: `status`, `type`,
+# `default`, the complete set of `flags` (primary + aliases), and the Click
+# semantics that affect invocation shape (`required`, `multiple`, `is_flag`).
+# The gate diffs ALL of these — renaming an alias, flipping `multiple` off,
+# or making an option required all break existing user scripts and must show
+# up in the YAML diff for explicit review.
+#
 # Entries are alphabetical within each subcommand to keep diffs clean as new
 # options are added.
 audit_mode: false
@@ -25,26 +32,54 @@ commands:
         type: float
         default: 0.0
         status: prototype
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--agent_percentage"
       agent_types:
         type: str
         default: null
         status: prototype
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--agent_types"
       allow_request_chat_template:
         type: bool
         default: false
         status: prototype
+        required: false
+        multiple: false
+        is_flag: true
+        flags:
+        - "--allow_request_chat_template"
       backend:
         type: Choice(['_autodeploy', 'pytorch', 'tensorrt'])
         default: pytorch
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--backend"
       chat_template:
         type: str
         default: null
         status: prototype
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--chat_template"
       context_parallel_size:
         type: int
         default: 1
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
         flags:
         - "--context_parallel_size"
         - "--cp_size"
@@ -52,26 +87,54 @@ commands:
         type: Path
         default: null
         status: prototype
+        required: false
+        multiple: true
+        is_flag: false
+        flags:
+        - "--custom_module_dirs"
       custom_tokenizer:
         type: str
         default: null
         status: prototype
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--custom_tokenizer"
       disagg_cluster_uri:
         type: str
         default: null
         status: prototype
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--disagg_cluster_uri"
       enable_attention_dp:
         type: bool
         default: false
         status: beta
+        required: false
+        multiple: false
+        is_flag: true
+        flags:
+        - "--enable_attention_dp"
       enable_chunked_prefill:
         type: bool
         default: false
         status: prototype
+        required: false
+        multiple: false
+        is_flag: true
+        flags:
+        - "--enable_chunked_prefill"
       extra_llm_api_options:
         type: str
         default: null
         status: prototype
+        required: false
+        multiple: false
+        is_flag: false
         flags:
         - "--config"
         - "--extra_llm_api_options"
@@ -79,10 +142,18 @@ commands:
         type: bool
         default: true
         status: deprecated
+        required: false
+        multiple: false
+        is_flag: true
+        flags:
+        - "--fail_fast_on_attention_window_too_large"
       free_gpu_memory_fraction:
         type: float
         default: 0.9
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
         flags:
         - "--free_gpu_memory_fraction"
         - "--kv_cache_free_gpu_memory_fraction"
@@ -90,54 +161,117 @@ commands:
         type: int
         default: null
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--gpus_per_node"
       grpc:
         type: bool
         default: false
         status: prototype
+        required: false
+        multiple: false
+        is_flag: true
+        flags:
+        - "--grpc"
       host:
         type: str
         default: localhost
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--host"
       kv_cache_dtype:
         type: Choice(['auto', 'fp8', 'nvfp4'])
         default: auto
         status: prototype
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--kv_cache_dtype"
       log_level:
         type: Choice(['debug', 'error', 'info', 'internal_error', 'trace', 'verbose', 'warning'])
         default: info
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--log_level"
       max_batch_size:
         type: int
         default: 2048
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--max_batch_size"
       max_beam_width:
         type: int
         default: 1
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--max_beam_width"
       max_num_tokens:
         type: int
         default: 8192
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--max_num_tokens"
       max_seq_len:
         type: int
         default: null
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--max_seq_len"
       media_io_kwargs:
         type: str
         default: null
         status: prototype
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--media_io_kwargs"
       metadata_server_config_file:
         type: str
         default: null
         status: prototype
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--metadata_server_config_file"
       middleware:
         type: str
         default: null
         status: prototype
+        required: false
+        multiple: true
+        is_flag: false
+        flags:
+        - "--middleware"
       moe_cluster_parallel_size:
         type: int
         default: null
         status: deprecated
+        required: false
+        multiple: false
+        is_flag: false
         flags:
         - "--cluster_size"
         - "--moe_cluster_parallel_size"
@@ -145,6 +279,9 @@ commands:
         type: int
         default: null
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
         flags:
         - "--ep_size"
         - "--moe_expert_parallel_size"
@@ -152,14 +289,27 @@ commands:
         type: int
         default: 0
         status: prototype
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--num_postprocess_workers"
       otlp_traces_endpoint:
         type: str
         default: null
         status: prototype
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--otlp_traces_endpoint"
       pipeline_parallel_size:
         type: int
         default: 1
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
         flags:
         - "--pipeline_parallel_size"
         - "--pp_size"
@@ -167,14 +317,27 @@ commands:
         type: int
         default: 8000
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--port"
       reasoning_parser:
         type: Choice(['auto', 'deepseek-r1', 'gemma4', 'kimi_k2', 'kimi_k25', 'laguna', 'minimax_m2', 'minimax_m2_append_think', 'minimax_m3', 'nano-v3', 'nemotron-v3', 'qwen3', 'qwen3_5'])
         default: null
         status: prototype
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--reasoning_parser"
       revision:
         type: str
         default: null
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
         flags:
         - "--hf_revision"
         - "--revision"
@@ -182,14 +345,27 @@ commands:
         type: str
         default: null
         status: prototype
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--served_model_name"
       server_role:
         type: str
         default: null
         status: prototype
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--server_role"
       telemetry:
         type: bool
         default: true
         status: beta
+        required: false
+        multiple: false
+        is_flag: true
         flags:
         - "--no-telemetry"
         - "--telemetry"
@@ -197,6 +373,9 @@ commands:
         type: int
         default: 1
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
         flags:
         - "--tensor_parallel_size"
         - "--tp_size"
@@ -204,29 +383,56 @@ commands:
         type: str
         default: null
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--tokenizer"
       tool_parser:
         type: Choice(['auto', 'deepseek_v3', 'deepseek_v31', 'deepseek_v32', 'gemma4', 'glm4', 'glm47', 'kimi_k2', 'minimax_m2', 'minimax_m3', 'poolside_v1', 'qwen3', 'qwen3_coder'])
         default: null
         status: prototype
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--tool_parser"
       trust_remote_code:
         type: bool
         default: false
         status: beta
+        required: false
+        multiple: false
+        is_flag: true
+        flags:
+        - "--trust_remote_code"
       video_pruning_rate:
         type: float
         default: null
         status: prototype
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--video_pruning_rate"
       visual_gen_args:
         type: str
         default: null
         status: prototype
-
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--visual_gen_args"
   disaggregated:
     options:
       config_file:
         type: str
         default: null
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
         flags:
         - "--config"
         - "--config_file"
@@ -235,6 +441,9 @@ commands:
         type: Choice(['debug', 'error', 'info', 'internal_error', 'trace', 'verbose', 'warning'])
         default: info
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
         flags:
         - "--log_level"
         - "-l"
@@ -242,6 +451,9 @@ commands:
         type: str
         default: null
         status: prototype
+        required: false
+        multiple: false
+        is_flag: false
         flags:
         - "--metadata_server_config_file"
         - "-m"
@@ -249,10 +461,18 @@ commands:
         type: int
         default: 0
         status: deprecated
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--metrics-log-interval"
       request_timeout:
         type: int
         default: 180
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
         flags:
         - "--request_timeout"
         - "-r"
@@ -260,6 +480,9 @@ commands:
         type: Choice(['context_first', 'generation_first'])
         default: null
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
         flags:
         - "--schedule_style"
         - "-s"
@@ -267,16 +490,21 @@ commands:
         type: int
         default: 180
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
         flags:
         - "--server_start_timeout"
         - "-t"
-
   disaggregated_mpi_worker:
     options:
       config_file:
         type: str
         default: null
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
         flags:
         - "--config"
         - "--config_file"
@@ -285,17 +513,29 @@ commands:
         type: Choice(['debug', 'error', 'info', 'internal_error', 'trace', 'verbose', 'warning'])
         default: info
         status: beta
-
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--log_level"
   mm_embedding_serve:
     options:
       allow_request_chat_template:
         type: bool
         default: false
         status: prototype
+        required: false
+        multiple: false
+        is_flag: true
+        flags:
+        - "--allow_request_chat_template"
       extra_encoder_options:
         type: str
         default: null
         status: prototype
+        required: false
+        multiple: false
+        is_flag: false
         flags:
         - "--config"
         - "--extra_encoder_options"
@@ -303,38 +543,81 @@ commands:
         type: float
         default: 0.9
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--free_gpu_memory_fraction"
       gpus_per_node:
         type: int
         default: null
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--gpus_per_node"
       host:
         type: str
         default: localhost
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--host"
       log_level:
         type: Choice(['debug', 'error', 'info', 'internal_error', 'trace', 'verbose', 'warning'])
         default: info
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--log_level"
       max_batch_size:
         type: int
         default: 2048
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--max_batch_size"
       max_num_tokens:
         type: int
         default: 16384
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--max_num_tokens"
       metadata_server_config_file:
         type: str
         default: null
         status: prototype
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--metadata_server_config_file"
       port:
         type: int
         default: 8000
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--port"
       revision:
         type: str
         default: null
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
         flags:
         - "--hf_revision"
         - "--revision"
@@ -342,6 +625,9 @@ commands:
         type: bool
         default: true
         status: beta
+        required: false
+        multiple: false
+        is_flag: true
         flags:
         - "--no-telemetry"
         - "--telemetry"
@@ -349,6 +635,9 @@ commands:
         type: int
         default: 1
         status: beta
+        required: false
+        multiple: false
+        is_flag: false
         flags:
         - "--tensor_parallel_size"
         - "--tp_size"
@@ -356,3 +645,8 @@ commands:
         type: bool
         default: false
         status: beta
+        required: false
+        multiple: false
+        is_flag: true
+        flags:
+        - "--trust_remote_code"

--- a/tests/unittest/api_stability/references/trtllm_serve_cli.yaml
+++ b/tests/unittest/api_stability/references/trtllm_serve_cli.yaml
@@ -128,6 +128,15 @@ commands:
         is_flag: true
         flags:
         - "--enable_chunked_prefill"
+      enable_visual_gen:
+        type: bool
+        default: false
+        status: prototype
+        required: false
+        multiple: false
+        is_flag: true
+        flags:
+        - "--enable_visual_gen"
       extra_llm_api_options:
         type: str
         default: null
@@ -322,8 +331,17 @@ commands:
         is_flag: false
         flags:
         - "--port"
+      post_processor_hook:
+        type: str
+        default: null
+        status: prototype
+        required: false
+        multiple: false
+        is_flag: false
+        flags:
+        - "--post_processor_hook"
       reasoning_parser:
-        type: Choice(['auto', 'deepseek-r1', 'gemma4', 'kimi_k2', 'kimi_k25', 'laguna', 'minimax_m2', 'minimax_m2_append_think', 'minimax_m3', 'nano-v3', 'nemotron-v3', 'qwen3', 'qwen3_5'])
+        type: Choice(['auto', 'deepseek-r1', 'deepseek_v4', 'gemma4', 'kimi_k2', 'kimi_k25', 'laguna', 'minimax_m2', 'minimax_m2_append_think', 'minimax_m3', 'nano-v3', 'nemotron-v3', 'qwen3', 'qwen3_5'])
         default: null
         status: prototype
         required: false
@@ -389,7 +407,7 @@ commands:
         flags:
         - "--tokenizer"
       tool_parser:
-        type: Choice(['auto', 'deepseek_v3', 'deepseek_v31', 'deepseek_v32', 'gemma4', 'glm4', 'glm47', 'kimi_k2', 'minimax_m2', 'minimax_m3', 'poolside_v1', 'qwen3', 'qwen3_coder'])
+        type: Choice(['auto', 'deepseek_v3', 'deepseek_v31', 'deepseek_v32', 'deepseek_v4', 'gemma4', 'glm4', 'glm47', 'kimi_k2', 'minimax_m2', 'minimax_m3', 'poolside_v1', 'qwen3', 'qwen3_coder'])
         default: null
         status: prototype
         required: false

--- a/tests/unittest/api_stability/references/trtllm_serve_cli.yaml
+++ b/tests/unittest/api_stability/references/trtllm_serve_cli.yaml
@@ -1,0 +1,358 @@
+# Stability reference for the `trtllm-serve` CLI surface.
+#
+# Every Click option on the `serve`, `disaggregated`, `disaggregated_mpi_worker`,
+# and `mm_embedding_serve` subcommands MUST be listed here with an explicit
+# stability status. The CI test (`tests/unittest/api_stability/test_serve_cli.py`)
+# diffs the live Click group against this file and fails on any divergence.
+#
+# Allowed statuses (forward transitions only):
+#     prototype  ->  beta  ->  stable  ->  deprecated  (-> removed after grace period)
+#
+# This is the AUDIT-COMPLETE reference. Every Click option declared on each
+# gated subcommand is listed below with the same status it carries in source
+# (via `help_info_with_stability_tag(...)`). `audit_mode: false` means the gate
+# is strict: adding a new option without a corresponding entry here is a build
+# failure, and so is removing, renaming, or retyping a listed option.
+#
+# Entries are alphabetical within each subcommand to keep diffs clean as new
+# options are added.
+audit_mode: false
+
+commands:
+  serve:
+    options:
+      agent_percentage:
+        type: float
+        default: 0.0
+        status: prototype
+      agent_types:
+        type: str
+        default: null
+        status: prototype
+      allow_request_chat_template:
+        type: bool
+        default: false
+        status: prototype
+      backend:
+        type: Choice(['_autodeploy', 'pytorch', 'tensorrt'])
+        default: pytorch
+        status: beta
+      chat_template:
+        type: str
+        default: null
+        status: prototype
+      context_parallel_size:
+        type: int
+        default: 1
+        status: beta
+        flags:
+        - "--context_parallel_size"
+        - "--cp_size"
+      custom_module_dirs:
+        type: Path
+        default: null
+        status: prototype
+      custom_tokenizer:
+        type: str
+        default: null
+        status: prototype
+      disagg_cluster_uri:
+        type: str
+        default: null
+        status: prototype
+      enable_attention_dp:
+        type: bool
+        default: false
+        status: beta
+      enable_chunked_prefill:
+        type: bool
+        default: false
+        status: prototype
+      extra_llm_api_options:
+        type: str
+        default: null
+        status: prototype
+        flags:
+        - "--config"
+        - "--extra_llm_api_options"
+      fail_fast_on_attention_window_too_large:
+        type: bool
+        default: true
+        status: deprecated
+      free_gpu_memory_fraction:
+        type: float
+        default: 0.9
+        status: beta
+        flags:
+        - "--free_gpu_memory_fraction"
+        - "--kv_cache_free_gpu_memory_fraction"
+      gpus_per_node:
+        type: int
+        default: null
+        status: beta
+      grpc:
+        type: bool
+        default: false
+        status: prototype
+      host:
+        type: str
+        default: localhost
+        status: beta
+      kv_cache_dtype:
+        type: Choice(['auto', 'fp8', 'nvfp4'])
+        default: auto
+        status: prototype
+      log_level:
+        type: Choice(['debug', 'error', 'info', 'internal_error', 'trace', 'verbose', 'warning'])
+        default: info
+        status: beta
+      max_batch_size:
+        type: int
+        default: 2048
+        status: beta
+      max_beam_width:
+        type: int
+        default: 1
+        status: beta
+      max_num_tokens:
+        type: int
+        default: 8192
+        status: beta
+      max_seq_len:
+        type: int
+        default: null
+        status: beta
+      media_io_kwargs:
+        type: str
+        default: null
+        status: prototype
+      metadata_server_config_file:
+        type: str
+        default: null
+        status: prototype
+      middleware:
+        type: str
+        default: null
+        status: prototype
+      moe_cluster_parallel_size:
+        type: int
+        default: null
+        status: deprecated
+        flags:
+        - "--cluster_size"
+        - "--moe_cluster_parallel_size"
+      moe_expert_parallel_size:
+        type: int
+        default: null
+        status: beta
+        flags:
+        - "--ep_size"
+        - "--moe_expert_parallel_size"
+      num_postprocess_workers:
+        type: int
+        default: 0
+        status: prototype
+      otlp_traces_endpoint:
+        type: str
+        default: null
+        status: prototype
+      pipeline_parallel_size:
+        type: int
+        default: 1
+        status: beta
+        flags:
+        - "--pipeline_parallel_size"
+        - "--pp_size"
+      port:
+        type: int
+        default: 8000
+        status: beta
+      reasoning_parser:
+        type: Choice(['auto', 'deepseek-r1', 'gemma4', 'kimi_k2', 'kimi_k25', 'laguna', 'minimax_m2', 'minimax_m2_append_think', 'minimax_m3', 'nano-v3', 'nemotron-v3', 'qwen3', 'qwen3_5'])
+        default: null
+        status: prototype
+      revision:
+        type: str
+        default: null
+        status: beta
+        flags:
+        - "--hf_revision"
+        - "--revision"
+      served_model_name:
+        type: str
+        default: null
+        status: prototype
+      server_role:
+        type: str
+        default: null
+        status: prototype
+      telemetry:
+        type: bool
+        default: true
+        status: beta
+        flags:
+        - "--no-telemetry"
+        - "--telemetry"
+      tensor_parallel_size:
+        type: int
+        default: 1
+        status: beta
+        flags:
+        - "--tensor_parallel_size"
+        - "--tp_size"
+      tokenizer:
+        type: str
+        default: null
+        status: beta
+      tool_parser:
+        type: Choice(['auto', 'deepseek_v3', 'deepseek_v31', 'deepseek_v32', 'gemma4', 'glm4', 'glm47', 'kimi_k2', 'minimax_m2', 'minimax_m3', 'poolside_v1', 'qwen3', 'qwen3_coder'])
+        default: null
+        status: prototype
+      trust_remote_code:
+        type: bool
+        default: false
+        status: beta
+      video_pruning_rate:
+        type: float
+        default: null
+        status: prototype
+      visual_gen_args:
+        type: str
+        default: null
+        status: prototype
+
+  disaggregated:
+    options:
+      config_file:
+        type: str
+        default: null
+        status: beta
+        flags:
+        - "--config"
+        - "--config_file"
+        - "-c"
+      log_level:
+        type: Choice(['debug', 'error', 'info', 'internal_error', 'trace', 'verbose', 'warning'])
+        default: info
+        status: beta
+        flags:
+        - "--log_level"
+        - "-l"
+      metadata_server_config_file:
+        type: str
+        default: null
+        status: prototype
+        flags:
+        - "--metadata_server_config_file"
+        - "-m"
+      metrics_log_interval:
+        type: int
+        default: 0
+        status: deprecated
+      request_timeout:
+        type: int
+        default: 180
+        status: beta
+        flags:
+        - "--request_timeout"
+        - "-r"
+      schedule_style:
+        type: Choice(['context_first', 'generation_first'])
+        default: null
+        status: beta
+        flags:
+        - "--schedule_style"
+        - "-s"
+      server_start_timeout:
+        type: int
+        default: 180
+        status: beta
+        flags:
+        - "--server_start_timeout"
+        - "-t"
+
+  disaggregated_mpi_worker:
+    options:
+      config_file:
+        type: str
+        default: null
+        status: beta
+        flags:
+        - "--config"
+        - "--config_file"
+        - "-c"
+      log_level:
+        type: Choice(['debug', 'error', 'info', 'internal_error', 'trace', 'verbose', 'warning'])
+        default: info
+        status: beta
+
+  mm_embedding_serve:
+    options:
+      allow_request_chat_template:
+        type: bool
+        default: false
+        status: prototype
+      extra_encoder_options:
+        type: str
+        default: null
+        status: prototype
+        flags:
+        - "--config"
+        - "--extra_encoder_options"
+      free_gpu_memory_fraction:
+        type: float
+        default: 0.9
+        status: beta
+      gpus_per_node:
+        type: int
+        default: null
+        status: beta
+      host:
+        type: str
+        default: localhost
+        status: beta
+      log_level:
+        type: Choice(['debug', 'error', 'info', 'internal_error', 'trace', 'verbose', 'warning'])
+        default: info
+        status: beta
+      max_batch_size:
+        type: int
+        default: 2048
+        status: beta
+      max_num_tokens:
+        type: int
+        default: 16384
+        status: beta
+      metadata_server_config_file:
+        type: str
+        default: null
+        status: prototype
+      port:
+        type: int
+        default: 8000
+        status: beta
+      revision:
+        type: str
+        default: null
+        status: beta
+        flags:
+        - "--hf_revision"
+        - "--revision"
+      telemetry:
+        type: bool
+        default: true
+        status: beta
+        flags:
+        - "--no-telemetry"
+        - "--telemetry"
+      tensor_parallel_size:
+        type: int
+        default: 1
+        status: beta
+        flags:
+        - "--tensor_parallel_size"
+        - "--tp_size"
+      trust_remote_code:
+        type: bool
+        default: false
+        status: beta

--- a/tests/unittest/api_stability/test_serve_cli.py
+++ b/tests/unittest/api_stability/test_serve_cli.py
@@ -20,10 +20,14 @@ YAML diff.
 How it works
 ------------
 1. Walk every Click subcommand on the `trtllm-serve` group and collect each
-   option's stability tag, type, default, and required-ness.
+   option's stability tag, type, default, full ``flags`` list, and the
+   Click semantics that shape how it's invoked (``required``, ``multiple``,
+   ``is_flag``).
 2. Load the reference YAML at ``references/trtllm_serve_cli.yaml``.
-3. Diff the live surface against the YAML. Report each divergence as a
-   structured failure.
+3. Diff the live surface against the YAML — across the *entire* recorded
+   contract. Anything user-visible (a renamed alias, a flag becoming
+   value-taking, a repeatable option going single-value, an option
+   becoming required) shows up as a structured failure.
 
 Strict vs audit mode
 --------------------
@@ -139,8 +143,13 @@ class TestServeCLIStability:
           * Option present in code but not in YAML  → "you added an option,
             update the YAML" (downgraded to a warning while ``audit_mode``
             is true)
-          * Status / type / default mismatch        → "you changed an option
+          * ``status / type / default`` mismatch    → "you changed an option
             in a way that needs explicit reviewer sign-off"
+          * ``flags`` drift                         → "you renamed, added,
+            or removed a CLI flag (or alias) — that is a user-visible break"
+          * ``required / multiple / is_flag`` drift → "you changed the
+            invocation shape (e.g. an option became required, a flag became
+            value-taking, a repeatable option went single-value)"
         """
         audit_mode = bool(reference.get("audit_mode", False))
         ref_commands = reference.get("commands", {})
@@ -176,10 +185,27 @@ class TestServeCLIStability:
                         errors.append(message)
                     continue
 
-                # 3) Field-level diff for options listed in both.
+                # 3) Field-level diff for options listed in both. The YAML
+                #    is the user-facing CLI contract, so every field that
+                #    affects how a user invokes the option is part of the
+                #    diff:
+                #
+                #      * ``status / type / default`` — the obvious metadata.
+                #      * ``flags``  — the full sorted list of accepted CLI
+                #        surface strings (primary + aliases, both ``--long``
+                #        and ``-s``). Diffed for EVERY option, not just
+                #        multi-flag ones: changing ``--log_level`` to
+                #        ``--log-level`` leaves the Click parameter name
+                #        ``log_level`` unchanged but breaks every user
+                #        invocation, and we want that to fail the gate.
+                #      * ``required / multiple / is_flag`` — these change
+                #        the invocation *shape* (``--middleware`` going from
+                #        repeatable to single-value, ``--grpc`` going from
+                #        a flag to a value-taking option, an option becoming
+                #        required) and would silently break existing scripts.
                 live_spec = live_opts[opt_name]
                 ref_spec = ref_opts[opt_name]
-                for key in ("status", "type", "default"):
+                for key in ("status", "type", "default", "required", "multiple", "is_flag"):
                     live_val = live_spec.get(key)
                     ref_val = ref_spec.get(key)
                     if live_val != ref_val:
@@ -189,23 +215,14 @@ class TestServeCLIStability:
                             f"yaml={ref_val!r}. Update one or the other."
                         )
 
-                # 4) Alias-set drift. Renaming or removing an alias (e.g.
-                #    dropping `--tp_size` while keeping `--tensor_parallel_size`)
-                #    is a user-visible break that wouldn't be caught by the
-                #    `status / type / default` diff above. The `flags:` field
-                #    captures the full set of CLI surface strings Click accepts
-                #    and is recorded in the YAML for every multi-flag option.
-                #    Single-flag options omit the field; we only diff when the
-                #    YAML explicitly records it.
-                ref_flags = ref_spec.get("flags")
-                if ref_flags is not None:
-                    live_flags = live_spec.get("flags") or []
-                    if list(ref_flags) != list(live_flags):
-                        errors.append(
-                            f"[{cmd_name}] option `--{opt_name}` flags drift: "
-                            f"code={live_flags!r} vs yaml={list(ref_flags)!r}. "
-                            "Update one or the other."
-                        )
+                live_flags = list(live_spec.get("flags") or [])
+                ref_flags = list(ref_spec.get("flags") or [])
+                if ref_flags != live_flags:
+                    errors.append(
+                        f"[{cmd_name}] option `--{opt_name}` flags drift: "
+                        f"code={live_flags!r} vs yaml={ref_flags!r}. "
+                        "Update one or the other."
+                    )
 
         for w in warnings_:
             warnings.warn(w, stacklevel=2)

--- a/tests/unittest/api_stability/test_serve_cli.py
+++ b/tests/unittest/api_stability/test_serve_cli.py
@@ -1,0 +1,242 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CI gate for the `trtllm-serve` CLI option surface.
+
+This test enforces *commitment #1* from the trtllm-serve stability proposal:
+the CLI option contract cannot drift without an explicit, reviewer-visible
+YAML diff.
+
+How it works
+------------
+1. Walk every Click subcommand on the `trtllm-serve` group and collect each
+   option's stability tag, type, default, and required-ness.
+2. Load the reference YAML at ``references/trtllm_serve_cli.yaml``.
+3. Diff the live surface against the YAML. Report each divergence as a
+   structured failure.
+
+Strict vs audit mode
+--------------------
+The YAML carries an ``audit_mode: true|false`` flag at the top level. While the
+audit of the full option list is in progress, ``audit_mode`` is true and
+"option-not-listed-in-yaml" is downgraded to a warning. Once every option has
+an entry, the audit-complete PR flips the flag to false and any new tag-less
+option fails the build.
+
+Transitions
+-----------
+Allowed status transitions are strictly forward:
+
+    prototype → beta → stable → deprecated
+
+The PR diff on the YAML is the human signal that an API change is happening.
+The checker enforces the mechanical invariants; reviewers approve intent.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import warnings
+from typing import Any
+
+import pytest
+import yaml
+
+from tensorrt_llm.commands import serve as serve_cmd
+from tensorrt_llm.commands._serve_stability import ALLOWED_TAGS, collect_command_options
+
+REFERENCE_PATH = pathlib.Path(__file__).parent / "references" / "trtllm_serve_cli.yaml"
+
+# Subcommands we gate. Names must match the keys in `main.commands` in
+# tensorrt_llm/commands/serve.py.
+GATED_SUBCOMMANDS = (
+    "serve",
+    "disaggregated",
+    "disaggregated_mpi_worker",
+    "mm_embedding_serve",
+)
+
+
+def _load_reference() -> dict[str, Any]:
+    with open(REFERENCE_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def _live_surface() -> dict[str, dict[str, dict[str, Any]]]:
+    """Collect the live CLI surface keyed by subcommand and option name."""
+    group = serve_cmd.main
+    out: dict[str, dict[str, dict[str, Any]]] = {}
+    for cmd_name in GATED_SUBCOMMANDS:
+        cmd = group.commands.get(cmd_name)
+        assert cmd is not None, (
+            f"Subcommand {cmd_name!r} is not registered on `trtllm-serve`. "
+            "If you renamed or removed it, update `GATED_SUBCOMMANDS` and the "
+            "reference YAML."
+        )
+        out[cmd_name] = collect_command_options(cmd)
+    return out
+
+
+class TestServeCLIStability:
+    """Diff the live `trtllm-serve` CLI against the reference YAML."""
+
+    @pytest.fixture(scope="class")
+    def reference(self) -> dict[str, Any]:
+        return _load_reference()
+
+    @pytest.fixture(scope="class")
+    def live(self) -> dict[str, dict[str, dict[str, Any]]]:
+        return _live_surface()
+
+    def test_every_option_has_a_stability_tag(self, live):
+        """Every CLI option must carry an explicit stability tag.
+
+        The tag may come from `stability_option(..., status=...)` (preferred,
+        for new options) or from the legacy `help_info_with_stability_tag`
+        helper (already in wide use). Anything without a tag is a violation:
+        either add a tag, or, if the option is being retired, mark it
+        ``deprecated`` and schedule removal.
+        """
+        violations: list[str] = []
+        for cmd_name, options in live.items():
+            for opt_name, spec in options.items():
+                if spec["status"] is None:
+                    violations.append(f"  {cmd_name} --{opt_name}")
+        if violations:
+            msg = (
+                "The following `trtllm-serve` options have no stability tag.\n"
+                "Tag each one with `stability_option(..., status=...)` or via "
+                "`help_info_with_stability_tag(...)` and update the YAML:\n" + "\n".join(violations)
+            )
+            pytest.fail(msg)
+
+    def test_tags_are_in_allowed_set(self, live):
+        """Defensive check: tag values must be one of the four allowed strings."""
+        bad: list[str] = []
+        for cmd_name, options in live.items():
+            for opt_name, spec in options.items():
+                status = spec["status"]
+                if status is not None and status not in ALLOWED_TAGS:
+                    bad.append(f"  {cmd_name} --{opt_name}: status={status!r}")
+        if bad:
+            pytest.fail(f"Invalid stability tags (allowed: {ALLOWED_TAGS}):\n" + "\n".join(bad))
+
+    def test_yaml_matches_live_surface(self, reference, live):
+        """The reference YAML and the live Click surface must agree.
+
+        Failure modes caught here:
+          * Option present in YAML but not in code  → "you removed an option"
+          * Option present in code but not in YAML  → "you added an option,
+            update the YAML" (downgraded to a warning while ``audit_mode``
+            is true)
+          * Status / type / default mismatch        → "you changed an option
+            in a way that needs explicit reviewer sign-off"
+        """
+        audit_mode = bool(reference.get("audit_mode", False))
+        ref_commands = reference.get("commands", {})
+
+        errors: list[str] = []
+        warnings_: list[str] = []
+
+        for cmd_name in GATED_SUBCOMMANDS:
+            live_opts = live.get(cmd_name, {})
+            ref_opts = (ref_commands.get(cmd_name, {}) or {}).get("options", {}) or {}
+
+            # 1) Options in YAML but not in code → always a hard failure.
+            for opt_name in ref_opts:
+                if opt_name not in live_opts:
+                    errors.append(
+                        f"[{cmd_name}] option `--{opt_name}` is in the YAML "
+                        "but no longer in the code. If you removed it, was "
+                        "it deprecated for at least one minor release first?"
+                    )
+
+            # 2) Options in code but not in YAML → fail (strict) or warn (audit).
+            for opt_name in live_opts:
+                if opt_name not in ref_opts:
+                    message = (
+                        f"[{cmd_name}] option `--{opt_name}` is missing from "
+                        "the stability reference YAML. Add it with an "
+                        "explicit `status:` (prototype | beta | stable | "
+                        "deprecated)."
+                    )
+                    if audit_mode:
+                        warnings_.append(message)
+                    else:
+                        errors.append(message)
+                    continue
+
+                # 3) Field-level diff for options listed in both.
+                live_spec = live_opts[opt_name]
+                ref_spec = ref_opts[opt_name]
+                for key in ("status", "type", "default"):
+                    live_val = live_spec.get(key)
+                    ref_val = ref_spec.get(key)
+                    if live_val != ref_val:
+                        errors.append(
+                            f"[{cmd_name}] option `--{opt_name}` field "
+                            f"`{key}` drift: code={live_val!r} vs "
+                            f"yaml={ref_val!r}. Update one or the other."
+                        )
+
+                # 4) Alias-set drift. Renaming or removing an alias (e.g.
+                #    dropping `--tp_size` while keeping `--tensor_parallel_size`)
+                #    is a user-visible break that wouldn't be caught by the
+                #    `status / type / default` diff above. The `flags:` field
+                #    captures the full set of CLI surface strings Click accepts
+                #    and is recorded in the YAML for every multi-flag option.
+                #    Single-flag options omit the field; we only diff when the
+                #    YAML explicitly records it.
+                ref_flags = ref_spec.get("flags")
+                if ref_flags is not None:
+                    live_flags = live_spec.get("flags") or []
+                    if list(ref_flags) != list(live_flags):
+                        errors.append(
+                            f"[{cmd_name}] option `--{opt_name}` flags drift: "
+                            f"code={live_flags!r} vs yaml={list(ref_flags)!r}. "
+                            "Update one or the other."
+                        )
+
+        for w in warnings_:
+            warnings.warn(w, stacklevel=2)
+
+        if errors:
+            pytest.fail("Stability gate violations:\n" + "\n".join(errors))
+
+    def test_no_status_demotion(self, reference, live):
+        """Status moves only forward.
+
+        prototype → beta → stable → deprecated. Going backward (e.g. relabelling
+        a `stable` option as `beta`) hides regressions and is rejected.
+        """
+        rank = {"prototype": 0, "beta": 1, "stable": 2, "deprecated": 3}
+        ref_commands = reference.get("commands", {})
+        demotions: list[str] = []
+
+        for cmd_name in GATED_SUBCOMMANDS:
+            live_opts = live.get(cmd_name, {})
+            ref_opts = (ref_commands.get(cmd_name, {}) or {}).get("options", {}) or {}
+            for opt_name, ref_spec in ref_opts.items():
+                if opt_name not in live_opts:
+                    continue
+                ref_status = ref_spec.get("status")
+                live_status = live_opts[opt_name].get("status")
+                if ref_status is None or live_status is None:
+                    continue
+                if rank.get(live_status, -1) < rank.get(ref_status, -1):
+                    demotions.append(
+                        f"[{cmd_name}] --{opt_name}: yaml={ref_status} -> code={live_status}"
+                    )
+
+        if demotions:
+            pytest.fail("Forbidden stability demotions:\n" + "\n".join(demotions))

--- a/tests/unittest/api_stability/test_serve_stability_helpers.py
+++ b/tests/unittest/api_stability/test_serve_stability_helpers.py
@@ -105,6 +105,50 @@ def test_collect_command_options_skips_arguments():
     assert out["port"]["status"] == "beta"
     assert out["port"]["type"] == "int"
     assert out["port"]["default"] == 8000
+    # Invocation-shape fields are part of the user contract and must be
+    # recorded for every option.
+    assert out["port"]["required"] is False
+    assert out["port"]["multiple"] is False
+    assert out["port"]["is_flag"] is False
+
+
+def test_collect_command_options_records_invocation_shape():
+    """``required``, ``multiple``, and ``is_flag`` are diffed by the CI gate.
+
+    Each one changes how users invoke the option (a flag becoming
+    value-taking, a repeatable option going single-value, an option
+    becoming required). The collector must surface them so the gate can
+    pin them.
+    """
+
+    @click.command("toy")
+    @stability_option(
+        "--required_field",
+        type=str,
+        required=True,
+        status="beta",
+        help="required field",
+    )
+    @stability_option(
+        "--repeatable",
+        type=str,
+        multiple=True,
+        status="prototype",
+        help="repeatable",
+    )
+    @stability_option(
+        "--switch",
+        is_flag=True,
+        default=False,
+        status="beta",
+        help="switch",
+    )
+    def toy(required_field, repeatable, switch): ...
+
+    out = collect_command_options(toy)
+    assert out["required_field"]["required"] is True
+    assert out["repeatable"]["multiple"] is True
+    assert out["switch"]["is_flag"] is True
 
 
 def test_allowed_tags_match_expected_set():

--- a/tests/unittest/api_stability/test_serve_stability_helpers.py
+++ b/tests/unittest/api_stability/test_serve_stability_helpers.py
@@ -1,0 +1,244 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Standalone unit tests for the `_serve_stability` helpers.
+
+These tests exercise the helpers in isolation (no full `tensorrt_llm` import)
+so they run quickly and stay green even on CPU-only CI shards.
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+from tensorrt_llm.commands._serve_stability import (
+    ALLOWED_TAGS,
+    collect_command_options,
+    get_option_stability,
+    help_info_with_stability_tag,
+    stability_option,
+)
+
+
+def test_help_info_includes_tag():
+    out = help_info_with_stability_tag("Port of the server.", "beta")
+    assert out.startswith(":tag:`beta`")
+    assert "Port of the server." in out
+
+
+def test_help_info_rejects_invalid_tag():
+    with pytest.raises(ValueError, match="Invalid stability tag"):
+        help_info_with_stability_tag("x", "experimental")  # type: ignore[arg-type]
+
+
+def test_stability_option_stamps_attribute():
+    @click.command("toy")
+    @stability_option(
+        "--threshold", type=int, default=5, status="prototype", help="A tunable knob."
+    )
+    def toy(threshold): ...
+
+    option = next(p for p in toy.params if p.name == "threshold")
+    assert get_option_stability(option) == "prototype"
+    assert option.help.startswith(":tag:`prototype`")
+
+
+def test_stability_option_rejects_invalid_status():
+    with pytest.raises(ValueError, match="Invalid stability tag"):
+
+        @click.command("toy")
+        @stability_option(
+            "--threshold",
+            status="experimental",  # type: ignore[arg-type]
+            help="x",
+        )
+        def toy(threshold): ...
+
+
+def test_get_option_stability_reads_legacy_help_tag():
+    """Cover legacy options tagged via help_info_with_stability_tag.
+
+    Existing options pass the rendered help string directly to ``@click.option``,
+    so the checker must still be able to extract the tag from that text.
+    """
+
+    @click.command("toy")
+    @click.option(
+        "--legacy", default=None, help=help_info_with_stability_tag("an old option", "stable")
+    )
+    def toy(legacy): ...
+
+    option = next(p for p in toy.params if p.name == "legacy")
+    assert get_option_stability(option) == "stable"
+
+
+def test_get_option_stability_returns_none_for_untagged():
+    @click.command("toy")
+    @click.option("--bare", default=None, help="No tag at all.")
+    def toy(bare): ...
+
+    option = next(p for p in toy.params if p.name == "bare")
+    assert get_option_stability(option) is None
+
+
+def test_collect_command_options_skips_arguments():
+    @click.command("toy")
+    @click.argument("model", type=str)
+    @stability_option("--port", type=int, default=8000, status="beta", help="port")
+    def toy(model, port): ...
+
+    out = collect_command_options(toy)
+    # `model` is a positional arg, not an option, so should be excluded.
+    assert "model" not in out
+    assert "port" in out
+    assert out["port"]["status"] == "beta"
+    assert out["port"]["type"] == "int"
+    assert out["port"]["default"] == 8000
+
+
+def test_allowed_tags_match_expected_set():
+    assert set(ALLOWED_TAGS) == {"stable", "beta", "prototype", "deprecated"}
+
+
+def test_legacy_tag_must_be_a_prefix():
+    """An embedded ``:tag:`...`` inside otherwise-untagged help is NOT accepted.
+
+    The legacy convention is that the tag is *prepended* to the help string;
+    anything else is considered untagged. Without this anchoring, an option
+    whose help happens to mention the markup (e.g. in an example) could be
+    accidentally blessed.
+    """
+
+    @click.command("toy")
+    @click.option(
+        "--no_prefix",
+        default=None,
+        help="See :tag:`stable` for the legacy format; this option is itself untagged.",
+    )
+    def toy(no_prefix): ...
+
+    option = next(p for p in toy.params if p.name == "no_prefix")
+    assert get_option_stability(option) is None
+
+
+def test_collect_command_options_unset_default_renders_as_none():
+    """``multiple=True`` without an explicit default stores Click's UNSET sentinel.
+
+    Round-tripping that through ``yaml.safe_dump`` would fail (it's a Sentinel
+    enum), so `_format_default` collapses it to plain ``None``.
+    """
+
+    @click.command("toy")
+    @stability_option("--tag", type=str, multiple=True, status="prototype", help="repeatable")
+    def toy(tag): ...
+
+    out = collect_command_options(toy)
+    # Sanity: the option has no explicit default; the spec must surface None.
+    assert out["tag"]["default"] is None
+    assert out["tag"]["multiple"] is True
+
+
+def test_collect_command_options_callable_default_serialises_to_string():
+    """Callable defaults (factory functions) render as a stable string.
+
+    Recording the live callable object would make the YAML non-deterministic
+    across processes (memory addresses, lambdas, etc.). The formatter
+    captures the fully-qualified name instead.
+    """
+
+    def make_default():
+        return 42
+
+    @click.command("toy")
+    @stability_option(
+        "--n",
+        type=int,
+        default=make_default,
+        status="prototype",
+        help="callable default",
+    )
+    def toy(n): ...
+
+    out = collect_command_options(toy)
+    rendered = out["n"]["default"]
+    assert isinstance(rendered, str)
+    assert rendered.startswith("<callable:")
+    assert "make_default" in rendered
+
+
+def test_collect_command_options_choice_type_renders_choices():
+    """``click.Choice`` is serialised as a sorted list so the diff is stable."""
+
+    @click.command("toy")
+    @stability_option(
+        "--mode",
+        type=click.Choice(["fast", "balanced", "thorough"]),
+        default="balanced",
+        status="beta",
+        help="mode",
+    )
+    def toy(mode): ...
+
+    out = collect_command_options(toy)
+    rendered_type = out["mode"]["type"]
+    # The serialisation sorts the choices so diff order is deterministic.
+    assert rendered_type == "Choice(['balanced', 'fast', 'thorough'])"
+
+
+def test_collect_command_options_path_type_renders_as_path():
+    """``click.Path`` collapses to the literal string ``Path`` for YAML stability."""
+
+    @click.command("toy")
+    @stability_option(
+        "--cfg",
+        type=click.Path(exists=False),
+        default=None,
+        status="prototype",
+        help="cfg",
+    )
+    def toy(cfg): ...
+
+    out = collect_command_options(toy)
+    assert out["cfg"]["type"] == "Path"
+
+
+def test_collect_command_options_captures_aliases():
+    """The ``flags`` field must list every CLI surface string Click accepts.
+
+    Without this, renaming or removing an alias (e.g. dropping ``--tp_size``
+    while keeping ``--tensor_parallel_size``) would silently pass the gate.
+    The test asserts both multi-flag aliases and the ``--foo/--no-foo``
+    boolean-flag-pair form are surfaced.
+    """
+
+    @click.command("toy")
+    @stability_option(
+        "--tensor_parallel_size",
+        "--tp_size",
+        type=int,
+        default=1,
+        status="beta",
+        help="tp",
+    )
+    @stability_option(
+        "--telemetry/--no-telemetry",
+        default=True,
+        status="beta",
+        help="telemetry",
+    )
+    def toy(tensor_parallel_size, telemetry): ...
+
+    out = collect_command_options(toy)
+    assert out["tensor_parallel_size"]["flags"] == ["--tensor_parallel_size", "--tp_size"]
+    assert out["telemetry"]["flags"] == ["--no-telemetry", "--telemetry"]


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized stability labels across `trtllm-serve` CLI options, making it clearer which commands and flags are stable, beta, prototype, or deprecated.
  * Updated CLI help text to display stability tags consistently for supported options.

* **Bug Fixes**
  * Improved consistency between the live command-line interface and its published reference, helping catch accidental option or default changes sooner.
  * Added validation to ensure every exposed option has a recognized stability label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

Add a stability contract for every trtllm-serve CLI option. Each option carries one of stable | beta | prototype | deprecated, and a CI test diffs the live Click surface against tests/unittest/api_stability/references/trtllm_serve_cli.yaml. Renaming or retyping a stable option, removing one without a deprecation cycle, or adding a new option without an explicit tag now fails the build.

### What's in the PR

1. Scaffolding — new _serve_stability.py (stability_option wrapper, help-tag helper, Click introspection), the reference YAML in audit_mode: true, the gate test (test_serve_cli.py), and helper unit tests.
2. Audit-complete — annotate every CLI option with an explicit status, fill out the reference YAML, flip audit_mode: false so the gate is strict.
3. Migrate to @stability_option — replace all 66 @click.option(...) decorators on gated subcommands with @stability_option(...), giving contributors a single unambiguous "use me" decorator. Behavior is identical (status, type, default of every option preserved).

### What does NOT change

- Runtime behavior of the CLI — every option's (name, type, default) is byte-identical before/after.
- The legacy help_info_with_stability_tag helper stays in _serve_stability.py so anything outside the audited subcommand set keeps working.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

- tests/unittest/api_stability/test_serve_cli.py — the gate itself; covered by the existing unittest/api_stability directory entry in tests/integration/test_lists/test-db/l0_a10.yml.
- tests/unittest/api_stability/test_serve_stability_helpers.py — unit tests for the wrapper.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
