### PR TITLE
[https://nvbugs/6344107][fix] Enable disagg partial reuse store for PP>1

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -563,6 +563,15 @@ class PyExecutor:
             self.enable_kv_cache_reuse
             and self.kv_cache_manager.enable_partial_reuse
             and not isinstance(self.kv_cache_manager, KVCacheManagerV2))
+        # Eager-store ctx blocks into the reuse trie at transfer start (and
+        # early-terminate via the same path) so a following request can reuse
+        # them immediately. Required for PP>1 disagg: lazy commit-on-terminate
+        # races behind the next request's reuse lookup, yielding a partial
+        # match. store_blocks_for_reuse is V1 KVCacheManager only;
+        # KVCacheManagerV2 has no equivalent yet.
+        self.enable_disagg_partial_reuse_store = (
+            self.enable_partial_reuse_for_disagg
+            and not self.kv_cache_manager.is_vswa)
 
         self.max_input_len = max_input_len
         # _executor_loop private data
@@ -607,12 +616,9 @@ class PyExecutor:
         # ADP dummy role for _pad_attention_dp_dummy_request. Default is gen;
         # updated from observed request types.
         self._adp_dummy_is_gen: bool = True
-        # TODO: Remove the condition on the PP size once disagg support from KVCache reuse
-        # path is fixed.
         self.async_transfer_manager = AsyncTransferManager(
             self.resource_manager,
-            should_store_blocks=self.enable_partial_reuse_for_disagg
-            and not self.kv_cache_manager.is_vswa and self.dist.pp_size == 1)
+            should_store_blocks=self.enable_disagg_partial_reuse_store)
 
         # Router is built after async_transfer_manager so KVCacheAwareADPRouter
         # can receive the transfer-manager reference at construction time.
@@ -5717,11 +5723,11 @@ class PyExecutor:
                                     f"Request {request.py_request_id} has no avg_decoded_tokens_per_iter"
                                 )
 
-                # TODO: Remove PP size == 1 gate for disagg + block reuse with PP > 1.
+                # Must stay consistent with should_store_blocks: when blocks
+                # are eager-stored, _end_transfer_and_maybe_terminate skips
+                # termination assuming this early-termination path ran.
                 force_terminate_for_partial_reuse = (
-                    self.enable_partial_reuse_for_disagg
-                    and not self.kv_cache_manager.is_vswa
-                    and self.dist.pp_size == 1)
+                    self.async_transfer_manager.should_store_blocks)
                 if request.is_disagg_context_complete_state:
                     # Already terminated by _check_disagg_ctx_cache_transfer_status;
                     # track for stats only to avoid double-free (nvbug/5961736).

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -563,15 +563,22 @@ class PyExecutor:
             self.enable_kv_cache_reuse
             and self.kv_cache_manager.enable_partial_reuse
             and not isinstance(self.kv_cache_manager, KVCacheManagerV2))
-        # Eager-store ctx blocks into the reuse trie at transfer start (and
-        # early-terminate via the same path) so a following request can reuse
-        # them immediately. Required for PP>1 disagg: lazy commit-on-terminate
-        # races behind the next request's reuse lookup, yielding a partial
-        # match. store_blocks_for_reuse is V1 KVCacheManager only;
+        # Store+pin ctx blocks into the reuse trie at transfer start so the next
+        # request reuses them immediately (PP>1 otherwise commits too late and
+        # only partially matches). No collective is required for the
+        # store-and-pin operation. store_blocks_for_reuse is V1-only;
         # KVCacheManagerV2 has no equivalent yet.
         self.enable_disagg_partial_reuse_store = (
             self.enable_partial_reuse_for_disagg
             and not self.kv_cache_manager.is_vswa)
+        # Early-terminating the ctx request in _handle_responses (at prefill
+        # done) is a PP=1-only latency win. Under PP>1, ctx termination is
+        # routed through the DisaggPPTerminationHandler cross-rank ring
+        # consensus, which is only validated against the transfer-complete
+        # trigger; driving it from the early path regressed to a hang in CI.
+        # So PP>1 keeps eager-store but terminates via the transfer-complete path.
+        self.force_terminate_ctx_for_partial_reuse = (
+            self.enable_disagg_partial_reuse_store and self.dist.pp_size == 1)
 
         self.max_input_len = max_input_len
         # _executor_loop private data
