### PR TITLE
[None][feat] Add Phase-4 rank-scatter variant to GVR Top-K decode kernels

### DIFF
--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode.py
@@ -231,7 +231,7 @@ class GvrTopKKernel:
         enable_smem_cache: bool = False,
         smem_cache_elems: int = 32768,
         seqlen_sorted: bool = False,
-        enable_p4_rank_scatter: bool = True,
+        enable_p4_rank_scatter: bool = False,
         enable_p4_rank_scatter_exact: bool = True,
     ):
         # cluster_size: number of CTAs cooperating per row. 1 = single-CTA
@@ -344,25 +344,35 @@ class GvrTopKKernel:
         self.FLT_MAX = 3.4028235e38
         self.NEG_FLT_MAX = -self.FLT_MAX
 
-        # Phase-4 variant select. When ``enable_p4_rank_scatter`` is True,
-        # the kernel dispatches :meth:`phase4_rank_scatter` instead of the
-        # iterative histogram-snap (:meth:`phase4_histogram_snap`). The
-        # rank-scatter path resolves the K-th rank with a single coarse
-        # histogram + (optionally) one fixed-256-bin fine recursion, then
-        # scatters survivors to their rank in one pass — collapsing the
-        # snap loop's ~14 block barriers to ~7. ``_exact`` adds the fine
-        # recursion that makes the straddling-bin tie-break exact (vdiff=0);
-        # without it the straddling bin is emitted in arbitrary order
-        # (set-correct, value-correct, but not rank-stable within ties).
-        # Both default on: the exact rank-scatter is a drop-in replacement
-        # for the snap Phase-4 (both exact, vdiff=0) and is the faster path
-        # (nsys cold-L2 median ~1.077x B300 / ~1.078x B200, 704-707/720 cells
-        # faster, hardware- and BS-invariant; see PR notes). ``_exact`` is
-        # kept on so the default stays exact like snap; pass
-        # enable_p4_rank_scatter_exact=False only when approximate
-        # straddling-tie order is acceptable in exchange for fewer barriers.
-        # Identical body is reused by the single-CTA path and the cluster
-        # leader-only path, so it stacks on cluster_size > 1.
+        # Phase-4 variant select (OPT-IN, default OFF). When
+        # ``enable_p4_rank_scatter`` is True the kernel dispatches
+        # :meth:`phase4_rank_scatter` instead of the exact iterative
+        # histogram-snap (:meth:`phase4_histogram_snap`). The rank-scatter
+        # path resolves the K-th rank with a coarse histogram + (optionally,
+        # ``_exact``) one fixed-256-bin fine recursion, then scatters
+        # survivors to their rank in a single pass — collapsing the snap
+        # loop's block barriers and running ~1.35x faster than snap on
+        # production temporally-coherent indexer logits (nsys cold-L2 B200,
+        # V4 Pro K1024 N64K).
+        #
+        # IMPORTANT — rank-scatter is NOT guaranteed exact on arbitrary
+        # continuous inputs. A fixed-depth histogram cannot separate two
+        # distinct values that land in the same (sub-)bin, so the straddling
+        # bin can emit a value below the true K-th rank. ``_exact`` (one
+        # fixed-256-bin fine recursion, default on when rank-scatter is
+        # enabled) resolves the straddling bin on typical distributions —
+        # exact (vdiff=0) on the temporally-coherent decode distribution
+        # (verified on V4 Pro/Flash synth) and on well-separated inputs — but
+        # a single recursion is still not sufficient for adversarial
+        # multi-bucket batches (large BS / cluster / varlen with uniform-random
+        # logits), where it can miss a boundary tie. Making it exact for ALL
+        # continuous inputs requires iterating to a real-value threshold, which
+        # costs about as much as the snap loop and so buys nothing over it.
+        # The exact histogram-snap is therefore the shipped DEFAULT; enable
+        # rank-scatter (opt-in) only where the production distribution holds
+        # and the ~1.35x P4 speedup (nsys cold-L2 B200, V4 Pro K1024 N64K) is
+        # wanted. Identical body is reused by the single-CTA and cluster
+        # leader-only paths, so it stacks on cluster_size > 1.
         self.enable_p4_rank_scatter = enable_p4_rank_scatter
         self.enable_p4_rank_scatter_exact = enable_p4_rank_scatter_exact
 

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode.py
@@ -231,8 +231,8 @@ class GvrTopKKernel:
         enable_smem_cache: bool = False,
         smem_cache_elems: int = 32768,
         seqlen_sorted: bool = False,
-        enable_p4_rank_scatter: bool = False,
-        enable_p4_rank_scatter_exact: bool = False,
+        enable_p4_rank_scatter: bool = True,
+        enable_p4_rank_scatter_exact: bool = True,
     ):
         # cluster_size: number of CTAs cooperating per row. 1 = single-CTA
         # path; 2/4 = thread-block cluster with DSMEM aggregation. Capped at
@@ -354,10 +354,15 @@ class GvrTopKKernel:
         # recursion that makes the straddling-bin tie-break exact (vdiff=0);
         # without it the straddling bin is emitted in arbitrary order
         # (set-correct, value-correct, but not rank-stable within ties).
-        # Both default off — opt-in, hardware-dependent gain (see module/PR
-        # notes: a consistent win on sm_103/B300, mixed on sm_100/B200 at
-        # BS=1). Identical body is reused by the single-CTA path and the
-        # cluster leader-only path, so it stacks on cluster_size > 1.
+        # Both default on: the exact rank-scatter is a drop-in replacement
+        # for the snap Phase-4 (both exact, vdiff=0) and is the faster path
+        # (nsys cold-L2 median ~1.077x B300 / ~1.078x B200, 704-707/720 cells
+        # faster, hardware- and BS-invariant; see PR notes). ``_exact`` is
+        # kept on so the default stays exact like snap; pass
+        # enable_p4_rank_scatter_exact=False only when approximate
+        # straddling-tie order is acceptable in exchange for fewer barriers.
+        # Identical body is reused by the single-CTA path and the cluster
+        # leader-only path, so it stacks on cluster_size > 1.
         self.enable_p4_rank_scatter = enable_p4_rank_scatter
         self.enable_p4_rank_scatter_exact = enable_p4_rank_scatter_exact
 

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode.py
@@ -1940,11 +1940,17 @@ class GvrTopKKernel:
                     for w3 in cutlass.range_constexpr(self.num_warps):
                         if cutlass.Int32(w3) < twf:
                             pre = pre + smem_wcnt[w3]
-                    smem_hist[0] = pre   # prefix into target fine warp
-                    smem_hist[1] = twf   # target fine warp
+                    # Stage prefix/target-warp metadata in spare s_iscalars
+                    # slots, NOT smem_hist[0]/[1]: the last fine warp's reverse
+                    # scan below walks fine bins down to 0/1, so reusing those
+                    # histogram bins as scratch would corrupt sb_star/ra_fine
+                    # when twf2 == num_warps-1. Slots [4]/[1] are dead here
+                    # (re-zeroed at the cnt_above/cnt_strad reset below).
+                    s_iscalars[4] = pre   # prefix into target fine warp
+                    s_iscalars[1] = twf   # target fine warp
                 cute.arch.barrier()
-                pre_f = smem_hist[0]
-                twf2 = smem_hist[1]
+                pre_f = s_iscalars[4]
+                twf2 = s_iscalars[1]
                 if warp_id == twf2 and lane == cutlass.Int32(0):
                     base_f = pre_f
                     sb_star = cutlass.Int32(fbins - 1)

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode.py
@@ -1815,8 +1815,12 @@ class GvrTopKKernel:
             bmin_r = cutlass.Float32(self.FLT_MAX)
             bmax_r = cutlass.Float32(self.NEG_FLT_MAX)
             for w in cutlass.range_constexpr(self.num_warps):
-                vmin = cutlass.Float32(llvm.bitcast(cutlass.Float32.mlir_type, smem_wcnt[w].ir_value()))
-                vmax = cutlass.Float32(llvm.bitcast(cutlass.Float32.mlir_type, smem_hist[w].ir_value()))
+                vmin = cutlass.Float32(
+                    llvm.bitcast(cutlass.Float32.mlir_type, smem_wcnt[w].ir_value())
+                )
+                vmax = cutlass.Float32(
+                    llvm.bitcast(cutlass.Float32.mlir_type, smem_hist[w].ir_value())
+                )
                 bmin_r = _fmin_f32_inline(bmin_r, vmin)
                 bmax_r = cute.arch.fmax(bmax_r, vmax)
             if bmax_r <= bmin_r:
@@ -1844,8 +1848,11 @@ class GvrTopKKernel:
             # ---- 3-step high→low bin search → straddling bin b* + rank_above ----
             warp_bin_sum = cutlass.Int32(0)
             for jb in cutlass.range_constexpr(bins_per_warp):
-                bidx_s = (cutlass.Int32(kBins - 1) - warp_id * cutlass.Int32(bins_per_warp)
-                          - cutlass.Int32(jb))
+                bidx_s = (
+                    cutlass.Int32(kBins - 1)
+                    - warp_id * cutlass.Int32(bins_per_warp)
+                    - cutlass.Int32(jb)
+                )
                 warp_bin_sum = warp_bin_sum + smem_hist[bidx_s]
             if lane == cutlass.Int32(0):
                 smem_wcnt[warp_id] = warp_bin_sum
@@ -1873,8 +1880,11 @@ class GvrTopKKernel:
                 rank_above = base_cum
                 set_d = cutlass.Int32(0)
                 for jb2 in cutlass.range_constexpr(bins_per_warp):
-                    bidx2 = (cutlass.Int32(kBins - 1) - target_warp * cutlass.Int32(bins_per_warp)
-                             - cutlass.Int32(jb2))
+                    bidx2 = (
+                        cutlass.Int32(kBins - 1)
+                        - target_warp * cutlass.Int32(bins_per_warp)
+                        - cutlass.Int32(jb2)
+                    )
                     ra_before = base_cum
                     base_cum = base_cum + smem_hist[bidx2]
                     if base_cum >= cutlass.Int32(kK) and set_d == cutlass.Int32(0):
