### PR TITLE
[NVBUG-6280721][fix] Unwaive DeepSeek-V3.2 FP4 MTP perf-sanity test

### DIFF
--- a/tests/integration/test_lists/waives.txt
+++ b/tests/integration/test_lists/waives.txt
@@ -536,7 +536,6 @@ perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-v32-fp4
 perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-v32-fp4_32k4k_con2048_ctx1_dep4_gen1_dep32_eplb288_mtp1_ccb-NIXL] SKIP (https://nvbugs/6374872)
 perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-v32-fp4_32k4k_con256_ctx1_dep4_gen1_dep32_eplb0_mtp3_ccb-NIXL] SKIP (https://nvbugs/6374898)
 perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-v32-fp4_32k4k_con256_ctx1_dep8_gen1_dep8_eplb0_mtp0_ccb-NIXL] SKIP (https://nvbugs/6374893)
-perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-v32-fp4_8k1k_con1_ctx1_dep4_gen1_tep8_eplb0_mtp3_ccb-NIXL] SKIP (https://nvbugs/6280721)
 perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_deepseek-v32-fp4_8k1k_con4096_ctx1_dep4_gen1_dep32_eplb256_mtp0_ccb-NIXL] SKIP (https://nvbugs/6302903)
 perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_gpt-oss-120b-fp4_1k1k_con2048_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL] SKIP (https://nvbugs/6324123)
 perf/test_perf_sanity.py::test_e2e[disagg_upload-gen_only-gb200_gpt-oss-120b-fp4_1k1k_con512_ctx1_tp1_gen1_dep2_eplb0_mtp0_ccb-NIXL] SKIP (https://nvbugs/6324123)


### PR DESCRIPTION
…s fixed by #14891

These 5 perf_sanity test_e2e cases were waived for nvbugs/6280721 (post-merge 2765/2769 on 06/08-06/09), a flaky CUDA illegal memory access hit during the generation CUDA-graph capture of DeepSeek-V3.2-Exp FP4 with MTP draft.

Root cause: the DSA indexer DSL atom-split path was taken for MTP-Eagle draft (i>=1) calls where next_n collapses to 1, while the cached (dsl_expand_factor, dsl_atom) and the pre-built expanded buffers still describe the verify-time next_n. The mismatch drives the paged-MQA-logits kernel with inflated kv-lens / block-table, producing out-of-range top-k indices that convertReqIndexToGlobal (no upper-bound check) maps to an unmapped KV-pool row. PR #14891 (57413893af) guards the split on
`next_n == dsl_expand_factor * dsl_atom`, landing 06/10 -- after the waive was added, so the waive was never re-evaluated.

Local validation on clean main (no other change): B200 aggr configs v32_fp4_dep8_mtp1_8k1k and v32_fp4_tep8_mtp3_8k1k pass repeatedly (mtp3 4/4 in CI-faithful pytest runs). The remaining GB200 / disagg configs share the same config-agnostic root cause and fix; relying on CI to validate them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Adjusted waived/skipped performance sanity test cases for certain DeepSeek v32 fp4 Blackwell scenarios.
  * Removed several no-longer-waived Blackwell variants and kept a smaller set of remaining waivers.
  * Updated waiver coverage for the upload-generation scenario by dropping one variant while preserving the others.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!--
Please write the PR title by following this template:

**[NVBUG-6280721][fix] Unwaive DeepSeek-V3.2 FP4 MTP perf-sanity test
**


Valid ticket formats:
  - JIRA ticket: [TRTLLM-1234] or [FOOBAR-123] for other FOOBAR project
  - NVBugs ID: [https://nvbugs/1234567]
  - GitHub issue: [#1234]
  - No ticket: [None]

Valid types (lowercase): [fix], [feat], [doc], [infra], [chore], etc.

Examples:
  - [TRTLLM-1234][feat] Add new feature
  - [https://nvbugs/1234567][fix] Fix some bugs
  - [#1234][doc] Update documentation
  - [None][chore] Minor clean-up

Alternative (faster) way using CodeRabbit AI:

**[JIRA ticket/NVBugs ID/GitHub issue/None] @coderabbitai title**

NOTE: "@coderabbitai title" will be replaced by the title generated by CodeRabbit AI, that includes the "[type]" and title.
For more info, see /.coderabbit.yaml.

-->

## Description

<!--
Please explain the issue and the solution in short.
-->

These waived perf sanity tests are related to flaky illegal memory access during CUDA-graph generation. The root cause in one line: when drafter is decoding, it shares the same config with verifier and thus adopting the wrong path where the verifier should go. This path assumes a longer sequence length than the true sequence length and led to accessing not existing kv cache ids. This problem is fixed by NVBUG-6241842's fix. 


## Test Coverage

<!--
Please list clearly what are the relevant test(s) that can safeguard the changes in the PR. This helps us to ensure we have sufficient test coverage for the PR.
-->

## PR Checklist

Please review the following before submitting your PR:
- PR description clearly explains what and why. If using CodeRabbit's summary, please make sure it makes sense.
- PR Follows [TRT-LLM CODING GUIDELINES](https://github.com/NVIDIA/TensorRT-LLM/blob/main/CODING_GUIDELINES.md) to the best of your knowledge.
- Test cases are provided for new code paths (see [test instructions](https://github.com/NVIDIA/TensorRT-LLM/tree/main/tests#1-how-does-the-ci-work))
- If PR introduces API changes, an appropriate PR label is added - either `api-compatible` or `api-breaking`. For `api-breaking`, include `BREAKING` in the PR title.
- Any new dependencies have been scanned for license and vulnerabilities
- [CODEOWNERS](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/CODEOWNERS) updated if ownership changes
- Documentation updated as needed
- Update [tava architecture diagram](https://github.com/NVIDIA/TensorRT-LLM/blob/main/.github/tava_architecture_diagram.md) if there is a significant design change in PR.
- The reviewers assigned automatically/manually are appropriate for the PR.


- [x] Please check this after reviewing the above items as appropriate for this PR.

## GitHub Bot Help

To see a list of available CI bot commands, please comment `/bot help`.
