### PR TITLE
[None][perf] disagg: opt-in ctx-side base64 int32 transport for prompt_token_ids

### DIFF
--- a/tensorrt_llm/llmapi/disagg_utils.py
+++ b/tensorrt_llm/llmapi/disagg_utils.py
@@ -90,6 +90,10 @@ class DisaggServerConfig():
     # worker's request body / JSON-parse GIL cost at high concurrency. Enable
     # ONLY for text-only, non-harmony deployments (see _get_gen_request).
     gen_strip_message_history: bool = False
+    # Ask context workers to return prompt_token_ids as a base64 int32 buffer so
+    # the orchestrator relays a string instead of materializing the token-id list
+    # on its event loop. Text-only, non-harmony deployments (see _get_ctx_request).
+    gen_tokids_ctxbytes: bool = False
 
 
 @dataclass
@@ -140,6 +144,7 @@ def extract_disagg_cfg(hostname: str = 'localhost',
                            'context_first',
                            'generation_first'] = 'context_first',
                        gen_strip_message_history: bool = False,
+                       gen_tokids_ctxbytes: bool = False,
                        **kwargs: Any) -> DisaggServerConfig:
     context_servers = context_servers or {}
     generation_servers = generation_servers or {}
@@ -188,6 +193,7 @@ def extract_disagg_cfg(hostname: str = 'localhost',
     if schedule_style:
         config.schedule_style = schedule_style
     config.gen_strip_message_history = gen_strip_message_history
+    config.gen_tokids_ctxbytes = gen_tokids_ctxbytes
     return config
 
 

--- a/tensorrt_llm/serve/openai_disagg_service.py
+++ b/tensorrt_llm/serve/openai_disagg_service.py
@@ -78,6 +78,8 @@ class OpenAIDisaggregatedService(OpenAIService):
         self._health_check_interval_secs = health_check_interval_secs
         # Opt-in body-shrink for generation_only requests; see _get_gen_request.
         self._strip_gen_message_history = config.gen_strip_message_history
+        # Opt-in: ask context workers to return prompt_token_ids as base64 int32.
+        self._tokids_ctxbytes = config.gen_tokids_ctxbytes
 
         self._ctx_client = None
         self._gen_client = None
@@ -320,6 +322,7 @@ class OpenAIDisaggregatedService(OpenAIService):
                     request_type="context_only",
                     disagg_request_id=disagg_request_id,
                     schedule_style=self._schedule_style,
+                    return_prompt_token_ids_b64=self._tokids_ctxbytes,
                 ),
                 "stream": False,
                 "stream_options": None,
@@ -342,7 +345,12 @@ class OpenAIDisaggregatedService(OpenAIService):
             if isinstance(request, CompletionRequest):
                 request.prompt = ctx_response.prompt_token_ids
             elif isinstance(request, ChatCompletionRequest):
-                request.prompt_token_ids = ctx_response.prompt_token_ids
+                # Relay the base64 token-id string verbatim (no int-list
+                # materialization on the orchestrator loop), else the int array.
+                if ctx_response.prompt_token_ids_b64 is not None:
+                    request.prompt_token_ids_b64 = ctx_response.prompt_token_ids_b64
+                else:
+                    request.prompt_token_ids = ctx_response.prompt_token_ids
                 # Opt-in: drop conversation history so the gen worker doesn't
                 # re-parse the full conversation JSON (dominates its GIL at high
                 # concurrency). It uses prompt_token_ids and only reads the last

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -137,6 +137,9 @@ class DisaggregatedParams(OpenAIBaseModel):
     ctx_dp_rank: Optional[int] = None
     ctx_info_endpoint: Optional[str] = None
     schedule_style: Optional[DisaggScheduleStyle] = None
+    # Orchestrator -> context-worker instruction: return prompt_token_ids as a
+    # base64 int32 buffer (prompt_token_ids_b64) instead of a JSON int array.
+    return_prompt_token_ids_b64: bool = False
 
 
 class ConversationParams(OpenAIBaseModel):
@@ -618,6 +621,9 @@ class ChatCompletionResponse(OpenAIBaseModel):
     # Add prompt_tokens_ids to the response to remove the tokenization
     # in the generation server in disaggreated serving
     prompt_token_ids: Optional[List[int]] = None
+    # base64 int32 buffer alternative to prompt_token_ids; set by the context
+    # worker so the orchestrator can relay a string instead of the int list.
+    prompt_token_ids_b64: Optional[str] = None
 
 
 class DeltaMessage(OpenAIBaseModel):
