### PR TITLE
[None][perf] executor: memcpy int32 token buffer into tle::Request ctor

### DIFF
--- a/cpp/tensorrt_llm/nanobind/executor/request.cpp
+++ b/cpp/tensorrt_llm/nanobind/executor/request.cpp
@@ -26,6 +26,7 @@
 #include "tensorrt_llm/runtime/cudaStream.h"
 
 #include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
 #include <nanobind/stl/chrono.h>
 #include <nanobind/stl/function.h>
 #include <nanobind/stl/list.h>
@@ -645,47 +646,69 @@ void initRequestBindings(nb::module_& m)
             nb::cast<std::optional<tle::CacheSaltIDType>>(state[33]), nb::cast<std::optional<tle::IdType>>(state[34]));
     };
 
+    // Convert input_token_ids to VecTokens. Fast path: a 1-D contiguous int32
+    // ndarray is memcpy'd into the vector (no per-element PyLong cast, which is
+    // O(ISL) on the GIL-held submit path). Anything else (list[int], etc.) falls
+    // back to the default nanobind sequence cast, so this is fully back-compatible.
+    // This complements PR #15134 (which bytes-encodes Request *pickling*); here we
+    // target Request *construction* on the RpcWorker.submit / _enqueue_request path.
+    auto toVecTokens = [](nb::handle ids) -> tle::VecTokens
+    {
+        nb::ndarray<int32_t const, nb::ndim<1>, nb::c_contig> arr;
+        if (nb::try_cast(ids, arr, /*convert=*/false))
+        {
+            tle::VecTokens out(arr.shape(0));
+            if (arr.shape(0) > 0)
+            {
+                std::memcpy(out.data(), arr.data(), arr.shape(0) * sizeof(int32_t));
+            }
+            return out;
+        }
+        return nb::cast<tle::VecTokens>(ids);
+    };
+
     nb::class_<tle::Request> request(m, "Request", nb::dynamic_attr());
     request
