### PR TITLE
[None][fix] Pipeline cache: Reactivate relevant graph args upon restore

### DIFF
--- a/tensorrt_llm/_torch/auto_deploy/transform/pipeline_cache/pipeline_cache.py
+++ b/tensorrt_llm/_torch/auto_deploy/transform/pipeline_cache/pipeline_cache.py
@@ -41,6 +41,7 @@ from pydantic import Field, model_validator
 
 from ...models.factory import ModelFactory
 from ...shim.interface import CachedSequenceInterface
+from ...utils._graph import named_graphmodules
 from ...utils.logger import ad_logger
 from ..interface import (
     BaseTransform,
@@ -83,6 +84,21 @@ def _validate_no_forward_hooks(model: nn.Module) -> None:
             "pipeline_cache does not support caching modules with forward hooks; "
             f"modules with forward hooks: {modules_with_hooks}"
         )
+
+
+def _restore_managed_graph_inputs(model: nn.Module, cm: CachedSequenceInterface) -> None:
+    """Activate interface-managed inputs required by a restored graph."""
+    active_args = set(cm.info.named_args)
+    available_args = cm.info.available_args
+
+    for _, graph_module in named_graphmodules(model):
+        for node in graph_module.graph.nodes:
+            if node.op != "placeholder":
+                continue
+            name = str(node.target)
+            if name in available_args and name not in active_args:
+                cm.info.activate_arg(name)
+                active_args.add(name)
 
 
 def _default_pipeline_cache_root() -> str:
@@ -186,7 +202,7 @@ class PipelineCache(BaseTransform):
 
     def maybe_restore(
         self,
-        _cm: CachedSequenceInterface,
+        cm: CachedSequenceInterface,
         factory: ModelFactory,
         shared_config: SharedConfig,
         transform_index: int,
@@ -203,6 +219,7 @@ class PipelineCache(BaseTransform):
         module: nn.Module | None = None
         try:
             module = self._load_module(context)
+            _restore_managed_graph_inputs(module, cm)
             local_success = True
         except Exception as exc:
             ad_logger.warning(f"Failed to restore AutoDeploy pipeline cache: {exc}")

--- a/tests/unittest/auto_deploy/singlegpu/transformations/test_pipeline_cache.py
+++ b/tests/unittest/auto_deploy/singlegpu/transformations/test_pipeline_cache.py
@@ -128,6 +128,11 @@ class _ToyModule(nn.Module):
         return x + self.weight
 
 
+class _BatchInfoToyModule(nn.Module):
+    def forward(self, input_ids, position_ids, batch_info_host):
+        return input_ids, position_ids, batch_info_host
+
+
 class _PartialBoundHookOwner:
     def __init__(self, payload_value):
         self.payload_value = payload_value
@@ -214,6 +219,20 @@ class _BuildGraphForPipelineCache(BaseTransform):
         _COUNTERS["build"] += 1
         gm = symbolic_trace(_ToyModule().to("meta"))
         gm.meta["build_counter"] = _COUNTERS["build"]
+        return gm, TransformInfo(
+            skipped=False,
+            num_matches=1,
+            is_clean=True,
+            has_valid_shapes=True,
+        )
+
+
+@TransformRegistry.register("_unit_test_build_graph_with_batch_info_for_pipeline_cache")
+class _BuildGraphWithBatchInfoForPipelineCache(BaseTransform):
+    def _apply_to_full_model(self, model, cm, factory, shared_config: SharedConfig):
+        _COUNTERS["build"] += 1
+        gm = symbolic_trace(_BatchInfoToyModule())
+        cm.info.activate_arg("batch_info_host")
         return gm, TransformInfo(
             skipped=False,
             num_matches=1,
@@ -532,6 +551,31 @@ def test_pipeline_cache_transform_restores_and_skips_prefix(monkeypatch, tmp_pat
     assert list(tmp_path.rglob(HOOKS_FILE_NAME))
     assert list(tmp_path.glob("*/rank_0"))
     assert not list(tmp_path.glob("*/pipeline_cache/rank_0"))
+
+
+def test_pipeline_cache_restore_preserves_graph_input_interface_state(monkeypatch, tmp_path):
+    """A cache hit restores interface state required by inputs in the cached graph."""
+    _reset_counters()
+    _patch_mem_stats(monkeypatch)
+    factory = _DummyFactory(model="dummy-model")
+    config = _optimizer_config(
+        tmp_path, "_unit_test_build_graph_with_batch_info_for_pipeline_cache"
+    )
+
+    cm_first = _cache_seq_interface()
+    model_first = InferenceOptimizer(factory=factory, config=config)(cm_first)
+    assert "batch_info_host" in cm_first.named_args
+    assert len(model_first(**cm_first.named_args)) == 3
+
+    cm_restored = _cache_seq_interface()
+    assert "batch_info_host" not in cm_restored.named_args
+    model_restored = InferenceOptimizer(factory=factory, config=config)(cm_restored)
+
+    batch_info_nodes = model_restored.graph.find_nodes(op="placeholder", target="batch_info_host")
+    assert _COUNTERS == {"build": 1, "boundary": 1, "after": 2}
+    assert len(batch_info_nodes) == 1
+    assert len(model_restored(**cm_restored.named_args)) == 3
+    assert "batch_info_host" in cm_restored.named_args
 
 
 def test_pipeline_cache_ignores_post_boundary_runtime_transform_config(monkeypatch, tmp_path):


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cached pipeline restores so required managed graph inputs are reactivated correctly after a cache hit.
  * Improved restored model behavior to preserve input interface state before re-running the pipeline.
* **Tests**
  * Added coverage for cache-hit restoration with interface-managed inputs.
  * Verified the restored graph keeps the expected input placeholder and active argument state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

Pipeline-cache hits restore the cached FX graph into a fresh CachedSequenceInterface while skipping the transforms that originally activated its managed graph
  inputs. For expert-parallel graphs, this leaves batch_info_host present in the restored graph but absent from SequenceInfo.named_args, causing:

  TypeError: forward() missing 1 required positional argument: 'batch_info_host'

  After loading a cached module, the pipeline cache now walks its GraphModule placeholders and activates any missing inputs recognized by
  SequenceInfo.available_args. Already-active and model-owned inputs remain untouched.

  This keeps the restored graph as the source of truth and requires no cache-format or manifest changes.

  ## Test Coverage

  Added test_pipeline_cache_restore_preserves_graph_input_interface_state, which:

  - Creates a cold cache entry requiring batch_info_host.
  - Restores it using a fresh CachedSequenceInterface.
  - Verifies the pre-cache transforms were skipped.
  - Verifies the restored graph executes with cm.named_args.

  The complete pipeline-cache unit suite passes: 48 passed.

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
