### PR TITLE
[#15735][feat] KV-cache transfer/staging between two TRT-LLM instances

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -4728,6 +4728,12 @@ class PyExecutor:
 
                 self._maybe_prepend_logprobs_and_logits(req, beam_width)
 
+                # kv_transfer_only: transfer done + first token adopted; finish now
+                # (no generation forward pass), KV is committed for reuse.
+                if (req.py_disaggregated_params is not None and getattr(
+                        req.py_disaggregated_params, "kv_transfer_only", None)):
+                    req.finish_by(FinishReason.LENGTH, 0)
+
     def _update_sampler_state_for_disagg_gen_request(self, req, beam_width,
                                                      first_gen_tokens) -> bool:
         """Update beam sampler state with context-side first-token data."""
@@ -5462,6 +5468,16 @@ class PyExecutor:
     def _handle_first_token_response(self, scheduled_batch):
         new_responses = []
         for req in scheduled_batch.generation_requests:
+            # A request already finished before its first-token response (only
+            # kv_transfer_only, which finish_by()s at transmission-complete) gets
+            # its single is_final result from the terminal _handle_responses path.
+            # Emitting a first-token response here too would be a SECOND final for
+            # the same client_id -> the proxy pops on the first and KeyErrors on
+            # this one (fatal engine shutdown). Mirror of the is_finished skip
+            # already in _emit_first_token_responses. Stock requests are never
+            # finished at this point, so this is a no-op for them.
+            if req.is_finished:
+                continue
             if req.py_decoding_iter == 1:
                 logger.debug(
                     f'Send first token response for request {req.py_request_id}'

--- a/tensorrt_llm/_torch/pyexecutor/py_executor.py
+++ b/tensorrt_llm/_torch/pyexecutor/py_executor.py
@@ -4698,6 +4698,7 @@ class PyExecutor:
                     requests)
             self._setup_sampler_step(requests)
 
+        kv_transfer_only_done = []
         for req in scheduled_batch.generation_requests:
             if req.is_disagg_generation_transmission_complete:
                 req.state = LlmRequestState.GENERATION_IN_PROGRESS
@@ -4728,11 +4729,30 @@ class PyExecutor:
 
                 self._maybe_prepend_logprobs_and_logits(req, beam_width)
 
-                # kv_transfer_only: transfer done + first token adopted; finish now
-                # (no generation forward pass), KV is committed for reuse.
+                # kv_transfer_only: transfer done + first token adopted; KV already
+                # committed for reuse above, so finish now and record for the trim below.
                 if (req.py_disaggregated_params is not None and getattr(
                         req.py_disaggregated_params, "kv_transfer_only", None)):
                     req.finish_by(FinishReason.LENGTH, 0)
+                    kv_transfer_only_done.append(req.py_request_id)
+
+        # kv_transfer_only reqs have committed their KV (above) and produce no
+        # output, so their forward is wasted -- but only drop them when OTHER work
+        # remains. Empirically, a lone transfer that skips its forward loses its
+        # reuse commit (a later query stops hitting it) and the emptied batch also
+        # trips the overlap loop; some forward in the iteration is needed to finalize
+        # the commit (appears gated on a CUDA event on the forward stream -- see
+        # KVCacheManagerV2._KVCache.commit). So when these are the whole batch we keep
+        # them: their own (discarded) forward finalizes it and is free while idle. The
+        # terminal response comes from _handle_responses (active_requests), so safe.
+        if kv_transfer_only_done:
+            done = set(kv_transfer_only_done)
+            remaining = [
+                req for req in scheduled_batch.generation_requests
+                if req.py_request_id not in done
+            ]
+            if remaining or scheduled_batch.context_requests:
+                scheduled_batch.generation_requests = remaining
 
     def _update_sampler_state_for_disagg_gen_request(self, req, beam_width,
                                                      first_gen_tokens) -> bool:

--- a/tensorrt_llm/disaggregated_params.py
+++ b/tensorrt_llm/disaggregated_params.py
@@ -54,6 +54,9 @@ class DisaggregatedParams:
     ctx_dp_rank: Optional[int] = None
     ctx_info_endpoint: Optional[str] = None
     schedule_style: Optional[DisaggScheduleStyle] = None
+    # generation_only: receive the KV transfer + commit it for reuse, then finish
+    # without generating (prewarming, cache migration/replication, pre-positioning).
+    kv_transfer_only: Optional[bool] = None
     ctx_usage: Optional[Dict[str, Any]] = None
 
     # E-P Disaggregated Params

--- a/tensorrt_llm/serve/openai_protocol.py
+++ b/tensorrt_llm/serve/openai_protocol.py
@@ -166,6 +166,7 @@ class DisaggregatedParams(OpenAIBaseModel):
     schedule_style: Optional[DisaggScheduleStyle] = None
     conversation_id: Optional[str] = None
     ctx_usage: Optional[UsageInfo] = None
+    kv_transfer_only: Optional[bool] = False
     # TODO(TRTLLM-12407): Multimodal E/PD over trtllm-serve needs these protocol fields too:
     # encoder embedding handles, multimodal hashes, and optional mRoPE handles.
     # Add them here and in to_disaggregated_params()/to_llm_disaggregated_params()
@@ -1352,6 +1353,7 @@ def to_llm_disaggregated_params(
         ctx_dp_rank=disaggregated_params.ctx_dp_rank,
         ctx_info_endpoint=disaggregated_params.ctx_info_endpoint,
         schedule_style=disaggregated_params.schedule_style,
+        kv_transfer_only=disaggregated_params.kv_transfer_only,
         ctx_usage=None if ctx_usage is None else ctx_usage.model_dump(),
     )
 

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -679,7 +679,16 @@ class OpenAIServer(_VideoRoutesMixin):
             return JSONResponse(
                 status_code=400,
                 content={"error": "require source and messages|prompt"})
-        if self._kvt_allow is not None and source not in self._kvt_allow:
+        # Fail closed: this endpoint makes the server POST to `source`, so require an
+        # explicit allowlist (KV_TRANSFER_SOURCE_ALLOW) to avoid an SSRF primitive.
+        if self._kvt_allow is None:
+            return JSONResponse(
+                status_code=403,
+                content={
+                    "error":
+                    "kv_transfer disabled: set KV_TRANSFER_SOURCE_ALLOW to enable"
+                })
+        if source not in self._kvt_allow:
             return JSONResponse(
                 status_code=403,
                 content={"error": f"source not allowed: {source}"})
@@ -721,6 +730,13 @@ class OpenAIServer(_VideoRoutesMixin):
                             })
 
     async def _do_kv_transfer(self, model, messages, prompt, source, h):