@@ -1926,8 +1936,11 @@ class GvrTopKKernel:
                 # fine 3-step search seeded at rank_above (over fbins bins)
                 fws = cutlass.Int32(0)
                 for jbf in cutlass.range_constexpr(fbpw):
-                    bif = (cutlass.Int32(fbins - 1) - warp_id * cutlass.Int32(fbpw)
-                           - cutlass.Int32(jbf))
+                    bif = (
+                        cutlass.Int32(fbins - 1)
+                        - warp_id * cutlass.Int32(fbpw)
+                        - cutlass.Int32(jbf)
+                    )
                     fws = fws + smem_hist[bif]
                 if lane == cutlass.Int32(0):
                     smem_wcnt[warp_id] = fws
@@ -1951,8 +1964,8 @@ class GvrTopKKernel:
                     # histogram bins as scratch would corrupt sb_star/ra_fine
                     # when twf2 == num_warps-1. Slots [4]/[1] are dead here
                     # (re-zeroed at the cnt_above/cnt_strad reset below).
-                    s_iscalars[4] = pre   # prefix into target fine warp
-                    s_iscalars[1] = twf   # target fine warp
+                    s_iscalars[4] = pre  # prefix into target fine warp
+                    s_iscalars[1] = twf  # target fine warp
                 cute.arch.barrier()
                 pre_f = s_iscalars[4]
                 twf2 = s_iscalars[1]
@@ -1962,8 +1975,11 @@ class GvrTopKKernel:
                     ra_fine = base_f
                     sd = cutlass.Int32(0)
                     for jb3 in cutlass.range_constexpr(fbpw):
-                        sbi = (cutlass.Int32(fbins - 1) - twf2 * cutlass.Int32(fbpw)
-                               - cutlass.Int32(jb3))
+                        sbi = (
+                            cutlass.Int32(fbins - 1)
+                            - twf2 * cutlass.Int32(fbpw)
+                            - cutlass.Int32(jb3)
+                        )
                         ra_b = base_f
                         base_f = base_f + smem_hist[sbi]
                         if base_f >= cutlass.Int32(kK) and sd == cutlass.Int32(0):

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode.py
@@ -231,6 +231,8 @@ class GvrTopKKernel:
         enable_smem_cache: bool = False,
         smem_cache_elems: int = 32768,
         seqlen_sorted: bool = False,
+        enable_p4_rank_scatter: bool = False,
+        enable_p4_rank_scatter_exact: bool = False,
     ):
         # cluster_size: number of CTAs cooperating per row. 1 = single-CTA
         # path; 2/4 = thread-block cluster with DSMEM aggregation. Capped at
@@ -341,6 +343,23 @@ class GvrTopKKernel:
         self.MAX_REFINE_ITERS = 15
         self.FLT_MAX = 3.4028235e38
         self.NEG_FLT_MAX = -self.FLT_MAX
+
+        # Phase-4 variant select. When ``enable_p4_rank_scatter`` is True,
+        # the kernel dispatches :meth:`phase4_rank_scatter` instead of the
+        # iterative histogram-snap (:meth:`phase4_histogram_snap`). The
+        # rank-scatter path resolves the K-th rank with a single coarse
+        # histogram + (optionally) one fixed-256-bin fine recursion, then
+        # scatters survivors to their rank in one pass — collapsing the
+        # snap loop's ~14 block barriers to ~7. ``_exact`` adds the fine
+        # recursion that makes the straddling-bin tie-break exact (vdiff=0);
+        # without it the straddling bin is emitted in arbitrary order
+        # (set-correct, value-correct, but not rank-stable within ties).
+        # Both default off — opt-in, hardware-dependent gain (see module/PR
+        # notes: a consistent win on sm_103/B300, mixed on sm_100/B200 at
+        # BS=1). Identical body is reused by the single-CTA path and the
+        # cluster leader-only path, so it stacks on cluster_size > 1.
+        self.enable_p4_rank_scatter = enable_p4_rank_scatter
+        self.enable_p4_rank_scatter_exact = enable_p4_rank_scatter_exact
 
     # ------------------------------------------------------------------
     # SMEM slice cache loader. Streams this CTA's slice GMEM → SMEM via
@@ -1721,6 +1740,330 @@ class GvrTopKKernel:
                 output_indices_row[i11] = cutlass.Int32(-1)
                 i11 = i11 + cutlass.Int32(num_threads)
 
