### PR TITLE
[None][perf] overlap LTX-2 v2a cross-attn comm with compute via async-Ulysses

### DIFF
--- a/cpp/tensorrt_llm/kernels/ulyssesPostUnscatterKernel.cu
+++ b/cpp/tensorrt_llm/kernels/ulyssesPostUnscatterKernel.cu
@@ -16,6 +16,7 @@
 
 #include "tensorrt_llm/common/cudaUtils.h"
 #include "ulyssesPostUnscatterKernel.h"
+#include <algorithm>
 #include <cuda_bf16.h>
 #include <cuda_runtime.h>
 
@@ -27,47 +28,61 @@ namespace kernels
 namespace
 {
 
-// Each block handles one (p, b, sp) tile across all H heads.
-// Reads H*D bf16 contiguous from input; writes the same bytes scattered across
-// H rows of the output in NHD layout [B, P*Sp, H, D]. The caller (op wrapper)
-// returns this storage as a transpose-view when an HND-shape output is needed,
-// so the resulting tensor is HND-shape with NHD-stride (matching what the
-// sync `_forward_unfused` path produces via `q.transpose(1, 2)`).
-//
-// threads/block = H * (D / 8); each thread copies one uint4 (8 bf16).
+// Each block copies one (p, b, psp) tile of ONE tensor (H*D bf16) into NHD storage
+// [B, P*Sp, H, D]. Q/K/V may differ in (Sp, H) (cross-attn: Q=audio vs K/V=video): grid.x
+// is packed over all three tensors' tiles (P*Sp_q + P*Sp_k + P*Sp_v) and each block maps
+// blockIdx.x to its tensor, so no block is idle even when shapes differ. Block is sized to
+// max(H)*(D/8); threads with h >= H idle only when H differs (GQA).
 template <typename T>
 __global__ void ulyssesPostUnscatterKernel(T const* __restrict__ q_in, T const* __restrict__ k_in,
     T const* __restrict__ v_in, T* __restrict__ q_out, T* __restrict__ k_out, T* __restrict__ v_out, int const P,
-    int const B, int const Sp, int const H, int const D, int const vec_per_row)
+    int const B, int const D, int const vec_per_row, int const Sp_q, int const H_q, int const Sp_k, int const H_k,
+    int const Sp_v, int const H_v)
 {
     constexpr int VEC = 8;
 
+    // blockIdx.x packed over Q|K|V tiles: [0, P*Sp_q) -> Q, next P*Sp_k -> K, rest -> V.
+    int const nq = P * Sp_q;
+    int const nk = P * Sp_k;
+    int const bx = blockIdx.x;
+
+    T const* in_ptr;
+    T* out_ptr;
+    int Sp, H, psp;
+    if (bx < nq)
+    {
+        in_ptr = q_in;
+        out_ptr = q_out;
+        Sp = Sp_q;
+        H = H_q;
+        psp = bx;
+    }
+    else if (bx < nq + nk)
+    {
+        in_ptr = k_in;
+        out_ptr = k_out;
+        Sp = Sp_k;
+        H = H_k;
+        psp = bx - nq;
+    }
+    else
+    {
+        in_ptr = v_in;
+        out_ptr = v_out;
+        Sp = Sp_v;
+        H = H_v;
+        psp = bx - nq - nk;
+    }
+
     int const h = threadIdx.x / vec_per_row;
+    if (h >= H) // block sized to max(H); mask extra heads only when H differs (GQA)
+        return;
     int const vec_idx = threadIdx.x - h * vec_per_row;
 
-    int const psp = blockIdx.x; // 0 .. P*Sp-1
     int const p = psp / Sp;
     int const sp = psp - p * Sp;
     int const b = blockIdx.y;
     int const PSp = P * Sp;
-
-    T const* in_ptr;
-    T* out_ptr;
-    switch (blockIdx.z)
-    {
-    case 0:
-        in_ptr = q_in;
-        out_ptr = q_out;
-        break;
-    case 1:
-        in_ptr = k_in;
-        out_ptr = k_out;
-        break;
-    default:
-        in_ptr = v_in;
-        out_ptr = v_out;
-        break;
-    }
 
     // in[p, b, sp, h, d]: ((((p*B + b)*Sp + sp)*H + h)*D + vec_idx*VEC)
     // NHD out[b, p*Sp+sp, h, d]: (((b*PSp + psp)*H + h)*D + vec_idx*VEC)
@@ -83,16 +98,18 @@ __global__ void ulyssesPostUnscatterKernel(T const* __restrict__ q_in, T const* 
 } // namespace
 
 void launchUlyssesPostUnscatter(void const* q_in, void const* k_in, void const* v_in, void* q_out, void* k_out,
-    void* v_out, int P, int B, int Sp, int H, int D, cudaStream_t stream)
+    void* v_out, int P, int B, int D, int Sp_q, int H_q, int Sp_k, int H_k, int Sp_v, int H_v, cudaStream_t stream)
 {
     constexpr int VEC = 8;
     TLLM_CHECK_WITH_INFO(D % VEC == 0, "ulyssesPostUnscatter: D must be a multiple of 8 (uint4 vec), got %d", D);
     int const vec_per_row = D / VEC;
-    int const threads = H * vec_per_row;
+    int const H_max = std::max(H_q, std::max(H_k, H_v));
+    int const threads = H_max * vec_per_row;
     TLLM_CHECK_WITH_INFO(threads <= 1024,
-        "ulyssesPostUnscatter: threads/block (H*D/8) must be <= 1024, got H=%d D=%d -> %d", H, D, threads);
+        "ulyssesPostUnscatter: threads/block (maxH*D/8) must be <= 1024, got maxH=%d D=%d -> %d", H_max, D, threads);
 
-    dim3 const grid(P * Sp, B, 3);
+    int const total_tiles = P * (Sp_q + Sp_k + Sp_v); // packed over Q/K/V, no idle blocks
+    dim3 const grid(total_tiles, B, 1);
     dim3 const block(threads);
 
     auto* q_in_typed = reinterpret_cast<__nv_bfloat16 const*>(q_in);
@@ -102,8 +119,8 @@ void launchUlyssesPostUnscatter(void const* q_in, void const* k_in, void const* 
     auto* k_out_typed = reinterpret_cast<__nv_bfloat16*>(k_out);
     auto* v_out_typed = reinterpret_cast<__nv_bfloat16*>(v_out);
 
-    ulyssesPostUnscatterKernel<__nv_bfloat16><<<grid, block, 0, stream>>>(
-        q_in_typed, k_in_typed, v_in_typed, q_out_typed, k_out_typed, v_out_typed, P, B, Sp, H, D, vec_per_row);
+    ulyssesPostUnscatterKernel<__nv_bfloat16><<<grid, block, 0, stream>>>(q_in_typed, k_in_typed, v_in_typed,
+        q_out_typed, k_out_typed, v_out_typed, P, B, D, vec_per_row, Sp_q, H_q, Sp_k, H_k, Sp_v, H_v);
 }
 
 } // namespace kernels

--- a/cpp/tensorrt_llm/kernels/ulyssesPostUnscatterKernel.h
+++ b/cpp/tensorrt_llm/kernels/ulyssesPostUnscatterKernel.h
@@ -47,16 +47,18 @@ namespace kernels
 //   - Each block reads one fully contiguous (p, b, sp, :H, :D) tile of
 //     H*D bf16
 //   - H*(D/8) threads/block — each thread copies one uint4 (8 bf16)
