### PR TITLE
[https://nvbugs/6376948][fix] Reduce per-request attribute overhead in model_engine hot path

### DIFF
--- a/tensorrt_llm/_torch/pyexecutor/model_engine.py
+++ b/tensorrt_llm/_torch/pyexecutor/model_engine.py
@@ -2944,6 +2944,10 @@ class PyTorchModelEngine(ModelEngine):
                 num_accepted_tokens_device, req_id_to_old_request,
                 resource_manager)
 
+        # Hoist self.use_mrope to a function-scope local so the per-request /
+        # per-context-request mrope branches use LOAD_FAST instead of LOAD_ATTR.
+        _use_mrope = self.use_mrope
+
         # if new_tensors_device exist, input_ids will only contain new context tokens
         input_ids = []  # per sequence
         sequence_lengths = []  # per sequence
@@ -3101,7 +3105,7 @@ class PyTorchModelEngine(ModelEngine):
                                                 self.model,
                                                 "multimodal_data_device_paths",
                                                 None))
-                if self.use_mrope:
+                if _use_mrope:
                     mrope_config = multimodal_params.multimodal_data[
                         'mrope_config']
                     mrope_pos_ids = mrope_config['mrope_position_ids']
@@ -3129,7 +3133,7 @@ class PyTorchModelEngine(ModelEngine):
                 # This creates new IPC handles owned by the prefill worker, so the decode worker
                 # can access them even after the encode worker's GC deallocates the original memory.
                 # Without this, the decode worker would receive handles pointing to freed memory.
-                if (request.is_context_only_request and self.use_mrope and
+                if (request.is_context_only_request and _use_mrope and
                         "mrope_config" in multimodal_params.multimodal_data):
                     mrope_config = multimodal_params.multimodal_data[
                         "mrope_config"]
@@ -3324,6 +3328,13 @@ class PyTorchModelEngine(ModelEngine):
         # Cache invariant method result to avoid repeated calls per-request
         _has_cp_helix = self.mapping.has_cp_helix()
         _n_gen = len(generation_requests)
+        # One-shot batch-level flag — True iff any generation request actually
+        # carries multimodal payload. Lets the strip_mm_data branch below
+        # short-circuit on a LOAD_FAST rather than a per-request LOAD_ATTR
+        # of py_multimodal_data for non-multimodal models (the gpt-oss-120b
+        # GEN case).
+        _has_any_multimodal_request = any(r.py_multimodal_data is not None
+                                          for r in generation_requests)
         if _n_gen > 0:
             # All generation requests have the same beam width
             beam_width = generation_requests[0].py_beam_width
@@ -3336,9 +3347,6 @@ class PyTorchModelEngine(ModelEngine):
 
             for request in generation_requests:
                 request_ids.append(request.py_request_id)
-                # py_batch_idx is set after a request occupies a generation slot.
-                # None means this is its first generation step on this worker.
-                is_generation_admission = request.py_batch_idx is None
                 # the request has no previous tensor:
                 # (1) new_tokens_device is None, which means overlap scheduler is disabled; or
                 # (2) a dummy request; or
@@ -3391,7 +3399,7 @@ class PyTorchModelEngine(ModelEngine):
                     prompt_lengths.append(request.py_prompt_len)
                     gather_ids.append(len(position_ids) - 1)
 
-                if self.use_mrope:
+                if _use_mrope:
                     mrope_position_delta = getattr(request,
                                                    "py_mrope_position_delta",
                                                    None)
@@ -3442,7 +3450,12 @@ class PyTorchModelEngine(ModelEngine):
                                  gen_mrope_position_ids))
                             mrope_delta_read_seq_slots.append(
                                 delta_read_seq_slot)
-                if is_generation_admission and request.py_multimodal_data:
+                # Equivalent to the original `is_generation_admission and
+                # request.py_multimodal_data`. The batch-level flag is checked
+                # first so non-multimodal models pay one LOAD_FAST per request
+                # instead of LOAD_ATTR(py_multimodal_data) + LOAD_ATTR(py_batch_idx).
+                if (_has_any_multimodal_request and request.py_multimodal_data
+                        and request.py_batch_idx is None):
                     strip_mm_data_for_generation(request.py_multimodal_data)
 
                 request.py_batch_idx = request.py_seq_slot
@@ -5027,7 +5040,11 @@ class PyTorchModelEngine(ModelEngine):
         with self.cuda_graph_runner.pad_batch(
                 scheduled_requests, resource_manager,
                 self.runtime_draft_len) as padded_requests:
-            self._pad_batch_seed_mrope_delta_cache(padded_requests)
+            # Callee already no-ops when use_mrope=False, but the Python call /
+            # frame setup itself is non-trivial under high concurrency. Gating
+            # at the caller avoids that overhead for non-mrope models.
+            if self.use_mrope:
+                self._pad_batch_seed_mrope_delta_cache(padded_requests)
 
             # Refresh is_all_greedy_sample for the *current* batch BEFORE the
             # CUDA graph key is built below. The key includes this flag to pick


### PR DESCRIPTION
## Summary
- **Root cause**: The generation-batch preparation loop in `PyTorchModelEngine` performed repeated `LOAD_ATTR` lookups on `self.use_mrope` and `request.py_multimodal_data` for every request, and unconditionally invoked `_pad_batch_seed_mrope_delta_cache` even for non-mrope models. Under high concurrency on the target hardware, this per-request Python attribute access and unnecessary function-call overhead accumulated into a measurable host-side regression for the gpt-oss-120b gen-only workload, which does not use mrope or multimodal data.
- **Fix**: Hoisted `self.use_mrope` into a function-scope local (`_use_mrope`) so the per-request branches use `LOAD_FAST` instead of `LOAD_ATTR`, and introduced a batch-level `_has_any_multimodal_request` short-circuit so non-multimodal models avoid the per-request `py_multimodal_data`/`py_batch_idx` attribute loads entirely. Additionally gated the `_pad_batch_seed_mrope_delta_cache` call on `self.use_mrope` at the call site to skip the Python frame setup when mrope is disabled. These are purely host-side micro-optimizations that preserve the original semantics.
- **Perf metric**: mean_gen_worker_per_iter_device_step_time (lower-is-better)
- **Bad perf**: 8.691
- **Good perf**: 8.384
- **Perf after fix**: 7.869
- Automated fix generated by repair-bot

## Test plan
- [x] Verify fix on the same GPU type as the original failure
- [x] Check for regressions in related tests

## Links
- Bug: https://nvbugs/6376948


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request preparation for generation to handle multimodal inputs more consistently.
  * Refined MRoPE-related handling during batching and graph padding to avoid unnecessary processing.
  * Reduced overhead in input preparation, which may help improve throughput and stability in affected workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->