### PR TITLE
[None][feat] feat: VisualGen TE-FP8 attention backend + per-layer quant

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/attention_backend/te.py
+++ b/tensorrt_llm/_torch/visual_gen/attention_backend/te.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Diffusion TransformerEngine FP8 Attention Backend
+
+FP8 self/cross-attention for visual generation (diffusion) models via
+TransformerEngine's ``DotProductAttention`` under ``fp8_autocast`` with a
+``DelayedScaling(fp8_dpa=True, fp8_mha=True)`` recipe. Ported from the vfly
+``te-fp8`` reference (3rdparty/vfly/vfly/ops/attention.py).
+
+Declares NHD layout ([B, S, H, D]) which maps directly to TE's
+``qkv_format="bshd"`` — avoids the bhsd->bshd transpose. The op is
+``torch.compiler.disable``-d because TE FP8 modules graph-break under
+torch.compile (matches vfly).
+"""
+
+import math
+from typing import Optional
+
+import torch
+
+from ...attention_backend.interface import PredefinedAttentionMask
+from .interface import AttentionBackend, AttentionTensorLayout
+
+try:
+    from transformer_engine.common.recipe import DelayedScaling
+    from transformer_engine.pytorch import DotProductAttention, fp8_autocast
+except ImportError:  # TE absent (e.g. client-only env); fail at construction, not import.
+    DotProductAttention = None
+    DelayedScaling = None
+    fp8_autocast = None
+
+
+class TEAttention(AttentionBackend):
+    """FP8 attention via TransformerEngine ``DotProductAttention``.
+
+    No KV cache (diffusion: full recompute each step). FP8 is always enabled —
+    this backend exists specifically to get FP8 attention; for BF16 use VANILLA.
+    """
+
+    def __init__(
+        self,
+        layer_idx: int = 0,
+        num_heads: int = 8,
+        head_dim: int = 64,
+        num_kv_heads: Optional[int] = None,
+        dtype: Optional[torch.dtype] = None,
+        **kwargs,
+    ):
+        if DotProductAttention is None:
+            raise ImportError(
+                "TransformerEngine is required for the TE attention backend "
+                "(transformer_engine.pytorch.DotProductAttention not importable)."
+            )
+        self.layer_idx = layer_idx
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.num_kv_heads = num_kv_heads or num_heads
+        self.dtype = dtype
+        self.scale = 1.0 / math.sqrt(head_dim)
+        # NHD == [B, S, H, D] == TE qkv_format="bshd" (no transpose needed).
+        self._preferred_layout = AttentionTensorLayout.NHD
+        self.recipe = DelayedScaling(fp8_dpa=True, fp8_mha=True)
+        # DotProductAttention is stateful (amax history); rebuild only when the
+        # (heads, dim, gqa, mask) traits change — mirrors vfly's lazy init.
+        self._attn_op = None
+        self._traits = None
+
+    def _lazy_init(self, num_gqa_groups: Optional[int], attn_mask_type: str) -> None:
+        traits = (self.num_heads, self.head_dim, num_gqa_groups, attn_mask_type)
+        if traits != self._traits:
+            self._attn_op = DotProductAttention(
+                self.num_heads,
+                self.head_dim,
+                num_gqa_groups=num_gqa_groups,
+                attn_mask_type=attn_mask_type,
+                softmax_scale=self.scale,
+                qkv_format="bshd",
+            )
+            self._traits = traits
+
+    @torch.compiler.disable
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        *,
+        attention_mask: PredefinedAttentionMask = PredefinedAttentionMask.FULL,
+        key_padding_mask: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """FP8 attention. q/k/v are NHD ([B, S, H, D]); returns [B, S, H, D]."""
+        assert q.dim() == 4 and q.shape[-1] == self.head_dim, (
+            f"Invalid q shape: expected [B, S, H, D={self.head_dim}], got {q.shape}"
+        )
+        if key_padding_mask is not None:
+            # The Wan T2V forward (full self-attn + fixed-length cross-attn) does
+            # not pass a padding mask; defer this rather than risk wrong masking.
+            raise NotImplementedError("TE attention backend does not yet support key_padding_mask.")
+
+        is_causal = attention_mask == PredefinedAttentionMask.CAUSAL
+        enable_gqa = self.num_heads != self.num_kv_heads
+        num_gqa_groups = k.shape[-2] if enable_gqa else None
+        attn_mask_type = "causal" if is_causal else "no_mask"
+
+        self._lazy_init(num_gqa_groups, attn_mask_type)
+
+        with fp8_autocast(enabled=True, fp8_recipe=self.recipe):
+            out = self._attn_op(q, k, v, attention_mask=None)
+        # TE returns [B, S, H*D]; restore [B, S, H, D] (NHD).
+        return out.unflatten(-1, (self.num_heads, self.head_dim))
+
+    @property
+    def preferred_layout(self) -> AttentionTensorLayout:
+        return self._preferred_layout
+
+    @classmethod
+    def support_fused_qkv(cls) -> bool:
+        return False

--- a/tensorrt_llm/_torch/visual_gen/attention_backend/utils.py
+++ b/tensorrt_llm/_torch/visual_gen/attention_backend/utils.py
@@ -68,6 +68,11 @@ def get_visual_gen_attention_backend(
         return FlashAttn4Attention
     elif backend_name == "CUTEDSL":
         return CuTeDSLAttention
+    elif backend_name == "TE":
+        # Lazy import: TransformerEngine is only needed for the FP8 attn path.
+        from .te import TEAttention
+
+        return TEAttention
     else:
         # Default to VANILLA for maximum compatibility
         return VanillaAttention

--- a/tensorrt_llm/_torch/visual_gen/config.py
+++ b/tensorrt_llm/_torch/visual_gen/config.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Internal VisualGen pipeline and model configuration helpers."""
 