@@ -976,11 +983,9 @@ class PyExecutor:
                 self._terminate_request(request)
             return
         if self.async_transfer_manager.end_transfer(request):
-            # When should_store_blocks is True, _handle_responses already
-            # terminated this request via the early-termination path
-            # (enable_partial_reuse_for_disagg branch). Skip the redundant
-            # termination to avoid double free_resources calls.
-            if not self.async_transfer_manager.should_store_blocks:
+            # Skip if the PP=1 early path already terminated this request;
+            # under PP>1 that path is off, so terminate here on transfer-complete.
+            if not self.force_terminate_ctx_for_partial_reuse:
                 self._terminate_request(request)
 
     def _flush_pending_transfer_responses(self):
@@ -5723,11 +5728,10 @@ class PyExecutor:
                                     f"Request {request.py_request_id} has no avg_decoded_tokens_per_iter"
                                 )
 
-                # Must stay consistent with should_store_blocks: when blocks
-                # are eager-stored, _end_transfer_and_maybe_terminate skips
-                # termination assuming this early-termination path ran.
+                # PP=1-only early termination; _end_transfer_and_maybe_terminate
+                # gates on the same flag so the request terminates exactly once.
                 force_terminate_for_partial_reuse = (
-                    self.async_transfer_manager.should_store_blocks)
+                    self.force_terminate_ctx_for_partial_reuse)
                 if request.is_disagg_context_complete_state:
                     # Already terminated by _check_disagg_ctx_cache_transfer_status;
                     # track for stats only to avoid double-free (nvbug/5961736).

--- a/tests/unittest/_torch/executor/test_py_executor.py
+++ b/tests/unittest/_torch/executor/test_py_executor.py
@@ -191,19 +191,24 @@ def test_getter_methods(mock_executor):
     assert mock_executor.get_waiting_queue_size() == 1
 
 
-def _classify_termination(request, enable_partial_reuse_for_disagg, is_vswa, is_kv_manager_v2):
+def _classify_termination(
+    request, enable_partial_reuse_for_disagg, is_vswa, is_kv_manager_v2, pp_size=1
+):
     """Reproduce the termination logic from _handle_responses (py_executor.py).
 
-    Mirrors ``force_terminate_for_partial_reuse = should_store_blocks``: the
-    eager-store/early-terminate path is enabled for partial-reuse disagg on the
-    V1 KVCacheManager regardless of PP size, and disabled for VSWA or
-    KVCacheManagerV2 (which has no store_blocks_for_reuse equivalent).
+    Mirrors ``force_terminate_for_partial_reuse = force_terminate_ctx_for_partial_reuse``:
+    the early-termination path is enabled only for partial-reuse disagg on the
+    V1 KVCacheManager at PP=1. It is disabled for VSWA, KVCacheManagerV2 (no
+    store_blocks_for_reuse equivalent), and PP>1 — where termination is routed
+    through the DisaggPPTerminationHandler ring consensus via the
+    transfer-complete path. (Eager block store stays enabled for PP>1, but it
+    is a separate, rank-local concern that does not affect this branch.)
 
     Returns:
         "terminate" | "stats_only" | "skip"
     """
     force_terminate_for_partial_reuse = (
-        enable_partial_reuse_for_disagg and not is_vswa and not is_kv_manager_v2
+        enable_partial_reuse_for_disagg and not is_vswa and not is_kv_manager_v2 and pp_size == 1
     )
     if request.is_disagg_context_complete_state:
         return "stats_only"
@@ -247,11 +252,14 @@ class TestDisaggTerminationGuard:
             req = _make_request(complete, transmission)
             assert _classify_termination(req, True, False, False) == "terminate"
 
-    def test_partial_reuse_terminates_in_transmission_regardless_of_pp(self):
-        """Eager-store path no longer gates on PP size: an in-transmission ctx
-        request is force-terminated whenever partial-reuse store is active."""
+    def test_partial_reuse_early_terminate_is_pp1_only(self):
+        """Early termination of an in-transmission ctx request is a PP=1-only
+        optimization. Under PP>1 it is skipped here and terminated later via
+        the transfer-complete path (ring consensus); eager store still applies."""
         req = _make_request(complete_state=False, transmission_state=True)
