### PR TITLE
[None][fix] report NCCL init timeout

### DIFF
--- a/cpp/tensorrt_llm/runtime/ncclCommunicator.cpp
+++ b/cpp/tensorrt_llm/runtime/ncclCommunicator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 #include "tensorrt_llm/runtime/ncclCommunicator.h"
 
+#include "tensorrt_llm/common/envUtils.h"
 #include "tensorrt_llm/common/logger.h"
 #include "tensorrt_llm/runtime/utils/multiDeviceUtils.h"
 
@@ -23,11 +24,80 @@
 #include <nccl.h>
 #endif // ENABLE_MULTI_DEVICE
 
+#include <chrono>
+#include <cstdlib>
+#include <thread>
+
 using namespace tensorrt_llm::runtime;
 
 namespace
 {
 #if ENABLE_MULTI_DEVICE
+constexpr int kDefaultNcclCommInitTimeoutSec = 60;
+constexpr int kNcclCommInitPollIntervalMs = 20;
+constexpr char const* kNcclCommInitTimeoutEnv = "TRTLLM_NCCL_COMM_INIT_TIMEOUT_SEC";
+
+int getNcclCommInitTimeoutSec()
+{
+    auto const timeoutSec
+        = tensorrt_llm::common::getIntEnv(kNcclCommInitTimeoutEnv).value_or(kDefaultNcclCommInitTimeoutSec);
+    return timeoutSec > 0 ? timeoutSec : kDefaultNcclCommInitTimeoutSec;
+}
+
+ncclComm_t initNcclCommWithTimeout(ncclUniqueId const& id, int worldSize, int rank, int timeoutSec)
+{
+    ncclComm_t comm{nullptr};
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    config.blocking = 0;
+
+    auto result = ncclCommInitRankConfig(&comm, worldSize, id, rank, &config);
+    if (result == ncclSuccess)
+    {
+        return comm;
+    }
+    if (result != ncclInProgress)
+    {
+        TLLM_THROW("NCCL communicator initialization failed on rank %d of %d: %s.", rank, worldSize,
+            ncclGetErrorString(result));
+    }
+    if (comm == nullptr)
+    {
+        TLLM_THROW(
+            "NCCL communicator initialization is in progress on rank %d of %d but returned a null "
+            "communicator.",
+            rank, worldSize);
+    }
+
+    auto const deadline = std::chrono::steady_clock::now() + std::chrono::seconds{timeoutSec};
+    while (true)
+    {
+        ncclResult_t asyncResult = ncclSuccess;
+        result = ncclCommGetAsyncError(comm, &asyncResult);
+        if (result != ncclSuccess)
+        {
+            TLLM_THROW("NCCL communicator initialization failed while polling rank %d of %d: %s.", rank, worldSize,
+                ncclGetErrorString(result));
+        }
+        if (asyncResult == ncclSuccess)
+        {
+            return comm;
+        }
+        if (asyncResult != ncclInProgress)
+        {
+            TLLM_THROW("NCCL communicator initialization failed asynchronously on rank %d of %d: %s.", rank, worldSize,
+                ncclGetErrorString(asyncResult));
+        }
+        if (std::chrono::steady_clock::now() >= deadline)
+        {
+            TLLM_THROW(
+                "NCCL communicator initialization timed out after %d seconds on rank %d of %d in "
+                "NcclCommunicator::createComm. This indicates NCCL init is hung. TensorRT-LLM will not retry "
+                "in-process. Set %s to adjust the timeout.",
+                timeoutSec, rank, worldSize, kNcclCommInitTimeoutEnv);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds{kNcclCommInitPollIntervalMs});
+    }
+}
 
 ncclDataType_t toNcclType(nvinfer1::DataType dataType)
 {
@@ -79,16 +149,14 @@ ncclComm_t NcclCommunicator::createComm(int worldSize, int rank, mpi::MpiComm co
         ncclGetUniqueId(&id);
     }
     mpiComm.bcastValue(id, 0);
-    ncclComm_t comm;
-// Need static connection initialization for accurate KV cache size estimation
+// Need static connection initialization for accurate KV cache size estimation.
 #if defined(_WIN32)
     if (getenv("NCCL_RUNTIME_CONNECT") == nullptr)
         _putenv_s("NCCL_RUNTIME_CONNECT", "0");
 #else
     setenv("NCCL_RUNTIME_CONNECT", "0", 0);
 #endif // _WIN32
-    TLLM_NCCL_CHECK(ncclCommInitRank(&comm, worldSize, id, rank));
-    return comm;
+    return initNcclCommWithTimeout(id, worldSize, rank, getNcclCommInitTimeoutSec());
 #else
     // Python runtime requires instantiation of a communicator even though it may never be used to enable
     // pipeline parallel code-path. To enable this, have an empty communicator with uninitialized state.

--- a/cpp/tensorrt_llm/runtime/ncclCommunicator.cpp
+++ b/cpp/tensorrt_llm/runtime/ncclCommunicator.cpp
@@ -45,35 +45,6 @@ int getNcclCommInitTimeoutSec()
     return timeoutSec > 0 ? timeoutSec : kDefaultNcclCommInitTimeoutSec;
 }
 
-void waitForNcclAsyncCompletion(ncclComm_t comm)
-{
-    while (true)
-    {
-        ncclResult_t asyncResult = ncclSuccess;
-        auto const result = ncclCommGetAsyncError(comm, &asyncResult);
-        TLLM_NCCL_CHECK(result);
-        if (asyncResult == ncclSuccess)
-        {
-            return;
-        }
-        if (asyncResult != ncclInProgress)
-        {
-            TLLM_NCCL_CHECK(asyncResult);
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds{kNcclCommInitPollIntervalMs});
-    }
-}
-
-void checkNcclAsyncResult(ncclComm_t comm, ncclResult_t result)
-{
-    if (result == ncclInProgress)
-    {
-        waitForNcclAsyncCompletion(comm);
-        return;
-    }
-    TLLM_NCCL_CHECK(result);
-}
-
 void initNcclCommProbeWithTimeout(ncclUniqueId const& id, int worldSize, int rank, int timeoutSec)
 {
     ncclComm_t comm{nullptr};
@@ -131,18 +102,6 @@ void initNcclCommProbeWithTimeout(ncclUniqueId const& id, int worldSize, int ran
     }
 }
 
-ncclComm_t initBlockingNcclComm(ncclUniqueId const& id, int worldSize, int rank)
-{
-    ncclComm_t comm{nullptr};
-    auto const result = ncclCommInitRank(&comm, worldSize, id, rank);
-    if (result != ncclSuccess)
-    {
-        TLLM_THROW("NCCL communicator initialization failed on rank %d of %d: %s.", rank, worldSize,
-            ncclGetErrorString(result));
-    }
-    return comm;
-}
-
 ncclDataType_t toNcclType(nvinfer1::DataType dataType)
 {
     switch (dataType)
@@ -167,7 +126,7 @@ void NcclCommunicator::send(
     void const* sendbuff, size_t count, nvinfer1::DataType dataType, int peer, CudaStream const& stream) const
 {
 #if ENABLE_MULTI_DEVICE
-    checkNcclAsyncResult(mComm, ncclSend(sendbuff, count, toNcclType(dataType), peer, mComm, stream.get()));
+    TLLM_NCCL_CHECK(ncclSend(sendbuff, count, toNcclType(dataType), peer, mComm, stream.get()));
 #else
     TLLM_THROW("Multi device support is disabled.");
 #endif // ENABLE_MULTI_DEVICE
@@ -177,7 +136,7 @@ void NcclCommunicator::receive(
     void* sendbuff, size_t count, nvinfer1::DataType dataType, int peer, CudaStream const& stream) const
 {
 #if ENABLE_MULTI_DEVICE
-    checkNcclAsyncResult(mComm, ncclRecv(sendbuff, count, toNcclType(dataType), peer, mComm, stream.get()));
+    TLLM_NCCL_CHECK(ncclRecv(sendbuff, count, toNcclType(dataType), peer, mComm, stream.get()));
 #else
     TLLM_THROW("Multi device support is disabled.");
 #endif // ENABLE_MULTI_DEVICE
@@ -210,7 +169,9 @@ ncclComm_t NcclCommunicator::createComm(int worldSize, int rank, mpi::MpiComm co
         TLLM_NCCL_CHECK(ncclGetUniqueId(&id));
     }
     mpiComm.bcastValue(id, 0);
-    return initBlockingNcclComm(id, worldSize, rank);
+    ncclComm_t comm;
+    TLLM_NCCL_CHECK(ncclCommInitRank(&comm, worldSize, id, rank));
+    return comm;
 #else
     // Python runtime requires instantiation of a communicator even though it may never be used to enable
     // pipeline parallel code-path. To enable this, have an empty communicator with uninitialized state.

--- a/cpp/tensorrt_llm/runtime/ncclCommunicator.cpp
+++ b/cpp/tensorrt_llm/runtime/ncclCommunicator.cpp
@@ -18,6 +18,7 @@
 
 #include "tensorrt_llm/common/envUtils.h"
 #include "tensorrt_llm/common/logger.h"
+#include "tensorrt_llm/runtime/ipcNvlsMemory.h"
 #include "tensorrt_llm/runtime/utils/multiDeviceUtils.h"
 
 #if ENABLE_MULTI_DEVICE
@@ -42,6 +43,35 @@ int getNcclCommInitTimeoutSec()
     auto const timeoutSec
         = tensorrt_llm::common::getIntEnv(kNcclCommInitTimeoutEnv).value_or(kDefaultNcclCommInitTimeoutSec);
     return timeoutSec > 0 ? timeoutSec : kDefaultNcclCommInitTimeoutSec;
+}
+
+void waitForNcclAsyncCompletion(ncclComm_t comm)
+{
+    while (true)
+    {
+        ncclResult_t asyncResult = ncclSuccess;
+        auto const result = ncclCommGetAsyncError(comm, &asyncResult);
+        TLLM_NCCL_CHECK(result);
+        if (asyncResult == ncclSuccess)
+        {
+            return;
+        }
+        if (asyncResult != ncclInProgress)
+        {
+            TLLM_NCCL_CHECK(asyncResult);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds{kNcclCommInitPollIntervalMs});
+    }
+}
+
+void checkNcclAsyncResult(ncclComm_t comm, ncclResult_t result)
+{
+    if (result == ncclInProgress)
+    {
+        waitForNcclAsyncCompletion(comm);
+        return;
+    }
+    TLLM_NCCL_CHECK(result);
 }
 
 ncclComm_t initNcclCommWithTimeout(ncclUniqueId const& id, int worldSize, int rank, int timeoutSec)
@@ -123,7 +153,7 @@ void NcclCommunicator::send(
     void const* sendbuff, size_t count, nvinfer1::DataType dataType, int peer, CudaStream const& stream) const
 {
 #if ENABLE_MULTI_DEVICE
-    TLLM_NCCL_CHECK(ncclSend(sendbuff, count, toNcclType(dataType), peer, mComm, stream.get()));
+    checkNcclAsyncResult(mComm, ncclSend(sendbuff, count, toNcclType(dataType), peer, mComm, stream.get()));
 #else
     TLLM_THROW("Multi device support is disabled.");
 #endif // ENABLE_MULTI_DEVICE
@@ -133,7 +163,7 @@ void NcclCommunicator::receive(
     void* sendbuff, size_t count, nvinfer1::DataType dataType, int peer, CudaStream const& stream) const
 {
 #if ENABLE_MULTI_DEVICE
-    TLLM_NCCL_CHECK(ncclRecv(sendbuff, count, toNcclType(dataType), peer, mComm, stream.get()));
+    checkNcclAsyncResult(mComm, ncclRecv(sendbuff, count, toNcclType(dataType), peer, mComm, stream.get()));
 #else
     TLLM_THROW("Multi device support is disabled.");
 #endif // ENABLE_MULTI_DEVICE
@@ -143,19 +173,23 @@ ncclComm_t NcclCommunicator::createComm(int worldSize, int rank, mpi::MpiComm co
 {
 #if ENABLE_MULTI_DEVICE
 
-    ncclUniqueId id;
-    if (rank == 0)
-    {
-        ncclGetUniqueId(&id);
-    }
-    mpiComm.bcastValue(id, 0);
 // Need static connection initialization for accurate KV cache size estimation.
 #if defined(_WIN32)
     if (getenv("NCCL_RUNTIME_CONNECT") == nullptr)
         _putenv_s("NCCL_RUNTIME_CONNECT", "0");
 #else
     setenv("NCCL_RUNTIME_CONNECT", "0", 0);
+    if (getenv("NCCL_NVLS_ENABLE") == nullptr && !ipcNvlsSupported())
+    {
+        setenv("NCCL_NVLS_ENABLE", "0", 0);
+    }
 #endif // _WIN32
+    ncclUniqueId id;
+    if (rank == 0)
+    {
+        ncclGetUniqueId(&id);
+    }
+    mpiComm.bcastValue(id, 0);
     return initNcclCommWithTimeout(id, worldSize, rank, getNcclCommInitTimeoutSec());
 #else
     // Python runtime requires instantiation of a communicator even though it may never be used to enable

--- a/cpp/tensorrt_llm/runtime/ncclCommunicator.cpp
+++ b/cpp/tensorrt_llm/runtime/ncclCommunicator.cpp
@@ -74,7 +74,7 @@ void checkNcclAsyncResult(ncclComm_t comm, ncclResult_t result)
     TLLM_NCCL_CHECK(result);
 }
 
-ncclComm_t initNcclCommWithTimeout(ncclUniqueId const& id, int worldSize, int rank, int timeoutSec)
+void initNcclCommProbeWithTimeout(ncclUniqueId const& id, int worldSize, int rank, int timeoutSec)
 {
     ncclComm_t comm{nullptr};
     ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
@@ -83,7 +83,8 @@ ncclComm_t initNcclCommWithTimeout(ncclUniqueId const& id, int worldSize, int ra
     auto result = ncclCommInitRankConfig(&comm, worldSize, id, rank, &config);
     if (result == ncclSuccess)
     {
-        return comm;
+        TLLM_NCCL_CHECK(ncclCommDestroy(comm));
+        return;
     }
     if (result != ncclInProgress)
     {
@@ -105,28 +106,41 @@ ncclComm_t initNcclCommWithTimeout(ncclUniqueId const& id, int worldSize, int ra
         result = ncclCommGetAsyncError(comm, &asyncResult);
         if (result != ncclSuccess)
         {
-            TLLM_THROW("NCCL communicator initialization failed while polling rank %d of %d: %s.", rank, worldSize,
-                ncclGetErrorString(result));
+            TLLM_THROW("NCCL communicator probe initialization failed while polling rank %d of %d: %s.", rank,
+                worldSize, ncclGetErrorString(result));
         }
         if (asyncResult == ncclSuccess)
         {
-            return comm;
+            TLLM_NCCL_CHECK(ncclCommDestroy(comm));
+            return;
         }
         if (asyncResult != ncclInProgress)
         {
-            TLLM_THROW("NCCL communicator initialization failed asynchronously on rank %d of %d: %s.", rank, worldSize,
-                ncclGetErrorString(asyncResult));
+            TLLM_THROW("NCCL communicator probe initialization failed asynchronously on rank %d of %d: %s.", rank,
+                worldSize, ncclGetErrorString(asyncResult));
         }
         if (std::chrono::steady_clock::now() >= deadline)
         {
             TLLM_THROW(
-                "NCCL communicator initialization timed out after %d seconds on rank %d of %d in "
+                "NCCL communicator probe initialization timed out after %d seconds on rank %d of %d in "
                 "NcclCommunicator::createComm. This indicates NCCL init is hung. TensorRT-LLM will not retry "
                 "in-process. Set %s to adjust the timeout.",
                 timeoutSec, rank, worldSize, kNcclCommInitTimeoutEnv);
         }
         std::this_thread::sleep_for(std::chrono::milliseconds{kNcclCommInitPollIntervalMs});
     }
+}
+
+ncclComm_t initBlockingNcclComm(ncclUniqueId const& id, int worldSize, int rank)
+{
+    ncclComm_t comm{nullptr};
+    auto const result = ncclCommInitRank(&comm, worldSize, id, rank);
+    if (result != ncclSuccess)
+    {
+        TLLM_THROW("NCCL communicator initialization failed on rank %d of %d: %s.", rank, worldSize,
+            ncclGetErrorString(result));
+    }
+    return comm;
 }
 
 ncclDataType_t toNcclType(nvinfer1::DataType dataType)
@@ -187,10 +201,16 @@ ncclComm_t NcclCommunicator::createComm(int worldSize, int rank, mpi::MpiComm co
     ncclUniqueId id;
     if (rank == 0)
     {
-        ncclGetUniqueId(&id);
+        TLLM_NCCL_CHECK(ncclGetUniqueId(&id));
     }
     mpiComm.bcastValue(id, 0);
-    return initNcclCommWithTimeout(id, worldSize, rank, getNcclCommInitTimeoutSec());
+    initNcclCommProbeWithTimeout(id, worldSize, rank, getNcclCommInitTimeoutSec());
+    if (rank == 0)
+    {
+        TLLM_NCCL_CHECK(ncclGetUniqueId(&id));
+    }
+    mpiComm.bcastValue(id, 0);
+    return initBlockingNcclComm(id, worldSize, rank);
 #else
     // Python runtime requires instantiation of a communicator even though it may never be used to enable
     // pipeline parallel code-path. To enable this, have an empty communicator with uninitialized state.


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-device startup reliability by adding safer communicator initialization with built-in timeout and clearer failure handling.
  * Prevented hangs during initialization by aborting and surfacing errors when setup does not complete in time.
  * Added more robust handling for device communication setup to better support complex multi-device runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Make NCCL communicator initialization nonblocking and fail with a clear timeout error instead of waiting indefinitely when NCCL init hangs. The timeout is controlled by `TRTLLM_NCCL_COMM_INIT_TIMEOUT_SEC` and defaults to 60 seconds.

## Test Coverage

- `pre-commit run --files cpp/tensorrt_llm/runtime/ncclCommunicator.cpp`
- `cmake --build cpp/build --target runtime_src -j 16`

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.