### PR TITLE
[None][perf] serve: parse request bodies with orjson to unblock the serving loop

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,7 @@ click_option_group
 aenum
 pyzmq
 fastapi>=0.120.1,<=0.121.3
+orjson
 starlette>=0.49.1
 uvicorn
 setuptools<80

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -35,6 +35,7 @@ import uvicorn
 from fastapi import Body, FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, Response, StreamingResponse
+from fastapi.routing import APIRoute
 from pydantic import ValidationError
 from starlette.routing import Mount
 from transformers import AutoProcessor
@@ -110,6 +111,56 @@ from .harmony_adapter import (HarmonyAdapter, get_harmony_adapter,
                               maybe_transform_reasoning_effort)
 
 # yapf: enable
+
+# orjson is an opt-in speedup for request-body parsing: the large agentic chat
+# body otherwise blocks the serving event loop on the stdlib json.loads.
+# Off by default; set TRTLLM_SERVE_ENABLE_ORJSON=1 to enable. When enabled, a
+# missing orjson raises at import time (rather than silently falling back to
+# stdlib json), so the flag can never silently no-op.
+if os.getenv("TRTLLM_SERVE_ENABLE_ORJSON", "0") == "1":
+    try:
+        import orjson
+    except ImportError as exc:
+        raise ImportError(
+            "TRTLLM_SERVE_ENABLE_ORJSON=1 requires the orjson package "
+            "(listed in requirements.txt).") from exc
+    _json_loads = orjson.loads
+else:
+    _json_loads = json.loads
+
+
+class _ORJSONRequest(Request):
+    """Request whose JSON body is parsed with orjson (falls back to stdlib json)."""
+
+    async def json(self):
+        if not hasattr(self, "_json_body"):
+            body = await self.body()
+            if not body:
+                self._json_body = {}
+            else:
+                try:
+                    self._json_body = _json_loads(body)
+                except ValueError:
+                    # orjson is stricter than the stdlib parser (e.g. it rejects
+                    # NaN/Infinity, which json.loads accepts); re-parse with the
+                    # stdlib parser so results are identical.
+                    self._json_body = json.loads(body)
+        return self._json_body
+
+
+class _ORJSONRoute(APIRoute):
+    """APIRoute that parses request bodies via :class:`_ORJSONRequest`."""
+
+    def get_route_handler(self):
+        original_route_handler = super().get_route_handler()
+
+        async def route_handler(request: Request):
+            return await original_route_handler(
+                _ORJSONRequest(request.scope, request.receive))
+
+        return route_handler
+
+
 TIMEOUT_KEEP_ALIVE = 5  # seconds.
 
 
@@ -322,6 +373,7 @@ class OpenAIServer(_VideoRoutesMixin):
             self.generator.shutdown()
 
         self.app = FastAPI(lifespan=lifespan)
+        self.app.router.route_class = _ORJSONRoute
 
         @self.app.exception_handler(RequestValidationError)
         async def validation_exception_handler(_, exc):


### PR DESCRIPTION
## Description

### Issue
Under high-concurrency disaggregated serving of an agentic-coding workload (DeepSeek-V4-Pro, 6 context + 1 generation server, ~3200 concurrent requests), the client-observed per-request output speed (server-sent events, ~21 tok/s) was materially below the engine's own steady-state decode rate (~25 tok/s) — a ~17% gap that did **not** show up in engine iteration timings, nsys, or `/metrics`. The engine was at speed-of-light (~100 ms/iter); the loss was a **~1.9 s per-request delay in delivering the streamed response over HTTP**.

### Root cause
The OpenAI-compatible server runs on a **single uvicorn / asyncio event loop**. Under load that loop is CPU-saturated, and a large share of the loop time goes to **request ingestion**, not response streaming. The agentic chat-completions request body is large (long multi-turn history + tool schemas, on the order of ~1 MB), and FastAPI parses it with the **synchronous stdlib `json.loads`**, which blocks the event loop for the entire duration of the parse. With a couple hundred concurrent streaming coroutines sharing that one loop, every blocking parse delays the scheduling of the response-streaming coroutines, so finished responses are flushed to the client late — inflating the client-side per-token speed even though the engine produced the tokens on time.

