### PR TITLE
[None][perf] Validate GPT-OSS transceiver v2 performance

### DIFF
--- a/tests/integration/defs/accuracy/test_disaggregated_serving.py
+++ b/tests/integration/defs/accuracy/test_disaggregated_serving.py
@@ -1568,7 +1568,8 @@ class TestGPTOSS(LlmapiAccuracyTestHarness):
         ctx_server_config = {
             "disable_overlap_scheduler": True,
             "cache_transceiver_config": {
-                "backend": "DEFAULT",
+                "backend": "NIXL",
+                "transceiver_runtime": "PYTHON",
                 "max_tokens_in_buffer": 4096
             },
             "tensor_parallel_size": 4
@@ -1576,7 +1577,8 @@ class TestGPTOSS(LlmapiAccuracyTestHarness):
         gen_server_config = {
             "disable_overlap_scheduler": False,
             "cache_transceiver_config": {
-                "backend": "DEFAULT",
+                "backend": "NIXL",
+                "transceiver_runtime": "PYTHON",
                 "max_tokens_in_buffer": 4096
             },
             "tensor_parallel_size": 4

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp2_gentp2_gptoss_eagle_triton.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp2_gentp2_gptoss_eagle_triton.yaml
@@ -26,7 +26,8 @@ context_servers:
   cuda_graph_config: null
   print_iter_log: true
   cache_transceiver_config:
-    backend: DEFAULT
+    backend: NIXL
+    transceiver_runtime: PYTHON
     max_tokens_in_buffer: 16384
 generation_servers:
   num_instances: 1
@@ -63,5 +64,6 @@ generation_servers:
     - 1024
   print_iter_log: true
   cache_transceiver_config:
-    backend: DEFAULT
+    backend: NIXL
+    transceiver_runtime: PYTHON
     max_tokens_in_buffer: 16384

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp2_gentp2_gptoss_eagle_trtllm.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp2_gentp2_gptoss_eagle_trtllm.yaml
@@ -26,7 +26,8 @@ context_servers:
   cuda_graph_config: null
   print_iter_log: true
   cache_transceiver_config:
-    backend: DEFAULT
+    backend: NIXL
+    transceiver_runtime: PYTHON
     max_tokens_in_buffer: 16384
 generation_servers:
   num_instances: 1
@@ -63,5 +64,6 @@ generation_servers:
     - 1024
   print_iter_log: true
   cache_transceiver_config:
-    backend: DEFAULT
+    backend: NIXL
+    transceiver_runtime: PYTHON
     max_tokens_in_buffer: 16384

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp2_gentp2_gptoss_tllm.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp2_gentp2_gptoss_tllm.yaml
@@ -22,7 +22,8 @@ context_servers:
   cuda_graph_config: null
   print_iter_log: true
   cache_transceiver_config:
-    backend: DEFAULT
+    backend: NIXL
+    transceiver_runtime: PYTHON
     max_tokens_in_buffer: 16384
 generation_servers:
   num_instances: 1
@@ -59,5 +60,6 @@ generation_servers:
     - 1024
   print_iter_log: true
   cache_transceiver_config:
-    backend: DEFAULT
+    backend: NIXL
+    transceiver_runtime: PYTHON
     max_tokens_in_buffer: 16384

--- a/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp2_gentp2_gptoss_triton.yaml
+++ b/tests/integration/defs/disaggregated/test_configs/disagg_config_ctxtp2_gentp2_gptoss_triton.yaml
@@ -21,7 +21,8 @@ context_servers:
   cuda_graph_config: null
   print_iter_log: true
   cache_transceiver_config:
-    backend: DEFAULT
+    backend: NIXL
+    transceiver_runtime: PYTHON
     max_tokens_in_buffer: 16384
 generation_servers:
   num_instances: 1
@@ -53,5 +54,6 @@ generation_servers:
     - 128
   print_iter_log: true
   cache_transceiver_config:
-    backend: DEFAULT
+    backend: NIXL
+    transceiver_runtime: PYTHON
     max_tokens_in_buffer: 16384

--- a/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_1k1k_con2048_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_1k1k_con2048_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL.yaml
@@ -57,6 +57,7 @@ worker_config:
       enable_padding: true
       max_batch_size: 1536
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -65,6 +66,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 1024
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     num_postprocess_workers: 4
     stream_interval: 20
@@ -79,6 +81,7 @@ worker_config:
     enable_attention_dp: false
     cuda_graph_config: null
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -88,4 +91,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 1024
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true

--- a/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_1k1k_con512_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_1k1k_con512_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL.yaml
@@ -57,6 +57,7 @@ worker_config:
       enable_padding: true
       max_batch_size: 1536
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -65,6 +66,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 1024
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     num_postprocess_workers: 4
     stream_interval: 20
@@ -79,6 +81,7 @@ worker_config:
     enable_attention_dp: false
     cuda_graph_config: null
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -88,4 +91,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 1024
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true

--- a/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_1k1k_con64_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_1k1k_con64_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
@@ -53,6 +53,7 @@ worker_config:
       enable_padding: true
       max_batch_size: 256
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -61,6 +62,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 1024
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     num_postprocess_workers: 4
     stream_interval: 20
@@ -75,6 +77,7 @@ worker_config:
     enable_attention_dp: false
     cuda_graph_config: null
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -84,4 +87,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 1024
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true

--- a/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con1024_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con1024_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
@@ -65,6 +65,7 @@ worker_config:
       enable_padding: true
       max_batch_size: 1280
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.85
       dtype: fp8
@@ -73,6 +74,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 9216
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: false
     num_postprocess_workers: 4
     stream_interval: 20
@@ -91,6 +93,7 @@ worker_config:
       enable_padding: true
       max_batch_size: 30
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.8
       dtype: fp8
@@ -99,6 +102,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 9216
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     num_postprocess_workers: 4
     stream_interval: 20

--- a/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con128_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con128_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
@@ -53,6 +53,7 @@ worker_config:
       enable_padding: true
       max_batch_size: 1024
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -61,6 +62,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     num_postprocess_workers: 4
     stream_interval: 20
@@ -75,6 +77,7 @@ worker_config:
     enable_attention_dp: false
     cuda_graph_config: null
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -84,4 +87,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true

--- a/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con4_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con4_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
@@ -53,6 +53,7 @@ worker_config:
       enable_padding: true
       max_batch_size: 1024
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -61,6 +62,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     num_postprocess_workers: 4
     stream_interval: 20
@@ -75,6 +77,7 @@ worker_config:
     enable_attention_dp: false
     cuda_graph_config: null
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -84,4 +87,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true

--- a/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con512_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf-sanity/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con512_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL.yaml
@@ -57,6 +57,7 @@ worker_config:
       enable_padding: true
       max_batch_size: 512
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -65,6 +66,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     num_postprocess_workers: 4
     stream_interval: 20
@@ -79,6 +81,7 @@ worker_config:
     enable_attention_dp: false
     cuda_graph_config: null
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -88,4 +91,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true

--- a/tests/scripts/perf/disaggregated/gb200_gpt-oss-120b-fp4_1k1k_con2048_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_gpt-oss-120b-fp4_1k1k_con2048_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL.yaml
@@ -68,6 +68,7 @@ worker_config:
       enable_padding: true
       max_batch_size: 1536
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -76,6 +77,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 1024
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     num_postprocess_workers: 4
     stream_interval: 20
@@ -90,6 +92,7 @@ worker_config:
     enable_attention_dp: false
     cuda_graph_config: null
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -99,4 +102,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 1024
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true

--- a/tests/scripts/perf/disaggregated/gb200_gpt-oss-120b-fp4_1k1k_con512_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_gpt-oss-120b-fp4_1k1k_con512_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL.yaml
@@ -68,6 +68,7 @@ worker_config:
       enable_padding: true
       max_batch_size: 1536
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -76,6 +77,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 1024
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     num_postprocess_workers: 4
     stream_interval: 20
@@ -90,6 +92,7 @@ worker_config:
     enable_attention_dp: false
     cuda_graph_config: null
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -99,4 +102,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 1024
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true

--- a/tests/scripts/perf/disaggregated/gb200_gpt-oss-120b-fp4_1k1k_con64_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_gpt-oss-120b-fp4_1k1k_con64_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
@@ -64,6 +64,7 @@ worker_config:
       enable_padding: true
       max_batch_size: 256
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -72,6 +73,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 1024
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     num_postprocess_workers: 4
     stream_interval: 20
@@ -86,6 +88,7 @@ worker_config:
     enable_attention_dp: false
     cuda_graph_config: null
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -95,4 +98,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 1024
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true

--- a/tests/scripts/perf/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con1024_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con1024_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
@@ -65,6 +65,7 @@ worker_config:
       enable_padding: true
       max_batch_size: 1280
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.85
       dtype: fp8
@@ -73,6 +74,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 9216
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: false
     num_postprocess_workers: 4
     stream_interval: 20
@@ -91,6 +93,7 @@ worker_config:
       enable_padding: true
       max_batch_size: 30
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.8
       dtype: fp8
@@ -99,6 +102,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 9216
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     num_postprocess_workers: 4
     stream_interval: 20

--- a/tests/scripts/perf/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con128_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con128_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
@@ -64,6 +64,7 @@ worker_config:
       enable_padding: true
       max_batch_size: 1024
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -72,6 +73,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     num_postprocess_workers: 4
     stream_interval: 20
@@ -86,6 +88,7 @@ worker_config:
     enable_attention_dp: false
     cuda_graph_config: null
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -95,4 +98,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true

--- a/tests/scripts/perf/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con4_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con4_ctx1_tp1_gen1_tp4_eplb0_mtp0_ccb-NIXL.yaml
@@ -64,6 +64,7 @@ worker_config:
       enable_padding: true
       max_batch_size: 1024
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -72,6 +73,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     num_postprocess_workers: 4
     stream_interval: 20
@@ -86,6 +88,7 @@ worker_config:
     enable_attention_dp: false
     cuda_graph_config: null
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -95,4 +98,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true

--- a/tests/scripts/perf/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con512_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_gpt-oss-120b-fp4_8k1k_con512_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL.yaml
@@ -68,6 +68,7 @@ worker_config:
       enable_padding: true
       max_batch_size: 512
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -76,6 +77,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     num_postprocess_workers: 4
     stream_interval: 20
@@ -90,6 +92,7 @@ worker_config:
     enable_attention_dp: false
     cuda_graph_config: null
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -99,4 +102,5 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true

--- a/tests/scripts/perf/disaggregated/gb200_stress-gpt-oss-120b-fp4_8k1k_ctx1_tp1_gen1_tp4_eplb0_eagle3_ccb-NIXL.yaml
+++ b/tests/scripts/perf/disaggregated/gb200_stress-gpt-oss-120b-fp4_8k1k_ctx1_tp1_gen1_tp4_eplb0_eagle3_ccb-NIXL.yaml
@@ -70,6 +70,7 @@ worker_config:
       enable_padding: true
       max_batch_size: 1024
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -78,6 +79,7 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: &id001
       decoding_type: Eagle
@@ -97,6 +99,7 @@ worker_config:
     enable_attention_dp: false
     cuda_graph_config: null
     kv_cache_config:
+      use_kv_cache_manager_v2: false
       enable_block_reuse: false
       free_gpu_memory_fraction: 0.9
       dtype: fp8
@@ -106,5 +109,6 @@ worker_config:
     cache_transceiver_config:
       max_tokens_in_buffer: 8448
       backend: NIXL
+      transceiver_runtime: PYTHON
     disable_overlap_scheduler: true
     speculative_config: *id001


### PR DESCRIPTION
## Description

Migrate existing NIXL-based GPT-OSS disaggregated tests from Transceiver V1 to V2 (`transceiver_runtime: PYTHON`).

This PR updates the accuracy, stress, and performance test configurations. Performance tests continue to use KV cache manager v1. A separate V1 test lane is not retained.

## Performance Validation

Run the existing GB200 GPT-OSS perf-sanity cases and compare the V2 pre-merge results with the historical V1 post-merge baseline.

[Performance results](https://tensorrt-llm.tensorrt-llm-perf-ci-report.sc2-paas.nvidia.com/pre-merge?selectedCurve=__all__&in_build-id-input=45936&in_job-name-select=LLM%2Fmain%2FL0_MergeRequest_PR)

- No regression was observed in the two E2E cases.
- No V2-specific regression was observed in the generation-performance cases.
- The `1k1k con64` result matches the post-merge level observed after its
  June 29 unwaive, indicating that its stored baseline is stale.

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated several performance sanity benchmark configurations to explicitly use the legacy KV cache manager setting and set cache transceiver runtime to Python for both generation and context workers.
  * Applied these settings across multiple disaggregated benchmark scenarios to keep test runs consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->