+import fnmatch
 import json
 from copy import deepcopy
 from pathlib import Path
@@ -144,11 +145,15 @@ class DiffusionModelConfig(_VisualGenConfigBase):
         return torch.bfloat16
 
     def get_quant_config(self, name: Optional[str] = None) -> QuantConfig:
-        """Get quantization config for a layer or global. Resembles LLM ModelConfig.get_quant_config."""
+        """Get quantization config for a layer or global. Resembles LLM ModelConfig.get_quant_config.
+
+        Keys in quant_config_dict are fnmatch patterns; first match wins.
+        """
         if name is None or self.quant_config_dict is None:
             return self.quant_config
-        if name in self.quant_config_dict:
-            return self.quant_config_dict[name]
+        for pattern, cfg in self.quant_config_dict.items():
+            if fnmatch.fnmatch(name, pattern):
+                return cfg
         return self.quant_config
 
 
@@ -318,8 +323,29 @@ class DiffusionPipelineConfig(_VisualGenConfigBase):
             exclude_modules=quant_config_dict.get("ignore"),
         )
 
-        # TODO: Per-layer config (None for now - future: parse mixed precision settings)
+        # Parse per-layer overrides for mixed-precision quantization.
+        # Format: {"per_layer": {"blocks.*.attn1.*": "FP8_BLOCK_SCALES", ...}}
+        # Keys are fnmatch patterns; values are quant_algo strings.
+        # Layers not matching any pattern use the global quant_config.
         layer_quant_config = None
+        per_layer_dict = quant_config_dict.get("per_layer")
+        if per_layer_dict:
+            layer_quant_config = {}
+            for pattern, layer_algo_str in per_layer_dict.items():
+                layer_algo = algo_map.get(layer_algo_str)
+                if layer_algo is None:
+                    raise ValueError(
+                        f"Unknown quant_algo in per_layer['{pattern}']: {layer_algo_str!r}. "
+                        f"Valid values: {list(algo_map)}"
+                    )
+                layer_group_size = None
+                if layer_algo == QuantAlgo.NVFP4:
+                    layer_group_size = 16
+                elif layer_algo == QuantAlgo.FP8_BLOCK_SCALES:
+                    layer_group_size = 128
+                layer_quant_config[pattern] = QuantConfig(
+                    quant_algo=layer_algo, group_size=layer_group_size
+                )
 
         return quant_config, layer_quant_config, dynamic_weight_quant, dynamic_activation_quant
 