This is **cross-request** contention, not a per-request ordering issue: at steady state (closed-loop traffic) the single loop is simultaneously *ingesting* newly-arrived requests (`json.loads`) and *egressing* tokens for other requests that have already finished decoding — the two opposite ends of the pipeline both live on this one thread. Because it is single-threaded, a blocking parse of an incoming request stalls delivery of an unrelated, already-finished response.

### Resolution
Parse request bodies with **orjson** (a native JSON parser, ~4x faster than stdlib `json`) via a small custom `APIRoute` / `Request` subclass installed as the FastAPI app's `route_class`. This shrinks the synchronous parse window so the loop interleaves the streaming coroutines promptly. The change is:

- self-contained in `tensorrt_llm/serve/openai_server.py` — no handler-signature changes, Pydantic validation unchanged;
- **gated** — off by default (opt-in); set `TRTLLM_SERVE_ENABLE_ORJSON=1` to enable;
- **fail-loud when enabled** — if the flag is set but `orjson` isn't importable it raises at startup (never a silent stdlib no-op); any input orjson rejects (e.g. `NaN`/`Infinity`, which stdlib `json` accepts) is still re-parsed per request with the stdlib parser, so results are identical to the `json` baseline;
- additive to `requirements.txt` (`orjson`).

### Perf gain
DeepSeek-V4-Pro 6p1d (6 context + 1 generation, DEP8) disaggregated serving, c3200, GB300 — orjson vs stdlib `json` body parsing on the generation frontend, strip-on:

| metric | stdlib `json` | orjson | change |
|---|---:|---:|---:|
| client output speed, SSE p50 (tok/s/req) | 22.2 | 26.4 | +19% |
| throughput per GPU (tok/s) | 1452 | 1545 | +6% |
| GEN in-flight batch (`num_scheduled_requests`) | 244 | 252 | +3% |

The gain **scales with request-body size**: at strip-off (full multi-turn body, ~1 MB) it is larger — **~+13% TPS/GPU** (~1330 → ~1500) — orjson helps more the bigger the body it parses.

**Root cause validated by stack-sampling the serving event loop.** With stdlib `json`, the single uvicorn/asyncio loop is pinned parsing the request body (`cpu_frac ≈ 0.99`, ~750 ms–1 s scheduling lag; the sampler shows it stuck in `json/decoder.py:raw_decode`), starving the response-streaming coroutines and delaying token delivery. With orjson (~4× faster, native) the synchronous parse window collapses and the loop stays responsive (~150 ms lag). The **GEN in-flight batch rises** (244 → 252) rather than falling — confirming the fix feeds the engine faster rather than shedding load.

> Note: orjson is **opt-in (off by default)**. When enabled it does **not** silently fall back — a missing `orjson` raises at startup, so the flag can never silently no-op; `orjson` is in `requirements.txt`.

## Test Coverage

- The chat/completions request path now flows through the orjson route. The existing OpenAI-server app tests under `tests/unittest/llmapi/apps/` (`_test_openai_chat.py`, `_test_openai_completions.py`, `_test_openai_multi_chat.py`, ...) exercise request bodies — including tool schemas and multi-turn messages — and validate correct parsing + responses.
- End-to-end accuracy (GSM8K), DeepSeek-V4-Pro via `trtllm-eval gsm8k` (raw 5-shot, greedy, full 1319): flexible-extract 95.38 / strict-match 95.45 (`exact_match`), matching the published DeepSeek baseline. This eval runs in-process via the LLM API, so it exercises the engine, not the changed serving code; `orjson.loads` returns the same Python objects as `json.loads` for valid JSON, so generated tokens are unchanged by construction. The orjson change is confined to HTTP request-body deserialization in `openai_server.py`.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
