### PR TITLE
[fix] VisualGen: lazy-load fixed latent to avoid MetaInitException

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
+++ b/tensorrt_llm/_torch/visual_gen/models/wan/pipeline_wan.py
@@ -105,14 +105,13 @@ class WanPipeline(BasePipeline):
         # Fixed latent for reproducible benchmarking (e.g. MLPerf).
         # Set TRTLLM_VIDEO_FIXED_LATENT_PATH to a .pt file containing a pre-sampled
         # noise tensor; it will be used in place of freshly sampled random latents for
-        # all T2V requests.  Loaded once at server startup, reused across requests.
+        # all T2V requests. Lazy-loaded on first real inference call to avoid
+        # MetaInitException: __init__ runs inside TRT-LLM's MetaInitMode context
+        # where torch.load triggers aten.set_.source_Storage_storage_offset on a
+        # meta tensor and raises MetaInitException.
         self._fixed_latent: Optional[torch.Tensor] = None
-        _fixed_latent_path = os.environ.get("TRTLLM_VIDEO_FIXED_LATENT_PATH")
-        if _fixed_latent_path:
-            self._fixed_latent = torch.load(_fixed_latent_path, weights_only=True)
-            logger.warning(
-                f"Loaded fixed latent from {_fixed_latent_path}, shape={self._fixed_latent.shape}"
-            )
+        self._fixed_latent_path: Optional[str] = os.environ.get(
+            "TRTLLM_VIDEO_FIXED_LATENT_PATH")
 
         super().__init__(pipeline_config)
 
@@ -503,7 +502,13 @@ class WanPipeline(BasePipeline):
             latents, i2v_condition, i2v_first_frame_mask = self._prepare_latents_wan22_5B_i2v(
                 batch_size, image, height, width, num_frames, generator
             )
-        elif self._fixed_latent is not None:
+        elif self._fixed_latent_path is not None:
+            if self._fixed_latent is None:
+                self._fixed_latent = torch.load(self._fixed_latent_path,
+                                                weights_only=True)
+                logger.warning(
+                    f"Loaded fixed latent from {self._fixed_latent_path}, "
+                    f"shape={self._fixed_latent.shape}")
             latents = self._fixed_latent.to(device=self.device, dtype=self.dtype)
         else:
             latents = self._prepare_latents(batch_size, height, width, num_frames, generator)


### PR DESCRIPTION
## Problem

`torch.load` called inside `WanPipeline.__init__` for `TRTLLM_VIDEO_FIXED_LATENT_PATH` triggers `aten.set_.source_Storage_storage_offset` on a meta tensor when TRT-LLM initialises model weights under `MetaInitMode`, raising:

```
MetaInitException: Meta tensor used in unsupported function: aten.set_.source_Storage_storage_offset
```

This crashes the server at startup whenever `TRTLLM_VIDEO_FIXED_LATENT_PATH` is set (confirmed on GB300-NVL72 DP32 and DP72 jobs FL1/FL2, 2140007/2140008).

## Fix

Defer `torch.load` to the first real inference call in `generate()`, where the model is fully materialised. Store only the path in `__init__`; load and cache the tensor on first use. Warmup calls already pass `_use_fixed_latent=False` so they are unaffected.

## Validation

- FL72 (job 2191174): DP72 GB300×72, async encode, `TRTLLM_VIDEO_FIXED_LATENT_PATH` set → server starts cleanly, fixed latent loads on first inference
- VBench Mean(6) = 0.6946 ✅ (gate ≥ 0.691), dynamic_degree = 0.9583

## Note

This is a single-commit fix on top of `feat/1.3-mlpinf-vg` tip (`33bf59e49f`). Supersedes PR #15668 (which was based on an older commit and is now redundant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)