### PR TITLE
[TRTLLM-6905][feat] MM encoder cache

### DIFF
--- a/docs/source/models/supported-models.md
+++ b/docs/source/models/supported-models.md
@@ -124,6 +124,26 @@ Note:
 - V: Video
 - A: Audio
 
+## Multimodal Encoder Optimizations
+
+The following optimizations are available to models that implement
+`MultimodalModelMixin`. Currently, only `Mistral3ForConditionalGeneration` supports them.
+
+| Model Architecture | Multimodal Encoder Side Stream | Multimodal Embeddings Cache |
+| ------------------ | ------------------------------ | --------------------------- |
+| `Mistral3ForConditionalGeneration` | Yes | Yes |
+
+- **Multimodal encoder side stream** prefetches encoder work for pending requests on a separate
+  CUDA stream, allowing it to overlap with work on the main stream. Set
+  `multimodal_config.encoder_side_stream_max_ahead` to a positive value to enable it; the value
+  limits the number of prefetched requests that can be ahead of admission. This option is mutually
+  exclusive with `multimodal_config.encoder_cuda_graph` and can increase peak GPU memory use.
+- **Multimodal embeddings cache** is a per-model, cross-request LRU cache of encoder embeddings.
+  Set `multimodal_config.encoder_cache_max_bytes` to its capacity (for example, `"512MiB"`), or
+  `0` to disable it. Entries are cached per multimodal item, but a request reuses cached embeddings
+  only when all of its items hit the cache. At present, only single-modality requests are cacheable;
+  mixed-modality requests bypass the cache.
+
 # Visual Generation Models
 
 TensorRT-LLM provides beta support for diffusion-based image and video generation.

--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -669,6 +669,8 @@ class Mistral3VLM(MultimodalModelMixin, PreTrainedModel):
     `tensorrt_llm/inputs/utils.py`).
     """
 
+    supports_encoder_cache = True
+
     def __init__(
         self,
         model_config: ModelConfig[Mistral3Config],

--- a/tensorrt_llm/_torch/models/modeling_mistral.py
+++ b/tensorrt_llm/_torch/models/modeling_mistral.py
@@ -786,8 +786,16 @@ class Mistral3VLM(MultimodalModelMixin, PreTrainedModel):
         return self._image_token_ids
 
     @property
-    def text_embedding_layer(self) -> torch.nn.Module:
+    def text_embedding_layer(self) -> Embedding:
         return self.llm.model.embed_tokens
+
+    @property
+    def embedding_dim(self) -> int:
+        return self.text_embedding_layer.embedding_dim
+
+    @property
+    def embedding_dtype(self) -> torch.dtype:
+        return self.text_embedding_layer.weight.dtype
 
     @property
     def draft_config(self):

--- a/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
@@ -312,20 +312,23 @@ class MultimodalModelMixin:
         the single tensor contract for both encoded and cached-only paths.
         """
         encoder_cache = self._get_multimodal_encoder_cache()
-        cache_hits = [False] * len(multimodal_params)
+        cache_misses = []
         if encoder_cache is not None:
-            cache_hits = [
-                self._attach_encoder_cache_hit(param, encoder_cache) for param in multimodal_params
-            ]
+            for param in multimodal_params:
+                if param.multimodal_data.get("multimodal_embedding") is not None:
+                    # The forward that attached this request-local embedding already populated the
+                    # persistent cache.
+                    continue
+                if not self._attach_encoder_cache_hit(param, encoder_cache):
+                    cache_misses.append(param)
 
         embeddings = get_multimodal_embeddings(
             encoder_forward_fn=self.encode_multimodal_inputs,
             multimodal_params=list(multimodal_params),
         )
         if encoder_cache is not None:
-            for param, cache_hit in zip(multimodal_params, cache_hits, strict=True):
-                if not cache_hit:
-                    self._write_encoder_cache_entries(param, encoder_cache)
+            for param in cache_misses:
+                self._write_encoder_cache_entries(param, encoder_cache)
 
         # Validate post-gather so cached-only paths (KV reuse, all-cached chunked prefill) are also
         # checked, not just paths that ran the encoder.

--- a/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
@@ -16,7 +16,17 @@
 
 import contextlib
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Hashable, Iterable, Iterator, Optional, Sequence
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Dict,
+    Hashable,
+    Iterable,
+    Iterator,
+    Optional,
+    Sequence,
+)
 
 import torch
 
@@ -119,6 +129,9 @@ class MultimodalModelMixin:
       hit the cache before cached embeddings are reused. Mixed-modality `MultimodalParams` objects
       bypass the persistent cache.
     """
+
+    supports_encoder_cache: ClassVar[bool] = False
+    """Whether the model's production forward path uses the persistent encoder cache."""
 
     model_config: ModelConfig
     _multimodal_encoder_cache: Optional[TensorLRUCache] = None
@@ -299,17 +312,20 @@ class MultimodalModelMixin:
         the single tensor contract for both encoded and cached-only paths.
         """
         encoder_cache = self._get_multimodal_encoder_cache()
+        cache_hits = [False] * len(multimodal_params)
         if encoder_cache is not None:
-            for param in multimodal_params:
-                self._attach_encoder_cache_hit(param, encoder_cache)
+            cache_hits = [
+                self._attach_encoder_cache_hit(param, encoder_cache) for param in multimodal_params
+            ]
 
         embeddings = get_multimodal_embeddings(
             encoder_forward_fn=self.encode_multimodal_inputs,
             multimodal_params=list(multimodal_params),
         )
         if encoder_cache is not None:
-            for param in multimodal_params:
-                self._write_encoder_cache_entries(param, encoder_cache)
+            for param, cache_hit in zip(multimodal_params, cache_hits, strict=True):
+                if not cache_hit:
+                    self._write_encoder_cache_entries(param, encoder_cache)
 
         # Validate post-gather so cached-only paths (KV reuse, all-cached chunked prefill) are also
         # checked, not just paths that ran the encoder.
@@ -336,9 +352,13 @@ class MultimodalModelMixin:
             return None
 
         if self._multimodal_encoder_cache is None:
+            # Per-item embeddings are views produced by splitting a request-level encoder output.
+            # Clone them so a cached item neither aliases mutable caller output nor retains the
+            # entire batch allocation while cache accounting charges only its logical size. This
+            # briefly needs source and clone memory during insertion, but preserves existing cache
+            # entries when the copy cannot be allocated.
             self._multimodal_encoder_cache = TensorLRUCache(
                 max_bytes,
-                clone_on_insert=True,
                 name=_MM_ENCODER_CACHE_LOG_NAME,
             )
             try:
@@ -347,8 +367,8 @@ class MultimodalModelMixin:
             except NotImplementedError:
                 logger.info(
                     f"{_MM_ENCODER_CACHE_LOG_NAME}: created with max_bytes={max_bytes}, "
-                    "clone_on_insert=True; embedding row capacity unavailable because the "
-                    "model does not implement embedding_dim and embedding_dtype."
+                    "embedding row capacity unavailable because the model does not implement "
+                    "embedding_dim and embedding_dtype."
                 )
             else:
                 bytes_per_embedding_row = (
@@ -358,7 +378,7 @@ class MultimodalModelMixin:
                 logger.info(
                     f"{_MM_ENCODER_CACHE_LOG_NAME}: created with max_bytes={max_bytes}, "
                     f"max_embedding_rows={max_embedding_rows}, embedding_dim={embedding_dim}, "
-                    f"embedding_dtype={embedding_dtype}, clone_on_insert=True"
+                    f"embedding_dtype={embedding_dtype}"
                 )
         return self._multimodal_encoder_cache
 
@@ -371,11 +391,17 @@ class MultimodalModelMixin:
         not cache mixed-modality params today.
         """
         mm_data = param.multimodal_data or {}
+        modalities = [key for key in _MM_DATA_INPUT_MODALITY_KEYS if key in mm_data]
+
         modality = mm_data.get("modality_type")
         if isinstance(modality, str):
-            return modality
+            # Trust the explicit `modality_type` only when it agrees with the actual data keys.
+            # Otherwise fall through to the mixed-modality skip so an inconsistent producer (e.g.
+            # `modality_type="image"` while both image and audio data are present) cannot bypass the
+            # safety check below and have the cache serve embeddings for the wrong modality.
+            if modalities == [modality]:
+                return modality
 
-        modalities = [key for key in _MM_DATA_INPUT_MODALITY_KEYS if key in mm_data]
         if len(modalities) != 1:
             # Mixed-modality params are skipped because the cache key metadata is request-item
             # oriented: `multimodal_hashes` and `multimodal_embedding_lengths` are parallel per
@@ -451,17 +477,18 @@ class MultimodalModelMixin:
         cls,
         param: MultimodalParams,
         encoder_cache: TensorLRUCache,
-    ) -> None:
+    ) -> bool:
+        """Attach a full persistent-cache hit and report whether one was found."""
         if param.multimodal_data.get("multimodal_embedding") is not None:
             logger.debug(
                 f"{_MM_ENCODER_CACHE_LOG_NAME}: request-local multimodal embedding present; "
                 "skipping persistent cache lookup"
             )
-            return
+            return False
 
         keys = cls._encoder_cache_keys(param)
         if not keys:
-            return
+            return False
 
         cached_embeddings = []
         for key in keys:
@@ -475,14 +502,18 @@ class MultimodalModelMixin:
                     f"{_MM_ENCODER_CACHE_LOG_NAME}: cache miss; hit_items={len(cached_embeddings)},"
                     f" total_items={len(keys)}."
                 )
-                return
+                return False
             cached_embeddings.append(cached_embedding)
 
-        param.multimodal_data["multimodal_embedding"] = torch.cat(cached_embeddings, dim=0)
+        if len(cached_embeddings) == 1:
+            param.multimodal_data["multimodal_embedding"] = cached_embeddings[0]
+        else:
+            param.multimodal_data["multimodal_embedding"] = torch.cat(cached_embeddings, dim=0)
         logger.debug(
             f"{_MM_ENCODER_CACHE_LOG_NAME}: full cache hit for {len(keys)} item entries, "
             f"rows={param.multimodal_data['multimodal_embedding'].shape[0]}."
         )
