### PR TITLE
[None][fix] Handle prefix-space variants for bad words

### DIFF
--- a/tensorrt_llm/sampling_params.py
+++ b/tensorrt_llm/sampling_params.py
@@ -472,9 +472,29 @@ class SamplingParams:
                 # For tiktokenizer, the encode method does not have add_special_tokens argument
                 return tokenizer.encode(text)
 
+        def _encode_bad_word(tokenizer, text, add_special_tokens):
+            """Encode a bad word as original and prefix-space token variants."""
+            token_ids = _encode(tokenizer, text, add_special_tokens)
+            word_ids = [token_ids]
+            prefixed_token_ids = _encode(
+                tokenizer, f" {text.lstrip()}", add_special_tokens
+            )
+            if (
+                len(prefixed_token_ids) == len(token_ids)
+                and prefixed_token_ids
+                and token_ids
+                and prefixed_token_ids[0] != token_ids[0]
+            ):
+                word_ids.append(prefixed_token_ids)
+            return word_ids
+
         if self.bad is not None:
             strs = [self.bad] if isinstance(self.bad, str) else self.bad
-            self._bad_word_ids = [_encode(tokenizer, s, add_special_tokens) for s in strs]
+            self._bad_word_ids = [
+                token_ids
+                for s in strs
+                for token_ids in _encode_bad_word(tokenizer, s, add_special_tokens)
+            ]
 
         if self.stop is not None:
             strs = [self.stop] if isinstance(self.stop, str) else self.stop

--- a/tests/unittest/llmapi/test_sampling_params.py
+++ b/tests/unittest/llmapi/test_sampling_params.py
@@ -32,6 +32,30 @@ from tensorrt_llm.serve.openai_protocol import (
 from tensorrt_llm.serve.resource_governor import ResourceGovernor
 
 
+@pytest.mark.parametrize(
+    ("tokenizations", "expected_bad_words"),
+    [
+        ({"London": [1], " London": [2]}, [[1], [2]]),
+        ({"London": [1], " London": [1]}, [[1]]),
+        ({"London": [1], " London": [3, 1]}, [[1]]),
+    ],
+)
+def test_bad_words_prefix_space_variants(tokenizations, expected_bad_words):
+    class FakeTokenizer:
+        eos_token_id = 0
+        pad_token_id = 0
+
+        def encode(self, text, add_special_tokens=False):
+            del add_special_tokens
+            return tokenizations[text]
+
+    tokenizer = FakeTokenizer()
+    sampling_params = SamplingParams(bad="London")
+    sampling_params._setup(tokenizer, hf_model_config=None, generation_config=None)
+
+    assert sampling_params._get_bad_words() == expected_bad_words
+
+
 @pytest.mark.parametrize("field", ["logprobs", "prompt_logprobs", "top_logprobs"])
 def test_check_logprobs_limit(field):
     check_logprobs_limit(field, None)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bad-word handling so both a word and the same word with a leading space are recognized correctly during sampling.
  * Prevented missed matches for tokenized bad-word variants, making filtering more reliable across tokenizers.
* **Tests**
  * Added coverage for prefix-space bad-word variants to verify both token forms are included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

Fix #15706 -- bad-word tokenization for prefix-space tokenizers.

TRT-LLM previously encoded each `SamplingParams.bad` string only once. Fortokenizers where `"word"` and `" word"` produce different token ids, this can miss bad words that appear in the middle of generated text.

The existing `test_generate_with_bad_words` uses `TinyLlama-1.1B-Chat-v1.0`. I checked that this tokenizer encodes the unprefixed form and the leading-space form to the same ids:

```text
word     encode(word)    encode(" " + word)    different?
London   [4517]          [4517]                False
the      [278]           [278]                 False
hello    [22172]         [22172]               False
```

Because TinyLlama collapses these two forms to the same ids, `test_generate_with_bad_words` can pass even when TRT-LLM only stores one bad-word tokenization. It cannot expose the prefix-space bug.

## Fix
When setting up bad words, encode both forms for each bad word:

```python
bad_word
f" {bad_word.lstrip()}"
```

Identical token sequences are deduplicated, so tokenizers like TinyLlama keep  the same behavior while prefix-space tokenizers get complete coverage.


## Test

Added a focused regression test using the GPT-2 tokenizer, because GPT-2 distinguishes unprefixed and space-prefixed word forms. The test verifies that both `"London"` and `" London"` token ids are included in `_get_bad_words()`.

```shell
python -m pytest tests/unittest/llmapi/test_llm.py::test_bad_words_prefix_space_variants -q
```



<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [-] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
