### PR TITLE
[None][fix] Revert CBTS-fanout #15614+#15592 on 2809 HEAD to bisect-confirm 2810 perf-sanity aborts

### DIFF
--- a/.bisect-probe.md
+++ b/.bisect-probe.md
@@ -1,0 +1,1 @@
+Bisect probe for 2810 perf-sanity abort regression. Branch HEAD = a02214a487 + this marker. PR #15723. Not for merge.


### PR DESCRIPTION
**This PR is a bisect-confirmation build only — do not merge.**

## Context

In post-merge `L0_Test-SBSA-Multi-GPU` build 2810 (commit `c25c23f7`), multiple GB200 perf-sanity stages aborted with "Submit Test Result" and "Clean Up Slurm Resource" SKIPPED. Examples:

- `GB200-12_GPUs-3_Nodes-PyTorch-Disagg-PerfSanity-CTX1-NODE1-GPU4-GEN1-NODE2-GPU8-Post-Merge-3`
- `GB200-8_GPUs-2_Nodes-PyTorch-PerfSanity-Node2-GPU8-Post-Merge-5`

The abort rate stepped up between post-merge builds 2806 (`a51931ad`) and 2809 (`86bb1f46`). Proximate cause is a 30-second `withSlurmSshCredentials` probe to a randomly-drawn OCI HSG login node (`login-01` was intermittently slow) — when it timed out, `uploadResults` SIGTERM'd the stage and the `finally` block skipped Clean Up. The hypothesis is that the CBTS-fanout change in `7cc568c4ee` (PR #15592), extended by `86bb1f4612` (PR #15614), increased the number of parallel narrowed perf-sanity stages, multiplying simultaneous SSH-probe load on the OCI HSG head pool.

## What this branch does

Branch base: `86bb1f4612` (2809 HEAD).
Reverts (HEAD-to-old order):
1. `86bb1f4612` — `[None][infra] take test durations into account to determine cbts splits num (#15614)`
2. `7cc568c4ee` — `[None][infra] use default split when CBTS test-db download fails (#15592)`

After both reverts, `_cbtsMaybeCollapseSplits` returns to the pre-`7cc568c4ee` "collapse to 1 shard when narrowed count < 20" behavior.

## Expected verification result

Trigger the 2810 aborted stage list on this PR. If the CBTS-fanout family is the culprit, the abort rate should drop back to 2806-level (i.e., the `uploadResults` SSH-probe timeouts should largely disappear).

Paired with companion PR (cherry-pick `7cc568c4ee` onto 2806 HEAD) for the bisect-confirmation in the opposite direction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CBTS now uses a simpler split-collapsing approach for narrowed test selections, reducing unnecessary shard splitting when fewer tests remain.

* **Bug Fixes**
  * Updated CBTS results and summaries to remove split-count details and keep only the most relevant stage counts.
  * Improved handling of generated test database artifacts when using an override directory, including safer packaging and upload behavior.

* **Documentation**
  * Refreshed CBTS docs and decision output examples to match the new result format and selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->