### PR TITLE
[TRTLLM-13446][test] Add FLUX infer() num_images_per_prompt forwardin…

### DIFF
--- a/tests/integration/test_lists/test-db/l0_a10.yml
+++ b/tests/integration/test_lists/test-db/l0_a10.yml
@@ -121,6 +121,7 @@ l0_a10:
   - unittest/visual_gen/test_iteration_stats.py
   - unittest/visual_gen/test_media_encoding.py
   - unittest/_torch/visual_gen/test_tensor_payload.py
+  - unittest/_torch/visual_gen/test_flux_infer.py
   - unittest/_torch/visual_gen/test_qwen_image_infer.py
   - unittest/_torch/visual_gen/test_qwen_image_pipeline.py
   # llmapi

--- a/tests/unittest/_torch/visual_gen/test_flux_infer.py
+++ b/tests/unittest/_torch/visual_gen/test_flux_infer.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for FLUX request orchestration."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from tensorrt_llm._torch.visual_gen.models.flux import Flux2Pipeline, FluxPipeline
+
+
+@pytest.mark.parametrize("pipeline_cls", [FluxPipeline, Flux2Pipeline])
+def test_infer_forwards_num_images_per_prompt(
+    pipeline_cls: type[FluxPipeline] | type[Flux2Pipeline],
+) -> None:
+    pipeline = pipeline_cls.__new__(pipeline_cls)
+    pipeline.forward = Mock(return_value="image")
+    request = SimpleNamespace(
+        prompt="a cat",
+        params=SimpleNamespace(
+            height=256,
+            width=256,
+            num_inference_steps=4,
+            guidance_scale=3.5,
+            seed=42,
+            max_sequence_length=512,
+            num_images_per_prompt=2,
+        ),
+    )
+
+    result = pipeline.infer(request)
+
+    assert result == "image"
+    pipeline.forward.assert_called_once()
+    assert pipeline.forward.call_args.kwargs["num_images_per_prompt"] == 2


### PR DESCRIPTION
…g test

The existing GPU tests call forward() directly, so a regression where infer() drops num_images_per_prompt (the original TRTLLM-12870 failure mode) would still pass. Add a CPU-only stubbed test that asserts infer() forwards the parameter to forward(), parametrized over FluxPipeline and Flux2Pipeline. Register in l0_a10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for image-generation request handling across multiple pipeline variants.
  * Verified that inference returns the pipeline’s direct output and correctly passes through the number of images requested per prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
