### PR TITLE
[https://nvbugs/6250439][fix] Correct speculative XQA attention sinks

### DIFF
--- a/cpp/kernels/xqa/mha.cu
+++ b/cpp/kernels/xqa/mha.cu
@@ -1475,10 +1475,19 @@ __device__ inline void addAttentionSinks(
 {
     for (uint32_t i = 0; i < globalRowSum.size; i++)
     {
-        uint32_t srcOffset = warp_size * i + laneId();
-        if (srcOffset < headGrpSize)
+        uint32_t const rowOffset = warp_size * i + laneId();
+        if constexpr (SPEC_DEC)
         {
-            globalRowSum[i] += expf(attentionSinks[srcOffset] - globalRowMax[i]);
+            // Spec-dec rows flatten [query token, head], so repeat the sink indices for every token.
+            if (rowOffset < warpTile.y)
+            {
+                uint32_t const srcOffset = rowOffset % headGrpSize;
+                globalRowSum[i] += expf(attentionSinks[srcOffset] - globalRowMax[i]);
+            }
+        }
+        else if (rowOffset < headGrpSize)
+        {
+            globalRowSum[i] += expf(attentionSinks[rowOffset] - globalRowMax[i]);
         }
     }
 }
@@ -1698,7 +1707,7 @@ CUBIN_EXPORT __global__
 
     uint32_t const cacheSeqLen = getCacheSeqLen<usePagedKVCache>(cacheList, idxReq);
 #if SLIDING_WINDOW && SPEC_DEC && !IS_SPEC_DEC_TREE
-    uint32_t const tok0SeqLen = cacheSeqLen - actualQSeqLen + 1 + idxHeadTokenInGrp; // ctaTokOffset;
+    uint32_t const tok0SeqLen = cacheSeqLen - actualQSeqLen + 1;
     int32_t const tok0WinBeg = int32_t(tok0SeqLen) - int32_t(slidingWinSize);
     uint32_t const nbTotalSkipTokens = mha::max(0, tok0WinBeg);
     bool const rtIsReallySliding = (cacheSeqLen + actualQSeqLen > slidingWinSize);

--- a/cpp/kernels/xqa/test/refAttention.cpp
+++ b/cpp/kernels/xqa/test/refAttention.cpp
@@ -180,7 +180,8 @@ template <typename MathElem, bool isPaged, bool useBeamSearch>
 #if SPEC_DEC
 Eigen::Matrix<float, headGrpSize, validElemsPerHead, Eigen::RowMajor> refAttention(IOHead const* q,
     CacheSeq<isPaged, useBeamSearch> const& k, CacheSeq<isPaged, useBeamSearch> const& v, uint32_t seqLen, float qScale,
-    float kvScale, float xScale, uint32_t slidingWinSize, bool* hostMask, const uint32_t qSeqLen, const uint32_t q_len)
+    float kvScale, float xScale, uint32_t slidingWinSize, float* attentionSinks, bool* hostMask, const uint32_t qSeqLen,
+    const uint32_t q_len)
 {
 #else
 Eigen::Matrix<float, headGrpSize, validElemsPerHead, Eigen::RowMajor> refAttention(IOHead const* q,
@@ -244,7 +245,6 @@ Eigen::Matrix<float, headGrpSize, validElemsPerHead, Eigen::RowMajor> refAttenti
     }
 
     // Add the attention sinks.
-#if !SPEC_DEC
     if (attentionSinks != nullptr)
     {
         for (uint32_t i = 0; i < headGrpSize; i++)
@@ -252,7 +252,6 @@ Eigen::Matrix<float, headGrpSize, validElemsPerHead, Eigen::RowMajor> refAttenti
             rowSum[i] += expf(attentionSinks[i] - rowMax[i]);
         }
     }
-#endif
 
     Eigen::Matrix<float, headGrpSize, validElemsPerHead, Eigen::RowMajor> out
         = gemm1Acc.array().colwise() * (xScale * kvScale / rowSum.array());
@@ -265,7 +264,7 @@ Eigen::Matrix<float, headGrpSize, validElemsPerHead, Eigen::RowMajor> refAttenti
     template Eigen::Matrix<float, headGrpSize, validElemsPerHead, Eigen::RowMajor>                                     \
     refAttention<prec, isPaged, useBeamSearch>(IOHead const* q, CacheSeq<isPaged, useBeamSearch> const& k,             \
         CacheSeq<isPaged, useBeamSearch> const& v, uint32_t seqLen, float qScale, float kvScale, float xScale,         \
-        uint32_t slidingWinSize, bool* hostMask, const uint32_t qSeqLen, const uint32_t q_len)
+        uint32_t slidingWinSize, float* attentionSinks, bool* hostMask, const uint32_t qSeqLen, const uint32_t q_len)
 #else
 #define INSTANTIATE_refAttention(prec, isPaged, useBeamSearch)                                                         \
     template Eigen::Matrix<float, headGrpSize, validElemsPerHead, Eigen::RowMajor>                                     \