+        return True
 
     @classmethod
     def _write_encoder_cache_entries(

--- a/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
+++ b/tensorrt_llm/_torch/models/modeling_multimodal_mixin.py
@@ -16,10 +16,12 @@
 
 import contextlib
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Dict, Hashable, Iterable, Iterator, Optional, Sequence
 
 import torch
 
+from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.tensor_lru_cache import TensorLRUCache
 from tensorrt_llm._utils import prefer_pinned
 from tensorrt_llm.inputs.multimodal import MultimodalParams, MultimodalRuntimeData
 from tensorrt_llm.logger import logger
@@ -37,6 +39,7 @@ if TYPE_CHECKING:
 
 _MM_DATA_INPUT_MODALITY_KEYS = frozenset({"audio", "image", "video"})
 _MM_AUX_STREAM: Optional[tuple[int, torch.cuda.Stream]] = None
+_MM_ENCODER_CACHE_LOG_NAME = "mm_encoder_cache"
 
 
 def _get_mm_aux_stream(max_prefetch_ahead: int = 0) -> Optional[torch.cuda.Stream]:
@@ -105,10 +108,20 @@ class PreparedLlmInputs:
 class MultimodalModelMixin:
     """Template-method mixin for PyTorch multimodal causal LM models.
 
-    Concrete model forwards can call `prepare_multimodal_inputs` while
-    keeping their explicit language-model delegation. A future optional
-    mixin-owned forward can build on the same template method.
+    Concrete model forwards can call `prepare_multimodal_inputs` while keeping their explicit
+    language-model delegation.
+
+    Current limitations:
+
+    * For the time being, the persistent multimodal encoder cache stores per-item embeddings for
+      single-modality `MultimodalParams` objects.
+    * Cache reuse is all-or-nothing for each `MultimodalParams` object: every item in that object
+      hit the cache before cached embeddings are reused. Mixed-modality `MultimodalParams` objects
+      bypass the persistent cache.
     """
+
+    model_config: ModelConfig
+    _multimodal_encoder_cache: Optional[TensorLRUCache] = None
 
     @classmethod
     def _cast_multimodal_encoder_dtype(
@@ -152,6 +165,16 @@ class MultimodalModelMixin:
     @property
     def text_embedding_layer(self):
         """Return the token embedding layer used by `fuse_input_embeds`."""
+        raise NotImplementedError
+
+    @property
+    def embedding_dim(self) -> int:
+        """Return the width of each cached multimodal embedding row."""
+        raise NotImplementedError
+
+    @property
+    def embedding_dtype(self) -> torch.dtype:
+        """Return the dtype of each cached multimodal embedding row."""
         raise NotImplementedError
 
     def select_multimodal_params(
@@ -204,6 +227,7 @@ class MultimodalModelMixin:
         # them as extra embeds without changing the base flow.
         return active_embeddings, ()
 
+    # A future optional mixin-owned forward can build on the same template method.
     def prepare_multimodal_inputs(
         self,
         *,
@@ -274,14 +298,240 @@ class MultimodalModelMixin:
         Delegates cache lookup and gather behavior to `get_multimodal_embeddings`, then validates
         the single tensor contract for both encoded and cached-only paths.
         """
+        encoder_cache = self._get_multimodal_encoder_cache()
+        if encoder_cache is not None:
+            for param in multimodal_params:
+                self._attach_encoder_cache_hit(param, encoder_cache)
+
         embeddings = get_multimodal_embeddings(
             encoder_forward_fn=self.encode_multimodal_inputs,
             multimodal_params=list(multimodal_params),
         )
+        if encoder_cache is not None:
+            for param in multimodal_params:
+                self._write_encoder_cache_entries(param, encoder_cache)
+
         # Validate post-gather so cached-only paths (KV reuse, all-cached chunked prefill) are also
         # checked, not just paths that ran the encoder.
         self._validate_embeddings(embeddings, multimodal_params)
         return embeddings[0]
+
+    def _get_multimodal_encoder_cache(self) -> Optional[TensorLRUCache]:
+        """Return the per-model encoder cache, if enabled.
+
+        The cache stores per-item embeddings for params that can be represented by one modality.
+        See `_encoder_cache_keys` for the mixed-modality skip path and its technical limitation.
+        """
+        multimodal_config = self.model_config.multimodal_config
+        if multimodal_config is None:
+            return None
+
+        max_bytes = multimodal_config.encoder_cache_max_bytes
+        if max_bytes <= 0:
+            logger.debug_once(
+                f"{_MM_ENCODER_CACHE_LOG_NAME}: disabled because "
+                "multimodal_config.encoder_cache_max_bytes=0.",
+                key="mm_encoder_cache_disabled",
+            )
+            return None
+
+        if self._multimodal_encoder_cache is None:
+            self._multimodal_encoder_cache = TensorLRUCache(
+                max_bytes,
+                clone_on_insert=True,
+                name=_MM_ENCODER_CACHE_LOG_NAME,
+            )
+            try:
+                embedding_dim = self.embedding_dim
+                embedding_dtype = self.embedding_dtype
+            except NotImplementedError:
+                logger.info(
+                    f"{_MM_ENCODER_CACHE_LOG_NAME}: created with max_bytes={max_bytes}, "
+                    "clone_on_insert=True; embedding row capacity unavailable because the "
+                    "model does not implement embedding_dim and embedding_dtype."
+                )
+            else:
+                bytes_per_embedding_row = (
+                    embedding_dim * torch.empty((), dtype=embedding_dtype).element_size()
+                )
+                max_embedding_rows = max_bytes // bytes_per_embedding_row
+                logger.info(
+                    f"{_MM_ENCODER_CACHE_LOG_NAME}: created with max_bytes={max_bytes}, "
+                    f"max_embedding_rows={max_embedding_rows}, embedding_dim={embedding_dim}, "
+                    f"embedding_dtype={embedding_dtype}, clone_on_insert=True"
+                )
+        return self._multimodal_encoder_cache
+
+    @staticmethod
+    def _encoder_cache_modality(param: MultimodalParams) -> Optional[str]:
+        """Return the single modality represented by `param`, if cacheable.
+
+        `None` means the params either do not identify a modality or contain
+        multiple modality inputs. The persistent encoder cache deliberately does
+        not cache mixed-modality params today.
+        """
+        mm_data = param.multimodal_data or {}
+        modality = mm_data.get("modality_type")
+        if isinstance(modality, str):
+            return modality
+
+        modalities = [key for key in _MM_DATA_INPUT_MODALITY_KEYS if key in mm_data]
+        if len(modalities) != 1:
+            # Mixed-modality params are skipped because the cache key metadata is request-item
+            # oriented: `multimodal_hashes` and `multimodal_embedding_lengths` are parallel per
+            # item, but there is no parallel per-item modality list. Without that, a cache key
+            # cannot unambiguously distinguish, for example, an image item from an audio item inside
+            # the same params object.
+            logger.debug(
+                f"{_MM_ENCODER_CACHE_LOG_NAME}: skipping params with {len(modalities)} detected "
+                "modalities."
+            )
+            return None
+        return modalities[0]
+
+    @classmethod
+    def _encoder_cache_keys(
+        cls,
+        param: MultimodalParams,
+    ) -> Optional[list[Hashable]]:
+        """Build per-item encoder cache keys for single-modality params.
+
+        The returned keys split one request's concatenated encoder output by
+        `multimodal_embedding_lengths`, using the same modality for every item.
+
+        Mixed-modality params are not cacheable until runtime metadata carries a
+        modality per item alongside `multimodal_hashes` and embedding lengths.
+        """
+        mm_input = param.multimodal_input
+        mm_data = param.multimodal_data or {}
+        if mm_input is None:
+            logger.debug(
+                f"{_MM_ENCODER_CACHE_LOG_NAME}: skipping params without multimodal hashes."
+            )
+            return None
+
+        modality = cls._encoder_cache_modality(param)
+        embedding_lengths = mm_data.get("multimodal_embedding_lengths")
+        kwargs_hash = mm_data.get("mm_processor_kwargs_hash")
+        if modality is None or not isinstance(embedding_lengths, list) or kwargs_hash is None:
+            logger.debug(
+                f"{_MM_ENCODER_CACHE_LOG_NAME}: skipping unkeyable params, "
+                f"has_modality={modality is not None}, "
+                f"has_embedding_lengths={isinstance(embedding_lengths, list)}, "
+                f"has_processor_kwargs_hash={kwargs_hash is not None}"
+            )
+            return None
+        if len(mm_input.multimodal_hashes) != len(embedding_lengths):
+            logger.debug(
+                f"{_MM_ENCODER_CACHE_LOG_NAME}: skipping params with mismatched "
+                "multimodal_hashes and multimodal_embedding_lengths counts"
+            )
+            return None
+
+        # The item hash, embedding row count, processor kwargs, and modality fully describe a
+        # reusable item embedding. Request order is excluded so the same item can be reused from a
+        # different request layout; the current request order is restored when cached item tensors
+        # are concatenated below.
+        return [
+            (
+                modality,
+                tuple(item_hash),
+                int(embedding_length),
+                kwargs_hash,
+            )
+            for item_hash, embedding_length in zip(
+                mm_input.multimodal_hashes,
+                embedding_lengths,
+                strict=True,
+            )
+        ]
+
+    @classmethod
+    def _attach_encoder_cache_hit(
+        cls,
+        param: MultimodalParams,
+        encoder_cache: TensorLRUCache,
+    ) -> None:
+        if param.multimodal_data.get("multimodal_embedding") is not None:
+            logger.debug(
+                f"{_MM_ENCODER_CACHE_LOG_NAME}: request-local multimodal embedding present; "
+                "skipping persistent cache lookup"
+            )
+            return
+
+        keys = cls._encoder_cache_keys(param)
+        if not keys:
+            return
+
+        cached_embeddings = []
+        for key in keys:
+            cached_embedding = encoder_cache.get(key)
+            if cached_embedding is None:
+                # TODO(TRTLLM-13996): allow re-computing only the uncached items.
+                # `get_multimodal_embeddings` treats a param as either fully cached or uncached.
+                # Attaching partial hits would make the later concatenated tensor ambiguous because
+                # there is no placeholder for missing item rows inside `multimodal_embedding`.
+                logger.debug(
+                    f"{_MM_ENCODER_CACHE_LOG_NAME}: cache miss; hit_items={len(cached_embeddings)},"
+                    f" total_items={len(keys)}."
+                )
+                return
+            cached_embeddings.append(cached_embedding)
+
+        param.multimodal_data["multimodal_embedding"] = torch.cat(cached_embeddings, dim=0)
+        logger.debug(
+            f"{_MM_ENCODER_CACHE_LOG_NAME}: full cache hit for {len(keys)} item entries, "
+            f"rows={param.multimodal_data['multimodal_embedding'].shape[0]}."
+        )
+
+    @classmethod
+    def _write_encoder_cache_entries(
+        cls,
+        param: MultimodalParams,
+        encoder_cache: TensorLRUCache,
+    ) -> None:
+        keys = cls._encoder_cache_keys(param)
+        if not keys:
+            return
+
+        embedding = param.multimodal_data.get("multimodal_embedding")
+        if isinstance(embedding, list):
+            embedding = torch.cat(embedding, dim=0)
+            param.multimodal_data["multimodal_embedding"] = embedding
+        if not isinstance(embedding, torch.Tensor):
+            logger.debug(
+                f"{_MM_ENCODER_CACHE_LOG_NAME}: skipping write because no tensor embedding was "
+                "attached after encoder execution."
+            )
+            return
+
+        embedding_lengths = param.multimodal_data["multimodal_embedding_lengths"]
+        if sum(embedding_lengths) != embedding.shape[0]:
+            logger.debug(
+                f"{_MM_ENCODER_CACHE_LOG_NAME}: skipping write because embedding row count "
+                "does not match multimodal_embedding_lengths."
+            )
+            return
+
+        # Encoder outputs are concatenated per params object. Splitting by item length lets future
+        # requests reuse matching items independently, even when their request-level item order
+        # differs.
+        inserted_entries = 0
+        rejected_entries = 0
+        for key, item_embedding in zip(
+            keys,
+            torch.split(embedding, embedding_lengths, dim=0),
+            strict=True,
+        ):
+            if encoder_cache.put(key, item_embedding):
+                inserted_entries += 1
+            else:
+                rejected_entries += 1
+        logger.debug(
+            f"{_MM_ENCODER_CACHE_LOG_NAME}: wrote {inserted_entries} item entries, "
+            f"rejected={rejected_entries}, rows={embedding.shape[0]}."
+        )
+        encoder_cache.log_stats("multimodal encoder cache write.")
 
     def _fuse_multimodal_embeddings(
         self,

--- a/tensorrt_llm/_torch/pyexecutor/_util.py
+++ b/tensorrt_llm/_torch/pyexecutor/_util.py
@@ -628,6 +628,21 @@ class KvCacheCreator:
             return self._model_engine.model.encode_multimodal_inputs(
                 self._dummy_encoder_inputs)
 
+    def _reserve_multimodal_encoder_cache_memory(
+        self,
+        peak_memory: int,
+    ) -> int:
+        """Reserve encoder-cache capacity when the model implements that cache."""
+        model = self._model_engine.model
+        if (not isinstance(model, MultimodalModelMixin)
+                or not model.supports_encoder_cache):
+            return peak_memory
+
+        multimodal_config = model.model_config.multimodal_config
+        if multimodal_config is None:
+            return peak_memory
+        return peak_memory + multimodal_config.encoder_cache_max_bytes
+
     def _get_token_num_for_estimation(self) -> int:
         """Compute KV cache capacity required for estimate_max_kv_cache_tokens to succeed."""
         if 'cp_type' in self._mapping.cp_config:
@@ -875,6 +890,14 @@ class KvCacheCreator:
             peak_memory = total_used_bytes
             allocated_bytes = 0
             activation_bytes = 0
+
+        peak_memory_without_encoder_cache = peak_memory
+        peak_memory = self._reserve_multimodal_encoder_cache_memory(peak_memory)
+        if peak_memory != peak_memory_without_encoder_cache:
+            mem_gb = (peak_memory - peak_memory_without_encoder_cache) / GB
+            logger.info(
+                f"Reserving {mem_gb:.2f} GiB for the multimodal encoder cache while estimating KV cache "
+                "capacity.", )
 
         # calculate max memory from peak memory and free gpu memory fraction
         kv_cache_max_memory = self._cal_max_memory(peak_memory,

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -158,11 +158,13 @@ def _filter_piecewise_capture_num_tokens(
 
 def _build_request_multimodal_input(
         request: LlmRequest, cache_enabled: bool) -> Optional[MultimodalInput]:
-    # `multimodal_input` is consumed only by the encoder-cache key path
-    # (`MultimodalModelMixin._encoder_cache_keys`), so skip building it (and its
-    # `from_components` validation) when the cache is disabled.
+    # Skip building this input (and its `from_components` validation) when the cache is disabled.
     if not cache_enabled or request.multimodal_hashes is None:
         return None
+    # `multimodal_input` is consumed only by the encoder-cache key path
+    # (`MultimodalModelMixin._encoder_cache_keys`), which uses UUID-aware multimodal hashes
+    # internally. Although the `multimodal_uuids` are not exposed as an attribute, they remain in
+    # the backing C++ request for KV-cache block keys and cache events.
     return MultimodalInput.from_components(
         request.multimodal_hashes,
         request.multimodal_positions,
@@ -378,7 +380,11 @@ class PyTorchModelEngine(ModelEngine):
             trust_remote_code=llm_args.trust_remote_code,
             **input_processor_kwargs)
         self.input_processor_with_hash = create_input_processor_with_hash(
-            self.input_processor)
+            self.input_processor,
+            encoder_cache_enabled=(
+                llm_args.multimodal_config is not None
+                and llm_args.multimodal_config.encoder_cache_max_bytes > 0),
+        )
         if model is None:
             lora_config: Optional[
                 LoraConfig] = None if is_draft_model else llm_args.lora_config

--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -22,7 +22,7 @@ from tensorrt_llm._utils import (is_trace_enabled, maybe_pin_memory, nvtx_range,
                                  prefer_pinned, release_gc, torch_dtype_to_str,
                                  trace_func)
 from tensorrt_llm.bindings.internal.runtime import TaskLayerModuleConfig
-from tensorrt_llm.inputs.multimodal import (MultimodalParams,
+from tensorrt_llm.inputs.multimodal import (MultimodalInput, MultimodalParams,
                                             MultimodalRuntimeData,
                                             _has_mm_payload_keys,
                                             check_mm_embed_cumsum_if_needed,
@@ -154,6 +154,23 @@ def _filter_piecewise_capture_num_tokens(
         if max_capturable_num_tokens < i <= max_num_tokens
     })
     return kept, unrecordable
+
+
+def _build_request_multimodal_input(
+        request: LlmRequest, cache_enabled: bool) -> Optional[MultimodalInput]:
+    # `multimodal_input` is consumed only by the encoder-cache key path
+    # (`MultimodalModelMixin._encoder_cache_keys`), so skip building it (and its
+    # `from_components` validation) when the cache is disabled.
+    if not cache_enabled or request.multimodal_hashes is None:
+        return None
+    return MultimodalInput.from_components(
+        request.multimodal_hashes,
+        request.multimodal_positions,
+        request.multimodal_lengths,
+        mm_item_run_cu_offsets=request.multimodal_item_run_cu_offsets,
+        mm_run_positions=request.multimodal_run_positions,
+        mm_run_lengths=request.multimodal_run_lengths,
+    )
 
 
 def _filter_cuda_graph_batch_sizes(cuda_graph_batch_sizes: list[int],
@@ -836,6 +853,13 @@ class PyTorchModelEngine(ModelEngine):
             pass
         logger.debug(f"Detected use_mrope: {use_mrope}")
         return use_mrope
+
+    @functools.cached_property
+    def _mm_encoder_cache_enabled(self) -> bool:
+        """Whether the multimodal encoder cache is active for this model."""
+        multimodal_config = self.model.model_config.multimodal_config
+        return (multimodal_config is not None
+                and multimodal_config.encoder_cache_max_bytes > 0)
 
     @property
     def is_warmup(self):
@@ -3421,6 +3445,8 @@ class PyTorchModelEngine(ModelEngine):
                 )
 
             multimodal_params = MultimodalParams(
+                multimodal_input=_build_request_multimodal_input(
+                    request, self._mm_encoder_cache_enabled),
                 multimodal_data=request.py_multimodal_data,
                 multimodal_runtime=py_multimodal_runtime,
                 input_ids_start_offset=context_start_idx)
@@ -4351,6 +4377,8 @@ class PyTorchModelEngine(ModelEngine):
             # Multimodal
             if request.py_multimodal_data is not None:
                 multimodal_params = MultimodalParams(
+                    multimodal_input=_build_request_multimodal_input(
+                        request, self._mm_encoder_cache_enabled),
                     multimodal_data=request.py_multimodal_data,
                     input_ids_start_offset=context_start_idx)
                 multimodal_params.to_device("multimodal_data",

--- a/tensorrt_llm/_torch/tensor_lru_cache.py
+++ b/tensorrt_llm/_torch/tensor_lru_cache.py
@@ -1,0 +1,213 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from collections.abc import Hashable
+from dataclasses import dataclass
+from threading import RLock
+from typing import Generic, NamedTuple, TypeVar
+
+import torch
+
+from tensorrt_llm.logger import logger
+
+K = TypeVar("K", bound=Hashable)
+
+
+class _Entry(NamedTuple):
+    value: torch.Tensor
+    size_bytes: int
+
+
+class TensorLRUCacheStats(NamedTuple):
+    max_bytes: int
+    current_bytes: int
+    item_count: int
+    hits: int
+    misses: int
+    insertions: int
+    replacements: int
+    evictions: int
+    rejected_insertions: int
+    hit_rate: float
+
+
+@dataclass
+class _CacheCounters:
+    hits: int = 0
+    misses: int = 0
+    insertions: int = 0
+    replacements: int = 0
+    evictions: int = 0
+    rejected_insertions: int = 0
+
+    @property
+    def hit_rate(self) -> float:
+        total_gets = self.hits + self.misses
+        return self.hits / total_gets if total_gets else 0.0
+
+
+class TensorLRUCache(Generic[K]):
+    """Thread-safe LRU cache from hashable keys to tensor values.
+
+    Size accounting uses logical tensor bytes: `tensor.numel() * tensor.element_size()`.
+    Returned tensors are the cached tensor objects themselves, so callers should treat them as
+    immutable while they remain cache-owned.
+
+    Args:
+        max_bytes: Maximum logical tensor bytes held by this cache.
+        clone_on_insert: Store `value.detach().clone()` instead of the caller's tensor object.
+        name: Short label used in debug log messages.
+    """
+
+    def __init__(
+        self,
+        max_bytes: int,
+        *,
+        clone_on_insert: bool = False,
+        name: str = "tensor_lru_cache",
+    ) -> None:
+        if max_bytes <= 0:
+            raise ValueError("max_bytes must be positive")
+
+        self._max_bytes = max_bytes
+        self._clone_on_insert = clone_on_insert
+        self._name = name
+        self._current_bytes = 0
+        self._items: OrderedDict[K, _Entry] = OrderedDict()
+        self._lock = RLock()
+        self._counters = _CacheCounters()
+
+    @property
+    def max_bytes(self) -> int:
+        return self._max_bytes
+
+    @property
+    def current_bytes(self) -> int:
+        with self._lock:
+            return self._current_bytes
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._items)
+
+    def get(self, key: K) -> torch.Tensor | None:
+        """Return a cached tensor and promote it to most-recently-used."""
+        with self._lock:
+            entry = self._items.get(key)
+            if entry is None:
+                self._counters.misses += 1
+                return None
+
+            self._counters.hits += 1
+            self._items.move_to_end(key)
+            return entry.value
+
+    def put(self, key: K, value: torch.Tensor) -> bool:
+        """Insert or replace a tensor.
+
+        Returns `False` and leaves the cache unchanged when `value` is larger than the full
+        cache capacity.
+        """
+        size_bytes = self._tensor_size_bytes(value)
+
+        if size_bytes > self._max_bytes:
+            with self._lock:
+                self._counters.rejected_insertions += 1
+            logger.debug(
+                f"{self._name}: rejected oversized tensor insertion, size_bytes={size_bytes}, "
+                f"max_bytes={self._max_bytes}"
+            )
+            return False
+
+        stored_value = value.detach().clone() if self._clone_on_insert else value
+
+        with self._lock:
+            old_entry = self._items.pop(key, None)
+            if old_entry is not None:
+                self._current_bytes -= old_entry.size_bytes
+                self._counters.replacements += 1
+            else:
+                self._counters.insertions += 1
+
+            self._items[key] = _Entry(value=stored_value, size_bytes=size_bytes)
+            self._current_bytes += size_bytes
+
+            evicted_count, evicted_bytes = self._evict_until_within_limit()
+            if evicted_count:
+                self._counters.evictions += evicted_count
+                logger.debug(
+                    f"{self._name}: evicted {evicted_count} LRU entries, "
+                    f"freed_bytes={evicted_bytes}, current_bytes={self._current_bytes}, "
+                    f"max_bytes={self._max_bytes}"
+                )
+            return True
+
+    def pop(self, key: K) -> torch.Tensor | None:
+        """Remove one key and return its tensor, or `None` on miss."""
+        with self._lock:
+            entry = self._items.pop(key, None)
+            if entry is None:
+                return None
+
+            self._current_bytes -= entry.size_bytes
+            return entry.value
+
+    def clear(self) -> None:
+        with self._lock:
+            self._items.clear()
+            self._current_bytes = 0
+
+    def stats(self) -> TensorLRUCacheStats:
+        with self._lock:
+            return TensorLRUCacheStats(
+                max_bytes=self._max_bytes,
+                current_bytes=self._current_bytes,
+                item_count=len(self._items),
+                hits=self._counters.hits,
+                misses=self._counters.misses,
+                insertions=self._counters.insertions,
+                replacements=self._counters.replacements,
+                evictions=self._counters.evictions,
+                rejected_insertions=self._counters.rejected_insertions,
+                hit_rate=self._counters.hit_rate,
+            )
+
+    def log_stats(self, reason: str) -> None:
+        stats = self.stats()
+        logger.debug(
+            f"{self._name}: stats after {reason}: items={stats.item_count}, "
+            f"bytes={stats.current_bytes}/{stats.max_bytes}, hits={stats.hits}, "
+            f"misses={stats.misses}, hit_rate={stats.hit_rate:.3f}, "
+            f"insertions={stats.insertions}, replacements={stats.replacements}, "
+            f"evictions={stats.evictions}, rejected_insertions={stats.rejected_insertions}"
+        )
+
+    @staticmethod
+    def _tensor_size_bytes(tensor: torch.Tensor) -> int:
+        return tensor.numel() * tensor.element_size()
+
+    def _evict_until_within_limit(self) -> tuple[int, int]:
+        evicted_count = 0
+        evicted_bytes = 0
+        while self._current_bytes > self._max_bytes:
+            _, entry = self._items.popitem(last=False)
+            self._current_bytes -= entry.size_bytes
+            evicted_count += 1
+            evicted_bytes += entry.size_bytes
+        return evicted_count, evicted_bytes

--- a/tensorrt_llm/_torch/tensor_lru_cache.py
+++ b/tensorrt_llm/_torch/tensor_lru_cache.py
@@ -66,12 +66,19 @@ class TensorLRUCache(Generic[K]):
     """Thread-safe LRU cache from hashable keys to tensor values.
 
     Size accounting uses logical tensor bytes: `tensor.numel() * tensor.element_size()`.
-    Returned tensors are the cached tensor objects themselves, so callers should treat them as
-    immutable while they remain cache-owned.
+    Returned tensors alias the cache-owned tensor objects. Callers must treat them as immutable
+    while they remain cache-owned.
+
+    The cache owns a detached copy rather than the caller's tensor or view. This prevents later
+    caller mutations from changing a cached value and prevents a small cached view from retaining
+    the caller's larger backing allocation. The copy is made before acquiring the lock and before
+    replacement or eviction, preserving existing cache entries if copying fails. Consequently,
+    `max_bytes` bounds steady-state logical cache contents, not peak allocation: insertion
+    temporarily needs both the source tensor and its copy and may exceed the cache limit until
+    eviction completes.
 
     Args:
         max_bytes: Maximum logical tensor bytes held by this cache.
-        clone_on_insert: Store `value.detach().clone()` instead of the caller's tensor object.
         name: Short label used in debug log messages.
     """
 
@@ -79,14 +86,12 @@ class TensorLRUCache(Generic[K]):
         self,
         max_bytes: int,
         *,
-        clone_on_insert: bool = False,
         name: str = "tensor_lru_cache",
     ) -> None:
         if max_bytes <= 0:
             raise ValueError("max_bytes must be positive")
 
         self._max_bytes = max_bytes
-        self._clone_on_insert = clone_on_insert
         self._name = name
         self._current_bytes = 0
         self._items: OrderedDict[K, _Entry] = OrderedDict()
@@ -107,7 +112,10 @@ class TensorLRUCache(Generic[K]):
             return len(self._items)
 
     def get(self, key: K) -> torch.Tensor | None:
-        """Return a cached tensor and promote it to most-recently-used."""
+        """Return a cache-owned, immutable tensor and promote it to most-recently-used.
+
+        The returned tensor aliases the cached value. Callers must not mutate it.
+        """
         with self._lock:
             entry = self._items.get(key)
             if entry is None:
@@ -135,7 +143,7 @@ class TensorLRUCache(Generic[K]):
             )
             return False
 
-        stored_value = value.detach().clone() if self._clone_on_insert else value
+        stored_value = value.detach().clone()
 
         with self._lock:
             old_entry = self._items.pop(key, None)

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -22,10 +22,21 @@ from .multimodal import (MultimodalInput, _as_cpu_tensor, _compute_mm_masks,
                          _find_mm_token_start_pos_from_masks, apply_mm_hashes,
                          default_hasher, find_mm_token_lengths,
                          hexdigest_to_int32, validate_mm_inputs)
+from .multimodal_data import serialize_item
 
 N = TypeVar("N", bound=Type[nn.Module])
 
 ExtraProcessedInputs = Dict[str, Any]
+
+
+def _hash_mm_processor_kwargs(mm_processor_kwargs: Dict[str, Any],
+                              hash_lib=default_hasher) -> Optional[str]:
+    hasher = hash_lib()
+    try:
+        hasher.update(serialize_item(mm_processor_kwargs))
+    except (TypeError, ValueError, RuntimeError):
+        return None
+    return hasher.hexdigest()
 
 
 class InputProcessor(Protocol):
@@ -1088,6 +1099,16 @@ def create_input_processor_with_hash(
 
         prompt_token_ids, extra_processed_inputs = input_processor(
             inputs, sampling_params)
+        mm_processor_kwargs_hash = _hash_mm_processor_kwargs(
+            inputs.get("mm_processor_kwargs") or {}, hash_lib)
+        if extra_processed_inputs is None:
+            extra_processed_inputs = {}
+        multimodal_data = extra_processed_inputs.setdefault(
+            "multimodal_data", {})
+        if not isinstance(multimodal_data, dict):
+            raise TypeError(
+                "extra_processed_inputs['multimodal_data'] must be a dict")
+        multimodal_data["mm_processor_kwargs_hash"] = mm_processor_kwargs_hash
 
         # TODO: here we assume there is only one modality for now
         num_mm_tokens_by_key = find_mm_token_lengths(

--- a/tensorrt_llm/inputs/registry.py
+++ b/tensorrt_llm/inputs/registry.py
@@ -1,3 +1,19 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import enum
 import traceback
 from abc import ABC, abstractmethod
@@ -1062,6 +1078,8 @@ def maybe_compute_mm_embed_cumsum(
 def create_input_processor_with_hash(
     input_processor: BaseMultimodalInputProcessor,
     hash_lib=default_hasher,
+    *,
+    encoder_cache_enabled: bool = False,
 ) -> Callable[[TextPrompt, SamplingParams], Tuple[
         List[int], Optional[ExtraProcessedInputs]]]:
     """Creates a modified processor that applies additional logic like (hashing, find mm chunk positions) to the input processor
@@ -1069,6 +1087,8 @@ def create_input_processor_with_hash(
     Args:
         original_processor: The original input processor to wrap.
         hash_lib: hasher to use (default: blake3)
+        encoder_cache_enabled: Whether to generate processor-kwargs hashes for
+            persistent multimodal encoder-cache keys.
 
     Returns:
         A wrapped processor that modifies prompts before processing.
@@ -1099,8 +1119,6 @@ def create_input_processor_with_hash(
 
         prompt_token_ids, extra_processed_inputs = input_processor(
             inputs, sampling_params)
-        mm_processor_kwargs_hash = _hash_mm_processor_kwargs(
-            inputs.get("mm_processor_kwargs") or {}, hash_lib)
         if extra_processed_inputs is None:
             extra_processed_inputs = {}
         multimodal_data = extra_processed_inputs.setdefault(
@@ -1108,7 +1126,10 @@ def create_input_processor_with_hash(
         if not isinstance(multimodal_data, dict):
             raise TypeError(
                 "extra_processed_inputs['multimodal_data'] must be a dict")
-        multimodal_data["mm_processor_kwargs_hash"] = mm_processor_kwargs_hash
+        if encoder_cache_enabled:
+            multimodal_data[
+                "mm_processor_kwargs_hash"] = _hash_mm_processor_kwargs(
+                    inputs.get("mm_processor_kwargs") or {}, hash_lib)
 
         # TODO: here we assume there is only one modality for now
         num_mm_tokens_by_key = find_mm_token_lengths(

--- a/tensorrt_llm/llmapi/llm.py
+++ b/tensorrt_llm/llmapi/llm.py
@@ -864,7 +864,12 @@ class BaseLLM:
                 # 1. Extend support for more modalities and models
                 # 2. Decouple input processor into distinct phases (preprocessor (all preprocessing logics), vision model (fuse in model fwd), etc.
                 input_processor_with_hash = create_input_processor_with_hash(
-                    self.input_processor)
+                    self.input_processor,
+                    encoder_cache_enabled=(
+                        self.args.multimodal_config is not None
+                        and self.args.multimodal_config.encoder_cache_max_bytes
+                        > 0),
+                )
                 with nvtx_range_debug("input_processor_with_hash"):
                     prompt_token_ids, extra_processed_inputs = input_processor_with_hash(
                         inputs, sampling_params)

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -512,14 +512,18 @@ class MultimodalEncoderCudaGraphConfig(StrictBaseModel):
         return self
 
 
-_BYTE_STRING_PATTERN = re.compile(r"^\s*(\d+)\s*([kmgt]ib|b)?\s*$",
+_BYTE_STRING_PATTERN = re.compile(r"^\s*(\d+)\s*([kmgt]i?b|b)?\s*$",
                                   re.IGNORECASE)
 _BINARY_BYTE_UNITS: dict[Optional[str], int] = {
     None: 1,
     "b": 1,
+    "kb": 1024,
     "kib": 1024,
+    "mb": 1024**2,
     "mib": 1024**2,
+    "gb": 1024**3,
     "gib": 1024**3,
+    "tb": 1024**4,
     "tib": 1024**4,
 }
 
@@ -532,7 +536,7 @@ def _parse_binary_byte_string(value: Any) -> Any:
     if match is None:
         raise ValueError(
             "Byte strings must be non-negative integers with optional "
-            "B/KiB/MiB/GiB/TiB suffix.")
+            "B/KB/MB/GB/TB or KiB/MiB/GiB/TiB suffix.")
 
     amount = int(match.group(1))
     unit = match.group(2)
@@ -568,7 +572,7 @@ class MultimodalConfig(StrictBaseModel):
         default=134_217_728,  # 128 MiB.
         description=
         ("Maximum bytes for the per-model cross-request multimodal encoder embedding cache. "
-         "Set to 0 to disable. String values such as '512MiB' and '1GiB' use binary units. "
+         "Set to 0 to disable. String values such as '512MB' and '1GiB' use binary units. "
          "Cache entries are per multimodal item, but reuse is all-or-nothing for each request: "
          "every item in the request must hit the cache before cached embeddings are reused. "
          "Only single-modality requests are cacheable for the time being. "
@@ -4566,6 +4570,16 @@ class TorchLlmArgs(BaseLlmArgs):
         default_factory=MultimodalConfig,
         description="Multimodal model configuration.",
         status="prototype")
+
+    @field_validator('multimodal_config', mode='before')
+    @classmethod
+    def init_multimodal_config(cls, v):
+        # The field is non-Optional, but callers (e.g. the multimodal
+        # quickstart) pass None to mean "unset". Coerce None back to the
+        # default so it does not fail type validation.
+        if v is None:
+            return MultimodalConfig()
+        return v
 
     attention_dp_config: Optional[AttentionDpConfig] = Field(
         default=None,

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -18,6 +18,7 @@ import functools
 import json
 import math
 import os
+import re
 import types
 from abc import ABC, abstractmethod
 from collections import defaultdict
@@ -511,6 +512,34 @@ class MultimodalEncoderCudaGraphConfig(StrictBaseModel):
         return self
 
 
+_BYTE_STRING_PATTERN = re.compile(r"^\s*(\d+)\s*([kmgt]ib|b)?\s*$",
+                                  re.IGNORECASE)
+_BINARY_BYTE_UNITS: dict[Optional[str], int] = {
+    None: 1,
+    "b": 1,
+    "kib": 1024,
+    "mib": 1024**2,
+    "gib": 1024**3,
+    "tib": 1024**4,
+}
+
+
+def _parse_binary_byte_string(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+
+    match = _BYTE_STRING_PATTERN.fullmatch(value)
+    if match is None:
+        raise ValueError(
+            "Byte strings must be non-negative integers with optional "
+            "B/KiB/MiB/GiB/TiB suffix.")
+
+    amount = int(match.group(1))
+    unit = match.group(2)
+    multiplier = _BINARY_BYTE_UNITS[unit.lower() if unit is not None else None]
+    return amount * multiplier
+
+
 class MultimodalConfig(StrictBaseModel):
     """Multimodal model configuration."""
 
@@ -535,6 +564,19 @@ class MultimodalConfig(StrictBaseModel):
         status="prototype",
     )
 
+    encoder_cache_max_bytes: NonNegativeInt = Field(
+        default=134_217_728,  # 128 MiB.
+        description=
+        ("Maximum bytes for the per-model cross-request multimodal encoder embedding cache. "
+         "Set to 0 to disable. String values such as '512MiB' and '1GiB' use binary units. "
+         "Cache entries are per multimodal item, but reuse is all-or-nothing for each request: "
+         "every item in the request must hit the cache before cached embeddings are reused. "
+         "Only single-modality requests are cacheable for the time being. "
+         "NOTE: This is only valid for child implementations of the `MultimodalModelMixin`."
+         ),
+        status="prototype",
+    )
+
     video_pruning_rate: Optional[float] = Field(
         default=None,
         ge=0.0,
@@ -545,6 +587,11 @@ class MultimodalConfig(StrictBaseModel):
          "None (default) disables EVS, values in [0, 1) enable pruning."),
         status="prototype",
     )
+
+    @field_validator('encoder_cache_max_bytes', mode='before')
+    @classmethod
+    def parse_encoder_cache_max_bytes(cls, value):
+        return _parse_binary_byte_string(value)
 
     @model_validator(mode='after')
     def validate_side_stream_cuda_graph_exclusive(self) -> 'MultimodalConfig':

--- a/tensorrt_llm/llmapi/llm_args.py
+++ b/tensorrt_llm/llmapi/llm_args.py
@@ -563,7 +563,8 @@ class MultimodalConfig(StrictBaseModel):
         description=
         ("Maximum number of pending multimodal requests whose encoder work can be prefetched "
          "on a side CUDA stream ahead of admission. 0 disables side-stream prefetch. "
-         "Incompatible with encoder_cuda_graph because graph replay uses static buffers."
+         "Incompatible with encoder_cuda_graph because graph replay uses static buffers. "
+         "For the time being, this is also incompatible with encoder_cache_max_bytes > 0."
          ),
         status="prototype",
     )
@@ -576,6 +577,7 @@ class MultimodalConfig(StrictBaseModel):
          "Cache entries are per multimodal item, but reuse is all-or-nothing for each request: "
          "every item in the request must hit the cache before cached embeddings are reused. "
          "Only single-modality requests are cacheable for the time being. "
+         "For the time being, this is incompatible with encoder_side_stream_max_ahead > 0. "
          "NOTE: This is only valid for child implementations of the `MultimodalModelMixin`."
          ),
         status="prototype",
@@ -598,7 +600,7 @@ class MultimodalConfig(StrictBaseModel):
         return _parse_binary_byte_string(value)
 
     @model_validator(mode='after')
-    def validate_side_stream_cuda_graph_exclusive(self) -> 'MultimodalConfig':
+    def validate_encoder_optimization_compatibility(self) -> 'MultimodalConfig':
         if (self.encoder_cuda_graph is not None
                 and self.encoder_side_stream_max_ahead > 0):
             raise ValueError(
@@ -606,6 +608,14 @@ class MultimodalConfig(StrictBaseModel):
                 "multimodal_config.encoder_side_stream_max_ahead > 0 are "
                 "mutually exclusive. Disable side-stream MM prefetch or "
                 "disable MM encoder CUDA graphs.")
+        # TODO(TRTLLM-14034): Make encoder side-stream read and write from the cache.
+        if (self.encoder_cache_max_bytes > 0
+                and self.encoder_side_stream_max_ahead > 0):
+            raise ValueError(
+                "multimodal_config.encoder_cache_max_bytes > 0 and "
+                "multimodal_config.encoder_side_stream_max_ahead > 0 are "
+                "mutually exclusive. Disable side-stream MM prefetch or set "
+                "the MM encoder cache capacity to 0.")
         return self
 
 

--- a/tensorrt_llm/usage/llm_args_golden_manifest.json
+++ b/tensorrt_llm/usage/llm_args_golden_manifest.json
@@ -969,6 +969,13 @@
       "annotation": "<class 'int'>",
       "converter": "",
       "kind": "value",
+      "path": "multimodal_config.encoder_cache_max_bytes"
+    },
+    {
+      "allowed_values": [],
+      "annotation": "<class 'int'>",
+      "converter": "",
+      "kind": "value",
       "path": "multimodal_config.encoder_side_stream_max_ahead"
     },
     {

--- a/tests/unittest/_torch/executor/test_kv_cache_estimation.py
+++ b/tests/unittest/_torch/executor/test_kv_cache_estimation.py
@@ -12,9 +12,11 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from tensorrt_llm._torch.model_config import ModelConfig
+from tensorrt_llm._torch.models.modeling_multimodal_mixin import MultimodalModelMixin
 from tensorrt_llm._torch.pyexecutor._util import CacheCost, KvCacheCreator
 from tensorrt_llm._torch.pyexecutor.kv_cache_manager_v2 import KVCacheManagerV2
-from tensorrt_llm.llmapi.llm_args import KvCacheConfig
+from tensorrt_llm.llmapi.llm_args import KvCacheConfig, MultimodalConfig
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -27,6 +29,24 @@ def _make_mock_request(num_input_tokens, beam_width=1):
     req.input_token_ids = list(range(num_input_tokens))
     req.sampling_config.beam_width = beam_width
     return req
+
+
+class _TextModel:
+    def __init__(self, encoder_cache_max_bytes):
+        self.model_config = ModelConfig(
+            multimodal_config=MultimodalConfig(encoder_cache_max_bytes=encoder_cache_max_bytes)
+        )
+
+
+class _MultimodalModel(MultimodalModelMixin):
+    def __init__(self, encoder_cache_max_bytes):
+        self.model_config = ModelConfig(
+            multimodal_config=MultimodalConfig(encoder_cache_max_bytes=encoder_cache_max_bytes)
+        )
+
+
+class _EncoderCacheMultimodalModel(_MultimodalModel):
+    supports_encoder_cache = True
 
 
 def _make_creator(
@@ -173,6 +193,27 @@ def test_regression_without_fix_would_overcount():
     wrong = tp * 3 * tpb  # 768  (all duplicates summed)
     assert result == correct
     assert result != wrong
+
+
+@pytest.mark.parametrize(
+    ("model_cls", "encoder_cache_max_bytes", "expected"),
+    [
+        (_TextModel, 64, 1000),
+        (_MultimodalModel, 0, 1000),
+        (_MultimodalModel, 64, 1000),
+        (_EncoderCacheMultimodalModel, 0, 1000),
+        (_EncoderCacheMultimodalModel, 64, 1064),
+    ],
+)
+def test_kv_cache_estimation_reserves_multimodal_encoder_cache(
+    model_cls,
+    encoder_cache_max_bytes,
+    expected,
+):
+    creator = object.__new__(KvCacheCreator)
+    creator._model_engine = SimpleNamespace(model=model_cls(encoder_cache_max_bytes))
+
+    assert creator._reserve_multimodal_encoder_cache_memory(1000) == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unittest/_torch/executor/test_pytorch_model_engine.py
+++ b/tests/unittest/_torch/executor/test_pytorch_model_engine.py
@@ -12,7 +12,8 @@ from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.pyexecutor.connectors.kv_cache_connector import \
     KvCacheConnectorWorker
 from tensorrt_llm._torch.pyexecutor.llm_request import LlmRequest
-from tensorrt_llm._torch.pyexecutor.model_engine import PyTorchModelEngine
+from tensorrt_llm._torch.pyexecutor.model_engine import (
+    PyTorchModelEngine, _build_request_multimodal_input)
 from tensorrt_llm.llmapi.llm_args import TorchLlmArgs
 
 # isort: off
@@ -146,6 +147,44 @@ def create_model_engine_and_kvcache(llm_args: TorchLlmArgs = None,
 
 
 class PyTorchModelEngineTestCase(unittest.TestCase):
+
+    def test_build_request_multimodal_input_preserves_uuids(self) -> None:
+        request = LlmRequest(
+            request_id=1,
+            max_new_tokens=1,
+            input_tokens=[0, 1, 2],
+            sampling_config=tensorrt_llm.bindings.SamplingConfig(1),
+            is_streaming=False,
+            multimodal_hashes=[[1, 2, 3, 4, 5, 6, 7, 8]],
+            multimodal_positions=[1],
+            multimodal_lengths=[1],
+            multimodal_uuids=["image-0"],
+        )
+
+        multimodal_input = _build_request_multimodal_input(request,
+                                                           cache_enabled=True)
+
+        self.assertIsNotNone(multimodal_input)
+        self.assertEqual(multimodal_input.multimodal_uuids, ["image-0"])
+
+    def test_build_request_multimodal_input_skips_when_cache_disabled(
+            self) -> None:
+        request = LlmRequest(
+            request_id=1,
+            max_new_tokens=1,
+            input_tokens=[0, 1, 2],
+            sampling_config=tensorrt_llm.bindings.SamplingConfig(1),
+            is_streaming=False,
+            multimodal_hashes=[[1, 2, 3, 4, 5, 6, 7, 8]],
+            multimodal_positions=[1],
+            multimodal_lengths=[1],
+            multimodal_uuids=["image-0"],
+        )
+
+        # With the encoder cache disabled, nothing consumes `multimodal_input`,
+        # so it should not be built at all.
+        self.assertIsNone(
+            _build_request_multimodal_input(request, cache_enabled=False))
 
     def test_pad_generation_requests(self) -> None:
         model_engine, kv_cache_manager = create_model_engine_and_kvcache()

--- a/tests/unittest/_torch/executor/test_pytorch_model_engine.py
+++ b/tests/unittest/_torch/executor/test_pytorch_model_engine.py
@@ -148,25 +148,6 @@ def create_model_engine_and_kvcache(llm_args: TorchLlmArgs = None,
 
 class PyTorchModelEngineTestCase(unittest.TestCase):
 
-    def test_build_request_multimodal_input_preserves_uuids(self) -> None:
-        request = LlmRequest(
-            request_id=1,
-            max_new_tokens=1,
-            input_tokens=[0, 1, 2],
-            sampling_config=tensorrt_llm.bindings.SamplingConfig(1),
-            is_streaming=False,
-            multimodal_hashes=[[1, 2, 3, 4, 5, 6, 7, 8]],
-            multimodal_positions=[1],
-            multimodal_lengths=[1],
-            multimodal_uuids=["image-0"],
-        )
-
-        multimodal_input = _build_request_multimodal_input(request,
-                                                           cache_enabled=True)
-
-        self.assertIsNotNone(multimodal_input)
-        self.assertEqual(multimodal_input.multimodal_uuids, ["image-0"])
-
     def test_build_request_multimodal_input_skips_when_cache_disabled(
             self) -> None:
         request = LlmRequest(

--- a/tests/unittest/_torch/multimodal/test_multimodal_mixin.py
+++ b/tests/unittest/_torch/multimodal/test_multimodal_mixin.py
@@ -14,12 +14,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest.mock import patch
+
 import pytest
 import torch
 
+from tensorrt_llm._torch.model_config import ModelConfig
 from tensorrt_llm._torch.models.modeling_multimodal_mixin import MultimodalModelMixin
 from tensorrt_llm._torch.modules.embedding import Embedding
-from tensorrt_llm.inputs.multimodal import MultimodalParams
+from tensorrt_llm.inputs.multimodal import MultimodalInput, MultimodalParams, MultimodalRuntimeData
+from tensorrt_llm.llmapi.llm_args import MultimodalConfig
 
 
 def make_embedding(
@@ -33,6 +37,7 @@ def make_embedding(
 
 class DummyMultimodalModel(MultimodalModelMixin):
     def __init__(self, embedding: Embedding, mm_token_ids: torch.Tensor):
+        self.model_config = ModelConfig()
         self.embedding = embedding
         self._mm_token_ids = mm_token_ids
 
@@ -43,6 +48,14 @@ class DummyMultimodalModel(MultimodalModelMixin):
     @property
     def text_embedding_layer(self) -> Embedding:
         return self.embedding
+
+    @property
+    def embedding_dim(self) -> int:
+        return self.embedding.embedding_dim
+
+    @property
+    def embedding_dtype(self) -> torch.dtype:
+        return self.embedding.weight.dtype
 
     def encode_multimodal_inputs(self, multimodal_params):
         raise AssertionError("Tests use cached multimodal embeddings and should not encode.")
@@ -62,12 +75,87 @@ class TensorEncoderMultimodalModel(DummyMultimodalModel):
         return self.mm_embeds
 
 
+class NoEmbeddingMetadataMultimodalModel(DummyMultimodalModel):
+    @property
+    def embedding_dim(self) -> int:
+        raise NotImplementedError
+
+    @property
+    def embedding_dtype(self) -> torch.dtype:
+        raise NotImplementedError
+
+
+class CountingEncoderMultimodalModel(DummyMultimodalModel):
+    def __init__(
+        self,
+        embedding: Embedding,
+        mm_token_ids: torch.Tensor,
+        *,
+        encoder_cache_max_bytes: int = 0,
+    ):
+        super().__init__(embedding, mm_token_ids)
+        self.model_config = ModelConfig(
+            multimodal_config=MultimodalConfig(encoder_cache_max_bytes=encoder_cache_max_bytes)
+        )
+        self.encode_calls = 0
+
+    def encode_multimodal_inputs(self, multimodal_params, **encoder_kwargs) -> torch.Tensor:
+        self.encode_calls += 1
+        total_rows = sum(
+            param.multimodal_runtime.total_embeds_in_request for param in multimodal_params
+        )
+        return torch.full(
+            (total_rows, self.embedding.embedding_dim),
+            float(self.encode_calls),
+            dtype=torch.float32,
+        )
+
+
 def make_cached_multimodal_param(mm_embeds: torch.Tensor) -> MultimodalParams:
     return MultimodalParams(multimodal_data={"multimodal_embedding": mm_embeds})
 
 
 def make_raw_multimodal_param() -> MultimodalParams:
     return MultimodalParams(multimodal_data={"image": {"pixel_values": torch.empty(1)}})
+
+
+def make_runtime(total_embeds: int) -> MultimodalRuntimeData:
+    return MultimodalRuntimeData(
+        embed_mask_cumsum=torch.arange(1, total_embeds + 1, dtype=torch.int64),
+        past_seen_token_num=0,
+        chunk_end_pos=total_embeds,
+    )
+
+
+def make_keyed_multimodal_param(
+    *,
+    item_hashes: list[list[int]] | None = None,
+    embedding_lengths: list[int] | None = None,
+    kwargs_hash: str | None = "kwargs-a",
+    local_embedding: torch.Tensor | None = None,
+) -> MultimodalParams:
+    if item_hashes is None:
+        item_hashes = [[1, 2, 3, 4, 5, 6, 7, 8]]
+    if embedding_lengths is None:
+        embedding_lengths = [2]
+
+    mm_data = {
+        "image": {"pixel_values": torch.empty(1)},
+        "multimodal_embedding_lengths": embedding_lengths,
+        "mm_processor_kwargs_hash": kwargs_hash,
+    }
+    if local_embedding is not None:
+        mm_data["multimodal_embedding"] = local_embedding
+
+    return MultimodalParams(
+        multimodal_input=MultimodalInput(
+            multimodal_hashes=item_hashes,
+            multimodal_positions=[0] * len(item_hashes),
+            multimodal_lengths=embedding_lengths,
+        ),
+        multimodal_data=mm_data,
+        multimodal_runtime=make_runtime(sum(embedding_lengths)),
+    )
 
 
 def test_cast_multimodal_encoder_dtype_keeps_meta_tensors_meta():
@@ -147,3 +235,193 @@ def test_prepare_multimodal_inputs_accepts_tensor_encoder_output(device):
         mm_emb.to(dtype=out.inputs_embeds.dtype, device=out.inputs_embeds.device),
     )
     torch.testing.assert_close(out.inputs_embeds[text_idx], emb(input_ids[text_idx]))
+
+
+def test_encoder_cache_first_request_writes_per_item_entries():
+    model = CountingEncoderMultimodalModel(
+        make_embedding(hidden_size=4),
+        torch.tensor([7]),
+        encoder_cache_max_bytes=4096,
+    )
+    param = make_keyed_multimodal_param(
+        item_hashes=[[1, 2, 3, 4, 5, 6, 7, 8], [8, 7, 6, 5, 4, 3, 2, 1]],
+        embedding_lengths=[2, 1],
+    )
+
+    embeddings = model._get_or_encode_multimodal_embeddings([param])
+
+    assert model.encode_calls == 1
+    assert embeddings.shape == (3, 4)
+    assert len(model._multimodal_encoder_cache) == 2
+
+
+def test_encoder_cache_creation_logs_embedding_row_capacity():
+    model = CountingEncoderMultimodalModel(
+        make_embedding(hidden_size=4),
+        torch.tensor([7]),
+        encoder_cache_max_bytes=4096,
+    )
+
+    with patch("tensorrt_llm._torch.models.modeling_multimodal_mixin.logger.info") as info:
+        model._get_multimodal_encoder_cache()
+
+    messages = [" ".join(map(str, call.args)) for call in info.call_args_list]
+    assert any(
+        "mm_encoder_cache: created with max_bytes=4096, max_embedding_rows=256, "
+        "embedding_dim=4, embedding_dtype=torch.float32, clone_on_insert=True" in message
+        for message in messages
+    )
+
+
+def test_encoder_cache_creation_logs_byte_capacity_without_embedding_metadata():
+    model = NoEmbeddingMetadataMultimodalModel(make_embedding(), torch.tensor([7]))
+    model.model_config = ModelConfig(
+        multimodal_config=MultimodalConfig(encoder_cache_max_bytes=4096)
+    )
+
+    with patch("tensorrt_llm._torch.models.modeling_multimodal_mixin.logger.info") as info:
+        model._get_multimodal_encoder_cache()
+
+    messages = [" ".join(map(str, call.args)) for call in info.call_args_list]
+    assert any(
+        "mm_encoder_cache: created with max_bytes=4096, clone_on_insert=True; "
+        "embedding row capacity unavailable because the model does not implement "
+        "embedding_dim and embedding_dtype." in message
+        for message in messages
+    )
+
+
+def test_encoder_cache_repeated_item_across_requests_skips_encoder():
+    model = CountingEncoderMultimodalModel(
+        make_embedding(hidden_size=4),
+        torch.tensor([7]),
+        encoder_cache_max_bytes=4096,
+    )
+    first = make_keyed_multimodal_param()
+    second = make_keyed_multimodal_param()
+
+    first_embeddings = model._get_or_encode_multimodal_embeddings([first])
+    second_embeddings = model._get_or_encode_multimodal_embeddings([second])
+
+    assert model.encode_calls == 1
+    torch.testing.assert_close(second_embeddings, first_embeddings)
+
+
+def test_encoder_cache_partial_hit_logs_and_uses_encoder():
+    model = CountingEncoderMultimodalModel(
+        make_embedding(hidden_size=4),
+        torch.tensor([7]),
+        encoder_cache_max_bytes=4096,
+    )
+    first = make_keyed_multimodal_param()
+    partial = make_keyed_multimodal_param(
+        item_hashes=[
+            [1, 2, 3, 4, 5, 6, 7, 8],
+            [9, 9, 9, 9, 9, 9, 9, 9],
+        ],
+        embedding_lengths=[2, 2],
+    )
+
+    model._get_or_encode_multimodal_embeddings([first])
+    with patch("tensorrt_llm._torch.models.modeling_multimodal_mixin.logger.debug") as debug:
+        embeddings = model._get_or_encode_multimodal_embeddings([partial])
+
+    messages = [" ".join(map(str, call.args)) for call in debug.call_args_list]
+    assert model.encode_calls == 2
+    assert embeddings.shape == (4, 4)
+    assert any(
+        "mm_encoder_cache: cache miss; hit_items=1, total_items=2" in msg for msg in messages
+    )
+
+
+def test_encoder_cache_logs_rejected_oversized_write():
+    model = CountingEncoderMultimodalModel(
+        make_embedding(hidden_size=4),
+        torch.tensor([7]),
+        encoder_cache_max_bytes=16,
+    )
+    param = make_keyed_multimodal_param(embedding_lengths=[2])
+
+    with patch("tensorrt_llm._torch.models.modeling_multimodal_mixin.logger.debug") as debug:
+        model._get_or_encode_multimodal_embeddings([param])
+
+    cache = model._multimodal_encoder_cache
+    assert cache is not None
+    assert len(cache) == 0
+    assert cache.stats().rejected_insertions == 1
+    messages = [" ".join(map(str, call.args)) for call in debug.call_args_list]
+    assert any("mm_encoder_cache: wrote 0 item entries, rejected=1" in msg for msg in messages)
+
+
+def test_encoder_cache_mm_processor_kwargs_do_not_collide():
+    model = CountingEncoderMultimodalModel(
+        make_embedding(hidden_size=4),
+        torch.tensor([7]),
+        encoder_cache_max_bytes=4096,
+    )
+    first = make_keyed_multimodal_param(kwargs_hash="kwargs-a")
+    second = make_keyed_multimodal_param(kwargs_hash="kwargs-b")
+
+    first_embeddings = model._get_or_encode_multimodal_embeddings([first])
+    second_embeddings = model._get_or_encode_multimodal_embeddings([second])
+
+    assert model.encode_calls == 2
+    assert not torch.equal(first_embeddings, second_embeddings)
+
+
+def test_disabled_encoder_cache_preserves_current_behavior():
+    model = CountingEncoderMultimodalModel(
+        make_embedding(hidden_size=4),
+        torch.tensor([7]),
+        encoder_cache_max_bytes=0,
+    )
+
+    model._get_or_encode_multimodal_embeddings([make_keyed_multimodal_param()])
+    model._get_or_encode_multimodal_embeddings([make_keyed_multimodal_param()])
+
+    assert model.encode_calls == 2
+    assert model._multimodal_encoder_cache is None
+
+
+@pytest.mark.parametrize(
+    "param",
+    [
+        MultimodalParams(
+            multimodal_data={
+                "image": {"pixel_values": torch.empty(1)},
+                "multimodal_embedding_lengths": [2],
+                "mm_processor_kwargs_hash": "kwargs-a",
+            },
+            multimodal_runtime=make_runtime(2),
+        ),
+        make_keyed_multimodal_param(kwargs_hash=None),
+    ],
+    ids=["missing_hashes", "unserializable_kwargs"],
+)
+def test_unkeyable_requests_skip_persistent_encoder_cache(param):
+    model = CountingEncoderMultimodalModel(
+        make_embedding(hidden_size=4),
+        torch.tensor([7]),
+        encoder_cache_max_bytes=4096,
+    )
+
+    model._get_or_encode_multimodal_embeddings([param])
+
+    assert model.encode_calls == 1
+    assert len(model._multimodal_encoder_cache) == 0
+
+
+def test_request_local_multimodal_embedding_wins_over_encoder_cache():
+    model = CountingEncoderMultimodalModel(
+        make_embedding(hidden_size=4),
+        torch.tensor([7]),
+        encoder_cache_max_bytes=4096,
+    )
+    model._get_or_encode_multimodal_embeddings([make_keyed_multimodal_param()])
+    local_embedding = torch.full((2, 4), 99.0)
+    chunk_param = make_keyed_multimodal_param(local_embedding=local_embedding)
+
+    embeddings = model._get_or_encode_multimodal_embeddings([chunk_param])
+
+    assert model.encode_calls == 1
+    torch.testing.assert_close(embeddings, local_embedding)

--- a/tests/unittest/_torch/multimodal/test_multimodal_mixin.py
+++ b/tests/unittest/_torch/multimodal/test_multimodal_mixin.py
@@ -268,7 +268,7 @@ def test_encoder_cache_creation_logs_embedding_row_capacity():
     messages = [" ".join(map(str, call.args)) for call in info.call_args_list]
     assert any(
         "mm_encoder_cache: created with max_bytes=4096, max_embedding_rows=256, "
-        "embedding_dim=4, embedding_dtype=torch.float32, clone_on_insert=True" in message
+        "embedding_dim=4, embedding_dtype=torch.float32" in message
         for message in messages
     )
 
@@ -284,8 +284,8 @@ def test_encoder_cache_creation_logs_byte_capacity_without_embedding_metadata():
 
     messages = [" ".join(map(str, call.args)) for call in info.call_args_list]
     assert any(
-        "mm_encoder_cache: created with max_bytes=4096, clone_on_insert=True; "
-        "embedding row capacity unavailable because the model does not implement "
+        "mm_encoder_cache: created with max_bytes=4096, embedding row capacity unavailable "
+        "because the model does not implement "
         "embedding_dim and embedding_dtype." in message
         for message in messages
     )
@@ -305,6 +305,23 @@ def test_encoder_cache_repeated_item_across_requests_skips_encoder():
 
     assert model.encode_calls == 1
     torch.testing.assert_close(second_embeddings, first_embeddings)
+
+
+def test_encoder_cache_full_hit_does_not_rewrite_entries():
+    model = CountingEncoderMultimodalModel(
+        make_embedding(hidden_size=4),
+        torch.tensor([7]),
+        encoder_cache_max_bytes=4096,
+    )
+    model._get_or_encode_multimodal_embeddings([make_keyed_multimodal_param()])
+    cache = model._multimodal_encoder_cache
+    assert cache is not None
+
+    with patch.object(cache, "put", wraps=cache.put) as put:
+        model._get_or_encode_multimodal_embeddings([make_keyed_multimodal_param()])
+
+    assert model.encode_calls == 1
+    put.assert_not_called()
 
 
 def test_encoder_cache_partial_hit_logs_and_uses_encoder():

--- a/tests/unittest/_torch/multimodal/test_multimodal_mixin.py
+++ b/tests/unittest/_torch/multimodal/test_multimodal_mixin.py
@@ -324,6 +324,54 @@ def test_encoder_cache_full_hit_does_not_rewrite_entries():
     put.assert_not_called()
 
 
+def test_encoder_cache_repeated_chunk_does_not_rewrite_entries():
+    model = CountingEncoderMultimodalModel(
+        make_embedding(hidden_size=4),
+        torch.tensor([7]),
+        encoder_cache_max_bytes=4096,
+    )
+    param = make_keyed_multimodal_param()
+    first_embeddings = model._get_or_encode_multimodal_embeddings([param])
+    cache = model._multimodal_encoder_cache
+    assert cache is not None
+    assert model.encode_calls == 1
+
+    with patch.object(cache, "put", wraps=cache.put) as put:
+        second_embeddings = model._get_or_encode_multimodal_embeddings([param])
+
+    # We should not have called the multimodal encoder forward a second time.
+    assert model.encode_calls == 1
+    torch.testing.assert_close(second_embeddings, first_embeddings)
+    put.assert_not_called()
+    assert cache.stats().replacements == 0
+
+
+def test_encoder_cache_mixed_attached_and_uncached_requests():
+    model = CountingEncoderMultimodalModel(
+        make_embedding(hidden_size=4),
+        torch.tensor([7]),
+        encoder_cache_max_bytes=4096,
+    )
+    local_embedding = torch.full((2, 4), 99.0)
+    attached = make_keyed_multimodal_param(local_embedding=local_embedding)
+    uncached = make_keyed_multimodal_param(
+        item_hashes=[[9] * 8],
+    )
+
+    embeddings = model._get_or_encode_multimodal_embeddings([attached, uncached])
+
+    assert model.encode_calls == 1
+    # Since we set `local_embedding` to be `99.0` above, if we had actually called
+    # `model.encode_multimodal_inputs` on it, we would have had `1.0` as the value instead for the
+    # first request's embeddings.
+    torch.testing.assert_close(embeddings[:2], local_embedding)
+    # For the 2nd request, it should be equal to the `model.encode_calls` above.
+    torch.testing.assert_close(embeddings[2:], torch.ones((2, 4)))
+    cache = model._multimodal_encoder_cache
+    assert cache is not None
+    assert len(cache) == 1
+
+
 def test_encoder_cache_partial_hit_logs_and_uses_encoder():
     model = CountingEncoderMultimodalModel(
         make_embedding(hidden_size=4),
@@ -437,8 +485,13 @@ def test_request_local_multimodal_embedding_wins_over_encoder_cache():
     model._get_or_encode_multimodal_embeddings([make_keyed_multimodal_param()])
     local_embedding = torch.full((2, 4), 99.0)
     chunk_param = make_keyed_multimodal_param(local_embedding=local_embedding)
+    cache = model._multimodal_encoder_cache
+    assert cache is not None
 
-    embeddings = model._get_or_encode_multimodal_embeddings([chunk_param])
+    with patch.object(cache, "put", wraps=cache.put) as put:
+        embeddings = model._get_or_encode_multimodal_embeddings([chunk_param])
 
     assert model.encode_calls == 1
     torch.testing.assert_close(embeddings, local_embedding)
+    put.assert_not_called()
+    assert cache.stats().replacements == 0

--- a/tests/unittest/_torch/test_tensor_lru_cache.py
+++ b/tests/unittest/_torch/test_tensor_lru_cache.py
@@ -1,0 +1,171 @@
+# Copyright 2026 NVIDIA CORPORATION & AFFILIATES
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+import torch
+
+from tensorrt_llm._torch.tensor_lru_cache import TensorLRUCache
+
+
+def test_rejects_non_positive_capacity() -> None:
+    with pytest.raises(ValueError, match="max_bytes must be positive"):
+        TensorLRUCache[str](0)
+
+
+def test_put_get_pop_and_clear_update_byte_accounting() -> None:
+    cache = TensorLRUCache[str](max_bytes=32)
+    tensor = torch.arange(4, dtype=torch.float32)
+
+    assert cache.max_bytes == 32
+    assert cache.get("missing") is None
+    assert cache.put("a", tensor)
+
+    assert len(cache) == 1
+    assert cache.current_bytes == 16
+    assert cache.get("a") is tensor
+
+    assert cache.pop("missing") is None
+    assert cache.pop("a") is tensor
+    assert len(cache) == 0
+    assert cache.current_bytes == 0
+
+    assert cache.put("a", tensor)
+    cache.clear()
+    assert len(cache) == 0
+    assert cache.current_bytes == 0
+    assert cache.get("a") is None
+
+
+def test_stats_track_hits_misses_insertions_and_replacements() -> None:
+    cache = TensorLRUCache[str](max_bytes=32)
+    tensor = torch.ones(2, dtype=torch.float32)
+    replacement = torch.zeros(2, dtype=torch.float32)
+
+    assert cache.get("missing") is None
+    assert cache.put("key", tensor)
+    assert cache.get("key") is tensor
+    assert cache.put("key", replacement)
+
+    stats = cache.stats()
+    assert stats.max_bytes == 32
+    assert stats.current_bytes == 8
+    assert stats.item_count == 1
+    assert stats.hits == 1
+    assert stats.misses == 1
+    assert stats.insertions == 1
+    assert stats.replacements == 1
+    assert stats.evictions == 0
+    assert stats.rejected_insertions == 0
+    assert stats.hit_rate == 0.5
+
+
+def test_stats_track_evictions_and_rejected_insertions() -> None:
+    cache = TensorLRUCache[str](max_bytes=16)
+
+    assert cache.put("first", torch.ones(2, dtype=torch.float32))
+    assert cache.put("second", torch.ones(2, dtype=torch.float32))
+    assert cache.put("third", torch.ones(2, dtype=torch.float32))
+    assert not cache.put("oversized", torch.ones(5, dtype=torch.float32))
+
+    stats = cache.stats()
+    assert stats.current_bytes == 16
+    assert stats.item_count == 2
+    assert stats.insertions == 3
+    assert stats.evictions == 1
+    assert stats.rejected_insertions == 1
+    assert cache.get("first") is None
+
+
+def test_stats_returns_immutable_snapshot() -> None:
+    cache = TensorLRUCache[str](max_bytes=16)
+
+    stats = cache.stats()
+    assert cache.get("missing") is None
+
+    assert stats.misses == 0
+    assert cache.stats().misses == 1
+
+
+def test_get_promotes_entry_before_lru_eviction() -> None:
+    cache = TensorLRUCache[str](max_bytes=16)
+    first = torch.tensor([1.0, 2.0])
+    second = torch.tensor([3.0, 4.0])
+    third = torch.tensor([5.0, 6.0])
+
+    assert cache.put("first", first)
+    assert cache.put("second", second)
+    assert cache.get("first") is first
+    assert cache.put("third", third)
+
+    assert cache.get("second") is None
+    assert cache.get("first") is first
+    assert cache.get("third") is third
+    assert len(cache) == 2
+    assert cache.current_bytes == 16
+
+
+def test_replace_updates_size_and_oversized_replace_leaves_old_value() -> None:
+    cache = TensorLRUCache[str](max_bytes=20)
+    small = torch.ones(2, dtype=torch.float32)
+    larger = torch.ones(3, dtype=torch.float32)
+    oversized = torch.ones(6, dtype=torch.float32)
+
+    assert cache.put("key", small)
+    assert cache.current_bytes == 8
+    assert cache.put("key", larger)
+    assert cache.current_bytes == 12
+    assert cache.get("key") is larger
+
+    assert not cache.put("key", oversized)
+    assert cache.get("key") is larger
+    assert cache.current_bytes == 12
+
+
+def test_clone_on_insert_detaches_and_owns_inserted_tensor_content() -> None:
+    cache = TensorLRUCache[str](max_bytes=32, clone_on_insert=True)
+    tensor = torch.tensor([1.0, 2.0], requires_grad=True)
+
+    assert cache.put("key", tensor)
+    cached = cache.get("key")
+    assert cached is not None
+    assert cached is not tensor
+    assert not cached.requires_grad
+
+    tensor.detach()[0] = 99.0
+    torch.testing.assert_close(cached, torch.tensor([1.0, 2.0]))
+
+
+def test_parallel_operations_keep_cache_metadata_consistent() -> None:
+    cache = TensorLRUCache[int](max_bytes=64)
+
+    def write_and_read(index: int) -> None:
+        value = torch.full((2,), index, dtype=torch.float32)
+        assert cache.put(index, value)
+        hit = cache.get(index)
+        if hit is not None:
+            assert hit.shape == value.shape
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(write_and_read, range(64)))
+
+    assert len(cache) <= 8
+    assert cache.current_bytes <= cache.max_bytes
+    for index in range(64):
+        hit = cache.get(index)
+        if hit is not None:
+            assert hit.numel() * hit.element_size() == 8

--- a/tests/unittest/_torch/test_tensor_lru_cache.py
+++ b/tests/unittest/_torch/test_tensor_lru_cache.py
@@ -34,13 +34,16 @@ def test_put_get_pop_and_clear_update_byte_accounting() -> None:
     assert cache.max_bytes == 32
     assert cache.get("missing") is None
     assert cache.put("a", tensor)
+    cached = cache.get("a")
 
     assert len(cache) == 1
     assert cache.current_bytes == 16
-    assert cache.get("a") is tensor
+    assert cached is not None
+    assert cached is not tensor
+    torch.testing.assert_close(cached, tensor)
 
     assert cache.pop("missing") is None
-    assert cache.pop("a") is tensor
+    assert cache.pop("a") is cached
     assert len(cache) == 0
     assert cache.current_bytes == 0
 
@@ -58,7 +61,9 @@ def test_stats_track_hits_misses_insertions_and_replacements() -> None:
 
     assert cache.get("missing") is None
     assert cache.put("key", tensor)
-    assert cache.get("key") is tensor
+    cached = cache.get("key")
+    assert cached is not None
+    torch.testing.assert_close(cached, tensor)
     assert cache.put("key", replacement)
 
     stats = cache.stats()
@@ -109,12 +114,16 @@ def test_get_promotes_entry_before_lru_eviction() -> None:
 
     assert cache.put("first", first)
     assert cache.put("second", second)
-    assert cache.get("first") is first
+    cached_first = cache.get("first")
+    assert cached_first is not None
+    torch.testing.assert_close(cached_first, first)
     assert cache.put("third", third)
 
     assert cache.get("second") is None
-    assert cache.get("first") is first
-    assert cache.get("third") is third
+    assert cache.get("first") is cached_first
+    cached_third = cache.get("third")
+    assert cached_third is not None
+    torch.testing.assert_close(cached_third, third)
     assert len(cache) == 2
     assert cache.current_bytes == 16
 
@@ -129,15 +138,17 @@ def test_replace_updates_size_and_oversized_replace_leaves_old_value() -> None:
     assert cache.current_bytes == 8
     assert cache.put("key", larger)
     assert cache.current_bytes == 12
-    assert cache.get("key") is larger
+    cached = cache.get("key")
+    assert cached is not None
+    torch.testing.assert_close(cached, larger)
 
     assert not cache.put("key", oversized)
-    assert cache.get("key") is larger
+    assert cache.get("key") is cached
     assert cache.current_bytes == 12
 
 
-def test_clone_on_insert_detaches_and_owns_inserted_tensor_content() -> None:
-    cache = TensorLRUCache[str](max_bytes=32, clone_on_insert=True)
+def test_insert_detaches_and_owns_inserted_tensor_content() -> None:
+    cache = TensorLRUCache[str](max_bytes=32)
     tensor = torch.tensor([1.0, 2.0], requires_grad=True)
 
     assert cache.put("key", tensor)

--- a/tests/unittest/inputs/test_multimodal.py
+++ b/tests/unittest/inputs/test_multimodal.py
@@ -104,6 +104,74 @@ def test_tokenized_multimodal_overwrites_stale_embedding_lengths():
     assert extra["multimodal_data"]["multimodal_embedding_lengths"] == [3]
 
 
+class _KwargsHashFakeProcessor:
+    multimodal_hashing_supported = True
+
+    def __call__(self, inputs, sampling_params):
+        return [10, 101, 102, 20], {"multimodal_data": {}}
+
+    def get_num_tokens_per_image(self, *, image):
+        return 2
+
+    def get_vocab_size(self):
+        return 100
+
+    def get_mm_token_ids(self):
+        return None
+
+    def get_mm_special_token_ids(self):
+        return None
+
+
+def test_mm_processor_kwargs_hash_is_stable_for_canonical_values():
+    input_processor = create_input_processor_with_hash(_KwargsHashFakeProcessor())
+    mm_data = {"image": [torch.tensor([1])]}
+
+    _, first = input_processor(
+        {
+            "prompt": "unused",
+            "multi_modal_data": mm_data,
+            "mm_processor_kwargs": {
+                "b": [2, 3],
+                "a": torch.tensor([1]),
+            },
+        },
+        sampling_params=None,
+    )
+    _, second = input_processor(
+        {
+            "prompt": "unused",
+            "multi_modal_data": mm_data,
+            "mm_processor_kwargs": {
+                "a": torch.tensor([1]),
+                "b": [2, 3],
+            },
+        },
+        sampling_params=None,
+    )
+
+    assert first["multimodal_data"]["mm_processor_kwargs_hash"] is not None
+    assert (
+        first["multimodal_data"]["mm_processor_kwargs_hash"]
+        == second["multimodal_data"]["mm_processor_kwargs_hash"]
+    )
+
+
+def test_unserializable_mm_processor_kwargs_disable_persistent_cache_keying():
+    input_processor = create_input_processor_with_hash(_KwargsHashFakeProcessor())
+
+    _, extra = input_processor(
+        {
+            "prompt": "unused",
+            "multi_modal_data": {"image": [torch.tensor([1])]},
+            "mm_processor_kwargs": {"custom": object()},
+        },
+        sampling_params=None,
+    )
+
+    assert extra["multimodal_data"]["mm_processor_kwargs_hash"] is None
+
+
 def test_multimodal_embedding_lengths_exclude_special_tokens():
     """Embedding lengths omit multimodal wrapper tokens used only in prompts."""
     mm_mask = torch.tensor([False, True, True, True, True, True, False, True, True, True, True])

--- a/tests/unittest/inputs/test_multimodal.py
+++ b/tests/unittest/inputs/test_multimodal.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 """Tests for MultimodalRuntimeData cumsum math and the flat-mask producer."""
 
+from unittest.mock import patch
+
 import pytest
 import torch
 
@@ -124,7 +126,10 @@ class _KwargsHashFakeProcessor:
 
 
 def test_mm_processor_kwargs_hash_is_stable_for_canonical_values():
-    input_processor = create_input_processor_with_hash(_KwargsHashFakeProcessor())
+    input_processor = create_input_processor_with_hash(
+        _KwargsHashFakeProcessor(),
+        encoder_cache_enabled=True,
+    )
     mm_data = {"image": [torch.tensor([1])]}
 
     _, first = input_processor(
@@ -158,7 +163,10 @@ def test_mm_processor_kwargs_hash_is_stable_for_canonical_values():
 
 
 def test_unserializable_mm_processor_kwargs_disable_persistent_cache_keying():
-    input_processor = create_input_processor_with_hash(_KwargsHashFakeProcessor())
+    input_processor = create_input_processor_with_hash(
+        _KwargsHashFakeProcessor(),
+        encoder_cache_enabled=True,
+    )
 
     _, extra = input_processor(
         {
@@ -170,6 +178,23 @@ def test_unserializable_mm_processor_kwargs_disable_persistent_cache_keying():
     )
 
     assert extra["multimodal_data"]["mm_processor_kwargs_hash"] is None
+
+
+def test_disabled_encoder_cache_skips_mm_processor_kwargs_hash():
+    input_processor = create_input_processor_with_hash(_KwargsHashFakeProcessor())
+
+    with patch("tensorrt_llm.inputs.registry._hash_mm_processor_kwargs") as kwargs_hash:
+        _, extra = input_processor(
+            {
+                "prompt": "unused",
+                "multi_modal_data": {"image": [torch.tensor([1])]},
+                "mm_processor_kwargs": {"image_sizes": torch.tensor([1, 2])},
+            },
+            sampling_params=None,
+        )
+
+    kwargs_hash.assert_not_called()
+    assert "mm_processor_kwargs_hash" not in extra["multimodal_data"]
 
 
 def test_multimodal_embedding_lengths_exclude_special_tokens():

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -515,6 +515,7 @@ class TestMultimodalConfig:
     def test_default_encoder_cuda_graph_is_none(self):
         assert MultimodalConfig().encoder_cuda_graph is None
         assert MultimodalConfig().encoder_side_stream_max_ahead == 0
+        assert MultimodalConfig().encoder_cache_max_bytes == 0
         assert MultimodalConfig().video_pruning_rate is None
 
     def test_torch_llm_args_default_multimodal_config(self):
@@ -522,7 +523,28 @@ class TestMultimodalConfig:
         assert isinstance(args.multimodal_config, MultimodalConfig)
         assert args.multimodal_config.encoder_cuda_graph is None
         assert args.multimodal_config.encoder_side_stream_max_ahead == 0
+        assert args.multimodal_config.encoder_cache_max_bytes == 0
         assert args.multimodal_config.video_pruning_rate is None
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (0, 0),
+            ("0", 0),
+            ("512MB", 512 * 1024**2),
+            ("1GB", 1024**3),
+            ("1GiB", 1024**3),
+            ("2TB", 2 * 1024**4),
+        ],
+    )
+    def test_encoder_cache_max_bytes_parses_binary_units(self, value, expected):
+        config = MultimodalConfig(encoder_cache_max_bytes=value)
+        assert config.encoder_cache_max_bytes == expected
+
+    @pytest.mark.parametrize("value", ["-1", "1.5GB", "1XB", "GB", object()])
+    def test_encoder_cache_max_bytes_rejects_invalid_values(self, value):
+        with pytest.raises(ValidationError):
+            MultimodalConfig(encoder_cache_max_bytes=value)
 
     def test_torch_llm_args_with_encoder_side_stream_max_ahead(self):
         args = TorchLlmArgs(

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -548,9 +548,11 @@ class TestMultimodalConfig:
             MultimodalConfig(encoder_cache_max_bytes=value)
 
     def test_torch_llm_args_with_encoder_side_stream_max_ahead(self):
-        args = TorchLlmArgs(
-            model=llama_model_path,
-            multimodal_config=MultimodalConfig(encoder_side_stream_max_ahead=2))
+        args = TorchLlmArgs(model=llama_model_path,
+                            multimodal_config=MultimodalConfig(
+                                encoder_side_stream_max_ahead=2,
+                                encoder_cache_max_bytes=0,
+                            ))
         assert args.multimodal_config.encoder_side_stream_max_ahead == 2
 
     def test_torch_llm_args_with_multimodal_video_pruning_rate(self):
@@ -590,6 +592,7 @@ class TestMultimodalConfig:
             model=llama_model_path,
             multimodal_config={
                 "encoder_side_stream_max_ahead": 2,
+                "encoder_cache_max_bytes": 0,
                 "video_pruning_rate": 0.5,
             },
         )
@@ -607,7 +610,15 @@ class TestMultimodalConfig:
                         }
                     },
                     "encoder_side_stream_max_ahead": 1,
+                    "encoder_cache_max_bytes": 0,
                 },
+            )
+
+    def test_encoder_cache_and_side_stream_max_ahead_are_exclusive(self):
+        with pytest.raises(ValidationError, match="mutually exclusive"):
+            MultimodalConfig(
+                encoder_cache_max_bytes="1MiB",
+                encoder_side_stream_max_ahead=1,
             )
 
 
@@ -1020,9 +1031,13 @@ class TestExplicitCliKeysPrecedence:
 
     def test_multimodal_config_yaml_siblings_preserved(self):
         base = {
-            "model": "dummy",
+            "model":
+            "dummy",
             "multimodal_config":
-            MultimodalConfig(encoder_side_stream_max_ahead=2),
+            MultimodalConfig(
+                encoder_side_stream_max_ahead=2,
+                encoder_cache_max_bytes=0,
+            ),
         }
         yaml_dict = {
             "multimodal_config": {
@@ -1036,9 +1051,13 @@ class TestExplicitCliKeysPrecedence:
 
     def test_multimodal_config_null_yaml_preserves_base_config(self):
         base = {
-            "model": "dummy",
+            "model":
+            "dummy",
             "multimodal_config":
-            MultimodalConfig(encoder_side_stream_max_ahead=2),
+            MultimodalConfig(
+                encoder_side_stream_max_ahead=2,
+                encoder_cache_max_bytes=0,
+            ),
         }
         yaml_dict = {"multimodal_config": None}
         merged = update_llm_args_with_extra_dict(base, yaml_dict)

--- a/tests/unittest/llmapi/test_llm_args.py
+++ b/tests/unittest/llmapi/test_llm_args.py
@@ -515,7 +515,7 @@ class TestMultimodalConfig:
     def test_default_encoder_cuda_graph_is_none(self):
         assert MultimodalConfig().encoder_cuda_graph is None
         assert MultimodalConfig().encoder_side_stream_max_ahead == 0
-        assert MultimodalConfig().encoder_cache_max_bytes == 0
+        assert MultimodalConfig().encoder_cache_max_bytes == 128 * 1024**2
         assert MultimodalConfig().video_pruning_rate is None
 
     def test_torch_llm_args_default_multimodal_config(self):
@@ -523,7 +523,7 @@ class TestMultimodalConfig:
         assert isinstance(args.multimodal_config, MultimodalConfig)
         assert args.multimodal_config.encoder_cuda_graph is None
         assert args.multimodal_config.encoder_side_stream_max_ahead == 0
-        assert args.multimodal_config.encoder_cache_max_bytes == 0
+        assert args.multimodal_config.encoder_cache_max_bytes == 128 * 1024**2
         assert args.multimodal_config.video_pruning_rate is None
 
     @pytest.mark.parametrize(
@@ -531,6 +531,7 @@ class TestMultimodalConfig:
         [
             (0, 0),
             ("0", 0),
+            ("4KB", 4 * 1024),
             ("512MB", 512 * 1024**2),
             ("1GB", 1024**3),
             ("1GiB", 1024**3),


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multimodal encoder optimization options, including an encoder-side stream and an encoder-side multimodal embeddings cache (currently available for supported multimodal models).
  * Introduced `multimodal_config.encoder_cache_max_bytes` to control cache size using byte values or binary-unit strings; set to `0` to disable caching.
  * Exposed multimodal embedding metadata (embedding dimension and dtype) on the Mistral 3 VLM text embedding layer.
* **Documentation**
  * Updated supported-models guidance with capability details and cache reuse/bypass behavior (single-modality reuse; mixed-modality bypasses).
* **Tests**
  * Added coverage for tensor LRU caching and multimodal encoder cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Description

* Why?

Repeated multimodal inputs can force the encoder to do the same work on
multiple requests, even when the input item and processor settings have not
changed. That wastes GPU time for workloads that reuse images, audio, or video
across prompts.

* What?

This adds an opt-out cache so users can trade a bounded amount of memory for
lower repeated multimodal encoding cost.

Add a per-model cache for multimodal encoder embeddings and wire it into the
PyTorch multimodal path. The cache is enabled by default (for supported models)
with a maximum size of 128MiB which is lazily allocated. This can be changed
via `multimodal_config.encoder_cache_max_bytes`.

The cache stores reusable per-item embeddings and keeps existing behavior when
an input cannot be keyed safely.

Current caveats:
- only single-modality requests are cacheable.
- reuse is all-or-nothing for each request. Partial cache hits still fall back
  to encoder execution.

## Example perf difference

Serving command:

```bash
MODEL=mistralai/Mistral-Small-3.1-24B-Instruct-2503

PYTORCH_ALLOC_CONF=expandable_segments:True \
trtllm-serve serve \
--port 8123 $MODEL \
--trust_remote_code --config <(cat <<'EOF'
kv_cache_config:
  enable_block_reuse: false
enable_chunked_prefill: true
max_batch_size: 128
multimodal_config:
  encoder_cache_max_bytes: 0  # or 128MiB
EOF
)
```

Profiling command:

```bash
MODEL=mistralai/Mistral-Small-3.1-24B-Instruct-2503
CONC=1
ISL=100
OSL=100

aiperf profile \
-m "$MODEL" \
--concurrency "$CONC" \
--endpoint "v1/chat/completions" \
--endpoint-type chat \
--streaming \
--tokenizer "$MODEL" \
-u http://localhost:8123 \
--num-prompts 1 \
--osl "$OSL" \
--random-seed 42 \
--request-count 5 \
--no-server-metrics \
--isl $ISL \
--extra-inputs "max_tokens:$OSL" \
--use-legacy-max-tokens \
--extra-inputs "ignore_eos:true" \
--image-width-mean 1536 \
--image-height-mean 1024 \
--image-format jpeg \
--batch-size-image 3 \
--num-warmup-requests 1 \
--use-server-token-count \
--request-timeout-seconds 600 \
--artifact-dir /tmp/poop
```

### Without cache

```text
[TRT-LLM] [I] [batchmgr][RANK 0] [MemUsageChange] Allocated 82.02 GiB for max tokens in paged KV cache (537504).
[TRT-LLM] [I] [_torch] Peak memory during memory usage profiling (torch + non-torch): 69.29 GiB, available KV cache memory when calculating max tokens: 82.02 GiB, fraction is set 0.9, kv size per token is 163840 bytes/token. device total memory 139.80 GiB, temporary kv cache memory during profiling 20.62 GiB

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━┓
┃                                        Metric ┃      avg ┃      min ┃      max ┃      p99 ┃      p90 ┃      p50 ┃  std ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━┩
│                      Time to First Token (ms) │   769.62 │   763.30 │   773.50 │   773.49 │   773.42 │   769.99 │ 3.77 │
│                     Time to Second Token (ms) │    13.95 │    12.95 │    14.55 │    14.55 │    14.53 │    14.48 │ 0.70 │
│               Time to First Output Token (ms) │   769.62 │   763.30 │   773.50 │   773.49 │   773.42 │   769.99 │ 3.77 │
│                          Request Latency (ms) │ 2,153.44 │ 2,146.84 │ 2,157.67 │ 2,157.66 │ 2,157.59 │ 2,154.39 │ 4.14 │
│                      Inter Token Latency (ms) │    13.98 │    13.97 │    13.98 │    13.98 │    13.98 │    13.98 │ 0.01 │
│              Output Token Throughput Per User │    71.54 │    71.51 │    71.60 │    71.59 │    71.58 │    71.52 │ 0.03 │
│                             (tokens/sec/user) │          │          │          │          │          │          │      │
│ E2E Output Token Throughput (tokens/sec/user) │    46.44 │    46.35 │    46.58 │    46.58 │    46.55 │    46.42 │ 0.09 │
│               Output Sequence Length (tokens) │   100.00 │   100.00 │   100.00 │   100.00 │   100.00 │   100.00 │ 0.00 │
│                Input Sequence Length (tokens) │ 6,497.00 │ 6,497.00 │ 6,497.00 │ 6,497.00 │ 6,497.00 │ 6,497.00 │ 0.00 │
│          Output Token Throughput (tokens/sec) │    46.38 │      N/A │      N/A │      N/A │      N/A │      N/A │  N/A │
│                 Image Throughput (images/sec) │     1.39 │     1.39 │     1.40 │     1.40 │     1.40 │     1.39 │ 0.00 │
│                      Image Latency (ms/image) │   717.81 │   715.61 │   719.22 │   719.22 │   719.20 │   718.13 │ 1.38 │
│             Request Throughput (requests/sec) │     0.46 │      N/A │      N/A │      N/A │      N/A │      N/A │  N/A │
│                      Request Count (requests) │     5.00 │      N/A │      N/A │      N/A │      N/A │      N/A │  N/A │
└───────────────────────────────────────────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────┘
```

### With cache

```
[TRT-LLM] [I] [batchmgr][RANK 0] [MemUsageChange] Allocated 81.90 GiB for max tokens in paged KV cache (536768).
[TRT-LLM] [I] [_torch] Reserving %.2f GiB for the multimodal encoder cache while estimating KV cache capacity. 0.125
[TRT-LLM] [I] [_torch] Peak memory during memory usage profiling (torch + non-torch): 69.42 GiB, available KV cache memory when calculating max tokens: 81.91 GiB, fraction is set 0.9, kv size per token is 163840 bytes/token. device total memory 139.80 GiB, temporary kv cache memory during profiling 20.62 GiB

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━┓
┃                                        Metric ┃      avg ┃      min ┃      max ┃      p99 ┃      p90 ┃      p50 ┃  std ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━┩
│                      Time to First Token (ms) │   662.78 │   651.54 │   668.76 │   668.74 │   668.51 │   666.82 │ 6.69 │
│                     Time to Second Token (ms) │    13.88 │    13.68 │    14.09 │    14.09 │    14.04 │    13.94 │ 0.16 │
│               Time to First Output Token (ms) │   662.78 │   651.54 │   668.76 │   668.74 │   668.51 │   666.82 │ 6.69 │
│                          Request Latency (ms) │ 2,046.91 │ 2,035.77 │ 2,053.77 │ 2,053.71 │ 2,053.23 │ 2,050.25 │ 6.83 │
│                      Inter Token Latency (ms) │    13.98 │    13.97 │    13.99 │    13.99 │    13.99 │    13.98 │ 0.01 │
│              Output Token Throughput Per User │    71.53 │    71.48 │    71.56 │    71.56 │    71.56 │    71.52 │ 0.03 │
│                             (tokens/sec/user) │          │          │          │          │          │          │      │
│ E2E Output Token Throughput (tokens/sec/user) │    48.85 │    48.69 │    49.12 │    49.12 │    49.06 │    48.77 │ 0.16 │
│               Output Sequence Length (tokens) │   100.00 │   100.00 │   100.00 │   100.00 │   100.00 │   100.00 │ 0.00 │
│                Input Sequence Length (tokens) │ 6,497.00 │ 6,497.00 │ 6,497.00 │ 6,497.00 │ 6,497.00 │ 6,497.00 │ 0.00 │
│          Output Token Throughput (tokens/sec) │    48.79 │      N/A │      N/A │      N/A │      N/A │      N/A │  N/A │
│                 Image Throughput (images/sec) │     1.47 │     1.46 │     1.47 │     1.47 │     1.47 │     1.46 │ 0.00 │
│                      Image Latency (ms/image) │   682.30 │   678.59 │   684.59 │   684.57 │   684.41 │   683.42 │ 2.28 │
│             Request Throughput (requests/sec) │     0.49 │      N/A │      N/A │      N/A │      N/A │      N/A │  N/A │
│                      Request Count (requests) │     5.00 │      N/A │      N/A │      N/A │      N/A │      N/A │  N/A │
└───────────────────────────────────────────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────┘
```

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