+    @cute.jit
+    def phase4_rank_scatter(
+        self,
+        smem_keys,
+        smem_vals,
+        smem_hist,
+        smem_wcnt,
+        s_thr,
+        s_iscalars,
+        output_values_row,
+        output_indices_row,
+        cand_count,
+        tidx,
+        warp_id,
+        lane,
+    ):
+        """Phase-4 fused rank-and-scatter (drop-in for phase4_histogram_snap).
+
+        Same three branches by ``cand_count`` vs ``kK`` and same
+        signature/SMEM contract as :meth:`phase4_histogram_snap`, so the
+        two are interchangeable at the dispatch site. The ``> kK`` branch
+        differs: instead of the iterative histogram-snap + 2-pass writeback
+        it does
+
+          1. one coarse ``kNumBins`` histogram over the candidate values,
+          2. a 3-step high→low bin search to the straddling bin ``b*`` and
+             the rank of everything strictly above it (``rank_above``),
+          3. (``_exact`` only) one fixed-256-bin fine-histogram recursion on
+             ``b*`` so the tie-break inside the straddling bin is exact, and
+          4. a single scatter pass writing each survivor directly to its
+             output rank.
+
+        This collapses the snap loop's block-barrier count (~14 → ~7). The
+        fixed 256 fine bins are independent of ``kNumBins`` (256 ≤ kNumBins
+        for every supported (dtype, top_k)), keeping the recursion cheap
+        even at kNumBins=2048. Result is exact (vdiff=0) on the realistic
+        temporally-coherent indexer distribution when ``_exact`` is set.
+        """
+        kK = cutlass.const_expr(self.top_k)
+        kBins = cutlass.const_expr(self.kNumBins)
+        num_threads = cutlass.const_expr(self.num_threads)
+        num_warps = cutlass.const_expr(self.num_warps)
+        bins_per_warp = cutlass.const_expr(kBins // self.num_warps)
+
+        if cand_count == cutlass.Int32(kK):
+            i4 = tidx
+            while i4 < cutlass.Int32(kK):
+                if cutlass.const_expr(self.return_output_values):
+                    output_values_row[i4] = self.dtype(smem_keys[i4])
+                output_indices_row[i4] = smem_vals[i4]
+                i4 = i4 + cutlass.Int32(num_threads)
+        elif cand_count > cutlass.Int32(kK):
+            # ---- block min/max over candidates ----
+            local_cmin = cutlass.Float32(self.FLT_MAX)
+            local_cmax = cutlass.Float32(self.NEG_FLT_MAX)
+            i5 = tidx
+            while i5 < cand_count:
+                v = smem_keys[i5]
+                local_cmin = _fmin_f32_inline(local_cmin, v)
+                local_cmax = cute.arch.fmax(local_cmax, v)
+                i5 = i5 + cutlass.Int32(num_threads)
+            cmin = self.warp_reduce_min_f32(local_cmin)
+            cmax = self.warp_reduce_max_f32(local_cmax)
+            if lane == cutlass.Int32(0):
+                smem_wcnt[warp_id] = float_as_uint32(cmin)
+                smem_hist[warp_id] = float_as_uint32(cmax)
+            cute.arch.barrier()
+            bmin_r = cutlass.Float32(self.FLT_MAX)
+            bmax_r = cutlass.Float32(self.NEG_FLT_MAX)
+            for w in cutlass.range_constexpr(self.num_warps):
+                vmin = cutlass.Float32(llvm.bitcast(cutlass.Float32.mlir_type, smem_wcnt[w].ir_value()))
+                vmax = cutlass.Float32(llvm.bitcast(cutlass.Float32.mlir_type, smem_hist[w].ir_value()))
+                bmin_r = _fmin_f32_inline(bmin_r, vmin)
+                bmax_r = cute.arch.fmax(bmax_r, vmax)
+            if bmax_r <= bmin_r:
+                bmax_r = bmin_r + cutlass.Float32(1e-6)
+            cute.arch.barrier()
+            # ---- zero + build histogram ----
+            i6 = tidx
+            while i6 < cutlass.Int32(kBins):
+                smem_hist[i6] = cutlass.Int32(0)
+                i6 = i6 + cutlass.Int32(num_threads)
+            cute.arch.barrier()
+            range1 = bmax_r - bmin_r
+            inv1 = (cutlass.Float32(kBins - 1) + cutlass.Float32(0.99)) / range1
+            i7 = tidx
+            while i7 < cand_count:
+                vk = smem_keys[i7]
+                bin_i = cutlass.Int32((vk - bmin_r) * inv1)
+                if bin_i < cutlass.Int32(0):
+                    bin_i = cutlass.Int32(0)
+                if bin_i > cutlass.Int32(kBins - 1):
+                    bin_i = cutlass.Int32(kBins - 1)
+                atomicAdd(smem_hist.iterator + bin_i, cutlass.Int32(1))
+                i7 = i7 + cutlass.Int32(num_threads)
+            cute.arch.barrier()
+            # ---- 3-step high→low bin search → straddling bin b* + rank_above ----
+            warp_bin_sum = cutlass.Int32(0)
+            for jb in cutlass.range_constexpr(bins_per_warp):
+                bidx_s = (cutlass.Int32(kBins - 1) - warp_id * cutlass.Int32(bins_per_warp)
+                          - cutlass.Int32(jb))
+                warp_bin_sum = warp_bin_sum + smem_hist[bidx_s]
+            if lane == cutlass.Int32(0):
+                smem_wcnt[warp_id] = warp_bin_sum
+            cute.arch.barrier()
+            if tidx == cutlass.Int32(0):
+                cum = cutlass.Int32(0)
+                tw = cutlass.Int32(num_warps - 1)
+                found = cutlass.Int32(0)
+                for w2 in cutlass.range_constexpr(self.num_warps):
+                    cum = cum + smem_wcnt[w2]
+                    if cum >= cutlass.Int32(kK) and found == cutlass.Int32(0):
+                        tw = cutlass.Int32(w2)
+                        found = cutlass.Int32(1)
+                cum2 = cutlass.Int32(0)
+                for w3 in cutlass.range_constexpr(self.num_warps):
+                    if cutlass.Int32(w3) < tw:
+                        cum2 = cum2 + smem_wcnt[w3]
+                s_iscalars[2] = cum2  # prefix-count before target warp
+                s_iscalars[3] = tw
+            cute.arch.barrier()
+            target_warp = s_iscalars[3]
+            if warp_id == target_warp and lane == cutlass.Int32(0):
+                base_cum = s_iscalars[2]
+                b_star = cutlass.Int32(kBins - 1)
+                rank_above = base_cum
+                set_d = cutlass.Int32(0)
+                for jb2 in cutlass.range_constexpr(bins_per_warp):
+                    bidx2 = (cutlass.Int32(kBins - 1) - target_warp * cutlass.Int32(bins_per_warp)
+                             - cutlass.Int32(jb2))
+                    ra_before = base_cum
+                    base_cum = base_cum + smem_hist[bidx2]
+                    if base_cum >= cutlass.Int32(kK) and set_d == cutlass.Int32(0):
+                        b_star = bidx2
+                        rank_above = ra_before  # count in bins strictly above b*
+                        set_d = cutlass.Int32(1)
+                s_iscalars[2] = rank_above
+                s_iscalars[3] = b_star
+                s_iscalars[4] = cutlass.Int32(0)  # cnt_above
+                s_iscalars[1] = cutlass.Int32(0)  # cnt_straddle
+            cute.arch.barrier()
+            b_star = s_iscalars[3]
+            rank_above = s_iscalars[2]
+
+            # ---- EXACT: one fine-histogram recursion on the straddling bin b* ----
+            if cutlass.const_expr(self.enable_p4_rank_scatter_exact):
+                # FIXED small fine-bin count (independent of kNumBins) — cuts the
+                # re-zero + 3-step cost (esp. K=2048 where kNumBins=2048); 256
+                # sub-bins over bin b* gives kNumBins×256 effective resolution,
+                # enough to resolve the straddling bin to ≤1 distinct value.
+                fbins = cutlass.const_expr(256)
+                fbpw = cutlass.const_expr(256 // self.num_warps)
+                # bin b* value range under the inv1 binning: [f_lo, f_lo + 1/inv1)
+                f_lo = bmin_r + cutlass.Float32(b_star) / inv1
+                finv = (cutlass.Float32(fbins - 1) + cutlass.Float32(0.99)) * inv1
+                # re-zero (only fbins slots) + build fine sub-hist of bin-b* cands
+                iz = tidx
+                while iz < cutlass.Int32(fbins):
+                    smem_hist[iz] = cutlass.Int32(0)
+                    iz = iz + cutlass.Int32(num_threads)
+                cute.arch.barrier()
+                ifb = tidx
+                while ifb < cand_count:
+                    vf = smem_keys[ifb]
+                    cb = cutlass.Int32((vf - bmin_r) * inv1)
+                    if cb < cutlass.Int32(0):
+                        cb = cutlass.Int32(0)
+                    if cb > cutlass.Int32(kBins - 1):
+                        cb = cutlass.Int32(kBins - 1)
+                    if cb == b_star:
+                        sb = cutlass.Int32((vf - f_lo) * finv)
+                        if sb < cutlass.Int32(0):
+                            sb = cutlass.Int32(0)
+                        if sb > cutlass.Int32(fbins - 1):
+                            sb = cutlass.Int32(fbins - 1)
+                        atomicAdd(smem_hist.iterator + sb, cutlass.Int32(1))
+                    ifb = ifb + cutlass.Int32(num_threads)
+                cute.arch.barrier()
+                # fine 3-step search seeded at rank_above (over fbins bins)
+                fws = cutlass.Int32(0)
+                for jbf in cutlass.range_constexpr(fbpw):
+                    bif = (cutlass.Int32(fbins - 1) - warp_id * cutlass.Int32(fbpw)
+                           - cutlass.Int32(jbf))
+                    fws = fws + smem_hist[bif]
+                if lane == cutlass.Int32(0):
+                    smem_wcnt[warp_id] = fws
+                cute.arch.barrier()
+                if tidx == cutlass.Int32(0):
+                    cumf = rank_above
+                    twf = cutlass.Int32(num_warps - 1)
+                    fnd = cutlass.Int32(0)
+                    for w2 in cutlass.range_constexpr(self.num_warps):
+                        cumf = cumf + smem_wcnt[w2]
+                        if cumf >= cutlass.Int32(kK) and fnd == cutlass.Int32(0):
+                            twf = cutlass.Int32(w2)
+                            fnd = cutlass.Int32(1)
+                    pre = rank_above
+                    for w3 in cutlass.range_constexpr(self.num_warps):
+                        if cutlass.Int32(w3) < twf:
+                            pre = pre + smem_wcnt[w3]
+                    smem_hist[0] = pre   # prefix into target fine warp
+                    smem_hist[1] = twf   # target fine warp
+                cute.arch.barrier()
+                pre_f = smem_hist[0]
+                twf2 = smem_hist[1]
+                if warp_id == twf2 and lane == cutlass.Int32(0):
+                    base_f = pre_f
+                    sb_star = cutlass.Int32(fbins - 1)
+                    ra_fine = base_f
+                    sd = cutlass.Int32(0)
+                    for jb3 in cutlass.range_constexpr(fbpw):
+                        sbi = (cutlass.Int32(fbins - 1) - twf2 * cutlass.Int32(fbpw)
+                               - cutlass.Int32(jb3))
+                        ra_b = base_f
+                        base_f = base_f + smem_hist[sbi]
+                        if base_f >= cutlass.Int32(kK) and sd == cutlass.Int32(0):
+                            sb_star = sbi
+                            ra_fine = ra_b
+                            sd = cutlass.Int32(1)
+                    smem_hist[2] = sb_star
+                    smem_hist[3] = ra_fine
+                cute.arch.barrier()
+                if tidx == cutlass.Int32(0):
+                    s_iscalars[4] = cutlass.Int32(0)  # cnt_above
+                    s_iscalars[0] = cutlass.Int32(0)  # cnt_mid (b*, sub>sb*)
+                    s_iscalars[1] = cutlass.Int32(0)  # cnt_strad (b*, sub==sb*)
+                cute.arch.barrier()
+                sb_star = smem_hist[2]
+                rank_above_fine = smem_hist[3]
+                isc = tidx
+                while isc < cand_count:
+                    v = smem_keys[isc]
+                    bin_i = cutlass.Int32((v - bmin_r) * inv1)
+                    if bin_i < cutlass.Int32(0):
+                        bin_i = cutlass.Int32(0)
+                    if bin_i > cutlass.Int32(kBins - 1):
+                        bin_i = cutlass.Int32(kBins - 1)
+                    if bin_i > b_star:
+                        pos = atomicAdd(s_iscalars.iterator + cutlass.Int32(4), cutlass.Int32(1))
+                        if pos < cutlass.Int32(kK):
+                            if cutlass.const_expr(self.return_output_values):
+                                output_values_row[pos] = self.dtype(v)
+                            output_indices_row[pos] = smem_vals[isc]
+                    elif bin_i == b_star:
+                        sb = cutlass.Int32((v - f_lo) * finv)
+                        if sb < cutlass.Int32(0):
+                            sb = cutlass.Int32(0)
+                        if sb > cutlass.Int32(fbins - 1):
+                            sb = cutlass.Int32(fbins - 1)
+                        if sb > sb_star:
+                            o = atomicAdd(s_iscalars.iterator + cutlass.Int32(0), cutlass.Int32(1))
+                            pos = rank_above + o
+                            if pos < cutlass.Int32(kK):
+                                if cutlass.const_expr(self.return_output_values):
+                                    output_values_row[pos] = self.dtype(v)
+                                output_indices_row[pos] = smem_vals[isc]
+                        elif sb == sb_star:
+                            o = atomicAdd(s_iscalars.iterator + cutlass.Int32(1), cutlass.Int32(1))
+                            pos = rank_above_fine + o
+                            if pos < cutlass.Int32(kK):
+                                if cutlass.const_expr(self.return_output_values):
+                                    output_values_row[pos] = self.dtype(v)
+                                output_indices_row[pos] = smem_vals[isc]
+                    isc = isc + cutlass.Int32(num_threads)
+                cute.arch.barrier()
+                cnt_strad = s_iscalars[1]
+                filled = rank_above_fine + cnt_strad
+                if filled > cutlass.Int32(kK):
+                    filled = cutlass.Int32(kK)
+                ipad = filled + tidx
+                while ipad < cutlass.Int32(kK):
+                    if cutlass.const_expr(self.return_output_values):
+                        output_values_row[ipad] = self.dtype(self.NEG_FLT_MAX)
+                    output_indices_row[ipad] = cutlass.Int32(-1)
+                    ipad = ipad + cutlass.Int32(num_threads)
+            else:
+                # ---- APPROX rank-and-scatter (single pass), arbitrary straddling order ----
+                isc = tidx
+                while isc < cand_count:
+                    v = smem_keys[isc]
+                    bin_i = cutlass.Int32((v - bmin_r) * inv1)
+                    if bin_i < cutlass.Int32(0):
+                        bin_i = cutlass.Int32(0)
+                    if bin_i > cutlass.Int32(kBins - 1):
+                        bin_i = cutlass.Int32(kBins - 1)
+                    if bin_i > b_star:
+                        pos = atomicAdd(s_iscalars.iterator + cutlass.Int32(4), cutlass.Int32(1))
+                        if pos < cutlass.Int32(kK):
+                            if cutlass.const_expr(self.return_output_values):
+                                output_values_row[pos] = self.dtype(v)
+                            output_indices_row[pos] = smem_vals[isc]
+                    elif bin_i == b_star:
+                        off = atomicAdd(s_iscalars.iterator + cutlass.Int32(1), cutlass.Int32(1))
+                        pos = rank_above + off
+                        if pos < cutlass.Int32(kK):
+                            if cutlass.const_expr(self.return_output_values):
+                                output_values_row[pos] = self.dtype(v)
+                            output_indices_row[pos] = smem_vals[isc]
+                    isc = isc + cutlass.Int32(num_threads)
+                cute.arch.barrier()
+                cnt_strad = s_iscalars[1]
+                filled = rank_above + cnt_strad
+                if filled > cutlass.Int32(kK):
+                    filled = cutlass.Int32(kK)
+                ipad = filled + tidx
+                while ipad < cutlass.Int32(kK):
+                    if cutlass.const_expr(self.return_output_values):
+                        output_values_row[ipad] = self.dtype(self.NEG_FLT_MAX)
+                    output_indices_row[ipad] = cutlass.Int32(-1)
+                    ipad = ipad + cutlass.Int32(num_threads)
+        else:
+            i10 = tidx
+            while i10 < cand_count:
+                if cutlass.const_expr(self.return_output_values):
+                    output_values_row[i10] = self.dtype(smem_keys[i10])
+                output_indices_row[i10] = smem_vals[i10]
+                i10 = i10 + cutlass.Int32(num_threads)
+            i11 = cand_count + tidx
+            while i11 < cutlass.Int32(kK):
+                if cutlass.const_expr(self.return_output_values):
+                    output_values_row[i11] = self.dtype(self.NEG_FLT_MAX)
+                output_indices_row[i11] = cutlass.Int32(-1)
+                i11 = i11 + cutlass.Int32(num_threads)
+
     # ------------------------------------------------------------------
     # Main kernel — one CTA per row
     # CUDA source: heuristicTopKDecode.cu:49-93 (heuristicTopKMultiRowKernel)
@@ -2167,23 +2510,43 @@ class GvrTopKKernel:
                             s_iscalars[0] = base_offset
                         cute.arch.barrier()
 
-                    # ---- Phase 4: histogram snap + writeback (leader only) ----
+                    # ---- Phase 4: snap / rank-scatter + writeback (leader only) ----
+                    # The candidate set sits entirely in this (leader) CTA's
+                    # SMEM after the DSMEM gather, so the rank-scatter path is
+                    # structurally identical to the single-CTA case and stacks
+                    # on cluster_size > 1 unchanged.
                     cand_count_p4 = min(s_iscalars[0], cutlass.Int32(self.kC))
 
-                    self.phase4_histogram_snap(
-                        smem_keys,
-                        smem_vals,
-                        smem_hist,
-                        smem_wcnt,
-                        s_thr,
-                        s_iscalars,
-                        output_values_row,
-                        output_indices_row,
-                        cand_count_p4,
-                        tidx,
-                        warp_id,
-                        lane,
-                    )
+                    if cutlass.const_expr(self.enable_p4_rank_scatter):
+                        self.phase4_rank_scatter(
+                            smem_keys,
+                            smem_vals,
+                            smem_hist,
+                            smem_wcnt,
+                            s_thr,
+                            s_iscalars,
+                            output_values_row,
+                            output_indices_row,
+                            cand_count_p4,
+                            tidx,
+                            warp_id,
+                            lane,
+                        )
+                    else:
+                        self.phase4_histogram_snap(
+                            smem_keys,
+                            smem_vals,
+                            smem_hist,
+                            smem_wcnt,
+                            s_thr,
+                            s_iscalars,
+                            output_values_row,
+                            output_indices_row,
+                            cand_count_p4,
+                            tidx,
+                            warp_id,
+                            lane,
+                        )
 
         # Final cluster barrier: keep peer CTAs (and their SMEM) alive
         # until the leader's gather + Phase 4 finish. Skipping this lets

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode_load_balance.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode_load_balance.py
@@ -218,13 +218,13 @@ class GvrTopKLBKernel:
         min_blocks_per_mp: int = 3,
         use_256bit_load: bool = True,
         enable_warp_parallel_reduce: Optional[bool] = None,
-        # Phase-4 rank-scatter (opt-in). Forwarded to BOTH underlying
-        # GvrTopKKernel instances, so the long (cluster / multi-CTA) branch
-        # and the short (single-CTA) branch use the same P4 variant. Default
-        # off; see GvrTopKKernel / PR notes for the hardware-dependent gain
-        # (consistent win on sm_103/B300, mixed on sm_100/B200 at BS=1).
-        enable_p4_rank_scatter: bool = False,
-        enable_p4_rank_scatter_exact: bool = False,
+        # Phase-4 rank-scatter. Forwarded to BOTH underlying GvrTopKKernel
+        # instances, so the long (cluster / multi-CTA) branch and the short
+        # (single-CTA) branch use the same P4 variant. Default on (exact),
+        # matching GvrTopKKernel: exact rank-scatter is a drop-in for the
+        # snap Phase-4 and the faster path (see GvrTopKKernel / PR notes).
+        enable_p4_rank_scatter: bool = True,
+        enable_p4_rank_scatter_exact: bool = True,
     ):
         assert cluster_size in (2, 4, 8), (
             f"cluster_size must be 2, 4, or 8 (GPC-bound); got {cluster_size}"

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode_load_balance.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode_load_balance.py
@@ -218,12 +218,13 @@ class GvrTopKLBKernel:
         min_blocks_per_mp: int = 3,
         use_256bit_load: bool = True,
         enable_warp_parallel_reduce: Optional[bool] = None,
-        # Phase-4 rank-scatter. Forwarded to BOTH underlying GvrTopKKernel
-        # instances, so the long (cluster / multi-CTA) branch and the short
-        # (single-CTA) branch use the same P4 variant. Default on (exact),
-        # matching GvrTopKKernel: exact rank-scatter is a drop-in for the
-        # snap Phase-4 and the faster path (see GvrTopKKernel / PR notes).
-        enable_p4_rank_scatter: bool = True,
+        # Phase-4 rank-scatter (OPT-IN, default OFF). Forwarded to BOTH
+        # underlying GvrTopKKernel instances, so the long (cluster / multi-CTA)
+        # and short (single-CTA) branches use the same P4 variant. Default off
+        # matches GvrTopKKernel: rank-scatter is faster but NOT exact on
+        # arbitrary inputs (see GvrTopKKernel docstring); the exact
+        # histogram-snap is the shipped default.
+        enable_p4_rank_scatter: bool = False,
         enable_p4_rank_scatter_exact: bool = True,
     ):
         assert cluster_size in (2, 4, 8), (

--- a/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode_load_balance.py
+++ b/tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode_load_balance.py
@@ -218,6 +218,13 @@ class GvrTopKLBKernel:
         min_blocks_per_mp: int = 3,
         use_256bit_load: bool = True,
         enable_warp_parallel_reduce: Optional[bool] = None,
+        # Phase-4 rank-scatter (opt-in). Forwarded to BOTH underlying
+        # GvrTopKKernel instances, so the long (cluster / multi-CTA) branch
+        # and the short (single-CTA) branch use the same P4 variant. Default
+        # off; see GvrTopKKernel / PR notes for the hardware-dependent gain
+        # (consistent win on sm_103/B300, mixed on sm_100/B200 at BS=1).
+        enable_p4_rank_scatter: bool = False,
+        enable_p4_rank_scatter_exact: bool = False,
     ):
         assert cluster_size in (2, 4, 8), (
             f"cluster_size must be 2, 4, or 8 (GPC-bound); got {cluster_size}"
@@ -247,6 +254,8 @@ class GvrTopKLBKernel:
             enable_warp_parallel_reduce=enable_warp_parallel_reduce,
             compress_ratio=compress_ratio,
             return_output_values=return_output_values,
+            enable_p4_rank_scatter=enable_p4_rank_scatter,
+            enable_p4_rank_scatter_exact=enable_p4_rank_scatter_exact,
         )
         self._cluster_kernel = GvrTopKKernel(cluster_size=cluster_size, **common_kwargs)
         self._single_kernel = GvrTopKKernel(cluster_size=1, **common_kwargs)
@@ -261,6 +270,8 @@ class GvrTopKLBKernel:
         self.return_output_values = return_output_values
         self.cluster_size = cluster_size
         self.max_batch_size = max_batch_size
+        self.enable_p4_rank_scatter = enable_p4_rank_scatter
+        self.enable_p4_rank_scatter_exact = enable_p4_rank_scatter_exact
 
         # Grid fixed at worst-case for graph capture; counters gates
         # the live clusters at runtime (dead overhead < 1us on B200).

--- a/tests/unittest/_torch/test_gvr_topk_rank_scatter.py
+++ b/tests/unittest/_torch/test_gvr_topk_rank_scatter.py
@@ -1,0 +1,235 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Correctness tests for the GVR Top-K Phase-4 rank-scatter variant.
+
+Exercises ``enable_p4_rank_scatter`` / ``enable_p4_rank_scatter_exact`` on the
+two paths the load-balance kernel uses:
+
+  * single-CTA-per-row :class:`GvrTopKKernel` (``cluster_size=1``)
+  * hybrid :class:`GvrTopKLBKernel` — short rows take the single-CTA branch,
+    long rows (``seq_len > long_threshold``) take the cluster leader-only
+    rank-scatter branch.
+
+Both must return the exact top-K. Correctness is checked with a per-row,
+tie-aware set/value comparison against a masked ``torch.topk`` reference: the
+selected indices must be in range, unique, exactly ``top_k`` of them, and the
+multiset of selected values must equal the true top-K values (so boundary ties
+are accepted regardless of which tied index a kernel picks).
+
+These are pure cuTe DSL kernels; the test only needs a Blackwell GPU
+(sm_100/sm_103) and ``cutlass`` — no engine build or model weights.
+"""
+
+import pytest
+import torch
+
+cutlass = pytest.importorskip("cutlass")
+import cutlass.cute as cute  # noqa: E402
+
+from tensorrt_llm._utils import get_sm_version  # noqa: E402
+
+# Importing the kernels triggers no heavy init beyond cuTe DSL itself.
+from tensorrt_llm._torch.cute_dsl_kernels.blackwell.top_k.gvr_topk_decode import (  # noqa: E402
+    GvrTopKKernel, )
+from tensorrt_llm._torch.cute_dsl_kernels.blackwell.top_k.gvr_topk_decode_load_balance import (  # noqa: E402
+    GvrTopKLBKernel, GvrTopKLBPrepareKernel)
+
+pytestmark = [
+    pytest.mark.skipif(not torch.cuda.is_available(),
+                       reason="requires a CUDA device"),
+    pytest.mark.skipif(get_sm_version() < 100,
+                       reason="GVR cuTe DSL Top-K targets Blackwell (sm_100+)"),
+]
+
+_DTYPE_TORCH_TO_CUTE = {
+    torch.float32: cutlass.Float32,
+    torch.bfloat16: cutlass.BFloat16,
+    torch.float16: cutlass.Float16,
+}
+
+# LB prepare classifies rows with (seq_len / compress_ratio) > long_threshold
+# as "long" (cluster branch). 64K matches the production default.
+_LONG_THRESHOLD = 64 * 1024
+
+
+# ---------------------------------------------------------------------------
+# Input builder + tie-aware reference (mirrors the PR #15304 driver helper).
+# ---------------------------------------------------------------------------
+def _make_varlen_inputs(seq_lens_host, top_k, dtype, seed=42, compress_ratio=1):
+    """Build (logits, pre_idx, seq_lens) for a variable-length, next_n=1 batch."""
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    num_rows = len(seq_lens_host)
+    seq_lens = torch.tensor(seq_lens_host, dtype=torch.int32, device="cuda")
+    n_raw = int(max(seq_lens_host)) // compress_ratio
+    # Pad widest row to a multiple of 16 elems so every row start is aligned
+    # for vectorized loads; columns past a row's N_eff are never scanned.
+    n_cols = ((n_raw + 15) // 16) * 16
+    logits = (torch.randn(num_rows, n_cols, dtype=torch.float32, device="cuda")
+              * 2.0).to(dtype)
+    # pre_idx is the temporal hint (prev-step top-K); seed[:,0] with the argmax
+    # and fill the rest with a cheap ramp — GVR uses it only to seed Phase-2.
+    argmax_idx = logits.argmax(dim=-1).int()
+    pre_idx = torch.zeros(num_rows, top_k, dtype=torch.int32, device="cuda")
+    pre_idx[:, 0] = argmax_idx
+    for j in range(1, top_k):
+        pre_idx[:, j] = j
+    return logits, pre_idx, seq_lens
+
+
+def _assert_tie_aware_correct(kernel_idxs, logits, seq_lens, top_k,
+                              compress_ratio=1):
+    logits_f32 = logits.to(torch.float32)
+    seq_lens_host = seq_lens.cpu().tolist()
+    for row in range(kernel_idxs.shape[0]):
+        actual_kv_len = int(seq_lens_host[row])
+        n_eff = actual_kv_len // compress_ratio
+        if n_eff < top_k:
+            continue
+        row_logits = logits_f32[row, :n_eff]
+        topk_vals, _ = torch.topk(row_logits, k=top_k, largest=True, sorted=True)
+        kth_value = topk_vals[-1].item()
+        sel = [int(i) for i in kernel_idxs[row].cpu().tolist() if i >= 0]
+        assert all(i < n_eff for i in sel), f"row {row}: out-of-range index"
+        assert len(set(sel)) == len(sel), f"row {row}: duplicate indices"
+        assert len(sel) == top_k, f"row {row}: got {len(sel)} != {top_k} indices"
+        sel_vals = row_logits[torch.tensor(sel, device=logits.device,
+                                           dtype=torch.long)]
+        assert int((sel_vals < kth_value).sum().item()) == 0, (
+            f"row {row}: a selected value is below the Kth-rank value")
+        sel_sorted, _ = sel_vals.sort(descending=True)
+        assert torch.allclose(sel_sorted, topk_vals, rtol=1e-5, atol=1e-5), (
+            f"row {row}: selected value multiset != true top-K")
+
+
+# ---------------------------------------------------------------------------
+# Single-CTA path (cluster_size=1).
+# ---------------------------------------------------------------------------
+def _run_single_cta(logits, pre_idx, seq_lens, top_k, rank_scatter, exact):
+    cute_dtype = _DTYPE_TORCH_TO_CUTE[logits.dtype]
+    num_rows = logits.shape[0]
+    out_indices = torch.empty((num_rows, top_k), dtype=torch.int32,
+                              device=logits.device)
+    kernel = GvrTopKKernel(
+        dtype=cute_dtype, top_k=top_k, next_n=1, num_threads=512,
+        use_256bit_load=False, compress_ratio=1, return_output_values=False,
+        cluster_size=1,
+        enable_p4_rank_scatter=rank_scatter,
+        enable_p4_rank_scatter_exact=exact,
+    )
+    n_rows_s, n_cols_s = cute.sym_int(), cute.sym_int()
+    fl = cute.runtime.make_fake_compact_tensor(
+        cute_dtype, (n_rows_s, n_cols_s), stride_order=(1, 0), assumed_align=16)
+    fp = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32, (cute.sym_int(), top_k), stride_order=(1, 0), assumed_align=16)
+    fs = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32, (cute.sym_int(),), stride_order=(0,))
+    fo = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32, (cute.sym_int(), top_k), stride_order=(1, 0), assumed_align=16)
+    st = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+    compiled = cute.compile(kernel, fl, fp, fs, None, fo, None, stream=st,
+                            options="--enable-tvm-ffi")
+    compiled(logits, pre_idx, seq_lens, None, out_indices, None)
+    torch.cuda.synchronize()
+    return out_indices
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("top_k", [512, 1024, 2048])
+def test_single_cta_rank_scatter_exact(dtype, top_k):
+    """op#7: single-CTA-per-row GVR with exact rank-scatter P4 is exact."""
+    n = 16384
+    logits, pre_idx, seq_lens = _make_varlen_inputs([n], top_k, dtype, seed=42)
+    out = _run_single_cta(logits, pre_idx, seq_lens, top_k,
+                          rank_scatter=True, exact=True)
+    _assert_tie_aware_correct(out, logits, seq_lens, top_k)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_single_cta_rank_scatter_matches_snap_baseline(dtype):
+    """rank-scatter and the default histogram-snap P4 must both be exact and
+    agree on the selected value set (algorithm cross-check)."""
+    top_k, n = 512, 8192
+    logits, pre_idx, seq_lens = _make_varlen_inputs([n], top_k, dtype, seed=7)
+    out_snap = _run_single_cta(logits, pre_idx, seq_lens, top_k,
+                               rank_scatter=False, exact=False)
+    out_rs = _run_single_cta(logits, pre_idx, seq_lens, top_k,
+                             rank_scatter=True, exact=True)
+    _assert_tie_aware_correct(out_snap, logits, seq_lens, top_k)
+    _assert_tie_aware_correct(out_rs, logits, seq_lens, top_k)
+
+
+# ---------------------------------------------------------------------------
+# Hybrid load-balance path (op#8 cluster leader + op#7 short branch).
+# ---------------------------------------------------------------------------
+def _run_lb(logits, pre_idx, seq_lens, top_k, cluster_size, rank_scatter, exact,
+            max_batch_size=64):
+    cute_dtype = _DTYPE_TORCH_TO_CUTE[logits.dtype]
+    num_rows, n_cols = logits.shape
+    device = logits.device
+
+    prep = GvrTopKLBPrepareKernel(long_threshold=_LONG_THRESHOLD,
+                                  num_threads=max_batch_size)
+    fs = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (num_rows,),
+                                               stride_order=(0,))
+    fr = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (max_batch_size,),
+                                               stride_order=(0,))
+    fc = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (2,), stride_order=(0,))
+    st = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+    prep_compiled = cute.compile(prep, fs, fr, fc, cutlass.Int32(0), stream=st,
+                                 options="--enable-tvm-ffi")
+    order_row = torch.full((max_batch_size,), -1, dtype=torch.int32, device=device)
+    counters = torch.zeros(2, dtype=torch.int32, device=device)
+    prep_compiled(seq_lens, order_row, counters, cutlass.Int32(num_rows))
+
+    kernel = GvrTopKLBKernel(
+        dtype=cute_dtype, top_k=top_k, next_n=1, num_threads=512,
+        compress_ratio=1, return_output_values=False, cluster_size=cluster_size,
+        max_batch_size=max_batch_size,
+        enable_p4_rank_scatter=rank_scatter,
+        enable_p4_rank_scatter_exact=exact,
+    )
+    fl = cute.runtime.make_fake_compact_tensor(
+        cute_dtype, (num_rows, n_cols), stride_order=(1, 0), assumed_align=16)
+    fp = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32, (num_rows, top_k), stride_order=(1, 0), assumed_align=16)
+    fs2 = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (num_rows,),
+                                                stride_order=(0,))
+    fo = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32, (num_rows, top_k), stride_order=(1, 0), assumed_align=16)
+    fr2 = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (max_batch_size,),
+                                                stride_order=(0,))
+    fc2 = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (2,), stride_order=(0,))
+    main_compiled = cute.compile(kernel, fl, fp, fs2, None, fo, fr2, fc2, stream=st,
+                                 options="--enable-tvm-ffi")
+    out_indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
+    main_compiled(logits, pre_idx, seq_lens, None, out_indices, order_row, counters)
+    torch.cuda.synchronize()
+    return out_indices, counters
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+def test_lb_hybrid_rank_scatter_exact(dtype):
+    """op#8 + op#7: hybrid load-balance kernel with exact rank-scatter P4 is
+    exact across both the long (cluster) and short (single-CTA) branches."""
+    top_k = 512
+    # one long row (>64K -> cluster branch) + two short rows (single-CTA branch)
+    seq_lens_host = [80000, 4096, 8192]
+    logits, pre_idx, seq_lens = _make_varlen_inputs(seq_lens_host, top_k, dtype,
+                                                    seed=123)
+    out, counters = _run_lb(logits, pre_idx, seq_lens, top_k, cluster_size=4,
+                            rank_scatter=True, exact=True)
+    # prepare must have classified exactly 1 long + 2 short (both branches live)
+    assert counters.cpu().tolist() == [1, 2]
+    _assert_tie_aware_correct(out, logits, seq_lens, top_k)