@@ -675,6 +681,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
     # Add prompt_tokens_ids to the request to remove the tokenization
     # in the generation server in disaggreated serving
     prompt_token_ids: Optional[List[int]] = None
+    # base64 int32 buffer relayed by the orchestrator from the ctx response;
+    # decoded back to prompt_token_ids on the generation worker. Not for clients.
+    prompt_token_ids_b64: Optional[str] = None
     model: str
     frequency_penalty: Optional[float] = 0.0
     logit_bias: Optional[Dict[str, float]] = None

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -1181,6 +1181,13 @@ class OpenAIServer(_VideoRoutesMixin):
                     self.multimodal_server_config,
                     request_media_io_kwargs=request.media_io_kwargs)
 
+            # Decode base64 int32 prompt_token_ids relayed by the orchestrator.
+            if request.prompt_token_ids is None and request.prompt_token_ids_b64:
+                import numpy as np
+                request.prompt_token_ids = np.frombuffer(
+                    base64.b64decode(request.prompt_token_ids_b64),
+                    dtype=np.int32).tolist()
+
             if request.prompt_token_ids is not None:
                 prompt = request.prompt_token_ids
             else:
@@ -1263,6 +1270,18 @@ class OpenAIServer(_VideoRoutesMixin):
             else:
                 response = await self._create_chat_response(
                     promise, postproc_params, raw_request, disaggregated_params)
+                # Context-only: optionally return prompt_token_ids as a base64
+                # int32 buffer (one string) so the disagg orchestrator relays it
+                # without materializing the int list on its event loop. The encode
+                # runs here on the context worker (1-of-N), not the orchestrator.
+                if (request.disaggregated_params is not None and
+                        request.disaggregated_params.return_prompt_token_ids_b64
+                        and response.prompt_token_ids is not None):
+                    import numpy as np
+                    response.prompt_token_ids_b64 = base64.b64encode(
+                        np.asarray(response.prompt_token_ids,
+                                   dtype=np.int32).tobytes()).decode("ascii")
+                    response.prompt_token_ids = None
                 return JSONResponse(content=response.model_dump())
         except CppExecutorError:
             logger.error(traceback.format_exc())


### PR DESCRIPTION
## What

In disaggregated serving the orchestrator (`trtllm-serve disaggregated`) is a **single asyncio event loop**. Per request it handles the context server's `prompt_token_ids` (~40k ints for long agentic prompts) **three times** on that one loop:

1. `json.loads` of the ctx response body (`openai_client._post_with_retry`),
2. pydantic-validate into `ChatCompletionResponse.prompt_token_ids` (`openai_client` `response_type(**resp_json)`),
3. `model_dump_json` re-serialize onto the generation request (`openai_client`).

At high concurrency this is the **binding host bottleneck** (the orchestrator loop saturates), and it sits on the **TTFT critical path**.

This PR adds an opt-in fast path, **config-gated via `DisaggServerConfig.gen_tokids_ctxbytes`** (default off): the orchestrator instructs context workers (via `DisaggregatedParams.return_prompt_token_ids_b64` on the context request) to serialize `prompt_token_ids` into the context response as a **base64-encoded int32 buffer** (one JSON string); the orchestrator then **relays that string verbatim** onto the generation request without ever materializing the int list (no `np.asarray`, no int-array (de)serialization); the generation worker decodes it back. The encode is thereby spread across the N context workers instead of concentrated on the one orchestrator loop. **Off ⇒ byte-identical to baseline.**

New fields: `prompt_token_ids_b64: Optional[str]` on `ChatCompletionResponse` and `ChatCompletionRequest`; `return_prompt_token_ids_b64: bool` on `DisaggregatedParams` (orchestrator→ctx instruction); `gen_tokids_ctxbytes: bool` on `DisaggServerConfig`.

## Why (measured: DeepSeek-V4-Pro 6p1d, GB300, AA-RWLT coding-agent dataset)

- **c2048 (stable, GPU-bound): TTFT p50 −57% (2.95s→1.28s), p95 −41%** (consistent across reps); throughput flat (GPU-bound there, so the orchestrator relief shows purely as lower first-token latency on the critical path).
- **c2600 (orchestrator-bound, multi-rep): +74% mean completions; raises the sustainable-concurrency-before-collapse ceiling** (baseline collapses ~2/3 runs near the cliff; the fast path stays healthy).

A counter-experiment that pins the mechanism: encoding the same base64 **on the orchestrator loop** instead (`np.asarray` there) *regresses ~6×* — it adds work to the binding loop. This PR does the opposite (encode on the ctx workers, orchestrator only relays a string)
