### PR TITLE
[TRTLLM-14029][feat] LTX-2 tile-parallel VAE decode

### DIFF
--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/ltx2_core/utils_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/ltx2_core/utils_ltx2.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import torch
 
+from tensorrt_llm._torch.modules.linear import NVFP4LinearMethod
 from tensorrt_llm._torch.utils import Fp4QuantizedTensor
 
 # NVFP4 fused-quant AdaLN: every fused AdaLN CUDA kernel below has a ``_quant``
@@ -22,6 +23,8 @@ def get_nvfp4_input_scale(linear) -> Optional[torch.Tensor]:
     Used by call sites to dispatch the fused-quant variant of the AdaLN wrappers
     when the downstream Linear can consume a pre-quantized Fp4QuantizedTensor.
     """
+    if not isinstance(getattr(linear, "quant_method", None), NVFP4LinearMethod):
+        return None
     input_scale = getattr(linear, "input_scale", None)
     if input_scale is None:
         return None

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/ltx2_core/video_vae/tiling.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/ltx2_core/video_vae/tiling.py
@@ -147,20 +147,19 @@ class Tile(NamedTuple):
     out_coords: Tuple[slice, ...]
     masks_1d: Tuple[Tuple[torch.Tensor, ...]]
 
-    @property
-    def blend_mask(self) -> torch.Tensor:
+    def blend_mask(self, device, dtype) -> torch.Tensor:
         num_dims = len(self.out_coords)
         per_dimension_masks: List[torch.Tensor] = []
         for dim_idx in range(num_dims):
             mask_1d = self.masks_1d[dim_idx]
             view_shape = [1] * num_dims
             if mask_1d is None:
-                one = torch.ones(1)
-                view_shape[dim_idx] = 1
-                per_dimension_masks.append(one.view(*view_shape))
+                per_dimension_masks.append(
+                    torch.ones(1, device=device, dtype=dtype).view(*view_shape)
+                )
                 continue
             view_shape[dim_idx] = mask_1d.shape[0]
-            per_dimension_masks.append(mask_1d.view(*view_shape))
+            per_dimension_masks.append(mask_1d.to(device=device, dtype=dtype).view(*view_shape))
         combined_mask = per_dimension_masks[0]
         for mask in per_dimension_masks[1:]:
             combined_mask = combined_mask * mask

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/ltx2_core/video_vae/video_vae.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/ltx2_core/video_vae/video_vae.py
@@ -589,7 +589,7 @@ class VideoDecoder(nn.Module):
         weights = torch.zeros_like(buffer)
         for tile in group_tiles:
             decoded_tile = self.forward(latent[tile.in_coords], timestep, generator)
-            mask = tile.blend_mask.to(device=buffer.device, dtype=buffer.dtype)
+            mask = tile.blend_mask(buffer.device, buffer.dtype)
             temporal_offset = tile.out_coords[2].start - temporal_slice.start
             expected_temporal_len = tile.out_coords[2].stop - tile.out_coords[2].start
             decoded_temporal_len = decoded_tile.shape[2]

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/parallel_vae.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/parallel_vae.py
@@ -23,6 +23,8 @@ from typing import TYPE_CHECKING, Optional
 import torch
 import torch.distributed as dist
 
+from tensorrt_llm.logger import logger
+
 from .ltx2_core.types import VideoLatentShape
 
 if TYPE_CHECKING:
@@ -35,6 +37,9 @@ def _tile_in_volume(tile) -> int:
     return (c[2].stop - c[2].start) * (c[3].stop - c[3].start) * (c[4].stop - c[4].start)
 
 
+_ZERO_TILE_WARNED = False
+
+
 def assign_tiles_lpt(tiles: list, world: int, rank: int) -> list:
     """LPT (longest-processing-time) greedy assignment by input volume.
 