-//   - Grid (P*Sp, B, 3): blockIdx.z selects Q / K / V
+//   - Grid (P*(Sp_q+Sp_k+Sp_v), B): blockIdx.x is packed over Q/K/V tiles and mapped
+//     to the owning tensor -> no idle blocks even when Q/K/V shapes differ
 //
 // Constraints:
 //   - dtype must be bf16
 //   - D must be a multiple of 8 (uint4 vector load/store, 8 bf16 per thread)
-//   - threads/block = H * (D / 8) must be <= 1024 (CUDA hw limit)
-void launchUlyssesPostUnscatter(void const* q_in, // [P, B, Sp, H, D]
-    void const* k_in, void const* v_in,
-    void* q_out,                                  // [B, P*Sp, H, D] NHD-contig
-    void* k_out, void* v_out, int P, int B, int Sp, int H, int D, cudaStream_t stream);
+//   - threads/block = max(H) * (D / 8) must be <= 1024 (CUDA hw limit)
+void launchUlyssesPostUnscatter(void const* q_in, // [P, B, Sp_q, H_q, D]
+    void const* k_in, void const* v_in,           // [P, B, Sp_{k,v}, H_{k,v}, D]
+    void* q_out,                                  // per-tensor [B, P*Sp, H, D] NHD-contig
+    void* k_out, void* v_out, int P, int B, int D, int Sp_q, int H_q, int Sp_k, int H_k, int Sp_v, int H_v,
+    cudaStream_t stream);
 
 } // namespace kernels
 

--- a/cpp/tensorrt_llm/thop/ulyssesPostUnscatterOp.cpp
+++ b/cpp/tensorrt_llm/thop/ulyssesPostUnscatterOp.cpp
@@ -27,19 +27,11 @@ namespace torch_ext
 
 // Post-Ulysses A2A unscatter: take Q/K/V tensors of shape [P, B, Sp, H, D]
 // (output of the head-dim -> seq-dim all-to-all) and produce SDPA-ready Q/K/V.