-        assert _classify_termination(req, True, False, False) == "terminate"
+        assert _classify_termination(req, True, False, False, pp_size=1) == "terminate"
+        req = _make_request(complete_state=False, transmission_state=True)
+        assert _classify_termination(req, True, False, False, pp_size=4) == "skip"
 
     def test_partial_reuse_skips_context_complete(self):
         """With partial reuse, CONTEXT_COMPLETE still goes to stats only."""
@@ -268,6 +276,45 @@ class TestDisaggTerminationGuard:
         store_blocks_for_reuse), falling back to normal logic."""
         req = _make_request(complete_state=False, transmission_state=True)
         assert _classify_termination(req, True, False, True) == "skip"
+
+    def test_pp_gt_1_terminates_on_transfer_complete(self):
+        """PP>1: the early path leaves the request out of requests_to_terminate
+        AND out of new_active_requests, so it is removed from active_requests
+        but retained by AsyncTransferManager. The real
+        _end_transfer_and_maybe_terminate must then terminate it exactly once
+        when the transfer completes (force_terminate_ctx_for_partial_reuse=False)."""
+        req = Mock()
+        executor = types.SimpleNamespace(
+            kv_cache_transceiver=Mock(),
+            active_requests=[],  # already removed by _handle_responses
+            async_transfer_manager=Mock(),
+            force_terminate_ctx_for_partial_reuse=False,
+            _terminate_request=Mock(),
+        )
+        executor.async_transfer_manager.end_transfer.return_value = True
+
+        PyExecutor._end_transfer_and_maybe_terminate(executor, req)
+
+        executor._terminate_request.assert_called_once_with(req)
+
+    def test_pp1_does_not_double_terminate_on_transfer_complete(self):
+        """PP=1: the early path already terminated the request (and removed it
+        from active_requests). The real _end_transfer_and_maybe_terminate must
+        skip re-terminating it (force_terminate_ctx_for_partial_reuse=True) to
+        avoid a double free_resources (nvbug/5961736)."""
+        req = Mock()
+        executor = types.SimpleNamespace(
+            kv_cache_transceiver=Mock(),
+            active_requests=[],  # already removed + terminated by early path
+            async_transfer_manager=Mock(),
+            force_terminate_ctx_for_partial_reuse=True,
+            _terminate_request=Mock(),
+        )
+        executor.async_transfer_manager.end_transfer.return_value = True
+
+        PyExecutor._end_transfer_and_maybe_terminate(executor, req)
+
+        executor._terminate_request.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittest/_torch/executor/test_py_executor.py
+++ b/tests/unittest/_torch/executor/test_py_executor.py
@@ -191,14 +191,19 @@ def test_getter_methods(mock_executor):
     assert mock_executor.get_waiting_queue_size() == 1
 
 
-def _classify_termination(request, enable_partial_reuse_for_disagg, is_vswa, pp_size):
+def _classify_termination(request, enable_partial_reuse_for_disagg, is_vswa, is_kv_manager_v2):
     """Reproduce the termination logic from _handle_responses (py_executor.py).