+        """Background worker: pull the prompt's KV from `source` and commit it locally.
+
+        Runs the two-phase disagg flow -- context_only on `source`, then
+        generation_only with kv_transfer_only on self -- checking both responses
+        before counting the transfer as successful. On failure, clears the dedup
+        entry so a transient error can be retried before the TTL elapses.
+        """
         is_chat = messages is not None
         path = "/v1/chat/completions" if is_chat else "/v1/completions"
         ctx_body = {
@@ -739,26 +755,35 @@ class OpenAIServer(_VideoRoutesMixin):
                     total=self._kvt_dedup_ttl)) as session:
                 async with session.post(source.rstrip("/") + path,
                                         json=ctx_body) as r:
+                    if r.status >= 300:
+                        raise RuntimeError(
+                            f"source context_only returned {r.status}")
                     ctx = await r.json()
                 dp = ctx.get("disaggregated_params") or (ctx.get(
                     "choices", [{}])[0].get("disaggregated_params"))
                 if not dp:
-                    self._kvt_stats["failed"] += 1
-                    return
+                    raise RuntimeError(
+                        "no disaggregated_params ticket from source")
                 gen_body = dict(ctx_body)
                 gen_body["disaggregated_params"] = dict(
                     dp, request_type="generation_only", kv_transfer_only=True)
                 async with session.post(f"http://127.0.0.1:{self.port}{path}",
                                         json=gen_body) as r2:
                     await r2.read()