--- a/cpp/kernels/xqa/test/refAttention.h
+++ b/cpp/kernels/xqa/test/refAttention.h
@@ -95,7 +95,8 @@ template <typename MathElem, bool isPaged, bool useBeamSearch>
 #if SPEC_DEC
 Eigen::Matrix<float, headGrpSize, validElemsPerHead, Eigen::RowMajor> refAttention(IOHead const* q,
     CacheSeq<isPaged, useBeamSearch> const& k, CacheSeq<isPaged, useBeamSearch> const& v, uint32_t seqLen, float qScale,
-    float kvScale, float xScale, uint32_t slidingWinSize, bool* hostMask, const uint32_t qSeqLen, const uint32_t q_len);
+    float kvScale, float xScale, uint32_t slidingWinSize, float* attentionSinks, bool* hostMask, const uint32_t qSeqLen,
+    const uint32_t q_len);
 #else
 Eigen::Matrix<float, headGrpSize, validElemsPerHead, Eigen::RowMajor> refAttention(IOHead const* q,
     CacheSeq<isPaged, useBeamSearch> const& k, CacheSeq<isPaged, useBeamSearch> const& v, uint32_t seqLen, float qScale,

--- a/cpp/kernels/xqa/test/test.cpp
+++ b/cpp/kernels/xqa/test/test.cpp
@@ -1225,15 +1225,15 @@ void runTest(uint32_t batchSize, uint32_t seqLen, bool testPerf, bool refCheck, 
 
 #endif
 #endif
+                        auto const refAttentionSinks
+                            = hasAttentionSinks ? attentionSinksPtr + headGrpSize * idxKHead : nullptr;
 #if SPEC_DEC
                         Eigen::Matrix<float, runtimeHeadGrpSize, validElemsPerHead, Eigen::RowMajor> refOutput;
                         refOutput = refAttention<InputElem>(&qHeads[req][b][q_len][runtimeHeadGrpSize * idxKHead],
                             kCacheSeq, vCacheSeq, seqLen, qScaleForRef, kvCacheScale[0], xScale, slidingWinSize,
-                            hostMask, qSeqLen, q_len);
+                            refAttentionSinks, hostMask, qSeqLen, q_len);
 #else
                     Eigen::Matrix<float, headGrpSize, validElemsPerHead, Eigen::RowMajor> refOutput;
-                    auto const refAttentionSinks
-                        = hasAttentionSinks ? attentionSinksPtr + headGrpSize * idxKHead : nullptr;
                     if (useQGMMA)
                     {
                         refOutput = refFlashAttention<CacheElem, 64>(&qHeads[req][b][headGrpSize * idxKHead], kCacheSeq,
@@ -1360,6 +1360,20 @@ TEST(RefCheck, llama_V2_70b_3)
 
 #endif
 }
+
+#if SLIDING_WINDOW && !IS_SPEC_DEC_TREE
+TEST(RefCheck, gpt_oss_spec_swa_rows)
+{
+    runTest<8, HEAD_GROUP_SIZE, 2>(1, 258, false, true, true, false, true, ~0U, 128);
+    runTest<8, HEAD_GROUP_SIZE, 4>(1, 260, false, true, true, false, true, ~0U, 128);
+    runTest<8, HEAD_GROUP_SIZE, 2>(4, 258, false, true, true, false, true, ~0U, 128);
+    runTest<8, HEAD_GROUP_SIZE, 4>(4, 260, false, true, true, false, true, ~0U, 128);
+    runTest<2, HEAD_GROUP_SIZE, 2>(1, 258, false, true, true, false, true, ~0U, 128);
+    runTest<2, HEAD_GROUP_SIZE, 4>(1, 260, false, true, true, false, true, ~0U, 128);
+    runTest<2, HEAD_GROUP_SIZE, 2>(4, 258, false, true, true, false, true, ~0U, 128);
+    runTest<2, HEAD_GROUP_SIZE, 4>(4, 260, false, true, true, false, true, ~0U, 128);
+}
+#endif
 
 #endif
 


### PR DESCRIPTION
## Description

Speculative HMMA XQA flattens output rows as `[query token, head]`, but attention-sink normalization only covered the first head group. For GPT-OSS Eagle, later speculative query-token rows therefore omitted the learned per-head sink contribution and produced corrupted target logits.

This change:

- repeats each per-head attention sink across every speculative query-token row;
- removes a duplicated speculative sliding-window row offset whose units did not match the token sequence length;
- makes the CPU reference attention-sink aware; and
- adds regression coverage for Eagle depths 1 and 3, batch sizes 1 and 4, and TP1/TP4 KV-head shapes.

The change is internal to XQA. It introduces no public API change, dependency, ownership change, documentation requirement, or architecture-diagram change.

## Test Coverage

- Pre-commit checks on all four modified XQA files and `git diff --check`.
- Native SM90 release build with `FAST_BUILD=OFF`.
- Focused HMMA reference regression on H100 PCIe and H200 for depth 1/3, batch 1/4, and 8/2 local KV heads. All cases passed with maximum absolute error `0.003906`.
- Full H200 TP4/EP1 Eagle depth-3 GSM8K: flexible exact match `0.4610`, strict exact match `0.2904`, return code `0`. This clears the NVBug `0.42` threshold.
- Full H100 PCIe TP4/EP1 Eagle depth-3 GSM8K: flexible exact match `0.4685`, strict exact match `0.2866`, return code `0`.

The focused and full Hopper validation will also be rerun on the rebased PR head.

## PR Checklist

Please review the following before submitting your PR:

- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of my knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work)).
- No public API change is introduced, so an API compatibility label is not required.
- No new dependencies are introduced.
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) does not need an update because ownership is unchanged.
- No user-facing documentation or architecture diagram changes are needed for this kernel correctness fix.
- `@jhaotingc` and `@lowsfer` are requested as the primary XQA/speculative-decoding reviewers.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, comment `/bot help`.
