### PR TITLE
[None][fix] disagg: use ctx retry id for gen request

### DIFF
--- a/tensorrt_llm/serve/openai_disagg_service.py
+++ b/tensorrt_llm/serve/openai_disagg_service.py
@@ -148,6 +148,9 @@ class OpenAIDisaggregatedService(OpenAIService):
                 ctx_req, server=ctx_server, hooks=hooks
             )
             await self._verify_ctx_response(ctx_response)
+            ctx_response_disagg_params = ctx_response.choices[0].disaggregated_params
+            if ctx_response_disagg_params.disagg_request_id is not None:
+                disagg_request_id = ctx_response_disagg_params.disagg_request_id
             gen_req = self._get_gen_request(request, ctx_response, disagg_request_id)
         else:
             # Clear synthetic disaggregated_params that may have been


### PR DESCRIPTION
@coderabbitai summary

## Description

Cherry-pick of #15309 (already merged to `feat/deepseek_v4`) onto `feat/deepseek_v4_bench`. Original author: @liji-nv. No changes beyond the cherry-pick; applies cleanly (1 file, +3 lines).

In disaggregated serving, the generation request should reuse the context response's `disagg_request_id` (the ctx retry id) instead of the original request id. When the context response carries a non-null `disagg_request_id`, propagate it into the generation request so the ctx and gen phases share the same id (correct behavior across context retries).

Change in `tensorrt_llm/serve/openai_disagg_service.py`: after verifying the context response, read `ctx_response.choices[0].disaggregated_params.disagg_request_id` and, when set, use it as the `disagg_request_id` passed to `_get_gen_request(...)`.

## Test Coverage

- Covered by the existing disaggregated-serving tests for the OpenAI disagg service path.
- Originally validated and CI-merged via #15309 on `feat/deepseek_v4`; this PR is an identical cherry-pick.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