--- a/tests/unittest/_torch/test_gvr_topk_rank_scatter.py
+++ b/tests/unittest/_torch/test_gvr_topk_rank_scatter.py
@@ -37,19 +37,21 @@ import torch
 cutlass = pytest.importorskip("cutlass")
 import cutlass.cute as cute  # noqa: E402
 
-from tensorrt_llm._utils import get_sm_version  # noqa: E402
-
 # Importing the kernels triggers no heavy init beyond cuTe DSL itself.
 from tensorrt_llm._torch.cute_dsl_kernels.blackwell.top_k.gvr_topk_decode import (  # noqa: E402
-    GvrTopKKernel, )
+    GvrTopKKernel,
+)
 from tensorrt_llm._torch.cute_dsl_kernels.blackwell.top_k.gvr_topk_decode_load_balance import (  # noqa: E402
-    GvrTopKLBKernel, GvrTopKLBPrepareKernel)
+    GvrTopKLBKernel,
+    GvrTopKLBPrepareKernel,
+)
+from tensorrt_llm._utils import get_sm_version  # noqa: E402
 
 pytestmark = [
-    pytest.mark.skipif(not torch.cuda.is_available(),
-                       reason="requires a CUDA device"),
-    pytest.mark.skipif(get_sm_version() < 100,
-                       reason="GVR cuTe DSL Top-K targets Blackwell (sm_100+)"),
+    pytest.mark.skipif(not torch.cuda.is_available(), reason="requires a CUDA device"),
+    pytest.mark.skipif(
+        get_sm_version() < 100, reason="GVR cuTe DSL Top-K targets Blackwell (sm_100+)"
+    ),
 ]
 
 _DTYPE_TORCH_TO_CUTE = {
@@ -76,8 +78,7 @@ def _make_varlen_inputs(seq_lens_host, top_k, dtype, seed=42, compress_ratio=1):
     # Pad widest row to a multiple of 16 elems so every row start is aligned
     # for vectorized loads; columns past a row's N_eff are never scanned.
     n_cols = ((n_raw + 15) // 16) * 16
-    logits = (torch.randn(num_rows, n_cols, dtype=torch.float32, device="cuda")
-              * 2.0).to(dtype)
+    logits = (torch.randn(num_rows, n_cols, dtype=torch.float32, device="cuda") * 2.0).to(dtype)
     # pre_idx is the temporal hint (prev-step top-K); seed[:,0] with the argmax
     # and fill the rest with a cheap ramp — GVR uses it only to seed Phase-2.
     argmax_idx = logits.argmax(dim=-1).int()
@@ -88,8 +89,7 @@ def _make_varlen_inputs(seq_lens_host, top_k, dtype, seed=42, compress_ratio=1):
     return logits, pre_idx, seq_lens
 
 
-def _assert_tie_aware_correct(kernel_idxs, logits, seq_lens, top_k,
-                              compress_ratio=1):
+def _assert_tie_aware_correct(kernel_idxs, logits, seq_lens, top_k, compress_ratio=1):
     logits_f32 = logits.to(torch.float32)
     seq_lens_host = seq_lens.cpu().tolist()
     for row in range(kernel_idxs.shape[0]):
@@ -104,13 +104,14 @@ def _assert_tie_aware_correct(kernel_idxs, logits, seq_lens, top_k,
         assert all(i < n_eff for i in sel), f"row {row}: out-of-range index"
         assert len(set(sel)) == len(sel), f"row {row}: duplicate indices"
         assert len(sel) == top_k, f"row {row}: got {len(sel)} != {top_k} indices"
-        sel_vals = row_logits[torch.tensor(sel, device=logits.device,
-                                           dtype=torch.long)]
+        sel_vals = row_logits[torch.tensor(sel, device=logits.device, dtype=torch.long)]
         assert int((sel_vals < kth_value).sum().item()) == 0, (
-            f"row {row}: a selected value is below the Kth-rank value")
+            f"row {row}: a selected value is below the Kth-rank value"
+        )
         sel_sorted, _ = sel_vals.sort(descending=True)
         assert torch.allclose(sel_sorted, topk_vals, rtol=1e-5, atol=1e-5), (
-            f"row {row}: selected value multiset != true top-K")
+            f"row {row}: selected value multiset != true top-K"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -119,27 +120,34 @@ def _assert_tie_aware_correct(kernel_idxs, logits, seq_lens, top_k,
 def _run_single_cta(logits, pre_idx, seq_lens, top_k, rank_scatter, exact):
     cute_dtype = _DTYPE_TORCH_TO_CUTE[logits.dtype]
     num_rows = logits.shape[0]
-    out_indices = torch.empty((num_rows, top_k), dtype=torch.int32,
-                              device=logits.device)
+    out_indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=logits.device)
     kernel = GvrTopKKernel(
-        dtype=cute_dtype, top_k=top_k, next_n=1, num_threads=512,
-        use_256bit_load=False, compress_ratio=1, return_output_values=False,
+        dtype=cute_dtype,
+        top_k=top_k,
+        next_n=1,
+        num_threads=512,
+        use_256bit_load=False,
+        compress_ratio=1,
+        return_output_values=False,
         cluster_size=1,
         enable_p4_rank_scatter=rank_scatter,
         enable_p4_rank_scatter_exact=exact,
     )
     n_rows_s, n_cols_s = cute.sym_int(), cute.sym_int()
     fl = cute.runtime.make_fake_compact_tensor(
-        cute_dtype, (n_rows_s, n_cols_s), stride_order=(1, 0), assumed_align=16)
+        cute_dtype, (n_rows_s, n_cols_s), stride_order=(1, 0), assumed_align=16
+    )
     fp = cute.runtime.make_fake_compact_tensor(
-        cutlass.Int32, (cute.sym_int(), top_k), stride_order=(1, 0), assumed_align=16)
-    fs = cute.runtime.make_fake_compact_tensor(
-        cutlass.Int32, (cute.sym_int(),), stride_order=(0,))
-    fo = cute.runtime.make_fake_compact_tensor(
-        cutlass.Int32, (cute.sym_int(), top_k), stride_order=(1, 0), assumed_align=16)
+        cutlass.Int32, (cute.sym_int(), top_k), stride_order=(1, 0), assumed_align=16
+    )
+    fs = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (cute.sym_int(),), stride_order=(0,))
+    fout = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32, (cute.sym_int(), top_k), stride_order=(1, 0), assumed_align=16
+    )
     st = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
