### PR TITLE
[https://nvbugs/4974458][fix] Account for PP in dynamic batch tuning

### DIFF
--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.cpp
@@ -2947,7 +2947,8 @@ nvinfer1::Dims TrtGptModelInflightBatching::getTensorShape(std::string const& na
 
 SizeType32 TrtGptModelInflightBatching::getMaxCapacityBatchSize(SizeType32 inputLength, SizeType32 outputLength) const
 {
-    return mKvCacheManager->getMaxCapacityBatchSize(inputLength, outputLength);
+    return detail::getRuntimeBatchTuningCapacity(mKvCacheManager->getMaxCapacityBatchSize(inputLength, outputLength),
+        mWorldConfig.isPipelineParallel(), mWorldConfig.getPipelineParallelism());
 }
 
 /*

--- a/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
+++ b/cpp/tensorrt_llm/batch_manager/trtGptModelInflightBatching.h
@@ -74,6 +74,18 @@ namespace rnn_state_manager
 class RnnStateManager;
 } // namespace rnn_state_manager
 
+namespace detail
+{
+
+inline runtime::SizeType32 getRuntimeBatchTuningCapacity(
+    runtime::SizeType32 maxCapacityBatchSize, bool isPipelineParallel, runtime::SizeType32 pipelineParallelism)
+{
+    TLLM_CHECK_WITH_INFO(pipelineParallelism > 0, "Pipeline parallelism must be positive, got %d", pipelineParallelism);
+    return isPipelineParallel ? maxCapacityBatchSize / pipelineParallelism : maxCapacityBatchSize;
+}
+
+} // namespace detail
+
 class SequenceSlotManager;
 class DecoderStepAsyncSend;
 class DecoderSlotAsyncSend;

--- a/cpp/tests/unit_tests/executor/dynamicBatchTunerTest.cpp
+++ b/cpp/tests/unit_tests/executor/dynamicBatchTunerTest.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "tensorrt_llm/executor/dynamicBatchTuner.h"
+#include "tensorrt_llm/batch_manager/trtGptModelInflightBatching.h"
 #include "tensorrt_llm/common/tllmException.h"
 #include "tensorrt_llm/executor/executor.h"
 #include "tensorrt_llm/executor/types.h"
@@ -27,6 +28,7 @@ using ::testing::Invoke;
 
 using namespace tensorrt_llm::executor;
 using namespace tensorrt_llm::common;
+using tensorrt_llm::batch_manager::detail::getRuntimeBatchTuningCapacity;
 
 TEST(DynamicBatchTunerTest, Stats)
 {
@@ -71,6 +73,22 @@ TEST(DynamicBatchConfig, RuntimeBatchSize)
     // fall back
     EXPECT_EQ(dynamicBatchTuner.getRuntimeBatchSize(2049), 2048);
     EXPECT_EQ(dynamicBatchTuner.getRuntimeBatchSize(1665), 1665);
+}
+
+TEST(DynamicBatchConfig, RuntimeBatchSizeUsesPerMicroBatchCapacityForPipelineParallelism)
+{
+    DynamicBatchConfig dynamicBatchConfig(true, true, 3);
+    DynamicBatchTuner dynamicBatchTuner(dynamicBatchConfig);
+
+    auto const ppCapacity = getRuntimeBatchTuningCapacity(/*maxCapacityBatchSize=*/640,
+        /*isPipelineParallel=*/true, /*pipelineParallelism=*/2);
+    EXPECT_EQ(ppCapacity, 320);
+    EXPECT_EQ(dynamicBatchTuner.getRuntimeBatchSize(ppCapacity), 256);
+
+    auto const nonPpCapacity = getRuntimeBatchTuningCapacity(/*maxCapacityBatchSize=*/640,
+        /*isPipelineParallel=*/false, /*pipelineParallelism=*/2);
+    EXPECT_EQ(nonPpCapacity, 640);
+    EXPECT_EQ(dynamicBatchTuner.getRuntimeBatchSize(nonPpCapacity), 512);
 }
 
 TEST(DynamicBatchConfig, RuntimeMaxNumTokens)


### PR DESCRIPTION
## Description

**max_capacity_size is calculated on the total requests in KV cache which is the sum of micro batch (ubatch) sizes, but the capping needs to be applied on ubatch processed in each PP stage. The capping condition may need to be applied on (max_capacity_size / PP) to reflect the ubatch size.**

Fixes NVBug 4974458. Under pipeline parallelism, KV-cache capacity represents all simultaneously resident requests across PP microbatches, while the runtime batch limit is applied to one microbatch. Normalize the capacity by pipeline-parallel size before passing it to `DynamicBatchTuner`.

## Test Coverage

- Added `DynamicBatchConfig.RuntimeBatchSizeUsesPerMicroBatchCapacityForPipelineParallelism`.
- Built `dynamicBatchTunerTest` and passed all three `DynamicBatchConfig.*` tests.
- Passed pre-commit on all three changed files.
- Completed a controlled 4x H200 Llama 3.1 70B FP8 TP2/PP2 A/B run against the parent commit. Under the same 640 globally active requests, the parent selected tuner/runtime/per-microbatch sizes `512/320/320`; the fix selected `256/256/256` and improved throughput by about 13.7%. Full results: https://github.com/NVIDIA/TensorRT-LLM/pull/15740#issuecomment-4839385767.

## PR Checklist

The description, coding guidelines, test coverage, ownership, dependency, API, documentation, and architecture-diagram items were reviewed as applicable. This change adds no API, dependency, CODEOWNERS, documentation, or architecture changes.

- [x] Please check this after reviewing the above items as appropriate for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime batch size calculation so it now accounts for pipeline-parallel configurations, leading to more accurate batching behavior in supported setups.
  * Batch capacity scaling now behaves consistently whether pipeline parallelism is enabled or not.

* **Tests**
  * Added coverage for batch sizing behavior across both pipeline-parallel and non-pipeline-parallel configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
