### PR TITLE
[None][feat] Optimize trtllmgen moe routing

### DIFF
--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/routing/RoutingCustom.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/routing/RoutingCustom.cu
@@ -750,25 +750,22 @@ struct ClusterPolicyTraits
 template <>
 struct ClusterPolicyTraits<ClusterBlockDim1024, NoOpPreprocess, SoftmaxPostprocess>
 {
-    using Pairs = TierList<Tier<128, 4>, Tier<128, 8>, Tier<160, 8>, Tier<256, 8>, Tier<256, 16>,
-        Tier<512, 8>, Tier<512, 16>, Tier<512, 22>, Tier<512, 32>, Tier<576, 8>, Tier<768, 32>,
-        Tier<1024, 32>, Tier<2048, 32>>;
+    using Pairs = TierList<Tier<128, 4>, Tier<128, 8>, Tier<160, 8>, Tier<256, 8>, Tier<256, 16>, Tier<512, 8>,
+        Tier<512, 16>, Tier<512, 22>, Tier<512, 32>, Tier<576, 8>, Tier<768, 32>, Tier<1024, 32>, Tier<2048, 32>>;
 };
 
 template <>
 struct ClusterPolicyTraits<ClusterBlockDim512, NoOpPreprocess, SoftmaxPostprocess>
 {
-    using Pairs = TierList<Tier<128, 4>, Tier<128, 8>, Tier<160, 8>, Tier<256, 8>, Tier<256, 16>,
-        Tier<512, 8>, Tier<512, 16>, Tier<512, 22>, Tier<512, 32>, Tier<1024, 32>, Tier<1536, 32>,
-        Tier<2048, 32>>;
+    using Pairs = TierList<Tier<128, 4>, Tier<128, 8>, Tier<160, 8>, Tier<256, 8>, Tier<256, 16>, Tier<512, 8>,
+        Tier<512, 16>, Tier<512, 22>, Tier<512, 32>, Tier<1024, 32>, Tier<1536, 32>, Tier<2048, 32>>;
 };
 
 template <>
 struct ClusterPolicyTraits<ClusterBlockDim256, NoOpPreprocess, SoftmaxPostprocess>
 {
-    using Pairs = TierList<Tier<128, 4>, Tier<128, 8>, Tier<160, 8>, Tier<256, 8>, Tier<256, 16>,
-        Tier<512, 8>, Tier<512, 16>, Tier<512, 22>, Tier<512, 32>, Tier<768, 32>, Tier<1024, 32>,
-        Tier<1536, 32>, Tier<2048, 32>>;
+    using Pairs = TierList<Tier<128, 4>, Tier<128, 8>, Tier<160, 8>, Tier<256, 8>, Tier<256, 16>, Tier<512, 8>,
+        Tier<512, 16>, Tier<512, 22>, Tier<512, 32>, Tier<768, 32>, Tier<1024, 32>, Tier<1536, 32>, Tier<2048, 32>>;
 };
 
 template <typename KernelParams, typename BaseType, int ClusterBlockDim, int ClusterNumWarps>
@@ -826,65 +823,78 @@ __device__ __forceinline__ void routingIndicesClusterKernelBody(
     }
 }
 
-template <typename KernelParams>
+template <typename KernelParams, int ClusterBlockDim = NumThreads>
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-__global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(NumThreads)
+__global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(ClusterBlockDim)
     routingIndicesClusterKernel(KernelParams params)
 {
     using InputT = typename KernelParams::InputT;
     using BaseType = typename KernelParams::ExpertSelectPolicy::template BaseType<InputT>;
     using TypePacked = PackedScoreIdx<BaseType>;
-    __shared__ TypePacked __attribute((aligned(128))) smemPackedScoreIdx[NumWarps * KernelParams::MaxNumTopExperts];
-    routingIndicesClusterKernelBody<KernelParams, BaseType, NumThreads, NumWarps>(params, smemPackedScoreIdx);
+    static constexpr int NumWarpsBlock = ClusterBlockDim / WarpSize;
+    static_assert(ClusterBlockDim % WarpSize == 0);
+    static_assert(ClusterBlockDim <= NumThreads);
+    __shared__ TypePacked __attribute((aligned(128)))
+    smemPackedScoreIdx[NumWarpsBlock * KernelParams::MaxNumTopExperts];
+    routingIndicesClusterKernelBody<KernelParams, BaseType, ClusterBlockDim, NumWarpsBlock>(params, smemPackedScoreIdx);
 }
 #else
-__global__ void __launch_bounds__(NumThreads) routingIndicesClusterKernel(KernelParams /* params */)
+__global__ void __launch_bounds__(ClusterBlockDim) routingIndicesClusterKernel(KernelParams /* params */)
 {
     assert(false && "routingIndicesClusterKernel is only supported on SM90+ architectures");
 }
 #endif // if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
 
-template <typename KernelParams>
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-__global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(ClusterBlockDim512)
-    routingIndicesClusterKernel512(KernelParams params)
+template <typename KernelParams, int ClusterBlockDim>
+void launchClusterKernelInstance(Data const& data, void* stream)
 {
-    using InputT = typename KernelParams::InputT;
-    using BaseType = typename KernelParams::ExpertSelectPolicy::template BaseType<InputT>;
-    using TypePacked = PackedScoreIdx<BaseType>;
-    static constexpr int NumWarpsBlock = ClusterBlockDim512 / WarpSize;
-    __shared__ TypePacked __attribute((aligned(128))) smemPackedScoreIdx[NumWarpsBlock
-        * KernelParams::MaxNumTopExperts];
-    routingIndicesClusterKernelBody<KernelParams, BaseType, ClusterBlockDim512, NumWarpsBlock>(
-        params, smemPackedScoreIdx);
-}
-#else
-__global__ void __launch_bounds__(ClusterBlockDim512) routingIndicesClusterKernel512(KernelParams /* params */)
-{
-    assert(false && "routingIndicesClusterKernel512 is only supported on SM90+ architectures");
-}
-#endif // if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+    static_assert(ClusterBlockDim % WarpSize == 0);
+    static_assert(ClusterBlockDim <= NumThreads);
 
