### PR TITLE
[https://nvbugs/6162506][test] AutoDeploy: fix NVFP4 MoE fp4 weight scale in test

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -469,7 +469,6 @@ unittest/_torch/visual_gen/multi_gpu/test_wan_tp.py::TestWanT2VTP::test_wan_t2v_
 unittest/_torch/visual_gen/multi_gpu/test_wan_transformer_parallel.py::TestWanTransformerParallel::test_parallel_all_combinations_vs_single_gpu_8gpu[attn2d_1x4_ul2] SKIP (https://nvbugs/6385134)
 unittest/_torch/visual_gen/test_attention_integration.py::test_sage_attention_self_attention[fp8-2-1560] SKIP (https://nvbugs/6198760)
 unittest/_torch/visual_gen/test_attention_integration.py::test_sage_attention_self_attention[int8-2-1560] SKIP (https://nvbugs/6198760)
-unittest/auto_deploy/singlegpu/smoke SKIP (https://nvbugs/6306936)
 unittest/bindings/test_transfer_agent_bindings.py::TestNixlFunctionalTransfer::test_nixl_wait_in_progress_on_zero_timeout SKIP (https://nvbugs/6260897)
 unittest/executor/test_rpc.py::TestRpcCorrectness::test_incremental_task_async SKIP (https://nvbugs/5741476)
 unittest/executor/test_rpc_proxy.py SKIP (https://nvbugs/5605741)

--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -469,8 +469,6 @@ unittest/_torch/visual_gen/multi_gpu/test_wan_tp.py::TestWanT2VTP::test_wan_t2v_
 unittest/_torch/visual_gen/multi_gpu/test_wan_transformer_parallel.py::TestWanTransformerParallel::test_parallel_all_combinations_vs_single_gpu_8gpu[attn2d_1x4_ul2] SKIP (https://nvbugs/6385134)
 unittest/_torch/visual_gen/test_attention_integration.py::test_sage_attention_self_attention[fp8-2-1560] SKIP (https://nvbugs/6198760)
 unittest/_torch/visual_gen/test_attention_integration.py::test_sage_attention_self_attention[int8-2-1560] SKIP (https://nvbugs/6198760)
-unittest/auto_deploy/singlegpu/custom_ops/moe/test_trtllm_moe.py::test_trtllm_fused_moe_nvfp4[4-otype0-2-2-2688-1856-1] SKIP (https://nvbugs/6162506)
-unittest/auto_deploy/singlegpu/custom_ops/moe/test_trtllm_moe.py::test_trtllm_fused_moe_nvfp4[4-otype1-2-2-2688-1856-1] SKIP (https://nvbugs/6162506)
 unittest/auto_deploy/singlegpu/smoke SKIP (https://nvbugs/6306936)
 unittest/bindings/test_transfer_agent_bindings.py::TestNixlFunctionalTransfer::test_nixl_wait_in_progress_on_zero_timeout SKIP (https://nvbugs/6260897)
 unittest/executor/test_rpc.py::TestRpcCorrectness::test_incremental_task_async SKIP (https://nvbugs/5741476)

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_trtllm_moe.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_trtllm_moe.py
@@ -639,6 +639,39 @@ def test_trtllm_fused_moe_nvfp4(
         def round_up(x, y):
             return math.ceil(x / y) * y
 
+        def quantize_weight_for_fused_moe(weight, global_scale):
+            fp4_weight, _ = torch.ops.trtllm.fp4_quantize(
+                weight,
+                global_scale,
+                NVFP4_BLOCK_SIZE,
+                isSfSwizzledLayout=False,
+            )
+
+            m, n = weight.shape
+            n_blocks = n // NVFP4_BLOCK_SIZE
+            weight_blocks = weight.view(m, n_blocks, NVFP4_BLOCK_SIZE)
+            block_maxes = weight_blocks.abs().amax(dim=2)
+            block_scales_fp8 = (
+                (block_maxes * global_scale / FLOAT8_E4M3_MAX)
+                .clamp(max=FLOAT8_E4M3_MAX)
+                .to(torch.float8_e4m3fn)
+            )
+
+            padded_m = round_up(m, TRTLLM_NVFP4_ROW_SIZE)
+            padded_n_blocks = round_up(n_blocks, TRTLLM_NVFP4_COLUMN_SIZE)
+            block_scales_padded = torch.zeros(
+                (padded_m, padded_n_blocks),
+                device=weight.device,
+                dtype=torch.uint8,
+            )
+            block_scales_padded[:m, :n_blocks] = block_scales_fp8.view(torch.uint8)
+
+            block_scales_swizzled = torch.ops.trtllm.block_scale_interleave(
+                block_scales_padded.cpu().contiguous()
+            ).reshape(padded_m, padded_n_blocks)
+
+            return fp4_weight, block_scales_swizzled.to(weight.device).view(torch.float8_e4m3fn)
+
         fc1_weights_n = fc1_weights.shape[1]
         sf_fc1_weights_n = round_up(fc1_weights_n, TRTLLM_NVFP4_ROW_SIZE)
         sf_fc1_weights_k = round_up(hidden_size // NVFP4_BLOCK_SIZE, TRTLLM_NVFP4_COLUMN_SIZE)
@@ -671,27 +704,18 @@ def test_trtllm_fused_moe_nvfp4(
             fc1_weights_gs[expert] = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / fc1_weights_amax
             fc2_weights_gs[expert] = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / fc2_weights_amax
 
-            # Quantize the weights to NVFP4 and ask for swizzled block scale factors because the
-            # MoE operator expects pre-swizzled block scale factors. Swizzling also flattens the
-            # block scale factors to a 1D tensor.
-            # Note that swizzling might create padded block scales
-            # because the block-scales are required to be padded to the nearest multiple of 128x4.
-            nvfp4_vals, fp8_block_scales = torch.ops.trtllm.fp4_quantize(
-                fc1_weights[expert],
-                fc1_weights_gs[expert],
-                NVFP4_BLOCK_SIZE,
-                isSfSwizzledLayout=True,
+            # fp4_quantize's swizzled scale layout targets nvfp4_gemm. The fused MoE kernel
+            # expects row-major per-block scales padded to 128x4 and then block_scale_interleave'd.
+            nvfp4_vals, fp8_block_scales = quantize_weight_for_fused_moe(
+                fc1_weights[expert], fc1_weights_gs[expert]
             )
             fc1_weights_q[expert] = nvfp4_vals
             fc1_weights_blockscale[expert] = fp8_block_scales.reshape(
                 fc1_weights_blockscale[expert].shape
             )
 
-            nvfp4_vals, fp8_block_scales = torch.ops.trtllm.fp4_quantize(
-                fc2_weights[expert],
-                fc2_weights_gs[expert],
-                NVFP4_BLOCK_SIZE,
-                isSfSwizzledLayout=True,
+            nvfp4_vals, fp8_block_scales = quantize_weight_for_fused_moe(
+                fc2_weights[expert], fc2_weights_gs[expert]
             )
             fc2_weights_q[expert] = nvfp4_vals
             fc2_weights_blockscale[expert] = fp8_block_scales.reshape(

--- a/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_trtllm_moe.py
+++ b/tests/unittest/auto_deploy/singlegpu/custom_ops/moe/test_trtllm_moe.py
@@ -574,7 +574,7 @@ FP4_TEST_SHAPES = [
 
 # Scale the input and weights to prevent large absolute values.
 FP4_X_GEN_SCALE = 0.5
-FP4_W_GEN_SCALE = 0.75
+FP4_W_GEN_SCALE = 0.075
 
 
 @pytest.mark.parametrize("batch_size", BATCH_SIZES)
@@ -639,39 +639,6 @@ def test_trtllm_fused_moe_nvfp4(
         def round_up(x, y):
             return math.ceil(x / y) * y
 
-        def quantize_weight_for_fused_moe(weight, global_scale):
-            fp4_weight, _ = torch.ops.trtllm.fp4_quantize(
-                weight,
-                global_scale,
-                NVFP4_BLOCK_SIZE,
-                isSfSwizzledLayout=False,
-            )
-
-            m, n = weight.shape
-            n_blocks = n // NVFP4_BLOCK_SIZE
-            weight_blocks = weight.view(m, n_blocks, NVFP4_BLOCK_SIZE)
-            block_maxes = weight_blocks.abs().amax(dim=2)
-            block_scales_fp8 = (
-                (block_maxes * global_scale / FLOAT8_E4M3_MAX)
-                .clamp(max=FLOAT8_E4M3_MAX)
-                .to(torch.float8_e4m3fn)
-            )
-
-            padded_m = round_up(m, TRTLLM_NVFP4_ROW_SIZE)
-            padded_n_blocks = round_up(n_blocks, TRTLLM_NVFP4_COLUMN_SIZE)
-            block_scales_padded = torch.zeros(
-                (padded_m, padded_n_blocks),
-                device=weight.device,
-                dtype=torch.uint8,
-            )
-            block_scales_padded[:m, :n_blocks] = block_scales_fp8.view(torch.uint8)
-
-            block_scales_swizzled = torch.ops.trtllm.block_scale_interleave(
-                block_scales_padded.cpu().contiguous()
-            ).reshape(padded_m, padded_n_blocks)
-
-            return fp4_weight, block_scales_swizzled.to(weight.device).view(torch.float8_e4m3fn)
-
         fc1_weights_n = fc1_weights.shape[1]
         sf_fc1_weights_n = round_up(fc1_weights_n, TRTLLM_NVFP4_ROW_SIZE)
         sf_fc1_weights_k = round_up(hidden_size // NVFP4_BLOCK_SIZE, TRTLLM_NVFP4_COLUMN_SIZE)
@@ -704,18 +671,27 @@ def test_trtllm_fused_moe_nvfp4(
             fc1_weights_gs[expert] = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / fc1_weights_amax
             fc2_weights_gs[expert] = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / fc2_weights_amax
 
-            # fp4_quantize's swizzled scale layout targets nvfp4_gemm. The fused MoE kernel
-            # expects row-major per-block scales padded to 128x4 and then block_scale_interleave'd.
-            nvfp4_vals, fp8_block_scales = quantize_weight_for_fused_moe(
-                fc1_weights[expert], fc1_weights_gs[expert]
+            # Quantize the weights to NVFP4 and ask for swizzled block scale factors because the
+            # MoE operator expects pre-swizzled block scale factors. Swizzling also flattens the
+            # block scale factors to a 1D tensor.
+            # Note that swizzling might create padded block scales
+            # because the block-scales are required to be padded to the nearest multiple of 128x4.
+            nvfp4_vals, fp8_block_scales = torch.ops.trtllm.fp4_quantize(
+                fc1_weights[expert],
+                fc1_weights_gs[expert],
+                NVFP4_BLOCK_SIZE,
+                isSfSwizzledLayout=True,
             )
             fc1_weights_q[expert] = nvfp4_vals
             fc1_weights_blockscale[expert] = fp8_block_scales.reshape(
                 fc1_weights_blockscale[expert].shape
             )
 
-            nvfp4_vals, fp8_block_scales = quantize_weight_for_fused_moe(
-                fc2_weights[expert], fc2_weights_gs[expert]
+            nvfp4_vals, fp8_block_scales = torch.ops.trtllm.fp4_quantize(
+                fc2_weights[expert],
+                fc2_weights_gs[expert],
+                NVFP4_BLOCK_SIZE,
+                isSfSwizzledLayout=True,
             )
             fc2_weights_q[expert] = nvfp4_vals
             fc2_weights_blockscale[expert] = fp8_block_scales.reshape(


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of NVFP4 fused MoE weight quantization for more reliable test behavior.
  - Updated test coverage so two previously waived test cases now run normally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[JIRA ticket/NVBugs ID/GitHub issue/None][type] Summary**

Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
