### PR TITLE
[https://nvbugs/6103083][fix] Make EAGLE functional on v1 KV cache manager

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -202,6 +202,66 @@ def is_vswa_enabled(kv_cache_config):
         set(max_attention_window)) > 1
 
 
+def _is_sliding_attention_layer(layer_type: object) -> bool:
+    layer_type_name = getattr(layer_type, "name", str(layer_type)).lower()
+    return "sliding" in layer_type_name
+
+
+def _normalize_attention_windows(
+    max_attention_window: List[int],
+    max_seq_len: int,
+) -> Optional[List[int]]:
+    normalized = [min(max_seq_len, window) for window in max_attention_window]
+    if all(window == max_seq_len for window in normalized):
+        return None
+    if len(set(normalized)) == 1:
+        return [normalized[0]]
+    return normalized
+
+
+def _derive_draft_max_attention_window(
+    kv_cache_config: KvCacheConfig,
+    draft_pretrained_config: object,
+    max_seq_len: int,
+    num_draft_layers: int,
+) -> Optional[List[int]]:
+    if not is_vswa_enabled(kv_cache_config):
+        max_attention_window = kv_cache_config.max_attention_window
+        if max_attention_window is None:
+            return None
+        return _normalize_attention_windows(max_attention_window, max_seq_len)
+
+    sliding_window = getattr(draft_pretrained_config, "sliding_window", None)
+    layer_types = getattr(draft_pretrained_config, "layer_types", None)
+    # HF configs today expose a single scalar `sliding_window`; `layer_types`
+    # only marks sliding vs full. A draft with *multiple distinct* sliding window
+    # sizes cannot be represented here — fail loudly instead of silently
+    # collapsing every sliding layer to one size. Extension point: map each
+    # sliding layer_type to its own window size.
+    if isinstance(sliding_window, (list, tuple)):
+        raise NotImplementedError(
+            "Draft KV window derivation assumes a single sliding-window size, "
+            f"got multiple: {sliding_window}")
+    if sliding_window is not None and layer_types:
+        layer_type_pattern = list(layer_types)
+        if layer_type_pattern:
+            draft_windows = []
+            for layer_idx in range(num_draft_layers):
+                layer_type = layer_type_pattern[layer_idx %
+                                                len(layer_type_pattern)]
+                draft_windows.append(
+                    int(sliding_window)
+                    if _is_sliding_attention_layer(layer_type) else max_seq_len)
+            return _normalize_attention_windows(draft_windows, max_seq_len)
+
+    use_sliding_window = getattr(draft_pretrained_config, "use_sliding_window",
+                                 None)
+    if sliding_window is not None and use_sliding_window is True:
+        return _normalize_attention_windows([int(sliding_window)], max_seq_len)
+
+    return None
+
+
 class KvCacheCreator:
     """Groups together logic related to KV cache construction."""
 
