### PR TITLE
[None][feat] add CI-enforced stability gate for trtllm-serve HTTP schema

### DIFF
--- a/tests/unittest/api_stability/references/trtllm_serve_api.yaml
+++ b/tests/unittest/api_stability/references/trtllm_serve_api.yaml
@@ -1,0 +1,1509 @@
+# Stability reference for the `trtllm-serve` HTTP request/response schemas.
+#
+# This YAML is the *single source of truth* for the stability status of every
+# field on the Pydantic request and response models in
+# `tensorrt_llm/serve/openai_protocol.py`. The models themselves carry no
+# inline stability annotations — `openai_protocol.py` is an internal module
+# that is not surfaced in any public document, so the metadata stays here.
+#
+# Field kinds
+# -----------
+# Every entry carries a `kind:`:
+#
+#   * `openai`     — defined by OpenAI's HTTP API (matched against
+#                    https://github.com/openai/openai-openapi). We follow OAI's
+#                    contract for these; status is `stable` by default.
+#   * `extension`  — TensorRT-LLM extension on top of the OAI schema. We own
+#                    the stability promise. Status is one of:
+#                        prototype | beta | stable | deprecated
+#
+# How statuses are chosen
+# -----------------------
+# For extension fields, the initial status reflects the field's age in this
+# file's git history (probed via `git log -S<field>`):
+#
+#   * added in the last 6 months  →  prototype
+#   * added 6–12 months ago       →  beta
+#   * added more than 12 months ago →  stable
+#
+# After the initial classification, statuses move only forward:
+#
+#   prototype → beta → stable → deprecated
+#
+# The CI test (`tests/unittest/api_stability/test_serve_api.py`) verifies:
+#   * every YAML-listed field still exists on the live Pydantic model
+#     (catches silent renames / removals);
+#   * every live field on a listed model is in the YAML (catches new fields
+#     landing without a YAML row — the forcing function);
+#   * the YAML `default:` matches the live `model_fields[fname].default`
+#     (catches accidental default changes);
+#   * the YAML `required:` matches `FieldInfo.is_required()` (catches a
+#     required→optional flip, which `default:` alone cannot distinguish
+#     because both render to `None`);
+#   * every `status:` is one of the allowed tags and every `kind:` is one
+#     of the allowed kinds.
+#
+# Helper / inner classes (e.g. `StreamOptions`, `UsageInfo`, `ToolCall`,
+# `DisaggregatedParams`, `ResponseFormat`) are not listed — they ship as
+# part of the OAI protocol shape and the user-facing request/response models
+# above already gate them indirectly through their nested types.
+#
+# The `type:` value on each entry is documentation-only; the gate enforces
+# `(kind, status, default, required)`. Type drift typically surfaces via a
+# default change or a rename, both of which the gate does catch.
+
+models:
+  CompletionRequest:
+    fields:
+      model:
+        kind: openai
+        type: str
+        default: null
+        status: stable
+        required: true
+      prompt:
+        kind: openai
+        type: Union[List[int], List[List[int]], str, List[str]]
+        default: null
+        status: stable
+        required: true
+      best_of:
+        kind: openai
+        type: Optional[int]
+        default: null
+        status: stable
+        required: false
+      echo:
+        kind: openai
+        type: Optional[bool]
+        default: false
+        status: stable
+        required: false
+      frequency_penalty:
+        kind: openai
+        type: Optional[float]
+        default: 0.0
+        status: stable
+        required: false
+      logit_bias:
+        kind: openai
+        type: Optional[Dict[str, float]]
+        default: null
+        status: stable
+        required: false
+      logprobs:
+        kind: openai
+        type: Optional[int]
+        default: null
+        status: stable
+        required: false
+      max_tokens:
+        kind: openai
+        type: Optional[int]
+        default: null
+        status: stable
+        required: false
+      n:
+        kind: openai
+        type: int
+        default: 1
+        status: stable
+        required: false
+      presence_penalty:
+        kind: openai
+        type: Optional[float]
+        default: 0.0
+        status: stable
+        required: false
+      seed:
+        kind: openai
+        type: Optional[int]
+        default: null
+        status: stable
+        required: false
+      stop:
+        kind: openai
+        type: Optional[Union[str, List[str]]]
+        default: <factory:list>
+        status: stable
+        required: false
+      stream:
+        kind: openai
+        type: Optional[bool]
+        default: false
+        status: stable
+        required: false
+      stream_options:
+        kind: openai
+        type: Optional[StreamOptions]
+        default: null
+        status: stable
+        required: false
+      suffix:
+        kind: openai
+        type: Optional[str]
+        default: null
+        status: stable
+        required: false
+      temperature:
+        kind: openai
+        type: Optional[float]
+        default: null
+        status: stable
+        required: false
+      top_p:
+        kind: openai
+        type: Optional[float]
+        default: null
+        status: stable
+        required: false
+      user:
+        kind: openai
+        type: Optional[str]
+        default: null
+        status: stable
+        required: false
+      lora_request:
+        kind: extension
+        type: Optional[LoRARequest]
+        default: null
+        status: beta
+        required: false
+      prompt_ignore_length:
+        kind: extension
+        type: Optional[int]
+        default: 0
+        status: beta
+        required: false
+      use_beam_search:
+        kind: extension
+        type: bool
+        default: false
+        status: stable
+        required: false
+      top_k:
+        kind: extension
+        type: int
+        default: 0
+        status: stable
+        required: false
+      top_p_min:
+        kind: extension
+        type: float
+        default: 0.0
+        status: stable
+        required: false
+      min_p:
+        kind: extension
+        type: float
+        default: 0.0
+        status: stable
+        required: false
+      repetition_penalty:
+        kind: extension
+        type: float
+        default: 1.0
+        status: stable
+        required: false
+      length_penalty:
+        kind: extension
+        type: float
+        default: 1.0
+        status: stable
+        required: false
+      early_stopping:
+        kind: extension
+        type: bool
+        default: false
+        status: stable
+        required: false
+      stop_token_ids:
+        kind: extension
+        type: Optional[List[int]]
+        default: <factory:list>
+        status: stable
+        required: false
+      include_stop_str_in_output:
+        kind: extension
+        type: bool
+        default: false
+        status: stable
+        required: false
+      ignore_eos:
+        kind: extension
+        type: bool
+        default: false
+        status: stable
+        required: false
+      min_tokens:
+        kind: extension
+        type: int
+        default: 0
+        status: stable
+        required: false
+      skip_special_tokens:
+        kind: extension
+        type: bool
+        default: true
+        status: stable
+        required: false
+      spaces_between_special_tokens:
+        kind: extension
+        type: bool
+        default: true
+        status: stable
+        required: false
+      truncate_prompt_tokens:
+        kind: extension
+        type: Optional[Annotated[int, Field(ge=1)]]
+        default: null
+        status: stable
+        required: false
+      return_context_logits:
+        kind: extension
+        type: bool
+        default: false
+        status: stable
+        required: false
+      detokenize:
+        kind: extension
+        type: bool
+        default: true
+        status: beta
+        required: false
+      thinking_token_budget:
+        kind: extension
+        type: Optional[int]
+        default: null
+        status: prototype
+        required: false
+      add_special_tokens:
+        kind: extension
+        type: bool
+        default: true
+        status: stable
+        required: false
+      response_format:
+        kind: extension
+        type: Optional[ResponseFormat]
+        default: null
+        status: stable
+        required: false
+      disaggregated_params:
+        kind: extension
+        type: Optional[DisaggregatedParams]
+        default: null
+        status: stable
+        required: false
+
+  CompletionResponseChoice:
+    fields:
+      index:
+        kind: openai
+        type: int
+        default: null
+        status: stable
+        required: true
+      text:
+        kind: openai
+        type: str
+        default: null
+        status: stable
+        required: true
+      token_ids:
+        kind: extension
+        type: Optional[List[int]]
+        default: null
+        status: stable
+        required: false
+      logprobs:
+        kind: openai
+        type: Optional[CompletionLogProbs]
+        default: null
+        status: stable
+        required: false
+      context_logits:
+        kind: extension
+        type: Optional[Union[List[float], List[List[float]]]]
+        default: null
+        status: stable
+        required: false
+      finish_reason:
+        kind: openai
+        type: Optional[str]
+        default: null
+        status: stable
+        required: false
+      stop_reason:
+        kind: extension
+        type: Optional[Union[int, str]]
+        default: null
+        status: stable
+        required: false
+      disaggregated_params:
+        kind: extension
+        type: Optional[DisaggregatedParams]
+        default: null
+        status: stable
+        required: false
+      avg_decoded_tokens_per_iter:
+        kind: extension
+        type: Optional[float]
+        default: null
+        status: beta
+        required: false
+
+  CompletionResponse:
+    fields:
+      id:
+        kind: openai
+        type: str
+        default: <factory:<lambda>>
+        status: stable
+        required: false
+      object:
+        kind: openai
+        type: str
+        default: text_completion
+        status: stable
+        required: false
+      created:
+        kind: openai
+        type: int
+        default: <factory:<lambda>>
+        status: stable
+        required: false
+      model:
+        kind: openai
+        type: str
+        default: null
+        status: stable
+        required: true
+      choices:
+        kind: openai
+        type: List[CompletionResponseChoice]
+        default: null
+        status: stable
+        required: true
+      usage:
+        kind: openai
+        type: UsageInfo
+        default: null
+        status: stable
+        required: true
+      prompt_token_ids:
+        kind: extension
+        type: Optional[Union[List[List[int]], List[int]]]
+        default: null
+        status: stable
+        required: false
+
+  CompletionResponseStreamChoice:
+    fields:
+      index:
+        kind: openai
+        type: int
+        default: null
+        status: stable
+        required: true
+      text:
+        kind: openai
+        type: str
+        default: null
+        status: stable
+        required: true
+      token_ids:
+        kind: extension
+        type: Optional[List[int]]
+        default: null
+        status: stable
+        required: false
+      logprobs:
+        kind: openai
+        type: Optional[CompletionLogProbs]
+        default: null
+        status: stable
+        required: false
+      finish_reason:
+        kind: openai
+        type: Optional[str]
+        default: null
+        status: stable
+        required: false
+      stop_reason:
+        kind: extension
+        type: Optional[Union[int, str]]
+        default: null
+        status: stable
+        required: false
+      avg_decoded_tokens_per_iter:
+        kind: extension
+        type: Optional[float]
+        default: null
+        status: beta
+        required: false
+
+  CompletionStreamResponse:
+    fields:
+      id:
+        kind: openai
+        type: str
+        default: <factory:<lambda>>
+        status: stable
+        required: false
+      object:
+        kind: openai
+        type: str
+        default: text_completion
+        status: stable
+        required: false
+      created:
+        kind: openai
+        type: int
+        default: <factory:<lambda>>
+        status: stable
+        required: false
+      model:
+        kind: openai
+        type: str
+        default: null
+        status: stable
+        required: true
+      choices:
+        kind: openai
+        type: List[CompletionResponseStreamChoice]
+        default: null
+        status: stable
+        required: true
+      usage:
+        kind: openai
+        type: Optional[UsageInfo]
+        default: null
+        status: stable
+        required: false
+
+  ChatCompletionRequest:
+    fields:
+      messages:
+        kind: openai
+        type: List[ChatCompletionMessageParam]
+        default: null
+        status: stable
+        required: true
+      prompt_token_ids:
+        kind: extension
+        type: Optional[List[int]]
+        default: null
+        status: stable
+        required: false
+      model:
+        kind: openai
+        type: str
+        default: null
+        status: stable
+        required: true
+      frequency_penalty:
+        kind: openai
+        type: Optional[float]
+        default: 0.0
+        status: stable
+        required: false
+      logit_bias:
+        kind: openai
+        type: Optional[Dict[str, float]]
+        default: null
+        status: stable
+        required: false
+      logprobs:
+        kind: openai
+        type: Optional[bool]
+        default: false
+        status: stable
+        required: false
+      top_logprobs:
+        kind: openai
+        type: Optional[int]
+        default: 0
+        status: stable
+        required: false
+      max_completion_tokens:
+        kind: openai
+        type: Optional[int]
+        default: null
+        status: stable
+        required: false
+      n:
+        kind: openai
+        type: int
+        default: 1
+        status: stable
+        required: false
+      presence_penalty:
+        kind: openai
+        type: Optional[float]
+        default: 0.0
+        status: stable
+        required: false
+      response_format:
+        kind: openai
+        type: Optional[ResponseFormat]
+        default: null
+        status: stable
+        required: false
+      seed:
+        kind: openai
+        type: Optional[int]
+        default: null
+        status: stable
+        required: false
+      stop:
+        kind: openai
+        type: Optional[Union[str, List[str]]]
+        default: <factory:list>
+        status: stable
+        required: false
+      stream:
+        kind: openai
+        type: Optional[bool]
+        default: false
+        status: stable
+        required: false
+      stream_options:
+        kind: openai
+        type: Optional[StreamOptions]
+        default: null
+        status: stable
+        required: false
+      temperature:
+        kind: openai
+        type: Optional[float]
+        default: null
+        status: stable
+        required: false
+      top_p:
+        kind: openai
+        type: Optional[float]
+        default: null
+        status: stable
+        required: false
+      tools:
+        kind: openai
+        type: Optional[List[ChatCompletionToolsParam]]
+        default: null
+        status: stable
+        required: false
+      tool_choice:
+        kind: openai
+        type: Optional[Union[Literal['none', 'auto'], ChatCompletionNamedToolChoiceParam]]
+        default: none
+        status: stable
+        required: false
+      user:
+        kind: openai
+        type: Optional[str]
+        default: null
+        status: stable
+        required: false
+      reasoning_effort:
+        kind: openai
+        type: Optional[ReasoningEffort | Literal['low', 'medium', 'high']]
+        default: "ReasoningEffort.LOW"
+        status: stable
+        required: false
+      thinking_token_budget:
+        kind: extension
+        type: Optional[int]
+        default: null
+        status: prototype
+        required: false
+      prompt_ignore_length:
+        kind: extension
+        type: Optional[int]
+        default: 0
+        status: beta
+        required: false
+      best_of:
+        kind: extension
+        type: Optional[int]
+        default: null
+        status: stable
+        required: false
+      use_beam_search:
+        kind: extension
+        type: bool
+        default: false
+        status: stable
+        required: false
+      top_k:
+        kind: extension
+        type: int
+        default: 0
+        status: stable
+        required: false
+      top_p_min:
+        kind: extension
+        type: float
+        default: 0.0
+        status: stable
+        required: false
+      min_p:
+        kind: extension
+        type: float
+        default: 0.0
+        status: stable
+        required: false
+      repetition_penalty:
+        kind: extension
+        type: float
+        default: 1.0
+        status: stable
+        required: false
+      length_penalty:
+        kind: extension
+        type: float
+        default: 1.0
+        status: stable
+        required: false
+      early_stopping:
+        kind: extension
+        type: bool
+        default: false
+        status: stable
+        required: false
+      stop_token_ids:
+        kind: extension
+        type: Optional[List[int]]
+        default: <factory:list>
+        status: stable
+        required: false
+      include_stop_str_in_output:
+        kind: extension
+        type: bool
+        default: false
+        status: stable
+        required: false
+      ignore_eos:
+        kind: extension
+        type: bool
+        default: false
+        status: stable
+        required: false
+      min_tokens:
+        kind: extension
+        type: int
+        default: 0
+        status: stable
+        required: false
+      skip_special_tokens:
+        kind: extension
+        type: bool
+        default: true
+        status: stable
+        required: false
+      spaces_between_special_tokens:
+        kind: extension
+        type: bool
+        default: true
+        status: stable
+        required: false
+      truncate_prompt_tokens:
+        kind: extension
+        type: Optional[Annotated[int, Field(ge=1)]]
+        default: null
+        status: stable
+        required: false
+      lora_request:
+        kind: extension
+        type: Optional[LoRARequest]
+        default: null
+        status: beta
+        required: false
+      echo:
+        kind: extension
+        type: bool
+        default: false
+        status: stable
+        required: false
+      add_generation_prompt:
+        kind: extension
+        type: bool
+        default: true
+        status: stable
+        required: false
+      add_special_tokens:
+        kind: extension
+        type: bool
+        default: false
+        status: stable
+        required: false
+      documents:
+        kind: extension
+        type: Optional[List[Dict[str, str]]]
+        default: null
+        status: stable
+        required: false
+      chat_template:
+        kind: extension
+        type: Optional[str]
+        default: null
+        status: stable
+        required: false
+      chat_template_kwargs:
+        kind: extension
+        type: Optional[Dict[str, Any]]
+        default: null
+        status: stable
+        required: false
+      media_io_kwargs:
+        kind: extension
+        type: Optional[Dict[MediaModality, Dict[str, Any]]]
+        default: null
+        status: prototype
+        required: false
+      disaggregated_params:
+        kind: extension
+        type: Optional[DisaggregatedParams]
+        default: null
+        status: stable
+        required: false
+      cache_salt:
+        kind: extension
+        type: Optional[str]
+        default: null
+        status: beta
+        required: false
+      agent_hierarchy:
+        kind: extension
+        type: Optional[AgentHierarchy]
+        default: null
+        status: prototype
+        required: false
+      mm_processor_kwargs:
+        kind: extension
+        type: Optional[Dict[str, Any]]
+        default: null
+        status: beta
+        required: false
+
+  ChatCompletionResponseChoice:
+    fields:
+      index:
+        kind: openai
+        type: int
+        default: null
+        status: stable
+        required: true
+      message:
+        kind: openai
+        type: ChatMessage
+        default: null
+        status: stable
+        required: true
+      logprobs:
+        kind: openai
+        type: Optional[ChatCompletionLogProbs]
+        default: null
+        status: stable
+        required: false
+      finish_reason:
+        kind: openai
+        type: Optional[str]
+        default: null
+        status: stable
+        required: false
+      stop_reason:
+        kind: extension
+        type: Optional[Union[int, str]]
+        default: null
+        status: stable
+        required: false
+      mm_embedding_handle:
+        kind: extension
+        type: Optional[Dict[str, Any]]
+        default: null
+        status: beta
+        required: false
+      disaggregated_params:
+        kind: extension
+        type: Optional[DisaggregatedParams]
+        default: null
+        status: stable
+        required: false
+      avg_decoded_tokens_per_iter:
+        kind: extension
+        type: Optional[float]
+        default: null
+        status: beta
+        required: false
+
+  ChatCompletionResponse:
+    fields:
+      id:
+        kind: openai
+        type: str
+        default: <factory:<lambda>>
+        status: stable
+        required: false
+      object:
+        kind: openai
+        type: Literal['chat.completion']
+        default: chat.completion
+        status: stable
+        required: false
+      created:
+        kind: openai
+        type: int
+        default: <factory:<lambda>>
+        status: stable
+        required: false
+      model:
+        kind: openai
+        type: str
+        default: null
+        status: stable
+        required: true
+      choices:
+        kind: openai
+        type: List[ChatCompletionResponseChoice]
+        default: null
+        status: stable
+        required: true
+      usage:
+        kind: openai
+        type: UsageInfo
+        default: null
+        status: stable
+        required: true
+      prompt_token_ids:
+        kind: extension
+        type: Optional[List[int]]
+        default: null
+        status: stable
+        required: false
+
+  ChatCompletionResponseStreamChoice:
+    fields:
+      index:
+        kind: openai
+        type: int
+        default: null
+        status: stable
+        required: true
+      delta:
+        kind: openai
+        type: DeltaMessage
+        default: null
+        status: stable
+        required: true
+      logprobs:
+        kind: openai
+        type: Optional[ChatCompletionLogProbs]
+        default: null
+        status: stable
+        required: false
+      finish_reason:
+        kind: openai
+        type: Optional[str]
+        default: null
+        status: stable
+        required: false
+      stop_reason:
+        kind: extension
+        type: Optional[Union[int, str]]
+        default: null
+        status: stable
+        required: false
+      avg_decoded_tokens_per_iter:
+        kind: extension
+        type: Optional[float]
+        default: null
+        status: beta
+        required: false
+
+  ChatCompletionStreamResponse:
+    fields:
+      id:
+        kind: openai
+        type: str
+        default: <factory:<lambda>>
+        status: stable
+        required: false
+      object:
+        kind: openai
+        type: Literal['chat.completion.chunk']
+        default: chat.completion.chunk
+        status: stable
+        required: false
+      created:
+        kind: openai
+        type: int
+        default: <factory:<lambda>>
+        status: stable
+        required: false
+      model:
+        kind: openai
+        type: str
+        default: null
+        status: stable
+        required: true
+      choices:
+        kind: openai
+        type: List[ChatCompletionResponseStreamChoice]
+        default: null
+        status: stable
+        required: true
+      usage:
+        kind: openai
+        type: Optional[UsageInfo]
+        default: null
+        status: stable
+        required: false
+
+  ResponsesRequest:
+    fields:
+      background:
+        kind: openai
+        type: Optional[bool]
+        default: false
+        status: stable
+        required: false
+      include:
+        kind: openai
+        type: Optional[list[Literal['code_interpreter_call.outputs', 'computer_call_output.output.image_url', 'file_search_call.results', 'message.input_image.image_url', 'message.output_text.logprobs', 'reasoning.encrypted_content'],]]
+        default: null
+        status: stable
+        required: false
+      input:
+        kind: openai
+        type: Union[str, list[ResponseInputOutputItem]]
+        default: null
+        status: stable
+        required: true
+      instructions:
+        kind: openai
+        type: Optional[str]
+        default: null
+        status: stable
+        required: false
+      max_output_tokens:
+        kind: openai
+        type: Optional[int]
+        default: null
+        status: stable
+        required: false
+      max_tool_calls:
+        kind: openai
+        type: Optional[int]
+        default: null
+        status: stable
+        required: false
+      metadata:
+        kind: openai
+        type: Optional[Metadata]
+        default: null
+        status: stable
+        required: false
+      model:
+        kind: openai
+        type: str
+        default: null
+        status: stable
+        required: true
+      parallel_tool_calls:
+        kind: openai
+        type: Optional[bool]
+        default: false
+        status: stable
+        required: false
+      previous_response_id:
+        kind: openai
+        type: Optional[str]
+        default: null
+        status: stable
+        required: false
+      prompt:
+        kind: openai
+        type: Optional[ResponsePrompt]
+        default: null
+        status: stable
+        required: false
+      reasoning:
+        kind: openai
+        type: Optional[Reasoning]
+        default: null
+        status: stable
+        required: false
+      thinking_token_budget:
+        kind: extension
+        type: Optional[int]
+        default: null
+        status: prototype
+        required: false
+      service_tier:
+        kind: openai
+        type: Literal['auto', 'default', 'flex', 'scale', 'priority']
+        default: auto
+        status: stable
+        required: false
+      store:
+        kind: openai
+        type: Optional[bool]
+        default: true
+        status: stable
+        required: false
+      stream:
+        kind: openai
+        type: Optional[bool]
+        default: false
+        status: stable
+        required: false
+      temperature:
+        kind: openai
+        type: Optional[float]
+        default: null
+        status: stable
+        required: false
+      text:
+        kind: openai
+        type: Optional[ResponseTextConfig]
+        default: null
+        status: stable
+        required: false
+      tool_choice:
+        kind: openai
+        type: ToolChoice
+        default: auto
+        status: stable
+        required: false
+      tools:
+        kind: openai
+        type: list[Tool]
+        default: <factory:list>
+        status: stable
+        required: false
+      top_logprobs:
+        kind: openai
+        type: Optional[int]
+        default: 0
+        status: stable
+        required: false
+      top_p:
+        kind: openai
+        type: Optional[float]
+        default: null
+        status: stable
+        required: false
+      truncation:
+        kind: openai
+        type: Optional[Literal['auto', 'disabled']]
+        default: disabled
+        status: stable
+        required: false
+      user:
+        kind: openai
+        type: Optional[str]
+        default: null
+        status: stable
+        required: false
+      request_id:
+        kind: extension
+        type: str
+        default: <factory:<lambda>>
+        status: stable
+        required: false
+
+  ResponsesResponse:
+    fields:
+      id:
+        kind: openai
+        type: str
+        default: <factory:<lambda>>
+        status: stable
+        required: false
+      created_at:
+        kind: openai
+        type: int
+        default: <factory:<lambda>>
+        status: stable
+        required: false
+      instructions:
+        kind: openai
+        type: Optional[str]
+        default: null
+        status: stable
+        required: false
+      metadata:
+        kind: openai
+        type: Optional[Metadata]
+        default: null
+        status: stable
+        required: false
+      model:
+        kind: openai
+        type: str
+        default: null
+        status: stable
+        required: true
+      object:
+        kind: openai
+        type: Literal['response']
+        default: response
+        status: stable
+        required: false
+      output:
+        kind: openai
+        type: list[ResponseOutputItem]
+        default: null
+        status: stable
+        required: true
+      parallel_tool_calls:
+        kind: openai
+        type: bool
+        default: null
+        status: stable
+        required: true
+      temperature:
+        kind: openai
+        type: float
+        default: null
+        status: stable
+        required: true
+      tool_choice:
+        kind: openai
+        type: ToolChoice
+        default: null
+        status: stable
+        required: true
+      tools:
+        kind: openai
+        type: list[Tool]
+        default: null
+        status: stable
+        required: true
+      top_p:
+        kind: openai
+        type: float
+        default: null
+        status: stable
+        required: true
+      background:
+        kind: openai
+        type: bool
+        default: null
+        status: stable
+        required: true
+      max_output_tokens:
+        kind: openai
+        type: Optional[int]
+        default: null
+        status: stable
+        required: false
+      max_tool_calls:
+        kind: openai
+        type: Optional[int]
+        default: null
+        status: stable
+        required: false
+      previous_response_id:
+        kind: openai
+        type: Optional[str]
+        default: null
+        status: stable
+        required: false
+      prompt:
+        kind: openai
+        type: Optional[ResponsePrompt]
+        default: null
+        status: stable
+        required: false
+      reasoning:
+        kind: openai
+        type: Optional[Reasoning]
+        default: null
+        status: stable
+        required: false
+      service_tier:
+        kind: openai
+        type: Literal['auto', 'default', 'flex', 'scale', 'priority']
+        default: null
+        status: stable
+        required: true
+      status:
+        kind: openai
+        type: ResponseStatus
+        default: null
+        status: stable
+        required: true
+      text:
+        kind: openai
+        type: Optional[ResponseTextConfig]
+        default: null
+        status: stable
+        required: false
+      top_logprobs:
+        kind: openai
+        type: int
+        default: null
+        status: stable
+        required: true
+      truncation:
+        kind: openai
+        type: Literal['auto', 'disabled']
+        default: null
+        status: stable
+        required: true
+      usage:
+        kind: openai
+        type: Optional[ResponseUsage]
+        default: null
+        status: stable
+        required: false
+      user:
+        kind: openai
+        type: Optional[str]
+        default: null
+        status: stable
+        required: false
+
+  ImageGenerationRequest:
+    fields:
+      prompt:
+        kind: openai
+        type: str
+        default: null
+        status: stable
+        required: true
+      response_format:
+        kind: openai
+        type: Literal['url', 'b64_json']
+        default: url
+        status: stable
+        required: false
+      format:
+        kind: extension
+        type: Literal['png', 'webp', 'jpeg', 'safetensors', 'pt']
+        default: png
+        status: stable
+        required: false
+      seed:
+        kind: extension
+        type: Optional[int]
+        default: null
+        status: stable
+        required: false
+      size:
+        kind: openai
+        type: Optional[str]
+        default: null
+        status: stable
+        required: false
+      width:
+        kind: extension
+        type: Optional[int]
+        default: null
+        status: stable
+        required: false
+      height:
+        kind: extension
+        type: Optional[int]
+        default: null
+        status: prototype
+        required: false
+      num_inference_steps:
+        kind: extension
+        type: Optional[int]
+        default: null
+        status: prototype
+        required: false
+      guidance_scale:
+        kind: extension
+        type: Optional[float]
+        default: null
+        status: prototype
+        required: false
+      max_sequence_length:
+        kind: extension
+        type: Optional[int]
+        default: null
+        status: prototype
+        required: false
+      negative_prompt:
+        kind: extension
+        type: Optional[str]
+        default: null
+        status: prototype
+        required: false
+      n:
+        kind: openai
+        type: Optional[int]
+        default: null
+        status: stable
+        required: false
+      extra_params:
+        kind: extension
+        type: Optional[Dict[str, Any]]
+        default: null
+        status: prototype
+        required: false
+      model:
+        kind: openai
+        type: Optional[str]
+        default: null
+        status: stable
+        required: false
+      quality:
+        kind: openai
+        type: Optional[Literal['standard', 'hd']]
+        default: null
+        status: stable
+        required: false
+      style:
+        kind: openai
+        type: Optional[Literal['vivid', 'natural']]
+        default: null
+        status: stable
+        required: false
+      user:
+        kind: openai
+        type: Optional[str]
+        default: null
+        status: stable
+        required: false
+
+  ImageGenerationResponse:
+    fields:
+      created:
+        kind: openai
+        type: int
+        default: <factory:<lambda>>
+        status: stable
+        required: false
+      data:
+        kind: openai
+        type: List[ImageObject]
+        default: null
+        status: stable
+        required: true
+      output_format:
+        kind: extension
+        type: Literal['png', 'webp', 'jpeg', 'safetensors', 'pt']
+        default: png
+        status: prototype
+        required: false
+      quality:
+        kind: extension
+        type: Literal['low', 'medium', 'high']
+        default: medium
+        status: prototype
+        required: false
+      size:
+        kind: extension
+        type: Optional[str]
+        default: null
+        status: beta
+        required: false
+
+  VideoGenerationRequest:
+    fields:
+      prompt:
+        kind: extension
+        type: str
+        default: null
+        status: stable
+        required: true
+      response_format:
+        kind: extension
+        type: Literal['url', 'b64_json']
+        default: url
+        status: stable
+        required: false
+      format:
+        kind: extension
+        type: Literal['mp4', 'avi', 'auto', 'safetensors', 'pt']
+        default: auto
+        status: stable
+        required: false
+      seed:
+        kind: extension
+        type: Optional[int]
+        default: null
+        status: stable
+        required: false
+      input_reference:
+        kind: extension
+        type: Optional[Union[str, UploadFile]]
+        default: null
+        status: prototype
+        required: false
+      size:
+        kind: extension
+        type: Optional[str]
+        default: null
+        status: beta
+        required: false
+      width:
+        kind: extension
+        type: Optional[int]
+        default: null
+        status: stable
+        required: false
+      height:
+        kind: extension
+        type: Optional[int]
+        default: null
+        status: prototype
+        required: false
+      num_frames:
+        kind: extension
+        type: Optional[int]
+        default: null
+        status: prototype
+        required: false
+      seconds:
+        kind: extension
+        type: Optional[float]
+        default: null
+        status: prototype
+        required: false
+      frame_rate:
+        kind: extension
+        type: Optional[float]
+        default: null
+        status: prototype
+        required: false
+      num_inference_steps:
+        kind: extension
+        type: Optional[int]
+        default: null
+        status: prototype
+        required: false
+      guidance_scale:
+        kind: extension
+        type: Optional[float]
+        default: null
+        status: prototype
+        required: false
+      max_sequence_length:
+        kind: extension
+        type: Optional[int]
+        default: null
+        status: prototype
+        required: false
+      negative_prompt:
+        kind: extension
+        type: Optional[str]
+        default: null
+        status: prototype
+        required: false
+      extra_params:
+        kind: extension
+        type: Optional[Dict[str, Any]]
+        default: null
+        status: prototype
+        required: false
+      model:
+        kind: extension
+        type: Optional[str]
+        default: null
+        status: stable
+        required: false