+
+    Mirrors ``force_terminate_for_partial_reuse = should_store_blocks``: the
+    eager-store/early-terminate path is enabled for partial-reuse disagg on the
+    V1 KVCacheManager regardless of PP size, and disabled for VSWA or
+    KVCacheManagerV2 (which has no store_blocks_for_reuse equivalent).
 
     Returns:
         "terminate" | "stats_only" | "skip"
     """
     force_terminate_for_partial_reuse = (
-        enable_partial_reuse_for_disagg and not is_vswa and pp_size == 1
+        enable_partial_reuse_for_disagg and not is_vswa and not is_kv_manager_v2
     )
     if request.is_disagg_context_complete_state:
         return "stats_only"
@@ -224,38 +229,45 @@ class TestDisaggTerminationGuard:
     def test_normal_path_skips_context_complete(self):
         """Without partial reuse, CONTEXT_COMPLETE goes to stats only."""
         req = _make_request(complete_state=True, transmission_state=False)
-        assert _classify_termination(req, False, False, 1) == "stats_only"
+        assert _classify_termination(req, False, False, False) == "stats_only"
 
     def test_normal_path_skips_transmission_in_progress(self):
         """Without partial reuse, TRANS_IN_PROGRESS is skipped (still in flight)."""
         req = _make_request(complete_state=False, transmission_state=True)
-        assert _classify_termination(req, False, False, 1) == "skip"
+        assert _classify_termination(req, False, False, False) == "skip"
 
     def test_normal_path_terminates_regular_request(self):
         """Without partial reuse, a normal finished request is terminated."""
         req = _make_request(complete_state=False, transmission_state=False)
-        assert _classify_termination(req, False, False, 1) == "terminate"
+        assert _classify_termination(req, False, False, False) == "terminate"
 
     def test_partial_reuse_terminates_non_complete(self):
         """With partial reuse, non-CONTEXT_COMPLETE requests are terminated."""
         for complete, transmission in [(False, True), (False, False)]:
             req = _make_request(complete, transmission)
-            assert _classify_termination(req, True, False, 1) == "terminate"
+            assert _classify_termination(req, True, False, False) == "terminate"
+
+    def test_partial_reuse_terminates_in_transmission_regardless_of_pp(self):
+        """Eager-store path no longer gates on PP size: an in-transmission ctx
+        request is force-terminated whenever partial-reuse store is active."""
+        req = _make_request(complete_state=False, transmission_state=True)
+        assert _classify_termination(req, True, False, False) == "terminate"
 
     def test_partial_reuse_skips_context_complete(self):
         """With partial reuse, CONTEXT_COMPLETE still goes to stats only."""
         req = _make_request(complete_state=True, transmission_state=False)
-        assert _classify_termination(req, True, False, 1) == "stats_only"
+        assert _classify_termination(req, True, False, False) == "stats_only"
 
     def test_partial_reuse_disabled_by_vswa(self):
         """VSWA disables partial reuse path, falling back to normal logic."""
-        req = _make_request(complete_state=True, transmission_state=False)
-        assert _classify_termination(req, True, True, 1) == "stats_only"
+        req = _make_request(complete_state=False, transmission_state=True)
+        assert _classify_termination(req, True, True, False) == "skip"
 
-    def test_partial_reuse_disabled_by_pp(self):
-        """PP > 1 disables partial reuse path, falling back to normal logic."""
-        req = _make_request(complete_state=True, transmission_state=False)
-        assert _classify_termination(req, True, False, 2) == "stats_only"
+    def test_partial_reuse_disabled_by_kv_manager_v2(self):
+        """KVCacheManagerV2 disables the eager-store path (no
+        store_blocks_for_reuse), falling back to normal logic."""
+        req = _make_request(complete_state=False, transmission_state=True)
+        assert _classify_termination(req, True, False, True) == "skip"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fix disaggregated gen-first cache reuse reporting for context PP > 1.

The ctx_pp4 overlap gen-first test sends the same prompt twice and expects the second response to report `cached_tokens == prompt_tokens - 1`. The usage propagation path was working, but the context-side `request.cached_tokens` was already too small before being packed into the aux buffer.

The root cause is that the eager context block store path for disagg partial reuse was gated to `pp_size == 1`. With PP>1, a following request could perform reuse lookup before the previous request's context blocks were committed for reuse, so it only observed a short partial prefix.

This PR:
- Adds a shared `enable_disagg_partial_reuse_store` condition.
- Enables eager `store_blocks_for_reuse(..., pin_blocks=True)` for PP>1 with the V1 KV cache manager.
- Keeps KVCacheManagerV2 excluded because it does not support this store/pin path yet.
- Reuses the same condition for partial-reuse early termination so request cleanup stays consistent with transfer block pinning.

## Test Coverage

Passed:

```bash
pytest -vs 'tests/integration/defs/disaggregated/test_disaggregated.py::test_disaggregated_overlap_gen_first[ctx_pp4-TinyLlama-1.1B-Chat-v1.0]'
pytest -vs 'tests/integration/defs/disaggregated/test_disaggregated.py::test_disaggregated_overlap_gen_first[ctx_pp1-TinyLlama-1.1B-Chat-v1.0]'
```

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KV-cache reuse behavior for disaggregated execution, making block storage and reuse decisions more consistent across supported cache manager types.
  * Adjusted response handling so termination behavior matches the updated eager-store logic, reducing unexpected interruptions during partial reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->