-        .def(nb::init<tle::VecTokens,                           // inputTokenIds
-                 tle::SizeType32,                               // maxTokens
-                 bool,                                          // streaming
-                 tle::SamplingConfig const&,                    // samplingConfig
-                 tle::OutputConfig const&,                      // outputConfig
-                 std::optional<tle::SizeType32> const&,         // endId
-                 std::optional<tle::SizeType32> const&,         // padId
-                 std::optional<std::vector<SizeType32>>,        // positionIds
-                 std::optional<std::list<tle::VecTokens>>,      // badWords
-                 std::optional<std::list<tle::VecTokens>>,      // stopWords
-                 std::optional<tle::Tensor>,                    // embeddingBias
-                 std::optional<tle::ExternalDraftTokensConfig>, // externalDraftTokensConfig
-                 std::optional<tle::PromptTuningConfig>,        // pTuningConfig
-                 std::optional<tle::MultimodalInput>,           // multimodalInput
-                 std::optional<tle::Tensor>,                    // multimodalEmbedding
-                 std::optional<tle::MropeConfig>,               // mRopeConfig
-                 std::optional<tle::LoraConfig>,                // loraConfig
-                 std::optional<tle::LookaheadDecodingConfig>,   // lookaheadConfig
-                 std::optional<tle::KvCacheRetentionConfig>,    // kvCacheRetentionConfig
-                 std::optional<std::string>,                    // logitsPostProcessorName
-                 std::optional<tle::LogitsPostProcessor>,       // logitsPostProcessor
-                 std::optional<tle::VecTokens>,                 // encoderInputTokenIds
-                 std::optional<tle::IdType>,                    // clientId
-                 bool,                                          // returnAllGeneratedTokens
-                 tle::PriorityType,                             // priority
-                 tle::RequestType,                              // type
-                 std::optional<tle::ContextPhaseParams>,        // contextPhaseParams
-                 std::optional<tle::Tensor>,                    // encoderInputFeatures
-                 std::optional<tle::SizeType32>,                // encoderOutputLength
-                 std::optional<tle::Tensor>,                    // crossAttentionMask
-                 SizeType32,                                    // numReturnSequences
-                 std::optional<tle::EagleConfig>,               // eagleConfig
-                 std::optional<tle::Tensor>,                    // skipCrossAttnBlocks
-                 std::optional<tle::GuidedDecodingParams>,      // guidedDecodingParams
-                 std::optional<tle::SizeType32>,                // languageAdapterUid
-                 std::optional<tle::MillisecondsType>,          // allottedTimeMs
-                 std::optional<tle::CacheSaltIDType>,           // cacheSaltID
-                 std::optional<tle::IdType>                     // disaggRequestId
-                 >(),
+        .def(
+            "__init__",
+            [toVecTokens](tle::Request* self,
+                nb::handle input_token_ids, // list[int] or int32 ndarray
+                tle::SizeType32 max_tokens, bool streaming, tle::SamplingConfig const& sampling_config,
+                tle::OutputConfig const& output_config, std::optional<tle::SizeType32> const& end_id,
+                std::optional<tle::SizeType32> const& pad_id, std::optional<std::vector<SizeType32>> position_ids,
+                std::optional<std::list<tle::VecTokens>> bad_words, std::optional<std::list<tle::VecTokens>> stop_words,
+                std::optional<tle::Tensor> embedding_bias,
+                std::optional<tle::ExternalDraftTokensConfig> external_draft_tokens_config,
+                std::optional<tle::PromptTuningConfig> prompt_tuning_config,
+                std::optional<tle::MultimodalInput> multimodal_input, std::optional<tle::Tensor> multimodal_embedding,
+                std::optional<tle::MropeConfig> mrope_config, std::optional<tle::LoraConfig> lora_config,
+                std::optional<tle::LookaheadDecodingConfig> lookahead_config,
+                std::optional<tle::KvCacheRetentionConfig> kv_cache_retention_config,
+                std::optional<std::string> logits_post_processor_name,
+                std::optional<tle::LogitsPostProcessor> logits_post_processor,
+                std::optional<tle::VecTokens> encoder_input_token_ids, std::optional<tle::IdType> client_id,
+                bool return_all_generated_tokens, tle::PriorityType priority, tle::RequestType type,
+                std::optional<tle::ContextPhaseParams> context_phase_params,
+                std::optional<tle::Tensor> encoder_input_features, std::optional<tle::SizeType32> encoder_output_length,
+                std::optional<tle::Tensor> cross_attention_mask, SizeType32 num_return_sequences,
+                std::optional<tle::EagleConfig> eagle_config, std::optional<tle::Tensor> skip_cross_attn_blocks,
+                std::optional<tle::GuidedDecodingParams> guided_decoding_params,
+                std::optional<tle::SizeType32> language_adapter_uid,
+                std::optional<tle::MillisecondsType> allotted_time_ms,
+                std::optional<tle::CacheSaltIDType> cache_salt_id, std::optional<tle::IdType> disagg_request_id)
+            {
+                new (self) tle::Request(toVecTokens(input_token_ids), max_tokens, streaming, sampling_config,
+                    output_config, end_id, pad_id, std::move(position_ids), std::move(bad_words), std::move(stop_words),
+                    std::move(embedding_bias), std::move(external_draft_tokens_config), std::move(prompt_tuning_config),
+                    std::move(multimodal_input), std::move(multimodal_embedding), std::move(mrope_config),
+                    std::move(lora_config), std::move(lookahead_config), std::move(kv_cache_retention_config),
+                    std::move(logits_post_processor_name), std::move(logits_post_processor),
+                    std::move(encoder_input_token_ids), client_id, return_all_generated_tokens, priority, type,
+                    std::move(context_phase_params), std::move(encoder_input_features), encoder_output_length,
+                    std::move(cross_attention_mask), num_return_sequences, std::move(eagle_config),
+                    std::move(skip_cross_attn_blocks), std::move(guided_decoding_params), language_adapter_uid,
+                    allotted_time_ms, cache_salt_id, disagg_request_id);
+            },
             // clang-format off
         nb::arg("input_token_ids"),
         nb::arg("max_tokens"),
@@ -726,7 +749,7 @@ void initRequestBindings(nb::module_& m)
         nb::arg("allotted_time_ms") = nb::none(),
                 nb::arg("cache_salt_id") = nb::none(),
         nb::arg("disagg_request_id") = nb::none()
-    )         // clang-format on
+    ) // clang-format on
         .def_prop_ro("input_token_ids", &tle::Request::getInputTokenIds)
         .def_prop_ro("max_tokens", &tle::Request::getMaxTokens)
         .def_prop_rw("streaming", &tle::Request::getStreaming, &tle::Request::setStreaming)

--- a/tensorrt_llm/executor/base_worker.py
+++ b/tensorrt_llm/executor/base_worker.py
@@ -430,7 +430,16 @@ class BaseWorker(GenerationExecutor):
         else:
             lora_config = None
 
-        prompt_token_ids = list(request.prompt_token_ids)
+        # prompt_token_ids stays list[int] for all consumers. If an int32 buffer
+        # rode along on the wire (GenerationRequest._prompt_token_ids_i32), hand
+        # THAT to the C++ Request ctor (memcpy) instead of the list -- this avoids
+        # the O(ISL) list copy + element-wise nanobind cast on the GIL-held submit
+        # thread. No buffer (in-process, or prompt-adapter prepend) -> list path.
+        i32_buf = getattr(request, "_prompt_token_ids_i32", None)
+        if i32_buf is not None and request.prompt_adapter_request is None:
+            prompt_token_ids = i32_buf
+        else:
+            prompt_token_ids = list(request.prompt_token_ids)
         prompt_tuning_config = None
         if request.prompt_adapter_request is not None:
             self._load_prompt_adapter(request.prompt_adapter_request)