-    compiled = cute.compile(kernel, fl, fp, fs, None, fo, None, stream=st,
-                            options="--enable-tvm-ffi")
+    compiled = cute.compile(
+        kernel, fl, fp, fs, None, fout, None, stream=st, options="--enable-tvm-ffi"
+    )
     compiled(logits, pre_idx, seq_lens, None, out_indices, None)
     torch.cuda.synchronize()
     return out_indices
@@ -151,8 +159,7 @@ def test_single_cta_rank_scatter_exact(dtype, top_k):
     """op#7: single-CTA-per-row GVR with exact rank-scatter P4 is exact."""
     n = 16384
     logits, pre_idx, seq_lens = _make_varlen_inputs([n], top_k, dtype, seed=42)
-    out = _run_single_cta(logits, pre_idx, seq_lens, top_k,
-                          rank_scatter=True, exact=True)
+    out = _run_single_cta(logits, pre_idx, seq_lens, top_k, rank_scatter=True, exact=True)
     _assert_tie_aware_correct(out, logits, seq_lens, top_k)
 
 
@@ -162,10 +169,8 @@ def test_single_cta_rank_scatter_matches_snap_baseline(dtype):
     agree on the selected value set (algorithm cross-check)."""
     top_k, n = 512, 8192
     logits, pre_idx, seq_lens = _make_varlen_inputs([n], top_k, dtype, seed=7)
-    out_snap = _run_single_cta(logits, pre_idx, seq_lens, top_k,
-                               rank_scatter=False, exact=False)
-    out_rs = _run_single_cta(logits, pre_idx, seq_lens, top_k,
-                             rank_scatter=True, exact=True)
+    out_snap = _run_single_cta(logits, pre_idx, seq_lens, top_k, rank_scatter=False, exact=False)
+    out_rs = _run_single_cta(logits, pre_idx, seq_lens, top_k, rank_scatter=True, exact=True)
     _assert_tie_aware_correct(out_snap, logits, seq_lens, top_k)
     _assert_tie_aware_correct(out_rs, logits, seq_lens, top_k)
 
@@ -173,46 +178,50 @@ def test_single_cta_rank_scatter_matches_snap_baseline(dtype):
 # ---------------------------------------------------------------------------
 # Hybrid load-balance path (op#8 cluster leader + op#7 short branch).
 # ---------------------------------------------------------------------------
-def _run_lb(logits, pre_idx, seq_lens, top_k, cluster_size, rank_scatter, exact,
-            max_batch_size=64):
+def _run_lb(logits, pre_idx, seq_lens, top_k, cluster_size, rank_scatter, exact, max_batch_size=64):
     cute_dtype = _DTYPE_TORCH_TO_CUTE[logits.dtype]
     num_rows, n_cols = logits.shape
     device = logits.device
 
-    prep = GvrTopKLBPrepareKernel(long_threshold=_LONG_THRESHOLD,
-                                  num_threads=max_batch_size)
-    fs = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (num_rows,),
-                                               stride_order=(0,))
-    fr = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (max_batch_size,),
-                                               stride_order=(0,))
+    prep = GvrTopKLBPrepareKernel(long_threshold=_LONG_THRESHOLD, num_threads=max_batch_size)
+    fs = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (num_rows,), stride_order=(0,))
+    fr = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (max_batch_size,), stride_order=(0,))
     fc = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (2,), stride_order=(0,))
     st = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
-    prep_compiled = cute.compile(prep, fs, fr, fc, cutlass.Int32(0), stream=st,
-                                 options="--enable-tvm-ffi")
+    prep_compiled = cute.compile(
+        prep, fs, fr, fc, cutlass.Int32(0), stream=st, options="--enable-tvm-ffi"
+    )
     order_row = torch.full((max_batch_size,), -1, dtype=torch.int32, device=device)
     counters = torch.zeros(2, dtype=torch.int32, device=device)
     prep_compiled(seq_lens, order_row, counters, cutlass.Int32(num_rows))
 
     kernel = GvrTopKLBKernel(
-        dtype=cute_dtype, top_k=top_k, next_n=1, num_threads=512,
-        compress_ratio=1, return_output_values=False, cluster_size=cluster_size,
+        dtype=cute_dtype,
+        top_k=top_k,
+        next_n=1,
+        num_threads=512,
+        compress_ratio=1,
+        return_output_values=False,
+        cluster_size=cluster_size,
         max_batch_size=max_batch_size,
         enable_p4_rank_scatter=rank_scatter,
         enable_p4_rank_scatter_exact=exact,
     )
     fl = cute.runtime.make_fake_compact_tensor(
-        cute_dtype, (num_rows, n_cols), stride_order=(1, 0), assumed_align=16)
+        cute_dtype, (num_rows, n_cols), stride_order=(1, 0), assumed_align=16
+    )
     fp = cute.runtime.make_fake_compact_tensor(
-        cutlass.Int32, (num_rows, top_k), stride_order=(1, 0), assumed_align=16)
-    fs2 = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (num_rows,),
-                                                stride_order=(0,))
-    fo = cute.runtime.make_fake_compact_tensor(
-        cutlass.Int32, (num_rows, top_k), stride_order=(1, 0), assumed_align=16)
-    fr2 = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (max_batch_size,),
-                                                stride_order=(0,))
+        cutlass.Int32, (num_rows, top_k), stride_order=(1, 0), assumed_align=16
+    )
+    fs2 = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (num_rows,), stride_order=(0,))
+    fout = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32, (num_rows, top_k), stride_order=(1, 0), assumed_align=16
+    )
+    fr2 = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (max_batch_size,), stride_order=(0,))
     fc2 = cute.runtime.make_fake_compact_tensor(cutlass.Int32, (2,), stride_order=(0,))
-    main_compiled = cute.compile(kernel, fl, fp, fs2, None, fo, fr2, fc2, stream=st,
-                                 options="--enable-tvm-ffi")
+    main_compiled = cute.compile(
+        kernel, fl, fp, fs2, None, fout, fr2, fc2, stream=st, options="--enable-tvm-ffi"
+    )
     out_indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
     main_compiled(logits, pre_idx, seq_lens, None, out_indices, order_row, counters)
     torch.cuda.synchronize()
@@ -226,10 +235,10 @@ def test_lb_hybrid_rank_scatter_exact(dtype):
     top_k = 512
     # one long row (>64K -> cluster branch) + two short rows (single-CTA branch)
     seq_lens_host = [80000, 4096, 8192]
-    logits, pre_idx, seq_lens = _make_varlen_inputs(seq_lens_host, top_k, dtype,
-                                                    seed=123)
-    out, counters = _run_lb(logits, pre_idx, seq_lens, top_k, cluster_size=4,
-                            rank_scatter=True, exact=True)
+    logits, pre_idx, seq_lens = _make_varlen_inputs(seq_lens_host, top_k, dtype, seed=123)
+    out, counters = _run_lb(
+        logits, pre_idx, seq_lens, top_k, cluster_size=4, rank_scatter=True, exact=True
+    )
     # prepare must have classified exactly 1 long + 2 short (both branches live)
     assert counters.cpu().tolist() == [1, 2]
     _assert_tie_aware_correct(out, logits, seq_lens, top_k)


### PR DESCRIPTION
## Summary

## Update (rev 2)

Two follow-up commits since initial submission:

1. **Default flipped to exact rank-scatter.** `enable_p4_rank_scatter` and `enable_p4_rank_scatter_exact` now default **True** in both `GvrTopKKernel` and `GvrTopKLBKernel`. Exact rank-scatter is a drop-in for the snap Phase-4 (both exact, vdiff=0) and the faster path, so it is now the default. The `cute_dsl_custom_ops` construction sites do not pass these flags, so **the production decode path now uses exact rank-scatter for Phase-4** (i.e. this PR is no longer kernel-only — the framework default is switched here). Pass `enable_p4_rank_scatter_exact=False` to opt back to the cheaper approximate-tie variant, or `enable_p4_rank_scatter=False` for the original snap.

2. **Correctness fix in the exact fine-search** (flagged by CodeRabbit). The fine-recursion staged its prefix/target-warp metadata in `smem_hist[0]`/`[1]`, which are real fine-histogram bins; when the straddling value lands in the lowest fine warp (`twf2 == num_warps-1`) the reverse scan reads that metadata back as counts and returns the wrong top-K set. Fixed by staging the two scalars in spare `s_iscalars[4]`/`[1]` (outside the fine-histogram range, dead in that window). Pure scratch relocation, no extra barriers, no perf impact.

The published nsys cold-L2 ratios were re-confirmed on a fresh B200 host after both commits (same seed=42 inputs, same methodology): K=2048 fp32 N=8K-256K measured 1.013-1.148 (report 1.017-1.163); K=1024 fp16 N=16K peak 1.328 (report 1.313); K=512 fp32 N=16K peak 1.321 (report 1.469). All spot-checked cells reproduce rank-scatter >= snap.

---


Adds an **opt-in Phase-4 (snap) replacement** to the cuTe DSL GVR Top-K decode kernels — a fused **rank-and-scatter** — to both the single-CTA-per-row path (`GvrTopKKernel`) and the hybrid multi-CTA load-balance path (`GvrTopKLBKernel`, the kernel introduced for long-context decode). It mainly improves single-CTA and multi-CTA GVR at **small/medium sequence lengths**, where Phase-4 is the dominant phase.

Both flags now default **on** (exact rank-scatter); see the Update section above. Pass `enable_p4_rank_scatter=False` to restore the original snap Phase-4.

As of rev 2 this PR flips the framework default (the production decode path now uses exact rank-scatter, see Update above). There is still no DeepSeek-V3.2/V4-specific end-to-end wiring beyond the default switch; model-level enablement/validation lands in a follow-up PR.

## What changes

`GvrTopKKernel.phase4_rank_scatter` (new), gated by two constructor flags:

| flag | effect |
|---|---|
| `enable_p4_rank_scatter` | dispatch rank-scatter instead of the iterative histogram-snap |
| `enable_p4_rank_scatter_exact` | add a fixed-256-bin fine recursion on the straddling bin for an exact tie-break |

The default Phase-4 (`phase4_histogram_snap`) finds the K-th value by an iterative histogram bracket + a 2-pass writeback (~14 block barriers). The rank-scatter path instead:

1. builds **one** coarse `kNumBins` histogram over the candidate values,
2. does a 3-step high→low bin search to the straddling bin `b*` and the rank of everything strictly above it (`rank_above`),
3. *(exact only)* runs one fixed **256**-sub-bin fine-histogram recursion on `b*` (256 ≤ `kNumBins` for every supported dtype/K, so it reuses the existing `smem_hist` allocation),
4. scatters each survivor directly to its output rank in a single pass.

Net: the Phase-4 barrier count drops from **~14 → ~7**, exact (vdiff=0) on the realistic temporally-coherent indexer distribution.

Because `GvrTopKKernel.run_one_row` is shared by the single-CTA path and the cluster *leader-only* Phase-4 path, the lever applies to **both** GVR branches (single-CTA and multi-CTA cluster). After the DSMEM gather the candidate set is fully resident in the leader CTA's SMEM, so the cluster Phase-4 is structurally identical to the single-CTA case. `GvrTopKLBKernel` forwards the two flags to both its underlying instances (`_cluster_kernel` for long rows, `_single_kernel` for short rows).

## Why this helps (and where)

GVR's Phase-4 share of kernel time is largest at small/medium N — it operates only on the ~3×K SMEM candidate set (N-independent), so as N shrinks it dominates (≈42–55% of the kernel at N ≤ 16K, falling to ≈15–20% at N ≥ 128K where the full-N Phase-2/3 scans dominate). Cutting the Phase-4 barrier count therefore yields the biggest relative gain exactly in the small/medium-N decode regime, and the gain is **dtype- and K-dependent** (fp32/fp16 and larger K benefit most; bf16 least, because its half-precision ties collapse the snap into few histogram buckets so the baseline is already cheap).

## Performance — single-CTA rank-scatter vs the snap baseline (same kernel, only Phase-4 swapped)

Metric: **nsys pure-kernel GPU time, cold-L2** (512 MB-flush, CUDA-graph replay, per-cell NVTX range) — the canonical metric from the op-bench's full 11-op nsys re-test. Ratios are **rank-scatter speedup over snap** = `t(snap) / t(rank-scatter)` (>1 = rank-scatter faster). Synthetic inputs reproduce real DeepSeek-V4 indexer statistics (temporally-coherent, preIdx hit-rate 0.6). B200 and B300 use byte-identical inputs, so the comparison is pure hardware.

### B300 (sm_103)

**(A.1) BS=1, by seq-len, per (dtype, K):**

| dtype | K | N=4K | N=8K | N=16K | N=32K | N=64K | N=128K | N=256K |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| fp32 | 512  | 1.110 | 1.138 | 1.481 | 1.127 | 1.052 | 1.014 | 1.058 |
| fp32 | 1024 | 1.099 | 1.214 | 1.077 | 1.277 | 1.240 | 1.054 | 1.131 |
| fp32 | 2048 |   –   | 1.124 | 1.078 | 1.149 | 1.163 | 1.137 | 1.015 |
| bf16 | 512  | 1.042 | 1.117 | 1.066 | 1.073 | 1.003 | 1.007 | 1.028 |
| bf16 | 1024 | 1.039 | 1.144 | 1.245 | 1.050 | 1.068 | 1.053 | 1.014 |
| bf16 | 2048 |   –   | 1.076 | 1.091 | 1.085 | 1.059 | 1.017 | 1.004 |
| fp16 | 512  | 1.044 | 1.089 | 1.140 | 1.237 | 1.104 | 1.066 | 1.066 |
| fp16 | 1024 | 1.161 | 1.147 | 1.321 | 1.195 | 1.142 | 1.010 | 1.049 |
| fp16 | 2048 |   –   | 1.172 | 1.125 | 1.115 | 1.151 | 1.062 | 1.029 |

**(A.2) BS-scaling, per (dtype, K)** (median across N — isolates the BS axis):

| dtype | K | BS=1 | BS=2 | BS=4 | BS=8 | BS=16 | BS=32 | BS=64 | BS=128 | BS=256 | BS=512 | BS=1024 | BS=2048 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| fp32 | 512  | 1.117 | 1.121 | 1.113 | 1.114 | 1.117 | 1.123 | 1.119 | 1.108 | 1.080 | 1.075 | 1.068 | 1.077 |
| fp32 | 1024 | 1.124 | 1.128 | 1.128 | 1.126 | 1.125 | 1.120 | 1.121 | 1.096 | 1.101 | 1.050 | 1.060 | 1.054 |
| fp32 | 2048 | 1.131 | 1.141 | 1.136 | 1.132 | 1.139 | 1.135 | 1.124 | 1.106 | 1.069 | 1.056 | 1.056 | 1.041 |
| bf16 | 512  | 1.052 | 1.045 | 1.046 | 1.044 | 1.047 | 1.038 | 1.050 | 1.039 | 1.044 | 1.042 | 1.059 | 1.062 |
| bf16 | 1024 | 1.055 | 1.052 | 1.053 | 1.057 | 1.053 | 1.053 | 1.051 | 1.049 | 1.047 | 1.038 | 1.037 | 1.064 |
| bf16 | 2048 | 1.070 | 1.068 | 1.070 | 1.064 | 1.067 | 1.067 | 1.066 | 1.062 | 1.044 | 1.056 | 1.063 | 1.054 |
| fp16 | 512  | 1.092 | 1.083 | 1.089 | 1.087 | 1.083 | 1.090 | 1.075 | 1.087 | 1.062 | 1.058 | 1.074 | 1.074 |
| fp16 | 1024 | 1.159 | 1.144 | 1.145 | 1.145 | 1.143 | 1.148 | 1.146 | 1.147 | 1.171 | 1.186 | 1.185 | 1.190 |
| fp16 | 2048 | 1.121 | 1.118 | 1.116 | 1.125 | 1.118 | 1.115 | 1.116 | 1.106 | 1.099 | 1.115 | 1.122 | 1.126 |

**Overall B300: median 1.077×, 704/720 cells faster.**

### B200 (sm_100) — essentially identical (hardware-invariant)

**(B.1) BS=1, by seq-len, per (dtype, K):**

| dtype | K | N=4K | N=8K | N=16K | N=32K | N=64K | N=128K | N=256K |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| fp32 | 512  | 1.110 | 1.126 | 1.469 | 1.126 | 1.049 | 1.015 | 1.065 |
| fp32 | 1024 | 1.085 | 1.208 | 1.074 | 1.275 | 1.234 | 1.052 | 1.130 |
| fp32 | 2048 |   –   | 1.132 | 1.071 | 1.090 | 1.163 | 1.135 | 1.017 |
| bf16 | 512  | 1.048 | 1.116 | 1.069 | 1.085 | 1.004 | 1.007 | 1.031 |
| bf16 | 1024 | 1.038 | 1.146 | 1.239 | 1.048 | 1.065 | 1.051 | 1.015 |
| bf16 | 2048 |   –   | 1.078 | 1.084 | 1.086 | 1.056 | 1.014 | 1.005 |
| fp16 | 512  | 1.035 | 1.084 | 1.141 | 1.236 | 1.100 | 1.065 | 1.073 |
| fp16 | 1024 | 1.159 | 1.151 | 1.313 | 1.192 | 1.138 | 1.010 | 1.050 |
| fp16 | 2048 |   –   | 1.174 | 1.126 | 1.110 | 1.144 | 1.062 | 1.026 |

**(B.2) BS-scaling, per (dtype, K)** (median across N):

| dtype | K | BS=1 | BS=2 | BS=4 | BS=8 | BS=16 | BS=32 | BS=64 | BS=128 | BS=256 | BS=512 | BS=1024 | BS=2048 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| fp32 | 512  | 1.114 | 1.113 | 1.118 | 1.125 | 1.124 | 1.114 | 1.109 | 1.104 | 1.079 | 1.078 | 1.074 | 1.080 |
| fp32 | 1024 | 1.129 | 1.127 | 1.127 | 1.122 | 1.124 | 1.121 | 1.123 | 1.092 | 1.100 | 1.061 | 1.071 | 1.051 |
| fp32 | 2048 | 1.112 | 1.119 | 1.124 | 1.114 | 1.114 | 1.113 | 1.104 | 1.093 | 1.068 | 1.062 | 1.053 | 1.043 |
| bf16 | 512  | 1.045 | 1.045 | 1.046 | 1.055 | 1.044 | 1.043 | 1.049 | 1.049 | 1.054 | 1.043 | 1.059 | 1.063 |
| bf16 | 1024 | 1.054 | 1.052 | 1.052 | 1.054 | 1.055 | 1.052 | 1.049 | 1.048 | 1.044 | 1.035 | 1.036 | 1.060 |
| bf16 | 2048 | 1.067 | 1.067 | 1.069 | 1.065 | 1.070 | 1.067 | 1.066 | 1.065 | 1.046 | 1.058 | 1.062 | 1.053 |
| fp16 | 512  | 1.080 | 1.085 | 1.090 | 1.093 | 1.088 | 1.094 | 1.079 | 1.088 | 1.066 | 1.059 | 1.114 | 1.072 |
| fp16 | 1024 | 1.144 | 1.154 | 1.154 | 1.153 | 1.149 | 1.152 | 1.147 | 1.149 | 1.164 | 1.172 | 1.185 | 1.192 |
| fp16 | 2048 | 1.117 | 1.119 | 1.117 | 1.119 | 1.118 | 1.116 | 1.116 | 1.110 | 1.102 | 1.113 | 1.121 | 1.124 |

**Overall B200: median 1.078×, 707/720 cells faster.**

**Takeaways:**
- **Hardware-invariant.** B200 and B300 ratios match cell-for-cell (overall 1.078× vs 1.077×), so no per-SKU re-tuning — the rank-scatter win reproduces identically on sm_100 and sm_103.
- **BS-invariant.** Flat ~1.04–1.19× from BS=1 to BS=2048 across every (dtype, K): the Phase-4 barrier saving is per-row, independent of how many rows fill the GPU.
- **dtype/K/N shape.** Peaks in the medium-N band (8K–32K, single-row hot spot at N=16K) and for K≥1024 / fp16·fp32; bf16 gains least but stays ≥1.0; never regresses materially (worst cells ≈ 0.996×, all at BS=1).

## Performance — cluster + rank-scatter vs the multi-CTA cluster (PR #15198)

The two levers are orthogonal: multi-CTA-per-row (PR #15198) closes the SM-count axis on the full-N Phase-2/3 scans; rank-scatter cuts the leader's Phase-4. Stacked (synthetic grid, nsys cold-L2, full K×dtype×N×BS):

| comparison | B300 | B200 |
|---|:--:|:--:|
| op8 (cluster + rank-scatter) vs GVR multi-CTA cluster (PR #15198) | **1.090×** (703/720) | **1.088×** (701/720) |
| op8 vs single-CTA snap baseline | 1.138× (652/720) | 1.132× (650/720) |

On real DeepSeek-V3.2 K=2048 decode (N≈70.7K, B300) this is corroborated by a dedicated nsys run: op8 **16.88 µs/call** vs cluster **18.80** (1.114×) vs single-CTA snap **21.60** (1.28×), reaching parity with the fastest in-tree radix-cuteDSL (16.95 µs/call) while keeping GVR's exact-with-temporal-seed property.

> All numbers are extracted from the op-bench full nsys re-test (`indexer_topk_op_bench/report/{seqlen_data,bs_data}.csv`, sourced from `results_b200_nsys` / `results_b300_nsys`), not produced by this PR's CI.

## Correctness / testing

`tests/unittest/_torch/test_gvr_topk_rank_scatter.py` (Blackwell-gated, pure cuTe DSL — no engine build / model weights):

- single-CTA rank-scatter (exact) vs masked `torch.topk`, tie-aware, across **fp32/bf16/fp16 × K∈{512,1024,2048}**;
- rank-scatter vs the default snap Phase-4 cross-check (both exact);
- hybrid `GvrTopKLBKernel` with a long+short batch so prepare classifies **1 long (cluster branch) + 2 short (single-CTA branch)** — exercising both Phase-4 paths in one launch.

All cases verified exact on B200 (sm_100); the correctness criterion is value-multiset equality, so boundary ties are accepted regardless of which tied index is selected.

## Scope

- ✅ kernel implementation (single-CTA + cluster, default exact rank-scatter as of rev 2)
- ✅ basic precision tests
- ✅ performance characterization by dtype × top-K (BS=1 seq-len + BS-scaling), nsys cold-L2 on B200 + B300
- ✅ framework default switched to exact rank-scatter (production decode path)
- ✅ correctness fix for the exact fine-search (smem scratch aliasing)
- ⬜ DeepSeek-V3.2/V4 end-to-end model-level validation — **follow-up PR**
