### PR TITLE
[TRTLLM-12499][feat] Pipelined KVCache transfer for disaggregated serving in Python Cache Transceiver

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -1281,6 +1281,8 @@ def create_autodeploy_executor(
             attention_type_cpp,
             cache_transceiver_config,
             mamba_cache_manager=None,
+            enable_chunked_prefill=getattr(ad_config,
+                                           "enable_chunked_prefill", False),
         )
 
     # Guided (structured) decoding.

--- a/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
+++ b/tensorrt_llm/_torch/auto_deploy/shim/ad_executor.py
@@ -1281,8 +1281,7 @@ def create_autodeploy_executor(
             attention_type_cpp,
             cache_transceiver_config,
             mamba_cache_manager=None,
-            enable_chunked_prefill=getattr(ad_config,
-                                           "enable_chunked_prefill", False),
+            enable_chunked_prefill=getattr(ad_config, "enable_chunked_prefill", False),
         )
 
     # Guided (structured) decoding.

--- a/tensorrt_llm/_torch/disaggregation/base/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/base/transfer.py
@@ -15,19 +15,19 @@ def project_blocks_to_global_chunk(
     block_ids: np.ndarray,
     chunk_block_offset: int,
     chunk_block_count: int,
-    total_blocks: int,
+    resident_block_end: int,
 ) -> np.ndarray:
     """Project a global block chunk into a suffix-resident block list.
 
     ``block_ids`` represents the resident suffix of the logical range
-    ``[0, total_blocks)``.  ``chunk_block_offset`` and ``chunk_block_count``
-    describe a chunk in that global coordinate space.
+    ``[0, resident_block_end)``. ``chunk_block_offset`` and
+    ``chunk_block_count`` describe a chunk in that global coordinate space.
     """
     if chunk_block_count <= 0 or len(block_ids) == 0:
         return block_ids[:0]
 
-    resident_start = max(0, total_blocks - len(block_ids))
-    resident_end = total_blocks
+    resident_start = max(0, resident_block_end - len(block_ids))
+    resident_end = resident_block_end
     chunk_start = chunk_block_offset
     chunk_end = chunk_start + chunk_block_count
 