--- a/tensorrt_llm/executor/request.py
+++ b/tensorrt_llm/executor/request.py
@@ -146,6 +146,77 @@ class GenerationRequest:
         self.id = id
         return self
 
+    # --- int32 token-id wire serialization + LAZY list materialization ----------
+    # Pickling a flat list[int] on the hot proxy->worker RPC-submit path emits one
+    # PyLong frame per token (O(ISL)). Encode token-ids as int32 bytes for the wire.
+    # On decode we DO NOT eagerly rebuild the list: stash the int32 ndarray in
+    # `_prompt_token_ids_i32` (the C++ Request ctor memcpy's it -- see
+    # base_worker._enqueue_request) and leave the backing `_prompt_token_ids` None.
+    # The list is built lazily (and cached) by the `prompt_token_ids` property below
+    # only if a consumer actually reads it (e.g. prompt-logprobs, star-attention).
+    # Plain decode never reads it -> the O(ISL) `.tolist()` never runs.
+    #
+    # NOTE: implemented as a *property* (scoped to this one name), NOT a class-level
+    # __getattr__. A __getattr__ is invoked by the interpreter on EVERY missing
+    # attribute access on the object -- hasattr()/getattr(default) probes, copy/
+    # pickle dunder lookups, duck-typing -- each paying a Python frame + an
+    # AttributeError raise. A property has identical lazy-materialize behavior with
+    # zero blast radius on any other attribute.
+    _I32 = "\x00i32be"
+
+    @property
+    def prompt_token_ids(self):
+        ptids = self.__dict__.get("_prompt_token_ids")
+        if ptids is None:
+            buf = self.__dict__.get("_prompt_token_ids_i32")
+            if buf is not None:
+                ptids = buf.tolist()
+                self._prompt_token_ids = ptids  # cache
+        return ptids
+
+    @prompt_token_ids.setter
+    def prompt_token_ids(self, value):
+        self._prompt_token_ids = value
+
+    @staticmethod
+    def _enc_tokens(v):
+        # flat list[int] -> (_I32, int32 bytes); leave None / list[list[int]] /
+        # ndarray untouched.
+        if type(v) is list and (len(v) == 0 or type(v[0]) is int):
+            return (GenerationRequest._I32,
+                    np.asarray(v, dtype=np.int32).tobytes())
+        return v
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        buf = state.pop("_prompt_token_ids_i32", None)
+        ptids = state.get("_prompt_token_ids")
+        if ptids is not None:
+            state["_prompt_token_ids"] = GenerationRequest._enc_tokens(ptids)
+        elif buf is not None:
+            # not yet materialized -> encode the buffer's bytes directly
+            state["_prompt_token_ids"] = (GenerationRequest._I32, buf.tobytes())
+        if state.get("query_token_ids") is not None:
+            state["query_token_ids"] = GenerationRequest._enc_tokens(
+                state["query_token_ids"])
+        return state
+
+    def __setstate__(self, state):
+        buf = None
+        pt = state.get("_prompt_token_ids")
+        if type(pt) is tuple and len(
+                pt) == 2 and pt[0] == GenerationRequest._I32:
+            buf = np.frombuffer(pt[1], dtype=np.int32)
+            state["_prompt_token_ids"] = None  # leave None -> lazy via property
+        qt = state.get("query_token_ids")
+        if type(qt) is tuple and len(
+                qt) == 2 and qt[0] == GenerationRequest._I32:
+            # query_token_ids is rare/small -> materialize to list eagerly
+            state["query_token_ids"] = np.frombuffer(qt[1],
+                                                     dtype=np.int32).tolist()
+        self.__dict__.update(state)
+        self._prompt_token_ids_i32 = buf
+
 
 class TruncateKVCacheRequest:
 


### PR DESCRIPTION
On the hot proxy->worker RPC-submit path, constructing tle::Request from a list[int] of prompt token-ids costs O(ISL): pickling emits one PyLong frame per token on the wire, and the nanobind ctor does an element-wise cast into VecTokens -- all on the GIL-held submit thread.

- request.cpp: add `toVecTokens`, which memcpy's a 1-D contiguous int32 ndarray straight into VecTokens (list[int] falls back to the element-wise cast, so the binding stays backward compatible).
- request.py: GenerationRequest.__getstate__/__setstate__ encode token-ids as int32 bytes for the wire (no per-token PyLong frame). On decode the int32 ndarray is stashed in `_prompt_token_ids_i32` for the ctor memcpy and the list is NOT eagerly rebuilt; the `prompt_token_ids` list is materialized lazily-and-cached via a property only if a consumer actually reads it. Implemented as a property (scoped to this one attribute) rather than a class-level __getattr__, which would fire on every missing-attribute access (hasattr/getattr-default probes, pickle/ copy dunder lookups) -- same lazy behavior, zero blast radius on other attributes.
- base_worker._enqueue_request: hand the int32 buffer to the ctor when present; prompt_token_ids stays a list[int] for all other consumers.

@coderabbitai summary

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [ ] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