@@ -44,13 +49,28 @@ def assign_tiles_lpt(tiles: list, world: int, rank: int) -> list:
     (no tile decoded twice or skipped). Balances by work (volume), not tile
     count, since boundary tiles are smaller than interior ones.
     """
+    global _ZERO_TILE_WARNED
     load = [0] * world
+    count = [0] * world
     mine = []
     for t in sorted(tiles, key=lambda t: -_tile_in_volume(t)):
         r = min(range(world), key=lambda i: load[i])
         load[r] += _tile_in_volume(t)
+        count[r] += 1
         if r == rank:
             mine.append(t)
+    if rank == 0:
+        if world > len(tiles) and not _ZERO_TILE_WARNED:
+            idle = sum(1 for c in count if c == 0)
+            logger.warning(
+                f"tile_parallel_decode: {idle} of {world} vae_ranks got 0 tiles "
+                f"({len(tiles)} tiles < {world} ranks); consider parallel_vae_size <= {len(tiles)}."
+            )
+            _ZERO_TILE_WARNED = True
+        logger.debug(
+            f"tile_parallel_decode load: tiles/rank={count}, volume/rank={load}, "
+            f"imbalance(max/min)={max(load) / max(min(load), 1):.2f}"
+        )
     return mine
 
 

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/parallel_vae.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/parallel_vae.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025–2026 Lightricks Ltd.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: LicenseRef-LTX-2
+
+"""Tile-parallel VAE decode for LTX-2.
+
+``VideoDecoder.tiled_decode`` decodes a latent as ~27 overlapping tiles, each an
+independent forward, then blends overlaps by a weighted sum
+(``out = Σ_tiles decode·mask / Σ_tiles mask``). The tiles are embarrassingly
+parallel; only the final blend couples them. ``tile_parallel_decode`` distributes
+the tiles across the VAE process group (LPT by volume), accumulates each rank's
+subset into a full-size buffer, then ``all_reduce`` the numerator + denominator so
+every rank ends up with the full decoded video — numerically equal to single-GPU
+``tiled_decode`` up to bf16 summation re-association (overlap regions only).
+
+The decode is deterministic for the production LTX-2 VAE (``timestep_conditioning``
+and per-block ``inject_noise`` are both False in the checkpoint), so the threaded
+``generator`` is never consumed and per-rank tile subsets cannot diverge.
+"""
+
+from typing import TYPE_CHECKING, Optional
+
+import torch
+import torch.distributed as dist
+
+from .ltx2_core.types import VideoLatentShape
+
+if TYPE_CHECKING:
+    from .ltx2_core.video_vae.video_vae import TilingConfig, VideoDecoder
+
+
+def _tile_in_volume(tile) -> int:
+    """Input-latent voxel count (T×H×W) — proxy for this tile's decode cost."""
+    c = tile.in_coords
+    return (c[2].stop - c[2].start) * (c[3].stop - c[3].start) * (c[4].stop - c[4].start)
+
+
+def assign_tiles_lpt(tiles: list, world: int, rank: int) -> list:
+    """LPT (longest-processing-time) greedy assignment by input volume.
+
+    Deterministic and identical on every rank (same sorted order, same
+    least-loaded tie-break), so each tile is owned by exactly one rank with no
+    cross-rank coordination — a hard requirement for the blend sum to be correct
+    (no tile decoded twice or skipped). Balances by work (volume), not tile
+    count, since boundary tiles are smaller than interior ones.
+    """
+    load = [0] * world
+    mine = []
+    for t in sorted(tiles, key=lambda t: -_tile_in_volume(t)):
+        r = min(range(world), key=lambda i: load[i])
+        load[r] += _tile_in_volume(t)
+        if r == rank:
+            mine.append(t)
+    return mine
+
+
+def tile_parallel_decode(
+    video_decoder: "VideoDecoder",
+    latent: torch.Tensor,
+    tiling_config: "TilingConfig",
+    pg: "dist.ProcessGroup",
+    timestep: Optional[torch.Tensor] = None,
+    generator: Optional[torch.Generator] = None,
+) -> torch.Tensor:
+    """Distributed equivalent of ``video_decoder.tiled_decode`` over group ``pg``.
+
+    Every rank in ``pg`` must hold the full ``latent`` (replicated) and call this
+    collectively. Returns the full decoded video on every rank.
+    """
+    if pg is None:
+        raise ValueError(
+            "tile_parallel_decode requires a valid VAE process group, got pg=None "
+            "(a None group would fall back to the world group and hang on non-VAE ranks)."
+        )
+    rank = dist.get_rank(pg)
+    world = dist.get_world_size(pg)
+
+    tiles = video_decoder._prepare_tiles(latent, tiling_config)
+    mine = assign_tiles_lpt(tiles, world, rank)
+
+    out_shape = (
+        VideoLatentShape.from_torch_shape(latent.shape)
+        .upscale(video_decoder.video_downscale_factors)
+        .to_torch_shape()
+    )
+    buf = torch.zeros(out_shape, device=latent.device, dtype=latent.dtype)
+    wts = torch.zeros(out_shape, device=latent.device, dtype=latent.dtype)
+
+    for tile in mine:
+        decoded = video_decoder.forward(latent[tile.in_coords], timestep, generator)
+        mask = tile.blend_mask(latent.device, latent.dtype)
+        oc = tile.out_coords
+        tlen = min(oc[2].stop - oc[2].start, decoded.shape[2], buf.shape[2] - oc[2].start)
+        mask_slice = mask[:, :, :tlen, :, :] if mask.shape[2] > 1 else mask
+        out_t = slice(oc[2].start, oc[2].start + tlen)
+        buf[:, :, out_t, oc[3], oc[4]] += decoded[:, :, :tlen, :, :] * mask_slice
+        wts[:, :, out_t, oc[3], oc[4]] += mask_slice
+
+    dist.all_reduce(buf, group=pg)
+    dist.all_reduce(wts, group=pg)
+    wts.clamp_(min=1e-8)
+    buf.div_(wts)
+    return buf

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2.py
@@ -44,6 +44,7 @@ from .ltx2_core.types import (
     VideoPixelShape,
 )
 from .ltx2_core.video_vae import TilingConfig, VideoDecoderConfigurator, VideoEncoderConfigurator
