### PR TITLE
[None][fix] VisualGen: gate trtllm-serve HTTP bind to rank 0

### DIFF
--- a/tensorrt_llm/commands/serve.py
+++ b/tensorrt_llm/commands/serve.py
@@ -571,6 +571,19 @@ def launch_visual_gen_server(
         visual_gen_args: Optional validated VisualGenArgs for model configuration.
         metadata_server_cfg: Optional metadata server configuration.
     """
+    # External-launch workers (rank > 0) must NOT bind the HTTP socket. Under an
+    # external launcher (torchrun/srun) every rank runs this command, but only
+    # rank 0 serves HTTP; ranks > 0 are pure compute workers. VisualGen() routes
+    # rank > 0 into the diffusion worker loop and sys.exit(0)s (never returns), so
+    # construct it *before* the rank-0-only bind below. Otherwise every rank races
+    # to bind (host, port) and, since a multi-GPU replica's tasks share a network
+    # namespace, all but one die with "Address already in use".
+    from tensorrt_llm._torch.visual_gen.executor import _detect_external_launch
+    _ext = _detect_external_launch()
+    if _ext is not None and _ext[0] != 0:
+        VisualGen(model=model, args=visual_gen_args)  # worker loop; sys.exit(0)s
+        return
+
     # Reserve the listening (host, port) by binding the socket *before*
     # constructing the VisualGen pipeline, then hand the bound socket to
     # uvicorn. VisualGen initialization can take many minutes; if we deferred


### PR DESCRIPTION
## Problem
Under an external launcher (`srun`/`torchrun`), every replica rank runs `trtllm-serve`, but `launch_visual_gen_server` binds the HTTP socket **before** constructing `VisualGen()`. `VisualGen.__init__` is what routes rank>0 into the diffusion worker loop (`run_diffusion_worker` + `sys.exit(0)`). Because the bind happens first, **every rank races to bind `(host, port)`**; on a multi-GPU replica whose tasks share a network namespace, all but one die with:

```
RuntimeError: Failed to bind socket to 0.0.0.0:8000: [Errno 98] Address already in use
```

so the replica never forms its worker group. This blocks any multi-rank single-replica VisualGen serve (e.g. CFG×Ulysses[×CP] video generation launched one task per GPU).

## Fix
Construct `VisualGen()` **before** the rank-0-only bind. rank>0 enters the worker loop and `sys.exit(0)`s (never returns); only rank 0 proceeds to bind the socket and run uvicorn. Single-process / single-GPU launches are unaffected (`_detect_external_launch()` returns `None`).

## Test
Verified on GB300 (srun, one task/GPU): before, 3 of 4 ranks crashed on bind; after, rank 0 serves and ranks 1-3 run as workers, server reaches `Application startup complete`.