### PR TITLE
[None][feat] DSA: adaptive indexer prefill chunk size for long sequences

### DIFF
--- a/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
+++ b/tensorrt_llm/_torch/attention_backend/sparse/dsa.py
@@ -347,6 +347,29 @@ def split_prefill_chunks(
     return chunk_groups
 
 
+# Shrink the indexer prefill chunk size for very long requests to bound the
+# fp8(_fp4)_mqa_logits activation memory (~ chunk_size * K_compressed), keyed on
+# the largest compressed KV length in the batch. Entries are
+# (k_compressed_lower_bound_exclusive, chunk_size); >512K -> 8K, [256K, 512K]
+# -> 16K, otherwise unchanged.
+_INDEXER_CHUNK_SIZE_HEURISTIC = (
+    (512 * 1024, 8 * 1024),
+    (256 * 1024 - 1, 16 * 1024),
+)
+
+
+def select_indexer_chunk_size(configured_chunk_size: int,
+                              max_k_compressed: int) -> int:
+    """Pick the indexer prefill chunk size from the batch's largest K_compressed.
+
+    Only reduces ``configured_chunk_size`` (never increases it).
+    """
+    for threshold, chunk_size in _INDEXER_CHUNK_SIZE_HEURISTIC:
+        if max_k_compressed > threshold:
+            return min(configured_chunk_size, chunk_size)
+    return configured_chunk_size
+
+
 def _select_indexer_compress_ratio(compress_ratios: List[int]) -> int:
     if 4 in compress_ratios:
         return 4
@@ -1778,9 +1801,15 @@ class Indexer(nn.Module):
         else:
             # Use indexer's own chunking logic to prevent L^2 complexity of indexer MQA logits computation for long sequences.
             # This is only used when MLA chunked prefill is not enabled.
+            # Adapt chunk size to the batch's largest K_compressed (see
+            # select_indexer_chunk_size).
+            max_k_compressed = int(indexer_params.kv_lens[:num_contexts].max().
+                                   item()) if num_contexts > 0 else 0
+            effective_chunk_size = select_indexer_chunk_size(
+                metadata.indexer_max_chunk_size, max_k_compressed)
             chunk_groups = split_prefill_chunks(
                 seq_lens[:num_contexts],
-                metadata.indexer_max_chunk_size,
+                effective_chunk_size,
                 start_idx=0,
             )
 


### PR DESCRIPTION
@coderabbitai summary

## Description

Cherry-pick of the core change from #15459 (already merged to `feat/deepseek_v4`) onto `feat/deepseek_v4_bench`. The CI-infra-only changes from that PR (bandit `# nosec`, the `gb200-x4-split` node-pool swap) are intentionally **not** included — this is the `dsa.py` change only.

The DSA indexer's `fp8(_fp4)_mqa_logits` activation memory scales with `indexer_max_chunk_size * K_compressed` (the compressed KV length of the request). For very long sequences this OOMs — e.g. a ~500K-token request at the default 32K chunk size needs ~16GB of activation memory. Uniformly lowering `indexer_max_chunk_size` (e.g. to 8K) avoids the OOM but sacrifices prefill throughput for the common case, where the vast majority of requests are far below these lengths.

This change makes the indexer prefill chunk size adaptive per-batch, keyed on the largest compressed KV length among the context requests:

| max K_compressed in batch | effective chunk size |
|---------------------------|----------------------|
| `> 512K`                  | 8K                   |
| `[256K, 512K]`            | 16K                  |
| `< 256K`                  | configured (default 32K, unchanged) |

Implementation notes:
- New helper `select_indexer_chunk_size(configured_chunk_size, max_k_compressed)` in `dsa.py`; thresholds centralized in `_INDEXER_CHUNK_SIZE_HEURISTIC` for easy tuning.
- It only ever **reduces** the configured chunk size (never increases it), so an explicitly configured `indexer_max_chunk_size` still acts as an upper bound.
- Wired into `Indexer.prepare_for_chunked_prefill`, on the indexer's own chunking path only. The MLA chunked-prefill path is untouched (it already bounds the chunk to the MLA chunk size).
- `max K_compressed` is read from `indexer_params.kv_lens` (already available host-side during prefill prepare; no extra device sync).
- Safe to vary per-batch because the prefill path does not use CUDA graphs.

## Test Coverage

- Covered by the existing DSA indexer prefill / chunked-prefill unit tests under `tests/unittest/_torch/attention/sparse/dsa/test_dsa_indexer.py`.
- The heuristic only **reduces** the chunk size for very long sequences (>256K K_compressed); for the common case (<256K) the configured chunk size is used unchanged, so existing behavior and test expectations are preserved.
- Originally validated and CI-merged via #15459 on `feat/deepseek_v4`; this PR is an identical cherry-pick of that `dsa.py` change.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
