### PR TITLE
[None][infra] Optionally redirect AutoDeploy imports to llm-c

### DIFF
--- a/examples/auto_deploy/llmc/README.md
+++ b/examples/auto_deploy/llmc/README.md
@@ -41,6 +41,20 @@ from llmc._compat import TRTLLM_AVAILABLE
 print(f"TRT-LLM available: {TRTLLM_AVAILABLE}")  # False in standalone mode
 ```
 
+### Use the TensorRT-LLM runtime
+
+TensorRT-LLM releases that still import their bundled AutoDeploy package can be redirected to use
+LLMC as the compiler implementation:
+
+```bash
+TRTLLM_REDIRECT_AD_TO_LLMC=true \
+python runners/trtllm/build_and_run_llmc_trtllm.py ...
+```
+
+The redirect is disabled by default and must be enabled before importing either LLMC or bundled
+AutoDeploy. It maps `tensorrt_llm._torch.auto_deploy.*` imports to the corresponding canonical
+`llmc.*` modules in the parent process and TensorRT-LLM MPI workers.
+
 In standalone mode the package uses the PyTorch, Triton, and FlashInfer kernel paths. TRT-LLM-only kernels (custom CUDA, optimized all-reduce, MoE fused kernels, the `pyexecutor` runtime) are skipped at registration time.
 
 ### Run the bundled tests

--- a/examples/auto_deploy/llmc/create_standalone_package.py
+++ b/examples/auto_deploy/llmc/create_standalone_package.py
@@ -207,6 +207,7 @@ EXCLUDE_TEST_FILES = {
 STANDALONE_MULTIGPU_TEST_FILES = (
     "custom_ops/test_dist.py",
     "custom_ops/test_sharded_rmsnorm.py",
+    "smoke/test_ad_build_small_multi.py",
     "transformations/library/test_apply_sharding_hints.py",
     "transformations/library/test_bmm_sharding.py",
     "transformations/library/test_ep_sharding.py",
@@ -222,6 +223,15 @@ STANDALONE_MULTIGPU_SUPPORT_FILES = ("transformations/library/conftest.py",)
 # Import path rewrite: old -> new (applied to test files only).
 _IMPORT_REWRITE = "tensorrt_llm._torch.auto_deploy"
 _IMPORT_TARGET = "llmc"
+_BUILD_AND_RUN_AD_IMPORT = "from build_and_run_ad import ExperimentConfig, main"
+_LLMC_TRTLLM_RUNNER_IMPORT = """
+if os.environ.get("TRTLLM_REDIRECT_AD_TO_LLMC") != "true":
+    pytest.skip(
+        "LLMC TRT-LLM redirect smoke requires TRTLLM_REDIRECT_AD_TO_LLMC=true",
+        allow_module_level=True,
+    )
+pytest.importorskip("tensorrt_llm")
+from runners.trtllm.build_and_run_llmc_trtllm import ExperimentConfig, main"""
 
 # Paths that the script owns and regenerates on every run.
 # Everything else in the output directory (e.g., .git/, .github/) is preserved
@@ -290,6 +300,9 @@ def _rewrite_imports_in_file(filepath: str) -> int:
 
     original = content
     content = content.replace(_IMPORT_REWRITE, _IMPORT_TARGET)
+    if _BUILD_AND_RUN_AD_IMPORT in content:
+        content = content.replace("import pytest\n", "import os\n\nimport pytest\n")
+        content = content.replace(_BUILD_AND_RUN_AD_IMPORT, _LLMC_TRTLLM_RUNNER_IMPORT)
 
     replacements = sum(1 for a, b in zip(original, content) if a != b)  # rough count
     if content != original:
@@ -438,10 +451,14 @@ def _create_test_conftest(tests_dir: str) -> None:
         import os
         import sys
 
+        _allow_trtllm_redirect = (
+            os.environ.get("TRTLLM_REDIRECT_AD_TO_LLMC") == "true"
+        )
         _trtllm_spec = importlib.util.find_spec("tensorrt_llm")
-        if _trtllm_spec is not None:
+        if _trtllm_spec is not None and not _allow_trtllm_redirect:
             raise RuntimeError(
                 "Standalone llmc tests must not be able to import tensorrt_llm; "
+                "set TRTLLM_REDIRECT_AD_TO_LLMC=true only for redirect smoke tests; "
                 f"found {getattr(_trtllm_spec, 'origin', None)!r}"
             )
 

--- a/examples/auto_deploy/llmc/create_standalone_package.py
+++ b/examples/auto_deploy/llmc/create_standalone_package.py
@@ -201,6 +201,24 @@ EXCLUDE_TEST_FILES = {
     "test_trtllm_quant_mxfp4_trtllm_gen_moe.py",
 }
 
+# Multi-GPU tests that exercise only AutoDeploy and its standalone dependencies.
+# Keep this list explicit: the remaining multi-GPU tests depend on TensorRT-LLM
+# runtime components, kernels, or test infrastructure that LLMC does not ship.
+STANDALONE_MULTIGPU_TEST_FILES = (
+    "custom_ops/test_dist.py",
+    "custom_ops/test_sharded_rmsnorm.py",
+    "transformations/library/test_apply_sharding_hints.py",
+    "transformations/library/test_bmm_sharding.py",
+    "transformations/library/test_ep_sharding.py",
+    "transformations/library/test_rmsnorm_sharding.py",
+    "transformations/library/test_sharding_num_correctness.py",
+    "transformations/library/test_step3p7_sharding_ir.py",
+    "transformations/library/test_tp_sharding.py",
+)
+
+# Pytest support files required by the allowlisted multi-GPU tests.
+STANDALONE_MULTIGPU_SUPPORT_FILES = ("transformations/library/conftest.py",)
+
 # Import path rewrite: old -> new (applied to test files only).
 _IMPORT_REWRITE = "tensorrt_llm._torch.auto_deploy"
 _IMPORT_TARGET = "llmc"
@@ -363,6 +381,19 @@ def _copy_tests(output_dir: str) -> int:
                 os.makedirs(os.path.dirname(dst_path), exist_ok=True)
                 shutil.copy2(src_path, dst_path)
                 count += 1
+
+    # Copy only the explicitly standalone-compatible multi-GPU tests. Unlike
+    # singlegpu/, this tree contains several tests that require TensorRT-LLM.
+    multigpu_src = os.path.join(AD_TESTS_DIR, "multigpu")
+    multigpu_files = STANDALONE_MULTIGPU_TEST_FILES + STANDALONE_MULTIGPU_SUPPORT_FILES
+    for rel_path in multigpu_files:
+        src_path = os.path.join(multigpu_src, rel_path)
+        if not os.path.isfile(src_path):
+            raise FileNotFoundError(f"Allowlisted multi-GPU test file does not exist: {src_path}")
+        dst_path = os.path.join(tests_dst, "multigpu", rel_path)
+        os.makedirs(os.path.dirname(dst_path), exist_ok=True)
+        shutil.copy2(src_path, dst_path)
+        count += 1
 
     # Copy test utilities
     if os.path.isdir(AD_UTILS_TEST_DIR):
@@ -550,6 +581,9 @@ def _create_pyproject_toml(output_dir: str, dependencies: list, dev_dependencies
         "\n"
         "[tool.pytest.ini_options]\n"
         'testpaths = ["tests"]\n'
+        "markers = [\n"
+        '    "threadleak(enabled): configure thread-leak checks (inert in standalone tests)",\n'
+        "]\n"
     )
 
     with open(os.path.join(output_dir, "pyproject.toml"), "w") as f:

--- a/tensorrt_llm/_torch/auto_deploy/__init__.py
+++ b/tensorrt_llm/_torch/auto_deploy/__init__.py
@@ -12,6 +12,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# This source tree is copied verbatim to the standalone ``llmc`` package.
+# Install the compatibility redirect before registration imports when running
+# from that generated package; bundled AutoDeploy must remain unchanged.
+if __name__ == "llmc":
+    from . import trtllm_compat as _trtllm_compat
+
+    _trtllm_compat.install_autodeploy_redirect_from_env()
+
 # import submodules that require registration process
 from . import compile, custom_ops, export, models  # noqa: F401
 from ._compat import TRTLLM_AVAILABLE

--- a/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/library/sharding.py
@@ -1710,10 +1710,12 @@ def _shard_parameter_node(
     # `strategy` is required on the trtllm op (no default) so the caller cannot
     # accidentally drop the AD-config-selected strategy. The torch op is a plain
     # torch.distributed all_gather and intentionally has no strategy/symm_mem.
-    if all_gather_op is torch.ops.auto_deploy.trtllm_dist_all_gather.default:
-        allgather_args = (config.allgather_strategy.name, -1, None)
-    else:
+    # Compare against the always-registered torch op so standalone mode never
+    # probes the optional TRT-LLM op merely to determine the call signature.
+    if all_gather_op is torch.ops.auto_deploy.torch_dist_all_gather.default:
         allgather_args = (-1,)
+    else:
+        allgather_args = (config.allgather_strategy.name, -1, None)
     dist_lookup = {
         0: (all_gather_op, *allgather_args),
         1: (all_reduce_op, allreduce_strategy),

--- a/tensorrt_llm/_torch/auto_deploy/trtllm_compat.py
+++ b/tensorrt_llm/_torch/auto_deploy/trtllm_compat.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compatibility redirect from TensorRT-LLM's bundled AutoDeploy namespace to LLMC."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.abc
+import importlib.util
+import os
+import sys
+import threading
+from collections.abc import Sequence
+from types import ModuleType
+
+REDIRECT_ENV_VAR = "TRTLLM_REDIRECT_AD_TO_LLMC"
+
+_LEGACY_PACKAGE = "tensorrt_llm._torch.auto_deploy"
+_TARGET_PACKAGE = "llmc"
+_FALSE_VALUES = frozenset({"", "0", "false", "no", "off"})
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+_FINDER_MARKER = "_is_llmc_autodeploy_redirect"
+_INSTALL_LOCK = threading.Lock()
+
+
+class _RedirectLoader(importlib.abc.Loader):
+    """Load an alias by returning its canonical LLMC module object."""
+
+    def __init__(self, target_name: str) -> None:
+        self._target_name = target_name
+        self._canonical_attributes: dict[str, object] | None = None
+
+    def create_module(self, spec: importlib.machinery.ModuleSpec) -> ModuleType:
+        del spec
+        module = importlib.import_module(self._target_name)
+        self._canonical_attributes = {
+            name: getattr(module, name)
+            for name in (
+                "__name__",
+                "__loader__",
+                "__package__",
+                "__spec__",
+                "__file__",
+                "__cached__",
+                "__path__",
+            )
+            if hasattr(module, name)
+        }
+        return module
+
+    def exec_module(self, module: ModuleType) -> None:
+        if self._canonical_attributes is None:
+            raise RuntimeError(f"Redirect loader for {self._target_name!r} was not initialized")
+
+        # Import machinery temporarily applies the alias spec to the canonical
+        # module returned by create_module(). Restore its LLMC identity so
+        # introspection and pickling continue to use canonical module names.
+        module.__dict__.update(self._canonical_attributes)
+
+
+class _AutoDeployRedirectFinder(importlib.abc.MetaPathFinder):
+    """Map the legacy AutoDeploy package prefix to the canonical LLMC prefix."""
+
+    _is_llmc_autodeploy_redirect = True
+
+    def find_spec(
+        self,
+        fullname: str,
+        path: Sequence[str] | None = None,
+        target: ModuleType | None = None,
+    ) -> importlib.machinery.ModuleSpec | None:
+        del path, target
+        if fullname != _LEGACY_PACKAGE and not fullname.startswith(_LEGACY_PACKAGE + "."):
+            return None
+
+        target_name = _TARGET_PACKAGE + fullname[len(_LEGACY_PACKAGE) :]
+        target_spec = importlib.util.find_spec(target_name)
+        if target_spec is None:
+            raise ModuleNotFoundError(
+                f"Cannot redirect {fullname!r}: LLMC module {target_name!r} does not exist",
+                name=target_name,
+            )
+
+        return importlib.util.spec_from_loader(
+            fullname,
+            _RedirectLoader(target_name),
+            origin=f"redirect:{target_name}",
+            is_package=target_spec.submodule_search_locations is not None,
+        )
+
+
+def _redirect_is_enabled() -> bool:
+    value = os.environ.get(REDIRECT_ENV_VAR)
+    if value is None:
+        return False
+
+    normalized = value.strip().lower()
+    if normalized in _FALSE_VALUES:
+        return False
+    if normalized in _TRUE_VALUES:
+        return True
+    raise ValueError(f"{REDIRECT_ENV_VAR} must be a boolean value, got {value!r}")
+
+
+def install_autodeploy_redirect() -> None:
+    """Redirect legacy TensorRT-LLM AutoDeploy imports to canonical LLMC modules.
+
+    The redirect must be installed before any module in the legacy namespace is
+    imported. Calling this function more than once is safe.
+
+    Raises:
+        RuntimeError: If bundled AutoDeploy modules were imported before the redirect.
+    """
+    with _INSTALL_LOCK:
+        for finder in sys.meta_path:
+            if getattr(finder, _FINDER_MARKER, False):
+                return
+
+        loaded_legacy_modules = sorted(
+            name
+            for name in sys.modules
+            if name == _LEGACY_PACKAGE or name.startswith(_LEGACY_PACKAGE + ".")
+        )
+        if loaded_legacy_modules:
+            raise RuntimeError(
+                "Cannot redirect TensorRT-LLM AutoDeploy after bundled modules were loaded: "
+                + ", ".join(loaded_legacy_modules)
+            )
+
+        sys.meta_path.insert(0, _AutoDeployRedirectFinder())
+
+
+def install_autodeploy_redirect_from_env() -> None:
+    """Install the AutoDeploy redirect when ``TRTLLM_REDIRECT_AD_TO_LLMC`` is enabled."""
+    if _redirect_is_enabled():
+        install_autodeploy_redirect()

--- a/tensorrt_llm/_torch/auto_deploy/trtllm_compat.py
+++ b/tensorrt_llm/_torch/auto_deploy/trtllm_compat.py
@@ -28,6 +28,12 @@ from types import ModuleType
 
 REDIRECT_ENV_VAR = "TRTLLM_REDIRECT_AD_TO_LLMC"
 
+__all__ = [
+    "REDIRECT_ENV_VAR",
+    "install_autodeploy_redirect",
+    "install_autodeploy_redirect_from_env",
+]
+
 _LEGACY_PACKAGE = "tensorrt_llm._torch.auto_deploy"
 _TARGET_PACKAGE = "llmc"
 _FALSE_VALUES = frozenset({"", "0", "false", "no", "off"})

--- a/tests/integration/defs/test_unittests.py
+++ b/tests/integration/defs/test_unittests.py
@@ -188,15 +188,39 @@ def test_unittests_v2(llm_root, llm_venv, case: str, output_dir, request):
 
     print(f"Running unit test:\"python {' '.join(command)}\"")
 
+    def build_pythonpath():
+        pythonpath = os.environ.get("PYTHONPATH", "")
+        pythonpath_entries = [f"{llm_root}/tests/unittest"]
+
+        # MPI worker processes start from the tests directory and otherwise
+        # may resolve an older site-packages triton_kernels package.
+        triton_kernels_src = os.path.join(llm_root, "triton_kernels")
+        if os.path.isdir(triton_kernels_src):
+            pythonpath_overrides_dir = os.path.join(
+                output_dir, f"pythonpath-overrides-{case_fn}")
+            os.makedirs(pythonpath_overrides_dir, exist_ok=True)
+            triton_kernels_link = os.path.join(pythonpath_overrides_dir,
+                                               "triton_kernels")
+            if os.path.lexists(triton_kernels_link):
+                is_expected_link = False
+                if os.path.islink(triton_kernels_link):
+                    is_expected_link = (
+                        os.readlink(triton_kernels_link) == triton_kernels_src)
+                if not is_expected_link:
+                    raise RuntimeError(
+                        f"Unexpected triton_kernels path: {triton_kernels_link}"
+                    )
+            else:
+                os.symlink(triton_kernels_src, triton_kernels_link)
+            pythonpath_entries.insert(0, pythonpath_overrides_dir)
+
+        if pythonpath:
+            pythonpath_entries.append(pythonpath)
+        return os.pathsep.join(pythonpath_entries)
+
     def run_command(cmd, num_workers=1):
         try:
-            pythonpath = os.environ.get("PYTHONPATH", "")
-            # Keep the source root ahead of site-packages so spawned MPI
-            # workers resolve repo-local packages such as triton_kernels.
-            pythonpath_entries = [llm_root, f"{llm_root}/tests/unittest"]
-            if pythonpath:
-                pythonpath_entries.append(pythonpath)
-            env = {'PYTHONPATH': os.pathsep.join(pythonpath_entries)}
+            env = {'PYTHONPATH': build_pythonpath()}
             if s3_secret_key:
                 env["S3_SECRET_KEY"] = s3_secret_key
             if num_workers > 1:

--- a/tests/integration/defs/test_unittests.py
+++ b/tests/integration/defs/test_unittests.py
@@ -191,7 +191,12 @@ def test_unittests_v2(llm_root, llm_venv, case: str, output_dir, request):
     def run_command(cmd, num_workers=1):
         try:
             pythonpath = os.environ.get("PYTHONPATH", "")
-            env = {'PYTHONPATH': f"{llm_root}/tests/unittest:{pythonpath}"}
+            # Keep the source root ahead of site-packages so spawned MPI
+            # workers resolve repo-local packages such as triton_kernels.
+            pythonpath_entries = [llm_root, f"{llm_root}/tests/unittest"]
+            if pythonpath:
+                pythonpath_entries.append(pythonpath)
+            env = {'PYTHONPATH': os.pathsep.join(pythonpath_entries)}
             if s3_secret_key:
                 env["S3_SECRET_KEY"] = s3_secret_key
             if num_workers > 1:

--- a/tests/unittest/auto_deploy/_utils_test/_sharding_ir_helpers.py
+++ b/tests/unittest/auto_deploy/_utils_test/_sharding_ir_helpers.py
@@ -9,8 +9,8 @@
 """Helpers for the offline sharding-IR equivalence test.
 
 The test takes a path to a sharding-IR-aware modeling file (e.g.
-``tensorrt_llm/_torch/auto_deploy/models/custom/modeling_deepseek.py``,
-``modeling_qwen3.py``, or any ``modeling_<name>.py`` whose canonical
+``models/custom/modeling_deepseek.py``, ``modeling_qwen3.py``, or any
+``modeling_<name>.py`` whose canonical
 implementation uses the sharding-IR path) and builds a tiny variant of that
 model -- few layers, small hidden size, random weights -- without touching
 the filesystem or LLM_MODELS_ROOT.
@@ -253,28 +253,28 @@ def _apply_per_family_quirks(config: Any) -> None:
 # -----------------------------------------------------------------------------
 
 
-def _path_to_dotted_module(path: str) -> str:
+def _path_to_dotted_module(path: str, custom_models_package: str) -> str:
     """Convert a modeling-file path to its Python dotted module name.
 
     Accepts:
 
-    * An absolute path: ``/.../tensorrt_llm/_torch/auto_deploy/models/custom/modeling_x.py``
-    * A path relative to cwd or repo root: ``tensorrt_llm/_torch/.../modeling_x.py``
-    * A bare module short name: ``modeling_x`` (resolved under
-      ``tensorrt_llm._torch.auto_deploy.models.custom``)
+    * An absolute path ending in ``models/custom/modeling_x.py``.
+    * A relative path ending in ``models/custom/modeling_x.py``.
+    * A bare module short name such as ``modeling_x``.
 
-    The conversion is purely syntactic -- no filename pattern is required.
+    ``custom_models_package`` comes from the loaded factory's module, so the
+    result targets either bundled AutoDeploy or standalone ``llmc`` without a
+    filesystem-root or top-level-package assumption. The conversion is purely
+    syntactic -- no filename pattern is required.
     """
-    if "/" not in path and not path.endswith(".py"):
-        return f"tensorrt_llm._torch.auto_deploy.models.custom.{path}"
-
-    p = Path(path).resolve() if not Path(path).is_absolute() else Path(path)
-    p = p.with_suffix("")
-    parts = p.parts
-    if "tensorrt_llm" not in parts:
-        raise ValueError(f"Path {path!r} does not contain a 'tensorrt_llm' package root anchor.")
-    idx = parts.index("tensorrt_llm")
-    return ".".join(parts[idx:])
+    candidate = Path(path.replace("\\", "/"))
+    if len(candidate.parts) > 1:
+        if candidate.suffix != ".py" or candidate.parent.name != "custom":
+            raise ValueError(f"Path {path!r} must identify a Python file under models/custom.")
+        if candidate.parent.parent.name != "models":
+            raise ValueError(f"Path {path!r} must identify a Python file under models/custom.")
+    module_name = candidate.stem
+    return f"{custom_models_package}.{module_name}"
 
 
 def _resolve_config_cls_from_transformers_registry(config_cls_name: str) -> Any:
@@ -319,12 +319,13 @@ def spec_from_modeling_file(path: str) -> IRModelSpec:
        files that only reference the config class by string in their
        registration call.
     """
-    module_name = _path_to_dotted_module(path)
-    mod = importlib.import_module(module_name)
-
-    # Deferred import: pulls in tensorrt_llm and so must run *after* the
-    # caller has done any necessary sys.path / env-var setup.
+    # Deferred import: pulls in the active AutoDeploy package and so must run
+    # after the caller has done any necessary sys.path / env-var setup.
     from tensorrt_llm._torch.auto_deploy.models.hf import AutoModelForCausalLMFactory
+
+    models_package = AutoModelForCausalLMFactory.__module__.rsplit(".", 1)[0]
+    module_name = _path_to_dotted_module(path, f"{models_package}.custom")
+    mod = importlib.import_module(module_name)
 
     # Walk AutoModelForCausalLMFactory AND every subclass. Each subclass gets
     # its own _custom_model_mapping via __init_subclass__ (see hf.py:668), so a

--- a/tests/unittest/auto_deploy/multigpu/custom_ops/test_sharded_rmsnorm.py
+++ b/tests/unittest/auto_deploy/multigpu/custom_ops/test_sharded_rmsnorm.py
@@ -22,29 +22,13 @@ compute the global mean of squared values across all shards, ensuring correct
 normalization equivalent to non-sharded global RMSNorm.
 """
 
-import pickle
-import sys
-import traceback
+from functools import partial
 
-import cloudpickle
 import pytest
 import torch
 import torch.distributed as dist
-from mpi4py import MPI
 
-from tensorrt_llm._torch.auto_deploy.distributed.common import initialize, is_initialized
-from tensorrt_llm._utils import get_free_port
-
-# Register this module for cloudpickle serialization for MPI workers
-cloudpickle.register_pickle_by_value(sys.modules[__name__])
-MPI.pickle.__init__(
-    cloudpickle.dumps,
-    cloudpickle.loads,
-    pickle.HIGHEST_PROTOCOL,
-)
-
-# needed since we reuse the mpi executor pool, first test running will leak a thread
-pytestmark = pytest.mark.threadleak(enabled=False)
+from tensorrt_llm._torch.auto_deploy.distributed.common import spawn_multiprocess_job
 
 
 def _reference_rmsnorm(input: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
@@ -56,14 +40,14 @@ def _reference_rmsnorm(input: torch.Tensor, weight: torch.Tensor, eps: float) ->
 
 
 def _run_sharded_rmsnorm_test(
-    tensor_parallel_size: int,
-    port: int,
+    rank: int,
+    world_size: int,
     batch_size: int = 2,
     seq_len: int = 8,
     hidden_size: int = 64,
     eps: float = 1e-6,
     dtype_str: str = "float16",
-):
+) -> None:
     """Test that sharded_rmsnorm matches non-sharded global RMSNorm.
 
     Each rank:
@@ -73,118 +57,60 @@ def _run_sharded_rmsnorm_test(
     4. Calls sharded_rmsnorm on local shard
     5. All-gathers results and compares with reference
     """
-    # Import inside worker to avoid cloudpickle serialization issues with torch.ops
-    import tensorrt_llm
     import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
 
-    rank = tensorrt_llm.mpi_rank()
-    world_size = tensor_parallel_size
-    torch.cuda.set_device(rank)
-
-    if not is_initialized():
-        initialize(rank, port=port)
-
-    # Map string to torch.dtype inside worker to avoid cloudpickle serialization issues
     dtype_map = {"float16": torch.float16, "bfloat16": torch.bfloat16}
     dtype = dtype_map[dtype_str]
 
-    try:
-        torch.manual_seed(42)  # Same seed for reproducibility across ranks
+    torch.manual_seed(42)  # Same seed for reproducibility across ranks
 
-        # Full tensors (same on all ranks due to seed)
-        full_input = torch.randn(batch_size, seq_len, hidden_size, device="cuda", dtype=dtype)
-        full_weight = torch.randn(hidden_size, device="cuda", dtype=dtype)
+    # Full tensors (same on all ranks due to seed)
+    full_input = torch.randn(batch_size, seq_len, hidden_size, device="cuda", dtype=dtype)
+    full_weight = torch.randn(hidden_size, device="cuda", dtype=dtype)
 
-        # Reference: non-sharded global RMSNorm
-        reference_output = _reference_rmsnorm(full_input, full_weight, eps)
+    # Reference: non-sharded global RMSNorm
+    reference_output = _reference_rmsnorm(full_input, full_weight, eps)
 
-        # Column shard: split hidden_size across ranks
-        local_hidden_size = hidden_size // world_size
-        start_idx = rank * local_hidden_size
-        end_idx = start_idx + local_hidden_size
+    # Column shard: split hidden_size across ranks
+    local_hidden_size = hidden_size // world_size
+    start_idx = rank * local_hidden_size
+    end_idx = start_idx + local_hidden_size
 
-        local_input = full_input[..., start_idx:end_idx].contiguous()
-        local_weight = full_weight[start_idx:end_idx].contiguous()
+    local_input = full_input[..., start_idx:end_idx].contiguous()
+    local_weight = full_weight[start_idx:end_idx].contiguous()
 
-        # Call sharded_rmsnorm using dynamic getattr to avoid cloudpickle capturing torch.ops
-        sharded_rmsnorm_op = getattr(getattr(torch, "ops"), "auto_deploy").sharded_rmsnorm
-        local_output = sharded_rmsnorm_op(local_input, local_weight, eps, world_size)
+    local_output = torch.ops.auto_deploy.sharded_rmsnorm(local_input, local_weight, eps, world_size)
 
-        # All-gather to reconstruct full output
-        gathered_outputs = [torch.zeros_like(local_output) for _ in range(world_size)]
-        dist.all_gather(gathered_outputs, local_output)
-        reconstructed_output = torch.cat(gathered_outputs, dim=-1)
+    # All-gather to reconstruct full output
+    gathered_outputs = [torch.zeros_like(local_output) for _ in range(world_size)]
+    dist.all_gather(gathered_outputs, local_output)
+    reconstructed_output = torch.cat(gathered_outputs, dim=-1)
 
-        # Compare with reference
-        torch.testing.assert_close(
-            reconstructed_output,
-            reference_output,
-            atol=1e-2,
-            rtol=1e-2,
-            msg=f"sharded_rmsnorm result doesn't match reference (rank={rank})",
-        )
-    except Exception:
-        traceback.print_exc()
-        raise
-
-    return True
+    # Compare with reference
+    torch.testing.assert_close(
+        reconstructed_output,
+        reference_output,
+        atol=1e-2,
+        rtol=1e-2,
+        msg=f"sharded_rmsnorm result doesn't match reference (rank={rank})",
+    )
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires at least 2 GPUs for this test")
-@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
-def test_sharded_rmsnorm_functional(mpi_pool_executor):
+def test_sharded_rmsnorm_functional() -> None:
     """Functional test: verify sharded_rmsnorm produces correct numerical results."""
-    torch.manual_seed(0)
-    tensor_parallel_size = mpi_pool_executor.num_workers
-    port = get_free_port()
-
-    results = mpi_pool_executor.map(
-        _run_sharded_rmsnorm_test,
-        *zip(*[(tensor_parallel_size, port)] * tensor_parallel_size),
-    )
-    for r in results:
-        assert r is True
-
-
-def _run_sharded_rmsnorm_hidden_size_test(tensor_parallel_size: int, port: int, hidden_size: int):
-    """Worker function for hidden size parametrized test."""
-    return _run_sharded_rmsnorm_test(tensor_parallel_size, port=port, hidden_size=hidden_size)
+    spawn_multiprocess_job(job=_run_sharded_rmsnorm_test, size=2)
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires at least 2 GPUs for this test")
-@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
 @pytest.mark.parametrize("hidden_size", [64, 128, 256])
-def test_sharded_rmsnorm_different_hidden_sizes(mpi_pool_executor, hidden_size):
+def test_sharded_rmsnorm_different_hidden_sizes(hidden_size: int) -> None:
     """Test sharded_rmsnorm with different hidden sizes."""
-    torch.manual_seed(0)
-    tensor_parallel_size = mpi_pool_executor.num_workers
-    port = get_free_port()
-
-    results = mpi_pool_executor.map(
-        _run_sharded_rmsnorm_hidden_size_test,
-        *zip(*[(tensor_parallel_size, port, hidden_size)] * tensor_parallel_size),
-    )
-    for r in results:
-        assert r is True
-
-
-def _run_sharded_rmsnorm_dtype_test(tensor_parallel_size: int, port: int, dtype_str: str):
-    """Worker function for dtype parametrized test."""
-    return _run_sharded_rmsnorm_test(tensor_parallel_size, port=port, dtype_str=dtype_str)
+    spawn_multiprocess_job(job=partial(_run_sharded_rmsnorm_test, hidden_size=hidden_size), size=2)
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires at least 2 GPUs for this test")
-@pytest.mark.parametrize("mpi_pool_executor", [2], indirect=True)
 @pytest.mark.parametrize("dtype_str", ["float16", "bfloat16"])
-def test_sharded_rmsnorm_different_dtypes(mpi_pool_executor, dtype_str):
+def test_sharded_rmsnorm_different_dtypes(dtype_str: str) -> None:
     """Test sharded_rmsnorm with different dtypes."""
-    torch.manual_seed(0)
-    tensor_parallel_size = mpi_pool_executor.num_workers
-    port = get_free_port()
-
-    results = mpi_pool_executor.map(
-        _run_sharded_rmsnorm_dtype_test,
-        *zip(*[(tensor_parallel_size, port, dtype_str)] * tensor_parallel_size),
-    )
-    for r in results:
-        assert r is True
+    spawn_multiprocess_job(job=partial(_run_sharded_rmsnorm_test, dtype_str=dtype_str), size=2)

--- a/tests/unittest/auto_deploy/multigpu/transformations/library/conftest.py
+++ b/tests/unittest/auto_deploy/multigpu/transformations/library/conftest.py
@@ -43,9 +43,23 @@ _DIST_CONFIG_DEFAULT_AUTO = "tp-only"
 # without importing it so test collection does not eagerly load every custom model.
 _AUTO_DEPLOY_PACKAGE = "tensorrt_llm._torch.auto_deploy"
 
-# ``modeling_eagle`` and ``modeling_gpt_oss`` have direct TRT-LLM dependencies
-# and therefore cannot import in standalone. Keep canonical discovery unchanged.
-_STANDALONE_DISCOVERY_EXCLUDED = {"modeling_eagle.py", "modeling_gpt_oss.py"}
+# These modeling files cannot participate in standalone LLMC auto-discovery.
+# They either depend on TRT-LLM-only router ops, need trust-remote-code config
+# classes that LLMC does not package, or are conditional-generation models not
+# registered as CausalLM classes for this harness. Keep canonical discovery
+# unchanged so the native TensorRT-LLM test matrix still covers them.
+_STANDALONE_DISCOVERY_EXCLUDED = {
+    "modeling_decilm.py",
+    "modeling_deepseek.py",
+    "modeling_eagle.py",
+    "modeling_glm4_moe.py",
+    "modeling_gpt_oss.py",
+    "modeling_hunyuan_moe.py",
+    "modeling_internlm3.py",
+    "modeling_nemotron_flash.py",
+    "modeling_nemotron_h.py",
+    "modeling_skywork_r1v2.py",
+}
 
 
 def _package_dir(package_name: str) -> Path:

--- a/tests/unittest/auto_deploy/multigpu/transformations/library/conftest.py
+++ b/tests/unittest/auto_deploy/multigpu/transformations/library/conftest.py
@@ -11,8 +11,8 @@
 ``test_sharding_num_correctness`` is parametrized intrinsically (one invocation
 per modeling file × dist config). The two CLI options pin a single value
 to that axis for per-file debugging; when omitted, the test auto-discovers
-every ``modeling_*.py`` under ``tensorrt_llm/_torch/auto_deploy/models/custom/``
-and runs the cheapest dist config across all of them.
+the supported ``modeling_*.py`` files from the active AutoDeploy package and
+runs the cheapest dist config across all of them.
 
 IR-marked files (graph carries ``torch.ops.auto_deploy.all_reduce`` per skill
 rule A3) run ``apply_sharding_hints`` + ``strip_sharding_hints``. Legacy
@@ -23,6 +23,7 @@ which the legacy heuristic inserts zero collectives ``pytest.skip`` cleanly
 (rather than rubber-stamping a trivial identity pass).
 """
 
+from importlib.util import find_spec
 from pathlib import Path
 
 import pytest
@@ -38,8 +39,29 @@ _QUANT_CHOICES = ("none", "nvfp4")
 _DIST_CONFIG_DEFAULT_CLI = "tep"
 _DIST_CONFIG_DEFAULT_AUTO = "tp-only"
 
-_REPO_ROOT = Path(__file__).resolve().parents[6]
-_MODELING_DIR = _REPO_ROOT / "tensorrt_llm" / "_torch" / "auto_deploy" / "models" / "custom"
+# This value is rewritten to ``llmc`` with the copied tests. Resolve the package
+# without importing it so test collection does not eagerly load every custom model.
+_AUTO_DEPLOY_PACKAGE = "tensorrt_llm._torch.auto_deploy"
+
+# ``modeling_eagle`` and ``modeling_gpt_oss`` have direct TRT-LLM dependencies
+# and therefore cannot import in standalone. Keep canonical discovery unchanged.
+_STANDALONE_DISCOVERY_EXCLUDED = {"modeling_eagle.py", "modeling_gpt_oss.py"}
+
+
+def _package_dir(package_name: str) -> Path:
+    """Resolve a package directory without importing the package."""
+    top_level, *subpackages = package_name.split(".")
+    spec = find_spec(top_level)
+    if spec is None or spec.submodule_search_locations is None:
+        raise ImportError(f"Could not locate package {package_name!r}")
+    for location in spec.submodule_search_locations:
+        package_dir = Path(location).joinpath(*subpackages)
+        if package_dir.is_dir():
+            return package_dir
+    raise ImportError(f"Package {package_name!r} has no filesystem location")
+
+
+_MODELING_DIR = _package_dir(_AUTO_DEPLOY_PACKAGE) / "models" / "custom"
 
 
 def pytest_addoption(parser):
@@ -50,10 +72,10 @@ def pytest_addoption(parser):
         help=(
             "Path to a single modeling file to verify with "
             "test_sharding_num_correctness. Accepts an absolute path, a path "
-            "relative to cwd or repo root, or a bare module short name "
-            "(resolved under tensorrt_llm._torch.auto_deploy.models.custom). "
+            "relative to cwd, or a bare module short name (resolved under "
+            "the active AutoDeploy package's models.custom package). "
             "When omitted, the test auto-discovers and parametrizes over "
-            "EVERY modeling_*.py in custom/."
+            "every supported modeling_*.py in custom/."
         ),
     )
     parser.addoption(
@@ -116,12 +138,15 @@ def _modeling_id(path: str) -> str:
 
 
 def _discover_modeling_files() -> list:
-    """Sorted absolute paths of every modeling_*.py in the AD custom models dir.
+    """Sorted absolute paths of supported modeling files in the AD custom models dir.
 
     Deterministic ordering is important: a flaky test mapped to a different
     parametrize id from run to run would mislead bisection.
     """
-    return sorted(str(p) for p in _MODELING_DIR.glob("modeling_*.py"))
+    excluded = _STANDALONE_DISCOVERY_EXCLUDED if _AUTO_DEPLOY_PACKAGE == "llmc" else set()
+    return sorted(
+        str(path) for path in _MODELING_DIR.glob("modeling_*.py") if path.name not in excluded
+    )
 
 
 def pytest_generate_tests(metafunc):

--- a/tests/unittest/auto_deploy/multigpu/transformations/library/test_bmm_sharding.py
+++ b/tests/unittest/auto_deploy/multigpu/transformations/library/test_bmm_sharding.py
@@ -23,6 +23,7 @@ from _dist_test_utils import get_device_counts
 from _graph_test_helpers import run_sharding_pattern_detection_test, run_test_transformed_gm
 
 import tensorrt_llm._torch.auto_deploy.distributed.common as dist_common
+from tensorrt_llm._torch.auto_deploy._compat import AllReduceStrategy
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transform.library.sharding import (
     BMMShardingInfo,
@@ -30,7 +31,6 @@ from tensorrt_llm._torch.auto_deploy.transform.library.sharding import (
 )
 from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimizer
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
-from tensorrt_llm.functional import AllReduceStrategy
 
 
 class BMM(nn.Module):

--- a/tests/unittest/auto_deploy/multigpu/transformations/library/test_ep_sharding.py
+++ b/tests/unittest/auto_deploy/multigpu/transformations/library/test_ep_sharding.py
@@ -23,6 +23,7 @@ from _graph_test_helpers import run_sharding_pattern_detection_test, run_test_tr
 from _model_test_utils import MoEOpModel
 
 import tensorrt_llm._torch.auto_deploy.distributed.common as dist_common
+from tensorrt_llm._torch.auto_deploy._compat import AllReduceStrategy
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.transform.library.sharding import (
     EPShardingInfo,
@@ -34,7 +35,6 @@ from tensorrt_llm._torch.auto_deploy.transform.optimizer import InferenceOptimiz
 from tensorrt_llm._torch.auto_deploy.utils._graph import lint, recompile
 from tensorrt_llm._torch.auto_deploy.utils.dist_config import DistConfig
 from tensorrt_llm._torch.auto_deploy.utils.node_utils import is_op
-from tensorrt_llm.functional import AllReduceStrategy
 
 
 def _run_ep_shard_job(

--- a/tests/unittest/auto_deploy/multigpu/transformations/library/test_sharding_num_correctness.py
+++ b/tests/unittest/auto_deploy/multigpu/transformations/library/test_sharding_num_correctness.py
@@ -32,7 +32,7 @@ source only). See ``_apply_sharding_to_gm`` for the branch.
 Usage:
 
   pytest tests/unittest/auto_deploy/multigpu/transformations/library/test_sharding_num_correctness.py \
-      --sharding-ir-modeling-file tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3.py
+      --sharding-ir-modeling-file modeling_qwen3
 
 The test is skipped (not failed) when ``--sharding-ir-modeling-file`` is
 absent. No filename pattern is assumed -- works for the canonical
@@ -367,7 +367,7 @@ def _run_equivalence_job_impl(
     the all-reduce inserted by sharding.
     """
     # Imports are deferred until inside the worker so spawn() picks up any
-    # parent-side sys.path / env-var setup before tensorrt_llm is loaded.
+    # parent-side sys.path / env-var setup before AutoDeploy is loaded.
     import tensorrt_llm._torch.auto_deploy.custom_ops  # noqa: F401
     import tensorrt_llm._torch.auto_deploy.models.custom  # noqa: F401 -- registers IR classes
     import tensorrt_llm._torch.auto_deploy.transform.library  # noqa: F401
@@ -723,8 +723,13 @@ def test_sharding_num_correctness(
         _preflight_spec = spec_from_modeling_file(sharding_ir_modeling_file)
         _ = build_ir_model(_preflight_spec, device=torch.device("cpu"), dtype=FORWARD_DTYPE)
     except RuntimeError as e:
+        from tensorrt_llm._torch.auto_deploy._compat import TRTLLM_AVAILABLE
+
         msg = str(e)
-        if "Could not resolve config class" in msg or "ForCausalLM' class registered" in msg:
+        known_native_setup_error = (
+            "Could not resolve config class" in msg or "ForCausalLM' class registered" in msg
+        )
+        if TRTLLM_AVAILABLE and known_native_setup_error:
             pytest.skip(f"Modeling file not set up for IR equivalence harness: {e}")
         raise
     except (TypeError, AttributeError, KeyError, ValueError, AssertionError) as e:

--- a/tests/unittest/auto_deploy/multigpu/transformations/library/test_step3p7_sharding_ir.py
+++ b/tests/unittest/auto_deploy/multigpu/transformations/library/test_step3p7_sharding_ir.py
@@ -42,9 +42,9 @@ from test_sharding_num_correctness import (  # noqa: E402
     _run_equivalence_job,
 )
 
-# Modeling file under test (bare path relative to repo root; the harness's
-# ``spec_from_modeling_file`` also accepts a bare module short name).
-_MODELING_FILE = "tensorrt_llm/_torch/auto_deploy/models/custom/modeling_step3p7.py"
+# A bare module name lets the harness resolve the model from either bundled
+# AutoDeploy or the generated standalone package.
+_MODELING_FILE = "modeling_step3p7"
 
 # Per-model relative-RMSE tolerance (see module docstring for the rationale).
 STEP3P7_REL_RMSE_TOL = 0.08

--- a/tests/unittest/auto_deploy/multigpu/transformations/library/test_tp_sharding.py
+++ b/tests/unittest/auto_deploy/multigpu/transformations/library/test_tp_sharding.py
@@ -30,6 +30,7 @@ from _torch_test_utils import fp4_compatible, trtllm_ops_available
 from torch._inductor.pattern_matcher import stable_topological_sort
 
 import tensorrt_llm._torch.auto_deploy.distributed.common as dist_common
+from tensorrt_llm._torch.auto_deploy._compat import AllReduceStrategy
 from tensorrt_llm._torch.auto_deploy.custom_ops.quantization.quant import _pad_nvfp4_weight
 from tensorrt_llm._torch.auto_deploy.export import torch_export_to_gm
 from tensorrt_llm._torch.auto_deploy.models.custom.modeling_nemotron_h import NemotronHMamba2Mixer
@@ -49,7 +50,6 @@ from tensorrt_llm._torch.auto_deploy.utils.quantization_utils import (
     fp4_global_scale,
     modelopt_fp4_scale_to_cutlass_fp4_scale,
 )
-from tensorrt_llm.functional import AllReduceStrategy
 
 
 class GQA_Block(nn.Module):

--- a/tests/unittest/auto_deploy/standalone/test_standalone_test_export.py
+++ b/tests/unittest/auto_deploy/standalone/test_standalone_test_export.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for exporting standalone-compatible AutoDeploy tests to LLMC."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CREATE_SCRIPT = REPO_ROOT / "examples" / "auto_deploy" / "llmc" / "create_standalone_package.py"
+AD_MULTIGPU_TESTS = REPO_ROOT / "tests" / "unittest" / "auto_deploy" / "multigpu"
+
+EXPECTED_MULTIGPU_FILES = {
+    Path("custom_ops/test_dist.py"),
+    Path("custom_ops/test_sharded_rmsnorm.py"),
+    Path("transformations/library/conftest.py"),
+    Path("transformations/library/test_apply_sharding_hints.py"),
+    Path("transformations/library/test_bmm_sharding.py"),
+    Path("transformations/library/test_ep_sharding.py"),
+    Path("transformations/library/test_rmsnorm_sharding.py"),
+    Path("transformations/library/test_sharding_num_correctness.py"),
+    Path("transformations/library/test_step3p7_sharding_ir.py"),
+    Path("transformations/library/test_tp_sharding.py"),
+}
+CANONICAL_IMPORT = "tensorrt_llm._torch.auto_deploy"
+STANDALONE_IMPORT = "llmc"
+
+
+@pytest.fixture(scope="module")
+def generated_multigpu_tests(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Generate the package once and return its multi-GPU test directory."""
+    output_dir = tmp_path_factory.mktemp("llmc_test_export")
+    subprocess.run(
+        [sys.executable, str(CREATE_SCRIPT), "--output-dir", str(output_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    return output_dir / "tests" / "multigpu"
+
+
+def test_exports_exact_multigpu_allowlist(generated_multigpu_tests: Path) -> None:
+    exported_files = {
+        path.relative_to(generated_multigpu_tests)
+        for path in generated_multigpu_tests.rglob("*.py")
+    }
+    assert exported_files == EXPECTED_MULTIGPU_FILES
+
+
+def test_registers_inert_threadleak_marker(generated_multigpu_tests: Path) -> None:
+    pyproject = generated_multigpu_tests.parents[1] / "pyproject.toml"
+    assert '"threadleak(enabled): configure thread-leak checks' in pyproject.read_text()
+
+
+@pytest.mark.parametrize("relative_path", sorted(EXPECTED_MULTIGPU_FILES, key=str), ids=str)
+def test_rewrites_multigpu_auto_deploy_imports(
+    generated_multigpu_tests: Path, relative_path: Path
+) -> None:
+    source = (AD_MULTIGPU_TESTS / relative_path).read_text()
+    exported = (generated_multigpu_tests / relative_path).read_text()
+
+    assert exported == source.replace(CANONICAL_IMPORT, STANDALONE_IMPORT)
+    assert CANONICAL_IMPORT not in exported

--- a/tests/unittest/auto_deploy/standalone/test_standalone_test_export.py
+++ b/tests/unittest/auto_deploy/standalone/test_standalone_test_export.py
@@ -24,10 +24,12 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[4]
 CREATE_SCRIPT = REPO_ROOT / "examples" / "auto_deploy" / "llmc" / "create_standalone_package.py"
 AD_MULTIGPU_TESTS = REPO_ROOT / "tests" / "unittest" / "auto_deploy" / "multigpu"
+LLMC_TRTLLM_SMOKE_TEST = Path("smoke/test_ad_build_small_multi.py")
 
 EXPECTED_MULTIGPU_FILES = {
     Path("custom_ops/test_dist.py"),
     Path("custom_ops/test_sharded_rmsnorm.py"),
+    LLMC_TRTLLM_SMOKE_TEST,
     Path("transformations/library/conftest.py"),
     Path("transformations/library/test_apply_sharding_hints.py"),
     Path("transformations/library/test_bmm_sharding.py"),
@@ -39,6 +41,23 @@ EXPECTED_MULTIGPU_FILES = {
 }
 CANONICAL_IMPORT = "tensorrt_llm._torch.auto_deploy"
 STANDALONE_IMPORT = "llmc"
+BUILD_AND_RUN_AD_IMPORT = "from build_and_run_ad import ExperimentConfig, main"
+LLMC_TRTLLM_RUNNER_IMPORT = """
+if os.environ.get("TRTLLM_REDIRECT_AD_TO_LLMC") != "true":
+    pytest.skip(
+        "LLMC TRT-LLM redirect smoke requires TRTLLM_REDIRECT_AD_TO_LLMC=true",
+        allow_module_level=True,
+    )
+pytest.importorskip("tensorrt_llm")
+from runners.trtllm.build_and_run_llmc_trtllm import ExperimentConfig, main"""
+
+
+def _expected_exported_test(source: str, relative_path: Path) -> str:
+    expected = source.replace(CANONICAL_IMPORT, STANDALONE_IMPORT)
+    if relative_path == LLMC_TRTLLM_SMOKE_TEST:
+        expected = expected.replace("import pytest\n", "import os\n\nimport pytest\n")
+        expected = expected.replace(BUILD_AND_RUN_AD_IMPORT, LLMC_TRTLLM_RUNNER_IMPORT)
+    return expected
 
 
 @pytest.fixture(scope="module")
@@ -68,6 +87,13 @@ def test_registers_inert_threadleak_marker(generated_multigpu_tests: Path) -> No
     assert '"threadleak(enabled): configure thread-leak checks' in pyproject.read_text()
 
 
+def test_conftest_allows_explicit_redirect_mode(generated_multigpu_tests: Path) -> None:
+    conftest = generated_multigpu_tests.parent / "conftest.py"
+    content = conftest.read_text()
+    assert "TRTLLM_REDIRECT_AD_TO_LLMC" in content
+    assert "set TRTLLM_REDIRECT_AD_TO_LLMC=true only for redirect smoke tests" in content
+
+
 @pytest.mark.parametrize("relative_path", sorted(EXPECTED_MULTIGPU_FILES, key=str), ids=str)
 def test_rewrites_multigpu_auto_deploy_imports(
     generated_multigpu_tests: Path, relative_path: Path
@@ -75,5 +101,9 @@ def test_rewrites_multigpu_auto_deploy_imports(
     source = (AD_MULTIGPU_TESTS / relative_path).read_text()
     exported = (generated_multigpu_tests / relative_path).read_text()
 
-    assert exported == source.replace(CANONICAL_IMPORT, STANDALONE_IMPORT)
+    assert exported == _expected_exported_test(source, relative_path)
     assert CANONICAL_IMPORT not in exported
+    if relative_path == LLMC_TRTLLM_SMOKE_TEST:
+        assert BUILD_AND_RUN_AD_IMPORT not in exported
+        assert "build_and_run_llmc_trtllm" in exported
+        assert "TRTLLM_REDIRECT_AD_TO_LLMC" in exported

--- a/tests/unittest/auto_deploy/standalone/test_trtllm_compat.py
+++ b/tests/unittest/auto_deploy/standalone/test_trtllm_compat.py
@@ -136,10 +136,17 @@ def test_redirect_is_disabled_by_default(generated_package: Path, env_value: str
     result = _run_generated(
         generated_package,
         """
+        import importlib
         import sys
         import llmc
 
         assert 'tensorrt_llm._torch.auto_deploy' not in sys.modules
+        try:
+            importlib.import_module('tensorrt_llm._torch.auto_deploy')
+        except RuntimeError as exc:
+            assert 'bundled AutoDeploy must not be imported' in str(exc)
+        else:
+            raise AssertionError('redirect unexpectedly enabled for falsey environment value')
         """,
         env_value=env_value,
     )
@@ -217,6 +224,7 @@ def test_redirect_bootstraps_during_child_unpickle(generated_package: Path) -> N
             capture_output=True,
             env=os.environ.copy(),
             text=True,
+            timeout=30,
         )
         assert child.returncode == 0, (child.stdout, child.stderr)
         """,

--- a/tests/unittest/auto_deploy/standalone/test_trtllm_compat.py
+++ b/tests/unittest/auto_deploy/standalone/test_trtllm_compat.py
@@ -1,0 +1,301 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the generated LLMC compatibility redirect."""
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CREATE_SCRIPT = REPO_ROOT / "examples" / "auto_deploy" / "llmc" / "create_standalone_package.py"
+REDIRECT_ENV_VAR = "TRTLLM_REDIRECT_AD_TO_LLMC"
+
+
+def _stub_preamble(package_dir: Path) -> str:
+    bundled_torch_dir = package_dir / "bundled_torch"
+    child_script = package_dir / "redirect_child.py"
+    return textwrap.dedent(
+        f"""
+        import importlib.machinery
+        import sys
+        import types
+
+        sys.path.insert(0, {str(package_dir)!r})
+        REDIRECT_CHILD_SCRIPT = {str(child_script)!r}
+
+        def make_module(name, *, is_package=False):
+            module = types.ModuleType(name)
+            module.__package__ = name if is_package else name.rpartition('.')[0]
+            module.__spec__ = importlib.machinery.ModuleSpec(name, loader=None, is_package=is_package)
+            if is_package:
+                module.__path__ = []
+            sys.modules[name] = module
+            return module
+
+        trtllm = make_module('tensorrt_llm', is_package=True)
+        trtllm_torch = make_module('tensorrt_llm._torch', is_package=True)
+        trtllm_torch.__path__ = [{str(bundled_torch_dir)!r}]
+        trtllm._torch = trtllm_torch
+
+        for name in ('llmc.compile', 'llmc.custom_ops', 'llmc.export', 'llmc.models'):
+            make_module(name, is_package=True)
+        compat = make_module('llmc._compat')
+        compat.TRTLLM_AVAILABLE = False
+        make_module('modelopt')
+        """
+    )
+
+
+@pytest.fixture(scope="module")
+def generated_package(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    package_dir = tmp_path_factory.mktemp("llmc_redirect")
+    subprocess.run(
+        [sys.executable, str(CREATE_SCRIPT), "--output-dir", str(package_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert (package_dir / "llmc" / "trtllm_compat.py").is_file()
+    (package_dir / "llmc" / "redirect_test_module.py").write_text(
+        "class RedirectProbe:\n    pass\n\nVALUE = 42\n"
+    )
+
+    bundled_ad_dir = package_dir / "bundled_torch" / "auto_deploy"
+    bundled_ad_dir.mkdir(parents=True)
+    (bundled_ad_dir / "__init__.py").write_text(
+        "raise RuntimeError('bundled AutoDeploy must not be imported')\n"
+    )
+
+    child_script = package_dir / "redirect_child.py"
+    child_script.write_text(
+        _stub_preamble(package_dir)
+        + textwrap.dedent(
+            """
+            import base64
+            import importlib
+            import pickle
+            import sys
+
+            probe = pickle.loads(base64.b64decode(sys.argv[1]))
+            canonical_module = importlib.import_module('llmc.redirect_test_module')
+            legacy_module = importlib.import_module(
+                'tensorrt_llm._torch.auto_deploy.redirect_test_module'
+            )
+            assert type(probe) is canonical_module.RedirectProbe
+            assert legacy_module is canonical_module
+            """
+        )
+    )
+    return package_dir
+
+
+def _run_generated(
+    package_dir: Path, script: str, env_value: str | None
+) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    if env_value is None:
+        env.pop(REDIRECT_ENV_VAR, None)
+    else:
+        env[REDIRECT_ENV_VAR] = env_value
+
+    return subprocess.run(
+        [sys.executable, "-c", _stub_preamble(package_dir) + textwrap.dedent(script)],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=30,
+    )
+
+
+def _assert_success(result: subprocess.CompletedProcess) -> None:
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+
+
+@pytest.mark.parametrize("env_value", [None, "", "0", "false", "NO", "off"])
+def test_redirect_is_disabled_by_default(generated_package: Path, env_value: str | None) -> None:
+    result = _run_generated(
+        generated_package,
+        """
+        import sys
+        import llmc
+
+        assert 'tensorrt_llm._torch.auto_deploy' not in sys.modules
+        """,
+        env_value=env_value,
+    )
+    _assert_success(result)
+
+
+@pytest.mark.parametrize("env_value", ["1", "true", "YES", "on"])
+def test_redirect_uses_canonical_llmc_modules(generated_package: Path, env_value: str) -> None:
+    result = _run_generated(
+        generated_package,
+        """
+        import importlib
+        import sys
+        import llmc
+
+        legacy_root = importlib.import_module('tensorrt_llm._torch.auto_deploy')
+        legacy_module = importlib.import_module(
+            'tensorrt_llm._torch.auto_deploy.redirect_test_module'
+        )
+        canonical_module = importlib.import_module('llmc.redirect_test_module')
+
+        assert legacy_root is llmc
+        assert legacy_module is canonical_module
+        assert legacy_module.__name__ == 'llmc.redirect_test_module'
+        assert legacy_module.__package__ == 'llmc'
+        assert legacy_module.__spec__.name == 'llmc.redirect_test_module'
+        assert legacy_module.__loader__ is canonical_module.__loader__
+        assert sys.modules['tensorrt_llm._torch.auto_deploy'] is llmc
+
+        from llmc.trtllm_compat import install_autodeploy_redirect
+        install_autodeploy_redirect()
+        """,
+        env_value=env_value,
+    )
+    _assert_success(result)
+
+
+def test_redirect_can_be_installed_explicitly(generated_package: Path) -> None:
+    result = _run_generated(
+        generated_package,
+        """
+        import importlib
+        import sys
+        import llmc
+
+        assert 'tensorrt_llm._torch.auto_deploy' not in sys.modules
+        from llmc.trtllm_compat import install_autodeploy_redirect
+        install_autodeploy_redirect()
+
+        legacy_root = importlib.import_module('tensorrt_llm._torch.auto_deploy')
+        assert legacy_root is llmc
+        """,
+        env_value=None,
+    )
+    _assert_success(result)
+
+
+def test_redirect_bootstraps_during_child_unpickle(generated_package: Path) -> None:
+    result = _run_generated(
+        generated_package,
+        """
+        import base64
+        import os
+        import pickle
+        import subprocess
+        import sys
+
+        import llmc
+        from llmc.redirect_test_module import RedirectProbe
+
+        payload = base64.b64encode(pickle.dumps(RedirectProbe())).decode('ascii')
+        child = subprocess.run(
+            [sys.executable, REDIRECT_CHILD_SCRIPT, payload],
+            check=False,
+            capture_output=True,
+            env=os.environ.copy(),
+            text=True,
+        )
+        assert child.returncode == 0, (child.stdout, child.stderr)
+        """,
+        env_value="true",
+    )
+    _assert_success(result)
+
+
+def test_redirects_real_trtllm_runtime_entrypoints(generated_package: Path) -> None:
+    env = os.environ.copy()
+    env[REDIRECT_ENV_VAR] = "true"
+    script = textwrap.dedent(
+        f"""
+        import importlib
+        import importlib.util
+        import pathlib
+        import sys
+
+        sys.path.insert(0, {str(generated_package)!r})
+
+        def reject_bundled_ad(event, args):
+            if event != 'open' or not args or not isinstance(args[0], (str, bytes)):
+                return
+            path = str(args[0]).replace('\\\\', '/')
+            if '/tensorrt_llm/_torch/auto_deploy/' in path:
+                raise RuntimeError(f'bundled AutoDeploy source opened: {{path}}')
+
+        sys.addaudithook(reject_bundled_ad)
+        if importlib.util.find_spec('tensorrt_llm') is None:
+            print('TensorRT-LLM unavailable')
+            raise SystemExit(77)
+
+        import tensorrt_llm
+        import llmc
+
+        legacy_args = importlib.import_module('tensorrt_llm._torch.auto_deploy.llm_args')
+        legacy_executor = importlib.import_module(
+            'tensorrt_llm._torch.auto_deploy.shim.ad_executor'
+        )
+        assert legacy_args is importlib.import_module('llmc.llm_args')
+        assert legacy_executor is importlib.import_module('llmc.shim.ad_executor')
+        assert legacy_args.LlmArgs.__module__ == 'llmc.llm_args'
+        assert pathlib.Path(legacy_args.__file__).is_relative_to({str(generated_package)!r})
+        assert pathlib.Path(legacy_executor.__file__).is_relative_to({str(generated_package)!r})
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        cwd=generated_package,
+        env=env,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode == 77:
+        pytest.skip(result.stdout.strip())
+    _assert_success(result)
+
+
+def test_redirect_rejects_invalid_environment_value(generated_package: Path) -> None:
+    result = _run_generated(generated_package, "import llmc", env_value="sometimes")
+    assert result.returncode != 0
+    assert f"{REDIRECT_ENV_VAR} must be a boolean value" in result.stderr
+
+
+def test_redirect_rejects_preloaded_bundled_modules(generated_package: Path) -> None:
+    result = _run_generated(
+        generated_package,
+        """
+        import sys
+        import types
+
+        sys.modules['tensorrt_llm._torch.auto_deploy'] = types.ModuleType(
+            'tensorrt_llm._torch.auto_deploy'
+        )
+        import llmc
+        """,
+        env_value="true",
+    )
+    assert result.returncode != 0
+    assert "after bundled modules were loaded" in result.stderr


### PR DESCRIPTION
## Description

build_and_run_llmc_trtllm.py                                                                                                                                  
    -> imports llmc.LLM and llmc.LlmArgs                                                                                                                        
    -> parses configuration using llm-c                                                                                                                         
    -> runtime=trtllm selects llmc.LLM                                                                                                                          
    -> llmc.LLM delegates execution to TensorRT-LLM's _TorchLLM                                                                                                 
    -> TensorRT-LLM sees backend="_autodeploy"                                                                                                                  
    -> TensorRT-LLM imports its legacy AutoDeploy paths 

Till we remove auto_deploy from trtllm and add a better integration with trtllm, we need to redirect autoDeploy imports to llm-c
`TRTLLM_REDIRECT_AD_TO_LLMC=true`.

This compatibility path allows llm-c to use TensorRT-LLM for runtime execution while bundled AutoDeploy is being removed from TensorRT-LLM.

In a follow up PR, we'll do the dependency inversion and make it ready to remove auto_deploy code from TRTLLM.

## Test Coverage

- Generated standalone LLMC package with redirect enabled and disabled.
- Canonical module identity for root and nested legacy imports.
- Explicit installation, invalid environment values, and late-install rejection.
- Child-process unpickling and TensorRT-LLM runtime entrypoint imports.