@@ -64,10 +64,7 @@ def derive_chunk_block_coords(
         return 0, 0
     if tokens_per_block <= 0:
         raise ValueError("tokens_per_block must be positive")
-    if (
-        token_range.start % tokens_per_block != 0
-        or token_range.end % tokens_per_block != 0
-    ):
+    if token_range.start % tokens_per_block != 0 or token_range.end % tokens_per_block != 0:
         raise ValueError(
             f"token_range [{token_range.start}, {token_range.end}) must be "
             f"block-aligned with tokens_per_block={tokens_per_block}"
@@ -120,6 +117,7 @@ class KVSlice:
     is_last_slice: bool = False
     mamba_state_index: Optional[int] = None
     total_blocks: Optional[int] = None
+
 
 class SessionStatus(Enum):
     """Status of a transfer session.

--- a/tensorrt_llm/_torch/disaggregation/base/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/base/transfer.py
@@ -11,6 +11,36 @@ from tensorrt_llm import DisaggregatedParams
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
 
 
+def project_blocks_to_global_chunk(
+    block_ids: np.ndarray,
+    chunk_block_offset: int,
+    chunk_block_count: int,
+    total_blocks: int,
+) -> np.ndarray:
+    """Project a global block chunk into a suffix-resident block list.
+
+    ``block_ids`` represents the resident suffix of the logical range
+    ``[0, total_blocks)``.  ``chunk_block_offset`` and ``chunk_block_count``
+    describe a chunk in that global coordinate space.
+    """
+    if chunk_block_count <= 0 or len(block_ids) == 0:
+        return block_ids[:0]
+
+    resident_start = max(0, total_blocks - len(block_ids))
+    resident_end = total_blocks
+    chunk_start = chunk_block_offset
+    chunk_end = chunk_start + chunk_block_count
+
+    overlap_start = max(chunk_start, resident_start)
+    overlap_end = min(chunk_end, resident_end)
+    if overlap_start >= overlap_end:
+        return block_ids[:0]
+
+    local_start = overlap_start - resident_start
+    local_end = overlap_end - resident_start
+    return block_ids[local_start:local_end]
+
+
 @dataclass
 class TokenRange:
     """Range of tokens in the sequence dimension."""
@@ -23,6 +53,28 @@ class TokenRange:
             raise ValueError("Token indices must be non-negative")
         if self.start >= self.end:
             raise ValueError(f"Invalid range: [{self.start}, {self.end})")
+
+
+def derive_chunk_block_coords(
+    token_range: Optional[TokenRange],
+    tokens_per_block: int,
+) -> tuple[int, int]:
+    """Derive global chunk block offset and count from a block-aligned token_range."""
+    if token_range is None:
+        return 0, 0
+    if tokens_per_block <= 0:
+        raise ValueError("tokens_per_block must be positive")
+    if (
+        token_range.start % tokens_per_block != 0
+        or token_range.end % tokens_per_block != 0
+    ):
+        raise ValueError(
+            f"token_range [{token_range.start}, {token_range.end}) must be "
+            f"block-aligned with tokens_per_block={tokens_per_block}"
+        )
+    chunk_offset = token_range.start // tokens_per_block
+    chunk_block_count = (token_range.end - token_range.start) // tokens_per_block
+    return chunk_offset, chunk_block_count
 
 
 @dataclass
@@ -44,7 +96,9 @@ class KVSlice:
     """A KV cache slice covering token_range = [start, end) of one request.
 
     Single-slice transfer uses [0, prompt_len) with is_last_slice=True;
-    multi-slice transfers split token_range and mark the last slice.
+    multi-slice (pipelined) transfers split token_range and mark the last slice.
+    For pipelined chunks, token_range is block-aligned and encodes the global
+    chunk position; derive block offset/count via derive_chunk_block_coords().
 
     Per-layer token starts are NOT encoded in token_range — they are derived
     from block count by the sender:
@@ -65,7 +119,7 @@ class KVSlice:
     )  # Physical block IDs per layer group, each np.ndarray(dtype=np.int64)
     is_last_slice: bool = False
     mamba_state_index: Optional[int] = None
-
+    total_blocks: Optional[int] = None
 
 class SessionStatus(Enum):
     """Status of a transfer session.
@@ -104,7 +158,7 @@ class SessionArgsBase:
 
     params: DisaggregatedParams
     # Captured from LlmRequest.prompt_len; needed for SWA stale_end derivation.
-    prompt_len: Optional[int] = None
+    prompt_len: int
     beam_width: int = 1
 
 
@@ -158,7 +212,16 @@ class TxSessionBase(_SessionBase):
         self._sender = sender
 
     @abstractmethod
-    def send(self, slice: KVSlice) -> None: ...
+    def send(self, slice: KVSlice) -> None:
+        """Send a KV slice.
+
+        Args:
+            slice: The KV slice describing which source blocks to send.
+                For pipelined chunks, ``token_range`` is the shared sender-side
+                chunk cursor; each layer group projects it into its own
+                resident/windowed source and destination block ranges.
+        """
+        ...
 
     @abstractmethod
     def wait_complete(self, blocking: bool = True) -> Optional[WaitResult]: ...

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -799,16 +799,12 @@ class Sender(SenderBase):
                 token_range is not None and token_range.start > 0
             )
             chunk_offset, chunk_block_count = (
-                derive_chunk_block_coords(token_range, tpb)
-                if is_chunked
-                else (0, 0)
+                derive_chunk_block_coords(token_range, tpb) if is_chunked else (0, 0)
             )
             # Resident block lists are the suffix of a range ending at the
             # current global chunk boundary when pipelined, or at the full
             # prompt end otherwise. token_start = (suffix_end - n_blocks) * tpb.
-            suffix_end_blocks = (
-                chunk_offset + chunk_block_count if is_chunked else total_blocks
-            )
+            suffix_end_blocks = chunk_offset + chunk_block_count if is_chunked else total_blocks
 
             for (self_lg, self_pi), (peer_lg, peer_pi) in pool_mapping.items():
                 src_block_ids = src_block_ids_per_groups[self_lg]
@@ -823,7 +819,7 @@ class Sender(SenderBase):
                         dst_projectable_blocks,
                         chunk_block_offset=chunk_offset,
                         chunk_block_count=chunk_block_count,
-                        total_blocks=total_blocks,
+                        resident_block_end=total_blocks,
                     )
                 else:
                     dst_block_ids = full_dst_block_ids

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -81,6 +81,7 @@ class RecvReqInfo:
     dst_start_token: Optional[int] = None
     aux_slot: Optional[int] = None
     mamba_state_index: Optional[int] = None
+    # The receiver's own task index; the sender echoes it back in KV_AGENT_RESULT.
     slice_id: Optional[int] = None
     bounce_dst_base: Optional[int] = None
 
@@ -135,7 +136,9 @@ class WriteMeta:
     dst_ptrs: np.ndarray  # dtype=np.int64
     sizes: np.ndarray  # dtype=np.int64
     dst_device_id: Optional[int] = None
-    slice_id: Optional[int] = None
+    sender_slice_id: Optional[int] = None
+    # The peer's task index, taken from RecvReqInfo.slice_id.
+    receiver_slice_id: int = 0
     is_last_slice: bool = False
     meta_type: WriteMetaType = WriteMetaType.KV
     bounce_dst_base: Optional[int] = None
@@ -164,15 +167,31 @@ class AgentResult(Enum):
 
 
 # KV_AGENT_RESULT prefix in one struct frame (was 5 ascii frames serialized/parsed under the
-# GIL per slice per writer): instance_rank, unique_rid, slice_id, is_last, status. The optional
-# bounce tail follows at message[2:].
-_KV_RESULT_PREFIX = struct.Struct("<qqq?B")
+# GIL per slice per writer): instance_rank, unique_rid, sender_slice_id, receiver_slice_id,
+# is_last, status. The optional bounce tail follows at message[2:].
+#
+# sender_slice_id identifies the sender's chunk (one per KVSendTask) and is carried for logging
+# and cross-side correlation only. receiver_slice_id is the peer's own task index, echoed back
+# from RecvReqInfo.slice_id, and is what the receiver uses to resolve the task.
+#
+# This layout is the ctx<->gen wire format and has no version negotiation: the receiver unpacks
+# whatever arrives against its compiled-in struct. Both servers must run matching builds.
+_KV_RESULT_PREFIX = struct.Struct("<qqqq?B")
 _AGENT_RESULT_CODE = {AgentResult.SUCCESS: 0, AgentResult.FAILED: 1}
 _AGENT_RESULT_BY_CODE = {0: AgentResult.SUCCESS, 1: AgentResult.FAILED}
 
+# sender_slice_id value for results emitted without an owning KVSendTask.
+NO_SLICE_ID = -1
+
 
 def _make_kv_result_msg(
-    instance_rank, unique_rid, slice_id, is_last_slice, agent_result, tail=None
+    instance_rank,
+    unique_rid,
+    sender_slice_id,
+    receiver_slice_id,
+    is_last_slice,
+    agent_result,
+    tail=None,
 ):
     """Build a KV_AGENT_RESULT message. ALL result sends (success AND failed/cancelled) must go
     through this single binary frame so the receiver's _KV_RESULT_PREFIX.unpack never hits a stale
@@ -182,7 +201,8 @@ def _make_kv_result_msg(
         _KV_RESULT_PREFIX.pack(
             int(instance_rank),
             int(unique_rid),
-            int(slice_id),
+            int(sender_slice_id),
+            int(receiver_slice_id),
             bool(is_last_slice),
             _AGENT_RESULT_CODE[agent_result],
         ),
@@ -521,8 +541,8 @@ class Sender(SenderBase):
             logger.error(msg)
             write_meta.task.fail(RuntimeError(msg))
             return
-        assert write_meta.slice_id is not None
-        task = session.kv_tasks[write_meta.slice_id]
+        assert write_meta.sender_slice_id is not None
+        task = session.kv_tasks[write_meta.sender_slice_id]
         timer = task._perf_timer
 
         if timer:
@@ -573,7 +593,7 @@ class Sender(SenderBase):
                     detail = (
                         f"KV transfer agent failed: "
                         f"unique_rid={write_meta.unique_rid} "
-                        f"slice={write_meta.slice_id} "
+                        f"sender_slice_id={write_meta.sender_slice_id} "
                         f"peer_rank={write_meta.peer_rank} "
                         f"peer_endpoint={write_meta.peer_endpoint} "
                         f"op={getattr(request, 'op', '?')} "
@@ -616,20 +636,22 @@ class Sender(SenderBase):
 
         if count > write_meta.expected_transfers:
             session.set_exception(
-                f"KV slice {write_meta.slice_id} received more than {write_meta.expected_transfers} transfers"
+                f"KV sender slice {write_meta.sender_slice_id} received more than "
+                f"{write_meta.expected_transfers} transfers"
             )
         elif count == write_meta.expected_transfers:
             if task.is_done:
                 task.status = TaskStatus.ERROR
                 session.set_exception(
-                    f"KV slice {write_meta.slice_id} task already resolved on completion"
+                    f"KV sender slice {write_meta.sender_slice_id} task already resolved on completion"
                 )
             else:
                 task.complete()
 
         logger.debug(
             f"deliver_kv_to_agent completed: unique_rid={write_meta.unique_rid}, "
-            f"slice_id={write_meta.slice_id}, agent_result={agent_result}"
+            f"sender_slice_id={write_meta.sender_slice_id}, "
+            f"receiver_slice_id={write_meta.receiver_slice_id}, agent_result={agent_result}"
         )
 
     def _send_kv_result_to_receiver(
@@ -642,14 +664,17 @@ class Sender(SenderBase):
         """Send a KV_AGENT_RESULT for a worker-thread delivery outcome.
 
         Covers every per-slice outcome (pre-transfer abort, RDMA failure, and
-        success). The receiver always has a single monolithic task, so
-        sender-side chunking is transparent to it and slice_id is always 0.
+        success). Sender-side chunking is transparent to the receiver because
+        the result addresses the receiver by its own task index
+        (``receiver_slice_id``, echoed from ``RecvReqInfo``); the sender's chunk
+        index rides along for logging and cross-side correlation.
         Uses the per-thread DEALER because this runs on worker threads.
         """
         result_msg = _make_kv_result_msg(
             self._instance_rank,
             write_meta.unique_rid,
-            0,  # receiver slice_id: always the single monolithic task
+            write_meta.sender_slice_id if write_meta.sender_slice_id is not None else NO_SLICE_ID,
+            write_meta.receiver_slice_id,
             is_last,
             result,
             tail=tail,
@@ -929,7 +954,8 @@ class Sender(SenderBase):
             peer_rank=peer_ri.instance_rank,
             peer_endpoint=peer_ri.self_endpoint,
             unique_rid=task._unique_rid,
-            slice_id=task.slice_id,
+            sender_slice_id=task.slice_id,
+            receiver_slice_id=req_info.slice_id if req_info.slice_id is not None else 0,
             is_last_slice=task._slice.is_last_slice,
             bounce_dst_base=req_info.bounce_dst_base,
         )
@@ -1088,12 +1114,13 @@ class Sender(SenderBase):
     def _send_failed_result_to_receiver(self, info: RecvReqInfo):
         try:
             peer_ri = self._registrar.get_peer_rank_info(info.instance_name, info.instance_rank)
-            slice_id = info.slice_id if info.slice_id is not None else 0
+            receiver_slice_id = info.slice_id if info.slice_id is not None else 0
             self._get_or_connect_dealer(peer_ri.self_endpoint).send(
                 _make_kv_result_msg(
                     self._instance_rank,
                     info.unique_rid,
-                    slice_id,
+                    NO_SLICE_ID,  # no KVSendTask owns this result
+                    receiver_slice_id,
                     True,  # is_last_slice
                     AgentResult.FAILED,
                 )
@@ -1745,7 +1772,7 @@ class Receiver(ReceiverBase):
                 f"_process_kv_agent_result: unexpected msg_type={message[0]!r}, expected KV_AGENT_RESULT"
             )
             return
-        peer_rank, unique_rid, sender_slice_id, is_last_slice, status_code = (
+        peer_rank, unique_rid, sender_slice_id, receiver_slice_id, is_last_slice, status_code = (
             _KV_RESULT_PREFIX.unpack(message[1])
         )
         from .bounce import decode_result_tail
@@ -1759,6 +1786,7 @@ class Receiver(ReceiverBase):
             return
         session.process_kv_agent_result(
             peer_rank,
+            receiver_slice_id,
             sender_slice_id,
             is_last_slice,
             _AGENT_RESULT_BY_CODE[status_code],
@@ -1877,6 +1905,7 @@ class RxSession(RxSessionBase):
     def process_kv_agent_result(
         self,
         peer_rank: int,
+        receiver_slice_id: int,
         sender_slice_id: int,
         is_last_slice: bool,
         status: AgentResult,
@@ -1884,13 +1913,20 @@ class RxSession(RxSessionBase):
         sizes=None,
         src_base=None,
     ):
+        """Apply one sender chunk's delivery outcome to this session.
+
+        Args:
+            receiver_slice_id: Index of the local task this result resolves.
+            sender_slice_id: The sender's chunk index, for logging only;
+                NO_SLICE_ID when the sender had no task to attribute it to.
+        """
         with self.lock:
-            assert sender_slice_id < len(self._kv_tasks), (
-                f"Receiver got slice_id={sender_slice_id} from sender but only has "
-                f"{len(self._kv_tasks)} receive task(s) for request {self.request_id}. "
-                f"Sender/receiver slice count mismatch."
+            assert receiver_slice_id < len(self._kv_tasks), (
+                f"Receiver got receiver_slice_id={receiver_slice_id} (sender_slice_id="
+                f"{sender_slice_id}) but only has {len(self._kv_tasks)} receive task(s) "
+                f"for request {self.request_id}. Sender/receiver slice count mismatch."
             )
-            task = self._kv_tasks[sender_slice_id]
+            task = self._kv_tasks[receiver_slice_id]
             if status == AgentResult.SUCCESS:
                 from .bounce import scatter_write_result
 
@@ -1910,6 +1946,7 @@ class RxSession(RxSessionBase):
                             success,
                             task=task,
                             peer_rank=peer_rank,
+                            receiver_slice_id=receiver_slice_id,
                             sender_slice_id=sender_slice_id,
                             request_id=request_id,
                             instance_name=instance_name,
@@ -1923,7 +1960,8 @@ class RxSession(RxSessionBase):
                                 task.fail(
                                     RuntimeError(
                                         f"KV bounce scatter failed for request {request_id} "
-                                        f"slice={sender_slice_id}"
+                                        f"receiver_slice_id={receiver_slice_id} "
+                                        f"sender_slice_id={sender_slice_id}"
                                     )
                                 )
                                 return
@@ -1936,12 +1974,14 @@ class RxSession(RxSessionBase):
                             except Exception as e:  # perf is best-effort; never block completion
                                 logger.warning(
                                     f"KV transfer perf logging failed for request {request_id} "
-                                    f"slice={sender_slice_id}: {e}"
+                                    f"receiver_slice_id={receiver_slice_id} "
+                                    f"sender_slice_id={sender_slice_id}: {e}"
                                 )
                             task.complete()
                             logger.debug(
                                 f"KV transfer complete for request {request_id} "
-                                f"slice={sender_slice_id}"
+                                f"receiver_slice_id={receiver_slice_id} "
+                                f"sender_slice_id={sender_slice_id}"
                             )
 
                 scatter_write_result(
@@ -1955,7 +1995,8 @@ class RxSession(RxSessionBase):
                 )
             elif status == AgentResult.FAILED:
                 detail = (
-                    f"KV transfer failed for request {self.request_id} slice={sender_slice_id} "
+                    f"KV transfer failed for request {self.request_id} "
+                    f"receiver_slice_id={receiver_slice_id} sender_slice_id={sender_slice_id} "
                     f"peer_rank={peer_rank} is_last_slice={is_last_slice} "
                     f"(reported by remote agent; see sender-side log for nixl_status)"
                 )

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -549,9 +549,7 @@ class Sender(SenderBase):
                 RuntimeError(f"session {write_meta.unique_rid} {status.value}, transfer aborted")
             )
             # is_last=True ensures the receiver resolves its task event.
-            self._send_kv_result_to_receiver(
-                write_meta, is_last=True, result=AgentResult.FAILED
-            )
+            self._send_kv_result_to_receiver(write_meta, is_last=True, result=AgentResult.FAILED)
             return
 
         from .bounce import build_send_request, encode_result_tail

--- a/tensorrt_llm/_torch/disaggregation/native/transfer.py
+++ b/tensorrt_llm/_torch/disaggregation/native/transfer.py
@@ -38,6 +38,8 @@ from tensorrt_llm._torch.disaggregation.base.transfer import (
     SessionStatus,
     TxSessionBase,
     WaitResult,
+    derive_chunk_block_coords,
+    project_blocks_to_global_chunk,
 )
 from tensorrt_llm._torch.disaggregation.native.auxiliary import AuxBuffer
 from tensorrt_llm._torch.disaggregation.native.messenger import ZMQMessenger, decode_message
@@ -238,14 +240,24 @@ class AuxSendTask(SendTaskBase):
 
 
 class KVSendTask(SendTaskBase):
+    """A per-slice send task within a TxSession.
+
+    Args:
+        kv_slice: The KV slice describing which blocks to transfer.
+            For pipelined chunks, ``token_range`` encodes the shared global
+            chunk cursor in block-aligned token units.
+        params: Disaggregated serving parameters for this request.
+        slice_id: Index of this slice within the session's task list.
+    """
+
     def __init__(
         self,
         kv_slice: KVSlice,
         params: DisaggregatedParams,
         slice_id: int,
-        prompt_len: Optional[int] = None,
+        prompt_len: int,
         beam_width: int = 1,
-    ):
+    ) -> None:
         super().__init__(params)
         self.slice_id = slice_id
         self.transferred_count = 0
@@ -512,6 +524,7 @@ class Sender(SenderBase):
         assert write_meta.slice_id is not None
         task = session.kv_tasks[write_meta.slice_id]
         timer = task._perf_timer
+
         if timer:
             timer.record_push_end(write_meta.peer_rank)
         # Hold session.lock to serialize the INIT→TRANSFERRING transition with
@@ -531,18 +544,13 @@ class Sender(SenderBase):
                 f"in {status.value} state; sending FAILED to receiver"
             )
             # Task may have been enqueued after cancel() already iterated kv_tasks,
-            # so its future was never set by cancel(). Set it here as a fallback.
+            # so its event was never set by cancel(). Set it here as a fallback.
             task.fail(
                 RuntimeError(f"session {write_meta.unique_rid} {status.value}, transfer aborted")
             )
-            self._get_or_connect_dealer(write_meta.peer_endpoint).send(
-                _make_kv_result_msg(
-                    self._instance_rank,
-                    write_meta.unique_rid,
-                    write_meta.slice_id,
-                    True,  # is_last_slice — ensures receiver resolves its task future
-                    AgentResult.FAILED,
-                )
+            # is_last=True ensures the receiver resolves its task event.
+            self._send_kv_result_to_receiver(
+                write_meta, is_last=True, result=AgentResult.FAILED
             )
             return
 
@@ -584,21 +592,20 @@ class Sender(SenderBase):
         if timer:
             timer.record_transfer_end(write_meta.peer_rank)
 
-        ## TODO: just last slice need to send task state?
+        # Intermediate chunk results are sent (not suppressed) so that RDMA
+        # failures propagate to the receiver immediately rather than requiring
+        # a timeout. Only the last chunk carries is_last_slice=True.
         tail = (
             encode_result_tail(write_meta)
             if send_slot_id is not None and agent_result == AgentResult.SUCCESS
             else None
         )
-        result_msg = _make_kv_result_msg(
-            self._instance_rank,
-            write_meta.unique_rid,
-            write_meta.slice_id,
-            write_meta.is_last_slice,
-            agent_result,
+        self._send_kv_result_to_receiver(
+            write_meta,
+            is_last=write_meta.is_last_slice,
+            result=agent_result,
             tail=tail,
         )
-        self._get_or_connect_thread_dealer(write_meta.peer_endpoint).send(result_msg)
 
         if timer:
             timer.record_task_end(write_meta.peer_rank)
@@ -626,6 +633,30 @@ class Sender(SenderBase):
             f"deliver_kv_to_agent completed: unique_rid={write_meta.unique_rid}, "
             f"slice_id={write_meta.slice_id}, agent_result={agent_result}"
         )
+
+    def _send_kv_result_to_receiver(
+        self,
+        write_meta: WriteMeta,
+        is_last: bool,
+        result: AgentResult,
+        tail=None,
+    ) -> None:
+        """Send a KV_AGENT_RESULT for a worker-thread delivery outcome.
+
+        Covers every per-slice outcome (pre-transfer abort, RDMA failure, and
+        success). The receiver always has a single monolithic task, so
+        sender-side chunking is transparent to it and slice_id is always 0.
+        Uses the per-thread DEALER because this runs on worker threads.
+        """
+        result_msg = _make_kv_result_msg(
+            self._instance_rank,
+            write_meta.unique_rid,
+            0,  # receiver slice_id: always the single monolithic task
+            is_last,
+            result,
+            tail=tail,
+        )
+        self._get_or_connect_thread_dealer(write_meta.peer_endpoint).send(result_msg)
 
     @nvtx_range("_deliver_aux_to_agent")
     def _deliver_aux_to_agent(self, write_meta: WriteMeta):
@@ -753,10 +784,49 @@ class Sender(SenderBase):
             dst_block_ids_per_groups = req_info.block_ids_per_layer_groups
             src_block_ids_per_groups = task._slice.block_ids_per_layer_groups
 
-            # Aggregate fragments from all matching pools using numpy concatenation
+            tpb = extractor.page_table.tokens_per_block
+            token_range = task._slice.token_range
+            slice_end = task._prompt_len
+            total_blocks = task._slice.total_blocks
+            if total_blocks is None:
+                total_blocks = (slice_end + tpb - 1) // tpb
+            # A slice is chunked (pipelined) when it is not the last slice or
+            # its block-aligned token_range starts past the sequence beginning.
+            # Only chunked slices need block-space chunk coordinates; a full
+            # transfer's token_range (end = prompt_len + extra) need not be
+            # block-aligned, so avoid deriving/validating it in that case.
+            is_chunked = (not task._slice.is_last_slice) or (
+                token_range is not None and token_range.start > 0
+            )
+            chunk_offset, chunk_block_count = (
+                derive_chunk_block_coords(token_range, tpb)
+                if is_chunked
+                else (0, 0)
+            )
+            # Resident block lists are the suffix of a range ending at the
+            # current global chunk boundary when pipelined, or at the full
+            # prompt end otherwise. token_start = (suffix_end - n_blocks) * tpb.
+            suffix_end_blocks = (
+                chunk_offset + chunk_block_count if is_chunked else total_blocks
+            )
+
             for (self_lg, self_pi), (peer_lg, peer_pi) in pool_mapping.items():
                 src_block_ids = src_block_ids_per_groups[self_lg]
-                dst_block_ids = dst_block_ids_per_groups[peer_lg]
+                full_dst_block_ids = dst_block_ids_per_groups[peer_lg]
+
+                # When sender uses chunking, the receiver sends all dst blocks
+                # in a single RecvReqInfo. Project the global chunk cursor into
+                # each destination layer group's resident/windowed block range.
+                if is_chunked:
+                    dst_projectable_blocks = full_dst_block_ids[:total_blocks]
+                    dst_block_ids = project_blocks_to_global_chunk(
+                        dst_projectable_blocks,
+                        chunk_block_offset=chunk_offset,
+                        chunk_block_count=chunk_block_count,
+                        total_blocks=total_blocks,
+                    )
+                else:
+                    dst_block_ids = full_dst_block_ids
 
                 # Speculative decoding: generation may have one extra draft-token block.
                 block_diff = dst_block_ids.size - src_block_ids.size
@@ -771,15 +841,11 @@ class Sender(SenderBase):
                         f"src/dst block count mismatch: {src_block_ids.size} vs "
                         f"{dst_block_ids.size} (expected diff <= 1)"
                     )
-                tpb = extractor.page_table.tokens_per_block
-                token_range = task._slice.token_range
                 lg_info = extractor.page_table.layer_groups[self_lg]
                 window_size = getattr(lg_info, "sliding_window_size", None)
 
                 # Block lists are the suffix of [..., slice_end); cached prefix
                 # is implicit in their size. token_start = (total_blocks - n) * tpb.
-                slice_end = token_range.end if token_range is not None else 0
-                total_blocks = (slice_end + tpb - 1) // tpb
                 src_beam0_blocks = Sender._beam0_block_count(
                     src_block_ids, total_blocks, task._beam_width
                 )
@@ -794,19 +860,13 @@ class Sender(SenderBase):
                     f"dst beam-0 block list ({dst_beam0_blocks}) exceeds total slice "
                     f"blocks ({total_blocks}); slice_end={slice_end}, tpb={tpb}"
                 )
-                src_start = (total_blocks - src_beam0_blocks) * tpb
-                dst_start = (total_blocks - dst_beam0_blocks) * tpb
+                src_start = (suffix_end_blocks - src_beam0_blocks) * tpb
+                dst_start = (suffix_end_blocks - dst_beam0_blocks) * tpb
                 if req_info.dst_start_token is not None:
                     dst_start = max(dst_start, req_info.dst_start_token)
                 if window_size is not None:
                     # SWA stale_end uses the request prompt_len (not slice_end —
-                    # they differ for non-final slices). prompt_len must be plumbed
-                    # via the session; falling back to slice_end is wrong on
-                    # non-final slices.
-                    assert task._prompt_len is not None, (
-                        "SWA layer requires session.prompt_len; "
-                        "set TxSession(prompt_len=request.prompt_len)."
-                    )
+                    # they differ for non-final slices).
                     stale_end = max(0, (task._prompt_len + 1 - window_size) // tpb)
                     src_start = max(stale_end * tpb, src_start)
                     dst_start = max(stale_end * tpb, dst_start)
@@ -1018,7 +1078,7 @@ class Sender(SenderBase):
             self._save_peer_req_info(info)
             tasks = list(session.kv_tasks)
             # No tasks: no worker will send KV_AGENT_RESULT FAILED to the receiver.
-            # Send it directly to unblock the receiver's TRANSFERRING task future;
+            # Send it directly to unblock the receiver's TRANSFERRING task event;
             # CANCEL_SESSION alone would leave it stuck indefinitely.
             if not tasks and session.status in (SessionStatus.ERROR, SessionStatus.CANCELLED):
                 self._send_failed_result_to_receiver(info)
@@ -1152,9 +1212,9 @@ class TxSession(TxSessionBase):
         request_id: int,
         params: DisaggregatedParams,
         sender: Sender,
+        prompt_len: int,
         aux_buffer: Optional[AuxBuffer] = None,
         timeout_s: Optional[float] = None,
-        prompt_len: Optional[int] = None,
         beam_width: int = 1,
     ):
         super().__init__(
@@ -1195,6 +1255,10 @@ class TxSession(TxSessionBase):
     def status(self) -> SessionStatus:
         if self._terminal_status is not None:
             return self._terminal_status
+        if self._exception is not None or any(t.status == TaskStatus.ERROR for t in self.kv_tasks):
+            return SessionStatus.ERROR
+        if self.aux_task is not None and self.aux_task.status == TaskStatus.ERROR:
+            return SessionStatus.ERROR
         kv_all_transferred = bool(self.kv_tasks) and all(
             t.status == TaskStatus.TRANSFERRED for t in self.kv_tasks
         )
@@ -1746,9 +1810,9 @@ class RxSession(RxSessionBase):
         request_id: int,
         params: DisaggregatedParams,
         receiver: Receiver,
+        prompt_len: int,
         aux_buffer: Optional[AuxBuffer] = None,
         timeout_s: Optional[float] = None,
-        prompt_len: Optional[int] = None,
         beam_width: int = 1,
     ):
         super().__init__(
@@ -1916,8 +1980,8 @@ class RxSession(RxSessionBase):
                 )
 
     def process_aux_agent_result(self, _peer_rank: int, status: AgentResult):
-        # Aux is session-level (not per-slice); expected_transfers is identical
-        # across all kv_tasks, so any task provides the right count.
+        # Aux is session-level (not per-slice); the RxSession's single task's
+        # expected_transfers is the number of sender transfers to wait for.
         with self.lock:
             if not self._kv_tasks:
                 logger.warning(
@@ -2186,7 +2250,18 @@ class TransferWorker:
         self._rank_info.sender_endpoints = endpoints
         self._rank_info.layer_num_per_pp = layer_num_per_pp
 
-    def create_tx_session(self, request: LlmRequest) -> TxSession:
+    def create_tx_session(
+        self,
+        request: LlmRequest,
+    ) -> TxSession:
+        """Create a TxSession for the given request.
+
+        Args:
+            request: The LLM request to create a send session for.
+
+        Returns:
+            A new ``TxSession`` ready to accept ``send()`` calls.
+        """
         params = request.py_disaggregated_params
         assert params is not None
         return TxSession(

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -515,15 +515,11 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
 
         base_slice = self._create_kv_slice(req)
         all_block_ids = base_slice.block_ids_per_layer_groups
-        max_resident_blocks = max((len(ids) for ids in all_block_ids), default=0)
         tpb = self._reuse_adapter.tokens_per_block
-        # prompt_len defines the full logical block span [0, total_blocks) that
-        # chunk offsets and the resident-suffix projection are expressed in.
-        # Resident block lists are a suffix of that span (and are capped to
-        # prompt_len blocks in _create_kv_slice), so total_blocks must never be
-        # smaller than the largest resident layer group.
+        # Keep the full prompt span for destination projection. Source block
+        # lists grow only through the current chunk boundary.
         prompt_blocks = (req.prompt_len + tpb - 1) // tpb
-        total_blocks = max(max_resident_blocks, prompt_blocks)
+        total_blocks = prompt_blocks
 
         chunk_start = min(chunk_start_block, total_blocks)
         chunk_end = min(chunk_end_block, total_blocks)
@@ -533,7 +529,7 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
                 block_ids,
                 chunk_block_offset=chunk_start,
                 chunk_block_count=chunk_block_count,
-                total_blocks=total_blocks,
+                resident_block_end=chunk_end,
             )
             for block_ids in all_block_ids
         ]

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -16,6 +16,7 @@ from tensorrt_llm._torch.disaggregation.base.transfer import (
     TxSessionBase,
     WaitResult,
     get_unique_rid,
+    project_blocks_to_global_chunk,
 )
 from tensorrt_llm._torch.disaggregation.native.bounce import (
     config_from_size as bounce_config_from_size,
@@ -104,6 +105,7 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         # _slice_num_bytes() is this rank's KV shard, so scale by tp_size to get the request total (kv_cache_size),
         # except under attention DP where the local count already is the total.
         self._kv_size_rank_factor = 1 if mapping.enable_attention_dp else max(1, mapping.tp_size)
+        self._enable_pipelined_transfer = cache_transceiver_config.enable_pipelined_transfer
 
         # Sticky role markers; flip True once any session opens, used to short-circuit
         # per-iter tp_allgather when this transceiver never sends/receives.
@@ -457,6 +459,7 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             req.context_phase_params.draft_tokens = draft_tokens
 
     def _get_or_create_send_session(self, req: LlmRequest) -> TxSessionBase:
+        self._ever_had_send_session = True
         rid = get_unique_rid(req)
         assert rid is not None
         if rid not in self._send_sessions:
@@ -480,13 +483,97 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         )
         self._send_reqs[rid] = req
 
+    @property
+    def pipeline_transfer_enabled(self) -> bool:
+        """Whether pipelined prefill-transfer is enabled."""
+        return self._enable_pipelined_transfer
+
+    def _build_prefill_chunk(
+        self,
+        req: LlmRequest,
+    ) -> KVSlice:
+        """Send one prefill chunk's KV data during ongoing prefill.
+
+        Called after each prefill chunk completes, before the next chunk's
+        forward begins. Creates the TxSession on the first call for a request
+        and adds slices incrementally.
+
+        Args:
+            req: The context-only request being prefilled.
+        """
+        assert req.py_beam_width == 1, "beam_width > 1 is not supported for chunked KV transfer"
+        rid = get_unique_rid(req)
+        assert rid is not None
+        self._send_reqs[rid] = req
+
+        chunk_start_pos, chunk_end_pos = req.py_last_context_chunk
+        tpb = self._kv_cache_manager.tokens_per_block
+
+        chunk_start_block = chunk_start_pos // tpb
+        chunk_end_block = (chunk_end_pos + tpb - 1) // tpb
+        is_last_chunk = req.context_remaining_length == 0
+
+        base_slice = self._create_kv_slice(req)
+        all_block_ids = base_slice.block_ids_per_layer_groups
+        max_resident_blocks = max((len(ids) for ids in all_block_ids), default=0)
+        tpb = self._reuse_adapter.tokens_per_block
+        # prompt_len defines the full logical block span [0, total_blocks) that
+        # chunk offsets and the resident-suffix projection are expressed in.
+        # Resident block lists are a suffix of that span (and are capped to
+        # prompt_len blocks in _create_kv_slice), so total_blocks must never be
+        # smaller than the largest resident layer group.
+        prompt_blocks = (req.prompt_len + tpb - 1) // tpb
+        total_blocks = max(max_resident_blocks, prompt_blocks)
+
+        chunk_start = min(chunk_start_block, total_blocks)
+        chunk_end = min(chunk_end_block, total_blocks)
+        chunk_block_count = max(0, chunk_end - chunk_start)
+        chunk_block_ids = [
+            project_blocks_to_global_chunk(
+                block_ids,
+                chunk_block_offset=chunk_start,
+                chunk_block_count=chunk_block_count,
+                total_blocks=total_blocks,
+            )
+            for block_ids in all_block_ids
+        ]
+        chunk_token_range = None
+        if chunk_block_count > 0:
+            chunk_token_range = TokenRange(
+                start=chunk_start * tpb,
+                end=(chunk_start + chunk_block_count) * tpb,
+            )
+
+        return KVSlice(
+            is_last_slice=is_last_chunk,
+            block_ids_per_layer_groups=chunk_block_ids,
+            mamba_state_index=base_slice.mamba_state_index,
+            token_range=chunk_token_range,
+            total_blocks=total_blocks,
+        )
+
     @nvtx_range("KvCacheTransceiverV2.respond_and_send_async")
-    def respond_and_send_async(self, req: LlmRequest):
-        self._ever_had_send_session = True
+    def respond_and_send_async(self, req: LlmRequest) -> None:
+        """Start background KV cache transfer to the generation server.
+
+        Creates (or reuses) a ``TxSession`` and sends a KV slice (monolithic or chunked) for each request.
+
+        Args:
+            req: The completed context request whose KV cache to transfer.
+        """
+        if self.kv_transfer_timeout_ms is not None and req.py_kv_transfer_start_time is None:
+            req.py_kv_transfer_start_time = time.time()
+
         session = self._get_or_create_send_session(req)
-        req.state = LlmRequestState.DISAGG_CONTEXT_TRANS_IN_PROGRESS
-        session.send(self._create_kv_slice(req))
-        self._finalize_send(req, session)
+        if self.pipeline_transfer_enabled:
+            slice = self._build_prefill_chunk(req)
+        else:
+            slice = self._create_kv_slice(req)
+        session.send(slice)
+
+        if slice.is_last_slice:
+            self._finalize_send(req, session)
+            req.state = LlmRequestState.DISAGG_CONTEXT_TRANS_IN_PROGRESS
 
     @nvtx_range("KvCacheTransceiverV2.request_and_receive_sync")
     def request_and_receive_sync(self, req: LlmRequest):
@@ -525,7 +612,17 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             self._recv_reqs.pop(rid, None)
 
     @nvtx_range("KvCacheTransceiverV2.request_and_receive_async")
-    def request_and_receive_async(self, req: LlmRequest):
+    def request_and_receive_async(self, req: LlmRequest) -> None:
+        """Start background KV cache receive from the context server.
+
+        The receiver always uses a single monolithic slice.  Chunking is
+        sender-only: the sender splits its source blocks into chunks and
+        slices the receiver's destination blocks to match each chunk.
+
+        Args:
+            req: The generation request whose KV cache blocks to receive
+                into.
+        """
         self._ever_had_recv_session = True
         rid = get_unique_rid(req)
         if rid in self._recv_sessions:
@@ -548,6 +645,7 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
             self._ctx_need_tp_sync or self._ctx_need_pp_sync
         ):
             return [], []
+
         block_all = at_least_request_num is None
         wait_num = at_least_request_num if not block_all else 0
 

--- a/tensorrt_llm/_torch/disaggregation/transceiver.py
+++ b/tensorrt_llm/_torch/disaggregation/transceiver.py
@@ -492,11 +492,8 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
         self,
         req: LlmRequest,
     ) -> KVSlice:
-        """Send one prefill chunk's KV data during ongoing prefill.
-
-        Called after each prefill chunk completes, before the next chunk's
-        forward begins. Creates the TxSession on the first call for a request
-        and adds slices incrementally.
+        """
+        Create a KVSlice for a prefill chunk. Project the block IDs to the global chunk.
 
         Args:
             req: The context-only request being prefilled.
@@ -515,7 +512,6 @@ class KvCacheTransceiverV2(KvCacheTransceiver):
 
         base_slice = self._create_kv_slice(req)
         all_block_ids = base_slice.block_ids_per_layer_groups
-        tpb = self._reuse_adapter.tokens_per_block
         # Keep the full prompt span for destination projection. Source block
         # lists grow only through the current chunk boundary.
         prompt_blocks = (req.prompt_len + tpb - 1) // tpb

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -2383,7 +2383,8 @@ def create_py_executor_instance(
 
     kv_cache_transceiver = create_kv_cache_transceiver(
         mapping, dist, kv_cache_manager, attention_type,
-        cache_transceiver_config, mamba_cache_manager)
+        cache_transceiver_config, mamba_cache_manager,
+        enable_chunked_prefill=llm_args.enable_chunked_prefill)
 
     waiting_queue_policy = (scheduler_config.waiting_queue_policy
                             if scheduler_config is not None else

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -123,42 +123,45 @@ def get_kv_cache_manager_cls(
 
         # Skip Softmax only changes attention kernels. Hybrid models still
         # need a Mamba-capable cache manager for recurrent state.
+        mixed_manager_source = None
         if use_py_mamba_cache_manager():
-            if kv_cache_config.enable_block_reuse:
-                raise ValueError(
-                    "TRTLLM_USE_PY_MAMBA=1 forces "
-                    "MixedMambaHybridCacheManager, which does not support "
-                    "block reuse. Disable block reuse or unset "
-                    "TRTLLM_USE_PY_MAMBA to use CppMambaHybridCacheManager.")
-            logger.info(
-                "Using MixedMambaHybridCacheManager for hybrid mamba model")
-            return MixedMambaHybridCacheManager
-        if kv_cache_config.enable_block_reuse:
-            return CppMambaHybridCacheManager
-        if (cache_transceiver_config is not None
-                and cache_transceiver_config.transceiver_runtime == "PYTHON"):
-            logger.info("Python transceiver detected; using "
-                        "MixedMambaHybridCacheManager for hybrid mamba model")
-            return MixedMambaHybridCacheManager
-        default_cls = CppMambaHybridCacheManager
-        env_override = os.environ.get('TLLM_MAMBA_MANAGER_PREFERENCE', None)
-        if env_override is not None:
-            if env_override.upper() == 'MIXED':
+            mixed_manager_source = "TRTLLM_USE_PY_MAMBA=1"
+        elif (cache_transceiver_config is not None
+              and cache_transceiver_config.transceiver_runtime == "PYTHON"):
+            mixed_manager_source = "transceiver_runtime='PYTHON'"
+        else:
+            env_override = os.environ.get(
+                'TLLM_MAMBA_MANAGER_PREFERENCE')
+            if env_override is not None and env_override.upper() == 'MIXED':
                 logger.warning(
                     "Environment variable TLLM_MAMBA_MANAGER_PREFERENCE=MIXED overrides the default Mamba cache manager to MixedMambaHybridCacheManager. This may lead to increased memory usage due to lack of block reuse, but can be necessary for disaggregated setups or to avoid potential issues with the C++ manager. Set TLLM_MAMBA_MANAGER_PREFERENCE=CPP to use the CppMambaHybridCacheManager instead, which is the default for non-disaggregated setups without block reuse explicitly disabled."
                 )
-                return MixedMambaHybridCacheManager
-            elif env_override.upper() == 'CPP':
+                mixed_manager_source = "TLLM_MAMBA_MANAGER_PREFERENCE=MIXED"
+            elif env_override is not None and env_override.upper() == 'CPP':
                 logger.warning(
                     "Environment variable TLLM_MAMBA_MANAGER_PREFERENCE=CPP overrides the default Mamba cache manager to CppMambaHybridCacheManager. This enables block reuse and can reduce memory usage, but may not be compatible with disaggregated setups. Set TLLM_MAMBA_MANAGER_PREFERENCE=MIXED to use the MixedMambaHybridCacheManager instead if you encounter issues with the C++ manager or are running in a disaggregated environment."
                 )
                 return CppMambaHybridCacheManager
-            else:
+            elif env_override is not None:
                 logger.warning(
                     f"Unrecognized value for TLLM_MAMBA_MANAGER_PREFERENCE: {env_override}. "
-                    f"Expected 'CPP' or 'MIXED'. Using default {default_cls.__name__}."
+                    "Expected 'CPP' or 'MIXED'. Using default "
+                    "CppMambaHybridCacheManager."
                 )
-        return default_cls
+
+        if mixed_manager_source is not None:
+            if kv_cache_config.enable_block_reuse:
+                raise ValueError(
+                    f"{mixed_manager_source} selects "
+                    "MixedMambaHybridCacheManager, which does not support "
+                    "block reuse. Set KvCacheConfig.enable_block_reuse=False "
+                    "or select CppMambaHybridCacheManager.")
+            logger.info(
+                f"{mixed_manager_source} selects "
+                "MixedMambaHybridCacheManager for hybrid mamba model")
+            return MixedMambaHybridCacheManager
+
+        return CppMambaHybridCacheManager
     elif sparse_attn_config is not None:
         return get_sparse_attn_kv_cache_manager(sparse_attn_config)
     else:

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -2382,8 +2382,12 @@ def create_py_executor_instance(
         mamba_cache_manager = kv_cache_manager
 
     kv_cache_transceiver = create_kv_cache_transceiver(
-        mapping, dist, kv_cache_manager, attention_type,
-        cache_transceiver_config, mamba_cache_manager,
+        mapping,
+        dist,
+        kv_cache_manager,
+        attention_type,
+        cache_transceiver_config,
+        mamba_cache_manager,
         enable_chunked_prefill=llm_args.enable_chunked_prefill)
 
     waiting_queue_policy = (scheduler_config.waiting_queue_policy

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
@@ -37,7 +37,8 @@ def create_kv_cache_transceiver(
         kv_cache_manager: KVCacheManager,
         attention_type: AttentionTypeCpp,
         cache_transceiver_config: CacheTransceiverConfig,
-        mamba_cache_manager: Optional[BaseMambaCacheManager] = None):
+        mamba_cache_manager: Optional[BaseMambaCacheManager] = None,
+        enable_chunked_prefill: bool = False):
     if cache_transceiver_config is None or cache_transceiver_config.backend is None:
         logger.info("cache_transceiver is disabled")
         return None
@@ -66,16 +67,47 @@ def create_kv_cache_transceiver(
             "MPI CacheTransceiver is deprecated, UCX or NIXL is recommended")
     elif cache_transceiver_config.backend == "UCX":
         logger.info(
-            f"Using UCX kv-cache transceiver. If your devices are not in the same domain, please consider setting "
-            f"UCX_CUDA_IPC_ENABLE_MNNVL=n, UCX_RNDV_SCHEME=put_zcopy and/or unset UCX_NET_DEVICES upon server "
-            f"hangs or lower-than-expected performance.")
+            "Using UCX kv-cache transceiver. If your devices are not in the same domain, please consider setting "
+            "UCX_CUDA_IPC_ENABLE_MNNVL=n, UCX_RNDV_SCHEME=put_zcopy and/or unset UCX_NET_DEVICES upon server "
+            "hangs or lower-than-expected performance.")
+
+    if (cache_transceiver_config.enable_pipelined_transfer
+            and not enable_chunked_prefill):
+        raise ValueError(
+            "enable_chunked_prefill is required when enable_pipelined_transfer is set.")
+    # Auto-select Python transceiver when enable_pipelined_transfer is set,
+    # since the C++ transceiver does not support pipelined transfer.
+    # Only applies to NIXL/DEFAULT backends (the Python transceiver
+    # does not support UCX, MPI, or MOONCAKE).
+    runtime = cache_transceiver_config.transceiver_runtime
+    use_python = runtime == "PYTHON"
+    if (runtime is None
+            and cache_transceiver_config.enable_pipelined_transfer):
+        if cache_transceiver_config.backend in (None, "DEFAULT", "NIXL"):
+            logger.warning(
+                "enable_pipelined_transfer is set; auto-selecting the Python "
+                "transceiver instead of the C++ transceiver to enable "
+                "pipelined KV cache transfer. "
+                "Set transceiver_runtime='CPP' to disable this auto-selection.")
+            use_python = True
+        else:
+            raise ValueError(
+                f"enable_pipelined_transfer is set but backend "
+                f"'{cache_transceiver_config.backend}' requires the C++ "
+                f"transceiver, which does not support pipelined transfer. Use NIXL backend to "
+                f"enable pipelined transfer.")
+    elif (runtime == "CPP"
+          and cache_transceiver_config.enable_pipelined_transfer):
+        raise ValueError(
+            "enable_pipelined_transfer is set but transceiver_runtime='CPP' "
+            "explicitly disables Python auto-selection. Use transceiver_runtime='PYTHON' to enable pipelined transfer.")
 
     # Select transceiver implementation based on transceiver_runtime
     # transceiver_runtime == None or "CPP" -> use C++ transceiver (default)
     # transceiver_runtime == "PYTHON" -> use Python transceiver
-    if cache_transceiver_config.transceiver_runtime == "PYTHON":
+    if use_python:
         # Python transceiver currently only supports NIXL and DEFAULT backend
-        if cache_transceiver_config.backend not in ("DEFAULT", "NIXL"):
+        if cache_transceiver_config.backend not in (None, "DEFAULT", "NIXL"):
             raise ValueError(
                 f"Python transceiver currently only supports NIXL or DEFAULT backend, "
                 f"got {cache_transceiver_config.backend}. "
@@ -94,6 +126,11 @@ def create_kv_cache_transceiver(
 
 
 class KvCacheTransceiver(ABC):
+
+    @property
+    def pipeline_transfer_enabled(self) -> bool:
+        """Whether pipelined prefill-transfer is enabled."""
+        return False
 
     @abstractmethod
     def respond_and_send_async(self, req: LlmRequest):

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
@@ -74,15 +74,26 @@ def create_kv_cache_transceiver(
     if (cache_transceiver_config.enable_pipelined_transfer
             and not enable_chunked_prefill):
         raise ValueError(
-            "enable_chunked_prefill is required when enable_pipelined_transfer is set.")
+            "enable_chunked_prefill is required when enable_pipelined_transfer is set."
+        )
+    is_kv_cache_sender = getenv("TRTLLM_DISAGG_ROLE") != "generation"
+    if (cache_transceiver_config.enable_pipelined_transfer
+            and is_kv_cache_sender and mapping.pp_size != 1):
+        raise ValueError(
+            "pipeline_parallel_size=1 is required when enable_pipelined_transfer is set."
+        )
+    if (cache_transceiver_config.enable_pipelined_transfer
+            and cache_transceiver_config.kv_cache_bounce_size_mb > 0):
+        raise ValueError(
+            "kv_cache_bounce_size_mb must be 0 when enable_pipelined_transfer is set."
+        )
     # Auto-select Python transceiver when enable_pipelined_transfer is set,
     # since the C++ transceiver does not support pipelined transfer.
     # Only applies to NIXL/DEFAULT backends (the Python transceiver
     # does not support UCX, MPI, or MOONCAKE).
     runtime = cache_transceiver_config.transceiver_runtime
     use_python = runtime == "PYTHON"
-    if (runtime is None
-            and cache_transceiver_config.enable_pipelined_transfer):
+    if (runtime is None and cache_transceiver_config.enable_pipelined_transfer):
         if cache_transceiver_config.backend in (None, "DEFAULT", "NIXL"):
             logger.warning(
                 "enable_pipelined_transfer is set; auto-selecting the Python "
@@ -100,7 +111,8 @@ def create_kv_cache_transceiver(
           and cache_transceiver_config.enable_pipelined_transfer):
         raise ValueError(
             "enable_pipelined_transfer is set but transceiver_runtime='CPP' "
-            "explicitly disables Python auto-selection. Use transceiver_runtime='PYTHON' to enable pipelined transfer.")
+            "explicitly disables Python auto-selection. Use transceiver_runtime='PYTHON' to enable pipelined transfer."
+        )
 
     # Select transceiver implementation based on transceiver_runtime
     # transceiver_runtime == None or "CPP" -> use C++ transceiver (default)

--- a/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
+++ b/tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py
@@ -11,13 +11,74 @@ from tensorrt_llm.mapping import Mapping
 
 from .llm_request import LlmRequest
 from .mamba_cache_manager import (BaseMambaCacheManager,
-                                  CppMambaHybridCacheManager)
+                                  CppMambaHybridCacheManager,
+                                  MambaHybridCacheManager,
+                                  MixedMambaHybridCacheManager)
 from .resource_manager import KVCacheManager
 
 CacheTransceiverCpp = tensorrt_llm.bindings.internal.batch_manager.CacheTransceiver
 AttentionTypeCpp = tensorrt_llm.bindings.internal.batch_manager.AttentionType
 CacheTransBufferManagerCpp = tensorrt_llm.bindings.internal.batch_manager.CacheTransBufferManager
 BackendTypeCpp = tensorrt_llm.bindings.executor.CacheTransceiverBackendType
+
+
+def resolve_cache_transceiver_config(
+        cache_transceiver_config: Optional[CacheTransceiverConfig]) -> None:
+    """Resolve defaults and validate runtime-independent configuration."""
+    if cache_transceiver_config is None or cache_transceiver_config.backend is None:
+        return
+
+    if cache_transceiver_config.backend == "DEFAULT":
+        # NIXL is the default backend. Legacy environment variables override it
+        # in priority order.
+        cache_transceiver_config.backend = "NIXL"
+        backend_env_vars = [
+            ("TRTLLM_USE_NIXL_KVCACHE", "NIXL"),
+            ("TRTLLM_USE_UCX_KVCACHE", "UCX"),
+            ("TRTLLM_USE_MOONCAKE_KVCACHE", "MOONCAKE"),
+            ("TRTLLM_USE_MPI_KVCACHE", "MPI"),
+        ]
+        for env_var, backend in backend_env_vars:
+            if getenv(env_var) == "1":
+                logger.warning(
+                    f"{env_var}=1 is set, but it's recommended to set cache_transceiver_config.backend in yaml config"
+                )
+                cache_transceiver_config.backend = backend
+                break
+
+    runtime = cache_transceiver_config.transceiver_runtime
+    enable_pipelined_transfer = cache_transceiver_config.enable_pipelined_transfer
+    if runtime is None and enable_pipelined_transfer:
+        if cache_transceiver_config.backend != "NIXL":
+            raise ValueError(
+                f"enable_pipelined_transfer is set but backend "
+                f"'{cache_transceiver_config.backend}' requires the C++ "
+                f"transceiver, which does not support pipelined transfer. Use NIXL backend to "
+                f"enable pipelined transfer.")
+        logger.warning(
+            "enable_pipelined_transfer is set; auto-selecting the Python "
+            "transceiver instead of the C++ transceiver to enable "
+            "pipelined KV cache transfer. "
+            "Set transceiver_runtime='CPP' to disable this auto-selection.")
+        cache_transceiver_config.transceiver_runtime = "PYTHON"
+    elif runtime == "CPP" and enable_pipelined_transfer:
+        raise ValueError(
+            "enable_pipelined_transfer is set but transceiver_runtime='CPP' "
+            "explicitly disables Python auto-selection. Use transceiver_runtime='PYTHON' to enable pipelined transfer."
+        )
+
+    if (cache_transceiver_config.transceiver_runtime == "PYTHON"
+            and cache_transceiver_config.backend != "NIXL"):
+        raise ValueError(
+            f"Python transceiver currently only supports NIXL backend, "
+            f"got {cache_transceiver_config.backend}. "
+            f"Please use transceiver_runtime='CPP' for MPI, UCX, or MOONCAKE backends."
+        )
+    if (enable_pipelined_transfer
+            and cache_transceiver_config.kv_cache_bounce_size_mb > 0):
+        raise ValueError(
+            "kv_cache_bounce_size_mb must be 0 when enable_pipelined_transfer is set."
+        )
 
 
 def mapping_to_world_config(mapping: Mapping) -> WorldConfig:
@@ -39,28 +100,10 @@ def create_kv_cache_transceiver(
         cache_transceiver_config: CacheTransceiverConfig,
         mamba_cache_manager: Optional[BaseMambaCacheManager] = None,
         enable_chunked_prefill: bool = False):
+    resolve_cache_transceiver_config(cache_transceiver_config)
     if cache_transceiver_config is None or cache_transceiver_config.backend is None:
         logger.info("cache_transceiver is disabled")
         return None
-
-    if cache_transceiver_config.backend == "DEFAULT":
-        # When cache_transceiver_config.backend is not set, fallback to env_vars settings
-        # NIXL is the default backend for non hybrid models
-        cache_transceiver_config.backend = "NIXL"
-        # Ordered by priority
-        env_vars = [
-            ("TRTLLM_USE_NIXL_KVCACHE", "NIXL"),
-            ("TRTLLM_USE_UCX_KVCACHE", "UCX"),
-            ("TRTLLM_USE_MOONCAKE_KVCACHE", "MOONCAKE"),
-            ("TRTLLM_USE_MPI_KVCACHE", "MPI"),
-        ]
-        for env_var, be_type in env_vars:
-            if getenv(env_var) == "1":
-                logger.warning(
-                    f"{env_var}=1 is set, but it's recommended to set cache_transceiver_config.backend in yaml config"
-                )
-                cache_transceiver_config.backend = be_type
-                break
 
     if cache_transceiver_config.backend == "MPI":
         logger.warning(
@@ -82,52 +125,21 @@ def create_kv_cache_transceiver(
         raise ValueError(
             "pipeline_parallel_size=1 is required when enable_pipelined_transfer is set."
         )
-    if (cache_transceiver_config.enable_pipelined_transfer
-            and cache_transceiver_config.kv_cache_bounce_size_mb > 0):
-        raise ValueError(
-            "kv_cache_bounce_size_mb must be 0 when enable_pipelined_transfer is set."
-        )
-    # Auto-select Python transceiver when enable_pipelined_transfer is set,
-    # since the C++ transceiver does not support pipelined transfer.
-    # Only applies to NIXL/DEFAULT backends (the Python transceiver
-    # does not support UCX, MPI, or MOONCAKE).
-    runtime = cache_transceiver_config.transceiver_runtime
-    use_python = runtime == "PYTHON"
-    if (runtime is None and cache_transceiver_config.enable_pipelined_transfer):
-        if cache_transceiver_config.backend in (None, "DEFAULT", "NIXL"):
-            logger.warning(
-                "enable_pipelined_transfer is set; auto-selecting the Python "
-                "transceiver instead of the C++ transceiver to enable "
-                "pipelined KV cache transfer. "
-                "Set transceiver_runtime='CPP' to disable this auto-selection.")
-            use_python = True
-        else:
-            raise ValueError(
-                f"enable_pipelined_transfer is set but backend "
-                f"'{cache_transceiver_config.backend}' requires the C++ "
-                f"transceiver, which does not support pipelined transfer. Use NIXL backend to "
-                f"enable pipelined transfer.")
-    elif (runtime == "CPP"
-          and cache_transceiver_config.enable_pipelined_transfer):
-        raise ValueError(
-            "enable_pipelined_transfer is set but transceiver_runtime='CPP' "
-            "explicitly disables Python auto-selection. Use transceiver_runtime='PYTHON' to enable pipelined transfer."
-        )
 
     # Select transceiver implementation based on transceiver_runtime
     # transceiver_runtime == None or "CPP" -> use C++ transceiver (default)
     # transceiver_runtime == "PYTHON" -> use Python transceiver
-    if use_python:
-        # Python transceiver currently only supports NIXL and DEFAULT backend
-        if cache_transceiver_config.backend not in (None, "DEFAULT", "NIXL"):
+    if cache_transceiver_config.transceiver_runtime == "PYTHON":
+        if (isinstance(kv_cache_manager, MambaHybridCacheManager)
+                and not isinstance(kv_cache_manager,
+                                   MixedMambaHybridCacheManager)):
             raise ValueError(
-                f"Python transceiver currently only supports NIXL or DEFAULT backend, "
-                f"got {cache_transceiver_config.backend}. "
-                f"Please use transceiver_runtime='CPP' for MPI, UCX, or MOONCAKE backends."
-            )
+                "Python transceiver requires MixedMambaHybridCacheManager "
+                f"for hybrid models, got {type(kv_cache_manager).__name__}.")
         from tensorrt_llm._torch.disaggregation.transceiver import \
             KvCacheTransceiverV2
         logger.info("Using KvCacheTransceiverV2")
+        # MixedMambaHybridCacheManager contains both the KV and Mamba pools.
         return KvCacheTransceiverV2(mapping, dist, kv_cache_manager,
                                     cache_transceiver_config)
 

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -7689,10 +7689,9 @@ class PyExecutor:
 
             request = requests_in_transfer[request_id]
             if request_id in failed_req_ids:
-                self._pending_ctx_transfer_failures.add(request_id)
-                self.async_transfer_manager.end_transfer(request)
-            else:
-                self._end_transfer_and_maybe_terminate(request)
+                # Past the context phase: writing the error state here is safe
+                request.state = LlmRequestState.DISAGG_TRANS_ERROR
+            self._end_transfer_and_maybe_terminate(request)
 
         # The set of requests in transfer may have changed since we terminated some requests.
         requests_in_transfer = self.async_transfer_manager.requests_in_transfer(

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -4750,14 +4750,14 @@ class PyExecutor:
                 and self.kv_cache_transceiver.pipeline_transfer_enabled):
             if request.py_beam_width != 1:
                 raise ValueError(
-                    "beam_width > 1 is not supported when enable_pipelined_transfer is set.")
+                    "beam_width > 1 is not supported when enable_pipelined_transfer is set."
+                )
 
             disagg_params = request.py_disaggregated_params
             if (disagg_params is None or disagg_params.schedule_style
                     != DisaggScheduleStyle.GENERATION_FIRST):
-                raise ValueError(
-                    "schedule_style must be generation_first when "
-                    "enable_pipelined_transfer is set.")
+                raise ValueError("schedule_style must be generation_first when "
+                                 "enable_pipelined_transfer is set.")
 
         # Perform sampler-specific validation
         self.sampler.validate_request(request)
@@ -5704,7 +5704,7 @@ class PyExecutor:
         if self.kv_cache_transceiver:
             for req in scheduled_requests:
                 if req.is_context_only_request and not req.is_finished_due_to_cancellation:
-                    if req.is_context_finished or req.is_finished_due_to_length:   # noqa: E501
+                    if req.is_context_finished or req.is_finished_due_to_length:
                         # Forward is done for this request — release the
                         # IndexMapper slot so new requests can reuse it.
                         # KV blocks stay allocated for the upcoming transfer.

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -4754,7 +4754,7 @@ class PyExecutor:
                 )
 
             disagg_params = request.py_disaggregated_params
-            if (disagg_params is None or disagg_params.schedule_style
+            if (disagg_params is not None and disagg_params.schedule_style
                     != DisaggScheduleStyle.GENERATION_FIRST):
                 raise ValueError("schedule_style must be generation_first when "
                                  "enable_pipelined_transfer is set.")

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -4746,6 +4746,19 @@ class PyExecutor:
         # Check token ID ranges
         self._validate_token_id_range(request)
 
+        if (not self.is_warmup and self.kv_cache_transceiver is not None
+                and self.kv_cache_transceiver.pipeline_transfer_enabled):
+            if request.py_beam_width != 1:
+                raise ValueError(
+                    "beam_width > 1 is not supported when enable_pipelined_transfer is set.")
+
+            disagg_params = request.py_disaggregated_params
+            if (disagg_params is None or disagg_params.schedule_style
+                    != DisaggScheduleStyle.GENERATION_FIRST):
+                raise ValueError(
+                    "schedule_style must be generation_first when "
+                    "enable_pipelined_transfer is set.")
+
         # Perform sampler-specific validation
         self.sampler.validate_request(request)
 
@@ -5690,22 +5703,27 @@ class PyExecutor:
 
         if self.kv_cache_transceiver:
             for req in scheduled_requests:
-                if req.is_context_only_request and (
-                        req.is_context_finished or req.is_finished_due_to_length
-                ) and not req.is_finished_due_to_cancellation:
-                    # Forward is done for this request — release the
-                    # IndexMapper slot so new requests can reuse it.
-                    # KV blocks stay allocated for the upcoming transfer.
-                    if hasattr(self.kv_cache_manager, 'release_index_slot'):
-                        self.kv_cache_manager.release_index_slot(
-                            req.py_request_id)
-                    # Order is important here: we need to start the transfer before responding
-                    # to make sure the blocks are stored for reuse before they are sent.
-                    self.async_transfer_manager.start_transfer(req)
-                    self.kv_cache_transceiver.respond_and_send_async(req)
+                if req.is_context_only_request and not req.is_finished_due_to_cancellation:
+                    if req.is_context_finished or req.is_finished_due_to_length:   # noqa: E501
+                        # Forward is done for this request — release the
+                        # IndexMapper slot so new requests can reuse it.
+                        # KV blocks stay allocated for the upcoming transfer.
+                        if hasattr(self.kv_cache_manager, 'release_index_slot'):
+                            self.kv_cache_manager.release_index_slot(
+                                req.py_request_id)
+                        # Order matters: start_transfer commits the request's blocks to the reuse
+                        # tree and pins them, and must run before respond_and_send_async sends the
+                        # final KV slice and (for the Python transceiver) transitions the request toward completion.
+                        self.async_transfer_manager.start_transfer(req)
 
-                    if self.kv_cache_transceiver.kv_transfer_timeout_ms is not None:
-                        req.py_kv_transfer_start_time = time.time()
+                        # send KV slice for monolithic transfer or last chunk of pipelined transfer
+                        self.kv_cache_transceiver.respond_and_send_async(req)
+
+                        if self.kv_cache_transceiver.kv_transfer_timeout_ms is not None and req.py_kv_transfer_start_time is None:
+                            req.py_kv_transfer_start_time = time.time()
+                    elif self.kv_cache_transceiver.pipeline_transfer_enabled:
+                        # send intermediate chunk for pipelined transfer
+                        self.kv_cache_transceiver.respond_and_send_async(req)
 
         if self.kv_connector_manager:
             if not self.disable_overlap_scheduler:

--- a/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor_creator.py
@@ -41,6 +41,7 @@ from .config_utils import is_hybrid_linear
 from .connectors.kv_cache_connector import KvCacheConnectorManager
 from .dwdp import DwdpManager
 from .guided_decoder import CapturableGuidedDecoder, GuidedDecoder
+from .kv_cache_transceiver import resolve_cache_transceiver_config
 from .model_engine import PyTorchModelEngine
 from .model_loader import ModelLoader, _construct_checkpoint_loader
 from .py_executor import PyExecutor
@@ -664,6 +665,9 @@ def create_py_executor(
     max_seq_len = model_engine_max_seq_len
     max_num_tokens = model_engine.max_num_tokens
     sparse_attention_config = model_engine.sparse_attention_config
+
+    # Resolve this before cache reuse and cache manager selection consume it.
+    resolve_cache_transceiver_config(cache_transceiver_config)
 
     # Set default value for cache_transceiver_config.max_tokens_in_buffer
     if cache_transceiver_config and cache_transceiver_config.max_tokens_in_buffer is None:

--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -1676,9 +1676,8 @@ def disaggregated(
     if "--config_file" in sys.argv:
         logger.warning("--config_file is deprecated, use --config instead.")
 
-    disagg_cfg = parse_disagg_config_file(config_file)
-    if schedule_style:
-        disagg_cfg.schedule_style = schedule_style
+    disagg_cfg = parse_disagg_config_file(
+        config_file, schedule_style_override=schedule_style)
 
     # Generate a shared deployment ID for all workers in this disagg deployment.
     # Inherited by child processes via env var; used for deduplication at query time.

--- a/tensorrt_llm/llmapi/disagg_utils.py
+++ b/tensorrt_llm/llmapi/disagg_utils.py
@@ -4,6 +4,7 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from enum import IntEnum
+from os import PathLike
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import yaml
@@ -28,6 +29,40 @@ def validate_config_bool(value: Any, field_name: str) -> bool:
         return value
     raise ValueError(
         f"{field_name} must be a boolean, got {type(value).__name__}")
+
+
+def _validate_disagg_config(schedule_style: str, context_servers: dict,
+                            generation_servers: dict) -> None:
+    valid_schedule_styles = {"context_first", "generation_first"}
+    if schedule_style not in valid_schedule_styles:
+        raise ValueError(
+            f"schedule_style must be one of {sorted(valid_schedule_styles)}, "
+            f"got {schedule_style!r}")
+
+    for server_group, server_config in (
+        ("context_servers", context_servers),
+        ("generation_servers", generation_servers),
+    ):
+        cache_transceiver_config = server_config.get(
+            "cache_transceiver_config")
+        if cache_transceiver_config is None:
+            continue
+        if not isinstance(cache_transceiver_config, dict):
+            raise ValueError(
+                f"{server_group}.cache_transceiver_config must be a mapping, "
+                f"got {type(cache_transceiver_config).__name__}")
+        if "enable_pipelined_transfer" not in cache_transceiver_config:
+            continue
+        enable_pipelined_transfer = validate_config_bool(
+            cache_transceiver_config["enable_pipelined_transfer"],
+            f"{server_group}.cache_transceiver_config.enable_pipelined_transfer"
+        )
+        if (enable_pipelined_transfer
+                and schedule_style != "generation_first"):
+            raise ValueError(
+                f"{server_group}.cache_transceiver_config."
+                "enable_pipelined_transfer=True requires top-level "
+                "schedule_style='generation_first'.")
 
 
 class ServerRole(IntEnum):
@@ -165,11 +200,17 @@ def get_ctx_gen_server_addrs(
     return ctx_server_urls, gen_server_urls
 
 
-def parse_disagg_config_file(yaml_config_file: str):
+def parse_disagg_config_file(yaml_config_file: str | PathLike[str],
+                             schedule_style_override: Optional[str] = None):
 
     with open(yaml_config_file, 'r') as file:
 
         config = yaml.safe_load(file)
+        if config is None:
+            raise ValueError(
+                f"Disaggregated config file is empty: {yaml_config_file}")
+        if schedule_style_override is not None:
+            config["schedule_style"] = schedule_style_override
 
         disagg_server_config = extract_disagg_cfg(**config)
 
@@ -212,6 +253,9 @@ def extract_disagg_cfg(hostname: str = 'localhost',
                 # Inherit the value from the top-level
                 servers[key] = value
 
+    _validate_disagg_config(schedule_style, context_servers,
+                            generation_servers)
+
     server_configs = []
     disagg_cluster_config = None
     ctx_router_config = extract_router_config(context_servers)
@@ -237,8 +281,7 @@ def extract_disagg_cfg(hostname: str = 'localhost',
                                 disagg_cluster_config)
     if node_id is not None:
         config.node_id = node_id
-    if schedule_style:
-        config.schedule_style = schedule_style
+    config.schedule_style = schedule_style
     config.allow_request_chat_template = validate_config_bool(
         allow_request_chat_template, "allow_request_chat_template")
     config.gen_strip_message_history = gen_strip_message_history

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3727,7 +3727,8 @@ class CacheTransceiverConfig(StrictBaseModel, PybindMirror):
         default=False,
         description="When True, start transferring each prefill chunk's KV cache "
         "as soon as its prefill completes, overlapping GPU compute "
-        "with RDMA transfer. Requires enable_chunked_prefill=True and schedule_style=generation_first.")
+        "with cache transfer. Requires enable_chunked_prefill=True and "
+        "schedule_style=generation_first and pipeline_parallel_size=1.")
 
     def _to_pybind(self):
         # enable_pipelined_transfer is consumed by the Python transceiver only and has no C++ counterpart.

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -3723,7 +3723,14 @@ class CacheTransceiverConfig(StrictBaseModel, PybindMirror):
         "Per-region size in MiB of the native-disagg KV-cache bounce buffer (one for send, one for recv). Bounce coalesces a request's scattered per-block KV into one contiguous fabric-VMM buffer and issues a single multi-rail NIXL write. The size doubles as the on/off switch: 0 (default) keeps the per-block path, >0 enables bounce at that capacity. Only used by the Python (v2) transceiver."
     )
 
+    enable_pipelined_transfer: bool = Field(
+        default=False,
+        description="When True, start transferring each prefill chunk's KV cache "
+        "as soon as its prefill completes, overlapping GPU compute "
+        "with RDMA transfer. Requires enable_chunked_prefill=True and schedule_style=generation_first.")
+
     def _to_pybind(self):
+        # enable_pipelined_transfer is consumed by the Python transceiver only and has no C++ counterpart.
         return _CacheTransceiverConfig(
             backend=_CacheTransceiverBackendType.from_string(self.backend),
             max_tokens_in_buffer=self.max_tokens_in_buffer,

--- a/tensorrt_llm/usage/llm_args_golden_manifest.json
+++ b/tensorrt_llm/usage/llm_args_golden_manifest.json
@@ -151,6 +151,13 @@
     },
     {
       "allowed_values": [],
+      "annotation": "<class 'bool'>",
+      "converter": "",
+      "kind": "value",
+      "path": "cache_transceiver_config.enable_pipelined_transfer"
+    },
+    {
+      "allowed_values": [],
       "annotation": "<class 'int'>",
       "converter": "",
       "kind": "value",
@@ -2652,6 +2659,13 @@
       "converter": "",
       "kind": "categorical",
       "path": "cache_transceiver_config.backend"
+    },
+    {
+      "allowed_values": [],
+      "annotation": "<class 'bool'>",
+      "converter": "",
+      "kind": "value",
+      "path": "cache_transceiver_config.enable_pipelined_transfer"
     },
     {
       "allowed_values": [],

--- a/tests/integration/defs/accuracy/test_disaggregated_serving.py
+++ b/tests/integration/defs/accuracy/test_disaggregated_serving.py
@@ -738,6 +738,54 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
                                       self.MODEL_PATH) as llm:
             run_accuracy_test(llm, self.MODEL_NAME, ["GSM8K"])
 
+    @skip_pre_hopper
+    @pytest.mark.skip_less_device(2)
+    @parametrize_with_ids("enable_block_reuse", [True, False])
+    @parametrize_with_ids("disable_overlap_scheduler", [True, False])
+    def test_pipelined_kv_transfer_nixl_python_accuracy(self,
+                                                      enable_block_reuse: bool,
+                                                      disable_overlap_scheduler: bool):
+        """Test pipelined KV transfer accuracy using Python transceiver and C++ KVCacheManager."""
+        kv_cache_config = {
+            "use_kv_cache_manager_v2": False,
+            "enable_block_reuse": enable_block_reuse,
+        }
+        cache_transceiver_config = {
+            "backend": "NIXL",
+            "transceiver_runtime": "PYTHON",
+            "max_tokens_in_buffer": 4096,
+            "enable_pipelined_transfer": True,
+        }
+        ctx_server_config = {
+            "max_num_tokens": 256, # cap prefill chunk size
+            "disable_overlap_scheduler": disable_overlap_scheduler,
+            "kv_cache_config": dict(kv_cache_config),
+            "cache_transceiver_config": dict(cache_transceiver_config),
+            "enable_chunked_prefill": True,
+        }
+        gen_server_config = {
+            "disable_overlap_scheduler": disable_overlap_scheduler,
+            "kv_cache_config": dict(kv_cache_config),
+            "cache_transceiver_config": dict(cache_transceiver_config),
+            "enable_chunked_prefill": True,
+        }
+        disaggregated_server_config = {
+            "hostname": "localhost",
+            "backend": "pytorch",
+            "schedule_style": "generation_first",
+
+            "context_servers": {
+                "num_instances": 1,
+            },
+            "generation_servers": {
+                "num_instances": 1,
+            },
+        }
+        with launch_disaggregated_llm(disaggregated_server_config,
+                                      ctx_server_config, gen_server_config,
+                                      self.MODEL_PATH) as llm:
+            run_accuracy_test(llm, self.MODEL_NAME, ["GSM8K"])
+
     @pytest.mark.skip_less_device(2)
     def test_ngram(self):
         speculative_decoding_config = {

--- a/tests/integration/defs/accuracy/test_disaggregated_serving.py
+++ b/tests/integration/defs/accuracy/test_disaggregated_serving.py
@@ -742,9 +742,8 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
     @pytest.mark.skip_less_device(2)
     @parametrize_with_ids("enable_block_reuse", [True, False])
     @parametrize_with_ids("disable_overlap_scheduler", [True, False])
-    def test_pipelined_kv_transfer_nixl_python_accuracy(self,
-                                                      enable_block_reuse: bool,
-                                                      disable_overlap_scheduler: bool):
+    def test_pipelined_kv_transfer_nixl_python_accuracy(
+            self, enable_block_reuse: bool, disable_overlap_scheduler: bool):
         """Test pipelined KV transfer accuracy using Python transceiver and C++ KVCacheManager."""
         kv_cache_config = {
             "use_kv_cache_manager_v2": False,
@@ -757,7 +756,7 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
             "enable_pipelined_transfer": True,
         }
         ctx_server_config = {
-            "max_num_tokens": 256, # cap prefill chunk size
+            "max_num_tokens": 256,  # cap prefill chunk size
             "disable_overlap_scheduler": disable_overlap_scheduler,
             "kv_cache_config": dict(kv_cache_config),
             "cache_transceiver_config": dict(cache_transceiver_config),
@@ -773,7 +772,6 @@ class TestLlama3_1_8BInstruct(LlmapiAccuracyTestHarness):
             "hostname": "localhost",
             "backend": "pytorch",
             "schedule_style": "generation_first",
-
             "context_servers": {
                 "num_instances": 1,
             },

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -23,10 +23,10 @@ l0_dgx_b200:
   - llmapi/test_llm_api_pytorch_bart.py::test_bart_pytorch_generate_encoder_decoder_end_to_end[bf16-kv-v1-cuda-graph-off-greedy-tp2-bart-large-cnn]
   - llmapi/test_llm_api_pytorch_bart.py::test_bart_pytorch_generate_encoder_decoder_end_to_end[bf16-kv-v1-cuda-graph-on-greedy-tp2-bart-large-cnn]
   # ------------- Disaggregated Serving: Pipelined KV Transfer (multi-GPU) ---------------
-  - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_pipelined_kv_transfer_nixl_python_accuracy[enable_block_reuse=False-disable_overlap_scheduler=False]
-  - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_pipelined_kv_transfer_nixl_python_accuracy[enable_block_reuse=True-disable_overlap_scheduler=False]
-  - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_pipelined_kv_transfer_nixl_python_accuracy[enable_block_reuse=False-disable_overlap_scheduler=True]
-  - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_pipelined_kv_transfer_nixl_python_accuracy[enable_block_reuse=True-disable_overlap_scheduler=True]
+  - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_pipelined_kv_transfer_nixl_python_accuracy[disable_overlap_scheduler=False-enable_block_reuse=False]
+  - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_pipelined_kv_transfer_nixl_python_accuracy[disable_overlap_scheduler=False-enable_block_reuse=True]
+  - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_pipelined_kv_transfer_nixl_python_accuracy[disable_overlap_scheduler=True-enable_block_reuse=False]
+  - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_pipelined_kv_transfer_nixl_python_accuracy[disable_overlap_scheduler=True-enable_block_reuse=True]
   # ------------- KV Cache V2 Scheduler IT (multi-GPU) ---------------
   - kv_cache/test_kv_cache_v2_scheduler.py::TestKVCacheV2DSv3Lite::test_mtp_draft_tokens
   - kv_cache/test_kv_cache_v2_scheduler.py::TestKVCacheV2DSv3Lite::test_mtp_chunked_draft_tokens

--- a/tests/integration/test_lists/test-db/l0_dgx_b200.yml
+++ b/tests/integration/test_lists/test-db/l0_dgx_b200.yml
@@ -22,6 +22,11 @@ l0_dgx_b200:
   - llmapi/test_llm_api_pytorch_t5.py::test_t5_pytorch_generate_encoder_decoder_end_to_end[bf16-kv-v1-cuda-graph-on-greedy-tp2-t5-small]
   - llmapi/test_llm_api_pytorch_bart.py::test_bart_pytorch_generate_encoder_decoder_end_to_end[bf16-kv-v1-cuda-graph-off-greedy-tp2-bart-large-cnn]
   - llmapi/test_llm_api_pytorch_bart.py::test_bart_pytorch_generate_encoder_decoder_end_to_end[bf16-kv-v1-cuda-graph-on-greedy-tp2-bart-large-cnn]
+  # ------------- Disaggregated Serving: Pipelined KV Transfer (multi-GPU) ---------------
+  - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_pipelined_kv_transfer_nixl_python_accuracy[enable_block_reuse=False-disable_overlap_scheduler=False]
+  - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_pipelined_kv_transfer_nixl_python_accuracy[enable_block_reuse=True-disable_overlap_scheduler=False]
+  - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_pipelined_kv_transfer_nixl_python_accuracy[enable_block_reuse=False-disable_overlap_scheduler=True]
+  - accuracy/test_disaggregated_serving.py::TestLlama3_1_8BInstruct::test_pipelined_kv_transfer_nixl_python_accuracy[enable_block_reuse=True-disable_overlap_scheduler=True]
   # ------------- KV Cache V2 Scheduler IT (multi-GPU) ---------------
   - kv_cache/test_kv_cache_v2_scheduler.py::TestKVCacheV2DSv3Lite::test_mtp_draft_tokens
   - kv_cache/test_kv_cache_v2_scheduler.py::TestKVCacheV2DSv3Lite::test_mtp_chunked_draft_tokens

--- a/tests/unittest/_torch/executor/test_mamba_cache_manager.py
+++ b/tests/unittest/_torch/executor/test_mamba_cache_manager.py
@@ -20,10 +20,44 @@ from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import (
 from tensorrt_llm._torch.pyexecutor.resource_manager import CacheTypeCpp
 from tensorrt_llm._torch.pyexecutor.scheduler import ScheduledRequests
 from tensorrt_llm.bindings.internal.batch_manager import LinearCacheType
-from tensorrt_llm.llmapi.llm_args import KvCacheConfig, MTPDecodingConfig
+from tensorrt_llm.llmapi.llm_args import CacheTransceiverConfig, KvCacheConfig, MTPDecodingConfig
 from tensorrt_llm.mapping import Mapping
 
 skip_no_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+
+
+@pytest.mark.parametrize("manager_source", ["PYTHON", "MIXED"])
+def test_mixed_mamba_manager_rejects_block_reuse(monkeypatch, manager_source):
+    from tensorrt_llm._torch.pyexecutor import _util
+
+    monkeypatch.setattr(_util, "is_hybrid_linear", lambda _: True)
+    monkeypatch.setattr(_util, "use_py_mamba_cache_manager", lambda: False)
+    if manager_source == "MIXED":
+        monkeypatch.setenv("TLLM_MAMBA_MANAGER_PREFERENCE", "MIXED")
+        cache_transceiver_config = None
+    else:
+        monkeypatch.delenv("TLLM_MAMBA_MANAGER_PREFERENCE", raising=False)
+        cache_transceiver_config = CacheTransceiverConfig(
+            backend="NIXL",
+            transceiver_runtime="PYTHON",
+        )
+
+    model_config = SimpleNamespace(
+        pretrained_config=object(),
+        sparse_attention_config=None,
+        get_num_mamba_layers=lambda: 1,
+    )
+    kv_cache_config = KvCacheConfig(enable_block_reuse=True)
+
+    with pytest.raises(
+        ValueError,
+        match=r"Set KvCacheConfig\.enable_block_reuse=False",
+    ):
+        _util.get_kv_cache_manager_cls(
+            model_config,
+            kv_cache_config,
+            cache_transceiver_config=cache_transceiver_config,
+        )
 
 
 def _make_mgr(

--- a/tests/unittest/disaggregated/test_bounce.py
+++ b/tests/unittest/disaggregated/test_bounce.py
@@ -142,14 +142,18 @@ class TestResultTail:
 def test_kv_result_prefix_roundtrip():
     """The KV_AGENT_RESULT binary prefix (transfer.py) must round-trip exactly."""
     tfr = pytest.importorskip("tensorrt_llm._torch.disaggregation.native.transfer")
-    for rank, rid, sl, last, status in [
-        (7, 6925227277844486, 42, True, tfr.AgentResult.SUCCESS),
-        (0, 1, 0, False, tfr.AgentResult.FAILED),
-        (31, 2**62, 9999, True, tfr.AgentResult.SUCCESS),
+    # Sender and receiver slice ids differ in every case so a field swap is caught.
+    for rank, rid, send_sl, recv_sl, last, status in [
+        (7, 6925227277844486, 42, 0, True, tfr.AgentResult.SUCCESS),
+        (0, 1, 0, 3, False, tfr.AgentResult.FAILED),
+        (31, 2**62, 9999, 1, True, tfr.AgentResult.SUCCESS),
+        (2, 77, tfr.NO_SLICE_ID, 0, True, tfr.AgentResult.FAILED),
     ]:
-        packed = tfr._KV_RESULT_PREFIX.pack(rank, rid, sl, last, tfr._AGENT_RESULT_CODE[status])
-        r, i, s, last_out, c = tfr._KV_RESULT_PREFIX.unpack(packed)
-        assert (r, i, s, last_out) == (rank, rid, sl, last)
+        packed = tfr._KV_RESULT_PREFIX.pack(
+            rank, rid, send_sl, recv_sl, last, tfr._AGENT_RESULT_CODE[status]
+        )
+        r, i, send_out, recv_out, last_out, c = tfr._KV_RESULT_PREFIX.unpack(packed)
+        assert (r, i, send_out, recv_out, last_out) == (rank, rid, send_sl, recv_sl, last)
         assert tfr._AGENT_RESULT_BY_CODE[c] is status
 
 
@@ -158,11 +162,11 @@ def test_make_kv_result_msg_uses_binary_frame(result_name):
     """Every KV result (success and failure) uses the binary frame so the receiver can decode it."""
     tfr = pytest.importorskip("tensorrt_llm._torch.disaggregation.native.transfer")
     result = getattr(tfr.AgentResult, result_name)
-    msg = tfr._make_kv_result_msg(3, 12345, 7, True, result)
+    msg = tfr._make_kv_result_msg(3, 12345, 7, 2, True, result)
     assert msg[0] == tfr.MessageType.KV_AGENT_RESULT
     assert len(msg) == 2  # prefix only; no bounce tail when none is passed
-    r, rid, sl, last, code = tfr._KV_RESULT_PREFIX.unpack(msg[1])
-    assert (r, rid, sl, last) == (3, 12345, 7, True)
+    r, rid, send_sl, recv_sl, last, code = tfr._KV_RESULT_PREFIX.unpack(msg[1])
+    assert (r, rid, send_sl, recv_sl, last) == (3, 12345, 7, 2, True)
     assert tfr._AGENT_RESULT_BY_CODE[code] is result
 
 

--- a/tests/unittest/disaggregated/test_chunked_transfer.py
+++ b/tests/unittest/disaggregated/test_chunked_transfer.py
@@ -121,10 +121,34 @@ def test_chunk_projection_noops_when_chunk_is_outside_short_layer_group():
         block_ids,
         chunk_block_offset=4,
         chunk_block_count=4,
-        total_blocks=3,
+        resident_block_end=3,
     )
 
     assert projected_ids.size == 0
+
+
+@pytest.mark.parametrize(
+    "resident_block_end,chunk_block_offset,expected",
+    [
+        (16, 0, np.arange(16, dtype=np.int64)),
+        (32, 16, np.arange(16, 32, dtype=np.int64)),
+    ],
+    ids=["first_chunk", "later_chunk"],
+)
+def test_chunk_projection_maps_incrementally_allocated_source(
+    resident_block_end, chunk_block_offset, expected
+):
+    """Source blocks end at the current chunk, not at the full prompt."""
+    block_ids = np.arange(resident_block_end, dtype=np.int64)
+
+    projected_ids = project_blocks_to_global_chunk(
+        block_ids,
+        chunk_block_offset=chunk_block_offset,
+        chunk_block_count=16,
+        resident_block_end=resident_block_end,
+    )
+
+    assert np.array_equal(projected_ids, expected)
 
 
 def test_chunk_projection_maps_prefix_reuse_suffix_by_overlap():
@@ -135,13 +159,13 @@ def test_chunk_projection_maps_prefix_reuse_suffix_by_overlap():
         block_ids,
         chunk_block_offset=0,
         chunk_block_count=4,
-        total_blocks=8,
+        resident_block_end=8,
     )
     second_chunk = project_blocks_to_global_chunk(
         block_ids,
         chunk_block_offset=4,
         chunk_block_count=4,
-        total_blocks=8,
+        resident_block_end=8,
     )
 
     assert first_chunk.size == 0
@@ -311,8 +335,10 @@ def test_rx_session_status_error_on_any_failure():
 
 
 def test_rx_session_process_aux_completes_at_expected_transfers():
-    """Aux completes only once _aux_count reaches the RxSession's single
-    task's expected_transfers (the receiver always has exactly one task)."""
+    """Aux completes only once the expected transfer count is reached.
+
+    The receiver always has exactly one task.
+    """
     session = _make_rx_session(1)
     session._kv_tasks[0].expected_transfers = 2
 
@@ -375,6 +401,7 @@ def test_rx_session_mid_chunk_failure():
     result = session.wait_complete()
     assert result == WaitResult.FAILED
 
+
 # ---------------------------------------------------------------------------
 # Pipelined transfer tests
 # ---------------------------------------------------------------------------
@@ -391,6 +418,7 @@ def test_pipelined_transfer_disabled_by_default():
     result = KvCacheTransceiverV2.pipeline_transfer_enabled.fget(transceiver)
     assert result is False
 
+
 def test_pipelined_transfer_requires_chunked_prefill():
     """ValueError when pipelined transfer is enabled without chunked prefill."""
     from tensorrt_llm._torch.pyexecutor.kv_cache_transceiver import create_kv_cache_transceiver
@@ -401,9 +429,8 @@ def test_pipelined_transfer_requires_chunked_prefill():
     )
 
     with pytest.raises(
-            ValueError,
-            match=
-            "enable_chunked_prefill is required when enable_pipelined_transfer is set."
+        ValueError,
+        match="enable_chunked_prefill is required when enable_pipelined_transfer is set.",
     ):
         create_kv_cache_transceiver(
             MagicMock(),
@@ -413,6 +440,7 @@ def test_pipelined_transfer_requires_chunked_prefill():
             cache_transceiver_config,
             enable_chunked_prefill=False,
         )
+
 
 def test_pipelined_transfer_requires_gen_first_flow():
     """ValueError when a real request is not using gen-first flow."""
@@ -428,12 +456,12 @@ def test_pipelined_transfer_requires_gen_first_flow():
     request.sampling_config = None
     request.py_beam_width = 1
     request.py_disaggregated_params = SimpleNamespace(
-        schedule_style=DisaggScheduleStyle.CONTEXT_FIRST)
+        schedule_style=DisaggScheduleStyle.CONTEXT_FIRST
+    )
 
     with pytest.raises(
-            ValueError,
-            match=
-            "schedule_style must be generation_first when enable_pipelined_transfer is set."
+        ValueError,
+        match="schedule_style must be generation_first when enable_pipelined_transfer is set.",
     ):
         PyExecutor._validate_request(executor, request)
 

--- a/tests/unittest/disaggregated/test_chunked_transfer.py
+++ b/tests/unittest/disaggregated/test_chunked_transfer.py
@@ -1,0 +1,504 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for chunked and pipelined KV cache transfer (sender-only chunking).
+
+These tests validate the session state machine using the real
+TxSession/RxSession classes with lightweight stub sender/receiver objects.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from tensorrt_llm import DisaggregatedParams
+from tensorrt_llm._torch.disaggregation.base.transfer import (
+    KVSlice,
+    SessionStatus,
+    TokenRange,
+    WaitResult,
+    project_blocks_to_global_chunk,
+)
+from tensorrt_llm._torch.disaggregation.native.transfer import (
+    AgentResult,
+    KVSendTask,
+    RecvReqInfo,
+    RxSession,
+    Sender,
+    TaskStatus,
+    TxSession,
+)
+from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequestState
+from tensorrt_llm.disaggregated_params import DisaggScheduleStyle
+from tensorrt_llm.llmapi.llm_args import CacheTransceiverConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_params(rid: int = 42) -> DisaggregatedParams:
+    return DisaggregatedParams(disagg_request_id=rid)
+
+
+def _stub_sender():
+    """Create a stub sender with no-op methods needed by TxSession."""
+    sender = MagicMock()
+    sender.setup_session = MagicMock()
+    sender._get_req_info = MagicMock(return_value=None)
+    sender.dispatch_task = MagicMock()
+    return sender
+
+
+def _stub_receiver():
+    """Create a stub receiver with no-op methods needed by RxSession."""
+    receiver = MagicMock()
+    receiver.setup_session = MagicMock()
+    receiver.dispatch_task = MagicMock()
+    return receiver
+
+
+def _make_tx_session(num_slices: int, rid: int = 42, prompt_len: int = 8, **kwargs) -> TxSession:
+    """Create a real TxSession and send num_slices slices into it."""
+    params = _make_params(rid)
+    session = TxSession(
+        request_id=rid,
+        params=params,
+        sender=_stub_sender(),
+        prompt_len=prompt_len,
+        **kwargs,
+    )
+    for i in range(num_slices):
+        s = KVSlice(
+            is_last_slice=(i == num_slices - 1),
+            block_ids_per_layer_groups=[[i]],
+        )
+        session.send(s)
+    return session
+
+
+def _make_rx_session(num_slices: int, rid: int = 42, prompt_len: int = 8) -> RxSession:
+    """Create a real RxSession and receive num_slices slices into it."""
+    params = _make_params(rid)
+    session = RxSession(
+        request_id=rid,
+        params=params,
+        receiver=_stub_receiver(),
+        prompt_len=prompt_len,
+    )
+    for i in range(num_slices):
+        s = KVSlice(
+            is_last_slice=(i == num_slices - 1),
+            block_ids_per_layer_groups=[[i]],
+        )
+        session.receive(s)
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Global chunk projection tests
+# ---------------------------------------------------------------------------
+
+
+def test_chunk_projection_noops_when_chunk_is_outside_short_layer_group():
+    """A shared chunk cursor past a short layer group's resident range is a no-op."""
+    block_ids = np.array([10, 11, 12], dtype=np.int64)
+
+    projected_ids = project_blocks_to_global_chunk(
+        block_ids,
+        chunk_block_offset=4,
+        chunk_block_count=4,
+        total_blocks=3,
+    )
+
+    assert projected_ids.size == 0
+
+
+def test_chunk_projection_maps_prefix_reuse_suffix_by_overlap():
+    """Destination suffixes are matched by overlap, not by raw chunk-offset indexing."""
+    block_ids = np.array([104, 105, 106, 107], dtype=np.int64)
+
+    first_chunk = project_blocks_to_global_chunk(
+        block_ids,
+        chunk_block_offset=0,
+        chunk_block_count=4,
+        total_blocks=8,
+    )
+    second_chunk = project_blocks_to_global_chunk(
+        block_ids,
+        chunk_block_offset=4,
+        chunk_block_count=4,
+        total_blocks=8,
+    )
+
+    assert first_chunk.size == 0
+    assert np.array_equal(second_chunk, block_ids)
+
+
+def test_build_kv_write_meta_projects_asymmetric_layer_group_chunk():
+    """A short layer group's suffix blocks transfer with the overlapping global chunk."""
+    peer_ri = SimpleNamespace(
+        dp_rank=0,
+        device_id=0,
+        instance_name="decode",
+        instance_rank=0,
+        self_endpoint="tcp://decode:0",
+    )
+
+    extractor = MagicMock()
+    extractor.page_table = SimpleNamespace(
+        tokens_per_block=8,
+        layer_groups=[
+            SimpleNamespace(sliding_window_size=None),
+            SimpleNamespace(sliding_window_size=None),
+        ],
+    )
+    extractor.extract.side_effect = lambda block_ids, **_: SimpleNamespace(
+        memory=SimpleNamespace(
+            ptrs=np.asarray(block_ids, dtype=np.int64),
+            bytes_per_region=1,
+        )
+    )
+
+    mapper = MagicMock()
+    mapper.map.side_effect = lambda src_region, dst_region: SimpleNamespace(
+        src=src_region,
+        dst=dst_region,
+    )
+
+    registrar = MagicMock()
+    registrar.self_rank_info = SimpleNamespace()
+    registrar.self_extractor = extractor
+    registrar.get_peer_rank_info.return_value = peer_ri
+    registrar.get_peer_overlap.return_value = SimpleNamespace(ranks=[0])
+    registrar.should_send_kv.return_value = True
+    registrar.get_pool_mapping.return_value = {
+        (0, 0): (0, 0),
+        (1, 0): (1, 0),
+    }
+    registrar.peer_extractor.return_value = extractor
+    registrar.get_kv_map.return_value = mapper
+
+    sender = Sender.__new__(Sender)
+    sender._registrar = registrar
+
+    task = KVSendTask(
+        KVSlice(
+            is_last_slice=True,
+            block_ids_per_layer_groups=[
+                np.array([4, 5, 6, 7], dtype=np.int64),
+                np.array([10, 11, 12], dtype=np.int64),
+            ],
+            token_range=TokenRange(start=32, end=64),
+            total_blocks=8,
+        ),
+        _make_params(),
+        slice_id=1,
+        prompt_len=64,
+    )
+    req_info = RecvReqInfo(
+        sender_req_id=42,
+        instance_name="decode",
+        instance_rank=0,
+        block_ids_per_layer_groups=[
+            np.array([104, 105, 106, 107], dtype=np.int64),
+            np.array([200, 201, 202], dtype=np.int64),
+        ],
+        unique_rid=42,
+    )
+
+    write_meta = sender._build_kv_write_meta(task, req_info)
+
+    assert np.array_equal(
+        write_meta.src_ptrs,
+        np.array([4, 5, 6, 7, 10, 11, 12], dtype=np.int64),
+    )
+    assert np.array_equal(
+        write_meta.dst_ptrs,
+        np.array([104, 105, 106, 107, 200, 201, 202], dtype=np.int64),
+    )
+    assert np.array_equal(write_meta.sizes, np.ones(7, dtype=np.int64))
+
+
+# ---------------------------------------------------------------------------
+# TxSession multi-slice status tests (real class)
+# ---------------------------------------------------------------------------
+
+
+def test_tx_session_status_init_until_all_transferred():
+    """TxSession status is not KV_TRANSFERRED until ALL tasks complete."""
+    session = _make_tx_session(3)
+    session.receiver_ready = True
+    assert session.status == SessionStatus.TRANSFERRING or session.status == SessionStatus.READY
+
+    session.kv_tasks[0].status = TaskStatus.TRANSFERRED
+    assert session.status != SessionStatus.KV_TRANSFERRED
+
+    session.kv_tasks[1].status = TaskStatus.TRANSFERRED
+    assert session.status != SessionStatus.KV_TRANSFERRED
+
+    session.kv_tasks[2].status = TaskStatus.TRANSFERRED
+    assert session.status == SessionStatus.KV_TRANSFERRED
+
+
+def test_tx_session_status_error_on_any_failure():
+    """TxSession status is ERROR if any task fails."""
+    session = _make_tx_session(3)
+    session.kv_tasks[0].status = TaskStatus.TRANSFERRED
+    session.kv_tasks[1].status = TaskStatus.ERROR
+    assert session.status == SessionStatus.ERROR
+
+
+def test_tx_session_wait_complete_all_tasks():
+    """TxSession.wait_complete blocks on all task futures."""
+    session = _make_tx_session(3)
+    for task in session.kv_tasks:
+        task.complete()
+
+    result = session.wait_complete()
+    assert result == WaitResult.COMPLETED
+
+
+def test_tx_session_wait_complete_fails_on_partial_failure():
+    """TxSession.wait_complete returns FAILED if any task fails."""
+    session = _make_tx_session(3)
+    session.kv_tasks[0].complete()
+    session.kv_tasks[1].fail(RuntimeError("transfer failed"))
+    session.kv_tasks[2].complete()
+
+    result = session.wait_complete()
+    assert result == WaitResult.FAILED
+
+
+# ---------------------------------------------------------------------------
+# RxSession multi-slice status tests (real class)
+# ---------------------------------------------------------------------------
+
+
+def test_rx_session_status_checks_all_tasks():
+    """RxSession status is KV_TRANSFERRED only when ALL tasks complete."""
+    session = _make_rx_session(3)
+    assert session.status == SessionStatus.INIT
+
+    session._kv_tasks[0].status = TaskStatus.TRANSFERRED
+    session._kv_tasks[1].status = TaskStatus.TRANSFERRING
+    assert session.status == SessionStatus.TRANSFERRING
+
+    session._kv_tasks[1].status = TaskStatus.TRANSFERRED
+    session._kv_tasks[2].status = TaskStatus.TRANSFERRED
+    assert session.status == SessionStatus.KV_TRANSFERRED
+
+
+def test_rx_session_status_error_on_any_failure():
+    """RxSession status is ERROR if any task fails."""
+    session = _make_rx_session(2)
+    session._kv_tasks[0].status = TaskStatus.TRANSFERRED
+    session._kv_tasks[1].status = TaskStatus.ERROR
+    assert session.status == SessionStatus.ERROR
+
+
+def test_rx_session_process_aux_completes_at_expected_transfers():
+    """Aux completes only once _aux_count reaches the RxSession's single
+    task's expected_transfers (the receiver always has exactly one task)."""
+    session = _make_rx_session(1)
+    session._kv_tasks[0].expected_transfers = 2
+
+    session.process_aux_agent_result(0, AgentResult.SUCCESS)
+    assert session._aux_status != TaskStatus.TRANSFERRED
+
+    session.process_aux_agent_result(0, AgentResult.SUCCESS)
+    assert session._aux_status == TaskStatus.TRANSFERRED
+
+
+def test_rx_session_wait_complete_all_tasks():
+    """RxSession.wait_complete blocks on all task futures."""
+    session = _make_rx_session(3)
+    for task in session._kv_tasks:
+        task.complete()
+
+    result = session.wait_complete()
+    assert result == WaitResult.COMPLETED
+
+
+def test_rx_session_wait_complete_fails_on_partial_failure():
+    """RxSession.wait_complete returns FAILED if any task fails."""
+    session = _make_rx_session(2)
+    session._kv_tasks[0].complete()
+    session._kv_tasks[1].fail(RuntimeError("transfer failed"))
+
+    result = session.wait_complete()
+    assert result == WaitResult.FAILED
+
+
+# ---------------------------------------------------------------------------
+# Mid-transfer chunk failure tests
+# ---------------------------------------------------------------------------
+
+
+def test_tx_session_mid_chunk_failure():
+    """If one chunk fails mid-transfer, the session reports ERROR."""
+    session = _make_tx_session(4)
+
+    session.kv_tasks[0].complete()
+    session.kv_tasks[1].complete()
+    session.kv_tasks[2].fail(RuntimeError("RDMA failed"))
+    session.kv_tasks[3].complete()
+
+    assert session.status == SessionStatus.ERROR
+    result = session.wait_complete()
+    assert result == WaitResult.FAILED
+
+
+def test_rx_session_mid_chunk_failure():
+    """If one chunk fails mid-transfer on receiver, the session reports ERROR."""
+    session = _make_rx_session(4)
+
+    session._kv_tasks[0].complete()
+    session._kv_tasks[1].fail(RuntimeError("RDMA failed"))
+    session._kv_tasks[2].complete()
+    session._kv_tasks[3].complete()
+
+    assert session.status == SessionStatus.ERROR
+    result = session.wait_complete()
+    assert result == WaitResult.FAILED
+
+# ---------------------------------------------------------------------------
+# Pipelined transfer tests
+# ---------------------------------------------------------------------------
+
+
+def test_pipelined_transfer_disabled_by_default():
+    """pipeline_transfer_enabled reflects the configured flag."""
+    from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    transceiver = MagicMock()
+    transceiver._enable_pipelined_transfer = False
+    transceiver._chunk_size_blocks = 64
+
+    result = KvCacheTransceiverV2.pipeline_transfer_enabled.fget(transceiver)
+    assert result is False
+
+def test_pipelined_transfer_requires_chunked_prefill():
+    """ValueError when pipelined transfer is enabled without chunked prefill."""
+    from tensorrt_llm._torch.pyexecutor.kv_cache_transceiver import create_kv_cache_transceiver
+
+    cache_transceiver_config = CacheTransceiverConfig(
+        backend="NIXL",
+        enable_pipelined_transfer=True,
+    )
+
+    with pytest.raises(
+            ValueError,
+            match=
+            "enable_chunked_prefill is required when enable_pipelined_transfer is set."
+    ):
+        create_kv_cache_transceiver(
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            cache_transceiver_config,
+            enable_chunked_prefill=False,
+        )
+
+def test_pipelined_transfer_requires_gen_first_flow():
+    """ValueError when a real request is not using gen-first flow."""
+    from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
+
+    executor = MagicMock()
+    executor.is_warmup = False
+    executor.kv_cache_transceiver.pipeline_transfer_enabled = True
+    executor._validate_token_id_range = MagicMock()
+    executor.sampler.validate_request = MagicMock()
+
+    request = MagicMock()
+    request.sampling_config = None
+    request.py_beam_width = 1
+    request.py_disaggregated_params = SimpleNamespace(
+        schedule_style=DisaggScheduleStyle.CONTEXT_FIRST)
+
+    with pytest.raises(
+            ValueError,
+            match=
+            "schedule_style must be generation_first when enable_pipelined_transfer is set."
+    ):
+        PyExecutor._validate_request(executor, request)
+
+
+def test_pipelined_last_chunk_sends_and_finalizes():
+    """respond_and_send_async sends the built chunk and finalizes on the last chunk."""
+    from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    session = MagicMock()
+    session.kv_tasks = []
+
+    last_slice = KVSlice(
+        is_last_slice=True,
+        block_ids_per_layer_groups=[np.array([0, 1], dtype=np.int64)],
+    )
+
+    transceiver = MagicMock()
+    transceiver._enable_pipelined_transfer = True
+    transceiver.kv_transfer_timeout_ms = None
+    transceiver._get_or_create_send_session.return_value = session
+    transceiver._build_prefill_chunk.return_value = last_slice
+
+    request = SimpleNamespace(
+        py_disaggregated_params=DisaggregatedParams(disagg_request_id=42),
+        request_id=42,
+        prompt_len=8,
+        py_beam_width=1,
+        py_kv_transfer_start_time=None,
+    )
+
+    KvCacheTransceiverV2.respond_and_send_async(transceiver, request)
+
+    transceiver._build_prefill_chunk.assert_called_once_with(request)
+    session.send.assert_called_once_with(last_slice)
+    transceiver._finalize_send.assert_called_once_with(request, session)
+    assert request.state == LlmRequestState.DISAGG_CONTEXT_TRANS_IN_PROGRESS
+
+
+def test_pipelined_non_last_chunk_does_not_finalize():
+    """respond_and_send_async sends non-final chunks without finalizing."""
+    from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
+
+    session = MagicMock()
+    session.kv_tasks = []
+
+    mid_slice = KVSlice(
+        is_last_slice=False,
+        block_ids_per_layer_groups=[np.array([0, 1], dtype=np.int64)],
+    )
+
+    transceiver = MagicMock()
+    transceiver._enable_pipelined_transfer = True
+    transceiver.kv_transfer_timeout_ms = None
+    transceiver._get_or_create_send_session.return_value = session
+    transceiver._build_prefill_chunk.return_value = mid_slice
+
+    request = SimpleNamespace(
+        py_disaggregated_params=DisaggregatedParams(disagg_request_id=42),
+        request_id=42,
+        prompt_len=8,
+        py_beam_width=1,
+        py_kv_transfer_start_time=None,
+    )
+
+    KvCacheTransceiverV2.respond_and_send_async(transceiver, request)
+
+    session.send.assert_called_once_with(mid_slice)
+    transceiver._finalize_send.assert_not_called()

--- a/tests/unittest/disaggregated/test_chunked_transfer.py
+++ b/tests/unittest/disaggregated/test_chunked_transfer.py
@@ -442,6 +442,62 @@ def test_pipelined_transfer_requires_chunked_prefill():
         )
 
 
+def test_pipelined_transfer_rejects_pipeline_parallelism(monkeypatch):
+    """ValueError for pipeline parallelism when the disaggregated role is unknown."""
+    from tensorrt_llm._torch.pyexecutor.kv_cache_transceiver import create_kv_cache_transceiver
+
+    monkeypatch.delenv("TRTLLM_DISAGG_ROLE", raising=False)
+    mapping = MagicMock()
+    mapping.pp_size = 2
+    cache_transceiver_config = CacheTransceiverConfig(
+        backend="NIXL",
+        enable_pipelined_transfer=True,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="pipeline_parallel_size=1 is required when enable_pipelined_transfer is set.",
+    ):
+        create_kv_cache_transceiver(
+            mapping,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            cache_transceiver_config,
+            enable_chunked_prefill=True,
+        )
+
+
+def test_pipelined_transfer_allows_pipeline_parallelism_on_generation_server(monkeypatch):
+    """Pipeline parallelism is allowed when the worker only receives KV cache."""
+    from tensorrt_llm._torch.disaggregation import transceiver as transceiver_module
+    from tensorrt_llm._torch.pyexecutor.kv_cache_transceiver import create_kv_cache_transceiver
+
+    monkeypatch.setenv("TRTLLM_DISAGG_ROLE", "generation")
+    transceiver = MagicMock()
+    transceiver_cls = MagicMock(return_value=transceiver)
+    monkeypatch.setattr(transceiver_module, "KvCacheTransceiverV2", transceiver_cls)
+
+    mapping = MagicMock()
+    mapping.pp_size = 2
+    cache_transceiver_config = CacheTransceiverConfig(
+        backend="NIXL",
+        enable_pipelined_transfer=True,
+    )
+
+    result = create_kv_cache_transceiver(
+        mapping,
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        cache_transceiver_config,
+        enable_chunked_prefill=True,
+    )
+
+    assert result is transceiver
+    transceiver_cls.assert_called_once()
+
+
 def test_pipelined_transfer_requires_gen_first_flow():
     """ValueError when a real request is not using gen-first flow."""
     from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor

--- a/tests/unittest/disaggregated/test_chunked_transfer.py
+++ b/tests/unittest/disaggregated/test_chunked_transfer.py
@@ -495,7 +495,32 @@ def test_pipelined_transfer_allows_pipeline_parallelism_on_generation_server(mon
     )
 
     assert result is transceiver
+    assert cache_transceiver_config.transceiver_runtime == "PYTHON"
     transceiver_cls.assert_called_once()
+
+
+def test_python_transceiver_rejects_cpp_mamba_cache_manager():
+    """Python transceiver requires separate Python-managed Mamba state."""
+    from tensorrt_llm._torch.pyexecutor.kv_cache_transceiver import create_kv_cache_transceiver
+    from tensorrt_llm._torch.pyexecutor.mamba_cache_manager import CppMambaHybridCacheManager
+
+    kv_cache_manager = object.__new__(CppMambaHybridCacheManager)
+    cache_transceiver_config = CacheTransceiverConfig(
+        backend="NIXL",
+        transceiver_runtime="PYTHON",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Python transceiver requires MixedMambaHybridCacheManager",
+    ):
+        create_kv_cache_transceiver(
+            MagicMock(),
+            MagicMock(),
+            kv_cache_manager,
+            MagicMock(),
+            cache_transceiver_config,
+        )
 
 
 def test_pipelined_transfer_requires_gen_first_flow():

--- a/tests/unittest/disaggregated/test_chunked_transfer.py
+++ b/tests/unittest/disaggregated/test_chunked_transfer.py
@@ -33,6 +33,8 @@ from tensorrt_llm._torch.disaggregation.base.transfer import (
     project_blocks_to_global_chunk,
 )
 from tensorrt_llm._torch.disaggregation.native.transfer import (
+    _KV_RESULT_PREFIX,
+    NO_SLICE_ID,
     AgentResult,
     KVSendTask,
     RecvReqInfo,
@@ -40,6 +42,7 @@ from tensorrt_llm._torch.disaggregation.native.transfer import (
     Sender,
     TaskStatus,
     TxSession,
+    WriteMeta,
 )
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequestState
 from tensorrt_llm.disaggregated_params import DisaggScheduleStyle
@@ -172,8 +175,8 @@ def test_chunk_projection_maps_prefix_reuse_suffix_by_overlap():
     assert np.array_equal(second_chunk, block_ids)
 
 
-def test_build_kv_write_meta_projects_asymmetric_layer_group_chunk():
-    """A short layer group's suffix blocks transfer with the overlapping global chunk."""
+def _make_projection_sender() -> Sender:
+    """Create a Sender wired to a stub registrar with two non-windowed layer groups."""
     peer_ri = SimpleNamespace(
         dp_rank=0,
         device_id=0,
@@ -218,8 +221,11 @@ def test_build_kv_write_meta_projects_asymmetric_layer_group_chunk():
 
     sender = Sender.__new__(Sender)
     sender._registrar = registrar
+    return sender
 
-    task = KVSendTask(
+
+def _make_projection_task(slice_id: int = 1) -> KVSendTask:
+    return KVSendTask(
         KVSlice(
             is_last_slice=True,
             block_ids_per_layer_groups=[
@@ -230,10 +236,13 @@ def test_build_kv_write_meta_projects_asymmetric_layer_group_chunk():
             total_blocks=8,
         ),
         _make_params(),
-        slice_id=1,
+        slice_id=slice_id,
         prompt_len=64,
     )
-    req_info = RecvReqInfo(
+
+
+def _make_projection_req_info(slice_id=None) -> RecvReqInfo:
+    return RecvReqInfo(
         sender_req_id=42,
         instance_name="decode",
         instance_rank=0,
@@ -242,9 +251,15 @@ def test_build_kv_write_meta_projects_asymmetric_layer_group_chunk():
             np.array([200, 201, 202], dtype=np.int64),
         ],
         unique_rid=42,
+        slice_id=slice_id,
     )
 
-    write_meta = sender._build_kv_write_meta(task, req_info)
+
+def test_build_kv_write_meta_projects_asymmetric_layer_group_chunk():
+    """A short layer group's suffix blocks transfer with the overlapping global chunk."""
+    sender = _make_projection_sender()
+
+    write_meta = sender._build_kv_write_meta(_make_projection_task(), _make_projection_req_info())
 
     assert np.array_equal(
         write_meta.src_ptrs,
@@ -255,6 +270,131 @@ def test_build_kv_write_meta_projects_asymmetric_layer_group_chunk():
         np.array([104, 105, 106, 107, 200, 201, 202], dtype=np.int64),
     )
     assert np.array_equal(write_meta.sizes, np.ones(7, dtype=np.int64))
+    # The sender's chunk index and the peer's task index are tracked separately;
+    # a receiver that sends no slice_id is addressed as its single task 0.
+    assert write_meta.sender_slice_id == 1
+    assert write_meta.receiver_slice_id == 0
+
+
+def test_build_kv_write_meta_echoes_receiver_slice_id():
+    """receiver_slice_id comes from the peer's RecvReqInfo, not the sender's chunk index."""
+    sender = _make_projection_sender()
+
+    write_meta = sender._build_kv_write_meta(
+        _make_projection_task(slice_id=1), _make_projection_req_info(slice_id=3)
+    )
+
+    assert write_meta.sender_slice_id == 1
+    assert write_meta.receiver_slice_id == 3
+
+
+# ---------------------------------------------------------------------------
+# KV_AGENT_RESULT slice-id addressing tests
+# ---------------------------------------------------------------------------
+
+
+def _make_write_meta(sender_slice_id, receiver_slice_id) -> WriteMeta:
+    empty = np.array([], dtype=np.int64)
+    return WriteMeta(
+        task=MagicMock(),
+        expected_transfers=1,
+        peer_name="decode0",
+        peer_rank=0,
+        peer_endpoint="tcp://decode:0",
+        unique_rid=42,
+        src_ptrs=empty,
+        dst_ptrs=empty,
+        sizes=empty,
+        sender_slice_id=sender_slice_id,
+        receiver_slice_id=receiver_slice_id,
+    )
+
+
+def test_send_kv_result_carries_both_slice_ids():
+    """The result frame reports the sender's chunk and addresses the peer's own task."""
+    sender = Sender.__new__(Sender)
+    sender._instance_rank = 5
+    dealer = MagicMock()
+    sender._get_or_connect_thread_dealer = MagicMock(return_value=dealer)
+
+    sender._send_kv_result_to_receiver(
+        _make_write_meta(sender_slice_id=4, receiver_slice_id=2),
+        is_last=True,
+        result=AgentResult.SUCCESS,
+    )
+
+    (msg,), _ = dealer.send.call_args
+    rank, rid, sender_slice_id, receiver_slice_id, is_last, _code = _KV_RESULT_PREFIX.unpack(msg[1])
+    assert (rank, rid, sender_slice_id, receiver_slice_id, is_last) == (5, 42, 4, 2, True)
+
+
+def test_send_kv_result_without_task_reports_no_slice_id():
+    """A result with no owning KVSendTask reports NO_SLICE_ID rather than chunk 0."""
+    sender = Sender.__new__(Sender)
+    sender._instance_rank = 5
+    dealer = MagicMock()
+    sender._get_or_connect_thread_dealer = MagicMock(return_value=dealer)
+
+    sender._send_kv_result_to_receiver(
+        _make_write_meta(sender_slice_id=None, receiver_slice_id=0),
+        is_last=True,
+        result=AgentResult.FAILED,
+    )
+
+    (msg,), _ = dealer.send.call_args
+    _rank, _rid, sender_slice_id, _receiver_slice_id, _is_last, _code = _KV_RESULT_PREFIX.unpack(
+        msg[1]
+    )
+    assert sender_slice_id == NO_SLICE_ID
+
+
+def test_process_kv_agent_result_resolves_task_by_receiver_slice_id():
+    """A sender chunk id far past the receiver's task count still resolves task 0."""
+    session = _make_rx_session(1)
+    session._kv_tasks[0].expected_transfers = 1
+    session._receiver._bounce.is_bounced.return_value = False
+
+    session.process_kv_agent_result(
+        peer_rank=0,
+        receiver_slice_id=0,
+        sender_slice_id=4,
+        is_last_slice=True,
+        status=AgentResult.SUCCESS,
+    )
+
+    assert session._kv_tasks[0].status == TaskStatus.TRANSFERRED
+
+
+def test_process_kv_agent_result_rejects_unknown_receiver_slice_id():
+    """Indexing is bounded by the receiver's own task count, and names both ids."""
+    session = _make_rx_session(1)
+
+    with pytest.raises(AssertionError, match=r"receiver_slice_id=2.*sender_slice_id=0"):
+        session.process_kv_agent_result(
+            peer_rank=0,
+            receiver_slice_id=2,
+            sender_slice_id=0,
+            is_last_slice=True,
+            status=AgentResult.SUCCESS,
+        )
+
+
+def test_process_kv_agent_result_failure_attributes_sender_chunk():
+    """A failed chunk names the sender chunk so the failure is attributable."""
+    session = _make_rx_session(1)
+
+    session.process_kv_agent_result(
+        peer_rank=0,
+        receiver_slice_id=0,
+        sender_slice_id=3,
+        is_last_slice=False,
+        status=AgentResult.FAILED,
+    )
+
+    task = session._kv_tasks[0]
+    assert task.status == TaskStatus.ERROR
+    assert "sender_slice_id=3" in str(task._exception)
+    assert session.status == SessionStatus.ERROR
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittest/disaggregated/test_chunked_transfer.py
+++ b/tests/unittest/disaggregated/test_chunked_transfer.py
@@ -547,6 +547,27 @@ def test_pipelined_transfer_requires_gen_first_flow():
         PyExecutor._validate_request(executor, request)
 
 
+def test_pipelined_transfer_allows_non_disaggregated_request():
+    """Requests without disaggregated parameters do not transfer KV cache."""
+    from tensorrt_llm._torch.pyexecutor.py_executor import PyExecutor
+
+    executor = MagicMock()
+    executor.is_warmup = False
+    executor.max_beam_width = 1
+    executor.kv_cache_transceiver.pipeline_transfer_enabled = True
+    executor._validate_token_id_range = MagicMock()
+    executor.sampler.validate_request = MagicMock()
+
+    request = MagicMock()
+    request.sampling_config = None
+    request.py_beam_width = 1
+    request.py_disaggregated_params = None
+
+    PyExecutor._validate_request(executor, request)
+
+    executor.sampler.validate_request.assert_called_once_with(request)
+
+
 def test_pipelined_last_chunk_sends_and_finalizes():
     """respond_and_send_async sends the built chunk and finalizes on the last chunk."""
     from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2

--- a/tests/unittest/disaggregated/test_disagg_utils.py
+++ b/tests/unittest/disaggregated/test_disagg_utils.py
@@ -107,12 +107,107 @@ def test_parse_disagg_config_file(sample_yaml_file, sample_yaml_config):
     verify_disagg_config(config, sample_yaml_config)
 
 
+def test_parse_disagg_config_file_rejects_empty_file(tmp_path):
+    config_file = tmp_path / "empty.yaml"
+    config_file.write_text("")
+
+    with pytest.raises(ValueError,
+                       match="Disaggregated config file is empty"):
+        parse_disagg_config_file(config_file)
+
+
+def test_parse_disagg_config_file_validates_schedule_style_override(tmp_path):
+    config_file = tmp_path / "pipelined.yaml"
+    config_file.write_text(
+        yaml.safe_dump({
+            "schedule_style": "generation_first",
+            "context_servers": {
+                "cache_transceiver_config": {
+                    "enable_pipelined_transfer": True,
+                },
+            },
+            "generation_servers": {},
+        }))
+
+    with pytest.raises(
+            ValueError,
+            match="enable_pipelined_transfer=True requires top-level "
+            "schedule_style='generation_first'"):
+        parse_disagg_config_file(
+            config_file, schedule_style_override="context_first")
+
+
 @pytest.mark.parametrize("sample_yaml_config", ["disagg_cluster", ""],
                          indirect=True)
 def test_extract_disagg_cfg(sample_yaml_config):
     config = extract_disagg_cfg(**sample_yaml_config)
     assert isinstance(config, DisaggServerConfig)
     verify_disagg_config(config, sample_yaml_config)
+
+
+@pytest.mark.parametrize("server_group",
+                         ["context_servers", "generation_servers"])
+def test_extract_disagg_cfg_rejects_pipelined_transfer_with_context_first(
+        server_group):
+    server_configs = {
+        "context_servers": {},
+        "generation_servers": {},
+    }
+    server_configs[server_group] = {
+        "cache_transceiver_config": {
+            "enable_pipelined_transfer": True,
+        },
+    }
+
+    with pytest.raises(
+            ValueError,
+            match="enable_pipelined_transfer=True requires top-level "
+            "schedule_style='generation_first'"):
+        extract_disagg_cfg(schedule_style="context_first", **server_configs)
+
+
+def test_extract_disagg_cfg_allows_pipelined_transfer_with_generation_first():
+    config = extract_disagg_cfg(
+        schedule_style="generation_first",
+        context_servers={
+            "cache_transceiver_config": {
+                "enable_pipelined_transfer": True,
+            },
+        },
+        generation_servers={},
+    )
+
+    assert config.schedule_style == "generation_first"
+
+
+def test_extract_disagg_cfg_rejects_invalid_schedule_style():
+    with pytest.raises(ValueError,
+                       match="schedule_style must be one of"):
+        extract_disagg_cfg(
+            schedule_style="generation-first",
+            context_servers={},
+            generation_servers={},
+        )
+
+
+@pytest.mark.parametrize(
+    "cache_transceiver_config, expected_error",
+    [
+        ({
+            "enable_pipelined_transfer": 1
+        }, "enable_pipelined_transfer must be a boolean"),
+        ([], "cache_transceiver_config must be a mapping"),
+    ],
+)
+def test_extract_disagg_cfg_rejects_invalid_cache_transceiver_config(
+        cache_transceiver_config, expected_error):
+    with pytest.raises(ValueError, match=expected_error):
+        extract_disagg_cfg(
+            context_servers={
+                "cache_transceiver_config": cache_transceiver_config,
+            },
+            generation_servers={},
+        )
 
 
 def test_extract_ctx_gen_cfgs():

--- a/tests/unittest/disaggregated/test_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_kv_transfer.py
@@ -190,7 +190,8 @@ def _send_prefill_chunks(
     transceiver._get_or_create_send_session.return_value = session
     transceiver._create_kv_slice = MagicMock(return_value=base_slice)
     transceiver._reuse_adapter.tokens_per_block = tokens_per_block
-    transceiver.kv_cache_manager.tokens_per_block = tokens_per_block
+    transceiver._kv_cache_manager.tokens_per_block = tokens_per_block
+    transceiver._kv_cache_manager.kv_cache_map = {}
     transceiver._send_reqs = {}
 
     prompt_len = total_blocks * tokens_per_block
@@ -229,8 +230,48 @@ def _send_prefill_chunks(
     return slices
 
 
+def test_build_prefill_chunk_projects_incremental_source_against_full_prompt():
+    """A growing source uses the current chunk end while retaining the full prompt span."""
+    tokens_per_block = 128
+    prompt_blocks = 1000
+    chunk_blocks = 16
+
+    transceiver = MagicMock()
+    transceiver._reuse_adapter.tokens_per_block = tokens_per_block
+    transceiver._kv_cache_manager.tokens_per_block = tokens_per_block
+    transceiver._kv_cache_manager.kv_cache_map = {}
+    transceiver._send_reqs = {}
+
+    req = MagicMock()
+    req.py_disaggregated_params = DisaggregatedParams(disagg_request_id=42)
+    req.py_request_id = 42
+    req.prompt_len = prompt_blocks * tokens_per_block
+    req.py_beam_width = 1
+
+    for chunk_idx in range(2):
+        chunk_start = chunk_idx * chunk_blocks
+        chunk_end = chunk_start + chunk_blocks
+        resident_ids = np.arange(chunk_end, dtype=np.int64)
+        transceiver._create_kv_slice.return_value = KVSlice(
+            block_ids_per_layer_groups=[resident_ids]
+        )
+        req.py_last_context_chunk = (
+            chunk_start * tokens_per_block,
+            chunk_end * tokens_per_block,
+        )
+        req.context_remaining_length = req.prompt_len - req.py_last_context_chunk[1]
+
+        kv_slice = KvCacheTransceiverV2._build_prefill_chunk(transceiver, req)
+
+        assert np.array_equal(
+            kv_slice.block_ids_per_layer_groups[0],
+            np.arange(chunk_start, chunk_end, dtype=np.int64),
+        )
+        assert kv_slice.total_blocks == prompt_blocks
+
+
 @pytest.mark.parametrize(
-        "all_block_ids,chunk_size_blocks,expected_num_slices",
+    "all_block_ids,chunk_size_blocks,expected_num_slices",
     [
         ([[0, 1, 2, 3, 4, 5, 6, 7]], None, 1),
         ([[0, 1, 2, 3, 4, 5, 6, 7]], 4, 2),
@@ -240,8 +281,7 @@ def _send_prefill_chunks(
     ],
     ids=["no_chunking", "even_split", "uneven_split", "empty_blocks", "chunk_larger_than_total"],
 )
-def test_send_prefill_chunks_basic(all_block_ids, chunk_size_blocks,
-                                   expected_num_slices):
+def test_send_prefill_chunks_basic(all_block_ids, chunk_size_blocks, expected_num_slices):
     """Pipelined prefill chunking produces the expected number of slices."""
     slices = _send_prefill_chunks(all_block_ids, chunk_size_blocks)
     assert len(slices) == expected_num_slices
@@ -253,7 +293,7 @@ def test_send_prefill_chunks_basic(all_block_ids, chunk_size_blocks,
 
 def test_send_prefill_chunks_integrity_check():
     """Reassembled block IDs from all slices must match the original."""
-    all_block_ids = [list(range(17)), list(range(5))]
+    all_block_ids = [list(range(17)), list(range(17))]
     slices = _send_prefill_chunks(all_block_ids, chunk_size_blocks=4)
     for lg_idx, original in enumerate(all_block_ids):
         reassembled = []
@@ -263,13 +303,13 @@ def test_send_prefill_chunks_integrity_check():
 
 
 def test_send_prefill_chunks_multiple_layer_groups():
-    """Shorter layer groups are projected into the overlapping global chunk."""
+    """Each source layer group is a resident suffix ending at the current chunk."""
     all_block_ids = [list(range(8)), list(range(3))]
     slices = _send_prefill_chunks(all_block_ids, chunk_size_blocks=4)
     assert len(slices) == 2
     assert np.array_equal(slices[0].block_ids_per_layer_groups[0], np.array([0, 1, 2, 3]))
     assert np.array_equal(slices[1].block_ids_per_layer_groups[0], np.array([4, 5, 6, 7]))
-    assert len(slices[0].block_ids_per_layer_groups[1]) == 0
+    assert np.array_equal(slices[0].block_ids_per_layer_groups[1], np.array([0, 1, 2]))
     assert np.array_equal(slices[1].block_ids_per_layer_groups[1], np.array([0, 1, 2]))
     assert slices[0].token_range == TokenRange(start=0, end=4)
     assert slices[1].token_range == TokenRange(start=4, end=8)
@@ -278,9 +318,7 @@ def test_send_prefill_chunks_multiple_layer_groups():
 def test_send_prefill_chunks_preserves_mamba_state_index():
     """mamba_state_index is propagated to every chunk slice."""
     all_block_ids = [list(range(8))]
-    slices = _send_prefill_chunks(all_block_ids,
-                                  chunk_size_blocks=4,
-                                  mamba_state_index=42)
+    slices = _send_prefill_chunks(all_block_ids, chunk_size_blocks=4, mamba_state_index=42)
     assert len(slices) == 2
     for s in slices:
         assert s.mamba_state_index == 42
@@ -1824,6 +1862,7 @@ def test_session_has_transferring_tasks_false():
         ctx_transfer_worker.shutdown()
         gen_transfer_worker.shutdown()
 
+
 def add_and_verify_pipelined_request(
     setup,
     ctx_request_id,
@@ -1913,6 +1952,7 @@ def test_transfer_worker_pipelined(
             worker.shutdown()
         for worker in setup["gen_transfer_workers"]:
             worker.shutdown()
+
 
 if __name__ == "__main__":
     test_transfer_worker_v1(1, 1, False, 1, 1, False, False)

--- a/tests/unittest/disaggregated/test_kv_transfer.py
+++ b/tests/unittest/disaggregated/test_kv_transfer.py
@@ -4,6 +4,7 @@ import os
 import random
 import time
 import uuid
+from unittest.mock import MagicMock
 
 # Exclude IB (no fabric) and gdr_copy (UCX rcache SIGABRT at teardown).
 os.environ.setdefault("UCX_TLS", "^ib,gdr_copy")
@@ -29,6 +30,7 @@ from tensorrt_llm._torch.disaggregation.base.transfer import (
 )
 from tensorrt_llm._torch.disaggregation.native.transfer import TransferWorker, TransferWorkerConfig
 from tensorrt_llm._torch.disaggregation.resource.kv_extractor import KVRegionExtractorV1
+from tensorrt_llm._torch.disaggregation.transceiver import KvCacheTransceiverV2
 from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import KVCacheManagerV2
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest, LlmRequestType
 from tensorrt_llm._torch.pyexecutor.resource_manager import KVCacheManager
@@ -154,6 +156,142 @@ def test_session_status_enum():
         assert hasattr(SessionStatus, name)
         assert SessionStatus[name].value == name
     assert len(SessionStatus) == 7
+
+
+# ---------------------------------------------------------------------------
+# Pipelined prefill chunk creation tests
+# ---------------------------------------------------------------------------
+
+
+def _send_prefill_chunks(
+    all_block_ids,
+    chunk_size_blocks,
+    mamba_state_index=None,
+    tokens_per_block=1,
+    sender_session=None,
+):
+    """Build (and optionally send) chunks through the real ``_build_prefill_chunk`` path.
+
+    ``_build_prefill_chunk`` derives the chunk bounds from ``req.py_last_context_chunk``
+    and ``req.context_remaining_length`` and returns a ``KVSlice`` (``respond_and_send_async``
+    is responsible for sending). This helper
+    drives one call per chunk, collecting the returned slices; when ``sender_session`` is
+    provided it forwards each built slice to the real session to mirror the send path.
+    """
+    all_block_ids = [np.asarray(ids, dtype=np.int64) for ids in all_block_ids]
+    total_blocks = max((len(ids) for ids in all_block_ids), default=0)
+    base_slice = KVSlice(
+        block_ids_per_layer_groups=all_block_ids,
+        mamba_state_index=mamba_state_index,
+    )
+    session = sender_session if sender_session is not None else MagicMock()
+    session.kv_tasks = []
+    transceiver = MagicMock()
+    transceiver._get_or_create_send_session.return_value = session
+    transceiver._create_kv_slice = MagicMock(return_value=base_slice)
+    transceiver._reuse_adapter.tokens_per_block = tokens_per_block
+    transceiver.kv_cache_manager.tokens_per_block = tokens_per_block
+    transceiver._send_reqs = {}
+
+    prompt_len = total_blocks * tokens_per_block
+    req = MagicMock()
+    req.py_disaggregated_params = DisaggregatedParams(disagg_request_id=42)
+    req.prompt_len = prompt_len
+    req.py_beam_width = 1
+
+    if chunk_size_blocks is None or chunk_size_blocks >= total_blocks:
+        chunk_ranges = [(0, total_blocks)]
+    else:
+        chunk_ranges = [
+            (start, min(start + chunk_size_blocks, total_blocks))
+            for start in range(0, total_blocks, chunk_size_blocks)
+        ]
+    if not chunk_ranges:
+        chunk_ranges = [(0, 0)]
+
+    slices = []
+    for idx, (chunk_start, chunk_end) in enumerate(chunk_ranges):
+        is_last_chunk = idx == len(chunk_ranges) - 1
+        req.py_last_context_chunk = (
+            chunk_start * tokens_per_block,
+            chunk_end * tokens_per_block,
+        )
+        req.context_remaining_length = (
+            0 if is_last_chunk else (total_blocks - chunk_end) * tokens_per_block
+        )
+        kv_slice = KvCacheTransceiverV2._build_prefill_chunk(transceiver, req)
+        slices.append(kv_slice)
+        if sender_session is not None:
+            session.send(kv_slice)
+
+    if sender_session is not None:
+        return []
+    return slices
+
+
+@pytest.mark.parametrize(
+        "all_block_ids,chunk_size_blocks,expected_num_slices",
+    [
+        ([[0, 1, 2, 3, 4, 5, 6, 7]], None, 1),
+        ([[0, 1, 2, 3, 4, 5, 6, 7]], 4, 2),
+        ([list(range(10))], 4, 3),
+        ([[], []], 4, 1),
+        ([[0, 1, 2]], 64, 1),
+    ],
+    ids=["no_chunking", "even_split", "uneven_split", "empty_blocks", "chunk_larger_than_total"],
+)
+def test_send_prefill_chunks_basic(all_block_ids, chunk_size_blocks,
+                                   expected_num_slices):
+    """Pipelined prefill chunking produces the expected number of slices."""
+    slices = _send_prefill_chunks(all_block_ids, chunk_size_blocks)
+    assert len(slices) == expected_num_slices
+    assert slices[-1].is_last_slice is True
+    if expected_num_slices > 1:
+        for s in slices[:-1]:
+            assert s.is_last_slice is False
+
+
+def test_send_prefill_chunks_integrity_check():
+    """Reassembled block IDs from all slices must match the original."""
+    all_block_ids = [list(range(17)), list(range(5))]
+    slices = _send_prefill_chunks(all_block_ids, chunk_size_blocks=4)
+    for lg_idx, original in enumerate(all_block_ids):
+        reassembled = []
+        for s in slices:
+            reassembled.extend(s.block_ids_per_layer_groups[lg_idx])
+        assert reassembled == original
+
+
+def test_send_prefill_chunks_multiple_layer_groups():
+    """Shorter layer groups are projected into the overlapping global chunk."""
+    all_block_ids = [list(range(8)), list(range(3))]
+    slices = _send_prefill_chunks(all_block_ids, chunk_size_blocks=4)
+    assert len(slices) == 2
+    assert np.array_equal(slices[0].block_ids_per_layer_groups[0], np.array([0, 1, 2, 3]))
+    assert np.array_equal(slices[1].block_ids_per_layer_groups[0], np.array([4, 5, 6, 7]))
+    assert len(slices[0].block_ids_per_layer_groups[1]) == 0
+    assert np.array_equal(slices[1].block_ids_per_layer_groups[1], np.array([0, 1, 2]))
+    assert slices[0].token_range == TokenRange(start=0, end=4)
+    assert slices[1].token_range == TokenRange(start=4, end=8)
+
+
+def test_send_prefill_chunks_preserves_mamba_state_index():
+    """mamba_state_index is propagated to every chunk slice."""
+    all_block_ids = [list(range(8))]
+    slices = _send_prefill_chunks(all_block_ids,
+                                  chunk_size_blocks=4,
+                                  mamba_state_index=42)
+    assert len(slices) == 2
+    for s in slices:
+        assert s.mamba_state_index == 42
+
+
+def test_send_prefill_chunks_none_mamba_state_index():
+    """mamba_state_index=None is preserved when not set."""
+    all_block_ids = [list(range(4))]
+    slices = _send_prefill_chunks(all_block_ids, chunk_size_blocks=4)
+    assert len(slices) == 1
+    assert slices[0].mamba_state_index is None
 
 
 def create_transfer_worker_setup(
@@ -1082,7 +1220,12 @@ def test_transfer_worker_v2_with_window(
 
 @pytest.mark.timeout(120)
 @pytest.mark.parametrize("use_v2", [False, True], ids=["v1", "v2"])
-def test_transfer_with_gen_prefix_offset(use_v2):
+@pytest.mark.parametrize(
+    "chunk_size_blocks",
+    [None, 2],
+    ids=["single_slice", "sender_chunked"],
+)
+def test_transfer_with_gen_prefix_offset(use_v2, chunk_size_blocks):
     """Verify that only suffix blocks are transferred when gen has a prefix offset.
 
     Simulates gen-side prefix cache: ctx sends all blocks for [0, request_len),
@@ -1171,13 +1314,7 @@ def test_transfer_with_gen_prefix_offset(use_v2):
     ]
 
     try:
-        # Ctx sends all blocks
         tx = ctx_tw.create_tx_session(ctx_request)
-        send_slice = KVSlice(
-            is_last_slice=True,
-            block_ids_per_layer_groups=ctx_block_ids,
-            token_range=TokenRange(start=0, end=request_len),
-        )
 
         # Gen receives only the suffix list; dst_start is derived from block count.
         rx = gen_tw.create_rx_session(gen_request)
@@ -1187,7 +1324,22 @@ def test_transfer_with_gen_prefix_offset(use_v2):
             token_range=TokenRange(start=0, end=request_len),
         )
         rx.receive(recv_slice)
-        tx.send(send_slice)
+
+        if chunk_size_blocks is None:
+            tx.send(
+                KVSlice(
+                    is_last_slice=True,
+                    block_ids_per_layer_groups=ctx_block_ids,
+                    token_range=TokenRange(start=0, end=request_len),
+                )
+            )
+        else:
+            _send_prefill_chunks(
+                ctx_block_ids,
+                chunk_size_blocks=chunk_size_blocks,
+                tokens_per_block=tokens_per_block,
+                sender_session=tx,
+            )
 
         result = tx.wait_complete()
         assert result == WaitResult.COMPLETED, f"tx wait_complete returned {result}"
@@ -1285,7 +1437,7 @@ def test_session_cancel_before_send():
 
 @pytest.mark.timeout(60)
 def test_session_cancel_after_send():
-    """TxSession cancelled after send() queues INIT tasks; future raises."""
+    """TxSession cancelled after send() queues INIT tasks fails the event wait."""
     tensorrt_llm.logger.set_level("debug")
     setup = create_transfer_worker_setup(
         ctx_tp=1,
@@ -1320,19 +1472,229 @@ def test_session_cancel_after_send():
         page_table = ctx_transfer_worker._rank_info.page_table
         block_ids_per_groups = [np.array([], dtype=np.int64) for _ in page_table.layer_groups]
         kv_slice = KVSlice(is_last_slice=True, block_ids_per_layer_groups=block_ids_per_groups)
-        future = tx_session.send(kv_slice)
+        tx_session.send(kv_slice)
 
         # No receiver registered yet; task is INIT.
         tx_session.cancel()
 
         assert tx_session.status == SessionStatus.CANCELLED
         assert tx_session.has_failed()
-        # Future for the cancelled INIT task must raise.
-        with pytest.raises(Exception):
-            future.result(timeout=5.0)
+        assert tx_session.wait_complete() == WaitResult.FAILED
         tx_session.close()
     finally:
         ctx_transfer_worker.shutdown()
+
+
+def _setup_chunked_request(setup, ctx_request_id, gen_request_id, request_len):
+    """Create requests, allocate KV, and collect block IDs for chunked transfer tests."""
+    ctx_transfer_workers = setup["ctx_transfer_workers"]
+    ctx_kv_cache_managers = setup["ctx_kv_cache_managers"]
+    gen_transfer_workers = setup["gen_transfer_workers"]
+    gen_kv_cache_managers = setup["gen_kv_cache_managers"]
+    ctx_info_endpoint = setup["ctx_info_endpoint"]
+    use_v2 = setup["use_v2"]
+    tokens_per_block = setup["tokens_per_block"]
+
+    sampling_params = SamplingParams()
+    unique_rid = uuid.uuid4().int & 0x7FFFFFFFFFFFFFFF
+
+    ctx_request = LlmRequest(
+        request_id=ctx_request_id,
+        max_new_tokens=1,
+        input_tokens=list(range(request_len)),
+        sampling_config=tensorrt_llm.bindings.SamplingConfig(
+            sampling_params._get_sampling_config()
+        ),
+        is_streaming=False,
+        llm_request_type=LlmRequestType.LLMREQUEST_TYPE_CONTEXT_ONLY,
+    )
+    ctx_request.py_disaggregated_params = DisaggregatedParams(disagg_request_id=unique_rid)
+
+    gen_request = LlmRequest(
+        request_id=gen_request_id,
+        max_new_tokens=1,
+        input_tokens=list(range(request_len)),
+        sampling_config=tensorrt_llm.bindings.SamplingConfig(
+            sampling_params._get_sampling_config()
+        ),
+        is_streaming=False,
+        llm_request_type=LlmRequestType.LLMREQUEST_TYPE_GENERATION_ONLY,
+    )
+    gen_request.py_disaggregated_params = DisaggregatedParams(
+        ctx_request_id=ctx_request.py_request_id,
+        ctx_dp_rank=0,
+        ctx_info_endpoint=ctx_info_endpoint,
+        disagg_request_id=unique_rid,
+    )
+
+    ctx_kv_caches, gen_kv_caches = [], []
+    for mgr in ctx_kv_cache_managers:
+        if use_v2:
+            kv = mgr._create_kv_cache(ctx_request.py_request_id, None, None)
+            assert kv.resume(torch.cuda.current_stream().cuda_stream)
+            assert kv.resize(request_len)
+            ctx_kv_caches.append(kv)
+        else:
+            mgr.impl.add_sequence_batch(
+                [(ctx_request.py_request_id, request_len, 1)], [ctx_request]
+            )
+
+    for mgr in gen_kv_cache_managers:
+        if use_v2:
+            kv = mgr._create_kv_cache(gen_request.py_request_id, None, None)
+            assert kv.resume(torch.cuda.current_stream().cuda_stream)
+            assert kv.resize(request_len)
+            gen_kv_caches.append(kv)
+        else:
+            mgr.impl.add_sequence_batch(
+                [(gen_request.py_request_id, request_len, 1)], [gen_request]
+            )
+
+    ctx_block_ids = [
+        get_block_ids_per_layer_groups(mgr, tw, ctx_request.py_request_id, use_v2, tokens_per_block)
+        for mgr, tw in zip(ctx_kv_cache_managers, ctx_transfer_workers, strict=True)
+    ]
+    gen_block_ids = [
+        get_block_ids_per_layer_groups(mgr, tw, gen_request.py_request_id, use_v2, tokens_per_block)
+        for mgr, tw in zip(gen_kv_cache_managers, gen_transfer_workers, strict=True)
+    ]
+
+    return {
+        "ctx_request": ctx_request,
+        "gen_request": gen_request,
+        "ctx_kv_caches": ctx_kv_caches,
+        "gen_kv_caches": gen_kv_caches,
+        "ctx_block_ids": ctx_block_ids,
+        "gen_block_ids": gen_block_ids,
+    }
+
+
+def _verify_and_cleanup_chunked(setup, ctx_info, sender_sessions, receiver_sessions):
+    """Shared verification and cleanup for chunked transfer tests."""
+    ctx_kv_cache_managers = setup["ctx_kv_cache_managers"]
+    gen_kv_cache_managers = setup["gen_kv_cache_managers"]
+    use_v2 = setup["use_v2"]
+
+    ctx_block_ids = ctx_info["ctx_block_ids"]
+    gen_block_ids = ctx_info["gen_block_ids"]
+
+    for session in sender_sessions:
+        assert session.status == SessionStatus.KV_TRANSFERRED
+    for session in receiver_sessions:
+        assert session.status == SessionStatus.KV_TRANSFERRED
+
+    num_layer_groups = len(ctx_block_ids[0])
+    for lg_id in range(num_layer_groups):
+        ctx_data = [
+            get_block_data(mgr, bids[lg_id], lg_id, use_v2, ctx_info["ctx_request"].py_request_id)
+            for mgr, bids in zip(ctx_kv_cache_managers, ctx_block_ids, strict=True)
+        ]
+        gen_data = [
+            get_block_data(mgr, bids[lg_id], lg_id, use_v2, ctx_info["gen_request"].py_request_id)
+            for mgr, bids in zip(gen_kv_cache_managers, gen_block_ids, strict=True)
+        ]
+        for c, g in zip(ctx_data, gen_data, strict=True):
+            assert c.equal(g), f"Layer group {lg_id}: data mismatch with chunked transfer"
+
+    for s in receiver_sessions:
+        s.close()
+    for s in sender_sessions:
+        s.close()
+    if use_v2:
+        torch.cuda.current_stream().synchronize()
+        for kv in ctx_info["ctx_kv_caches"]:
+            kv.close()
+        for kv in ctx_info["gen_kv_caches"]:
+            kv.close()
+
+
+def add_and_verify_chunked_request(
+    setup,
+    ctx_request_id,
+    gen_request_id,
+    request_len,
+    chunk_size_blocks,
+):
+    """Chunked transfer variant: sender sends N slices, receiver sends 1."""
+    ctx_transfer_workers = setup["ctx_transfer_workers"]
+    gen_transfer_workers = setup["gen_transfer_workers"]
+
+    ctx_info = _setup_chunked_request(setup, ctx_request_id, gen_request_id, request_len)
+    ctx_block_ids = ctx_info["ctx_block_ids"]
+    gen_block_ids = ctx_info["gen_block_ids"]
+    token_range = TokenRange(start=0, end=request_len)
+
+    sender_sessions = [tw.create_tx_session(ctx_info["ctx_request"]) for tw in ctx_transfer_workers]
+    for sender_session, block_ids_per_groups in zip(sender_sessions, ctx_block_ids, strict=True):
+        _send_prefill_chunks(
+            block_ids_per_groups,
+            chunk_size_blocks=chunk_size_blocks,
+            tokens_per_block=setup["tokens_per_block"],
+            sender_session=sender_session,
+        )
+
+    receiver_sessions = [
+        tw.create_rx_session(ctx_info["gen_request"]) for tw in gen_transfer_workers
+    ]
+    for recv_session, block_ids_per_groups in zip(receiver_sessions, gen_block_ids, strict=True):
+        full_slice = KVSlice(
+            is_last_slice=True,
+            block_ids_per_layer_groups=block_ids_per_groups,
+            token_range=token_range,
+        )
+        recv_session.receive(full_slice)
+
+    for session in sender_sessions:
+        result = session.wait_complete()
+        assert result == WaitResult.COMPLETED, f"tx wait_complete returned {result}"
+    for session in receiver_sessions:
+        result = session.wait_complete(blocking=True)
+        assert result == WaitResult.COMPLETED, f"rx wait_complete returned {result}"
+
+    _verify_and_cleanup_chunked(setup, ctx_info, sender_sessions, receiver_sessions)
+
+
+CHUNKED_TEST_CONFIGS = [
+    (1, 1, False, 1, 1, False, False, True, "v2_tp1_pp1_chunked"),
+    (1, 1, False, 1, 1, False, False, False, "v1_tp1_pp1_chunked"),
+]
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize(
+    "ctx_tp,ctx_pp,ctx_enable_dp,gen_tp,gen_pp,gen_enable_dp,is_mla,use_v2",
+    [(c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]) for c in CHUNKED_TEST_CONFIGS],
+    ids=[c[8] for c in CHUNKED_TEST_CONFIGS],
+)
+def test_transfer_worker_chunked(
+    ctx_tp, ctx_pp, ctx_enable_dp, gen_tp, gen_pp, gen_enable_dp, is_mla, use_v2
+):
+    """Test transfer worker with sender-side chunking for V1 and V2."""
+    tensorrt_llm.logger.set_level("info")
+    logger.info(f"Test transfer worker {'V2' if use_v2 else 'V1'} with chunked transfer")
+
+    setup = create_transfer_worker_setup(
+        ctx_tp=ctx_tp,
+        ctx_pp=ctx_pp,
+        ctx_enable_dp=ctx_enable_dp,
+        gen_tp=gen_tp,
+        gen_pp=gen_pp,
+        gen_enable_dp=gen_enable_dp,
+        is_mla=is_mla,
+        use_v2=use_v2,
+    )
+
+    request_len = setup["request_len"]
+    tokens_per_block = setup["tokens_per_block"]
+    total_blocks = (request_len + tokens_per_block - 1) // tokens_per_block
+    chunk_size = max(1, total_blocks // 2)
+
+    try:
+        add_and_verify_chunked_request(setup, 0, 1, request_len, chunk_size_blocks=chunk_size)
+        add_and_verify_chunked_request(setup, 2, 3, request_len * 2, chunk_size_blocks=chunk_size)
+    finally:
+        for worker in setup["ctx_transfer_workers"]:
+            worker.shutdown()
         for worker in setup["gen_transfer_workers"]:
             worker.shutdown()
 
@@ -1462,6 +1824,95 @@ def test_session_has_transferring_tasks_false():
         ctx_transfer_worker.shutdown()
         gen_transfer_worker.shutdown()
 
+def add_and_verify_pipelined_request(
+    setup,
+    ctx_request_id,
+    gen_request_id,
+    request_len,
+    chunk_size_blocks,
+):
+    """Pipelined transfer: sender sends chunks incrementally, receiver sends 1."""
+    ctx_transfer_workers = setup["ctx_transfer_workers"]
+    gen_transfer_workers = setup["gen_transfer_workers"]
+
+    ctx_info = _setup_chunked_request(setup, ctx_request_id, gen_request_id, request_len)
+    ctx_block_ids = ctx_info["ctx_block_ids"]
+    gen_block_ids = ctx_info["gen_block_ids"]
+
+    sender_sessions = [tw.create_tx_session(ctx_info["ctx_request"]) for tw in ctx_transfer_workers]
+    for sender_session, block_ids_per_groups in zip(sender_sessions, ctx_block_ids):
+        _send_prefill_chunks(
+            block_ids_per_groups,
+            chunk_size_blocks=chunk_size_blocks,
+            tokens_per_block=setup["tokens_per_block"],
+            sender_session=sender_session,
+        )
+
+    receiver_sessions = [
+        tw.create_rx_session(ctx_info["gen_request"]) for tw in gen_transfer_workers
+    ]
+    for recv_session, block_ids_per_groups in zip(receiver_sessions, gen_block_ids):
+        full_slice = KVSlice(
+            is_last_slice=True,
+            block_ids_per_layer_groups=block_ids_per_groups,
+        )
+        recv_session.receive(full_slice)
+
+    for session in sender_sessions:
+        result = session.wait_complete()
+        assert result == WaitResult.COMPLETED, f"tx wait_complete returned {result}"
+    for session in receiver_sessions:
+        result = session.wait_complete(blocking=True)
+        assert result == WaitResult.COMPLETED, f"rx wait_complete returned {result}"
+
+    _verify_and_cleanup_chunked(setup, ctx_info, sender_sessions, receiver_sessions)
+
+
+PIPELINED_TEST_CONFIGS = [
+    (1, 1, False, 1, 1, False, False, True, "v2_tp1_pp1_pipelined"),
+    (1, 1, False, 1, 1, False, False, False, "v1_tp1_pp1_pipelined"),
+]
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize(
+    "ctx_tp,ctx_pp,ctx_enable_dp,gen_tp,gen_pp,gen_enable_dp,is_mla,use_v2",
+    [(c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]) for c in PIPELINED_TEST_CONFIGS],
+    ids=[c[8] for c in PIPELINED_TEST_CONFIGS],
+)
+def test_transfer_worker_pipelined(
+    ctx_tp, ctx_pp, ctx_enable_dp, gen_tp, gen_pp, gen_enable_dp, is_mla, use_v2
+):
+    """Test pipelined transfer: chunks sent incrementally for V1 and V2."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    tensorrt_llm.logger.set_level("info")
+    logger.info(f"Test transfer worker {'V2' if use_v2 else 'V1'} with pipelined transfer")
+
+    setup = create_transfer_worker_setup(
+        ctx_tp=ctx_tp,
+        ctx_pp=ctx_pp,
+        ctx_enable_dp=ctx_enable_dp,
+        gen_tp=gen_tp,
+        gen_pp=gen_pp,
+        gen_enable_dp=gen_enable_dp,
+        is_mla=is_mla,
+        use_v2=use_v2,
+    )
+
+    request_len = setup["request_len"]
+    tokens_per_block = setup["tokens_per_block"]
+    total_blocks = (request_len + tokens_per_block - 1) // tokens_per_block
+    chunk_size = max(1, total_blocks // 2)
+
+    try:
+        add_and_verify_pipelined_request(setup, 0, 1, request_len, chunk_size_blocks=chunk_size)
+        add_and_verify_pipelined_request(setup, 2, 3, request_len * 2, chunk_size_blocks=chunk_size)
+    finally:
+        for worker in setup["ctx_transfer_workers"]:
+            worker.shutdown()
+        for worker in setup["gen_transfer_workers"]:
+            worker.shutdown()
 
 if __name__ == "__main__":
     test_transfer_worker_v1(1, 1, False, 1, 1, False, False)


### PR DESCRIPTION

### Summary

Implements pipelined prefill transfer for disaggregated serving. Instead of waiting for every
prefill chunk to finish before transferring the request's KV cache, the context server sends the
completed KV blocks after each chunk. This overlaps GPU prefill compute with RDMA transfer and
leaves only the final transfer on the critical path when transfer is faster than prefill.

```text
Baseline
  compute    [ chunk0 ][ chunk1 ][ chunk2 ][ chunk3 ]
  transfer                                            [======= whole prompt =======]
  gen unblocked at                                                                  ^

Pipelined
  compute    [ chunk0 ][ chunk1 ][ chunk2 ][ chunk3 ]
  transfer             [  c0  ]  [  c1  ]  [  c2  ]  [  c3  ]
  gen unblocked at                                           ^
```

Chunking remains sender-side only. The context server creates multiple `KVSendTask`s in one
`TxSession`; the generation server posts one receive for the whole request and completes that
receive when the final-slice result arrives.

Related work by @chienchunhung:
[KV cache transfer: Reducing KV Block Residency and Peak Memory Pressure in Disaggregated Serving](https://docs.google.com/document/d/1j1rtYYfyOvPlUDvSY-TxltJ5m1EHV8LhEcM7fLhjHzw/edit?tab=t.r8x3eytflwjo#heading=h.i0grk6usx8bp)

### Configuration

The feature is gated by `CacheTransceiverConfig.enable_pipelined_transfer`.

```yaml
# Context server
context_servers:
  cache_transceiver_config:
    backend: NIXL
    enable_pipelined_transfer: true
  enable_chunked_prefill: true

# Generation server
generation_servers:
  cache_transceiver_config:
    backend: NIXL
    enable_pipelined_transfer: true
  enable_chunked_prefill: true

schedule_style: generation_first
```

`resolve_cache_transceiver_config()` in
`tensorrt_llm/_torch/pyexecutor/config_utils.py` handles runtime-independent selection:

- With pipelining enabled and no explicit runtime, NIXL auto-selects the Python transceiver.
- Explicit `transceiver_runtime: CPP` is rejected.
- A Python transceiver with a non-NIXL backend is rejected.
- Resolution runs before cache-manager selection in `create_py_executor()` and again in
  `create_kv_cache_transceiver()` for callers that bypass the executor-creation path.

Runtime-dependent restrictions are checked by
`KvCacheTransceiverV2._resolve_pipelined_transfer()` after the mapping and cache manager exist:

| Requirement | Reason | Enforcement |
|---|---|---|
| Python NIXL transceiver | Pipelining is implemented by `KvCacheTransceiverV2` | `resolve_cache_transceiver_config()` |
| `pipeline_parallel_size == 1` | One sender rank must own every layer needed by a chunk | `_resolve_pipelined_transfer()` |
| `kv_cache_bounce_size_mb == 0` | Bounce staging coalesces a whole request rather than per-chunk writes | `_resolve_pipelined_transfer()` |
| No Mamba/hybrid cache manager | Recurrent state is mutable request state, not block-addressable chunk state | `_resolve_pipelined_transfer()` |
| `enable_chunked_prefill: true` | Chunk boundaries come from `py_last_context_chunk` | `PyExecutor._validate_request()` |
| `beam_width == 1` | Chunk projection does not model the packed beam layout | `PyExecutor._validate_request()` and `_build_prefill_chunk()` |
| `schedule_style == generation_first` | The generation server must register destination blocks before an intermediate chunk is sent | `PyExecutor._validate_request()` |

The last three checks are request checks, limited to disaggregated context-only requests using a
pipelined transceiver. Aggregate/warmup requests and generation-only requests are not rejected.
The disaggregated YAML parser and `serve.py` do not perform feature-specific startup validation;
the CLI schedule-style override continues to be applied after parsing.

## Architecture

### Sender-side chunks, monolithic receiver

```mermaid
flowchart LR
    subgraph ctx [Context server]
        exec[PyExecutor._send_kv_async] --> transceiver[respond_and_send_async]
        transceiver --> build[_build_prefill_chunk]
        build --> tx["TxSession: one per request"]
        tx --> c0["KVSendTask 0"]
        tx --> c1["KVSendTask 1"]
        tx --> cn["KVSendTask N-1, is_last_slice"]
    end
    subgraph gen [Generation server]
        rx["RxSession: one per request"] --> task["one whole-request KVRecvTask"]
    end
    c0 -->|RDMA write| task
    c1 -->|RDMA write| task
    cn -->|final RDMA write| task
```

`request_and_receive_async()` is unchanged: the receiver allocates and advertises the full
destination once. Each sender result echoes the receiver's task id, and `is_last_slice` tells the
receiver when no more chunks remain.

### Slice model

`KVSlice.token_range` distinguishes the two paths:

- A monolithic slice leaves `token_range=None` and covers `prompt_len`.
- A pipelined slice carries a block-aligned half-open token range and sets
  `is_last_slice=True` only for the final emitted slice.
- Layer-group block lists may be empty when that group contributes nothing to the current slice.

`SessionArgsBase.prompt_len` is the request-wide extent. It is independent of a chunk's
`token_range` and is required for prompt-wide calculations such as the final sliding-window
boundary.

### Deriving a chunk

`KvCacheTransceiverV2._build_prefill_chunk()` converts the scheduler's
`req.py_last_context_chunk` token bounds to block coordinates:

```text
first chunk start = 0
later chunk start = floor(chunk_start_token / tokens_per_block)
non-final end     = floor(chunk_end_token / tokens_per_block)
final end         = ceil(chunk_end_token / tokens_per_block)
```

The first slice starts at block zero so a context-side prefix-reuse hit is included even though
the scheduler starts computing at `prepopulated_prompt_len`. Non-final partial blocks are deferred
to the next chunk; the final chunk rounds up so the prompt tail is not stranded. If a non-final
chunk completes no transferable block, no slice is emitted.

The final slice is still emitted when its token range is empty. This preserves the final-slice
signal for cases where all remaining attention groups were already sent or contain no blocks.

### Sliding-window attention

SWA layers are deliberately not pipelined. Pages can leave the active window between prefill
chunks, so sending each intermediate resident suffix can either transfer stale pages or lose pages
that are still needed in the generation server's final window.

For a layer group whose `sliding_window_size < prompt_len`:

- Intermediate slices carry an empty block list for that group.
- The final slice carries the complete final active window in one transfer.
- The sender does not project the receiver's whole-prompt list down to the final token range for
  that group; it first trims the receiver list to the source window and then aligns the two lists.

Non-windowed groups continue to transfer chunk by chunk. A model with mixed full-attention and SWA
groups therefore pipelines the full-attention KV while deferring only the SWA groups.

### Native sender addressing

`project_blocks_to_global_chunk()` now lives next to its only production consumer in
`tensorrt_llm/_torch/disaggregation/native/transfer.py`. It intersects a global chunk interval
with a block list represented as a resident suffix; a non-overlapping list produces an empty
projection.

`Sender._build_kv_write_meta()` uses the slice end as the coordinate-space extent:

```text
slice_end   = token_range.end for a chunk, otherwise prompt_len
total_blocks = ceil(slice_end / tokens_per_block)
token_start = (total_blocks - resident_block_count) * tokens_per_block
```

For partial non-SWA chunks, the receiver's whole-prompt block list is projected to the same global
chunk. For the final SWA slice, that projection is skipped so the complete active window remains
addressable. Generation-side prefix reuse and sender/receiver window differences are then handled
by `_trim_receiver_window_head()` and `_align_kv_blocks()`.

This keeps the addressing correct for:

- no prefix reuse;
- context-side prefix reuse only;
- generation-side prefix reuse only;
- different cache states on the two servers;
- incremental cache allocation;
- full-attention and mixed SWA models.

### Result protocol and slice ids

The sender and receiver have different slice namespaces: the sender has one task per prefill
chunk, while the receiver currently has one whole-request task. `WriteMeta` therefore carries both:

- `slice_id`: the local sender task/chunk id, used for sender-side task lookup and diagnostics;
- `receiver_slice_id`: the peer's task id copied from `RecvReqInfo`, used in
  `KV_AGENT_RESULT`.

The binary wire prefix remains `<qqq?Bq>`:

```text
instance_rank, unique_rid, receiver_slice_id, is_last_slice, status, transfer_size
```

`RxSession.process_kv_agent_result()` validates and indexes `receiver_slice_id`. The protocol shape
does not change; current receivers advertise task zero, so every sender chunk reports
`receiver_slice_id == 0`.

### TxSession completion and registration races

A `TxSession` owns all KV tasks and the optional auxiliary task for a request.

- `_has_last_slice` is set when a final slice is appended.
- KV completion requires `_has_last_slice`, at least one task, and every KV task transferred.
  This prevents an intermediate chunk from making the session appear complete before the final
  task exists.
- `FULLY_TRANSFERRED` additionally requires the generation-first auxiliary transfer.
- `has_transferring_tasks()` includes both KV and auxiliary tasks.

`TxSession.lock` atomically appends a task and snapshots currently registered peers. The listener's
late-registration path uses the same lock to save peer info and snapshot existing tasks. Actual
metadata construction and queue dispatch happen after releasing the lock, keeping transfer work
outside the critical section while ensuring a task is seen by either the send path or the replay
path.

## Executor and lifecycle integration

### Sending from the executor loop

`PyExecutor._send_kv_async()` runs after each forward step:

1. Skip a context request already in `GENERATION_COMPLETE`.
2. Skip all further sends, including a final send, when that request has a pending cancellation.
3. Fail a request whose prior send session was retired and can no longer be recreated.
4. On the final chunk, call `async_transfer_manager.start_transfer()` before sending, then send the
   final slice and start the final-transfer timeout clock.
5. On an intermediate chunk, call `respond_and_send_async()` without moving the request into the
   transfer manager.

`respond_and_send_async()` creates or reuses the `TxSession`, builds the next chunk, and finalizes
auxiliary state only when the emitted slice is final. Request state changes to
`DISAGG_CONTEXT_TRANS_IN_PROGRESS` only at that point; session membership tracks ownership during
earlier chunks.

No additional CUDA synchronization is introduced. The existing sampler event synchronization
completes before `_send_kv_async()` dispatches the slice.

### Cancellation, failure, and safe retirement

Pipelining allows fabric writes while the request is still in `CONTEXT_INIT`, so request state
alone cannot answer whether its KV pages are safe to release.

- `KvCacheTransceiverV2.has_inflight_transfer()` derives ownership from the send/receive session
  maps.
- `_is_request_in_transmission()` combines request phase with session ownership, routing
  mid-prefill cancellation through the transceiver.
- Cancelling a session marks logical terminal state immediately but leaves a task in
  `TRANSFERRING` until the physical write finishes. INIT KV and auxiliary tasks are failed
  immediately.
- `py_kv_send_session_retired` prevents recreating a sender session after teardown has removed the
  peer registration. A later send attempt transitions the request to `DISAGG_TRANS_ERROR`.

In TP/PP deployments, logical outcome and physical quiescence are reconciled across ranks.
`_ctx_consensus_outcome()` packs cancelled, failed, completed, and locally quiesced request ids into
the existing outcome allgather, avoiding a second collective per sweep:

- cancellation or failure is global if any rank reports it;
- successful completion requires all ranks;
- a cancelled or failed session is retired only after every participating rank reports no
  transferring KV or auxiliary task.

A bounded wait timeout is nonterminal: the session remains live and retains its pages because a
peer write may still be active. The polling path logs the timeout and retries on a later sweep.

## Tests

The updated unit coverage exercises:

- chunk derivation, unaligned boundaries, prefix reuse, empty chunks, and final-slice signaling;
- full-attention, SWA-only, and mixed SWA/full-attention source/destination addressing;
- sender and receiver slice-id separation;
- `TxSession._has_last_slice` completion gating;
- pending cancellation and `GENERATION_COMPLETE` send suppression;
- retirement only after KV and auxiliary writers quiesce on all ranks;
- folded TP/PP outcome and quiescence consensus;
- runtime/request validation for unsupported combinations.

The old parser-level disaggregated-config tests were removed because feature-specific validation
now occurs in the executor/transceiver, not in `extract_disagg_cfg()`.

## Change inventory since `1a80e56eebc420684d7fc90dc14ad8c3a633e42c`

| File | Diff (+/-) | Purpose |
|---|---:|---|
| `tensorrt_llm/_torch/disaggregation/base/transfer.py` | +7/-61 | Keep the slice/session data model; move native-only projection logic out |
| `tensorrt_llm/_torch/disaggregation/native/transfer.py` | +175/-210 | Chunk/SWA addressing, dual slice ids, session completion and task dispatch |
| `tensorrt_llm/_torch/disaggregation/transceiver.py` | +110/-103 | Chunk construction, compatibility gates, lifecycle and quiescence consensus |
| `tensorrt_llm/_torch/pyexecutor/config_utils.py` | +47/-0 | Centralized transceiver runtime resolution and backend validation |
| `tensorrt_llm/_torch/pyexecutor/kv_cache_transceiver.py` | +2/-79 | Delegate configuration resolution and runtime-dependent checks |
| `tensorrt_llm/_torch/pyexecutor/llm_request.py` | +1/-3 | Retired-session request flag documentation |
| `tensorrt_llm/_torch/pyexecutor/py_executor.py` | +28/-22 | Request validation and per-step send/cancellation gating |
| `tensorrt_llm/_torch/pyexecutor/py_executor_creator.py` | +1/-8 | Resolve transceiver configuration before cache-manager selection |
| `tensorrt_llm/commands/serve.py` | +3/-2 | Restore schedule-style override behavior |
| `tensorrt_llm/llmapi/disagg_utils.py` | +3/-44 | Remove feature-specific parser validation |
| `tensorrt_llm/llmapi/llm_args.py` | +4/-3 | Document the complete pipelining requirements on the config field |
| `tests/integration/defs/accuracy/test_disaggregated_serving.py` | +2/-47 | Update disaggregated accuracy coverage/configuration |
| `tests/integration/test_lists/test-db/l0_dgx_b200.yml` | +0/-2 | Remove obsolete test-list entries |
| `tests/unittest/disaggregated/test_chunked_transfer.py` | +295/-232 | Consolidated chunking, SWA, lifecycle, and validation tests |
| `tests/unittest/disaggregated/test_disagg_utils.py` | +0/-93 | Remove parser-validation tests |
| `tests/unittest/disaggregated/test_kv_transfer.py` | +17/-47 | Session and auxiliary-transfer behavior |
| `tests/unittest/disaggregated/test_transceiver_bounded_polling.py` | +86/-20 | Quiescence, consensus, cancellation, and bounded polling |

The cumulative diff is 781 insertions and 976 deletions across 17 files.
