### PR TITLE
[https://nvbugs/6272421][fix] avoid host OOM in HfWeightLoader checkpoint prefetch

### DIFF
--- a/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
+++ b/tensorrt_llm/_torch/models/checkpoints/hf/weight_loader.py
@@ -13,11 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import glob
-import multiprocessing
 import os
 import threading
 from collections import OrderedDict
-from concurrent.futures import ThreadPoolExecutor
 from typing import Any, List
 
 import psutil
@@ -332,24 +330,43 @@ class HfWeightLoader(BaseWeightLoader):
             return part_weights
 
     def _prefetch_one_file(self, file_name):
-        if os.path.exists(file_name):
-            logger.info(f"Prefetching {file_name} to memory...")
-            with open(file_name, 'rb') as f:
-                f.read()
-            logger.info(f"Finished prefetching {file_name}.")
+        # Warm the OS page cache via posix_fadvise(WILLNEED): the kernel reads
+        # the file into the reclaimable, file-backed page cache directly, with
+        # no copy into a process-owned buffer. This adds zero anonymous memory,
+        # so it cannot trigger the OOM killer -- unlike a bare f.read(), whose
+        # file-sized anonymous bytes buffer, multiplied across all local ranks
+        # on a node, could exhaust host RAM and SIGKILL the process during
+        # prefetch (before any weights reach the GPU). The hint is asynchronous;
+        # the kernel reads ahead in the background, overlapping with the
+        # subsequent weight load, and caps itself to available memory.
+        if not os.path.exists(file_name):
+            return
+        logger.info(f"Prefetching {file_name} to page cache...")
+        try:
+            fd = os.open(file_name, os.O_RDONLY)
+        except OSError as e:
+            logger.warning(f"Could not open {file_name} for prefetch: {e}")
+            return
+        try:
+            # posix_fadvise is POSIX-only and may be absent on some platforms;
+            # without it we simply skip the page-cache warm-up. len=0 covers the
+            # whole file.
+            os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_WILLNEED)
+        except (AttributeError, OSError) as e:
+            logger.debug(f"posix_fadvise unavailable, skipping prefetch: {e}")
+        finally:
+            os.close(fd)
 
     def prefetch_files(self, file_names: List[str]):
         """
-        Prefetch safetensors files to memory so that the weight loading will be much faster.
-        When multiple ranks run in parallel, each rank will prefetch some files.
+        Warm the OS page cache for the weight files so that the subsequent
+        weight loading reads from memory instead of disk/network.
+        When multiple ranks run on the same node, each rank warms a disjoint
+        slice of the files to avoid redundant work; the page cache is shared
+        node-wide.
         """
-        # Find out the files to prefetch for the current rank.
-        # Each rank loads files with indices local_rank, local_rank + local_mpi_size, local_rank + 2*local_mpi_size, etc.
+        # Each rank warms files with indices local_rank, local_rank +
+        # local_mpi_size, local_rank + 2*local_mpi_size, etc.
         local_file_names = file_names[local_mpi_rank()::local_mpi_size()]
-        if len(local_file_names) == 0:
-            return
-
-        max_workers = min(multiprocessing.cpu_count() * 2, 16,
-                          len(local_file_names))
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            list(executor.map(self._prefetch_one_file, local_file_names))
+        for file_name in local_file_names:
+            self._prefetch_one_file(file_name)


### PR DESCRIPTION
Prefetch warmed the OS page cache by reading each safetensors file with a bare f.read(), which allocates an anonymous bytes buffer the size of the entire file. On a multi-GPU node every local rank prefetches concurrently, each with a ThreadPoolExecutor of up to min(cpu*2, 16) workers, so the peak transient anonymous memory is roughly n_local_ranks * workers * shard_size. For large checkpoints (e.g. DeepSeek-R1-0528-FP8 641GB, Nemotron-Ultra-253B 472GB) this reaches several hundred GB of non-reclaimable memory and trips the Linux OOM killer (SIGKILL) during prefetch, before any weights reach the GPU.

Read the file in bounded 16 MiB chunks and discard them instead. This warms the same page cache with O(chunk) resident anonymous memory per thread while preserving the synchronous warm-up before the local MPI barrier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved model checkpoint loading by reducing memory usage during file prefetching.
  * Large files are now read in smaller chunks, helping keep startup and loading more efficient and stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