-template <typename KernelParams>
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-__global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(ClusterBlockDim256)
-    routingIndicesClusterKernel256(KernelParams params)
-{
-    using InputT = typename KernelParams::InputT;
-    using BaseType = typename KernelParams::ExpertSelectPolicy::template BaseType<InputT>;
-    using TypePacked = PackedScoreIdx<BaseType>;
-    static constexpr int NumWarpsBlock = ClusterBlockDim256 / WarpSize;
-    __shared__ TypePacked __attribute((aligned(128))) smemPackedScoreIdx[NumWarpsBlock
-        * KernelParams::MaxNumTopExperts];
-    routingIndicesClusterKernelBody<KernelParams, BaseType, ClusterBlockDim256, NumWarpsBlock>(
-        params, smemPackedScoreIdx);
+    cudaLaunchConfig_t config{};
+    config.gridDim = NumBlocksPerCluster;
+    config.blockDim = ClusterBlockDim;
+    config.dynamicSmemBytes = 0;
+    config.stream = (cudaStream_t) stream;
+
+    cudaLaunchAttribute attributes[2] = {};
+    attributes[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attributes[0].val.programmaticStreamSerializationAllowed = int(data.mUsePdl);
+    attributes[1].id = cudaLaunchAttributeCooperative;
+    attributes[1].val.cooperative = 0;
+    config.attrs = attributes;
+    config.numAttrs = 2;
+
+    auto params = KernelParams::setKernelParams(data);
+    auto kernelTyped = routingIndicesClusterKernel<KernelParams, ClusterBlockDim>;
+    TLLM_CUDA_CHECK(cudaLaunchKernelEx(&config, kernelTyped, params));
 }
-#else
-__global__ void __launch_bounds__(ClusterBlockDim256) routingIndicesClusterKernel256(KernelParams /* params */)
+
+template <int ClusterBlockDim, typename PreProc, typename PostProc, int MaxNumExperts, int MaxNumTopExperts>
+void launchClusterKernelForTier(Data const& data, void* stream)
 {
-    assert(false && "routingIndicesClusterKernel256 is only supported on SM90+ architectures");
+    using ExpertSelect = TopKExpertSelect<PreProc, PostProc>;
+    if (data.mDtypeOutput == tg::Dtype::Fp32)
+    {
+        using ParamsT = KernelParams<float, float, MaxNumExperts, MaxNumTopExperts, ExpertSelect>;
+        launchClusterKernelInstance<ParamsT, ClusterBlockDim>(data, stream);
+    }
+    else if (data.mDtypeOutput == tg::Dtype::Bfloat16 && data.mDtypeInput == tg::Dtype::Fp32)
+    {
+        using ParamsT = KernelParams<float, __nv_bfloat16, MaxNumExperts, MaxNumTopExperts, ExpertSelect>;
+        launchClusterKernelInstance<ParamsT, ClusterBlockDim>(data, stream);
+    }
+    else if (data.mDtypeOutput == tg::Dtype::Bfloat16 && data.mDtypeInput == tg::Dtype::Bfloat16)
+    {
+        using ParamsT = KernelParams<__nv_bfloat16, __nv_bfloat16, MaxNumExperts, MaxNumTopExperts, ExpertSelect>;
+        launchClusterKernelInstance<ParamsT, ClusterBlockDim>(data, stream);
+    }
+    else
+    {
+        TLLM_LOG_ERROR("Unsupported dtype combination: dtypeOutput=%d, dtypeInput=%d",
+            static_cast<int>(data.mDtypeOutput), static_cast<int>(data.mDtypeInput));
+    }
 }
-#endif // if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
 
 template <int ClusterBlockDim, typename PreProc, typename PostProc>
 void launchClusterKernelForPolicy(Data const& data, void* stream)
@@ -893,24 +903,8 @@ void launchClusterKernelForPolicy(Data const& data, void* stream)
     bool dispatched = dispatchTierPairs(static_cast<Pairs*>(nullptr), data,
         [&](auto eTag, auto kTag)
         {
-            if constexpr (ClusterBlockDim == ClusterBlockDim256)
-            {
-                LAUNCH_ROUTING_WITH_POLICIES(data, false, routingIndicesClusterKernel256, NumBlocksPerCluster,
-                    ClusterBlockDim256,
-                    /*smemSize=*/0, stream, PreProc, PostProc, decltype(eTag)::value, decltype(kTag)::value);
-            }
-            else if constexpr (ClusterBlockDim == ClusterBlockDim512)
-            {
-                LAUNCH_ROUTING_WITH_POLICIES(data, false, routingIndicesClusterKernel512, NumBlocksPerCluster,
-                    ClusterBlockDim512,
-                    /*smemSize=*/0, stream, PreProc, PostProc, decltype(eTag)::value, decltype(kTag)::value);
-            }
-            else
-            {
-                LAUNCH_ROUTING_WITH_POLICIES(data, false, routingIndicesClusterKernel, NumBlocksPerCluster,
-                    ClusterBlockDim1024,
-                    /*smemSize=*/0, stream, PreProc, PostProc, decltype(eTag)::value, decltype(kTag)::value);
-            }
+            launchClusterKernelForTier<ClusterBlockDim, PreProc, PostProc, decltype(eTag)::value,
+                decltype(kTag)::value>(data, stream);
         });
     if (!dispatched)
     {
@@ -923,9 +917,7 @@ void launchClusterKernelForBlockDim(Data const& data, void* stream)
 {
     dispatchRoutingPolicy(data,
         [&](auto preProc, auto postProc)
-        {
-            launchClusterKernelForPolicy<ClusterBlockDim, decltype(preProc), decltype(postProc)>(data, stream);
-        });
+        { launchClusterKernelForPolicy<ClusterBlockDim, decltype(preProc), decltype(postProc)>(data, stream); });
 }
 
 void launchClusterKernel(Data const& data, void* stream)
@@ -943,8 +935,7 @@ void launchClusterKernel(Data const& data, void* stream)
         return;
     }
 
-    bool const useNoOpSoftmaxScores = data.mPtrScores != nullptr
-        && data.mPreprocessType == RoutingPreprocessType::None
+    bool const useNoOpSoftmaxScores = data.mPtrScores != nullptr && data.mPreprocessType == RoutingPreprocessType::None
         && data.mPostprocessType == RoutingPostprocessType::Softmax;
     if (useNoOpSoftmaxScores)
     {
@@ -975,8 +966,7 @@ struct HistogramScoresLaunchConfig : DefaultRoutingLaunchConfig<MaxNumExperts, M
     // warps per CTA gives each thread more register headroom while preserving total warp-level
     // parallelism by scaling the grid cap below.
     static constexpr bool UseHistogramScoresBlockDim = DefaultBlockDim > HistogramScoresBlockDim;
-    static constexpr int BlockDim
-        = UseHistogramScoresBlockDim ? HistogramScoresBlockDim : DefaultBlockDim;
+    static constexpr int BlockDim = UseHistogramScoresBlockDim ? HistogramScoresBlockDim : DefaultBlockDim;
 
     static_assert(BlockDim % WarpSize == 0);
     static_assert(BlockDim <= NumThreads);
@@ -999,7 +989,8 @@ struct HistogramScoresLaunchConfig : DefaultRoutingLaunchConfig<MaxNumExperts, M
         }
         else
         {
-            return DefaultRoutingLaunchConfig<MaxNumExperts, MaxNumTopExperts>::gridDim(data, numBlocks, DefaultBlockDim);
+            return DefaultRoutingLaunchConfig<MaxNumExperts, MaxNumTopExperts>::gridDim(
+                data, numBlocks, DefaultBlockDim);
         }
     }
 };
@@ -1017,9 +1008,9 @@ struct HistogramScoresPolicyTraits : PolicyTraits<PreProc, PostProc>
 template <>
 struct HistogramScoresPolicyTraits<NoOpPreprocess, SoftmaxPostprocess>
 {
-    using Pairs = TierList<Tier<128, 4>, Tier<128, 8>, Tier<160, 8>, Tier<256, 8>, Tier<256, 16>,
-        Tier<512, 8>, Tier<512, 16>, Tier<512, 22>, Tier<512, 32>, Tier<576, 8>, Tier<768, 32>,
-        Tier<1024, 32>, Tier<1536, 32>, Tier<2048, 32>>;
+    using Pairs
+        = TierList<Tier<128, 4>, Tier<128, 8>, Tier<160, 8>, Tier<256, 8>, Tier<256, 16>, Tier<512, 8>, Tier<512, 16>,
+            Tier<512, 22>, Tier<512, 32>, Tier<576, 8>, Tier<768, 32>, Tier<1024, 32>, Tier<1536, 32>, Tier<2048, 32>>;
 };
 
 template <typename KernelParams>
@@ -1103,7 +1094,8 @@ static void launchHistogramScoresKernel(Data const& data, uint32_t maxNumBlocks,
                     using LaunchConfig
                         = HistogramScoresKernelConfig<ExpertSelect, decltype(eTag)::value, decltype(kTag)::value>;
                     int const effectiveThreads = LaunchConfig::blockDim(data, static_cast<int>(numThreadsHist));
-                    int const effectiveBlocks = LaunchConfig::gridDim(data, static_cast<int>(maxNumBlocks), effectiveThreads);
+                    int const effectiveBlocks
+                        = LaunchConfig::gridDim(data, static_cast<int>(maxNumBlocks), effectiveThreads);
                     LAUNCH_ROUTING_WITH_POLICIES(data, false, routingIndicesHistogramScoresKernel, effectiveBlocks,
                         effectiveThreads,
                         /*smemSize=*/0, stream, PreProc, PostProc, decltype(eTag)::value, decltype(kTag)::value);

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/routing/RoutingCustom.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/routing/RoutingCustom.cu
@@ -715,9 +715,36 @@ static constexpr int ClusterBlockDim1024 = NumThreads;
 static constexpr int MaxNumTokensClusterScores256 = NumBlocksPerCluster * (ClusterBlockDim256 / WarpSize);
 static constexpr int MaxNumTokensClusterScores512 = NumBlocksPerCluster * (ClusterBlockDim512 / WarpSize);
 
-template <int ClusterBlockDim, typename PreProc, typename PostProc>
-struct ClusterPolicyTraits : PolicyTraits<PreProc, PostProc>
+template <typename TierT, typename TierListT>
+struct PrependTier;
+
+template <typename TierT, typename... Tiers>
+struct PrependTier<TierT, TierList<Tiers...>>
 {
+    using type = TierList<TierT, Tiers...>;
+};
+
+template <int ClusterBlockDim, typename TierListT>
+struct FilterClusterTiers;
+
+template <int ClusterBlockDim>
+struct FilterClusterTiers<ClusterBlockDim, TierList<>>
+{
+    using type = TierList<>;
+};
+
+template <int ClusterBlockDim, typename First, typename... Rest>
+struct FilterClusterTiers<ClusterBlockDim, TierList<First, Rest...>>
+{
+    using Tail = typename FilterClusterTiers<ClusterBlockDim, TierList<Rest...>>::type;
+    static constexpr bool IsValid = First::kExperts <= ClusterBlockDim || First::kExperts % ClusterBlockDim == 0;
+    using type = std::conditional_t<IsValid, typename PrependTier<First, Tail>::type, Tail>;
+};
+
+template <int ClusterBlockDim, typename PreProc, typename PostProc>
+struct ClusterPolicyTraits
+{
+    using Pairs = typename FilterClusterTiers<ClusterBlockDim, typename PolicyTraits<PreProc, PostProc>::Pairs>::type;
 };
 
 template <>
@@ -859,10 +886,10 @@ __global__ void __launch_bounds__(ClusterBlockDim256) routingIndicesClusterKerne
 }
 #endif // if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
 