+from .parallel_vae import tile_parallel_decode
 from .transformer_ltx2 import LTXModel, LTXModelType
 
 LTX2_FORCE_ONE_STAGE_ENV = "TLLM_LTX2_FORCE_ONE_STAGE_PIPELINE"
@@ -1051,6 +1052,31 @@ class LTX2Pipeline(BasePipeline):
 
         logger.info("LTX2 pipeline post-load complete")
 
+    def setup_parallel_vae(self) -> None:
+        """Enable tile-parallel VAE decode for LTX-2.
+
+        LTX-2 decodes via ``self.video_decoder`` (not ``self.vae``), so the base
+        ``setup_parallel_vae`` — which gates on ``self.vae`` + the halo-shaped
+        ``ParallelVAEFactory`` — never engages. Set the global
+        ``_parallel_vae_enabled`` flag directly from config + mapping so
+        ``decode_latents`` routes the decode to ``vae_ranks``; the tile-shard +
+        ``all_reduce`` happens in ``decode_video_fn`` via ``tile_parallel_decode``.
+        The flag is global (computed identically on every rank).
+        """
+        parallel_cfg = self.pipeline_config.parallel
+        vgm = self.pipeline_config.visual_gen_mapping
+        self._parallel_vae_enabled = (
+            parallel_cfg.parallel_vae_size > 1
+            and dist.is_initialized()
+            and dist.get_world_size() > 1
+            and vgm is not None
+        )
+        if self._parallel_vae_enabled and self.rank == 0:
+            logger.info(
+                f"LTX-2 tile-parallel VAE enabled: vae_ranks={vgm.vae_ranks}, "
+                f"parallel_vae_size={parallel_cfg.parallel_vae_size}"
+            )
+
     # ------------------------------------------------------------------
     # Text encoding
     # ------------------------------------------------------------------
@@ -1996,14 +2022,28 @@ class LTX2Pipeline(BasePipeline):
 
             vid_latents = vid_latents.to(self.dtype)
             tiling_config = TilingConfig.default()