@@ -603,7 +629,12 @@ class DiffusionPipelineConfig(_VisualGenConfigBase):
 
         # Enable tunable FP4 quantize for visual gen: larger activation
         # tensors (full image/video latents) amortize the AutoTuner overhead.
-        if quant_config.quant_algo == QuantAlgo.NVFP4:
+        # Check both the global algo and any per-layer overrides for NVFP4.
+        uses_nvfp4 = quant_config.quant_algo == QuantAlgo.NVFP4 or (
+            quant_config_dict is not None
+            and any(cfg.quant_algo == QuantAlgo.NVFP4 for cfg in quant_config_dict.values())
+        )
+        if uses_nvfp4:
             from tensorrt_llm._torch.modules.linear import NVFP4LinearMethod
 
             NVFP4LinearMethod.use_tunable_quantize = True

--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
@@ -105,14 +105,12 @@ class WanPipeline(BasePipeline):
         # Fixed latent for reproducible benchmarking (e.g. MLPerf).
         # Set TRTLLM_VIDEO_FIXED_LATENT_PATH to a .pt file containing a pre-sampled
         # noise tensor; it will be used in place of freshly sampled random latents for
-        # all T2V requests.  Loaded once at server startup, reused across requests.
+        # all T2V requests. Lazy-loaded on first real inference call to avoid
+        # MetaInitException: __init__ runs inside TRT-LLM's MetaInitMode context
+        # where torch.load triggers aten.set_.source_Storage_storage_offset on a
+        # meta tensor and raises MetaInitException.
         self._fixed_latent: Optional[torch.Tensor] = None
-        _fixed_latent_path = os.environ.get("TRTLLM_VIDEO_FIXED_LATENT_PATH")
-        if _fixed_latent_path:
-            self._fixed_latent = torch.load(_fixed_latent_path, weights_only=True)
-            logger.warning(
-                f"Loaded fixed latent from {_fixed_latent_path}, shape={self._fixed_latent.shape}"
-            )
+        self._fixed_latent_path: Optional[str] = os.environ.get("TRTLLM_VIDEO_FIXED_LATENT_PATH")
 
         super().__init__(pipeline_config)
 
@@ -503,7 +501,13 @@ class WanPipeline(BasePipeline):
             latents, i2v_condition, i2v_first_frame_mask = self._prepare_latents_wan22_5B_i2v(
                 batch_size, image, height, width, num_frames, generator
             )
-        elif self._fixed_latent is not None:
+        elif self._fixed_latent_path is not None:
+            if self._fixed_latent is None:
+                self._fixed_latent = torch.load(self._fixed_latent_path, weights_only=True)
+                logger.warning(
+                    f"Loaded fixed latent from {self._fixed_latent_path}, "
+                    f"shape={self._fixed_latent.shape}"
+                )
             latents = self._fixed_latent.to(device=self.device, dtype=self.dtype)
         else:
             latents = self._prepare_latents(batch_size, height, width, num_frames, generator)

--- a/tensorrt_llm/_torch/visual_gen/models/wan/transformer_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/transformer_wan.py
@@ -1,3 +1,4 @@
+import fnmatch
 import math
 from typing import Tuple
 
@@ -624,6 +625,19 @@ class WanTransformer3DModel(BaseDiffusionModel):
 
     def apply_quant_config_exclude_modules(self):
         quant_config = self.model_config.quant_config
+        quant_config_dict = self.model_config.quant_config_dict
+
+        # Apply per-layer quant overrides (mixed-precision: first matching pattern wins).
+        if quant_config_dict is not None:
+            for name, module in self.named_modules():
+                if not isinstance(module, Linear):
+                    continue
+                for pattern, layer_cfg in quant_config_dict.items():
+                    if fnmatch.fnmatch(name, pattern):
+                        module.quant_config = layer_cfg
+                        break
+
+        # Apply exclusions (excluded modules revert to no-quant).
         if quant_config is None or quant_config.exclude_modules is None:
             return
 