@@ -953,7 +1013,40 @@ class KvCacheCreator:
         effective_draft_config = self._get_effective_draft_config()
 
         draft_kv_config = (kv_cache_config_override if kv_cache_config_override
-                           is not None else self._kv_cache_config)
+                           is not None else self._kv_cache_config).model_copy()
+        draft_kv_config.max_attention_window = _derive_draft_max_attention_window(
+            self._kv_cache_config,
+            effective_draft_config.pretrained_config,
+            self._max_seq_len,
+            num_draft_layers,
+        )
+        # A draft whose *own* config is VSWA (mixed sliding/full attention
+        # layers, so the derived window has >1 distinct size) is envisioned but
+        # not yet supported here. ``draft_kv_config`` inherits the target's
+        # combined ``max_gpu_total_bytes`` via the ``model_copy()`` above; a
+        # VSWA draft would route through ``calculate_max_num_blocks_for_vswa``,
+        # which sizes pools from that full byte budget rather than the draft's
+        # ``max_tokens`` share — so the separate draft manager would re-allocate
+        # the whole KV budget and OOM. Only the non-SWA draft path (single/None
+        # window, which falls back to the ``max_tokens``-partitioned allocation)
+        # is exercised today; no draft model currently ships with mixed
+        # ``layer_types``. When one does, partition the budget here before the
+        # per-window split, e.g.:
+        #     _, draft_cost = self._get_target_and_draft_cache_costs()
+        #     draft_kv_config.max_gpu_total_bytes = draft_cost.bytes_for_tokens(
+        #         self._kv_cache_config.max_tokens)
+        if is_vswa_enabled(draft_kv_config):
+            raise NotImplementedError(
+                "A VSWA draft model (mixed sliding-window and full-attention "
+                "layers) is not yet supported for one-model speculative "
+                "decoding with a separate draft KV cache manager: its KV budget "
+                "would not be partitioned from the target's and would overrun "
+                "GPU memory. Derived draft max_attention_window="
+                f"{draft_kv_config.max_attention_window}.")
+        if is_vswa_enabled(self._kv_cache_config):
+            logger.info(
+                f"Derived draft KV cache max_attention_window for separate "
+                f"draft manager: {draft_kv_config.max_attention_window}")
         # Get the appropriate KV cache manager class for the draft model
         draft_kv_cache_manager_cls = get_kv_cache_manager_cls(
             effective_draft_config, draft_kv_config, is_disagg=self._is_disagg)

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -17,7 +17,8 @@ from tensorrt_llm._utils import get_sm_version, global_mpi_rank
 from tensorrt_llm.llmapi.llm_args import (CapacitySchedulerPolicy,
                                           ContextChunkingPolicy,
                                           ExecutorMemoryType,
-                                          GuidedDecodingConfig, LoadFormat,
+                                          GuidedDecodingConfig, KvCacheConfig,
+                                          LoadFormat, SpeculativeConfig,
                                           TorchLlmArgs)
 from tensorrt_llm.llmapi.tokenizer import (TokenizerBase,
                                            _llguidance_tokenizer_info,
@@ -204,6 +205,31 @@ def update_sampler_max_seq_len(max_seq_len, sampler):
     if isinstance(sampler, TRTLLMSampler):
         assert hasattr(sampler, "max_seq_len")
         sampler.max_seq_len = max_seq_len
+
+
+def _extend_full_attention_windows_for_spec_decode(
+    kv_cache_config: KvCacheConfig,
+    spec_config: Optional[SpeculativeConfig],
+    net_max_seq_len: int,
+    model_engine_max_seq_len: int,
+) -> None:
+    max_attention_window = kv_cache_config.max_attention_window
+    if spec_config is None or max_attention_window is None:
+        return
+    if model_engine_max_seq_len <= net_max_seq_len:
+        return
+
+    adjusted_max_attention_window = [
+        model_engine_max_seq_len if window >= net_max_seq_len else window
+        for window in max_attention_window
+    ]
+    if adjusted_max_attention_window == max_attention_window:
+        return
+
+    logger.info("Extending full-attention max_attention_window entries for "
+                f"speculative decoding from {max_attention_window} to "
+                f"{adjusted_max_attention_window}.")
+    kv_cache_config.max_attention_window = adjusted_max_attention_window
 
 
 def get_guided_decoding_config(guided_decoding_backend: str,
@@ -622,6 +648,13 @@ def create_py_executor(
     if spec_config is not None:
         model_engine_max_seq_len += get_num_extra_kv_tokens(spec_config)
         model_engine_max_seq_len += spec_config.tokens_per_gen_step - 1
+
+    _extend_full_attention_windows_for_spec_decode(
+        kv_cache_config=kv_cache_config,
+        spec_config=spec_config,
+        net_max_seq_len=net_max_seq_len,
+        model_engine_max_seq_len=model_engine_max_seq_len,
+    )
 
     if has_draft_model_engine and not llm_args.disable_overlap_scheduler:
         logger.warning(

--- a/tensorrt_llm/_torch/speculative/eagle3.py
+++ b/tensorrt_llm/_torch/speculative/eagle3.py
@@ -395,6 +395,10 @@ class Eagle3OneModelSpecMetadata(SpecMetadata):
     # for the first loop iteration and per-sequence token counts for
     # subsequent iterations.
     subseq_all_rank_num_tokens: Optional[List[int]] = None
+    # Real (unpadded) scheduled token count for the target forward. Captured in
+    # prepare() before self.num_tokens is decremented to the attention-DP subseq
+    # shape; maybe_capture_hidden_states must bound by this, not self.num_tokens.
+    num_capture_tokens: int = 0
 
     def __post_init__(self):
         if self.layers_to_capture is None:
@@ -487,6 +491,12 @@ class Eagle3OneModelSpecMetadata(SpecMetadata):
                                      pin_memory=prefer_pinned())
         self.batch_indices_cuda[:num_seqs].copy_(batch_indices,
                                                  non_blocking=True)
+        # Snapshot the real (unpadded) scheduled token count before the decrement
+        # below. maybe_capture_hidden_states runs during the target forward and
+        # must bound the capture by this count; self.num_tokens is about to be
+        # rewritten to the attention-DP subseq shape and would otherwise drop the
+        # draft-verification positions from the captured hidden states.
+        self.num_capture_tokens = self.num_tokens
         # `num_tokens` here only feeds the attention-DP shape hint
         # (allgathered in model_engine and overridden into
         # `attn_metadata.all_rank_num_tokens` on the step-0 draft forward).
@@ -529,7 +539,32 @@ class Eagle3OneModelSpecMetadata(SpecMetadata):
 
         for i, captured_layer_id in enumerate(self.layers_to_capture):
             if captured_layer_id == layer_id:
-                to_save = hidden_states + residual if residual is not None else hidden_states
+                assert self.hidden_states is not None
+                # CUDA graph padding can make hidden_states larger than the
+                # scheduled token count. Capture only real tokens; otherwise
+                # EAGLE one-model can overrun the preallocated capture buffer.
+                # Use num_capture_tokens (the real scheduled token count), not
+                # self.num_tokens which prepare() decremented to the
+                # attention-DP subseq shape.
+                num_tokens = self.num_capture_tokens
+                if num_tokens > self.hidden_states.shape[0]:
+                    raise RuntimeError(
+                        "EAGLE3 hidden-state capture token count exceeds "
+                        f"buffer capacity: num_tokens={num_tokens}, "
+                        f"capacity={self.hidden_states.shape[0]}")
+                if num_tokens > hidden_states.shape[0]:
+                    raise RuntimeError(
+                        "EAGLE3 hidden-state capture token count exceeds "
+                        f"available hidden states: num_tokens={num_tokens}, "
+                        f"hidden_states={hidden_states.shape[0]}")
+                to_save = hidden_states[:num_tokens]
+                if residual is not None:
+                    if num_tokens > residual.shape[0]:
+                        raise RuntimeError(
+                            "EAGLE3 hidden-state capture token count exceeds "
+                            f"available residual states: num_tokens={num_tokens}, "
+                            f"residual={residual.shape[0]}")
+                    to_save = to_save + residual[:num_tokens]
                 inplace_slice_copy(self.hidden_states, to_save,
                                    i * self.hidden_size,
                                    (i + 1) * self.hidden_size)

--- a/tests/unittest/_torch/speculative/test_eagle3.py
+++ b/tests/unittest/_torch/speculative/test_eagle3.py
@@ -4,23 +4,134 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 import torch
 from test_common.llm_data import with_mocked_hf_download_for_single_gpu
 from utils.llm_data import llm_models_root
-from utils.util import skip_blackwell
+from utils.util import skip_blackwell, skip_num_gpus_less_than
 
 from tensorrt_llm import LLM, SamplingParams
 from tensorrt_llm._torch.attention_backend.trtllm import TrtllmAttentionMetadata
 from tensorrt_llm._torch.metadata import KVCacheParams
+from tensorrt_llm._torch.pyexecutor._util import \
+    _derive_draft_max_attention_window
+from tensorrt_llm._torch.pyexecutor.py_executor_creator import \
+    _extend_full_attention_windows_for_spec_decode
+from tensorrt_llm._torch.speculative.eagle3 import Eagle3OneModelSpecMetadata
 from tensorrt_llm.executor.request import LoRARequest
 from tensorrt_llm.llmapi import (CudaGraphConfig, Eagle3DecodingConfig,
                                  KvCacheConfig)
 from tensorrt_llm.lora_helper import LoraConfig
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+
+def test_eagle3_draft_kv_cache_uses_full_window_when_draft_has_no_swa() -> None:
+    kv_cache_config = KvCacheConfig(max_attention_window=[128, 131072])
+    draft_pretrained_config = SimpleNamespace(num_hidden_layers=3)
+
+    max_attention_window = _derive_draft_max_attention_window(
+        kv_cache_config=kv_cache_config,
+        draft_pretrained_config=draft_pretrained_config,
+        max_seq_len=131072,
+        num_draft_layers=3,
+    )
+
+    assert max_attention_window is None
+
+
+def test_eagle3_draft_kv_cache_uses_draft_layer_types_for_swa() -> None:
+    kv_cache_config = KvCacheConfig(max_attention_window=[128, 131072])
+    draft_pretrained_config = SimpleNamespace(
+        sliding_window=512,
+        layer_types=["sliding_attention", "full_attention"],
+    )
+
+    max_attention_window = _derive_draft_max_attention_window(
+        kv_cache_config=kv_cache_config,
+        draft_pretrained_config=draft_pretrained_config,
+        max_seq_len=4096,
+        num_draft_layers=3,
+    )
+
+    assert max_attention_window == [512, 4096, 512]
+
+
+def test_eagle3_draft_kv_cache_rejects_multiple_sliding_window_sizes() -> None:
+    # The derivation assumes a single scalar sliding_window per model. A future
+    # draft config exposing multiple distinct sliding sizes must fail loudly
+    # rather than silently collapse every sliding layer to one size.
+    kv_cache_config = KvCacheConfig(max_attention_window=[128, 131072])
+    draft_pretrained_config = SimpleNamespace(
+        sliding_window=[512, 1024],
+        layer_types=["sliding_attention", "full_attention"],
+    )
+
+    with pytest.raises(NotImplementedError):
+        _derive_draft_max_attention_window(
+            kv_cache_config=kv_cache_config,
+            draft_pretrained_config=draft_pretrained_config,
+            max_seq_len=4096,
+            num_draft_layers=3,
+        )
+
+
+def test_eagle3_target_kv_cache_extends_full_window_for_spec_decode() -> None:
+    kv_cache_config = KvCacheConfig(max_attention_window=[128, 131072])
+    spec_config = Eagle3DecodingConfig(max_draft_len=3,
+                                       speculative_model="draft")
+
+    _extend_full_attention_windows_for_spec_decode(
+        kv_cache_config=kv_cache_config,
+        spec_config=spec_config,
+        net_max_seq_len=131072,
+        model_engine_max_seq_len=131080,
+    )
+
+    assert kv_cache_config.max_attention_window == [128, 131080]
+
+
+@skip_num_gpus_less_than(1)
+def test_eagle3_one_model_capture_uses_real_token_count() -> None:
+    # maybe_capture_hidden_states routes through inplace_slice_copy, a CUDA-only
+    # custom op, so this test runs on GPU. It verifies that the capture is bounded
+    # by the real scheduled token count (num_capture_tokens) and not self.num_tokens.
+    #
+    # prepare() decrements self.num_tokens to the attention-DP subseq shape while
+    # leaving num_capture_tokens at the real (unpadded) count. Simulate that
+    # post-prepare state: if the capture wrongly used self.num_tokens it would drop
+    # the draft-verification rows (regressing the acceptance rate); if it wrongly
+    # used the padded input it would overrun the buffer.
+    spec_metadata = Eagle3OneModelSpecMetadata(
+        max_num_requests=1,
+        max_draft_len=3,
+        max_total_draft_tokens=3,
+        num_layers=36,
+        hidden_size=2,
+        max_num_tokens=4,
+        dtype=torch.float32,
+        layers_to_capture={23},
+    )
+    assert spec_metadata.hidden_states is not None
+    spec_metadata.hidden_states.fill_(-1)
+    # Real scheduled count is 4; num_tokens is decremented below it by prepare().
+    spec_metadata.num_capture_tokens = 4
+    spec_metadata.num_tokens = 1
+
+    # 6 rows simulate CUDA-graph padding beyond the 4 scheduled tokens.
+    hidden_states = torch.arange(12, dtype=torch.float32,
+                                 device="cuda").reshape(6, 2)
+    residual = torch.ones_like(hidden_states)
+    spec_metadata.maybe_capture_hidden_states(23, hidden_states, residual)
+    torch.cuda.synchronize()
+
+    # All 4 real tokens captured (not truncated to num_tokens=1), padding dropped.
+    assert torch.equal(spec_metadata.hidden_states[:4, :2],
+                       hidden_states[:4] + residual[:4])
+    assert spec_metadata.hidden_states.shape == (4, 2)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
## Description

This PR extracts the **EAGLE-only** fixes from #13731 (Simeng Liu) so that EAGLE / one-model
speculative decoding is **no longer a functionality limitation for the v1 KV cache manager**.
The SWA window-management (placeholder blocks, cyclic-span page tables, `detachSwaFrontBlocks`)
and VSWA pool-sizing parts of #13731 are intentionally **left out** and tracked separately — they
are SWA-gated and inert on the common full-attention v1 path. This addresses nvbug 6103083
"Root Cause 1" (the OOM accounting) for the v1 manager; the SWA-specific root causes remain in the
separate SWA PR.

The changes are scoped to **exactly 4 Python files, zero C++**.

### Problem

EAGLE / one-model speculative decoding hit two independent failures on the v1 KV cache manager:

**1. eagle3 one-model hidden-state capture buffer overrun (memory safety, model-agnostic).**
In one-model EAGLE, the target model's intermediate hidden states are captured into a preallocated
buffer (`Eagle3OneModelSpecMetadata.hidden_states`, sized for `max_num_tokens` real tokens) so the
draft layer can read them. With **CUDA graphs**, the forward pass runs on a *padded* batch, so
`hidden_states.shape[0]` (padded token count) exceeds the real scheduled token count
(`self.num_tokens`). `maybe_capture_hidden_states` copied every row it was handed — including
padding rows — writing past the real-token region and overrunning the capture buffer.

**2. Under-sized full-attention windows → OOM (nvbug 6103083 Root Cause 1).**
- When a separate draft KV cache manager is created, it reused the **target's**
  `max_attention_window` instead of deriving windows from the **draft** model's config. For a VSWA
  target (mixed sliding/full, e.g. GPT-OSS) whose draft has a different attention layout, the draft
  pool is mis-sized.
- Speculative decoding inflates the effective sequence length
  (`model_engine_max_seq_len += tokens_per_gen_step - 1 + get_num_extra_kv_tokens(spec_config)`),
  but full-attention entries in `max_attention_window` were left at the pre-spec (`net`) seq len. A
  "full" window narrower than the token budget the engine pushes through it is the OOM source.

### Fix

**Fix 1 — bound the capture to real tokens** (`tensorrt_llm/_torch/speculative/eagle3.py`).
`Eagle3OneModelSpecMetadata.maybe_capture_hidden_states` now slices `hidden_states`/`residual` to
`self.num_tokens` *before* the copy, so CUDA-graph padding rows are never captured. Adds explicit
bounds checks (buffer capacity, available hidden states, available residual) that turn a silent
overrun into an actionable error.

**Fix 2a — derive draft windows from the draft config** (`tensorrt_llm/_torch/pyexecutor/_util.py`).
New helpers `_derive_draft_max_attention_window` / `_normalize_attention_windows` /
`_is_sliding_attention_layer`, wired into `_create_one_model_draft_kv_cache_manager`. The draft
`KvCacheConfig` is `model_copy()`'d and its `max_attention_window` is derived from the draft model's
`sliding_window` + `layer_types` (falling back to `use_sliding_window`), normalized against
`max_seq_len`.

**Fix 2b — extend full-attention windows for the spec-decode budget**
(`tensorrt_llm/_torch/pyexecutor/py_executor_creator.py`).
New `_extend_full_attention_windows_for_spec_decode`, called once `model_engine_max_seq_len` is
finalized. Any window entry that was a "full" window (`>= net_max_seq_len`) is widened to
`model_engine_max_seq_len`; genuinely-sliding entries are untouched.

### Notes on the extraction

- Each hunk was **re-derived against current `main`** — PR #13731's base branch (`feat/bench_x`) had
  diverged substantially, so a wholesale file checkout was not viable.
- On `main`, the one-model `maybe_capture_hidden_states` routes through the CUDA-only
  `inplace_slice_copy` custom op, so the bounding is applied to `to_save` *before* that call and the
  corresponding unit test is GPU-gated.
- The top-level `assert self.hidden_states is not None` from the source patch was moved **inside** the
  matched-layer branch so it does not break the MTP-eagle one-model path (which legitimately leaves
  `hidden_states = None` with an empty capture set).

## Test Coverage

`tests/unittest/_torch/speculative/test_eagle3.py` (4 new tests; each is red if its corresponding fix
is reverted):

- `test_eagle3_draft_kv_cache_uses_full_window_when_draft_has_no_swa` — VSWA target + draft without
  SWA → no draft window override (Fix 2a).
- `test_eagle3_draft_kv_cache_uses_draft_layer_types_for_swa` — draft `layer_types` → per-layer draft
  windows `[512, 4096, 512]` (Fix 2a).
- `test_eagle3_target_kv_cache_extends_full_window_for_spec_decode` — full-attention entry widened
  from `131072` to `131080` for the spec-decode budget (Fix 2b).
- `test_eagle3_one_model_capture_uses_real_token_count` (GPU) — 6-row (padded) input with
  `num_tokens=4` captures only the 4 real rows (Fix 1).

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved speculative decoding support for attention-window settings, including better handling of sliding-window and full-attention configurations.
  * Added safer hidden-state capture for EAGLE3 flows so only real tokens are copied.

* **Bug Fixes**
  * Prevents invalid attention-window configurations from being used in cases that could exceed memory limits.
  * Ensures attention-window values stay aligned when speculative decoding extends sequence length.
  * Adds clearer failures when captured token counts exceed available tensor sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->