-template <int ClusterBlockDim>
-void launchNoOpSoftmaxClusterKernel(Data const& data, void* stream)
+template <int ClusterBlockDim, typename PreProc, typename PostProc>
+void launchClusterKernelForPolicy(Data const& data, void* stream)
 {
-    using Pairs = typename ClusterPolicyTraits<ClusterBlockDim, NoOpPreprocess, SoftmaxPostprocess>::Pairs;
+    using Pairs = typename ClusterPolicyTraits<ClusterBlockDim, PreProc, PostProc>::Pairs;
     bool dispatched = dispatchTierPairs(static_cast<Pairs*>(nullptr), data,
         [&](auto eTag, auto kTag)
         {
@@ -870,22 +897,19 @@ void launchNoOpSoftmaxClusterKernel(Data const& data, void* stream)
             {
                 LAUNCH_ROUTING_WITH_POLICIES(data, false, routingIndicesClusterKernel256, NumBlocksPerCluster,
                     ClusterBlockDim256,
-                    /*smemSize=*/0, stream, NoOpPreprocess, SoftmaxPostprocess, decltype(eTag)::value,
-                    decltype(kTag)::value);
+                    /*smemSize=*/0, stream, PreProc, PostProc, decltype(eTag)::value, decltype(kTag)::value);
             }
             else if constexpr (ClusterBlockDim == ClusterBlockDim512)
             {
                 LAUNCH_ROUTING_WITH_POLICIES(data, false, routingIndicesClusterKernel512, NumBlocksPerCluster,
                     ClusterBlockDim512,
-                    /*smemSize=*/0, stream, NoOpPreprocess, SoftmaxPostprocess, decltype(eTag)::value,
-                    decltype(kTag)::value);
+                    /*smemSize=*/0, stream, PreProc, PostProc, decltype(eTag)::value, decltype(kTag)::value);
             }
             else
             {
                 LAUNCH_ROUTING_WITH_POLICIES(data, false, routingIndicesClusterKernel, NumBlocksPerCluster,
                     ClusterBlockDim1024,
-                    /*smemSize=*/0, stream, NoOpPreprocess, SoftmaxPostprocess, decltype(eTag)::value,
-                    decltype(kTag)::value);
+                    /*smemSize=*/0, stream, PreProc, PostProc, decltype(eTag)::value, decltype(kTag)::value);
             }
         });
     if (!dispatched)
@@ -894,28 +918,37 @@ void launchNoOpSoftmaxClusterKernel(Data const& data, void* stream)
     }
 }
 
+template <int ClusterBlockDim>
+void launchClusterKernelForBlockDim(Data const& data, void* stream)
+{
+    dispatchRoutingPolicy(data,
+        [&](auto preProc, auto postProc)
+        {
+            launchClusterKernelForPolicy<ClusterBlockDim, decltype(preProc), decltype(postProc)>(data, stream);
+        });
+}
+
 void launchClusterKernel(Data const& data, void* stream)
 {
-    // Reduced-thread cluster variants are only used for the raw-score NoOp+Softmax path. In that path
-    // each warp owns one token, so the token capacity scales with the number of warps per block.
-    // Post-topK cluster routing keeps the original 1024-thread launch to preserve its 8192-token
-    // capacity and existing policy coverage.
+    // Each warp owns one token, so the reduced-thread cluster variants have lower token capacity.
+    // Use them only where the requested token count fits; otherwise keep the original 1024-thread launch.
+    if (data.mNumTokens <= MaxNumTokensClusterScores256)
+    {
+        launchClusterKernelForBlockDim<ClusterBlockDim256>(data, stream);
+        return;
+    }
+    if (data.mNumTokens <= MaxNumTokensClusterScores512)
+    {
+        launchClusterKernelForBlockDim<ClusterBlockDim512>(data, stream);
+        return;
+    }
+
     bool const useNoOpSoftmaxScores = data.mPtrScores != nullptr
         && data.mPreprocessType == RoutingPreprocessType::None
         && data.mPostprocessType == RoutingPostprocessType::Softmax;
-    if (useNoOpSoftmaxScores && data.mNumTokens <= MaxNumTokensClusterScores256)
-    {
-        launchNoOpSoftmaxClusterKernel<ClusterBlockDim256>(data, stream);
-        return;
-    }
-    if (useNoOpSoftmaxScores && data.mNumTokens <= MaxNumTokensClusterScores512)
-    {
-        launchNoOpSoftmaxClusterKernel<ClusterBlockDim512>(data, stream);
-        return;
-    }
     if (useNoOpSoftmaxScores)
     {
-        launchNoOpSoftmaxClusterKernel<ClusterBlockDim1024>(data, stream);
+        launchClusterKernelForPolicy<ClusterBlockDim1024, NoOpPreprocess, SoftmaxPostprocess>(data, stream);
         return;
     }
 
@@ -971,6 +1004,11 @@ struct HistogramScoresLaunchConfig : DefaultRoutingLaunchConfig<MaxNumExperts, M
     }
 };
 
+template <typename ExpertSelect, int MaxNumExperts, int MaxNumTopExperts>
+struct HistogramScoresKernelConfig : HistogramScoresLaunchConfig<MaxNumExperts, MaxNumTopExperts>
+{
+};
+
 template <typename PreProc, typename PostProc>
 struct HistogramScoresPolicyTraits : PolicyTraits<PreProc, PostProc>
 {
@@ -985,15 +1023,15 @@ struct HistogramScoresPolicyTraits<NoOpPreprocess, SoftmaxPostprocess>
 };
 
 template <typename KernelParams>