--- a/tensorrt_llm/_torch/visual_gen/quantization/loader.py
+++ b/tensorrt_llm/_torch/visual_gen/quantization/loader.py
@@ -166,7 +166,11 @@ class DynamicLinearWeightLoader:
         return False
 
     def _maybe_dynamic_quantize(
-        self, weight_dict: Dict[str, torch.Tensor], quant_algo: Optional[QuantAlgo], name: str
+        self,
+        weight_dict: Dict[str, torch.Tensor],
+        quant_algo: Optional[QuantAlgo],
+        name: str,
+        group_size: Optional[int] = None,
     ) -> Dict[str, torch.Tensor]:
         """Conditionally quantize weight at load time on GPU."""
         if not self._should_dynamic_quantize(weight_dict, quant_algo, name):
@@ -182,7 +186,9 @@ class DynamicLinearWeightLoader:
             qweight, scale = quantize_fp8_per_tensor(weight)
             return {**weight_dict, "weight": qweight, "weight_scale": scale}
         elif quant_algo == QuantAlgo.FP8_BLOCK_SCALES:
-            block_size = self.quant_config.group_size if self.quant_config else 128
+            # Use caller-supplied group_size (from per-layer config) if provided;
+            # fall back to global config, then 128.
+            block_size = group_size or (self.quant_config.group_size if self.quant_config else 128)
             qweight, scale = quantize_fp8_blockwise(weight, block_size=block_size)
             return {**weight_dict, "weight": qweight, "weight_scale": scale}
         elif quant_algo == QuantAlgo.NVFP4:
@@ -268,8 +274,11 @@ class DynamicLinearWeightLoader:
         module_quant_config = getattr(module, "quant_config", None)
         if module_quant_config is not None:
             quant_algo = module_quant_config.quant_algo
+            # Use per-layer group_size if available (covers mixed-precision configs).
+            effective_group_size = getattr(module_quant_config, "group_size", None)
         else:
             quant_algo = self._get_quant_algo_for_layer(name)
+            effective_group_size = None
 
         # Special handling for fused NVFP4 dynamic quantization
         # Fused weights (Q,K,V or gate,up) must be quantized TOGETHER
@@ -278,7 +287,8 @@ class DynamicLinearWeightLoader:
             quantized_weight_dicts = self._quantize_fused_nvfp4(weight_dicts)
         else:
             quantized_weight_dicts = [
-                self._maybe_dynamic_quantize(wd, quant_algo, name) for wd in weight_dicts
+                self._maybe_dynamic_quantize(wd, quant_algo, name, group_size=effective_group_size)
+                for wd in weight_dicts
             ]
 
         module.load_weights(quantized_weight_dicts)

--- a/tensorrt_llm/media/encoding.py
+++ b/tensorrt_llm/media/encoding.py
@@ -141,20 +141,13 @@ class _FfmpegCliEncoder(_VideoEncoder):
                 audio_output_args = ["-c:a", "aac", "-shortest"]
 
             ffmpeg_path = _get_ffmpeg_path()