-            chunks = list(
-                self.video_decoder.tiled_decode(
+            if self._parallel_vae_enabled:
+                # Tile-parallel: shard tiled_decode's tiles across vae_ranks and
+                # all_reduce the blend buffer. Output matches serial tiled_decode
+                # up to bf16 re-association. decode_latents calls this only on
+                # vae_ranks, so the all_reduce over vgm.vae_group is collective.
+                vgm = self.pipeline_config.visual_gen_mapping
+                video = tile_parallel_decode(
+                    self.video_decoder,
                     vid_latents,
                     tiling_config,
+                    pg=vgm.vae_group,
                     generator=generator,
                 )
-            )
-            video = torch.cat(chunks, dim=2)
+            else:
+                chunks = list(
+                    self.video_decoder.tiled_decode(
+                        vid_latents,
+                        tiling_config,
+                        generator=generator,
+                    )
+                )
+                video = torch.cat(chunks, dim=2)
             video = postprocess_video_tensor(video)
             return video
 

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/pipeline_ltx2_two_stages.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 
 import safetensors.torch
 import torch
+import torch.distributed as dist
 
 from tensorrt_llm._torch.modules.linear import Linear, UnquantizedLinearMethod
 from tensorrt_llm._torch.visual_gen.cuda_graph_runner import CUDAGraphRunnerConfig
@@ -37,6 +38,7 @@ from .ltx2_core.types import (
 )
 from .ltx2_core.upsampler import LatentUpsamplerConfigurator, upsample_video
 from .ltx2_core.video_vae import TilingConfig
+from .parallel_vae import tile_parallel_decode
 from .pipeline_ltx2 import (
     LTX2Pipeline,
     _assert_resolution,
@@ -1173,8 +1175,123 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
             return timer.fill(PipelineOutput(video=None, audio=None, frame_rate=float(frame_rate)))
 
         # ================================================================
-        # Spatial upsample: 2x via learned upsampler
+        # Stage 2: spatial upsample + refinement denoise (rank-0 only)
         # ================================================================
+        # Only rank 0 refines; other vae_ranks skip Stage 2 and rejoin at the
+        # collective decode below, receiving the refined latents via broadcast.
+        if self.rank == 0:
+            video_latents, audio_latents = self._upsample_and_refine(
+                video_latents=video_latents,
+                audio_latents=audio_latents,
+                prompt=prompt,
+                height=height,
+                width=width,
+                num_frames=num_frames,
+                frame_rate=frame_rate,
+                seed=seed,
+                max_sequence_length=max_sequence_length,
+                image=image,
+                image_cond_strength=image_cond_strength,
+            )
+        else:
+            video_latents, audio_latents = None, None
+
+        # ================================================================
+        # Decode
+        # ================================================================
+        if output_type == "latent":
+            # No decode: only rank 0 holds the refined latents.
+            video_out, audio_out = (
+                (video_latents, audio_latents) if self.rank == 0 else (None, None)
+            )
+            if self.rank == 0:
+                logger.info(f"Two-stage total time: {time.time() - pipeline_start:.2f}s")
+            timer.mark_end()
+            return timer.fill(
+                PipelineOutput(
+                    video=video_out,
+                    audio=audio_out,
+                    frame_rate=float(frame_rate),
+                    audio_sample_rate=(
+                        int(self.audio_sampling_rate)
+                        if getattr(self, "audio_sampling_rate", None) is not None
+                        and audio_out is not None
+                        else None
+                    ),
+                )
+            )
+
+        if self._parallel_vae_enabled:
+            # Broadcast rank-0's refined Stage-2 latents to every vae_rank, then
+            # decode collectively (tile-parallel over vgm.vae_group).
+            vgm = self.pipeline_config.visual_gen_mapping
+            video_latents = self._broadcast_video_latents(video_latents, vgm.vae_group)
+            logger.info("Decoding upsampled video (tile-parallel)...")
+            video = tile_parallel_decode(
+                self.video_decoder,
+                video_latents,
+                TilingConfig.default(),
+                pg=vgm.vae_group,
+            )
+            video = postprocess_video_tensor(video)
+        else:
+            logger.info("Decoding upsampled video (tiled)...")
+            video_latents = video_latents.to(self.dtype)
+            chunks = list(
+                self.video_decoder.tiled_decode(
+                    video_latents,
+                    TilingConfig.default(),
+                    generator=None,
+                )
+            )
+            video = torch.cat(chunks, dim=2)
+            video = postprocess_video_tensor(video)
+
+        # Audio decode is rank-0 only (not tile-parallel).
+        audio_out = None
+        if self.rank == 0 and audio_latents is not None:
+            audio_latents = audio_latents.to(self.dtype)
+            audio_out = decode_audio(audio_latents, self.audio_decoder, self.vocoder)
+
+        if self.rank == 0:
+            logger.info(f"Two-stage total time: {time.time() - pipeline_start:.2f}s")
+        timer.mark_end()
+        return timer.fill(
+            PipelineOutput(
+                video=video,
+                audio=audio_out,
+                frame_rate=float(frame_rate),
+                audio_sample_rate=(
+                    int(self.audio_sampling_rate)
+                    if getattr(self, "audio_sampling_rate", None) is not None
+                    and audio_out is not None
+                    else None
+                ),
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _upsample_and_refine(
+        self,
+        video_latents: torch.Tensor,
+        audio_latents: Optional[torch.Tensor],
+        prompt: Union[str, List[str]],
+        height: int,
+        width: int,
+        num_frames: int,
+        frame_rate: float,
+        seed: int,
+        max_sequence_length: int,
+        image: Optional[Union[str, torch.Tensor]] = None,
+        image_cond_strength: float = 1.0,
+    ) -> tuple:
+        """Stage 2 (rank-0 only): learned 2x spatial upsample + refinement denoise.
+
+        Returns the refined ``(video_latents, audio_latents)`` in 5-D form.
+        """
         per_ch_stats = self._get_per_channel_statistics()
         video_latents = upsample_video(
             video_latents[:1],
@@ -1183,9 +1300,6 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
         )
         logger.info("Upsampled video latents via learned upsampler")
 
-        # ================================================================
-        # Stage 2: refinement denoising with distilled LoRA
-        # ================================================================
         # The persistent cache owns original and merged tensors when it can be
         # built at load time. Stage 2 only rebinds pointers and FP4 quant_method
         # state, so no per-request clone, merge, or unmerge math is needed.
@@ -1274,65 +1388,34 @@ class LTX2TwoStagesPipeline(LTX2Pipeline):
             else:
                 self._lora_cuda_graph_state = "original"
 
-        # ================================================================
-        # Decode
-        # ================================================================
-        if output_type == "latent":
-            if self.rank == 0:
-                logger.info(f"Two-stage total time: {time.time() - pipeline_start:.2f}s")
-            timer.mark_end()
-            return timer.fill(
-                PipelineOutput(
-                    video=video_latents,
-                    audio=audio_latents,
-                    frame_rate=float(frame_rate),
-                    audio_sample_rate=(
-                        int(self.audio_sampling_rate)
-                        if getattr(self, "audio_sampling_rate", None) is not None
-                        and audio_latents is not None
-                        else None
-                    ),
-                )
+        return video_latents, audio_latents
+
+    def _broadcast_video_latents(
+        self, video_latents: Optional[torch.Tensor], vae_group
+    ) -> torch.Tensor:
+        """Broadcast rank-0's refined Stage-2 latents to every ``vae_rank``.
+
+        ``tile_parallel_decode`` needs the full latent replicated on each rank of
+        ``vae_group``; only rank 0 ran Stage 2, so it is the broadcast source.
+        Video latents are 5-D ``(B, C, F, H, W)``.
+        """
+        if vae_group is None:
+            raise ValueError(
+                "parallel VAE decode requires a valid vae_group, got None "
+                "(a None group would fall back to the world group and hang on non-VAE ranks)."
             )
-
-        logger.info("Decoding upsampled video (tiled)...")
-        video_latents = video_latents.to(self.dtype)
-        tiling_config = TilingConfig.default()
-        chunks = list(
-            self.video_decoder.tiled_decode(
-                video_latents,
-                tiling_config,
-                generator=None,
-            )
-        )
-        video = torch.cat(chunks, dim=2)
-        video = postprocess_video_tensor(video)
-
-        audio_out = None
-        if audio_latents is not None:
-            audio_latents = audio_latents.to(self.dtype)
-            audio_out = decode_audio(audio_latents, self.audio_decoder, self.vocoder)
-
         if self.rank == 0:
-            logger.info(f"Two-stage total time: {time.time() - pipeline_start:.2f}s")
-        timer.mark_end()
-        return timer.fill(
-            PipelineOutput(
-                video=video,
-                audio=audio_out,
-                frame_rate=float(frame_rate),
-                audio_sample_rate=(
-                    int(self.audio_sampling_rate)
-                    if getattr(self, "audio_sampling_rate", None) is not None
-                    and audio_out is not None
-                    else None
-                ),
+            video_latents = video_latents.to(self.dtype).contiguous()
+            shape = torch.tensor(video_latents.shape, dtype=torch.long, device=self.device)
+        else:
+            shape = torch.empty(5, dtype=torch.long, device=self.device)
+        dist.broadcast(shape, src=0, group=vae_group)
+        if self.rank != 0:
+            video_latents = torch.empty(
+                torch.Size(shape.tolist()), dtype=self.dtype, device=self.device
             )
-        )
-
-    # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
+        dist.broadcast(video_latents, src=0, group=vae_group)
+        return video_latents
 
     def _get_per_channel_statistics(self) -> torch.nn.Module:
         """Return per-channel statistics for un-normalize/normalize.

--- a/tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_parallel_vae.py
+++ b/tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_parallel_vae.py
@@ -1,0 +1,182 @@
+"""Multi-GPU tests for LTX-2 tile-parallel VAE decode.
+
+Validates that ``tile_parallel_decode`` (tiles distributed across VAE ranks +
+all_reduce of the blend buffer) is numerically equivalent to single-GPU serial
+``VideoDecoder.tiled_decode``. Equivalence is up to bf16 summation re-association
+in the tile-overlap regions (a few ulp), so the check is ``allclose``, not
+``torch.equal``.
+
+Uses a small randomly-initialised VideoDecoder (no pretrained weights). The
+decoder is bf16 and decode is deterministic (``timestep_conditioning`` and
+per-block ``inject_noise`` are False), so the threaded ``generator`` is unused.
+
+Run with:
+    pytest tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_parallel_vae.py -v
+"""
+
+import os
+
+os.environ["TLLM_DISABLE_MPI"] = "1"
+
+import sys
+from pathlib import Path
+from typing import Callable
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from tensorrt_llm._torch.visual_gen.models.ltx2.ltx2_core.video_vae import TilingConfig
+from tensorrt_llm._torch.visual_gen.models.ltx2.ltx2_core.video_vae.model_configurator import (
+    VideoDecoderConfigurator,
+)
+from tensorrt_llm._torch.visual_gen.models.ltx2.parallel_vae import tile_parallel_decode
+
+# Spawn distributed workers via a helper that retries with a fresh master
+# port when the c10d rendezvous TCPStore loses the bind race (EADDRINUSE).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _visual_gen_dist_utils import spawn_with_retry  # noqa: E402
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _cleanup_mpi_env():
+    yield
+    os.environ.pop("TLLM_DISABLE_MPI", None)
+
+
+# ---------------------------------------------------------------------------
+# Distributed helpers
+# ---------------------------------------------------------------------------
+def _init_worker(rank: int, world_size: int, port: int):
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    torch.cuda.set_device(rank % torch.cuda.device_count())
+    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+
+
+def _cleanup():
+    if dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def _distributed_worker(rank, world_size, test_fn, port):
+    try:
+        _init_worker(rank, world_size, port)
+        test_fn(rank, world_size)
+    except Exception as e:
+        print(f"Rank {rank} failed: {e}")
+        raise
+    finally:
+        _cleanup()
+
+
+def _run(world_size: int, test_fn: Callable):
+    if torch.cuda.device_count() < world_size:
+        pytest.skip(f"Need {world_size} GPUs, have {torch.cuda.device_count()}")
+    spawn_with_retry(
+        lambda port: mp.spawn(
+            _distributed_worker, args=(world_size, test_fn, port), nprocs=world_size, join=True
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model + data helpers
+# ---------------------------------------------------------------------------
+# Small VideoDecoder: keep patch_size=4 + three compress_all(x2) so the fixed
+# 8x temporal / 32x spatial upscale holds, but shrink latent_channels and
+# res-block depth so the model + decode stay light. feature_channels derive
+# from latent_channels (x8 here -> 256).
+_SMALL_VAE_CONFIG = {
+    "vae": {
+        "dims": 3,
+        "latent_channels": 32,
+        "out_channels": 3,
+        "patch_size": 4,
+        "norm_layer": "pixel_norm",
+        "causal_decoder": False,
+        "timestep_conditioning": False,
+        "decoder_blocks": [
+            ["res_x", {"num_layers": 1, "inject_noise": False}],
+            ["compress_all", {"residual": True, "multiplier": 2}],
+            ["res_x", {"num_layers": 1, "inject_noise": False}],
+            ["compress_all", {"residual": True, "multiplier": 2}],
+            ["res_x", {"num_layers": 1, "inject_noise": False}],
+            ["compress_all", {"residual": True, "multiplier": 2}],
+            ["res_x", {"num_layers": 1, "inject_noise": False}],
+        ],
+    }
+}
+# Latent sized so TilingConfig.default() splits into multiple tiles along both
+# spatial (2x2) and temporal (3 groups) axes -> exercises overlap blend + the
+# cross-temporal-group stitch that tile_parallel_decode must reproduce.
+_LATENT_SHAPE = (1, 32, 16, 18, 18)
+
+
+def _create_small_video_decoder(device):
+    dec = (
+        VideoDecoderConfigurator.from_config(_SMALL_VAE_CONFIG)
+        .to(device=device, dtype=torch.bfloat16)
+        .eval()
+    )
+    # Config-initialised per-channel stats are uncalibrated; bypass un_normalize
+    # so the (otherwise NaN) decode is well-defined. It is a per-element op applied
+    # identically in serial and parallel, so it does not affect the parity check.
+    dec.per_channel_statistics.un_normalize = lambda x, *a, **k: x
+    return dec
+
+
+def _broadcast_params(module):
+    for p in module.parameters():
+        dist.broadcast(p.data, src=0)
+    for b in module.buffers():
+        dist.broadcast(b.data, src=0)
+
+
+# ===========================================================================
+# Test-logic functions
+# ===========================================================================
+def _logic_tile_parallel_decode_parity(rank, world_size):
+    """tile_parallel_decode matches single-GPU serial tiled_decode (within bf16 ulp)."""
+    device = f"cuda:{rank}"
+
+    torch.manual_seed(0)
+    dec = _create_small_video_decoder(device)
+    _broadcast_params(dec)  # ensure every rank shares identical weights
+
+    latent = torch.randn(*_LATENT_SHAPE, device=device, dtype=torch.bfloat16)
+    dist.broadcast(latent, src=0)
+
+    cfg = TilingConfig.default()
+    pg = dist.new_group(list(range(world_size)), use_local_synchronization=False)
+
+    with torch.no_grad():
+        # serial reference (deterministic -> identical on every rank)
+        ref = torch.cat(list(dec.tiled_decode(latent, cfg)), dim=2)
+        # distributed tile-parallel decode
+        par = tile_parallel_decode(dec, latent, cfg, pg)
+
+    assert par.shape == ref.shape, f"Rank {rank}: shape {tuple(par.shape)} != {tuple(ref.shape)}"
+    diff = (par.float() - ref.float()).abs()
+    max_abs = diff.max().item()
+    scale = ref.float().abs().max().item()
+    rel = max_abs / max(scale, 1e-6)
+    # bf16 re-association in the overlap regions -> a few ulp (~2^-7 relative).
+    assert rel < 0.02, (
+        f"Rank {rank}: tile-parallel parity rel={rel:.4f} (max_abs={max_abs:.4e}, scale={scale:.4e})"
+    )
+
+
+# ===========================================================================
+# Pytest test classes
+# ===========================================================================
+class TestLTX2ParallelVAEDecode:
+    def test_tile_parallel_decode_parity_2gpu(self):
+        _run(2, _logic_tile_parallel_decode_parity)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description

Tile-parallel VAE decode for LTX-2. The VAE decode (`VideoDecoder.tiled_decode`) is a large, embarrassingly-parallel pass over ~27 overlapping spatial/temporal tiles that, served serially, dominates the non-transformer wall time at high resolution. This PR distributes those tiles across the VAE ranks and reassembles the result, so decode latency scales with the number of VAE ranks while per-rank peak memory stays flat.

## Approach

- `tile_parallel_decode` (new `parallel_vae.py`): assign `tiled_decode`'s tiles across `vae_ranks` by **LPT on input volume** (deterministic, identical partition on every rank), decode each assigned tile, blend it into a full-size output buffer, then `all_reduce` the buffer + the overlap-weight buffer over `vae_group` and divide. Output matches serial `tiled_decode` up to bf16 summation re-association in the tile-overlap regions (a few ulp).
- `setup_parallel_vae` (override in `pipeline_ltx2.py`): LTX-2 decodes via `self.video_decoder` (not `self.vae`), so the base factory never engages — set the global `_parallel_vae_enabled` flag directly from config + mapping. `decode_video_fn` then routes to `tile_parallel_decode` on `vae_ranks`, else the original serial `tiled_decode`.
- `Tile.blend_mask` assembles the per-tile blend mask **on-device** from its 1-D components, used by both the serial and tile-parallel paths. Assembling the full tile-sized mask on the CPU and copying it to the GPU per tile makes the decode loop host-bound: in a busy multi-process pipeline that host work does not overlap the GPU forward and leaves the GPU ~50% idle. On-device assembly keeps the decode GPU-bound (see E2E below).
- Per-rank peak memory is flat: each rank decodes one tile at a time (same as serial), so the tiling memory benefit is preserved; the only extra is the (shared-size) output buffer.

## Performance (B200)

### VAE module bench (real VAE size, bf16 `VideoDecoder`)

`tile_parallel_decode` vs serial `tiled_decode`, latent → `(1, 3, 121, 768, 1280)` (27 tiles), both on the shipped on-device blend mask:

| VAE ranks | serial (OFF) | tile-parallel (ON) | speedup | peak mem / rank |
|---|---|---|---|---|
| 1 | 874 ms | 872 ms | 1.00× | 4.0 GB |
| 2 | 874 ms | 449 ms | 1.95× | 4.0 GB |
| 4 | 874 ms | 231 ms | 3.79× | 4.0 GB |
| 8 | 873 ms | 129 ms | **6.74×** | 4.0 GB |

Per-rank peak memory is **constant ~4.0 GB** across world sizes (no memory blow-up from parallelism).

### End-to-end (FA4 backend, 8-GPU cfg=2×uly=4, 768×1280×121, 40-step, guidance=4.0, CUDA-graph + torch.compile)

Tile-parallel VAE (pvs=8) vs serial VAE (pvs=1), same seed:

| Stage | serial VAE (pvs=1) | tile-parallel VAE (pvs=8) | Δ |
|---|---|---|---|
| Denoise (40 steps) | 4.38 s | 4.40 s | identical (VAE-orthogonal) |
| E2E wall (text-encode + denoise + decode) | 7.71 s | **6.91 s** | **−10% (−0.80 s, 1.12×)** |

The clean, same-basis decode comparison is the module bench above (serial 873 ms → tile-parallel 129 ms, **6.74×**). In the FA4 pipeline the parallel VAE decode is **0.14 s** (GPU-timed via CUDA events), matching that module-bench floor; that decode saving is what surfaces as the **~10% (0.80 s) E2E wall reduction**, with the percentage diluted by the fixed, VAE-orthogonal remainder (text-encode + the 4.4 s denoise + result IPC) that this change does not touch. Denoise is unchanged, confirming the change is VAE-only. The on-device blend mask is what lets the in-pipeline decode reach the module-bench floor — with the mask built on the CPU the decode is ~0.25 s here (GPU ~50% idle waiting on the host mask).

## Numerical accuracy

`tile_parallel_decode` is numerically equivalent to serial `tiled_decode`: identical tiles and blend masks, so the only difference is **bf16 summation re-association** in the tile-overlap regions — per-rank partial sums combined by `all_reduce` vs sequential accumulation on one GPU. Direct parity on the **real VAE, world=8, full 768×1280×121 output** (same latent, `tile_parallel_decode` vs single-GPU `tiled_decode`):

| max-abs | mean-abs | rel-max | cosine |
|---|---|---|---|
| 0.0156 (= 1 bf16 ULP) | 6.2e-5 | 0.6% | 0.99999928 |

So parallelizing the decode adds **no algorithmic error — only floating-point re-association at the bf16 ULP level**. The multi-GPU parity unit test (below) asserts rel max-abs < 0.02 and passes.

Perceptually this is invisible. On a deterministic attention backend (same seed → identical denoise, so only the VAE decode differs), parallel (pvs=8) vs serial (pvs=1) decoded video is **mean LPIPS 0.017** — at/below the run-to-run noise floor (**0.021** for two separate serial runs), i.e. indistinguishable (left = serial, right = tile-parallel; per-frame LPIPS baked in):

![parallel-vs-serial VAE, deterministic backend](https://raw.githubusercontent.com/luyiyun1021/TensorRT-LLM/lpips-assets/ltx2-vae-vanilla-lpips.png)

## Tests

`tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_parallel_vae.py` — multi-GPU (world=2) parity: a small bf16 `VideoDecoder` (random weights, broadcast so every rank is identical), `tile_parallel_decode` vs single-GPU serial `tiled_decode`, asserting relative max-abs diff `< 0.02` (bf16 ulp from overlap-region re-association). Passes on B200 (2-GPU).

## PR Checklist

- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md).
- Test cases are provided for new code paths.
- Any new dependencies have been scanned for license and vulnerabilities.
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes.
- Documentation updated as needed.
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if significant design change.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