-__global__ void __launch_bounds__(
-    HistogramScoresLaunchConfig<KernelParams::MaxNumExperts, KernelParams::MaxNumTopExperts>::BlockDim)
+__global__ void __launch_bounds__(HistogramScoresKernelConfig<typename KernelParams::ExpertSelectPolicy,
+    KernelParams::MaxNumExperts, KernelParams::MaxNumTopExperts>::BlockDim)
     routingIndicesHistogramScoresKernel(KernelParams params)
 {
     using OutputT = typename KernelParams::OutputT;
     using InputT = typename KernelParams::InputT;
     using BaseType = typename KernelParams::ExpertSelectPolicy::template BaseType<InputT>;
-    static constexpr int NumThreadsBlock
-        = HistogramScoresLaunchConfig<KernelParams::MaxNumExperts, KernelParams::MaxNumTopExperts>::BlockDim;
+    static constexpr int NumThreadsBlock = HistogramScoresKernelConfig<typename KernelParams::ExpertSelectPolicy,
+        KernelParams::MaxNumExperts, KernelParams::MaxNumTopExperts>::BlockDim;
 
     // VecSize stays based on MaxNumExperts — each warp still processes all experts for one token.
     static constexpr int VecSize = KernelParams::MaxNumExperts / WarpSize;
@@ -1061,7 +1099,9 @@ static void launchHistogramScoresKernel(Data const& data, uint32_t maxNumBlocks,
             bool dispatched = dispatchTierPairs(static_cast<Pairs*>(nullptr), data,
                 [&](auto eTag, auto kTag)
                 {
-                    using LaunchConfig = HistogramScoresLaunchConfig<decltype(eTag)::value, decltype(kTag)::value>;
+                    using ExpertSelect = TopKExpertSelect<PreProc, PostProc>;
+                    using LaunchConfig
+                        = HistogramScoresKernelConfig<ExpertSelect, decltype(eTag)::value, decltype(kTag)::value>;
                     int const effectiveThreads = LaunchConfig::blockDim(data, static_cast<int>(numThreadsHist));
                     int const effectiveBlocks = LaunchConfig::gridDim(data, static_cast<int>(maxNumBlocks), effectiveThreads);
                     LAUNCH_ROUTING_WITH_POLICIES(data, false, routingIndicesHistogramScoresKernel, effectiveBlocks,

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/routing/RoutingCustom.cu
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/routing/RoutingCustom.cu
@@ -709,23 +709,54 @@ void launchDynBlockKernel(Data const& data, uint32_t numThreadsHist, void* strea
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-template <typename KernelParams>
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
-__global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(NumThreads)
-    routingIndicesClusterKernel(KernelParams params)
+static constexpr int ClusterBlockDim256 = NumExperts256Experts;
+static constexpr int ClusterBlockDim512 = NumExperts512Experts;
+static constexpr int ClusterBlockDim1024 = NumThreads;
+static constexpr int MaxNumTokensClusterScores256 = NumBlocksPerCluster * (ClusterBlockDim256 / WarpSize);
+static constexpr int MaxNumTokensClusterScores512 = NumBlocksPerCluster * (ClusterBlockDim512 / WarpSize);
+
+template <int ClusterBlockDim, typename PreProc, typename PostProc>
+struct ClusterPolicyTraits : PolicyTraits<PreProc, PostProc>
+{
+};
+
+template <>
+struct ClusterPolicyTraits<ClusterBlockDim1024, NoOpPreprocess, SoftmaxPostprocess>
+{
+    using Pairs = TierList<Tier<128, 4>, Tier<128, 8>, Tier<160, 8>, Tier<256, 8>, Tier<256, 16>,
+        Tier<512, 8>, Tier<512, 16>, Tier<512, 22>, Tier<512, 32>, Tier<576, 8>, Tier<768, 32>,
+        Tier<1024, 32>, Tier<2048, 32>>;
+};
+
+template <>
+struct ClusterPolicyTraits<ClusterBlockDim512, NoOpPreprocess, SoftmaxPostprocess>
+{
+    using Pairs = TierList<Tier<128, 4>, Tier<128, 8>, Tier<160, 8>, Tier<256, 8>, Tier<256, 16>,
+        Tier<512, 8>, Tier<512, 16>, Tier<512, 22>, Tier<512, 32>, Tier<1024, 32>, Tier<1536, 32>,
+        Tier<2048, 32>>;
+};
+
+template <>
+struct ClusterPolicyTraits<ClusterBlockDim256, NoOpPreprocess, SoftmaxPostprocess>
+{
+    using Pairs = TierList<Tier<128, 4>, Tier<128, 8>, Tier<160, 8>, Tier<256, 8>, Tier<256, 16>,
+        Tier<512, 8>, Tier<512, 16>, Tier<512, 22>, Tier<512, 32>, Tier<768, 32>, Tier<1024, 32>,
+        Tier<1536, 32>, Tier<2048, 32>>;
+};
+
+template <typename KernelParams, typename BaseType, int ClusterBlockDim, int ClusterNumWarps>
+__device__ __forceinline__ void routingIndicesClusterKernelBody(
+    KernelParams params, PackedScoreIdx<BaseType>* smemPackedScoreIdx)
 {
     using OutputT = typename KernelParams::OutputT;
     using InputT = typename KernelParams::InputT;
-    using BaseType = typename KernelParams::ExpertSelectPolicy::template BaseType<InputT>;
     using TypePacked = PackedScoreIdx<BaseType>;
     static constexpr int VecSize = KernelParams::MaxNumExperts / WarpSize;
-
-    __shared__ TypePacked __attribute((aligned(128))) smemPackedScoreIdx[NumWarps * KernelParams::MaxNumTopExperts];
 
     uint32_t const clusterBlockRank = blockIdx.x;
     int32_t const warpIdx = __shfl_sync(0xffffffff, threadIdx.x / WarpSize, 0);
     int32_t const laneIdx = cutlass::arch::LaneId();
-    auto warpTokenIdx = clusterBlockRank * NumWarps + warpIdx;
+    auto warpTokenIdx = clusterBlockRank * ClusterNumWarps + warpIdx;
     auto scoreOffset = warpTokenIdx * params.mNumExperts;
     bool validToken = warpTokenIdx < params.mNumTokens;
     auto block = cg::this_thread_block();
@@ -758,14 +789,26 @@ __global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(Nu
 
     if (params.mPtrScores != nullptr)
     {
-        routingPermutation<KernelParams, BaseType, NumThreads, NumWarps, KernelParams::MaxNumTopExperts,
+        routingPermutation<KernelParams, BaseType, ClusterBlockDim, ClusterNumWarps, KernelParams::MaxNumTopExperts,
             /*LoadExpertIdxFromGlobal=*/false>(params, smemPackedScoreIdx, warpIdx, clusterBlockRank);
     }
     else
     {
-        routingPermutation<KernelParams, BaseType, NumThreads, NumWarps, KernelParams::MaxNumTopExperts,
+        routingPermutation<KernelParams, BaseType, ClusterBlockDim, ClusterNumWarps, KernelParams::MaxNumTopExperts,
             /*LoadExpertIdxFromGlobal=*/true>(params, smemPackedScoreIdx, warpIdx, clusterBlockRank);
     }
+}
+
+template <typename KernelParams>
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+__global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(NumThreads)
+    routingIndicesClusterKernel(KernelParams params)
+{
+    using InputT = typename KernelParams::InputT;
+    using BaseType = typename KernelParams::ExpertSelectPolicy::template BaseType<InputT>;
+    using TypePacked = PackedScoreIdx<BaseType>;
+    __shared__ TypePacked __attribute((aligned(128))) smemPackedScoreIdx[NumWarps * KernelParams::MaxNumTopExperts];
+    routingIndicesClusterKernelBody<KernelParams, BaseType, NumThreads, NumWarps>(params, smemPackedScoreIdx);
 }
 #else
 __global__ void __launch_bounds__(NumThreads) routingIndicesClusterKernel(KernelParams /* params */)
@@ -774,8 +817,108 @@ __global__ void __launch_bounds__(NumThreads) routingIndicesClusterKernel(Kernel
 }
 #endif // if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
 
+template <typename KernelParams>
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+__global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(ClusterBlockDim512)
+    routingIndicesClusterKernel512(KernelParams params)
+{
+    using InputT = typename KernelParams::InputT;
+    using BaseType = typename KernelParams::ExpertSelectPolicy::template BaseType<InputT>;
+    using TypePacked = PackedScoreIdx<BaseType>;
+    static constexpr int NumWarpsBlock = ClusterBlockDim512 / WarpSize;
+    __shared__ TypePacked __attribute((aligned(128))) smemPackedScoreIdx[NumWarpsBlock
+        * KernelParams::MaxNumTopExperts];
+    routingIndicesClusterKernelBody<KernelParams, BaseType, ClusterBlockDim512, NumWarpsBlock>(
+        params, smemPackedScoreIdx);
+}
+#else
+__global__ void __launch_bounds__(ClusterBlockDim512) routingIndicesClusterKernel512(KernelParams /* params */)
+{
+    assert(false && "routingIndicesClusterKernel512 is only supported on SM90+ architectures");
+}
+#endif // if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+
+template <typename KernelParams>
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+__global__ void __cluster_dims__(NumBlocksPerCluster, 1, 1) __launch_bounds__(ClusterBlockDim256)
+    routingIndicesClusterKernel256(KernelParams params)
+{
+    using InputT = typename KernelParams::InputT;
+    using BaseType = typename KernelParams::ExpertSelectPolicy::template BaseType<InputT>;
+    using TypePacked = PackedScoreIdx<BaseType>;
+    static constexpr int NumWarpsBlock = ClusterBlockDim256 / WarpSize;
+    __shared__ TypePacked __attribute((aligned(128))) smemPackedScoreIdx[NumWarpsBlock
+        * KernelParams::MaxNumTopExperts];
+    routingIndicesClusterKernelBody<KernelParams, BaseType, ClusterBlockDim256, NumWarpsBlock>(
+        params, smemPackedScoreIdx);
+}
+#else
+__global__ void __launch_bounds__(ClusterBlockDim256) routingIndicesClusterKernel256(KernelParams /* params */)
+{
+    assert(false && "routingIndicesClusterKernel256 is only supported on SM90+ architectures");
+}
+#endif // if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+
+template <int ClusterBlockDim>
+void launchNoOpSoftmaxClusterKernel(Data const& data, void* stream)
+{
+    using Pairs = typename ClusterPolicyTraits<ClusterBlockDim, NoOpPreprocess, SoftmaxPostprocess>::Pairs;
+    bool dispatched = dispatchTierPairs(static_cast<Pairs*>(nullptr), data,
+        [&](auto eTag, auto kTag)
+        {
+            if constexpr (ClusterBlockDim == ClusterBlockDim256)
+            {
+                LAUNCH_ROUTING_WITH_POLICIES(data, false, routingIndicesClusterKernel256, NumBlocksPerCluster,
+                    ClusterBlockDim256,
+                    /*smemSize=*/0, stream, NoOpPreprocess, SoftmaxPostprocess, decltype(eTag)::value,
+                    decltype(kTag)::value);
+            }
+            else if constexpr (ClusterBlockDim == ClusterBlockDim512)
+            {
+                LAUNCH_ROUTING_WITH_POLICIES(data, false, routingIndicesClusterKernel512, NumBlocksPerCluster,
+                    ClusterBlockDim512,
+                    /*smemSize=*/0, stream, NoOpPreprocess, SoftmaxPostprocess, decltype(eTag)::value,
+                    decltype(kTag)::value);
+            }
+            else
+            {
+                LAUNCH_ROUTING_WITH_POLICIES(data, false, routingIndicesClusterKernel, NumBlocksPerCluster,
+                    ClusterBlockDim1024,
+                    /*smemSize=*/0, stream, NoOpPreprocess, SoftmaxPostprocess, decltype(eTag)::value,
+                    decltype(kTag)::value);
+            }
+        });
+    if (!dispatched)
+    {
+        TLLM_LOG_ERROR("No tier covers numExperts=%d topK=%d", data.mNumExperts, data.mTopK);
+    }
+}
+
 void launchClusterKernel(Data const& data, void* stream)
 {
+    // Reduced-thread cluster variants are only used for the raw-score NoOp+Softmax path. In that path
+    // each warp owns one token, so the token capacity scales with the number of warps per block.
+    // Post-topK cluster routing keeps the original 1024-thread launch to preserve its 8192-token
+    // capacity and existing policy coverage.
+    bool const useNoOpSoftmaxScores = data.mPtrScores != nullptr
+        && data.mPreprocessType == RoutingPreprocessType::None
+        && data.mPostprocessType == RoutingPostprocessType::Softmax;
+    if (useNoOpSoftmaxScores && data.mNumTokens <= MaxNumTokensClusterScores256)
+    {
+        launchNoOpSoftmaxClusterKernel<ClusterBlockDim256>(data, stream);
+        return;
+    }
+    if (useNoOpSoftmaxScores && data.mNumTokens <= MaxNumTokensClusterScores512)
+    {
+        launchNoOpSoftmaxClusterKernel<ClusterBlockDim512>(data, stream);
+        return;
+    }
+    if (useNoOpSoftmaxScores)
+    {
+        launchNoOpSoftmaxClusterKernel<ClusterBlockDim1024>(data, stream);
+        return;
+    }
+
     LAUNCH_ROUTING_CUSTOM(data, false, routingIndicesClusterKernel, NumBlocksPerCluster, NumThreads,
         /*smemSize=*/0, // No dynamic smem
         stream);
@@ -788,15 +931,69 @@ void launchClusterKernel(Data const& data, void* stream)
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+template <int MaxNumExperts, int MaxNumTopExperts>
+struct HistogramScoresLaunchConfig : DefaultRoutingLaunchConfig<MaxNumExperts, MaxNumTopExperts>
+{
+    static constexpr int DefaultBlockDim = DefaultRoutingLaunchConfig<MaxNumExperts, MaxNumTopExperts>::BlockDim;
+    static constexpr int HistogramScoresBlockDim = NumExperts256Experts;
+
+    // This kernel uses one warp per token and keeps per-warp arrays sized by both the expert tier and
+    // the topK tier. The 256-expert tier already launches with 256 threads; for larger tiers, fewer
+    // warps per CTA gives each thread more register headroom while preserving total warp-level
+    // parallelism by scaling the grid cap below.
+    static constexpr bool UseHistogramScoresBlockDim = DefaultBlockDim > HistogramScoresBlockDim;
+    static constexpr int BlockDim
+        = UseHistogramScoresBlockDim ? HistogramScoresBlockDim : DefaultBlockDim;
+
+    static_assert(BlockDim % WarpSize == 0);
+    static_assert(BlockDim <= NumThreads);
+
+    static int blockDim(Data const& /*data*/, int /*numThreads*/)
+    {
+        return BlockDim;
+    }
+
+    static int gridDim(Data const& data, int numBlocks, int /*blockDim*/)
+    {
+        if constexpr (UseHistogramScoresBlockDim)
+        {
+            static constexpr int NumWarpsBlock = BlockDim / WarpSize;
+            static constexpr int MaxBlockScale = (DefaultBlockDim + BlockDim - 1) / BlockDim;
+            int const tokenBlocks = (static_cast<int>(data.mNumTokens) + NumWarpsBlock - 1) / NumWarpsBlock;
+            int const scaledMaxBlocks = numBlocks * MaxBlockScale;
+            int const selectedBlocks = tokenBlocks < scaledMaxBlocks ? tokenBlocks : scaledMaxBlocks;
+            return selectedBlocks > 0 ? selectedBlocks : 1;
+        }
+        else
+        {
+            return DefaultRoutingLaunchConfig<MaxNumExperts, MaxNumTopExperts>::gridDim(data, numBlocks, DefaultBlockDim);
+        }
+    }
+};
+
+template <typename PreProc, typename PostProc>
+struct HistogramScoresPolicyTraits : PolicyTraits<PreProc, PostProc>
+{
+};
+
+template <>
+struct HistogramScoresPolicyTraits<NoOpPreprocess, SoftmaxPostprocess>
+{
+    using Pairs = TierList<Tier<128, 4>, Tier<128, 8>, Tier<160, 8>, Tier<256, 8>, Tier<256, 16>,
+        Tier<512, 8>, Tier<512, 16>, Tier<512, 22>, Tier<512, 32>, Tier<576, 8>, Tier<768, 32>,
+        Tier<1024, 32>, Tier<1536, 32>, Tier<2048, 32>>;
+};
+
 template <typename KernelParams>
-__global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelParams::MaxNumExperts : 1024)
+__global__ void __launch_bounds__(
+    HistogramScoresLaunchConfig<KernelParams::MaxNumExperts, KernelParams::MaxNumTopExperts>::BlockDim)
     routingIndicesHistogramScoresKernel(KernelParams params)
 {
     using OutputT = typename KernelParams::OutputT;
     using InputT = typename KernelParams::InputT;
     using BaseType = typename KernelParams::ExpertSelectPolicy::template BaseType<InputT>;
-    // Cap actual thread count at 1024 when MaxNumExperts > 1024.
-    static constexpr int NumThreadsBlock = KernelParams::MaxNumExperts <= 1024 ? KernelParams::MaxNumExperts : 1024;
+    static constexpr int NumThreadsBlock
+        = HistogramScoresLaunchConfig<KernelParams::MaxNumExperts, KernelParams::MaxNumTopExperts>::BlockDim;
 
     // VecSize stays based on MaxNumExperts — each warp still processes all experts for one token.
     static constexpr int VecSize = KernelParams::MaxNumExperts / WarpSize;
@@ -855,9 +1052,27 @@ __global__ void __launch_bounds__(KernelParams::MaxNumExperts <= 1024 ? KernelPa
 
 static void launchHistogramScoresKernel(Data const& data, uint32_t maxNumBlocks, uint32_t numThreadsHist, void* stream)
 {
-    LAUNCH_ROUTING_CUSTOM(data, false, routingIndicesHistogramScoresKernel, maxNumBlocks, numThreadsHist,
-        /*smemSize=*/0, // No dynamic smem
-        stream);
+    dispatchRoutingPolicy(data,
+        [&](auto preProc, auto postProc)
+        {
+            using PreProc = decltype(preProc);
+            using PostProc = decltype(postProc);
+            using Pairs = typename HistogramScoresPolicyTraits<PreProc, PostProc>::Pairs;
+            bool dispatched = dispatchTierPairs(static_cast<Pairs*>(nullptr), data,
+                [&](auto eTag, auto kTag)
+                {
+                    using LaunchConfig = HistogramScoresLaunchConfig<decltype(eTag)::value, decltype(kTag)::value>;
+                    int const effectiveThreads = LaunchConfig::blockDim(data, static_cast<int>(numThreadsHist));
+                    int const effectiveBlocks = LaunchConfig::gridDim(data, static_cast<int>(maxNumBlocks), effectiveThreads);
+                    LAUNCH_ROUTING_WITH_POLICIES(data, false, routingIndicesHistogramScoresKernel, effectiveBlocks,
+                        effectiveThreads,
+                        /*smemSize=*/0, stream, PreProc, PostProc, decltype(eTag)::value, decltype(kTag)::value);
+                });
+            if (!dispatched)
+            {
+                TLLM_LOG_ERROR("No tier covers numExperts=%d topK=%d", data.mNumExperts, data.mTopK);
+            }
+        });
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/routing/RoutingCustomPolicy.cuh
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/routing/RoutingCustomPolicy.cuh
@@ -649,8 +649,8 @@ struct DefaultRoutingLaunchConfig
 //   - "fixed 1024" kernels (cluster): numThreads=1024 ≥ MaxNumExperts → unchanged            ✓
 // Kernels with a different internal block size can pass a custom LaunchConfig through the
 // WITH_CONFIG variants and must keep their own launch bounds, blockDim, and gridDim consistent.
-#define LAUNCH_ROUTING_FOR_POLICY_WITH_CONFIG(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream,       \
-    PreProc, PostProc, LaunchConfig)                                                                                   \
+#define LAUNCH_ROUTING_FOR_POLICY_WITH_CONFIG(                                                                         \
+    data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream, PreProc, PostProc, LaunchConfig)                \
     [&](auto pt_tag_)                                                                                                  \
     {                                                                                                                  \
         using Pairs_ = typename decltype(pt_tag_)::Pairs;                                                              \
@@ -659,7 +659,7 @@ struct DefaultRoutingLaunchConfig
             {                                                                                                          \
                 using LaunchConfig_ = LaunchConfig<decltype(eTag_)::value, decltype(kTag_)::value>;                    \
                 int const effectiveThreads_ = LaunchConfig_::blockDim(data, static_cast<int>(numThreads));             \
-                int const effectiveBlocks_                                                                              \
+                int const effectiveBlocks_                                                                             \
                     = LaunchConfig_::gridDim(data, static_cast<int>(numBlocks), effectiveThreads_);                    \
                 LAUNCH_ROUTING_WITH_POLICIES(data, coopLaunch, kernel, effectiveBlocks_, effectiveThreads_, smemSize,  \
                     stream, PreProc, PostProc, decltype(eTag_)::value, decltype(kTag_)::value);                        \

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/routing/RoutingCustomPolicy.cuh
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/routing/RoutingCustomPolicy.cuh
@@ -482,12 +482,12 @@ inline bool dispatchTierPairs(TierList<First, Rest...>*, Data const& data, Fn&& 
 // Only these pairs are compiled as kernel instantiations.
 // To add support for a new model config, add a Tier<E, K> to the appropriate TierList.
 //
-// THREAD-COUNT SAFETY: LAUNCH_ROUTING_FOR_POLICY automatically clamps the launch thread
-// count to at least min(MaxNumExperts, 1024) from the dispatched tier.  This prevents
+// THREAD-COUNT SAFETY: the default launch config clamps the launch thread count to at
+// least min(MaxNumExperts, 1024) from the dispatched tier.  This prevents
 // mismatches when a policy's smallest tier is larger than getMaxNumExperts() returns for
 // the same numExperts (e.g., 72 experts → getMaxNumExperts returns 128, but a policy
 // whose smallest tier is 256 would produce MaxNumExperts=256).  See the comment on
-// LAUNCH_ROUTING_FOR_POLICY for details.
+// DefaultRoutingLaunchConfig for details.
 //
 // ┌──────────────────────────────────────────────────────────────────────────────┐
 // │  Policy (PreProc + PostProc)           Supported pairs                      │
@@ -619,36 +619,61 @@ template <> struct PolicyTraits<FirstKExpertSelect, void>
 // (expert, topK) as compile-time integral_constants.
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+template <int MaxNumExperts, int MaxNumTopExperts>
+struct DefaultRoutingLaunchConfig
+{
+    static constexpr int BlockDim = MaxNumExperts <= 1024 ? MaxNumExperts : 1024;
+
+    static int blockDim(Data const& /*data*/, int numThreads)
+    {
+        return std::max(numThreads, BlockDim);
+    }
+
+    static int gridDim(Data const& /*data*/, int numBlocks, int /*blockDim*/)
+    {
+        return numBlocks;
+    }
+};
+
 // Generic per-policy dispatch.  Iterates PolicyTraits<PreProc, PostProc>::Pairs,
 // picking the first (expert, topK) pair that covers the runtime values.
 //
-// IMPORTANT: numThreads is clamped to at least min(MaxNumExperts, 1024) from the dispatched tier.
+// IMPORTANT: DefaultRoutingLaunchConfig clamps numThreads to at least min(MaxNumExperts, 1024)
+// from the dispatched tier.
 // Many routing kernels derive their internal NumThreadsBlock from MaxNumExperts and use it for
 // grid-stride addressing, initArr strides, and cub::BlockScan.  If the caller's numThreads
 // (typically getMaxNumExperts(mNumExperts)) is smaller than the tier's MaxNumExperts, the kernel
-// would compute wrong indices, skip initialization, and corrupt memory.  The max() below
+// would compute wrong indices, skip initialization, and corrupt memory.  The default max()
 // guarantees the launch thread count always matches or exceeds the kernel's NumThreadsBlock:
 //   - "derive from tier" kernels: numThreadsHist < MaxNumExperts → bumped to MaxNumExperts  ✓
 //   - "fixed 1024" kernels (cluster): numThreads=1024 ≥ MaxNumExperts → unchanged            ✓
-#define LAUNCH_ROUTING_FOR_POLICY(                                                                                     \
-    data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream, PreProc, PostProc)                              \
+// Kernels with a different internal block size can pass a custom LaunchConfig through the
+// WITH_CONFIG variants and must keep their own launch bounds, blockDim, and gridDim consistent.
+#define LAUNCH_ROUTING_FOR_POLICY_WITH_CONFIG(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream,       \
+    PreProc, PostProc, LaunchConfig)                                                                                   \
     [&](auto pt_tag_)                                                                                                  \
     {                                                                                                                  \
         using Pairs_ = typename decltype(pt_tag_)::Pairs;                                                              \
         bool dispatched_ = dispatchTierPairs(static_cast<Pairs_*>(nullptr), data,                                      \
             [&](auto eTag_, auto kTag_)                                                                                \
             {                                                                                                          \
-                constexpr int tierMaxExp_ = decltype(eTag_)::value;                                                    \
-                constexpr int tierThreads_ = tierMaxExp_ <= 1024 ? tierMaxExp_ : 1024;                                 \
-                int const effectiveThreads_ = std::max(static_cast<int>(numThreads), tierThreads_);                    \
-                LAUNCH_ROUTING_WITH_POLICIES(data, coopLaunch, kernel, numBlocks, effectiveThreads_, smemSize, stream, \
-                    PreProc, PostProc, decltype(eTag_)::value, decltype(kTag_)::value);                                \
+                using LaunchConfig_ = LaunchConfig<decltype(eTag_)::value, decltype(kTag_)::value>;                    \
+                int const effectiveThreads_ = LaunchConfig_::blockDim(data, static_cast<int>(numThreads));             \
+                int const effectiveBlocks_                                                                              \
+                    = LaunchConfig_::gridDim(data, static_cast<int>(numBlocks), effectiveThreads_);                    \
+                LAUNCH_ROUTING_WITH_POLICIES(data, coopLaunch, kernel, effectiveBlocks_, effectiveThreads_, smemSize,  \
+                    stream, PreProc, PostProc, decltype(eTag_)::value, decltype(kTag_)::value);                        \
             });                                                                                                        \
         if (!dispatched_)                                                                                              \
         {                                                                                                              \
             TLLM_LOG_ERROR("No tier covers numExperts=%d topK=%d", data.mNumExperts, data.mTopK);                      \
         }                                                                                                              \
     }(PolicyTraits<PreProc, PostProc>{})
+
+#define LAUNCH_ROUTING_FOR_POLICY(                                                                                     \
+    data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream, PreProc, PostProc)                              \
+    LAUNCH_ROUTING_FOR_POLICY_WITH_CONFIG(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream, PreProc,  \
+        PostProc, DefaultRoutingLaunchConfig)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // CUSTOM EXPERT SELECT DISPATCH
@@ -782,13 +807,18 @@ inline int32_t queryDispatchedMaxExperts(Data const& data)
 
 // Top-level dispatch: maps runtime preprocess/postprocess enums to compile-time policy types,
 // then delegates to LAUNCH_ROUTING_FOR_POLICY which reads PolicyTraits for tier support.
-#define LAUNCH_ROUTING_CUSTOM(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream)                       \
+#define LAUNCH_ROUTING_CUSTOM_WITH_CONFIG(                                                                             \
+    data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream, LaunchConfig)                                   \
     dispatchRoutingPolicy(data,                                                                                        \
         [&](auto preProc_, auto postProc_)                                                                             \
         {                                                                                                              \
-            LAUNCH_ROUTING_FOR_POLICY(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream,               \
-                decltype(preProc_), decltype(postProc_));                                                              \
+            LAUNCH_ROUTING_FOR_POLICY_WITH_CONFIG(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream,   \
+                decltype(preProc_), decltype(postProc_), LaunchConfig);                                                \
         })
+
+#define LAUNCH_ROUTING_CUSTOM(data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream)                       \
+    LAUNCH_ROUTING_CUSTOM_WITH_CONFIG(                                                                                 \
+        data, coopLaunch, kernel, numBlocks, numThreads, smemSize, stream, DefaultRoutingLaunchConfig)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/routing/RoutingKernelTopK.cuh
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/routing/RoutingKernelTopK.cuh
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2022-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/routing/RoutingKernelTopK.cuh
+++ b/cpp/tensorrt_llm/kernels/trtllmGenKernels/blockScaleMoe/routing/RoutingKernelTopK.cuh
@@ -91,14 +91,25 @@ struct TopKRedType
     __device__ inline TypeCmp reduce(cg::thread_block_tile<WarpSize> const& warp)
     {
         static constexpr bool hasFastRedux = tensorrt_llm::kernels::arch::is_major_v<10>;
-        if constexpr (!hasFastRedux || sizeof(TypeCmp) == 8)
+        if constexpr (!hasFastRedux)
         {
             return cg::reduce(warp, compVal, cg::greater<TypeCmp>{});
+        }
+        else if constexpr (sizeof(TypeCmp) == 8)
+        {
+            uint32_t hi = static_cast<uint32_t>(compVal >> 32);
+            uint32_t lo = static_cast<uint32_t>(compVal & 0xffffffffu);
+            uint32_t maxHi;
+            asm volatile("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(maxHi) : "r"(hi));
+            uint32_t loContrib = (hi == maxHi) ? lo : 0u;
+            uint32_t maxLo;
+            asm volatile("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(maxLo) : "r"(loContrib));
+            return (static_cast<TypeCmp>(maxHi) << 32) | static_cast<TypeCmp>(maxLo);
         }
         else
         {
             TypeCmp result;
-            asm("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(result) : "r"(compVal));
+            asm volatile("redux.sync.max.u32 %0, %1, 0xffffffff;\n" : "=r"(result) : "r"(compVal));
             return result;
         }
     }
@@ -120,6 +131,92 @@ struct IsPowerOf2
 {
     static constexpr bool value = (N > 0) && ((N & (N - 1)) == 0);
 };
+
+// Helper to compute the next power of 2 (>= N).
+template <int N>
+struct NextPow2
+{
+private:
+    static constexpr unsigned u = static_cast<unsigned>(N - 1);
+    static constexpr unsigned s1 = u | (u >> 1);
+    static constexpr unsigned s2 = s1 | (s1 >> 2);
+    static constexpr unsigned s3 = s2 | (s2 >> 4);
+    static constexpr unsigned s4 = s3 | (s3 >> 8);
+    static constexpr unsigned s5 = s4 | (s4 >> 16);
+
+public:
+    static constexpr int value = (N <= 1) ? 1 : static_cast<int>(s5 + 1);
+};
+
+template <int A, int B, int Size, typename T>
+__device__ __forceinline__ void topkCompareSwap(T* a)
+{
+    if constexpr (A < Size && B < Size)
+    {
+        if (a[A] < a[B])
+        {
+            T tmp = a[A];
+            a[A] = a[B];
+            a[B] = tmp;
+        }
+    }
+    else
+    {
+        (void) a;
+    }
+}
+
+template <int I, int End, int Step, int PairStride, int Size, typename T>
+__device__ __forceinline__ void topkMergePairs(T* a)
+{
+    if constexpr (I + Step < End)
+    {
+        topkCompareSwap<I, I + Step, Size, T>(a);
+        topkMergePairs<I + PairStride, End, Step, PairStride, Size, T>(a);
+    }
+    else
+    {
+        (void) a;
+    }
+}
+
+template <int Lo, int N, int R, int Size, typename T>
+__device__ __forceinline__ void topkOddEvenMerge(T* a)
+{
+    constexpr int M = R * 2;
+    if constexpr (M < N)
+    {
+        topkOddEvenMerge<Lo, N, M, Size, T>(a);
+        topkOddEvenMerge<Lo + R, N - R, M, Size, T>(a);
+        topkMergePairs<Lo + R, Lo + N, R, M, Size, T>(a);
+    }
+    else if constexpr (R < N)
+    {
+        topkCompareSwap<Lo, Lo + R, Size, T>(a);
+    }
+    else
+    {
+        (void) a;
+    }
+}
+
+// Batcher odd-even mergesort over NextPow2<Size>. Comparators touching the padded
+// tail are dropped at compile time, so non-power-of-two sizes need no runtime padding.
+template <int Lo, int N, int Size, typename T>
+__device__ __forceinline__ void topkSortBatcher(T* a)
+{
+    if constexpr (N > 1)
+    {
+        constexpr int Half = N / 2;
+        topkSortBatcher<Lo, Half, Size, T>(a);
+        topkSortBatcher<Lo + Half, N - Half, Size, T>(a);
+        topkOddEvenMerge<Lo, N, 1, Size, T>(a);
+    }
+    else
+    {
+        (void) a;
+    }
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <int N, typename RedType>
@@ -169,31 +266,8 @@ struct Sort
         }
         else
         {
-// Odd-even transposition sort for non-power-of-2 sizes
-#pragma unroll
-            for (int pass = 0; pass < N; ++pass)
-            {
-#pragma unroll
-                for (int i = 0; i < N - 1; i += 2)
-                {
-                    if (topK[i].compVal < topK[i + 1].compVal)
-                    {
-                        auto tmp = topK[i].compVal;
-                        topK[i].compVal = topK[i + 1].compVal;
-                        topK[i + 1].compVal = tmp;
-                    }
-                }
-#pragma unroll
-                for (int i = 1; i < N - 1; i += 2)
-                {
-                    if (topK[i].compVal < topK[i + 1].compVal)
-                    {
-                        auto tmp = topK[i].compVal;
-                        topK[i].compVal = topK[i + 1].compVal;
-                        topK[i + 1].compVal = tmp;
-                    }
-                }
-            }
+            constexpr int PaddedN = NextPow2<N>::value;
+            topkSortBatcher<0, PaddedN, N, RedType>(topK);
         }
     }
 };


### PR DESCRIPTION
## Description

Optimize TRTLLM-Gen MoE routing to reduce register pressure and avoid heavy spilling in high-expert routing cases.

  - Add templated cluster routing kernels for 256/512/1024 thread block sizes while preserving the original default kernel path.
  - Apply the updated routing block-size heuristic to cluster and histogram-score routing paths.
  - Optimize the non-power-of-two experts top K.
  - Extend the routing tier coverage for non-power-of-two expert counts.

## Test Coverage

./cpp/tests/unit_tests/kernels/routingKernelsTest


## Perf Benchmark
### noop_softmax


| E | K | tokens | baseline ms | opt ms | speedup |
|---:|---:|---:|---:|---:|---:|
| 256 | 8 | 8 | 0.009216 | 0.009184 | 1.00x |
| 256 | 8 | 16 | 0.009280 | 0.009440 | 0.98x |
| 256 | 8 | 32 | 0.011264 | 0.009248 | 1.22x |
| 256 | 8 | 64 | 0.012832 | 0.009248 | 1.39x |
| 256 | 8 | 128 | 0.012800 | 0.010784 | 1.19x |
| 256 | 8 | 256 | 0.012832 | 0.013312 | 0.96x |
| 256 | 8 | 512 | 0.014208 | 0.014368 | 0.99x |
| 256 | 8 | 1024 | 0.014400 | 0.014336 | 1.00x |
| 256 | 8 | 2048 | 0.015744 | 0.016288 | 0.97x |
| 256 | 8 | 4096 | 0.018336 | 0.018336 | 1.00x |
| 256 | 8 | 8192 | 0.020512 | 0.020448 | 1.00x |
| 512 | 8 | 8 | 0.009312 | 0.009184 | 1.01x |
| 512 | 8 | 16 | 0.011168 | 0.009248 | 1.21x |
| 512 | 8 | 32 | 0.014720 | 0.009408 | 1.56x |
| 512 | 8 | 64 | 0.015392 | 0.011296 | 1.36x |
| 512 | 8 | 128 | 0.015424 | 0.011296 | 1.37x |
| 512 | 8 | 256 | 0.017376 | 0.015744 | 1.10x |
| 512 | 8 | 512 | 0.018432 | 0.016576 | 1.11x |
| 512 | 8 | 1024 | 0.018496 | 0.017920 | 1.03x |
| 512 | 8 | 2048 | 0.021696 | 0.018464 | 1.18x |
| 512 | 8 | 4096 | 0.024544 | 0.020640 | 1.19x |
| 512 | 8 | 8192 | 0.026624 | 0.024544 | 1.08x |
| 512 | 10 | 8 | 0.009376 | 0.009280 | 1.01x |
| 512 | 10 | 16 | 0.011328 | 0.009312 | 1.22x |
| 512 | 10 | 32 | 0.015392 | 0.011232 | 1.37x |
| 512 | 10 | 64 | 0.015392 | 0.011200 | 1.37x |
| 512 | 10 | 128 | 0.017440 | 0.013088 | 1.33x |
| 512 | 10 | 256 | 0.017408 | 0.017376 | 1.00x |
| 512 | 10 | 512 | 0.018432 | 0.016544 | 1.11x |
| 512 | 10 | 1024 | 0.018496 | 0.018080 | 1.02x |
| 512 | 10 | 2048 | 0.022528 | 0.018496 | 1.22x |
| 512 | 10 | 4096 | 0.024704 | 0.022368 | 1.10x |
| 512 | 10 | 8192 | 0.028480 | 0.024768 | 1.15x |
| 1024 | 32 | 8 | 0.029408 | 0.015328 | 1.92x |
| 1024 | 32 | 16 | 0.043872 | 0.015424 | 2.84x |
| 1024 | 32 | 32 | 0.078688 | 0.017408 | 4.52x |
| 1024 | 32 | 64 | 0.080608 | 0.017472 | 4.61x |
| 1024 | 32 | 128 | 0.080960 | 0.021472 | 3.77x |
| 1024 | 32 | 256 | 0.082624 | 0.031552 | 2.62x |
| 1024 | 32 | 512 | 0.097952 | 0.020608 | 4.75x |
| 1024 | 32 | 1024 | 0.100224 | 0.022464 | 4.46x |
| 1024 | 32 | 2048 | 0.100928 | 0.026688 | 3.78x |
| 1024 | 32 | 4096 | 0.112736 | 0.037312 | 3.02x |
| 1024 | 32 | 8192 | 0.183776 | 0.053760 | 3.42x |
| 2048 | 32 | 8 | 0.031264 | 0.029728 | 1.05x |
| 2048 | 32 | 16 | 0.046112 | 0.031456 | 1.47x |
| 2048 | 32 | 32 | 0.080608 | 0.033312 | 2.42x |
| 2048 | 32 | 64 | 0.082784 | 0.035584 | 2.33x |
| 2048 | 32 | 128 | 0.084448 | 0.037344 | 2.26x |
| 2048 | 32 | 256 | 0.084704 | 0.076544 | 1.11x |
| 2048 | 32 | 512 | 0.109440 | 0.037664 | 2.91x |
| 2048 | 32 | 1024 | 0.111456 | 0.037664 | 2.96x |
| 2048 | 32 | 2048 | 0.111776 | 0.047872 | 2.33x |
| 2048 | 32 | 4096 | 0.123488 | 0.068512 | 1.80x |
| 2048 | 32 | 8192 | 0.193216 | 0.101152 | 1.91x |

### softmax_sum

| E | K | tokens | baseline ms | opt ms | speedup |
|---:|---:|---:|---:|---:|---:|
| 256 | 8 | 8 | 0.009248 | 0.009216 | 1.00x |
| 256 | 8 | 16 | 0.011264 | 0.011232 | 1.00x |
| 256 | 8 | 32 | 0.013408 | 0.009344 | 1.43x |
| 256 | 8 | 64 | 0.015360 | 0.010752 | 1.43x |
| 256 | 8 | 128 | 0.015392 | 0.011456 | 1.34x |
| 256 | 8 | 256 | 0.015424 | 0.015424 | 1.00x |
| 256 | 8 | 512 | 0.015648 | 0.015456 | 1.01x |
| 256 | 8 | 1024 | 0.015904 | 0.016320 | 0.97x |
| 256 | 8 | 2048 | 0.018368 | 0.017568 | 1.05x |
| 256 | 8 | 4096 | 0.020544 | 0.020480 | 1.00x |
| 256 | 8 | 8192 | 0.024704 | 0.024384 | 1.01x |
| 512 | 8 | 8 | 0.013280 | 0.011328 | 1.17x |
| 512 | 8 | 16 | 0.015360 | 0.011456 | 1.34x |
| 512 | 8 | 32 | 0.021440 | 0.013280 | 1.61x |
| 512 | 8 | 64 | 0.021600 | 0.012896 | 1.67x |
| 512 | 8 | 128 | 0.023616 | 0.015424 | 1.53x |
| 512 | 8 | 256 | 0.023520 | 0.023552 | 1.00x |
| 512 | 8 | 512 | 0.022528 | 0.019584 | 1.15x |
| 512 | 8 | 1024 | 0.022528 | 0.019904 | 1.13x |
| 512 | 8 | 2048 | 0.028512 | 0.022528 | 1.27x |
| 512 | 8 | 4096 | 0.028576 | 0.028544 | 1.00x |
| 512 | 8 | 8192 | 0.040896 | 0.037088 | 1.10x |
| 512 | 10 | 8 | 0.013312 | 0.011392 | 1.17x |
| 512 | 10 | 16 | 0.016608 | 0.013152 | 1.26x |
| 512 | 10 | 32 | 0.023456 | 0.013344 | 1.76x |
| 512 | 10 | 64 | 0.023584 | 0.013344 | 1.77x |
| 512 | 10 | 128 | 0.024416 | 0.015648 | 1.56x |
| 512 | 10 | 256 | 0.025536 | 0.025568 | 1.00x |
| 512 | 10 | 512 | 0.022528 | 0.019840 | 1.14x |
| 512 | 10 | 1024 | 0.022560 | 0.020320 | 1.11x |
| 512 | 10 | 2048 | 0.028800 | 0.022656 | 1.27x |
| 512 | 10 | 4096 | 0.029888 | 0.029920 | 1.00x |
| 512 | 10 | 8192 | 0.042816 | 0.038848 | 1.10x |
| 1024 | 32 | 8 | 0.136224 | 0.048032 | 2.84x |
| 1024 | 32 | 16 | 0.281088 | 0.050048 | 5.62x |
| 1024 | 32 | 32 | 0.573312 | 0.051776 | 11.07x |
| 1024 | 32 | 64 | 0.575520 | 0.052128 | 11.04x |
| 1024 | 32 | 128 | 0.576832 | 0.072480 | 7.96x |
| 1024 | 32 | 256 | 0.578560 | 0.578208 | 1.00x |
| 1024 | 32 | 512 | 0.655584 | 0.052864 | 12.40x |
| 1024 | 32 | 1024 | 0.670816 | 0.053056 | 12.64x |
| 1024 | 32 | 2048 | 0.665152 | 0.084800 | 7.84x |
| 1024 | 32 | 4096 | 0.796704 | 0.149408 | 5.33x |
| 1024 | 32 | 8192 | 1.321440 | 0.249472 | 5.30x |
| 2048 | 32 | 8 | 0.134176 | 0.050048 | 2.68x |
| 2048 | 32 | 16 | 0.278016 | 0.050176 | 5.54x |
| 2048 | 32 | 32 | 0.570304 | 0.053984 | 10.56x |
| 2048 | 32 | 64 | 0.572480 | 0.055968 | 10.23x |
| 2048 | 32 | 128 | 0.574144 | 0.072352 | 7.94x |
| 2048 | 32 | 256 | 0.576256 | 0.575744 | 1.00x |
| 2048 | 32 | 512 | 0.662112 | 0.058208 | 11.37x |
| 2048 | 32 | 1024 | 0.667264 | 0.058336 | 11.44x |
| 2048 | 32 | 2048 | 0.670048 | 0.086912 | 7.71x |
| 2048 | 32 | 4096 | 0.776832 | 0.144128 | 5.39x |
| 2048 | 32 | 8192 | 1.321120 | 0.230336 | 5.74x |

### sigmoid_bias_scaled

| E | K | tokens | baseline ms | opt ms | speedup |
|---:|---:|---:|---:|---:|---:|
| 256 | 8 | 8 | 0.011136 | 0.011232 | 0.99x |
| 256 | 8 | 16 | 0.012768 | 0.013216 | 0.97x |
| 256 | 8 | 32 | 0.015296 | 0.011296 | 1.35x |
| 256 | 8 | 64 | 0.015456 | 0.011328 | 1.36x |
| 256 | 8 | 128 | 0.017376 | 0.013312 | 1.31x |
| 256 | 8 | 256 | 0.017440 | 0.017312 | 1.01x |
| 256 | 8 | 512 | 0.016768 | 0.016448 | 1.02x |
| 256 | 8 | 1024 | 0.018400 | 0.017696 | 1.04x |
| 256 | 8 | 2048 | 0.018496 | 0.018496 | 1.00x |
| 256 | 8 | 4096 | 0.021728 | 0.021568 | 1.01x |
| 256 | 8 | 8192 | 0.026048 | 0.025760 | 1.01x |
| 512 | 8 | 8 | 0.015360 | 0.014624 | 1.05x |
| 512 | 8 | 16 | 0.017376 | 0.015360 | 1.13x |
| 512 | 8 | 32 | 0.023520 | 0.015360 | 1.53x |
| 512 | 8 | 64 | 0.023712 | 0.015456 | 1.53x |
| 512 | 8 | 128 | 0.025568 | 0.017536 | 1.46x |
| 512 | 8 | 256 | 0.025632 | 0.025504 | 1.00x |
| 512 | 8 | 512 | 0.025984 | 0.022048 | 1.18x |
| 512 | 8 | 1024 | 0.026560 | 0.022688 | 1.17x |
| 512 | 8 | 2048 | 0.030688 | 0.024736 | 1.24x |
| 512 | 8 | 4096 | 0.030720 | 0.032256 | 0.95x |
| 512 | 8 | 8192 | 0.044800 | 0.040800 | 1.10x |
| 1024 | 32 | 8 | 0.033696 | 0.029440 | 1.14x |
| 1024 | 32 | 16 | 0.049792 | 0.029600 | 1.68x |
| 1024 | 32 | 32 | 0.082784 | 0.029664 | 2.79x |
| 1024 | 32 | 64 | 0.083040 | 0.031744 | 2.62x |
| 1024 | 32 | 128 | 0.084512 | 0.039776 | 2.12x |
| 1024 | 32 | 256 | 0.084704 | 0.084768 | 1.00x |
| 1024 | 32 | 512 | 0.130912 | 0.034912 | 3.75x |
| 1024 | 32 | 1024 | 0.134880 | 0.036576 | 3.69x |
| 1024 | 32 | 2048 | 0.137920 | 0.046816 | 2.95x |
| 1024 | 32 | 4096 | 0.150528 | 0.071552 | 2.10x |
| 1024 | 32 | 8192 | 0.249312 | 0.110560 | 2.25x |


## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