--- a/tests/unittest/api_stability/test_serve_api.py
+++ b/tests/unittest/api_stability/test_serve_api.py
@@ -1,0 +1,307 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CI gate for the `trtllm-serve` HTTP request/response schema surface.
+
+The reference YAML (``references/trtllm_serve_api.yaml``) is the *single
+source of truth* for the stability status of every field on the Pydantic
+request and response models in ``tensorrt_llm/serve/openai_protocol.py``.
+The models themselves carry no inline stability annotations — that module
+is internal and not surfaced in any public document, so the metadata stays
+in the YAML.
+
+What the gate enforces, per gated model:
+
+1. **Every live field is in the YAML.** Adding a new Pydantic field without
+   a matching YAML row fails the build. This is the lock that turns the
+   YAML into a forcing function: a PR that adds (say) a new flag on
+   ``ChatCompletionRequest`` cannot land until the contributor picks a
+   ``kind:`` and ``status:`` for it and commits the YAML row, which is
+   visible in the PR diff.
+2. **Every YAML-listed field still exists on the live model.** Removing or
+   renaming a field without first updating the YAML fails the build.
+3. **Defaults match.** The YAML ``default:`` must equal the live
+   ``model_fields[fname].default`` (with sensible rendering for
+   ``default_factory`` callables and Pydantic's "no default" sentinel).
+4. **Required-ness matches.** The YAML ``required:`` flag must equal
+   ``model_fields[fname].is_required()``. This separates two wire contracts
+   that ``default`` alone collapses: a required field
+   (``CompletionRequest.model: str``) renders the same default (``None``) as
+   an optional field with ``default=None`` (``Optional[str] = None``), yet
+   flipping between them is a breaking change.
+5. **Allowed tags and kinds.** Every ``status:`` must be one of
+   ``stable | beta | prototype | deprecated``; every ``kind:`` must be one
+   of ``openai | extension``.
+
+What the gate intentionally does NOT enforce:
+
+* Status policy on ``openai`` fields. We follow OAI's evolution for those;
+  the YAML records them so the audit is visible, but we don't promote /
+  demote them ourselves.
+* Helper / inner classes (e.g. ``StreamOptions``, ``UsageInfo``,
+  ``DisaggregatedParams``). They aren't listed at the top level; if a
+  user-facing request / response model exposes a nested type, the
+  reference uses the nested type's ``Type`` string and the consumer's
+  contract is captured through that.
+
+The PR diff on the YAML is the reviewer-visible signal that an API change
+is happening. The checker enforces the mechanical invariants; reviewers
+approve intent.
+"""
+
+from __future__ import annotations
+
+import enum
+import importlib
+import pathlib
+from typing import Any
+
+import pytest
+import yaml
+
+REFERENCE_PATH = pathlib.Path(__file__).parent / "references" / "trtllm_serve_api.yaml"
+
+_PROTOCOL_MODULE = "tensorrt_llm.serve.openai_protocol"
+
+# Single source of truth for the allowed status vocabulary AND its forward-only
+# rank ordering. The CI gate derives everything else from this dict so the
+# vocabulary cannot drift between checks: adding a new status here automatically
+# updates both the membership test and the rank check.
+#
+# Forward-only transitions:
+#     prototype → beta → stable → deprecated
+STATUS_RANK: dict[str, int] = {
+    "prototype": 0,
+    "beta": 1,
+    "stable": 2,
+    "deprecated": 3,
+}
+ALLOWED_TAGS: tuple[str, ...] = tuple(STATUS_RANK.keys())
+ALLOWED_KINDS: tuple[str, ...] = ("openai", "extension")
+
+
+def _load_reference() -> dict[str, Any]:
+    with open(REFERENCE_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def _load_model(name: str):
+    """Resolve a Pydantic model class by name from the protocol module."""
+    module = importlib.import_module(_PROTOCOL_MODULE)
+    cls = getattr(module, name, None)
+    assert cls is not None, (
+        f"Model {name!r} is in the stability reference YAML but not in "
+        f"{_PROTOCOL_MODULE}. Was the class renamed or moved?"
+    )
+    return cls
+
+
+def _render_live_default(field_info) -> Any:
+    """Render a Pydantic FieldInfo's default into the YAML's wire shape.
+
+    * ``default_factory=<fn>`` → ``"<factory:<fn.__name__>>"``.
+    * Pydantic's ``PydanticUndefined`` sentinel (no default given) → ``None``.
+      This is ambiguous with "optional with default=None"; the separate
+      ``required:`` check disambiguates the two.
+    * Enum-valued defaults (e.g. ``ReasoningEffort.LOW``) → render as
+      ``"<ClassName>.<MEMBER>"`` so the YAML stays human-readable and
+      diffable without quoting tricks.
+    * Otherwise the literal default value (yaml.safe_load returns the same
+      Python types we get from ``model_fields[].default``).
+    """
+    if field_info.default_factory is not None:
+        return f"<factory:{field_info.default_factory.__name__}>"
+    default = field_info.default
+    from pydantic_core import PydanticUndefined
+
+    if default is PydanticUndefined:
+        return None
+    if isinstance(default, enum.Enum):
+        return f"{type(default).__name__}.{default.name}"
+    return default
+
+
+class TestServeAPIStability:
+    """Diff the YAML reference against the live Pydantic schema."""
+
+    @pytest.fixture(scope="class")
+    def reference(self) -> dict[str, Any]:
+        return _load_reference()
+
+    def test_tags_are_in_allowed_set(self, reference):
+        """Every YAML entry's ``status`` must be one of the allowed values."""
+        bad: list[str] = []
+        for model_name, model_spec in (reference.get("models", {}) or {}).items():
+            for fname, ref_spec in ((model_spec or {}).get("fields", {}) or {}).items():
+                status = (ref_spec or {}).get("status")
+                if status not in ALLOWED_TAGS:
+                    bad.append(f"  {model_name}.{fname}: status={status!r}")
+        if bad:
+            pytest.fail(
+                f"YAML entries with invalid status (allowed: {ALLOWED_TAGS}):\n" + "\n".join(bad)
+            )
+
+    def test_kinds_are_in_allowed_set(self, reference):
+        """Every YAML entry's ``kind`` must be one of the allowed values."""
+        bad: list[str] = []
+        for model_name, model_spec in (reference.get("models", {}) or {}).items():
+            for fname, ref_spec in ((model_spec or {}).get("fields", {}) or {}).items():
+                kind = (ref_spec or {}).get("kind")
+                if kind not in ALLOWED_KINDS:
+                    bad.append(f"  {model_name}.{fname}: kind={kind!r}")
+        if bad:
+            pytest.fail(
+                f"YAML entries with invalid kind (allowed: {ALLOWED_KINDS}):\n" + "\n".join(bad)
+            )
+
+    def test_yaml_fields_exist_on_live_model(self, reference):
+        """Every YAML-listed field must still exist on the live Pydantic model.
+
+        Failure modes caught here:
+          * Field renamed in code without YAML update.
+          * Field removed in code without a deprecation cycle first.
+          * Whole model removed / moved without YAML update.
+        """
+        errors: list[str] = []
+        for model_name, model_spec in (reference.get("models", {}) or {}).items():
+            cls = _load_model(model_name)
+            live_fields = dict(cls.model_fields)
+            ref_fields = (model_spec or {}).get("fields", {}) or {}
+            for fname in ref_fields:
+                if fname not in live_fields:
+                    errors.append(
+                        f"[{model_name}] field `{fname}` is in the YAML but "
+                        "no longer in the code. If you removed it, was it "
+                        "deprecated for at least one minor release first?"
+                    )
+        if errors:
+            pytest.fail("Missing-in-code violations:\n" + "\n".join(errors))
+
+    def test_live_fields_are_in_yaml(self, reference):
+        """Every live Pydantic field on a gated model must be listed in the YAML.
+
+        This is the forcing function: a PR that adds a new field on a gated
+        request / response model cannot land until the contributor picks a
+        ``kind:`` (``openai`` or ``extension``) and a ``status:``
+        (``prototype | beta | stable | deprecated``) and commits the matching
+        YAML row. The YAML diff is the reviewer-visible signal that the API
+        surface changed.
+
+        Models are considered "gated" iff they appear under ``models:`` in
+        the YAML. Helper / inner classes that have no top-level entry are
+        not gated here.
+        """
+        errors: list[str] = []
+        for model_name, model_spec in (reference.get("models", {}) or {}).items():
+            cls = _load_model(model_name)
+            live_fields = dict(cls.model_fields)
+            ref_fields = (model_spec or {}).get("fields", {}) or {}
+            for fname in live_fields:
+                if fname not in ref_fields:
+                    errors.append(
+                        f"[{model_name}] live field `{fname}` is missing "
+                        "from the stability reference YAML. Add a row with "
+                        "`kind:` (openai | extension) and `status:` "
+                        "(prototype | beta | stable | deprecated). New "
+                        "TRT-LLM extensions should start at `status: "
+                        "prototype`."
+                    )
+        if errors:
+            pytest.fail("Untracked-field violations:\n" + "\n".join(errors))
+
+    def test_defaults_match_yaml(self, reference):
+        """Per-field default in the YAML must match the live model's default.
+
+        We only diff ``default`` (not ``type``). Type strings in the YAML
+        are documentation-only — a type change typically surfaces via a
+        default change, a required-ness flip, or a rename, all of which the
+        other checks catch.
+        """
+        errors: list[str] = []
+        for model_name, model_spec in (reference.get("models", {}) or {}).items():
+            cls = _load_model(model_name)
+            live_fields = dict(cls.model_fields)
+            ref_fields = (model_spec or {}).get("fields", {}) or {}
+            for fname, ref_spec in ref_fields.items():
+                if fname not in live_fields:
+                    # Already reported by test_yaml_fields_exist_on_live_model.
+                    continue
+                live_default = _render_live_default(live_fields[fname])
+                ref_default = (ref_spec or {}).get("default")
+                if live_default != ref_default:
+                    errors.append(
+                        f"[{model_name}.{fname}] default drift: "
+                        f"code={live_default!r} vs yaml={ref_default!r}. "
+                        "Update one or the other."
+                    )
+        if errors:
+            pytest.fail("Default-drift violations:\n" + "\n".join(errors))
+
+    def test_required_matches_yaml(self, reference):
+        """Required-ness in the YAML must match ``FieldInfo.is_required()``.
+
+        Without this check, two distinct wire contracts collapse into one:
+          * a *required* field (``model: str``, no default), and
+          * an *optional* field with an explicit None default
+            (``model: Optional[str] = None``).
+
+        Both render ``_render_live_default`` to ``None``, so
+        ``test_defaults_match_yaml`` cannot distinguish them. Flipping
+        between the two is a breaking change for clients: the former
+        rejects requests that omit ``model``, the latter accepts them.
+        Recording ``required:`` separately and diffing it here closes that
+        gap.
+        """
+        errors: list[str] = []
+        for model_name, model_spec in (reference.get("models", {}) or {}).items():
+            cls = _load_model(model_name)
+            live_fields = dict(cls.model_fields)
+            ref_fields = (model_spec or {}).get("fields", {}) or {}
+            for fname, ref_spec in ref_fields.items():
+                if fname not in live_fields:
+                    continue
+                live_required = bool(live_fields[fname].is_required())
+                ref_required = (ref_spec or {}).get("required")
+                if ref_required is None:
+                    errors.append(
+                        f"[{model_name}.{fname}] YAML row missing `required:` "
+                        "field. Add `required: true` or `required: false`."
+                    )
+                    continue
+                if live_required != bool(ref_required):
+                    errors.append(
+                        f"[{model_name}.{fname}] required drift: "
+                        f"code={live_required!r} vs yaml={bool(ref_required)!r}. "
+                        "A required→optional flip is a breaking change; update "
+                        "the code or the YAML to match."
+                    )
+        if errors:
+            pytest.fail("Required-drift violations:\n" + "\n".join(errors))
+
+    def test_status_values_are_rankable(self, reference):
+        """Every status in the YAML must be in the forward-only rank table.
+
+        ``prototype → beta → stable → deprecated``. This is a shape check
+        on the YAML itself; cross-revision demotion checks (was-stable-
+        now-beta) are a reviewer job, not a CI one.
+        """
+        bad: list[str] = []
+        for model_name, model_spec in (reference.get("models", {}) or {}).items():
+            for fname, ref_spec in ((model_spec or {}).get("fields", {}) or {}).items():
+                status = (ref_spec or {}).get("status")
+                if status not in STATUS_RANK:
+                    bad.append(
+                        f"  {model_name}.{fname}: status={status!r} not in the ranked status set."
+                    )
+        if bad:
+            pytest.fail("Unrankable statuses:\n" + "\n".join(bad))


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated checks to keep the `trtllm-serve` HTTP API stable and consistent over time.
  * The API stability checks now verify field presence, default values, and allowed status/type labels across request and response schemas.
  * This helps catch unintended API changes earlier and improves confidence in OpenAI-compatible and extension fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

Tag every field on the user-facing Pydantic request/response models in
`openai_protocol.py` with `kind:` (`openai | extension`) and `status:`
(`stable | beta | prototype | deprecated`), recorded in a single YAML. A CI test
diffs the live schema against the YAML and fails on drift.

**YAML-only metadata.** `openai_protocol.py` is internal and not in any public
doc, so we don't clutter every field with an inline annotation — the YAML alone
is the contract.

**Status assignment.**
- `kind: openai` fields matched against
  [`openai/openai-openapi`](https://github.com/openai/openai-openapi) → all `stable`.
- `kind: extension` fields bucketed by age in `git log -S`: <6m `prototype`,
  6–12m `beta`, >12m `stable`. Forward-only after that.

15 models, 235 fields (136 openai, 99 extension).

**The gate enforces:**
1. Every live field has a YAML row — adding a flag without updating the YAML
   fails the build (the forcing function).
2. Every YAML row still exists in code (catches renames / removals).
3. Defaults match between code and YAML.
4. `status` and `kind` values are in the allowed sets.

Pydantic models are untouched — strictly additive (2 new files). No existing
test needs to change.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

- `tests/unittest/api_stability/test_serve_api.py`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