-            cmd = [
-                ffmpeg_path,
-                "-y",
-                "-f",
-                "rawvideo",
-                "-pix_fmt",
-                "rgb24",
-                "-s",
-                f"{width}x{height}",
-                "-r",
-                str(frame_rate),
-                "-i",
-                "-",
-                *audio_input_args,
+            # Prototype: TRTLLM_VIDEO_NVENC=1 attempts the NVENC H.264 hardware
+            # encoder (-cq + named presets p1..p7), then falls back to CPU libx264
+            # if NVENC can't open a session. NB: datacenter GPUs (A100/H100, and
+            # GB200/GB300 Blackwell) have NO usable NVENC engine -> the attempt
+            # fails with "unsupported device" and we fall back. Kept for GPUs that
+            # do have NVENC; on GB300 this is effectively libx264.
+            libx264_args = [
                 "-c:v",
                 "libx264",
                 "-pix_fmt",
@@ -163,23 +156,55 @@ class _FfmpegCliEncoder(_VideoEncoder):
                 "medium",
                 "-crf",
                 "23",
-                *audio_output_args,
-                output_path,
             ]
+            nvenc_args = ["-c:v", "h264_nvenc", "-pix_fmt", "yuv420p", "-preset", "p4", "-cq", "23"]
+            want_nvenc = os.environ.get("TRTLLM_VIDEO_NVENC", "0") == "1"
+            raw_frames = video_np.tobytes()
 
-            try:
-                process = subprocess.Popen(
-                    cmd,
-                    stdin=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                )
-                raw_frames = video_np.tobytes()
-                _, stderr = process.communicate(input=raw_frames)
-                if process.returncode != 0:
-                    raise RuntimeError(f"ffmpeg encoding failed: {stderr.decode()}")
-            except FileNotFoundError:
-                raise RuntimeError("ffmpeg not found. Install ffmpeg for video encoding.")
+            def _run_ffmpeg(codec_args: list) -> Tuple[int, bytes]:
+                cmd = [
+                    ffmpeg_path,
+                    "-y",
+                    "-f",
+                    "rawvideo",
+                    "-pix_fmt",
+                    "rgb24",
+                    "-s",
+                    f"{width}x{height}",
+                    "-r",
+                    str(frame_rate),
+                    "-i",
+                    "-",
+                    *audio_input_args,
+                    *codec_args,
+                    *audio_output_args,
+                    output_path,
+                ]
+                try:
+                    proc = subprocess.Popen(
+                        cmd,
+                        stdin=subprocess.PIPE,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                    )
+                    _, err = proc.communicate(input=raw_frames)
+                    return proc.returncode, err
+                except FileNotFoundError:
+                    raise RuntimeError("ffmpeg not found. Install ffmpeg for video encoding.")
+
+            if want_nvenc:
+                rc, stderr = _run_ffmpeg(nvenc_args)
+                if rc != 0:
+                    logger.warning(
+                        "h264_nvenc encode failed (rc=%s); falling back to libx264. ffmpeg: %s",
+                        rc,
+                        stderr.decode(errors="replace")[-300:],
+                    )
+                    rc, stderr = _run_ffmpeg(libx264_args)
+            else:
+                rc, stderr = _run_ffmpeg(libx264_args)
+            if rc != 0:
+                raise RuntimeError(f"ffmpeg encoding failed: {stderr.decode(errors='replace')}")
 
         logger.info(f"Saved video{' with audio' if audio is not None else ''} to {output_path}")
         return output_path
@@ -385,6 +410,8 @@ def resolve_video_format(output_format) -> Tuple[str, str]:
         )
     elif output_format == "avi":
         return "avi", ".avi"
+    elif output_format == "raw":
+        return "raw", ".rgb.bin"
     elif output_format == "auto":
         if _check_ffmpeg_available():
             return "mp4", ".mp4"