-// The kernel ALWAYS writes NHD-contig storage [B, P*Sp, H, D]. The returned
-// tensor shape depends on ``layout``:
-//   layout=0 (HND) → returns transpose-view [B, H, P*Sp, D]
-//                    (HND-shape, NHD-stride, NON-contig — mirrors the
-//                    `q.transpose(1, 2)` result in the sync `_forward_unfused`
-//                    path, which lets cudnn SDPA preserve NHD-stride through
-//                    its output and collapses the downstream
-//                    `_output_a2a.transpose(1, 2).contiguous()` to a no-op)
-//   layout=1 (NHD) → returns storage as-is [B, P*Sp, H, D] (NHD contig)
-// Replaces the eager chain
-//     t.permute(1, 0, 2, 3, 4).reshape(B, P * Sp, H, D).contiguous()           // NHD
-//     [.transpose(1, 2)]                                                       // HND: stride view only
-// for Q, K, V in one kernel launch.
+// The kernel writes NHD-contig storage [B, P*Sp, H, D]; the return depends on ``layout``:
+//   layout=0 (HND) → transpose-view [B, H, P*Sp, D] (HND-shape, NHD-stride, non-contig)
+//   layout=1 (NHD) → storage as-is [B, P*Sp, H, D] (NHD-contig)
+// Equivalent eager: t.permute(1,0,2,3,4).reshape(B, P*Sp, H, D).contiguous()[.transpose(1,2) if HND].
+// Q/K/V may differ in (Sp, H) (cross-attn: Q=audio vs K/V=video) — one packed launch handles both.
 std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> ulysses_post_unscatter_qkv(
     torch::Tensor& q_in, // [P, B, Sp, H, D]
     torch::Tensor& k_in, // [P, B, Sp, H, D]
@@ -48,38 +40,39 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> ulysses_post_unscatter_q
 {
     TORCH_CHECK(q_in.dim() == 5 && k_in.dim() == 5 && v_in.dim() == 5,
         "ulysses_post_unscatter_qkv expects 5D tensors [P, B, Sp, H, D]");
-    TORCH_CHECK(q_in.sizes() == k_in.sizes() && q_in.sizes() == v_in.sizes(), "Q/K/V must share the same shape");
     TORCH_CHECK(layout == 0 || layout == 1, "layout must be 0 (HND) or 1 (NHD), got ", layout);
 
     CHECK_INPUT(q_in, torch::kBFloat16);
     CHECK_INPUT(k_in, torch::kBFloat16);
     CHECK_INPUT(v_in, torch::kBFloat16);
 
-    // D % 8 enforced here at op boundary (mirrors sibling ulysses_permute_scatter).
-    // Without this, torch::empty allocates the three output tensors before the
-    // kernel launcher's TLLM_CHECK_WITH_INFO fires, producing a less-actionable
-    // error path. Vec width is 8 elements for bf16 (16-byte vectorized stores).
-    TORCH_CHECK(q_in.size(-1) % 8 == 0, "D (last dim) must be divisible by 8 (bf16 vec=8)");
-
+    // P (ulysses degree), B (batch), D (head dim) are shared across Q/K/V; Sp (seq shard)
+    // and H (heads/rank) may differ (cross-attn: Q=audio vs K/V=video). The launcher's
+    // packed grid handles equal or different shapes in one launch.
     int64_t const P = q_in.size(0);
     int64_t const B = q_in.size(1);
-    int64_t const Sp = q_in.size(2);
-    int64_t const H = q_in.size(3);
     int64_t const D = q_in.size(4);
+    TORCH_CHECK(k_in.size(0) == P && v_in.size(0) == P, "Q/K/V must share P (ulysses degree)");
+    TORCH_CHECK(k_in.size(1) == B && v_in.size(1) == B, "Q/K/V must share B (batch)");
+    TORCH_CHECK(k_in.size(4) == D && v_in.size(4) == D, "Q/K/V must share D (head dim)");
+    // D % 8 enforced at the op boundary: vec width is 8 bf16 (16-byte vectorized stores).
+    TORCH_CHECK(D % 8 == 0, "D (last dim) must be divisible by 8 (bf16 vec=8)");
+
+    int64_t const Sp_q = q_in.size(2), H_q = q_in.size(3);
+    int64_t const Sp_k = k_in.size(2), H_k = k_in.size(3);
+    int64_t const Sp_v = v_in.size(2), H_v = v_in.size(3);
 
     bool const is_hnd = (layout == 0);
     auto opts = q_in.options();
-    // Always allocate NHD-contig storage [B, P*Sp, H, D].
-    auto const storage_shape = std::vector<int64_t>{B, P * Sp, H, D};
-    auto q_out = torch::empty(storage_shape, opts);
-    auto k_out = torch::empty(storage_shape, opts);
-    auto v_out = torch::empty(storage_shape, opts);
+    // Per-tensor NHD-contig storage [B, P*Sp, H, D].
+    auto q_out = torch::empty({B, P * Sp_q, H_q, D}, opts);
+    auto k_out = torch::empty({B, P * Sp_k, H_k, D}, opts);
+    auto v_out = torch::empty({B, P * Sp_v, H_v, D}, opts);
 
-    // Empty-tensor no-op: P=0/B=0/Sp=0 produces zero grid extent in the
-    // kernel launcher (undefined cuLaunchKernel behavior across CUDA versions).
-    // The three output tensors above are already empty-shaped via P*Sp=0 or B=0,
-    // so returning them directly preserves the output-shape contract.
-    if (q_in.numel() == 0)
+    // Empty-tensor no-op: only when ALL three are empty (P=0 / B=0 / all Sp=0) is the grid
+    // extent zero (UB in the launcher). If any tensor is non-empty the launch is valid and
+    // the kernel bounds-checks each tensor's own (Sp, H), so a per-tensor empty is fine.
+    if (q_in.numel() == 0 && k_in.numel() == 0 && v_in.numel() == 0)
     {
         if (is_hnd)
         {
@@ -91,7 +84,8 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> ulysses_post_unscatter_q
     auto stream = at::cuda::getCurrentCUDAStream();
     tensorrt_llm::kernels::launchUlyssesPostUnscatter(q_in.data_ptr(), k_in.data_ptr(), v_in.data_ptr(),
         q_out.data_ptr(), k_out.data_ptr(), v_out.data_ptr(), static_cast<int>(P), static_cast<int>(B),
-        static_cast<int>(Sp), static_cast<int>(H), static_cast<int>(D), stream);
+        static_cast<int>(D), static_cast<int>(Sp_q), static_cast<int>(H_q), static_cast<int>(Sp_k),
+        static_cast<int>(H_k), static_cast<int>(Sp_v), static_cast<int>(H_v), stream);
 
     // HND callers get a transpose-view of the NHD storage (zero-copy stride
     // reinterpretation). NHD callers get the storage as-is.

--- a/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
+++ b/tensorrt_llm/_torch/custom_ops/cpp_custom_ops.py
@@ -1094,14 +1094,11 @@ def _register_fake():
 
     @torch.library.register_fake("trtllm::ulysses_post_unscatter_qkv")
     def _(q_in, k_in, v_in, layout=0):
-        # Storage is always NHD-contig [B, P*Sp, H, D]. HND-shape return is a
-        # transpose-view (HND-shape, NHD-stride, non-contig) so Inductor sees
-        # the same stride pattern as the real op.
-        P, B, Sp, H, D = q_in.shape
-        nhd_shape = (B, P * Sp, H, D)
-
+        # Per-tensor NHD-contig storage [B, P*Sp, H, D] (Q/K/V may differ in Sp/H for
+        # cross-attn); layout=0 (HND) returns a transpose-view (HND-shape, NHD-stride).
         def _mk(t):
-            base = t.new_empty(nhd_shape)
+            P, B, Sp, H, D = t.shape
+            base = t.new_empty((B, P * Sp, H, D))
             return base.transpose(1, 2) if layout == 0 else base
 
         return (_mk(q_in), _mk(k_in), _mk(v_in))

--- a/tensorrt_llm/_torch/visual_gen/attention_backend/parallel.py
+++ b/tensorrt_llm/_torch/visual_gen/attention_backend/parallel.py
@@ -259,9 +259,10 @@ class UlyssesAttention(AttentionBackend):
         compute_q: Callable[[], torch.Tensor],
         compute_k: Callable[[], torch.Tensor],
         compute_v: Callable[[], torch.Tensor],
+        issue_order: tuple = ("v", "q", "k"),
         **attn_kwargs,
     ) -> torch.Tensor:
-        """Run the async ulysses attention path (V/Q/K rolling A2A).
+        """Run the async ulysses attention path (Q/K/V rolling A2A).
 
         Args:
             compute_q / compute_k / compute_v : caller-provided closures that
@@ -269,29 +270,39 @@ class UlyssesAttention(AttentionBackend):
                 typically does `GEMM → (RMSNorm) → (RoPE) → view(4D)`; closures
                 live in the caller's compiled forward so inductor fuses each
                 into a single Triton kernel.
+            issue_order : order in which the three closures are computed +
+                issued. Default `("v", "q", "k")` (self-attn). Cross-attn passes
+                `("q", "k", "v")` to issue the small audio-Q first. Order is
+                correctness-neutral (`_join_async` syncs all recv bufs).
             **attn_kwargs : forwarded to the wrapped inner attention backend
                 (mask, scale, etc.).
 
         Returns:
             output tensor in the caller's sharded layout `[B, S/P, H, D]`.
 
-        Pipeline: V/Q/K computed in V→Q→K order on the default stream; each
-        compute's output is fed to `_issue_async` which queues push+barrier on
-        the comm side stream. Default stream proceeds to the next compute
-        immediately, so V's push overlaps with Q's compute, Q's push overlaps
-        with K's compute. `_join_async` makes default wait on the last push.
+        Pipeline: the three closures run on the default stream in `issue_order`;
+        each compute's output is fed to `_issue_async` which queues push+barrier
+        on the comm side stream. Default stream proceeds to the next compute
+        immediately, so each push overlaps with the next compute. `_join_async`
+        makes default wait on the last push.
         Post-attention permute / SDPA / reverse A2A run in the caller's outer
         compile region for additional inductor fusion."""
         P = self.world_size
 
-        v_4d = compute_v()
-        v_5d = self._issue_async(v_4d)
-
-        q_4d = compute_q()
-        q_5d = self._issue_async(q_4d)
-
-        k_4d = compute_k()
-        k_5d = self._issue_async(k_4d)
+        # Issue order tunes which push overlaps which compute. self-attn: V->Q->K
+        # (V is cheapest to compute, so its push hides behind the Q+K computes).
+        # Cross-attn (v2a, Q=small audio, K/V=large video): Q->K->V issues the small
+        # audio-Q first so the comm pipeline starts before the large video K/V GEMMs,
+        # which then overlap the in-flight pushes. Order is correctness-neutral
+        # (_join_async syncs all recv bufs before the post step).
+        if issue_order == ("q", "k", "v"):
+            q_5d = self._issue_async(compute_q())
+            k_5d = self._issue_async(compute_k())
+            v_5d = self._issue_async(compute_v())
+        else:
+            v_5d = self._issue_async(compute_v())
+            q_5d = self._issue_async(compute_q())
+            k_5d = self._issue_async(compute_k())
 
         self._join_async()
 
@@ -301,11 +312,15 @@ class UlyssesAttention(AttentionBackend):
         # only instantiated for __nv_bfloat16.
         _, B_q, Sp_q, HpP_q, D_q = q_5d.shape
         is_hnd = self.inner_backend.preferred_layout == AttentionTensorLayout.HND
-        use_fused_post_unscatter = q_5d.dtype == torch.bfloat16
+        # The 3-in-1 fused unscatter requires identical Q/K/V shape (self-attn MHA).
+        # Cross-attn (Q=audio seq ≠ K/V=video seq) → per-tensor unscatter + distinct seq_len_kv.
+        shapes_match = q_5d.shape == k_5d.shape == v_5d.shape
+        use_fused_post_unscatter = q_5d.dtype == torch.bfloat16 and shapes_match
         if use_fused_post_unscatter:
             q_out, k_out, v_out = _ulysses_post_unscatter(q_5d, k_5d, v_5d, is_hnd=is_hnd)
             B = B_q
             seq_len_full = P * Sp_q
+            seq_len_kv_full = seq_len_full
         else:
             v_out = post_permute_5d_to_4d(v_5d, P)
             q_out = post_permute_5d_to_4d(q_5d, P)
@@ -313,13 +328,14 @@ class UlyssesAttention(AttentionBackend):
 
             B = q_out.shape[0]
             seq_len_full = q_out.shape[1]
+            seq_len_kv_full = k_out.shape[1]  # cross-attn: K/V seq differs from Q
             if is_hnd:
                 q_out = q_out.transpose(1, 2).contiguous()
                 k_out = k_out.transpose(1, 2).contiguous()
                 v_out = v_out.transpose(1, 2).contiguous()
 
         attn_kwargs["seq_len"] = seq_len_full
-        attn_kwargs["seq_len_kv"] = seq_len_full
+        attn_kwargs["seq_len_kv"] = seq_len_kv_full
         output = self.inner_backend.forward(q=q_out, k=k_out, v=v_out, **attn_kwargs)
         return self._output_a2a(output, B, seq_len_full)
 

--- a/tensorrt_llm/_torch/visual_gen/attention_backend/parallel.py
+++ b/tensorrt_llm/_torch/visual_gen/attention_backend/parallel.py
@@ -289,22 +289,14 @@ class UlyssesAttention(AttentionBackend):
         compile region for additional inductor fusion."""
         P = self.world_size
 
-        # Issue order tunes which push overlaps which compute. self-attn: V->Q->K
-        # (V is cheapest to compute, so its push hides behind the Q+K computes).
-        # Cross-attn (v2a, Q=small audio, K/V=large video): Q->K->V issues the small
-        # audio-Q first so the comm pipeline starts before the large video K/V GEMMs,
-        # which then overlap the in-flight pushes. Order is correctness-neutral
-        # (_join_async syncs all recv bufs before the post step).
-        if issue_order == ("q", "k", "v"):
-            q_5d = self._issue_async(compute_q())
-            k_5d = self._issue_async(compute_k())
-            v_5d = self._issue_async(compute_v())
-        else:
-            v_5d = self._issue_async(compute_v())
-            q_5d = self._issue_async(compute_q())
-            k_5d = self._issue_async(compute_k())
-
+        # Issue the closures in issue_order. Order is correctness-neutral (_join_async
+        # syncs all recv bufs); it only tunes which push overlaps which compute.
+        computes = {"q": compute_q, "k": compute_k, "v": compute_v}
+        recv = {}
+        for name in issue_order:
+            recv[name] = self._issue_async(computes[name]())
         self._join_async()
+        q_5d, k_5d, v_5d = recv["q"], recv["k"], recv["v"]
 
         # Fast path: one fused kernel replaces the eager post-A2A chain
         # (6 ops for HND target: permute+reshape+contig + transpose+contig
@@ -312,15 +304,12 @@ class UlyssesAttention(AttentionBackend):
         # only instantiated for __nv_bfloat16.
         _, B_q, Sp_q, HpP_q, D_q = q_5d.shape
         is_hnd = self.inner_backend.preferred_layout == AttentionTensorLayout.HND
-        # The 3-in-1 fused unscatter requires identical Q/K/V shape (self-attn MHA).
-        # Cross-attn (Q=audio seq ≠ K/V=video seq) → per-tensor unscatter + distinct seq_len_kv.
-        shapes_match = q_5d.shape == k_5d.shape == v_5d.shape
-        use_fused_post_unscatter = q_5d.dtype == torch.bfloat16 and shapes_match
+        use_fused_post_unscatter = q_5d.dtype == torch.bfloat16
         if use_fused_post_unscatter:
             q_out, k_out, v_out = _ulysses_post_unscatter(q_5d, k_5d, v_5d, is_hnd=is_hnd)
             B = B_q
             seq_len_full = P * Sp_q
-            seq_len_kv_full = seq_len_full
+            seq_len_kv_full = P * k_5d.shape[2]  # cross-attn: K/V seq (Sp_k) differs from Q
         else:
             v_out = post_permute_5d_to_4d(v_5d, P)
             q_out = post_permute_5d_to_4d(q_5d, P)

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
@@ -101,7 +101,6 @@ class LTX2Attention(Attention):
         layer_idx: int = 0,
         module_name: Optional[str] = None,
         enable_sequence_parallel: bool = False,
-        use_ulysses: bool = False,
         async_ulysses: bool = False,
     ):
         from tensorrt_llm._torch.visual_gen.config import DiffusionModelConfig
@@ -115,14 +114,14 @@ class LTX2Attention(Attention):
         self._is_cross_attn = context_dim is not None
 
         # Async ulysses opt-in: V/Q/K GEMMs interleave with the all-to-all on a
-        # side stream. Forces SEPARATE_QKV so the 3 projections can issue
-        # independently.
+        # side stream. Forces SEPARATE_QKV so the 3 projections issue independently.
+        # Gated per-attn on enable_sequence_parallel + async_ulysses: only attns that
+        # pass async_ulysses=True opt in (video self-attn and v2a). audio_attn1 is
+        # enable_sequence_parallel=True but does NOT pass async_ulysses -- it needs
+        # key_padding_mask (audio is padded), which forward_async has no param for --
+        # so it stays on the sync path.
         self._use_async_ulysses = bool(
-            use_ulysses
-            and not self._is_cross_attn
-            and async_ulysses
-            and vgm is not None
-            and vgm.ulysses_size > 1
+            enable_sequence_parallel and async_ulysses and vgm is not None and vgm.ulysses_size > 1
         )
 
         # Self-attention: FUSE_QKV enables the optimized backend + auto Ulysses
@@ -182,13 +181,19 @@ class LTX2Attention(Attention):
             # cross-attn paths.
 
         # Build a Ulysses/plain dual-attn pair so set_ulysses_active() can toggle
-        # at runtime. Needed for self-attn (audio seq not always divisible by
-        # ulysses_size) and for v2a cross-attn under pure Ulysses (cp_size == 1),
-        # where it lets the block forward use Ulysses a2a instead of all-gathering
-        # the full video K/V. Combined ring/attn2d + Ulysses (cp_size > 1) keeps
-        # cross-attn on the all-gather fallback. The base class already set
-        # self.attn to UlyssesAttention(inner_backend=sharded_backend).
-        if use_ulysses and (cp_size == 1 or not self._is_cross_attn) and ulysses_size > 1:
+        # at runtime. Built for every sequence-parallel attn: self-attn (audio seq
+        # not always divisible by ulysses_size; for audio both the Ulysses-inner and
+        # the plain backend are key_padding_mask-capable via the same backend choice)
+        # and v2a cross-attn under pure Ulysses (cp_size == 1), where it lets the
+        # block forward use Ulysses a2a instead of all-gathering the full video K/V.
+        # Combined ring/attn2d + Ulysses (cp_size > 1) keeps cross-attn on the
+        # all-gather fallback. The base class already set self.attn to
+        # UlyssesAttention(inner_backend=sharded_backend).
+        if (
+            enable_sequence_parallel
+            and (cp_size == 1 or not self._is_cross_attn)
+            and ulysses_size > 1
+        ):
             self._ulysses_attn = self.attn
             self._plain_attn = create_attention(
                 backend=self.attn_backend,
@@ -448,87 +453,105 @@ class LTX2Attention(Attention):
 
     def forward_async(
         self,
-        x: torch.Tensor,
+        q_input: torch.Tensor,
         freqs: tuple[torch.Tensor, torch.Tensor] | None = None,
+        kv_input: torch.Tensor | None = None,
+        kv_freqs: tuple[torch.Tensor, torch.Tensor] | None = None,
         timestep=None,
     ) -> torch.Tensor:
-        """LTX-2 async-Ulysses self-attn driver. Structurally mirrors base
-        ``Attention.forward_async`` (single function, fused/unfused branches)
-        but uses LTX-2's ``apply_rotary_emb`` (with ``rope_type``) on the
-        unfused fallback and injects gated-attention scaling in 4D between
-        the attn output and ``to_out``.
+        """LTX-2 async-Ulysses attention driver, self-attn or cross-attn.
 
-        Precondition: caller in ``LTX2Attention.forward`` gates on
-        ``_use_async_ulysses`` + ``hasattr(self.attn, "forward_async")``.
+        Self-attn (``kv_input is None``): Q/K/V all from ``q_input`` with one
+        ``freqs``; the three projections share one fp4 input-quant. Cross-attn
+        (v2a, ``kv_input`` given): Q from ``q_input`` (audio), K/V from
+        ``kv_input`` (video) — different seq lengths and RoPE freqs, each Linear
+        does its own fp4 input-quant (audio != video). K/V projection + RoPE run
+        INSIDE the closures on the LOCAL video shard so the video K/V GEMMs
+        overlap the a2a (replacing the sync ``project_kv`` pre-projection;
+        value-preserving). Issue order: self-attn V->Q->K, cross-attn Q->K->V
+        (issue the small audio-Q first; see ``UlyssesAttention.forward_async``).
 
-        Returns 3D ``[B, S, H*D]`` matching ``forward``'s output contract.
+        Structurally mirrors base ``Attention.forward_async`` (fused/unfused
+        branches) but uses LTX-2's ``apply_rotary_emb`` (with ``rope_type``) on
+        the unfused fallback and injects gated-attention scaling in 4D before
+        ``to_out``. Returns 3D ``[B, S_q, H*D]`` (Q seq), matching ``forward``.
+
+        Precondition: caller gates on ``_use_async_ulysses`` +
+        ``hasattr(self.attn, "forward_async")``.
         """
-        B, S, _ = x.shape
+        self_attn = kv_input is None
+        if self_attn:
+            kv_input, kv_freqs = q_input, freqs
+        Bq, Sq, _ = q_input.shape
+        Bk, Sk, _ = kv_input.shape
         H = self.num_attention_heads
         KV = self.num_key_value_heads
         D = self.head_dim
-        # Mirrors LTX2Attention.forward's fused gate; qkv_mode is implicitly
-        # SEPARATE_QKV under async (caller-enforced). head_dim check matches
-        # the fused split kernel's HEAD_DIM template instantiations {64, 128}.
-        use_fused = (
-            self.fuse_qk_norm_rope
-            and self.head_dim in (64, 128)
-            and freqs is not None
-            and self.qk_norm
-        )
+        # qkv_mode is implicitly SEPARATE_QKV under async (caller-enforced);
+        # head_dim check matches the fused split kernel's {64, 128} templates.
+        use_fused = self.fuse_qk_norm_rope and self.head_dim in (64, 128) and self.qk_norm
 
-        # SEPARATE_QKV self-attn shares ONE input quant across to_q/to_k/to_v (mirrors
-        # Attention.forward_async): reuse x if already fp4, else quantize once.
-        if isinstance(x, Fp4QuantizedTensor):
-            qkv_input = x
-        elif self._maybe_share_qkv_quantize and getattr(self.to_q, "input_scale", None) is not None:
-            x_2d = x.reshape(-1, x.shape[-1])
-            fp4, sf = torch.ops.trtllm.tunable_fp4_quantize(
-                x_2d, self.to_q.input_scale, self.to_q.scaling_vector_size, False
-            )
-            qkv_input = Fp4QuantizedTensor(fp4, sf, is_sf_swizzled=False)
+        # Input quant. Self-attn shares ONE fp4 across to_q/to_k/to_v (same input):
+        # reuse q_input if already fp4, else quantize once. Cross-attn quantizes
+        # per input (Q=audio, K/V=video differ) -> each Linear does its own.
+        if self_attn:
+            if isinstance(q_input, Fp4QuantizedTensor):
+                q_src = kv_src = q_input
+            elif (
+                self._maybe_share_qkv_quantize
+                and getattr(self.to_q, "input_scale", None) is not None
+            ):
+                x_2d = q_input.reshape(-1, q_input.shape[-1])
+                fp4, sf = torch.ops.trtllm.tunable_fp4_quantize(
+                    x_2d, self.to_q.input_scale, self.to_q.scaling_vector_size, False
+                )
+                q_src = kv_src = Fp4QuantizedTensor(fp4, sf, is_sf_swizzled=False)
+            else:
+                q_src = kv_src = q_input
         else:
-            qkv_input = x
+            q_src, kv_src = q_input, kv_input
 
         def compute_q():
-            q = self.to_q(qkv_input)
+            q = self.to_q(q_src)
             if q.dim() == 2:
-                q = q.view(B, S, -1)
-            if use_fused:
+                q = q.view(Bq, Sq, -1)
+            if use_fused and freqs is not None:
                 self.apply_split_norm_rope(q, self.norm_q.weight, H, freqs[0], freqs[1])
-                return q.view(B, S, H, D)
+                return q.view(Bq, Sq, H, D)
             # Unfused fallback (mini-config); LTX-2 RoPE with rope_type.
             if self.qk_norm:
                 q = self.norm_q(q)
-            q = q.view(B, S, H, D)
+            q = q.view(Bq, Sq, H, D)
             if freqs is not None:
                 q = apply_rotary_emb(q, freqs, self.rope_type)
             return q
 
         def compute_k():
-            k = self.to_k(qkv_input)
+            k = self.to_k(kv_src)
             if k.dim() == 2:
-                k = k.view(B, S, -1)
-            if use_fused:
-                self.apply_split_norm_rope(k, self.norm_k.weight, KV, freqs[0], freqs[1])
-                return k.view(B, S, KV, D)
+                k = k.view(Bk, Sk, -1)
+            if use_fused and kv_freqs is not None:
+                self.apply_split_norm_rope(k, self.norm_k.weight, KV, kv_freqs[0], kv_freqs[1])
+                return k.view(Bk, Sk, KV, D)
             if self.qk_norm:
                 k = self.norm_k(k)
-            k = k.view(B, S, KV, D)
-            if freqs is not None:
-                k = apply_rotary_emb(k, freqs, self.rope_type)
+            k = k.view(Bk, Sk, KV, D)
+            if kv_freqs is not None:
+                k = apply_rotary_emb(k, kv_freqs, self.rope_type)
             return k
 
         def compute_v():
-            return self.to_v(qkv_input).view(B, S, KV, D)
+            return self.to_v(kv_src).view(Bk, Sk, KV, D)
 
-        out_4d = self.attn.forward_async(compute_q, compute_k, compute_v, timestep=timestep)
+        issue_order = ("v", "q", "k") if self_attn else ("q", "k", "v")
+        out_4d = self.attn.forward_async(
+            compute_q, compute_k, compute_v, issue_order=issue_order, timestep=timestep
+        )
 
-        # LTX-2 gated-attention scaling in 4D before to_out.
+        # LTX-2 gated-attention scaling in 4D before to_out (gate on the Q input).
         if self.to_gate_logits is not None:
-            gates = 2.0 * torch.sigmoid(self.to_gate_logits(x))
+            gates = 2.0 * torch.sigmoid(self.to_gate_logits(q_input))
             out_4d = out_4d * gates.unsqueeze(-1)
-
         b, t = out_4d.shape[:2]
         return self.to_out[0](out_4d.reshape(b, t, H * D))
 
@@ -606,6 +629,7 @@ class BasicAVTransformerBlock(nn.Module):
 
     def _init_video_modules(self, cfg, rope_type, eps, model_config, idx):
         _async_ulysses = model_config.parallel.async_ulysses if model_config is not None else False
+        self._async_ulysses = _async_ulysses  # block-level gate for v2a async cross-attn
         self.attn1 = LTX2Attention(
             query_dim=cfg.dim,
             heads=cfg.heads,
@@ -618,7 +642,6 @@ class BasicAVTransformerBlock(nn.Module):
             layer_idx=idx,
             module_name=f"transformer_blocks.{idx}.attn1",
             enable_sequence_parallel=True,
-            use_ulysses=True,
             async_ulysses=_async_ulysses,
         )
         self.attn2 = LTX2Attention(
@@ -709,7 +732,7 @@ class BasicAVTransformerBlock(nn.Module):
             layer_idx=idx,
             module_name=f"transformer_blocks.{idx}.video_to_audio_attn",
             enable_sequence_parallel=True,
-            use_ulysses=True,
+            async_ulysses=self._async_ulysses,
         )
         self.scale_shift_table_a2v_ca_audio = nn.Parameter(torch.empty(5, a_cfg.dim))
         self.scale_shift_table_a2v_ca_video = nn.Parameter(torch.empty(5, v_cfg.dim))
@@ -1144,32 +1167,46 @@ class BasicAVTransformerBlock(nn.Module):
                     )
 
             if run_v2a and not skip_v2a:
-                # v2a: when the Ulysses wrapper is active, K/V (video, large)
-                # stay seq-sharded and the wrapper handles Q + K|V + output
-                # a2a internally. RoPE is applied to K in project_kv on the
-                # local shard (commutes with a2a along the seq dim, so
-                # rotate-before-gather is value-preserving). No
-                # key_padding_mask — video K/V is unpadded; padded audio Q is
-                # stripped on exit by LTXModel.forward. When inactive (no
-                # wrapper built, Stage 2 disable, or audio not sharded), fall
-                # back to AG so the plain backend sees full K/V. Gate on
-                # is_ulysses_active() — _audio_is_sharded can be true under
-                # Attention2D where no wrapper was built.
-                k_v2a, v_v2a = self.video_to_audio_attn.project_kv(
-                    vx_scaled_v2a, pe=video.cross_positional_embeddings
-                )
-                if not self.video_to_audio_attn.is_ulysses_active() and self._sharder.is_active:
-                    # Fallback: wrapper inactive → all-gather sharded video
-                    # K/V to full so plain backend can run.
-                    k_v2a = self._sp_all_gather(k_v2a)
-                    v_v2a = self._sp_all_gather(v_v2a)
+                if self._async_ulysses and self.video_to_audio_attn.is_ulysses_active():
+                    # Async-Ulysses v2a: compute Q(audio)/K/V(video) inside the async
+                    # driver so the video K/V GEMMs overlap the a2a (replaces the
+                    # project_kv pre-projection). RoPE-on-K stays on the local shard
+                    # (value-preserving). No key_padding_mask — video K/V unpadded;
+                    # padded audio Q stripped on exit by LTXModel.forward.
+                    v2a_attn_raw = self.video_to_audio_attn.forward_async(
+                        q_input=ax_scaled_v2a,
+                        freqs=audio.cross_positional_embeddings,
+                        kv_input=vx_scaled_v2a,
+                        kv_freqs=video.cross_positional_embeddings,
+                        timestep=audio.timesteps,
+                    )
+                else:
+                    # v2a sync: when the Ulysses wrapper is active, K/V (video, large)
+                    # stay seq-sharded and the wrapper handles Q + K|V + output
+                    # a2a internally. RoPE is applied to K in project_kv on the
+                    # local shard (commutes with a2a along the seq dim, so
+                    # rotate-before-gather is value-preserving). No
+                    # key_padding_mask — video K/V is unpadded; padded audio Q is
+                    # stripped on exit by LTXModel.forward. When inactive (no
+                    # wrapper built, Stage 2 disable, or audio not sharded), fall
+                    # back to AG so the plain backend sees full K/V. Gate on
+                    # is_ulysses_active() — _audio_is_sharded can be true under
+                    # Attention2D where no wrapper was built.
+                    k_v2a, v_v2a = self.video_to_audio_attn.project_kv(
+                        vx_scaled_v2a, pe=video.cross_positional_embeddings
+                    )
+                    if not self.video_to_audio_attn.is_ulysses_active() and self._sharder.is_active:
+                        # Fallback: wrapper inactive → all-gather sharded video
+                        # K/V to full so plain backend can run.
+                        k_v2a = self._sp_all_gather(k_v2a)
+                        v_v2a = self._sp_all_gather(v_v2a)
 
-                v2a_attn_raw = self.video_to_audio_attn(
-                    ax_scaled_v2a,
-                    pre_projected_kv=(k_v2a, v_v2a),
-                    pe=audio.cross_positional_embeddings,
-                    timestep=audio.timesteps,
-                )
+                    v2a_attn_raw = self.video_to_audio_attn(
+                        ax_scaled_v2a,
+                        pre_projected_kv=(k_v2a, v_v2a),
+                        pe=audio.cross_positional_embeddings,
+                        timestep=audio.timesteps,
+                    )
                 if has_perturbations and perturbations.any_in_batch(
                     PerturbationType.SKIP_V2A_CROSS_ATTN, self.idx
                 ):

--- a/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
+++ b/tensorrt_llm/_torch/visual_gen/models/ltx2/transformer_ltx2.py
@@ -113,13 +113,8 @@ class LTX2Attention(Attention):
         self.rope_type = rope_type
         self._is_cross_attn = context_dim is not None
 
-        # Async ulysses opt-in: V/Q/K GEMMs interleave with the all-to-all on a
-        # side stream. Forces SEPARATE_QKV so the 3 projections issue independently.
-        # Gated per-attn on enable_sequence_parallel + async_ulysses: only attns that
-        # pass async_ulysses=True opt in (video self-attn and v2a). audio_attn1 is
-        # enable_sequence_parallel=True but does NOT pass async_ulysses -- it needs
-        # key_padding_mask (audio is padded), which forward_async has no param for --
-        # so it stays on the sync path.
+        # Async-Ulysses opt-in: interleaves the Q/K/V GEMMs with the all-to-all on a side
+        # stream. Gated on enable_sequence_parallel + async_ulysses + ulysses_size > 1.
         self._use_async_ulysses = bool(
             enable_sequence_parallel and async_ulysses and vgm is not None and vgm.ulysses_size > 1
         )
@@ -471,13 +466,9 @@ class LTX2Attention(Attention):
         value-preserving). Issue order: self-attn V->Q->K, cross-attn Q->K->V
         (issue the small audio-Q first; see ``UlyssesAttention.forward_async``).
 
-        Structurally mirrors base ``Attention.forward_async`` (fused/unfused
-        branches) but uses LTX-2's ``apply_rotary_emb`` (with ``rope_type``) on
-        the unfused fallback and injects gated-attention scaling in 4D before
-        ``to_out``. Returns 3D ``[B, S_q, H*D]`` (Q seq), matching ``forward``.
-
-        Precondition: caller gates on ``_use_async_ulysses`` +
-        ``hasattr(self.attn, "forward_async")``.
+        Injects LTX-2 gated-attention scaling in 4D before ``to_out``; returns
+        3D ``[B, S_q, H*D]`` (Q seq). Precondition: caller gates on
+        ``_use_async_ulysses`` + ``hasattr(self.attn, "forward_async")``.
         """
         self_attn = kv_input is None
         if self_attn:
@@ -661,13 +652,9 @@ class BasicAVTransformerBlock(nn.Module):
         self.scale_shift_table = nn.Parameter(torch.empty(6, cfg.dim))
 
     def _init_audio_modules(self, cfg, rope_type, eps, model_config, idx):
-        # Audio under Ulysses needs key_padding_mask support on audio_attn1
-        # (audio is padded to be divisible by ulysses_size; mask zeros pad
-        # slots). TRTLLM self-attn silently drops key_padding_mask, so downgrade
-        # to VANILLA whenever Ulysses is active under a TRTLLM backend config.
-        # Mirrors the existing cross-attn TRTLLM→VANILLA fallback
-        # (modules/attention.py); audio is small (T_a ~ 126) so the downgrade
-        # is negligible.
+        # audio_attn1 needs key_padding_mask (audio is padded to divide ulysses_size; the
+        # mask zeros pad slots), but TRTLLM self-attn silently drops it — so downgrade to
+        # VANILLA when Ulysses is active under a TRTLLM backend.
         audio_self_config = model_config
         vgm = model_config.visual_gen_mapping
         ulysses_size = vgm.ulysses_size if vgm is not None else 1
@@ -1169,10 +1156,9 @@ class BasicAVTransformerBlock(nn.Module):
             if run_v2a and not skip_v2a:
                 if self._async_ulysses and self.video_to_audio_attn.is_ulysses_active():
                     # Async-Ulysses v2a: compute Q(audio)/K/V(video) inside the async
-                    # driver so the video K/V GEMMs overlap the a2a (replaces the
-                    # project_kv pre-projection). RoPE-on-K stays on the local shard
-                    # (value-preserving). No key_padding_mask — video K/V unpadded;
-                    # padded audio Q stripped on exit by LTXModel.forward.
+                    # driver so the video K/V GEMMs overlap the a2a. RoPE-on-K on the local
+                    # shard is value-preserving; no key_padding_mask (video K/V unpadded,
+                    # padded audio Q stripped on exit by LTXModel.forward).
                     v2a_attn_raw = self.video_to_audio_attn.forward_async(
                         q_input=ax_scaled_v2a,
                         freqs=audio.cross_positional_embeddings,
@@ -1181,17 +1167,12 @@ class BasicAVTransformerBlock(nn.Module):
                         timestep=audio.timesteps,
                     )
                 else:
-                    # v2a sync: when the Ulysses wrapper is active, K/V (video, large)
-                    # stay seq-sharded and the wrapper handles Q + K|V + output
-                    # a2a internally. RoPE is applied to K in project_kv on the
-                    # local shard (commutes with a2a along the seq dim, so
-                    # rotate-before-gather is value-preserving). No
-                    # key_padding_mask — video K/V is unpadded; padded audio Q is
-                    # stripped on exit by LTXModel.forward. When inactive (no
-                    # wrapper built, Stage 2 disable, or audio not sharded), fall
-                    # back to AG so the plain backend sees full K/V. Gate on
-                    # is_ulysses_active() — _audio_is_sharded can be true under
-                    # Attention2D where no wrapper was built.
+                    # v2a sync: with the Ulysses wrapper active, K/V (video) stay
+                    # seq-sharded and the wrapper does the Q + K|V + output a2a; RoPE-on-K
+                    # in project_kv commutes with the seq-dim a2a (value-preserving). When
+                    # inactive, all-gather so the plain backend sees full K/V — gate on
+                    # is_ulysses_active(), since _audio_is_sharded can be true under
+                    # Attention2D where no wrapper exists.
                     k_v2a, v_v2a = self.video_to_audio_attn.project_kv(
                         vx_scaled_v2a, pe=video.cross_positional_embeddings
                     )

--- a/tests/unittest/_torch/thop/parallel_hw_agnostic/test_ulysses_post_unscatter.py
+++ b/tests/unittest/_torch/thop/parallel_hw_agnostic/test_ulysses_post_unscatter.py
@@ -77,6 +77,47 @@ def test_ulysses_post_unscatter_exact_match(P, B, Sp, H, D, layout):
         assert max_diff == 0, f"{name}: max_diff={max_diff} (expected exact match)"
 
 
+@pytest.mark.parametrize("layout", [0, 1], ids=["HND", "NHD"])
+@pytest.mark.parametrize(
+    "P,B,D,Sp_q,H_q,Sp_kv,H_kv",
+    [
+        # v2a cross-attn (ulysses=4): Q=audio, K/V=video — different seq, same heads (MHA).
+        (4, 2, 128, 256, 8, 1024, 8),
+        (4, 2, 64, 128, 8, 512, 8),
+        # GQA-like: Q vs K/V differ in BOTH seq and heads-per-rank.
+        (4, 2, 128, 256, 8, 1024, 4),
+        (2, 1, 128, 128, 16, 384, 8),
+    ],
+    ids=["mha_seqdiff", "mha_seqdiff_d64", "gqa_seq+head", "gqa_small"],
+)
+@torch.inference_mode()
+def test_ulysses_post_unscatter_cross_attn_varshape(P, B, D, Sp_q, H_q, Sp_kv, H_kv, layout):
+    """Cross-attn (v2a): Q (audio) and K/V (video) have different (Sp, H), so the op
+    can't fuse them into one launch — it launches per-tensor with each tensor's own
+    (Sp, H). Output must still match the eager per-tensor permute exactly (max_diff == 0)
+    and carry per-tensor shapes. K/V share shape (both video); Q differs."""
+    is_hnd = layout == 0
+    torch.manual_seed(0)
+    q = torch.randn(P, B, Sp_q, H_q, D, device="cuda", dtype=torch.bfloat16).contiguous()
+    k = torch.randn(P, B, Sp_kv, H_kv, D, device="cuda", dtype=torch.bfloat16).contiguous()
+    v = torch.randn(P, B, Sp_kv, H_kv, D, device="cuda", dtype=torch.bfloat16).contiguous()
+
+    q_ref, k_ref, v_ref = torch_ref(q, k, v, is_hnd=is_hnd)
+    q_out, k_out, v_out = torch.ops.trtllm.ulysses_post_unscatter_qkv(q, k, v, layout)
+
+    exp_q = (B, H_q, P * Sp_q, D) if is_hnd else (B, P * Sp_q, H_q, D)
+    exp_kv = (B, H_kv, P * Sp_kv, D) if is_hnd else (B, P * Sp_kv, H_kv, D)
+    assert q_out.shape == exp_q, f"Q shape {q_out.shape} != {exp_q}"
+    assert k_out.shape == exp_kv and v_out.shape == exp_kv
+    if is_hnd:
+        assert not q_out.is_contiguous() and not k_out.is_contiguous() and not v_out.is_contiguous()
+    else:
+        assert q_out.is_contiguous() and k_out.is_contiguous() and v_out.is_contiguous()
+    for name, ref, got in [("Q", q_ref, q_out), ("K", k_ref, k_out), ("V", v_ref, v_out)]:
+        max_diff = (ref - got).abs().max().item()
+        assert max_diff == 0, f"{name}: max_diff={max_diff} (expected exact match)"
+
+
 @torch.inference_mode()
 def test_ulysses_post_unscatter_rejects_invalid_layout():
     """layout must be 0 (HND) or 1 (NHD)."""


### PR DESCRIPTION
## Description

Give the LTX-2 v2a (audio→video) cross-attention the same compute/comm overlap that self-attention async-Ulysses already has. Today v2a pre-projects K/V (`project_kv`) on the local shard, then the Ulysses wrapper runs a large all-to-all (Q + K/V + output) that is fully exposed. This PR computes v2a's Q (audio) and K/V (video) *inside* the async-Ulysses driver — dropping `project_kv` — so the video K/V projection GEMMs overlap the v2a all-to-all, the same mechanism self-attn async already uses. It activates whenever the model's `async_ulysses` config is set and Ulysses is active; no new config or flag.

Rebased onto main, which now includes the merged #15718 (NVFP4 rank-3 `Fp4QuantizedTensor` fixes) that the LTX-2 NVFP4 transformer forward relies on; no external dependency remains.

## Changes

- `_torch/visual_gen/attention_backend/parallel.py`: `UlyssesAttention.forward_async` takes an `issue_order` arg (self-attn V→Q→K; v2a cross-attn Q→K→V — the small audio-Q is issued first so the comm pipeline starts before the large video K/V GEMMs; correctness-neutral, `_join_async` syncs all recv bufs) and handles cross-attn where Q (audio) and K/V (video) have different sequence lengths via the fused `ulysses_post_unscatter_qkv` op with a distinct `seq_len_kv` from K's shard — the `shapes_match` gate is dropped so any bf16 unscatter (self + cross) takes the fused path.
- `_torch/visual_gen/models/ltx2/transformer_ltx2.py`: a single `LTX2Attention.forward_async` drives both self-attn (Q/K/V from one input, shared fp4 input-quant) and cross-attn (Q=audio + K/V=video closures, per-input quant, K/V projection + RoPE on the local shard — value-preserving — replacing the sync `project_kv` pre-projection); the v2a block routes through it when `async_ulysses` is active, and passes `async_ulysses` to the v2a attention so its `UlyssesAttention` initializes the async side-stream + boxed process-group.
- `cpp/tensorrt_llm/kernels/ulyssesPostUnscatterKernel.{cu,h}` + `thop/ulyssesPostUnscatterOp.cpp`: generalize the fused post-A2A unscatter to per-tensor `(Sp, H)` so v2a cross-attn (Q=audio ≠ K/V=video) uses it instead of the eager permute+contiguous chain. `grid.x` is packed over all three tensors' tiles (`P*(Sp_q+Sp_k+Sp_v)`) and each block maps to its owning tensor — one launch, no idle blocks even when shapes differ; equal shapes (self-attn) are byte-identical to the prior 3-in-1 launch.
- Simplify per-attn gating to two orthogonal flags and drop the `use_ulysses` param. `_use_async_ulysses` is now `(enable_sequence_parallel and async_ulysses)` — audio self-attn is `enable_sequence_parallel=True` but does not pass `async_ulysses` (it needs `key_padding_mask`, which `forward_async` has no param for) so it stays sync. The `set_ulysses_active` dual-attn pair is now built for every sequence-parallel attn (gated on `enable_sequence_parallel`), so audio self-attn gets one too — both its Ulysses-inner and plain backends are `key_padding_mask`-capable (TRTLLM is downgraded to VANILLA; FA4/VANILLA carry the mask).

## Performance (8×B200, cfg2·uly4, 768×1280, 121 frames, guidance 4.0, FA4)

e2e denoise, 2 deterministic timed runs:

| v2a | per-step | 40-step denoise |
|---|---|---|
| sync  | 0.1105 s | 4.42 s |
| async | 0.1096 s | 4.385 s |

≈ **0.8% (~0.9 ms/step)** faster. nsys (denoise step 4, summed over 8 ranks): the v2a all-to-all moves off the NCCL-on-SM path onto the symm-mem copy-engine side stream — `ncclDevKernel_SendRecv` −43% (−40.5 ms), total GPU-busy −3.0% (−28 ms). The wall gain is modest because the symm-mem prep (permute/clone + scatter + barriers, ≈ +30 ms) and a K/V GEMM-tactic shift offset most of the comm offload. Headroom: fold the permute+scatter into the fused-norm epilogue (write directly into the symm-mem slot) and pin the K/V GEMM tactic.

**Cross-attn post-unscatter kernel** (CUDA-graph microbench, B200, per-call GPU time): the packed-grid fused `ulysses_post_unscatter_qkv` is **~3.6× faster than the eager permute+contiguous chain** and **~1.02–1.15× faster than `torch.compile`**'s fused triton (larger edge on smaller tensors; ~1.07× at the real ~Sp4096 video shard), with exact output (`maxdiff 0`) across self / cross / GQA shapes. Because the DiT runs under torch.compile, the practical win over the compiled cross-attn path is small (~7% on this kernel, ~0.1–0.2 ms/rank/step at e2e); the main value is unifying self + cross on one fused kernel with no idle SMs.

## Output Quality (LPIPS)

Deterministic same-seed sync-vs-async (AlexNet LPIPS on decoded mp4, 121 frames): **mean 0.098** (min 0.089, max 0.123) — the expected "same scene, fine-detail drift" band at 768×1280 (the fused-vs-eager kernel reference is ≈ 0.11). The montage confirms identical scene / subject / pose / composition / quality, so the change is behavior-preserving up to chaotic numerical divergence.

![v2a sync (left) vs async (right) — per-frame LPIPS montage](https://raw.githubusercontent.com/luyiyun1021/TensorRT-LLM/lpips-assets/v2a_lpips_cmp.png)

## Test Coverage

- 8×B200 e2e + nsys A/B (sync vs async), deterministic — table above.
- LPIPS correctness montage above.
- Gating/`use_ulysses` refactor verified output-preserving on 8×B200: a deterministic same-seed generation with the post-refactor build vs the pre-refactor build is the same scene (LPIPS 0.13, within the ~0.11 run-to-run chaotic-divergence floor), and the AV model runs OFF+ON without error (audio self-attn's new dual-attn path included).
- Unified `forward_async` (self + cross) verified output- and perf-preserving on 8×B200: deterministic same-seed merged vs pre-merge ON is the same scene (LPIPS 0.123, within the ~0.11 floor) at 0.11 s/step (unchanged) — the issue-order split is correctness-neutral.
- `tests/unittest/_torch/thop/parallel_hw_agnostic/test_ulysses_post_unscatter.py`: extended with cross-attn varshape cases (Q≠K/V seq, incl. GQA head+seq-diff) across NHD/HND — **23/23 pass**, exact match vs the eager permute reference.
- Follow-up: a multi-GPU unit test exercising the cross-attn branch of `forward_async` end-to-end (extend `tests/unittest/_torch/visual_gen/multi_gpu/test_ltx2_async_ulysses.py`).

## PR Checklist

- PR description clearly explains what and why.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md).
- Test cases are provided for new code paths.
- Any new dependencies have been scanned for license and vulnerabilities.
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes.
- Documentation updated as needed.
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if significant design change.

- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