+                    if r2.status >= 300:
+                        raise RuntimeError(
+                            f"local generation_only returned {r2.status}")
             self._kvt_stats["transferred"] += 1
-        except Exception as e:
+        except (aiohttp.ClientError, asyncio.TimeoutError, ValueError,
+                RuntimeError) as e:
             self._kvt_stats["failed"] += 1
+            self._kvt_seen.pop(h, None)  # not a real dedup hit -> allow retry
             logger.warning(f"[kv-transfer] {h[:8]} failed: {repr(e)[:120]}")
         finally:
             self._kvt_inflight -= 1
 
     async def kv_transfer_stats(self, request: Request):
+        """Return KV-transfer counters plus live inflight, dedup-table size, cap."""
         return JSONResponse(
             content={
                 **self._kvt_stats, "inflight": self._kvt_inflight,

--- a/tensorrt_llm/serve/openai_server.py
+++ b/tensorrt_llm/serve/openai_server.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import asyncio
 import base64
+import hashlib
 import json
 import os
 import re
@@ -17,6 +18,7 @@ from pathlib import Path
 from typing import (Annotated, Any, AsyncGenerator, AsyncIterator, List,
                     Optional, Union)
 
+import aiohttp
 import uvicorn
 from fastapi import Body, FastAPI, Request
 from fastapi.exceptions import RequestValidationError
@@ -202,6 +204,21 @@ class OpenAIServer(_VideoRoutesMixin):
         self.binding_addr = None
         self.host = None
         self.port = None
+        self._kvt_stats = {
+            "fired": 0,
+            "transferred": 0,
+            "failed": 0,
+            "deduped": 0,
+            "skipped_busy": 0
+        }
+        self._kvt_seen = {}
+        self._kvt_inflight = 0
+        self._kvt_max = int(os.environ.get("KV_TRANSFER_MAX_INFLIGHT", "4"))
+        self._kvt_dedup_ttl = float(
+            os.environ.get("KV_TRANSFER_DEDUP_TTL", "300"))
+        _allow = os.environ.get("KV_TRANSFER_SOURCE_ALLOW", "").strip()
+        self._kvt_allow = set(s.strip() for s in _allow.split(",")
+                              if s.strip()) if _allow else None
 
         model_dir = Path(model)
         if model_dir.exists() and model_dir.is_dir():
@@ -631,6 +648,124 @@ class OpenAIServer(_VideoRoutesMixin):
             return self.generator._check_health()
         return True
 
+    async def kv_transfer(self, request: Request):
+        """Start a background KV-cache transfer and return 202 immediately.
+
+        Request JSON:
+          source:   base URL of a context-capable server to pull the KV from.
+          messages | prompt: the prompt to transfer (chat or completions form).
+          model:    optional; defaults to this server's served model.
+
+        Fetches the prompt's KV from `source` over the disaggregated-serving
+        transceiver and commits it to this server's reuse cache; no tokens are
+        generated. The transfer runs in the background -- the response does not
+        wait for it.
+
+        Returns 202 with {status, request_hash}, where status is one of
+        `accepted`, `deduped` (an identical prompt was seen within the dedup
+        TTL), or `skipped_busy` (the in-flight transfer cap was reached).
+        Returns 400 if `source` or the prompt is missing, 403 if `source` is
+        not in the configured allowlist.
+        """
+        try:
+            body = await request.json()
+        except Exception:
+            return JSONResponse(status_code=400, content={"error": "bad json"})
+        source = body.get("source")
+        model = body.get("model") or self.model
+        messages = body.get("messages")
+        prompt = body.get("prompt")
+        if not source or (messages is None and prompt is None):
+            return JSONResponse(
+                status_code=400,
+                content={"error": "require source and messages|prompt"})
+        if self._kvt_allow is not None and source not in self._kvt_allow:
+            return JSONResponse(
+                status_code=403,
+                content={"error": f"source not allowed: {source}"})
+        key = json.dumps(
+            messages, sort_keys=True) if messages is not None else str(prompt)
+        h = hashlib.sha1(key.encode(), usedforsecurity=False).hexdigest()
+        now = time.monotonic()
+        last = self._kvt_seen.get(h)
+        if last is not None and (now - last) < self._kvt_dedup_ttl:
+            self._kvt_stats["deduped"] += 1
+            return JSONResponse(status_code=202,
+                                content={
+                                    "status": "deduped",
+                                    "request_hash": h
+                                })
+        if self._kvt_inflight >= self._kvt_max:
+            self._kvt_stats["skipped_busy"] += 1
+            return JSONResponse(status_code=202,
+                                content={
+                                    "status": "skipped_busy",
+                                    "request_hash": h
+                                })
+        self._kvt_seen[h] = now
+        if len(self._kvt_seen) > 20000:
+            self._kvt_seen = {
+                k: v
+                for k, v in self._kvt_seen.items()
+                if now - v < self._kvt_dedup_ttl
+            }
+        self._kvt_inflight += 1
+        self._kvt_stats["fired"] += 1
+        asyncio.create_task(
+            self._do_kv_transfer(model, messages, prompt, source, h))
+        return JSONResponse(status_code=202,
+                            content={
+                                "status": "accepted",
+                                "request_hash": h,
+                                "deduped": False
+                            })
+
+    async def _do_kv_transfer(self, model, messages, prompt, source, h):
+        is_chat = messages is not None
+        path = "/v1/chat/completions" if is_chat else "/v1/completions"
+        ctx_body = {
+            "model": model,
+            "max_tokens": 1,
+            "temperature": 0,
+            "stream": False,
+            "disaggregated_params": {
+                "request_type": "context_only"
+            }
+        }
+        ctx_body["messages"
+                 if is_chat else "prompt"] = messages if is_chat else prompt
+        try:
+            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(
+                    total=self._kvt_dedup_ttl)) as session:
+                async with session.post(source.rstrip("/") + path,
+                                        json=ctx_body) as r:
+                    ctx = await r.json()
+                dp = ctx.get("disaggregated_params") or (ctx.get(
+                    "choices", [{}])[0].get("disaggregated_params"))
+                if not dp:
+                    self._kvt_stats["failed"] += 1
+                    return
+                gen_body = dict(ctx_body)
+                gen_body["disaggregated_params"] = dict(
+                    dp, request_type="generation_only", kv_transfer_only=True)
+                async with session.post(f"http://127.0.0.1:{self.port}{path}",
+                                        json=gen_body) as r2:
+                    await r2.read()
+            self._kvt_stats["transferred"] += 1
+        except Exception as e:
+            self._kvt_stats["failed"] += 1
+            logger.warning(f"[kv-transfer] {h[:8]} failed: {repr(e)[:120]}")
+        finally:
+            self._kvt_inflight -= 1
+
+    async def kv_transfer_stats(self, request: Request):
+        return JSONResponse(
+            content={
+                **self._kvt_stats, "inflight": self._kvt_inflight,
+                "seen": len(self._kvt_seen),
+                "max_inflight": self._kvt_max
+            })
+
     def register_routes(self):
         self.app.add_api_route("/health", self.health, methods=["GET"])
         self.app.add_api_route("/health_generate",
@@ -693,6 +828,12 @@ class OpenAIServer(_VideoRoutesMixin):
             "/v1/chat/completions",
             self.openai_chat if not self.use_harmony else self.chat_harmony,
             methods=["POST"])
+        self.app.add_api_route("/v1/kv_transfer",
+                               self.kv_transfer,
+                               methods=["POST"])
+        self.app.add_api_route("/v1/kv_transfer/stats",
+                               self.kv_transfer_stats,
+                               methods=["GET"])
         self.app.add_api_route("/v1/responses",
                                self.openai_responses,
                                methods=["POST"])

--- a/tests/unittest/disaggregated/test_kv_transfer_endpoint.py
+++ b/tests/unittest/disaggregated/test_kv_transfer_endpoint.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the /v1/kv_transfer endpoint request handling.
+
+Exercises the HTTP-layer logic of ``OpenAIServer.kv_transfer`` /
+``kv_transfer_stats`` -- validation, dedup, the in-flight cap, the source
+allowlist, and the stats counters -- with the background transfer
+(``_do_kv_transfer``) stubbed out, so no engine or GPU is required.
+"""
+
+import asyncio
+import json
+import types
+
+import pytest
+
+from tensorrt_llm.serve.openai_server import OpenAIServer
+
+
+class _FakeRequest:
+    """Minimal stand-in for starlette Request; .json() returns the body."""
+
+    def __init__(self, body, bad=False):
+        self._body = body
+        self._bad = bad
+
+    async def json(self):
+        if self._bad:
+            raise ValueError("bad json")
+        return self._body
+
+
+async def _noop_transfer(*args, **kwargs):
+    return None
+
+
+def _make_server(max_inflight=4, dedup_ttl=300.0, allow=None, inflight=0):
+    """A bare object carrying just the state kv_transfer touches."""
+    s = types.SimpleNamespace()
+    s.model = "test-model"
+    s.port = 8000
+    s._kvt_stats = {
+        "fired": 0,
+        "transferred": 0,
+        "failed": 0,
+        "deduped": 0,
+        "skipped_busy": 0,
+    }
+    s._kvt_seen = {}
+    s._kvt_inflight = inflight
+    s._kvt_max = max_inflight
+    s._kvt_dedup_ttl = dedup_ttl
+    s._kvt_allow = allow
+    # Never run the real two-step transfer in a unit test.
+    s._do_kv_transfer = _noop_transfer
+    return s
+
+
+def _call(server, body=None, bad=False):
+    req = _FakeRequest(body, bad=bad)
+    resp = asyncio.run(OpenAIServer.kv_transfer(server, req))
+    return resp.status_code, json.loads(resp.body)
+
+
+def _stats(server):
+    resp = asyncio.run(OpenAIServer.kv_transfer_stats(server, _FakeRequest({})))
+    return json.loads(resp.body)
+
+
+def test_bad_json_returns_400():
+    s = _make_server()
+    code, body = _call(s, bad=True)
+    assert code == 400
+    assert "error" in body
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"messages": [{"role": "user", "content": "hi"}]},  # no source
+        {"source": "http://a:8001"},  # no messages/prompt
+        {},  # neither
+    ],
+)
+def test_missing_required_fields_returns_400(body):
+    s = _make_server()
+    code, _ = _call(s, body)
+    assert code == 400
+
+
+def test_valid_request_is_accepted_and_counted():
+    s = _make_server()
+    code, body = _call(s, {"source": "http://a:8001", "prompt": "hello"})
+    assert code == 202
+    assert body["status"] == "accepted"
+    assert "request_hash" in body
+    assert s._kvt_stats["fired"] == 1
+
+
+def test_duplicate_within_ttl_is_deduped():
+    s = _make_server()
+    req = {"source": "http://a:8001", "prompt": "same"}
+    code1, _ = _call(s, req)
+    code2, body2 = _call(s, req)
+    assert code1 == 202 and code2 == 202
+    assert body2["status"] == "deduped"
+    assert s._kvt_stats["deduped"] == 1
+    assert s._kvt_stats["fired"] == 1  # only the first one fired
+
+
+def test_inflight_cap_sheds_as_skipped_busy():
+    s = _make_server(max_inflight=2, inflight=2)
+    code, body = _call(s, {"source": "http://a:8001", "prompt": "x"})
+    assert code == 202
+    assert body["status"] == "skipped_busy"
+    assert s._kvt_stats["skipped_busy"] == 1
+    assert s._kvt_stats["fired"] == 0
+
+
+def test_source_allowlist_blocks_and_allows():
+    blocked = _make_server(allow={"http://allowed:8001"})
+    code, _ = _call(blocked, {"source": "http://evil:8001", "prompt": "x"})
+    assert code == 403
+
+    ok = _make_server(allow={"http://allowed:8001"})
+    code, body = _call(ok, {"source": "http://allowed:8001", "prompt": "x"})
+    assert code == 202 and body["status"] == "accepted"
+
+
+def test_stats_endpoint_reports_counters():
+    s = _make_server(max_inflight=7)
+    _call(s, {"source": "http://a:8001", "prompt": "p"})
+    st = _stats(s)
+    for k in (
+        "fired",
+        "transferred",
+        "failed",
+        "deduped",
+        "skipped_busy",
+        "inflight",
+        "seen",
+        "max_inflight",
+    ):
+        assert k in st
+    assert st["fired"] == 1
+    assert st["max_inflight"] == 7
+    assert st["seen"] == 1

--- a/tests/unittest/disaggregated/test_kv_transfer_endpoint.py
+++ b/tests/unittest/disaggregated/test_kv_transfer_endpoint.py
@@ -45,8 +45,12 @@ async def _noop_transfer(*args, **kwargs):
     return None
 
 
-def _make_server(max_inflight=4, dedup_ttl=300.0, allow=None, inflight=0):
-    """A bare object carrying just the state kv_transfer touches."""
+def _make_server(max_inflight=4, dedup_ttl=300.0, allow=frozenset({"http://a:8001"}), inflight=0):
+    """A bare object carrying just the state kv_transfer touches.
+
+    `allow` defaults to a single-source allowlist so the happy-path tests pass the
+    fail-closed gate; pass allow=None to exercise the disabled-by-default behavior.
+    """
     s = types.SimpleNamespace()
     s.model = "test-model"
     s.port = 8000
@@ -136,6 +140,13 @@ def test_source_allowlist_blocks_and_allows():
     ok = _make_server(allow={"http://allowed:8001"})
     code, body = _call(ok, {"source": "http://allowed:8001", "prompt": "x"})
     assert code == 202 and body["status"] == "accepted"
+
+
+def test_no_allowlist_is_disabled_fail_closed():
+    # With no allowlist configured the endpoint fails closed (SSRF guard).
+    s = _make_server(allow=None)
+    code, _ = _call(s, {"source": "http://a:8001", "prompt": "x"})
+    assert code == 403
 
 
 def test_stats_endpoint_reports_counters():


### PR DESCRIPTION
## Description

Implements #15735.

Builds on the disagg transceiver to add a general, **cross-instance** KV-transfer mechanism. A
`generation_only` request with a new **`kv_transfer_only`** flag pulls the prompt's KV from a
**source instance** over the transceiver, commits it to the local reuse cache, and **finishes
immediately, producing no output tokens**. The two instances just need the cache transceiver enabled — they
are not limited to a dedicated context/generation pair, and need not be co-located (UCX does
cross-node over IB too).

### New API

**`POST /v1/kv_transfer`** — accepts the request, starts the transfer in the background, and returns
`202` immediately (does not wait for the transfer to finish).
- Request body:
  - `source` (required) — base URL of the instance to pull the prompt's KV from.
  - `messages` **or** `prompt` (one required) — the prompt, in chat or completions form.
  - `model` (optional) — defaults to the server's served model.
- Response: `202` with `{status, request_hash}`, where `status` is one of `accepted`, `deduped`
  (an identical prompt was seen within the dedup TTL), or `skipped_busy` (the in-flight transfer cap
  was reached). Errors: `400` (missing `source` or prompt), `403` (no allowlist configured, or
  `source` not on it).
- Guards: de-duplicates identical prompts seen within a TTL; caps concurrent transfers and sheds the
  excess as `skipped_busy`; and **requires** a `source` allowlist — the endpoint fails closed (403)
  until `KV_TRANSFER_SOURCE_ALLOW` is set, to avoid an SSRF primitive. Tunables:
  `KV_TRANSFER_MAX_INFLIGHT`, `KV_TRANSFER_DEDUP_TTL`, `KV_TRANSFER_SOURCE_ALLOW`.

**`GET /v1/kv_transfer/stats`** — observability counters: `fired`, `transferred`, `failed`,
`deduped`, `skipped_busy`, plus live `inflight`, `seen` (dedup-table size), and `max_inflight`.

### How it works

It composes the existing disaggregated-serving interface rather than adding new transport. The
endpoint runs the two-phase disagg flow internally: the `context_only` leg makes `source` prefill the
prompt and return its disagg ticket (the opaque transceiver handle for that prompt's KV), and
replaying that ticket back to this instance as a `generation_only` request (with `kv_transfer_only`)
makes the engine pull the KV over the transceiver and commit it for reuse. The internal
`generation_only` leg is issued over loopback HTTP so it goes through the normal serving path
(validation, `disaggregated_params` handling, executor submission).

### Changes (all additive; regular disagg/serving paths unchanged)

- **`disaggregated_params.py` / `serve/openai_protocol.py`** — add the `kv_transfer_only` field and
  pass it through the request converter.
- **`_torch/pyexecutor/py_executor.py`**
  - `_prepare_disagg_gen_transmission_complete`: when `kv_transfer_only`, commit the KV and
    `finish_by(LENGTH, 0)` after the normal sampler setup (skipping that setup corrupts the batched
    sampler under concurrency), then drop the request from the forward batch to skip a wasted
    decode — but only when other work remains; a lone transfer keeps its (output-discarded) forward,
    which is what finalizes the reuse commit (and avoids an empty batch).
  - `_handle_first_token_response`: skip already-finished requests. A `kv_transfer_only` req is
    finished at transmission-complete, so without this it would emit a first-token response *and* the
    terminal response — two `is_final` results for one `client_id`. The skip mirrors the existing
    `is_finished` guard in `_emit_first_token_responses`, and is a no-op for stock requests (which
    are never finished at first-token).
- **`serve/openai_server.py`** — the `POST /v1/kv_transfer` and `GET /v1/kv_transfer/stats` handlers.
  The endpoint fails closed without an allowlist (SSRF guard), and `_do_kv_transfer` checks both POST
  responses before counting a transfer, clears the dedup entry on failure (so transient errors can
  retry), and narrows its `except` to HTTP/JSON/timeout.

`kv_transfer_only` requests compose with the existing idle-only transfer-progress blocking, so they
pull and commit without stalling live traffic.

## Test Coverage

Adds **`tests/unittest/disaggregated/test_kv_transfer_endpoint.py`** — unit tests for the endpoint's
request handling (bad JSON / missing fields → 400, allowlist + fail-closed → 403, accept + counters,
dedup within TTL, in-flight cap → `skipped_busy`, and the `/stats` counters), with the background
transfer stubbed so no engine/GPU is required (10 tests).

The engine-level transfer + reuse path was validated manually on the rc19 release image with
gpt-oss-120b across two instances (one source, one destination): reuse correctness (the transferred KV
is reused on a subsequent request with correct output), zero cross-contamination under sustained mixed
load (concurrent unrelated requests + mid-stream cancellations), and no fatal engine errors. Happy to
add an automated 2-GPU disagg integration test following the `tests/unittest/disaggregated` patterns
if maintainers prefer.

(Note vs rc19: rc19 still has an always-on transfer-progress wait, so there `kv_transfer_only` also
needs excluding from that wait; `main` blocks only when idle, so this PR does not touch the blocking
path.)

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work)).
- If PR introduces API changes, an appropriate PR label is added — this PR is **api-compatible** (the flag and endpoints are additive and off by default).
- Any new dependencies have been scanned for license and vulnerabilities — no new dependencies.
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes — n/a.
- Documentation updated as needed.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.

@coderabbitai summary