@@ -581,6 +608,22 @@ def save_video(
 
     if format in ("mp4", "avi"):
         return _save_encoded_video(video, audio, output_path, frame_rate, audio_sample_rate)
+    if format == "raw":
+        # No encoding: dump uint8 RGB bytes directly (T*H*W*3 layout).
+        # Audio is dropped — raw mode only carries video pixel data.
+        tensor = video
+        if hasattr(tensor, "detach"):
+            tensor = tensor.detach()
+        if hasattr(tensor, "cpu"):
+            tensor = tensor.cpu()
+        if getattr(tensor, "dtype", None) is not None and tensor.dtype != torch.uint8:
+            if tensor.dtype.is_floating_point:
+                tensor = (tensor.clamp(0, 1) * 255.0).to(torch.uint8)
+            else:
+                tensor = tensor.to(torch.uint8)
+        with open(output_path, "wb") as f:
+            f.write(tensor.contiguous().numpy().tobytes())
+        return output_path
     logger.warning(f"Unsupported video format: {format}, defaulting to mp4")
     output_path = output_path.rsplit(".", 1)[0] + ".mp4"
     return _save_encoded_video(video, audio, output_path, frame_rate, audio_sample_rate)

--- a/tensorrt_llm/visual_gen/args.py
+++ b/tensorrt_llm/visual_gen/args.py
@@ -94,10 +94,10 @@ SparseAttentionConfig = Annotated[
 class AttentionConfig(StrictBaseModel):
     """Configuration for Attention layers."""
 
-    backend: Literal["VANILLA", "TRTLLM", "FA4", "CUTEDSL"] = Field(
+    backend: Literal["VANILLA", "TRTLLM", "FA4", "CUTEDSL", "TE"] = Field(
         "VANILLA",
         status="prototype",
-        description="Attention backend: VANILLA (PyTorch SDPA), TRTLLM, FA4, CUTEDSL",
+        description="Attention backend: VANILLA (PyTorch SDPA), TRTLLM, FA4, CUTEDSL, TE (TransformerEngine FP8)",
     )
     quant_attention_config: Optional[QuantAttentionConfig] = Field(
         None,

--- a/tests/unittest/_torch/visual_gen/test_model_loader.py
+++ b/tests/unittest/_torch/visual_gen/test_model_loader.py
@@ -534,3 +534,138 @@ def test_fp8_vs_bf16_memory_comparison(checkpoint_exists):
         f"FP8 Blockwise:  {fp8_block_model_mem:.2f} GB model, {fp8_block_peak_mem:.2f} GB peak "
         f"({block_model_mem_ratio:.2f}x savings)"
     )
+
+
+# =============================================================================
+# Mixed-Precision Quantization Tests
+# =============================================================================
+
+
+def test_load_diffusion_quant_config_per_layer_parsing():
+    """Test that per_layer overrides are parsed into a Dict[pattern, QuantConfig]."""
+    from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig
+    from tensorrt_llm.quantization.mode import QuantAlgo
+
+    parse = DiffusionModelConfig.load_diffusion_quant_config
+
+    # Mixed: global NVFP4, attention layers override to FP8_BLOCK_SCALES.
+    qc, layer_cfg, dwq, daq = parse(
+        {
+            "quant_algo": "NVFP4",
+            "per_layer": {
+                "blocks.*.attn1.*": "FP8_BLOCK_SCALES",
+                "blocks.*.attn2.*": "FP8_BLOCK_SCALES",
+            },
+        }
+    )
+
+    assert qc.quant_algo == QuantAlgo.NVFP4
+    assert layer_cfg is not None
+    assert len(layer_cfg) == 2
+    assert layer_cfg["blocks.*.attn1.*"].quant_algo == QuantAlgo.FP8_BLOCK_SCALES
+    assert layer_cfg["blocks.*.attn1.*"].group_size == 128
+    assert layer_cfg["blocks.*.attn2.*"].quant_algo == QuantAlgo.FP8_BLOCK_SCALES
+    assert dwq is True  # auto-enabled for NVFP4
+
+
+def test_load_diffusion_quant_config_per_layer_invalid_algo():
+    """Unknown algo in per_layer raises a clear ValueError."""
+    import pytest
+
+    from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig
+
+    with pytest.raises(ValueError, match="Unknown quant_algo in per_layer"):
+        DiffusionModelConfig.load_diffusion_quant_config(
+            {
+                "quant_algo": "NVFP4",
+                "per_layer": {"blocks.*.attn1.*": "BOGUS_ALGO"},
+            }
+        )
+
+
+def test_get_quant_config_fnmatch():
+    """get_quant_config uses fnmatch patterns; first match wins; fallback to global."""
+    from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig
+    from tensorrt_llm.models.modeling_utils import QuantConfig
+    from tensorrt_llm.quantization.mode import QuantAlgo
+
+    global_cfg = QuantConfig(quant_algo=QuantAlgo.NVFP4, group_size=16)
+    attn_cfg = QuantConfig(quant_algo=QuantAlgo.FP8_BLOCK_SCALES, group_size=128)
+
+    model_cfg = DiffusionModelConfig(
+        quant_config=global_cfg,
+        quant_config_dict={"blocks.*.attn1.*": attn_cfg},
+    )
+
+    # Matching pattern
+    result = model_cfg.get_quant_config("blocks.0.attn1.qkv_proj")
+    assert result.quant_algo == QuantAlgo.FP8_BLOCK_SCALES
+
+    result = model_cfg.get_quant_config("blocks.5.attn1.to_out.0")
+    assert result.quant_algo == QuantAlgo.FP8_BLOCK_SCALES
+
+    # Non-matching → global fallback
+    result = model_cfg.get_quant_config("blocks.0.ffn.ff_in")
+    assert result.quant_algo == QuantAlgo.NVFP4
+
+    # No name → global
+    result = model_cfg.get_quant_config()
+    assert result.quant_algo == QuantAlgo.NVFP4
+
+
+def test_load_wan_pipeline_with_mixed_precision(checkpoint_exists):
+    """Test loading with mixed precision: NVFP4 for FFN, FP8_BLOCK_SCALES for attn linears.
+
+    Verifies:
+    - Attention Linear modules (attn1.*, attn2.*) have FP8 weight buffers
+    - FFN Linear modules (ffn.*) have NVFP4 weight buffers
+    """
+    if not checkpoint_exists:
+        pytest.skip("Checkpoint not available")
+
+    from tensorrt_llm._torch.modules.linear import Linear
+    from tensorrt_llm._torch.visual_gen import PipelineLoader
+    from tensorrt_llm.visual_gen.args import VisualGenArgs
+
+    args = VisualGenArgs(
+        model=CHECKPOINT_PATH,
+        quant_config={
+            "quant_algo": "NVFP4",
+            "per_layer": {
+                "blocks.*.attn1.*": "FP8_BLOCK_SCALES",
+                "blocks.*.attn2.*": "FP8_BLOCK_SCALES",
+            },
+        },
+    )
+    pipeline = PipelineLoader(args).load(skip_warmup=True, skip_components=SKIP_HEAVY_COMPONENTS)
+
+    attn_fp8_count = 0
+    ffn_nvfp4_count = 0
+
+    for name, module in pipeline.transformer.named_modules():
+        if not isinstance(module, Linear):
+            continue
+        if module.weight is None:
+            continue
+
+        is_attn = ".attn1." in name or ".attn2." in name
+        is_ffn = ".ffn." in name
+
+        if is_attn:
+            assert module.weight.dtype == torch.float8_e4m3fn, (
+                f"Attention Linear {name} should have FP8 weight, got {module.weight.dtype}"
+            )
+            assert hasattr(module, "weight_scale") and module.weight_scale is not None, (
+                f"Attention Linear {name} missing weight_scale"
+            )
+            attn_fp8_count += 1
+        elif is_ffn:
+            from tensorrt_llm.quantization.utils import fp4_utils
+
+            assert module.weight.dtype == fp4_utils.float4_e2m1x2, (
+                f"FFN Linear {name} should have NVFP4 weight, got {module.weight.dtype}"
+            )
+            ffn_nvfp4_count += 1
+
+    assert attn_fp8_count > 0, "Expected at least one FP8 attention Linear module"
+    assert ffn_nvfp4_count > 0, "Expected at least one NVFP4 FFN Linear module"


### PR DESCRIPTION
## Summary

Two commits on top of `feat/1.3-mlpinf-vg`:


- **`358e7880da`** — `[feat] VisualGen: TE FP8 attention backend + fixed-latent env var`

## Changes

- **TE-FP8 attention backend** (`attention_backend/te.py`): `TEAttention` using TransformerEngine `DotProductAttention` under `fp8_autocast` / `DelayedScaling(fp8_dpa, fp8_mha)`. Registered as `"TE"` in `AttentionConfig.backend`.

## Test plan


🤖 Generated with [Claude Code](https://claude.com/claude-code)