### PR TITLE
[None][fix] Cherry-pick CBTS-fanout #15592+#15614 onto 2806 HEAD to bisect-confirm 2810 perf-sanity aborts

### DIFF
--- a/.bisect-probe.md
+++ b/.bisect-probe.md
@@ -1,0 +1,1 @@
+Bisect probe for 2810 perf-sanity abort regression. Branch HEAD = 4ab9bc54c1 + this marker. PR #15724. Not for merge.


### PR DESCRIPTION
**This PR is a bisect-confirmation build only — do not merge.**

## Context

In post-merge `L0_Test-SBSA-Multi-GPU` build 2810 (commit `c25c23f7`), 26 GB200 perf-sanity stages aborted with "Submit Test Result" and "Clean Up Slurm Resource" SKIPPED. The abort rate stepped up between builds 2806 (`a51931ad`) and 2809 (`86bb1f46`). The hypothesis is that the CBTS-fanout commit pair `7cc568c4ee` (PR #15592) + `86bb1f4612` (PR #15614) is the culprit: it changed CBTS Layer 2.5 from "collapse narrowed stage to 1 shard" to "k = min(count, splits) shards" then to duration-based `k`, multiplying simultaneous SSH-probe load on OCI HSG head nodes inside `uploadResults`'s fresh `withSlurmSshCredentials` session.

## What this branch does

Branch base: `a51931ad2f` (2806 HEAD).
Cherry-picks (in merge order):
1. `7cc568c4ee` — `[None][infra] use default split when CBTS test-db download fails (#15592)`
2. `86bb1f4612` — `[None][infra] take test durations into account to determine cbts splits num (#15614)`

The branch is therefore 2806 state + the two suspected CBTS-fanout commits and nothing else from 2807/2808/2809. This isolates the pair's effect.

## Expected verification result

Trigger the 2810 aborted stage list on this PR. If the CBTS-fanout pair is the culprit, the abort symptom should appear at 2809-level rate. If aborts stay at 2806-level, the regression involves another commit in the range.

Paired with companion PR #15723 (revert the same two commits on 2809 HEAD) for the bisect-confirmation in the opposite direction.